### PR TITLE
[ClangImporter] Do not construct CodeGenOpts when not needed

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -213,6 +213,7 @@ public:
   create(ASTContext &ctx, const IRGenOptions *IRGenOpts = nullptr,
          StringRef swiftPCHHash = "", std::string casidForPCH = "",
          DependencyTracker *tracker = nullptr, bool ignoreFileMapping = false,
+         bool needCodeGenTargetOpts = true,
          std::shared_ptr<llvm::cas::ObjectStore> CAS = nullptr,
          std::shared_ptr<llvm::cas::ActionCache> Cache = nullptr);
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1474,12 +1474,11 @@ std::unique_ptr<clang::CompilerInvocation> ClangImporter::createClangInvocation(
   return CI;
 }
 
-std::unique_ptr<ClangImporter>
-ClangImporter::create(ASTContext &ctx, const IRGenOptions *IRGenOpts,
-                      StringRef swiftPCHHash, std::string casidForPCH,
-                      DependencyTracker *tracker, bool ignoreFileMapping,
-                      std::shared_ptr<llvm::cas::ObjectStore> CAS,
-                      std::shared_ptr<llvm::cas::ActionCache> Cache) {
+std::unique_ptr<ClangImporter> ClangImporter::create(
+    ASTContext &ctx, const IRGenOptions *IRGenOpts, StringRef swiftPCHHash,
+    std::string casidForPCH, DependencyTracker *tracker, bool ignoreFileMapping,
+    bool needCodeGenTargetOpts, std::shared_ptr<llvm::cas::ObjectStore> CAS,
+    std::shared_ptr<llvm::cas::ActionCache> Cache) {
   std::unique_ptr<ClangImporter> importer{new ClangImporter(ctx, tracker)};
   auto &importerOpts = ctx.ClangImporterOpts;
 
@@ -1593,7 +1592,7 @@ ClangImporter::create(ASTContext &ctx, const IRGenOptions *IRGenOpts,
   clangDiags.setFatalsAsError(ctx.Diags.getShowDiagnosticsAfterFatalError());
 
   // Use Clang to configure/save options for Swift IRGen/CodeGen
-  if (ctx.LangOpts.ClangTarget.has_value()) {
+  if (ctx.LangOpts.ClangTarget.has_value() && needCodeGenTargetOpts) {
     // If '-clang-target' is set, create a mock invocation with the Swift triple
     // to configure CodeGen and Target options for Swift compilation.
     auto swiftTargetClangInvocation = importer->createClangInvocation(

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -882,13 +882,17 @@ bool CompilerInstance::setUpModuleLoaders() {
           IgnoreSourceInfoFile);
   }
 
+  bool needTargetCodeGenOpts =
+      FrontendOptions::doesActionGenerateSIL(FEOpts.RequestedAction);
+
   // Wire up the Clang importer. If the user has specified an SDK, use it.
   // Otherwise, we just keep it around as our interface to Clang's ABI
   // knowledge.
   std::unique_ptr<ClangImporter> clangImporter = ClangImporter::create(
       *Context, &Invocation.getIRGenOptions(), Invocation.getPCHHash(),
       CASIDForPCH, getDependencyTracker(), /*ignoreFileMapping=*/false,
-      getSharedCASInstance(), getSharedCacheInstance());
+      /*needCodeGenTargetOpts=*/needTargetCodeGenOpts, getSharedCASInstance(),
+      getSharedCacheInstance());
   if (!clangImporter) {
     Diagnostics.diagnose(SourceLoc(), diag::error_clang_importer_create_fail);
     return true;

--- a/test/ScanDependencies/direct-cc1-cpu-target.swift
+++ b/test/ScanDependencies/direct-cc1-cpu-target.swift
@@ -7,7 +7,8 @@
 
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json A | %FileCheck %s
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json Test | %FileCheck %s
-// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:B | %FileCheck %s
+// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:B > %t/clangB.rsp
+// RUN: %FileCheck %s --input-file %t/clangB.rsp
 
 /// ios26 is default to a12 CPU and ios18 is a10 CPU. -Xcc is selecting frontend parsing target options so it should be a12.
 // CHECK: target-cpu
@@ -15,6 +16,10 @@
 // CHECK-NEXT: apple-a12
 
 // RUN: %{python} %S/../../utils/swift-build-modules.py %swift_frontend_plain %t/deps.json -o %t/Test.cmd
+
+// RUN: %swift_frontend_plain @%t/clangB.rsp -dump-clang-diagnostics 2>&1 | %FileCheck %s --check-prefix CLANG-DIAG
+
+// CLANG-DIAG-NOT: clang importer driver args:
 
 // RUN: %swift-frontend-plain -target arm64-apple-ios18 -clang-target arm64-apple-ios26 \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -enable-builtin-module \


### PR DESCRIPTION
In #90037, ClangImporter is updated to fix the CodeGen target info when using directCC1 mode. This causes some regression on specific platforms for emitPCM actions. EmitPCM action in explicit module build only get a minimal set of the swift flags and on some platforms the minimal flags cannot generate clang driver arguments that can be accepted by ClangImporter.

The fix is to not regenerating driver arguments for CodeGen target options when there are no CodeGen is in the RequestedAction. This also saves the unnecessary round trip into clang driver when CodeGenOption is not needed.

rdar://181058499

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
