### PR TITLE
Suppress spurious useless availability check warnings

### DIFF
--- a/lib/AST/AvailabilityScope.cpp
+++ b/lib/AST/AvailabilityScope.cpp
@@ -439,6 +439,8 @@ AvailabilityScope::getExplicitAvailabilityRange(AvailabilityDomain domain,
                                                 ASTContext &ctx) const {
   switch (getReason()) {
   case Reason::Root:
+  case Reason::SwitchStmt:
+  case Reason::SwitchStmtCaseBody:
     return std::nullopt;
 
   case Reason::Decl: {
@@ -459,8 +461,6 @@ AvailabilityScope::getExplicitAvailabilityRange(AvailabilityDomain domain,
   case Reason::GuardStmtFallthrough:
   case Reason::GuardStmtElseBranch:
   case Reason::WhileStmtBody:
-  case Reason::SwitchStmt:
-  case Reason::SwitchStmtCaseBody:
     // Availability is inherently explicit for all of these nodes.
     return getAvailabilityContext().getAvailabilityRange(domain, ctx);
   }

--- a/lib/AST/AvailabilityScopeBuilder.cpp
+++ b/lib/AST/AvailabilityScopeBuilder.cpp
@@ -1233,17 +1233,6 @@ private:
           if (isUnavailability.value())
             continue;
 
-          if (currentScope->getReason() == AvailabilityScope::Reason::Root)
-            continue;
-
-          // Don't warn about checks that are always true because the enclosing
-          // scope was inferred from a switch case body's matched enum element.
-          // The inference is invisible to the developer, making the diagnostic
-          // confusing.
-          if (currentScope->getReason() ==
-              AvailabilityScope::Reason::SwitchStmtCaseBody)
-            continue;
-
           // Skip diagnosing useless availability in fragile functions with
           // opaque result types since removing an availability check could
           // change the ABI of the function and result in a miscompilation.

--- a/test/Availability/availability_implicitly_unnecessary.swift
+++ b/test/Availability/availability_implicitly_unnecessary.swift
@@ -1,9 +1,0 @@
-// RUN: %target-typecheck-verify-swift -verify -target %target-cpu-apple-macosx11.2 -disable-objc-attr-requires-foundation-module
-// REQUIRES: OS=macosx
-
-@available(macOS 11.0, *)
-class Foo {
-    func foo() {
-        if #available(macOS 11.1, *) {}
-    }
-}

--- a/test/Availability/availability_unnecessary.swift
+++ b/test/Availability/availability_unnecessary.swift
@@ -1,14 +1,152 @@
-// Ensure that the `unnecessary check` availability warning is emitted when unnecessary due to
-// scope's explicit annotation
-
-// RUN: %target-typecheck-verify-swift -verify -target %target-cpu-apple-macosx11.2
+// RUN: %target-typecheck-verify-swift -verify -target %target-cpu-apple-macosx12.0
 // REQUIRES: OS=macosx
 
-@available(macOS 11.1, *)
-class Foo {
-    // expected-note@-1 {{enclosing scope here}}
-    func foo() {
-        // expected-warning@+1 {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}{{group-name=UselessAvailabilityCheck}}
-        if #available(macOS 11.0, *) {}
+enum MacOSVersions {
+  @available(macOS 10, *)
+  case macOS_10
+  @available(macOS 11, *)
+  case macOS_11
+  @available(macOS 12, *)
+  case macOS_12
+  @available(macOS 13, *)
+  case macOS_13
+}
+
+@available(macOS 11, *)
+func annotatedFunc( // expected-note 3 {{enclosing scope here}}
+  _ e: MacOSVersions,
+) {
+  if #available(macOS 10, *) { } // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}} {{group-name=UselessAvailabilityCheck}}
+  if #available(macOS 11, *) { } // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+  if #available(macOS 12, *) { }
+  if #available(macOS 13, *) { }
+  if #available(iOS 8.0, *) { }
+
+  if #unavailable(macOS 10) { }
+
+  func localFunc() {
+    if #available(macOS 10, *) { } // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+  }
+  localFunc()
+
+  // FIXME: [availability] Incorrect scope noted
+  switch e { // expected-note 3 {{enclosing scope here}}
+  case .macOS_10:
+    if #available(macOS 10, *) { _ = 1 } // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+  case .macOS_11:
+    if #available(macOS 11, *) { _ = 1 } // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+  case .macOS_12:
+    // FIXME: [availability] Spurious warning
+    if #available(macOS 12, *) { _ = 1 } // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+  case .macOS_13:
+    if #available(macOS 13, *) { _ = 1 }
+  }
+}
+
+@available(macOS 11, *)
+class AnnotatedClass { // expected-note {{enclosing scope here}}
+  func method() {
+    if #available(macOS 10, *) { } // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}} {{group-name=UselessAvailabilityCheck}}
+  }
+}
+
+@available(macOS 11, *)
+struct AnnotatedStruct { // expected-note {{enclosing scope here}}
+  func method() {
+    if #available(macOS 10, *) { } // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+  }
+}
+
+func testIfStmt() {
+  // This check is useless because it is below the deployment target,
+  // but it shouldn't warn since there's no scope to point to.
+  if #available(macOS 11, *) { }
+
+  if #available(macOS 13, *) { // expected-note {{enclosing scope here}}
+    if #available(macOS 10, *) { } // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+  }
+
+  if #available(macOS 13, *) {
+  } else {
+    if #available(macOS 12, *) { }
+    if #available(macOS 14, *) { }
+  }
+
+  if #available(macOS 11, *) { // expected-note 2 {{enclosing scope here}}
+  } else {
+    // This branch is unreachable because the deployment target is macOS 12.
+    // FIXME: [availability] Spurious warnings
+    if #available(macOS 10, *) { } // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+    if #available(macOS 13, *) { } // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+  }
+}
+
+func testGuardStmt() {
+  func gaurdAboveDeployment() {
+    guard #available(macOS 13, *) else { // expected-note {{enclosing scope here}}
+      if #available(macOS 12, *) { }
+      if #available(macOS 14, *) { }
+      return
     }
+    if #available(macOS 12, *) { } // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+    if #available(macOS 14, *) { }
+  }
+
+  func gaurdBelowDeployment() {
+    guard #available(macOS 11, *) else { // expected-note 2 {{enclosing scope here}}
+      // This branch is unreachable because the deployment target is macOS 12.
+      // FIXME: [availability] Spurious warnings
+      if #available(macOS 10, *) { } // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+      if #available(macOS 12, *) { } // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+      return
+    }
+    if #available(macOS 10, *) { } // FIXME: [availability] Should warn
+    if #available(macOS 12, *) { }
+  }
+}
+
+func testWhileStmt() {
+  while #available(macOS 13, *) { // expected-note {{enclosing scope here}}
+    if #available(macOS 10, *) { } // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+    break
+  }
+}
+
+func testSwitchStmt(
+  _ e: MacOSVersions,
+) {
+  // FIXME: [availability] Spurious warnings
+  switch e { // expected-note 3 {{enclosing scope here}}
+  case .macOS_10:
+    if #available(macOS 10, *) { _ = 1 } // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+  case .macOS_11:
+    if #available(macOS 11, *) { _ = 1 } // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+  case .macOS_12:
+    if #available(macOS 12, *) { _ = 1 } // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+  case .macOS_13:
+    if #available(macOS 13, *) { _ = 1 }
+  }
+}
+
+
+@available(macOS 11, *)
+@inlinable
+public func fragileFunc() { // expected-note {{enclosing scope here}}
+  if #available(macOS 10, *) { } // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+}
+
+public protocol Mystery { }
+public struct Secret: Mystery { public init() { } }
+public struct SuperSecret: Mystery { public init() { } }
+
+@available(macOS 11, *)
+@inlinable
+public func fragileFuncWithOpaqueResult() -> some Mystery {
+  // Removing an availability check from a fragile function (e.g. @inlinable)
+  // with an opaque result type could change the function's ABI, so the
+  // diagnostic is suppressed.
+  if #available(macOS 10, *) {
+    return Secret()
+  }
+  return SuperSecret()
 }

--- a/test/Availability/availability_unnecessary.swift
+++ b/test/Availability/availability_unnecessary.swift
@@ -29,15 +29,13 @@ func annotatedFunc( // expected-note 3 {{enclosing scope here}}
   }
   localFunc()
 
-  // FIXME: [availability] Incorrect scope noted
-  switch e { // expected-note 3 {{enclosing scope here}}
+  switch e {
   case .macOS_10:
-    if #available(macOS 10, *) { _ = 1 } // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+    if #available(macOS 10, *) { _ = 1 } // FIXME: [availability] Should be diagnosed
   case .macOS_11:
-    if #available(macOS 11, *) { _ = 1 } // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+    if #available(macOS 11, *) { _ = 1 } // FIXME: [availability] Should be diagnosed
   case .macOS_12:
-    // FIXME: [availability] Spurious warning
-    if #available(macOS 12, *) { _ = 1 } // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+    if #available(macOS 12, *) { _ = 1 }
   case .macOS_13:
     if #available(macOS 13, *) { _ = 1 }
   }
@@ -115,14 +113,13 @@ func testWhileStmt() {
 func testSwitchStmt(
   _ e: MacOSVersions,
 ) {
-  // FIXME: [availability] Spurious warnings
-  switch e { // expected-note 3 {{enclosing scope here}}
+  switch e {
   case .macOS_10:
-    if #available(macOS 10, *) { _ = 1 } // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+    if #available(macOS 10, *) { _ = 1 }
   case .macOS_11:
-    if #available(macOS 11, *) { _ = 1 } // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+    if #available(macOS 11, *) { _ = 1 }
   case .macOS_12:
-    if #available(macOS 12, *) { _ = 1 } // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+    if #available(macOS 12, *) { _ = 1 }
   case .macOS_13:
     if #available(macOS 13, *) { _ = 1 }
   }

--- a/test/Availability/availability_versions.swift
+++ b/test/Availability/availability_versions.swift
@@ -1347,51 +1347,6 @@ class NestedClassTest {
   class InnerClass : WidelyAvailableBase {}
 }
 
-// Useless #available(...) checks
-
-func functionWithDefaultAvailabilityAndUselessCheck(_ p: Bool) {
-// Default availability reflects minimum deployment: 10.9 and up
-
-  if #available(OSX 10.9, *) { // no-warning
-    let _ = globalFuncAvailableOn10_9()
-  }
-  
-  if #available(OSX 51, *) { // expected-note {{enclosing scope here}}
-    let _ = globalFuncAvailableOn51()
-    
-    if #available(OSX 51, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
-      let _ = globalFuncAvailableOn51()
-    }
-  }
-
-  if #available(OSX 10.9, *) { // expected-note {{enclosing scope here}}
-  } else {
-    // Make sure we generate a warning about an unnecessary check even if the else branch of if is dead.
-    if #available(OSX 51, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
-    }
-  }
-
-  // This 'if' is strictly to limit the scope of the guard fallthrough
-  if p {
-    guard #available(OSX 10.9, *) else { // expected-note {{enclosing scope here}}
-      // Make sure we generate a warning about an unnecessary check even if the else branch of guard is dead.
-      if #available(OSX 51, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
-      }
-    }
-  }
-
-  // We don't want * generate a warn about useless checks; the check may be required on
-  // another platform
-  if #available(iOS 8.0, *) {
-  }
-
-  if #available(OSX 51, *) {
-    // Similarly do not want '*' to generate a warning in a refined scope.
-    if #available(iOS 8.0, *) {
-    }
-  }
-}
-
 @available(OSX, unavailable)
 func explicitlyUnavailable() { } // expected-note 2{{'explicitlyUnavailable()' has been explicitly marked unavailable here}}
 
