### PR TITLE
Fix Emscripten libc module under C++ interop, add UUID support

### DIFF
--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 # On non-Darwin require UUID.
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" OR CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
   set(UUID_INCLUDE "")
   set(UUID_LIBRARIES "")
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")

--- a/lib/Basic/UUID.cpp
+++ b/lib/Basic/UUID.cpp
@@ -31,6 +31,11 @@
 #include <uuid/uuid.h>
 #endif
 
+#if defined(__EMSCRIPTEN__)
+static inline void uuid_generate_random(uuid_t out) { uuid_generate(out); }
+static inline void uuid_generate_time(uuid_t out) { uuid_generate(out); }
+#endif
+
 using namespace swift;
 
 swift::UUID::UUID(FromRandom_t) {

--- a/stdlib/public/Platform/emscripten-libc.modulemap
+++ b/stdlib/public/Platform/emscripten-libc.modulemap
@@ -10,12 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-module SwiftEmscriptenLibc [system] {
+module SwiftEmscriptenLibc [system] [no_undeclared_includes] {
   header "stdc-predef.h"
   header "features.h"
 
   // C standard library
-  header "complex.h"
   header "ctype.h"
   header "errno.h"
   header "fenv.h"
@@ -74,4 +73,9 @@ module SwiftEmscriptenLibc [system] {
   // includes this header and maps POSIX errno names to __WASI_ERRNO_* values.
   header "wasi/api.h"
   export *
+
+  explicit module Complex {
+    header "complex.h"
+    export *
+  }
 }


### PR DESCRIPTION
Building the `SwiftEmscriptenLibc` module under `-cxx-interoperability-mode` fails two ways. An internal `#include <inttypes.h>` resolves to libc++'s wrapper module and cycles back to this module. `complex.h`'s `#define complex _Complex` leaks through `export *` and breaks libc++'s `std` module. Adding `[no_undeclared_includes]` and moving `complex.h` into an explicit submodule fixes both. Emscripten's `<uuid/uuid.h>` declares only the generic `uuid_generate`, so this adds `uuid_generate_random` and `uuid_generate_time` shims. The symbols are in the auto-linked libc, so UUID is handled like Darwin with no separate library.