### PR TITLE
[Sema] Implicit member syntax through function types

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -645,6 +645,11 @@ EXPERIMENTAL_FEATURE(AbstractStoredPropertyLayout, false)
 /// Allow use of macros to derive various conformances
 EXPERIMENTAL_FEATURE(DeriveConformancesViaMacros, false)
 
+/// Extend implicit member syntax (the leading dot) so that, when the expected
+/// type is a function type '(P...) -> R', member lookup also considers static
+/// members (such as enum cases with payloads) of the return type 'R'.
+EXPERIMENTAL_FEATURE(ImplicitMemberOnFunctionType, true)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/include/swift/Sema/OverloadChoice.h
+++ b/include/swift/Sema/OverloadChoice.h
@@ -51,9 +51,6 @@ enum class OverloadChoiceKind : int {
   /// was found by bridging the base value type to its Objective-C
   /// class type.
   DeclViaBridge,
-  /// The overload choice selects a particular declaration that
-  /// was found by unwrapping an optional context type.
-  DeclViaUnwrappedOptional,
   /// The overload choice materializes a pack from a tuple.
   MaterializePack,
   /// The overload choice extracts the isolation of a dynamically isolated
@@ -84,14 +81,16 @@ class OverloadChoice {
     /// Indicates that this declaration was bridged, turning a
     /// "Decl" kind into "DeclViaBridge" kind.
     IsDeclViaBridge = 0x01,
-    /// Indicates that this declaration was resolved by unwrapping an
-    /// optional context type, turning a "Decl" kind into
-    /// "DeclViaUnwrappedOptional".
+    /// Indicates that this declaration was resolved by unwrapping an optional
+    /// context type. Like \c IsDeclViaFunctionResult below, this is NOT a
+    /// distinct OverloadChoiceKind: it reads as a plain "Decl"
+    /// (\c getKind() returns \c Decl) and is distinguished via
+    /// \c isDeclViaUnwrappedOptional().
     IsDeclViaUnwrappedOptional = 0x02,
-    /// Indicates that there are viable members found on `Optional`
-    /// type and its underlying type. And current overload choice
-    /// is a backup one, which should be picked only if members
-    /// found directly on `Optional` do not match.
+    /// As \c IsDeclViaUnwrappedOptional, but there are also viable members on
+    /// `Optional` itself, so this one is a backup that should be picked only if
+    /// those don't match; \c isFallbackMemberOnUnwrappedBase() reads this to
+    /// score it below them.
     IsFallbackDeclViaUnwrappedOptional = 0x03,
     /// Indicates that this declaration was resolved by looking through a
     /// function-typed context '(P...) -> R' to a static member of the return
@@ -155,7 +154,6 @@ public:
     assert(kind != OverloadChoiceKind::Decl &&
            kind != OverloadChoiceKind::DeclViaDynamic &&
            kind != OverloadChoiceKind::DeclViaBridge &&
-           kind != OverloadChoiceKind::DeclViaUnwrappedOptional &&
            "wrong constructor for decl");
   }
 
@@ -276,12 +274,11 @@ public:
       switch (BaseAndDeclKind.getInt()) {
       case IsDeclViaBridge: return OverloadChoiceKind::DeclViaBridge;
       case IsDeclViaDynamic: return OverloadChoiceKind::DeclViaDynamic;
-      case IsDeclViaUnwrappedOptional:
-      case IsFallbackDeclViaUnwrappedOptional:
-        return OverloadChoiceKind::DeclViaUnwrappedOptional;
-      // IsDeclViaFunctionResult is deliberately not mapped to a distinct kind;
-      // it reads as a plain Decl and is distinguished via
-      // isDeclViaFunctionResult().
+      // IsDeclViaUnwrappedOptional, IsFallbackDeclViaUnwrappedOptional, and
+      // IsDeclViaFunctionResult are deliberately not mapped to distinct kinds;
+      // each reads as a plain Decl and is distinguished via a predicate
+      // (isDeclViaUnwrappedOptional / isFallbackMemberOnUnwrappedBase,
+      // isDeclViaFunctionResult).
       default: return OverloadChoiceKind::Decl;
       }
     }
@@ -297,7 +294,6 @@ public:
     case OverloadChoiceKind::Decl:
     case OverloadChoiceKind::DeclViaBridge:
     case OverloadChoiceKind::DeclViaDynamic:
-    case OverloadChoiceKind::DeclViaUnwrappedOptional:
     case OverloadChoiceKind::DynamicMemberLookup:
     case OverloadChoiceKind::KeyPathDynamicMemberLookup:
       return true;
@@ -335,6 +331,15 @@ public:
   /// members found directly on `Optional` didn't match.
   bool isFallbackMemberOnUnwrappedBase() const {
     return BaseAndDeclKind.getInt() == IsFallbackDeclViaUnwrappedOptional;
+  }
+
+  /// Whether this choice was found by unwrapping an optional context type (the
+  /// member lives on the wrapped type). Such a choice is an ordinary \c Decl
+  /// (\c getKind() returns \c Decl); this covers both the regular and the
+  /// fallback form (see \c isFallbackMemberOnUnwrappedBase).
+  bool isDeclViaUnwrappedOptional() const {
+    return BaseAndDeclKind.getInt() == IsDeclViaUnwrappedOptional ||
+           BaseAndDeclKind.getInt() == IsFallbackDeclViaUnwrappedOptional;
   }
 
   /// Whether this choice was found by looking through a function-typed context

--- a/include/swift/Sema/OverloadChoice.h
+++ b/include/swift/Sema/OverloadChoice.h
@@ -93,6 +93,15 @@ class OverloadChoice {
     /// is a backup one, which should be picked only if members
     /// found directly on `Optional` do not match.
     IsFallbackDeclViaUnwrappedOptional = 0x03,
+    /// Indicates that this declaration was resolved by looking through a
+    /// function-typed context '(P...) -> R' to a static member of the return
+    /// type 'R'. Like \c IsFallbackDeclViaUnwrappedOptional above, this is NOT
+    /// a distinct OverloadChoiceKind: it reads as a plain "Decl" everywhere
+    /// (\c getKind() returns \c Decl), and the one place that cares -- ranking,
+    /// where it must score strictly below a directly-found member -- reads it
+    /// via \c isDeclViaFunctionResult(). This keeps the leading-dot look-through
+    /// from spreading a bespoke kind across every overload-choice switch.
+    IsDeclViaFunctionResult = 0x04,
     /// Indicates that this declaration was dynamic, turning a
     /// "Decl" kind into "DeclViaDynamic" kind.
     IsDeclViaDynamic = 0x07,
@@ -220,6 +229,21 @@ public:
     return result;
   }
 
+  /// Retrieve an overload choice for a declaration that was found by looking
+  /// through a function-typed context '(P...) -> R' to a static member of the
+  /// return type 'R'.
+  ///
+  /// \param base The metatype of the return type 'R'.
+  static OverloadChoice getDeclViaFunctionResult(Type base, ValueDecl *value,
+                                                 FunctionRefInfo functionRefInfo) {
+    OverloadChoice result;
+    result.BaseAndDeclKind.setPointer(base);
+    result.BaseAndDeclKind.setInt(IsDeclViaFunctionResult);
+    result.DeclOrKind = value;
+    result.TheFunctionRefInfo = functionRefInfo;
+    return result;
+  }
+
   /// Retrieve an overload choice for a declaration that was found via
   /// dynamic member lookup. The `ValueDecl` is a `subscript(dynamicMember:...)`
   /// method.
@@ -255,6 +279,9 @@ public:
       case IsDeclViaUnwrappedOptional:
       case IsFallbackDeclViaUnwrappedOptional:
         return OverloadChoiceKind::DeclViaUnwrappedOptional;
+      // IsDeclViaFunctionResult is deliberately not mapped to a distinct kind;
+      // it reads as a plain Decl and is distinguished via
+      // isDeclViaFunctionResult().
       default: return OverloadChoiceKind::Decl;
       }
     }
