### PR TITLE
OpaqueValues: enable for swift-backtrace executable build

### DIFF
--- a/stdlib/public/libexec/swift-backtrace/CMakeLists.txt
+++ b/stdlib/public/libexec/swift-backtrace/CMakeLists.txt
@@ -52,6 +52,7 @@ set(BACKTRACING_COMPILE_FLAGS
   "-Xcc;-I${SWIFT_SOURCE_DIR}/include"
   "-Xcc;-I${CMAKE_BINARY_DIR}/include"
   "-disable-upcoming-feature;MemberImportVisibility"
+  "-Xfrontend;-enable-sil-opaque-values"
   "-Xfrontend;-disable-availability-checking")
 
 set(BACKTRACING_SOURCES


### PR DESCRIPTION
As a stepping-stone to enabling the feature always in the compiler, let's have it on for swift-backtrace.

It's one of the few bits of real code we build with the in-tree compiler that not part of the ABI of the libSwift* dylibs.