### PR TITLE
[AST] Fix false NonSendableSuperclass diagnostic for cross-module @MainActor ObjC classes

### DIFF
--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -988,6 +988,31 @@ ConformanceLookupTable::getConformance(NominalTypeDecl *nominal,
       inheritedTypeRepr = entry->Source.getInheritedTypeRepr();
     }
 
+    // If this is a Sendable conformance on a class whose superclass is
+    // already Sendable, form an inherited conformance instead of a
+    // normal one. The superclass's implicit Sendable (e.g. from
+    // @MainActor isolation) may not have been in the conformance table
+    // when inherited conformances were collected, so the table may only
+    // have an Implied or Explicit entry. Fixing up here keeps
+    // isa<InheritedProtocolConformance> correct for downstream
+    // diagnostics regardless of entry kind.
+    if (protocol->isSpecificProtocol(KnownProtocolKind::Sendable)) {
+      if (auto *classDecl = dyn_cast<ClassDecl>(nominal)) {
+        if (auto *superclassDecl = classDecl->getSuperclassDecl()) {
+          Type superclassTy = type->getSuperclassForDecl(superclassDecl);
+          if (superclassTy) {
+            auto superConf = swift::lookupConformance(
+                superclassTy, protocol, /*allowMissing=*/false);
+            if (superConf.isConcrete()) {
+              entry->Conformance = ctx.getInheritedConformance(
+                  type, superConf.getConcrete());
+              return cast<ProtocolConformance *>(entry->Conformance);
+            }
+          }
+        }
+      }
+    }
+
     // Create or find the normal conformance.
     auto normalConf = ctx.getNormalConformance(
         conformingType, protocol, conformanceLoc, inheritedTypeRepr,

--- a/test/Concurrency/nonsendable_superclass_objc.swift
+++ b/test/Concurrency/nonsendable_superclass_objc.swift
@@ -1,0 +1,172 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/src)
+// RUN: %empty-directory(%t/sdk)
+// RUN: %empty-directory(%t/sdk/ObjCActorModule)
+// RUN: split-file %s %t/src
+
+// Build ObjC module
+// RUN: %target-clang -fmodules -dynamiclib %t/src/ObjCActorModule.m -I %t/src -o %t/sdk/ObjCActorModule/libObjCActorModule.dylib -lobjc -framework Foundation
+// RUN: cp %t/src/ObjCActorModule.modulemap %t/sdk/ObjCActorModule/module.modulemap
+// RUN: cp %t/src/ObjCActorModule.h %t/sdk/ObjCActorModule/ObjCActorModule.h
+
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -strict-concurrency=complete %t/src/main.swift -emit-sil -o /dev/null -verify -I %t/sdk/ObjCActorModule
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %t/src/main.swift -emit-sil -o /dev/null -verify -verify-additional-prefix swift6- -swift-version 6 -I %t/sdk/ObjCActorModule
+
+// REQUIRES: concurrency
+// REQUIRES: objc_interop
+
+//--- ObjCActorModule.modulemap
+
+module ObjCActorModule {
+  header "ObjCActorModule.h"
+  export *
+}
+
+//--- ObjCActorModule.h
+
+#import <Foundation/Foundation.h>
+
+// Models the UIKit chain: NSObject -> @MainActor UIResponder -> @MainActor UIViewController/UIView
+// The entire chain is @MainActor-isolated with a Sendable root (NSObject).
+
+__attribute__((swift_attr("@MainActor")))
+@interface ObjCResponder : NSObject
+@end
+
+__attribute__((swift_attr("@MainActor")))
+@interface ObjCController : ObjCResponder
+@end
+
+__attribute__((swift_attr("@MainActor")))
+@interface ObjCView : ObjCResponder
+@end
+
+//--- ObjCActorModule.m
+
+#import "ObjCActorModule.h"
+
+@implementation ObjCResponder
+@end
+
+@implementation ObjCController
+@end
+
+@implementation ObjCView
+@end
+
+//--- main.swift
+
+import ObjCActorModule
+
+// ============================================================================
+// Implied Sendable through protocol refinement
+// ============================================================================
+//
+// When Sendable comes through a protocol (e.g. MyDelegate: Sendable),
+// the conformance table builds it as Implied -> NormalProtocolConformance
+// because the superclass's implicit Sendable from @MainActor wasn't in
+// the table yet when the Inherited stage ran.
+//
+// The protocol conformance must be checked BEFORE any code that would
+// trigger eager Sendable derivation on ObjCController (e.g. a
+// requiresSendable() call), because early derivation masks the bug by
+// materializing an InheritedProtocolConformance.
+
+protocol MyDelegate: Sendable {
+  func didDoThing()
+}
+
+@MainActor
+final class MyDelegateController: ObjCController {}
+
+extension MyDelegateController: @preconcurrency MyDelegate {
+  func didDoThing() {}
+}
+
+@MainActor
+protocol MyIsolatedDelegate: Sendable {
+  func didDoThing()
+}
+
+@MainActor
+final class MyIsolatedDelegateController: ObjCController, MyIsolatedDelegate {
+  func didDoThing() {}
+}
+
+// ============================================================================
+// Explicit Sendable on @MainActor classes with @MainActor ObjC superclasses
+// ============================================================================
+//
+// Real-world pattern: @MainActor final classes that inherit from UIView or
+// UIViewController (modeled here as ObjCView / ObjCController) and explicitly
+// declare Sendable. The superclass chain is @MainActor all the way down to
+// NSObject, so the superclass IS Sendable. No diagnostic should fire.
+
+@MainActor
+final class ExplicitSendableView: ObjCView, Sendable {}
+
+@MainActor
+final class ExplicitSendableController: ObjCController, Sendable {}
+
+// Public @MainActor view subclass with explicit Sendable, matching the
+// pattern of public UI component views.
+@MainActor
+public final class PublicExplicitSendableView: ObjCView, Sendable {}
+
+// ============================================================================
+// Non-final @MainActor classes with explicit Sendable
+// ============================================================================
+//
+// A non-final @MainActor class with a Sendable superclass chain is
+// still valid: subclasses inherit @MainActor isolation, so they can't
+// add unsynchronized state. The non-final restriction only applies to
+// non-isolated classes.
+
+@MainActor
+class NonFinalExplicitSendableController: ObjCController, Sendable {}
+
+// ============================================================================
+// Implicit Sendable (no explicit annotation)
+// ============================================================================
+//
+// ObjC defines:
+//   @MainActor ObjCResponder : NSObject
+//   @MainActor ObjCController : ObjCResponder
+//   @MainActor ObjCView : ObjCResponder
+//
+// Swift subclasses inherit @MainActor isolation and should be implicitly
+// Sendable with no diagnostic.
+
+class MyController: ObjCController {} // no diagnostic expected
+class MyView: ObjCView {} // no diagnostic expected
+
+// ============================================================================
+// Verify all of the above are usable as Sendable
+// ============================================================================
+
+func requiresSendable<T: Sendable>(_: T) {}
+func testObjCChainIsSendable(
+  _ r: ObjCResponder,
+  _ c: ObjCController,
+  _ v: ObjCView,
+  _ mc: MyController,
+  _ mv: MyView,
+  _ dc: MyDelegateController,
+  _ ic: MyIsolatedDelegateController,
+  _ ec: ExplicitSendableController,
+  _ ev: ExplicitSendableView,
+  _ pv: PublicExplicitSendableView,
+  _ nf: NonFinalExplicitSendableController
+) {
+  requiresSendable(r)
+  requiresSendable(c)
+  requiresSendable(v)
+  requiresSendable(mc)
+  requiresSendable(mv)
+  requiresSendable(dc)
+  requiresSendable(ic)
+  requiresSendable(ec)
+  requiresSendable(ev)
+  requiresSendable(pv)
+  requiresSendable(nf)
+}

