### PR TITLE
[6.4][IRGen] Pass generic signature when mangling same-type requirement RHS

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -7964,9 +7964,23 @@ GenericArgumentMetadata irgen::addGenericRequirements(
                                            /*key argument*/false,
                                            isPackRequirement,
                                            isValueRequirement);
+      // Pass along the generic signature so that, if the runtime demangler is
+      // too old to understand this type's mangled name and we fall back to a
+      // dangling metadata-accessor function, the accessor can map the
+      // type-parameter-dependent type into a generic environment and bind it
+      // from the generic requirements buffer at runtime.
+      //
+      // Use the CanType overload rather than the Type overload: the latter
+      // reduces the type against the signature, which would collapse the RHS
+      // of a same-type requirement onto its equivalence-class representative
+      // (e.g. `T.A == T.B` would be recorded as `T.A == T.A`) and corrupt the
+      // requirement. We want the original RHS, just mangled with the signature
+      // available for the dangling-accessor fallback.
       auto typeName =
-          IGM.getTypeRef(requirement.getSecondType(), nullptr,
-                         MangledTypeRefRole::Metadata).first;
+          IGM.getTypeRef(requirement.getSecondType()->getCanonicalType(),
+                         sig.getCanonicalSignature(),
+                         MangledTypeRefRole::Metadata)
+              .first;
 
       addGenericRequirement(IGM, B, metadata, sig, flags,
                             requirement.getFirstType(),

--- a/test/IRGen/inverse_generics_same_type_requirement_backdeploy.swift
+++ b/test/IRGen/inverse_generics_same_type_requirement_backdeploy.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend -emit-ir -target %target-swift-6.0-abi-triple %s -module-name test | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-PRESENT %s
+// RUN: %target-swift-frontend -emit-ir -target %target-swift-5.10-abi-triple %s -module-name test | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-SUPPRESSED %s
+
+// REQUIRES: OS=macosx
+// UNSUPPORTED: CPU=arm64e
+
+// A same-type generic requirement whose right-hand side is a type that needs
+// the Swift 6.0 runtime demangler (here, a nominal type with an inverse
+// requirement) and that is still type-parameter dependent used to crash IRGen
+// when deploying to a pre-6.0 runtime: the dangling-metadata-accessor fallback
+// was built without the enclosing generic signature, so the dependent type
+// could not be mapped into a generic environment.
+
+public struct Inner<T: ~Copyable> {}
+
+public protocol P { associatedtype A }
+
+// CHECK: @"$s4test5CrashVMn" =
+// The second type of the `U.A == Inner<T>` requirement is emitted as a relative
+// reference to a mangled type-ref. On a 6.0+ runtime that is a plain symbolic
+// mangled name; on an older runtime it is a dangling accessor function (which
+// must capture the generic signature so the dependent `Inner<T>` can be bound).
+// CHECK-PRESENT: @"symbolic{{.*}}4test5InnerVAARi_zrlE"
+// CHECK-SUPPRESSED: @"get_type_metadata{{.*}}5InnerVyxG{{.*}}"
+public struct Crash<T, U: P> where U.A == Inner<T> {}


### PR DESCRIPTION
  - **Explanation**:
    IRGen crashed when emitting the generic context descriptor for a type with a
    same-type/superclass/same-shape requirement whose right-hand-side type both
    (a) needs the Swift 6.0 runtime demangler (e.g. a nominal type with an inverse
    requirement) and (b) is still type-parameter dependent, when deploying to a
    pre-6.0 runtime. `addGenericRequirements` emitted the RHS type-ref with a null
    generic signature, so the dangling metadata-accessor fallback (taken because
    the older runtime can't demangle the name) could not map the dependent type
    into a generic environment, tripping the
    `!hasArchetype() && !hasTypeParameter()` assertion in
    `getAddrOfTypeMetadataAccessFunction`. The fix passes the enclosing signature
    so the accessor binds the dependent type from the generic requirements buffer
    at runtime.

  - **Scope**:
    Narrow. Only affects the mangled type-ref emitted for the RHS of
    same-type/superclass/same-shape generic requirements in type context
    descriptors. Only the pre-6.0-deployment-target fallback path changes
    behavior (crash → correct dangling accessor that captures the signature); the
    6.0+ path emits a byte-identical symbolic mangled name, so there is no ABI
    change.

  - **Issues**: rdar://176870286

  - **Original PRs**: https://github.com/swiftlang/swift/pull/90226

  - **Risk**:
    Low. One-line change confined to one branch of `addGenericRequirements`. The
    normal (6.0+) mangling is verified unchanged, so no ABI impact; the only
    behavioral difference is that the previously-crashing back-deployment path now
    emits a correct accessor.

  - **Testing**:
    Added regression test
    `test/IRGen/inverse_generics_same_type_requirement_backdeploy.swift` (crashes
    pre-fix at the 5.10 ABI triple, passes post-fix; verifies the plain symbolic
    name at 6.0 and the signature-capturing `get_type_metadata` accessor at 5.10).
    Confirmed the 6.0 mangling is byte-identical before and after the change.

  - **Reviewers**: @hjyamauchi 
