### PR TITLE
IRGen: Guard std::thread use behind LLVM_ENABLE_THREADS

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -1615,7 +1615,6 @@ GeneratedModule IRGenRequest::evaluate(Evaluator &evaluator,
     SILMod.reset(nullptr);
   };
 #if LLVM_ENABLE_THREADS
-  // Execute this task in parallel to the embedding of bitcode.
   auto Thread = std::thread(SILModuleRelease);
   // Wait for the thread to terminate.
   SWIFT_DEFER { Thread.join(); };

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -104,6 +104,7 @@
 #include "llvm/IR/LLVMRemarkStreamer.h"
 #include "llvm/Support/ToolOutputFile.h"
 
+#include "llvm/Config/llvm-config.h"
 #include <thread>
 
 #if HAVE_UNISTD_H
@@ -1610,15 +1611,22 @@ GeneratedModule IRGenRequest::evaluate(Evaluator &evaluator,
   if (Ctx.hadError()) return GeneratedModule::null();
 
   // Free the memory occupied by the SILModule.
-  // Execute this task in parallel to the embedding of bitcode.
   auto SILModuleRelease = [&SILMod]() {
     SILMod.reset(nullptr);
   };
+#if LLVM_ENABLE_THREADS
+  // Execute this task in parallel to the embedding of bitcode.
   auto Thread = std::thread(SILModuleRelease);
   // Wait for the thread to terminate.
   SWIFT_DEFER { Thread.join(); };
 
   embedBitcode(IGM.getModule(), Opts);
+#else
+  // Starting a std::thread aborts on the no-pthread host (single-threaded
+  // WebAssembly), so run these serially instead.
+  SILModuleRelease();
+  embedBitcode(IGM.getModule(), Opts);
+#endif
 
   // TODO: Turn the module hash into an actual output.
   if (auto **outModuleHash = desc.outModuleHash) {
@@ -1980,6 +1988,7 @@ static void performParallelIRGeneration(IRGenDescriptor desc) {
 
   llvm::sys::Mutex DiagMutex;
 
+#if LLVM_ENABLE_THREADS
   // Start all the threads and do the LLVM compilation.
 
   LLVMCodeGenThreads codeGenThreads(&irgen, &DiagMutex, Opts.NumThreads - 1);
@@ -1997,6 +2006,11 @@ static void performParallelIRGeneration(IRGenDescriptor desc) {
   // Wait for all threads.
   releaseModuleThread.join();
   codeGenThreads.join();
+#else
+  LLVMCodeGenThreads codeGenThreads(&irgen, &DiagMutex, /*numThreads=*/0);
+  codeGenThreads.runMainThread();
+  SILMod.reset(nullptr);
+#endif
 }
 
 GeneratedModule swift::performIRGeneration(


### PR DESCRIPTION
IRGen spawns `std::thread` to free the SILModule alongside bitcode embedding and to run parallel LLVM codegen. Starting a thread aborts on a host built without thread support, such as single-threaded WebAssembly. A new `#if LLVM_ENABLE_THREADS` guard runs both serially otherwise, leaving threaded hosts unchanged.