### PR TITLE
SimplifyCopyValue: remove copy of projections

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyCopyValue.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyCopyValue.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import AST
 import SIL
 
 extension CopyValueInst : OnoneSimplifiable, SILCombineSimplifiable {
@@ -17,6 +18,153 @@ extension CopyValueInst : OnoneSimplifiable, SILCombineSimplifiable {
     if fromValue.ownership == .none {
       uses.replaceAll(with: fromValue, context)
       context.erase(instruction: self)
+      return
+    }
+    if !context.preserveDebugInfo {
+      tryRemoveProjectedCopy(copy: self, context)
     }
   }
+}
+
+/// Remove a `copy_value` from a projected owned value which outlives the enclosing owned value.
+///
+/// ```
+///   %2 = begin_borrow %1
+///   %3 = struct_extract %2, #S.a
+///   %4 = copy_value %3                   // to be removed
+///   %5 = some_forwarding_instructions %4
+///   end_borrow %2
+///   destroy_value %1                     // end of lifetime of the enclosing owned value
+///   use %5                               // use of the copied value outside of the owned value's lifetime
+/// ```
+
+/// The `destroy_value` is replaced with destructure operations (`destructure_struct`, `destructure_tuple`).
+/// The copied value can then be replaced by the corresponding element of the destructure.
+/// The remaining elements are element-wise destroyed.
+/// Any forwarding instructions of the copied value are moved out of the owned value's liferange.
+
+/// ```
+///   %2 = begin_borrow %1
+///   end_borrow %2
+///   (%3, %4) = destructure_struct %1
+///   destroy_value %3                      // destroy the unused elements
+///   %5 = some_forwarding_instructions %4  // moved out of %1's liferange
+///   use %5
+/// ```
+///
+/// Preconditions:
+///   * The `destroy_value` must be in the same basic block as the `copy_value`
+///   * There are no uses of the copy or its forwarding instructions inside the owned value's liverange
+///
+private func tryRemoveProjectedCopy(copy: CopyValueInst, _ context: SimplifyContext) {
+  let block = copy.parentBlock
+
+  let (projectionPath, root) = getProjectionPath(of: copy.fromValue)
+
+  guard !projectionPath.isEmpty,
+        projectionPath.isMaterializable,
+        let beginBorrow = root as? BeginBorrowInst
+  else {
+    return
+  }
+
+  let ownedValue = beginBorrow.borrowedValue
+
+  guard ownedValue.ownership == .owned,
+        // Find the destroy_value of the owned value in the same block as copy.
+        let destroy = ownedValue.uses.users(ofType: DestroyValueInst.self).first(where: { $0.parentBlock == block })
+  else {
+    return
+  }
+
+  guard checkForwardingChain(from: copy, to: destroy) else {
+    return
+  }
+
+  // ---- All checks passed. Perform the transformation. ----
+
+  let builder = Builder(before: destroy, context)
+  let finalFieldElement = createDestructureChain(of: ownedValue, path: projectionPath, builder)
+
+  moveForwardingChain(from: copy, before: destroy, context)
+
+  copy.replace(with: finalFieldElement, context)
+
+  context.erase(instruction: destroy)
+}
+
+/// Returns true if every non-forwarding, non-debug use of `copy` and its forwarding
+/// chain is outside the owned value's liverange which ends at `destroy`.
+private func checkForwardingChain(from value: Value, to destroy: DestroyValueInst) -> Bool {
+  for use in value.uses {
+    let user = use.instruction
+    if user.parentBlock != destroy.parentBlock || destroy.strictlyDominatesInBlock(user) {
+      continue
+    }
+    guard let fwdInst = user as? (SingleValueInstruction & ForwardingInstruction),
+          fwdInst.singleForwardedOperand == use,
+          fwdInst.operands.count == 1,
+          checkForwardingChain(from: fwdInst, to: destroy)
+    else {
+      return false
+    }
+  }
+  return true
+}
+
+/// Moves every forwarding instruction in the chain starting at `copy` to just
+/// before `destroy`.
+private func moveForwardingChain(from value: Value,
+                                 before destroy: DestroyValueInst,
+                                 _ context: SimplifyContext) {
+  for use in value.uses {
+    let user = use.instruction
+    if user.parentBlock != destroy.parentBlock || destroy.strictlyDominatesInBlock(user) {
+      continue
+    }
+    let fwdInst = user as! (SingleValueInstruction & ForwardingInstruction)
+    fwdInst.move(before: destroy, context)
+    moveForwardingChain(from: fwdInst, before: destroy, context)
+  }
+}
+
+private func getProjectionPath(of value: Value,
+                               initialPath: SmallProjectionPath = SmallProjectionPath()
+) -> (SmallProjectionPath, root: Value) {
+  switch value {
+  case let sei as StructExtractInst:
+    let structType = sei.struct.type
+    guard structType.getNominalFields(in: sei.parentFunction) != nil,
+          (structType.nominal as! StructDecl).valueTypeDestructor == nil
+    else {
+      return (initialPath, root: sei)
+    }
+    return getProjectionPath(of: sei.struct, initialPath: initialPath.push(.structField, index: sei.fieldIndex))
+  case let tei as TupleExtractInst:
+    return getProjectionPath(of: tei.tuple, initialPath: initialPath.push(.tupleField, index: tei.fieldIndex))
+  default:
+    return (initialPath, root: value)
+  }
+}
+
+private func createDestructureChain(of value: Value, path: SmallProjectionPath, _ builder: Builder) -> Value {
+  let (kind, index, subPath) = path.pop()
+
+  let destructure: MultipleValueInstruction
+  switch kind {
+  case .root:
+    return value
+  case .structField:
+    destructure = builder.createDestructureStruct(struct: value)
+  case .tupleField:
+    destructure = builder.createDestructureTuple(tuple: value)
+  default:
+    fatalError("unsupported projection kind")
+  }
+  for (i, element) in destructure.results.enumerated() {
+    if i != index && element.ownership != .none {
+      builder.createDestroyValue(operand: element)
+    }
+  }
+  return createDestructureChain(of: destructure.results[index], path: subPath, builder)
 }

