### PR TITLE
[SILOptimizer] Create pass to delete invalid debug values in OSSA

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
@@ -27,6 +27,7 @@ swift_compiler_sources(Optimizer
   DiagnoseInfiniteRecursion.swift
   EmbeddedWitnessCallSpecialization.swift
   InitializeStaticGlobals.swift
+  KillInvalidDebugValues.swift
   LetPropertyLowering.swift
   LifetimeDependenceDiagnostics.swift
   LifetimeDependenceInsertion.swift

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/KillInvalidDebugValues.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/KillInvalidDebugValues.swift
@@ -1,0 +1,119 @@
+//===--- KillInvalidDebugValues.swift --------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SIL
+
+/// Kills `debug_value` instructions that reference a value after the underlying memory has been freed.
+///
+/// For each `debug_value`, the pass walks up through `begin_borrow` and guaranteed forwarding instructions
+/// to find the root owned value. It then follows forwarding consumers (struct, tuple, etc.) transitively
+/// (since those don't free the bits) until it reaches actual destroying consumers (`destroy_value`,
+/// consuming `apply`, `store`). Forwarding consumes whose instruction is not a `ForwardingInstruction`
+/// (e.g. `return`) are treated as range endpoints because the value leaves the function.
+///
+/// An `InstructionRange` from the root's definition to those transitive destroying consumers determines
+/// the region where the bits are alive. Any `debug_value` outside this range has its operand killed.
+///
+/// This must run before OwnershipModelEliminator because it relies on ownership information.
+let killInvalidDebugValuesPass = FunctionPass(name: "kill-invalid-debug-values") {
+  (function: Function, context: FunctionPassContext) in
+
+  guard function.hasOwnership else {
+    return
+  }
+
+  // Collect debug_values grouped by root, so ranges are only computed once.
+  var rootWorklist = ValueWorklist(context)
+  defer { rootWorklist.deinitialize() }
+  var debugValuesForRoot: [ObjectIdentifier: [DebugValueInst]] = [:]
+
+  for block in function.blocks {
+    for inst in block.instructions {
+      guard let dbg = inst as? DebugValueInst,
+            let root = findOwnershipRoot(of: dbg.operand.value) else {
+        continue
+      }
+      rootWorklist.pushIfNotVisited(root)
+      debugValuesForRoot[ObjectIdentifier(root), default: []].append(dbg)
+    }
+  }
+
+  while let root = rootWorklist.pop() {
+    let debugValues = debugValuesForRoot[ObjectIdentifier(root)]!
+    guard context.continueWithNextSubpassRun(forValue: root) else {
+      return
+    }
+    killInvalidDebugValues(debugValues, root: root, context)
+  }
+}
+
+private func killInvalidDebugValues(_ debugValues: [DebugValueInst], root: Value,
+                                    _ context: FunctionPassContext) {
+  // Build a range from the root to where the content is actually destroyed.
+  // Forwarding consumers (struct, tuple, etc.) don't free the content, so having debug values on
+  // the original value is still fine: we follow through their results transitively until we reach
+  // actual destroying consumers.
+  var range = InstructionRange(for: root, context)
+  defer { range.deinitialize() }
+
+  var worklist = ValueWorklist(context)
+  defer { worklist.deinitialize() }
+  worklist.pushIfNotVisited(root)
+
+  while let current = worklist.pop() {
+    for use in current.uses {
+      if use.ownership == .destroyingConsume {
+        range.insert(use.instruction)
+      } else if use.ownership == .forwardingConsume {
+        if let fwd = use.instruction as? ForwardingInstruction {
+          for result in fwd.forwardedResults {
+            worklist.pushIfNotVisited(result)
+          }
+        } else {
+          // Treat non-forwarding instruction forwardingConsumes as an endpoint since we can't
+          // follow further (return, throw, br, etc).
+          range.insert(use.instruction)
+        }
+      }
+    }
+  }
+
+  for dbg in debugValues {
+    if !range.contains(dbg) {
+      dbg.killOperand()
+    }
+  }
+}
+
+/// Walk up from a value through `begin_borrow` and guaranteed forwarding instructions to find the
+/// owned value whose destroy frees the underlying memory.
+///
+/// Returns nil if no owned root can be found (e.g. guaranteed function arguments, `load_borrow`).
+private func findOwnershipRoot(of value: Value) -> Value? {
+  var current = value
+  while true {
+    if current.ownership == .owned {
+      return current
+    }
+    if let bbi = current.definingInstruction as? BeginBorrowInst {
+      current = bbi.borrowedValue
+      continue
+    }
+    if let fwd = current.forwardingInstruction,
+       current.ownership == .guaranteed,
+       let singleOp = fwd.singleForwardedOperand {
+      current = singleOp.value
+      continue
+    }
+    return nil
+  }
+}

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/FunctionPassContext.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/FunctionPassContext.swift
@@ -25,6 +25,10 @@ struct FunctionPassContext : MutatingContext {
     return bridgedPassContext.continueWithNextSubpassRun(inst.bridged)
   }
 
+  func continueWithNextSubpassRun(forValue value: Value?) -> Bool {
+    return bridgedPassContext.continueWithNextSubpassRun(value.bridged)
+  }
+
   func createSimplifyContext(preserveDebugInfo: Bool,
                              notifyInstructionChanged: @escaping (Instruction) -> ()
   ) -> SimplifyContext {

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -117,6 +117,7 @@ private func registerSwiftPasses() {
   registerPass(closureSpecialization, { closureSpecialization.run($0) })
   registerPass(autodiffClosureSpecialization, { autodiffClosureSpecialization.run($0) })
   registerPass(loopInvariantCodeMotionPass, { loopInvariantCodeMotionPass.run($0) })
+  registerPass(killInvalidDebugValuesPass, { killInvalidDebugValuesPass.run($0) })
   registerPass(packSpecialization, { packSpecialization.run($0) })
 
   // Instruction passes

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -272,6 +272,7 @@ struct BridgedPassContext {
   // Passmanager housekeeping
 
   BRIDGED_INLINE bool continueWithNextSubpassRun(OptionalBridgedInstruction inst) const;
+  BRIDGED_INLINE bool continueWithNextSubpassRun(OptionalBridgedValue value) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedContext initializeNestedPassContext(BridgedFunction newFunction) const;
   BRIDGED_INLINE void deinitializedNestedPassContext() const;
   BRIDGED_INLINE void

--- a/include/swift/SILOptimizer/OptimizerBridgingImpl.h
+++ b/include/swift/SILOptimizer/OptimizerBridgingImpl.h
@@ -373,6 +373,13 @@ bool BridgedPassContext::continueWithNextSubpassRun(OptionalBridgedInstruction i
       inst.unbridged(), invocation->getFunction(), invocation->getTransform());
 }
 
+bool BridgedPassContext::continueWithNextSubpassRun(OptionalBridgedValue value) const {
+  swift::SILPassManager *pm = invocation->getPassManager();
+  swift::SILValue silValue = value.getSILValue();
+  return pm->continueWithNextSubpassRun(
+      silValue, invocation->getFunction(), invocation->getTransform());
+}
+
 BridgedContext BridgedPassContext::initializeNestedPassContext(BridgedFunction newFunction) const {
   return { invocation->initializeNestedSwiftPassInvocation(newFunction.getFunction()) };
 }

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -132,6 +132,8 @@ PASS(LateOnoneSimplification, "late-onone-simplification",
     "Peephole simplifications which can only run late in the -Onone pipeline")
 PASS(CleanupDebugSteps, "cleanup-debug-steps",
     "Cleanup debug_step instructions for Onone")
+PASS(KillInvalidDebugValues, "kill-invalid-debug-values",
+    "Kill debug_value instructions that appear after destroying consumers")
 PASS(NamedReturnValueOptimization, "named-return-value-optimization",
     "Optimize copies to an indirect return value")
 PASS(StripObjectHeaders, "strip-object-headers",

--- a/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
@@ -67,29 +67,10 @@ struct OwnershipModelEliminatorVisitor
   /// builderCtxStorage.
   SILBuilderContext builderCtx;
 
-  /// A possibly null, possibly owned, possibly unowned pointer.
-  /// Owned if the boolean is true.
-  llvm::PointerIntPair<DominanceInfo *, 1, bool> domTree;
-
-  DominanceInfo *getDomTree(SILFunction *fn) {
-    if (!domTree.getPointer())
-      domTree = {new DominanceInfo(fn), true};
-    return domTree.getPointer();
-  }
-
-  ~OwnershipModelEliminatorVisitor() {
-    if (domTree.getInt())
-      delete domTree.getPointer();
-  }
-
   /// Construct an OME visitor for eliminating ownership from \p fn.
-  OwnershipModelEliminatorVisitor(SILFunction &fn,
-                                  DominanceAnalysis *da = nullptr)
+  OwnershipModelEliminatorVisitor(SILFunction &fn)
       : trackingList(), instructionsToSimplify(),
         builderCtx(fn.getModule(), &trackingList) {
-    if (da)
-      if (auto *cached = da->maybeGet(&fn).getPtrOrNull())
-        domTree = {cached, false};
   }
 
   /// A "syntactic" high level function that combines our insertPt with a
@@ -664,13 +645,6 @@ bool OwnershipModelEliminatorVisitor::visitDestroyValueInst(
   withBuilder<void>(dvi, [&](SILBuilder &b, SILLocation loc) {
     b.emitDestroyValueOperation(loc, operand);
   });
-  // Kill debug_values that appear after the destroy: this instruction might
-  // free stored pointers, so later debug uses are wrong.
-  for (auto *use : getDebugUses(operand)) {
-    auto *dbgInst = cast<DebugValueInst>(use->getUser());
-    if (getDomTree(dvi->getFunction())->dominates(dvi, dbgInst))
-      dbgInst->killOperand();
-  }
   if (dvi->poisonRefs()) {
     injectDebugPoison(dvi);
   }
@@ -822,8 +796,7 @@ bool OwnershipModelEliminatorVisitor::visitDestructureTupleInst(
 //                           Top Level Entry Point
 //===----------------------------------------------------------------------===//
 
-static bool stripOwnership(SILFunction &func,
-                           DominanceAnalysis *domAnalysis = nullptr) {
+static bool stripOwnership(SILFunction &func) {
   // If F is an external declaration, do not process it.
   if (func.isExternalDeclaration())
     return false;
@@ -865,7 +838,7 @@ static bool stripOwnership(SILFunction &func,
 
   bool madeChange = false;
   SmallVector<SILInstruction *, 32> createdInsts;
-  OwnershipModelEliminatorVisitor visitor(func, domAnalysis);
+  OwnershipModelEliminatorVisitor visitor(func);
 
   for (auto &block : func) {
     // Change all arguments to have OwnershipKind::None.
@@ -966,7 +939,7 @@ struct OwnershipModelEliminator : SILModuleTransform {
         getPassManager()->runSwiftFunctionVerification(&f);
       }
 
-      if (stripOwnership(f, getAnalysis<DominanceAnalysis>())) {
+      if (stripOwnership(f)) {
         auto InvalidKind = SILAnalysis::InvalidationKind::BranchesAndInstructions;
         invalidateAnalysis(&f, InvalidKind);
       }

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -88,6 +88,7 @@ static void addModulePrinterPipeline(SILPassPipelinePlan &plan,
 static void addMandatoryDebugSerialization(SILPassPipelinePlan &P) {
   P.startPipeline("Mandatory Debug Serialization");
   P.addAddressLowering();
+  P.addKillInvalidDebugValues();
   P.addOwnershipModelEliminator();
   P.addMandatoryInlining();
 }
@@ -354,6 +355,7 @@ SILPassPipelinePlan SILPassPipelinePlan::getOwnershipEliminatorPassPipeline(
   SILPassPipelinePlan P(Options);
   P.startPipeline("Ownership Model Eliminator");
   P.addAddressLowering();
+  P.addKillInvalidDebugValues();
   P.addOwnershipModelEliminator();
   return P;
 }
@@ -921,6 +923,7 @@ SILPassPipelinePlan::getLoweringPassPipeline(const SILOptions &Options) {
   // Lower thunks.
   P.addThunkLowering();
   P.addLowerHopToActor(); // FIXME: earlier for more opportunities?
+  P.addKillInvalidDebugValues();
   P.addOwnershipModelEliminator();
   P.addAlwaysEmitConformanceMetadataPreservation();
   P.addIRGenPrepare();
@@ -1025,6 +1028,7 @@ SILPassPipelinePlan::getPerformancePassPipeline(const SILOptions &Options) {
   // Perform optimizations that specialize.
   addClosureSpecializePassPipeline(P);
 
+  P.addKillInvalidDebugValues();
   P.addOwnershipModelEliminator();
 
   // Run another iteration of the SSA optimizations to optimize the
@@ -1094,6 +1098,7 @@ SILPassPipelinePlan::getOnonePassPipeline(const SILOptions &Options) {
   if (P.Options.StopOptimizationBeforeLoweringOwnership)
     return P;
 
+  P.addKillInvalidDebugValues();
   P.addOwnershipModelEliminator();
 
   // Finally perform some small transforms.

--- a/test/DebugInfo/kill_invalid_debug_values.sil
+++ b/test/DebugInfo/kill_invalid_debug_values.sil
@@ -1,0 +1,244 @@
+// RUN: %target-sil-opt -sil-print-types %s -kill-invalid-debug-values | %FileCheck %s
+
+// Tests for the kill-invalid-debug-values pass which kills debug_value
+// instructions that appear after the underlying memory has been freed.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+class Klass {}
+
+struct Pair {
+  var first: Klass
+  var second: Klass
+}
+
+// =============================================================================
+// Basic: debug_value before destroy is kept, after destroy is killed.
+// =============================================================================
+
+// CHECK-LABEL: sil [ossa] @test_basic_destroy
+// CHECK:         debug_value %0 : $Klass, let, name "before"
+// CHECK:         destroy_value %0
+// CHECK:         debug_value undef : $Klass, let, name "after"
+// CHECK-LABEL: } // end sil function 'test_basic_destroy'
+sil [ossa] @test_basic_destroy : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
+  debug_value %0 : $Klass, let, name "before"
+  destroy_value %0 : $Klass
+  debug_value %0 : $Klass, let, name "after"
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// =============================================================================
+// Diamond: destroys on both branches, debug_value after merge is killed.
+// =============================================================================
+
+// CHECK-LABEL: sil [ossa] @test_diamond_destroy
+// CHECK:       bb0({{.*}}):
+// CHECK:         debug_value %0 : $Klass, let, name "before"
+// CHECK:       bb3:
+// CHECK:         debug_value undef : $Klass, let, name "after_merge"
+// CHECK-LABEL: } // end sil function 'test_diamond_destroy'
+sil [ossa] @test_diamond_destroy : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
+  debug_value %0 : $Klass, let, name "before"
+  cond_br undef, bb1, bb2
+bb1:
+  destroy_value %0 : $Klass
+  br bb3
+bb2:
+  destroy_value %0 : $Klass
+  br bb3
+bb3:
+  debug_value %0 : $Klass, let, name "after_merge"
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// =============================================================================
+// Borrow: debug_value on begin_borrow result after destroy of original.
+// =============================================================================
+
+// CHECK-LABEL: sil [ossa] @test_borrow_after_destroy
+// CHECK:         debug_value %1 : $Klass, let, name "borrow_before"
+// CHECK:         destroy_value %0
+// CHECK:         debug_value undef : $Klass, let, name "borrow_after"
+// CHECK-LABEL: } // end sil function 'test_borrow_after_destroy'
+sil [ossa] @test_borrow_after_destroy : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
+  %1 = begin_borrow %0 : $Klass
+  end_borrow %1 : $Klass
+  debug_value %1 : $Klass, let, name "borrow_before"
+  destroy_value %0 : $Klass
+  debug_value %1 : $Klass, let, name "borrow_after"
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// =============================================================================
+// Forwarding consume: debug_value kept between struct and its destroy.
+// The class, after being forwarded into a struct, is still available for debug
+// info. After the pair is destroyed, the class is released, and might be
+// deallocated, so referencing it is unsafe.
+// =============================================================================
+
+// CHECK-LABEL: sil [ossa] @test_forwarding_consume
+// CHECK:         debug_value %0 : $Klass, let, name "before_struct"
+// CHECK:         %{{.*}} = struct $Pair
+// CHECK:         debug_value %0 : $Klass, let, name "after_struct"
+// CHECK:         destroy_value
+// CHECK:         debug_value undef : $Klass, let, name "after_destroy"
+// CHECK-LABEL: } // end sil function 'test_forwarding_consume'
+sil [ossa] @test_forwarding_consume : $@convention(thin) (@owned Klass, @owned Klass) -> () {
+bb0(%0 : @owned $Klass, %1 : @owned $Klass):
+  debug_value %0 : $Klass, let, name "before_struct"
+  %pair = struct $Pair (%0 : $Klass, %1 : $Klass)
+  debug_value %0 : $Klass, let, name "after_struct"
+  destroy_value %pair : $Pair
+  debug_value %0 : $Klass, let, name "after_destroy"
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// =============================================================================
+// Return path: debug_value before return of owned value is kept.
+// =============================================================================
+
+// CHECK-LABEL: sil [ossa] @test_return_path
+// CHECK:       bb1:
+// CHECK:         debug_value %0 : $Klass, let, name "before_return"
+// CHECK:         return %0
+// CHECK-LABEL: } // end sil function 'test_return_path'
+sil [ossa] @test_return_path : $@convention(thin) (@owned Klass) -> @owned Klass {
+bb0(%0 : @owned $Klass):
+  cond_br undef, bb1, bb2
+bb1:
+  debug_value %0 : $Klass, let, name "before_return"
+  return %0 : $Klass
+bb2:
+  destroy_value %0 : $Klass
+  unreachable
+}
+
+// =============================================================================
+// Mixed paths: destroy on one branch, return on another.
+// =============================================================================
+
+// CHECK-LABEL: sil [ossa] @test_destroy_and_return
+// CHECK:       bb0({{.*}}):
+// CHECK:         debug_value %0 : $Klass, let, name "entry"
+// CHECK:       bb2:
+// CHECK:         debug_value undef : $Klass, let, name "after_destroy"
+// CHECK-LABEL: } // end sil function 'test_destroy_and_return'
+sil [ossa] @test_destroy_and_return : $@convention(thin) (@owned Klass) -> @owned Klass {
+bb0(%0 : @owned $Klass):
+  debug_value %0 : $Klass, let, name "entry"
+  cond_br undef, bb1, bb2
+bb1:
+  return %0 : $Klass
+bb2:
+  destroy_value %0 : $Klass
+  debug_value %0 : $Klass, let, name "after_destroy"
+  unreachable
+}
+
+// =============================================================================
+// Guaranteed forwarding: debug_value on struct_extract result after destroy.
+// =============================================================================
+
+// CHECK-LABEL: sil [ossa] @test_guaranteed_forwarding
+// CHECK:         debug_value %2 : $Klass, let, name "extract_in_borrow"
+// CHECK:         debug_value %2 : $Klass, let, name "extract_end_borrow"
+// CHECK:         destroy_value %0
+// CHECK:         debug_value undef : $Klass, let, name "extract_destroy"
+// CHECK-LABEL: } // end sil function 'test_guaranteed_forwarding'
+sil [ossa] @test_guaranteed_forwarding : $@convention(thin) (@owned Pair) -> () {
+bb0(%0 : @owned $Pair):
+  %1 = begin_borrow %0 : $Pair
+  %2 = struct_extract %1 : $Pair, #Pair.first
+  debug_value %2 : $Klass, let, name "extract_in_borrow"
+  end_borrow %1 : $Pair
+  debug_value %2 : $Klass, let, name "extract_end_borrow"
+  destroy_value %0 : $Pair
+  debug_value %2 : $Klass, let, name "extract_destroy"
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// =============================================================================
+// Trivial value: debug_value is never killed (nil ownership root).
+// =============================================================================
+
+// CHECK-LABEL: sil [ossa] @test_trivial_not_killed
+// CHECK:         debug_value %0 : $Builtin.Int64, let, name "trivial"
+// CHECK-NOT:     undef
+// CHECK-LABEL: } // end sil function 'test_trivial_not_killed'
+sil [ossa] @test_trivial_not_killed : $@convention(thin) (Builtin.Int64) -> () {
+bb0(%0 : $Builtin.Int64):
+  debug_value %0 : $Builtin.Int64, let, name "trivial"
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// =============================================================================
+// Chained forwarding: value forwarded through multiple structs.
+// =============================================================================
+
+// CHECK-LABEL: sil [ossa] @test_chained_forwarding
+// CHECK:         debug_value %0 : $Klass, let, name "alive"
+// CHECK:         debug_value %1 : $Klass, let, name "still_alive"
+// CHECK:         destroy_value
+// CHECK:         debug_value undef : $Klass, let, name "dead"
+// CHECK-LABEL: } // end sil function 'test_chained_forwarding'
+sil [ossa] @test_chained_forwarding : $@convention(thin) (@owned Klass, @owned Klass, @owned Klass, @owned Klass) -> () {
+bb0(%0 : @owned $Klass, %1 : @owned $Klass, %2 : @owned $Klass, %3 : @owned $Klass):
+  %p1 = struct $Pair (%0 : $Klass, %1 : $Klass)
+  debug_value %0 : $Klass, let, name "alive"
+  %p2 = struct $Pair (%2 : $Klass, %3 : $Klass)
+  %tup = tuple (%p1, %p2)
+  debug_value %1 : $Klass, let, name "still_alive"
+  destroy_value %tup : $(Pair, Pair)
+  debug_value %0 : $Klass, let, name "dead"
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// =============================================================================
+// Consuming apply: debug_value after consuming apply is killed.
+// =============================================================================
+
+sil @take_owned : $@convention(thin) (@owned Klass) -> ()
+
+// CHECK-LABEL: sil [ossa] @test_consuming_apply
+// CHECK:         debug_value %0 : $Klass, let, name "before_apply"
+// CHECK:         apply
+// CHECK:         debug_value undef : $Klass, let, name "after_apply"
+// CHECK-LABEL: } // end sil function 'test_consuming_apply'
+sil [ossa] @test_consuming_apply : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
+  debug_value %0 : $Klass, let, name "before_apply"
+  %fn = function_ref @take_owned : $@convention(thin) (@owned Klass) -> ()
+  %apply = apply %fn(%0) : $@convention(thin) (@owned Klass) -> ()
+  debug_value %0 : $Klass, let, name "after_apply"
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// =============================================================================
+// Guaranteed function argument: no ownership root, debug_value kept.
+// =============================================================================
+
+// CHECK-LABEL: sil [ossa] @test_guaranteed_arg
+// CHECK:         debug_value %0 : $Klass, let, name "guaranteed"
+// CHECK-NOT:     undef
+// CHECK-LABEL: } // end sil function 'test_guaranteed_arg'
+sil [ossa] @test_guaranteed_arg : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  debug_value %0 : $Klass, let, name "guaranteed"
+  %ret = tuple ()
+  return %ret : $()
+}

--- a/test/DebugInfo/salvage_struct_extract_lifetime.sil
+++ b/test/DebugInfo/salvage_struct_extract_lifetime.sil
@@ -1,7 +1,7 @@
-// RUN: %target-sil-opt -sil-print-types %s -ownership-model-eliminator | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-types %s -kill-invalid-debug-values -ownership-model-eliminator | %FileCheck %s
 
-// Test that OwnershipModelEliminator kills debug_values that appear after
-// a destroy_value, since the object may be freed by the release.
+// Test that the kill-invalid-debug-values pass kills debug_values that appear
+// after a destroy_value, since the object may be freed by the release.
 
 sil_stage canonical
 

--- a/test/sil-passpipeline-dump/basic.test-sh
+++ b/test/sil-passpipeline-dump/basic.test-sh
@@ -10,6 +10,7 @@
 // CHECK: ---
 // CHECK: name:            Serialization
 // CHECK: passes:          [ "serialize-sil", "sil-moved-async-var-dbginfo-propagator",
+// CHECK-NEXT:               "mandatory-temp-rvalue-elimination", "kill-invalid-debug-values",
 // CHECK-NEXT:               "ownership-model-eliminator" ]
 // CHECK: ---
 // CHECK: name:            Rest of Onone


### PR DESCRIPTION
The KillInvalidDebugValues pass removes debug_values on values that might have been freed by a destroying consume.

This replaces the naive dominance-based implementation within OwnershipModelEliminator

This change has almost no impact on the DWARF variable stats of the standard library or the source compatibility test suite