### PR TITLE
  [test][Interpreter] Make tests work under cross-compile/remote-run

### DIFF
--- a/test/Interpreter/dynamic_isolation_checks_for_closures.swift
+++ b/test/Interpreter/dynamic_isolation_checks_for_closures.swift
@@ -5,23 +5,24 @@
 // RUN:    -target %target-cpu-apple-macosx10.15 -swift-version 5 \
 // RUN:    -enable-library-evolution \
 // RUN:    -module-name Interface \
+// RUN:    -Xlinker -install_name -Xlinker @executable_path/%target-library-name(Interface) \
 // RUN:    -o %t/%target-library-name(Interface) \
 // RUN:    -emit-module-interface-path %t/Interface.swiftinterface
 
 // RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 -swift-version 5 -Xfrontend -enable-upcoming-feature -Xfrontend DynamicActorIsolation -I %t -L %t -lInterface %t/src/Crash1.swift -o %t/crash1.out
 // RUN: %target-codesign %t/crash1.out
-// RUN: not --crash env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 SWIFT_BACKTRACE=enable=no %target-run %t/crash1.out 2>&1 | %FileCheck %t/src/Crash1.swift --check-prefix=LEGACY_CHECK
-// RUN: not --crash env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 SWIFT_BACKTRACE=enable=no %target-run %t/crash1.out 2>&1 | %FileCheck %t/src/Crash1.swift --check-prefix=SWIFT6_CHECK --dump-input=always
+// RUN: not --crash env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %env-SWIFT_BACKTRACE=enable=no %target-run %t/crash1.out %t/%target-library-name(Interface) 2>&1 | %FileCheck %t/src/Crash1.swift --check-prefix=LEGACY_CHECK
+// RUN: not --crash env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %env-SWIFT_BACKTRACE=enable=no %target-run %t/crash1.out %t/%target-library-name(Interface) 2>&1 | %FileCheck %t/src/Crash1.swift --check-prefix=SWIFT6_CHECK --dump-input=always
 
 // RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 -swift-version 6 -I %t -L %t -lInterface %t/src/Crash2.swift -o %t/crash2.out
 // RUN: %target-codesign %t/crash2.out
-// RUN: not --crash env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 SWIFT_BACKTRACE=enable=no %target-run %t/crash2.out 2>&1 | %FileCheck %t/src/Crash2.swift --check-prefix=LEGACY_CHECK
-// RUN: not --crash env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 SWIFT_BACKTRACE=enable=no %target-run %t/crash2.out 2>&1 | %FileCheck %t/src/Crash2.swift --check-prefix=SWIFT6_CHECK --dump-input=always
+// RUN: not --crash env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %env-SWIFT_BACKTRACE=enable=no %target-run %t/crash2.out %t/%target-library-name(Interface) 2>&1 | %FileCheck %t/src/Crash2.swift --check-prefix=LEGACY_CHECK
+// RUN: not --crash env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %env-SWIFT_BACKTRACE=enable=no %target-run %t/crash2.out %t/%target-library-name(Interface) 2>&1 | %FileCheck %t/src/Crash2.swift --check-prefix=SWIFT6_CHECK --dump-input=always
 
 // RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 -swift-version 6 -I %t -L %t -lInterface %t/src/Crash3.swift -o %t/crash3.out
 // RUN: %target-codesign %t/crash3.out
-// RUN: not --crash env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 SWIFT_BACKTRACE=enable=no %target-run %t/crash3.out 2>&1 | %FileCheck %t/src/Crash3.swift --check-prefix=LEGACY_CHECK
-// RUN: not --crash env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 SWIFT_BACKTRACE=enable=no %target-run %t/crash3.out 2>&1 | %FileCheck %t/src/Crash3.swift --check-prefix=SWIFT6_CHECK --dump-input=always
+// RUN: not --crash env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %env-SWIFT_BACKTRACE=enable=no %target-run %t/crash3.out %t/%target-library-name(Interface) 2>&1 | %FileCheck %t/src/Crash3.swift --check-prefix=LEGACY_CHECK
+// RUN: not --crash env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %env-SWIFT_BACKTRACE=enable=no %target-run %t/crash3.out %t/%target-library-name(Interface) 2>&1 | %FileCheck %t/src/Crash3.swift --check-prefix=SWIFT6_CHECK --dump-input=always
 
 // We set SWIFT_BACKTRACE=enable=no, as backtracing output can cause false
 // positive matches with CHECK-NOT: OK.

