### PR TITLE
[test] Allow testing without building the standard library for all architectures

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -386,6 +386,7 @@ foreach(SDK ${SWIFT_SDKS})
     foreach(BUILD_FLAVOR ${build_flavors})
       # Configure variables for this subdirectory.
       set(VARIANT_SDK "${SWIFT_SDK_${SDK}_ARCH_${ARCH}_PATH}")
+      set(SWIFT_STDLIB_DARWIN_ARCHS "${SWIFT_SDK_${SDK}_ARCHITECTURES}")
       get_swift_test_variant_suffix(VARIANT_SUFFIX "${SDK}" "${ARCH}" "${BUILD_FLAVOR}")
       get_swift_test_variant_suffix(DEFAULT_OSX_VARIANT_SUFFIX "${SDK}" "${ARCH}" "default")
       get_swift_test_versioned_target_triple(VARIANT_TRIPLE "${SDK}" "${ARCH}" "${SWIFT_SDK_${SDK}_DEPLOYMENT_VERSION}" "${BUILD_FLAVOR}")

--- a/test/Concurrency/concurrency_availability.swift
+++ b/test/Concurrency/concurrency_availability.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -parse-stdlib -target x86_64-apple-macosx10.14 -typecheck -verify %s
 // RUN: %target-swift-frontend -parse-stdlib -target x86_64-apple-macosx11 -typecheck %s
 // RUN: %target-swift-frontend -parse-stdlib -target x86_64-apple-macosx12 -typecheck %s -DTARGET_MACOS_12
-// REQUIRES: OS=macosx
+// REQUIRES: OS=macosx, SWIFT_STDLIB_ARCH=x86_64
 
 import _Concurrency
 

--- a/test/Concurrency/dynamic_checks_for_func_refs_in_preconcurrency_apis_objc.swift
+++ b/test/Concurrency/dynamic_checks_for_func_refs_in_preconcurrency_apis_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -target arm64-apple-macosx10.15 -enable-upcoming-feature DynamicActorIsolation -Xllvm -sil-print-types -emit-silgen -verify %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -target %target-cpu-apple-macosx10.15 -enable-upcoming-feature DynamicActorIsolation -Xllvm -sil-print-types -emit-silgen -verify %s | %FileCheck %s
 // REQUIRES: objc_interop
 // REQUIRES: swift_feature_DynamicActorIsolation
 

--- a/test/Generics/inverse_casting_availability.swift
+++ b/test/Generics/inverse_casting_availability.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift \
 // RUN:   -enable-experimental-feature LifetimeDependence  \
-// RUN:   -debug-diagnostic-names -target arm64-apple-macos14.4 
+// RUN:   -debug-diagnostic-names -target %target-cpu-apple-macos14.4
 
 // REQUIRES: swift_feature_LifetimeDependence
 

--- a/test/IRGen/availability_maccatalyst_zippered.swift
+++ b/test/IRGen/availability_maccatalyst_zippered.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -primary-file %s -target x86_64-apple-macosx10.50 -target-variant x86_64-apple-ios48.0-macabi -emit-ir | %FileCheck %s
-// RUN: %target-swift-frontend -primary-file %s -target x86_64-apple-macosx10.50 -target-variant x86_64-apple-ios48.0-macabi -O -emit-ir | %FileCheck %s --check-prefix=OPT
+// RUN: %target-swift-frontend -primary-file %s -target %target-cpu-apple-macosx10.50 -target-variant %target-cpu-apple-ios48.0-macabi -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -target %target-cpu-apple-macosx10.50 -target-variant %target-cpu-apple-ios48.0-macabi -O -emit-ir | %FileCheck %s --check-prefix=OPT
 
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx || OS=maccatalyst

--- a/test/IRGen/framepointer_arm64.sil
+++ b/test/IRGen/framepointer_arm64.sil
@@ -4,6 +4,7 @@
 // RUN: %target-swift-frontend -target arm64-apple-ios8.0 -primary-file %s -S -Xcc -mno-omit-leaf-frame-pointer | %FileCheck %s --check-prefix=CHECKASM-ALL
 
 // REQUIRES: CODEGENERATOR=AArch64
+// REQUIRES: SWIFT_STDLIB_ARCH=arm64
 // REQUIRES: OS=ios
 
 sil_stage canonical

--- a/test/IRGen/implicitactor_to_opaqueisolation_cast.sil
+++ b/test/IRGen/implicitactor_to_opaqueisolation_cast.sil
@@ -7,6 +7,7 @@ import _Concurrency
 
 // REQUIRES: concurrency
 // REQUIRES: CODEGENERATOR=AArch64
+// REQUIRES: SWIFT_STDLIB_ARCH=arm64
 // REQUIRES: OS=macosx
 
 // TAGGED_POINTER: define swiftcc { i64, i64 } @test_cast_implicitactor_to_opaqueisolation(i64 [[WORD1:%.*]], i64 [[WORD2:%.*]])

