### PR TITLE
BorrowingForLoop: add SILGen support for Opaque Values

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Utilities/BorrowUtils.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/BorrowUtils.swift
@@ -640,7 +640,7 @@ extension Value {
     guard apply.singleDirectResult != nil else {
       return false
     }
-    return apply.functionConvention.resultsWithError[0].convention == .guaranteed
+    return apply.hasGuaranteedResult
   }
 }
 

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1506,8 +1506,13 @@ public:
   void copyOrInitValueInto(SILGenFunction &SGF, SILLocation loc,
                            ManagedValue value, bool isInit) override {
 
-    auto bindValue = SGF.B.createMarkUnresolvedNonCopyableValueInst(
-        pattern, value,
+    ManagedValue bindValue = value;
+    if (!SGF.useLoweredAddresses()) {
+      bindValue = bindValue.copy(SGF, loc);
+    }
+
+    bindValue = SGF.B.createMarkUnresolvedNonCopyableValueInst(
+        pattern, bindValue,
         MarkUnresolvedNonCopyableValueInst::CheckKind::NoConsumeOrAssign,
         MarkUnresolvedNonCopyableValueInst::IsStrict);
 

--- a/test/SILGen/foreach_borrowing.swift
+++ b/test/SILGen/foreach_borrowing.swift
@@ -1,11 +1,18 @@
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -Xllvm -sil-print-types -g -Xllvm -sil-print-debuginfo-verbose -enable-experimental-feature BorrowingForLoop -enable-experimental-feature BorrowingSequence %s
+// RUN: %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -Xllvm -sil-print-types -g -Xllvm -sil-print-debuginfo-verbose -enable-experimental-feature BorrowingForLoop -enable-experimental-feature BorrowingSequence %s
+
+// RUN: not --crash %target-swift-emit-sil -sil-verify-all -enable-sil-opaque-values -enable-experimental-feature BorrowingForLoop -enable-experimental-feature BorrowingSequence -o /dev/null %s
 
 // RUN: %target-swift-emit-silgen -Xllvm -sil-print-types \
 // RUN:     -g -Xllvm -sil-print-debuginfo-verbose \
 // RUN:     -enable-experimental-feature BorrowingForLoop \
 // RUN:     -enable-experimental-feature BorrowingSequence \
-// RUN:     %s | %FileCheck %s
+// RUN:     %s | %FileCheck %s --check-prefixes=CHECK,CHECK-ADDR
+// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types \
+// RUN:     -g -Xllvm -sil-print-debuginfo-verbose \
+// RUN:     -enable-experimental-feature BorrowingForLoop \
+// RUN:     -enable-experimental-feature BorrowingSequence \
+// RUN:     -enable-sil-opaque-values \
+// RUN:     %s | %FileCheck %s --check-prefixes=CHECK,CHECK-OPAQUE
 
 // REQUIRES: swift_feature_BorrowingForLoop
 // REQUIRES: swift_feature_BorrowingSequence
@@ -184,7 +191,8 @@ func testForEachLocations(seq: borrowing Span<Int>, val: Int) {
 // CHECK-LABEL: sil hidden {{.*}}[ossa] @$s17foreach_borrowing34testForEachNonCopyableSILDebugInfo3seqys4SpanVyAA14NoncopyableIntVG_tF : $@convention(thin) (@guaranteed Span<NoncopyableInt>) -> () {
 @available(SwiftStdlib 6.4, *)
 func testForEachNonCopyableSILDebugInfo(seq: borrowing Span<NoncopyableInt>){
-  // CHECK: debug_value {{.*}} : $*NoncopyableInt, let, name "element", expr op_deref, loc "{{.*}}":[[@LINE+1]]:7 isImplicit: false
+  // CHECK-ADDR: debug_value {{.*}} : $*NoncopyableInt, let, name "element", expr op_deref, loc "{{.*}}":[[@LINE+2]]:7 isImplicit: false
+  // CHECK-OPAQUE: debug_value {{.*}} : $NoncopyableInt, let, name "element", loc "{{.*}}":[[@LINE+1]]:7 isImplicit: false
   for element in seq {
       if (element.value == 0){
           continue


### PR DESCRIPTION
Under -enable-sil-opaque-values, SILGen aborts while emitting a borrowing for-in loop over a noncopyable Span element. The loop body binds the element with a borrow binding; under opaque values the borrowed element is a guaranteed opaque object value (neither +1 nor an address nor an lvalue), which violates the precondition for creating the mark_unresolved_non_copyable_value instruction.

Reproducer: test/SILGen/foreach_borrowing.swift, testNonCopyableBorrowingSequence(seq:), line 25 (for-in over a Span<NoncopyableInt>). Run with: swift-frontend -emit-silgen-ossa -sil-verify-all -enable-sil-opaque-values -enable-experimental-feature BorrowingForLoop -enable-experimental-feature BorrowingSequence -swift-version 4

What the compiler reports:

    Assertion failed: ((value.isPlusOne(SGF) || value.isLValue() || value.getType().isAddress()) && "Argument must be at +1 or be an address!"), function createMarkUnresolvedNonCopyableValueInst, file SILGenBuilder.cpp, line 1245.

Resolves rdar://180980708.