### PR TITLE
[IRGen] Pass generic signature when mangling same-type requirement RHS

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -7964,9 +7964,23 @@ GenericArgumentMetadata irgen::addGenericRequirements(
                                            /*key argument*/false,
                                            isPackRequirement,
                                            isValueRequirement);
+      // Pass along the generic signature so that, if the runtime demangler is
+      // too old to understand this type's mangled name and we fall back to a
+      // dangling metadata-accessor function, the accessor can map the
+      // type-parameter-dependent type into a generic environment and bind it
+      // from the generic requirements buffer at runtime.
+      //
+      // Use the CanType overload rather than the Type overload: the latter
+      // reduces the type against the signature, which would collapse the RHS
+      // of a same-type requirement onto its equivalence-class representative
+      // (e.g. `T.A == T.B` would be recorded as `T.A == T.A`) and corrupt the
+      // requirement. We want the original RHS, just mangled with the signature
+      // available for the dangling-accessor fallback.
       auto typeName =
-          IGM.getTypeRef(requirement.getSecondType(), nullptr,
-                         MangledTypeRefRole::Metadata).first;
+          IGM.getTypeRef(requirement.getSecondType()->getCanonicalType(),
+                         sig.getCanonicalSignature(),
+                         MangledTypeRefRole::Metadata)
+              .first;
 
       addGenericRequirement(IGM, B, metadata, sig, flags,
                             requirement.getFirstType(),

--- a/test/IRGen/inverse_generics_same_type_requirement_backdeploy.swift
+++ b/test/IRGen/inverse_generics_same_type_requirement_backdeploy.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend -emit-ir -target %target-swift-6.0-abi-triple %s -module-name test | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-PRESENT %s
+// RUN: %target-swift-frontend -emit-ir -target %target-swift-5.10-abi-triple %s -module-name test | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-SUPPRESSED %s
+
+// REQUIRES: OS=macosx
+// UNSUPPORTED: CPU=arm64e
+
+// A same-type generic requirement whose right-hand side is a type that needs
+// the Swift 6.0 runtime demangler (here, a nominal type with an inverse
+// requirement) and that is still type-parameter dependent used to crash IRGen
+// when deploying to a pre-6.0 runtime: the dangling-metadata-accessor fallback
+// was built without the enclosing generic signature, so the dependent type
+// could not be mapped into a generic environment.
+
+public struct Inner<T: ~Copyable> {}
+
+public protocol P { associatedtype A }
+
+// CHECK: @"$s4test5CrashVMn" =
+// The second type of the `U.A == Inner<T>` requirement is emitted as a relative
+// reference to a mangled type-ref. On a 6.0+ runtime that is a plain symbolic
+// mangled name; on an older runtime it is a dangling accessor function (which
+// must capture the generic signature so the dependent `Inner<T>` can be bound).
+// CHECK-PRESENT: @"symbolic{{.*}}4test5InnerVAARi_zrlE"
+// CHECK-SUPPRESSED: @"get_type_metadata{{.*}}5InnerVyxG{{.*}}"
+public struct Crash<T, U: P> where U.A == Inner<T> {}


### PR DESCRIPTION
  rdar://176870286

  Same-type/superclass requirements emitted their RHS type-ref with a null
  signature. On pre-6.0 targets, a type needing the 6.0 demangler (e.g. a
  nominal with an inverse requirement) takes the dangling-accessor fallback,
  which couldn't map the dependent RHS into a generic environment, tripping
  an assertion in getAddrOfTypeMetadataAccessFunction. Pass the signature so
  the accessor binds it at runtime; the 6.0+ mangling is unchanged.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
