### PR TITLE
[AST] Guard against null dest/src when printing AssignExpr

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -5454,9 +5454,11 @@ void PrintAST::visitTypeJoinExpr(TypeJoinExpr *expr) {
 }
 
 void PrintAST::visitAssignExpr(AssignExpr *expr) {
-  visit(expr->getDest());
+  if (auto dest = expr->getDest())
+    visit(dest);
   Printer << " = ";
-  visit(expr->getSrc());
+  if (auto src = expr->getSrc())
+    visit(src);
 }
 
 void PrintAST::visitBinaryExpr(BinaryExpr *expr) {


### PR DESCRIPTION
Previously, `ASTPrinter` would crash when printing a non-typechecked AST containing an `AssignExpr` whose destination or source was null.
This surfaced when experimenting with synthetic macro expansions.
Fix by only visiting the dest and src when they are set, matching the existing null-guard pattern in `visitTernaryExpr`.