### PR TITLE
Support ObjC protocols in the SIL metatype instruction

### DIFF
--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -26,6 +26,7 @@
 #include "GenMeta.h"
 #include "GenPack.h"
 #include "GenPointerAuth.h"
+#include "GenCast.h"
 #include "GenProto.h"
 #include "GenTuple.h"
 #include "GenType.h"
@@ -4050,6 +4051,60 @@ llvm::Value *irgen::emitClassHeapMetadataRef(IRGenFunction &IGF, CanType type,
   return result;
 }
 
+/// This is like emitClassHeapMetadataRef but additionally supports
+/// ObjC protocols.
+llvm::Value *irgen::emitObjCMetatypeRef(IRGenFunction &IGF, CanType type,
+                                        DynamicMetadataRequest request,
+                                        bool allowUninitialized) {
+  assert(request.canResponseStatusBeIgnored() &&
+         "emitClassConstrainedMetadataRef only supports satisfied requests");
+  assert(type->satisfiesClassConstraint());
+
+  if (auto archetype = dyn_cast<ArchetypeType>(type)) {
+    // Look up the Swift metadata from context.
+    auto archetypeMeta = IGF.emitTypeMetadataRef(type, request).getMetadata();
+    auto deploymentAvailability =
+        AvailabilityRange::forDeploymentTarget(IGF.IGM.Context);
+    auto getObjCMetatypeFromMetadataAvail =
+        IGF.IGM.Context.getGetObjCMetatypeFromMetadataAvailability();
+    // Use getObjCMetatypeFromMetadata if available. Otherwise, use old
+    // getObjCClassFromMetadata.
+    llvm::Value *metatypePtr = nullptr;
+    if (deploymentAvailability.isContainedIn(getObjCMetatypeFromMetadataAvail)) {
+      metatypePtr = emitObjCMetatypeForMetatype(IGF, archetypeMeta, archetype);
+    } else {
+      metatypePtr = emitClassHeapMetadataRefForMetatype(IGF, archetypeMeta,
+                                                        archetype);
+    }
+    return metatypePtr;
+  }
+
+  if (type.isObjCExistentialType()) {
+    auto layout = type.getExistentialLayout();
+    auto protocols = layout.getProtocols();
+    assert(protocols.size() == 1 && "ObjC existential should have one protocol");
+    llvm::Value *result = emitReferenceToObjCProtocol(IGF, protocols[0]);
+    result = IGF.emitObjCRetainCall(result);
+    return result;
+  }
+
+  if (ClassDecl *theClass = dyn_cast_or_null<ClassDecl>(type->getAnyNominal())) {
+    if (!hasKnownSwiftMetadata(IGF.IGM, theClass)) {
+      llvm::Value *result =
+          emitObjCHeapMetadataRef(IGF, theClass, allowUninitialized);
+      return result;
+    }
+  }
+
+  if (IGF.IGM.Context.LangOpts.hasFeature(Feature::Embedded)) {
+    llvm::Constant *result = IGF.IGM.getAddrOfTypeMetadata(type);
+    return result;
+  }
+
+  llvm::Value *result = IGF.emitTypeMetadataRef(type, request).getMetadata();
+  return result;
+}
+
 /// Emit a metatype value for a known type.
 void irgen::emitMetatypeRef(IRGenFunction &IGF, CanMetatypeType type,
                             Explosion &explosion) {
@@ -4063,9 +4118,8 @@ void irgen::emitMetatypeRef(IRGenFunction &IGF, CanMetatypeType type,
     break;
 
   case MetatypeRepresentation::ObjC:
-    explosion.add(emitClassHeapMetadataRef(IGF, type.getInstanceType(),
-                                           MetadataValueType::ObjCClass,
-                                           MetadataState::Complete));
+    explosion.add(emitObjCMetatypeRef(IGF, type.getInstanceType(),
+                                      MetadataState::Complete));
     break;
   }
 }

--- a/lib/IRGen/MetadataRequest.h
+++ b/lib/IRGen/MetadataRequest.h
@@ -672,6 +672,14 @@ llvm::Value *emitClassHeapMetadataRef(IRGenFunction &IGF, CanType type,
                                       DynamicMetadataRequest request,
                                       bool allowUninitialized = false);
 
+/// Emit a reference to the ObjC metatype for a class or protocol.
+///
+/// Only requests whose response status can be ignored can be used.
+///
+llvm::Value *emitObjCMetatypeRef(IRGenFunction &IGF, CanType type,
+                                 DynamicMetadataRequest request,
+                                 bool allowUninitialized = false);
+
 /// Emit a reference to the (initialized) ObjC heap metadata for a class.
 ///
 /// \returns a value of type ObjCClassPtrTy

--- a/test/IRGen/anyobject-cast-crash.swift
+++ b/test/IRGen/anyobject-cast-crash.swift
@@ -2,6 +2,9 @@
 // RUN: %target-build-swift %s -target %module-target-future -o %t/anyobject-cast-crash
 // RUN: %target-codesign %t/anyobject-cast-crash
 // RUN: %target-run %t/anyobject-cast-crash
+// RUN: %target-build-swift %s -target %module-target-future -O -o %t/anyobject-cast-crash-opt
+// RUN: %target-codesign %t/anyobject-cast-crash-opt
+// RUN: %target-run %t/anyobject-cast-crash-opt
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 


### PR DESCRIPTION
This fixes the assertion failure in the anyobject-cas-crash test with optimizations enabled.

rdar://180590931