--- a/test/IRGen/memtag_stack.swift
+++ b/test/IRGen/memtag_stack.swift
@@ -1,4 +1,5 @@
 // REQUIRES: CODEGENERATOR=AArch64
+// REQUIRES: SWIFT_STDLIB_ARCH=arm64
 // REQUIRES: OS=macosx
 
 // RUN: %swift -emit-ir -sanitize=memtag-stack -parse-as-library -target arm64-apple-macosx10.9 %s | %FileCheck %s

--- a/test/IRGen/original-defined-attr-linker-directives-fail.swift
+++ b/test/IRGen/original-defined-attr-linker-directives-fail.swift
@@ -6,7 +6,7 @@
 // RUN: not %target-swift-frontend -swift-version 4 -enforce-exclusivity=checked %s -emit-ir -module-name CurrentModule -D CURRENT_MODULE -previous-module-installname-map-file %t/nil.json >& %t/error.txt
 // RUN: %FileCheck %s -check-prefix=CHECK-ERROR < %t/error.txt
 
-// RUN: %target-swift-frontend -target x86_64-apple-macosx10.6 -swift-version 4 -enforce-exclusivity=checked %s -emit-ir -disable-legacy-type-info -module-name CurrentModule -D CURRENT_MODULE -previous-module-installname-map-file %t/install-name.json | %FileCheck %s -check-prefix=CHECK-SYMBOLS-LOW-TARGET
+// RUN: %target-swift-frontend -target %target-cpu-apple-macosx10.6 -swift-version 4 -enforce-exclusivity=checked %s -emit-ir -disable-legacy-type-info -module-name CurrentModule -D CURRENT_MODULE -previous-module-installname-map-file %t/install-name.json | %FileCheck %s -check-prefix=CHECK-SYMBOLS-LOW-TARGET
 
 @available(OSX 10.8, *)
 @_originallyDefinedIn(module: "OriginalModule", macOS 10.10)

--- a/test/IRGen/swift_async_extended_frame_info.swift
+++ b/test/IRGen/swift_async_extended_frame_info.swift
@@ -11,6 +11,7 @@
 
 // REQUIRES: OS=macosx
 // REQUIRES: CODEGENERATOR=X86 && CODEGENERATOR=AArch64
+// REQUIRES: SWIFT_STDLIB_ARCH=x86_64 && SWIFT_STDLIB_ARCH=arm64
 
 @_silgen_name("opaque_function")
 func blarpy()

--- a/test/IRGen/typed_allocation.swift
+++ b/test/IRGen/typed_allocation.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -enable-experimental-feature TypedAllocation -target arm64-apple-macos99.99 -wmo | %FileCheck %s
 
 // REQUIRES: OS=macosx
-// REQUIRES: embedded_stdlib
+// REQUIRES: SWIFT_STDLIB_ARCH=arm64
 // REQUIRES: embedded_stdlib
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_feature_TypedAllocation

--- a/test/Interop/Cxx/objc-correctness/sret.swift
+++ b/test/Interop/Cxx/objc-correctness/sret.swift
@@ -4,6 +4,7 @@
 // RUN: %target-swift-emit-ir -I %t/Inputs -cxx-interoperability-mode=default %t/test.swift -target arm64-apple-macos12 | %FileCheck %s
 
 // REQUIRES: objc_interop
+// REQUIRES: SWIFT_STDLIB_ARCH=arm64
 
 //--- Inputs/header.h
 

--- a/test/Interop/Cxx/stdlib/overlay-backdeployment-ios-simulator.swift
+++ b/test/Interop/Cxx/stdlib/overlay-backdeployment-ios-simulator.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -c %s -cxx-interoperability-mode=default -target arm64-apple-ios7.0-simulator
+// RUN: %swift -c %s -cxx-interoperability-mode=default -target %target-cpu-apple-ios7.0-simulator
 
 // REQUIRES: DARWIN_SIMULATOR=ios
 

--- a/test/Interop/Cxx/stdlib/overlay-backdeployment-ios.swift
+++ b/test/Interop/Cxx/stdlib/overlay-backdeployment-ios.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -c %s -cxx-interoperability-mode=default -target arm64-apple-ios7.0
+// RUN: %swift -c %s -cxx-interoperability-mode=default -target %target-cpu-apple-ios7.0
 
 // REQUIRES: OS=ios
 

--- a/test/Interop/Cxx/stdlib/overlay-backdeployment.swift
+++ b/test/Interop/Cxx/stdlib/overlay-backdeployment.swift
@@ -1,4 +1,4 @@
-// RUN: %target-build-swift %s -cxx-interoperability-mode=default -target arm64-apple-macos11.0
+// RUN: %target-build-swift %s -cxx-interoperability-mode=default -target %target-cpu-apple-macos11.0
 
 // REQUIRES: OS=macosx
 

--- a/test/PrintAsObjC/availability_any_apple_os_objc.swift
+++ b/test/PrintAsObjC/availability_any_apple_os_objc.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -emit-objc-header-path %t/anyAppleOS.h -target arm64-apple-macos26 -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -emit-objc-header-path %t/anyAppleOS.h -target %target-cpu-apple-macos26 -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/anyAppleOS.h
 
 // REQUIRES: objc_interop

