### PR TITLE
[ExistentialSpecializer] Fix missing destroy_addr for class-constrained @in_guaranteed existential

### DIFF
--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
@@ -245,6 +245,13 @@ void ExistentialSpecializerCloner::cloneArguments(
                                             StoreOwnershipQualifier::Init);
         InitRef = alloc;
         AllocStackInsts.push_back(alloc);
+        // When the argument is not consumed (@in_guaranteed), the
+        // load [copy] created a +1 that was stored into the stack. The
+        // original function body borrows but doesn't consume it, so we
+        // must destroy_addr before dealloc_stack.
+        if (NewFBuilder.hasOwnership() && !origConsumed) {
+          CleanupValues.push_back(alloc);
+        }
       }
 
       entryArgs.push_back(InitRef);
@@ -487,7 +494,15 @@ void ExistentialTransform::populateThunkBody() {
           SILValue ASI = Builder.createAllocStack(Loc, OpenedSILType);
           Builder.emitStoreValueOperation(Loc, archetypeValue, ASI,
                                           StoreOwnershipQualifier::Init);
-          Temps.push_back({ASI, SILValue()});
+          // When the argument is not consumed (@in_guaranteed), the load [copy]
+          // created a +1 that was forwarded through open_existential_ref and
+          // stored into the stack. The callee borrows but doesn't consume it,
+          // so we must destroy_addr before dealloc_stack.
+          if (Builder.hasOwnership() && !OriginallyConsumed) {
+            Temps.push_back({ASI, ASI});
+          } else {
+            Temps.push_back({ASI, SILValue()});
+          }
           archetypeValue = ASI;
         } else {
           // Otherwise in ossa, we need to add open_existential_ref as something

--- a/test/SILOptimizer/existential_specializer_class_guaranteed_destroy.sil
+++ b/test/SILOptimizer/existential_specializer_class_guaranteed_destroy.sil
@@ -1,0 +1,63 @@
+// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -O -wmo -sil-disable-pass=DeadFunctionAndGlobalElimination -sil-disable-pass=function-signature-opts | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+// ExistentialTransform's cloner was missing destroy_addr before
+// dealloc_stack for class-constrained @in_guaranteed existential
+// arguments. The MemoryLifetimeVerifier caught this as "memory is
+// initialized, but shouldn't be" at the dealloc_stack.
+//
+// The cloner creates: load [copy] -> init_existential_ref ->
+// alloc_stack -> store [init] -> (cloned body borrows via
+// @in_guaranteed) -> dealloc_stack. Without destroy_addr, the +1
+// from load [copy] is leaked.
+
+import Builtin
+import Swift
+
+protocol ClassProto: AnyObject {
+  func doSomething()
+}
+
+class ConcreteClass: ClassProto {
+  func doSomething()
+}
+
+sil @ConcreteClass_doSomething : $@convention(method) (@guaranteed ConcreteClass) -> ()
+sil @ConcreteClass_doSomething_witness : $@convention(witness_method: ClassProto) (@guaranteed ConcreteClass) -> ()
+
+// Verify that the existential specializer produces a valid specialized
+// function without crashing in the MemoryLifetimeVerifier.
+//
+// CHECK-LABEL: sil shared [noinline] @$s32use_class_existential_guaranteedTf4e_n :
+// CHECK: bb0(
+// CHECK:   return
+// CHECK: } // end sil function '$s32use_class_existential_guaranteedTf4e_n'
+sil [ossa] [noinline] @use_class_existential_guaranteed : $@convention(thin) (@in_guaranteed ClassProto) -> () {
+bb0(%0 : $*ClassProto):
+  %1 = load [copy] %0 : $*ClassProto
+  %2 = open_existential_ref %1 : $ClassProto to $@opened("AABBCCDD-0011-2233-4455-66778899AABB", ClassProto) Self
+  %f = witness_method $@opened("AABBCCDD-0011-2233-4455-66778899AABB", ClassProto) Self, #ClassProto.doSomething : <Self: ClassProto> (Self) -> () -> (), %2 : $@opened("AABBCCDD-0011-2233-4455-66778899AABB", ClassProto) Self : $@convention(witness_method: ClassProto) <Self: ClassProto> (@guaranteed Self) -> ()
+  apply %f<@opened("AABBCCDD-0011-2233-4455-66778899AABB", ClassProto) Self>(%2) : $@convention(witness_method: ClassProto) <Self: ClassProto> (@guaranteed Self) -> ()
+  destroy_value %2 : $@opened("AABBCCDD-0011-2233-4455-66778899AABB", ClassProto) Self
+  %r = tuple ()
+  return %r : $()
+}
+
+sil [ossa] @invoke_class_existential_guaranteed : $@convention(thin) (@guaranteed ConcreteClass) -> () {
+bb0(%0 : @guaranteed $ConcreteClass):
+  %copy = copy_value %0 : $ConcreteClass
+  %1 = init_existential_ref %copy : $ConcreteClass : $ConcreteClass, $ClassProto
+  %z = alloc_stack $ClassProto
+  store %1 to [init] %z : $*ClassProto
+  %f = function_ref @use_class_existential_guaranteed : $@convention(thin) (@in_guaranteed ClassProto) -> ()
+  apply %f(%z) : $@convention(thin) (@in_guaranteed ClassProto) -> ()
+  destroy_addr %z : $*ClassProto
+  dealloc_stack %z : $*ClassProto
+  %r = tuple ()
+  return %r : $()
+}
+
+sil_witness_table ConcreteClass: ClassProto module main {
+  method #ClassProto.doSomething: <Self: ClassProto> (Self) -> () -> () : @ConcreteClass_doSomething_witness
+}


### PR DESCRIPTION
## Summary

The ExistentialSpecializer crashes in the MemoryLifetimeVerifier when specializing a function that takes a class-constrained existential argument as `@in_guaranteed` (borrowed, not consumed).

```
SIL memory lifetime failure: memory is initialized, but shouldn't be
memory location:   %3 = alloc_stack $any ClassProto
at instruction:   dealloc_stack %3 : $*any ClassProto
```

## Root Cause

When the ExistentialSpecializer creates a specialized function for a class-constrained `@in_guaranteed` existential, both the cloner (`cloneArguments`) and the thunk (`populateThunkBody`) emit:

```
load [copy] %arg            // +1
init_existential_ref ...    // forwards +1
alloc_stack $ExistentialTy
store [init] ...            // stores +1 into stack
apply @in_guaranteed(...)   // borrows, does NOT consume
dealloc_stack               // no destroy_addr -- leaks +1
```

The `Opaque` representation case correctly adds the alloc_stack to `CleanupValues` when not consumed (so `destroy_addr` is emitted before `dealloc_stack`), but the `Class` representation case does not.

## Fix

In both the cloner (`cloneArguments`, Class + address case) and the thunk (`populateThunkBody`, Class + address + non-consumed case), add the alloc_stack to the cleanup list so `destroy_addr` is emitted before `dealloc_stack` when the argument is not consumed. This matches the existing handling for the `Opaque` representation.

## Reproduction

Any function taking `@in_guaranteed` of a class-constrained protocol existential, called with a concrete class at a call site visible to the optimizer. For example, `[SomeClassExistential].forEach(someBlock)` generates a reabstraction thunk that hits this path.

Compile with `-O -enable-sil-verify-all`.