### PR TITLE
[6.4][Sema] BorrowingForLoop: run feature by default

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -579,7 +579,7 @@ EXPERIMENTAL_FEATURE(ImportMacroAliases, true)
 LANGUAGE_FEATURE(BorrowAndMutateAccessors, 507, "borrow and mutate accessors")
 
 /// Enable borrowing for-in loops
-EXPERIMENTAL_FEATURE(BorrowingForLoop, true)
+LANGUAGE_FEATURE(BorrowingForLoop, 0, "borrowing for-in loops")
 
 /// Allow use of @inline(always) attribute
 SUPPRESSIBLE_LANGUAGE_FEATURE(InlineAlways, 496, "@inline(always) attribute")

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -3456,10 +3456,6 @@ FuncDecl *TypeChecker::getForEachIteratorNextFunction(
 bool swift::shouldUseBorrowingSequence(ASTContext &ctx, Type seqTy,
                                        bool isAsync, SourceLoc loc,
                                        DeclContext *dc) {
-  if (!ctx.LangOpts.hasFeature(Feature::BorrowingForLoop)) {
-    return false;
-  }
-
   if (isAsync || seqTy->isExistentialType()) {
     return false;
   }

--- a/test/Availability/foreach_borrowing.swift
+++ b/test/Availability/foreach_borrowing.swift
@@ -1,9 +1,7 @@
 // RUN: %target-typecheck-verify-swift \
-// RUN:     -enable-experimental-feature BorrowingForLoop \
 // RUN:     -enable-experimental-feature BorrowingSequence \
 // RUN:     -verify-ignore-unrelated
 
-// REQUIRES: swift_feature_BorrowingForLoop
 // REQUIRES: swift_feature_BorrowingSequence
 // REQUIRES: OS=macosx
 

--- a/test/Interop/Cxx/stdlib/use-std-span-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span-typechecker.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop -Xcc -std=c++20 2>&1 -disable-availability-checking -enable-experimental-feature BorrowingSequence
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop -Xcc -std=c++20 -disable-availability-checking -enable-experimental-feature BorrowingSequence %if OS_FAMILY=darwin %{ -verify-additional-prefix darwin- %}
 // REQUIRES: std_span
 // REQUIRES: swift_feature_BorrowingSequence
 
@@ -30,7 +30,8 @@ takesSpan(s1)
 
 let s2 = makeSpanOfNonCopyable()
 for _ in s2 {}
-// expected-error@-1 {{for-in loop requires 'SpanOfNonCopyable'}} to conform to 'Sequence'
+// expected-darwin-error@-1 {{conform to 'BorrowingSequence', which is only available in}}
+// expected-darwin-note@-2 {{add 'if #available' version check}}
 takesSequence(s2)
 // expected-error@-1 {{global function 'takesSequence' requires that 'SpanOfNonCopyable'}} conform to 'Sequence'
 takesBorrowingSequence(s2)

--- a/test/Interop/Cxx/stdlib/use-std-span.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span.swift
@@ -1,7 +1,5 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -enable-experimental-feature BorrowingSequence)
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -Xcc -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG -enable-experimental-feature BorrowingSequence)
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -enable-experimental-feature BorrowingForLoop -enable-experimental-feature BorrowingSequence)
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -Xcc -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG -enable-experimental-feature BorrowingForLoop -enable-experimental-feature BorrowingSequence)
 
 
 // TODO: test failed in macOS PR testing but passes locally: rdar://163049442
@@ -9,7 +7,6 @@
 
 // REQUIRES: executable_test
 // REQUIRES: std_span
-// REQUIRES: swift_feature_BorrowingForLoop
 // REQUIRES: swift_feature_BorrowingSequence
 
 import StdlibUnittest
@@ -734,8 +731,6 @@ StdSpanTestSuite.test("CxxSpan conforms to CxxBorrowingSequence")
   expectEqual(counter, 3)
 }
 
-#if hasFeature(BorrowingForLoop)
-
 StdSpanTestSuite.test("CxxSpan of noncopyable conforms to CxxBorrowingSequence")
 .require(.stdlib_6_4).code {
   guard #available(SwiftStdlib 6.4, *) else { return }
@@ -769,7 +764,5 @@ StdSpanTestSuite.test("Borrowing for loop")
   }
   expectEqual(counter, 3)
 }
-
-#endif
 
 runAllTests()

--- a/test/Interpreter/foreach_borrowing.swift
+++ b/test/Interpreter/foreach_borrowing.swift
@@ -6,11 +6,9 @@
 // cited below, where the stdlib symbols will not be present, to avoid crashes.
 // Make sure to update this test accordingly when a more appropriate tool is added.
 
-// RUN: %target-run-simple-swift(-enable-experimental-feature BorrowingForLoop \
-// RUN: -Xfrontend -disable-availability-checking) \
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking) \
 // RUN: %s | %FileCheck %s
 
-// REQUIRES: swift_feature_BorrowingForLoop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/Profiler/coverage_foreach_borrowing.swift
+++ b/test/Profiler/coverage_foreach_borrowing.swift
@@ -1,7 +1,5 @@
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -suppress-warnings -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_foreach_borrowing -enable-experimental-feature BorrowingForLoop %s | %FileCheck %s
-// RUN: %target-swift-frontend -profile-generate -profile-coverage-mapping -emit-ir -enable-experimental-feature BorrowingForLoop %s
-
-// REQUIRES: swift_feature_BorrowingForLoop
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -suppress-warnings -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_foreach_borrowing %s | %FileCheck %s
+// RUN: %target-swift-frontend -profile-generate -profile-coverage-mapping -emit-ir %s
 
 // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_foreach_borrowing.forEachBasic
 @available(SwiftStdlib 6.4, *)

--- a/test/SILGen/foreach_borrowing.swift
+++ b/test/SILGen/foreach_borrowing.swift
@@ -1,10 +1,8 @@
 // RUN: %target-swift-emit-silgen -Xllvm -sil-print-types \
 // RUN:     -g -Xllvm -sil-print-debuginfo-verbose \
-// RUN:     -enable-experimental-feature BorrowingForLoop \
 // RUN:     -enable-experimental-feature BorrowingSequence \
 // RUN:     %s | %FileCheck %s
 
-// REQUIRES: swift_feature_BorrowingForLoop
 // REQUIRES: swift_feature_BorrowingSequence
 
 struct NoncopyableInt: ~Copyable {

--- a/test/Sema/foreach_borrowing.swift
+++ b/test/Sema/foreach_borrowing.swift
@@ -1,9 +1,7 @@
 // RUN: %target-typecheck-verify-swift \
-// RUN:     -enable-experimental-feature BorrowingForLoop \
 // RUN:     -enable-experimental-feature BorrowingSequence \
 // RUN:     -verify-ignore-unrelated
 
-// REQUIRES: swift_feature_BorrowingForLoop
 // REQUIRES: swift_feature_BorrowingSequence
 
 @available(SwiftStdlib 6.4, *)


### PR DESCRIPTION
Explanation: Currently, BorrowingForLoop is an experimental feature. The aim is to run it by default once the swift-evolution proposal for it is approved.
Scope: Sema
Issues:  Resolves rdar://180431383.
Original PRs:  #90017 
Risk: Low
Testing: Lit tests + source compatibility + benchmarks
Reviewers: @kavon @susmonteiro @natecook1000