### PR TITLE
[Sema] Avoid setting bogus SourceLocs for synthesized braces

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4893,7 +4893,7 @@ public:
 
   SourceLoc getStartLoc() const { return EnumLoc; }
   SourceRange getSourceRange() const {
-    return SourceRange(EnumLoc, getBraces().End);
+    return SourceRange::combine(EnumLoc, getBraces().End);
   }
 
 public:
@@ -5097,7 +5097,7 @@ public:
 
   SourceLoc getStartLoc() const { return StructLoc; }
   SourceRange getSourceRange() const {
-    return SourceRange(StructLoc, getBraces().End);
+    return SourceRange::combine(StructLoc, getBraces().End);
   }
 
   // Implement isa/cast/dyncast/etc.
@@ -5253,7 +5253,7 @@ public:
 
   SourceLoc getStartLoc() const { return ClassLoc; }
   SourceRange getSourceRange() const {
-    return SourceRange(ClassLoc, getBraces().End);
+    return SourceRange::combine(ClassLoc, getBraces().End);
   }
 
   /// Determine whether the member area of this class's metadata (which consists
@@ -5741,7 +5741,7 @@ public:
   
   SourceLoc getStartLoc() const { return ProtocolLoc; }
   SourceRange getSourceRange() const {
-    return SourceRange(ProtocolLoc, getBraces().End);
+    return SourceRange::combine(ProtocolLoc, getBraces().End);
   }
 
   /// True if this protocol can only be conformed to by class types.

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4106,7 +4106,7 @@ void PrintAST::visitEnumDecl(EnumDecl *decl) {
   printAttributes(decl);
   printAccess(decl);
 
-  if (Options.PrintOriginalSourceText && decl->getStartLoc().isValid()) {
+  if (Options.PrintOriginalSourceText && !decl->isImplicit()) {
     ASTContext &Ctx = decl->getASTContext();
     printSourceRange(CharSourceRange(Ctx.SourceMgr, decl->getStartLoc(),
                               decl->getBraces().Start.getAdvancedLoc(-1)), Ctx);
@@ -4137,7 +4137,7 @@ void PrintAST::visitStructDecl(StructDecl *decl) {
   printAttributes(decl);
   printAccess(decl);
 
-  if (Options.PrintOriginalSourceText && decl->getStartLoc().isValid()) {
+  if (Options.PrintOriginalSourceText && !decl->isImplicit()) {
     ASTContext &Ctx = decl->getASTContext();
     printSourceRange(CharSourceRange(Ctx.SourceMgr, decl->getStartLoc(),
                               decl->getBraces().Start.getAdvancedLoc(-1)), Ctx);
@@ -4168,7 +4168,7 @@ void PrintAST::visitClassDecl(ClassDecl *decl) {
   printAttributes(decl);
   printAccess(decl);
 
-  if (Options.PrintOriginalSourceText && decl->getStartLoc().isValid()) {
+  if (Options.PrintOriginalSourceText && !decl->isImplicit()) {
     ASTContext &Ctx = decl->getASTContext();
     printSourceRange(CharSourceRange(Ctx.SourceMgr, decl->getStartLoc(),
                               decl->getBraces().Start.getAdvancedLoc(-1)), Ctx);
@@ -4228,7 +4228,7 @@ void PrintAST::visitProtocolDecl(ProtocolDecl *decl) {
   printAttributes(decl);
   printAccess(decl);
 
-  if (Options.PrintOriginalSourceText && decl->getStartLoc().isValid()) {
+  if (Options.PrintOriginalSourceText && !decl->isImplicit()) {
     ASTContext &Ctx = decl->getASTContext();
     printSourceRange(CharSourceRange(Ctx.SourceMgr, decl->getStartLoc(),
                               decl->getBraces().Start.getAdvancedLoc(-1)), Ctx);
@@ -4697,7 +4697,7 @@ void PrintAST::visitFuncDecl(FuncDecl *decl) {
   printAttributes(decl);
   printAccess(decl);
 
-  if (Options.PrintOriginalSourceText && decl->getStartLoc().isValid()) {
+  if (Options.PrintOriginalSourceText && !decl->isImplicit()) {
     SourceLoc StartLoc = decl->getStartLoc();
     SourceLoc EndLoc;
     if (decl->getResultTypeRepr()) {

--- a/lib/Sema/DerivedConformance/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceCodable.cpp
@@ -153,7 +153,6 @@ addImplicitCodingKeys(NominalTypeDecl *target,
   auto anchorLoc = target->getStartLoc();
   auto *enumDecl = new (C) EnumDecl(anchorLoc, codingKeysEnumIdentifier,
                                     SourceLoc(), inherited, nullptr, target);
-  enumDecl->setBraces(anchorLoc);
   enumDecl->setImplicit();
   enumDecl->setSynthesized();
   enumDecl->setAccess(AccessLevel::Private);

--- a/lib/Sema/DerivedConformance/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceDifferentiable.cpp
@@ -394,7 +394,6 @@ getOrSynthesizeTangentVectorStruct(DerivedConformance &derived, Identifier id) {
       new (C) StructDecl(synthesizedLoc, C.Id_TangentVector, synthesizedLoc,
                          /*Inherited*/ C.AllocateCopy(tvDesiredProtoInherited),
                          /*GenericParams*/ {}, parentDC);
-  structDecl->setBraces({synthesizedLoc, synthesizedLoc});
   structDecl->setImplicit();
   structDecl->setSynthesized();
   structDecl->copyFormalAccessFrom(nominal, /*sourceIsParentContext*/ true);

--- a/test/SourceKit/CodeComplete/complete_cached_codingkeys.swift
+++ b/test/SourceKit/CodeComplete/complete_cached_codingkeys.swift
@@ -1,0 +1,24 @@
+struct A {
+  var x: Int? {
+
+struct B: Codable {
+  static func f() -> X
+}
+
+// Make sure the synthesized CodingKeys does not crash by triggering parsing in
+// the replaced function body buffer when re-using AST.
+
+// RUN: %sourcekitd-test \
+// RUN:   -req=complete -pos=5:22 %s -- %s == \
+// RUN:   -req=complete -pos=5:22 %s -- %s | %FileCheck %s
+
+// CHECK-LABEL: key.results: [
+// CHECK-DAG: key.name: "A"
+// CHECK-DAG: key.name: "B"
+// CHECK-DAG: key.name: "Self"
+
+// CHECK-LABEL: key.results: [
+// CHECK-DAG: key.name: "A"
+// CHECK-DAG: key.name: "B"
+// CHECK-DAG: key.name: "Self"
+// CHECK: key.reusingastcontext: 1

--- a/validation-test/IDE/crashers_fixed/SourceManager-getLocOffsetInBuffer-dd5d62.swift
+++ b/validation-test/IDE/crashers_fixed/SourceManager-getLocOffsetInBuffer-dd5d62.swift
@@ -1,5 +1,5 @@
 // {"kind":"complete","original":"05c97bf1","signature":"swift::SourceManager::getLocOffsetInBuffer(swift::SourceLoc, unsigned int) const","signatureAssert":"Assertion failed: (Loc.getPointer() >= Buffer->getBuffer().begin() && Loc.getPointer() <= Buffer->getBuffer().end() && \"Location is not from the specified buffer\"), function getLocOffsetInBuffer","signatureNext":"Lexer::getStateForBeginningOfTokenLoc","useSourceOrderCompletion":true}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-order-completion -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-order-completion -source-filename %s
 // REQUIRES: OS=macosx
 import _Differentiation func a {
 #^^#


### PR DESCRIPTION
Setting a SourceLoc for a brace of a nominal type is used to indicate that we should attempt to parse members for it. Avoid doing this in synthesized cases since we supply the members directly. Instead,  make the SourceRange computation resilient to missing brace locations. This avoids a crash when attempting to do cached code completion in cases where there are nested local types that synthesize nominals such as CodingKeys.