### PR TITLE
[PrintAsClang] Add protocol existential wrappers in C++ generated header

### DIFF
--- a/docs/CppInteroperability/SwiftTypeRepresentationInC++.md
+++ b/docs/CppInteroperability/SwiftTypeRepresentationInC++.md
@@ -127,4 +127,348 @@ class swift::any<swift::Hashable>: public swift::OpaqueExistential {
 };
 ```
 
+**Inline vs outline storage.** Values that are bitwiseTakable and fit in
+24 bytes are stored directly in `_buffer`. Larger values are heap-allocated
+via `swift_allocBox`; the `HeapObject*` is stored in `_buffer[0]` and the
+value pointer is recovered via `swift_projectBox`. The `_initializeWithValue`,
+`_destroyValue`, and `_projectValue` methods check the VWT size/flags to
+dispatch between the two paths.
+
+**Method definitions.** The special member functions and helpers are declared
+in `_SwiftCxxInteroperability.h` but defined out-of-line in the generated
+scaffolding (emitted by `PrintSwiftToClangCoreScaffold.cpp`), because they
+need the complete `ValueWitnessTable` type and ptrauth discriminators.
+
+#### `swift::Any`
+
+`swift::Any` is a zero-witness-table existential container. It inherits from
+`SwiftExistentialType` and serves two purposes:
+
+1. Base class for marker protocol wrappers (which have no witness tables).
+2. Default template parameter for unconstrained primary associated types
+   (e.g., `Container<Element = swift::Any>`).
+
+```c++
+class Any : public _impl::SwiftExistentialType {
+protected:
+  Any() noexcept : SwiftExistentialType(uninit_t{}) {}
+};
+```
+
+C++ code cannot inspect values inside `Any` but can pass them back to Swift
+APIs for unboxing.
+
+#### Per-protocol wrapper classes
+
+Each non-marker protocol `P` emits a `final` class inheriting from
+`SwiftExistentialType`. The class adds a single `_witnessTable` pointer
+(not an array -- protocol inheritance does NOT add witness tables; multiple
+WTs only arise from ad-hoc compositions like `any A & B`).
+
+```c++
+// Generated for: public protocol Drawable { func draw() -> Int }
+class Drawable final : public swift::_impl::SwiftExistentialType {
+public:
+  swift::Int draw() const {
+    struct _w { /* witness function signature */ };
+    return _loadWitness<1, DISC, decltype(&_w::call)>(_witnessTable)(
+        _type, _witnessTable, _projectValue());
+  }
+  Drawable(const Circle &value) noexcept;  // boxing constructor
+
+private:
+  Drawable() noexcept : SwiftExistentialType(uninit_t{}) {}
+  const void *_witnessTable;
+  friend class _impl::_impl_Drawable;
+};
+```
+
+**Layout:** `[buffer: 3 * sizeof(void*)] [type metadata] [witness table]`
+-- 40 bytes total for a single-protocol existential on 64-bit platforms.
+
+**No C++ inheritance between protocol wrappers.** Existential-to-existential
+conversion (e.g., `Stylable` to `Drawable`) is a value copy into a new
+container via `_initializeWithCopy`, not a pointer cast. Different protocol
+compositions have different container sizes.
+
+#### Marker protocols
+
+Marker protocols (declared with `@_marker`) have no witness tables and no
+protocol requirements. They emit as `final` subclasses of `swift::Any`:
+
+```c++
+class Priority final : public swift::Any {
+private:
+  Priority() noexcept : Any() {}
+  friend class _impl::_impl_Priority;
+};
+```
+
+Note: inheriting from `Sendable` does NOT make a protocol a marker. Only
+protocols with the explicit `@_marker` attribute are treated as markers.
+
+#### Protocol requirement method dispatch
+
+Protocol methods are emitted directly on the wrapper class. Each method
+loads a witness function pointer from the witness table at a compile-time
+offset, with ptrauth signing on arm64e, and calls it with `(type, wt, self)`:
+
+```c++
+swift::Int draw() const {
+  struct _w { _w() = delete;
+    static SWIFT_CALL swift::Int call(
+        void *, const void *, SWIFT_CONTEXT void *); };
+  return _loadWitness<1, DISC, decltype(&_w::call)>(_witnessTable)(
+      _type, _witnessTable, _projectValue());
+}
+```
+
+**Inherited methods** are flattened into the wrapper. If `Stylable: Drawable`,
+the `Stylable` wrapper gets both `style()` and `draw()`. Inherited methods
+use two-level witness table dispatch: load the base protocol's WT from the
+base conformance slot in the derived WT, then dispatch through the base WT.
+
+**Conversion methods** like `asDrawable()` are emitted for each direct base
+protocol conformance. They copy the existential buffer into a new wrapper
+with the base witness table extracted from the derived WT.
+
+#### Primary associated types (PATs)
+
+Protocols with primary associated types emit as class templates. The template
+parameter is a compile-time type tag only -- it does not affect existential
+container layout:
+
+```c++
+template <typename Element = swift::Any>
+class Container final : public swift::_impl::SwiftExistentialType {
+public:
+  swift::Int count() const { /* witness dispatch */ }
+private:
+  const void *_witnessTable;
+};
+```
+
+#### Existential boxing (C++ to Swift)
+
+Per-conformance implicit conversion constructors allow C++ code to construct
+existential wrappers from concrete types:
+
+```c++
+// Generated when Circle: Drawable in the same module
+Drawable::Drawable(const Circle &value) noexcept
+    : SwiftExistentialType(uninit_t{}) {
+  _type = swift::TypeMetadataTrait<Circle>::getTypeMetadata();
+  _witnessTable = reinterpret_cast<const void *>(_impl::$sCircleDrawableWP);
+  _initializeWithValue(_impl::_impl_Circle::getOpaquePointer(value));
+}
+```
+
+Boxing constructors are declared in the class body but defined out-of-line
+(via `outOfLineDefinitionsOS`) to avoid forward declaration ordering issues --
+the conforming type's `_impl` class and `TypeMetadataTrait` specialization
+may not be declared until later in the header.
+
+`std::convertible_to<T, Drawable>` provides a generic constraint for free --
+C++ template code can constrain on convertibility without any custom concept.
+No runtime `swift_conformsToProtocol` lookup is used; only same-module
+conformances with statically known witness table symbols are supported.
+
+#### Ad-hoc protocol compositions
+
+Ad-hoc compositions (`any A & B`) are not yet supported -- they require
+multiple witness table pointers which changes the container layout. A
+typealias like `typealias AB = A & B` does NOT help because it still
+resolves to a composition type with multiple WTs. The workaround is to
+declare a new protocol: `protocol AB: A, B {}`, which gets a single WT
+with base conformance slots.
+
+#### Class-bound protocol existentials
+
+Protocols that inherit from `AnyObject` (or are declared as class-bound)
+have a different, smaller existential container layout. Instead of the
+three-word value buffer + type metadata used by opaque existentials, a
+class-bound existential stores only a class pointer (since the value is
+always a reference type):
+
+```
+Opaque existential:      [buffer: 24] [type: 8] [WT: 8] = 40 bytes
+Class-bound existential: [class ptr: 8] [WT: 8]         = 16 bytes
+```
+
+These wrappers inherit from `SwiftClassExistentialType` instead of
+`SwiftExistentialType`:
+
+```c++
+// Generated for: public protocol Renderable: AnyObject { func render() -> Int }
+class Renderable final : public swift::_impl::SwiftClassExistentialType {
+public:
+  swift::Int render() const {
+    struct _w { /* witness function signature */ };
+    return _loadWitness<1, DISC, decltype(&_w::call)>(_witnessTable)(
+        _getType(), _witnessTable, _projectValue());
+  }
+  Renderable(const Canvas &value) noexcept;  // boxing constructor
+
+private:
+  Renderable() noexcept : SwiftClassExistentialType(uninit_t{}) {}
+  const void *_witnessTable;
+  friend class _impl::_impl_Renderable;
+};
+```
+
+Key differences from opaque existentials:
+
+- **Lifecycle:** `swift_retain`/`swift_release` instead of VWT-delegated
+  `initializeBufferWithCopyOfBuffer`/`destroy`. Always bitwise-takable.
+- **Type metadata:** Recovered via `swift_getObjectType(_value)` which
+  reads the isa pointer. No stored `_type` field.
+- **Method dispatch:** Uses `_getType()` instead of `_type` in witness
+  function calls.
+- **Loadable direct-pass:** Class existentials are always loadable (16 bytes)
+  and get `swift_interop_passDirect_` treatment in C function signatures,
+  unlike opaque existentials which are always passed as `const void *`.
+- **Boxing constructor:** Extracts the class pointer via
+  `_impl_RefCountedClass::getOpaquePointer` and calls `swift_retain`,
+  rather than packing a value buffer with VWT.
+
+```c++
+class SwiftClassExistentialType {
+public:
+  SwiftClassExistentialType(const SwiftClassExistentialType &other) noexcept;
+  SwiftClassExistentialType(SwiftClassExistentialType &&other) noexcept;
+  SwiftClassExistentialType &operator=(const SwiftClassExistentialType &other) noexcept;
+  SwiftClassExistentialType &operator=(SwiftClassExistentialType &&other) noexcept;
+  ~SwiftClassExistentialType() noexcept;
+
+protected:
+  struct uninit_t {};
+  SwiftClassExistentialType(uninit_t) noexcept : _value(nullptr) {}
+  void _initializeWithCopy(const SwiftClassExistentialType &src) noexcept;
+  void *_projectValue() const noexcept;
+  void *_getType() const noexcept;  // swift_getObjectType
+
+  template <size_t EntryOffset, uint16_t PtrAuthDisc, typename FnTy>
+  FnTy _loadWitness(const void *wt) const;
+
+  void *_value;  // retained class pointer
+};
+```
+
+#### Stdlib protocol conformance records
+
+Types conforming to `Equatable`, `Hashable`, or `Comparable` get conformance
+record specializations and free operator templates in the generated header.
+
+**Conformance records** are template specializations that lazily resolve the
+protocol witness table. The primary templates are declared in
+`_SwiftCxxInteroperability.h`:
+
+```c++
+template<typename T> struct EquatableConformance {};
+template<typename T> struct HashableConformance {};
+template<typename T> struct ComparableConformance {};
+```
+
+For each same-module conformance, `ModuleContentsWriter::emitStdlibConformanceRecords`
+emits a specialization in `globalScopeDefinitionsOS` (outside the module namespace,
+since it specializes a `swift::` template):
+
+```c++
+template<>
+struct swift::EquatableConformance<MyModule::Point> {
+  static inline const void* getWitnessTable() {
+    static const void *wt = swift::_impl::swift_getWitnessTable(
+        MyModule::_impl::$s8MyModule5PointVSQAAMc,
+        swift::TypeMetadataTrait<MyModule::Point>::getTypeMetadata(), nullptr);
+    return wt;
+  }
+};
+```
+
+The `getWitnessTable()` method (not a static pointer) is required because
+cross-module protocol witness tables are not emitted as standalone global
+symbols (`$s...WP`). They are lazily instantiated at runtime via
+`swift_getWitnessTable`. The conformance descriptor (`$s...Mc` suffix) IS a
+global symbol and serves as the input. The `static const` local ensures the
+runtime call happens at most once per type.
+
+The conformance descriptor extern is emitted in `outOfLineDefinitionsOS`
+(inside the module namespace) wrapped in `_impl`:
+
+```c++
+namespace MyModule {
+namespace _impl {
+SWIFT_EXTERN const char $s8MyModule5PointVSQAAMc[];
+} // namespace _impl
+} // namespace MyModule
+```
+
+**Free operator templates** are defined at global scope in
+`_SwiftCxxInteroperability.h`, gated on `__cpp_concepts`:
+
+```c++
+template<typename T>
+    requires requires { swift::EquatableConformance<T>::getWitnessTable(); }
+bool operator==(const T& lhs, const T& rhs) noexcept {
+  auto *wt = swift::EquatableConformance<T>::getWitnessTable();
+  auto fn = swift::_impl::_loadWitnessFromTable<1, 38891, ...>(wt);
+  auto *metadata = swift::TypeMetadataTrait<T>::getTypeMetadata();
+  return fn(&lhs, &rhs, metadata, metadata, wt);
+}
+```
+
+Operators are at global scope (not `namespace swift`) because C++ argument types
+live in module namespaces (e.g., `MyModule::Point`), and operators inside
+`namespace swift` would not be found by unqualified lookup.
+
+**ADL using declarations** are emitted inside the module namespace by
+`emitStdlibConformanceRecords` so that STL algorithms (`std::sort`,
+`std::find`, etc.) can find the operators via argument-dependent lookup:
+
+```c++
+namespace MyModule {
+#ifdef __cpp_concepts
+using ::operator==;
+using ::operator!=;
+using ::operator<;
+// ...
+#endif
+}
+```
+
+Without these, STL algorithms that use `==` or `<` on dependent types fail --
+ADL searches the argument type's associated namespace (`MyModule`), not the
+global scope.
+
+**ABI-frozen witness table offsets and ptrauth discriminators:**
+
+| Protocol | Operator | WT offset | Ptrauth disc |
+|----------|----------|-----------|--------------|
+| Equatable | `==` | 1 | 38891 |
+| Comparable | `<` | 2 | 59511 |
+
+`!=` is `!(lhs == rhs)`. `<=`, `>`, `>=` are derived from `<` and `==`.
+
+#### Import context limitations
+
+Existential wrappers (and class wrappers) are recognized and imported back
+as Swift existential types only in **function parameter and return type**
+positions. These paths have explicit `CxxRecordAsSwiftType` checks in
+`importMethodType`, `importFunctionReturnType`, and
+`importFunctionParamsAndReturnType`.
+
+The general `VisitRecordType` path -- used for struct fields, local
+variable types, typedef bodies, and other non-function contexts -- does
+**not** perform this check. `importDecl` returns `nullptr` for any
+`CxxRecordDecl` with `CxxRecordSemanticsKind::SwiftExistentialType` (or
+`SwiftClassType`), so the type fails to import in those positions.
+
+This is a **pre-existing limitation** shared with the class interop path
+(see the FIXME at `ImportDecl.cpp:3367`). Lifting it requires adding a
+`CxxRecordAsSwiftType` lookup inside `VisitRecordType` itself, which
+would fix both class and existential wrappers in all type positions.
+This will likely need to be addressed for class template specialization
+round-tripping, where C++ wrapper types appear as template arguments and
+struct fields.
+
 * Debug info: ...

--- a/docs/CppInteroperability/SwiftTypeRepresentationInC++.md
+++ b/docs/CppInteroperability/SwiftTypeRepresentationInC++.md
@@ -149,7 +149,7 @@ need the complete `ValueWitnessTable` type and ptrauth discriminators.
    (e.g., `Container<Element = swift::Any>`).
 
 ```c++
