### PR TITLE
[Concurrency] Downgrade cross module warning for NS superclass + iso

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7650,13 +7650,23 @@ bool swift::checkSendableConformance(
       conformanceDC->getOutermostParentSourceFile() !=
       nominal->getOutermostParentSourceFile()) {
     if (!(nominal->hasClangNode() && wasImplied)) {
-      conformanceDecl
-          ->diagnose(diag::concurrent_value_outside_source_file, nominal)
-          .limitBehaviorWithPreconcurrency(
-              behavior, impliedByPreconcurrencyProtocol, LanguageMode::v6);
+      InFlightDiagnostic outsideSourceFileDiag = conformanceDecl
+          ->diagnose(diag::concurrent_value_outside_source_file, nominal);
 
-      if (behavior == DiagnosticBehavior::Unspecified)
-        return true;
+      // TODO: Remove this staging (and suppress the conformance) once people
+      // have had a chance to adopt...
+      if (isGlobalActorIsolated) {
+        // This branch was being skipped for global actor isolated tests
+        // until 6.4 so we can't emit this as an error for isolated decls.
+        outsideSourceFileDiag.limitBehaviorWithPreconcurrency(
+            behavior, impliedByPreconcurrencyProtocol, LanguageMode::future);
+      } else {
+        outsideSourceFileDiag.limitBehaviorWithPreconcurrency(
+            behavior, impliedByPreconcurrencyProtocol, LanguageMode::v6);
+
+        if (behavior == DiagnosticBehavior::Unspecified)
+          return true;
+      }
     }
   }
 

