### PR TITLE
[Windows] set LLDB_TEST_INFERIOR_RUNTIME_BIN

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3320,6 +3320,7 @@ function Test-Compilers([Hashtable] $Platform, [string] $Variant, [switch] $Test
         # No watchpoint support on windows: https://github.com/llvm/llvm-project/issues/24820
         LLDB_TEST_USER_ARGS = "--skip-category=watchpoint;--sysroot=$SwiftSDK";
         LLDB_TEST_SWIFT_DRIVER_EXTRA_FLAGS = "-sdk '$SwiftSDK'"
+        LLDB_TEST_INFERIOR_RUNTIME_BIN = "$SwiftRuntime";
         # gtest sharding breaks llvm-lit's --xfail and LIT_XFAIL inputs: https://github.com/llvm/llvm-project/issues/102264
         LLVM_LIT_ARGS = "-v --no-gtest-sharding --time-tests";
         # LLDB Unit tests link against this library


### PR DESCRIPTION
Pass `LLDB_TEST_INFERIOR_RUNTIME_BIN = "$SwiftRuntime"` to the lldb test build.

`lit.cfg.py` uses this value to put the Swift runtime directory on the PATH of every test inferior on Windows. Without it, `lit.cfg.py` falls back to `<sysroot>/usr/bin`, which is the pre-bootstrap SDK layout and no longer contains the runtime DLLs. Test inferiors then fail to load `swiftCore.dll` at launch and exit before hitting any breakpoint.

Paired with https://github.com/swiftlang/llvm-project/pull/13212.