-class Any : public _impl::SwiftExistentialType {
+class Any : public _impl::SwiftExistentialType<> {
 protected:
   Any() noexcept : SwiftExistentialType(uninit_t{}) {}
 };
@@ -161,30 +161,37 @@ APIs for unboxing.
 #### Per-protocol wrapper classes
 
 Each non-marker protocol `P` emits a `final` class inheriting from
-`SwiftExistentialType`. The class adds a single `_witnessTable` pointer
-(not an array -- protocol inheritance does NOT add witness tables; multiple
-WTs only arise from ad-hoc compositions like `any A & B`).
+`SwiftExistentialType<_impl::PTag>`. The tag struct's `WitnessTable`
+member type indicates the protocol contributes one witness table slot.
+The `_witnessTables` array is in the base class template, sized by the
+number of WT-bearing tags in the pack.
 
 ```c++
+// Tag struct in _impl namespace:
+struct DrawableTag {
+  using WitnessTable = const void *_Nonnull;
+};
+
 // Generated for: public protocol Drawable { func draw() -> Int }
-class Drawable final : public swift::_impl::SwiftExistentialType {
+class Drawable final : public swift::_impl::SwiftExistentialType<_impl::DrawableTag> {
 public:
   swift::Int draw() const {
     struct _w { /* witness function signature */ };
-    return _loadWitness<1, DISC, decltype(&_w::call)>(_witnessTable)(
-        _type, _witnessTable, _projectValue());
+    return _loadWitness<1, DISC, decltype(&_w::call)>(_witnessTables[0])(
+        _type, _witnessTables[0], _projectValue());
   }
   Drawable(const Circle &value) noexcept;  // boxing constructor
 
 private:
-  Drawable() noexcept : SwiftExistentialType(uninit_t{}) {}
-  const void *_witnessTable;
+  Drawable() noexcept : SwiftExistentialType(typename SwiftExistentialType::uninit_t{}) {}
   friend class _impl::_impl_Drawable;
 };
 ```
 
-**Layout:** `[buffer: 3 * sizeof(void*)] [type metadata] [witness table]`
--- 40 bytes total for a single-protocol existential on 64-bit platforms.
+**Layout:** `[buffer: 3 * sizeof(void*)] [type metadata] [witness tables...]`
+-- 40 bytes for a single-protocol existential on 64-bit platforms (one WT slot).
+Protocol inheritance does NOT add witness tables; multiple WT slots only
+arise from ad-hoc compositions like `any A & B`.
 
 **No C++ inheritance between protocol wrappers.** Existential-to-existential
 conversion (e.g., `Stylable` to `Drawable`) is a value copy into a new
@@ -194,12 +201,18 @@ compositions have different container sizes.
 #### Marker protocols
 
 Marker protocols (declared with `@_marker`) have no witness tables and no
-protocol requirements. They emit as `final` subclasses of `swift::Any`:
+protocol requirements. Their tag struct has `static constexpr bool IsMarker = true`
+instead of a `WitnessTable` member. They emit as `final` subclasses of
+`SwiftExistentialType` with a marker tag:
 
 ```c++
-class Priority final : public swift::Any {
+struct PriorityTag {
+  static constexpr bool IsMarker = true;
+};
+
+class Priority final : public swift::_impl::SwiftExistentialType<_impl::PriorityTag> {
 private:
-  Priority() noexcept : Any() {}
+  Priority() noexcept : SwiftExistentialType(typename SwiftExistentialType::uninit_t{}) {}
   friend class _impl::_impl_Priority;
 };
 ```
@@ -218,8 +231,8 @@ swift::Int draw() const {
   struct _w { _w() = delete;
     static SWIFT_CALL swift::Int call(
         void *, const void *, SWIFT_CONTEXT void *); };
-  return _loadWitness<1, DISC, decltype(&_w::call)>(_witnessTable)(
-      _type, _witnessTable, _projectValue());
+  return _loadWitness<1, DISC, decltype(&_w::call)>(_witnessTables[0])(
+      _type, _witnessTables[0], _projectValue());
 }
 ```
 
@@ -240,11 +253,11 @@ container layout:
 
 ```c++
 template <typename Element = swift::Any>
-class Container final : public swift::_impl::SwiftExistentialType {
+class Container final : public swift::_impl::SwiftExistentialType<_impl::ContainerTag> {
 public:
   swift::Int count() const { /* witness dispatch */ }
 private:
-  const void *_witnessTable;
+  friend class _impl::_impl_Container;
 };
 ```
 
@@ -256,10 +269,10 @@ existential wrappers from concrete types:
 ```c++
 // Generated when Circle: Drawable in the same module
 Drawable::Drawable(const Circle &value) noexcept
-    : SwiftExistentialType(uninit_t{}) {
+    : SwiftExistentialType(typename SwiftExistentialType::uninit_t{}) {
   _type = swift::TypeMetadataTrait<Circle>::getTypeMetadata();
-  _witnessTable = reinterpret_cast<const void *>(_impl::$sCircleDrawableWP);
   _initializeWithValue(_impl::_impl_Circle::getOpaquePointer(value));
+  _witnessTables[0] = reinterpret_cast<const void *>(_impl::$sCircleDrawableWP);
 }
 ```
 
@@ -275,12 +288,125 @@ conformances with statically known witness table symbols are supported.
 
 #### Ad-hoc protocol compositions
 
-Ad-hoc compositions (`any A & B`) are not yet supported -- they require
-multiple witness table pointers which changes the container layout. A
-typealias like `typealias AB = A & B` does NOT help because it still
-resolves to a composition type with multiple WTs. The workaround is to
-declare a new protocol: `protocol AB: A, B {}`, which gets a single WT
-with base conformance slots.
+Ad-hoc compositions like `any Drawable & Resizable` emit named wrapper
+classes inheriting from `SwiftExistentialType<DrawableTag, ResizableTag>`.
+The wrapper gets methods from all constituent protocols plus `asFoo()`
+extraction methods:
+
+```c++
+class AnyDrawableAndResizable final
+    : public swift::_impl::SwiftExistentialType<_impl::DrawableTag, _impl::ResizableTag> {
+public:
+  swift::Int draw() const { /* dispatch via _witnessTables[0] */ }
+  bool resize(swift::Int factor) const { /* dispatch via _witnessTables[1] */ }
+
+  Drawable asDrawable() const;
+  Resizable asResizable() const;
+
+private:
+  AnyDrawableAndResizable() noexcept
+      : SwiftExistentialType(typename SwiftExistentialType::uninit_t{}) {}
+  friend class _impl::_impl_AnyDrawableAndResizable;
+};
+```
+
+**Naming.** The class name is `Any` + sorted protocol names joined with
+`And` (e.g., `AnyDrawableAndResizable`). The canonical protocol ordering
+comes from `ExistentialLayout::getProtocols()` -- `any Drawable & Resizable`
+and `any Resizable & Drawable` produce the same type and wrapper.
+
+**WT ordering.** Witness tables in `_witnessTables[]` follow the same
+canonical ordering. For `AnyDrawableAndResizable`, slot 0 is Drawable's
+WT and slot 1 is Resizable's.
+
+**Lazy emission.** Composition wrappers are emitted lazily by
+`DeclAndTypePrinter::ensureCompositionEmitted()` when a function
+signature first references the composition type. A `StringSet<>` ensures
+each composition is emitted at most once per module header.
+
+**`asFoo()` extraction.** Each constituent protocol gets an `asFoo()`
+method that copies the existential buffer into a single-protocol
+wrapper with the corresponding WT. These are needed because C++ has no
+implicit base-to-derived conversion -- the generic subset conversion
+operator (below) produces the base `SwiftExistentialType<Tag>`, not
+the named wrapper class.
+
+**No boxing constructors.** Composition wrappers do not have boxing
+constructors. Compositions are obtained from Swift function returns.
+
+##### Composition parameter convention
+
+Swift functions taking a composition parameter use the base template
+type in C++ rather than the named wrapper class:
+
+```c++
+// Swift: func drawAndResize(_ x: any Drawable & Resizable) -> Int
+swift::Int drawAndResize(
+    const swift::_impl::SwiftExistentialType<
+        Module::_impl::DrawableTag, Module::_impl::ResizableTag>& x);
+```
+
+This allows implicit derived-to-base conversion from any wrapper that
+inherits from the same base, including wider compositions. Return types
+use the named wrapper class so callers get method access:
+
+```c++
+Module::AnyDrawableAndResizable makeDrawableAndResizable();
+```
+
+#### Inverse tags
+
+Protocols that opt out of `Copyable` or `Escapable` via `~Copyable` or
+`~Escapable` get inverse tags appended to their template parameter list:
+
+```c++
+// public protocol Resource: ~Copyable { func use() -> Int }
+class Resource final
+    : public swift::_impl::SwiftExistentialType<_impl::ResourceTag, swift::_impl::NonCopyable> {
+  // ...
+};
+```
+
+`NonCopyable` and `NonEscapable` are tag structs satisfying the
+`InverseTag` concept. They contribute no WT slots. The `Traits` struct
+template uses them to set `IsCopyable = false` / `IsEscapable = false`,
+which disables copy/move special members and the subset conversion
+operator.
+
+Detection uses `ProtocolDecl::canConformTo(InvertibleProtocolKind)` --
+a return value of `Never` means the protocol has opted out. For
+compositions, `NonCopyable` is appended if any constituent protocol
+opts out of `Copyable` (likewise for `NonEscapable`).
+
+#### Generic subset conversion
+
+`SwiftExistentialType<Tags...>` provides a templated conversion operator
+for implicit narrowing from wider compositions to narrower ones:
+
+```c++
+template <typename... TargetTags>
+  requires (sizeof...(TargetTags) < sizeof...(Tags) &&
+            Traits::IsCopyable &&
+            ((ProtocolTag<TargetTags> || MarkerTag<TargetTags> ||
+              InverseTag<TargetTags>) && ...) &&
+            ((std::is_same_v<TargetTags, Tags> || ...) && ...))
+operator SwiftExistentialType<TargetTags...>() const noexcept;
+```
+
+The operator copies the existential buffer and selects WT slots using
+`_wtIndexOf<T, Tags...>()`, a constexpr helper that finds a tag's
+position in the source pack. The `IsCopyable` constraint prevents
+narrowing non-copyable existentials.
+
+**Conversion to Any.** When `TargetTags` is empty, the result is
+`SwiftExistentialType<>` (i.e., `Any`). The constraint
+`sizeof...(TargetTags) < sizeof...(Tags)` is satisfied as long as the
+source has at least one tag.
+
+**Class-bound existentials.** `SwiftClassExistentialType<Tags...>` has
+an analogous operator that converts to `SwiftExistentialType<TargetTags...>`
+(not `SwiftClassExistentialType`), because the result may not be
+class-bound.
 
 #### Class-bound protocol existentials
 
@@ -295,23 +421,22 @@ Opaque existential:      [buffer: 24] [type: 8] [WT: 8] = 40 bytes
 Class-bound existential: [class ptr: 8] [WT: 8]         = 16 bytes
 ```
 
-These wrappers inherit from `SwiftClassExistentialType` instead of
+These wrappers inherit from `SwiftClassExistentialType<RenderableTag>` instead of
 `SwiftExistentialType`:
 
 ```c++
 // Generated for: public protocol Renderable: AnyObject { func render() -> Int }
-class Renderable final : public swift::_impl::SwiftClassExistentialType {
+class Renderable final : public swift::_impl::SwiftClassExistentialType<_impl::RenderableTag> {
 public:
   swift::Int render() const {
     struct _w { /* witness function signature */ };
-    return _loadWitness<1, DISC, decltype(&_w::call)>(_witnessTable)(
-        _getType(), _witnessTable, _projectValue());
+    return _loadWitness<1, DISC, decltype(&_w::call)>(_witnessTables[0])(
+        _getType(), _witnessTables[0], _projectValue());
   }
   Renderable(const Canvas &value) noexcept;  // boxing constructor
 
 private:
-  Renderable() noexcept : SwiftClassExistentialType(uninit_t{}) {}
-  const void *_witnessTable;
+  Renderable() noexcept : SwiftClassExistentialType(typename SwiftClassExistentialType::uninit_t{}) {}
   friend class _impl::_impl_Renderable;
 };
 ```
@@ -332,6 +457,7 @@ Key differences from opaque existentials:
   rather than packing a value buffer with VWT.
 
 ```c++
+template <typename... Tags>
 class SwiftClassExistentialType {
 public:
   SwiftClassExistentialType(const SwiftClassExistentialType &other) noexcept;

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -906,6 +906,9 @@ public:
   /// and results.
   const clang::Type *getClangTypeForIRGen(Type ty);
 
+  /// Register a Clang type to use for IRGen when converting a Swift type.
+  void registerClangTypeForIRGen(Type swiftType, clang::QualType clangType);
+
   /// Determine whether the given Swift type is representable in a
   /// given foreign language.
   ForeignRepresentationInfo

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -531,6 +531,9 @@ EXPERIMENTAL_FEATURE(ImportCxxMembersLazily, true)
 /// superclass.
 EXPERIMENTAL_FEATURE(ForeignReferenceTypeInheritance, true)
 
+/// Enable C++ existential wrappers for Swift protocol types.
+EXPERIMENTAL_FEATURE(CxxExistentialInterop, false)
+
 /// `yielding borrow`/`yielding mutate` single-yield coroutine accessors
 // TODO: When this is turned on by default, take care of:
 // * "TODO" around line 8100 of lib/Parse/ParseDecl.cpp

--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -425,7 +425,9 @@ enum class CxxRecordSemanticsKind {
   Reference,
   Iterator,
   // A C++ record that represents a Swift class type exposed to C++ from Swift.
-  SwiftClassType
+  SwiftClassType,
+  // A C++ record that represents a Swift protocol existential wrapper.
+  SwiftExistentialType
 };
 
 struct CxxRecordSemanticsDescriptor final {

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -6952,6 +6952,11 @@ ASTContext::getClangTypeForIRGen(Type ty) {
   return getClangTypeConverter().convert(ty).getTypePtrOrNull();
 }
 
+void ASTContext::registerClangTypeForIRGen(Type swiftType,
+                                           clang::QualType clangType) {
+  getClangTypeConverter().registerMapping(swiftType, clangType);
+}
+
 GenericParamList *ASTContext::getSelfGenericParamList(DeclContext *dc) const {
   auto *theParamList = getImpl().SelfGenericParamList;
   if (theParamList)

--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -865,6 +865,11 @@ clang::QualType ClangTypeConverter::visit(Type type) {
   return static_cast<super *>(this)->visit(type);
 }
 
+void ClangTypeConverter::registerMapping(Type swiftType,
+                                         clang::QualType clangType) {
+  Cache.insert({swiftType, clangType});
+}
+
 clang::QualType ClangTypeConverter::convert(Type type) {
   auto it = Cache.find(type);
   if (it != Cache.end())

--- a/lib/AST/ClangTypeConverter.h
+++ b/lib/AST/ClangTypeConverter.h
@@ -111,9 +111,11 @@ private:
 
   std::optional<unsigned> classifySIMD(Type type);
 
-  friend ASTContext; // HACK: expose `convert` method to ASTContext
+  friend ASTContext; // HACK: expose `convert` and `registerMapping` to ASTContext
 
   clang::QualType convert(Type type);
+
+  void registerMapping(Type swiftType, clang::QualType clangType);
 
   clang::QualType convertMemberType(NominalTypeDecl *DC,
                                     StringRef memberName);

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -481,6 +481,7 @@ UNINTERESTING_FEATURE(AssumeResilientCxxTypes)
 UNINTERESTING_FEATURE(ImportNonPublicCxxMembers)
 UNINTERESTING_FEATURE(ImportCxxMembersLazily)
 UNINTERESTING_FEATURE(ForeignReferenceTypeInheritance)
+UNINTERESTING_FEATURE(CxxExistentialInterop)
 UNINTERESTING_FEATURE(CoroutineAccessorsUnwindOnCallerError)
 UNINTERESTING_FEATURE(AllowRuntimeSymbolDeclarations)
 

--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -340,6 +340,11 @@ swift::cxx_translation::getDeclRepresentation(
     if (isa<ProtocolDecl>(typeDecl)) {
       if (typeDecl->hasClangNode())
         return {ObjCxxOnly, std::nullopt};
+      if (typeDecl->isObjC())
+        return {ObjCxxOnly, std::nullopt};
+      if (typeDecl->getASTContext().LangOpts.hasFeature(
+              Feature::CxxExistentialInterop))
+        return {Representable, std::nullopt};
       return {Unsupported, UnrepresentableProtocol};
     }
     // Swift's consume semantics are not yet supported in C++.

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -42,6 +42,7 @@
 #include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/Defer.h"
+#include "swift/Basic/Feature.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/Platform.h"
 #include "swift/Basic/SourceLoc.h"
@@ -8501,6 +8502,7 @@ static bool isSwiftClassType(const clang::CXXRecordDecl *decl) {
   auto baseDecl = decl->getDefinition();
   if (!baseDecl)
     return false;
+  int depth = 0;
   do {
     if (baseDecl->getNumBases() != 1)
       return false;
@@ -8510,9 +8512,52 @@ static bool isSwiftClassType(const clang::CXXRecordDecl *decl) {
     if (!nextBaseDecl)
       return false;
     baseDecl = nextBaseDecl->getDefinition();
-    if (!baseDecl)
+    if (!baseDecl || ++depth > 8)
       return false;
   } while (baseDecl->getName() != "RefCountedClass");
+
+  return true;
+}
+
+/// Get the ExternalSourceSymbolAttr from a CXXRecordDecl, looking through
+/// ClassTemplateSpecializationDecl to the primary template if needed.
+static const clang::ExternalSourceSymbolAttr *
+getSwiftSourceSymbolAttr(const clang::CXXRecordDecl *decl) {
+  if (auto essAttr = decl->getAttr<clang::ExternalSourceSymbolAttr>())
+    return essAttr;
+  if (auto specDecl =
+          dyn_cast<clang::ClassTemplateSpecializationDecl>(decl)) {
+    auto *templatedDecl = specDecl->getSpecializedTemplate()->getTemplatedDecl();
+    return templatedDecl->getAttr<clang::ExternalSourceSymbolAttr>();
+  }
+  return nullptr;
+}
+
+static bool isSwiftExistentialType(const clang::CXXRecordDecl *decl) {
+  auto essAttr = getSwiftSourceSymbolAttr(decl);
+  if (!essAttr || essAttr->getLanguage() != "Swift" ||
+      essAttr->getDefinedIn().empty() || essAttr->getUSR().empty())
+    return false;
+
+  const clang::CXXRecordDecl *baseDecl = decl;
+  if (auto specDecl =
+          dyn_cast<clang::ClassTemplateSpecializationDecl>(decl))
+    baseDecl = specDecl->getSpecializedTemplate()->getTemplatedDecl();
+
+  int depth = 0;
+  do {
+    if (baseDecl->getNumBases() != 1)
+      return false;
+    auto baseClassSpecifier = *baseDecl->bases_begin();
+    auto Ty = baseClassSpecifier.getType();
+    auto nextBaseDecl = Ty->getAsCXXRecordDecl();
+    if (!nextBaseDecl)
+      return false;
+    baseDecl = nextBaseDecl;
+    if (++depth > 8)
+      return false;
+  } while (baseDecl->getName() != "SwiftExistentialType" &&
+           baseDecl->getName() != "SwiftClassExistentialType");
 
   return true;
 }
@@ -8533,6 +8578,10 @@ CxxRecordSemantics::evaluate(Evaluator &evaluator,
   if (isSwiftClassType(cxxDecl))
     return CxxRecordSemanticsKind::SwiftClassType;
 
+  if (isSwiftExistentialType(cxxDecl) &&
+      desc.ctx.LangOpts.hasFeature(Feature::CxxExistentialInterop))
+    return CxxRecordSemanticsKind::SwiftExistentialType;
+
   if (hasIteratorAPIAttr(cxxDecl) || hasIteratorCategory(cxxDecl)) {
     return CxxRecordSemanticsKind::Iterator;
   }
@@ -8546,23 +8595,31 @@ CxxRecordAsSwiftType::evaluate(Evaluator &evaluator,
   auto cxxDecl = dyn_cast<clang::CXXRecordDecl>(desc.decl);
   if (!cxxDecl)
     return nullptr;
-  if (!isSwiftClassType(cxxDecl))
+  bool isClass = isSwiftClassType(cxxDecl);
+  bool isExistential = !isClass && isSwiftExistentialType(cxxDecl) &&
+                       desc.ctx.LangOpts.hasFeature(Feature::CxxExistentialInterop);
+  if (!isClass && !isExistential)
     return nullptr;
 
   SmallVector<ValueDecl *, 1> results;
-  auto *essaAttr = cxxDecl->getAttr<clang::ExternalSourceSymbolAttr>();
+  auto *essaAttr = getSwiftSourceSymbolAttr(cxxDecl);
   auto *mod = desc.ctx.getModuleByName(essaAttr->getDefinedIn());
   if (!mod) {
-    // TODO: warn about missing 'import'.
     return nullptr;
   }
   // FIXME: Support renamed declarations.
-  auto swiftName = cxxDecl->getName();
+  // For template specializations, get the name from the primary template.
+  StringRef swiftName = cxxDecl->getName();
+  if (auto specDecl =
+          dyn_cast<clang::ClassTemplateSpecializationDecl>(cxxDecl))
+    swiftName = specDecl->getSpecializedTemplate()->getTemplatedDecl()->getName();
   // FIXME: handle nested Swift types once they're supported.
   mod->lookupValue(desc.ctx.getIdentifier(swiftName), NLKind::UnqualifiedLookup,
                    results);
   if (results.size() == 1) {
-    if (isa<ClassDecl>(results[0]))
+    if (isClass && isa<ClassDecl>(results[0]))
+      return results[0];
+    if (isExistential && isa<ProtocolDecl>(results[0]))
       return results[0];
   }
   return nullptr;
@@ -8811,7 +8868,9 @@ bool IsSafeUseOfCxxDecl::evaluate(Evaluator &evaluator,
             method->getReturnType().getCanonicalType())) {
       if (auto cxxRecordReturnType =
               dyn_cast<clang::CXXRecordDecl>(returnType->getDecl())) {
-        if (isSwiftClassType(cxxRecordReturnType))
+        if (isSwiftClassType(cxxRecordReturnType) ||
+            (isSwiftExistentialType(cxxRecordReturnType) &&
+             desc.ctx.LangOpts.hasFeature(Feature::CxxExistentialInterop)))
           return true;
 
         if (hasIteratorAPIAttr(cxxRecordReturnType) ||

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3362,7 +3362,8 @@ namespace {
           Impl.SwiftContext.evaluator,
           CxxRecordSemantics({decl, Impl.SwiftContext}), {});
 
-      if (cxxRecordsemanticsKind == CxxRecordSemanticsKind::SwiftClassType) {
+      if (cxxRecordsemanticsKind == CxxRecordSemanticsKind::SwiftClassType ||
+          cxxRecordsemanticsKind == CxxRecordSemanticsKind::SwiftExistentialType) {
         // FIXME: add a diagnostic here for unsupported imported use of Swift
         // type?
         return nullptr;

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3415,6 +3415,14 @@ namespace {
 
     Decl *VisitClassTemplateSpecializationDecl(
                  const clang::ClassTemplateSpecializationDecl *decl) {
+      // Skip existential wrapper template specializations (PAT protocols).
+      auto cxxRecordSemanticsKind = evaluateOrDefault(
+          Impl.SwiftContext.evaluator,
+          CxxRecordSemantics({decl, Impl.SwiftContext}), {});
+      if (cxxRecordSemanticsKind == CxxRecordSemanticsKind::SwiftClassType ||
+          cxxRecordSemanticsKind == CxxRecordSemanticsKind::SwiftExistentialType)
+        return nullptr;
+
       // Importing std::conditional substantially increases compile times when
       // building with libstdc++, i.e. on most Linux distros.
       if (decl->isInStdNamespace() && decl->getIdentifier() &&
@@ -5102,6 +5110,15 @@ namespace {
     }
 
     Decl *VisitClassTemplateDecl(const clang::ClassTemplateDecl *decl) {
+      // Skip existential wrapper class templates (PAT protocols).
+      auto *templatedDecl = decl->getTemplatedDecl();
+      auto cxxRecordSemanticsKind = evaluateOrDefault(
+          Impl.SwiftContext.evaluator,
+          CxxRecordSemantics({templatedDecl, Impl.SwiftContext}), {});
+      if (cxxRecordSemanticsKind == CxxRecordSemanticsKind::SwiftClassType ||
+          cxxRecordSemanticsKind == CxxRecordSemanticsKind::SwiftExistentialType)
+        return nullptr;
+
       ImportedName importedName;
       std::tie(importedName, std::ignore) = importFullName(decl);
       auto name = importedName.getBaseIdentifier(Impl.SwiftContext);

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2343,16 +2343,107 @@ applyImportTypeAttrs(ImportTypeAttrs attrs, Type type,
 }
 
 /// Build the Swift existential type for a protocol that was round-tripped
-/// through C++.
+/// through C++. If the Clang record is a template specialization (i.e., a PAT
+/// protocol wrapper like Container<swift::Int>), extract the template args,
+/// import them as Swift types, and construct a ParameterizedProtocolType.
 static Type
 buildExistentialTypeForProtocol(ProtocolDecl *pd,
                                 const clang::CXXRecordDecl *recordDecl,
                                 ClangImporter::Implementation &impl) {
-  auto clangRecordType =
-      recordDecl->getASTContext().getRecordType(recordDecl);
-  impl.SwiftContext.registerClangTypeForIRGen(
-      ExistentialType::get(pd->getDeclaredInterfaceType()), clangRecordType);
-  return ExistentialType::get(pd->getDeclaredInterfaceType());
+  auto registerAndReturn = [&](Type result) -> Type {
+    auto clangRecordType =
+        recordDecl->getASTContext().getRecordType(recordDecl);
+    impl.SwiftContext.registerClangTypeForIRGen(result, clangRecordType);
+    return result;
+  };
+
+  auto pats = pd->getPrimaryAssociatedTypes();
+  if (pats.empty())
+    return registerAndReturn(
+        ExistentialType::get(pd->getDeclaredInterfaceType()));
+
+  auto specDecl =
+      dyn_cast<clang::ClassTemplateSpecializationDecl>(recordDecl);
+  if (!specDecl)
+    return registerAndReturn(
+        ExistentialType::get(pd->getDeclaredInterfaceType()));
+
+  auto *templateDecl = specDecl->getSpecializedTemplate();
+  auto *templateParams = templateDecl->getTemplateParameters();
+  const auto &templateArgs = specDecl->getTemplateArgs();
+
+  // Check if all template args are defaults (e.g., Container<swift::Any>).
+  bool allDefaults = true;
+  for (unsigned i = 0, e = templateArgs.size(); i < e && i < templateParams->size(); ++i) {
+    auto *param = templateParams->getParam(i);
+    auto *typeParam = dyn_cast<clang::TemplateTypeParmDecl>(param);
+    if (!typeParam || !typeParam->hasDefaultArgument()) {
+      allDefaults = false;
+      break;
+    }
+    auto defaultType = typeParam->getDefaultArgument()
+                           .getArgument()
+                           .getAsType()
+                           .getCanonicalType();
+    if (templateArgs[i].getKind() != clang::TemplateArgument::Type) {
+      allDefaults = false;
+      break;
+    }
+    auto argType = templateArgs[i].getAsType().getCanonicalType();
+    if (defaultType != argType) {
+      allDefaults = false;
+      break;
+    }
+  }
+  if (allDefaults)
+    return registerAndReturn(
+        ExistentialType::get(pd->getDeclaredInterfaceType()));
+
+  // Import each template arg as a Swift type, matching positionally to PATs.
+  SmallVector<Type, 2> swiftArgs;
+  for (unsigned i = 0, e = std::min((unsigned)pats.size(),
+                                    templateArgs.size()); i < e; ++i) {
+    auto arg = templateArgs[i];
+    if (arg.getKind() != clang::TemplateArgument::Type)
+      return registerAndReturn(
+          ExistentialType::get(pd->getDeclaredInterfaceType()));
+
+    auto clangArgType = arg.getAsType();
+
+    // Try round-trip import first (the arg may be another existential wrapper).
+    if (auto argRecordDecl = clangArgType->getAsCXXRecordDecl()) {
+      if (auto *vd = evaluateOrDefault(
+              impl.SwiftContext.evaluator,
+              CxxRecordAsSwiftType({argRecordDecl, impl.SwiftContext}),
+              nullptr)) {
+        if (auto *argPD = dyn_cast<ProtocolDecl>(vd)) {
+          swiftArgs.push_back(
+              buildExistentialTypeForProtocol(argPD, argRecordDecl, impl));
+          continue;
+        }
+        if (auto *argCD = dyn_cast<ClassDecl>(vd)) {
+          swiftArgs.push_back(ClassType::get(argCD, Type(), impl.SwiftContext));
+          continue;
+        }
+      }
+    }
+
+    // Fall back to normal type import.
+    auto imported = impl.importType(
+        clangArgType, ImportTypeKind::Value,
+        ImportDiagnosticAdder(impl, nullptr, clang::SourceLocation()),
+        /*allowNSUIntegerAsInt=*/false, Bridgeability::None, ImportTypeAttrs());
+    if (!imported)
+      return registerAndReturn(
+          ExistentialType::get(pd->getDeclaredInterfaceType()));
+
+    swiftArgs.push_back(imported.getType());
+  }
+
+  auto *protoType = pd->getDeclaredInterfaceType()->castTo<ProtocolType>();
+  auto paramProtoType =
+      ParameterizedProtocolType::get(impl.SwiftContext, protoType, swiftArgs);
+  return registerAndReturn(ExistentialType::get(paramProtoType));
 }
 
 ImportedType ClangImporter::Implementation::importFunctionReturnType(

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2342,6 +2342,19 @@ applyImportTypeAttrs(ImportTypeAttrs attrs, Type type,
   return type;
 }
 
+/// Build the Swift existential type for a protocol that was round-tripped
+/// through C++.
+static Type
+buildExistentialTypeForProtocol(ProtocolDecl *pd,
+                                const clang::CXXRecordDecl *recordDecl,
+                                ClangImporter::Implementation &impl) {
+  auto clangRecordType =
+      recordDecl->getASTContext().getRecordType(recordDecl);
+  impl.SwiftContext.registerClangTypeForIRGen(
+      ExistentialType::get(pd->getDeclaredInterfaceType()), clangRecordType);
+  return ExistentialType::get(pd->getDeclaredInterfaceType());
+}
+
 ImportedType ClangImporter::Implementation::importFunctionReturnType(
     DeclContext *dc, const clang::FunctionDecl *clangDecl,
     bool allowNSUIntegerAsInt) {
@@ -2440,12 +2453,16 @@ ImportedType ClangImporter::Implementation::importFunctionReturnType(
 
   // Import the underlying result type.
   if (clangDecl) {
-    if (auto recordType = returnType->getAsCXXRecordDecl()) {
+    if (auto recordDecl = returnType->getAsCXXRecordDecl()) {
       if (auto *vd = evaluateOrDefault(
               SwiftContext.evaluator,
-              CxxRecordAsSwiftType({recordType, SwiftContext}), nullptr)) {
+              CxxRecordAsSwiftType({recordDecl, SwiftContext}), nullptr)) {
         if (auto *cd = dyn_cast<ClassDecl>(vd)) {
           Type t = ClassType::get(cd, Type(), SwiftContext);
+          return ImportedType(t, /*implicitlyUnwraps=*/false);
+        }
+        if (auto *pd = dyn_cast<ProtocolDecl>(vd)) {
+          Type t = buildExistentialTypeForProtocol(pd, recordDecl, *this);
           return ImportedType(t, /*implicitlyUnwraps=*/false);
         }
       }
@@ -2503,6 +2520,22 @@ ImportedType ClangImporter::Implementation::importFunctionParamsAndReturnType(
   returnType = desugarIfBoundsAttributed(returnType);
 
   ImportedType importedType = importer::findOptionSetEnum(returnType, *this);
+
+  // Check if the return type is a Swift type round-tripped through C++.
+  if (!importedType) {
+    if (auto recordDecl = returnType->getAsCXXRecordDecl()) {
+      if (auto *vd = evaluateOrDefault(
+              SwiftContext.evaluator,
+              CxxRecordAsSwiftType({recordDecl, SwiftContext}), nullptr)) {
+        if (auto *cd = dyn_cast<ClassDecl>(vd)) {
+          importedType = {ClassType::get(cd, Type(), SwiftContext), false};
+        } else if (auto *pd = dyn_cast<ProtocolDecl>(vd)) {
+          importedType = {buildExistentialTypeForProtocol(pd, recordDecl, *this),
+                          false};
+        }
+      }
+    }
+  }
 
   if (auto templateType =
           dyn_cast<clang::TemplateTypeParmType>(returnType)) {
@@ -2724,6 +2757,8 @@ ClangImporter::Implementation::importParameterType(
         if (auto *cd = dyn_cast<ClassDecl>(vd)) {
 
           swiftParamTy = ClassType::get(cd, Type(), SwiftContext);
+        } else if (auto *pd = dyn_cast<ProtocolDecl>(vd)) {
+          swiftParamTy = buildExistentialTypeForProtocol(pd, recordType, *this);
         }
       }
     }

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2342,6 +2342,67 @@ applyImportTypeAttrs(ImportTypeAttrs attrs, Type type,
   return type;
 }
 
+/// Try to build a Swift protocol composition existential type for a C++
+/// composition wrapper (e.g., AnyDrawableAndResizable) that was round-tripped
+/// through C++. Returns nullopt if the record is not a composition wrapper.
+static std::optional<Type>
+tryBuildCompositionExistentialType(const clang::CXXRecordDecl *recordDecl,
+                                   ClangImporter::Implementation &impl) {
+  auto *essAttr = recordDecl->getAttr<clang::ExternalSourceSymbolAttr>();
+  if (!essAttr || essAttr->getLanguage() != "Swift" ||
+      essAttr->getUSR() != "composition")
+    return std::nullopt;
+
+  auto *mod = impl.SwiftContext.getModuleByName(essAttr->getDefinedIn());
+  if (!mod)
+    return std::nullopt;
+
+  if (recordDecl->getNumBases() != 1)
+    return std::nullopt;
+  auto baseTy = recordDecl->bases_begin()->getType();
+  auto *baseDecl = dyn_cast_or_null<clang::ClassTemplateSpecializationDecl>(
+      baseTy->getAsCXXRecordDecl());
+  if (!baseDecl)
+    return std::nullopt;
+
+  SmallVector<Type, 4> memberTypes;
+  const auto &args = baseDecl->getTemplateArgs();
+  for (unsigned i = 0; i < args.size(); ++i) {
+    if (args[i].getKind() != clang::TemplateArgument::Type)
+      continue;
+    auto *tagDecl = args[i].getAsType()->getAsCXXRecordDecl();
+    if (!tagDecl)
+      continue;
+    StringRef tagName = tagDecl->getName();
+    if (!tagName.ends_with("Tag"))
+      continue;
+    StringRef protoName = tagName.drop_back(3);
+    SmallVector<ValueDecl *, 1> results;
+    mod->lookupValue(impl.SwiftContext.getIdentifier(protoName),
+                     NLKind::UnqualifiedLookup, results);
+    if (results.size() != 1)
+      return std::nullopt;
+    auto *pd = dyn_cast<ProtocolDecl>(results[0]);
+    if (!pd)
+      return std::nullopt;
+    memberTypes.push_back(pd->getDeclaredInterfaceType());
+  }
+
+  if (memberTypes.size() < 2)
+    return std::nullopt;
+
+  auto compositionType = ProtocolCompositionType::get(
+      impl.SwiftContext, memberTypes, InvertibleProtocolSet(),
+      /*HasExplicitAnyObject=*/false);
+  auto existentialType = ExistentialType::get(compositionType);
+
+  auto clangRecordType =
+      recordDecl->getASTContext().getRecordType(recordDecl);
+  impl.SwiftContext.registerClangTypeForIRGen(existentialType, clangRecordType);
+
+  return existentialType;
+}
+
 /// Build the Swift existential type for a protocol that was round-tripped
 /// through C++. If the Clang record is a template specialization (i.e., a PAT
 /// protocol wrapper like Container<swift::Int>), extract the template args,
@@ -2557,6 +2618,9 @@ ImportedType ClangImporter::Implementation::importFunctionReturnType(
           return ImportedType(t, /*implicitlyUnwraps=*/false);
         }
       }
+      if (auto compType =
+              tryBuildCompositionExistentialType(recordDecl, *this))
+        return ImportedType(*compType, /*implicitlyUnwraps=*/false);
     }
   }
 
@@ -2624,6 +2688,11 @@ ImportedType ClangImporter::Implementation::importFunctionParamsAndReturnType(
           importedType = {buildExistentialTypeForProtocol(pd, recordDecl, *this),
                           false};
         }
+      }
+      if (!importedType) {
+        if (auto compType =
+                tryBuildCompositionExistentialType(recordDecl, *this))
+          importedType = {*compType, false};
       }
     }
   }
@@ -2851,6 +2920,11 @@ ClangImporter::Implementation::importParameterType(
         } else if (auto *pd = dyn_cast<ProtocolDecl>(vd)) {
           swiftParamTy = buildExistentialTypeForProtocol(pd, recordType, *this);
         }
+      }
+      if (!swiftParamTy) {
+        if (auto compType =
+                tryBuildCompositionExistentialType(recordType, *this))
+          swiftParamTy = *compType;
       }
     }
   }

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -3428,6 +3428,7 @@ FuncDecl *SwiftDeclSynthesizer::findExplicitDestroy(
 
   case CxxRecordSemanticsKind::Iterator:
   case CxxRecordSemanticsKind::SwiftClassType:
+  case CxxRecordSemanticsKind::SwiftExistentialType:
     return nullptr;
   }
 }

--- a/lib/PrintAsClang/CMakeLists.txt
+++ b/lib/PrintAsClang/CMakeLists.txt
@@ -42,6 +42,7 @@ add_swift_host_library(swiftPrintAsClang STATIC
   PrimitiveTypeMapping.cpp
   PrintAsClang.cpp
   PrintClangClassType.cpp
+  PrintClangExistentialType.cpp
   PrintClangFunction.cpp
   PrintClangValueType.cpp
   PrintSwiftToClangCoreScaffold.cpp

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -3199,6 +3199,16 @@ bool DeclAndTypePrinter::shouldInclude(const ValueDecl *VD) {
   return true;
 }
 
+std::string DeclAndTypePrinter::ensureCompositionEmitted(
+    ArrayRef<const ProtocolDecl *> protocols) {
+  auto name = ClangExistentialTypePrinter::getCompositionName(protocols);
+  if (emittedCompositions.insert(name).second) {
+    ClangExistentialTypePrinter(os, outOfLineDefinitionsOS)
+        .printCompositionTypeDecl(protocols, name, *this);
+  }
+  return name;
+}
+
 bool DeclAndTypePrinter::isZeroSized(const NominalTypeDecl *decl) {
   if (decl->isResilient())
     return false;

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1777,6 +1777,8 @@ private:
     os << "}\n";
     if (result.isObjCxxOnly())
       os << "#endif // defined(__OBJC__)\n";
+    if (result.needsExistentialGuard())
+      os << "#endif // SWIFT_CXX_EXISTENTIAL_INTEROP && __cpp_concepts\n";
   }
 
   enum class PrintLeadingSpace : bool {

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -15,6 +15,7 @@
 #include "OutputLanguageMode.h"
 #include "PrimitiveTypeMapping.h"
 #include "PrintClangClassType.h"
+#include "PrintClangExistentialType.h"
 #include "PrintClangFunction.h"
 #include "PrintClangValueType.h"
 #include "SwiftToClangInteropContext.h"
@@ -38,6 +39,7 @@
 #include "swift/AST/TypeVisitor.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/Feature.h"
 #include "swift/IDE/CommentConversion.h"
 #include "swift/IRGen/IRABIDetailsProvider.h"
 #include "swift/IRGen/Linking.h"
@@ -465,6 +467,16 @@ private:
 
   void visitProtocolDecl(ProtocolDecl *PD) {
     printDocumentationComment(PD);
+
+    if (outputLang == OutputLanguageMode::Cxx) {
+      if (!PD->isObjC() &&
+          getASTContext().LangOpts.hasFeature(
+              Feature::CxxExistentialInterop)) {
+        ClangExistentialTypePrinter(os, owningPrinter.outOfLineDefinitionsOS)
+            .printExistentialTypeDecl(PD, owningPrinter);
+      }
+      return;
+    }
 
     StringRef customName = getNameForObjC(PD, CustomNamesOnly);
     if (customName.empty()) {

--- a/lib/PrintAsClang/DeclAndTypePrinter.h
+++ b/lib/PrintAsClang/DeclAndTypePrinter.h
@@ -86,6 +86,9 @@ private:
   OutputLanguageMode outputLang;
   llvm::DenseMap<Type, std::optional<ClangRepresentation>> typeRepresentations;
 
+  /// Names of ad-hoc protocol composition wrappers that have been emitted.
+  llvm::StringSet<> emittedCompositions;
+
   /// The name 'CFTypeRef'.
   ///
   /// Cached for convenience.
@@ -133,6 +136,11 @@ public:
   /// Returns true if \p VD should be included in a compatibility header for
   /// the options the printer was constructed with.
   bool shouldInclude(const ValueDecl *VD);
+
+  /// Ensures a composition wrapper class has been emitted for the given
+  /// protocol set. Returns the composition name. Idempotent.
+  std::string ensureCompositionEmitted(
+      ArrayRef<const ProtocolDecl *> protocols);
 
   bool isZeroSized(const NominalTypeDecl *decl);
 

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -1009,7 +1009,12 @@ public:
           success = writeFunc(FD);
         else if (auto SD = dyn_cast<StructDecl>(D))
           success = writeStruct(SD);
-        else if (auto *vd = dyn_cast<ValueDecl>(D))
+        else if (auto PD = dyn_cast<ProtocolDecl>(D);
+                 PD && M.getASTContext().LangOpts.hasFeature(
+                            Feature::CxxExistentialInterop)) {
+          printer.print(PD);
+          success = true;
+        } else if (auto *vd = dyn_cast<ValueDecl>(D))
           topLevelEmissionScope.additionalUnrepresentableDeclarations.insert(
               {vd, ""});
       } else if (isa<ValueDecl>(D)) {

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -33,6 +33,7 @@
 #include "swift/Basic/Feature.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/ClangImporter/ClangImporter.h"
+#include "swift/IRGen/Linking.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/Strings.h"
 
@@ -390,6 +391,8 @@ class ModuleWriter {
   PrimitiveTypeMapping typeMapping;
   std::string outOfLineDefinitions;
   llvm::raw_string_ostream outOfLineDefinitionsOS;
+  std::string globalScopeDefinitions;
+  llvm::raw_string_ostream globalScopeDefinitionsOS;
   DeclAndTypePrinter printer;
   OutputLanguageMode outputLangMode;
   bool dependsOnStdlib = false;
@@ -402,12 +405,20 @@ public:
                OutputLanguageMode outputLang)
       : os(os), imports(imports), M(mod),
         outOfLineDefinitionsOS(outOfLineDefinitions),
+        globalScopeDefinitionsOS(globalScopeDefinitions),
         printer(M, os, prologueOS, outOfLineDefinitionsOS, objcDelayedMembers,
                 topLevelEmissionScope, typeMapping, interopContext, access,
                 requiresExposedAttribute, exposedModules, outputLang),
         outputLangMode(outputLang) {}
 
   PrimitiveTypeMapping &getTypeMapping() { return typeMapping; }
+
+  /// Returns definitions that must be emitted at global scope
+  /// (outside the module namespace), such as conformance record
+  /// template specializations.
+  llvm::StringRef getGlobalScopeDefinitions() {
+    return globalScopeDefinitionsOS.str();
+  }
 
   /// Returns true if a Stdlib dependency was seen during the emission of this module.
   bool isStdlibRequired() const {
@@ -930,6 +941,133 @@ public:
     return true;
   }
 
+  void emitStdlibConformanceRecords() {
+    if (M.isStdlibModule())
+      return;
+
+    auto &ctx = M.getASTContext();
+
+    struct StdlibProto {
+      ProtocolDecl *proto;
+      const char *recordName;
+    };
+    SmallVector<StdlibProto, 3> stdlibProtos;
+    if (auto *p = ctx.getProtocol(KnownProtocolKind::Equatable))
+      stdlibProtos.push_back({p, "EquatableConformance"});
+    if (auto *p = ctx.getProtocol(KnownProtocolKind::Hashable))
+      stdlibProtos.push_back({p, "HashableConformance"});
+    if (auto *p = ctx.getProtocol(KnownProtocolKind::Comparable))
+      stdlibProtos.push_back({p, "ComparableConformance"});
+
+    if (stdlibProtos.empty())
+      return;
+
+    SmallVector<Decl *, 64> decls;
+    M.getTopLevelDeclsWithAuxiliaryDecls(decls);
+
+    struct ConformanceRecord {
+      NominalTypeDecl *type;
+      std::string confDescSymbol;
+      const char *recordName;
+    };
+    SmallVector<ConformanceRecord, 8> records;
+
+    for (auto *D : decls) {
+      auto *NTD = dyn_cast<NominalTypeDecl>(D);
+      if (!NTD || isa<ProtocolDecl>(NTD) || isa<ClassDecl>(NTD))
+        continue;
+      if (NTD->getModuleContext() != &M)
+        continue;
+      if (!printer.shouldInclude(NTD))
+        continue;
+
+      for (auto &sp : stdlibProtos) {
+        SmallVector<ProtocolConformance *, 1> conformances;
+        if (!NTD->lookupConformance(sp.proto, conformances))
+          continue;
+        if (conformances.empty())
+          continue;
+
+        auto *conf = conformances.front()->getRootConformance();
+        auto confDescEntity =
+            irgen::LinkEntity::forProtocolConformanceDescriptor(conf);
+        records.push_back(
+            {NTD, confDescEntity.mangleAsString(ctx), sp.recordName});
+      }
+    }
+
+    if (records.empty())
+      return;
+
+    auto moduleName = M.getName().str();
+
+    // Conformance descriptor extern declarations go inside the module
+    // namespace (which outOfLineDefinitionsOS is already inside of),
+    // wrapped in _impl.
+    outOfLineDefinitionsOS << "// Conformance records for stdlib protocols.\n";
+    outOfLineDefinitionsOS << "namespace "
+                           << cxx_synthesis::getCxxImplNamespaceName()
+                           << " {\n";
+    for (auto &r : records) {
+      outOfLineDefinitionsOS << "SWIFT_EXTERN const char " << r.confDescSymbol
+                             << "[];\n";
+    }
+    outOfLineDefinitionsOS << "} // namespace "
+                           << cxx_synthesis::getCxxImplNamespaceName()
+                           << "\n\n";
+
+    // Conformance record specializations must be at global scope
+    // (outside the module namespace) to specialize swift:: templates.
+    ClangSyntaxPrinter syntaxPrinter(ctx, globalScopeDefinitionsOS);
+    globalScopeDefinitionsOS << "#pragma clang diagnostic push\n";
+    globalScopeDefinitionsOS
+        << "#pragma clang diagnostic ignored \"-Wc++17-extensions\"\n";
+    for (auto &r : records) {
+      globalScopeDefinitionsOS << "template<>\n";
+      globalScopeDefinitionsOS << "struct swift::" << r.recordName << "<"
+                             << moduleName << "::";
+      syntaxPrinter.printBaseName(r.type);
+      globalScopeDefinitionsOS << "> {\n";
+      globalScopeDefinitionsOS
+          << "  static inline const void* getWitnessTable() {\n"
+          << "    static const void *wt = swift::_impl::swift_getWitnessTable("
+          << moduleName << "::"
+          << cxx_synthesis::getCxxImplNamespaceName() << "::" << r.confDescSymbol
+          << ", swift::TypeMetadataTrait<" << moduleName << "::";
+      syntaxPrinter.printBaseName(r.type);
+      globalScopeDefinitionsOS
+          << ">::getTypeMetadata(), nullptr);\n"
+          << "    return wt;\n"
+          << "  }\n";
+      globalScopeDefinitionsOS << "};\n\n";
+    }
+    globalScopeDefinitionsOS << "#pragma clang diagnostic pop\n";
+
+    // Pull free operators from global scope into the module namespace
+    // so ADL finds them inside STL algorithms (std::sort, std::find, etc.).
+    bool hasEquatable = false, hasComparable = false;
+    for (auto &r : records) {
+      if (StringRef(r.recordName) == "EquatableConformance")
+        hasEquatable = true;
+      else if (StringRef(r.recordName) == "ComparableConformance")
+        hasComparable = true;
+    }
+    if (hasEquatable || hasComparable) {
+      outOfLineDefinitionsOS << "#ifdef __cpp_concepts\n";
+      if (hasEquatable) {
+        outOfLineDefinitionsOS << "using ::operator==;\n";
+        outOfLineDefinitionsOS << "using ::operator!=;\n";
+      }
+      if (hasComparable) {
+        outOfLineDefinitionsOS << "using ::operator<;\n";
+        outOfLineDefinitionsOS << "using ::operator<=;\n";
+        outOfLineDefinitionsOS << "using ::operator>;\n";
+        outOfLineDefinitionsOS << "using ::operator>=;\n";
+      }
+      outOfLineDefinitionsOS << "#endif // __cpp_concepts\n";
+    }
+  }
+
   void write() {
     SmallVector<Decl *, 64> decls;
     M.getTopLevelDeclsWithAuxiliaryDecls(decls);
@@ -1055,6 +1193,13 @@ public:
             make_range(groupBegin, objcDelayedMembers.end()));
       }
 
+    // Emit conformance records for stdlib protocols
+    // (Equatable, Hashable, Comparable) before the out-of-line
+    // definitions are flushed.
+    if (outputLangMode == OutputLanguageMode::Cxx &&
+        M.getASTContext().LangOpts.hasFeature(Feature::CxxExistentialInterop))
+      emitStdlibConformanceRecords();
+
     // Print any out of line definitions.
     os << outOfLineDefinitionsOS.str();
 
@@ -1082,13 +1227,26 @@ public:
         llvm::remove_if(
             removedVDList,
             [&](const ValueDecl *vd) {
-              return !printer.isVisible(vd) || vd->isObjC() ||
-                     (vd->isStdlibDecl() && !vd->getName().isSpecial() &&
-                      vd->getBaseIdentifier().hasUnderscoredNaming()) ||
-                     (vd->isStdlibDecl() && isa<StructDecl>(vd)) ||
-                     (vd->isStdlibDecl() &&
-                      vd->getASTContext().getErrorDecl() == vd) ||
-                     swift::hasExposeNotCxxAttr(vd);
+              if (!printer.isVisible(vd) || vd->isObjC() ||
+                  (vd->isStdlibDecl() && !vd->getName().isSpecial() &&
+                   vd->getBaseIdentifier().hasUnderscoredNaming()) ||
+                  (vd->isStdlibDecl() && isa<StructDecl>(vd)) ||
+                  (vd->isStdlibDecl() &&
+                   vd->getASTContext().getErrorDecl() == vd) ||
+                  swift::hasExposeNotCxxAttr(vd))
+                return true;
+              if (auto *PD = dyn_cast<ProtocolDecl>(vd)) {
+                if (M.getASTContext().LangOpts.hasFeature(
+                        Feature::CxxExistentialInterop)) {
+                  if (auto kind = PD->getKnownProtocolKind()) {
+                    if (*kind == KnownProtocolKind::Equatable ||
+                        *kind == KnownProtocolKind::Hashable ||
+                        *kind == KnownProtocolKind::Comparable)
+                      return true;
+                  }
+                }
+              }
+              return false;
             }),
         removedVDList.end());
     // Sort the unavaiable decls by their name and kind.
@@ -1309,6 +1467,12 @@ EmittedClangHeaderDependencyInfo swift::printModuleContentsAsCxx(
           [&](raw_ostream &os) { os << moduleOS.str(); },
           ClangSyntaxPrinter::NamespaceTrivia::AttributeSwiftPrivate, &M);
   os << "#pragma clang diagnostic pop\n";
+
+  // Emit global-scope definitions (conformance record specializations)
+  // after the module namespace is closed.
+  auto globalDefs = writer.getGlobalScopeDefinitions();
+  if (!globalDefs.empty())
+    os << "\n" << globalDefs;
 
   if (M.isStdlibModule()) {
     os << "#pragma clang diagnostic pop\n";

--- a/lib/PrintAsClang/PrintAsClang.cpp
+++ b/lib/PrintAsClang/PrintAsClang.cpp
@@ -21,6 +21,7 @@
 #include "swift/AST/Module.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/Feature.h"
 #include "swift/Basic/Version.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/Frontend/FrontendOptions.h"
@@ -86,6 +87,11 @@ static void writePtrauthPrologue(raw_ostream &os, ASTContext &ctx) {
                 os << "# endif\n";
                 os << "# ifndef __ptrauth_swift_class_method_pointer\n";
                 os << "#  define __ptrauth_swift_class_method_pointer(x)\n";
+                os << "# endif\n";
+                os << "# ifndef "
+                      "__ptrauth_swift_protocol_witness_function_pointer\n";
+                os << "#  define "
+                      "__ptrauth_swift_protocol_witness_function_pointer(x)\n";
                 os << "# endif\n";
               });
           os << "#endif\n";
@@ -670,6 +676,8 @@ bool swift::printAsClangHeader(raw_ostream &os, ModuleDecl *M,
       exposedModules.insert(mod.moduleName);
 
     // Include the shim header only in the C++ mode.
+    if (M->getASTContext().LangOpts.hasFeature(Feature::CxxExistentialInterop))
+      os << "#define SWIFT_CXX_EXISTENTIAL_INTEROP 1\n";
     ClangSyntaxPrinter(M->getASTContext(), os).printIncludeForShimHeader(
         "_SwiftCxxInteroperability.h");
 

--- a/lib/PrintAsClang/PrintClangExistentialType.cpp
+++ b/lib/PrintAsClang/PrintClangExistentialType.cpp
@@ -19,6 +19,7 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/ParameterList.h"
+#include "swift/AST/ProtocolAssociations.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/Types.h"
 #include "swift/IRGen/Linking.h"
@@ -283,9 +284,25 @@ void ClangExistentialTypePrinter::printImplFromExistentialFactory(
     const ProtocolDecl *PD, DeclAndTypePrinter &declAndTypePrinter) {
   ClangSyntaxPrinter printer(PD->getASTContext(), os);
 
+  auto pats = PD->getPrimaryAssociatedTypes();
+  if (!pats.empty()) {
+    os << "  template <";
+    llvm::interleaveComma(pats, os, [&](const AssociatedTypeDecl *pat) {
+      os << "typename " << pat->getNameStr();
+    });
+    os << ">\n";
+  }
+
   os << "  static ";
   printer.printInlineForThunk();
   printer.printBaseName(PD);
+  if (!pats.empty()) {
+    os << "<";
+    llvm::interleaveComma(pats, os, [&](const AssociatedTypeDecl *pat) {
+      os << pat->getNameStr();
+    });
+    os << ">";
+  }
   if (isClassBound) {
     os << " _fromExistential("
           "void *_Nullable classPtr, "
@@ -298,6 +315,13 @@ void ClangExistentialTypePrinter::printImplFromExistentialFactory(
   }
   os << "    ";
   printer.printBaseName(PD);
+  if (!pats.empty()) {
+    os << "<";
+    llvm::interleaveComma(pats, os, [&](const AssociatedTypeDecl *pat) {
+      os << pat->getNameStr();
+    });
+    os << ">";
+  }
   os << " result;\n";
   if (isClassBound) {
     os << "    result._value = classPtr;\n";
@@ -455,6 +479,15 @@ void ClangExistentialTypePrinter::printExistentialTypeDecl(
 
     // Existential wrapper class: subclass of SwiftExistentialType
     // or SwiftClassExistentialType for class-bound protocols.
+    // Protocols with primary associated types become class templates.
+    auto pats = PD->getPrimaryAssociatedTypes();
+    if (!pats.empty()) {
+      os << "template <";
+      llvm::interleaveComma(pats, os, [&](const AssociatedTypeDecl *pat) {
+        os << "typename " << pat->getNameStr() << " = swift::Any";
+      });
+      os << ">\n";
+    }
     os << "class";
     declAndTypePrinter.printAvailability(os, PD);
     ClangSyntaxPrinter(PD->getASTContext(), os).printSymbolUSRAttribute(PD);
@@ -515,33 +548,82 @@ void ClangExistentialTypePrinter::printExistentialTypeDecl(
 void ClangExistentialTypePrinter::printImplGetOpaquePointer(
     const ProtocolDecl *PD) {
   ClangSyntaxPrinter printer(PD->getASTContext(), os);
+  auto pats = PD->getPrimaryAssociatedTypes();
+  auto printProtoName = [&]() {
+    printer.printBaseName(PD);
+    if (!pats.empty()) {
+      os << "<";
+      llvm::interleaveComma(pats, os, [&](const AssociatedTypeDecl *pat) {
+        os << pat->getNameStr();
+      });
+      os << ">";
+    }
+  };
+
   // const overload
+  if (!pats.empty()) {
+    os << "  template <";
+    llvm::interleaveComma(pats, os, [&](const AssociatedTypeDecl *pat) {
+      os << "typename " << pat->getNameStr();
+    });
+    os << ">\n";
+  }
   os << "  static ";
   printer.printInlineForThunk();
   os << "const char * _Nonnull getOpaquePointer(const ";
-  printer.printBaseName(PD);
+  printProtoName();
   os << " &object) { return reinterpret_cast<const char *>(&object); }\n";
 
   // non-const overload
+  if (!pats.empty()) {
+    os << "  template <";
+    llvm::interleaveComma(pats, os, [&](const AssociatedTypeDecl *pat) {
+      os << "typename " << pat->getNameStr();
+    });
+    os << ">\n";
+  }
   os << "  static ";
   printer.printInlineForThunk();
   os << "char * _Nonnull getOpaquePointer(";
-  printer.printBaseName(PD);
+  printProtoName();
   os << " &object) { return reinterpret_cast<char *>(&object); }\n";
 }
 
 void ClangExistentialTypePrinter::printImplReturnNewValue(
     const ProtocolDecl *PD) {
   ClangSyntaxPrinter printer(PD->getASTContext(), os);
+  auto pats = PD->getPrimaryAssociatedTypes();
 
-  os << "  template <class T>\n";
+  os << "  template <";
+  bool needsComma = false;
+  for (auto *pat : pats) {
+    if (needsComma) os << ", ";
+    os << "typename " << pat->getNameStr();
+    needsComma = true;
+  }
+  if (needsComma) os << ", ";
+  os << "class T>\n";
 
   os << "  static ";
   printer.printInlineForHelperFunction();
   printer.printBaseName(PD);
+  if (!pats.empty()) {
+    os << "<";
+    llvm::interleaveComma(pats, os, [&](const AssociatedTypeDecl *pat) {
+      os << pat->getNameStr();
+    });
+    os << ">";
+  }
   os << " returnNewValue(T callable) {\n";
   os << "    ";
   printer.printBaseName(PD);
+  if (!pats.empty()) {
+    os << "<";
+    llvm::interleaveComma(pats, os, [&](const AssociatedTypeDecl *pat) {
+      os << pat->getNameStr();
+    });
+    os << ">";
+  }
   os << " result;\n";
   os << "    callable(reinterpret_cast<char *>(&result));\n";
   os << "    return result;\n";
@@ -555,6 +637,8 @@ void ClangExistentialTypePrinter::printBoxingConstructors(
   ClangSyntaxPrinter printer(PD->getASTContext(), os);
   ClangSyntaxPrinter ooPrinter(PD->getASTContext(), outOfLineOS);
 
+  auto pats = PD->getPrimaryAssociatedTypes();
+
   for (auto &c : boxingConformances) {
     // Inline declaration (forward-declared type is enough).
     os << "  ";
@@ -567,9 +651,27 @@ void ClangExistentialTypePrinter::printBoxingConstructors(
     // Out-of-line definition (emitted after all types are declared).
     outOfLineOS << "#if defined(SWIFT_CXX_EXISTENTIAL_INTEROP) && "
                    "defined(__cpp_concepts) && __cpp_concepts >= 202002L\n";
+    // For protocols with primary associated types (class templates),
+    // emit a template prefix and qualified name with template args.
+    if (!pats.empty()) {
+      outOfLineOS << "  template <";
+      llvm::interleaveComma(pats, outOfLineOS,
+                            [&](const AssociatedTypeDecl *pat) {
+                              outOfLineOS << "typename " << pat->getNameStr();
+                            });
+      outOfLineOS << ">\n";
+    }
     outOfLineOS << "  ";
     ooPrinter.printInlineForThunk();
     ooPrinter.printBaseName(PD);
+    if (!pats.empty()) {
+      outOfLineOS << "<";
+      llvm::interleaveComma(pats, outOfLineOS,
+                            [&](const AssociatedTypeDecl *pat) {
+                              outOfLineOS << pat->getNameStr();
+                            });
+      outOfLineOS << ">";
+    }
     outOfLineOS << "::";
     ooPrinter.printBaseName(PD);
     outOfLineOS << "(const ";

--- a/lib/PrintAsClang/PrintClangExistentialType.cpp
+++ b/lib/PrintAsClang/PrintClangExistentialType.cpp
@@ -741,7 +741,8 @@ void ClangExistentialTypePrinter::printCompositionTypeDecl(
   SmallVector<const ProtocolDecl *, 4> wtProtocols;
   for (auto *PD : protocols) {
     if (!PD->isMarkerProtocol() &&
-        Lowering::TypeConverter::protocolRequiresWitnessTable(PD))
+        Lowering::TypeConverter::protocolRequiresWitnessTable(
+            const_cast<ProtocolDecl *>(PD)))
       wtProtocols.push_back(PD);
   }
 
@@ -754,7 +755,7 @@ void ClangExistentialTypePrinter::printCompositionTypeDecl(
   os << "} // namespace " << cxx_synthesis::getCxxImplNamespaceName() << "\n";
 
   // Wrapper class inheriting from SwiftExistentialType<Tags...>.
-  os << "class " << compositionName
+  os << "class SWIFT_SYMBOL(\"composition\") " << compositionName
      << " final : public swift::_impl::SwiftExistentialType<";
   llvm::interleaveComma(wtProtocols, os, [&](const ProtocolDecl *PD) {
     os << cxx_synthesis::getCxxImplNamespaceName() << "::";

--- a/lib/PrintAsClang/PrintClangExistentialType.cpp
+++ b/lib/PrintAsClang/PrintClangExistentialType.cpp
@@ -1,0 +1,602 @@
+//===--- PrintClangExistentialType.cpp - Print existential types -*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "PrintClangExistentialType.h"
+#include "ClangSyntaxPrinter.h"
+#include "DeclAndTypePrinter.h"
+#include "PrimitiveTypeMapping.h"
+#include "PrintClangValueType.h"
+#include "swift/AST/ConformanceLookup.h"
+#include "swift/AST/Decl.h"
+#include "swift/AST/Module.h"
+#include "swift/AST/ParameterList.h"
+#include "swift/AST/ProtocolConformance.h"
+#include "swift/AST/Types.h"
+#include "swift/IRGen/Linking.h"
+#include "swift/SIL/SILDeclRef.h"
+#include "swift/SIL/TypeLowering.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/SipHash.h"
+
+using namespace swift;
+
+std::optional<std::string>
+ClangExistentialTypePrinter::getCxxTypeName(Type ty,
+                                            DeclAndTypePrinter &printer) {
+  if (ty->isVoid())
+    return std::string("void");
+
+  if (auto *typeDecl = ty->getAnyNominal()) {
+    auto info = printer.getTypeMapping().getKnownCxxTypeInfo(typeDecl);
+    if (info)
+      return info->name.str();
+  }
+
+  return std::nullopt;
+}
+
+bool ClangExistentialTypePrinter::canEmitExistentialMethod(
+    const FuncDecl *FD, DeclAndTypePrinter &printer) {
+  if (FD->isStatic())
+    return false;
+  if (FD->isOperator())
+    return false;
+  if (FD->hasAsync())
+    return false;
+  if (FD->hasThrows())
+    return false;
+  if (FD->getAttrs().hasAttribute<MutatingAttr>())
+    return false;
+  if (FD->isMutating())
+    return false;
+  if (!FD->requiresNewWitnessTableEntry())
+    return false;
+
+  auto methodTy = FD->getMethodInterfaceType()->castTo<FunctionType>();
+
+  if (!getCxxTypeName(methodTy->getResult(), printer))
+    return false;
+
+  for (auto &param : methodTy->getParams()) {
+    if (param.isInOut())
+      return false;
+    if (!getCxxTypeName(param.getPlainType(), printer))
+      return false;
+  }
+
+  return true;
+}
+
+void ClangExistentialTypePrinter::printProtocolRequirementMethods(
+    const ProtocolDecl *PD, DeclAndTypePrinter &declAndTypePrinter) {
+  llvm::SmallPtrSet<const FuncDecl *, 8> emittedMethods;
+  SmallVector<BaseWTStep, 4> emptyChain;
+  emitMethodsForProtocol(PD, emptyChain, emittedMethods, declAndTypePrinter);
+}
+
+void ClangExistentialTypePrinter::emitMethodsForProtocol(
+    const ProtocolDecl *PD, ArrayRef<BaseWTStep> baseChain,
+    llvm::SmallPtrSetImpl<const FuncDecl *> &emittedMethods,
+    DeclAndTypePrinter &declAndTypePrinter) {
+  // Walk PD's witness table layout in the same order as SILWitnessVisitor.
+  // Offset 0 is the conformance descriptor.
+  size_t currentOffset = 1;
+
+  // 1. Base protocol conformances from the requirement signature.
+  //    For Self-type conformance requirements, recurse into the base
+  //    protocol to emit its methods (and its bases' methods).
+  auto requirements = PD->getRequirementSignature().getRequirements();
+  for (const auto &reqt : requirements) {
+    if (reqt.getKind() != RequirementKind::Conformance)
+      continue;
+
+    auto protocol = reqt.getProtocolDecl();
+
+    if (!Lowering::TypeConverter::protocolRequiresWitnessTable(protocol))
+      continue;
+
+    auto type = reqt.getFirstType()->getCanonicalType();
+    if (isa<GenericTypeParamType>(type)) {
+      // Base protocol conformance (Self: Protocol).
+      // The base WT is at currentOffset in PD's WT.
+      SmallVector<BaseWTStep, 4> extendedChain(baseChain);
+      extendedChain.push_back({currentOffset});
+      emitMethodsForProtocol(protocol, extendedChain, emittedMethods,
+                             declAndTypePrinter);
+    }
+
+    currentOffset++;
+  }
+
+  // 2. Associated types.
+  for (auto *assocType : PD->getAssociatedTypeMembers()) {
+    if (assocType->getOverriddenDecls().empty())
+      currentOffset++;
+  }
+
+  // 3. Method entries from ABI members.
+  for (Decl *member : PD->getABIMembers()) {
+    if (!member->isAvailableDuringLowering())
+      continue;
+
+    if (auto *FD = dyn_cast<FuncDecl>(member)) {
+      if (isa<AccessorDecl>(FD))
+        continue;
+      if (!FD->requiresNewWitnessTableEntry()) {
+        continue;
+      }
+
+      size_t methodOffset = currentOffset;
+      currentOffset++;
+
+      if (!canEmitExistentialMethod(FD, declAndTypePrinter))
+        continue;
+
+      if (!emittedMethods.insert(FD).second)
+        continue;
+
+      uint16_t ptrAuthDisc =
+          llvm::getPointerAuthStableSipHash(SILDeclRef(FD).mangle());
+
+      emitExistentialMethod(FD, methodOffset, ptrAuthDisc, baseChain,
+                            declAndTypePrinter);
+    } else if (auto *ASD = dyn_cast<AbstractStorageDecl>(member)) {
+      ASD->visitOpaqueAccessors([&](AccessorDecl *accessor) {
+        if (accessor->requiresNewWitnessTableEntry())
+          currentOffset++;
+      });
+    } else if (auto *CD = dyn_cast<ConstructorDecl>(member)) {
+      if (CD->requiresNewWitnessTableEntry())
+        currentOffset++;
+    }
+  }
+}
+
+void ClangExistentialTypePrinter::emitExistentialMethod(
+    const FuncDecl *FD, size_t methodOffset, uint16_t ptrAuthDisc,
+    ArrayRef<BaseWTStep> baseChain,
+    DeclAndTypePrinter &declAndTypePrinter) {
+  ClangSyntaxPrinter printer(FD->getASTContext(), os);
+
+  auto methodTy = FD->getMethodInterfaceType()->castTo<FunctionType>();
+  auto resultCxxName =
+      getCxxTypeName(methodTy->getResult(), declAndTypePrinter);
+
+  // Method signature.
+  os << "  ";
+  printer.printInlineForThunk();
+  os << *resultCxxName << " ";
+  os << FD->getBaseIdentifier().str() << "(";
+
+  bool firstParam = true;
+  for (auto *param : *FD->getParameters()) {
+    if (!firstParam)
+      os << ", ";
+    firstParam = false;
+    auto paramCxxName =
+        getCxxTypeName(param->getInterfaceType(), declAndTypePrinter);
+    os << *paramCxxName << " " << param->getNameStr();
+  }
+
+  os << ") const {\n";
+
+  // Type-only witness signature.
+  os << "    // Type-only witness signature (never instantiated).\n";
+  os << "    struct _w { _w() = delete; static SWIFT_CALL " << *resultCxxName
+     << " call(";
+
+  bool firstTyParam = true;
+  for (auto *param : *FD->getParameters()) {
+    if (!firstTyParam)
+      os << ", ";
+    firstTyParam = false;
+    auto paramCxxName =
+        getCxxTypeName(param->getInterfaceType(), declAndTypePrinter);
+    os << *paramCxxName;
+  }
+  if (!firstTyParam)
+    os << ", ";
+  os << "void *_Nonnull, const void *_Nonnull, "
+        "SWIFT_CONTEXT void *_Nonnull); };\n";
+
+  // Emit the chain of base WT loads for inherited methods.
+  // Each step loads the next base protocol's WT from the previous one.
+  std::string wtExpr = "_witnessTables[0]";
+  for (size_t i = 0; i < baseChain.size(); i++) {
+    std::string varName = "_bwt" + std::to_string(i);
+    os << "    auto *" << varName
+       << " = reinterpret_cast<const void *const *>(" << wtExpr << ")["
+       << baseChain[i].offset << "];\n";
+    wtExpr = varName;
+  }
+
+  // Dispatch through the (possibly base) witness table.
+  os << "    return _loadWitness<" << methodOffset << ", " << ptrAuthDisc
+     << ", decltype(&_w::call)>(" << wtExpr << ")(";
+
+  bool firstArg = true;
+  for (auto *param : *FD->getParameters()) {
+    if (!firstArg)
+      os << ", ";
+    firstArg = false;
+    os << param->getNameStr();
+  }
+  if (!firstArg)
+    os << ", ";
+  os << (isClassBound ? "_getType(), " : "_type, ")
+     << wtExpr << ", _projectValue());\n";
+  os << "  }\n";
+}
+
+void ClangExistentialTypePrinter::printConversionMethods(
+    const ProtocolDecl *PD, DeclAndTypePrinter &declAndTypePrinter) {
+  auto printCxxImplClassName = ClangValueTypePrinter::printCxxImplClassName;
+  ClangSyntaxPrinter printer(PD->getASTContext(), os);
+
+  auto requirements = PD->getRequirementSignature().getRequirements();
+  size_t currentOffset = 1; // offset 0 is conformance descriptor
+
+  for (const auto &reqt : requirements) {
+    if (reqt.getKind() != RequirementKind::Conformance)
+      continue;
+
+    auto protocol = reqt.getProtocolDecl();
+    if (!Lowering::TypeConverter::protocolRequiresWitnessTable(protocol))
+      continue;
+
+    auto type = reqt.getFirstType()->getCanonicalType();
+    if (isa<GenericTypeParamType>(type) && !protocol->isMarkerProtocol()) {
+      // Emit asBaseProtocol() conversion method.
+      os << "  ";
+      printer.printInlineForThunk();
+      printer.printBaseName(protocol);
+      os << " as";
+      printer.printBaseName(protocol);
+      os << "() const {\n";
+      os << "    auto *baseWT = reinterpret_cast<const void *const *>"
+            "(_witnessTables[0])["
+         << currentOffset << "];\n";
+      os << "    return " << cxx_synthesis::getCxxImplNamespaceName() << "::";
+      printCxxImplClassName(os, protocol);
+      if (isClassBound) {
+        os << "::_fromExistential(_value, baseWT);\n";
+      } else {
+        os << "::_fromExistential(_type, _projectValue(), baseWT);\n";
+      }
+      os << "  }\n";
+    }
+
+    currentOffset++;
+  }
+}
+
+void ClangExistentialTypePrinter::printImplFromExistentialFactory(
+    const ProtocolDecl *PD, DeclAndTypePrinter &declAndTypePrinter) {
+  ClangSyntaxPrinter printer(PD->getASTContext(), os);
+
+  os << "  static ";
+  printer.printInlineForThunk();
+  printer.printBaseName(PD);
+  if (isClassBound) {
+    os << " _fromExistential("
+          "void *_Nullable classPtr, "
+          "const void *_Nonnull wt) {\n";
+  } else {
+    os << " _fromExistential("
+          "void *_Nonnull typeMetadata, "
+          "void *_Nonnull projectedValue, "
+          "const void *_Nonnull wt) {\n";
+  }
+  os << "    ";
+  printer.printBaseName(PD);
+  os << " result;\n";
+  if (isClassBound) {
+    os << "    result._value = classPtr;\n";
+    os << "    if (result._value)\n";
+    os << "      swift::_impl::swift_retain("
+          "reinterpret_cast<void *_Nonnull>(result._value));\n";
+  } else {
+    os << "    result._type = typeMetadata;\n";
+    os << "    result._initializeWithValue(projectedValue);\n";
+  }
+  os << "    result._witnessTables[0] = wt;\n";
+  os << "    return result;\n";
+  os << "  }\n";
+}
+
+void ClangExistentialTypePrinter::printMarkerProtocolDecl(
+    const ProtocolDecl *PD, DeclAndTypePrinter &declAndTypePrinter) {
+  auto printCxxImplClassName = ClangValueTypePrinter::printCxxImplClassName;
+  ClangSyntaxPrinter printer(PD->getASTContext(), os);
+
+  printer.printParentNamespaceForNestedTypes(PD, [&](raw_ostream &os) {
+    // Forward declaration of the _impl helper class.
+    printer.printNamespace(cxx_synthesis::getCxxImplNamespaceName(),
+                           [&](raw_ostream &os) {
+                             os << "class";
+                             declAndTypePrinter.printAvailability(os, PD);
+                             os << ' ';
+                             printCxxImplClassName(os, PD);
+                             os << ";\n";
+                             os << "struct ";
+                             printer.printBaseName(PD);
+                             os << "Tag {\n";
+                             os << "  static constexpr bool IsMarker "
+                                   "= true;\n";
+                             os << "};\n";
+                           });
+
+    // Marker protocol: empty subclass of swift::Any (zero witness tables).
+    os << "class";
+    declAndTypePrinter.printAvailability(os, PD);
+    ClangSyntaxPrinter(PD->getASTContext(), os).printSymbolUSRAttribute(PD);
+    os << ' ';
+    printer.printBaseName(PD);
+    os << " final : public swift::_impl::SwiftExistentialType<"
+       << cxx_synthesis::getCxxImplNamespaceName() << "::";
+    printer.printBaseName(PD);
+    os << "Tag>";
+    os << " {\npublic:\n";
+
+    os << "private:\n";
+    os << "  ";
+    printer.printInlineForThunk();
+    printer.printBaseName(PD);
+    os << "() noexcept : SwiftExistentialType("
+          "typename SwiftExistentialType::uninit_t{}) {}\n";
+    os << "  friend class " << cxx_synthesis::getCxxImplNamespaceName() << "::";
+    printCxxImplClassName(os, PD);
+    os << ";\n";
+
+    printer.printSwiftMangledNameForDebugger(PD);
+
+    os << "};\n\n";
+
+    // The _impl helper class.
+    printer.printNamespace(
+        cxx_synthesis::getCxxImplNamespaceName(), [&](raw_ostream &os) {
+          os << "class";
+          declAndTypePrinter.printAvailability(os, PD);
+          os << ' ';
+          printCxxImplClassName(os, PD);
+          os << " {\npublic:\n";
+          os << "};\n";
+        });
+  });
+}
+
+void ClangExistentialTypePrinter::printExistentialTypeDecl(
+    const ProtocolDecl *PD, DeclAndTypePrinter &declAndTypePrinter) {
+  os << "#if defined(SWIFT_CXX_EXISTENTIAL_INTEROP) && "
+        "defined(__cpp_concepts) && __cpp_concepts >= 202002L\n";
+
+  if (PD->isMarkerProtocol()) {
+    printMarkerProtocolDecl(PD, declAndTypePrinter);
+    os << "#endif // SWIFT_CXX_EXISTENTIAL_INTEROP && __cpp_concepts\n";
+    return;
+  }
+
+  isClassBound = PD->requiresClass();
+
+  auto printCxxImplClassName = ClangValueTypePrinter::printCxxImplClassName;
+  ClangSyntaxPrinter printer(PD->getASTContext(), os);
+
+  // Collect same-module conformances for boxing constructors.
+  SmallVector<ConformingType, 4> boxingConformances;
+  {
+    auto *module = PD->getModuleContext();
+    SmallVector<Decl *, 64> decls;
+    module->getTopLevelDeclsWithAuxiliaryDecls(decls);
+    for (auto *D : decls) {
+      auto *NTD = dyn_cast<NominalTypeDecl>(D);
+      if (!NTD || isa<ProtocolDecl>(NTD))
+        continue;
+      if (NTD->isGenericContext())
+        continue;
+      if (isClassBound && !isa<ClassDecl>(NTD))
+        continue;
+      if (!isClassBound && isa<ClassDecl>(NTD))
+        continue;
+      if (!declAndTypePrinter.shouldInclude(NTD))
+        continue;
+      SmallVector<ProtocolConformance *, 1> conformances;
+      if (!NTD->lookupConformance(const_cast<ProtocolDecl *>(PD),
+                                  conformances))
+        continue;
+      if (conformances.empty())
+        continue;
+      auto *conformance = conformances.front()->getRootConformance();
+      auto wtEntity =
+          irgen::LinkEntity::forProtocolWitnessTable(conformance);
+      boxingConformances.push_back(
+          {NTD, wtEntity.mangleAsString(PD->getASTContext())});
+    }
+  }
+
+  printer.printParentNamespaceForNestedTypes(PD, [&](raw_ostream &os) {
+    // Forward declaration of the _impl helper class, plus WT externs
+    // for boxing constructors.
+    printer.printNamespace(cxx_synthesis::getCxxImplNamespaceName(),
+                           [&](raw_ostream &os) {
+                             os << "class";
+                             declAndTypePrinter.printAvailability(os, PD);
+                             os << ' ';
+                             printCxxImplClassName(os, PD);
+                             os << ";\n";
+                             for (auto &c : boxingConformances) {
+                               os << "SWIFT_EXTERN const char "
+                                  << c.wtSymbol << "[];\n";
+                             }
+                             os << "struct ";
+                             printer.printBaseName(PD);
+                             os << "Tag {\n";
+                             os << "  using WitnessTable = "
+                                   "const void *_Nonnull;\n";
+                             os << "};\n";
+                           });
+
+    // Forward-declare conforming types so boxing constructor
+    // declarations can reference them (definitions are emitted
+    // out-of-line after all types).
+    for (auto &c : boxingConformances) {
+      os << "class ";
+      ClangSyntaxPrinter(PD->getASTContext(), os).printBaseName(c.type);
+      os << ";\n";
+    }
+
+    // Existential wrapper class: subclass of SwiftExistentialType
+    // or SwiftClassExistentialType for class-bound protocols.
+    os << "class";
+    declAndTypePrinter.printAvailability(os, PD);
+    ClangSyntaxPrinter(PD->getASTContext(), os).printSymbolUSRAttribute(PD);
+    os << ' ';
+    printer.printBaseName(PD);
+    os << " final : public swift::_impl::";
+    os << (isClassBound ? "SwiftClassExistentialType"
+                        : "SwiftExistentialType");
+    os << "<" << cxx_synthesis::getCxxImplNamespaceName() << "::";
+    printer.printBaseName(PD);
+    os << "Tag>";
+    os << " {\npublic:\n";
+
+    // Emit protocol requirement methods.
+    printProtocolRequirementMethods(PD, declAndTypePrinter);
+
+    // Emit conversion methods (asBaseProtocol()) for direct base protocols.
+    printConversionMethods(PD, declAndTypePrinter);
+
+    // Emit per-conformance boxing constructors for concrete types in
+    // this module that conform to the protocol.
+    printBoxingConstructors(PD, boxingConformances, declAndTypePrinter);
+
+    os << "private:\n";
+    os << "  ";
+    printer.printInlineForThunk();
+    printer.printBaseName(PD);
+    auto baseClassName =
+        isClassBound ? "SwiftClassExistentialType" : "SwiftExistentialType";
+    os << "() noexcept : " << baseClassName
+       << "(typename " << baseClassName << "::uninit_t{}) {}\n";
+    os << "  friend class " << cxx_synthesis::getCxxImplNamespaceName() << "::";
+    printCxxImplClassName(os, PD);
+    os << ";\n";
+
+    printer.printSwiftMangledNameForDebugger(PD);
+
+    os << "};\n\n";
+
+    // The _impl helper class.
+    printer.printNamespace(
+        cxx_synthesis::getCxxImplNamespaceName(), [&](raw_ostream &os) {
+          os << "class";
+          declAndTypePrinter.printAvailability(os, PD);
+          os << ' ';
+          printCxxImplClassName(os, PD);
+          os << " {\npublic:\n";
+          printImplFromExistentialFactory(PD, declAndTypePrinter);
+          printImplGetOpaquePointer(PD);
+          printImplReturnNewValue(PD);
+          os << "};\n";
+        });
+  });
+
+  os << "#endif // SWIFT_CXX_EXISTENTIAL_INTEROP && __cpp_concepts\n";
+}
+
+void ClangExistentialTypePrinter::printImplGetOpaquePointer(
+    const ProtocolDecl *PD) {
+  ClangSyntaxPrinter printer(PD->getASTContext(), os);
+  // const overload
+  os << "  static ";
+  printer.printInlineForThunk();
+  os << "const char * _Nonnull getOpaquePointer(const ";
+  printer.printBaseName(PD);
+  os << " &object) { return reinterpret_cast<const char *>(&object); }\n";
+
+  // non-const overload
+  os << "  static ";
+  printer.printInlineForThunk();
+  os << "char * _Nonnull getOpaquePointer(";
+  printer.printBaseName(PD);
+  os << " &object) { return reinterpret_cast<char *>(&object); }\n";
+}
+
+void ClangExistentialTypePrinter::printImplReturnNewValue(
+    const ProtocolDecl *PD) {
+  ClangSyntaxPrinter printer(PD->getASTContext(), os);
+
+  os << "  template <class T>\n";
+
+  os << "  static ";
+  printer.printInlineForHelperFunction();
+  printer.printBaseName(PD);
+  os << " returnNewValue(T callable) {\n";
+  os << "    ";
+  printer.printBaseName(PD);
+  os << " result;\n";
+  os << "    callable(reinterpret_cast<char *>(&result));\n";
+  os << "    return result;\n";
+  os << "  }\n";
+}
+
+void ClangExistentialTypePrinter::printBoxingConstructors(
+    const ProtocolDecl *PD,
+    ArrayRef<ConformingType> boxingConformances,
+    DeclAndTypePrinter &declAndTypePrinter) {
+  ClangSyntaxPrinter printer(PD->getASTContext(), os);
+  ClangSyntaxPrinter ooPrinter(PD->getASTContext(), outOfLineOS);
+
+  for (auto &c : boxingConformances) {
+    // Inline declaration (forward-declared type is enough).
+    os << "  ";
+    printer.printInlineForThunk();
+    printer.printBaseName(PD);
+    os << "(const ";
+    printer.printBaseName(c.type);
+    os << " &value) noexcept;\n";
+
+    // Out-of-line definition (emitted after all types are declared).
+    outOfLineOS << "#if defined(SWIFT_CXX_EXISTENTIAL_INTEROP) && "
+                   "defined(__cpp_concepts) && __cpp_concepts >= 202002L\n";
+    outOfLineOS << "  ";
+    ooPrinter.printInlineForThunk();
+    ooPrinter.printBaseName(PD);
+    outOfLineOS << "::";
+    ooPrinter.printBaseName(PD);
+    outOfLineOS << "(const ";
+    ooPrinter.printBaseName(c.type);
+    outOfLineOS << " &value) noexcept\n";
+    auto baseClass =
+        isClassBound ? "SwiftClassExistentialType" : "SwiftExistentialType";
+    outOfLineOS << "    : " << baseClass
+       << "(typename " << baseClass << "::uninit_t{}) {\n";
+    if (isClassBound) {
+      outOfLineOS << "    _value = "
+         << "swift::_impl::_impl_RefCountedClass::getOpaquePointer(value);\n";
+      outOfLineOS << "    swift::_impl::swift_retain("
+         << "reinterpret_cast<void *_Nonnull>(_value));\n";
+    } else {
+      outOfLineOS << "    _type = swift::TypeMetadataTrait<";
+      ooPrinter.printBaseName(c.type);
+      outOfLineOS << ">::getTypeMetadata();\n";
+      outOfLineOS << "    _initializeWithValue(";
+      outOfLineOS << cxx_synthesis::getCxxImplNamespaceName() << "::";
+      ClangValueTypePrinter::printCxxImplClassName(outOfLineOS, c.type);
+      outOfLineOS << "::getOpaquePointer(value));\n";
+    }
+    outOfLineOS << "    _witnessTables[0] = reinterpret_cast<const void *>("
+       << cxx_synthesis::getCxxImplNamespaceName() << "::" << c.wtSymbol
+       << ");\n";
+    outOfLineOS << "  }\n";
+    outOfLineOS << "#endif // SWIFT_CXX_EXISTENTIAL_INTEROP && __cpp_concepts\n";
+  }
+}

--- a/lib/PrintAsClang/PrintClangExistentialType.cpp
+++ b/lib/PrintAsClang/PrintClangExistentialType.cpp
@@ -15,6 +15,7 @@
 #include "DeclAndTypePrinter.h"
 #include "PrimitiveTypeMapping.h"
 #include "PrintClangValueType.h"
+#include "swift/ABI/InvertibleProtocols.h"
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Module.h"
@@ -29,6 +30,14 @@
 #include "llvm/Support/SipHash.h"
 
 using namespace swift;
+
+static void printInverseTags(raw_ostream &os, const ProtocolDecl *PD) {
+  using CBR = TypeDecl::CanBeInvertible::Result;
+  if (PD->canConformTo(InvertibleProtocolKind::Copyable) == CBR::Never)
+    os << ", swift::_impl::NonCopyable";
+  if (PD->canConformTo(InvertibleProtocolKind::Escapable) == CBR::Never)
+    os << ", swift::_impl::NonEscapable";
+}
 
 std::optional<std::string>
 ClangExistentialTypePrinter::getCxxTypeName(Type ty,
@@ -368,7 +377,9 @@ void ClangExistentialTypePrinter::printMarkerProtocolDecl(
     os << " final : public swift::_impl::SwiftExistentialType<"
        << cxx_synthesis::getCxxImplNamespaceName() << "::";
     printer.printBaseName(PD);
-    os << "Tag>";
+    os << "Tag";
+    printInverseTags(os, PD);
+    os << ">";
     os << " {\npublic:\n";
 
     os << "private:\n";
@@ -498,7 +509,9 @@ void ClangExistentialTypePrinter::printExistentialTypeDecl(
                         : "SwiftExistentialType");
     os << "<" << cxx_synthesis::getCxxImplNamespaceName() << "::";
     printer.printBaseName(PD);
-    os << "Tag>";
+    os << "Tag";
+    printInverseTags(os, PD);
+    os << ">";
     os << " {\npublic:\n";
 
     // Emit protocol requirement methods.
@@ -748,6 +761,20 @@ void ClangExistentialTypePrinter::printCompositionTypeDecl(
     printer.printBaseName(PD);
     os << "Tag";
   });
+  // Emit inverse tags if any constituent protocol opts out.
+  {
+    using CBR = TypeDecl::CanBeInvertible::Result;
+    bool needsNonCopyable = llvm::any_of(wtProtocols, [](const ProtocolDecl *P) {
+      return P->canConformTo(InvertibleProtocolKind::Copyable) == CBR::Never;
+    });
+    bool needsNonEscapable = llvm::any_of(wtProtocols, [](const ProtocolDecl *P) {
+      return P->canConformTo(InvertibleProtocolKind::Escapable) == CBR::Never;
+    });
+    if (needsNonCopyable)
+      os << ", swift::_impl::NonCopyable";
+    if (needsNonEscapable)
+      os << ", swift::_impl::NonEscapable";
+  }
   os << "> {\n";
   os << "public:\n";
 

--- a/lib/PrintAsClang/PrintClangExistentialType.cpp
+++ b/lib/PrintAsClang/PrintClangExistentialType.cpp
@@ -702,3 +702,239 @@ void ClangExistentialTypePrinter::printBoxingConstructors(
     outOfLineOS << "#endif // SWIFT_CXX_EXISTENTIAL_INTEROP && __cpp_concepts\n";
   }
 }
+
+std::string ClangExistentialTypePrinter::getCompositionName(
+    ArrayRef<const ProtocolDecl *> protocols) {
+  SmallVector<StringRef, 4> names;
+  for (auto *PD : protocols)
+    names.push_back(PD->getName().str());
+  llvm::sort(names);
+
+  std::string result = "Any";
+  for (size_t i = 0; i < names.size(); ++i) {
+    if (i > 0)
+      result += "And";
+    result += names[i];
+  }
+  return result;
+}
+
+void ClangExistentialTypePrinter::printCompositionTypeDecl(
+    ArrayRef<const ProtocolDecl *> protocols, StringRef compositionName,
+    DeclAndTypePrinter &declAndTypePrinter) {
+  ClangSyntaxPrinter printer(protocols[0]->getASTContext(), os);
+
+  // Filter to non-marker protocols that contribute witness tables.
+  SmallVector<const ProtocolDecl *, 4> wtProtocols;
+  for (auto *PD : protocols) {
+    if (!PD->isMarkerProtocol() &&
+        Lowering::TypeConverter::protocolRequiresWitnessTable(PD))
+      wtProtocols.push_back(PD);
+  }
+
+  os << "#if defined(SWIFT_CXX_EXISTENTIAL_INTEROP) && "
+        "defined(__cpp_concepts) && __cpp_concepts >= 202002L\n";
+
+  // _impl class forward declaration.
+  os << "namespace " << cxx_synthesis::getCxxImplNamespaceName() << " {\n";
+  os << "class _impl_" << compositionName << ";\n";
+  os << "} // namespace " << cxx_synthesis::getCxxImplNamespaceName() << "\n";
+
+  // Wrapper class inheriting from SwiftExistentialType<Tags...>.
+  os << "class " << compositionName
+     << " final : public swift::_impl::SwiftExistentialType<";
+  llvm::interleaveComma(wtProtocols, os, [&](const ProtocolDecl *PD) {
+    os << cxx_synthesis::getCxxImplNamespaceName() << "::";
+    printer.printBaseName(PD);
+    os << "Tag";
+  });
+  os << "> {\n";
+  os << "public:\n";
+
+  // Emit methods from all constituent protocols, with the correct WT index.
+  llvm::SmallPtrSet<const FuncDecl *, 16> emittedMethods;
+  for (size_t wtIdx = 0; wtIdx < wtProtocols.size(); ++wtIdx) {
+    auto *PD = wtProtocols[wtIdx];
+    emitCompositionMethodsForProtocol(PD, wtIdx, emittedMethods,
+                                      declAndTypePrinter);
+  }
+
+  // Conversion methods to each individual protocol wrapper.
+  for (size_t wtIdx = 0; wtIdx < wtProtocols.size(); ++wtIdx) {
+    auto *PD = wtProtocols[wtIdx];
+    os << "  ";
+    printer.printBaseName(PD);
+    os << " as";
+    printer.printBaseName(PD);
+    os << "() const {\n";
+    os << "    return " << cxx_synthesis::getCxxImplNamespaceName()
+       << "::_impl_";
+    printer.printBaseName(PD);
+    os << "::_fromExistential(_type, _projectValue(), _witnessTables["
+       << wtIdx << "]);\n";
+    os << "  }\n";
+  }
+
+  os << "private:\n";
+  os << "  " << compositionName
+     << "() noexcept : SwiftExistentialType(typename "
+        "SwiftExistentialType::uninit_t{}) {}\n";
+  os << "  friend class " << cxx_synthesis::getCxxImplNamespaceName()
+     << "::_impl_" << compositionName << ";\n";
+  os << "};\n";
+
+  // _impl helper class.
+  os << "namespace " << cxx_synthesis::getCxxImplNamespaceName() << " {\n";
+  os << "class _impl_" << compositionName << " {\n";
+  os << "public:\n";
+
+  // _fromExistential factory.
+  os << "  static ";
+  printer.printInlineForThunk();
+  os << compositionName << " _fromExistential("
+        "void *_Nonnull typeMetadata, "
+        "void *_Nonnull projectedValue";
+  for (size_t i = 0; i < wtProtocols.size(); ++i)
+    os << ", const void *_Nonnull wt" << i;
+  os << ") {\n";
+  os << "    " << compositionName << " result;\n";
+  os << "    result._type = typeMetadata;\n";
+  os << "    result._initializeWithValue(projectedValue);\n";
+  for (size_t i = 0; i < wtProtocols.size(); ++i)
+    os << "    result._witnessTables[" << i << "] = wt" << i << ";\n";
+  os << "    return result;\n";
+  os << "  }\n";
+
+  // getOpaquePointer (const + non-const).
+  os << "  static ";
+  printer.printInlineForThunk();
+  os << "const char * _Nonnull getOpaquePointer(const " << compositionName
+     << " &object) { return reinterpret_cast<const char *>(&object); }\n";
+  os << "  static ";
+  printer.printInlineForThunk();
+  os << "char * _Nonnull getOpaquePointer(" << compositionName
+     << " &object) { return reinterpret_cast<char *>(&object); }\n";
+
+  // returnNewValue.
+  os << "  template <class T>\n";
+  os << "  static ";
+  printer.printInlineForHelperFunction();
+  os << compositionName << " returnNewValue(T callable) {\n";
+  os << "    " << compositionName << " result;\n";
+  os << "    callable(reinterpret_cast<char *>(&result));\n";
+  os << "    return result;\n";
+  os << "  }\n";
+
+  os << "};\n";
+  os << "} // namespace " << cxx_synthesis::getCxxImplNamespaceName() << "\n";
+
+  os << "#endif // SWIFT_CXX_EXISTENTIAL_INTEROP && __cpp_concepts\n";
+}
+
+void ClangExistentialTypePrinter::emitCompositionMethodsForProtocol(
+    const ProtocolDecl *PD, size_t wtIndex,
+    llvm::SmallPtrSetImpl<const FuncDecl *> &emittedMethods,
+    DeclAndTypePrinter &declAndTypePrinter) {
+  size_t currentOffset = 1;
+
+  auto requirements = PD->getRequirementSignature().getRequirements();
+  for (const auto &reqt : requirements) {
+    if (reqt.getKind() != RequirementKind::Conformance)
+      continue;
+    auto protocol = reqt.getProtocolDecl();
+    if (!Lowering::TypeConverter::protocolRequiresWitnessTable(protocol))
+      continue;
+    currentOffset++;
+  }
+
+  for (auto *assocType : PD->getAssociatedTypeMembers()) {
+    if (assocType->getOverriddenDecls().empty())
+      currentOffset++;
+  }
+
+  for (Decl *member : PD->getABIMembers()) {
+    if (!member->isAvailableDuringLowering())
+      continue;
+
+    if (auto *FD = dyn_cast<FuncDecl>(member)) {
+      if (isa<AccessorDecl>(FD))
+        continue;
+      if (!FD->requiresNewWitnessTableEntry())
+        continue;
+
+      size_t methodOffset = currentOffset;
+      currentOffset++;
+
+      if (!canEmitExistentialMethod(FD, declAndTypePrinter))
+        continue;
+      if (!emittedMethods.insert(FD).second)
+        continue;
+
+      uint16_t ptrAuthDisc =
+          llvm::getPointerAuthStableSipHash(SILDeclRef(FD).mangle());
+
+      emitCompositionMethod(FD, methodOffset, ptrAuthDisc, wtIndex,
+                            declAndTypePrinter);
+    } else if (auto *ASD = dyn_cast<AbstractStorageDecl>(member)) {
+      ASD->visitOpaqueAccessors([&](AccessorDecl *accessor) {
+        if (accessor->requiresNewWitnessTableEntry())
+          currentOffset++;
+      });
+    } else if (auto *CD = dyn_cast<ConstructorDecl>(member)) {
+      if (CD->requiresNewWitnessTableEntry())
+        currentOffset++;
+    }
+  }
+}
+
+void ClangExistentialTypePrinter::emitCompositionMethod(
+    const FuncDecl *FD, size_t methodOffset, uint16_t ptrAuthDisc,
+    size_t wtIndex, DeclAndTypePrinter &declAndTypePrinter) {
+  ClangSyntaxPrinter printer(FD->getASTContext(), os);
+
+  auto methodTy = FD->getMethodInterfaceType()->castTo<FunctionType>();
+  auto resultCxxName =
+      getCxxTypeName(methodTy->getResult(), declAndTypePrinter);
+
+  os << "  ";
+  printer.printInlineForThunk();
+  os << *resultCxxName << " ";
+  os << FD->getBaseIdentifier().str() << "(";
+
+  bool firstParam = true;
+  for (auto *param : *FD->getParameters()) {
+    if (!firstParam)
+      os << ", ";
+    firstParam = false;
+    auto paramCxxName =
+        getCxxTypeName(param->getInterfaceType(), declAndTypePrinter);
+    os << *paramCxxName << " " << param->getNameStr();
+  }
+
+  os << ") const {\n";
+
+  os << "    struct _w { _w() = delete; static SWIFT_CALL " << *resultCxxName
+     << " call(";
+  bool firstTyParam = true;
+  for (auto *param : *FD->getParameters()) {
+    if (!firstTyParam)
+      os << ", ";
+    firstTyParam = false;
+    auto paramCxxName =
+        getCxxTypeName(param->getInterfaceType(), declAndTypePrinter);
+    os << *paramCxxName;
+  }
+  if (!firstTyParam)
+    os << ", ";
+  os << "void *_Nonnull, const void *_Nonnull, "
+        "SWIFT_CONTEXT void *_Nonnull); };\n";
+
+  os << "    return _loadWitness<" << methodOffset << ", " << ptrAuthDisc
+     << ", decltype(&_w::call)>(_witnessTables[" << wtIndex << "])(";
+
+  for (auto *param : *FD->getParameters())
+    os << param->getNameStr() << ", ";
+
+  os << "_type, _witnessTables[" << wtIndex << "], _projectValue());\n";
+  os << "  }\n";
+}

--- a/lib/PrintAsClang/PrintClangExistentialType.h
+++ b/lib/PrintAsClang/PrintClangExistentialType.h
@@ -1,0 +1,117 @@
+//===--- PrintClangExistentialType.h - Print existential types ---*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_PRINTASCLANG_PRINTCLANGEXISTENTIALTYPE_H
+#define SWIFT_PRINTASCLANG_PRINTCLANGEXISTENTIALTYPE_H
+
+#include "swift/Basic/LLVM.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/raw_ostream.h"
+#include <optional>
+#include <string>
+
+namespace swift {
+
+class DeclAndTypePrinter;
+class FuncDecl;
+class NominalTypeDecl;
+class ProtocolDecl;
+class Type;
+
+/// Prints a C++ wrapper class for a Swift protocol existential type.
+/// Non-marker protocols inherit from SwiftExistentialType with a witness
+/// table pointer. Marker protocols inherit from swift::Any (zero WTs).
+class ClangExistentialTypePrinter {
+public:
+  ClangExistentialTypePrinter(raw_ostream &os, raw_ostream &outOfLineOS)
+      : os(os), outOfLineOS(outOfLineOS) {}
+
+  void printExistentialTypeDecl(const ProtocolDecl *PD,
+                                DeclAndTypePrinter &declAndTypePrinter);
+
+private:
+  void printMarkerProtocolDecl(const ProtocolDecl *PD,
+                               DeclAndTypePrinter &declAndTypePrinter);
+
+  /// Emits C++ methods for protocol requirements, including inherited
+  /// requirements from base protocols (flattened into the wrapper).
+  void printProtocolRequirementMethods(const ProtocolDecl *PD,
+                                       DeclAndTypePrinter &declAndTypePrinter);
+
+  /// A step in the chain of base witness table loads needed to reach
+  /// an inherited protocol's witness table from _witnessTable.
+  struct BaseWTStep {
+    size_t offset;
+  };
+
+  /// Recursively emits methods for PD and all its base protocols.
+  /// baseChain describes the sequence of WT loads from _witnessTable
+  /// needed to reach PD's witness table.
+  void emitMethodsForProtocol(
+      const ProtocolDecl *PD, ArrayRef<BaseWTStep> baseChain,
+      llvm::SmallPtrSetImpl<const FuncDecl *> &emittedMethods,
+      DeclAndTypePrinter &declAndTypePrinter);
+
+  /// Emits a single C++ method that dispatches through a witness table.
+  void emitExistentialMethod(const FuncDecl *FD, size_t methodOffset,
+                             uint16_t ptrAuthDisc,
+                             ArrayRef<BaseWTStep> baseChain,
+                             DeclAndTypePrinter &declAndTypePrinter);
+
+  /// Emits asBaseProtocol() conversion methods for each direct base
+  /// protocol conformance.
+  void printConversionMethods(const ProtocolDecl *PD,
+                              DeclAndTypePrinter &declAndTypePrinter);
+
+  /// Emits the _fromExistential factory in the _impl class body.
+  void printImplFromExistentialFactory(const ProtocolDecl *PD,
+                                       DeclAndTypePrinter &declAndTypePrinter);
+
+  /// Emits getOpaquePointer helpers in the _impl class body.
+  void printImplGetOpaquePointer(const ProtocolDecl *PD);
+
+  /// Emits returnNewValue helper in the _impl class body.
+  void printImplReturnNewValue(const ProtocolDecl *PD);
+
+  /// A concrete type in the same module that conforms to the protocol,
+  /// along with the mangled symbol for its witness table.
+  struct ConformingType {
+    NominalTypeDecl *type;
+    std::string wtSymbol;
+  };
+
+  /// Emits per-conformance boxing constructors that allow constructing
+  /// an existential wrapper from a concrete type that conforms to the protocol.
+  void printBoxingConstructors(const ProtocolDecl *PD,
+                               ArrayRef<ConformingType> boxingConformances,
+                               DeclAndTypePrinter &declAndTypePrinter);
+
+  /// Returns the C++ type name for a Swift type if it is a simple
+  /// C-representable primitive, or None otherwise.
+  std::optional<std::string> getCxxTypeName(Type ty,
+                                            DeclAndTypePrinter &printer);
+
+  /// Returns true if the given FuncDecl can be emitted as a C++ method
+  /// on an existential wrapper (non-throwing, non-mutating, non-static,
+  /// all params and return C-primitive).
+  bool canEmitExistentialMethod(const FuncDecl *FD,
+                                DeclAndTypePrinter &printer);
+
+  raw_ostream &os;
+  raw_ostream &outOfLineOS;
+  bool isClassBound = false;
+};
+
+} // end namespace swift
+
+#endif

--- a/lib/PrintAsClang/PrintClangExistentialType.h
+++ b/lib/PrintAsClang/PrintClangExistentialType.h
@@ -39,6 +39,18 @@ public:
   void printExistentialTypeDecl(const ProtocolDecl *PD,
                                 DeclAndTypePrinter &declAndTypePrinter);
 
+  /// Emits a C++ wrapper class for an ad-hoc protocol composition
+  /// (e.g., `any A & B`). The protocols must be in canonical WT order
+  /// (from ExistentialLayout::getProtocols). The wrapper inherits from
+  /// SwiftExistentialType<ATag, BTag, ...> with one WT slot per protocol.
+  void printCompositionTypeDecl(ArrayRef<const ProtocolDecl *> protocols,
+                                StringRef compositionName,
+                                DeclAndTypePrinter &declAndTypePrinter);
+
+  /// Generates a stable C++ name for a protocol composition.
+  /// Protocols are sorted alphabetically: `any A & B` -> `AnyAAndB`.
+  static std::string getCompositionName(ArrayRef<const ProtocolDecl *> protocols);
+
 private:
   void printMarkerProtocolDecl(const ProtocolDecl *PD,
                                DeclAndTypePrinter &declAndTypePrinter);
@@ -106,6 +118,19 @@ private:
   /// all params and return C-primitive).
   bool canEmitExistentialMethod(const FuncDecl *FD,
                                 DeclAndTypePrinter &printer);
+
+  /// Emits methods from a single protocol in a composition, dispatching
+  /// through the witness table at the given index.
+  void emitCompositionMethodsForProtocol(
+      const ProtocolDecl *PD, size_t wtIndex,
+      llvm::SmallPtrSetImpl<const FuncDecl *> &emittedMethods,
+      DeclAndTypePrinter &declAndTypePrinter);
+
+  /// Emits a single method in a composition wrapper, dispatching through
+  /// the witness table at wtIndex.
+  void emitCompositionMethod(const FuncDecl *FD, size_t methodOffset,
+                             uint16_t ptrAuthDisc, size_t wtIndex,
+                             DeclAndTypePrinter &declAndTypePrinter);
 
   raw_ostream &os;
   raw_ostream &outOfLineOS;

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -354,8 +354,8 @@ public:
         }
 
       // Ad-hoc protocol compositions (any A & B).
-      if (auto *compTy = ty->getConstraintType()
-                             ->getAs<ProtocolCompositionType>()) {
+      if (ty->getConstraintType()
+                             ->is<ProtocolCompositionType>()) {
         auto layout = ty->getExistentialLayout();
         auto protocols = layout.getProtocols();
         SmallVector<const ProtocolDecl *, 4> wtProtocols;
@@ -375,9 +375,18 @@ public:
             if (!isInOutParam)
               os << "const ";
             printOptional(optionalKind, [&]() {
-              ClangSyntaxPrinter(moduleContext->getASTContext(), os)
-                  .printBaseName(moduleContext);
-              os << "::" << compName;
+              os << "swift::_impl::SwiftExistentialType<";
+              llvm::interleaveComma(wtProtocols, os,
+                                    [&](const ProtocolDecl *PD) {
+                ClangSyntaxPrinter(moduleContext->getASTContext(), os)
+                    .printBaseName(moduleContext);
+                os << "::" << cxx_synthesis::getCxxImplNamespaceName()
+                   << "::";
+                ClangSyntaxPrinter(PD->getASTContext(), os)
+                    .printBaseName(PD);
+                os << "Tag";
+              });
+              os << '>';
             });
             os << '&';
           } else {
@@ -394,7 +403,9 @@ public:
               }
             });
           }
-          return ClangRepresentation::representable;
+          ClangRepresentation repr(ClangRepresentation::representable);
+          repr.setNeedsExistentialGuard();
+          return repr;
         }
       }
     }
@@ -1293,7 +1304,8 @@ void DeclAndTypeClangFunctionPrinter::printCxxToCFunctionParameterUse(
         return;
       }
 
-      // Ad-hoc composition param: use composition _impl::getOpaquePointer.
+      // Ad-hoc composition param: cast address directly (same as
+      // getOpaquePointer but avoids depending on the composition _impl).
       if (existTy->getConstraintType()->is<ProtocolCompositionType>()) {
         auto layout = existTy->getExistentialLayout();
         auto protocols = layout.getProtocols();
@@ -1303,12 +1315,7 @@ void DeclAndTypeClangFunctionPrinter::printCxxToCFunctionParameterUse(
             wtProtocols.push_back(proto);
         }
         if (wtProtocols.size() >= 2) {
-          auto compName =
-              ClangExistentialTypePrinter::getCompositionName(wtProtocols);
-          ClangSyntaxPrinter(moduleContext->getASTContext(), os)
-              .printBaseName(moduleContext);
-          os << "::" << cxx_synthesis::getCxxImplNamespaceName()
-             << "::_impl_" << compName << "::getOpaquePointer(";
+          os << "reinterpret_cast<const char *>(&";
           namePrinter();
           os << ')';
           return;

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -30,6 +30,7 @@
 #include "swift/AST/TypeVisitor.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/Feature.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/IRGen/IRABIDetailsProvider.h"
 #include "clang/AST/ASTContext.h"
@@ -301,6 +302,55 @@ public:
         printInoutTypeModifier();
       }
       return ClangRepresentation::objcxxonly;
+    }
+
+    // Non-ObjC existential with a single protocol constraint:
+    // emit the C++ existential wrapper class name.
+    if (languageMode == OutputLanguageMode::Cxx &&
+        moduleContext->getASTContext().LangOpts.hasFeature(
+            Feature::CxxExistentialInterop)) {
+      ProtocolDecl *PD = nullptr;
+      ArrayRef<Type> patArgs;
+      if (auto *protoTy = ty->getConstraintType()->getAs<ProtocolType>())
+        PD = protoTy->getDecl();
+      else if (auto *paramProtoTy =
+                   ty->getConstraintType()
+                       ->getAs<ParameterizedProtocolType>()) {
+        PD = paramProtoTy->getProtocol();
+        patArgs = paramProtoTy->getArgs();
+      }
+      if (PD && !PD->isObjC() && !PD->isMarkerProtocol() &&
+            declPrinter.shouldInclude(PD)) {
+          if (typeUseKind == FunctionSignatureTypeUse::ParamType) {
+            if (!isInOutParam)
+              os << "const ";
+            printOptional(optionalKind, [&]() {
+              ClangSyntaxPrinter(PD->getASTContext(), os)
+                  .printPrimaryCxxTypeName(PD, moduleContext);
+              visitGenericArgs(patArgs);
+            });
+            os << '&';
+          } else {
+            printOptional(optionalKind, [&]() {
+              if (modifiersDelegate.mapValueTypeUseKind) {
+                ClangSyntaxPrinter printer(PD->getASTContext(), os);
+                printer.printModuleNamespaceQualifiersIfNeeded(
+                    PD->getModuleContext(), moduleContext);
+                if (!printer.printNestedTypeNamespaceQualifiers(PD))
+                  os << "::";
+                os << cxx_synthesis::getCxxImplNamespaceName() << "::";
+                ClangValueTypePrinter::printCxxImplClassName(os, PD);
+              } else {
+                ClangSyntaxPrinter(PD->getASTContext(), os)
+                    .printPrimaryCxxTypeName(PD, moduleContext);
+                visitGenericArgs(patArgs);
+              }
+            });
+          }
+          ClangRepresentation repr(ClangRepresentation::representable);
+          repr.setNeedsExistentialGuard();
+          return repr;
+        }
     }
 
     return visitPart(ty->getConstraintType(), optionalKind, isInOutParam);
@@ -1116,6 +1166,10 @@ ClangRepresentation DeclAndTypeClangFunctionPrinter::printFunctionSignature(
     if (resultingRepresentation.isObjCxxOnly() &&
         outputLang == OutputLanguageMode::Cxx)
       os << "#if defined(__OBJC__)\n";
+    if (resultingRepresentation.needsExistentialGuard() &&
+        outputLang == OutputLanguageMode::Cxx)
+      os << "#if defined(SWIFT_CXX_EXISTENTIAL_INTEROP) && "
+            "defined(__cpp_concepts) && __cpp_concepts >= 202002L\n";
     os << functionSignatureOS.str();
   }
   return resultingRepresentation;
@@ -1157,6 +1211,43 @@ void DeclAndTypeClangFunctionPrinter::printCxxToCFunctionParameterUse(
       namePrinter();
       return;
     }
+
+    // Non-ObjC existential: pass pointer to the wrapper's storage.
+    // Class-bound existentials are loadable and may be passed directly
+    // (via a passStub struct), so wrap in swift_interop_passDirect when needed.
+    if (auto *existTy = type->getAs<ExistentialType>()) {
+      ProtocolDecl *PD = nullptr;
+      if (auto *protoTy =
+              existTy->getConstraintType()->getAs<ProtocolType>())
+        PD = protoTy->getDecl();
+      else if (auto *paramProtoTy =
+                   existTy->getConstraintType()
+                       ->getAs<ParameterizedProtocolType>())
+        PD = paramProtoTy->getProtocol();
+      if (PD) {
+        if (!directTypeEncoding.empty()) {
+          ClangSyntaxPrinter(moduleContext->getASTContext(), os)
+              .printBaseName(moduleContext);
+          os << "::" << cxx_synthesis::getCxxImplNamespaceName()
+             << "::swift_interop_passDirect_" << directTypeEncoding << '(';
+        }
+        ClangSyntaxPrinter(PD->getASTContext(), os)
+            .printModuleNamespaceQualifiersIfNeeded(PD->getModuleContext(),
+                                                    moduleContext);
+        if (!ClangSyntaxPrinter(PD->getASTContext(), os)
+                 .printNestedTypeNamespaceQualifiers(PD))
+          os << "::";
+        os << cxx_synthesis::getCxxImplNamespaceName() << "::";
+        ClangValueTypePrinter::printCxxImplClassName(os, PD);
+        os << "::getOpaquePointer(";
+        namePrinter();
+        os << ')';
+        if (!directTypeEncoding.empty())
+          os << ')';
+        return;
+      }
+    }
+
     if (auto *classDecl = type->getClassOrBoundGenericClass()) {
       if (classDecl->hasClangNode()) {
         if (isInOut)
@@ -1545,6 +1636,51 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
           os, classDecl, moduleContext,
           [&]() { printCallToCFunc(/*additionalParam=*/std::nullopt); });
       return;
+    }
+    // Non-ObjC existential return: construct wrapper via _impl::returnNewValue.
+    if (auto *existTy = resultTy->getAs<ExistentialType>()) {
+      if (!existTy->isObjCExistentialType()) {
+        if (existTy->getConstraintType()->is<ProtocolType>() ||
+            existTy->getConstraintType()
+                ->is<ParameterizedProtocolType>()) {
+          os << "  return ";
+          printTypeImplTypeSpecifier(resultTy, moduleContext);
+          os << "::returnNewValue";
+          if (auto *paramProtoTy =
+                  existTy->getConstraintType()
+                      ->getAs<ParameterizedProtocolType>()) {
+            os << '<';
+            llvm::interleaveComma(
+                paramProtoTy->getArgs(), os, [&](Type argTy) {
+                  CFunctionSignatureTypePrinter typePrinter(
+                      os, cPrologueOS, typeMapping, OutputLanguageMode::Cxx,
+                      interopContext,
+                      CFunctionSignatureTypePrinterModifierDelegate(),
+                      moduleContext, declPrinter,
+                      FunctionSignatureTypeUse::TypeReference);
+                  typePrinter.visit(argTy, std::nullopt, false);
+                });
+            os << '>';
+          }
+          os << "([&](char * _Nonnull result) "
+                "SWIFT_INLINE_THUNK_ATTRIBUTES {\n    ";
+          if (auto directResultType = signature.getDirectResultType()) {
+            std::string typeEncoding =
+                encodeTypeInfo(*directResultType, moduleContext, typeMapping);
+            ClangSyntaxPrinter(moduleContext->getASTContext(), os)
+                .printBaseName(moduleContext);
+            os << "::" << cxx_synthesis::getCxxImplNamespaceName()
+               << "::swift_interop_returnDirect_" << typeEncoding << '('
+               << "result" << ", ";
+            printCallToCFunc(std::nullopt);
+            os << ')';
+          } else {
+            printCallToCFunc(/*firstParam=*/StringRef("result"));
+          }
+          os << ";\n  });\n";
+          return;
+        }
+      }
     }
     if (auto *decl = resultTy->getNominalOrBoundGenericNominal();
         decl && !resultTy->isObjCExistentialType() &&

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -16,6 +16,7 @@
 #include "OutputLanguageMode.h"
 #include "PrimitiveTypeMapping.h"
 #include "PrintClangClassType.h"
+#include "PrintClangExistentialType.h"
 #include "PrintClangValueType.h"
 #include "SwiftToClangInteropContext.h"
 #include "swift/ABI/MetadataValues.h"
@@ -351,6 +352,51 @@ public:
           repr.setNeedsExistentialGuard();
           return repr;
         }
+
+      // Ad-hoc protocol compositions (any A & B).
+      if (auto *compTy = ty->getConstraintType()
+                             ->getAs<ProtocolCompositionType>()) {
+        auto layout = ty->getExistentialLayout();
+        auto protocols = layout.getProtocols();
+        SmallVector<const ProtocolDecl *, 4> wtProtocols;
+        bool allIncludable = true;
+        for (auto *proto : protocols) {
+          if (proto->isObjC() || proto->isMarkerProtocol())
+            continue;
+          if (!declPrinter.shouldInclude(proto)) {
+            allIncludable = false;
+            break;
+          }
+          wtProtocols.push_back(proto);
+        }
+        if (allIncludable && wtProtocols.size() >= 2) {
+          auto compName = declPrinter.ensureCompositionEmitted(wtProtocols);
+          if (typeUseKind == FunctionSignatureTypeUse::ParamType) {
+            if (!isInOutParam)
+              os << "const ";
+            printOptional(optionalKind, [&]() {
+              ClangSyntaxPrinter(moduleContext->getASTContext(), os)
+                  .printBaseName(moduleContext);
+              os << "::" << compName;
+            });
+            os << '&';
+          } else {
+            printOptional(optionalKind, [&]() {
+              if (modifiersDelegate.mapValueTypeUseKind) {
+                ClangSyntaxPrinter(moduleContext->getASTContext(), os)
+                    .printBaseName(moduleContext);
+                os << "::" << cxx_synthesis::getCxxImplNamespaceName()
+                   << "::_impl_" << compName;
+              } else {
+                ClangSyntaxPrinter(moduleContext->getASTContext(), os)
+                    .printBaseName(moduleContext);
+                os << "::" << compName;
+              }
+            });
+          }
+          return ClangRepresentation::representable;
+        }
+      }
     }
 
     return visitPart(ty->getConstraintType(), optionalKind, isInOutParam);
@@ -1246,6 +1292,28 @@ void DeclAndTypeClangFunctionPrinter::printCxxToCFunctionParameterUse(
           os << ')';
         return;
       }
+
+      // Ad-hoc composition param: use composition _impl::getOpaquePointer.
+      if (existTy->getConstraintType()->is<ProtocolCompositionType>()) {
+        auto layout = existTy->getExistentialLayout();
+        auto protocols = layout.getProtocols();
+        SmallVector<const ProtocolDecl *, 4> wtProtocols;
+        for (auto *proto : protocols) {
+          if (!proto->isObjC() && !proto->isMarkerProtocol())
+            wtProtocols.push_back(proto);
+        }
+        if (wtProtocols.size() >= 2) {
+          auto compName =
+              ClangExistentialTypePrinter::getCompositionName(wtProtocols);
+          ClangSyntaxPrinter(moduleContext->getASTContext(), os)
+              .printBaseName(moduleContext);
+          os << "::" << cxx_synthesis::getCxxImplNamespaceName()
+             << "::_impl_" << compName << "::getOpaquePointer(";
+          namePrinter();
+          os << ')';
+          return;
+        }
+      }
     }
 
     if (auto *classDecl = type->getClassOrBoundGenericClass()) {
@@ -1679,6 +1747,44 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
           }
           os << ";\n  });\n";
           return;
+        }
+        // Ad-hoc composition return: _impl_AnyAAndB::returnNewValue.
+        if (existTy->getConstraintType()
+                ->is<ProtocolCompositionType>()) {
+          auto layout = existTy->getExistentialLayout();
+          auto protocols = layout.getProtocols();
+          SmallVector<const ProtocolDecl *, 4> wtProtocols;
+          for (auto *proto : protocols) {
+            if (!proto->isObjC() && !proto->isMarkerProtocol())
+              wtProtocols.push_back(proto);
+          }
+          if (wtProtocols.size() >= 2) {
+            auto compName =
+                declPrinter.ensureCompositionEmitted(wtProtocols);
+            os << "  return ";
+            ClangSyntaxPrinter(moduleContext->getASTContext(), os)
+                .printBaseName(moduleContext);
+            os << "::" << cxx_synthesis::getCxxImplNamespaceName()
+               << "::_impl_" << compName << "::returnNewValue"
+               << "([&](char * _Nonnull result) "
+                  "SWIFT_INLINE_THUNK_ATTRIBUTES {\n    ";
+            if (auto directResultType =
+                    signature.getDirectResultType()) {
+              std::string typeEncoding = encodeTypeInfo(
+                  *directResultType, moduleContext, typeMapping);
+              ClangSyntaxPrinter(moduleContext->getASTContext(), os)
+                  .printBaseName(moduleContext);
+              os << "::" << cxx_synthesis::getCxxImplNamespaceName()
+                 << "::swift_interop_returnDirect_" << typeEncoding
+                 << '(' << "result" << ", ";
+              printCallToCFunc(std::nullopt);
+              os << ')';
+            } else {
+              printCallToCFunc(/*firstParam=*/StringRef("result"));
+            }
+            os << ";\n  });\n";
+            return;
+          }
         }
       }
     }

--- a/lib/PrintAsClang/PrintClangFunction.h
+++ b/lib/PrintAsClang/PrintClangFunction.h
@@ -63,11 +63,17 @@ struct ClangRepresentation {
       kind = unsupported;
     else if (kind == representable)
       kind = other.kind;
+    if (other.existentialGuard)
+      existentialGuard = true;
     return *this;
   }
 
+  bool needsExistentialGuard() const { return existentialGuard; }
+  void setNeedsExistentialGuard() { existentialGuard = true; }
+
 private:
   Kind kind;
+  bool existentialGuard = false;
 };
 
 /// Responsible for printing a Swift function decl or type in C or C++ mode, to

--- a/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
+++ b/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
@@ -228,6 +228,210 @@ void printPrimitiveGenericTypeTraits(raw_ostream &os, ASTContext &astContext,
   }
 }
 
+static void printSwiftExistentialTypeMethodDefs(raw_ostream &os) {
+  os << "#if defined(SWIFT_CXX_EXISTENTIAL_INTEROP) && "
+        "defined(__cpp_concepts) && __cpp_concepts >= 202002L\n";
+  os << "// Out-of-line SwiftExistentialType methods.\n";
+  os << "// Needs the complete VWT declared above.\n\n";
+
+  // Template prefix for all out-of-line definitions.
+  const char *tmplPrefix = "template <typename... Tags>\n"
+    "  requires ((ProtocolTag<Tags> || MarkerTag<Tags> || InverseTag<Tags>) "
+    "&& ...)\n";
+  const char *cls = "SwiftExistentialType<Tags...>";
+
+  // _getVWT
+  os << tmplPrefix;
+  os << "SWIFT_INLINE_PRIVATE_HELPER\n";
+  os << "const ValueWitnessTable *_Nonnull\n";
+  os << cls << "::_getVWT() const noexcept {\n";
+  os << "  auto *vwTableAddr = "
+        "reinterpret_cast<ValueWitnessTable **>(_type) - 1;\n";
+  os << "#ifdef __arm64e__\n";
+  os << "  return reinterpret_cast<ValueWitnessTable *>(\n";
+  os << "      ptrauth_auth_data(\n";
+  os << "          reinterpret_cast<void *>(*vwTableAddr),\n";
+  os << "          ptrauth_key_process_independent_data,\n";
+  os << "          ptrauth_blend_discriminator(vwTableAddr, "
+     << SpecialPointerAuthDiscriminators::ValueWitnessTable << ")));\n";
+  os << "#else\n";
+  os << "  return *vwTableAddr;\n";
+  os << "#endif\n";
+  os << "}\n\n";
+
+  // _initializeWithCopy
+  os << tmplPrefix;
+  os << "SWIFT_INLINE_PRIVATE_HELPER\n";
+  os << "void\n";
+  os << cls << "::_initializeWithCopy(\n";
+  os << "    const " << cls << " &src) noexcept {\n";
+  os << "  _type = src._type;\n";
+  os << "  _getVWT()->initializeBufferWithCopyOfBuffer(\n";
+  os << "      _buffer, const_cast<void **>(src._buffer), _type);\n";
+  os << "  if constexpr (ExistentialTagTraits<Tags...>::NumWitnessTables > 0)\n";
+  os << "    for (size_t i = 0; i < ExistentialTagTraits<Tags...>::NumWitnessTables; ++i)\n";
+  os << "      this->_witnessTables[i] = src._witnessTables[i];\n";
+  os << "}\n\n";
+
+  // _initializeWithValue
+  os << tmplPrefix;
+  os << "SWIFT_INLINE_PRIVATE_HELPER\n";
+  os << "void\n";
+  os << cls << "::_initializeWithValue(\n";
+  os << "    const void *_Nonnull src) noexcept {\n";
+  os << "  auto *vwt = _getVWT();\n";
+  os << "  if (!(vwt->flags & "
+     << TargetValueWitnessFlags<uint64_t>::IsNonInline << ")) {\n";
+  os << "    vwt->initializeWithCopy(\n";
+  os << "        reinterpret_cast<char *>(_buffer),\n";
+  os << "        const_cast<char *>(\n";
+  os << "            reinterpret_cast<const char *>(src)),\n";
+  os << "        _type);\n";
+  os << "  } else {\n";
+  os << "    auto box = swift_allocBox(_type);\n";
+  os << "    _buffer[0] = box.object;\n";
+  os << "    vwt->initializeWithCopy(\n";
+  os << "        reinterpret_cast<char *>(box.buffer),\n";
+  os << "        const_cast<char *>(\n";
+  os << "            reinterpret_cast<const char *>(src)),\n";
+  os << "        _type);\n";
+  os << "  }\n";
+  os << "}\n\n";
+
+  // _projectValue
+  os << tmplPrefix;
+  os << "SWIFT_INLINE_PRIVATE_HELPER\n";
+  os << "void *_Nonnull\n";
+  os << cls << "::_projectValue() const noexcept {\n";
+  os << "  auto *vwTable = _getVWT();\n";
+  os << "  if (!(vwTable->flags & "
+     << TargetValueWitnessFlags<uint64_t>::IsNonInline << "))\n";
+  os << "    return const_cast<void **>(_buffer);\n";
+  os << "  return swift_projectBox(_buffer[0]);\n";
+  os << "}\n\n";
+
+  // _destroyValue
+  os << tmplPrefix;
+  os << "SWIFT_INLINE_PRIVATE_HELPER\n";
+  os << "void\n";
+  os << cls << "::_destroyValue() noexcept {\n";
+  os << "  auto *vwt = _getVWT();\n";
+  os << "  if (!(vwt->flags & "
+     << TargetValueWitnessFlags<uint64_t>::IsNonInline << ")) {\n";
+  os << "    vwt->destroy(reinterpret_cast<char *>(_buffer), _type);\n";
+  os << "  } else {\n";
+  os << "    vwt->destroy(\n";
+  os << "        reinterpret_cast<char *>(swift_projectBox(_buffer[0])),\n";
+  os << "        _type);\n";
+  os << "    swift_release(_buffer[0]);\n";
+  os << "  }\n";
+  os << "}\n\n";
+
+  // Copy constructor
+  os << tmplPrefix;
+  os << "SWIFT_INLINE_THUNK\n";
+  os << cls << "::" << "SwiftExistentialType(\n";
+  os << "    const " << cls << " &other) noexcept\n";
+  os << "    requires(ExistentialTagTraits<Tags...>::IsCopyable)\n";
+  os << "    : _type(other._type) {\n";
+  os << "  _getVWT()->initializeBufferWithCopyOfBuffer(\n";
+  os << "      _buffer, const_cast<void **>(other._buffer), _type);\n";
+  os << "  if constexpr (ExistentialTagTraits<Tags...>::NumWitnessTables > 0)\n";
+  os << "    for (size_t i = 0; i < ExistentialTagTraits<Tags...>::NumWitnessTables; ++i)\n";
+  os << "      this->_witnessTables[i] = other._witnessTables[i];\n";
+  os << "}\n\n";
+
+  // Move constructor. Uses copy semantics; C++ move is non-consuming.
+  os << tmplPrefix;
+  os << "SWIFT_INLINE_THUNK\n";
+  os << cls << "::" << "SwiftExistentialType(\n";
+  os << "    " << cls << " &&other) noexcept\n";
+  os << "    : _type(other._type) {\n";
+  os << "  _getVWT()->initializeBufferWithCopyOfBuffer(\n";
+  os << "      _buffer, other._buffer, _type);\n";
+  os << "  if constexpr (ExistentialTagTraits<Tags...>::NumWitnessTables > 0)\n";
+  os << "    for (size_t i = 0; i < ExistentialTagTraits<Tags...>::NumWitnessTables; ++i)\n";
+  os << "      this->_witnessTables[i] = other._witnessTables[i];\n";
+  os << "}\n\n";
+
+  // Copy assignment
+  os << tmplPrefix;
+  os << "SWIFT_INLINE_THUNK\n";
+  os << cls << " &\n";
+  os << cls << "::operator=(\n";
+  os << "    const " << cls << " &other) noexcept\n";
+  os << "    requires(ExistentialTagTraits<Tags...>::IsCopyable) {\n";
+  os << "  if (this != &other) {\n";
+  os << "    _destroyValue();\n";
+  os << "    _type = other._type;\n";
+  os << "    _getVWT()->initializeBufferWithCopyOfBuffer(\n";
+  os << "        _buffer, const_cast<void **>(other._buffer), _type);\n";
+  os << "    if constexpr (ExistentialTagTraits<Tags...>::NumWitnessTables > 0)\n";
+  os << "      for (size_t i = 0; i < ExistentialTagTraits<Tags...>::NumWitnessTables; ++i)\n";
+  os << "        this->_witnessTables[i] = other._witnessTables[i];\n";
+  os << "  }\n";
+  os << "  return *this;\n";
+  os << "}\n\n";
+
+  // Move assignment (copy semantics)
+  os << tmplPrefix;
+  os << "SWIFT_INLINE_THUNK\n";
+  os << cls << " &\n";
+  os << cls << "::operator=(\n";
+  os << "    " << cls << " &&other) noexcept {\n";
+  os << "  if (this != &other) {\n";
+  os << "    _destroyValue();\n";
+  os << "    _type = other._type;\n";
+  os << "    _getVWT()->initializeBufferWithCopyOfBuffer(\n";
+  os << "        _buffer, other._buffer, _type);\n";
+  os << "    if constexpr (ExistentialTagTraits<Tags...>::NumWitnessTables > 0)\n";
+  os << "      for (size_t i = 0; i < ExistentialTagTraits<Tags...>::NumWitnessTables; ++i)\n";
+  os << "        this->_witnessTables[i] = other._witnessTables[i];\n";
+  os << "  }\n";
+  os << "  return *this;\n";
+  os << "}\n\n";
+
+  // Destructor
+  os << tmplPrefix;
+  os << "SWIFT_INLINE_THUNK\n";
+  os << cls << "::~SwiftExistentialType() noexcept {\n";
+  os << "  _destroyValue();\n";
+  os << "}\n\n";
+
+  // Implicit conversion to Any (SwiftExistentialType<>)
+  os << tmplPrefix;
+  os << "SWIFT_INLINE_THUNK\n";
+  os << cls << "::operator SwiftExistentialType<>() const noexcept\n";
+  os << "    requires(sizeof...(Tags) > 0 && ExistentialTagTraits<Tags...>::IsCopyable) {\n";
+  os << "  SwiftExistentialType<> result(\n";
+  os << "      typename SwiftExistentialType<>::uninit_t{});\n";
+  os << "  result._type = _type;\n";
+  os << "  _getVWT()->initializeBufferWithCopyOfBuffer(\n";
+  os << "      result._buffer, const_cast<void **>(_buffer), _type);\n";
+  os << "  return result;\n";
+  os << "}\n\n";
+
+  // SwiftClassExistentialType: implicit conversion to Any
+  const char *clsTmplPrefix = "template <typename... Tags>\n"
+    "  requires ((ProtocolTag<Tags> || MarkerTag<Tags> || InverseTag<Tags>) "
+    "&& ...)\n";
+  const char *clsCls = "SwiftClassExistentialType<Tags...>";
+  os << clsTmplPrefix;
+  os << "SWIFT_INLINE_THUNK\n";
+  os << clsCls << "::operator SwiftExistentialType<>() const noexcept {\n";
+  os << "  SwiftExistentialType<> result(\n";
+  os << "      typename SwiftExistentialType<>::uninit_t{});\n";
+  os << "  result._type = swift_getObjectType(\n";
+  os << "      reinterpret_cast<void *_Nonnull>(_value));\n";
+  os << "  result._buffer[0] = reinterpret_cast<void *_Nonnull>(_value);\n";
+  os << "  if (_value) swift_retain(\n";
+  os << "      reinterpret_cast<void *_Nonnull>(_value));\n";
+  os << "  return result;\n";
+  os << "}\n\n";
+
+  os << "#endif // SWIFT_CXX_EXISTENTIAL_INTEROP && __cpp_concepts\n\n";
+}
+
 void swift::printSwiftToClangCoreScaffold(SwiftToClangInteropContext &ctx,
                                           ASTContext &astContext,
                                           PrimitiveTypeMapping &typeMapping,
@@ -247,6 +451,9 @@ void swift::printSwiftToClangCoreScaffold(SwiftToClangInteropContext &ctx,
                                                 /*isCForwardDefinition=*/true);
               });
               os << "\n";
+              if (astContext.LangOpts.hasFeature(
+                      Feature::CxxExistentialInterop))
+                printSwiftExistentialTypeMethodDefs(os);
             });
         os << "\n";
         // C++ only supports inline variables from C++17.

--- a/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
+++ b/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
@@ -398,34 +398,69 @@ static void printSwiftExistentialTypeMethodDefs(raw_ostream &os) {
   os << "  _destroyValue();\n";
   os << "}\n\n";
 
-  // Implicit conversion to Any (SwiftExistentialType<>)
+  // Generic subset conversion (includes conversion to Any when
+  // TargetTags is empty): SwiftExistentialType<Tags...> ->
+  // SwiftExistentialType<TargetTags...> where TargetTags ⊆ Tags.
   os << tmplPrefix;
+  os << "template <typename... TargetTags>\n";
+  os << "  requires (sizeof...(TargetTags) < sizeof...(Tags) &&\n";
+  os << "            ExistentialTagTraits<Tags...>::IsCopyable &&\n";
+  os << "            ((ProtocolTag<TargetTags> || MarkerTag<TargetTags> || "
+        "InverseTag<TargetTags>) && ...) &&\n";
+  os << "            (ContainedIn<TargetTags, Tags...> && ...))\n";
   os << "SWIFT_INLINE_THUNK\n";
-  os << cls << "::operator SwiftExistentialType<>() const noexcept\n";
-  os << "    requires(sizeof...(Tags) > 0 && ExistentialTagTraits<Tags...>::IsCopyable) {\n";
-  os << "  SwiftExistentialType<> result(\n";
-  os << "      typename SwiftExistentialType<>::uninit_t{});\n";
+  os << cls << "::operator SwiftExistentialType<TargetTags...>()"
+        " const noexcept {\n";
+  os << "  SwiftExistentialType<TargetTags...> result(\n";
+  os << "      typename SwiftExistentialType<TargetTags...>::uninit_t{});\n";
   os << "  result._type = _type;\n";
   os << "  _getVWT()->initializeBufferWithCopyOfBuffer(\n";
   os << "      result._buffer, const_cast<void **>(_buffer), _type);\n";
+  os << "  if constexpr (SwiftExistentialType<TargetTags...>"
+        "::Traits::NumWitnessTables > 0) {\n";
+  os << "    size_t ti = 0;\n";
+  os << "    auto copyIfProtocol = [&]<typename T>() {\n";
+  os << "      if constexpr (ProtocolTag<T>)\n";
+  os << "        result._witnessTables[ti++] = "
+        "this->_witnessTables[_wtIndexOf<T, Tags...>()];\n";
+  os << "    };\n";
+  os << "    (copyIfProtocol.template operator()<TargetTags>(), ...);\n";
+  os << "  }\n";
   os << "  return result;\n";
   os << "}\n\n";
 
-  // SwiftClassExistentialType: implicit conversion to Any
+  // SwiftClassExistentialType: generic subset conversion to opaque
+  // layout (includes conversion to Any when TargetTags is empty).
   const char *clsTmplPrefix = "template <typename... Tags>\n"
     "  requires ((ProtocolTag<Tags> || MarkerTag<Tags> || InverseTag<Tags>) "
     "&& ...)\n";
   const char *clsCls = "SwiftClassExistentialType<Tags...>";
   os << clsTmplPrefix;
+  os << "template <typename... TargetTags>\n";
+  os << "  requires (sizeof...(TargetTags) < sizeof...(Tags) &&\n";
+  os << "            ((ProtocolTag<TargetTags> || MarkerTag<TargetTags> || "
+        "InverseTag<TargetTags>) && ...) &&\n";
+  os << "            (ContainedIn<TargetTags, Tags...> && ...))\n";
   os << "SWIFT_INLINE_THUNK\n";
-  os << clsCls << "::operator SwiftExistentialType<>() const noexcept {\n";
-  os << "  SwiftExistentialType<> result(\n";
-  os << "      typename SwiftExistentialType<>::uninit_t{});\n";
+  os << clsCls << "::operator SwiftExistentialType<TargetTags...>()"
+        " const noexcept {\n";
+  os << "  SwiftExistentialType<TargetTags...> result(\n";
+  os << "      typename SwiftExistentialType<TargetTags...>::uninit_t{});\n";
   os << "  result._type = swift_getObjectType(\n";
   os << "      reinterpret_cast<void *_Nonnull>(_value));\n";
   os << "  result._buffer[0] = reinterpret_cast<void *_Nonnull>(_value);\n";
   os << "  if (_value) swift_retain(\n";
   os << "      reinterpret_cast<void *_Nonnull>(_value));\n";
+  os << "  if constexpr (SwiftExistentialType<TargetTags...>"
+        "::Traits::NumWitnessTables > 0) {\n";
+  os << "    size_t ti = 0;\n";
+  os << "    auto copyIfProtocol = [&]<typename T>() {\n";
+  os << "      if constexpr (ProtocolTag<T>)\n";
+  os << "        result._witnessTables[ti++] = "
+        "this->_witnessTables[_wtIndexOf<T, Tags...>()];\n";
+  os << "    };\n";
+  os << "    (copyIfProtocol.template operator()<TargetTags>(), ...);\n";
+  os << "  }\n";
   os << "  return result;\n";
   os << "}\n\n";
 

--- a/lib/PrintAsClang/_SwiftCxxInteroperability.h
+++ b/lib/PrintAsClang/_SwiftCxxInteroperability.h
@@ -21,6 +21,9 @@
 
 #include <cstdint>
 #include <stdlib.h>
+#if __cplusplus >= 202002L
+#include <type_traits>
+#endif
 #if defined(_WIN32)
 #include <malloc.h>
 #endif
@@ -92,6 +95,9 @@ namespace _impl {
 extern "C" void *_Nonnull swift_retain(void *_Nonnull) noexcept;
 
 extern "C" void swift_release(void *_Nonnull) noexcept;
+
+extern "C" SWIFT_CALL void *_Nonnull swift_getObjectType(
+    void *_Nonnull object) noexcept;
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wreserved-identifier"
@@ -237,7 +243,243 @@ public:
   }
 };
 
+#if defined(SWIFT_CXX_EXISTENTIAL_INTEROP) && defined(__cpp_concepts) && __cpp_concepts >= 202002L
+
+// Forward-declared; defined after VWT in the generated scaffolding.
+struct ValueWitnessTable;
+
+struct BoxPair {
+  void *_Nonnull object;
+  void *_Nonnull buffer;
+};
+extern "C" BoxPair swift_allocBox(void *_Nonnull type) noexcept;
+extern "C" void *_Nonnull swift_projectBox(void *_Nonnull object) noexcept;
+
+// --- Tag concepts for existential type parameters ---
+
+/// A protocol tag has a WitnessTable typedef (generated per-protocol).
+template <typename T>
+concept ProtocolTag = requires { typename T::WitnessTable; };
+
+/// A marker protocol tag has IsMarker but no WitnessTable.
+template <typename T>
+concept MarkerTag = requires { T::IsMarker; } && !ProtocolTag<T>;
+
+/// Inverse tags for ~Copyable and ~Escapable.
+struct NonCopyable {};
+struct NonEscapable {};
+template <typename T>
+concept InverseTag = std::is_same_v<T, NonCopyable> ||
+                     std::is_same_v<T, NonEscapable>;
+
+template <typename T, typename... Pack>
+concept ContainedIn = (std::is_same_v<T, Pack> || ...);
+
+// --- Shared tag traits ---
+
+template <typename... Tags>
+struct ExistentialTagTraits {
+  static constexpr size_t NumWitnessTables =
+      (0 + ... + (ProtocolTag<Tags> ? 1 : 0));
+  static constexpr bool IsCopyable =
+      !(... || std::is_same_v<Tags, NonCopyable>);
+};
+
+// --- Opaque existential container ---
+
+/// C++ wrapper for a Swift opaque existential container.
+/// Layout: [value buffer: 3 words][type metadata][witness tables...]
+template <typename... Tags>
+  requires ((ProtocolTag<Tags> || MarkerTag<Tags> || InverseTag<Tags>) && ...)
+class SwiftExistentialType {
+  using Traits = ExistentialTagTraits<Tags...>;
+
+  template <typename... U>
+    requires ((ProtocolTag<U> || MarkerTag<U> || InverseTag<U>) && ...)
+  friend class SwiftExistentialType;
+  template <typename... U>
+    requires ((ProtocolTag<U> || MarkerTag<U> || InverseTag<U>) && ...)
+  friend class SwiftClassExistentialType;
+
+  // Defined out-of-line; needs complete VWT and arm64e ptrauth.
+  SWIFT_INLINE_PRIVATE_HELPER const ValueWitnessTable *_Nonnull
+  _getVWT() const noexcept;
+
+  // Defined out-of-line; needs complete VWT.
+  SWIFT_INLINE_PRIVATE_HELPER void _destroyValue() noexcept;
+
+public:
+  // Defined out-of-line; needs complete VWT.
+  SWIFT_INLINE_THUNK SwiftExistentialType(
+      const SwiftExistentialType &other) noexcept
+      requires(Traits::IsCopyable);
+  SWIFT_INLINE_THUNK SwiftExistentialType(
+      SwiftExistentialType &&other) noexcept;
+  SWIFT_INLINE_THUNK SwiftExistentialType &
+  operator=(const SwiftExistentialType &other) noexcept
+      requires(Traits::IsCopyable);
+  SWIFT_INLINE_THUNK SwiftExistentialType &
+  operator=(SwiftExistentialType &&other) noexcept;
+  SWIFT_INLINE_THUNK ~SwiftExistentialType() noexcept;
+
+  /// Implicit conversion to Any (drops witness tables).
+  SWIFT_INLINE_THUNK operator SwiftExistentialType<>() const noexcept
+      requires(sizeof...(Tags) > 0 && Traits::IsCopyable);
+
+protected:
+  struct uninit_t {};
+  SWIFT_INLINE_THUNK SwiftExistentialType(uninit_t) noexcept {}
+
+  // Defined out-of-line; needs complete VWT.
+  SWIFT_INLINE_PRIVATE_HELPER void
+  _initializeWithCopy(const SwiftExistentialType &src) noexcept;
+
+  // Defined out-of-line; needs complete VWT. _type must be set first.
+  SWIFT_INLINE_PRIVATE_HELPER void
+  _initializeWithValue(const void *_Nonnull src) noexcept;
+
+  // Defined out-of-line; needs complete VWT.
+  SWIFT_INLINE_PRIVATE_HELPER void *_Nonnull
+  _projectValue() const noexcept;
+
+  template <size_t EntryOffset, uint16_t PtrAuthDisc, typename FnTy>
+  SWIFT_INLINE_PRIVATE_HELPER FnTy _loadWitness(
+      const void *_Nonnull wt) const {
+    struct slot {
+      FnTy __ptrauth_swift_protocol_witness_function_pointer(PtrAuthDisc) fn;
+    };
+    auto *s = reinterpret_cast<const slot *>(
+        reinterpret_cast<const void *const *>(wt) + EntryOffset);
+    return s->fn;
+  }
+
+  void *_Nonnull _buffer[3];
+  void *_Nonnull _type;
+  const void *_Nonnull
+      _witnessTables[Traits::NumWitnessTables > 0 ? Traits::NumWitnessTables
+                                                  : 1];
+};
+
+// --- Class-bound existential container ---
+
+/// C++ wrapper for a Swift class-bound existential container.
+/// Layout: [class pointer][witness tables...]
+template <typename... Tags>
+  requires ((ProtocolTag<Tags> || MarkerTag<Tags> || InverseTag<Tags>) && ...)
+class SwiftClassExistentialType {
+  using Traits = ExistentialTagTraits<Tags...>;
+
+  template <typename... U>
+    requires ((ProtocolTag<U> || MarkerTag<U> || InverseTag<U>) && ...)
+  friend class SwiftExistentialType;
+  template <typename... U>
+    requires ((ProtocolTag<U> || MarkerTag<U> || InverseTag<U>) && ...)
+  friend class SwiftClassExistentialType;
+
+public:
+  SWIFT_INLINE_THUNK SwiftClassExistentialType(
+      const SwiftClassExistentialType &other) noexcept
+      : _value(other._value) {
+    if (_value) swift_retain(reinterpret_cast<void *_Nonnull>(_value));
+    if constexpr (Traits::NumWitnessTables > 0) {
+      for (size_t i = 0; i < Traits::NumWitnessTables; ++i)
+        this->_witnessTables[i] = other._witnessTables[i];
+    }
+  }
+  SWIFT_INLINE_THUNK SwiftClassExistentialType(
+      SwiftClassExistentialType &&other) noexcept
+      : _value(other._value) {
+    other._value = nullptr;
+    if constexpr (Traits::NumWitnessTables > 0) {
+      for (size_t i = 0; i < Traits::NumWitnessTables; ++i)
+        this->_witnessTables[i] = other._witnessTables[i];
+    }
+  }
+  SWIFT_INLINE_THUNK SwiftClassExistentialType &
+  operator=(const SwiftClassExistentialType &other) noexcept {
+    if (this != &other) {
+      auto *old = _value;
+      _value = other._value;
+      if (_value) swift_retain(reinterpret_cast<void *_Nonnull>(_value));
+      if (old) swift_release(reinterpret_cast<void *_Nonnull>(old));
+      if constexpr (Traits::NumWitnessTables > 0) {
+        for (size_t i = 0; i < Traits::NumWitnessTables; ++i)
+          this->_witnessTables[i] = other._witnessTables[i];
+      }
+    }
+    return *this;
+  }
+  SWIFT_INLINE_THUNK SwiftClassExistentialType &
+  operator=(SwiftClassExistentialType &&other) noexcept {
+    if (this != &other) {
+      if (_value) swift_release(reinterpret_cast<void *_Nonnull>(_value));
+      _value = other._value;
+      other._value = nullptr;
+      if constexpr (Traits::NumWitnessTables > 0) {
+        for (size_t i = 0; i < Traits::NumWitnessTables; ++i)
+          this->_witnessTables[i] = other._witnessTables[i];
+      }
+    }
+    return *this;
+  }
+  SWIFT_INLINE_THUNK ~SwiftClassExistentialType() noexcept {
+    if (_value) swift_release(reinterpret_cast<void *_Nonnull>(_value));
+  }
+
+  /// Implicit conversion to Any (repacks from class-bound to opaque layout).
+  SWIFT_INLINE_THUNK operator SwiftExistentialType<>() const noexcept;
+
+protected:
+  struct uninit_t {};
+  SWIFT_INLINE_THUNK SwiftClassExistentialType(uninit_t) noexcept
+      : _value(nullptr) {}
+
+  SWIFT_INLINE_PRIVATE_HELPER void
+  _initializeWithCopy(const SwiftClassExistentialType &src) noexcept {
+    _value = src._value;
+    if (_value) swift_retain(reinterpret_cast<void *_Nonnull>(_value));
+    if constexpr (Traits::NumWitnessTables > 0) {
+      for (size_t i = 0; i < Traits::NumWitnessTables; ++i)
+        this->_witnessTables[i] = src._witnessTables[i];
+    }
+  }
+
+  SWIFT_INLINE_PRIVATE_HELPER void *_Nonnull
+  _projectValue() const noexcept {
+    return reinterpret_cast<void *_Nonnull>(_value);
+  }
+
+  SWIFT_INLINE_PRIVATE_HELPER void *_Nonnull
+  _getType() const noexcept {
+    return swift_getObjectType(
+        reinterpret_cast<void *_Nonnull>(_value));
+  }
+
+  template <size_t EntryOffset, uint16_t PtrAuthDisc, typename FnTy>
+  SWIFT_INLINE_PRIVATE_HELPER FnTy _loadWitness(
+      const void *_Nonnull wt) const {
+    struct slot {
+      FnTy __ptrauth_swift_protocol_witness_function_pointer(PtrAuthDisc) fn;
+    };
+    auto *s = reinterpret_cast<const slot *>(
+        reinterpret_cast<const void *const *>(wt) + EntryOffset);
+    return s->fn;
+  }
+
+  void *_Nullable _value;
+  const void *_Nonnull
+      _witnessTables[Traits::NumWitnessTables > 0 ? Traits::NumWitnessTables
+                                                  : 1];
+};
+
+#endif // SWIFT_CXX_EXISTENTIAL_INTEROP && __cpp_concepts
+
 } // namespace _impl
+
+#if defined(SWIFT_CXX_EXISTENTIAL_INTEROP) && defined(__cpp_concepts) && __cpp_concepts >= 202002L
+/// Swift.Any -- the unconstrained existential type.
+using Any = _impl::SwiftExistentialType<>;
+#endif // SWIFT_CXX_EXISTENTIAL_INTEROP && __cpp_concepts
 
 /// Swift's Int type.
 using Int = ptrdiff_t;

--- a/lib/PrintAsClang/_SwiftCxxInteroperability.h
+++ b/lib/PrintAsClang/_SwiftCxxInteroperability.h
@@ -285,6 +285,21 @@ struct ExistentialTagTraits {
       !(... || std::is_same_v<Tags, NonCopyable>);
 };
 
+/// Returns the witness-table slot index of tag T within Tags...,
+/// counting only ProtocolTag entries (markers and inverses occupy no slot).
+template <typename T, typename... Tags>
+constexpr size_t _wtIndexOf() {
+  size_t idx = 0;
+  bool found = false;
+  auto step = [&]<typename U>() {
+    if (found) return;
+    if constexpr (std::is_same_v<T, U>) { found = true; }
+    else if constexpr (ProtocolTag<U>) { ++idx; }
+  };
+  (step.template operator()<Tags>(), ...);
+  return idx;
+}
+
 // --- Opaque existential container ---
 
 /// C++ wrapper for a Swift opaque existential container.
@@ -322,9 +337,16 @@ public:
   operator=(SwiftExistentialType &&other) noexcept;
   SWIFT_INLINE_THUNK ~SwiftExistentialType() noexcept;
 
-  /// Implicit conversion to Any (drops witness tables).
-  SWIFT_INLINE_THUNK operator SwiftExistentialType<>() const noexcept
-      requires(sizeof...(Tags) > 0 && Traits::IsCopyable);
+  /// Implicit narrowing to any subset of protocol tags (including
+  /// empty = conversion to Any).
+  template <typename... TargetTags>
+    requires (sizeof...(TargetTags) < sizeof...(Tags) &&
+              Traits::IsCopyable &&
+              ((ProtocolTag<TargetTags> || MarkerTag<TargetTags> ||
+                InverseTag<TargetTags>) && ...) &&
+              (ContainedIn<TargetTags, Tags...> && ...))
+  SWIFT_INLINE_THUNK operator SwiftExistentialType<TargetTags...>()
+      const noexcept;
 
 protected:
   struct uninit_t {};
@@ -426,8 +448,15 @@ public:
     if (_value) swift_release(reinterpret_cast<void *_Nonnull>(_value));
   }
 
-  /// Implicit conversion to Any (repacks from class-bound to opaque layout).
-  SWIFT_INLINE_THUNK operator SwiftExistentialType<>() const noexcept;
+  /// Implicit narrowing to any subset of protocol tags (opaque layout),
+  /// including empty = conversion to Any.
+  template <typename... TargetTags>
+    requires (sizeof...(TargetTags) < sizeof...(Tags) &&
+              ((ProtocolTag<TargetTags> || MarkerTag<TargetTags> ||
+                InverseTag<TargetTags>) && ...) &&
+              (ContainedIn<TargetTags, Tags...> && ...))
+  SWIFT_INLINE_THUNK operator SwiftExistentialType<TargetTags...>()
+      const noexcept;
 
 protected:
   struct uninit_t {};

--- a/test/Interop/SwiftToCxx/core/Inputs/stdlib-conformances.swift
+++ b/test/Interop/SwiftToCxx/core/Inputs/stdlib-conformances.swift
@@ -1,0 +1,16 @@
+public struct Point: Equatable, Hashable {
+    public var x: Int
+    public var y: Int
+    public init(x: Int, y: Int) { self.x = x; self.y = y }
+}
+
+public struct Temperature: Comparable {
+    public var degrees: Int
+    public init(degrees: Int) { self.degrees = degrees }
+    public static func < (lhs: Temperature, rhs: Temperature) -> Bool {
+        return lhs.degrees < rhs.degrees
+    }
+    public static func == (lhs: Temperature, rhs: Temperature) -> Bool {
+        return lhs.degrees == rhs.degrees
+    }
+}

--- a/test/Interop/SwiftToCxx/core/stdlib-conformance-dispatch.swift
+++ b/test/Interop/SwiftToCxx/core/stdlib-conformance-dispatch.swift
@@ -1,0 +1,166 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend %t/ConformLib.swift -module-name ConformLib -clang-header-expose-decls=all-public -emit-module -emit-module-path %t/ConformLib.swiftmodule -emit-clang-header-path %t/ConformLib.h -cxx-interoperability-mode=upcoming-swift -parse-as-library -enable-experimental-feature CxxExistentialInterop
+
+// RUN: %target-interop-build-clangxx -std=gnu++20 -c %t/test.cpp -I %t -o %t/test.o
+// RUN: %target-interop-build-swift %t/ConformLib.swift -o %t/ConformLib.o -c -module-name ConformLib -cxx-interoperability-mode=default -parse-as-library
+// RUN: %target-interop-build-clangxx %t/test.o %t/ConformLib.o -o %t/test
+// RUN: %target-codesign %t/test
+// RUN: %target-run %t/test
+
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_CxxExistentialInterop
+
+//--- ConformLib.swift
+
+public struct Point: Equatable, Hashable {
+    public var x: Int
+    public var y: Int
+    public init(x: Int, y: Int) { self.x = x; self.y = y }
+}
+
+public struct Temperature: Comparable {
+    public var degrees: Int
+    public init(degrees: Int) { self.degrees = degrees }
+    public static func < (lhs: Temperature, rhs: Temperature) -> Bool {
+        return lhs.degrees < rhs.degrees
+    }
+    public static func == (lhs: Temperature, rhs: Temperature) -> Bool {
+        return lhs.degrees == rhs.degrees
+    }
+}
+
+//--- test.cpp
+
+#include "ConformLib.h"
+#include <algorithm>
+#include <cassert>
+#include <set>
+#include <vector>
+
+int main() {
+  using namespace ConformLib;
+
+  // --- Direct operator dispatch ---
+
+  auto p1 = Point::init(1, 2);
+  auto p2 = Point::init(1, 2);
+  auto p3 = Point::init(3, 4);
+
+  assert(p1 == p2);
+  assert(!(p1 == p3));
+  assert(p1 != p3);
+  assert(!(p1 != p2));
+
+  auto t1 = Temperature::init(20);
+  auto t2 = Temperature::init(30);
+  auto t3 = Temperature::init(20);
+
+  assert(t1 < t2);
+  assert(!(t2 < t1));
+  assert(t1 <= t2);
+  assert(t1 <= t3);
+  assert(t2 > t1);
+  assert(!(t1 > t2));
+  assert(t2 >= t1);
+  assert(t1 >= t3);
+
+  assert(t1 == t3);
+  assert(!(t1 == t2));
+  assert(t1 != t2);
+
+  // --- STL algorithms over Equatable types ---
+
+  std::vector<Point> points = {
+    Point::init(3, 4),
+    Point::init(1, 2),
+    Point::init(3, 4),
+    Point::init(5, 6),
+    Point::init(1, 2),
+  };
+
+  // std::find dispatches through operator==.
+  auto it = std::find(points.begin(), points.end(), Point::init(5, 6));
+  assert(it != points.end());
+  assert(*it == Point::init(5, 6));
+
+  auto missing = std::find(points.begin(), points.end(), Point::init(9, 9));
+  assert(missing == points.end());
+
+  // std::count dispatches through operator==.
+  assert(std::count(points.begin(), points.end(), Point::init(3, 4)) == 2);
+  assert(std::count(points.begin(), points.end(), Point::init(1, 2)) == 2);
+  assert(std::count(points.begin(), points.end(), Point::init(5, 6)) == 1);
+
+  // --- STL algorithms over Comparable types ---
+
+  std::vector<Temperature> temps = {
+    Temperature::init(30),
+    Temperature::init(10),
+    Temperature::init(20),
+    Temperature::init(10),
+    Temperature::init(40),
+  };
+
+  // std::sort dispatches through operator<.
+  std::sort(temps.begin(), temps.end());
+  assert(temps[0] == Temperature::init(10));
+  assert(temps[1] == Temperature::init(10));
+  assert(temps[2] == Temperature::init(20));
+  assert(temps[3] == Temperature::init(30));
+  assert(temps[4] == Temperature::init(40));
+
+  // std::unique dispatches through operator==.
+  auto last = std::unique(temps.begin(), temps.end());
+  temps.erase(last, temps.end());
+  assert(temps.size() == 4);
+  assert(temps[0] == Temperature::init(10));
+  assert(temps[1] == Temperature::init(20));
+  assert(temps[2] == Temperature::init(30));
+  assert(temps[3] == Temperature::init(40));
+
+  // std::min / std::max dispatch through operator<.
+  auto lo = std::min(Temperature::init(15), Temperature::init(25));
+  auto hi = std::max(Temperature::init(15), Temperature::init(25));
+  assert(lo == Temperature::init(15));
+  assert(hi == Temperature::init(25));
+
+  // std::min_element / std::max_element.
+  auto minIt = std::min_element(temps.begin(), temps.end());
+  auto maxIt = std::max_element(temps.begin(), temps.end());
+  assert(*minIt == Temperature::init(10));
+  assert(*maxIt == Temperature::init(40));
+
+  // std::lower_bound (binary search) dispatches through operator<.
+  auto lb = std::lower_bound(temps.begin(), temps.end(), Temperature::init(20));
+  assert(lb != temps.end());
+  assert(*lb == Temperature::init(20));
+
+  auto ub = std::upper_bound(temps.begin(), temps.end(), Temperature::init(20));
+  assert(ub != temps.end());
+  assert(*ub == Temperature::init(30));
+
+  // std::binary_search.
+  assert(std::binary_search(temps.begin(), temps.end(), Temperature::init(30)));
+  assert(!std::binary_search(temps.begin(), temps.end(), Temperature::init(35)));
+
+  // --- STL ordered containers ---
+
+  // std::set uses operator< for ordering.
+  std::set<Temperature> tempSet;
+  tempSet.insert(Temperature::init(30));
+  tempSet.insert(Temperature::init(10));
+  tempSet.insert(Temperature::init(20));
+  tempSet.insert(Temperature::init(10)); // duplicate
+  assert(tempSet.size() == 3);
+  assert(tempSet.count(Temperature::init(10)) == 1);
+  assert(tempSet.count(Temperature::init(99)) == 0);
+
+  auto setIt = tempSet.begin();
+  assert(*setIt == Temperature::init(10)); ++setIt;
+  assert(*setIt == Temperature::init(20)); ++setIt;
+  assert(*setIt == Temperature::init(30));
+
+  return 0;
+}

--- a/test/Interop/SwiftToCxx/core/stdlib-conformance-records.swift
+++ b/test/Interop/SwiftToCxx/core/stdlib-conformance-records.swift
@@ -1,0 +1,46 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %S/Inputs/stdlib-conformances.swift -module-name StdlibConf -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/stdlib-conf.h -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature CxxExistentialInterop
+
+// RUN: %FileCheck %s < %t/stdlib-conf.h
+
+// REQUIRES: swift_feature_CxxExistentialInterop
+
+
+// Verify that conformance records for stdlib protocols (Equatable,
+// Hashable, Comparable) are emitted in the generated C++ header for
+// same-module conformances.
+
+// --- Conformance descriptor extern declarations ---
+
+// CHECK-LABEL: // Conformance records for stdlib protocols.
+// CHECK-NEXT: namespace _impl {
+// CHECK-DAG: SWIFT_EXTERN const char $s10StdlibConf5PointVSQAAMc[];
+// CHECK-DAG: SWIFT_EXTERN const char $s10StdlibConf5PointVSHAAMc[];
+// CHECK-DAG: SWIFT_EXTERN const char $s10StdlibConf11TemperatureVSLAAMc[];
+// CHECK-DAG: SWIFT_EXTERN const char $s10StdlibConf11TemperatureVSQAAMc[];
+// CHECK: } // namespace _impl
+
+// --- ADL using declarations for free operators ---
+
+// CHECK: #ifdef __cpp_concepts
+// CHECK-DAG: using ::operator==;
+// CHECK-DAG: using ::operator!=;
+// CHECK-DAG: using ::operator<;
+// CHECK-DAG: using ::operator<=;
+// CHECK-DAG: using ::operator>;
+// CHECK-DAG: using ::operator>=;
+// CHECK: #endif
+
+// --- Conformance record specializations ---
+
+// CHECK: #pragma clang diagnostic push
+// CHECK-NEXT: #pragma clang diagnostic ignored "-Wc++17-extensions"
+
+// CHECK-DAG: struct swift::EquatableConformance<StdlibConf::Point>
+// CHECK-DAG: static inline const void* getWitnessTable()
+// CHECK-DAG: swift_getWitnessTable
+// CHECK-DAG: struct swift::HashableConformance<StdlibConf::Point>
+// CHECK-DAG: struct swift::EquatableConformance<StdlibConf::Temperature>
+// CHECK-DAG: struct swift::ComparableConformance<StdlibConf::Temperature>
+
+// CHECK: #pragma clang diagnostic pop

--- a/test/Interop/SwiftToCxx/core/swift-existential-type-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/core/swift-existential-type-in-cxx.swift
@@ -72,21 +72,20 @@
 // CHECK:   _destroyValue();
 // CHECK: }
 
-// --- Conversion operator to Any (SwiftExistentialType<>) ---
+// --- Generic subset conversion operator (subsumes conversion to Any) ---
 
-// CHECK: SwiftExistentialType<Tags...>::operator SwiftExistentialType<>() const noexcept
-// CHECK:     requires(sizeof...(Tags) > 0 && Traits::IsCopyable) {
-// CHECK:   SwiftExistentialType<> result(
-// CHECK:       typename SwiftExistentialType<>::uninit_t{});
+// CHECK: SwiftExistentialType<Tags...>::operator SwiftExistentialType<TargetTags...>() const noexcept {
+// CHECK:   SwiftExistentialType<TargetTags...> result(
+// CHECK:       typename SwiftExistentialType<TargetTags...>::uninit_t{});
 // CHECK:   result._type = _type;
 // CHECK:   _getVWT()->initializeBufferWithCopyOfBuffer(
 // CHECK: }
 
-// --- SwiftClassExistentialType conversion operator to Any ---
+// --- SwiftClassExistentialType generic subset conversion ---
 
-// CHECK: SwiftClassExistentialType<Tags...>::operator SwiftExistentialType<>() const noexcept {
-// CHECK:   SwiftExistentialType<> result(
-// CHECK:       typename SwiftExistentialType<>::uninit_t{});
+// CHECK: SwiftClassExistentialType<Tags...>::operator SwiftExistentialType<TargetTags...>() const noexcept {
+// CHECK:   SwiftExistentialType<TargetTags...> result(
+// CHECK:       typename SwiftExistentialType<TargetTags...>::uninit_t{});
 // CHECK:   result._type = swift_getObjectType(
 // CHECK: }
 

--- a/test/Interop/SwiftToCxx/core/swift-existential-type-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/core/swift-existential-type-in-cxx.swift
@@ -1,0 +1,93 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name Core -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/core.h -enable-experimental-feature CxxExistentialInterop
+// RUN: %FileCheck %s < %t/core.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/core.h)
+
+// REQUIRES: swift_feature_CxxExistentialInterop
+
+
+// Verify that SwiftExistentialType<Tags...> out-of-line method definitions
+// appear in the generated header after the ValueWitnessTable struct.
+// The class template declaration is in _SwiftCxxInteroperability.h (included
+// via #include).
+
+// --- Check the #include of _SwiftCxxInteroperability.h ---
+// CHECK: _SwiftCxxInteroperability.h
+
+// --- Check the out-of-line method definitions in the scaffolding ---
+
+// CHECK-LABEL: // Out-of-line SwiftExistentialType methods.
+
+// CHECK: SwiftExistentialType<Tags...>::_getVWT() const noexcept {
+// CHECK:   auto *vwTableAddr = reinterpret_cast<ValueWitnessTable **>(_type) - 1;
+// CHECK: }
+
+// CHECK: SwiftExistentialType<Tags...>::_initializeWithCopy(
+// CHECK:     const SwiftExistentialType<Tags...> &src) noexcept {
+// CHECK:   _type = src._type;
+// CHECK:   _getVWT()->initializeBufferWithCopyOfBuffer(
+// CHECK: }
+
+// CHECK: SwiftExistentialType<Tags...>::_initializeWithValue(
+// CHECK:     const void *_Nonnull src) noexcept {
+// CHECK:   auto *vwt = _getVWT();
+// CHECK:   if (!(vwt->flags & 131072)) {
+// CHECK:     vwt->initializeWithCopy(
+// CHECK:   } else {
+// CHECK:     auto box = swift_allocBox(_type);
+// CHECK:     _buffer[0] = box.object;
+// CHECK:     vwt->initializeWithCopy(
+// CHECK:   }
+// CHECK: }
+
+// CHECK: SwiftExistentialType<Tags...>::_projectValue() const noexcept {
+// CHECK:   auto *vwTable = _getVWT();
+// CHECK:   if (!(vwTable->flags & 131072))
+// CHECK: }
+
+// CHECK: SwiftExistentialType<Tags...>::SwiftExistentialType(
+// CHECK:     const SwiftExistentialType<Tags...> &other) noexcept
+// CHECK:   _getVWT()->initializeBufferWithCopyOfBuffer(
+// CHECK: }
+
+// CHECK: SwiftExistentialType<Tags...>::SwiftExistentialType(
+// CHECK:     SwiftExistentialType<Tags...> &&other) noexcept
+// CHECK:   _getVWT()->initializeBufferWithCopyOfBuffer(
+// CHECK: }
+
+// CHECK: SwiftExistentialType<Tags...>::operator=(
+// CHECK:     const SwiftExistentialType<Tags...> &other) noexcept
+// CHECK:     _destroyValue();
+// CHECK:     _getVWT()->initializeBufferWithCopyOfBuffer(
+// CHECK: }
+
+// CHECK: SwiftExistentialType<Tags...>::operator=(
+// CHECK:     SwiftExistentialType<Tags...> &&other) noexcept {
+// CHECK:     _destroyValue();
+// CHECK:     _getVWT()->initializeBufferWithCopyOfBuffer(
+// CHECK: }
+
+// CHECK: SwiftExistentialType<Tags...>::~SwiftExistentialType() noexcept {
+// CHECK:   _destroyValue();
+// CHECK: }
+
+// --- Conversion operator to Any (SwiftExistentialType<>) ---
+
+// CHECK: SwiftExistentialType<Tags...>::operator SwiftExistentialType<>() const noexcept
+// CHECK:     requires(sizeof...(Tags) > 0 && Traits::IsCopyable) {
+// CHECK:   SwiftExistentialType<> result(
+// CHECK:       typename SwiftExistentialType<>::uninit_t{});
+// CHECK:   result._type = _type;
+// CHECK:   _getVWT()->initializeBufferWithCopyOfBuffer(
+// CHECK: }
+
+// --- SwiftClassExistentialType conversion operator to Any ---
+
+// CHECK: SwiftClassExistentialType<Tags...>::operator SwiftExistentialType<>() const noexcept {
+// CHECK:   SwiftExistentialType<> result(
+// CHECK:       typename SwiftExistentialType<>::uninit_t{});
+// CHECK:   result._type = swift_getObjectType(
+// CHECK: }
+
+// CHECK: } // namespace _impl

--- a/test/Interop/SwiftToCxx/protocols/Inputs/protocols-dispatch-base.swift
+++ b/test/Interop/SwiftToCxx/protocols/Inputs/protocols-dispatch-base.swift
@@ -1,0 +1,59 @@
+public protocol Drawable {
+    func draw() -> Int
+}
+
+public protocol Resizable {
+    func resize(to factor: Int) -> Bool
+}
+
+public protocol Stylable: Drawable {
+    func style() -> Bool
+}
+
+public protocol Renderable: AnyObject {
+    func render() -> Int
+}
+
+public protocol MultiReq {
+    func first() -> Int
+    func second() -> Int
+}
+
+public struct Circle: Drawable, Resizable {
+    var radius: Int
+    public init(radius: Int) { self.radius = radius }
+    public func draw() -> Int { return radius * radius }
+    public func resize(to factor: Int) -> Bool { return factor > 0 && factor <= radius }
+}
+
+public struct StyledCircle: Stylable {
+    var radius: Int
+    public init(radius: Int) { self.radius = radius }
+    public func draw() -> Int { return radius * radius * 3 }
+    public func style() -> Bool { return radius > 5 }
+}
+
+public class Canvas: Renderable {
+    var size: Int
+    public init(size: Int) { self.size = size }
+    public func render() -> Int { return size * 2 }
+}
+
+public struct Pair: MultiReq {
+    var a: Int
+    var b: Int
+    public init(a: Int, b: Int) { self.a = a; self.b = b }
+    public func first() -> Int { return a }
+    public func second() -> Int { return b }
+}
+
+public struct LargeDrawable: Drawable {
+    var a: Int
+    var b: Int
+    var c: Int
+    var d: Int
+    public init(a: Int, b: Int, c: Int, d: Int) {
+        self.a = a; self.b = b; self.c = c; self.d = d
+    }
+    public func draw() -> Int { return a + b + c + d }
+}

--- a/test/Interop/SwiftToCxx/protocols/Inputs/protocols-dispatch-base.swift
+++ b/test/Interop/SwiftToCxx/protocols/Inputs/protocols-dispatch-base.swift
@@ -10,6 +10,11 @@ public protocol Stylable: Drawable {
     func style() -> Bool
 }
 
+public protocol Container<Element> {
+    associatedtype Element
+    func count() -> Int
+}
+
 public protocol Renderable: AnyObject {
     func render() -> Int
 }
@@ -31,6 +36,13 @@ public struct StyledCircle: Stylable {
     public init(radius: Int) { self.radius = radius }
     public func draw() -> Int { return radius * radius * 3 }
     public func style() -> Bool { return radius > 5 }
+}
+
+public struct IntArray: Container {
+    public typealias Element = Int
+    var n: Int
+    public init(count: Int) { self.n = count }
+    public func count() -> Int { return n }
 }
 
 public class Canvas: Renderable {

--- a/test/Interop/SwiftToCxx/protocols/Inputs/protocols-dispatch.swift
+++ b/test/Interop/SwiftToCxx/protocols/Inputs/protocols-dispatch.swift
@@ -85,3 +85,15 @@ public func drawAndResize(_ x: any Drawable & Resizable) -> Int {
 public func makeDrawableAndResizable() -> any Drawable & Resizable {
     return Circle(radius: 5)
 }
+
+public protocol Scalable {
+    func scale() -> Int
+}
+
+extension Circle: Scalable {
+    public func scale() -> Int { return radius * 3 }
+}
+
+public func makeDrawableResizableAndScalable() -> any Drawable & Resizable & Scalable {
+    return Circle(radius: 5)
+}

--- a/test/Interop/SwiftToCxx/protocols/Inputs/protocols-dispatch.swift
+++ b/test/Interop/SwiftToCxx/protocols/Inputs/protocols-dispatch.swift
@@ -77,3 +77,11 @@ public func drawTwice(_ d: any Drawable) -> Int {
 public func bestDrawable(_ a: any Drawable, _ b: any Drawable) -> any Drawable {
     return a.draw() >= b.draw() ? a : b
 }
+
+public func drawAndResize(_ x: any Drawable & Resizable) -> Int {
+    return x.draw() + (x.resize(to: 3) ? 1 : 0)
+}
+
+public func makeDrawableAndResizable() -> any Drawable & Resizable {
+    return Circle(radius: 5)
+}

--- a/test/Interop/SwiftToCxx/protocols/Inputs/protocols-dispatch.swift
+++ b/test/Interop/SwiftToCxx/protocols/Inputs/protocols-dispatch.swift
@@ -69,3 +69,11 @@ public struct LargeDrawable: Drawable {
     }
     public func draw() -> Int { return a + b + c + d }
 }
+
+public func drawTwice(_ d: any Drawable) -> Int {
+    return d.draw() + d.draw()
+}
+
+public func bestDrawable(_ a: any Drawable, _ b: any Drawable) -> any Drawable {
+    return a.draw() >= b.draw() ? a : b
+}

--- a/test/Interop/SwiftToCxx/protocols/protocols-dispatch-execution.cpp
+++ b/test/Interop/SwiftToCxx/protocols/protocols-dispatch-execution.cpp
@@ -110,6 +110,24 @@ int main() {
 // CHECK-NEXT: copy.draw() = 25
 // CHECK-NEXT: copy.resize(3) = true
 
+    // Test 9: Subset conversion -- pass 3-way composition to 2-way function.
+    // Exercises the generic subset operator at runtime:
+    // SwiftExistentialType<DrawableTag, ResizableTag, ScalableTag> narrows to
+    // SwiftExistentialType<DrawableTag, ResizableTag> via implicit conversion.
+    {
+        auto comp3 = ProtoDispatch::makeDrawableResizableAndScalable();
+        printf("comp3.draw() = %ld\n", comp3.draw());
+        printf("comp3.scale() = %ld\n", comp3.scale());
+        assert(comp3.draw() == 25);
+        assert(comp3.scale() == 15);  // radius * 3
+        swift::Int result = ProtoDispatch::drawAndResize(comp3);
+        printf("drawAndResize(3-way) = %ld\n", result);
+        assert(result == 26);
+    }
+// CHECK-NEXT: comp3.draw() = 25
+// CHECK-NEXT: comp3.scale() = 15
+// CHECK-NEXT: drawAndResize(3-way) = 26
+
     printf("done\n");
 // CHECK-NEXT: done
     return 0;

--- a/test/Interop/SwiftToCxx/protocols/protocols-dispatch-execution.cpp
+++ b/test/Interop/SwiftToCxx/protocols/protocols-dispatch-execution.cpp
@@ -1,0 +1,50 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %S/Inputs/protocols-dispatch.swift -module-name ProtoDispatch -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/proto-dispatch.h -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature CxxExistentialInterop
+
+// RUN: %target-interop-build-clangxx -std=gnu++20 -c %s -I %t -o %t/proto-dispatch-execution.o
+// RUN: %target-interop-build-swift %S/Inputs/protocols-dispatch.swift -o %t/proto-dispatch-execution -Xlinker %t/proto-dispatch-execution.o -module-name ProtoDispatch -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+
+// RUN: %target-codesign %t/proto-dispatch-execution
+// RUN: %target-run %t/proto-dispatch-execution | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_CxxExistentialInterop
+
+// End-to-end test: Swift functions that take and return protocol
+// existentials, called from C++ via generated thunks.
+
+#include <cassert>
+#include <cstdio>
+#include "proto-dispatch.h"
+
+int main() {
+    // Test 1: drawTwice(any Drawable) existential parameter.
+    {
+        auto circle = ProtoDispatch::Circle::init(7);
+        ProtoDispatch::Drawable drawable(circle);
+        swift::Int result = ProtoDispatch::drawTwice(drawable);
+        printf("drawTwice() = %ld\n", result);
+        assert(result == 98);  // 49 + 49
+    }
+// CHECK: drawTwice() = 98
+
+    // Test 2: bestDrawable existential return picks the higher draw().
+    {
+        auto ca = ProtoDispatch::Circle::init(7);
+        ProtoDispatch::Drawable a(ca);
+
+        auto cb = ProtoDispatch::Circle::init(3);
+        ProtoDispatch::Drawable b(cb);
+
+        ProtoDispatch::Drawable best = ProtoDispatch::bestDrawable(a, b);
+        swift::Int result = best.draw();
+        printf("bestDrawable().draw() = %ld\n", result);
+        assert(result == 49);  // a wins
+    }
+// CHECK-NEXT: bestDrawable().draw() = 49
+
+    printf("done\n");
+// CHECK-NEXT: done
+    return 0;
+}

--- a/test/Interop/SwiftToCxx/protocols/protocols-dispatch-execution.cpp
+++ b/test/Interop/SwiftToCxx/protocols/protocols-dispatch-execution.cpp
@@ -44,6 +44,72 @@ int main() {
     }
 // CHECK-NEXT: bestDrawable().draw() = 49
 
+    // Test 3: makeDrawableAndResizable() composition return + method dispatch.
+    {
+        auto comp = ProtoDispatch::makeDrawableAndResizable();
+        swift::Int drawResult = comp.draw();
+        printf("comp.draw() = %ld\n", drawResult);
+        assert(drawResult == 25);
+
+        bool resizeResult = comp.resize(3);
+        printf("comp.resize(3) = %s\n", resizeResult ? "true" : "false");
+        assert(resizeResult == true);
+    }
+// CHECK-NEXT: comp.draw() = 25
+// CHECK-NEXT: comp.resize(3) = true
+
+    // Test 4: drawAndResize() composition parameter (derived-to-base).
+    {
+        auto comp = ProtoDispatch::makeDrawableAndResizable();
+        swift::Int result = ProtoDispatch::drawAndResize(comp);
+        printf("drawAndResize() = %ld\n", result);
+        assert(result == 26);  // draw()=25 + resize(to:3)=true=1
+    }
+// CHECK-NEXT: drawAndResize() = 26
+
+    // Test 5: asDrawable() extracts single-protocol Drawable from composition.
+    {
+        auto comp = ProtoDispatch::makeDrawableAndResizable();
+        ProtoDispatch::Drawable drawable = comp.asDrawable();
+        swift::Int result = drawable.draw();
+        printf("asDrawable().draw() = %ld\n", result);
+        assert(result == 25);
+    }
+// CHECK-NEXT: asDrawable().draw() = 25
+
+    // Test 6: asResizable() extracts single-protocol Resizable from composition.
+    {
+        auto comp = ProtoDispatch::makeDrawableAndResizable();
+        ProtoDispatch::Resizable resizable = comp.asResizable();
+        bool result = resizable.resize(3);
+        printf("asResizable().resize(3) = %s\n", result ? "true" : "false");
+        assert(result == true);
+    }
+// CHECK-NEXT: asResizable().resize(3) = true
+
+    // Test 7: Extracted Drawable passed to drawTwice() -- composition extraction
+    // feeds single-protocol function dispatch.
+    {
+        auto comp = ProtoDispatch::makeDrawableAndResizable();
+        ProtoDispatch::Drawable drawable = comp.asDrawable();
+        swift::Int result = ProtoDispatch::drawTwice(drawable);
+        printf("drawTwice(asDrawable()) = %ld\n", result);
+        assert(result == 50);  // 25 + 25
+    }
+// CHECK-NEXT: drawTwice(asDrawable()) = 50
+
+    // Test 8: Composition copy construction preserves both WTs.
+    {
+        auto comp = ProtoDispatch::makeDrawableAndResizable();
+        auto copy(comp);
+        printf("copy.draw() = %ld\n", copy.draw());
+        printf("copy.resize(3) = %s\n", copy.resize(3) ? "true" : "false");
+        assert(copy.draw() == 25);
+        assert(copy.resize(3) == true);
+    }
+// CHECK-NEXT: copy.draw() = 25
+// CHECK-NEXT: copy.resize(3) = true
+
     printf("done\n");
 // CHECK-NEXT: done
     return 0;

--- a/test/Interop/SwiftToCxx/protocols/protocols-wrapper-execution.cpp
+++ b/test/Interop/SwiftToCxx/protocols/protocols-wrapper-execution.cpp
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/Inputs/protocols-dispatch-base.swift -module-name ProtoDispatch -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/proto-dispatch.h -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature CxxExistentialInterop
+// RUN: %target-swift-frontend %S/Inputs/protocols-dispatch.swift -module-name ProtoDispatch -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/proto-dispatch.h -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature CxxExistentialInterop
 
 // RUN: %target-interop-build-clangxx -std=gnu++20 -c %s -I %t -o %t/proto-dispatch-execution.o
-// RUN: %target-interop-build-swift %S/Inputs/protocols-dispatch-base.swift -o %t/proto-dispatch-execution -Xlinker %t/proto-dispatch-execution.o -module-name ProtoDispatch -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+// RUN: %target-interop-build-swift %S/Inputs/protocols-dispatch.swift -o %t/proto-dispatch-execution -Xlinker %t/proto-dispatch-execution.o -module-name ProtoDispatch -Xfrontend -entry-point-function-name -Xfrontend swiftMain
 
 // RUN: %target-codesign %t/proto-dispatch-execution
 // RUN: %target-run %t/proto-dispatch-execution | %FileCheck %s

--- a/test/Interop/SwiftToCxx/protocols/protocols-wrapper-execution.cpp
+++ b/test/Interop/SwiftToCxx/protocols/protocols-wrapper-execution.cpp
@@ -1,0 +1,198 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %S/Inputs/protocols-dispatch-base.swift -module-name ProtoDispatch -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/proto-dispatch.h -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature CxxExistentialInterop
+
+// RUN: %target-interop-build-clangxx -std=gnu++20 -c %s -I %t -o %t/proto-dispatch-execution.o
+// RUN: %target-interop-build-swift %S/Inputs/protocols-dispatch-base.swift -o %t/proto-dispatch-execution -Xlinker %t/proto-dispatch-execution.o -module-name ProtoDispatch -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+
+// RUN: %target-codesign %t/proto-dispatch-execution
+// RUN: %target-run %t/proto-dispatch-execution | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_CxxExistentialInterop
+
+// End-to-end test: protocol existential wrappers with boxing
+// constructors, method dispatch, conversion, and VWT lifecycle.
+
+#include <cassert>
+#include <cstdio>
+#include "proto-dispatch.h"
+
+int main() {
+    // Test 1: Drawable boxing constructor + draw().
+    {
+        auto circle = ProtoDispatch::Circle::init(7);
+        ProtoDispatch::Drawable drawable(circle);
+        swift::Int result = drawable.draw();
+        printf("draw() = %ld\n", result);
+        assert(result == 49);
+    }
+// CHECK: draw() = 49
+
+    // Test 2: Resizable boxing constructor + resize(to:).
+    {
+        auto circle = ProtoDispatch::Circle::init(5);
+        ProtoDispatch::Resizable resizable(circle);
+        bool ok = resizable.resize(3);
+        printf("resize(3) = %s\n", ok ? "true" : "false");
+        assert(ok == true);
+
+        bool bad = resizable.resize(10);
+        printf("resize(10) = %s\n", bad ? "true" : "false");
+        assert(bad == false);
+    }
+// CHECK-NEXT: resize(3) = true
+// CHECK-NEXT: resize(10) = false
+
+    // Test 3: Stylable inherited draw() via two-level WT dispatch,
+    // plus own style() via direct dispatch.
+    {
+        auto sc = ProtoDispatch::StyledCircle::init(7);
+        ProtoDispatch::Stylable stylable(sc);
+
+        swift::Int drawResult = stylable.draw();
+        printf("stylable.draw() = %ld\n", drawResult);
+        assert(drawResult == 147);  // 7*7*3
+
+        bool styleResult = stylable.style();
+        printf("stylable.style() = %s\n", styleResult ? "true" : "false");
+        assert(styleResult == true);  // 7 > 5
+    }
+// CHECK-NEXT: stylable.draw() = 147
+// CHECK-NEXT: stylable.style() = true
+
+    // Test 4: Stylable::asDrawable() copies the
+    // existential into a Drawable wrapper with the base WT.
+    {
+        auto sc = ProtoDispatch::StyledCircle::init(7);
+        ProtoDispatch::Stylable stylable(sc);
+
+        ProtoDispatch::Drawable drawable = stylable.asDrawable();
+        swift::Int drawResult = drawable.draw();
+        printf("asDrawable().draw() = %ld\n", drawResult);
+        assert(drawResult == 147);
+    }
+// CHECK-NEXT: asDrawable().draw() = 147
+
+    // Test 5: VWT copy construction (opaque existential).
+    {
+        auto circle = ProtoDispatch::Circle::init(5);
+        ProtoDispatch::Drawable original(circle);
+        ProtoDispatch::Drawable copy(original);
+        swift::Int result = copy.draw();
+        printf("copy.draw() = %ld\n", result);
+        assert(result == 25);
+    }
+// CHECK-NEXT: copy.draw() = 25
+
+    // Test 6: VWT copy assignment.
+    {
+        auto c1 = ProtoDispatch::Circle::init(5);
+        ProtoDispatch::Drawable assigned(c1);
+        printf("before assign: %ld\n", assigned.draw());
+
+        auto c2 = ProtoDispatch::Circle::init(3);
+        ProtoDispatch::Drawable other(c2);
+        assigned = other;
+        printf("after assign: %ld\n", assigned.draw());
+        assert(assigned.draw() == 9);
+    }
+// CHECK-NEXT: before assign: 25
+// CHECK-NEXT: after assign: 9
+
+    // Test 7: Move construction. Value is transferred, source is
+    // left in a moved-from state (opaque existential).
+    {
+        auto circle = ProtoDispatch::Circle::init(6);
+        ProtoDispatch::Drawable original(circle);
+        ProtoDispatch::Drawable moved(std::move(original));
+        swift::Int result = moved.draw();
+        printf("moved.draw() = %ld\n", result);
+        assert(result == 36);
+    }
+// CHECK-NEXT: moved.draw() = 36
+
+    // Test 8: Move assignment (opaque existential).
+    {
+        auto c1 = ProtoDispatch::Circle::init(4);
+        ProtoDispatch::Drawable target(c1);
+
+        auto c2 = ProtoDispatch::Circle::init(8);
+        ProtoDispatch::Drawable source(c2);
+        target = std::move(source);
+        printf("move-assigned.draw() = %ld\n", target.draw());
+        assert(target.draw() == 64);
+    }
+// CHECK-NEXT: move-assigned.draw() = 64
+
+    // Test 9: Class-bound protocol boxing, dispatch, copy, move.
+    {
+        auto canvas = ProtoDispatch::Canvas::init(21);
+        ProtoDispatch::Renderable renderable(canvas);
+        swift::Int result = renderable.render();
+        printf("renderable.render() = %ld\n", result);
+        assert(result == 42);
+
+        ProtoDispatch::Renderable copy(renderable);
+        printf("copy.render() = %ld\n", copy.render());
+        assert(copy.render() == 42);
+
+        ProtoDispatch::Renderable moved(std::move(copy));
+        printf("moved.render() = %ld\n", moved.render());
+        assert(moved.render() == 42);
+
+        auto canvas2 = ProtoDispatch::Canvas::init(50);
+        ProtoDispatch::Renderable r2(canvas2);
+        r2 = renderable;
+        printf("copy-assigned.render() = %ld\n", r2.render());
+        assert(r2.render() == 42);
+
+        auto canvas3 = ProtoDispatch::Canvas::init(99);
+        ProtoDispatch::Renderable r3(canvas3);
+        r3 = std::move(renderable);
+        printf("move-assigned.render() = %ld\n", r3.render());
+        assert(r3.render() == 42);
+    }
+// CHECK-NEXT: renderable.render() = 42
+// CHECK-NEXT: copy.render() = 42
+// CHECK-NEXT: moved.render() = 42
+// CHECK-NEXT: copy-assigned.render() = 42
+// CHECK-NEXT: move-assigned.render() = 42
+
+    // Test 10: Multi-requirement protocol at offsets 1 and 2.
+    {
+        auto pair = ProtoDispatch::Pair::init(10, 20);
+        ProtoDispatch::MultiReq mr(pair);
+        printf("first() = %ld\n", mr.first());
+        printf("second() = %ld\n", mr.second());
+        assert(mr.first() == 10);
+        assert(mr.second() == 20);
+    }
+// CHECK-NEXT: first() = 10
+// CHECK-NEXT: second() = 20
+
+    // Test 11: Large value type exceeds inline buffer (4 words > 3-word buffer),
+    // exercises VWT outline storage (swift_allocBox / swift_projectBox).
+    {
+        auto large = ProtoDispatch::LargeDrawable::init(1, 2, 3, 4);
+        ProtoDispatch::Drawable drawable(large);
+        swift::Int result = drawable.draw();
+        printf("large.draw() = %ld\n", result);
+        assert(result == 10);
+
+        ProtoDispatch::Drawable copy(drawable);
+        printf("large copy.draw() = %ld\n", copy.draw());
+        assert(copy.draw() == 10);
+
+        ProtoDispatch::Drawable moved(std::move(drawable));
+        printf("large moved.draw() = %ld\n", moved.draw());
+        assert(moved.draw() == 10);
+    }
+// CHECK-NEXT: large.draw() = 10
+// CHECK-NEXT: large copy.draw() = 10
+// CHECK-NEXT: large moved.draw() = 10
+
+    printf("done\n");
+// CHECK-NEXT: done
+    return 0;
+}

--- a/test/Interop/SwiftToCxx/protocols/protocols-wrapper-execution.cpp
+++ b/test/Interop/SwiftToCxx/protocols/protocols-wrapper-execution.cpp
@@ -74,7 +74,17 @@ int main() {
     }
 // CHECK-NEXT: asDrawable().draw() = 147
 
-    // Test 5: VWT copy construction (opaque existential).
+    // Test 5: Container<swift::Int> PAT class template via boxing.
+    {
+        auto arr = ProtoDispatch::IntArray::init(5);
+        ProtoDispatch::Container<swift::Int> container(arr);
+        swift::Int n = container.count();
+        printf("container.count() = %ld\n", n);
+        assert(n == 5);
+    }
+// CHECK-NEXT: container.count() = 5
+
+    // Test 6: VWT copy construction (opaque existential).
     {
         auto circle = ProtoDispatch::Circle::init(5);
         ProtoDispatch::Drawable original(circle);
@@ -85,7 +95,7 @@ int main() {
     }
 // CHECK-NEXT: copy.draw() = 25
 
-    // Test 6: VWT copy assignment.
+    // Test 7: VWT copy assignment.
     {
         auto c1 = ProtoDispatch::Circle::init(5);
         ProtoDispatch::Drawable assigned(c1);
@@ -100,7 +110,7 @@ int main() {
 // CHECK-NEXT: before assign: 25
 // CHECK-NEXT: after assign: 9
 
-    // Test 7: Move construction. Value is transferred, source is
+    // Test 8: Move construction. Value is transferred, source is
     // left in a moved-from state (opaque existential).
     {
         auto circle = ProtoDispatch::Circle::init(6);
@@ -112,7 +122,7 @@ int main() {
     }
 // CHECK-NEXT: moved.draw() = 36
 
-    // Test 8: Move assignment (opaque existential).
+    // Test 9: Move assignment (opaque existential).
     {
         auto c1 = ProtoDispatch::Circle::init(4);
         ProtoDispatch::Drawable target(c1);
@@ -125,7 +135,7 @@ int main() {
     }
 // CHECK-NEXT: move-assigned.draw() = 64
 
-    // Test 9: Class-bound protocol boxing, dispatch, copy, move.
+    // Test 10: Class-bound protocol boxing, dispatch, copy, move.
     {
         auto canvas = ProtoDispatch::Canvas::init(21);
         ProtoDispatch::Renderable renderable(canvas);
@@ -159,7 +169,7 @@ int main() {
 // CHECK-NEXT: copy-assigned.render() = 42
 // CHECK-NEXT: move-assigned.render() = 42
 
-    // Test 10: Multi-requirement protocol at offsets 1 and 2.
+    // Test 11: Multi-requirement protocol at offsets 1 and 2.
     {
         auto pair = ProtoDispatch::Pair::init(10, 20);
         ProtoDispatch::MultiReq mr(pair);
@@ -171,7 +181,7 @@ int main() {
 // CHECK-NEXT: first() = 10
 // CHECK-NEXT: second() = 20
 
-    // Test 11: Large value type exceeds inline buffer (4 words > 3-word buffer),
+    // Test 12: Large value type exceeds inline buffer (4 words > 3-word buffer),
     // exercises VWT outline storage (swift_allocBox / swift_projectBox).
     {
         auto large = ProtoDispatch::LargeDrawable::init(1, 2, 3, 4);

--- a/test/Interop/SwiftToCxx/protocols/swift-composition-in-function-cxx.swift
+++ b/test/Interop/SwiftToCxx/protocols/swift-composition-in-function-cxx.swift
@@ -1,0 +1,60 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name Functions -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/functions.h -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature CxxExistentialInterop
+// RUN: %FileCheck %s < %t/functions.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/functions.h -DSWIFT_CXX_INTEROP_UPCOMING_SWIFT -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
+
+// REQUIRES: swift_feature_CxxExistentialInterop
+
+// expected-no-diagnostics
+
+public protocol Drawable {
+    func draw() -> Int
+}
+
+public protocol Resizable {
+    func resize() -> Int
+}
+
+public struct Widget: Drawable, Resizable {
+    var size: Int
+    public init(size: Int) { self.size = size }
+    public func draw() -> Int { return size }
+    public func resize() -> Int { return size * 2 }
+}
+
+// Composition parameter.
+public func drawAndResize(_ x: any Drawable & Resizable) -> Int {
+    return x.draw() + x.resize()
+}
+
+// Composition return.
+public func makeDrawableAndResizable() -> any Drawable & Resizable {
+    return Widget(size: 42)
+}
+
+// --- Composition wrapper class ---
+
+// CHECK-LABEL: class AnyDrawableAndResizable final : public swift::_impl::SwiftExistentialType<_impl::DrawableTag, _impl::ResizableTag>
+// CHECK: draw() const
+// CHECK: resize() const
+// CHECK: Drawable asDrawable() const
+// CHECK: Resizable asResizable() const
+
+// --- _impl helper class ---
+
+// CHECK-LABEL: class _impl_AnyDrawableAndResizable
+// CHECK: static {{.*}} AnyDrawableAndResizable _fromExistential(
+// CHECK: static {{.*}} const char * _Nonnull getOpaquePointer(const AnyDrawableAndResizable &object)
+// CHECK: static {{.*}} AnyDrawableAndResizable returnNewValue
+
+// --- Composition parameter: drawAndResize ---
+
+// CHECK-LABEL: SWIFT_INLINE_THUNK swift::Int drawAndResize
+// CHECK-SAME: const Functions::AnyDrawableAndResizable&
+// CHECK: _impl::_impl_AnyDrawableAndResizable::getOpaquePointer(
+
+// --- Composition return: makeDrawableAndResizable ---
+
+// CHECK-LABEL: SWIFT_INLINE_THUNK {{.*}}AnyDrawableAndResizable makeDrawableAndResizable
+// CHECK: _impl::_impl_AnyDrawableAndResizable::returnNewValue

--- a/test/Interop/SwiftToCxx/protocols/swift-composition-in-function-cxx.swift
+++ b/test/Interop/SwiftToCxx/protocols/swift-composition-in-function-cxx.swift
@@ -49,10 +49,11 @@ public func makeDrawableAndResizable() -> any Drawable & Resizable {
 // CHECK: static {{.*}} AnyDrawableAndResizable returnNewValue
 
 // --- Composition parameter: drawAndResize ---
+// Parameter uses base template type for implicit subset conversion.
 
 // CHECK-LABEL: SWIFT_INLINE_THUNK swift::Int drawAndResize
-// CHECK-SAME: const Functions::AnyDrawableAndResizable&
-// CHECK: _impl::_impl_AnyDrawableAndResizable::getOpaquePointer(
+// CHECK-SAME: const swift::_impl::SwiftExistentialType<Functions::_impl::DrawableTag, Functions::_impl::ResizableTag>&
+// CHECK: reinterpret_cast<const char *>(&
 
 // --- Composition return: makeDrawableAndResizable ---
 

--- a/test/Interop/SwiftToCxx/protocols/swift-composition-in-function-cxx.swift
+++ b/test/Interop/SwiftToCxx/protocols/swift-composition-in-function-cxx.swift
@@ -35,7 +35,7 @@ public func makeDrawableAndResizable() -> any Drawable & Resizable {
 
 // --- Composition wrapper class ---
 
-// CHECK-LABEL: class AnyDrawableAndResizable final : public swift::_impl::SwiftExistentialType<_impl::DrawableTag, _impl::ResizableTag>
+// CHECK-LABEL: class SWIFT_SYMBOL("composition") AnyDrawableAndResizable final : public swift::_impl::SwiftExistentialType<_impl::DrawableTag, _impl::ResizableTag>
 // CHECK: draw() const
 // CHECK: resize() const
 // CHECK: Drawable asDrawable() const

--- a/test/Interop/SwiftToCxx/protocols/swift-existential-in-function-cxx.swift
+++ b/test/Interop/SwiftToCxx/protocols/swift-existential-in-function-cxx.swift
@@ -1,0 +1,49 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name Functions -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/functions.h -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature CxxExistentialInterop
+// RUN: %FileCheck %s < %t/functions.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/functions.h -DSWIFT_CXX_INTEROP_UPCOMING_SWIFT -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
+
+// REQUIRES: swift_feature_CxxExistentialInterop
+
+// expected-no-diagnostics
+
+public protocol Drawable {
+    func draw() -> Int
+}
+
+public struct Circle: Drawable {
+    var radius: Int
+    public init(radius: Int) { self.radius = radius }
+    public func draw() -> Int { return radius * radius }
+}
+
+// Existential parameter.
+public func drawTwice(_ d: any Drawable) -> Int {
+    return d.draw() + d.draw()
+}
+
+// Existential return.
+public func bestDrawable(_ a: any Drawable, _ b: any Drawable) -> any Drawable {
+    return a.draw() >= b.draw() ? a : b
+}
+
+// --- C prologue: bestDrawable (alphabetical order) ---
+
+// CHECK-LABEL: SWIFT_EXTERN void $s9Functions12bestDrawable{{[^(]+}}(SWIFT_INDIRECT_RESULT void * _Nonnull, const void * _Nonnull a, const void * _Nonnull b) SWIFT_NOEXCEPT SWIFT_CALL;
+
+// --- C prologue: drawTwice ---
+
+// CHECK: SWIFT_EXTERN ptrdiff_t $s9Functions9drawTwice{{[^(]+}}(const void * _Nonnull d) SWIFT_NOEXCEPT SWIFT_CALL;
+
+// --- C++ thunks (guarded, alphabetical order) ---
+
+// CHECK: #if defined(SWIFT_CXX_EXISTENTIAL_INTEROP) && defined(__cpp_concepts) && __cpp_concepts >= 202002L
+// CHECK: Drawable bestDrawable(const Drawable& a, const Drawable& b)
+// CHECK:   return _impl::_impl_Drawable::returnNewValue
+// CHECK: #endif
+
+// CHECK: #if defined(SWIFT_CXX_EXISTENTIAL_INTEROP) && defined(__cpp_concepts) && __cpp_concepts >= 202002L
+// CHECK: swift::Int drawTwice(const Drawable& d)
+// CHECK:   _impl::_impl_Drawable::getOpaquePointer(d)
+// CHECK: #endif

--- a/test/Interop/SwiftToCxx/protocols/swift-protocol-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/protocols/swift-protocol-in-cxx.swift
@@ -8,6 +8,11 @@
 
 // expected-no-diagnostics
 
+public protocol Container<Element> {
+    associatedtype Element
+    func count() -> Int
+}
+
 public protocol Drawable {
     func draw() -> Int
 }
@@ -43,6 +48,37 @@ public struct Circle: Drawable {
 }
 
 // CHECK-LABEL: namespace Protocols
+
+// --- Protocol with primary associated type: Container<Element> ---
+
+// CHECK-LABEL: class _impl_Container;
+
+// Tag struct for Container.
+// CHECK:       struct ContainerTag {
+// CHECK-NEXT:    using WitnessTable = const void *_Nonnull;
+// CHECK-NEXT:  };
+
+// CHECK:       template <typename Element = swift::Any>
+// CHECK-NEXT:  class
+// CHECK-SAME:  Container final : public swift::_impl::SwiftExistentialType<_impl::ContainerTag> {
+// CHECK-NEXT:  public:
+// CHECK:         swift::Int count() const {
+// CHECK:       private:
+// CHECK:         Container() noexcept : SwiftExistentialType(typename SwiftExistentialType::uninit_t{}) {}
+// CHECK:         friend class _impl::_impl_Container;
+// CHECK:       };
+
+// CHECK:       class _impl_Container {
+// CHECK-NEXT:  public:
+// CHECK:         template <typename Element>
+// CHECK-NEXT:    static {{.*}} Container<Element> _fromExistential(void *_Nonnull typeMetadata, void *_Nonnull projectedValue, const void *_Nonnull wt) {
+// CHECK-NEXT:      Container<Element> result;
+// CHECK:         template <typename Element>
+// CHECK-NEXT:    static {{.*}} const char * _Nonnull getOpaquePointer(const Container<Element> &object)
+// CHECK:         template <typename Element>
+// CHECK-NEXT:    static {{.*}} char * _Nonnull getOpaquePointer(Container<Element> &object)
+// CHECK:         static {{.*}} Container<Element> returnNewValue(T callable) {
+// CHECK:       };
 
 // --- Non-marker protocol: Drawable ---
 

--- a/test/Interop/SwiftToCxx/protocols/swift-protocol-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/protocols/swift-protocol-in-cxx.swift
@@ -40,6 +40,11 @@ public protocol Stylable: Drawable {
     func style() -> Bool
 }
 
+// Non-copyable protocol.
+public protocol Resource: ~Copyable {
+    func use() -> Int
+}
+
 // Concrete type conforming to Drawable (for boxing constructor test).
 public struct Circle: Drawable {
     var radius: Int
@@ -199,6 +204,30 @@ public struct Circle: Drawable {
 // CHECK:         static {{.*}} Resizable _fromExistential(void *_Nonnull typeMetadata, void *_Nonnull projectedValue, const void *_Nonnull wt) {
 // CHECK:         static {{.*}} const char * _Nonnull getOpaquePointer(const Resizable &object)
 // CHECK:         static {{.*}} Resizable returnNewValue(T callable) {
+// CHECK:       };
+
+// --- Non-copyable protocol: Resource (NonCopyable inverse tag) ---
+
+// CHECK-LABEL: class _impl_Resource;
+
+// CHECK:       struct ResourceTag {
+// CHECK-NEXT:    using WitnessTable = const void *_Nonnull;
+// CHECK-NEXT:  };
+
+// CHECK:       class
+// CHECK-SAME:  Resource final : public swift::_impl::SwiftExistentialType<_impl::ResourceTag, swift::_impl::NonCopyable> {
+// CHECK-NEXT:  public:
+// CHECK:         swift::Int use() const {
+// CHECK:       private:
+// CHECK:         Resource() noexcept : SwiftExistentialType(typename SwiftExistentialType::uninit_t{}) {}
+// CHECK:         friend class _impl::_impl_Resource;
+// CHECK:       };
+
+// CHECK:       class _impl_Resource {
+// CHECK-NEXT:  public:
+// CHECK:         static {{.*}} Resource _fromExistential(void *_Nonnull typeMetadata, void *_Nonnull projectedValue, const void *_Nonnull wt) {
+// CHECK:         static {{.*}} const char * _Nonnull getOpaquePointer(const Resource &object)
+// CHECK:         static {{.*}} Resource returnNewValue(T callable) {
 // CHECK:       };
 
 // --- Non-marker protocol inheriting Drawable: Stylable ---

--- a/test/Interop/SwiftToCxx/protocols/swift-protocol-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/protocols/swift-protocol-in-cxx.swift
@@ -1,0 +1,244 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name Protocols -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/protocols.h -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature CxxExistentialInterop
+// RUN: %FileCheck %s < %t/protocols.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/protocols.h -DSWIFT_CXX_INTEROP_UPCOMING_SWIFT -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
+
+// REQUIRES: swift_feature_CxxExistentialInterop
+
+// expected-no-diagnostics
+
+public protocol Drawable {
+    func draw() -> Int
+}
+
+public protocol Resizable {
+    func resize(to factor: Int) -> Bool
+}
+
+public protocol Taggable: Sendable {}
+
+@_marker public protocol Priority {}
+
+// Class-bound protocol.
+public protocol Renderable: AnyObject {
+    func render() -> Int
+}
+
+public class Canvas: Renderable {
+    var width: Int
+    public init(width: Int) { self.width = width }
+    public func render() -> Int { return width }
+}
+
+public protocol Stylable: Drawable {
+    func style() -> Bool
+}
+
+// Concrete type conforming to Drawable (for boxing constructor test).
+public struct Circle: Drawable {
+    var radius: Int
+    public init(radius: Int) { self.radius = radius }
+    public func draw() -> Int { return radius * radius }
+}
+
+// CHECK-LABEL: namespace Protocols
+
+// --- Non-marker protocol: Drawable ---
+
+// CHECK-LABEL: class _impl_Drawable;
+// CHECK-NEXT: SWIFT_EXTERN const char $s9Protocols6CircleVAA8DrawableAAWP[];
+
+// Tag struct for Drawable.
+// CHECK:       struct DrawableTag {
+// CHECK-NEXT:    using WitnessTable = const void *_Nonnull;
+// CHECK-NEXT:  };
+
+// Forward declaration of conforming type for boxing constructor.
+// CHECK: class Circle;
+
+// CHECK:       class
+// CHECK-SAME:  Drawable final : public swift::_impl::SwiftExistentialType<_impl::DrawableTag> {
+// CHECK-NEXT:  public:
+// CHECK:         swift::Int draw() const {
+// CHECK-NEXT:      // Type-only witness signature (never instantiated).
+// CHECK-NEXT:      struct _w { _w() = delete; static SWIFT_CALL swift::Int call(void *_Nonnull, const void *_Nonnull, SWIFT_CONTEXT void *_Nonnull); };
+// CHECK-NEXT:      return _loadWitness<1, {{[0-9]+}}, decltype(&_w::call)>(_witnessTables[0])(_type, _witnessTables[0], _projectValue());
+// CHECK-NEXT:    }
+// CHECK:         Drawable(const Circle &value) noexcept;
+// CHECK:       private:
+// CHECK:         Drawable() noexcept : SwiftExistentialType(typename SwiftExistentialType::uninit_t{}) {}
+// CHECK:         friend class _impl::_impl_Drawable;
+// CHECK:       };
+
+// CHECK:       class _impl_Drawable {
+// CHECK-NEXT:  public:
+// CHECK:         static {{.*}} Drawable _fromExistential(void *_Nonnull typeMetadata, void *_Nonnull projectedValue, const void *_Nonnull wt) {
+// CHECK-NEXT:      Drawable result;
+// CHECK-NEXT:      result._type = typeMetadata;
+// CHECK-NEXT:      result._initializeWithValue(projectedValue);
+// CHECK-NEXT:      result._witnessTables[0] = wt;
+// CHECK-NEXT:      return result;
+// CHECK-NEXT:    }
+// CHECK:         static {{.*}} const char * _Nonnull getOpaquePointer(const Drawable &object)
+// CHECK:         static {{.*}} char * _Nonnull getOpaquePointer(Drawable &object)
+// CHECK:         static {{.*}} Drawable returnNewValue(T callable) {
+// CHECK:       };
+
+// --- Marker protocol: Priority (SwiftExistentialType with MarkerTag) ---
+
+// CHECK-LABEL: class _impl_Priority;
+
+// CHECK:       struct PriorityTag {
+// CHECK-NEXT:    static constexpr bool IsMarker = true;
+// CHECK-NEXT:  };
+
+// CHECK:       class
+// CHECK-SAME:  Priority final : public swift::_impl::SwiftExistentialType<_impl::PriorityTag> {
+// CHECK-NEXT:  public:
+// CHECK-NEXT:  private:
+// CHECK:         Priority() noexcept : SwiftExistentialType(typename SwiftExistentialType::uninit_t{}) {}
+// CHECK:         friend class _impl::_impl_Priority;
+// CHECK:       };
+
+// CHECK:       class _impl_Priority {
+// CHECK-NEXT:  public:
+// CHECK-NEXT:  };
+
+// --- Class-bound protocol: Renderable (SwiftClassExistentialType base) ---
+
+// CHECK-LABEL: class _impl_Renderable;
+// CHECK-NEXT: SWIFT_EXTERN const char $s9Protocols6CanvasCAA10RenderableAAWP[];
+
+// CHECK:       struct RenderableTag {
+// CHECK-NEXT:    using WitnessTable = const void *_Nonnull;
+// CHECK-NEXT:  };
+
+// CHECK: class Canvas;
+
+// CHECK:       class
+// CHECK-SAME:  Renderable final : public swift::_impl::SwiftClassExistentialType<_impl::RenderableTag> {
+// CHECK-NEXT:  public:
+// CHECK:         swift::Int render() const {
+// CHECK-NEXT:      // Type-only witness signature (never instantiated).
+// CHECK-NEXT:      struct _w { _w() = delete; static SWIFT_CALL swift::Int call(void *_Nonnull, const void *_Nonnull, SWIFT_CONTEXT void *_Nonnull); };
+// CHECK-NEXT:      return _loadWitness<1, {{[0-9]+}}, decltype(&_w::call)>(_witnessTables[0])(_getType(), _witnessTables[0], _projectValue());
+// CHECK-NEXT:    }
+// CHECK:         Renderable(const Canvas &value) noexcept;
+// CHECK:       private:
+// CHECK:         Renderable() noexcept : SwiftClassExistentialType(typename SwiftClassExistentialType::uninit_t{}) {}
+// CHECK:         friend class _impl::_impl_Renderable;
+// CHECK:       };
+
+// CHECK:       class _impl_Renderable {
+// CHECK-NEXT:  public:
+// CHECK:         static {{.*}} Renderable _fromExistential(void *_Nullable classPtr, const void *_Nonnull wt) {
+// CHECK:         static {{.*}} const char * _Nonnull getOpaquePointer(const Renderable &object)
+// CHECK:         static {{.*}} Renderable returnNewValue(T callable) {
+// CHECK:       };
+
+// --- Non-marker protocol: Resizable ---
+
+// CHECK-LABEL: class _impl_Resizable;
+
+// CHECK:       struct ResizableTag {
+// CHECK-NEXT:    using WitnessTable = const void *_Nonnull;
+// CHECK-NEXT:  };
+
+// CHECK:       class
+// CHECK-SAME:  Resizable final : public swift::_impl::SwiftExistentialType<_impl::ResizableTag> {
+// CHECK-NEXT:  public:
+// CHECK:         bool resize(swift::Int factor) const {
+// CHECK-NEXT:      // Type-only witness signature (never instantiated).
+// CHECK-NEXT:      struct _w { _w() = delete; static SWIFT_CALL bool call(swift::Int, void *_Nonnull, const void *_Nonnull, SWIFT_CONTEXT void *_Nonnull); };
+// CHECK-NEXT:      return _loadWitness<1, {{[0-9]+}}, decltype(&_w::call)>(_witnessTables[0])(factor, _type, _witnessTables[0], _projectValue());
+// CHECK-NEXT:    }
+// CHECK:       private:
+// CHECK:         Resizable() noexcept : SwiftExistentialType(typename SwiftExistentialType::uninit_t{}) {}
+// CHECK:         friend class _impl::_impl_Resizable;
+// CHECK:       };
+
+// CHECK:       class _impl_Resizable {
+// CHECK-NEXT:  public:
+// CHECK:         static {{.*}} Resizable _fromExistential(void *_Nonnull typeMetadata, void *_Nonnull projectedValue, const void *_Nonnull wt) {
+// CHECK:         static {{.*}} const char * _Nonnull getOpaquePointer(const Resizable &object)
+// CHECK:         static {{.*}} Resizable returnNewValue(T callable) {
+// CHECK:       };
+
+// --- Non-marker protocol inheriting Drawable: Stylable ---
+// Inherited draw() uses two-level dispatch through base WT.
+
+// CHECK-LABEL: class _impl_Stylable;
+
+// CHECK:       struct StylableTag {
+// CHECK-NEXT:    using WitnessTable = const void *_Nonnull;
+// CHECK-NEXT:  };
+
+// CHECK:       class
+// CHECK-SAME:  Stylable final : public swift::_impl::SwiftExistentialType<_impl::StylableTag> {
+// CHECK-NEXT:  public:
+// CHECK:         swift::Int draw() const {
+// CHECK-NEXT:      // Type-only witness signature (never instantiated).
+// CHECK-NEXT:      struct _w { _w() = delete; static SWIFT_CALL swift::Int call(void *_Nonnull, const void *_Nonnull, SWIFT_CONTEXT void *_Nonnull); };
+// CHECK-NEXT:      auto *_bwt0 = reinterpret_cast<const void *const *>(_witnessTables[0])[1];
+// CHECK-NEXT:      return _loadWitness<1, {{[0-9]+}}, decltype(&_w::call)>(_bwt0)(_type, _bwt0, _projectValue());
+// CHECK-NEXT:    }
+// CHECK:         bool style() const {
+// CHECK-NEXT:      // Type-only witness signature (never instantiated).
+// CHECK-NEXT:      struct _w { _w() = delete; static SWIFT_CALL bool call(void *_Nonnull, const void *_Nonnull, SWIFT_CONTEXT void *_Nonnull); };
+// CHECK-NEXT:      return _loadWitness<2, {{[0-9]+}}, decltype(&_w::call)>(_witnessTables[0])(_type, _witnessTables[0], _projectValue());
+// CHECK-NEXT:    }
+// CHECK:         Drawable asDrawable() const {
+// CHECK-NEXT:      auto *baseWT = reinterpret_cast<const void *const *>(_witnessTables[0])[1];
+// CHECK-NEXT:      return _impl::_impl_Drawable::_fromExistential(_type, _projectValue(), baseWT);
+// CHECK-NEXT:    }
+// CHECK:       private:
+// CHECK:         Stylable() noexcept : SwiftExistentialType(typename SwiftExistentialType::uninit_t{}) {}
+// CHECK:         friend class _impl::_impl_Stylable;
+// CHECK:       };
+
+// CHECK:       class _impl_Stylable {
+// CHECK-NEXT:  public:
+// CHECK:         static {{.*}} Stylable _fromExistential(void *_Nonnull typeMetadata, void *_Nonnull projectedValue, const void *_Nonnull wt) {
+// CHECK:         static {{.*}} const char * _Nonnull getOpaquePointer(const Stylable &object)
+// CHECK:         static {{.*}} Stylable returnNewValue(T callable) {
+// CHECK:       };
+
+// --- Non-marker protocol inheriting Sendable: Taggable ---
+
+// CHECK-LABEL: class _impl_Taggable;
+
+// CHECK:       struct TaggableTag {
+// CHECK-NEXT:    using WitnessTable = const void *_Nonnull;
+// CHECK-NEXT:  };
+
+// CHECK:       class
+// CHECK-SAME:  Taggable final : public swift::_impl::SwiftExistentialType<_impl::TaggableTag> {
+// CHECK-NEXT:  public:
+// CHECK-NEXT:  private:
+// CHECK:         Taggable() noexcept : SwiftExistentialType(typename SwiftExistentialType::uninit_t{}) {}
+// CHECK:         friend class _impl::_impl_Taggable;
+// CHECK:       };
+
+// CHECK:       class _impl_Taggable {
+// CHECK-NEXT:  public:
+// CHECK:         static {{.*}} Taggable _fromExistential(void *_Nonnull typeMetadata, void *_Nonnull projectedValue, const void *_Nonnull wt) {
+// CHECK:         static {{.*}} const char * _Nonnull getOpaquePointer(const Taggable &object)
+// CHECK:         static {{.*}} Taggable returnNewValue(T callable) {
+// CHECK:       };
+
+// --- Out-of-line boxing constructor definitions (emitted after all types) ---
+
+// CHECK-LABEL: Drawable::Drawable(const Circle &value) noexcept
+// CHECK-NEXT:    : SwiftExistentialType(typename SwiftExistentialType::uninit_t{}) {
+// CHECK-NEXT:    _type = swift::TypeMetadataTrait<Circle>::getTypeMetadata();
+// CHECK-NEXT:    _initializeWithValue(_impl::_impl_Circle::getOpaquePointer(value));
+// CHECK-NEXT:    _witnessTables[0] = reinterpret_cast<const void *>(_impl::$s9Protocols6CircleVAA8DrawableAAWP);
+// CHECK-NEXT:  }
+
+// CHECK-LABEL: Renderable::Renderable(const Canvas &value) noexcept
+// CHECK-NEXT:    : SwiftClassExistentialType(typename SwiftClassExistentialType::uninit_t{}) {
+// CHECK-NEXT:    _value = swift::_impl::_impl_RefCountedClass::getOpaquePointer(value);
+// CHECK-NEXT:    swift::_impl::swift_retain(reinterpret_cast<void *_Nonnull>(_value));
+// CHECK-NEXT:    _witnessTables[0] = reinterpret_cast<const void *>(_impl::$s9Protocols6CanvasCAA10RenderableAAWP);
+// CHECK-NEXT:  }

--- a/test/Interop/SwiftToCxx/unsupported/unsupported-generics-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/unsupported-generics-in-cxx.swift
@@ -1,11 +1,13 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -module-name Decls -verify -clang-header-expose-decls=has-expose-attr -disable-availability-checking -typecheck -verify -emit-clang-header-path %t/decls.h
+// RUN: %target-swift-frontend %s -module-name Decls -verify -clang-header-expose-decls=has-expose-attr -disable-availability-checking -typecheck -verify -emit-clang-header-path %t/decls.h -enable-experimental-feature CxxExistentialInterop
 
 // RUN: cat %s | grep -v _expose > %t/clean.swift
-// RUN: %target-swift-frontend %t/clean.swift -module-name Decls -clang-header-expose-decls=all-public -disable-availability-checking -typecheck -verify -emit-clang-header-path %t/decls.h
+// RUN: %target-swift-frontend %t/clean.swift -module-name Decls -clang-header-expose-decls=all-public -disable-availability-checking -typecheck -verify -emit-clang-header-path %t/decls.h -enable-experimental-feature CxxExistentialInterop
 // RUN: %FileCheck %s < %t/decls.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/decls.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
+
+// REQUIRES: swift_feature_CxxExistentialInterop
 
 public protocol Proto { init() }
 
@@ -66,7 +68,8 @@ public func makeQueryResult() -> QueryResult<UInt32> { .init(glyphIDs: []) }
 // CHECK: class SWIFT_SYMBOL("s:5Decls6Class1C") Class1 : public swift::_impl::RefCountedClass {
 // CHECK: 'index1' cannot be printed
 
-// CHECK: namespace Decls SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("Decls") {
+// CHECK: class{{.*}} Proto final : public swift::_impl::SwiftExistentialType<_impl::ProtoTag> {
+
 // CHECK: namespace Decls SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("Decls") {
 // CHECK: SWIFT_INLINE_THUNK void supportedFunc(const T_0_0& x) noexcept SWIFT_SYMBOL("s:5Decls13supportedFuncyyxlF") {
 
@@ -75,8 +78,6 @@ public func makeQueryResult() -> QueryResult<UInt32> { .init(glyphIDs: []) }
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: #endif // __cpp_concepts
 // CHECK-NEXT: class GlyphIndex { } SWIFT_UNAVAILABLE_MSG("generic requirements for generic struct 'GlyphIndex' can not yet be represented in C++");
-
-// CHECK: class Proto { } SWIFT_UNAVAILABLE_MSG("protocol 'Proto' can not yet be represented in C++");
 
 // CHECK: template<class T_0_0>
 // CHECK-NEXT: #ifdef __cpp_concepts

--- a/test/Interop/SwiftToCxx/unsupported/unsupported-types-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/unsupported-types-in-cxx.swift
@@ -1,8 +1,10 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -module-name Functions -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %s -module-name Functions -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/functions.h -enable-experimental-feature CxxExistentialInterop
 // RUN: %FileCheck %s < %t/functions.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/functions.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
+
+// REQUIRES: swift_feature_CxxExistentialInterop
 
 public func takeFloat(_ x: Float) {}
 
@@ -11,6 +13,10 @@ public func takesTuple(_ x: (Float, Float)) {}
 public func takesVoid(_ x: ()) {}
 
 // CHECK:     takeFloat
+
+public protocol TestProtocol {}
+
+// CHECK: class{{.*}} TestProtocol final : public swift::_impl::SwiftExistentialType<_impl::TestProtocolTag> {
 
 public enum MoveOnlyEnum: ~Copyable {
     case a
@@ -23,10 +29,6 @@ public struct MoveOnlyStruct: ~Copyable {
 }
 
 // CHECK: class MoveOnlyStruct { } SWIFT_UNAVAILABLE_MSG("noncopyable struct 'MoveOnlyStruct' can not yet be represented in C++");
-
-public protocol TestProtocol {}
-
-// CHECK: class TestProtocol { } SWIFT_UNAVAILABLE_MSG("protocol 'TestProtocol' can not yet be represented in C++");
 
 // CHECK: // Unavailable in C++: Swift global function 'takesTuple(_:)'. Parameter 'x' of type '(Float, Float)' is not representable in C++.
 // CHECK: // Unavailable in C++: Swift global function 'takesVoid(_:)'. Parameter 'x' of type '()' is not representable in C++.

--- a/test/Interop/SwiftToCxxToSwift/import-swift-existential-back-to-swift-execution.swift
+++ b/test/Interop/SwiftToCxxToSwift/import-swift-existential-back-to-swift-execution.swift
@@ -48,6 +48,17 @@ inline SwiftMod::Renderable passThroughRenderable(const SwiftMod::Renderable& r)
     return copy;
 }
 
+// --- PAT round-trips ---
+
+inline SwiftMod::Container<swift::Int> createIntContainer() {
+    return SwiftMod::Container<swift::Int>(SwiftMod::IntArray::init(3));
+}
+
+inline SwiftMod::Container<SwiftMod::Drawable> createDrawableContainer() {
+    return SwiftMod::Container<SwiftMod::Drawable>(
+        SwiftMod::DrawableArray::init(5));
+}
+
 #endif
 
 //--- module.modulemap
@@ -67,6 +78,11 @@ public protocol Renderable: AnyObject {
     func render() -> Int
 }
 
+public protocol Container<Element> {
+    associatedtype Element
+    func count() -> Int
+}
+
 public struct Circle: Drawable {
     var radius: Int
     public init(_ radius: Int) { self.radius = radius }
@@ -77,6 +93,20 @@ public class Canvas: Renderable {
     var size: Int
     public init(_ size: Int) { self.size = size }
     public func render() -> Int { return size * 2 }
+}
+
+public struct IntArray: Container {
+    public typealias Element = Int
+    var n: Int
+    public init(_ n: Int) { self.n = n }
+    public func count() -> Int { return n }
+}
+
+public struct DrawableArray: Container {
+    public typealias Element = any Drawable
+    var n: Int
+    public init(_ n: Int) { self.n = n }
+    public func count() -> Int { return n }
 }
 
 #if SECOND_PASS
@@ -103,8 +133,17 @@ func testClassBoundRoundTrip() {
     print("passThrough render: \(r2.render())")
 }
 
+func testPATRoundTrip() {
+    let c = createIntContainer()
+    print("int count: \(c.count())")
+
+    let dc = createDrawableContainer()
+    print("drawable count: \(dc.count())")
+}
+
 testOpaqueRoundTrip()
 testClassBoundRoundTrip()
+testPATRoundTrip()
 
 #endif
 
@@ -114,5 +153,7 @@ testClassBoundRoundTrip()
 // CHECK-NEXT: render: 84
 // CHECK-NEXT: passRenderable ok
 // CHECK-NEXT: passThrough render: 84
+// CHECK-NEXT: int count: 3
+// CHECK-NEXT: drawable count: 5
 
 // expected-no-diagnostics

--- a/test/Interop/SwiftToCxxToSwift/import-swift-existential-back-to-swift-execution.swift
+++ b/test/Interop/SwiftToCxxToSwift/import-swift-existential-back-to-swift-execution.swift
@@ -59,6 +59,18 @@ inline SwiftMod::Container<SwiftMod::Drawable> createDrawableContainer() {
         SwiftMod::DrawableArray::init(5));
 }
 
+// --- Composition round-trips ---
+
+inline SwiftMod::AnyDrawableAndResizable createComposition() {
+    return SwiftMod::makeDrawableAndResizable();
+}
+
+inline SwiftMod::AnyDrawableAndResizable passThroughComposition(
+    const SwiftMod::AnyDrawableAndResizable& d) {
+    auto copy = d;
+    return copy;
+}
+
 #endif
 
 //--- module.modulemap
@@ -74,6 +86,10 @@ public protocol Drawable {
     func draw() -> Int
 }
 
+public protocol Resizable {
+    func resize(to factor: Int) -> Bool
+}
+
 public protocol Renderable: AnyObject {
     func render() -> Int
 }
@@ -83,10 +99,11 @@ public protocol Container<Element> {
     func count() -> Int
 }
 
-public struct Circle: Drawable {
+public struct Circle: Drawable, Resizable {
     var radius: Int
     public init(_ radius: Int) { self.radius = radius }
     public func draw() -> Int { return radius * radius }
+    public func resize(to factor: Int) -> Bool { return factor > 0 && factor <= radius }
 }
 
 public class Canvas: Renderable {
@@ -107,6 +124,10 @@ public struct DrawableArray: Container {
     var n: Int
     public init(_ n: Int) { self.n = n }
     public func count() -> Int { return n }
+}
+
+public func makeDrawableAndResizable() -> any Drawable & Resizable {
+    return Circle(5)
 }
 
 #if SECOND_PASS
@@ -141,9 +162,18 @@ func testPATRoundTrip() {
     print("drawable count: \(dc.count())")
 }
 
+func testCompositionRoundTrip() {
+    let comp = createComposition()
+    print("comp draw: \(comp.draw())")
+
+    let comp2 = passThroughComposition(comp)
+    print("passThrough comp draw: \(comp2.draw())")
+}
+
 testOpaqueRoundTrip()
 testClassBoundRoundTrip()
 testPATRoundTrip()
+testCompositionRoundTrip()
 
 #endif
 
@@ -155,5 +185,7 @@ testPATRoundTrip()
 // CHECK-NEXT: passThrough render: 84
 // CHECK-NEXT: int count: 3
 // CHECK-NEXT: drawable count: 5
+// CHECK-NEXT: comp draw: 25
+// CHECK-NEXT: passThrough comp draw: 25
 
 // expected-no-diagnostics

--- a/test/Interop/SwiftToCxxToSwift/import-swift-existential-back-to-swift-execution.swift
+++ b/test/Interop/SwiftToCxxToSwift/import-swift-existential-back-to-swift-execution.swift
@@ -1,0 +1,118 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend %t/swiftMod.swift -module-name SwiftMod -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/swiftMod.h -I %t -enable-experimental-cxx-interop -Xcc -DFIRSTPASS -enable-experimental-feature CxxExistentialInterop
+
+// RUN: %target-interop-build-swift %t/swiftMod.swift -o %t/swift-execution -module-name SwiftMod -I %t -g -DSECOND_PASS -Xcc -DSWIFT_CXX_INTEROP_HIDE_SWIFT_ERROR
+
+// RUN: %target-codesign %t/swift-execution
+// RUN: %target-run %t/swift-execution | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_CxxExistentialInterop
+
+// UNSUPPORTED: OS=windows-msvc
+
+//--- header.h
+#ifndef FIRSTPASS
+
+#include "swiftMod.h"
+
+// --- Opaque existential round-trips ---
+
+inline SwiftMod::Drawable createDrawable() {
+    return SwiftMod::Drawable(SwiftMod::Circle::init(10));
+}
+
+inline void passDrawable(const SwiftMod::Drawable& d) {
+    (void)d.draw();
+}
+
+inline SwiftMod::Drawable passThroughDrawable(const SwiftMod::Drawable& d) {
+    auto copy = d;
+    return copy;
+}
+
+// --- Class-bound existential round-trips ---
+
+inline SwiftMod::Renderable createRenderable() {
+    return SwiftMod::Renderable(SwiftMod::Canvas::init(42));
+}
+
+inline void passRenderable(const SwiftMod::Renderable& r) {
+    (void)r.render();
+}
+
+inline SwiftMod::Renderable passThroughRenderable(const SwiftMod::Renderable& r) {
+    auto copy = r;
+    return copy;
+}
+
+#endif
+
+//--- module.modulemap
+module SwiftToCxxTest {
+    header "header.h"
+    requires cplusplus
+}
+
+//--- swiftMod.swift
+import SwiftToCxxTest
+
+public protocol Drawable {
+    func draw() -> Int
+}
+
+public protocol Renderable: AnyObject {
+    func render() -> Int
+}
+
+public struct Circle: Drawable {
+    var radius: Int
+    public init(_ radius: Int) { self.radius = radius }
+    public func draw() -> Int { return radius * radius }
+}
+
+public class Canvas: Renderable {
+    var size: Int
+    public init(_ size: Int) { self.size = size }
+    public func render() -> Int { return size * 2 }
+}
+
+#if SECOND_PASS
+
+func testOpaqueRoundTrip() {
+    let d = createDrawable()
+    print("draw: \(d.draw())")
+
+    passDrawable(d)
+    print("passDrawable ok")
+
+    let d2 = passThroughDrawable(d)
+    print("passThrough draw: \(d2.draw())")
+}
+
+func testClassBoundRoundTrip() {
+    let r = createRenderable()
+    print("render: \(r.render())")
+
+    passRenderable(r)
+    print("passRenderable ok")
+
+    let r2 = passThroughRenderable(r)
+    print("passThrough render: \(r2.render())")
+}
+
+testOpaqueRoundTrip()
+testClassBoundRoundTrip()
+
+#endif
+
+// CHECK: draw: 100
+// CHECK-NEXT: passDrawable ok
+// CHECK-NEXT: passThrough draw: 100
+// CHECK-NEXT: render: 84
+// CHECK-NEXT: passRenderable ok
+// CHECK-NEXT: passThrough render: 84
+
+// expected-no-diagnostics

--- a/test/Interop/SwiftToCxxToSwift/import-swift-existential-back-to-swift.swift
+++ b/test/Interop/SwiftToCxxToSwift/import-swift-existential-back-to-swift.swift
@@ -1,0 +1,71 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend %t/swiftMod.swift -module-name SwiftMod -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/swiftMod.h -I %t -enable-experimental-cxx-interop -Xcc -DFIRSTPASS -enable-experimental-feature CxxExistentialInterop
+
+// RUN: %target-swift-frontend %t/swiftMod.swift -module-name SwiftMod -clang-header-expose-decls=all-public -emit-module -o %t/SwiftMod.swiftmodule -I %t -enable-experimental-cxx-interop -Xcc -DFIRSTPASS -enable-experimental-feature CxxExistentialInterop
+
+// RUN: %target-swift-ide-test -print-module -module-to-print=SwiftMod -module-to-print=SwiftToCxxTest -I %t -source-filename=x -enable-experimental-cxx-interop -Xcc -DSWIFT_CXX_INTEROP_HIDE_SWIFT_ERROR -Xcc -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -enable-experimental-feature CxxExistentialInterop | %FileCheck --check-prefix=INTERFACE %s
+
+// UNSUPPORTED: OS=windows-msvc
+// REQUIRES: swift_feature_CxxExistentialInterop
+
+//--- header.h
+#ifndef FIRSTPASS
+#include "swiftMod.h"
+
+// --- Opaque existential round-trip ---
+SwiftMod::Drawable createDrawable();
+
+void passDrawable(const SwiftMod::Drawable& d);
+
+SwiftMod::Drawable bestDrawable(const SwiftMod::Drawable& a,
+                                const SwiftMod::Drawable& b);
+
+// INTERFACE: func createDrawable() -> any Drawable
+// INTERFACE: func passDrawable(_ d: any Drawable)
+// INTERFACE: func bestDrawable(_ a: any Drawable, _ b: any Drawable) -> any Drawable
+
+// --- Class-bound protocol round-trip ---
+SwiftMod::Renderable createRenderable();
+
+void passRenderable(const SwiftMod::Renderable& r);
+
+SwiftMod::Renderable passThroughRenderable(const SwiftMod::Renderable& r);
+
+// INTERFACE: func createRenderable() -> any Renderable
+// INTERFACE: func passRenderable(_ r: any Renderable)
+// INTERFACE: func passThroughRenderable(_ r: any Renderable) -> any Renderable
+
+#endif
+
+//--- module.modulemap
+module SwiftToCxxTest {
+    header "header.h"
+    requires cplusplus
+}
+
+//--- swiftMod.swift
+import SwiftToCxxTest
+
+public protocol Drawable {
+    func draw() -> Int
+}
+
+public protocol Renderable: AnyObject {
+    func render() -> Int
+}
+
+public struct Circle: Drawable {
+    var radius: Int
+    public init(radius: Int) { self.radius = radius }
+    public func draw() -> Int { return radius * radius }
+}
+
+public class Canvas: Renderable {
+    var size: Int
+    public init(_ size: Int) { self.size = size }
+    public func render() -> Int { return size * 2 }
+}
+
+// expected-no-diagnostics

--- a/test/Interop/SwiftToCxxToSwift/import-swift-existential-back-to-swift.swift
+++ b/test/Interop/SwiftToCxxToSwift/import-swift-existential-back-to-swift.swift
@@ -58,6 +58,18 @@ SwiftMod::Container<SwiftMod::Drawable> createDrawableContainer();
 // INTERFACE: func createAnyContainer() -> any Container
 // INTERFACE: func createDrawableContainer() -> any Container<any Drawable>
 
+// --- Composition round-trip ---
+SwiftMod::AnyDrawableAndResizable createComposition();
+
+void passComposition(const SwiftMod::AnyDrawableAndResizable& d);
+
+SwiftMod::AnyDrawableAndResizable passThroughComposition(
+    const SwiftMod::AnyDrawableAndResizable& a);
+
+// INTERFACE: func createComposition() -> any Drawable & Resizable
+// INTERFACE: func passComposition(_ d: any Drawable & Resizable)
+// INTERFACE: func passThroughComposition(_ a: any Drawable & Resizable) -> any Drawable & Resizable
+
 #endif
 
 //--- module.modulemap
@@ -73,6 +85,10 @@ public protocol Drawable {
     func draw() -> Int
 }
 
+public protocol Resizable {
+    func resize(to factor: Int) -> Bool
+}
+
 public protocol Renderable: AnyObject {
     func render() -> Int
 }
@@ -82,16 +98,21 @@ public protocol Container<Element> {
     func count() -> Int
 }
 
-public struct Circle: Drawable {
+public struct Circle: Drawable, Resizable {
     var radius: Int
     public init(radius: Int) { self.radius = radius }
     public func draw() -> Int { return radius * radius }
+    public func resize(to factor: Int) -> Bool { return factor > 0 && factor <= radius }
 }
 
 public class Canvas: Renderable {
     var size: Int
     public init(_ size: Int) { self.size = size }
     public func render() -> Int { return size * 2 }
+}
+
+public func makeDrawableAndResizable() -> any Drawable & Resizable {
+    return Circle(radius: 5)
 }
 
 // expected-no-diagnostics

--- a/test/Interop/SwiftToCxxToSwift/import-swift-existential-back-to-swift.swift
+++ b/test/Interop/SwiftToCxxToSwift/import-swift-existential-back-to-swift.swift
@@ -37,6 +37,27 @@ SwiftMod::Renderable passThroughRenderable(const SwiftMod::Renderable& r);
 // INTERFACE: func passRenderable(_ r: any Renderable)
 // INTERFACE: func passThroughRenderable(_ r: any Renderable) -> any Renderable
 
+// --- PAT protocol round-trip ---
+SwiftMod::Container<swift::Int> createIntContainer();
+
+void passIntContainer(const SwiftMod::Container<swift::Int>& c);
+
+SwiftMod::Container<swift::Int> firstIntContainer(
+    const SwiftMod::Container<swift::Int>& a,
+    const SwiftMod::Container<swift::Int>& b);
+
+// Default template arg (swift::Any) => unconstrained existential
+SwiftMod::Container<> createAnyContainer();
+
+// Nested existential PAT arg
+SwiftMod::Container<SwiftMod::Drawable> createDrawableContainer();
+
+// INTERFACE: func createIntContainer() -> any Container<Int>
+// INTERFACE: func passIntContainer(_ c: any Container<Int>)
+// INTERFACE: func firstIntContainer(_ a: any Container<Int>, _ b: any Container<Int>) -> any Container<Int>
+// INTERFACE: func createAnyContainer() -> any Container
+// INTERFACE: func createDrawableContainer() -> any Container<any Drawable>
+
 #endif
 
 //--- module.modulemap
@@ -54,6 +75,11 @@ public protocol Drawable {
 
 public protocol Renderable: AnyObject {
     func render() -> Int
+}
+
+public protocol Container<Element> {
+    associatedtype Element
+    func count() -> Int
 }
 
 public struct Circle: Drawable {


### PR DESCRIPTION
## Summary

Add C++ wrapper types for Swift protocol existentials in the generated interop header, enabling C++ code to call Swift functions that take or return `any Protocol`, dispatch protocol methods, box conforming values, and work with protocol compositions. Builds on the variadic template scaffolding from #90449.

### What this enables

```cpp
// Call Swift functions with existential parameters/returns
Drawable d = bestDrawable(a, b);
swift::Int area = drawTwice(d);

// Protocol method dispatch
swift::Int result = d.draw();

// Box concrete conforming values
Drawable fromCircle(Circle{radius: 5});

// Composition existentials
AnyDrawableAndResizable comp = makeDrawableAndResizable();
Drawable narrowed = comp.asDrawable();

// Implicit subset conversion
SwiftExistentialType<DrawableTag, ResizableTag> wide = ...;
SwiftExistentialType<DrawableTag> narrow = wide;  // implicit
```

### Design

Following [Gabor Horvath's feedback](https://forums.swift.org/t/88116/4), this is a type-erasure-only model. Per-protocol wrappers are concrete `final` classes that C++ functions accept directly (`void f(const Drawable& d)`), with no concepts or templates in the user-facing API. Protocol compositions use the variadic template base (`SwiftExistentialType<DrawableTag, ResizableTag>`) as Gabor suggested, so compound protocol support falls naturally out of the tag model.

The tag indirection layer (lightweight structs like `DrawableTag` rather than the wrapper types themselves as template arguments) is necessary because wrapper classes are defined after the base template in the generated header, a forward declaration constraint.

**Per-protocol wrapper emission.** Non-marker protocols emit as `final` subclasses of `SwiftExistentialType<ProtocolTag>`. Marker protocols emit with `MarkerTag` (zero witness tables). Class-bound protocols (`: AnyObject`) emit as `SwiftClassExistentialType<ProtocolTag>` subclasses. `~Copyable` protocols add an `InverseTag` (`NonCopyable`), which suppresses copy constructor/assignment via `requires(IsCopyable)`. Protocols with primary associated types emit as class templates (`Container<Element>`).

**Protocol requirement methods** dispatch through the witness table at compile-time offsets with ptrauth signing on arm64e. Inherited methods use two-level witness table dispatch (load base WT from derived WT's base conformance slot, then dispatch through base WT). Conversion methods (`asDrawable()`) copy the existential buffer and base witness table into a new wrapper.

**Ad-hoc protocol compositions** (`any Drawable & Resizable`) emit as named wrapper classes inheriting from `SwiftExistentialType<DrawableTag, ResizableTag>` with methods from all constituent protocols and `asDrawable()` / `asResizable()` accessors.

**Boxing constructors.** Per-conformance implicit conversion constructors for each same-module conformance. Generic types and type-mismatched conformances are filtered out. Constructors are defined out-of-line after all type declarations.

**Stdlib conformance records.** `Equatable`, `Hashable`, and `Comparable` conformances emit `getWitnessTable()` specializations and free operator templates (`==`, `!=`, `<`, `<=`, `>`, `>=`). ADL using declarations in the module namespace make operators visible to STL algorithms.

**Subset conversion operators.** `SwiftExistentialType<A, B, C>` implicitly converts to any `SwiftExistentialType<A>` or `SwiftExistentialType<B, C>` via generic conversion operators using the `ContainedIn` concept. The `_wtIndexOf` helper remaps witness table indices.

**Function signatures.** Swift functions taking or returning existential types emit C++ inline thunks that construct/destructure existential containers. Functions using existential types are guarded by `#if defined(SWIFT_CXX_EXISTENTIAL_INTEROP)` so C++14/17 code sees the underlying C thunks but not the C++ wrappers.

**ClangImporter round-trip.** C++ existential wrappers are recognized via `isSwiftExistentialType` (walks base classes to find `SwiftExistentialType`/`SwiftClassExistentialType`) and imported back as Swift existential types in function signatures. `@objc` protocols are excluded from wrapper emission since they use a different ABI.

### Current limitations

- **Stdlib protocol existentials** (`any Hashable`, `any Equatable`) as function parameters are skipped. The protocols themselves are ABI-frozen so witness table offsets are stable, but `Self`-constrained methods (`==`, `<`) require both operands to be the same concrete type at runtime.
- **Throwing, mutating, and static protocol requirements** are excluded from method emission.
- **Protocol requirements with associated type parameters** lose AT information. Only primary AT constraints on the existential type itself are supported.
- **Import context**: existential wrappers round-trip back to Swift existential types only in function parameter and return type positions. The general `VisitRecordType` path (struct fields, local variables, typedef bodies) returns `nullptr` for these record types.

### Test coverage

- `swift-protocol-in-cxx.swift`: wrapper emission for non-marker, marker, class-bound, PAT, ~Copyable, inherited-method, and boxing constructor protocols
- `swift-existential-in-function-cxx.swift`: existential parameters and returns in function signatures with `#if` guards
- `swift-composition-in-function-cxx.swift`: composition wrappers, composition parameters with implicit subset conversion, composition returns
- `swift-existential-type-in-cxx.swift`: scaffolding out-of-line method definitions
- `protocols-dispatch-execution.cpp`: end-to-end runtime verification of VWT copy/destroy, protocol method dispatch, inherited method two-level dispatch, conversion methods, boxing constructors, class-bound retain/release, move semantics, multi-requirement dispatch, large value outline storage
- `protocols-wrapper-execution.cpp`: runtime verification of ad-hoc composition construction, method dispatch on composition wrappers, accessor conversion
- `%check-interop-cxx-header-in-clang`: generated header compiles with Clang under `-Weverything -Werror` in C++14/17/20