### PR TITLE
[cxx-interop] Fix crashes when iterating over containers of foreign reference types

### DIFF
--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -1065,7 +1065,17 @@ conformToCxxSequenceIfNeeded(ClangImporter::Implementation &impl,
     // begin() and end() need to have the same return type
     return;
 
-  if (!iterTy->isPointerOrReferenceType()) {
+  if (iterTy->isPointerOrReferenceType()) {
+    auto pointeeQualType = iterTy->getPointeeType().getCanonicalType();
+    if (auto *pointeeRecord = pointeeQualType->getAsCXXRecordDecl()) {
+      auto info = evaluateOrDefault(
+          ctx.evaluator, ForeignReferenceTypeInfoRequest({pointeeRecord}), {});
+      // If begin()/end() return a pointer to an FRT, the pointer will be
+      // stripped to the bare FRT class in Swift, which is not a usable iterator
+      if (info.isReference())
+        return;
+    }
+  } else {
     // Check if begin() returns an iterator.
     auto *iterDecl = iterTy->getAsCXXRecordDecl();
     if (!iterDecl || !iterDecl->hasDefinition())

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -1825,6 +1825,14 @@ SubscriptDecl *SwiftDeclSynthesizer::makeSubscript(FuncDecl *getter,
   bool useAddress =
       rawElementTy->getAnyPointerElementType() && elementIsNoncopyable;
 
+  // Foreign references (e.g., FRT* or FRT&) are directly mapped to the FRT
+  // class type rather than UnsafeMutablePointer<FRT>, and isn't something we
+  // can synthesize a valid setter for.
+  //
+  // ty->isForeignReferenceType() implies !ty->getAnyPointerElementType().
+  if (rawElementTy->isForeignReferenceType())
+    setterImpl = nullptr;
+
   AccessorDecl *getterDecl = AccessorDecl::create(
       ctx, getterImpl->getLoc(), getterImpl->getLoc(),
       useAddress ? AccessorKind::Address : AccessorKind::Get, subscript,
@@ -1926,6 +1934,14 @@ SwiftDeclSynthesizer::makeDereferencedPointeeProperty(FuncDecl *getter,
   bool isImplicit = !(isNoncopyable || resultDependsOnSelf);
   bool useAddress =
       rawElementTy->getAnyPointerElementType() && (isNoncopyable || resultDependsOnSelf);
+
+  // Foreign references (e.g., FRT* or FRT&) are directly mapped to the FRT
+  // class type rather than UnsafeMutablePointer<FRT>, and isn't something we
+  // can synthesize a valid setter for.
+  //
+  // ty->isForeignReferenceType() implies !ty->getAnyPointerElementType().
+  if (rawElementTy->isForeignReferenceType())
+    setterImpl = nullptr;
 
   auto result = new (ctx)
       VarDecl(/*isStatic*/ false, VarDecl::Introducer::Var,

--- a/test/Interop/Cxx/foreign-reference/Inputs/frt-sequence.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/frt-sequence.h
@@ -1,0 +1,54 @@
+#pragma once
+#include <vector>
+#include <swift/bridging>
+
+struct ImmortalNode {
+  int value;
+} SWIFT_IMMORTAL_REFERENCE;
+
+struct ImmortalNode2 {
+  int value;
+} SWIFT_IMMORTAL_REFERENCE;
+
+struct SharedNode {
+  int value;
+  mutable int retainCount = 1;
+
+  SharedNode(int v) : value(v), retainCount(1) {}
+  SharedNode(const SharedNode &o) : value(o.value), retainCount(1) {}
+
+  void retain() const { ++retainCount; }
+  void release() const { --retainCount; }
+} SWIFT_SHARED_REFERENCE(.retain, .release);
+
+inline std::vector<ImmortalNode *> makeImmortalPtrVector() {
+  static ImmortalNode a{10}, b{20}, c{30};
+  return {&a, &b, &c};
+}
+
+inline std::vector<SharedNode *> makeSharedPtrVector() {
+  return {new SharedNode(101), new SharedNode(202), new SharedNode(303)};
+}
+
+// Use a distinct type from ImmortalNode to avoid a known duplicate witness
+// table bug when vector<T> and vector<T*> coexist for the same T.
+inline std::vector<ImmortalNode2> makeImmortalValVector() {
+  return {{11}, {22}, {33}};
+}
+
+// Custom container whose methods return raw pointers to an FRT, which get
+// imported as Optional<FRT> and cannot be iterated over.
+struct RawPtrIterContainer {
+  ImmortalNode *data;
+  int size;
+
+  RawPtrIterContainer() {
+    static ImmortalNode storage[3] = {{10}, {20}, {30}};
+    data = storage;
+    size = 3;
+  }
+
+  const ImmortalNode *begin() const { return data; }
+  const ImmortalNode *end() const { return data + size; }
+  const ImmortalNode *operator[](int i) const { return &data[i]; }
+};

--- a/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
+++ b/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
@@ -134,3 +134,8 @@ module ImmortalFRTHashable {
   header "immortal-frt-hashable.h"
   requires cplusplus
 }
+
+module FrtSequence {
+  header "frt-sequence.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/foreign-reference/frt-sequence-executable.swift
+++ b/test/Interop/Cxx/foreign-reference/frt-sequence-executable.swift
@@ -1,0 +1,49 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default)
+// REQUIRES: executable_test
+
+import FrtSequence
+import CxxStdlib
+import StdlibUnittest
+
+var FrtSequenceTests = TestSuite("Iterating over std::vector of FRTs")
+
+FrtSequenceTests.test("iterate over vector of ImmortalNode pointers") {
+  let vec = makeImmortalPtrVector()
+  var values: [CInt] = []
+  for node in vec {
+    values.append(node!.value)
+  }
+  expectEqual(values, [10, 20, 30])
+}
+
+FrtSequenceTests.test("subscript assignment on vector of ImmortalNode pointers") {
+  var vec = makeImmortalPtrVector()
+  let first = vec[0]
+  let second = vec[1]
+  // Swap first two elements via subscript assignment.
+  vec[0] = second
+  vec[1] = first
+  expectEqual(vec[0]!.value, 20)
+  expectEqual(vec[1]!.value, 10)
+  expectEqual(vec[2]!.value, 30)
+}
+
+FrtSequenceTests.test("iterate over vector of SharedNode pointers") {
+  let vec = makeSharedPtrVector()
+  var values: [CInt] = []
+  for node in vec {
+    values.append(node!.value)
+  }
+  expectEqual(values, [101, 202, 303])
+}
+
+FrtSequenceTests.test("iterate over vector of ImmortalNode2 values") {
+  let vec = makeImmortalValVector()
+  var values: [CInt] = []
+  for node in vec {
+    values.append(node.value)
+  }
+  expectEqual(values, [11, 22, 33])
+}
+
+runAllTests()

--- a/test/Interop/Cxx/foreign-reference/frt-sequence-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/frt-sequence-module-interface.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=FrtSequence \
+// RUN:   -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default \
+// RUN:   | %FileCheck %s
+
+// FRT types are imported as Swift classes.
+// CHECK: class ImmortalNode {
+// CHECK:   var value: Int32
+// CHECK: }
+
+// CHECK: class ImmortalNode2 {
+// CHECK:   var value: Int32
+// CHECK: }
+
+// CHECK: class SharedNode {
+// CHECK:   var value: Int32
+// CHECK:   func retain()
+// CHECK:   func release()
+// CHECK: }
+
+// CHECK: func makeImmortalPtrVector()
+// CHECK: func makeSharedPtrVector()
+// CHECK: func makeImmortalValVector()
+
+// CHECK: struct RawPtrIterContainer {
+// CHECK:   func __beginUnsafe() -> ImmortalNode!
+// CHECK:   func __endUnsafe() -> ImmortalNode!
+// CHECK: }

--- a/test/Interop/Cxx/foreign-reference/frt-sequence-typechecker.swift
+++ b/test/Interop/Cxx/foreign-reference/frt-sequence-typechecker.swift
@@ -1,0 +1,81 @@
+// RUN: %target-typecheck-verify-swift \
+// RUN:   -I %S/Inputs -cxx-interoperability-mode=default \
+// RUN:   -disable-availability-checking -disable-typo-correction
+
+import FrtSequence
+import CxxStdlib
+
+// --- std::vector<ImmortalNode*> iteration yields ImmortalNode? ---
+
+let ipv = makeImmortalPtrVector()
+let _ = ipv.begin() // expected-error {{has no member 'begin'}}
+                    // expected-note@-1 {{C++ method 'begin' that returns an iterator is unavailable}}
+                    // expected-note@-2 {{do you want to use a for-in loop instead?}}
+let _ = ipv.end()   // expected-error {{has no member 'end'}}
+                    // expected-note@-1 {{C++ method 'end' that returns an iterator is unavailable}}
+                    // expected-note@-2 {{do you want to compare against 'nil' instead?}}
+let _ = ipv.__beginUnsafe()
+let _ = ipv.__endUnsafe()
+for i in ipv {
+  let _: ImmortalNode? = i
+}
+
+// Subscript on vector<FRT*> is read-write: operator[] returns FRT*& which
+// is not FRT-stripped at the reference level, so the setter is preserved.
+var mutableIpv = makeImmortalPtrVector()
+let elem: ImmortalNode? = mutableIpv[0]
+mutableIpv[0] = elem
+
+// --- std::vector<SharedNode*> iteration yields SharedNode? ---
+
+let spv = makeSharedPtrVector()
+let _ = spv.begin() // expected-error {{has no member 'begin'}}
+                    // expected-note@-1 {{C++ method 'begin' that returns an iterator is unavailable}}
+                    // expected-note@-2 {{do you want to use a for-in loop instead?}}
+let _ = spv.end()   // expected-error {{has no member 'end'}}
+                    // expected-note@-1 {{C++ method 'end' that returns an iterator is unavailable}}
+                    // expected-note@-2 {{do you want to compare against 'nil' instead?}}
+let _ = spv.__beginUnsafe()
+let _ = spv.__endUnsafe()
+for i in spv {
+  let _: SharedNode? = i
+}
+
+// --- std::vector<ImmortalNode2> iteration yields ImmortalNode2 ---
+
+let ivv = makeImmortalValVector()
+let _ = ivv.begin() // expected-error {{has no member 'begin'}}
+                    // expected-note@-1 {{C++ method 'begin' that returns an iterator is unavailable}}
+                    // expected-note@-2 {{do you want to use a for-in loop instead?}}
+let _ = ivv.end()   // expected-error {{has no member 'end'}}
+                    // expected-note@-1 {{C++ method 'end' that returns an iterator is unavailable}}
+                    // expected-note@-2 {{do you want to compare against 'nil' instead?}}
+let _ = ivv.__beginUnsafe()
+let _ = ivv.__endUnsafe()
+for i in ivv {
+  let _: ImmortalNode2 = i
+}
+
+// --- RawPtrIterContainer: raw pointer begin()/end() over FRT ---
+
+let rpc = RawPtrIterContainer()
+
+// begin()/end() return const ImmortalNode*, which gets imported without the
+// pointer as ImmortalNode? and cannot be iterated over.
+for _ in rpc {} // expected-error {{for-in loop requires 'RawPtrIterContainer' to conform to 'Sequence'}}
+
+// begin()/end() are still renamed to __beginUnsafe/__endUnsafe
+
+let _ = rpc.begin() // expected-error {{has no member 'begin'}}
+                    // expected-note@-1 {{C++ method 'begin' that returns an iterator is unavailable}}
+                    // expected-note@-2 {{C++ methods that return iterators are potentially unsafe; try using Swift collection APIs instead}}
+let _ = rpc.end()   // expected-error {{has no member 'end'}}
+                    // expected-note@-1 {{C++ method 'end' that returns an iterator is unavailable}}
+                    // expected-note@-2 {{C++ methods that return iterators are potentially unsafe; try using Swift collection APIs instead}}
+let _: ImmortalNode? = rpc.__beginUnsafe()
+let _: ImmortalNode? = rpc.__endUnsafe()
+
+// operator[] returns const ImmortalNode* which is a get-only subscript that
+// returns ImmortalNode? (FRT pointer stripping + nullable pointer).
+let node: ImmortalNode? = rpc[0]
+rpc[1] = node // expected-error {{subscript is get-only}}


### PR DESCRIPTION
Two issues caused compiler crashes when iterating over containers of FRTs:

- The subscript setter and iterator pointee setter assumed `operator[]` and `operator*()` return `UnsafeMutablePointer<T>`, but FRT collapses `T&` to bare `T` (a class type), leading to an invalid setter body that crashes during SIL verification.

- Containers with raw pointer `begin()`/`end()` returning `FRT*` had the similarly stripped to `FRT?`, which triggered a downstream conformance check failure for `UnsafeCxxInputIterator`.

This patch bails out of the setter synthesis and conformance derivation when this happens, and adds tests for both `std::vector<FRT*>` and `std::vector<FRT>`, as well as a custom container with `begin()` and `end()` return `FRT *`.

Known issue: using both `vector<FRT>` and `vector<FRT*>` for the same FRT in one compilation unit crashes due to a separate bug where the conformance checker creates duplicate `CxxSequence` conformances.

rdar://180479293

Stacked on top of https://github.com/swiftlang/swift/pull/90175, which ensure the `begin()` -> `__beginUnsafe()` renaming always happen even when `begin()` returns an FRT.