--- a/test/Interpreter/preconcurrency_conformances.swift
+++ b/test/Interpreter/preconcurrency_conformances.swift
@@ -5,44 +5,46 @@
 // RUN:    -target %target-cpu-apple-macosx10.15 -swift-version 5 \
 // RUN:    -enable-library-evolution \
 // RUN:    -module-name Interface \
+// RUN:    -Xlinker -install_name -Xlinker @executable_path/%target-library-name(Interface) \
 // RUN:    -o %t/%target-library-name(Interface) \
 // RUN:    -emit-module-interface-path %t/Interface.swiftinterface
 
 // RUN: %target-build-swift %t/src/Types.swift -swift-version 5 -emit-module -emit-library -enable-library-evolution -module-name Types -o %t/%target-library-name(Types) \
 // RUN:    -target %target-cpu-apple-macosx10.15 \
 // RUN:    -I %t -L %t -l Interface \
+// RUN:    -Xlinker -install_name -Xlinker @executable_path/%target-library-name(Types) \
 // RUN:    -emit-module-interface-path %t/Types.swiftinterface \
 // RUN:    -Xfrontend -enable-upcoming-feature -Xfrontend DynamicActorIsolation
 
 // RUN: %target-build-swift -Xfrontend -enable-upcoming-feature -Xfrontend DynamicActorIsolation -I %t -L %t -l Types %t/src/Crash1.swift -o %t/crash1.out
 // RUN: %target-codesign %t/crash1.out
-// RUN: not --crash env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 SWIFT_BACKTRACE=enable=no %target-run %t/crash1.out 2>&1 | %FileCheck %t/src/Crash1.swift --check-prefix=LEGACY_CHECK
-// RUN: not --crash env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 SWIFT_BACKTRACE=enable=no %target-run %t/crash1.out 2>&1 | %FileCheck %t/src/Crash1.swift --check-prefix=SWIFT6_CHECK --dump-input=always
+// RUN: not --crash env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %env-SWIFT_BACKTRACE=enable=no %target-run %t/crash1.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Crash1.swift --check-prefix=LEGACY_CHECK
+// RUN: not --crash env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %env-SWIFT_BACKTRACE=enable=no %target-run %t/crash1.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Crash1.swift --check-prefix=SWIFT6_CHECK --dump-input=always
 
 // RUN: %target-build-swift -Xfrontend -enable-upcoming-feature -Xfrontend DynamicActorIsolation -I %t -L %t -l Types %t/src/Crash2.swift -o %t/crash2.out
 // RUN: %target-codesign %t/crash2.out
-// RUN: not --crash env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 SWIFT_BACKTRACE=enable=no %target-run %t/crash2.out 2>&1 | %FileCheck %t/src/Crash2.swift --check-prefix=LEGACY_CHECK
-// RUN: not --crash env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 SWIFT_BACKTRACE=enable=no %target-run %t/crash2.out 2>&1 | %FileCheck %t/src/Crash2.swift --check-prefix=SWIFT6_CHECK --dump-input=always
+// RUN: not --crash env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %env-SWIFT_BACKTRACE=enable=no %target-run %t/crash2.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Crash2.swift --check-prefix=LEGACY_CHECK
+// RUN: not --crash env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %env-SWIFT_BACKTRACE=enable=no %target-run %t/crash2.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Crash2.swift --check-prefix=SWIFT6_CHECK --dump-input=always
 
 // RUN: %target-build-swift -Xfrontend -enable-upcoming-feature -Xfrontend DynamicActorIsolation -I %t -L %t -l Types %t/src/Crash3.swift -o %t/crash3.out
 // RUN: %target-codesign %t/crash3.out
