### PR TITLE
OpaqueValues: refresh opaque_values_silgen[_lib] CHECK lines for OSSA

### DIFF
--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -2,8 +2,6 @@
 
 // Test SILGen -enable-sil-opaque-values with tests that depend on the stdlib.
 
-// FIXME: "HECK" lines all need to be updated for OSSA.
-
 class C {}
 
 struct MyInt {
@@ -22,15 +20,14 @@ func source<T>(_ t: T.Type) -> T
 // Test array initialization - we are still (somewhat) using addresses
 // ---
 // CHECK-LABEL: sil [ossa] @$s20opaque_values_silgen10callVarArgyyF : $@convention(thin) () -> () {
-// HECK: %[[APY:.*]] = apply %{{.*}}<Any>(%{{.*}}) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
-// HECK: %[[BRW:.*]] = begin_borrow %[[APY]]
-// HECK: %[[TPL:.*]] = tuple_extract %[[BRW]] : $(Array<Any>, Builtin.RawPointer), 1
-// HECK: end_borrow %[[BRW]] : $(Array<Any>, Builtin.RawPointer)
-// HECK: destroy_value %[[APY]]
-// HECK: %[[PTR:.*]] = pointer_to_address %[[TPL]] : $Builtin.RawPointer to [strict] $*Any
-// HECK: [[IOPAQUE:%.*]] = init_existential_value %{{.*}} : $Int, $Int, $Any
-// HECK: store [[IOPAQUE]] to [init] %[[PTR]] : $*Any
-// HECK: return %{{.*}} : $()
+// CHECK: [[ALLOC:%[^,]+]] = apply %{{.*}}<Any>(%{{.*}}) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
+// CHECK: ([[ARRAY:%[^,]+]], {{%[^)]+}}) = destructure_tuple [[ALLOC]] : $(Array<Any>, Builtin.RawPointer)
+// CHECK: [[BORROW:%[^,]+]] = begin_borrow [[ARRAY]] : $Array<Any>
+// CHECK: [[ELT_ADDR:%[^,]+]] = index_addr [projection] {{%[^,]+}} : $*Any, {{%[^,]+}}
+// CHECK: [[IOPAQUE:%[^,]+]] = init_existential_value {{%[^,]+}} : $Int, $Int, $Any
+// CHECK: store [[IOPAQUE]] to [init] [[ELT_ADDR]] : $*Any
+// CHECK: end_borrow [[BORROW]] : $Array<Any>
+// CHECK: return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '$s20opaque_values_silgen10callVarArgyyF'
 public func callVarArg() {
   hasVarArg(3)
@@ -39,28 +36,24 @@ public func callVarArg() {
 // Tests For-each statements
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$s20opaque_values_silgen11forEachStmtyyF : $@convention(thin) () -> () {
-// HECK: bb0:
-// HECK:   [[PROJ_BOX_ARG:%.*]] = project_box %{{.*}} : ${ var IndexingIterator<Range<Int>> }
-// HECK:   [[APPLY_ARG1:%.*]] = apply
-// HECK-NOT: alloc_stack $Int
-// HECK-NOT: store [[APPLY_ARG1]] to [trivial]
-// HECK-NOT: alloc_stack $Range<Int>
-// HECK-NOT: dealloc_stack
-// HECK:   [[APPLY_ARG2:%.*]] = apply %{{.*}}<Range<Int>>
-// HECK:   store [[APPLY_ARG2]] to [trivial] [[PROJ_BOX_ARG]]
-// HECK:   br bb1
-// HECK: bb1:
-// CHECK-NOT: alloc_stack $Optional<Int>
-// HECK:   [[APPLY_ARG3:%.*]] = apply %{{.*}}<Range<Int>>
+// CHECK: bb0:
+// CHECK:   [[PROJ_BOX_ARG:%.*]] = project_box %{{.*}} : ${ var IndexingIterator<Range<Int>> }
+// CHECK-NOT: alloc_stack $Int
+// CHECK-NOT: alloc_stack $Range<Int>
 // CHECK-NOT: dealloc_stack
-// HECK:   switch_enum [[APPLY_ARG3]]
-// HECK: bb2:
-// HECK:   br bb3
-// HECK: bb3:
-// HECK:   return %{{.*}} : $()
-// HECK: bb4([[ENUM_ARG:%.*]] : $Int):
+// CHECK:   [[ITER:%.*]] = apply %{{.*}}<Range<Int>>({{.*}}) : $@convention(method) <τ_0_0 where τ_0_0 : Collection, τ_0_0.Iterator == IndexingIterator<τ_0_0>> (@in τ_0_0) -> @out IndexingIterator<τ_0_0>
+// CHECK:   store [[ITER]] to [trivial] [[PROJ_BOX_ARG]]
+// CHECK:   br bb1
+// CHECK: bb1:
+// CHECK-NOT: alloc_stack $Optional<Int>
+// CHECK:   [[NEXT:%.*]] = apply %{{.*}}<Range<Int>>
+// CHECK-NOT: dealloc_stack
+// CHECK:   switch_enum [[NEXT]] : $Optional<Int>, case #Optional.some!enumelt: bb2, case #Optional.none!enumelt: bb3
+// CHECK: bb2([[ENUM_ARG:%.*]] : $Int):
 // CHECK-NOT:   unchecked_enum_data
-// HECK:   br bb1
+// CHECK:   br bb1
+// CHECK: bb3:
+// CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '$s20opaque_values_silgen11forEachStmtyyF'
 func forEachStmt() {
   for _ in 1..<42 {
@@ -87,14 +80,14 @@ func openExistBox(_ x: Error) -> String {
 // Tests conditional value casts and correspondingly generated reabstraction thunk
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$s20opaque_values_silgen11condFromAnyyyypF : $@convention(thin) (@in_guaranteed Any) -> () {
-// HECK: bb0([[ARG:%.*]] : $Any):
-// HECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]]
-// HECK:   checked_cast_br Any in [[COPY_ARG]] : $Any to $@callee_guaranteed (@in_guaranteed (Int, (Int, (Int, Int)), Int)) -> @out (Int, (Int, (Int, Int)), Int), bb2, bb1
-// HECK: bb2([[THUNK_PARAM:%.*]] : $@callee_guaranteed (@in_guaranteed (Int, (Int, (Int, Int)), Int)) -> @out (Int, (Int, (Int, Int)), Int)):
-// HECK:   [[THUNK_REF:%.*]] = function_ref @{{.*}} : $@convention(thin) (Int, Int, Int, Int, Int, @guaranteed @callee_guaranteed (@in_guaranteed (Int, (Int, (Int, Int)), Int)) -> @out (Int, (Int, (Int, Int)), Int)) -> (Int, Int, Int, Int, Int)
-// HECK:   partial_apply [callee_guaranteed] [[THUNK_REF]]([[THUNK_PARAM]])
-// HECK: bb6:
-// HECK:   return %{{.*}} : $()
+// CHECK: bb0([[ARG:%.*]] : @guaranteed $Any):
+// CHECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]]
+// CHECK:   checked_cast_br Any in [[COPY_ARG]] : $Any to (Int, (Int, (Int, Int)), Int) -> (Int, (Int, (Int, Int)), Int), [[SUCCESS:bb[0-9]+]], {{bb[0-9]+}}
+// CHECK: [[SUCCESS]]([[CAST:%.*]] : @owned $@callee_guaranteed @substituted <{{.*}}> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1, @in_guaranteed τ_0_2) -> @out τ_0_3 for <{{.*}}>):
+// CHECK:   [[CONVERTED:%.*]] = convert_function [[CAST]] {{.*}} to $@callee_guaranteed (@in_guaranteed Int, @in_guaranteed (Int, (Int, Int)), @in_guaranteed Int) -> @out (Int, (Int, (Int, Int)), Int)
+// CHECK:   [[THUNK_REF:%.*]] = function_ref @{{.*}} : $@convention(thin) (Int, Int, Int, Int, Int, @guaranteed @callee_guaranteed (@in_guaranteed Int, @in_guaranteed (Int, (Int, Int)), @in_guaranteed Int) -> @out (Int, (Int, (Int, Int)), Int)) -> (Int, Int, Int, Int, Int)
+// CHECK:   partial_apply [callee_guaranteed] [[THUNK_REF]]([[CONVERTED]])
+// CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '$s20opaque_values_silgen11condFromAnyyyypF'
 func condFromAny(_ x: Any) {
   if let f = x as? (Int, (Int, (Int, Int)), Int) -> (Int, (Int, (Int, Int)), Int) {
@@ -109,25 +102,27 @@ protocol EmptyP {}
 struct AddressOnlyStruct : EmptyP {}
 
 // CHECK-LABEL: sil hidden [ossa] @$s20opaque_values_silgen10addrOnlyIf1xAA6EmptyP_pSb_tF : $@convention(thin) (Bool) -> @out any EmptyP {
-// HECK: bb0([[ARG:%.*]] : $Bool):
-// HECK:   [[ALLOC_OF_BOX:%.*]] = alloc_box ${ var any EmptyP }, var
-// HECK:   [[PROJ_BOX:%.*]] = project_box [[ALLOC_OF_BOX]]
-// HECK:   [[APPLY_FOR_BOX:%.*]] = apply %{{.*}}(%{{.*}}) : $@convention(method) (@thin AddressOnlyStruct.Type) -> AddressOnlyStruct
-// HECK:   [[INIT_OPAQUE:%.*]] = init_existential_value [[APPLY_FOR_BOX]] : $AddressOnlyStruct, $AddressOnlyStruct, $any EmptyP
-// HECK:   store [[INIT_OPAQUE]] to [init] [[PROJ_BOX]] : $*any EmptyP
-// HECK:   [[APPLY_FOR_BRANCH:%.*]] = apply %{{.*}}([[ARG]]) : $@convention(method) (Bool) -> Builtin.Int1
-// HECK:   cond_br [[APPLY_FOR_BRANCH]], bb2, bb1
-// HECK: bb1:
-// HECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PROJ_BOX]] : $*EmptyP
-// HECK:   [[RETVAL1:%.*]] = load [copy] [[READ]] : $*EmptyP
-// HECK:   br bb3([[RETVAL1]] : $EmptyP)
-// HECK: bb2:
-// HECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PROJ_BOX]] : $*EmptyP
-// HECK:   [[RETVAL2:%.*]] = load [copy] [[READ]] : $*EmptyP
-// HECK:   br bb3([[RETVAL2]] : $EmptyP)
-// HECK: bb3([[RETVAL:%.*]] : $EmptyP):
-// HECK:   destroy_value [[ALLOC_OF_BOX]]
-// HECK:   return [[RETVAL]] : $EmptyP
+// CHECK: bb0([[ARG:%.*]] : $Bool):
+// CHECK:   [[ALLOC_OF_BOX:%.*]] = alloc_box ${ var any EmptyP }, var
+// CHECK:   [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[ALLOC_OF_BOX]]
+// CHECK:   [[PROJ_BOX:%.*]] = project_box [[BOX_LIFETIME]]
+// CHECK:   [[APPLY_FOR_BOX:%.*]] = apply %{{.*}}(%{{.*}}) : $@convention(method) (@thin AddressOnlyStruct.Type) -> AddressOnlyStruct
+// CHECK:   [[INIT_OPAQUE:%.*]] = init_existential_value [[APPLY_FOR_BOX]] : $AddressOnlyStruct, $AddressOnlyStruct, $any EmptyP
+// CHECK:   store [[INIT_OPAQUE]] to [init] [[PROJ_BOX]] : $*any EmptyP
+// CHECK:   [[COND:%.*]] = struct_extract [[ARG]] : $Bool, #Bool._value
+// CHECK:   cond_br [[COND]], bb1, bb2
+// CHECK: bb1:
+// CHECK:   [[READ1:%.*]] = begin_access [read] [unknown] [[PROJ_BOX]] : $*any EmptyP
+// CHECK:   [[RETVAL1:%.*]] = load [copy] [[READ1]] : $*any EmptyP
+// CHECK:   br bb3([[RETVAL1]] : $any EmptyP)
+// CHECK: bb2:
+// CHECK:   [[READ2:%.*]] = begin_access [read] [unknown] [[PROJ_BOX]] : $*any EmptyP
+// CHECK:   [[RETVAL2:%.*]] = load [copy] [[READ2]] : $*any EmptyP
+// CHECK:   br bb3([[RETVAL2]] : $any EmptyP)
+// CHECK: bb3([[RETVAL:%.*]] : @owned $any EmptyP):
+// CHECK:   end_borrow [[BOX_LIFETIME]]
+// CHECK:   destroy_value [[ALLOC_OF_BOX]]
+// CHECK:   return [[RETVAL]] : $any EmptyP
 // CHECK-LABEL: } // end sil function '$s20opaque_values_silgen10addrOnlyIf1xAA6EmptyP_pSb_tF'
 func addrOnlyIf(x: Bool) -> EmptyP {
   var a : EmptyP = AddressOnlyStruct()
@@ -138,19 +133,21 @@ func addrOnlyIf(x: Bool) -> EmptyP {
 // Tests LValue of error types / existential boxes
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$s20opaque_values_silgen12propOfLValueySSs5Error_pF : $@convention(thin) (@guaranteed any Error) -> @owned String {
-// HECK: bb0([[ARG:%.*]] : $any Error):
-// HECK:   [[ALLOC_OF_BOX:%.*]] = alloc_box ${ var any Error }
-// HECK:   [[PROJ_BOX:%.*]] = project_box [[ALLOC_OF_BOX]]
-// HECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]]
-// HECK:   store [[COPY_ARG]] to [init] [[PROJ_BOX]]
-// HECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PROJ_BOX]] : $*any Error
-// HECK:   [[LOAD_BOX:%.*]] = load [copy] [[READ]]
-// HECK:   [[OPAQUE_ARG:%.*]] = open_existential_box [[LOAD_BOX]] : $any Error to $*@opened({{.*}}, any Error) Self
-// HECK:   [[LOAD_OPAQUE:%.*]] = load [copy] [[OPAQUE_ARG]]
-// HECK:   [[ALLOC_OPEN:%.*]] = alloc_stack $@opened({{.*}}, any Error) Self
-// HECK:   store [[LOAD_OPAQUE]] to [init] [[ALLOC_OPEN]]
-// HECK:   [[RET_VAL:%.*]] = apply {{.*}}<@opened({{.*}}, any Error) Self>([[ALLOC_OPEN]])
-// HECK:   return [[RET_VAL]] : $String
+// CHECK: bb0([[ARG:%.*]] : @guaranteed $any Error):
+// CHECK:   [[ALLOC_OF_BOX:%.*]] = alloc_box ${ var any Error }
+// CHECK:   [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[ALLOC_OF_BOX]]
+// CHECK:   [[PROJ_BOX:%.*]] = project_box [[BOX_LIFETIME]]
+// CHECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]]
+// CHECK:   store [[COPY_ARG]] to [init] [[PROJ_BOX]]
+// CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PROJ_BOX]] : $*any Error
+// CHECK:   [[LOAD_BOX:%.*]] = load [copy] [[READ]]
+// CHECK:   [[BORROW_BOX:%.*]] = begin_borrow [[LOAD_BOX]] : $any Error
+// CHECK:   [[OPAQUE_ARG:%.*]] = open_existential_box [[BORROW_BOX]] : $any Error to $*@opened({{.*}}, any Error) Self
+// CHECK:   [[LOAD_OPAQUE:%.*]] = load [copy] [[OPAQUE_ARG]]
+// CHECK:   [[ALLOC_OPEN:%.*]] = alloc_stack $@opened({{.*}}, any Error) Self
+// CHECK:   store {{%[^,]+}} to [init] [[ALLOC_OPEN]]
+// CHECK:   [[RET_VAL:%.*]] = apply {{.*}}<@opened({{.*}}, any Error) Self>([[ALLOC_OPEN]])
+// CHECK:   return [[RET_VAL]] : $String
 // CHECK-LABEL: } // end sil function '$s20opaque_values_silgen12propOfLValueySSs5Error_pF'
 func propOfLValue(_ x: Error) -> String {
   var x = x
@@ -161,8 +158,8 @@ func propOfLValue(_ x: Error) -> String {
 // Test SILGenBuilder.loadCopy().
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$s20opaque_values_silgen7lastValyxxd_tlF : $@convention(thin) <T> (@guaranteed Array<T>) -> @out T {
-// HECK: [[LOAD:%.*]] = load [copy] %{{.*}} : $*T
-// HECK: return [[LOAD]] : $T
+// CHECK: [[LOAD:%.*]] = load [copy] %{{.*}} : $*T
+// CHECK: return [[LOAD]] : $T
 // CHECK-LABEL: } // end sil function '$s20opaque_values_silgen7lastValyxxd_tlF'
 func lastVal<T>(_ rest: T...) -> T {
   var minValue: T
@@ -175,8 +172,8 @@ func lastVal<T>(_ rest: T...) -> T {
 // Test SILGenFunction::emitPointerToPointer.
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$s20opaque_values_silgen3foo1pSRyxGSPyxG_tlF : $@convention(thin) <Element> (UnsafePointer<Element>) -> UnsafeBufferPointer<Element> {
-// HECK: [[F:%.*]] = function_ref @$sconvertPointerToB8Argumentyq_xB0RzsABR_r0_lF : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : _Pointer, τ_0_1 : _Pointer> (@in_guaranteed τ_0_0) -> @out τ_0_1
-// HECK: apply [[F]]<UnsafePointer<Element>, UnsafePointer<Element>>(%0) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : _Pointer, τ_0_1 : _Pointer> (@in_guaranteed τ_0_0) -> @out τ_0_1
+// CHECK: [[F:%.*]] = function_ref @{{.*}} : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : _Pointer, τ_0_1 : _Pointer> (@in_guaranteed τ_0_0) -> @out τ_0_1
+// CHECK: apply [[F]]<UnsafePointer<Element>, UnsafePointer<Element>>(%0) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : _Pointer, τ_0_1 : _Pointer> (@in_guaranteed τ_0_0) -> @out τ_0_1
 // CHECK-LABEL: } // end sil function '$s20opaque_values_silgen3foo1pSRyxGSPyxG_tlF'
 func foo<Element>(p: UnsafePointer<Element>) -> UnsafeBufferPointer<Element> {
   return UnsafeBufferPointer(start: p, count: 1)
@@ -190,20 +187,23 @@ protocol FooP {
 
 // CHECK-LABEL: sil private [ossa] @$s20opaque_values_silgen10loadBorrowyyF4FooPL_V3foo3pos7ElementQzSg5IndexQz_tF : $@convention(method) <Elements where Elements : Collection> (@in_guaranteed Elements.Index, @inout FooP<Elements>) -> @out Optional<Elements.Element> {
 // CHECK: bb0([[ARG0:%.*]] : @guaranteed $Elements.Index, [[ARG1:%.*]] : $*FooP<Elements>):
-// HECK: [[READ:%.*]] = begin_access [read] [unknown] [[ARG1]] : $*FooP<Elements>
-// HECK: [[LOAD:%.*]] = load [copy] [[READ]] : $*FooP<Elements>
-// HECK: end_access [[READ]] : $*FooP<Elements>
-// HECK: [[BORROW_LOAD:%.*]] = begin_borrow [[LOAD]]
-// HECK: [[EXTRACT:%.*]] = struct_extract [[BORROW_LOAD]] : $FooP<Elements>, #<abstract function>FooP._elements
-// HECK: [[COPYELT:%.*]] = copy_value [[EXTRACT]] : $Elements
-// HECK: [[COPYIDX:%.*]] = copy_value [[ARG0]] : $Elements.Index
-// HECK: [[WT:%.*]] = witness_method $Elements, #Collection.subscript!getter : <Self where Self : Collection> (Self) -> (Self.Index) -> Self.Element : $@convention(witness_method: Collection) <τ_0_0 where τ_0_0 : Collection> (@in_guaranteed τ_0_0.Index, @in_guaranteed τ_0_0) -> @out τ_0_0.Element
-// HECK: [[RESULT:%.*]] = apply [[WT]]<Elements>([[COPYIDX]], [[COPYELT]]) : $@convention(witness_method: Collection) <τ_0_0 where τ_0_0 : Collection> (@in_guaranteed τ_0_0.Index, @in_guaranteed τ_0_0) -> @out τ_0_0.Element
-// HECK: destroy_value [[COPYELT]] : $Elements
-// HECK: [[ENUM_RESULT:%.*]] = enum $Optional<Elements.Element>, #Optional.some!enumelt, [[RESULT]] : $Elements.Element
-// HECK: destroy_value [[LOAD]]
+// CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[ARG1]] : $*FooP<Elements>
+// CHECK: [[LOAD:%.*]] = load [copy] [[READ]] : $*FooP<Elements>
+// CHECK: end_access [[READ]] : $*FooP<Elements>
+// CHECK: [[BORROW_LOAD:%.*]] = begin_borrow [[LOAD]]
+// CHECK: [[EXTRACT:%.*]] = struct_extract [[BORROW_LOAD]] : $FooP<Elements>, #<abstract function>FooP._elements
+// CHECK: [[COPYELT:%.*]] = copy_value [[EXTRACT]] : $Elements
+// CHECK: [[COPYIDX:%.*]] = copy_value [[ARG0]] : $Elements.Index
+// CHECK: [[BORROWELT:%.*]] = begin_borrow [[COPYELT]] : $Elements
+// CHECK: [[BORROWIDX:%.*]] = begin_borrow [[COPYIDX]] : $Elements.Index
+// CHECK: [[WT:%.*]] = witness_method $Elements, #Collection.subscript!read : <Self where Self : Collection> (Self) -> (Self.Index) -> () : $@yield_once @convention(witness_method: Collection) <τ_0_0 where τ_0_0 : Collection> (@in_guaranteed τ_0_0.Index, @in_guaranteed τ_0_0) -> @yields @in_guaranteed τ_0_0.Element
+// CHECK: ([[YIELD:%.*]], [[TOKEN:%.*]]) = begin_apply [[WT]]<Elements>([[BORROWIDX]], [[BORROWELT]]) : $@yield_once @convention(witness_method: Collection) <τ_0_0 where τ_0_0 : Collection> (@in_guaranteed τ_0_0.Index, @in_guaranteed τ_0_0) -> @yields @in_guaranteed τ_0_0.Element
+// CHECK: [[RESULT:%.*]] = copy_value [[YIELD]] : $Elements.Element
+// CHECK: end_apply [[TOKEN]]
+// CHECK: destroy_value [[COPYELT]] : $Elements
+// CHECK: [[ENUM_RESULT:%.*]] = enum $Optional<Elements.Element>, #Optional.some!enumelt, [[RESULT]] : $Elements.Element
 // CHECK-NOT: destroy_value [[ARG0]] : $Elements.Index
-// HECK: return [[ENUM_RESULT]] : $Optional<Elements.Element>
+// CHECK: return [[ENUM_RESULT]] : $Optional<Elements.Element>
 // CHECK-LABEL: } // end sil function '$s20opaque_values_silgen10loadBorrowyyF4FooPL_V3foo3pos7ElementQzSg5IndexQz_tF'
 func loadBorrow() {
   struct FooP<Elements : Collection> {
@@ -218,32 +218,50 @@ func loadBorrow() {
 }
 
 
-// Tests LogicalPathComponent's writeback for opaque value types
+// Tests LogicalPathComponent's writeback for opaque value types.
+//
+// The subscript getter/setter are now trivial (the writeback orchestration that
+// materializeForSet used to perform lives in the caller, inoutAccessOfSubscript
+// below). They serve here to confirm opaque values flow through the subscript
+// accessors directly rather than via addresses.
 // ---
 // Dictionary.subscript.getter
 // CHECK-LABEL: sil [heuristic_always_inline] [ossa] @$sSD20opaque_values_silgenEyq_Sgq_cig : $@convention(method) <Key, Value where Key : Hashable> (@in_guaranteed Value, @guaranteed Dictionary<Key, Value>) -> @out Optional<Value> {
-// HECK: bb0([[ARG0:%.*]] : $Value, [[ARG1:%.*]] : $*Dictionary<Key, Value>):
-// HECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] [[ARG1]] : $*Dictionary<Key, Value>
-// HECK:   [[OPTIONAL_ALLOC:%.*]] = alloc_stack $Optional<Value>
-// HECK:   switch_enum_addr [[OPTIONAL_ALLOC]] : $*Optional<Value>, case #Optional.some!enumelt: bb2, case #Optional.none!enumelt: bb1
-// HECK: bb2:
-// HECK:   [[OPTIONAL_LOAD:%.*]] = load [take] [[OPTIONAL_ALLOC]] : $*Optional<Value>
-// HECK:   apply {{.*}}<Key, Value>([[OPTIONAL_LOAD]], {{.*}}, [[WRITE]]) : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@in Optional<τ_0_1>, @in τ_0_1, @inout Dictionary<τ_0_0, τ_0_1>) -> ()
-// HECK:   return %{{.*}} : $()
+// CHECK: bb0([[KEY:%.*]] : @guaranteed $Value, {{%.*}} : @guaranteed $Dictionary<Key, Value>):
+// CHECK:   [[COPY:%.*]] = copy_value [[KEY]] : $Value
+// CHECK:   [[SOME:%.*]] = enum $Optional<Value>, #Optional.some!enumelt, [[COPY]] : $Value
+// CHECK:   return [[SOME]] : $Optional<Value>
 // CHECK-LABEL: } // end sil function '$sSD20opaque_values_silgenEyq_Sgq_cig'
 
-// Tests materializeForSet's createSetterCallback for opaque values
-// ---
 // Dictionary.subscript.setter
 // CHECK-LABEL: sil [ossa] @$sSD20opaque_values_silgenEyq_Sgq_cis : $@convention(method) <Key, Value where Key : Hashable> (@in Optional<Value>, @in Value, @inout Dictionary<Key, Value>) -> () {
-// HECK: bb0([[ARG0:%.*]] : $Builtin.RawPointer, [[ARG1:%.*]] : $*Builtin.UnsafeValueBuffer, [[ARG2:%.*]] : $*Dictionary<Key, Value>, [[ARG3:%.*]] : $@thick Dictionary<Key, Value>.Type):
-// HECK:   [[PROJ_VAL1:%.*]] = project_value_buffer $Value in [[ARG1]] : $*Builtin.UnsafeValueBuffer
-// HECK:   [[LOAD_VAL1:%.*]] = load [take] [[PROJ_VAL1]] : $*Value
-// HECK:   [[ADDR_VAL0:%.*]] = pointer_to_address [[ARG0]] : $Builtin.RawPointer to [strict] $*Optional<Value>
-// HECK:   [[LOAD_VAL0:%.*]] = load [take] [[ADDR_VAL0]] : $*Optional<Value>
-// HECK:   apply {{.*}}<Key, Value>([[LOAD_VAL0]], [[LOAD_VAL1]], [[ARG2]]) : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@in Optional<τ_0_1>, @in τ_0_1, @inout Dictionary<τ_0_0, τ_0_1>) -> ()
-// HECK:   return %{{.*}} : $()
+// CHECK: bb0([[NEWVALUE:%.*]] : @owned $Optional<Value>, [[KEY:%.*]] : @owned $Value, {{%.*}} : $*Dictionary<Key, Value>):
+// CHECK:   destroy_value [[KEY]] : $Value
+// CHECK:   destroy_value [[NEWVALUE]] : $Optional<Value>
+// CHECK:   return
 // CHECK-LABEL: } // end sil function '$sSD20opaque_values_silgenEyq_Sgq_cis'
+
+// The actual writeback: read through the getter into a temporary, mutate the
+// in-place payload, then store it back through the setter. The optionals are
+// opaque values stored to/loaded from the temporary; no value is materialized
+// to an address except for the temporary itself.
+// CHECK-LABEL: sil {{.*}}[ossa] @$sSD20opaque_values_silgenE22inoutAccessOfSubscript3keyyq__tF : $@convention(method) <Key, Value where Key : Hashable> (@in_guaranteed Value, @inout Dictionary<Key, Value>) -> () {
+// CHECK:       bb0({{%.*}} : @guaranteed $Value, [[SELF:%.*]] : $*Dictionary<Key, Value>):
+// CHECK:         [[WRITE:%.*]] = begin_access [modify] [unknown] [[SELF]] : $*Dictionary<Key, Value>
+// CHECK:         [[OPTIONAL_ALLOC:%.*]] = alloc_stack $Optional<Value>
+// CHECK:         [[GETTER:%.*]] = function_ref @$sSD20opaque_values_silgenEyq_Sgq_cig
+// CHECK:         [[OPTIONAL:%.*]] = apply [[GETTER]]<Key, Value>({{.*}}) : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@in_guaranteed τ_0_1, @guaranteed Dictionary<τ_0_0, τ_0_1>) -> @out Optional<τ_0_1>
+// CHECK:         store [[OPTIONAL]] to [init] [[OPTIONAL_ALLOC]] : $*Optional<Value>
+// CHECK:         switch_enum_addr [[OPTIONAL_ALLOC]] : $*Optional<Value>, case #Optional.some!enumelt: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: {{bb[0-9]+}}
+// CHECK:       [[SOME_BB]]:
+// CHECK:         [[PAYLOAD:%.*]] = unchecked_inplace_enum_data_addr [[OPTIONAL_ALLOC]] : $*Optional<Value>, #Optional.some!enumelt
+// CHECK:         [[INCREMENT:%.*]] = function_ref @{{.*}}increment
+// CHECK:         apply [[INCREMENT]]<Key, Value>([[PAYLOAD]])
+// CHECK:         [[WRITTEN:%.*]] = load [take] [[OPTIONAL_ALLOC]] : $*Optional<Value>
+// CHECK:         [[SETTER:%.*]] = function_ref @$sSD20opaque_values_silgenEyq_Sgq_cis
+// CHECK:         apply [[SETTER]]<Key, Value>([[WRITTEN]], {{.*}}, [[WRITE]]) : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@in Optional<τ_0_1>, @in τ_0_1, @inout Dictionary<τ_0_0, τ_0_1>) -> ()
+// CHECK:         end_access [[WRITE]] : $*Dictionary<Key, Value>
+// CHECK-LABEL: } // end sil function '$sSD20opaque_values_silgenE22inoutAccessOfSubscript3keyyq__tF'
 extension Dictionary {
   public subscript(key: Value) -> Value? {
     @inline(__always)
@@ -265,11 +283,11 @@ extension Dictionary {
 // ---
 // protocol witness for static Swift.Equatable.== infix(A, A) -> Swift.Bool in conformance Swift.FloatingPointSign : Swift.Equatable
 // CHECK-LABEL: sil shared [transparent] [serialized] [thunk] [ossa] @$s20opaque_values_silgen17FloatingPointSignOSQAASQ2eeoiySbx_xtFZTW : $@convention(witness_method: Equatable) (@in_guaranteed FloatingPointSign, @in_guaranteed FloatingPointSign, @thick FloatingPointSign.Type) -> Bool {
-// HECK: bb0(%0 : $FloatingPointSign, %1 : $FloatingPointSign, %2 : $@thick FloatingPointSign.Type):
-// HECK:   %3 = metatype $@thin FloatingPointSign.Type // user: %5
-// HECK:   %4 = function_ref @$ss17FloatingPointSignO21__derived_enum_equalsySbAB_ABtFZ : $@convention(method) (FloatingPointSign, FloatingPointSign, @thin FloatingPointSign.Type) -> Bool // user: %5
-// HECK:   %5 = apply %4(%0, %1, %3) : $@convention(method) (FloatingPointSign, FloatingPointSign, @thin FloatingPointSign.Type) -> Bool // user: %6
-// HECK:   return %5 : $Bool
+// CHECK: bb0(%0 : $FloatingPointSign, %1 : $FloatingPointSign, %2 : $@thick FloatingPointSign.Type):
+// CHECK:   [[META:%[^,]+]] = metatype $@thin FloatingPointSign.Type
+// CHECK:   [[FN:%[^,]+]] = function_ref @$s20opaque_values_silgen17FloatingPointSignO21__derived_enum_equalsySbAC_ACtFZ : $@convention(method) (FloatingPointSign, FloatingPointSign, @thin FloatingPointSign.Type) -> Bool
+// CHECK:   [[RESULT:%[^,]+]] = apply [[FN]](%0, %1, [[META]]) : $@convention(method) (FloatingPointSign, FloatingPointSign, @thin FloatingPointSign.Type) -> Bool
+// CHECK:   return [[RESULT]] : $Bool
 // CHECK-LABEL: } // end sil function '$s20opaque_values_silgen17FloatingPointSignOSQAASQ2eeoiySbx_xtFZTW'
 public enum FloatingPointSign {
   /// The sign for a positive value.
@@ -343,16 +361,16 @@ public struct EnumIter<Base : IP> : IP, Seq {
 }
 
 // CHECK-LABEL: sil [ossa] @$s20opaque_values_silgen7EnumSeqV12makeIteratorAA0D4IterVy0G0QzGyF : $@convention(method) <Base where Base : Seq> (@in_guaranteed EnumSeq<Base>) -> @out EnumIter<Base.Iterator> {
-// HECK: bb0(%0 : @guaranteed $EnumSeq<Base>):
-// HECK:  [[MT:%.*]] = metatype $@thin EnumIter<Base.Iterator>.Type
-// HECK:  [[FIELD:%.*]] = struct_extract %0 : $EnumSeq<Base>, #EnumSeq._base
-// HECK:  [[COPY:%.*]] = copy_value [[FIELD]] : $Base
-// HECK:  [[WT:%.*]] = witness_method $Base, #Seq.makeIterator : <Self where Self : Seq> (Self) -> () -> Self.Iterator : $@convention(witness_method: Seq) <τ_0_0 where τ_0_0 : Seq> (@in_guaranteed τ_0_0) -> @out τ_0_0.Iterator
-// HECK:  [[ITER:%.*]] = apply [[WT]]<Base>([[COPY]]) : $@convention(witness_method: Seq) <τ_0_0 where τ_0_0 : Seq> (@in_guaranteed τ_0_0) -> @out τ_0_0.Iterator
-// HECK:  destroy_value [[COPY]] : $Base
-// HECK: [[FN:%.*]] = function_ref @$ss8EnumIterV5_baseAByxGx_tcfC : $@convention(method) <τ_0_0 where τ_0_0 : IP> (@in τ_0_0, @thin EnumIter<τ_0_0>.Type) -> @out EnumIter<τ_0_0>
-// HECK:  [[RET:%.*]] = apply [[FN]]<Base.Iterator>([[ITER]], [[MT]]) : $@convention(method) <τ_0_0 where τ_0_0 : IP> (@in τ_0_0, @thin EnumIter<τ_0_0>.Type) -> @out EnumIter<τ_0_0>
-// HECK:  return [[RET]] : $EnumIter<Base.Iterator>
+// CHECK: bb0([[SELF:%.*]] : @guaranteed $EnumSeq<Base>):
+// CHECK:  [[MT:%.*]] = metatype $@thin EnumIter<Base.Iterator>.Type
+// CHECK:  [[FIELD:%.*]] = struct_extract [[SELF]] : $EnumSeq<Base>, #EnumSeq._base
+// CHECK:  [[COPY:%.*]] = copy_value [[FIELD]] : $Base
+// CHECK:  [[WT:%.*]] = witness_method $Base, #Seq.makeIterator : <Self where Self : Seq> (Self) -> () -> Self.Iterator : $@convention(witness_method: Seq) <τ_0_0 where τ_0_0 : Seq> (@in_guaranteed τ_0_0) -> @out τ_0_0.Iterator
+// CHECK:  [[ITER:%.*]] = apply [[WT]]<Base>([[COPY]]) : $@convention(witness_method: Seq) <τ_0_0 where τ_0_0 : Seq> (@in_guaranteed τ_0_0) -> @out τ_0_0.Iterator
+// CHECK:  destroy_value [[COPY]] : $Base
+// CHECK: [[FN:%.*]] = function_ref @$s20opaque_values_silgen8EnumIterV5_baseACyxGx_tcfC : $@convention(method) <τ_0_0 where τ_0_0 : IP> (@in τ_0_0, @thin EnumIter<τ_0_0>.Type) -> @out EnumIter<τ_0_0>
+// CHECK:  [[RET:%.*]] = apply [[FN]]<Base.Iterator>([[ITER]], [[MT]]) : $@convention(method) <τ_0_0 where τ_0_0 : IP> (@in τ_0_0, @thin EnumIter<τ_0_0>.Type) -> @out EnumIter<τ_0_0>
+// CHECK:  return [[RET]] : $EnumIter<Base.Iterator>
 // CHECK-LABEL: } // end sil function '$s20opaque_values_silgen7EnumSeqV12makeIteratorAA0D4IterVy0G0QzGyF'
 public struct EnumSeq<Base : Seq> : Seq {
   public typealias Iterator = EnumIter<Base.Iterator>

--- a/test/SILGen/opaque_values_silgen_lib.swift
+++ b/test/SILGen/opaque_values_silgen_lib.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-opaque-values -Xllvm -sil-full-demangle -parse-stdlib -parse-as-library -module-name Swift %s | %FileCheck %s --check-prefix=CHECK
+// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types -enable-sil-opaque-values -Xllvm -sil-full-demangle -parse-stdlib -parse-as-library -module-name Swift %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
 
 // Test SILGen -enable-sil-opaque-values
 
@@ -144,11 +144,11 @@ enum PAndSEnum { case A(EmptyP, String) }
 // ---
 // Swift.f010_PAndS_cases() -> ()
 // CHECK-LABEL: sil hidden [ossa] @$ss16f010_PAndS_casesyyF : $@convention(thin) () -> () {
-// HECK: bb0:
-// HECK:   [[MTYPE:%.*]] = metatype $@thin PAndSEnum.Type
-// HECK:   [[EAPPLY:%.*]] = apply {{.*}}([[MTYPE]]) : $@convention(thin) (@thin PAndSEnum.Type) -> @owned @callee_guaranteed (@in_guaranteed EmptyP, @guaranteed String) -> @out PAndSEnum
-// HECK:   destroy_value [[EAPPLY]]
-// HECK:   return %{{.*}} : $()
+// CHECK: bb0:
+// CHECK:   [[MTYPE:%.*]] = metatype $@thin PAndSEnum.Type
+// CHECK:   [[EAPPLY:%.*]] = apply {{.*}}([[MTYPE]]) : $@convention(thin) (@thin PAndSEnum.Type) -> @owned @callee_guaranteed (@in_guaranteed any EmptyP, @guaranteed String) -> @out PAndSEnum
+// CHECK:   destroy_value [[EAPPLY]]
+// CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '$ss16f010_PAndS_casesyyF'
 func f010_PAndS_cases() {
   _ = PAndSEnum.A
@@ -158,23 +158,23 @@ func f010_PAndS_cases() {
 // ---
 // implicit closure #2 (Swift.EmptyP, Swift.String) -> Swift.PAndSEnum in implicit closure #1 (Swift.PAndSEnum.Type) -> (Swift.EmptyP, Swift.String) -> Swift.PAndSEnum in Swift.f010_PAndS_cases() -> ()
 // CHECK-LABEL: sil private [ossa] @$ss16f010_PAndS_casesyyFs0B5SEnumOs6EmptyP_p_SStcACmcfu_ACsAD_p_SStcfu0_ : $@convention(thin) (@in_guaranteed any EmptyP, @guaranteed String, @thin PAndSEnum.Type) -> @out PAndSEnum {
-// HECK: bb0([[ARG0:%.*]] : @guaranteed $any EmptyP, [[ARG1:%.*]] : @guaranteed $String, [[ARG2:%.*]] : $@thin PAndSEnum.Type):
-// HECK:   [[COPY0:%.*]] = copy_value [[ARG0]]
-// HECK:   [[COPY1:%.*]] = copy_value [[ARG1]]
-// HECK:   [[RTUPLE:%.*]] = tuple ([[COPY0]] : $any EmptyP, [[COPY1]] : $String)
-// HECK:   [[RETVAL:%.*]] = enum $PAndSEnum, #PAndSEnum.A!enumelt, [[RTUPLE]] : $(any EmptyP, String)
-// HECK:   return [[RETVAL]] : $PAndSEnum
+// CHECK: bb0([[ARG0:%.*]] : @guaranteed $any EmptyP, [[ARG1:%.*]] : @guaranteed $String, [[ARG2:%.*]] : @closureCapture $@thin PAndSEnum.Type):
+// CHECK:   [[COPY0:%.*]] = copy_value [[ARG0]]
+// CHECK:   [[COPY1:%.*]] = copy_value [[ARG1]]
+// CHECK:   [[RTUPLE:%.*]] = tuple ([[COPY0]] : $any EmptyP, [[COPY1]] : $String)
+// CHECK:   [[RETVAL:%.*]] = enum $PAndSEnum, #PAndSEnum.A!enumelt, [[RTUPLE]] : $(any EmptyP, String)
+// CHECK:   return [[RETVAL]] : $PAndSEnum
 // CHECK-LABEL: } // end sil function '$ss16f010_PAndS_casesyyFs0B5SEnumOs6EmptyP_p_SStcACmcfu_ACsAD_p_SStcfu0_'
 
 // Test emitBuiltinReinterpretCast.
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss12f020_bitCast_2toq_x_q_mtr0_lF : $@convention(thin) <T, U> (@in_guaranteed T, @thick U.Type) -> @out U {
-// HECK: bb0([[ARG:%.*]] : @guaranteed $T,
-// HECK: [[COPY:%.*]] = copy_value [[ARG]] : $T
-// HECK: [[CAST:%.*]] = unchecked_bitwise_cast [[COPY]] : $T to $U
-// HECK: [[RET:%.*]] = copy_value [[CAST]] : $U
-// HECK: destroy_value [[COPY]] : $T
-// HECK: return [[RET]] : $U
+// CHECK: bb0([[ARG:%.*]] : @guaranteed $T,
+// CHECK: [[COPY:%.*]] = copy_value [[ARG]] : $T
+// CHECK: [[CAST:%.*]] = unchecked_bitwise_cast [[COPY]] : $T to $U
+// CHECK: [[RET:%.*]] = copy_value [[CAST]] : $U
+// CHECK: destroy_value [[COPY]] : $T
+// CHECK: return [[RET]] : $U
 // CHECK-LABEL: } // end sil function '$ss12f020_bitCast_2toq_x_q_mtr0_lF'
 func f020_bitCast<T, U>(_ x: T, to type: U.Type) -> U {
   return Builtin.reinterpretCast(x)
@@ -184,16 +184,16 @@ func f020_bitCast<T, U>(_ x: T, to type: U.Type) -> U {
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss12f021_refCast_2toq_x_q_mtr0_lF : $@convention(thin) <T, U> (@in_guaranteed T, @thick U.Type) -> @out U {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $T, %1 : $@thick U.Type):
-// HECK: [[COPY:%.*]] = copy_value [[ARG]] : $T
-// HECK: [[SRC:%.*]] = alloc_stack $T
-// HECK: store [[COPY]] to [init] [[SRC]] : $*T
-// HECK: [[DEST:%.*]] = alloc_stack $U
-// HECK: unchecked_ref_cast_addr  T in [[SRC]] : $*T to U in [[DEST]] : $*U
-// HECK: [[LOAD:%.*]] = load [take] [[DEST]] : $*U
-// HECK: dealloc_stack [[DEST]] : $*U
-// HECK: dealloc_stack [[SRC]] : $*T
+// CHECK: [[COPY:%.*]] = copy_value [[ARG]] : $T
+// CHECK: [[SRC:%.*]] = alloc_stack $T
+// CHECK: store [[COPY]] to [init] [[SRC]] : $*T
+// CHECK: [[DEST:%.*]] = alloc_stack $U
+// CHECK: unchecked_ref_cast_addr  T in [[SRC]] : $*T to U in [[DEST]] : $*U
+// CHECK: [[LOAD:%.*]] = load [take] [[DEST]] : $*U
+// CHECK: dealloc_stack [[DEST]] : $*U
+// CHECK: dealloc_stack [[SRC]] : $*T
 // CHECK-NOT: destroy_value [[ARG]] : $T
-// HECK: return [[LOAD]] : $U
+// CHECK: return [[LOAD]] : $U
 // CHECK-LABEL: } // end sil function '$ss12f021_refCast_2toq_x_q_mtr0_lF'
 func f021_refCast<T, U>(_ x: T, to: U.Type) -> U {
   return Builtin.castReference(x)
@@ -202,12 +202,12 @@ func f021_refCast<T, U>(_ x: T, to: U.Type) -> U {
 // Test unsafe_bitwise_cast nontrivial ownership.
 // ---
 // CHECK-LABEL: sil [ossa] @$ss18f022_unsafeBitCast_2toq_x_q_mtr0_lF : $@convention(thin) <T, U> (@in_guaranteed T, @thick U.Type) -> @out U {
-// HECK: bb0([[ARG0:%.*]] : @guaranteed $T, [[ARG1:%.*]] : $@thick U.Type):
-// HECK:   [[ARG_COPY:%.*]] = copy_value [[ARG0]] : $T
-// HECK:   [[RESULT:%.*]] = unchecked_bitwise_cast [[ARG_COPY]] : $T to $U
-// HECK:   [[RESULT_COPY:%.*]] = copy_value [[RESULT]] : $U
-// HECK:   destroy_value [[ARG_COPY]] : $T
-// HECK:   return [[RESULT_COPY]] : $U
+// CHECK: bb0([[ARG0:%.*]] : @guaranteed $T, [[ARG1:%.*]] : $@thick U.Type):
+// CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG0]] : $T
+// CHECK:   [[RESULT:%.*]] = unchecked_bitwise_cast [[ARG_COPY]] : $T to $U
+// CHECK:   [[RESULT_COPY:%.*]] = copy_value [[RESULT]] : $U
+// CHECK:   destroy_value [[ARG_COPY]] : $T
+// CHECK:   return [[RESULT_COPY]] : $U
 // CHECK-LABEL: } // end sil function '$ss18f022_unsafeBitCast_2toq_x_q_mtr0_lF'
 public func f022_unsafeBitCast<T, U>(_ x: T, to type: U.Type) -> U {
   return Builtin.reinterpretCast(x)
@@ -217,11 +217,11 @@ public func f022_unsafeBitCast<T, U>(_ x: T, to type: U.Type) -> U {
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss16f030_assigninoutyyxz_xtlF : $@convention(thin) <T> (@inout T, @in_guaranteed T) -> () {
 // CHECK: bb0([[ARG0:%.*]] : $*T, [[ARG1:%.*]] : @guaranteed $T):
-// HECK:   [[CPY:%.*]] = copy_value [[ARG1]] : $T
-// HECK:   [[READ:%.*]] = begin_access [modify] [unknown] [[ARG0]] : $*T
-// HECK:   assign [[CPY]] to [[READ]] : $*T
+// CHECK:   [[CPY:%.*]] = copy_value [[ARG1]] : $T
+// CHECK:   [[READ:%.*]] = begin_access [modify] [unknown] [[ARG0]] : $*T
+// CHECK:   assign [[CPY]] to [[READ]] : $*T
 // CHECK-NOT:   destroy_value [[ARG1]] : $T
-// HECK:   return %{{.*}} : $()
+// CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '$ss16f030_assigninoutyyxz_xtlF'
 func f030_assigninout<T>(_ a: inout T, _ b: T) {
   a = b
@@ -230,21 +230,17 @@ func f030_assigninout<T>(_ a: inout T, _ b: T) {
 // Test that we no longer use copy_addr or tuple_element_addr when copy by value is possible
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss19f040_tupleReturnIntyBi64_Bi64__xt_tlF : $@convention(thin) <T> (Builtin.Int64, @in_guaranteed T) -> Builtin.Int64 {
-// HECK: bb0([[ARG0:%.*]] : $Builtin.Int64, [[ARG1:%.*]] : $T):
-// HECK:   [[ARG1_COPY:%.*]] = copy_value [[ARG1]]
-// HECK:   [[TPL:%.*]] = tuple ([[ARG0]] : $Builtin.Int64, [[ARG1_COPY]] : $T)
-// HECK:   [[BORROWED_ARG1:%.*]] = begin_borrow [[TPL]] : $(Builtin.Int64, T)
-// HECK:   [[CPY:%.*]] = copy_value [[BORROWED_ARG1]] : $(Builtin.Int64, T)
-// HECK:   [[BORROWED_CPY:%.*]] = begin_borrow [[CPY]]
-// HECK:   [[INT:%.*]] = tuple_extract [[BORROWED_CPY]] : $(Builtin.Int64, T), 0
-// HECK:   [[GEN:%.*]] = tuple_extract [[BORROWED_CPY]] : $(Builtin.Int64, T), 1
-// HECK:   [[COPY_GEN:%.*]] = copy_value [[GEN]]
-// HECK:   destroy_value [[COPY_GEN]]
-// HECK:   end_borrow [[BORROWED_CPY]]
-// HECK:   destroy_value [[CPY]]
-// HECK:   end_borrow [[BORROWED_ARG1]] : $(Builtin.Int64, T)
-// HECK:   destroy_value [[TPL]] : $(Builtin.Int64, T)
-// HECK:   return [[INT]]
+// CHECK: bb0([[ARG0:%.*]] : $Builtin.Int64, [[ARG1:%.*]] : @guaranteed $T):
+// CHECK:   [[ARG1_COPY:%.*]] = copy_value [[ARG1]]
+// CHECK:   [[TPL:%.*]] = tuple ([[ARG0]] : $Builtin.Int64, [[ARG1_COPY]] : $T)
+// CHECK:   [[BORROWED_TPL:%.*]] = begin_borrow [[TPL]] : $(Builtin.Int64, T)
+// CHECK:   [[CPY:%.*]] = copy_value [[BORROWED_TPL]] : $(Builtin.Int64, T)
+// CHECK:   ([[INT:%.*]], [[GEN:%.*]]) = destructure_tuple [[CPY]] : $(Builtin.Int64, T)
+// CHECK:   [[INT_LIFETIME:%.*]] = move_value [var_decl] [[INT]] : $Builtin.Int64
+// CHECK:   destroy_value [[GEN]]
+// CHECK:   end_borrow [[BORROWED_TPL]] : $(Builtin.Int64, T)
+// CHECK:   destroy_value [[TPL]] : $(Builtin.Int64, T)
+// CHECK:   return [[INT_LIFETIME]]
 // CHECK-LABEL: } // end sil function '$ss19f040_tupleReturnIntyBi64_Bi64__xt_tlF'
 func f040_tupleReturnInt<T>(_ x: (Builtin.Int64, T)) -> Builtin.Int64 {
   let y = x.0
@@ -254,13 +250,13 @@ func f040_tupleReturnInt<T>(_ x: (Builtin.Int64, T)) -> Builtin.Int64 {
 // Test returning an opaque tuple of tuples.
 // ---
 // CHECK-LABEL: sil hidden [noinline] [ossa] @$ss16f050_multiResultyx_x_xttxlF : $@convention(thin) <T> (@in_guaranteed T) -> (@out T, @out T, @out T) {
-// HECK: bb0(%0 : $T):
-// HECK: %[[CP1:.*]] = copy_value %{{.*}} : $T
-// HECK: %[[CP2:.*]] = copy_value %{{.*}} : $T
-// HECK: %[[CP3:.*]] = copy_value %{{.*}} : $T
+// CHECK: bb0(%0 : @guaranteed $T):
+// CHECK: %[[CP1:.*]] = copy_value %{{.*}} : $T
+// CHECK: %[[CP2:.*]] = copy_value %{{.*}} : $T
+// CHECK: %[[CP3:.*]] = copy_value %{{.*}} : $T
 // CHECK-NOT: destroy_value %0 : $T
-// HECK: %[[TPL:.*]] = tuple (%[[CP1]] : $T, %[[CP2]] : $T, %[[CP3]] : $T)
-// HECK: return %[[TPL]] : $(T, T, T)
+// CHECK: %[[TPL:.*]] = tuple (%[[CP1]] : $T, %[[CP2]] : $T, %[[CP3]] : $T)
+// CHECK: return %[[TPL]] : $(T, T, T)
 // CHECK-LABEL: } // end sil function '$ss16f050_multiResultyx_x_xttxlF'
 @inline(never)
 func f050_multiResult<T>(_ t: T) -> (T, (T, T)) {
@@ -270,14 +266,12 @@ func f050_multiResult<T>(_ t: T) -> (T, (T, T)) {
 // Test returning an opaque tuple of tuples as a concrete tuple.
 // ---
 // CHECK-LABEL: sil [ossa] @$ss20f060_callMultiResult1iBi64__Bi64__Bi64_ttBi64__tF : $@convention(thin) (Builtin.Int64) -> (Builtin.Int64, Builtin.Int64, Builtin.Int64) {
-// HECK: bb0(%0 : $Builtin.Int64):
-// HECK: %[[FN:.*]] = function_ref @$s20opaque_values_silgen21f050_multiResultyx_x_xttxlF : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> (@out τ_0_0, @out τ_0_0, @out τ_0_0)
-// HECK: %[[TPL:.*]] = apply %[[FN]]<Builtin.Int64>(%0) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> (@out τ_0_0, @out τ_0_0, @out τ_0_0)
-// HECK: %[[I1:.*]] = tuple_extract %[[TPL]] : $(Builtin.Int64, Builtin.Int64, Builtin.Int64), 0
-// HECK: %[[I2:.*]] = tuple_extract %[[TPL]] : $(Builtin.Int64, Builtin.Int64, Builtin.Int64), 1
-// HECK: %[[I3:.*]] = tuple_extract %[[TPL]] : $(Builtin.Int64, Builtin.Int64, Builtin.Int64), 2
-// HECK: %[[R:.*]] = tuple (%[[I1]] : $Builtin.Int64, %[[I2]] : $Builtin.Int64, %[[I3]] : $Builtin.Int64)
-// HECK: return %[[R]] : $(Builtin.Int64, Builtin.Int64, Builtin.Int64)
+// CHECK: bb0(%0 : $Builtin.Int64):
+// CHECK: %[[FN:.*]] = function_ref @$ss16f050_multiResultyx_x_xttxlF : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> (@out τ_0_0, @out τ_0_0, @out τ_0_0)
+// CHECK: %[[TPL:.*]] = apply %[[FN]]<Builtin.Int64>(%0) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> (@out τ_0_0, @out τ_0_0, @out τ_0_0)
+// CHECK: (%[[I1:.*]], %[[I2:.*]], %[[I3:.*]]) = destructure_tuple %[[TPL]] : $(Builtin.Int64, Builtin.Int64, Builtin.Int64)
+// CHECK: %[[R:.*]] = tuple (%[[I1]] : $Builtin.Int64, %[[I2]] : $Builtin.Int64, %[[I3]] : $Builtin.Int64)
+// CHECK: return %[[R]] : $(Builtin.Int64, Builtin.Int64, Builtin.Int64)
 // CHECK-LABEL: } // end sil function '$ss20f060_callMultiResult1iBi64__Bi64__Bi64_ttBi64__tF'
 public func f060_callMultiResult(i: Builtin.Int64) -> (Builtin.Int64, (Builtin.Int64, Builtin.Int64)) {
   return f050_multiResult(i)
@@ -288,10 +282,10 @@ public func f060_callMultiResult(i: Builtin.Int64) -> (Builtin.Int64, (Builtin.I
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss20f070_materializeSelf1tyx_tRlzCs4FooPRzlF : $@convention(thin) <T where T : AnyObject, T : FooP> (@guaranteed T) -> () {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $T):
-// HECK: [[WITNESS_METHOD:%.*]] = witness_method $T, #FooP.foo : <Self where Self : FooP> (Self) -> () -> () : $@convention(witness_method: FooP) <τ_0_0 where τ_0_0 : FooP> (@in_guaranteed τ_0_0) -> ()
-// HECK: apply [[WITNESS_METHOD]]<T>([[ARG]]) : $@convention(witness_method: FooP) <τ_0_0 where τ_0_0 : FooP> (@in_guaranteed τ_0_0) -> ()
+// CHECK: [[WITNESS_METHOD:%.*]] = witness_method $T, #FooP.foo : <Self where Self : FooP> (Self) -> () -> () : $@convention(witness_method: FooP) <τ_0_0 where τ_0_0 : FooP> (@in_guaranteed τ_0_0) -> ()
+// CHECK: apply [[WITNESS_METHOD]]<T>([[ARG]]) : $@convention(witness_method: FooP) <τ_0_0 where τ_0_0 : FooP> (@in_guaranteed τ_0_0) -> ()
 // CHECK-NOT: destroy_value [[ARG]] : $T
-// HECK: return %{{[0-9]+}} : $()
+// CHECK: return %{{[0-9]+}} : $()
 // CHECK-LABEL: } // end sil function '$ss20f070_materializeSelf1tyx_tRlzCs4FooPRzlF'
 func f070_materializeSelf<T: FooP>(t: T) where T: AnyObject {
   t.foo()
@@ -301,11 +295,11 @@ func f070_materializeSelf<T: FooP>(t: T) where T: AnyObject {
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss8f080_bar1pBi64_s1P_p_tF : $@convention(thin) (@in_guaranteed any P) -> Builtin.Int64 {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $any P):
-// HECK:   [[OPENED_ARG:%.*]] = open_existential_value [[ARG]] : $any P to $@opened
-// HECK:   [[WITNESS_FUNC:%.*]] = witness_method $@opened
-// HECK:   [[RESULT:%.*]] = apply [[WITNESS_FUNC]]<{{.*}}>([[OPENED_ARG]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Builtin.Int64
+// CHECK:   [[OPENED_ARG:%.*]] = open_existential_value [[ARG]] : $any P to $@opened
+// CHECK:   [[WITNESS_FUNC:%.*]] = witness_method $@opened
+// CHECK:   [[RESULT:%.*]] = apply [[WITNESS_FUNC]]<{{.*}}>([[OPENED_ARG]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Builtin.Int64
 // CHECK-NOT:   destroy_value [[ARG]] : $any P
-// HECK:   return [[RESULT]] : $Builtin.Int64
+// CHECK:   return [[RESULT]] : $Builtin.Int64
 // CHECK-LABEL: } // end sil function '$ss8f080_bar1pBi64_s1P_p_tF'
 func f080_bar(p: P) -> Builtin.Int64 {
   return p.x
@@ -316,9 +310,9 @@ func f080_bar(p: P) -> Builtin.Int64 {
 // CHECK-LABEL: sil hidden [ossa] @$ss11f090_calleryxxlF : $@convention(thin) <T> (@in_guaranteed T) -> @out T {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $T):
 // CHECK-NOT: copy_value
-// HECK:   [[RESULT:%.*]] = apply {{%.*}}<T>([[ARG]]) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> @out τ_0_0
+// CHECK:   [[RESULT:%.*]] = apply {{%.*}}<T>([[ARG]]) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> @out τ_0_0
 // CHECK-NOT:   destroy_value [[ARG]] : $T
-// HECK:   return %{{.*}} : $T
+// CHECK:   return %{{.*}} : $T
 // CHECK-LABEL: } // end sil function '$ss11f090_calleryxxlF'
 func f090_caller<T>(_ t: T) -> T {
   return f090_caller(t)
@@ -328,9 +322,9 @@ func f090_caller<T>(_ t: T) -> T {
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss13f100_identityyxxlF : $@convention(thin) <T> (@in_guaranteed T) -> @out T {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $T):
-// HECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]] : $T
+// CHECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]] : $T
 // CHECK-NOT:   destroy_value [[ARG]] : $T
-// HECK:   return [[COPY_ARG]] : $T
+// CHECK:   return [[COPY_ARG]] : $T
 // CHECK-LABEL: } // end sil function '$ss13f100_identityyxxlF'
 func f100_identity<T>(_ t: T) -> T {
   return t
@@ -340,9 +334,9 @@ func f100_identity<T>(_ t: T) -> T {
 // ---
 // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$ss19f110_GuaranteedSelfVs4FooPssACP3fooyyFTW : $@convention(witness_method: FooP) (@in_guaranteed f110_GuaranteedSelf) -> () {
 // CHECK: bb0(%0 : $f110_GuaranteedSelf):
-// HECK:   %[[F:.*]] = function_ref @$s20opaque_values_silgen21f110_GuaranteedSelfV3fooyyF : $@convention(method) (f110_GuaranteedSelf) -> ()
-// HECK:   apply %[[F]](%0) : $@convention(method) (f110_GuaranteedSelf) -> ()
-// HECK:   return
+// CHECK:   %[[F:.*]] = function_ref @$ss19f110_GuaranteedSelfV3fooyyF : $@convention(method) (f110_GuaranteedSelf) -> ()
+// CHECK:   apply %[[F]](%0) : $@convention(method) (f110_GuaranteedSelf) -> ()
+// CHECK:   return
 // CHECK-LABEL: } // end sil function '$ss19f110_GuaranteedSelfVs4FooPssACP3fooyyFTW'
 struct f110_GuaranteedSelf : FooP {
   func foo() {}
@@ -352,11 +346,12 @@ struct f110_GuaranteedSelf : FooP {
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss16f120_returnValueyxxlF : $@convention(thin) <T> (@in_guaranteed T) -> @out T {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $T):
-// HECK:   [[COPY_ARG1:%.*]] = copy_value [[ARG]] : $T
-// HECK:   [[BORROWED_ARG2:%.*]] = begin_borrow [[COPY_ARG1]]
-// HECK:   [[COPY_ARG2:%.*]] = copy_value [[BORROWED_ARG2]] : $T
-// HECK:   end_borrow [[BORROWED_ARG2]]
-// HECK:   return [[COPY_ARG2]] : $T
+// CHECK:   [[COPY_ARG1:%.*]] = copy_value [[ARG]] : $T
+// CHECK:   [[MOVE:%.*]] = move_value [lexical] [var_decl] [[COPY_ARG1]] : $T
+// CHECK:   [[BORROWED_ARG2:%.*]] = begin_borrow [[MOVE]]
+// CHECK:   [[COPY_ARG2:%.*]] = copy_value [[BORROWED_ARG2]] : $T
+// CHECK:   end_borrow [[BORROWED_ARG2]]
+// CHECK:   return [[COPY_ARG2]] : $T
 // CHECK-LABEL: } // end sil function '$ss16f120_returnValueyxxlF'
 func f120_returnValue<T>(_ x: T) -> T {
   let y = x
@@ -367,10 +362,10 @@ func f120_returnValue<T>(_ x: T) -> T {
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss9f130_wrapyxSgxlF : $@convention(thin) <T> (@in_guaranteed T) -> @out Optional<T> {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $T):
-// HECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]] : $T
-// HECK:   [[OPTIONAL_ARG:%.*]] = enum $Optional<T>, #Optional.some!enumelt, [[COPY_ARG]] : $T
+// CHECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]] : $T
+// CHECK:   [[OPTIONAL_ARG:%.*]] = enum $Optional<T>, #Optional.some!enumelt, [[COPY_ARG]] : $T
 // CHECK-NOT:   destroy_value [[ARG]] : $T
-// HECK:   return [[OPTIONAL_ARG]] : $Optional<T>
+// CHECK:   return [[OPTIONAL_ARG]] : $Optional<T>
 // CHECK-LABEL: } // end sil function '$ss9f130_wrapyxSgxlF'
 func f130_wrap<T>(_ x: T) -> T? {
   return x
@@ -382,12 +377,12 @@ func f150_anyArg(_: Any) {}
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss15f160_callAnyArgyyF : $@convention(thin) () -> () {
 // CHECK: bb0:
-// HECK:   [[INT_TYPE:%.*]] = metatype $@thin Builtin.Int64.Type
-// HECK:   [[INT_LIT:%.*]] = integer_literal $Builtin.Builtin.Int64Literal, 42
-// HECK:   [[INT_ARG:%.*]] = apply %{{.*}}([[INT_LIT]], [[INT_TYPE]]) : $@convention(method) (Builtin.Builtin.Int64Literal, @thin Builtin.Int64.Type) -> Builtin.Int64
-// HECK:   [[INIT_OPAQUE:%.*]] = init_existential_value [[INT_ARG]] : $Builtin.Int64, $Builtin.Int64, $Any
-// HECK:   apply %{{.*}}([[INIT_OPAQUE]]) : $@convention(thin) (@in_guaranteed Any) -> ()
-// HECK:   return %{{.*}} : $()
+// CHECK:   [[INT_LIT:%.*]] = integer_literal $Builtin.IntLiteral, 42
+// CHECK:   [[INT_TYPE:%.*]] = metatype $@thin Int64.Type
+// CHECK:   [[INT_ARG:%.*]] = apply %{{.*}}([[INT_LIT]], [[INT_TYPE]]) : $@convention(method) (Builtin.IntLiteral, @thin Int64.Type) -> Int64
+// CHECK:   [[INIT_OPAQUE:%.*]] = init_existential_value [[INT_ARG]] : $Int64, $Int64, $Any
+// CHECK:   apply %{{.*}}([[INIT_OPAQUE]]) : $@convention(thin) (@in_guaranteed Any) -> ()
+// CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '$ss15f160_callAnyArgyyF'
 func f160_callAnyArg() {
   f150_anyArg(Int64(42))
@@ -397,16 +392,17 @@ func f160_callAnyArg() {
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss18f170_force_convertxylF : $@convention(thin) <T> () -> @out T {
 // CHECK: bb0:
-// HECK-NOT: alloc_stack
-// HECK:   [[INT_TYPE:%.*]] = metatype $@thin Builtin.Int64.Type
-// HECK:   [[INT_LIT:%.*]] = integer_literal $Builtin.Builtin.Int64Literal, 42
-// HECK:   [[INT_ARG:%.*]] = apply %{{.*}}([[INT_LIT]], [[INT_TYPE]]) : $@convention(method) (Builtin.Builtin.Int64Literal, @thin Builtin.Int64.Type) -> Builtin.Int64
-// HECK:   [[INT_CAST:%.*]] = unconditional_checked_cast_value [[INT_ARG]] : $Builtin.Int64 to $T
-// HECK:   [[CAST_BORROW:%.*]] = begin_borrow [[INT_CAST]] : $T
-// HECK:   [[RETURN_VAL:%.*]] = copy_value [[CAST_BORROW]] : $T
-// HECK:   end_borrow [[CAST_BORROW]] : $T
-// HECK:   destroy_value [[INT_CAST]] : $T
-// HECK:   return [[RETURN_VAL]] : $T
+// CHECK-NOT: alloc_stack
+// CHECK:   [[INT_LIT:%.*]] = integer_literal $Builtin.IntLiteral, 42
+// CHECK:   [[INT_TYPE:%.*]] = metatype $@thin Int64.Type
+// CHECK:   [[INT_ARG:%.*]] = apply %{{.*}}([[INT_LIT]], [[INT_TYPE]]) : $@convention(method) (Builtin.IntLiteral, @thin Int64.Type) -> Int64
+// CHECK:   [[INT_CAST:%.*]] = unconditional_checked_cast [[INT_ARG]] : $Int64 to T
+// CHECK:   [[CAST_LIFETIME:%.*]] = move_value [lexical] [var_decl] [[INT_CAST]] : $T
+// CHECK:   [[CAST_BORROW:%.*]] = begin_borrow [[CAST_LIFETIME]] : $T
+// CHECK:   [[RETURN_VAL:%.*]] = copy_value [[CAST_BORROW]] : $T
+// CHECK:   end_borrow [[CAST_BORROW]] : $T
+// CHECK:   destroy_value [[CAST_LIFETIME]] : $T
+// CHECK:   return [[RETURN_VAL]] : $T
 // CHECK-LABEL: } // end sil function '$ss18f170_force_convertxylF'
 func f170_force_convert<T>() -> T {
   let x : T = Int64(42) as! T
@@ -417,10 +413,11 @@ func f170_force_convert<T>() -> T {
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss15f180_return_foos4FooP_pyF : $@convention(thin) () -> @out any FooP {
 // CHECK: bb0:
-// HECK:   [[INT_LIT:%.*]] = integer_literal $Builtin.Builtin.Int64Literal, 42
-// HECK:   [[INT_ARG:%.*]] = apply %{{.*}}([[INT_LIT]], [[INT_TYPE]]) : $@convention(method) (Builtin.Builtin.Int64Literal, @thin Builtin.Int64.Type) -> Builtin.Int64
-// HECK:   [[INT_CAST:%.*]] = unconditional_checked_cast_value [[INT_ARG]] : $Builtin.Int64 to $any FooP
-// HECK:   return [[INT_CAST]] : $any FooP
+// CHECK:   [[INT_LIT:%.*]] = integer_literal $Builtin.IntLiteral, 42
+// CHECK:   [[INT_TYPE:%.*]] = metatype $@thin Int64.Type
+// CHECK:   [[INT_ARG:%.*]] = apply %{{.*}}([[INT_LIT]], [[INT_TYPE]]) : $@convention(method) (Builtin.IntLiteral, @thin Int64.Type) -> Int64
+// CHECK:   [[INT_CAST:%.*]] = unconditional_checked_cast [[INT_ARG]] : $Int64 to any FooP
+// CHECK:   return [[INT_CAST]] : $any FooP
 // CHECK-LABEL: } // end sil function '$ss15f180_return_foos4FooP_pyF'
 func f180_return_foo() -> FooP {
   return Int64(42) as! FooP
@@ -431,10 +428,12 @@ var foo_var : FooP = f180_return_foo()
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss19f190_return_foo_vars4FooP_pyF : $@convention(thin) () -> @out any FooP {
 // CHECK: bb0:
-// HECK:   [[GLOBAL:%.*]] = global_addr {{.*}} : $*any FooP
-// HECK:   [[READ:%.*]] = begin_access [read] [dynamic] [[GLOBAL]] : $*any FooP
-// HECK:   [[LOAD_GLOBAL:%.*]] = load [copy] [[READ]] : $*any FooP
-// HECK:   return [[LOAD_GLOBAL]] : $any FooP
+// CHECK:   [[ADDRESSOR:%.*]] = function_ref @$ss7foo_vars4FooP_pvau : $@convention(thin) () -> Builtin.RawPointer
+// CHECK:   [[RAW:%.*]] = apply [[ADDRESSOR]]()
+// CHECK:   [[GLOBAL:%.*]] = pointer_to_address [[RAW]] : $Builtin.RawPointer to [strict] $*any FooP
+// CHECK:   [[READ:%.*]] = begin_access [read] [dynamic] [[GLOBAL]] : $*any FooP
+// CHECK:   [[LOAD_GLOBAL:%.*]] = load [copy] [[READ]] : $*any FooP
+// CHECK:   return [[LOAD_GLOBAL]] : $any FooP
 // CHECK-LABEL: } // end sil function '$ss19f190_return_foo_vars4FooP_pyF'
 func f190_return_foo_var() -> FooP {
   return foo_var
@@ -444,16 +443,18 @@ func f190_return_foo_var() -> FooP {
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss16f200_use_foo_varyyF : $@convention(thin) () -> () {
 // CHECK: bb0:
-// HECK:   [[GLOBAL:%.*]] = global_addr {{.*}} : $*FooP
-// HECK:   [[READ:%.*]] = begin_access [read] [dynamic] [[GLOBAL]] : $*FooP
-// HECK:   [[LOAD_GLOBAL:%.*]] = load [copy] [[READ]] : $*FooP
-// HECK:   [[BORROW:%.*]] = begin_borrow [[LOAD_GLOBAL]] : $FooP
-// HECK:   [[OPEN_VAR:%.*]] = open_existential_value [[BORROW]] : $FooP
-// HECK:   [[WITNESS:%.*]] = witness_method $@opened
-// HECK:   apply [[WITNESS]]
-// HECK:   end_borrow [[BORROW]]
-// HECK:   destroy_value [[LOAD_GLOBAL]]
-// HECK:   return %{{.*}} : $()
+// CHECK:   [[ADDRESSOR:%.*]] = function_ref @$ss7foo_vars4FooP_pvau : $@convention(thin) () -> Builtin.RawPointer
+// CHECK:   [[RAW:%.*]] = apply [[ADDRESSOR]]()
+// CHECK:   [[GLOBAL:%.*]] = pointer_to_address [[RAW]] : $Builtin.RawPointer to [strict] $*any FooP
+// CHECK:   [[READ:%.*]] = begin_access [read] [dynamic] [[GLOBAL]] : $*any FooP
+// CHECK:   [[LOAD_GLOBAL:%.*]] = load [copy] [[READ]] : $*any FooP
+// CHECK:   [[BORROW:%.*]] = begin_borrow [[LOAD_GLOBAL]] : $any FooP
+// CHECK:   [[OPEN_VAR:%.*]] = open_existential_value [[BORROW]] : $any FooP
+// CHECK:   [[WITNESS:%.*]] = witness_method $@opened
+// CHECK:   apply [[WITNESS]]
+// CHECK:   end_borrow [[BORROW]]
+// CHECK:   destroy_value [[LOAD_GLOBAL]]
+// CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '$ss16f200_use_foo_varyyF'
 func f200_use_foo_var() {
   foo_var.foo()
@@ -464,13 +465,16 @@ func f200_use_foo_var() {
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss16f210_compErasureys5Error_psAB_s4FooPpF : $@convention(thin) (@in_guaranteed any Error & FooP) -> @owned any Error {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $any Error & FooP):
-// HECK:   [[OPAQUE_ARG:%.*]] = open_existential_value [[ARG]] : $any Error & FooP to $@opened({{.*}}, any Error) Self & FooP
-// HECK:   [[EXIST_BOX:%.*]] = alloc_existential_box $any Error, $@opened({{.*}}, any Error) Self & FooP
-// HECK:   [[PROJ_BOX:%.*]] = project_existential_box $@opened({{.*}}, any Error) Self & FooP in [[EXIST_BOX]]
-// HECK:   [[COPY_OPAQUE:%.*]] = copy_value [[OPAQUE_ARG]] : $@opened({{.*}}, any Error) Self & FooP
-// HECK:   store [[COPY_OPAQUE]] to [init] [[PROJ_BOX]] : $*@opened({{.*}}, any Error) Self & FooP
+// CHECK:   [[OPAQUE_ARG:%.*]] = open_existential_value [[ARG]] : $any Error & FooP to $@opened({{.*}}, any Error & FooP) Self
+// CHECK:   [[TEMP:%.*]] = alloc_stack $any Error
+// CHECK:   [[EXIST_BOX:%.*]] = alloc_existential_box $any Error, $@opened({{.*}}, any Error & FooP) Self
+// CHECK:   [[PROJ_BOX:%.*]] = project_existential_box $@opened({{.*}}, any Error & FooP) Self in [[EXIST_BOX]]
+// CHECK:   store [[EXIST_BOX]] to [init] [[TEMP]] : $*any Error
+// CHECK:   [[COPY_OPAQUE:%.*]] = copy_value [[OPAQUE_ARG]] : $@opened({{.*}}, any Error & FooP) Self
+// CHECK:   store [[COPY_OPAQUE]] to [init] [[PROJ_BOX]] : $*@opened({{.*}}, any Error & FooP) Self
+// CHECK:   [[RESULT:%.*]] = load [take] [[TEMP]] : $*any Error
 // CHECK-NOT:   destroy_value [[ARG]] : $any Error & FooP
-// HECK:   return [[EXIST_BOX]] : $any Error
+// CHECK:   return [[RESULT]] : $any Error
 // CHECK-LABEL: } // end sil function '$ss16f210_compErasureys5Error_psAB_s4FooPpF'
 func f210_compErasure(_ x: FooP & Error) -> Error {
   return x
@@ -483,8 +487,8 @@ func f210_compErasure(_ x: FooP & Error) -> Error {
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss3BoxV1tAByxGx_tcfC : $@convention(method) <T> (@in T, @thin Box<T>.Type) -> @out Box<T> {
 // CHECK: bb0([[ARG0:%.*]] : @owned $T, [[ARG1:%.*]] : $@thin Box<T>.Type):
-// HECK:   [[RETVAL:%.*]] = struct $Box<T> ([[ARG0]] : $T)
-// HECK:   return [[RETVAL]] : $Box<T>
+// CHECK:   [[RETVAL:%.*]] = struct $Box<T> ([[ARG0]] : $T)
+// CHECK:   return [[RETVAL]] : $Box<T>
 // CHECK-LABEL: } // end sil function '$ss3BoxV1tAByxGx_tcfC'
 struct Box<T> {
   let t: T
@@ -492,12 +496,12 @@ struct Box<T> {
 
 // CHECK-LABEL: sil hidden [ossa] @$ss13f250_testBoxTyyF : $@convention(thin) () -> () {
 // CHECK: bb0:
-// HECK:   [[BOX_MTYPE:%.*]] = metatype $@thin Box<Builtin.Int64>.Type
-// HECK:   [[MTYPE:%.*]] = metatype $@thin Builtin.Int64.Type
-// HECK:   [[INTLIT:%.*]] = integer_literal $Builtin.Builtin.Int64Literal, 42
-// HECK:   [[AINT:%.*]] = apply {{.*}}([[INTLIT]], [[MTYPE]]) : $@convention(method) (Builtin.Builtin.Int64Literal, @thin Builtin.Int64.Type) -> Builtin.Int64
-// HECK:   apply {{.*}}<Builtin.Int64>([[AINT]], [[BOX_MTYPE]]) : $@convention(method) <τ_0_0> (@in τ_0_0, @thin Box<τ_0_0>.Type) -> @out Box<τ_0_0>
-// HECK:   return %{{.*}} : $()
+// CHECK:   [[BOX_MTYPE:%.*]] = metatype $@thin Box<Int64>.Type
+// CHECK:   [[INTLIT:%.*]] = integer_literal $Builtin.IntLiteral, 42
+// CHECK:   [[MTYPE:%.*]] = metatype $@thin Int64.Type
+// CHECK:   [[AINT:%.*]] = apply {{.*}}([[INTLIT]], [[MTYPE]]) : $@convention(method) (Builtin.IntLiteral, @thin Int64.Type) -> Int64
+// CHECK:   apply {{.*}}<Int64>([[AINT]], [[BOX_MTYPE]]) : $@convention(method) <τ_0_0> (@in τ_0_0, @thin Box<τ_0_0>.Type) -> @out Box<τ_0_0>
+// CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '$ss13f250_testBoxTyyF'
 func f250_testBoxT() {
   let _ = Box(t: Int64(42))
@@ -513,18 +517,18 @@ enum AddressOnlyEnum {
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss15f260_AOnly_enumyys17AddressOnlyStructVF : $@convention(thin) (AddressOnlyStruct) -> () {
 // CHECK: bb0([[ARG:%.*]] : $AddressOnlyStruct):
-// HECK:   [[MTYPE1:%.*]] = metatype $@thin AddressOnlyEnum.Type
-// HECK:   [[APPLY1:%.*]] =  apply {{.*}}([[MTYPE1]]) : $@convention(thin) (@thin AddressOnlyEnum.Type) -> @owned @callee_guaranteed (@in_guaranteed EmptyP) -> @out AddressOnlyEnum
-// HECK:   destroy_value [[APPLY1]]
-// HECK:   [[MTYPE2:%.*]] = metatype $@thin AddressOnlyEnum.Type
-// HECK:   [[ENUM1:%.*]] = enum $AddressOnlyEnum, #AddressOnlyEnum.nought!enumelt
-// HECK:   [[MTYPE3:%.*]] = metatype $@thin AddressOnlyEnum.Type
-// HECK:   [[INIT_OPAQUE:%.*]] = init_existential_value [[ARG]] : $AddressOnlyStruct, $AddressOnlyStruct, $EmptyP
-// HECK:   [[ENUM2:%.*]] = enum $AddressOnlyEnum, #AddressOnlyEnum.mere!enumelt, [[INIT_OPAQUE]] : $EmptyP
-// HECK:   destroy_value [[ENUM2]]
-// HECK:   [[MTYPE4:%.*]] = metatype $@thin AddressOnlyEnum.Type
-// HECK:   [[ENUM3:%.*]] = enum $AddressOnlyEnum, #AddressOnlyEnum.phantom!enumelt, [[ARG]] : $AddressOnlyStruct
-// HECK:   return %{{.*}} : $()
+// CHECK:   [[MTYPE1:%.*]] = metatype $@thin AddressOnlyEnum.Type
+// CHECK:   [[APPLY1:%.*]] = apply {{.*}}([[MTYPE1]]) : $@convention(thin) (@thin AddressOnlyEnum.Type) -> @owned @callee_guaranteed (@in_guaranteed any EmptyP) -> @out AddressOnlyEnum
+// CHECK:   destroy_value [[APPLY1]]
+// CHECK:   [[MTYPE2:%.*]] = metatype $@thin AddressOnlyEnum.Type
+// CHECK:   [[ENUM1:%.*]] = enum $AddressOnlyEnum, #AddressOnlyEnum.nought!enumelt
+// CHECK:   [[MTYPE3:%.*]] = metatype $@thin AddressOnlyEnum.Type
+// CHECK:   [[INIT_OPAQUE:%.*]] = init_existential_value [[ARG]] : $AddressOnlyStruct, $AddressOnlyStruct, $any EmptyP
+// CHECK:   [[ENUM2:%.*]] = enum $AddressOnlyEnum, #AddressOnlyEnum.mere!enumelt, [[INIT_OPAQUE]] : $any EmptyP
+// CHECK:   destroy_value [[ENUM2]]
+// CHECK:   [[MTYPE4:%.*]] = metatype $@thin AddressOnlyEnum.Type
+// CHECK:   [[ENUM3:%.*]] = enum $AddressOnlyEnum, #AddressOnlyEnum.phantom!enumelt, [[ARG]] : $AddressOnlyStruct
+// CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '$ss15f260_AOnly_enumyys17AddressOnlyStructVF'
 func f260_AOnly_enum(_ s: AddressOnlyStruct) {
   _ = AddressOnlyEnum.mere
@@ -539,12 +543,12 @@ func f260_AOnly_enum(_ s: AddressOnlyStruct) {
 // Tests InjectOptional for opaque value types + conversion of opaque structs
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss21f270_convOptAnyStructyys0dE0VACSgcF : $@convention(thin) (@guaranteed @callee_guaranteed (@in_guaranteed Optional<AnyStruct>) -> @out AnyStruct) -> () {
-// HECK: bb0([[ARG:%.*]] : $@callee_guaranteed (@in_guaranteed Optional<AnyStruct>) -> @out AnyStruct):
-// HECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]]
-// HECK:   [[PAPPLY:%.*]] = partial_apply [callee_guaranteed] %{{.*}}([[COPY_ARG]]) : $@convention(thin) (@in_guaranteed Optional<AnyStruct>, @guaranteed @callee_guaranteed (@in_guaranteed Optional<AnyStruct>) -> @out AnyStruct) -> @out Optional<AnyStruct>
-// HECK:   destroy_value [[PAPPLY]] : $@callee_guaranteed (@in_guaranteed Optional<AnyStruct>) -> @out Optional<AnyStruct>
-// HECK-NOT:   destroy_value [[ARG]] : $@callee_guaranteed (@in_guaranteed Optional<AnyStruct>) -> @out AnyStruct
-// HECK:   return %{{.*}} : $()
+// CHECK: bb0([[ARG:%.*]] : @guaranteed $@callee_guaranteed (@in_guaranteed Optional<AnyStruct>) -> @out AnyStruct):
+// CHECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]]
+// CHECK:   [[PAPPLY:%.*]] = partial_apply [callee_guaranteed] %{{.*}}([[COPY_ARG]]) : $@convention(thin) (@in_guaranteed Optional<AnyStruct>, @guaranteed @callee_guaranteed (@in_guaranteed Optional<AnyStruct>) -> @out AnyStruct) -> @out Optional<AnyStruct>
+// CHECK:   destroy_value [[PAPPLY]] : $@callee_guaranteed (@in_guaranteed Optional<AnyStruct>) -> @out Optional<AnyStruct>
+// CHECK-NOT:   destroy_value [[ARG]] : $@callee_guaranteed (@in_guaranteed Optional<AnyStruct>) -> @out AnyStruct
+// CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '$ss21f270_convOptAnyStructyys0dE0VACSgcF'
 func f270_convOptAnyStruct(_ a1: @escaping (AnyStruct?) -> AnyStruct) {
   let _: (AnyStruct?) -> AnyStruct? = a1
@@ -554,20 +558,20 @@ func f270_convOptAnyStruct(_ a1: @escaping (AnyStruct?) -> AnyStruct) {
 // ---
 // CHECK-LABEL: sil shared [transparent] [serialized] [reabstraction_thunk] [ossa] @$ss9AnyStructVSgABIegnr_A2CIegnr_TR : $@convention(thin) (@in_guaranteed Optional<AnyStruct>, @guaranteed @callee_guaranteed (@in_guaranteed Optional<AnyStruct>) -> @out AnyStruct) -> @out Optional<AnyStruct> {
 // CHECK: bb0([[ARG0:%.*]] : @guaranteed $Optional<AnyStruct>, [[ARG1:%.*]] : @guaranteed $@callee_guaranteed (@in_guaranteed Optional<AnyStruct>) -> @out AnyStruct):
-// HECK:   [[APPLYARG:%.*]] = apply [[ARG1]]([[ARG0]]) : $@callee_guaranteed (@in_guaranteed Optional<AnyStruct>) -> @out AnyStruct
-// HECK:   [[RETVAL:%.*]] = enum $Optional<AnyStruct>, #Optional.some!enumelt, [[APPLYARG]] : $AnyStruct
-// HECK:   return [[RETVAL]] : $Optional<AnyStruct>
+// CHECK:   [[APPLYARG:%.*]] = apply [[ARG1]]([[ARG0]]) : $@callee_guaranteed (@in_guaranteed Optional<AnyStruct>) -> @out AnyStruct
+// CHECK:   [[RETVAL:%.*]] = enum $Optional<AnyStruct>, #Optional.some!enumelt, [[APPLYARG]] : $AnyStruct
+// CHECK:   return [[RETVAL]] : $Optional<AnyStruct>
 // CHECK-LABEL: } // end sil function '$ss9AnyStructVSgABIegnr_A2CIegnr_TR'
 
 // Tests conversion between existential types
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss21f280_convExistTrivialyys0D6StructVs1P_pcF : $@convention(thin) (@guaranteed @callee_guaranteed (@in_guaranteed any P) -> TrivialStruct) -> () {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $@callee_guaranteed (@in_guaranteed any P) -> TrivialStruct):
-// HECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]]
-// HECK:   [[PAPPLY:%.*]] = partial_apply [callee_guaranteed] %{{.*}}([[COPY_ARG]]) : $@convention(thin) (@in_guaranteed P2, @guaranteed @callee_guaranteed (@in_guaranteed any P) -> TrivialStruct) -> @out P2
-// HECK:   destroy_value [[PAPPLY]] : $@callee_guaranteed (@in_guaranteed P2) -> @out P2
+// CHECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]]
+// CHECK:   [[PAPPLY:%.*]] = partial_apply [callee_guaranteed] %{{.*}}([[COPY_ARG]]) : $@convention(thin) (@in_guaranteed any P2, @guaranteed @callee_guaranteed (@in_guaranteed any P) -> TrivialStruct) -> @out any P2
+// CHECK:   destroy_value [[PAPPLY]] : $@callee_guaranteed (@in_guaranteed any P2) -> @out any P2
 // CHECK-NOT:   destroy_value [[ARG]]
-// HECK:   return %{{.*}} : $()
+// CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '$ss21f280_convExistTrivialyys0D6StructVs1P_pcF'
 func f280_convExistTrivial(_ s: @escaping (P) -> TrivialStruct) {
   let _: (P2) -> P2 = s
@@ -577,26 +581,26 @@ func f280_convExistTrivial(_ s: @escaping (P) -> TrivialStruct) {
 // ---
 // CHECK-LABEL: sil shared [transparent] [serialized] [reabstraction_thunk] [ossa] @$ss1P_ps13TrivialStructVIegnd_s2P2_psAD_pIegnr_TR : $@convention(thin) (@in_guaranteed any P2, @guaranteed @callee_guaranteed (@in_guaranteed any P) -> TrivialStruct) -> @out any P2 {
 // CHECK: bb0([[ARG0:%.*]] : @guaranteed $any P2, [[ARG1:%.*]] : @guaranteed $@callee_guaranteed (@in_guaranteed any P) -> TrivialStruct):
-// HECK:   [[OPENED_ARG:%.*]] = open_existential_value [[ARG]] : $any P2 to $@opened({{.*}}, any P2) Self
-// HECK:   [[COPIED_VAL:%.*]] = copy_value [[OPENED_ARG]]
-// HECK:   [[INIT_P:%.*]] = init_existential_value [[COPIED_VAL]] : $@opened({{.*}}, any P2) Self, $@opened({{.*}}, any P2) Self, $any P
-// HECK:   [[BORROWED_INIT_P:%.*]] = begin_borrow [[INIT_P]]
-// HECK:   [[APPLY_P:%.*]] = apply [[ARG1]]([[BORROWED_INIT_P]]) : $@callee_guaranteed (@in_guaranteed any P) -> TrivialStruct
-// HECK:   [[RETVAL:%.*]] = init_existential_value [[APPLY_P]] : $TrivialStruct, $TrivialStruct, $any P2
-// HECK:   end_borrow [[BORROWED_INIT_P]]
+// CHECK:   [[OPENED_ARG:%.*]] = open_existential_value [[ARG]] : $any P2 to $@opened({{.*}}, any P2) Self
+// CHECK:   [[COPIED_VAL:%.*]] = copy_value [[OPENED_ARG]]
+// CHECK:   [[INIT_P:%.*]] = init_existential_value [[COPIED_VAL]] : $@opened({{.*}}, any P2) Self, $@opened({{.*}}, any P2) Self, $any P
+// CHECK:   [[BORROWED_INIT_P:%.*]] = begin_borrow [[INIT_P]]
+// CHECK:   [[APPLY_P:%.*]] = apply [[ARG1]]([[BORROWED_INIT_P]]) : $@callee_guaranteed (@in_guaranteed any P) -> TrivialStruct
+// CHECK:   [[RETVAL:%.*]] = init_existential_value [[APPLY_P]] : $TrivialStruct, $TrivialStruct, $any P2
+// CHECK:   end_borrow [[BORROWED_INIT_P]]
 // CHECK-NOT:   destroy_value [[ARG0]]
-// HECK:   return [[RETVAL]] : $any P2
+// CHECK:   return [[RETVAL]] : $any P2
 // CHECK-LABEL: } // end sil function '$ss1P_ps13TrivialStructVIegnd_s2P2_psAD_pIegnr_TR'
 
 // Tests conversion between existential types - optionals case
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss21f290_convOptExistTrivyys13TrivialStructVs1P_pSgcF : $@convention(thin) (@guaranteed @callee_guaranteed (@in_guaranteed Optional<any P>) -> TrivialStruct) -> () {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $@callee_guaranteed (@in_guaranteed Optional<any P>) -> TrivialStruct):
-// HECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]]
-// HECK:   [[PAPPLY:%.*]] = partial_apply [callee_guaranteed] %{{.*}}([[COPY_ARG]]) : $@convention(thin) (Optional<TrivialStruct>, @guaranteed @callee_guaranteed (@in_guaranteed Optional<any P>) -> TrivialStruct) -> @out any P2
-// HECK:   destroy_value [[PAPPLY]] : $@callee_guaranteed (Optional<TrivialStruct>) -> @out any P2
+// CHECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]]
+// CHECK:   [[PAPPLY:%.*]] = partial_apply [callee_guaranteed] %{{.*}}([[COPY_ARG]]) : $@convention(thin) (Optional<TrivialStruct>, @guaranteed @callee_guaranteed (@in_guaranteed Optional<any P>) -> TrivialStruct) -> @out any P2
+// CHECK:   destroy_value [[PAPPLY]] : $@callee_guaranteed (Optional<TrivialStruct>) -> @out any P2
 // CHECK-NOT:   destroy_value [[ARG]]
-// HECK:   return %{{.*}} : $()
+// CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '$ss21f290_convOptExistTrivyys13TrivialStructVs1P_pSgcF'
 func f290_convOptExistTriv(_ s: @escaping (P?) -> TrivialStruct) {
   let _: (TrivialStruct?) -> P2 = s
@@ -606,30 +610,30 @@ func f290_convOptExistTriv(_ s: @escaping (P?) -> TrivialStruct) {
 // ---
 // CHECK-LABEL: sil shared [transparent] [serialized] [reabstraction_thunk] [ossa] @$ss1P_pSgs13TrivialStructVIegnd_ADSgs2P2_pIegyr_TR : $@convention(thin) (Optional<TrivialStruct>, @guaranteed @callee_guaranteed (@in_guaranteed Optional<any P>) -> TrivialStruct) -> @out any P2 {
 // CHECK: bb0([[ARG0:%.*]] : $Optional<TrivialStruct>, [[ARG1:%.*]] : @guaranteed $@callee_guaranteed (@in_guaranteed Optional<any P>) -> TrivialStruct):
-// HECK:   switch_enum [[ARG0]] : $Optional<TrivialStruct>, case #Optional.some!enumelt: bb2, case #Optional.none!enumelt: bb1
-// HECK: bb1:
-// HECK:   [[ONONE:%.*]] = enum $Optional<any P>, #Optional.none!enumelt
-// HECK:   br bb3([[ONONE]] : $Optional<any P>)
-// HECK: bb2([[OSOME:%.*]] : $TrivialStruct):
-// HECK:   [[INIT_S:%.*]] = init_existential_value [[OSOME]] : $TrivialStruct, $TrivialStruct, $any P
-// HECK:   [[ENUM_S:%.*]] = enum $Optional<any P>, #Optional.some!enumelt, [[INIT_S]] : $any P
-// HECK:   br bb3([[ENUM_S]] : $Optional<any P>)
-// HECK: bb3([[OPT_S:%.*]] : $Optional<any P>):
-// HECK:   [[BORROWED_OPT_S:%.*]] = begin_borrow [[OPT_S]]
-// HECK:   [[APPLY_P:%.*]] = apply [[ARG1]]([[BORROWED_OPT_S]]) : $@callee_guaranteed (@in_guaranteed Optional<any P>) -> TrivialStruct
-// HECK:   [[RETVAL:%.*]] = init_existential_value [[APPLY_P]] : $TrivialStruct, $TrivialStruct, $any P2
-// HECK:   return [[RETVAL]] : $any P2
+// CHECK:   switch_enum [[ARG0]] : $Optional<TrivialStruct>, case #Optional.some!enumelt: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
+// CHECK: [[SOME_BB]]([[OSOME:%.*]] : $TrivialStruct):
+// CHECK:   [[INIT_S:%.*]] = init_existential_value [[OSOME]] : $TrivialStruct, $TrivialStruct, $any P
+// CHECK:   [[ENUM_S:%.*]] = enum $Optional<any P>, #Optional.some!enumelt, [[INIT_S]] : $any P
+// CHECK:   br [[CONT_BB:bb[0-9]+]]([[ENUM_S]] : $Optional<any P>)
+// CHECK: [[NONE_BB]]:
+// CHECK:   [[ONONE:%.*]] = enum $Optional<any P>, #Optional.none!enumelt
+// CHECK:   br [[CONT_BB]]([[ONONE]] : $Optional<any P>)
+// CHECK: [[CONT_BB]]([[OPT_S:%.*]] : @owned $Optional<any P>):
+// CHECK:   [[BORROWED_OPT_S:%.*]] = begin_borrow [[OPT_S]]
+// CHECK:   [[APPLY_P:%.*]] = apply [[ARG1]]([[BORROWED_OPT_S]]) : $@callee_guaranteed (@in_guaranteed Optional<any P>) -> TrivialStruct
+// CHECK:   [[RETVAL:%.*]] = init_existential_value [[APPLY_P]] : $TrivialStruct, $TrivialStruct, $any P2
+// CHECK:   return [[RETVAL]] : $any P2
 // CHECK-LABEL: } // end sil function '$ss1P_pSgs13TrivialStructVIegnd_ADSgs2P2_pIegyr_TR'
 
 // Tests corner-case: reabstraction of an empty tuple to any
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss20f300_convETupleToAnyyyyycF : $@convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> () {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $@callee_guaranteed () -> ()):
-// HECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]]
-// HECK:   [[PAPPLY:%.*]] = partial_apply [callee_guaranteed] %{{.*}}([[COPY_ARG]]) : $@convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> @out Any
-// HECK:   destroy_value [[PAPPLY]] : $@callee_guaranteed () -> @out Any
+// CHECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]]
+// CHECK:   [[PAPPLY:%.*]] = partial_apply [callee_guaranteed] %{{.*}}([[COPY_ARG]]) : $@convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> @out Any
+// CHECK:   destroy_value [[PAPPLY]] : $@callee_guaranteed () -> @out Any
 // CHECK-NOT:   destroy_value [[ARG]]
-// HECK:   return %{{.*}} : $()
+// CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '$ss20f300_convETupleToAnyyyyycF'
 func f300_convETupleToAny(_ t: @escaping () -> ()) {
   let _: () -> Any = t
@@ -639,23 +643,23 @@ func f300_convETupleToAny(_ t: @escaping () -> ()) {
 // ---
 // CHECK-LABEL: sil shared [transparent] [serialized] [reabstraction_thunk] [ossa] @$sIeg_ypIegr_TR : $@convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> @out Any {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $@callee_guaranteed () -> ()):
-// HECK:   [[ASTACK:%.*]] = alloc_stack $Any
-// HECK:   [[IADDR:%.*]] = init_existential_addr [[ASTACK]] : $*Any, $()
-// HECK:   [[APPLYARG:%.*]] = apply [[ARG]]() : $@callee_guaranteed () -> ()
-// HECK:   [[LOAD_EXIST:%.*]] = load [trivial] [[IADDR]] : $*()
-// HECK:   [[RETVAL:%.*]] = init_existential_value [[LOAD_EXIST]] : $(), $(), $Any
-// HECK:   return [[RETVAL]] : $Any
+// CHECK:   [[ASTACK:%.*]] = alloc_stack $Any
+// CHECK:   [[IADDR:%.*]] = init_existential_addr [[ASTACK]] : $*Any, $()
+// CHECK:   [[APPLYARG:%.*]] = apply [[ARG]]() : $@callee_guaranteed () -> ()
+// CHECK:   [[LOAD_EXIST:%.*]] = load [trivial] [[IADDR]] : $*()
+// CHECK:   [[RETVAL:%.*]] = init_existential_value [[LOAD_EXIST]] : $(), $(), $Any
+// CHECK:   return [[RETVAL]] : $Any
 // CHECK-LABEL: } // end sil function '$sIeg_ypIegr_TR'
 
 // Tests corner-case: reabstraction of a non-empty tuple to any
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss21f310_convnIntTupleAnyyyBi64__Bi64_tycF : $@convention(thin) (@guaranteed @callee_guaranteed () -> (Builtin.Int64, Builtin.Int64)) -> () {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $@callee_guaranteed () -> (Builtin.Int64, Builtin.Int64)):
-// HECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]]
-// HECK:   [[PAPPLY:%.*]] = partial_apply [callee_guaranteed] %{{.*}}([[COPY_ARG]]) : $@convention(thin) (@guaranteed @callee_guaranteed () -> (Builtin.Int64, Builtin.Int64)) -> @out Any
-// HECK:   destroy_value [[PAPPLY]] : $@callee_guaranteed () -> @out Any
+// CHECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]]
+// CHECK:   [[PAPPLY:%.*]] = partial_apply [callee_guaranteed] %{{.*}}([[COPY_ARG]]) : $@convention(thin) (@guaranteed @callee_guaranteed () -> (Builtin.Int64, Builtin.Int64)) -> @out Any
+// CHECK:   destroy_value [[PAPPLY]] : $@callee_guaranteed () -> @out Any
 // CHECK-NOT:   destroy_value [[ARG]]
-// HECK:   return %{{.*}} : $()
+// CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '$ss21f310_convnIntTupleAnyyyBi64__Bi64_tycF'
 func f310_convnIntTupleAny(_ t: @escaping () -> (Builtin.Int64, Builtin.Int64)) {
   let _: () -> Any = t
@@ -665,30 +669,29 @@ func f310_convnIntTupleAny(_ t: @escaping () -> (Builtin.Int64, Builtin.Int64)) 
 // ---
 // CHECK-LABEL: sil shared [transparent] [serialized] [reabstraction_thunk] [ossa] @$sBi64_Bi64_Iegdd_ypIegr_TR : $@convention(thin) (@guaranteed @callee_guaranteed () -> (Builtin.Int64, Builtin.Int64)) -> @out Any {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $@callee_guaranteed () -> (Builtin.Int64, Builtin.Int64)):
-// HECK:   [[ASTACK:%.*]] = alloc_stack $Any
-// HECK:   [[IADDR:%.*]] = init_existential_addr [[ASTACK]] : $*Any, $(Builtin.Int64, Builtin.Int64)
-// HECK:   [[TADDR0:%.*]] = tuple_element_addr [[IADDR]] : $*(Builtin.Int64, Builtin.Int64), 0
-// HECK:   [[TADDR1:%.*]] = tuple_element_addr [[IADDR]] : $*(Builtin.Int64, Builtin.Int64), 1
-// HECK:   [[APPLYARG:%.*]] = apply [[ARG]]() : $@callee_guaranteed () -> (Builtin.Int64, Builtin.Int64)
-// HECK:   [[TEXTRACT0:%.*]] = tuple_extract [[APPLYARG]] : $(Builtin.Int64, Builtin.Int64), 0
-// HECK:   [[TEXTRACT1:%.*]] = tuple_extract [[APPLYARG]] : $(Builtin.Int64, Builtin.Int64), 1
-// HECK:   store [[TEXTRACT0]] to [trivial] [[TADDR0]] : $*Builtin.Int64
-// HECK:   store [[TEXTRACT1]] to [trivial] [[TADDR1]] : $*Builtin.Int64
-// HECK:   [[LOAD_EXIST:%.*]] = load [trivial] [[IADDR]] : $*(Builtin.Int64, Builtin.Int64)
-// HECK:   [[RETVAL:%.*]] = init_existential_value [[LOAD_EXIST]] : $(Builtin.Int64, Builtin.Int64), $(Builtin.Int64, Builtin.Int64), $Any
-// HECK:   dealloc_stack [[ASTACK]] : $*Any
-// HECK:   return [[RETVAL]] : $Any
+// CHECK:   [[ASTACK:%.*]] = alloc_stack $Any
+// CHECK:   [[IADDR:%.*]] = init_existential_addr [[ASTACK]] : $*Any, $(Builtin.Int64, Builtin.Int64)
+// CHECK:   [[TADDR0:%.*]] = tuple_element_addr [[IADDR]] : $*(Builtin.Int64, Builtin.Int64), 0
+// CHECK:   [[TADDR1:%.*]] = tuple_element_addr [[IADDR]] : $*(Builtin.Int64, Builtin.Int64), 1
+// CHECK:   [[APPLYARG:%.*]] = apply [[ARG]]() : $@callee_guaranteed () -> (Builtin.Int64, Builtin.Int64)
+// CHECK:   ([[TEXTRACT0:%.*]], [[TEXTRACT1:%.*]]) = destructure_tuple [[APPLYARG]] : $(Builtin.Int64, Builtin.Int64)
+// CHECK:   store [[TEXTRACT0]] to [trivial] [[TADDR0]] : $*Builtin.Int64
+// CHECK:   store [[TEXTRACT1]] to [trivial] [[TADDR1]] : $*Builtin.Int64
+// CHECK:   [[LOAD_EXIST:%.*]] = load [trivial] [[IADDR]] : $*(Builtin.Int64, Builtin.Int64)
+// CHECK:   [[RETVAL:%.*]] = init_existential_value [[LOAD_EXIST]] : $(Builtin.Int64, Builtin.Int64), $(Builtin.Int64, Builtin.Int64), $Any
+// CHECK:   dealloc_stack [[ASTACK]] : $*Any
+// CHECK:   return [[RETVAL]] : $Any
 // CHECK-LABEL: } // end sil function '$sBi64_Bi64_Iegdd_ypIegr_TR'
 
 // Tests translating and imploding into Any under opaque value mode
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss20f320_transImplodeAnyyyyypcF : $@convention(thin) (@guaranteed @callee_guaranteed (@in_guaranteed Any) -> ()) -> () {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $@callee_guaranteed (@in_guaranteed Any) -> ()):
-// HECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]]
-// HECK:   [[PAPPLY:%.*]] = partial_apply [callee_guaranteed] %{{.*}}([[COPY_ARG]]) : $@convention(thin) (Builtin.Int64, Builtin.Int64, @guaranteed @callee_guaranteed (@in_guaranteed Any) -> ()) -> ()
-// HECK:   destroy_value [[PAPPLY]] : $@callee_guaranteed (Builtin.Int64, Builtin.Int64) -> ()
+// CHECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]]
+// CHECK:   [[PAPPLY:%.*]] = partial_apply [callee_guaranteed] %{{.*}}([[COPY_ARG]]) : $@convention(thin) (Builtin.Int64, Builtin.Int64, @guaranteed @callee_guaranteed (@in_guaranteed Any) -> ()) -> ()
+// CHECK:   destroy_value [[PAPPLY]] : $@callee_guaranteed (Builtin.Int64, Builtin.Int64) -> ()
 // CHECK-NOT:   destroy_value [[ARG]]
-// HECK:   return %{{.*}} : $()
+// CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '$ss20f320_transImplodeAnyyyyypcF'
 func f320_transImplodeAny(_ t: @escaping (Any) -> ()) {
   let _: ((Builtin.Int64, Builtin.Int64)) -> () = t
@@ -698,26 +701,26 @@ func f320_transImplodeAny(_ t: @escaping (Any) -> ()) {
 // ---
 // CHECK-LABEL: sil shared [transparent] [serialized] [reabstraction_thunk] [ossa] @$sypIegn_Bi64_Bi64_Iegyy_TR : $@convention(thin) (Builtin.Int64, Builtin.Int64, @guaranteed @callee_guaranteed (@in_guaranteed Any) -> ()) -> () {
 // CHECK: bb0([[ARG0:%.*]] : $Builtin.Int64, [[ARG1:%.*]] : $Builtin.Int64, [[ARG2:%.*]] : @guaranteed $@callee_guaranteed (@in_guaranteed Any) -> ()):
-// HECK:   [[ASTACK:%.*]] = alloc_stack $Any
-// HECK:   [[IADDR:%.*]] = init_existential_addr [[ASTACK]] : $*Any, $(Builtin.Int64, Builtin.Int64)
-// HECK:   [[TADDR0:%.*]] = tuple_element_addr [[IADDR]] : $*(Builtin.Int64, Builtin.Int64), 0
-// HECK:   store [[ARG0]] to [trivial] [[TADDR0]] : $*Builtin.Int64
-// HECK:   [[TADDR1:%.*]] = tuple_element_addr [[IADDR]] : $*(Builtin.Int64, Builtin.Int64), 1
-// HECK:   store [[ARG1]] to [trivial] [[TADDR1]] : $*Builtin.Int64
-// HECK:   [[LOAD_EXIST:%.*]] = load [trivial] [[IADDR]] : $*(Builtin.Int64, Builtin.Int64)
-// HECK:   [[INIT_OPAQUE:%.*]] = init_existential_value [[LOAD_EXIST]] : $(Builtin.Int64, Builtin.Int64), $(Builtin.Int64, Builtin.Int64), $Any
-// HECK:   [[BORROWED_INIT_OPAQUE:%.*]] = begin_borrow [[INIT_OPAQUE]]
-// HECK:   [[APPLYARG:%.*]] = apply [[ARG2]]([[BORROWED_INIT_OPAQUE]]) : $@callee_guaranteed (@in_guaranteed Any) -> ()
-// HECK:   dealloc_stack [[ASTACK]] : $*Any
-// HECK:   return %{{.*}} : $()
+// CHECK:   [[ASTACK:%.*]] = alloc_stack $Any
+// CHECK:   [[IADDR:%.*]] = init_existential_addr [[ASTACK]] : $*Any, $(Builtin.Int64, Builtin.Int64)
+// CHECK:   [[TADDR0:%.*]] = tuple_element_addr [[IADDR]] : $*(Builtin.Int64, Builtin.Int64), 0
+// CHECK:   store [[ARG0]] to [trivial] [[TADDR0]] : $*Builtin.Int64
+// CHECK:   [[TADDR1:%.*]] = tuple_element_addr [[IADDR]] : $*(Builtin.Int64, Builtin.Int64), 1
+// CHECK:   store [[ARG1]] to [trivial] [[TADDR1]] : $*Builtin.Int64
+// CHECK:   [[LOAD_EXIST:%.*]] = load [trivial] [[IADDR]] : $*(Builtin.Int64, Builtin.Int64)
+// CHECK:   [[INIT_OPAQUE:%.*]] = init_existential_value [[LOAD_EXIST]] : $(Builtin.Int64, Builtin.Int64), $(Builtin.Int64, Builtin.Int64), $Any
+// CHECK:   [[BORROWED_INIT_OPAQUE:%.*]] = begin_borrow [[INIT_OPAQUE]]
+// CHECK:   [[APPLYARG:%.*]] = apply [[ARG2]]([[BORROWED_INIT_OPAQUE]]) : $@callee_guaranteed (@in_guaranteed Any) -> ()
+// CHECK:   dealloc_stack [[ASTACK]] : $*Any
+// CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '$sypIegn_Bi64_Bi64_Iegyy_TR'
 
 // Tests support for address only let closures under opaque value mode - they are not by-address anymore
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss19f330_addrLetClosureyxxlF : $@convention(thin) <T> (@in_guaranteed T) -> @out T {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $T):
-// HECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]] : $T
-// HECK:   return [[COPY_ARG]] : $T
+// CHECK:   [[RESULT:%.*]] = apply {{%.*}}<T>([[ARG]]) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> @out τ_0_0
+// CHECK:   return [[RESULT]] : $T
 // CHECK-LABEL: } // end sil function '$ss19f330_addrLetClosureyxxlF'
 func f330_addrLetClosure<T>(_ x:T) -> T {
   return { { x }() }()
@@ -727,15 +730,15 @@ func f330_addrLetClosure<T>(_ x:T) -> T {
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss15f340_captureBoxyyF : $@convention(thin) () -> () {
 // CHECK: bb0:
-// HECK:   [[ALLOC_OF_BOX:%.*]] = alloc_box ${ var EmptyP }, var, name "mutableAddressOnly"
-// HECK:   [[PROJ_BOX:%.*]] = project_box [[ALLOC_OF_BOX]]
-// HECK:   [[APPLY_FOR_BOX:%.*]] = apply %{{.*}}(%{{.*}}) : $@convention(method) (@thin AddressOnlyStruct.Type) -> AddressOnlyStruct
-// HECK:   [[INIT_OPAQUE:%.*]] = init_existential_value [[APPLY_FOR_BOX]] : $AddressOnlyStruct, $AddressOnlyStruct, $EmptyP
-// HECK:   store [[INIT_OPAQUE]] to [init] [[PROJ_BOX]] : $*EmptyP
-// HECK:   [[BORROW_BOX:%.*]] = begin_borrow [[ALLOC_OF_BOX]] : ${ var EmptyP }
-// HECK:   mark_function_escape [[PROJ_BOX]] : $*EmptyP
-// HECK:   apply %{{.*}}([[BORROW_BOX]]) : $@convention(thin) (@guaranteed { var EmptyP }) -> ()
-// HECK:   return %{{.*}} : $()
+// CHECK:   [[ALLOC_OF_BOX:%.*]] = alloc_box ${ var any EmptyP }, var, name "mutableAddressOnly"
+// CHECK:   [[BORROW_BOX:%.*]] = begin_borrow [lexical] [var_decl] [[ALLOC_OF_BOX]] : ${ var any EmptyP }
+// CHECK:   [[PROJ_BOX:%.*]] = project_box [[BORROW_BOX]]
+// CHECK:   [[APPLY_FOR_BOX:%.*]] = apply %{{.*}}(%{{.*}}) : $@convention(method) (@thin AddressOnlyStruct.Type) -> AddressOnlyStruct
+// CHECK:   [[INIT_OPAQUE:%.*]] = init_existential_value [[APPLY_FOR_BOX]] : $AddressOnlyStruct, $AddressOnlyStruct, $any EmptyP
+// CHECK:   store [[INIT_OPAQUE]] to [init] [[PROJ_BOX]] : $*any EmptyP
+// CHECK:   mark_function_escape [[PROJ_BOX]] : $*any EmptyP
+// CHECK:   apply %{{.*}}([[BORROW_BOX]]) : $@convention(thin) (@guaranteed { var any EmptyP }) -> ()
+// CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '$ss15f340_captureBoxyyF'
 func f340_captureBox() {
   var mutableAddressOnly: EmptyP = AddressOnlyStruct()
@@ -751,29 +754,25 @@ func f340_captureBox() {
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss14f360_guardEnumyys08IndirectC0OyxGlF : $@convention(thin) <T> (@guaranteed IndirectEnum<T>) -> () {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $IndirectEnum<T>):
-// HECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]]
-// HECK:   switch_enum [[COPY_ARG]] : $IndirectEnum<T>, case #IndirectEnum.Node!enumelt: [[NODE_BB:bb[0-9]+]], case #IndirectEnum.Nil!enumelt: [[NIL_BB:bb[0-9]+]]
+// CHECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]]
+// CHECK:   switch_enum [[COPY_ARG]] : $IndirectEnum<T>, case #IndirectEnum.Node!enumelt: [[NODE_BB:bb[0-9]+]], case #IndirectEnum.Nil!enumelt: [[NIL_BB:bb[0-9]+]]
 //
-// HECK: [[NIL_BB]]:
-// HECK:   br [[NIL_TRAMPOLINE:bb[0-9]+]]
+// CHECK: [[NODE_BB]]([[EARG:%.*]] : @owned $<τ_0_0> { var τ_0_0 } <T>):
+// CHECK:   [[PROJ_BOX:%.*]] = project_box [[EARG]]
+// CHECK:   [[LOAD_BOX:%.*]] = load_borrow [[PROJ_BOX]] : $*T
+// CHECK:   [[COPY_BOX:%.*]] = copy_value [[LOAD_BOX]] : $T
+// CHECK:   end_borrow [[LOAD_BOX]] : $T
+// CHECK:   [[MOVE_BOX:%.*]] = move_value [lexical] [var_decl] [[COPY_BOX]] : $T
+// CHECK:   destroy_value [[EARG]]
+// CHECK:   destroy_value [[MOVE_BOX]]
+// CHECK:   br [[EPILOG_BB:bb[0-9]+]]
 //
-// HECK: [[NIL_TRAMPOLINE]]:
-// HECK:   br [[EPILOG_BB:bb[0-9]+]]
+// CHECK: [[NIL_BB]]:
+// CHECK:   br [[EPILOG_BB]]
 //
-// HECK: [[NODE_BB]]([[EARG:%.*]] : $<τ_0_0> { var τ_0_0 } <T>):
-// HECK:   [[PROJ_BOX:%.*]] = project_box [[EARG]]
-// HECK:   [[LOAD_BOX:%.*]] = load [take] [[PROJ_BOX]] : $*T
-// HECK:   [[COPY_BOX:%.*]] = copy_value [[LOAD_BOX]] : $T
-// HECK:   destroy_value [[EARG]]
-// HECK:   br [[CONT_BB:bb[0-9]+]]
-//
-// HECK: [[CONT_BB]]:
-// HECK:   destroy_value [[COPY_BOX]]
-// HECK:   br [[EPILOG_BB]]
-//
-// HECK: [[EPILOG_BB]]:
+// CHECK: [[EPILOG_BB]]:
 // CHECK-NOT:   destroy_value [[ARG]]
-// HECK:   return %{{.*}} : $()
+// CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '$ss14f360_guardEnumyys08IndirectC0OyxGlF'
 func f360_guardEnum<T>(_ e: IndirectEnum<T>) {
   do {
@@ -786,9 +785,9 @@ func f360_guardEnum<T>(_ e: IndirectEnum<T>) {
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss17f370_optToOptCastyxSgABlF : $@convention(thin) <T> (@in_guaranteed Optional<T>) -> @out Optional<T> {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $Optional<T>):
-// HECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]]
+// CHECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]]
 // CHECK-NOT:   destroy_value [[ARG]]
-// HECK:   return [[COPY_ARG]] : $Optional<T>
+// CHECK:   return [[COPY_ARG]] : $Optional<T>
 // CHECK-LABEL: } // end sil function '$ss17f370_optToOptCastyxSgABlF'
 func f370_optToOptCast<T>(_ x : T!) -> T? {
   return x
@@ -798,11 +797,12 @@ func f370_optToOptCast<T>(_ x : T!) -> T? {
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss19f380_contextualInityyBi64_SgF : $@convention(thin) (Optional<Builtin.Int64>) -> () {
 // CHECK: bb0([[ARG:%.*]] : $Optional<Builtin.Int64>):
-// HECK:   [[ALLOC_OF_BOX:%.*]] = alloc_box ${ var Optional<Builtin.Int64> }, var
-// HECK:   [[PROJ_BOX:%.*]] = project_box [[ALLOC_OF_BOX]]
-// HECK:   store [[ARG]] to [trivial] [[PROJ_BOX]] : $*Optional<Builtin.Int64>
-// HECK:   destroy_value [[ALLOC_OF_BOX]]
-// HECK:   return %{{.*}} : $()
+// CHECK:   [[ALLOC_OF_BOX:%.*]] = alloc_box ${ var Optional<Builtin.Int64> }, var
+// CHECK:   [[BORROW_BOX:%.*]] = begin_borrow [var_decl] [[ALLOC_OF_BOX]]
+// CHECK:   [[PROJ_BOX:%.*]] = project_box [[BORROW_BOX]]
+// CHECK:   store [[ARG]] to [trivial] [[PROJ_BOX]] : $*Optional<Builtin.Int64>
+// CHECK:   destroy_value [[ALLOC_OF_BOX]]
+// CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '$ss19f380_contextualInityyBi64_SgF'
 func f380_contextualInit(_ a : Builtin.Int64?) {
   var x: Builtin.Int64? = a
@@ -814,18 +814,21 @@ func f380_contextualInit(_ a : Builtin.Int64?) {
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss19f390_addrCallResultyyxycSglF : $@convention(thin) <T> (@guaranteed Optional<@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <T>>) -> () {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $Optional<@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <T>>):
-// HECK:   [[ALLOC_OF_BOX:%.*]] = alloc_box $<τ_0_0> { var Optional<τ_0_0> } <T>
-// HECK:   [[PROJ_BOX:%.*]] = project_box [[ALLOC_OF_BOX]]
-// HECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]]
-// HECK:   [[SENUM:%.*]] = select_enum [[COPY_ARG]]
-// HECK:   cond_br [[SENUM]], bb3, bb1
-// HECK: bb1:
-// HECK:   br bb2
-// HECK: bb2:
-// HECK:   [[ONONE:%.*]] = enum $Optional<T>, #Optional.none!enumelt
-// HECK:   br bb4([[ONONE]] : $Optional<T>)
-// HECK: bb4(%{{.*}} : $Optional<T>):
-// HECK:   return %{{.*}} : $()
+// CHECK:   [[ALLOC_OF_BOX:%.*]] = alloc_box $<τ_0_0> { var Optional<τ_0_0> } <T>
+// CHECK:   [[BORROW_BOX:%.*]] = begin_borrow [lexical] [var_decl] [[ALLOC_OF_BOX]]
+// CHECK:   [[PROJ_BOX:%.*]] = project_box [[BORROW_BOX]]
+// CHECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]]
+// CHECK:   switch_enum [[COPY_ARG]] : $Optional<@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <T>>, case #Optional.some!enumelt: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
+// CHECK: [[SOME_BB]]([[CLOSURE:%.*]] : @owned $@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <T>):
+// CHECK:   [[BORROW_CLOSURE:%.*]] = begin_borrow [[CLOSURE]]
+// CHECK:   [[CALL:%.*]] = apply [[BORROW_CLOSURE]]() : $@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <T>
+// CHECK:   [[SOME:%.*]] = enum $Optional<T>, #Optional.some!enumelt, [[CALL]] : $T
+// CHECK:   br [[CONT_BB:bb[0-9]+]]([[SOME]] : $Optional<T>)
+// CHECK: [[CONT_BB]]([[OPT:%.*]] : @owned $Optional<T>):
+// CHECK:   store [[OPT]] to [init] [[PROJ_BOX]] : $*Optional<T>
+// CHECK: [[NONE_BB]]:
+// CHECK:   [[ONONE:%.*]] = enum $Optional<T>, #Optional.none!enumelt
+// CHECK:   br [[CONT_BB]]([[ONONE]] : $Optional<T>)
 // CHECK-LABEL: } // end sil function '$ss19f390_addrCallResultyyxycSglF'
 func f390_addrCallResult<T>(_ f: (() -> T)?) {
   var x = f?()
@@ -837,11 +840,11 @@ func f390_addrCallResult<T>(_ f: (() -> T)?) {
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss16f400_maybeCloneP1cys8Clonable_p_tF : $@convention(thin) (@in_guaranteed any Clonable) -> () {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $any Clonable):
-// HECK:   [[OPEN_ARG:%.*]] = open_existential_value [[ARG]] : $any Clonable
-// HECK:   [[APPLY_OPAQUE:%.*]] = apply %{{.*}}<@opened({{.*}}, any Clonable) Self>([[OPEN_ARG]]) : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@in_guaranteed τ_0_0) -> @owned @callee_guaranteed () -> @out Optional<τ_0_0>
-// HECK:   [[PAPPLY:%.*]] = partial_apply [callee_guaranteed] %{{.*}}<@opened({{.*}}, any Clonable) Self>([[APPLY_OPAQUE]]) : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@guaranteed @callee_guaranteed () -> @out Optional<τ_0_0>) -> @out Optional<any Clonable>
+// CHECK:   [[CLOSURE_FN:%.*]] = function_ref @{{.*}} : $@convention(thin) (@in_guaranteed any Clonable) -> @owned @callee_guaranteed () -> @out Optional<any Clonable>
+// CHECK:   [[CLOSURE:%.*]] = apply [[CLOSURE_FN]]([[ARG]]) : $@convention(thin) (@in_guaranteed any Clonable) -> @owned @callee_guaranteed () -> @out Optional<any Clonable>
+// CHECK:   destroy_value [[CLOSURE]]
 // CHECK-NOT:   destroy_value [[ARG]]
-// HECK:   return %{{.*}} : $()
+// CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '$ss16f400_maybeCloneP1cys8Clonable_p_tF'
 func f400_maybeCloneP(c: Clonable) {
   let _: () -> Clonable? = c.maybeClone
@@ -851,13 +854,18 @@ func f400_maybeCloneP(c: Clonable) {
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss20f410_globalRvalueGetyBi64_Bi64_F : $@convention(thin) (Builtin.Int64) -> Builtin.Int64 {
 // CHECK: bb0([[ARG:%.*]] : $Builtin.Int64):
-// HECK:   [[GLOBAL_ADDR:%.*]] = global_addr @$s20opaque_values_silgen16subscriptableGetAA013SubscriptableE0_pvp : $*SubscriptableGet
-// HECK:   [[READ:%.*]] = begin_access [read] [dynamic] [[GLOBAL_ADDR]] : $*SubscriptableGet
-// HECK:   [[OPEN_ARG:%.*]] = open_existential_addr immutable_access [[READ]] : $*SubscriptableGet to $*@opened
-// HECK:   [[GET_OPAQUE:%.*]] = load [copy] [[OPEN_ARG]] : $*@opened
-// HECK:   [[RETVAL:%.*]] = apply %{{.*}}<@opened({{.*}}, SubscriptableGet) Self>([[ARG]], [[GET_OPAQUE]]) : $@convention(witness_method: SubscriptableGet) <τ_0_0 where τ_0_0 : SubscriptableGet> (Builtin.Int64, @in_guaranteed τ_0_0) -> Builtin.Int64
-// HECK:   destroy_value [[GET_OPAQUE]]
-// HECK:   return [[RETVAL]] : $Builtin.Int64
+// CHECK:   [[ADDRESSOR:%.*]] = function_ref @{{.*}} : $@convention(thin) () -> Builtin.RawPointer
+// CHECK:   [[RAW:%.*]] = apply [[ADDRESSOR]]()
+// CHECK:   [[GLOBAL_ADDR:%.*]] = pointer_to_address [[RAW]] : $Builtin.RawPointer to [strict] $*Optional<any SubscriptableGet>
+// CHECK:   [[READ:%.*]] = begin_access [read] [dynamic] [[GLOBAL_ADDR]] : $*Optional<any SubscriptableGet>
+// CHECK:   switch_enum_addr [[READ]] : $*Optional<any SubscriptableGet>, case #Optional.some!enumelt: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: {{bb[0-9]+}}
+// CHECK: [[SOME_BB]]:
+// CHECK:   [[PAYLOAD:%.*]] = unchecked_inplace_enum_data_addr [[READ]] : $*Optional<any SubscriptableGet>, #Optional.some!enumelt
+// CHECK:   [[OPEN_ARG:%.*]] = open_existential_addr immutable_access [[PAYLOAD]] : $*any SubscriptableGet to $*@opened
+// CHECK:   [[GET_OPAQUE:%.*]] = load [copy] [[OPEN_ARG]] : $*@opened
+// CHECK:   [[RETVAL:%.*]] = apply %{{.*}}<@opened({{.*}}, any SubscriptableGet) Self>([[ARG]], {{%.*}}) : $@convention(witness_method: SubscriptableGet) <τ_0_0 where τ_0_0 : SubscriptableGet> (Builtin.Int64, @in_guaranteed τ_0_0) -> Builtin.Int64
+// CHECK:   destroy_value [[GET_OPAQUE]]
+// CHECK:   return [[RETVAL]] : $Builtin.Int64
 // CHECK-LABEL: } // end sil function '$ss20f410_globalRvalueGetyBi64_Bi64_F'
 func f410_globalRvalueGet(_ i : Builtin.Int64) -> Builtin.Int64 {
   return subscriptableGet![i]
@@ -867,13 +875,19 @@ func f410_globalRvalueGet(_ i : Builtin.Int64) -> Builtin.Int64 {
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss20f420_globalLvalueGetyBi64_SgBi64_F : $@convention(thin) (Builtin.Int64) -> Optional<Builtin.Int64> {
 // CHECK: bb0([[ARG:%.*]] : $Builtin.Int64):
-// HECK:   [[GLOBAL_ADDR:%.*]] = global_addr @$s20opaque_values_silgen19subscriptableGetSetAA013SubscriptableeF0_pvp : $*SubscriptableGetSet
-// HECK:   [[READ:%.*]] = begin_access [read] [dynamic] [[GLOBAL_ADDR]] : $*SubscriptableGetSet
-// HECK:   [[OPEN_ARG:%.*]] = open_existential_addr immutable_access [[READ]] : $*SubscriptableGetSet to $*@opened
-// HECK:   [[GET_OPAQUE:%.*]] = load [copy] [[OPEN_ARG]] : $*@opened
-// HECK:   [[RETVAL:%.*]] = apply %{{.*}}<@opened({{.*}}, SubscriptableGetSet) Self>([[ARG]], [[GET_OPAQUE]]) : $@convention(witness_method: SubscriptableGetSet) <τ_0_0 where τ_0_0 : SubscriptableGetSet> (Builtin.Int64, @in_guaranteed τ_0_0) -> Builtin.Int64
-// HECK:   destroy_value [[GET_OPAQUE]]
-// HECK:   return [[RETVAL]] : $Builtin.Int64
+// CHECK:   [[ADDRESSOR:%.*]] = function_ref @{{.*}} : $@convention(thin) () -> Builtin.RawPointer
+// CHECK:   [[RAW:%.*]] = apply [[ADDRESSOR]]()
+// CHECK:   [[GLOBAL_ADDR:%.*]] = pointer_to_address [[RAW]] : $Builtin.RawPointer to [strict] $*Optional<any SubscriptableGetSet>
+// CHECK:   [[READ:%.*]] = begin_access [read] [dynamic] [[GLOBAL_ADDR]] : $*Optional<any SubscriptableGetSet>
+// CHECK:   switch_enum_addr [[READ]] : $*Optional<any SubscriptableGetSet>, case #Optional.some!enumelt: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: {{bb[0-9]+}}
+// CHECK: [[SOME_BB]]:
+// CHECK:   [[PAYLOAD:%.*]] = unchecked_inplace_enum_data_addr [[READ]] : $*Optional<any SubscriptableGetSet>, #Optional.some!enumelt
+// CHECK:   [[OPEN_ARG:%.*]] = open_existential_addr immutable_access [[PAYLOAD]] : $*any SubscriptableGetSet to $*@opened
+// CHECK:   [[GET_OPAQUE:%.*]] = load_borrow [[OPEN_ARG]] : $*@opened
+// CHECK:   [[RESULT:%.*]] = apply %{{.*}}<@opened({{.*}}, any SubscriptableGetSet) Self>([[ARG]], [[GET_OPAQUE]]) : $@convention(witness_method: SubscriptableGetSet) <τ_0_0 where τ_0_0 : SubscriptableGetSet> (Builtin.Int64, @in_guaranteed τ_0_0) -> Builtin.Int64
+// CHECK:   end_borrow [[GET_OPAQUE]]
+// CHECK:   [[RETVAL:%.*]] = enum $Optional<Builtin.Int64>, #Optional.some!enumelt, [[RESULT]] : $Builtin.Int64
+// CHECK:   return [[RETVAL]] : $Optional<Builtin.Int64>
 // CHECK-LABEL: } // end sil function '$ss20f420_globalLvalueGetyBi64_SgBi64_F'
 func f420_globalLvalueGet(_ i : Builtin.Int64) -> Builtin.Int64? {
   return subscriptableGetSet![i]
@@ -883,19 +897,21 @@ func f420_globalLvalueGet(_ i : Builtin.Int64) -> Builtin.Int64? {
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss21f430_callUnreachableF1tyx_tlF : $@convention(thin) <T> (@in_guaranteed T) -> () {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $T):
-// HECK:   [[APPLY_T:%.*]] = apply %{{.*}}<((T) -> (), T)>() : $@convention(thin) <τ_0_0> () -> @out Optional<(Builtin.Int64, τ_0_0)>
-// HECK:   switch_enum [[APPLY_T]] : $Optional<(Builtin.Int64, (@callee_guaranteed (@in_guaranteed T) -> @out (), T))>, case #Optional.some!enumelt: bb2, case #Optional.none!enumelt: bb1
-// HECK: bb2([[ENUMARG:%.*]] : $(Builtin.Int64, (@callee_guaranteed (@in_guaranteed T) -> @out (), T))):
-// HECK:   ([[TELEM0:%.*]], [[TELEM1:%.*]]) = destructure_tuple [[ENUMARG]] : $(Builtin.Int64, (@callee_guaranteed (@in_guaranteed T) -> @out (), T))
-// HECK:   ([[TELEM10:%.*]], [[TELEM11:%.*]]) = destructure_tuple [[TELEM1]] : $(@callee_guaranteed (@in_guaranteed T) -> @out (), T)
-// HECK:   [[PAPPLY:%.*]] = partial_apply [callee_guaranteed] %{{.*}}<T>([[TELEM10]]) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0, @guaranteed @callee_guaranteed (@in_guaranteed τ_0_0) -> @out ()) -> ()
-// HECK:   [[NEWT0:%.*]] = tuple ([[PAPPLY]] : $@callee_guaranteed (@in_guaranteed T) -> (), [[TELEM11]] : $T)
-// HECK:   [[NEWT1:%.*]] = tuple ([[TELEM0]] : $Builtin.Int64, [[NEWT0]] : $(@callee_guaranteed (@in_guaranteed T) -> (), T))
-// HECK:   [[NEWENUM:%.*]] = enum $Optional<(Builtin.Int64, (@callee_guaranteed (@in_guaranteed T) -> (), T))>, #Optional.some!enumelt, [[NEWT1]] : $(Builtin.Int64, (@callee_guaranteed (@in_guaranteed T) -> (), T))
-// HECK:   br bb3([[NEWENUM]] : $Optional<(Builtin.Int64, (@callee_guaranteed (@in_guaranteed T) -> (), T))>)
-// HECK: bb3([[ENUMIN:%.*]] : $Optional<(Builtin.Int64, (@callee_guaranteed (@in_guaranteed T) -> (), T))>):
-// HECK:   destroy_value [[ENUMIN]]
-// HECK:   return %{{.*}} : $()
+// CHECK:   [[APPLY_T:%.*]] = apply %{{.*}}<((T) -> (), T)>() : $@convention(thin) <τ_0_0> () -> @out Optional<(Builtin.Int64, τ_0_0)>
+// CHECK:   switch_enum [[APPLY_T]] : $Optional<(Builtin.Int64, (@callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0) -> @out τ_0_1 for <T, ()>, T))>, case #Optional.some!enumelt: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
+// CHECK: [[SOME_BB]]([[ENUMARG:%.*]] : @owned $(Builtin.Int64, (@callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0) -> @out τ_0_1 for <T, ()>, T))):
+// CHECK:   ([[TELEM0:%.*]], [[TELEM1:%.*]]) = destructure_tuple [[ENUMARG]]
+// CHECK:   ([[TELEM10:%.*]], [[TELEM11:%.*]]) = destructure_tuple [[TELEM1]]
+// CHECK:   [[CONVERTED:%.*]] = convert_function [[TELEM10]] {{.*}} to $@callee_guaranteed (@in_guaranteed T) -> @out ()
+// CHECK:   [[PAPPLY:%.*]] = partial_apply [callee_guaranteed] %{{.*}}<T>([[CONVERTED]]) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0, @guaranteed @callee_guaranteed (@in_guaranteed τ_0_0) -> @out ()) -> ()
+// CHECK:   [[PAPPLY_CONV:%.*]] = convert_function [[PAPPLY]] {{.*}} to $@callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <T>
+// CHECK:   [[NEWT0:%.*]] = tuple ([[PAPPLY_CONV]] : $@callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <T>, [[TELEM11]] : $T)
+// CHECK:   [[NEWT1:%.*]] = tuple ([[TELEM0]] : $Builtin.Int64, [[NEWT0]] : $(@callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <T>, T))
+// CHECK:   [[NEWENUM:%.*]] = enum $Optional<(Builtin.Int64, (@callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <T>, T))>, #Optional.some!enumelt, [[NEWT1]]
+// CHECK:   br [[CONT_BB:bb[0-9]+]]([[NEWENUM]] :
+// CHECK: [[CONT_BB]]([[ENUMIN:%.*]] : @owned
+// CHECK:   destroy_value [[ENUMIN]]
+// CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '$ss21f430_callUnreachableF1tyx_tlF'
 func f430_callUnreachableF<T>(t: T) {
   let _: (Builtin.Int64, ((T) -> (), T))? = unreachableF()
@@ -906,32 +922,32 @@ func f430_callUnreachableF<T>(t: T) {
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss20f440_cleanupEmissionyyxlF : $@convention(thin) <T> (@in_guaranteed T) -> () {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $T):
-// HECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]]
-// HECK:   checked_cast_value_br [[COPY_ARG]] : $T to $EmptyP, bb2, bb1
+// CHECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]]
+// CHECK:   checked_cast_br T in [[COPY_ARG]] : $T to any EmptyP, [[CAST_OK:bb[0-9]+]], [[CAST_FAIL:bb[0-9]+]]
 //
-// HECK: bb2([[PTYPE:%.*]] : $EmptyP):
-// HECK:   [[PSOME:%.*]] = enum $Optional<EmptyP>, #Optional.some!enumelt, [[PTYPE]] : $EmptyP
-// HECK:   br bb3([[PSOME]] : $Optional<EmptyP>)
+// CHECK: [[CAST_OK]]([[PTYPE:%.*]] : @owned $any EmptyP):
+// CHECK:   [[PSOME:%.*]] = enum $Optional<any EmptyP>, #Optional.some!enumelt, [[PTYPE]] : $any EmptyP
+// CHECK:   br [[MERGE_BB:bb[0-9]+]]([[PSOME]] : $Optional<any EmptyP>)
 //
-// HECK: bb3([[ENUMRES:%.*]] : $Optional<EmptyP>):
-// HECK:   switch_enum [[ENUMRES]] : $Optional<EmptyP>, case #Optional.some!enumelt: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
+// CHECK: [[CAST_FAIL]]([[FAILVAL:%.*]] : @owned $T):
+// CHECK:   destroy_value [[FAILVAL]]
+// CHECK:   [[NONE1:%.*]] = enum $Optional<any EmptyP>, #Optional.none!enumelt
+// CHECK:   br [[MERGE_BB]]([[NONE1]] : $Optional<any EmptyP>)
 //
-// HECK: [[NONE_BB]]:
-// HECK:   br [[NONE_TRAMPOLINE:bb[0-9]+]]
+// CHECK: [[MERGE_BB]]([[ENUMRES:%.*]] : @owned $Optional<any EmptyP>):
+// CHECK:   switch_enum [[ENUMRES]] : $Optional<any EmptyP>, case #Optional.some!enumelt: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
 //
-// HECK: [[NONE_TRAMPOLINE]]:
-// HECK:   br [[EPILOG_BB:bb[0-9]+]]
+// CHECK: [[SOME_BB]]([[ENUMRES2:%.*]] : @owned $any EmptyP):
+// CHECK:   [[X2:%.*]] = move_value [lexical] [var_decl] [[ENUMRES2]]
+// CHECK:   destroy_value [[X2]]
+// CHECK:   br [[EPILOG_BB:bb[0-9]+]]
 //
-// HECK: [[SOME_BB]]([[ENUMRES2:%.*]] : $EmptyP):
-// HECK:   br [[CONT_BB:bb[0-9]+]]
+// CHECK: [[NONE_BB]]:
+// CHECK:   br [[EPILOG_BB]]
 //
-// HECK: [[CONT_BB]]:
-// HECK:   destroy_value [[ENUMRES2]]
-// HECK:   br [[EPILOG_BB]]
-//
-// HECK: [[EPILOG_BB]]:
+// CHECK: [[EPILOG_BB]]:
 // CHECK-NOT:   destroy_value [[ARG]]
-// HECK:   return %{{.*}} : $()
+// CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '$ss20f440_cleanupEmissionyyxlF'
 func f440_cleanupEmission<T>(_ x: T) {
   guard let x2 = x as? EmptyP else { return }
@@ -941,16 +957,22 @@ func f440_cleanupEmission<T>(_ x: T) {
 
 // Test emitNativeToCBridgedNonoptionalValue.
 // ---
+// A stdlib intrinsic SILGen references when bridging an arbitrary value to
+// AnyObject; declaring it makes the bridging call below get emitted rather than
+// stubbed out.
+@_silgen_name("_bridgeAnythingToObjectiveC")
+func _bridgeAnythingToObjectiveC<T>(_ x: T) -> AnyObject
 // CHECK-objc-LABEL: sil hidden [ossa] @$ss14f470_nativeToC7fromAnyyXlyp_tF : $@convention(thin) (@in_guaranteed Any) -> @owned AnyObject {
-// CHECK-objc: bb0(%0 : $Any):
-// CHECK-objc: [[BORROW:%.*]] = begin_borrow %0 : $Any
-// CHECK-objc: [[SRC:%.*]] = copy_value [[BORROW]] : $Any
-// CHECK-objc: [[OPEN:%.*]] = open_existential_opaque [[SRC]] : $Any to $@opened
-// CHECK-objc: [[COPY:%.*]] = copy_value [[OPEN]] : $@opened
-// CHECK-objc: [[F:%.*]] = function_ref @$sf27_bridgeAnythingToObjectiveCyyXlxlF : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> @owned AnyObject
+// CHECK-objc: bb0([[ARG:%.*]] : @guaranteed $Any):
+// CHECK-objc: [[SRC:%.*]] = copy_value [[ARG]] : $Any
+// CHECK-objc: [[BORROW:%.*]] = begin_borrow [[SRC]] : $Any
+// CHECK-objc: [[OPEN:%.*]] = open_existential_value [[BORROW]] : $Any to $@opened("{{.*}}", Any) Self
+// CHECK-objc: [[COPY:%.*]] = copy_value [[OPEN]] : $@opened("{{.*}}", Any) Self
+// CHECK-objc: end_borrow [[BORROW]] : $Any
+// CHECK-objc: [[F:%.*]] = function_ref @_bridgeAnythingToObjectiveC : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> @owned AnyObject
 // CHECK-objc: [[RET:%.*]] = apply [[F]]<@opened("{{.*}}", Any) Self>([[COPY]]) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> @owned AnyObject
+// CHECK-objc: destroy_value [[COPY]] : $@opened("{{.*}}", Any) Self
 // CHECK-objc: destroy_value [[SRC]] : $Any
-// CHECK-objc: destroy_value %0 : $Any
 // CHECK-objc: return [[RET]] : $AnyObject
 // CHECK-objc-LABEL: } // end sil function '$ss14f470_nativeToC7fromAnyyXlyp_tF'
 #if _runtime(_ObjC)
@@ -964,11 +986,11 @@ func f470_nativeToC(fromAny any: Any) -> AnyObject {
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss13f480_getError04someC0yps0C0_p_tF : $@convention(thin) (@guaranteed any Error) -> @out Any {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $any Error):
-// HECK: [[VAL:%.*]] = open_existential_box_value [[ARG]] : $any Error to $@opened("{{.*}}", any Error) Self
-// HECK: [[COPY:%.*]] = copy_value [[VAL]] : $@opened("{{.*}}", any Error) Self
-// HECK: [[ANY:%.*]] = init_existential_value [[COPY]] : $@opened("{{.*}}", any Error) Self, $@opened("{{.*}}", any Error) Self, $Any
+// CHECK: [[VAL:%.*]] = open_existential_box_value [[ARG]] : $any Error to $@opened("{{.*}}", any Error) Self
+// CHECK: [[COPY:%.*]] = copy_value [[VAL]] : $@opened("{{.*}}", any Error) Self
+// CHECK: [[ANY:%.*]] = init_existential_value [[COPY]] : $@opened("{{.*}}", any Error) Self, $@opened("{{.*}}", any Error) Self, $Any
 // CHECK-NOT: destroy_value [[ARG]] : $any Error
-// HECK: return [[ANY]] : $Any
+// CHECK: return [[ANY]] : $Any
 // CHECK-LABEL: } // end sil function '$ss13f480_getError04someC0yps0C0_p_tF'
 func f480_getError(someError: Error) -> Any {
   return someError
@@ -978,16 +1000,17 @@ func f480_getError(someError: Error) -> Any {
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss15f500_getAnyHashys1P_pSgs14ConvertibleToP_pSgF : $@convention(thin) (@in_guaranteed Optional<any ConvertibleToP>) -> @out Optional<any P> {
 // CHECK: bb0(%0 : @guaranteed $Optional<any ConvertibleToP>):
-// HECK: [[COPY:%.*]] = copy_value [[ARG]] : $Optional<any ConvertibleToP>
-// HECK: [[DATA:%.*]] = unchecked_enum_data [[COPY]] : $Optional<any ConvertibleToP>, #Optional.some!enumelt
-// HECK: [[BORROW_DATA:%.*]] = begin_borrow [[DATA]] : $any ConvertibleToP
-// HECK: [[VAL:%.*]] = open_existential_value [[BORROW_DATA]] : $any ConvertibleToP to $@opened("{{.*}}", any ConvertibleToP) Self
-// HECK: [[WT:%.*]] = witness_method $@opened("{{.*}}", any ConvertibleToP) Self, #ConvertibleToP.asP : <Self where Self : ConvertibleToP> (Self) -> () -> P, [[VAL]] : $@opened("{{.*}}", any ConvertibleToP) Self : $@convention(witness_method: ConvertibleToP) <τ_0_0 where τ_0_0 : ConvertibleToP> (@in_guaranteed τ_0_0) -> @out any P
-// HECK: [[AS_P:%.*]] = apply [[WT]]<@opened("{{.*}}", any ConvertibleToP) Self>([[VAL]]) : $@convention(witness_method: ConvertibleToP) <τ_0_0 where τ_0_0 : ConvertibleToP> (@in_guaranteed τ_0_0) -> @out any P
-// HECK: [[ENUM:%.*]] = enum $Optional<any P>, #Optional.some!enumelt, [[AS_P]] : $any P
-// HECK: destroy_value [[DATA]] : $any ConvertibleToP
-// HECK: br bb{{.*}}([[ENUM]] : $Optional<any P>)
-// HECK: } // end sil function '$ss15f500_getAnyHashys1P_pSgs14ConvertibleToP_pSgF'
+// CHECK: [[COPY:%.*]] = copy_value %0 : $Optional<any ConvertibleToP>
+// CHECK: switch_enum [[COPY]] : $Optional<any ConvertibleToP>, case #Optional.some!enumelt: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: {{bb[0-9]+}}
+// CHECK: [[SOME_BB]]([[DATA:%.*]] : @owned $any ConvertibleToP):
+// CHECK: [[BORROW_DATA:%.*]] = begin_borrow [[DATA]] : $any ConvertibleToP
+// CHECK: [[VAL:%.*]] = open_existential_value [[BORROW_DATA]] : $any ConvertibleToP to $@opened("{{.*}}", any ConvertibleToP) Self
+// CHECK: [[WT:%.*]] = witness_method $@opened("{{.*}}", any ConvertibleToP) Self, #ConvertibleToP.asP : <Self where Self : ConvertibleToP> (Self) -> () -> any P, [[VAL]] : $@opened("{{.*}}", any ConvertibleToP) Self : $@convention(witness_method: ConvertibleToP) <τ_0_0 where τ_0_0 : ConvertibleToP> (@in_guaranteed τ_0_0) -> @out any P
+// CHECK: [[AS_P:%.*]] = apply [[WT]]<@opened("{{.*}}", any ConvertibleToP) Self>([[VAL]]) : $@convention(witness_method: ConvertibleToP) <τ_0_0 where τ_0_0 : ConvertibleToP> (@in_guaranteed τ_0_0) -> @out any P
+// CHECK: [[ENUM:%.*]] = enum $Optional<any P>, #Optional.some!enumelt, [[AS_P]] : $any P
+// CHECK: destroy_value [[DATA]] : $any ConvertibleToP
+// CHECK: br {{bb[0-9]+}}([[ENUM]] : $Optional<any P>)
+// CHECK: } // end sil function '$ss15f500_getAnyHashys1P_pSgs14ConvertibleToP_pSgF'
 func f500_getAnyHash(_ value: ConvertibleToP?) -> P? {
   return value?.asP()
 }
@@ -999,9 +1022,9 @@ public protocol FooPP {
 // ---
 // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$ss15f510_OpaqueSelfVyxGs5FooPPssADP3fooxyFTW : $@convention(witness_method: FooPP) <τ_0_0> (@in_guaranteed f510_OpaqueSelf<τ_0_0>) -> @out f510_OpaqueSelf<τ_0_0> {
 // CHECK: bb0(%0 : @guaranteed $f510_OpaqueSelf<τ_0_0>):
-// HECK:   [[FN:%.*]] = function_ref @$s20opaque_values_silgen21f510_OpaqueSelfV3fooACyxGyF : $@convention(method) <τ_0_0> (@in_guaranteed f510_OpaqueSelf<τ_0_0>) -> @out f510_OpaqueSelf<τ_0_0>
-// HECK:   [[RESULT:%.*]] = apply [[FN]]<τ_0_0>(%0) : $@convention(method) <τ_0_0> (@in_guaranteed f510_OpaqueSelf<τ_0_0>) -> @out f510_OpaqueSelf<τ_0_0>
-// HECK:   return [[RESULT]] : $f510_OpaqueSelf<τ_0_0>
+// CHECK:   [[FN:%.*]] = function_ref @$ss15f510_OpaqueSelfV3fooAByxGyF : $@convention(method) <τ_0_0> (@in_guaranteed f510_OpaqueSelf<τ_0_0>) -> @out f510_OpaqueSelf<τ_0_0>
+// CHECK:   [[RESULT:%.*]] = apply [[FN]]<τ_0_0>(%0) : $@convention(method) <τ_0_0> (@in_guaranteed f510_OpaqueSelf<τ_0_0>) -> @out f510_OpaqueSelf<τ_0_0>
+// CHECK:   return [[RESULT]] : $f510_OpaqueSelf<τ_0_0>
 // CHECK-LABEL: } // end sil function '$ss15f510_OpaqueSelfVyxGs5FooPPssADP3fooxyFTW'
 struct f510_OpaqueSelf<Base> : FooPP {
   var x: Base
@@ -1015,13 +1038,13 @@ struct f510_OpaqueSelf<Base> : FooPP {
 // ---
 // CHECK-LABEL: sil hidden [ossa] @$ss17f520_condTFromAnyyyyp_xtlF : $@convention(thin) <T> (@in_guaranteed Any, @in_guaranteed T) -> () {
 // CHECK: bb0([[ARG0:%.*]] : @guaranteed $Any, [[ARG1:%.*]] : @guaranteed $T):
-// HECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]]
-// HECK:   checked_cast_value_br [[COPY_ARG]] : $Any to $@callee_guaranteed (@in_guaranteed (Builtin.Int64, T)) -> @out (Builtin.Int64, T), bb2, bb1
-// HECK: bb2([[THUNK_PARAM:%.*]] : $@callee_guaranteed (@in_guaranteed (Builtin.Int64, T)) -> @out (Builtin.Int64, T)):
-// HECK:   [[THUNK_REF:%.*]] = function_ref @{{.*}} : $@convention(thin) <τ_0_0> (Builtin.Int64, @in_guaranteed τ_0_0, @guaranteed @callee_guaranteed (@in_guaranteed (Builtin.Int64, τ_0_0)) -> @out (Builtin.Int64, τ_0_0)) -> (Builtin.Int64, @out τ_0_0)
-// HECK:   partial_apply [callee_guaranteed] [[THUNK_REF]]<T>([[THUNK_PARAM]])
-// CHECK: bb6:
-// HECK:   return %{{.*}} : $()
+// CHECK:   [[COPY_ARG:%.*]] = copy_value [[ARG0]]
+// CHECK:   checked_cast_br Any in [[COPY_ARG]] : $Any to (Int64, T) -> (Int64, T), [[SUCCESS:bb[0-9]+]], {{bb[0-9]+}}
+// CHECK: [[SUCCESS]]([[CAST:%.*]] : @owned $@callee_guaranteed @substituted <{{.*}}> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1) -> @out τ_0_2 for <{{.*}}>):
+// CHECK:   [[CONVERTED:%.*]] = convert_function [[CAST]] {{.*}} to $@callee_guaranteed (@in_guaranteed Int64, @in_guaranteed T) -> @out (Int64, T)
+// CHECK:   [[THUNK_REF:%.*]] = function_ref @{{.*}} : $@convention(thin) <τ_0_0> (Int64, @in_guaranteed τ_0_0, @guaranteed @callee_guaranteed (@in_guaranteed Int64, @in_guaranteed τ_0_0) -> @out (Int64, τ_0_0)) -> (Int64, @out τ_0_0)
+// CHECK:   partial_apply [callee_guaranteed] [[THUNK_REF]]<T>([[CONVERTED]])
+// CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '$ss17f520_condTFromAnyyyyp_xtlF'
 func f520_condTFromAny<T>(_ x: Any, _ y: T) {
   if let f = x as? (Int64, T) -> (Int64, T) {
@@ -1032,21 +1055,24 @@ func f520_condTFromAny<T>(_ x: Any, _ y: T) {
 // Make sure that we insert a destroy of the box even though we used an Builtin.Int64 type.
 // CHECK-LABEL: sil [ossa] @$ss16f530_assignToVaryyF : $@convention(thin) () -> () {
 // CHECK: bb0:
-// HECK:   [[Y_BOX:%.*]] = alloc_box ${ var Builtin.Int64 }, var, name "y"
-// HECK:   [[PROJECT_Y_BOX:%.*]] = project_box [[Y_BOX]] : ${ var Builtin.Int64 }, 0
-// HECK:   [[X_BOX:%.*]] = alloc_box ${ var Any }, var, name "x"
-// HECK:   [[PROJECT_X_BOX:%.*]] = project_box [[X_BOX]] : ${ var Any }, 0
-// HECK:   [[ACCESS_PROJECT_Y_BOX:%.*]] = begin_access [read] [unknown] [[PROJECT_Y_BOX]] : $*Builtin.Int64
-// HECK:   [[Y:%.*]] = load [trivial] [[ACCESS_PROJECT_Y_BOX]] : $*Builtin.Int64
-// HECK:   [[Y_ANY_FOR_X:%.*]] = init_existential_value [[Y]] : $Builtin.Int64, $Builtin.Int64, $Any
-// HECK:   store [[Y_ANY_FOR_X]] to [init] [[PROJECT_X_BOX]]
-// HECK:   [[ACCESS_PROJECT_Y_BOX:%.*]] = begin_access [read] [unknown] [[PROJECT_Y_BOX]] : $*Builtin.Int64
-// HECK:   [[Y:%.*]] = load [trivial] [[ACCESS_PROJECT_Y_BOX]] : $*Builtin.Int64
-// HECK:   [[Y_ANY_FOR_Z:%.*]] = init_existential_value [[Y]] : $Builtin.Int64, $Builtin.Int64, $Any
-// HECK:   destroy_value [[Y_ANY_FOR_Z]]
-// HECK:   destroy_value [[X_BOX]]
-// HECK:   destroy_value [[Y_BOX]]
-// HECK: } // end sil function '$ss16f530_assignToVaryyF'
+// CHECK:   [[Y_BOX:%.*]] = alloc_box ${ var Int64 }, var, name "y"
+// CHECK:   [[Y_BOX_BORROW:%.*]] = begin_borrow [var_decl] [[Y_BOX]] : ${ var Int64 }
+// CHECK:   [[PROJECT_Y_BOX:%.*]] = project_box [[Y_BOX_BORROW]] : ${ var Int64 }, 0
+// CHECK:   [[X_BOX:%.*]] = alloc_box ${ var Any }, var, name "x"
+// CHECK:   [[X_BOX_BORROW:%.*]] = begin_borrow [lexical] [var_decl] [[X_BOX]] : ${ var Any }
+// CHECK:   [[PROJECT_X_BOX:%.*]] = project_box [[X_BOX_BORROW]] : ${ var Any }, 0
+// CHECK:   [[ACCESS1:%.*]] = begin_access [read] [unknown] [[PROJECT_Y_BOX]] : $*Int64
+// CHECK:   [[Y1:%.*]] = load [trivial] [[ACCESS1]] : $*Int64
+// CHECK:   [[Y_ANY_FOR_X:%.*]] = init_existential_value [[Y1]] : $Int64, $Int64, $Any
+// CHECK:   store [[Y_ANY_FOR_X]] to [init] [[PROJECT_X_BOX]]
+// CHECK:   [[ACCESS2:%.*]] = begin_access [read] [unknown] [[PROJECT_Y_BOX]] : $*Int64
+// CHECK:   [[Y2:%.*]] = load [trivial] [[ACCESS2]] : $*Int64
+// CHECK:   [[Y_ANY_FOR_Z:%.*]] = init_existential_value [[Y2]] : $Int64, $Int64, $Any
+// CHECK:   [[Z:%.*]] = move_value [lexical] [var_decl] [[Y_ANY_FOR_Z]] : $Any
+// CHECK:   destroy_value [[Z]]
+// CHECK:   destroy_value [[X_BOX]]
+// CHECK:   destroy_value [[Y_BOX]]
+// CHECK: } // end sil function '$ss16f530_assignToVaryyF'
 public func f530_assignToVar() {
   var y: Int64 = 3
   var x: Any = y
@@ -1060,19 +1086,20 @@ public func f530_assignToVar() {
 // ---
 // CHECK-LABEL: sil [ossa] @$ss16f540_takeDecoder4fromBi1_s0C0_p_tKF : $@convention(thin) (@in_guaranteed any Decoder) -> (Builtin.Int1, @error any Error) {
 // CHECK: bb0(%0 : @guaranteed $any Decoder):
-// HECK:  [[OPENED:%.*]] = open_existential_value %0 : $any Decoder to $@opened("{{.*}}", any Decoder) Self
-// HECK:  [[WT:%.*]] = witness_method $@opened("{{.*}}", any Decoder) Self, #Decoder.unkeyedContainer : <Self where Self : Decoder> (Self) -> () throws -> UnkeyedDecodingContainer, %3 : $@opened("{{.*}}", any Decoder) Self : $@convention(witness_method: Decoder) <τ_0_0 where τ_0_0 : Decoder> (@in_guaranteed τ_0_0) -> (@out UnkeyedDecodingContainer, @error any Error)
-// HECK:  try_apply [[WT]]<@opened("{{.*}}", any Decoder) Self>([[OPENED]]) : $@convention(witness_method: Decoder) <τ_0_0 where τ_0_0 : Decoder> (@in_guaranteed τ_0_0) -> (@out UnkeyedDecodingContainer, @error any Error), normal bb2, error bb1
+// CHECK:  [[OPENED:%.*]] = open_existential_value %0 : $any Decoder to $@opened("{{.*}}", any Decoder) Self
+// CHECK:  [[WT:%.*]] = witness_method $@opened("{{.*}}", any Decoder) Self, #Decoder.unkeyedContainer : <Self where Self : Decoder> (Self) -> () throws -> any UnkeyedDecodingContainer, [[OPENED]] : $@opened("{{.*}}", any Decoder) Self : $@convention(witness_method: Decoder) <τ_0_0 where τ_0_0 : Decoder> (@in_guaranteed τ_0_0) -> (@out any UnkeyedDecodingContainer, @error any Error)
+// CHECK:  try_apply [[WT]]<@opened("{{.*}}", any Decoder) Self>([[OPENED]]) : $@convention(witness_method: Decoder) <τ_0_0 where τ_0_0 : Decoder> (@in_guaranteed τ_0_0) -> (@out any UnkeyedDecodingContainer, @error any Error), normal [[NORMAL_BB:bb[0-9]+]], error {{bb[0-9]+}}
 //
-// CHECK:bb{{.*}}([[RET1:%.*]] : @owned $any UnkeyedDecodingContainer):
-// HECK:  [[BORROW2:%.*]] = begin_borrow [lexical] [var_decl] [[RET1]] : $any UnkeyedDecodingContainer
-// HECK:  [[OPENED2:%.*]] = open_existential_value [[BORROW2]] : $any UnkeyedDecodingContainer to $@opened("{{.*}}", any UnkeyedDecodingContainer) Self
-// HECK:  [[WT2:%.*]] = witness_method $@opened("{{.*}}", any UnkeyedDecodingContainer) Self, #UnkeyedDecodingContainer.isAtEnd!getter : <Self where Self : UnkeyedDecodingContainer> (Self) -> () -> Builtin.Int1, [[OPENED2]] : $@opened("{{.*}}", UnkeyedDecodingContainer) Self : $@convention(witness_method: UnkeyedDecodingContainer) <τ_0_0 where τ_0_0 : UnkeyedDecodingContainer> (@in_guaranteed τ_0_0) -> Builtin.Int1
-// HECK:  [[RET2:%.*]] = apply [[WT2]]<@opened("{{.*}}", any UnkeyedDecodingContainer) Self>([[OPENED2]]) : $@convention(witness_method: UnkeyedDecodingContainer) <τ_0_0 where τ_0_0 : UnkeyedDecodingContainer> (@in_guaranteed τ_0_0) -> Builtin.Int1
-// HECK:  end_borrow [[BORROW2]] : $any UnkeyedDecodingContainer
-// HECK:  destroy_value [[RET1]] : $any UnkeyedDecodingContainer
+// CHECK: [[NORMAL_BB]]([[RET1:%.*]] : @owned $any UnkeyedDecodingContainer):
+// CHECK:  [[CONTAINER:%.*]] = move_value [lexical] [var_decl] [[RET1]] : $any UnkeyedDecodingContainer
+// CHECK:  [[BORROW2:%.*]] = begin_borrow [[CONTAINER]] : $any UnkeyedDecodingContainer
+// CHECK:  [[OPENED2:%.*]] = open_existential_value [[BORROW2]] : $any UnkeyedDecodingContainer to $@opened("{{.*}}", any UnkeyedDecodingContainer) Self
+// CHECK:  [[WT2:%.*]] = witness_method $@opened("{{.*}}", any UnkeyedDecodingContainer) Self, #UnkeyedDecodingContainer.isAtEnd!getter : <Self where Self : UnkeyedDecodingContainer> (Self) -> () -> Builtin.Int1, [[OPENED2]] : $@opened("{{.*}}", any UnkeyedDecodingContainer) Self : $@convention(witness_method: UnkeyedDecodingContainer) <τ_0_0 where τ_0_0 : UnkeyedDecodingContainer> (@in_guaranteed τ_0_0) -> Builtin.Int1
+// CHECK:  [[RET2:%.*]] = apply [[WT2]]<@opened("{{.*}}", any UnkeyedDecodingContainer) Self>([[OPENED2]]) : $@convention(witness_method: UnkeyedDecodingContainer) <τ_0_0 where τ_0_0 : UnkeyedDecodingContainer> (@in_guaranteed τ_0_0) -> Builtin.Int1
+// CHECK:  end_borrow [[BORROW2]] : $any UnkeyedDecodingContainer
+// CHECK:  destroy_value [[CONTAINER]] : $any UnkeyedDecodingContainer
 // CHECK-NOT:  destroy_value %0 : $any Decoder
-// HECK:  return [[RET2]] : $Builtin.Int1
+// CHECK:  return [[RET2]] : $Builtin.Int1
 // CHECK-LABEL: } // end sil function '$ss16f540_takeDecoder4fromBi1_s0C0_p_tKF'
 public func f540_takeDecoder(from decoder: Decoder) throws -> Builtin.Int1 {
   let container = try decoder.unkeyedContainer()


### PR DESCRIPTION
The interior checks in these two SILGen tests were left disabled as "// HECK:" lines ever since the OSSA migration. This patch restores them to to live "// CHECK:" lines matching current opaque-values SILGen output.