### PR TITLE
[Macros] Ignore empty messages in the in-process plugin host

### DIFF
--- a/include/swift/AST/PluginRegistry.h
+++ b/include/swift/AST/PluginRegistry.h
@@ -179,7 +179,6 @@ public:
       : CompilerPlugin(ExecutablePath),
         LastModificationTime(LastModificationTime),
         disableSandbox(disableSandbox){};
-  ~LoadedExecutablePlugin();
 
   /// The last modification time of 'ExecutablePath' when this object is
   /// created.

--- a/lib/AST/PluginRegistry.cpp
+++ b/lib/AST/PluginRegistry.cpp
@@ -66,6 +66,12 @@ llvm::Error InProcessPlugins::sendMessage(llvm::StringRef message) {
   assert(receivedResponse.empty() &&
          "sendMessage() called before consuming previous response?");
 
+  // Empty messages are a stream-level termination signal for pipe-backed
+  // executable plugins. The in-process plugin server handles one complete
+  // request per call, so there is no stream to tear down.
+  if (message.empty())
+    return llvm::Error::success();
+
   if (shouldDumpMessaging()) {
     llvm::dbgs() << "->(plugin:0) " << message << '\n';
   }
@@ -170,16 +176,6 @@ PluginRegistry::loadExecutablePlugin(StringRef path, bool disableSandbox) {
 
   storage = std::move(plugin);
   return storage.get();
-}
-
-LoadedExecutablePlugin::~LoadedExecutablePlugin() {
-  if (Process) {
-    // If the process is alive, send an empty message as the termination signal.
-    // The plugin should exit itself when receiving it.
-    if (auto error = sendMessage(""))
-      llvm::consumeError(std::move(error));
-    Process.reset();
-  }
 }
 
 llvm::Error LoadedExecutablePlugin::spawnIfNeeded() {

--- a/test/Macros/macro_plugin_basic.swift
+++ b/test/Macros/macro_plugin_basic.swift
@@ -34,7 +34,7 @@
 // CHECK: <-(plugin:[[#PID]]) {"expandFreestandingMacroResult":{"diagnostics":[],"expandedSource":"\"123\"\n  +   \"foo  \""}}
 // CHECK: ->(plugin:[[#PID]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","lexicalContext":[{{.*}}],"macro":{"moduleName":"TestPlugin","name":"testStringWithError","typeName":"TestStringWithErrorMacro"},"macroRole":"expression","staticBuildConfiguration"{{.*}},"syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"{{.+}}test.swift","line":6,"offset":336},"source":"#testStringWithError(321)"}}}
 // CHECK: <-(plugin:[[#PID]]) {"expandFreestandingMacroResult":{"diagnostics":[{"fixIts":[],"highlights":[],"message":"message from plugin","notes":[],"position":{"fileName":"{{.*}}test.swift","offset":336},"severity":"error"}],"expandedSource":"\"bar\""}}
-// CHECK: ->(plugin:[[#PID:]]) {{$}}
+// CHECK-NOT: ->(plugin:[[#PID]]) {{$}}
 
 //--- test.swift
 @freestanding(expression) macro testString(_: Any) -> String = #externalMacro(module: "TestPlugin", type: "TestStringMacro")

--- a/test/Macros/macro_plugin_error.swift
+++ b/test/Macros/macro_plugin_error.swift
@@ -26,7 +26,7 @@
 // CHECK-NEXT: <-(plugin:[[#PID2]]) {"getCapabilityResult":{"capability":{"protocolVersion":1}}}
 // CHECK-NEXT: ->(plugin:[[#PID2]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","lexicalContext":[{{.*}}],"macro":{"moduleName":"TestPlugin","name":"fooMacro","typeName":"FooMacro"},"macroRole":"expression","staticBuildConfiguration"{{.*}},"syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"{{.+}}test.swift","line":11,"offset":[[#]]},"source":"#fooMacro(3)"}}}
 // CHECK-NEXT: <-(plugin:[[#PID2:]]) {"expandFreestandingMacroResult":{"diagnostics":[],"expandedSource":"3.description"}}
-// CHECK-NEXT: ->(plugin:[[#PID2:]]) {{$}}
+// CHECK-NOT: ->(plugin:[[#PID2]]) {{$}}
 
 //--- test.swift
 @freestanding(expression) macro fooMacro(_: Any) -> String = #externalMacro(module: "TestPlugin", type: "FooMacro")

--- a/test/Macros/macro_plugin_server.swift
+++ b/test/Macros/macro_plugin_server.swift
@@ -89,7 +89,7 @@
 // CHECK-NEXT: <-(plugin:[[#PID2]]) {"expandMacroResult":{"diagnostics":[{"fixIts":[],"highlights":[{{{.*}}}],"message":"type 'MacroDefinition.TypeDoesNotExist' could not be found in library plugin '{{.*}}MacroDefinition.{{dylib|so|dll}}'","notes":[],"position":{{{.*}}},"severity":"error"}]}}
 // CHECK-NEXT: ->(plugin:[[#PID2]]) {"expandFreestandingMacro":{"discriminator":"${{.*}}","lexicalContext":[{{.*}}],"macro":{"moduleName":"MacroDefinition","name":"notMacro","typeName":"NotMacroStruct"},"macroRole":"expression","staticBuildConfiguration"{{.*}},"syntax":{"kind":"expression","location":{{({.+})}},"source":"#notMacro()"}}}
 // CHECK-NEXT: <-(plugin:[[#PID2]]) {"expandMacroResult":{"diagnostics":[{"fixIts":[],"highlights":[{{{.*}}}],"message":"type 'MacroDefinition.NotMacroStruct' is not a valid macro implementation type in library plugin '{{.*}}MacroDefinition.{{dylib|so|dll}}'","notes":[],"position":{{{.*}}},"severity":"error"}]}}
-// CHECK-NEXT: ->(plugin:[[#PID2]]) {{$}}
+// CHECK-NOT: ->(plugin:[[#PID2]]) {{$}}
 
 @freestanding(expression) macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
 @freestanding(expression) macro evil(_ value: Int) -> String = #externalMacro(module: "EvilMacros", type: "CrashingMacro")

--- a/test/Macros/macro_plugin_server_mod.swift
+++ b/test/Macros/macro_plugin_server_mod.swift
@@ -65,7 +65,7 @@
 // CHECK-NEXT: <-(plugin:[[#PID3]]) {"loadPluginLibraryResult":{"diagnostics":[],"loaded":true}}
 // CHECK-NEXT: ->(plugin:[[#PID3]]) {"expandFreestandingMacro":{"discriminator":"{{.*}}","lexicalContext":{{.*}},"macro":{"moduleName":"MacroDefinition","name":"stringify","typeName":"StringifyMacro"}{{.*}}
 // CHECK-NEXT: <-(plugin:[[#PID3]]) {"expandMacroResult":{"diagnostics":[],"expandedSource":"(1, \"1\")"}}
-// CHECK-NEXT: ->(plugin:[[#PID3]]) {{$}}
+// CHECK-NOT: ->(plugin:[[#PID3]]) {{$}}
 
 //--- MacroDefinition.swift
 import SwiftSyntax


### PR DESCRIPTION
Fix https://forums.swift.org/t/internal-error-corrupted-json-logged-during-builds/87660/4

Empty messages are used as a stream-level termination signal for pipe-backed executable macro plugins. However, the in-process plugin path handles each `sendMessage` call as one complete request and decodes the payload directly as JSON.

On affected toolchains, that means an empty teardown message can be routed through the in-process plugin JSON decoder, producing an internal corrupted JSON EOF diagnostic such as:

```text
Internal Error: dataCorrupted(... debugDescription: "Corrupted JSON", underlyingError: Optional(unexpected end of file))
```

This change treats empty messages sent to the in-process plugin host as a no-op, since there is no stream to tear down in that path. It also updates the macro plugin messaging tests so they no longer expect a final empty plugin message.