-// RUN: not --crash env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 SWIFT_BACKTRACE=enable=no %target-run %t/crash3.out 2>&1 | %FileCheck %t/src/Crash3.swift --check-prefix=LEGACY_CHECK
-// RUN: not --crash env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 SWIFT_BACKTRACE=enable=no %target-run %t/crash3.out 2>&1 | %FileCheck %t/src/Crash3.swift --check-prefix=SWIFT6_CHECK --dump-input=always
+// RUN: not --crash env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %env-SWIFT_BACKTRACE=enable=no %target-run %t/crash3.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Crash3.swift --check-prefix=LEGACY_CHECK
+// RUN: not --crash env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %env-SWIFT_BACKTRACE=enable=no %target-run %t/crash3.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Crash3.swift --check-prefix=SWIFT6_CHECK --dump-input=always
 
 // RUN: %target-build-swift -Xfrontend -enable-upcoming-feature -Xfrontend DynamicActorIsolation -I %t -L %t -l Types %t/src/Crash4.swift -o %t/crash4.out
 // RUN: %target-codesign %t/crash4.out
-// RUN: not --crash env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 SWIFT_BACKTRACE=enable=no %target-run %t/crash4.out 2>&1 | %FileCheck %t/src/Crash4.swift --check-prefix=LEGACY_CHECK
-// RUN: not --crash env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 SWIFT_BACKTRACE=enable=no %target-run %t/crash4.out 2>&1 | %FileCheck %t/src/Crash4.swift --check-prefix=SWIFT6_CHECK --dump-input=always
+// RUN: not --crash env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %env-SWIFT_BACKTRACE=enable=no %target-run %t/crash4.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Crash4.swift --check-prefix=LEGACY_CHECK
+// RUN: not --crash env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %env-SWIFT_BACKTRACE=enable=no %target-run %t/crash4.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Crash4.swift --check-prefix=SWIFT6_CHECK --dump-input=always
 
 // RUN: %target-build-swift -Xfrontend -enable-upcoming-feature -Xfrontend DynamicActorIsolation -I %t -L %t -l Types %t/src/Crash5.swift -o %t/crash5.out
 // RUN: %target-codesign %t/crash5.out
-// RUN: not --crash env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 SWIFT_BACKTRACE=enable=no %target-run %t/crash5.out 2>&1 | %FileCheck %t/src/Crash5.swift --check-prefix=LEGACY_CHECK
-// RUN: not --crash env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 SWIFT_BACKTRACE=enable=no %target-run %t/crash5.out 2>&1 | %FileCheck %t/src/Crash5.swift --check-prefix=SWIFT6_CHECK --dump-input=always
+// RUN: not --crash env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %env-SWIFT_BACKTRACE=enable=no %target-run %t/crash5.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Crash5.swift --check-prefix=LEGACY_CHECK
+// RUN: not --crash env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %env-SWIFT_BACKTRACE=enable=no %target-run %t/crash5.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Crash5.swift --check-prefix=SWIFT6_CHECK --dump-input=always
 
 // RUN: %target-build-swift -Xfrontend -enable-upcoming-feature -Xfrontend DynamicActorIsolation -I %t -L %t -l Types %t/src/Crash6.swift -o %t/crash6.out
 // RUN: %target-codesign %t/crash6.out
-// RUN: not --crash env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 SWIFT_BACKTRACE=enable=no %target-run %t/crash6.out 2>&1 | %FileCheck %t/src/Crash6.swift --check-prefix=LEGACY_CHECK
-// RUN: not --crash env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 SWIFT_BACKTRACE=enable=no %target-run %t/crash6.out 2>&1 | %FileCheck %t/src/Crash6.swift --check-prefix=SWIFT6_CHECK --dump-input=always
+// RUN: not --crash env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %env-SWIFT_BACKTRACE=enable=no %target-run %t/crash6.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Crash6.swift --check-prefix=LEGACY_CHECK
+// RUN: not --crash env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %env-SWIFT_BACKTRACE=enable=no %target-run %t/crash6.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Crash6.swift --check-prefix=SWIFT6_CHECK --dump-input=always
 
 // We set SWIFT_BACKTRACE=enable=no, as backtracing output can cause false
 // positive matches with CHECK-NOT: OK.

