### PR TITLE
[cxx-interop] Add memory consumption statistics

### DIFF
--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -92,6 +92,35 @@ FRONTEND_STATISTIC(Frontend, WallClockMicroseconds)
 /// Maximum number of bytes allocated via malloc.
 FRONTEND_STATISTIC(Frontend, MaxMallocUsage)
 
+/// Convenience sum of the accounted Clang memory: clang ASTContext
+/// bump-allocator + side tables + malloc-backed loaded-module buffers. Excludes
+/// mmap-backed .pcm buffers, which are file-backed/demand-paged and not
+/// necessarily resident.
+FRONTEND_STATISTIC(ClangImporter, ClangTotalBytes)
+
+/// Total bytes held by the Swift ASTContext (all arenas, including the solver).
+FRONTEND_STATISTIC(AST, SwiftASTContextBytes)
+
+/// Bytes held by the single shared Clang ASTContext (bump allocator + side
+/// tables). Covers all imported Clang modules together; cannot be split per
+/// module because they share one ASTContext.
+FRONTEND_STATISTIC(ClangImporter, ClangASTContextBytes)
+
+/// In-memory bytes of mmap-backed loaded-module (.pcm) buffers. Informational:
+/// mapped, not necessarily resident; excluded from ClangTotalBytes.
+FRONTEND_STATISTIC(ClangImporter, ClangModuleBufferBytesMMap)
+
+/// In-memory bytes of malloc-backed loaded-module (.pcm) buffers (resident heap).
+FRONTEND_STATISTIC(ClangImporter, ClangModuleBufferBytesMalloc)
+
+/// Number of Clang modules loaded by the importer's ASTReader.
+FRONTEND_STATISTIC(ClangImporter, NumLoadedClangModules)
+
+/// Number of Clang decls actually deserialized (materialized) into the shared
+/// ASTContext, summed across modules. Per-module breakdown is emitted separately
+/// (clang-module-memory.json / -print-clang-stats).
+FRONTEND_STATISTIC(ClangImporter, NumMaterializedClangDecls)
+
 /// Number of source buffers visible in the source manager.
 FRONTEND_STATISTIC(AST, NumSourceBuffers)
 

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -593,6 +593,50 @@ public:
   // Print statistics from the Clang AST reader.
   void printStatistics() const override;
 
