### PR TITLE
[6.4][rbi] use getArgumentOperands in translateSILPartialApply (#88828)

### DIFF
--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -2727,7 +2727,7 @@ public:
     translateSILMultiAssign(
         directResults,
         ArrayRef<Operand *>(), // No indirect results for a partial_apply.
-        makeOperandRefRange(pai->getAllOperands()));
+        pai->getRealOperands());
   }
 
   void translateCreateAsyncTask(BuiltinInst *bi) {

--- a/test/Concurrency/transfernonsendable_dynamic_self_metatype_capture.swift
+++ b/test/Concurrency/transfernonsendable_dynamic_self_metatype_capture.swift
@@ -1,0 +1,42 @@
+// RUN: %target-swift-frontend -emit-sil -parse-as-library -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify %s -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -parse-as-library -strict-concurrency=complete -target %target-swift-5.1-abi-triple %s -o - | %FileCheck %s
+
+// REQUIRES: concurrency
+
+// The region-based isolation checker used to report an "unknown pattern"
+// false positive for a `sending` closure that calls `Self.foo { ... }` from
+// within a non-final class method. The outer closure's `partial_apply`
+// captures a `@dynamic_self` metatype, which causes `self` to appear as a
+// type-defs operand on the PA. The region analysis merged every operand
+// including type-dependent ones, which incorrectly pulled `self` into the
+// closure's region and tripped the unknown-pattern fallback.
+
+func withSendingFree<R: Sendable>(
+  _ body: sending () async throws -> sending R
+) async throws -> R {
+  try await body()
+}
+
+class DynamicSelfCapture {
+  // Verify that SILGen actually emits the `@dynamic_self` metatype capture
+  // that this test is meant to exercise. If a future SILGen change stops
+  // emitting the capture, this CHECK will fail and the test should be
+  // updated to construct the pattern another way.
+  // CHECK-LABEL: sil hidden @$s49transfernonsendable_dynamic_self_metatype_capture18DynamicSelfCaptureC4testyyYaKF :
+  // CHECK: partial_apply {{.*}} : $@convention(thin) {{.*}}(@thick @dynamic_self DynamicSelfCapture.Type) ->
+  // CHECK: } // end sil function '$s49transfernonsendable_dynamic_self_metatype_capture18DynamicSelfCaptureC4testyyYaKF'
+  // expected-no-diagnostics
+  func test() async throws {
+    try await withSendingFree {
+      try await Self.withSending {
+        return ()
+      }
+    }
+  }
+
+  static func withSending<R: Sendable>(
+    _ body: sending () async throws -> sending R
+  ) async throws -> R {
+    try await body()
+  }
+}

--- a/test/Concurrency/transfernonsendable_partitionop_translation.sil
+++ b/test/Concurrency/transfernonsendable_partitionop_translation.sil
@@ -1973,6 +1973,40 @@ bb0(%0 : @guaranteed $NonSendableKlass):
   return %r : $()
 }
 
+// A chained `partial_apply` whose callee is itself a previously-built
+// closure must merge the callee's region into the outer PA. PA1 captures
+// %0; PA2 takes PA1 as its callee and additionally captures %1. The
+// translation of PA2 should `require` and `merge` against both PA1 (the
+// callee, transitively bringing %0 with it) and %1 — verifying that we
+// do not accidentally drop the callee operand when filtering out
+// type-dependent operands.
+// CHECK-LABEL: begin running test {{.*}} on test_chained_partial_apply: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %1 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %4 = partial_apply [callee_guaranteed] %2(%3) : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %6 = partial_apply [callee_guaranteed] %4(%5) : $@callee_guaranteed (@guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: require %%2:   %6 = partial_apply [callee_guaranteed] %4(%5) : $@callee_guaranteed (@guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: require %%1:   %6 = partial_apply [callee_guaranteed] %4(%5) : $@callee_guaranteed (@guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: merge %%2 with %%1:   %6 = partial_apply [callee_guaranteed] %4(%5) : $@callee_guaranteed (@guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: assign_direct %%3 = %%2:   %6 = partial_apply [callee_guaranteed] %4(%5) : $@callee_guaranteed (@guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: end running test {{.*}} on test_chained_partial_apply: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_chained_partial_apply : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass, %1 : @guaranteed $NonSendableKlass):
+  %f = function_ref @takes_two : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+  %copy0 = copy_value %0
+  %pa1 = partial_apply [callee_guaranteed] %f(%copy0) : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+  %copy1 = copy_value %1
+  %pa2 = partial_apply [callee_guaranteed] %pa1(%copy1) : $@callee_guaranteed (@guaranteed NonSendableKlass) -> ()
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %pa2 : $@callee_guaranteed () -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
 //===----------------------------------------------------------------------===//
 // MARK: Terminator Instructions
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
A closure that captures a `@dynamic_self` metatype produces a `partial_apply` with `self` appearing as a type-defs operand. The region analysis was iterating `pai->getAllOperands()` and feeding every operand to `translateSILMultiAssign`, which then merged `self`'s region with the PA's region even though no runtime value of `self` is captured.

For `sending`-parameter closures this manifested as a bogus "pattern that the region-based isolation checker does not understand how to check" diagnostic, because the spurious merge violated the region-disjoint invariant required by `sending`.

Switch to `ApplySite(pai).getArgumentOperands()`, matching `translateSILPartialApplyAsyncLetBegin` and
`translateIsolatedPartialApply`, which already use that idiom and so were never affected. The apply-site code in
`translateNonIsolationCrossingSILApply` likewise filters `isTypeDependent()` operands.

rdar://165832957

(cherry picked from commit 9d78f8493bd09cbf721857fab2b064a30b687c11)

----

- **Explanation**: Fixes a region-based isolation checker false positive ("pattern that the region-based isolation checker does not understand how to check") that fires when a closure captures a `@dynamic_self` metatype. `translateSILPartialApply` was iterating `pai->getAllOperands()` and feeding every operand — including the type-dependent `self` operand — through `translateSILMultiAssign`, which merged `self`'s region with the partial_apply's region even though no runtime value of `self` is captured. Under `sending` parameters, this spurious merge violated the region-disjoint invariant and tripped `RegionIsolationUnknownPattern`. The fix switches to `ApplySite(pai).getRealOperands()`, matching the idiom already used by `translateSILPartialApplyAsyncLetBegin` and `translateIsolatedPartialApply` (and the apply-site code in `translateNonIsolationCrossingSILApply`, which filters `isTypeDependent()` operands).
- **Scope**: Narrow. Only affects RegionAnalysis handling of `partial_apply` instructions whose `getAllOperands()` includes type-dependent operands (e.g., closures capturing a `@dynamic_self` metatype). Eliminates a false-positive diagnostic; does not relax checking in any other path.
- **Issues**: rdar://165832957
- **Original PRs**: https://github.com/swiftlang/swift/pull/88828
- **Risk**: Low. The change is localized to a single iteration in `translateSILPartialApply` and aligns it with the idiom already used by sibling partial_apply translators. Non-type-dependent operands are unchanged; worst case would be a missed diagnostic in the previously-misbehaving case, not a miscompile.
- **Testing**: Covered by the test additions in the original PR. Full check-swift run locally.
- **Original Author**: @airspeedswift (Ben Cohen)
- **Reviewers**: @gottesmm (Michael Gottesman) reviewed and approved the original PR. Note: Michael is opening this cherry-pick PR on behalf of the original author; he was the reviewer, not the author.