### PR TITLE
[IRGen] Fix witness table instantiation for protocols refining Actor.

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1135,12 +1135,14 @@ static bool isDependentConformance(
     if (assocConformance.isInvalid())
       return false;
 
-    if (assocConformance.isAbstract() ||
-        isDependentConformance(IGM,
-                               assocConformance.getConcrete()
-                                 ->getRootConformance(),
-                               isResilient,
-                               visited))
+    if (assocConformance.isAbstract())
+      return true;
+
+    auto *assocRoot = assocConformance.getConcrete()->getRootConformance();
+    if (isDependentConformance(
+            IGM, assocRoot,
+            IGM.isResilientConformance(assocRoot, /*disableOptimizations=*/true),
+            visited))
       return true;
   }
 

--- a/test/Interpreter/witness_table_actor_base_conformance.swift
+++ b/test/Interpreter/witness_table_actor_base_conformance.swift
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -target %target-swift-5.1-abi-triple -parse-as-library -module-name main -Onone -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+
+protocol InstancedActor: Actor {
+  static var instances: [Layer<Self>] { get }
+}
+
+struct Layer<T: Actor> { var value: T }
+
+extension InstancedActor {
+  static func firstInstance() -> Self { instances.first!.value }
+}
+
+extension MainActor: InstancedActor {
+  static var instances: [Layer<MainActor>] {
+    [Layer(value: .shared)]
+  }
+}
+
+@main
+struct Main {
+  static func main() {
+    // Verify that we can successfully create Layer<MainActor>.
+    let _ = MainActor.firstInstance()
+  }
+}


### PR DESCRIPTION
isDependentConformance threaded the outer conformance's isResilient flag into recursive base-conformance checks. When a non-resilient conformance (e.g. MainActor: UserProtocol) had a resilient base (MainActor: Actor), the base was incorrectly judged non-dependent, causing requiresSpecialization to be false. The instantiation function was built but silently dropped, leaving a null inherited witness-table slot.

Recompute resilience per-conformance in the recursion to match what getConformanceInfo uses.

rdar://180176512

Assisted-by: Claude