### PR TITLE
[cxx-interop] Fix cycle in macro expansion request

### DIFF
--- a/lib/AST/ConformanceLookup.cpp
+++ b/lib/AST/ConformanceLookup.cpp
@@ -706,10 +706,21 @@ LookupConformanceRequest::evaluate(Evaluator &evaluator,
   // extension macro can generate a conformance to the
   // given protocol, but conformance macros do not specify
   // that information upfront.
-  (void)evaluateOrDefault(
-      ctx.evaluator,
-      ExpandExtensionMacros{nominal},
-      { });
+  //
+  // As a special case, skip the expansion when looking up an invertible
+  // protocol (Copyable/Escapable) conformance on a Clang-imported type. An
+  // invertible conformance must be declared in the same source file as the
+  // type (see diag::invertible_conformance_other_source_file), so a
+  // macro-generated extension can never introduce one for an imported type.
+  // Skipping the expansion here also breaks a cycle: expanding extension macros
+  // on a Clang-imported type pretty-prints the declaration, which computes the
+  // interface types of its members, which queries invertible conformances,
+  // which would otherwise re-enter extension macro expansion.
+  auto knownProtocol = protocol->getKnownProtocolKind();
+  if (!(nominal->hasClangNode() && knownProtocol &&
+        getInvertibleProtocolKind(*knownProtocol))) {
+    (void)evaluateOrDefault(ctx.evaluator, ExpandExtensionMacros{nominal}, {});
+  }
 
   // Find the root conformance in the nominal type declaration's
   // conformance lookup table.

--- a/test/Interop/Cxx/macros/extension-macro-on-imported-type.swift
+++ b/test/Interop/Cxx/macros/extension-macro-on-imported-type.swift
@@ -1,0 +1,50 @@
+// REQUIRES: swift_swift_parser
+// REQUIRES: swift_feature_MacrosOnImports
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/../../../Macros/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+// RUN: %target-swift-frontend -swift-version 5 -emit-module -o %t/macro_decl.swiftmodule %t/macro_decl.swift -module-name macro_decl -load-plugin-library %t/%target-library-name(MacroDefinition)
+// RUN: %target-swift-frontend -swift-version 5 -typecheck -verify -cxx-interoperability-mode=default -enable-experimental-feature MacrosOnImports -load-plugin-library %t/%target-library-name(MacroDefinition) -I %t -I %t/Inputs %t/client.swift
+
+//--- macro_decl.swift
+@attached(extension)
+public macro EmptyExtension() = #externalMacro(module: "MacroDefinition", type: "EmptyExtensionMacro")
+
+//--- Inputs/module.modulemap
+module CxxAPI {
+    header "cxx.h"
+    requires cplusplus
+    export *
+}
+
+//--- Inputs/cxx.h
+#pragma once
+
+struct __attribute__((swift_attr("@macro_decl.EmptyExtension"))) Thing {};
+
+// Two types that carry the macro and reference each other, to make sure
+// expanding the macro on one does not cycle through the other.
+struct MutualCaller1;
+struct __attribute__((swift_attr("@macro_decl.EmptyExtension"))) MutualCaller2 {
+  MutualCaller1 *foo;
+  void bar(MutualCaller1 *mc);
+};
+struct __attribute__((swift_attr("@macro_decl.EmptyExtension"))) MutualCaller1 {
+  MutualCaller2 baz;
+  void qux(MutualCaller2 *mc);
+};
+
+//--- client.swift
+import CxxAPI
+import macro_decl
+
+func use() {
+  let t: Thing? = nil
+  _ = t
+  let a: MutualCaller1? = nil
+  _ = a
+  let b: MutualCaller2? = nil
+  _ = b
+}

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -1698,6 +1698,34 @@ public struct EmptyPeerMacro: PeerMacro {
   }
 }
 
+public struct EmptyExtensionMacro: ExtensionMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo declaration: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    return []
+  }
+}
+
+/// Adds a conditional conformance to the invertible protocol `Copyable`, i.e.
+/// `extension <T>: Copyable where T: Copyable {}`.
+public struct ConditionalCopyableMacro: ExtensionMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo declaration: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    let ext: DeclSyntax =
+      "extension \(type.trimmed): Copyable where T: Copyable {}"
+    return [ext.cast(ExtensionDeclSyntax.self)]
+  }
+}
+
 public struct EquatableMacro: ExtensionMacro {
   public static func expansion(
     of node: AttributeSyntax,

--- a/test/Macros/extension_macro_conditional_invertible_conformance.swift
+++ b/test/Macros/extension_macro_conditional_invertible_conformance.swift
@@ -1,0 +1,21 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+// RUN: %target-swift-frontend -swift-version 5 -typecheck -verify -load-plugin-library %t/%target-library-name(MacroDefinition) %s
+
+@attached(extension, conformances: Copyable)
+macro ConditionalCopyable() = #externalMacro(module: "MacroDefinition", type: "ConditionalCopyableMacro")
+
+@ConditionalCopyable
+struct Box<T: ~Copyable>: ~Copyable {
+  var value: T
+}
+
+func needsCopy<T>(_ x: T) -> (T, T) { (x, x) }
+
+// `Box<Int>` is Copyable only because of the macro-generated conditional
+// conformance; if the macro were not expanded here this would fail to compile.
+func test(_ b: Box<Int>) {
+  _ = needsCopy(b)
+}


### PR DESCRIPTION
Importing the problematic macro on a C++ type resulted in the following cycle:

  ExpandExtensionMacros(Thing)
    → PrettyPrintDeclRequest(Thing)          // done for Clang-imported decls
      → InterfaceTypeRequest(Thing.init())    // printing the implicit member
        → LifetimeDependenceInfoRequest(init)
          → lookupConformance(Escapable, Thing)
            → ExpandExtensionMacros(Thing)     // <- re-entry

To sidestep this problem, we do not expand macros for imported types during the lookup of invertible protocol conformances. Such conformance can only be introduced by an extension in the same source file, this can never happen for imported types.

rdar://180667125

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
