### PR TITLE
SIL: change the ownership of `value_to_bridge_object` from "owned" to "none"

### DIFF
--- a/lib/SIL/IR/ValueOwnership.cpp
+++ b/lib/SIL/IR/ValueOwnership.cpp
@@ -182,7 +182,7 @@ CONSTANT_OWNERSHIP_INST(None, DifferentiabilityWitnessFunction)
 // TODO: It would be great to get rid of these.
 CONSTANT_OWNERSHIP_INST(Unowned, RawPointerToRef)
 CONSTANT_OWNERSHIP_INST(Unowned, ObjCProtocol)
-CONSTANT_OWNERSHIP_INST(Unowned, ValueToBridgeObject)
+CONSTANT_OWNERSHIP_INST(None, ValueToBridgeObject)
 CONSTANT_OWNERSHIP_INST(None, GetAsyncContinuation)
 CONSTANT_OWNERSHIP_INST(None, GetAsyncContinuationAddr)
 CONSTANT_OWNERSHIP_INST(None, ThinToThickFunction)

--- a/test/SILGen/builtins.swift
+++ b/test/SILGen/builtins.swift
@@ -941,8 +941,7 @@ func once(control: Builtin.RawPointer) {
 // CHECK-LABEL: sil hidden [ossa] @$s8builtins19valueToBridgeObjectyBbSuF : $@convention(thin) (UInt) -> @owned Builtin.BridgeObject {
 // CHECK: bb0([[UINT:%.*]] : $UInt):
 // CHECK:   [[BI:%.*]] = struct_extract [[UINT]] : $UInt, #UInt._value
-// CHECK:   [[CAST:%.*]] = value_to_bridge_object [[BI]]
-// CHECK:   [[RET:%.*]] = copy_value [[CAST]] : $Builtin.BridgeObject
+// CHECK:   [[RET:%.*]] = value_to_bridge_object [[BI]]
 // CHECK:   return [[RET]] : $Builtin.BridgeObject
 // CHECK: } // end sil function '$s8builtins19valueToBridgeObjectyBbSuF'
 func valueToBridgeObject(_ x: UInt) -> Builtin.BridgeObject {


### PR DESCRIPTION
This instruction constructs a "object" out of an integer literal. This bridged object is of course not heap allocated and has no reference count semantics. Therefore it can be treated with "none" ownership.
