### PR TITLE
prevent update-verify-tests from being blocked by unrelated prefixes in expansions

### DIFF
--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -788,6 +788,10 @@ void DiagnosticVerifier::parseNestedExpectedDiagInfoBlock(
     unsigned &PrevExpectedContinuationLine,
     std::vector<ExpectedDiagnosticInfo> &NestedDiagsOut, size_t &End) {
   size_t NestedMatch = MatchStartIn.find("expected-");
+  if (NestedMatch == StringRef::npos) {
+    End = MatchStartIn.find("}}");
+    return;
+  }
   // Scan the memory buffer looking for expected-note/warning/error.
   while (NestedMatch != StringRef::npos) {
     StringRef NestedMatchStartIn = MatchStartIn.substr(NestedMatch);
@@ -994,10 +998,6 @@ unsigned DiagnosticVerifier::parseExpectedDiagInfo(
       addError(DiagnosticLoc,
                "didn't find '}}' to match '{{' in expected-expansion");
       return 0;
-    }
-    if (Expected.NestedDiags.size() == 0) {
-      addError(DiagnosticLoc, "expected-expansion block is empty");
-      // Keep going
     }
   } else {
     End = MatchStart.find("}}");
@@ -1248,9 +1248,7 @@ void DiagnosticVerifier::verifyDiagnostics(
     if (expected.Classification == DiagnosticKindExpansion) {
       SourceLoc Loc = SM.getLocForLineCol(BufferID, expected.LineNo, *expected.ColumnNo);
       if (Expansions.count(Loc) == 0) {
-        addError(expected.ExpectedStart,
-                 "no expansion with diagnostics starting at " +
-                     std::to_string(expected.LineNo) + ":" + std::to_string(*expected.ColumnNo));
+        addError(expected.ExpectedStart, "expected expansion not produced");
         continue;
       }
       unsigned ExpansionBufferID = Expansions[Loc];

--- a/test/Frontend/DiagnosticVerifier/expansion-remarks.swift
+++ b/test/Frontend/DiagnosticVerifier/expansion-remarks.swift
@@ -1,10 +1,14 @@
 // REQUIRES: swift_swift_parser, executable_test
 
 // RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
 // RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(UnstringifyMacroDefinition) -module-name=UnstringifyMacroDefinition %S/Inputs/macro/unstringify-macro.swift -g -no-toolchain-stdlib-rpath
 
-// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -Rmacro-expansions
+// RUN: %target-swift-frontend-verify -swift-version 5 -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -Rmacro-expansions -typecheck %t/main.swift
+// RUN: not %target-swift-frontend-verify -swift-version 5 -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -Rmacro-expansions -typecheck %t/empty-no-expansion.swift 2>&1 | %FileCheck --check-prefix=CHECK-MISSING %t/empty-no-expansion.swift
 
+//--- main.swift
 @attached(peer, names: overloaded)
 macro unstringifyPeer(_ s: String) =
     #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
@@ -35,3 +39,12 @@ func bar() {
     }}
     */
 }
+
+//--- empty-no-expansion.swift
+// CHECK-MISSING:     error: expected expansion not produced
+// CHECK-MISSING-NOT: didn't find '}}'
+// CHECK-MISSING-NOT: no expansion with diagnostics starting at
+
+// expected-expansion@+2:14{{
+// }}
+func qux() {}

--- a/test/Utils/update-verify-tests/expansion.swift
+++ b/test/Utils/update-verify-tests/expansion.swift
@@ -47,6 +47,21 @@
 // RUN: %target-swift-frontend-verify -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/escaped.swift -Rmacro-expansions
 // RUN: %diff %t/escaped.swift %t/escaped.swift.expected
 
+// RUN: not %target-swift-frontend-verify -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/empty-expansion-fill.swift 2>%t/output.txt -Rmacro-expansions
+// RUN: %update-verify-tests < %t/output.txt
+// RUN: %target-swift-frontend-verify -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/empty-expansion-fill.swift -Rmacro-expansions
+// RUN: %diff %t/empty-expansion-fill.swift %t/empty-expansion-fill.swift.expected
+
+// RUN: not %target-swift-frontend-verify -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/empty-expansion-remove.swift 2>%t/output.txt -Rmacro-expansions
+// RUN: %update-verify-tests < %t/output.txt
+// RUN: %target-swift-frontend-verify -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/empty-expansion-remove.swift -Rmacro-expansions
+// RUN: %diff %t/empty-expansion-remove.swift %t/empty-expansion-remove.swift.expected
+
+// RUN: not %target-swift-frontend-verify -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/empty-expansion-for-prefix.swift 2>%t/output.txt -Rmacro-expansions
+// RUN: %update-verify-tests < %t/output.txt
+// RUN: %target-swift-frontend-verify -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/empty-expansion-for-prefix.swift -Rmacro-expansions
+// RUN: %diff %t/empty-expansion-for-prefix.swift %t/empty-expansion-for-prefix.swift.expected
+
 //--- single.swift
 @attached(peer, names: overloaded)
 macro unstringifyPeer(_ s: String) =
@@ -304,4 +319,62 @@ func foo(_ x: Int) {
 //   expected-remark@4{{macro content: |}|}}
 // }}
 func foo() { let _ = "\(2)" }
+
+//--- empty-expansion-fill.swift
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+@unstringifyPeer("""
+func foo(_ x: Int) -> Int {
+    return x
+}
+""")
+// expected-expansion@+2:30{{
+// }}
+func foo() { let _ = "\(2)" }
+
+//--- empty-expansion-fill.swift.expected
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+// expected-note@+1 3{{in expansion of macro 'unstringifyPeer' on global function 'foo()' here}}
+@unstringifyPeer("""
+func foo(_ x: Int) -> Int {
+    return x
+}
+""")
+// expected-expansion@+5:30{{
+//   expected-remark@1{{macro content: |func foo(_ x: Int) -> Int {|}}
+//   expected-remark@2{{macro content: |    return x|}}
+//   expected-remark@3{{macro content: |}|}}
+// }}
+func foo() { let _ = "\(2)" }
+
+//--- empty-expansion-remove.swift
+// expected-expansion@+2:14{{
+// }}
+func foo() {}
+
+//--- empty-expansion-remove.swift.expected
+func foo() {}
+
+//--- empty-expansion-for-prefix.swift
+// expected-expansion@+5:14{{
+//   expected-asdf-remark@1{{asdf}}
+//   expected-hjkl-remark@1{{hjkl}}
+//   expected-hjkl-remark@2{{hjkl}}
+// }}
+func foo() {}
+
+//--- empty-expansion-for-prefix.swift.expected
+// expected-asdf-expansion@+7:14{{
+//   expected-asdf-remark@1{{asdf}}
+// }}
+// expected-hjkl-expansion@+4:14{{
+//   expected-hjkl-remark@1{{hjkl}}
+//   expected-hjkl-remark@2{{hjkl}}
+// }}
+func foo() {}
 

--- a/utils/update_verify_tests/core.py
+++ b/utils/update_verify_tests/core.py
@@ -671,6 +671,81 @@ def add_diag(
     return new_diag
 
 
+def _split_dead_expansion_for_foreign_prefixes(line, lines, prefix):
+    """If the dead `expected-expansion` directive at `line` has surviving
+    nested entries with foreign prefixes, replace it with one new expansion
+    directive per foreign prefix at the same source location, each owning
+    only the entries with its prefix. Returns True if any new directives
+    were inserted, False otherwise."""
+    # Group surviving nested entries by their prefix, preserving source order.
+    groups = []  # list of (foreign_prefix, [Line, ...])
+    for nested_line in line.diag.nested_lines:
+        if not nested_line.diag or nested_line.diag.count == 0:
+            continue
+        nested_prefix = nested_line.diag.prefix
+        if not nested_prefix or nested_prefix == prefix:
+            continue
+        for gp, gl in groups:
+            if gp == nested_prefix:
+                gl.append(nested_line)
+                break
+        else:
+            groups.append((nested_prefix, [nested_line]))
+    if not groups:
+        return False
+
+    indent = get_indent(line.content)
+    closer_ws = (
+        line.diag.closer.diag.whitespace
+        if line.diag.closer and isinstance(line.diag.closer.diag, ExpansionDiagClose)
+        else " "
+    )
+    insertion_line_n = line.line_n
+    for foreign_prefix, nested in groups:
+        # Reset nested line_n's so they sit at their own positions within the
+        # new expansion (fold/expand later renumbers them in the main lines).
+        for i, nl in enumerate(nested):
+            nl.line_n = i + 1
+        new_line = Line(indent + "{{DIAG}}\n", insertion_line_n)
+        new_diag = Diag(
+            foreign_prefix,
+            "",
+            "expansion",
+            line.diag.parsed_target_line_n,
+            line.diag.line_is_absolute,
+            line.diag._col,
+            1,
+            new_line,
+            False,
+            line.diag.whitespace_strings,
+            # Marking as "from source" prevents remove_dead_diags's take()
+            # from absorbing this synthesized sibling into the (dead)
+            # original directive that we are about to remove.
+            True,
+            list(nested),
+        )
+        new_line.diag = new_diag
+        # Synthesize a closer that mirrors the original's whitespace.
+        closer_line = Line(indent + "{{DIAG}}\n", None)
+        closer_line.diag = ExpansionDiagClose(closer_ws, closer_line)
+        new_diag.closer = closer_line
+        # Pick a target. Normally the original parent's target Line is
+        # preserved so all split directives still resolve to the same
+        # absolute line. However, if the original target Line happens to
+        # land inside *this* new directive's own nested_lines, pointing the
+        # directive at its own body is meaningless; redirect to its closer
+        # so the rendered `@+N:C` lands just past the directive's body.
+        if line.diag.target is not None and line.diag.target in nested:
+            new_diag.set_target(closer_line)
+        elif line.diag.target is not None:
+            new_diag.set_target(line.diag.target)
+
+        add_line(new_line, lines)
+        insertion_line_n = new_line.line_n + 1
+
+    return True
+
+
 def remove_dead_diags(lines, prefix):
     for line in lines.copy():
         if line not in lines:
@@ -680,8 +755,23 @@ def remove_dead_diags(lines, prefix):
             continue
         if line.diag.category == "expansion":
             if not line.diag.prefix or line.diag.prefix == prefix:
+                # Whether the verifier already reported this expansion as
+                # missing (parent count was decremented to 0 in update_lines).
+                was_reported_missing = line.diag.count == 0
                 remove_dead_diags(line.diag.nested_lines, prefix)
-                if line.diag.nested_lines:
+                if (
+                    was_reported_missing
+                    and _split_dead_expansion_for_foreign_prefixes(
+                        line, lines, prefix
+                    )
+                ):
+                    # The dead expansion has been replaced with one new
+                    # expansion directive per foreign prefix. Drop the original
+                    # so the cleanup at the bottom of the loop removes it.
+                    line.diag.nested_lines = []
+                    line.diag.closer = None
+                    line.diag.count = 0
+                elif line.diag.nested_lines:
                     line.diag.count = 1
                 else:
                     line.diag.count = 0


### PR DESCRIPTION
This updates DiagnosticVerifier and update-verify-tests to enable update-verify-tests to update missing expansions in some cases where they still have contents with another prefix.