### PR TITLE
[build-script] Make CMake file API queries for the compiler runtimes

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/cmake_product.py
+++ b/utils/swift_build_support/swift_build_support/products/cmake_product.py
@@ -23,6 +23,13 @@ class CMakeProduct(product.Product):
     def is_verbose(self):
         return self.args.verbose_build
 
+    @staticmethod
+    def write_cmake_file_api_query(build_dir):
+        query_dir = os.path.join(build_dir, ".cmake", "api", "v1", "query")
+        os.makedirs(query_dir, exist_ok=True)
+        open(os.path.join(query_dir, "codemodel-v2"), "a").close()
+        open(os.path.join(query_dir, "cache-v2"), "a").close()
+
     def build_with_cmake(self, build_targets, build_type, build_args,
                          prefer_native_toolchain=False, 
                          ignore_extra_cmake_options=False, build_llvm=True):
@@ -52,11 +59,7 @@ class CMakeProduct(product.Product):
                 os.makedirs(self.build_dir)
 
             # Use `cmake-file-api` in case it is available.
-            query_dir = os.path.join(self.build_dir, ".cmake", "api", "v1", "query")
-            if not os.path.exists(query_dir):
-                os.makedirs(query_dir)
-            open(os.path.join(query_dir, "codemodel-v2"), 'a').close()
-            open(os.path.join(query_dir, "cache-v2"), 'a').close()
+            self.write_cmake_file_api_query(self.build_dir)
 
             env = None
             if self.toolchain.distcc:

--- a/utils/swift_build_support/swift_build_support/products/llvm.py
+++ b/utils/swift_build_support/swift_build_support/products/llvm.py
@@ -454,6 +454,9 @@ class LLVM(cmake_product.CMakeProduct):
 
         self._handle_cxx_headers(host_target, platform)
 
+        # Use `cmake-file-api` in case it is available.
+        self._write_runtime_cmake_file_api_queries(builtins_runtimes_target_for_darwin)
+
         self.build_with_cmake(build_targets, self.args.llvm_build_variant, [],
                               build_llvm=build)
 
@@ -516,6 +519,20 @@ class LLVM(cmake_product.CMakeProduct):
               'clang build directory ({}).'.format(
                   host_cxx_headers_dir, built_cxx_include_dir), flush=True)
         shell.call(['ln', '-s', '-f', host_cxx_headers_dir, built_cxx_include_dir])
+
+    def _write_runtime_cmake_file_api_queries(self, builtins_runtimes_target_for_darwin):
+        if system() == "Darwin":
+            sub_build_names = [
+                f"builtins-{builtins_runtimes_target_for_darwin}",
+                f"runtimes-{builtins_runtimes_target_for_darwin}",
+            ]
+        else:
+            sub_build_names = ["builtins", "runtimes"]
+
+        runtimes_base = os.path.join(self.build_dir, "runtimes")
+        for sub_build in sub_build_names:
+            self.write_cmake_file_api_query(
+                os.path.join(runtimes_base, f"{sub_build}-bins"))
 
     def should_test(self, host_target):
         """should_test() -> Bool


### PR DESCRIPTION
The LLVM sub-build sources (i.e. compiler-rt) are invisible to CMake file API clients. Write queries for those so that clients can see them, or open them as standalone projects.

Assisted-by: Claude Code