### PR TITLE
[cxx-interop] [test] Suppress notes for two .begin()/.end() tests

### DIFF
--- a/test/Interop/Cxx/class/method/unsafe-ref-sequence-typechecker.swift
+++ b/test/Interop/Cxx/class/method/unsafe-ref-sequence-typechecker.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unrelated \
+// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unrelated -suppress-notes \
 // RUN:   -I %t/Inputs %t/test.swift \
 // RUN:   -cxx-interoperability-mode=default
 
@@ -48,20 +48,12 @@ func use() {
   _ = cw.items.__beginUnsafe()
   _ = cw.items.__endUnsafe()
   _ = cw.items.begin() // expected-error {{value of type 'Container' has no member 'begin'}}
-  // expected-note@-1 {{C++ method 'begin' that returns an iterator is unavailable}}
-  // expected-note@-2 {{C++ methods that return iterators are potentially unsafe; try using Swift collection APIs instead}}
   _ = cw.items.end() // expected-error {{value of type 'Container' has no member 'end'}}
-  // expected-note@-1 {{C++ method 'end' that returns an iterator is unavailable}}
-  // expected-note@-2 {{C++ methods that return iterators are potentially unsafe; try using Swift collection APIs instead}}
 
   let vw = VWrapper()
   _ = vw.items.__beginUnsafe()
   _ = vw.items.__endUnsafe()
   _ = vw.items.begin() // expected-error {{has no member 'begin'}}
-  // expected-note@-1 {{C++ method 'begin' that returns an iterator is unavailable}}
-  // expected-note@-2 {{do you want to use a for-in loop instead?}}
   _ = vw.items.end() // expected-error {{has no member 'end'}}
-  // expected-note@-1 {{C++ method 'end' that returns an iterator is unavailable}}
-  // expected-note@-2 {{do you want to compare against 'nil' instead?}}
   for i in vw.items {}
 }

--- a/test/Interop/Cxx/foreign-reference/frt-sequence-typechecker.swift
+++ b/test/Interop/Cxx/foreign-reference/frt-sequence-typechecker.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift \
 // RUN:   -I %S/Inputs -cxx-interoperability-mode=default \
-// RUN:   -disable-availability-checking -disable-typo-correction
+// RUN:   -disable-availability-checking -disable-typo-correction -suppress-notes
 
 import FrtSequence
 import CxxStdlib
@@ -9,11 +9,7 @@ import CxxStdlib
 
 let ipv = makeImmortalPtrVector()
 let _ = ipv.begin() // expected-error {{has no member 'begin'}}
-                    // expected-note@-1 {{C++ method 'begin' that returns an iterator is unavailable}}
-                    // expected-note@-2 {{do you want to use a for-in loop instead?}}
 let _ = ipv.end()   // expected-error {{has no member 'end'}}
-                    // expected-note@-1 {{C++ method 'end' that returns an iterator is unavailable}}
-                    // expected-note@-2 {{do you want to compare against 'nil' instead?}}
 let _ = ipv.__beginUnsafe()
 let _ = ipv.__endUnsafe()
 for i in ipv {
@@ -30,11 +26,7 @@ mutableIpv[0] = elem
 
 let spv = makeSharedPtrVector()
 let _ = spv.begin() // expected-error {{has no member 'begin'}}
-                    // expected-note@-1 {{C++ method 'begin' that returns an iterator is unavailable}}
-                    // expected-note@-2 {{do you want to use a for-in loop instead?}}
 let _ = spv.end()   // expected-error {{has no member 'end'}}
-                    // expected-note@-1 {{C++ method 'end' that returns an iterator is unavailable}}
-                    // expected-note@-2 {{do you want to compare against 'nil' instead?}}
 let _ = spv.__beginUnsafe()
 let _ = spv.__endUnsafe()
 for i in spv {
@@ -45,11 +37,7 @@ for i in spv {
 
 let ivv = makeImmortalValVector()
 let _ = ivv.begin() // expected-error {{has no member 'begin'}}
-                    // expected-note@-1 {{C++ method 'begin' that returns an iterator is unavailable}}
-                    // expected-note@-2 {{do you want to use a for-in loop instead?}}
 let _ = ivv.end()   // expected-error {{has no member 'end'}}
-                    // expected-note@-1 {{C++ method 'end' that returns an iterator is unavailable}}
-                    // expected-note@-2 {{do you want to compare against 'nil' instead?}}
 let _ = ivv.__beginUnsafe()
 let _ = ivv.__endUnsafe()
 for i in ivv {
@@ -67,11 +55,7 @@ for _ in rpc {} // expected-error {{for-in loop requires 'RawPtrIterContainer' t
 // begin()/end() are still renamed to __beginUnsafe/__endUnsafe
 
 let _ = rpc.begin() // expected-error {{has no member 'begin'}}
-                    // expected-note@-1 {{C++ method 'begin' that returns an iterator is unavailable}}
-                    // expected-note@-2 {{C++ methods that return iterators are potentially unsafe; try using Swift collection APIs instead}}
 let _ = rpc.end()   // expected-error {{has no member 'end'}}
-                    // expected-note@-1 {{C++ method 'end' that returns an iterator is unavailable}}
-                    // expected-note@-2 {{C++ methods that return iterators are potentially unsafe; try using Swift collection APIs instead}}
 let _: ImmortalNode? = rpc.__beginUnsafe()
 let _: ImmortalNode? = rpc.__endUnsafe()
 


### PR DESCRIPTION
These notes depend on CxxRandomAccessCollection conformance, which is apparently flakey on 32-bit Android and possibly other platforms. The diagnostic is not the focus of these tests so let's ignore them for now.

Supersedes #90323
