### PR TITLE
Test: remove some `not --crash` opaque values lines

### DIFF
--- a/test/SILGen/borrowing_switch_resilience.swift
+++ b/test/SILGen/borrowing_switch_resilience.swift
@@ -1,6 +1,3 @@
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -enable-library-evolution %s
-
 // RUN: %target-swift-emit-silgen -enable-library-evolution %s | %FileCheck %s
 @_silgen_name("use")
 public func use<T: ~Copyable>(_: borrowing T)
@@ -178,4 +175,3 @@ func testNondestructiveBecauseGenericInstanceL(foo: borrowing Bar<AnyObject>) {
 		use(x)
 	}
 }
-

--- a/test/SILGen/builtin_vector.swift
+++ b/test/SILGen/builtin_vector.swift
@@ -1,6 +1,3 @@
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -Xllvm -sil-print-types -disable-experimental-parser-round-trip -disable-availability-checking -enable-experimental-feature BuiltinModule %s
-
 // RUN: %target-swift-emit-silgen -Xllvm -sil-print-types -disable-experimental-parser-round-trip -disable-availability-checking -enable-experimental-feature BuiltinModule %s | %FileCheck %s
 
 // REQUIRES: swift_feature_BuiltinModule
@@ -69,4 +66,3 @@ func ao_dep<let N: Int>(a: MyVector<N, Any>)
 {
     return (a, a)
 }
-

--- a/test/SILGen/effectsattr.swift
+++ b/test/SILGen/effectsattr.swift
@@ -1,6 +1,3 @@
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -parse-stdlib %s
-
 // RUN: %target-swift-emit-silgen -parse-stdlib %s | %FileCheck %s
 
 
@@ -37,4 +34,3 @@ struct Mystr<T> {
   @_effects(escaping s.value** -> t.sf.value**)
   @_silgen_name("func7") func func7<T>(_ t: inout Mystr<T>, _ s: T) -> T { }
 }
-

--- a/test/SILGen/existential_erasure.swift
+++ b/test/SILGen/existential_erasure.swift
@@ -1,7 +1,3 @@
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -module-name existential_erasure %s
-
-
 // RUN: %target-swift-emit-silgen -Xllvm -sil-print-types -module-name existential_erasure %s | %FileCheck %s
 
 protocol P {

--- a/test/SILGen/existential_erasure_mutating_covariant_self.swift
+++ b/test/SILGen/existential_erasure_mutating_covariant_self.swift
@@ -1,6 +1,3 @@
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -verify %s
-
 // RUN: %target-swift-emit-silgen -verify %s
 // RUN: %target-swift-emit-sil %s | %FileCheck --check-prefix=AFTER-MANDATORY-PASSES %s
 

--- a/test/SILGen/infinite_type_from_generic_substitution.swift
+++ b/test/SILGen/infinite_type_from_generic_substitution.swift
@@ -1,6 +1,3 @@
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -verify %s
-
 // RUN: %target-swift-emit-sil -verify %s
 
 protocol P {

--- a/test/SILGen/opaque_result_type_underlying_type_abstraction.swift
+++ b/test/SILGen/opaque_result_type_underlying_type_abstraction.swift
@@ -1,6 +1,3 @@
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -disable-availability-checking %s
-
 // RUN: %target-swift-emit-silgen -disable-availability-checking %s | %FileCheck %s
 
 // CHECK-LABEL: sil {{.*}}9withTuple

--- a/test/SILGen/trivial_address_only_switch.swift
+++ b/test/SILGen/trivial_address_only_switch.swift
@@ -1,6 +1,3 @@
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -verify -disable-availability-checking %s
-
 // RUN: %target-swift-emit-silgen -verify -disable-availability-checking %s
 
 public enum StreamYieldResult<let count: Int>: Sendable {

--- a/test/SILGen/variadic-generic-class-methods.swift
+++ b/test/SILGen/variadic-generic-class-methods.swift
@@ -1,6 +1,3 @@
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -Xllvm -sil-print-types -target %target-swift-5.9-abi-triple %s
-
 // RUN: %target-swift-emit-silgen -Xllvm -sil-print-types -target %target-swift-5.9-abi-triple %s | %FileCheck %s
 
 public class A<each T> {


### PR DESCRIPTION
Some of the crashes are due to assertions that are only tripped in asserts builds and do not crash or trigger verifier issues otherwise.

In that case, let's not try to expect a crash.

This takes care of a concern raised in https://github.com/swiftlang/swift/pull/90278#issuecomment-4855473100 after landing https://github.com/swiftlang/swift/pull/90278 