### PR TITLE
[ClangImporter] Fix use-after-free of CodeGenOpts.Argv0

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1410,6 +1410,10 @@ std::unique_ptr<clang::CompilerInvocation> ClangImporter::createClangInvocation(
     CI = clang::createInvocation(invocationArgs, std::move(CIOpts));
     if (!CI)
       return nullptr;
+
+    // CodeGenOpts.Argv0 is a raw const char* into driverArgs[0]; re-anchor it
+    // to clangPath, which outlives the invocation.
+    CI->getCodeGenOpts().Argv0 = ctx.ClangImporterOpts.clangPath.c_str();
   }
 
   // FIXME: clang fails to generate a module if there is a `-fmodule-map-file`


### PR DESCRIPTION
clang::createInvocation stores Argv0 as a raw const char* pointing into the first element of its argument list. In createClangInvocation that points into the local driverArgs vector, which is destroyed before the invocation is used, leaving Argv0 dangling. The PCH worker thread later hits this in initTargetOptions when assigning Argv0 into MCTargetOptions (a std::string), producing a heap-use-after-free under ASan.

Re-anchor Argv0 to ClangImporterOpts.clangPath, which is owned by the ASTContext and outlives the invocation.

rdar://180460686

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
