### PR TITLE
[stdlib] Optimize lazy-filter terminal operations

### DIFF
--- a/stdlib/public/core/Filter.swift
+++ b/stdlib/public/core/Filter.swift
@@ -105,6 +105,16 @@ extension LazyFilterSequence: Sequence {
     guard _predicate(element) else { return false }
     return _base._customContainsEquatableElement(element)
   }
+
+  @_alwaysEmitIntoClient
+  @inlinable // lazy-performance
+  public func first(
+    where predicate: (Element) throws -> Bool
+  ) rethrows -> Element? {
+    return try _base.first {
+      try _predicate($0) && predicate($0)
+    }
+  }
 }
 
 extension LazyFilterSequence: LazySequenceProtocol { }
@@ -122,6 +132,20 @@ public typealias LazyFilterCollection<T: Collection> = LazyFilterSequence<T>
 
 extension LazyFilterCollection: Collection {
   public typealias SubSequence = LazyFilterCollection<Base.SubSequence>
+
+  @_alwaysEmitIntoClient
+  @inlinable // lazy-performance
+  public var first: Element? {
+    var index = _base.startIndex
+    while index != _base.endIndex {
+      let element = _base[index]
+      if _predicate(element) {
+        return element
+      }
+      _base.formIndex(after: &index)
+    }
+    return nil
+  }
 
   // https://github.com/apple/swift/issues/46747
   // Any estimate of the number of elements that pass `_predicate` requires
@@ -305,6 +329,52 @@ extension LazyFilterCollection: LazyCollectionProtocol { }
 
 extension LazyFilterCollection: BidirectionalCollection
   where Base: BidirectionalCollection {
+
+  @_alwaysEmitIntoClient
+  @inlinable // lazy-performance
+  public var last: Element? {
+    var index = _base.endIndex
+    while index != _base.startIndex {
+      _base.formIndex(before: &index)
+      let element = _base[index]
+      if _predicate(element) {
+        return element
+      }
+    }
+    return nil
+  }
+
+  @_alwaysEmitIntoClient
+  @inlinable // lazy-performance
+  public func last(
+    where predicate: (Element) throws -> Bool
+  ) rethrows -> Element? {
+    var index = _base.endIndex
+    while index != _base.startIndex {
+      _base.formIndex(before: &index)
+      let element = _base[index]
+      if try _predicate(element) && predicate(element) {
+        return element
+      }
+    }
+    return nil
+  }
+
+  @_alwaysEmitIntoClient
+  @inlinable // lazy-performance
+  public func lastIndex(
+    where predicate: (Element) throws -> Bool
+  ) rethrows -> Index? {
+    var index = _base.endIndex
+    while index != _base.startIndex {
+      _base.formIndex(before: &index)
+      let element = _base[index]
+      if try _predicate(element) && predicate(element) {
+        return index
+      }
+    }
+    return nil
+  }
 
   @inlinable // lazy-performance
   public func index(before i: Index) -> Index {

--- a/test/stdlib/Filter.swift
+++ b/test/stdlib/Filter.swift
@@ -17,6 +17,22 @@ import StdlibUnittest
 
 let FilterTests = TestSuite("Filter")
 
+enum FilterTestError: Error {
+  case stopped
+}
+
+func expectFilterTestError(_ body: () throws -> Void) {
+  var didThrow = false
+  do {
+    try body()
+  } catch FilterTestError.stopped {
+    didThrow = true
+  } catch {
+    expectUnreachable("unexpected error: \(error)")
+  }
+  expectTrue(didThrow)
+}
+
 // Check that the generic parameter is called 'Base'.
 protocol TestProtocol1 {}
 
@@ -35,6 +51,50 @@ extension LazyFilterSequence where Base : TestProtocol1 {
 extension LazyFilterCollection where Base : TestProtocol1 {
   var _baseIsTestProtocol1: Bool {
     fatalError("not implemented")
+  }
+}
+
+final class FilterCollectionCounters {
+  var subscriptCount = 0
+  var indexBeforeCount = 0
+}
+
+struct CountingFilterCollection: Collection {
+  var elements: [Int]
+  var counters: FilterCollectionCounters
+
+  var startIndex: Int { elements.startIndex }
+  var endIndex: Int { elements.endIndex }
+
+  subscript(position: Int) -> Int {
+    counters.subscriptCount += 1
+    return elements[position]
+  }
+
+  func index(after i: Int) -> Int {
+    return i + 1
+  }
+}
+
+struct CountingBidirectionalFilterCollection: BidirectionalCollection {
+  var elements: [Int]
+  var counters: FilterCollectionCounters
+
+  var startIndex: Int { elements.startIndex }
+  var endIndex: Int { elements.endIndex }
+
+  subscript(position: Int) -> Int {
+    counters.subscriptCount += 1
+    return elements[position]
+  }
+
+  func index(after i: Int) -> Int {
+    return i + 1
+  }
+
+  func index(before i: Int) -> Int {
+    counters.indexBeforeCount += 1
+    return i - 1
   }
 }
 
@@ -93,6 +153,270 @@ FilterTests.test("chained filter order") {
   
   expectEqual(lazyResult.count, 0)
   expectEqual(result.count, 0)
+}
+
+FilterTests.test("lazy filter first") {
+  let counters = FilterCollectionCounters()
+  var filterCount = 0
+
+  let result = CountingFilterCollection(
+    elements: Array(0..<10),
+    counters: counters
+  ).lazy
+    .filter {
+      filterCount += 1
+      return $0 == 4
+    }
+    .first
+
+  expectEqual(Optional(4), result)
+  expectEqual(5, filterCount)
+  expectEqual(5, counters.subscriptCount)
+}
+
+FilterTests.test("lazy filter first(where:)") {
+  var filterCount = 0
+  var firstCount = 0
+
+  let result = (0..<10).makeIterator().lazy
+    .filter {
+      filterCount += 1
+      return $0 % 2 == 0
+    }
+    .first {
+      firstCount += 1
+      return $0 > 4
+    }
+
+  expectEqual(Optional(6), result)
+  expectEqual(7, filterCount)
+  expectEqual(4, firstCount)
+}
+
+FilterTests.test("lazy filter last") {
+  let counters = FilterCollectionCounters()
+  var filterCount = 0
+
+  let result = CountingBidirectionalFilterCollection(
+    elements: Array(0..<10),
+    counters: counters
+  )
+    .lazy
+    .filter {
+      filterCount += 1
+      return $0 == 9
+    }
+    .last
+
+  expectEqual(Optional(9), result)
+  expectEqual(1, filterCount)
+  expectEqual(1, counters.subscriptCount)
+  expectEqual(1, counters.indexBeforeCount)
+}
+
+FilterTests.test("lazy filter last(where:)") {
+  var filterCount = 0
+  var lastCount = 0
+
+  let result = (0..<10).lazy
+    .filter {
+      filterCount += 1
+      return $0 % 2 == 1
+    }
+    .last {
+      lastCount += 1
+      return $0 < 8
+    }
+
+  expectEqual(Optional(7), result)
+  expectEqual(3, filterCount)
+  expectEqual(2, lastCount)
+}
+
+FilterTests.test("lazy filter lastIndex(where:)") {
+  var filterCount = 0
+  var lastIndexCount = 0
+
+  let result = (0..<10).lazy
+    .filter {
+      filterCount += 1
+      return $0 % 2 == 1
+    }
+    .lastIndex {
+      lastIndexCount += 1
+      return $0 < 8
+    }
+
+  expectEqual(Optional(7), result)
+  expectEqual(3, filterCount)
+  expectEqual(2, lastIndexCount)
+}
+
+FilterTests.test("lazy filter terminal operations with no match") {
+  var filterCount = 0
+
+  let first = (0..<5).lazy
+    .filter { _ in
+      filterCount += 1
+      return false
+    }
+    .first
+
+  expectNil(first)
+  expectEqual(5, filterCount)
+
+  filterCount = 0
+  let last = (0..<5).lazy
+    .filter { _ in
+      filterCount += 1
+      return false
+    }
+    .last
+
+  expectNil(last)
+  expectEqual(5, filterCount)
+
+  filterCount = 0
+  var predicateCount = 0
+  let lastWhere = (0..<5).lazy
+    .filter {
+      filterCount += 1
+      return $0 % 2 == 1
+    }
+    .last {
+      predicateCount += 1
+      return $0 < 0
+    }
+
+  expectNil(lastWhere)
+  expectEqual(5, filterCount)
+  expectEqual(2, predicateCount)
+
+  filterCount = 0
+  predicateCount = 0
+  let lastIndexWhere = (0..<5).lazy
+    .filter {
+      filterCount += 1
+      return $0 % 2 == 1
+    }
+    .lastIndex {
+      predicateCount += 1
+      return $0 < 0
+    }
+
+  expectNil(lastIndexWhere)
+  expectEqual(5, filterCount)
+  expectEqual(2, predicateCount)
+}
+
+FilterTests.test("lazy filter terminal operations on empty bases") {
+  var filterCount = 0
+  var predicateCount = 0
+  let filtered = [Int]().lazy.filter { _ in
+    filterCount += 1
+    return true
+  }
+
+  expectNil(filtered.first)
+  expectNil(filtered.last)
+  expectNil(filtered.last { _ in
+    predicateCount += 1
+    return true
+  })
+  expectNil(filtered.lastIndex { _ in
+    predicateCount += 1
+    return true
+  })
+  expectEqual(0, filterCount)
+  expectEqual(0, predicateCount)
+}
+
+FilterTests.test("lazy filter first(where:) with no match") {
+  var filterCount = 0
+  var firstCount = 0
+
+  let result = (0..<5).makeIterator().lazy
+    .filter {
+      filterCount += 1
+      return $0 % 2 == 0
+    }
+    .first {
+      firstCount += 1
+      return $0 < 0
+    }
+
+  expectNil(result)
+  expectEqual(5, filterCount)
+  expectEqual(3, firstCount)
+}
+
+FilterTests.test("lazy filter first(where:) propagates throws") {
+  var filterCount = 0
+  var firstCount = 0
+
+  expectFilterTestError {
+    _ = try (0..<10).makeIterator().lazy
+      .filter {
+        filterCount += 1
+        return $0 % 2 == 0
+      }
+      .first {
+        firstCount += 1
+        if $0 == 4 {
+          throw FilterTestError.stopped
+        }
+        return false
+      }
+  }
+
+  expectEqual(5, filterCount)
+  expectEqual(3, firstCount)
+}
+
+FilterTests.test("lazy filter last(where:) propagates throws") {
+  var filterCount = 0
+  var lastCount = 0
+
+  expectFilterTestError {
+    _ = try (0..<10).lazy
+      .filter {
+        filterCount += 1
+        return $0 % 2 == 1
+      }
+      .last {
+        lastCount += 1
+        if $0 == 7 {
+          throw FilterTestError.stopped
+        }
+        return false
+      }
+  }
+
+  expectEqual(3, filterCount)
+  expectEqual(2, lastCount)
+}
+
+FilterTests.test("lazy filter lastIndex(where:) propagates throws") {
+  var filterCount = 0
+  var lastIndexCount = 0
+
+  expectFilterTestError {
+    _ = try (0..<10).lazy
+      .filter {
+        filterCount += 1
+        return $0 % 2 == 1
+      }
+      .lastIndex {
+        lastIndexCount += 1
+        if $0 == 7 {
+          throw FilterTestError.stopped
+        }
+        return false
+      }
+  }
+
+  expectEqual(3, filterCount)
+  expectEqual(2, lastIndexCount)
 }
 
 runAllTests()


### PR DESCRIPTION
## Title

[stdlib] Optimize lazy-filter terminal operations

## Body

Implements the lazy-filter case discussed in #53066.

This is intentionally scoped to the lazy-filter terminal-operation subset. It
does not try to solve all of the prefix/suffix/drop/first/last chain
permutations discussed in #53066, and it does not add compiler-side pattern
matching.

### Summary

This patch adds concrete stdlib-owned terminal-operation paths for
`LazyFilterSequence` / `LazyFilterCollection`:

- `LazyFilterSequence.first(where:)`
- `LazyFilterCollection.first`
- `LazyFilterCollection.last` when `Base: BidirectionalCollection`
- `LazyFilterCollection.last(where:)` when `Base: BidirectionalCollection`
- `LazyFilterCollection.lastIndex(where:)` when `Base: BidirectionalCollection`

The implementation keeps the optimization inside the stdlib lazy-filter
representation instead of relying on generic collection defaults. That avoids
the issue discussed in #53066 where the generic `BidirectionalCollection.last`
path asks the filtered collection for `isEmpty` / `startIndex` before walking
backward, which can force an unnecessary forward scan through the base
collection.

The forward `first` path is included because #53066 specifically calls out
`filter(where: predicate).first -> first(where: predicate)` as one of the
optimization shapes. The backward paths apply the same stdlib-owned approach to
the bidirectional terminal operations that otherwise route through filtered
indices and filtered `startIndex`.

### Why This Shape

For `LazyFilterCollection`, the existing generic defaults lose important
knowledge:

- `Collection.first` computes `startIndex`, then subscripts the same accepted
  element.
- `BidirectionalCollection.last` checks `isEmpty`, which computes filtered
  `startIndex`, before retrieving `index(before: endIndex)`.
- `BidirectionalCollection.last(where:)` and `lastIndex(where:)` operate
  through filtered indices instead of directly searching the base collection
  from the back.

The new overloads search the base collection directly and apply the lazy-filter
predicate only as needed. For backward terminal operations, that preserves the
expected bidirectional behavior: start at `base.endIndex`, step backward, and
stop at the first base element accepted by the filter and terminal predicate.

The new public members are marked `@_alwaysEmitIntoClient @inlinable`, so they
are available to clients as performance helpers without adding exported runtime
function bodies to `libswiftCore`.

### Evidence

Using a local operation-count probe against the just-built stdlib, with a
`LazyFilterCollection` over `0..<100_000` where the only accepted element is
`99_999`:

```text
patched last:              filter=1      subscript=1      after=0     before=1
legacy last:               filter=100001 subscript=100002 after=99999 before=1
patched last(where:):      filter=1      subscript=1      after=0     before=1
legacy last(where:):       filter=100001 subscript=100003 after=99999 before=1
patched lastIndex(where:): filter=1      subscript=1      after=0     before=1
legacy lastIndex(where:):  filter=100001 subscript=100002 after=99999 before=1
```

This demonstrates the main behavioral improvement deterministically: the old
path pays a forward lazy-filter search before the backward terminal operation,
while the new path performs one backward base step and one predicate evaluation
when the last accepted element is already at the end.

This intentionally changes the number and order of filter-predicate evaluations
for these terminal operations. That is the performance fix: lazy-filter
terminal operations should not evaluate filtered-prefix elements that are not
needed to produce the requested terminal result.

### Tests

Added stdlib coverage for:

- early exit for `first`
- early exit for `first(where:)`
- backward early exit for `last`
- backward early exit for `last(where:)`
- backward early exit for `lastIndex(where:)`
- no-match behavior
- empty-base behavior
- thrown-predicate propagation

### Validation

Validated locally with:

```text
ninja -C /Users/joshuakaunert/Developer/swift-project/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64 libswiftCore.dylib
git diff --check
lit.py -sv --param swift_test_mode=optimize_none --param swift_test_subset=primary --filter 'stdlib/Filter\.swift$' ...
lit.py -sv --param swift_test_mode=optimize --param swift_test_subset=primary --filter 'stdlib/Filter\.swift$' ...
swift-api-digester ABI comparison against utils/api_checker/FrameworkABIBaseline/Swift/ABI/macos.json
nm -gU libswiftCore.dylib lazy-filter symbol check
```

Focused `stdlib/Filter.swift` tests passed in both `optimize_none` and
`optimize`.

After adding `@_alwaysEmitIntoClient`, the API/ABI digester no longer reports
`LazyFilter` additions as new runtime ABI API. Remaining digester output was
unrelated local baseline drift.

The source-tree API checker wrapper was also run against the saved post-change
Swift module dumps:

```text
/Applications/Xcode-27.0.0-Beta.2.app/Contents/Developer/usr/bin/python3 utils/api_checker/swift-api-checker.py --tool-path /Users/joshuakaunert/Developer/swift-project/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-api-digester --action diagnose --dump-before utils/api_checker/FrameworkABIBaseline/Swift/API/macos.json --dump-after /tmp/swift-filter-api-aeic.MrYUby/Swift.API.json --opts disable-fail-on-error
/Applications/Xcode-27.0.0-Beta.2.app/Contents/Developer/usr/bin/python3 utils/api_checker/swift-api-checker.py --tool-path /Users/joshuakaunert/Developer/swift-project/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-api-digester --action diagnose --abi --dump-before utils/api_checker/FrameworkABIBaseline/Swift/ABI/macos.json --dump-after /tmp/swift-filter-api-aeic.MrYUby/Swift.ABI.json --opts disable-fail-on-error
```

Both wrapper commands exited with status 0. Logs were written to
`/tmp/swift-filter-api-checker-api.out` and
`/tmp/swift-filter-api-checker-abi.out`. Searching those logs for the
lazy-filter symbols produced no matches; the remaining output was unrelated
baseline drift from the local build.

The symbol check did not show exported function-body symbols for the new
lazy-filter terminal overloads; only property metadata-variable symbols for the
`first` / `last` properties remained visible.

### Review Caveat

This patch covers the terminal operations on `LazyFilterSequence` and `LazyFilterCollection` that can avoid going through the generic sequence/collection defaults. The forward `first` cases are included because #53066 calls out `filter(where: predicate).first -> first(where: predicate)`. The backward cases use the same stdlib-owned approach for bidirectional collections, where the generic defaults otherwise route through filtered indices and filtered `startIndex`.

If maintainers would prefer this to land in a narrower first step, the patch can be reduced to the `first`/`first(where:)` cases directly named in #53066.