### PR TITLE
[test] Sema/large_int_array.swift.gyb fails when building for debug

### DIFF
--- a/test/Sema/large_int_array.swift.gyb
+++ b/test/Sema/large_int_array.swift.gyb
@@ -3,6 +3,7 @@
 
 // The compiler should finish in less than 10 seconds. To give some slack,
 // specify a timeout of 1 minute.
+// REQUIRES: tools-release
 
 // RUN: %{python} %S/../../test/Inputs/timeout.py 60 %target-swift-frontend -typecheck -verify %t/large_int_array.swift
 // RUN: %{python} %S/../../test/Inputs/timeout.py 60 %target-swift-frontend -O %t/large_int_array.swift -emit-sil -o /dev/null

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -114,6 +114,14 @@ else:
 if "@SWIFT_OPTIMIZED@" == "TRUE":
     config.available_features.add("optimized_stdlib")
 
+# If tools have debug info, set the tools-debuginfo flag.
+if "@CMAKE_BUILD_TYPE@" in ["Debug", "RelWithDebInfo"]:
+    config.available_features.add('tools-debuginfo')
+
+# If tools are release-mode, set the tools-release flag.
+if "@CMAKE_BUILD_TYPE@" in ["Release", "RelWithDebInfo"]:
+    config.available_features.add('tools-release')
+
 if "@SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY@" == "TRUE":
     config.available_features.add("single_threaded_concurrency")
 


### PR DESCRIPTION
Copy the tools-debuginfo and tools-release features from the validation tests to the regular tests, and require tools-release in Sema/large_int_array.swift.gyb so that it doesn't fail in debug builds.

Assisted-by: Claude Code

rdar://180484721