### PR TITLE
[Sema] Suppress non-Sendable superclass diagnostic for inherited isolation

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7684,7 +7684,13 @@ bool swift::checkSendableConformance(
       if (auto superclassDecl = classDecl->getSuperclassDecl()) {
         // `NSObject` is permitted as a superclass for Objective-C interop.
         // TODO: can `NSObject` be `Sendable` or `~Sendable` instead?
-        if (!superclassDecl->isNSObject()) {
+        // Synthesizing a Sendable conformance for global-actor-isolated
+        // classes with non-Sendable superclasses was a mistake, but we
+        // maintain it for source compatibility. When the conformance
+        // is implicit (the user never wrote Sendable), skip the
+        // diagnostic entirely.
+        if (!superclassDecl->isNSObject() &&
+            !(isGlobalActorIsolated && isImplicitSendableCheck(check))) {
           // Inheritance checking for global-actor-isolated classes was
           // historically skipped, so we need to downgrade this to a warning to
           // stage it in.

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -393,6 +393,34 @@ final class C14: Sendable { // expected-warning{{default initializer for 'C14' c
   @SomeActor let nc1 = NotConcurrent()
 }
 
+// Synthesizing an implicit Sendable conformance for global-actor-isolated
+// classes with non-Sendable superclasses was a mistake, but it is maintained
+// for source compatibility. When Sendable is not explicitly stated, the
+// diagnostic is suppressed.
+@MainActor
+class IsolatedNonSendable: NotSendable {}
+
+final class InheritedIsolationSubclass: IsolatedNonSendable {}
+
+func requiresSendable<T: Sendable>(_: T.Type) {}
+func testInheritedIsolationIsSendable() {
+  requiresSendable(InheritedIsolationSubclass.self)
+}
+
+// When Sendable IS explicitly requested, the diagnostic should still fire.
+protocol RefinesSendable: Sendable {}
+
+final class InheritedIsolationExplicitSendable: IsolatedNonSendable, Sendable {}
+// expected-warning @-1 {{class 'InheritedIsolationExplicitSendable' cannot conform to the 'Sendable' protocol; this will be an error in a future Swift language mode}}
+// expected-note @-2 {{a 'Sendable' class cannot inherit from a non-Sendable class}}
+// expected-note @-3 {{inherits from non-Sendable class 'IsolatedNonSendable'}}
+
+@MainActor
+final class IsolatedRefinedSendable: NotSendable, RefinesSendable {}
+// expected-warning @-1 {{class 'IsolatedRefinedSendable' cannot conform to the 'Sendable' protocol; this will be an error in a future Swift language mode}}
+// expected-note @-2 {{a 'Sendable' class cannot inherit from a non-Sendable class}}
+// expected-note @-3 {{inherits from non-Sendable class 'NotSendable'}}
+
 extension NotConcurrent {
   func f() { }
 

--- a/test/Concurrency/concurrent_value_checking_objc.swift
+++ b/test/Concurrency/concurrent_value_checking_objc.swift
@@ -1,5 +1,6 @@
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -strict-concurrency=complete %s -emit-sil -o /dev/null -verify -verify-additional-prefix ni-
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -strict-concurrency=complete %s -emit-sil -o /dev/null -verify -verify-additional-prefix ni-ns- -enable-upcoming-feature NonisolatedNonsendingByDefault
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -strict-concurrency=complete %s -emit-sil -o /dev/null -verify -verify-additional-prefix ni- -verify-additional-prefix swift5-
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -strict-concurrency=complete %s -emit-sil -o /dev/null -verify -verify-additional-prefix ni-ns- -verify-additional-prefix swift5- -enable-upcoming-feature NonisolatedNonsendingByDefault
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-sil -o /dev/null -verify -verify-additional-prefix ni- -verify-additional-prefix swift6- -swift-version 6
 
 // REQUIRES: concurrency
 // REQUIRES: objc_interop
@@ -13,17 +14,21 @@ final class A: NSObject, Sendable {
 }
 
 final class B: NSObject, Sendable {
-  var x: Int = 5 // expected-warning{{stored property 'x' of 'Sendable'-conforming class 'B' is mutable}}
+  var x: Int = 5
+  // expected-swift5-warning @-1 {{stored property 'x' of 'Sendable'-conforming class 'B' is mutable}}
+  // expected-swift6-error @-2 {{stored property 'x' of 'Sendable'-conforming class 'B' is mutable}}
 }
 
 class C { } // expected-note{{class 'C' does not conform to the 'Sendable' protocol}}
 
 final class D: NSObject, Sendable {
-  let c: C = C() // expected-warning{{stored property 'c' of 'Sendable'-conforming class 'D' has non-Sendable type 'C'}}
+  let c: C = C()
+  // expected-swift5-warning @-1 {{stored property 'c' of 'Sendable'-conforming class 'D' has non-Sendable type 'C'}}
+  // expected-swift6-error @-2 {{stored property 'c' of 'Sendable'-conforming class 'D' has non-Sendable type 'C'}}
 }
 
 @MainActor
-final class IsolatedNSObjectSubclass: NSObject, Sendable {}
+class IsolatedNSObjectSubclass: NSObject, Sendable {}
 
 class NSObjectSubclass: NSObject {}
 
@@ -33,4 +38,13 @@ class IsolatedObjCSubclass: NSObjectSubclass, Sendable {}
 // expected-note@-2:7 {{a 'Sendable' class cannot inherit from a non-Sendable class}}
 // expected-note@-3:29 {{inherits from non-Sendable class 'NSObjectSubclass'}}
 
+// NSObject is Sendable, so @MainActor subclasses of NSObject inherit
+// Sendable through the normal inherited-conformance path. Their subclasses
+// should also be Sendable with no diagnostic.
+class InheritedFromIsolatedNSObject: IsolatedNSObjectSubclass {}
 
+func requiresSendable<T: Sendable>(_: T.Type) {}
+func testNSObjectChainIsSendable() {
+  requiresSendable(IsolatedNSObjectSubclass.self)
+  requiresSendable(InheritedFromIsolatedNSObject.self)
+}


### PR DESCRIPTION
## Summary

When a class inherits global actor isolation from its superclass rather than declaring `@MainActor` directly, the compiler incorrectly emits a `NonSendableSuperclass` diagnostic even though the class never declares `Sendable` conformance.

```swift
public class NonSendableSuperclass {}

@MainActor
public class IsolatedNonSendable: NonSendableSuperclass {}

// On main this produces a spurious warning:
//   class 'InheritedIsolationSubclass' cannot conform to the 'Sendable' protocol
//   a 'Sendable' class cannot inherit from a non-Sendable class
//   inherits from non-Sendable class 'IsolatedNonSendable'
public final class InheritedIsolationSubclass: IsolatedNonSendable {}
```

The expected behavior is no diagnostic. The class does not declare `Sendable`, so no implicit conformance should be formed.

The same bug fires for classes that pick up `@MainActor` via file-level default isolation (`using @MainActor`).

## Root cause

In `GetImplicitSendableRequest::evaluate`, there is a guard that suppresses implicit `Sendable` for global-actor-isolated classes with non-Sendable superclasses:

```cpp
if (nominal->getGlobalActorAttr() && !superclassDecl->isNSObject()) {
    return nullptr;
}
```

`getGlobalActorAttr()` evaluates `GlobalActorAttributeRequest`, which scans the declaration's custom attributes for an explicit `@MainActor`. When isolation is inherited from a superclass or inferred from default file isolation, there is no explicit attribute on the declaration at the time this request evaluates, so `getGlobalActorAttr()` returns `nullopt` and the guard does not fire.

The code then falls through to `getActorIsolation(nominal).isGlobalActor()`, which resolves isolation through all inference paths including superclass inheritance. This returns true, so an implicit `Sendable` conformance is formed. `checkSendableConformance` then finds the non-Sendable superclass and emits the diagnostic.

## Fix

Handle this in `checkSendableConformance`: when the conformance is implicit (`isImplicitSendableCheck`) and the class is global-actor-isolated with a non-Sendable, non-NSObject superclass, silently invalidate the conformance via `setInvalid()` instead of diagnosing. The user never asked for `Sendable`, so we simply withhold the conformance without producing a diagnostic.

## Testing

- Added `test/Concurrency/default_isolation_sendable_superclass.swift` covering the inherited-isolation case
- Verified the test fails on unpatched main with the spurious diagnostic
- Verified the test passes with the fix
- Existing sendable tests all pass: `sendable_conformance_checking.swift`, `sendable_objc_protocol_attr.swift`, `unavailable_sendable_conformance.swift`, `concurrent_value_checking_objc.swift`