### PR TITLE
Mark URP's load[Unaligned] and store transparent.

### DIFF
--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -441,7 +441,7 @@ extension UnsafeRawPointer {
   /// - Returns: A new instance of type `T`, read from the raw bytes at
   ///   `offset`. The returned instance is memory-managed and unassociated
   ///   with the value in the memory referenced by this pointer.
-  @inlinable
+  @_transparent
   @_preInverseGenerics
   @_lifetime(borrow self)
   public func load<T: ~Escapable>(
@@ -488,7 +488,7 @@ extension UnsafeRawPointer {
   /// - Returns: A new instance of type `T`, read from the raw bytes at
   ///   `offset`. The returned instance isn't associated
   ///   with the value in the range of memory referenced by this pointer.
-  @inlinable
+  @_transparent
   @_alwaysEmitIntoClient
   @_lifetime(borrow self)
   public func loadUnaligned<T: BitwiseCopyable & ~Escapable>(
@@ -1283,7 +1283,7 @@ extension UnsafeMutableRawPointer {
   /// - Returns: A new instance of type `T`, read from the raw bytes at
   ///   `offset`. The returned instance is memory-managed and unassociated
   ///   with the value in the memory referenced by this pointer.
-  @inlinable
+  @_transparent
   @_preInverseGenerics
   @_lifetime(borrow self)
   public func load<T: ~Escapable>(
@@ -1331,7 +1331,7 @@ extension UnsafeMutableRawPointer {
   /// - Returns: A new instance of type `T`, read from the raw bytes at
   ///   `offset`. The returned instance isn't associated
   ///   with the value in the range of memory referenced by this pointer.
-  @inlinable
+  @_transparent
   @_alwaysEmitIntoClient
   @_lifetime(borrow self)
   public func loadUnaligned<T: BitwiseCopyable & ~Escapable>(
@@ -1420,7 +1420,7 @@ extension UnsafeMutableRawPointer {
   ///   - offset: The offset from this pointer, in bytes. `offset` must be
   ///     nonnegative. The default is zero.
   ///   - type: The type of `value`.
-  @inlinable
+  @_transparent
   @_alwaysEmitIntoClient
   public func storeBytes<T: BitwiseCopyable & ~Escapable>(
     of value: T, toByteOffset offset: Int = 0, as type: T.Type
@@ -1464,7 +1464,7 @@ extension UnsafeMutableRawPointer {
   ///   - offset: The offset from this pointer, in bytes. `offset` must be
   ///     nonnegative. The default is zero.
   ///   - type: The type of `value`.
-  @inlinable
+  @_transparent
   @_alwaysEmitIntoClient
   // This custom silgen name is chosen to not interfere with the old ABI
   @_silgen_name("_swift_se0349_UnsafeMutableRawPointer_storeBytes")
@@ -1477,7 +1477,6 @@ extension UnsafeMutableRawPointer {
     )
 
     withUnsafePointer(to: value) { source in
-      // FIXME: to be replaced by _memcpy when conversions are implemented.
       unsafe Builtin.int_memcpy_RawPointer_RawPointer_Int64(
         (self + offset)._rawValue,
         source._rawValue,


### PR DESCRIPTION
This nets fairly large wins for debug codegen, at least in some cases.