### PR TITLE
[test] Don't override StdlibDeploymentTarget in backdeployment runs

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -584,6 +584,16 @@ def availability_macro_to_current(macro):
     stdlib_vers = matches.group(1)
     orig_spec = matches.group(2)
 
+    # In backdeployment test runs (where tests use the OS-shipped stdlib
+    # rather than the just-built one) we want to exercise the real
+    # availability constraints with no compile-time overrides, so
+    # `StdlibDeploymentTarget X.Y` must exactly match `SwiftStdlib X.Y`.
+    # Otherwise `#available(StdlibDeploymentTarget X.Y, *)` would fold to
+    # the runner's OS version and execute code paths that the OS-shipped
+    # stdlib doesn't actually provide.
+    if 'use_os_stdlib' in lit_config.params:
+        return f"StdlibDeploymentTarget {stdlib_vers}:{orig_spec}"
+
     vers_by_platform = {}
     for platform_vers in orig_spec.split(', '):
         components = platform_vers.split(' ')


### PR DESCRIPTION
## Summary

`availability_macro_to_current` in `test/lit.cfg` builds a `StdlibDeploymentTarget X.Y` macro for every `SwiftStdlib X.Y` defined in `utils/availability-macros.def`, capping the platform version at the runner's OS version. The intent (per the comment in `utils/availability-macros.def`) is that the cap lets tests of the just-built standard library use new functions and types that ship in the OS that the runner is on.

In backdeployment test runs that swap to the OS-shipped stdlib via the `use_os_stdlib` lit param, that cap turns into a footgun. With the cap in place, `#available(StdlibDeploymentTarget X.Y, *)` on (say) a macOS 10.15 runner folds to `#available(macOS 10.15, *)`, which is always true, and tests then exercise code that the OS-shipped stdlib on that runner doesn't actually provide.

In backdeployment mode we want availability checks to be exactly what the source says, with no test-harness overrides. Skip the back-dating when `use_os_stdlib` is set so that `StdlibDeploymentTarget X.Y` matches `SwiftStdlib X.Y` exactly.

rdar://162993317
