### PR TITLE
[build-script] Properly disable index-store when sccache is used

### DIFF
--- a/utils/swift_build_support/swift_build_support/build_script_invocation.py
+++ b/utils/swift_build_support/swift_build_support/build_script_invocation.py
@@ -438,6 +438,10 @@ class BuildScriptInvocation(object):
                     shlex.quote(opt) for opt in args.extra_cmake_options)
             ]
 
+        impl_args += [
+            "--llvm-enable-index-store=%s" % (1 if args.llvm_enable_index_store else 0)
+        ]
+
         if args.lto_type is not None:
             impl_args += [
                 "--llvm-enable-lto=%s" % args.lto_type,


### PR DESCRIPTION
We disable llvm_enable_index_store when sccache is enabled, but we don't forward this value to the implementation. This causes that all sccache bots currently rebuild the Swift project from scratch without any caching.