### PR TITLE
build: Fix variable expansion in Windows CI script

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -125,7 +125,7 @@ set "args=%args% --skip-repository ninja"
 set "args=%args% --skip-repository swift-integration-tests"
 set "args=%args% --skip-repository swift-stress-tester"
 
-call "%SourceRoot%\swift\utils\update-checkout.cmd" %args% --clone --skip-history --reset-to-remote --github-comment "!ghprbCommentBody!"
+call "%SourceRoot%\swift\utils\update-checkout.cmd" %args% --clone --skip-history --reset-to-remote
 
 goto :eof
 endlocal

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -1002,14 +1002,15 @@ def main() -> int:
     validate_config(config)
 
     cross_repos_pr: Dict[str, str] = {}
-    if args.github_comment:
+    github_comment = args.github_comment or os.environ.get("ghprbCommentBody")
+    if github_comment:
         regex_pr = (
             r"(apple/[-a-zA-Z0-9_]+/pull/\d+"
             r"|apple/[-a-zA-Z0-9_]+#\d+"
             r"|swiftlang/[-a-zA-Z0-9_]+/pull/\d+"
             r"|swiftlang/[-a-zA-Z0-9_]+#\d+)"
         )
-        repos_with_pr = re.findall(regex_pr, args.github_comment)
+        repos_with_pr = re.findall(regex_pr, github_comment)
         print("Found related pull requests:", str(repos_with_pr))
         repos_with_pr = [pr.replace("/pull/", "#") for pr in repos_with_pr]
         cross_repos_pr = dict(pr.split("#") for pr in repos_with_pr)


### PR DESCRIPTION
Remove the `--github-comment "!ghprbCommentBody!"` argument from the update-checkout call in build-windows-toolchain.bat. cmd.exe delayed expansion injects the variable's value directly into the command line, so shell metacharacters in a GitHub PR comment body (`&`, `|`, `>`) could cause quoting or text escaping issues.

Instead, update_checkout.py now reads ghprbCommentBody directly from the environment when --github-comment is not passed on the command line.

Execution trace showing no functionality is lost:

  build-windows-toolchain.bat (:CloneRepositories, line 128)
    → call update-checkout.cmd %args% ...
    → update-checkout.cmd: python "%~dp0\update-checkout" %*
    → update_checkout.main() (update_checkout.py:972)
    → github_comment = args.github_comment or os.environ.get("ghprbCommentBody")
    → if github_comment: <extract cross-repo PRs via regex>

Previously: bat expanded !ghprbCommentBody! into the command line → argparse stored it in args.github_comment → used at line 1005.

Now: Python reads the same value safely from os.environ → same regex extraction, same cross_repos_pr dict, no shell interpretation.