### PR TITLE
[cxx-interop] Try to disambiguate retain/release operations

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8788,6 +8788,73 @@ SourceLoc swift::extractNearestSourceLoc(ClangDeclExplicitSafetyDescriptor desc)
   return SourceLoc();
 }
 
+RetainReleaseOperationKind importer::checkRetainReleaseOperationValidity(
+    const ClassDecl *classDecl, ValueDecl *operation,
+    CustomRefCountingOperationKind operationKind) {
+  auto operationFn = dyn_cast<FuncDecl>(operation);
+  if (!operationFn)
+    return RetainReleaseOperationKind::notAfunction;
+
+  if (operationFn->isStatic())
+    return RetainReleaseOperationKind::notAnInstanceFunction;
+
+  if (operationFn->isInstanceMember()) {
+    if (operationFn->getParameters()->size() != 0)
+      return RetainReleaseOperationKind::invalidParameters;
+  } else {
+    if (operationFn->getParameters()->size() != 1)
+      return RetainReleaseOperationKind::invalidParameters;
+  }
+
+  Type paramType;
+  NominalTypeDecl *paramDecl = nullptr;
+  if (!operationFn->isInstanceMember()) {
+    paramType = operationFn->getParameters()
+                    ->get(0)
+                    ->getInterfaceType()
+                    ->lookThroughSingleOptionalType();
+
+    paramDecl = paramType->getAnyNominal();
+  } else {
+    paramDecl = cast<NominalTypeDecl>(operationFn->getParent());
+    paramType = paramDecl->getDeclaredInterfaceType();
+  }
+
+  // The return type should be void (for release functions), or void
+  // or the parameter type (for retain functions).
+  auto resultInterfaceType = operationFn->getResultInterfaceType();
+  if (!resultInterfaceType->isVoid() && !resultInterfaceType->isUInt() &&
+      !resultInterfaceType->isUInt8() && !resultInterfaceType->isUInt16() &&
+      !resultInterfaceType->isUInt32() && !resultInterfaceType->isUInt64() &&
+      !resultInterfaceType->isInt() && !resultInterfaceType->isInt8() &&
+      !resultInterfaceType->isInt16() && !resultInterfaceType->isInt32() &&
+      !resultInterfaceType->isInt64()) {
+    if (operationKind == CustomRefCountingOperationKind::release ||
+        !resultInterfaceType->lookThroughSingleOptionalType()->isEqual(
+            paramType))
+      return RetainReleaseOperationKind::invalidReturnType;
+  }
+
+  // The parameter of the retain/release function should be pointer to the
+  // same FRT or a base FRT.
+  if (paramDecl != classDecl) {
+    if (auto cxxDecl =
+            dyn_cast<clang::CXXRecordDecl>(classDecl->getClangDecl())) {
+      if (const clang::Decl *paramClangDecl = paramDecl->getClangDecl()) {
+        if (const auto *paramTypeDecl =
+                dyn_cast<clang::CXXRecordDecl>(paramClangDecl)) {
+          if (cxxDecl->isDerivedFrom(paramTypeDecl)) {
+            return RetainReleaseOperationKind::valid;
+          }
+        }
+      }
+    }
+    return RetainReleaseOperationKind::invalidParameters;
+  }
+
+  return RetainReleaseOperationKind::valid;
+}
+
 CustomRefCountingOperationResult CustomRefCountingOperation::evaluate(
     Evaluator &evaluator, CustomRefCountingOperationDescriptor desc) const {
   auto swiftDecl = desc.decl;
@@ -8823,11 +8890,25 @@ CustomRefCountingOperationResult CustomRefCountingOperation::evaluate(
     return {CustomRefCountingOperationResult::immortal, nullptr, name};
 
   auto results = getValueDeclsForName(const_cast<ClassDecl *>(swiftDecl), name);
-  if (results.size() == 1)
-    return {CustomRefCountingOperationResult::foundOperation, results.front(),
-            name};
 
-  if (results.empty())
+  TinyPtrVector<ValueDecl *> validResults;
+  if (results.size() > 1) {
+    // If we have ambiguous retain/release operations, try to disambiguate.
+    for (auto *candidate : results) {
+      if (importer::checkRetainReleaseOperationValidity(swiftDecl, candidate,
+                                                        operation) ==
+          RetainReleaseOperationKind::valid)
+        validResults.push_back(candidate);
+    }
+  } else if (results.size() == 1) {
+    validResults.push_back(results.front());
+  }
+
+  if (validResults.size() == 1)
+    return {CustomRefCountingOperationResult::foundOperation,
+            validResults.front(), name};
+
+  if (validResults.empty())
     return {CustomRefCountingOperationResult::notFound, nullptr, name};
 
   return {CustomRefCountingOperationResult::tooManyFound, nullptr, name};

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3059,85 +3059,6 @@ namespace {
         return;
       }
 
-      enum class RetainReleaseOperationKind {
-        notAfunction,
-        notAnInstanceFunction,
-        invalidReturnType,
-        invalidParameters,
-        valid
-      };
-
-      auto getOperationValidity =
-          [&](ValueDecl *operation,
-              CustomRefCountingOperationKind operationKind)
-          -> RetainReleaseOperationKind {
-        auto operationFn = dyn_cast<FuncDecl>(operation);
-        if (!operationFn)
-          return RetainReleaseOperationKind::notAfunction;
-
-        if (operationFn->isStatic())
-          return RetainReleaseOperationKind::notAnInstanceFunction;
-
-        if (operationFn->isInstanceMember()) {
-          if (operationFn->getParameters()->size() != 0)
-            return RetainReleaseOperationKind::invalidParameters;
-        } else {
-          if (operationFn->getParameters()->size() != 1)
-            return RetainReleaseOperationKind::invalidParameters;
-        }
-
-        Type paramType;
-        NominalTypeDecl *paramDecl = nullptr;
-        if (!operationFn->isInstanceMember()) {
-          paramType = operationFn->getParameters()
-                          ->get(0)
-                          ->getInterfaceType()
-                          ->lookThroughSingleOptionalType();
-
-          paramDecl = paramType->getAnyNominal();
-        } else {
-          paramDecl = cast<NominalTypeDecl>(operationFn->getParent());
-          paramType = paramDecl->getDeclaredInterfaceType();
-        }
-
-        // The return type should be void (for release functions), or void
-        // or the parameter type (for retain functions).
-        auto resultInterfaceType = operationFn->getResultInterfaceType();
-        if (!resultInterfaceType->isVoid() &&
-            !resultInterfaceType->isUInt() &&
-            !resultInterfaceType->isUInt8() &&
-            !resultInterfaceType->isUInt16() &&
-            !resultInterfaceType->isUInt32() &&
-            !resultInterfaceType->isUInt64() &&
-            !resultInterfaceType->isInt() &&
-            !resultInterfaceType->isInt8() &&
-            !resultInterfaceType->isInt16() &&
-            !resultInterfaceType->isInt32() &&
-            !resultInterfaceType->isInt64()) {
-          if (operationKind == CustomRefCountingOperationKind::release ||
-              !resultInterfaceType->lookThroughSingleOptionalType()->isEqual(paramType))
-            return RetainReleaseOperationKind::invalidReturnType;
-        }
-
-        // The parameter of the retain/release function should be pointer to the
-        // same FRT or a base FRT.
-        if (paramDecl != classDecl) {
-          if (auto cxxDecl = dyn_cast<clang::CXXRecordDecl>(decl)) {
-            if (const clang::Decl *paramClangDecl = paramDecl->getClangDecl()) {
-              if (const auto *paramTypeDecl =
-                      dyn_cast<clang::CXXRecordDecl>(paramClangDecl)) {
-                if (cxxDecl->isDerivedFrom(paramTypeDecl)) {
-                  return RetainReleaseOperationKind::valid;
-                }
-              }
-            }
-          }
-          return RetainReleaseOperationKind::invalidParameters;
-        }
-
-        return RetainReleaseOperationKind::valid;
-      };
-
       HeaderLoc loc(decl->getLocation());
 
       if (retainOperation.kind ==
@@ -3165,8 +3086,10 @@ namespace {
                       false, retainOperation.name, decl->getNameAsString());
       } else if (retainOperation.kind ==
                  CustomRefCountingOperationResult::foundOperation) {
-        RetainReleaseOperationKind operationKind = getOperationValidity(
-            retainOperation.operation, CustomRefCountingOperationKind::retain);
+        RetainReleaseOperationKind operationKind =
+            importer::checkRetainReleaseOperationValidity(
+                classDecl, retainOperation.operation,
+                CustomRefCountingOperationKind::retain);
         switch (operationKind) {
         case RetainReleaseOperationKind::notAfunction:
           Impl.diagnose(
@@ -3226,8 +3149,9 @@ namespace {
       } else if (releaseOperation.kind ==
                  CustomRefCountingOperationResult::foundOperation) {
         RetainReleaseOperationKind operationKind =
-            getOperationValidity(releaseOperation.operation,
-                                 CustomRefCountingOperationKind::release);
+            importer::checkRetainReleaseOperationValidity(
+                classDecl, releaseOperation.operation,
+                CustomRefCountingOperationKind::release);
         switch (operationKind) {
         case RetainReleaseOperationKind::notAfunction:
           Impl.diagnose(

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -2320,6 +2320,18 @@ bool diagnoseForeignReferenceType(const clang::CXXRecordDecl *decl,
 /// Note that \p Node cannot itself be a clang::Module.
 const clang::Module *getClangOwningModule(ClangNode Node,
                                           const clang::ASTContext &ClangCtx);
+
+enum class RetainReleaseOperationKind {
+  notAfunction,
+  notAnInstanceFunction,
+  invalidReturnType,
+  invalidParameters,
+  valid
+};
+
+RetainReleaseOperationKind checkRetainReleaseOperationValidity(
+    const ClassDecl *classDecl, ValueDecl *operation,
+    CustomRefCountingOperationKind operationKind);
 } // end namespace importer
 } // end namespace swift
 

--- a/test/Interop/Cxx/foreign-reference/Inputs/refcounting-methods.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/refcounting-methods.h
@@ -142,3 +142,33 @@ struct SharedB {
 // expected-warning@+1 {{unable to infer SWIFT_SHARED_REFERENCE}}
 struct SharedAB : SharedA, SharedB { SharedAB(int) {} };
 #endif
+
+// Multiple retain/release operations,
+// but we disambiguate them by arity.
+struct AmbiguousReleaseMethods {
+  int value;
+
+  SWIFT_RETURNS_RETAINED
+  AmbiguousReleaseMethods(int value) : value(value) {}
+
+  virtual void doRetain();
+  virtual void doRelease();
+  virtual void doRelease(int argument);
+} SWIFT_SHARED_REFERENCE(.doRetain, .doRelease);
+
+struct AmbiguousFreeReleaseAndRetainMethods {
+  int value;
+
+  SWIFT_RETURNS_RETAINED
+  AmbiguousFreeReleaseAndRetainMethods(int value) : value(value) {}
+} SWIFT_SHARED_REFERENCE(retainAmbiguousFreeReleaseAndRetainMethods,
+                         releaseAmbiguousFreeReleaseAndRetainMethods);
+
+void retainAmbiguousFreeReleaseAndRetainMethods(
+    AmbiguousFreeReleaseAndRetainMethods *v);
+void retainAmbiguousFreeReleaseAndRetainMethods(); // wrong arity: 0
+void releaseAmbiguousFreeReleaseAndRetainMethods(
+    AmbiguousFreeReleaseAndRetainMethods *v);
+void releaseAmbiguousFreeReleaseAndRetainMethods(
+    AmbiguousFreeReleaseAndRetainMethods *v,
+    int argument); // wrong arity: 2

--- a/test/Interop/Cxx/foreign-reference/invalid-retain-operation-errors.swift
+++ b/test/Interop/Cxx/foreign-reference/invalid-retain-operation-errors.swift
@@ -295,8 +295,6 @@ public func testBadAnonymousStruct(x: BadAnonymousStruct) { }
 @available(macOS 13.3, *)
 public func testRetainReleaseAsNonFunction(x: BadFRT) {}
 
-// CHECK: error: multiple functions 'retain' found; there must be exactly one retain function for reference type 'MultipleRetainReleaseFRT'
-// CHECK: error: multiple functions 'release' found; there must be exactly one release function for reference type 'MultipleRetainReleaseFRT'
 @available(macOS 13.3, *)
 public func testMultipleRetainRelease(x: MultipleRetainReleaseFRT) {}
 

--- a/test/Interop/Cxx/foreign-reference/refcounting-methods-typechecker.swift
+++ b/test/Interop/Cxx/foreign-reference/refcounting-methods-typechecker.swift
@@ -5,3 +5,6 @@ import RefCountingMethods
 let _ = StaticRetainRelease(123)
 let _ = DerivedStaticRetainRelease(123, 456)
 let _ = SharedAB(123)
+
+let _ = AmbiguousReleaseMethods(321)
+let _ = AmbiguousFreeReleaseAndRetainMethods(456)


### PR DESCRIPTION
The following FRT has multiple `release` operations:

```
class FRT {
public:
    virtual void retain();
    virtual void release();
    virtual void release(int invalid);
} SWIFT_SHARED_REFERENCE(.retain, .release);
```

We used to not import this type due to it having multiple `release` operations. However, only the first one is actually valid, so we can try to disambiguate these cases by checking the parameters of the multiple candidates.

rdar://179728235

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
