### PR TITLE
 [RemoteInspection] Substitute generic params inside protocol composition superclass

### DIFF
--- a/stdlib/public/RemoteInspection/TypeRef.cpp
+++ b/stdlib/public/RemoteInspection/TypeRef.cpp
@@ -1668,6 +1668,14 @@ public:
 
   const TypeRef *
   visitProtocolCompositionTypeRef(const ProtocolCompositionTypeRef *PC) {
+    // The "superclass" of a protocol composition is its class bound
+    // (the `C` in `(C & P)`), not a parent class in an inheritance chain.
+    if (auto *Superclass = PC->getSuperclass()) {
+      auto *NewSuperclass = visit(Superclass);
+      return ProtocolCompositionTypeRef::create(Builder, PC->getProtocols(),
+                                                NewSuperclass,
+                                                PC->hasExplicitAnyObject());
+    }
     return PC;
   }
 

--- a/stdlib/public/RemoteInspection/TypeRef.cpp
+++ b/stdlib/public/RemoteInspection/TypeRef.cpp
@@ -1727,6 +1727,7 @@ public:
 
   const TypeRef *
   visitConstrainedExistentialTypeRef(const ConstrainedExistentialTypeRef *CET) {
+    auto *Base = cast<ProtocolCompositionTypeRef>(visit(CET->getBase()));
     std::vector<TypeRefRequirement> constraints;
     for (auto Req : CET->getRequirements()) {
       auto substReq = visitTypeRefRequirement(Req);
@@ -1734,8 +1735,7 @@ public:
         continue;
       constraints.emplace_back(*substReq);
     }
-    return ConstrainedExistentialTypeRef::create(Builder, CET->getBase(),
-                                                 constraints);
+    return ConstrainedExistentialTypeRef::create(Builder, Base, constraints);
   }
 
   const TypeRef *visitSymbolicExtendedExistentialTypeRef(

--- a/stdlib/public/RemoteInspection/TypeRef.cpp
+++ b/stdlib/public/RemoteInspection/TypeRef.cpp
@@ -1668,15 +1668,21 @@ public:
 
   const TypeRef *
   visitProtocolCompositionTypeRef(const ProtocolCompositionTypeRef *PC) {
+    // Visit every member of the composition. The protocols are either
+    // NominalTypeRef or ObjCProtocolTypeRef and substituting them is a no-op,
+    // but visit them anyway so this visitor stays exhaustive.
+    std::vector<const TypeRef *> Protocols;
+    for (auto *Protocol : PC->getProtocols())
+      Protocols.push_back(visit(Protocol));
+
     // The "superclass" of a protocol composition is its class bound
     // (the `C` in `(C & P)`), not a parent class in an inheritance chain.
-    if (auto *Superclass = PC->getSuperclass()) {
-      auto *NewSuperclass = visit(Superclass);
-      return ProtocolCompositionTypeRef::create(Builder, PC->getProtocols(),
-                                                NewSuperclass,
-                                                PC->hasExplicitAnyObject());
-    }
-    return PC;
+    const TypeRef *Superclass = nullptr;
+    if (PC->getSuperclass())
+      Superclass = visit(PC->getSuperclass());
+
+    return ProtocolCompositionTypeRef::create(Builder, Protocols, Superclass,
+                                              PC->hasExplicitAnyObject());
   }
 
   const TypeRef *visitMetatypeTypeRef(const MetatypeTypeRef *M) {

--- a/test/Reflection/Inputs/TypeLowering.swift
+++ b/test/Reflection/Inputs/TypeLowering.swift
@@ -333,3 +333,17 @@ public class ClassBox<T>: P1 {
 public struct ClassBoundCompositionHolder<T> {
   public let field: (ClassBox<T> & P1)?
 }
+
+public class PPClassBox<X>: P1, PP {
+  public typealias T = X
+  public let v: X
+  public init(_ v: X) { self.v = v }
+}
+
+public struct ParameterizedProtocolHolder<T> {
+  public let field: (any PP<T> & P1)?
+}
+
+public struct ClassBoundParameterizedProtocolHolder<T> {
+  public let field: (PPClassBox<T> & PP<T> & P1)?
+}

--- a/test/Reflection/Inputs/TypeLowering.swift
+++ b/test/Reflection/Inputs/TypeLowering.swift
@@ -324,3 +324,12 @@ public struct AlmostBig {
 public struct Big {
   var a, b, c, d, e: Int
 }
+
+public class ClassBox<T>: P1 {
+  public let v: T
+  public init(_ v: T) { self.v = v }
+}
+
+public struct ClassBoundCompositionHolder<T> {
+  public let field: (ClassBox<T> & P1)?
+}

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -1447,3 +1447,13 @@ SpySiGXu
 // CHECK-32-NEXT: (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))
 // CHECK-32-NEXT: (field name=wtable offset=4
 // CHECK-32-NEXT: (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1)))
+
+// Protocol composition with class component.
+12TypeLowering27ClassBoundCompositionHolderVySiG
+// CHECK:      (bound_generic_struct TypeLowering.ClassBoundCompositionHolder
+// CHECK-NEXT:   (struct Swift.Int))
+// CHECK-NEXT: (struct size={{[0-9]+}} {{.*}}
+// CHECK-NEXT:   (field name=field offset=0
+// CHECK:          (class_existential {{.*}}
+// CHECK:            (field name=object {{.*}}
+// CHECK:              (reference kind=strong {{.*}}))

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -1450,10 +1450,83 @@ SpySiGXu
 
 // Protocol composition with class component.
 12TypeLowering27ClassBoundCompositionHolderVySiG
-// CHECK:      (bound_generic_struct TypeLowering.ClassBoundCompositionHolder
-// CHECK-NEXT:   (struct Swift.Int))
-// CHECK-NEXT: (struct size={{[0-9]+}} {{.*}}
-// CHECK-NEXT:   (field name=field offset=0
-// CHECK:          (class_existential {{.*}}
-// CHECK:            (field name=object {{.*}}
-// CHECK:              (reference kind=strong {{.*}}))
+// CHECK:           (bound_generic_struct TypeLowering.ClassBoundCompositionHolder
+// CHECK-NEXT:        (struct Swift.Int))
+// CHECK-64-NEXT: (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=1
+// CHECK-64-NEXT:   (field name=field offset=0
+// CHECK-64-NEXT:     (single_payload_enum size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=1
+// CHECK-64-NEXT:       (case name=some index=0 offset=0
+// CHECK-64-NEXT:         (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
+// CHECK-64-NEXT:           (field name=object offset=0
+// CHECK-64-NEXT:             (reference kind=strong refcounting=native))
+// CHECK-64-NEXT:           (field name=wtable offset=8
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))))
+// CHECK-64-NEXT:       (case name=none index=1)))
+// CHECK-32-NEXT: (struct size=8 alignment=4 stride=8 num_extra_inhabitants=4095 bitwise_takable=1
+// CHECK-32-NEXT:   (field name=field offset=0
+// CHECK-32-NEXT:     (single_payload_enum size=8 alignment=4 stride=8 num_extra_inhabitants=4095 bitwise_takable=1
+// CHECK-32-NEXT:       (case name=some index=0 offset=0
+// CHECK-32-NEXT:         (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=1
+// CHECK-32-NEXT:           (field name=object offset=0
+// CHECK-32-NEXT:             (reference kind=strong refcounting=native))
+// CHECK-32-NEXT:           (field name=wtable offset=4
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))))
+// CHECK-32-NEXT:       (case name=none index=1)))
+
+// Parameterized protocol composition (no class bound).
+12TypeLowering27ParameterizedProtocolHolderVySiG
+// CHECK:           (bound_generic_struct TypeLowering.ParameterizedProtocolHolder
+// CHECK-NEXT:        (struct Swift.Int))
+// CHECK-64-NEXT: (struct size=48 alignment=8 stride=48 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=1
+// CHECK-64-NEXT:   (field name=field offset=0
+// CHECK-64-NEXT:     (single_payload_enum size=48 alignment=8 stride=48 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=1
+// CHECK-64-NEXT:       (case name=some index=0 offset=0
+// CHECK-64-NEXT:         (opaque_existential size=48 alignment=8 stride=48 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
+// CHECK-64-NEXT:           (field name=metadata offset=24
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1))
+// CHECK-64-NEXT:           (field name=wtable offset=32
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))
+// CHECK-64-NEXT:           (field name=wtable offset=40
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))))
+// CHECK-64-NEXT:       (case name=none index=1)))
+// CHECK-32-NEXT: (struct size=24 alignment=4 stride=24 num_extra_inhabitants=4095 bitwise_takable=1
+// CHECK-32-NEXT:   (field name=field offset=0
+// CHECK-32-NEXT:     (single_payload_enum size=24 alignment=4 stride=24 num_extra_inhabitants=4095 bitwise_takable=1
+// CHECK-32-NEXT:       (case name=some index=0 offset=0
+// CHECK-32-NEXT:         (opaque_existential size=24 alignment=4 stride=24 num_extra_inhabitants=4096 bitwise_takable=1
+// CHECK-32-NEXT:           (field name=metadata offset=12
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))
+// CHECK-32-NEXT:           (field name=wtable offset=16
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))
+// CHECK-32-NEXT:           (field name=wtable offset=20
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))))
+// CHECK-32-NEXT:       (case name=none index=1)))
+
+// Parameterized protocol composition with class bound.
+12TypeLowering37ClassBoundParameterizedProtocolHolderVySiG
+// CHECK:           (bound_generic_struct TypeLowering.ClassBoundParameterizedProtocolHolder
+// CHECK-NEXT:        (struct Swift.Int))
+// CHECK-64-NEXT: (struct size=24 alignment=8 stride=24 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=1
+// CHECK-64-NEXT:   (field name=field offset=0
+// CHECK-64-NEXT:     (single_payload_enum size=24 alignment=8 stride=24 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=1
+// CHECK-64-NEXT:       (case name=some index=0 offset=0
+// CHECK-64-NEXT:         (class_existential size=24 alignment=8 stride=24 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
+// CHECK-64-NEXT:           (field name=object offset=0
+// CHECK-64-NEXT:             (reference kind=strong refcounting=native))
+// CHECK-64-NEXT:           (field name=wtable offset=8
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))
+// CHECK-64-NEXT:           (field name=wtable offset=16
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))))
+// CHECK-64-NEXT:       (case name=none index=1)))
+// CHECK-32-NEXT: (struct size=12 alignment=4 stride=12 num_extra_inhabitants=4095 bitwise_takable=1
+// CHECK-32-NEXT:   (field name=field offset=0
+// CHECK-32-NEXT:     (single_payload_enum size=12 alignment=4 stride=12 num_extra_inhabitants=4095 bitwise_takable=1
+// CHECK-32-NEXT:       (case name=some index=0 offset=0
+// CHECK-32-NEXT:         (class_existential size=12 alignment=4 stride=12 num_extra_inhabitants=4096 bitwise_takable=1
+// CHECK-32-NEXT:           (field name=object offset=0
+// CHECK-32-NEXT:             (reference kind=strong refcounting=native))
+// CHECK-32-NEXT:           (field name=wtable offset=4
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))
+// CHECK-32-NEXT:           (field name=wtable offset=8
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))))
+// CHECK-32-NEXT:       (case name=none index=1)))


### PR DESCRIPTION
- **Explanation**: The substitution visitor's `visitProtocolCompositionTypeRef` returned the input unchanged, so any generic parameters appearing in the class bound of a `(Class & Protocol)` composition were left unsubstituted.  
- **Scope**: Impacts resolution of protocol composition existentials in remote mirrors.
- **Issues**: rdar://177199559
- **Original PRs**: https://github.com/swiftlang/swift/pull/89305
- **Risk**: Low
- **Testing**:  Testing added in this PR and in lldb exercising the feature
- **Reviewers**: @mikeash 