--- a/test/SILOptimizer/pointer_conversion_linux.swift
+++ b/test/SILOptimizer/pointer_conversion_linux.swift
@@ -26,14 +26,14 @@ public func testOptionalArray() {
   // CHECK: bb0:
   // CHECK:   switch_enum {{.*}}, case #Optional.some!enumelt: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
 
-  // CHECK: [[SOME_BB]](
-  // CHECK: [[ORIGINAL_OWNER:%.*]] = struct_extract {{%.*}} : $_ContiguousArrayBuffer<Int>, #_ContiguousArrayBuffer._storage
-  // CHECK: [[ORIGINAL_OWNER_EXISTENTIAL:%.*]] = init_existential_ref [[ORIGINAL_OWNER]]
-  // CHECK: [[OWNER:%.+]] = enum $Optional<AnyObject>, #Optional.some!enumelt, [[ORIGINAL_OWNER_EXISTENTIAL]]
-  // CHECK-NEXT: [[POINTER:%.+]] = struct $UnsafeRawPointer (
-  // CHECK-NEXT: [[DEP_POINTER:%.+]] = mark_dependence [[POINTER]] : $UnsafeRawPointer on [[ORIGINAL_OWNER]]
-  // CHECK-NEXT: [[OPT_POINTER:%.+]] = enum $Optional<UnsafeRawPointer>, #Optional.some!enumelt, [[DEP_POINTER]]
-  // CHECK-NEXT: br [[CALL_BRANCH:bb[0-9]+]]([[OPT_POINTER]] : $Optional<UnsafeRawPointer>, [[OWNER]] : $Optional<AnyObject>)
+  // CHECK:     [[SOME_BB]](
+  // CHECK:       [[ORIGINAL_OWNER:%.*]] = struct_extract {{%.*}} : $_ContiguousArrayBuffer<Int>, #_ContiguousArrayBuffer._storage
+  // CHECK:       [[POINTER:%.+]] = struct $UnsafeRawPointer (
+  // CHECK:       [[ORIGINAL_OWNER_EXISTENTIAL:%.*]] = init_existential_ref [[ORIGINAL_OWNER]]
+  // CHECK:       [[OWNER:%.+]] = enum $Optional<AnyObject>, #Optional.some!enumelt, [[ORIGINAL_OWNER_EXISTENTIAL]]
+  // CHECK-NEXT:  [[DEP_POINTER:%.+]] = mark_dependence [[POINTER]] : $UnsafeRawPointer on [[ORIGINAL_OWNER]]
+  // CHECK-NEXT:  [[OPT_POINTER:%.+]] = enum $Optional<UnsafeRawPointer>, #Optional.some!enumelt, [[DEP_POINTER]]
+  // CHECK-NEXT:  br [[CALL_BRANCH:bb[0-9]+]]([[OPT_POINTER]] : $Optional<UnsafeRawPointer>, [[OWNER]] : $Optional<AnyObject>)
 
   // CHECK: [[CALL_BRANCH]]([[OPT_POINTER:%.+]] : $Optional<UnsafeRawPointer>, [[OWNER:%.+]] : $Optional<AnyObject>):
   // CHECK-NOT: release

--- a/test/SILOptimizer/pointer_conversion_objc.swift
+++ b/test/SILOptimizer/pointer_conversion_objc.swift
@@ -27,14 +27,15 @@ public func testOptionalArray() {
   // CHECK: bb0:
   // CHECK:   switch_enum {{.*}}, case #Optional.some!enumelt: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
 
-  // CHECK: [[SOME_BB]](
-  // CHECK: [[ORIGINAL_OWNER:%.*]] = unchecked_ref_cast {{%.*}} : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
-  // CHECK: [[ORIGINAL_OWNER_EXISTENTIAL:%.*]] = init_existential_ref [[ORIGINAL_OWNER]]
-  // CHECK: [[OWNER:%.+]] = enum $Optional<AnyObject>, #Optional.some!enumelt, [[ORIGINAL_OWNER_EXISTENTIAL]]
-  // CHECK-NEXT: [[POINTER:%.+]] = struct $UnsafeRawPointer (
-  // CHECK-NEXT: [[DEP_POINTER:%.+]] = mark_dependence [[POINTER]] : $UnsafeRawPointer on [[ORIGINAL_OWNER]]
-  // CHECK-NEXT: [[OPT_POINTER:%.+]] = enum $Optional<UnsafeRawPointer>, #Optional.some!enumelt, [[DEP_POINTER]]
-  // CHECK-NEXT: br [[CALL_BRANCH:bb[0-9]+]]([[OPT_POINTER]] : $Optional<UnsafeRawPointer>, [[OWNER]] : $Optional<AnyObject>)
+  // CHECK:      [[SOME_BB]](
+  // CHECK-NOT:    retain
+  // CHECK:        [[ORIGINAL_OWNER:%.*]] = unchecked_ref_cast {{%.*}} : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
+  // CHECK:        [[POINTER:%.+]] = struct $UnsafeRawPointer (
+  // CHECK-NEXT:   [[ORIGINAL_OWNER_EXISTENTIAL:%.*]] = init_existential_ref [[ORIGINAL_OWNER]]
+  // CHECK-NEXT:   [[OWNER:%.+]] = enum $Optional<AnyObject>, #Optional.some!enumelt, [[ORIGINAL_OWNER_EXISTENTIAL]]
+  // CHECK-NEXT:   [[DEP_POINTER:%.+]] = mark_dependence [[POINTER]] : $UnsafeRawPointer on [[ORIGINAL_OWNER]]
+  // CHECK-NEXT:   [[OPT_POINTER:%.+]] = enum $Optional<UnsafeRawPointer>, #Optional.some!enumelt, [[DEP_POINTER]]
+  // CHECK-NEXT:   br [[CALL_BRANCH:bb[0-9]+]]([[OPT_POINTER]] : $Optional<UnsafeRawPointer>, [[OWNER]] : $Optional<AnyObject>)
 
   // CHECK: [[CALL_BRANCH]]([[OPT_POINTER:%.+]] : $Optional<UnsafeRawPointer>, [[OWNER:%.+]] : $Optional<AnyObject>):
   // CHECK-NOT: release

--- a/test/SILOptimizer/simplify_copy_value.sil
+++ b/test/SILOptimizer/simplify_copy_value.sil
@@ -1,6 +1,4 @@
-// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -onone-simplification -simplify-instruction=copy_value | %FileCheck %s
-
-// REQUIRES: swift_in_compiler
+// RUN: %target-sil-opt -enable-sil-verify-all %s -simplification -simplify-instruction=copy_value | %FileCheck %s
 
 sil_stage canonical
 
@@ -12,8 +10,27 @@ sil @cl : $@convention(thin) () -> Int
 
 actor A {}
 
+class B {}
+class C : B {}
+
+struct S1 {
+  @_hasStorage let c: C
+}
+
+struct S2 {
+  @_hasStorage let c1: C
+  @_hasStorage let c2: C
+}
+
+struct S3 {
+  @_hasStorage let i: Int
+  @_hasStorage let ci: (Int, C)
+}
+
+sil @takeOwnedC : $@convention(thin) (@owned C) -> ()
+
 // CHECK-LABEL: sil [ossa] @remove_copy :
-// CHECK:         [[F:%.*]] = thin_to_thick_function %0 : $@convention(thin) () -> Int to $@callee_guaranteed () -> Int
+// CHECK:         [[F:%.*]] = thin_to_thick_function %0 to $@callee_guaranteed () -> Int
 // CHECK-NEXT:    destroy_value [[F]]
 // CHECK:       } // end sil function 'remove_copy'
 sil [ossa] @remove_copy : $@convention(thin) () -> () {
@@ -37,4 +54,169 @@ bb0:
   %3 = tuple (%1, %2)
   return %3
 }
+
+// Single-field struct: copy_value from struct_extract of a borrow.
+// The owned value is replaced by a destructure; no unused elements to destroy.
+//
+// CHECK-LABEL: sil [ossa] @projected_copy_single_field :
+// CHECK:         end_borrow
+// CHECK:         %3 = destructure_struct %0
+// CHECK-NOT:     copy_value
+// CHECK-NOT:     destroy_value {{.*}} : $S1
+// CHECK:         return %3
+// CHECK:       } // end sil function 'projected_copy_single_field'
+sil [ossa] @projected_copy_single_field : $@convention(thin) (@owned S1) -> @owned C {
+bb0(%0 : @owned $S1):
+  %1 = begin_borrow %0
+  %2 = struct_extract %1, #S1.c
+  %3 = copy_value %2
+  end_borrow %1
+  destroy_value %0
+  return %3
+}
+
+// Two-field struct: copy_value extracts c1; c2 is destroyed as the unused element.
+//
+// CHECK-LABEL: sil [ossa] @projected_copy_two_fields :
+// CHECK:         end_borrow
+// CHECK:         (%3, %4) = destructure_struct %0
+// CHECK:         destroy_value %4
+// CHECK-NOT:     copy_value
+// CHECK:         return %3
+// CHECK:       } // end sil function 'projected_copy_two_fields'
+sil [ossa] @projected_copy_two_fields : $@convention(thin) (@owned S2) -> @owned C {
+bb0(%0 : @owned $S2):
+  %1 = begin_borrow %0
+  %2 = struct_extract %1, #S2.c1
+  %3 = copy_value %2
+  end_borrow %1
+  destroy_value %0
+  return %3
+}
+
+// Same as above but extracts the second field; c1 is destroyed as unused.
+//
+// CHECK-LABEL: sil [ossa] @projected_copy_second_field :
+// CHECK:         end_borrow
+// CHECK:         (%3, %4) = destructure_struct %0
+// CHECK:         destroy_value %3
+// CHECK-NOT:     copy_value
+// CHECK:         return %4
+// CHECK:       } // end sil function 'projected_copy_second_field'
+sil [ossa] @projected_copy_second_field : $@convention(thin) (@owned S2) -> @owned C {
+bb0(%0 : @owned $S2):
+  %1 = begin_borrow %0
+  %2 = struct_extract %1, #S2.c2
+  %3 = copy_value %2
+  end_borrow %1
+  destroy_value %0
+  return %3
+}
+
+// Tuple with two class elements: copy_value extracts element 0; element 1 is destroyed.
+//
+// CHECK-LABEL: sil [ossa] @projected_copy_tuple_element :
+// CHECK:         end_borrow
+// CHECK:         (%3, %4) = destructure_tuple %0
+// CHECK:         destroy_value %4
+// CHECK-NOT:     copy_value
+// CHECK:         return %3
+// CHECK:       } // end sil function 'projected_copy_tuple_element'
+sil [ossa] @projected_copy_tuple_element : $@convention(thin) (@owned (C, C)) -> @owned C {
+bb0(%0 : @owned $(C, C)):
+  %1 = begin_borrow %0
+  %2 = tuple_extract %1, 0
+  %3 = copy_value %2
+  end_borrow %1
+  destroy_value %0
+  return %3
+}
+
+// S3 { i: Int, ci: (Int, C) }: two-level projection extracts the C from ci.
+// Two destructures are emitted; no destroy_values because Int is trivial.
+//
+// CHECK-LABEL: sil [ossa] @projected_copy_nested_struct_tuple :
+// CHECK:         end_borrow
+// CHECK:         ([[I:%[0-9]+]], [[CI:%[0-9]+]]) = destructure_struct %0
+// CHECK-NOT:     destroy_value [[I]]
+// CHECK:         ([[CI_INT:%[0-9]+]], [[C:%[0-9]+]]) = destructure_tuple [[CI]]
+// CHECK-NOT:     destroy_value [[CI_INT]]
+// CHECK-NOT:     copy_value
+// CHECK:         return [[C]]
+// CHECK:       } // end sil function 'projected_copy_nested_struct_tuple'
+sil [ossa] @projected_copy_nested_struct_tuple : $@convention(thin) (@owned S3) -> @owned C {
+bb0(%0 : @owned $S3):
+  %1 = begin_borrow %0
+  %2 = struct_extract %1, #S3.ci
+  %3 = tuple_extract %2, 1
+  %4 = copy_value %3
+  end_borrow %1
+  destroy_value %0
+  return %4
+}
+
+// The copy_value result is forwarded through an upcast before its terminal use.
+// The upcast is moved out of the owned value's liverange (to after the destructure).
+//
+// CHECK-LABEL: sil [ossa] @projected_copy_with_forwarding :
+// CHECK:         end_borrow
+// CHECK:         [[C:%.*]] = destructure_struct %0
+// CHECK-NEXT:    [[B:%.*]] = upcast [[C]] to $B
+// CHECK-NEXT:    [[D:%.*]] = unchecked_ref_cast [[B]]
+// CHECK-NOT:     copy_value
+// CHECK:         return [[D]]
+// CHECK:       } // end sil function 'projected_copy_with_forwarding'
+sil [ossa] @projected_copy_with_forwarding : $@convention(thin) (@owned S1) -> @owned C {
+bb0(%0 : @owned $S1):
+  %1 = begin_borrow %0
+  %2 = struct_extract %1, #S1.c
+  %3 = copy_value %2
+  %4 = upcast %3 to $B
+  %5 = unchecked_ref_cast %4 to $C
+  end_borrow %1
+  destroy_value %0
+  return %5
+}
+
+// -----------------------------------------------------------------------------
+// negative tests (optimization must NOT fire)
+// -----------------------------------------------------------------------------
+
+// The copy_value is consumed inside the owned value's liverange (before destroy_value).
+// The optimization requires all uses of the copy chain to be outside the liverange.
+//
+// CHECK-LABEL: sil [ossa] @no_projected_copy_use_in_liverange :
+// CHECK:         copy_value
+// CHECK-NOT:     destructure_struct
+// CHECK:       } // end sil function 'no_projected_copy_use_in_liverange'
+sil [ossa] @no_projected_copy_use_in_liverange : $@convention(thin) (@owned S1) -> @owned C {
+bb0(%0 : @owned $S1):
+  %1 = begin_borrow %0
+  %2 = struct_extract %1, #S1.c
+  %3 = copy_value %2
+  apply undef(%3) : $@convention(thin) (@guaranteed C) -> ()
+  end_borrow %1
+  destroy_value %0
+  return %3
+}
+
+
+// The optimization requires them to be in the same block.
+//
+// CHECK-LABEL: sil [ossa] @no_projected_copy_destroy_different_block :
+// CHECK:         copy_value
+// CHECK-NOT:     destructure_struct
+// CHECK:       } // end sil function 'no_projected_copy_destroy_different_block'
+sil [ossa] @no_projected_copy_destroy_different_block : $@convention(thin) (@owned S1) -> @owned C {
+bb0(%0 : @owned $S1):
+  %1 = begin_borrow %0 : $S1
+  %2 = struct_extract %1 : $S1, #S1.c
+  %3 = copy_value %2 : $C
+  end_borrow %1 : $S1
+  br bb1
+bb1:
+  destroy_value %0 : $S1
+  return %3 : $C
+}
+
 


### PR DESCRIPTION
Remove a `copy_value` from a projected owned value which outlives the enclosing owned value.
```
  %2 = begin_borrow %1
  %3 = struct_extract %2, #S.a
  %4 = copy_value %3                   // to be removed
  %5 = some_forwarding_instructions %4
  end_borrow %2
  destroy_value %1                     // end of lifetime of the enclosing owned value
  use %5                               // use of the copied value outside of the owned value's lifetime
```

The `destroy_value` is replaced with destructure operations (`destructure_struct`, `destructure_tuple`). The copied value can then be replaced by the corresponding element of the destructure. The remaining elements are element-wise destroyed. Any forwarding instructions of the copied value are moved out of the owned value's liferange.

```
  %2 = begin_borrow %1
  end_borrow %2
  (%3, %4) = destructure_struct %1
  destroy_value %3                      // destroy the unused elements
  %5 = some_forwarding_instructions %4  // moved out of %1's liferange
  use %5
```

Preconditions:
  * The `destroy_value` must be in the same basic block as the `copy_value`
  * There are no uses of the copy or its forwarding instructions inside the owned value's liverange
