### PR TITLE
[Swiftify] chain nullable base pointer when not unwrapped

### DIFF
--- a/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
@@ -1154,7 +1154,8 @@ struct CountedOrSizedPointerThunkBuilder: ParamBoundsThunkBuilder, PointerBounds
     }
     if isSizedBy {
       if let pointeeType = getPointeeType(type) {
-        return "\(baseAddress).assumingMemoryBound(to: \(pointeeType).self)"
+        let unwrap = oldTypeIsAnyOptional ? "?" : "" // already unwrapped with "!" otherwise
+        return "\(baseAddress)\(raw: unwrap).assumingMemoryBound(to: \(pointeeType).self)"
       }
     }
     return baseAddress

--- a/test/Interop/C/swiftify-import/sized-by-legacy.swift
+++ b/test/Interop/C/swiftify-import/sized-by-legacy.swift
@@ -117,12 +117,11 @@ typedef opaque_t *opaqueptr_t;
 // }}
 void opaqueptr(int len, opaqueptr_t __sized_by(len) p);
 
-// expected-expansion@+8:48{{
+// expected-expansion@+7:48{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func charsized(_ _charsized_param0: UnsafeMutableRawBufferPointer) {|}}
 //   expected-remark@3{{macro content: |    let _charsized_param1 = Int32(exactly: _charsized_param0.count)!|}}
-//   expected-error@4{{value of optional type 'UnsafeMutableRawPointer?' must be unwrapped to refer to member 'assumingMemoryBound' of wrapped base type 'UnsafeMutableRawPointer'}}
-//   expected-remark@4{{macro content: |    return unsafe charsized(_charsized_param0.baseAddress.assumingMemoryBound(to: CChar.self), _charsized_param1)|}}
+//   expected-remark@4{{macro content: |    return unsafe charsized(_charsized_param0.baseAddress?.assumingMemoryBound(to: CChar.self), _charsized_param1)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 void charsized(char *__sized_by(size), int size);
@@ -138,12 +137,11 @@ uint8_t *__sized_by(size) bytesized(int size);
 void doublebytesized(uint16_t *__sized_by(size), int size);
 
 typedef uint8_t * bytesizedptr_t;
-// expected-expansion@+8:66{{
+// expected-expansion@+7:66{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func aliasedBytesized(_ p: UnsafeMutableRawBufferPointer) {|}}
 //   expected-remark@3{{macro content: |    let size = Int32(exactly: p.count)!|}}
-//   expected-error@4{{value of optional type 'UnsafeMutableRawPointer?' must be unwrapped to refer to member 'assumingMemoryBound' of wrapped base type 'UnsafeMutableRawPointer'}}
-//   expected-remark@4{{macro content: |    return unsafe aliasedBytesized(p.baseAddress.assumingMemoryBound(to: UInt8.self), size)|}}
+//   expected-remark@4{{macro content: |    return unsafe aliasedBytesized(p.baseAddress?.assumingMemoryBound(to: UInt8.self), size)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 void aliasedBytesized(bytesizedptr_t __sized_by(size) p, int size);

