### PR TITLE
AST: Stop special-casing universal domain in `computeRuntimeAvailability()`

### DIFF
--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -505,10 +505,6 @@ computeDeclRuntimeAvailability(const Decl *decl) {
       continue;
 
     llvm::erase_if(unavailableDomains, [domain](auto unavailableDomain) {
-      // Unavailability in '*' cannot be superseded by an @available attribute
-      // for a more specific availability domain.
-      if (unavailableDomain.isUniversal())
-        return false;
       return unavailableDomain.contains(domain);
     });
   }


### PR DESCRIPTION
When https://github.com/swiftlang/swift/pull/87874 stopped treating the universal availability domain as the bottom domain, the special case in `computeRuntimeAvailability()` became unnecessary. The tests introduced in https://github.com/swiftlang/swift/pull/84070 verify that code generation behavior remains correct without the exception.
