### PR TITLE
Modularize unistd.h.

### DIFF
--- a/stdlib/public/Platform/glibc.modulemap.gyb
+++ b/stdlib/public/Platform/glibc.modulemap.gyb
@@ -57,6 +57,13 @@ module signal_h [system] {
 }
 % end
 
+% if CMAKE_SDK == "OPENBSD":
+module unistd_h [system] {
+  header "unistd.h"
+  export *
+}
+% end
+
 module CUUID [system] {
   header "uuid/uuid.h"
   link "uuid"


### PR DESCRIPTION
In swiftlang/swift-subprocess#293, it was discovered that some types like pid_t and uid_t were leaking from a C shim library instead of from the Glibc import. This meant that some public typealiases referencing those types and the non-public library import were mismatching in accessor visibility.

Figuring out what was awry wasn't immediately obvious from first principles but on suggestion of swiftlang/swift#85229, adopting a similar change for unistd.h for OpenBSD fixes the issue.