### PR TITLE
[Diagnostics] Fix missing diagnostic for init as value

### DIFF
--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -1632,6 +1632,12 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
+  // May have overloaded methods being partially applied, causing ambiguity that
+  // does not currently impact diagnostic produced
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
+    return diagnose(*commonFixes.front().first);
+  }
+
   static AllowInvalidPartialApplication *create(bool isWarning,
                                                 ConstraintSystem &cs,
                                                 ConstraintLocator *locator);

--- a/test/expr/postfix/init/unqualified.swift
+++ b/test/expr/postfix/init/unqualified.swift
@@ -7,7 +7,7 @@ class Aaron {
     func foo() {
       // Make sure we recover and assume 'self.init'.
       // expected-error@+2 {{initializer expression requires explicit access; did you mean to prepend it with 'self.'?}} {{11-11=self.}}
-      // expected-error@+1 {{failed to produce diagnostic for expression}}
+      // expected-error@+1 {{cannot reference 'self.init' initializer delegation as function value}}
       _ = init
     }
   }
@@ -48,7 +48,7 @@ class Theodosia: Aaron {
 
     // Make sure we recover and assume 'self.init'.
     // expected-error@+2 {{initializer expression requires explicit access; did you mean to prepend it with 'self.'?}} {{22-22=self.}}
-    // expected-error@+1 {{failed to produce diagnostic for expression}}
+    // expected-error@+1 {{cannot reference 'self.init' initializer delegation as function value}}
     func foo() { _ = init }
   }
 


### PR DESCRIPTION
Returning false (the default) in diagnoseForAmbiguity causes cases with overloaded inits to skip the fix attached to each of the overloads in these circumstances (and possibly other cases for invalidPartialApplication). 
And then we do not get a diagnostic result. 

Returning the first result is here acceptable because there are no changes to the diagnostic based on the different overloads, we just want to recognise the fix already found. 