### PR TITLE
Add CMake for Emscripten-hosted compiler

### DIFF
--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -231,6 +231,8 @@ function(add_swift_compiler_modules_library name)
     string(STRIP "${swiftly_dir}" swiftly_dir)
 
     list(APPEND sdk_option "-I" "${swiftly_dir}/usr/lib" "-I" "${swiftly_dir}/usr/lib")
+  elseif(SWIFT_HOST_VARIANT_SDK STREQUAL "EMSCRIPTEN")
+    list(APPEND sdk_option "-I" "${SWIFT_PATH_TO_SWIFT_SDK}/lib")
   else()
     list(APPEND sdk_option "-I" "${swift_exec_bin_dir}/../lib" "-I" "${sdk_path}/usr/lib")
   endif()
@@ -308,7 +310,11 @@ function(add_swift_compiler_modules_library name)
       COMMENT "Building swift module ${module}")
 
     if(BOOTSTRAPPING_MODE STREQUAL "CROSSCOMPILE")
-      add_dependencies(${dep_target} swift-stdlib-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH})
+      # The swift-stdlib target is absent when building against a prebuilt target
+      # stdlib (e.g. a wasm host), so only add the ordering dependency if it exists.
+      if(TARGET swift-stdlib-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH})
+        add_dependencies(${dep_target} swift-stdlib-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH})
+      endif()
     endif()
     set("${module}_dep_target" ${dep_target})
     set(all_module_targets ${all_module_targets} ${dep_target})

--- a/cmake/caches/EmscriptenHostLLVM.cmake
+++ b/cmake/caches/EmscriptenHostLLVM.cmake
@@ -1,0 +1,42 @@
+# Cross-build LLVM to run hosted on a WebAssembly (Emscripten) runtime. Consumed
+# by the EmscriptenHostLLVM build-script product via `emcmake cmake -C ...`.
+# Standalone:
+#   emcmake cmake -G Ninja -S <llvm-project>/llvm -B <build> \
+#     -C <swift>/cmake/caches/EmscriptenHostLLVM.cmake -DLLVM_TABLEGEN=<native llvm-tblgen>
+#
+# Pin the host/default triples explicitly: auto-detection runs config.guess on
+# the build machine and bakes in the build host, and the default target triple
+# does not reliably inherit the host triple.
+
+set(LLVM_HOST_TRIPLE "wasm32-unknown-emscripten" CACHE STRING "")
+set(LLVM_DEFAULT_TARGET_TRIPLE "wasm32-unknown-emscripten" CACHE STRING "")
+set(LLVM_TARGETS_TO_BUILD "WebAssembly" CACHE STRING "")
+set(LLVM_ENABLE_PROJECTS "clang;lld" CACHE STRING "")
+
+set(LLVM_TOOL_LLVM_DRIVER_BUILD ON CACHE BOOL "")
+
+set(LLVM_DISTRIBUTION_COMPONENTS "clang;lld" CACHE STRING "")
+
+set(CLANG_SPAWN_CC1 OFF CACHE BOOL "")
+
+set(LLVM_BUILD_LLVM_DYLIB OFF CACHE BOOL "")
+set(LLVM_LINK_LLVM_DYLIB OFF CACHE BOOL "")
+set(CLANG_LINK_CLANG_DYLIB OFF CACHE BOOL "")
+
+set(CLANG_ENABLE_ARCMT OFF CACHE BOOL "")
+set(CLANG_ENABLE_STATIC_ANALYZER OFF CACHE BOOL "")
+
+set(LLVM_llvm-driver_LINKER_FLAGS
+    "-sALLOW_MEMORY_GROWTH=1;-sSTACK_SIZE=8388608;-sINITIAL_MEMORY=134217728;-sMODULARIZE=1;-sEXPORT_NAME=createLLVMDriver;-sFORCE_FILESYSTEM=1;-sEXIT_RUNTIME=0;-sENVIRONMENT=node,web;-sEXPORTED_RUNTIME_METHODS=FS,callMain;-gseparate-dwarf"
+    CACHE STRING "")
+
+set(LLVM_ENABLE_THREADS OFF CACHE BOOL "")
+set(LLVM_ENABLE_PLUGINS OFF CACHE BOOL "")
+set(LLVM_ENABLE_ZLIB OFF CACHE BOOL "")
+set(LLVM_ENABLE_ZSTD OFF CACHE BOOL "")
+set(LLVM_ENABLE_LIBXML2 OFF CACHE BOOL "")
+set(LLVM_ENABLE_LIBEDIT OFF CACHE BOOL "")
+
+set(LLVM_INCLUDE_TESTS OFF CACHE BOOL "")
+set(LLVM_INCLUDE_BENCHMARKS OFF CACHE BOOL "")
+set(LLVM_INCLUDE_EXAMPLES OFF CACHE BOOL "")

