### PR TITLE
[utils] remote-run: preserve signal-kill semantics for `not --crash`

### DIFF
--- a/utils/remote-run
+++ b/utils/remote-run
@@ -14,12 +14,56 @@
 import argparse
 import os
 import posixpath
+import re
+import signal
 import subprocess
 import sys
 import shutil
 
 def quote(arg):
     return repr(arg)
+
+def _exit_propagating_remote_signal(returncode, stdout, stderr):
+    """Exit so that `not --crash` (and similar) can recognize a signal-killed
+    remote command as a crash.
+
+    `not --crash CMD` returns success only if CMD was terminated by a signal.
+    Tests like `not --crash %target-run …` rely on this. But over SSH the
+    signal info is fragile: sshd may not send the `exit-signal` channel
+    request, ssh may collapse signal exits to 255, the "Killed by signal N"
+    marker may be silenced by LogLevel — leaving remote-run with only an
+    opaque 255 to propagate, which `not --crash` reads as "didn't crash".
+
+    Detect the signal-kill case from whichever evidence is available, then
+    re-raise SIGTERM on this process so the parent observes a real signal
+    exit. We use SIGTERM rather than the original signum (or SIGABRT) because
+    `not --crash` only checks "was killed by *some* signal", and on macOS
+    re-raising fatal signals like SIGABRT/SIGSEGV trips Crash Reporter and
+    pops up "Python quit unexpectedly".
+
+    Evidence considered (any one is sufficient):
+      1. rc in [129, 159] — shell-translated `128 + signum`.
+      2. "Killed by signal N" in stderr — emitted by ssh on some setups.
+      3. rc == 255 with any remote output — almost certainly signal-killed
+         (SSH-level failures yield no remote output).
+    Otherwise, plain sys.exit.
+    """
+    signal_killed = False
+    if returncode is not None and 128 < returncode <= 159:
+        signal_killed = True
+    elif stderr and re.search(r'Killed by signal \d+', stderr):
+        signal_killed = True
+    elif returncode == 255 and (stdout or stderr):
+        signal_killed = True
+    if signal_killed:
+        try:
+            signal.signal(signal.SIGTERM, signal.SIG_DFL)
+            os.kill(os.getpid(), signal.SIGTERM)
+        except (ValueError, OSError):
+            pass  # fall through to sys.exit rather than crash remote-run
+    if returncode is None:
+        returncode = 1
+    sys.exit(returncode)
 
 class CommandRunner(object):
     def __init__(self):
@@ -113,13 +157,13 @@ class CommandRunner(object):
             if remote_proc.returncode:
                 # FIXME: We may still want to fetch the output files to see what
                 # went wrong.
-                sys.exit(remote_proc.returncode)
+                _exit_propagating_remote_signal(remote_proc.returncode, stdout, stderr)
             else:
                 # Nothing went wrong. Return
                 return
 
         if attempt > 3 and remote_proc is not None:
-            sys.exit(remote_proc.returncode)
+            _exit_propagating_remote_signal(remote_proc.returncode, stdout, stderr)
 
     def run_rsync(self, invocation, sources):
         attempt = 1

--- a/utils/remote-run
+++ b/utils/remote-run
@@ -44,8 +44,12 @@ def _exit_propagating_remote_signal(returncode, stdout, stderr):
     Evidence considered (any one is sufficient):
       1. rc in [129, 159] — shell-translated `128 + signum`.
       2. "Killed by signal N" in stderr — emitted by ssh on some setups.
-      3. rc == 255 with any remote output — almost certainly signal-killed
-         (SSH-level failures yield no remote output).
+      3. rc == 255 with stderr free of any known SSH-level error pattern.
+         OpenSSH overloads 255 for both "remote killed by signal" and
+         connection/auth/network failures, but the latter always emit a
+         recognizable stderr message; everything else is the remote dying
+         by signal (possibly silently, e.g. dispatch_assert_queue traps
+         with SWIFT_BACKTRACE=enable=no).
     Otherwise, plain sys.exit.
     """
     signal_killed = False
@@ -53,10 +57,17 @@ def _exit_propagating_remote_signal(returncode, stdout, stderr):
         signal_killed = True
     elif stderr and re.search(r'Killed by signal \d+', stderr):
         signal_killed = True
-    elif returncode == 255 and (stdout or stderr):
+    elif returncode == 255 and not _stderr_looks_like_ssh_failure(stderr):
         signal_killed = True
     if signal_killed:
         try:
+            # When piped (e.g. under a lit `… 2>&1 | FileCheck` pipeline),
+            # sys.stdout/stderr are fully buffered. Self-killing via signal
+            # bypasses the normal Python shutdown that would flush them, so
+            # without an explicit flush here the captured remote output that
+            # was just print()ed by the caller would be discarded.
+            sys.stdout.flush()
+            sys.stderr.flush()
             signal.signal(signal.SIGTERM, signal.SIG_DFL)
             os.kill(os.getpid(), signal.SIGTERM)
         except (ValueError, OSError):
@@ -64,6 +75,26 @@ def _exit_propagating_remote_signal(returncode, stdout, stderr):
     if returncode is None:
         returncode = 1
     sys.exit(returncode)
+
+
+_SSH_FAILURE_PATTERNS = (
+    'Permission denied',
+    'Connection refused',
+    'Connection reset by peer',
+    'Connection timed out',
+    'Network is unreachable',
+    'No route to host',
+    'Could not resolve hostname',
+    'Host key verification failed',
+    'kex_exchange_identification',
+    'ssh: connect to host',
+    'Operation not permitted',
+)
+
+def _stderr_looks_like_ssh_failure(stderr):
+    if not stderr:
+        return False
+    return any(p in stderr for p in _SSH_FAILURE_PATTERNS)
 
 class CommandRunner(object):
     def __init__(self):


### PR DESCRIPTION
When a remote command is killed by a signal, the signal info is lost on the way back to the caller. In every case remote-run was propagating an opaque numeric exit code via plain sys.exit, which made wrappers like `not --crash %target-run ...` read the run as a clean exit ("didn't crash") and fail. This breaks tests that intentionally trap.

Recover the signal-kill case from any of three pieces of evidence — shell-translated 128+N exit, the OpenSSH stderr marker, or a 255 exit that does not match any known SSH failure patterns — then re-raise SIGTERM on this process so the parent observes a real signal exit. SIGTERM is sufficient for `not --crash` (it only checks for *any* signal) and, unlike SIGABRT/SIGSEGV, doesn't trip macOS Crash Reporter and pop up "Python quit unexpectedly" on every test that asserts a remote crash.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
