### PR TITLE
[SILOptimizer] Specialize closures with a mark_dependence on a capture

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
@@ -316,7 +316,39 @@ private func analyzeArguments(of apply: ApplySite, _ context: FunctionPassContex
   if argumentsToSpecialize.isEmpty {
     return nil
   }
+  for (argOp, _) in argumentsToSpecialize
+  where hasMultiplyCapturedDependenceBase(of: argOp.value, in: rootClosures) {
+    return nil
+  }
   return SpecializationInfo(apply: apply, closureArguments: argumentsToSpecialize, rootClosures: rootClosures)
+}
+
+private func hasMultiplyCapturedDependenceBase(of value: Value, in rootClosures: [PartialApplyInst]) -> Bool {
+  switch value {
+  case is ConvertFunctionInst,
+       is ConvertEscapeToNoEscapeInst,
+       is MoveValueInst,
+       is CopyValueInst:
+    return hasMultiplyCapturedDependenceBase(of: (value as! UnaryInstruction).operand.value, in: rootClosures)
+  case let mdi as MarkDependenceInst:
+    return isCapturedMoreThanOnce(mdi.base, in: rootClosures) ||
+      hasMultiplyCapturedDependenceBase(of: mdi.value, in: rootClosures)
+  case let partialApply as PartialApplyInst where partialApply.isPartialApplyOfThunk:
+    return hasMultiplyCapturedDependenceBase(of: partialApply.arguments[0], in: rootClosures)
+  default:
+    return false
+  }
+}
+
+private func isCapturedMoreThanOnce(_ value: Value, in rootClosures: [PartialApplyInst]) -> Bool {
+  var count = 0
+  for closure in rootClosures {
+    for capture in closure.arguments where capture == value {
+      count += 1
+      if count > 1 { return true }
+    }
+  }
+  return false
 }
 
 // Walks down the use-def chain of a function argument, recursively, to find a rootClosure.
