### PR TITLE
OpaqueValues: fix infinite types and unchecked_ownership

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/ForwardingInstruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/ForwardingInstruction.swift
@@ -306,6 +306,12 @@ extension MoveOnlyWrapperToCopyableBoxInst : ConversionInstruction {
   public var canForwardOwnedValues: Bool { true }
 }
 
+extension UncheckedOwnershipInst : ConversionInstruction {
+  public var preservesRepresentation: Bool { true }
+  public var canForwardGuaranteedValues: Bool { true }
+  public var canForwardOwnedValues: Bool { true }
+}
+
 extension UpcastInst : ConversionInstruction {
   public var preservesRepresentation: Bool { true }
   public var canForwardGuaranteedValues: Bool { true }

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2391,6 +2391,7 @@ namespace {
       // opaque for code generation purposes.
       properties.setAddressOnly();
       properties.setInfinite();
+      properties.setNonTrivial();
       return handleAddressOnly(type, properties);
     }
 

--- a/lib/SIL/Utils/InstWrappers.cpp
+++ b/lib/SIL/Utils/InstWrappers.cpp
@@ -59,6 +59,7 @@ bool ForwardingOperation::hasSameRepresentation() const {
   case SILInstructionKind::TupleExtractInst:
   case SILInstructionKind::TuplePackExtractInst:
   case SILInstructionKind::ImplicitActorToOpaqueIsolationCastInst:
+  case SILInstructionKind::UncheckedOwnershipInst:
     return true;
   }
 }

--- a/test/SILGen/borrow_accessor.swift
+++ b/test/SILGen/borrow_accessor.swift
@@ -1,5 +1,5 @@
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values %s
+// FIXME: unexpected error diagnostic under opaque values
+// RUN: not %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values %s
 
 // RUN:%target-swift-frontend -emit-silgen %s | %FileCheck %s
 // RUN:%target-swift-frontend -c %s -Xllvm -sil-print-after=SILGenCleanup 2>&1 | %FileCheck %s --check-prefixes=CHECK-SIL

--- a/test/SILGen/borrow_accessor_container.swift
+++ b/test/SILGen/borrow_accessor_container.swift
@@ -1,5 +1,4 @@
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -strict-memory-safety -verify %s
+// RUN: %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -strict-memory-safety -verify %s
 
 // RUN:%target-swift-frontend -emit-silgen %s -verify   -strict-memory-safety | %FileCheck %s
 

--- a/test/SILGen/borrow_accessor_protocol.swift
+++ b/test/SILGen/borrow_accessor_protocol.swift
@@ -1,5 +1,4 @@
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values %s
+// RUN: %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values %s
 
 // RUN:%target-swift-frontend -emit-silgen %s | %FileCheck %s
 // RUN:%target-swift-frontend -c %s -Xllvm -sil-print-after=SILGenCleanup 2>&1 | %FileCheck %s --check-prefixes=CHECK-SIL

--- a/test/SILGen/builtin_borrowat.swift
+++ b/test/SILGen/builtin_borrowat.swift
@@ -1,5 +1,4 @@
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -module-name main -enable-experimental-feature BuiltinModule -enable-experimental-feature AddressableTypes -enable-experimental-feature Lifetimes %s
+// RUN: %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -module-name main -enable-experimental-feature BuiltinModule -enable-experimental-feature AddressableTypes -enable-experimental-feature Lifetimes %s
 
 // RUN: %target-swift-emit-silgen -module-name main \
 // RUN: -enable-experimental-feature BuiltinModule \

--- a/test/SILGen/infinite_type_from_generic_substitution.swift
+++ b/test/SILGen/infinite_type_from_generic_substitution.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-emit-sil -verify %s
+// RUN: %target-swift-emit-sil -sil-verify-all %s -enable-sil-opaque-values -o /dev/null
+// RUN: %target-swift-emit-sil -sil-verify-all %s -o /dev/null
 
 protocol P {
     associatedtype A
@@ -35,3 +36,24 @@ enum EU<T: P> {
 
 func zim(x: EU<ER>) -> EU<ER> { return x }
 func zang(x: E<ER>) -> E<ER> { return x }
+
+
+struct CCC {
+  var members: [Member]
+  var isInverted: Bool
+}
+enum Member {
+  case atom(Int)
+  case custom(CCC)
+  indirect case intersection(CCC, CCC)
+}
+indirect enum Node {
+  case customCharacterClass(CCC)
+  case leaf
+}
+func f(_ n: Node) -> Int {
+  switch n {
+  case .customCharacterClass: return 1
+  case .leaf: return 0
+  }
+}

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -1019,3 +1019,21 @@ func forceIndirectErrorThunk<T: Error>(_ x: () throws(T) -> Void) throws {
 // CHECK:       [[ERROR_BB]]({{%[^,]+}} : @owned $T):
 // CHECK:         throw {{%[^,]+}} : $any Error
 // CHECK-LABEL: } // end sil function '$sxIgzr_s5Error_pIegzo_sAARzlTR'
+
+
+
+struct CCC {
+  var members: [Member]
+  var isInverted: Bool
+}
+enum Member {
+  case atom(Int)
+  case custom(CCC)
+  indirect case intersection(CCC, CCC)
+}
+
+// Ensure we treat infinite types as non-trivial & loadable (rdar://180569048)
+// CHECK-LABEL: sil {{.*}}3CCCV7membersSayAA6MemberOGvs : $@convention(method) (@owned Array<Member>, @inout CCC) -> () {
+// CHECK: bb0(%0 : @owned $Array<Member>
+// CHECK:   destroy_value %0
+// CHECK: } // end sil function

--- a/validation-test/compiler_crashers_fixed/CxxInterop/TypeConverter-verifyTrivialLowering-82dbd2.swift
+++ b/validation-test/compiler_crashers_fixed/CxxInterop/TypeConverter-verifyTrivialLowering-82dbd2.swift
@@ -1,5 +1,5 @@
 // {"extraArgs":["-experimental-allow-module-with-compiler-errors","-cxx-interoperability-mode=default","-emit-clang-header-min-access","internal","-emit-clang-header-path","/dev/null"],"kind":"emit-sil","original":"034478b5","signature":"swift::Lowering::TypeConverter::verifyTrivialLowering(swift::Lowering::TypeLowering const&, swift::Lowering::AbstractionPattern, swift::CanType, swift::TypeExpansionContext)","signatureAssert":"Assertion failed: (false), function verifyTrivialLowering","signatureNext":"Lowering::TypeConverter::getTypeLowering"}
-// RUN: not --crash %target-swift-frontend -emit-sil -experimental-allow-module-with-compiler-errors -cxx-interoperability-mode=default -emit-clang-header-min-access internal -emit-clang-header-path /dev/null %s
+// RUN: not %target-swift-frontend -emit-sil -experimental-allow-module-with-compiler-errors -cxx-interoperability-mode=default -emit-clang-header-min-access internal -emit-clang-header-path /dev/null %s
 struct a {
   var b: a
 }


### PR DESCRIPTION
A bundle of small fixes for opaque values:

- OpaqueValues: treat infinite types as non-trivial rdar://180569048
- SIL: define forwarding semantics of unchecked_ownership rdar://180980055