--- a/cmake/caches/EmscriptenHostSwift.cmake
+++ b/cmake/caches/EmscriptenHostSwift.cmake
@@ -1,0 +1,49 @@
+# Cross-build `swift-frontend` to run hosted on a WebAssembly (Emscripten)
+# runtime. The Swift half of the wasm-hosted toolchain; LLVM/clang uses
+# EmscriptenHostLLVM.cmake.
+# Consumed by the EmscriptenHostSwift build-script product, which also passes
+# the path-dependent -D flags (LLVM_DIR, Clang_DIR, SDK/sysroot, native tools,
+# and the EmscriptenHostSwiftLLDShim.cmake top-level include).
+#
+# These `set(... CACHE ...)` entries are no-FORCE: they apply only on a fresh
+# build dir, not an existing one (even with --reconfigure). Remove the build
+# dir and reconfigure after editing this file.
+
+# BOOTSTRAPPING_MODE is BOOTSTRAPPING, but the product also passes
+# SWIFT_NATIVE_SWIFT_TOOLS_PATH (a prebuilt native swiftc), which flips the
+# effective mode to CROSSCOMPILE: that swiftc compiles SwiftCompilerSources
+# instead of in-tree bootstrapping stages.
+set(SWIFT_ENABLE_SWIFT_IN_SWIFT ON CACHE BOOL "")
+set(SWIFT_BUILD_SWIFT_SYNTAX OFF CACHE BOOL "")
+set(BOOTSTRAPPING_MODE "BOOTSTRAPPING" CACHE STRING "")
+
+set(SWIFT_HOST_VARIANT_SDK "EMSCRIPTEN" CACHE STRING "")
+set(SWIFT_HOST_VARIANT_ARCH "wasm32" CACHE STRING "")
+
+# No immediate (JIT) mode on the wasm host.
+set(SWIFT_INCLUDE_TOOLS ON CACHE BOOL "")
+set(SWIFT_BUILD_IMMEDIATE_MODE OFF CACHE BOOL "")
+
+# Auxiliary tool libraries not run on the wasm host.
+set(SWIFT_TOOL_LIBSWIFTSCAN_BUILD OFF CACHE BOOL "")
+set(SWIFT_TOOL_LIBSTATICMIRROR_BUILD OFF CACHE BOOL "")
+set(SWIFT_TOOL_LIBMOCKPLUGIN_BUILD OFF CACHE BOOL "")
+
+# The stdlib, overlays, and SourceKit are prebuilt inputs; this build produces
+# the frontend, not the runtime.
+set(SWIFT_BUILD_DYNAMIC_STDLIB OFF CACHE BOOL "")
+set(SWIFT_BUILD_STATIC_STDLIB OFF CACHE BOOL "")
+set(SWIFT_BUILD_REMOTE_MIRROR OFF CACHE BOOL "")
+set(SWIFT_BUILD_SOURCEKIT OFF CACHE BOOL "")
+set(SWIFT_BUILD_CLANG_OVERLAYS OFF CACHE BOOL "")
+set(SWIFT_BUILD_DYNAMIC_SDK_OVERLAY OFF CACHE BOOL "")
+
+set(SWIFT_INCLUDE_TESTS OFF CACHE BOOL "")
+set(SWIFT_INCLUDE_DOCS OFF CACHE BOOL "")
+
+# Emscripten link flags: grow memory up to 4 GiB (wasm32 max), access the host
+# filesystem directly (NODERAWFS), and emit DWARF into a sidecar so the main
+# module stays under the wasm engine's per-module size limit.
+set(CMAKE_EXE_LINKER_FLAGS
+    "-sALLOW_MEMORY_GROWTH=1 -sMAXIMUM_MEMORY=4294967296 -sSTACK_SIZE=8388608 -sINITIAL_MEMORY=134217728 -sNODERAWFS=1 -sENVIRONMENT=node -gseparate-dwarf"
+    CACHE STRING "")