--- a/test/Concurrency/sendable_conformance_checking_cross_file_isolated_objc.swift
+++ b/test/Concurrency/sendable_conformance_checking_cross_file_isolated_objc.swift
@@ -42,10 +42,10 @@ extension IsolatedObjCClass: Sendable {}
 // expected-note@-2 {{add '@retroactive' to silence this warning}}
 // expected-warning@-3:1 {{conformance to 'Sendable' must occur in the same source file as class 'IsolatedObjCClass'; use '@unchecked Sendable' for retroactive conformance; this will be an error in a future Swift language mode}}
 
+// InheritsObjCIsolation's superclass (IsolatedObjCBase) is @MainActor and
+// therefore Sendable. The conformance is inherited, so no retroactive or
+// cross-file warnings fire.
 extension InheritsObjCIsolation: Sendable {}
-// expected-warning@-1:1 {{extension declares a conformance of imported type 'InheritsObjCIsolation' to imported protocol 'Sendable'; this will not behave correctly if the owners of 'IsolatedObjC' introduce this conformance in the future}}
-// expected-note@-2 {{add '@retroactive' to silence this warning}}
-// expected-warning@-3:1 {{conformance to 'Sendable' must occur in the same source file as class 'InheritsObjCIsolation'; use '@unchecked Sendable' for retroactive conformance; this will be an error in a future Swift language mode}}
 
 // Clang imported + implied is totally ignored, not sure this is correct but its the existing behavior.
 extension RefinedObjCClass: RefinesSendable {}


