### PR TITLE
Runtimes: introduce the new COM supplemental module

### DIFF
--- a/Runtimes/Supplemental/CMakeLists.txt
+++ b/Runtimes/Supplemental/CMakeLists.txt
@@ -85,6 +85,18 @@ if(SwiftRuntime_ENABLE_distributed)
       ${COMMON_OPTIONS})
 endif()
 
+# COM
+if(SwiftRuntime_ENABLE_com)
+  ExternalProject_Add(COM
+    PREFIX "COM"
+    SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/COM"
+    INSTALL_DIR "${CMAKE_INSTALL_PREFIX}"
+    INSTALL_COMMAND ""
+    # To ensure incremental builds work as expected
+    BUILD_ALWAYS 1
+    CMAKE_ARGS
+      ${COMMON_OPTIONS})
+endif()
 
 # Differentiation
 if(SwiftRuntime_ENABLE_differentiation)

--- a/Runtimes/Supplemental/COM/CMakeLists.txt
+++ b/Runtimes/Supplemental/COM/CMakeLists.txt
@@ -1,0 +1,96 @@
+cmake_minimum_required(VERSION 3.29)
+# TODO before requiring CMake 4.1 or later
+# and/or enforcing CMP0195, please check/update
+# the implementation  of `emit_swift_interface`
+# in `EmitSwiftInterface.cmake`
+# to ensure it keeps laying down nested swiftmodule folders
+
+list(APPEND CMAKE_MODULE_PATH
+  "${CMAKE_SOURCE_DIR}/../cmake/modules"
+  "${CMAKE_SOURCE_DIR}/../../cmake/modules")
+
+include(SwiftProjectVersion)
+project(SwiftCOM
+  LANGUAGES Swift
+  VERSION ${SWIFT_RUNTIME_VERSION})
+
+# This also enables Windows resource compilation used by embed_manifest().
+# GNUInstallDirs additionally requires a non-Swift language.
+enable_language(C)
+
+# FIXME(compnerd) add a compatibility shim for WASI on older CMake releases.
+if(CMAKE_VERSION VERSION_LESS 3.31)
+  if(CMAKE_SYSTEM_NAME STREQUAL "Generic" AND CMAKE_SYSTEM_PROCESSOR MATCHES "wasm32")
+    set(CMAKE_SYSTEM_NAME WASI)
+    set(WASI 1)
+  endif()
+endif()
+
+if(NOT PROJECT_IS_TOP_LEVEL)
+  message(SEND_ERROR "Swift COM must build as a standalone project")
+endif()
+
+set(CMAKE_POSITION_INDEPENDENT_CODE YES)
+set(CMAKE_Swift_LANGUAGE_VERSION 5)
+
+set(${PROJECT_NAME}_SWIFTC_SOURCE_DIR
+  "${PROJECT_SOURCE_DIR}/../../../"
+  CACHE FILEPATH "Path to the root source directory of the Swift compiler")
+
+# Hook point for vendor-specific extensions to the build system
+# Allowed extension points:
+#   - DefaultSettings.cmake
+#   - Settings.cmake
+set(${PROJECT_NAME}_VENDOR_MODULE_DIR "${CMAKE_SOURCE_DIR}/../cmake/modules/vendor"
+  CACHE FILEPATH "Location for private build system extension")
+
+find_package(SwiftCore REQUIRED)
+find_package(SwiftOverlay)
+find_package(SwiftSynchronization REQUIRED)
+
+include(GNUInstallDirs)
+
+include(AvailabilityMacros)
+include(EmitSwiftInterface)
+include(InstallSwiftInterface)
+include(PlatformInfo)
+include(ResourceEmbedding)
+
+option(${PROJECT_NAME}_INSTALL_NESTED_SUBDIR "Install libraries under a platform and architecture subdirectory" ON)
+set(${PROJECT_NAME}_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>$<$<BOOL:${${PROJECT_NAME}_INSTALL_NESTED_SUBDIR}>:/${${PROJECT_NAME}_PLATFORM_SUBDIR}/${${PROJECT_NAME}_ARCH_SUBDIR}>" CACHE STRING "")
+set(${PROJECT_NAME}_INSTALL_SWIFTMODULEDIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>$<$<BOOL:${${PROJECT_NAME}_INSTALL_NESTED_SUBDIR}>:/${${PROJECT_NAME}_PLATFORM_SUBDIR}>" CACHE STRING "")
+
+include("${${PROJECT_NAME}_VENDOR_MODULE_DIR}/Settings.cmake" OPTIONAL)
+
+option(${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION "Generate ABI resilient runtime libraries"
+  ${SwiftCore_ENABLE_LIBRARY_EVOLUTION})
+
+add_compile_options(
+  $<$<COMPILE_LANGUAGE:Swift>:SHELL:-explicit-module-build>
+  $<$<COMPILE_LANGUAGE:Swift>:-nostdlibimport>
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-package-name COM>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature MemberImportVisibility>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature Extern>"
+  $<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION}>,$<COMPILE_LANGUAGE:Swift>>:-enable-library-evolution>
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-concurrency-module-import>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-string-processing-module-import>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -enable-experimental-com-interop>")
+
+find_package(SwiftSwiftDirectRuntime)
+
+# LNK4049: symbol 'symbol' defined in 'filename.obj' is imported
+# LNK4286: symbol 'symbol' defined in 'filename_1.obj' is imported by 'filename_2.obj'
+# LNK4217: symbol 'symbol' defined in 'filename_1.obj' is imported by 'filename_2.obj' in function 'function'
+#
+# We cannot selectively filter the linker warnings as we do not use the MSVC
+# frontned and `clang-cl` (and `clang`) currently do not support `/WX:nnnn`. As
+# a compromise, treat all linker warnings as errors.
+# FIXME(#83444) - enable this once we fix DLL storage for
+# `_fatalErrorForwardModeDifferentiationDisabled`
+# add_link_options($<$<PLATFORM_ID:Windows>:LINKER:/WX>)
+# Ensure all symbols are fully resolved on Linux
+add_link_options($<$<PLATFORM_ID:Android,Linux>:LINKER:-z,defs>)
+
+add_subdirectory(Sources)
+
+include("${${PROJECT_NAME}_VENDOR_MODULE_DIR}/swiftCOM.cmake" OPTIONAL)

--- a/Runtimes/Supplemental/COM/CMakeLists.txt
+++ b/Runtimes/Supplemental/COM/CMakeLists.txt
@@ -1,0 +1,89 @@
+cmake_minimum_required(VERSION 3.29)
+# TODO before requiring CMake 4.1 or later
+# and/or enforcing CMP0195, please check/update
+# the implementation  of `emit_swift_interface`
+# in `EmitSwiftInterface.cmake`
+# to ensure it keeps laying down nested swiftmodule folders
+
+list(APPEND CMAKE_MODULE_PATH
+  "${CMAKE_SOURCE_DIR}/../cmake/modules"
+  "${CMAKE_SOURCE_DIR}/../../cmake/modules")
+
+include(SwiftProjectVersion)
+project(SwiftCOM
+  LANGUAGES Swift
+  VERSION ${SWIFT_RUNTIME_VERSION})
+
+# FIXME(compnerd) add a compatibility shim for WASI on older CMake releases.
+if(CMAKE_VERSION VERSION_LESS 3.31)
+  if(CMAKE_SYSTEM_NAME STREQUAL "Generic" AND CMAKE_SYSTEM_PROCESSOR MATCHES "wasm32")
+    set(CMAKE_SYSTEM_NAME WASI)
+    set(WASI 1)
+  endif()
+endif()
+
+if(NOT PROJECT_IS_TOP_LEVEL)
+  message(SEND_ERROR "Swift COM must build as a standalone project")
+endif()
+
+set(CMAKE_POSITION_INDEPENDENT_CODE YES)
+set(CMAKE_Swift_LANGUAGE_VERSION 5)
+
+set(${PROJECT_NAME}_SWIFTC_SOURCE_DIR
+  "${PROJECT_SOURCE_DIR}/../../../"
+  CACHE FILEPATH "Path to the root source directory of the Swift compiler")
+
+# Hook point for vendor-specific extensions to the build system
+# Allowed extension points:
+#   - DefaultSettings.cmake
+#   - Settings.cmake
+set(${PROJECT_NAME}_VENDOR_MODULE_DIR "${CMAKE_SOURCE_DIR}/../cmake/modules/vendor"
+  CACHE FILEPATH "Location for private build system extension")
+
+find_package(SwiftCore REQUIRED)
+find_package(SwiftOverlay)
+find_package(SwiftSynchronization REQUIRED)
+
+include(GNUInstallDirs)
+
+include(AvailabilityMacros)
+include(PlatformInfo)
+include(ResourceEmbedding)
+
+option(${PROJECT_NAME}_INSTALL_NESTED_SUBDIR "Install libraries under a platform and architecture subdirectory" ON)
+set(${PROJECT_NAME}_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>$<$<BOOL:${${PROJECT_NAME}_INSTALL_NESTED_SUBDIR}>:/${${PROJECT_NAME}_PLATFORM_SUBDIR}/${${PROJECT_NAME}_ARCH_SUBDIR}>" CACHE STRING "")
+set(${PROJECT_NAME}_INSTALL_SWIFTMODULEDIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>$<$<BOOL:${${PROJECT_NAME}_INSTALL_NESTED_SUBDIR}>:/${${PROJECT_NAME}_PLATFORM_SUBDIR}>" CACHE STRING "")
+
+include("${${PROJECT_NAME}_VENDOR_MODULE_DIR}/Settings.cmake" OPTIONAL)
+
+option(${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION "Generate ABI resilient runtime libraries"
+  ${SwiftCore_ENABLE_LIBRARY_EVOLUTION})
+
+add_compile_options(
+  $<$<COMPILE_LANGUAGE:Swift>:SHELL:-explicit-module-build>
+  $<$<COMPILE_LANGUAGE:Swift>:-nostdlibimport>
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature MemberImportVisibility>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature Extern>"
+  $<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION}>,$<COMPILE_LANGUAGE:Swift>>:-enable-library-evolution>
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-concurrency-module-import>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-string-processing-module-import>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -enable-experimental-com-interop>")
+
+find_package(SwiftSwiftDirectRuntime)
+
+# LNK4049: symbol 'symbol' defined in 'filename.obj' is imported
+# LNK4286: symbol 'symbol' defined in 'filename_1.obj' is imported by 'filename_2.obj'
+# LNK4217: symbol 'symbol' defined in 'filename_1.obj' is imported by 'filename_2.obj' in function 'function'
+#
+# We cannot selectively filter the linker warnings as we do not use the MSVC
+# frontned and `clang-cl` (and `clang`) currently do not support `/WX:nnnn`. As
+# a compromise, treat all linker warnings as errors.
+# FIXME(#83444) - enable this once we fix DLL storage for
+# `_fatalErrorForwardModeDifferentiationDisabled`
+# add_link_options($<$<PLATFORM_ID:Windows>:LINKER:/WX>)
+# Ensure all symbols are fully resolved on Linux
+add_link_options($<$<PLATFORM_ID:Android,Linux>:LINKER:-z,defs>)
+
+add_subdirectory(Sources)
+
+include("${${PROJECT_NAME}_VENDOR_MODULE_DIR}/swift_COM.cmake" OPTIONAL)

--- a/Runtimes/Supplemental/COM/Sources/CMakeLists.txt
+++ b/Runtimes/Supplemental/COM/Sources/CMakeLists.txt
@@ -1,0 +1,2 @@
+
+add_subdirectory(COM)

--- a/Runtimes/Supplemental/COM/Sources/CMakeLists.txt
+++ b/Runtimes/Supplemental/COM/Sources/CMakeLists.txt
@@ -1,0 +1,6 @@
+
+add_subdirectory(COM)
+add_subdirectory(_COM_Concurrency)
+
+install(FILES "Concurrency.swiftoverlay"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/${${PROJECT_NAME}_PLATFORM_SUBDIR}/COM.swiftcrossimport")

--- a/Runtimes/Supplemental/COM/Sources/COM/CLSID.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/CLSID.swift
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A phantom type tag used to distinguish Class Identifiers (CLSIDs) from other
+/// GUIDs.
+///
+/// `CLSIDTag` serves as a compile-time marker to create a distinct type for
+/// CLSIDs through generic specialization.  It carries no runtime value but
+/// enables the type system to differentiate between CLSIDs and general-purpose
+/// GUIDs.
+public enum CLSIDTag {}
+
+/// A globally unique identifier that specifically represents a COM Class
+/// Identifier (CLSID).
+///
+/// A `CLSID` is a specialized `GUID` that uniquely identifies a COM class or
+/// component. CLSIDs are used for object instantiation, registration, and
+/// runtime identification of concrete COM implementations.
+///
+/// CLSIDs for Swift-specific classes can be derived deterministically using the
+/// Swift UUID namespace (see the file-level documentation in ISwiftObject.swift
+/// for details on GUID generation).
+///
+/// ## Relationship to GUID
+///
+/// `CLSID` is a type-safe wrapper around `GUID` that prevents accidental mixing
+/// of class identifiers with other types of GUIDs at compile time.
+public typealias CLSID = GUID<CLSIDTag>

--- a/Runtimes/Supplemental/COM/Sources/COM/CLSID.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/CLSID.swift
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if $_MicrosoftCOM
+
+/// A phantom type tag used to distinguish Class Identifiers (CLSIDs) from other
+/// GUIDs.
+///
+/// `CLSIDTag` serves as a compile-time marker to create a distinct type for
+/// CLSIDs through generic specialization.  It carries no runtime value but
+/// enables the type system to differentiate between CLSIDs and general-purpose
+/// GUIDs.
+public enum CLSIDTag {}
+
+/// A globally unique identifier that specifically represents a COM Class
+/// Identifier (CLSID).
+///
+/// A `CLSID` is a specialized `GUID` that uniquely identifies a COM class or
+/// component. CLSIDs are used for object instantiation, registration, and
+/// runtime identification of concrete COM implementations.
+///
+/// CLSIDs for Swift-specific classes can be derived deterministically using the
+/// Swift UUID namespace (see the file-level documentation in ISwiftObject.swift
+/// for details on GUID generation).
+///
+/// ## Relationship to GUID
+///
+/// `CLSID` is a type-safe wrapper around `GUID` that prevents accidental mixing
+/// of class identifiers with other types of GUIDs at compile time.
+public typealias CLSID = GUID<CLSIDTag>
+
+#endif // $_MicrosoftCOM

--- a/Runtimes/Supplemental/COM/Sources/COM/CMakeLists.txt
+++ b/Runtimes/Supplemental/COM/Sources/COM/CMakeLists.txt
@@ -1,0 +1,36 @@
+add_library(swift_COM
+  CLSID.swift
+  COMActivationOptions.swift
+  COMAggregate.swift
+  COMContext.swift
+  COMError.swift
+  COMInterface.swift
+  COMInterfaceResolver.swift
+  COMServerInfo.swift
+  GUID.swift
+  HRESULT.swift
+  IErrorInfo.swift
+  IID.swift
+  ISwiftObject.swift
+  IUnknown.swift
+  "IUnknown+Aggregation.swift"
+  SwiftRuntime.swift
+  TearOffInterfaces.swift
+  ThreadingModel.swift
+  UnsafeMutableRawPointer+COM.swift)
+set_target_properties(swift_COM PROPERTIES
+  Swift_MODULE_NAME COM)
+target_link_libraries(swift_COM PRIVATE
+  swiftCore
+  swiftSynchronization
+  $<$<PLATFORM_ID:Windows>:swiftWinSDK>
+  $<$<BOOL:${SwiftSwiftDirectRuntime_FOUND}>:swiftSwiftDirectRuntime>)
+
+install(TARGETS swift_COM
+  EXPORT SwiftSupplementalTargets
+  COMPONENT ${PROJECT_NAME}_runtime
+  ARCHIVE DESTINATION "${${PROJECT_NAME}_INSTALL_LIBDIR}"
+  LIBRARY DESTINATION "${${PROJECT_NAME}_INSTALL_LIBDIR}"
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+
+embed_manifest(swift_COM)

--- a/Runtimes/Supplemental/COM/Sources/COM/CMakeLists.txt
+++ b/Runtimes/Supplemental/COM/Sources/COM/CMakeLists.txt
@@ -1,0 +1,45 @@
+add_library(swiftCOM
+  "Extensions/String+Extensions.swift"
+  CLSID.swift
+  COMActivatable.swift
+  COMActivation.swift
+  COMActivationOptions.swift
+  COMAggregate.swift
+  COMContext.swift
+  COMError.swift
+  COMInterface.swift
+  COMInterfaceResolution.swift
+  COMInterfaceResolver.swift
+  COMServerInfo.swift
+  GUID.swift
+  HRESULT.swift
+  IErrorInfo.swift
+  IID.swift
+  ISwiftObject.swift
+  IUnknown.swift
+  "IUnknown+Aggregation.swift"
+  "IUnknown+Identity.swift"
+  ManagedObject.swift
+  SwiftRuntime.swift
+  TearOffInterfaces.swift
+  ThreadingModel.swift)
+set_target_properties(swiftCOM PROPERTIES
+  Swift_MODULE_NAME COM)
+target_compile_options(swiftCOM PRIVATE
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature BuiltinModule>")
+target_link_libraries(swiftCOM PRIVATE
+  swiftCore
+  swiftSynchronization
+  $<$<PLATFORM_ID:Windows>:swiftWinSDK>
+  $<$<BOOL:${SwiftSwiftDirectRuntime_FOUND}>:swiftSwiftDirectRuntime>)
+
+install(TARGETS swiftCOM
+  EXPORT SwiftSupplementalTargets
+  COMPONENT ${PROJECT_NAME}_runtime
+  ARCHIVE DESTINATION "${${PROJECT_NAME}_INSTALL_LIBDIR}"
+  LIBRARY DESTINATION "${${PROJECT_NAME}_INSTALL_LIBDIR}"
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+emit_swift_interface(swiftCOM)
+install_swift_interface(swiftCOM)
+
+embed_manifest(swiftCOM)

--- a/Runtimes/Supplemental/COM/Sources/COM/COMActivatable.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/COMActivatable.swift
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Identifies a Swift COM class that supports activation.
+///
+/// The metatype of a `@com` class with an activation identity conforms to
+/// `COMActivatable`, allowing activation APIs to obtain the identity used by
+/// the selected COM model.
+///
+/// This conformance is automatic and cannot be written explicitly.
+public protocol COMActivatable {
+#if $_MicrosoftCOM
+  /// The CLSID of this class.
+  var CLSID: CLSID { get }
+#endif // $_MicrosoftCOM
+}

--- a/Runtimes/Supplemental/COM/Sources/COM/COMActivation.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/COMActivation.swift
@@ -1,0 +1,357 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if $_MicrosoftCOM
+
+public import WinSDK
+
+/// # COM Activation
+///
+/// Type-safe activation of COM classes over `CoCreateInstance` and
+/// `CoCreateInstanceEx`. The public surface is shaped so that only valid
+/// activations can be written: every parameter combination COM would reject at
+/// runtime should be unrepresentable.
+///
+/// ## Design
+///
+/// The overloads are derived from the *constraints* of COM activation rather
+/// than from the raw Win32 parameter list. The dangerous forms — aggregation
+/// with an arbitrary interface, activation with zero interfaces, aggregation on
+/// a remote server — are not available. Each public entry point is
+/// a point in the activation space that is always valid. The activation context
+/// and server travel as one ``COMActivationOptions`` value, so inheriting the
+/// ambient configuration requires one lookup and the correct call remains the
+/// shortest one.
+///
+/// ## Axes of activation
+///
+/// - term Class identity: a ``CLSID``, a `WinSDK.GUID`, or an activatable Swift
+///   type conforming to ``COMActivatable``.
+/// - term Arity: one interface, or several requested in a single activation.
+/// - term Server: in-process/local by default, or a specific, possibly remote
+///   host via ``COMServerInfo``.
+/// - term Aggregation: composing the new instance into an outer `IUnknown`.
+///
+/// The class-identity axis is handled by overloading and the server axis by the
+/// activation options; arity and aggregation change the *shape* of the result,
+/// so they select distinct entry points.
+///
+/// ## Entry points
+///
+/// ### One interface — ``CoCreateInstance(_:activation:as:)``
+///
+/// Prefer this whenever you need a single interface. It returns the interface
+/// directly and throws ``COMError`` if activation or the implied
+/// `QueryInterface` fails. Overloaded for ``CLSID``, `GUID`, and
+/// ``COMActivatable`` implementations; the `GUID` form is a transparent bridge
+/// to the `CLSID` form. `activation` defaults from
+/// ``COMActivationOptions/current``, so a bare call inherits one snapshot of
+/// the ambient configuration.
+///
+/// ### Aggregation — ``CoCreateInstance(_:activation:aggregating:)``
+///
+/// Use this when composing the instance into an outer object. It returns
+/// `any IUnknown`, and only `IUnknown`, because `IClassFactory::CreateInstance`
+/// requires the requested IID to be `IID_IUnknown` while aggregating. There is
+/// deliberately no `as:` parameter — requesting any other interface during
+/// aggregation is invalid, so it is made unspellable rather than rejected at
+/// runtime — and no `server:` parameter, because aggregation is in-process only
+/// and cannot be combined with a remote server.
+///
+/// ### Several interfaces — ``CoCreateInstanceEx(_:activation:requesting:_:)``
+///
+/// Use this when you need more than one interface on the instance in a single
+/// activation round-trip — the reason `MULTI_QI` exists, and worth the most
+/// against a remote server. It returns a tuple of optionals: each requested
+/// interface is independently optional because a per-interface `QueryInterface`
+/// may fail with `E_NOINTERFACE` while the activation as a whole succeeds. A
+/// thrown ``COMError`` means the activation call itself failed; a `nil` element
+/// means that one interface was unavailable. The signature takes a mandatory
+/// `first` interface followed by a variadic pack, so a zero-interface request —
+/// which COM rejects with `E_INVALIDARG` — cannot be written.
+///
+/// ## What you cannot spell, and why
+///
+/// - Aggregation with a specific interface: the aggregating overload returns
+///   `any IUnknown` only. `IClassFactory::CreateInstance` mandates
+///   `IID_IUnknown` when aggregating.
+/// - Aggregation with a server: no overload accepts both `aggregating:` and
+///   `server:`. A remote aggregate is meaningless — aggregation is in-process.
+/// - An empty request to ``CoCreateInstanceEx``: `first` is mandatory, so the
+///   `E_INVALIDARG` case is unrepresentable.
+/// - A single interface through ``CoCreateInstanceEx``: not exposed, because it
+///   is identical in effect to ``CoCreateInstance(_:activation:as:)``.
+///   The single-interface `Ex` path exists only as an internal funnel, used
+///   for remote activation.
+///
+/// ## Choosing an entry point
+///
+/// - One interface, local or remote → ``CoCreateInstance(_:activation:as:)``
+/// - Several interfaces at once → ``CoCreateInstanceEx(_:activation:requesting:_:)``
+/// - Aggregating into an outer → ``CoCreateInstance(_:activation:aggregating:)``
+/// - A Swift ``COMActivatable`` type → the `Implementation` overload of either
+///
+/// - SeeAlso: The asynchronous model, documented alongside the `async`
+///   overloads.
+
+/// Every proper activation semantic maps to exactly one public entry point:
+///
+///              Semantic             |               Family               |                 Return                 |
+/// ----------------------------------+------------------------------------+----------------------------------------+
+/// one interface, local or remote    | CoCreateInstance(…, as:)           | Interface                              |
+/// N ≥ 1 interfaces, local or remote | CoCreateInstanceEx(…, requesting:) | (Interface, repeat (each Interfaces)?) |
+/// aggregation (IUnknown, in-proc)   | CoCreateInstance(…, aggregating:)  | any IUnknown                           |
+///
+/// IClassFactory::CreateInstance mandates that `riid` is `IID_IUnknown` when
+/// the interface is aggregated.
+
+
+@usableFromInline
+@_alwaysEmitIntoClient
+package func CoCreateInstance<Interface>(_ clsid: borrowing CLSID,
+                                         activation context: CLSCTX,
+                                         server: consuming COMServerInfo?,
+                                         outer: borrowing IUnknown? = nil,
+                                         as: Interface.Type = Interface.self)
+    throws(COMError) -> Interface where Interface.Type: COMInterface {
+  precondition(server == nil || outer == nil, "remote aggregation is disallowed")
+
+  if let server {
+    return try CoCreateInstanceEx(clsid, activation: context, server: server,
+                                  as: Interface.self)
+  }
+
+  var instance: UnsafeMutableRawPointer?
+  let hr = withUnsafePointer(to: clsid) {
+    let rclsid = UnsafeRawPointer($0).assumingMemoryBound(to: WinSDK.CLSID.self)
+    return withUnsafePointer(to: Interface.IID) {
+      let riid = UnsafeRawPointer($0).assumingMemoryBound(to: WinSDK.IID.self)
+
+      let pUnknown = outer.map {
+        ManagedObject<IUnknown>.passUnretained($0)
+            .assumingMemoryBound(to: WinSDK.IUnknown.self)
+      }
+      return WinSDK.CoCreateInstance(rclsid, pUnknown, DWORD(context.rawValue),
+                                     riid, &instance)
+    }
+  }
+
+  guard SUCCEEDED(hr) else {
+    throw COMError(hr: hr)
+  }
+  guard let instance else {
+    throw COMError(hr: E_UNEXPECTED)
+  }
+  return ManagedObject<Interface>.takeRetainedValue(instance)
+}
+
+@_alwaysEmitIntoClient
+package func CoCreateInstanceEx(_ clsid: CLSID,
+                                activation context: CLSCTX,
+                                server: consuming COMServerInfo? = nil,
+                                interface: borrowing IID)
+    throws(COMError) -> WinSDK.MULTI_QI {
+  var result = WinSDK.MULTI_QI()
+  let hr = withUnsafePointer(to: interface) { interface in
+    result.pIID = UnsafeRawPointer(interface)
+        .assumingMemoryBound(to: WinSDK.IID.self)
+    return withUnsafePointer(to: clsid) {
+      let rclsid =
+          UnsafeRawPointer($0).assumingMemoryBound(to: WinSDK.CLSID.self)
+      return withUnsafeMutablePointer(to: &result) { result in
+        guard let server else {
+          return WinSDK.CoCreateInstanceEx(rclsid, nil, DWORD(context.rawValue),
+                                           nil, 1, result)
+        }
+
+        return server.name.withCString(encodedAs: UTF16.self) { lpszServerName in
+          var info = COSERVERINFO()
+          info.pwszName = UnsafeMutablePointer(mutating: lpszServerName)
+          return WinSDK.CoCreateInstanceEx(rclsid, nil, DWORD(context.rawValue),
+                                           &info, 1, result)
+        }
+      }
+    }
+  }
+
+  guard SUCCEEDED(hr) || hr == E_NOINTERFACE else {
+    throw COMError(hr: hr)
+  }
+  guard SUCCEEDED(result.hr) else {
+    throw COMError(hr: result.hr)
+  }
+  result.pIID = nil
+  return result
+}
+
+@_alwaysEmitIntoClient
+package func CoCreateInstanceEx<Interface>(_ clsid: borrowing CLSID,
+                                           activation context: CLSCTX,
+                                           server: consuming COMServerInfo? = nil,
+                                           as interface: Interface.Type = Interface.self)
+    throws(COMError) -> Interface where Interface.Type: COMInterface {
+  let result = try CoCreateInstanceEx(clsid, activation: context,
+                                      server: server, interface: Interface.IID)
+  guard let pointer = result.pItf else {
+    throw COMError(hr: E_UNEXPECTED)
+  }
+  return ManagedObject<Interface>.takeRetainedValue(UnsafeMutableRawPointer(pointer))
+}
+
+// MARK: - CoCreateInstance
+
+@_alwaysEmitIntoClient
+public func CoCreateInstance<Interface>(_ clsid: borrowing CLSID,
+                                        activation options: consuming COMActivationOptions = COMActivationOptions.current,
+                                        as: Interface.Type = Interface.self)
+    throws(COMError) -> Interface where Interface.Type: COMInterface {
+  return try CoCreateInstance(clsid, activation: options.context,
+                              server: options.server,
+                              outer: nil, as: Interface.self)
+}
+
+@_transparent
+public func CoCreateInstance<Interface>(_ clsid: borrowing WinSDK.GUID,
+                                        activation options: consuming COMActivationOptions = COMActivationOptions.current,
+                                        as: Interface.Type = Interface.self)
+    throws(COMError) -> Interface where Interface.Type: COMInterface {
+  return try CoCreateInstance(CLSID(clsid), activation: options,
+                              as: Interface.self)
+}
+
+@_transparent
+public func CoCreateInstance<Implementation, Interface>(_ implementation: Implementation.Type,
+                                                        activation options: consuming COMActivationOptions = COMActivationOptions.current,
+                                                        as: Interface.Type = Interface.self)
+    throws(COMError) -> Interface
+    where Implementation.Type: COMActivatable, Interface.Type: COMInterface {
+  return try CoCreateInstance(Implementation.CLSID, activation: options,
+                              as: Interface.self)
+}
+
+@_alwaysEmitIntoClient
+public func CoCreateInstance(_ clsid: borrowing CLSID,
+                             activation context: CLSCTX = COMActivationOptions.current.context,
+                             aggregating outer: any IUnknown)
+    throws(COMError) -> any IUnknown {
+  return try CoCreateInstance(clsid, activation: context, server: nil,
+                              outer: outer, as: IUnknown.self)
+}
+
+@_transparent
+public func CoCreateInstance(_ clsid: borrowing WinSDK.GUID,
+                             activation context: CLSCTX = COMActivationOptions.current.context,
+                             aggregating outer: any IUnknown)
+    throws(COMError) -> any IUnknown {
+  return try CoCreateInstance(CLSID(clsid), activation: context,
+                              aggregating: outer)
+}
+
+// MARK: - CoCreateInstanceEx
+
+@_alwaysEmitIntoClient
+package func CoCreateInstanceEx<PrimaryInterface, each SecondaryInterface>(_ clsid: CLSID,
+                                                                           activation options: consuming COMActivationOptions = COMActivationOptions.current,
+                                                                           requesting primary: PrimaryInterface.Type,
+                                                                           _ interfaces: repeat (each SecondaryInterface).Type)
+    throws(COMError) -> (PrimaryInterface?, repeat (each SecondaryInterface)?)
+    where PrimaryInterface.Type: COMInterface, repeat (each SecondaryInterface).Type: COMInterface {
+  let context = options.context
+  let server = options.server
+  var count = 1
+  for _ in repeat each interfaces {
+    count += 1
+  }
+
+  var failure: HRESULT?
+  let instances = withUnsafeTemporaryAllocation(of: IID.self, capacity: count) { storage in
+    var iids = OutputSpan(buffer: storage, initializedCount: 0)
+    iids.append(PrimaryInterface.IID)
+    for interface in repeat each interfaces {
+      iids.append(interface.IID)
+    }
+
+    return withUnsafeTemporaryAllocation(of: WinSDK.MULTI_QI.self,
+                                         capacity: count) { results in
+      results.initialize(repeating: WinSDK.MULTI_QI())
+      defer { results.deinitialize() }
+
+      let hr = iids.span.withUnsafeBufferPointer { interfaces in
+        return withUnsafePointer(to: clsid) {
+          let rclsid = UnsafeRawPointer($0)
+              .assumingMemoryBound(to: WinSDK.CLSID.self)
+          for index in results.indices {
+            let iid = interfaces.baseAddress!.advanced(by: index)
+            results[index].pIID = UnsafeRawPointer(iid)
+                .assumingMemoryBound(to: WinSDK.IID.self)
+          }
+
+          guard let server else {
+            return WinSDK.CoCreateInstanceEx(rclsid, nil, DWORD(context.rawValue),
+                                             nil, DWORD(results.count),
+                                             results.baseAddress!)
+          }
+
+          return server.name.withCString(encodedAs: UTF16.self) { lpszServerName in
+            var info = COSERVERINFO()
+            info.pwszName = UnsafeMutablePointer(mutating: lpszServerName)
+            return WinSDK.CoCreateInstanceEx(rclsid, nil, DWORD(context.rawValue),
+                                             &info, DWORD(results.count),
+                                             results.baseAddress!)
+          }
+        }
+      }
+      if SUCCEEDED(hr) || hr == E_NOINTERFACE {
+        for index in results.indices where FAILED(results[index].hr) {
+          results[index].pItf = nil
+        }
+      } else {
+        failure = hr
+      }
+
+      var iterator = results[...]
+      let primary =
+          ManagedObject<PrimaryInterface>.takeRetainedValue(iterator.removeFirst().pItf)
+      return (primary, repeat ManagedObject<each SecondaryInterface>.takeRetainedValue(iterator.removeFirst().pItf))
+    }
+  }
+
+  if let failure {
+    throw COMError(hr: failure)
+  }
+  return instances
+}
+
+@_transparent
+public func CoCreateInstanceEx<PrimaryInterface, each SecondaryInterface>(_ clsid: borrowing WinSDK.GUID,
+                                                                          activation options: consuming COMActivationOptions = COMActivationOptions.current,
+                                                                          requesting primary: PrimaryInterface.Type,
+                                                                          _ interface: repeat (each SecondaryInterface).Type)
+    throws(COMError) -> (PrimaryInterface?, repeat (each SecondaryInterface)?)
+    where PrimaryInterface.Type: COMInterface, repeat (each SecondaryInterface).Type: COMInterface {
+  try CoCreateInstanceEx(CLSID(clsid), activation: options,
+                         requesting: primary, repeat each interface)
+}
+
+@_transparent
+public func CoCreateInstanceEx<Implementation, Primary, each SecondaryInterface>(_ implementation: Implementation.Type,
+                                                                                 activation options: consuming COMActivationOptions = COMActivationOptions.current,
+                                                                                 requesting primary: Primary.Type,
+                                                                                 _ interfaces: repeat (each SecondaryInterface).Type)
+    throws(COMError) -> (Primary?, repeat (each SecondaryInterface)?)
+    where Implementation.Type: COMActivatable, Primary.Type: COMInterface,
+        repeat (each SecondaryInterface).Type: COMInterface {
+  try CoCreateInstanceEx(Implementation.CLSID, activation: options,
+                         requesting: primary, repeat each interfaces)
+}
+
+#endif // $_MicrosoftCOM

--- a/Runtimes/Supplemental/COM/Sources/COM/COMActivationOptions.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/COMActivationOptions.swift
@@ -1,0 +1,79 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// FIXME(compnerd): we should prefer WinSDK's definitions canonically typed on
+// Windows.
+
+/// The class context flags controlling which server types `CoCreateInstance`
+/// considers.
+///
+/// These flags filter the activation scope. The COM runtime searches the
+/// registry for server entries matching the requested CLSID and the allowed
+/// context flags.
+@frozen
+public struct CLSCTX: OptionSet, Sendable {
+  public let rawValue: UInt32
+
+  public init(rawValue: UInt32) {
+    self.rawValue = rawValue
+  }
+
+  /// In-process DLL server (`CLSCTX_INPROC_SERVER`).
+  public static let inproc  = CLSCTX(rawValue: 0x1)
+  /// In-process OLE handler (`CLSCTX_INPROC_HANDLER`).
+  public static let handler = CLSCTX(rawValue: 0x2)
+  /// Out-of-process EXE on the local machine (`CLSCTX_LOCAL_SERVER`).
+  public static let local   = CLSCTX(rawValue: 0x4)
+  /// DCOM remote machine (`CLSCTX_REMOTE_SERVER`).
+  public static let remote  = CLSCTX(rawValue: 0x10)
+  /// Any available server.
+  public static let all: CLSCTX = [.inproc, .handler, .local, .remote]
+}
+
+/// Options controlling how COM objects are activated via `CoCreateInstance`.
+///
+/// `COMActivationOptions` is the value stored in the `@TaskLocal` that
+/// `withActivationContext` manages. The default is `.all` with no remote
+/// server, meaning `CoCreateInstance` will search all available server types
+/// (in-process DLL, local EXE, remote DCOM) on the local machine.
+///
+/// Most code never constructs this type directly. Instead, use
+///  `withActivationContext` to scope the activation context over a block:
+///
+/// ```swift
+/// try withActivationContext(.inproc) {
+///     let obj = try CImplementation()  // activates in-process only
+/// }
+/// ```
+///
+/// For DCOM remote activation, pass a `COMServerInfo`:
+///
+/// ```swift
+/// try await withActivationContext(.remote, server: COMServerInfo(name: "host.example.com")) {
+///     let obj = try CImplementation()  // activates on remote machine
+/// }
+/// ```
+public struct COMActivationOptions {
+  /// The class context flags controlling which server types are considered.
+  public var context: CLSCTX
+
+  /// The remote server to activate on, or `nil` for local activation.
+  public var server: COMServerInfo?
+}
+
+extension COMActivationOptions {
+  /// The default activation options: `.all` context, no remote server.
+  public static let `default` = COMActivationOptions(context: .all)
+}
+
+extension COMActivationOptions: Sendable {
+}

--- a/Runtimes/Supplemental/COM/Sources/COM/COMActivationOptions.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/COMActivationOptions.swift
@@ -1,0 +1,116 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if $_MicrosoftCOM
+
+public import WinSDK
+
+@usableFromInline
+internal let kActivationOptionsKey: DWORD = TlsAlloc()
+
+/// The class context flags controlling which server types `CoCreateInstance`
+/// considers.
+///
+/// These flags filter the activation scope. The COM runtime searches the
+/// registry for server entries matching the requested CLSID and the allowed
+/// context flags.
+@frozen
+public struct CLSCTX: OptionSet, Sendable {
+  public let rawValue: UInt32
+
+  @_transparent
+  public init(rawValue: UInt32) {
+    self.rawValue = rawValue
+  }
+
+  /// In-process DLL server (`CLSCTX_INPROC_SERVER`).
+  @_transparent
+  public static var inproc: CLSCTX { CLSCTX(rawValue: 0x1) }
+
+  /// In-process OLE handler (`CLSCTX_INPROC_HANDLER`).
+  @_transparent
+  public static var handler: CLSCTX { CLSCTX(rawValue: 0x2) }
+
+  /// Out-of-process EXE on the local machine (`CLSCTX_LOCAL_SERVER`).
+  @_transparent
+  public static var local: CLSCTX { CLSCTX(rawValue: 0x4) }
+
+  /// DCOM remote machine (`CLSCTX_REMOTE_SERVER`).
+  @_transparent
+  public static var remote: CLSCTX { CLSCTX(rawValue: 0x10) }
+
+  /// Any available server.
+  @_transparent
+  public static var all: CLSCTX { CLSCTX(rawValue: 0x17) }
+}
+
+/// Options controlling how COM objects are activated via `CoCreateInstance`.
+///
+/// A `withCOMContext` scope supplies the class context inherited by calls to
+/// `CoCreateInstance`. The default is `.all`, meaning `CoCreateInstance` will
+/// search all available server types on the local machine.
+///
+/// Most code never constructs this type directly. Instead, use
+/// `withCOMContext` to scope COM initialize and activation context together:
+///
+/// ```swift
+/// try withCOMContext(activation: .inproc) {
+///     let obj = try CImplementation()  // activates in-process only
+/// }
+/// ```
+///
+/// For DCOM remote activation, pass a `COMServerInfo`:
+///
+/// ```swift
+/// try await withCOMContext(activation: .remote, server: COMServerInfo(name: "host.example.com")) {
+///     let obj = try CImplementation()  // activates on remote machine
+/// }
+/// ```
+public struct COMActivationOptions {
+  /// The class context flags controlling which server types are considered.
+  public var context: CLSCTX
+
+  /// The remote server to activate on, or `nil` for local activation.
+  public var server: COMServerInfo?
+
+  public init(context: CLSCTX, server: consuming COMServerInfo? = nil) {
+    self.context = context
+    self.server = server
+  }
+}
+
+extension COMActivationOptions {
+  /// The default activation options: `.all` context, no remote server.
+  @_alwaysEmitIntoClient
+  public static var `default`: COMActivationOptions {
+    COMActivationOptions(context: .all)
+  }
+}
+
+extension COMActivationOptions: Sendable {
+}
+
+extension COMActivationOptions {
+  @usableFromInline
+  @_alwaysEmitIntoClient
+  internal static var current: COMActivationOptions {
+    if kActivationOptionsKey == TLS_OUT_OF_INDEXES {
+      return COMActivationOptions.default
+    }
+    guard let value = TlsGetValue(kActivationOptionsKey) else {
+      return COMActivationOptions.default
+    }
+    return value.assumingMemoryBound(to: COMActivationOptions.self).pointee
+  }
+}
+
+#endif // $_MicrosoftCOM

--- a/Runtimes/Supplemental/COM/Sources/COM/COMAggregate.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/COMAggregate.swift
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if $_MicrosoftCOM /* || $_XPCOM */
+
+/// A protocol that opts a `@com` class into COM aggregation.
+///
+/// When the compiler sees a `@com` class conforming to `COMAggregatable`, it
+/// emits delegating variants of the three `IUnknown` vtable slots
+/// (`AggregatedQueryInterface`, `AggregatedAddRef`, `AggregatedRelease`)
+/// instead of the non-delegating versions. The delegating variants read the
+/// `controller` property and forward all `IUnknown` operations to the outer
+/// object's `IUnknown`. Classes that do not conform get the non-delegating
+/// fast path with zero overhead.
+///
+/// This is a compile-time vtable slot selection — the only compiler awareness
+/// needed is checking `COMAggregatable` conformance at vtable emission time.
+///
+/// Conformance is typically added by the `@COMAggregation` macro on the
+/// generated forwarding class. Direct conformance is permitted for advanced
+/// use cases.
+///
+/// ```swift
+/// @com
+/// final class ForwarderImpl: IAccessible, COMAggregatable {
+///     let controller: (any IUnknown)?
+///     private let inner: any IAccessible
+///
+///     var role: Int32 { get throws { try inner.role } }
+/// }
+/// ```
+public protocol COMAggregatable: AnyObject {
+  /// The outer object's `IUnknown`, or `nil` if the object is not aggregated.
+  var controller: (any IUnknown)? { get }
+}
+
+#endif

--- a/Runtimes/Supplemental/COM/Sources/COM/COMAggregate.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/COMAggregate.swift
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if $_MicrosoftCOM /* || $_XPCOM */
+
+/// A COM implementation whose identity and lifetime can be controlled by a
+/// controlling `IUnknown`.
+///
+/// When `controller` is non-`nil`, `QueryInterface`, `AddRef`, and `Release`
+/// are forwarded to the controlling `IUnknown`. When it is `nil`, the
+/// implementation behaves as a standalone COM object.
+///
+/// Conformance is typically added by the `@COMAggregation` macro on the
+/// generated forwarding class. Direct conformance is permitted for advanced
+/// use cases.
+///
+/// ```swift
+/// @com
+/// final class ForwarderImpl: IAccessible, COMAggregatable {
+///     let controller: (any IUnknown)?
+///     private let inner: any IAccessible
+///
+///     var role: Int32 { get throws { try inner.role } }
+/// }
+/// ```
+public protocol COMAggregatable: AnyObject {
+  /// The controlling `IUnknown`, or `nil` if the object is standalone.
+  var controller: (any IUnknown)? { borrow }
+}
+
+#endif

--- a/Runtimes/Supplemental/COM/Sources/COM/COMContext.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/COMContext.swift
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if os(Windows)
+private import WinSDK
+#endif
+
+/// Manages COM initialisation on the current thread with explicit lifetime.
+///
+/// `COMContext` calls `CoInitializeEx` at construction and `CoUninitialize` at
+/// deallocation. It is suited to long-lived programs where wrapping the entire
+/// body in a `withCOMContext` closure is impractical.
+///
+/// ```swift
+/// func main() throws {
+///     let com = try COMContext(.apartment)
+///
+///     let voice = try SpVoice()
+///     try voice.speak("Hello")
+///     processEvents()
+///     // ...
+/// }
+/// // CoUninitialize called when `com` goes out of scope
+/// ```
+///
+/// For scoped usage, prefer `withCOMContext(_:operation:)`. For entry-point
+/// programs, prefer `@COMMain`.
+///
+/// `COMContext` is non-copyable because `CoInitializeEx`/`CoUninitialize` are
+/// paired per-thread and must not be duplicated.
+public struct COMContext: ~Copyable {
+  /// Initialises COM on the current thread with the specified threading model.
+  ///
+  /// - Parameter model: The apartment threading model for this thread.
+  /// - Throws: If `CoInitializeEx` fails (e.g., the thread is already initialised
+  ///   with a different threading model).
+  public init(_ model: COMThreadingModel) throws(COMError) {
+#if os(Windows)
+    let hr = CoInitializeEx(nil, DWORD(model.rawValue))
+    guard hr >= 0 else { throw COMError(hr: hr) }
+#endif
+  }
+
+  deinit {
+#if os(Windows)
+  CoUninitialize()
+#endif
+  }
+}

--- a/Runtimes/Supplemental/COM/Sources/COM/COMContext.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/COMContext.swift
@@ -1,0 +1,118 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if $_MicrosoftCOM
+
+public import WinSDK
+
+@frozen
+public struct COINIT: OptionSet, Sendable {
+  public let rawValue: UInt32
+
+  @_transparent
+  public init(rawValue: UInt32) {
+    self.rawValue = rawValue
+  }
+
+  /// Initialize the thread as part of the MTA.
+  @_transparent
+  public static var multithreaded: COINIT { COINIT(rawValue: 0) }
+
+  /// Initialize the thread as an STA.
+  @_transparent
+  public static var apartment: COINIT { COINIT(rawValue: 0x2) }
+
+  /// Disable obsolete OLE 1 DDE support.
+  @_transparent
+  public static var NDDE: COINIT { COINIT(rawValue: 0x4) }
+
+  /// Prefer speed over memory use.
+  @_transparent
+  public static var speed: COINIT { COINIT(rawValue: 0x8) }
+}
+
+extension COINIT {
+  /// MTA initialization with obsolete OLE 1 DDE disabled.
+  @_transparent
+  public static var `default`: COINIT { .NDDE }
+}
+
+/// Manages COM initialisation on the current thread with explicit lifetime.
+///
+/// `COMContext` calls `CoInitializeEx` at construction and `CoUninitialize` at
+/// deallocation. It is suited to long-lived programs where wrapping the entire
+/// body in a `withCOMContext` closure is impractical.
+///
+/// ```swift
+/// func main() throws {
+///     let com = try COMContext(.apartment)
+///
+///     let voice = try SpVoice()
+///     try voice.speak("Hello")
+///     processEvents()
+///     // ...
+/// }
+/// // CoUninitialize called when `com` goes out of scope
+/// ```
+///
+/// For scoped usage, prefer `withCOMContext(_:activation:server:_:)`. For
+/// entry-point programs, prefer `@COMMain`.
+///
+/// `COMContext` is non-copyable because `CoInitializeEx`/`CoUninitialize` are
+/// paired per-thread and must not be duplicated.
+public struct COMContext: ~Copyable {
+  /// Initialises COM on the current thread with the specified threading model.
+  ///
+  /// - Parameter options: The apartment threading model for this thread.
+  /// - Throws: If `CoInitializeEx` fails (e.g., the thread is already initialised
+  ///   with a different threading model).
+  @_alwaysEmitIntoClient
+  public init(_ options: COINIT) throws(COMError) {
+    let hr = CoInitializeEx(nil, DWORD(options.rawValue))
+    guard hr >= 0 else { throw COMError(hr: hr) }
+  }
+
+  @_alwaysEmitIntoClient
+  deinit {
+    CoUninitialize()
+  }
+}
+
+/// Runs a synchronous operation in an initialized COM apartment.
+///
+/// Activation operations made during `body` inherit the context and server.
+/// Initialization and activation are thread-bound, so this scope cannot cross
+/// an `await`.
+@_alwaysEmitIntoClient
+public func withCOMContext<Result: ~Copyable>(_ options: COINIT = .default,
+                                              activation: CLSCTX = .all,
+                                              server: consuming COMServerInfo? = nil,
+                                              _ body: () throws -> Result) throws -> Result {
+  let context = try COMContext(options)
+  let options = COMActivationOptions(context: activation, server: server)
+  return try withExtendedLifetime(context) {
+    if kActivationOptionsKey == TLS_OUT_OF_INDEXES {
+      throw COMError(hr: E_OUTOFMEMORY)
+    }
+    return try withUnsafePointer(to: options) { options in
+      let previous = TlsGetValue(kActivationOptionsKey)
+      guard TlsSetValue(kActivationOptionsKey,
+                        UnsafeMutableRawPointer(mutating: options)) else {
+        throw COMError(hr: HRESULT_FROM_WIN32(GetLastError()))
+      }
+      defer { _ = TlsSetValue(kActivationOptionsKey, previous) }
+      return try body()
+    }
+  }
+}
+
+#endif // $_MicrosoftCOM

--- a/Runtimes/Supplemental/COM/Sources/COM/COMError.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/COMError.swift
@@ -1,0 +1,81 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if os(Windows)
+public import WinSDK
+#endif
+
+/// An error thrown when a COM method returns a failing `HRESULT`.
+///
+/// When the synthesised HRESULT-to-`throws` wrapper detects a failing result code, it
+/// captures the thread-local `IErrorInfo` (if available) and throws a `COMError` populated
+/// with the HRESULT and the error information fields. If no `IErrorInfo` is set, the
+/// optional fields are `nil` and only the `hresult` is available.
+///
+/// When a Swift `@com` method throws, the synthesised wrapper populates the thread-local
+/// `IErrorInfo` from the error before returning the HRESULT to the COM caller. If the
+/// thrown error is a `COMError`, its `hresult` is returned directly and its fields are
+/// used to populate `IErrorInfo`. Other Swift errors map to `E_FAIL` with
+/// `localizedDescription` as the error message.
+///
+/// ```swift
+/// do {
+///     try comObject.doWork()
+/// } catch let error as COMError {
+///     print(error)  // "0x80004005: The operation failed"
+/// }
+/// ```
+@frozen
+public struct COMError: Error {
+  /// The failing HRESULT value.
+  public let hresult: HRESULT
+
+  /// The error message from `IErrorInfo::GetDescription`, or `nil` if
+  /// no `IErrorInfo` was set by the callee.
+  public let message: String?
+
+  /// The source component name from `IErrorInfo::GetSource`, or `nil`.
+  public let source: String?
+
+  /// Help information from `IErrorInfo`.
+  ///
+  /// `file` is the help file path from `IErrorInfo::GetHelpFile`, or `nil`.
+  /// `context` is the help context identifier from `IErrorInfo::GetHelpContext`.
+  public let help: (file: String?, context: UInt32)
+
+  internal init(hr: HRESULT, info: (any IErrorInfo)? = nil) {
+    self.hresult = hr
+    if let info {
+      self.message = try? info.description
+      self.source = try? info.source
+      self.help = (try? info.helpFile, (try? info.helpContext) ?? 0)
+    } else {
+      self.message = nil
+      self.source = nil
+      self.help = (nil, 0)
+    }
+  }
+}
+
+extension COMError: CustomStringConvertible {
+  /// A human-readable description of the error.
+  ///
+  /// If a message was captured from `IErrorInfo`, the description includes both
+  /// the HRESULT and the message. Otherwise, only the HRESULT is shown.
+  @inlinable
+  public var description: String {
+    if let message { "\(hresult): \(message)" } else { "\(hresult)" }
+  }
+}
+
+extension COMError: Sendable {
+}

--- a/Runtimes/Supplemental/COM/Sources/COM/COMError.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/COMError.swift
@@ -1,0 +1,95 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if os(Windows)
+public import WinSDK
+#endif
+
+/// An error thrown when a COM method returns a failing `HRESULT`.
+///
+/// When the synthesised HRESULT-to-`throws` wrapper detects a failing result code, it
+/// captures the thread-local `IErrorInfo` (if available) and throws a `COMError` populated
+/// with the HRESULT and the error information fields. If no `IErrorInfo` is set, the
+/// optional fields are `nil` and only the `hresult` is available.
+///
+/// When a Swift `@com` method throws, the synthesised wrapper populates the thread-local
+/// `IErrorInfo` from the error before returning the HRESULT to the COM caller. If the
+/// thrown error is a `COMError`, its `hresult` is returned directly and its fields are
+/// used to populate `IErrorInfo`. Other Swift errors map to `E_FAIL` with
+/// `localizedDescription` as the error message.
+///
+/// ```swift
+/// do {
+///     try object.work()
+/// } catch let error as COMError {
+///     print(error)  // "0x80004005: The operation failed"
+/// }
+/// ```
+@frozen
+public struct COMError: Error {
+  /// The failing HRESULT value.
+  public let hresult: HRESULT
+
+#if $_MicrosoftCOM
+  /// The error message from `IErrorInfo::GetDescription`, or `nil` if
+  /// no `IErrorInfo` was set by the callee.
+  public let message: String?
+
+  /// The source component name from `IErrorInfo::GetSource`, or `nil`.
+  public let source: String?
+
+  /// Help information from `IErrorInfo`.
+  ///
+  /// `file` is the help file path from `IErrorInfo::GetHelpFile`, or `nil`.
+  /// `context` is the help context identifier from `IErrorInfo::GetHelpContext`.
+  public let help: (file: String?, context: UInt32)
+
+  @usableFromInline
+  @_alwaysEmitIntoClient
+  package init(hr: HRESULT, info: consuming (any IErrorInfo)? = nil) {
+    self.hresult = hr
+    if let info {
+      self.message = try? info.description
+      self.source = try? info.source
+      self.help = (try? info.helpFile,
+                   UInt32(truncatingIfNeeded: (try? info.helpContext) ?? 0))
+    } else {
+      self.message = nil
+      self.source = nil
+      self.help = (nil, 0)
+    }
+  }
+#else
+  @usableFromInline
+  @_transparent
+  package init(hr: HRESULT) {
+    self.hresult = hr
+  }
+#endif
+}
+
+extension COMError: CustomStringConvertible {
+  /// A human-readable description of the error.
+  ///
+  /// If a message was captured from `IErrorInfo`, the description includes both
+  /// the HRESULT and the message. Otherwise, only the HRESULT is shown.
+  @_alwaysEmitIntoClient
+  public var description: String {
+#if $_MicrosoftCOM
+    if let message { return "\(hresult): \(message)" }
+#endif
+    return "\(hresult)"
+  }
+}
+
+extension COMError: Sendable {
+}

--- a/Runtimes/Supplemental/COM/Sources/COM/COMInterface.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/COMInterface.swift
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+
+/// Marks a Swift protocol as a COM interface with a stable interface ID.
+///
+/// The compiler synthesizes this conformance for `@com` protocol declarations.
+/// This allows generic code to recover the exact interface ID from a
+/// requirement such as `Interface.Type: COMInterface` without making conforming
+/// implementations carry that identity.
+public protocol COMInterface {
+  /// The IID of this interface.
+  var IID: IID { get }
+}

--- a/Runtimes/Supplemental/COM/Sources/COM/COMInterface.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/COMInterface.swift
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Marks a Swift protocol as a COM interface with a stable interface ID.
+///
+/// The compiler makes the metatype of every `@com` protocol conform to
+/// `COMInterface`. This allows generic code to recover the IID from a
+/// requirement such as `Interface.Type: COMInterface` without making conforming
+/// implementation types carry that identity.
+///
+/// This conformance is compiler-managed and cannot be written explicitly.
+public protocol COMInterface {
+  /// The IID of this interface.
+  var IID: IID { get }
+}

--- a/Runtimes/Supplemental/COM/Sources/COM/COMInterfaceResolution.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/COMInterfaceResolution.swift
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// An owned COM interface reference returned by a dynamic interface resolver.
+///
+/// A result owns exactly one reference to `pointer`. Destroying it invokes
+/// `Release` through the interface's vtable. Consuming it through the compiler
+/// hook transfers that reference to the `QueryInterface` caller.
+@frozen
+public struct COMInterfaceResolution: ~Copyable {
+  @usableFromInline
+  internal let pointer: UnsafeMutableRawPointer
+
+  /// Creates an owned result by retaining a COM interface.
+  ///
+  /// - Parameter interface: The interface to retain.
+  @_transparent
+  public init<Interface>(_ interface: borrowing Interface)
+      where Interface.Type: COMInterface {
+    typealias AddRef = @convention(c) (UnsafeMutableRawPointer) -> UInt32
+
+    let pointer = ManagedObject<Interface>.passUnretained(interface)
+    let vtable = pointer.load(as: UnsafePointer<UnsafeRawPointer>.self)
+    _ = unsafeBitCast(vtable[1], to: AddRef.self)(pointer)
+    self.pointer = pointer
+  }
+
+  /// Creates a result by consuming an existing "+1" COM reference.
+  ///
+  /// The caller must ensure `pointer` is a valid COM interface pointer for
+  /// which it owns exactly one reference.
+  @_transparent
+  public init(consuming pointer: UnsafeMutableRawPointer) {
+    self.pointer = pointer
+  }
+
+  @_transparent
+  deinit {
+    typealias Release = @convention(c) (UnsafeMutableRawPointer) -> UInt32
+
+    let vtable = pointer.load(as: UnsafePointer<UnsafeRawPointer>.self)
+    _ = unsafeBitCast(vtable[2], to: Release.self)(pointer)
+  }
+
+  /// Transfers the owned reference out of this result.
+  @usableFromInline
+  @_transparent
+  internal consuming func take() -> UnsafeMutableRawPointer {
+    let pointer = self.pointer
+    discard self
+    return pointer
+  }
+}

--- a/Runtimes/Supplemental/COM/Sources/COM/COMInterfaceResolver.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/COMInterfaceResolver.swift
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// An extension point for `QueryInterface` beyond a class's declared `@com`
+/// conformances.
+///
+/// The synthesised `QueryInterface` checks `COMAggregatable` (forwarding to the
+/// controlling unknown if present), then `ISwiftObject`, then `IUnknown`, then
+/// scans the class's static conformance table. If no match is found and the
+/// class conforms to `COMInterfaceResolver`, the `resolve(_:)` method is
+/// called as a final step before returning `E_NOINTERFACE`.
+///
+/// This protocol enables COM patterns that add interfaces dynamically at
+/// runtime:
+///
+/// - **Aggregation**: the `@COMAggregation` macro synthesises a
+///   `COMInterfaceResolver` conformance that delegates to inner objects for
+///   aggregated interfaces.
+/// - **Cached tear-offs** (`CachedTearOff<T>`): create an interface
+///   implementation on first query and return the cached instance on subsequent
+///   queries.
+/// - **Disposable tear-offs** (`DisposableTearOff<T>`): create a fresh,
+///   independently reference-counted implementation on every query.
+/// - **Conditional interfaces**: return a pointer for an IID only when some
+///   runtime condition is met.
+///
+/// Classes that do not conform to `COMInterfaceResolver` pay no cost for this
+/// extension point; the synthesised `QueryInterface` skips the callback
+/// entirely.
+public protocol COMInterfaceResolver {
+  /// Called by the synthesised `QueryInterface` for IIDs not found in the
+  /// static conformance table.
+  ///
+  /// Return a valid COM interface pointer for the requested IID, or `nil` to
+  /// decline.  If a non-nil pointer is returned, `QueryInterface` will `AddRef`
+  /// it before returning it to the caller.
+  ///
+  /// - Parameter iid: The interface identifier being queried.
+  /// - Returns: A COM interface pointer, or `nil` if this resolver does not
+  ///            handle the IID.
+  func resolve(_ iid: borrowing IID) -> UnsafeMutableRawPointer?
+}

--- a/Runtimes/Supplemental/COM/Sources/COM/COMInterfaceResolver.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/COMInterfaceResolver.swift
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Provides interfaces that are not declared directly by a COM implementation.
+///
+/// `QueryInterface` checks the implementation's declared interfaces before
+/// consulting this protocol. Use it for conditional interfaces and tear-offs.
+public protocol COMInterfaceResolver {
+  /// Return an owned interface reference for `iid`, or `nil` when the
+  /// interface is unsupported.
+  func resolve(_ iid: borrowing IID) -> COMInterfaceResolution?
+}

--- a/Runtimes/Supplemental/COM/Sources/COM/COMServerInfo.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/COMServerInfo.swift
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Identifies a remote machine for DCOM activation.
+///
+/// Passed to `withActivationContext(_:server:operation:)` when activating COM
+/// objects on a remote machine via `CLSCTX.remote`. Wraps the information
+/// needed by the underlying `CoCreateInstanceEx` call.
+///
+/// ```swift
+/// try await withActivationContext(.remote, server: COMServerInfo(name: "host.example.com")) {
+///     let engine = try CImplementation()
+/// }
+/// ```
+public struct COMServerInfo {
+  /// The hostname or IP address of the remote machine.
+  public var name: String
+
+  /// Creates a server info targeting the specified host.
+  ///
+  /// - Parameter name: The hostname or IP address of the remote DCOM server.
+  public init(name: String) {
+    self.name = name
+  }
+}
+
+extension COMServerInfo: Sendable {
+}

--- a/Runtimes/Supplemental/COM/Sources/COM/COMServerInfo.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/COMServerInfo.swift
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if $_MicrosoftCOM
+
+/// Identifies a remote machine for DCOM activation.
+///
+/// Passed to `withActivationContext(_:server:operation:)` when activating COM
+/// objects on a remote machine via `CLSCTX.remote`. Wraps the information
+/// needed by the underlying `CoCreateInstanceEx` call.
+///
+/// ```swift
+/// try await withActivationContext(.remote, server: COMServerInfo(name: "host.example.com")) {
+///     let engine = try CImplementation()
+/// }
+/// ```
+public struct COMServerInfo {
+  /// The hostname or IP address of the remote machine.
+  public var name: String
+
+  /// Creates a server info targeting the specified host.
+  ///
+  /// - Parameter name: The hostname or IP address of the remote DCOM server.
+  public init(name: consuming String) {
+    self.name = name
+  }
+}
+
+extension COMServerInfo: Sendable {
+}
+
+#endif // $_MicrosoftCOM

--- a/Runtimes/Supplemental/COM/Sources/COM/Extensions/String+Extensions.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/Extensions/String+Extensions.swift
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if $_MicrosoftCOM
+
+public import WinSDK
+
+extension String {
+  @usableFromInline
+  @_alwaysEmitIntoClient
+  internal init?(_ bstr: BSTR?) {
+    guard let bstr else { return nil }
+    self = String(decoding: UnsafeBufferPointer(start: bstr,
+                                                count: Int(SysStringLen(bstr))),
+                  as: UTF16.self)
+  }
+
+  @usableFromInline
+  @_alwaysEmitIntoClient
+  internal init?(consuming bstr: consuming BSTR?) {
+    guard let bstr else { return nil }
+    defer { SysFreeString(bstr) }
+    self = String(decoding: UnsafeBufferPointer(start: bstr,
+                                                count: Int(SysStringLen(bstr))),
+                  as: UTF16.self)
+  }
+}
+
+extension BSTR {
+  @usableFromInline
+  @_alwaysEmitIntoClient
+  internal init(_ string: borrowing String) {
+    self = string.withCString(encodedAs: UTF16.self) { buffer in
+      SysAllocStringLen(buffer, UINT(string.utf16.count))
+    }
+  }
+}
+
+#endif

--- a/Runtimes/Supplemental/COM/Sources/COM/GUID.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/GUID.swift
@@ -1,0 +1,116 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A 128-bit Globally Unique Identifier (GUID) with compile-time type safety
+/// through generic tagging.
+///
+/// `GUID` is a generic structure that holds the four components of a standard
+/// UUID, organized according to RFC 4122. The `Tag` generic parameter is a
+/// phantom type used to distinguish different kinds of GUIDs (such as Interface
+/// Identifiers and Class Identifiers) at compile time without any runtime
+/// overhead.
+///
+/// This is an internal type meant to be used through type aliases like `IID`
+/// and `CLSID`. Direct use outside of the module is not recommended.
+///
+/// ## Structure
+///
+/// A GUID consists of:
+/// - `data1`: A 32-bit value
+/// - `data2`: A 16-bit value
+/// - `data3`: A 16-bit value
+/// - `data4`: An 8-byte array
+///
+/// These four components form the standard 128-bit UUID representation.
+@frozen
+public struct GUID<Tag> {
+  /// The first 32-bit component of the GUID.
+  public let data1: UInt32
+  /// The first 16-bit component of the GUID.
+  public let data2: UInt16
+  /// The second 16-bit component of the GUID.
+  public let data3: UInt16
+  /// The final 8-byte array component of the GUID.
+  public let data4: InlineArray<8, UInt8>
+
+  /// Creates a GUID with the four standard UUID components.
+  ///
+  /// - Parameters:
+  ///   - data1: The first 32-bit component
+  ///   - data2: The first 16-bit component
+  ///   - data3: The second 16-bit component
+  ///   - data4: The final 8-byte array component
+  @inlinable @_transparent
+  internal init(data1: UInt32, data2: UInt16, data3: UInt16,
+                data4: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)) {
+    self.data1 = data1
+    self.data2 = data2
+    self.data3 = data3
+    self.data4 = unsafeBitCast(data4, to: InlineArray<8, UInt8>.self)
+  }
+}
+
+extension GUID: Equatable {
+  @inlinable
+  public static func == (_ lhs: borrowing GUID, _ rhs: borrowing GUID) -> Bool {
+    unsafeBitCast(lhs, to: UInt128.self) == unsafeBitCast(rhs, to: UInt128.self)
+  }
+}
+
+extension GUID: Hashable {
+  @inlinable
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(unsafeBitCast(self, to: UInt128.self))
+  }
+}
+
+extension GUID: Sendable {
+}
+
+extension GUID: CustomStringConvertible {
+  @inlinable
+  public var description: String {
+    String(unsafeUninitializedCapacity: 36) { buffer in
+      let characters: StaticString = "0123456789abcdef"
+
+      @inline(__always)
+      func emit(byte value: UInt8, at offset: UnsafeMutableBufferPointer<UInt8>.Index) {
+        let hi = Int((value >> 4) & 0xf)
+        let lo = Int((value >> 0) & 0xf)
+        buffer[offset + 0] = characters.utf8Start.advanced(by: hi).pointee
+        buffer[offset + 1] = characters.utf8Start.advanced(by: lo).pointee
+      }
+
+      emit(byte: UInt8(truncatingIfNeeded: data1 >> 24), at: 0)
+      emit(byte: UInt8(truncatingIfNeeded: data1 >> 16), at: 2)
+      emit(byte: UInt8(truncatingIfNeeded: data1 >>  8), at: 4)
+      emit(byte: UInt8(truncatingIfNeeded: data1 >>  0), at: 6)
+      buffer[8] = UInt8(ascii: "-")
+      emit(byte: UInt8(truncatingIfNeeded: data2 >>  8), at: 9)
+      emit(byte: UInt8(truncatingIfNeeded: data2 >>  0), at: 11)
+      buffer[13] = UInt8(ascii: "-")
+      emit(byte: UInt8(truncatingIfNeeded: data3 >>  8), at: 14)
+      emit(byte: UInt8(truncatingIfNeeded: data3 >>  0), at: 16)
+      buffer[18] = UInt8(ascii: "-")
+      emit(byte: data4[0], at: 19)
+      emit(byte: data4[1], at: 21)
+      buffer[23] = UInt8(ascii: "-")
+      emit(byte: data4[2], at: 24)
+      emit(byte: data4[3], at: 26)
+      emit(byte: data4[4], at: 28)
+      emit(byte: data4[5], at: 30)
+      emit(byte: data4[6], at: 32)
+      emit(byte: data4[7], at: 34)
+      return 36
+    }
+  }
+}

--- a/Runtimes/Supplemental/COM/Sources/COM/GUID.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/GUID.swift
@@ -1,0 +1,136 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if os(Windows)
+public import WinSDK
+#endif
+
+/// A 128-bit Globally Unique Identifier (GUID) with compile-time type safety
+/// through generic tagging.
+///
+/// `GUID` is a generic structure that holds the four components of a standard
+/// UUID, organized according to RFC 4122. The `Tag` generic parameter is a
+/// phantom type used to distinguish different kinds of GUIDs (such as Interface
+/// Identifiers and Class Identifiers) at compile time without any runtime
+/// overhead.
+///
+/// This is an internal type meant to be used through type aliases like `IID`
+/// and `CLSID`. Direct use outside of the module is not recommended.
+///
+/// ## Structure
+///
+/// A GUID consists of:
+/// - `data1`: A 32-bit value
+/// - `data2`: A 16-bit value
+/// - `data3`: A 16-bit value
+/// - `data4`: An 8-byte array
+///
+/// These four components form the standard 128-bit UUID representation.
+@frozen
+public struct GUID<Tag> {
+  /// The first 32-bit component of the GUID.
+  public let data1: UInt32
+  /// The first 16-bit component of the GUID.
+  public let data2: UInt16
+  /// The second 16-bit component of the GUID.
+  public let data3: UInt16
+  /// The final 8-byte array component of the GUID.
+  public let data4: InlineArray<8, UInt8>
+
+  /// Creates a GUID with the four standard UUID components.
+  ///
+  /// - Parameters:
+  ///   - data1: The first 32-bit component
+  ///   - data2: The first 16-bit component
+  ///   - data3: The second 16-bit component
+  ///   - data4: The final 8-byte array component
+  @usableFromInline
+  @_transparent
+  internal init(data1: UInt32, data2: UInt16, data3: UInt16,
+                data4: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)) {
+    self.data1 = data1
+    self.data2 = data2
+    self.data3 = data3
+    self.data4 = unsafeBitCast(data4, to: InlineArray<8, UInt8>.self)
+  }
+}
+
+#if os(Windows)
+
+extension GUID {
+  @_transparent
+  public init(_ guid: WinSDK.GUID) {
+    self = GUID(data1: UInt32(truncatingIfNeeded: guid.Data1),
+                data2: guid.Data2,
+                data3: guid.Data3,
+                data4: (guid.Data4.0, guid.Data4.1, guid.Data4.2, guid.Data4.3,
+                        guid.Data4.4, guid.Data4.5, guid.Data4.6, guid.Data4.7))
+  }
+}
+
+#endif
+
+extension GUID: Equatable {
+  @_transparent
+  public static func == (_ lhs: borrowing GUID, _ rhs: borrowing GUID) -> Bool {
+    unsafeBitCast(lhs, to: UInt128.self) == unsafeBitCast(rhs, to: UInt128.self)
+  }
+}
+
+extension GUID: Hashable {
+  @_alwaysEmitIntoClient
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(unsafeBitCast(self, to: UInt128.self))
+  }
+}
+
+extension GUID: Sendable {
+}
+
+extension GUID: CustomStringConvertible {
+  @_alwaysEmitIntoClient
+  public var description: String {
+    String(unsafeUninitializedCapacity: 36) { buffer in
+      let characters: StaticString = "0123456789abcdef"
+
+      @inline(__always)
+      func emit(byte value: UInt8, at offset: UnsafeMutableBufferPointer<UInt8>.Index) {
+        let hi = Int((value >> 4) & 0xf)
+        let lo = Int((value >> 0) & 0xf)
+        buffer[offset + 0] = characters.utf8Start.advanced(by: hi).pointee
+        buffer[offset + 1] = characters.utf8Start.advanced(by: lo).pointee
+      }
+
+      emit(byte: UInt8(truncatingIfNeeded: data1 >> 24), at: 0)
+      emit(byte: UInt8(truncatingIfNeeded: data1 >> 16), at: 2)
+      emit(byte: UInt8(truncatingIfNeeded: data1 >>  8), at: 4)
+      emit(byte: UInt8(truncatingIfNeeded: data1 >>  0), at: 6)
+      buffer[8] = UInt8(ascii: "-")
+      emit(byte: UInt8(truncatingIfNeeded: data2 >>  8), at: 9)
+      emit(byte: UInt8(truncatingIfNeeded: data2 >>  0), at: 11)
+      buffer[13] = UInt8(ascii: "-")
+      emit(byte: UInt8(truncatingIfNeeded: data3 >>  8), at: 14)
+      emit(byte: UInt8(truncatingIfNeeded: data3 >>  0), at: 16)
+      buffer[18] = UInt8(ascii: "-")
+      emit(byte: data4[0], at: 19)
+      emit(byte: data4[1], at: 21)
+      buffer[23] = UInt8(ascii: "-")
+      emit(byte: data4[2], at: 24)
+      emit(byte: data4[3], at: 26)
+      emit(byte: data4[4], at: 28)
+      emit(byte: data4[5], at: 30)
+      emit(byte: data4[6], at: 32)
+      emit(byte: data4[7], at: 34)
+      return 36
+    }
+  }
+}

--- a/Runtimes/Supplemental/COM/Sources/COM/HRESULT.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/HRESULT.swift
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if os(Windows)
+public import WinSDK
+#else
+public typealias HRESULT = Int32
+#endif
+
+// MARK: - Standard HRESULT constants
+
+/// The operation completed successfully.
+public let S_OK = HRESULT(bitPattern: 0)
+
+/// The operation completed successfully with a negative condition
+/// (e.g., no more items).
+public let S_FALSE = HRESULT(bitPattern: 1)
+
+/// Unspecified failure.
+public let E_FAIL = HRESULT(bitPattern: 0x80004005)
+
+/// No such interface supported.
+public let E_NOINTERFACE = HRESULT(bitPattern: 0x80004002)
+
+/// Not implemented.
+public let E_NOTIMPL = HRESULT(bitPattern: 0x80004001)
+
+/// Ran out of memory.
+public let E_OUTOFMEMORY = HRESULT(bitPattern: 0x8007000E)
+
+/// One or more arguments are not valid.
+public let E_INVALIDARG = HRESULT(bitPattern: 0x80070057)
+
+/// Pointer that is not valid.
+public let E_POINTER = HRESULT(bitPattern: 0x80004003)
+
+/// Operation aborted.
+public let E_ABORT = HRESULT(bitPattern: 0x80004004)
+
+/// Unexpected failure.
+public let E_UNEXPECTED = HRESULT(bitPattern: 0x8000FFFF)
+
+/// General access denied error.
+public let E_ACCESSDENIED = HRESULT(bitPattern: 0x80070005)
+
+// MARK: - HRESULT predicates
+
+extension HRESULT {
+  /// Whether this HRESULT indicates success (bit 31 is clear).
+  @inlinable @_transparent
+  public var succeeded: Bool { self >= 0 }
+
+  /// Whether this HRESULT indicates failure (bit 31 is set).
+  @inlinable @_transparent
+  public var failed: Bool { self < 0 }
+}

--- a/Runtimes/Supplemental/COM/Sources/COM/HRESULT.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/HRESULT.swift
@@ -1,0 +1,103 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if $_MicrosoftCOM
+
+public import WinSDK
+
+// WinSDK defines these constants through `_HRESULT_TYPEDEF_`, which the Clang
+// importer cannot represent. Preserve their canonical spellings in Swift.
+
+// MARK: - Standard HRESULT constants
+
+/// The operation completed successfully.
+@_transparent
+public var S_OK: HRESULT {
+  HRESULT(bitPattern: 0)
+}
+
+/// The operation completed successfully with a negative condition
+/// (e.g., no more items).
+@_transparent
+public var S_FALSE: HRESULT {
+  HRESULT(bitPattern: 1)
+}
+
+/// Unspecified failure.
+@_transparent
+public var E_FAIL: HRESULT {
+  HRESULT(bitPattern: 0x8000_4005)
+}
+
+/// No such interface supported.
+@_transparent
+public var E_NOINTERFACE: HRESULT {
+  HRESULT(bitPattern: 0x8000_4002)
+}
+
+/// Not implemented.
+@_transparent
+public var E_NOTIMPL: HRESULT {
+  HRESULT(bitPattern: 0x8000_4001)
+}
+
+/// Ran out of memory.
+@_transparent
+public var E_OUTOFMEMORY: HRESULT {
+  HRESULT(bitPattern: 0x8007_000E)
+}
+
+/// One or more arguments are not valid.
+@_transparent
+public var E_INVALIDARG: HRESULT {
+  HRESULT(bitPattern: 0x8007_0057)
+}
+
+/// Pointer that is not valid.
+@_transparent
+public var E_POINTER: HRESULT {
+  HRESULT(bitPattern: 0x8000_4003)
+}
+
+/// Operation aborted.
+@_transparent
+public var E_ABORT: HRESULT {
+  HRESULT(bitPattern: 0x8000_4004)
+}
+
+/// Unexpected failure.
+@_transparent
+public var E_UNEXPECTED: HRESULT {
+  HRESULT(bitPattern: 0x8000_FFFF)
+}
+
+/// General access denied error.
+@_transparent
+public var E_ACCESSDENIED: HRESULT {
+  HRESULT(bitPattern: 0x8007_0005)
+}
+
+// MARK: - HRESULT predicates
+
+@_transparent
+@usableFromInline
+package func SUCCEEDED(_ hr: HRESULT) -> Bool {
+  return hr >= 0
+}
+
+@_transparent
+@usableFromInline
+package func FAILED(_ hr: HRESULT) -> Bool {
+  return hr < 0
+}
+
+#endif // $_MicrosoftCOM

--- a/Runtimes/Supplemental/COM/Sources/COM/IErrorInfo.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/IErrorInfo.swift
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if $_MicrosoftCOM
+
+/// Rich error information for a failed COM `HRESULT`.
+///
+/// `IErrorInfo` is the standard COM interface for providing human-readable
+/// error details alongside a failing `HRESULT`. When a COM method fails, the
+/// synthesised wrapper captures the thread-local `IErrorInfo` into a
+/// `COMError`.
+///
+/// On Windows, `IErrorInfo` is imported from the SDK headers. On non-Windows
+/// platforms, the `COM` module defines it directly. The vtable layout matches
+/// the COM specification: `IUnknown` slots 0-2, then `GetGUID` (3),
+/// `GetSource` (4), `GetDescription` (5), `GetHelpFile` (6),
+/// `GetHelpContext` (7).
+///
+/// Classes that opt into `ISupportErrorInfo` must also conform to `IErrorInfo`
+/// to provide the error detail fields that `ISupportErrorInfo` advertises.
+@com(interface: "1CF2B120-547D-101B-8E65-08002B2BD119")
+public protocol IErrorInfo: IUnknown {
+  /// The GUID of the interface that defined the error.
+  var guid: IID { get throws }
+
+  /// The programmatic identifier of the component that raised the error.
+  var source: String { get throws }
+
+  /// A human-readable description of the error.
+  var description: String { get throws }
+
+  /// The path to the help file that describes the error.
+  var helpFile: String { get throws }
+
+  /// The help context identifier within the help file.
+  var helpContext: UInt32 { get throws }
+}
+
+#endif

--- a/Runtimes/Supplemental/COM/Sources/COM/IErrorInfo.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/IErrorInfo.swift
@@ -1,0 +1,111 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if $_MicrosoftCOM
+
+public import WinSDK
+
+/// Rich error information for a failed COM `HRESULT`.
+///
+/// `IErrorInfo` is the standard COM interface for providing human-readable
+/// error details alongside a failing `HRESULT`. When a COM method fails, the
+/// synthesised wrapper captures the thread-local `IErrorInfo` into a
+/// `COMError`.
+///
+/// Classes that opt into `ISupportErrorInfo` must also conform to `IErrorInfo`
+/// to provide the error detail fields that `ISupportErrorInfo` advertises.
+@com(interface: "1CF2B120-547D-101B-8E65-08002B2BD119")
+public protocol IErrorInfo: IUnknown {
+  /// The GUID of the interface that defined the error.
+  func GetGUID(_ pGUID: UnsafeMutablePointer<WinSDK.GUID>?) -> HRESULT
+
+  /// The programmatic identifier of the component that raised the error.
+  func GetSource(_ pBstrSource: UnsafeMutablePointer<BSTR?>?) -> HRESULT
+
+  /// A human-readable description of the error.
+  func GetDescription(_ pBstrDescription: UnsafeMutablePointer<BSTR?>?) -> HRESULT
+
+  /// The path to the help file that describes the error.
+  func GetHelpFile(_ pBstrHelpFile: UnsafeMutablePointer<BSTR?>?) -> HRESULT
+
+  /// The help context identifier within the help file.
+  func GetHelpContext(_ pdwHelpContext: UnsafeMutablePointer<DWORD>?) -> HRESULT
+}
+
+extension IErrorInfo {
+  @usableFromInline
+  @_alwaysEmitIntoClient
+  internal var guid: WinSDK.GUID {
+    get throws {
+      var iid: WinSDK.GUID = GUID_NULL
+      let hr = GetGUID(&iid)
+      guard SUCCEEDED(hr), iid != GUID_NULL else {
+        throw COMError(hr: hr)
+      }
+      return iid
+    }
+  }
+
+  @usableFromInline
+  @_alwaysEmitIntoClient
+  internal var source: String {
+    get throws {
+      var bstr: BSTR?
+      let hr = GetSource(&bstr)
+      guard SUCCEEDED(hr), let source = String(consuming: bstr) else {
+        throw COMError(hr: hr)
+      }
+      return source
+    }
+  }
+
+  @usableFromInline
+  @_alwaysEmitIntoClient
+  internal var description: String {
+    get throws {
+      var bstr: BSTR?
+      let hr = GetDescription(&bstr)
+      guard SUCCEEDED(hr), let description = String(consuming: bstr) else {
+        throw COMError(hr: hr)
+      }
+      return description
+    }
+  }
+
+  @usableFromInline
+  @_alwaysEmitIntoClient
+  internal var helpFile: String {
+    get throws {
+      var bstr: BSTR?
+      let hr = GetHelpFile(&bstr)
+      guard SUCCEEDED(hr), let helpFile = String(consuming: bstr) else {
+        throw COMError(hr: hr)
+      }
+      return helpFile
+    }
+  }
+
+  @usableFromInline
+  @_alwaysEmitIntoClient
+  internal var helpContext: DWORD {
+    get throws {
+      var dwContext: DWORD = .max
+      let hr = GetHelpContext(&dwContext)
+      guard SUCCEEDED(hr) else {
+        throw COMError(hr: hr)
+      }
+      return dwContext
+    }
+  }
+}
+
+#endif

--- a/Runtimes/Supplemental/COM/Sources/COM/IID.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/IID.swift
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A phantom type tag used to distinguish Interface Identifiers (IIDs) from
+/// other GUIDs.
+///
+/// `IIDTag` serves as a compile-time marker to create a distinct type for IIDs
+/// through generic specialization. It carries no runtime value but enables the
+/// type system to differentiate between IIDs and general-purpose GUIDs.
+public enum IIDTag {}
+
+/// A globally unique identifier that specifically represents a COM Interface
+/// Identifier (IID).
+///
+/// An `IID` is a specialized `GUID` that uniquely identifies a COM interface.
+/// Each COM interface has a corresponding IID that is used for runtime
+/// identification and interface querying.
+///
+/// IIDs for Swift-specific interfaces can be derived deterministically using
+/// the Swift UUID namespace (see the file-level documentation for details on
+/// GUID generation).
+///
+/// ## Relationship to GUID
+///
+/// `IID` is a type-safe wrapper around `GUID` that prevents accidental mixing
+/// of interface identifiers with other types of GUIDs at compile time.
+public typealias IID = GUID<IIDTag>

--- a/Runtimes/Supplemental/COM/Sources/COM/IID.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/IID.swift
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A phantom type tag used to distinguish Interface Identifiers (IIDs) from
+/// other GUIDs.
+///
+/// `IIDTag` serves as a compile-time marker to create a distinct type for IIDs
+/// through generic specialization. It carries no runtime value but enables the
+/// type system to differentiate between IIDs and general-purpose GUIDs.
+public enum IIDTag {}
+
+/// A globally unique identifier that specifically represents a COM Interface
+/// Identifier (IID).
+///
+/// An `IID` is a specialized `GUID` that uniquely identifies a COM interface.
+/// Each COM interface has a corresponding IID that is used for runtime
+/// identification and interface querying.
+///
+/// IIDs for Swift-specific interfaces can be derived deterministically using
+/// the Swift UUID namespace (see the file-level documentation for details on
+/// GUID generation).
+///
+/// ## Relationship to GUID
+///
+/// `IID` is a type-safe wrapper around `GUID` that prevents accidental mixing
+/// of interface identifiers with other types of GUIDs at compile time.
+public typealias IID = GUID<IIDTag>

--- a/Runtimes/Supplemental/COM/Sources/COM/ISwiftObject.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/ISwiftObject.swift
@@ -1,0 +1,73 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// The Swift UUID Namespace
+///
+/// IIDs for Swift-specific COM interfaces are derived deterministically using
+/// UUID version 5 (SHA-1, RFC 4122 Section 4.3) from a reserved Swift namespace
+/// UUID:
+///
+/// ```
+/// Namespace: {E29CA80E-0000-0000-C000-000000000000}
+/// ```
+///
+/// To derive an IID, the namespace bytes are concatenated with the UTF-8
+/// encoding of the interface name, SHA-1 hashed, and the first 16 bytes are
+/// formatted as a UUID v5 (version nibble set to 5, variant bits set to RFC
+/// 4122). This produces a stable, deterministic IID for each name within the
+/// namespace, with no external registry needed.
+
+/// A COM interface for recovering the underlying Swift heap object from a COM
+/// interface pointer.
+///
+/// `ISwiftObject` is synthesised implicitly on every `@com` class. The runtime
+/// uses it to implement `as?` casting from COM existentials to concrete Swift
+/// types. Explicitly conforming a `@com` class to `ISwiftObject` is a
+/// compile-time error.
+///
+/// The interface has a single method (`object`, at vtable slot 3) that returns
+/// a borrowed reference to the Swift heap object. Like `IUnknown`'s methods,
+/// this is not exposed as a Swift protocol requirement because the
+/// implementation is compiler-managed and sealed.
+///
+/// The `object` getter recovers the Swift object pointer using the non-virtual
+/// thunk adjustment stored at `vtable[−1]`. Each COM interface on an object has
+/// its own vtable, and each vtable carries its own adjustment value at this
+/// negative offset. The adjustment records the byte distance from the COM
+/// interface pointer to the Swift object pointer. This is analogous to the
+/// Itanium C++ ABI's `offset_to_top` field in structure — a per-vtable fixed
+/// displacement stored at a negative index — though the direction is reversed:
+/// rather than retreating to the lowest address of the complete object, the
+/// adjustment advances forward to where the Swift heap object begins within the
+/// allocation. The adjustment is per-vtable because each interface's vtable
+/// pointer sits at a different offset within the object's COM block.
+///
+/// A user-provided implementation would bypass this per-vtable adjustment and
+/// produce incorrect results. The runtime calls `object` only after
+/// `QueryInterface` for `ISwiftObject` has confirmed the object is
+/// Swift-originated, so the adjustment is never read speculatively on foreign
+/// COM objects.
+@com(interface: "8E369447-5188-5ADA-B9EC-8FCB732D226B")
+public protocol ISwiftObject {
+  var object: UnsafeMutableRawPointer { get }
+  var metadata: UnsafeRawPointer { get }
+}
+
+extension ISwiftObject {
+  var object: UnsafeMutableRawPointer {
+    unsafeBitCast(self, to: UnsafeMutableRawPointer.self)
+  }
+
+  var metadata: UnsafeRawPointer {
+    unsafeBitCast(type(of: self), to: UnsafeRawPointer.self)
+  }
+}

--- a/Runtimes/Supplemental/COM/Sources/COM/ISwiftObject.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/ISwiftObject.swift
@@ -1,0 +1,76 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// The Swift UUID Namespace
+///
+/// IIDs for Swift-specific COM interfaces are derived deterministically using
+/// UUID version 5 (SHA-1, RFC 4122 Section 4.3) from a reserved Swift namespace
+/// UUID:
+///
+/// ```
+/// Namespace: {E29CA80E-0000-0000-C000-000000000000}
+/// ```
+///
+/// To derive an IID, the namespace bytes are concatenated with the UTF-8
+/// encoding of the interface name, SHA-1 hashed, and the first 16 bytes are
+/// formatted as a UUID v5 (version nibble set to 5, variant bits set to RFC
+/// 4122). This produces a stable, deterministic IID for each name within the
+/// namespace, with no external registry needed.
+
+/// A COM interface for recovering the underlying Swift heap object from a COM
+/// interface pointer.
+///
+/// `ISwiftObject` is synthesised implicitly on every `@com` class. The runtime
+/// uses it to implement `as?` casting from COM existentials to concrete Swift
+/// types. Explicitly conforming a `@com` class to `ISwiftObject` is a
+/// compile-time error.
+///
+/// The interface has a single method (`object`, at vtable slot 3) that returns
+/// a borrowed reference to the Swift heap object. Like `IUnknown`'s methods,
+/// this is not exposed as a Swift protocol requirement because the
+/// implementation is compiler-managed and sealed.
+///
+/// Before calling a property witness, its native COM entry recovers the Swift
+/// object pointer using the non-virtual adjustment stored at `vtable[−1]`.
+/// Each COM interface on an object has its own vtable, and each vtable carries
+/// its own adjustment value at this negative offset. The adjustment records the
+/// byte distance from the COM interface pointer to the Swift object pointer.
+/// This is analogous to the Itanium C++ ABI's `offset_to_top` field in
+/// structure (a per-vtable fixed displacement stored at a negative index)
+/// though the direction is reversed: rather than retreating to the lowest
+/// address of the complete object, the adjustment advances forward to where the
+/// Swift heap object begins within the allocation. The adjustment is per-vtable
+/// because each interface's vtable pointer sits at a different offset within
+/// the object's COM block.
+///
+/// A user-provided implementation would bypass this per-vtable adjustment and
+/// produce incorrect results. The runtime calls `object` only after
+/// `QueryInterface` for `ISwiftObject` has confirmed the object is
+/// Swift-originated, so the adjustment is never read speculatively on foreign
+/// COM objects.
+@com(interface: "8E369447-5188-5ADA-B9EC-8FCB732D226B")
+public protocol ISwiftObject {
+  var object: UnsafeMutableRawPointer { get }
+  var metadata: UnsafeRawPointer { get }
+}
+
+extension ISwiftObject {
+  @_transparent
+  public var object: UnsafeMutableRawPointer {
+    unsafeBitCast(self, to: UnsafeMutableRawPointer.self)
+  }
+
+  @_transparent
+  public var metadata: UnsafeRawPointer {
+    unsafeBitCast(type(of: self), to: UnsafeRawPointer.self)
+  }
+}

--- a/Runtimes/Supplemental/COM/Sources/COM/IUnknown+Aggregation.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/IUnknown+Aggregation.swift
@@ -1,0 +1,89 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if $_MicrosoftCOM
+
+public import WinSDK
+public import _SwiftCOMShims
+
+// MARK: - Helpers
+
+extension Unmanaged where Instance == AnyObject {
+  /// Recovers the Swift object pointer `P` and the heap object from a COM
+  /// interface pointer via the `vtable[-1]` byte adjustment.
+  @_transparent
+  @usableFromInline
+  internal static func from(unsafeCOMPointer pUnk: UnsafeMutableRawPointer) -> Self {
+    let vtable = pUnk.load(as: UnsafePointer<UnsafeRawPointer>.self)
+    let object = pUnk.advanced(by: Int(bitPattern: vtable.advanced(by: -1).pointee))
+    return Unmanaged<AnyObject>.fromOpaque(object)
+  }
+}
+
+// MARK: - Aggregated IUnknown Methods
+
+/// Aggregated `QueryInterface`.
+///
+/// Forwards the operation to the controlling `IUnknown` when the receiver is
+/// aggregated, or queries the receiver directly when it is standalone.
+@implementation @c
+@_alwaysEmitIntoClient
+public func AggregatedQueryInterface(_ pUnk: UnsafeMutableRawPointer, _ riid: UnsafeRawPointer,
+                                     _ ppvObject: UnsafeMutablePointer<UnsafeMutableRawPointer?>)
+    -> HRESULT {
+  let aggregate = Unmanaged<AnyObject>.from(unsafeCOMPointer: pUnk).takeUnretainedValue() as! COMAggregatable
+  guard let controller = aggregate.controller else {
+    return QueryInterface(pUnk, riid, ppvObject)
+  }
+
+  let outer = ManagedObject<IUnknown>.passUnretained(controller)
+  let vtable = outer.load(as: UnsafePointer<UnsafeRawPointer>.self)
+  let operation = unsafeBitCast(vtable[0],
+                                to: _SwiftCOMQueryInterfaceFunction.self)
+  return operation(outer, riid, ppvObject)
+}
+
+/// Aggregated `AddRef`.
+///
+/// Forwards the operation to the controlling `IUnknown` when the receiver is
+/// aggregated, or calls the receiver's `AddRef` directly when it is standalone.
+@implementation @c
+@_alwaysEmitIntoClient
+public func AggregatedAddRef(_ pUnk: UnsafeMutableRawPointer) -> UInt32 {
+  let aggregate = Unmanaged<AnyObject>.from(unsafeCOMPointer: pUnk).takeUnretainedValue() as! COMAggregatable
+  guard let controller = aggregate.controller else {
+    return AddRef(pUnk)
+  }
+
+  let outer = ManagedObject<IUnknown>.passUnretained(controller)
+  let vtable = outer.load(as: UnsafePointer<UnsafeRawPointer>.self)
+  return unsafeBitCast(vtable[1], to: _SwiftCOMLifetimeFunction.self)(outer)
+}
+
+/// Aggregated `Release`.
+///
+/// Forwards the operation to the controlling `IUnknown` when the receiver is
+/// aggregated, or calls the receiver's `Release` directly when it is standalone.
+@implementation @c
+@_alwaysEmitIntoClient
+public func AggregatedRelease(_ pUnk: UnsafeMutableRawPointer) -> UInt32 {
+  let aggregate = Unmanaged<AnyObject>.from(unsafeCOMPointer: pUnk).takeUnretainedValue() as! COMAggregatable
+  guard let controller = aggregate.controller else {
+    return Release(pUnk)
+  }
+
+  let outer = ManagedObject<IUnknown>.passUnretained(controller)
+  let vtable = outer.load(as: UnsafePointer<UnsafeRawPointer>.self)
+  return unsafeBitCast(vtable[2], to: _SwiftCOMLifetimeFunction.self)(outer)
+}
+
+#endif

--- a/Runtimes/Supplemental/COM/Sources/COM/IUnknown+Aggregation.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/IUnknown+Aggregation.swift
@@ -1,0 +1,64 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if $_MicrosoftCOM
+
+// MARK: - Helpers
+
+extension Unmanaged where Instance == AnyObject {
+  /// Recovers the Swift object pointer `P` and the heap object from a COM
+  /// interface pointer via the `vtable[-1]` byte adjustment.
+  @_transparent
+  @usableFromInline
+  internal static func from(unsafeCOMPointer pUnk: UnsafeMutableRawPointer) -> Self {
+    let vtable = pUnk.load(as: UnsafePointer<UnsafeRawPointer>.self)
+    let object = pUnk.advanced(by: Int(bitPattern: vtable.advanced(by: -1).pointee))
+    return Unmanaged<AnyObject>.fromOpaque(object)
+  }
+}
+
+// MARK: - Aggregated IUnknown Methods
+
+/// Aggregated `QueryInterface`.
+///
+/// Used by the compiler for `@com` classes that conform to `COMAggregatable`.
+/// Forwards the entire call to the controlling unknown's `QueryInterface`.
+@_alwaysEmitIntoClient
+public func AggregatedQueryInterface(_ pUnk: UnsafeMutableRawPointer, _ riid: borrowing IID,
+                                     _ ppvObject: UnsafeMutablePointer<UnsafeMutableRawPointer?>,
+                                     conformances table: borrowing Span<IID>) -> HRESULT {
+  let aggregate = Unmanaged<AnyObject>.from(unsafeCOMPointer: pUnk).takeUnretainedValue() as! COMAggregatable
+  let outer = UnsafeMutableRawPointer(aggregate.controller!)
+  return QueryInterface(outer, riid, ppvObject, conformances: table)
+}
+
+/// Aggregated `AddRef`.
+///
+/// Used by the compiler for `@com` classes that conform to `COMAggregatable`.
+/// Forwards to the controlling unknown's `AddRef`.
+@_alwaysEmitIntoClient
+public func AggregatedAddRef(_ pUnk: UnsafeMutableRawPointer) -> UInt32 {
+  let aggregate = Unmanaged<AnyObject>.from(unsafeCOMPointer: pUnk).takeUnretainedValue() as! COMAggregatable
+  return AddRef(UnsafeMutableRawPointer(aggregate.controller!))
+}
+
+/// Aggregated `Release`.
+///
+/// Used by the compiler for `@com` classes that conform to `COMAggregatable`.
+/// Forwards to the controlling unknown's `Release`.
+@_alwaysEmitIntoClient
+public func AggregatedRelease(_ pUnk: UnsafeMutableRawPointer) -> UInt32 {
+  let aggregate = Unmanaged<AnyObject>.from(unsafeCOMPointer: pUnk).takeUnretainedValue() as! COMAggregatable
+  return Release(UnsafeMutableRawPointer(aggregate.controller!))
+}
+
+#endif

--- a/Runtimes/Supplemental/COM/Sources/COM/IUnknown+Identity.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/IUnknown+Identity.swift
@@ -1,0 +1,86 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if $_MicrosoftCOM
+
+public import _SwiftCOMShims
+
+extension ObjectIdentifier {
+  /// Creates an identifier for the COM identity of an interface.
+  ///
+  /// COM defines object identity as the interface pointer returned by
+  /// `QueryInterface` for `IUnknown`. Different interfaces on the same object
+  /// therefore produce the same identifier even when their own interface
+  /// pointers differ.
+  @_alwaysEmitIntoClient
+  public init<Interface>(_ interface: borrowing Interface)
+      where Interface.Type: COMInterface {
+    let pUnk = ManagedObject<Interface>.passUnretained(interface)
+    let vtable = pUnk.load(as: UnsafePointer<UnsafeRawPointer>.self)
+    let queryInterface =
+      unsafeBitCast(vtable[0], to: _SwiftCOMQueryInterfaceFunction.self)
+
+    var identity: UnsafeMutableRawPointer?
+    let hr = withUnsafePointer(to: IUnknown.IID) { iid in
+      queryInterface(pUnk, UnsafeRawPointer(iid), &identity)
+    }
+    guard hr >= 0, let identity else {
+      preconditionFailure("QueryInterface for IUnknown failed")
+    }
+
+    self = unsafeBitCast(identity, to: ObjectIdentifier.self)
+
+    let identityVTable =
+      identity.load(as: UnsafePointer<UnsafeRawPointer>.self)
+    let release =
+      unsafeBitCast(identityVTable[2], to: _SwiftCOMLifetimeFunction.self)
+    _ = release(identity)
+  }
+}
+
+/// Returns whether two COM interfaces identify the same object.
+@_alwaysEmitIntoClient
+public func === <Left, Right>(_ lhs: borrowing Left,
+                              _ rhs: borrowing Right) -> Bool
+    where Left.Type: COMInterface, Right.Type: COMInterface {
+  return ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
+}
+
+/// Returns whether two optional COM interfaces identify the same object.
+@_alwaysEmitIntoClient
+public func === <Left, Right>(_ lhs: Left?, _ rhs: Right?) -> Bool
+    where Left.Type: COMInterface, Right.Type: COMInterface {
+  guard let lhs else {
+    return rhs == nil
+  }
+  guard let rhs else {
+    return false
+  }
+  return lhs === rhs
+}
+
+/// Returns whether two COM interfaces identify different objects.
+@_alwaysEmitIntoClient
+public func !== <Left, Right>(_ lhs: borrowing Left,
+                              _ rhs: borrowing Right) -> Bool
+    where Left.Type: COMInterface, Right.Type: COMInterface {
+  return !(lhs === rhs)
+}
+
+/// Returns whether two optional COM interfaces identify different objects.
+@_alwaysEmitIntoClient
+public func !== <Left, Right>(_ lhs: Left?, _ rhs: Right?) -> Bool
+    where Left.Type: COMInterface, Right.Type: COMInterface {
+  return !(lhs === rhs)
+}
+
+#endif // $_MicrosoftCOM

--- a/Runtimes/Supplemental/COM/Sources/COM/IUnknown.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/IUnknown.swift
@@ -1,0 +1,169 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+internal import SwiftShims
+public import _SwiftCOMShims
+
+#if $_MicrosoftCOM
+
+public import WinSDK
+
+/// The root interface for all COM objects.
+///
+/// Every COM interface derives from `IUnknown`, which provides the three
+/// fundamental operations of the COM binary interface: `QueryInterface`
+/// (interface discovery), `AddRef` (reference count increment), and `Release`
+/// (reference count decrement).
+///
+/// In Swift, these three operations are compiler-managed and sealed:
+///
+/// - `QueryInterface` is expressed as Swift's `as?` operator. Casting between
+///   `@com` protocol existentials generates a `QueryInterface` call with the
+///   target protocol's IID.
+/// - `AddRef` and `Release` are managed by Swift ARC through the unified
+///   reference count.  Swift developers never call them directly.
+///
+/// The protocol body is empty because the three COM methods cannot be expressed
+/// as ordinary Swift protocol requirements. They occupy vtable slots 0–2 but
+/// are sealed: `AddRef`/`Release` must go through ARC (manual calls would
+/// corrupt the refcount), and `QueryInterface` must go through `as?` (which
+/// handles existential wrapping and the `ISwiftObject` recovery path). Allowing
+/// override of any of the three would break the COM identity rule, QI symmetry,
+/// or the unified refcount contract.
+///
+/// For advanced use cases that require raw `QueryInterface` access (e.g.,
+/// dynamic IIDs not known at compile time), the underlying C functions remain
+/// available through `WinSDK`.
+///
+/// `IUnknown` conformance is implied automatically on every `@com` class.
+/// Writing `: IUnknown` explicitly is allowed but unnecessary.
+///
+/// The IID `{00000000-0000-0000-C000-000000000046}` is the well-known
+/// identifier assigned to `IUnknown` by the COM specification. `QueryInterface`
+/// for this IID returns the primary interface pointer, satisfying the COM
+/// identity rule.
+@com(interface: "00000000-0000-0000-C000-000000000046")
+public protocol IUnknown {
+}
+
+#endif // $_MicrosoftCOM
+
+// MARK: - QueryInterface
+
+@usableFromInline
+@_alwaysEmitIntoClient
+internal func QueryInterface(_ pUnk: UnsafeMutableRawPointer,
+                             _ riid: borrowing IID,
+                             _ ppvObject: UnsafeMutablePointer<UnsafeMutableRawPointer?>)
+    -> HRESULT {
+  ppvObject.pointee = nil
+
+  let stride = MemoryLayout<UnsafeRawPointer>.stride
+
+  let vtable = pUnk.load(as: UnsafePointer<UnsafeRawPointer>.self)
+  let object = pUnk.advanced(by: Int(bitPattern: vtable.advanced(by: -1).pointee))
+
+  // ISwiftObject fast path: always at object[-1]. This is the most common QI
+  // in Swift — every `as?` to a concrete @com class goes through here.
+  if riid == ISwiftObject.IID {
+    ppvObject.pointee = object.advanced(by: -stride)
+    _ = Unmanaged<AnyObject>.fromOpaque(object).retain()
+    return S_OK
+  }
+
+  let map = vtable.advanced(by: -2).pointee
+
+  let header =
+      map.assumingMemoryBound(to: _SwiftCOMInterfaceMapHeader.self).pointee
+  let entries = map.advanced(by: MemoryLayout<_SwiftCOMInterfaceMapHeader>.stride)
+
+  for index in 0 ..< Int(header.count) {
+    let address =
+        entries.advanced(by: index * MemoryLayout<_SwiftCOMInterfaceMapEntry>.stride)
+    let entry =
+        address.assumingMemoryBound(to: _SwiftCOMInterfaceMapEntry.self).pointee
+
+    let offset = entry.descriptor
+    var descriptor = address.advanced(by: Int(offset & -2))
+    if (offset & 1) == 1 {
+      descriptor = descriptor.load(as: UnsafeRawPointer.self)
+    }
+
+    let iid: IID =
+        descriptor.advanced(by: MemoryLayout<_SwiftProtocolDescriptorHeader>.stride)
+            .load(as: IID.self)
+    guard iid == riid else {
+      continue
+    }
+
+    let pointer = object.advanced(by: -(Int(entry.index) + 1) * stride)
+    ppvObject.pointee = pointer
+
+    _ = Unmanaged<AnyObject>.fromOpaque(object).retain()
+    return S_OK
+  }
+
+  // COMInterfaceResolver callback — AnyObject cast only on this fallback path.
+  let instance = Unmanaged<AnyObject>.fromOpaque(object).takeUnretainedValue()
+  if let resolver = instance as? COMInterfaceResolver,
+     let resolution = resolver.resolve(riid) {
+    ppvObject.pointee = resolution.take()
+    return S_OK
+  }
+
+  return E_NOINTERFACE
+}
+
+/// Non-delegating `QueryInterface`.
+///
+/// Used by the compiler for `@com` classes that do not conform to
+/// `COMAggregatable`. The `AnyObject` cast is deferred to the
+/// `COMInterfaceResolver` fallback path; the `IUnknown` and `ISwiftObject`
+/// fast paths are pure pointer arithmetic.
+@implementation @c
+@_alwaysEmitIntoClient
+public func QueryInterface(_ pUnk: UnsafeMutableRawPointer,
+                           _ riid: UnsafeRawPointer,
+                           _ ppvObject: UnsafeMutablePointer<UnsafeMutableRawPointer?>)
+    -> HRESULT {
+  return QueryInterface(pUnk, riid.load(as: IID.self), ppvObject)
+}
+
+// MARK: - AddRef
+
+/// Non-delegating `AddRef`.
+///
+/// Used by the compiler for `@com` classes that do not conform to
+/// `COMAggregatable`. Recovers `P` via `vtable[-1]` and calls
+/// `swift_retainReturningCount` directly. No dynamic checks.
+@implementation @c
+@_alwaysEmitIntoClient
+public func AddRef(_ pUnk: UnsafeMutableRawPointer) -> UInt32 {
+  let vtable = pUnk.load(as: UnsafePointer<UnsafeRawPointer>.self)
+  let P = pUnk.advanced(by: Int(bitPattern: vtable.advanced(by: -1).pointee))
+  return UInt32(truncatingIfNeeded: swift_retainReturningCount(P))
+}
+
+// MARK: - Release
+
+/// Non-delegating `Release`.
+///
+/// Used by the compiler for `@com` classes that do not conform to
+/// `COMAggregatable`. Recovers `P` via `vtable[-1]` and calls
+/// `swift_releaseReturningCount` directly. No dynamic checks.
+@implementation @c
+@_alwaysEmitIntoClient
+public func Release(_ pUnk: UnsafeMutableRawPointer) -> UInt32 {
+  let vtable = pUnk.load(as: UnsafePointer<UnsafeRawPointer>.self)
+  let P = pUnk.advanced(by: Int(bitPattern: vtable.advanced(by: -1).pointee))
+  return UInt32(truncatingIfNeeded: swift_releaseReturningCount(P))
+}

--- a/Runtimes/Supplemental/COM/Sources/COM/IUnknown.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/IUnknown.swift
@@ -1,0 +1,147 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if os(Windows)
+public import WinSDK
+#endif
+
+/// The root interface for all COM objects.
+///
+/// Every COM interface derives from `IUnknown`, which provides the three
+/// fundamental operations of the COM binary interface: `QueryInterface`
+/// (interface discovery), `AddRef` (reference count increment), and `Release`
+/// (reference count decrement).
+///
+/// In Swift, these three operations are compiler-managed and sealed:
+///
+/// - `QueryInterface` is expressed as Swift's `as?` operator. Casting between
+///   `@com` protocol existentials generates a `QueryInterface` call with the
+///   target protocol's IID.
+/// - `AddRef` and `Release` are managed by Swift ARC through the unified
+///   reference count.  Swift developers never call them directly.
+///
+/// The protocol body is empty because the three COM methods cannot be expressed
+/// as ordinary Swift protocol requirements. They occupy vtable slots 0–2 but
+/// are sealed: `AddRef`/`Release` must go through ARC (manual calls would
+/// corrupt the refcount), and `QueryInterface` must go through `as?` (which
+/// handles existential wrapping and the `ISwiftObject` recovery path). Allowing
+/// override of any of the three would break the COM identity rule, QI symmetry,
+/// or the unified refcount contract.
+///
+/// For advanced use cases that require raw `QueryInterface` access (e.g.,
+/// dynamic IIDs not known at compile time), the underlying C functions remain
+/// available through `WinSDK`.
+///
+/// `IUnknown` conformance is implied automatically on every `@com` class.
+/// Writing `: IUnknown` explicitly is allowed but unnecessary.
+///
+/// The IID `{00000000-0000-0000-C000-000000000046}` is the well-known
+/// identifier assigned to `IUnknown` by the COM specification. `QueryInterface`
+/// for this IID returns the primary interface pointer, satisfying the COM
+/// identity rule.
+@com(interface: "00000000-0000-0000-C000-000000000046")
+public protocol IUnknown {
+}
+
+// MARK: - QueryInterface
+
+/// Non-delegating `QueryInterface`.
+///
+/// Used by the compiler for `@com` classes that do not conform to
+/// `COMAggregatable`. The `AnyObject` cast is deferred to the
+/// `COMInterfaceResolver` fallback path; the `IUnknown` and `ISwiftObject`
+/// fast paths are pure pointer arithmetic.
+@_alwaysEmitIntoClient
+public func QueryInterface(_ pUnk: UnsafeMutableRawPointer, _ riid: borrowing IID,
+                           _ ppvObject: UnsafeMutablePointer<UnsafeMutableRawPointer?>,
+                           conformances table: borrowing Span<IID>) -> HRESULT {
+  let stride = MemoryLayout<UnsafeRawPointer>.stride
+
+  // Recover P via vtable[-1]. No AnyObject cast on the fast path.
+  let vtable = pUnk.load(as: UnsafePointer<UnsafeRawPointer>.self)
+  let P = pUnk.advanced(by: Int(bitPattern: vtable.advanced(by: -1).pointee))
+
+  // ISwiftObject fast path: always at P[-1]. This is the most common QI
+  // in Swift — every `as?` to a concrete @com class goes through here.
+  if riid == ISwiftObject.IID {
+    ppvObject.pointee = P.advanced(by: -stride)
+    _ = swift_retain(P)
+    return S_OK
+  }
+
+  // IUnknown returns the primary interface pointer at P[-2].
+  if riid == IUnknown.IID {
+    ppvObject.pointee = P.advanced(by: -2 * stride)
+    _ = swift_retain(P)
+    return S_OK
+  }
+
+  // Walk the conformance table. Entry i maps to P[-(i + 2)].
+  // ISwiftObject.IID serves as a sentinel: the fast path above already
+  // handled the match case, so hitting it here terminates the scan.
+  for offset in 0 ..< table.count {
+    let iid = table[offset]
+
+    guard iid == riid else {
+      if iid == ISwiftObject.IID { break }
+      continue
+    }
+
+    ppvObject.pointee = P.advanced(by: -(offset + 2) * stride)
+    _ = swift_retain(P)
+    return S_OK
+  }
+
+  // COMInterfaceResolver callback — AnyObject cast only on this fallback path.
+  let object = Unmanaged<AnyObject>.fromOpaque(P).takeUnretainedValue()
+  if let resolver = object as? COMInterfaceResolver,
+     let pointer = resolver.resolve(riid) {
+    ppvObject.pointee = pointer
+
+    typealias AddRef = @convention(c) (UnsafeMutableRawPointer) -> UInt32
+    let lpVtbl = pointer.load(as: UnsafePointer<UnsafeRawPointer>.self)
+    _ = unsafeBitCast(lpVtbl[1], to: AddRef.self)(pointer)
+
+    return S_OK
+  }
+
+  ppvObject.pointee = nil
+  return E_NOINTERFACE
+}
+
+// MARK: - AddRef
+
+/// Non-delegating `AddRef`.
+///
+/// Used by the compiler for `@com` classes that do not conform to
+/// `COMAggregatable`. Recovers `P` via `vtable[-1]` and calls
+/// `swift_retainReturningCount` directly. No dynamic checks.
+@_alwaysEmitIntoClient
+public func AddRef(_ pUnk: UnsafeMutableRawPointer) -> UInt32 {
+  let vtable = pUnk.load(as: UnsafePointer<UnsafeRawPointer>.self)
+  let P = pUnk.advanced(by: Int(bitPattern: vtable.advanced(by: -1).pointee))
+  return UInt32(truncatingIfNeeded: swift_retainReturningCount(P))
+}
+
+// MARK: - Release
+
+/// Non-delegating `Release`.
+///
+/// Used by the compiler for `@com` classes that do not conform to
+/// `COMAggregatable`. Recovers `P` via `vtable[-1]` and calls
+/// `swift_releaseReturningCount` directly. No dynamic checks.
+@_alwaysEmitIntoClient
+public func Release(_ pUnk: UnsafeMutableRawPointer) -> UInt32 {
+  let vtable = pUnk.load(as: UnsafePointer<UnsafeRawPointer>.self)
+  let P = pUnk.advanced(by: Int(bitPattern: vtable.advanced(by: -1).pointee))
+  return UInt32(truncatingIfNeeded: swift_releaseReturningCount(P))
+}

--- a/Runtimes/Supplemental/COM/Sources/COM/ManagedObject.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/ManagedObject.swift
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+private import Builtin
+
+/// Converts between a COM interface reference and its ABI pointer.
+///
+/// Use `takeRetainedValue(_:)` to adopt a "+1" interface pointer returned by a
+/// COM operation. Use `passUnretained(_:)` to borrow the pointer represented by
+/// an existing interface reference without changing its reference count.
+@unsafe
+public enum ManagedObject<Interface> where Interface.Type: COMInterface {
+  /// Adopts a "+1" COM interface pointer as a managed interface reference.
+  @_transparent
+  public static func takeRetainedValue(_ pointer: UnsafeMutableRawPointer)
+      -> Interface {
+    return Builtin.takeFromRawPointer(pointer._rawValue)
+  }
+
+  /// Adopts an optional "+1" COM interface pointer.
+  @_transparent
+  public static func takeRetainedValue(_ pointer: UnsafeMutableRawPointer?)
+      -> Interface? {
+    guard let pointer else { return nil }
+    return takeRetainedValue(pointer)
+  }
+
+  /// Adopts an optional typed "+1" COM interface pointer.
+  @_transparent
+  public static func takeRetainedValue<Pointee>(_ pointer: UnsafeMutablePointer<Pointee>?)
+      -> Interface? {
+    guard let pointer else { return nil }
+    return takeRetainedValue(UnsafeMutableRawPointer(pointer))
+  }
+
+  /// Borrows the ABI pointer represented by a COM interface reference.
+  @_transparent
+  public static func passUnretained(_ interface: borrowing Interface)
+      -> UnsafeMutableRawPointer {
+    return UnsafeMutableRawPointer(Builtin.bridgeToRawPointer(interface))
+  }
+}

--- a/Runtimes/Supplemental/COM/Sources/COM/SwiftRuntime.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/SwiftRuntime.swift
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// MARK: - Runtime Imports
+
+/// Retains the object and returns the new strong reference count.
+///
+/// This is the COM "CountingRR" entry point — distinct from the runtime's
+/// `swift_retain`, which the compiler emits and whose return value the ABI
+/// cannot widen on Windows x64. The COM `AddRef`/`Release` vtable thunks need
+/// the post-operation count, so they use these dedicated entries instead.
+@usableFromInline
+@_extern(c, "swift_retainReturningCount")
+internal func swift_retainReturningCount(_: UnsafeMutableRawPointer) -> Int
+
+/// Releases the object and returns the new strong reference count
+/// (`0` indicates the object was deallocated).
+@usableFromInline
+@_extern(c, "swift_releaseReturningCount")
+internal func swift_releaseReturningCount(_: UnsafeMutableRawPointer) -> Int

--- a/Runtimes/Supplemental/COM/Sources/COM/SwiftRuntime.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/SwiftRuntime.swift
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// MARK: - Runtime Imports
+
+/// The normal runtime retain.  Returns the object pointer (the runtime marks
+/// the argument `returned`); callers needing only the side effect ignore it.
+/// Used for COM `AddRef`-on-return where the resulting count isn't needed —
+/// e.g. `QueryInterface` retaining the interface pointer it hands back.
+///
+/// Referencing the reserved `swift_retain` symbol directly is intentional and
+/// the accompanying diagnostic is expected: this module is part of the Swift
+/// runtime.  `AddRef`/`Release`, which must return the count, use the
+/// `*ReturningCount` entries below.
+@usableFromInline
+@_extern(c, "swift_retain")
+internal func swift_retain(_: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer
+
+/// Retains the object and returns the new strong reference count.
+///
+/// This is the COM "CountingRR" entry point — distinct from the runtime's
+/// `swift_retain`, which the compiler emits and whose return value the ABI
+/// cannot widen on Windows x64. The COM `AddRef`/`Release` vtable thunks need
+/// the post-operation count, so they use these dedicated entries instead.
+@usableFromInline
+@_extern(c, "swift_retainReturningCount")
+internal func swift_retainReturningCount(_: UnsafeMutableRawPointer) -> Int
+
+/// Releases the object and returns the new strong reference count
+/// (`0` indicates the object was deallocated).
+@usableFromInline
+@_extern(c, "swift_releaseReturningCount")
+internal func swift_releaseReturningCount(_: UnsafeMutableRawPointer) -> Int

--- a/Runtimes/Supplemental/COM/Sources/COM/TearOffInterfaces.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/TearOffInterfaces.swift
@@ -1,0 +1,189 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+private import Synchronization
+
+/// A tear-off interface implementation that is created on first
+/// `QueryInterface` and cached for the lifetime of the owning object.
+///
+/// `CachedTearOff` is used with ``COMInterfaceResolver`` to lazily provide a
+/// COM interface that is expensive to set up but stateless once created. The
+/// first call to ``resolve(_:)`` matching the interface's IID creates the
+/// implementation; subsequent calls return the cached instance.
+///
+/// The tear-off delegates its `IUnknown` to the owning object (the
+/// controlling-unknown pattern), satisfying the COM identity rule:
+/// `QueryInterface` for `IUnknown` on the tear-off returns the owner's primary
+/// interface pointer.
+///
+/// ```swift
+/// @com(implementation: "...")
+/// final class CImplementation: IInterface, COMInterfaceResolver {
+///     private var accessibility = CachedTearOff<IAccessible> {
+///         AccessibilityImpl(owner: self)
+///     }
+///
+///     func resolve(_ iid: borrowing IID) -> UnsafeMutableRawPointer? {
+///         accessibility.resolve(iid)
+///     }
+/// }
+/// ```
+public struct CachedTearOff<Interface> where Interface.Type: COMInterface {
+  private let factory: () -> Interface
+  private var instance: Interface?
+
+  /// Creates a cached tear-off that will use `factory` to create the
+  /// implementation on first query.
+  ///
+  /// The factory is called at most once. The returned object must delegate its
+  /// `IUnknown` to the owning object's controlling unknown.
+  ///
+  /// - Parameter factory: A closure that creates the tear-off implementation.
+  public init(_ factory: @escaping () -> Interface) {
+    self.factory = factory
+    self.instance = nil
+  }
+
+  /// Returns the COM interface pointer if `iid` matches `T.IID`, or `nil`
+  /// otherwise.
+  ///
+  /// On the first matching call, the factory is invoked and the result is
+  /// cached. Subsequent calls return the cached instance.
+  ///
+  /// - Parameter iid: The interface identifier being queried.
+  /// - Returns: A COM interface pointer, or `nil` if `iid` does not match
+  ///   `T.IID`.
+  public mutating func resolve(_ riid: borrowing IID) -> UnsafeMutableRawPointer? {
+    guard riid == Interface.IID else { return nil }
+    if instance == nil {
+      instance = factory()
+    }
+    guard let instance else { return nil }
+    return UnsafeMutableRawPointer(instance)
+  }
+}
+
+/// A thread-safe variant of `CachedTearOff` for free-threaded objects.
+///
+/// `AtomicCachedTearOff` provides the same semantics as `CachedTearOff` —
+/// created on first `QueryInterface`, cached for the owner's lifetime — but
+/// uses atomic initialization to handle concurrent `QueryInterface` calls
+/// safely. On the post-initialization fast path, the cost is a single atomic
+/// load.
+///
+/// Use `AtomicCachedTearOff` for `@com` classes with `ThreadingModel: .free`,
+/// `.both`, or `.neutral`, where COM permits concurrent calls. For
+/// apartment-threaded objects, prefer `CachedTearOff` (no synchronization
+/// overhead).
+///
+/// ```swift
+/// @com(implementation: "...", threading: .both)
+/// final class CImplementation: IInterface, COMInterfaceResolver {
+///     private let accessibility = AtomicCachedTearOff<IAccessible> {
+///         AccessibilityImpl(owner: self)
+///     }
+///
+///     func resolve(_ iid: borrowing IID) -> UnsafeMutableRawPointer? {
+///         accessibility.resolve(iid)
+///     }
+/// }
+/// ```
+public struct AtomicCachedTearOff<Interface>: ~Copyable where Interface.Type: COMInterface {
+  private let factory: () -> Interface
+  private let state: Mutex<Interface?>
+
+  /// Creates an atomic cached tear-off that will use `factory` to create the
+  /// implementation on first query.
+  ///
+  /// The factory is called at most once. The returned object must delegate its
+  /// `IUnknown` to the owning object's controlling unknown via `COMAggregatable`.
+  ///
+  /// - Parameter factory: A closure that creates the tear-off implementation.
+  public init(_ factory: @escaping () -> Interface) {
+    self.factory = factory
+    self.state = Mutex(nil)
+  }
+
+  /// Returns the COM interface pointer if `iid` matches `T.IID`, or `nil`
+  /// otherwise.
+  ///
+  /// On the first matching call, the factory is invoked under a lock and the
+  /// result is cached. Subsequent calls return the cached instance.
+  ///
+  /// - Parameter iid: The interface identifier being queried.
+  /// - Returns: A COM interface pointer, or `nil` if `iid` does not match
+  ///   `T.IID`.
+  public func resolve(_ riid: borrowing IID) -> UnsafeMutableRawPointer? {
+    guard riid == Interface.IID else { return nil }
+    let instance = state.withLock { cached -> Interface in
+      if let cached { return cached }
+      let new = factory()
+      cached = new
+      return new
+    }
+    return UnsafeMutableRawPointer(instance)
+  }
+}
+
+/// A tear-off interface implementation that creates a fresh instance on every
+/// `QueryInterface`.
+///
+/// `DisposableTearOff` is used with ``COMInterfaceResolver`` to provide a COM
+/// interface where each caller receives its own independently reference-counted
+/// instance. This is suited to interfaces that hold per-caller state (e.g.,
+/// enumerators, connection points).
+///
+/// Each instance returned by ``resolve(_:)`` delegates its `IUnknown` to the
+/// owning object (the controlling-unknown pattern), satisfying the COM identity
+/// rule.
+///
+/// ```swift
+/// @com(implementation: "...")
+/// final class CImplementation: IInterface, COMInterfaceResolver {
+///     private let connectionPoint = DisposableTearOff<IConnectionPoint> {
+///         ConnectionPointImpl()
+///     }
+///
+///     func resolve(_ iid: borrowing IID) -> UnsafeMutableRawPointer? {
+///         connectionPoint.resolve(iid)
+///     }
+/// }
+/// ```
+public struct DisposableTearOff<Interface> where Interface.Type: COMInterface {
+  private let factory: () -> Interface
+
+  /// Creates a disposable tear-off that will use `factory` to create a fresh
+  /// implementation on every query.
+  ///
+  /// Each invocation of the factory must return a new instance. The returned
+  /// object must delegate its `IUnknown` to the owning object's controlling
+  /// unknown.
+  ///
+  /// - Parameter factory: A closure that creates a tear-off implementation.
+  public init(_ factory: @escaping () -> Interface) {
+    self.factory = factory
+  }
+
+  /// Returns a fresh COM interface pointer if `iid` matches `T.IID`, or `nil`
+  /// otherwise.
+  ///
+  /// Each call creates a new instance via the factory. The caller receives an
+  /// independently reference-counted object.
+  ///
+  /// - Parameter iid: The interface identifier being queried.
+  /// - Returns: A COM interface pointer to a new instance, or `nil` if `iid`
+  ///   does not match `T.IID`.
+  public func resolve(_ riid: borrowing IID) -> UnsafeMutableRawPointer? {
+    guard riid == Interface.IID else { return nil }
+    return UnsafeMutableRawPointer(factory())
+  }
+}

--- a/Runtimes/Supplemental/COM/Sources/COM/TearOffInterfaces.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/TearOffInterfaces.swift
@@ -1,0 +1,199 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+private import Synchronization
+
+/// A tear-off interface implementation that is created on first
+/// `QueryInterface` and cached for the lifetime of the owning object.
+///
+/// `CachedTearOff` is used with ``COMInterfaceResolver`` to lazily provide a
+/// COM interface that is expensive to set up but stateless once created. The
+/// first call to ``resolve(_:)`` matching the interface's IID creates the
+/// implementation; subsequent calls return the cached instance.
+///
+/// The tear-off's identity relationship to its owner is determined by the active
+/// object model. Models with a controlling identity interface can use their
+/// aggregation policy; rootless models can expose an independent object.
+///
+/// ```swift
+/// @com(implementation: "...")
+/// final class CImplementation: IInterface, COMInterfaceResolver {
+///     private var accessibility = CachedTearOff<IAccessible> {
+///         AccessibilityImpl(owner: self)
+///     }
+///
+///     func resolve(_ iid: borrowing IID) -> COMInterfaceResolution? {
+///         accessibility.resolve(iid)
+///     }
+/// }
+/// ```
+public struct CachedTearOff<Interface>: ~Copyable where Interface.Type: COMInterface {
+  private var factory: (() -> Interface)?
+  private var instance: Interface?
+
+  /// Creates a cached tear-off that will use `factory` to create the
+  /// implementation on first query.
+  ///
+  /// The factory is called at most once. The returned object must follow the
+  /// active object model's identity policy.
+  ///
+  /// - Parameter factory: A closure that creates the tear-off implementation.
+  public init(_ factory: consuming @escaping () -> Interface) {
+    self.factory = factory
+    self.instance = nil
+  }
+
+  /// Returns the COM interface pointer if `iid` matches `Interface.IID`, or
+  /// `nil` otherwise.
+  ///
+  /// On the first matching call, the factory is invoked and the result is
+  /// cached. Subsequent calls return the cached instance.
+  ///
+  /// - Parameter iid: The interface identifier being queried.
+  /// - Returns: An owned COM interface result, or `nil` if `iid` does not match
+  ///   `Interface.IID`.
+  public mutating func resolve(_ riid: borrowing IID) -> COMInterfaceResolution? {
+    guard riid == Interface.IID else { return nil }
+    if let instance {
+      return COMInterfaceResolution(instance)
+    }
+    guard let factory else {
+      preconditionFailure("cached tear-off has no factory or instance")
+    }
+    let instance = factory()
+    self.factory = nil
+    self.instance = instance
+    return COMInterfaceResolution(instance)
+  }
+}
+
+private struct AtomicCachedTearOffState<Interface>: ~Copyable {
+  var factory: (() -> Interface)?
+  var instance: Interface?
+}
+
+/// A thread-safe variant of `CachedTearOff` for free-threaded objects.
+///
+/// `AtomicCachedTearOff` provides the same semantics as `CachedTearOff` —
+/// created on first `QueryInterface`, cached for the owner's lifetime — but
+/// uses a mutex to handle concurrent `QueryInterface` calls safely. The
+/// post-initialization path reads the cached instance while holding that lock.
+///
+/// Use `AtomicCachedTearOff` whenever the active object model permits concurrent
+/// interface discovery. For externally serialized objects, prefer `CachedTearOff`
+/// and avoid the synchronization overhead.
+///
+/// ```swift
+/// @com(implementation: "...", threading: .both)
+/// final class CImplementation: IInterface, COMInterfaceResolver {
+///     private let accessibility = AtomicCachedTearOff<IAccessible> {
+///         AccessibilityImpl(owner: self)
+///     }
+///
+///     func resolve(_ iid: borrowing IID) -> COMInterfaceResolution? {
+///         accessibility.resolve(iid)
+///     }
+/// }
+/// ```
+public struct AtomicCachedTearOff<Interface>: ~Copyable where Interface.Type: COMInterface {
+  private let state: Mutex<AtomicCachedTearOffState<Interface>>
+
+  /// Creates an atomic cached tear-off that will use `factory` to create the
+  /// implementation on first query.
+  ///
+  /// The factory is called at most once. The returned object must follow the
+  /// active object model's identity policy.
+  ///
+  /// - Parameter factory: A closure that creates the tear-off implementation.
+  public init(_ factory: consuming @escaping () -> Interface) {
+    self.state = Mutex(AtomicCachedTearOffState(factory: factory,
+                                                instance: nil))
+  }
+
+  /// Returns the COM interface pointer if `iid` matches `Interface.IID`, or `nil`
+  /// otherwise.
+  ///
+  /// On the first matching call, the factory is invoked under a lock and the
+  /// result is cached. Subsequent calls return the cached instance.
+  ///
+  /// - Parameter iid: The interface identifier being queried.
+  /// - Returns: An owned COM interface result, or `nil` if `iid` does not match
+  ///   `Interface.IID`.
+  public func resolve(_ riid: borrowing IID) -> COMInterfaceResolution? {
+    guard riid == Interface.IID else { return nil }
+    return state.withLock { state -> COMInterfaceResolution in
+      if let instance = state.instance {
+        return COMInterfaceResolution(instance)
+      }
+      guard let factory = state.factory else {
+        preconditionFailure("cached tear-off has no factory or instance")
+      }
+      let instance = factory()
+      state.factory = nil
+      state.instance = instance
+      return COMInterfaceResolution(instance)
+    }
+  }
+}
+
+/// A tear-off interface implementation that creates a fresh instance on every
+/// `QueryInterface`.
+///
+/// `DisposableTearOff` is used with ``COMInterfaceResolver`` to provide a COM
+/// interface where each caller receives its own independently reference-counted
+/// instance. This is suited to interfaces that hold per-caller state (e.g.,
+/// enumerators, connection points).
+///
+/// Each instance returned by ``resolve(_:)`` delegates its `IUnknown` to the
+/// owning object (the controlling-unknown pattern), satisfying the COM identity
+/// rule.
+///
+/// ```swift
+/// @com(implementation: "...")
+/// final class CImplementation: IInterface, COMInterfaceResolver {
+///     private let connectionPoint = DisposableTearOff<IConnectionPoint> {
+///         ConnectionPointImpl()
+///     }
+///
+///     func resolve(_ iid: borrowing IID) -> COMInterfaceResolution? {
+///         connectionPoint.resolve(iid)
+///     }
+/// }
+/// ```
+public struct DisposableTearOff<Interface> where Interface.Type: COMInterface {
+  private let factory: () -> Interface
+
+  /// Creates a disposable tear-off that will use `factory` to create a fresh
+  /// implementation on every query.
+  ///
+  /// Each invocation of the factory must return a new instance. The returned
+  /// object must follow the active object model's identity policy.
+  ///
+  /// - Parameter factory: A closure that creates a tear-off implementation.
+  public init(_ factory: consuming @escaping () -> Interface) {
+    self.factory = factory
+  }
+
+  /// Returns a fresh COM interface pointer if `iid` matches `Interface.IID`, or
+  /// `nil` otherwise.
+  ///
+  /// Each call creates a new instance via the factory. The caller receives an
+  /// independently reference-counted object.
+  ///
+  /// - Parameter iid: The interface identifier being queried.
+  /// - Returns: An owned COM interface result for a new instance, or `nil` if
+  ///   `iid` does not match `Interface.IID`.
+  public func resolve(_ riid: borrowing IID) -> COMInterfaceResolution? {
+    guard riid == Interface.IID else { return nil }
+    return COMInterfaceResolution(factory())
+  }
+}

--- a/Runtimes/Supplemental/COM/Sources/COM/ThreadingModel.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/ThreadingModel.swift
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// The COM apartment threading model for an activatable coclass.
+///
+/// The threading model declares how the COM runtime should handle concurrent
+/// access to instances of the class. It is specified via
+/// `@com(implementation:, threading:)` and written to the Windows registry by
+/// the synthesised `DllRegisterServer` (for DLL servers) or used with
+/// `CoRegisterClassObject` (for EXE servers).
+///
+/// The threading model is only meaningful on `@com` classes that carry a
+/// `CLSID:`. Bare `@com` classes without a `CLSID:` are not registered with
+/// the COM runtime and express their thread safety through Swift's own
+/// concurrency model (actors, `Sendable`).
+///
+/// On `@com` actors, `.apartment` is implied and `.free` or `.both` is a
+/// compile-time error, because actor isolation already provides the
+/// serialisation that apartment threading requires.
+public enum COMThreadingModel: Int {
+  /// Single threading. The object lives on the main STA thread (thread 0)
+  /// and all calls are marshalled there. This is the most restrictive model,
+  /// used for legacy objects that must run on the process's main thread.
+  /// Corresponds to `@MainActor` semantics in Swift.
+  case single
+
+  /// Apartment threading. The object lives on a single STA thread, and COM
+  /// serialises calls through that thread's message loop. Only one thread
+  /// may call the object at a time. This is the default threading model.
+  case apartment
+
+  /// Free threading. Any thread may call the object concurrently.
+  /// The implementation must provide its own synchronisation.
+  case free
+
+  /// Compatible with both apartment and free threading. COM may place the
+  /// object in whichever apartment type the caller is in. The implementation
+  /// must be thread-safe.
+  case both
+
+  /// Neutral Apartment (COM+). Calls execute on the calling thread without
+  /// thread switching or message-loop involvement. The implementation must
+  /// be thread-safe.
+  case neutral
+}
+
+extension COMThreadingModel {
+  /// Alias for `.apartment`.
+  ///
+  /// Preserve `STA` alias as it is what developers use. `apartment` is the
+  /// proper name, and `STA` is the mirror for `MTA` which was introduced with
+  /// the multithreaded COM.
+  @available(*, deprecated, renamed: "apartment")
+  public static var sta: Self { .apartment }
+
+  /// Alias for `.free`.
+  ///
+  /// Preserve `MTA` alias as it is what developers use. `free` is the
+  /// proper name.
+  @available(*, deprecated, renamed: "free")
+  public static var mta: Self { .free }
+}
+
+extension COMThreadingModel: Sendable {
+}

--- a/Runtimes/Supplemental/COM/Sources/COM/ThreadingModel.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/ThreadingModel.swift
@@ -1,0 +1,80 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if $_MicrosoftCOM
+
+/// The COM apartment threading model for an activatable coclass.
+///
+/// The threading model declares how the COM runtime should handle concurrent
+/// access to instances of the class. It is specified via
+/// `@com(implementation:, threading:)` and written to the Windows registry by
+/// the synthesised `DllRegisterServer` (for DLL servers) or used with
+/// `CoRegisterClassObject` (for EXE servers).
+///
+/// The threading model is only meaningful on `@com` classes that carry a
+/// `CLSID:`. Bare `@com` classes without a `CLSID:` are not registered with
+/// the COM runtime and express their thread safety through Swift's own
+/// concurrency model (actors, `Sendable`).
+///
+/// On `@com` actors, `.apartment` is implied and `.free` or `.both` is a
+/// compile-time error, because actor isolation already provides the
+/// serialisation that apartment threading requires.
+public enum COMThreadingModel: Int {
+  /// Single threading. The object lives on the main STA thread (thread 0)
+  /// and all calls are marshalled there. This is the most restrictive model,
+  /// used for legacy objects that must run on the process's main thread.
+  /// Corresponds to `@MainActor` semantics in Swift.
+  case single
+
+  /// Apartment threading. The object lives on a single STA thread, and COM
+  /// serialises calls through that thread's message loop. Only one thread
+  /// may call the object at a time. This is the default threading model.
+  case apartment
+
+  /// Free threading. Any thread may call the object concurrently.
+  /// The implementation must provide its own synchronisation.
+  case free
+
+  /// Compatible with both apartment and free threading. COM may place the
+  /// object in whichever apartment type the caller is in. The implementation
+  /// must be thread-safe.
+  case both
+
+  /// Neutral Apartment (COM+). Calls execute on the calling thread without
+  /// thread switching or message-loop involvement. The implementation must
+  /// be thread-safe.
+  case neutral
+}
+
+extension COMThreadingModel {
+  /// Alias for `.apartment`.
+  ///
+  /// Preserve `STA` alias as it is what developers use. `apartment` is the
+  /// proper name, and `STA` is the mirror for `MTA` which was introduced with
+  /// the multithreaded COM.
+  @available(*, deprecated, renamed: "apartment")
+  @_transparent
+  public static var sta: Self { .apartment }
+
+  /// Alias for `.free`.
+  ///
+  /// Preserve `MTA` alias as it is what developers use. `free` is the
+  /// proper name.
+  @available(*, deprecated, renamed: "free")
+  @_transparent
+  public static var mta: Self { .free }
+}
+
+extension COMThreadingModel: Sendable {
+}
+
+#endif

--- a/Runtimes/Supplemental/COM/Sources/COM/UnsafeMutableRawPointer+COM.swift
+++ b/Runtimes/Supplemental/COM/Sources/COM/UnsafeMutableRawPointer+COM.swift
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+extension UnsafeMutableRawPointer {
+  /// Creates a raw pointer from the COM interface pointer of a `@com` object.
+  ///
+  /// The returned pointer points to the vtable pointer in the object's COM block.
+  /// It is borrowed and valid for the lifetime of the object. No `AddRef` is performed.
+  ///
+  /// - Parameter unknown: The COM object to extract the interface pointer from.
+  @_transparent
+  @usableFromInline
+  internal init<Interface>(_ pUnk: borrowing Interface) where Interface.Type: COMInterface {
+    // A `@com` object's Swift reference is its heap-object pointer `P`; the
+    // primary COM interface pointer is the vtable-pointer slot at `P[-2]`.
+    // `passUnretained(_:).toOpaque()` is the inverse of the `fromOpaque(_:)`
+    // recovery used elsewhere in the module and performs no retain.
+    self = unsafeBitCast(pUnk, to: UnsafeMutableRawPointer.self)
+  }
+}

--- a/Runtimes/Supplemental/COM/Sources/Concurrency.swiftoverlay
+++ b/Runtimes/Supplemental/COM/Sources/Concurrency.swiftoverlay
@@ -1,0 +1,3 @@
+  version: 1
+  modules:
+    - name: _COM_Concurrency

--- a/Runtimes/Supplemental/COM/Sources/_COM_Concurrency/CMakeLists.txt
+++ b/Runtimes/Supplemental/COM/Sources/_COM_Concurrency/CMakeLists.txt
@@ -1,0 +1,23 @@
+add_library(swift_COM_Concurrency
+  COMActivation.swift
+  "COMContext+Concurrency.swift")
+set_target_properties(swift_COM_Concurrency PROPERTIES
+  Swift_MODULE_NAME _COM_Concurrency)
+target_link_libraries(swift_COM_Concurrency PRIVATE
+  swiftCore
+  swift_Concurrency
+  swiftSynchronization
+  swiftCOM
+  $<$<PLATFORM_ID:Windows>:swiftWinSDK>
+  $<$<BOOL:${SwiftSwiftDirectRuntime_FOUND}>:swiftSwiftDirectRuntime>)
+
+install(TARGETS swift_COM_Concurrency
+  EXPORT SwiftSupplementalTargets
+  COMPONENT ${PROJECT_NAME}_runtime
+  ARCHIVE DESTINATION "${${PROJECT_NAME}_INSTALL_LIBDIR}"
+  LIBRARY DESTINATION "${${PROJECT_NAME}_INSTALL_LIBDIR}"
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+emit_swift_interface(swift_COM_Concurrency)
+install_swift_interface(swift_COM_Concurrency)
+
+embed_manifest(swift_COM_Concurrency)

--- a/Runtimes/Supplemental/COM/Sources/_COM_Concurrency/COMActivation.swift
+++ b/Runtimes/Supplemental/COM/Sources/_COM_Concurrency/COMActivation.swift
@@ -1,0 +1,166 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if $_MicrosoftCOM
+
+/// # COM Activation — Asynchronous Model
+///
+/// The `async` overloads mirror the synchronous surface for use from Swift
+/// concurrency, with one categorical difference: they operate only in the
+/// multithreaded apartment (MTA).
+///
+/// ## Why `async` implies the MTA
+///
+/// A task can suspend at any `await` and resume on a different cooperative-pool
+/// thread. COM's apartment models react to that migration very differently:
+///
+/// - term Single-threaded apartment (STA): objects have thread affinity — a
+///   reference is valid only on the thread and apartment that created it. Held
+///   across a suspension point, it is called from the wrong thread on resume,
+///   which is undefined; a correct cross-apartment call needs marshaling that a
+///   raw interface pointer does not perform.
+/// - term Multithreaded apartment (MTA): a single apartment shared by every MTA
+///   thread in the process. A reference produced there — a free-threaded
+///   pointer, or a marshaled proxy to a host STA — is callable from any MTA
+///   thread, and with an implicit MTA established every cooperative-pool worker
+///   acts as an MTA member.
+///
+/// An interface activated in the MTA therefore survives task migration; one
+/// activated in an STA does not. The async surface is MTA-only, and the STA is
+/// not expressible on it.
+///
+/// ## Entry and establishment — ``withCOMContext(activation:server:_:)``
+///
+/// Enter the async COM context with `try await withCOMContext { … }`. It
+/// publishes the activation options as a task-local and keeps an implicit MTA
+/// alive for the body's duration via `CoIncrementMTAUsage`.
+///
+/// - Important: It does not call `CoInitializeEx` and does not enter an
+///   apartment. `CoInitializeEx`/`CoUninitialize` are thread-affine and must
+///   balance on one thread; across an `await` the init and the uninit would
+///   land on different threads — leaking the first, mismatching the second.
+///   `CoIncrementMTAUsage` has no thread affinity — its cookie may be released
+///   on any thread — which is precisely why it, and not apartment
+///   initialization, is the async establishment primitive.
+///
+/// The context is reference-counted and nests cleanly: an inner
+/// `withCOMContext` under ``COMMain`` or another enclosing context is a harmless
+/// increment over a context that never drops.
+///
+/// ## The async surface
+///
+/// The `async` overloads of ``CoCreateInstance`` and ``CoCreateInstanceEx``
+/// match their synchronous counterparts in shape and defaults, with three
+/// deliberate omissions:
+///
+/// - No apartment parameter — async is MTA-only, and the STA cannot be named
+///   because it cannot survive migration.
+/// - No aggregation — it is in-process, synchronous, and apartment-affine, so it
+///   stays on ``CoCreateInstance(_:activation:aggregating:)``.
+/// - No single-interface `Ex` — single-interface activation is
+///   ``CoCreateInstance``; `Ex` is strictly the multi-interface form.
+///
+/// Results are ordinary escapable interfaces whose lifetime is governed by their
+/// own reference count, not by the `withCOMContext` scope. That is correct under
+/// a process-lifetime context such as ``COMMain``, where the MTA outlives any
+/// single call.
+///
+/// - Warning: When `withCOMContext` is the *only* thing keeping the MTA alive,
+///   an interface must not outlive that scope: once the context releases its
+///   `CoIncrementMTAUsage`, an escaped object has no live apartment behind it.
+///   Under ``COMMain`` or an enclosing context this cannot happen; for a bounded
+///   region with no such backstop, keep activated objects inside the scope.
+///
+/// ## Blocking
+///
+/// Activation can block — spawning a local server, or a network round-trip to a
+/// remote one. All async activation routes through a single seam that relies on
+/// the ambient MTA and is the one place such work may be moved off the
+/// cooperative pool; in-process activation can run inline.
+///
+/// ## When to prefer `async`
+///
+/// - Use the async surface when activation may block and you are already within
+///   an MTA context (``COMMain`` or `withCOMContext`).
+/// - Use the *synchronous* `withCOMContext`, which can enter an STA, when you
+///   need apartment-threaded objects — many UI and shell interfaces. Those
+///   cannot be activated or held on the async surface.
+///
+/// - SeeAlso: The synchronous activation model.
+
+private import COM
+public import WinSDK
+
+@_transparent
+public func CoCreateInstance<Interface>(_ clsid: borrowing COM.CLSID,
+                                        activation options: consuming COMActivationOptions = COMActivationOptions.current,
+                                        as interface: Interface.Type = Interface.self)
+    async throws(COMError) -> Interface where Interface.Type: COMInterface {
+  return try COM.CoCreateInstance(clsid, activation: options,
+                                  as: interface)
+}
+
+@_transparent
+public func CoCreateInstance<Interface>(_ clsid: borrowing WinSDK.GUID,
+                                        activation options: consuming COMActivationOptions = COMActivationOptions.current,
+                                        as interface: Interface.Type = Interface.self)
+    async throws(COMError) -> Interface where Interface.Type: COMInterface {
+  return try await CoCreateInstance(CLSID(clsid), activation: options,
+                                    as: interface)
+}
+
+@_transparent
+public func CoCreateInstance<Implementation, Interface>(_ implementation: Implementation.Type,
+                                                        activation options: consuming COMActivationOptions = COMActivationOptions.current,
+                                                        as interface: Interface.Type = Interface.self)
+    async throws(COMError) -> Interface
+    where Implementation.Type: COMActivatable, Interface.Type: COMInterface {
+  return try await CoCreateInstance(Implementation.CLSID, activation: options,
+                                    as: interface)
+}
+
+@_transparent
+public func CoCreateInstanceEx<PrimaryInterface, each SecondaryInterface>(_ clsid: borrowing COM.CLSID,
+                                                                          activation options: consuming COMActivationOptions = COMActivationOptions.current,
+                                                                          requesting first: PrimaryInterface.Type,
+                                                                          _ interfaces: repeat (each SecondaryInterface).Type)
+    async throws(COMError) -> (PrimaryInterface?, repeat (each SecondaryInterface)?)
+    where PrimaryInterface.Type: COMInterface, repeat (each SecondaryInterface).Type: COMInterface {
+  return try COM.CoCreateInstanceEx(clsid, activation: options,
+                                    requesting: first, repeat each interfaces)
+}
+
+@_transparent
+public func CoCreateInstanceEx<PrimaryInterface, each SecondaryInterface>(_ clsid: borrowing WinSDK.GUID,
+                                                                          activation options: consuming COMActivationOptions = COMActivationOptions.current,
+                                                                          requesting first: PrimaryInterface.Type,
+                                                                          _ interfaces: repeat (each SecondaryInterface).Type)
+    async throws(COMError) -> (PrimaryInterface?, repeat (each SecondaryInterface)?)
+    where PrimaryInterface.Type: COMInterface, repeat (each SecondaryInterface).Type: COMInterface {
+  return try await CoCreateInstanceEx(CLSID(clsid), activation: options,
+                                      requesting: first, repeat each interfaces)
+}
+
+@_transparent
+public func CoCreateInstanceEx<Implementation, PrimaryInterface, each SecondaryInterface>(_ implementation: Implementation.Type,
+                                                                                          activation options: consuming COMActivationOptions = COMActivationOptions.current,
+                                                                                          requesting first: PrimaryInterface.Type,
+                                                                                          _ interfaces: repeat (each SecondaryInterface).Type)
+    async throws(COMError) -> (PrimaryInterface?, repeat (each SecondaryInterface)?)
+    where Implementation.Type: COMActivatable,
+        PrimaryInterface.Type: COMInterface,
+        repeat (each SecondaryInterface).Type: COMInterface {
+  return try await CoCreateInstanceEx(Implementation.CLSID, activation: options,
+                                      requesting: first, repeat each interfaces)
+}
+
+#endif

--- a/Runtimes/Supplemental/COM/Sources/_COM_Concurrency/COMContext+Concurrency.swift
+++ b/Runtimes/Supplemental/COM/Sources/_COM_Concurrency/COMContext+Concurrency.swift
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if $_MicrosoftCOM
+
+public import COM
+public import _Concurrency
+public import WinSDK
+
+extension COMActivationOptions {
+  /// The activation options inherited by the current task and its child tasks.
+  @TaskLocal
+  public static var current: COMActivationOptions = .default
+}
+
+/// Runs an asynchronous operation in the process multithreaded apartment.
+///
+/// An asynchronous task may resume on a different worker thread, so this
+/// overload cannot establish a thread-bound single-threaded apartment. Use the
+/// synchronous overload from `COM` for an apartment-threaded context.
+// TODO(compnerd): use `~Copyable` for `Result` when `withValue` permits it.
+@_alwaysEmitIntoClient
+public func withCOMContext<Result>(activation: COM.CLSCTX = .all,
+                                   server: consuming COMServerInfo? = nil,
+                                   _ body: () async throws -> sending Result)
+    async throws -> sending Result {
+  let activation = COMActivationOptions(context: activation, server: server)
+  return try await COMActivationOptions.$current.withValue(activation) {
+    var cookie: CO_MTA_USAGE_COOKIE?
+    let hr = CoIncrementMTAUsage(&cookie)
+    guard SUCCEEDED(hr), let cookie else {
+      throw COMError(hr: hr)
+    }
+    defer {
+      let hr = CoDecrementMTAUsage(cookie)
+      precondition(SUCCEEDED(hr))
+    }
+    return try await body()
+  }
+}
+
+#endif // $_MicrosoftCOM

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -849,6 +849,7 @@ enum Project {
   BootstrapRuntimeModule
   BootstrapStringProcessing
   BootstrapSynchronization
+  BootstrapCOM
   BootstrapDistributed
   BootstrapObservation
   BootstrapDifferentiation
@@ -909,6 +910,7 @@ enum Project {
   DynamicRuntimeModule
   DynamicStringProcessing
   DynamicSynchronization
+  DynamicCOM
   DynamicDistributed
   DynamicObservation
   DynamicDispatch
@@ -921,6 +923,7 @@ enum Project {
   StaticRuntimeModule
   StaticStringProcessing
   StaticSynchronization
+  StaticCOM
   StaticDistributed
   StaticObservation
   StaticDifferentiation
@@ -4197,6 +4200,7 @@ function Repair-WindowsSDKAssemblyManifests([Hashtable] $Platform, [string] $Run
 $SDKSupplementalRuntimes = @(
   "StringProcessing",
   "Synchronization",
+  "COM",
   "Distributed",
   "Observation",
   "Differentiation",
@@ -4225,9 +4229,10 @@ function Build-SDK([Hashtable] $Platform, [Hashtable] $Context) {
     $SDKInstallDefines.CMAKE_INSTALL_BINDIR = $SDKRuntimeBin
     $SDKInstallDefines.CMAKE_INSTALL_LIBEXECDIR = $SDKLibexecDir
   }
-  $BUILD_SHARED_LIBS     = if ($Static) { "NO" } else { "YES" }
-  $RuntimeBinaryCache    = Get-ProjectBinaryCache $Platform ([Project]"${Variant}Runtime")
-  $OverlayBinaryCache    = Get-ProjectBinaryCache $Platform ([Project]"${Variant}Overlay")
+  $BUILD_SHARED_LIBS          = if ($Static) { "NO" } else { "YES" }
+  $RuntimeBinaryCache         = Get-ProjectBinaryCache $Platform ([Project]"${Variant}Runtime")
+  $OverlayBinaryCache         = Get-ProjectBinaryCache $Platform ([Project]"${Variant}Overlay")
+  $SynchronizationBinaryCache = Get-ProjectBinaryCache $Platform ([Project]"${Variant}Synchronization")
 
   # TODO: remove this once the migration is completed.
   Invoke-IsolatingEnvVars {
@@ -4362,6 +4367,32 @@ function Build-SDK([Hashtable] $Platform, [Hashtable] $Context) {
             # FIXME(compnerd) this currently causes a build failure on Windows, but
             # this should be enabled when building the dynamic runtime.
             SwiftSynchronization_ENABLE_LIBRARY_EVOLUTION = "NO";
+          })
+      }
+    }
+
+    if ($SupplementalRuntimes -contains "COM") {
+      Record-OperationTime $Platform "Build-${Variant}COM" {
+        Build-CMakeProject `
+          -Src $SourceCache\swift\Runtimes\Supplemental\COM `
+          -Bin (Get-ProjectBinaryCache $Platform ([Project]"${Variant}COM")) `
+          -InstallTo "$SDKRoot\usr" `
+          -Platform $Platform `
+          -SwiftCompiler $Compilers.Swift `
+          -SwiftSDK $null `
+          -Defines ($SDKInstallDefines + @{
+            BUILD_SHARED_LIBS = $BUILD_SHARED_LIBS;
+            CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
+            SWIFT_ASSEMBLY_VERSION = "$ProductVersion";
+            SWIFT_PUBLIC_KEY_TOKEN = "$WindowsSxSAssemblyPublicKeyToken";
+
+            SwiftCore_DIR             = "$RuntimeBinaryCache\cmake\SwiftCore";
+            SwiftOverlay_DIR          = "$OverlayBinaryCache\cmake\SwiftOverlay";
+            SwiftSynchronization_DIR  = "$SynchronizationBinaryCache\cmake\SwiftSynchronization";
+
+            # FIXME(compnerd) this currently causes a build failure on Windows, but
+            # this should be enabled when building the dynamic runtime.
+            SwiftCOM_ENABLE_LIBRARY_EVOLUTION = "NO";
           })
       }
     }


### PR DESCRIPTION
This module enables the COM interop story. This module provides the runtime support required for COM where the majority of the function is externalised from the compiler. The compiler's responsibility is limited to object layout and vtable emission. The metadata handling is performed in this module which is fully inlined into the clients image.