### PR TITLE
[OSSACanonicalizeOwned] Kill rather than remove dead debug_values

### DIFF
--- a/lib/SILOptimizer/Utils/OSSACanonicalizeOwned.cpp
+++ b/lib/SILOptimizer/Utils/OSSACanonicalizeOwned.cpp
@@ -1371,8 +1371,8 @@ void OSSACanonicalizeOwned::rewriteCopies(
               deadEndBlocksAnalysis->get(getCurrentDef()->getFunction()))) {
         continue;
       }
-      LLVM_DEBUG(llvm::dbgs() << "  Removing debug_value: " << *dvi);
-      deleter.forceDelete(dvi);
+      LLVM_DEBUG(llvm::dbgs() << "  Killing debug_value: " << *dvi);
+      dvi->killOperand();
     }
   }
 

--- a/test/SILOptimizer/copy_propagation_opaque.sil
+++ b/test/SILOptimizer/copy_propagation_opaque.sil
@@ -141,6 +141,7 @@ bb3(%11 : @owned $T):
 //
 // The non-consuming use now uses the original value.
 // CHECK-DEBUG-NEXT:   debug_value [[INSTANCE]] : $T
+// CHECK-OPT-NEXT:   debug_value undef : $T
 // CHECK-NEXT:   debug_value [[ADDR]] : $*T, expr op_deref
 //
 // The original destroy is deleted with optimizations enabled.
@@ -178,6 +179,7 @@ bb0(%addr : $*T):
 // The original copy is deleted in both cases.
 // CHECK-DEBUG-NEXT:   debug_value [[INSTANCE]] : $T
 // CHECK-DEBUG-NEXT:   destroy_value [[INSTANCE]] : $T
+// CHECK-OPT-NEXT:   debug_value undef : $T
 // CHECK-NEXT:   br bb3
 //
 // CHECK: bb3:

--- a/test/SILOptimizer/devirt_inherited_conformance.swift
+++ b/test/SILOptimizer/devirt_inherited_conformance.swift
@@ -163,6 +163,8 @@ public func compareComparable<T:Comparable>(_ x: T, _ y:T) -> Bool {
 // Check that a call of inherited Equatable.== can be devirtualized.
 // CHECK-LABEL: sil @$s28devirt_inherited_conformance17testCompareEqualsSbyF : $@convention(thin) () -> Bool {
 // CHECK: bb0
+// CHECK-NEXT: debug_value undef : $D, let, name "self"
+// CHECK-NEXT: debug_value undef : $D, let, name "self"
 // CHECK-NEXT: integer_literal $Builtin.Int1, -1
 // CHECK-NEXT: struct $Bool
 // CHECK: return
@@ -176,6 +178,8 @@ public func testCompareEquals() -> Bool {
 // Check that a call of inherited Simple.== can be devirtualized.
 // CHECK-LABEL: sil @$s28devirt_inherited_conformance014testCompareMinfF0SbyF : $@convention(thin) () -> Bool {
 // CHECK: bb0
+// CHECK-NEXT: debug_value undef : $D, let, name "self"
+// CHECK-NEXT: debug_value undef : $D, let, name "self"
 // CHECK-NEXT: integer_literal $Builtin.Int1, -1
 // CHECK-NEXT: struct $Bool
 // CHECK: return
@@ -186,6 +190,8 @@ public func testCompareMinMinMin() -> Bool {
 // Check that a call of inherited Comparable.== can be devirtualized.
 // CHECK-LABEL: sil @$s28devirt_inherited_conformance21testCompareComparableSbyF : $@convention(thin) () -> Bool {
 // CHECK: bb0
+// CHECK-NEXT: debug_value undef : $D, let, name "self"
+// CHECK-NEXT: debug_value undef : $D, let, name "self"
 // CHECK-NEXT: integer_literal $Builtin.Int1, -1
 // CHECK-NEXT: struct $Bool
 // CHECK: return
@@ -200,6 +206,8 @@ public func BooCall<T:Simple>(_ x:T, _ y:T) -> Bool {
 // Check that a call of inherited Simple.boo can be devirtualized.
 // CHECK-LABEL: sil @$s28devirt_inherited_conformance11testBooCallSbyF : $@convention(thin) () -> Bool {
 // CHECK: bb0
+// CHECK-NEXT: debug_value undef : $D, let, name "self"
+// CHECK-NEXT: debug_value undef : $D, let, name "self"
 // CHECK-NEXT: integer_literal $Builtin.Int1, 0
 // CHECK-NEXT: struct $Bool
 // CHECK: return


### PR DESCRIPTION
Removing debug values may lose the information that the whole variable exists or show a stale value for it. Killing the debug value is the right thing to do.

Fixes 99.9% of lost debug variables from CopyPropagation in the stdlib.
