### PR TITLE
[6.4][Sema] Suppress non-Sendable superclass diagnostic for inherited isolation

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7635,7 +7635,13 @@ bool swift::checkSendableConformance(
       if (auto superclassDecl = classDecl->getSuperclassDecl()) {
         // `NSObject` is permitted as a superclass for Objective-C interop.
         // TODO: can `NSObject` be `Sendable` or `~Sendable` instead?
-        if (!superclassDecl->isNSObject()) {
+        // Synthesizing a Sendable conformance for global-actor-isolated
+        // classes with non-Sendable superclasses was a mistake, but we
+        // maintain it for source compatibility. When the conformance
+        // is implicit (the user never wrote Sendable), skip the
+        // diagnostic entirely.
+        if (!superclassDecl->isNSObject() &&
+            !(isGlobalActorIsolated && isImplicitSendableCheck(check))) {
           // Inheritance checking for global-actor-isolated classes was
           // historically skipped, so we need to downgrade this to a warning to
           // stage it in.

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -393,6 +393,34 @@ final class C14: Sendable { // expected-warning{{default initializer for 'C14' c
   @SomeActor let nc1 = NotConcurrent()
 }
 
+// Synthesizing an implicit Sendable conformance for global-actor-isolated
+// classes with non-Sendable superclasses was a mistake, but it is maintained
+// for source compatibility. When Sendable is not explicitly stated, the
+// diagnostic is suppressed.
+@MainActor
+class IsolatedNonSendable: NotSendable {}
+
+final class InheritedIsolationSubclass: IsolatedNonSendable {}
+
+func requiresSendable<T: Sendable>(_: T.Type) {}
+func testInheritedIsolationIsSendable() {
+  requiresSendable(InheritedIsolationSubclass.self)
+}
+
+// When Sendable IS explicitly requested, the diagnostic should still fire.
+protocol RefinesSendable: Sendable {}
+
+final class InheritedIsolationExplicitSendable: IsolatedNonSendable, Sendable {}
+// expected-warning @-1 {{class 'InheritedIsolationExplicitSendable' cannot conform to the 'Sendable' protocol; this will be an error in a future Swift language mode}}
+// expected-note @-2 {{a 'Sendable' class cannot inherit from a non-Sendable class}}
+// expected-note @-3 {{inherits from non-Sendable class 'IsolatedNonSendable'}}
+
+@MainActor
+final class IsolatedRefinedSendable: NotSendable, RefinesSendable {}
+// expected-warning @-1 {{class 'IsolatedRefinedSendable' cannot conform to the 'Sendable' protocol; this will be an error in a future Swift language mode}}
+// expected-note @-2 {{a 'Sendable' class cannot inherit from a non-Sendable class}}
+// expected-note @-3 {{inherits from non-Sendable class 'NotSendable'}}
+
 extension NotConcurrent {
   func f() { }
 

--- a/test/Concurrency/concurrent_value_checking_objc.swift
+++ b/test/Concurrency/concurrent_value_checking_objc.swift
@@ -1,5 +1,6 @@
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -strict-concurrency=complete %s -emit-sil -o /dev/null -verify -verify-additional-prefix ni-
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -strict-concurrency=complete %s -emit-sil -o /dev/null -verify -verify-additional-prefix ni-ns- -enable-upcoming-feature NonisolatedNonsendingByDefault
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -strict-concurrency=complete %s -emit-sil -o /dev/null -verify -verify-additional-prefix ni- -verify-additional-prefix swift5-
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -strict-concurrency=complete %s -emit-sil -o /dev/null -verify -verify-additional-prefix ni-ns- -verify-additional-prefix swift5- -enable-upcoming-feature NonisolatedNonsendingByDefault
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-sil -o /dev/null -verify -verify-additional-prefix ni- -verify-additional-prefix swift6- -swift-version 6
 
 // REQUIRES: concurrency
 // REQUIRES: objc_interop
@@ -13,17 +14,21 @@ final class A: NSObject, Sendable {
 }
 
 final class B: NSObject, Sendable {
-  var x: Int = 5 // expected-warning{{stored property 'x' of 'Sendable'-conforming class 'B' is mutable}}
+  var x: Int = 5
+  // expected-swift5-warning @-1 {{stored property 'x' of 'Sendable'-conforming class 'B' is mutable}}
+  // expected-swift6-error @-2 {{stored property 'x' of 'Sendable'-conforming class 'B' is mutable}}
 }
 
 class C { } // expected-note{{class 'C' does not conform to the 'Sendable' protocol}}
 
 final class D: NSObject, Sendable {
-  let c: C = C() // expected-warning{{stored property 'c' of 'Sendable'-conforming class 'D' has non-Sendable type 'C'}}
+  let c: C = C()
+  // expected-swift5-warning @-1 {{stored property 'c' of 'Sendable'-conforming class 'D' has non-Sendable type 'C'}}
+  // expected-swift6-error @-2 {{stored property 'c' of 'Sendable'-conforming class 'D' has non-Sendable type 'C'}}
 }
 
 @MainActor
-final class IsolatedNSObjectSubclass: NSObject, Sendable {}
+class IsolatedNSObjectSubclass: NSObject, Sendable {}
 
 class NSObjectSubclass: NSObject {}
 
@@ -33,4 +38,13 @@ class IsolatedObjCSubclass: NSObjectSubclass, Sendable {}
 // expected-note@-2:7 {{a 'Sendable' class cannot inherit from a non-Sendable class}}
 // expected-note@-3:29 {{inherits from non-Sendable class 'NSObjectSubclass'}}
 
+// NSObject is Sendable, so @MainActor subclasses of NSObject inherit
+// Sendable through the normal inherited-conformance path. Their subclasses
+// should also be Sendable with no diagnostic.
+class InheritedFromIsolatedNSObject: IsolatedNSObjectSubclass {}
 
+func requiresSendable<T: Sendable>(_: T.Type) {}
+func testNSObjectChainIsSendable() {
+  requiresSendable(IsolatedNSObjectSubclass.self)
+  requiresSendable(InheritedFromIsolatedNSObject.self)
+}


### PR DESCRIPTION
- **Explanation**:
Suppresses the diagnostic added in https://github.com/swiftlang/swift/pull/89980 in the case where the Sendability was incorrectly inferred. Since the other cherry pick only emitted a warning and didn't change isolation / Sendability, this isn't a compilation issue, but it is annoying for users. We need to stop inferring Sendable in this case, but we can't make that change in 6.4 so we must not emit a warning the programmer can't do anything about and didn't cause. 
- **Scope**:
This prevents emitting a warning when `Sendable` wasn't written anywhere by the programmer, but we infer it and then complain that it can't coexist with isolation. It doesn't disable the inferred isolation / `Sendable`, so it shouldn't affect how anything complies. 
- **Issues**:
Fixes an issue from resolving rdar://138927573
- **Original PRs**:
https://github.com/swiftlang/swift/pull/90186 authored by @AdamCmiel
- **Risk**:
It is possible that this now under diagnoses in some legitimately unsound case, although I feel its more important not to introduce spurious warnings at this point in 6.4. Since we were not diagnosing at all in this case prior to the previous change I made, and it is only a warning which does not affect sendability or isolation, I think there is no real risk of underdiagnosing.
- **Testing**:
The tests added in this PR, which emit a warning without this code change even though the programmer didn't write `Sendable`. 
- **Reviewers**:
@a-viv-a + a discussion in DMs with @xedin 