### PR TITLE
[cxx-interop] Prevent IRGen from visiting templated code

### DIFF
--- a/lib/IRGen/GenClangDecl.cpp
+++ b/lib/IRGen/GenClangDecl.cpp
@@ -19,6 +19,7 @@
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclGroup.h"
+#include "clang/AST/DeclTemplate.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/ExprCXX.h"
 #include "clang/AST/GlobalDecl.h"
@@ -26,7 +27,6 @@
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/CodeGen/ModuleBuilder.h"
 #include "clang/Sema/Sema.h"
-#include "llvm/ADT/SmallPtrSet.h"
 
 using namespace swift;
 using namespace irgen;
@@ -165,6 +165,14 @@ public:
   // Do not traverse type locs, as they might contain expressions that reference
   // code that should not be instantiated and/or emitted.
   bool TraverseTypeLoc(clang::TypeLoc TL) { return true; }
+
+  // IRGen only ever emits concrete declarations, never templates. We must not
+  // descend into a template declaration at all.
+  bool TraverseFunctionTemplateDecl(clang::FunctionTemplateDecl *) {
+    return true;
+  }
+  bool TraverseClassTemplateDecl(clang::ClassTemplateDecl *) { return true; }
+  bool TraverseVarTemplateDecl(clang::VarTemplateDecl *) { return true; }
 
   bool shouldVisitTemplateInstantiations() const { return true; }
   bool shouldVisitImplicitCode() const { return true; }

--- a/test/Interop/Cxx/templates/Inputs/dependent-placement-new.h
+++ b/test/Interop/Cxx/templates/Inputs/dependent-placement-new.h
@@ -1,0 +1,26 @@
+#ifndef TEST_INTEROP_CXX_TEMPLATES_INPUTS_DEPENDENT_PLACEMENT_NEW_H
+#define TEST_INTEROP_CXX_TEMPLATES_INPUTS_DEPENDENT_PLACEMENT_NEW_H
+
+void *operator new(__SIZE_TYPE__, void *p) noexcept;
+
+struct Widget {
+  int value;
+};
+
+// A generic lambda's call operator is a member function template of the
+// closure type. In its *uninstantiated* pattern the placement-new allocates a
+// dependent type (decltype(value)), so clang leaves
+// CXXNewExpr::getOperatorNew() == nullptr. IRGen's ClangDeclFinder used to
+// descend into this pattern while looking for referenced declarations and
+// crashed dereferencing the null operator-new. It must only ever look at
+// concrete instantiations, never the dependent template pattern.
+inline Widget makeWidget() {
+  Widget result;
+  auto make = [](void *storage, auto value) {
+    ::new (storage) decltype(value)(value);
+  };
+  make(&result, Widget{42});
+  return result;
+}
+
+#endif // TEST_INTEROP_CXX_TEMPLATES_INPUTS_DEPENDENT_PLACEMENT_NEW_H

--- a/test/Interop/Cxx/templates/Inputs/module.modulemap
+++ b/test/Interop/Cxx/templates/Inputs/module.modulemap
@@ -158,6 +158,11 @@ module DefineReferencedInline {
   requires cplusplus
 }
 
+module DependentPlacementNew {
+  header "dependent-placement-new.h"
+  requires cplusplus
+}
+
 module DependentTypes {
   header "dependent-types.h"
   requires cplusplus

--- a/test/Interop/Cxx/templates/dependent-placement-new-irgen.swift
+++ b/test/Interop/Cxx/templates/dependent-placement-new-irgen.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -cxx-interoperability-mode=default | %FileCheck %s
+
+// Referencing makeWidget() forces IRGen to scan the referenced C++ decls,
+// including the generic lambda inside makeWidget() whose templated call
+// operator contains a placement-new of a dependent type. IRGen used to crash
+// traversing that uninstantiated template pattern; now it only looks at the
+// concrete instantiation and emits IR successfully.
+
+import DependentPlacementNew
+
+public func test() {
+  _ = makeWidget()
+}
+
+// CHECK: define {{.*}} @{{.*}}makeWidget


### PR DESCRIPTION
IRGen only supposed to generate code for concrete template instantiations. The RecrusiveASTVisitor that we used to collect the referenced declarations ended up visiting the primary templates as well. This resulted in occasional crashes (and potentially doing codegen for more declarations that we supposed to as visiting the template also resulted in visiting all the instantiations.)

rdar://180894858
