### PR TITLE
[AST] Handle synthetic macros in `ASTSourceFileScope`

### DIFF
--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -298,7 +298,8 @@ ASTSourceFileScope::ASTSourceFileScope(SourceFile *SF,
   if (auto enclosingSF = SF->getEnclosingSourceFile()) {
     SourceLoc parentLoc;
 
-    if (SF->Kind == SourceFileKind::DefaultArgument) {
+    if (SF->Kind == SourceFileKind::DefaultArgument ||
+        SF->Kind == SourceFileKind::SyntheticMacro) {
       auto genInfo = *SF->getASTContext().SourceMgr.getGeneratedSourceInfo(
           SF->getBufferID());
       parentLoc = ASTNode::getFromOpaqueValue(genInfo.astNode).getStartLoc();
@@ -315,7 +316,7 @@ ASTSourceFileScope::ASTSourceFileScope(SourceFile *SF,
     // Determine the parent source location based on the macro role.
     AbstractFunctionDecl *bodyForDecl = nullptr;
 
-    switch (*macroRole) {
+    switch (macroRole.value()) {
     case MacroRole::Expression:
     case MacroRole::Declaration:
     case MacroRole::CodeItem: {


### PR DESCRIPTION
**Context**
In `ASTSourceFileScope::ASTSourceFileScope(SourceFile *SF, ScopeCreator *scopeCreator)`, if the source file kind was not a `DefaultArgument` then it was expected to be a macro. This meant its fulfilled role (`std::optional<MacroRole>`) was expected not to be `std::nullopt`. Moreover, the value was accessed by the `*` prefix operator which can cause UB. 

This was a problem when the function was called for a synthetic macro source file kind where it would be treated as a macro and the behaviour was UB when switching over the role.

**Changes**
- Handle the case when the source file kind is `SyntheticMacro` by using its generated source info 
- removed prefix `*` on `std::optional` (UB on `std::nullopt`) `macroRole` in favor of `.value()`
