### PR TITLE
[6.4][Concurrency] TaskLocal synthesized decl must always be nonisolated

### DIFF
--- a/lib/Macros/Sources/SwiftMacros/TaskLocalMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/TaskLocalMacro.swift
@@ -99,16 +99,19 @@ extension TaskLocalMacro: PeerMacro {
 
     // If the property is global, do not prefix the synthesised decl with 'static'
     let isGlobal = context.lexicalContext.isEmpty
-    let staticKeyword: TokenSyntax?
+    let staticKw: TokenSyntax?
     if isGlobal {
-      staticKeyword = nil
+      staticKw = nil
     } else {
-      staticKeyword = TokenSyntax.keyword(.static, trailingTrivia: .space)
+      staticKw = TokenSyntax.keyword(.static, trailingTrivia: .space)
     }
+
+    let nonisolatedKw = TokenSyntax.keyword(.nonisolated, trailingTrivia: .space)
+    let dollarName = "$\(name.text)"
 
     return [
       """
-      \(attributes)\(access)\(staticKeyword)let $\(name)\(explicitTypeAnnotation) = TaskLocal(wrappedValue: \(initialValue))
+      \(attributes)\(access)\(nonisolatedKw)\(staticKw)let \(raw: dollarName)\(explicitTypeAnnotation) = TaskLocal(wrappedValue: \(initialValue))
       """
     ]
   }

--- a/test/Concurrency/Macros/task_local_macro_expansion.swift
+++ b/test/Concurrency/Macros/task_local_macro_expansion.swift
@@ -13,7 +13,7 @@ struct Nein {
   public static var example: String = "hello"
 }
 
-// CHECK: public static let $example: TaskLocal<String> = TaskLocal(wrappedValue: "hello")
+// CHECK: public nonisolated static let $example: TaskLocal<String> = TaskLocal(wrappedValue: "hello")
 //
 // CHECK:  {
 // CHECK:    get {
@@ -31,7 +31,7 @@ struct Available {
 }
 
 // CHECK: @available(OSX 10.9, *)
-// CHECK: private static let $example: TaskLocal<AvailableValue?> = TaskLocal(wrappedValue: nil)
+// CHECK: private nonisolated static let $example: TaskLocal<AvailableValue?> = TaskLocal(wrappedValue: nil)
 //
 // CHECK:  {
 // CHECK:    get {
@@ -49,7 +49,7 @@ public struct UsableFromInline {
 }
 
 // CHECK: @usableFromInline
-// CHECK: internal static let $usableVar: TaskLocal<Int?>
+// CHECK: internal nonisolated static let $usableVar: TaskLocal<Int?>
 
 @available(SwiftStdlib 5.1, *)
 extension UsableFromInline {
@@ -66,7 +66,7 @@ struct SPIExample {
 }
 
 // CHECK: @_spi(ExampleSPI)
-// CHECK: public static let $spiVar: TaskLocal<Int?>
+// CHECK: public nonisolated static let $spiVar: TaskLocal<Int?>
 
 struct SPIAvailableExample {
   @TaskLocal
@@ -75,4 +75,4 @@ struct SPIAvailableExample {
 }
 
 // CHECK: @_spi_available(macOS 10.15, *)
-// CHECK: public static let $spiAvailableVar: TaskLocal<Int?>
+// CHECK: public nonisolated static let $spiAvailableVar: TaskLocal<Int?>

--- a/test/Concurrency/async_task_locals_basic_warnings.swift
+++ b/test/Concurrency/async_task_locals_basic_warnings.swift
@@ -4,6 +4,10 @@
 // RUN: %target-swift-frontend -I %t -plugin-path %swift-plugin-dir -target %target-swift-5.1-abi-triple -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend -I %t -plugin-path %swift-plugin-dir -disable-availability-checking -swift-version 6 -parse-as-library %s -emit-sil -o /dev/null -verify
 
+// In MainActor isolation by default mode, the synthesized $variable
+// must not become MainActor isolated as that would be nonsensical
+// RUN: %target-swift-frontend -I %t -plugin-path %swift-plugin-dir -disable-availability-checking -swift-version 6 -default-isolation MainActor -parse-as-library %s -emit-sil -o /dev/null -verify
+
 // REQUIRES: concurrency
 
 actor Test {
@@ -20,4 +24,18 @@ actor Test {
   func work() async {
     print("Hello \(Self.local ?? 0)")
   }
+}
+
+@globalActor
+struct OtherGlobalActor {
+  static let shared = Test()
+}
+
+class TaskLocalContainer {
+  @TaskLocal nonisolated static var number: Int = 42
+
+  // It is allowed to @GlobalActor the variable although not very useful... 
+  // Accesses may be performed from child tasks anyway,
+  // so this doesn't guarantee only accesses from the specified actor.
+  @TaskLocal @OtherGlobalActor static var other: Int = 7
 }

--- a/test/Concurrency/task_local.swift
+++ b/test/Concurrency/task_local.swift
@@ -9,7 +9,7 @@ struct TL {
   static var number: Int = 0
   /*
   expected-expansion@-2:29{{
-    expected-note@1:8{{change 'let' to 'var' to make it mutable}}
+    expected-note@1:20{{change 'let' to 'var' to make it mutable}}
   }}
   */
 


### PR DESCRIPTION
**Explanation**: 
`@TaskLocal` synthesized variables must always be nonisolated, even in (main) actor isolated by default mode. There's no meaning in isolating these variables to the main actor because all their reads/writes are local to the task.

**Scope**: 
- TaskLocal synthesized properties are now explicitly nonisolated
- specifically this prevents compile issues in main actor isolated by default mode


**Risk**: 
- Low, these properties always were supposed to be nonisolated, other uses would have failed to compile because of conflicting isolation in the synthesized code.

**Testing**: 
- CI testing

**Original PR**:
- https://github.com/swiftlang/swift/pull/90151

**Reviewed by**:
- @xedin

**Issues**: 
- Resolves rdar://166570154