### PR TITLE
[test] Two new tests around version normalization and defined availabilities

### DIFF
--- a/test/Availability/availability_define.swift
+++ b/test/Availability/availability_define.swift
@@ -4,7 +4,8 @@
 // RUN:   -define-availability "_iOS54:iOS 54.0" \
 // RUN:   -define-availability "_macOS51_0:macOS 51.0" \
 // RUN:   -define-availability "_myProject 1.0:macOS 51.0" \
-// RUN:   -define-availability "_myProject 2.5:macOS 52.5"
+// RUN:   -define-availability "_myProject 2.5:macOS 52.5" \
+// RUN:   -define-availability "_myProject 16.0:macOS 16.0"
 
 // RUN: %target-typecheck-verify-swift \
 // RUN:   -enable-experimental-feature AvailabilityMacro='_iOS53Aligned:macOS 50.0, iOS 53.0' \
@@ -12,7 +13,8 @@
 // RUN:   -enable-experimental-feature AvailabilityMacro='_iOS54:iOS 54.0' \
 // RUN:   -enable-experimental-feature AvailabilityMacro="_macOS51_0:macOS 51.0" \
 // RUN:   -enable-experimental-feature AvailabilityMacro='_myProject 1.0:macOS 51.0' \
-// RUN:   -enable-experimental-feature AvailabilityMacro="_myProject 2.5:macOS 52.5"
+// RUN:   -enable-experimental-feature AvailabilityMacro="_myProject 2.5:macOS 52.5" \
+// RUN:   -enable-experimental-feature AvailabilityMacro="_myProject 16.0:macOS 16.0"
 
 // REQUIRES: OS=macosx
 
@@ -38,6 +40,10 @@ public func onMyProjectV1() {}
 
 @available(_myProject 2.5, *)
 public func onMyProjectV2_5() {}
+
+/// This should not fail when defining 16.0 and using just 16
+@available(_myProject 16, *)
+public func onMyProjectV16() {}
 
 @available(_myProject 3.0, *)// expected-error {{expected declaration}}
 // expected-error @-1 {{reference to undefined version '3.0' for availability macro '_myProject'}}

--- a/test/Availability/availability_define_parsing.swift
+++ b/test/Availability/availability_define_parsing.swift
@@ -8,6 +8,8 @@
 // RUN:   -define-availability "_noVersion: macOS" \
 // RUN:   -define-availability "_duplicateVersion 1.0:iOS 13.0" \
 // RUN:   -define-availability "_duplicateVersion 1.0:iOS 13.0" \
+// RUN:   -define-availability "_duplicateCanonicalVersion 17:macOS 16" \
+// RUN:   -define-availability "_duplicateCanonicalVersion 17.0:macOS 16.0" \
 // RUN:   -define-availability "_allowJustWildcard:*" \
 // RUN:   2>&1 | %FileCheck %s
 
@@ -35,6 +37,9 @@ public func noVersionMulti() {}
 
 // CHECK: duplicate definition of availability macro '_duplicateVersion' for version '1.0'
 // CHECK-NEXT: _duplicateVersion
+
+// CHECK: -define-availability argument:1:1: error: duplicate definition of availability macro '_duplicateCanonicalVersion' for version '17.0'
+// CHECK-NEXT: _duplicateCanonicalVersion
 
 // CHECK: -define-availability argument:1:18: warning: unrecognized platform name 'spaceOS'; did you mean 'macOS'?
 // CHECK-NEXT: _brokenPlatforms:spaceOS 10.11


### PR DESCRIPTION
llvm/llvm-project#206872 changes the implementation of `VersionTuple` `DenseMapInfo` hashing to re-use `VersionTuple` own `hash_value`. The previous implementation of `getHashValue` was returning different hashes for versions that were considered equal, which caused `-define-availability` miss some cases of duplicated versions, and availability checks fail to find the availability in some cases if the defined availability and the used availability used different "spellings".

Currently these two tests are failing in the `main` branch when using the current `stable/21.x` or `swift/release/6.4.x` branches of LLVM.

The new check in `availability_define_parsing.swift` should print "duplicate definition of availability macro '_duplicateCanonicalVersion' for version '17.0'" but prints nothing.

The new check in `availability_define.swift` should compile correctly, but currently it fails with "error: reference to undefined version '16' for availability macro '_myProject'".
