### PR TITLE
Fix testing with Xcode 27 beta, pt 2

### DIFF
--- a/validation-test/IDE/crashers_fixed/ConstraintSystem-repairFailures-731b5f.swift
+++ b/validation-test/IDE/crashers_fixed/ConstraintSystem-repairFailures-731b5f.swift
@@ -1,5 +1,5 @@
 // {"kind":"complete","original":"fc5babc7","signature":"swift::constraints::ConstraintSystem::repairFailures(swift::Type, swift::Type, swift::constraints::ConstraintKind, swift::optionset::OptionSet<swift::constraints::ConstraintSystem::TypeMatchFlags, unsigned int>, llvm::SmallVectorImpl<swift::constraints::RestrictionOrFix>&, swift::constraints::ConstraintLocatorBuilder)","signatureAssert":"Assertion failed: (!hasCallerSideDefaultExpr()), function getTypeOfDefaultExpr","signatureNext":"ConstraintSystem::matchTypes"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 // REQUIRES: OS=macosx
 import Foundation
 NSError(


### PR DESCRIPTION
Building the main branch with Xcode 27 beta shows one XFAILed test that is no longer failing.  Let's enable it and see what happens.