--- a/test/Interop/C/swiftify-import/sized-by-lifetimebound-legacy.swift
+++ b/test/Interop/C/swiftify-import/sized-by-lifetimebound-legacy.swift
@@ -174,7 +174,7 @@ opaque_t * __sized_by(len) opaque(int len, int len2, opaque_t * p __sized_by(len
 // }}
 const void * __sized_by(len) nonsizedLifetime(int len, const void * p __lifetimebound);
 
-// expected-experimental-expansion@+19:65{{
+// expected-experimental-expansion@+18:65{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func bytesized(_ p: RawSpan) -> MutableRawSpan {|}}
 //   expected-experimental-remark@3{{macro content: |    let size = Int32(exactly: p.byteCount)!|}}
@@ -184,8 +184,7 @@ const void * __sized_by(len) nonsizedLifetime(int len, const void * p __lifetime
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeMutablePointer<UInt8>? = unsafe bytesized(size, _pPtr.baseAddress.assumingMemoryBound(to: UInt8.self))|}}
-//   expected-experimental-error@10{{value of optional type 'UnsafeRawPointer?' must be unwrapped to refer to member 'assumingMemoryBound' of wrapped base type 'UnsafeRawPointer'}}
+//   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeMutablePointer<UInt8>? = unsafe bytesized(size, _pPtr.baseAddress?.assumingMemoryBound(to: UInt8.self))|}}
 //   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
 //   expected-experimental-remark@12{{macro content: |      precondition(size == 0, "sized_by may only be null if size is 0 (unlike sized_by_or_null)")|}}
 //   expected-experimental-remark@13{{macro content: |      return MutableRawSpan()|}}
@@ -195,7 +194,7 @@ const void * __sized_by(len) nonsizedLifetime(int len, const void * p __lifetime
 // }}
 uint8_t *__sized_by(size)  bytesized(int size, const uint8_t * p __sized_by(size) __lifetimebound);
 
-// expected-experimental-expansion@+19:85{{
+// expected-experimental-expansion@+18:85{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func charsized(_ p: inout MutableRawSpan) -> MutableRawSpan {|}}
 //   expected-experimental-remark@3{{macro content: |    let size = Int32(exactly: p.byteCount)!|}}
@@ -205,8 +204,7 @@ uint8_t *__sized_by(size)  bytesized(int size, const uint8_t * p __sized_by(size
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeMutablePointer<CChar>? = unsafe charsized(_pPtr.baseAddress.assumingMemoryBound(to: CChar.self), size)|}}
-//   expected-experimental-error@10{{value of optional type 'UnsafeMutableRawPointer?' must be unwrapped to refer to member 'assumingMemoryBound' of wrapped base type 'UnsafeMutableRawPointer'}}
+//   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeMutablePointer<CChar>? = unsafe charsized(_pPtr.baseAddress?.assumingMemoryBound(to: CChar.self), size)|}}
 //   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
 //   expected-experimental-remark@12{{macro content: |      precondition(size == 0, "sized_by may only be null if size is 0 (unlike sized_by_or_null)")|}}
 //   expected-experimental-remark@13{{macro content: |      return MutableRawSpan()|}}

--- a/test/Interop/C/swiftify-import/sized-by-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/sized-by-lifetimebound.swift
@@ -173,7 +173,7 @@ opaque_t * __sized_by(len) opaque(int len, int len2, opaque_t * p __sized_by(len
 // }}
 const void * __sized_by(len) nonsizedLifetime(int len, const void * p __lifetimebound);
 
-// expected-experimental-expansion@+19:65{{
+// expected-experimental-expansion@+18:65{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func bytesized(_ p: RawSpan) -> MutableRawSpan {|}}
 //   expected-experimental-remark@3{{macro content: |    let size = Int32(exactly: p.byteCount)!|}}
@@ -183,8 +183,7 @@ const void * __sized_by(len) nonsizedLifetime(int len, const void * p __lifetime
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeMutablePointer<UInt8>? = unsafe bytesized(size, _pPtr.baseAddress.assumingMemoryBound(to: UInt8.self))|}}
-//   expected-experimental-error@10{{value of optional type 'UnsafeRawPointer?' must be unwrapped to refer to member 'assumingMemoryBound' of wrapped base type 'UnsafeRawPointer'}}
+//   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeMutablePointer<UInt8>? = unsafe bytesized(size, _pPtr.baseAddress?.assumingMemoryBound(to: UInt8.self))|}}
 //   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
 //   expected-experimental-remark@12{{macro content: |      precondition(size == 0, "sized_by may only be null if size is 0 (unlike sized_by_or_null)")|}}
 //   expected-experimental-remark@13{{macro content: |      return MutableRawSpan()|}}
@@ -194,7 +193,7 @@ const void * __sized_by(len) nonsizedLifetime(int len, const void * p __lifetime
 // }}
 uint8_t *__sized_by(size)  bytesized(int size, const uint8_t * p __sized_by(size) __lifetimebound);
 
-// expected-experimental-expansion@+19:85{{
+// expected-experimental-expansion@+18:85{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func charsized(_ p: inout MutableRawSpan) -> MutableRawSpan {|}}
 //   expected-experimental-remark@3{{macro content: |    let size = Int32(exactly: p.byteCount)!|}}
@@ -204,8 +203,7 @@ uint8_t *__sized_by(size)  bytesized(int size, const uint8_t * p __sized_by(size
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeMutablePointer<CChar>? = unsafe charsized(_pPtr.baseAddress.assumingMemoryBound(to: CChar.self), size)|}}
-//   expected-experimental-error@10{{value of optional type 'UnsafeMutableRawPointer?' must be unwrapped to refer to member 'assumingMemoryBound' of wrapped base type 'UnsafeMutableRawPointer'}}
+//   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeMutablePointer<CChar>? = unsafe charsized(_pPtr.baseAddress?.assumingMemoryBound(to: CChar.self), size)|}}
 //   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
 //   expected-experimental-remark@12{{macro content: |      precondition(size == 0, "sized_by may only be null if size is 0 (unlike sized_by_or_null)")|}}
 //   expected-experimental-remark@13{{macro content: |      return MutableRawSpan()|}}

--- a/test/Interop/C/swiftify-import/sized-by-noescape-legacy.swift
+++ b/test/Interop/C/swiftify-import/sized-by-noescape-legacy.swift
@@ -164,7 +164,7 @@ typedef struct foo opaque_t;
 // }}
 void opaque(int len, opaque_t * __sized_by(len) __noescape p);
 
-// expected-expansion@+14:41{{
+// expected-expansion@+13:41{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload public func bytesized(_ _bytesized_param1: RawSpan) {|}}
 //   expected-remark@3{{macro content: |    let _bytesized_param0 = Int32(exactly: _bytesized_param1.byteCount)!|}}
@@ -174,13 +174,12 @@ void opaque(int len, opaque_t * __sized_by(len) __noescape p);
 //   expected-remark@7{{macro content: |    defer {|}}
 //   expected-remark@8{{macro content: |        _fixLifetime(_bytesized_param1)|}}
 //   expected-remark@9{{macro content: |    }|}}
-//   expected-error@10{{value of optional type 'UnsafeRawPointer?' must be unwrapped to refer to member 'assumingMemoryBound' of wrapped base type 'UnsafeRawPointer'}}
-//   expected-remark@10{{macro content: |    return unsafe bytesized(_bytesized_param0, __bytesized_param1Ptr.baseAddress.assumingMemoryBound(to: UInt8.self))|}}
+//   expected-remark@10{{macro content: |    return unsafe bytesized(_bytesized_param0, __bytesized_param1Ptr.baseAddress?.assumingMemoryBound(to: UInt8.self))|}}
 //   expected-remark@11{{macro content: |}|}}
 // }}
 void bytesized(int size, const uint8_t *__sized_by(size) __noescape);
 
-// expected-expansion@+14:59{{
+// expected-expansion@+13:59{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(_charsized_param0: copy _charsized_param0) @_disfavoredOverload public func charsized(_ _charsized_param0: inout MutableRawSpan) {|}}
 //   expected-remark@3{{macro content: |    let _charsized_param1 = Int32(exactly: _charsized_param0.byteCount)!|}}
@@ -190,8 +189,7 @@ void bytesized(int size, const uint8_t *__sized_by(size) __noescape);
 //   expected-remark@7{{macro content: |    defer {|}}
 //   expected-remark@8{{macro content: |        _fixLifetime(_charsized_param0)|}}
 //   expected-remark@9{{macro content: |    }|}}
-//   expected-error@10{{value of optional type 'UnsafeMutableRawPointer?' must be unwrapped to refer to member 'assumingMemoryBound' of wrapped base type 'UnsafeMutableRawPointer'}}
-//   expected-remark@10{{macro content: |    return unsafe charsized(__charsized_param0Ptr.baseAddress.assumingMemoryBound(to: CChar.self), _charsized_param1)|}}
+//   expected-remark@10{{macro content: |    return unsafe charsized(__charsized_param0Ptr.baseAddress?.assumingMemoryBound(to: CChar.self), _charsized_param1)|}}
 //   expected-remark@11{{macro content: |}|}}
 // }}
 void charsized(char *__sized_by(size) __noescape, int size);

--- a/test/Interop/C/swiftify-import/sized-by-noescape.swift
+++ b/test/Interop/C/swiftify-import/sized-by-noescape.swift
@@ -160,7 +160,7 @@ typedef struct foo opaque_t;
 // }}
 void opaque(int len, opaque_t * __sized_by(len) __noescape p);
 
-// expected-expansion@+14:41{{
+// expected-expansion@+13:41{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload public func bytesized(_ _bytesized_param1: RawSpan) {|}}
 //   expected-remark@3{{macro content: |    let _bytesized_param0 = Int32(exactly: _bytesized_param1.byteCount)!|}}
@@ -170,13 +170,12 @@ void opaque(int len, opaque_t * __sized_by(len) __noescape p);
 //   expected-remark@7{{macro content: |    defer {|}}
 //   expected-remark@8{{macro content: |        _fixLifetime(_bytesized_param1)|}}
 //   expected-remark@9{{macro content: |    }|}}
-//   expected-error@10{{value of optional type 'UnsafeRawPointer?' must be unwrapped to refer to member 'assumingMemoryBound' of wrapped base type 'UnsafeRawPointer'}}
-//   expected-remark@10{{macro content: |    return unsafe bytesized(_bytesized_param0, __bytesized_param1Ptr.baseAddress.assumingMemoryBound(to: UInt8.self))|}}
+//   expected-remark@10{{macro content: |    return unsafe bytesized(_bytesized_param0, __bytesized_param1Ptr.baseAddress?.assumingMemoryBound(to: UInt8.self))|}}
 //   expected-remark@11{{macro content: |}|}}
 // }}
 void bytesized(int size, const uint8_t *__sized_by(size) __noescape);
 
-// expected-expansion@+14:59{{
+// expected-expansion@+13:59{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(_charsized_param0: copy _charsized_param0) @_disfavoredOverload public func charsized(_ _charsized_param0: inout MutableRawSpan) {|}}
 //   expected-remark@3{{macro content: |    let _charsized_param1 = Int32(exactly: _charsized_param0.byteCount)!|}}
@@ -186,8 +185,7 @@ void bytesized(int size, const uint8_t *__sized_by(size) __noescape);
 //   expected-remark@7{{macro content: |    defer {|}}
 //   expected-remark@8{{macro content: |        _fixLifetime(_charsized_param0)|}}
 //   expected-remark@9{{macro content: |    }|}}
-//   expected-error@10{{value of optional type 'UnsafeMutableRawPointer?' must be unwrapped to refer to member 'assumingMemoryBound' of wrapped base type 'UnsafeMutableRawPointer'}}
-//   expected-remark@10{{macro content: |    return unsafe charsized(__charsized_param0Ptr.baseAddress.assumingMemoryBound(to: CChar.self), _charsized_param1)|}}
+//   expected-remark@10{{macro content: |    return unsafe charsized(__charsized_param0Ptr.baseAddress?.assumingMemoryBound(to: CChar.self), _charsized_param1)|}}
 //   expected-remark@11{{macro content: |}|}}
 // }}
 void charsized(char *__sized_by(size) __noescape, int size);

--- a/test/Interop/C/swiftify-import/sized-by-or-null-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/sized-by-or-null-lifetimebound.swift
@@ -172,7 +172,7 @@ opaque_t * __sized_by_or_null(len) opaque(int len, int len2, opaque_t * p __size
 // }}
 const void * __sized_by_or_null(len) nonsizedLifetime(int len, const void * p __lifetimebound);
 
-// expected-experimental-expansion@+19:73{{
+// expected-experimental-expansion@+18:73{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func bytesized(_ p: RawSpan) -> MutableRawSpan {|}}
 //   expected-experimental-remark@3{{macro content: |    let size = Int32(exactly: p.byteCount)!|}}
@@ -182,8 +182,7 @@ const void * __sized_by_or_null(len) nonsizedLifetime(int len, const void * p __
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeMutablePointer<UInt8>? = unsafe bytesized(size, _pPtr.baseAddress.assumingMemoryBound(to: UInt8.self))|}}
-//   expected-experimental-error@10{{value of optional type 'UnsafeRawPointer?' must be unwrapped to refer to member 'assumingMemoryBound' of wrapped base type 'UnsafeRawPointer'}}
+//   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeMutablePointer<UInt8>? = unsafe bytesized(size, _pPtr.baseAddress?.assumingMemoryBound(to: UInt8.self))|}}
 //   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
 //   expected-experimental-remark@12{{macro content: |      precondition(size == 0, "sized_by may only be null if size is 0 (unlike sized_by_or_null)")|}}
 //   expected-experimental-remark@13{{macro content: |      return MutableRawSpan()|}}
@@ -193,7 +192,7 @@ const void * __sized_by_or_null(len) nonsizedLifetime(int len, const void * p __
 // }}
 uint8_t *__sized_by_or_null(size)  bytesized(int size, const uint8_t * p __sized_by_or_null(size) __lifetimebound);
 
-// expected-experimental-expansion@+19:101{{
+// expected-experimental-expansion@+18:101{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func charsized(_ p: inout MutableRawSpan) -> MutableRawSpan {|}}
 //   expected-experimental-remark@3{{macro content: |    let size = Int32(exactly: p.byteCount)!|}}
@@ -203,8 +202,7 @@ uint8_t *__sized_by_or_null(size)  bytesized(int size, const uint8_t * p __sized
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeMutablePointer<CChar>? = unsafe charsized(_pPtr.baseAddress.assumingMemoryBound(to: CChar.self), size)|}}
-//   expected-experimental-error@10{{value of optional type 'UnsafeMutableRawPointer?' must be unwrapped to refer to member 'assumingMemoryBound' of wrapped base type 'UnsafeMutableRawPointer'}}
+//   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeMutablePointer<CChar>? = unsafe charsized(_pPtr.baseAddress?.assumingMemoryBound(to: CChar.self), size)|}}
 //   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
 //   expected-experimental-remark@12{{macro content: |      precondition(size == 0, "sized_by may only be null if size is 0 (unlike sized_by_or_null)")|}}
 //   expected-experimental-remark@13{{macro content: |      return MutableRawSpan()|}}

--- a/test/Interop/C/swiftify-import/sized-by-or-null-noescape.swift
+++ b/test/Interop/C/swiftify-import/sized-by-or-null-noescape.swift
@@ -160,7 +160,7 @@ typedef struct foo opaque_t;
 // }}
 void opaque(int len, opaque_t * __sized_by_or_null(len) __noescape p);
 
-// expected-expansion@+14:41{{
+// expected-expansion@+13:41{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload public func bytesized(_ _bytesized_param1: RawSpan) {|}}
 //   expected-remark@3{{macro content: |    let _bytesized_param0 = Int32(exactly: _bytesized_param1.byteCount)!|}}
@@ -170,13 +170,12 @@ void opaque(int len, opaque_t * __sized_by_or_null(len) __noescape p);
 //   expected-remark@7{{macro content: |    defer {|}}
 //   expected-remark@8{{macro content: |        _fixLifetime(_bytesized_param1)|}}
 //   expected-remark@9{{macro content: |    }|}}
-//   expected-error@10{{value of optional type 'UnsafeRawPointer?' must be unwrapped to refer to member 'assumingMemoryBound' of wrapped base type 'UnsafeRawPointer'}}
-//   expected-remark@10{{macro content: |    return unsafe bytesized(_bytesized_param0, __bytesized_param1Ptr.baseAddress.assumingMemoryBound(to: UInt8.self))|}}
+//   expected-remark@10{{macro content: |    return unsafe bytesized(_bytesized_param0, __bytesized_param1Ptr.baseAddress?.assumingMemoryBound(to: UInt8.self))|}}
 //   expected-remark@11{{macro content: |}|}}
 // }}
 void bytesized(int size, const uint8_t *__sized_by_or_null(size) __noescape);
 
-// expected-expansion@+14:67{{
+// expected-expansion@+13:67{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(_charsized_param0: copy _charsized_param0) @_disfavoredOverload public func charsized(_ _charsized_param0: inout MutableRawSpan) {|}}
 //   expected-remark@3{{macro content: |    let _charsized_param1 = Int32(exactly: _charsized_param0.byteCount)!|}}
@@ -186,8 +185,7 @@ void bytesized(int size, const uint8_t *__sized_by_or_null(size) __noescape);
 //   expected-remark@7{{macro content: |    defer {|}}
 //   expected-remark@8{{macro content: |        _fixLifetime(_charsized_param0)|}}
 //   expected-remark@9{{macro content: |    }|}}
-//   expected-error@10{{value of optional type 'UnsafeMutableRawPointer?' must be unwrapped to refer to member 'assumingMemoryBound' of wrapped base type 'UnsafeMutableRawPointer'}}
-//   expected-remark@10{{macro content: |    return unsafe charsized(__charsized_param0Ptr.baseAddress.assumingMemoryBound(to: CChar.self), _charsized_param1)|}}
+//   expected-remark@10{{macro content: |    return unsafe charsized(__charsized_param0Ptr.baseAddress?.assumingMemoryBound(to: CChar.self), _charsized_param1)|}}
 //   expected-remark@11{{macro content: |}|}}
 // }}
 void charsized(char *__sized_by_or_null(size) __noescape, int size);

--- a/test/Interop/C/swiftify-import/sized-by-or-null.swift
+++ b/test/Interop/C/swiftify-import/sized-by-or-null.swift
@@ -113,12 +113,11 @@ typedef opaque_t *opaqueptr_t;
 // }}
 void opaqueptr(int len, opaqueptr_t __sized_by_or_null(len) p);
 
-// expected-expansion@+8:56{{
+// expected-expansion@+7:56{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func charsized(_ _charsized_param0: UnsafeMutableRawBufferPointer) {|}}
 //   expected-remark@3{{macro content: |    let _charsized_param1 = Int32(exactly: _charsized_param0.count)!|}}
-//   expected-error@4{{value of optional type 'UnsafeMutableRawPointer?' must be unwrapped to refer to member 'assumingMemoryBound' of wrapped base type 'UnsafeMutableRawPointer'}}
-//   expected-remark@4{{macro content: |    return unsafe charsized(_charsized_param0.baseAddress.assumingMemoryBound(to: CChar.self), _charsized_param1)|}}
+//   expected-remark@4{{macro content: |    return unsafe charsized(_charsized_param0.baseAddress?.assumingMemoryBound(to: CChar.self), _charsized_param1)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 void charsized(char *__sized_by_or_null(size), int size);
@@ -134,12 +133,11 @@ uint8_t *__sized_by_or_null(size) bytesized(int size);
 void doublebytesized(uint16_t *__sized_by_or_null(size), int size);
 
 typedef uint8_t * bytesizedptr_t;
-// expected-expansion@+8:74{{
+// expected-expansion@+7:74{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func aliasedBytesized(_ p: UnsafeMutableRawBufferPointer) {|}}
 //   expected-remark@3{{macro content: |    let size = Int32(exactly: p.count)!|}}
-//   expected-error@4{{value of optional type 'UnsafeMutableRawPointer?' must be unwrapped to refer to member 'assumingMemoryBound' of wrapped base type 'UnsafeMutableRawPointer'}}
-//   expected-remark@4{{macro content: |    return unsafe aliasedBytesized(p.baseAddress.assumingMemoryBound(to: UInt8.self), size)|}}
+//   expected-remark@4{{macro content: |    return unsafe aliasedBytesized(p.baseAddress?.assumingMemoryBound(to: UInt8.self), size)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 void aliasedBytesized(bytesizedptr_t __sized_by_or_null(size) p, int size);

--- a/test/Interop/C/swiftify-import/sized-by.swift
+++ b/test/Interop/C/swiftify-import/sized-by.swift
@@ -77,6 +77,15 @@ void nullUnspecified(int len, void * __sized_by(len) _Null_unspecified p);
 // }}
 void nonnull(int len, void * __sized_by(len) _Nonnull p);
 
+// expected-expansion@+7:61{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nonnullTyped(_ p: UnsafeMutableRawBufferPointer) {|}}
+//   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
+//   expected-remark@4{{macro content: |    return unsafe nonnullTyped(len, p.baseAddress!.assumingMemoryBound(to: CChar.self))|}}
+//   expected-remark@5{{macro content: |}|}}
+// }}
+void nonnullTyped(int len, char * __sized_by(len) _Nonnull p);
+
 // expected-expansion@+7:58{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nullable(_ p: UnsafeMutableRawBufferPointer) {|}}
@@ -85,6 +94,15 @@ void nonnull(int len, void * __sized_by(len) _Nonnull p);
 //   expected-remark@5{{macro content: |}|}}
 // }}
 void nullable(int len, void * __sized_by(len) _Nullable p);
+
+// expected-expansion@+7:63{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nullableTyped(_ p: UnsafeMutableRawBufferPointer) {|}}
+//   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
+//   expected-remark@4{{macro content: |    return unsafe nullableTyped(len, p.baseAddress?.assumingMemoryBound(to: CChar.self))|}}
+//   expected-remark@5{{macro content: |}|}}
+// }}
+void nullableTyped(int len, char * __sized_by(len) _Nullable p);
 
 // expected-expansion@+6:45{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
@@ -114,12 +132,11 @@ typedef opaque_t *opaqueptr_t;
 // }}
 void opaqueptr(int len, opaqueptr_t __sized_by(len) p);
 
-// expected-expansion@+8:48{{
+// expected-expansion@+7:48{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func charsized(_ _charsized_param0: UnsafeMutableRawBufferPointer) {|}}
 //   expected-remark@3{{macro content: |    let _charsized_param1 = Int32(exactly: _charsized_param0.count)!|}}
-//   expected-error@4{{value of optional type 'UnsafeMutableRawPointer?' must be unwrapped to refer to member 'assumingMemoryBound' of wrapped base type 'UnsafeMutableRawPointer'}}
-//   expected-remark@4{{macro content: |    return unsafe charsized(_charsized_param0.baseAddress.assumingMemoryBound(to: CChar.self), _charsized_param1)|}}
+//   expected-remark@4{{macro content: |    return unsafe charsized(_charsized_param0.baseAddress?.assumingMemoryBound(to: CChar.self), _charsized_param1)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 void charsized(char *__sized_by(size), int size);
@@ -135,12 +152,11 @@ uint8_t *__sized_by(size) bytesized(int size);
 void doublebytesized(uint16_t *__sized_by(size), int size);
 
 typedef uint8_t * bytesizedptr_t;
-// expected-expansion@+8:66{{
+// expected-expansion@+7:66{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func aliasedBytesized(_ p: UnsafeMutableRawBufferPointer) {|}}
 //   expected-remark@3{{macro content: |    let size = Int32(exactly: p.count)!|}}
-//   expected-error@4{{value of optional type 'UnsafeMutableRawPointer?' must be unwrapped to refer to member 'assumingMemoryBound' of wrapped base type 'UnsafeMutableRawPointer'}}
-//   expected-remark@4{{macro content: |    return unsafe aliasedBytesized(p.baseAddress.assumingMemoryBound(to: UInt8.self), size)|}}
+//   expected-remark@4{{macro content: |    return unsafe aliasedBytesized(p.baseAddress?.assumingMemoryBound(to: UInt8.self), size)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 void aliasedBytesized(bytesizedptr_t __sized_by(size) p, int size);
@@ -151,8 +167,8 @@ module Test {
 }
 
 //--- test.swift
-// GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappersNullAsEmptySpan -Xcc -Wno-nullability-completeness > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
-// GENERATED-HASH: aa0ef698c5b89ce6cae09977d23227d1ff414b5f3d685beb8e3fae593ab566a0
+// GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -plugin-path %swift-plugin-dir -I %t -source-filename=x -Xcc -Wno-nullability-completeness > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
+// GENERATED-HASH: c9f56333ee5d9c85c5969a72839549c1d3a62e640a72f5bd98d1d278f295f363
 import Test
 
 
@@ -181,8 +197,16 @@ func call_nonnull(_ len: Int32, _ p: UnsafeMutableRawPointer) {
   return unsafe nonnull(len, p)
 }
 
+func call_nonnullTyped(_ len: Int32, _ p: UnsafeMutablePointer<CChar>) {
+  return unsafe nonnullTyped(len, p)
+}
+
 func call_nullable(_ len: Int32, _ p: UnsafeMutableRawPointer?) {
   return unsafe nullable(len, p)
+}
+
+func call_nullableTyped(_ len: Int32, _ p: UnsafeMutablePointer<CChar>?) {
+  return unsafe nullableTyped(len, p)
 }
 
 func call_returnPointer(_ len: Int32) -> UnsafeMutableRawPointer! {
@@ -233,12 +257,20 @@ func call_aliasedBytesized(_ p: UnsafeMutablePointer<UInt8>!, _ size: Int32) {
   return unsafe nonnull(p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnullTyped(_ p: UnsafeMutableRawBufferPointer) {
+  return unsafe nonnullTyped(p)
+}
+
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ p: UnsafeMutableRawBufferPointer) {
   return unsafe nullUnspecified(p)
 }
 
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ p: UnsafeMutableRawBufferPointer) {
   return unsafe nullable(p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullableTyped(_ p: UnsafeMutableRawBufferPointer) {
+  return unsafe nullableTyped(p)
 }
 
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_opaque(_ p: UnsafeRawBufferPointer) {


### PR DESCRIPTION
In a recent commit we stopped unwrapping baseAddress when not necessary. This unintentionally introduced an error in macro expansions for `__sized_by` with typed pointers, where we call
`assumingMemoryBound(to:)` on an optional pointer.

rdar://180531503