### PR TITLE
[6.4][Distributed/SIL] Fix sil isolation of computed properties

### DIFF
--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -537,6 +537,9 @@ struct SILDeclRef {
   /// True if the decl ref references a thunk handling potentially distributed actor functions
   bool isDistributedThunk() const;
 
+  /// If this is a distributed-thunk decl ref, return its distributed thunk.
+  FuncDecl *getDistributedThunk() const;
+
   /// True if the decl references a 'distributed' function.
   bool isDistributed() const;
 

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -1321,6 +1321,15 @@ bool SILDeclRef::isDistributedThunk() const {
     return false;
   return kind == Kind::Func;
 }
+
+FuncDecl *SILDeclRef::getDistributedThunk() const {
+  if (!isDistributedThunk())
+    return nullptr;
+  if (auto *afd = getAbstractFunctionDecl())
+    return afd->getDistributedThunk();
+  return nullptr;
+}
+
 bool SILDeclRef::isDistributed() const {
   if (!hasFuncDecl())
     return false;

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -4361,6 +4361,12 @@ CanAnyFunctionType TypeConverter::makeConstantInterfaceType(SILDeclRef c) {
   }
 
   auto *vd = c.loc.dyn_cast<ValueDecl *>();
+
+  // If the value is a distributed thunk, its isolation must be computed
+  // off the 'distributed_thunk', not the original decl.
+  if (auto *thunk = c.getDistributedThunk())
+    vd = thunk;
+
   switch (c.kind) {
   case SILDeclRef::Kind::Func: {
     CanAnyFunctionType funcTy;

--- a/test/Distributed/distributed_thunk_sync_decl_cross_module.swift
+++ b/test/Distributed/distributed_thunk_sync_decl_cross_module.swift
@@ -1,0 +1,63 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-5.7-abi-triple %S/Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend -module-name Lib -emit-module -emit-module-path %t/Lib.swiftmodule -O -parse-as-library -target %target-swift-5.7-abi-triple -I %t %s -DLIB
+// RUN: %target-swift-frontend -emit-sil -module-name Client -O -parse-as-library -target %target-swift-5.7-abi-triple -I %t %s -DCLIENT -o /dev/null
+
+// REQUIRES: concurrency
+// REQUIRES: distributed
+// UNSUPPORTED: back_deploy_concurrency
+
+// Reproduces a SILFunction type mismatch uncovered by DistributedCluster.
+// This happens only for a synchronous distributed var decl, across modules.
+// rdar://180980491
+
+import Distributed
+import FakeDistributedActorSystems
+
+#if LIB
+
+public protocol DistWorker: DistributedActor where ActorSystem == FakeActorSystem {
+  associatedtype Item: Codable & Sendable
+  distributed func handle(item: Item) async throws
+}
+
+public distributed actor WorkerPool<W: DistWorker>: DistributedActor {
+  public typealias ActorSystem = FakeActorSystem
+  var workers: [W] = []
+
+  public distributed var size: Int {
+    self.workers.count
+  }
+
+  public distributed func count() async throws -> Int {
+    self.workers.count
+  }
+}
+
+#endif
+
+#if CLIENT
+import Lib
+
+public struct Job: Codable, Sendable {
+  public let id: Int
+  public init(id: Int) { self.id = id }
+}
+
+public distributed actor ExampleWorker: DistWorker {
+  public typealias ActorSystem = FakeActorSystem
+  public typealias Item = Job
+
+  public distributed func handle(item: Job) async throws {
+    _ = item.id
+  }
+}
+
+public func use(_ system: FakeActorSystem) async throws {
+  let pool = WorkerPool<ExampleWorker>(actorSystem: system)
+  // Reading 'pool.size' across an isolation boundary forces the
+  // distributed thunk to be deserialized.
+  _ = try await pool.size
+  _ = try await pool.count()
+}
+#endif

--- a/test/Distributed/distributed_thunk_sync_var_silgen.swift
+++ b/test/Distributed/distributed_thunk_sync_var_silgen.swift
@@ -1,0 +1,36 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-5.7-abi-triple %S/Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend -Xllvm -sil-print-types -emit-silgen %s -module-name test -swift-version 5 -target %target-swift-5.7-abi-triple -I %t | %FileCheck %s
+
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+import Distributed
+import FakeDistributedActorSystems
+
+public protocol DistWorker: DistributedActor where ActorSystem == FakeActorSystem {
+  associatedtype Item: Codable & Sendable
+  distributed func handle(item: Item) async throws
+}
+
+public distributed actor WorkerPool<W: DistWorker>: DistributedActor {
+  public typealias ActorSystem = FakeActorSystem
+  var workers: [W] = []
+
+  public distributed var size: Int {
+    self.workers.count
+  }
+
+  public distributed func count() async throws -> Int {
+    self.workers.count
+  }
+}
+
+// The synchronous 'distributed var size' thunk must take a nonisolated '@guaranteed self', not '@sil_isolated @guaranteed self'.
+// CHECK-LABEL: sil [thunk] [distributed] {{.*}}@$s4test10WorkerPoolC4sizeSiyYaKFTE :
+// CHECK-SAME:  $@convention(method) @async <W where W : DistWorker> (@guaranteed WorkerPool<W>) -> (Int, @error any Error)
+
+// The 'distributed func count()' thunk must also be nonisolated
+// '@guaranteed self'.
+// CHECK-LABEL: sil [thunk] [distributed] {{.*}}@$s4test10WorkerPoolC5countSiyYaKFTE :
+// CHECK-SAME:  $@convention(method) @async <W where W : DistWorker> (@guaranteed WorkerPool<W>) -> (Int, @error any Error)


### PR DESCRIPTION
**Explanation**: 
This is a minimal fix to resolve a compilation regression discovered in the DistributedCluster, since makeConstantInterfaceType wasn't handling distributed thunks properly, leading to SIL validation crashes.

Details:

A `distributed` member's thunk is a synthesized FuncDecl annotated `@nonisolated @concurrent`, so its `self` must not be actor-isolated.

SILGen builds the SIL type from `SILDeclRef(thunkDecl).asDistributed()` (nonisolated). Client module's call sites in `SILGenApply` instead flip the distributedThunk bit on the *original* accessor's SILDeclRef, leaving `getDecl()` as the actor-isolated originator.

`makeConstantInterfaceType` then used the type of the original decl which would be actor isolated, causing the `@sil_isolated @guaranteed self` type to be produced, clashing with the correct nonisolated real state of the func.

Note that this is fixed the same way for autodiff in this func already a few lines above.


**Scope**: 
- All distributed methods, was uncovered in DistributedCluster build only recently. Not sure when things regressed exactly.

**Risk**: 
- low, this is a trivial fix

**Testing**: 
- CI testing

**Original PR**:
- https://github.com/swiftlang/swift/pull/90287
  - Original PR contains this minimal fix and then more future-proof hardening, we're just picking the trivial fix here.

**Reviewed by**:
- @xedin 

**Issues**: 
- Resolves rdar://180980491