### PR TITLE
[test][Distributed] Fix two Runtime tests under remote execution

### DIFF
--- a/test/Distributed/Runtime/distributed_actor_cross_module_final_class_adhoc_requirement_not_optimized_away.swift
+++ b/test/Distributed/Runtime/distributed_actor_cross_module_final_class_adhoc_requirement_not_optimized_away.swift
@@ -1,7 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -target %target-cpu-apple-macosx13.0 -parse-as-library -emit-library -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems %S/../Inputs/FakeDistributedActorSystems.swift -o %t/%target-library-name(FakeDistributedActorSystems)
+// RUN: %target-build-swift -target %target-cpu-apple-macosx13.0 -parse-as-library -emit-library -Xlinker -install_name -Xlinker @executable_path/%target-library-name(FakeDistributedActorSystems) -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems %S/../Inputs/FakeDistributedActorSystems.swift -o %t/%target-library-name(FakeDistributedActorSystems)
 // RUN: %target-build-swift -target %target-cpu-apple-macosx13.0 -parse-as-library -lFakeDistributedActorSystems -module-name main -I %t -L %t %s -o %t/a.out
-// RUN: %target-run %t/a.out | %FileCheck %s
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out %t/%target-library-name(FakeDistributedActorSystems) | %FileCheck %s
 
 // REQUIRES: OS=macosx && (CPU=x86_64 || CPU=arm64)
 // REQUIRES: executable_test

--- a/test/Distributed/Runtime/distributed_actor_library_evolution_da_protocol_use.swift
+++ b/test/Distributed/Runtime/distributed_actor_library_evolution_da_protocol_use.swift
@@ -8,11 +8,11 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-build-swift -Xfrontend -validate-tbd-against-ir=all -enable-library-evolution -target %target-swift-5.9-abi-triple -parse-as-library -emit-library -emit-module-path %t/Library.swiftmodule -module-name Library %t/library.swift -o %t/%target-library-name(Library)
+// RUN: %target-build-swift -Xfrontend -validate-tbd-against-ir=all -enable-library-evolution -target %target-swift-5.9-abi-triple -parse-as-library -emit-library -Xlinker -install_name -Xlinker @executable_path/%target-library-name(Library) -emit-module-path %t/Library.swiftmodule -module-name Library %t/library.swift -o %t/%target-library-name(Library)
 // RUN: %target-build-swift -Xfrontend -validate-tbd-against-ir=all -target %target-swift-5.9-abi-triple -parse-as-library -lLibrary -module-name main -I %t -L %t %t/main.swift -o %t/a.out
 
 // RUN: %target-codesign %t/a.out
-// RUN: %target-run %t/a.out | %FileCheck %s
+// RUN: %target-run %t/a.out %t/%target-library-name(Library) | %FileCheck %s
 
 //--- library.swift
 import Distributed


### PR DESCRIPTION
Both tests built a helper dylib whose install_name defaulted to the build-host absolute path, so on remote targets dyld could not find the helper at runtime. In addition, remote-run only rsyncs files whose paths appear as command arguments, so the dylib was never being uploaded to the remote at all.

For each test:
- Set the dylib's install_name to @executable_path/libX.dylib so it resolves next to the binary regardless of the build host.
- Pass the dylib path as a trailing positional argument to %target-run so remote-run uploads it alongside the binary. The binary ignores the extra argv slot.

This mirrors the established pattern used by test/Interpreter/objc_runtime_visible.swift and test/Interpreter/SDK/class_getImageName.swift.
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
