### PR TITLE
MoveOnlyChecker: Don't destroy inout or local variables before end of dead end

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -400,6 +400,19 @@ static bool isReinitToInitConvertibleInst(SILInstruction *memInst) {
 
 using ScopeRequiringFinalInit = DiagnosticEmitter::ScopeRequiringFinalInit;
 
+/// Unwrap a mark_unresolved_non_copyable_value to get the underlying address.
+static SILValue
+unwrapMarkedAddrOperand(MarkUnresolvedNonCopyableValueInst *markedAddr) {
+  SILValue operand = markedAddr->getOperand();
+
+  // Look through wrappers.
+  if (auto m = dyn_cast<CopyableToMoveOnlyWrapperAddrInst>(operand)) {
+    operand = m->getOperand();
+  }
+
+  return operand;
+}
+
 /// If \p markedAddr's operand must be initialized at the end of the scope it
 /// introduces, visit those scope ending ends.
 ///
@@ -431,7 +444,6 @@ using ScopeRequiringFinalInit = DiagnosticEmitter::ScopeRequiringFinalInit;
 static bool visitScopeEndsRequiringInit(
     MarkUnresolvedNonCopyableValueInst *markedAddr,
     llvm::function_ref<void(SILInstruction *, ScopeRequiringFinalInit)> visit) {
-  SILValue operand = markedAddr->getOperand();
 
   // TODO: This should really be a property of the marker instruction.
   switch (markedAddr->getCheckKind()) {
@@ -446,10 +458,7 @@ static bool visitScopeEndsRequiringInit(
     llvm_unreachable("invalid check!?");
   }
 
-  // Look through wrappers.
-  if (auto m = dyn_cast<CopyableToMoveOnlyWrapperAddrInst>(operand)) {
-    operand = m->getOperand();
-  }
+  SILValue operand = unwrapMarkedAddrOperand(markedAddr);
 
   // Check for inout types of arguments that are marked with consumable and
   // assignable.
@@ -3361,6 +3370,140 @@ void MoveOnlyAddressCheckerPImpl::insertDestroysOnBoundary(
     });
   };
 
+  auto *deadEndBlocks = deba->get(markedValue->getFunction());
+
+  // Determine the argument convention, if any, of the marked address.
+  // 
+  // If the marked address is not an argument, determine if it is a local
+  // variable by checking if the marked address wraps an alloc_stack.
+  // TODO: Is there a better way to detect local variables?
+  SILValue unwrappedValue = unwrapMarkedAddrOperand(markedValue);
+  std::optional<SILArgumentConvention> argumentConvention = std::nullopt;
+  AllocStackInst *unwrappedAllocStack = nullptr;
+  if (auto *fArg = dyn_cast<SILFunctionArgument>(unwrappedValue)) {
+    argumentConvention = fArg->getArgumentConvention();
+  } else {
+    unwrappedAllocStack = dyn_cast<AllocStackInst>(unwrappedValue);
+  }
+
+  // Local helper to insert a destroy and accompanying debug_value undef for a
+  // value before the specified instruction if appropriate.
+  auto maybeInsertDestroyAndUndef = [&](SILInstruction *insertPt,
+                                        SmallBitVector &bv) {
+    auto *insertBlock = insertPt->getParent();
+
+    // Both inout arguments and local variables are expected to be live at the
+    // end of a dead end (i.e. the `unreachable` instruction).
+    //
+    // If the lifetime boundary is in a dead-end block, then we may have to
+    // defer destroy insertion until the next reinit on each path, if any, to
+    // avoid prematurely destroying these addresses.
+    //
+    // If the address is not reinitialised in the same block, and this block is
+    // not itself a terminator, we can defer destroying the address until the
+    // start of the next block where the address is live (which must be where it
+    // is reinitialised).
+    auto shouldDeferDestroyInsertion = [&] {
+      // Only defer dead end destroy insertion for inout arguments and local
+      // variables.
+      if (argumentConvention.has_value()) {
+        if (!argumentConvention->isInoutConvention())
+          return false;
+      } else if (nullptr == unwrappedAllocStack) {
+        return false;
+      }
+
+      // Only defer the destroy if it would be inserted in a dead end block
+      if (!deadEndBlocks->isDeadEnd(insertBlock)) {
+        return false;
+      }
+
+      // Do not defer the destroy if the address will be reinitialised in the
+      // same basic block. Check the insertPt separately, since
+      // precedesReinitInSameBlock checks only the instructions after its
+      // operand.
+      if (addressUseState.reinitInsts.contains(insertPt) ||
+          addressUseState.precedesReinitInSameBlock(insertPt)) {
+        return false;
+      }
+
+      return true;
+    };
+
+    SILValue baseAddress = liveness.getRootValue();
+
+    auto insertDestroyAndUndefBeforePoint = [&](SILInstruction *insertPt,
+                                                SmallBitVector &bv) {
+      insertDestroyBeforeInstruction(addressUseState, insertPt, baseAddress, bv,
+                                     consumes);
+      // We insert the debug_value undef /after/ the last use since we
+      // want the value to be around when we stop at the last use
+      // instruction.
+      insertUndefDebugValue(insertPt);
+    };
+
+    if (!shouldDeferDestroyInsertion()) {
+      insertDestroyAndUndefBeforePoint(insertPt, bv);
+      return;
+    }
+
+    LLVM_DEBUG(llvm::dbgs() << "Deferring address destruction in dead end.\n");
+
+    // Inserting a destroy before the end of a dead end could shorten the
+    // lifetime of an inout parameter or local, which would normally be expected
+    // to live to be alive at that point. If there is no subsequent
+    // reinitialisation and use of the address before the end of a dead end
+    // region, do not emit a destroy.
+    //
+    // Do a forward scan from the insertBlock.
+    if (insertBlock->succ_empty()) {
+      // This is a terminator block. The address cannot be reinitialised. Do
+      // nothing.
+      return;
+    }
+    auto discovered = liveness.getDiscoveredBlocks();
+    if (discovered.size() < 2) {
+      // There is at most one live block. The insertBlock contains the
+      // lifetime boundary, so it must be that single block.
+      // We do not need to insert any destroys in this case.
+      //
+      // TODO: Verify & strengthen this logic.
+      return;
+    }
+
+    auto *function = insertBlock->getFunction();
+
+    BasicBlockSet liveSet(function);
+    for (auto *liveBlock : discovered) {
+      if (liveBlock != insertBlock)
+        liveSet.insert(liveBlock);
+    }
+
+    // A local allocation may be dead prior to any dealloc_stack instructions,
+    // but we still must ensure the address is destroyed before it, so add any
+    // blocks containing deallocations to the "live set".
+    if (unwrappedAllocStack) {
+      for (auto user : baseAddress->getUsersOfType<DeallocStackInst>()) {
+        auto deallocBlock = user->getParentBlock();
+        if (deallocBlock != insertBlock)
+          liveSet.insert(deallocBlock);
+      }
+    }
+
+    BasicBlockWorklist worklist(function);
+    for (auto *succ : insertBlock->getSuccessorBlocks())
+      worklist.pushIfNotVisited(succ);
+    while (auto *block = worklist.pop()) {
+      if (liveSet.contains(block)) {
+        // This is a live block; insert a destroy_addr at the top.
+        insertDestroyAndUndefBeforePoint(&*block->begin(), bv);
+      }
+      // This is not a live block; continue scanning forward.
+      for (auto *succ : block->getSuccessorBlocks())
+        worklist.pushIfNotVisited(succ);
+    }
+  };
+
   // Control flow merge blocks used as insertion points.
   llvm::DenseMap<SILBasicBlock *, SmallBitVector> mergeBlocks;
 
@@ -3424,13 +3567,7 @@ void MoveOnlyAddressCheckerPImpl::insertDestroysOnBoundary(
             }
 
             auto *insertPt = &*succBlock->begin();
-            insertDestroyBeforeInstruction(addressUseState, insertPt,
-                                           liveness.getRootValue(), bits,
-                                           consumes);
-            // We insert the debug_value undef /after/ the last use since we
-            // want the value to be around when we stop at the last use
-            // instruction.
-            insertUndefDebugValue(insertPt);
+            maybeInsertDestroyAndUndef(insertPt, bits);
           }
           continue;
         }
