### PR TITLE
[Embedded] Diagnose uses of _openExistential in Embedded Swift

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8954,6 +8954,11 @@ GROUPED_WARNING(dynamic_cast_involving_protocol_in_embedded_swift,
                 "cannot perform a dynamic cast to a type involving %kind0 in Embedded Swift",
                 (const Decl *))
 
+GROUPED_WARNING(open_existential_in_embedded_swift,
+                EmbeddedRestrictions, none,
+                "cannot open existential type %0 in Embedded Swift",
+                (Type))
+
 GROUPED_ERROR(self_referential_superclass_in_embedded_swift,
               EmbeddedRestrictions, none,
               "class %0 cannot inherit from %1 in Embedded Swift because "

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -2427,7 +2427,7 @@ bool swift::specializeClassMethodInst(ClassMethodInst *cm) {
     classTy = classTy.getLoweredInstanceTypeOfMetatype(cm->getFunction());
 
   CanType astType = classTy.getASTType();
-  if (!astType->isSpecialized())
+  if (!astType->isSpecialized() || astType->hasPrimaryArchetype())
     return false;
 
   SubstitutionMap subs = astType->getContextSubstitutionMap();

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8481,6 +8481,16 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
           OpenExistentialExpr(existential, opaqueValue, callSubExpr,
                               resultTy);
         cs.setType(replacement, resultTy);
+
+        // Embedded Swift prohibits opened existentials.
+        if (auto behavior = shouldDiagnoseEmbeddedLimitations(
+                dc, apply->getLoc())) {
+          ctx.Diags.diagnose(apply->getLoc(),
+                             diag::open_existential_in_embedded_swift,
+                             existentialInstanceTy)
+            .limitBehavior(*behavior);
+        }
+
         return replacement;
       }
       

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -1118,6 +1118,7 @@ func __abi_withoutActuallyEscaping<ClosureType, ResultType>(
   Builtin.unreachable()
 }
 
+@_unavailableInEmbedded
 @_alwaysEmitIntoClient
 @_transparent
 @_semantics("typechecker._openExistential(_:do:)")
@@ -1134,6 +1135,7 @@ public func _openExistential<ExistentialType, ContainedType, ResultType, Failure
   Builtin.unreachable()
 }
 
+#if !hasFeature(Embedded)
 @usableFromInline
 @_silgen_name("$ss16_openExistential_2doq0_x_q0_q_KXEtKr1_lF")
 func __abi_openExistential<ExistentialType, ContainedType, ResultType>(
@@ -1148,6 +1150,7 @@ func __abi_openExistential<ExistentialType, ContainedType, ResultType>(
      as StaticString).utf8Start._rawValue)
   Builtin.unreachable()
 }
+#endif
 
 /// Given a string that is constructed from a string literal, return a pointer
 /// to the global string table location that contains the string literal.

--- a/test/embedded/restrictions.swift
+++ b/test/embedded/restrictions.swift
@@ -160,3 +160,21 @@ func stillNotProblematicAtAll(object: AnyObject) throws {
   }
 }
 #endif
+
+// ---------------------------------------------------------------------------
+// Existential opening is not permitted
+// ---------------------------------------------------------------------------
+
+func acceptP<T: P>(_ t: T) { }
+
+func openme(p: any P) {
+  func generic<T: P>(_ t: T) { }
+
+  // explicit opening
+  // expected-warning@+1{{cannot open existential type 'any P' in Embedded Swift}}
+  _openExistential(p, do: generic)
+
+  // implicit opening
+  // expected-warning@+1{{cannot use generic global function 'acceptP' on a value of type 'any P' in Embedded Swift}}
+  acceptP(p)
+}


### PR DESCRIPTION
_openExistential is an explicit (albeit undocumented) way of opening existentials, which cannot be supported in Embedded Swift. Mark it as @_unavailableInEmbedded, but because the type checker pattern-matches calls to it, also add a sema diagnostic for such calls. The annotation on the function is effectively for documentation purposes.

The SIL change is a backstop for cases where a generic class_method instruction slips through to the optimizer, because we're staging in this diagnostic as a warning.