### PR TITLE
BorrowingForLoop: disable availability checking

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -3778,10 +3778,12 @@ public:
     seqConformanceRef = lookupConformance(seqType, sequenceProto);
     ASSERT(!seqConformanceRef.isInvalid() || seqType->isExistentialType());
 
-    if (auto constraint = seqConformanceRef.getAvailabilityConstraint(
-            dc, stmt->getForLoc())) {
-      emitDiagnosticsForUnavailableConformance(seqType, constraint.value());
-      return nullptr;
+    if (!ctx.LangOpts.DisableAvailabilityChecking) {
+      if (auto constraint = seqConformanceRef.getAvailabilityConstraint(
+              dc, stmt->getForLoc())) {
+        emitDiagnosticsForUnavailableConformance(seqType, constraint.value());
+        return nullptr;
+      }
     }
 
     buildMakeIteratorVar();


### PR DESCRIPTION
During ForEach desugaring, before querying `getAvailabilityConstraint` for a given conformance, we would not check whether availability checking had been disabled.
This results in emitting an error diagnostic when the `-disable-availability-checking` was explicitly passed to avoid that.


Resolves rdar://180771310.