--- a/cmake/caches/EmscriptenHostSwiftLLDShim.cmake
+++ b/cmake/caches/EmscriptenHostSwiftLLDShim.cmake
@@ -1,0 +1,16 @@
+if(NOT SWIFT_EMSCRIPTEN_HOST_LLVM_LIB_DIR)
+  message(FATAL_ERROR
+    "SWIFT_EMSCRIPTEN_HOST_LLVM_LIB_DIR is not set. This top-level include "
+    "expects -DSWIFT_EMSCRIPTEN_HOST_LLVM_LIB_DIR=<emscriptenhostllvm>/lib, "
+    "pointing at the EmscriptenHostLLVM build's lib directory (the one "
+    "containing liblldWasm.a / liblldCommon.a).")
+endif()
+
+foreach(_lldlib lldWasm lldCommon)
+  if(NOT TARGET ${_lldlib})
+    add_library(${_lldlib} STATIC IMPORTED GLOBAL)
+    set_target_properties(${_lldlib} PROPERTIES
+      IMPORTED_LOCATION
+        "${SWIFT_EMSCRIPTEN_HOST_LLVM_LIB_DIR}/lib${_lldlib}.a")
+  endif()
+endforeach()

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -622,6 +622,18 @@ function(_add_swift_runtime_link_flags target relpath_to_lib_dir bootstrapping)
     else()
       message(FATAL_ERROR "Unknown BOOTSTRAPPING_MODE '${ASRLF_BOOTSTRAPPING_MODE}'")
     endif()
+  elseif(SWIFT_HOST_VARIANT_SDK STREQUAL "EMSCRIPTEN")
+    if(NOT SWIFT_PATH_TO_SWIFT_SDK)
+      message(FATAL_ERROR "SWIFT_PATH_TO_SWIFT_SDK must point at the prebuilt "
+        "Emscripten Swift stdlib when building a wasm host compiler; without it "
+        "the Swift runtime link path would resolve to '/lib/swift/...' and mislink.")
+    endif()
+    set(host_lib_arch_dir
+        "${SWIFT_PATH_TO_SWIFT_SDK}/lib/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}/${SWIFT_HOST_VARIANT_ARCH}")
+    target_link_libraries(${target} PRIVATE
+        "${host_lib_arch_dir}/swiftrt${CMAKE_C_OUTPUT_EXTENSION}")
+    target_link_libraries(${target} PRIVATE "${host_lib_arch_dir}/libswiftCore.a")
+    target_link_directories(${target} PRIVATE ${host_lib_arch_dir})
   else()
     target_link_directories(${target} PRIVATE
       ${SWIFT_PATH_TO_SWIFT_SDK}/usr/lib/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}/${SWIFT_HOST_VARIANT_ARCH})


### PR DESCRIPTION
This adds three cache files: one each for the cross-LLVM and the Swift compiler, the third is a top-level include that pre-defines the lld imported targets `find_package(Clang)` expects. Two existing CMake files gain `SWIFT_HOST_VARIANT_SDK == EMSCRIPTEN` branches for the runtime link and module include paths, which don't affect other hosts. The one non-gated change wraps a `CROSSCOMPILE` swift-stdlib ordering dependency in an existence check. It is a no-op unless that target is absent, which happens only when building against a prebuilt stdlib.
