### PR TITLE
[RBI]: don't interleave requires & sends in isolated partial applys

### DIFF
--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -2697,13 +2697,16 @@ public:
     REGIONBASEDISOLATION_LOG(llvm::dbgs()
                              << "Translating Isolated Partial Apply!\n");
 
-    // For each argument operand.
+    // First, require all tracked operands.
     for (auto &op : applySite.getArgumentOperands()) {
-      // See if we tracked it.
       if (auto lookupResult = tryToTrackValue(op.get())) {
-        // If we are tracking it, sent it and if it is actor derived, mark
-        // our partial apply as actor derived.
         builder.addRequire(*lookupResult);
+      }
+    }
+
+    // Next, send all tracked operands.
+    for (auto &op : applySite.getArgumentOperands()) {
+      if (auto lookupResult = tryToTrackValue(op.get())) {
         builder.addSend(lookupResult->value, &op);
       }
     }

--- a/test/Concurrency/transfernonsendable_global_actor_swift6.swift
+++ b/test/Concurrency/transfernonsendable_global_actor_swift6.swift
@@ -23,8 +23,10 @@ struct CustomActor {
   static let shared = CustomActorInstance()
 }
 
+func merge<T, U>(_ t: T, _ u: U) {}
 func transferToNonIsolated<T>(_ t: T) async {}
 @MainActor func transferToMainActor<T>(_ t: T) async {}
+@MainActor func transferToMainActor2<T, U>(_ t: T, _ u: U) async {}
 @CustomActor func transferToCustomActor<T>(_ t: T) async {}
 func useValue<T>(_ t: T) {}
 func useValueAsync<T>(_ t: T) async {}
@@ -86,4 +88,32 @@ var booleanFlag: Bool { false }
 
   await useValueAsync(erased) // expected-ni-error {{sending 'erased' risks causing data races}}
   // expected-ni-note @-1 {{sending main actor-isolated 'erased' to @concurrent global function 'useValueAsync' risks causing data races between @concurrent and main actor-isolated uses}}
+}
+
+@concurrent
+func nonisolatedToGlobalActorMergedRegionNoError() async {
+  let x = NonSendableKlass()
+  let y = NonSendableKlass()
+
+  merge(x, y)
+
+  switch Int.random(in: 1...3) {
+    case 1:
+    await transferToMainActor2(x, y)
+
+    case 2:
+    let c = { @MainActor in
+      useValue(x)
+      useValue(y)
+    }
+    await c()
+
+    // TODO: should this behave similarly?
+    // case 3:
+    // async let v = transferToMainActor2(x, y)
+    // await v
+
+    default:
+    fatalError()
+  }
 }


### PR DESCRIPTION
This changes the implementation of `translateIsolatedPartialApply` to first require all its arguments and then send them vs the prior implementation which interleaved requires & sends. This eliminates a false-positive diagnostic when values in a merged but un-sent region are both captured by an isolated closure.

[Forum discussion](https://forums.swift.org/t/proposed-fix-for-a-false-positive-region-analysis-diagnostic-involving-isolated-closure-captures/88097)

Resolves https://github.com/swiftlang/swift/issues/90254