### PR TITLE
[crashers] Move check protecting against a crash to eliminate optiona…

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3888,8 +3888,12 @@ bool NonClassTypeToAnyObjectConversionFailure::diagnoseAsError() {
   }
 
   if (locator->isLastElement<LocatorPathElt::ApplyArgToParam>()) {
-    ArgumentMismatchFailure failure(getSolution(), fromType, toType, locator);
-    return failure.diagnoseAsError();
+    std::optional<ArgumentMismatchFailure> failure =
+        ArgumentMismatchFailure::create(getSolution(), fromType, toType,
+                                        locator);
+    if (!failure)
+      return false;
+    return failure.value().diagnoseAsError();
   }
 
   std::optional<Diag<Type, Type>> diagnostic;
@@ -3929,9 +3933,12 @@ bool NonClassTypeToAnyObjectConversionFailure::diagnoseAsNote() {
   }
 
   if (locator->isLastElement<LocatorPathElt::ApplyArgToParam>()) {
-    ArgumentMismatchFailure failure(getSolution(), getFromType(), getToType(),
-                                    getLocator());
-    return failure.diagnoseAsNote();
+    std::optional<ArgumentMismatchFailure> failure =
+        ArgumentMismatchFailure::create(getSolution(), getFromType(),
+                                        getToType(), getLocator());
+    if (!failure)
+      return false;
+    return failure.value().diagnoseAsNote();
   }
 
   return false;
