### PR TITLE
[cxx-interop] Fix trival foreign self being considered as a value borrow

### DIFF
--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1863,6 +1863,11 @@ class DestructureInputs {
   SmallBitVector &AddressableLoweredParameters;
   SmallBitVector &ConditionallyAddressableLoweredParameters;
   unsigned NextOrigParamIndex = 0;
+  /// Whether the result has a scoped (borrow) lifetime dependency on a foreign
+  /// 'self' (e.g. a C++ method's 'this'). Set before
+  /// maybeAddForeignParameters() so that the foreign self is lowered as
+  /// addressable-for-dependencies.
+  bool ForeignSelfHasScopedDependency = false;
 
   void addLoweredParameter(SILParameterInfo parameter,
                            unsigned formalParameterIndex) {
@@ -1974,11 +1979,6 @@ private:
       }
     }
 
-    // Add any foreign parameters that are positioned at the start
-    // of the sequence.  visit() will add foreign parameters that are
-    // positioned after any parameters it adds.
-    maybeAddForeignParameters();
-    
     // Parameters may lower differently when they have scoped dependencies.
     SmallBitVector paramsWithScopedDependencies(params.size(), false);
     for (auto &depInfo : extInfoBuilder.getLifetimeDependencies()) {
@@ -1986,7 +1986,18 @@ private:
         paramsWithScopedDependencies |= scopeIndices->getBitVector();
       }
     }
-    
+
+    if (Foreign.self.isInstance() && !params.empty()) {
+      // The foreign self is the last formal parameter.
+      ForeignSelfHasScopedDependency =
+          paramsWithScopedDependencies[params.size() - 1];
+    }
+
+    // Add any foreign parameters that are positioned at the start
+    // of the sequence.  visit() will add foreign parameters that are
+    // positioned after any parameters it adds.
+    maybeAddForeignParameters();
+
     // Process all the non-self parameters.
     origType.forEachFunctionParam(params.drop_back(hasSelf ? 1 : 0),
                                   /*ignore final orig param*/ hasSelf,
@@ -2301,7 +2312,7 @@ private:
       // This is a "self", but it's not a Swift self, we handle it differently.
       visit(ForeignSelf->SubstSelfParam.getValueOwnership(),
             Foreign.self.getSelfIndex(),
-            /*forSelf=*/false, /*scoped dependency=*/false,
+            /*forSelf=*/false, ForeignSelfHasScopedDependency,
             ForeignSelf->OrigSelfParam,
             ForeignSelf->SubstSelfParam.getParameterType(), {});
     }

--- a/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
+++ b/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
@@ -2,8 +2,10 @@
 // RUN: split-file %s %t
 // RUN: %target-swift-frontend  -I %t/Inputs -emit-sil %t/test.swift -enable-experimental-feature LifetimeDependence -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s
 // RUN: %target-swift-frontend  -I %t/Inputs -emit-sil %t/test.swift -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend  -I %t/Inputs -emit-sil -verify %t/globals.swift -enable-experimental-feature Lifetimes -cxx-interoperability-mode=default -diagnostic-style llvm
 
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 //--- Inputs/module.modulemap
 module Test {
@@ -220,8 +222,8 @@ NonEscapableHasAnonUnionNonEscapable makeNonEscapableHasAnonUnionNonEscapable(
 // CHECK: sil {{.*}}[clang getView] {{.*}} : $@convention(c) (@in_guaranteed Owner) -> @lifetime(borrow address 0) @owned View
 // CHECK: sil {{.*}}[clang getViewFromFirst] {{.*}} : $@convention(c) (@in_guaranteed Owner, @in_guaranteed Owner) -> @lifetime(borrow address 0) @owned View
 // CHECK: sil {{.*}}[clang getViewFromEither] {{.*}} : $@convention(c) (@in_guaranteed Owner, @in_guaranteed Owner) -> @lifetime(borrow address 0, borrow address 1) @owned View
-// CHECK: sil {{.*}}[clang Owner.handOutView] {{.*}} : $@convention(cxx_method) (@in_guaranteed Owner) -> @lifetime(borrow 0) @owned View
-// CHECK: sil {{.*}}[clang Owner.handOutView2] {{.*}} : $@convention(cxx_method) (View, @in_guaranteed Owner) -> @lifetime(borrow 1) @owned View
+// CHECK: sil {{.*}}[clang Owner.handOutView] {{.*}} : $@convention(cxx_method) (@in_guaranteed Owner) -> @lifetime(borrow address_for_deps 0) @owned View
+// CHECK: sil {{.*}}[clang Owner.handOutView2] {{.*}} : $@convention(cxx_method) (View, @in_guaranteed Owner) -> @lifetime(borrow address_for_deps 1) @owned View
 // CHECK: sil {{.*}}[clang getViewFromEither] {{.*}} : $@convention(c) (View, View) -> @lifetime(copy 0, copy 1) @owned View
 // CHECK: sil {{.*}}[clang View.init] {{.*}} : $@convention(c) () -> @lifetime(immortal) @out View
 // CHECK: sil {{.*}}[clang OtherView.init] {{.*}} : $@convention(c) (View) -> @lifetime(copy 0) @out OtherView
@@ -274,4 +276,45 @@ func anonymousUnionsAndStructs(_ v: borrowing View) {
     let _ = makeAnonUnionNonEscapable(o)
     let _ = makeAnonStructNonEscapable(o)
     let _ = makeNonEscapableHasAnonUnionNonEscapable(o)
+}
+
+//--- globals.swift
+
+import Test
+
+var globalOwner = makeOwner()
+
+struct Wrapper { var o: Owner }
+var globalWrapper = Wrapper(o: makeOwner())
+
+@_lifetime(immortal)
+func viaMethod() -> View {
+  return globalOwner.handOutView()
+  // expected-error @-1 {{lifetime-dependent value escapes its scope}}
+  // expected-note @-2 {{it depends on this scoped access to variable 'globalOwner'}}
+  // expected-note @-3 {{this use causes the lifetime-dependent value to escape}}
+}
+
+@_lifetime(immortal)
+func viaFreeFunc() -> View {
+  return getView(globalOwner)
+  // expected-error @-1 {{lifetime-dependent value escapes its scope}}
+  // expected-note @-2 {{it depends on this scoped access to variable 'globalOwner'}}
+  // expected-note @-3 {{this use causes the lifetime-dependent value to escape}}
+}
+
+@_lifetime(immortal)
+func viaFieldMethod() -> View {
+  return globalWrapper.o.handOutView()
+  // expected-error @-1 {{lifetime-dependent value escapes its scope}}
+  // expected-note @-2 {{it depends on this scoped access to variable 'globalWrapper'}}
+  // expected-note @-3 {{this use causes the lifetime-dependent value to escape}}
+}
+
+@_lifetime(immortal)
+func viaFieldFreeFunc() -> View {
+  return getView(globalWrapper.o)
+  // expected-error @-1 {{lifetime-dependent value escapes its scope}}
+  // expected-note @-2 {{it depends on this scoped access to variable 'globalWrapper'}}
+  // expected-note @-3 {{this use causes the lifetime-dependent value to escape}}
 }


### PR DESCRIPTION

C++ methods returning a value with scoped lifetime dependence on self should always consider self as an addressable parameter. Unfortunately, this was not the case when self was a trivial type. The scoped dependence was not plumbed through lowering in this case. This can result in subtle lifetime issues like not diagnosing borrows from mutable globals. This PR also expands the tests to make sure we always diagnose borrows from mutable globals.

rdar://179532388

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
