### PR TITLE
 update-checkout: Make stale PR merge ref refresh work during shallow clone

### DIFF
--- a/utils/update_checkout/tests/test_cross_repo_pr.py
+++ b/utils/update_checkout/tests/test_cross_repo_pr.py
@@ -54,6 +54,14 @@ class CrossRepoPRTestCase(scheme_mock.SchemeMockTestCase):
                         "swift": "main",
                     },
                 },
+                "rebranch": {
+                    "aliases": ["rebranch"],
+                    "repos": {
+                        "repo1": "rebranch1",
+                        "repo2": "main",
+                        "swift": "main",
+                    },
+                },
             },
         }
 
@@ -61,10 +69,16 @@ class CrossRepoPRTestCase(scheme_mock.SchemeMockTestCase):
 
         self.call(self.update_checkout_base_args + ["--clone"])
 
+    def get_branch(self, *, rev_scheme_name: str, repo_name: str):
+        return self.config["branch-schemes"][rev_scheme_name]["repos"][repo_name]
+
     def set_up_pr_merge_ref(
         self,
         *,
         repo_name: str,
+        # The revision scheme (aka branch scheme) is used to determine the base
+        # branch for our imaginary PR.
+        rev_scheme_name: str,
         pr_id: int,
         stale: bool,
         conflicts_with_base: bool = False,
@@ -72,7 +86,9 @@ class CrossRepoPRTestCase(scheme_mock.SchemeMockTestCase):
         # Conflict is only relevant for the stale case.
         self.assertTrue(stale is True or conflicts_with_base is False)
 
-        pr_base_branch = "main"
+        pr_base_branch = self.get_branch(
+            rev_scheme_name=rev_scheme_name, repo_name=repo_name
+        )
         pr_head_branch = "pr_head_branch"
 
         # Goal:
@@ -145,12 +161,22 @@ class CrossRepoPRTestCase(scheme_mock.SchemeMockTestCase):
 
     # When the merge ref is stale, update-checkout is expected to check it out
     # and merge the tip of the base branch into it.
-    def verify_head_for_stale_pr_merge_ref(self, *, repo_name: str, pr_id: int):
+    def verify_head_for_stale_pr_merge_ref(
+        self, *, repo_name: str, rev_scheme_name: str, pr_id: int
+    ):
         repo_path = os.path.join(self.source_root, repo_name)
         remote_path = self.remote_path(repo_name=repo_name)
+        pr_base_branch = self.get_branch(
+            rev_scheme_name=rev_scheme_name, repo_name=repo_name
+        )
 
         expected_parent_commits = self.call(
-            ["git", "rev-parse", f"refs/pull/{pr_id}/merge", "refs/heads/main"],
+            [
+                "git",
+                "rev-parse",
+                f"refs/pull/{pr_id}/merge",
+                f"refs/heads/{pr_base_branch}",
+            ],
             cwd=remote_path,
         ).split()
 
@@ -177,11 +203,16 @@ class CrossRepoPRTestCase(scheme_mock.SchemeMockTestCase):
 
     def test_checkout_stale_pr_merge_ref(self):
         repo_name = "repo1"
+        rev_scheme = "main"
         pr_id = 1
-        self.set_up_pr_merge_ref(repo_name=repo_name, pr_id=pr_id, stale=True)
+        self.set_up_pr_merge_ref(
+            repo_name=repo_name, rev_scheme_name=rev_scheme, pr_id=pr_id, stale=True
+        )
         self.call(
             self.update_checkout_base_args
             + [
+                "--scheme",
+                rev_scheme,
                 "--github-comment",
                 f"""
                 https://github.com/apple/{repo_name}/pull/{pr_id}
@@ -189,15 +220,45 @@ class CrossRepoPRTestCase(scheme_mock.SchemeMockTestCase):
                 """,
             ]
         )
-        self.verify_head_for_stale_pr_merge_ref(repo_name=repo_name, pr_id=pr_id)
+        self.verify_head_for_stale_pr_merge_ref(
+            repo_name=repo_name, rev_scheme_name=rev_scheme, pr_id=pr_id
+        )
 
-    def test_checkout_stale_pr_merge_ref_swift(self):
-        repo_name = "swift"
+    def test_checkout_stale_pr_merge_ref_other_rev_scheme(self):
+        repo_name = "repo1"
+        rev_scheme = "rebranch"
         pr_id = 1
-        self.set_up_pr_merge_ref(repo_name=repo_name, pr_id=pr_id, stale=True)
+        self.set_up_pr_merge_ref(
+            repo_name=repo_name, rev_scheme_name=rev_scheme, pr_id=pr_id, stale=True
+        )
         self.call(
             self.update_checkout_base_args
             + [
+                "--scheme",
+                rev_scheme,
+                "--github-comment",
+                f"""
+                https://github.com/apple/{repo_name}/pull/{pr_id}
+                @swift-ci please test
+                """,
+            ]
+        )
+        self.verify_head_for_stale_pr_merge_ref(
+            repo_name=repo_name, rev_scheme_name=rev_scheme, pr_id=pr_id
+        )
+
+    def test_checkout_stale_pr_merge_ref_swift(self):
+        repo_name = "swift"
+        rev_scheme = "main"
+        pr_id = 1
+        self.set_up_pr_merge_ref(
+            repo_name=repo_name, rev_scheme_name=rev_scheme, pr_id=pr_id, stale=True
+        )
+        self.call(
+            self.update_checkout_base_args
+            + [
+                "--scheme",
+                rev_scheme,
                 "--github-comment",
                 f"""
                 https://github.com/swiftlang/{repo_name}/pull/{pr_id}
@@ -205,12 +266,19 @@ class CrossRepoPRTestCase(scheme_mock.SchemeMockTestCase):
                 """,
             ]
         )
-        self.verify_head_for_stale_pr_merge_ref(repo_name=repo_name, pr_id=pr_id)
+        self.verify_head_for_stale_pr_merge_ref(
+            repo_name=repo_name, rev_scheme_name=rev_scheme, pr_id=pr_id
+        )
 
     def test_checkout_stale_pr_merge_ref_conflict_with_base_branch(self):
+        rev_scheme = "main"
         pr_id = 1
         self.set_up_pr_merge_ref(
-            repo_name="repo1", pr_id=pr_id, stale=True, conflicts_with_base=True
+            repo_name="repo1",
+            rev_scheme_name=rev_scheme,
+            pr_id=pr_id,
+            stale=True,
+            conflicts_with_base=True,
         )
 
         # update-checkout should fail because re-merging main into the PR
@@ -219,6 +287,8 @@ class CrossRepoPRTestCase(scheme_mock.SchemeMockTestCase):
             self.call(
                 self.update_checkout_base_args
                 + [
+                    "--scheme",
+                    rev_scheme,
                     "--github-comment",
                     f"""
                     https://github.com/apple/repo1/pull/{pr_id}
@@ -241,11 +311,18 @@ class CrossRepoPRTestCase(scheme_mock.SchemeMockTestCase):
         pr2_id = 2
         repo1_name = "repo1"
         repo2_name = "repo2"
-        self.set_up_pr_merge_ref(repo_name=repo1_name, pr_id=pr1_id, stale=True)
-        self.set_up_pr_merge_ref(repo_name=repo2_name, pr_id=pr2_id, stale=True)
+        rev_scheme = "main"
+        self.set_up_pr_merge_ref(
+            repo_name=repo1_name, rev_scheme_name=rev_scheme, pr_id=pr1_id, stale=True
+        )
+        self.set_up_pr_merge_ref(
+            repo_name=repo2_name, rev_scheme_name=rev_scheme, pr_id=pr2_id, stale=True
+        )
         self.call(
             self.update_checkout_base_args
             + [
+                "--scheme",
+                rev_scheme,
                 "--github-comment",
                 f"""
                 https://github.com/apple/{repo1_name}/pull/{pr1_id}
@@ -254,16 +331,25 @@ class CrossRepoPRTestCase(scheme_mock.SchemeMockTestCase):
                 """,
             ]
         )
-        self.verify_head_for_stale_pr_merge_ref(repo_name=repo1_name, pr_id=pr1_id)
-        self.verify_head_for_stale_pr_merge_ref(repo_name=repo2_name, pr_id=pr2_id)
+        self.verify_head_for_stale_pr_merge_ref(
+            repo_name=repo1_name, rev_scheme_name=rev_scheme, pr_id=pr1_id
+        )
+        self.verify_head_for_stale_pr_merge_ref(
+            repo_name=repo2_name, rev_scheme_name=rev_scheme, pr_id=pr2_id
+        )
 
     def test_checkout_up_to_date_pr_merge_ref(self):
         repo_name = "repo1"
+        rev_scheme = "main"
         pr_id = 1
-        self.set_up_pr_merge_ref(repo_name=repo_name, pr_id=pr_id, stale=False)
+        self.set_up_pr_merge_ref(
+            repo_name=repo_name, rev_scheme_name=rev_scheme, pr_id=pr_id, stale=False
+        )
         self.call(
             self.update_checkout_base_args
             + [
+                "--scheme",
+                rev_scheme,
                 "--github-comment",
                 f"""
                 https://github.com/apple/{repo_name}/pull/{pr_id}
@@ -275,10 +361,15 @@ class CrossRepoPRTestCase(scheme_mock.SchemeMockTestCase):
 
     def test_checkout_stale_pr_merge_ref_idempotency(self):
         repo_name = "repo1"
+        rev_scheme = "main"
         pr_id = 1
-        self.set_up_pr_merge_ref(repo_name=repo_name, pr_id=pr_id, stale=True)
+        self.set_up_pr_merge_ref(
+            repo_name=repo_name, rev_scheme_name=rev_scheme, pr_id=pr_id, stale=True
+        )
 
         update_checkout_args = self.update_checkout_base_args + [
+            "--scheme",
+            rev_scheme,
             "--github-comment",
             f"""
             https://github.com/apple/{repo_name}/pull/{pr_id}
@@ -288,4 +379,6 @@ class CrossRepoPRTestCase(scheme_mock.SchemeMockTestCase):
         # Calling repeatedly should not affect the result.
         self.call(update_checkout_args)
         self.call(update_checkout_args)
-        self.verify_head_for_stale_pr_merge_ref(repo_name=repo_name, pr_id=pr_id)
+        self.verify_head_for_stale_pr_merge_ref(
+            repo_name=repo_name, rev_scheme_name=rev_scheme, pr_id=pr_id
+        )

--- a/utils/update_checkout/tests/test_cross_repo_pr.py
+++ b/utils/update_checkout/tests/test_cross_repo_pr.py
@@ -119,12 +119,11 @@ class CrossRepoPRTestCase(scheme_mock.SchemeMockTestCase):
         if stale:
             self.call(["git", "checkout", pr_base_branch], cwd=repo_path)
 
-            # Arrange for an eventual conflict between commits E and D if
-            # asked to.
-            if conflicts_with_base:
-                with open(change_file_path, "w") as f:
-                    f.write("base-version\n")
-                self.call(["git", "add", "."], cwd=repo_path)
+            # Always add an actual change to this commit so that soft-resetting
+            # it has an effect on the working directory.
+            with open(change_file_path, "w") as f:
+                f.write("base-version\n")
+            self.call(["git", "add", "."], cwd=repo_path)
 
             # Create commit E.
             self.call(
@@ -273,3 +272,20 @@ class CrossRepoPRTestCase(scheme_mock.SchemeMockTestCase):
             ]
         )
         self.verify_head_for_up_to_date_pr_merge_ref(repo_name=repo_name, pr_id=pr_id)
+
+    def test_checkout_stale_pr_merge_ref_idempotency(self):
+        repo_name = "repo1"
+        pr_id = 1
+        self.set_up_pr_merge_ref(repo_name=repo_name, pr_id=pr_id, stale=True)
+
+        update_checkout_args = self.update_checkout_base_args + [
+            "--github-comment",
+            f"""
+            https://github.com/apple/{repo_name}/pull/{pr_id}
+            @swift-ci please test
+            """,
+        ]
+        # Calling repeatedly should not affect the result.
+        self.call(update_checkout_args)
+        self.call(update_checkout_args)
+        self.verify_head_for_stale_pr_merge_ref(repo_name=repo_name, pr_id=pr_id)

--- a/utils/update_checkout/tests/test_cross_repo_pr.py
+++ b/utils/update_checkout/tests/test_cross_repo_pr.py
@@ -72,17 +72,22 @@ class CrossRepoPRTestCase(scheme_mock.SchemeMockTestCase):
         # Conflict is only relevant for the stale case.
         self.assertTrue(stale is True or conflicts_with_base is False)
 
-        repo_path = os.path.join(self.local_path, repo_name)
-        conflict_filename = "conflict.txt"
-        conflict_file_path = os.path.join(repo_path, conflict_filename)
+        pr_base_branch = "main"
+        pr_head_branch = "pr_head_branch"
 
         # Goal:
-        #   C---D (my_branch)
+        #   C---D (pr_head_branch)
         #  /   /
-        # A---B---E (main)
+        # A---B---E (pr_base_branch)
         #
         # We will use commit D for the PR merge ref. Commit E is created if
         # the `stale` argument is true.
+
+        repo_path = os.path.join(self.local_path, repo_name)
+
+        # Create and checkout pr_base_branch if it does not exist (e.g. because
+        # we cloned using a different branch scheme).
+        self.call(["git", "checkout", "-B", pr_base_branch, "HEAD"], cwd=repo_path)
 
         # Create commit B. Commit A should already exist from initial setup.
         self.call(
@@ -90,33 +95,36 @@ class CrossRepoPRTestCase(scheme_mock.SchemeMockTestCase):
             cwd=repo_path,
         )
 
-        # Create my_branch.
-        self.call(["git", "checkout", "-b", "my_branch", "HEAD~1"], cwd=repo_path)
+        # Create and checkout pr_head_branch.
+        self.call(["git", "checkout", "-b", pr_head_branch, "HEAD~1"], cwd=repo_path)
 
-        # Arrange for an eventual conflict between commits E and D if asked to.
+        # NOTE: This file is not dead weight.
+        change_file_path = os.path.join(repo_path, "change.txt")
+
+        # If asked to, arrange for an eventual conflict between commits E and D.
         if conflicts_with_base:
-            with open(conflict_file_path, "w") as f:
+            with open(change_file_path, "w") as f:
                 f.write("pr-version\n")
-            self.call(["git", "add", conflict_filename], cwd=repo_path)
+            self.call(["git", "add", "."], cwd=repo_path)
 
         # Create commit C and the merge commit D.
         self.call(
             ["git", "commit", "--allow-empty", "-m", "C"],
             cwd=repo_path,
         )
-        self.call(["git", "merge", "--no-ff", "-m", "D", "main"], cwd=repo_path)
+        self.call(["git", "merge", "--no-ff", "-m", "D", pr_base_branch], cwd=repo_path)
 
-        # Advance main (create commit E) to make the merge commit D stale if
-        # asked to.
+        # If asked to, advance pr_base_branch (create commit E) to make the
+        # merge commit D stale.
         if stale:
-            self.call(["git", "checkout", "main"], cwd=repo_path)
+            self.call(["git", "checkout", pr_base_branch], cwd=repo_path)
 
             # Arrange for an eventual conflict between commits E and D if
             # asked to.
             if conflicts_with_base:
-                with open(conflict_file_path, "w") as f:
-                    f.write("main-version\n")
-                self.call(["git", "add", conflict_filename], cwd=repo_path)
+                with open(change_file_path, "w") as f:
+                    f.write("base-version\n")
+                self.call(["git", "add", "."], cwd=repo_path)
 
             # Create commit E.
             self.call(
@@ -124,9 +132,15 @@ class CrossRepoPRTestCase(scheme_mock.SchemeMockTestCase):
                 cwd=repo_path,
             )
 
-        # Push main and the PR merge ref to the remote.
+        # Push pr_base_branch and the PR merge ref to the remote.
         self.call(
-            ["git", "push", "origin", "main", f"my_branch:refs/pull/{pr_id}/merge"],
+            [
+                "git",
+                "push",
+                "origin",
+                pr_base_branch,
+                f"{pr_head_branch}:refs/pull/{pr_id}/merge",
+            ],
             cwd=repo_path,
         )
 
@@ -163,34 +177,36 @@ class CrossRepoPRTestCase(scheme_mock.SchemeMockTestCase):
         self.assertEqual(expected_head, actual_head)
 
     def test_checkout_stale_pr_merge_ref(self):
+        repo_name = "repo1"
         pr_id = 1
-        self.set_up_pr_merge_ref(repo_name="repo1", pr_id=pr_id, stale=True)
+        self.set_up_pr_merge_ref(repo_name=repo_name, pr_id=pr_id, stale=True)
         self.call(
             self.update_checkout_base_args
             + [
                 "--github-comment",
                 f"""
-                https://github.com/apple/repo1/pull/{pr_id}
+                https://github.com/apple/{repo_name}/pull/{pr_id}
                 @swift-ci please test
                 """,
             ]
         )
-        self.verify_head_for_stale_pr_merge_ref(repo_name="repo1", pr_id=pr_id)
+        self.verify_head_for_stale_pr_merge_ref(repo_name=repo_name, pr_id=pr_id)
 
     def test_checkout_stale_pr_merge_ref_swift(self):
+        repo_name = "swift"
         pr_id = 1
-        self.set_up_pr_merge_ref(repo_name="swift", pr_id=pr_id, stale=True)
+        self.set_up_pr_merge_ref(repo_name=repo_name, pr_id=pr_id, stale=True)
         self.call(
             self.update_checkout_base_args
             + [
                 "--github-comment",
                 f"""
-                https://github.com/swiftlang/swift/pull/{pr_id}
+                https://github.com/swiftlang/{repo_name}/pull/{pr_id}
                 @swift-ci please test
                 """,
             ]
         )
-        self.verify_head_for_stale_pr_merge_ref(repo_name="swift", pr_id=pr_id)
+        self.verify_head_for_stale_pr_merge_ref(repo_name=repo_name, pr_id=pr_id)
 
     def test_checkout_stale_pr_merge_ref_conflict_with_base_branch(self):
         pr_id = 1
@@ -222,33 +238,38 @@ class CrossRepoPRTestCase(scheme_mock.SchemeMockTestCase):
         self.assertEqual(status_output.strip(), "")
 
     def test_checkout_multiple_stale_pr_merge_ref(self):
-        self.set_up_pr_merge_ref(repo_name="repo1", pr_id=1, stale=True)
-        self.set_up_pr_merge_ref(repo_name="repo2", pr_id=2, stale=True)
+        pr1_id = 1
+        pr2_id = 2
+        repo1_name = "repo1"
+        repo2_name = "repo2"
+        self.set_up_pr_merge_ref(repo_name=repo1_name, pr_id=pr1_id, stale=True)
+        self.set_up_pr_merge_ref(repo_name=repo2_name, pr_id=pr2_id, stale=True)
         self.call(
             self.update_checkout_base_args
             + [
                 "--github-comment",
                 f"""
-                https://github.com/apple/repo1/pull/1
+                https://github.com/apple/{repo1_name}/pull/{pr1_id}
                 @swift-ci please test
-                https://github.com/swiftlang/repo2/pull/2
+                https://github.com/swiftlang/{repo2_name}/pull/{pr2_id}
                 """,
             ]
         )
-        self.verify_head_for_stale_pr_merge_ref(repo_name="repo1", pr_id=1)
-        self.verify_head_for_stale_pr_merge_ref(repo_name="repo2", pr_id=2)
+        self.verify_head_for_stale_pr_merge_ref(repo_name=repo1_name, pr_id=pr1_id)
+        self.verify_head_for_stale_pr_merge_ref(repo_name=repo2_name, pr_id=pr2_id)
 
     def test_checkout_up_to_date_pr_merge_ref(self):
+        repo_name = "repo1"
         pr_id = 1
-        self.set_up_pr_merge_ref(repo_name="repo1", pr_id=pr_id, stale=False)
+        self.set_up_pr_merge_ref(repo_name=repo_name, pr_id=pr_id, stale=False)
         self.call(
             self.update_checkout_base_args
             + [
                 "--github-comment",
                 f"""
-                https://github.com/apple/repo1/pull/{pr_id}
+                https://github.com/apple/{repo_name}/pull/{pr_id}
                 @swift-ci please test
                 """,
             ]
         )
-        self.verify_head_for_up_to_date_pr_merge_ref(repo_name="repo1", pr_id=pr_id)
+        self.verify_head_for_up_to_date_pr_merge_ref(repo_name=repo_name, pr_id=pr_id)

--- a/utils/update_checkout/tests/test_cross_repo_pr.py
+++ b/utils/update_checkout/tests/test_cross_repo_pr.py
@@ -67,8 +67,6 @@ class CrossRepoPRTestCase(scheme_mock.SchemeMockTestCase):
 
         super().setUp()
 
-        self.call(self.update_checkout_base_args + ["--clone"])
-
     def get_branch(self, *, rev_scheme_name: str, repo_name: str):
         return self.config["branch-schemes"][rev_scheme_name]["repos"][repo_name]
 
@@ -206,6 +204,7 @@ class CrossRepoPRTestCase(scheme_mock.SchemeMockTestCase):
         self.assertEqual(expected_head, actual_head)
 
     def test_checkout_stale_pr_merge_ref(self):
+        self.call(self.update_checkout_base_args + ["--clone"])
         repo_name = "repo1"
         rev_scheme = "main"
         pr_id = 1
@@ -228,7 +227,81 @@ class CrossRepoPRTestCase(scheme_mock.SchemeMockTestCase):
             repo_name=repo_name, rev_scheme_name=rev_scheme, pr_id=pr_id
         )
 
+    def test_checkout_stale_pr_merge_ref_shallow_clone(self):
+        self.call(self.update_checkout_base_args + ["--clone", "--skip-history"])
+        repo_name = "repo1"
+        rev_scheme = "main"
+        pr_id = 1
+        self.set_up_pr_merge_ref(
+            repo_name=repo_name, rev_scheme_name=rev_scheme, pr_id=pr_id, stale=True
+        )
+        self.call(
+            self.update_checkout_base_args
+            + [
+                "--scheme",
+                rev_scheme,
+                "--github-comment",
+                f"""
+                https://github.com/apple/{repo_name}/pull/{pr_id}
+                @swift-ci please test
+                """,
+            ]
+        )
+        self.verify_head_for_stale_pr_merge_ref(
+            repo_name=repo_name, rev_scheme_name=rev_scheme, pr_id=pr_id
+        )
+
+    def test_checkout_stale_pr_merge_ref_during_clone(self):
+        repo_name = "repo1"
+        rev_scheme = "main"
+        pr_id = 1
+        self.set_up_pr_merge_ref(
+            repo_name=repo_name, rev_scheme_name=rev_scheme, pr_id=pr_id, stale=True
+        )
+        self.call(
+            self.update_checkout_base_args
+            + [
+                "--clone",
+                "--scheme",
+                rev_scheme,
+                "--github-comment",
+                f"""
+                https://github.com/apple/{repo_name}/pull/{pr_id}
+                @swift-ci please test
+                """,
+            ]
+        )
+        self.verify_head_for_stale_pr_merge_ref(
+            repo_name=repo_name, rev_scheme_name=rev_scheme, pr_id=pr_id
+        )
+
+    def test_checkout_stale_pr_merge_ref_during_shallow_clone(self):
+        repo_name = "repo1"
+        rev_scheme = "main"
+        pr_id = 1
+        self.set_up_pr_merge_ref(
+            repo_name=repo_name, rev_scheme_name=rev_scheme, pr_id=pr_id, stale=True
+        )
+        self.call(
+            self.update_checkout_base_args
+            + [
+                "--clone",
+                "--skip-history",
+                "--scheme",
+                rev_scheme,
+                "--github-comment",
+                f"""
+                https://github.com/apple/{repo_name}/pull/{pr_id}
+                @swift-ci please test
+                """,
+            ]
+        )
+        self.verify_head_for_stale_pr_merge_ref(
+            repo_name=repo_name, rev_scheme_name=rev_scheme, pr_id=pr_id
+        )
+
     def test_checkout_stale_pr_merge_ref_other_rev_scheme(self):
+        self.call(self.update_checkout_base_args + ["--clone"])
         repo_name = "repo1"
         rev_scheme = "rebranch"
         pr_id = 1
@@ -252,6 +325,7 @@ class CrossRepoPRTestCase(scheme_mock.SchemeMockTestCase):
         )
 
     def test_checkout_stale_pr_merge_ref_swift(self):
+        self.call(self.update_checkout_base_args + ["--clone"])
         repo_name = "swift"
         rev_scheme = "main"
         pr_id = 1
@@ -275,6 +349,7 @@ class CrossRepoPRTestCase(scheme_mock.SchemeMockTestCase):
         )
 
     def test_checkout_stale_pr_merge_ref_conflict_with_base_branch(self):
+        self.call(self.update_checkout_base_args + ["--clone"])
         rev_scheme = "main"
         pr_id = 1
         self.set_up_pr_merge_ref(
@@ -311,6 +386,7 @@ class CrossRepoPRTestCase(scheme_mock.SchemeMockTestCase):
         self.assertEqual(status_output.strip(), "")
 
     def test_checkout_multiple_stale_pr_merge_ref(self):
+        self.call(self.update_checkout_base_args + ["--clone"])
         pr1_id = 1
         pr2_id = 2
         repo1_name = "repo1"
@@ -343,6 +419,7 @@ class CrossRepoPRTestCase(scheme_mock.SchemeMockTestCase):
         )
 
     def test_checkout_up_to_date_pr_merge_ref(self):
+        self.call(self.update_checkout_base_args + ["--clone"])
         repo_name = "repo1"
         rev_scheme = "main"
         pr_id = 1
@@ -364,6 +441,7 @@ class CrossRepoPRTestCase(scheme_mock.SchemeMockTestCase):
         self.verify_head_for_up_to_date_pr_merge_ref(repo_name=repo_name, pr_id=pr_id)
 
     def test_checkout_stale_pr_merge_ref_idempotency(self):
+        self.call(self.update_checkout_base_args + ["--clone"])
         repo_name = "repo1"
         rev_scheme = "main"
         pr_id = 1

--- a/utils/update_checkout/tests/test_cross_repo_pr.py
+++ b/utils/update_checkout/tests/test_cross_repo_pr.py
@@ -90,11 +90,14 @@ class CrossRepoPRTestCase(scheme_mock.SchemeMockTestCase):
             rev_scheme_name=rev_scheme_name, repo_name=repo_name
         )
         pr_head_branch = "pr_head_branch"
+        pr_merge_branch = f"pull/{pr_id}/merge"
 
         # Goal:
-        #   C---D (pr_head_branch)
-        #  /   /
-        # A---B---E (pr_base_branch)
+        #       .---C (pr_head_branch)
+        #      /     \
+        #     /   .---D (pr_merge_branch)
+        #    /   /
+        # --o---B---------E (pr_base_branch)
         #
         # We will use commit D for the PR merge ref. Commit E is created if
         # the `stale` argument is true.
@@ -105,11 +108,8 @@ class CrossRepoPRTestCase(scheme_mock.SchemeMockTestCase):
         # we cloned using a different branch scheme).
         self.call(["git", "checkout", "-B", pr_base_branch, "HEAD"], cwd=repo_path)
 
-        # Create commit B. Commit A should already exist from initial setup.
-        self.call(
-            ["git", "commit", "--allow-empty", "-m", "B"],
-            cwd=repo_path,
-        )
+        # Create commit B.
+        self.call(["git", "commit", "--allow-empty", "-m", "B"], cwd=repo_path)
 
         # Create and checkout pr_head_branch.
         self.call(["git", "checkout", "-b", pr_head_branch, "HEAD~1"], cwd=repo_path)
@@ -123,12 +123,16 @@ class CrossRepoPRTestCase(scheme_mock.SchemeMockTestCase):
                 f.write("pr-version\n")
             self.call(["git", "add", "."], cwd=repo_path)
 
-        # Create commit C and the merge commit D.
+        # Create commit C.
+        self.call(["git", "commit", "--allow-empty", "-m", "C"], cwd=repo_path)
+
+        # Create and checkout pr_merge_branch.
         self.call(
-            ["git", "commit", "--allow-empty", "-m", "C"],
-            cwd=repo_path,
+            ["git", "checkout", "-b", pr_merge_branch, pr_base_branch], cwd=repo_path
         )
-        self.call(["git", "merge", "--no-ff", "-m", "D", pr_base_branch], cwd=repo_path)
+
+        # Create commit D (merge pr_head_branch into pr_merge_branch).
+        self.call(["git", "merge", "--no-ff", "-m", "D", pr_head_branch], cwd=repo_path)
 
         # If asked to, advance pr_base_branch (create commit E) to make the
         # merge commit D stale.
@@ -154,7 +158,7 @@ class CrossRepoPRTestCase(scheme_mock.SchemeMockTestCase):
                 "push",
                 "origin",
                 pr_base_branch,
-                f"{pr_head_branch}:refs/pull/{pr_id}/merge",
+                f"{pr_merge_branch}:refs/{pr_merge_branch}",
             ],
             cwd=repo_path,
         )

--- a/utils/update_checkout/tests/test_cross_repo_pr.py
+++ b/utils/update_checkout/tests/test_cross_repo_pr.py
@@ -464,3 +464,44 @@ class CrossRepoPRTestCase(scheme_mock.SchemeMockTestCase):
         self.verify_head_for_stale_pr_merge_ref(
             repo_name=repo_name, rev_scheme_name=rev_scheme, pr_id=pr_id
         )
+
+    # Make sure we do check PR merge ref staleness against
+    # 'refs/heads/base_branch', and not some other 'refs/heads/*/base_branch'.
+    # This failure mode can occur when 'git-ls-remote' is asked to enumerate
+    # refs matching just 'base_branch' instead of 'refs/heads/base_branch'.
+    def test_no_branch_ambiguity_in_staleness_check(self):
+        repo_name = "repo1"
+        rev_scheme = "main"
+        pr_id = 1
+        self.set_up_pr_merge_ref(
+            repo_name=repo_name, rev_scheme_name=rev_scheme, pr_id=pr_id, stale=True
+        )
+
+        # To simulate the scenario described above, create a branch that, if
+        # mistaken for the actual base branch, would cause update-checkout to
+        # conclude that the merge ref is up to date.
+        base_branch = self.get_branch(rev_scheme_name=rev_scheme, repo_name=repo_name)
+        not_base_branch = f"foo/{base_branch}"
+        repo_path = os.path.join(self.local_path, repo_name)
+        self.call(
+            ["git", "branch", not_base_branch, f"pull/{pr_id}/merge^1"], cwd=repo_path
+        )
+        self.call(["git", "push", "origin", not_base_branch], cwd=repo_path)
+
+        self.call(
+            self.update_checkout_base_args
+            + [
+                "--clone",
+                "--scheme",
+                rev_scheme,
+                "--github-comment",
+                f"""
+                https://github.com/apple/{repo_name}/pull/{pr_id}
+                @swift-ci please test
+                """,
+            ]
+        )
+        # Check that update-checkout took the path for a stale merge ref.
+        self.verify_head_for_stale_pr_merge_ref(
+            repo_name=repo_name, rev_scheme_name=rev_scheme, pr_id=pr_id
+        )

--- a/utils/update_checkout/update_checkout/git_command.py
+++ b/utils/update_checkout/update_checkout/git_command.py
@@ -124,6 +124,23 @@ class Git:
     def _quote_command(command: List[Any]) -> str:
         return " ".join(Git._quote(arg) for arg in command)
 
+    @staticmethod
+    def is_shallow(*, repo_path: Path) -> bool:
+        """
+        Returns whether a repository is shallow.
+
+        Args:
+            repo_path (Path): The path to the repository.
+
+        Returns:
+            bool: A Boolean value indicating whether the repository is shallow.
+        """
+
+        is_shallow_output, _, _ = Git.run(
+            repo_path, ["rev-parse", "--is-shallow-repository"],
+        )
+        return is_shallow_output.strip() == "true"
+
 
 def is_git_repository(path: Path) -> bool:
     """Returns whether a Path object is a Git repository.

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -104,28 +104,34 @@ def get_pr_branch(
     base_branch: str,
 ):
     prefix = output_prefix(repo_name)
-
+    is_shallow_repository = Git.is_shallow(repo_path=repo_path)
     pr_merge_ref_name = f"pull/{pr_id}/merge"
     local_pr_merge_ref = f"refs/remotes/origin/{pr_merge_ref_name}"
 
-    # Fetch the PR merge ref, and also fetch the scheme branch, which ought to
-    # match the PR base branch.
+    # 1. Fetch the PR merge ref.
     Git.run(
         repo_path,
         [
             "fetch",
             "origin",
-            "--tags",
-            # Overwrite the ref if it exists.
+            # Overwrite the ref if it already exists.
             "--force",
+            # If we omitted the depth and the local repository was shallow, this
+            # command would effectively (and wastefully) unshallow it, so do
+            # not fetch more than necessary.
+            #
+            # If it happens that we need to update the PR merge ref, its parent
+            # commits are enough history to find a merge base between it and the
+            # PR base branch.
+            "--depth=2",
             f"refs/{pr_merge_ref_name}:{local_pr_merge_ref}",
-            base_branch,
         ],
         echo=True,
         prefix=prefix,
     )
 
-    # Check out a branch at the ref, resetting the branch if it exists.
+    # 2. Check out a dedicated branch at the PR merge ref, resetting the branch
+    #    if it exists.
     pr_branch = "ci_pr_{0}".format(pr_id)
     Git.run(
         repo_path,
@@ -134,8 +140,103 @@ def get_pr_branch(
         prefix=prefix,
     )
 
-    # Merge the base branch into it. GitHub cannot be trusted to keep PR merge
-    # refs up-to-date.
+    # A PR merge ref is up to date if its first parent matches the remote tip
+    # of the PR base branch.
+    def is_pr_merge_ref_up_to_date():
+        # The PR merge ref's first parent is the base branch tip at the time
+        # GitHub last computed the ref. If that still matches the current remote
+        # base branch tip, the merge ref is up to date and we can skip the
+        # re-merge.
+        base_parent_object_id, _, _ = Git.run(
+            repo_path,
+            ["rev-parse", f"{local_pr_merge_ref}^1"],
+            echo=True,
+            prefix=prefix,
+        )
+        remote_base_branch_object_id_and_ref, _, _ = Git.run(
+            repo_path,
+            [
+                "ls-remote",
+                # This command should fail if no matching refs are found.
+                "--exit-code",
+                "--heads",
+                "origin",
+                base_branch,
+            ],
+            echo=True,
+            prefix=prefix,
+        )
+
+        remote_base_branch_object_id, _ = remote_base_branch_object_id_and_ref.split()
+
+        return base_parent_object_id == remote_base_branch_object_id
+
+    # 3. Check whether the merge ref is stale. If up to date, that's it.
+    if is_pr_merge_ref_up_to_date():
+        return pr_branch
+
+    # The PR merge ref is out of date. This path exists because GitHub is not
+    # consistent in keeping PR merge refs up to date.
+    #
+    # 4. If the local repository is non-shallow, fetch the base branch.
+    #    Otherwise, fetch and deepen the base branch incrementally until we
+    #    find a merge base and until a certain limit.
+    deepen_increment = 100
+    max_iterations = 10
+    for _ in range(max_iterations):
+        Git.run(
+            repo_path,
+            [
+                "fetch",
+                "origin",
+                # This matters only when the local repository is shallow, and
+                # has no effect otherwise.
+                f"--deepen={deepen_increment}",
+                base_branch,
+            ],
+            echo=True,
+            prefix=prefix,
+        )
+
+        # If the local repository is non-shallow, we should never be missing a
+        # merge base after the above fetch.
+        if not is_shallow_repository:
+            break
+
+        def merge_base_exists():
+            # Exit code 0 means true, 1 means false. Errors are signaled
+            # by other exit codes.
+            try:
+                Git.run(
+                    repo_path,
+                    ["merge-base", local_pr_merge_ref, f"origin/{base_branch}"],
+                    echo=True,
+                    prefix=prefix,
+                )
+                return True
+            except GitException as e:
+                if e.returncode == 1:
+                    return False
+                else:
+                    raise  # Pass the error up the chain.
+
+        # Do we have a merge base between .
+        if merge_base_exists():
+            break
+    else:
+        # This is probably a shallow repository, and the PR merge ref is
+        # WAY behind. Give up and ask them to rebase. This seems better than
+        # to waste traffic on unshallowing a potentially huge repository
+        # like llvm-project on a machine where the checkout is regularly
+        # wiped clean.
+        raise RuntimeError(
+            f"Could not find a merge-base between {local_pr_merge_ref} "
+            f"and origin/{base_branch} after deepening by "
+            f"{max_iterations * deepen_increment} commits. The PR may be "
+            f"too far behind the base branch; please rebase."
+        )
+
+    # 5. Merge in the freshly fetched base branch.
     try:
         Git.run(
             repo_path,
@@ -145,9 +246,8 @@ def get_pr_branch(
         )
     except Exception:
         # If the merge fails, odds are there's a conflict. Either way
-        # we do not want to proceed. Abort the merge to leave a clean
-        # working directory behind, ignoring errors, and fail with the
-        # merge error.
+        # we do not want to proceed. Abort the merge (ignoring errors) to leave
+        # a clean working directory behind, and fail with the merge error.
         try:
             Git.run(repo_path, ["merge", "--abort"], echo=True, prefix=prefix)
         except Exception:

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -161,7 +161,9 @@ def get_pr_branch(
                 "--exit-code",
                 "--heads",
                 "origin",
-                base_branch,
+                # Important for disambiguation. Just 'base_branch' matches
+                # both 'base_branch' and '*/base_branch'.
+                f"refs/heads/{base_branch}",
             ],
             echo=True,
             prefix=prefix,

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -96,6 +96,67 @@ def output_prefix(repo_name: str):
     return f"[{repo_name}] ".ljust(40)
 
 
+def get_pr_branch(
+    *,
+    repo_path: Path,
+    repo_name: str,
+    pr_id: str,
+    base_branch: str,
+):
+    prefix = output_prefix(repo_name)
+
+    pr_merge_ref_name = f"pull/{pr_id}/merge"
+    local_pr_merge_ref = f"refs/remotes/origin/{pr_merge_ref_name}"
+
+    # Fetch the PR merge ref, and also fetch the scheme branch, which ought to
+    # match the PR base branch.
+    Git.run(
+        repo_path,
+        [
+            "fetch",
+            "origin",
+            "--tags",
+            # Overwrite the ref if it exists.
+            "--force",
+            f"refs/{pr_merge_ref_name}:{local_pr_merge_ref}",
+            base_branch,
+        ],
+        echo=True,
+        prefix=prefix,
+    )
+
+    # Check out a branch at the ref, resetting the branch if it exists.
+    pr_branch = "ci_pr_{0}".format(pr_id)
+    Git.run(
+        repo_path,
+        ["checkout", "-B", pr_branch, local_pr_merge_ref],
+        echo=True,
+        prefix=prefix,
+    )
+
+    # Merge the base branch into it. GitHub cannot be trusted to keep PR merge
+    # refs up-to-date.
+    try:
+        Git.run(
+            repo_path,
+            ["merge", f"origin/{base_branch}", "--no-edit"],
+            echo=True,
+            prefix=prefix,
+        )
+    except Exception:
+        # If the merge fails, odds are there's a conflict. Either way
+        # we do not want to proceed. Abort the merge to leave a clean
+        # working directory behind, ignoring errors, and fail with the
+        # merge error.
+        try:
+            Git.run(repo_path, ["merge", "--abort"], echo=True, prefix=prefix)
+        except Exception:
+            pass
+        raise
+
+    return pr_branch
+
+
 def get_branch_for_repo(
     repo_path: Path,
     config: Dict[str, Any],
@@ -126,50 +187,14 @@ def get_branch_for_repo(
         scheme_branch = scheme_map[repo_name]
         remote_repo_id = config["repos"][repo_name]["remote"]["id"]
         if remote_repo_id in cross_repos_pr:
-            prefix = output_prefix(repo_name)
             cross_repo = True
             pr_id = cross_repos_pr[remote_repo_id]
-            repo_branch = "ci_pr_{0}".format(pr_id)
-
-            # Fetch the PR merge branch into repo_branch, and also fetch the
-            # scheme branch, which ought to match the PR base branch.
-            Git.run(
-                repo_path,
-                [
-                    "fetch",
-                    "origin",
-                    # If repo_branch exists, overwrite it.
-                    "--force",
-                    # If repo_branch exists and is checked out, this will
-                    # prevent Git from refusing the fetch.
-                    "--update-head-ok",
-                    "--tags",
-                    f"pull/{pr_id}/merge:{repo_branch}",
-                    scheme_branch,
-                ],
-                echo=True,
-                prefix=prefix,
+            repo_branch = get_pr_branch(
+                repo_path=repo_path,
+                repo_name=repo_name,
+                pr_id=pr_id,
+                base_branch=scheme_branch,
             )
-            # Check out repo_branch and merge the base branch into it.
-            # GitHub cannot be trusted to keep PR merge branches up-to-date.
-            Git.run(repo_path, ["checkout", repo_branch], echo=True, prefix=prefix)
-            try:
-                Git.run(
-                    repo_path,
-                    ["merge", f"origin/{scheme_branch}", "--no-edit"],
-                    echo=True,
-                    prefix=prefix,
-                )
-            except Exception as e:
-                # If the merge fails, odds are there's a conflict. Either way
-                # we do not want to proceed. Abort the merge to leave a clean
-                # working directory behind, ignoring errors, and fail with the
-                # merge error.
-                try:
-                    Git.run(repo_path, ["merge", "--abort"], echo=True, prefix=prefix)
-                except:
-                    pass
-                raise e
         else:
             repo_branch = scheme_branch
 

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -130,12 +130,12 @@ def get_pr_branch(
         prefix=prefix,
     )
 
-    # 2. Check out a dedicated branch at the PR merge ref, resetting the branch
-    #    if it exists.
+    # 2. Check out a dedicated branch at the PR merge ref, hard-resetting the
+    #    branch if it's already checked out or exists.
     pr_branch = "ci_pr_{0}".format(pr_id)
     Git.run(
         repo_path,
-        ["checkout", "-B", pr_branch, local_pr_merge_ref],
+        ["checkout", "--force", "-B", pr_branch, local_pr_merge_ref],
         echo=True,
         prefix=prefix,
     )


### PR DESCRIPTION
A regular fetch will not deepen a grafted commit, so the correct approach fails for a fresh shallow clone. Instead:
    
1. Fetch the merge ref as we already do, but with depth 2.

   If we omitted the depth and the local repository was shallow, this command would effectively (and wastefully) unshallow it, so do not fetch more than necessary. If it happens that we need to update the PR merge ref, its parent commits are enough history to find a merge base between it and the PR base branch.
3. No changes. Check out a branch at the PR merge ref, resetting the branch if it exists.
4. Grab the first parent of the merge ref and compare it to the remote base branch tip to determine whether the merge ref is stale. If up to date, that's it. Otherwise, proceed.
5. If the local repository is non-shallow, fetch the base branch. Otherwise, fetch and deepen the base branch incrementally until we find a merge base and until a certain limit. If we hit the limit, give up and ask the user to rebase the PR.
6. No changes. Merge in the freshly fetched base branch.