### PR TITLE
Update CI docs: Include Apple Silicon macOS

### DIFF
--- a/docs/ContinuousIntegration.md
+++ b/docs/ContinuousIntegration.md
@@ -79,18 +79,19 @@ A smoke test on Linux does the following:
 
 ### Validation Testing
 
-Platform     | Comment | Check Status
------------- | ------- | ------------
-All supported platforms     | @swift-ci Please test                         | Swift Test Linux Platform (smoke test)<br>Swift Test macOS Platform (smoke test)<br>Swift Test Linux Platform<br>Swift Test macOS Platform<br>
-All supported platforms     | @swift-ci Please clean test                   | Swift Test Linux Platform (smoke test)<br>Swift Test macOS Platform (smoke test)<br>Swift Test Linux Platform<br>Swift Test macOS Platform<br>
-macOS platform               | @swift-ci Please test macOS platform           | Swift Test macOS Platform (smoke test)<br>Swift Test macOS Platform
-macOS platform               | @swift-ci Please clean test macOS platform     | Swift Test macOS Platform (smoke test)<br>Swift Test macOS Platform
-macOS platform               | @swift-ci Please benchmark                    | Swift Benchmark on macOS Platform (many runs - rigorous)
-macOS platform               | @swift-ci Please smoke benchmark              | Swift Benchmark macOS Platform (few runs - soundness)
-Linux platform               | @swift-ci Please test Linux platform          | Swift Test Linux Platform (smoke test)<br>Swift Test Linux Platform
-Linux platform               | @swift-ci Please clean test Linux platform    | Swift Test Linux Platform (smoke test)<br>Swift Test Linux Platform
-Linux platform               | @swift-ci Please test WebAssembly             | Swift Test WebAssembly (Ubuntu 20.04)
-Swift SDK for Android        | @swift-ci Please test android                 | Swift SDK for Android
+Platform                       | Comment                                              | Check Status
+------------------------------ | ---------------------------------------------------- | ------------
+All supported platforms        | @swift-ci Please test                                | Swift Test Linux Platform (smoke test)<br>Swift Test macOS Platform (smoke test)<br>Swift Test Linux Platform<br>Swift Test macOS Platform<br>
+All supported platforms        | @swift-ci Please clean test                          | Swift Test Linux Platform (smoke test)<br>Swift Test macOS Platform (smoke test)<br>Swift Test Linux Platform<br>Swift Test macOS Platform<br>
+macOS platform                 | @swift-ci Please test macOS platform                 | Swift Test macOS Platform (smoke test)<br>Swift Test macOS Platform
+macOS platform (Apple Silicon) | @swift-ci Please test Apple Silicon macOS platform   | Swift Test Apple Silicon macOS Platform
+macOS platform                 | @swift-ci Please clean test macOS platform           | Swift Test macOS Platform (smoke test)<br>Swift Test macOS Platform
+macOS platform                 | @swift-ci Please benchmark                           | Swift Benchmark on macOS Platform (many runs - rigorous)
+macOS platform                 | @swift-ci Please smoke benchmark                     | Swift Benchmark macOS Platform (few runs - soundness)
+Linux platform                 | @swift-ci Please test Linux platform                 | Swift Test Linux Platform (smoke test)<br>Swift Test Linux Platform
+Linux platform                 | @swift-ci Please clean test Linux platform           | Swift Test Linux Platform (smoke test)<br>Swift Test Linux Platform
+Linux platform                 | @swift-ci Please test WebAssembly                    | Swift Test WebAssembly (Ubuntu 20.04)
+Swift SDK for Android          | @swift-ci Please test android                        | Swift SDK for Android
 
 The core principles of validation testing is that:
 


### PR DESCRIPTION
The validation table was missing the trigger for the Apple Silicon job. Adding it to the docs.