### PR TITLE
[Concurrency] Add _concurrency_current_task_storage_kind to Debug.h

### DIFF
--- a/include/swift/Threading/ThreadLocalStorage.h
+++ b/include/swift/Threading/ThreadLocalStorage.h
@@ -212,12 +212,23 @@ public:
 #ifdef SWIFT_THREAD_LOCAL
 #define SWIFT_THREAD_LOCAL_TYPE(TYPE, KEY)                                     \
   SWIFT_THREAD_LOCAL swift::ThreadLocal<TYPE>
+#if SWIFT_THREADING_NONE
+#define SWIFT_THREAD_LOCAL_STORAGE_KIND                                        \
+  _concurrency_current_task_storage_kind::global
+#else
+#define SWIFT_THREAD_LOCAL_STORAGE_KIND                                        \
+  _concurrency_current_task_storage_kind::cxx_thread_local
+#endif
 #elif SWIFT_THREADING_USE_RESERVED_TLS_KEYS
 #define SWIFT_THREAD_LOCAL_TYPE(TYPE, KEY)                                     \
   swift::ThreadLocal<TYPE, swift::ConstantThreadLocalKey<KEY>>
+#define SWIFT_THREAD_LOCAL_STORAGE_KIND                                        \
+  _concurrency_current_task_storage_kind::pthread_reserved_key
 #else
 #define SWIFT_THREAD_LOCAL_TYPE(TYPE, KEY)                                     \
   swift::ThreadLocal<TYPE, swift::ThreadLocalKey>
+#define SWIFT_THREAD_LOCAL_STORAGE_KIND                                        \
+  _concurrency_current_task_storage_kind::pthread_allocated_key
 #endif
 
 #endif // SWIFT_THREADING_THREADLOCALSTORAGE_H

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -24,10 +24,11 @@
 #endif
 
 #include "../CompatibilityOverride/CompatibilityOverride.h"
-#include "swift/ABI/Actor.h"
-#include "swift/ABI/Task.h"
+#include "Debug.h"
 #include "ExecutorBridge.h"
 #include "TaskPrivate.h"
+#include "swift/ABI/Actor.h"
+#include "swift/ABI/Task.h"
 #include "swift/Basic/HeaderFooterLayout.h"
 #include "swift/Basic/PriorityQueue.h"
 #include "swift/Concurrency/Actor.h"
@@ -2960,3 +2961,11 @@ bool swift::swift_distributed_actor_is_remote(HeapObject *_actor) {
 bool DefaultActorImpl::isDistributedRemote() {
   return this->isDistributedRemoteActor;
 }
+
+// ************************* PLEASE UPDATE DEBUG.H DOCS ************************
+// * When changing this version number you MUST document the change in         *
+// * `Concurrency/Debug.h`.                                                    *
+// *****************************************************************************
+[[gnu::used, gnu::retain]]
+uint32_t swift::_swift_concurrency_debug_internal_layout_version =
+    (static_cast<uint32_t>(SWIFT_THREAD_LOCAL_STORAGE_KIND) << 24) | 3;

--- a/stdlib/public/Concurrency/Debug.h
+++ b/stdlib/public/Concurrency/Debug.h
@@ -62,11 +62,40 @@ const void *const _swift_concurrency_debug_task_future_wait_resume_adapter;
 SWIFT_EXPORT_FROM(swift_Concurrency)
 bool _swift_concurrency_debug_supportsPriorityEscalation;
 
+/// Identifies how the runtime stores the currently executing AsyncTask.
+/// Debuggers use this to decide how to locate the current task on a thread.
+///
+/// The values are part of the debug ABI — once published, a value must
+/// never be reused for a different storage strategy. New strategies get a
+/// new value; bump _swift_concurrency_debug_internal_layout_version when
+/// adding one.
+enum class _concurrency_current_task_storage_kind : uint8_t {
+  /// The task pointer lives in TLS at offset 0 of the runtime's internal
+  /// current-task variable, which the debugger locates via debug info.
+  cxx_thread_local = 1,
+
+  /// The task pointer lives at offset 0 of the runtime's internal current-task
+  /// variable (no TLS resolution). Used by single-threaded /
+  /// SWIFT_THREADING_NONE builds where `SWIFT_THREAD_LOCAL` expands to nothing.
+  global = 2,
+
+  /// Pthread thread-specific data with a *reserved* (compile-time constant)
+  /// key. Used on Darwin. The key value should be inferred by the debugger.
+  pthread_reserved_key = 3,
+
+  /// Pthread thread-specific data with a *dynamically-allocated* key. Support
+  /// for this may require writing the key value in a yet-to-be-defined global
+  /// variable.
+  pthread_allocated_key = 4,
+};
+
 /// The current version of internal data structures that lldb may decode.
 /// The version numbers used so far are:
 /// 1 - The initial version number when this variable was added, in swift 6.1.
 /// 2 - Task names moved from a record to a dedicated fragment,
 ///     tail allocated just after the AsyncTask itself.
+/// 3 - The top 8 bits of this value have been reserved to expose how runtimes
+///     store the current task (_concurrency_current_task_storage_kind).
 SWIFT_EXPORT_FROM(swift_Concurrency)
 uint32_t _swift_concurrency_debug_internal_layout_version;
 

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -89,11 +89,6 @@ const void *const swift::_swift_concurrency_debug_asyncTaskSlabMetadata =
 bool swift::_swift_concurrency_debug_supportsPriorityEscalation =
     SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION;
 
-// ************************* PLEASE UPDATE DEBUG.H DOCS ***************************************
-// * When changing this version number you MUST document the change in `Concurrency/Debug.h`. *
-// ********************************************************************************************
-uint32_t swift::_swift_concurrency_debug_internal_layout_version = 2;
-
 void FutureFragment::destroy() {
   auto queueHead = waitQueue.load(std::memory_order_acquire);
   switch (queueHead.getStatus()) {


### PR DESCRIPTION
    This variable is used to tell the debugger how the runtime stores the
    currently executing task. Prior to this patch, the debugger had no way
    of knowing how the concurrency library was configured for the target, as
    this is a build-time decision; as a result, it is forced to assume the
    "common" configuration of swift for macos targets.

    Bumping the concurrency version number is not necessary, as this is not
    changing the debug ABI in any way. The debugger can simply test the
    presence of the symbol.

This PR is required for https://github.com/swiftlang/llvm-project/pull/13279