### PR TITLE
Runtimes: remove WMO workaround for the old driver

### DIFF
--- a/Runtimes/Overlay/CMakeLists.txt
+++ b/Runtimes/Overlay/CMakeLists.txt
@@ -14,10 +14,6 @@ list(APPEND CMAKE_MODULE_PATH
   "${CMAKE_SOURCE_DIR}/cmake/modules"
   "${CMAKE_SOURCE_DIR}/../cmake/modules")
 
-if(POLICY CMP0157 AND CMAKE_Swift_COMPILER_USE_OLD_DRIVER)
-  cmake_policy(SET CMP0157 OLD)
-endif()
-
 include(SwiftProjectVersion)
 project(SwiftOverlay
   LANGUAGES C CXX Swift

--- a/Runtimes/Supplemental/Differentiation/CMakeLists.txt
+++ b/Runtimes/Supplemental/Differentiation/CMakeLists.txt
@@ -5,10 +5,6 @@ cmake_minimum_required(VERSION 3.29)
 # in `EmitSwiftInterface.cmake`
 # to ensure it keeps laying down nested swiftmodule folders
 
-if(POLICY CMP0157 AND CMAKE_Swift_COMPILER_USE_OLD_DRIVER)
-  cmake_policy(SET CMP0157 OLD)
-endif()
-
 list(APPEND CMAKE_MODULE_PATH
   "${CMAKE_SOURCE_DIR}/../cmake/modules"
   "${CMAKE_SOURCE_DIR}/../../cmake/modules")

--- a/Runtimes/Supplemental/Distributed/CMakeLists.txt
+++ b/Runtimes/Supplemental/Distributed/CMakeLists.txt
@@ -5,10 +5,6 @@ cmake_minimum_required(VERSION 3.29)
 # in `EmitSwiftInterface.cmake`
 # to ensure it keeps laying down nested swiftmodule folders
 
-if(POLICY CMP0157 AND CMAKE_Swift_COMPILER_USE_OLD_DRIVER)
-  cmake_policy(SET CMP0157 OLD)
-endif()
-
 list(APPEND CMAKE_MODULE_PATH
   "${CMAKE_SOURCE_DIR}/../cmake/modules"
   "${CMAKE_SOURCE_DIR}/../../cmake/modules")

--- a/Runtimes/Supplemental/Observation/CMakeLists.txt
+++ b/Runtimes/Supplemental/Observation/CMakeLists.txt
@@ -5,10 +5,6 @@ cmake_minimum_required(VERSION 3.29)
 # in `EmitSwiftInterface.cmake`
 # to ensure it keeps laying down nested swiftmodule folders
 
-if(POLICY CMP0157 AND CMAKE_Swift_COMPILER_USE_OLD_DRIVER)
-  cmake_policy(SET CMP0157 OLD)
-endif()
-
 list(APPEND CMAKE_MODULE_PATH
   "${CMAKE_SOURCE_DIR}/../cmake/modules"
   "${CMAKE_SOURCE_DIR}/../../cmake/modules")

--- a/Runtimes/Supplemental/Runtime/CMakeLists.txt
+++ b/Runtimes/Supplemental/Runtime/CMakeLists.txt
@@ -5,10 +5,6 @@ cmake_minimum_required(VERSION 3.29)
 # in `EmitSwiftInterface.cmake`
 # to ensure it keeps laying down nested swiftmodule folders
 
-if(POLICY CMP0157 AND CMAKE_Swift_COMPILER_USE_OLD_DRIVER)
-  cmake_policy(SET CMP0157 OLD)
-endif()
-
 list(APPEND CMAKE_MODULE_PATH
   "${CMAKE_SOURCE_DIR}/../cmake/modules"
   "${CMAKE_SOURCE_DIR}/../../cmake/modules")

--- a/Runtimes/Supplemental/StackWalker/CMakeLists.txt
+++ b/Runtimes/Supplemental/StackWalker/CMakeLists.txt
@@ -1,9 +1,5 @@
 cmake_minimum_required(VERSION 3.29)
 
-if(POLICY CMP0157 AND CMAKE_Swift_COMPILER_USE_OLD_DRIVER)
-  cmake_policy(SET CMP0157 OLD)
-endif()
-
 list(APPEND CMAKE_MODULE_PATH
   "${CMAKE_SOURCE_DIR}/../../cmake/modules")
 

--- a/Runtimes/Supplemental/StringProcessing/CMakeLists.txt
+++ b/Runtimes/Supplemental/StringProcessing/CMakeLists.txt
@@ -5,11 +5,6 @@ cmake_minimum_required(VERSION 3.29)
 # in `EmitSwiftInterface.cmake`
 # to ensure it keeps laying down nested swiftmodule folders
 
-if(POLICY CMP0157 AND CMAKE_Swift_COMPILER_USE_OLD_DRIVER)
-  cmake_policy(SET CMP0157 OLD)
-endif()
-
-
 list(APPEND CMAKE_MODULE_PATH
   "${CMAKE_SOURCE_DIR}/../cmake/modules"
   "${CMAKE_SOURCE_DIR}/../../cmake/modules")

--- a/Runtimes/Supplemental/Synchronization/CMakeLists.txt
+++ b/Runtimes/Supplemental/Synchronization/CMakeLists.txt
@@ -5,10 +5,6 @@ cmake_minimum_required(VERSION 3.29)
 # in `EmitSwiftInterface.cmake`
 # to ensure it keeps laying down nested swiftmodule folders
 
-if(POLICY CMP0157 AND CMAKE_Swift_COMPILER_USE_OLD_DRIVER)
-  cmake_policy(SET CMP0157 OLD)
-endif()
-
 list(APPEND CMAKE_MODULE_PATH
   "${CMAKE_SOURCE_DIR}/../cmake/modules"
   "${CMAKE_SOURCE_DIR}/../../cmake/modules")
@@ -176,30 +172,6 @@ if(WIN32 AND CMAKE_SYSTEM_PROCESSOR STREQUAL i686)
   else()
     target_compile_options(swiftSynchronization PRIVATE
       $<$<COMPILE_LANGUAGE:Swift>:-whole-module-optimization>)
-  endif()
-
-  # WMO requires the early-swift-driver to be usable, which is not yet ready on
-  # Windows. Workaround this by creating an empty stub for swiftCore, removing
-  # the import library from the command line, and adding the library search path
-  # associated with it. Due to the autolink, we will still link against the
-  # library from the correct location but will also use an empty file for the
-  # additional input allowing us to perform the WMO.
-  if(CMAKE_Swift_COMPILER_USE_OLD_DRIVER)
-    get_target_property(_swiftCore_IMPORTED_IMPLIB_RELEASE swiftCore
-      IMPORTED_IMPLIB_RELEASE)
-    if(_swiftCore_IMPORTED_IMPLIB_RELEASE)
-      # Compute the library directory to allow us to find the import library by
-      # name.
-      get_filename_component(_swiftCore_IMPORTED_IMPLIB_RELEASE_DIRNAME
-        ${_swiftCore_IMPORTED_IMPLIB_RELEASE} DIRECTORY)
-      # Create a (empty) stub library
-      file(TOUCH "${CMAKE_CURRENT_BINARY_DIR}/swiftCoreStub.lib")
-      # Replace the import library with a stub to bypass the driver and frontend.
-      # Add the library search path to allow linking via autolinking.
-      set_target_properties(swiftCore PROPERTIES
-        IMPORTED_IMPLIB_RELEASE "${CMAKE_CURRENT_BINARY_DIR}/swiftCoreStub.lib"
-        INTERFACE_LINK_DIRECTORIES ${_swiftCore_IMPORTED_IMPLIB_RELEASE_DIRNAME})
-    endif()
   endif()
 endif()
 

--- a/Runtimes/Supplemental/Volatile/CMakeLists.txt
+++ b/Runtimes/Supplemental/Volatile/CMakeLists.txt
@@ -5,10 +5,6 @@ cmake_minimum_required(VERSION 3.29)
 # in `EmitSwiftInterface.cmake`
 # to ensure it keeps laying down nested swiftmodule folders
 
-if(POLICY CMP0157 AND CMAKE_Swift_COMPILER_USE_OLD_DRIVER)
-  cmake_policy(SET CMP0157 OLD)
-endif()
-
 list(APPEND CMAKE_MODULE_PATH
   "${CMAKE_SOURCE_DIR}/../cmake/modules"
   "${CMAKE_SOURCE_DIR}/../../cmake/modules")


### PR DESCRIPTION
Windows was the one hold out for the early swift-driver. Now that active platforms support the early swift-driver it is unclear if we should hold on to the old path. Now with bootstrapping enabled, we are slowly moving towards a world where Swift is a hard requirement and the workaround has no remaining value.

Fixes: #90235