### PR TITLE
Fix false-positive `#IsolatedConformances` warning for actor-isolated default value initializers

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4134,6 +4134,20 @@ namespace {
       if (!unsatisfiedIsolation)
         return false;
 
+      // Record whether the callee isolation or the context isolation
+      // is preconcurrency, which is used later to downgrade errors to
+      // warnings in minimal checking.
+      bool preconcurrency = getContextIsolation().preconcurrency() ||
+          (calleeDecl && getActorIsolation(calleeDecl).preconcurrency());
+      unsatisfiedIsolation =
+          unsatisfiedIsolation->withPreconcurrency(preconcurrency);
+
+      bool onlyArgsCrossIsolation = callOptions.contains(
+          ActorReferenceResult::Flags::OnlyArgsCrossIsolation);
+      if (!onlyArgsCrossIsolation &&
+          refineRequiredIsolation(*unsatisfiedIsolation))
+        return false;
+
       // Check for isolated conformances escaping through the callee's
       // generic substitutions across the isolation boundary.
       {
@@ -4151,20 +4165,6 @@ namespace {
               RefineConformances{*this});
         }
       }
-
-      // Record whether the callee isolation or the context isolation
-      // is preconcurrency, which is used later to downgrade errors to
-      // warnings in minimal checking.
-      bool preconcurrency = getContextIsolation().preconcurrency() ||
-          (calleeDecl && getActorIsolation(calleeDecl).preconcurrency());
-      unsatisfiedIsolation =
-          unsatisfiedIsolation->withPreconcurrency(preconcurrency);
-
-      bool onlyArgsCrossIsolation = callOptions.contains(
-          ActorReferenceResult::Flags::OnlyArgsCrossIsolation);
-      if (!onlyArgsCrossIsolation &&
-          refineRequiredIsolation(*unsatisfiedIsolation))
-        return false;
 
       // At this point, we know a jump is made to the callee that yields
       // an isolation requirement unsatisfied by the calling context, so

--- a/test/Concurrency/isolated_conformance_generic_escape.swift
+++ b/test/Concurrency/isolated_conformance_generic_escape.swift
@@ -185,3 +185,15 @@ func test() async {
   // @MainActor callee — same caller isolation, this is allowed
   await callDoSomethingFromMainActor(MyClass())
 }
+
+protocol DefaultInitProtocol {
+  init()
+}
+
+@MainActor
+func passthrough<T: DefaultInitProtocol>(_ t: T) -> T { t }
+
+@MainActor
+struct DefaultValueContainer<T: DefaultInitProtocol> {
+  let value = passthrough(T()) // ok, default-value initializer adopts the callee's @MainActor isolation
+}


### PR DESCRIPTION
## Description

resolve: #90243

A false-positive `#IsolatedConformances` isolation-crossing warning was emitted for actor-isolated default value initializers, even when no isolation boundary is actually crossed.

The cause was ordering in `TypeCheckConcurrency.cpp`: the isolated-conformance crossing check ran before `refineRequiredIsolation`. An isolation of a default value initializer is resolved by the refinement but the warning had already been produced.

This moves the isolated-conformance crossing check to *after* `refineRequiredIsolation`

## Changes

- `lib/Sema/TypeCheckConcurrency.cpp`: run the isolated-conformance crossing check after isolation refinement.
- `test/Concurrency/isolated_conformance_generic_escape.swift`: add a regression test for the default value initializer case.