### PR TITLE
[Diagnostics] Make it possible to diagnose wrong argument order as a …

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1667,6 +1667,18 @@ ERROR(argument_out_of_order_unnamed_unnamed,none,
 ERROR(argument_out_of_order_binary_op,none,
       "operator argument #%0 must precede operator argument #%1",
       (unsigned, unsigned))
+NOTE(argument_out_of_order_note_named, none,
+     "candidate expects argument %0 must precede argument %1",
+     (Identifier, Identifier))
+NOTE(argument_out_of_order_note_unnamed, none,
+     "candidate expects argument #%0 must precede argument #%1",
+     (unsigned, unsigned))
+NOTE(argument_out_of_order_note_named_unnamed, none,
+     "candidate expects argument %0 must precede argument #%1",
+     (Identifier, unsigned))
+NOTE(argument_out_of_order_note_unnamed_named, none,
+     "candidate expects argument #%0 must precede argument #%1",
+     (unsigned, Identifier))
 NOTE(candidate_expected_different_labels,none,
      "incorrect labels for candidate (have: '%0', expected: '%1')",
      (StringRef, StringRef))

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6221,6 +6221,38 @@ bool OutOfOrderArgumentFailure::diagnoseAsError() {
   return true;
 }
 
+bool OutOfOrderArgumentFailure::diagnoseAsNote() {
+  auto overload = getCalleeOverloadChoiceIfAvailable(getLocator());
+  if (!(overload && overload->choice.isDecl()))
+    return false;
+
+  auto *argList = getArgumentListFor(getLocator());
+  if (!argList)
+    return false;
+
+  auto first = argList->getLabel(ArgIdx);
+  auto second = argList->getLabel(PrevArgIdx);
+
+  if (first.nonempty() && second.nonempty()) {
+    emitDiagnosticAt(overload->choice.getDecl(),
+                     diag::argument_out_of_order_note_named, first, second);
+  } else if (first.empty() && second.empty()) {
+    emitDiagnosticAt(overload->choice.getDecl(),
+                     diag::argument_out_of_order_note_unnamed, ArgIdx + 1,
+                     PrevArgIdx + 1);
+  } else if (first.empty()) {
+    emitDiagnosticAt(overload->choice.getDecl(),
+                     diag::argument_out_of_order_note_unnamed_named, ArgIdx + 1,
+                     second);
+  } else {
+    emitDiagnosticAt(overload->choice.getDecl(),
+                     diag::argument_out_of_order_note_named_unnamed, first,
+                     PrevArgIdx + 1);
+  }
+
+  return true;
+}
+
 SourceLoc ExtraneousArgumentsFailure::getLoc() const {
   if (auto *argList = getArgumentListFor(getLocator()))
     return argList->getLoc();

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1616,6 +1616,7 @@ public:
         PrevArgIdx(prevArgIdx), Bindings(bindings.begin(), bindings.end()) {}
 
   bool diagnoseAsError() override;
+  bool diagnoseAsNote() override;
 };
 
 /// Diagnose an attempt to destructure a single tuple closure parameter

--- a/test/Constraints/argument_matching.swift
+++ b/test/Constraints/argument_matching.swift
@@ -1830,3 +1830,20 @@ do {
   f(0, "")
   // expected-error@-1:4 {{missing argument label 'p:' in call}}{{5-5=p: }}
 }
+
+do {
+  func testNamed(_: String, a: Int? = nil, b: Int? = nil, action: () -> Void = {}) {}
+  // expected-note@-1 {{candidate expects argument 'a' must precede argument 'b'}}
+  func testNamed(d labeled: String, b: Int? = nil, a: Int? = nil, action: () -> Void = {}) {}
+  // expected-note@-1 {{incorrect labels for candidate (have: '(_:b:a:)', expected: '(d:b:a:)')}}
+
+  testNamed("", b: 0, a: 0)
+  // expected-error@-1 {{no exact matches in call to local function 'testNamed'}}
+
+  func testUnnamed(_: String, a: Int? = nil, _: Int? = nil, action: () -> Void = {}) {}
+  func testUnNamed(d labeled: String, _: Int? = nil, a: Int? = nil, action: () -> Void = {}) {}
+
+  testUnnamed("", 0, a: 0) // expected-error {{argument 'a' must precede unnamed argument #2}}
+  testUnnamed("", b: 0, a: 0) // expected-error {{incorrect argument labels in call (have '_:b:a:', expected '_:a:_:action:')}}
+  testUnnamed(d: "", 0, a: 0) // expected-error {{incorrect argument labels in call (have 'd:_:a:', expected '_:a:_:action:')}}
+}


### PR DESCRIPTION
…note

Previously `OutOfOrderArgumentFailure` supported only error diagnostics, expand it to support notes as well. This helps to diagnose problems when different overloads have different argument-related issues (i.e. one with out-of-order arguments and another is with missing or mismatched labels).

Resolves: rdar://167657233

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
