### PR TITLE
[ASTBridging] Add missing forward declaration of `COMThreadingModel`

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -50,6 +50,7 @@ class ASTContext;
 struct ASTNode;
 class CanGenericSignature;
 struct CaptureListEntry;
+enum class COMThreadingModel : uint8_t;
 class DeclAttributes;
 class DeclBaseName;
 class DeclNameLoc;


### PR DESCRIPTION
Add a forward declaration of `enum class COMThreadingModel : uint8_t` to ASTBridging.h so the header is self-contained in debug builds where the full definition may not be pulled in transitively.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
