### PR TITLE
Make compiler's data structures 32-bit-safe

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Utilities/SmallProjectionPath.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/SmallProjectionPath.swift
@@ -960,15 +960,9 @@ let smallProjectionPathTest = Test("small_projection_path") {
     let (k2, _, s2) = p2.pop()
     assert(k2 == .anything && s2.isEmpty)
 
-#if _pointerBitWidth(_64)
-    let p3 = SmallProjectionPath(.indexedElement, index: 0xfffffffffffff)
+    let p3 = SmallProjectionPath(.indexedElement, index: Int.max >> 12)
     let (k3, i3, s3) = p3.pop()
-    assert(k3 == .indexedElement && i3 == 0xfffffffffffff && s3.isEmpty)
-#else
-    let p3 = SmallProjectionPath(.indexedElement, index: 0xfffffff)
-    let (k3, i3, s3) = p3.pop()
-    assert(k3 == .indexedElement && i3 == 0xfffffff && s3.isEmpty)
-#endif
+    assert(k3 == .indexedElement && i3 == Int.max >> 12 && s3.isEmpty)
 
     let p4 = p3.push(.indexedElement, index: Int.max)
     let (k4, _, s4) = p4.pop()

--- a/SwiftCompilerSources/Sources/SIL/Utilities/SmallProjectionPath.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/SmallProjectionPath.swift
@@ -960,9 +960,15 @@ let smallProjectionPathTest = Test("small_projection_path") {
     let (k2, _, s2) = p2.pop()
     assert(k2 == .anything && s2.isEmpty)
 
+#if _pointerBitWidth(_64)
     let p3 = SmallProjectionPath(.indexedElement, index: 0xfffffffffffff)
     let (k3, i3, s3) = p3.pop()
     assert(k3 == .indexedElement && i3 == 0xfffffffffffff && s3.isEmpty)
+#else
+    let p3 = SmallProjectionPath(.indexedElement, index: 0xfffffff)
+    let (k3, i3, s3) = p3.pop()
+    assert(k3 == .indexedElement && i3 == 0xfffffff && s3.isEmpty)
+#endif
 
     let p4 = p3.push(.indexedElement, index: Int.max)
     let (k4, _, s4) = p4.pop()

--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -42,7 +42,7 @@ public:
   static inline swift::AbstractConformance *getFromVoidPointer(void *ptr) {
     return (swift::AbstractConformance *)ptr;
   }
-  enum { NumLowBitsAvailable = swift::TypeAlignInBits };
+  enum { NumLowBitsAvailable = swift::ConformanceAlignInBits };
 };
 }
 

