### PR TITLE
[Interop] Allow Swift overrides of ObjC methods with C++ types

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2493,7 +2493,8 @@ static void emitEntryPointArgumentsCOrObjC(IRGenSILFunction &IGF,
   emitPolymorphicParameters(
       IGF, *IGF.CurSILFn, *emission, nullptr,
       [&](unsigned paramIndex) -> llvm::Value * {
-        SILValue parameter = entry->getArguments()[paramIndex];
+        SILValue parameter =
+            IGF.CurSILFn->getArgumentsWithoutIndirectResults()[paramIndex];
         return IGF.getLoweredSingletonExplosion(parameter);
       });
 }

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -31,6 +31,7 @@
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/StringExtras.h"
 
+#include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclObjC.h"
 
 using namespace swift;
@@ -815,31 +816,44 @@ bool swift::isRepresentableInLanguage(
   if (auto init = dyn_cast<ConstructorDecl>(AFD))
     isSpecialInit = init->isObjCZeroParameterWithLongSelector();
 
-  if (!isSpecialInit &&
-      !isParamListRepresentableInLanguage(AFD,
-                                          AFD->getParameters(),
-                                          Reason)) {
-    return false;
+  // When overriding a Clang-imported ObjC(++) method, the parameter and return
+  // types are guaranteed to match the base (enforced by the override matcher).
+  // Clang already validated those types for ObjC++, so skip the Swift-side
+  // representability checks that would otherwise reject C++ record types.
+  bool overridesClangImport = false;
+  if (Reason == ObjCReason::OverridesObjC) {
+    if (auto *overridden = AFD->getOverriddenDecl())
+      overridesClangImport = overridden->hasClangNode();
   }
 
-  if (auto FD = dyn_cast<FuncDecl>(AFD)) {
-    Type ResultType = FD->mapTypeIntoEnvironment(FD->getResultInterfaceType());
-    if (!FD->hasAsync() &&
-        !ResultType->hasError() &&
-        !ResultType->isVoid() &&
-        !ResultType->isUninhabited() &&
-        !ResultType->isRepresentableIn(language,
-                                       const_cast<FuncDecl *>(FD))) {
-      softenIfAccessNote(AFD, Reason.getAttr(),
-       AFD->diagnose(diag::objc_invalid_on_func_result_type,
-                     FD, getObjCDiagnosticAttrKind(Reason),
-                     language)
-            .limitBehavior(behavior));
-      diagnoseTypeNotRepresentableInObjC(FD, ResultType,
-                                         FD->getResultTypeSourceRange(),
-                                         behavior, Reason);
-      Reason.describe(FD);
+  if (!overridesClangImport) {
+    if (!isSpecialInit &&
+        !isParamListRepresentableInLanguage(AFD,
+                                            AFD->getParameters(),
+                                            Reason)) {
       return false;
+    }
+
+    if (auto FD = dyn_cast<FuncDecl>(AFD)) {
+      Type ResultType =
+          FD->mapTypeIntoEnvironment(FD->getResultInterfaceType());
+      if (!FD->hasAsync() &&
+          !ResultType->hasError() &&
+          !ResultType->isVoid() &&
+          !ResultType->isUninhabited() &&
+          !ResultType->isRepresentableIn(language,
+                                         const_cast<FuncDecl *>(FD))) {
+        softenIfAccessNote(AFD, Reason.getAttr(),
+         AFD->diagnose(diag::objc_invalid_on_func_result_type,
+                       FD, getObjCDiagnosticAttrKind(Reason),
+                       language)
+              .limitBehavior(behavior));
+        diagnoseTypeNotRepresentableInObjC(FD, ResultType,
+                                           FD->getResultTypeSourceRange(),
+                                           behavior, Reason);
+        Reason.describe(FD);
+        return false;
+      }
     }
   }
 

--- a/test/Interop/Cxx/objc-correctness/Inputs/module.modulemap
+++ b/test/Interop/Cxx/objc-correctness/Inputs/module.modulemap
@@ -49,3 +49,9 @@ module CxxForeignRef {
   header "cxx-frt.h"
   requires cplusplus
 }
+
+module ObjCBaseWithCxxParams {
+  header "objc-base-with-cxx-params.h"
+  requires objc
+  requires cplusplus
+}

--- a/test/Interop/Cxx/objc-correctness/Inputs/objc-base-with-cxx-params.h
+++ b/test/Interop/Cxx/objc-correctness/Inputs/objc-base-with-cxx-params.h
@@ -1,0 +1,17 @@
+#import <Foundation/Foundation.h>
+
+class CxxRecord {
+public:
+    CxxRecord() : value(0) {}
+    CxxRecord(int v) : value(v) {}
+    CxxRecord(const CxxRecord &other) : value(other.value) {}
+    ~CxxRecord() {}
+
+    int value;
+};
+
+@interface ObjCBase : NSObject
+- (CxxRecord)getRecord;
+- (void)processRecord:(CxxRecord)record;
+- (CxxRecord)transformRecord:(CxxRecord)input;
+@end

--- a/test/Interop/Cxx/objc-correctness/Inputs/objc-base-with-cxx-params.mm
+++ b/test/Interop/Cxx/objc-correctness/Inputs/objc-base-with-cxx-params.mm
@@ -1,0 +1,13 @@
+#import "objc-base-with-cxx-params.h"
+
+@implementation ObjCBase
+- (CxxRecord)getRecord {
+    return CxxRecord(100);
+}
+- (void)processRecord:(CxxRecord)record {
+    // base does nothing
+}
+- (CxxRecord)transformRecord:(CxxRecord)input {
+    return CxxRecord(input.value * 2);
+}
+@end

--- a/test/Interop/Cxx/objc-correctness/objc-override-cxx-param-types-execution.swift
+++ b/test/Interop/Cxx/objc-correctness/objc-override-cxx-param-types-execution.swift
@@ -1,0 +1,56 @@
+// RUN: %empty-directory(%t2)
+
+// RUN: %target-interop-build-clangxx -c %S/Inputs/objc-base-with-cxx-params.mm -o %t2/objc-base-impl.o -fobjc-arc
+
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -Xcc -fignore-exceptions -Xlinker %t2/objc-base-impl.o) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Foundation
+import ObjCBaseWithCxxParams
+
+class SwiftSub: ObjCBase {
+    override func getRecord() -> CxxRecord {
+        return CxxRecord(42)
+    }
+
+    override func processRecord(_ record: CxxRecord) {
+        print("processRecord: \(record.value)")
+    }
+
+    override func transform(_ input: CxxRecord) -> CxxRecord {
+        return CxxRecord(input.value + 1)
+    }
+}
+
+func testDynamicDispatch() {
+    let obj: ObjCBase = SwiftSub()
+
+    let r = obj.getRecord()
+    print("getRecord: \(r.value)")
+
+    obj.processRecord(CxxRecord(99))
+
+    let t = obj.transform(CxxRecord(10))
+    print("transformRecord: \(t.value)")
+}
+
+func testBaseClass() {
+    let base = ObjCBase()
+
+    let r = base.getRecord()
+    print("base getRecord: \(r.value)")
+
+    let t = base.transform(CxxRecord(10))
+    print("base transformRecord: \(t.value)")
+}
+
+testDynamicDispatch()
+testBaseClass()
+
+// CHECK: getRecord: 42
+// CHECK-NEXT: processRecord: 99
+// CHECK-NEXT: transformRecord: 11
+// CHECK-NEXT: base getRecord: 100
+// CHECK-NEXT: base transformRecord: 20

--- a/test/Interop/Cxx/objc-correctness/objc-override-cxx-param-types-irgen.swift
+++ b/test/Interop/Cxx/objc-correctness/objc-override-cxx-param-types-irgen.swift
@@ -1,0 +1,53 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend %t/test.swift -I %t/Inputs -import-objc-header %t/Inputs/header.h -cxx-interoperability-mode=default -emit-ir -o - | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+//--- Inputs/header.h
+
+#import <Foundation/Foundation.h>
+
+class CxxRecord {
+public:
+    CxxRecord() : value(0) {}
+    CxxRecord(int v) : value(v) {}
+    CxxRecord(const CxxRecord &other) : value(other.value) {}
+    ~CxxRecord() {}
+
+    int value;
+};
+
+@interface ObjCBase : NSObject
+- (CxxRecord)getRecord;
+- (void)processRecord:(CxxRecord)record;
+@end
+
+//--- Inputs/module.modulemap
+
+module CxxObjCTypes {
+    header "header.h"
+    requires cplusplus
+    export *
+}
+
+//--- test.swift
+
+import Foundation
+import CxxObjCTypes
+
+class SwiftSub: ObjCBase {
+    override func getRecord() -> CxxRecord {
+        return CxxRecord(42)
+    }
+
+    override func processRecord(_ record: CxxRecord) {
+    }
+}
+
+// The @objc thunk for getRecord returns via sret (indirect return for non-trivial C++ type).
+// CHECK: define internal void @"$s4test8SwiftSubC9getRecordSo03CxxE0VyFTo"(ptr noalias sret({{.*}}) %0, ptr %1, ptr %2)
+
+// The @objc thunk for processRecord takes the C++ record as an indirect parameter.
+// CHECK: define internal void @"$s4test8SwiftSubC13processRecordyySo03CxxE0VFTo"(ptr %0, ptr %1, ptr %2)

--- a/test/Interop/Cxx/objc-correctness/objc-override-cxx-param-types.swift
+++ b/test/Interop/Cxx/objc-correctness/objc-override-cxx-param-types.swift
@@ -1,0 +1,80 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -typecheck -I %t/Inputs -cxx-interoperability-mode=default -verify -verify-ignore-unrelated %t/test.swift
+
+// REQUIRES: objc_interop
+
+//--- Inputs/header.h
+
+#import <Foundation/Foundation.h>
+
+struct TrivialCxxStruct {
+    int x;
+    int y;
+};
+
+class NonTrivialCxxStruct {
+public:
+    NonTrivialCxxStruct() : x(0), y(0) {}
+    NonTrivialCxxStruct(int x, int y) : x(x), y(y) {}
+    NonTrivialCxxStruct(const NonTrivialCxxStruct &other) : x(other.x), y(other.y) {}
+    ~NonTrivialCxxStruct() {}
+
+    int x;
+    int y;
+};
+
+@interface BaseObjCClass : NSObject
+
+- (TrivialCxxStruct)getTrivialStruct;
+- (void)processTrivialStruct:(TrivialCxxStruct)s;
+- (TrivialCxxStruct)transformTrivial:(TrivialCxxStruct)input;
+
+- (NonTrivialCxxStruct)getNonTrivialStruct;
+- (void)processNonTrivialStruct:(NonTrivialCxxStruct)s;
+- (NonTrivialCxxStruct)transformNonTrivial:(NonTrivialCxxStruct)input;
+
+@end
+
+//--- Inputs/module.modulemap
+
+module CxxObjCBase {
+    header "header.h"
+    requires cplusplus
+    export *
+}
+
+//--- test.swift
+
+import Foundation
+import CxxObjCBase
+
+// expected-no-diagnostics
+
+class SwiftSubclass: BaseObjCClass {
+    // Trivial C++ struct overrides should work.
+    override func getTrivialStruct() -> TrivialCxxStruct {
+        return TrivialCxxStruct(x: 42, y: 43)
+    }
+
+    override func processTrivialStruct(_ s: TrivialCxxStruct) {
+    }
+
+    override func transformTrivial(_ input: TrivialCxxStruct) -> TrivialCxxStruct {
+        return TrivialCxxStruct(x: input.x + 1, y: input.y + 1)
+    }
+
+    // Non-trivial C++ struct overrides should also work when overriding
+    // imported ObjC methods -- Clang already validated these types for ObjC++.
+    override func getNonTrivialStruct() -> NonTrivialCxxStruct {
+        return NonTrivialCxxStruct(0, 0)
+    }
+
+    override func processNonTrivialStruct(_ s: NonTrivialCxxStruct) {
+    }
+
+    override func transformNonTrivial(_ input: NonTrivialCxxStruct) -> NonTrivialCxxStruct {
+        return input
+    }
+}


### PR DESCRIPTION
## Summary

When a Swift class subclasses an ObjC class imported from an ObjC++ header, it cannot override methods whose signatures contain non-trivial C++ record types. This PR fixes that with two changes:

- **Sema**: skip param/return type representability checks in `isRepresentableInLanguage` when the method is an override of a Clang-imported method (`ObjCReason::OverridesObjC` + `hasClangNode()`). The override matcher already enforces type compatibility with the base declaration, and Clang validated the types for ObjC++ at import time.

- **IRGen**: fix a latent parameter index bug in `emitEntryPointArgumentsCOrObjC`. The `emitPolymorphicParameters` callback indexed into `entry->getArguments()`, which includes indirect results (`@out`). For methods returning address-only types (non-trivial C++ records via sret), `paramIndex=0` (self) hits the indirect result address instead, crashing in `getSingletonExplosion`. Changed to `getArgumentsWithoutIndirectResults()` to match the native CC path.

The IRGen fix is not independently testable today as no address-only type currently passes the `@objc` representability gate, but it is the foundation for any future work that allows address-only types in `@objc` signatures in swift including:

- #90062 -- Expanding on nontrivial C struct representation in ObjC mode

## Prior art

Builds on foundational work by @ahatanaka:
- #73019 -- introduced the `@in_cxx` parameter convention for non-trivial C++ classes passed indirectly, which the `@objc` thunk uses for parameters
- #71459 -- fixed a related sret annotation bug in `expandExternalSignatureTypes` for ObjC methods returning results indirectly

## Test plan

- `objc-override-cxx-param-types.swift` -- Sema test verifying overrides of both trivial and non-trivial C++ struct methods compile without diagnostics
- `objc-override-cxx-param-types-irgen.swift` -- IRGen test verifying the `@objc` thunks emit correct IR (sret for return, indirect pointer for params)
- `objc-override-cxx-param-types-execution.swift` -- Execution test verifying runtime dispatch correctness: Swift overrides dispatch correctly through ObjC runtime via a base-typed reference
- `at-objc-api-using-non-trivial-cxx.swift` -- existing test still passes (explicit `@objc` with non-trivial C++ types correctly rejected)