### PR TITLE
[Observation] Assert `track()` is entered on `apply`'s isolation

### DIFF
--- a/stdlib/public/Observation/Sources/Observation/ContinuousObservation.swift
+++ b/stdlib/public/Observation/Sources/Observation/ContinuousObservation.swift
@@ -173,6 +173,10 @@ extension ContinuousObservation.State {
         borrowing ObservationTracking.Event
       ) -> Void
   ) async -> Bool {
+    // This function is `nonisolated(nonsending)` and is only reached through
+    // `trackingLoop()`, which is isolated to `apply.isolation`, so it runs on
+    // that executor on entry. Verify the chain delivered it before invoking `apply`.
+    apply.isolation?.assertIsolated()
     return await withTaskCancellationHandler(
       operation: {
         return await withUnsafeContinuation {


### PR DESCRIPTION
Follow-up to #89046.

`ContinuousObservation.State.track()` is `nonisolated(nonsending)` and is reached only through `trackingLoop()`, which is isolated to `apply.isolation`, so on entry it runs on that isolation's executor. This PR asserts this at the function boundary, before any tracking is set up. If a future change breaks the `nonisolated(nonsending)` chain, this fires instead of silently running `apply` on the wrong executor. It's a no-op when `apply` is `nonisolated`, where there is no actor to check against.

We discussed a precondition in the review of #89046, but I opted for `assertIsolated()` rather than `preconditionIsolated()` to match the general stdlib convention, and since I didn't see the latter used as a guard outside its own overload and the test suite.

There are now two `assertIsolated()` calls in `track()`: the new boundary check, and the existing one in the tracking closure. Since no suspension separates them and `apply.isolation` is immutable, the in-closure call can't fail when the boundary check passes. I left it in place as it's pre-existing, but in principle we can drop it for a single boundary check if you'd prefer.