--- a/include/swift/AST/TypeAlignments.h
+++ b/include/swift/AST/TypeAlignments.h
@@ -74,6 +74,7 @@ namespace swift {
   constexpr size_t ExprAlignInBits = 3;
   constexpr size_t StmtAlignInBits = 3;
   constexpr size_t TypeAlignInBits = 3;
+  constexpr size_t ConformanceAlignInBits = 3;
   constexpr size_t PatternAlignInBits = 3;
   constexpr size_t TypeReprAlignInBits = 3;
 

--- a/include/swift/Basic/BridgedSwiftObject.h
+++ b/include/swift/Basic/BridgedSwiftObject.h
@@ -40,11 +40,7 @@ typedef const void * _Nonnull SwiftMetatype;
 /// It must be layout compatible with the Swift object header.
 struct BridgedSwiftObject {
   SwiftMetatype metatype;
-#if __SIZEOF_POINTER__ == 4
-  int32_t refCounts;
-#else
-  int64_t refCounts;
-#endif
+  intptr_t refCounts;
 };
 
 typedef struct BridgedSwiftObject * _Nonnull SwiftObject;

--- a/include/swift/Basic/BridgedSwiftObject.h
+++ b/include/swift/Basic/BridgedSwiftObject.h
@@ -40,7 +40,11 @@ typedef const void * _Nonnull SwiftMetatype;
 /// It must be layout compatible with the Swift object header.
 struct BridgedSwiftObject {
   SwiftMetatype metatype;
+#if __SIZEOF_POINTER__ == 4
+  int32_t refCounts;
+#else
   int64_t refCounts;
+#endif
 };
 
 typedef struct BridgedSwiftObject * _Nonnull SwiftObject;

--- a/include/swift/Basic/PointerIntPair.h
+++ b/include/swift/Basic/PointerIntPair.h
@@ -1,0 +1,70 @@
+//===--- PointerIntPair.h - Pointer/int pair with 32-bit fallback -*- C++ -*-=//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_POINTERINTPAIR_H
+#define SWIFT_BASIC_POINTERINTPAIR_H
+
+#include "llvm/ADT/PointerIntPair.h"
+#include "llvm/Support/PointerLikeTypeTraits.h"
+
+namespace swift {
+namespace pointer_int_pair_detail {
+
+/// Same value interface as llvm::PointerIntPair, but with the pointer and the
+/// integer in separate fields, used when the pointer type has too few spare
+/// low bits to pack IntBits into.
+template <typename PointerTy, typename IntType>
+class SeparateStorage {
+  PointerTy Ptr{};
+  IntType Int{};
+
+public:
+  constexpr SeparateStorage() = default;
+  SeparateStorage(PointerTy P, IntType I) : Ptr(P), Int(I) {}
+  explicit SeparateStorage(PointerTy P) : Ptr(P) {}
+
+  PointerTy getPointer() const { return Ptr; }
+  IntType getInt() const { return Int; }
+  void setPointer(PointerTy P) & { Ptr = P; }
+  void setInt(IntType I) & { Int = I; }
+  void initWithPointer(PointerTy P) & { Ptr = P; Int = IntType{}; }
+  void setPointerAndInt(PointerTy P, IntType I) & { Ptr = P; Int = I; }
+
+  bool operator==(const SeparateStorage &RHS) const {
+    return Ptr == RHS.Ptr && Int == RHS.Int;
+  }
+  bool operator!=(const SeparateStorage &RHS) const { return !(*this == RHS); }
+};
+
+template <bool HasEnoughBits, typename PointerTy, unsigned IntBits,
+          typename IntType, typename PtrTraits>
+struct Selector {
+  using type = llvm::PointerIntPair<PointerTy, IntBits, IntType, PtrTraits>;
+};
+
+template <typename PointerTy, unsigned IntBits, typename IntType,
+          typename PtrTraits>
+struct Selector<false, PointerTy, IntBits, IntType, PtrTraits> {
+  using type = SeparateStorage<PointerTy, IntType>;
+};
+
+} // namespace pointer_int_pair_detail
+
+template <typename PointerTy, unsigned IntBits, typename IntType = unsigned,
+          typename PtrTraits = llvm::PointerLikeTypeTraits<PointerTy>>
+using PointerIntPair = typename pointer_int_pair_detail::Selector<
+    (PtrTraits::NumLowBitsAvailable >= IntBits), PointerTy, IntBits, IntType,
+    PtrTraits>::type;
+
+} // namespace swift
+
+#endif // SWIFT_BASIC_POINTERINTPAIR_H

--- a/include/swift/Basic/SwiftObjectHeader.h
+++ b/include/swift/Basic/SwiftObjectHeader.h
@@ -25,11 +25,7 @@
 struct SwiftObjectHeader : BridgedSwiftObject {
   SwiftObjectHeader(SwiftMetatype metatype) {
     this->metatype = metatype;
-#if __SIZEOF_POINTER__ == 4
-    this->refCounts = ~(uint32_t)0;
-#else
-    this->refCounts = ~(uint64_t)0;
-#endif
+    this->refCounts = ~(uintptr_t)0;
   }
 
   bool isBridged() const { return metatype != nullptr; }

--- a/include/swift/Basic/SwiftObjectHeader.h
+++ b/include/swift/Basic/SwiftObjectHeader.h
@@ -25,7 +25,11 @@
 struct SwiftObjectHeader : BridgedSwiftObject {
   SwiftObjectHeader(SwiftMetatype metatype) {
     this->metatype = metatype;
+#if __SIZEOF_POINTER__ == 4
+    this->refCounts = ~(uint32_t)0;
+#else
     this->refCounts = ~(uint64_t)0;
+#endif
   }
 
   bool isBridged() const { return metatype != nullptr; }

--- a/lib/AST/AbstractConformance.h
+++ b/lib/AST/AbstractConformance.h
@@ -19,18 +19,19 @@
 #define SWIFT_AST_ABSTRACT_CONFORMANCE_H
 
 #include "swift/AST/Type.h"
+#include "swift/AST/TypeAlignments.h"
 #include "llvm/ADT/FoldingSet.h"
 
 namespace swift {
 // ProtocolConformanceRef stores this in a 3-member PointerUnion whose
 // discriminator lives in the low bits per
 // PointerLikeTypeTraits<AbstractConformance *>::NumLowBitsAvailable
-// (== TypeAlignInBits, i.e. 8-byte alignment). This class is just three
+// (== ConformanceAlignInBits, i.e. 8-byte alignment). This class is just three
 // pointers, so its *natural* alignment is 8 only where pointers are 8 bytes;
 // on 32-bit hosts (e.g. wasm32) it is 4, which is too few low bits and
 // corrupts the union's tag. Force the alignment the traits already promise.
 // No-op on 64-bit, where the class is already 8-byte aligned.
-class alignas(1 << TypeAlignInBits) AbstractConformance final
+class alignas(1 << ConformanceAlignInBits) AbstractConformance final
     : public llvm::FoldingSetNode {
   Type conformingType;
   ProtocolDecl *requirement;

--- a/lib/AST/AbstractConformance.h
+++ b/lib/AST/AbstractConformance.h
@@ -22,7 +22,16 @@
 #include "llvm/ADT/FoldingSet.h"
 
 namespace swift {
-class AbstractConformance final : public llvm::FoldingSetNode {
+// ProtocolConformanceRef stores this in a 3-member PointerUnion whose
+// discriminator lives in the low bits per
+// PointerLikeTypeTraits<AbstractConformance *>::NumLowBitsAvailable
+// (== TypeAlignInBits, i.e. 8-byte alignment). This class is just three
+// pointers, so its *natural* alignment is 8 only where pointers are 8 bytes;
+// on 32-bit hosts (e.g. wasm32) it is 4, which is too few low bits and
+// corrupts the union's tag. Force the alignment the traits already promise.
+// No-op on 64-bit, where the class is already 8-byte aligned.
+class alignas(1 << TypeAlignInBits) AbstractConformance final
+    : public llvm::FoldingSetNode {
   Type conformingType;
   ProtocolDecl *requirement;
 

--- a/lib/AST/AbstractConformance.h
+++ b/lib/AST/AbstractConformance.h
@@ -23,14 +23,6 @@
 #include "llvm/ADT/FoldingSet.h"
 
 namespace swift {
-// ProtocolConformanceRef stores this in a 3-member PointerUnion whose
-// discriminator lives in the low bits per
-// PointerLikeTypeTraits<AbstractConformance *>::NumLowBitsAvailable
-// (== ConformanceAlignInBits, i.e. 8-byte alignment). This class is just three
-// pointers, so its *natural* alignment is 8 only where pointers are 8 bytes;
-// on 32-bit hosts (e.g. wasm32) it is 4, which is too few low bits and
-// corrupts the union's tag. Force the alignment the traits already promise.
-// No-op on 64-bit, where the class is already 8-byte aligned.
 class alignas(1 << ConformanceAlignInBits) AbstractConformance final
     : public llvm::FoldingSetNode {
   Type conformingType;

--- a/lib/IRGen/Address.h
+++ b/lib/IRGen/Address.h
@@ -173,13 +173,28 @@ public:
   /// The address of an object of type T.
   Address Addr;
 
+#if __SIZEOF_POINTER__ == 4
+  // On 32-bit targets (e.g. wasm32) llvm::Value* exposes only 2 low bits — too few
+  // to pack the 3-bit Kind via PointerIntPair — so store the extra-info pointer and
+  // the Kind in separate fields. 64-bit targets keep the packed representation.
+  llvm::Value *ExtraInfo;
+  Kind TheKind;
+#else
   llvm::PointerIntPair<llvm::Value*, 3, Kind> ExtraInfoAndKind;
+#endif
 
 public:
+#if __SIZEOF_POINTER__ == 4
+  StackAddress() : ExtraInfo(nullptr), TheKind(StaticAlloca) {}
+
+  explicit StackAddress(Address address, Kind kind, llvm::Value *extraInfo = nullptr)
+    : Addr(address), ExtraInfo(extraInfo), TheKind(kind) {}
+#else
   StackAddress() : ExtraInfoAndKind(nullptr, StaticAlloca) {}
 
   explicit StackAddress(Address address, Kind kind, llvm::Value *extraInfo = nullptr)
     : Addr(address), ExtraInfoAndKind(extraInfo, kind) {}
+#endif
 
   /// Return a StackAddress with the address changed in some superficial way.
   StackAddress withAddress(Address addr) const {
@@ -189,13 +204,22 @@ public:
   llvm::Value *getAddressPointer() const { return Addr.getAddress(); }
   Alignment getAlignment() const { return Addr.getAlignment(); }
   Address getAddress() const { return Addr; }
+#if __SIZEOF_POINTER__ == 4
+  Kind getKind() const { return TheKind; }
+  llvm::Value *getExtraInfo() const { return ExtraInfo; }
+#else
   Kind getKind() const { return ExtraInfoAndKind.getInt(); }
   llvm::Value *getExtraInfo() const { return ExtraInfoAndKind.getPointer(); }
+#endif
 
   bool isValid() const { return Addr.isValid(); }
 
   bool operator==(StackAddress RHS) const {
+#if __SIZEOF_POINTER__ == 4
+    return Addr == RHS.Addr && ExtraInfo == RHS.ExtraInfo && TheKind == RHS.TheKind;
+#else
     return Addr == RHS.Addr && ExtraInfoAndKind == RHS.ExtraInfoAndKind;
+#endif
   }
   bool operator!=(StackAddress RHS) const { return !(*this == RHS); }
 };

--- a/lib/IRGen/Address.h
+++ b/lib/IRGen/Address.h
@@ -18,6 +18,7 @@
 #define SWIFT_IRGEN_ADDRESS_H
 
 #include "IRGen.h"
+#include "swift/Basic/PointerIntPair.h"
 #include "llvm/ADT/ilist.h"
 #include "llvm/IR/Argument.h"
 #include "llvm/IR/DerivedTypes.h"
@@ -173,28 +174,13 @@ public:
   /// The address of an object of type T.
   Address Addr;
 
-#if __SIZEOF_POINTER__ == 4
-  // On 32-bit targets (e.g. wasm32) llvm::Value* exposes only 2 low bits — too few
-  // to pack the 3-bit Kind via PointerIntPair — so store the extra-info pointer and
-  // the Kind in separate fields. 64-bit targets keep the packed representation.
-  llvm::Value *ExtraInfo;
-  Kind TheKind;
-#else
-  llvm::PointerIntPair<llvm::Value*, 3, Kind> ExtraInfoAndKind;
-#endif
+  swift::PointerIntPair<llvm::Value*, 3, Kind> ExtraInfoAndKind;
 
 public:
-#if __SIZEOF_POINTER__ == 4
-  StackAddress() : ExtraInfo(nullptr), TheKind(StaticAlloca) {}
-
-  explicit StackAddress(Address address, Kind kind, llvm::Value *extraInfo = nullptr)
-    : Addr(address), ExtraInfo(extraInfo), TheKind(kind) {}
-#else
   StackAddress() : ExtraInfoAndKind(nullptr, StaticAlloca) {}
 
   explicit StackAddress(Address address, Kind kind, llvm::Value *extraInfo = nullptr)
     : Addr(address), ExtraInfoAndKind(extraInfo, kind) {}
-#endif
 
   /// Return a StackAddress with the address changed in some superficial way.
   StackAddress withAddress(Address addr) const {
@@ -204,22 +190,13 @@ public:
   llvm::Value *getAddressPointer() const { return Addr.getAddress(); }
   Alignment getAlignment() const { return Addr.getAlignment(); }
   Address getAddress() const { return Addr; }
-#if __SIZEOF_POINTER__ == 4
-  Kind getKind() const { return TheKind; }
-  llvm::Value *getExtraInfo() const { return ExtraInfo; }
-#else
   Kind getKind() const { return ExtraInfoAndKind.getInt(); }
   llvm::Value *getExtraInfo() const { return ExtraInfoAndKind.getPointer(); }
-#endif
 
   bool isValid() const { return Addr.isValid(); }
 
   bool operator==(StackAddress RHS) const {
-#if __SIZEOF_POINTER__ == 4
-    return Addr == RHS.Addr && ExtraInfo == RHS.ExtraInfo && TheKind == RHS.TheKind;
-#else
     return Addr == RHS.Addr && ExtraInfoAndKind == RHS.ExtraInfoAndKind;
-#endif
   }
   bool operator!=(StackAddress RHS) const { return !(*this == RHS); }
 };

--- a/lib/SILOptimizer/Utils/StackNesting.cpp
+++ b/lib/SILOptimizer/Utils/StackNesting.cpp
@@ -286,28 +286,58 @@ static StringRef getNameForStatus(AllocationStatus status) {
 }
 
 class ActiveAllocation {
+#if __SIZEOF_POINTER__ == 4
+  // On wasm32, SILInstruction* exposes only 2 low bits (4-byte pointers, and
+  // SILInstruction itself is not over-aligned) — too few to pack the 3-bit
+  // AllocationStatus via PointerIntPair. Store the pointer and the status in separate
+  // fields. Other targets keep the packed representation unchanged.
+  SILInstruction *theValue;
+  AllocationStatus theStatus;
+#else
   llvm::PointerIntPair<SILInstruction*, 3, AllocationStatus> valueAndStatus;
+#endif
 
 public:
+#if __SIZEOF_POINTER__ == 4
+  explicit ActiveAllocation(SILInstruction *value)
+    : theValue(value), theStatus(AllocationStatus::Allocated) {}
+#else
   explicit ActiveAllocation(SILInstruction *value)
     : valueAndStatus(value, AllocationStatus::Allocated) {}
+#endif
 
   SILInstruction *getValue() const {
+#if __SIZEOF_POINTER__ == 4
+    return theValue;
+#else
     return valueAndStatus.getPointer();
+#endif
   }
 
   AllocationStatus getStatus() const {
+#if __SIZEOF_POINTER__ == 4
+    return theStatus;
+#else
     return valueAndStatus.getInt();
+#endif
   }
 
   void setPending() {
     assert(getStatus() == AllocationStatus::Allocated);
+#if __SIZEOF_POINTER__ == 4
+    theStatus = AllocationStatus::Pending;
+#else
     valueAndStatus.setInt(AllocationStatus::Pending);
+#endif
   }
 
   void setNonNested() {
     assert(getStatus() == AllocationStatus::Allocated);
+#if __SIZEOF_POINTER__ == 4
+    theStatus = AllocationStatus::AllocatedAndNonNested;
+#else
     valueAndStatus.setInt(AllocationStatus::AllocatedAndNonNested);
+#endif
   }
 
   void setDeallocated(bool expectPending) {
@@ -315,18 +345,34 @@ public:
              ? getStatus() == AllocationStatus::Pending
              : (getStatus() == AllocationStatus::Allocated ||
                 getStatus() == AllocationStatus::AllocatedAndNonNested));
+#if __SIZEOF_POINTER__ == 4
+    theStatus = AllocationStatus::Deallocated;
+#else
     valueAndStatus.setInt(AllocationStatus::Deallocated);
+#endif
   }
 
   void setUndeallocatable() {
+#if __SIZEOF_POINTER__ == 4
+    theStatus = AllocationStatus::Undeallocatable;
+#else
     valueAndStatus.setInt(AllocationStatus::Undeallocatable);
+#endif
   }
 
   bool operator==(const ActiveAllocation &other) const {
+#if __SIZEOF_POINTER__ == 4
+    return theValue == other.theValue && theStatus == other.theStatus;
+#else
     return valueAndStatus == other.valueAndStatus;
+#endif
   }
   bool operator!=(const ActiveAllocation &other) const {
+#if __SIZEOF_POINTER__ == 4
+    return theValue != other.theValue || theStatus != other.theStatus;
+#else
     return valueAndStatus != other.valueAndStatus;
+#endif
   }
 };
 

--- a/lib/SILOptimizer/Utils/StackNesting.cpp
+++ b/lib/SILOptimizer/Utils/StackNesting.cpp
@@ -12,6 +12,7 @@
 
 #include "swift/SILOptimizer/Utils/StackNesting.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/PointerIntPair.h"
 #include "swift/SIL/BasicBlockUtils.h"
 #include "swift/SIL/Dominance.h"
 #include "swift/SIL/SILBuilder.h"
@@ -286,93 +287,39 @@ static StringRef getNameForStatus(AllocationStatus status) {
 }
 
 class ActiveAllocation {
-#if __SIZEOF_POINTER__ == 4
-  // On wasm32, SILInstruction* exposes only 2 low bits (4-byte pointers, and
-  // SILInstruction itself is not over-aligned) — too few to pack the 3-bit
-  // AllocationStatus via PointerIntPair. Store the pointer and the status in separate
-  // fields. Other targets keep the packed representation unchanged.
-  SILInstruction *theValue;
-  AllocationStatus theStatus;
-#else
-  llvm::PointerIntPair<SILInstruction*, 3, AllocationStatus> valueAndStatus;
-#endif
+  swift::PointerIntPair<SILInstruction*, 3, AllocationStatus> valueAndStatus;
 
 public:
-#if __SIZEOF_POINTER__ == 4
-  explicit ActiveAllocation(SILInstruction *value)
-    : theValue(value), theStatus(AllocationStatus::Allocated) {}
-#else
   explicit ActiveAllocation(SILInstruction *value)
     : valueAndStatus(value, AllocationStatus::Allocated) {}
-#endif
 
-  SILInstruction *getValue() const {
-#if __SIZEOF_POINTER__ == 4
-    return theValue;
-#else
-    return valueAndStatus.getPointer();
-#endif
-  }
-
-  AllocationStatus getStatus() const {
-#if __SIZEOF_POINTER__ == 4
-    return theStatus;
-#else
-    return valueAndStatus.getInt();
-#endif
-  }
+  SILInstruction *getValue() const { return valueAndStatus.getPointer(); }
+  AllocationStatus getStatus() const { return valueAndStatus.getInt(); }
 
   void setPending() {
     assert(getStatus() == AllocationStatus::Allocated);
-#if __SIZEOF_POINTER__ == 4
-    theStatus = AllocationStatus::Pending;
-#else
     valueAndStatus.setInt(AllocationStatus::Pending);
-#endif
   }
-
   void setNonNested() {
     assert(getStatus() == AllocationStatus::Allocated);
-#if __SIZEOF_POINTER__ == 4
-    theStatus = AllocationStatus::AllocatedAndNonNested;
-#else
     valueAndStatus.setInt(AllocationStatus::AllocatedAndNonNested);
-#endif
   }
-
   void setDeallocated(bool expectPending) {
     assert(expectPending
              ? getStatus() == AllocationStatus::Pending
              : (getStatus() == AllocationStatus::Allocated ||
                 getStatus() == AllocationStatus::AllocatedAndNonNested));
-#if __SIZEOF_POINTER__ == 4
-    theStatus = AllocationStatus::Deallocated;
-#else
     valueAndStatus.setInt(AllocationStatus::Deallocated);
-#endif
   }
-
   void setUndeallocatable() {
-#if __SIZEOF_POINTER__ == 4
-    theStatus = AllocationStatus::Undeallocatable;
-#else
     valueAndStatus.setInt(AllocationStatus::Undeallocatable);
-#endif
   }
 
   bool operator==(const ActiveAllocation &other) const {
-#if __SIZEOF_POINTER__ == 4
-    return theValue == other.theValue && theStatus == other.theStatus;
-#else
     return valueAndStatus == other.valueAndStatus;
-#endif
   }
   bool operator!=(const ActiveAllocation &other) const {
-#if __SIZEOF_POINTER__ == 4
-    return theValue != other.theValue || theStatus != other.theStatus;
-#else
     return valueAndStatus != other.valueAndStatus;
-#endif
   }
 };
 

--- a/unittests/Basic/CMakeLists.txt
+++ b/unittests/Basic/CMakeLists.txt
@@ -29,6 +29,7 @@ add_swift_unittest(SwiftBasicTests
   OwnedStringTest.cpp
   MultiMapCacheTest.cpp
   PointerIntEnumTest.cpp
+  PointerIntPairTest.cpp
   PrefixMapTest.cpp
   RangeTest.cpp
   SmallMapTest.cpp

--- a/unittests/Basic/PointerIntPairTest.cpp
+++ b/unittests/Basic/PointerIntPairTest.cpp
@@ -1,0 +1,76 @@
+//===--- PointerIntPairTest.cpp -------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Basic/PointerIntPair.h"
+#include "llvm/ADT/PointerIntPair.h"
+#include "gtest/gtest.h"
+#include <type_traits>
+
+using namespace swift;
+
+namespace {
+enum class E : unsigned { A, B, C, D, E_, F, G, H };
+}
+
+static_assert(
+    std::is_same<PointerIntPair<int *, 2, unsigned>,
+                 llvm::PointerIntPair<int *, 2, unsigned>>::value,
+    "sufficient-bit case must alias llvm::PointerIntPair");
+static_assert(
+    std::is_same<PointerIntPair<int *, 3, E>,
+                 pointer_int_pair_detail::SeparateStorage<int *, E>>::value,
+    "insufficient-bit case must use the separate-storage fallback");
+
+TEST(PointerIntPair, PackedPathRoundTrips) {
+  int x = 0, y = 0;
+  PointerIntPair<int *, 2, unsigned> p(&x, 3);
+  EXPECT_EQ(p.getPointer(), &x);
+  EXPECT_EQ(p.getInt(), 3u);
+  p.setInt(1);
+  EXPECT_EQ(p.getInt(), 1u);
+  p.setPointer(&y);
+  EXPECT_EQ(p.getPointer(), &y);
+  EXPECT_EQ(p.getInt(), 1u);
+  p.setPointerAndInt(&x, 2);
+  EXPECT_EQ(p.getPointer(), &x);
+  EXPECT_EQ(p.getInt(), 2u);
+}
+
+TEST(PointerIntPair, FallbackPathRoundTrips) {
+  int x = 0, y = 0;
+  PointerIntPair<int *, 3, E> p;
+  EXPECT_EQ(p.getPointer(), nullptr);
+  EXPECT_EQ(p.getInt(), E::A);
+
+  p = PointerIntPair<int *, 3, E>(&x, E::F);
+  EXPECT_EQ(p.getPointer(), &x);
+  EXPECT_EQ(p.getInt(), E::F);
+
+  for (unsigned i = 0; i < 8; ++i) {
+    p.setInt(static_cast<E>(i));
+    EXPECT_EQ(p.getInt(), static_cast<E>(i));
+    EXPECT_EQ(p.getPointer(), &x);
+  }
+
+  p.setPointerAndInt(&y, E::C);
+  EXPECT_EQ(p.getPointer(), &y);
+  EXPECT_EQ(p.getInt(), E::C);
+
+  p.initWithPointer(&x);
+  EXPECT_EQ(p.getPointer(), &x);
+  EXPECT_EQ(p.getInt(), E::A);
+
+  PointerIntPair<int *, 3, E> q(&x, E::A);
+  EXPECT_TRUE(p == q);
+  q.setInt(E::D);
+  EXPECT_TRUE(p != q);
+}


### PR DESCRIPTION
On 32-bit hosts, pointers lack the spare low bits the compiler's `PointerIntPair`-based structures pack tags into, and the object-header refcount is the wrong width. A new `swift::PointerIntPair` packs the tag when those low bits exist and stores it in a separate field otherwise. The refcount becomes pointer-width, `AbstractConformance` is force-aligned, and 64-bit builds are unchanged.

`include/swift/Basic/SwiftObjectHeader.h` is also updated to use `intptr_t`.