### PR TITLE
[test] Cxx/foreign-reference/array-of-classes: set -target to macosx13.3

### DIFF
--- a/test/Interop/Cxx/foreign-reference/array-of-classes.swift
+++ b/test/Interop/Cxx/foreign-reference/array-of-classes.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
-// RUN: %swiftc_driver -target %target-cpu-apple-macosx13.3 -O -I %t/Inputs  %t/test.swift -cxx-interoperability-mode=default -o %t/a.out
+// RUN: %target-build-swift -O -I %t/Inputs %t/test.swift -cxx-interoperability-mode=default %if OS=macosx %{ -target %target-cpu-apple-macosx13.3 %} -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 

--- a/test/Interop/Cxx/foreign-reference/array-of-classes.swift
+++ b/test/Interop/Cxx/foreign-reference/array-of-classes.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
-// RUN: %target-build-swift -O -I %t/Inputs %t/test.swift -cxx-interoperability-mode=default %if OS=macosx %{ -target %target-cpu-apple-macosx13.3 %} -o %t/a.out
+// RUN: %swiftc_driver -target %target-swift-5.8-abi-triple -O -I %t/Inputs %t/test.swift -cxx-interoperability-mode=default -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 

--- a/test/Interop/Cxx/foreign-reference/array-of-classes.swift
+++ b/test/Interop/Cxx/foreign-reference/array-of-classes.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
-// RUN: %swiftc_driver -O -I %t/Inputs  %t/test.swift -cxx-interoperability-mode=default -o %t/a.out
+// RUN: %swiftc_driver -target %target-cpu-apple-macosx13.3 -O -I %t/Inputs  %t/test.swift -cxx-interoperability-mode=default -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 


### PR DESCRIPTION
Line 3 used %swiftc_driver, which doesn't inject -target like %target-build-swift does, so the test binary was built for the build host's arch. When cross- compiling, shipping it to the target fails with "Bad CPU type in executable". Add -target %target-triple to pin the build to the variant.

The test's `RefType` is annotated `@available(macOS 13.3.0, *)`. Using %target-cpu-apple-macosx13.3 satisfies the availability constraint.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
