### PR TITLE
[Distributed][Windows] Fix witness table allocation style for windows

### DIFF
--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -3083,7 +3083,12 @@ swift_distributed_getWitnessTables(GenericEnvironmentDescriptor *genericEnv,
   if (witnessTables.empty())
     return {/*ptr=*/nullptr, 0};
 
-  void **tables = (void **)malloc(witnessTables.size() * sizeof(void *));
+  // Note: this MUST be swift_slowAlloc because it will be deallocated with
+  // Unsafe*Pointer which uses swift_slowDealloc which will use aligned deallocation.
+  // On Windows, aligned deallocations must match aligned allocations, even if
+  // other platforms are more flexible here.
+  void **tables = (void **)swift_slowAlloc(
+      witnessTables.size() * sizeof(void *), ~size_t(0));
   for (unsigned i = 0, n = witnessTables.size(); i != n; ++i)
     tables[i] = const_cast<void *>(witnessTables[i]);
 

--- a/test/Distributed/Runtime/distributed_actor_resolvable_any_some_param.swift
+++ b/test/Distributed/Runtime/distributed_actor_resolvable_any_some_param.swift
@@ -11,7 +11,6 @@
 //
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
-// UNSUPPORTED: OS=windows-msvc
 
 // This test exercises the **remote-branch** wire round-trip for a
 // `distributed func` that takes a `some/any P` parameter where `P` is a


### PR DESCRIPTION
Follow up for https://github.com/swiftlang/swift/pull/89411/

The witness tables allocated in swift_distributed_getWitnessTables were allocated using malloc, but then released in Swift with UnsafePointer which causes swift_slowDealloc.

On Windows, both allocation and deallocation must be done in aligned mode with the alloc was; so here we have a mismatch which Windows then crashes on during dealloc.

Thanks @al45tair for finding this; I'll follow up if perhaps we unblocked other tests as well with this