### PR TITLE
[stdlib] Fixed `Int128` for big endian

### DIFF
--- a/stdlib/public/core/Int128.swift
+++ b/stdlib/public/core/Int128.swift
@@ -47,7 +47,7 @@ public struct Int128: Sendable, BitwiseCopyable {
 #if _endian(little)
     self = unsafe unsafeBitCast((_low, _high), to: Self.self)
 #else
-    self = unsafeBitCast((_high, _low), to: Self.self)
+    self = unsafe unsafeBitCast((_high, _low), to: Self.self)
 #endif
   }
   


### PR DESCRIPTION
This issue gets triggered then compiling any big endian embedded target, like MIPS.