### PR TITLE
[Embedded] Add PowerPC target support for Embedded StdLib

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -277,6 +277,12 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING)
         "avr  avr-none-none-elf    avr-none-none-elf"
       )
     endif()
+
+    if("PowerPC" IN_LIST LLVM_TARGETS_TO_BUILD)
+      list(APPEND EMBEDDED_STDLIB_TARGET_TRIPLES
+        "powerpc  powerpc-none-none-eabi    powerpc-none-none-eabi"
+      )
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Adds support for Swift Embedded PowerPC 32-bit target (e.g. Nintendo GameCube, Nintendo Wii). 
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

There is an associated LLVM patch for the actual codegen https://github.com/llvm/llvm-project/pull/205457

Related to https://github.com/swiftlang/swift/issues/58206