### PR TITLE
[update-checkout] ensure cross repo testing can merge histories

### DIFF
--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -141,6 +141,18 @@ def get_branch_for_repo(
             # at the time GitHub created it. Depth=2 makes X visible locally.
             Git.run(
                 repo_path,
+                ["rev-parse", "--is-shallow-repository"],
+                echo=True,
+                prefix=prefix,
+            )
+            Git.run(
+                repo_path,
+                ["log", "--oneline", f"origin/{scheme_branch}"],
+                echo=True,
+                prefix=prefix,
+            )
+            Git.run(
+                repo_path,
                 [
                     "fetch",
                     "origin",
@@ -153,6 +165,31 @@ def get_branch_for_repo(
                     "--depth", "2",
                     f"pull/{pr_id}/merge:{repo_branch}",
                 ],
+                echo=True,
+                prefix=prefix,
+            )
+            Git.run(
+                repo_path,
+                ["rev-parse", f"{repo_branch}^1"],
+                echo=True,
+                prefix=prefix,
+            )
+            Git.run(
+                repo_path,
+                ["merge-base", repo_branch, f"origin/{scheme_branch}"],
+                echo=True,
+                prefix=prefix,
+                allow_non_zero_exit=True,
+            )
+            Git.run(
+                repo_path,
+                ["log", "--oneline", repo_branch],
+                echo=True,
+                prefix=prefix,
+            )
+            Git.run(
+                repo_path,
+                ["log", "--oneline", f"origin/{scheme_branch}"],
                 echo=True,
                 prefix=prefix,
             )
@@ -175,6 +212,26 @@ def get_branch_for_repo(
                 echo=True,
                 prefix=prefix,
             )
+            Git.run(
+                repo_path,
+                ["merge-base", repo_branch, f"origin/{scheme_branch}"],
+                echo=True,
+                prefix=prefix,
+                allow_non_zero_exit=True,
+            )
+            Git.run(
+                repo_path,
+                ["log", "--oneline", repo_branch],
+                echo=True,
+                prefix=prefix,
+            )
+            Git.run(
+                repo_path,
+                ["log", "--oneline", f"origin/{scheme_branch}"],
+                echo=True,
+                prefix=prefix,
+            )
+
             # Check out repo_branch and merge the base branch into it.
             # GitHub cannot be trusted to keep PR merge branches up-to-date.
             Git.run(repo_path, ["checkout", repo_branch], echo=True, prefix=prefix)

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -149,6 +149,7 @@ def get_branch_for_repo(
                     # If repo_branch exists and is checked out, this will
                     # prevent Git from refusing the fetch.
                     "--update-head-ok",
+                    "--tags",
                     "--depth", "2",
                     f"pull/{pr_id}/merge:{repo_branch}",
                 ],

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -133,6 +133,12 @@ def get_branch_for_repo(
 
             # Fetch the PR merge branch into repo_branch, and also fetch the
             # scheme branch, which ought to match the PR base branch.
+            #
+            # Two-step fetch so the merge below can find the common ancestor:
+            #
+            # Step 1: fetch the PR merge ref at depth=2. GitHub's merge ref
+            # is a merge commit whose parent is the base-branch HEAD (X)
+            # at the time GitHub created it. Depth=2 makes X visible locally.
             Git.run(
                 repo_path,
                 [
@@ -143,8 +149,26 @@ def get_branch_for_repo(
                     # If repo_branch exists and is checked out, this will
                     # prevent Git from refusing the fetch.
                     "--update-head-ok",
-                    "--tags",
+                    "--depth", "2",
                     f"pull/{pr_id}/merge:{repo_branch}",
+                ],
+                echo=True,
+                prefix=prefix,
+            )
+            # Step 2: fetch the scheme branch back to X's timestamp so its
+            # history includes X. Using timestamp-1 ensures X itself is
+            # included.
+            timestamp, _, _ = Git.run(
+                repo_path,
+                ["log", "--format=%ct", "-1", f"{repo_branch}^1"],
+            )
+            Git.run(
+                repo_path,
+                [
+                    "fetch",
+                    "origin",
+                    "--tags",
+                    f"--shallow-since=@{int(timestamp) - 1}",
                     scheme_branch,
                 ],
                 echo=True,


### PR DESCRIPTION
When cross repo testing we need to fetch at least enough history from both branches so they can be merged when the repository is shallow cloned. 

This means finding the common commit in both which would be PR/ID/merge^1

Fixing https://ci-external.swift.org/job/swift-PR-windows/57461/console