### PR TITLE
[6.4] [DebugInfo] Relax lifetime checking of debug values

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
@@ -416,7 +416,7 @@ extension OwnershipUseVisitor {
       }
       return pointerEscapingUse(of: operand)
 
-    case .instantaneousUse, .forwardingUnowned, .unownedInstantaneousUse, .bitwiseEscape:
+    case .instantaneousUse, .forwardingUnowned, .unownedInstantaneousUse, .debugUse, .bitwiseEscape:
       return ownershipLeafUse(of: operand, isInnerLifetime: false)
 
     case .borrow:
@@ -448,7 +448,7 @@ extension OwnershipUseVisitor {
       }
       return pointerEscapingUse(of: operand)
 
-    case .instantaneousUse, .forwardingUnowned, .unownedInstantaneousUse, .bitwiseEscape, .endBorrow, .reborrow:
+    case .instantaneousUse, .forwardingUnowned, .unownedInstantaneousUse, .debugUse, .bitwiseEscape, .endBorrow, .reborrow:
       return ownershipLeafUse(of: operand, isInnerLifetime: false)
 
     case .guaranteedForwarding:

--- a/SwiftCompilerSources/Sources/SIL/Operand.swift
+++ b/SwiftCompilerSources/Sources/SIL/Operand.swift
@@ -263,7 +263,10 @@ public enum OperandOwnership {
   
   /// Use a value without requiring or propagating ownership. The operation may not have side-effects that could affect ownership. This is limited to a small number of operations that are allowed to take Unowned values. (copy_value, single-instruction apply with @unowned argument))
   case unownedInstantaneousUse
-  
+
+  /// A debug_value use. Behaves like unownedInstantaneousUse, but the value isn't required to be alive.
+  case debugUse
+
   /// Forwarding instruction with an Unowned result. Its operands may have any ownership.
   case forwardingUnowned
   
@@ -304,7 +307,7 @@ public enum OperandOwnership {
   public var endsLifetime: Bool {
     switch self {
     case .nonUse, .trivialUse, .instantaneousUse, .unownedInstantaneousUse,
-         .forwardingUnowned, .pointerEscape, .bitwiseEscape, .borrow,
+         .debugUse, .forwardingUnowned, .pointerEscape, .bitwiseEscape, .borrow,
          .interiorPointer, .anyInteriorPointer, .guaranteedForwarding:
       return false
     case .destroyingConsume, .forwardingConsume, .endBorrow, .reborrow:
@@ -322,6 +325,8 @@ public enum OperandOwnership {
       return BridgedOperand.OperandOwnership.InstantaneousUse
     case .unownedInstantaneousUse:
       return BridgedOperand.OperandOwnership.UnownedInstantaneousUse
+    case .debugUse:
+      return BridgedOperand.OperandOwnership.DebugUse
     case .forwardingUnowned:
       return BridgedOperand.OperandOwnership.ForwardingUnowned
     case .pointerEscape:
@@ -355,6 +360,7 @@ extension Operand {
     case .TrivialUse: return .trivialUse
     case .InstantaneousUse: return .instantaneousUse
     case .UnownedInstantaneousUse: return .unownedInstantaneousUse
+    case .DebugUse: return .debugUse
     case .ForwardingUnowned: return .forwardingUnowned
     case .PointerEscape: return .pointerEscape
     case .BitwiseEscape: return .bitwiseEscape

--- a/include/swift/SIL/OwnershipUseVisitor.h
+++ b/include/swift/SIL/OwnershipUseVisitor.h
@@ -381,6 +381,7 @@ bool OwnershipUseVisitor<Impl>::visitOwnedUse(Operand *use) {
   case OperandOwnership::InstantaneousUse:
   case OperandOwnership::ForwardingUnowned:
   case OperandOwnership::UnownedInstantaneousUse:
+  case OperandOwnership::DebugUse:
   case OperandOwnership::BitwiseEscape:
     return handleUsePoint(use, UseLifetimeConstraint::NonLifetimeEnding);
 
@@ -416,6 +417,7 @@ bool OwnershipUseVisitor<Impl>::visitGuaranteedUse(Operand *use) {
   case OperandOwnership::InstantaneousUse:
   case OperandOwnership::ForwardingUnowned:
   case OperandOwnership::UnownedInstantaneousUse:
+  case OperandOwnership::DebugUse:
   case OperandOwnership::BitwiseEscape:
     return handleUsePoint(use, UseLifetimeConstraint::NonLifetimeEnding);
   case OperandOwnership::EndBorrow:

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -399,6 +399,7 @@ struct BridgedOperand {
     TrivialUse,
     InstantaneousUse,
     UnownedInstantaneousUse,
+    DebugUse,
     ForwardingUnowned,
     PointerEscape,
     BitwiseEscape,

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -628,6 +628,8 @@ BridgedOperand::OperandOwnership BridgedOperand::getOperandOwnership() const {
     return OperandOwnership::InstantaneousUse;
   case swift::OperandOwnership::UnownedInstantaneousUse:
     return OperandOwnership::UnownedInstantaneousUse;
+  case swift::OperandOwnership::DebugUse:
+    return OperandOwnership::DebugUse;
   case swift::OperandOwnership::ForwardingUnowned:
     return OperandOwnership::ForwardingUnowned;
   case swift::OperandOwnership::PointerEscape:

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -837,6 +837,11 @@ struct OperandOwnership {
     /// (copy_value, single-instruction apply with @unowned argument))
     UnownedInstantaneousUse,
 
+    /// A debug_value use. Semantically equivalent to UnownedInstantaneousUse
+    /// but the value is not required to be alive. The OwnershipModelEliminator
+    /// automatically removes such invalid debug uses.
+    DebugUse,
+
     /// Forwarding instruction with an Unowned result. Its operands may have any
     /// ownership.
     ForwardingUnowned,
@@ -968,6 +973,7 @@ inline OwnershipConstraint OperandOwnership::getOwnershipConstraint() {
   case OperandOwnership::NonUse:
   case OperandOwnership::InstantaneousUse:
   case OperandOwnership::UnownedInstantaneousUse:
+  case OperandOwnership::DebugUse:
   case OperandOwnership::ForwardingUnowned:
   case OperandOwnership::PointerEscape:
   case OperandOwnership::BitwiseEscape:
@@ -998,6 +1004,7 @@ inline bool canAcceptUnownedValue(OperandOwnership operandOwnership) {
   switch (operandOwnership) {
   case OperandOwnership::NonUse:
   case OperandOwnership::UnownedInstantaneousUse:
+  case OperandOwnership::DebugUse:
   case OperandOwnership::ForwardingUnowned:
   case OperandOwnership::PointerEscape:
   case OperandOwnership::BitwiseEscape:

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -240,8 +240,12 @@ OPERAND_OWNERSHIP(InstantaneousUse, MergeIsolationRegion)
   OPERAND_OWNERSHIP(InstantaneousUse, StrongCopy##Name##Value)
 #include "swift/AST/ReferenceStorage.def"
 
+// A debug_value use does not require liveness for ownership verification.
+// Uses can appear out of lifetime after instruction salvaging in optimizations.
+// OwnershipModelEliminator will kill debug uses after a destroy_value.
+OPERAND_OWNERSHIP(DebugUse, DebugValue)
+
 // Unowned uses ignore the value's ownership
-OPERAND_OWNERSHIP(UnownedInstantaneousUse, DebugValue)
 OPERAND_OWNERSHIP(UnownedInstantaneousUse, CopyBlock)
 OPERAND_OWNERSHIP(UnownedInstantaneousUse, CopyValue)
 OPERAND_OWNERSHIP(UnownedInstantaneousUse, ExplicitCopyValue)

--- a/lib/SIL/IR/SILValue.cpp
+++ b/lib/SIL/IR/SILValue.cpp
@@ -563,6 +563,8 @@ StringRef OperandOwnership::asString() const {
     return "instantaneous";
   case OperandOwnership::UnownedInstantaneousUse:
     return "unowned-instantaneous";
+  case OperandOwnership::DebugUse:
+    return "debug-use";
   case OperandOwnership::ForwardingUnowned:
     return "forwarding-unowned";
   case OperandOwnership::PointerEscape:

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -237,6 +237,7 @@ bool swift::findInnerTransitiveGuaranteedUses(
 
     case OperandOwnership::InstantaneousUse:
     case OperandOwnership::UnownedInstantaneousUse:
+    case OperandOwnership::DebugUse:
     case OperandOwnership::BitwiseEscape:
     // Reborrow only happens when this is called on a value that creates a
     // borrow scope.
@@ -377,6 +378,7 @@ bool swift::findExtendedUsesOfSimpleBorrowedValue(
 
     case OperandOwnership::InstantaneousUse:
     case OperandOwnership::UnownedInstantaneousUse:
+    case OperandOwnership::DebugUse:
     case OperandOwnership::BitwiseEscape:
     // EndBorrow either happens when this is called on a value that creates a
     // borrow scope, or when it is pushed as a use when processing a nested

--- a/lib/SIL/Verifier/SILOwnershipVerifier.cpp
+++ b/lib/SIL/Verifier/SILOwnershipVerifier.cpp
@@ -237,7 +237,8 @@ bool SILValueOwnershipChecker::gatherNonGuaranteedUsers(
 
     // For example, type dependent operands are non-use. It is not interesting
     // from an ownership perspective.
-    if (op->getOperandOwnership() == OperandOwnership::NonUse)
+    if (op->getOperandOwnership() == OperandOwnership::NonUse ||
+        op->getOperandOwnership() == OperandOwnership::DebugUse)
       continue;
 
     // First check if this recursive use is compatible with our values ownership
@@ -351,9 +352,10 @@ bool SILValueOwnershipChecker::gatherUsers(
       return false;
     }
 
-    // If this op is a type dependent operand, skip it. It is not interesting
+    // For example, type dependent operands are non-use. It is not interesting
     // from an ownership perspective.
-    if (user->isTypeDependentOperand(*op))
+    if (op->getOperandOwnership() == OperandOwnership::NonUse ||
+        op->getOperandOwnership() == OperandOwnership::DebugUse)
       continue;
 
     // First check if this recursive use is compatible with our values

--- a/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
@@ -120,6 +120,7 @@ bool CheckerLivenessInfo::compute() {
         break;
       case OperandOwnership::InstantaneousUse:
       case OperandOwnership::UnownedInstantaneousUse:
+      case OperandOwnership::DebugUse:
       case OperandOwnership::BitwiseEscape:
         liveness->updateForUse(user, /*lifetimeEnding*/ false);
         break;

--- a/lib/SILOptimizer/Mandatory/DiagnoseLifetimeIssues.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseLifetimeIssues.cpp
@@ -215,6 +215,7 @@ visitUses(SILValue def, bool updateLivenessAndWeakStores, int callDepth) {
         return CanEscape;
       case OperandOwnership::InstantaneousUse:
       case OperandOwnership::UnownedInstantaneousUse:
+      case OperandOwnership::DebugUse:
       case OperandOwnership::BitwiseEscape:
         if (updateLivenessAndWeakStores)
           liveness->updateForUse(user, /*lifetimeEnding*/ false);

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -1714,6 +1714,7 @@ struct CopiedLoadBorrowEliminationVisitor
       auto *nextUse = useWorklist.pop_back_val();
       switch (nextUse->getOperandOwnership()) {
       case OperandOwnership::NonUse:
+      case OperandOwnership::DebugUse:
       case OperandOwnership::ForwardingUnowned:
       case OperandOwnership::PointerEscape:
         continue;

--- a/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureUtils.cpp
@@ -297,6 +297,7 @@ bool Implementation::gatherUses(SILValue value) {
     case OperandOwnership::TrivialUse:
     case OperandOwnership::InstantaneousUse:
     case OperandOwnership::UnownedInstantaneousUse:
+    case OperandOwnership::DebugUse:
     case OperandOwnership::InteriorPointer:
     case OperandOwnership::AnyInteriorPointer:
     case OperandOwnership::BitwiseEscape: {
@@ -1575,6 +1576,7 @@ static bool gatherBorrows(SILValue rootValue,
 
     case OperandOwnership::InstantaneousUse:
     case OperandOwnership::UnownedInstantaneousUse:
+    case OperandOwnership::DebugUse:
     case OperandOwnership::BitwiseEscape:
       // We don't care about these types of uses.
       continue;

--- a/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerUtils.cpp
@@ -232,6 +232,7 @@ bool MoveOnlyObjectCheckerPImpl::checkForSameInstMultipleUseErrors(
     case OperandOwnership::TrivialUse:
     case OperandOwnership::InstantaneousUse:
     case OperandOwnership::UnownedInstantaneousUse:
+    case OperandOwnership::DebugUse:
       // Look through copy_value.
       if (auto *cvi = dyn_cast<CopyValueInst>(nextUse->getUser())) {
         for (auto *use : cvi->getUses())

--- a/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
@@ -67,10 +67,29 @@ struct OwnershipModelEliminatorVisitor
   /// builderCtxStorage.
   SILBuilderContext builderCtx;
 
+  /// A possibly null, possibly owned, possibly unowned pointer.
+  /// Owned if the boolean is true.
+  llvm::PointerIntPair<DominanceInfo *, 1, bool> domTree;
+
+  DominanceInfo *getDomTree(SILFunction *fn) {
+    if (!domTree.getPointer())
+      domTree = {new DominanceInfo(fn), true};
+    return domTree.getPointer();
+  }
+
+  ~OwnershipModelEliminatorVisitor() {
+    if (domTree.getInt())
+      delete domTree.getPointer();
+  }
+
   /// Construct an OME visitor for eliminating ownership from \p fn.
-  OwnershipModelEliminatorVisitor(SILFunction &fn)
+  OwnershipModelEliminatorVisitor(SILFunction &fn,
+                                  DominanceAnalysis *da = nullptr)
       : trackingList(), instructionsToSimplify(),
         builderCtx(fn.getModule(), &trackingList) {
+    if (da)
+      if (auto *cached = da->maybeGet(&fn).getPtrOrNull())
+        domTree = {cached, false};
   }
 
   /// A "syntactic" high level function that combines our insertPt with a
@@ -645,6 +664,13 @@ bool OwnershipModelEliminatorVisitor::visitDestroyValueInst(
   withBuilder<void>(dvi, [&](SILBuilder &b, SILLocation loc) {
     b.emitDestroyValueOperation(loc, operand);
   });
+  // Kill debug_values that appear after the destroy: this instruction might
+  // free stored pointers, so later debug uses are wrong.
+  for (auto *use : getDebugUses(operand)) {
+    auto *dbgInst = cast<DebugValueInst>(use->getUser());
+    if (getDomTree(dvi->getFunction())->dominates(dvi, dbgInst))
+      dbgInst->setOperand(SILUndef::get(dbgInst->getOperand()));
+  }
   if (dvi->poisonRefs()) {
     injectDebugPoison(dvi);
   }
@@ -796,7 +822,8 @@ bool OwnershipModelEliminatorVisitor::visitDestructureTupleInst(
 //                           Top Level Entry Point
 //===----------------------------------------------------------------------===//
 
-static bool stripOwnership(SILFunction &func) {
+static bool stripOwnership(SILFunction &func,
+                           DominanceAnalysis *domAnalysis = nullptr) {
   // If F is an external declaration, do not process it.
   if (func.isExternalDeclaration())
     return false;
@@ -838,7 +865,7 @@ static bool stripOwnership(SILFunction &func) {
 
   bool madeChange = false;
   SmallVector<SILInstruction *, 32> createdInsts;
-  OwnershipModelEliminatorVisitor visitor(func);
+  OwnershipModelEliminatorVisitor visitor(func, domAnalysis);
 
   for (auto &block : func) {
     // Change all arguments to have OwnershipKind::None.
@@ -939,7 +966,7 @@ struct OwnershipModelEliminator : SILModuleTransform {
         getPassManager()->runSwiftFunctionVerification(&f);
       }
 
-      if (stripOwnership(f)) {
+      if (stripOwnership(f, getAnalysis<DominanceAnalysis>())) {
         auto InvalidKind = SILAnalysis::InvalidationKind::BranchesAndInstructions;
         invalidateAnalysis(&f, InvalidKind);
       }

--- a/lib/SILOptimizer/Utils/OSSACanonicalizeGuaranteed.cpp
+++ b/lib/SILOptimizer/Utils/OSSACanonicalizeGuaranteed.cpp
@@ -301,6 +301,7 @@ bool OSSACanonicalizeGuaranteed::visitBorrowScopeUses(SILValue innerValue,
       case OperandOwnership::Borrow:
       case OperandOwnership::InstantaneousUse:
       case OperandOwnership::UnownedInstantaneousUse:
+      case OperandOwnership::DebugUse:
       case OperandOwnership::BitwiseEscape:
       case OperandOwnership::DestroyingConsume:
         if (!visitor.visitUse(use)) {

--- a/lib/SILOptimizer/Utils/OSSACanonicalizeOwned.cpp
+++ b/lib/SILOptimizer/Utils/OSSACanonicalizeOwned.cpp
@@ -219,6 +219,7 @@ bool OSSACanonicalizeOwned::computeCanonicalLiveness() {
         return false;
       case OperandOwnership::InstantaneousUse:
       case OperandOwnership::UnownedInstantaneousUse:
+      case OperandOwnership::DebugUse:
         liveness->updateForUse(user, /*lifetimeEnding*/ false);
         break;
       case OperandOwnership::ForwardingConsume:

--- a/test/DebugInfo/salvage_struct_extract_lifetime.sil
+++ b/test/DebugInfo/salvage_struct_extract_lifetime.sil
@@ -1,0 +1,43 @@
+// RUN: %target-sil-opt -sil-print-types %s -ownership-model-eliminator | %FileCheck %s
+
+// Test that OwnershipModelEliminator kills debug_values that appear after
+// a destroy_value, since the object may be freed by the release.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+struct Job: ~Copyable {
+  var context: Builtin.Int64
+}
+
+// CHECK-LABEL: sil @test_destroy_kills_debug_value
+// CHECK:       bb0(%0 : $Job):
+// CHECK:         debug_value %0 : $Job, let, name "before_destroy", {{.*}}transform {
+// CHECK:           bb0(%0 : $Job):
+// CHECK:             %1 = struct_extract %0 : $Job, #Job.context
+// CHECK:             return %1 : $Builtin.Int64
+// CHECK:         }
+// CHECK:         release_value %0
+// CHECK:         debug_value undef : $Job, let, name "after_destroy", {{.*}}transform
+// CHECK-LABEL: } // end sil function 'test_destroy_kills_debug_value'
+sil [ossa] @test_destroy_kills_debug_value : $@convention(thin) (@owned Job) -> () {
+bb0(%0 : @owned $Job):
+  %1 = begin_borrow %0
+  %2 = struct_extract %1, #Job.context
+  end_borrow %1
+  debug_value %0 : $Job, let, name "before_destroy", transform {
+  bb0(%a : $Job):
+    %b = struct_extract %a, #Job.context
+    return %b : $Builtin.Int64
+  }
+  destroy_value %0
+  debug_value %0 : $Job, let, name "after_destroy", transform {
+  bb0(%c : $Job):
+    %d = struct_extract %c, #Job.context
+    return %d : $Builtin.Int64
+  }
+  %ret = tuple ()
+  return %ret : $()
+}


### PR DESCRIPTION
- **Explanation**: Changes the ownership semantics of debug_values to allow out-of-lifetime debug uses. OwnershipModelEliminator then kills debug values that are after a destroy_value.
- **Scope**: Fixes a crash if a debug_value is created outside of the lifetime of a value, by replacing those with an undef operand.
- **Issues**: #89639 
- **Original PRs**: First commit of #89692
- **Risk**: Low, only touches debug_values
- **Testing**: None
- **Reviewers**: @adrian-prantl 