### PR TITLE
TBDGen: Skip initializing entry point for non-`@objc` convenience inits

### DIFF
--- a/lib/SIL/IR/SILSymbolVisitor.cpp
+++ b/lib/SIL/IR/SILSymbolVisitor.cpp
@@ -738,10 +738,15 @@ public:
     if (CD->getParent()->getSelfClassDecl()) {
       // Class constructors come in two forms, allocating and non-allocating.
       // The default ValueDecl handling gives the allocating one, so we have to
-      // manually include the non-allocating one.
-      addFunction(SILDeclRef(CD, SILDeclRef::Kind::Initializer));
-      if (CD->hasAsync()) {
-        addAsyncFunctionPointer(SILDeclRef(CD, SILDeclRef::Kind::Initializer));
+      // manually include the non-allocating one. Only designated and @objc
+      // convenience inits have a separate initializing entry point; non-@objc
+      // convenience inits are lowered as a single allocating entry point (see
+      // SILGenModule::emitConstructor).
+      if (CD->isDesignatedInit() || CD->isObjC()) {
+        addFunction(SILDeclRef(CD, SILDeclRef::Kind::Initializer));
+        if (CD->hasAsync()) {
+          addAsyncFunctionPointer(SILDeclRef(CD, SILDeclRef::Kind::Initializer));
+        }
       }
     }
 

--- a/test/TBD/class_objc.swift.gyb
+++ b/test/TBD/class_objc.swift.gyb
@@ -1,13 +1,13 @@
 // RUN: %empty-directory(%t)
 // RUN: %gyb %s > %t/main.swift
 
-// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -import-objc-header %S/Inputs/objc_class_header.h -validate-tbd-against-ir=missing %t/main.swift -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -import-objc-header %S/Inputs/objc_class_header.h -validate-tbd-against-ir=all %t/main.swift -disable-objc-attr-requires-foundation-module
 
-// RUN: %target-swift-frontend -enable-library-evolution -emit-ir -o/dev/null -parse-as-library -module-name test -import-objc-header %S/Inputs/objc_class_header.h -validate-tbd-against-ir=missing %t/main.swift -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend -enable-library-evolution -emit-ir -o/dev/null -parse-as-library -module-name test -import-objc-header %S/Inputs/objc_class_header.h -validate-tbd-against-ir=all %t/main.swift -disable-objc-attr-requires-foundation-module
 
-// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -import-objc-header %S/Inputs/objc_class_header.h -validate-tbd-against-ir=missing %t/main.swift -disable-objc-attr-requires-foundation-module -O
+// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -import-objc-header %S/Inputs/objc_class_header.h -validate-tbd-against-ir=all %t/main.swift -disable-objc-attr-requires-foundation-module -O
 
-// RUN: %target-swift-frontend -enable-library-evolution -emit-ir -o/dev/null -parse-as-library -module-name test -import-objc-header %S/Inputs/objc_class_header.h -validate-tbd-against-ir=missing %t/main.swift -disable-objc-attr-requires-foundation-module -O
+// RUN: %target-swift-frontend -enable-library-evolution -emit-ir -o/dev/null -parse-as-library -module-name test -import-objc-header %S/Inputs/objc_class_header.h -validate-tbd-against-ir=all %t/main.swift -disable-objc-attr-requires-foundation-module -O
 
 // With -enable-testing:
 
@@ -74,5 +74,23 @@ ${classBody(i)}
 @objc
 internal class InternalObjCOnlyUsableFromInline {
 ${classBody(names.index("Internal"))}
+}
+
+extension NSString {
+  public convenience init(convenienceExtension: Bool) {
+    self.init()
+  }
+}
+
+public class PublicNSObjectSubclass: NSObject {
+  public convenience init(x: Int) {
+    self.init()
+  }
+}
+
+public class PublicNSObjectSubclassObjC: NSObject {
+  @objc public convenience init(y: Int) {
+    self.init()
+  }
 }
 


### PR DESCRIPTION
SILGen only emits a separate initializing entry point for designated inits and `@objc` convenience inits; non-`@objc` convenience inits collapse to a single allocating entry point. TBDGen was unconditionally emitting the initializing symbol for every class constructor, producing a phantom symbol.

Resolves rdar://86057658.
