### PR TITLE
[IRGen] Borrow should vend its referent type to compute extra inhabitants

### DIFF
--- a/lib/IRGen/GenBorrow.cpp
+++ b/lib/IRGen/GenBorrow.cpp
@@ -211,22 +211,32 @@ public:
                                        Address src,
                                        SILType T,
                                        bool isOutlined) const override {
-    return ReferentTI.getExtraInhabitantIndex(IGF, src, T, isOutlined);
+    auto astBorrowTy = T.getASTType()->castTo<BuiltinBorrowType>();
+    auto referentTy =
+        SILType::getPrimitiveObjectType(astBorrowTy->getReferentType());
+    return ReferentTI.getExtraInhabitantIndex(IGF, src, referentTy, isOutlined);
   }
 
   void storeExtraInhabitant(IRGenFunction &IGF, llvm::Value *index,
                             Address dest, SILType T,
                             bool isOutlined) const override {
-    return ReferentTI.storeExtraInhabitant(IGF, index, dest, T, isOutlined);
+    auto astBorrowTy = T.getASTType()->castTo<BuiltinBorrowType>();
+    auto referentTy =
+        SILType::getPrimitiveObjectType(astBorrowTy->getReferentType());
+    return ReferentTI.storeExtraInhabitant(IGF, index, dest, referentTy,
+                                           isOutlined);
   }
 
   APInt getFixedExtraInhabitantMask(IRGenModule &IGM) const override {
     return ReferentTI.getFixedExtraInhabitantMask(IGM);
   }
-  
+
   TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM, SILType T,
                                         bool useStructLayouts) const override {
-    return ReferentTI.buildTypeLayoutEntry(IGM, T, useStructLayouts);
+    auto astBorrowTy = T.getASTType()->castTo<BuiltinBorrowType>();
+    auto referentTy =
+        SILType::getPrimitiveObjectType(astBorrowTy->getReferentType());
+    return ReferentTI.buildTypeLayoutEntry(IGM, referentTy, useStructLayouts);
   }
 
   static bool classof(const BorrowByPointerTypeInfo *) { return true; }

--- a/test/IRGen/builtin_borrow_single_payload_enum_referent.swift
+++ b/test/IRGen/builtin_borrow_single_payload_enum_referent.swift
@@ -1,0 +1,44 @@
+// RUN: %target-swift-frontend -enable-experimental-feature BuiltinModule -enable-experimental-feature Lifetimes -emit-ir %s | %FileCheck %s
+
+// REQUIRES: swift_feature_BuiltinModule
+// REQUIRES: swift_feature_Lifetimes
+
+// Regression test: emitting metadata for a struct containing a
+// `Builtin.Borrow<E>` field, where `E` is a single-payload enum whose payload
+// has extra inhabitants, was tripping an assertion because the Borrow's type was being
+// sent down instead of the referent's type.
+
+import Builtin
+
+// Tests verify that the `getEnumTagSinglePayload` is emitted in the VWT
+
+// CHECK: define {{.*}} @"$s{{.*}}12BorrowOptAnyVwet"
+struct BorrowOptAny: ~Escapable {
+  let b: Builtin.Borrow<AnyObject?>
+}
+
+final class MyClass {}
+// CHECK: define {{.*}} @"$s{{.*}}14BorrowOptKlassVwet"
+struct BorrowOptKlass: ~Escapable {
+  let b: Builtin.Borrow<MyClass?>
+}
+
+// Bool has many extra inhabitants (0x02..0xFF); same trigger path as classes.
+// CHECK: define {{.*}} @"$s{{.*}}13BorrowOptBoolVwet"
+struct BorrowOptBool: ~Escapable {
+  let b: Builtin.Borrow<Bool?>
+}
+
+protocol P: AnyObject {}
+// CHECK: define {{.*}} @"$s{{.*}}10BorrowOptPVwet"
+struct BorrowOptP: ~Escapable {
+  let b: Builtin.Borrow<(any P)?>
+}
+
+// Single-payload enum that isn't Optional, to confirm the trigger isn't
+// specific to `Optional`.
+enum E { case some(AnyObject); case none }
+// CHECK: define {{.*}} @"$s{{.*}}10BorrowEnumVwet"
+struct BorrowEnum: ~Escapable {
+  let b: Builtin.Borrow<E>
+}


### PR DESCRIPTION
There's an assertion being hit when emitting the witness for getEnumTagSinglePayload of a type containing a Borrow to a single payload enum.

This is reproducible on a compiler build with asserts enabled for any type which contains a `Ref` to a single payload enum where the payload has extra inhabitants:
```
struct BorrowOptAny: ~Escapable {
  let b: Builtin.Borrow<AnyObject?>
}
```
Produces assertion: 
```
  SILType swift::SILType::getEnumElementType(EnumElementDecl *, TypeConverter &,
  TypeExpansionContext) const: Assertion
  `elt->getDeclContext() == getEnumOrBoundGenericEnum()' failed.
```

This is hit because the `BorrowInlineTypeInfo` forwards its own SILType to the referent's type info which later hits an assertion when checking the enum case and expecting the type provided to be the source enum type, but finds it as `Borrow<TheEnum>`.

The fix is to forward the referent's SILType.