### PR TITLE
[windows] fix build with Visual Studio 2026

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1819,7 +1819,7 @@ $Compilers = @{
     C = @{
       Executable        = "cl.exe"
       DriverStyle       = [DriverStyle]::CL
-      Flags             = @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:inline", "/Zc:preprocessor")
+      Flags             = @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:inline", "/Zc:preprocessor", "/source-charset:utf-8")
       DebugFlags        = { param([string] $Format)
         @()
       }
@@ -1828,7 +1828,7 @@ $Compilers = @{
     CXX = @{
       Executable        = "cl.exe"
       DriverStyle       = [DriverStyle]::CL
-      Flags             = @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:inline", "/Zc:preprocessor", "/Zc:__cplusplus")
+      Flags             = @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:inline", "/Zc:preprocessor", "/Zc:__cplusplus", "/source-charset:utf-8")
       DebugFlags        = { param([string] $Format)
         @()
       }
@@ -2621,6 +2621,17 @@ function Get-CMarkBinaryCache([Hashtable] $Platform) {
 }
 
 function Build-CMark([Hashtable] $Platform) {
+  $Defines = @{
+    BUILD_SHARED_LIBS = "YES";
+    BUILD_TESTING = "NO";
+    CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP = "YES";
+  }
+
+  if ($Compilers.Host.C.DriverStyle -eq [DriverStyle]::CL) {
+    $Defines["CMAKE_C_FLAGS"] = @("/execution-charset:utf-8")
+    $Defines["CMAKE_CXX_FLAGS"] = @("/execution-charset:utf-8")
+  }
+
   Build-CMakeProject `
     -Src $SourceCache\cmark `
     -Bin (Get-CMarkBinaryCache $Platform) `
@@ -2628,11 +2639,7 @@ function Build-CMark([Hashtable] $Platform) {
     -Platform $Platform `
     -CCompiler $Compilers.Host.C `
     -CXXCompiler $Compilers.Host.CXX `
-    -Defines @{
-      BUILD_SHARED_LIBS = "YES";
-      BUILD_TESTING = "NO";
-      CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP = "YES";
-    }
+    -Defines $Defines
 }
 
 function Copy-CMarkRuntimeToToolchain([Hashtable] $Platform, [string] $ToolchainRoot) {

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1838,7 +1838,7 @@ $Compilers = @{
     C = @{
       Executable        = "cl.exe"
       DriverStyle       = [DriverStyle]::CL
-      Flags             = @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:inline", "/Zc:preprocessor")
+      Flags             = @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:inline", "/Zc:preprocessor", "/source-charset:utf-8")
       DebugFlags        = { param([string] $Format)
         @()
       }
@@ -1847,7 +1847,7 @@ $Compilers = @{
     CXX = @{
       Executable        = "cl.exe"
       DriverStyle       = [DriverStyle]::CL
-      Flags             = @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:inline", "/Zc:preprocessor", "/Zc:__cplusplus")
+      Flags             = @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:inline", "/Zc:preprocessor", "/Zc:__cplusplus", "/source-charset:utf-8")
       DebugFlags        = { param([string] $Format)
         @()
       }


### PR DESCRIPTION
Building with Visual Studio 2026 fails due to non unicode characters in the codebase (https://github.com/swiftlang/swift/blob/4fc88ac5bf0c5261227e8373be4c308411920f11/include/swift/AST/LocalizationLanguages.def#L138)

This patch adds the `/source-charset:utf-8` flag to both the C and CXX compiler to tell it that the source code encoding is `UTF-8`.