### PR TITLE
 [Serialization] Recover from XREF context change in SIL function deserialization

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -354,17 +354,19 @@ ModularizationError::diagnose(const ModuleFile *MF,
   // decls moving between both modules.
   if (errorKind == Kind::DeclMoved ||
       errorKind == Kind::DeclKindChanged) {
-    StringRef foundModuleName = foundModule->getName().str();
-    StringRef expectedModuleName = expectedModule->getName().str();
-    if (foundModuleName != expectedModuleName &&
-        (foundModuleName.starts_with(expectedModuleName) ||
-         expectedModuleName.starts_with(foundModuleName)) &&
-        (expectedUnderlying ||
-         expectedModule->findUnderlyingClangModule())) {
-      std::string name = path.getFullName();
-      ctx.Diags.diagnose(loc,
-                         diag::modularization_issue_related_modules,
-                         declIsType, name);
+    if (foundModule) {
+      StringRef foundModuleName = foundModule->getName().str();
+      StringRef expectedModuleName = expectedModule->getName().str();
+      if (foundModuleName != expectedModuleName &&
+          (foundModuleName.starts_with(expectedModuleName) ||
+           expectedModuleName.starts_with(foundModuleName)) &&
+          (expectedUnderlying ||
+           expectedModule->findUnderlyingClangModule())) {
+        std::string name = path.getFullName();
+        ctx.Diags.diagnose(loc,
+                           diag::modularization_issue_related_modules,
+                           declIsType, name);
+      }
     }
   }
 

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -649,6 +649,12 @@ SILFunction *SILDeserializer::getFuncForReference(StringRef name,
   SILSerializationFunctionBuilder builder(SILMod);
   fn = builder.createDeclaration(name, type,
                                  RegularLocation(sourceLoc));
+  // This declaration stands in for a function whose body we could not
+  // deserialize (e.g. it referenced a Clang declaration broken by a context
+  // change). It has no body, so give it external linkage; otherwise the
+  // `didDeserialize` linkage update below would try to externalize a private
+  // definition and assert.
+  fn->setLinkage(SILLinkage::PublicExternal);
   // The function is not really de-serialized, but it's important to call
   // `didDeserialize` on every new function. Otherwise some Analysis might miss
   // `notifyAddedOrModifiedFunction` notifications.
@@ -886,7 +892,15 @@ llvm::Expected<SILFunction *> SILDeserializer::readSILFunctionChecked(
 
   ValueDecl *clangNodeOwner = nullptr;
   if (clangNodeOwnerID != 0) {
-    clangNodeOwner = dyn_cast_or_null<ValueDecl>(MF->getDecl(clangNodeOwnerID));
+    auto clangNodeOwnerOrErr = MF->getDeclChecked(clangNodeOwnerID);
+    if (!clangNodeOwnerOrErr) {
+      // Emit the diagnostic (e.g. a modularization issue such as a referenced
+      // Clang declaration changing kind) without aborting, then fail this SIL
+      // function read so the caller can recover.
+      MF->diagnoseAndConsumeFatal(clangNodeOwnerOrErr.takeError());
+      return MF->createFatalError();
+    }
+    clangNodeOwner = dyn_cast_or_null<ValueDecl>(clangNodeOwnerOrErr.get());
     if (!clangNodeOwner)
       return MF->diagnoseFatal("invalid clang node owner for SILFunction");
   }

--- a/test/Serialization/Recovery/module-recovery-remarks-on-type-changed.swift
+++ b/test/Serialization/Recovery/module-recovery-remarks-on-type-changed.swift
@@ -10,15 +10,17 @@
 // RUN: %target-swift-frontend -c -O %t/Client.swift -I %t \
 // RUN:   -validate-tbd-against-ir=none -swift-version 5
 
-// Replace headers, changing the type of `foo`.
+// Replace headers, changing the type of `foo`. The client must recover with a
+// normal diagnostic instead of aborting with a deserialization failure.
 // RUN: mv %t/A_DifferentAPI.h %t/A.h
-// RUN: not --crash %target-swift-frontend -c -O %t/Client.swift -I %t \
+// RUN: not %target-swift-frontend -c -O %t/Client.swift -I %t \
 // RUN:   -validate-tbd-against-ir=none -swift-version 5 2>&1 \
 // RUN:   -diagnostic-style llvm | %FileCheck %s
 // CHECK: error: reference to declaration 'foo' broken by a context change; the declaration kind of 'foo' from 'A' changed since building 'LibWithXRef'
 // CHECK: note: the declaration was expected to be found in module 'A' at '{{.*}}module.modulemap'
 // CHECK: note: the declaration was actually found in module 'A' at '{{.*}}module.modulemap'
 // CHECK: note: a candidate was filtered out because of a type mismatch; expected: '() -> ()', found: '() -> Float'
+// CHECK-NOT: *** DESERIALIZATION FAILURE ***
 
 //--- module.modulemap
 module A {

--- a/test/Serialization/modularization-error-member.swift
+++ b/test/Serialization/modularization-error-member.swift
@@ -12,14 +12,14 @@
 
 // Replace headers, changing the type of `foo`.
 // RUN: cp %t/A_Changed.h %t/A.h
-// RUN: not --crash %target-swift-frontend -c -O %t/Client.swift -I %t \
+// RUN: not %target-swift-frontend -c -O %t/Client.swift -I %t \
 // RUN:   -validate-tbd-against-ir=none -swift-version 5 \
 // RUN:   -diagnostic-style llvm 2> %t/out
 // RUN: %FileCheck %t/A_Changed.h --input-file %t/out
 
 // Replace headers, disappearing `foo`.
 // RUN: cp %t/A_Disappeared.h %t/A.h
-// RUN: not --crash %target-swift-frontend -c -O %t/Client.swift -I %t \
+// RUN: not %target-swift-frontend -c -O %t/Client.swift -I %t \
 // RUN:   -validate-tbd-against-ir=none -swift-version 5 \
 // RUN:   -diagnostic-style llvm 2> %t/out
 // RUN: %FileCheck %t/A_Disappeared.h --input-file %t/out
@@ -41,6 +41,7 @@ struct S *create() __attribute__((swift_name("S.init()")));
 // CHECK: error: reference to declaration 'S.foo' broken by a context change; 'S.foo' is not found, it was expected to be in 'A'
 // CHECK: note: the declaration was expected to be found in module 'A' at '{{.*}}module.modulemap'
 // CHECK-NOT: actually found
+// CHECK-NOT: *** DESERIALIZATION FAILURE ***
 
 //--- A_Changed.h
 struct S {};
@@ -50,6 +51,7 @@ float foo(struct S *data) __attribute__((swift_name("S.foo(self:)")));
 // CHECK: error: reference to declaration 'S.foo' broken by a context change; the declaration kind of 'S.foo' from 'A' changed since building 'LibWithXRef'
 // CHECK: note: the declaration was expected to be found in module 'A' at '{{.*}}module.modulemap'
 // CHECK: note: a candidate was filtered out because of a type mismatch; expected: '(inout S) -> () -> Double', found: '(inout S) -> () -> Float'
+// CHECK-NOT: *** DESERIALIZATION FAILURE ***
 
 //--- LibWithXRef.swift
 import A


### PR DESCRIPTION
An @inlinable body referencing a Clang declaration that changed kind (e.g. a signature gated by a preprocessor macro) aborted with "DESERIALIZATION FAILURE" instead of diagnosing. Read the clang node owner with getDeclChecked and recover, so that we only show proper diagnostics rather than crashing.

rdar://180570904