--- a/test/Interpreter/preconcurrency_conformances_with_disabled_checks.swift
+++ b/test/Interpreter/preconcurrency_conformances_with_disabled_checks.swift
@@ -5,51 +5,53 @@
 // RUN:    -target %target-cpu-apple-macosx10.15 -swift-version 5 \
 // RUN:    -enable-library-evolution \
 // RUN:    -module-name Interface \
+// RUN:    -Xlinker -install_name -Xlinker @executable_path/%target-library-name(Interface) \
 // RUN:    -o %t/%target-library-name(Interface) \
 // RUN:    -emit-module-interface-path %t/Interface.swiftinterface
 
 // RUN: %target-build-swift %t/src/Types.swift -swift-version 5 -emit-module -emit-library -enable-library-evolution -module-name Types -o %t/%target-library-name(Types) \
 // RUN:    -target %target-cpu-apple-macosx10.15 \
 // RUN:    -I %t -L %t -l Interface \
+// RUN:    -Xlinker -install_name -Xlinker @executable_path/%target-library-name(Types) \
 // RUN:    -emit-module-interface-path %t/Types.swiftinterface \
 // RUN:    -Xfrontend -enable-upcoming-feature -Xfrontend DynamicActorIsolation \
 // RUN:    -Xfrontend -disable-dynamic-actor-isolation
 
 // RUN: %target-build-swift -I %t -L %t -l Types %t/src/Test1.swift -o %t/test1.out
 // RUN: %target-codesign %t/test1.out
-// RUN: env SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test1.out 2>&1 | %FileCheck %t/src/Test1.swift
-// RUN: env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test1.out 2>&1 | %FileCheck %t/src/Test1.swift
-// RUN: env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test1.out 2>&1 | %FileCheck %t/src/Test1.swift
+// RUN: env %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test1.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Test1.swift
+// RUN: env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test1.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Test1.swift
+// RUN: env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test1.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Test1.swift
 
 // RUN: %target-build-swift -I %t -L %t -l Types %t/src/Test2.swift -o %t/test2.out
 // RUN: %target-codesign %t/test2.out
-// RUN: env SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test2.out 2>&1 | %FileCheck %t/src/Test2.swift
-// RUN: env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test2.out 2>&1 | %FileCheck %t/src/Test2.swift
-// RUN: env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test2.out 2>&1 | %FileCheck %t/src/Test2.swift
+// RUN: env %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test2.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Test2.swift
+// RUN: env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test2.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Test2.swift
+// RUN: env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test2.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Test2.swift
 
 // RUN: %target-build-swift -I %t -L %t -l Types %t/src/Test3.swift -o %t/test3.out
 // RUN: %target-codesign %t/test3.out
-// RUN: env SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test3.out 2>&1 | %FileCheck %t/src/Test3.swift
-// RUN: env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test3.out 2>&1 | %FileCheck %t/src/Test3.swift
-// RUN: env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test3.out 2>&1 | %FileCheck %t/src/Test3.swift
+// RUN: env %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test3.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Test3.swift
+// RUN: env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test3.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Test3.swift
+// RUN: env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test3.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Test3.swift
 
 // RUN: %target-build-swift -I %t -L %t -l Types %t/src/Test4.swift -o %t/test4.out
 // RUN: %target-codesign %t/test4.out
-// RUN: env SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test4.out 2>&1 | %FileCheck %t/src/Test4.swift
-// RUN: env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test4.out 2>&1 | %FileCheck %t/src/Test4.swift
-// RUN: env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test4.out 2>&1 | %FileCheck %t/src/Test4.swift
+// RUN: env %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test4.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Test4.swift
+// RUN: env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test4.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Test4.swift
+// RUN: env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test4.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Test4.swift
 
 // RUN: %target-build-swift -I %t -L %t -l Types %t/src/Test5.swift -o %t/test5.out
 // RUN: %target-codesign %t/test5.out
-// RUN: env SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test5.out 2>&1 | %FileCheck %t/src/Test5.swift
-// RUN: env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test5.out 2>&1 | %FileCheck %t/src/Test5.swift
-// RUN: env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test5.out 2>&1 | %FileCheck %t/src/Test5.swift
+// RUN: env %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test5.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Test5.swift
+// RUN: env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test5.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Test5.swift
+// RUN: env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test5.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Test5.swift
 
 // RUN: %target-build-swift -I %t -L %t -l Types %t/src/Test6.swift -o %t/test6.out
 // RUN: %target-codesign %t/test6.out