@@ -4015,9 +4022,12 @@ bool MissingCallFailure::diagnoseAsError() {
       auto fnType = type->castTo<FunctionType>();
 
       if (MissingArgumentsFailure::isMisplacedMissingArgument(getSolution(), locator)) {
-        ArgumentMismatchFailure failure(getSolution(), fnType,
-                                        fnType->getResult(), locator);
-        return failure.diagnoseMisplacedMissingArgument();
+        std::optional<ArgumentMismatchFailure> failure =
+            ArgumentMismatchFailure::create(getSolution(), fnType,
+                                            fnType->getResult(), locator);
+        if (!failure)
+          return false;
+        return failure.value().diagnoseMisplacedMissingArgument();
       }
 
       emitDiagnostic(diag::missing_nullary_call, fnType->getResult())
@@ -7709,6 +7719,35 @@ void InOutConversionFailure::fixItChangeArgumentType() const {
       .fixItReplaceChars(startLoc, endLoc, scratch);
 }
 
+std::optional<FunctionArgApplyInfo>
+ArgumentMismatchFailure::buildInfo(const Solution &solution,
+                                   ConstraintLocator *locator) {
+  auto info = solution.getFunctionArgApplyInfo(locator);
+  if (!info) {
+    auto path = locator->getPath();
+    auto iter = path.rbegin();
+    if (locator->findLast<LocatorPathElt::ApplyArgument>(iter)) {
+      auto *newLoc = solution.getConstraintLocator(
+          locator->getAnchor(), path.drop_back(iter - path.rbegin()));
+      if (hasFixFor(solution, newLoc, FixKind::AddMissingArguments))
+        return std::nullopt;
+    }
+    ABORT("expected function arg apply info for apply argument locator");
+  }
+  return info;
+}
+
+std::optional<ArgumentMismatchFailure>
+ArgumentMismatchFailure::create(const Solution &solution, Type argType,
+                                Type paramType, ConstraintLocator *locator,
+                                FixBehavior fixBehavior) {
+  auto info = buildInfo(solution, locator);
+  if (!info)
+    return std::nullopt;
+  return ArgumentMismatchFailure(solution, argType, paramType, locator,
+                                 info.value(), fixBehavior);
+}
+
 bool ArgumentMismatchFailure::diagnoseAsError() {
   const auto paramType = getToType();
 
@@ -7718,25 +7757,6 @@ bool ArgumentMismatchFailure::diagnoseAsError() {
   // fulfill, and let the member access failure prevail.
   if (paramType->hasOpenedExistential()) {
     return false;
-  }
-
-  // FIXME: After Argument Synthesis, we're still generating Argument Mismatch
-  // fixes and errors
-  //  But the locator for the ApplyArgument is not a suitable match for a
-  //  FunctionApplyArgInfo This causes crashes when attempting to build one.
-  //  Blocking here is a stop gap while we devise a means of either not having
-  //  argument mismatches or of having usable locators.
-  if (!Info) {
-    auto locator = getLocator();
-    auto path = locator->getPath();
-    auto iter = path.rbegin();
-    if (locator->findLast<LocatorPathElt::ApplyArgument>(iter)) {
-      auto *newLoc = getSolution().getConstraintLocator(
-          locator->getAnchor(), path.drop_back(iter - path.rbegin()));
-      if (hasFixFor(getSolution(), newLoc, FixKind::AddMissingArguments))
-        return false;
-    }
-    ABORT("expected function arg apply info for argument mismatch");
   }
 
   if (diagnoseKeyPathLiteralMutabilityMismatch())
@@ -8079,7 +8099,7 @@ bool ArgumentMismatchFailure::diagnoseAttemptedRegexBuilder() const {
   auto &ctx = getASTContext();
 
   // Should be a lone trailing closure argument.
-  if (!Info->isTrailingClosure() || !Info->getArgList()->isUnary())
+  if (!Info.isTrailingClosure() || !Info.getArgList()->isUnary())
     return false;
 
   // Check if this an application of a Regex initializer, and the user has not
@@ -8117,7 +8137,7 @@ bool ArgumentMismatchFailure::diagnoseClosureMismatch() const {
   if (paramType->lookThroughAllOptionalTypes()->is<AnyFunctionType>())
     return false;
 
-  emitDiagnostic(diag::closure_bad_param, paramType, Info->isTrailingClosure())
+  emitDiagnostic(diag::closure_bad_param, paramType, Info.isTrailingClosure())
       .highlight(getSourceRange());
 
   if (auto overload = getCalleeOverloadChoiceIfAvailable(getLocator())) {
@@ -8225,6 +8245,20 @@ bool ExtraneousCallFailure::diagnoseAsError() {
       emitDiagnostic(diag::cannot_call_non_function_value, getType(anchor));
   removeParensFixIt(diagnostic);
   return true;
+}
+
+std::optional<NonEphemeralConversionFailure>
+NonEphemeralConversionFailure::create(const Solution &solution,
+                                      ConstraintLocator *locator, Type fromType,
+                                      Type toType,
+                                      ConversionRestrictionKind conversionKind,
+                                      FixBehavior fixBehavior) {
+  auto info = ArgumentMismatchFailure::buildInfo(solution, locator);
+  if (!info)
+    return std::nullopt;
+  return NonEphemeralConversionFailure(solution, locator, info.value(),
+                                       fromType, toType, conversionKind,
+                                       fixBehavior);
 }
 
 void NonEphemeralConversionFailure::emitSuggestionNotes() const {

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -35,7 +35,7 @@
 namespace swift {
 namespace constraints {
 
-class FunctionArgApplyInfo;
+class FunctionArgpplyInfo;
 
 /// Base class for all of the possible diagnostics,
 /// provides most basic information such as location of
@@ -2283,14 +2283,31 @@ public:
 /// func bar(_ v: Int) { foo(v) } // `Int` is not convertible to `String`
 /// ```
 class ArgumentMismatchFailure : public ContextualFailure {
-  std::optional<FunctionArgApplyInfo> Info;
+  FunctionArgApplyInfo Info;
 
-public:
+protected:
   ArgumentMismatchFailure(const Solution &solution, Type argType,
                           Type paramType, ConstraintLocator *locator,
+                          FunctionArgApplyInfo info,
                           FixBehavior fixBehavior = FixBehavior::Error)
       : ContextualFailure(solution, argType, paramType, locator, fixBehavior),
-        Info(getFunctionArgApplyInfo(locator)) {}
+        Info(info) {}
+
+  static std::optional<FunctionArgApplyInfo>
+  buildInfo(const Solution &solution, ConstraintLocator *locator);
+
+public:
+  // FIXME: After Argument Synthesis, we're still generating Argument Mismatch
+  // fixes and related fixes that require a FunctionApplyArgInfo
+  //  But the locator for the ApplyArgument is not a suitable match for a
+  // FunctionApplyArgInfo This causes crashes when attempting to build one.
+  //  Aborting here when we are not in an apply argument allows us to identify
+  // other cases while we work on a better solution for ApplyArgument
+  // synthesized locators.
+  static std::optional<ArgumentMismatchFailure>
+  create(const Solution &solution, Type argType, Type paramType,
+         ConstraintLocator *locator,
+         FixBehavior fixBehavior = FixBehavior::Error);
 
   bool diagnoseAsError() override;
   bool diagnoseAsNote() override;
@@ -2336,10 +2353,10 @@ public:
 
 protected:
   /// \returns The position of the argument being diagnosed, starting at 1.
-  unsigned getArgPosition() const { return Info->getArgPosition(); }
+  unsigned getArgPosition() const { return Info.getArgPosition(); }
 
   /// \returns The position of the parameter being diagnosed, starting at 1.
-  unsigned getParamPosition() const { return Info->getParamPosition(); }
+  unsigned getParamPosition() const { return Info.getParamPosition(); }
 
   /// Returns the argument expression being diagnosed.
   ///
@@ -2349,7 +2366,7 @@ protected:
   /// the conversion from T to U may fail. In this case, \c getArgExpr() will
   /// return the (T, U) expression, whereas \c getAnchor() will return the T
   /// expression.
-  Expr *getArgExpr() const { return Info->getArgExpr(); }
+  Expr *getArgExpr() const { return Info.getArgExpr(); }
 
   /// Returns the argument type for the conversion being diagnosed.
   ///
@@ -2362,25 +2379,25 @@ protected:
   /// In this case, \c getArgType() will return T?, whereas \c getFromType()
   /// will return T.
   Type getArgType(bool withSpecifier = false) const {
-    return Info->getArgType(withSpecifier);
+    return Info.getArgType(withSpecifier);
   }
 
   /// \returns A textual description of the argument suitable for diagnostics.
   /// For an argument with an unambiguous label, this will the label. Otherwise
   /// it will be its position in the argument list.
   StringRef getArgDescription(SmallVectorImpl<char> &scratch) const {
-    return Info->getArgDescription(scratch);
+    return Info.getArgDescription(scratch);
   }
 
   /// \returns The interface type for the function being applied.
-  Type getFnInterfaceType() const { return Info->getFnInterfaceType(); }
+  Type getFnInterfaceType() const { return Info.getFnInterfaceType(); }
 
   /// \returns The function type being applied, including any generic
   /// substitutions.
-  FunctionType *getFnType() const { return Info->getFnType(); }
+  FunctionType *getFnType() const { return Info.getFnType(); }
 
   /// \returns The callee for the argument conversion, if any.
-  const ValueDecl *getCallee() const { return Info->getCallee(); }
+  const ValueDecl *getCallee() const { return Info.getCallee(); }
 
   /// \returns The full name of the callee, or a null decl name if there is no
   /// callee.
@@ -2396,7 +2413,7 @@ protected:
   ///
   /// Note this may differ from \c getToType(), see the note on \c getArgType().
   Type getParamType(bool lookThroughAutoclosure = true) const {
-    return Info->getParamType(lookThroughAutoclosure);
+    return Info.getParamType(lookThroughAutoclosure);
   }
 
   /// Returns the type of the parameter involved in the mismatch.
@@ -2406,17 +2423,17 @@ protected:
   ///
   /// Note this may differ from \c getToType(), see the note on \c getArgType().
   Type getParamInterfaceType(bool lookThroughAutoclosure = true) const {
-    return Info->getParamInterfaceType(lookThroughAutoclosure);
+    return Info.getParamInterfaceType(lookThroughAutoclosure);
   }
 
   /// \returns The flags of the parameter involved in the mismatch.
   ParameterTypeFlags getParameterFlags() const {
-    return Info->getParameterFlags();
+    return Info.getParameterFlags();
   }
 
   /// \returns The flags of a parameter at a given index.
   ParameterTypeFlags getParameterFlagsAtIndex(unsigned idx) const {
-    return Info->getParameterFlagsAtIndex(idx);
+    return Info.getParameterFlagsAtIndex(idx);
   }
 };
 
@@ -2457,18 +2474,23 @@ class NonEphemeralConversionFailure final : public ArgumentMismatchFailure {
   ConversionRestrictionKind ConversionKind;
 
 public:
+  bool diagnoseAsError() override;
+  bool diagnoseAsNote() override;
+  static std::optional<NonEphemeralConversionFailure>
+  create(const Solution &solution, ConstraintLocator *locator, Type fromType,
+         Type toType, ConversionRestrictionKind conversionKind,
+         FixBehavior fixBehavior);
+
+protected:
   NonEphemeralConversionFailure(const Solution &solution,
-                                ConstraintLocator *locator, Type fromType,
+                                ConstraintLocator *locator,
+                                FunctionArgApplyInfo info, Type fromType,
                                 Type toType,
                                 ConversionRestrictionKind conversionKind,
                                 FixBehavior fixBehavior)
-      : ArgumentMismatchFailure(
-            solution, fromType, toType, locator, fixBehavior),
-        ConversionKind(conversionKind) {
-  }
-
-  bool diagnoseAsError() override;
-  bool diagnoseAsNote() override;
+      : ArgumentMismatchFailure(solution, fromType, toType, locator, info,
+                                fixBehavior),
+        ConversionKind(conversionKind) {}
 
 private:
   /// Attempts to emit a specialized diagnostic for

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1987,9 +1987,12 @@ unsigned AllowArgumentMismatch::getParamIdx() const {
 
 bool AllowArgumentMismatch::diagnose(const Solution &solution,
                                      bool asNote) const {
-  ArgumentMismatchFailure failure(solution, getFromType(), getToType(),
-                                  getLocator());
-  return failure.diagnose(asNote);
+  std::optional<ArgumentMismatchFailure> failure =
+      ArgumentMismatchFailure::create(solution, getFromType(), getToType(),
+                                      getLocator());
+  if (!failure)
+    return false;
+  return failure.value().diagnose(asNote);
 }
 
 AllowArgumentMismatch *
@@ -2011,10 +2014,14 @@ RemoveInvalidCall *RemoveInvalidCall::create(ConstraintSystem &cs,
 
 bool TreatEphemeralAsNonEphemeral::diagnose(const Solution &solution,
                                             bool asNote) const {
-  NonEphemeralConversionFailure failure(solution, getLocator(), getFromType(),
-                                        getToType(), ConversionKind,
-                                        fixBehavior);
-  return failure.diagnose(asNote);
+
+  std::optional<NonEphemeralConversionFailure> failure =
+      NonEphemeralConversionFailure::create(solution, getLocator(),
+                                            getFromType(), getToType(),
+                                            ConversionKind, fixBehavior);
+  if (failure.has_value())
+    return failure.value().diagnose(asNote);
+  return false;
 }
 
 TreatEphemeralAsNonEphemeral *TreatEphemeralAsNonEphemeral::create(


### PR DESCRIPTION
…l type

Moving check around whether FunctionArgApplyInfo has been successfully created to diagnose, or before creating the Diagnostic class where otherwise applicable, to avoid needing an optional FunctionalApplyInfo inside of the Diagnostic class while still avoiding crashes caused when the creation did not succeed.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
