### PR TITLE
[Simplify] Optional mismatch in repair failures

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5029,7 +5029,8 @@ repairViaOptionalUnwrap(ConstraintSystem &cs, Type fromType, Type toType,
   // `let _: Bool = try? foo()` and `foo()` produces `Int`
   // we should diagnose it as type mismatch instead of missing unwrap.
   bool possibleContextualMismatch = [&]() {
-    if (!locator.endsWith<LocatorPathElt::ContextualType>())
+    if (!(locator.endsWith<LocatorPathElt::ContextualType>() ||
+          locator.endsWith<LocatorPathElt::ApplyArgToParam>()))
       return false;
 
     // If the contextual type is optional as well, it's definitely a

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2067,6 +2067,12 @@ SolutionResult ConstraintSystem::salvage() {
     // but we should not record any more changes from this point on.
     state.Trail.close();
 
+    if (isDebugMode()) {
+      llvm::errs() << "While salvaging, we have " << viable.size() << " viable solutions\n";
+      for(auto &s : viable)
+        s.dump();
+    }
+
     // If we hit a threshold, we're done.
     if (isTooComplex(viable))
       return SolutionResult::forTooComplex(getTooComplexRange());

--- a/test/Constraints/fixes.swift
+++ b/test/Constraints/fixes.swift
@@ -229,9 +229,10 @@ func moreComplexUnwrapFixes() {
   // expected-note@-3{{chain the optional using '?'}}{{17-17=?}}
   // expected-note@-4{{force-unwrap using '!'}}{{17-17=!}}
 
-  takeNon(os?.value) // expected-error{{value of optional type 'Int?' must be unwrapped to a value of type 'Int'}}
-  // expected-note@-1{{force-unwrap using '!'}}{{13-14=!}}
-  // expected-note@-2{{coalesce}}
+  takeNon(os?.value) // expected-error {{cannot convert value of type 'Int?' to expected argument type 'Int'}}
+  // former error {{value of optional type 'Int?' must be unwrapped to a value of type 'Int'}}
+  // former note {{force-unwrap using '!'}}{{13-14=!}}
+  // former note {{coalesce}}
   takeNon(os?.optValue) // expected-error{{value of optional type 'Int?' must be unwrapped to a value of type 'Int'}}
   // expected-note@-1{{force-unwrap using '!'}}{{11-11=(}} {{23-23=)!}}
   // expected-note@-2{{coalesce}}

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -652,3 +652,14 @@ do {
     context(from: TestSyntax(v) ?? TestSyntax(other.first?.value), root: v) // Ok (no warnings)
   }
 }
+
+func flood(_: Int) {
+}
+
+struct Balderdash {
+  let x: UInt
+}
+func bazzle(b: Balderdash?) -> Void {
+  return flood(b?.x) // expected-error {{cannot convert value of type 'UInt?' to expected argument type 'Int'}}
+}
+


### PR DESCRIPTION
In repair failure, we're missing a case in repairViaOptionalUnwrap when the optional is in an ApplyArgToParam location for context and the type of the unwrapped and wrapped types do not match under Bind. 

Ideally, we wouldn't bind these types here so that a missed type wouldn't arise early but if we don't bind, we generate holes and errors for potentially the entire expression in the unwrap chain. 

This potential solution adds ApplyArgToParam to to the possibleContextualMismatch condition, which catches cases where the type does not match. And argument cases still catch cases where the two types do match; however, the error messaging no longer catches that the solution is to unwrap. 

This is evident in the two diagnostics with the change.