-// RUN: env SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test6.out 2>&1 | %FileCheck %t/src/Test6.swift
-// RUN: env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test6.out 2>&1 | %FileCheck %t/src/Test6.swift
-// RUN: env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test6.out 2>&1 | %FileCheck %t/src/Test6.swift
+// RUN: env %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test6.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Test6.swift
+// RUN: env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test6.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Test6.swift
+// RUN: env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/test6.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Test6.swift
 
 // REQUIRES: concurrency
 // REQUIRES: concurrency_runtime

--- a/test/Interpreter/preconcurrency_conformances_with_legacy_isSameExecutor.swift
+++ b/test/Interpreter/preconcurrency_conformances_with_legacy_isSameExecutor.swift
@@ -5,31 +5,33 @@
 // RUN:    -target %target-cpu-apple-macosx10.15 -swift-version 5 \
 // RUN:    -enable-library-evolution \
 // RUN:    -module-name Interface \
+// RUN:    -Xlinker -install_name -Xlinker @executable_path/%target-library-name(Interface) \
 // RUN:    -o %t/%target-library-name(Interface) \
 // RUN:    -emit-module-interface-path %t/Interface.swiftinterface
 
 // RUN: %target-build-swift %t/src/Types.swift -swift-version 5 -emit-module -emit-library -enable-library-evolution -module-name Types -o %t/%target-library-name(Types) \
 // RUN:    -target %target-cpu-apple-macosx10.15 \
 // RUN:    -I %t -L %t -l Interface \
+// RUN:    -Xlinker -install_name -Xlinker @executable_path/%target-library-name(Types) \
 // RUN:    -emit-module-interface-path %t/Types.swiftinterface \
 // RUN:    -Xfrontend -enable-upcoming-feature -Xfrontend DynamicActorIsolation \
 // RUN:    -Xfrontend -disable-dynamic-actor-isolation
 
 // RUN: %target-build-swift -I %t -L %t -l Types %t/src/Test1.swift -o %t/test1.out
 // RUN: %target-codesign %t/test1.out
-// RUN: env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %target-run %t/test1.out 2>&1 | %FileCheck %t/src/Test1.swift
+// RUN: env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %target-run %t/test1.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Test1.swift
 
 // RUN: %target-build-swift -I %t -L %t -l Types %t/src/Test2.swift -o %t/test2.out
 // RUN: %target-codesign %t/test2.out
-// RUN: env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %target-run %t/test2.out 2>&1 | %FileCheck %t/src/Test2.swift
+// RUN: env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %target-run %t/test2.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Test2.swift
 
 // RUN: %target-build-swift -I %t -L %t -l Types %t/src/Test3.swift -o %t/test3.out
 // RUN: %target-codesign %t/test3.out
-// RUN: env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %target-run %t/test3.out 2>&1 | %FileCheck %t/src/Test3.swift
+// RUN: env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %target-run %t/test3.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Test3.swift
 
 // RUN: %target-build-swift -I %t -L %t -l Types %t/src/Test4.swift -o %t/test4.out
 // RUN: %target-codesign %t/test4.out
-// RUN: env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %target-run %t/test4.out 2>&1 | %FileCheck %t/src/Test4.swift
+// RUN: env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %target-run %t/test4.out %t/%target-library-name(Interface) %t/%target-library-name(Types) 2>&1 | %FileCheck %t/src/Test4.swift
 
 // REQUIRES: concurrency
 // REQUIRES: concurrency_runtime

--- a/test/Interpreter/static_keypaths.swift
+++ b/test/Interpreter/static_keypaths.swift
@@ -2,7 +2,7 @@
 // RUN: split-file %s %t/src
 
 /// Build LibA
