### PR TITLE
[test] Interpreter/static_keypaths: use %target-build-swift for LibA

### DIFF
--- a/test/Interpreter/static_keypaths.swift
+++ b/test/Interpreter/static_keypaths.swift
@@ -2,7 +2,7 @@
 // RUN: split-file %s %t/src
 
 /// Build LibA
-// RUN: %host-build-swift %t/src/LibA.swift -swift-version 5 -enable-experimental-feature KeyPathWithMethodMembers -emit-module -emit-library -enable-library-evolution -module-name LibA -o %t/%target-library-name(LibA) -emit-module-interface-path %t/LibA.swiftinterface
+// RUN: %target-build-swift %t/src/LibA.swift -swift-version 5 -enable-experimental-feature KeyPathWithMethodMembers -emit-module -emit-library -enable-library-evolution -module-name LibA -o %t/%target-library-name(LibA) -emit-module-interface-path %t/LibA.swiftinterface
 
 // Build LibB
 // RUN: %target-build-swift %t/src/LibB.swift -I %t -L %t -l LibA -swift-version 5 -enable-experimental-feature KeyPathWithMethodMembers -emit-module -emit-library -module-name LibB -o %t/%target-library-name(LibB)


### PR DESCRIPTION
The first RUN line built LibA with %host-build-swift while LibB and the rest of the test use %target-build-swift. In a native build the two substitutions resolve to the same triple so the inconsistency is invisible, but on a cross-compile run LibA and LibB are built for different targets and LibB then fails to import libA.

There's no architectural reason this particular library needs to be the host arch — it's just exercising KeyPathWithMethodMembers, which is target-independent. Use %target-build-swift for consistency.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
