### PR TITLE
[cxx-interop] Make sure begin() is imported as __beginUnsafe()

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8668,14 +8668,14 @@ bool IsSafeUseOfCxxDecl::evaluate(Evaluator &evaluator,
         isa<clang::CXXConstructorDecl>(decl))
       return true;
 
-    if (clangTypeIsForeignReference(method->getReturnType(), desc.ctx))
-      return true;
-
-    // begin and end methods likely return an interator, so they're unsafe. This
-    // is required so that automatic the conformance to RAC works properly.
+    // begin and end methods likely return an iterator, so they're unsafe.
+    // This is required so that automatic the conformance to RAC works properly.
     if (method->getNameAsString() == "begin" ||
         method->getNameAsString() == "end")
       return false;
+
+    if (clangTypeIsForeignReference(method->getReturnType(), desc.ctx))
+      return true;
 
     auto parentQualType = method
       ->getParent()->getTypeForDecl()->getCanonicalTypeUnqualified();

--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -280,7 +280,7 @@ const uint16_t SWIFT_LOOKUP_TABLE_VERSION_MAJOR = 1;
 /// Lookup table minor version number.
 ///
 /// When the format changes IN ANY WAY, this number should be incremented.
-const uint16_t SWIFT_LOOKUP_TABLE_VERSION_MINOR = 23; // effective ctx of nested unscoped enums
+const uint16_t SWIFT_LOOKUP_TABLE_VERSION_MINOR = 24; // begin() returning FRT is __Unsafe
 
 /// A lookup table that maps Swift names to the set of Clang
 /// declarations with that particular name.

--- a/test/Interop/Cxx/class/method/unsafe-ref-sequence-typechecker.swift
+++ b/test/Interop/Cxx/class/method/unsafe-ref-sequence-typechecker.swift
@@ -1,0 +1,67 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unrelated \
+// RUN:   -I %t/Inputs %t/test.swift \
+// RUN:   -cxx-interoperability-mode=default
+
+//--- Inputs/module.modulemap
+module UnsafeRefContainer {
+  header "unsafe-ref-container.h"
+  requires cplusplus
+}
+
+//--- Inputs/unsafe-ref-container.h
+#pragma once
+#include <vector>
+
+struct __attribute__((swift_attr("import_reference")))
+       __attribute__((swift_attr("retain:immortal")))
+       __attribute__((swift_attr("release:immortal")))
+       __attribute__((swift_attr("unsafe")))
+UnsafeRef {
+  int doSomething(int x) { return x; }
+};
+
+class Container {
+  UnsafeRef *storage;
+  int count;
+public:
+  const UnsafeRef *begin() const { return storage; }
+  const UnsafeRef *end() const { return storage + count; }
+};
+
+struct CWrapper {
+  Container items;
+};
+
+struct VWrapper {
+  std::vector<UnsafeRef> items;
+};
+
+//--- test.swift
+
+import UnsafeRefContainer
+import CxxStdlib
+
+func use() {
+  let cw = CWrapper()
+  _ = cw.items.__beginUnsafe()
+  _ = cw.items.__endUnsafe()
+  _ = cw.items.begin() // expected-error {{value of type 'Container' has no member 'begin'}}
+  // expected-note@-1 {{C++ method 'begin' that returns an iterator is unavailable}}
+  // expected-note@-2 {{C++ methods that return iterators are potentially unsafe; try using Swift collection APIs instead}}
+  _ = cw.items.end() // expected-error {{value of type 'Container' has no member 'end'}}
+  // expected-note@-1 {{C++ method 'end' that returns an iterator is unavailable}}
+  // expected-note@-2 {{C++ methods that return iterators are potentially unsafe; try using Swift collection APIs instead}}
+
+  let vw = VWrapper()
+  _ = vw.items.__beginUnsafe()
+  _ = vw.items.__endUnsafe()
+  _ = vw.items.begin() // expected-error {{has no member 'begin'}}
+  // expected-note@-1 {{C++ method 'begin' that returns an iterator is unavailable}}
+  // expected-note@-2 {{do you want to use a for-in loop instead?}}
+  _ = vw.items.end() // expected-error {{has no member 'end'}}
+  // expected-note@-1 {{C++ method 'end' that returns an iterator is unavailable}}
+  // expected-note@-2 {{do you want to compare against 'nil' instead?}}
+  for i in vw.items {}
+}


### PR DESCRIPTION
We need to defer the "return type is FRT" check to after the "begin" and "end" logic, otherwise the imported names of "begin" and "end" become even less stable.

rdar://180479293