### PR TITLE
[test][android] Temporarily disable Reflection/typeref_lowering.swift test

### DIFF
--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -12,6 +12,9 @@
 // rdar://100558042
 // UNSUPPORTED: CPU=arm64e
 
+// This started failing for Android with #89305, disable until NDK 30 is used.
+// XFAIL: OS=linux-android, OS=linux-androideabi
+
 // RUN: %target-build-swift -target %target-swift-5.2-abi-triple -Xfrontend -disable-availability-checking %S/Inputs/TypeLowering.swift -parse-as-library -emit-module -emit-library %no-fixup-chains -module-name TypeLowering -o %t/%target-library-name(TypesToReflect)
 // RUN: %target-build-swift -target %target-swift-5.2-abi-triple -Xfrontend -disable-availability-checking %S/Inputs/TypeLowering.swift %S/Inputs/main.swift -emit-module -emit-executable %no-fixup-chains -module-name TypeLowering -o %t/TypesToReflect
 


### PR DESCRIPTION
This can be enabled again once we switch to the upcoming LTS NDK 30.