### PR TITLE
[CMake] Propagate SWIFT_USE_SWIFT_EMBEDDED_PLATFORM into the Concurrency build as well

### DIFF
--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -356,6 +356,10 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
       endif()
     endif()
 
+    if(SWIFT_USE_SWIFT_EMBEDDED_PLATFORM)
+      list(APPEND extra_c_compile_flags "-DSWIFT_USE_EMBEDDED_SWIFT_PLATFORM=1")
+    endif()
+
     if("${arch}" MATCHES "wasm32")
       set(SWIFT_RUNTIME_CONCURRENCY_EMBEDDED_SWIFT_SOURCES
         ExecutorImpl.swift


### PR DESCRIPTION
Make sure we set -DSWIFT_USE_EMBEDDED_SWIFT_PLATFORM=1 for the C sources built in the concurrency library when
SWIFT_USE_SWIFT_EMBEDDED_PLATFORM has been enabled.