--- a/test/Concurrency/predates_concurrency_import_swift6.swift
+++ b/test/Concurrency/predates_concurrency_import_swift6.swift
@@ -27,3 +27,9 @@ extension NonStrictClass {
 extension StrictStruct {
   @Sendable func f() { } // expected-warning{{instance method of non-Sendable type 'StrictStruct' cannot be marked as '@Sendable'}}
 }
+
+@preconcurrency protocol RefinesSendable: Sendable {}
+extension StrictClass: RefinesSendable {}
+// expected-warning@-1{{extension declares a conformance of imported type 'StrictClass' to imported protocol 'Sendable'; this will not behave correctly if the owners of 'StrictModule' introduce this conformance in the future}}
+// expected-note@-2{{add '@retroactive' to silence this warning}}
+// expected-warning@-3{{conformance to 'Sendable' must occur in the same source file as class 'StrictClass'; use '@unchecked Sendable' for retroactive conformance}}

--- a/test/Concurrency/sendable_conformance_checking_cross_file_isolated.swift
+++ b/test/Concurrency/sendable_conformance_checking_cross_file_isolated.swift
@@ -1,0 +1,51 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file --leading-lines %s %t
+
+// RUN: %target-swift-frontend -typecheck -verify %t/Definitions.swift %t/Conformance.swift -swift-version 5
+// RUN: %target-swift-frontend -typecheck -verify %t/Definitions.swift %t/Conformance.swift -swift-version 5 -strict-concurrency=complete
+// RUN: %target-swift-frontend -typecheck -verify %t/Definitions.swift %t/Conformance.swift -swift-version 6
+
+// REQUIRES: concurrency
+
+//--- Definitions.swift
+class NonSendable {}
+
+protocol RefinesSendable: Sendable {}
+
+@MainActor
+class Extends: NonSendable {}
+// expected-note@-1:16 {{inherits from non-Sendable class 'NonSendable'}}
+
+@MainActor
+class Refined: NonSendable {}
+// expected-note@-1:16 {{inherits from non-Sendable class 'NonSendable'}}
+
+@MainActor
+class IsolatedBase: NonSendable {}
+
+// '@MainActor' inherited from the superclass, not stated.
+class InheritsIsolation: IsolatedBase {}
+// expected-note@-1:26 {{inherits from non-Sendable class 'IsolatedBase'}}
+
+//--- Conformance.swift
+extension Extends: Sendable {}
+// expected-warning@-1:1 {{conformance to 'Sendable' must occur in the same source file as class 'Extends'; use '@unchecked Sendable' for retroactive conformance; this will be an error in a future Swift language mode}}
+// expected-warning@-2:1 {{class 'Extends' cannot conform to the 'Sendable' protocol; this will be an error in a future Swift language mode}}
+// expected-note@-3:1 {{a 'Sendable' class cannot inherit from a non-Sendable class}}
+
+extension InheritsIsolation: Sendable {}
+// expected-warning@-1:1 {{conformance to 'Sendable' must occur in the same source file as class 'InheritsIsolation'; use '@unchecked Sendable' for retroactive conformance; this will be an error in a future Swift language mode}}
+// expected-warning@-2:1 {{class 'InheritsIsolation' cannot conform to the 'Sendable' protocol; this will be an error in a future Swift language mode}}
+// expected-note@-3:1 {{a 'Sendable' class cannot inherit from a non-Sendable class}}
+
+extension Refined: RefinesSendable {}
+// expected-warning@-1:1 {{conformance to 'Sendable' must occur in the same source file as class 'Refined'; use '@unchecked Sendable' for retroactive conformance; this will be an error in a future Swift language mode}}
+// expected-warning@-2:1 {{class 'Refined' cannot conform to the 'Sendable' protocol; this will be an error in a future Swift language mode}}
+// expected-note@-3:1 {{a 'Sendable' class cannot inherit from a non-Sendable class}}
+
+func requiresSendable<T: Sendable>(_: T.Type) {}
+func testStillSendable() {
+  requiresSendable(Extends.self)
+  requiresSendable(InheritsIsolation.self)
+  requiresSendable(Refined.self)
+}

--- a/test/Concurrency/sendable_conformance_checking_cross_file_isolated_objc.swift
+++ b/test/Concurrency/sendable_conformance_checking_cross_file_isolated_objc.swift
@@ -1,0 +1,58 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -typecheck -verify %t/main.swift -I %t -enable-objc-interop -parse-as-library -swift-version 5
+// RUN: %target-swift-frontend -typecheck -verify %t/main.swift -I %t -enable-objc-interop -parse-as-library -swift-version 5 -strict-concurrency=complete
+// RUN: %target-swift-frontend -typecheck -verify %t/main.swift -I %t -enable-objc-interop -parse-as-library -swift-version 6
+
+// REQUIRES: concurrency
+// REQUIRES: objc_interop
+
+//--- module.modulemap
+module IsolatedObjC {
+  header "IsolatedObjC.h"
+}
+
+//--- IsolatedObjC.h
+__attribute__((objc_root_class))
+__attribute__((__swift_attr__("@MainActor")))
+@interface IsolatedObjCClass
+@end
+
+__attribute__((objc_root_class))
+__attribute__((__swift_attr__("@MainActor")))
+@interface IsolatedObjCBase
+@end
+
+@interface InheritsObjCIsolation : IsolatedObjCBase
+@end
+
+__attribute__((objc_root_class))
+__attribute__((__swift_attr__("@MainActor")))
+@interface RefinedObjCClass
+@end
+
+//--- main.swift
+import IsolatedObjC
+
+protocol RefinesSendable: Sendable {}
+
+extension IsolatedObjCClass: Sendable {}
+// expected-warning@-1:1 {{extension declares a conformance of imported type 'IsolatedObjCClass' to imported protocol 'Sendable'; this will not behave correctly if the owners of 'IsolatedObjC' introduce this conformance in the future}}
+// expected-note@-2 {{add '@retroactive' to silence this warning}}
+// expected-warning@-3:1 {{conformance to 'Sendable' must occur in the same source file as class 'IsolatedObjCClass'; use '@unchecked Sendable' for retroactive conformance; this will be an error in a future Swift language mode}}
+
+extension InheritsObjCIsolation: Sendable {}
+// expected-warning@-1:1 {{extension declares a conformance of imported type 'InheritsObjCIsolation' to imported protocol 'Sendable'; this will not behave correctly if the owners of 'IsolatedObjC' introduce this conformance in the future}}
+// expected-note@-2 {{add '@retroactive' to silence this warning}}
+// expected-warning@-3:1 {{conformance to 'Sendable' must occur in the same source file as class 'InheritsObjCIsolation'; use '@unchecked Sendable' for retroactive conformance; this will be an error in a future Swift language mode}}
+
+// Clang imported + implied is totally ignored, not sure this is correct but its the existing behavior.
+extension RefinedObjCClass: RefinesSendable {}
+
+func requiresSendable<T: Sendable>(_: T.Type) {}
+func testStillSendable() {
+  requiresSendable(IsolatedObjCClass.self)
+  requiresSendable(InheritsObjCIsolation.self)
+  requiresSendable(RefinedObjCClass.self)
+}


### PR DESCRIPTION
Ungating isolated decls from this logic means they can also trigger this error, downgrade it to a warning for isolated decls.

Resolves rdar://180885245

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