@@ -3448,11 +3585,7 @@ void MoveOnlyAddressCheckerPImpl::insertDestroysOnBoundary(
         }
 
         auto *insertPt = inst->getNextInstruction();
-        insertDestroyBeforeInstruction(addressUseState, insertPt,
-                                       liveness.getRootValue(), bits, consumes);
-        // We insert the debug_value undef /after/ the last use since we want
-        // the value to be around when we stop at the last use instruction.
-        insertUndefDebugValue(insertPt);
+        maybeInsertDestroyAndUndef(insertPt, bits);
         continue;
       }
     }
@@ -3460,10 +3593,7 @@ void MoveOnlyAddressCheckerPImpl::insertDestroysOnBoundary(
 
   for (auto pair : boundary.getBoundaryEdges()) {
     auto *insertPt = &*pair.first->begin();
-    insertDestroyBeforeInstruction(addressUseState, insertPt,
-                                   liveness.getRootValue(), pair.second,
-                                   consumes);
-    insertUndefDebugValue(insertPt);
+    maybeInsertDestroyAndUndef(insertPt, pair.second);
     LLVM_DEBUG(llvm::dbgs() << "    Inserting destroy on edge bb"
                             << pair.first->getDebugID() << "\n");
   }
@@ -3474,10 +3604,7 @@ void MoveOnlyAddressCheckerPImpl::insertDestroysOnBoundary(
 
     if (auto *arg = dyn_cast<SILArgument>(defPair.first)) {
       auto *insertPt = &*arg->getParent()->begin();
-      insertDestroyBeforeInstruction(addressUseState, insertPt,
-                                     liveness.getRootValue(), defPair.second,
-                                     consumes);
-      insertUndefDebugValue(insertPt);
+      maybeInsertDestroyAndUndef(insertPt, defPair.second);
     } else {
       auto *inst = cast<SILInstruction>(defPair.first);
 
@@ -3501,10 +3628,7 @@ void MoveOnlyAddressCheckerPImpl::insertDestroysOnBoundary(
         insertPt = inst->getNextInstruction();
         assert(insertPt && "instruction is a terminator that wasn't handled?");
       }
-      insertDestroyBeforeInstruction(addressUseState, insertPt,
-                                     liveness.getRootValue(), defPair.second,
-                                     consumes);
-      insertUndefDebugValue(insertPt);
+      maybeInsertDestroyAndUndef(insertPt, defPair.second);
     }
   }
 

--- a/test/SILOptimizer/moveonly_addresschecker.sil
+++ b/test/SILOptimizer/moveonly_addresschecker.sil
@@ -607,7 +607,9 @@ struct M2: ~Copyable {
   let s2: M
 }
 
+sil @get_M : $@convention(thin) () -> @owned M
 sil @get_M2 : $@convention(thin) () -> @owned M2
+sil @borrow_M : $@convention(thin) (@in_guaranteed M) -> ()
 sil @end_addr_see_addr : $@convention(thin) (@in M, @in_guaranteed M) -> ()
 
 /// A single instruction, apply @end_addr_see_addr, consumes one field and
@@ -1094,3 +1096,342 @@ bb0:
   %36 = tuple ()
   return %36 : $()
 } // end sil function 'reinitMutableSpanThroughModifyAccess'
