### PR TITLE
[test] Ignore conformance removal to BitwiseCopyable

### DIFF
--- a/test/api-digester/Outputs/Cake.txt
+++ b/test/api-digester/Outputs/Cake.txt
@@ -50,7 +50,6 @@ cake: Var C1.CIIns2 changes from strong to weak
 cake: EnumElement FrozenKind.AddedCase has been added as a new enum case
 
 /* Conformance changes */
-cake: Enum IceKind has removed conformance to BitwiseCopyable
 cake: Enum IceKind has removed conformance to Sendable
 cake: Enum IceKind has removed conformance to SendableMetatype
 cake: Func ObjCProtocol.removeOptional() is no longer an optional requirement


### PR DESCRIPTION
compare-dump.swift and compare-dump-parsable-interface.swift are failing because "Enum IceKind has removed conformance to BitwiseCopyable" is no longer being reported. Remove that, similar to what was done previously in Cake-abi.txt

rdar://180485365