### PR TITLE
[test][Reflection] Fix tests under remote-run

### DIFF
--- a/validation-test/Reflection/reflect_Enum_values_resilient.swift
+++ b/validation-test/Reflection/reflect_Enum_values_resilient.swift
@@ -6,7 +6,7 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -L %t -I %t -lresilient_enums -o %t/reflect_Enum_values_resilient %target-rpath(%t)
 // RUN: %target-codesign %t/reflect_Enum_values_resilient
 
-// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_values_resilient | tee /dev/stderr | %FileCheck %s --dump-input=fail
+// RUN: env %env-_EXTRA_DYLIB=%t/%target-library-name(resilient_enums) %target-run %target-swift-reflection-test %t/reflect_Enum_values_resilient | tee /dev/stderr | %FileCheck %s --dump-input=fail
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop, OS=macosx

--- a/validation-test/Reflection/reflect_extension_parent_class.swift
+++ b/validation-test/Reflection/reflect_extension_parent_class.swift
@@ -7,7 +7,7 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %t/main.swift -L %t -I %t -lBase -o %t/reflect_extension_parent_class %target-rpath(%t)
 // RUN: %target-codesign %t/reflect_extension_parent_class
 
-// RUN: %target-run %target-swift-reflection-test %t/reflect_extension_parent_class | tee /dev/stderr | %FileCheck %s --dump-input=fail
+// RUN: env %env-_EXTRA_DYLIB=%t/%target-library-name(Base) %target-run %target-swift-reflection-test %t/reflect_extension_parent_class | tee /dev/stderr | %FileCheck %s --dump-input=fail
 
 // REQUIRES: executable_test
 // REQUIRES: reflection_test_support


### PR DESCRIPTION
`remote-run` walks each whole command-line argument and any `REMOTE_RUN_CHILD_*` env-var value, and uploads paths that start with `--output-prefix` (which lit sets to `%t`). This is purely a textual match on argv elements. For the two tests modified in this PR, helper dylibs do not appear on the command line and are therefore not uploaded to the remote host under remote-run.

This PR fixes that by:
- `reflect_extension_parent_class.swift`: set a dummy env var to the dylib path. remote-run's `EnvVarProcessor` runs every `REMOTE_RUN_CHILD_*` value through the same upload logic as argv, so the dylib gets rsynced
  the remote process.
- `reflect_Enum_values_resilient.swift`: same fix with `libresilient_enums.dylib`.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