### PR DESCRIPTION
## Summary

Fixes `ConformanceLookupTable::getConformance()` to correctly represent Sendable conformances on classes whose superclasses are already Sendable through `@MainActor` isolation.

When the table materializes a Sendable conformance (whether Implied from a protocol refinement or Explicit from the user writing `, Sendable`), it now calls `lookupConformance` on the superclass. If the superclass conforms, it forms an `InheritedProtocolConformance` instead of a `NormalProtocolConformance`.

### Root cause

The conformance table build order for a class like `MyController: ObjCController` is:

1. **Inherited stage** -- resolves the superclass's table to Resolved, walks it via `inheritConformances`
2. **ExpandedImplied stage** -- expands protocol inheritance (e.g. `MyDelegate: Sendable`) and adds Implied entries
3. **Resolved stage** -- resolves conflicts

At step 1, the superclass's implicit Sendable from `@MainActor` isolation hasn't been derived yet (it's lazy, via `ImplicitKnownProtocolConformanceRequest`). So `inheritConformances` never finds it, no Inherited entry is created, and the Implied or Explicit entry from step 2 wins uncontested. `getConformance()` builds a `NormalProtocolConformance`, `isa<InheritedProtocolConformance>` returns false downstream, and `checkSendableConformance` emits a spurious `concurrent_value_nonsendable_superclass` diagnostic.

### Patterns fixed

All patterns below model real-world code in large Swift 6 codebases where `@MainActor` classes inherit from UIKit superclasses and declare `Sendable`:

| # | Pattern | Entry Kind |
|---|---------|-----------|
| 1 | `final class: ObjCController` + `@preconcurrency MyDelegate: Sendable` | Implied |
| 2 | `final class: ObjCController, @MainActor MyIsolatedDelegate` (refines Sendable) | Implied |
| 3 | `@MainActor final class: ObjCController, Sendable` | Explicit |
| 4 | `@MainActor class (non-final): ObjCController, Sendable` | Explicit |

### SE basis

Per [SE-0316](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0316-global-actors.md): *"A non-protocol type that is annotated with a global actor implicitly conforms to `Sendable`."* No `final` restriction. And: *"A subclass of a global-actor-annotated class must be isolated to the same global actor."* So `@MainActor` Sendable conformance propagates through inheritance, and non-final `@MainActor` classes are safe.

The non-final class diagnostic (`concurrent_value_nonfinal_class`) already correctly exempts `@MainActor` classes at line 7668: `if (!isSemanticallyFinal() && !isGlobalActorIsolated)`.

### Relationship to #90288

Orthogonal to #90288 (which downgrades the diagnostic to a warning for global-actor-isolated types). #90288 stages the diagnostic; this PR fixes the conformance representation so `isa<InheritedProtocolConformance>` returns the correct answer at the source. Anything keying off conformance kind gets the right answer, not just this one diagnostic.

## Test plan

- New `test/Concurrency/nonsendable_superclass_objc.swift` covers all 4 fixed patterns plus implicit-Sendable cases (which were never broken) with both `-strict-concurrency=complete` and `-swift-version 6`.
- Cross-module ObjC test module models the UIKit chain: `NSObject -> @MainActor ObjCResponder -> @MainActor ObjCController / ObjCView`.
- Verified locally that all patterns compile with no diagnostic.