### PR TITLE
[AST] Reflect type-body changes in non-resilient module fingerprints

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2265,10 +2265,13 @@ void ModuleDecl::collectSerializedSearchPath(
 Fingerprint ModuleDecl::getFingerprint() const {
   StableHasher hasher = StableHasher::defaultHasher();
   SmallVector<Fingerprint, 16> FPs;
+  // Clients of non-strictly-resilient modules embed type sizes and offsets;
+  // type-body changes can break that ABI, so include them in the fingerprint.
+  const bool useTypeMembers = !isStrictlyResilient();
   collectBasicSourceFileInfo([&](const BasicSourceFileInfo &bsfi) {
-    // For incremental imports, the hash must be insensitive to type-body
-    // changes, so use the one without type members.
-    FPs.emplace_back(bsfi.getInterfaceHashExcludingTypeMembers());
+    FPs.emplace_back(useTypeMembers
+                         ? bsfi.getInterfaceHashIncludingTypeMembers()
+                         : bsfi.getInterfaceHashExcludingTypeMembers());
   });
   
   // Sort the fingerprints lexicographically so we have a stable hash despite

--- a/test/Serialization/Inputs/incremental-imports-layout/Erased-after.swift
+++ b/test/Serialization/Inputs/incremental-imports-layout/Erased-after.swift
@@ -1,0 +1,8 @@
+public struct Erased {
+    private let f: (Int) -> Int
+    private let pad: (Int, Int, Int) = (0, 0, 0)
+    public init<T>(_ value: T, _ k: Int) {
+        f = { x in (value is Int ? 0 : 0) &+ x &+ k }
+    }
+    public func callAsFunction(_ x: Int) -> Int { f(x) }
+}

--- a/test/Serialization/Inputs/incremental-imports-layout/Erased-before.swift
+++ b/test/Serialization/Inputs/incremental-imports-layout/Erased-before.swift
@@ -1,0 +1,7 @@
+public struct Erased {
+    private let f: (Int) -> Int
+    public init<T>(_ value: T, _ k: Int) {
+        f = { x in (value is Int ? 0 : 0) &+ x &+ k }
+    }
+    public func callAsFunction(_ x: Int) -> Int { f(x) }
+}

--- a/test/Serialization/incremental-imports-layout.swift
+++ b/test/Serialization/incremental-imports-layout.swift
@@ -1,0 +1,22 @@
+// Adding a private stored property to a public struct in a non-resilient
+// module changes layout but not the public interface. The module
+// fingerprint must still change so the driver reads the dependency
+// graph and invalidates dependents.
+
+// RUN: %empty-directory(%t)
+// RUN: cp %S/Inputs/incremental-imports-layout/Erased-before.swift %t/Erased.swift
+
+// RUN: %target-swift-frontend -emit-module -module-name IncrementalImportsLayout -experimental-skip-non-inlinable-function-bodies-without-types -o %t/IncrementalImportsLayout.swiftmodule %t/Erased.swift
+
+// RUN: %llvm-bcanalyzer -dump %t/IncrementalImportsLayout.swiftmodule | %FileCheck %s --check-prefix=BEFORE
+
+// BEFORE-LABEL: SOURCE_FILE_DEP_GRAPH_NODE abbrevid=5 op0=6
+// BEFORE-NEXT: FINGERPRINT_NODE {{.*}} blob data = '400d6f14974cc4b2319972949ae59e77'
+
+// RUN: cp %S/Inputs/incremental-imports-layout/Erased-after.swift %t/Erased.swift
+// RUN: %target-swift-frontend -emit-module -module-name IncrementalImportsLayout -experimental-skip-non-inlinable-function-bodies-without-types -o %t/IncrementalImportsLayout.swiftmodule %t/Erased.swift
+
+// RUN: %llvm-bcanalyzer -dump %t/IncrementalImportsLayout.swiftmodule | %FileCheck %s --check-prefix=AFTER
+
+// AFTER-LABEL: SOURCE_FILE_DEP_GRAPH_NODE abbrevid=5 op0=6
+// AFTER-NEXT: FINGERPRINT_NODE {{.*}} blob data = '769ff2954a40be6aa0686156fb89bed0'


### PR DESCRIPTION
Adding a private stored property to a non-resilient struct changes its memory layout without changing the module fingerprint, leaving clients to run with the old layout and corrupt memory.

Since 90ee114b4af the module fingerprint has been computed via `getInterfaceHashExcludingTypeMembers`. The driver invalidates dependents only when that fingerprint changes, so type-body changes never triggered invalidation.

Use `getInterfaceHashIncludingTypeMembers` unless the module is strictly resilient.

Fixes #89636