### PR TITLE
[6.4][Concurrency] Downgrade preconcurrency sendable proto + non-sendable …

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7591,6 +7591,12 @@ bool swift::checkSendableConformance(
   bool wasImplied = (conformance->getSourceKind() ==
                      ConformanceEntryKind::Implied);
 
+  // If Sendable came from a `@preconcurrency` protocol the error
+  // should be downgraded even with strict concurrency checking to
+  // allow clients time to address the new requirement.
+  bool impliedByPreconcurrencyProtocol =
+      check == SendableCheck::ImpliedByPreconcurrencyProtocol;
+
   // Sendable can only be used in the same source file.
   auto conformanceDecl = conformanceDC->getAsDecl();
   SendableCheckContext checkContext(conformanceDC, check);
@@ -7607,7 +7613,8 @@ bool swift::checkSendableConformance(
     if (!(nominal->hasClangNode() && wasImplied)) {
       conformanceDecl
           ->diagnose(diag::concurrent_value_outside_source_file, nominal)
-          .limitBehaviorUntilLanguageMode(behavior, LanguageMode::v6);
+          .limitBehaviorWithPreconcurrency(
+              behavior, impliedByPreconcurrencyProtocol, LanguageMode::v6);
 
       if (behavior == DiagnosticBehavior::Unspecified)
         return true;
@@ -7620,9 +7627,12 @@ bool swift::checkSendableConformance(
     // A non-final class cannot conform to `Sendable` unless it is protected by
     // global actor isolation.
     if (!classDecl->isSemanticallyFinal() && !isGlobalActorIsolated) {
-      classDecl->diagnose(diag::concurrent_value_nonfinal_class,classDecl->getName())
+      classDecl
+          ->diagnose(diag::concurrent_value_nonfinal_class,
+                     classDecl->getName())
           .fixItInsert(classDecl->getStartLoc(), "final ")
-          .limitBehaviorUntilLanguageMode(behavior, LanguageMode::v6);
+          .limitBehaviorWithPreconcurrency(
+              behavior, impliedByPreconcurrencyProtocol, LanguageMode::v6);
 
       if (behavior == DiagnosticBehavior::Unspecified)
         return true;
@@ -7646,12 +7656,16 @@ bool swift::checkSendableConformance(
             conformanceDecl
                 ->diagnose(diag::concurrent_value_nonsendable_superclass,
                            classDecl->getName())
-                .warnUntilLanguageMode(LanguageMode::future);
+                .limitBehaviorWithPreconcurrency(
+                    DiagnosticBehavior::Warning,
+                    impliedByPreconcurrencyProtocol, LanguageMode::future);
           } else {
             conformanceDecl
                 ->diagnose(diag::concurrent_value_nonsendable_superclass,
                            classDecl->getName())
-                .limitBehaviorUntilLanguageMode(behavior, LanguageMode::v6);
+                .limitBehaviorWithPreconcurrency(
+                    behavior, impliedByPreconcurrencyProtocol,
+                    LanguageMode::v6);
             isError = behavior == DiagnosticBehavior::Unspecified;
           }
 

--- a/test/Concurrency/concurrency_warnings.swift
+++ b/test/Concurrency/concurrency_warnings.swift
@@ -17,7 +17,7 @@ let rs = GlobalCounter() // expected-warning {{let 'rs' is not concurrency-safe 
 
 import GlobalVariables
 
-class MyError: Error { // expected-warning{{non-final class 'MyError' cannot conform to the 'Sendable' protocol; this is an error in the Swift 6 language mode}}
+class MyError: Error { // expected-warning{{non-final class 'MyError' cannot conform to the 'Sendable' protocol}}
   var storage = 0 // expected-warning{{stored property 'storage' of 'Sendable'-conforming class 'MyError' is mutable}}
 }
 

--- a/test/Concurrency/sendable_conformance_checking.swift
+++ b/test/Concurrency/sendable_conformance_checking.swift
@@ -219,11 +219,22 @@ class OtherIsolatedSendableSubclass: NonSendableSuperclass, Sendable {}
 protocol RefinesSendable: Sendable {}
 
 @available(SwiftStdlib 5.1, *)
+@preconcurrency protocol PreconcurrencyRefinesSendable: Sendable {}
+
+@available(SwiftStdlib 5.1, *)
 @MainActor
 class IsolatedImpliedSendableSubclass: NonSendableSuperclass, RefinesSendable {}
 // expected-warning@-1:7 {{class 'IsolatedImpliedSendableSubclass' cannot conform to the 'Sendable' protocol; this will be an error in a future Swift language mode}}
 // expected-note@-2:7 {{a 'Sendable' class cannot inherit from a non-Sendable class}}
 // expected-note@-3:40 {{inherits from non-Sendable class 'NonSendableSuperclass'}}
+
+// Warning even in future language version due to preconcurrency implied conformance.
+@available(SwiftStdlib 5.1, *)
+@MainActor
+class IsolatedPreconcurrencySendableSubclass: NonSendableSuperclass, PreconcurrencyRefinesSendable {}
+// expected-warning@-1:7 {{class 'IsolatedPreconcurrencySendableSubclass' cannot conform to the 'Sendable' protocol}}
+// expected-note@-2:7 {{a 'Sendable' class cannot inherit from a non-Sendable class}}
+// expected-note@-3:47 {{inherits from non-Sendable class 'NonSendableSuperclass'}}
 
 @available(SwiftStdlib 5.1, *)
 @MainActor

--- a/test/Concurrency/sendable_objc_protocol_attr.swift
+++ b/test/Concurrency/sendable_objc_protocol_attr.swift
@@ -41,7 +41,7 @@ extension MyObjCProtocol {
 }
 
 class K : NSObject, MyObjCProtocol {
-  // expected-warning@-1 {{non-final class 'K' cannot conform to the 'Sendable' protocol; this is an error in the Swift 6 language mode}}
+  // expected-warning@-1 {{non-final class 'K' cannot conform to the 'Sendable' protocol}}
   let test: String = "k"
 }
 
@@ -50,7 +50,7 @@ class UncheckedK : NSObject, MyObjCProtocol, @unchecked Sendable { // ok
 }
 
 class KRefined : NSObject, MyRefinedObjCProtocol {
-  // expected-warning@-1 {{non-final class 'KRefined' cannot conform to the 'Sendable' protocol; this is an error in the Swift 6 language mode}}
+  // expected-warning@-1 {{non-final class 'KRefined' cannot conform to the 'Sendable' protocol}}
   let test: String = "refined"
 }
 
@@ -74,9 +74,8 @@ protocol SwiftRefinesObjCProtocol : MyObjCProtocol {}
 do {
   class A : NSObject {}
 
-  // @preconcurrency P must not silence the warning.
   final class B : A, P {
-    // expected-warning@-1:15 {{class 'B' cannot conform to the 'Sendable' protocol; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1:15 {{class 'B' cannot conform to the 'Sendable' protocol}}
     // expected-note@-2:15 {{a 'Sendable' class cannot inherit from a non-Sendable class}}
     // expected-note@-3:19 {{inherits from non-Sendable class 'A'}}
   }
@@ -88,8 +87,8 @@ do {
   // it gets two similar warnings. Could be nice to collect all the reasons a
   // conformance is illegal into one diagnostic.
   class C : A, MyObjCProtocol {
-    // expected-warning@-1:9 {{non-final class 'C' cannot conform to the 'Sendable' protocol; this is an error in the Swift 6 language mode}}
-    // expected-warning@-2:9 {{class 'C' cannot conform to the 'Sendable' protocol; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1:9 {{non-final class 'C' cannot conform to the 'Sendable' protocol}}
+    // expected-warning@-2:9 {{class 'C' cannot conform to the 'Sendable' protocol}}
     // expected-note@-3:9 {{a 'Sendable' class cannot inherit from a non-Sendable class}}
     // expected-note@-4:13 {{inherits from non-Sendable class 'A'}}
     let test: String = "c"
@@ -106,14 +105,15 @@ do {
   }
 
   final class SwiftRefinedSub : A, SwiftRefinesObjCProtocol {
-    // expected-warning@-1:15 {{class 'SwiftRefinedSub' cannot conform to the 'Sendable' protocol; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1:15 {{class 'SwiftRefinedSub' cannot conform to the 'Sendable' protocol}}
     // expected-note@-2:15 {{a 'Sendable' class cannot inherit from a non-Sendable class}}
     // expected-note@-3:33 {{inherits from non-Sendable class 'A'}}
     let test: String = "refinedSub"
   }
 
+  // Conformance through P is @preconcurrency, downgrading the error even though Q isn't...
   final class PQSub : A, P, Q {
-    // expected-warning@-1:15 {{class 'PQSub' cannot conform to the 'Sendable' protocol; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1:15 {{class 'PQSub' cannot conform to the 'Sendable' protocol}}
     // expected-note@-2:15 {{a 'Sendable' class cannot inherit from a non-Sendable class}}
     // expected-note@-3:23 {{inherits from non-Sendable class 'A'}}
   }


### PR DESCRIPTION
- **Explanation**:
Adds a preconcurrency downgrade when `SendableCheck::ImpliedByPreconcurrencyProtocol` is true for implied sendable conformances.
- **Scope**:
This shouldn't be able to break existing code. It should allow more code to compile, specifically Swift 6 conformances to prconcurrency sendable protocols. It allows libraries to evolve concurrency annotations on their protocols even when they have Swift 6 consumers that might conform on nonfinal / nonsendable classes, without breaking their consumers. I think these cases were just forgotten about wrt preconcurrency + Swift 6, and as more clients adopt Swift 6 it would be really good to allow libraries to keep adding annotations without breaking their consumers. Without this change, this protocol adoption would break a Swift 6 consumer:
```swift
@preconcurrency protocol DataProcessor: Sendable
```
```swift
class MyProcessor: DataProcessor // error
```
- **Issues**:
rdar://175462525, https://github.com/swiftlang/swift/issues/88637
- **Original PRs**:
https://github.com/swiftlang/swift/pull/90108
- **Risk**:
We could potentially change how these diagnostics are emitted, although I don't see how since we would already have been emitting an error to reach this point. If the conformance is considered to be implied by preconcurrency is dependent on the order of the protocols (in the case where multiple protocols refine `Sendable`), but while unfortunate that's already the case for the other preconcurrency sendable conformance downgrades.
- **Testing**:
Just the tests in this PR
- **Reviewers**:
@xedin 