+
+// rdar://161636828
+//
+// A move-only inout parameter's deinitialiser should not be called, even in
+// dead-end blocks.
+
+// CHECK-LABEL: sil [ossa] @dead_block_deferred_deinit_positive1 : $@convention(method) (@inout M) -> () {
+// CHECK:       bb0(%0 : $*M):
+// CHECK-NEXT:    unreachable
+// CHECK-LABEL: } // end sil function 'dead_block_deferred_deinit_positive1'
+sil [ossa] @dead_block_deferred_deinit_positive1 : $@convention(method) (@inout M) -> () {
+bb0(%addr : $*M):
+  %mark = mark_unresolved_non_copyable_value [consumable_and_assignable] %addr
+  unreachable
+}
+
+// CHECK-LABEL: sil [ossa] @dead_block_deferred_deinit_positive2 : $@convention(method) (@inout M) -> () {
+// CHECK:       bb0(%0 : $*M):
+// CHECK-NEXT:    unreachable
+// CHECK-LABEL: } // end sil function 'dead_block_deferred_deinit_positive2'
+sil [ossa] @dead_block_deferred_deinit_positive2 : $@convention(method) (@inout M) -> () {
+bb0(%addr : $*M):
+  %mark = mark_unresolved_non_copyable_value [no_consume_or_assign] %addr
+  unreachable
+}
+
+// CHECK-LABEL: sil [ossa] @dead_block_deferred_deinit_positive3 : $@convention(thin) (@inout M) -> () {
+// CHECK:       bb0(%0 : $*M):
+// CHECK-NEXT:    unreachable
+// CHECK-LABEL: } // end sil function 'dead_block_deferred_deinit_positive3'
+sil [ossa] @dead_block_deferred_deinit_positive3 : $@convention(thin) (@inout M) -> () {
+bb0(%addr : $*M):
+  %mark = mark_unresolved_non_copyable_value [consumable_and_assignable] %addr
+  unreachable
+}
+
+// @in parameters are expected to be consumed by the method.
+// CHECK-LABEL: sil [ossa] @dead_block_deferred_deinit_negative1 : $@convention(thin) (@in M) -> () {
+// CHECK:       bb0(%0 : $*M):
+// CHECK-NEXT:    destroy_addr %0
+// CHECK-NEXT:    unreachable
+// CHECK-LABEL: } // end sil function 'dead_block_deferred_deinit_negative1'
+sil [ossa] @dead_block_deferred_deinit_negative1 : $@convention(thin) (@in M) -> () {
+bb0(%addr : $*M):
+  %mark = mark_unresolved_non_copyable_value [consumable_and_assignable] %addr
+  unreachable
+}
+
+// Skip destroying local variables in the same situations as inout arguments.
+// CHECK-LABEL: sil [ossa] @dead_block_deferred_deinit_alloc_stack : $@convention(thin) () -> () {
+// CHECK:         store {{.*}} to [init]
+// CHECK-NOT:     destroy_addr
+// CHECK:         unreachable
+// CHECK-LABEL: } // end sil function 'dead_block_deferred_deinit_alloc_stack'
+sil [ossa] @dead_block_deferred_deinit_alloc_stack : $@convention(thin) () -> () {
+bb0:
+  %stack = alloc_stack $M
+  %mark = mark_unresolved_non_copyable_value [consumable_and_assignable] %stack
+  %f = function_ref @get_M : $@convention(thin) () -> @owned M
+  %v = apply %f() : $@convention(thin) () -> @owned M
+  store %v to [init] %mark : $*M
+  unreachable
+}
+
+// Insertion point is itself a reinit (store [assign]).
+// CHECK-LABEL: sil [ossa] @dead_block_deferred_deinit_neg_isReinit : $@convention(thin) (@inout M) -> () {
+// CHECK:         destroy_addr
+// CHECK:         unreachable
+// CHECK-LABEL: } // end sil function 'dead_block_deferred_deinit_neg_isReinit'
+sil [ossa] @dead_block_deferred_deinit_neg_isReinit : $@convention(thin) (@inout M) -> () {
+bb0(%addr : $*M):
+  %mark = mark_unresolved_non_copyable_value [consumable_and_assignable] %addr
+  %f = function_ref @get_M : $@convention(thin) () -> @owned M
+  %v = apply %f() : $@convention(thin) () -> @owned M
+  store %v to [assign] %mark : $*M
+  unreachable
+}
+
+// Insertion point precedes a reinit later in the same block.
+// CHECK-LABEL: sil [ossa] @dead_block_deferred_deinit_neg_precedesReinit : $@convention(thin) (@inout M) -> () {
+// CHECK:         destroy_addr
+// CHECK:         unreachable
+// CHECK-LABEL: } // end sil function 'dead_block_deferred_deinit_neg_precedesReinit'
+sil [ossa] @dead_block_deferred_deinit_neg_precedesReinit : $@convention(thin) (@inout M) -> () {
+bb0(%addr : $*M):
+  %mark = mark_unresolved_non_copyable_value [consumable_and_assignable] %addr
+  %borrow = function_ref @borrow_M : $@convention(thin) (@in_guaranteed M) -> ()
+  %_ = apply %borrow(%mark) : $@convention(thin) (@in_guaranteed M) -> ()
+  %f = function_ref @get_M : $@convention(thin) () -> @owned M
+  %v = apply %f() : $@convention(thin) () -> @owned M
+  store %v to [assign] %mark : $*M
+  unreachable
+}
+
+// Insert block has successors but none where the address is live.
+// CHECK-LABEL: sil [ossa] @dead_block_deferred_deinit_pos_succNotEmpty_nothingDominated : $@convention(thin) (@inout M) -> () {
+// CHECK-NOT:    destroy_addr
+// CHECK-LABEL: } // end sil function 'dead_block_deferred_deinit_pos_succNotEmpty_nothingDominated'
+sil [ossa] @dead_block_deferred_deinit_pos_succNotEmpty_nothingDominated : $@convention(thin) (@inout M) -> () {
+bb0(%addr : $*M):
+  %mark = mark_unresolved_non_copyable_value [consumable_and_assignable] %addr
+  cond_br undef, bb1, bb2
+bb1:
+  unreachable
+bb2:
+  unreachable
+}
+
+// Downstream reinitialisation + use in another block reachable from the insert
+// block. The destroy must be emitted.
+// CHECK-LABEL: sil [ossa] @dead_block_deferred_deinit_neg_reachesLive : $@convention(thin) (@inout M) -> () {
+// CHECK:         destroy_addr
+// CHECK:         store {{.*}} to [init] %0
+// CHECK-NOT:     destroy_addr
+// CHECK:         unreachable
+// CHECK-LABEL: } // end sil function 'dead_block_deferred_deinit_neg_reachesLive'
+sil [ossa] @dead_block_deferred_deinit_neg_reachesLive : $@convention(thin) (@inout M) -> () {
+bb0(%addr : $*M):
+  %mark = mark_unresolved_non_copyable_value [consumable_and_assignable] %addr
+  %borrow = function_ref @borrow_M : $@convention(thin) (@in_guaranteed M) -> ()
+  %_ = apply %borrow(%mark) : $@convention(thin) (@in_guaranteed M) -> ()
+  br bb1
+bb1:
+  br bb2
+bb2:
+  %f = function_ref @get_M : $@convention(thin) () -> @owned M
+  %v = apply %f() : $@convention(thin) () -> @owned M
+  store %v to [assign] %mark : $*M
+  %_2 = apply %borrow(%mark) : $@convention(thin) (@in_guaranteed M) -> ()
+  unreachable
+}
+
+// Downstream reinitialisation in a block with multiple paths to it.
+// CHECK-LABEL: sil [ossa] @dead_block_deferred_deinit_multiplePaths : $@convention(thin) (@inout M) -> () {
+// CHECK:       bb0(%0 : $*M):
+// CHECK-NOT:     destroy_addr
+// CHECK:       bb1:
+// CHECK-NOT:     destroy_addr
+// CHECK:       bb2:
+// CHECK-NOT:     destroy_addr
+// CHECK:       bb3:
+// CHECK          destroy_addr
+// CHECK:         store {{.*}} to [init] %0
+// CHECK-NOT:     destroy_addr
+// CHECK:         unreachable
+// CHECK-LABEL: } // end sil function 'dead_block_deferred_deinit_multiplePaths'
+sil [ossa] @dead_block_deferred_deinit_multiplePaths : $@convention(thin) (@inout M) -> () {
+bb0(%addr : $*M):
+  %mark = mark_unresolved_non_copyable_value [consumable_and_assignable] %addr
+  %borrow = function_ref @borrow_M : $@convention(thin) (@in_guaranteed M) -> ()
+  %_ = apply %borrow(%mark) : $@convention(thin) (@in_guaranteed M) -> ()
+  cond_br undef, bb1, bb2
+bb1:
+  br bb3
+bb2:
+  br bb3
+bb3:
+  %f = function_ref @get_M : $@convention(thin) () -> @owned M
+  %v = apply %f() : $@convention(thin) () -> @owned M
+  store %v to [init] %mark : $*M
+  %_2 = apply %borrow(%mark) : $@convention(thin) (@in_guaranteed M) -> ()
+  unreachable
+}
+
+// Downstream reinitialisation in one but not all paths to function exit.
+// CHECK-LABEL: sil [ossa] @dead_block_deferred_deinit_conditionalReinit : $@convention(thin) (@inout M) -> () {
+// CHECK:       bb0(%0 : $*M):
+// CHECK-NOT:     destroy_addr
+// CHECK:       bb1:
+// CHECK-NOT:     destroy_addr
+// CHECK:         unreachable
+// CHECK:       bb2:
+// CHECK-NOT:     destroy_addr
+// CHECK:         br bb3
+// CHECK:       bb3:
+// CHECK-NOT:     destroy_addr
+// CHECK:         cond_br undef, bb4, bb5
+// CHECK:       bb4:
+// CHECK-NEXT:    unreachable
+// CHECK:       bb5:
+// CHECK:         destroy_addr
+// CHECK:         store {{.*}} to [init] %0
+// CHECK-NOT:     destroy_addr
+// CHECK:         unreachable
+// CHECK-LABEL: } // end sil function 'dead_block_deferred_deinit_conditionalReinit'
+sil [ossa] @dead_block_deferred_deinit_conditionalReinit : $@convention(thin) (@inout M) -> () {
+bb0(%addr : $*M):
+  %mark = mark_unresolved_non_copyable_value [consumable_and_assignable] %addr
+  %borrow = function_ref @borrow_M : $@convention(thin) (@in_guaranteed M) -> ()
+  %_ = apply %borrow(%mark) : $@convention(thin) (@in_guaranteed M) -> ()
+  cond_br undef, bb1, bb2
+bb1:
+  %_1 = apply %borrow(%mark) : $@convention(thin) (@in_guaranteed M) -> ()
+  unreachable
+bb2:
+  br bb3
+bb3:
+  cond_br undef, bb4, bb5
+bb4:
+  unreachable
+bb5:
+  %f = function_ref @get_M : $@convention(thin) () -> @owned M
+  %v = apply %f() : $@convention(thin) () -> @owned M
+  store %v to [init] %mark : $*M
+  %_2 = apply %borrow(%mark) : $@convention(thin) (@in_guaranteed M) -> ()
+  unreachable
+}
+
+// Downstream reinitialisation in one but not all paths to function exit.
+// CHECK-LABEL: sil [ossa] @dead_block_deferred_deinit_conditionalReinitLocalVar : $@convention(thin) () -> () {
+// CHECK:       bb0:
+// CHECK-NOT:     destroy_addr
+// CHECK:       bb1:
+// CHECK-NOT:     destroy_addr
+// CHECK:         unreachable
+// CHECK:       bb2:
+// CHECK-NOT:     destroy_addr
+// CHECK:         br bb3
+// CHECK:       bb3:
+// CHECK-NOT:     destroy_addr
+// CHECK:         cond_br undef, bb4, bb5
+// CHECK:       bb4:
+// CHECK-NEXT:    unreachable
+// CHECK:       bb5:
+// CHECK:         destroy_addr
+// CHECK:         store {{.*}} to [init] %0
+// CHECK-NOT:     destroy_addr
+// CHECK:         unreachable
+// CHECK-LABEL: } // end sil function 'dead_block_deferred_deinit_conditionalReinitLocalVar'
+sil [ossa] @dead_block_deferred_deinit_conditionalReinitLocalVar : $@convention(thin) () -> () {
+bb0:
+  %stack = alloc_stack $M
+  %mark = mark_unresolved_non_copyable_value [consumable_and_assignable] %stack
+  %f = function_ref @get_M : $@convention(thin) () -> @owned M
+  %v = apply %f() : $@convention(thin) () -> @owned M
+  store %v to [init] %mark : $*M
+  cond_br undef, bb1, bb2
+bb1:
+  %borrow = function_ref @borrow_M : $@convention(thin) (@in_guaranteed M) -> ()
+  %_1 = apply %borrow(%mark) : $@convention(thin) (@in_guaranteed M) -> ()
+  unreachable
+bb2:
+  br bb3
+bb3:
+  cond_br undef, bb4, bb5
+bb4:
+  unreachable
+bb5:
+  %v2 = apply %f() : $@convention(thin) () -> @owned M
+  store %v2 to [init] %mark : $*M
+  %borrow2 = function_ref @borrow_M : $@convention(thin) (@in_guaranteed M) -> ()
+  %_2 = apply %borrow2(%mark) : $@convention(thin) (@in_guaranteed M) -> ()
+  unreachable
+}
+
+// Return on one but not all paths to function exit.
+// CHECK-LABEL: sil [ossa] @dead_block_deferred_deinit_conditionalReturn : $@convention(thin) (@inout M) -> () {
+// CHECK-NOT:     destroy_addr
+// CHECK-LABEL: } // end sil function 'dead_block_deferred_deinit_conditionalReturn'
+sil [ossa] @dead_block_deferred_deinit_conditionalReturn : $@convention(thin) (@inout M) -> () {
+bb0(%addr : $*M):
+  %mark = mark_unresolved_non_copyable_value [consumable_and_assignable] %addr
+  %borrow = function_ref @borrow_M : $@convention(thin) (@in_guaranteed M) -> ()
+  %_ = apply %borrow(%mark) : $@convention(thin) (@in_guaranteed M) -> ()
+  cond_br undef, bb1, bb2
+bb1:
+  %_1 = apply %borrow(%mark) : $@convention(thin) (@in_guaranteed M) -> ()
+  unreachable
+bb2:
+  br bb3
+bb3:
+  cond_br undef, bb4, bb5
+bb4:
+  unreachable
+bb5:
+  %result = tuple ()
+  return %result
+}
+
+// The liveness boundary for this local variable occurs in a non-dead-end block
+// (bb2), so the address is destroyed there. As a result it is not initialised
+// at the dead end in bb4.
+// TODO: Fix this, possibly once we have OSSA lifetime completion for addresses.
+// 
+// CHECK-LABEL: sil [ossa] @dead_block_deferred_deinit_conditionalReturnLocalVar : $@convention(thin) () -> () {
+// CHECK:       bb0:
+// CHECK-NOT:     destroy_addr
+// CHECK:       bb1:
+// CHECK-NOT:     destroy_addr
+// CHECK:         unreachable
+// CHECK:       bb2:
+// CHECK:         destroy_addr
+// CHECK:         br bb3
+// CHECK:       bb3:
+// CHECK-NOT:     destroy_addr
+// CHECK:         cond_br undef, bb4, bb5
+// CHECK:       bb4:
+// CHECK-NOT:     destroy_addr
+// CHECK:         unreachable
+// CHECK:       bb5:
+// CHECK-NOT:     destroy_addr
+// CHECK:         dealloc_stack
+// CHECK-LABEL: } // end sil function 'dead_block_deferred_deinit_conditionalReturnLocalVar'
+sil [ossa] @dead_block_deferred_deinit_conditionalReturnLocalVar : $@convention(thin) () -> () {
+bb0:
+  %stack = alloc_stack $M
+  %mark = mark_unresolved_non_copyable_value [consumable_and_assignable] %stack
+  %f = function_ref @get_M : $@convention(thin) () -> @owned M
+  %v = apply %f() : $@convention(thin) () -> @owned M
+  store %v to [init] %mark : $*M
+  cond_br undef, bb1, bb2
+bb1:
+  %borrow = function_ref @borrow_M : $@convention(thin) (@in_guaranteed M) -> ()
+  %_1 = apply %borrow(%mark) : $@convention(thin) (@in_guaranteed M) -> ()
+  unreachable
+bb2:
+  br bb3
+bb3:
+  cond_br undef, bb4, bb5
+bb4:
+  unreachable
+bb5:
+  dealloc_stack %stack
+  %result = tuple ()
+  return %result
+}
+
+// Debug-info variant of the skip case: confirms debug info is also omitted when
+// the destroy is skipped.
+// CHECK-LABEL: sil [ossa] @dead_block_deferred_deinit_pos_unreachable_debug : $@convention(thin) (@inout M) -> () {
+// CHECK-NOT:    destroy_addr
+// CHECK-NOT:    debug_value undef
+// CHECK-LABEL: } // end sil function 'dead_block_deferred_deinit_pos_unreachable_debug'
+sil [ossa] @dead_block_deferred_deinit_pos_unreachable_debug : $@convention(thin) (@inout M) -> () {
+bb0(%addr : $*M):
+  debug_value %addr : $*M, var, name "x", argno 1, expr op_deref
+  %mark = mark_unresolved_non_copyable_value [consumable_and_assignable] %addr
+  unreachable
+}

