### PR TITLE
[CS] NFC: Remove unused `InvalidUseOfTrailingClosure` declaration

### DIFF
--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2405,15 +2405,6 @@ public:
   bool diagnoseAsError() override;
 };
 
-class InvalidUseOfTrailingClosure final : public ArgumentMismatchFailure {
-public:
-  InvalidUseOfTrailingClosure(const Solution &solution, Type argType,
-                              Type paramType, ConstraintLocator *locator)
-      : ArgumentMismatchFailure(solution, argType, paramType, locator) {}
-
-  bool diagnoseAsError() override;
-};
-
 /// Diagnose the invalid conversion of a temporary pointer argument generated
 /// from an X-to-pointer conversion to an @_nonEphemeral parameter.
 ///


### PR DESCRIPTION
The definition was removed in 7f2d4e00fc74acf8efd20532b48b1b0257e87c09