### PR TITLE
[SILBuilder] Fix inlining of move-only structs in debug blocks

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1727,6 +1727,11 @@ public:
                            ArrayRef<SILValue> Elements,
                            ValueOwnershipKind forwardingOwnershipKind) {
     ASSERT(isLoadableOrOpaque(Ty) || isInsertingIntoGlobal());
+    // Debug reconstruction blocks have no ownership semantics.
+    if (BB && BB->isDebugReconstructionBlock())
+      forwardingOwnershipKind = OwnershipKind::None;
+    else
+      forwardingOwnershipKind = forwardingOwnershipKind.forwardToInit(Ty);
     return insert(StructInst::create(getSILDebugLocation(Loc), Ty, Elements,
                                      getModule(), forwardingOwnershipKind));
   }
@@ -1776,6 +1781,12 @@ public:
            (isInsertingIntoGlobal() && getTypeLowering(Ty).isFixedABI()));
     // Assert that this works and does not crash.
     (void)getModule().getCaseIndex(Element);
+
+    // Debug reconstruction blocks have no ownership semantics.
+    if (BB && BB->isDebugReconstructionBlock())
+      forwardingOwnershipKind = OwnershipKind::None;
+    else
+      forwardingOwnershipKind = forwardingOwnershipKind.forwardToInit(Ty);
 
     return insert(new (getModule())
                       EnumInst(getSILDebugLocation(Loc), Operand, Element, Ty,

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -7343,8 +7343,7 @@ class EnumInst
   EnumInst(SILDebugLocation DebugLoc, SILValue Operand,
            EnumElementDecl *Element, SILType ResultTy,
            ValueOwnershipKind forwardingOwnershipKind)
-    : InstructionBase(DebugLoc, ResultTy,
-                      forwardingOwnershipKind.forwardToInit(ResultTy)),
+    : InstructionBase(DebugLoc, ResultTy, forwardingOwnershipKind),
       Element(Element) {
     sharedUInt32().EnumInst.caseIndex = InvalidCaseIndex;
 

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -1772,7 +1772,7 @@ StructInst::StructInst(SILDebugLocation Loc, SILType Ty,
                        ArrayRef<SILValue> Elems,
                        ValueOwnershipKind forwardingOwnershipKind)
     : InstructionBaseWithTrailingOperands(
-      Elems, Loc, Ty, forwardingOwnershipKind.forwardToInit(Ty))
+      Elems, Loc, Ty, forwardingOwnershipKind)
 {
   assert(!Ty.getStructOrBoundGenericStruct()->hasUnreferenceableStorage());
 }

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -1950,8 +1950,6 @@ static void salvageUnaryInst(SingleValueInstruction *SVI) {
     // original operands, which we fix up below.
     auto *cloned =
         cast<SingleValueInstruction>(SVI->clone(&*debugBB->begin()));
-    if (auto *fwdInst = ForwardingInstruction::get(cloned))
-      fwdInst->setForwardingOwnershipKind(OwnershipKind::None);
     oldArg->replaceAllUsesWith(cloned);
 
     // Replace the block arg type with the input operand type.
@@ -2146,7 +2144,6 @@ void swift::salvageDebugInfo(SILInstruction *I) {
             elements.push_back(SILUndef::get(elt));
           auto *newStructInst = builder.createStruct(
             DbgInst->getLoc(), structTy, elements);
-          newStructInst->setForwardingOwnershipKind(OwnershipKind::None);
           oldArg->replaceAllUsesWith(newStructInst);
 
           // Replace the block arg and wire the operand.

--- a/test/DebugInfo/moveonly_enum_inline.swift
+++ b/test/DebugInfo/moveonly_enum_inline.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -emit-sil %s -g -O -module-name a
+
+// Make sure inlining a function with a move-only optional does not crash
+// due to forwardToInit forcing owned ownership in debug reconstruction blocks.
+
+// TODO: investigate why all debug values end up being undef.
+
+struct TrivialMoveOnly: ~Copyable {
+    var payload: Int
+}
+
+func someFunction() {
+    let instance = TrivialMoveOnly(payload: 100)
+    let container: TrivialMoveOnly? = instance
+
+    if case .some(let boundValue) = container {
+        let _ = boundValue.payload
+    }
+}
+
+someFunction()


### PR DESCRIPTION
Force ownership off for struct/enum of move-only types in debug reconstruction blocks within SILBuilder, so that the SILCloner doesn't create debug_values with ownership issues.

Fixes a crash in the added test case.

This replaces the fix in #89771 with a more generic one.