### PR TITLE
[windows][NFC] remove Resolve-SDKRuntimeBin

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1798,14 +1798,6 @@ function Get-SDKLibexecDir([Hashtable] $Platform, [string] $SDKRoot, [bool] $Ins
   return [IO.Path]::Combine($SDKRoot, "usr", "libexec")
 }
 
-function Resolve-SDKRuntimeBin([Hashtable] $Platform, [string] $SDKRoot, [bool] $InstallRuntimeToStage = $true) {
-  $RuntimeBin = Get-SDKRuntimeBin $Platform $SDKRoot $InstallRuntimeToStage
-  if (Test-Path $RuntimeBin -PathType Container) {
-    return $RuntimeBin
-  }
-  return [IO.Path]::Combine($SDKRoot, "usr", "bin")
-}
-
 enum DriverStyle {
   CL
   ClangCL
@@ -2531,7 +2523,7 @@ function Build-SPMProject {
   Invoke-IsolatingEnvVars {
 
     $HostSDKRoot = Get-SwiftSDK -OS $HostPlatform.OS
-    $HostRuntimeBin = Resolve-SDKRuntimeBin $HostPlatform $HostSDKRoot
+    $HostRuntimeBin = Get-SDKRuntimeBin $HostPlatform $HostSDKRoot
     $env:Path = "$HostRuntimeBin;$($HostPlatform.ToolchainInstallRoot)\usr\bin;${env:Path}"
     $env:SDKROOT = $HostSDKRoot
     $env:SWIFTCI_USE_LOCAL_DEPS = "1"
@@ -3278,7 +3270,7 @@ function Set-WindowsSxSToolchainRuntimePerDLL {
 function Test-Compilers([Hashtable] $Platform, [string] $Variant, [switch] $TestClang, [switch] $TestLLD, [switch] $TestLLDB, [switch] $TestLLDBSwift, [switch] $TestLLVM, [switch] $TestSwift) {
   Invoke-IsolatingEnvVars {
     $SwiftSDK = Get-SwiftSDK -OS $Platform.OS
-    $SwiftRuntime = Resolve-SDKRuntimeBin $Platform $SwiftSDK
+    $SwiftRuntime = Get-SDKRuntimeBin $Platform $SwiftSDK
     $Stage2BinDir = [IO.Path]::Combine((Get-ProjectBinaryCache $Platform Stage2Compilers), "bin")
     $CDispatchBinaryCache = Get-ProjectBinaryCache $Platform DynamicCDispatch
     $env:Path = "$SwiftRuntime;$Stage2BinDir;$CDispatchBinaryCache;$CDispatchBinaryCache\bin;$(Get-CMarkBinaryCache $Platform)\src;$env:Path;$VSInstallRoot\DIA SDK\bin\$($HostPlatform.Architecture.VSName);$UnixToolsBinDir"
@@ -5939,7 +5931,7 @@ if ($Toolchain) {
 
   if ($HostPlatform.OS -eq [OS]::Windows) {
     $HostSDKRoot = Get-SwiftSDK -OS $HostPlatform.OS
-    $HostRuntimeBin = Resolve-SDKRuntimeBin $HostPlatform $HostSDKRoot
+    $HostRuntimeBin = Get-SDKRuntimeBin $HostPlatform $HostSDKRoot
     Invoke-BuildStep Stage-WindowsToolchainSxS $HostPlatform @{
       ToolchainRoot   = $HostPlatform.ToolchainInstallRoot;
       RuntimeLocation = $HostRuntimeBin;
@@ -6020,7 +6012,7 @@ if ($Windows) {
   # copies after the final runtime image is in place.
   if ($Toolchain -and $RebuiltHostDynamicRuntime) {
     $HostSDKRoot = Get-SwiftSDK -OS $HostPlatform.OS
-    $HostRuntimeBin = Resolve-SDKRuntimeBin $HostPlatform $HostSDKRoot
+    $HostRuntimeBin = Get-SDKRuntimeBin $HostPlatform $HostSDKRoot
     Invoke-BuildStep Stage-WindowsToolchainSxS $HostPlatform @{
       ToolchainRoot   = $HostPlatform.ToolchainInstallRoot;
       RuntimeLocation = $HostRuntimeBin;
@@ -6112,7 +6104,7 @@ if ($Stage) {
 if (-not $IsCrossCompiling) {
   if (-not $Toolchain -and $HostPlatform.OS -eq [OS]::Windows -and $Test.Count -gt 0) {
     $HostSDKRoot = Get-SwiftSDK -OS $HostPlatform.OS
-    $HostRuntimeBin = Resolve-SDKRuntimeBin $HostPlatform $HostSDKRoot
+    $HostRuntimeBin = Get-SDKRuntimeBin $HostPlatform $HostSDKRoot
     Invoke-BuildStep Stage-WindowsToolchainSxS $HostPlatform @{
       ToolchainRoot   = $HostPlatform.ToolchainInstallRoot;
       RuntimeLocation = $HostRuntimeBin;


### PR DESCRIPTION
`Resolve-SDKRuntimeBin` wrapped `Get-SDKRuntimeBin` with a "fall back to <SDKRoot>/usr/bin if missing" branch. That fallback predates the bootstrap changes and is no longer used: It can now only resolve to a stale or empty path, silently binding callers to the wrong runtime. Inline the five callers and delete the wrapper.