### PR TITLE
[rbi] Fix compile error in NDEBUG.

### DIFF
--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -256,24 +256,37 @@ void PartitionOp::print(llvm::raw_ostream &os, bool extraSpace) const {
 Partition Partition::singleRegion(SILLocation loc, ArrayRef<Element> indices,
                                   IsolationHistory inputHistory) {
   Partition p(inputHistory);
-  if (!indices.empty()) {
-    // Sort so the lowest element is our region representative. Callers must
-    // pass distinct elements: pushing AddNewRegionForElement / merge nodes
-    // for the same element more than once is unrecoverable in popHistory
-    // (the second pop's removeElement asserts because the first pop already
-    // extracted the element), so a duplicate is a caller bug we trap here
-    // rather than silently absorb.
+  if (indices.empty()) {
+    assert(p.is_canonical_correct());
+    return p;
+  }
+  
+    // Callers must pass distinct elements: pushing AddNewRegionForElement /
+    // merge nodes for the same element more than once is unrecoverable in
+    // popHistory (the second pop's removeElement asserts because the first pop
+    // already extracted the element), so a duplicate is a caller bug we trap
+    // here rather than silently absorb.
 #ifndef NDEBUG
     SmallVector<Element, 8> sortedIndices(indices.begin(), indices.end());
     llvm::sort(sortedIndices);
-    assert(std::adjacent_find(sortedIndices.begin(), sortedIndices.end()) ==
-               sortedIndices.end() &&
-           "Partition::singleRegion does not support duplicate indices");
+    auto dup = std::adjacent_find(sortedIndices.begin(), sortedIndices.end());
+    if (dup != sortedIndices.end()) {
+      llvm::errs() << "Partition::singleRegion does not support duplicate "
+                      "indices, but element "
+                   << unsigned(*dup) << " appears more than once in {";
+      llvm::interleaveComma(indices, llvm::errs(),
+                            [](Element e) { llvm::errs() << unsigned(e); });
+      llvm::errs() << "}\n";
+      llvm_unreachable("Partition::singleRegion given duplicate indices");
+    }
 #endif
 
-    // Lowest element is our region representative and the value that our
-    // region takes.
-    Element repElement = sortedIndices[0];
+    // The lowest element is our region representative and the value that our
+    // region takes. Canonicality requires the region label to be <= every
+    // element in the region (see is_canonical_correct), so we must use the
+    // minimum element here rather than indices[0]: callers are not required to
+    // pass indices in sorted order.
+    Element repElement = *llvm::min_element(indices);
     Region repElementRegion = Region(repElement);
     p.nextAvailableRegionNum = Region(repElementRegion + 1);
 
@@ -284,15 +297,16 @@ Partition Partition::singleRegion(SILLocation loc, ArrayRef<Element> indices,
     // First create a region for repElement. We are going to merge each other
     // element into its region one at a time.
     p.pushNewElementRegion(repElement);
-    for (Element index : sortedIndices) {
+    for (Element index : indices) {
+      // Map every element (including repElement) into the region;
+      // pushNewElementRegion only records history, it does not populate
+      // elementToRegionMap.
       p.elementToRegionMap.insert_or_assign(index, repElementRegion);
       if (index == repElement)
         continue;
-
       p.pushNewElementRegion(index);
       p.pushMergeElementRegions(repElement, index);
     }
-  }
 
   assert(p.is_canonical_correct());
   return p;

--- a/unittests/SILOptimizer/IsolationHistory.cpp
+++ b/unittests/SILOptimizer/IsolationHistory.cpp
@@ -412,6 +412,45 @@ TEST(IsolationHistory, SingleRegionParentChainShape) {
   EXPECT_EQ(node->getNext(), nullptr);
 }
 
+// Callers are NOT required to pass indices in ascending order (e.g.
+// RegionAnalysis builds the joined-argument list in function-argument order,
+// but the element IDs are assigned at first-encounter and can be interleaved
+// by the pre-dataflow scan). singleRegion must still pick the *minimum*
+// element as the region representative, because is_canonical_correct requires
+// the region label to be <= every element in the region. Using indices[0]
+// instead of the minimum would trip that assertion whenever indices[0] is not
+// the smallest element. Here indices[0] == 3 but the rep must be 0.
+TEST(IsolationHistory, SingleRegionUnsortedRepIsMinimum) {
+  llvm::BumpPtrAllocator allocator;
+  IsolationHistory::Factory historyFactory(allocator);
+
+  SILLocation loc = SILLocation::invalid();
+  auto p = Partition::singleRegion(
+      loc, {Element(3), Element(1), Element(2), Element(0)},
+      historyFactory.get());
+
+  // All four elements are tracked and land in the same region, whose label is
+  // the minimum element (0) — not indices[0] (3).
+  PartitionTester tester(p);
+  for (Element e : {Element(0), Element(1), Element(2), Element(3)}) {
+    ASSERT_TRUE(p.isTrackingElement(e))
+        << "Element " << unsigned(e) << " was not tracked";
+    EXPECT_EQ(tester.getRegion(unsigned(e)), 0u)
+        << "Element " << unsigned(e)
+        << " should be in the region labelled by the minimum element (0)";
+  }
+
+  // Every merge node must name the minimum element (0) as its rep, regardless
+  // of the order indices were passed in.
+  for (const IsolationHistory::Node *n = p.getIsolationHistory().getHead(); n;
+       n = n->getNext()) {
+    if (n->getKind() != IsolationHistory::Node::MergeElementRegions)
+      continue;
+    EXPECT_EQ(n->getFirstArgAsElement(), Element(0))
+        << "singleRegion must merge peers into the minimum element's region";
+  }
+}
+
 // Partition::singleRegion requires distinct indices. A repeated element
 // would push pushNewElementRegion(index) + pushMergeElementRegions(rep,
 // index) twice for the same element, which popHistoryOnce cannot rewind


### PR DESCRIPTION
This commit removes references to sortedIndices from outside of an NDEBUG block despite it being defined in an NDEBUG block.

At the same time, I noticed that we really didn't need sortedIndices. Instead, just use the minimum element as the representative.... so I just added a min element check. Another possibility we could consider in the future is just making it non-canonical and leaving the fixup to later occur lazily.

rdar://181024977
