### PR TITLE
IRGen: Apply class-member scope to dynamic replacement variable linkage

### DIFF
--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -952,8 +952,23 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
 
   case Kind::DynamicallyReplaceableFunctionVariable:
     return getSILFunction()->getEffectiveSymbolLinkage();
-  case Kind::DynamicallyReplaceableFunctionVariableAST:
-    return getSILLinkage(getDeclLinkage(getDecl()), forDefinition);
+  case Kind::DynamicallyReplaceableFunctionVariableAST: {
+    // Match the SIL-level linkage IRGen uses for the actual variable
+    // emission, which applies the class-member scope transform. Otherwise
+    // the AST-level linkage claims the entity is public when IRGen emits it
+    // with hidden linkage (e.g. dynamic methods of a resilient class).
+    auto silLinkage = getSILLinkage(getDeclLinkage(getDecl()), forDefinition);
+    auto *afd = cast<AbstractFunctionDecl>(const_cast<ValueDecl *>(getDecl()));
+    SILDeclRef declRef;
+    if (auto *ctor = dyn_cast<ConstructorDecl>(afd)) {
+      declRef = SILDeclRef(ctor, isAllocator() ? SILDeclRef::Kind::Allocator
+                                               : SILDeclRef::Kind::Initializer);
+    } else {
+      declRef = SILDeclRef(afd);
+    }
+    return effectiveLinkageForClassMember(silLinkage,
+                                          declRef.getSubclassScope());
+  }
 
   case Kind::SILGlobalVariable:
   case Kind::ReadOnlyGlobalObject:

--- a/test/TBD/class.swift
+++ b/test/TBD/class.swift
@@ -1,11 +1,11 @@
-// REQUIRES: VENDOR=apple 
+// REQUIRES: VENDOR=apple
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s
-// RUN: %target-swift-frontend -enable-library-evolution -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s
+// RUN: %target-swift-frontend -enable-library-evolution -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all %s
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s -enable-testing
 // RUN: %target-swift-frontend -enable-library-evolution -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s -enable-testing
 
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing -O %s
-// RUN: %target-swift-frontend -enable-library-evolution -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing -O %s
+// RUN: %target-swift-frontend -enable-library-evolution -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all -O %s
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s -enable-testing -O
 // RUN: %target-swift-frontend -enable-library-evolution -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s -enable-testing -O
 


### PR DESCRIPTION
The AST variant of the dynamic replacement variable `LinkEntity` returned raw formal linkage, while the SIL variant applies the class-member scope transform via `getEffectiveSymbolLinkage()`. For a `dynamic` method on a resilient class, that mismatch caused TBDGen to export the `TX` symbol as public while IRGen emitted the variable with hidden linkage.
