### PR TITLE
[NFC][Concurrency] Add note explaining concurrent iteration behavior for Async{Throwing}Stream

### DIFF
--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -380,6 +380,9 @@ public struct AsyncStream<Element> {
 @available(SwiftStdlib 5.1, *)
 extension AsyncStream: AsyncSequence {
   /// The asynchronous iterator for iterating an asynchronous stream.
+  ///
+  /// This type doesn't conform to `Sendable`. Don't use it from multiple
+  /// concurrent contexts.
   public struct Iterator: AsyncIteratorProtocol {
     let context: _Context
 

--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -29,14 +29,20 @@ import Swift
 /// `finish()` method. This causes the sequence iterator to produce a `nil`,
 /// which terminates the sequence. The continuation conforms to `Sendable`, which permits
 /// calling it from concurrent contexts external to the iteration of the
-/// `AsyncStream`. When you iterate the stream concurrently,
-/// each element you provide to the `yield(_:)` method is delivered to only a single consumer.
+/// `AsyncStream`.
+///
+/// ### Backpressure
 ///
 /// An arbitrary source of elements can produce elements faster than they are
 /// consumed by a caller iterating over them. Because of this, `AsyncStream`
 /// defines a buffering behavior, allowing the stream to buffer a specific
 /// number of oldest or newest elements. By default, the buffer limit is
 /// `Int.max`, which means the value is unbounded.
+///
+/// ### Concurrent Iteration
+///
+/// When you iterate the stream concurrently,
+/// each element you provide to the `yield(_:)` method is delivered to only a single consumer.
 ///
 /// ### Adapting Existing Code to Use Streams
 ///
@@ -374,11 +380,6 @@ public struct AsyncStream<Element> {
 @available(SwiftStdlib 5.1, *)
 extension AsyncStream: AsyncSequence {
   /// The asynchronous iterator for iterating an asynchronous stream.
-  ///
-  /// This type doesn't conform to `Sendable`. Don't use it from multiple
-  /// concurrent contexts. It is a programmer error to invoke `next()` from a
-  /// concurrent context that contends with another such call, which
-  /// results in a call to `fatalError()`.
   public struct Iterator: AsyncIteratorProtocol {
     let context: _Context
 
@@ -386,10 +387,6 @@ extension AsyncStream: AsyncSequence {
     ///
     /// When `next()` returns `nil`, this signifies the end of the
     /// `AsyncStream`.
-    ///
-    /// It is a programmer error to invoke `next()` from a
-    /// concurrent context that contends with another such call, which
-    /// results in a call to `fatalError()`.
     ///
     /// If you cancel the task this iterator is running in while `next()` is
     /// awaiting a value, the `AsyncStream` terminates. In this case, `next()`
@@ -402,10 +399,6 @@ extension AsyncStream: AsyncSequence {
     ///
     /// When `next()` returns `nil`, this signifies the end of the
     /// `AsyncStream`.
-    ///
-    /// It is a programmer error to invoke `next()` from a concurrent
-    /// context that contends with another such call, which results in a call to
-    /// `fatalError()`.
     ///
     /// If you cancel the task this iterator is running in while `next()`
     /// is awaiting a value, the `AsyncStream` terminates. In this case,

--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -29,7 +29,8 @@ import Swift
 /// `finish()` method. This causes the sequence iterator to produce a `nil`,
 /// which terminates the sequence. The continuation conforms to `Sendable`, which permits
 /// calling it from concurrent contexts external to the iteration of the
-/// `AsyncStream`.
+/// `AsyncStream`. When you iterate the stream concurrently,
+/// each element you provide to the `yield(_:)` method is delivered to only a single consumer.
 ///
 /// An arbitrary source of elements can produce elements faster than they are
 /// consumed by a caller iterating over them. Because of this, `AsyncStream`

--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2020-2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -41,8 +41,8 @@ import Swift
 ///
 /// ### Concurrent Iteration
 ///
-/// When you iterate the stream concurrently,
-/// each element you provide to the `yield(_:)` method is delivered to only a single consumer.
+/// When you iterate the stream concurrently, each element you yield
+/// to the stream is delivered to only a single iterator once.
 ///
 /// ### Adapting Existing Code to Use Streams
 ///
@@ -400,12 +400,12 @@ extension AsyncStream: AsyncSequence {
 
     /// The next value from the asynchronous stream.
     ///
-    /// When `next()` returns `nil`, this signifies the end of the
+    /// When `next(isolation:)` returns `nil`, this signifies the end of the
     /// `AsyncStream`.
     ///
-    /// If you cancel the task this iterator is running in while `next()`
+    /// If you cancel the task this iterator is running in while `next(isolation:)`
     /// is awaiting a value, the `AsyncStream` terminates. In this case,
-    /// `next()` might return `nil` immediately, or return `nil` on
+    /// `next(isolation:)` might return `nil` immediately, or return `nil` on
     /// subsequent calls.
     @available(SwiftStdlib 6.0, *)
     public mutating func next(isolation actor: isolated (any Actor)?) async -> Element? {

--- a/stdlib/public/Concurrency/AsyncThrowingStream.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingStream.swift
@@ -34,7 +34,8 @@ import Swift
 /// `finish(throwing:)` method, which causes the iterator's `next()` method to
 /// throw the error to the awaiting call point. The continuation is `Sendable`,
 /// which permits calling it from concurrent contexts external to the iteration
-/// of the `AsyncThrowingStream`.
+/// of the `AsyncThrowingStream`. When you iterate the stream concurrently,
+/// each element you provide to the `yield(_:)` method is delivered to only a single consumer.
 ///
 /// An arbitrary source of elements can produce elements faster than they are
 /// consumed by a caller iterating over them. Because of this, `AsyncThrowingStream`

--- a/stdlib/public/Concurrency/AsyncThrowingStream.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingStream.swift
@@ -417,6 +417,9 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
 @available(SwiftStdlib 5.1, *)
 extension AsyncThrowingStream: AsyncSequence {
   /// The asynchronous iterator for iterating an asynchronous stream.
+  ///
+  /// This type doesn't conform to `Sendable`. Don't use it from multiple
+  /// concurrent contexts.
   public struct Iterator: AsyncIteratorProtocol {
     let context: _Context
 

--- a/stdlib/public/Concurrency/AsyncThrowingStream.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingStream.swift
@@ -34,14 +34,20 @@ import Swift
 /// `finish(throwing:)` method, which causes the iterator's `next()` method to
 /// throw the error to the awaiting call point. The continuation is `Sendable`,
 /// which permits calling it from concurrent contexts external to the iteration
-/// of the `AsyncThrowingStream`. When you iterate the stream concurrently,
-/// each element you provide to the `yield(_:)` method is delivered to only a single consumer.
+/// of the `AsyncThrowingStream`.
+///
+/// ### Backpressure
 ///
 /// An arbitrary source of elements can produce elements faster than they are
 /// consumed by a caller iterating over them. Because of this, `AsyncThrowingStream`
 /// defines a buffering behavior, allowing the stream to buffer a specific
 /// number of oldest or newest elements. By default, the buffer limit is
 /// `Int.max`, which means it's unbounded.
+///
+/// ### Concurrent Iteration
+///
+/// When you iterate the stream concurrently, each element you provide
+/// to the `yield(_:)` method is delivered to only a single consumer.
 ///
 /// ### Adapting Existing Code to Use Streams
 ///
@@ -298,21 +304,23 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
   ///   `AsyncThrowingStream.Continuation` instance that it uses to provide
   ///   elements to the stream and terminate the stream when finished.
   ///
-  /// The `AsyncStream.Continuation` received by the `build` closure is
+  /// The `AsyncThrowingStream.Continuation` received by the `build` closure is
   /// appropriate for use in concurrent contexts. It is thread safe to send and
   /// finish; all calls to the continuation are serialized. However, calling
   /// this from multiple concurrent contexts could result in out-of-order
   /// delivery.
   ///
-  /// The following example shows an `AsyncStream` created with this
+  /// The following example shows an `AsyncThrowingStream` created with this
   /// initializer that produces 100 random numbers on a one-second interval,
   /// calling `yield(_:)` to deliver each element to the awaiting call point.
   /// When the `for` loop exits, the stream finishes by calling the
-  /// continuation's `finish()` method. If the random number is divisible by 5
+  /// continuation's `finish(throwing:)` method. If the random number is divisible by 5
   /// with no remainder, the stream throws a `MyRandomNumberError`.
   ///
-  ///     let stream = AsyncThrowingStream<Int, Error>(Int.self,
-  ///                                                  bufferingPolicy: .bufferingNewest(5)) { continuation in
+  ///     let stream = AsyncThrowingStream<Int, Error>(
+  ///         Int.self,
+  ///         bufferingPolicy: .bufferingNewest(5)
+  ///     ) { continuation in
   ///         Task.detached {
   ///             for _ in 0..<100 {
   ///                 await Task.sleep(1 * 1_000_000_000)
@@ -409,11 +417,6 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
 @available(SwiftStdlib 5.1, *)
 extension AsyncThrowingStream: AsyncSequence {
   /// The asynchronous iterator for iterating an asynchronous stream.
-  ///
-  /// This type is not `Sendable`. Don't use it from multiple
-  /// concurrent contexts. It is a programmer error to invoke `next()` from a
-  /// concurrent context that contends with another such call, which
-  /// results in a call to `fatalError()`.
   public struct Iterator: AsyncIteratorProtocol {
     let context: _Context
 
@@ -421,10 +424,6 @@ extension AsyncThrowingStream: AsyncSequence {
     ///
     /// When `next()` returns `nil`, this signifies the end of the
     /// `AsyncThrowingStream`.
-    ///
-    /// It is a programmer error to invoke `next()` from a concurrent context
-    /// that contends with another such call, which results in a call to
-    ///  `fatalError()`.
     ///
     /// If you cancel the task this iterator is running in while `next()` is
     /// awaiting a value, the `AsyncThrowingStream` terminates. In this case,
@@ -438,10 +437,6 @@ extension AsyncThrowingStream: AsyncSequence {
     ///
     /// When `next()` returns `nil`, this signifies the end of the
     /// `AsyncThrowingStream`.
-    ///
-    /// It is a programmer error to invoke `next()` from a concurrent
-    /// context that contends with another such call, which results in a call to
-    /// `fatalError()`.
     ///
     /// If you cancel the task this iterator is running in while `next()`
     /// is awaiting a value, the `AsyncThrowingStream` terminates. In this case,

--- a/stdlib/public/Concurrency/AsyncThrowingStream.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingStream.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2020-2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -46,8 +46,8 @@ import Swift
 ///
 /// ### Concurrent Iteration
 ///
-/// When you iterate the stream concurrently, each element you provide
-/// to the `yield(_:)` method is delivered to only a single consumer.
+/// When you iterate the stream concurrently, each element you yield
+/// to the stream is delivered to only a single iterator once.
 ///
 /// ### Adapting Existing Code to Use Streams
 ///
@@ -438,12 +438,12 @@ extension AsyncThrowingStream: AsyncSequence {
 
     /// The next value from the asynchronous stream.
     ///
-    /// When `next()` returns `nil`, this signifies the end of the
+    /// When `next(isolation:)` returns `nil`, this signifies the end of the
     /// `AsyncThrowingStream`.
     ///
-    /// If you cancel the task this iterator is running in while `next()`
+    /// If you cancel the task this iterator is running in while `next(isolation:)`
     /// is awaiting a value, the `AsyncThrowingStream` terminates. In this case,
-    /// `next()` may return `nil` immediately, or else return `nil` on
+    /// `next(isolation:)` may return `nil` immediately, or else return `nil` on
     /// subsequent calls.
     @available(SwiftStdlib 6.0, *)
     public mutating func next(isolation actor: isolated (any Actor)?) async throws(Failure) -> Element? {


### PR DESCRIPTION
We could further explain that the receiving consumer is neither always the same one nor random, but rather follows a FIFO policy. Then again, there is still a race among the consumers to the `next` method, so it isn't fully predictable either. This also doesn't apply to the unfolding variant.

I also thought about creating a separate "Concurrent Iteration" section, but I think we should save that idea for a larger rewrite of the documentation later on.

This PR, together with #88017, resolves #76547.