### PR TITLE
ASTBridging: add `BridgedCOMThreadingModel` for `COMThreadingModel`

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -936,13 +936,21 @@ BridgedBackDeployedAttr BridgedBackDeployedAttr_createParsed(
     swift::SourceRange range, swift::PlatformKind platform,
     BridgedVersionTuple cVersion);
 
+enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedCOMThreadingModel {
+  BridgedCOMThreadingModelSingle,
+  BridgedCOMThreadingModelApartment,
+  BridgedCOMThreadingModelFree,
+  BridgedCOMThreadingModelBoth,
+  BridgedCOMThreadingModelNeutral,
+};
+
 SWIFT_NAME("BridgedCOMAttr.createParsed(_:atLoc:range:interface:implementation:threading:)")
 BridgedCOMAttr BridgedCOMAttr_createParsed(BridgedASTContext context,
                                            swift::SourceLoc location,
                                            swift::SourceRange range,
                                            BridgedStringRef interface,
                                            BridgedStringRef implementation,
-                                           swift::COMThreadingModel threading);
+                                           BridgedCOMThreadingModel threading);
 
 SWIFT_NAME("BridgedCDeclAttr.createParsed(_:atLoc:range:name:underscored:)")
 BridgedCDeclAttr BridgedCDeclAttr_createParsed(BridgedASTContext cContext,

--- a/lib/AST/Bridging/DeclAttributeBridging.cpp
+++ b/lib/AST/Bridging/DeclAttributeBridging.cpp
@@ -198,18 +198,35 @@ BridgedBackDeployedAttr BridgedBackDeployedAttr_createParsed(
       atLoc, range, platform, cVersion.unbridged(), /*Implicit=*/false);
 }
 
+static swift::COMThreadingModel unbridge(BridgedCOMThreadingModel value) {
+  switch (value) {
+    case BridgedCOMThreadingModelSingle:
+      return swift::COMThreadingModel::Single;
+    case BridgedCOMThreadingModelApartment:
+      return swift::COMThreadingModel::Apartment;
+    case BridgedCOMThreadingModelFree:
+      return swift::COMThreadingModel::Free;
+    case BridgedCOMThreadingModelBoth:
+      return swift::COMThreadingModel::Both;
+    case BridgedCOMThreadingModelNeutral:
+      return swift::COMThreadingModel::Neutral;
+  }
+  llvm_unreachable("unhandled enum value");
+}
+
+
 BridgedCOMAttr BridgedCOMAttr_createParsed(BridgedASTContext context,
                                            swift::SourceLoc location,
                                            swift::SourceRange range,
                                            BridgedStringRef interface,
                                            BridgedStringRef implementation,
-                                           swift::COMThreadingModel threading) {
+                                           BridgedCOMThreadingModel threading) {
   std::optional<StringRef> CLSID;
   if (implementation.unbridged().data())
     CLSID = implementation.unbridged();
   return new (context.unbridged()) COMAttr(location, range,
                                            interface.unbridged(), CLSID,
-                                           threading);
+                                           unbridge(threading));
 }
 
 BridgedCDeclAttr BridgedCDeclAttr_createParsed(BridgedASTContext cContext,

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -692,19 +692,19 @@ extension ASTGenVisitor {
     if node.arguments == nil {
       return .createParsed(ctx, atLoc: location, range: range, interface: "",
                            implementation: BridgedStringRef(), threading:
-                           .Apartment)
+                           .apartment)
     }
 
     typealias Result =
         (interface: BridgedStringRef,
          implementation: BridgedStringRef,
-         threading: swift.COMThreadingModel)
+         threading: BridgedCOMThreadingModel)
 
     guard let parsed =
         generateWithLabeledExprListArguments(attribute: node, { arguments -> Result? in
           var interface: BridgedStringRef = ""
           var implementation: BridgedStringRef = BridgedStringRef()
-          var threading: swift.COMThreadingModel? = .Apartment
+          var threading: BridgedCOMThreadingModel? = .apartment
 
           for argument in arguments {
             switch argument.label?.rawText {
@@ -730,11 +730,11 @@ extension ASTGenVisitor {
               threading =
                   switch argument.expression.as(MemberAccessExprSyntax.self)?
                             .declName.baseName.rawText {
-                  case "single"?: .Single
-                  case "apartment"?, "sta"?: .Apartment
-                  case "free"?, "mta"?: .Free
-                  case "both"?: .Both
-                  case "neutral"?: .Neutral
+                  case "single"?: .single
+                  case "apartment"?, "sta"?: .apartment
+                  case "free"?, "mta"?: .free
+                  case "both"?: .both
+                  case "neutral"?: .neutral
                   default: nil
                   }
             default:


### PR DESCRIPTION
Fixes a compiler error when building a debug compiler (which uses pure bridging mode). In pure bridging mode it's not possible to include swift header files. Therefore we cannot directly use `swift::COMThreadingModel`.