--- a/test/SILOptimizer/moveonly_addresschecker.swift
+++ b/test/SILOptimizer/moveonly_addresschecker.swift
@@ -47,6 +47,35 @@ struct TestTrivialReturnValue : ~Copyable {
 // MARK: Misc Tests //
 //////////////////////
 
+// rdar://161636828
+@inline(never)
+public func opaque() -> Bool {
+  true
+}
+
+public struct PostconditionGuard: ~Copyable {
+  // CHECK-LABEL: sil hidden @$s23moveonly_addresschecker18PostconditionGuardV9terminateyyF : $@convention(method) (@inout PostconditionGuard) -> () {
+  // CHECK:       bb0(%0 : $*PostconditionGuard):
+  // CHECK:         cond_br {{.*}}, bb1, bb2
+  // CHECK:       bb1:
+  // CHECK-NOT:     destroy_addr %0
+  // CHECK:         unreachable
+  // CHECK:       bb2:
+  // CHECK-NEXT:    [[RESULT:%[0-9]+]] = tuple ()
+  // CHECK-NEXT:    return [[RESULT]]
+  // CHECK-LABEL: } // end sil function '$s23moveonly_addresschecker18PostconditionGuardV9terminateyyF'
+  mutating func terminate() {
+    if opaque() {
+      foo()
+      fatalError()
+    }
+  }
+
+  @inline(never)
+  mutating func foo() {}
+}
+
+// assert like use different bits
 func testAssertLikeUseDifferentBits() {
     struct S : ~Copyable {
         var s: [Int] = []


### PR DESCRIPTION
The MoveOnlyChecker could previously insert a destroy_addr on an inout parameter or local after its last use in a dead end block ending with an unreachable.

Inserting a destroy_addr before the end of a dead end could shorten the lifetime of an inout parameter or local, which would normally be expected to be alive at  function exit. If the address is not reinitialised within the same block, defer emitting the destroy_addr until the start of the first block where the address is reinitialised, along each path from the end of the current lifetime. If the address is never reinitialised on a path, no `destroy_addr` is emitted.
  
  Fixes: rdar://161636828

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
