### PR TITLE
Frontend: introduce -emit-silgen-ossa

### DIFF
--- a/docs/DebuggingTheCompiler.md
+++ b/docs/DebuggingTheCompiler.md
@@ -85,10 +85,18 @@ Here is how to dump the IR after the main phases of the Swift compiler
 swiftc -dump-ast -O file.swift
 ```
 
-* **SILGen** To print the SIL immediately after SILGen:
+* **SILGen** To print the SIL immediately after SILGen (without any SIL verification):
 
 ```sh
-swiftc -emit-silgen -O file.swift
+swiftc -emit-silgen file.swift
+```
+
+* **SILGen (OSSA)** To print verified SIL immediately after SILGen's cleanup passes that 
+  turn it into complete OSSA SIL, stopping before running any diagnostic passes. This is a
+  frontend-only flag:
+
+```sh
+swift-frontend -emit-silgen-ossa file.swift
 ```
 
 * **Mandatory SIL passes** To print the SIL after the mandatory passes:

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -197,6 +197,7 @@ public:
     EmitImportedModules, ///< Emit the modules that this one imports
     EmitPCH,             ///< Emit PCH of imported bridging header
 
+    EmitSILGenOSSA, ///< SIL after SILGen's cleanup passes (complete OSSA).
     EmitSILGen, ///< Emit raw SIL
     EmitSIL,    ///< Emit canonical SIL
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1449,6 +1449,8 @@ def emit_sil : Flag<["-"], "emit-sil">,
   HelpText<"Emit canonical SIL file(s)">, ModeOpt;
 def emit_silgen : Flag<["-"], "emit-silgen">,
   HelpText<"Emit raw SIL file(s)">, ModeOpt;
+def emit_silgen_ossa : Flag<["-"], "emit-silgen-ossa">,
+  HelpText<"Emit raw SIL file(s) at the earliest point it has reached complete OSSA after SILGen">, ModeOpt;
 def emit_lowered_sil : Flag<["-"], "emit-lowered-sil">,
   HelpText<"Emit lowered SIL file(s)">, ModeOpt;
 def emit_sib : Flag<["-"], "emit-sib">,

--- a/include/swift/SILOptimizer/PassManager/Passes.h
+++ b/include/swift/SILOptimizer/PassManager/Passes.h
@@ -28,10 +28,16 @@ namespace swift {
     class IRGenModule;
   }
 
+  /// Run the SIL passes that SILGen relies on to produce fully verified SIL.
+  /// This happens immediately after SILGen.
+  ///
+  /// \param VerifySILGen whether the caller requests verification.
+  void runSILGenPasses(SILModule &M, bool VerifySILGen=false);
+
   /// Run all the SIL diagnostic passes on \p M.
   ///
   /// \returns true if the diagnostic passes produced an error
-  bool runSILDiagnosticPasses(SILModule &M);
+  bool runSILDiagnosticPasses(SILModule &M, bool RunSILGenPasses=true);
 
   /// Run all the SIL performance optimization passes on \p M.
   void runSILOptimizationPasses(SILModule &M);

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -668,6 +668,8 @@ ArgsToFrontendOptionsConverter::determineRequestedAction(const ArgList &args) {
     return FrontendOptions::ActionType::EmitSIL;
   if (Opt.matches(OPT_emit_silgen))
     return FrontendOptions::ActionType::EmitSILGen;
+  if (Opt.matches(OPT_emit_silgen_ossa))
+    return FrontendOptions::ActionType::EmitSILGenOSSA;
   if (Opt.matches(OPT_emit_lowered_sil))
     return FrontendOptions::ActionType::EmitLoweredSIL;
   if (Opt.matches(OPT_emit_sib))

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -533,6 +533,7 @@ static bool shouldEmitFineModuleTrace(FrontendOptions::ActionType action) {
   switch(action) {
   case swift::FrontendOptions::ActionType::Typecheck:
   case swift::FrontendOptions::ActionType::EmitSILGen:
+  case swift::FrontendOptions::ActionType::EmitSILGenOSSA:
   case swift::FrontendOptions::ActionType::EmitSIL:
   case swift::FrontendOptions::ActionType::EmitAssembly:
   case swift::FrontendOptions::ActionType::EmitLoweredSIL:

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1855,9 +1855,10 @@ static bool performMandatorySILPasses(CompilerInvocation &Invocation,
                                       SILModule *SM) {
   FrontendStatsTracer tracer(SM->getASTContext().Stats,
                              "SIL-mandatory-passes");
+  auto Action = Invocation.getFrontendOptions().RequestedAction;
+
   // Don't run diagnostic passes at all when merging modules.
-  if (Invocation.getFrontendOptions().RequestedAction ==
-      FrontendOptions::ActionType::MergeModules) {
+  if (Action == FrontendOptions::ActionType::MergeModules) {
     return false;
   }
   if (Invocation.getDiagnosticOptions().SkipDiagnosticPasses) {
@@ -1865,7 +1866,18 @@ static bool performMandatorySILPasses(CompilerInvocation &Invocation,
     // to run the ownership evaluator.
     return runSILOwnershipEliminatorPass(*SM);
   }
-  return runSILDiagnosticPasses(*SM);
+
+  const bool RequestedSILGenOSSA =
+    (Action == FrontendOptions::ActionType::EmitSILGenOSSA);
+
+  // Run the passes SILGen relies on to reach verified OSSA SIL.
+  runSILGenPasses(*SM, /*VerifySILGen=*/RequestedSILGenOSSA);
+
+  // Stop here if the OSSA after SILGen is all that was requested.
+  if (RequestedSILGenOSSA)
+    return true;
+
+  return runSILDiagnosticPasses(*SM, /*RunSILGenPasses=*/false);
 }
 
 /// Perform SIL optimization passes if optimizations haven't been disabled.

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -45,6 +45,7 @@ bool FrontendOptions::needsProperModuleName(ActionType action) {
   case ActionType::EmitPCH:
   case ActionType::EmitPolyglotAST:
     return false;
+  case ActionType::EmitSILGenOSSA:
   case ActionType::EmitSILGen:
   case ActionType::EmitSIL:
   case ActionType::EmitLoweredSIL:
@@ -112,6 +113,7 @@ bool FrontendOptions::doesActionRequireSwiftStandardLibrary(ActionType action) {
   case ActionType::PrintAST:
   case ActionType::PrintASTDecl:
   case ActionType::DumpScopeMaps:
+  case ActionType::EmitSILGenOSSA:
   case ActionType::EmitSILGen:
   case ActionType::EmitSIL:
   case ActionType::EmitLoweredSIL:
@@ -158,6 +160,7 @@ bool FrontendOptions::doesActionRequireInputs(ActionType action) {
   case ActionType::PrintAST:
   case ActionType::PrintASTDecl:
   case ActionType::DumpScopeMaps:
+  case ActionType::EmitSILGenOSSA:
   case ActionType::EmitSILGen:
   case ActionType::EmitSIL:
   case ActionType::EmitLoweredSIL:
@@ -201,6 +204,7 @@ bool FrontendOptions::doesActionPerformEndOfPipelineActions(ActionType action) {
   case ActionType::PrintAST:
   case ActionType::PrintASTDecl:
   case ActionType::DumpScopeMaps:
+  case ActionType::EmitSILGenOSSA:
   case ActionType::EmitSILGen:
   case ActionType::EmitSIL:
   case ActionType::EmitLoweredSIL:
@@ -254,6 +258,7 @@ bool FrontendOptions::supportCompilationCaching(ActionType action) {
   case ActionType::EmitIR:
   case ActionType::EmitBC:
   case ActionType::EmitObject:
+  case ActionType::EmitSILGenOSSA:
   case ActionType::EmitSILGen:
   case ActionType::EmitSIL:
   case ActionType::EmitLoweredSIL:
@@ -313,6 +318,7 @@ FrontendOptions::formatForPrincipalOutputFileForAction(ActionType action) {
   case ActionType::EmitPCH:
     return TY_PCH;
 
+  case ActionType::EmitSILGenOSSA:
   case ActionType::EmitSILGen:
     return TY_RawSIL;
 
@@ -394,6 +400,7 @@ bool FrontendOptions::canActionEmitDependencies(ActionType action) {
   case ActionType::MergeModules:
   case ActionType::EmitModuleOnly:
   case ActionType::EmitPCH:
+  case ActionType::EmitSILGenOSSA:
   case ActionType::EmitSILGen:
   case ActionType::EmitSIL:
   case ActionType::EmitLoweredSIL:
@@ -439,6 +446,7 @@ bool FrontendOptions::canActionEmitReferenceDependencies(ActionType action) {
   case ActionType::MergeModules:
   case ActionType::EmitModuleOnly:
   case ActionType::EmitPCH:
+  case ActionType::EmitSILGenOSSA:
   case ActionType::EmitSILGen:
   case ActionType::EmitSIL:
   case ActionType::EmitLoweredSIL:
@@ -469,6 +477,7 @@ bool FrontendOptions::canActionEmitModuleSummary(ActionType action) {
   case ActionType::EmitPCH:
   case ActionType::DumpScopeMaps:
   case ActionType::DumpTypeInfo:
+  case ActionType::EmitSILGenOSSA:
   case ActionType::EmitSILGen:
   case ActionType::EmitSIBGen:
   case ActionType::CompileModuleFromInterface:
@@ -525,6 +534,7 @@ bool FrontendOptions::canActionEmitClangHeader(ActionType action) {
   case ActionType::Typecheck:
   case ActionType::MergeModules:
   case ActionType::EmitModuleOnly:
+  case ActionType::EmitSILGenOSSA:
   case ActionType::EmitSILGen:
   case ActionType::EmitSIL:
   case ActionType::EmitLoweredSIL:
@@ -568,6 +578,7 @@ bool FrontendOptions::canActionEmitLoadedModuleTrace(ActionType action) {
   case ActionType::MergeModules:
   case ActionType::EmitModuleOnly:
   case ActionType::EmitPCH:
+  case ActionType::EmitSILGenOSSA:
   case ActionType::EmitSILGen:
   case ActionType::EmitSIL:
   case ActionType::EmitLoweredSIL:
@@ -602,6 +613,7 @@ bool FrontendOptions::canActionEmitModuleSemanticInfo(ActionType action) {
   case ActionType::EmitPCH:
   case ActionType::DumpScopeMaps:
   case ActionType::DumpTypeInfo:
+  case ActionType::EmitSILGenOSSA:
   case ActionType::EmitSILGen:
   case ActionType::TypecheckModuleFromInterface:
   case ActionType::Immediate:
@@ -660,6 +672,7 @@ bool FrontendOptions::canActionEmitConstValues(ActionType action) {
   case ActionType::MergeModules:
   case ActionType::EmitModuleOnly:
   case ActionType::EmitPCH:
+  case ActionType::EmitSILGenOSSA:
   case ActionType::EmitSILGen:
   case ActionType::EmitSIL:
   case ActionType::EmitLoweredSIL:
@@ -689,6 +702,7 @@ bool FrontendOptions::canActionEmitModule(ActionType action) {
   case ActionType::EmitPCH:
   case ActionType::DumpScopeMaps:
   case ActionType::DumpTypeInfo:
+  case ActionType::EmitSILGenOSSA:
   case ActionType::EmitSILGen:
   case ActionType::CompileModuleFromInterface:
   case ActionType::TypecheckModuleFromInterface:
@@ -735,6 +749,7 @@ bool FrontendOptions::canActionEmitInterface(ActionType action) {
   case ActionType::EmitPCH:
   case ActionType::DumpScopeMaps:
   case ActionType::DumpTypeInfo:
+  case ActionType::EmitSILGenOSSA:
   case ActionType::EmitSILGen:
   case ActionType::EmitSIBGen:
   case ActionType::CompileModuleFromInterface:
@@ -778,6 +793,7 @@ bool FrontendOptions::canActionEmitAPIDescriptor(ActionType action) {
   case ActionType::EmitPCH:
   case ActionType::DumpScopeMaps:
   case ActionType::DumpTypeInfo:
+  case ActionType::EmitSILGenOSSA:
   case ActionType::EmitSILGen:
   case ActionType::EmitSIBGen:
   case ActionType::CompileModuleFromInterface:
@@ -820,6 +836,7 @@ bool FrontendOptions::doesActionProduceOutput(ActionType action) {
   case ActionType::PrintASTDecl:
   case ActionType::DumpScopeMaps:
   case ActionType::EmitPCH:
+  case ActionType::EmitSILGenOSSA:
   case ActionType::EmitSILGen:
   case ActionType::EmitSIL:
   case ActionType::EmitLoweredSIL:
@@ -879,6 +896,7 @@ bool FrontendOptions::doesActionProduceTextualOutput(ActionType action) {
   case ActionType::PrintASTDecl:
   case ActionType::DumpScopeMaps:
   case ActionType::EmitImportedModules:
+  case ActionType::EmitSILGenOSSA:
   case ActionType::EmitSILGen:
   case ActionType::EmitSIL:
   case ActionType::EmitLoweredSIL:
@@ -919,6 +937,7 @@ bool FrontendOptions::doesActionGenerateSIL(ActionType action) {
   case ActionType::PrintArguments:
   case ActionType::EmitPolyglotAST:
     return false;
+  case ActionType::EmitSILGenOSSA:
   case ActionType::EmitSILGen:
   case ActionType::EmitSIBGen:
   case ActionType::EmitSIL:
@@ -957,6 +976,7 @@ bool FrontendOptions::doesActionGenerateIR(ActionType action) {
   case ActionType::MergeModules:
   case ActionType::EmitModuleOnly:
   case ActionType::EmitPCH:
+  case ActionType::EmitSILGenOSSA:
   case ActionType::EmitSILGen:
   case ActionType::EmitSIL:
   case ActionType::EmitLoweredSIL:
@@ -1001,6 +1021,7 @@ bool FrontendOptions::doesActionBuildModuleFromInterface(ActionType action) {
   case ActionType::MergeModules:
   case ActionType::EmitModuleOnly:
   case ActionType::EmitPCH:
+  case ActionType::EmitSILGenOSSA:
   case ActionType::EmitSILGen:
   case ActionType::EmitSIL:
   case ActionType::EmitLoweredSIL:

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1444,6 +1444,7 @@ static bool performAction(CompilerInstance &Instance, int &ReturnValue,
         });
   }
   case FrontendOptions::ActionType::EmitSILGen:
+  case FrontendOptions::ActionType::EmitSILGenOSSA:
   case FrontendOptions::ActionType::EmitSIBGen:
   case FrontendOptions::ActionType::EmitSIL:
   case FrontendOptions::ActionType::EmitLoweredSIL:
@@ -2201,8 +2202,17 @@ static bool performCompileStepsPostSILGen(
   SM->setSerializeSILAction(SerializeSILModuleAction);
 
   // Perform optimizations and mandatory/diagnostic passes.
-  if (Instance.performSILProcessing(SM.get()))
+  if (Instance.performSILProcessing(SM.get())) {
+
+    // If requested, the performSILProcessing stopped at the first point
+    // it reached OSSA SIL, so emit that.
+    if (Action == FrontendOptions::ActionType::EmitSILGenOSSA) {
+      return writeSIL(*SM, PSPs, Instance, Invocation.getSILOptions());
+    }
+
+    // Some other error occurred.
     return true;
+  }
 
   if (observer)
     observer->performedSILProcessing(*SM);

--- a/lib/SILOptimizer/PassManager/Passes.cpp
+++ b/lib/SILOptimizer/PassManager/Passes.cpp
@@ -41,25 +41,44 @@
 
 using namespace swift;
 
-bool swift::runSILDiagnosticPasses(SILModule &Module) {
+void swift::runSILGenPasses(SILModule &Module, bool VerifySILGen) {
   auto &opts = Module.getOptions();
 
   // Verify the module, if required.
-  // OSSA lifetimes are incomplete until the SILGenCleanup pass runs.
-  if (opts.VerifyAll)
+  // OSSA lifetimes are incomplete until after the SILGenCleanup pass runs.
+  if (opts.VerifyAll || VerifySILGen)
     Module.verifyIncompleteOSSA();
 
   // If we parsed a .sil file that is already in canonical form, don't rerun
-  // the diagnostic passes.
+  // the SILGen passes.
+  // TODO: would be nice if we had a "SILGen stage".
   if (Module.getStage() != SILStage::Raw)
-    return false;
+    return;
 
   executePassPipelinePlan(&Module,
                           SILPassPipelinePlan::getSILGenPassPipeline(opts),
                           /*isMandatory*/ true);
 
-  if (opts.VerifyAll)
+  // Check linear OSSA lifetimes.
+  if (opts.VerifyAll || VerifySILGen)
     Module.verifyOwnership();
+}
+
+bool swift::runSILDiagnosticPasses(SILModule &Module, bool RunSILGenPasses) {
+  // Callers may need us to run the pre-requisite SILGenPassPipeline first.
+  if (RunSILGenPasses)
+    runSILGenPasses(Module);
+
+  auto &opts = Module.getOptions();
+
+  // Ensure we're starting with something verified.
+  if (opts.VerifyAll)
+    Module.verify();
+
+  // If we parsed a .sil file that is already in canonical form, don't rerun
+  // the diagnostic passes.
+  if (Module.getStage() != SILStage::Raw)
+    return false;
 
   executePassPipelinePlan(&Module,
                           SILPassPipelinePlan::getDiagnosticPassPipeline(opts),

--- a/test/SILGen/argument_shuffle.swift
+++ b/test/SILGen/argument_shuffle.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s
+// RUN: %target-swift-emit-silgen-ossa %s
 
 struct Horse<T> {
   func walk(_: (String, Int), reverse: Bool) {}

--- a/test/SILGen/capture_list.swift
+++ b/test/SILGen/capture_list.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s
+// RUN: %target-swift-emit-silgen-ossa %s
 
 // Capture list with weak capture vs noescape closure
 func transform<T>(fn: () -> T) -> T {
@@ -10,23 +10,6 @@ func transform<T>(fn: () -> T) -> T {
 class Bar {
   var x: Int = 27
 
-  // CHECK-LABEL: sil hidden @$s12capture_list3BarC4testyyF : $@convention(method) (@guaranteed Bar) -> ()
-  // CHECK: [[FN:%.*]] = function_ref @$s12capture_list9transformxxyc2fn_tlF : $@convention(thin) <τ_0_0> (@owned @callee_owned () -> @out τ_0_0) -> @out τ_0_0
-  // CHECK: [[RESULT:%.*]] = alloc_stack $Int
-  // CHECK: [[BOX:%.*]] = alloc_box ${ var @sil_weak Optional<Bar> }
-  // CHECK: [[PAYLOAD:%.*]] = project_box [[BOX]]
-  // CHECK: [[COPY:%.*]] = copy_value %0
-  // CHECK: [[OPTIONAL_COPY:%.*]] = enum $Optional<Bar>, #Optional.some!enumelt
-  // CHECK: store_weak [[OPTIONAL_COPY]] to [init] [[PAYLOAD]]
-  // CHECK: destroy_value [[OPTIONAL_COPY]]
-  // CHECK: [[CLOSURE_FN:%.*]] = function_ref @$s12capture_list3BarC4testyyFSiycfU_ : $@convention(thin) (@owned { var @sil_weak Optional<Bar> }) -> Int
-  // CHECK: [[BOX_COPY:%.*]] = copy_value [[BOX]]
-  // CHECK: [[CLOSURE:%.*]] = partial_apply [[CLOSURE_FN]]([[BOX_COPY]])
-  // CHECK: [[THUNK_FN:%.*]] = function_ref @$sSiIxd_SiIxr_TR
-  // CHECK: [[THUNK:%.*]] = partial_apply [[THUNK_FN]]([[CLOSURE]]])
-  // CHECK: destroy_value [[BOX]]
-  // CHECK: apply [[FN]]([[THUNK]])
-  // CHECK: return
   func test() {
     transform { [weak self] in
       return self!.x

--- a/test/SILGen/function_conversion_opaque.swift
+++ b/test/SILGen/function_conversion_opaque.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s
+// RUN: %target-swift-emit-silgen-ossa %s
 
 func f0<V>(_: () -> any P<V>) {}
 func f1<V>(_: V.Type, _: () -> any P<V>) {}

--- a/test/SILGen/silgen-ossa.swift
+++ b/test/SILGen/silgen-ossa.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s --check-prefix SILGEN
+// RUN: %target-swift-emit-silgen-ossa %s | %FileCheck %s --check-prefix OSSA
+// RUN: %target-swift-emit-silgen-ossa(mock-sdk: %clang-importer-sdk) %s | %FileCheck %s --check-prefix OSSA
+
+// In -emit-silgen, we don't emit an end_borrow or destroy_value as there is no expression in the body.
+// It's raw output from the compiler without having run the verifier on it.
+
+// In -emit-silgen-ossa, we should see those pieces as the follow-up passes make this valid OSSA SIL.
+
+// SILGEN: sil hidden{{.*}}helloySixnRi_zlF : $@convention(thin)
+// SILGEN: bb0
+// SILGEN-NEXT: alloc_box
+// SILGEN-NEXT: begin_borrow
+// SILGEN-NEXT: project_box
+// SILGEN-NEXT: copy_addr
+// SILGEN-NEXT: unreachable
+// SILGEN: } // end sil function
+
+// OSSA: sil hidden{{.*}}helloySixnRi_zlF : $@convention(thin)
+// OSSA:      copy_addr
+// OSSA-NEXT: end_borrow
+// OSSA-NEXT: destroy_value [dead_end]
+// OSSA-NEXT: unreachable
+// OSSA: } // end sil function
+func hello<T: ~Copyable>(_ t: consuming T) -> Int {}

--- a/test/SILGen/subst_function_type_existential.swift
+++ b/test/SILGen/subst_function_type_existential.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s
+// RUN: %target-swift-emit-silgen-ossa %s
 
 // https://github.com/swiftlang/swift/issues/62061
 

--- a/test/SILGen/typed_throws_async.swift
+++ b/test/SILGen/typed_throws_async.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s
+// RUN: %target-swift-emit-silgen-ossa %s
 
 enum CustomError: Error {
     case error

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -3038,9 +3038,14 @@ config.substitutions.append((r'%target-swift-typecheck-module-from-interface\(([
 
 config.substitutions.append(('%target-typecheck-verify-swift', config.target_parse_verify_swift))
 
+config.substitutions.append((r'%target-swift-emit-silgen-ossa\(mock-sdk:([^)]+)\)',
+                             SubstituteCaptures(r'%target-swift-frontend(mock-sdk:\1) -emit-silgen-ossa -sil-verify-all')))
+config.substitutions.append(('%target-swift-emit-silgen-ossa', '%target-swift-frontend -emit-silgen-ossa -sil-verify-all'))
+
 config.substitutions.append((r'%target-swift-emit-silgen\(mock-sdk:([^)]+)\)',
                              SubstituteCaptures(r'%target-swift-frontend(mock-sdk:\1) -emit-silgen')))
 config.substitutions.append(('%target-swift-emit-silgen', '%target-swift-frontend -emit-silgen'))
+
 config.substitutions.append((r'%target-swift-emit-sil\(mock-sdk:([^)]+)\)',
                              SubstituteCaptures(r'%target-swift-frontend(mock-sdk:\1) -emit-sil')))
 config.substitutions.append(('%target-swift-emit-sil', '%target-swift-frontend -emit-sil'))


### PR DESCRIPTION
This is a version of -emit-silgen that runs SILGenCleanup (and other SILGen-specific passes) and if `-sil-verify-all` is included will actually run the SILVerifier too, ensuring the SIL coming out of SILGen is correct by the verifier's standards.

This is handy for people just wanting to ensure programs can make it through SILGen, without running any extra SIL passes or triggering any of the diagnostics in the mandatory SIL pipeline.