### PR TITLE
[6.4🍒][Compile Time Constant Extraction] Extract builders in extension conformances

### DIFF
--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -1330,8 +1330,7 @@ extractBuilderValueIfExists(const swift::NominalTypeDecl *TypeDecl,
     return createBuilderCompileTimeValue(attr, VarDecl);
   }
 
-  for (ProtocolDecl *Decl :
-       TypeDecl->getLocalProtocols(ConformanceLookupKind::All)) {
+  for (ProtocolDecl *Decl : TypeDecl->getAllProtocols()) {
     // FIXME(noncopyable_generics): Should these be included?
     if (Decl->getInvertibleProtocolKind())
       continue;

--- a/test/ConstExtraction/ExtractResultBuilders.swift
+++ b/test/ConstExtraction/ExtractResultBuilders.swift
@@ -145,6 +145,14 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
     }
 }
 
+public struct MyFooProviderInExtension {}
+extension MyFooProviderInExtension: FooProvider {
+    public static var foos: [Foo] {
+        Foo(name: "MyFooProviderInExtension.foos.1")
+        Foo(name: "MyFooProviderInExtension.foos.2")
+    }
+}
+
 // CHECK: [
 // CHECK-NEXT:   {
 // CHECK-NEXT:     "typeName": "ExtractResultBuilders.MyFooProvider",
@@ -753,6 +761,73 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:             }
 // CHECK-NEXT:           }
 // CHECK-NEXT:         ]
+// CHECK-NEXT:       }
+// CHECK-NEXT:     ]
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "typeName": "ExtractResultBuilders.MyFooProviderInExtension",
+// CHECK:          "kind": "struct",
+// CHECK-NEXT:     "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:     "line": 148,
+// CHECK-NEXT:     "conformances": [
+// CHECK-NEXT:       "ExtractResultBuilders.FooProvider"
+// CHECK-NEXT:     ],
+// CHECK-NEXT:    "allConformances": [
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "protocolName": "ExtractResultBuilders.FooProvider"
+// CHECK-NEXT:        "conformanceDefiningModule": "ExtractResultBuilders"
+// CHECK-NEXT:      }
+// CHECK-NEXT:    ],
+// CHECK-NEXT:     "associatedTypeAliases": [],
+// CHECK-NEXT:     "properties": [
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "label": "foos",
+// CHECK-NEXT:         "type": "Swift.Array<ExtractResultBuilders.Foo>",
+// CHECK-NEXT:         "mangledTypeName": "n/a - deprecated",
+// CHECK-NEXT:         "isStatic": "true",
+// CHECK-NEXT:         "isComputed": "true",
+// CHECK-NEXT:         "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:         "line": 150,
+// CHECK-NEXT:         "valueKind": "Builder",
+// CHECK-NEXT:         "value": {
+// CHECK-NEXT:           "type": "ExtractResultBuilders.FooBuilder",
+// CHECK-NEXT:           "members": [
+// CHECK-NEXT:             {
+// CHECK-NEXT:               "kind": "buildExpression",
+// CHECK-NEXT:               "element": {
+// CHECK-NEXT:                 "valueKind": "InitCall",
+// CHECK-NEXT:                 "value": {
+// CHECK-NEXT:                   "type": "ExtractResultBuilders.Foo",
+// CHECK-NEXT:                   "arguments": [
+// CHECK-NEXT:                     {
+// CHECK-NEXT:                       "label": "name",
+// CHECK-NEXT:                       "type": "Swift.String",
+// CHECK-NEXT:                       "valueKind": "RawLiteral",
+// CHECK-NEXT:                       "value": "MyFooProviderInExtension.foos.1"
+// CHECK-NEXT:                     }
+// CHECK-NEXT:                   ]
+// CHECK-NEXT:                 }
+// CHECK-NEXT:               }
+// CHECK-NEXT:             },
+// CHECK-NEXT:             {
+// CHECK-NEXT:               "kind": "buildExpression",
+// CHECK-NEXT:               "element": {
+// CHECK-NEXT:                 "valueKind": "InitCall",
+// CHECK-NEXT:                 "value": {
+// CHECK-NEXT:                   "type": "ExtractResultBuilders.Foo",
+// CHECK-NEXT:                   "arguments": [
+// CHECK-NEXT:                     {
+// CHECK-NEXT:                       "label": "name",
+// CHECK-NEXT:                       "type": "Swift.String",
+// CHECK-NEXT:                       "valueKind": "RawLiteral",
+// CHECK-NEXT:                       "value": "MyFooProviderInExtension.foos.2"
+// CHECK-NEXT:                     }
+// CHECK-NEXT:                   ]
+// CHECK-NEXT:                 }
+// CHECK-NEXT:               }
+// CHECK-NEXT:             }
+// CHECK-NEXT:           ]
+// CHECK-NEXT:         }
 // CHECK-NEXT:       }
 // CHECK-NEXT:     ]
 // CHECK-NEXT:   }


### PR DESCRIPTION
- **Explanation**:
  Adds support for extracting builders in extension conformances. Previously extensions were incorrectly omitted, which caused incorrect extraction as a runtime value instead of a builder.
- **Scope**:
  Impacts the JSON produced with `-emit-const-values-path` for extracting constant values.
- **Issues**:
  rdar://180420850
- **Original PRs**:
  https://github.com/swiftlang/swift/pull/90118
- **Risk**:
  Low
- **Testing**:
  In addition to the tests in this PR, this change has been validated with manual and automated tests in clients that consume the extracted JSON.
- **Reviewers**:
  @artemcm, @quinntaylor