### PR TITLE
🍒 [Windows] set LLDB_TEST_INFERIOR_RUNTIME_BIN

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1734,14 +1734,6 @@ function Get-SDKLibexecDir([Hashtable] $Platform, [string] $SDKRoot, [bool] $Ins
   return [IO.Path]::Combine($SDKRoot, "usr", "libexec")
 }
 
-function Resolve-SDKRuntimeBin([Hashtable] $Platform, [string] $SDKRoot, [bool] $InstallRuntimeToStage = $true) {
-  $RuntimeBin = Get-SDKRuntimeBin $Platform $SDKRoot $InstallRuntimeToStage
-  if (Test-Path $RuntimeBin -PathType Container) {
-    return $RuntimeBin
-  }
-  return [IO.Path]::Combine($SDKRoot, "usr", "bin")
-}
-
 enum DriverStyle {
   CL
   ClangCL
@@ -2532,7 +2524,7 @@ function Build-SPMProject {
   Invoke-IsolatingEnvVars {
 
     $HostSDKRoot = Get-SwiftSDK -OS $HostPlatform.OS
-    $HostRuntimeBin = Resolve-SDKRuntimeBin $HostPlatform $HostSDKRoot
+    $HostRuntimeBin = Get-SDKRuntimeBin $HostPlatform $HostSDKRoot
     $env:Path = "$HostRuntimeBin;$($HostPlatform.ToolchainInstallRoot)\usr\bin;${env:Path}"
     $env:SDKROOT = $HostSDKRoot
     $env:SWIFTCI_USE_LOCAL_DEPS = "1"
@@ -3269,7 +3261,7 @@ function Set-WindowsSxSToolchainRuntimePerDLL {
 function Test-Compilers([Hashtable] $Platform, [string] $Variant, [switch] $TestClang, [switch] $TestLLD, [switch] $TestLLDB, [switch] $TestLLDBSwift, [switch] $TestLLVM, [switch] $TestSwift) {
   Invoke-IsolatingEnvVars {
     $SwiftSDK = Get-SwiftSDK -OS $Platform.OS
-    $SwiftRuntime = Resolve-SDKRuntimeBin $Platform $SwiftSDK
+    $SwiftRuntime = Get-SDKRuntimeBin $Platform $SwiftSDK
     $Stage2BinDir = [IO.Path]::Combine((Get-ProjectBinaryCache $Platform Stage2Compilers), "bin")
     $CDispatchBinaryCache = Get-ProjectBinaryCache $Platform DynamicCDispatch
     $env:Path = "$SwiftRuntime;$Stage2BinDir;$CDispatchBinaryCache;$CDispatchBinaryCache\bin;$(Get-CMarkBinaryCache $Platform)\src;$env:Path;$VSInstallRoot\DIA SDK\bin\$($HostPlatform.Architecture.VSName);$UnixToolsBinDir"
@@ -5837,7 +5829,7 @@ if ($Toolchain) {
 
   if ($HostPlatform.OS -eq [OS]::Windows) {
     $HostSDKRoot = Get-SwiftSDK -OS $HostPlatform.OS
-    $HostRuntimeBin = Resolve-SDKRuntimeBin $HostPlatform $HostSDKRoot
+    $HostRuntimeBin = Get-SDKRuntimeBin $HostPlatform $HostSDKRoot
     Invoke-BuildStep Stage-WindowsToolchainSxS $HostPlatform @{
       ToolchainRoot   = $HostPlatform.ToolchainInstallRoot;
       RuntimeLocation = $HostRuntimeBin;
@@ -5918,7 +5910,7 @@ if ($Windows) {
   # copies after the final runtime image is in place.
   if ($Toolchain -and $RebuiltHostDynamicRuntime) {
     $HostSDKRoot = Get-SwiftSDK -OS $HostPlatform.OS
-    $HostRuntimeBin = Resolve-SDKRuntimeBin $HostPlatform $HostSDKRoot
+    $HostRuntimeBin = Get-SDKRuntimeBin $HostPlatform $HostSDKRoot
     Invoke-BuildStep Stage-WindowsToolchainSxS $HostPlatform @{
       ToolchainRoot   = $HostPlatform.ToolchainInstallRoot;
       RuntimeLocation = $HostRuntimeBin;
@@ -6010,7 +6002,7 @@ if ($Stage) {
 if (-not $IsCrossCompiling) {
   if (-not $Toolchain -and $HostPlatform.OS -eq [OS]::Windows -and $Test.Count -gt 0) {
     $HostSDKRoot = Get-SwiftSDK -OS $HostPlatform.OS
-    $HostRuntimeBin = Resolve-SDKRuntimeBin $HostPlatform $HostSDKRoot
+    $HostRuntimeBin = Get-SDKRuntimeBin $HostPlatform $HostSDKRoot
     Invoke-BuildStep Stage-WindowsToolchainSxS $HostPlatform @{
       ToolchainRoot   = $HostPlatform.ToolchainInstallRoot;
       RuntimeLocation = $HostRuntimeBin;

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3311,6 +3311,7 @@ function Test-Compilers([Hashtable] $Platform, [string] $Variant, [switch] $Test
         # No watchpoint support on windows: https://github.com/llvm/llvm-project/issues/24820
         LLDB_TEST_USER_ARGS = "--skip-category=watchpoint;--sysroot=$SwiftSDK";
         LLDB_TEST_SWIFT_DRIVER_EXTRA_FLAGS = "-sdk '$SwiftSDK'"
+        LLDB_TEST_INFERIOR_RUNTIME_BIN = "$SwiftRuntime";
         # gtest sharding breaks llvm-lit's --xfail and LIT_XFAIL inputs: https://github.com/llvm/llvm-project/issues/102264
         LLVM_LIT_ARGS = "-v --no-gtest-sharding --time-tests";
         # LLDB Unit tests link against this library


### PR DESCRIPTION
- **Explanation**:
  Swift lldb tests on Windows, which use Foundation fail to hit breakpoints. This is because the tests inferiors are using the wrong `swiftCore.dll`. This patch, paired with https://github.com/swiftlang/llvm-project/pull/13227, points lldb tests to the correct library, allowing the tests to be enabled.

- **Scope**:
  Only affects the Windows lldb test suite.

- **Issues**:
  - https://github.com/swiftlang/llvm-project/issues/13287

- **Original PRs**:
  - https://github.com/swiftlang/swift/pull/90312
  - https://github.com/swiftlang/swift/pull/90324

- **Risk**:
  Low. One patch removes dead code while the other passes an extra flag to lldb test invocations.

- **Testing**:
  Tested in CI on `main` and at desk on the `release/6.4.x` branch.

- **Reviewers**:
  - @compnerd 
  - @al45tair 