--- a/test/SILGen/back_deployed_attr_maccatalyst_zippered.swift
+++ b/test/SILGen/back_deployed_attr_maccatalyst_zippered.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values %s
-// RUN: %target-swift-emit-sil -Xllvm -sil-print-types -parse-as-library -module-name back_deploy %s -target x86_64-apple-macosx10.15 -target-variant x86_64-apple-ios13.1-macabi -verify
-// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types -parse-as-library -module-name back_deploy %s -target x86_64-apple-macosx10.15 -target-variant x86_64-apple-ios13.1-macabi | %FileCheck %s
+// RUN: %target-swift-emit-sil -Xllvm -sil-print-types -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.15 -target-variant %target-cpu-apple-ios13.1-macabi -verify
+// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.15 -target-variant %target-cpu-apple-ios13.1-macabi | %FileCheck %s
 
 // REQUIRES: OS=macosx || OS=maccatalyst
 

--- a/test/decl/ext/objc_implementation_deployment_target.swift
+++ b/test/decl/ext/objc_implementation_deployment_target.swift
@@ -3,6 +3,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx
 // REQUIRES: swift_feature_ObjCImplementation
+// REQUIRES: SWIFT_STDLIB_ARCH=x86_64
 
 @objc @implementation extension ObjCImplSubclass {
   // expected-error@-1 {{'@implementation' of an Objective-C class requires a minimum deployment target of at least macOS 10.14.4}}

--- a/test/embedded/availability-macos.swift
+++ b/test/embedded/availability-macos.swift
@@ -1,9 +1,9 @@
 // Checks that in Embedded Swift, we allow using stdlib types even when they
 // have declared availability to be higher than our macOS deployment target.
 
-// RUN: %target-typecheck-verify-swift -target arm64-apple-macos14 -enable-experimental-feature Embedded
-// RUN: %target-typecheck-verify-swift -target arm64-apple-macos15 -enable-experimental-feature Embedded
-// RUN: %target-typecheck-verify-swift -target x86_64-apple-macos14 -enable-experimental-feature Embedded -target-min-inlining-version min
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macos14 -enable-experimental-feature Embedded
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macos15 -enable-experimental-feature Embedded
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macos14 -enable-experimental-feature Embedded -target-min-inlining-version min
 
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: OS=macosx

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -977,6 +977,11 @@ if run_cpu != 'wasm32':
 for target in config.llvm_code_generators:
   config.available_features.add("CODEGENERATOR=" + target)
 
+# Add each Swift stdlib Darwin arch as a feature.
+if config.darwin_supported_archs:
+  for arch in config.darwin_supported_archs.split(';'):
+    config.available_features.add("SWIFT_STDLIB_ARCH=" + arch)
+
 # Add the run target CPU, OS, and pointer size as features.
 config.available_features.add("CPU=" + run_cpu)
 config.available_features.add("OS=" + run_os)

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -56,6 +56,7 @@ config.shared_linker_flags = r'''@CMAKE_SHARED_LINKER_FLAGS@'''
 
 # --- Darwin ---
 config.darwin_xcrun_toolchain = "@SWIFT_DARWIN_XCRUN_TOOLCHAIN@"
+config.darwin_supported_archs = "@SWIFT_STDLIB_DARWIN_ARCHS@"
 
 # --- android ---
 config.android_ndk_path = "@SWIFT_ANDROID_NDK_PATH@"

--- a/validation-test/Sema/type_checker_crashers_fixed/embedded_with_default_isolation.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/embedded_with_default_isolation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -target arm64-apple-macos14 -enable-experimental-feature Embedded -default-isolation MainActor
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macos14 -enable-experimental-feature Embedded -default-isolation MainActor
 
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: OS=macosx

--- a/validation-test/lit.site.cfg.in
+++ b/validation-test/lit.site.cfg.in
@@ -40,6 +40,7 @@ config.swift_ide_test_test_options = "@SWIFT_IDE_TEST_TEST_OPTIONS@"
 
 # --- Darwin Configuration ---
 config.darwin_xcrun_toolchain = "@SWIFT_DARWIN_XCRUN_TOOLCHAIN@"
+config.darwin_supported_archs = "@SWIFT_STDLIB_DARWIN_ARCHS@"
 
 # --- Android Configuration ---
 config.android_ndk_path = "@SWIFT_ANDROID_NDK_PATH@"


### PR DESCRIPTION
Building with `build-script --swift-darwin-supported-archs "$(uname -m)" --test` makes for a lot of failed tests due to standard library use with hard coded architectures. Some of these can use `%target-cpu` instead of a hard coded architecture, but some of them really do rely on the standard library being built for a particular architecture.

Set the archs used to build the standard library in `SWIFT_STDLIB_ARCH=` features, and then use those to filter out tests that require the standard library in a different architecture.

Assisted-by: Claude Code

rdar://180485531