### PR TITLE
[test] Check that Werror on parent group applies to normal emitted child

### DIFF
--- a/test/diagnostics/werror_parent_group_region_isolation.swift
+++ b/test/diagnostics/werror_parent_group_region_isolation.swift
@@ -1,0 +1,22 @@
+// Default: the child group's diagnostic is a warning in language mode 5.
+// RUN: %target-swift-frontend -emit-sil -o /dev/null %s -target %target-swift-5.1-abi-triple -strict-concurrency=complete -swift-version 5 -verify -verify-additional-prefix warnonly-
+
+// Ensure escalated with `-Werror` on the child group.
+// RUN: %target-swift-frontend -emit-sil -o /dev/null %s -target %target-swift-5.1-abi-triple -strict-concurrency=complete -swift-version 5 -Werror SendingRisksDataRace -verify -verify-additional-prefix erronly-
+
+// Ensure escalated with `-Werror` on the parent group.
+// RUN: %target-swift-frontend -emit-sil -o /dev/null %s -target %target-swift-5.1-abi-triple -strict-concurrency=complete -swift-version 5 -Werror RegionIsolation -verify -verify-additional-prefix erronly-
+
+// REQUIRES: concurrency
+
+class NS {}
+
+@MainActor func take(_ x: NS) {}
+
+func test() async {
+  let x = NS()
+  await take(x) // expected-warnonly-warning {{sending 'x' risks causing data races}}
+  // expected-erronly-error@-1 {{sending 'x' risks causing data races}}
+  // expected-note@-2 {{sending 'x' to main actor-isolated global function 'take' risks causing data races between main actor-isolated and local nonisolated uses}}
+  print(x) // expected-note {{access can happen concurrently}}
+}


### PR DESCRIPTION
Just adding a regression test, I don't think we have a test in the case that isn't default ignored, like RBI

Resolves rdar://169618849
Resolves #86978

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
