### PR TITLE
[Sema] Diagnose implicit Sendable from inherited isolation with non-Sendable superclass

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6268,6 +6268,15 @@ NOTE(concurrent_value_nonsendable_superclass_note,none,
      "a 'Sendable' class cannot inherit from a non-Sendable class", ())
 NOTE(concurrent_value_nonsendable_superclass_here,none,
      "inherits from non-Sendable class %0", (DeclName))
+GROUPED_ERROR(implicit_sendable_nonsendable_superclass,NonSendableSuperclass,none,
+     "class %0 is implicitly 'Sendable' due to inherited %1 isolation "
+     "but has a non-Sendable superclass", (DeclName, Type))
+NOTE(implicit_sendable_nonsendable_superclass_fixit,none,
+     "make %0 explicitly %1 to retain implicit 'Sendable' conformance",
+     (DeclName, Type))
+NOTE(implicit_sendable_nonsendable_superclass_suppress,none,
+     "mark %0 as '~Sendable' to suppress the implicit conformance",
+     (DeclName))
 ERROR(non_sendable_type,none,
       "type %0 does not conform to the 'Sendable' protocol", (Type))
 GROUPED_ERROR(non_sendable_metatype_type,SendableMetatypes,none,

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7608,7 +7608,8 @@ bool swift::checkSendableConformance(
   // not be 'final'. Adding global-actor isolation to a non-Sendable superclass,
   // however, does not make the subclass safely 'Sendable'.
   bool isGlobalActorIsolated = false;
-  switch (getActorIsolation(nominal)) {
+  auto nominalIsolation = getActorIsolation(nominal);
+  switch (nominalIsolation) {
   case ActorIsolation::Unspecified:
   case ActorIsolation::ActorInstance:
   case ActorIsolation::Nonisolated:
@@ -7684,66 +7685,114 @@ bool swift::checkSendableConformance(
       if (auto superclassDecl = classDecl->getSuperclassDecl()) {
         // `NSObject` is permitted as a superclass for Objective-C interop.
         // TODO: can `NSObject` be `Sendable` or `~Sendable` instead?
-        // For implicit conformances on global-actor-isolated classes,
-        // skip the diagnostic. The user never asked for Sendable; the
-        // conformance was synthesized and is maintained for source
-        // compatibility.
-        if (!superclassDecl->isNSObject() &&
-            !(isGlobalActorIsolated && isImplicitSendableCheck(check))) {
-          // Inheritance checking for global-actor-isolated classes was
-          // historically skipped, so we need to downgrade this to a warning to
-          // stage it in.
-          bool isError = false;
-          if (isGlobalActorIsolated) {
-            // TODO: remove this staging once people have had a chance to fix
-            // their code.
-            conformanceDecl
-                ->diagnose(diag::concurrent_value_nonsendable_superclass,
-                           classDecl->getName())
-                .limitBehaviorWithPreconcurrency(
-                    DiagnosticBehavior::Warning,
-                    impliedByPreconcurrencyProtocol, LanguageMode::future);
+        if (!superclassDecl->isNSObject()) {
+          if (isGlobalActorIsolated && isImplicitSendableCheck(check)) {
+            // The user never asked for Sendable; the conformance was
+            // synthesized from inherited global actor isolation and is
+            // maintained for source compatibility. Warn starting in
+            // Swift 6; error in a future language mode.
+            auto globalActorType = nominalIsolation.getGlobalActor();
+            classDecl
+                ->diagnose(
+                    diag::implicit_sendable_nonsendable_superclass,
+                    classDecl->getName(), globalActorType)
+                .limitBehaviorUntilLanguageMode(
+                    DiagnosticBehavior::Warning, LanguageMode::future)
+                .limitBehaviorUntilLanguageMode(
+                    DiagnosticBehavior::Ignore, LanguageMode::v6);
+
+            // Fix-it: add explicit global actor attribute.
+            {
+              std::string attrStr = "@" +
+                  globalActorType->getString() + " ";
+              classDecl
+                  ->diagnose(
+                      diag::implicit_sendable_nonsendable_superclass_fixit,
+                      classDecl->getName(), globalActorType)
+                  .fixItInsert(
+                      classDecl->getAttributeInsertionLoc(false),
+                      attrStr)
+                  .limitBehaviorUntilLanguageMode(
+                      DiagnosticBehavior::Ignore, LanguageMode::v6);
+            }
+
+            // Fix-it: suppress with ~Sendable.
+            {
+              auto inheritance = classDecl->getInherited();
+              auto note = classDecl->diagnose(
+                  diag::implicit_sendable_nonsendable_superclass_suppress,
+                  classDecl->getName());
+              if (inheritance.empty()) {
+                auto *genericParams = classDecl->getGenericParams();
+                auto insertionLoc = genericParams
+                    ? genericParams->getRAngleLoc()
+                    : classDecl->getNameLoc();
+                note.fixItInsertAfter(insertionLoc, ": ~Sendable");
+              } else {
+                note.fixItInsertAfter(
+                    inheritance.getEndLoc(), ", ~Sendable");
+              }
+              note.limitBehaviorUntilLanguageMode(
+                  DiagnosticBehavior::Ignore, LanguageMode::v6);
+            }
           } else {
-            conformanceDecl
-                ->diagnose(diag::concurrent_value_nonsendable_superclass,
-                           classDecl->getName())
-                .limitBehaviorWithPreconcurrency(
-                    behavior, impliedByPreconcurrencyProtocol,
-                    LanguageMode::v6);
-            isError = behavior == DiagnosticBehavior::Unspecified;
+            // Inheritance checking for global-actor-isolated classes was
+            // historically skipped, so we need to downgrade this to a
+            // warning to stage it in.
+            bool isError = false;
+            if (isGlobalActorIsolated) {
+              // TODO: remove this staging once people have had a chance
+              // to fix their code.
+              conformanceDecl
+                  ->diagnose(diag::concurrent_value_nonsendable_superclass,
+                             classDecl->getName())
+                  .limitBehaviorWithPreconcurrency(
+                      DiagnosticBehavior::Warning,
+                      impliedByPreconcurrencyProtocol, LanguageMode::future);
+            } else {
+              conformanceDecl
+                  ->diagnose(diag::concurrent_value_nonsendable_superclass,
+                             classDecl->getName())
+                  .limitBehaviorWithPreconcurrency(
+                      behavior, impliedByPreconcurrencyProtocol,
+                      LanguageMode::v6);
+              isError = behavior == DiagnosticBehavior::Unspecified;
+            }
+
+            conformanceDecl->diagnose(
+                diag::concurrent_value_nonsendable_superclass_note);
+
+            // Point at where the class inherits the non-Sendable superclass.
+            // Be slightly defensive here in the presence of badly-ordered
+            // inheritance clauses: the superclass is not necessarily the first
+            // entry once `superclass must appear first` recovery has run.
+            // TODO: abstract this? The same search exists in
+            // TypeCheckAccess.cpp.
+            auto inheritedEntries = classDecl->getInherited().getEntries();
+            auto superclassLocIter = std::find_if(
+                inheritedEntries.begin(), inheritedEntries.end(),
+                [&](TypeLoc inherited) {
+                  if (!inherited.wasValidated())
+                    return false;
+                  Type ty = inherited.getType();
+                  if (ty->is<ProtocolCompositionType>())
+                    if (auto superclass =
+                            ty->getExistentialLayout().explicitSuperclass)
+                      ty = superclass;
+                  return ty->getAnyNominal() == superclassDecl;
+                });
+            SourceLoc superclassLoc =
+                superclassLocIter == inheritedEntries.end()
+                    ? classDecl->getLoc()
+                    : superclassLocIter->getSourceRange().Start;
+            classDecl->getASTContext().Diags.diagnose(
+                superclassLoc,
+                diag::concurrent_value_nonsendable_superclass_here,
+                superclassDecl->getName());
+
+            if (isError)
+              return true;
           }
-
-          conformanceDecl->diagnose(
-              diag::concurrent_value_nonsendable_superclass_note);
-
-          // Point at where the class inherits the non-Sendable superclass. Be
-          // slightly defensive here in the presence of badly-ordered
-          // inheritance clauses: the superclass is not necessarily the first
-          // entry once `superclass must appear first` recovery has run.
-          // TODO: abstract this? The same search exists in TypeCheckAccess.cpp.
-          auto inheritedEntries = classDecl->getInherited().getEntries();
-          auto superclassLocIter = std::find_if(
-              inheritedEntries.begin(), inheritedEntries.end(),
-              [&](TypeLoc inherited) {
-                if (!inherited.wasValidated())
-                  return false;
-                Type ty = inherited.getType();
-                if (ty->is<ProtocolCompositionType>())
-                  if (auto superclass =
-                          ty->getExistentialLayout().explicitSuperclass)
-                    ty = superclass;
-                return ty->getAnyNominal() == superclassDecl;
-              });
-          SourceLoc superclassLoc =
-              superclassLocIter == inheritedEntries.end()
-                  ? classDecl->getLoc()
-                  : superclassLocIter->getSourceRange().Start;
-          classDecl->getASTContext().Diags.diagnose(
-              superclassLoc, diag::concurrent_value_nonsendable_superclass_here,
-              superclassDecl->getName());
-
-          if (isError)
-            return true;
         }
       }
     }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7684,7 +7684,12 @@ bool swift::checkSendableConformance(
       if (auto superclassDecl = classDecl->getSuperclassDecl()) {
         // `NSObject` is permitted as a superclass for Objective-C interop.
         // TODO: can `NSObject` be `Sendable` or `~Sendable` instead?
-        if (!superclassDecl->isNSObject()) {
+        // For implicit conformances on global-actor-isolated classes,
+        // skip the diagnostic. The user never asked for Sendable; the
+        // conformance was synthesized and is maintained for source
+        // compatibility.
+        if (!superclassDecl->isNSObject() &&
+            !(isGlobalActorIsolated && isImplicitSendableCheck(check))) {
           // Inheritance checking for global-actor-isolated classes was
           // historically skipped, so we need to downgrade this to a warning to
           // stage it in.

--- a/test/Concurrency/default_isolation_sendable_superclass.swift
+++ b/test/Concurrency/default_isolation_sendable_superclass.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify -strict-concurrency=targeted -swift-version 5
-// RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify -swift-version 6
+// RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify -verify-additional-prefix swift6- -swift-version 6
 
 // REQUIRES: concurrency
 // REQUIRES: objc_interop
@@ -13,9 +13,8 @@ import Foundation
 
 // When a class inherits global-actor isolation from its superclass (rather
 // than declaring it explicitly), the implicit Sendable conformance is
-// maintained for source compatibility with no diagnostic. The user never
-// asked for Sendable, so diagnosing the non-Sendable superclass would be
-// confusing.
+// maintained for source compatibility. Starting in Swift 6, a warning
+// explains where the conformance came from and offers fix-its.
 
 public class NonSendableSuperclass {}
 
@@ -23,9 +22,13 @@ public class NonSendableSuperclass {}
 public class IsolatedNonSendable: NonSendableSuperclass {}
 
 // Inherits @MainActor from the superclass. The implicit Sendable conformance
-// is kept silently -- no diagnostic expected.
+// is kept but diagnosed starting in Swift 6.
 public final class InheritedIsolationSubclass: IsolatedNonSendable {}
+// expected-swift6-warning @-1 {{class 'InheritedIsolationSubclass' is implicitly 'Sendable' due to inherited 'MainActor' isolation but has a non-Sendable superclass; this will be an error in a future Swift language mode}}
+// expected-swift6-note @-2 {{make 'InheritedIsolationSubclass' explicitly 'MainActor' to retain implicit 'Sendable' conformance}} {{1-1=@MainActor }}
+// expected-swift6-note @-3 {{mark 'InheritedIsolationSubclass' as '~Sendable' to suppress the implicit conformance}} {{67-67=, ~Sendable}}
 
+// The subclass is still Sendable (source compatibility), so this compiles.
 func requiresSendable<T: Sendable>(_: T.Type) {}
 func testInheritedIsolationIsSendable() {
   requiresSendable(InheritedIsolationSubclass.self)

--- a/test/Concurrency/default_isolation_sendable_superclass.swift
+++ b/test/Concurrency/default_isolation_sendable_superclass.swift
@@ -1,0 +1,68 @@
+// RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify -strict-concurrency=targeted -swift-version 5
+// RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify -swift-version 6
+
+// REQUIRES: concurrency
+// REQUIRES: objc_interop
+
+// Tests for implicit Sendable conformance with inherited global actor
+// isolation and non-Sendable superclasses.
+
+import Foundation
+
+// MARK: - Inherited isolation, no explicit Sendable
+
+// When a class inherits global-actor isolation from its superclass (rather
+// than declaring it explicitly), the implicit Sendable conformance is
+// maintained for source compatibility with no diagnostic. The user never
+// asked for Sendable, so diagnosing the non-Sendable superclass would be
+// confusing.
+
+public class NonSendableSuperclass {}
+
+@MainActor
+public class IsolatedNonSendable: NonSendableSuperclass {}
+
+// Inherits @MainActor from the superclass. The implicit Sendable conformance
+// is kept silently -- no diagnostic expected.
+public final class InheritedIsolationSubclass: IsolatedNonSendable {}
+
+func requiresSendable<T: Sendable>(_: T.Type) {}
+func testInheritedIsolationIsSendable() {
+  requiresSendable(InheritedIsolationSubclass.self)
+}
+
+// MARK: - NSObject superclass (SE-0434)
+
+// NSObject is Sendable, so @MainActor subclasses of NSObject inherit
+// Sendable through the normal inherited-conformance path. Their subclasses
+// should also be Sendable with no diagnostic.
+
+@MainActor
+class IsolatedNSObjectSubclass: NSObject {}
+
+class InheritedFromIsolatedNSObject: IsolatedNSObjectSubclass {}
+
+func testNSObjectChainIsSendable() {
+  requiresSendable(IsolatedNSObjectSubclass.self)
+  requiresSendable(InheritedFromIsolatedNSObject.self)
+}
+
+// MARK: - Inherited isolation with explicit Sendable (should diagnose)
+
+// When Sendable IS explicitly requested somewhere in the chain, the
+// non-Sendable superclass diagnostic should still fire.
+
+protocol RefinesSendable: Sendable {}
+
+// Explicit Sendable on a class with inherited isolation.
+final class InheritedIsolationExplicitSendable: IsolatedNonSendable, Sendable {}
+// expected-warning @-1 {{class 'InheritedIsolationExplicitSendable' cannot conform to the 'Sendable' protocol; this will be an error in a future Swift language mode}}
+// expected-note @-2 {{a 'Sendable' class cannot inherit from a non-Sendable class}}
+// expected-note @-3 {{inherits from non-Sendable class 'IsolatedNonSendable'}}
+
+// Sendable implied through a protocol refinement.
+@MainActor
+final class InheritedIsolationRefinedSendable: NonSendableSuperclass, RefinesSendable {}
+// expected-warning @-1 {{class 'InheritedIsolationRefinedSendable' cannot conform to the 'Sendable' protocol; this will be an error in a future Swift language mode}}
+// expected-note @-2 {{a 'Sendable' class cannot inherit from a non-Sendable class}}
+// expected-note @-3 {{inherits from non-Sendable class 'NonSendableSuperclass'}}


### PR DESCRIPTION
## Summary

When a class inherits global actor isolation from its superclass and gets an implicit `Sendable` conformance despite having a non-Sendable superclass, the compiler currently silently maintains the conformance (#90186 suppresses the spurious diagnostic). This PR adds a staged diagnostic that explains where the conformance came from and offers fix-its.

Starting in Swift 6 mode, a warning is emitted:

```
warning: class 'InheritedIsolationSubclass' is implicitly 'Sendable' due to
inherited 'MainActor' isolation but has a non-Sendable superclass;
this will be an error in a future Swift language mode
```

Two fix-its are provided:

1. **Add explicit global actor attribute** (e.g. `@MainActor`) to retain the implicit `Sendable` conformance.
2. **Mark as `~Sendable`** to suppress the implicit conformance.

The diagnostic is:
- Suppressed before Swift 6 mode
- A warning in Swift 6 mode
- An error in a future language mode

The conformance itself is still maintained for source compatibility.

## Changes

- Added three new diagnostics in `DiagnosticsSema.def`: `implicit_sendable_nonsendable_superclass` (grouped error under `NonSendableSuperclass`), and two notes with fix-its
- In `checkSendableConformance`, when the implicit Sendable conformance comes from inherited global actor isolation and the superclass is non-Sendable (non-NSObject), emit the staged diagnostic instead of silently suppressing
- Updated test expectations in `default_isolation_sendable_superclass.swift` to verify the new warnings and fix-its in Swift 6 mode

## Depends on

- #90186 (suppress-only fix, cherry-pick candidate for 6.4) -- the first commit in this branch will get rebased out once #90186 lands on main