### PR TITLE
Sema: allow applying @objc @implementation on extensions to internally imported types

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -275,8 +275,22 @@ const {
   }
 
   // Allow references to hidden dependencies from `@c/objc @implementation`
-  // decl signatures.
-  if (getDeclContext()->isInObjCImplementationContext()) {
+  // decl signatures, and from the extended type / where clause of an
+  // `@objc @implementation` extension — its members are implementations, not
+  // API, so they do not require the extended type to be imported publicly.
+  bool inObjCImplementation = getDeclContext()->isInObjCImplementationContext();
+  if (!inObjCImplementation) {
+    if (auto *ED =
+            dyn_cast_or_null<ExtensionDecl>(getDeclContext()->getAsDecl())) {
+      if (auto reason = getExportabilityReason())
+        inObjCImplementation =
+            ED->isObjCImplementation() &&
+            (*reason == ExportabilityReason::ExtensionWithPublicMembers ||
+             *reason ==
+                 ExportabilityReason::ExtensionWithConditionalConformances);
+    }
+  }
+  if (inObjCImplementation) {
     switch (originKind) {
     case DisallowedOriginKind::None:
     case DisallowedOriginKind::NonPublicImport:

--- a/test/ClangImporter/restricted_import_and_c_objc_implementation.swift
+++ b/test/ClangImporter/restricted_import_and_c_objc_implementation.swift
@@ -60,7 +60,7 @@ typedef double MyDouble; // expected-note {{type declared here}}
 void canReferenceHiddenDependency(MyPoint, MyDouble);
 void stillUnusableFromInlinable(); // expected-note {{global function 'stillUnusableFromInlinable()' is not '@usableFromInline' or public}}
 
-@interface ObjCImplClass: NSObject // expected-note {{class declared here}}
+@interface ObjCImplClass: NSObject
 @property MyPoint point;
 - (nonnull instancetype)initWithPoint:(MyPoint)point;
 - (void)method:(MyDouble)a;
@@ -75,7 +75,6 @@ void stillUnusableFromInlinable(); // expected-note {{global function 'stillUnus
 #else
   internal import Lib // expected-note {{type alias 'MyDouble' imported as 'internal' from 'Lib' here}}
   // expected-note @-1 {{global function 'stillUnusableFromInlinable()' imported as 'internal' from 'Lib' here}}
-  // expected-note @-2 {{class 'ObjCImplClass' imported as 'internal' from 'Lib' here}}
 #endif
 
 @c @implementation
@@ -85,7 +84,7 @@ public func canReferenceHiddenDependency(_ a: MyPoint, _ b: MyDouble) { }
 public func stillUnusableFromInlinable() { }
 
 @objc @implementation
-extension ObjCImplClass { // expected-error {{cannot use class 'ObjCImplClass' in an extension with public or '@usableFromInline' members; 'Lib' was not imported publicly}}
+extension ObjCImplClass {
   var point: MyPoint
 
   public init(point: MyPoint) {


### PR DESCRIPTION
Extend the existing @c/@objc @implementation hidden-dependency exemption to cover the extension's extended-type and where-clause checks

rdar://178750930