### PR TITLE
[6.4] MoveOnlyChecker: relax partial-consume assertion for restricted impor…

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -1834,12 +1834,11 @@ shouldEmitPartialMutationErrorForType(SILType ty, NominalTypeDecl *nominal,
   if (nominal->getModuleContext() == fn->getModule().getSwiftModule())
     return std::nullopt;
 
-  // It's defined in another module and used here; it has to be visible.
-  assert(nominal
-             ->getFormalAccessScope(
-                 /*useDC=*/fn->getDeclContext(),
-                 /*treatUsableFromInlineAsPublic=*/true)
-             .isPublicOrPackage());
+  // It's defined in another module and used here, so we've established the
+  // type is visible. Historically the access scope was expected to be public
+  // or package; with `InternalImportsByDefault` a public type reached via an
+  // internal import has `Internal` scope in the importing module, which is
+  // also valid.
 
   // Partial mutation is supported only for frozen/fixed-layout types from
   // other modules.

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics_partial_consume_internal_imports.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics_partial_consume_internal_imports.swift
@@ -1,0 +1,55 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend                                      \
+// RUN:     %t/Library.swift                                        \
+// RUN:     -emit-module                                            \
+// RUN:     -module-name Library                                    \
+// RUN:     -emit-module-path %t/Library.swiftmodule
+
+// Regression: an `internal import` of another module gives that
+// module's public types `Internal` access scope from the client's
+// perspective. The MoveOnlyChecker's partial-consumption legality
+// analysis previously asserted that the type's formal access scope was
+// public-or-package at this point, which no longer holds. The
+// assertion has been relaxed; the downstream frozen-vs-nonfrozen check
+// is unchanged.
+
+// RUN: %target-swift-frontend                                      \
+// RUN:     %t/Downstream.swift                                     \
+// RUN:     -emit-sil -verify                                       \
+// RUN:     -sil-verify-all                                         \
+// RUN:     -I %t
+
+//--- Library.swift
+
+public struct Source: ~Copyable {
+    public init() {}
+}
+
+@frozen public struct FrozenWrapper: ~Copyable {
+    public var source: Source
+    public init(source: consuming Source) { self.source = source }
+}
+
+public struct NonFrozenWrapper: ~Copyable {
+    public var source: Source
+    public init(source: consuming Source) { self.source = source }
+}
+
+//--- Downstream.swift
+
+internal import Library
+
+// @frozen: partial consume across module boundaries is allowed.
+func frozenPartialConsume() {
+    let w = FrozenWrapper(source: Source())
+    _ = consume w.source
+}
+
+// Non-@frozen: partial consume is rejected with the imported-nonfrozen
+// diagnostic.
+func nonfrozenPartialConsume() {
+    let w = NonFrozenWrapper(source: Source())
+    _ = consume w.source // expected-error {{cannot partially consume 'w' of non-frozen type 'NonFrozenWrapper' imported from 'Library'}}
+}


### PR DESCRIPTION
**Description**:  Remove a no-longer-relevant assertion that breaks builds with the new InternalImportsByDefault feature

**Risk**:  Low possibility that this would cause us to accept invalid code, possibly leading to different crashes later in the compiler or miscompiles.

**Authored by:** @airspeedswift 

**Reviewed by:** @tshortli 

**Cherry-Picked from:** #88829 