-// RUN: %host-build-swift %t/src/LibA.swift -swift-version 5 -enable-experimental-feature KeyPathWithMethodMembers -emit-module -emit-library -enable-library-evolution -module-name LibA -o %t/%target-library-name(LibA) -emit-module-interface-path %t/LibA.swiftinterface
+// RUN: %target-build-swift %t/src/LibA.swift -swift-version 5 -enable-experimental-feature KeyPathWithMethodMembers -emit-module -emit-library -enable-library-evolution -module-name LibA -o %t/%target-library-name(LibA) -emit-module-interface-path %t/LibA.swiftinterface
 
 // Build LibB
 // RUN: %target-build-swift %t/src/LibB.swift -I %t -L %t -l LibA -swift-version 5 -enable-experimental-feature KeyPathWithMethodMembers -emit-module -emit-library -module-name LibB -o %t/%target-library-name(LibB)

--- a/test/Interpreter/static_keypaths.swift
+++ b/test/Interpreter/static_keypaths.swift
@@ -2,13 +2,13 @@
 // RUN: split-file %s %t/src
 
 /// Build LibA
-// RUN: %target-build-swift %t/src/LibA.swift -swift-version 5 -enable-experimental-feature KeyPathWithMethodMembers -emit-module -emit-library -enable-library-evolution -module-name LibA -o %t/%target-library-name(LibA) -emit-module-interface-path %t/LibA.swiftinterface
+// RUN: %target-build-swift %t/src/LibA.swift -swift-version 5 -enable-experimental-feature KeyPathWithMethodMembers -emit-module -emit-library -enable-library-evolution -module-name LibA -Xlinker -install_name -Xlinker @executable_path/%target-library-name(LibA) -o %t/%target-library-name(LibA) -emit-module-interface-path %t/LibA.swiftinterface
 
 // Build LibB
-// RUN: %target-build-swift %t/src/LibB.swift -I %t -L %t -l LibA -swift-version 5 -enable-experimental-feature KeyPathWithMethodMembers -emit-module -emit-library -module-name LibB -o %t/%target-library-name(LibB)
+// RUN: %target-build-swift %t/src/LibB.swift -I %t -L %t -l LibA -swift-version 5 -enable-experimental-feature KeyPathWithMethodMembers -emit-module -emit-library -module-name LibB -Xlinker -install_name -Xlinker @executable_path/%target-library-name(LibB) -o %t/%target-library-name(LibB)
 
 // Build LibC
-// RUN: %target-build-swift %t/src/LibC.swift -I %t -L %t -l LibA -swift-version 5 -enable-experimental-feature KeyPathWithMethodMembers -emit-module -emit-library -module-name LibC -o %t/%target-library-name(LibC)
+// RUN: %target-build-swift %t/src/LibC.swift -I %t -L %t -l LibA -swift-version 5 -enable-experimental-feature KeyPathWithMethodMembers -emit-module -emit-library -module-name LibC -Xlinker -install_name -Xlinker @executable_path/%target-library-name(LibC) -o %t/%target-library-name(LibC)
 
 // Build & run main.swift
 // RUN: %target-build-swift -I %t -L %t -l LibA -l LibB -l LibC %t/src/main.swift -o %t/a.out
@@ -16,7 +16,7 @@
 // RUN: %target-codesign %t/%target-library-name(LibB)
 // RUN: %target-codesign %t/%target-library-name(LibC)
 // RUN: %target-codesign %t/a.out
-// RUN: %target-run %t/a.out | %FileCheck %s
+// RUN: %target-run %t/a.out %t/%target-library-name(LibA) %t/%target-library-name(LibB) %t/%target-library-name(LibC) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx


### PR DESCRIPTION
This PR fixes several Interpreter tests when executing test executables on remote targets:

 - Set helper dylib `install_name`s to `@executable_path/lib<X>.dylib` and pass each dylib as a
  positional arg to `%target-run` so remote-run uploads it. Applied to `static_keypaths.swift` 
  (libLibA/libLibB/libLibC), `dynamic_isolation_checks_for_closures.swift` (libInterface), and the three
  `preconcurrency_conformances*.swift` tests (libInterface, libTypes).
  - Prefix `SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE`, `SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL`, and
  `SWIFT_BACKTRACE` with `%env-` so they cross to the remote. Applied to
  `dynamic_isolation_checks_for_closures.swift` and the three `preconcurrency_conformances*.swift` tests.
  - `static_keypaths.swift`: build LibA with `%target-build-swift` instead of `%host-build-swift` so its
  module triple matches LibB/LibC/main under cross-compile.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
