### PR TITLE
LifetimeDependenceDiagnostics: handle withoutActuallyEscaping thunks

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
@@ -53,9 +53,7 @@ let lifetimeDependenceDiagnosticsPass = FunctionPass(
   log("\(function)")
   log("\(function.convention)")
 
-  for argument in function.arguments
-      where !argument.type.isEscapable(in: function) && !argument.type.rawType.fullyUnwrappedType.isLoweredFunction
-  {
+  for argument in function.arguments where !argument.type.isEscapable(in: function) {
     // Indirect results are not checked here. Type checking ensures
     // that they have a lifetime dependence.
     if let lifetimeDep = LifetimeDependence(argument, context) {

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
@@ -66,10 +66,21 @@ let lifetimeDependenceDiagnosticsPass = FunctionPass(
     if let markDep = instruction as? MarkDependenceInstruction, markDep.isUnresolved {
       if let lifetimeDep = LifetimeDependence(markDep, context) {
         if analyze(dependence: lifetimeDep, context) {
+          // A mark_dependence that forwards an escapable value currently must be marked "escaping". Marking it
+          // nonescaping requires proving that all of the dependent uses including projections are discoverable (it
+          // cannot have any "pointer-escape" uses), and all those uses are within the base lifetime. The
+          // LifetimeDependenceDefUseWalker, however, simply ignores escapable values and reports success. Until we have
+          // a separate analysis for escapable values, conservatively mark them as "escaping" even when lifetime
+          // dependence analysis succeeded.
+          let objectType = markDep.valueOrAddress.type.objectType
+          if (objectType.mayEscape(in: function) && !objectType.isTrivial(in: function)) {
+            markDep.settleToEscaping(context)
+            continue
+          }
           // Note: This promotes the mark_dependence flag but does not invalidate analyses; preserving analyses is good,
           // although the change won't appear in -sil-print-function. Ideally, we could notify context of a flag change
           // without invalidating analyses.
-          lifetimeDep.resolve(context)
+          markDep.resolveToNonEscaping(context)
           continue
         }
       }

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceInsertion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceInsertion.swift
@@ -113,6 +113,9 @@ extension LifetimeDependentApply {
     if let beginApply = applySite as? BeginApplyInst {
       return getYieldDependenceSources(beginApply: beginApply)
     }
+    // applySite.captureDependence is ignored here because captures are always an inherited dependence relative to the
+    // apply site's callee operand (whenever the callee is copied the closure context is copied). We don't insert any
+    // mark_dependence for inherited dependencies.
     for operand in applySite.parameterOperands {
       guard let dep = applySite.resultDependence(on: operand) else {
         continue

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -765,6 +765,12 @@ extension LifetimeDependenceDefUseWalker {
     if let apply = operand.instruction as? FullApplySite {
       return visitAppliedUse(of: operand, by: apply)
     }
+    // withoutActuallyEscaping captures a noescape closure while returning an escaping closure.
+    if let pa = operand.instruction as? PartialApplyInst,
+       let closureFunction = pa.referencedFunction,
+       closureFunction.isWithoutActuallyEscapingThunk {
+      return .continueWalk
+    }
     if operand.instruction is ReturnInstruction, !operand.value.isEscapable {
       return returnedDependence(result: operand)
     }
@@ -851,6 +857,13 @@ extension LifetimeDependenceDefUseWalker {
   }
 
   mutating func pointerEscapingUse(of operand: Operand) -> WalkResult {
+    // OwnershipUseVisitor calls pointerEscapingUse for an escaping mark_dependence. If, however, the dependent value is
+    // escapable, then it can be ignored by lifetime dependence analysis, which generally ignores escapable
+    // values. SILGen may generate an escaping mark_dependence for patterns that don't otherwise have proper ownership
+    // support, e.g. createWithoutActuallyEscapingClosure().
+    if let mdi = operand.instruction as? MarkDependenceInst, operand == mdi.baseOperand, mdi.mayEscape {
+      return .continueWalk
+    }
     return escapingDependence(on: operand)
   }
 

--- a/SwiftCompilerSources/Sources/SIL/ApplySite.swift
+++ b/SwiftCompilerSources/Sources/SIL/ApplySite.swift
@@ -280,6 +280,10 @@ extension ApplySite {
     functionConvention.resultDependencies != nil
   }
 
+  public var captureDependence: LifetimeDependenceConvention? {
+    (functionConvention.resultDependencies?.hasCaptures ?? false) ? .inherit : nil
+  }
+
   public func isAddressable(operand: Operand) -> Bool {
     for targetOperand in argumentOperands {
       guard !targetOperand.value.isEscapable else {

--- a/SwiftCompilerSources/Sources/SIL/Function.swift
+++ b/SwiftCompilerSources/Sources/SIL/Function.swift
@@ -283,6 +283,10 @@ final public class Function : CustomStringConvertible, HasShortDescription, Hash
     }
   }
 
+  /// True if this is a reabstraction thunk of escaping function type whose
+  /// single argument is a potentially non-escaping closure.
+  public var isWithoutActuallyEscapingThunk: Bool { bridged.isWithoutActuallyEscapingThunk() }
+
   public var accessorKindName: String? {
     guard bridged.isAccessor() else {
       return nil

--- a/SwiftCompilerSources/Sources/SIL/FunctionConvention.swift
+++ b/SwiftCompilerSources/Sources/SIL/FunctionConvention.swift
@@ -357,6 +357,7 @@ extension FunctionConvention {
     let bridged: BridgedLifetimeDependenceInfo
     let paramCount: Int
     let hasSelfParam: Bool
+    let hasCaptures: Bool
 
     init(bridged: BridgedLifetimeDependenceInfo, parameterCount: Int,
          hasSelfParameter: Bool) {
@@ -364,6 +365,7 @@ extension FunctionConvention {
       self.bridged = bridged
       self.paramCount = parameterCount
       self.hasSelfParam = hasSelfParameter
+      self.hasCaptures = bridged.hasCaptures
     }
 
     public var startIndex: Int { 0 }
@@ -394,8 +396,10 @@ extension FunctionConvention {
     }
 
     public var description: String {
-      String(taking: bridged.getDebugDescription()) +
-        "\nparamCount: \(paramCount) self: \(hasSelfParam)"
+      String(taking: bridged.getDebugDescription()) + """
+        paramCount: \(paramCount) self: \(hasSelfParam) \
+        hasCaptures: \(hasCaptures)
+        """
     }
   }
 }

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -581,6 +581,7 @@ struct BridgedFunction {
   BRIDGED_INLINE bool hasValidLinkageForFragileRef(SerializedKind) const;
   BRIDGED_INLINE ThunkKind isThunk() const;
   BRIDGED_INLINE void setThunk(ThunkKind) const;
+  BRIDGED_INLINE bool isWithoutActuallyEscapingThunk() const;
   BRIDGED_INLINE bool needsStackProtection() const;
   BRIDGED_INLINE bool shouldOptimize() const;
   BRIDGED_INLINE bool isReferencedInModule() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -945,6 +945,10 @@ void BridgedFunction::setThunk(ThunkKind kind) const {
   getFunction()->setThunk((swift::IsThunk_t)kind);
 }
 
+bool BridgedFunction::isWithoutActuallyEscapingThunk() const {
+  return getFunction()->isWithoutActuallyEscapingThunk();
+}
+
 BridgedFunction::SerializedKind BridgedFunction::getSerializedKind() const {
   return (SerializedKind)getFunction()->getSerializedKind();
 }

--- a/test/SILGen/addressors.swift
+++ b/test/SILGen/addressors.swift
@@ -185,7 +185,7 @@ func test_carray(_ array: inout CArray<(Int32) -> Int32>) -> Int32 {
 // CHECK:   [[T1:%.*]] = apply [[T0]]<(Int32) -> Int32>({{%.*}}, [[WRITE]])
 // CHECK:   [[T2:%.*]] = struct_extract [[T1]] : $UnsafeMutablePointer<(Int32) -> Int32>, #UnsafeMutablePointer._rawValue
 // CHECK:   [[T3:%.*]] = pointer_to_address [[T2]] : $Builtin.RawPointer to [strict] $*@callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0) -> @out τ_0_1 for <Int32, Int32>
-// CHECK:   [[MD:%.*]] = mark_dependence [nonescaping] [[T3]] : $*@callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0) -> @out τ_0_1 for <Int32, Int32> on [[WRITE]] : $*CArray<(Int32) -> Int32>
+// CHECK:   [[MD:%.*]] = mark_dependence [[T3]] : $*@callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0) -> @out τ_0_1 for <Int32, Int32> on [[WRITE]] : $*CArray<(Int32) -> Int32>
 // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unsafe] [[MD]]
 // CHECK:   store {{%.*}} to [[ACCESS]] :
   array[0] = id_int

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_closure.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_closure.swift
@@ -2,6 +2,7 @@
 // RUN:   -o /dev/null \
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
+// RUN:   -disable-availability-checking \
 // RUN:   -module-name test \
 // RUN:   -enable-experimental-feature Lifetimes
 
@@ -239,4 +240,48 @@ func copyClosureNE(body: () -> NE) -> NE {
 func callCopyClosureNE(ne: NE) -> NE {
   let neo = copyClosureNE { ne }
   return neo
+}
+
+// =============================================================================
+// easily recognizable patterns involving the capture of an array's span
+
+func closure_array_int(_: [Int], _ f: ()->Int) -> Int { f() }
+
+func testCaptureSpanReturnElement(array: consuming [Int]) -> Int {
+  let span = array.span
+  return closure_array_int(array) { span[0] }
+}
+
+func closure_consuming_array_int(_: consuming [Int], _ f: ()->Int) -> Int { f() }
+
+func testConsumeAndCaptureSpanReturnElement(array: consuming [Int]) -> Int {
+  // expected-error@-1{{'array' used after consume}}
+  let span = array.span // expected-note{{conflicting access is here}}
+  return closure_consuming_array_int(array) { span[0] }
+  // expected-error@-1{{overlapping accesses to 'array', but deinitialization requires exclusive access}}
+  // expected-note@-2{{consumed here}}
+}
+
+func closure_span(_ f: ()->Span<Int>) -> Span<Int> { f() }
+
+func testArgSpanCaptureReturnSpan(array: [Int]) -> Span<Int> {
+  let span = array.span
+  return closure_span { span }
+}
+
+@_lifetime(immortal)
+func testConsumingArgSpanCaptureReturnSpan(array: consuming [Int]) -> Span<Int> {
+  let span = array.span // expected-note{{it depends on this scoped access to variable 'array'}}
+  return closure_span { span }
+  // expected-error@-1{{lifetime-dependent value escapes its scope}}
+  // expected-note@-2{{this use causes the lifetime-dependent value to escape}}
+}
+
+@_lifetime(immortal)
+func testLocalSpanCaptureReturnSpan() -> Span<Int> {
+  let array = [1,2,3] // expected-note{{it depends on the lifetime of variable 'array'}}
+  let span = array.span
+  return closure_span { span }
+  // expected-error@-1{{lifetime-dependent value escapes its scope}}
+  // expected-note@-2{{this use causes the lifetime-dependent value to escape}}
 }

--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics.sil
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics.sil
@@ -4,7 +4,7 @@
 // RUN:   -sil-verify-all \
 // RUN:   -enable-experimental-feature Lifetimes \
 // RUN:   -enable-experimental-feature AddressableTypes \
-// RUN:   -o /dev/null
+// RUN:   | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_Lifetimes
@@ -451,29 +451,65 @@ bb0(%0 : $*BorrowWrapper<T>, %1 : $*T, %2 : $@thin BorrowWrapper<T>.Type):
   return %15
 }
 
+sil [reabstraction_thunk] [without_actually_escaping] @noescape_to_escape_thunk : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> ()) -> ()
+
 // rdar://177381648: error: lifetime-dependent variable escapes its scope
 //
-// Test that lifetime diagnostics are disabled for @noescape function arguments.
-// The diagnostics would fail here because the mark_dependence is on the conditionally unwrapped value.
-sil @noescape_to_escape_thunk : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> ()) -> ()
-
-sil shared [serialized] [thunk] [ossa] @testNoEscapeBlockEscape : $@convention(thin) (@owned Optional<@noescape @callee_guaranteed () -> ()>) -> () {
+// Test that a noescape closure can be captured by an escaping closure. Normally, the DiagnoseInvalidEscapes diagnostics
+// catches cases like this, but it ignores thunks. This is required for withoutActuallyEscaping to work. Lifetime
+// diagnostics simply needs to ignore escapable values. In this example that means ignoring the result of both:
+// 1. the partial_apply which captures a noescape closure and returns an escaping closure
+// 2. the mark_dependence which forwards an escaping closure
+sil shared [serialized] [thunk] [ossa] @testNoEscapeThunkEscape : $@convention(thin) (@owned Optional<@noescape @callee_guaranteed () -> ()>) -> () {
 bb0(%0 : @owned $Optional<@noescape @callee_guaranteed () -> ()>):
   switch_enum %0, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
 
-bb1(%3 : @owned $@noescape @callee_guaranteed () -> ()):
-  %4 = copy_value %3
-  %5 = function_ref @noescape_to_escape_thunk : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> ()) -> ()
-  %6 = partial_apply [callee_guaranteed] %5(%4) : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> ()) -> ()
-  %7 = mark_dependence [unresolved] %6 on %3
-  destroy_value %7
-  destroy_value %3
-  br bb3
+bb1(%2 : @owned $@noescape @callee_guaranteed () -> ()):
+  %3 = copy_value %2
+
+  %4 = function_ref @noescape_to_escape_thunk : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> ()) -> ()
+  %5 = partial_apply [callee_guaranteed] %4(%3) : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> ()) -> ()
+  %6 = mark_dependence %5 on %2
+  %7 = enum $Optional<@callee_guaranteed () -> ()>, #Optional.some!enumelt, %6
+  destroy_value %2
+  br bb3(%7)
 
 bb2:
-  br bb3
+  %10 = enum $Optional<@callee_guaranteed () -> ()>, #Optional.none!enumelt
+  br bb3(%10)
 
-bb3:
-  %tup = tuple ()
-  return %tup
+bb3(%12 : @owned $Optional<@callee_guaranteed () -> ()>):
+  destroy_value %12
+  %14 = tuple ()
+  return %14
+}
+
+// This is the same as the above case except that mark_dependence is still [unresolved]. The diagnostic pass should
+// settle it as an escaping mark_dependence since it doesn't actually verify the escapable dependency uses.
+//
+// CHECK-LABEL: sil shared [serialized] [thunk] [ossa] @testNoEscapeThunkEscapeUnresolved : $@convention(thin) (@owned Optional<@noescape @callee_guaranteed () -> ()>) -> () {
+// CHECK: mark_dependence %{{.*}}
+// CHECK-LABEL: } // end sil function 'testNoEscapeThunkEscapeUnresolved'
+sil shared [serialized] [thunk] [ossa] @testNoEscapeThunkEscapeUnresolved : $@convention(thin) (@owned Optional<@noescape @callee_guaranteed () -> ()>) -> () {
+bb0(%0 : @owned $Optional<@noescape @callee_guaranteed () -> ()>):
+  switch_enum %0, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
+
+bb1(%2 : @owned $@noescape @callee_guaranteed () -> ()):
+  %3 = copy_value %2
+
+  %4 = function_ref @noescape_to_escape_thunk : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> ()) -> ()
+  %5 = partial_apply [callee_guaranteed] %4(%3) : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> ()) -> ()
+  %6 = mark_dependence [unresolved] %5 on %2
+  %7 = enum $Optional<@callee_guaranteed () -> ()>, #Optional.some!enumelt, %6
+  destroy_value %2
+  br bb3(%7)
+
+bb2:
+  %10 = enum $Optional<@callee_guaranteed () -> ()>, #Optional.none!enumelt
+  br bb3(%10)
+
+bb3(%12 : @owned $Optional<@callee_guaranteed () -> ()>):
+  destroy_value %12
+  %14 = tuple ()
+  return %14
 }

--- a/test/SILOptimizer/unsafeAddress.swift
+++ b/test/SILOptimizer/unsafeAddress.swift
@@ -54,7 +54,7 @@ func mod(_ nc: inout NC) {}
 
 // CHECK-LABEL: sil hidden @$s4main11testCBorrow1cyAA1CC_tF : $@convention(thin) (@guaranteed C) -> () {
 // CHECK: [[ADR:%.*]] = pointer_to_address %4 to [strict] $*NC
-// CHECK: [[MD:%.*]] = mark_dependence [nonescaping] [[ADR]] on %0
+// CHECK: [[MD:%.*]] = mark_dependence [[ADR]] on %0
 // CHECK: begin_access [read] [unsafe] [[MD]]
 // CHECK: apply
 // CHECK: end_access
@@ -65,7 +65,7 @@ func testCBorrow(c: C) {
 
 // CHECK-LABEL: sil hidden @$s4main8testCMod1cyAA1CC_tF : $@convention(thin) (@guaranteed C) -> () {
 // CHECK: [[ADR:%.*]] = pointer_to_address %{{.*}} to [strict] $*NC
-// CHECK: [[MD:%.*]] = mark_dependence [nonescaping] [[ADR]] on %0
+// CHECK: [[MD:%.*]] = mark_dependence [[ADR]] on %0
 // CHECK: begin_access [modify] [unsafe] [[MD]]
 // CHECK: apply
 // CHECK: end_access
@@ -76,7 +76,7 @@ func testCMod(c: C) {
 
 // CHECK-LABEL: sil hidden @$s4main11testSBorrow1syAA1SV_tF : $@convention(thin) (@guaranteed S) -> () {
 // CHECK: [[ADR:%.*]] = pointer_to_address %{{.*}} to [strict] $*NC
-// CHECK: [[MD:%.*]] = mark_dependence [nonescaping] [[ADR]] on %0
+// CHECK: [[MD:%.*]] = mark_dependence [[ADR]] on %0
 // CHECK: begin_access [read] [unsafe] [[MD]]
 // CHECK: apply
 // CHECK: end_access
@@ -88,7 +88,7 @@ func testSBorrow(s: S) {
 // CHECK-LABEL: sil hidden @$s4main8testSMod1syAA1SVz_tF : $@convention(thin) (@inout S) -> () {
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [static] %0
 // CHECK: [[ADR:%.*]] = pointer_to_address %{{.*}} to [strict] $*NC
-// CHECK: [[MD:%.*]] = mark_dependence [nonescaping] [[ADR]] on [[ACCESS]]
+// CHECK: [[MD:%.*]] = mark_dependence [[ADR]] on [[ACCESS]]
 // CHECK: begin_access [modify] [unsafe] [[MD]]
 // CHECK: apply
 // CHECK: end_access
@@ -103,7 +103,7 @@ func testSMod(s: inout S) {
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [static] %0
 // CHECK: [[LD:%.*]] = load [[ACCESS]]
 // CHECK: [[ADR:%.*]] = pointer_to_address %{{.*}} to [strict] $*NC
-// CHECK: [[MD:%.*]] = mark_dependence [nonescaping] [[ADR]] on [[LD]]
+// CHECK: [[MD:%.*]] = mark_dependence [[ADR]] on [[LD]]
 // CHECK: begin_access [read] [unsafe] [[MD]]
 // CHECK: apply
 // CHECK: end_access
@@ -116,7 +116,7 @@ func testSInoutBorrow(mut_s s: inout S) {
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [static] %0
 // CHECK: [[LD:%.*]] = load [[ACCESS]]
 // CHECK: [[ADR:%.*]] = pointer_to_address %{{.*}} to [strict] $*NC
-// CHECK: [[MD:%.*]] = mark_dependence [nonescaping] [[ADR]] on [[ACCESS]]
+// CHECK: [[MD:%.*]] = mark_dependence [[ADR]] on [[ACCESS]]
 // CHECK: begin_access [read] [unsafe] [[MD]]
 // CHECK: apply
 // CHECK: end_access
@@ -128,7 +128,7 @@ func testSInoutMutBorrow(mut_s s: inout S) {
 // CHECK-LABEL: sil hidden @$s4main13testSInoutMod5mut_syAA1SVz_tF : $@convention(thin) (@inout S) -> () {
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [static] %0
 // CHECK: [[ADR:%.*]] = pointer_to_address %{{.*}} to [strict] $*NC
-// CHECK: [[MD:%.*]] = mark_dependence [nonescaping] [[ADR]] on [[ACCESS]]
+// CHECK: [[MD:%.*]] = mark_dependence [[ADR]] on [[ACCESS]]
 // CHECK: begin_access [modify] [unsafe] [[MD]]
 // CHECK: apply
 // CHECK: end_access
@@ -139,7 +139,7 @@ func testSInoutMod(mut_s s: inout S) {
 
 // CHECK-LABEL: sil hidden @$s4main13testSNCBorrow3sncyAA3SNCV_tF : $@convention(thin) (@guaranteed SNC) -> () {
 // CHECK: [[ADR:%.*]] = pointer_to_address %{{.*}} to [strict] $*NC
-// CHECK: [[MD:%.*]] = mark_dependence [nonescaping] [[ADR]] on %0
+// CHECK: [[MD:%.*]] = mark_dependence [[ADR]] on %0
 // CHECK: begin_access [read] [unsafe] [[MD]]
 // CHECK: apply
 // CHECK: end_access
@@ -150,7 +150,7 @@ func testSNCBorrow(snc: borrowing SNC) {
 
 // CHECK-LABEL: sil hidden @$s4main16testSNCMutBorrow3sncyAA3SNCV_tF : $@convention(thin) (@guaranteed SNC) -> () {
 // CHECK: [[ADR:%.*]] = pointer_to_address %{{.*}} to [strict] $*NC
-// CHECK: [[MD:%.*]] = mark_dependence [nonescaping] [[ADR]] on %0
+// CHECK: [[MD:%.*]] = mark_dependence [[ADR]] on %0
 // CHECK: begin_access [read] [unsafe] [[MD]]
 // CHECK: apply
 // CHECK: end_access
@@ -162,7 +162,7 @@ func testSNCMutBorrow(snc: borrowing SNC) {
 // CHECK-LABEL: sil hidden @$s4main10testSNCMod7mut_sncyAA3SNCVz_tF : $@convention(thin) (@inout SNC) -> () {
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [static] %0
 // CHECK: [[ADR:%.*]] = pointer_to_address %{{.*}} to [strict] $*NC
-// CHECK: [[MD:%.*]] = mark_dependence [nonescaping] [[ADR]] on [[ACCESS]]
+// CHECK: [[MD:%.*]] = mark_dependence [[ADR]] on [[ACCESS]]
 // CHECK: begin_access [modify] [unsafe] [[MD]]
 // CHECK: apply
 // CHECK: end_access


### PR DESCRIPTION
- **[NFC] Bridge LifetimeDependencyInfo::hasCaptures to Swift**
  Make this flag available as ApplySite.captureDependence alongside
  hasResultDependencies so clients don't forget to check it as easily.
  

- **[NFC] bridge isWithoutActuallyEscapingThunk to Swift**
  Bridge SILFunction.isWithoutActuallyEscapingThunk() to SwiftCompilerSources.
  

- **LifetimeDependenceDiagnostics: handle withoutActuallyEscaping thunks**
  This is fall-out from making noescape function types behave like ~Escapable
  types.
  
  When SILGen generates a call to a withoutActuallyEscaping thunk it emits
  an escaping mark_dependence on the escapable closure that depends on the
  non-escaping closure. Lifetime diagnostics do not currently analyze the
  lifetime of escapable values. Simply ignore such dependencies for the purpose of
  lifetime diagnostics.
  
  We should also handle the same situation when the mark_dependence is initially
  marked unresolved. But in this case, simply ignored the dependence would caused
  it to be marked nonescaping. This can result in a SIL ownership violation. Some
  SIL patterns involving ObjC blocks actually violate the required OSSA
  conditions. Instead, conservative mark the depenence as "escaping."
  
  Re-fixes rdar://177381648 error: lifetime-dependent variable 'eventActionBlock'
  escapes its scope)
  

- **Reenable LifetimeDependenceDiagnostics on function-type parameters**
  This was disabled in:
  https://github.com/swiftlang/swift/pull/89310
  
  But completely disabling this case is a safety hole because we now allow a
  function to return a closure's result that depends only on the closure captures,
  but we never actually insert a mark_dependence for closure captures.
  

- **Add closure capture unit tests involving array spans.**
  Add some easily recognizable patterns involving closures and array spans to
  quickly verify that basic closure lifetime analysis is enabled.
  