@@ -1417,40 +1372,6 @@ func functionWithUnavailableInDeadBranch() {
 
     explicitlyUnavailable() // expected-error {{'explicitlyUnavailable()' is unavailable}}
   }
-}
-
-@available(OSX, introduced: 51)
-func functionWithSpecifiedAvailabilityAndUselessCheck() { // expected-note 2{{enclosing scope here}}
-  if #available(OSX 10.9, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
-    let _ = globalFuncAvailableOn10_9()
-  }
-  
-  if #available(OSX 51, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
-    let _ = globalFuncAvailableOn51()
-  }
-}
-
-@available(OSX, introduced: 51)
-@inlinable
-public func fragileFunctionWithSpecifiedAvailabilityAndUselessCheck() { // expected-note {{enclosing scope here}}
-  if #available(OSX 51, *) { } // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
-}
-
-public protocol Mystery { }
-public struct Secret: Mystery {
-  public init() { }
-}
-public struct SuperSecret: Mystery {
-  public init() { }
-}
-
-@available(OSX, introduced: 51)
-@inlinable
-public func fragileFunctionWithSpecifiedAvailabilityUselessCheckAndOpaqueResult() -> some Mystery {
-  if #available(OSX 51, *) {
-    return Secret()
-  }
-  return SuperSecret()
 }
 
 // #available(...) outside if statement guards


### PR DESCRIPTION
`getExplicitAvailabilityRange` is supposed to return the version range that was explicitly written in source for a given scope. Switch statements and case bodies were incorrectly treated as representing "explicit" availability contexts, leading to spurious `#UselessAvailabilityCheck` warnings being emitted for checks that were only made useless by the deployment target.

This fix ensures `if #available` utility is not over-diagnosed in switch case bodies. Unfortunately, now it is under-diagnosed. The lazily expanded switch body availability scope prevents the builder from seeing explicit availability scopes that may contain the switch so diagnostics that should be emitted are not. Fixing this requires deeper work in the diagnostic implementation.