### PR TITLE
build-script: Default --llvm-enable-index-store=0 when --sccache is set

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -339,6 +339,13 @@ def apply_default_arguments(toolchain, args):
     if ninja_required and toolchain.ninja is None:
         args.build_ninja = True
 
+    # Force --llvm-enable-index-store off when --sccache is in use. sccache
+    # can't cache compilations that emit -index-store-path side outputs, so
+    # leaving the index store enabled forces a cache miss on every
+    # translation unit.
+    if args.sccache:
+        args.llvm_enable_index_store = False
+
     # Enable test colors if we're on a tty.
     if args.color_in_tests and sys.stdout.isatty():
         args.lit_args += " --param color_output"

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -1520,7 +1520,10 @@ def create_argument_parser():
            default=True,
            help='emit -index-store-path while building LLVM/Clang and Swift '
                 'host tools (gated on the host compiler accepting the flag, '
-                'so it is a no-op for older compilers). Defaults to ON.')
+                'so it is a no-op for older compilers). Defaults to ON, but '
+                'is forced OFF when --sccache is in use (sccache cannot '
+                'cache the index-store side outputs and would otherwise '
+                'miss on every translation unit).')
 
     option('--llvm-targets-to-build', store,
            default='X86;ARM;AArch64;PowerPC;SystemZ;Mips;RISCV;WebAssembly;AVR;BPF',


### PR DESCRIPTION
sccache can't cache compilations that emit -index-store-path side outputs: it sees the extra .o.indexstore-derived files as inputs that vary per source location and bails. With the index store left on, every translation unit misses the cache, which defeats the entire reason sccache was requested.

Switch --llvm-enable-index-store's default from a hard True to a None sentinel, then resolve it in apply_default_arguments() against args.sccache: ON when sccache is off (preserves prior behavior), OFF when sccache is on. Explicit --llvm-enable-index-store / --no-llvm- enable-index-store on the command line still wins because the action overwrites the None during parse.