@@ -339,8 +371,12 @@ private func findSpecializableClosure(of value: Value, _ visited: inout ValueSet
     guard let operandClosure = findSpecializableClosure(of: mdi.value, &visited) else {
       return nil
     }
-    // Make sure that the mark_dependence's base is part of the use-def chain and will therefore be cloned as well.
-    if !visited.contains(mdi.base) {
+    // The cloned mark_dependence must reference its base in the specialized function: the base is
+    // either in the closure's use-def chain (cloned) or a root-closure capture (passed as an argument).
+    var baseIsRootClosureCapture: Bool {
+      (operandClosure as? PartialApplyInst)?.arguments.contains(where: { $0 == mdi.base }) ?? false
+    }
+    if !visited.contains(mdi.base), !baseIsRootClosureCapture {
       return nil
     }
     return operandClosure
@@ -675,6 +711,10 @@ private struct SpecializationInfo {
         cloner.context)
       if !cloner.isCloned(value: originalClosureArg) {
         cloner.recordFoldedValue(originalClosureArg, mappedTo: capturedArg)
+        if let cast = originalClosureArg as? UncheckedValueCastInst,
+           !cloner.isCloned(value: cast.fromValue) {
+          cloner.recordFoldedValue(cast.fromValue, mappedTo: capturedArg)
+        }
       }
     }
   }

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
@@ -293,19 +293,22 @@ private func isCalleeSpecializable(of apply: ApplySite) -> Bool {
 private func analyzeArguments(of apply: ApplySite, _ context: FunctionPassContext) -> SpecializationInfo? {
   var argumentsToSpecialize = [(Operand, Closure)]()
   var rootClosures = [PartialApplyInst]()
+  var capturedDependencies = [CapturedDependency]()
   var rootClosuresAdded = InstructionSet(context)
   defer { rootClosuresAdded.deinitialize() }
 
   for argOp in apply.argumentOperands {
     var visited = ValueSet(context)
     defer { visited.deinitialize() }
-    if let closure = findSpecializableClosure(of: argOp.value, &visited),
+    var argumentDependencies = [CapturedDependency]()
+    if let closure = findSpecializableClosure(of: argOp.value, &visited, &argumentDependencies),
        // Ok, we know that we can perform the optimization but not whether or not the optimization
        // is profitable. Check if the closure is actually called in the callee (or in a function
        // called by the callee). This opens optimization opportunities, like inlining.
        isClosureApplied(apply.calleeArgument(of: argOp, in: apply.referencedFunction!)!)
     {
       argumentsToSpecialize.append((argOp, closure))
+      capturedDependencies.append(contentsOf: argumentDependencies)
       if let partialApply = closure as? PartialApplyInst,
          rootClosuresAdded.insert(partialApply)
       {
@@ -316,43 +319,13 @@ private func analyzeArguments(of apply: ApplySite, _ context: FunctionPassContex
   if argumentsToSpecialize.isEmpty {
     return nil
   }
-  for (argOp, _) in argumentsToSpecialize
-  where hasMultiplyCapturedDependenceBase(of: argOp.value, in: rootClosures) {
-    return nil
-  }
-  return SpecializationInfo(apply: apply, closureArguments: argumentsToSpecialize, rootClosures: rootClosures)
-}
-
-private func hasMultiplyCapturedDependenceBase(of value: Value, in rootClosures: [PartialApplyInst]) -> Bool {
-  switch value {
-  case is ConvertFunctionInst,
-       is ConvertEscapeToNoEscapeInst,
-       is MoveValueInst,
-       is CopyValueInst:
-    return hasMultiplyCapturedDependenceBase(of: (value as! UnaryInstruction).operand.value, in: rootClosures)
-  case let mdi as MarkDependenceInst:
-    return isCapturedMoreThanOnce(mdi.base, in: rootClosures) ||
-      hasMultiplyCapturedDependenceBase(of: mdi.value, in: rootClosures)
-  case let partialApply as PartialApplyInst where partialApply.isPartialApplyOfThunk:
-    return hasMultiplyCapturedDependenceBase(of: partialApply.arguments[0], in: rootClosures)
-  default:
-    return false
-  }
-}
-
-private func isCapturedMoreThanOnce(_ value: Value, in rootClosures: [PartialApplyInst]) -> Bool {
-  var count = 0
-  for closure in rootClosures {
-    for capture in closure.arguments where capture == value {
-      count += 1
-      if count > 1 { return true }
-    }
-  }
-  return false
+  return SpecializationInfo(apply: apply, closureArguments: argumentsToSpecialize, rootClosures: rootClosures,
+                            capturedDependencies: capturedDependencies)
 }
 
 // Walks down the use-def chain of a function argument, recursively, to find a rootClosure.
-private func findSpecializableClosure(of value: Value, _ visited: inout ValueSet) -> Closure? {
+private func findSpecializableClosure(of value: Value, _ visited: inout ValueSet,
+                                      _ capturedDependencies: inout [CapturedDependency]) -> Closure? {
   visited.insert(value)
 
   let specializationLevelLimit = 2
@@ -362,22 +335,23 @@ private func findSpecializableClosure(of value: Value, _ visited: inout ValueSet
        is ConvertEscapeToNoEscapeInst,
        is MoveValueInst,
        is CopyValueInst:
-    return findSpecializableClosure(of: (value as! UnaryInstruction).operand.value, &visited)
+    return findSpecializableClosure(of: (value as! UnaryInstruction).operand.value, &visited, &capturedDependencies)
 
   case let mdi as MarkDependenceInst:
     guard mdi.value.type.isNoEscapeFunction, mdi.value.type.isThickFunction else {
       return nil
     }
-    guard let operandClosure = findSpecializableClosure(of: mdi.value, &visited) else {
+    guard let operandClosure = findSpecializableClosure(of: mdi.value, &visited, &capturedDependencies) else {
       return nil
     }
-    // The cloned mark_dependence must reference its base in the specialized function: the base is
-    // either in the closure's use-def chain (cloned) or a root-closure capture (passed as an argument).
-    var baseIsRootClosureCapture: Bool {
-      (operandClosure as? PartialApplyInst)?.arguments.contains(where: { $0 == mdi.base }) ?? false
-    }
-    if !visited.contains(mdi.base), !baseIsRootClosureCapture {
-      return nil
+    // A base not in the closure's use-def chain must be a root-closure capture; record it for `uniqueCaptureArguments`.
+    if !visited.contains(mdi.base) {
+      guard let rootClosure = operandClosure as? PartialApplyInst,
+            rootClosure.arguments.contains(where: { $0 == mdi.base })
+      else {
+        return nil
+      }
+      capturedDependencies.append((closure: rootClosure, markDependence: mdi))
     }
     return operandClosure
 
@@ -391,7 +365,7 @@ private func findSpecializableClosure(of value: Value, _ visited: inout ValueSet
     //   apply %f(%3)
     // ```
     if partialApply.isPartialApplyOfThunk,
-       let argumentClosure = findSpecializableClosure(of: partialApply.arguments[0], &visited)
+       let argumentClosure = findSpecializableClosure(of: partialApply.arguments[0], &visited, &capturedDependencies)
     {
       return argumentClosure
     }
@@ -441,6 +415,9 @@ private func findSpecializableClosure(of value: Value, _ visited: inout ValueSet
 /// Either a `partial_apply` or a `thin_to_thick_function`
 private typealias Closure = SingleValueInstruction
 
+/// A `mark_dependence` whose base is a root-closure capture, paired with that capturing closure.
+private typealias CapturedDependency = (closure: PartialApplyInst, markDependence: MarkDependenceInst)
+
 /// Information about the function to be specialized and for which closure arguments.
 private struct SpecializationInfo {
 
@@ -462,6 +439,9 @@ private struct SpecializationInfo {
   // All rootClosures of `closureArguments` which are `partial_apply`s, and uniqued: if a rootClosure
   // appears multiple times in `closureArguments`, it's only added a single time here.
   let rootClosures: [PartialApplyInst]
+
+  // `mark_dependence`s whose base is a root-closure capture, redirected onto the capture's cast in `uniqueCaptureArguments`.
+  let capturedDependencies: [CapturedDependency]
 
   // The function to specialize
   var callee: Function { apply.referencedFunction! }
@@ -711,10 +691,6 @@ private struct SpecializationInfo {
         cloner.context)
       if !cloner.isCloned(value: originalClosureArg) {
         cloner.recordFoldedValue(originalClosureArg, mappedTo: capturedArg)
-        if let cast = originalClosureArg as? UncheckedValueCastInst,
-           !cloner.isCloned(value: cast.fromValue) {
-          cloner.recordFoldedValue(cast.fromValue, mappedTo: capturedArg)
-        }
       }
     }
   }
@@ -787,8 +763,15 @@ private struct SpecializationInfo {
     //
     for closure in rootClosures {
       for argOp in closure.argumentOperands {
-        let cast = builder.createUncheckedValueCast(from: argOp.value, to: argOp.value.type)
+        let capturedValue = argOp.value
+        let cast = builder.createUncheckedValueCast(from: capturedValue, to: capturedValue.type)
         argOp.set(to: cast, context)
+
+        // Redirect the mark_dependence base onto the same cast, so it stays unique alongside its capture.
+        for dependency in capturedDependencies
+        where dependency.closure == closure && dependency.markDependence.base == capturedValue {
+          dependency.markDependence.baseOperand.set(to: cast, context)
+        }
       }
     }
   }

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
@@ -364,10 +364,15 @@ private func findSpecializableClosure(of value: Value, _ visited: inout ValueSet
     //   %3 = partial_apply %2(%1)      // re-abstraction
     //   apply %f(%3)
     // ```
-    if partialApply.isPartialApplyOfThunk,
-       let argumentClosure = findSpecializableClosure(of: partialApply.arguments[0], &visited, &capturedDependencies)
-    {
-      return argumentClosure
+    if partialApply.isPartialApplyOfThunk {
+      // Keep the recorded dependencies only if the thunk's argument provides the root closure;
+      // otherwise the thunk's partial_apply itself is tried as the root, below.
+      var argumentDependencies = [CapturedDependency]()
+      if let argumentClosure = findSpecializableClosure(of: partialApply.arguments[0], &visited,
+                                                        &argumentDependencies) {
+        capturedDependencies.append(contentsOf: argumentDependencies)
+        return argumentClosure
+      }
     }
     guard let callee = partialApply.referencedFunction,
           !partialApply.hasSubstitutions,
@@ -440,7 +445,8 @@ private struct SpecializationInfo {
   // appears multiple times in `closureArguments`, it's only added a single time here.
   let rootClosures: [PartialApplyInst]
 
-  // `mark_dependence`s whose base is a root-closure capture, redirected onto the capture's cast in `uniqueCaptureArguments`.
+  // `mark_dependence`s whose base is a root-closure capture. The base is redirected onto the
+  // capture's cast in `uniqueCaptureArguments`.
   let capturedDependencies: [CapturedDependency]
 
   // The function to specialize
@@ -767,7 +773,8 @@ private struct SpecializationInfo {
         let cast = builder.createUncheckedValueCast(from: capturedValue, to: capturedValue.type)
         argOp.set(to: cast, context)
 
-        // Redirect the mark_dependence base onto the same cast, so it stays unique alongside its capture.
+        // Redirect the mark_dependence base onto the same cast: the cloner only maps the cast to
+        // the capture argument, and a shared base must follow its own closure's capture.
         for dependency in capturedDependencies
         where dependency.closure == closure && dependency.markDependence.base == capturedValue {
           dependency.markDependence.baseOperand.set(to: cast, context)

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -1009,7 +1009,15 @@ deadMarkDependenceUser(SILInstruction *inst,
     return false;
   deleteInsts.push_back(inst);
   for (auto *use : cast<SingleValueInstruction>(inst)->getUses()) {
-    if (!deadMarkDependenceUser(use->getUser(), deleteInsts))
+    SILInstruction *user = use->getUser();
+    // In OSSA, destroys of the closure are on the forwarded mark_dependence
+    // value; accept them like the destroys of the partial_apply itself.
+    if (isa<DeallocStackInst>(user) || isa<DebugValueInst>(user) ||
+        isa<DestroyValueInst>(user)) {
+      deleteInsts.push_back(user);
+      continue;
+    }
+    if (!deadMarkDependenceUser(user, deleteInsts))
       return false;
   }
   return true;
@@ -1129,7 +1137,8 @@ bool swift::tryDeleteDeadClosure(SingleValueInstruction *closure,
     return false;
 
   // A stack allocated partial apply does not have any release users. Delete it
-  // if the only users are the dealloc_stack and mark_dependence instructions.
+  // if the only users are dealloc_stack, debug_value and destroy_value
+  // instructions, either directly or forwarded through mark_dependence.
   if (pa && pa->isOnStack()) {
     SmallVector<SILInstruction *, 8> deleteInsts;
     for (auto *use : pa->getUses()) {

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -1002,22 +1002,29 @@ void swift::releasePartialApplyCapturedArg(SILBuilder &builder, SILLocation loc,
   emitDestroyOperation(builder, loc, arg, callbacks);
 }
 
+/// Returns true if \p user is a user of an on-stack closure which can be
+/// deleted together with the closure.
+static bool isDeadOnStackClosureUser(SILInstruction *user) {
+  return isa<DeallocStackInst>(user) || isa<DebugValueInst>(user) ||
+         isa<DestroyValueInst>(user);
+}
+
 static bool
-deadMarkDependenceUser(SILInstruction *inst,
+deadMarkDependenceUser(Operand *use,
                        SmallVectorImpl<SILInstruction *> &deleteInsts) {
-  if (!isa<MarkDependenceInst>(inst))
+  auto *mdi = dyn_cast<MarkDependenceInst>(use->getUser());
+  // If the closure is the base operand, another value depends on it. Deleting
+  // the mark_dependence and the destroys of its result would leak that value.
+  if (!mdi || use->getOperandNumber() != MarkDependenceInst::Dependent)
     return false;
-  deleteInsts.push_back(inst);
-  for (auto *use : cast<SingleValueInstruction>(inst)->getUses()) {
-    SILInstruction *user = use->getUser();
-    // In OSSA, destroys of the closure are on the forwarded mark_dependence
-    // value; accept them like the destroys of the partial_apply itself.
-    if (isa<DeallocStackInst>(user) || isa<DebugValueInst>(user) ||
-        isa<DestroyValueInst>(user)) {
-      deleteInsts.push_back(user);
+  deleteInsts.push_back(mdi);
+  for (auto *mdiUse : mdi->getUses()) {
+    // In OSSA the closure is destroyed via the forwarding mark_dependence.
+    if (isDeadOnStackClosureUser(mdiUse->getUser())) {
+      deleteInsts.push_back(mdiUse->getUser());
       continue;
     }
-    if (!deadMarkDependenceUser(user, deleteInsts))
+    if (!deadMarkDependenceUser(mdiUse, deleteInsts))
       return false;
   }
   return true;
@@ -1137,17 +1144,14 @@ bool swift::tryDeleteDeadClosure(SingleValueInstruction *closure,
     return false;
 
   // A stack allocated partial apply does not have any release users. Delete it
-  // if the only users are dealloc_stack, debug_value and destroy_value
+  // if the only users are the dealloc_stack, debug_value and destroy_value
   // instructions, either directly or forwarded through mark_dependence.
   if (pa && pa->isOnStack()) {
     SmallVector<SILInstruction *, 8> deleteInsts;
     for (auto *use : pa->getUses()) {
-      SILInstruction *user = use->getUser();
-      if (isa<DeallocStackInst>(user)
-          || isa<DebugValueInst>(user)
-          || isa<DestroyValueInst>(user)) {
-        deleteInsts.push_back(user);
-      } else if (!deadMarkDependenceUser(user, deleteInsts)) {
+      if (isDeadOnStackClosureUser(use->getUser())) {
+        deleteInsts.push_back(use->getUser());
+      } else if (!deadMarkDependenceUser(use, deleteInsts)) {
         return false;
       }
     }

--- a/test/DebugInfo/salvage_convert_function.sil
+++ b/test/DebugInfo/salvage_convert_function.sil
@@ -28,11 +28,13 @@ bb0(%0 : $@callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error an
   return %r : $()
 }
 
-sil @closure_body : $@convention(thin) (Int, @in_guaranteed Array<Int>) -> Int
-
 // Test that when the debug_value is on a begin_borrow of the convert_function,
 // it still gets salvaged.
 // This is reduced SIL from the standard library that was causing a crash.
+//
+// Here and in the test below the closure is a function argument and not an
+// on-stack partial_apply, so that SILCombine cannot delete it as a dead
+// closure. Otherwise the debug_value would be deleted along with it.
 
 // CHECK-LABEL: sil [ossa] @test_salvage_convert_function_through_borrow
 // CHECK:   debug_value %{{[0-9]+}}, let, name "body", argno 1, transform {
@@ -41,14 +43,12 @@ sil @closure_body : $@convention(thin) (Int, @in_guaranteed Array<Int>) -> Int
 // CHECK:     return %1
 // CHECK:   }
 // CHECK: } // end sil function 'test_salvage_convert_function_through_borrow'
-sil [ossa] @test_salvage_convert_function_through_borrow : $@convention(thin) (@guaranteed Array<Int>, Int) -> Int {
-bb0(%0 : @guaranteed $Array<Int>, %1 : $Int):
+sil [ossa] @test_salvage_convert_function_through_borrow : $@convention(thin) (@owned @noescape @callee_guaranteed (Int) -> Int, @guaranteed Array<Int>) -> () {
+bb0(%closure : @owned $@noescape @callee_guaranteed (Int) -> Int, %0 : @guaranteed $Array<Int>):
   %alloc = alloc_stack $Array<Int>
   %sb = store_borrow %0 to %alloc : $*Array<Int>
 
-  %fn = function_ref @closure_body : $@convention(thin) (Int, @in_guaranteed Array<Int>) -> Int
-  %pa = partial_apply [callee_guaranteed] [on_stack] %fn(%sb) : $@convention(thin) (Int, @in_guaranteed Array<Int>) -> Int
-  %md = mark_dependence [nonescaping] %pa : $@noescape @callee_guaranteed (Int) -> Int on %sb : $*Array<Int>
+  %md = mark_dependence [nonescaping] %closure : $@noescape @callee_guaranteed (Int) -> Int on %sb : $*Array<Int>
   %cf = convert_function %md : $@noescape @callee_guaranteed (Int) -> Int to $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>
   %bb = begin_borrow %cf : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>
 
@@ -57,12 +57,12 @@ bb0(%0 : @guaranteed $Array<Int>, %1 : $Int):
     return %d0 : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>
   }
 
-  %r = apply %bb(%1) : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>
   end_borrow %bb : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>
   destroy_value %cf : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>
   end_borrow %sb : $*Array<Int>
   dealloc_stack %alloc : $*Array<Int>
-  return %r : $Int
+  %r = tuple ()
+  return %r : $()
 }
 
 // Test multiple levels, with both a begin_borrow and a copy_value.
@@ -74,14 +74,12 @@ bb0(%0 : @guaranteed $Array<Int>, %1 : $Int):
 // CHECK:     return %1
 // CHECK:   }
 // CHECK: } // end sil function 'test_salvage_convert_function_multilevel'
-sil [ossa] @test_salvage_convert_function_multilevel : $@convention(thin) (@guaranteed Array<Int>, Int) -> Int {
-bb0(%0 : @guaranteed $Array<Int>, %1 : $Int):
+sil [ossa] @test_salvage_convert_function_multilevel : $@convention(thin) (@owned @noescape @callee_guaranteed (Int) -> Int, @guaranteed Array<Int>) -> () {
+bb0(%closure : @owned $@noescape @callee_guaranteed (Int) -> Int, %0 : @guaranteed $Array<Int>):
   %alloc = alloc_stack $Array<Int>
   %sb = store_borrow %0 to %alloc : $*Array<Int>
 
-  %fn = function_ref @closure_body : $@convention(thin) (Int, @in_guaranteed Array<Int>) -> Int
-  %pa = partial_apply [callee_guaranteed] [on_stack] %fn(%sb) : $@convention(thin) (Int, @in_guaranteed Array<Int>) -> Int
-  %md = mark_dependence [nonescaping] %pa : $@noescape @callee_guaranteed (Int) -> Int on %sb : $*Array<Int>
+  %md = mark_dependence [nonescaping] %closure : $@noescape @callee_guaranteed (Int) -> Int on %sb : $*Array<Int>
   %cf = convert_function %md : $@noescape @callee_guaranteed (Int) -> Int to $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>
   %bb = begin_borrow %cf : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>
   %cp = copy_value %bb : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>
@@ -91,11 +89,11 @@ bb0(%0 : @guaranteed $Array<Int>, %1 : $Int):
     return %d0 : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>
   }
 
-  %r = apply %cp(%1) : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>
   destroy_value %cp : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>
   end_borrow %bb : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>
   destroy_value %cf : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>
   end_borrow %sb : $*Array<Int>
   dealloc_stack %alloc : $*Array<Int>
-  return %r : $Int
+  %r = tuple ()
+  return %r : $()
 }

--- a/test/SILOptimizer/closure_specialization_attrs.sil
+++ b/test/SILOptimizer/closure_specialization_attrs.sil
@@ -57,10 +57,13 @@ bb0(%0 : @owned $C):
 // the closure's `mark_dependence` on its capture.)
 
 // The specialized function takes the capture @guaranteed (never @owned) and contains no
-// retain, so it remains [readonly]-safe.
+// retain, so it remains [readonly]-safe. The closure is re-formed inside the specialized
+// function, so its `mark_dependence` is re-materialized on the @guaranteed capture argument.
 // CHECK-LABEL: sil private [readonly] [ossa] @$s20takesReadOnlyClosure{{.*}}Tf1c_n : $@convention(thin) (@guaranteed Storage) -> Val {
-// CHECK-NOT: @owned
-// CHECK-NOT: copy_value
+// CHECK:       [[PA:%[0-9]+]] = partial_apply [callee_guaranteed] [on_stack] {{%[0-9]+}}(%0)
+// CHECK:       mark_dependence [[PA]] on %0
+// CHECK-NOT:   @owned
+// CHECK-NOT:   copy_value
 // CHECK-LABEL: } // end sil function '$s20takesReadOnlyClosure{{.*}}Tf1c_n'
 sil private [readonly] [ossa] @takesReadOnlyClosure : $@convention(thin) (@guaranteed @noescape @callee_guaranteed (Val) -> Val) -> Val {
 bb0(%2 : @guaranteed $@noescape @callee_guaranteed (Val) -> Val):

--- a/test/SILOptimizer/closure_specialization_attrs.sil
+++ b/test/SILOptimizer/closure_specialization_attrs.sil
@@ -51,14 +51,11 @@ bb0(%0 : @owned $C):
 // =============================================================================
 // rdar://105887096: do not insert a retain inside a read-only function.
 //
-// A non-escaping (on-stack) closure passed to a [readonly] function can be specialized:
-// the closure's captures are passed as @guaranteed arguments, so no retain/copy is
-// introduced and the [readonly] effect is preserved. (This is reached by looking through
-// the closure's `mark_dependence` on its capture.)
+// A non-escaping (on-stack) closure can be specialized even for a [readonly] callee: its
+// captures are passed as @guaranteed arguments, so no retain is introduced.
 
-// The specialized function takes the capture @guaranteed (never @owned) and contains no
-// retain, so it remains [readonly]-safe. The closure is re-formed inside the specialized
-// function, so its `mark_dependence` is re-materialized on the @guaranteed capture argument.
+// The capture stays @guaranteed (never @owned) and the re-formed closure's mark_dependence
+// is re-materialized on the capture argument.
 // CHECK-LABEL: sil private [readonly] [ossa] @$s20takesReadOnlyClosure{{.*}}Tf1c_n : $@convention(thin) (@guaranteed Storage) -> Val {
 // CHECK:       [[PA:%[0-9]+]] = partial_apply [callee_guaranteed] [on_stack] {{%[0-9]+}}(%0)
 // CHECK:       mark_dependence [[PA]] on %0
@@ -78,11 +75,15 @@ bb0(%0 : $Val, %1 : @closureCapture @guaranteed $Storage):
   return %46 : $Val
 }
 
-// The closure is replaced by a direct call to the specialized function, passing the
-// capture @guaranteed (no @owned Storage, so no retain at the call site either).
+// The apply is rewritten to a direct call passing the capture @guaranteed; the dead closure
+// and its mark_dependence are deleted.
 // CHECK-LABEL: sil [ossa] @testPassReadOnlyClosure : $@convention(method) (@guaranteed Storage) -> Val {
 // CHECK-NOT: @owned Storage
+// CHECK-NOT: partial_apply
+// CHECK-NOT: mark_dependence
 // CHECK: apply %{{.*}} : $@convention(thin) (@guaranteed Storage) -> Val
+// CHECK-NOT: partial_apply
+// CHECK-NOT: mark_dependence
 // CHECK-LABEL: } // end sil function 'testPassReadOnlyClosure'
 sil [ossa] @testPassReadOnlyClosure : $@convention(method) (@guaranteed Storage) -> Val {
 bb0(%0 : @guaranteed $Storage):

--- a/test/SILOptimizer/closure_specialization_attrs.sil
+++ b/test/SILOptimizer/closure_specialization_attrs.sil
@@ -50,13 +50,18 @@ bb0(%0 : @owned $C):
 
 // =============================================================================
 // rdar://105887096: do not insert a retain inside a read-only function.
-// For now, the specialization is disabled.
 //
-// TODO: A @noescape closure should never be converted to an @owned argument
-// regardless of the function attribute.
+// A non-escaping (on-stack) closure passed to a [readonly] function can be specialized:
+// the closure's captures are passed as @guaranteed arguments, so no retain/copy is
+// introduced and the [readonly] effect is preserved. (This is reached by looking through
+// the closure's `mark_dependence` on its capture.)
 
-// This should not be specialized until we support guaranteed arguments.
-// CHECK-NOT: @$s20takesReadOnlyClosure
+// The specialized function takes the capture @guaranteed (never @owned) and contains no
+// retain, so it remains [readonly]-safe.
+// CHECK-LABEL: sil private [readonly] [ossa] @$s20takesReadOnlyClosure{{.*}}Tf1c_n : $@convention(thin) (@guaranteed Storage) -> Val {
+// CHECK-NOT: @owned
+// CHECK-NOT: copy_value
+// CHECK-LABEL: } // end sil function '$s20takesReadOnlyClosure{{.*}}Tf1c_n'
 sil private [readonly] [ossa] @takesReadOnlyClosure : $@convention(thin) (@guaranteed @noescape @callee_guaranteed (Val) -> Val) -> Val {
 bb0(%2 : @guaranteed $@noescape @callee_guaranteed (Val) -> Val):
   %46 = struct $Val ()
@@ -70,9 +75,11 @@ bb0(%0 : $Val, %1 : @closureCapture @guaranteed $Storage):
   return %46 : $Val
 }
 
+// The closure is replaced by a direct call to the specialized function, passing the
+// capture @guaranteed (no @owned Storage, so no retain at the call site either).
 // CHECK-LABEL: sil [ossa] @testPassReadOnlyClosure : $@convention(method) (@guaranteed Storage) -> Val {
 // CHECK-NOT: @owned Storage
-// CHECK: apply %{{.*}} : $@convention(thin) (@guaranteed @noescape @callee_guaranteed (Val) -> Val) -> Val
+// CHECK: apply %{{.*}} : $@convention(thin) (@guaranteed Storage) -> Val
 // CHECK-LABEL: } // end sil function 'testPassReadOnlyClosure'
 sil [ossa] @testPassReadOnlyClosure : $@convention(method) (@guaranteed Storage) -> Val {
 bb0(%0 : @guaranteed $Storage):

--- a/test/SILOptimizer/closure_specialization_multiple_captures.sil
+++ b/test/SILOptimizer/closure_specialization_multiple_captures.sil
@@ -1,8 +1,7 @@
 // RUN: %target-sil-opt -enable-sil-verify-all -closure-specialization %s | %FileCheck %s
 
-// A value captured more than once by a non-escaping closure must still be specialized.
-// `uniqueCaptureArguments` gives each capture its own identity cast and redirects the
-// `mark_dependence` base onto that cast, so cloning maps each captured value exactly once.
+// A value captured more than once, with a mark_dependence on it, must still be specialized:
+// uniqueCaptureArguments redirects the mark_dependence base onto the capture's identity cast.
 
 import Builtin
 
@@ -18,7 +17,7 @@ bb0(%0 : @guaranteed $@noescape @callee_guaranteed (Val) -> Val):
 }
 
 // %0 is captured twice; the specialized function takes it as two @guaranteed arguments and
-// re-materializes the `mark_dependence` on the first one.
+// re-materializes the mark_dependence on the first one.
 // CHECK-LABEL: sil {{.*}}@$s12takesClosure{{.*}}Tf1c_n : $@convention(thin) (@guaranteed Storage, @guaranteed Storage) -> Val {
 // CHECK:       [[PA:%[0-9]+]] = partial_apply [callee_guaranteed] [on_stack] {{%[0-9]+}}(%0, %1)
 // CHECK:       mark_dependence [[PA]] on %0
@@ -29,11 +28,14 @@ bb0(%0 : $Val, %1 : @closureCapture @guaranteed $Storage, %2 : @closureCapture @
   return %r : $Val
 }
 
-// The closure is specialized away: a direct call passing the capture twice, with no residual
-// `partial_apply` / `mark_dependence` at the call site.
+// The apply is rewritten to a direct call passing the capture twice; the dead closure and its
+// mark_dependence are deleted.
 // CHECK-LABEL: sil [ossa] @testMultiplyCaptured : $@convention(method) (@guaranteed Storage) -> Val {
+// CHECK-NOT:   partial_apply
+// CHECK-NOT:   mark_dependence
 // CHECK:       [[F:%[0-9]+]] = function_ref @$s12takesClosure{{.*}}Tf1c_n
 // CHECK:       apply [[F]](%0, %0)
+// CHECK-NOT:   partial_apply
 // CHECK-NOT:   mark_dependence
 // CHECK-LABEL: } // end sil function 'testMultiplyCaptured'
 sil [ossa] @testMultiplyCaptured : $@convention(method) (@guaranteed Storage) -> Val {

--- a/test/SILOptimizer/closure_specialization_multiple_captures.sil
+++ b/test/SILOptimizer/closure_specialization_multiple_captures.sil
@@ -1,0 +1,48 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -closure-specialization %s | %FileCheck %s
+
+// A value captured more than once by a non-escaping closure must still be specialized.
+// `uniqueCaptureArguments` gives each capture its own identity cast and redirects the
+// `mark_dependence` base onto that cast, so cloning maps each captured value exactly once.
+
+import Builtin
+
+class Storage {}
+
+struct Val {}
+
+sil private [readonly] [ossa] @takesClosure : $@convention(thin) (@guaranteed @noescape @callee_guaranteed (Val) -> Val) -> Val {
+bb0(%0 : @guaranteed $@noescape @callee_guaranteed (Val) -> Val):
+  %v = struct $Val ()
+  %r = apply %0(%v) : $@noescape @callee_guaranteed (Val) -> Val
+  return %r : $Val
+}
+
+// %0 is captured twice; the specialized function takes it as two @guaranteed arguments and
+// re-materializes the `mark_dependence` on the first one.
+// CHECK-LABEL: sil {{.*}}@$s12takesClosure{{.*}}Tf1c_n : $@convention(thin) (@guaranteed Storage, @guaranteed Storage) -> Val {
+// CHECK:       [[PA:%[0-9]+]] = partial_apply [callee_guaranteed] [on_stack] {{%[0-9]+}}(%0, %1)
+// CHECK:       mark_dependence [[PA]] on %0
+// CHECK-LABEL: } // end sil function '$s12takesClosure{{.*}}Tf1c_n'
+sil private [ossa] @twiceCapturingClosure : $@convention(thin) (Val, @guaranteed Storage, @guaranteed Storage) -> Val {
+bb0(%0 : $Val, %1 : @closureCapture @guaranteed $Storage, %2 : @closureCapture @guaranteed $Storage):
+  %r = struct $Val ()
+  return %r : $Val
+}
+
+// The closure is specialized away: a direct call passing the capture twice, with no residual
+// `partial_apply` / `mark_dependence` at the call site.
+// CHECK-LABEL: sil [ossa] @testMultiplyCaptured : $@convention(method) (@guaranteed Storage) -> Val {
+// CHECK:       [[F:%[0-9]+]] = function_ref @$s12takesClosure{{.*}}Tf1c_n
+// CHECK:       apply [[F]](%0, %0)
+// CHECK-NOT:   mark_dependence
+// CHECK-LABEL: } // end sil function 'testMultiplyCaptured'
+sil [ossa] @testMultiplyCaptured : $@convention(method) (@guaranteed Storage) -> Val {
+bb0(%0 : @guaranteed $Storage):
+  %c = function_ref @twiceCapturingClosure : $@convention(thin) (Val, @guaranteed Storage, @guaranteed Storage) -> Val
+  %pa = partial_apply [callee_guaranteed] [on_stack] %c(%0, %0) : $@convention(thin) (Val, @guaranteed Storage, @guaranteed Storage) -> Val
+  %md = mark_dependence %pa : $@noescape @callee_guaranteed (Val) -> Val on %0 : $Storage
+  %f = function_ref @takesClosure : $@convention(thin) (@guaranteed @noescape @callee_guaranteed (Val) -> Val) -> Val
+  %r = apply %f(%md) : $@convention(thin) (@guaranteed @noescape @callee_guaranteed (Val) -> Val) -> Val
+  destroy_value %md
+  return %r : $Val
+}

--- a/test/SILOptimizer/closure_specialization_shared_dependence_base.sil
+++ b/test/SILOptimizer/closure_specialization_shared_dependence_base.sil
@@ -1,9 +1,7 @@
 // RUN: %target-sil-opt -enable-sil-verify-all -closure-specialization %s | %FileCheck %s
 
-// The same value is captured by two different non-escaping closures passed to one call. Each
-// closure's `mark_dependence` base is that shared value. After specialization, each base must be
-// re-materialized on *its own* captured argument -- not both on the first one -- which is why the
-// dependence is recorded per root closure (see `findSpecializableClosure` / `uniqueCaptureArguments`).
+// The same value is captured by two closures passed to one call, each with a mark_dependence
+// on it. After specialization, each base must be re-materialized on its own closure's argument.
 
 import Builtin
 
@@ -31,7 +29,7 @@ bb0(%0 : $Val, %1 : @closureCapture @guaranteed $Storage):
   return %r : $Val
 }
 
-// The two captures become two arguments, and each closure's `mark_dependence` is re-materialized on
+// The two captures become two arguments, and each closure's mark_dependence is re-materialized on
 // its own argument: closureA's on %0, closureB's on %1.
 // CHECK-LABEL: sil {{.*}}@$s16takesTwoClosures{{.*}}Tf1cc_n : $@convention(thin) (@guaranteed Storage, @guaranteed Storage) -> Val {
 // CHECK:       [[PA0:%[0-9]+]] = partial_apply [callee_guaranteed] [on_stack] {{%[0-9]+}}(%0)
@@ -39,6 +37,17 @@ bb0(%0 : $Val, %1 : @closureCapture @guaranteed $Storage):
 // CHECK:       [[PA1:%[0-9]+]] = partial_apply [callee_guaranteed] [on_stack] {{%[0-9]+}}(%1)
 // CHECK:       mark_dependence [[PA1]] on %1
 // CHECK-LABEL: } // end sil function '$s16takesTwoClosures{{.*}}Tf1cc_n'
+
+// The apply is rewritten to a direct call passing the shared capture once per closure; the dead
+// closures and their mark_dependences are deleted.
+// CHECK-LABEL: sil [ossa] @testSharedDependenceBase : $@convention(method) (@guaranteed Storage) -> Val {
+// CHECK-NOT:   partial_apply
+// CHECK-NOT:   mark_dependence
+// CHECK:       [[F:%[0-9]+]] = function_ref @$s16takesTwoClosures{{.*}}Tf1cc_n
+// CHECK:       apply [[F]](%0, %0)
+// CHECK-NOT:   partial_apply
+// CHECK-NOT:   mark_dependence
+// CHECK-LABEL: } // end sil function 'testSharedDependenceBase'
 sil [ossa] @testSharedDependenceBase : $@convention(method) (@guaranteed Storage) -> Val {
 bb0(%0 : @guaranteed $Storage):
   %fa = function_ref @closureA : $@convention(thin) (Val, @guaranteed Storage) -> Val

--- a/test/SILOptimizer/closure_specialization_shared_dependence_base.sil
+++ b/test/SILOptimizer/closure_specialization_shared_dependence_base.sil
@@ -1,0 +1,55 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -closure-specialization %s | %FileCheck %s
+
+// The same value is captured by two different non-escaping closures passed to one call. Each
+// closure's `mark_dependence` base is that shared value. After specialization, each base must be
+// re-materialized on *its own* captured argument -- not both on the first one -- which is why the
+// dependence is recorded per root closure (see `findSpecializableClosure` / `uniqueCaptureArguments`).
+
+import Builtin
+
+class Storage {}
+
+struct Val {}
+
+sil private [readonly] [ossa] @takesTwoClosures : $@convention(thin) (@guaranteed @noescape @callee_guaranteed (Val) -> Val, @guaranteed @noescape @callee_guaranteed (Val) -> Val) -> Val {
+bb0(%0 : @guaranteed $@noescape @callee_guaranteed (Val) -> Val, %1 : @guaranteed $@noescape @callee_guaranteed (Val) -> Val):
+  %v = struct $Val ()
+  %a = apply %0(%v) : $@noescape @callee_guaranteed (Val) -> Val
+  %b = apply %1(%v) : $@noescape @callee_guaranteed (Val) -> Val
+  return %a : $Val
+}
+
+sil private [ossa] @closureA : $@convention(thin) (Val, @guaranteed Storage) -> Val {
+bb0(%0 : $Val, %1 : @closureCapture @guaranteed $Storage):
+  %r = struct $Val ()
+  return %r : $Val
+}
+
+sil private [ossa] @closureB : $@convention(thin) (Val, @guaranteed Storage) -> Val {
+bb0(%0 : $Val, %1 : @closureCapture @guaranteed $Storage):
+  %r = struct $Val ()
+  return %r : $Val
+}
+
+// The two captures become two arguments, and each closure's `mark_dependence` is re-materialized on
+// its own argument: closureA's on %0, closureB's on %1.
+// CHECK-LABEL: sil {{.*}}@$s16takesTwoClosures{{.*}}Tf1cc_n : $@convention(thin) (@guaranteed Storage, @guaranteed Storage) -> Val {
+// CHECK:       [[PA0:%[0-9]+]] = partial_apply [callee_guaranteed] [on_stack] {{%[0-9]+}}(%0)
+// CHECK:       mark_dependence [[PA0]] on %0
+// CHECK:       [[PA1:%[0-9]+]] = partial_apply [callee_guaranteed] [on_stack] {{%[0-9]+}}(%1)
+// CHECK:       mark_dependence [[PA1]] on %1
+// CHECK-LABEL: } // end sil function '$s16takesTwoClosures{{.*}}Tf1cc_n'
+sil [ossa] @testSharedDependenceBase : $@convention(method) (@guaranteed Storage) -> Val {
+bb0(%0 : @guaranteed $Storage):
+  %fa = function_ref @closureA : $@convention(thin) (Val, @guaranteed Storage) -> Val
+  %paA = partial_apply [callee_guaranteed] [on_stack] %fa(%0) : $@convention(thin) (Val, @guaranteed Storage) -> Val
+  %mdA = mark_dependence %paA : $@noescape @callee_guaranteed (Val) -> Val on %0 : $Storage
+  %fb = function_ref @closureB : $@convention(thin) (Val, @guaranteed Storage) -> Val
+  %paB = partial_apply [callee_guaranteed] [on_stack] %fb(%0) : $@convention(thin) (Val, @guaranteed Storage) -> Val
+  %mdB = mark_dependence %paB : $@noescape @callee_guaranteed (Val) -> Val on %0 : $Storage
+  %f = function_ref @takesTwoClosures : $@convention(thin) (@guaranteed @noescape @callee_guaranteed (Val) -> Val, @guaranteed @noescape @callee_guaranteed (Val) -> Val) -> Val
+  %r = apply %f(%mdA, %mdB) : $@convention(thin) (@guaranteed @noescape @callee_guaranteed (Val) -> Val, @guaranteed @noescape @callee_guaranteed (Val) -> Val) -> Val
+  destroy_value %mdB
+  destroy_value %mdA
+  return %r : $Val
+}

--- a/test/SILOptimizer/closure_specialize_mark_dependence.swift
+++ b/test/SILOptimizer/closure_specialize_mark_dependence.swift
@@ -1,10 +1,9 @@
 // RUN: %target-swift-frontend -parse-as-library -O -emit-sil %s -disable-availability-checking | %FileCheck %s
 // REQUIRES: swift_in_compiler
 
-// A non-escaping closure that captures a ~Escapable value (here a `MutableSpan`) is wrapped
-// in a `mark_dependence` on the capture. Closure specialization has to look through that
-// `mark_dependence`; otherwise `callClosure` is never specialized and the closure survives as
-// a `partial_apply` with an indirect call, which pessimizes code using `MutableSpan`.
+// A non-escaping closure capturing a ~Escapable value (here a MutableSpan) is wrapped in a
+// mark_dependence on the capture. Closure specialization must look through it; otherwise
+// callClosure is never specialized and the closure survives as an indirect call.
 // https://github.com/swiftlang/swift/issues/89954
 
 @inline(never)
@@ -12,12 +11,14 @@ func callClosure(_ body: (UInt8) -> Void) {
   body(42)
 }
 
-// The closure capturing `span` must be specialized away: no residual `partial_apply` /
-// `mark_dependence`, just a direct call to the specialized `callClosure`.
+// The closure is specialized away: no residual partial_apply / mark_dependence, just a direct call.
 // CHECK-LABEL: sil {{.*}}@$s{{.*}}3useyySvF :
 // CHECK-NOT: partial_apply
 // CHECK-NOT: mark_dependence
-// CHECK: function_ref @{{.*}}callClosure{{.*}}Tf1c_n
+// CHECK: [[F:%[0-9]+]] = function_ref @{{.*}}callClosure{{.*}}Tf1c_n
+// CHECK: apply [[F]]
+// CHECK-NOT: partial_apply
+// CHECK-NOT: mark_dependence
 // CHECK-LABEL: } // end sil function '{{.*}}3useyySvF'
 @inline(never)
 public func use(_ p: UnsafeMutableRawPointer) {

--- a/test/SILOptimizer/closure_specialize_mark_dependence.swift
+++ b/test/SILOptimizer/closure_specialize_mark_dependence.swift
@@ -1,0 +1,26 @@
+// RUN: %target-swift-frontend -parse-as-library -O -emit-sil %s -disable-availability-checking | %FileCheck %s
+// REQUIRES: swift_in_compiler
+
+// A non-escaping closure that captures a ~Escapable value (here a `MutableSpan`) is wrapped
+// in a `mark_dependence` on the capture. Closure specialization has to look through that
+// `mark_dependence`; otherwise `callClosure` is never specialized and the closure survives as
+// a `partial_apply` with an indirect call, which pessimizes code using `MutableSpan`.
+// https://github.com/swiftlang/swift/issues/89954
+
+@inline(never)
+func callClosure(_ body: (UInt8) -> Void) {
+  body(42)
+}
+
+// The closure capturing `span` must be specialized away: no residual `partial_apply` /
+// `mark_dependence`, just a direct call to the specialized `callClosure`.
+// CHECK-LABEL: sil {{.*}}@$s{{.*}}3useyySvF :
+// CHECK-NOT: partial_apply
+// CHECK-NOT: mark_dependence
+// CHECK: function_ref @{{.*}}callClosure{{.*}}Tf1c_n
+// CHECK-LABEL: } // end sil function '{{.*}}3useyySvF'
+@inline(never)
+public func use(_ p: UnsafeMutableRawPointer) {
+  var span = unsafe MutableSpan(_unsafeStart: p.assumingMemoryBound(to: UInt8.self), count: 1)
+  callClosure { span[0] = $0 }
+}

--- a/test/SILOptimizer/closure_specialize_mark_dependence.swift
+++ b/test/SILOptimizer/closure_specialize_mark_dependence.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -parse-as-library -O -emit-sil %s -disable-availability-checking | %FileCheck %s
-// REQUIRES: swift_in_compiler
 
 // A non-escaping closure capturing a ~Escapable value (here a MutableSpan) is wrapped in a
 // mark_dependence on the capture. Closure specialization must look through it; otherwise

--- a/test/SILOptimizer/sil_combine_apply_ossa.sil
+++ b/test/SILOptimizer/sil_combine_apply_ossa.sil
@@ -1208,6 +1208,43 @@ bb0(%0 : $Int):
   return %r : $()
 }
 
+// The destroy of the dead closure is on the mark_dependence.
+// CHECK-LABEL: sil [ossa] @test_dead_on_stack_closure_with_mark_dependence :
+// CHECK-NOT:     partial_apply
+// CHECK-NOT:     mark_dependence
+// CHECK-LABEL: } // end sil function 'test_dead_on_stack_closure_with_mark_dependence'
+sil [ossa] @test_dead_on_stack_closure_with_mark_dependence : $@convention(thin) (Int, @guaranteed Klass) -> () {
+bb0(%0 : $Int, %1 : @guaranteed $Klass):
+  %2 = function_ref @closure2 : $@convention(thin) (Int) -> ()
+  %3 = partial_apply [callee_guaranteed] [on_stack] %2(%0) : $@convention(thin) (Int) -> ()
+  %4 = mark_dependence [nonescaping] %3 : $@noescape @callee_guaranteed () -> () on %1 : $Klass
+  debug_value %4 : $@noescape @callee_guaranteed () -> (), let, name "closure"
+  destroy_value %4 : $@noescape @callee_guaranteed () -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+// The closure is the base of the mark_dependence and not its forwarded value.
+// Deleting the mark_dependence would leave %4 without a destroy.
+// CHECK-LABEL: sil [ossa] @test_dead_on_stack_closure_as_mark_dependence_base :
+// CHECK:         partial_apply
+// CHECK:         mark_dependence
+// CHECK-LABEL: } // end sil function 'test_dead_on_stack_closure_as_mark_dependence_base'
+sil [ossa] @test_dead_on_stack_closure_as_mark_dependence_base : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %1 = function_ref @closure2 : $@convention(thin) (Int) -> ()
+  %2 = partial_apply [callee_guaranteed] [on_stack] %1(%0) : $@convention(thin) (Int) -> ()
+  %3 = function_ref @make_klass : $@convention(thin) () -> @owned Klass
+  %4 = apply %3() : $@convention(thin) () -> @owned Klass
+  %5 = mark_dependence %4 : $Klass on %2 : $@noescape @callee_guaranteed () -> ()
+  destroy_value %5 : $Klass
+  destroy_value %2 : $@noescape @callee_guaranteed () -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+sil @make_klass : $@convention(thin) () -> @owned Klass
+
 sil [ossa] @closure2 : $@convention(thin) (Int) -> ()
 
 sil [ossa] @yield1 : $@yield_once(Float) -> (@yields Float) {


### PR DESCRIPTION
Let's preface the PR with: I'm not a compiler engineer. This fix was made with help from Claude (max effort). While I've tested the effectiveness of the changes locally, I'm not sure how sound the changes actually are (I would think they are at least OK. If not actually good). You can feel free to close the PR and apply the fix yourself in a better way after reading the result of my investigations below.

Resolves https://github.com/swiftlang/swift/issues/89954.

## 

### Proof of Issue

```bash
cat > issue-89954.swift <<'EOF'
@inline(never)
func asDecimal(_ x: UInt8, writeByte: (UInt8) -> Void) {
  let (q, r) = x.quotientAndRemainder(dividingBy: 10)
  writeByte(q &+ 48); writeByte(r &+ 48)
}

// A) Captures a MutableSpan (~Escapable): closure is wrapped in mark_dependence.
@inline(never)
public func viaMutableSpan(_ p: UnsafeMutableRawPointer, _ n: Int) -> Int {
  var span = unsafe MutableSpan(_unsafeStart: p.assumingMemoryBound(to: UInt8.self), count: n)
  var i = 0
  asDecimal(123) { span[i] = $0; i &+= 1 }
  asDecimal(45)  { span[i] = $0; i &+= 1 }
  return i
}

// B) Same shape, Copyable pointer (no mark_dependence): specializes today.
@inline(never)
public func viaBuffer(_ p: UnsafeMutableRawPointer, _ n: Int) -> Int {
  let buf = unsafe UnsafeMutableBufferPointer(start: p.assumingMemoryBound(to: UInt8.self), count: n)
  var i = 0
  asDecimal(123) { buf[i] = $0; i &+= 1 }
  asDecimal(45)  { buf[i] = $0; i &+= 1 }
  return i
}
EOF
swiftc -O -emit-sil issue-89954.swift | swift demangle
```

<details>
  <summary>Click for the swift code but with syntax highlighting</summary>

```swift
@inline(never)
func asDecimal(_ x: UInt8, writeByte: (UInt8) -> Void) {
  let (q, r) = x.quotientAndRemainder(dividingBy: 10)
  writeByte(q &+ 48); writeByte(r &+ 48)
}

// A) Captures a MutableSpan (~Escapable): closure is wrapped in mark_dependence.
@inline(never)
public func viaMutableSpan(_ p: UnsafeMutableRawPointer, _ n: Int) -> Int {
  var span = unsafe MutableSpan(_unsafeStart: p.assumingMemoryBound(to: UInt8.self), count: n)
  var i = 0
  asDecimal(123) { span[i] = $0; i &+= 1 }
  asDecimal(45)  { span[i] = $0; i &+= 1 }
  return i
}

// B) Same shape, Copyable pointer (no mark_dependence): specializes today.
@inline(never)
public func viaBuffer(_ p: UnsafeMutableRawPointer, _ n: Int) -> Int {
  let buf = unsafe UnsafeMutableBufferPointer(start: p.assumingMemoryBound(to: UInt8.self), count: n)
  var i = 0
  asDecimal(123) { buf[i] = $0; i &+= 1 }
  asDecimal(45)  { buf[i] = $0; i &+= 1 }
  return i
}
```

</details>

<details>
  <summary>Click for full result of the command on my machine</summary>

Moved to [this comment](https://github.com/swiftlang/swift/pull/90161#issuecomment-5226621894).

</details>

You can see that `viaMutableSpan`'s SIL is as follows:

```bash
// viaMutableSpan(_:_:)
// Isolation: unspecified
sil [noinline] @main.viaMutableSpan(Swift.UnsafeMutableRawPointer, Swift.Int) -> Swift.Int : $@convention(thin) (UnsafeMutableRawPointer, Int) -> Int {
[%0: noescape **, read v**.c*.v**, write v**.c*.v**, copy v**.c*.v**, destroy v**.c*.v**]
[global: read,write,copy,destroy,allocate,deinit_barrier]
// %0 "p"                                         // users: %11, %2
// %1 "n"                                         // users: %6, %3
bb0(%0 : $UnsafeMutableRawPointer, %1 : $Int):
  debug_value %0, let, name "p", argno 1          // id: %2
  debug_value %1, let, name "n", argno 2          // id: %3
  %4 = alloc_stack [lexical] [var_decl] $MutableSpan<UInt8>, var, name "span", type $MutableSpan<UInt8> // users: %13, %29, %28, %21, %20, %34
  %5 = integer_literal $Builtin.Int64, 0          // users: %15, %7
  %6 = struct_extract %1, #Int._value             // users: %9, %7
  %7 = builtin "cmp_slt_Int64"(%6, %5) : $Builtin.Int1 // user: %8
  cond_fail %7, "Count must not be negative"      // id: %8
  %9 = builtin "assumeNonNegative_Int64"(%6) : $Builtin.Int64 // user: %10
  %10 = struct $Int (%9)                          // user: %12
  %11 = enum $Optional<UnsafeMutableRawPointer>, #Optional.some!enumelt, %0 // user: %12
  %12 = struct $MutableSpan<UInt8> (%11, %10)     // user: %13
  store %12 to %4                                 // id: %13
  %14 = alloc_stack [var_decl] $Int, var, name "i", type $Int // users: %32, %16, %28, %20, %33
  %15 = struct $Int (%5)                          // user: %16
  store %15 to %14                                // id: %16
  %17 = integer_literal $Builtin.Int8, 123        // user: %18
  %18 = struct $UInt8 (%17)                       // user: %23
  // function_ref closure #1 in viaMutableSpan(_:_:)
  %19 = function_ref @closure #1 (Swift.UInt8) -> () in main.viaMutableSpan(Swift.UnsafeMutableRawPointer, Swift.Int) -> Swift.Int : $@convention(thin) (UInt8, @inout_aliasable MutableSpan<UInt8>, @inout_aliasable Int) -> () // user: %20
  %20 = partial_apply [callee_guaranteed] [on_stack] %19(%4, %14) : $@convention(thin) (UInt8, @inout_aliasable MutableSpan<UInt8>, @inout_aliasable Int) -> () // users: %24, %21
  %21 = mark_dependence [nonescaping] %20 on %4   // user: %23
  // function_ref asDecimal(_:writeByte:)
  %22 = function_ref @main.asDecimal(_: Swift.UInt8, writeByte: (Swift.UInt8) -> ()) -> () : $@convention(thin) (UInt8, @guaranteed @noescape @callee_guaranteed (UInt8) -> ()) -> () // users: %30, %23
  %23 = apply %22(%18, %21) : $@convention(thin) (UInt8, @guaranteed @noescape @callee_guaranteed (UInt8) -> ()) -> ()
  dealloc_stack %20                               // id: %24
  %25 = integer_literal $Builtin.Int8, 45         // user: %26
  %26 = struct $UInt8 (%25)                       // user: %30
  // function_ref closure #2 in viaMutableSpan(_:_:)
  %27 = function_ref @closure #2 (Swift.UInt8) -> () in main.viaMutableSpan(Swift.UnsafeMutableRawPointer, Swift.Int) -> Swift.Int : $@convention(thin) (UInt8, @inout_aliasable MutableSpan<UInt8>, @inout_aliasable Int) -> () // user: %28
  %28 = partial_apply [callee_guaranteed] [on_stack] %27(%4, %14) : $@convention(thin) (UInt8, @inout_aliasable MutableSpan<UInt8>, @inout_aliasable Int) -> () // users: %31, %29
  %29 = mark_dependence [nonescaping] %28 on %4   // user: %30
  %30 = apply %22(%26, %29) : $@convention(thin) (UInt8, @guaranteed @noescape @callee_guaranteed (UInt8) -> ()) -> ()
  dealloc_stack %28                               // id: %31
  %32 = load %14                                  // user: %35
  dealloc_stack %14                               // id: %33
  dealloc_stack %4                                // id: %34
  return %32                                      // id: %35
} // end sil function 'main.viaMutableSpan(Swift.UnsafeMutableRawPointer, Swift.Int) -> Swift.Int'
```

And for `viaBuffer`:

```bash
// viaBuffer(_:_:)
// Isolation: unspecified
sil [noinline] @main.viaBuffer(Swift.UnsafeMutableRawPointer, Swift.Int) -> Swift.Int : $@convention(thin) (UnsafeMutableRawPointer, Int) -> Int {
[%0: noescape **, write s0.v**.c*.v**]
[global: write,deinit_barrier]
// %0 "p"                                         // users: %4, %2
// %1 "n"                                         // user: %3
bb0(%0 : $UnsafeMutableRawPointer, %1 : $Int):
  debug_value %0, let, name "p", argno 1          // id: %2
  debug_value %1, let, name "n", argno 2          // id: %3
  %4 = struct_extract %0, #UnsafeMutableRawPointer._rawValue // user: %5
  %5 = struct $UnsafeMutablePointer<UInt8> (%4)   // user: %6
  %6 = enum $Optional<UnsafeMutablePointer<UInt8>>, #Optional.some!enumelt, %5 // users: %7, %19, %15
  debug_value %6, let, name "buf", type $UnsafeMutableBufferPointer<UInt8>, expr op_fragment:#UnsafeMutableBufferPointer._position // id: %7
  %8 = alloc_stack [var_decl] $Int, var, name "i", type $Int // users: %15, %19, %20, %11, %21
  %9 = integer_literal $Builtin.Int64, 0          // user: %10
  %10 = struct $Int (%9)                          // user: %11
  store %10 to %8                                 // id: %11
  %12 = integer_literal $Builtin.Int8, 123        // user: %13
  %13 = struct $UInt8 (%12)                       // user: %15
  // function_ref specialized asDecimal(_:writeByte:)
  %14 = function_ref @function signature specialization <Arg[1] = Exploded> of function signature specialization <Arg[1] = [Closure Propagated : $s4main9viaBufferySiSv_SitFys5UInt8VXEfU_, Argument Types : [Swift.UnsafeMutableBufferPointer<Swift.UInt8>Swift.Int]> of main.asDecimal(_: Swift.UInt8, writeByte: (Swift.UInt8) -> ()) -> () : $@convention(thin) (UInt8, Optional<UnsafeMutablePointer<UInt8>>, @inout_aliasable Int) -> () // user: %15
  %15 = apply %14(%13, %6, %8) : $@convention(thin) (UInt8, Optional<UnsafeMutablePointer<UInt8>>, @inout_aliasable Int) -> ()
  %16 = integer_literal $Builtin.Int8, 45         // user: %17
  %17 = struct $UInt8 (%16)                       // user: %19
  // function_ref specialized asDecimal(_:writeByte:)
  %18 = function_ref @function signature specialization <Arg[1] = Exploded> of function signature specialization <Arg[1] = [Closure Propagated : $s4main9viaBufferySiSv_SitFys5UInt8VXEfU0_, Argument Types : [Swift.UnsafeMutableBufferPointer<Swift.UInt8>Swift.Int]> of main.asDecimal(_: Swift.UInt8, writeByte: (Swift.UInt8) -> ()) -> () : $@convention(thin) (UInt8, Optional<UnsafeMutablePointer<UInt8>>, @inout_aliasable Int) -> () // user: %19
  %19 = apply %18(%17, %6, %8) : $@convention(thin) (UInt8, Optional<UnsafeMutablePointer<UInt8>>, @inout_aliasable Int) -> ()
  %20 = load %8                                   // user: %22
  dealloc_stack %8                                // id: %21
  return %20                                      // id: %22
} // end sil function 'main.viaBuffer(Swift.UnsafeMutableRawPointer, Swift.Int) -> Swift.Int'
```

One difference is that in `viaMutableSpan` we have:
```bash
function_ref closure #1 in viaSpan(_:_:)
```
But in `viaBuffer`:
```bash
function_ref specialized asDecimal(_:writeByte:)
```

So clearly, in `viaMutableSpan`, the `asDecimal(_:writeByte:)` function fails to get specialized/inlined.
This then disables some optimizations of the compiler, which result in a relatively considerable amount of lower performance for `MutableSpan`.

In Claude's words:

> Both functions are the same shape; the only difference is the captured type. MutableSpan (~Escapable) ⇒ mark_dependence ⇒ optimizer gives up ⇒ generic call with an indirect closure call. UnsafeMutableBufferPointer (Copyable) ⇒ no mark_dependence ⇒ optimizer specializes ⇒ direct call. That contrast is the bug.

### The solution

I'm not a compiler engineer so the changes are made by Claude. I did persuade it a lot to try to make sure it has made proper changes, but I can't be sure that it actually did (well, apart from the fact that the changes are indeed working, since I asked Claude to compile and verify as well even though it takes a while to compile):

```md
### Problem
findSpecializableClosure's MarkDependenceInst case bailed unless visited.contains(mdi.base). A non-escaping closure capturing a ~Escapable value has a mark_dependence whose base is a capture (not in the chain), so it never specialized — leaving a generic callee with a per-call indirect apply.

### Fix
Accept when the base is a captured operand of the root closure (computed lazily, so it's only evaluated when the visited check fails):


var baseIsRootClosureCapture: Bool {
  (operandClosure as? PartialApplyInst)?.arguments.contains { $0 == mdi.base } ?? false
}
Existing gates still run via the recursion into mdi.value.

Resolve the base into the specialization. uniqueCaptureArguments rewrites the partial_apply operands to identity casts but not the mark_dependence base, so mdi.base == cast.fromValue. visitMarkDependenceInst resolves the base through the cloner map, so fold the pre-cast value too:


if let cast = originalClosureArg as? UncheckedValueCastInst,
   !cloner.isCloned(value: cast.fromValue) {
  cloner.recordFoldedValue(cast.fromValue, mappedTo: capturedArg)
}
Guard: the cloner map is value-keyed, so bail if a base is captured >1× (otherwise a reused specialization mis-maps). hasMultiplyCapturedDependenceBase walks the closure-argument chain (mirroring findSpecializableClosure, including reabstraction thunks) and short-circuits via isCapturedMoreThanOnce — no value accumulation.

### Soundness
Gated on isNoEscapeFunction ⇒ captures are forwarded @guaranteed and outlive the apply; the mark_dependence is re-materialized on the new argument. Every accepted base is either cloned (in chain) or a uniquely-captured value folded to its arg.

### Tests
closure_specialization_attrs.sil updated (on-stack [readonly] now specializes, @guaranteed, no retain). Full test/SILOptimizer green (1167 passed, 0 failures); standard library rebuilds under -enable-sil-verify-all with no optimizer crash; the reproducer specializes (no residual partial_apply/mark_dependence).
```

### Environment

```bash
$ swiftc --version
swift-driver version: 1.167 Apple Swift version 6.4 (swiftlang-6.4.0.20.104 clang-2100.3.20.102)
Target: arm64-apple-macosx27.0.0
```