### PR TITLE
test: adjust helper for extended path on Windows

### DIFF
--- a/test/ModuleInterface/ModuleCache/Inputs/check-is-forwarding-module.py
+++ b/test/ModuleInterface/ModuleCache/Inputs/check-is-forwarding-module.py
@@ -1,7 +1,17 @@
+import os
+import platform
 import sys
 
+def extended(path):
+    if platform.system() == 'Windows':
+        path = os.path.abspath(path)
+        if path.startswith('\\\\'):
+            return "\\\\?\\UNC\\{0}".format(path[2:])
+        return "\\\\?\\{0}".format(path)
+    return path
+
 for input_path in sys.argv[1:]:
-    with open(input_path, 'rb') as yaml_file:
+    with open(extended(input_path), 'rb') as yaml_file:
         # Forwarding files are YAML files that start with '---'
         if yaml_file.read(3) != b'---':
             print("swiftmodule '%s' is not a forwarding module!" % input_path)


### PR DESCRIPTION
Add support for using extended paths when doing file system operations. This is required to use paths that exceed the Win32 261 character limit.