@@ -308,6 +335,14 @@ public:
   /// members found directly on `Optional` didn't match.
   bool isFallbackMemberOnUnwrappedBase() const {
     return BaseAndDeclKind.getInt() == IsFallbackDeclViaUnwrappedOptional;
+  }
+
+  /// Whether this choice was found by looking through a function-typed context
+  /// '(P...) -> R' to a static member of the return type 'R'. Such a choice is
+  /// an ordinary \c Decl (\c getKind() returns \c Decl) but must be scored
+  /// strictly below a member found directly on the expected type.
+  bool isDeclViaFunctionResult() const {
+    return BaseAndDeclKind.getInt() == IsDeclViaFunctionResult;
   }
 
   /// Whether this choice is for any kind of dynamic member lookup.

--- a/include/swift/Sema/Score.h
+++ b/include/swift/Sema/Score.h
@@ -45,6 +45,12 @@ enum ScoreKind: unsigned int {
   SK_DisfavoredOverload,
   /// A member for an \c UnresolvedMemberExpr found via unwrapped optional base.
   SK_UnresolvedMemberViaOptional,
+  /// A member for an \c UnresolvedMemberExpr found by looking through a
+  /// function-typed context to a static member of its return type. This is
+  /// strictly lower priority than any member found directly on the expected
+  /// type, so the new lookup only wins where the direct lookup has no
+  /// viable candidate.
+  SK_UnresolvedMemberViaFunctionResult,
   /// An implicit force of an implicitly unwrapped optional value.
   SK_ForceUnchecked,
   /// An implicit conversion from a value of one type (lhs)
@@ -202,6 +208,10 @@ struct Score {
 
     case SK_UnresolvedMemberViaOptional:
       return "unwrapping optional at unresolved member base";
+
+    case SK_UnresolvedMemberViaFunctionResult:
+      return "looking through function-typed context to its return type at "
+             "unresolved member base";
 
     case SK_ForceUnchecked:
       return "force of an implicitly unwrapped optional";

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -691,7 +691,7 @@ static bool usesFeatureReparenting(Decl *decl) {
 UNINTERESTING_FEATURE(StrictAccessControl)
 UNINTERESTING_FEATURE(BorrowingSequence)
 UNINTERESTING_FEATURE(AbstractStoredPropertyLayout)
-
+UNINTERESTING_FEATURE(ImplicitMemberOnFunctionType)
 UNINTERESTING_FEATURE(DeriveConformancesViaMacros)
 
 static bool usesFeatureBorrowInout(Decl *decl) {

--- a/lib/IDE/SelectedOverloadInfo.cpp
+++ b/lib/IDE/SelectedOverloadInfo.cpp
@@ -31,8 +31,7 @@ swift::ide::getSelectedOverloadInfo(const Solution &S,
   case OverloadChoiceKind::KeyPathApplication:
   case OverloadChoiceKind::Decl:
   case OverloadChoiceKind::DeclViaDynamic:
-  case OverloadChoiceKind::DeclViaBridge:
-  case OverloadChoiceKind::DeclViaUnwrappedOptional: {
+  case OverloadChoiceKind::DeclViaBridge: {
     Result.BaseTy = SelectedOverload->choice.getBaseType();
     if (Result.BaseTy) {
       Result.BaseTy = S.simplifyType(Result.BaseTy)->getRValueType();

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3632,7 +3632,6 @@ namespace {
       }
 
       case OverloadChoiceKind::Decl:
-      case OverloadChoiceKind::DeclViaUnwrappedOptional:
       case OverloadChoiceKind::DeclViaDynamic:
         return buildMemberRef(base, dotLoc, selected, nameLoc,
                               cs.getConstraintLocator(expr), memberLocator,

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1593,8 +1593,14 @@ private:
 
   bool isContextualMismatch() const {
     auto *locator = getLocator();
+    // A leading-dot member reference whose (unapplied) function type has too
+    // many parameters for the contextual function type is a conversion
+    // failure, not a call with extra arguments to remove -- there is no call
+    // to attach an argument-removal diagnostic to. Treat it as a contextual
+    // mismatch so it reports "cannot convert value of type ... to ...".
     return locator->isLastElement<LocatorPathElt::ContextualType>() ||
-           locator->isLastElement<LocatorPathElt::ApplyArgToParam>();
+           locator->isLastElement<LocatorPathElt::ApplyArgToParam>() ||
+           locator->isLastElement<LocatorPathElt::UnresolvedMemberChainResult>();
   }
 };
 

--- a/lib/Sema/CSDisjunction.cpp
+++ b/lib/Sema/CSDisjunction.cpp
@@ -267,7 +267,6 @@ static bool areConservativelyCompatibleArgumentLabels(
   case OverloadChoiceKind::Decl:
   case OverloadChoiceKind::DeclViaBridge:
   case OverloadChoiceKind::DeclViaDynamic:
-  case OverloadChoiceKind::DeclViaUnwrappedOptional:
     decl = choice.getDecl();
     break;
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -594,6 +594,21 @@ bool ContextualMismatch::diagnoseForAmbiguity(
     return primary.second->diagnose(*primary.first, /*asNote=*/false);
   }
 
+  // The types don't match across solutions, but this fix belongs to an
+  // unresolved member chain (a leading dot like `.foo`) that failed the
+  // same way in every solution. This happens when the member reference is
+  // passed to an overloaded call, so each overload imposes a different
+  // contextual type -- and, if the member resolves through a function-typed
+  // parameter's return type, potentially a different member per overload.
+  // The member-chain diagnostic explains why the member cannot be used in
+  // this position; emit it once from the primary solution rather than
+  // failing to produce any diagnostic.
+  if (getLocator()
+          ->isLastElement<LocatorPathElt::UnresolvedMemberChainResult>()) {
+    const auto &primary = commonFixes.front();
+    return primary.second->diagnose(*primary.first, /*asNote=*/false);
+  }
+
   return false;
 }
 

--- a/lib/Sema/CSOptimizer.cpp
+++ b/lib/Sema/CSOptimizer.cpp
@@ -297,7 +297,8 @@ static bool isArithmeticOperator(ValueDecl *decl) {
 /// that would they'd require solving to figure out whether they are a
 /// potential match or not.
 static bool isSupportedGenericOverloadChoice(ValueDecl *decl,
-                                             GenericFunctionType *choiceType) {
+                                             GenericFunctionType *choiceType,
+                                             bool hasImplicitMemberArgs) {
   // Same type requirements cannot be handled because each
   // candidate-parameter pair is (currently) considered in isolation.
   if (llvm::any_of(choiceType->getRequirements(), [](const Requirement &req) {
@@ -322,14 +323,38 @@ static bool isSupportedGenericOverloadChoice(ValueDecl *decl,
   if (!paramList)
     return false;
 
-  return llvm::all_of(paramList->getArray(), [](const ParamDecl *P) {
+  return llvm::all_of(paramList->getArray(), [&](const ParamDecl *P) {
     auto paramType = P->getInterfaceType();
-    return paramType->is<GenericTypeParamType>() ||
-           !paramType->hasTypeParameter();
+    if (paramType->is<GenericTypeParamType>() ||
+        !paramType->hasTypeParameter())
+      return true;
+
+    // If the call has implicit member (leading-dot) arguments, allow
+    // function-typed parameters composed of generic parameters and/or
+    // concrete types i.e. `(P) -> Event`. Such parameters can be
+    // analyzed through the name of the member (via the return type)
+    // even though their types are only partially concrete.
+    if (hasImplicitMemberArgs) {
+      if (auto *fnTy = paramType->getAs<AnyFunctionType>()) {
+        auto isAnalyzable = [](Type type) {
+          return type->is<GenericTypeParamType>() ||
+                 !type->hasTypeParameter();
+        };
+
+        return llvm::all_of(fnTy->getParams(),
+                            [&](const auto &param) {
+                              return isAnalyzable(param.getPlainType());
+                            }) &&
+               isAnalyzable(fnTy->getResult());
+      }
+    }
+
+    return false;
   });
 }
 
-static bool isSupportedDisjunction(Constraint *disjunction) {
+static bool isSupportedDisjunction(Constraint *disjunction,
+                                   bool hasImplicitMemberArgs = false) {
   auto choices = disjunction->getNestedConstraints();
 
   if (isOperatorDisjunction(disjunction))
@@ -365,7 +390,8 @@ static bool isSupportedDisjunction(Constraint *disjunction) {
         return true;
 
       if (auto *genericFn = choiceType->getAs<GenericFunctionType>())
-        return isSupportedGenericOverloadChoice(decl, genericFn);
+        return isSupportedGenericOverloadChoice(decl, genericFn,
+                                                hasImplicitMemberArgs);
 
       return false;
     }
@@ -408,6 +434,189 @@ static ValueDecl *isViableOverloadChoice(ConstraintSystem &cs,
     return nullptr;
 
   return decl;
+}
+
+namespace {
+
+/// An implicit member (leading-dot) argument i.e. `.foo`, `.foo(...)`,
+/// or `.foo.bar`, for which only the name of the leading member is known
+/// before the contextual type is resolved.
+struct ImplicitMemberArgument {
+  /// The name of the leading (base) member of the chain.
+  DeclNameRef name;
+  /// Whether the leading member has postfix syntax applied to it
+  /// (a call, member access, etc.), which means that the type of the
+  /// whole argument is not the type of the leading member reference.
+  bool hasPostfix;
+};
+
+} // end anonymous namespace
+
+/// If the given argument expression is an implicit member expression
+/// (or a chain rooted in one), extract information about it.
+static std::optional<ImplicitMemberArgument>
+getImplicitMemberArgument(Expr *argument) {
+  // Look through parentheses.
+  while (auto *PE = dyn_cast_or_null<ParenExpr>(argument))
+    argument = PE->getSubExpr();
+
+  if (!argument)
+    return std::nullopt;
+
+  if (auto *chain = dyn_cast<UnresolvedMemberChainResultExpr>(argument)) {
+    if (auto *base = chain->getChainBase()) {
+      return ImplicitMemberArgument{base->getName(),
+                                    /*hasPostfix=*/chain->getSubExpr() !=
+                                        base};
+    }
+    return std::nullopt;
+  }
+
+  // Defensive: a bare unresolved member that wasn't wrapped in a chain
+  // result expression.
+  if (auto *UME = dyn_cast<UnresolvedMemberExpr>(argument))
+    return ImplicitMemberArgument{UME->getName(), /*hasPostfix=*/false};
+
+  return std::nullopt;
+}
+
+/// Attempt to determine whether an implicit member (leading-dot) argument
+/// could match the given parameter type, based only on a (cached) lookup
+/// of the member name and cheap shape checks that never resolve any types.
+///
+/// Returns:
+///  - \c std::nullopt when nothing could be determined;
+///  - \c 0 when the parameter provably cannot accept the argument
+///    because the very same member lookup the solver would perform
+///    cannot succeed;
+///  - a positive score when a member with a compatible shape exists.
+static std::optional<unsigned>
+scoreImplicitMemberArgument(ConstraintSystem &cs,
+                            const ImplicitMemberArgument &argument,
+                            Type paramType) {
+  auto &ctx = cs.getASTContext();
+  auto name = argument.name;
+
+  // Only simple, non-special names can be analyzed; e.g. `.init` refers
+  // to constructors, `$`-prefixed names to property wrappers, and module
+  // selectors change the lookup.
+  if (!name.isSimpleName() || name.isSpecial() || name.hasModuleSelector() ||
+      name.getBaseIdentifier().hasDollarPrefix())
+    return std::nullopt;
+
+  // `.isolation` has special meaning for @isolated(any) function types.
+  if (name.getBaseIdentifier() == ctx.Id_isolation)
+    return std::nullopt;
+
+  // If the contextual type is optional, members could come from the
+  // wrapped type or from `Optional` itself (i.e. `.some`, `.none`, or
+  // an unapplied instance member like `.map`). If the name exists on
+  // `Optional`, the possibilities can't be told apart cheaply.
+  {
+    Type unwrappedTy = paramType->lookThroughAllOptionalTypes();
+    if (!unwrappedTy->isEqual(paramType)) {
+      auto &optionalLookup = cs.lookupMember(paramType, name, SourceLoc());
+      if (!optionalLookup.empty())
+        return std::nullopt;
+
+      paramType = unwrappedTy;
+
+      // An optional-of-function parameter is not analyzable: member
+      // lookup through it is not the same as lookup into the function
+      // type itself.
+      if (paramType->is<FunctionType>())
+        return std::nullopt;
+    }
+  }
+
+  // A function-typed parameter: function types themselves have no
+  // members, so a leading dot can only resolve through the return type
+  // (and only when the feature that enables that is turned on).
+  bool viaFunctionResult = false;
+  unsigned expectedArity = 0;
+  if (auto *fnTy = paramType->getAs<FunctionType>()) {
+    if (!ctx.LangOpts.hasFeature(Feature::ImplicitMemberOnFunctionType))
+      return 0;
+
+    viaFunctionResult = true;
+    expectedArity = fnTy->getNumParams();
+    // Note: return-type lookup doesn't itself look through optionals
+    // or a second level of function types, so the result is used as-is.
+    paramType = fnTy->getResult();
+  }
+
+  // The base of the lookup has to be a fully concrete nominal type
+  // without any lookup "escape hatches".
+  if (paramType->hasTypeVariable() || paramType->hasTypeParameter() ||
+      paramType->hasUnboundGenericType() || paramType->hasError() ||
+      paramType->hasArchetype() || paramType->is<DynamicSelfType>())
+    return std::nullopt;
+
+  if (paramType->isExistentialType() || paramType->isAnyObject())
+    return std::nullopt;
+
+  // `String` members could come from the bridged `NSString`; `Double`
+  // and `CGFloat` are implicitly convertible to each other, so for them
+  // the lookup type is not guaranteed to be the parameter type.
+  if (paramType->isString() || paramType->isDouble() || paramType->isCGFloat())
+    return std::nullopt;
+
+  if (!paramType->getAnyNominal())
+    return std::nullopt;
+
+  // This is exactly the (cached) lookup the solver is going to use to
+  // find candidates for the unresolved member, so if it comes up empty
+  // the overload choice cannot possibly succeed.
+  auto &lookup = cs.lookupMember(paramType, name, SourceLoc());
+  if (lookup.empty())
+    return 0;
+
+  // With postfix syntax applied (i.e. `.foo(...)` or `.foo.bar`) the
+  // type of the argument is not the type of the leading member, so
+  // existence of the member is all that can be checked.
+  if (argument.hasPostfix)
+    return 30;
+
+  // A bare implicit member: the unapplied reference to the member has
+  // to be convertible to the parameter type. Without resolving any
+  // types it's only possible to reason about shapes:
+  //
+  //  - function conversions preserve arity, so an enum element can only
+  //    match a function-typed parameter if it has a payload with the
+  //    same number of elements;
+  //  - a no-payload enum element is a value of the enum type and can
+  //    never match a function type;
+  //  - an unapplied reference to a function (or a payload enum element)
+  //    is always function-typed and can never match a non-function
+  //    nominal parameter type.
+  //
+  // Everything else (variables, nested types, etc.) is conservatively
+  // considered viable.
+  bool anyViable = false;
+  for (const auto &entry : lookup) {
+    auto *decl = entry.getValueDecl();
+
+    if (auto *EED = dyn_cast<EnumElementDecl>(decl)) {
+      if (viaFunctionResult) {
+        anyViable |= EED->hasAssociatedValues() &&
+                     EED->getParameterList()->size() == expectedArity;
+      } else {
+        anyViable |= !EED->hasAssociatedValues();
+      }
+      continue;
+    }
+
+    if (isa<FuncDecl>(decl)) {
+      // Arity of functions is not checked because of curried self,
+      // default arguments, variadics, etc.
+      anyViable |= viaFunctionResult;
+      continue;
+    }
+
+    anyViable = true;
+  }
+
+  return anyViable ? 30 : 0;
 }
 
 /// If the given expression represents a chain of operators that have
@@ -623,6 +832,12 @@ static std::optional<DisjunctionInfo> preserveFavoringOfUnlabeledUnaryArgument(
 
   if (!isExpr<ApplyExpr>(
           cs.getParentExpr(argumentList->getUnlabeledUnaryExpr())))
+    return std::nullopt;
+
+  // Implicit member (leading-dot) arguments carry no type information,
+  // but they can be analyzed based on their member name by the general
+  // argument matching below.
+  if (getImplicitMemberArgument(argumentList->getUnlabeledUnaryExpr()))
     return std::nullopt;
 
   // The hack rolled back favoring choices if one of the overloads was a
@@ -1209,6 +1424,19 @@ static DisjunctionInfo computeDisjunctionInfo(
     }
   }
 
+  // Implicit member (leading-dot) arguments i.e. `.member` don't have
+  // any type information associated with them before the contextual
+  // type is resolved, but the name of the member is known and can be
+  // used to check whether a particular overload choice could possibly
+  // have a member with a matching name and shape.
+  SmallVector<std::optional<ImplicitMemberArgument>, 4> implicitMemberArgs;
+  bool hasImplicitMemberArgs = false;
+  for (const auto &argument : *argumentList) {
+    auto member = getImplicitMemberArgument(argument.getExpr());
+    hasImplicitMemberArgs |= member.has_value();
+    implicitMemberArgs.push_back(member);
+  }
+
   // This maintains an "old hack" behavior where overloads
   // of `OverloadedDeclRef` calls were favored purely
   // based on arity of arguments and parameters matching.
@@ -1233,7 +1461,7 @@ static DisjunctionInfo computeDisjunctionInfo(
     return info.value();
   }
 
-  if (!isSupportedDisjunction(disjunction))
+  if (!isSupportedDisjunction(disjunction, hasImplicitMemberArgs))
     return DisjunctionInfo();
 
   SmallVector<FunctionType::Param, 8> argsWithLabels;
@@ -1456,6 +1684,76 @@ static DisjunctionInfo computeDisjunctionInfo(
                               /*allow fixes*/ false, listener, std::nullopt);
   };
 
+  // Analyze an implicit member argument against the parameter it's
+  // matched to. Always starts from the raw parameter so that both the
+  // coverage pre-pass below and the scoring pass produce identical
+  // results.
+  auto analyzeImplicitMemberParam =
+      [&](const AnyFunctionType::Param &param,
+          const ImplicitMemberArgument &member) -> std::optional<unsigned> {
+    auto flags = param.getParameterFlags();
+    // Variadic arity is unknown and `inout` requires an l-value; neither
+    // is analyzable through a member name.
+    if (flags.isVariadic() || flags.isInOut())
+      return std::nullopt;
+
+    auto paramType = param.getPlainType();
+    if (flags.isAutoClosure())
+      paramType = paramType->castTo<AnyFunctionType>()->getResult();
+
+    return scoreImplicitMemberArgument(cs, member, paramType);
+  };
+
+  // Implicit member scores may only be used when the analysis is
+  // definitive for *every* viable overload choice the argument could
+  // be matched to. Favoring one choice while a competing choice is
+  // merely *unanalyzable* (e.g. its parameter is a `Double`, `String`,
+  // or an existential) would place the unanalyzable choice in a later
+  // partition and let the solver skip it entirely once the favored
+  // choice succeeds - changing overload resolution and suppressing
+  // ambiguities in existing code.
+  SmallVector<bool, 4> implicitMemberAnalysisIsDefinitive;
+  if (hasImplicitMemberArgs) {
+    implicitMemberAnalysisIsDefinitive.resize(implicitMemberArgs.size());
+    for (unsigned i : indices(implicitMemberArgs))
+      implicitMemberAnalysisIsDefinitive[i] = implicitMemberArgs[i].has_value();
+
+    forEachDisjunctionChoice(
+        cs, disjunction,
+        [&](Constraint *choice, ValueDecl *decl, FunctionType *overloadType) {
+          auto matchings =
+              matchArguments(choice->getOverloadChoice(), overloadType);
+          // A choice that cannot match the argument list at all never
+          // gets favored or scored, so it doesn't participate in the
+          // analysis (this mirrors the scoring loop below).
+          if (!matchings)
+            return;
+
+          for (unsigned paramIdx = 0, n = overloadType->getNumParams();
+               paramIdx != n; ++paramIdx) {
+            auto argIndices = matchings->parameterBindings[paramIdx];
+            // Mirror the scoring loop: multiple argument matchings drop
+            // the choice from scoring entirely.
+            if (argIndices.size() > 1)
+              return;
+            if (argIndices.empty())
+              continue;
+
+            auto argIdx = argIndices.front();
+            if (argIdx >= implicitMemberArgs.size())
+              continue;
+
+            auto member = implicitMemberArgs[argIdx];
+            if (!member)
+              continue;
+
+            if (!analyzeImplicitMemberParam(
+                    overloadType->getParams()[paramIdx], *member))
+              implicitMemberAnalysisIsDefinitive[argIdx] = false;
+          }
+        });
+  }
+
   // The choice with the best score.
   unsigned bestScore = 0;
   SmallVector<std::pair<Constraint *, unsigned>, 2> favoredChoices;
@@ -1507,10 +1805,6 @@ static DisjunctionInfo computeDisjunctionInfo(
 
           auto argIdx = argIndices.front();
 
-          // Looks like there is nothing know about the argument.
-          if (argumentCandidates[argIdx].empty())
-            continue;
-
           const auto paramFlags = param.getParameterFlags();
 
           // If parameter is variadic we cannot compare because we don't know
@@ -1522,6 +1816,30 @@ static DisjunctionInfo computeDisjunctionInfo(
 
           if (paramFlags.isAutoClosure())
             paramType = paramType->castTo<AnyFunctionType>()->getResult();
+
+          // Looks like there is nothing known about the argument except,
+          // possibly, that it's an implicit member reference i.e. `.foo`,
+          // which can be analyzed based on the name of the member (but
+          // only when the analysis is definitive for every choice, see
+          // the coverage pre-pass above).
+          if (argumentCandidates[argIdx].empty()) {
+            if (argIdx < implicitMemberAnalysisIsDefinitive.size() &&
+                implicitMemberAnalysisIsDefinitive[argIdx]) {
+              if (auto member = implicitMemberArgs[argIdx]) {
+                if (auto memberScore =
+                        analyzeImplicitMemberParam(param, *member)) {
+                  // Member lookup into this parameter type cannot find
+                  // the named member, so the overload cannot possibly
+                  // match; drop it from any further consideration.
+                  if (*memberScore == 0)
+                    return;
+
+                  score += *memberScore;
+                }
+              }
+            }
+            continue;
+          }
 
           // FIXME: Let's skip matching function types for now
           // because they have special rules for e.g. Concurrency
@@ -1662,6 +1980,23 @@ static DisjunctionInfo computeDisjunctionInfo(
           bestScore = std::max(bestScore, score);
         }
       });
+
+  // If the implicit member argument analysis didn't produce any
+  // favorings, restore the previous treatment of this disjunction:
+  // both a unary call with an implicit member argument (which used to
+  // be terminated by the unary argument hack above) and a disjunction
+  // that is only "supported" due to having implicit member arguments
+  // used to be ranked as not optimizable.
+  if (favoredChoices.empty() && hasImplicitMemberArgs) {
+    bool wasHandledByUnaryHack =
+        argumentList->isUnlabeledUnary() && implicitMemberArgs[0].has_value() &&
+        isExpr<ApplyExpr>(
+            cs.getParentExpr(argumentList->getUnlabeledUnaryExpr()));
+
+    if (wasHandledByUnaryHack ||
+        !isSupportedDisjunction(disjunction, /*hasImplicitMemberArgs=*/false))
+      return DisjunctionInfo::none();
+  }
 
   // Determine if the score and favoring decisions here are
   // based only on "speculative" sources i.e. inference from

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -1244,7 +1244,9 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
       identical = false;
       
       // A declaration found directly beats any declaration found via dynamic
-      // lookup, bridging, or optional unwrapping.
+      // lookup, bridging, or optional unwrapping. (A function-result
+      // look-through reads as a plain Decl here and is ranked below a direct
+      // member by SK_UnresolvedMemberViaFunctionResult instead.)
       if ((choice1.getKind() == OverloadChoiceKind::Decl) &&
           (choice2.getKind() == OverloadChoiceKind::DeclViaDynamic ||
            choice2.getKind() == OverloadChoiceKind::DeclViaBridge ||

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -237,7 +237,6 @@ static bool sameOverloadChoice(const OverloadChoice &x,
   case OverloadChoiceKind::Decl:
   case OverloadChoiceKind::DeclViaDynamic:
   case OverloadChoiceKind::DeclViaBridge:
-  case OverloadChoiceKind::DeclViaUnwrappedOptional:
   case OverloadChoiceKind::DynamicMemberLookup:
   case OverloadChoiceKind::KeyPathDynamicMemberLookup:
     return sameDecl(x.getDecl(), y.getDecl());
@@ -1239,26 +1238,49 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
       }
     }
     
+    // A directly-found member beats one found by unwrapping an optional base.
+    // Both read as OverloadChoiceKind::Decl, so this is not a kind mismatch
+    // below; distinguish them via the sub-flag. This mirrors the Decl-vs-
+    // DeclViaUnwrappedOptional case of the kind-mismatch rule that applied
+    // before DeclViaUnwrappedOptional was demoted to a Decl sub-flag. A member
+    // reached by looking through a function result also reads as a plain Decl
+    // and so also beats an unwrapped one here, exactly as it did then. (Uses
+    // getKind() == Decl rather than isDecl() so that dynamic/bridge choices --
+    // which also carry a decl -- are left to the kind-mismatch rule below.)
+    if (choice1.getKind() == OverloadChoiceKind::Decl &&
+        choice2.getKind() == OverloadChoiceKind::Decl &&
+        choice1.isDeclViaUnwrappedOptional() !=
+            choice2.isDeclViaUnwrappedOptional()) {
+      identical = false;
+      if (choice1.isDeclViaUnwrappedOptional())
+        score2 += weight;
+      else
+        score1 += weight;
+      continue;
+    }
+
     // If the kinds of overload choice don't match...
     if (choice1.getKind() != choice2.getKind()) {
       identical = false;
-      
+
       // A declaration found directly beats any declaration found via dynamic
-      // lookup, bridging, or optional unwrapping. (A function-result
-      // look-through reads as a plain Decl here and is ranked below a direct
-      // member by SK_UnresolvedMemberViaFunctionResult instead.)
-      if ((choice1.getKind() == OverloadChoiceKind::Decl) &&
+      // lookup or bridging. A member found by unwrapping an optional base reads
+      // as a plain Decl but is *not* "direct" for this purpose -- before the
+      // demotion it tied with dynamic/bridge -- so exclude it. (A function-
+      // result look-through also reads as Decl and does beat them, as it did
+      // when it too was a distinct kind.)
+      if ((choice1.getKind() == OverloadChoiceKind::Decl &&
+           !choice1.isDeclViaUnwrappedOptional()) &&
           (choice2.getKind() == OverloadChoiceKind::DeclViaDynamic ||
-           choice2.getKind() == OverloadChoiceKind::DeclViaBridge ||
-           choice2.getKind() == OverloadChoiceKind::DeclViaUnwrappedOptional)) {
+           choice2.getKind() == OverloadChoiceKind::DeclViaBridge)) {
         score1 += weight;
         continue;
       }
 
       if ((choice1.getKind() == OverloadChoiceKind::DeclViaDynamic ||
-           choice1.getKind() == OverloadChoiceKind::DeclViaBridge ||
-           choice1.getKind() == OverloadChoiceKind::DeclViaUnwrappedOptional) &&
-          choice2.getKind() == OverloadChoiceKind::Decl) {
+           choice1.getKind() == OverloadChoiceKind::DeclViaBridge) &&
+          (choice2.getKind() == OverloadChoiceKind::Decl &&
+           !choice2.isDeclViaUnwrappedOptional())) {
         score2 += weight;
         continue;
       }
@@ -1303,7 +1325,6 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
     case OverloadChoiceKind::DeclViaDynamic:
     case OverloadChoiceKind::Decl:
     case OverloadChoiceKind::DeclViaBridge:
-    case OverloadChoiceKind::DeclViaUnwrappedOptional:
     case OverloadChoiceKind::DynamicMemberLookup:
     case OverloadChoiceKind::KeyPathDynamicMemberLookup:
       break;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10567,6 +10567,66 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
     }
   }
 
+  // Implicit member syntax against a function-typed expected type: look up the
+  // member on the function's return type. This lets a leading dot name a static
+  // member (e.g. an enum case with a payload) whose unapplied reference is a
+  // function producing the return type, as in 'Foo<X>(.b)' where '.b' resolves
+  // to the case constructor 'X.b: (Int) -> X'. Such candidates are ranked
+  // strictly below any member found directly on the expected type, so they only
+  // win where the direct lookup has no viable candidate.
+  if (ctx.LangOpts.hasFeature(Feature::ImplicitMemberOnFunctionType) &&
+      constraintKind == ConstraintKind::UnresolvedValueMember &&
+      baseObjTy->is<AnyMetatypeType>()) {
+    if (auto *fnTy = instanceTy->getAs<FunctionType>()) {
+      Type resultTy = fnTy->getResult();
+
+      // If the return type isn't resolved enough to look members up, delay.
+      if (resultTy->isTypeVariableOrMember()) {
+        result.OverallResult = MemberLookupResult::Unsolved;
+        return result;
+      }
+
+      if (resultTy->mayHaveMembers()) {
+        auto resultLookup = performMemberLookup(
+            constraintKind, memberName, MetatypeType::get(resultTy),
+            functionRefInfo, memberLocator, includeInaccessibleMembers);
+
+        // If the return-type lookup can't be resolved yet, delay rather than
+        // fall through to a premature "no such member" result.
+        if (resultLookup.OverallResult == MemberLookupResult::Unsolved) {
+          result.OverallResult = MemberLookupResult::Unsolved;
+          return result;
+        }
+
+        // Re-form the static members found on the return type as
+        // 'DeclViaFunctionResult' choices. Only plain declaration references
+        // are considered: we deliberately do not look through a second layer
+        // of bridging, optional unwrapping, or dynamic lookup on the return
+        // type. Whether each candidate's unapplied type is actually compatible
+        // with the function type is determined later by the surrounding
+        // conversion constraints.
+        //
+        // We intentionally do *not* pre-filter to only function-shaped members
+        // here. In a chained implicit member expression (SE-0287) the leading
+        // dot may name a plain value member of the return type that a later
+        // element turns into the function type (e.g. '.a.asFunction', where 'a'
+        // has no payload), so dropping non-function members would reject valid
+        // chains. Filtering only terminal (non-chain) positions was measured to
+        // remove no viable candidates -- it only drops losers that the solver's
+        // score cutoff and disjunction-favoring already prune -- so it isn't
+        // worth the added machinery.
+        for (const auto &choice : resultLookup.ViableCandidates) {
+          if (choice.getKind() != OverloadChoiceKind::Decl)
+            continue;
+
+          result.addViable(OverloadChoice::getDeclViaFunctionResult(
+              choice.getBaseType(), choice.getDecl(),
+              choice.getFunctionRefInfo()));
+        }
+      }
+    }
+  }
+
   if (!instanceTy->mayHaveMembers())
     return result;
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10616,7 +10616,15 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
         // score cutoff and disjunction-favoring already prune -- so it isn't
         // worth the added machinery.
         for (const auto &choice : resultLookup.ViableCandidates) {
-          if (choice.getKind() != OverloadChoiceKind::Decl)
+          // Only a plain, first-level declaration reference. Optional unwrapping
+          // and function-result look-through both now read as
+          // OverloadChoiceKind::Decl, so exclude them explicitly (a bare
+          // getKind() check no longer does) to preserve the no-second-hop rule
+          // documented above -- e.g. don't resolve '.b' against '(Int) -> E?' by
+          // unwrapping the optional return type.
+          if (choice.getKind() != OverloadChoiceKind::Decl ||
+              choice.isDeclViaUnwrappedOptional() ||
+              choice.isDeclViaFunctionResult())
             continue;
 
           result.addViable(OverloadChoice::getDeclViaFunctionResult(
@@ -12273,9 +12281,7 @@ static Type getOpenedResultBuilderTypeFor(ConstraintSystem &cs,
   auto *calleeLocator = cs.getCalleeLocator(cs.getConstraintLocator(locator));
   auto selectedOverload = cs.findSelectedOverloadFor(calleeLocator);
   if (!(selectedOverload &&
-        (selectedOverload->choice.getKind() == OverloadChoiceKind::Decl ||
-         selectedOverload->choice.getKind() ==
-             OverloadChoiceKind::DeclViaUnwrappedOptional)))
+        selectedOverload->choice.getKind() == OverloadChoiceKind::Decl))
     return Type();
 
   auto *choice = selectedOverload->choice.getDecl();

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1978,7 +1978,6 @@ DeclName OverloadChoice::getName() const {
     case OverloadChoiceKind::Decl:
     case OverloadChoiceKind::DeclViaDynamic:
     case OverloadChoiceKind::DeclViaBridge:
-    case OverloadChoiceKind::DeclViaUnwrappedOptional:
       return getDecl()->getName();
 
     case OverloadChoiceKind::KeyPathApplication:
@@ -3392,8 +3391,7 @@ bool ConstraintSystem::diagnoseAmbiguity(ArrayRef<Solution> solutions) {
       switch (choice.getKind()) {
       case OverloadChoiceKind::Decl:
       case OverloadChoiceKind::DeclViaDynamic:
-      case OverloadChoiceKind::DeclViaBridge:
-      case OverloadChoiceKind::DeclViaUnwrappedOptional: {
+      case OverloadChoiceKind::DeclViaBridge: {
         // FIXME: show deduced types, etc, etc.
         auto decl = choice.getDecl();
         if (EmittedDecls.insert(decl).second) {

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1154,6 +1154,8 @@ void OverloadChoice::dump(Type adjustedOpenedType, SourceManager *sm,
     printDecl();
     if (isDeclViaFunctionResult())
       out << " via function result";
+    else if (isDeclViaUnwrappedOptional())
+      out << " unwrapped";
     break;
 
   case OverloadChoiceKind::DeclViaDynamic:
@@ -1164,11 +1166,6 @@ void OverloadChoice::dump(Type adjustedOpenedType, SourceManager *sm,
   case OverloadChoiceKind::DeclViaBridge:
     printDecl();
     out << " bridged";
-    break;
-
-  case OverloadChoiceKind::DeclViaUnwrappedOptional:
-    printDecl();
-    out << " unwrapped";
     break;
 
   case OverloadChoiceKind::KeyPathApplication:
@@ -1471,7 +1468,6 @@ void ConstraintSystem::print(raw_ostream &out) const {
       case OverloadChoiceKind::Decl:
       case OverloadChoiceKind::DeclViaDynamic:
       case OverloadChoiceKind::DeclViaBridge:
-      case OverloadChoiceKind::DeclViaUnwrappedOptional:
         if (choice.getBaseType())
           out << choice.getBaseType()->getString(PO) << ".";
         out << choice.getDecl()->getBaseName() << ": "

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1152,6 +1152,8 @@ void OverloadChoice::dump(Type adjustedOpenedType, SourceManager *sm,
   switch (getKind()) {
   case OverloadChoiceKind::Decl:
     printDecl();
+    if (isDeclViaFunctionResult())
+      out << " via function result";
     break;
 
   case OverloadChoiceKind::DeclViaDynamic:

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -2173,6 +2173,13 @@ DeclReferenceType ConstraintSystem::getTypeOfMemberReference(
 Type ConstraintSystem::getEffectiveOverloadType(ConstraintLocator *locator,
                                                 const OverloadChoice &overload,
                                                 DeclContext *useDC) {
+  // A member found by unwrapping an optional base reads as a plain Decl, but
+  // its member type does not account for the T -> T? promotion at the use site,
+  // so -- as when DeclViaUnwrappedOptional was a distinct kind -- don't offer a
+  // simplified type for it (which would mislead disjunction pre-filtering).
+  if (overload.isDeclViaUnwrappedOptional())
+    return Type();
+
   switch (overload.getKind()) {
   case OverloadChoiceKind::Decl:
     // Declaration choices are handled below.
@@ -2180,7 +2187,6 @@ Type ConstraintSystem::getEffectiveOverloadType(ConstraintLocator *locator,
 
   case OverloadChoiceKind::DeclViaBridge:
   case OverloadChoiceKind::DeclViaDynamic:
-  case OverloadChoiceKind::DeclViaUnwrappedOptional:
   case OverloadChoiceKind::DynamicMemberLookup:
   case OverloadChoiceKind::KeyPathDynamicMemberLookup:
   case OverloadChoiceKind::KeyPathApplication:
@@ -2386,7 +2392,6 @@ void ConstraintSystem::bindOverloadType(const SelectedOverload &overload,
   switch (choice.getKind()) {
   case OverloadChoiceKind::Decl:
   case OverloadChoiceKind::DeclViaBridge:
-  case OverloadChoiceKind::DeclViaUnwrappedOptional:
   case OverloadChoiceKind::TupleIndex:
   case OverloadChoiceKind::MaterializePack:
   case OverloadChoiceKind::ExtractFunctionIsolation:
@@ -2966,7 +2971,6 @@ void ConstraintSystem::resolveOverload(OverloadChoice choice, DeclContext *useDC
   case OverloadChoiceKind::Decl:
   case OverloadChoiceKind::DeclViaBridge:
   case OverloadChoiceKind::DeclViaDynamic:
-  case OverloadChoiceKind::DeclViaUnwrappedOptional:
   case OverloadChoiceKind::DynamicMemberLookup:
   case OverloadChoiceKind::KeyPathDynamicMemberLookup: {
     Type openedType, thrownErrorType;

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -3287,6 +3287,15 @@ void ConstraintSystem::resolveOverload(OverloadChoice choice, DeclContext *useDC
   if (choice.isFallbackMemberOnUnwrappedBase()) {
     increaseScore(SK_UnresolvedMemberViaOptional, locator);
   }
+
+  // A member found by looking through a function-typed context to its return
+  // type is strictly lower priority than any member found directly, so that a
+  // direct candidate always wins when one exists. This is the one place that
+  // distinguishes such a choice from an ordinary Decl (see
+  // OverloadChoice::isDeclViaFunctionResult).
+  if (choice.isDeclViaFunctionResult()) {
+    increaseScore(SK_UnresolvedMemberViaFunctionResult, locator);
+  }
 }
 
 void ConstraintSystem::verifyThatArgumentIsHashable(unsigned index,

--- a/test/Constraints/implicit_member_function_type.swift
+++ b/test/Constraints/implicit_member_function_type.swift
@@ -1,0 +1,119 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature ImplicitMemberOnFunctionType
+
+// REQUIRES: swift_feature_ImplicitMemberOnFunctionType
+
+// Implicit member syntax (the leading dot) may look through a function-typed
+// expected type '(P...) -> R' to a static member of the return type 'R'.
+
+struct Foo<T> {
+  init(_ t: T) {}
+  init<P>(_ t: (P) -> T) {}
+}
+
+enum X { case a; case b(Int) }
+
+let a1 = Foo<X>(.a)         // uses init(_: T), .a == X.a
+let b1 = Foo<X>(.b)         // uses init<P>(_:), .b == X.b
+let b2 = Foo<X>(X.b)        // still works: explicit unapplied case
+let b3 = Foo<X> { X.b($0) } // still works: explicit closure
+
+// To verify which overload is selected, use free functions whose overloads
+// return distinct types and pin the result with a type annotation. If the
+// wrong overload were chosen, the annotation would fail to type-check.
+func choose(_: X) -> Int { 0 }
+func choose<P>(_: (P) -> X) -> String { "" }
+
+let chosenA: Int = choose(.a)    // value overload: '.a' is a value of type X
+let chosenB: String = choose(.b) // function overload: '.b' is '(Int) -> X'
+_ = chosenA
+_ = chosenB
+
+// The motivating DSL shape: two overloads, one taking an event value and one
+// taking an event constructor '(Payload) -> Event'.
+enum LifeEvent: Hashable {
+  case clear
+  case toggleCell(Int)
+  case running
+}
+
+struct XTransition {
+  init(on: LifeEvent, to: LifeEvent) {}
+  init<P>(on: @escaping (P) -> LifeEvent, to: LifeEvent) {}
+}
+
+_ = XTransition(on: .clear, to: .running)      // value overload
+_ = XTransition(on: .toggleCell, to: .running) // constructor overload
+
+// Generalizes to any static member whose unapplied type is a function
+// returning the contextual type, e.g. a static factory method.
+struct Widget {
+  static func make(_ x: Int) -> Widget { Widget() }
+}
+
+func build(_: Widget) -> Int { 0 }
+func build<P>(_: (P) -> Widget) -> String { "" }
+
+let built: String = build(.make) // .make == Widget.make: (Int) -> Widget
+_ = built
+
+// Multiple payload elements resolve through the curried constructor type.
+enum Multi { case pair(Int, String) }
+
+func sink(_: Multi) -> Int { 0 }
+func sink<A, B>(_: (A, B) -> Multi) -> String { "" }
+
+let sunk: String = sink(.pair) // .pair == Multi.pair: (Int, String) -> Multi
+_ = sunk
+
+// The new candidate is *strictly lower priority* than a member found directly
+// on the expected type. When the same name exists both as a value and as a
+// function on the return type, matched against value-vs-function overloads, the
+// value interpretation always wins and the program stays unambiguous.
+struct Both {
+  static var thing: Both { Both() }
+  static func thing(_: Int) -> Both { Both() }
+}
+
+func pick(_: Both) -> Int { 0 }
+func pick<P>(_: (P) -> Both) -> String { "" }
+
+// No contextual type is supplied to the call, so the result is decided purely
+// by ranking. The value member is strictly higher priority than the
+// function-result member, so this is unambiguous and resolves to the 'Int'
+// (value) overload. If the function-result candidate were not lower priority,
+// this would be ambiguous, or 'picked' would be 'String' and the annotation
+// below would fail.
+let picked = pick(.thing)
+let _: Int = picked
+
+// A plain non-function contextual type is unaffected: '.a' still resolves
+// directly against 'X'.
+func takesX(_: X) {}
+takesX(.a)
+
+// Chained implicit member expressions (SE-0287).
+//
+// The look-through applies at the *leading* dot of a chain, whose base is the
+// whole chain's contextual type. So a chain can begin from a member of the
+// return type even when the surrounding context is a function type, then be
+// transformed into that function type by ordinary member accesses.
+enum Y {
+  case a
+  case b(Int)
+  var asFunction: (Int) -> Y { { Y.b($0) } }
+}
+
+// Leading dot resolved via the return type ('Y.a'), then chained to the
+// function-typed context.
+let chained: (Int) -> Y = .a.asFunction
+
+// A function-result member can itself lead a chain; '.self' is one of the few
+// members a function value offers.
+let chainedSelf: (Int) -> Y = .b.self
+
+// Existing (non-function) implicit member chains are unaffected.
+struct Color {
+  static var red: Color { Color() }
+  func withAlpha(_ a: Double) -> Color { self }
+}
+let color: Color = .red.withAlpha(0.5)

--- a/test/Constraints/implicit_member_function_type_disabled.swift
+++ b/test/Constraints/implicit_member_function_type_disabled.swift
@@ -1,0 +1,18 @@
+// RUN: %target-typecheck-verify-swift
+
+// Without the 'ImplicitMemberOnFunctionType' feature enabled, a leading dot
+// does not look through a function-typed parameter to the return type. This
+// pins the pre-feature behavior so the change stays additive / source
+// compatible: only code that is an error today starts to compile, and only
+// when the feature is enabled.
+
+struct Foo<T> {
+  init(_ t: T) {}
+  init<P>(_ t: (P) -> T) {}
+}
+
+enum X { case a; case b(Int) }
+
+let a1 = Foo<X>(.a) // no-payload case still resolves directly against 'X'
+let b1 = Foo<X>(.b) // expected-error {{member 'b' expects argument of type 'Int'}}
+let b2 = Foo<X>(X.b) // spelling out the type is the pre-feature workaround

--- a/test/Constraints/implicit_member_function_type_overloads.swift
+++ b/test/Constraints/implicit_member_function_type_overloads.swift
@@ -1,0 +1,96 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature ImplicitMemberOnFunctionType
+
+// REQUIRES: swift_feature_ImplicitMemberOnFunctionType
+
+// Implicit member syntax through a function type behaves exactly like the
+// explicit 'Type.member' form: it can't introduce an ambiguity that the
+// explicit spelling doesn't already have, and the return-type look-through is
+// ranked strictly below any direct member of the contextual type.
+
+struct Theme {}
+extension Theme {
+  static var custom: (String) -> Theme { { _ in Theme() } }
+  // An *instance* method is not a competitor: its unapplied reference carries
+  // 'self' ('(Theme) -> (String) -> Theme'), so it can't be '(String) -> Theme'.
+  func custom(name: String) -> Theme { self }
+}
+
+// Resolves unambiguously to the static var (the instance method doesn't match).
+let a1: (String) -> Theme = .custom
+
+struct Palette {}
+extension Palette {
+  static var custom: (String) -> Palette { { _ in Palette() } }
+  // Even a static func with the same signature isn't ambiguous: a property is
+  // preferred over an unapplied function of the same name (pre-existing rule).
+  static func custom(_ name: String) -> Palette { Palette() }
+}
+
+let a2: (String) -> Palette = .custom
+
+// An implicit member argument to an *overloaded* call that can't be satisfied
+// must still produce a real diagnostic (regression: this used to emit the
+// internal "failed to produce diagnostic" fallback).
+struct Widget {}
+extension Widget {
+  func update(_ x: Int) -> Widget { self } // instance method: carries self
+}
+
+func process(_ handler: (Int) -> Widget) {}
+func process(_ handler: (String) -> Widget) {}
+
+func testInstanceMethodDoesNotMatch() {
+  process(.update)
+  // expected-error@-1 {{member 'update' expects argument of type 'Widget'}}
+}
+
+// A genuine ambiguity across the return type's members is diagnosed as such,
+// not silently resolved.
+struct View {}
+extension Widget {
+  static func make(_ x: Int) -> Widget { Widget() } // expected-note {{found this candidate}}
+}
+extension View {
+  static func make(_ x: Double) -> View { View() } // expected-note {{found this candidate}}
+}
+
+func build(_ handler: (Int) -> Widget) {}
+func build(_ handler: (Double) -> View) {}
+
+func testGenuineAmbiguity() {
+  build(.make) // expected-error {{ambiguous use of 'make'}}
+}
+
+// A static factory with the wrong arity for the parameter (e.g. a parameter
+// was added and a call site wasn't updated) reports a conversion failure, not
+// the internal "failed to produce diagnostic" fallback.
+struct Card {}
+extension Card {
+  static func make(_ title: String, _ subtitle: String) -> Card { Card() }
+}
+
+func render(_ build: (String) -> Card) {}
+func render(_ build: (Int) -> Card) {}
+
+func testWrongArity() {
+  render(.make)
+  // expected-error@-1 {{cannot convert value of type '(String, String) -> Card' to expected argument type '(String) -> Card'}}
+}
+
+// Source compatibility: a member found *directly* on one overload's parameter
+// type outranks a same-named member reached by *looking through* another
+// overload's function-typed parameter -- even when both overloads are
+// non-generic, so nothing else can break the tie. 'route(.item)' resolved to
+// the value overload before this feature existed and must still do so; without
+// the strictly-lower-priority ranking of the look-through the two would tie and
+// this would regress to 'ambiguous use of item'.
+struct Anchor { static let item = Anchor() }
+enum Node { case item(Int) }
+
+func route(_ x: Anchor) -> Int { 0 }
+func route(_ f: (Int) -> Node) -> String { "" }
+
+func testDirectMemberOutranksLookThrough() {
+  let selected = route(.item)
+  let _: Int = selected // Anchor.item (direct) wins: not ambiguous, not String
+}

--- a/test/Constraints/implicit_member_overload_favoring.swift
+++ b/test/Constraints/implicit_member_overload_favoring.swift
@@ -1,0 +1,92 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -enable-experimental-feature ImplicitMemberOnFunctionType
+
+// REQUIRES: swift_feature_ImplicitMemberOnFunctionType
+
+// The constraint optimizer analyzes implicit member (leading-dot) arguments
+// by member name to favor / prune overload choices. That analysis must be
+// all-or-nothing across an overload set: when any choice's parameter type is
+// unanalyzable (Double/CGFloat/String, optionals whose `Optional` type has a
+// member with the name, existentials, ...), no favoring may be applied at
+// all — otherwise the unanalyzable choice would be skipped by the solver and
+// existing ambiguities (or baseline overload selections) would silently
+// change. These tests pin the pre-optimizer behavior; they must behave
+// identically with and without the feature flag.
+
+// An analyzable nominal choice must not shadow an unanalyzable Double choice.
+struct Q {
+  static var pi = Q() // expected-note {{found this candidate}}
+}
+func f0(_ x: Q) {}
+func f0(_ x: Double) {}
+
+func testAmbiguousStaysAmbiguous() {
+  f0(.pi) // expected-error {{ambiguous use of 'pi'}}
+}
+
+// When both overloads are viable but ranking prefers the exact `Double`
+// match over optional injection, favoring must not flip the selection.
+func f1(_ x: Q?) -> String { "" }
+func f1(_ x: Double) -> Int { 0 }
+
+func testSelectionNotFlipped() {
+  let r = f1(.pi)
+  let _: Int = r // baseline ranking picks f1(_: Double)
+}
+
+// A name that exists on `Optional` itself (`some`/`none`) makes the optional
+// choice unanalyzable; the ambiguity with a same-named nominal member stays.
+struct S2 {
+  static func some(_ x: Int) -> S2 { S2() } // expected-note {{found this candidate}}
+  static var none = S2() // expected-note {{found this candidate}}
+}
+func f2(_ x: S2) {}
+func f2(_ x: Int?) {}
+
+func testOptionalMemberNamesStayAmbiguous() {
+  f2(.some(1)) // expected-error {{ambiguous use of 'some'}}
+  f2(.none) // expected-error {{ambiguous use of 'none'}}
+}
+
+// Standard-library `Double.pi` vs a same-named enum case.
+enum EPi { case pi } // expected-note {{found this candidate}}
+func f3(_ x: Double) -> Int { 0 }
+func f3(_ x: EPi) -> String { "" }
+
+func testStdlibMemberStaysAmbiguous() {
+  _ = f3(.pi) // expected-error {{ambiguous use of 'pi'}}
+}
+
+// Both choices unanalyzable (Double and Float are both on the bail list).
+func f4(_ x: Double) -> Int { 0 }
+func f4(_ x: Float) -> String { "" }
+
+func testBothUnanalyzableStaysAmbiguous() {
+  _ = f4(.pi) // expected-error {{ambiguous use of 'pi'}}
+}
+
+// An existential choice (SE-0299 static members on protocol extensions) is
+// unanalyzable; ambiguity with an enum case of the same name stays.
+protocol Style {}
+struct Bold: Style {}
+extension Style where Self == Bold {
+  static var fancy: Bold { Bold() } // expected-note {{found this candidate}}
+}
+enum Mode { case fancy } // expected-note {{found this candidate}}
+func apply(_ s: any Style) -> Int { 0 }
+func apply(_ m: Mode) -> String { "" }
+
+func testExistentialStaysAmbiguous() {
+  _ = apply(.fancy) // expected-error {{ambiguous use of 'fancy'}}
+}
+
+// Positive control: when every choice is analyzable the favoring applies
+// and selects the (only possible) value overload for a no-payload case.
+enum E { case a; case b(Int) }
+func g(_ x: E) -> Int { 0 }
+func g<P>(_ x: (P) -> E) -> String { "" }
+
+func testFavoringStillWorks() {
+  let r = g(.a)
+  let _: Int = r
+}

--- a/unittests/Sema/ConstraintSystemDumpTests.cpp
+++ b/unittests/Sema/ConstraintSystemDumpTests.cpp
@@ -34,7 +34,7 @@ TEST_F(SemaTest, DumpConstraintSystemBasic) {
       TupleType::get({Type(t0), Type(t1)}, Context), emptyLoc));
 
   std::string expectedOutput =
-      R"(Score: <default 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0>
+      R"(Score: <default 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0>
 Type Variables:
   $T0 [can bind to: lvalue] [adjacent to: $T1, $T2] [potential bindings: <none>] @ locator@ []
   $T1 [adjacent to: $T0, $T2] [potential bindings: <none>] @ locator@ []


### PR DESCRIPTION
Swift evolution pitch: https://forums.swift.org/t/pitch-implicit-member-expressions-for-function-typed-parameters/87892

Extend implicit member resolution so that, when the expected type of a leading-dot member expression is a function type '(P...) -> R', member lookup also considers static members of the return type 'R'.

This lets a leading dot name a static member whose unapplied reference is a function producing the contextual type -- most notably an enum case with associated values. Previously '.b' against an expected type of '(Int) -> X' failed because lookup refused to peer through the function type, forcing the author to spell out 'X.b'; '.a' (no payload) already worked, so the abbreviation was available for some cases of an enum and not others.

Implementation:

- Add an experimental feature 'ImplicitMemberOnFunctionType' gating the new behavior.
- An earlier revision introduced a bespoke DeclViaFunctionResult overload-choice kind, which had to be named in ~13 places across the solver, IDE, and diagnostics. Pitch feedback indicated this to be undesirable. Refactored it as below.
- return-type lookup produces an ordinary Decl overload choice based at R's metatype... same identical choice the solver forms for an explicit R.member, exactly as R.member already did
- uses same mechanism as `isFallbackMemberOnUnwrappedBase()` to rank strictly below any member found directly on the expected type and ensure no impact on existing code
- read by `isDeclViaFunctionResult()` via `SK_UnresolvedMemberViaFunctionResult`
- performs well since look-through candidates carry a strictly-worse score, so they land in a lower disjunction partition that `DisjunctionStep::shouldStopAt` properly stops at (so has speed zero impact on existing code; measured solver time on existing code is zero across several adversarial examples)
- companion optimizer change (`determineBestChoicesInContext`) analyzes implicit-member arguments by name during disjunction checking, so an implicit-dot argument to an overloaded call costs the same as an explicit spelling (i.e. no performance degradation from existing explicit syntax for these function types)

As per request for additional cleanup from pitch review:

- applies the same demotion from `DeclVia...` to plan `Decl` to the pre-existing `DeclViaUnwrappedOptional`
- independent of the feature and can be split into its own PR on request
- optional-unwrap now reads as Decl, so it's excluded by predicate rather than by kind

It's since been reworked so the feature adds no new overload-choice kind and no new conversion:
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