+  /// Per-module memory information for a single loaded Clang module.
+  struct ClangModuleMemoryInfo {
+    std::string moduleName;
+    /// In-memory size of the serialized module (.pcm) buffer. This is the
+    /// serialized bitstream, not the deserialized AST.
+    uint64_t inMemoryBufferBytes = 0;
+    /// Whether the buffer is mmap-backed (file-backed/demand-paged) rather than
+    /// malloc-backed (resident heap).
+    bool bufferIsMMapped = false;
+    /// Total entities serialized in the module on disk (upper bound).
+    uint64_t onDiskDecls = 0;
+    uint64_t onDiskTypes = 0;
+    uint64_t onDiskIdentifiers = 0;
+    uint64_t onDiskMacros = 0;
+    /// Decls actually deserialized (materialized) into the shared ASTContext.
+    /// Only populated when a stats reporter is active (see DeclRead listener).
+    uint64_t materializedDecls = 0;
+  };
+
+  /// Aggregate Clang memory statistics plus a per-module breakdown. All imported
+  /// modules share a single ASTContext, so the deserialized-AST byte figure is
+  /// aggregate; per-module data is buffer bytes + entity counts.
+  struct ClangMemoryStats {
+    /// Bytes held by the shared Clang ASTContext (bump allocator + side tables).
+    uint64_t astContextBytes = 0;
+    /// In-memory bytes of mmap-backed loaded-module buffers (informational).
+    uint64_t moduleBufferMMapBytes = 0;
+    /// In-memory bytes of malloc-backed loaded-module buffers (resident heap).
+    uint64_t moduleBufferMallocBytes = 0;
+    uint64_t numLoadedModules = 0;
+    uint64_t numMaterializedDecls = 0;
+    std::vector<ClangModuleMemoryInfo> perModule;
+  };
+
+  /// Collect Clang memory statistics for the importer's main instance.
+  ClangMemoryStats getClangMemoryStats() const;
+
+  /// Enable per-module materialized-decl tracking by the deserialization
+  /// listener. Should be called soon after importer creation; decls deserialized
+  /// before this call (e.g. while setting up a bridging header) are not counted,
+  /// but module-import deserialization (the bulk) is. Off by default to avoid
+  /// per-decl overhead in builds that don't request memory statistics.
+  void enableMemoryStatistics();
+
   /// Dump Swift lookup tables.
   void dumpSwiftLookupTables() const override;
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -165,6 +165,7 @@ namespace {
 
   class PCHDeserializationCallbacks : public clang::ASTDeserializationListener {
     ClangImporter::Implementation &Impl;
+    clang::ASTReader *Reader = nullptr;
   public:
     explicit PCHDeserializationCallbacks(ClangImporter::Implementation &impl)
       : Impl(impl) {}
@@ -176,11 +177,25 @@ namespace {
     }
 
     void ReaderInitialized(clang::ASTReader *Reader) override {
+      // Stash the reader so DeclRead can map decls back to their owning module.
+      this->Reader = Reader;
+
       if (!Impl.IsReadingBridgingPCH)
         return;
 
       if (Impl.CASIDForPCH)
         Reader->getModuleManager().getPrimaryModule().CASID = *Impl.CASIDForPCH;
+    }
+
+    void DeclRead(clang::GlobalDeclID ID, const clang::Decl *D) override {
+      // Attribute each materialized (deserialized) decl to its owning serialized
+      // module, so we can report per-module in-RAM AST cost. Only tracked when
+      // memory-stat collection is enabled, to avoid per-decl overhead in normal
+      // builds.
+      if (!Impl.CollectMemoryStats || !Reader)
+        return;
+      if (auto *MF = Reader->getOwningModuleFile(ID))
+        ++Impl.MaterializedDeclsPerModule[MF];
     }
   };
 
@@ -4585,8 +4600,91 @@ ClangImporter::importDeclCached(const clang::NamedDecl *ClangDecl) {
   return Impl.importDeclCached(ClangDecl, Impl.CurrentVersion);
 }
 
+void ClangImporter::enableMemoryStatistics() {
+  Impl.CollectMemoryStats = true;
+}
+
+ClangImporter::ClangMemoryStats ClangImporter::getClangMemoryStats() const {
+  ClangMemoryStats stats;
+  // All imported modules share one ASTContext, so this is the aggregate
+  // deserialized-AST cost across every module (it cannot be split per module).
+  auto &clangCtx = Impl.getClangASTContext();
+  stats.astContextBytes =
+      clangCtx.getASTAllocatedMemory() + clangCtx.getSideTableAllocatedMemory();
+
+  auto *reader = Impl.Instance->getASTReader().get();
+  if (!reader)
+    return stats;
+
+  auto &moduleMgr = reader->getModuleManager();
+  stats.numLoadedModules = moduleMgr.size();
+  stats.perModule.reserve(stats.numLoadedModules);
+
+  for (clang::serialization::ModuleFile &MF : moduleMgr) {
+    ClangModuleMemoryInfo info;
+    info.moduleName = MF.ModuleName;
+    if (MF.Buffer) {
+      // In-memory size of the serialized (.pcm) bitstream buffer. The buffer
+      // may be malloc-backed (heap-allocated) or mmap-backed (file-backed and
+      // demand-paged). These are reported separately because their cost to the
+      // process differs and is hard to attribute uniformly (e.g. mmap pages may
+      // be shared or paged out, and CAS-backed storage differs again).
+      info.inMemoryBufferBytes = MF.Buffer->getBufferSize();
+      info.bufferIsMMapped =
+          MF.Buffer->getBufferKind() == llvm::MemoryBuffer::MemoryBuffer_MMap;
+      if (info.bufferIsMMapped)
+        stats.moduleBufferMMapBytes += info.inMemoryBufferBytes;
+      else
+        stats.moduleBufferMallocBytes += info.inMemoryBufferBytes;
+    }
+    info.onDiskDecls = MF.LocalNumDecls;
+    info.onDiskTypes = MF.LocalNumTypes;
+    info.onDiskIdentifiers = MF.LocalNumIdentifiers;
+    info.onDiskMacros = MF.LocalNumMacros;
+
+    auto it = Impl.MaterializedDeclsPerModule.find(&MF);
+    if (it != Impl.MaterializedDeclsPerModule.end()) {
+      info.materializedDecls = it->second;
+      stats.numMaterializedDecls += it->second;
+    }
+    stats.perModule.push_back(std::move(info));
+  }
+  return stats;
+}
+
 void ClangImporter::printStatistics() const {
   Impl.Instance->getASTReader()->PrintStats();
+
+  // Memory accounting summary + per-module breakdown.
+  auto stats = getClangMemoryStats();
+  uint64_t swiftBytes = Impl.SwiftContext.getTotalMemory();
+  auto &os = llvm::errs();
+  os << "\n*** Clang importer memory ***\n";
+  os << "Clang ASTContext bytes (shared, all modules): "
+     << stats.astContextBytes << "\n";
+  os << "Module buffer bytes (malloc):                 "
+     << stats.moduleBufferMallocBytes << "\n";
+  os << "Module buffer bytes (mmap):                   "
+     << stats.moduleBufferMMapBytes << "\n";
+  os << "Swift ASTContext bytes:                       " << swiftBytes << "\n";
+  os << "Loaded Clang modules: " << stats.numLoadedModules
+     << ", materialized decls: " << stats.numMaterializedDecls << "\n";
+
+  // Sort heaviest-first by materialized decls, then by buffer size.
+  llvm::stable_sort(stats.perModule,
+                    [](const ClangModuleMemoryInfo &a,
+                       const ClangModuleMemoryInfo &b) {
+                      if (a.materializedDecls != b.materializedDecls)
+                        return a.materializedDecls > b.materializedDecls;
+                      return a.inMemoryBufferBytes > b.inMemoryBufferBytes;
+                    });
+  os << "Per-module (sorted by materialized decls):\n";
+  os << "  materializedDecls / onDiskDecls  bufferBytes(kind)  module\n";
+  for (const auto &m : stats.perModule) {
+    os << "  " << m.materializedDecls << " / " << m.onDiskDecls << "  "
+       << m.inMemoryBufferBytes << (m.bufferIsMMapped ? "(mmap)" : "(malloc)")
+       << "  " << m.moduleName << "\n";
+  }
 }
 
 void ClangImporter::verifyAllModules() {

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -72,6 +72,9 @@ class ParmVarDecl;
 class Parser;
 class QualType;
 class TypedefNameDecl;
+namespace serialization {
+class ModuleFile;
+} // namespace serialization
 } // namespace clang
 
 namespace swift {
@@ -576,6 +579,20 @@ public:
 
   /// Mapping of already-imported declarations.
   llvm::DenseMap<std::pair<const clang::Decl *, Version>, Decl *> ImportedDecls;
+
+  /// Per-module count of Clang decls actually deserialized (materialized) into
+  /// the shared ASTContext, keyed by the owning serialized module. Populated by
+  /// the deserialization listener's DeclRead callback only when
+  /// \c CollectMemoryStats is set; used to attribute in-RAM AST cost per module
+  /// (the deserialized AST bytes themselves live in one shared allocator and
+  /// cannot be split).
+  llvm::DenseMap<const clang::serialization::ModuleFile *, uint64_t>
+      MaterializedDeclsPerModule;
+
+  /// When set, the deserialization listener records per-module materialized decl
+  /// counts. Enabled by \c -stats-output-dir or \c -print-clang-stats; off by
+  /// default to avoid per-decl overhead in normal builds.
+  bool CollectMemoryStats = false;
 
   /// The set of "special" typedef-name declarations, which are
   /// mapped to specific Swift types.

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -894,6 +894,12 @@ bool CompilerInstance::setUpModuleLoaders() {
     return true;
   }
 
+  // If memory statistics were requested, start tracking per-module materialized
+  // decl counts now, before any significant deserialization occurs.
+  if (FEOpts.CompilerDebuggingOpts.PrintClangStats ||
+      !FEOpts.StatsOutputDir.empty())
+    clangImporter->enableMemoryStatistics();
+
   // Configure ModuleInterfaceChecker for the ASTContext.
   auto const &Clang = clangImporter->getClangInstance();
   std::string ModuleCachePath = ModuleCachePathFromInvocation.empty()

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -96,6 +96,7 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/JSON.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/Process.h"
 #include "llvm/Support/VirtualOutputBackend.h"
 #include "llvm/Support/VirtualOutputBackends.h"
 #include "llvm/Support/raw_ostream.h"
@@ -259,6 +260,54 @@ static void countStatsOfSourceFile(UnifiedStatsReporter &Stats,
     SM.getEntireTextForBuffer(SF->getBufferID()).count('\n');
 }
 
+/// Emit the per-module Clang memory breakdown as a dedicated JSON file in the
+/// stats output directory. The fixed FRONTEND_STATISTIC schema can only hold
+/// aggregate scalars, so the variable-length per-module data goes here. This is
+/// best-effort: a failure to write must not fail the compilation.
+///
+/// The driver forwards a single -stats-output-dir to every frontend job, so the
+/// filename is made unique per job (module name + pid) to avoid clobbering in
+/// multi-file / batch builds. The name deliberately does not match the
+/// `stats-*.json` pattern that process-stats-dir.py loads, so it is ignored
+/// there.
+static void writeClangModuleMemoryJSON(
+    StringRef statsDir, StringRef moduleName,
+    const ClangImporter::ClangMemoryStats &stats) {
+  SmallString<256> fileName;
+  llvm::raw_svector_ostream(fileName)
+      << "clang-module-memory-" << moduleName << "-"
+      << llvm::sys::Process::getProcessId() << ".json";
+  SmallString<256> path(statsDir);
+  llvm::sys::path::append(path, fileName);
+  std::error_code EC;
+  llvm::raw_fd_ostream out(path, EC, llvm::sys::fs::OF_Text);
+  if (EC)
+    return;
+
+  llvm::json::OStream J(out, /*IndentSize=*/2);
+  J.object([&] {
+    J.attribute("clangASTContextBytes", stats.astContextBytes);
+    J.attribute("moduleBufferBytesMMap", stats.moduleBufferMMapBytes);
+    J.attribute("moduleBufferBytesMalloc", stats.moduleBufferMallocBytes);
+    J.attribute("numLoadedModules", stats.numLoadedModules);
+    J.attribute("numMaterializedDecls", stats.numMaterializedDecls);
+    J.attributeArray("modules", [&] {
+      for (const auto &m : stats.perModule) {
+        J.object([&] {
+          J.attribute("module", m.moduleName);
+          J.attribute("inMemoryBufferBytes", m.inMemoryBufferBytes);
+          J.attribute("bufferKind", m.bufferIsMMapped ? "mmap" : "malloc");
+          J.attribute("onDiskDecls", m.onDiskDecls);
+          J.attribute("onDiskTypes", m.onDiskTypes);
+          J.attribute("onDiskIdentifiers", m.onDiskIdentifiers);
+          J.attribute("onDiskMacros", m.onDiskMacros);
+          J.attribute("materializedDecls", m.materializedDecls);
+        });
+      }
+    });
+  });
+}
+
 static void countASTStats(UnifiedStatsReporter &Stats,
                           CompilerInstance& Instance) {
   auto &C = Stats.getFrontendCounters();
@@ -268,6 +317,29 @@ static void countASTStats(UnifiedStatsReporter &Stats,
 
   auto const &AST = Instance.getASTContext();
   C.NumLoadedModules = AST.getNumLoadedModules();
+
+  // Memory metrics. Swift ASTContext bytes (all arenas), and the Clang
+  // importer's aggregate + per-module memory. Snapshots taken here at
+  // end-of-pipeline while both ASTContexts and the importer are still alive.
+  C.SwiftASTContextBytes = AST.getTotalMemory();
+  if (auto *clangImporter =
+          static_cast<ClangImporter *>(AST.getClangModuleLoader())) {
+    auto clangStats = clangImporter->getClangMemoryStats();
+    C.ClangASTContextBytes = clangStats.astContextBytes;
+    C.ClangModuleBufferBytesMMap = clangStats.moduleBufferMMapBytes;
+    C.ClangModuleBufferBytesMalloc = clangStats.moduleBufferMallocBytes;
+    C.NumLoadedClangModules = clangStats.numLoadedModules;
+    C.NumMaterializedClangDecls = clangStats.numMaterializedDecls;
+    // Convenience sum; mmap buffers excluded (file-backed, not necessarily
+    // resident).
+    C.ClangTotalBytes =
+        clangStats.astContextBytes + clangStats.moduleBufferMallocBytes;
+
+    const auto &FEOpts = Instance.getInvocation().getFrontendOptions();
+    if (!FEOpts.StatsOutputDir.empty())
+      writeClangModuleMemoryJSON(FEOpts.StatsOutputDir, FEOpts.ModuleName,
+                                 clangStats);
+  }
 
   if (auto *D = Instance.getDependencyTracker()) {
     C.NumDependencies = D->getDependencies().size();

--- a/test/ClangImporter/clang_importer_memory_stats.swift
+++ b/test/ClangImporter/clang_importer_memory_stats.swift
@@ -1,0 +1,57 @@
+// Verify the Clang/Swift memory statistics emitted via -stats-output-dir
+// (aggregate counters + per-module clang-module-memory.json) and the
+// -print-clang-stats stderr dump.
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %empty-directory(%t/stats)
+
+// --- Aggregate counters in the stats JSON.
+// RUN: %target-swift-frontend -typecheck -cxx-interoperability-mode=default -I %t/Inputs %t/test.swift -module-name Test -stats-output-dir %t/stats
+// RUN: %{python} %utils/process-stats-dir.py --set-csv-baseline %t/frontend.csv %t/stats
+// RUN: %FileCheck --check-prefix=CSV -input-file %t/frontend.csv %s
+
+// CSV-DAG: {{"AST.SwiftASTContextBytes".*[1-9][0-9]*$}}
+// CSV-DAG: {{"ClangImporter.ClangASTContextBytes".*[1-9][0-9]*$}}
+// CSV-DAG: {{"ClangImporter.ClangTotalBytes".*[1-9][0-9]*$}}
+// CSV-DAG: {{"ClangImporter.NumLoadedClangModules".*[1-9][0-9]*$}}
+// CSV-DAG: {{"ClangImporter.NumMaterializedClangDecls".*[1-9][0-9]*$}}
+
+// --- Per-module breakdown JSON file (name carries a pid suffix).
+// RUN: cat %t/stats/clang-module-memory-*.json | %FileCheck --check-prefix=PERMOD %s
+
+// PERMOD: "numLoadedModules": {{[1-9][0-9]*}}
+// PERMOD: "modules": [
+// PERMOD-DAG: "module": "CxxMod"
+// PERMOD-DAG: "materializedDecls": {{[1-9][0-9]*}}
+
+// --- Human-readable stderr dump via -print-clang-stats.
+// RUN: %target-swift-frontend -typecheck -cxx-interoperability-mode=default -I %t/Inputs %t/test.swift -module-name Test -print-clang-stats 2>&1 | %FileCheck --check-prefix=STDERR %s
+
+// STDERR: *** Clang importer memory ***
+// STDERR: Clang ASTContext bytes
+// STDERR: Per-module (sorted by materialized decls)
+// STDERR: CxxMod
+
+//--- Inputs/module.modulemap
+module CxxMod {
+  header "cxxmod.h"
+  requires cplusplus
+  export *
+}
+
+//--- Inputs/cxxmod.h
+#pragma once
+struct Point {
+  int x;
+  int y;
+};
+
+//--- test.swift
+import CxxMod
+
+func use() {
+  var p = Point(x: 1, y: 2)
+  p.x = 3
+  _ = p.y
+}


### PR DESCRIPTION
These statistics should help investigate memory consumption issues. It has a per-module breakdown of the number of matierialized declarations from the pcm files, and gathers some memory statistics that are readily available to help quickly determine the culprit, where did all the memory go?
