### PR TITLE
[stdlib] upgrade to `@export(implementation)`

### DIFF
--- a/stdlib/private/OSLog/OSLogFloatingPointTypes.swift
+++ b/stdlib/private/OSLog/OSLogFloatingPointTypes.swift
@@ -146,14 +146,14 @@ extension OSLogArguments {
 /// specified by os_log. Note that this is marked transparent instead of
 /// @inline(__always) as it is used in optimize(none) functions.
 @_transparent
-@_alwaysEmitIntoClient
+@export(implementation)
 internal func doubleSizeInBytes() -> Int {
   return 8
 }
 
 /// Serialize a double at the buffer location that `position` points to and
 /// increment `position` by the byte size of the double.
-@_alwaysEmitIntoClient
+@export(implementation)
 @inline(__always)
 internal func serialize(
   _ value: Double,

--- a/stdlib/private/OSLog/OSLogIntegerTypes.swift
+++ b/stdlib/private/OSLog/OSLogIntegerTypes.swift
@@ -239,7 +239,7 @@ extension OSLogArguments {
 /// it is marked transparent instead of @inline(__always) as it is used in
 /// optimize(none) functions.
 @_transparent
-@_alwaysEmitIntoClient
+@export(implementation)
 internal func sizeForEncoding<T>(
   _ type: T.Type
 ) -> Int where T : FixedWidthInteger  {
@@ -248,7 +248,7 @@ internal func sizeForEncoding<T>(
 
 /// Serialize an integer at the buffer location that `position` points to and
 /// increment `position` by the byte size of `T`.
-@_alwaysEmitIntoClient
+@export(implementation)
 @inline(__always)
 internal func serialize<T>(
   _ value: T,

--- a/stdlib/private/OSLog/OSLogMessage.swift
+++ b/stdlib/private/OSLog/OSLogMessage.swift
@@ -26,7 +26,7 @@ public var maxOSLogArgumentCount: UInt8 { return 48 }
 // Note that this is marked transparent instead of @inline(__always) as it is
 // used in optimize(none) functions.
 @_transparent
-@_alwaysEmitIntoClient
+@export(implementation)
 internal var logBitsPerByte: Int { return 3 }
 
 /// Represents a string interpolation passed to the log APIs.
@@ -307,7 +307,7 @@ internal struct OSLogArguments {
 
 /// Serialize a UInt8 value at the buffer location pointed to by `bufferPosition`,
 /// and increment the `bufferPosition` with the byte size of the serialized value.
-@_alwaysEmitIntoClient
+@export(implementation)
 @inline(__always)
 internal func serialize(
   _ value: UInt8,
@@ -322,7 +322,7 @@ internal func serialize(
 // are used to hold onto NSObjects and Strings that are interpolated in the log
 // message until the end of the log call.
 
-@_alwaysEmitIntoClient
+@export(implementation)
 @inline(__always)
 internal func createStorage<T>(
   capacity: Int,
@@ -334,7 +334,7 @@ internal func createStorage<T>(
       UnsafeMutablePointer<T>.allocate(capacity: capacity)
 }
 
-@_alwaysEmitIntoClient
+@export(implementation)
 @inline(__always)
 internal func initializeAndAdvance<T>(
   _ storageOpt: inout ObjectStorage<T>,
@@ -347,7 +347,7 @@ internal func initializeAndAdvance<T>(
   }
 }
 
-@_alwaysEmitIntoClient
+@export(implementation)
 @inline(__always)
 internal func destroyStorage<T>(_ storageOpt: ObjectStorage<T>, count: Int) {
   // This if statement should get optimized away.

--- a/stdlib/private/OSLog/OSLogNSObjectType.swift
+++ b/stdlib/private/OSLog/OSLogNSObjectType.swift
@@ -110,7 +110,7 @@ extension OSLogArguments {
 
 /// Serialize an NSObject pointer at the buffer location pointed by
 /// `bufferPosition`.
-@_alwaysEmitIntoClient
+@export(implementation)
 @inline(__always)
 internal func serialize(
   _ object: NSObject,

--- a/stdlib/private/OSLog/OSLogStringTypes.swift
+++ b/stdlib/private/OSLog/OSLogStringTypes.swift
@@ -144,14 +144,14 @@ extension OSLogArguments {
 /// This function must be constant evaluable. Note that it is marked transparent
 /// instead of @inline(__always) as it is used in optimize(none) functions.
 @_transparent
-@_alwaysEmitIntoClient
+@export(implementation)
 internal func pointerSizeInBytes() -> Int {
   return Int.bitWidth &>> logBitsPerByte
 }
 
 /// Serialize a stable pointer to the string `stringValue` at the buffer location
 /// pointed to by `bufferPosition`.
-@_alwaysEmitIntoClient
+@export(implementation)
 @inline(__always)
 internal func serialize(
   _ stringValue: String,
@@ -173,7 +173,7 @@ internal func serialize(
 /// Return a pointer that points to a contiguous sequence of null-terminated,
 /// UTF8 characters. If necessary, extends the lifetime of `stringValue` by
 /// using `stringArgumentOwners`.
-@_alwaysEmitIntoClient
+@export(implementation)
 @inline(never)
 internal func getNullTerminatedUTF8Pointer(
   _ stringValue: String,

--- a/stdlib/private/OSLog/OSLogTestHelper.swift
+++ b/stdlib/private/OSLog/OSLogTestHelper.swift
@@ -41,7 +41,7 @@ public let _noopClosure = { (x : String, y : UnsafeBufferPointer<UInt8>) in retu
 ///     byte buffer and asserts a condition.
 @_semantics("oslog.requires_constant_arguments")
 @_transparent
-@_alwaysEmitIntoClient
+@export(implementation)
 @_optimize(none)
 public // @testable
 func _osLogTestHelper(

--- a/stdlib/public/Concurrency/Actor.swift
+++ b/stdlib/public/Concurrency/Actor.swift
@@ -109,7 +109,7 @@ public macro isolation<T>() -> T = Builtin.IsolationMacro
 #endif
 
 #if $IsolatedAny
-@_alwaysEmitIntoClient
+@export(implementation)
 @available(SwiftStdlib 5.1, *)
 @available(*, deprecated, message: "Use `.isolation` on @isolated(any) closure values instead.")
 public func extractIsolation<each Arg, Result>(

--- a/stdlib/public/Concurrency/AsyncFlatMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncFlatMapSequence.swift
@@ -73,8 +73,7 @@ extension AsyncSequence {
   /// - Returns: A single, flattened asynchronous sequence that contains all
   ///   elements in all the asynchronous sequences produced by `transform`.
   @preconcurrency 
-  @_alwaysEmitIntoClient
-  @inlinable
+  @export(implementation)
   public __consuming func flatMap<SegmentOfResult: AsyncSequence>(
     _ transform: @Sendable @escaping (Element) async -> SegmentOfResult
   ) -> AsyncFlatMapSequence<Self, SegmentOfResult>
@@ -109,8 +108,7 @@ extension AsyncSequence {
   /// - Returns: A single, flattened asynchronous sequence that contains all
   ///   elements in all the asynchronous sequences produced by `transform`.
   @preconcurrency 
-  @_alwaysEmitIntoClient
-  @inlinable
+  @export(implementation)
   public __consuming func flatMap<SegmentOfResult: AsyncSequence>(
     _ transform: @Sendable @escaping (Element) async -> SegmentOfResult
   ) -> AsyncFlatMapSequence<Self, SegmentOfResult>
@@ -145,8 +143,7 @@ extension AsyncSequence {
   /// - Returns: A single, flattened asynchronous sequence that contains all
   ///   elements in all the asynchronous sequences produced by `transform`.
   @preconcurrency 
-  @_alwaysEmitIntoClient
-  @inlinable
+  @export(implementation)
   public __consuming func flatMap<SegmentOfResult: AsyncSequence>(
     _ transform: @Sendable @escaping (Element) async -> SegmentOfResult
   ) -> AsyncFlatMapSequence<Self, SegmentOfResult>

--- a/stdlib/public/Concurrency/CheckedContinuation.swift
+++ b/stdlib/public/Concurrency/CheckedContinuation.swift
@@ -214,7 +214,7 @@ extension CheckedContinuation {
   /// After `resume` enqueues the task, control immediately returns to
   /// the caller. The task continues executing when its executor is
   /// able to reschedule it.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func resume<Er: Error>(with result: __shared sending Result<T, Er>) where E == Error {
     switch result {
       case .success(let val):
@@ -238,7 +238,7 @@ extension CheckedContinuation {
   /// After `resume` enqueues the task, control immediately returns to
   /// the caller. The task continues executing when its executor is
   /// able to reschedule it.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func resume(with result: __shared sending Result<T, E>) {
     switch result {
       case .success(let val):
@@ -258,7 +258,7 @@ extension CheckedContinuation {
   /// After `resume` enqueues the task, control immediately returns to
   /// the caller. The task continues executing when its executor is
   /// able to reschedule it.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func resume() where T == Void {
     self.resume(returning: ())
   }
@@ -290,8 +290,7 @@ extension CheckedContinuation {
 /// - SeeAlso: `withCheckedThrowingContinuation(function:_:)`
 /// - SeeAlso: `withUnsafeContinuation(function:_:)`
 /// - SeeAlso: `withUnsafeThrowingContinuation(function:_:)`
-@inlinable
-@_alwaysEmitIntoClient
+@export(implementation)
 @available(SwiftStdlib 5.1, *)
 // ABI Note: We need to use @abi here because the ABI of this function otherwise conflicts with the legacy
 // @_unsafeInheritExecutor declaration, as none of them have (or mangle) the implicit actor parameter
@@ -378,8 +377,7 @@ public func _unsafeInheritExecutor_withCheckedContinuation<T>(
 /// - SeeAlso: `withCheckedContinuation(function:_:)`
 /// - SeeAlso: `withUnsafeContinuation(function:_:)`
 /// - SeeAlso: `withUnsafeThrowingContinuation(function:_:)`
-@inlinable
-@_alwaysEmitIntoClient
+@export(implementation)
 @available(SwiftStdlib 5.1, *)
 // ABI Note: We need to use @abi here because the ABI of this function otherwise conflicts with the legacy
 // @_unsafeInheritExecutor declaration, as none of them have (or mangle) the implicit actor parameter
@@ -404,8 +402,7 @@ public nonisolated(nonsending) func withCheckedThrowingContinuation<T, E>(
   }
 }
 
-@inlinable
-@_alwaysEmitIntoClient
+@export(implementation)
 @available(SwiftStdlib 5.1, *)
 // ABI Note: We need to use @abi here because the ABI of this function otherwise conflicts with the legacy
 // @_unsafeInheritExecutor declaration, as none of them have (or mangle) the implicit actor parameter
@@ -467,7 +464,7 @@ public func _unsafeInheritExecutor_withCheckedThrowingContinuation<T>(
 
 // Intrinsics used by SILGen to create, resume, or fail checked continuations.
 @available(SwiftStdlib 5.1, *)
-@_alwaysEmitIntoClient
+@export(implementation)
 internal func _createCheckedContinuation<T>(
   _ continuation: __owned UnsafeContinuation<T, Never>
 ) -> CheckedContinuation<T, Never> {
@@ -475,7 +472,7 @@ internal func _createCheckedContinuation<T>(
 }
 
 @available(SwiftStdlib 5.1, *)
-@_alwaysEmitIntoClient
+@export(implementation)
 internal func _createCheckedThrowingContinuation<T>(
   _ continuation: __owned UnsafeContinuation<T, Error>
 ) -> CheckedContinuation<T, Error> {
@@ -483,7 +480,7 @@ internal func _createCheckedThrowingContinuation<T>(
 }
 
 @available(SwiftStdlib 5.1, *)
-@_alwaysEmitIntoClient
+@export(implementation)
 internal func _resumeCheckedContinuation<T>(
   _ continuation: CheckedContinuation<T, Never>,
   _ value: sending T
@@ -492,7 +489,7 @@ internal func _resumeCheckedContinuation<T>(
 }
 
 @available(SwiftStdlib 5.1, *)
-@_alwaysEmitIntoClient
+@export(implementation)
 internal func _resumeCheckedThrowingContinuation<T>(
   _ continuation: CheckedContinuation<T, Error>,
   _ value: sending T
@@ -501,7 +498,7 @@ internal func _resumeCheckedThrowingContinuation<T>(
 }
 
 @available(SwiftStdlib 5.1, *)
-@_alwaysEmitIntoClient
+@export(implementation)
 internal func _resumeCheckedThrowingContinuationWithError<T>(
   _ continuation: CheckedContinuation<T, Error>,
   _ error: consuming Error

--- a/stdlib/public/Concurrency/Clock.swift
+++ b/stdlib/public/Concurrency/Clock.swift
@@ -66,7 +66,7 @@ extension Clock {
   ///          await someWork()
   ///       }
   @available(StdlibDeploymentTarget 5.7, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public nonisolated(nonsending) func measure(
     _ work: nonisolated(nonsending) () async throws -> Void
   ) async rethrows -> Instant.Duration {
@@ -77,7 +77,7 @@ extension Clock {
   }
 
   @available(StdlibDeploymentTarget 5.7, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, deprecated, message: "Replaced by nonisolated(nonsending) overload")
   public func measure(
     isolation: isolated (any Actor)? = #isolation,
@@ -116,7 +116,7 @@ extension Clock {
   /// Prefer to use the `sleep(until:tolerance:)` method on `Clock` if you have
   /// access to an absolute instant.
   @available(StdlibDeploymentTarget 5.7, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func sleep(
     for duration: Instant.Duration,
     tolerance: Instant.Duration? = nil

--- a/stdlib/public/Concurrency/Continuation.swift
+++ b/stdlib/public/Concurrency/Continuation.swift
@@ -56,7 +56,7 @@ public struct Continuation<Success: ~Copyable, Failure: Error>: ~Copyable, @unch
 
   /// Extract the underlying raw continuation and discard `self`
   /// without firing the deinit trap
-  @_alwaysEmitIntoClient
+  @export(implementation)
   consuming func _takeContext() -> Builtin.RawUnsafeContinuation {
     let ctx = self.context
     discard self
@@ -67,7 +67,7 @@ public struct Continuation<Success: ~Copyable, Failure: Error>: ~Copyable, @unch
   /// from its suspension point
   ///
   /// - Parameter value: The value to return from the continuation
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public consuming func resume(returning value: consuming sending Success) where Failure == Never {
     #if $BuiltinContinuationNonCopyableSuccess
     Builtin.resumeNonThrowingContinuationReturning(context, value)
@@ -81,7 +81,7 @@ public struct Continuation<Success: ~Copyable, Failure: Error>: ~Copyable, @unch
   /// from its suspension point
   ///
   /// - Parameter value: The value to return from the continuation
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public consuming func resume(returning value: consuming sending Success) {
     #if $BuiltinContinuationNonCopyableSuccess
     Builtin.resumeThrowingContinuationReturning(context, value)
@@ -95,7 +95,7 @@ public struct Continuation<Success: ~Copyable, Failure: Error>: ~Copyable, @unch
   /// from its suspension point
   ///
   /// - Parameter error: The error to throw from the continuation
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public consuming func resume(throwing error: __owned Failure) {
     #if $BuiltinContinuationNonCopyableSuccess
     Builtin.resumeThrowingContinuationThrowing(context, error)
@@ -111,7 +111,7 @@ public struct Continuation<Success: ~Copyable, Failure: Error>: ~Copyable, @unch
   ///
   /// - Parameter result: A value to either return or throw from the
   ///   continuation
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public consuming func resume(
     with result: consuming sending Result<Success, Failure>
   ) {
@@ -130,7 +130,7 @@ public struct Continuation<Success: ~Copyable, Failure: Error>: ~Copyable, @unch
 
   /// Resume the task awaiting the continuation by having it return
   /// from its suspension point
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public consuming func resume() where Success == Void {
     self.resume(returning: ())
   }
@@ -158,7 +158,7 @@ public struct Continuation<Success: ~Copyable, Failure: Error>: ~Copyable, @unch
 ///   - throwing: The `Failure` type that may be thrown
 ///   - body: A closure that takes a `Continuation` parameter
 /// - Returns: The value the continuation is resumed with
-@_alwaysEmitIntoClient
+@export(implementation)
 @available(SwiftStdlib 6.4, *)
 public nonisolated(nonsending) func withContinuation<Success: ~Copyable, Failure: Error>(
   of: Success.Type = Success.self,
@@ -195,7 +195,7 @@ public nonisolated(nonsending) func withContinuation<Success: ~Copyable, Failure
 ///   - of: The `Success` type returned by the continuation
 ///   - body: A closure that takes a `Continuation` parameter
 /// - Returns: The value the continuation is resumed with
-@_alwaysEmitIntoClient
+@export(implementation)
 @available(SwiftStdlib 6.4, *)
 public nonisolated(nonsending) func withContinuation<Success: ~Copyable>(
   of: Success.Type = Success.self,
@@ -221,7 +221,7 @@ extension CheckedContinuation {
   /// the non-copyable semantics would not be able to statically enforce
   /// the resume-once semantics, however the correct use of the
   /// continuation is enforced in some way at runtime.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(
     _ continuation: consuming Continuation<T, E>,
     function: String = #function
@@ -243,7 +243,7 @@ extension UnsafeContinuation {
   /// the non-copyable semantics would not be able to statically enforce
   /// the resume-once semantics, however the correct use of the
   /// continuation is enforced in some way at runtime.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(
     _ continuation: consuming Continuation<T, E>
   ) {

--- a/stdlib/public/Concurrency/ContinuousClock.swift
+++ b/stdlib/public/Concurrency/ContinuousClock.swift
@@ -137,7 +137,7 @@ extension ContinuousClock: Clock {
 @_unavailableInEmbedded
 extension ContinuousClock {
   @available(SwiftStdlib 5.7, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var systemEpoch: Instant {
     unsafe unsafeBitCast(Duration.seconds(0), to: Instant.self)
   }
@@ -172,40 +172,35 @@ extension ContinuousClock.Instant: InstantProtocol {
     return lhs._value < rhs._value
   }
 
-  @_alwaysEmitIntoClient
-  @inlinable
+  @export(implementation)
   public static func + (
     _ lhs: ContinuousClock.Instant, _ rhs: Swift.Duration
   ) -> ContinuousClock.Instant {
     lhs.advanced(by: rhs)
   }
 
-  @_alwaysEmitIntoClient
-  @inlinable
+  @export(implementation)
   public static func += (
     _ lhs: inout ContinuousClock.Instant, _ rhs: Swift.Duration
   ) {
     lhs = lhs.advanced(by: rhs)
   }
 
-  @_alwaysEmitIntoClient
-  @inlinable
+  @export(implementation)
   public static func - (
     _ lhs: ContinuousClock.Instant, _ rhs: Swift.Duration
   ) -> ContinuousClock.Instant {
     lhs.advanced(by: .zero - rhs)
   }
 
-  @_alwaysEmitIntoClient
-  @inlinable
+  @export(implementation)
   public static func -= (
     _ lhs: inout ContinuousClock.Instant, _ rhs: Swift.Duration
   ) {
     lhs = lhs.advanced(by: .zero - rhs)
   }
 
-  @_alwaysEmitIntoClient
-  @inlinable
+  @export(implementation)
   public static func - (
     _ lhs: ContinuousClock.Instant, _ rhs: ContinuousClock.Instant
   ) -> Swift.Duration {

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -95,7 +95,7 @@ extension Actor {
   /// This converts the actor's ``Actor/unownedExecutor`` to a ``SerialExecutor`` while
   /// retaining the actor for the duration of the operation. This is to ensure the lifetime
   /// of the executor while performing the operation.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(SwiftStdlib 5.1, *)
   public nonisolated func withSerialExecutor<T: ~Copyable, E: Error>(_ operation: (any SerialExecutor) throws(E) -> T) throws(E) -> T {
     try operation(unsafe unsafeBitCast(self.unownedExecutor, to: (any SerialExecutor).self))
@@ -106,7 +106,7 @@ extension Actor {
   /// This converts the actor's ``Actor/unownedExecutor`` to a ``SerialExecutor`` while
   /// retaining the actor for the duration of the operation. This is to ensure the lifetime
   /// of the executor while performing the operation.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(SwiftStdlib 5.1, *)
   public nonisolated func withSerialExecutor<T: ~Copyable, E: Error>(_ operation: nonisolated(nonsending) (any SerialExecutor) async throws(E) -> T) async throws(E) -> T {
     try await operation(unsafe unsafeBitCast(self.unownedExecutor, to: (any SerialExecutor).self))
@@ -879,7 +879,7 @@ extension UnownedTaskExecutor {
   /// This function is available independently from the `Hashable` conformance,
   /// allowing back-deployment to older runtimes when implementing `Hashable`
   /// in user code
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func hash(into hasher: inout Hasher) {
     let (ident, impl) = unsafe unsafeBitCast(self.executor, to: (Int, Int).self)
     hasher.combine(ident)

--- a/stdlib/public/Concurrency/ExecutorAssertions.swift
+++ b/stdlib/public/Concurrency/ExecutorAssertions.swift
@@ -330,7 +330,7 @@ extension Actor {
   /// - Returns: the return value of the `operation`
   /// - Throws: rethrows the `Error` thrown by the operation if it threw
   @available(SwiftStdlib 5.1, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_unavailableFromAsync(message: "express the closure as an explicit function declared on the specified 'actor' instead")
   @_unavailableInEmbedded
   public nonisolated func assumeIsolated<T : Sendable>(

--- a/stdlib/public/Concurrency/MainActor.swift
+++ b/stdlib/public/Concurrency/MainActor.swift
@@ -82,7 +82,7 @@ extension MainActor {
   }
 
   /// Execute the given body closure on the main actor.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func run<T: Sendable>(
     resultType: T.Type = T.self,
     body: @MainActor @Sendable () throws -> T
@@ -129,7 +129,7 @@ extension MainActor {
   /// - Returns: the return value of the `operation`
   /// - Throws: rethrows the `Error` thrown by the operation if it threw
   @available(SwiftStdlib 5.1, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_unavailableFromAsync(message: "await the call to the @MainActor closure directly")
   public static func assumeIsolated<T : Sendable>(
       _ operation: @MainActor () throws -> T,
@@ -175,7 +175,7 @@ extension MainActor {
 internal func pthread_main_np() -> CInt
 
 @available(SwiftStdlib 5.1, *)
-@_alwaysEmitIntoClient
+@export(implementation)
 @_silgen_name("swift_task_deinitOnExecutorMainActorBackDeploy")
 public func _deinitOnExecutorMainActorBackDeploy(
   _ object: __owned AnyObject,

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -103,8 +103,7 @@ public struct UnownedJob: Sendable {
   }
 
   /// Deprecated API to run a job on a specific executor.
-  @_alwaysEmitIntoClient
-  @inlinable
+  @export(implementation)
   @available(*, deprecated, renamed: "ExecutorJob.runSynchronously(on:)")
   public func _runSynchronously(on executor: UnownedSerialExecutor) {
     unsafe _swiftJobRun(self, executor)
@@ -120,8 +119,7 @@ public struct UnownedJob: Sendable {
   /// and should be the same executor as the one semantically calling the `runSynchronously` method.
   ///
   /// - Parameter executor: the executor this job will be semantically running on.
-  @_alwaysEmitIntoClient
-  @inlinable
+  @export(implementation)
   public func runSynchronously(on executor: UnownedSerialExecutor) {
     unsafe _swiftJobRun(self, executor)
   }
@@ -145,8 +143,7 @@ public struct UnownedJob: Sendable {
   /// - SeeAlso: ``runSynchronously(isolatedTo:taskExecutor:)``
   @_unavailableInEmbedded
   @available(StdlibDeploymentTarget 6.0, *)
-  @_alwaysEmitIntoClient
-  @inlinable
+  @export(implementation)
   public func runSynchronously(on executor: UnownedTaskExecutor) {
     unsafe _swiftJobRunOnTaskExecutor(self, executor)
   }
@@ -173,8 +170,7 @@ public struct UnownedJob: Sendable {
   /// - SeeAlso: ``runSynchronously(on:)``
   @_unavailableInEmbedded
   @available(StdlibDeploymentTarget 6.0, *)
-  @_alwaysEmitIntoClient
-  @inlinable
+  @export(implementation)
   public func runSynchronously(isolatedTo serialExecutor: UnownedSerialExecutor,
                                taskExecutor: UnownedTaskExecutor) {
     unsafe _swiftJobRunOnTaskExecutor(self, serialExecutor, taskExecutor)
@@ -270,8 +266,7 @@ extension Job {
   /// as a job can only ever be run once, and must not be accessed after it has been run.
   ///
   /// - Parameter executor: the executor this job will be semantically running on.
-  @_alwaysEmitIntoClient
-  @inlinable
+  @export(implementation)
   __consuming public func runSynchronously(on executor: UnownedSerialExecutor) {
     unsafe _swiftJobRun(UnownedJob(self), executor)
   }
@@ -400,8 +395,7 @@ extension ExecutorJob {
   /// as a job can only ever be run once, and must not be accessed after it has been run.
   ///
   /// - Parameter executor: the executor this job will be semantically running on.
-  @_alwaysEmitIntoClient
-  @inlinable
+  @export(implementation)
   __consuming public func runSynchronously(on executor: UnownedSerialExecutor) {
     unsafe _swiftJobRun(UnownedJob(self), executor)
   }
@@ -425,8 +419,7 @@ extension ExecutorJob {
   /// - SeeAlso: ``runSynchronously(isolatedTo:taskExecutor:)``
   @_unavailableInEmbedded
   @available(StdlibDeploymentTarget 6.0, *)
-  @_alwaysEmitIntoClient
-  @inlinable
+  @export(implementation)
   __consuming public func runSynchronously(on executor: UnownedTaskExecutor) {
     unsafe _swiftJobRunOnTaskExecutor(UnownedJob(self), executor)
   }
@@ -448,8 +441,7 @@ extension ExecutorJob {
   /// - SeeAlso: ``runSynchronously(on:)``
   @_unavailableInEmbedded
   @available(StdlibDeploymentTarget 6.0, *)
-  @_alwaysEmitIntoClient
-  @inlinable
+  @export(implementation)
   __consuming public func runSynchronously(isolatedTo serialExecutor: UnownedSerialExecutor,
                                taskExecutor: UnownedTaskExecutor) {
     unsafe _swiftJobRunOnTaskExecutor(UnownedJob(self), serialExecutor, taskExecutor)
@@ -695,7 +687,7 @@ extension JobPriority: Comparable {
 public struct UnsafeContinuation<T, E: Error>: Sendable {
   @usableFromInline internal var context: Builtin.RawUnsafeContinuation
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal init(_ context: Builtin.RawUnsafeContinuation) {
     unsafe self.context = context
   }
@@ -713,7 +705,7 @@ public struct UnsafeContinuation<T, E: Error>: Sendable {
   /// control immediately returns to the caller.
   /// The task continues executing
   /// when its executor schedules it.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func resume(returning value: sending T) where E == Never {
     #if compiler(>=5.5) && $BuiltinContinuation
     unsafe Builtin.resumeNonThrowingContinuationReturning(context, value)
@@ -735,7 +727,7 @@ public struct UnsafeContinuation<T, E: Error>: Sendable {
   /// control immediately returns to the caller.
   /// The task continues executing
   /// when its executor schedules it.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func resume(returning value: sending T) {
     #if compiler(>=5.5) && $BuiltinContinuation
     unsafe Builtin.resumeThrowingContinuationReturning(context, value)
@@ -757,7 +749,7 @@ public struct UnsafeContinuation<T, E: Error>: Sendable {
   /// control immediately returns to the caller.
   /// The task continues executing
   /// when its executor schedules it.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func resume(throwing error: consuming E) {
     #if compiler(>=5.5) && $BuiltinContinuation
     unsafe Builtin.resumeThrowingContinuationThrowing(context, error)
@@ -785,7 +777,7 @@ extension UnsafeContinuation {
   /// control immediately returns to the caller.
   /// The task continues executing
   /// when its executor schedules it.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func resume<Er: Error>(with result: __shared sending Result<T, Er>) where E == Error {
     switch result {
       case .success(let val):
@@ -811,7 +803,7 @@ extension UnsafeContinuation {
   /// control immediately returns to the caller.
   /// The task continues executing
   /// when its executor schedules it.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func resume(with result: __shared sending Result<T, E>) {
     switch result {
       case .success(let val):
@@ -831,7 +823,7 @@ extension UnsafeContinuation {
   /// control immediately returns to the caller.
   /// The task continues executing
   /// when its executor schedules it.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func resume() where T == Void {
     unsafe self.resume(returning: ())
   }
@@ -841,7 +833,7 @@ extension UnsafeContinuation {
 
 // Intrinsics used by SILGen to resume or fail continuations.
 @available(SwiftStdlib 5.1, *)
-@_alwaysEmitIntoClient
+@export(implementation)
 internal func _resumeUnsafeContinuation<T>(
   _ continuation: UnsafeContinuation<T, Never>,
   _ value: sending T
@@ -850,7 +842,7 @@ internal func _resumeUnsafeContinuation<T>(
 }
 
 @available(SwiftStdlib 5.1, *)
-@_alwaysEmitIntoClient
+@export(implementation)
 internal func _resumeUnsafeThrowingContinuation<T>(
   _ continuation: UnsafeContinuation<T, Error>,
   _ value: sending T
@@ -859,7 +851,7 @@ internal func _resumeUnsafeThrowingContinuation<T>(
 }
 
 @available(SwiftStdlib 5.1, *)
-@_alwaysEmitIntoClient
+@export(implementation)
 internal func _resumeUnsafeThrowingContinuationWithError<T>(
   _ continuation: UnsafeContinuation<T, Error>,
   _ error: consuming Error
@@ -894,7 +886,7 @@ internal func _resumeUnsafeThrowingContinuationWithError<T>(
 /// - SeeAlso: `withCheckedContinuation(function:_:)`
 /// - SeeAlso: `withCheckedThrowingContinuation(function:_:)`
 @available(SwiftStdlib 5.1, *)
-@_alwaysEmitIntoClient
+@export(implementation)
 @unsafe
 public nonisolated(nonsending) func withUnsafeContinuation<T>(
   _ fn: (UnsafeContinuation<T, Never>) -> Void
@@ -907,7 +899,7 @@ public nonisolated(nonsending) func withUnsafeContinuation<T>(
 /// Source-compatibility overload; replaced by
 /// ``withUnsafeContinuation(_:)``.
 @available(SwiftStdlib 5.1, *)
-@_alwaysEmitIntoClient
+@export(implementation)
 @unsafe
 @_disfavoredOverload
 @available(*, deprecated, message: "Replaced by nonisolated(nonsending) overload")
@@ -946,7 +938,7 @@ public func withUnsafeContinuation<T>( // source-compatibility overload
 /// - SeeAlso: `withCheckedContinuation(function:_:)`
 /// - SeeAlso: `withCheckedThrowingContinuation(function:_:)`
 @available(SwiftStdlib 5.1, *)
-@_alwaysEmitIntoClient
+@export(implementation)
 @unsafe
 public nonisolated(nonsending) func withUnsafeThrowingContinuation<T, E>(
   _ fn: (UnsafeContinuation<T, E>) -> Void
@@ -961,7 +953,7 @@ public nonisolated(nonsending) func withUnsafeThrowingContinuation<T, E>(
 }
 
 @available(SwiftStdlib 5.1, *)
-@_alwaysEmitIntoClient
+@export(implementation)
 @unsafe
 public nonisolated(nonsending) func withUnsafeThrowingContinuation<T>(
   _ fn: (UnsafeContinuation<T, Error>) -> Void
@@ -974,7 +966,7 @@ public nonisolated(nonsending) func withUnsafeThrowingContinuation<T>(
 /// Source-compatibility overload; replaced by
 /// ``withUnsafeThrowingContinuation(_:)``.
 @available(SwiftStdlib 5.1, *)
-@_alwaysEmitIntoClient
+@export(implementation)
 @unsafe
 @_disfavoredOverload
 @available(*, deprecated, message: "Replaced by nonisolated(nonsending) overload")
@@ -991,7 +983,7 @@ public func withUnsafeThrowingContinuation<T>( // source-compatibility overload
 // in favor of #isolation. The _unsafeInheritExecutor_ prefix is meaningful
 // to the type checker.
 @available(SwiftStdlib 5.1, *)
-@_alwaysEmitIntoClient
+@export(implementation)
 @_unsafeInheritExecutor
 public func _unsafeInheritExecutor_withUnsafeContinuation<T>(
   _ fn: (UnsafeContinuation<T, Never>) -> Void
@@ -1005,7 +997,7 @@ public func _unsafeInheritExecutor_withUnsafeContinuation<T>(
 // in favor of #isolation. The _unsafeInheritExecutor_ prefix is meaningful
 // to the type checker.
 @available(SwiftStdlib 5.1, *)
-@_alwaysEmitIntoClient
+@export(implementation)
 @_unsafeInheritExecutor
 public func _unsafeInheritExecutor_withUnsafeThrowingContinuation<T>(
   _ fn: (UnsafeContinuation<T, Error>) -> Void
@@ -1017,7 +1009,7 @@ public func _unsafeInheritExecutor_withUnsafeThrowingContinuation<T>(
 
 /// A hack to mark an SDK that supports swift_continuation_await.
 @available(SwiftStdlib 5.1, *)
-@_alwaysEmitIntoClient
+@export(implementation)
 public func _abiEnableAwaitContinuation() {
   fatalError("never use this function")
 }

--- a/stdlib/public/Concurrency/Result+AsyncInit.swift
+++ b/stdlib/public/Concurrency/Result+AsyncInit.swift
@@ -19,7 +19,7 @@ extension Result where Success: ~Copyable {
   /// returned value as a success, or any thrown error as a failure.
   ///
   /// - Parameter body: A potentially throwing async closure to evaluate.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public nonisolated(nonsending) init(
     catching body: nonisolated(nonsending) () async throws(Failure) -> Success
   ) async {

--- a/stdlib/public/Concurrency/SourceCompatibilityShims.swift
+++ b/stdlib/public/Concurrency/SourceCompatibilityShims.swift
@@ -24,13 +24,13 @@ extension Task where Success == Never, Failure == Never {
   public typealias Handle = _Concurrency.Task
 
   @available(*, deprecated, message: "Task.CancellationError has been removed; use CancellationError")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func CancellationError() -> _Concurrency.CancellationError {
     return _Concurrency.CancellationError()
   }
 
   @available(*, deprecated, renamed: "yield()")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func suspend() async {
     await yield()
   }
@@ -39,20 +39,20 @@ extension Task where Success == Never, Failure == Never {
 @available(SwiftStdlib 5.1, *)
 extension TaskPriority {
   @available(*, deprecated, message: "unspecified priority will be removed; use nil")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static var unspecified: TaskPriority {
     .init(rawValue: 0x00)
   }
 
   @available(*, deprecated, message: "userInteractive priority will be removed")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static var userInteractive: TaskPriority {
     .init(rawValue: 0x21)
   }
 }
 
 @available(SwiftStdlib 5.1, *)
-@_alwaysEmitIntoClient
+@export(implementation)
 @available(*, deprecated, renamed: "withTaskCancellationHandler(operation:onCancel:)")
 public func withTaskCancellationHandler<T>(
   handler: @Sendable () -> Void,
@@ -65,7 +65,7 @@ public func withTaskCancellationHandler<T>(
 // in favor of #isolation. The _unsafeInheritExecutor_ prefix is meaningful
 // to the type checker.
 @available(SwiftStdlib 5.1, *)
-@_alwaysEmitIntoClient
+@export(implementation)
 @_unsafeInheritExecutor
 @available(*, deprecated, renamed: "withTaskCancellationHandler(operation:onCancel:)")
 public func _unsafeInheritExecutor_withTaskCancellationHandler<T>(
@@ -78,7 +78,7 @@ public func _unsafeInheritExecutor_withTaskCancellationHandler<T>(
 @available(SwiftStdlib 5.1, *)
 extension Task where Success == Never, Failure == Never {
   @available(*, deprecated, message: "`Task.withCancellationHandler` has been replaced by `withTaskCancellationHandler` and will be removed shortly.")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func withCancellationHandler<T>(
     handler: @Sendable () -> Void,
     operation: () async throws -> T
@@ -93,7 +93,7 @@ extension Task where Success == Never, Failure == Never {
   public typealias Group<TaskResult: Sendable> = ThrowingTaskGroup<TaskResult, Error>
 
   @available(*, deprecated, message: "`Task.withGroup` was replaced by `withThrowingTaskGroup` and `withTaskGroup` and will be removed shortly.")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func withGroup<TaskResult: Sendable, BodyResult>(
     resultType: TaskResult.Type,
     returning returnType: BodyResult.Type = BodyResult.self,
@@ -108,13 +108,13 @@ extension Task where Success == Never, Failure == Never {
 @available(SwiftStdlib 5.1, *)
 extension Task {
   @available(*, deprecated, message: "get() has been replaced by .value")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func get() async throws -> Success {
     return try await value
   }
 
   @available(*, deprecated, message: "getResult() has been replaced by .result")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func getResult() async -> Result<Success, Failure>  {
     return await result
   }
@@ -123,7 +123,7 @@ extension Task {
 @available(SwiftStdlib 5.1, *)
 extension Task where Failure == Never {
   @available(*, deprecated, message: "get() has been replaced by .value")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func get() async -> Success {
     return await value
   }
@@ -133,7 +133,7 @@ extension Task where Failure == Never {
 @available(SwiftStdlib 5.1, *)
 extension TaskGroup {
   @available(*, deprecated, renamed: "addTask(priority:operation:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func add(
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async -> ChildTaskResult
@@ -144,7 +144,7 @@ extension TaskGroup {
   }
 
   @available(*, deprecated, renamed: "addTask(priority:operation:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func spawn(
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async -> ChildTaskResult
@@ -153,7 +153,7 @@ extension TaskGroup {
   }
 
   @available(*, deprecated, renamed: "addTaskUnlessCancelled(priority:operation:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func spawnUnlessCancelled(
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async -> ChildTaskResult
@@ -162,7 +162,7 @@ extension TaskGroup {
   }
 
   @available(*, deprecated, renamed: "addTask(priority:operation:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func async(
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async -> ChildTaskResult
@@ -171,7 +171,7 @@ extension TaskGroup {
   }
 
   @available(*, deprecated, renamed: "addTaskUnlessCancelled(priority:operation:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func asyncUnlessCancelled(
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async -> ChildTaskResult
@@ -191,7 +191,7 @@ extension TaskGroup {
   }
 
   @available(*, deprecated, renamed: "addTaskUnlessCancelled(operation:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func add(
     operation: __owned @Sendable @escaping () async -> ChildTaskResult
   ) async -> Bool {
@@ -209,7 +209,7 @@ extension TaskGroup {
   }
 
   @available(*, deprecated, renamed: "addTask(operation:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func spawn(
     operation: __owned @Sendable @escaping () async -> ChildTaskResult
   ) {
@@ -225,7 +225,7 @@ extension TaskGroup {
   }
 
   @available(*, deprecated, renamed: "addTaskUnlessCancelled(operation:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func spawnUnlessCancelled(
     operation: __owned @Sendable @escaping () async -> ChildTaskResult
   ) -> Bool {
@@ -241,7 +241,7 @@ extension TaskGroup {
   }
 
   @available(*, deprecated, renamed: "addTask(operation:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func async(
     operation: __owned @Sendable @escaping () async -> ChildTaskResult
   ) {
@@ -257,7 +257,7 @@ extension TaskGroup {
   }
 
   @available(*, deprecated, renamed: "addTaskUnlessCancelled(operation:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func asyncUnlessCancelled(
     operation: __owned @Sendable @escaping () async -> ChildTaskResult
   ) -> Bool {
@@ -270,7 +270,7 @@ extension TaskGroup {
 @available(SwiftStdlib 5.1, *)
 extension ThrowingTaskGroup {
   @available(*, deprecated, renamed: "addTask(priority:operation:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func add(
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
@@ -281,7 +281,7 @@ extension ThrowingTaskGroup {
   }
 
   @available(*, deprecated, renamed: "addTask(priority:operation:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func spawn(
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
@@ -290,7 +290,7 @@ extension ThrowingTaskGroup {
   }
 
   @available(*, deprecated, renamed: "addTaskUnlessCancelled(priority:operation:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func spawnUnlessCancelled(
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
@@ -299,7 +299,7 @@ extension ThrowingTaskGroup {
   }
 
   @available(*, deprecated, renamed: "addTask(priority:operation:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func async(
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
@@ -308,7 +308,7 @@ extension ThrowingTaskGroup {
   }
 
   @available(*, deprecated, renamed: "addTaskUnlessCancelled(priority:operation:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func asyncUnlessCancelled(
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
@@ -328,7 +328,7 @@ extension ThrowingTaskGroup {
   }
 
   @available(*, deprecated, renamed: "addTaskUnlessCancelled(operation:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func add(
     operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
   ) async -> Bool {
@@ -346,7 +346,7 @@ extension ThrowingTaskGroup {
   }
 
   @available(*, deprecated, renamed: "addTask(operation:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func spawn(
     operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
   ) {
@@ -362,7 +362,7 @@ extension ThrowingTaskGroup {
   }
 
   @available(*, deprecated, renamed: "addTaskUnlessCancelled(operation:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func spawnUnlessCancelled(
     operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
   ) -> Bool {
@@ -378,7 +378,7 @@ extension ThrowingTaskGroup {
   }
 
   @available(*, deprecated, renamed: "addTask(operation:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func async(
     operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
   ) {
@@ -394,7 +394,7 @@ extension ThrowingTaskGroup {
   }
 
   @available(*, deprecated, renamed: "addTaskUnlessCancelled(operation:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func asyncUnlessCancelled(
     operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
   ) -> Bool {

--- a/stdlib/public/Concurrency/SuspendingClock.swift
+++ b/stdlib/public/Concurrency/SuspendingClock.swift
@@ -125,7 +125,7 @@ extension SuspendingClock: Clock {
 @_unavailableInEmbedded
 extension SuspendingClock {
   @available(SwiftStdlib 5.7, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var systemEpoch: Instant {
     unsafe unsafeBitCast(Duration.seconds(0), to: Instant.self)
   }

--- a/stdlib/public/Concurrency/Task+PriorityEscalation.swift
+++ b/stdlib/public/Concurrency/Task+PriorityEscalation.swift
@@ -106,7 +106,7 @@ extension UnsafeCurrentTask {
 ///              and the second argument is the new escalated priority.
 /// - Returns: the value returned by `operation`
 /// - Throws: when the `operation` throws an error
-@_alwaysEmitIntoClient
+@export(implementation)
 @available(SwiftStdlib 6.2, *)
 public nonisolated(nonsending) func withTaskPriorityEscalationHandler<T, E>(
   operation: nonisolated(nonsending)  () async throws(E) -> T,
@@ -141,7 +141,7 @@ public func _isolatedParameter_withTaskPriorityEscalationHandler<T, E>(
 
 // Method necessary in order to avoid the handler0 to be destroyed too eagerly.
 @available(SwiftStdlib 6.2, *)
-@_alwaysEmitIntoClient
+@export(implementation)
 nonisolated(nonsending) func __withTaskPriorityEscalationHandler0<T, E>(
   operation: nonisolated(nonsending) () async throws(E) -> T,
   onPriorityEscalated handler0: @Sendable (UInt8, UInt8) -> Void

--- a/stdlib/public/Concurrency/Task+immediate.swift.gyb
+++ b/stdlib/public/Concurrency/Task+immediate.swift.gyb
@@ -71,7 +71,7 @@ extension Task where Failure == ${FAILURE_TYPE} {
   ///   - operation: the operation to be run immediately upon entering the task.
   /// - Returns: A reference to the unstructured task which may be awaited on.
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @discardableResult
   public static func ${METHOD_NAME}(
     name: String? = nil,
@@ -256,7 +256,7 @@ extension ${GROUP_TYPE} {
   ///   otherwise `false`.
   % end
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func ${METHOD_NAME}( // in ${GROUP_TYPE}
     name: String? = nil,
     priority: TaskPriority? = nil,

--- a/stdlib/public/Concurrency/Task+init.swift.gyb
+++ b/stdlib/public/Concurrency/Task+init.swift.gyb
@@ -20,7 +20,7 @@ import Swift
 %      'init/*throws*/',
 %   ],
 %   [ # ALL_AVAILABILITY
-%     '@_alwaysEmitIntoClient',
+%     '@export(implementation)',
 %     '@available(SwiftStdlib 5.1, *)',
 %   ],
 %   [ # PARAMS
@@ -34,7 +34,7 @@ import Swift
 %      'static func detached/*throws*/',
 %   ],
 %   [
-%     '@_alwaysEmitIntoClient',
+%     '@export(implementation)',
 %     '@available(SwiftStdlib 5.1, *)',
 %   ],
 %   [ # PARAMS
@@ -49,7 +49,7 @@ import Swift
 %      'init/*throws*/',
 %   ],
 %   [ # ALL_AVAILABILITY
-%     '@_alwaysEmitIntoClient',
+%     '@export(implementation)',
 %     '@available(SwiftStdlib 6.0, *)',
 %   ],
 %   [ # PARAMS
@@ -64,7 +64,7 @@ import Swift
 %      'static func detached/*throws*/',
 %   ],
 %   [
-%     '@_alwaysEmitIntoClient',
+%     '@export(implementation)',
 %     '@available(SwiftStdlib 6.0, *)',
 %   ],
 %   [ # PARAMS
@@ -85,7 +85,7 @@ import Swift
 %      'func detach<Success>/*throws*/',
 %   ],
 %   [ # ALL_AVAILABILITY
-%     '@_alwaysEmitIntoClient',
+%     '@export(implementation)',
 %     '@available(SwiftStdlib 5.1, *)',
 %     '@available(*, deprecated, message: "`detach` was replaced by `Task.detached` and will be removed shortly.")',
 %   ],
@@ -100,7 +100,7 @@ import Swift
 %      'static func runDetached/*throws*/',
 %   ],
 %   [ # ALL_AVAILABILITY
-%     '@_alwaysEmitIntoClient',
+%     '@export(implementation)',
 %     '@available(SwiftStdlib 5.1, *)',
 %     '@available(*, deprecated, message: "`Task.runDetached` was replaced by `Task.detached` and will be removed shortly.")',
 %   ],
@@ -115,7 +115,7 @@ import Swift
 %      'func asyncDetached<Success>/*throws*/',
 %   ],
 %   [ # ALL_AVAILABILITY
-%     '@_alwaysEmitIntoClient',
+%     '@export(implementation)',
 %     '@available(SwiftStdlib 5.1, *)',
 %     '@available(*, deprecated, message: "`asyncDetached` was replaced by `Task.detached` and will be removed shortly.")',
 %   ],
@@ -130,7 +130,7 @@ import Swift
 %      'func async<Success>/*throws*/',
 %   ],
 %   [ # ALL_AVAILABILITY
-%     '@_alwaysEmitIntoClient',
+%     '@export(implementation)',
 %     '@available(SwiftStdlib 5.1, *)',
 %     '@available(*, deprecated, message: "`async` was replaced by `Task.init` and will be removed shortly.")',
 %   ],
@@ -194,7 +194,7 @@ extension Task where Failure == ${FAILURE_TYPE} {
 % # --------------------------------------------------------------------------------------------------------------------
 #if SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
   @discardableResult
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
   public ${METHOD_VARIANT}(
       ${",\n    ".join(adjust_params_for_kind(PARAMS))}
@@ -206,7 +206,7 @@ extension Task where Failure == ${FAILURE_TYPE} {
 % if not HAS_TASK_EXECUTOR:
 #elseif $Embedded
   @discardableResult
-  @_alwaysEmitIntoClient
+  @export(implementation)
   ${"  \n".join(adjust_availability(['@available(SwiftStdlib 5.1, *)']))}
   public ${METHOD_VARIANT}(
       ${",\n    ".join(adjust_params_for_kind(PARAMS))}

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -145,7 +145,7 @@ public struct Task<Success: Sendable, Failure: Error>: Sendable {
   @available(SwiftStdlib 5.1, *)
   internal let _task: Builtin.NativeObject
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal init(_ task: Builtin.NativeObject) {
     self._task = task
   }
@@ -168,7 +168,7 @@ extension Task {
   ///
   /// - Returns: The task's result.
   public var value: Success {
-    @_alwaysEmitIntoClient
+    @export(implementation)
     // This name is slightly different purely to avoid a clash with
     // the original property and keep the mangling concise.
     @_silgen_name("$sScT6_valuexvg")
@@ -332,7 +332,7 @@ public struct TaskPriority: RawRepresentable, Sendable {
 
   public static let high: TaskPriority = .init(rawValue: 0x19)
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static var medium: TaskPriority {
     .init(rawValue: 0x15)
   }
@@ -562,7 +562,7 @@ struct JobFlags {
 
 /// Form task creation flags for use with the createAsyncTask builtins.
 @available(SwiftStdlib 5.1, *)
-@_alwaysEmitIntoClient
+@export(implementation)
 func taskCreateFlags(
   priority: TaskPriority?, isChildTask: Bool, copyTaskLocals: Bool,
   inheritContext: Bool, enqueueJob: Bool,
@@ -883,7 +883,7 @@ public struct UnsafeCurrentTask {
 
   /// Check if the task is cancelled, optionally ignoring active cancellation shields.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func _isCancelled(ignoreTaskCancellationShield: Bool) -> Bool {
     let flags: UInt64 = ignoreTaskCancellationShield ? 0x1 : 0x0
     return unsafe _taskIsCancelledWithFlags(_rawTask, flags: flags)
@@ -938,9 +938,9 @@ public struct UnsafeCurrentTask {
   /// - SeeAlso: ``withTaskCancellationShield(operation:)``
   /// - SeeAlso: ``Task/hasActiveCancellationShield``
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var hasActiveCancellationShield: Bool {
-    @_alwaysEmitIntoClient
+    @export(implementation)
     get {
       unsafe _taskHasActiveCancellationShield(_rawTask)
     }
@@ -1233,8 +1233,7 @@ extension Task where Failure == Never {
 @available(SwiftStdlib 5.8, *)
 extension Task where Failure == Error {
   @available(SwiftStdlib 5.8, *)
-  @_alwaysEmitIntoClient
-  @usableFromInline
+  @export(implementation)
   internal static func _runInlineHelper<T>(
     body: () async -> Result<T, Error>,
     rescue: (Result<T, Error>) throws -> T
@@ -1273,8 +1272,7 @@ extension Task where Failure == Error {
 /// Intrinsic used by SILGen to launch a task for bridging a Swift async method
 /// which was called through its ObjC-exported completion-handler-based API.
 @available(SwiftStdlib 5.1, *)
-@_alwaysEmitIntoClient
-@usableFromInline
+@export(implementation)
 internal func _runTaskForBridgedAsyncMethod(@_inheritActorContext _ body: __owned @Sendable @escaping () async -> Void) {
 #if compiler(>=5.6)
   Task(operation: body)

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -73,7 +73,7 @@ import Swift
 /// Therefore, if a cancellation handler must acquire a lock, other code should
 /// not cancel tasks or resume continuations while holding that lock.
 @available(SwiftStdlib 5.1, *)
-@_alwaysEmitIntoClient
+@export(implementation)
 public nonisolated(nonsending) func withTaskCancellationHandler<Return, Failure>(
   operation: nonisolated(nonsending) () async throws(Failure) -> Return,
   onCancel handler: sending () -> Void
@@ -372,7 +372,7 @@ func _taskRemoveCancellationHandler(
 /// }
 /// ```
 @available(SwiftStdlib 6.4, *)
-@_alwaysEmitIntoClient
+@export(implementation)
 public nonisolated(nonsending) func withTaskCancellationShield<Value, Failure>(
   operation: nonisolated(nonsending) () async throws(Failure) -> Value,
 ) async throws(Failure) -> Value {
@@ -466,7 +466,7 @@ public nonisolated(nonsending) func withTaskCancellationShield<Value, Failure>(
 /// }
 /// ```
 @available(SwiftStdlib 6.4, *)
-@_alwaysEmitIntoClient
+@export(implementation)
 public func withTaskCancellationShield<Value, Failure>(
   operation: () throws(Failure) -> Value,
 ) throws(Failure) -> Value {
@@ -505,9 +505,9 @@ extension Task where Success == Never, Failure == Never {
   /// - SeeAlso: ``withTaskCancellationShield(operation:)``
   /// - SeeAlso: ``UnsafeCurrentTask/hasActiveCancellationShield``
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static var hasActiveCancellationShield: Bool {
-    @_alwaysEmitIntoClient
+    @export(implementation)
     get {
       unsafe withUnsafeCurrentTask { task in
         unsafe task?.hasActiveCancellationShield ?? false

--- a/stdlib/public/Concurrency/TaskGroup+addTask.swift.gyb
+++ b/stdlib/public/Concurrency/TaskGroup+addTask.swift.gyb
@@ -247,7 +247,7 @@ extension ${TYPE} {
   /// - Returns: `true` if the child task was added to the group;
   ///   otherwise `false`.
   % end
-  @_alwaysEmitIntoClient
+  @export(implementation)
   ${"\n  ".join(ALL_AVAILABILITY)}
   public mutating func ${METHOD_NAME}( // ${TYPE}/${METHOD_NAME}
     ${",\n    ".join(adjust_params_for_group_kind(PARAMS))}

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -450,13 +450,13 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   }
 
   /// Wait for all of the group's remaining tasks to complete.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public nonisolated(nonsending) mutating func waitForAll() async {
     await awaitAllRemainingTasks(isolation: #isolation)
   }
 
   /// Wait for all of the group's remaining tasks to complete.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, deprecated, message: "Replaced by nonisolated(nonsending) overload")
   public mutating func waitForAll(isolation: isolated (any Actor)? = #isolation) async {
     await awaitAllRemainingTasks(isolation: isolation)
@@ -647,7 +647,7 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   ///
   /// - Throws: The *first* error that was thrown by a child task during draining all the tasks.
   ///           This first error is stored until all other tasks have completed, and is re-thrown afterwards.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public nonisolated(nonsending) mutating func waitForAll() async throws {
     var firstError: Error? = nil
 
@@ -668,7 +668,7 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
     }
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, deprecated, message: "Replaced by nonisolated(nonsending) overload")
   public mutating func waitForAll(isolation: isolated (any Actor)? = #isolation) async throws {
     var firstError: Error? = nil
@@ -808,12 +808,12 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   ///   containing the error that the child task threw.
   ///
   /// - SeeAlso: `next()`
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public nonisolated(nonsending) mutating func nextResult() async -> Result<ChildTaskResult, Failure>? {
     return try! await nextResultForABI()
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, deprecated, message: "Replaced by nonisolated(nonsending) overload")
   public mutating func nextResult(isolation: isolated (any Actor)? = #isolation) async -> Result<ChildTaskResult, Failure>? {
     return try! await nextResultForABI()
@@ -1183,7 +1183,7 @@ struct TaskGroupFlags {
 
 /// Form task creation flags for use with the createAsyncTask builtins.
 @available(SwiftStdlib 5.8, *)
-@_alwaysEmitIntoClient
+@export(implementation)
 func taskGroupCreateFlags(
         discardResults: Bool) -> Int {
   var bits = 0

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -172,7 +172,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
     self.defaultValue = defaultValue
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   var key: Builtin.RawPointer {
     unsafe unsafeBitCast(self, to: Builtin.RawPointer.self)
   }
@@ -203,7 +203,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   /// task present, as the underlying storage will fallback to using a managed thread-local value
   /// when no task is available. From the perspective of task local APIs, the presented semantics
   /// remain exactly the same as when a task is present.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @abi(func get_aeic() -> Value)
   public func get() -> Value {
     guard let rawValue = unsafe _taskLocalValueGet(key: key) else {
@@ -234,7 +234,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   /// If this method is called form a context where no current Swift concurrency task
   /// is available, a fallback thread-local is used to manage the task locals and
   /// all existing semantics of task-locals are upheld as-if a task was actually available.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @discardableResult
   @available(SwiftStdlib 5.1, *)
   // ABI Note: @abi needed because the mangling otherwise conflicts with the
@@ -311,7 +311,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   /// calls to swift_task_de/alloc for the copy as follows:
   /// - withValue contains the compiler-emitted calls swift_task_de/alloc.
   /// - withValueImpl contains the calls to Builtin.{add,remove}TaskLocalValue
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @discardableResult
   @available(SwiftStdlib 5.1, *)
   internal nonisolated(nonsending) func withValueImpl<R>(

--- a/stdlib/public/Concurrency/TaskSleepDuration.swift
+++ b/stdlib/public/Concurrency/TaskSleepDuration.swift
@@ -235,7 +235,7 @@ extension Task where Success == Never, Failure == Never {
   ///       try await Task.sleep(for: .seconds(3))
   ///
   @available(SwiftStdlib 5.7, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func sleep<C: Clock>(
     for duration: C.Instant.Duration,
     tolerance: C.Instant.Duration? = nil,
@@ -260,7 +260,7 @@ extension Task where Success == Never, Failure == Never {
   }
   @available(SwiftStdlib 5.7, *)
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func sleep<C: Clock>(
     for duration: C.Instant.Duration,
     tolerance: C.Instant.Duration? = nil,

--- a/stdlib/public/Cxx/CxxSpan.swift
+++ b/stdlib/public/Cxx/CxxSpan.swift
@@ -25,7 +25,7 @@ internal func unsafeBitCast<T: ~Escapable & ~Copyable, U>(
 /// This mimics the stdlib definition. It is public for use with import macros.
 @unsafe
 @_unsafeNonescapableResult
-@_alwaysEmitIntoClient
+@export(implementation)
 @_transparent
 @lifetime(borrow source)
 public func _cxxOverrideLifetime<
@@ -45,7 +45,7 @@ public func _cxxOverrideLifetime<
 /// This mimics the stdlib definition. It is public for use with import macros.
 @unsafe
 @_unsafeNonescapableResult
-@_alwaysEmitIntoClient
+@export(implementation)
 @_transparent
 @lifetime(copy source)
 public func _cxxOverrideLifetime<
@@ -74,14 +74,14 @@ public protocol CxxSpan<Element> {
 
 extension CxxSpan where Element: ~Copyable {
   /// Creates a C++ span from a Swift UnsafeBufferPointer
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(_ unsafeBufferPointer: UnsafeBufferPointer<Element>) {
     unsafe precondition(unsafeBufferPointer.baseAddress != nil, 
                   "UnsafeBufferPointer should not point to nil")
     unsafe self.init(unsafeBufferPointer.baseAddress!, Size(unsafeBufferPointer.count))
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(_ unsafeMutableBufferPointer: UnsafeMutableBufferPointer<Element>) {
     unsafe precondition(unsafeMutableBufferPointer.baseAddress != nil, 
                   "UnsafeMutableBufferPointer should not point to nil")
@@ -89,7 +89,7 @@ extension CxxSpan where Element: ~Copyable {
   }
 
   @available(SwiftCompatibilitySpan 5.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @unsafe
   public init(_ span: Span<Element>) {
     let p = span.withUnsafeBufferPointer {
@@ -104,7 +104,7 @@ extension CxxSpan where Element: ~Copyable {
 
 @available(SwiftCompatibilitySpan 5.0, *)
 extension Span where Element: ~Copyable {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @unsafe
   @_unsafeNonescapableResult
   @lifetime(borrow span)
@@ -120,7 +120,7 @@ extension Span where Element: ~Copyable {
 
 @available(SwiftCompatibilitySpan 5.0, *)
 extension MutableSpan where Element: ~Copyable {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @unsafe
   @_unsafeNonescapableResult
   @lifetime(borrow span)
@@ -147,7 +147,7 @@ public protocol CxxMutableSpan<Element> {
 
 extension CxxMutableSpan where Element: ~Copyable {
   /// Creates a C++ span from a Swift UnsafeMutableBufferPointer
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(_ unsafeMutableBufferPointer: UnsafeMutableBufferPointer<Element>) {
     unsafe precondition(unsafeMutableBufferPointer.baseAddress != nil, 
                   "UnsafeMutableBufferPointer should not point to nil")
@@ -155,7 +155,7 @@ extension CxxMutableSpan where Element: ~Copyable {
   }
 
   @available(SwiftCompatibilitySpan 5.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @unsafe
   public init(_ span: consuming MutableSpan<Element>) {
     let p = span.withUnsafeMutableBufferPointer {

--- a/stdlib/public/Cxx/CxxVector.swift
+++ b/stdlib/public/Cxx/CxxVector.swift
@@ -54,7 +54,7 @@ extension CxxVector {
 extension CxxVector {
   public var span: Span<Element> {
     @lifetime(borrow self)
-    @_alwaysEmitIntoClient
+    @export(implementation)
     borrowing get {
       let buffer = unsafe UnsafeBufferPointer(start: self.__dataUnsafe(), count: Int(self.size()))
       let span = unsafe Span(_unsafeElements: buffer)

--- a/stdlib/public/Cxx/std/Chrono.swift
+++ b/stdlib/public/Cxx/std/Chrono.swift
@@ -14,7 +14,7 @@ import CxxStdlibShim
 
 extension std.chrono.seconds {
   @available(SwiftStdlib 5.7, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(_ duration: Duration) {
     let (seconds, _) = duration.components
     self = __swift_interopMakeChronoSeconds(seconds)
@@ -23,7 +23,7 @@ extension std.chrono.seconds {
 
 extension std.chrono.milliseconds {
   @available(SwiftStdlib 5.7, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(_ duration: Duration) {
     let (seconds, attoseconds) = duration.components
     self = __swift_interopMakeChronoMilliseconds(
@@ -34,7 +34,7 @@ extension std.chrono.milliseconds {
 
 extension std.chrono.microseconds {
   @available(SwiftStdlib 5.7, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(_ duration: Duration) {
     let (seconds, attoseconds) = duration.components
     self = __swift_interopMakeChronoMicroseconds(
@@ -45,7 +45,7 @@ extension std.chrono.microseconds {
 
 extension std.chrono.nanoseconds {
   @available(SwiftStdlib 5.7, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(_ duration: Duration) {
     let (seconds, attoseconds) = duration.components
     self = __swift_interopMakeChronoNanoseconds(
@@ -56,22 +56,22 @@ extension std.chrono.nanoseconds {
 
 @available(SwiftStdlib 5.7, *)
 extension Duration {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(_ seconds: std.chrono.seconds) {
     self = Duration.seconds(seconds.count())
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(_ milliseconds: std.chrono.milliseconds) {
     self = Duration.milliseconds(milliseconds.count())
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(_ microseconds: std.chrono.microseconds) {
     self = Duration.microseconds(microseconds.count())
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(_ nanoseconds: std.chrono.nanoseconds) {
     self = Duration.nanoseconds(nanoseconds.count())
   }

--- a/stdlib/public/Cxx/std/String.swift
+++ b/stdlib/public/Cxx/std/String.swift
@@ -19,7 +19,7 @@ extension std.string {
   ///
   /// - Complexity: O(*n*), where *n* is the number of UTF-8 code units in the
   ///   Swift string.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(_ string: String) {
     self = string.withCString(encodedAs: UTF8.self) { buffer in
       // MSVC STL has a enable_if template guard on the 3-parameter constructor,
@@ -38,13 +38,13 @@ extension std.string {
   }
 
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, unavailable, message: "initializing std::string with an optional String is not supported; unwrap the optional value before passing it to std.string()")
   public init(_ string: String?) {
       fatalError("This initializer is unavailable and should never be called.")
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(_ string: UnsafePointer<CChar>) {
 #if os(Linux)
     unsafe self.init(string, UTF8._nullCodeUnitOffset(in: string), .init())
@@ -53,7 +53,7 @@ extension std.string {
 #endif
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_disfavoredOverload
   @available(*, deprecated, message: "unwrap the optional value and use init(_ string: UnsafePointer<CChar>) instead")
   public init(_ string: UnsafePointer<CChar>?) {
@@ -71,7 +71,7 @@ extension std.u16string {
   ///
   /// - Complexity: O(*n*), where *n* is the number of UTF-16 code units in the
   ///   Swift string.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(_ string: String) {
     self.init()
     for char in string.utf16 {
@@ -86,7 +86,7 @@ extension std.u32string {
   ///
   /// - Complexity: O(*n*), where *n* is the number of UTF-32 code units in the
   ///   Swift string.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(_ string: String) {
     self.init()
     for char in string.unicodeScalars {
@@ -104,7 +104,7 @@ extension std.wstring {
   ///
   /// - Complexity: O(*n*), where *n* is the number of wide characters in the
   ///   Swift string.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(_ string: String) {
     self.init()
 #if os(Windows)
@@ -124,7 +124,7 @@ extension std.wstring {
 extension std.string: ExpressibleByStringLiteral,
   ExpressibleByStringInterpolation {
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(stringLiteral value: String) {
     self.init(value)
   }
@@ -133,7 +133,7 @@ extension std.string: ExpressibleByStringLiteral,
 extension std.u16string: ExpressibleByStringLiteral,
   ExpressibleByStringInterpolation {
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(stringLiteral value: String) {
     self.init(value)
   }
@@ -142,7 +142,7 @@ extension std.u16string: ExpressibleByStringLiteral,
 extension std.u32string: ExpressibleByStringLiteral,
   ExpressibleByStringInterpolation {
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(stringLiteral value: String) {
     self.init(value)
   }
@@ -151,7 +151,7 @@ extension std.u32string: ExpressibleByStringLiteral,
 extension std.wstring: ExpressibleByStringLiteral,
   ExpressibleByStringInterpolation {
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(stringLiteral value: String) {
     self.init(value)
   }
@@ -160,27 +160,27 @@ extension std.wstring: ExpressibleByStringLiteral,
 // MARK: Concatenating and comparing C++ strings
 
 extension std.string: Equatable, Comparable {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func ==(lhs: std.string, rhs: std.string) -> Bool {
     return lhs.compare(rhs) == 0
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func <(lhs: std.string, rhs: std.string) -> Bool {
     return lhs.compare(rhs) < 0
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func +=(lhs: inout std.string, rhs: std.string) {
     lhs.append(rhs)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func append(_ other: std.string) {
     unsafe __appendUnsafe(other) // ignore the returned pointer
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func +(lhs: std.string, rhs: std.string) -> std.string {
     var copy = lhs
     copy += rhs
@@ -189,27 +189,27 @@ extension std.string: Equatable, Comparable {
 }
 
 extension std.u16string: Equatable, Comparable {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func ==(lhs: std.u16string, rhs: std.u16string) -> Bool {
     return lhs.compare(rhs) == 0
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func <(lhs: std.u16string, rhs: std.u16string) -> Bool {
     return lhs.compare(rhs) < 0
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func +=(lhs: inout std.u16string, rhs: std.u16string) {
     lhs.append(rhs)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func append(_ other: std.u16string) {
     unsafe __appendUnsafe(other) // ignore the returned pointer
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func +(lhs: std.u16string, rhs: std.u16string) -> std.u16string {
     var copy = lhs
     copy += rhs
@@ -218,27 +218,27 @@ extension std.u16string: Equatable, Comparable {
 }
 
 extension std.u32string: Equatable, Comparable {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func ==(lhs: std.u32string, rhs: std.u32string) -> Bool {
     return lhs.compare(rhs) == 0
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func <(lhs: std.u32string, rhs: std.u32string) -> Bool {
     return lhs.compare(rhs) < 0
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func +=(lhs: inout std.u32string, rhs: std.u32string) {
     lhs.append(rhs)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func append(_ other: std.u32string) {
     unsafe __appendUnsafe(other) // ignore the returned pointer
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func +(lhs: std.u32string, rhs: std.u32string) -> std.u32string {
     var copy = lhs
     copy += rhs
@@ -247,27 +247,27 @@ extension std.u32string: Equatable, Comparable {
 }
 
 extension std.wstring: Equatable, Comparable {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func ==(lhs: std.wstring, rhs: std.wstring) -> Bool {
     return lhs.compare(rhs) == 0
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func <(lhs: std.wstring, rhs: std.wstring) -> Bool {
     return lhs.compare(rhs) < 0
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func +=(lhs: inout std.wstring, rhs: std.wstring) {
     lhs.append(rhs)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func append(_ other: std.wstring) {
     unsafe __appendUnsafe(other) // ignore the returned pointer
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func +(lhs: std.wstring, rhs: std.wstring) -> std.wstring {
     var copy = lhs
     copy += rhs
@@ -278,7 +278,7 @@ extension std.wstring: Equatable, Comparable {
 // MARK: Hashing C++ strings
 
 extension std.string: Hashable {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func hash(into hasher: inout Hasher) {
     // Call std::hash<std::string>::operator()
     let cxxHash = __swift_interopComputeHashOfString(self)
@@ -287,7 +287,7 @@ extension std.string: Hashable {
 }
 
 extension std.u16string: Hashable {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func hash(into hasher: inout Hasher) {
     // Call std::hash<std::u16string>::operator()
     let cxxHash = __swift_interopComputeHashOfU16String(self)
@@ -296,7 +296,7 @@ extension std.u16string: Hashable {
 }
 
 extension std.u32string: Hashable {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func hash(into hasher: inout Hasher) {
     // Call std::hash<std::u32string>::operator()
     let cxxHash = __swift_interopComputeHashOfU32String(self)
@@ -305,7 +305,7 @@ extension std.u32string: Hashable {
 }
 
 extension std.wstring: Hashable {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func hash(into hasher: inout Hasher) {
     // Call std::hash<std::wstring>::operator()
     let cxxHash = __swift_interopComputeHashOfWString(self)
@@ -316,56 +316,56 @@ extension std.wstring: Hashable {
 // MARK: Getting a Swift description of a C++ string
 
 extension std.string: CustomDebugStringConvertible {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var debugDescription: String {
     return "std.string(\(String(self)))"
   }
 }
 
 extension std.u16string: CustomDebugStringConvertible {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var debugDescription: String {
     return "std.u16string(\(String(self)))"
   }
 }
 
 extension std.u32string: CustomDebugStringConvertible {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var debugDescription: String {
     return "std.u32string(\(String(self)))"
   }
 }
 
 extension std.wstring: CustomDebugStringConvertible {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var debugDescription: String {
     return "std.wstring(\(String(self)))"
   }
 }
 
 extension std.string: CustomStringConvertible {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var description: String {
     return String(self)
   }
 }
 
 extension std.u16string: CustomStringConvertible {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var description: String {
     return String(self)
   }
 }
 
 extension std.u32string: CustomStringConvertible {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var description: String {
     return String(self)
   }
 }
 
 extension std.wstring: CustomStringConvertible {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var description: String {
     return String(self)
   }
@@ -381,7 +381,7 @@ extension String {
   /// (`"\u{FFFD}"`).
   ///
   /// - Complexity: O(*n*), where *n* is the number of bytes in the C++ string.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(_ cxxString: std.string) {
     let buffer = unsafe UnsafeBufferPointer<CChar>(
       start: cxxString.__c_strUnsafe(),
@@ -400,7 +400,7 @@ extension String {
   ///
   /// - Complexity: O(*n*), where *n* is the number of bytes in the C++ UTF-16
   ///   string.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(_ cxxU16String: std.u16string) {
     let buffer = unsafe UnsafeBufferPointer<UInt16>(
       start: cxxU16String.__dataUnsafe(),
@@ -417,7 +417,7 @@ extension String {
   ///
   /// - Complexity: O(*n*), where *n* is the number of bytes in the C++ UTF-32
   ///   string.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(_ cxxU32String: std.u32string) {
     let buffer = unsafe UnsafeBufferPointer<Unicode.Scalar>(
       start: cxxU32String.__dataUnsafe(),
@@ -440,7 +440,7 @@ extension String {
   ///
   /// - Complexity: O(*n*), where *n* is the number of wide characters in the
   ///   C++ string.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(_ cxxWString: std.wstring) {
 #if os(Windows)
     let buffer = unsafe UnsafeBufferPointer<UInt16>(
@@ -470,7 +470,7 @@ extension String {
   ///
   /// - Complexity: O(*n*), where *n* is the number of bytes in the C++ string
   ///   view.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(_ cxxStringView: std.string_view) {
     let buffer = unsafe UnsafeBufferPointer<CChar>(
       start: cxxStringView.__dataUnsafe(),
@@ -490,7 +490,7 @@ extension String {
   ///
   /// - Complexity: O(*n*), where *n* is the number of bytes in the C++ UTF-16
   ///   string view.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(_ cxxU16StringView: std.u16string_view) {
     let buffer = unsafe UnsafeBufferPointer<UInt16>(
       start: cxxU16StringView.__dataUnsafe(),
@@ -508,7 +508,7 @@ extension String {
   ///
   /// - Complexity: O(*n*), where *n* is the number of bytes in the C++ UTF-32
   ///   string view.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(_ cxxU32StringView: std.u32string_view) {
     let buffer = unsafe UnsafeBufferPointer<Unicode.Scalar>(
       start: cxxU32StringView.__dataUnsafe(),
@@ -519,7 +519,7 @@ extension String {
     unsafe withExtendedLifetime(cxxU32StringView) {}
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(_ cxxWStringView: std.wstring_view) {
 #if os(Windows)
     let buffer = unsafe UnsafeBufferPointer<UInt16>(
@@ -542,7 +542,7 @@ extension String {
 extension std.string {
   public var span: Span<CChar> {
     @_lifetime(borrow self)
-    @_alwaysEmitIntoClient
+    @export(implementation)
     borrowing get {
       let buffer = unsafe UnsafeBufferPointer(start: self.__dataUnsafe(), count: Int(self.size()))
       let span = unsafe Span(_unsafeElements: buffer)
@@ -555,7 +555,7 @@ extension std.string {
 extension std.string {
   public var utf8Span: UTF8Span? {
     @_lifetime(borrow self)
-    @_alwaysEmitIntoClient
+    @export(implementation)
     borrowing get {
       let buffer = unsafe UnsafeBufferPointer(start: self.__dataUnsafe(), count: Int(self.size()))
       let rawBuffer = UnsafeRawBufferPointer(buffer)
@@ -571,7 +571,7 @@ extension std.string {
 extension std.u16string {
   public var span: Span<UInt16> {
     @_lifetime(borrow self)
-    @_alwaysEmitIntoClient
+    @export(implementation)
     borrowing get {
       let buffer = unsafe UnsafeBufferPointer(start: self.__dataUnsafe(), count: Int(self.size()))
       let rawBuffer = UnsafeRawBufferPointer(buffer)
@@ -586,7 +586,7 @@ extension std.u16string {
 extension std.u32string {
   public var span: Span<UInt32> {
     @_lifetime(borrow self)
-    @_alwaysEmitIntoClient
+    @export(implementation)
     borrowing get {
       let buffer = unsafe UnsafeBufferPointer(start: self.__dataUnsafe(), count: Int(self.size()))
       let rawBuffer = UnsafeRawBufferPointer(buffer)
@@ -601,7 +601,7 @@ extension std.u32string {
 extension std.wstring {
   public var span: Span<CWideChar> {
     @_lifetime(borrow self)
-    @_alwaysEmitIntoClient
+    @export(implementation)
     borrowing get {
       let buffer = unsafe UnsafeBufferPointer(start: self.__dataUnsafe(), count: Int(self.size()))
       let rawBuffer = UnsafeRawBufferPointer(buffer)

--- a/stdlib/public/Differentiation/Differentiable.swift
+++ b/stdlib/public/Differentiation/Differentiable.swift
@@ -39,8 +39,7 @@ public protocol Differentiable {
 }
 
 public extension Differentiable where TangentVector == Self {
-  @_alwaysEmitIntoClient
-  @inlinable
+  @export(implementation)
   mutating func move(by offset: TangentVector) {
     self += offset
   }

--- a/stdlib/public/Differentiation/OptionalDifferentiation.swift
+++ b/stdlib/public/Differentiation/OptionalDifferentiation.swift
@@ -73,7 +73,7 @@ extension Optional.TangentVector: CustomReflectable {
 
 @derivative(of: ??)
 @_transparent
-@_alwaysEmitIntoClient
+@export(implementation)
 func _vjpNilCoalescing<T: Differentiable>(optional: T?, defaultValue: @autoclosure () throws -> T)
  rethrows -> (value: T, pullback: (T.TangentVector) -> Optional<T>.TangentVector) {
   let hasValue = optional != nil

--- a/stdlib/public/Differentiation/SIMDDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/SIMDDifferentiation.swift.gyb
@@ -413,8 +413,7 @@ where
   Scalar.TangentVector: BinaryFloatingPoint,
   TangentVector == Self
 {
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @derivative(of: sum)
   func _vjpSum() -> (
     value: Scalar, pullback: (Scalar.TangentVector) -> TangentVector
@@ -422,8 +421,7 @@ where
     return (sum(), { v in Self(repeating: Scalar(v)) })
   }
 
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @derivative(of: sum)
   func _jvpSum() -> (
     value: Scalar, differential: (TangentVector) -> Scalar.TangentVector
@@ -459,8 +457,7 @@ where
 %for (Scalar, bits) in [('Float',32), ('Double',64)]:
 % for n in vectorscalarCounts:
 extension SIMD${n} where Scalar == ${Scalar} {
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @derivative(of: init(repeating:))
   static func _vjpInit(repeating value: Scalar)
     -> (value: Self, pullback: (TangentVector) -> Scalar.TangentVector)
@@ -468,8 +465,7 @@ extension SIMD${n} where Scalar == ${Scalar} {
     return (Self(repeating: value), { v in v.sum() })
   }
 
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @derivative(of: init(repeating:))
   static func _jvpInit(repeating value: Scalar)
     -> (value: Self, differential: (Scalar.TangentVector) -> TangentVector)

--- a/stdlib/public/Distributed/DistributedActor.swift
+++ b/stdlib/public/Distributed/DistributedActor.swift
@@ -363,7 +363,7 @@ extension DistributedActor {
   /// state.
   ///
   /// When the actor is remote, the closure won't be executed and this function will return nil.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   // we need to silgen_name here because the signature is the same as __abi_whenLocal,
   // and even though this is @AEIC, the symbol name would conflict.
   @_silgen_name("$s11Distributed0A5ActorPAAE20whenLocalTypedThrowsyqd__Sgqd__xYiYaYbqd_0_YKXEYaqd_0_YKs8SendableRd__s5ErrorRd_0_r0_lF")
@@ -403,7 +403,7 @@ extension DistributedActor {
 /// distributed actor
 @available(SwiftStdlib 5.7, *)
 extension DistributedActor {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_implements(Actor, unownedExecutor)
   public nonisolated var __actorUnownedExecutor: UnownedSerialExecutor {
     if #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) {

--- a/stdlib/public/Distributed/DistributedAssertions.swift
+++ b/stdlib/public/Distributed/DistributedAssertions.swift
@@ -153,7 +153,7 @@ extension DistributedActor {
   /// - Throws: rethrows the `Error` thrown by the operation if it threw
   @available(SwiftStdlib 5.9, *)
   @_unavailableFromAsync(message: "express the closure as an explicit function declared on the specified 'distributed actor' instead")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public nonisolated func assumeIsolated<T : Sendable>(
       _ operation: (isolated Self) throws -> T,
       file: StaticString = #fileID, line: UInt = #line

--- a/stdlib/public/Synchronization/Atomics/Atomic.swift
+++ b/stdlib/public/Synchronization/Atomics/Atomic.swift
@@ -19,14 +19,14 @@ import Builtin
 @_staticExclusiveOnly
 public struct Atomic<Value: AtomicRepresentable>: ~Copyable {
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   var _address: UnsafeMutablePointer<Value.AtomicRepresentation> {
     unsafe UnsafeMutablePointer<Value.AtomicRepresentation>(_rawAddress)
   }
 
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   var _rawAddress: Builtin.RawPointer {
     Builtin.addressOfRawLayout(self)
@@ -36,7 +36,7 @@ public struct Atomic<Value: AtomicRepresentable>: ~Copyable {
   ///
   /// - Parameter initialValue: The initial value to set this atomic.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public init(_ initialValue: consuming Value) {
     unsafe _address.initialize(to: Value.encodeAtomicRepresentation(initialValue))
@@ -45,8 +45,7 @@ public struct Atomic<Value: AtomicRepresentable>: ~Copyable {
   // Deinit's can't be marked @_transparent. Do these things need all of these
   // attributes..?
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
-  @inlinable
+  @export(implementation)
   deinit {
     let oldValue = unsafe Value.decodeAtomicRepresentation(_address.pointee)
     _ = consume oldValue

--- a/stdlib/public/Synchronization/Atomics/AtomicBool.swift
+++ b/stdlib/public/Synchronization/Atomics/AtomicBool.swift
@@ -34,7 +34,7 @@ extension Bool: AtomicRepresentable {
   ///   to encode an instance of its `AtomicRepresentation`.
   /// - Returns: The newly encoded `AtomicRepresentation` storage.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func encodeAtomicRepresentation(
     _ value: borrowing Bool
@@ -55,7 +55,7 @@ extension Bool: AtomicRepresentable {
   ///   within atomic operations.
   /// - Returns: The newly decoded logical type `Self`.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func decodeAtomicRepresentation(
     _ representation: consuming AtomicRepresentation
@@ -82,7 +82,7 @@ extension Atomic where Value == Bool {
   @available(SwiftStdlib 6.0, *)
   @discardableResult
   @_semantics("atomics.requires_constant_orderings")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public func logicalAnd(
     _ operand: Bool,
@@ -140,7 +140,7 @@ extension Atomic where Value == Bool {
   @available(SwiftStdlib 6.0, *)
   @discardableResult
   @_semantics("atomics.requires_constant_orderings")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public func logicalOr(
     _ operand: Bool,
@@ -198,7 +198,7 @@ extension Atomic where Value == Bool {
   @available(SwiftStdlib 6.0, *)
   @discardableResult
   @_semantics("atomics.requires_constant_orderings")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public func logicalXor(
     _ operand: Bool,

--- a/stdlib/public/Synchronization/Atomics/AtomicFloats.swift
+++ b/stdlib/public/Synchronization/Atomics/AtomicFloats.swift
@@ -34,7 +34,7 @@ extension Float16: AtomicRepresentable {
   ///   to encode an instance of its `AtomicRepresentation`.
   /// - Returns: The newly encoded `AtomicRepresentation` storage.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func encodeAtomicRepresentation(
     _ value: consuming Float16
@@ -53,7 +53,7 @@ extension Float16: AtomicRepresentable {
   ///   within atomic operations.
   /// - Returns: The newly decoded logical type `Self`.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func decodeAtomicRepresentation(
     _ representation: consuming AtomicRepresentation
@@ -86,7 +86,7 @@ extension Float: AtomicRepresentable {
   ///   to encode an instance of its `AtomicRepresentation`.
   /// - Returns: The newly encoded `AtomicRepresentation` storage.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func encodeAtomicRepresentation(
     _ value: consuming Float
@@ -105,7 +105,7 @@ extension Float: AtomicRepresentable {
   ///   within atomic operations.
   /// - Returns: The newly decoded logical type `Self`.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func decodeAtomicRepresentation(
     _ representation: consuming AtomicRepresentation
@@ -138,7 +138,7 @@ extension Double: AtomicRepresentable {
   ///   to encode an instance of its `AtomicRepresentation`.
   /// - Returns: The newly encoded `AtomicRepresentation` storage.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func encodeAtomicRepresentation(
     _ value: consuming Double
@@ -157,7 +157,7 @@ extension Double: AtomicRepresentable {
   ///   within atomic operations.
   /// - Returns: The newly decoded logical type `Self`.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func decodeAtomicRepresentation(
     _ representation: consuming AtomicRepresentation

--- a/stdlib/public/Synchronization/Atomics/AtomicIntegers.swift.gyb
+++ b/stdlib/public/Synchronization/Atomics/AtomicIntegers.swift.gyb
@@ -58,7 +58,7 @@ extension ${intType}: AtomicRepresentable {
   ///   to encode an instance of its `AtomicRepresentation`.
   /// - Returns: The newly encoded `AtomicRepresentation` storage.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func encodeAtomicRepresentation(
     _ value: borrowing ${intType}
@@ -77,7 +77,7 @@ extension ${intType}: AtomicRepresentable {
   ///   within atomic operations.
   /// - Returns: The newly decoded logical type `Self`.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func decodeAtomicRepresentation(
     _ representation: consuming AtomicRepresentation
@@ -108,7 +108,7 @@ extension Atomic where Value == ${intType} {
   @available(SwiftStdlib 6.0, *)
   @discardableResult
   @_semantics("atomics.requires_constant_orderings")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public func ${lowerFirst(name)}(
     _ operand: ${intType},
@@ -175,7 +175,7 @@ extension Atomic where Value == ${intType} {
   @available(SwiftStdlib 6.0, *)
   @discardableResult
   @_semantics("atomics.requires_constant_orderings")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public func add(
     _ operand: ${intType},
@@ -219,7 +219,7 @@ extension Atomic where Value == ${intType} {
   @available(SwiftStdlib 6.0, *)
   @discardableResult
   @_semantics("atomics.requires_constant_orderings")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public func subtract(
     _ operand: ${intType},

--- a/stdlib/public/Synchronization/Atomics/AtomicMemoryOrderings.swift
+++ b/stdlib/public/Synchronization/Atomics/AtomicMemoryOrderings.swift
@@ -42,7 +42,7 @@ extension AtomicLoadOrdering {
   /// This value corresponds to `std::memory_order_relaxed` in C++.
   @available(SwiftStdlib 6.0, *)
   @_semantics("constant_evaluable")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static var relaxed: Self {
     Self(_rawValue: 0)
@@ -56,7 +56,7 @@ extension AtomicLoadOrdering {
   /// This value corresponds to `std::memory_order_acquire` in C++.
   @available(SwiftStdlib 6.0, *)
   @_semantics("constant_evaluable")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static var acquiring: Self {
     Self(_rawValue: 2)
@@ -70,7 +70,7 @@ extension AtomicLoadOrdering {
   /// This value corresponds to `std::memory_order_seq_cst` in C++.
   @available(SwiftStdlib 6.0, *)
   @_semantics("constant_evaluable")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static var sequentiallyConsistent: Self {
     Self(_rawValue: 5)
@@ -139,7 +139,7 @@ extension AtomicStoreOrdering {
   /// This value corresponds to `std::memory_order_relaxed` in C++.
   @available(SwiftStdlib 6.0, *)
   @_semantics("constant_evaluable")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static var relaxed: Self {
     Self(_rawValue: 0)
@@ -153,7 +153,7 @@ extension AtomicStoreOrdering {
   /// This value corresponds to `std::memory_order_release` in C++.
   @available(SwiftStdlib 6.0, *)
   @_semantics("constant_evaluable")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static var releasing: Self {
     Self(_rawValue: 3)
@@ -167,7 +167,7 @@ extension AtomicStoreOrdering {
   /// This value corresponds to `std::memory_order_seq_cst` in C++.
   @available(SwiftStdlib 6.0, *)
   @_semantics("constant_evaluable")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static var sequentiallyConsistent: Self {
     Self(_rawValue: 5)
@@ -236,7 +236,7 @@ extension AtomicUpdateOrdering {
   /// This value corresponds to `std::memory_order_relaxed` in C++.
   @available(SwiftStdlib 6.0, *)
   @_semantics("constant_evaluable")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static var relaxed: Self {
     Self(_rawValue: 0)
@@ -250,7 +250,7 @@ extension AtomicUpdateOrdering {
   /// This value corresponds to `std::memory_order_acquire` in C++.
   @available(SwiftStdlib 6.0, *)
   @_semantics("constant_evaluable")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static var acquiring: Self {
     Self(_rawValue: 2)
@@ -264,7 +264,7 @@ extension AtomicUpdateOrdering {
   /// This value corresponds to `std::memory_order_release` in C++.
   @available(SwiftStdlib 6.0, *)
   @_semantics("constant_evaluable")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static var releasing: Self {
     Self(_rawValue: 3)
@@ -276,7 +276,7 @@ extension AtomicUpdateOrdering {
   /// This value corresponds to `std::memory_order_acq_rel` in C++.
   @available(SwiftStdlib 6.0, *)
   @_semantics("constant_evaluable")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static var acquiringAndReleasing: Self {
     Self(_rawValue: 4)
@@ -291,7 +291,7 @@ extension AtomicUpdateOrdering {
   /// This value corresponds to `std::memory_order_seq_cst` in C++.
   @available(SwiftStdlib 6.0, *)
   @_semantics("constant_evaluable")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static var sequentiallyConsistent: Self {
     Self(_rawValue: 5)
@@ -337,7 +337,7 @@ extension AtomicLoadOrdering {
   @available(SwiftStdlib 6.0, *)
   @_semantics("constant_evaluable")
   @_semantics("atomics.requires_constant_orderings")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   static func _failureOrdering(
     for ordering: AtomicUpdateOrdering
@@ -380,7 +380,7 @@ extension AtomicLoadOrdering {
 /// false-positive races for data protected by a fence.
 @available(SwiftStdlib 6.0, *)
 @_semantics("atomics.requires_constant_orderings")
-@_alwaysEmitIntoClient
+@export(implementation)
 @_transparent
 public func atomicMemoryFence(
   ordering: AtomicUpdateOrdering

--- a/stdlib/public/Synchronization/Atomics/AtomicOptional.swift
+++ b/stdlib/public/Synchronization/Atomics/AtomicOptional.swift
@@ -77,7 +77,7 @@ where
   ///   destroyed to encode an instance of its `AtomicOptionalRepresentation`.
   /// - Returns: The newly encoded `AtomicOptionalRepresentation` storage.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func encodeAtomicOptionalRepresentation(
     _ value: consuming Self?
@@ -105,7 +105,7 @@ where
   ///   that's used within atomic operations on `Optional`.
   /// - Returns: The newly decoded logical type `Self?`.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func decodeAtomicOptionalRepresentation(
     _ representation: consuming RawValue.AtomicOptionalRepresentation
@@ -138,7 +138,7 @@ extension Optional: AtomicRepresentable where Wrapped: AtomicOptionalRepresentab
   ///   to encode an instance of its `AtomicRepresentation`.
   /// - Returns: The newly encoded `AtomicRepresentation` storage.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func encodeAtomicRepresentation(
     _ value: consuming Wrapped?
@@ -157,7 +157,7 @@ extension Optional: AtomicRepresentable where Wrapped: AtomicOptionalRepresentab
   ///   within atomic operations.
   /// - Returns: The newly decoded logical type `Self`.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func decodeAtomicRepresentation(
     _ representation: consuming AtomicRepresentation

--- a/stdlib/public/Synchronization/Atomics/AtomicPointers.swift
+++ b/stdlib/public/Synchronization/Atomics/AtomicPointers.swift
@@ -32,7 +32,7 @@ extension UnsafePointer: @unsafe AtomicRepresentable where Pointee: ~Copyable {
   ///   to encode an instance of its `AtomicRepresentation`.
   /// - Returns: The newly encoded `AtomicRepresentation` storage.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func encodeAtomicRepresentation(
     _ value: consuming UnsafePointer<Pointee>
@@ -53,7 +53,7 @@ extension UnsafePointer: @unsafe AtomicRepresentable where Pointee: ~Copyable {
   ///   within atomic operations.
   /// - Returns: The newly decoded logical type `Self`.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func decodeAtomicRepresentation(
     _ representation: consuming AtomicRepresentation
@@ -83,7 +83,7 @@ extension UnsafePointer: @unsafe AtomicOptionalRepresentable where Pointee: ~Cop
   ///   destroyed to encode an instance of its `AtomicOptionalRepresentation`.
   /// - Returns: The newly encoded `AtomicOptionalRepresentation` storage.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func encodeAtomicOptionalRepresentation(
     _ value: consuming UnsafePointer<Pointee>?
@@ -105,7 +105,7 @@ extension UnsafePointer: @unsafe AtomicOptionalRepresentable where Pointee: ~Cop
   ///   that's used within atomic operations on `Optional`.
   /// - Returns: The newly decoded logical type `Self?`.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func decodeAtomicOptionalRepresentation(
     _ representation: consuming AtomicOptionalRepresentation
@@ -138,7 +138,7 @@ extension UnsafeMutablePointer: @unsafe AtomicRepresentable where Pointee: ~Copy
   ///   to encode an instance of its `AtomicRepresentation`.
   /// - Returns: The newly encoded `AtomicRepresentation` storage.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func encodeAtomicRepresentation(
     _ value: consuming UnsafeMutablePointer<Pointee>
@@ -159,7 +159,7 @@ extension UnsafeMutablePointer: @unsafe AtomicRepresentable where Pointee: ~Copy
   ///   within atomic operations.
   /// - Returns: The newly decoded logical type `Self`.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func decodeAtomicRepresentation(
     _ representation: consuming AtomicRepresentation
@@ -190,7 +190,7 @@ where Pointee: ~Copyable {
   ///   destroyed to encode an instance of its `AtomicOptionalRepresentation`.
   /// - Returns: The newly encoded `AtomicOptionalRepresentation` storage.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func encodeAtomicOptionalRepresentation(
     _ value: consuming UnsafeMutablePointer<Pointee>?
@@ -212,7 +212,7 @@ where Pointee: ~Copyable {
   ///   that's used within atomic operations on `Optional`.
   /// - Returns: The newly decoded logical type `Self?`.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func decodeAtomicOptionalRepresentation(
     _ representation: consuming AtomicOptionalRepresentation
@@ -245,7 +245,7 @@ extension UnsafeRawPointer: @unsafe AtomicRepresentable {
   ///   to encode an instance of its `AtomicRepresentation`.
   /// - Returns: The newly encoded `AtomicRepresentation` storage.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func encodeAtomicRepresentation(
     _ value: consuming UnsafeRawPointer
@@ -266,7 +266,7 @@ extension UnsafeRawPointer: @unsafe AtomicRepresentable {
   ///   within atomic operations.
   /// - Returns: The newly decoded logical type `Self`.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func decodeAtomicRepresentation(
     _ representation: consuming AtomicRepresentation
@@ -296,7 +296,7 @@ extension UnsafeRawPointer: @unsafe AtomicOptionalRepresentable {
   ///   destroyed to encode an instance of its `AtomicOptionalRepresentation`.
   /// - Returns: The newly encoded `AtomicOptionalRepresentation` storage.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func encodeAtomicOptionalRepresentation(
     _ value: consuming UnsafeRawPointer?
@@ -318,7 +318,7 @@ extension UnsafeRawPointer: @unsafe AtomicOptionalRepresentable {
   ///   that's used within atomic operations on `Optional`.
   /// - Returns: The newly decoded logical type `Self?`.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func decodeAtomicOptionalRepresentation(
     _ representation: consuming AtomicOptionalRepresentation
@@ -351,7 +351,7 @@ extension UnsafeMutableRawPointer: @unsafe AtomicRepresentable {
   ///   to encode an instance of its `AtomicRepresentation`.
   /// - Returns: The newly encoded `AtomicRepresentation` storage.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func encodeAtomicRepresentation(
     _ value: consuming UnsafeMutableRawPointer
@@ -372,7 +372,7 @@ extension UnsafeMutableRawPointer: @unsafe AtomicRepresentable {
   ///   within atomic operations.
   /// - Returns: The newly decoded logical type `Self`.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func decodeAtomicRepresentation(
     _ representation: consuming AtomicRepresentation
@@ -402,7 +402,7 @@ extension UnsafeMutableRawPointer: @unsafe AtomicOptionalRepresentable {
   ///   destroyed to encode an instance of its `AtomicOptionalRepresentation`.
   /// - Returns: The newly encoded `AtomicOptionalRepresentation` storage.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func encodeAtomicOptionalRepresentation(
     _ value: consuming UnsafeMutableRawPointer?
@@ -424,7 +424,7 @@ extension UnsafeMutableRawPointer: @unsafe AtomicOptionalRepresentable {
   ///   that's used within atomic operations on `Optional`.
   /// - Returns: The newly decoded logical type `Self?`.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func decodeAtomicOptionalRepresentation(
     _ representation: consuming AtomicOptionalRepresentation
@@ -457,7 +457,7 @@ extension Unmanaged: @unsafe AtomicRepresentable {
   ///   to encode an instance of its `AtomicRepresentation`.
   /// - Returns: The newly encoded `AtomicRepresentation` storage.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func encodeAtomicRepresentation(
     _ value: consuming Unmanaged<Instance>
@@ -478,7 +478,7 @@ extension Unmanaged: @unsafe AtomicRepresentable {
   ///   within atomic operations.
   /// - Returns: The newly decoded logical type `Self`.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func decodeAtomicRepresentation(
     _ representation: consuming AtomicRepresentation
@@ -508,7 +508,7 @@ extension Unmanaged: @unsafe AtomicOptionalRepresentable {
   ///   destroyed to encode an instance of its `AtomicOptionalRepresentation`.
   /// - Returns: The newly encoded `AtomicOptionalRepresentation` storage.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func encodeAtomicOptionalRepresentation(
     _ value: consuming Unmanaged<Instance>?
@@ -538,7 +538,7 @@ extension Unmanaged: @unsafe AtomicOptionalRepresentable {
   ///   that's used within atomic operations on `Optional`.
   /// - Returns: The newly decoded logical type `Self?`.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func decodeAtomicOptionalRepresentation(
     _ representation: consuming AtomicOptionalRepresentation
@@ -571,7 +571,7 @@ extension OpaquePointer: @unsafe AtomicRepresentable {
   ///   to encode an instance of its `AtomicRepresentation`.
   /// - Returns: The newly encoded `AtomicRepresentation` storage.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func encodeAtomicRepresentation(
     _ value: consuming OpaquePointer
@@ -592,7 +592,7 @@ extension OpaquePointer: @unsafe AtomicRepresentable {
   ///   within atomic operations.
   /// - Returns: The newly decoded logical type `Self`.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func decodeAtomicRepresentation(
     _ representation: consuming AtomicRepresentation
@@ -622,7 +622,7 @@ extension OpaquePointer: @unsafe AtomicOptionalRepresentable {
   ///   destroyed to encode an instance of its `AtomicOptionalRepresentation`.
   /// - Returns: The newly encoded `AtomicOptionalRepresentation` storage.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func encodeAtomicOptionalRepresentation(
     _ value: consuming OpaquePointer?
@@ -644,7 +644,7 @@ extension OpaquePointer: @unsafe AtomicOptionalRepresentable {
   ///   that's used within atomic operations on `Optional`.
   /// - Returns: The newly decoded logical type `Self?`.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func decodeAtomicOptionalRepresentation(
     _ representation: consuming AtomicOptionalRepresentation
@@ -677,7 +677,7 @@ extension ObjectIdentifier: AtomicRepresentable {
   ///   to encode an instance of its `AtomicRepresentation`.
   /// - Returns: The newly encoded `AtomicRepresentation` storage.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func encodeAtomicRepresentation(
     _ value: consuming ObjectIdentifier
@@ -698,7 +698,7 @@ extension ObjectIdentifier: AtomicRepresentable {
   ///   within atomic operations.
   /// - Returns: The newly decoded logical type `Self`.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func decodeAtomicRepresentation(
     _ representation: consuming AtomicRepresentation
@@ -730,7 +730,7 @@ extension ObjectIdentifier: AtomicOptionalRepresentable {
   ///   destroyed to encode an instance of its `AtomicOptionalRepresentation`.
   /// - Returns: The newly encoded `AtomicOptionalRepresentation` storage.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func encodeAtomicOptionalRepresentation(
     _ value: consuming ObjectIdentifier?
@@ -754,7 +754,7 @@ extension ObjectIdentifier: AtomicOptionalRepresentable {
   ///   that's used within atomic operations on `Optional`.
   /// - Returns: The newly decoded logical type `Self?`.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func decodeAtomicOptionalRepresentation(
     _ representation: consuming AtomicOptionalRepresentation
@@ -791,7 +791,7 @@ extension UnsafeBufferPointer: @unsafe AtomicRepresentable where Element: ~Copya
   ///   to encode an instance of its `AtomicRepresentation`.
   /// - Returns: The newly encoded `AtomicRepresentation` storage.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func encodeAtomicRepresentation(
     _ value: consuming UnsafeBufferPointer<Element>
@@ -817,7 +817,7 @@ extension UnsafeBufferPointer: @unsafe AtomicRepresentable where Element: ~Copya
   ///   within atomic operations.
   /// - Returns: The newly decoded logical type `Self`.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func decodeAtomicRepresentation(
     _ representation: consuming AtomicRepresentation
@@ -859,7 +859,7 @@ where Element: ~Copyable
   ///   to encode an instance of its `AtomicRepresentation`.
   /// - Returns: The newly encoded `AtomicRepresentation` storage.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func encodeAtomicRepresentation(
     _ value: consuming UnsafeMutableBufferPointer<Element>
@@ -885,7 +885,7 @@ where Element: ~Copyable
   ///   within atomic operations.
   /// - Returns: The newly decoded logical type `Self`.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func decodeAtomicRepresentation(
     _ representation: consuming AtomicRepresentation
@@ -925,7 +925,7 @@ extension UnsafeRawBufferPointer: @unsafe AtomicRepresentable {
   ///   to encode an instance of its `AtomicRepresentation`.
   /// - Returns: The newly encoded `AtomicRepresentation` storage.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func encodeAtomicRepresentation(
     _ value: consuming UnsafeRawBufferPointer
@@ -951,7 +951,7 @@ extension UnsafeRawBufferPointer: @unsafe AtomicRepresentable {
   ///   within atomic operations.
   /// - Returns: The newly decoded logical type `Self`.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func decodeAtomicRepresentation(
     _ representation: consuming AtomicRepresentation
@@ -991,7 +991,7 @@ extension UnsafeMutableRawBufferPointer: @unsafe AtomicRepresentable {
   ///   to encode an instance of its `AtomicRepresentation`.
   /// - Returns: The newly encoded `AtomicRepresentation` storage.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func encodeAtomicRepresentation(
     _ value: consuming UnsafeMutableRawBufferPointer
@@ -1017,7 +1017,7 @@ extension UnsafeMutableRawBufferPointer: @unsafe AtomicRepresentable {
   ///   within atomic operations.
   /// - Returns: The newly decoded logical type `Self`.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func decodeAtomicRepresentation(
     _ representation: consuming AtomicRepresentation

--- a/stdlib/public/Synchronization/Atomics/AtomicRepresentable.swift
+++ b/stdlib/public/Synchronization/Atomics/AtomicRepresentable.swift
@@ -221,7 +221,7 @@ where
   ///   to encode an instance of its `AtomicRepresentation`.
   /// - Returns: The newly encoded `AtomicRepresentation` storage.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func encodeAtomicRepresentation(
     _ value: consuming Self
@@ -241,7 +241,7 @@ where
   ///   within atomic operations.
   /// - Returns: The newly decoded logical type `Self`.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func decodeAtomicRepresentation(
     _ representation: consuming RawValue.AtomicRepresentation
@@ -273,7 +273,7 @@ extension Never: AtomicRepresentable {
   ///   to encode an instance of its `AtomicRepresentation`.
   /// - Returns: The newly encoded `AtomicRepresentation` storage.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func encodeAtomicRepresentation(
     _ value: consuming Never
@@ -291,7 +291,7 @@ extension Never: AtomicRepresentable {
   ///   within atomic operations.
   /// - Returns: The newly decoded logical type `Self`.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func decodeAtomicRepresentation(
     _ representation: consuming Never
@@ -323,7 +323,7 @@ extension Duration: AtomicRepresentable {
   ///   to encode an instance of its `AtomicRepresentation`.
   /// - Returns: The newly encoded `AtomicRepresentation` storage.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func encodeAtomicRepresentation(
     _ value: consuming Duration
@@ -348,7 +348,7 @@ extension Duration: AtomicRepresentable {
   ///   within atomic operations.
   /// - Returns: The newly decoded logical type `Self`.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func decodeAtomicRepresentation(
     _ representation: consuming AtomicRepresentation

--- a/stdlib/public/Synchronization/Atomics/AtomicStorage.swift.gyb
+++ b/stdlib/public/Synchronization/Atomics/AtomicStorage.swift.gyb
@@ -27,7 +27,7 @@ public struct ${type} {
   public var _storage: ${builtin}
 
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public init(_ _builtin: ${builtin}) {
     self._storage = _builtin
@@ -47,7 +47,7 @@ extension Atomic where Value.AtomicRepresentation == ${type} {
   /// - Returns: The current value.
   @available(SwiftStdlib 6.0, *)
   @_semantics("atomics.requires_constant_orderings")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public func load(ordering: AtomicLoadOrdering) -> Value {
     let result = switch ordering {
@@ -77,7 +77,7 @@ extension Atomic where Value.AtomicRepresentation == ${type} {
   /// - Parameter ordering: The memory ordering to apply on this operation.
   @available(SwiftStdlib 6.0, *)
   @_semantics("atomics.requires_constant_orderings")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public func store(
     _ desired: consuming Value,
@@ -112,7 +112,7 @@ extension Atomic where Value.AtomicRepresentation == ${type} {
   /// - Returns: The original value.
   @available(SwiftStdlib 6.0, *)
   @_semantics("atomics.requires_constant_orderings")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public func exchange(
     _ desired: consuming Value,
@@ -165,7 +165,7 @@ extension Atomic where Value.AtomicRepresentation == ${type} {
   ///   the exchange was successful, and `original` is the original value.
   @available(SwiftStdlib 6.0, *)
   @_semantics("atomics.requires_constant_orderings")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public func compareExchange(
     expected: consuming Value,
@@ -213,7 +213,7 @@ extension Atomic where Value.AtomicRepresentation == ${type} {
   ///   the exchange was successful, and `original` is the original value.
   @available(SwiftStdlib 6.0, *)
   @_semantics("atomics.requires_constant_orderings")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public func compareExchange(
     expected: consuming Value,
@@ -285,7 +285,7 @@ extension Atomic where Value.AtomicRepresentation == ${type} {
   ///   the exchange was successful, and `original` is the original value.
   @available(SwiftStdlib 6.0, *)
   @_semantics("atomics.requires_constant_orderings")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public func weakCompareExchange(
     expected: consuming Value,
@@ -343,7 +343,7 @@ extension Atomic where Value.AtomicRepresentation == ${type} {
   ///   the exchange was successful, and `original` is the original value.
   @available(SwiftStdlib 6.0, *)
   @_semantics("atomics.requires_constant_orderings")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public func weakCompareExchange(
     expected: consuming Value,

--- a/stdlib/public/Synchronization/Atomics/WordPair.swift
+++ b/stdlib/public/Synchronization/Atomics/WordPair.swift
@@ -54,7 +54,7 @@ public struct WordPair {
   /// - Parameter first: The first word to use in the pair.
   /// - Parameter second: The second word to use in the pair.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public init(first: UInt, second: UInt) {
     self.first = first
@@ -89,7 +89,7 @@ extension WordPair: AtomicRepresentable {
   ///   to encode an instance of its `AtomicRepresentation`.
   /// - Returns: The newly encoded `AtomicRepresentation` storage.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func encodeAtomicRepresentation(
     _ value: consuming WordPair
@@ -126,7 +126,7 @@ extension WordPair: AtomicRepresentable {
   ///   within atomic operations.
   /// - Returns: The newly decoded logical type `Self`.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func decodeAtomicRepresentation(
     _ representation: consuming AtomicRepresentation
@@ -160,7 +160,7 @@ extension WordPair: Equatable {
   /// - Parameter rhs: The second value to compare.
   /// - Returns: True if both values were equal, or false if they were unequal.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func ==(lhs: WordPair, rhs: WordPair) -> Bool {
     lhs.first == rhs.first && lhs.second == rhs.second
@@ -175,7 +175,7 @@ extension WordPair: Hashable {
   /// - Parameter hasher: The hasher to use when combining the components
   ///   of this instance.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public func hash(into hasher: inout Hasher) {
     hasher.combine(first)
@@ -186,7 +186,7 @@ extension WordPair: Hashable {
 @available(SwiftStdlib 6.1, *)
 extension WordPair: Comparable {
   @available(SwiftStdlib 6.1, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public static func <(lhs: WordPair, rhs: WordPair) -> Bool {
     (lhs.first, lhs.second) < (rhs.first, rhs.second)

--- a/stdlib/public/Synchronization/Cell.swift
+++ b/stdlib/public/Synchronization/Cell.swift
@@ -17,29 +17,28 @@ import Builtin
 @_rawLayout(like: Value, movesAsLike)
 public struct _Cell<Value: ~Copyable>: ~Copyable {
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public var _address: UnsafeMutablePointer<Value> {
     unsafe UnsafeMutablePointer<Value>(_rawAddress)
   }
 
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal var _rawAddress: Builtin.RawPointer {
     Builtin.addressOfRawLayout(self)
   }
 
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public init(_ initialValue: consuming Value) {
     unsafe _address.initialize(to: initialValue)
   }
 
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
-  @inlinable
+  @export(implementation)
   deinit {
     unsafe _address.deinitialize(count: 1)
   }

--- a/stdlib/public/Synchronization/Mutex/DarwinImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/DarwinImpl.swift
@@ -20,28 +20,28 @@ public struct _MutexHandle: ~Copyable {
   let value: _Cell<os_unfair_lock>
 
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public init() {
     value = _Cell(os_unfair_lock())
   }
 
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal borrowing func _lock() {
     unsafe os_unfair_lock_lock(value._address)
   }
 
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal borrowing func _tryLock() -> Bool {
     unsafe os_unfair_lock_trylock(value._address)
   }
 
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal borrowing func _unlock() {
     unsafe os_unfair_lock_unlock(value._address)

--- a/stdlib/public/Synchronization/Mutex/FreeBSDImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/FreeBSDImpl.swift
@@ -20,28 +20,28 @@ public struct _MutexHandle: ~Copyable {
   let value: _Cell<umutex>
 
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public init() {
     value = _Cell(umutex())
   }
 
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal borrowing func _lock() {
     unsafe _umtx_op(value._address, UMTX_OP_MUTEX_LOCK, 0, nil, nil)
   }
 
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal borrowing func _tryLock() -> Bool {
     unsafe _umtx_op(value._address, UMTX_OP_MUTEX_TRYLOCK, 0, nil, nil) != -1
   }
 
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal borrowing func _unlock() {
     unsafe _umtx_op(value._address, UMTX_OP_MUTEX_UNLOCK, 0, nil, nil)

--- a/stdlib/public/Synchronization/Mutex/LinuxImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/LinuxImpl.swift
@@ -70,7 +70,7 @@ public struct _MutexHandle: ~Copyable {
   let slowPathDepth: Atomic<UInt32>
 
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public init() {
     storage = Atomic(0)
@@ -93,7 +93,7 @@ private var maxActiveSpinners: UInt32 { 4 }
 @available(SwiftStdlib 6.0, *)
 extension _MutexHandle {
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal borrowing func _lock() {
     let (exchanged, _) = storage.compareExchange(
@@ -229,7 +229,7 @@ extension _MutexHandle {
   }
 
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal borrowing func _tryLock() -> Bool {
     // Do a user space cmpxchg to see if we can easily acquire the lock.
@@ -242,7 +242,7 @@ extension _MutexHandle {
   }
 
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal borrowing func _unlock() {
     // Release the lock atomically in userspace. Previous value tells us whether anyone is parked.

--- a/stdlib/public/Synchronization/Mutex/Mutex.swift
+++ b/stdlib/public/Synchronization/Mutex/Mutex.swift
@@ -45,7 +45,7 @@ public struct Mutex<Value: ~Copyable>: ~Copyable {
   ///
   /// - Parameter initialValue: The initial value to give to the mutex.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public init(_ initialValue: consuming sending Value) {
     value = _Cell(initialValue)
@@ -82,7 +82,7 @@ extension Mutex where Value: ~Copyable {
   ///
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public borrowing func withLock<Result: ~Copyable, E: Error>(
     _ body: (inout sending Value) throws(E) -> sending Result
@@ -128,7 +128,7 @@ extension Mutex where Value: ~Copyable {
   ///   `mtx_trylock()`) is platform-dependent and may differ from Swift's
   ///   behavior.
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public borrowing func withLockIfAvailable<Result: ~Copyable, E: Error>(
     _ body: (inout sending Value) throws(E) -> sending Result
@@ -148,21 +148,21 @@ extension Mutex where Value: ~Copyable {
 @available(SwiftStdlib 6.0, *)
 extension Mutex where Value == Void {
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public borrowing func _unsafeLock() {
     handle._lock()
   }
 
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public borrowing func _unsafeTryLock() -> Bool {
     handle._tryLock()
   }
 
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public borrowing func _unsafeUnlock() {
     handle._unlock()
@@ -172,7 +172,7 @@ extension Mutex where Value == Void {
 @available(SwiftStdlib 6.0, *)
 extension _MutexHandle {
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   @unsafe
   public borrowing func unsafeLock() {
@@ -180,7 +180,7 @@ extension _MutexHandle {
   }
 
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   @unsafe
   public borrowing func unsafeTryLock() -> Bool {
@@ -188,7 +188,7 @@ extension _MutexHandle {
   }
 
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   @unsafe
   public borrowing func unsafeUnlock() {

--- a/stdlib/public/Synchronization/Mutex/OpenBSDImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/OpenBSDImpl.swift
@@ -32,7 +32,7 @@ public struct _MutexHandle: ~Copyable {
   let value: _Cell<pthread_mutex_t?>
 
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public init() {
     var mx = unsafe pthread_mutex_t(bitPattern: 0)
@@ -44,7 +44,7 @@ public struct _MutexHandle: ~Copyable {
   }
 
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal borrowing func _lock() {
     let r = unsafe pthread_mutex_lock(value._address)
@@ -54,14 +54,14 @@ public struct _MutexHandle: ~Copyable {
   }
 
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal borrowing func _tryLock() -> Bool {
     unsafe pthread_mutex_trylock(value._address) == 0
   }
 
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal borrowing func _unlock() {
     let r = unsafe pthread_mutex_unlock(value._address)
@@ -71,7 +71,7 @@ public struct _MutexHandle: ~Copyable {
   }
 
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   deinit {
     let r = unsafe pthread_mutex_destroy(value._address)

--- a/stdlib/public/Synchronization/Mutex/WasmImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/WasmImpl.swift
@@ -82,7 +82,7 @@ public struct _MutexHandle: ~Copyable {
   let storage: Atomic<State>
 
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public init() {
     storage = Atomic(.unlocked)

--- a/stdlib/public/Synchronization/Mutex/WindowsImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/WindowsImpl.swift
@@ -21,21 +21,21 @@ public struct _MutexHandle: ~Copyable {
   let value: _Cell<SRWLOCK>
 
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public init() {
     unsafe value = _Cell(SRWLOCK())
   }
 
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal borrowing func _lock() {
     unsafe AcquireSRWLockExclusive(value._address)
   }
 
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal borrowing func _tryLock() -> Bool {
     // Windows BOOLEAN gets imported as 'UInt8'...
@@ -43,7 +43,7 @@ public struct _MutexHandle: ~Copyable {
   }
 
   @available(SwiftStdlib 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal borrowing func _unlock() {
     unsafe ReleaseSRWLockExclusive(value._address)

--- a/stdlib/public/core/ASCII.swift
+++ b/stdlib/public/core/ASCII.swift
@@ -24,7 +24,7 @@ extension Unicode.ASCII: Unicode.Encoding {
   }
 
   /// Returns whether the given code unit represents an ASCII scalar
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func isASCII(_ x: CodeUnit) -> Bool { return UTF8.isASCII(x) }
 
   @inline(__always)

--- a/stdlib/public/core/AnyHashable.swift
+++ b/stdlib/public/core/AnyHashable.swift
@@ -290,7 +290,7 @@ extension AnyHashable: _HasCustomAnyHashableRepresentation {
 
 @_unavailableInEmbedded
 extension AnyHashable {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public __consuming func _toCustomAnyHashable() -> AnyHashable? {
     return self
   }

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -356,7 +356,7 @@ extension Array {
   }
 
 #if INTERNAL_CHECKS_ENABLED && COW_CHECKS_ENABLED
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_semantics("array.make_mutable")
   @_effects(notEscaping self.**)
   internal mutating func _makeMutableAndUniqueUnchecked() {
@@ -370,7 +370,7 @@ extension Array {
   ///
   /// After a call to `_endMutation` the buffer must not be mutated until a call
   /// to `_makeMutableAndUnique`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_semantics("array.end_mutation")
   @_effects(notEscaping self.**)
   internal mutating func _endMutation() {
@@ -415,7 +415,7 @@ extension Array {
   /// `0 ≤ index < count`.
   ///
   /// - Precondition: The buffer must be uniquely referenced and native.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_semantics("array.check_subscript")
   @_effects(notEscaping self.**)
   internal func _checkSubscript_mutating(_ index: Int) {
@@ -1089,7 +1089,7 @@ extension Array: RangeReplaceableCollection {
   /// If a new buffer needs to be allocated and `growForAppend` is true,
   /// the new capacity is calculated using `_growArrayCapacity`, but at least
   /// kept at `minimumCapacity`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func _reserveCapacityImpl(
     minimumCapacity: Int, growForAppend: Bool
   ) {
@@ -1112,7 +1112,7 @@ extension Array: RangeReplaceableCollection {
   /// The `minimumCapacity` is the lower bound for the new capacity.
   /// If `growForAppend` is true, the new capacity is calculated using
   /// `_growArrayCapacity`, but at least kept at `minimumCapacity`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func _createNewBuffer(
     bufferIsUnique: Bool, minimumCapacity: Int, growForAppend: Bool
   ) {
@@ -1535,7 +1535,7 @@ extension Array {
   /// Implementation for:
   /// Array(unsafeUninitializedCapacity:initializingWith:)
   /// and ContiguousArray(unsafeUninitializedCapacity:initializingWith:)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal init<E: Error>(
     _unsafeUninitializedCapacity: Int,
     initializingWithTypedThrowsInitializer initializer: (
@@ -1592,7 +1592,7 @@ extension Array {
   ///       - initializedCount: The count of initialized elements in the array,
   ///         which begins as zero. Set `initializedCount` to the number of
   ///         elements you initialize.
-  @_alwaysEmitIntoClient @inlinable
+  @export(implementation)
   public init<E: Error>(
     unsafeUninitializedCapacity: Int,
     initializingWith initializer: (
@@ -1631,7 +1631,7 @@ extension Array {
   ///     - Parameters:
   ///       - span: An `OutputSpan` covering uninitialized memory with
   ///         space for the specified number of elements.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init<E: Error>(
     capacity: Int,
     initializingWith initializer: (
@@ -1662,7 +1662,7 @@ extension Array {
   ///     - Parameters:
   ///       - span: An `OutputSpan` covering uninitialized memory with
   ///         space for the specified number of additional elements.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func append<E: Error>(
     addingCapacity uninitializedCount: Int,
     initializingWith initializer: (
@@ -1737,7 +1737,7 @@ extension Array {
   ///   for the `withUnsafeBufferPointer(_:)` method. The pointer argument is
   ///   valid only for the duration of the method's execution.
   /// - Returns: The return value, if any, of the `body` closure parameter.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @safe
   public func withUnsafeBufferPointer<R, E>(
     _ body: (UnsafeBufferPointer<Element>) throws(E) -> R
@@ -1757,7 +1757,7 @@ extension Array {
   @available(SwiftStdlib 6.2, *)
   public var span: Span<Element> {
     @_lifetime(borrow self)
-    @_alwaysEmitIntoClient
+    @export(implementation)
     borrowing get {
 #if _runtime(_ObjC)
       if _slowPath(!_buffer._isNative) {
@@ -1844,7 +1844,7 @@ extension Array {
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @_semantics("array.withUnsafeMutableBufferPointer")
   @_effects(notEscaping self.value**)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always) // Performance: This method should get inlined into the
   // caller such that we can combine the partial apply with the apply in this
   // function saving on allocating a closure context. This becomes unnecessary
@@ -1881,7 +1881,7 @@ extension Array {
   /// - Complexity: O(1) when the array's storage is uniquely referenced,
   ///   O(*n*) otherwise.
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var mutableSpan: MutableSpan<Element> {
     @_lifetime(&self)
     mutating get {
@@ -2139,7 +2139,7 @@ extension Array {
   // This allows us to test the `_copyContents` implementation in
   // `_ArrayBuffer`. (It's like `_copyToContiguousArray` but it always makes a
   // copy.)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func _copyToNewArray() -> [Element] {
     unsafe Array(unsafeUninitializedCapacity: self.count) { buffer, count in
       var (it, c) = unsafe self._buffer._copyContents(initializing: buffer)
@@ -2311,7 +2311,7 @@ extension Array {
   /// but not all equal arrays are identical.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func isTriviallyIdentical(to other: Self) -> Bool {
     unsafe self._buffer.identity == other._buffer.identity
   }

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -118,7 +118,7 @@ extension _ArrayBuffer {
   ///
   /// - Warning: It's a requirement to call `beginCOWMutation` before the buffer
   ///   is mutated.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func beginCOWMutation() -> Bool {
     let isUnique: Bool
     if !_isClassOrObjCExistential(Element.self) {
@@ -137,7 +137,7 @@ extension _ArrayBuffer {
   }
 
 #if INTERNAL_CHECKS_ENABLED && COW_CHECKS_ENABLED
-   @_alwaysEmitIntoClient
+   @export(implementation)
   internal mutating func beginCOWMutationUnchecked() -> Bool {
     let isUnique: Bool
     if !_isClassOrObjCExistential(Element.self) {
@@ -157,7 +157,7 @@ extension _ArrayBuffer {
   ///
   /// - Warning: After a call to `endCOWMutation` the buffer must not be mutated
   ///   until the next call of `beginCOWMutation`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   internal mutating func endCOWMutation() {
 #if INTERNAL_CHECKS_ENABLED && COW_CHECKS_ENABLED
@@ -178,7 +178,7 @@ extension _ArrayBuffer {
   /// this buffer.
   ///
   /// This buffer is consumed, i.e. it's released.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(never)
   @_semantics("optimize.sil.specialize.owned2guarantee.never")
   internal __consuming func _consumeAndCreateNew() -> _ArrayBuffer {
@@ -198,7 +198,7 @@ extension _ArrayBuffer {
   /// `_growArrayCapacity`, but at least kept at `minimumCapacity`.
   ///
   /// This buffer is consumed, i.e. it's released.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(never)
   @_semantics("optimize.sil.specialize.owned2guarantee.never")
   internal __consuming func _consumeAndCreateNew(
@@ -376,7 +376,7 @@ extension _ArrayBuffer {
   /// A mutable pointer to the first element.
   ///
   /// - Precondition: the buffer must be mutable.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal var mutableFirstElementAddress: UnsafeMutablePointer<Element> {
     _internalInvariant(_isNative, "must be a native buffer")
     return unsafe _native.mutableFirstElementAddress
@@ -407,7 +407,7 @@ extension _ArrayBuffer {
   /// The number of elements of the buffer.
   ///
   /// - Precondition: The buffer must be immutable.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal var immutableCount: Int {
     return _fastPath(_isNative) ? _native.immutableCount : _nonNative.endIndex
   }
@@ -415,7 +415,7 @@ extension _ArrayBuffer {
   /// The number of elements of the buffer.
   ///
   /// - Precondition: The buffer must be mutable.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal var mutableCount: Int {
     @inline(__always)
     get {
@@ -477,7 +477,7 @@ extension _ArrayBuffer {
   /// `0 ≤ index < count`.
   ///
   /// - Precondition: The buffer must be mutable.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func _checkValidSubscriptMutating(_ index: Int) {
     _native._checkValidSubscriptMutating(index)
   }
@@ -495,7 +495,7 @@ extension _ArrayBuffer {
   /// The number of elements the buffer can store without reallocation.
   ///
   /// - Precondition: The buffer must be immutable.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal var immutableCapacity: Int {
     return _fastPath(_isNative) ? _native.immutableCapacity : _nonNative.count
   }
@@ -503,7 +503,7 @@ extension _ArrayBuffer {
   /// The number of elements the buffer can store without reallocation.
   ///
   /// - Precondition: The buffer must be mutable.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal var mutableCapacity: Int {
     _internalInvariant(_isNative, "attempting to get mutating-capacity of non-native buffer")
     return _native.mutableCapacity
@@ -582,13 +582,13 @@ extension _ArrayBuffer {
     }
   }
 
-  @inlinable @_alwaysEmitIntoClient
+  @export(implementation)
   static var associationKey: UnsafeRawPointer {
     //We never dereference this, we just need an address to use as a unique key
     unsafe UnsafeRawPointer(Builtin.addressof(&_swiftEmptyArrayStorage))
   }
   
-  @inlinable @_alwaysEmitIntoClient
+  @export(implementation)
   internal func getAssociatedBuffer() -> _ContiguousArrayBuffer<Element>? {
     let getter = unsafe unsafeBitCast(
       getGetAssociatedObjectPtr(),
@@ -608,7 +608,7 @@ extension _ArrayBuffer {
     return nil
   }
   
-  @inlinable @_alwaysEmitIntoClient
+  @export(implementation)
   internal func setAssociatedBuffer(_ buffer: _ContiguousArrayBuffer<Element>) {
     let setter = unsafe unsafeBitCast(getSetAssociatedObjectPtr(), to: (@convention(c)(
       AnyObject,
@@ -624,7 +624,7 @@ extension _ArrayBuffer {
     )
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func getOrAllocateAssociatedObjectBuffer(
   ) -> _ContiguousArrayBuffer<Element> {
     let unwrapped: _ContiguousArrayBuffer<Element>
@@ -650,7 +650,7 @@ extension _ArrayBuffer {
     return unwrapped
   }
 
-  @_alwaysEmitIntoClient @inline(never)
+  @export(implementation) @inline(never)
   @safe
   internal func withUnsafeBufferPointer_nonNative<R, E>(
     _ body: (UnsafeBufferPointer<Element>) throws(E) -> R
@@ -681,7 +681,7 @@ extension _ArrayBuffer {
   /// Call `body(p)`, where `p` is an `UnsafeBufferPointer` over the
   /// underlying contiguous storage.  If no such storage exists, it is
   /// created on-demand.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @safe
   internal func withUnsafeBufferPointer<R, E>(
     _ body: (UnsafeBufferPointer<Element>) throws(E) -> R
@@ -708,7 +708,7 @@ extension _ArrayBuffer {
   /// over the underlying contiguous storage.
   ///
   /// - Precondition: Such contiguous storage exists or the buffer is empty.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @safe
   internal mutating func withUnsafeMutableBufferPointer<R, E>(
     _ body: (UnsafeMutableBufferPointer<Element>) throws(E) -> R

--- a/stdlib/public/core/ArrayShared.swift
+++ b/stdlib/public/core/ArrayShared.swift
@@ -70,7 +70,7 @@ func _deallocateUninitializedArray<Element>(
 }
 
 #if !INTERNAL_CHECKS_ENABLED
-@_alwaysEmitIntoClient
+@export(implementation)
 @_semantics("array.finalize_intrinsic")
 @_effects(readnone)
 @_effects(escaping array.value** => return.value**)
@@ -86,7 +86,7 @@ func _finalizeUninitializedArray<Element>(
 #else
 // When asserts are enabled, _endCOWMutation writes to _native.isImmutable
 // So we cannot have @_effects(readnone)
-@_alwaysEmitIntoClient
+@export(implementation)
 @_semantics("array.finalize_intrinsic")
 public // COMPILER_INTRINSIC
 func _finalizeUninitializedArray<Element>(
@@ -180,7 +180,7 @@ internal func _growArrayCapacity(_ capacity: Int) -> Int {
   return capacity * 2
 }
 
-@_alwaysEmitIntoClient
+@export(implementation)
 internal func _growArrayCapacity(
   oldCapacity: Int, minimumCapacity: Int, growForAppend: Bool
 ) -> Int {

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -170,7 +170,7 @@ extension ArraySlice {
   }
   
 #if INTERNAL_CHECKS_ENABLED && COW_CHECKS_ENABLED
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_semantics("array.make_mutable")
   internal mutating func _makeMutableAndUniqueUnchecked() {
     if _slowPath(!_buffer.beginCOWMutationUnchecked()) {
@@ -183,7 +183,7 @@ extension ArraySlice {
   ///
   /// After a call to `_endMutation` the buffer must not be mutated until a call
   /// to `_makeMutableAndUnique`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_semantics("array.end_mutation")
   internal mutating func _endMutation() {
     _buffer.endCOWMutation()
@@ -1216,7 +1216,7 @@ extension ArraySlice {
   ///   for the `withUnsafeBufferPointer(_:)` method. The pointer argument is
   ///   valid only for the duration of the method's execution.
   /// - Returns: The return value, if any, of the `body` closure parameter.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @safe
   public func withUnsafeBufferPointer<R, E>(
     _ body: (UnsafeBufferPointer<Element>) throws(E) -> R
@@ -1234,7 +1234,7 @@ extension ArraySlice {
   ///
   /// - Complexity: O(1)
   @available(SwiftCompatibilitySpan 5.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var span: Span<Element> {
     @_lifetime(borrow self)
     borrowing get {
@@ -1295,7 +1295,7 @@ extension ArraySlice {
   ///   method's execution.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @_semantics("array.withUnsafeMutableBufferPointer")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always) // Performance: This method should get inlined into the
   // caller such that we can combine the partial apply with the apply in this
   // function saving on allocating a closure context. This becomes unnecessary
@@ -1336,7 +1336,7 @@ extension ArraySlice {
   ///
   /// - Complexity: O(1) when the array's storage is uniquely referenced,
   ///   O(*n*) otherwise.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var mutableSpan: MutableSpan<Element> {
     @_lifetime(&self)
     mutating get {
@@ -1615,7 +1615,7 @@ extension ArraySlice {
   // This allows us to test the `_copyContents` implementation in
   // `_SliceBuffer`. (It's like `_copyToContiguousArray` but it always makes a
   // copy.)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func _copyToNewArray() -> [Element] {
     unsafe Array(unsafeUninitializedCapacity: self.count) { buffer, count in
       var (it, c) = unsafe self._buffer._copyContents(initializing: buffer)
@@ -1661,7 +1661,7 @@ extension ArraySlice {
   /// identical.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func isTriviallyIdentical(to other: Self) -> Bool {
     self._buffer.isTriviallyIdentical(to: other._buffer)
   }

--- a/stdlib/public/core/ArrayType.swift
+++ b/stdlib/public/core/ArrayType.swift
@@ -70,7 +70,7 @@ extension _ArrayProtocol {
   // Since RangeReplaceableCollection now has a version of filter that is less
   // efficient, we should make the default implementation coming from Sequence
   // preferred.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public consuming func filter<E: Error>(
     _ isIncluded: (Element) throws(E) -> Bool
   ) throws(E) -> [Element] {

--- a/stdlib/public/core/Assert.swift
+++ b/stdlib/public/core/Assert.swift
@@ -422,7 +422,7 @@ internal func _internalInvariant(
 }
 
 // Only perform the invariant check on Swift 5.1 and later
-@_alwaysEmitIntoClient // Swift 5.1
+@export(implementation) // Swift 5.1
 @_transparent
 internal func _internalInvariant_5_1(
   _ condition: @autoclosure () -> Bool, _ message: StaticString = StaticString(),

--- a/stdlib/public/core/AssertCommon.swift
+++ b/stdlib/public/core/AssertCommon.swift
@@ -60,7 +60,7 @@ func _isStdlibInternalChecksEnabled() -> Bool {
 }
 
 @_transparent
-@_alwaysEmitIntoClient // Introduced in 5.7
+@export(implementation) // Introduced in 5.7
 public // @testable
 func _isStdlibDebugChecksEnabled() -> Bool {
 #if SWIFT_STDLIB_ENABLE_DEBUG_PRECONDITIONS_IN_RELEASE
@@ -329,7 +329,7 @@ internal func _undefined<T>(
 #else
 @inline(__always)
 #endif
-@_alwaysEmitIntoClient // COMPILER_INTRINSIC
+@export(implementation) // COMPILER_INTRINSIC
 internal func _undefinedEditorPlaceholder(
   _filenameStart: Builtin.RawPointer,
   _filenameLength: Builtin.Word,

--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -29,7 +29,7 @@ import SwiftShims
 /// that are unnecessary due to the current deployment target. We call through
 /// to the _stdlib_isOSVersionAtLeast_AEIC function below to work around this,
 /// as the optimizer is able to perform this optimization for a
-/// @_alwaysEmitIntoClient function. We can't use @_alwaysEmitIntoClient
+/// @export(implementation) function. We can't use @export(implementation)
 /// directly on this call because it would break ABI for existing apps.
 ///
 /// `@_transparent` breaks the interpreter mode on macOS, as it creates a direct
@@ -66,7 +66,7 @@ public func _stdlib_isOSVersionAtLeast(
 
 @_semantics("availability.osversion")
 @_effects(readnone)
-@_alwaysEmitIntoClient
+@export(implementation)
 #if hasFeature(Macros)
 @_noLocks
 #endif
@@ -203,7 +203,7 @@ public typealias _SwiftStdlibVersion = SwiftShims._SwiftStdlibVersion
 ///     if #available(Swift 6.2, *) { }
 ///
 @available(SwiftStdlib 5.7, *)
-@_alwaysEmitIntoClient
+@export(implementation)
 internal func _isSwiftRuntimeVersionAtLeast(
   _ major: Builtin.Word,
   _ minor: Builtin.Word,
@@ -234,33 +234,33 @@ internal func _isExecutableLinkedOnOrAfter(
 }
 
 extension _SwiftStdlibVersion {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static var v5_6_0: Self { Self(_value: 0x050600) }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static var v5_7_0: Self { Self(_value: 0x050700) }
 
   // Note: As of now, there is no bincompat level defined for the versions
   // below. If you need to use one of these in a call to
   // `_isExecutableLinkedOnOrAfter`, then you'll need to define the
   // corresponding version in the runtime.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static var v5_8_0: Self { Self(_value: 0x050800) }
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static var v5_9_0: Self { Self(_value: 0x050900) }
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static var v5_10_0: Self { Self(_value: 0x050A00) }
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static var v6_0_0: Self { Self(_value: 0x060000) }
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static var v6_1_0: Self { Self(_value: 0x060100) }
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static var v6_2_0: Self { Self(_value: 0x060200) }
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static var v6_3_0: Self { Self(_value: 0x060300) }
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static var v6_4_0: Self { Self(_value: 0x060400) }
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static var v6_5_0: Self { Self(_value: 0x060500) }
 
   private static var _current: Self { .v6_5_0 }
@@ -280,7 +280,7 @@ extension _SwiftStdlibVersion {
   }
 #endif
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal init(
     _ major: Builtin.Word,
     _ minor: Builtin.Word,

--- a/stdlib/public/core/Bitset.swift
+++ b/stdlib/public/core/Bitset.swift
@@ -352,7 +352,7 @@ extension _UnsafeBitset.Word: @unsafe Sequence, @unsafe IteratorProtocol {
 }
 
 extension _UnsafeBitset {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   internal static func _withTemporaryUninitializedBitset<R, E: Error>(
     wordCount: Int,
@@ -367,7 +367,7 @@ extension _UnsafeBitset {
     }
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   internal static func withTemporaryBitset<R, E: Error>(
     capacity: Int,
@@ -384,7 +384,7 @@ extension _UnsafeBitset {
 }
 
 extension _UnsafeBitset {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   internal static func withTemporaryCopy<R, E: Error>(
     of original: _UnsafeBitset,

--- a/stdlib/public/core/BorrowingSequence.swift
+++ b/stdlib/public/core/BorrowingSequence.swift
@@ -75,7 +75,7 @@ public protocol BorrowingIteratorProtocol<Element>: ~Copyable, ~Escapable {
 extension BorrowingIteratorProtocol where Self: ~Copyable & ~Escapable, Element: ~Copyable {
   /// Returns a span over the next group of elements that are ready to by visited,
   /// up to the specifed maximum.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   @_lifetime(self: copy self)
   @_transparent
@@ -83,7 +83,7 @@ extension BorrowingIteratorProtocol where Self: ~Copyable & ~Escapable, Element:
     nextSpan(maximumCount: Int.max)
   }
   
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(self: copy self)
   public mutating func skip(by offset: Int) -> Int {
     var remainder = offset
@@ -114,7 +114,7 @@ public struct SpanIterator<Element>: BorrowingIteratorProtocol, ~Copyable, ~Esca
     _count = elements.count
   }
   
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   @_lifetime(self: copy self)
   @_transparent
@@ -127,7 +127,7 @@ public struct SpanIterator<Element>: BorrowingIteratorProtocol, ~Copyable, ~Esca
     return _span.extracting(droppingFirst: _start).extracting(first: c)
   }
   
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(self: copy self)
   public mutating func skip(by offset: Int) -> Int {
     let c = Swift.min(offset, _count)

--- a/stdlib/public/core/BridgeStorage.swift
+++ b/stdlib/public/core/BridgeStorage.swift
@@ -77,7 +77,7 @@ internal struct _BridgeStorage<NativeClass: AnyObject> {
     return isNative && _isUnique(&rawValue)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   internal mutating func beginCOWMutationNative() -> Bool {
     return Bool(Builtin.beginCOWMutation(&rawValue))
@@ -139,14 +139,14 @@ internal struct _BridgeStorage<NativeClass: AnyObject> {
     return _isUnique_native(&rawValue)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   internal mutating func beginCOWMutationUnflaggedNative() -> Bool {
     _internalInvariant(isNative)
     return Bool(Builtin.beginCOWMutation_native(&rawValue))
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   internal mutating func endCOWMutation() {
     _internalInvariant(isNative)
@@ -190,7 +190,7 @@ internal struct _BridgeStorage<NativeClass: AnyObject> {
     return _isUnique(&rawValue)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   internal mutating func beginCOWMutationNative() -> Bool {
     return Bool(Builtin.beginCOWMutation(&rawValue))
@@ -223,13 +223,13 @@ internal struct _BridgeStorage<NativeClass: AnyObject> {
     return _isUnique_native(&rawValue)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   internal mutating func beginCOWMutationUnflaggedNative() -> Bool {
     return Bool(Builtin.beginCOWMutation_native(&rawValue))
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   internal mutating func endCOWMutation() {
     Builtin.endCOWMutation(&rawValue)

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -115,7 +115,7 @@ public func _identityCast<T, U>(_ x: T, to expectedType: U.Type) -> U {
 ///
 /// This cast can be useful for dispatching to specializations of generic
 /// functions.
-@_alwaysEmitIntoClient
+@export(implementation)
 @_transparent
 public func _specialize<T, U>(_ x: T, for: U.Type) -> U? {
   guard T.self == U.self else {
@@ -165,7 +165,7 @@ internal func != (lhs: Builtin.RawPointer, rhs: Builtin.RawPointer) -> Bool {
 ///   - t1: Another type to compare.
 /// - Returns: `true` if both `t0` and `t1` are `nil` or if they represent the
 ///   same type; otherwise, `false`.
-@_alwaysEmitIntoClient
+@export(implementation)
 @_transparent
 public func == (
   t0: (any (~Copyable & ~Escapable).Type)?,
@@ -196,7 +196,7 @@ public func == (
 ///   - t1: Another type to compare.
 /// - Returns: `true` if one, but not both, of `t0` and `t1` are `nil`, or if
 ///   they represent different types; otherwise, `false`.
-@_alwaysEmitIntoClient
+@export(implementation)
 @_transparent
 public func != (
   t0: (any (~Copyable & ~Escapable).Type)?,
@@ -786,7 +786,7 @@ func _isUnique_native<T>(_ object: inout T) -> Bool {
   return Bool(Builtin.isUnique_native(&object))
 }
 
-@_alwaysEmitIntoClient
+@export(implementation)
 @_transparent
 public // @testable
 func _COWBufferForReading<T: AnyObject>(_ object: T) -> T {
@@ -808,7 +808,7 @@ func _isPOD<T: ~Copyable & ~Escapable>(_ type: T.Type) -> Bool {
 ///
 /// Note that there may be cases in which, despite `T` being concrete at some
 /// point in the caller chain, this function will return `false`.
-@_alwaysEmitIntoClient
+@export(implementation)
 @_transparent
 public // @testable
 func _isConcrete<T>(_ type: T.Type) -> Bool {
@@ -839,7 +839,7 @@ func _isOptional<T>(_ type: T.Type) -> Bool {
 ///
 /// Optimizations performed at various stages during compilation may affect the
 /// result of this function.
-@_alwaysEmitIntoClient @inline(__always)
+@export(implementation) @inline(__always)
 internal func _isComputed(_ value: Int) -> Bool {
   return !Bool(Builtin.int_is_constant_Word(value._builtinWordValue))
 }
@@ -982,7 +982,7 @@ func _trueAfterDiagnostics() -> Builtin.Int1 {
 ///
 /// - Parameter value: The value for which to find the dynamic type.
 /// - Returns: The dynamic type, which is a metatype instance.
-@_alwaysEmitIntoClient
+@export(implementation)
 @_semantics("typechecker.type(of:)")
 public func type<T: ~Copyable & ~Escapable, Metatype>(
   of value: borrowing T
@@ -1087,7 +1087,7 @@ func __abi_type<T, Metatype>(of value: T) -> Metatype {
 ///   - body: A closure that is executed immediately with an escapable copy of
 ///     `closure` as its argument.
 /// - Returns: The return value, if any, of the `body` closure.
-@_alwaysEmitIntoClient
+@export(implementation)
 @_transparent
 @_semantics("typechecker.withoutActuallyEscaping(_:do:)")
 public func withoutActuallyEscaping<ClosureType, ResultType, Failure>(
@@ -1119,7 +1119,7 @@ func __abi_withoutActuallyEscaping<ClosureType, ResultType>(
 }
 
 @_unavailableInEmbedded
-@_alwaysEmitIntoClient
+@export(implementation)
 @_transparent
 @_semantics("typechecker._openExistential(_:do:)")
 public func _openExistential<ExistentialType, ContainedType, ResultType, Failure>(
@@ -1158,7 +1158,7 @@ func __abi_openExistential<ExistentialType, ContainedType, ResultType>(
 /// constructed from literals or if the construction site of the string is not
 /// in the function containing the call to this SPI.
 @_transparent
-@_alwaysEmitIntoClient
+@export(implementation)
 public // @SPI(OSLog)
 func _getGlobalStringTablePointer(_ constant: String) -> UnsafePointer<CChar> {
   return unsafe UnsafePointer<CChar>(Builtin.globalStringTablePointer(constant));

--- a/stdlib/public/core/CString.swift
+++ b/stdlib/public/core/CString.swift
@@ -65,8 +65,7 @@ extension String {
   ///
   /// - Parameter nullTerminatedUTF8:
   ///     An array containing a null-terminated sequence of UTF-8 code units.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(swift, deprecated: 6, message:
     "Use String(decoding: array, as: UTF8.self) instead, after truncating the null termination."
   )
@@ -76,7 +75,7 @@ extension String {
     }
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal init(_checkingCString bytes: UnsafeBufferPointer<UInt8>) {
     guard let length = unsafe bytes.firstIndex(of: 0) else {
       _preconditionFailure(
@@ -91,8 +90,7 @@ extension String {
     ).0
   }
 
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, deprecated, message: "Use String(_ scalar: Unicode.Scalar)")
   public init(cString nullTerminatedUTF8: inout CChar) {
     guard nullTerminatedUTF8 == 0 else {
@@ -129,8 +127,7 @@ extension String {
   ///
   /// - Parameter nullTerminatedUTF8:
   ///     An array containing a null-terminated UTF-8 code unit sequence.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(swift, deprecated: 6, message:
     "Use String(decoding: array, as: UTF8.self) instead, after truncating the null termination."
   )
@@ -140,15 +137,13 @@ extension String {
     }
   }
 
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, deprecated, message: "Use a copy of the String argument")
   public init(cString nullTerminatedUTF8: String) {
     self = unsafe nullTerminatedUTF8.withCString(String.init(cString:))
   }
 
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, deprecated, message: "Use String(_ scalar: Unicode.Scalar)")
   public init(cString nullTerminatedUTF8: inout UInt8) {
     guard nullTerminatedUTF8 == 0 else {
@@ -228,8 +223,7 @@ extension String {
   ///
   /// - Parameter cString:
   ///     A pointer to a null-terminated sequence of UTF-8 code units.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(swift, deprecated: 6, renamed: "String.init(validatingCString:)")
   @_silgen_name("_swift_se0405_String_validatingUTF8")
   public init?(validatingUTF8 cString: UnsafePointer<CChar>) {
@@ -248,8 +242,7 @@ extension String {
   ///
   /// - Parameter nullTerminatedUTF8:
   ///     An array containing a null-terminated sequence of UTF-8 code units.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(swift, deprecated: 6, message:
     "Use String(validating: array, as: UTF8.self) instead, after truncating the null termination."
   )
@@ -278,8 +271,7 @@ extension String {
   ///
   /// - Parameter cString:
   ///     An array containing a null-terminated sequence of UTF-8 code units.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(swift, deprecated: 6, message:
     "Use String(validating: array, as: UTF8.self) instead, after truncating the null termination."
   )
@@ -287,22 +279,19 @@ extension String {
     self.init(validatingCString: cString)
   }
 
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, deprecated, message: "Use a copy of the String argument")
   public init?(validatingCString nullTerminatedUTF8: String) {
     self = unsafe nullTerminatedUTF8.withCString(String.init(cString:))
   }
 
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, deprecated, message: "Use a copy of the String argument")
   public init?(validatingUTF8 cString: String) {
     self.init(validatingCString: cString)
   }
 
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, deprecated, message: "Use String(_ scalar: Unicode.Scalar)")
   public init?(validatingCString nullTerminatedUTF8: inout CChar) {
     guard nullTerminatedUTF8 == 0 else {
@@ -313,8 +302,7 @@ extension String {
     self = ""
   }
 
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, deprecated, message: "Use String(_ scalar: Unicode.Scalar)")
   public init?(validatingUTF8 cString: inout CChar) {
     self.init(validatingCString: &cString)
@@ -396,8 +384,7 @@ extension String {
       codeUnits, encoding: encoding, repair: isRepairing)
   }
 
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func decodeCString<Encoding: _UnicodeEncoding>(
     _ cString: [Encoding.CodeUnit],
     as encoding: Encoding.Type,
@@ -430,8 +417,7 @@ extension String {
     }
   }
 
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, deprecated, message: "Use a copy of the String argument")
   public static func decodeCString<Encoding: _UnicodeEncoding>(
     _ cString: String,
@@ -445,8 +431,7 @@ extension String {
     }
   }
 
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, deprecated, message: "Use String(_ scalar: Unicode.Scalar)")
   public static func decodeCString<Encoding: _UnicodeEncoding>(
     _ cString: inout Encoding.CodeUnit,
@@ -499,8 +484,7 @@ extension String {
   ///     sequence of code units encoded in `encoding`.
   ///   - encoding: The encoding in which the code units should be
   ///     interpreted.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(swift, deprecated: 6, message:
     "Use String(decoding: array, as: Encoding.self) instead, after truncating the null termination."
   )
@@ -511,8 +495,7 @@ extension String {
     self = String.decodeCString(nullTerminatedCodeUnits, as: encoding)!.0
   }
 
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, deprecated, message: "Use a copy of the String argument")
   public init<Encoding: _UnicodeEncoding>(
     decodingCString nullTerminatedCodeUnits: String,
@@ -523,8 +506,7 @@ extension String {
     }
   }
 
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, deprecated, message: "Use String(_ scalar: Unicode.Scalar)")
   public init<Encoding: Unicode.Encoding>(
     decodingCString nullTerminatedCodeUnits: inout Encoding.CodeUnit,

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -71,7 +71,7 @@ public struct ClosedRange<Bound: Comparable> {
   // This works around _debugPrecondition() impacting the performance of
   // optimized code. (rdar://72246338)
   @unsafe
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   internal init(_uncheckedBounds bounds: (lower: Bound, upper: Bound)) {
     self.lowerBound = bounds.lower
     self.upperBound = bounds.upper
@@ -357,7 +357,7 @@ where Bound: Strideable, Bound.Stride: SignedInteger
   ///   closed range; otherwise, `false`.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func contains(_ other: Range<Bound>) -> Bool {
     if other.isEmpty { return true }
     let otherInclusiveUpper = other.upperBound.advanced(by: -1)
@@ -383,7 +383,7 @@ extension ClosedRange {
   ///   otherwise, `false`.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public func contains(_ other: ClosedRange<Bound>) -> Bool {
     lowerBound <= other.lowerBound && upperBound >= other.upperBound

--- a/stdlib/public/core/CocoaArray.swift
+++ b/stdlib/public/core/CocoaArray.swift
@@ -153,7 +153,7 @@ internal struct _CocoaArrayWrapper: RandomAccessCollection {
     }
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal __consuming func _copyContents(
     initializing buffer: UnsafeMutableBufferPointer<Element>
   ) -> (Iterator, UnsafeMutableBufferPointer<Element>.Index) {

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1043,7 +1043,7 @@ extension Collection {
   // runtime the generic implementation would call itself
   // in an infinite recursion because of the absence of a better option.
   @available(*, unavailable)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public subscript(bounds: Range<Index>) -> SubSequence { fatalError() }
 }
 
@@ -1188,8 +1188,7 @@ extension Collection {
   ///   value of the same or of a different type.
   /// - Returns: An array containing the transformed elements of this
   ///   sequence.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func map<T, E>(
     _ transform: (Element) throws(E) -> T
   ) throws(E) -> [T] {

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -160,7 +160,7 @@ extension CollectionOfOne: RandomAccessCollection, MutableCollection {
 }
 
 extension CollectionOfOne {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func withContiguousStorageIfAvailable<R: ~Copyable, E: Error>(
     _ body: (UnsafeBufferPointer<Element>) throws(E) -> R
   ) throws(E) -> R? {
@@ -179,7 +179,7 @@ extension CollectionOfOne {
   /// - Returns: A `Span` over the element of this collection.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var span: Span<Element> {
     @_lifetime(borrow self)
     get {
@@ -194,7 +194,7 @@ extension CollectionOfOne {
   /// - Returns: A `MutableSpan` over the element of this collection.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var mutableSpan: MutableSpan<Element> {
     @_lifetime(&self)
     mutating get {
@@ -227,19 +227,19 @@ extension CollectionOfOne: Sendable where Element: Sendable { }
 extension CollectionOfOne.Iterator: Sendable where Element: Sendable { }
 
 extension CollectionOfOne where Element: Equatable {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func ==(lhs: CollectionOfOne<Element>, rhs: CollectionOfOne<Element>) -> Bool {
     return lhs._element == rhs._element
   }
 }
 
 extension CollectionOfOne where Element: Hashable {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func hash(into hasher: inout Hasher) {
     hasher.combine(self._element)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var hashValue: Int { // Prevent compiler from synthesizing hashValue.
     var hasher = Hasher()
     self.hash(into: &hasher)

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -75,7 +75,7 @@ extension ContiguousArray {
   }
 
 #if INTERNAL_CHECKS_ENABLED && COW_CHECKS_ENABLED
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_semantics("array.make_mutable")
   internal mutating func _makeMutableAndUniqueUnchecked() {
     if _slowPath(!_buffer.beginCOWMutationUnchecked()) {
@@ -88,7 +88,7 @@ extension ContiguousArray {
   ///
   /// After a call to `_endMutation` the buffer must not be mutated until a call
   /// to `_makeMutableAndUnique`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_semantics("array.end_mutation")
   internal mutating func _endMutation() {
     _buffer.endCOWMutation()
@@ -106,7 +106,7 @@ extension ContiguousArray {
   /// `0 ≤ index < count`.
   ///
   /// - Precondition: The buffer must be uniquely referenced and native.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_semantics("array.check_subscript")
   internal func _checkSubscript_mutating(_ index: Int) {
     _buffer._checkValidSubscriptMutating(index)
@@ -703,7 +703,7 @@ extension ContiguousArray: RangeReplaceableCollection {
   /// Reserves enough space to store `minimumCapacity` elements.
   /// If a new buffer needs to be allocated and `growForAppend` is true,
   /// the new capacity is calculated using `_growArrayCapacity`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func _reserveCapacityImpl(
     minimumCapacity: Int, growForAppend: Bool
   ) {
@@ -725,7 +725,7 @@ extension ContiguousArray: RangeReplaceableCollection {
   /// The `minimumCapacity` is the lower bound for the new capacity.
   /// If `growForAppend` is true, the new capacity is calculated using
   /// `_growArrayCapacity`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(never)
   internal mutating func _createNewBuffer(
     bufferIsUnique: Bool, minimumCapacity: Int, growForAppend: Bool
@@ -1106,7 +1106,7 @@ extension ContiguousArray {
   ///       - initializedCount: The count of initialized elements in the array,
   ///         which begins as zero. Set `initializedCount` to the number of
   ///         elements you initialize.
-  @_alwaysEmitIntoClient @inlinable
+  @export(implementation)
   public init<E>(
     unsafeUninitializedCapacity: Int,
     initializingWith initializer: (
@@ -1159,7 +1159,7 @@ extension ContiguousArray {
   ///     - Parameters:
   ///       - span: An `OutputSpan` covering uninitialized memory with
   ///         space for the specified number of elements.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init<E: Error>(
     capacity: Int,
     initializingWith initializer: (
@@ -1206,7 +1206,7 @@ extension ContiguousArray {
   ///     - Parameters:
   ///       - span: An `OutputSpan` covering uninitialized memory with
   ///         space for the specified number of additional elements.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func append<E: Error>(
     addingCapacity uninitializedCount: Int,
     initializingWith initializer: (
@@ -1281,7 +1281,7 @@ extension ContiguousArray {
   ///   for the `withUnsafeBufferPointer(_:)` method. The pointer argument is
   ///   valid only for the duration of the method's execution.
   /// - Returns: The return value, if any, of the `body` closure parameter.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @safe
   public func withUnsafeBufferPointer<R, E>(
     _ body: (UnsafeBufferPointer<Element>) throws(E) -> R
@@ -1298,7 +1298,7 @@ extension ContiguousArray {
   /// - Returns: A `Span` over the elements of this array.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var span: Span<Element> {
     @_lifetime(borrow self)
     borrowing get {
@@ -1360,7 +1360,7 @@ extension ContiguousArray {
   ///   method's execution.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @_semantics("array.withUnsafeMutableBufferPointer")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always) // Performance: This method should get inlined into the
   // caller such that we can combine the partial apply with the apply in this
   // function saving on allocating a closure context. This becomes unnecessary
@@ -1400,7 +1400,7 @@ extension ContiguousArray {
   ///
   /// - Complexity: O(1) when the array's storage is uniquely referenced,
   ///   O(*n*) otherwise.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var mutableSpan: MutableSpan<Element> {
     @_lifetime(&self)
     mutating get {
@@ -1692,7 +1692,7 @@ extension ContiguousArray {
   /// identical.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func isTriviallyIdentical(to other: Self) -> Bool {
     unsafe self._buffer.identity == other._buffer.identity
   }

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -309,13 +309,13 @@ internal final class _ContiguousArrayStorage<
   }
 }
 
-@_alwaysEmitIntoClient
+@export(implementation)
 @inline(__always)
 internal func _uncheckedUnsafeBitCast<T, U>(_ x: T, to type: U.Type) -> U {
   return Builtin.reinterpretCast(x)
 }
 
-@_alwaysEmitIntoClient
+@export(implementation)
 @inline(never)
 @_effects(readonly)
 @_semantics("array.getContiguousArrayStorageType")
@@ -436,7 +436,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   /// A mutable pointer to the first element.
   ///
   /// - Precondition: The buffer must be mutable.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal var mutableFirstElementAddress: UnsafeMutablePointer<Element> {
     return unsafe UnsafeMutablePointer(Builtin.projectTailElems(mutableOrEmptyStorage,
                                                          Element.self))
@@ -461,7 +461,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
 
   /// Call `body(p)`, where `p` is an `UnsafeBufferPointer` over the
   /// underlying contiguous storage.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @safe
   internal func withUnsafeBufferPointer<R, E>(
     _ body: (UnsafeBufferPointer<Element>) throws(E) -> R
@@ -485,7 +485,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
 
   /// Call `body(p)`, where `p` is an `UnsafeMutableBufferPointer`
   /// over the underlying contiguous storage.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @safe
   internal mutating func withUnsafeMutableBufferPointer<R, E>(
     _ body: (UnsafeMutableBufferPointer<Element>) throws(E) -> R
@@ -543,7 +543,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   /// The storage of an immutable buffer.
   ///
   /// - Precondition: The buffer must be immutable.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   internal var immutableStorage : __ContiguousArrayStorageBase {
 #if INTERNAL_CHECKS_ENABLED && COW_CHECKS_ENABLED
@@ -555,7 +555,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   /// The storage of a mutable buffer.
   ///
   /// - Precondition: The buffer must be mutable.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   internal var mutableStorage : __ContiguousArrayStorageBase {
 #if INTERNAL_CHECKS_ENABLED && COW_CHECKS_ENABLED
@@ -567,7 +567,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   /// The storage of a mutable or empty buffer.
   ///
   /// - Precondition: The buffer must be mutable or the empty array singleton.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   internal var mutableOrEmptyStorage : __ContiguousArrayStorageBase {
 #if INTERNAL_CHECKS_ENABLED && COW_CHECKS_ENABLED
@@ -578,7 +578,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   }
 
 #if INTERNAL_CHECKS_ENABLED && COW_CHECKS_ENABLED
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal var isImmutable: Bool {
     get {
       if (_COWChecksEnabled()) {
@@ -604,7 +604,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
     }
   }
   
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal var isMutable: Bool {
     if (_COWChecksEnabled()) {
       return !_swift_isImmutableCOWBuffer(_storage)
@@ -659,7 +659,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   /// The number of elements of the buffer.
   ///
   /// - Precondition: The buffer must be immutable.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   internal var immutableCount: Int {
     return immutableStorage.countAndCapacity.count
@@ -668,7 +668,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   /// The number of elements of the buffer.
   ///
   /// - Precondition: The buffer must be mutable.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal var mutableCount: Int {
     @inline(__always)
     get {
@@ -703,7 +703,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   /// `0 ≤ index < count`.
   ///
   /// - Precondition: The buffer must be mutable.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   internal func _checkValidSubscriptMutating(_ index: Int) {
     _precondition(
@@ -725,7 +725,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   /// The number of elements the buffer can store without reallocation.
   ///
   /// - Precondition: The buffer must be immutable.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   internal var immutableCapacity: Int {
     return immutableStorage.countAndCapacity.capacity
@@ -734,7 +734,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   /// The number of elements the buffer can store without reallocation.
   ///
   /// - Precondition: The buffer must be mutable.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   internal var mutableCapacity: Int {
     return mutableOrEmptyStorage.countAndCapacity.capacity
@@ -812,7 +812,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   ///
   /// - Warning: It's a requirement to call `beginCOWMutation` before the buffer
   ///   is mutated.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func beginCOWMutation() -> Bool {
     if Bool(Builtin.beginCOWMutation(&_storage)) {
 #if INTERNAL_CHECKS_ENABLED && COW_CHECKS_ENABLED
@@ -824,7 +824,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   }
 
 #if INTERNAL_CHECKS_ENABLED && COW_CHECKS_ENABLED
- @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func beginCOWMutationUnchecked() -> Bool {
     if Bool(Builtin.beginCOWMutation(&_storage)) {
       return true
@@ -839,7 +839,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   ///
   /// - Warning: After a call to `endCOWMutation` the buffer must not be mutated
   ///   until the next call of `beginCOWMutation`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   internal mutating func endCOWMutation() {
 #if INTERNAL_CHECKS_ENABLED && COW_CHECKS_ENABLED
@@ -852,7 +852,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   /// this buffer.
   ///
   /// This buffer is consumed, i.e. it's released.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(never)
   @_semantics("optimize.sil.specialize.owned2guarantee.never")
   internal __consuming func _consumeAndCreateNew() -> _ContiguousArrayBuffer {
@@ -872,7 +872,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   /// `_growArrayCapacity`, but at least kept at `minimumCapacity`.
   ///
   /// This buffer is consumed, i.e. it's released.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(never)
   @_semantics("optimize.sil.specialize.owned2guarantee.never")
   internal __consuming func _consumeAndCreateNew(

--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -386,7 +386,7 @@ public func _stringForPrintObject(_ value: Any) -> String {
 
 public func _debuggerTestingCheckExpect(_: String, _: String) { }
 
-@_alwaysEmitIntoClient @_transparent
+@export(implementation) @_transparent
 internal func _withHeapObject<R>(
   of object: AnyObject,
   _ body: (UnsafeMutableRawPointer) -> R
@@ -404,19 +404,19 @@ internal func _swift_unownedRetainCount(_: UnsafeMutableRawPointer) -> Int
 internal func _swift_weakRetainCount(_: UnsafeMutableRawPointer) -> Int
 
 // Utilities to get refcount(s) of class objects.
-@_alwaysEmitIntoClient
+@export(implementation)
 public func _getRetainCount(_ object: AnyObject) -> UInt {
   let count = unsafe _withHeapObject(of: object) { unsafe _swift_retainCount($0) }
   return UInt(bitPattern: count)
 }
 
-@_alwaysEmitIntoClient
+@export(implementation)
 public func _getUnownedRetainCount(_ object: AnyObject) -> UInt {
   let count = unsafe _withHeapObject(of: object) { unsafe _swift_unownedRetainCount($0) }
   return UInt(bitPattern: count)
 }
 
-@_alwaysEmitIntoClient
+@export(implementation)
 public func _getWeakRetainCount(_ object: AnyObject) -> UInt {
   let count = unsafe _withHeapObject(of: object) { unsafe _swift_weakRetainCount($0) }
   return UInt(bitPattern: count)

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -515,7 +515,7 @@ public struct Dictionary<Key: Hashable, Value> {
   ///   - combine: A closure that is called with the values for any duplicate
   ///     keys that are encountered. The closure returns the desired value for
   ///     the final dictionary.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init<S: Sequence, E: Error>(
     _ keysAndValues: __owned S,
     uniquingKeysWith combine: (Value, Value) throws(E) -> Value
@@ -568,7 +568,7 @@ public struct Dictionary<Key: Hashable, Value> {
   ///   - values: A sequence of values to group into a dictionary.
   ///   - keyForValue: A closure that returns a key for each element in
   ///     `values`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init<S: Sequence, E: Error>(
     grouping values: __owned S,
     by keyForValue: (S.Element) throws(E) -> Key
@@ -636,7 +636,7 @@ extension Dictionary {
   ///   argument and returns a Boolean value indicating whether the pair
   ///   should be included in the returned dictionary.
   /// - Returns: A dictionary of the key-value pairs that `isIncluded` allows.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(swift, introduced: 4.0)
   public consuming func filter<E: Error>(
     _ isIncluded: (Element) throws(E) -> Bool
@@ -966,7 +966,7 @@ extension Dictionary {
   ///   this dictionary.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the dictionary.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func mapValues<T, E: Error>(
     _ transform: (Value) throws(E) -> T
   ) throws(E) -> Dictionary<Key, T> {
@@ -1099,7 +1099,7 @@ extension Dictionary {
   ///   - combine: A closure that takes the current and new values for any
   ///     duplicate keys. The closure returns the desired value for the final
   ///     dictionary.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func merge<S: Sequence, E: Error>(
     _ other: __owned S,
     uniquingKeysWith combine: (Value, Value) throws(E) -> Value
@@ -1154,7 +1154,7 @@ extension Dictionary {
   ///   - combine: A closure that takes the current and new values for any
   ///     duplicate keys. The closure returns the desired value for the final
   ///     dictionary.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func merge<E: Error>(
     _ other: __owned [Key: Value],
     uniquingKeysWith combine: (Value, Value) throws(E) -> Value
@@ -1211,7 +1211,7 @@ extension Dictionary {
   ///     dictionary.
   /// - Returns: A new dictionary with the combined keys and values of this
   ///   dictionary and `other`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public __consuming func merging<S: Sequence, E: Error>(
     _ other: __owned S,
     uniquingKeysWith combine: (Value, Value) throws(E) -> Value
@@ -1271,7 +1271,7 @@ extension Dictionary {
   ///     dictionary.
   /// - Returns: A new dictionary with the combined keys and values of this
   ///   dictionary and `other`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public __consuming func merging<E: Error>(
     _ other: __owned [Key: Value],
     uniquingKeysWith combine: (Value, Value) throws(E) -> Value
@@ -1694,7 +1694,7 @@ extension Dictionary.Keys {
 }
 
 extension Dictionary.Keys {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func hash(into hasher: inout Hasher) {
     var commutativeHash = 0
     for element in self {
@@ -1707,7 +1707,7 @@ extension Dictionary.Keys {
     hasher.combine(commutativeHash)
   }
   
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var hashValue: Int { // Prevent compiler from synthesizing hashValue.
     var hasher = Hasher()
     self.hash(into: &hasher)
@@ -2352,7 +2352,7 @@ extension Dictionary {
   /// considered identical.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func isTriviallyIdentical(to other: Self) -> Bool {
 #if _runtime(_ObjC)
     if

--- a/stdlib/public/core/DictionaryBridging.swift
+++ b/stdlib/public/core/DictionaryBridging.swift
@@ -559,7 +559,7 @@ extension __CocoaDictionary: _DictionaryBuffer {
 }
 
 extension __CocoaDictionary {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func mapValues<Key: Hashable, Value, T, E: Error>(
     _ transform: (Value) throws(E) -> T
   ) throws(E) -> _NativeDictionary<Key, T> {

--- a/stdlib/public/core/DictionaryBuilder.swift
+++ b/stdlib/public/core/DictionaryBuilder.swift
@@ -74,7 +74,7 @@ extension Dictionary {
   ///   - body: A closure that can initialize the dictionary's elements. This
   ///     closure must return the count of the initialized elements, starting at
   ///     the beginning of the buffer.
-  @_alwaysEmitIntoClient // Introduced in 5.1
+  @export(implementation) // Introduced in 5.1
   public // SPI(Foundation)
   init(
     _unsafeUninitializedCapacity capacity: Int,
@@ -92,7 +92,7 @@ extension Dictionary {
 }
 
 extension _NativeDictionary {
-  @_alwaysEmitIntoClient // Introduced in 5.1
+  @export(implementation) // Introduced in 5.1
   internal init(
     _unsafeUninitializedCapacity capacity: Int,
     allowingDuplicates: Bool,

--- a/stdlib/public/core/DictionaryCasting.swift
+++ b/stdlib/public/core/DictionaryCasting.swift
@@ -13,7 +13,7 @@
 //===--- Compiler conversion/casting entry points for Dictionary<K, V> ----===//
 
 extension Dictionary {
-  @_alwaysEmitIntoClient @inlinable // Introduced in 5.1
+  @export(implementation) // Introduced in 5.1
   @inline(__always)
   internal init?<C: Collection>(
     _mapping source: C,

--- a/stdlib/public/core/DictionaryStorage.swift
+++ b/stdlib/public/core/DictionaryStorage.swift
@@ -223,7 +223,7 @@ extension __RawDictionaryStorage {
       Builtin.addressof(&_swiftEmptyDictionarySingleton))
   }
   
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   internal final func uncheckedKey<Key: Hashable>(at bucket: _HashTable.Bucket) -> Key {
     defer { unsafe _fixLifetime(self) }
@@ -233,14 +233,14 @@ extension __RawDictionaryStorage {
   }
 
   @safe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(never)
   internal final func find<Key: Hashable>(_ key: Key) -> (bucket: _HashTable.Bucket, found: Bool) {
     return unsafe find(key, hashValue: key._rawHashValue(seed: _seed))
   }
 
   @safe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(never)
   internal final func find<Key: Hashable>(_ key: Key, hashValue: Int) -> (bucket: _HashTable.Bucket, found: Bool) {
       let hashTable = unsafe _hashTable

--- a/stdlib/public/core/DictionaryVariant.swift
+++ b/stdlib/public/core/DictionaryVariant.swift
@@ -452,7 +452,7 @@ extension Dictionary._Variant {
 }
 
 extension Dictionary._Variant {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func mapValues<T, E: Error>(
     _ transform: (Value) throws(E) -> T
   ) throws(E) -> _NativeDictionary<Key, T> {
@@ -482,7 +482,7 @@ extension Dictionary._Variant {
   }
 #endif
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func merge<S: Sequence, E: Error>(
     _ keysAndValues: __owned S,
     uniquingKeysWith combine: (Value, Value) throws(E) -> Value

--- a/stdlib/public/core/Duration.swift
+++ b/stdlib/public/core/Duration.swift
@@ -101,7 +101,7 @@ extension Duration {
   ///     let d = Duration.seconds(1)
   ///     print(d.attoseconds) // 1_000_000_000_000_000_000
   @available(StdlibDeploymentTarget 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var attoseconds: Int128 {
     Int128(_low: _low, _high: _high)
   }
@@ -115,7 +115,7 @@ extension Duration {
   ///
   /// - Parameter attoseconds: The total duration expressed in attoseconds.
   @available(StdlibDeploymentTarget 6.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(attoseconds: Int128) {
     self.init(_high: attoseconds._high, low: attoseconds._low)
   }

--- a/stdlib/public/core/EmptyCollection.swift
+++ b/stdlib/public/core/EmptyCollection.swift
@@ -165,7 +165,7 @@ extension EmptyCollection: RandomAccessCollection, MutableCollection {
 }
 
 extension EmptyCollection {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func withContiguousStorageIfAvailable<R: ~Copyable, E: Error>(
     _ body: (UnsafeBufferPointer<Element>) throws(E) -> R
   ) throws(E) -> R? {
@@ -186,12 +186,12 @@ extension EmptyCollection: Sendable { }
 extension EmptyCollection.Iterator: Sendable { }
 
 extension EmptyCollection {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func hash(into hasher: inout Hasher) {
     hasher.combine(0)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var hashValue: Int { // Prevent compiler from synthesizing hashValue.
     var hasher = Hasher()
     self.hash(into: &hasher)

--- a/stdlib/public/core/EnumeratedSequence.swift
+++ b/stdlib/public/core/EnumeratedSequence.swift
@@ -112,7 +112,7 @@ extension EnumeratedSequence: Collection where Base: Collection {
     let _offset: Int
 
     @available(SwiftStdlib 6.2, *)
-    @_alwaysEmitIntoClient
+    @export(implementation)
     init(base: Base.Index, offset: Int) {
       self.base = base
       self._offset = offset
@@ -120,25 +120,25 @@ extension EnumeratedSequence: Collection where Base: Collection {
   }
 
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var startIndex: Index {
     Index(base: _base.startIndex, offset: 0)
   }
 
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var endIndex: Index {
     Index(base: _base.endIndex, offset: 0)
   }
 
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var count: Int {
     _base.count
   }
 
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var isEmpty: Bool {
     _base.isEmpty
   }
@@ -148,13 +148,13 @@ extension EnumeratedSequence: Collection where Base: Collection {
   /// - Complexity: O(*n*) if `index == endIndex` and `Base` does not conform to
   ///   `RandomAccessCollection`, O(1) otherwise.
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   func _offset(of index: Index) -> Int {
     index.base == _base.endIndex ? _base.count : index._offset
   }
 
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func distance(from start: Index, to end: Index) -> Int {
     if start.base == _base.endIndex || end.base == _base.endIndex {
       return _base.distance(from: start.base, to: end.base)
@@ -164,13 +164,13 @@ extension EnumeratedSequence: Collection where Base: Collection {
   }
 
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func index(after index: Index) -> Index {
     Index(base: _base.index(after: index.base), offset: index._offset + 1)
   }
 
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func index(_ i: Index, offsetBy distance: Int) -> Index {
     let index = _base.index(i.base, offsetBy: distance)
     let offset = distance >= 0 ? i._offset : _offset(of: i)
@@ -178,7 +178,7 @@ extension EnumeratedSequence: Collection where Base: Collection {
   }
 
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func index(
     _ i: Index,
     offsetBy distance: Int,
@@ -197,7 +197,7 @@ extension EnumeratedSequence: Collection where Base: Collection {
   }
 
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public subscript(_ position: Index) -> Element {
     _precondition(
       _base.startIndex <= position.base && position.base < _base.endIndex,
@@ -211,13 +211,13 @@ extension EnumeratedSequence: Collection where Base: Collection {
 @available(SwiftStdlib 6.2, *)
 extension EnumeratedSequence.Index: Comparable {
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func ==(lhs: Self, rhs: Self) -> Bool {
     lhs.base == rhs.base
   }
 
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func <(lhs: Self, rhs: Self) -> Bool {
     lhs.base < rhs.base
   }
@@ -226,7 +226,7 @@ extension EnumeratedSequence.Index: Comparable {
 @available(SwiftStdlib 6.2, *)
 extension EnumeratedSequence: BidirectionalCollection where Base: BidirectionalCollection & RandomAccessCollection {
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func index(before index: Index) -> Index {
     Index(base: _base.index(before: index.base), offset: _offset(of: index) - 1)
   }

--- a/stdlib/public/core/ErrorType.swift
+++ b/stdlib/public/core/ErrorType.swift
@@ -192,8 +192,7 @@ func _willThrowTypedImpl<E: Error>(_ error: E)
 ///
 /// On older platforms, the error will not be passed into the runtime, because
 /// doing so would require memory allocation (to create the 'any Error').
-@inlinable
-@_alwaysEmitIntoClient
+@export(implementation)
 @_silgen_name("swift_willThrowTyped")
 public func _willThrowTyped<E: Error>(_ error: E) {
   if #available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *) {
@@ -228,8 +227,7 @@ public func _unexpectedError(
 /// Invoked by the compiler when the subexpression of a `try!` expression
 /// throws an error.
 @_silgen_name("swift_unexpectedErrorTyped")
-@_alwaysEmitIntoClient
-@inlinable
+@export(implementation)
 public func _unexpectedErrorTyped<E: Error>(
   _ error: __owned E,
   filenameStart: Builtin.RawPointer,
@@ -258,7 +256,7 @@ public func _errorInMain(_ error: Error) {
 }
 
 /// Invoked by the compiler when code at top level throws an uncaught, typed error.
-@_alwaysEmitIntoClient
+@export(implementation)
 public func _errorInMainTyped<Failure: Error>(_ error: Failure) -> Never {
   #if !$Embedded
   fatalError("Error raised at top level: \(String(reflecting: error))")

--- a/stdlib/public/core/ExistentialCollection.swift
+++ b/stdlib/public/core/ExistentialCollection.swift
@@ -1335,8 +1335,7 @@ extension AnySequence {
   }
 
 #if !$Embedded
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func map<T, E>(
     _ transform: (Element) throws(E) -> T
   ) throws(E) -> [T] {
@@ -1441,8 +1440,7 @@ extension AnyCollection {
   }
 
 #if !$Embedded
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func map<T, E>(
     _ transform: (Element) throws(E) -> T
   ) throws(E) -> [T] {
@@ -1553,8 +1551,7 @@ extension AnyBidirectionalCollection {
   }
 
 #if !$Embedded
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func map<T, E>(
     _ transform: (Element) throws(E) -> T
   ) throws(E) -> [T] {
@@ -1667,8 +1664,7 @@ extension AnyRandomAccessCollection {
   }
 
 #if !$Embedded
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func map<T, E>(
     _ transform: (Element) throws(E) -> T
   ) throws(E) -> [T] {

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1093,7 +1093,7 @@ extension ${Self} {
 
   // Fast-path for conversion when the source is representable as int,
   // falling back on the generic _convert operation otherwise.
-  @_alwaysEmitIntoClient @inline(never)
+  @export(implementation) @inline(never)
   public init?<Source: BinaryInteger>(exactly value: Source) {
     if value.bitWidth <= ${word_bits} {
       // If the source is small enough to fit in a word, we can use the LLVM

--- a/stdlib/public/core/FullyInhabited.swift
+++ b/stdlib/public/core/FullyInhabited.swift
@@ -50,7 +50,7 @@ public typealias FullyInhabited = ConvertibleToBytes & ConvertibleFromBytes
 ///   - original: The instance to cast to `type`.
 ///   - type: The type to cast `original` to.
 /// - Returns: A new instance of type `U`, cast from `original`.
-@_alwaysEmitIntoClient
+@export(implementation)
 @_transparent
 public func bitCast<T, U>(
   _ original: T, to type: U.Type

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -60,7 +60,7 @@ internal struct _HashTable {
   /// bitset, then its out-of-bounds bits are guaranteed to be all set. These
   /// filler bits are there to speed up finding holes -- they don't correspond
   /// to occupied buckets in the table.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal var bitset: _UnsafeBitset {
     unsafe _UnsafeBitset(words: words, wordCount: wordCount)
   }

--- a/stdlib/public/core/Indices.swift
+++ b/stdlib/public/core/Indices.swift
@@ -82,19 +82,19 @@ extension DefaultIndices: Collection {
     return self
   }
   
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func index(_ i: Index, offsetBy distance: Int) -> Index {
     return _elements.index(i, offsetBy: distance)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func index(
     _ i: Index, offsetBy distance: Int, limitedBy limit: Index
   ) -> Index? {
     return _elements.index(i, offsetBy: distance, limitedBy: limit)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func distance(from start: Index, to end: Index) -> Int {
     return _elements.distance(from: start, to: end)
   }

--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -120,7 +120,7 @@ extension InlineArray: @unchecked Sendable where Element: Sendable & ~Copyable {
 extension InlineArray where Element: ~Copyable {
   /// Returns a pointer to the first element in the array.
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal var _address: UnsafePointer<Element> {
 #if $AddressOfProperty2
@@ -132,7 +132,7 @@ extension InlineArray where Element: ~Copyable {
 
   /// Returns a buffer pointer over the entire array.
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal var _buffer: UnsafeBufferPointer<Element> {
     unsafe UnsafeBufferPointer<Element>(start: _address, count: count)
@@ -144,7 +144,7 @@ extension InlineArray where Element: ~Copyable {
   /// Use this when the value of the pointer could potentially be directly used
   /// by users (e.g. through the use of span or the unchecked subscript).
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal var _protectedAddress: UnsafePointer<Element> {
 #if $AddressOfProperty2
@@ -160,7 +160,7 @@ extension InlineArray where Element: ~Copyable {
   /// Use this when the value of the pointer could potentially be directly used
   /// by users (e.g. through the use of span or the unchecked subscript).
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal var _protectedBuffer: UnsafeBufferPointer<Element> {
     unsafe UnsafeBufferPointer<Element>(start: _protectedAddress, count: count)
@@ -168,7 +168,7 @@ extension InlineArray where Element: ~Copyable {
 
   /// Returns a mutable pointer to the first element in the array.
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal var _mutableAddress: UnsafeMutablePointer<Element> {
     mutating get {
@@ -182,7 +182,7 @@ extension InlineArray where Element: ~Copyable {
 
   /// Returns a mutable buffer pointer over the entire array.
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal var _mutableBuffer: UnsafeMutableBufferPointer<Element> {
     mutating get {
@@ -199,7 +199,7 @@ extension InlineArray where Element: ~Copyable {
   /// Use this when the value of the pointer could potentially be directly used
   /// by users (e.g. through the use of span or the unchecked subscript).
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal var _protectedMutableAddress: UnsafeMutablePointer<Element> {
     mutating get {
@@ -217,7 +217,7 @@ extension InlineArray where Element: ~Copyable {
   /// Use this when the value of the pointer could potentially be directly used
   /// by users (e.g. through the use of span or the unchecked subscript).
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal var _protectedMutableBuffer: UnsafeMutableBufferPointer<Element> {
     mutating get {
@@ -232,7 +232,7 @@ extension InlineArray where Element: ~Copyable {
   /// instance, to a mutable buffer suitable for initialization.
   @available(SwiftStdlib 6.2, *)
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal static func _initializationBuffer(
     start: Builtin.RawPointer
@@ -267,7 +267,7 @@ extension InlineArray where Element: ~Copyable {
   /// - Parameter body: A closure that returns an owned `Element` to emplace at
   ///   the passed in index.
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init<E: Error>(_ body: (Index) throws(E) -> Element) throws(E) {
     _storage = try Builtin.emplace { (rawPtr) throws(E) -> () in
       let buffer = unsafe Self._initializationBuffer(start: rawPtr)
@@ -309,7 +309,7 @@ extension InlineArray where Element: ~Copyable {
   ///     preceding element, and returns an owned `Element` instance to emplace
   ///     into the array.
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init<E: Error>(
     first: consuming Element,
     next: (borrowing Element) throws(E) -> Element
@@ -350,7 +350,7 @@ extension InlineArray where Element: ~Copyable {
   }
 
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init<E: Error>(
     initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
   ) throws(E) {
@@ -373,7 +373,7 @@ extension InlineArray where Element: Copyable {
   ///
   /// - Parameter value: The instance to initialize this array with.
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(repeating value: Element) {
     _storage = Builtin.emplace {
       let buffer = unsafe Self._initializationBuffer(start: $0)
@@ -405,7 +405,7 @@ extension InlineArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_semantics("fixed_storage.get_count")
   @inline(__always)
   public var count: Int {
@@ -416,7 +416,7 @@ extension InlineArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public var isEmpty: Bool {
     count == 0
@@ -428,7 +428,7 @@ extension InlineArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public var startIndex: Index {
     0
@@ -441,7 +441,7 @@ extension InlineArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public var endIndex: Index {
     count
@@ -451,7 +451,7 @@ extension InlineArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public var indices: Range<Index> {
     unsafe Range(_uncheckedBounds: (0, count))
@@ -465,7 +465,7 @@ extension InlineArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public borrowing func index(after i: Index) -> Index {
     i &+ 1
@@ -479,13 +479,13 @@ extension InlineArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public borrowing func index(before i: Index) -> Index {
     i &- 1
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_semantics("fixed_storage.check_index")
   @inline(__always)
   internal func _checkIndex(_ i: Index) {
@@ -500,7 +500,7 @@ extension InlineArray where Element: ~Copyable {
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.2, *)
   @_addressableSelf
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public subscript(_ i: Index) -> Element {
     @_transparent
     borrow {
@@ -526,7 +526,7 @@ extension InlineArray where Element: ~Copyable {
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.2, *)
   @_addressableSelf
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @unsafe
   public subscript(unchecked i: Index) -> Element {
     @_transparent
@@ -560,7 +560,7 @@ extension InlineArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func swapAt(
     _ i: Index,
     _ j: Index
@@ -591,7 +591,7 @@ extension InlineArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var span: Span<Element> {
     @_lifetime(borrow self)
     @_transparent
@@ -611,7 +611,7 @@ extension InlineArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var mutableSpan: MutableSpan<Element> {
     @_lifetime(&self)
     @_transparent

--- a/stdlib/public/core/Instant.swift
+++ b/stdlib/public/core/Instant.swift
@@ -21,32 +21,27 @@ public protocol InstantProtocol<Duration>: Comparable, Hashable, Sendable {
 /*
 disabled for now - this perturbs operator resolution
 extension InstantProtocol {
-  @_alwaysEmitIntoClient
-  @inlinable
+  @export(implementation)
   public static func + (_ lhs: Self, _ rhs: Duration) -> Self {
     lhs.advanced(by: rhs)
   }
 
-  @_alwaysEmitIntoClient
-  @inlinable
+  @export(implementation)
   public static func += (_ lhs: inout Self, _ rhs: Duration) {
     lhs = lhs.advanced(by: rhs)
   }
 
-  @_alwaysEmitIntoClient
-  @inlinable
+  @export(implementation)
   public static func - (_ lhs: Self, _ rhs: Duration) -> Self {
     lhs.advanced(by: .zero - rhs)
   }
 
-  @_alwaysEmitIntoClient
-  @inlinable
+  @export(implementation)
   public static func -= (_ lhs: inout Self, _ rhs: Duration) {
     lhs = lhs.advanced(by: .zero - rhs)
   }
 
-  @_alwaysEmitIntoClient
-  @inlinable
+  @export(implementation)
   public static func - (_ lhs: Self, _ rhs: Self) -> Duration {
     rhs.duration(to: lhs)
   }

--- a/stdlib/public/core/Int128.swift
+++ b/stdlib/public/core/Int128.swift
@@ -532,22 +532,22 @@ extension Int128 {
   // IMPORTANT: The following four apparently unnecessary overloads of
   // comparison operations are necessary for literal comparands to be
   // inferred as the desired type.
-  @_transparent @_alwaysEmitIntoClient
+  @_transparent @export(implementation)
   public static func != (lhs: Self, rhs: Self) -> Bool {
     return !(lhs == rhs)
   }
 
-  @_transparent @_alwaysEmitIntoClient
+  @_transparent @export(implementation)
   public static func <= (lhs: Self, rhs: Self) -> Bool {
     return !(rhs < lhs)
   }
 
-  @_transparent @_alwaysEmitIntoClient
+  @_transparent @export(implementation)
   public static func >= (lhs: Self, rhs: Self) -> Bool {
     return !(lhs < rhs)
   }
 
-  @_transparent @_alwaysEmitIntoClient
+  @_transparent @export(implementation)
   public static func > (lhs: Self, rhs: Self) -> Bool {
     return rhs < lhs
   }

--- a/stdlib/public/core/IntegerParsing.swift
+++ b/stdlib/public/core/IntegerParsing.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_alwaysEmitIntoClient
+@export(implementation)
 internal func _parseIntegerDigits<Result: FixedWidthInteger>(
   ascii codeUnits: UnsafeBufferPointer<UInt8>, radix: Int, isNegative: Bool
 ) -> Result? {
@@ -56,7 +56,7 @@ internal func _parseIntegerDigits<Result: FixedWidthInteger>(
   return result
 }
 
-@_alwaysEmitIntoClient
+@export(implementation)
 @inline(__always)
 internal func _parseInteger<Result: FixedWidthInteger>(
   ascii codeUnits: UnsafeBufferPointer<UInt8>, radix: Int
@@ -80,7 +80,7 @@ internal func _parseInteger<Result: FixedWidthInteger>(
   return unsafe _parseIntegerDigits(ascii: codeUnits, radix: radix, isNegative: false)
 }
 
-@_alwaysEmitIntoClient
+@export(implementation)
 @inline(never)
 internal func _parseInteger<S: StringProtocol, Result: FixedWidthInteger>(
   ascii text: S, radix: Int

--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -691,7 +691,7 @@ extension ${Self} {
   // to get literal expression comparands typed Int in generic contexts,
   // but there's also a pretty straightforward workaround (adding an
   // explicit type).
-  @_transparent @_alwaysEmitIntoClient
+  @_transparent @export(implementation)
   public static func !=(lhs: ${Self}, rhs: ${Self}) -> Bool {
     return !(lhs == rhs)
   }

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -127,12 +127,12 @@ public protocol AdditiveArithmetic: Equatable {
 }
 
 extension AdditiveArithmetic {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func +=(lhs: inout Self, rhs: Self) {
     lhs = lhs + rhs
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func -=(lhs: inout Self, rhs: Self) {
     lhs = lhs - rhs
   }
@@ -2584,7 +2584,7 @@ extension FixedWidthInteger {
   // surely be improved on even for Int64, but that is mostly an optimization
   // problem; the basic algorithm here gives the compiler all the information
   // that it needs to generate efficient code.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func multipliedFullWidth(by other: Self) -> (high: Self, low: Magnitude) {
     // We define a utility function for splitting an integer into high and low
     // halves. Note that the low part is always unsigned, while the high part
@@ -3154,7 +3154,7 @@ extension FixedWidthInteger {
     }
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal static func _truncatingInit<T: BinaryInteger>(_ source: T) -> Self {
     let neg = source < (0 as T)
     var result: Self = neg ? ~0 : 0
@@ -3457,7 +3457,7 @@ extension UnsignedInteger where Self: FixedWidthInteger {
   @_transparent
   public static var min: Self { return 0 }
   
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func dividingFullWidth(
     _ dividend: (high: Self, low: Magnitude)
   ) -> (quotient: Self, remainder: Self) {
@@ -3686,7 +3686,7 @@ extension SignedInteger where Self: FixedWidthInteger {
     return self % other == 0
   }
   
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func dividingFullWidth(
     _ dividend: (high: Self, low: Magnitude)
   ) -> (quotient: Self, remainder: Self) {

--- a/stdlib/public/core/KeyValuePairs.swift
+++ b/stdlib/public/core/KeyValuePairs.swift
@@ -134,7 +134,7 @@ extension KeyValuePairs {
   ///
   /// - Complexity: O(1)
   @available(SwiftCompatibilitySpan 5.0, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var span: Span<Element> {
     @_lifetime(borrow self)
     get {

--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -14,7 +14,7 @@
 ///
 /// - Parameters:
 ///   - x: An instance to preserve until this function returns.
-@_alwaysEmitIntoClient
+@export(implementation)
 @_transparent
 public func extendLifetime<T: ~Copyable & ~Escapable>(
   _ x: borrowing T
@@ -31,7 +31,7 @@ public func extendLifetime<T: ~Copyable & ~Escapable>(
 ///     extended. If `body` has a return value, that value is also used as the
 ///     return value for the `withExtendedLifetime(_:_:)` method.
 /// - Returns: The return value, if any, of the `body` closure parameter.
-@_alwaysEmitIntoClient
+@export(implementation)
 @inline(always)
 public func withExtendedLifetime<
   T: ~Copyable & ~Escapable,
@@ -65,7 +65,7 @@ internal func __abi_withExtendedLifetime<T, Result>(
 ///     extended. If `body` has a return value, that value is also used as the
 ///     return value for the `withExtendedLifetime(_:_:)` method.
 /// - Returns: The return value, if any, of the `body` closure parameter.
-@_alwaysEmitIntoClient
+@export(implementation)
 @inline(always)
 public func withExtendedLifetime<
   T: ~Copyable & ~Escapable,
@@ -119,7 +119,7 @@ public func _fixLifetime<T: ~Copyable & ~Escapable>(_ x: borrowing T) {
 ///     The pointer argument is valid only for the duration of the function's
 ///     execution.
 /// - Returns: The return value, if any, of the `body` closure.
-@_alwaysEmitIntoClient
+@export(implementation)
 @inline(always)
 @safe
 public func withUnsafeMutablePointer<
@@ -145,7 +145,7 @@ internal func __abi_se0413_withUnsafeMutablePointer<T, Result>(
 ///
 /// This function is similar to `withUnsafeMutablePointer`, except that it
 /// doesn't trigger stack protection for the pointer.
-@_alwaysEmitIntoClient
+@export(implementation)
 @inline(always)
 public func _withUnprotectedUnsafeMutablePointer<
   T: ~Copyable, E: Error, Result: ~Copyable
@@ -181,7 +181,7 @@ public func _withUnprotectedUnsafeMutablePointer<
 ///     type. If you need to mutate the argument through the pointer, use
 ///     `withUnsafeMutablePointer(to:_:)` instead.
 /// - Returns: The return value, if any, of the `body` closure.
-@_alwaysEmitIntoClient
+@export(implementation)
 @inline(always)
 @safe
 public func withUnsafePointer<T: ~Copyable, E: Error, Result: ~Copyable>(
@@ -231,7 +231,7 @@ internal func __abi_withUnsafePointer<T, Result>(
 ///     type. If you need to mutate the argument through the pointer, use
 ///     `withUnsafeMutablePointer(to:_:)` instead.
 /// - Returns: The return value, if any, of the `body` closure.
-@_alwaysEmitIntoClient
+@export(implementation)
 @inline(always)
 @safe
 public func withUnsafePointer<T: ~Copyable, E: Error, Result: ~Copyable>(
@@ -259,7 +259,7 @@ internal func __abi_se0413_withUnsafePointer<T, Result>(
 ///
 /// This function is similar to `withUnsafePointer`, except that it
 /// doesn't trigger stack protection for the pointer.
-@_alwaysEmitIntoClient
+@export(implementation)
 @inline(always)
 public func _withUnprotectedUnsafePointer<
   T: ~Copyable, E: Error, Result: ~Copyable
@@ -278,7 +278,7 @@ public func _withUnprotectedUnsafePointer<
 ///
 /// This function is similar to `withUnsafePointer`, except that it
 /// doesn't trigger stack protection for the pointer.
-@_alwaysEmitIntoClient
+@export(implementation)
 @inline(always)
 public func _withUnprotectedUnsafePointer<
   T: ~Copyable, E: Error, Result: ~Copyable
@@ -290,8 +290,7 @@ public func _withUnprotectedUnsafePointer<
 }
 
 @available(*, deprecated, message: "Use the copy operator")
-@_alwaysEmitIntoClient
-@inlinable
+@export(implementation)
 @_transparent
 @_semantics("lifetimemanagement.copy")
 public func _copy<T>(_ value: T) -> T {
@@ -303,7 +302,7 @@ public func _copy<T>(_ value: T) -> T {
 /// borrow scope of the `source` argument.
 @unsafe
 @_unsafeNonescapableResult
-@_alwaysEmitIntoClient
+@export(implementation)
 @_transparent
 @_lifetime(borrow source)
 public func _overrideLifetime<
@@ -319,7 +318,7 @@ public func _overrideLifetime<
 /// the `source` argument.
 @unsafe
 @_unsafeNonescapableResult
-@_alwaysEmitIntoClient
+@export(implementation)
 @_transparent
 @_lifetime(copy source)
 public func _overrideLifetime<
@@ -335,7 +334,7 @@ public func _overrideLifetime<
 /// on the caller's exclusive borrow scope of the `source` argument.
 @unsafe
 @_unsafeNonescapableResult
-@_alwaysEmitIntoClient
+@export(implementation)
 @_transparent
 @_lifetime(&source)
 public func _overrideLifetime<
@@ -352,7 +351,7 @@ public func _overrideLifetime<
 /// on the caller's borrow scope of the `source` argument.
 @unsafe
 @_unsafeNonescapableResult
-@_alwaysEmitIntoClient
+@export(implementation)
 @_transparent
 @_lifetime(dependent: borrow source)
 public func _overrideLifetime<

--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -137,7 +137,7 @@ extension ManagedBuffer where Element: ~Copyable {
   ///   call to `body`. The caller is responsible for ensuring that
   ///   the buffer is not being accessed elsewhere while performing
   ///   this call.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   @unsafe
   public final func withUnsafeMutablePointerToHeader<E: Error, R: ~Copyable>(
@@ -153,7 +153,7 @@ extension ManagedBuffer where Element: ~Copyable {
   ///   call to `body`. The caller is responsible for ensuring that
   ///   the buffer is not being accessed elsewhere while performing
   ///   this call.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   @unsafe
   public final func withUnsafeMutablePointerToElements<E: Error, R: ~Copyable>(
@@ -169,7 +169,7 @@ extension ManagedBuffer where Element: ~Copyable {
   ///   call to `body`. The caller is responsible for ensuring that
   ///   the buffer is not being accessed elsewhere while performing
   ///   this call.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   @unsafe
   public final func withUnsafeMutablePointers<E: Error, R: ~Copyable>(
@@ -442,7 +442,7 @@ extension ManagedBufferPointer where Element: ~Copyable {
   /// - Note: This pointer is valid only for the duration of the call to
   /// `body`. The caller is responsible for ensuring that the buffer is not
   /// being accessed anyone else while performing this call.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @unsafe
   public func withUnsafeMutablePointerToHeader<E: Error, R: ~Copyable>(
     _ body: (UnsafeMutablePointer<Header>) throws(E) -> R
@@ -456,7 +456,7 @@ extension ManagedBufferPointer where Element: ~Copyable {
   /// - Note: This pointer is valid only for the duration of the
   ///   call to `body`. The caller is responsible for ensuring that the
   ///   buffer is not being accessed anyone else while performing this call.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @unsafe
   public func withUnsafeMutablePointerToElements<E: Error, R: ~Copyable>(
     _ body: (UnsafeMutablePointer<Element>) throws(E) -> R
@@ -471,7 +471,7 @@ extension ManagedBufferPointer where Element: ~Copyable {
   ///   call to `body`. The caller is responsible for ensuring that
   ///   the buffer is not being accessed elsewhere while performing
   ///   this call.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @unsafe
   public func withUnsafeMutablePointers<E: Error, R: ~Copyable>(
     _ body: (

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -166,7 +166,7 @@ internal func _getTypeByMangledNameInContextQuiet(
   -> Any.Type?
 
 /// Prevents performance diagnostics in the passed closure.
-@_alwaysEmitIntoClient
+@export(implementation)
 @_semantics("no_performance_analysis")
 @unsafe
 public func _unsafePerformance<T>(_ c: () -> T) -> T {
@@ -176,8 +176,7 @@ public func _unsafePerformance<T>(_ c: () -> T) -> T {
 // Helper function that exploits a bug in rethrows checking to
 // allow us to call rethrows functions from generic typed-throws functions
 // and vice-versa.
-@usableFromInline
-@_alwaysEmitIntoClient
+@export(implementation)
 @inline(__always)
 func _rethrowsViaClosure(_ fn: () throws -> ()) rethrows {
   try fn()

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -301,7 +301,7 @@ extension MutableCollection {
   // runtime the generic implementation would call itself
   // in an infinite recursion due to the absence of a better option.
   @available(*, unavailable)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public subscript(bounds: Range<Index>) -> SubSequence {
     get { fatalError() }
     set { fatalError() }
@@ -353,8 +353,7 @@ extension MutableCollection where SubSequence == Slice<Self> {
   ///   the range must be valid indices of the collection.
   ///
   /// - Complexity: O(1)
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public subscript(bounds: Range<Index>) -> Slice<Self> {
     get {
       _failEarlyRangeCheck(bounds, bounds: startIndex..<endIndex)
@@ -543,7 +542,7 @@ public func swap<T: ~Copyable>(_ a: inout T, _ b: inout T) {
 ///   - item: A mutable binding.
 ///   - newValue: The new value of `item`.
 /// - Returns: The original value of `item`.
-@_alwaysEmitIntoClient
+@export(implementation)
 public func exchange<T: ~Copyable>(
   _ item: inout T,
   with newValue: consuming T

--- a/stdlib/public/core/MutableRef.swift
+++ b/stdlib/public/core/MutableRef.swift
@@ -22,7 +22,7 @@ public struct MutableRef<Value: ~Copyable>: ~Copyable, ~Escapable {
   /// creates a mutable reference to that value preventing writes to the
   /// original value while this mutable reference is still active.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&value)
   @_transparent
   public init(_ value: inout Value) {
@@ -39,7 +39,7 @@ public struct MutableRef<Value: ~Copyable>: ~Copyable, ~Escapable {
   ///                    lifetime is based on.
   @available(SwiftStdlib 6.4, *)
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&owner)
   @_transparent
   public init<Owner: ~Copyable & ~Escapable>(
@@ -58,7 +58,7 @@ extension MutableRef where Value: ~Copyable {
   /// Dereferences the mutable reference allowing for in-place reads and writes
   /// to the underlying value.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public var value: Value {
     @_unsafeSelfDependentResult

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -189,7 +189,7 @@ extension _NativeDictionary { // Low-level lookup operations
 }
 
 extension _NativeDictionary { // ensureUnique
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(never)
   internal mutating func _copyOrMoveAndResize(
     capacity: Int,
@@ -501,7 +501,7 @@ extension _NativeDictionary { // Insertions
   /// Insert a new element into uniquely held storage, replacing an existing
   /// value (if any).  Storage must be uniquely referenced with adequate
   /// capacity.
-  @_alwaysEmitIntoClient @inlinable // Introduced in 5.1
+  @export(implementation) // Introduced in 5.1
   internal mutating func _unsafeUpdate(
     key: __owned Key,
     value: __owned Value
@@ -620,7 +620,7 @@ extension _NativeDictionary {
     unsafe (_values + b.offset).initialize(to: value)
   }
   
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func extractDictionary(
     using bitset: _UnsafeBitset, 
     count: Int
@@ -755,7 +755,7 @@ extension _NativeDictionary { // Deletion
 }
 
 extension _NativeDictionary { // High-level operations
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func mapValues<T, E: Error>(
     _ transform: (Value) throws(E) -> T
   ) throws(E) -> _NativeDictionary<Key, T> {
@@ -791,7 +791,7 @@ extension _NativeDictionary { // High-level operations
   }
 #endif
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func merge<S: Sequence, E: Error>(
     _ keysAndValues: __owned S,
     isUnique: Bool,
@@ -810,7 +810,7 @@ extension _NativeDictionary { // High-level operations
     }
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func merge<S: Sequence>(
     trappingOnDuplicates keysAndValues: __owned S,
   ) where S.Element == (Key, Value) {
@@ -852,7 +852,7 @@ extension _NativeDictionary { // High-level operations
   }
 #endif
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   internal init<S: Sequence, E: Error>(
     grouping values: __owned S,
@@ -890,7 +890,7 @@ extension _NativeDictionary { // High-level operations
   }
 #endif
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func filter<E: Error>(
     _ isIncluded: (Element) throws(E) -> Bool
   ) throws(E) -> _NativeDictionary<Key, Value> {

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -81,7 +81,7 @@ extension _NativeSet { // Primitive fields
     }
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   internal var bucketCount: Int {
     unsafe _assumeNonNegative(_storage._bucketCount)
@@ -135,7 +135,7 @@ extension _NativeSet { // Low-level unchecked operations
     unsafe (_elements + bucket.offset).initialize(to: element)
   }
 
-  @_alwaysEmitIntoClient @inlinable // Introduced in 5.1
+  @export(implementation) // Introduced in 5.1
   @inline(__always)
   @unsafe
   internal func uncheckedAssign(
@@ -475,7 +475,7 @@ extension _NativeSet { // Insertions
 
   /// Insert an element into uniquely held storage, replacing an existing value
   /// (if any).  Storage must be uniquely referenced with adequate capacity.
-  @_alwaysEmitIntoClient @inlinable // Introduced in 5.1
+  @export(implementation) // Introduced in 5.1
   internal mutating func _unsafeUpdate(
     with element: __owned Element
   ) {
@@ -616,7 +616,7 @@ extension _NativeSet.Iterator: IteratorProtocol {
 }
 
 extension _NativeSet {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func isSubset<S: Sequence>(of possibleSuperset: S) -> Bool
   where S.Element == Element {
     unsafe _UnsafeBitset.withTemporaryBitset(capacity: self.bucketCount) { seen in
@@ -637,7 +637,7 @@ extension _NativeSet {
     }
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func isStrictSubset<S: Sequence>(of possibleSuperset: S) -> Bool
   where S.Element == Element {
     unsafe _UnsafeBitset.withTemporaryBitset(capacity: self.bucketCount) { seen in
@@ -665,7 +665,7 @@ extension _NativeSet {
     }
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func isStrictSuperset<S: Sequence>(of possibleSubset: S) -> Bool
   where S.Element == Element {
     unsafe _UnsafeBitset.withTemporaryBitset(capacity: self.bucketCount) { seen in
@@ -686,7 +686,7 @@ extension _NativeSet {
     }
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal __consuming func extractSubset(
     using bitset: _UnsafeBitset,
     count: Int
@@ -705,7 +705,7 @@ extension _NativeSet {
     return result
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal __consuming func subtracting<S: Sequence>(_ other: S) -> _NativeSet
   where S.Element == Element {
     guard count > 0 else { return _NativeSet() }
@@ -747,7 +747,7 @@ extension _NativeSet {
     }
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal consuming func filter<E: Error>(
     _ isIncluded: (Element) throws(E) -> Bool
   ) throws(E) -> _NativeSet<Element> {
@@ -764,7 +764,7 @@ extension _NativeSet {
     }
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal __consuming func intersection(
     _ other: _NativeSet<Element>
   ) -> _NativeSet<Element> {
@@ -797,7 +797,7 @@ extension _NativeSet {
     }
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal __consuming func genericIntersection<S: Sequence>(
     _ other: S
   ) -> _NativeSet<Element>

--- a/stdlib/public/core/ObjectIdentifier.swift
+++ b/stdlib/public/core/ObjectIdentifier.swift
@@ -62,7 +62,7 @@ public struct ObjectIdentifier: Sendable {
   ///
   /// - Parameters:
   ///   - x: A metatype.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(_ x: any (~Copyable & ~Escapable).Type) {
     self._value = unsafe unsafeBitCast(x, to: Builtin.RawPointer.self)
   }
@@ -128,7 +128,7 @@ extension ObjectIdentifier: Hashable {
     hasher.combine(Int(Builtin.ptrtoint_Word(_value)))
   }
 
-  @_alwaysEmitIntoClient // For back deployment
+  @export(implementation) // For back deployment
   public func _rawHashValue(seed: Int) -> Int {
     Int(Builtin.ptrtoint_Word(_value))._rawHashValue(seed: seed)
   }

--- a/stdlib/public/core/OptionSet.swift
+++ b/stdlib/public/core/OptionSet.swift
@@ -376,7 +376,7 @@ extension OptionSet where RawValue: FixedWidthInteger {
 }
 
 extension OptionSet where RawValue: FixedWidthInteger, Element == Self {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @discardableResult
   public mutating func insert(
     _ newMember: Element

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -194,7 +194,7 @@ extension Optional {
   ///   of the instance.
   /// - Returns: The result of the given closure. If this instance is `nil`,
   ///   returns `nil`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func map<E: Error, U: ~Copyable>(
     _ transform: (Wrapped) throws(E) -> U
   ) throws(E) -> U? {
@@ -222,7 +222,7 @@ extension Optional {
 
 extension Optional where Wrapped: ~Copyable {
   // FIXME(NCG): Make this public.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public consuming func _consumingMap<U: ~Copyable, E: Error>(
     _ transform: (consuming Wrapped) throws(E) -> U
   ) throws(E) -> U? {
@@ -235,7 +235,7 @@ extension Optional where Wrapped: ~Copyable {
   }
 
   // FIXME(NCG): Make this public.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public borrowing func _borrowingMap<U: ~Copyable, E: Error>(
     _ transform: (borrowing Wrapped) throws(E) -> U
   ) throws(E) -> U? {
@@ -268,7 +268,7 @@ extension Optional {
   ///   of the instance.
   /// - Returns: The result of the given closure. If this instance is `nil`,
   ///   returns `nil`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func flatMap<E: Error, U: ~Copyable>(
     _ transform: (Wrapped) throws(E) -> U?
   ) throws(E) -> U? {
@@ -296,7 +296,7 @@ extension Optional {
 
 extension Optional where Wrapped: ~Copyable {
   // FIXME(NCG): Make this public.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public consuming func _consumingFlatMap<U: ~Copyable, E: Error>(
     _ transform: (consuming Wrapped) throws(E) -> U?
   ) throws(E) -> U? {
@@ -309,7 +309,7 @@ extension Optional where Wrapped: ~Copyable {
   }
 
   // FIXME(NCG): Make this public.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func _borrowingFlatMap<U: ~Copyable, E: Error>(
     _ transform: (borrowing Wrapped) throws(E) -> U?
   ) throws(E) -> U? {
@@ -366,7 +366,7 @@ extension Optional where Wrapped: ~Escapable {
 
 extension Optional where Wrapped: ~Copyable & ~Escapable {
   // FIXME(NCG): Do we want this? It seems like we do. Make this public.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   public consuming func _consumingUnsafelyUnwrap() -> Wrapped {
     switch consume self {
@@ -402,7 +402,7 @@ extension Optional where Wrapped: ~Copyable & ~Escapable {
   ///
   /// This version is for internal stdlib use; it avoids any checking
   /// overhead for users, even in Debug builds.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   internal consuming func _consumingUncheckedUnwrapped() -> Wrapped {
     if let x = self {
@@ -415,7 +415,7 @@ extension Optional where Wrapped: ~Copyable & ~Escapable {
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Optional where Wrapped: ~Copyable & Escapable {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_addressableSelf
   @_lifetime(borrow self)
   public func _span() -> Span<Wrapped> {
@@ -445,7 +445,7 @@ extension Optional where Wrapped: ~Copyable & ~Escapable {
   ///
   /// - Returns: The wrapped value being stored in this instance. If this
   ///   instance is `nil`, returns `nil`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   public mutating func take() -> Self {
     let result = consume self
@@ -831,7 +831,7 @@ extension Optional where Wrapped: ~Copyable & ~Escapable {
 ///   - defaultValue: A value to use as a default. `defaultValue` is the same
 ///     type as the `Wrapped` type of `optional`.
 @_transparent
-@_alwaysEmitIntoClient
+@export(implementation)
 public func ?? <T: ~Copyable>(
   optional: consuming T?,
   defaultValue: @autoclosure () throws -> T // FIXME: typed throws
@@ -907,7 +907,7 @@ internal func _legacy_abi_optionalNilCoalescingOperator <T>(
 ///   - defaultValue: A value to use as a default. `defaultValue` and
 ///     `optional` have the same type.
 @_transparent
-@_alwaysEmitIntoClient
+@export(implementation)
 public func ?? <T: ~Copyable>(
   optional: consuming T?,
   defaultValue: @autoclosure () throws -> T? // FIXME: typed throws

--- a/stdlib/public/core/Pointer.swift
+++ b/stdlib/public/core/Pointer.swift
@@ -136,8 +136,7 @@ extension _Pointer /*: Equatable */ {
   ///   - rhs: Another pointer.
   /// - Returns: `true` if `lhs` and `rhs` reference the same memory address;
   ///            otherwise, `false`.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func == <Other: _Pointer>(lhs: Self, rhs: Other) -> Bool {
     return Bool(Builtin.cmp_eq_RawPointer(lhs._rawValue, rhs._rawValue))
   }
@@ -150,8 +149,7 @@ extension _Pointer /*: Equatable */ {
   ///   - rhs: Another pointer.
   /// - Returns: `true` if `lhs` and `rhs` reference different memory addresses;
   ///            otherwise, `false`.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func != <Other: _Pointer>(lhs: Self, rhs: Other) -> Bool {
     return Bool(Builtin.cmp_ne_RawPointer(lhs._rawValue, rhs._rawValue))
   }
@@ -181,8 +179,7 @@ extension _Pointer /*: Comparable */ {
   ///   - rhs: Another pointer.
   /// - Returns: `true` if `lhs` references a memory address
   ///            earlier than `rhs`; otherwise, `false`.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func < <Other: _Pointer>(lhs: Self, rhs: Other) -> Bool {
     return Bool(Builtin.cmp_ult_RawPointer(lhs._rawValue, rhs._rawValue))
   }
@@ -195,8 +192,7 @@ extension _Pointer /*: Comparable */ {
   ///   - rhs: Another pointer.
   /// - Returns: `true` if `lhs` references a memory address
   ///            earlier than or the same as `rhs`; otherwise, `false`.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func <= <Other: _Pointer>(lhs: Self, rhs: Other) -> Bool {
     return Bool(Builtin.cmp_ule_RawPointer(lhs._rawValue, rhs._rawValue))
   }
@@ -209,8 +205,7 @@ extension _Pointer /*: Comparable */ {
   ///   - rhs: Another pointer.
   /// - Returns: `true` if `lhs` references a memory address
   ///            later than `rhs`; otherwise, `false`.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func > <Other: _Pointer>(lhs: Self, rhs: Other) -> Bool {
     return Bool(Builtin.cmp_ugt_RawPointer(lhs._rawValue, rhs._rawValue))
   }
@@ -223,8 +218,7 @@ extension _Pointer /*: Comparable */ {
   ///   - rhs: Another pointer.
   /// - Returns: `true` if `lhs` references a memory address
   ///            later than or the same as `rhs`; otherwise, `false`.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func >= <Other: _Pointer>(lhs: Self, rhs: Other) -> Bool {
     return Bool(Builtin.cmp_uge_RawPointer(lhs._rawValue, rhs._rawValue))
   }
@@ -311,7 +305,7 @@ extension _Pointer /*: Strideable*/ {
   /// - Parameter i: The index of the element to project.
   /// - Returns: A pointer to the element at position `i`.
   @_transparent
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func project(_ i: Int) -> Self {
 #if $BuiltinGepProjection
     return Self(Builtin.gepProjection_Word(

--- a/stdlib/public/core/Random.swift
+++ b/stdlib/public/core/Random.swift
@@ -71,7 +71,7 @@ extension RandomNumberGenerator {
   // unsigned integer will be used, recursing infinitely and probably blowing
   // the stack.
   @available(*, unavailable)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func next() -> UInt64 { fatalError() }
   
   /// Returns a value from a uniform, independent distribution of binary data.

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -161,7 +161,7 @@ public struct Range<Bound: Comparable> {
   // This works around _debugPrecondition() impacting the performance of
   // optimized code. (rdar://72246338)
   @unsafe
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   internal init(_uncheckedBounds bounds: (lower: Bound, upper: Bound)) {
     self.lowerBound = bounds.lower
     self.upperBound = bounds.upper
@@ -1074,7 +1074,7 @@ extension Range {
   ///   range; otherwise, `false`.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public func contains(_ other: Range<Bound>) -> Bool {
     other.isEmpty ||
@@ -1102,7 +1102,7 @@ extension Range {
   ///   otherwise, `false`.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public func contains(_ other: ClosedRange<Bound>) -> Bool {
     lowerBound <= other.lowerBound && upperBound > other.upperBound
@@ -1126,7 +1126,7 @@ extension PartialRangeFrom: Sendable where Bound: Sendable { }
 extension PartialRangeFrom.Iterator: Sendable where Bound: Sendable { }
 
 extension Range where Bound == String.Index {
-  @_alwaysEmitIntoClient // Swift 5.7
+  @export(implementation) // Swift 5.7
   internal var _encodedOffsetRange: Range<Int> {
     _internalInvariant(
       (lowerBound._canBeUTF8 && upperBound._canBeUTF8)

--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -763,7 +763,7 @@ extension RangeReplaceableCollection {
   // `RangeExpression` would call itself in an infinite recursion
   // due to the absence of a better option.
   @available(*, unavailable)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func replaceSubrange<C>(
     _ subrange: Range<Index>,
     with newElements: C
@@ -1111,7 +1111,7 @@ extension RangeReplaceableCollection {
   /// - Returns: A collection of the elements that `isIncluded` allowed.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(swift, introduced: 4.0)
   public consuming func filter<E: Error>(
     _ isIncluded: (Element) throws(E) -> Bool

--- a/stdlib/public/core/Ref.swift
+++ b/stdlib/public/core/Ref.swift
@@ -21,7 +21,7 @@ public struct Ref<Value: ~Copyable>: Copyable, ~Escapable {
   /// creates a constant reference to that value preventing writes on the 
   /// original value while this reference is still active.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow value)
   @_transparent
   public init(_ value: borrowing Value) {
@@ -38,7 +38,7 @@ public struct Ref<Value: ~Copyable>: Copyable, ~Escapable {
   ///                    lifetime is based on.
   @available(SwiftStdlib 6.4, *)
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow owner)
   @_transparent
   public init<Owner: ~Copyable & ~Escapable>(
@@ -60,7 +60,7 @@ extension Ref where Value: ~Copyable {
   /// Dereferences the constant reference allowing for in-place reads to the
   /// underlying value.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public var value: Value {
     borrow {

--- a/stdlib/public/core/Result.swift
+++ b/stdlib/public/core/Result.swift
@@ -50,7 +50,7 @@ extension Result {
   ///   instance.
   /// - Returns: A `Result` instance with the result of evaluating `transform`
   ///   as the new success value if this instance represents a success.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_disfavoredOverload // FIXME: Workaround for source compat issue with
                        // functions that used to shadow the original map
                        // (rdar://125016028)
@@ -84,7 +84,7 @@ extension Result {
 
 extension Result where Success: ~Copyable {
   // FIXME(NCG): Make this public.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public consuming func _consumingMap<NewSuccess: ~Copyable>(
     _ transform: (consuming Success) -> NewSuccess
   ) -> Result<NewSuccess, Failure> {
@@ -97,7 +97,7 @@ extension Result where Success: ~Copyable {
   }
 
   // FIXME(NCG): Make this public.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public borrowing func _borrowingMap<NewSuccess: ~Copyable>(
     _ transform: (borrowing Success) -> NewSuccess
   ) -> Result<NewSuccess, Failure> {
@@ -137,7 +137,7 @@ extension Result where Success: ~Copyable & ~Escapable {
   ///   instance.
   /// - Returns: A `Result` instance with the result of evaluating `transform`
   ///   as the new failure value if this instance represents a failure.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   public consuming func mapError<NewFailure>(
     _ transform: (Failure) -> NewFailure
@@ -193,7 +193,7 @@ extension Result {
   ///   instance.
   /// - Returns: A `Result` instance, either from the closure or the previous
   ///   `.failure`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_disfavoredOverload // FIXME: Workaround for source compat issue with
                        // functions that used to shadow the original flatMap
                        // (rdar://125016028)
@@ -227,7 +227,7 @@ extension Result {
 
 extension Result where Success: ~Copyable {
   // FIXME(NCG): Make this public.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public consuming func _consumingFlatMap<NewSuccess: ~Copyable>(
     _ transform: (consuming Success) -> Result<NewSuccess, Failure>
   ) -> Result<NewSuccess, Failure> {
@@ -240,7 +240,7 @@ extension Result where Success: ~Copyable {
   }
 
   // FIXME(NCG): Make this public.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public borrowing func _borrowingFlatMap<NewSuccess: ~Copyable>(
     _ transform: (borrowing Success) -> Result<NewSuccess, Failure>
   ) -> Result<NewSuccess, Failure> {
@@ -264,7 +264,7 @@ extension Result where Success: ~Copyable {
   ///   instance.
   /// - Returns: A `Result` instance, either from the closure or the previous
   ///   `.success`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public consuming func flatMapError<NewFailure>(
     _ transform: (Failure) -> Result<Success, NewFailure>
   ) -> Result<Success, NewFailure> {
@@ -310,7 +310,7 @@ extension Result where Success: ~Copyable & ~Escapable {
   ///
   /// - Returns: The success value, if the instance represents a success.
   /// - Throws: The failure value, if the instance represents a failure.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   public consuming func get() throws(Failure) -> Success {
     switch consume self {
@@ -343,7 +343,7 @@ extension Result where Success: ~Copyable {
   /// returned value as a success, or any thrown error as a failure.
   ///
   /// - Parameter body: A potentially throwing closure to evaluate.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(catching body: () throws(Failure) -> Success) {
     // FIXME: This should allow a non-escapable `Success` -- but what's `self`'s lifetime dependence in that case?
     do {

--- a/stdlib/public/core/RigidArray/RigidArray+Append.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Append.swift
@@ -21,7 +21,7 @@ extension _RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func append(_ item: consuming Element) {
     _precondition(!isFull, "RigidArray capacity overflow")
     unsafe _storage.initializeElement(at: _count, to: item)
@@ -39,7 +39,7 @@ extension _RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func pushLast(_ item: consuming Element) -> Element? {
     if isFull { return item }
     append(item)
@@ -69,7 +69,7 @@ extension _RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(`newItemCount`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func append<E: Error>(
     addingCount newItemCount: Int,
     initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
@@ -100,7 +100,7 @@ extension _RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(`items.count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func append(
     moving items: UnsafeMutableBufferPointer<Element>
   ) {
@@ -122,7 +122,7 @@ extension _RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(`items.count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func append(
     moving items: inout OutputSpan<Element>
   ) {
@@ -147,7 +147,7 @@ extension _RigidArray {
   ///
   /// - Complexity: O(`newElements.count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func append(
     copying newElements: UnsafeBufferPointer<Element>
   ) {
@@ -171,7 +171,7 @@ extension _RigidArray {
   ///
   /// - Complexity: O(`newElements.count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func append(
     copying items: UnsafeMutableBufferPointer<Element>
   ) {
@@ -188,14 +188,14 @@ extension _RigidArray {
   ///
   /// - Complexity: O(`newElements.count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func append(copying items: Span<Element>) {
     items.withUnsafeBufferPointer { source in
       unsafe self.append(copying: source)
     }
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal mutating func _append<S: Sequence<Element>>(
     prefixOf items: S
@@ -215,7 +215,7 @@ extension _RigidArray {
   ///
   /// - Complexity: O(*m*), where *m* is the length of `newElements`.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func append(copying newElements: some Sequence<Element>) {
     let done: Void? = newElements.withContiguousStorageIfAvailable { buffer in
       unsafe self.append(copying: buffer)

--- a/stdlib/public/core/RigidArray/RigidArray+Container.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Container.swift
@@ -16,7 +16,7 @@ extension _RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal var isEmpty: Bool {
     count == 0
@@ -26,7 +26,7 @@ extension _RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal var count: Int {
     _count
@@ -48,7 +48,7 @@ extension _RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal var startIndex: Int {
     0
@@ -60,7 +60,7 @@ extension _RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal var endIndex: Int {
     count
@@ -70,13 +70,13 @@ extension _RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal var indices: Range<Int> {
     unsafe Range(uncheckedBounds: (0, count))
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal func _checkItemIndex(_ index: Int) {
     _precondition(
@@ -84,7 +84,7 @@ extension _RigidArray where Element: ~Copyable {
       "Index out of bounds")
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal func _checkValidIndex(_ index: Int) {
     _precondition(
@@ -92,7 +92,7 @@ extension _RigidArray where Element: ~Copyable {
       "Index out of bounds")
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal func _checkValidBounds(_ subrange: Range<Int>) {
     _precondition(
@@ -103,7 +103,7 @@ extension _RigidArray where Element: ~Copyable {
 
 @available(SwiftStdlib 6.4, *)
 extension _RigidArray where Element: ~Copyable {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal func _ptr(to index: Int) -> UnsafePointer<Element> {
     _checkItemIndex(index)
@@ -111,7 +111,7 @@ extension _RigidArray where Element: ~Copyable {
     return unsafe UnsafePointer(p)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal mutating func _mutablePtr(
     to index: Int
@@ -128,7 +128,7 @@ extension _RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal subscript(position: Int) -> Element {
     @_transparent
     @_unsafeSelfDependentResult
@@ -156,7 +156,7 @@ extension _RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func swapAt(_ i: Int, _ j: Int) {
     _checkItemIndex(i)
     _checkItemIndex(j)
@@ -178,7 +178,7 @@ extension _RigidArray where Element: ~Copyable {
   /// - Returns: The index immediately following `i`.
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal func index(after index: Int) -> Int {
     index + 1
@@ -196,7 +196,7 @@ extension _RigidArray where Element: ~Copyable {
   /// - Returns: The index immediately preceding `i`.
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal func index(before index: Int) -> Int {
     index - 1
@@ -213,7 +213,7 @@ extension _RigidArray where Element: ~Copyable {
   ///     than `endIndex`.
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal func formIndex(after index: inout Int) {
     index += 1
@@ -230,7 +230,7 @@ extension _RigidArray where Element: ~Copyable {
   ///     `startIndex`.
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal func formIndex(before index: inout Int) {
     index -= 1
@@ -254,7 +254,7 @@ extension _RigidArray where Element: ~Copyable {
   ///    calls to `index(before:)`.
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal func index(_ index: Int, offsetBy n: Int) -> Int {
     index + n
@@ -273,7 +273,7 @@ extension _RigidArray where Element: ~Copyable {
   /// - Returns: The distance between `start` and `end`.
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal func distance(from start: Index, to end: Index) -> Int {
     end - start
@@ -311,7 +311,7 @@ extension _RigidArray where Element: ~Copyable {
   ///    effect.
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func formIndex(
     _ index: inout Index,
     offsetBy n: inout Int,

--- a/stdlib/public/core/RigidArray/RigidArray+Equatable.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Equatable.swift
@@ -12,7 +12,7 @@
 
 @available(SwiftStdlib 6.4, *)
 extension _RigidArray where Element: ~Copyable {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func isTriviallyIdentical(to other: borrowing Self) -> Bool {
     unsafe _count == other._count &&
     _storage.isTriviallyIdentical(to: other._storage)
@@ -22,7 +22,7 @@ extension _RigidArray where Element: ~Copyable {
 @available(SwiftStdlib 6.4, *)
 extension _RigidArray: Equatable where Element: Equatable & ~Copyable {
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal static func ==(
     left: borrowing Self,
     right: borrowing Self

--- a/stdlib/public/core/RigidArray/RigidArray+Hashable.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Hashable.swift
@@ -13,7 +13,7 @@
 @available(SwiftStdlib 6.4, *)
 extension _RigidArray: Hashable where Element: Hashable & ~Copyable {
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func hash(into hasher: inout Hasher) {
     hasher.combine(self.count)
     self.span._hashContents(into: &hasher)

--- a/stdlib/public/core/RigidArray/RigidArray+Initializers.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Initializers.swift
@@ -16,7 +16,7 @@ extension _RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal init() {
     unsafe _storage = .init(start: nil, count: 0)
@@ -25,7 +25,7 @@ extension _RigidArray where Element: ~Copyable {
   
   /// Initializes a new rigid array with the specified capacity and no elements.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal init(capacity: Int) {
     _precondition(capacity >= 0, "Array capacity must be nonnegative")
     if capacity > 0 {
@@ -50,7 +50,7 @@ extension _RigidArray where Element: ~Copyable {
   ///       initialized with however many items the callback adds to the
   ///       output span before it returns (or before it throws an error).
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal init<E: Error>(
     capacity: Int,
     initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
@@ -72,7 +72,7 @@ extension _RigidArray where Element: Copyable {
   ///
   /// - Complexity: O(`count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal init(repeating repeatedValue: Element, count: Int) {
     self.init(capacity: count)
     unsafe _freeSpace.initialize(repeating: repeatedValue)
@@ -90,7 +90,7 @@ extension _RigidArray where Element: Copyable {
   ///   - contents: The sequence whose contents to copy into the new array.
   ///      The sequence must not contain more than `capacity` elements.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal init(
     capacity: Int,
@@ -109,7 +109,7 @@ extension _RigidArray where Element: Copyable {
   ///   - contents: The collection whose contents to copy into the new array.
   ///      The collection must not contain more than `capacity` elements.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal init(
     capacity: Int? = nil,
@@ -128,7 +128,7 @@ extension _RigidArray where Element: Copyable {
   ///   - span: The span whose contents to copy into the new array.
   ///      The span must not contain more than `capacity` elements.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal init(
     capacity: Int? = nil,

--- a/stdlib/public/core/RigidArray/RigidArray+Insertions.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Insertions.swift
@@ -30,7 +30,7 @@ extension _RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(`self.count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func insert(_ item: consuming Element, at index: Int) {
     _checkValidIndex(index)
     _precondition(!isFull, "RigidArray capacity overflow")
@@ -88,7 +88,7 @@ extension _RigidArray where Element: ~Copyable {
   /// - Complexity: O(`self.count` + `newItemCount`) in addition to the complexity
   ///    of the callback invocations.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func insert<E: Error>(
     addingCount newItemCount: Int,
     at index: Int,
@@ -132,7 +132,7 @@ extension _RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(`self.count` + `items.count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func insert(
     moving items: UnsafeMutableBufferPointer<Element>,
     at index: Int
@@ -159,7 +159,7 @@ extension _RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(`self.count` + `items.count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func insert(
     moving items: inout OutputSpan<Element>,
     at index: Int
@@ -195,7 +195,7 @@ extension _RigidArray where Element: Copyable {
   ///
   /// - Complexity: O(`count` + `newElements.count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func insert(
     copying newElements: UnsafeBufferPointer<Element>, at index: Int
   ) {
@@ -226,7 +226,7 @@ extension _RigidArray where Element: Copyable {
   ///
   /// - Complexity: O(`count` + `newElements.count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func insert(
     copying newElements: UnsafeMutableBufferPointer<Element>,
     at index: Int
@@ -253,7 +253,7 @@ extension _RigidArray where Element: Copyable {
   ///
   /// - Complexity: O(`count` + `newElements.count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func insert(
     copying newElements: Span<Element>, at index: Int
   ) {
@@ -263,7 +263,7 @@ extension _RigidArray where Element: Copyable {
     }
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func _insertCollection(
     at index: Int,
     copying items: some Collection<Element>,
@@ -309,7 +309,7 @@ extension _RigidArray where Element: Copyable {
   ///
   /// - Complexity: O(`count` + `newElements.count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func insert(
     copying newElements: some Collection<Element>, at index: Int
   ) {

--- a/stdlib/public/core/RigidArray/RigidArray+Removals.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Removals.swift
@@ -23,7 +23,7 @@ extension _RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(`count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @discardableResult
   internal mutating func remove(at index: Int) -> Element {
     _checkItemIndex(index)
@@ -37,7 +37,7 @@ extension _RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(*n*), where *n* is the original count of the array.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func removeAll() {
     unsafe _items.deinitialize()
     _count = 0
@@ -51,7 +51,7 @@ extension _RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @discardableResult
   internal mutating func removeLast() -> Element {
     _precondition(!isEmpty, "Cannot remove last element from an empty array")
@@ -72,7 +72,7 @@ extension _RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(`k`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func removeLast(_ k: Int) {
     if k == 0 { return }
     _precondition(
@@ -94,7 +94,7 @@ extension _RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(`count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func removeSubrange(_  bounds: Range<Int>) {
     _checkValidBounds(bounds)
     guard !bounds.isEmpty else { return }
@@ -110,7 +110,7 @@ extension _RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(`count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func removeSubrange(_  bounds: some RangeExpression<Int>) {
     // FIXME: Remove this in favor of a standard algorithm.
     removeSubrange(bounds.relative(to: indices))
@@ -126,7 +126,7 @@ extension _RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func popLast() -> Element? {
     // FIXME: Remove this in favor of a standard algorithm.
     if isEmpty { return nil }

--- a/stdlib/public/core/RigidArray/RigidArray+Replacements.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Replacements.swift
@@ -53,7 +53,7 @@ extension _RigidArray where Element: ~Copyable {
   /// - Complexity: O(`self.count` + `newItemCount`) in addition to the complexity
   ///    of the callback invocations.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func replaceSubrange<E: Error>(
     _ subrange: Range<Int>,
     addingCount newItemCount: Int,
@@ -70,7 +70,7 @@ extension _RigidArray where Element: ~Copyable {
       initializingWith: initializer)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func _uncheckedReplaceSubrange<E: Error>(
     _ subrange: Range<Int>,
     addingCount newItemCount: Int,
@@ -125,7 +125,7 @@ extension _RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(`self.count` + `newElements.count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func replaceSubrange(
     _ subrange: Range<Int>,
     moving newElements: UnsafeMutableBufferPointer<Element>,
@@ -164,7 +164,7 @@ extension _RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(`self.count` + `items.count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func replaceSubrange(
     _ subrange: Range<Int>,
     moving items: inout OutputSpan<Element>
@@ -206,7 +206,7 @@ extension _RigidArray where Element: Copyable {
   ///
   /// - Complexity: O(`self.count` + `newElements.count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func replaceSubrange(
     _ subrange: Range<Int>,
     copying newElements: UnsafeBufferPointer<Element>
@@ -245,7 +245,7 @@ extension _RigidArray where Element: Copyable {
   ///
   /// - Complexity: O(`self.count` + `newElements.count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func replaceSubrange(
     _ subrange: Range<Int>,
     copying newElements: UnsafeMutableBufferPointer<Element>
@@ -282,7 +282,7 @@ extension _RigidArray where Element: Copyable {
   ///
   /// - Complexity: O(`self.count` + `newElements.count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func replaceSubrange(
     _ subrange: Range<Int>,
     copying newElements: Span<Element>
@@ -292,7 +292,7 @@ extension _RigidArray where Element: Copyable {
     }
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func _replaceSubrange(
     _ subrange: Range<Int>,
     copyingCollection newElements: __owned some Collection<Element>,
@@ -345,7 +345,7 @@ extension _RigidArray where Element: Copyable {
   ///
   /// - Complexity: O(`self.count` + `newElements.count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func replaceSubrange(
     _ subrange: Range<Int>,
     copying newElements: consuming some Collection<Element>

--- a/stdlib/public/core/RigidArray/RigidArray.swift
+++ b/stdlib/public/core/RigidArray/RigidArray.swift
@@ -58,13 +58,13 @@ internal struct _RigidArray<Element: ~Copyable>: ~Copyable {
   @usableFromInline
   internal var _count: Int
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   deinit {
     unsafe _storage.extracting(0 ..< _count).deinitialize()
     unsafe _storage.deallocate()
   }
   
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal init(_storage: UnsafeMutableBufferPointer<Element>, count: Int) {
     unsafe self._storage = _storage
     self._count = count
@@ -80,7 +80,7 @@ extension _RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal var capacity: Int {
     _assumeNonNegative(unsafe _storage.count)
@@ -91,7 +91,7 @@ extension _RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal var freeCapacity: Int {
     _assumeNonNegative(capacity &- count)
@@ -103,7 +103,7 @@ extension _RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal var isFull: Bool {
     freeCapacity == 0
@@ -112,12 +112,12 @@ extension _RigidArray where Element: ~Copyable {
 
 @available(SwiftStdlib 6.4, *)
 extension _RigidArray where Element: ~Copyable {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal var _items: UnsafeMutableBufferPointer<Element> {
     unsafe _storage.extracting(Range(uncheckedBounds: (0, _count)))
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal var _freeSpace: UnsafeMutableBufferPointer<Element> {
     unsafe _storage.extracting(Range(uncheckedBounds: (_count, capacity)))
   }
@@ -129,7 +129,7 @@ extension _RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal var span: Span<Element> {
     @_lifetime(borrow self)
@@ -144,7 +144,7 @@ extension _RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal var mutableSpan: MutableSpan<Element> {
     @_lifetime(&self)
@@ -154,13 +154,13 @@ extension _RigidArray where Element: ~Copyable {
     }
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow self)
   internal func _span(in range: Range<Int>) -> Span<Element> {
     span.extracting(range)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   internal mutating func _mutableSpan(
     in range: Range<Int>
@@ -190,7 +190,7 @@ extension _RigidArray where Element: ~Copyable {
   /// - Complexity: Adds O(1) overhead to the complexity of the function
   ///    argument.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func edit<E: Error, R: ~Copyable>(
     _ body: (inout OutputSpan<Element>) throws(E) -> R
   ) throws(E) -> R {
@@ -204,7 +204,7 @@ extension _RigidArray where Element: ~Copyable {
 
   // FIXME: Stop using and remove this in favor of `edit`
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func _unsafeEdit<E: Error, R: ~Copyable>(
     _ body: (UnsafeMutableBufferPointer<Element>, inout Int) throws(E) -> R
   ) throws(E) -> R {
@@ -215,14 +215,14 @@ extension _RigidArray where Element: ~Copyable {
 
 @available(SwiftStdlib 6.4, *)
 extension _RigidArray where Element: ~Copyable {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func _contiguousSubrange(following index: inout Int) -> Range<Int> {
     _precondition(index >= 0 && index <= _count, "Index out of bounds")
     defer { index = _count }
     return unsafe Range(uncheckedBounds: (index, _count))
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func _contiguousSubrange(preceding index: inout Int) -> Range<Int> {
     _precondition(index >= 0 && index <= _count, "Index out of bounds")
     defer { index = 0 }
@@ -244,7 +244,7 @@ extension _RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(`count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func setCapacity(_ newCapacity: Int) {
     guard newCapacity != capacity else { return }
     let newStorage: UnsafeMutableBufferPointer<Element> = .allocate(
@@ -264,7 +264,7 @@ extension _RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(`count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func reserveCapacity(_ n: Int) {
     guard capacity < n else { return }
     setCapacity(n)
@@ -278,7 +278,7 @@ extension _RigidArray {
   ///
   /// - Complexity: O(`count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func clone() -> Self {
     clone(capacity: self.count)
   }
@@ -291,7 +291,7 @@ extension _RigidArray {
   ///
   /// - Complexity: O(`count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func clone(capacity: Int) -> Self {
     _precondition(capacity >= count, "RigidArray capacity overflow")
     var result = Self(capacity: capacity)
@@ -304,7 +304,7 @@ extension _RigidArray {
 
 @available(SwiftStdlib 6.4, *)
 extension _RigidArray where Element: ~Copyable {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func _closeGap(
     at index: Int, count: Int
   ) {
@@ -318,7 +318,7 @@ extension _RigidArray where Element: ~Copyable {
   }
 
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func _openGap(
     at index: Int, count: Int
   ) -> UnsafeMutableBufferPointer<Element> {
@@ -342,7 +342,7 @@ extension _RigidArray where Element: ~Copyable {
   /// - Returns: A buffer pointer addressing the newly opened gap, to be
   ///     initialized by the caller.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func _resizeGap(
     in subrange: Range<Int>, to newItemCount: Int
   ) -> UnsafeMutableBufferPointer<Element> {

--- a/stdlib/public/core/Runtime.swift
+++ b/stdlib/public/core/Runtime.swift
@@ -166,7 +166,7 @@ func _stdlib_atomicLoadARCRef(
 }
 
 @_transparent
-@_alwaysEmitIntoClient
+@export(implementation)
 @discardableResult
 public func _stdlib_atomicAcquiringInitializeARCRef<T: AnyObject>(
   object target: UnsafeMutablePointer<T?>,
@@ -192,7 +192,7 @@ public func _stdlib_atomicAcquiringInitializeARCRef<T: AnyObject>(
   return unsafe Unmanaged<T>.fromOpaque(ptr)
 }
 
-@_alwaysEmitIntoClient
+@export(implementation)
 @_transparent
 public func _stdlib_atomicAcquiringLoadARCRef<T: AnyObject>(
   object target: UnsafeMutablePointer<T?>

--- a/stdlib/public/core/SIMDFloatConcreteOperations.swift.gyb
+++ b/stdlib/public/core/SIMDFloatConcreteOperations.swift.gyb
@@ -29,7 +29,7 @@ vectorscalarCounts = storagescalarCounts + [3]
 @available(SwiftStdlib 5.3, *)
 %  end
 extension SIMD${n} where Scalar == ${Scalar} {
-  @_alwaysEmitIntoClient @_transparent
+  @export(implementation) @_transparent
   internal init(_ _builtin: Builtin.${Builtin}) {
     _storage = ${Scalar}.SIMD${storageN}Storage(_builtin)
   }
@@ -43,7 +43,7 @@ extension SIMD${n} where Scalar == ${Scalar} {
   ///   result[i] = scalar
   /// }
   /// ```
-  @_alwaysEmitIntoClient @_transparent
+  @export(implementation) @_transparent
   public init(repeating scalar: ${Scalar}) {
     let asVector = Builtin.insertelement_${Builtin}_FPIEEE${bits}_Int32(
       Builtin.zeroInitializer(), scalar._value, Builtin.zeroInitializer()
@@ -71,7 +71,7 @@ extension SIMD${n} where Scalar == ${Scalar} {
   ///   result[${n//2}+i] = highHalf[i]
   /// }
   /// ```
-  @_alwaysEmitIntoClient @_transparent
+  @export(implementation) @_transparent
   public init(
     lowHalf: SIMD${n//2}<${Scalar}>,
     highHalf: SIMD${n//2}<${Scalar}>
@@ -103,7 +103,7 @@ compares = [
   ///   result[i] = (a[i] ${op} b[i])
   /// }
   /// ```
-  @_alwaysEmitIntoClient @_transparent
+  @export(implementation) @_transparent
   public static func .${op}(a: Self, b: Self) -> SIMDMask<MaskStorage> {
     SIMDMask<MaskStorage>(${MaskExt}(
       Builtin.fcmp_${bi}_${Builtin}(a._storage._value, b._storage._value)
@@ -122,7 +122,7 @@ compares = [
   ///   result[i] = (a[i] ${op} b)
   /// }
   /// ```
-  @_alwaysEmitIntoClient @_transparent @_disfavoredOverload
+  @export(implementation) @_transparent @_disfavoredOverload
   public static func .${op}(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
     a .${op} Self(repeating: b)
   }
@@ -139,7 +139,7 @@ compares = [
   ///   result[i] = (a ${op} b[i])
   /// }
   /// ```
-  @_alwaysEmitIntoClient @_transparent @_disfavoredOverload
+  @export(implementation) @_transparent @_disfavoredOverload
   public static func .${op}(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
     Self(repeating: a) .${op} b
   }

--- a/stdlib/public/core/SIMDIntegerConcreteOperations.swift.gyb
+++ b/stdlib/public/core/SIMDIntegerConcreteOperations.swift.gyb
@@ -26,7 +26,7 @@ vectorscalarCounts = storagescalarCounts + [3]
 %  Builtin = "Vec" + str(storageN) + "xInt" + str(int.bits)
 %  MaskExt = "Builtin.sext_Vec" + str(storageN) + "xInt1_" + Builtin
 extension SIMD${n} where Scalar == ${Scalar} {
-  @_alwaysEmitIntoClient @_transparent
+  @export(implementation) @_transparent
   internal init(_ _builtin: Builtin.${Builtin}) {
     _storage = ${Scalar}.SIMD${storageN}Storage(_builtin)
   }
@@ -40,7 +40,7 @@ extension SIMD${n} where Scalar == ${Scalar} {
   ///   result[i] = scalar
   /// }
   /// ```
-  @_alwaysEmitIntoClient @_transparent
+  @export(implementation) @_transparent
   public init(repeating scalar: ${Scalar}) {
     let asVector = Builtin.insertelement_${Builtin}_Int${int.bits}_Int32(
       Builtin.zeroInitializer(), scalar._value, Builtin.zeroInitializer()
@@ -68,7 +68,7 @@ extension SIMD${n} where Scalar == ${Scalar} {
   ///   result[${n//2}+i] = highHalf[i]
   /// }
   /// ```
-  @_alwaysEmitIntoClient @_transparent
+  @export(implementation) @_transparent
   public init(
     lowHalf: SIMD${n//2}<${Scalar}>,
     highHalf: SIMD${n//2}<${Scalar}>
@@ -78,7 +78,7 @@ extension SIMD${n} where Scalar == ${Scalar} {
   
 %  end
   /// A vector mask with the result of a pointwise equality comparison.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func .==(a: Self, b: Self) -> SIMDMask<MaskStorage> {
     SIMDMask<MaskStorage>(${MaskExt}(
       Builtin.cmp_eq_${Builtin}(a._storage._value, b._storage._value)
@@ -86,7 +86,7 @@ extension SIMD${n} where Scalar == ${Scalar} {
   }
   
   /// A vector mask with the result of a pointwise inequality comparison.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func .!=(a: Self, b: Self) -> SIMDMask<MaskStorage> {
     SIMDMask<MaskStorage>(${MaskExt}(
       Builtin.cmp_ne_${Builtin}(a._storage._value, b._storage._value)
@@ -94,7 +94,7 @@ extension SIMD${n} where Scalar == ${Scalar} {
   }
   
   /// A vector mask with the result of a pointwise less-than comparison.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func .<(a: Self, b: Self) -> SIMDMask<MaskStorage> {
     SIMDMask<MaskStorage>(${MaskExt}(
       Builtin.cmp_${s}lt_${Builtin}(a._storage._value, b._storage._value)
@@ -102,7 +102,7 @@ extension SIMD${n} where Scalar == ${Scalar} {
   }
   
   /// A vector mask with the result of a pointwise less-than-or-equal-to comparison.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func .<=(a: Self, b: Self) -> SIMDMask<MaskStorage> {
     SIMDMask<MaskStorage>(${MaskExt}(
       Builtin.cmp_${s}le_${Builtin}(a._storage._value, b._storage._value)
@@ -110,7 +110,7 @@ extension SIMD${n} where Scalar == ${Scalar} {
   }
   
   /// A vector mask with the result of a pointwise greater-than comparison.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func .>(a: Self, b: Self) -> SIMDMask<MaskStorage> {
     SIMDMask<MaskStorage>(${MaskExt}(
       Builtin.cmp_${s}gt_${Builtin}(a._storage._value, b._storage._value)
@@ -118,7 +118,7 @@ extension SIMD${n} where Scalar == ${Scalar} {
   }
   
   /// A vector mask with the result of a pointwise greater-than-or-equal-to comparison.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func .>=(a: Self, b: Self) -> SIMDMask<MaskStorage> {
     SIMDMask<MaskStorage>(${MaskExt}(
       Builtin.cmp_${s}ge_${Builtin}(a._storage._value, b._storage._value)
@@ -126,36 +126,36 @@ extension SIMD${n} where Scalar == ${Scalar} {
   }
     
   /// The wrapping sum of two vectors.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func &+(a: Self, b: Self) -> Self {
     Self(Builtin.add_${Builtin}(a._storage._value, b._storage._value))
   }
     
   /// The wrapping difference of two vectors.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func &-(a: Self, b: Self) -> Self {
     Self(Builtin.sub_${Builtin}(a._storage._value, b._storage._value))
   }
     
   /// The pointwise wrapping product of two vectors.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func &*(a: Self, b: Self) -> Self {
     Self(Builtin.mul_${Builtin}(a._storage._value, b._storage._value))
   }
         
   /// Updates the left hand side with the wrapping sum of the two
   /// vectors.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func &+=(a: inout Self, b: Self) { a = a &+ b }
     
   /// Updates the left hand side with the wrapping difference of the two
   /// vectors.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func &-=(a: inout Self, b: Self) { a = a &- b }
     
   /// Updates the left hand side with the pointwise wrapping product of two
   /// vectors.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func &*=(a: inout Self, b: Self) { a = a &* b }
 }
 

--- a/stdlib/public/core/SIMDMaskConcreteOperations.swift.gyb
+++ b/stdlib/public/core/SIMDMaskConcreteOperations.swift.gyb
@@ -26,17 +26,17 @@ vectorscalarCounts = storagescalarCounts + [3]
 %  Builtin = "Vec" + str(storageN) + "xInt" + str(int.bits)
 %  MaskExt = "Builtin.sext_Vec" + str(storageN) + "xInt1_" + Builtin
 extension SIMDMask where Storage == ${Vector} {
-  @_alwaysEmitIntoClient @_transparent
+  @export(implementation) @_transparent
   internal init(_ _builtin: Builtin.${Builtin}) {
     _storage = ${Vector}(_builtin)
   }
   
-  @_alwaysEmitIntoClient @_transparent
+  @export(implementation) @_transparent
   public init(repeating scalar: Bool) {
     _storage = ${Vector}(repeating: scalar ? -1 : 0)
   }
   
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal static var allTrue: Self {
     let zero = ${Vector}()
     return zero .== zero
@@ -51,7 +51,7 @@ extension SIMDMask where Storage == ${Vector} {
   ///   result[i] = !a[i]
   /// }
   /// ```
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static prefix func .!(a: Self) -> Self {
     a .^ .allTrue
   }
@@ -68,7 +68,7 @@ extension SIMDMask where Storage == ${Vector} {
   ///
   /// Note that unlike the scalar `&&` operator, the SIMD `.&` operator
   /// always fully evaluates both arguments.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func .&(a: Self, b: Self) -> Self {
     Self(${Vector}(Builtin.and_${Builtin}(
       a._storage._storage._value,
@@ -84,7 +84,7 @@ extension SIMDMask where Storage == ${Vector} {
   ///   a[i] = a[i] && b[i]
   /// }
   /// ```
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func .&=(a: inout Self, b: Self) {
     a = a .& b
   }
@@ -98,7 +98,7 @@ extension SIMDMask where Storage == ${Vector} {
   ///   result[i] = a[i] != b[i]
   /// }
   /// ```
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func .^(a: Self, b: Self) -> Self {
     Self(${Vector}(Builtin.xor_${Builtin}(
       a._storage._storage._value,
@@ -114,7 +114,7 @@ extension SIMDMask where Storage == ${Vector} {
   ///   a[i] = a[i] != b[i]
   /// }
   /// ```
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func .^=(a: inout Self, b: Self) {
     a = a .^ b
   }
@@ -131,7 +131,7 @@ extension SIMDMask where Storage == ${Vector} {
   ///
   /// Note that unlike the scalar `||` operator, the SIMD `.|` operator
   /// always fully evaluates both arguments.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func .|(a: Self, b: Self) -> Self {
     Self(${Vector}(Builtin.or_${Builtin}(
       a._storage._storage._value,
@@ -147,7 +147,7 @@ extension SIMDMask where Storage == ${Vector} {
   ///   a[i] = a[i] || b[i]
   /// }
   /// ```
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func .|=(a: inout Self, b: Self) {
     a = a .| b
   }
@@ -161,7 +161,7 @@ extension SIMDMask where Storage == ${Vector} {
   ///   result[i] = a[i] == b[i]
   /// }
   /// ```
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func .==(a: Self, b: Self) -> Self {
     .!(a .^ b)
   }
@@ -175,7 +175,7 @@ extension SIMDMask where Storage == ${Vector} {
   ///   result[i] = a[i] != b[i]
   /// }
   /// ```
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func .!=(a: Self, b: Self) -> Self {
     a .^ b
   }
@@ -189,7 +189,7 @@ extension SIMDMask where Storage == ${Vector} {
   ///   if mask[i] { self[i] = other[i] }
   /// }
   /// ```
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func replace(with other: Self, where mask: Self) {
     self = replacing(with: other, where: mask)
   }
@@ -204,7 +204,7 @@ extension SIMDMask where Storage == ${Vector} {
   ///   result[i] = mask[i] ? other[i] : self[i]
   /// }
   /// ```
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func replacing(with other: Self, where mask: Self) -> Self {
     (self .& .!mask) .| (other .& mask)
   }

--- a/stdlib/public/core/SIMDVector.swift
+++ b/stdlib/public/core/SIMDVector.swift
@@ -54,7 +54,7 @@ public protocol SIMDStorage {
 
 extension SIMDStorage {
   /// The number of scalars, or elements, in a vector of this type.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static var scalarCount: Int {
     // Wouldn't it make more sense to define the instance var in terms of the
     // static var? Yes, probably, but by doing it this way we make the static
@@ -269,7 +269,7 @@ extension SIMD {
   /// The elements of the index vector are wrapped modulo the count of elements
   /// in this vector. Because of this, the index is always in-range and no trap
   /// can occur.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public subscript<Index>(index: SIMD2<Index>) -> SIMD2<Scalar>
   where Index: FixedWidthInteger {
     var result = SIMD2<Scalar>()
@@ -284,7 +284,7 @@ extension SIMD {
   /// The elements of the index vector are wrapped modulo the count of elements
   /// in this vector. Because of this, the index is always in-range and no trap
   /// can occur.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public subscript<Index>(index: SIMD3<Index>) -> SIMD3<Scalar>
   where Index: FixedWidthInteger {
     var result = SIMD3<Scalar>()
@@ -299,7 +299,7 @@ extension SIMD {
   /// The elements of the index vector are wrapped modulo the count of elements
   /// in this vector. Because of this, the index is always in-range and no trap
   /// can occur.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public subscript<Index>(index: SIMD4<Index>) -> SIMD4<Scalar>
   where Index: FixedWidthInteger {
     var result = SIMD4<Scalar>()
@@ -314,7 +314,7 @@ extension SIMD {
   /// The elements of the index vector are wrapped modulo the count of elements
   /// in this vector. Because of this, the index is always in-range and no trap
   /// can occur.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public subscript<Index>(index: SIMD8<Index>) -> SIMD8<Scalar>
   where Index: FixedWidthInteger {
     var result = SIMD8<Scalar>()
@@ -329,7 +329,7 @@ extension SIMD {
   /// The elements of the index vector are wrapped modulo the count of elements
   /// in this vector. Because of this, the index is always in-range and no trap
   /// can occur.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public subscript<Index>(index: SIMD16<Index>) -> SIMD16<Scalar>
   where Index: FixedWidthInteger {
     var result = SIMD16<Scalar>()
@@ -344,7 +344,7 @@ extension SIMD {
   /// The elements of the index vector are wrapped modulo the count of elements
   /// in this vector. Because of this, the index is always in-range and no trap
   /// can occur.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public subscript<Index>(index: SIMD32<Index>) -> SIMD32<Scalar>
   where Index: FixedWidthInteger {
     var result = SIMD32<Scalar>()
@@ -359,7 +359,7 @@ extension SIMD {
   /// The elements of the index vector are wrapped modulo the count of elements
   /// in this vector. Because of this, the index is always in-range and no trap
   /// can occur.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public subscript<Index>(index: SIMD64<Index>) -> SIMD64<Scalar>
   where Index: FixedWidthInteger {
     var result = SIMD64<Scalar>()
@@ -392,7 +392,7 @@ extension SIMD where Scalar: Comparable {
   }
   
   /// The least element in the vector.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public func min() -> Scalar {
     var result = self[0]
@@ -403,7 +403,7 @@ extension SIMD where Scalar: Comparable {
   }
 
   /// The greatest element in the vector.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public func max() -> Scalar {
     var result = self[0]
@@ -557,12 +557,12 @@ extension SIMD where Scalar: Comparable {
     return a .> Self(repeating: b)
   }
   
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func clamp(lowerBound: Self, upperBound: Self) {
     self = self.clamped(lowerBound: lowerBound, upperBound: upperBound)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func clamped(lowerBound: Self, upperBound: Self) -> Self {
     return pointwiseMin(upperBound, pointwiseMax(lowerBound, self))
   }
@@ -576,7 +576,7 @@ extension SIMD where Scalar: FixedWidthInteger {
   }
   
   /// A vector with one in all lanes.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static var one: Self {
     return Self(repeating: 1)
   }
@@ -635,17 +635,17 @@ extension SIMD where Scalar: FloatingPoint {
   }
   
   /// A vector with one in all lanes.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static var one: Self {
     return Self(repeating: 1)
   }
   
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func clamp(lowerBound: Self, upperBound: Self) {
     self = self.clamped(lowerBound: lowerBound, upperBound: upperBound)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func clamped(lowerBound: Self, upperBound: Self) -> Self {
     return pointwiseMin(upperBound, pointwiseMax(lowerBound, self))
   }
@@ -864,7 +864,7 @@ extension SIMD where Scalar: FixedWidthInteger {
   /// addition.
   ///
   /// Equivalent to `indices.reduce(into: 0) { $0 &+= self[$1] }`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public func wrappedSum() -> Scalar {
     var result: Scalar = 0
@@ -930,7 +930,7 @@ extension SIMD where Scalar: FloatingPoint {
   }
   
   /// The least scalar in the vector.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public func min() -> Scalar {
     var result = self[0]
@@ -941,7 +941,7 @@ extension SIMD where Scalar: FloatingPoint {
   }
 
   /// The greatest scalar in the vector.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public func max() -> Scalar {
     var result = self[0]
@@ -952,7 +952,7 @@ extension SIMD where Scalar: FloatingPoint {
   }
   
   /// The sum of the scalars in the vector.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func sum() -> Scalar {
     // Implementation note: this eventually be defined to lower to either
     // llvm.experimental.vector.reduce.fadd or an explicit tree-sum. Open-
@@ -1558,14 +1558,14 @@ extension SIMDMask {
 }
 
 /// True if any lane of mask is true.
-@_alwaysEmitIntoClient
+@export(implementation)
 @_transparent
 public func any<Storage>(_ mask: SIMDMask<Storage>) -> Bool {
   return mask._storage.min() < 0
 }
 
 /// True if every lane of mask is true.
-@_alwaysEmitIntoClient
+@export(implementation)
 @_transparent
 public func all<Storage>(_ mask: SIMDMask<Storage>) -> Bool {
   return mask._storage.max() < 0
@@ -1575,7 +1575,7 @@ public func all<Storage>(_ mask: SIMDMask<Storage>) -> Bool {
 ///
 /// Each element of the result is the minimum of the corresponding elements
 /// of the inputs.
-@_alwaysEmitIntoClient
+@export(implementation)
 public func pointwiseMin<T>(_ a: T, _ b: T) -> T
 where T: SIMD, T.Scalar: Comparable {
   var result = T()
@@ -1589,7 +1589,7 @@ where T: SIMD, T.Scalar: Comparable {
 ///
 /// Each element of the result is the minimum of the corresponding elements
 /// of the inputs.
-@_alwaysEmitIntoClient
+@export(implementation)
 public func pointwiseMax<T>(_ a: T, _ b: T) -> T
 where T: SIMD, T.Scalar: Comparable {
   var result = T()
@@ -1604,7 +1604,7 @@ where T: SIMD, T.Scalar: Comparable {
 ///
 /// Each element of the result is the minimum of the corresponding elements
 /// of the inputs.
-@_alwaysEmitIntoClient
+@export(implementation)
 public func pointwiseMin<T>(_ a: T, _ b: T) -> T
 where T: SIMD, T.Scalar: FloatingPoint {
   var result = T()
@@ -1618,7 +1618,7 @@ where T: SIMD, T.Scalar: FloatingPoint {
 ///
 /// Each element of the result is the maximum of the corresponding elements
 /// of the inputs.
-@_alwaysEmitIntoClient
+@export(implementation)
 public func pointwiseMax<T>(_ a: T, _ b: T) -> T
 where T: SIMD, T.Scalar: FloatingPoint {
   var result = T()
@@ -1630,12 +1630,12 @@ where T: SIMD, T.Scalar: FloatingPoint {
 
 // Break the ambiguity between AdditiveArithmetic and SIMD for += and -=
 extension SIMD where Self: AdditiveArithmetic, Self.Scalar: FloatingPoint {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func +=(a: inout Self, b: Self) {
     a = a + b
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func -=(a: inout Self, b: Self) {
     a = a - b
   }

--- a/stdlib/public/core/SIMDVectorTypes.swift.gyb
+++ b/stdlib/public/core/SIMDVectorTypes.swift.gyb
@@ -216,7 +216,7 @@ extension SIMD${n}: ConvertibleFromBytes
 
 extension SIMD3 {
   /// A three-element vector created by appending a scalar to a two-element vector.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(_ xy: SIMD2<Scalar>, _ z: Scalar) {
     self.init(xy.x, xy.y, z)
   }
@@ -224,7 +224,7 @@ extension SIMD3 {
 
 extension SIMD4 {
   /// A four-element vector created by appending a scalar to a three-element vector.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(_ xyz: SIMD3<Scalar>, _ w: Scalar) {
     self.init(xyz.x, xyz.y, xyz.z, w)
   }
@@ -257,7 +257,7 @@ extension ${Self}: SIMDScalar {
       _value = Builtin.zeroInitializer()
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     internal init(_ _builtin: Builtin.Vec${n}x${BuiltinName}) {
       _value = _builtin
     }
@@ -311,7 +311,7 @@ extension ${Self} : SIMDScalar {
       _value = Builtin.zeroInitializer()
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     internal init(_ _builtin: Builtin.Vec${n}xFPIEEE${bits}) {
       _value = _builtin
     }

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -683,8 +683,7 @@ extension Sequence {
   ///   sequence.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the sequence.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func map<T, E>(
     _ transform: (Element) throws(E) -> T
   ) throws(E) -> [T] {
@@ -736,7 +735,7 @@ extension Sequence {
   /// - Returns: An array of the elements that `isIncluded` allowed.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the sequence.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public __consuming func filter<E: Error>(
     _ isIncluded: (Element) throws(E) -> Bool
   ) throws(E) -> [Element] {
@@ -761,7 +760,7 @@ extension Sequence {
   }
 #endif // !hasFeature(Embedded)
 
-  @_alwaysEmitIntoClient  @_transparent
+  @export(implementation) @_transparent
   public func _filter<E: Error>(
     _ isIncluded: (Element) throws(E) -> Bool
   ) throws(E) -> [Element] {
@@ -1266,7 +1265,7 @@ extension Sequence {
     return unsafe _copySequenceContents(initializing: buffer)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal __consuming func _copySequenceContents(
     initializing buffer: UnsafeMutableBufferPointer<Element>
   ) -> (Iterator, UnsafeMutableBufferPointer<Element>.Index) {

--- a/stdlib/public/core/SequenceAlgorithms.swift
+++ b/stdlib/public/core/SequenceAlgorithms.swift
@@ -604,7 +604,7 @@ extension Sequence {
   ///   the element should be included in the count.
   /// - Returns: The number of elements in the sequence that satisfy the given
   ///   predicate.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func count<E>(
     where predicate: (Element) throws(E) -> Bool
   ) throws(E) -> Int {
@@ -664,7 +664,7 @@ extension Sequence {
   ///   the result is `initialResult`.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the sequence.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func reduce<Result: ~Copyable>(
     _ initialResult: consuming Result,
     _ nextPartialResult:

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -222,7 +222,7 @@ extension Set: ExpressibleByArrayLiteral {
     self.init(_nonEmptyArrayLiteral: elements)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal init(_nonEmptyArrayLiteral elements: [Element]) {
     let native = _NativeSet<Element>(capacity: elements.count)
     for element in elements {
@@ -297,7 +297,7 @@ extension Set {
   ///   and returns a Boolean value indicating whether the element should be
   ///   included in the returned set.
   /// - Returns: A set of the elements that `isIncluded` allows.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(swift, introduced: 4.0)
   public consuming func filter<E: Error>(
     _ isIncluded: (Element) throws(E) -> Bool
@@ -1709,7 +1709,7 @@ extension Set {
   /// with `==`, but not all equal sets are considered identical.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func isTriviallyIdentical(to other: Self) -> Bool {
 #if _runtime(_ObjC)
     if

--- a/stdlib/public/core/SetCasting.swift
+++ b/stdlib/public/core/SetCasting.swift
@@ -13,7 +13,7 @@
 //===--- Compiler conversion/casting entry points for Set<Element> --------===//
 
 extension Set {
-  @_alwaysEmitIntoClient @inlinable // Introduced in 5.1
+  @export(implementation) // Introduced in 5.1
   @inline(__always)
   internal init?<C: Collection>(
     _mapping source: C,

--- a/stdlib/public/core/SetVariant.swift
+++ b/stdlib/public/core/SetVariant.swift
@@ -111,7 +111,7 @@ extension Set._Variant {
   }
 #endif
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal var convertedToNative: _NativeSet<Element> {
 #if _runtime(_ObjC)
     guard isNative else {  return _NativeSet<Element>(asCocoa) }
@@ -380,7 +380,7 @@ extension Set._Variant {
 }
 
 extension Set._Variant {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal consuming func filter<E: Error>(
     _ isIncluded: (Element) throws(E) -> Bool
   ) throws(E) -> _NativeSet<Element> {
@@ -400,7 +400,7 @@ extension Set._Variant {
     return try asNative.filter(isIncluded)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal __consuming func intersection(
     _ other: Set<Element>
   ) -> _NativeSet<Element> {

--- a/stdlib/public/core/Shims.swift
+++ b/stdlib/public/core/Shims.swift
@@ -37,7 +37,7 @@ internal let _fastEnumerationStorageMutationsPtr =
   unsafe UnsafeMutablePointer<CUnsignedLong>(Builtin.addressof(&_fastEnumerationStorageMutationsTarget))
 #endif
 
-@usableFromInline @_alwaysEmitIntoClient
+@export(implementation)
 internal func _mallocSize(ofAllocation ptr: UnsafeRawPointer) -> Int? {
   return unsafe _swift_stdlib_has_malloc_size() ? _swift_stdlib_malloc_size(ptr) : nil
 }

--- a/stdlib/public/core/Slice.swift
+++ b/stdlib/public/core/Slice.swift
@@ -136,7 +136,7 @@ public struct Slice<Base: Collection> {
     return _base
   }
 
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   internal var _bounds: Range<Base.Index> {
     unsafe Range(_uncheckedBounds: (_startIndex, _endIndex))
   }
@@ -221,7 +221,7 @@ extension Slice: Collection {
     _base._failEarlyRangeCheck(range, bounds: bounds)
   }
 
-  @_alwaysEmitIntoClient @inlinable
+  @export(implementation)
   @safe
   public func withContiguousStorageIfAvailable<R>(
     _ body: (UnsafeBufferPointer<Element>) throws -> R
@@ -236,7 +236,7 @@ extension Slice: Collection {
 }
 
 extension Slice {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public __consuming func _copyContents(
       initializing buffer: UnsafeMutableBufferPointer<Element>
   ) -> (Iterator, UnsafeMutableBufferPointer<Element>.Index) {
@@ -293,7 +293,7 @@ extension Slice: MutableCollection where Base: MutableCollection {
     }
   }
 
-  @_alwaysEmitIntoClient @inlinable
+  @export(implementation)
   @safe
   public mutating func withContiguousMutableStorageIfAvailable<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R

--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -109,7 +109,7 @@ internal struct _SliceBuffer<Element>
     }
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   internal func getSubscriptBaseAddress() -> UnsafeMutablePointer<Element> {
 #if $BuiltinMarkDependence
@@ -351,7 +351,7 @@ internal struct _SliceBuffer<Element>
   ///
   /// - Warning: It's a requirement to call `beginCOWMutation` before the buffer
   ///   is mutated.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func beginCOWMutation() -> Bool {
     if !_hasNativeBuffer {
       return false
@@ -371,7 +371,7 @@ internal struct _SliceBuffer<Element>
   ///
   /// - Warning: After a call to `endCOWMutation` the buffer must not be mutated
   ///   until the next call of `beginCOWMutation`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   internal mutating func endCOWMutation() {
 #if INTERNAL_CHECKS_ENABLED && COW_CHECKS_ENABLED
@@ -455,7 +455,7 @@ internal struct _SliceBuffer<Element>
 
   /// Call `body(p)`, where `p` is an `UnsafeBufferPointer` over the
   /// underlying contiguous storage.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func withUnsafeBufferPointer<R, E>(
     _ body: (UnsafeBufferPointer<Element>) throws(E) -> R
   ) throws(E) -> R {
@@ -478,7 +478,7 @@ internal struct _SliceBuffer<Element>
 
   /// Call `body(p)`, where `p` is an `UnsafeMutableBufferPointer`
   /// over the underlying contiguous storage.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func withUnsafeMutableBufferPointer<R, E>(
     _ body: (UnsafeMutableBufferPointer<Element>) throws(E) -> R
   ) throws(E) -> R {
@@ -523,7 +523,7 @@ extension _SliceBuffer {
 }
 
 extension _SliceBuffer {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func isTriviallyIdentical(to other: Self) -> Bool {
 #if $Embedded
     if

--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -93,7 +93,7 @@ extension _SmallString {
 #endif
   }
 
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   internal static func contiguousCapacity() -> Int {
 #if os(watchOS) && _pointerBitWidth(_32)
     return capacity &- 2
@@ -223,13 +223,13 @@ extension _SmallString: RandomAccessCollection, MutableCollection {
     }
     // This setter is required for _SmallString to be a valid MutableCollection.
     // Since _SmallString is internal and this setter unused, we cheat.
-    @_alwaysEmitIntoClient set { fatalError() }
-    @_alwaysEmitIntoClient _modify { fatalError() }
+    @export(implementation) set { fatalError() }
+    @export(implementation) _modify { fatalError() }
   }
 }
 
 extension _SmallString {
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   @safe
   internal func withUTF8<Result, E: Error>(
     _ f: (UnsafeBufferPointer<UInt8>) throws(E) -> Result
@@ -284,8 +284,7 @@ extension _SmallString {
     self = _SmallString(leading: _storage.0, trailing: _storage.1, count: len)
   }
 
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal static func zeroTrailingBytes(
     of storage: inout RawBitPattern, from index: Int
   ) {

--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -28,13 +28,13 @@ public struct MutableRawSpan: ~Copyable & ~Escapable {
   internal let _count: Int
 
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func _start() -> UnsafeMutableRawPointer {
     unsafe _pointer._unsafelyUnwrappedUnchecked
   }
 
   /// Create an empty span.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   @_lifetime(immortal)
   public init() {
@@ -43,7 +43,7 @@ public struct MutableRawSpan: ~Copyable & ~Escapable {
   }
 
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow pointer)
   internal init(
     _unchecked pointer: UnsafeMutableRawPointer?,
@@ -63,7 +63,7 @@ extension MutableRawSpan: @unchecked Sendable {}
 extension MutableRawSpan {
 
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow bytes)
   public init(
     _unsafeBytes bytes: UnsafeMutableRawBufferPointer
@@ -74,7 +74,7 @@ extension MutableRawSpan {
   }
 
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow bytes)
   public init(
     _unsafeBytes bytes: borrowing Slice<UnsafeMutableRawBufferPointer>
@@ -85,7 +85,7 @@ extension MutableRawSpan {
   }
 
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow pointer)
   public init(
     _unsafeStart pointer: UnsafeMutableRawPointer,
@@ -96,7 +96,7 @@ extension MutableRawSpan {
   }
 
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow elements)
   public init<Element: BitwiseCopyable>(
     _unsafeElements elements: UnsafeMutableBufferPointer<Element>
@@ -107,7 +107,7 @@ extension MutableRawSpan {
   }
 
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow elements)
   public init<Element: BitwiseCopyable>(
     _unsafeElements elements: borrowing Slice<UnsafeMutableBufferPointer<Element>>
@@ -117,7 +117,7 @@ extension MutableRawSpan {
     self = unsafe _overrideLifetime(span, borrowing: elements)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&elements)
   @unsafe
   public init<Element: BitwiseCopyable>(
@@ -134,7 +134,7 @@ extension MutableRawSpan {
   /// address of `elements` must be well-aligned for `Element`.
   ///
   /// - Parameter elements: A typed span to reinterpret as raw bytes.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&elements)
   public init<Element: ConvertibleFromBytes & ConvertibleToBytes>(
     mutating elements: inout MutableSpan<Element>
@@ -150,7 +150,7 @@ extension MutableRawSpan {
   /// - Parameters:
   ///   - elements: An existing `MutableSpan<Element>`, from which this
   ///     `MutableRawSpan` will inherit its lifetime.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @unsafe
   @_lifetime(copy elements)
   public init<Element>(
@@ -175,7 +175,7 @@ extension MutableRawSpan {
   /// - Parameters:
   ///   - elements: An existing `MutableSpan<Element>`, from which this
   ///     `MutableRawSpan` will inherit its lifetime.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy elements)
   public init<Element: ConvertibleToBytes & ConvertibleFromBytes>(
     elements: consuming MutableSpan<Element>
@@ -188,19 +188,19 @@ extension MutableRawSpan {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableRawSpan {
   /// The number of bytes in the span.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_semantics("fixed_storage.get_count")
   public var byteCount: Int { _assumeNonNegative(_count) }
 
   /// A Boolean value indicating whether the span is empty.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public var isEmpty: Bool { byteCount == 0 }
 
   /// The valid byte offsets for accessing this span, in ascending order.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var byteOffsets: Range<Int> {
     unsafe Range(_uncheckedBounds: (0, byteCount))
   }
@@ -212,7 +212,7 @@ extension MutableRawSpan {
   // SILOptimizer looks for fixed_storage.check_index semantics
   // for bounds checking optimizations.
   @_semantics("fixed_storage.check_index")
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   internal func _checkIndex(_ position: Int) {
     _precondition(byteOffsets.contains(position), "Index out of bounds")
   }
@@ -221,7 +221,7 @@ extension MutableRawSpan {
   ///
   /// - Parameter byteOffset: The offset of the byte to access. `byteOffset`
   ///     must be greater than or equal to zero, and less than `byteCount`.
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   public subscript(_ byteOffset: Int) -> UInt8 {
     get {
       _checkIndex(byteOffset)
@@ -240,7 +240,7 @@ extension MutableRawSpan {
   ///
   /// - Parameter byteOffset: The offset of the byte to access. `byteOffset`
   ///     must be greater than or equal to zero, and less than `byteCount`.
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   @unsafe
   public subscript(unchecked byteOffset: Int) -> UInt8 {
     get {
@@ -272,7 +272,7 @@ extension MutableRawSpan {
   ///   The closure's parameter is valid only for the duration of
   ///   its execution.
   /// - Returns: The return value of the `body` closure parameter.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   @safe
   public func withUnsafeBytes<E: Error, Result: ~Copyable>(
@@ -295,7 +295,7 @@ extension MutableRawSpan {
   ///   The closure's parameter is valid only for the duration of
   ///   its execution.
   /// - Returns: The return value of the `body` closure parameter.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   @_lifetime(self: copy self)
   @safe
@@ -310,7 +310,7 @@ extension MutableRawSpan {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension RawSpan {
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow mutableRawSpan)
   public init(_mutableRawSpan mutableRawSpan: borrowing MutableRawSpan) {
     let (start, count) = unsafe (mutableRawSpan._pointer, mutableRawSpan._count)
@@ -325,7 +325,7 @@ extension MutableRawSpan {
 
   /// Borrow the underlying initialized memory for read-only access.
   public var bytes: RawSpan {
-    @_alwaysEmitIntoClient
+    @export(implementation)
     @_transparent
     @_lifetime(borrow self)
     borrowing get {
@@ -334,7 +334,7 @@ extension MutableRawSpan {
   }
 
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow self)
   public borrowing func _unsafeView<T: BitwiseCopyable>(
     as type: T.Type
@@ -345,7 +345,7 @@ extension MutableRawSpan {
   }
 
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   public mutating func _unsafeMutableView<T: BitwiseCopyable>(
     as type: T.Type
@@ -380,7 +380,7 @@ extension MutableRawSpan {
   ///     `offset`. The returned instance is memory-managed and unassociated
   ///     with the value in the memory referenced by this pointer.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func unsafeLoad<T>(
     fromByteOffset offset: Int = 0, as type: T.Type
   ) -> T {
@@ -411,7 +411,7 @@ extension MutableRawSpan {
   ///     `offset`. The returned instance is memory-managed and unassociated
   ///     with the value in the memory referenced by this pointer.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func unsafeLoad<T>(
     fromUncheckedByteOffset offset: Int, as type: T.Type
   ) -> T {
@@ -435,7 +435,7 @@ extension MutableRawSpan {
   ///     `offset`. The returned instance isn't associated
   ///     with the value in the range of memory referenced by this pointer.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func unsafeLoadUnaligned<T: BitwiseCopyable>(
     fromByteOffset offset: Int = 0, as type: T.Type
   ) -> T {
@@ -465,7 +465,7 @@ extension MutableRawSpan {
   ///     `offset`. The returned instance isn't associated
   ///     with the value in the range of memory referenced by this pointer.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func unsafeLoadUnaligned<T: BitwiseCopyable>(
     fromUncheckedByteOffset offset: Int, as type: T.Type
   ) -> T {
@@ -483,7 +483,7 @@ extension MutableRawSpan {
   ///     `offset` must be nonnegative.
   ///   - type: The type of the instance to create.
   /// - Returns: A new value of type `T`, read from `offset`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func load<T: ConvertibleFromBytes>(
     fromByteOffset offset: Int,
     as type: T.Type
@@ -503,7 +503,7 @@ extension MutableRawSpan {
   ///   - type: The type of the instance to create.
   ///   - byteOrder: The order in which the bytes will be decoded.
   /// - Returns: A new value of type `T`, read from `offset`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(SwiftStdlib 6.4, *)
   public func load<T: ConvertibleFromBytes & FixedWidthInteger>(
     fromByteOffset offset: Int,
@@ -526,7 +526,7 @@ extension MutableRawSpan {
   ///     `offset` must be nonnegative. The default is zero.
   ///   - type: The type of `value`.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(self: copy self)
   public mutating func storeBytes<T: BitwiseCopyable>(
     of value: T, toByteOffset offset: Int = 0, as type: T.Type
@@ -535,7 +535,7 @@ extension MutableRawSpan {
   }
 
   @unsafe
-  @_alwaysEmitIntoClient @_transparent
+  @export(implementation) @_transparent
   @_lifetime(self: copy self)
   internal mutating func _storeBytes<T: BitwiseCopyable>(
     of value: T, toByteOffset offset: Int, as type: T.Type
@@ -559,7 +559,7 @@ extension MutableRawSpan {
   ///     `offset` must be nonnegative.
   ///   - type: The type of `value`.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(self: copy self)
   public mutating func storeBytes<T: BitwiseCopyable>(
     of value: T, toUncheckedByteOffset offset: Int, as type: T.Type
@@ -578,7 +578,7 @@ extension MutableRawSpan {
   ///   - offset: The offset in bytes into the span's memory at which to begin
   ///       writing the bytes from the value.
   ///   - type: The type of the instance to store.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(self: copy self)
   public mutating func storeBytes<T: ConvertibleToBytes & BitwiseCopyable>(
     of value: T, toByteOffset offset: Int, as type: T.Type
@@ -599,7 +599,7 @@ extension MutableRawSpan {
   ///       writing the bytes from the value.
   ///   - type: The type of the instance to store.
   ///   - byteOrder: The order in which the bytes will be encoded to the span.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(SwiftStdlib 6.4, *)
   @_lifetime(self: copy self)
   public mutating func storeBytes<
@@ -629,7 +629,7 @@ extension MutableRawSpan {
   ///      into this span.
   ///   - type: The type of the instance to store repeatedly.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(self: copy self)
   public mutating func storeBytes<T: BitwiseCopyable>(
     repeating repeatedValue: T, count: Int, as type: T.Type
@@ -638,7 +638,7 @@ extension MutableRawSpan {
   }
 
   @unsafe
-  @_alwaysEmitIntoClient @_transparent
+  @export(implementation) @_transparent
   @_lifetime(self: copy self)
   internal mutating func _storeBytes<T: BitwiseCopyable>(
     repeating repeatedValue: T, count: Int, as type: T.Type
@@ -662,7 +662,7 @@ extension MutableRawSpan {
   ///   - count: The number of copies of `repeatedValue` to store
   ///      into this span.
   ///   - type: The type of the instance to store repeatedly.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(self: copy self)
   public mutating func storeBytes<T: ConvertibleToBytes & BitwiseCopyable>(
     repeating repeatedValue: T, count: Int, as type: T.Type
@@ -681,7 +681,7 @@ extension MutableRawSpan {
   ///      into this span.
   ///   - type: The type of the instance to store repeatedly.
   ///   - byteOrder: The order in which the bytes will be encoded to the span.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(SwiftStdlib 6.4, *)
   @_lifetime(self: copy self)
   public mutating func storeBytes<
@@ -720,7 +720,7 @@ extension MutableRawSpan {
   /// - Returns: A `MutableRawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func _mutatingExtracting(_ bounds: Range<Int>) -> Self {
     _precondition(
@@ -747,7 +747,7 @@ extension MutableRawSpan {
   ///
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(_:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func extracting(_ bounds: Range<Int>) -> Self {
     _mutatingExtracting(bounds)
@@ -766,7 +766,7 @@ extension MutableRawSpan {
   /// - Returns: A `MutableRawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   consuming public func _consumingExtracting(_ bounds: Range<Int>) -> Self {
     _precondition(
@@ -795,7 +795,7 @@ extension MutableRawSpan {
   ///
   /// - Complexity: O(1)
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func _mutatingExtracting(unchecked bounds: Range<Int>) -> Self {
     let newStart = unsafe _pointer?.advanced(by: bounds.lowerBound)
@@ -822,7 +822,7 @@ extension MutableRawSpan {
   /// - Complexity: O(1)
   @unsafe
   @available(*, deprecated, renamed: "_mutatingExtracting(unchecked:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func extracting(unchecked bounds: Range<Int>) -> Self {
     unsafe _mutatingExtracting(unchecked: bounds)
@@ -844,7 +844,7 @@ extension MutableRawSpan {
   ///
   /// - Complexity: O(1)
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   consuming public func _consumingExtracting(unchecked bounds: Range<Int>) -> Self {
     let newStart = unsafe _pointer?.advanced(by: bounds.lowerBound)
@@ -867,7 +867,7 @@ extension MutableRawSpan {
   /// - Returns: A `MutableRawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func _mutatingExtracting(
     _ bounds: some RangeExpression<Int>
@@ -891,7 +891,7 @@ extension MutableRawSpan {
   ///
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(_:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func extracting(
     _ bounds: some RangeExpression<Int>
@@ -912,7 +912,7 @@ extension MutableRawSpan {
   /// - Returns: A `MutableRawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   consuming public func _consumingExtracting(
     _ bounds: some RangeExpression<Int>
@@ -938,7 +938,7 @@ extension MutableRawSpan {
   ///
   /// - Complexity: O(1)
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func _mutatingExtracting(
     unchecked bounds: ClosedRange<Int>
@@ -968,7 +968,7 @@ extension MutableRawSpan {
   /// - Complexity: O(1)
   @unsafe
   @available(*, deprecated, renamed: "_mutatingExtracting(unchecked:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func extracting(
     unchecked bounds: ClosedRange<Int>
@@ -992,7 +992,7 @@ extension MutableRawSpan {
   ///
   /// - Complexity: O(1)
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   consuming public func _consumingExtracting(
     unchecked bounds: ClosedRange<Int>
@@ -1014,7 +1014,7 @@ extension MutableRawSpan {
   /// - Returns: A `MutableRawSpan` over all the bytes of this span.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func _mutatingExtracting(_: UnboundedRange) -> Self {
     unsafe _overrideLifetime(
@@ -1022,7 +1022,7 @@ extension MutableRawSpan {
     )
   }
 
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   internal var _reborrowed: Self {
     @_lifetime(&self)
     mutating get { _mutatingExtracting(...) }
@@ -1040,7 +1040,7 @@ extension MutableRawSpan {
   ///
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(_:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func extracting(_: UnboundedRange) -> Self {
     _mutatingExtracting(...)
@@ -1055,7 +1055,7 @@ extension MutableRawSpan {
   /// - Returns: A `MutableRawSpan` over all the bytes of this span.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   consuming public func _consumingExtracting(_: UnboundedRange) -> Self {
     self
@@ -1084,7 +1084,7 @@ extension MutableRawSpan {
   /// - Returns: A span with at most `maxLength` bytes.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func _mutatingExtracting(first maxLength: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)
@@ -1115,7 +1115,7 @@ extension MutableRawSpan {
   ///
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(first:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func extracting(first maxLength: Int) -> Self {
     _mutatingExtracting(first: maxLength)
@@ -1136,7 +1136,7 @@ extension MutableRawSpan {
   /// - Returns: A span with at most `maxLength` bytes.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   consuming public func _consumingExtracting(first maxLength: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)
@@ -1165,7 +1165,7 @@ extension MutableRawSpan {
   /// - Returns: A span leaving off the specified number of bytes at the end.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func _mutatingExtracting(droppingLast k: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)
@@ -1196,7 +1196,7 @@ extension MutableRawSpan {
   ///
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(droppingLast:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func extracting(droppingLast k: Int) -> Self {
     _mutatingExtracting(droppingLast: k)
@@ -1216,7 +1216,7 @@ extension MutableRawSpan {
   /// - Returns: A span leaving off the specified number of bytes at the end.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   consuming public func _consumingExtracting(droppingLast k: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)
@@ -1247,7 +1247,7 @@ extension MutableRawSpan {
   /// - Returns: A span with at most `maxLength` bytes.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func _mutatingExtracting(last maxLength: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)
@@ -1279,7 +1279,7 @@ extension MutableRawSpan {
   ///
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(last:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func extracting(last maxLength: Int) -> Self {
     _mutatingExtracting(last: maxLength)
@@ -1300,7 +1300,7 @@ extension MutableRawSpan {
   /// - Returns: A span with at most `maxLength` bytes.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   consuming public func _consumingExtracting(last maxLength: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)
@@ -1330,7 +1330,7 @@ extension MutableRawSpan {
   /// - Returns: A span starting after the specified number of bytes.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func _mutatingExtracting(droppingFirst k: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)
@@ -1362,7 +1362,7 @@ extension MutableRawSpan {
   ///
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(droppingFirst:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func extracting(droppingFirst k: Int) -> Self {
     _mutatingExtracting(droppingFirst: k)
@@ -1382,7 +1382,7 @@ extension MutableRawSpan {
   /// - Returns: A span starting after the specified number of bytes.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   consuming public func _consumingExtracting(droppingFirst k: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -29,14 +29,14 @@ public struct MutableSpan<Element: ~Copyable>
   internal let _count: Int
 
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal func _start() -> UnsafeMutableRawPointer {
     unsafe _pointer._unsafelyUnwrappedUnchecked
   }
 
   /// Create an empty span.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   @_lifetime(immortal)
   public init() {
@@ -45,7 +45,7 @@ public struct MutableSpan<Element: ~Copyable>
   }
 
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow start)
   internal init(
     _unchecked start: UnsafeMutableRawPointer?,
@@ -65,7 +65,7 @@ extension MutableSpan: @unchecked Sendable where Element: Sendable & ~Copyable {
 extension MutableSpan where Element: ~Copyable {
 
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow elements)
   internal init(
     _unchecked elements: UnsafeMutableBufferPointer<Element>
@@ -75,7 +75,7 @@ extension MutableSpan where Element: ~Copyable {
   }
 
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow buffer)
   public init(
     _unsafeElements buffer: UnsafeMutableBufferPointer<Element>
@@ -90,7 +90,7 @@ extension MutableSpan where Element: ~Copyable {
   }
 
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   @_lifetime(borrow start)
   public init(
@@ -109,7 +109,7 @@ extension MutableSpan where Element: ~Copyable {
 extension MutableSpan {
 
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow elements)
   public init(
     _unsafeElements elements: borrowing Slice<UnsafeMutableBufferPointer<Element>>
@@ -125,7 +125,7 @@ extension MutableSpan {
 extension MutableSpan where Element: BitwiseCopyable {
 
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow buffer)
   public init(
     _unsafeBytes buffer: UnsafeMutableRawBufferPointer
@@ -147,7 +147,7 @@ extension MutableSpan where Element: BitwiseCopyable {
   }
 
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow pointer)
   public init(
     _unsafeStart pointer: UnsafeMutableRawPointer,
@@ -162,7 +162,7 @@ extension MutableSpan where Element: BitwiseCopyable {
   }
 
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow buffer)
   public init(
     _unsafeBytes buffer: borrowing Slice<UnsafeMutableRawBufferPointer>
@@ -184,7 +184,7 @@ extension MutableSpan where Element: ConvertibleFromBytes & ConvertibleToBytes {
   /// this initializer will trap at runtime.
   ///
   /// - Parameter mutableBytes: A raw span to reinterpret as typed elements.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&mutableBytes)
   public init(mutating mutableBytes: inout MutableRawSpan) {
     _precondition(
@@ -210,7 +210,7 @@ extension MutableSpan where Element: ConvertibleFromBytes & ConvertibleToBytes {
   /// this initializer will trap at runtime.
   ///
   /// - Parameter mutableBytes: A raw span to reinterpret as typed elements.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy mutableBytes)
   public init(mutableBytes: consuming MutableRawSpan) {
     _precondition(
@@ -233,7 +233,7 @@ extension MutableSpan where Element: ConvertibleFromBytes & ConvertibleToBytes {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Span where Element: ~Copyable {
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow mutableSpan)
   public init(_mutableSpan mutableSpan: borrowing MutableSpan<Element>) {
     let pointer =
@@ -251,7 +251,7 @@ extension Span where Element: ~Copyable {
 extension MutableSpan where Element: ~Copyable {
 
   /// Borrow the underlying initialized memory for read-only access.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public var span: Span<Element> {
     @_lifetime(borrow self)
@@ -265,7 +265,7 @@ extension MutableSpan where Element: ~Copyable {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension RawSpan {
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @unsafe
   @_lifetime(borrow mutableSpan)
   public init<Element>(
@@ -283,7 +283,7 @@ extension RawSpan {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableSpan where Element: ~Copyable {
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var _description: String {
     let addr = unsafe String(
       UInt(bitPattern: _pointer), radix: 16, uppercase: false
@@ -298,12 +298,12 @@ extension MutableSpan where Element: ~Copyable {
 extension MutableSpan where Element: ~Copyable {
 
   /// The number of elements in the span.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_semantics("fixed_storage.get_count")
   public var count: Int { _assumeNonNegative(_count) }
 
   /// A Boolean value indicating whether the span is empty.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public var isEmpty: Bool { _count == 0 }
 
@@ -311,7 +311,7 @@ extension MutableSpan where Element: ~Copyable {
   public typealias Index = Int
 
   /// The range of valid indices for subscripting the span.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var indices: Range<Index> {
     unsafe Range(_uncheckedBounds: (0, count))
   }
@@ -324,7 +324,7 @@ extension MutableSpan where Element: Copyable {
   /// Construct a raw span over the memory represented by this span.
   ///
   /// - Returns: A `RawSpan` over the memory represented by this span.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   @unsafe
   public var bytes: RawSpan {
@@ -346,7 +346,7 @@ extension MutableSpan where Element: BitwiseCopyable {
   /// bit pattern in the corresponding instance of `Element`.
   ///
   /// - Returns: A `MutableRawSpan` over the memory represented by this span.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   @unsafe
   public var mutableBytes: MutableRawSpan {
@@ -363,7 +363,7 @@ extension MutableSpan where Element: ConvertibleToBytes {
   /// A raw span over the memory represented by this span.
   ///
   /// - Returns: A RawSpan over the memory represented by this span.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public var bytes: RawSpan {
     @_lifetime(borrow self)
@@ -379,7 +379,7 @@ extension MutableSpan where Element: ConvertibleToBytes & ConvertibleFromBytes {
   /// A mutable raw span over the memory represented by this span.
   ///
   /// - Returns: A MutableRawSpan over the memory represented by this span.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public var mutableBytes: MutableRawSpan {
     @_lifetime(&self)
@@ -395,7 +395,7 @@ extension MutableSpan where Element: ~Copyable {
   // SILOptimizer looks for fixed_storage.check_index semantics for bounds check optimizations.
   @_semantics("fixed_storage.check_index")
   @inline(__always)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func _checkIndex(_ position: Index) {
     _precondition(indices.contains(position), "index out of bounds")
   }
@@ -405,7 +405,7 @@ extension MutableSpan where Element: ~Copyable {
   ///     must be greater or equal to zero, and less than `count`.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public subscript(_ position: Index) -> Element {
     @_transparent
     borrow {
@@ -429,7 +429,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public subscript(unchecked position: Index) -> Element {
     @_transparent
     @_unsafeSelfDependentResult
@@ -447,7 +447,7 @@ extension MutableSpan where Element: ~Copyable {
   }
 
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal func _unsafeAddressOfElement(
     unchecked position: Index
@@ -469,7 +469,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Parameter i: A valid index into this span.
   /// - Parameter j: A valid index into this span.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(self: copy self)
   public mutating func swapAt(_ i: Index, _ j: Index) {
     _precondition(indices.contains(Index(i)))
@@ -484,7 +484,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Parameter i: A valid index into this span.
   /// - Parameter j: A valid index into this span.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(self: copy self)
   public mutating func swapAt(unchecked i: Index, unchecked j: Index) {
     let ri = unsafe _unsafeAddressOfElement(unchecked: i)
@@ -514,7 +514,7 @@ extension MutableSpan where Element: ~Copyable {
   ///   parameter is valid only for the duration of its execution.
   /// - Returns: The return value of the `body` closure parameter.
   //FIXME: mark closure parameter as non-escaping
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   @safe
   public func withUnsafeBufferPointer<E: Error, Result: ~Copyable>(
@@ -537,7 +537,7 @@ extension MutableSpan where Element: ~Copyable {
   ///   parameter is valid only for the duration of its execution.
   /// - Returns: The return value of the `body` closure parameter.
   //FIXME: mark closure parameter as non-escaping
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   @_lifetime(self: copy self)
   @safe
@@ -575,7 +575,7 @@ extension MutableSpan where Element: BitwiseCopyable {
   ///   its execution.
   /// - Returns: The return value of the `body` closure parameter.
   //FIXME: mark closure parameter as non-escaping
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   @safe
   public func withUnsafeBytes<E: Error, Result: ~Copyable>(
@@ -599,7 +599,7 @@ extension MutableSpan where Element: BitwiseCopyable {
   ///   its execution.
   /// - Returns: The return value of the `body` closure parameter.
   //FIXME: mark closure parameter as non-escaping
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   @_lifetime(self: copy self)
   @safe
@@ -621,7 +621,7 @@ extension MutableSpan {
   /// Update every element of this span to the given value.
   ///
   /// - Parameter repeatedValue: The value to set for every element.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(self: copy self)
   public mutating func update(repeating repeatedValue: consuming Element) {
     guard !isEmpty else { return }
@@ -651,7 +651,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Returns: A `MutableSpan` over the items within `bounds`.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func _mutatingExtracting(_ bounds: Range<Index>) -> Self {
     _precondition(
@@ -678,7 +678,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(_:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func extracting(_ bounds: Range<Index>) -> Self {
     _mutatingExtracting(bounds)
@@ -697,7 +697,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Returns: A `MutableSpan` over the items within `bounds`.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   consuming public func _consumingExtracting(_ bounds: Range<Index>) -> Self {
     _precondition(
@@ -726,7 +726,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func _mutatingExtracting(unchecked bounds: Range<Index>) -> Self {
     let delta = bounds.lowerBound &* MemoryLayout<Element>.stride
@@ -754,7 +754,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Complexity: O(1)
   @unsafe
   @available(*, deprecated, renamed: "_mutatingExtracting(unchecked:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func extracting(unchecked bounds: Range<Index>) -> Self {
     unsafe _mutatingExtracting(unchecked: bounds)
@@ -776,7 +776,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   consuming public func _consumingExtracting(unchecked bounds: Range<Index>) -> Self {
     let delta = bounds.lowerBound &* MemoryLayout<Element>.stride
@@ -800,7 +800,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Returns: A `MutableSpan` over the items within `bounds`.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func _mutatingExtracting(
     _ bounds: some RangeExpression<Index>
@@ -824,7 +824,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(_:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func extracting(
     _ bounds: some RangeExpression<Index>
@@ -845,7 +845,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Returns: A `MutableSpan` over the items within `bounds`.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   consuming public func _consumingExtracting(
     _ bounds: some RangeExpression<Index>
@@ -871,7 +871,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func _mutatingExtracting(
     unchecked bounds: ClosedRange<Index>
@@ -901,7 +901,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Complexity: O(1)
   @unsafe
   @available(*, deprecated, renamed: "_mutatingExtracting(unchecked:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func extracting(
     unchecked bounds: ClosedRange<Index>
@@ -925,7 +925,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   consuming public func _consumingExtracting(
     unchecked bounds: ClosedRange<Index>
@@ -947,7 +947,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Returns: A `MutableSpan` over all the items of this span.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func _mutatingExtracting(_: UnboundedRange) -> Self {
     unsafe _overrideLifetime(
@@ -955,7 +955,7 @@ extension MutableSpan where Element: ~Copyable {
     )
   }
 
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   internal var _reborrowed: Self {
     @_lifetime(&self)
     mutating get { _mutatingExtracting(...) }
@@ -973,7 +973,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(_:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func extracting(_: UnboundedRange) -> Self {
     _mutatingExtracting(...)
@@ -988,7 +988,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Returns: A `MutableSpan` over all the items of this span.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   consuming public func _consumingExtracting(_: UnboundedRange) -> Self {
     self
@@ -1017,7 +1017,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Returns: A span with at most `maxLength` elements.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func _mutatingExtracting(first maxLength: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)
@@ -1048,7 +1048,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(first:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func extracting(first maxLength: Int) -> Self {
     _mutatingExtracting(first: maxLength)
@@ -1069,7 +1069,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Returns: A span with at most `maxLength` elements.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   consuming public func _consumingExtracting(first maxLength: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)
@@ -1098,7 +1098,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Returns: A span leaving off the specified number of elements at the end.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func _mutatingExtracting(droppingLast k: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)
@@ -1129,7 +1129,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(droppingLast:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func extracting(droppingLast k: Int) -> Self {
     _mutatingExtracting(droppingLast: k)
@@ -1149,7 +1149,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Returns: A span leaving off the specified number of elements at the end.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   consuming public func _consumingExtracting(droppingLast k: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)
@@ -1180,7 +1180,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Returns: A span with at most `maxLength` elements.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func _mutatingExtracting(last maxLength: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)
@@ -1213,7 +1213,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(last:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func extracting(last maxLength: Int) -> Self {
     _mutatingExtracting(last: maxLength)
@@ -1234,7 +1234,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Returns: A span with at most `maxLength` elements.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   consuming public func _consumingExtracting(last maxLength: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)
@@ -1265,7 +1265,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Returns: A span starting after the specified number of elements.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func _mutatingExtracting(droppingFirst k: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)
@@ -1298,7 +1298,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(droppingFirst:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(&self)
   mutating public func extracting(droppingFirst k: Int) -> Self {
     _mutatingExtracting(droppingFirst: k)
@@ -1318,7 +1318,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Returns: A span starting after the specified number of elements.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   consuming public func _consumingExtracting(droppingFirst k: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)

--- a/stdlib/public/core/Span/OutputRawSpan.swift
+++ b/stdlib/public/core/Span/OutputRawSpan.swift
@@ -33,7 +33,7 @@ public struct OutputRawSpan: ~Copyable, ~Escapable {
   internal var _count: Int
 
   /// Create an OutputRawSpan with zero capacity.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(immortal)
   public init() {
     unsafe _pointer = nil
@@ -49,14 +49,14 @@ extension OutputRawSpan: @unchecked Sendable {}
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension OutputRawSpan {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   @unsafe
   internal func _start() -> UnsafeMutableRawPointer {
     unsafe _pointer._unsafelyUnwrappedUnchecked
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   @unsafe
   internal func _tail() -> UnsafeMutableRawPointer {
@@ -69,22 +69,22 @@ extension OutputRawSpan {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension OutputRawSpan {
   /// The number of initialized bytes in this span.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_semantics("fixed_storage.get_count")
   public var byteCount: Int { _assumeNonNegative(_count) }
 
   /// The number of additional bytes that can be appended to this span.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public var freeCapacity: Int { capacity &- _count }
 
   /// A Boolean value indicating whether the span is empty.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public var isEmpty: Bool { _count == 0 }
 
   /// A Boolean value indicating whether the span is full.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public var isFull: Bool { _count == capacity }
 
@@ -92,7 +92,7 @@ extension OutputRawSpan {
   /// order.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var byteOffsets: Range<Int> {
     unsafe Range(_uncheckedBounds: (0, byteCount))
   }
@@ -103,7 +103,7 @@ extension OutputRawSpan {
 extension OutputRawSpan {
 
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow buffer)
   internal init(
     _uncheckedBuffer buffer: UnsafeMutableRawBufferPointer,
@@ -126,7 +126,7 @@ extension OutputRawSpan {
   ///   - initializedCount: the number of initialized bytes
   ///                       at the beginning of `buffer`.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow buffer)
   public init(
     buffer: UnsafeMutableRawBufferPointer,
@@ -159,7 +159,7 @@ extension OutputRawSpan {
   ///   - initializedCount: the number of initialized bytes
   ///                       at the beginning of `buffer`.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow buffer)
   public init(
     buffer: borrowing Slice<UnsafeMutableRawBufferPointer>,
@@ -180,7 +180,7 @@ extension OutputRawSpan {
   /// Append a single byte to this span.
   ///
   /// - Parameter value: The byte to append.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(self: copy self)
   public mutating func append(_ value: UInt8) {
     unsafe _append(value, as: UInt8.self)
@@ -191,7 +191,7 @@ extension OutputRawSpan {
   /// Returns the last byte. The `OutputRawSpan` must not be empty.
   ///
   /// - Returns: The removed byte.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @discardableResult
   @_lifetime(self: copy self)
   public mutating func removeLast() -> UInt8 {
@@ -207,7 +207,7 @@ extension OutputRawSpan {
   ///
   /// - Parameter n: The number of bytes to remove.
   ///     `n` must not be negative or greater than `byteCount`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(self: copy self)
   public mutating func removeLast(_ n: Int) {
     _precondition(n >= 0, "Can't remove a negative number of bytes")
@@ -217,7 +217,7 @@ extension OutputRawSpan {
 
   /// Remove all this span's bytes and return its memory
   /// to the uninitialized state.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(self: copy self)
   public mutating func removeAll() {
     // TODO: Consider an option to zero the `_count` bytes being removed.
@@ -229,7 +229,7 @@ extension OutputRawSpan {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension OutputRawSpan {
   // Can we use: @_semantics("fixed_storage.check_index")
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   internal func _checkIndex(_ position: Int) {
     _precondition(position >= 0 && position < _count, "Index out of bounds")
   }
@@ -238,7 +238,7 @@ extension OutputRawSpan {
   ///
   /// - Parameter byteOffset: The offset of the byte to access. `byteOffset`
   ///     must be greater than or equal to zero, and less than `byteCount`.
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   public subscript(_ byteOffset: Int) -> UInt8 {
     get {
       _checkIndex(byteOffset)
@@ -257,7 +257,7 @@ extension OutputRawSpan {
   ///
   /// - Parameter byteOffset: The offset of the byte to access. `byteOffset`
   ///     must be greater than or equal to zero, and less than `byteCount`.
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   @unsafe
   public subscript(unchecked byteOffset: Int) -> UInt8 {
     get {
@@ -280,7 +280,7 @@ extension OutputRawSpan {
   /// - Parameters:
   ///   - value: The value to store as raw bytes.
   ///   - type: The type of the value.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @unsafe
   @_lifetime(self: copy self)
   public mutating func append<T: BitwiseCopyable>(_ value: T, as type: T.Type) {
@@ -288,7 +288,7 @@ extension OutputRawSpan {
   }
 
   /// Appends the given value's bytes to this span's bytes.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   @unsafe
   @_lifetime(self: copy self)
@@ -310,7 +310,7 @@ extension OutputRawSpan {
   /// - Parameters:
   ///   - value: The value to store as raw bytes.
   ///   - type: The type of the instance to store.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(self: copy self)
   public mutating func append<T>(
     _ value: T, as type: T.Type
@@ -327,7 +327,7 @@ extension OutputRawSpan {
   ///   - value: The value to store as raw bytes.
   ///   - type: The type of the instance to store.
   ///   - byteOrder: The order in which the bytes will be encoded to the span.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(SwiftStdlib 6.4, *)
   @_lifetime(self: copy self)
   public mutating func append<T>(
@@ -352,7 +352,7 @@ extension OutputRawSpan {
   ///   - count: The number of copies of `repeatedValue` to append
   ///       to this span.
   ///   - type: The type of the instance to store repeatedly.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @unsafe
   @_lifetime(self: copy self)
   public mutating func append<T: BitwiseCopyable>(
@@ -363,7 +363,7 @@ extension OutputRawSpan {
     unsafe _append(repeating: repeatedValue, count: count, as: T.self)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @unsafe
   @_lifetime(self: copy self)
   internal mutating func _append<T: BitwiseCopyable>(
@@ -387,7 +387,7 @@ extension OutputRawSpan {
   ///   - count: The number of copies of `repeatedValue` to append
   ///       to this span.
   ///   - type: The type of the instance to store repeatedly.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(self: copy self)
   public mutating func append<T>(
     repeating repeatedValue: T,
@@ -408,7 +408,7 @@ extension OutputRawSpan {
   ///       to this span.
   ///   - type: The type of the instance to store repeatedly.
   ///   - byteOrder: The order in which the bytes will be encoded to the span.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(SwiftStdlib 6.4, *)
   @_lifetime(self: copy self)
   public mutating func append<T>(
@@ -429,7 +429,7 @@ extension OutputRawSpan {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension OutputRawSpan {
   /// Borrow the underlying initialized memory for read-only access.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public var bytes: RawSpan {
     @_lifetime(borrow self)
@@ -441,7 +441,7 @@ extension OutputRawSpan {
   }
 
   /// Exclusively borrow the underlying initialized memory for mutation.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public var mutableBytes: MutableRawSpan {
     @_lifetime(&self)
@@ -484,7 +484,7 @@ extension OutputRawSpan {
   /// - Parameter body: A closure that can read from and write to the
   ///     buffer and update the initialized count.
   /// - Returns: The return value of the `body` closure.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   @_lifetime(self: copy self)
   @unsafe
@@ -528,7 +528,7 @@ extension OutputRawSpan {
   /// - Returns: The number of initialized bytes in the same buffer, as
   ///      tracked by the consumed `OutputRawSpan` instance.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public consuming func finalize(
     for buffer: UnsafeMutableRawBufferPointer
   ) -> Int {
@@ -555,7 +555,7 @@ extension OutputRawSpan {
   /// - Returns: The number of initialized bytes in the same buffer, as
   ///      tracked by the consumed `OutputRawSpan` instance.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public consuming func finalize(
     for buffer: Slice<UnsafeMutableRawBufferPointer>
   ) -> Int {

--- a/stdlib/public/core/Span/OutputSpan.swift
+++ b/stdlib/public/core/Span/OutputSpan.swift
@@ -32,8 +32,7 @@ public struct OutputSpan<Element: ~Copyable>: ~Copyable, ~Escapable {
   @usableFromInline
   internal var _count: Int
 
-  @_alwaysEmitIntoClient
-  @inlinable
+  @export(implementation)
   deinit {
     if _count > 0 {
       unsafe _start().withMemoryRebound(
@@ -46,7 +45,7 @@ public struct OutputSpan<Element: ~Copyable>: ~Copyable, ~Escapable {
   }
 
   /// Create an OutputSpan with zero capacity.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(immortal)
   public init() {
     unsafe _pointer = nil
@@ -62,14 +61,14 @@ extension OutputSpan: @unchecked Sendable where Element: Sendable & ~Copyable {}
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension OutputSpan where Element: ~Copyable {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   @unsafe
   internal func _start() -> UnsafeMutableRawPointer {
     unsafe _pointer._unsafelyUnwrappedUnchecked
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   @unsafe
   internal func _tail() -> UnsafeMutableRawPointer {
@@ -82,22 +81,22 @@ extension OutputSpan where Element: ~Copyable {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension OutputSpan where Element: ~Copyable {
   /// The number of initialized elements in this span.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_semantics("fixed_storage.get_count")
   public var count: Int { _assumeNonNegative(_count) }
 
   /// The number of additional elements that can be added to this span.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public var freeCapacity: Int { capacity &- _count }
 
   /// A Boolean value indicating whether the span is empty.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public var isEmpty: Bool { _count == 0 }
 
   /// A Boolean value indicating whether the span is full.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public var isFull: Bool { _count == capacity }
 }
@@ -107,9 +106,8 @@ extension OutputSpan where Element: ~Copyable {
 extension OutputSpan where Element: ~Copyable  {
 
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow buffer)
-  @usableFromInline
   internal init(
     _uncheckedBuffer buffer: UnsafeMutableBufferPointer<Element>,
     initializedCount: Int
@@ -132,7 +130,7 @@ extension OutputSpan where Element: ~Copyable  {
   ///   - initializedCount: the number of initialized elements
   ///                       at the beginning of `buffer`.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow buffer)
   public init(
     buffer: UnsafeMutableBufferPointer<Element>,
@@ -172,7 +170,7 @@ extension OutputSpan {
   ///   - initializedCount: the number of initialized elements
   ///                       at the beginning of `buffer`.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow buffer)
   public init(
     buffer: borrowing Slice<UnsafeMutableBufferPointer<Element>>,
@@ -193,7 +191,7 @@ extension OutputSpan where Element: ~Copyable {
   public typealias Index = Int
 
   /// The range of initialized indices for this `OutputSpan`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var indices: Range<Index> {
     unsafe Range(_uncheckedBounds: (0, count))
   }
@@ -201,7 +199,7 @@ extension OutputSpan where Element: ~Copyable {
   // SILOptimizer looks for fixed_storage.check_index semantics for bounds check optimizations.
   @_semantics("fixed_storage.check_index")
   @inline(__always)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func _checkIndex(_ index: Index) {
     _precondition(indices.contains(index), "index out of bounds")
   }
@@ -211,7 +209,7 @@ extension OutputSpan where Element: ~Copyable {
   /// - Parameter index: A valid index into this span.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public subscript(_ index: Index) -> Element {
     @_transparent
     borrow {
@@ -234,7 +232,7 @@ extension OutputSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public subscript(unchecked index: Index) -> Element {
     @_unsafeSelfDependentResult
     borrow {
@@ -250,7 +248,7 @@ extension OutputSpan where Element: ~Copyable {
   }
 
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func _unsafeAddressOfElement(
     unchecked index: Index
   ) -> Builtin.RawPointer {
@@ -262,7 +260,7 @@ extension OutputSpan where Element: ~Copyable {
   ///
   /// - Parameter i: A valid index into this span.
   /// - Parameter j: A valid index into this span.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(self: copy self)
   public mutating func swapAt(_ i: Index, _ j: Index) {
     _precondition(indices.contains(i))
@@ -277,7 +275,7 @@ extension OutputSpan where Element: ~Copyable {
   /// - Parameter i: A valid index into this span.
   /// - Parameter j: A valid index into this span.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(self: copy self)
   public mutating func swapAt(unchecked i: Index, unchecked j: Index) {
     let ri = unsafe _unsafeAddressOfElement(unchecked: i)
@@ -296,7 +294,7 @@ extension OutputSpan where Element: ~Copyable {
   /// Append a single element to this span.
   ///
   /// - Parameter value: The element to append.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(self: copy self)
   public mutating func append(_ value: consuming Element) {
     _precondition(_count < capacity, "OutputSpan capacity overflow")
@@ -309,7 +307,7 @@ extension OutputSpan where Element: ~Copyable {
   /// Returns the last element. The `OutputSpan` must not be empty.
   ///
   /// - Returns: The removed element.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(self: copy self)
   public mutating func removeLast() -> Element {
     _precondition(!isEmpty, "OutputSpan underflow")
@@ -326,7 +324,7 @@ extension OutputSpan where Element: ~Copyable {
   ///
   /// - Parameter n: The number of elements to remove.
   ///     `n` must not be negative or greater than `count`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(self: copy self)
   public mutating func removeLast(_ n: Int) {
     _precondition(n >= 0, "Can't remove a negative number of elements")
@@ -339,7 +337,7 @@ extension OutputSpan where Element: ~Copyable {
 
   /// Remove all this span's elements and return its memory
   /// to the uninitialized state.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(self: copy self)
   public mutating func removeAll() {
     guard count > 0 else { return }
@@ -361,7 +359,7 @@ extension OutputSpan {
   ///   - repeatedValue: The element to append repeatedly.
   ///   - count: The number of times to append `repeatedValue`.
   ///       `count` must not exceed `freeCapacity`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(self: copy self)
   public mutating func append(repeating repeatedValue: Element, count: Int) {
     _precondition(count <= freeCapacity, "OutputSpan capacity overflow")
@@ -376,7 +374,7 @@ extension OutputSpan {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension OutputSpan where Element: ~Copyable {
   /// Borrow the underlying initialized memory for read-only access.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public var span: Span<Element> {
     @_lifetime(borrow self)
@@ -389,7 +387,7 @@ extension OutputSpan where Element: ~Copyable {
   }
 
   /// Exclusively borrow the underlying initialized memory for mutation.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public var mutableSpan: MutableSpan<Element> {
     @_lifetime(&self)
@@ -432,7 +430,7 @@ extension OutputSpan where Element: ~Copyable {
   /// - Parameter body: A closure that can read from and write to the
   ///     buffer and update the initialized count.
   /// - Returns: The return value of the `body` closure.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   @_lifetime(self: copy self)
   @unsafe
@@ -479,7 +477,7 @@ extension OutputSpan where Element: ~Copyable {
   /// - Returns: The number of initialized elements in the same buffer, as
   ///      tracked by the consumed `OutputSpan` instance.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public consuming func finalize(
     for buffer: UnsafeMutableBufferPointer<Element>
   ) -> Int {
@@ -513,7 +511,7 @@ extension OutputSpan {
   /// - Returns: The number of initialized elements in the same buffer, as
   ///      tracked by the consumed `OutputSpan` instance.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public consuming func finalize(
     for buffer: Slice<UnsafeMutableBufferPointer<Element>>
   ) -> Int {
@@ -525,7 +523,7 @@ extension OutputSpan {
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension OutputSpan where Element: ~Copyable {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(self: copy self)
   internal mutating func _append(
     moving source: UnsafeMutableBufferPointer<Element>
@@ -541,7 +539,7 @@ extension OutputSpan where Element: ~Copyable {
     }
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(self: copy self)
   @_lifetime(source: copy source)
   internal mutating func _append(moving source: inout OutputSpan<Element>) {
@@ -557,7 +555,7 @@ extension OutputSpan where Element: ~Copyable {
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension OutputSpan where Element: Copyable {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(self: copy self)
   internal mutating func _append(copying source: UnsafeBufferPointer<Element>) {
     unsafe self.withUnsafeMutableBufferPointer { dst, dstCount in
@@ -570,7 +568,7 @@ extension OutputSpan where Element: Copyable {
     }
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(self: copy self)
   internal mutating func _append(copying source: Span<Element>) {
     source.withUnsafeBufferPointer { buffer in

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -38,7 +38,7 @@ public struct RawSpan: ~Escapable, Copyable, BitwiseCopyable {
   internal let _pointer: UnsafeRawPointer?
 
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func _start() -> UnsafeRawPointer {
     unsafe _pointer._unsafelyUnwrappedUnchecked
   }
@@ -52,7 +52,7 @@ public struct RawSpan: ~Escapable, Copyable, BitwiseCopyable {
   internal let _count: Int
 
   /// Create an empty span.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   @_lifetime(immortal)
   public init() {
@@ -74,7 +74,7 @@ public struct RawSpan: ~Escapable, Copyable, BitwiseCopyable {
   ///   - pointer: a pointer to the first initialized byte.
   ///   - byteCount: the number of initialized bytes in the span.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   @_lifetime(borrow pointer)
   internal init(
@@ -103,7 +103,7 @@ extension RawSpan {
   /// - Parameters:
   ///   - buffer: an `UnsafeRawBufferPointer` to initialized memory.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow buffer)
   public init(
     _unsafeBytes buffer: UnsafeRawBufferPointer
@@ -124,7 +124,7 @@ extension RawSpan {
   /// - Parameters:
   ///   - buffer: a `Slice<UnsafeRawBufferPointer>` to initialized memory.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow buffer)
   public init(
     _unsafeBytes buffer: borrowing Slice<UnsafeRawBufferPointer>
@@ -145,7 +145,7 @@ extension RawSpan {
   /// - Parameters:
   ///   - buffer: an `UnsafeMutableRawBufferPointer` to initialized memory.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow buffer)
   public init(
     _unsafeBytes buffer: UnsafeMutableRawBufferPointer
@@ -166,7 +166,7 @@ extension RawSpan {
   /// - Parameters:
   ///   - buffer: a `Slice<UnsafeMutableRawBufferPointer>` to initialized memory.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow buffer)
   public init(
     _unsafeBytes buffer: borrowing Slice<UnsafeMutableRawBufferPointer>
@@ -191,7 +191,7 @@ extension RawSpan {
   ///   - pointer: a pointer to the first initialized byte.
   ///   - byteCount: the number of initialized bytes in the span.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow pointer)
   public init(
     _unsafeStart pointer: UnsafeRawPointer,
@@ -210,7 +210,7 @@ extension RawSpan {
   /// - Parameters:
   ///   - buffer: an `UnsafeBufferPointer<T>` to initialized memory.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow buffer)
   public init<T: BitwiseCopyable>(
     _unsafeElements buffer: UnsafeBufferPointer<T>
@@ -231,7 +231,7 @@ extension RawSpan {
   /// - Parameters:
   ///   - buffer: a `Slice<UnsafeBufferPointer<T>>` to initialized memory.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow buffer)
   public init<T: BitwiseCopyable>(
     _unsafeElements buffer: borrowing Slice<UnsafeBufferPointer<T>>
@@ -252,7 +252,7 @@ extension RawSpan {
   /// - Parameters:
   ///   - buffer: an `UnsafeMutableBufferPointer<T>` to initialized memory.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow buffer)
   public init<T: BitwiseCopyable>(
     _unsafeElements buffer: UnsafeMutableBufferPointer<T>
@@ -273,7 +273,7 @@ extension RawSpan {
   /// - Parameters:
   ///   - buffer: a `Slice<UnsafeMutableBufferPointer<T>>` to initialized memory.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow buffer)
   public init<T: BitwiseCopyable>(
     _unsafeElements buffer: borrowing Slice<UnsafeMutableBufferPointer<T>>
@@ -298,7 +298,7 @@ extension RawSpan {
   ///   - pointer: a pointer to the first initialized byte.
   ///   - count: the number of initialized elements in the span.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow pointer)
   public init<T: BitwiseCopyable>(
     _unsafeStart pointer: UnsafePointer<T>,
@@ -318,7 +318,7 @@ extension RawSpan {
   ///   - span: An existing `Span<Element>`, from which this `RawSpan` will
   ///     inherit its lifetime.
   @available(*, deprecated, renamed: "init(unsafeElements:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @unsafe
   @_lifetime(copy span)
   public init<Element>(_elements span: Span<Element>) {
@@ -332,7 +332,7 @@ extension RawSpan {
   /// - Parameters:
   ///   - unsafeElements: An existing `Span<Element>`, from which this
   ///     `RawSpan` will inherit its lifetime.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @unsafe
   @_lifetime(copy span)
   public init<Element>(unsafeElements span: Span<Element>) {
@@ -351,7 +351,7 @@ extension RawSpan {
   /// - Parameters:
   ///   - elements: An existing `Span<Element>`, from which this `RawSpan` will
   ///     inherit its lifetime.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy span)
   public init<Element: ConvertibleToBytes>(elements span: Span<Element>) {
     unsafe self = Self.init(unsafeElements: span)
@@ -368,14 +368,14 @@ extension RawSpan {
   /// instead of comparing `byteCount` to zero.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_semantics("fixed_storage.get_count")
   public var byteCount: Int { _assumeNonNegative(_count) }
 
   /// A Boolean value indicating whether the span is empty.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public var isEmpty: Bool { byteCount == 0 }
 
@@ -383,7 +383,7 @@ extension RawSpan {
   /// order.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var byteOffsets: Range<Int> {
     unsafe Range(_uncheckedBounds: (0, byteCount))
   }
@@ -395,7 +395,7 @@ extension RawSpan {
   // SILOptimizer looks for fixed_storage.check_index semantics
   // for bounds checking optimizations.
   @_semantics("fixed_storage.check_index")
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   internal func _checkIndex(_ position: Int) {
     _precondition(byteOffsets.contains(position), "Index out of bounds")
   }
@@ -404,7 +404,7 @@ extension RawSpan {
   ///
   /// - Parameter byteOffset: The offset of the byte to access. `byteOffset`
   ///     must be greater than or equal to zero, and less than `byteCount`.
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   public subscript(_ byteOffset: Int) -> UInt8 {
     _checkIndex(byteOffset)
     return unsafe self[unchecked: byteOffset]
@@ -417,7 +417,7 @@ extension RawSpan {
   ///
   /// - Parameter byteOffset: The offset of the byte to access. `byteOffset`
   ///     must be greater than or equal to zero, and less than `byteCount`.
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   @unsafe
   public subscript(unchecked byteOffset: Int) -> UInt8 {
     unsafe unsafeLoad(fromUncheckedByteOffset: byteOffset, as: UInt8.self)
@@ -442,7 +442,7 @@ extension RawSpan {
   /// - Returns: A `RawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   public func extracting(_ bounds: Range<Int>) -> Self {
     _precondition(
@@ -454,7 +454,7 @@ extension RawSpan {
   }
 
   @available(*, deprecated, renamed: "extracting(_:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   public func _extracting(_ bounds: Range<Int>) -> Self {
     extracting(bounds)
@@ -476,7 +476,7 @@ extension RawSpan {
   ///
   /// - Complexity: O(1)
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   public func extracting(unchecked bounds: Range<Int>) -> Self {
     let newStart = unsafe _pointer?.advanced(by: bounds.lowerBound)
@@ -486,7 +486,7 @@ extension RawSpan {
 
   @unsafe
   @available(*, deprecated, renamed: "extracting(unchecked:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   public func _extracting(unchecked bounds: Range<Int>) -> Self {
     unsafe extracting(unchecked: bounds)
@@ -505,14 +505,14 @@ extension RawSpan {
   /// - Returns: A `RawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   public func extracting(_ bounds: some RangeExpression<Int>) -> Self {
     extracting(bounds.relative(to: byteOffsets))
   }
 
   @available(*, deprecated, renamed: "extracting(_:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   public func _extracting(_ bounds: some RangeExpression<Int>) -> Self {
     extracting(bounds)
@@ -534,7 +534,7 @@ extension RawSpan {
   ///
   /// - Complexity: O(1)
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   public func extracting(
     unchecked bounds: ClosedRange<Int>
@@ -547,7 +547,7 @@ extension RawSpan {
 
   @unsafe
   @available(*, deprecated, renamed: "extracting(unchecked:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   public func _extracting(unchecked bounds: ClosedRange<Int>) -> Self {
     unsafe extracting(unchecked: bounds)
@@ -562,14 +562,14 @@ extension RawSpan {
   /// - Returns: A `RawSpan` over all the bytes of this span.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   public func extracting(_: UnboundedRange) -> Self {
     self
   }
 
   @available(*, deprecated, renamed: "extracting(_:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   public func _extracting(_: UnboundedRange) -> Self {
     self
@@ -594,7 +594,7 @@ extension RawSpan {
   ///   The closure's parameter is valid only for the duration of
   ///   its execution.
   /// - Returns: The return value of the `body` closure parameter.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   @safe
   public func withUnsafeBytes<E: Error, Result: ~Copyable>(
@@ -623,7 +623,7 @@ extension RawSpan {
   ///   - type: The type as which to view the bytes of this span.
   /// - Returns: A typed span viewing these bytes as instances of `T`.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   consuming public func _unsafeView<T: BitwiseCopyable>(
     as type: T.Type
@@ -659,7 +659,7 @@ extension RawSpan {
   ///     `offset`. The returned instance is memory-managed and unassociated
   ///     with the value in the memory referenced by this pointer.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func unsafeLoad<T>(
     fromByteOffset offset: Int = 0, as type: T.Type
   ) -> T {
@@ -690,7 +690,7 @@ extension RawSpan {
   ///     `offset`. The returned instance is memory-managed and unassociated
   ///     with the value in the memory referenced by this pointer.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func unsafeLoad<T>(
     fromUncheckedByteOffset offset: Int, as type: T.Type
   ) -> T {
@@ -714,7 +714,7 @@ extension RawSpan {
   ///     `offset`. The returned instance isn't associated
   ///     with the value in the range of memory referenced by this pointer.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func unsafeLoadUnaligned<T: BitwiseCopyable>(
     fromByteOffset offset: Int = 0, as type: T.Type
   ) -> T {
@@ -746,7 +746,7 @@ extension RawSpan {
   ///     `offset`. The returned instance isn't associated
   ///     with the value in the range of memory referenced by this pointer.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func unsafeLoadUnaligned<T: BitwiseCopyable>(
     fromUncheckedByteOffset offset: Int, as type: T.Type
   ) -> T {
@@ -764,7 +764,7 @@ extension RawSpan {
   ///     `offset` must be nonnegative.
   ///   - type: The type of the instance to create.
   /// - Returns: A new value of type `T`, read from `offset`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func load<T: ConvertibleFromBytes>(
     fromByteOffset offset: Int,
     as type: T.Type
@@ -784,7 +784,7 @@ extension RawSpan {
   ///   - type: The type of the instance to create.
   ///   - byteOrder: The order in which the bytes will be decoded.
   /// - Returns: A new value of type `T`, read from `offset`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(SwiftStdlib 6.4, *)
   public func load<T: ConvertibleFromBytes & FixedWidthInteger>(
     fromByteOffset offset: Int,
@@ -813,7 +813,7 @@ extension RawSpan {
   ///     in memory.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func isIdentical(to other: Self) -> Bool {
     unsafe (self._pointer == other._pointer) && (self._count == other._count)
   }
@@ -829,7 +829,7 @@ extension RawSpan {
   ///     in memory.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func isTriviallyIdentical(to other: Self) -> Bool {
     unsafe (self._pointer == other._pointer) && (self._count == other._count)
   }
@@ -840,7 +840,7 @@ extension RawSpan {
   /// - Parameters:
   ///   - other: a span that may be a subrange of `self`
   /// - Returns: A range of byte offsets within `self`, or `nil`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func byteOffsets(of other: borrowing Self) -> Range<Int>? {
     if other._count > _count { return nil }
     guard let spanStart = unsafe other._pointer, _count > 0 else {
@@ -874,7 +874,7 @@ extension RawSpan {
   /// - Returns: A span with at most `maxLength` bytes.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   public func extracting(first maxLength: Int) -> Self {
     _precondition(maxLength >= 0, "Can't have a prefix of negative length")
@@ -884,7 +884,7 @@ extension RawSpan {
   }
 
   @available(*, deprecated, renamed: "extracting(first:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   public func _extracting(first maxLength: Int) -> Self {
     extracting(first: maxLength)
@@ -904,7 +904,7 @@ extension RawSpan {
   /// - Returns: A span leaving off the specified number of bytes at the end.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   public func extracting(droppingLast k: Int) -> Self {
     _precondition(k >= 0, "Can't drop a negative number of bytes")
@@ -915,7 +915,7 @@ extension RawSpan {
   }
 
   @available(*, deprecated, renamed: "extracting(droppingLast:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   public func _extracting(droppingLast k: Int) -> Self {
     extracting(droppingLast: k)
@@ -936,7 +936,7 @@ extension RawSpan {
   /// - Returns: A span with at most `maxLength` bytes.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   public func extracting(last maxLength: Int) -> Self {
     _precondition(maxLength >= 0, "Can't have a suffix of negative length")
@@ -949,7 +949,7 @@ extension RawSpan {
   }
 
   @available(*, deprecated, renamed: "extracting(last:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   public func _extracting(last maxLength: Int) -> Self {
     extracting(last: maxLength)
@@ -969,7 +969,7 @@ extension RawSpan {
   /// - Returns: A span starting after the specified number of bytes.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   public func extracting(droppingFirst k: Int) -> Self {
     _precondition(k >= 0, "Can't drop a negative number of bytes")
@@ -983,7 +983,7 @@ extension RawSpan {
   }
 
   @available(*, deprecated, renamed: "extracting(droppingFirst:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy self)
   public func _extracting(droppingFirst k: Int) -> Self {
     extracting(droppingFirst: k)
@@ -999,43 +999,43 @@ extension RawSpan {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension RawSpan {
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, unavailable, renamed: "extracting(_:)")
   public subscript(bounds: Range<Int>) -> Self {
     Builtin.unreachable()
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, unavailable, renamed: "extracting(_:)")
   public subscript(bounds: some RangeExpression<Int>) -> Self {
     Builtin.unreachable()
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, unavailable, renamed: "extracting(_:)")
   public subscript(bounds: UnboundedRange) -> Self {
     Builtin.unreachable()
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, unavailable, renamed: "extracting(first:)")
   public func prefix(_ maxLength: Int) -> Self {
     Builtin.unreachable()
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, unavailable, renamed: "extracting(last:)")
   public func suffix(_ maxLength: Int) -> Self {
     Builtin.unreachable()
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, unavailable, renamed: "extracting(droppingFirst:)")
   public func dropFirst(_ k: Int = 1) -> Self {
     Builtin.unreachable()
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, unavailable, renamed: "extracting(droppingLast:)")
   public func dropLast(_ k: Int = 1) -> Self {
     Builtin.unreachable()

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -38,7 +38,7 @@ public struct Span<Element: ~Copyable>: ~Escapable, Copyable, BitwiseCopyable {
   internal let _pointer: UnsafeRawPointer?
 
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func _start() -> UnsafeRawPointer {
     unsafe _pointer._unsafelyUnwrappedUnchecked
   }
@@ -52,7 +52,7 @@ public struct Span<Element: ~Copyable>: ~Escapable, Copyable, BitwiseCopyable {
   internal let _count: Int
 
   /// Create an empty span.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   @lifetime(immortal)
   public init() {
@@ -74,7 +74,7 @@ public struct Span<Element: ~Copyable>: ~Escapable, Copyable, BitwiseCopyable {
   ///   - pointer: a pointer to the first initialized element.
   ///   - count: the number of initialized elements in the span.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   @lifetime(borrow pointer)
   internal init(
@@ -102,7 +102,7 @@ extension Span where Element: ~Copyable {
   ///
   /// - Parameters:
   ///   - buffer: an `UnsafeBufferPointer` to initialized elements.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @lifetime(borrow buffer)
   @unsafe
   public init(
@@ -129,7 +129,7 @@ extension Span where Element: ~Copyable {
   ///
   /// - Parameters:
   ///   - buffer: an `UnsafeMutableBufferPointer` to initialized elements.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @lifetime(borrow buffer)
   @unsafe
   public init(
@@ -152,7 +152,7 @@ extension Span where Element: ~Copyable {
   /// - Parameters:
   ///   - pointer: a pointer to the first initialized element.
   ///   - count: the number of initialized elements in the span.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @lifetime(borrow pointer)
   @unsafe
   public init(
@@ -180,7 +180,7 @@ extension Span /*where Element: Copyable*/ {
   ///
   /// - Parameters:
   ///   - buffer: an `UnsafeBufferPointer` to initialized elements.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @lifetime(borrow buffer)
   @unsafe
   public init(
@@ -201,7 +201,7 @@ extension Span /*where Element: Copyable*/ {
   ///
   /// - Parameters:
   ///   - buffer: an `UnsafeMutableBufferPointer` to initialized elements.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @lifetime(borrow buffer)
   @unsafe
   public init(
@@ -231,7 +231,7 @@ extension Span where Element: BitwiseCopyable {
   ///
   /// - Parameters:
   ///   - buffer: a buffer to initialized elements.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @lifetime(borrow buffer)
   @unsafe
   public init(
@@ -267,7 +267,7 @@ extension Span where Element: BitwiseCopyable {
   ///
   /// - Parameters:
   ///   - buffer: a buffer to initialized elements.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @lifetime(borrow buffer)
   @unsafe
   public init(
@@ -294,7 +294,7 @@ extension Span where Element: BitwiseCopyable {
   /// - Parameters:
   ///   - pointer: a pointer to the first initialized element.
   ///   - byteCount: the number of bytes in the span.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @lifetime(borrow pointer)
   @unsafe
   public init(
@@ -323,7 +323,7 @@ extension Span where Element: BitwiseCopyable {
   ///
   /// - Parameters:
   ///   - buffer: a buffer to initialized elements.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @lifetime(borrow buffer)
   @unsafe
   public init(
@@ -348,7 +348,7 @@ extension Span where Element: BitwiseCopyable {
   ///
   /// - Parameters:
   ///   - buffer: a buffer to initialized elements.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @lifetime(borrow buffer)
   @unsafe
   public init(
@@ -366,7 +366,7 @@ extension Span where Element: BitwiseCopyable {
   /// - Parameters:
   ///   - bytes: An existing `RawSpan`, which will define both this
   ///            `Span`'s lifetime and the memory it represents.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @unsafe
   @lifetime(copy bytes)
   public init(_bytes bytes: consuming RawSpan) {
@@ -389,7 +389,7 @@ extension Span where Element: BitwiseCopyable {
   /// - Parameters:
   ///   - bytes: An existing `RawSpan`, which will define both this
   ///            `Span`'s lifetime and the memory it represents.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy bytes)
   public init(viewing bytes: RawSpan) where Element: ConvertibleFromBytes {
     let rawBuffer = unsafe UnsafeRawBufferPointer(
@@ -410,14 +410,14 @@ extension Span where Element: ~Copyable {
   /// instead of comparing `count` to zero.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_semantics("fixed_storage.get_count")
   public var count: Int { _assumeNonNegative(_count) }
 
   /// A Boolean value indicating whether the span is empty.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public var isEmpty: Bool { _count == 0 }
 
@@ -428,7 +428,7 @@ extension Span where Element: ~Copyable {
   /// order.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var indices: Range<Index> {
     unsafe Range(_uncheckedBounds: (0, count))
   }
@@ -440,7 +440,7 @@ extension Span where Element: ~Copyable {
   // SILOptimizer looks for fixed_storage.check_index semantics for bounds check optimizations.
   @_semantics("fixed_storage.check_index")
   @inline(__always)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func _checkIndex(_ position: Index) {
     _precondition(indices.contains(position), "Index out of bounds")
   }
@@ -451,7 +451,7 @@ extension Span where Element: ~Copyable {
   ///     must be greater or equal to zero, and less than `count`.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public subscript(_ position: Index) -> Element {
     @_transparent
     borrow {
@@ -470,7 +470,7 @@ extension Span where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public subscript(unchecked position: Index) -> Element {
     @_unsafeSelfDependentResult
     borrow {
@@ -480,7 +480,7 @@ extension Span where Element: ~Copyable {
   }
 
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func _unsafeAddressOfElement(
     unchecked position: Index
   ) -> Builtin.RawPointer {
@@ -502,7 +502,7 @@ extension Span where Element: BitwiseCopyable {
   ///     must be greater or equal to zero, and less than `count`.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public subscript(_ position: Index) -> Element {
     @_transparent
     get {
@@ -521,7 +521,7 @@ extension Span where Element: BitwiseCopyable {
   ///
   /// - Complexity: O(1)
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public subscript(unchecked position: Index) -> Element {
     get {
       let address = unsafe _unsafeAddressOfElement(unchecked: position)
@@ -537,7 +537,7 @@ extension Span where Element: Copyable {
   /// Construct a raw span over the memory represented by this span.
   ///
   /// - Returns: A `RawSpan` over the memory represented by this span.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   @unsafe
   public var bytes: RawSpan {
@@ -556,7 +556,7 @@ extension Span where Element: ConvertibleToBytes {
   /// A raw span over the memory represented by this span.
   ///
   /// - Returns: A RawSpan over the memory represented by this span.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public var bytes: RawSpan {
     @_lifetime(copy self)
@@ -584,7 +584,7 @@ extension Span where Element: ~Copyable {
   /// - Returns: A `Span` over the items within `bounds`.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @lifetime(copy self)
   public func extracting(_ bounds: Range<Index>) -> Self {
     _precondition(
@@ -596,7 +596,7 @@ extension Span where Element: ~Copyable {
   }
 
   @available(*, deprecated, renamed: "extracting(_:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @lifetime(copy self)
   public func _extracting(_ bounds: Range<Index>) -> Self {
     extracting(bounds)
@@ -618,7 +618,7 @@ extension Span where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @lifetime(copy self)
   public func extracting(unchecked bounds: Range<Index>) -> Self {
     let delta = bounds.lowerBound &* MemoryLayout<Element>.stride
@@ -631,7 +631,7 @@ extension Span where Element: ~Copyable {
 
   @unsafe
   @available(*, deprecated, renamed: "extracting(unchecked:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @lifetime(copy self)
   public func _extracting(unchecked bounds: Range<Index>) -> Self {
     unsafe extracting(unchecked: bounds)
@@ -650,7 +650,7 @@ extension Span where Element: ~Copyable {
   /// - Returns: A `Span` over the items within `bounds`.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @lifetime(copy self)
   public func extracting(
     _ bounds: some RangeExpression<Index>
@@ -659,7 +659,7 @@ extension Span where Element: ~Copyable {
   }
 
   @available(*, deprecated, renamed: "extracting(_:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @lifetime(copy self)
   public func _extracting(_ bounds: some RangeExpression<Index>) -> Self {
     extracting(bounds)
@@ -681,7 +681,7 @@ extension Span where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @lifetime(copy self)
   public func extracting(
     unchecked bounds: ClosedRange<Index>
@@ -694,7 +694,7 @@ extension Span where Element: ~Copyable {
 
   @unsafe
   @available(*, deprecated, renamed: "extracting(unchecked:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @lifetime(copy self)
   public func _extracting(unchecked bounds: ClosedRange<Index>) -> Self {
     unsafe extracting(unchecked: bounds)
@@ -709,14 +709,14 @@ extension Span where Element: ~Copyable {
   /// - Returns: A `Span` over all the items of this span.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @lifetime(copy self)
   public func extracting(_: UnboundedRange) -> Self {
     self
   }
 
   @available(*, deprecated, renamed: "extracting(_:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @lifetime(copy self)
   public func _extracting(_: UnboundedRange) -> Self {
     self
@@ -740,7 +740,7 @@ extension Span where Element: ~Copyable  {
   ///   for the `withUnsafeBufferPointer(_:)` method. The closure's
   ///   parameter is valid only for the duration of its execution.
   /// - Returns: The return value of the `body` closure parameter.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   @safe
   public func withUnsafeBufferPointer<E: Error, Result: ~Copyable>(
@@ -774,7 +774,7 @@ extension Span where Element: BitwiseCopyable {
   ///   The closure's parameter is valid only for the duration of
   ///   its execution.
   /// - Returns: The return value of the `body` closure parameter.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   @safe
   public func withUnsafeBytes<E: Error, Result: ~Copyable>(
@@ -801,7 +801,7 @@ extension Span where Element: ~Copyable {
   ///     in memory.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func isIdentical(to other: Self) -> Bool {
     unsafe (self._pointer == other._pointer) && (self._count == other._count)
   }
@@ -817,7 +817,7 @@ extension Span where Element: ~Copyable {
   ///     in memory.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func isTriviallyIdentical(to other: Self) -> Bool {
     unsafe (self._pointer == other._pointer) && (self._count == other._count)
   }
@@ -828,7 +828,7 @@ extension Span where Element: ~Copyable {
   /// - Parameters:
   ///   - other: a span that may be a subrange of `self`
   /// - Returns: A range of indices within `self`, or `nil`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func indices(of other: borrowing Self) -> Range<Index>? {
     if other._count > _count { return nil }
     guard let spanStart = unsafe other._pointer, _count > 0 else {
@@ -867,7 +867,7 @@ extension Span where Element: ~Copyable {
   /// - Returns: A span with at most `maxLength` elements.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @lifetime(copy self)
   public func extracting(first maxLength: Int) -> Self {
     _precondition(maxLength >= 0, "Can't have a prefix of negative length")
@@ -877,7 +877,7 @@ extension Span where Element: ~Copyable {
   }
 
   @available(*, deprecated, renamed: "extracting(first:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @lifetime(copy self)
   public func _extracting(first maxLength: Int) -> Self {
     extracting(first: maxLength)
@@ -897,7 +897,7 @@ extension Span where Element: ~Copyable {
   /// - Returns: A span leaving off the specified number of elements at the end.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @lifetime(copy self)
   public func extracting(droppingLast k: Int) -> Self {
     _precondition(k >= 0, "Can't drop a negative number of elements")
@@ -907,7 +907,7 @@ extension Span where Element: ~Copyable {
   }
 
   @available(*, deprecated, renamed: "extracting(droppingLast:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @lifetime(copy self)
   public func _extracting(droppingLast k: Int) -> Self {
     extracting(droppingLast: k)
@@ -928,7 +928,7 @@ extension Span where Element: ~Copyable {
   /// - Returns: A span with at most `maxLength` elements.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @lifetime(copy self)
   public func extracting(last maxLength: Int) -> Self {
     _precondition(maxLength >= 0, "Can't have a suffix of negative length")
@@ -942,7 +942,7 @@ extension Span where Element: ~Copyable {
   }
 
   @available(*, deprecated, renamed: "extracting(last:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @lifetime(copy self)
   public func _extracting(last maxLength: Int) -> Self {
     extracting(last: maxLength)
@@ -962,7 +962,7 @@ extension Span where Element: ~Copyable {
   /// - Returns: A span starting after the specified number of elements.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @lifetime(copy self)
   public func extracting(droppingFirst k: Int) -> Self {
     _precondition(k >= 0, "Can't drop a negative number of elements")
@@ -977,7 +977,7 @@ extension Span where Element: ~Copyable {
   }
 
   @available(*, deprecated, renamed: "extracting(droppingFirst:)")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @lifetime(copy self)
   public func _extracting(droppingFirst k: Int) -> Self {
     extracting(droppingFirst: k)
@@ -993,43 +993,43 @@ extension Span where Element: ~Copyable {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Span where Element: ~Copyable {
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, unavailable, renamed: "extracting(_:)")
   public subscript(bounds: Range<Index>) -> Self {
     Builtin.unreachable()
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, unavailable, renamed: "extracting(_:)")
   public subscript(bounds: some RangeExpression<Index>) -> Self {
     Builtin.unreachable()
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, unavailable, renamed: "extracting(_:)")
   public subscript(bounds: UnboundedRange) -> Self {
     Builtin.unreachable()
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, unavailable, renamed: "extracting(first:)")
   public func prefix(_ maxLength: Int) -> Self {
     Builtin.unreachable()
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, unavailable, renamed: "extracting(last:)")
   public func suffix(_ maxLength: Int) -> Self {
     Builtin.unreachable()
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, unavailable, renamed: "extracting(droppingFirst:)")
   public func dropFirst(_ k: Int = 1) -> Self {
     Builtin.unreachable()
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, unavailable, renamed: "extracting(droppingLast:)")
   public func dropLast(_ k: Int = 1) -> Self {
     Builtin.unreachable()
@@ -1044,7 +1044,7 @@ extension Span where Element == UInt8 {
   /// - Parameters:
   ///   - bytes: An existing `RawSpan`, which will define both this
   ///            `Span`'s lifetime and the memory it represents.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(copy bytes)
   public init(viewing bytes: RawSpan) {
     let span = unsafe Self(_unchecked: bytes._pointer, count: bytes._count)
@@ -1067,7 +1067,7 @@ extension Span: BorrowingSequence where Element: ~Copyable {
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Span where Element: Equatable & ~Copyable {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func _elementsEqual(to other: borrowing Self) -> Bool {
     return self.withUnsafeBufferPointer { a in
       other.withUnsafeBufferPointer { b in
@@ -1087,7 +1087,7 @@ extension Span where Element: Equatable & ~Copyable {
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Span where Element: Hashable & ~Copyable {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func _hashContents(into hasher: inout Hasher) {
     // Note: no discriminating combine call -- caller is expected to do that
     // separately when needed.

--- a/stdlib/public/core/StaticPrint.swift
+++ b/stdlib/public/core/StaticPrint.swift
@@ -364,7 +364,7 @@ extension ConstantVPrintFIntegerFormatting {
 
   /// Constructs an os_log format specifier for the given `type`.
   @_semantics("constant_evaluable")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_optimize(none)
   @_effects(readonly)
   internal func formatSpecifier<I: FixedWidthInteger>(
@@ -608,7 +608,7 @@ extension ConstantVPrintFInterpolation {
   ///     messages. An example of an attribute is "xcode:size-in-bytes". If the target tool
   ///     that processes these messages doesn't understand the attribute it would be ignored.
   @_semantics("constant_evaluable")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_optimize(none)
   @_semantics("oslog.requires_constant_arguments")
   public mutating func appendInterpolation<T: FixedWidthInteger>(
@@ -623,7 +623,7 @@ extension ConstantVPrintFInterpolation {
   /// format string property. Also, append the integer along with necessary headers
   /// to the ConstantVPrintFArguments property.
   @_semantics("constant_evaluable")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_optimize(none)
   internal mutating func appendInteger<T>(
     _ number: @escaping () -> T,
@@ -680,7 +680,7 @@ extension ConstantVPrintFInterpolation {
   /// - Parameters:
   ///   - argumentString: The interpolated expression of type String, which is autoclosured.
   @_semantics("constant_evaluable")
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_optimize(none)
   @_semantics("oslog.requires_constant_arguments")
   public mutating func appendInterpolation(
@@ -855,9 +855,8 @@ internal func constant_vprintf_backend(
 }
 
 @_semantics("oslog.requires_constant_arguments")
-@inlinable
 @_transparent
-@_alwaysEmitIntoClient
+@export(implementation)
 @_optimize(none)
 public func print(_ message: ConstantVPrintFMessage) {
   let formatString = message.interpolation.formatString

--- a/stdlib/public/core/StaticString.swift
+++ b/stdlib/public/core/StaticString.swift
@@ -160,7 +160,7 @@ public struct StaticString: Sendable {
     return Int(_utf8CodeUnitCount)
   }
 
-  @_alwaysEmitIntoClient @_transparent
+  @export(implementation) @_transparent
   internal var unsafeRawPointer: Builtin.RawPointer {
     return Builtin.inttoptr_Word(_startPtrOrData)
   }

--- a/stdlib/public/core/Stride.swift
+++ b/stdlib/public/core/Stride.swift
@@ -225,7 +225,7 @@ extension Strideable {
 }
 
 extension Strideable where Self: FixedWidthInteger & SignedInteger {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func _step(
     after current: (index: Int?, value: Self),
     from start: Self, by distance: Self.Stride
@@ -243,7 +243,7 @@ extension Strideable where Self: FixedWidthInteger & SignedInteger {
 }
 
 extension Strideable where Self: FixedWidthInteger & UnsignedInteger {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func _step(
     after current: (index: Int?, value: Self),
     from start: Self, by distance: Self.Stride
@@ -289,7 +289,7 @@ extension Strideable where Self: FloatingPoint, Self == Stride {
 }
 
 extension Strideable {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func _advance(
     by distance: inout Stride, limitedBy limit: Self
   ) {

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -356,10 +356,9 @@ public struct String {
   // an initializer would conflict with the Int-parsing initializer, when used
   // as function name, e.g.
   //   [1, 2, 3].map(String.init)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_semantics("string.init_empty_with_capacity")
   @_semantics("inline_late")
-  @inlinable
   internal static func _createEmpty(withInitialCapacity: Int) -> String {
     return String(_StringGuts(_initialCapacity: withInitialCapacity))
   }
@@ -408,7 +407,7 @@ extension String {
   /// identical.
   ///
   /// - Performance: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func _isIdentical(to other: Self) -> Bool {
     self._guts.rawBits == other._guts.rawBits
   }
@@ -418,7 +417,7 @@ extension String {
   // This force type-casts element to UInt8, since we cannot currently
   // communicate to the type checker that we proved this with our dynamic
   // check in String(decoding:as:).
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(never) // slow-path
   internal static func _fromNonContiguousUnsafeBitcastUTF8Repairing<
     C: Collection
@@ -642,7 +641,7 @@ extension String {
   ///     memory with room for `capacity` UTF-8 code units, initializes
   ///     that memory, and returns the number of initialized elements.
 #if hasFeature(Embedded)
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   @available(SwiftStdlib 5.3, *)
   @safe
   public init<E: Error>(
@@ -674,7 +673,7 @@ extension String {
     )
   }
 #else
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   @available(SwiftStdlib 5.3, *)
   @safe
   public init<E: Error>(
@@ -760,7 +759,7 @@ extension String {
   ///   `withCString(_:)` method. The pointer argument is valid only for the
   ///   duration of the method's execution.
   /// - Returns: The return value, if any, of the `body` closure parameter.
-  @_alwaysEmitIntoClient // (Primarily @inlinable) fast-path: already C-string compatible
+  @export(implementation) // (Primarily @inlinable) fast-path: already C-string compatible
   @safe
   public func withCString<Result, E: Error>(
     _ body: (UnsafePointer<Int8>) throws(E) -> Result
@@ -799,7 +798,7 @@ extension String {
   ///   - targetEncoding: The encoding in which the code units should be
   ///     interpreted.
   /// - Returns: The return value, if any, of the `body` closure parameter.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always) // Eliminate dynamic type check when possible
   @safe
   public func withCString<Result, TargetEncoding: Unicode.Encoding, E: Error>(
@@ -835,7 +834,7 @@ extension String {
   }
 #endif // !hasFeature(Embedded)
 
-  @_alwaysEmitIntoClient @inline(never) // slow-path
+  @export(implementation) @inline(never) // slow-path
   @_effects(releasenone)
   internal func _slowWithCString<Result, TargetEncoding: Unicode.Encoding, E: Error>(
     encodedAs targetEncoding: TargetEncoding.Type,
@@ -1226,7 +1225,7 @@ extension String {
   }
 
 #if hasFeature(Embedded)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public // @testable
   func _withNFCCodeUnits<E: Error>(
     _ f: (UInt8) throws(E) -> Void
@@ -1245,7 +1244,7 @@ extension String {
     try _gutsSlice._withNFCCodeUnits(f)
   }
 #else
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public // @testable
   func _withNFCCodeUnits<E: Error>(
     _ f: (UInt8) throws(E) -> Void

--- a/stdlib/public/core/StringComparable.swift
+++ b/stdlib/public/core/StringComparable.swift
@@ -87,7 +87,7 @@ extension Substring: Equatable {}
 // Below are concrete overloads to give us most of the benefit without potential
 // harm to expression type checking performance.
 extension String {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   @_effects(readonly)
   public static func ~= (lhs: String, rhs: Substring) -> Bool {
@@ -95,7 +95,7 @@ extension String {
   }
 }
 extension Substring {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   @_effects(readonly)
   public static func ~= (lhs: Substring, rhs: String) -> Bool {

--- a/stdlib/public/core/StringCreate.swift
+++ b/stdlib/public/core/StringCreate.swift
@@ -467,12 +467,12 @@ extension String {
     return String._copying(substring)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(never) // slow-path
   internal static func _copying(_ str: String) -> String {
     return String._copying(str[...])
   }
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(never) // slow-path
   internal static func _copying(_ str: Substring) -> String {
     if _fastPath(str._wholeGuts.isFastUTF8) {

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -162,7 +162,7 @@ extension _StringGuts {
      return _slowPath(_object.isForeign)
   }
 
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   @safe
   internal func withFastUTF8<R, E: Error>(
     _ f: (UnsafeBufferPointer<UInt8>) throws(E) -> R
@@ -190,7 +190,7 @@ extension _StringGuts {
   }
 #endif // !hasFeature(Embedded)
 
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   @safe
   internal func withFastUTF8<R, E: Error>(
     range: Range<Int>,
@@ -218,7 +218,7 @@ extension _StringGuts {
   }
 #endif // !hasFeature(Embedded)
 
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   internal func withFastCChar<R, E: Error>(
     _ f: (UnsafeBufferPointer<CChar>) throws(E) -> R
   ) throws(E) -> R {
@@ -271,7 +271,7 @@ extension _StringGuts {
 
 // C String interop
 extension _StringGuts {
-  @_alwaysEmitIntoClient @inline(__always) // fast-path: already C-string compatible
+  @export(implementation) @inline(__always) // fast-path: already C-string compatible
   internal func withCString<Result, E: Error>(
     _ body: (UnsafePointer<Int8>) throws(E) -> Result
   ) throws(E) -> Result {
@@ -300,7 +300,7 @@ extension _StringGuts {
 #endif // !hasFeature(Embedded)
 
   @inline(never) // slow-path
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func _slowWithCString<Result, E: Error>(
     _ body: (UnsafePointer<Int8>) throws(E) -> Result
   ) throws(E) -> Result {
@@ -406,11 +406,11 @@ extension _StringGuts {
   /// If this returns false, then the string is encoded in UTF-16.
   ///
   /// This always returns a value corresponding to the string's actual encoding.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   internal var isUTF8: Bool { _object.isUTF8 }
 
-  @_alwaysEmitIntoClient // Swift 5.7
+  @export(implementation) // Swift 5.7
   @inline(__always)
   internal func markEncoding(_ i: String.Index) -> String.Index {
     isUTF8 ? i._knownUTF8 : i._knownUTF16
@@ -424,7 +424,7 @@ extension _StringGuts {
   /// is guaranteed to never incorrectly return false. If all loaded binaries
   /// were built in 5.7+, then this method is guaranteed to always return the
   /// correct value.
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   internal func hasMatchingEncoding(_ i: String.Index) -> Bool {
     i._hasMatchingEncoding(isUTF8: isUTF8)
   }
@@ -445,14 +445,14 @@ extension _StringGuts {
   /// not set the flags that this method relies on. However, false positives
   /// cannot happen: if this method detects a mismatch, then it is guaranteed to
   /// be a real one.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   internal func ensureMatchingEncoding(_ i: Index) -> Index {
     if _fastPath(hasMatchingEncoding(i)) { return i }
     return _slowEnsureMatchingEncoding(i)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(never)
   @_effects(releasenone)
   internal func _slowEnsureMatchingEncoding(_ i: Index) -> Index {

--- a/stdlib/public/core/StringIndex.swift
+++ b/stdlib/public/core/StringIndex.swift
@@ -249,19 +249,19 @@ extension String.Index {
 }
 
 extension String.Index {
-  @_alwaysEmitIntoClient @inline(__always) // Swift 5.7
+  @export(implementation) @inline(__always) // Swift 5.7
   internal static var __scalarAlignmentBit: UInt64 { 0x1 }
 
-  @_alwaysEmitIntoClient @inline(__always) // Swift 5.7
+  @export(implementation) @inline(__always) // Swift 5.7
   internal static var __characterAlignmentBit: UInt64 { 0x2 }
 
-  @_alwaysEmitIntoClient @inline(__always) // Swift 5.7
+  @export(implementation) @inline(__always) // Swift 5.7
   internal static var __utf8Bit: UInt64 { 0x4 }
 
-  @_alwaysEmitIntoClient @inline(__always) // Swift 5.7
+  @export(implementation) @inline(__always) // Swift 5.7
   internal static var __utf16Bit: UInt64 { 0x8 }
 
-  @_alwaysEmitIntoClient @inline(__always) // Swift 5.7
+  @export(implementation) @inline(__always) // Swift 5.7
   internal static func __encodingBit(utf16: Bool) -> UInt64 {
     let utf16 = Int8(Builtin.zext_Int1_Int8(utf16._value))
     return __utf8Bit &<< utf16
@@ -307,13 +307,13 @@ extension String.Index {
 
 */
 extension String.Index {
-  @_alwaysEmitIntoClient // Swift 5.1
+  @export(implementation) // Swift 5.1
   @inline(__always)
   internal var _isScalarAligned: Bool {
     0 != _rawBits & Self.__scalarAlignmentBit
   }
 
-  @_alwaysEmitIntoClient // Swift 5.1
+  @export(implementation) // Swift 5.1
   @inline(__always)
   internal var _scalarAligned: String.Index {
     var idx = self
@@ -345,7 +345,7 @@ extension String.Index {
 // fine -- `index(after:)` and `index(before:)` still do the right thing with
 // minimal/no performance loss. (The start/end index is handled specially.)
 extension String.Index {
-  @_alwaysEmitIntoClient // Swift 5.7
+  @export(implementation) // Swift 5.7
   @inline(__always)
   internal var _isCharacterAligned: Bool {
     0 != _rawBits & Self.__characterAlignmentBit
@@ -355,7 +355,7 @@ extension String.Index {
   /// set.
   ///
   /// (`Character` alignment implies scalar alignment.)
-  @_alwaysEmitIntoClient // Swift 5.7
+  @export(implementation) // Swift 5.7
   @inline(__always)
   internal var _characterAligned: String.Index {
     let r = _rawBits | Self.__characterAlignmentBit | Self.__scalarAlignmentBit
@@ -366,7 +366,7 @@ extension String.Index {
 }
 
 extension String.Index {
-  @_alwaysEmitIntoClient // Swift 5.7
+  @export(implementation) // Swift 5.7
   internal func _copyingAlignment(from index: Self) -> Self {
     let mask = Self.__scalarAlignmentBit | Self.__characterAlignmentBit
     return Self((_rawBits & ~mask) | (index._rawBits & mask))
@@ -418,7 +418,7 @@ extension String.Index {
 // handled in `_StringGuts.ensureMatchingEncoding(_:)`; see there for the sordid
 // details.
 extension String.Index {
-  @_alwaysEmitIntoClient // Swift 5.7
+  @export(implementation) // Swift 5.7
   @inline(__always)
   internal var _encodingBits: UInt64 {
     _rawBits & (Self.__utf8Bit | Self.__utf16Bit)
@@ -429,7 +429,7 @@ extension String.Index {
   ///
   /// (This returns true if either we know for sure that this is an UTF-8 index,
   /// or if we don't have enough information to determine its encoding.)
-  @_alwaysEmitIntoClient // Swift 5.7
+  @export(implementation) // Swift 5.7
   @inline(__always)
   internal var _canBeUTF8: Bool {
     // The only way an index cannot be UTF-8 is it has only the UTF-16 flag set.
@@ -442,7 +442,7 @@ extension String.Index {
   /// (This returns true if either we know for sure that this is an UTF-16
   /// index, or if we don't have enough information to determine its
   /// encoding.)
-  @_alwaysEmitIntoClient // Swift 5.7
+  @export(implementation) // Swift 5.7
   @inline(__always)
   internal var _canBeUTF16: Bool {
     // The only way an index cannot be UTF-16 is it has only the UTF-8 flag set.
@@ -457,30 +457,30 @@ extension String.Index {
   /// is guaranteed to never incorrectly return false. If all loaded binaries
   /// were built in 5.7+, then this method is guaranteed to always return the
   /// correct value.
-  @_alwaysEmitIntoClient // Swift 5.7
+  @export(implementation) // Swift 5.7
   @inline(__always)
   internal func _hasMatchingEncoding(isUTF8 utf8: Bool) -> Bool {
     _encodingBits != Self.__encodingBit(utf16: utf8)
   }
 
   /// Returns the same index with the UTF-8 bit set.
-  @_alwaysEmitIntoClient // Swift 5.7
+  @export(implementation) // Swift 5.7
   @inline(__always)
   internal var _knownUTF8: Self { Self(_rawBits | Self.__utf8Bit) }
 
   /// Returns the same index with the UTF-16 bit set.
-  @_alwaysEmitIntoClient // Swift 5.7
+  @export(implementation) // Swift 5.7
   @inline(__always)
   internal var _knownUTF16: Self { Self(_rawBits | Self.__utf16Bit) }
 
   /// Returns the same index with both UTF-8 & UTF-16 bits set.
-  @_alwaysEmitIntoClient // Swift 5.7
+  @export(implementation) // Swift 5.7
   @inline(__always)
   internal var _encodingIndependent: Self {
     Self(_rawBits | Self.__utf8Bit | Self.__utf16Bit)
   }
 
-  @_alwaysEmitIntoClient // Swift 5.7
+  @export(implementation) // Swift 5.7
   internal func _copyingEncoding(from index: Self) -> Self {
     let mask = Self.__utf8Bit | Self.__utf16Bit
     return Self((_rawBits & ~mask) | (index._rawBits & mask))
@@ -514,7 +514,7 @@ extension String.Index: Hashable {
 }
 
 extension String.Index {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal var _encodingDescription: String {
     switch (_rawBits & Self.__utf8Bit != 0, _rawBits & Self.__utf16Bit != 0) {
     case (false, false): return "unknown"
@@ -528,7 +528,7 @@ extension String.Index {
   ///
   /// - Important: The contents of the returned string are not guaranteed to
   ///    remain stable: they may arbitrarily change in any Swift release.
-  @_alwaysEmitIntoClient // FIXME: Use @backDeployed
+  @export(implementation) // FIXME: Use @backDeployed
   @inline(never)
   public var debugDescription: String {
     // 23[utf8]+1
@@ -548,7 +548,7 @@ extension String.Index {
   ///
   /// - Important: The contents of the returned string are not guaranteed to
   ///    remain stable: they may arbitrarily change in any Swift release.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, deprecated, renamed: "debugDescription")
   public var _description: String {
     debugDescription
@@ -558,7 +558,7 @@ extension String.Index {
   ///
   /// - Important: The contents of the returned string are not guaranteed to
   ///    remain stable: they may arbitrarily change in any Swift release.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, deprecated, renamed: "debugDescription")
   public var _debugDescription: String {
     debugDescription

--- a/stdlib/public/core/StringIndexConversions.swift
+++ b/stdlib/public/core/StringIndexConversions.swift
@@ -243,7 +243,7 @@ extension String.UnicodeScalarView {
   ///    shared by this view.
   /// - Returns: The largest valid index within this view that doesn't exceed
   ///     `i`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public // SPI(Foundation) FIXME: This should be API
   func _index(roundingDown i: Index) -> Index {
     _guts.validateInclusiveScalarIndex(i)
@@ -264,7 +264,7 @@ extension Substring.UnicodeScalarView {
   ///    substring shared by this view.
   /// - Returns: The largest valid index within this view that doesn't exceed
   ///     `i`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public // SPI(Foundation) FIXME: This should be API
   func _index(roundingDown i: Index) -> Index {
     _wholeGuts.validateInclusiveScalarIndex(i, in: _bounds)
@@ -285,7 +285,7 @@ extension String.UTF8View {
   ///    substring shared by this view.
   /// - Returns: The largest valid index within this view that doesn't exceed
   ///     `i`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public // SPI(Foundation) FIXME: This should be API
   func _index(roundingDown i: Index) -> Index {
     let i = _guts.validateInclusiveSubscalarIndex(i)
@@ -308,7 +308,7 @@ extension Substring.UTF8View {
   ///    substring shared by this view.
   /// - Returns: The largest valid index within this view that doesn't exceed
   ///     `i`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public // SPI(Foundation) FIXME: This should be API
   func _index(roundingDown i: Index) -> Index {
     let i = _wholeGuts.validateInclusiveSubscalarIndex(i, in: _bounds)
@@ -329,7 +329,7 @@ extension String.UTF16View {
   ///    substring shared by this view.
   /// - Returns: The valid index in `self` that this view considers equivalent
   ///    to `i`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public // SPI(Foundation) FIXME: This should be API
   func _index(roundingDown i: Index) -> Index {
     let i = _guts.validateInclusiveSubscalarIndex(i)
@@ -350,7 +350,7 @@ extension Substring.UTF16View {
   ///    substring shared by this view.
   /// - Returns: The valid index in `self` that this view considers equivalent
   ///    to `i`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public // SPI(Foundation) FIXME: This should be API
   func _index(roundingDown i: Index) -> Index {
     let i = _wholeGuts.validateInclusiveSubscalarIndex(i, in: _bounds)

--- a/stdlib/public/core/StringIndexValidation.swift
+++ b/stdlib/public/core/StringIndexValidation.swift
@@ -12,12 +12,12 @@
 
 // Index validation
 extension _StringGuts {
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   internal func isFastScalarIndex(_ i: String.Index) -> Bool {
     hasMatchingEncoding(i) && i._isScalarAligned
   }
 
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   internal func isFastCharacterIndex(_ i: String.Index) -> Bool {
     hasMatchingEncoding(i) && i._isCharacterAligned
   }
@@ -25,14 +25,14 @@ extension _StringGuts {
 
 // Subscalar index validation (UTF-8 & UTF-16 views)
 extension _StringGuts {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func validateSubscalarIndex(_ i: String.Index) -> String.Index {
     let i = ensureMatchingEncoding(i)
     _precondition(i._encodedOffset < count, "String index is out of bounds")
     return i
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func validateSubscalarIndex(
     _ i: String.Index,
     in bounds: Range<String.Index>
@@ -45,7 +45,7 @@ extension _StringGuts {
     return i
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func validateInclusiveSubscalarIndex(
     _ i: String.Index
   ) -> String.Index {
@@ -54,7 +54,7 @@ extension _StringGuts {
     return i
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func validateInclusiveSubscalarIndex(
     _ i: String.Index,
     in bounds: Range<String.Index>
@@ -67,7 +67,7 @@ extension _StringGuts {
     return i
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func validateSubscalarRange(
     _ range: Range<String.Index>
   ) -> Range<String.Index> {
@@ -83,7 +83,7 @@ extension _StringGuts {
     return unsafe Range(_uncheckedBounds: (lower, upper))
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func validateSubscalarRange(
     _ range: Range<String.Index>,
     in bounds: Range<String.Index>
@@ -115,7 +115,7 @@ extension _StringGuts {
   /// - has an encoding that matches this string,
   /// - is within the bounds of this string, and
   /// - is aligned on a scalar boundary.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func validateScalarIndex(_ i: String.Index) -> String.Index {
     if isFastScalarIndex(i) {
       _precondition(i._encodedOffset < count, "String index is out of bounds")
@@ -132,7 +132,7 @@ extension _StringGuts {
   /// - has an encoding that matches this string,
   /// - is within `start ..< end`, and
   /// - is aligned on a scalar boundary.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func validateScalarIndex(
     _ i: String.Index,
     in bounds: Range<String.Index>
@@ -157,7 +157,7 @@ extension _StringGuts {
   /// - has an encoding that matches this string,
   /// - is within the bounds of this string (including the `endIndex`), and
   /// - is aligned on a scalar boundary.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func validateInclusiveScalarIndex(
     _ i: String.Index
   ) -> String.Index {
@@ -176,7 +176,7 @@ extension _StringGuts {
   /// - has an encoding that matches this string,
   /// - is within the bounds of this string (including the `endIndex`), and
   /// - is aligned on a scalar boundary.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func validateInclusiveScalarIndex(
     _ i: String.Index,
     in bounds: Range<String.Index>

--- a/stdlib/public/core/StringInterpolation.swift
+++ b/stdlib/public/core/StringInterpolation.swift
@@ -183,7 +183,7 @@ public struct DefaultStringInterpolation: StringInterpolationProtocol, Sendable 
     #endif
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_unavailableInEmbedded
   public mutating func appendInterpolation(_ value: Any.Type) {
 	  _typeName(value, qualified: false).write(to: &self)
@@ -216,7 +216,7 @@ extension DefaultStringInterpolation {
   /// - Parameters:
   ///   - value: The value to include in a string interpolation, if non-`nil`.
   ///   - default: The string to include if `value` is `nil`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func appendInterpolation<T>(
     _ value: T?,
     default: @autoclosure () -> some StringProtocol
@@ -246,7 +246,7 @@ extension DefaultStringInterpolation {
   /// - Parameters:
   ///   - value: The value to include in a string interpolation, if non-`nil`.
   ///   - default: The string to include if `value` is `nil`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func appendInterpolation<T>(
     _ value: T?,
     default: @autoclosure () -> some StringProtocol
@@ -276,7 +276,7 @@ extension DefaultStringInterpolation {
   /// - Parameters:
   ///   - value: The value to include in a string interpolation, if non-`nil`.
   ///   - default: The string to include if `value` is `nil`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func appendInterpolation<T>(
     _ value: T?, 
     default: @autoclosure () -> some StringProtocol
@@ -306,7 +306,7 @@ extension DefaultStringInterpolation {
   /// - Parameters:
   ///   - value: The value to include in a string interpolation, if non-`nil`.
   ///   - default: The string to include if `value` is `nil`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func appendInterpolation<T>(
     _ value: T?, 
     default: @autoclosure () -> some StringProtocol

--- a/stdlib/public/core/StringObject.swift
+++ b/stdlib/public/core/StringObject.swift
@@ -184,7 +184,7 @@ internal struct _StringObject {
   }
 
   // FIXME: This ought to be the setter for property `_countAndFlags`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func _setCountAndFlags(to value: CountAndFlags) {
 #if _pointerBitWidth(_64)
     self._countAndFlagsBits = value._storage
@@ -571,7 +571,7 @@ extension _StringObject {
 
   // Whether this string is in one of our fastest representations:
   // small or tail-allocated (i.e. mortal/immortal native)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   internal var isPreferredRepresentation: Bool {
     return _fastPath(isSmall || _countAndFlags.isTailAllocated)
@@ -781,7 +781,7 @@ extension _StringObject.CountAndFlags {
     return 0x1000_0000_0000_0000
   }
 
-  @_alwaysEmitIntoClient // Swift 5.7
+  @export(implementation) // Swift 5.7
   @inline(__always)
   internal static var isForeignUTF8Mask: UInt64 {
     return 0x0800_0000_0000_0000
@@ -904,7 +904,7 @@ extension _StringObject.CountAndFlags {
   ///
   /// As of Swift 5.7, this bit is never set; however, future releases may
   /// introduce such forms.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always) // Swift 5.7
   internal var isForeignUTF8: Bool {
     (_storage & Self.isForeignUTF8Mask) != 0
@@ -945,7 +945,7 @@ extension _StringObject {
   }
 
   @inline(__always)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal var largeAddress: UnsafeRawPointer {
     unsafe UnsafeRawPointer(bitPattern: largeAddressBits)
       ._unsafelyUnwrappedUnchecked
@@ -1112,8 +1112,7 @@ extension _StringObject {
 #endif
   }
 
-  @_alwaysEmitIntoClient
-  @inlinable
+  @export(implementation)
   @inline(__always)
   internal var owner: _ConvertedObject? {
     guard self.isMortal else { return nil }
@@ -1158,7 +1157,7 @@ extension _StringObject {
   /// If this returns false, then the string is encoded in UTF-16.
   ///
   /// This always returns a value corresponding to the string's actual encoding.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always) // Swift 5.7
   internal var isUTF8: Bool {
     // This is subtle. It is designed to return the right value in all past &

--- a/stdlib/public/core/StringProtocol.swift
+++ b/stdlib/public/core/StringProtocol.swift
@@ -184,7 +184,7 @@ extension String {
   /// a result for String.UTF8View.withContiguousStorageIfAvailable, and always
   /// return a non-nil value from `String._utf8Span` and `String.UTF8View._span`.
   /// Contiguous strings also benefit from fast-paths and better optimizations.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var isContiguousUTF8: Bool {
     if _guts.isFastUTF8 {
 #if os(watchOS) && _pointerBitWidth(_32)
@@ -204,7 +204,7 @@ extension String {
   ///
   /// Complexity: O(n) if non-contiguous, O(1) if already contiguous
   ///
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func makeContiguousUTF8() {
     if _fastPath(isContiguousUTF8) { return }
     self = String._copying(self)
@@ -223,7 +223,7 @@ extension String {
   ///
   /// Complexity: O(n) if non-contiguous, O(1) if already contiguous
   ///
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @safe
   public mutating func withUTF8<R, E: Error>(
     _ body: (UnsafeBufferPointer<UInt8>) throws(E) -> R
@@ -243,7 +243,7 @@ extension Substring {
   /// always return a non-nil value from `Substring._utf8Span` and
   /// `Substring.UTF8View._span`.
   /// Contiguous strings also benefit from fast-paths and better optimizations.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var isContiguousUTF8: Bool { return self.base.isContiguousUTF8 }
 
   /// If this string is not contiguous, make it so. If this mutates the
@@ -251,13 +251,13 @@ extension Substring {
   ///
   /// Complexity: O(n) if non-contiguous, O(1) if already contiguous
   ///
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   public mutating func makeContiguousUTF8() {
     if isContiguousUTF8 { return }
     return _slowMakeContiguousUTF8()
   }
 
-  @_alwaysEmitIntoClient // Swift 5.7
+  @export(implementation) // Swift 5.7
   @inline(never)
   internal mutating func _slowMakeContiguousUTF8() {
     _internalInvariant(!isContiguousUTF8)
@@ -291,7 +291,7 @@ extension Substring {
   ///
   /// Complexity: O(n) if non-contiguous, O(1) if already contiguous
   ///
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @safe
   public mutating func withUTF8<R, E: Error>(
     _ body: (UnsafeBufferPointer<UInt8>) throws(E) -> R

--- a/stdlib/public/core/StringTesting.swift
+++ b/stdlib/public/core/StringTesting.swift
@@ -60,7 +60,7 @@ extension String {
   public // @testable
   func _classify() -> _StringRepresentation { return _guts._classify() }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public // @testable
   func _deconstructUTF8<ToPointer: _Pointer>(
     scratch: UnsafeMutableRawBufferPointer?
@@ -136,7 +136,7 @@ extension _StringGuts {
 └────────────────────╨───────────────────────┴─────────────────────┴─────────────┴─────────────────┘
 
 */
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal // TODO: figure out if this works as a compiler intrinsic
   func _deconstructUTF8<ToPointer: _Pointer>(
     scratch: UnsafeMutableRawBufferPointer?
@@ -183,7 +183,7 @@ extension _StringGuts {
       allocatedMemory: true)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(never) // slow path
   internal
   func _allocateForDeconstruct() -> (

--- a/stdlib/public/core/StringUTF16View.swift
+++ b/stdlib/public/core/StringUTF16View.swift
@@ -425,7 +425,7 @@ extension String.UTF16View: BidirectionalCollection {
     return self[_unchecked: idx]
   }
 
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   internal subscript(_unchecked idx: Index) -> UTF16.CodeUnit {
     if _fastPath(_guts.isFastUTF8) {
       let scalar = _guts.fastUTF8Scalar(
@@ -708,7 +708,7 @@ extension String.UTF16View {
   // (referring to the second surrogate) and returns `idx`. Otherwise, this will
   // scalar-align the index. This is needed because we may be passed a
   // non-scalar-aligned index from the UTF8View.
-  @_alwaysEmitIntoClient // Swift 5.1
+  @export(implementation) // Swift 5.1
   @inline(__always)
   internal func _utf16AlignNativeIndex(_ idx: String.Index) -> String.Index {
     _internalInvariant(!_guts.isForeign)

--- a/stdlib/public/core/StringUTF8Validation.swift
+++ b/stdlib/public/core/StringUTF8Validation.swift
@@ -77,32 +77,32 @@ internal struct _UTF8EncodingErrorKind: Error, Sendable, Hashable
   }
 
   /// A continuation byte (`10xxxxxx`) outside of a multi-byte sequence
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal static var unexpectedContinuationByte: Self {
     .init(rawValue: 0)
   }
 
   /// A byte in a surrogate code point (`U+D800..U+DFFF`) sequence
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal static var surrogateCodePointByte: Self {
     .init(rawValue: 1)
   }
 
   /// A byte in an invalid, non-surrogate code point (`>U+10FFFF`) sequence
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal static var invalidNonSurrogateCodePointByte: Self {
     .init(rawValue: 2)
   }
 
   /// A byte in an overlong encoding sequence
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal static var overlongEncodingByte: Self {
     .init(rawValue: 3)
   }
 
   /// A multi-byte sequence that is the start of a valid multi-byte scalar
   /// but is cut off before ending correctly
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal static var truncatedScalar: Self {
     .init(rawValue: 4)
   }

--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -230,7 +230,7 @@ extension String.UTF8View: BidirectionalCollection {
     return self[_unchecked: i]
   }
 
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   internal subscript(_unchecked i: Index) -> UTF8.CodeUnit {
     if _fastPath(_guts.isFastUTF8) {
       return _guts.withFastUTF8 { utf8 in unsafe utf8[_unchecked: i._encodedOffset] }
@@ -376,7 +376,7 @@ extension String.UTF8View {
   ///   UTF-16 strings.
   @available(SwiftStdlib 6.2, *)
   public var _span: Span<UTF8.CodeUnit>? {
-    @_alwaysEmitIntoClient @inline(__always)
+    @export(implementation) @inline(__always)
     @_lifetime(borrow self)
     borrowing get {
       span
@@ -541,7 +541,7 @@ extension String.UTF8View {
   // (referring to a continuation byte) and returns `idx`. Otherwise, this will
   // scalar-align the index. This is needed because we may be passed a
   // non-scalar-aligned foreign index from the UTF16View.
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   internal func _utf8AlignForeignIndex(_ idx: String.Index) -> String.Index {
     _internalInvariant(_guts.isForeign)
     guard idx.transcodedOffset == 0 else { return idx }

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -110,7 +110,7 @@ extension String.UnicodeScalarView: BidirectionalCollection {
     return _uncheckedIndex(after: i)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   internal func _uncheckedIndex(after i: Index) -> Index {
     // TODO(String performance): isASCII fast-path
@@ -134,7 +134,7 @@ extension String.UnicodeScalarView: BidirectionalCollection {
     return _uncheckedIndex(before: i)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   internal func _uncheckedIndex(before i: Index) -> Index {
     // TODO(String performance): isASCII fast-path
@@ -171,7 +171,7 @@ extension String.UnicodeScalarView: BidirectionalCollection {
     return _guts.errorCorrectedScalar(startingAt: i._encodedOffset).0
   }
 
-  @_alwaysEmitIntoClient // Swift 5.1 bug fix
+  @export(implementation) // Swift 5.1 bug fix
   public func distance(from start: Index, to end: Index) -> Int {
     let start = _guts.validateInclusiveScalarIndex(start)
     let end = _guts.validateInclusiveScalarIndex(end)
@@ -192,7 +192,7 @@ extension String.UnicodeScalarView: BidirectionalCollection {
     return count
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func index(_ i: Index, offsetBy distance: Int) -> Index {
     var i = _guts.validateInclusiveScalarIndex(i)
 
@@ -210,7 +210,7 @@ extension String.UnicodeScalarView: BidirectionalCollection {
     return i
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func index(
     _ i: Index, offsetBy distance: Int, limitedBy limit: Index
   ) -> Index? {

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -97,14 +97,14 @@ public struct Substring: Sendable {
   @usableFromInline
   internal var _slice: Slice<String>
 
-  @_alwaysEmitIntoClient // Swift 5.7
+  @export(implementation) // Swift 5.7
   @inline(__always)
   internal init(_unchecked slice: Slice<String>) {
     self._slice = slice
     _invariantCheck()
   }
 
-  @_alwaysEmitIntoClient // Swift 5.7
+  @export(implementation) // Swift 5.7
   @inline(__always)
   internal init(_unchecked guts: _StringGuts, bounds: Range<Index>) {
     self.init(_unchecked: Slice(base: String(guts), bounds: bounds))
@@ -132,7 +132,7 @@ public struct Substring: Sendable {
 
 extension Substring {
   /// Returns the underlying string from which this substring was derived.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var base: String { return _slice._base }
 
   @inlinable @inline(__always)
@@ -141,7 +141,7 @@ extension Substring {
   @inlinable @inline(__always)
   internal var _offsetRange: Range<Int> { _slice._bounds._encodedOffsetRange }
 
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   internal var _bounds: Range<Index> { _slice._bounds }
 }
 
@@ -517,7 +517,7 @@ extension Substring: StringProtocol {
   ///   `withCString(_:)` method. The pointer argument is valid only for the
   ///   duration of the method's execution.
   /// - Returns: The return value, if any, of the `body` closure parameter.
-  @_alwaysEmitIntoClient // (Primarily @inlinable) specialization
+  @export(implementation) // (Primarily @inlinable) specialization
   @safe
   public func withCString<Result, E: Error>(
     _ body: (UnsafePointer<CChar>) throws(E) -> Result) throws(E) -> Result {
@@ -557,7 +557,7 @@ extension Substring: StringProtocol {
   ///   - targetEncoding: The encoding in which the code units should be
   ///     interpreted.
   /// - Returns: The return value, if any, of the `body` closure parameter.
-  @_alwaysEmitIntoClient // (Primarily @inlinable) specialization
+  @export(implementation) // (Primarily @inlinable) specialization
   @safe
   public func withCString<Result, TargetEncoding: _UnicodeEncoding, E: Error>(
     encodedAs targetEncoding: TargetEncoding.Type,
@@ -674,13 +674,13 @@ extension Substring {
       _slice = Slice(base: base, bounds: _bounds)
     }
 
-    @_alwaysEmitIntoClient @inline(__always)
+    @export(implementation) @inline(__always)
     internal var _wholeGuts: _StringGuts { _slice._base._guts }
 
-    @_alwaysEmitIntoClient @inline(__always)
+    @export(implementation) @inline(__always)
     internal var _base: String.UTF8View { _slice._base }
 
-    @_alwaysEmitIntoClient @inline(__always)
+    @export(implementation) @inline(__always)
     internal var _bounds: Range<Index> { _slice._bounds }
   }
 }
@@ -739,8 +739,7 @@ extension Substring.UTF8View: BidirectionalCollection {
     return _base.distance(from: start, to: end)
   }
 
-  @_alwaysEmitIntoClient
-  @inlinable
+  @export(implementation)
   public func withContiguousStorageIfAvailable<R>(
     _ body: (UnsafeBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
@@ -885,7 +884,7 @@ extension Substring.UTF8View {
   ///   strings.
   @available(SwiftStdlib 6.2, *)
   public var _span: Span<UTF8.CodeUnit>? {
-    @_alwaysEmitIntoClient @inline(__always)
+    @export(implementation) @inline(__always)
     @_lifetime(borrow self)
     borrowing get {
       span
@@ -1010,13 +1009,13 @@ extension Substring {
       _slice = Slice(base: base, bounds: _bounds)
     }
 
-    @_alwaysEmitIntoClient @inline(__always)
+    @export(implementation) @inline(__always)
     internal var _wholeGuts: _StringGuts { _slice._base._guts }
 
-    @_alwaysEmitIntoClient @inline(__always)
+    @export(implementation) @inline(__always)
     internal var _base: String.UTF16View { _slice._base }
 
-    @_alwaysEmitIntoClient @inline(__always)
+    @export(implementation) @inline(__always)
     internal var _bounds: Range<Index> { _slice._bounds }
   }
 }
@@ -1171,7 +1170,7 @@ extension Substring {
     internal var _slice: Slice<String.UnicodeScalarView>
 
     /// Creates an instance that slices `base` at `_bounds`.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     internal init(
       _unchecked base: String.UnicodeScalarView, bounds: Range<Index>
     ) {
@@ -1193,23 +1192,23 @@ extension Substring {
 }
 
 extension Substring.UnicodeScalarView {
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   internal var _wholeGuts: _StringGuts { _slice._base._guts }
 
   @inline(__always)
   internal var _offsetRange: Range<Int> { _slice._bounds._encodedOffsetRange }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   internal var _bounds: Range<Index> { _slice._bounds }
 }
 
 extension Substring.UnicodeScalarView {
   #if !INTERNAL_CHECKS_ENABLED
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   internal func _invariantCheck() {}
   #else
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(never) @_effects(releasenone)
   internal func _invariantCheck() {
     _internalInvariant(endIndex <= _wholeGuts.endIndex)
@@ -1414,7 +1413,7 @@ extension Substring {
     return String(self).uppercased()
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func filter<E: Error>(
     _ isIncluded: (Element) throws(E) -> Bool
   ) throws(E) -> String {

--- a/stdlib/public/core/SwiftifyImport.swift
+++ b/stdlib/public/core/SwiftifyImport.swift
@@ -115,7 +115,7 @@ public enum _SwiftifyProtocolMethodInfo {
 /// This mimics the stdlib definition. It is public for use with import macros.
 @unsafe
 @_unsafeNonescapableResult
-@_alwaysEmitIntoClient
+@export(implementation)
 @_transparent
 @_lifetime(borrow source)
 public func _swiftifyOverrideLifetime<
@@ -135,7 +135,7 @@ public func _swiftifyOverrideLifetime<
 /// This mimics the stdlib definition. It is public for use with import macros.
 @unsafe
 @_unsafeNonescapableResult
-@_alwaysEmitIntoClient
+@export(implementation)
 @_transparent
 @_lifetime(copy source)
 public func _swiftifyOverrideLifetime<

--- a/stdlib/public/core/TemporaryAllocation.swift
+++ b/stdlib/public/core/TemporaryAllocation.swift
@@ -23,7 +23,7 @@ import SwiftShims
 ///     not be negative.
 ///
 /// - Returns: The number of bytes required for the allocation.
-@_alwaysEmitIntoClient @_transparent
+@export(implementation) @_transparent
 internal func _byteCountForTemporaryAllocation<T: ~Copyable>(
   of type: T.Type,
   capacity: Int
@@ -58,7 +58,7 @@ internal func _byteCountForTemporaryAllocation<T: ~Copyable>(
 ///
 /// - Returns: Whether or not there is sufficient space on the stack to allocate
 ///   `byteCount` bytes of memory.
-@_alwaysEmitIntoClient @_transparent
+@export(implementation) @_transparent
 internal func _isStackAllocationSafe(byteCount: Int, alignment: Int) -> Bool {
   // PRECONDITIONS: Non-positive alignments are nonsensical, as are
   // non-power-of-two alignments.
@@ -112,7 +112,7 @@ internal func _isStackAllocationSafe(byteCount: Int, alignment: Int) -> Bool {
 ///
 /// This function encapsulates the various calls to builtins required by
 /// `withUnsafeTemporaryAllocation()`.
-@_alwaysEmitIntoClient @_transparent
+@export(implementation) @_transparent
 internal func _withUnsafeTemporaryAllocation<
   T: ~Copyable, R: ~Copyable, E: Error
 >(
@@ -141,7 +141,7 @@ internal func _withUnsafeTemporaryAllocation<
   return try body(stackAddress)
 }
 
-@_alwaysEmitIntoClient @_transparent
+@export(implementation) @_transparent
 internal func _withUnprotectedUnsafeTemporaryAllocation<
   T: ~Copyable, R: ~Copyable, E: Error
 >(
@@ -170,7 +170,7 @@ internal func _withUnprotectedUnsafeTemporaryAllocation<
   return try body(stackAddress)
 }
 
-@_alwaysEmitIntoClient @_transparent
+@export(implementation) @_transparent
 internal func _fallBackToHeapAllocation<R: ~Copyable, E: Error>(
   byteCount: Int,
   alignment: Int,
@@ -215,7 +215,7 @@ internal func _fallBackToHeapAllocation<R: ~Copyable, E: Error>(
 /// The buffer pointer passed to `body` (as well as any pointers to elements in
 /// the buffer) must not escape. It will be deallocated when `body` returns and
 /// cannot be used afterward.
-@_alwaysEmitIntoClient @_transparent
+@export(implementation) @_transparent
 @safe
 public func withUnsafeTemporaryAllocation<R: ~Copyable, E: Error>(
   byteCount: Int,
@@ -257,7 +257,7 @@ public func withUnsafeTemporaryAllocation<R: ~Copyable, E: Error>(
 ///
 /// - Throws: Whatever is thrown by `body`.
 @available(SwiftCompatibilitySpan 5.0, *)
-@_alwaysEmitIntoClient @_transparent
+@export(implementation) @_transparent
 public func withTemporaryAllocation<T: ~Copyable, R: ~Copyable, E: Error>(
   of type: T.Type,
   capacity: Int,
@@ -299,7 +299,7 @@ public func withTemporaryAllocation<T: ~Copyable, R: ~Copyable, E: Error>(
 ///
 /// - Throws: Whatever is thrown by `body`.
 @available(SwiftCompatibilitySpan 5.0, *)
-@_alwaysEmitIntoClient @_transparent
+@export(implementation) @_transparent
 public func withTemporaryAllocation<R: ~Copyable, E: Error>(
   byteCount: Int,
   alignment: Int,
@@ -321,7 +321,7 @@ public func withTemporaryAllocation<R: ~Copyable, E: Error>(
 ///
 /// This function is similar to `withUnsafeTemporaryAllocation`, except that it
 /// doesn't trigger stack protection for the stack allocated memory.
-@_alwaysEmitIntoClient @_transparent
+@export(implementation) @_transparent
 public func _withUnprotectedUnsafeTemporaryAllocation<R: ~Copyable, E: Error>(
   byteCount: Int,
   alignment: Int,
@@ -367,7 +367,7 @@ public func _withUnprotectedUnsafeTemporaryAllocation<R: ~Copyable, E: Error>(
 /// The buffer pointer passed to `body` (as well as any pointers to elements in
 /// the buffer) must not escape. It will be deallocated when `body` returns and
 /// cannot be used afterward.
-@_alwaysEmitIntoClient @_transparent
+@export(implementation) @_transparent
 @safe
 public func withUnsafeTemporaryAllocation<
   T: ~Copyable, R: ~Copyable,
@@ -396,7 +396,7 @@ public func withUnsafeTemporaryAllocation<
 ///
 /// This function is similar to `withUnsafeTemporaryAllocation`, except that it
 /// doesn't trigger stack protection for the stack allocated memory.
-@_alwaysEmitIntoClient @_transparent
+@export(implementation) @_transparent
 public func _withUnprotectedUnsafeTemporaryAllocation<
   T: ~Copyable, R: ~Copyable,
   E: Error

--- a/stdlib/public/core/UInt128.swift
+++ b/stdlib/public/core/UInt128.swift
@@ -571,22 +571,22 @@ extension UInt128 {
   // IMPORTANT: The following four apparently unnecessary overloads of
   // comparison operations are necessary for literal comparands to be
   // inferred as the desired type.
-  @_transparent @_alwaysEmitIntoClient
+  @_transparent @export(implementation)
   public static func != (lhs: Self, rhs: Self) -> Bool {
     return !(lhs == rhs)
   }
 
-  @_transparent @_alwaysEmitIntoClient
+  @_transparent @export(implementation)
   public static func <= (lhs: Self, rhs: Self) -> Bool {
     return !(rhs < lhs)
   }
 
-  @_transparent @_alwaysEmitIntoClient
+  @_transparent @export(implementation)
   public static func >= (lhs: Self, rhs: Self) -> Bool {
     return !(lhs < rhs)
   }
 
-  @_transparent @_alwaysEmitIntoClient
+  @_transparent @export(implementation)
   public static func > (lhs: Self, rhs: Self) -> Bool {
     return rhs < lhs
   }

--- a/stdlib/public/core/UTF16.swift
+++ b/stdlib/public/core/UTF16.swift
@@ -148,7 +148,7 @@ extension Unicode.UTF16 {
 
   /// Returns a Boolean value indicating whether the specified code unit is a
   /// high or low surrogate code unit.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func isSurrogate(_ x: CodeUnit) -> Bool {
     return isLeadSurrogate(x) || isTrailSurrogate(x)
   }
@@ -275,7 +275,7 @@ extension Unicode.UTF16: _UnicodeEncoding {
   }
 
   /// Returns whether the given code unit represents an ASCII scalar
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func isASCII(_ x: CodeUnit) -> Bool {
     return x <= 0x7f
   }

--- a/stdlib/public/core/UTF32.swift
+++ b/stdlib/public/core/UTF32.swift
@@ -37,7 +37,7 @@ extension Unicode.UTF32: Unicode.Encoding {
   }
 
   /// Returns whether the given code unit represents an ASCII scalar
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func isASCII(_ x: CodeUnit) -> Bool {
     return x <= 0x7F
   }

--- a/stdlib/public/core/UTF8.swift
+++ b/stdlib/public/core/UTF8.swift
@@ -39,7 +39,7 @@ extension Unicode.UTF8 {
   ///
   /// - Parameter x: A Unicode scalar value.
   /// - Returns: The width of `x` when encoded in UTF-8, from `1` to `4`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func width(_ x: Unicode.Scalar) -> Int {
     switch x.value {
       case 0..<0x80: return 1
@@ -66,7 +66,7 @@ extension Unicode.UTF8: _UnicodeEncoding {
   }
 
   /// Returns whether the given code unit represents an ASCII scalar
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   public static func isASCII(_ x: CodeUnit) -> Bool {
     return x & 0b1000_0000 == 0

--- a/stdlib/public/core/UTF8EncodingError.swift
+++ b/stdlib/public/core/UTF8EncodingError.swift
@@ -110,7 +110,7 @@ extension Unicode.UTF8 {
     /// The range of offsets into our input containing the error
     public var byteOffsets: Range<Int>
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(
       _ kind: Unicode.UTF8.ValidationError.Kind,
       _ byteOffsets: Range<Int>
@@ -127,7 +127,7 @@ extension Unicode.UTF8 {
       self.byteOffsets = byteOffsets
     }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(
       _ kind: Unicode.UTF8.ValidationError.Kind, at byteOffset: Int
     ) {
@@ -152,32 +152,32 @@ extension UTF8.ValidationError {
     }
 
     /// A continuation byte (`10xxxxxx`) outside of a multi-byte sequence
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var unexpectedContinuationByte: Self {
       .init(rawValue: 0)!
     }
 
     /// A byte in a surrogate code point (`U+D800..U+DFFF`) sequence
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var surrogateCodePointByte: Self {
       .init(rawValue: 1)!
     }
 
     /// A byte in an invalid, non-surrogate code point (`>U+10FFFF`) sequence
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var invalidNonSurrogateCodePointByte: Self {
       .init(rawValue: 2)!
     }
 
     /// A byte in an overlong encoding sequence
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var overlongEncodingByte: Self {
       .init(rawValue: 3)!
     }
 
     /// A multi-byte sequence that is the start of a valid multi-byte scalar
     /// but is cut off before ending correctly
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var truncatedScalar: Self {
       .init(rawValue: 4)!
     }

--- a/stdlib/public/core/UTF8Span.swift
+++ b/stdlib/public/core/UTF8Span.swift
@@ -34,7 +34,7 @@ public struct UTF8Span: Copyable, ~Escapable, BitwiseCopyable {
   @usableFromInline
   internal var _countAndFlags: UInt64
 
-  // @_alwaysEmitIntoClient
+  // @export(implementation)
   @inline(__always)
   @_lifetime(borrow start)
   internal init(
@@ -67,7 +67,7 @@ public struct UTF8Span: Copyable, ~Escapable, BitwiseCopyable {
 
   // FIXME: we need to make sure ALL API are nil safe, that is they
   // at least check the count first
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func _start() -> UnsafeRawPointer {
     unsafe _unsafeBaseAddress._unsafelyUnwrappedUnchecked
   }
@@ -158,7 +158,7 @@ extension UTF8Span {
   ///   for the `withUnsafeBufferPointer(_:)` method. The closure's
   ///   parameter is valid only for the duration of its execution.
   /// - Returns: The return value of the `body` closure parameter.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   borrowing public func _withUnsafeBufferPointer<
     E: Error, Result: ~Copyable //& ~Escapable
   >(
@@ -286,7 +286,7 @@ extension String {
   ///   UTF-16 strings.
   @available(SwiftStdlib 6.2, *)
   public var _utf8Span: UTF8Span? {
-    @_alwaysEmitIntoClient @inline(__always)
+    @export(implementation) @inline(__always)
     @_lifetime(borrow self)
     borrowing get {
       utf8Span
@@ -428,7 +428,7 @@ extension Substring {
   ///   strings.
   @available(SwiftStdlib 6.2, *)
   public var _utf8Span: UTF8Span? {
-    @_alwaysEmitIntoClient @inline(__always)
+    @export(implementation) @inline(__always)
     @_lifetime(borrow self)
     borrowing get {
       utf8Span

--- a/stdlib/public/core/UTF8SpanBits.swift
+++ b/stdlib/public/core/UTF8SpanBits.swift
@@ -26,7 +26,7 @@ extension UTF8Span {
   /// non-ASCII content.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var isKnownASCII: Bool {
     0 != _countAndFlags & Self._asciiBit
   }
@@ -53,20 +53,20 @@ extension UTF8Span {
   /// always checked at initialization time and is set by `checkForNFC`.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var isKnownNFC: Bool {
     0 != _countAndFlags & Self._nfcBit
   }
 
   // Set the isKnownASCII bit to true (also isNFC)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(self: copy self)
   internal mutating func _setIsASCII() {
     self._countAndFlags |= Self._asciiBit | Self._nfcBit
   }
 
   // Set the isKnownNFC bit to true (also isNFC)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(self: copy self)
   internal mutating func _setIsNFC() {
     self._countAndFlags |= Self._nfcBit
@@ -116,22 +116,22 @@ extension UTF8Span {
 
 @available(SwiftStdlib 6.2, *)
 extension UTF8Span {
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   internal static var _asciiBit: UInt64 {
     0x8000_0000_0000_0000
   }
 
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   internal static var _nfcBit: UInt64 {
     0x4000_0000_0000_0000
   }
 
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   internal static var _countMask: UInt64 {
     0x00FF_FFFF_FFFF_FFFF
   }
 
-  @_alwaysEmitIntoClient @inline(__always)
+  @export(implementation) @inline(__always)
   internal static var _flagsMask: UInt64 {
     0xFF00_0000_0000_0000
   }
@@ -139,7 +139,7 @@ extension UTF8Span {
   /// The number of UTF-8 code units in the span.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var count: Int {
     Int(truncatingIfNeeded: _countAndFlags & Self._countMask)
   }

--- a/stdlib/public/core/UTF8SpanComparisons.swift
+++ b/stdlib/public/core/UTF8SpanComparisons.swift
@@ -15,7 +15,7 @@ extension UTF8Span {
   /// Whether this span has the same bytes as `other`.
   ///
   /// - Complexity: O(n)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func bytesEqual(to other: some Sequence<UInt8>) -> Bool {
     unsafe _withUnsafeBufferPointer { unsafe $0.elementsEqual(other) }
   }
@@ -23,7 +23,7 @@ extension UTF8Span {
   /// Whether this span has the same `Unicode.Scalar`s as `other`.
   ///
   /// - Complexity: O(n)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func unicodeScalarsEqual(
     to other: some Sequence<Unicode.Scalar>
   ) -> Bool {
@@ -47,7 +47,7 @@ extension UTF8Span {
   ///
   /// - Complexity: O(n)
   @_unavailableInEmbedded
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func charactersEqual(
     to other: some Sequence<Character>
   ) -> Bool {
@@ -110,7 +110,7 @@ extension UTF8Span {
   /// memory region, and have the same flags (such as ``isKnownASCII``).
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func isTriviallyIdentical(to other: Self) -> Bool {
     unsafe (self._unsafeBaseAddress == other._unsafeBaseAddress) &&
     (self._countAndFlags == other._countAndFlags)

--- a/stdlib/public/core/UTF8SpanFundamentals.swift
+++ b/stdlib/public/core/UTF8SpanFundamentals.swift
@@ -355,12 +355,12 @@ extension UTF8Span {
 @available(SwiftStdlib 6.2, *)
 extension UTF8Span {
   /// Whether `i` is in bounds
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func _boundsCheck(_ i: Int) -> Bool {
     i >= 0 && i < count
   }
   /// Whether `bounds` is in bounds
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func _boundsCheck(_ bounds: Range<Int>) -> Bool {
     _boundsCheck(bounds.lowerBound)
     && _boundsCheck(bounds.upperBound &- 1)

--- a/stdlib/public/core/UTF8SpanInternalHelpers.swift
+++ b/stdlib/public/core/UTF8SpanInternalHelpers.swift
@@ -15,30 +15,30 @@
 // import Builtin
 
 extension UnsafeRawPointer {
-  // @_alwaysEmitIntoClient
+  // @export(implementation)
   internal func _loadByte(_ i: Int) -> UInt8 {
     _internalInvariant(i >= 0)
     return unsafe (self+i).loadUnaligned(as: UInt8.self)
   }
 
-  // @_alwaysEmitIntoClient
+  // @export(implementation)
   internal func _isUTF8Continuation(_ i: Int) -> Bool {
     unsafe UTF8.isContinuation(_loadByte(i))
   }
 
-  // @_alwaysEmitIntoClient
+  // @export(implementation)
   internal func _isScalarAligned(_ i: Int) -> Bool {
     _internalInvariant(i >= 0)
     return unsafe !_isUTF8Continuation(i)
   }
 
-  // @_alwaysEmitIntoClient
+  // @export(implementation)
   internal func _scalarLength(startingAt i: Int) -> Int {
     unsafe _utf8ScalarLength(_loadByte(i))
   }
 
   // NOTE: Adaptation of `_decodeScalar` to work on URP
-//  @_alwaysEmitIntoClient
+//  @export(implementation)
   internal func _decodeScalar(
     startingAt i: Int
   ) -> (Unicode.Scalar, nextScalarStart: Int) {
@@ -62,7 +62,7 @@ extension UnsafeRawPointer {
     }
   }
 
-  // @_alwaysEmitIntoClient
+  // @export(implementation)
   internal func _decodeScalar(
     endingAt i: Int
   ) -> (Unicode.Scalar, previousScalarStart: Int) {
@@ -71,7 +71,7 @@ extension UnsafeRawPointer {
     return unsafe (_decodeScalar(startingAt: start).0, start)
   }
 
-  // @_alwaysEmitIntoClient
+  // @export(implementation)
   internal func _previousScalarStart(_ i: Int) -> Int {
     var prev = i &- 1
     _internalInvariant(prev >= 0)
@@ -83,7 +83,7 @@ extension UnsafeRawPointer {
     return prev
   }
 
-  // @_alwaysEmitIntoClient
+  // @export(implementation)
   internal func _scalarAlign(_ i: Int) -> Int {
     var i = i
     while _slowPath(unsafe !_isScalarAligned(i)) {
@@ -101,7 +101,7 @@ extension UnsafeRawPointer {
     unsafe .init(start: self + range.lowerBound, count: range.count)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func _ubp(_ range: Range<Int>) -> UnsafeBufferPointer<UInt8> {
     unsafe UnsafeBufferPointer<UInt8>(
       start: UnsafePointer((self+range.lowerBound)._rawValue),

--- a/stdlib/public/core/UnicodeHelpers.swift
+++ b/stdlib/public/core/UnicodeHelpers.swift
@@ -156,7 +156,7 @@ extension _StringGuts {
   }
 
   @inline(never) // slow-path
-  @_alwaysEmitIntoClient // Swift 5.1
+  @export(implementation) // Swift 5.1
   @_effects(releasenone)
   internal func scalarAlignSlow(_ idx: Index) -> Index {
     _internalInvariant_5_1(!idx._isScalarAligned)
@@ -213,7 +213,7 @@ extension _StringGuts {
     return self.withFastUTF8 { unsafe _decodeScalar($0, startingAt: i).0 }
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   internal func isOnUnicodeScalarBoundary(_ offset: Int) -> Bool {
     isOnUnicodeScalarBoundary(String.Index(_encodedOffset: offset))

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -520,7 +520,7 @@ extension Unicode.Scalar {
   }
 
   // Access the scalar as encoded in UTF-8
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @safe
   internal func withUTF8CodeUnits<Result, E: Error>(
     _ body: (UnsafeBufferPointer<UInt8>) throws(E) -> Result

--- a/stdlib/public/core/UniqueArray/UniqueArray+Append.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Append.swift
@@ -22,7 +22,7 @@ extension UniqueArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1) as amortized over many invocations on the same array.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func append(_ item: consuming Element) {
     _ensureFreeCapacity(1)
     _storage.append(item)
@@ -52,7 +52,7 @@ extension UniqueArray where Element: ~Copyable {
   ///
   /// - Complexity: O(`uninitializedCount`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func append<E: Error>(
     addingCount newItemCount: Int,
     initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
@@ -79,7 +79,7 @@ extension UniqueArray where Element: ~Copyable {
   ///
   /// - Complexity: O(`count` + `items.count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func append(
     moving items: UnsafeMutableBufferPointer<Element>
   ) {
@@ -99,7 +99,7 @@ extension UniqueArray where Element: ~Copyable {
   ///
   /// - Complexity: O(`items.count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func append(
     moving items: inout OutputSpan<Element>
   ) {
@@ -123,7 +123,7 @@ extension UniqueArray where Element: Copyable {
   /// - Complexity: O(`newElements.count`) when amortized over many
   ///     invocations on the same array.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func append(
     copying newElements: UnsafeBufferPointer<Element>
   ) {
@@ -144,7 +144,7 @@ extension UniqueArray where Element: Copyable {
   /// - Complexity: O(`newElements.count`) when amortized over many
   ///     invocations on the same array.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func append(
     copying newElements: UnsafeMutableBufferPointer<Element>
   ) {
@@ -163,7 +163,7 @@ extension UniqueArray where Element: Copyable {
   /// - Complexity: O(`newElements.count`) when amortized over many
   ///     invocations on the same array.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func append(copying newElements: Span<Element>) {
     _ensureFreeCapacity(newElements.count)
     _storage.append(copying: newElements)
@@ -183,7 +183,7 @@ extension UniqueArray where Element: Copyable {
   /// - Complexity: O(*m*), where *m* is the length of `newElements`, when
   ///     amortized over many invocations over the same array.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func append(copying newElements: some Sequence<Element>) {
     let done: Void? = newElements.withContiguousStorageIfAvailable { buffer in
       _ensureFreeCapacity(buffer.count)

--- a/stdlib/public/core/UniqueArray/UniqueArray+Container.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Container.swift
@@ -16,7 +16,7 @@ extension UniqueArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public var isEmpty: Bool {
     _storage.isEmpty
@@ -26,7 +26,7 @@ extension UniqueArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public var count: Int {
     _storage.count
@@ -47,7 +47,7 @@ extension UniqueArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public var startIndex: Int {
     _storage.startIndex
@@ -58,7 +58,7 @@ extension UniqueArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public var endIndex: Int {
     _storage.count
@@ -68,7 +68,7 @@ extension UniqueArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public var indices: Range<Int> {
     _storage.indices
@@ -82,7 +82,7 @@ extension UniqueArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public subscript(position: Int) -> Element {
     @_transparent
     @_unsafeSelfDependentResult
@@ -110,7 +110,7 @@ extension UniqueArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func swapAt(_ i: Int, _ j: Int) {
     _storage.swapAt(i, j)
   }
@@ -130,7 +130,7 @@ extension UniqueArray where Element: ~Copyable {
   /// - Returns: The index immediately following `i`.
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public func index(after index: Int) -> Int {
     index + 1
@@ -148,7 +148,7 @@ extension UniqueArray where Element: ~Copyable {
   /// - Returns: The index immediately preceding `i`.
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public func index(before index: Int) -> Int {
     index - 1
@@ -165,7 +165,7 @@ extension UniqueArray where Element: ~Copyable {
   ///     than `endIndex`.
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public func formIndex(after index: inout Int) {
     index += 1
@@ -182,7 +182,7 @@ extension UniqueArray where Element: ~Copyable {
   ///     `startIndex`.
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public func formIndex(before index: inout Int) {
     index -= 1
@@ -206,7 +206,7 @@ extension UniqueArray where Element: ~Copyable {
   ///    calls to `index(before:)`.
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public func index(_ index: Int, offsetBy n: Int) -> Int {
     index + n
@@ -225,7 +225,7 @@ extension UniqueArray where Element: ~Copyable {
   /// - Returns: The distance between `start` and `end`.
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public func distance(from start: Index, to end: Index) -> Int {
     end - start
@@ -263,7 +263,7 @@ extension UniqueArray where Element: ~Copyable {
   ///    effect.
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func formIndex(
     _ index: inout Index,
     offsetBy n: inout Int,

--- a/stdlib/public/core/UniqueArray/UniqueArray+Equatable.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Equatable.swift
@@ -12,7 +12,7 @@
 
 @available(SwiftStdlib 6.4, *)
 extension UniqueArray where Element: ~Copyable {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func isTriviallyIdentical(to other: borrowing Self) -> Bool {
     _storage.isTriviallyIdentical(to: other._storage)
   }
@@ -21,7 +21,7 @@ extension UniqueArray where Element: ~Copyable {
 @available(SwiftStdlib 6.4, *)
 extension UniqueArray: Equatable where Element: Equatable & ~Copyable {
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public static func ==(
     left: borrowing Self,
     right: borrowing Self

--- a/stdlib/public/core/UniqueArray/UniqueArray+Hashable.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Hashable.swift
@@ -13,7 +13,7 @@
 @available(SwiftStdlib 6.4, *)
 extension UniqueArray: Hashable where Element: Hashable & ~Copyable {
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func hash(into hasher: inout Hasher) {
     _storage.hash(into: &hasher)
   }

--- a/stdlib/public/core/UniqueArray/UniqueArray+Initializers.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Initializers.swift
@@ -14,21 +14,21 @@
 extension UniqueArray where Element: ~Copyable {
   /// Initializes a new unique array with no elements.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init() {
     _storage = .init(capacity: 0)
   }
   
   /// Initializes a new unique array with the specified capacity and no elements.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(capacity: Int) {
     _storage = .init(capacity: capacity)
   }
 
   /// Initializes a new unique array with the specified capacity and no elements.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(minimumCapacity: Int) {
     self.init(capacity: minimumCapacity)
   }
@@ -47,7 +47,7 @@ extension UniqueArray where Element: ~Copyable {
   ///       initialized with however many items the callback adds to the
   ///       output span before it returns (or before it throws an error).
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init<E: Error>(
     capacity: Int,
     initializingWith body: (inout OutputSpan<Element>) throws(E) -> Void
@@ -69,7 +69,7 @@ extension UniqueArray where Element: Copyable {
   ///
   /// - Complexity: O(`count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(repeating repeatedValue: Element, count: Int) {
     self.init(consuming: _RigidArray(repeating: repeatedValue, count: count))
   }
@@ -82,7 +82,7 @@ extension UniqueArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal init(consuming storage: consuming _RigidArray<Element>) {
     self._storage = storage
   }
@@ -98,7 +98,7 @@ extension UniqueArray where Element: Copyable {
   ///      just enough capacity to store the contents.
   ///   - contents: The sequence whose contents to copy into the new array.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(
     capacity: Int? = nil,
     copying contents: some Sequence<Element>
@@ -116,7 +116,7 @@ extension UniqueArray where Element: Copyable {
   ///   - span: The span whose contents to copy into the new array.
   ///      The span must not contain more than `capacity` elements.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(
     capacity: Int? = nil,
     copying span: Span<Element>

--- a/stdlib/public/core/UniqueArray/UniqueArray+Insertions.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Insertions.swift
@@ -31,7 +31,7 @@ extension UniqueArray where Element: ~Copyable {
   ///
   /// - Complexity: O(`self.count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func insert(_ item: consuming Element, at index: Int) {
     _precondition(index >= 0 && index <= count)
     // FIXME: Avoid moving the subsequent elements twice.
@@ -75,7 +75,7 @@ extension UniqueArray where Element: ~Copyable {
   ///
   /// - Complexity: O(`self.count` + `count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func insert<E: Error>(
     addingCount newItemCount: Int,
     at index: Int,
@@ -105,7 +105,7 @@ extension UniqueArray where Element: ~Copyable {
   ///
   /// - Complexity: O(`self.count` + `items.count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func insert(
     moving items: UnsafeMutableBufferPointer<Element>,
     at index: Int
@@ -133,7 +133,7 @@ extension UniqueArray where Element: ~Copyable {
   ///
   /// - Complexity: O(`self.count` + `items.count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func insert(
     moving items: inout OutputSpan<Element>,
     at index: Int
@@ -167,7 +167,7 @@ extension UniqueArray where Element: Copyable {
   ///
   /// - Complexity: O(`self.count` + `newElements.count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func insert(
     copying newElements: UnsafeBufferPointer<Element>, at index: Int
   ) {
@@ -198,7 +198,7 @@ extension UniqueArray where Element: Copyable {
   ///
   /// - Complexity: O(`self.count` + `newElements.count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func insert(
     copying newElements: UnsafeMutableBufferPointer<Element>,
     at index: Int
@@ -226,7 +226,7 @@ extension UniqueArray where Element: Copyable {
   ///
   /// - Complexity: O(`self.count` + `newElements.count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func insert(
     copying newElements: Span<Element>, at index: Int
   ) {
@@ -256,7 +256,7 @@ extension UniqueArray where Element: Copyable {
   ///
   /// - Complexity: O(`self.count` + `newElements.count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func insert(
     copying newElements: some Collection<Element>, at index: Int
   ) {

--- a/stdlib/public/core/UniqueArray/UniqueArray+Removals.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Removals.swift
@@ -16,7 +16,7 @@ extension UniqueArray where Element: ~Copyable {
   ///
   /// - Complexity: O(*n*), where *n* is the original count of the array.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func removeAll() {
     _storage.removeAll()
   }
@@ -30,7 +30,7 @@ extension UniqueArray where Element: ~Copyable {
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
   @discardableResult
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func removeLast() -> Element {
     _storage.removeLast()
   }
@@ -47,7 +47,7 @@ extension UniqueArray where Element: ~Copyable {
   ///
   /// - Complexity: O(`k`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func removeLast(_ k: Int) {
     _storage.removeLast(k)
   }
@@ -64,7 +64,7 @@ extension UniqueArray where Element: ~Copyable {
   /// - Complexity: O(`self.count`)
   @available(SwiftStdlib 6.4, *)
   @discardableResult
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func remove(at index: Int) -> Element {
     _storage.remove(at: index)
   }
@@ -79,7 +79,7 @@ extension UniqueArray where Element: ~Copyable {
   ///
   /// - Complexity: O(`self.count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func removeSubrange(_  bounds: Range<Int>) {
     _storage.removeSubrange(bounds)
   }
@@ -91,7 +91,7 @@ extension UniqueArray where Element: ~Copyable {
   ///
   /// - Complexity: O(`self.count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func removeSubrange(_  bounds: some RangeExpression<Int>) {
     // FIXME: Remove this in favor of a standard algorithm.
     removeSubrange(bounds.relative(to: indices))
@@ -107,7 +107,7 @@ extension UniqueArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func popLast() -> Element? {
     if isEmpty { return nil }
     return removeLast()

--- a/stdlib/public/core/UniqueArray/UniqueArray+Replacements.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Replacements.swift
@@ -54,7 +54,7 @@ extension UniqueArray where Element: ~Copyable {
   /// - Complexity: O(`self.count` + `newItemCount`) in addition to the complexity
   ///    of the callback invocations.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func replaceSubrange<E: Error>(
     _ subrange: Range<Int>,
     addingCount newItemCount: Int,
@@ -103,7 +103,7 @@ extension UniqueArray where Element: ~Copyable {
   ///
   /// - Complexity: O(`self.count` + `newElements.count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func replaceSubrange(
     _ subrange: Range<Int>,
     moving newElements: UnsafeMutableBufferPointer<Element>,
@@ -141,7 +141,7 @@ extension UniqueArray where Element: ~Copyable {
   ///
   /// - Complexity: O(`self.count` + `items.count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func replaceSubrange(
     _ subrange: Range<Int>,
     moving items: inout OutputSpan<Element>
@@ -183,7 +183,7 @@ extension UniqueArray where Element: Copyable {
   /// - Complexity: O(*n* + *m*), where *n* is count of this array and
   ///   *m* is the count of `newElements`.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func replaceSubrange(
     _ subrange: Range<Int>,
     copying newElements: UnsafeBufferPointer<Element>
@@ -222,7 +222,7 @@ extension UniqueArray where Element: Copyable {
   /// - Complexity: O(*n* + *m*), where *n* is count of this array and
   ///   *m* is the count of `newElements`.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func replaceSubrange(
     _ subrange: Range<Int>,
     copying newElements: UnsafeMutableBufferPointer<Element>
@@ -261,7 +261,7 @@ extension UniqueArray where Element: Copyable {
   /// - Complexity: O(*n* + *m*), where *n* is count of this array and
   ///   *m* is the count of `newElements`.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func replaceSubrange(
     _ subrange: Range<Int>,
     copying newElements: Span<Element>
@@ -300,7 +300,7 @@ extension UniqueArray where Element: Copyable {
   /// - Complexity: O(*n* + *m*), where *n* is count of this array and
   ///   *m* is the count of `newElements`.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func replaceSubrange(
     _ subrange: Range<Int>,
     copying newElements: consuming some Collection<Element>

--- a/stdlib/public/core/UniqueArray/UniqueArray.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray.swift
@@ -43,7 +43,7 @@ public struct UniqueArray<Element: ~Copyable>: ~Copyable {
   @usableFromInline
   internal var _storage: _RigidArray<Element>
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal init(_storage: consuming _RigidArray<Element>) {
     self._storage = _storage
   }
@@ -59,7 +59,7 @@ extension UniqueArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public var capacity: Int {
     _assumeNonNegative(_storage.capacity)
@@ -70,7 +70,7 @@ extension UniqueArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public var freeCapacity: Int {
     _assumeNonNegative(_storage.capacity &- _storage.count)
@@ -83,7 +83,7 @@ extension UniqueArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var span: Span<Element> {
     @_lifetime(borrow self)
     @_transparent
@@ -97,7 +97,7 @@ extension UniqueArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var mutableSpan: MutableSpan<Element> {
     @_lifetime(&self)
     @_transparent
@@ -127,7 +127,7 @@ extension UniqueArray where Element: ~Copyable {
   /// - Complexity: Adds O(1) overhead to the complexity of the function
   ///    argument.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public mutating func edit<E: Error, R: ~Copyable>(
     _ body: (inout OutputSpan<Element>) throws(E) -> R
@@ -136,7 +136,7 @@ extension UniqueArray where Element: ~Copyable {
   }
 }
 
-@_alwaysEmitIntoClient
+@export(implementation)
 @_transparent
 internal func _growUniqueArrayCapacity(_ capacity: Int) -> Int {
   // A growth factor of 1.5 seems like a reasonable compromise between
@@ -159,7 +159,7 @@ extension UniqueArray where Element: ~Copyable {
   ///
   /// - Complexity: O(`count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func setCapacity(_ newCapacity: Int) {
     _storage.setCapacity(newCapacity)
   }
@@ -173,19 +173,19 @@ extension UniqueArray where Element: ~Copyable {
   ///
   /// - Complexity: O(`count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public mutating func reserveCapacity(_ n: Int) {
     _storage.reserveCapacity(n)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal mutating func _ensureFreeCapacity(_ freeCapacity: Int) {
     guard _storage.freeCapacity < freeCapacity else { return }
     _ensureFreeCapacitySlow(freeCapacity)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal func _grow(freeCapacity: Int) -> Int {
     Swift.max(
@@ -193,7 +193,7 @@ extension UniqueArray where Element: ~Copyable {
       _growUniqueArrayCapacity(capacity))
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func _ensureFreeCapacitySlow(_ freeCapacity: Int) {
     let newCapacity = _grow(freeCapacity: freeCapacity)
     setCapacity(newCapacity)
@@ -207,7 +207,7 @@ extension UniqueArray {
   ///
   /// - Complexity: O(`count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func clone() -> Self {
     UniqueArray(consuming: _storage.clone())
   }
@@ -220,7 +220,7 @@ extension UniqueArray {
   ///
   /// - Complexity: O(`count`)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func clone(capacity: Int) -> Self {
     UniqueArray(consuming: _storage.clone(capacity: capacity))
   }

--- a/stdlib/public/core/UniqueBox.swift
+++ b/stdlib/public/core/UniqueBox.swift
@@ -23,14 +23,14 @@ public struct UniqueBox<Value: ~Copyable>: ~Copyable {
   /// - Parameter initialValue: The initial value to initialize the unqiue box
   ///                           with.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public init(_ initialValue: consuming Value) {
     unsafe pointer = UnsafeMutablePointer<Value>.allocate(capacity: 1)
     unsafe pointer.initialize(to: initialValue)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   deinit {
     unsafe pointer.deinitialize(count: 1)
@@ -46,7 +46,7 @@ extension UniqueBox where Value: ~Copyable {
   /// Dereferences the unique box allowing for in-place reads and writes to the
   /// stored `Value`.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var value: Value {
     @_transparent
     @_unsafeSelfDependentResult
@@ -64,7 +64,7 @@ extension UniqueBox where Value: ~Copyable {
   /// Consumes the unique box and returns the instance of `Value` that was
   /// within the box.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public consuming func consume() -> Value {
     let result = unsafe pointer.move()
@@ -82,7 +82,7 @@ extension UniqueBox where Value: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var span: Span<Value> {
     @_lifetime(borrow self)
     @_transparent
@@ -97,7 +97,7 @@ extension UniqueBox where Value: ~Copyable {
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var mutableSpan: MutableSpan<Value> {
     @_lifetime(&self)
     @_transparent
@@ -112,7 +112,7 @@ extension UniqueBox where Value: Copyable {
   /// Copies the value within the unqiue box and returns it in a new unique
   /// instance.
   @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func clone() -> Self {
     UniqueBox(value)
   }

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -48,7 +48,7 @@ public struct Unsafe${Mutable}BufferPointer<Element: ~Copyable>: Copyable {
 
   // This works around _debugPrecondition() impacting the performance of
   // optimized code. (rdar://72246338)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal init(
     @_nonEphemeral _uncheckedStart start: Unsafe${Mutable}Pointer<Element>?,
     count: Int
@@ -231,7 +231,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   /// A Boolean value indicating whether the buffer is empty.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_preInverseGenerics
   @safe
   public var isEmpty: Bool { count == 0 }
@@ -263,7 +263,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
     unsafe Range(uncheckedBounds: (0, count))
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(__always)
   @safe
   public func _checkBounds(_ bounds: Range<Index>) -> Bool {
@@ -424,7 +424,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   ///
   /// - Parameter i: The position of the element to access. `i` must be in the
   ///   range `0..<count`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public subscript(i: Int) -> Element {
     @_transparent
     unsafeAddress {
@@ -443,7 +443,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   }
 
   // Skip all debug and runtime checks
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal subscript(_unchecked i: Int) -> Element {
     @_transparent
     unsafeAddress {
@@ -515,7 +515,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   ///
   /// - Parameter bounds: A valid range of indices within this buffer.
   /// - Returns: A new buffer pointer over the items at `bounds`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @safe
   public func extracting(_ bounds: Range<Int>) -> Self {
     _precondition(_checkBounds(bounds), "Index out of range")
@@ -553,7 +553,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   ///
   /// - Parameter bounds: A valid range of indices within this buffer.
   /// - Returns: A new buffer pointer over the items at `bounds`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @safe
   public func extracting(_ bounds: some RangeExpression<Int>) -> Self {
     extracting(bounds.relative(to: unsafe Range(uncheckedBounds: (0, count))))
@@ -573,7 +573,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   /// even if `Element` happens to be noncopyable.
   ///
   /// - Returns: The same buffer as `self`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @safe
   public func extracting(_ bounds: UnboundedRange) -> Self {
     unsafe self
@@ -590,7 +590,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   ///
   /// - Parameter bounds: A valid range of indices within this buffer.
   /// - Returns: A new buffer pointer over the items at `bounds`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func extracting(unchecked bounds: Range<Int>) -> Self {
     let newStart = unsafe _position?.advanced(by: bounds.lowerBound)
     return unsafe Self(start: newStart, count: bounds.count)
@@ -607,7 +607,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   ///
   /// - Parameter bounds: A valid range of indices within this buffer.
   /// - Returns: A new buffer pointer over the items at `bounds`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func extracting(unchecked bounds: ClosedRange<Int>) -> Self {
     let range = unsafe Range(
       _uncheckedBounds: (bounds.lowerBound, bounds.upperBound + 1)
@@ -624,7 +624,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   /// - Parameter maxLength: The maximum number of elements to return.
   ///   `maxLength` must be greater than or equal to zero.
   /// - Returns: A buffer pointer with at most `maxLength` elements.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @safe
   public func extracting(first maxLength: Int) -> Self {
     _precondition(maxLength >= 0, "Can't have a prefix of negative length")
@@ -642,7 +642,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   ///   `k` must be greater than or equal to zero.
   /// - Returns: A buffer pointer leaving off the specified number of trailing
   ///   elements.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @safe
   public func extracting(droppingLast k: Int) -> Self {
     _precondition(k >= 0, "Can't drop a negative number of elements")
@@ -659,7 +659,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   /// - Parameter maxLength: The maximum number of elements to return.
   ///   `maxLength` must be greater than or equal to zero.
   /// - Returns: A buffer pointer with at most `maxLength` elements.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @safe
   public func extracting(last maxLength: Int) -> Self {
     _precondition(maxLength >= 0, "Can't have a suffix of negative length")
@@ -678,7 +678,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   ///   buffer. `k` must be greater than or equal to zero.
   /// - Returns: A buffer pointer starting after the specified number of
   ///   elements.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @safe
   public func extracting(droppingFirst k: Int) -> Self {
     _precondition(k >= 0, "Can't drop a negative number of elements")
@@ -698,7 +698,7 @@ extension UnsafeMutableBufferPointer where Element: Copyable {
   /// The `source` buffer must fit entirely in `self`.
   ///
   /// - Returns: The index after the last item that was initialized in this buffer.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func _initializePrefix(
     copying source: UnsafeBufferPointer<Element>
   ) -> Int {
@@ -711,13 +711,13 @@ extension UnsafeMutableBufferPointer where Element: Copyable {
     return source.count
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func _initializeAll(fromContentsOf source: Self) {
     let i = unsafe self.initialize(fromContentsOf: source)
     _internalInvariant(i == self.endIndex)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func _initializeAll(
     fromContentsOf source: UnsafeBufferPointer<Element>
   ) {
@@ -727,7 +727,7 @@ extension UnsafeMutableBufferPointer where Element: Copyable {
 }
 
 extension UnsafeMutableBufferPointer where Element: ~Copyable {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func _moveInitializePrefix(
     from source: UnsafeMutableBufferPointer<Element>
   ) -> Int {
@@ -740,7 +740,7 @@ extension UnsafeMutableBufferPointer where Element: ~Copyable {
     return source.count
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func _moveInitializeAll(fromContentsOf source: Self) {
     let i = unsafe self.moveInitialize(fromContentsOf: source)
     _internalInvariant(i == self.endIndex)
@@ -767,7 +767,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var span: Span<Element> {
     @_lifetime(borrow self)
     @_transparent
@@ -793,7 +793,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var mutableSpan: MutableSpan<Element> {
     @_lifetime(borrow self)
     @_transparent
@@ -809,7 +809,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   /// memory region.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @safe
   public func isTriviallyIdentical(to other: Self) -> Bool {
     unsafe (self._position == other._position) && (self.count == other.count)
@@ -1011,7 +1011,7 @@ extension Unsafe${Mutable}BufferPointer:
 
 extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   @safe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func _isWellAligned() -> Bool {
     guard let p = baseAddress else { return true }
     return p._isWellAligned()
@@ -1218,7 +1218,7 @@ extension UnsafeMutableBufferPointer {
   ///     initialize the buffer's storage.
   /// - Returns: The index one past the last element of the buffer initialized
   ///     by this function.
-  @_alwaysEmitIntoClient @_transparent 
+  @export(implementation) @_transparent 
   public func initialize(
     fromContentsOf source: some Collection<Element>
   ) -> Index {
@@ -1268,7 +1268,7 @@ extension UnsafeMutableBufferPointer {
     unsafe dstBase.update(repeating: repeatedValue, count: count)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, deprecated, renamed: "update(repeating:)")
   @_silgen_name("_swift_se0370_UnsafeMutableBufferPointer_assign_repeating")
   public func assign(repeating repeatedValue: Element) {
@@ -1286,7 +1286,7 @@ extension UnsafeMutableBufferPointer {
   ///   the buffer's contents.
   /// - Returns: An iterator to any elements of `source` that didn't fit in the
   ///   buffer, and the index one past the last updated element in the buffer.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func update<S: Sequence>(
     from source: S
   ) -> (unwritten: S.Iterator, index: Index) where S.Element == Element {
@@ -1323,7 +1323,7 @@ extension UnsafeMutableBufferPointer {
   /// - Parameter source: A collection of elements to be used to update
   ///   the buffer's contents.
   /// - Returns: An index one past the index of the last element updated.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func update(
     fromContentsOf source: some Collection<Element>
   ) -> Index {
@@ -1394,7 +1394,7 @@ extension UnsafeMutableBufferPointer where Element: ~Copyable {
   ///     region underlying `source` must be initialized.
   /// - Returns: The index one past the last element of the buffer initialized
   ///     by this function.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func moveInitialize(fromContentsOf source: Self) -> Index {
     guard let sourceAddress = source.baseAddress, !source.isEmpty else {
       return startIndex
@@ -1439,7 +1439,7 @@ extension UnsafeMutableBufferPointer {
   ///     region underlying `source` must be initialized.
   /// - Returns: The index one past the last element of the buffer initialized
   ///     by this function.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func moveInitialize(fromContentsOf source: Slice<Self>) -> Index {
     return unsafe moveInitialize(fromContentsOf: Self(rebasing: source))
   }
@@ -1470,7 +1470,7 @@ extension UnsafeMutableBufferPointer where Element: ~Copyable {
   /// - Parameter source: A buffer containing the values to move.
   ///     The memory region underlying `source` must be initialized.
   /// - Returns: An index one past the index of the last element updated.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func moveUpdate(fromContentsOf source: Self) -> Index {
     guard let sourceAddress = source.baseAddress, !source.isEmpty else {
       return startIndex
@@ -1511,7 +1511,7 @@ extension UnsafeMutableBufferPointer {
   /// - Parameter source: A buffer slice containing the values to move.
   ///     The memory region underlying `source` must be initialized.
   /// - Returns: An index one past the index of the last element updated.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func moveUpdate(fromContentsOf source: Slice<Self>) -> Index {
     return unsafe moveUpdate(fromContentsOf: Self(rebasing: source))
   }
@@ -1529,7 +1529,7 @@ extension UnsafeMutableBufferPointer where Element: ~Copyable {
   /// - Returns: A raw buffer to the same range of memory as this buffer.
   ///   The range of memory is still bound to `Element`.
   @discardableResult
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func deinitialize() -> UnsafeMutableRawBufferPointer {
     guard let rawValue = baseAddress?._rawValue
       else { return unsafe .init(start: nil, count: 0) }
@@ -1547,7 +1547,7 @@ extension UnsafeMutableBufferPointer where Element: ~Copyable {
   /// - Parameters:
   ///   - value: The value used to initialize the buffer element's memory.
   ///   - index: The index of the element to initialize
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func initializeElement(at index: Index, to value: consuming Element) {
     _debugPrecondition(startIndex <= index && index < endIndex)
     let p = unsafe baseAddress._unsafelyUnwrappedUnchecked.advanced(by: index)
@@ -1564,7 +1564,7 @@ extension UnsafeMutableBufferPointer where Element: ~Copyable {
   /// - Parameters:
   ///   - index: The index of the buffer element to retrieve and deinitialize.
   /// - Returns: The instance referenced by this index in this buffer.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func moveElement(from index: Index) -> Element {
     _debugPrecondition(startIndex <= index && index < endIndex)
     return unsafe baseAddress._unsafelyUnwrappedUnchecked.advanced(by: index).move()
@@ -1578,7 +1578,7 @@ extension UnsafeMutableBufferPointer where Element: ~Copyable {
   ///
   /// - Parameters:
   ///   - index: The index of the buffer element to deinitialize.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func deinitializeElement(at index: Index) {
     _debugPrecondition(startIndex <= index && index < endIndex)
     let p = unsafe baseAddress._unsafelyUnwrappedUnchecked.advanced(by: index)
@@ -1643,7 +1643,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   ///     method.
   ///   - buffer: The buffer temporarily bound to `T`.
   /// - Returns: The return value, if any, of the `body` closure parameter.
-  @_alwaysEmitIntoClient @_transparent
+  @export(implementation) @_transparent
   public func withMemoryRebound<T: ~Copyable, E: Error, Result: ~Copyable>(
     to type: T.Type,
     _ body: (_ buffer: ${Self}<T>) throws(E) -> Result

--- a/stdlib/public/core/UnsafeBufferPointerSlice.swift
+++ b/stdlib/public/core/UnsafeBufferPointerSlice.swift
@@ -24,8 +24,7 @@ extension Slice where Base == UnsafeMutableRawBufferPointer {
   ///
   /// - Parameter source: A collection of `UInt8` elements. `source.count` must
   ///   be less than or equal to this buffer slice's `count`.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func copyBytes<C: Collection>(
     from source: C
   ) where C.Element == UInt8 {
@@ -57,8 +56,7 @@ extension Slice where Base == UnsafeMutableRawBufferPointer {
   ///     The typed buffer contains `self.count / MemoryLayout<T>.stride`
   ///     instances of `T`.
   @discardableResult
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func initializeMemory<T>(
     as type: T.Type, repeating repeatedValue: T
   ) -> UnsafeMutableBufferPointer<T> {
@@ -89,8 +87,7 @@ extension Slice where Base == UnsafeMutableRawBufferPointer {
   ///   buffer, and a typed buffer of the written elements. The returned
   ///   buffer references memory starting at the same base address as this
   ///   buffer.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func initializeMemory<S: Sequence>(
     as type: S.Element.Type, from source: S
   ) -> (unwritten: S.Iterator, initialized: UnsafeMutableBufferPointer<S.Element>) {
@@ -121,8 +118,7 @@ extension Slice where Base == UnsafeMutableRawBufferPointer {
   /// - Returns: A typed buffer referencing the initialized elements.
   ///     The returned buffer references memory starting at the same
   ///     base address as this slice, and its count is equal to `source.count`
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func initializeMemory<C: Collection>(
     as type: C.Element.Type,
     fromContentsOf source: C
@@ -159,8 +155,7 @@ extension Slice where Base == UnsafeMutableRawBufferPointer {
   ///     The returned buffer references memory starting at the same
   ///     base address as this slice, and its count is equal to `source.count`.
   @discardableResult
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func moveInitializeMemory<T: ~Copyable>(
     as type: T.Type,
     fromContentsOf source: UnsafeMutableBufferPointer<T>
@@ -197,8 +192,7 @@ extension Slice where Base == UnsafeMutableRawBufferPointer {
   ///     The returned buffer references memory starting at the same
   ///     base address as this slice, and its count is equal to `source.count`.
   @discardableResult
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func moveInitializeMemory<T>(
     as type: T.Type,
     fromContentsOf source: Slice<UnsafeMutableBufferPointer<T>>
@@ -226,8 +220,7 @@ extension Slice where Base == UnsafeMutableRawBufferPointer {
   ///   The typed buffer references `self.count / MemoryLayout<T>.stride`
   ///   instances of `T`.
   @discardableResult
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func bindMemory<T: ~Copyable>(
     to type: T.Type
   ) -> UnsafeMutableBufferPointer<T> {
@@ -279,8 +272,7 @@ extension Slice where Base == UnsafeMutableRawBufferPointer {
   ///     the return value for the `withMemoryRebound(to:capacity:_:)` method.
   ///   - buffer: The buffer temporarily bound to instances of `T`.
   /// - Returns: The return value, if any, of the `body` closure parameter.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func withMemoryRebound<T: ~Copyable, E: Error, Result: ~Copyable>(
     to type: T.Type,
     _ body: (UnsafeMutableBufferPointer<T>) throws(E) -> Result
@@ -305,8 +297,7 @@ extension Slice where Base == UnsafeMutableRawBufferPointer {
   ///
   /// - Parameter to: The type `T` that the memory has already been bound to.
   /// - Returns: A typed pointer to the same memory as this raw pointer.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func assumingMemoryBound<T: ~Copyable>(
     to type: T.Type
   ) -> UnsafeMutableBufferPointer<T> {
@@ -343,8 +334,7 @@ extension Slice where Base == UnsafeMutableRawBufferPointer {
   ///     with `type`.
   /// - Returns: A new instance of type `T`, copied from the buffer pointer
   ///   slice's memory.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func load<T>(fromByteOffset offset: Int = 0, as type: T.Type) -> T {
     let buffer = unsafe Base(rebasing: self)
     return unsafe buffer.load(fromByteOffset: offset, as: T.self)
@@ -381,8 +371,7 @@ extension Slice where Base == UnsafeMutableRawBufferPointer {
   ///     with `type`.
   /// - Returns: A new instance of type `T`, copied from the buffer pointer's
   ///   memory.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func loadUnaligned<T : BitwiseCopyable>(
     fromByteOffset offset: Int = 0,
     as type: T.Type
@@ -390,8 +379,7 @@ extension Slice where Base == UnsafeMutableRawBufferPointer {
     let buffer = unsafe Base(rebasing: self)
     return unsafe buffer.loadUnaligned(fromByteOffset: offset, as: T.self)
   }
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func loadUnaligned<T>(
     fromByteOffset offset: Int = 0,
     as type: T.Type
@@ -435,8 +423,7 @@ extension Slice where Base == UnsafeMutableRawBufferPointer {
   ///   - type: The type to use for the newly constructed instance. The memory
   ///     must be initialized to a value of a type that is layout compatible
   ///     with `type`.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func storeBytes<T>(
     of value: T, toByteOffset offset: Int = 0, as type: T.Type
   ) {
@@ -466,8 +453,7 @@ extension Slice where Base == UnsafeRawBufferPointer {
   ///   The typed buffer references `self.count / MemoryLayout<T>.stride`
   ///   instances of `T`.
   @discardableResult
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func bindMemory<T: ~Copyable>(
     to type: T.Type
   ) -> UnsafeBufferPointer<T> {
@@ -519,8 +505,7 @@ extension Slice where Base == UnsafeRawBufferPointer {
   ///     the return value for the `withMemoryRebound(to:capacity:_:)` method.
   ///   - buffer: The buffer temporarily bound to instances of `T`.
   /// - Returns: The return value, if any, of the `body` closure parameter.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func withMemoryRebound<T: ~Copyable, E: Error, Result: ~Copyable>(
     to type: T.Type,
     _ body: (UnsafeBufferPointer<T>) throws(E) -> Result
@@ -545,8 +530,7 @@ extension Slice where Base == UnsafeRawBufferPointer {
   ///
   /// - Parameter to: The type `T` that the memory has already been bound to.
   /// - Returns: A typed pointer to the same memory as this raw pointer.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func assumingMemoryBound<T: ~Copyable>(
     to type: T.Type
   ) -> UnsafeBufferPointer<T> {
@@ -583,8 +567,7 @@ extension Slice where Base == UnsafeRawBufferPointer {
   ///     with `type`.
   /// - Returns: A new instance of type `T`, copied from the buffer pointer
   ///   slice's memory.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func load<T>(fromByteOffset offset: Int = 0, as type: T.Type) -> T {
     let buffer = unsafe Base(rebasing: self)
     return unsafe buffer.load(fromByteOffset: offset, as: T.self)
@@ -621,8 +604,7 @@ extension Slice where Base == UnsafeRawBufferPointer {
   ///     with `type`.
   /// - Returns: A new instance of type `T`, copied from the buffer pointer's
   ///   memory.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func loadUnaligned<T : BitwiseCopyable>(
     fromByteOffset offset: Int = 0,
     as type: T.Type
@@ -630,8 +612,7 @@ extension Slice where Base == UnsafeRawBufferPointer {
     let buffer = unsafe Base(rebasing: self)
     return unsafe buffer.loadUnaligned(fromByteOffset: offset, as: T.self)
   }
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func loadUnaligned<T>(
     fromByteOffset offset: Int = 0,
     as type: T.Type
@@ -697,8 +678,7 @@ extension Slice {
   ///     method.
   ///   - buffer: The buffer temporarily bound to `T`.
   /// - Returns: The return value, if any, of the `body` closure parameter.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func withMemoryRebound<
     T: ~Copyable, E: Error, Result: ~Copyable, Element
   >(
@@ -723,8 +703,7 @@ extension Slice {
   ///
   /// - Parameter repeatedValue: The value with which to initialize this
   ///   buffer slice's memory.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func initialize<Element>(repeating repeatedValue: Element)
     where Base == UnsafeMutableBufferPointer<Element> {
     unsafe Base(rebasing: self).initialize(repeating: repeatedValue)
@@ -751,8 +730,7 @@ extension Slice {
   ///   buffer.
   /// - Returns: An iterator to any elements of `source` that didn't fit in the
   ///   buffer, and an index to the next uninitialized element in the buffer.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func initialize<S>(
     from source: S
   ) -> (unwritten: S.Iterator, index: Index)
@@ -790,8 +768,7 @@ extension Slice {
   ///     initialize the buffer slice's storage.
   /// - Returns: The index one past the last element of the buffer slice
   ///    initialized by this function.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func initialize<Element>(
     fromContentsOf source: some Collection<Element>
   ) -> Index where Base == UnsafeMutableBufferPointer<Element> {
@@ -810,8 +787,7 @@ extension Slice {
   ///
   /// - Parameters:
   ///   - repeatedValue: The value used when updating this pointer's memory.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func update<Element>(repeating repeatedValue: Element)
     where Base == UnsafeMutableBufferPointer<Element> {
     unsafe Base(rebasing: self).update(repeating: repeatedValue)
@@ -826,8 +802,7 @@ extension Slice {
   ///   the contents of the buffer slice.
   /// - Returns: An iterator to any elements of `source` that didn't fit in the
   ///   buffer slice, and the index one past the last updated element.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func update<S>(
     from source: S
   ) -> (unwritten: S.Iterator, index: Index)
@@ -860,8 +835,7 @@ extension Slice {
   /// - Parameter source: A collection of elements to be used to update
   ///     the buffer's contents.
   /// - Returns: An index one past the index of the last element updated.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func update<Element>(
     fromContentsOf source: some Collection<Element>
   ) -> Index where Base == UnsafeMutableBufferPointer<Element> {
@@ -899,8 +873,7 @@ extension Slice {
   ///     The memory region underlying `source` must be initialized.
   /// - Returns: The index one past the last element of the buffer slice
   ///    initialized by this function.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func moveInitialize<Element>(
     fromContentsOf source: UnsafeMutableBufferPointer<Element>
   ) -> Index where Base == UnsafeMutableBufferPointer<Element> {
@@ -938,8 +911,7 @@ extension Slice {
   ///     The memory region underlying `source` must be initialized.
   /// - Returns: The index one past the last element of the buffer slice
   ///    initialized by this function.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func moveInitialize<Element>(
     fromContentsOf source: Slice<UnsafeMutableBufferPointer<Element>>
   ) -> Index where Base == UnsafeMutableBufferPointer<Element> {
@@ -974,8 +946,7 @@ extension Slice {
   /// - Parameter source: A buffer containing the values to move.
   ///     The memory region underlying `source` must be initialized.
   /// - Returns: An index one past the index of the last element updated.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func moveUpdate<Element>(
     fromContentsOf source: UnsafeMutableBufferPointer<Element>
   ) -> Index where Base == UnsafeMutableBufferPointer<Element> {
@@ -1010,8 +981,7 @@ extension Slice {
   /// - Parameter source: A buffer slice containing the values to move.
   ///     The memory region underlying `source` must be initialized.
   /// - Returns: An index one past the index of the last element updated.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func moveUpdate<Element>(
     fromContentsOf source: Slice<UnsafeMutableBufferPointer<Element>>
   ) -> Index where Base == UnsafeMutableBufferPointer<Element> {
@@ -1032,8 +1002,7 @@ extension Slice {
   /// - Returns: A raw buffer to the same range of memory as this buffer.
   ///   The range of memory is still bound to `Element`.
   @discardableResult
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func deinitialize<Element>() -> UnsafeMutableRawBufferPointer
     where Base == UnsafeMutableBufferPointer<Element> {
     unsafe Base(rebasing: self).deinitialize()
@@ -1048,8 +1017,7 @@ extension Slice {
   /// - Parameters:
   ///   - value: The value used to initialize the buffer element's memory.
   ///   - index: The index of the element to initialize
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func initializeElement<Element>(at index: Int, to value: Element)
     where Base == UnsafeMutableBufferPointer<Element> {
     unsafe assert(startIndex <= index && index < endIndex)
@@ -1066,8 +1034,7 @@ extension Slice {
   /// - Parameters:
   ///   - index: The index of the buffer element to retrieve and deinitialize.
   /// - Returns: The instance referenced by this index in this buffer.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func moveElement<Element>(from index: Index) -> Element
     where Base == UnsafeMutableBufferPointer<Element> {
     unsafe assert(startIndex <= index && index < endIndex)
@@ -1082,8 +1049,7 @@ extension Slice {
   ///
   /// - Parameters:
   ///   - index: The index of the buffer element to deinitialize.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func deinitializeElement<Element>(at index: Base.Index)
     where Base == UnsafeMutableBufferPointer<Element> {
     unsafe assert(startIndex <= index && index < endIndex)
@@ -1145,8 +1111,7 @@ extension Slice {
   ///     method.
   ///   - buffer: The buffer temporarily bound to `T`.
   /// - Returns: The return value, if any, of the `body` closure parameter.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func withMemoryRebound<
     T: ~Copyable, E: Error, Result: ~Copyable, Element
   >(
@@ -1158,8 +1123,7 @@ extension Slice {
     try unsafe Base(rebasing: self).withMemoryRebound(to: T.self, body)
   }
 
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func withContiguousMutableStorageIfAvailable<R, Element>(
     _ body: (_ buffer: inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? where Base == UnsafeMutableBufferPointer<Element> {

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -281,7 +281,7 @@ extension UnsafePointer where Pointee: ~Copyable {
   ///
   /// When reading from the `pointee` property, the instance referenced by
   /// this pointer must already be initialized.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var pointee: Pointee {
     @_transparent unsafeAddress {
       return unsafe self
@@ -292,7 +292,7 @@ extension UnsafePointer where Pointee: ~Copyable {
 extension UnsafePointer {
   // This preserves the ABI of the original (pre-6.0) `pointee` property that
   // used to export a getter. The current one above would export a read
-  // accessor, if it wasn't @_alwaysEmitIntoClient.
+  // accessor, if it wasn't @export(implementation).
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
   @usableFromInline
   internal var pointee: Pointee {
@@ -309,7 +309,7 @@ extension UnsafePointer where Pointee: ~Copyable {
   ///
   /// - Parameter i: The offset from this pointer at which to access an
   ///   instance, measured in strides of the pointer's `Pointee` type.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public subscript(i: Int) -> Pointee {
     @_transparent
     unsafeAddress {
@@ -321,7 +321,7 @@ extension UnsafePointer where Pointee: ~Copyable {
 extension UnsafePointer {
   // This preserves the ABI of the original (pre-6.0) subscript that used to
   // export a getter. The current one above would export a read accessor, if it
-  // wasn't @_alwaysEmitIntoClient.
+  // wasn't @export(implementation).
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
   @usableFromInline
   internal subscript(i: Int) -> Pointee {
@@ -394,7 +394,7 @@ extension UnsafePointer where Pointee: ~Copyable {
   ///     the return value for the `withMemoryRebound(to:capacity:_:)` method.
   ///   - pointer: The pointer temporarily bound to `T`.
   /// - Returns: The return value, if any, of the `body` closure parameter.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func withMemoryRebound<T: ~Copyable, E: Error, Result: ~Copyable>(
     to type: T.Type,
     capacity count: Int,
@@ -444,7 +444,7 @@ extension UnsafePointer {
   /// - Parameter property: A `KeyPath` whose `Root` is `Pointee`.
   /// - Returns: A pointer to the stored property represented
   ///            by the key path, or `nil`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public func pointer<Property>(
     to property: KeyPath<Pointee, Property>
@@ -471,7 +471,7 @@ extension UnsafePointer where Pointee: ~Copyable {
 
 extension UnsafePointer where Pointee: ~Copyable {
   @safe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func _isWellAligned() -> Bool {
     (Int(bitPattern: self) & (MemoryLayout<Pointee>.alignment &- 1)) == 0
   }
@@ -850,7 +850,7 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
   /// Uninitialized memory cannot be initialized to a nontrivial type
   /// using `pointee`. Instead, use an initializing method, such as
   /// `initialize(to:)`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var pointee: Pointee {
     @_transparent unsafeAddress {
       return unsafe UnsafePointer(self)
@@ -864,7 +864,7 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
 extension UnsafeMutablePointer {
   // This preserves the ABI of the original (pre-6.0) `pointee` property that
   // used to export a getter. The current one above would export a read
-  // accessor, if it wasn't @_alwaysEmitIntoClient.
+  // accessor, if it wasn't @export(implementation).
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
   @usableFromInline
   internal var pointee: Pointee {
@@ -914,7 +914,7 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
   ///
   /// - Parameters:
   ///   - value: The instance to initialize this pointer's pointee to.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func initialize(to value: consuming Pointee) {
     Builtin.initialize(value, self._rawValue)
   }
@@ -974,7 +974,7 @@ extension UnsafeMutablePointer {
     }
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, deprecated, renamed: "update(repeating:count:)")
   @_silgen_name("_swift_se0370_UnsafeMutablePointer_assign_repeating_count")
   public func assign(repeating repeatedValue: Pointee, count: Int) {
@@ -1026,7 +1026,7 @@ extension UnsafeMutablePointer {
     }
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, deprecated, renamed: "update(from:count:)")
   @_silgen_name("_swift_se0370_UnsafeMutablePointer_assign_from_count")
   @unsafe
@@ -1158,7 +1158,7 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
 }
 
 extension UnsafeMutablePointer {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @available(*, deprecated, renamed: "moveUpdate(from:count:)")
   @_silgen_name("_swift_se0370_UnsafeMutablePointer_moveAssign_from_count")
   public func moveAssign(
@@ -1252,7 +1252,7 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
   ///     the return value for the `withMemoryRebound(to:capacity:_:)` method.
   ///   - pointer: The pointer temporarily bound to `T`.
   /// - Returns: The return value, if any, of the `body` closure parameter.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @unsafe
   public func withMemoryRebound<T: ~Copyable, E: Error, Result: ~Copyable>(
     to type: T.Type,
@@ -1307,7 +1307,7 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
   ///
   /// - Parameter i: The offset from this pointer at which to access an
   ///   instance, measured in strides of the pointer's `Pointee` type.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public subscript(i: Int) -> Pointee {
     @_transparent
     unsafeAddress {
@@ -1323,7 +1323,7 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
 extension UnsafeMutablePointer {
   // This preserves the ABI of the original (pre-6.0) subscript that used to
   // export a getter. The current one above would export a read accessor, if it
-  // wasn't @_alwaysEmitIntoClient.
+  // wasn't @export(implementation).
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
   @usableFromInline
   internal subscript(i: Int) -> Pointee {
@@ -1347,7 +1347,7 @@ extension UnsafeMutablePointer {
   /// - Parameter property: A `KeyPath` whose `Root` is `Pointee`.
   /// - Returns: A pointer to the stored property represented
   ///            by the key path, or `nil`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public func pointer<Property>(
     to property: KeyPath<Pointee, Property>
@@ -1369,7 +1369,7 @@ extension UnsafeMutablePointer {
   /// - Parameter property: A `WritableKeyPath` whose `Root` is `Pointee`.
   /// - Returns: A mutable pointer to the stored property represented
   ///            by the key path, or `nil`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public func pointer<Property>(
     to property: WritableKeyPath<Pointee, Property>
@@ -1396,7 +1396,7 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
 
 extension UnsafeMutablePointer where Pointee: ~Copyable {
   @safe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func _isWellAligned() -> Bool {
     (Int(bitPattern: self) & (MemoryLayout<Pointee>.alignment &- 1)) == 0
   }

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -102,7 +102,7 @@ public struct Unsafe${Mutable}RawBufferPointer {
 
   // This works around _debugPrecondition() impacting the performance of
   // optimized code. (rdar://72246338)
-  @_alwaysEmitIntoClient @_transparent
+  @export(implementation) @_transparent
   internal init(
     @_nonEphemeral _uncheckedStart start: Unsafe${Mutable}RawPointer?,
     count: Int
@@ -131,7 +131,7 @@ public struct Unsafe${Mutable}RawBufferPointer {
   }
 
   @safe @_transparent
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public init(_empty: ()) {
     unsafe _position = nil
     unsafe _end = nil
@@ -212,7 +212,7 @@ extension Unsafe${Mutable}RawBufferPointer: @unsafe Sequence {
   ///
   /// - Returns: an iterator over any remaining elements of `self` and the
   ///   number of elements copied.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func _copyContents(
     initializing destination: UnsafeMutableBufferPointer<UInt8>
   ) -> (Iterator, UnsafeMutableBufferPointer<UInt8>.Index) {
@@ -259,7 +259,7 @@ extension Unsafe${Mutable}RawBufferPointer: @unsafe ${Mutable}Collection {
     return unsafe Indices(uncheckedBounds: (startIndex, endIndex))
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @inline(always)
   @safe
   public func _checkBounds(_ bounds: Range<Index>) -> Bool {
@@ -468,7 +468,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///     with `type`.
   /// - Returns: A new instance of type `T`, copied from the buffer pointer's
   ///   memory.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow self)
   public func loadUnaligned<T: BitwiseCopyable & ~Escapable>(
     fromByteOffset offset: Int = 0,
@@ -481,7 +481,7 @@ extension Unsafe${Mutable}RawBufferPointer {
     return unsafe _overrideLifetime(value, borrowing: self)
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func loadUnaligned<T>(
     fromByteOffset offset: Int = 0,
     as type: T.Type
@@ -527,7 +527,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///   - type: The type to use for the newly constructed instance. The memory
   ///     must be initialized to a value of a type that is layout compatible
   ///     with `type`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   // This custom silgen name is chosen to not interfere with the old ABI
   @_silgen_name("_swift_se0349_UnsafeMutableRawBufferPointer_storeBytes")
   public func storeBytes<T>(
@@ -898,7 +898,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// - Returns: A typed buffer referencing the initialized elements.
   ///     The returned buffer references memory starting at the same
   ///     base address as this buffer, and its count is equal to `source.count`
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func initializeMemory<C: Collection>(
     as type: C.Element.Type,
     fromContentsOf source: C
@@ -986,7 +986,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///     The returned buffer references memory starting at the same
   ///     base address as this buffer, and its count is equal to `source.count`.
   @discardableResult
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func moveInitializeMemory<T: ~Copyable>(
     as type: T.Type,
     fromContentsOf source: UnsafeMutableBufferPointer<T>
@@ -1038,7 +1038,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///     The returned buffer references memory starting at the same
   ///     base address as this buffer, and its count is equal to `source.count`.
   @discardableResult
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func moveInitializeMemory<T>(
     as type: T.Type,
     fromContentsOf source: Slice<UnsafeMutableBufferPointer<T>>
@@ -1128,7 +1128,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///     the return value for the `withMemoryRebound(to:capacity:_:)` method.
   ///   - buffer: The buffer temporarily bound to instances of `T`.
   /// - Returns: The return value, if any, of the `body` closure parameter.
-  @_alwaysEmitIntoClient @_transparent
+  @export(implementation) @_transparent
   public func withMemoryRebound<T: ~Copyable, E: Error, Result: ~Copyable>(
     to type: T.Type,
     _ body: (_ buffer: Unsafe${Mutable}BufferPointer<T>) throws(E) -> Result
@@ -1165,7 +1165,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///
   /// - Parameter to: The type `T` that the memory has already been bound to.
   /// - Returns: A typed pointer to the same memory as this raw pointer.
-  @_alwaysEmitIntoClient @_transparent
+  @export(implementation) @_transparent
   public func assumingMemoryBound<T: ~Copyable>(
     to: T.Type
   ) -> Unsafe${Mutable}BufferPointer<T> {
@@ -1180,7 +1180,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   }
 
 %  if Mutable:
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public func withContiguousMutableStorageIfAvailable<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
@@ -1198,7 +1198,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   }
 
 %  end
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   public func withContiguousStorageIfAvailable<R>(
     _ body: (UnsafeBufferPointer<Element>) throws -> R
@@ -1219,7 +1219,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///
   /// - Parameter bounds: A valid range of byte offsets within this buffer.
   /// - Returns: A new buffer pointer over the bytes at `bounds`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @safe
   public func extracting(_ bounds: Range<Int>) -> Self {
     _precondition(_checkBounds(bounds), "Byte offset out of range")
@@ -1239,7 +1239,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///
   /// - Parameter bounds: A valid range of byte offsets within this buffer.
   /// - Returns: A new buffer pointer over the bytes at `bounds`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @safe
   public func extracting(_ bounds: some RangeExpression<Int>) -> Self {
     extracting(bounds.relative(to: unsafe Range(uncheckedBounds: (0, count))))
@@ -1248,7 +1248,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// Extracts and returns a copy of the entire buffer.
   ///
   /// - Returns: The same buffer as `self`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @safe
   public func extracting(_ bounds: UnboundedRange) -> Self {
     unsafe self
@@ -1265,7 +1265,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///
   /// - Parameter bounds: A valid range of byte offsets within this buffer.
   /// - Returns: A new buffer pointer over the bytes at `bounds`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func extracting(unchecked bounds: Range<Int>) -> Self {
     let newStart = unsafe baseAddress?.advanced(by: bounds.lowerBound)
     return unsafe Self(_uncheckedStart: newStart, count: bounds.count)
@@ -1282,7 +1282,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///
   /// - Parameter bounds: A valid range of byte offsets within this buffer.
   /// - Returns: A new buffer pointer over the bytes at `bounds`.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func extracting(unchecked bounds: ClosedRange<Int>) -> Self {
     let range = unsafe Range(
       _uncheckedBounds: (bounds.lowerBound, bounds.upperBound + 1)
@@ -1299,7 +1299,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// - Parameter maxLength: The maximum number of bytes to return.
   ///   `maxLength` must be greater than or equal to zero.
   /// - Returns: A buffer pointer with at most `maxLength` bytes.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @safe
   public func extracting(first maxLength: Int) -> Self {
     _precondition(maxLength >= 0, "Can't have a prefix of negative length")
@@ -1316,7 +1316,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///   `k` must be greater than or equal to zero.
   /// - Returns: A buffer pointer leaving off the specified number of trailing
   ///   bytes.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @safe
   public func extracting(droppingLast k: Int) -> Self {
     _precondition(k >= 0, "Can't drop a negative number of bytes")
@@ -1334,7 +1334,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// - Parameter maxLength: The maximum number of bytes to return.
   ///   `maxLength` must be greater than or equal to zero.
   /// - Returns: A buffer pointer with at most `maxLength` bytes.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @safe
   public func extracting(last maxLength: Int) -> Self {
     _precondition(maxLength >= 0, "Can't have a suffix of negative length")
@@ -1351,7 +1351,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// - Parameter k: The number of bytes to drop from the beginning of the
   ///   buffer. `k` must be greater than or equal to zero.
   /// - Returns: A buffer pointer starting after the specified number of bytes.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @safe
   public func extracting(droppingFirst k: Int) -> Self {
     _precondition(k >= 0, "Can't drop a negative number of bytes")
@@ -1380,7 +1380,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///
   /// - Complexity: O(1)
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var bytes: RawSpan {
     @_lifetime(borrow self)
     @_transparent
@@ -1406,7 +1406,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///
   /// - Complexity: O(1)
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public var mutableBytes: MutableRawSpan {
     @_lifetime(borrow self)
     @_transparent
@@ -1422,7 +1422,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// memory region.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @safe
   public func isTriviallyIdentical(to other: Self) -> Bool {
     unsafe (self._position == other._position) && (self._end == other._end)
@@ -1483,7 +1483,7 @@ extension Unsafe${Mutable}RawBufferPointer: ConvertibleToBytes {}
 ///     function. The buffer pointer argument is valid only for the duration
 ///     of the closure's execution.
 /// - Returns: The return value, if any, of the `body` closure.
-@_alwaysEmitIntoClient
+@export(implementation)
 @safe
 public func withUnsafeMutableBytes<T: ~Copyable & ~Escapable, E: Error, Result: ~Copyable>(
   of value: inout T,
@@ -1516,7 +1516,7 @@ func __abi_se0413_withUnsafeMutableBytes<T, Result>(
 ///
 /// This function is similar to `withUnsafeMutableBytes`, except that it
 /// doesn't trigger stack protection for the pointer.
-@_alwaysEmitIntoClient
+@export(implementation)
 public func _withUnprotectedUnsafeMutableBytes<
   T: ~Copyable & ~Escapable, E: Error, Result: ~Copyable
 >(
@@ -1555,7 +1555,7 @@ public func _withUnprotectedUnsafeMutableBytes<
 ///     If you want to mutate a value by writing through a pointer, use
 ///     `withUnsafeMutableBytes(of:_:)` instead.
 /// - Returns: The return value, if any, of the `body` closure.
-@_alwaysEmitIntoClient
+@export(implementation)
 @safe
 public func withUnsafeBytes<T: ~Copyable & ~Escapable, E: Error, Result: ~Copyable>(
   of value: inout T,
@@ -1587,7 +1587,7 @@ func __abi_se0413_withUnsafeBytes<T, Result>(
 ///
 /// This function is similar to `withUnsafeBytes`, except that it
 /// doesn't trigger stack protection for the pointer.
-@_alwaysEmitIntoClient
+@export(implementation)
 public func _withUnprotectedUnsafeBytes<
   T: ~Copyable & ~Escapable, E: Error, Result: ~Copyable
 >(
@@ -1626,7 +1626,7 @@ public func _withUnprotectedUnsafeBytes<
 // FIXME: Support `T: ~Copyable & ~Escapable` when we have an _overrideLifetime
 // that returns a borrowed value. This requires compiler support for emitting
 // tracking Builtin.Borrow<T> as ~Escapable.
-@_alwaysEmitIntoClient
+@export(implementation)
 @safe
 public func withUnsafeBytes<
   T: ~Copyable, E: Error, Result: ~Copyable
@@ -1663,7 +1663,7 @@ func __abi_se0413_withUnsafeBytes<T, Result>(
 // FIXME: Support `T: ~Copyable & ~Escapable` when we have an _overrideLifetime
 // that returns a borrowed value. This requires compiler support for emitting
 // tracking Builtin.Borrow<T> as ~Escapable.
-@_alwaysEmitIntoClient
+@export(implementation)
 public func _withUnprotectedUnsafeBytes<
   T: ~Copyable, E: Error, Result: ~Copyable
 >(

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -393,7 +393,7 @@ extension UnsafeRawPointer {
   ///     the return value for the `withMemoryRebound(to:capacity:_:)` method.
   ///   - pointer: The pointer temporarily bound to `T`.
   /// - Returns: The return value, if any, of the `body` closure parameter.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func withMemoryRebound<T: ~Copyable, E: Error, Result: ~Copyable>(
     to type: T.Type,
     capacity count: Int,
@@ -489,7 +489,7 @@ extension UnsafeRawPointer {
   ///   `offset`. The returned instance isn't associated
   ///   with the value in the range of memory referenced by this pointer.
   @_transparent
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow self)
   public func loadUnaligned<T: BitwiseCopyable & ~Escapable>(
     fromByteOffset offset: Int = 0,
@@ -520,8 +520,7 @@ extension UnsafeRawPointer {
   /// - Returns: A new instance of type `T`, read from the raw bytes at
   ///   `offset`. The returned instance isn't associated
   ///   with the value in the range of memory referenced by this pointer.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func loadUnaligned<T>(
     fromByteOffset offset: Int = 0,
     as type: T.Type
@@ -560,8 +559,7 @@ extension UnsafeRawPointer {
   /// - Parameters:
   ///   - type: the type to be stored at the returned address.
   /// - Returns: a pointer properly aligned to store a value of type `T`.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func alignedUp<T: ~Copyable & ~Escapable>(for type: T.Type) -> Self {
     let mask = UInt(Builtin.alignof(T.self)) &- 1
     let bits = (UInt(Builtin.ptrtoint_Word(_rawValue)) &+ mask) & ~mask
@@ -578,8 +576,7 @@ extension UnsafeRawPointer {
   /// - Parameters:
   ///   - type: the type to be stored at the returned address.
   /// - Returns: a pointer properly aligned to store a value of type `T`.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func alignedDown<T: ~Copyable & ~Escapable>(for type: T.Type) -> Self {
     let mask = UInt(Builtin.alignof(T.self)) &- 1
     let bits = UInt(Builtin.ptrtoint_Word(_rawValue)) & ~mask
@@ -596,8 +593,7 @@ extension UnsafeRawPointer {
   ///   - alignment: the alignment of the returned pointer, in bytes.
   ///     `alignment` must be a whole power of 2.
   /// - Returns: a pointer aligned to `alignment`.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func alignedUp(toMultipleOf alignment: Int) -> Self {
     let mask = UInt(alignment._builtinWordValue) &- 1
     _debugPrecondition(
@@ -619,8 +615,7 @@ extension UnsafeRawPointer {
   ///   - alignment: the alignment of the returned pointer, in bytes.
   ///     `alignment` must be a whole power of 2.
   /// - Returns: a pointer aligned to `alignment`.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func alignedDown(toMultipleOf alignment: Int) -> Self {
     let mask = UInt(alignment._builtinWordValue) &- 1
     _debugPrecondition(
@@ -1013,7 +1008,7 @@ extension UnsafeMutableRawPointer {
   ///     the return value for the `withMemoryRebound(to:capacity:_:)` method.
   ///   - pointer: The pointer temporarily bound to `T`.
   /// - Returns: The return value, if any, of the `body` closure parameter.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func withMemoryRebound<T: ~Copyable, E: Error, Result: ~Copyable>(
     to type: T.Type,
     capacity count: Int,
@@ -1077,7 +1072,7 @@ extension UnsafeMutableRawPointer {
   ///   - value: The value used to initialize this memory.
   /// - Returns: A typed pointer to the memory referenced by this raw pointer.
   @discardableResult
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func initializeMemory<T: ~Copyable>(
     as type: T.Type, to value: consuming T
   ) -> UnsafeMutablePointer<T> {
@@ -1332,7 +1327,7 @@ extension UnsafeMutableRawPointer {
   ///   `offset`. The returned instance isn't associated
   ///   with the value in the range of memory referenced by this pointer.
   @_transparent
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow self)
   public func loadUnaligned<T: BitwiseCopyable & ~Escapable>(
     fromByteOffset offset: Int = 0,
@@ -1363,8 +1358,7 @@ extension UnsafeMutableRawPointer {
   /// - Returns: A new instance of type `T`, read from the raw bytes at
   ///   `offset`. The returned instance isn't associated
   ///   with the value in the range of memory referenced by this pointer.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func loadUnaligned<T>(
     fromByteOffset offset: Int = 0,
     as type: T.Type
@@ -1421,7 +1415,7 @@ extension UnsafeMutableRawPointer {
   ///     nonnegative. The default is zero.
   ///   - type: The type of `value`.
   @_transparent
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func storeBytes<T: BitwiseCopyable & ~Escapable>(
     of value: T, toByteOffset offset: Int = 0, as type: T.Type
   ) {
@@ -1465,7 +1459,7 @@ extension UnsafeMutableRawPointer {
   ///     nonnegative. The default is zero.
   ///   - type: The type of `value`.
   @_transparent
-  @_alwaysEmitIntoClient
+  @export(implementation)
   // This custom silgen name is chosen to not interfere with the old ABI
   @_silgen_name("_swift_se0349_UnsafeMutableRawPointer_storeBytes")
   public func storeBytes<T>(
@@ -1501,7 +1495,7 @@ extension UnsafeMutableRawPointer {
   }
 
   // This is the implementation of `storeBytes` from SwiftStdlib 5.6
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func _legacy_se0349_storeBytes_internal<T>(
     of value: T, toByteOffset offset: Int = 0, as type: T.Type
   ) {
@@ -1567,8 +1561,7 @@ extension UnsafeMutableRawPointer {
   /// - Parameters:
   ///   - type: the type to be stored at the returned address.
   /// - Returns: a pointer properly aligned to store a value of type `T`.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func alignedUp<T: ~Copyable & ~Escapable>(for type: T.Type) -> Self {
     let mask = UInt(Builtin.alignof(T.self)) &- 1
     let bits = (UInt(Builtin.ptrtoint_Word(_rawValue)) &+ mask) & ~mask
@@ -1585,8 +1578,7 @@ extension UnsafeMutableRawPointer {
   /// - Parameters:
   ///   - type: the type to be stored at the returned address.
   /// - Returns: a pointer properly aligned to store a value of type `T`.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func alignedDown<T: ~Copyable & ~Escapable>(for type: T.Type) -> Self {
     let mask = UInt(Builtin.alignof(T.self)) &- 1
     let bits = UInt(Builtin.ptrtoint_Word(_rawValue)) & ~mask
@@ -1603,8 +1595,7 @@ extension UnsafeMutableRawPointer {
   ///   - alignment: the alignment of the returned pointer, in bytes.
   ///     `alignment` must be a whole power of 2.
   /// - Returns: a pointer aligned to `alignment`.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func alignedUp(toMultipleOf alignment: Int) -> Self {
     let mask = UInt(alignment._builtinWordValue) &- 1
     _debugPrecondition(
@@ -1626,8 +1617,7 @@ extension UnsafeMutableRawPointer {
   ///   - alignment: the alignment of the returned pointer, in bytes.
   ///     `alignment` must be a whole power of 2.
   /// - Returns: a pointer aligned to `alignment`.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @export(implementation)
   public func alignedDown(toMultipleOf alignment: Int) -> Self {
     let mask = UInt(alignment._builtinWordValue) &- 1
     _debugPrecondition(

--- a/stdlib/public/core/_InlineArray.swift
+++ b/stdlib/public/core/_InlineArray.swift
@@ -30,7 +30,7 @@ extension _InlineArray: @unchecked Sendable where Element: Sendable & ~Copyable 
 
 extension _InlineArray where Element: ~Copyable {
   /// Returns a pointer to the first element in the array.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal var _address: UnsafePointer<Element> {
 #if $AddressOfProperty2
@@ -41,7 +41,7 @@ extension _InlineArray where Element: ~Copyable {
   }
 
   /// Returns a buffer pointer over the entire array.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal var _buffer: UnsafeBufferPointer<Element> {
     unsafe UnsafeBufferPointer<Element>(start: _address, count: count)
@@ -52,7 +52,7 @@ extension _InlineArray where Element: ~Copyable {
   ///
   /// Use this when the value of the pointer could potentially be directly used
   /// by users (e.g. through the use of span or the unchecked subscript).
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal var _protectedAddress: UnsafePointer<Element> {
 #if $AddressOfProperty2
@@ -67,14 +67,14 @@ extension _InlineArray where Element: ~Copyable {
   ///
   /// Use this when the value of the pointer could potentially be directly used
   /// by users (e.g. through the use of span or the unchecked subscript).
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal var _protectedBuffer: UnsafeBufferPointer<Element> {
     unsafe UnsafeBufferPointer<Element>(start: _protectedAddress, count: count)
   }
 
   /// Returns a mutable pointer to the first element in the array.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal var _mutableAddress: UnsafeMutablePointer<Element> {
     mutating get {
@@ -87,7 +87,7 @@ extension _InlineArray where Element: ~Copyable {
   }
 
   /// Returns a mutable buffer pointer over the entire array.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal var _mutableBuffer: UnsafeMutableBufferPointer<Element> {
     mutating get {
@@ -103,7 +103,7 @@ extension _InlineArray where Element: ~Copyable {
   ///
   /// Use this when the value of the pointer could potentially be directly used
   /// by users (e.g. through the use of span or the unchecked subscript).
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal var _protectedMutableAddress: UnsafeMutablePointer<Element> {
     mutating get {
@@ -120,7 +120,7 @@ extension _InlineArray where Element: ~Copyable {
   ///
   /// Use this when the value of the pointer could potentially be directly used
   /// by users (e.g. through the use of span or the unchecked subscript).
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal var _protectedMutableBuffer: UnsafeMutableBufferPointer<Element> {
     mutating get {
@@ -134,7 +134,7 @@ extension _InlineArray where Element: ~Copyable {
   /// Converts the given raw pointer, which points at an uninitialized array
   /// instance, to a mutable buffer suitable for initialization.
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal static func _initializationBuffer(
     start: Builtin.RawPointer
@@ -167,7 +167,7 @@ extension _InlineArray where Element: ~Copyable {
   ///
   /// - Parameter body: A closure that returns an owned `Element` to emplace at
   ///   the passed in index.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal init<E: Error>(_ body: (Index) throws(E) -> Element) throws(E) {
     _storage = try Builtin.emplace { (rawPtr) throws(E) -> () in
       let buffer = unsafe Self._initializationBuffer(start: rawPtr)
@@ -208,7 +208,7 @@ extension _InlineArray where Element: ~Copyable {
   ///   - next: A closure that takes an immutable borrow reference to the
   ///     preceding element, and returns an owned `Element` instance to emplace
   ///     into the array.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal init<E: Error>(
     first: consuming Element,
     next: (borrowing Element) throws(E) -> Element
@@ -248,7 +248,7 @@ extension _InlineArray where Element: ~Copyable {
     }
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal init<E: Error>(
     initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
   ) throws(E) {
@@ -267,7 +267,7 @@ extension _InlineArray where Element: Copyable {
   /// Initializes every element in this array to a copy of the given value.
   ///
   /// - Parameter value: The instance to initialize this array with.
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal init(repeating value: Element) {
     _storage = Builtin.emplace {
       let buffer = unsafe Self._initializationBuffer(start: $0)
@@ -295,7 +295,7 @@ extension _InlineArray where Element: ~Copyable {
   /// The number of elements in the array.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_semantics("fixed_storage.get_count")
   @inline(__always)
   internal var count: Int {
@@ -305,7 +305,7 @@ extension _InlineArray where Element: ~Copyable {
   /// A Boolean value indicating whether the array is empty.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal var isEmpty: Bool {
     count == 0
@@ -316,7 +316,7 @@ extension _InlineArray where Element: ~Copyable {
   /// If the array is empty, `startIndex` is equal to `endIndex`.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal var startIndex: Index {
     0
@@ -328,7 +328,7 @@ extension _InlineArray where Element: ~Copyable {
   /// If the array is empty, `endIndex` is equal to `startIndex`.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal var endIndex: Index {
     count
@@ -337,7 +337,7 @@ extension _InlineArray where Element: ~Copyable {
   /// The indices that are valid for subscripting the array, in ascending order.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal var indices: Range<Index> {
     unsafe Range(_uncheckedBounds: (0, count))
@@ -350,7 +350,7 @@ extension _InlineArray where Element: ~Copyable {
   /// - Returns: The index immediately after `i`.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal borrowing func index(after i: Index) -> Index {
     i &+ 1
@@ -363,13 +363,13 @@ extension _InlineArray where Element: ~Copyable {
   /// - Returns: The index value immediately before `i`.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_transparent
   internal borrowing func index(before i: Index) -> Index {
     i &- 1
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_semantics("fixed_storage.check_index")
   @inline(__always)
   internal func _checkIndex(_ i: Index) {
@@ -383,7 +383,7 @@ extension _InlineArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @_addressableSelf
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal subscript(_ i: Index) -> Element {
     @_transparent
     borrow {
@@ -408,7 +408,7 @@ extension _InlineArray where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @_addressableSelf
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @unsafe
   internal subscript(unchecked i: Index) -> Element {
     @_transparent
@@ -440,7 +440,7 @@ extension _InlineArray where Element: ~Copyable {
   ///   - j: The index of the second value to swap.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal mutating func swapAt(
     _ i: Index,
     _ j: Index
@@ -464,7 +464,7 @@ extension _InlineArray where Element: ~Copyable {
 //===----------------------------------------------------------------------===//
 
 extension _InlineArray where Element: ~Copyable {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal var span: Span<Element> {
     @_lifetime(borrow self)
     @_transparent
@@ -474,7 +474,7 @@ extension _InlineArray where Element: ~Copyable {
     }
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal var mutableSpan: MutableSpan<Element> {
     @_lifetime(&self)
     @_transparent

--- a/stdlib/toolchain/CompatibilitySpan/FakeStdlib.swift
+++ b/stdlib/toolchain/CompatibilitySpan/FakeStdlib.swift
@@ -17,7 +17,7 @@
 
 import Swift
 
-@_alwaysEmitIntoClient @_transparent
+@export(implementation) @_transparent
 internal func _precondition(
   _ condition: @autoclosure () -> Bool, _ message: StaticString = StaticString(),
   file: StaticString = #file, line: UInt = #line
@@ -25,7 +25,7 @@ internal func _precondition(
 	fatalError()
 }
 
-@_alwaysEmitIntoClient @_transparent
+@export(implementation) @_transparent
 internal func _internalInvariantFailure(
   _ message: StaticString = StaticString(),
   file: StaticString = #file, line: UInt = #line
@@ -35,7 +35,7 @@ internal func _internalInvariantFailure(
 
 @unsafe
 @_unsafeNonescapableResult
-@_alwaysEmitIntoClient
+@export(implementation)
 @_transparent
 @lifetime(borrow source)
 internal func _overrideLifetime<
@@ -48,7 +48,7 @@ internal func _overrideLifetime<
 
 @unsafe
 @_unsafeNonescapableResult
-@_alwaysEmitIntoClient
+@export(implementation)
 @_transparent
 @lifetime(copy source)
 internal func _overrideLifetime<
@@ -61,7 +61,7 @@ internal func _overrideLifetime<
 
 @unsafe
 @_unsafeNonescapableResult
-@_alwaysEmitIntoClient
+@export(implementation)
 @_transparent
 @lifetime(&source)
 internal func _overrideLifetime<
@@ -75,14 +75,14 @@ internal func _overrideLifetime<
 
 extension Range {
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal init(_uncheckedBounds bounds: (lower: Bound, upper: Bound)) {
     self.init(uncheckedBounds: bounds)
   }
 }
 
 extension Optional {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal var _unsafelyUnwrappedUnchecked: Wrapped {
     get {
       if let x = self {

--- a/test/SourceKit/DocSupport/doc_clang_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift.response
@@ -82,7 +82,7 @@ struct FooRuncingOptions : OptionSet {
     static func != (_ lhs: borrowing FooRuncingOptions, _ rhs: borrowing FooRuncingOptions) -> Bool
 
     @discardableResult
-    mutating func insert(_ newMember: FooRuncingOptions) -> (inserted: Bool, memberAfterInsert: FooRuncingOptions)
+    @export(implementation) mutating func insert(_ newMember: FooRuncingOptions) -> (inserted: Bool, memberAfterInsert: FooRuncingOptions)
 
     @inlinable init(arrayLiteral arrayLiteral: FooRuncingOptions...)
 }
@@ -1592,613 +1592,589 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 1840,
+    key.length: 23
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1864,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1849,
+    key.offset: 1873,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1854,
+    key.offset: 1878,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1861,
+    key.offset: 1885,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1863,
+    key.offset: 1887,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 1874,
+    key.offset: 1898,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1897,
+    key.offset: 1921,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 1907,
+    key.offset: 1931,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1913,
+    key.offset: 1937,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 1932,
+    key.offset: 1956,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1956,
+    key.offset: 1980,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1967,
+    key.offset: 1991,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1972,
+    key.offset: 1996,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1985,
+    key.offset: 2009,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 1999,
+    key.offset: 2023,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2024,
+    key.offset: 2048,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2034,
+    key.offset: 2058,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2059,
+    key.offset: 2083,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2070,
+    key.offset: 2094,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2075,
+    key.offset: 2099,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 2081,
+    key.offset: 2105,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 2083,
+    key.offset: 2107,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2090,
+    key.offset: 2114,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2112,
+    key.offset: 2136,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2135,
+    key.offset: 2159,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2146,
+    key.offset: 2170,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2151,
+    key.offset: 2175,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 2164,
+    key.offset: 2188,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 2166,
+    key.offset: 2190,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2173,
+    key.offset: 2197,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2195,
+    key.offset: 2219,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2218,
+    key.offset: 2242,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2229,
+    key.offset: 2253,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2234,
+    key.offset: 2258,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 2254,
+    key.offset: 2278,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 2256,
+    key.offset: 2280,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2263,
+    key.offset: 2287,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2285,
+    key.offset: 2309,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2306,
+    key.offset: 2330,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2316,
+    key.offset: 2340,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2341,
+    key.offset: 2365,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2352,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2357,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 2366,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 2368,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "FooRuncingOptions",
-    key.usr: "c:@E@FooRuncingOptions",
     key.offset: 2376,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2381,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 2390,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 2392,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "FooRuncingOptions",
+    key.usr: "c:@E@FooRuncingOptions",
+    key.offset: 2400,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 2398,
+    key.offset: 2422,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2408,
+    key.offset: 2432,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2431,
+    key.offset: 2455,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2442,
+    key.offset: 2466,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2451,
+    key.offset: 2475,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2456,
+    key.offset: 2480,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 2463,
+    key.offset: 2487,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 2465,
+    key.offset: 2489,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2476,
+    key.offset: 2500,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2499,
+    key.offset: 2523,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 2509,
+    key.offset: 2533,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2515,
+    key.offset: 2539,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2534,
-    key.length: 17
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 2558,
+    key.length: 17
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2582,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2581,
+    key.offset: 2605,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2592,
+    key.offset: 2616,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2601,
+    key.offset: 2625,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2606,
+    key.offset: 2630,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 2613,
+    key.offset: 2637,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 2615,
+    key.offset: 2639,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2623,
+    key.offset: 2647,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2645,
-    key.length: 17
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 2669,
+    key.length: 17
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2693,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2692,
+    key.offset: 2716,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2703,
+    key.offset: 2727,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2712,
+    key.offset: 2736,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2717,
+    key.offset: 2741,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 2724,
+    key.offset: 2748,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 2729,
+    key.offset: 2753,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2740,
+    key.offset: 2764,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2762,
+    key.offset: 2786,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2784,
+    key.offset: 2808,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2794,
+    key.offset: 2818,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2819,
+    key.offset: 2843,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2830,
+    key.offset: 2854,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2842,
+    key.offset: 2866,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2853,
+    key.offset: 2877,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2862,
+    key.offset: 2886,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2867,
+    key.offset: 2891,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 2877,
+    key.offset: 2901,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 2879,
+    key.offset: 2903,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2886,
+    key.offset: 2910,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2910,
+    key.offset: 2934,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2921,
+    key.offset: 2945,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2930,
+    key.offset: 2954,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2935,
+    key.offset: 2959,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 2952,
+    key.offset: 2976,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 2954,
+    key.offset: 2978,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2961,
+    key.offset: 2985,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2985,
+    key.offset: 3009,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2996,
+    key.offset: 3020,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3005,
+    key.offset: 3029,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3010,
+    key.offset: 3034,
     key.length: 23
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3034,
+    key.offset: 3058,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3036,
+    key.offset: 3060,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 3043,
+    key.offset: 3067,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3065,
+    key.offset: 3089,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 3075,
+    key.offset: 3099,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3100,
+    key.offset: 3124,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3111,
+    key.offset: 3135,
     key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.ref.generic_type_param,
-    key.name: "S",
-    key.usr: "s:s10SetAlgebraPsEyxqd__ncSTRd__7ElementQyd__ACRtzlufc1SL_qd__mfp",
-    key.offset: 3116,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3119,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3121,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.ref.generic_type_param,
-    key.name: "S",
-    key.usr: "s:s10SetAlgebraPsEyxqd__ncSTRd__7ElementQyd__ACRtzlufc1SL_qd__mfp",
-    key.offset: 3131,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3134,
-    key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
@@ -2208,786 +2184,781 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.length: 1
   },
   {
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 3143,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 3145,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.ref.generic_type_param,
+    key.name: "S",
+    key.usr: "s:s10SetAlgebraPsEyxqd__ncSTRd__7ElementQyd__ACRtzlufc1SL_qd__mfp",
+    key.offset: 3155,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 3158,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.ref.generic_type_param,
+    key.name: "S",
+    key.usr: "s:s10SetAlgebraPsEyxqd__ncSTRd__7ElementQyd__ACRtzlufc1SL_qd__mfp",
+    key.offset: 3164,
+    key.length: 1
+  },
+  {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Sequence",
     key.usr: "s:ST",
-    key.offset: 3144,
+    key.offset: 3168,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 3154,
+    key.offset: 3178,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.operator,
-    key.offset: 3172,
+    key.offset: 3196,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "S",
     key.usr: "s:s10SetAlgebraPsEyxqd__ncSTRd__7ElementQyd__ACRtzlufc1SL_qd__mfp",
-    key.offset: 3175,
+    key.offset: 3199,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.associatedtype,
     key.name: "Element",
     key.usr: "s:ST7ElementQa",
-    key.offset: 3177,
+    key.offset: 3201,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3190,
+    key.offset: 3214,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3201,
+    key.offset: 3225,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3210,
+    key.offset: 3234,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3215,
+    key.offset: 3239,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3224,
+    key.offset: 3248,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3226,
+    key.offset: 3250,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 3233,
+    key.offset: 3257,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3257,
+    key.offset: 3281,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3268,
+    key.offset: 3292,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3273,
+    key.offset: 3297,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3282,
+    key.offset: 3306,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3285,
+    key.offset: 3309,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 3292,
+    key.offset: 3316,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 3314,
+    key.offset: 3338,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3324,
+    key.offset: 3348,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3335,
+    key.offset: 3359,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3340,
+    key.offset: 3364,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3351,
+    key.offset: 3375,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3354,
+    key.offset: 3378,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 3361,
+    key.offset: 3385,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 3383,
+    key.offset: 3407,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3393,
+    key.offset: 3417,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3404,
+    key.offset: 3428,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3409,
+    key.offset: 3433,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3420,
+    key.offset: 3444,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3425,
+    key.offset: 3449,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 3432,
+    key.offset: 3456,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 3454,
+    key.offset: 3478,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3464,
+    key.offset: 3488,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3475,
+    key.offset: 3499,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3480,
+    key.offset: 3504,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3492,
+    key.offset: 3516,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3494,
+    key.offset: 3518,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 3501,
+    key.offset: 3525,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 3523,
+    key.offset: 3547,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3546,
+    key.offset: 3570,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3557,
+    key.offset: 3581,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3561,
+    key.offset: 3585,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 3570,
+    key.offset: 3594,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3577,
+    key.offset: 3601,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3588,
+    key.offset: 3612,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3599,
+    key.offset: 3623,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3604,
+    key.offset: 3628,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3621,
+    key.offset: 3645,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3624,
+    key.offset: 3648,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 3631,
+    key.offset: 3655,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 3653,
+    key.offset: 3677,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3663,
+    key.offset: 3687,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3674,
+    key.offset: 3698,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3679,
+    key.offset: 3703,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3694,
+    key.offset: 3718,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3697,
+    key.offset: 3721,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 3704,
+    key.offset: 3728,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 3726,
+    key.offset: 3750,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3734,
+    key.offset: 3758,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3741,
+    key.offset: 3765,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3759,
+    key.offset: 3783,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3771,
+    key.offset: 3795,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3776,
+    key.offset: 3800,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3778,
+    key.offset: 3802,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 3781,
+    key.offset: 3805,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3788,
+    key.offset: 3812,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3790,
+    key.offset: 3814,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Double",
     key.usr: "s:Sd",
-    key.offset: 3793,
+    key.offset: 3817,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3806,
+    key.offset: 3830,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3810,
+    key.offset: 3834,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 3813,
+    key.offset: 3837,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3824,
+    key.offset: 3848,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3828,
+    key.offset: 3852,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Double",
     key.usr: "s:Sd",
-    key.offset: 3831,
+    key.offset: 3855,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3841,
+    key.offset: 3865,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3851,
+    key.offset: 3875,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UnsafeMutablePointer",
     key.usr: "s:Sp",
-    key.offset: 3871,
+    key.offset: 3895,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooStruct1",
     key.usr: "c:@S@FooStruct1",
-    key.offset: 3892,
+    key.offset: 3916,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3905,
+    key.offset: 3929,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3912,
+    key.offset: 3936,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3930,
+    key.offset: 3954,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3942,
+    key.offset: 3966,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3947,
+    key.offset: 3971,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3949,
+    key.offset: 3973,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 3952,
+    key.offset: 3976,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3959,
+    key.offset: 3983,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3961,
+    key.offset: 3985,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Double",
     key.usr: "s:Sd",
-    key.offset: 3964,
+    key.offset: 3988,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3977,
+    key.offset: 4001,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3981,
+    key.offset: 4005,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 3984,
+    key.offset: 4008,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3995,
+    key.offset: 4019,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3999,
+    key.offset: 4023,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Double",
     key.usr: "s:Sd",
-    key.offset: 4002,
+    key.offset: 4026,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4012,
+    key.offset: 4036,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4022,
+    key.offset: 4046,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooStruct2",
     key.usr: "c:@S@FooStruct2",
-    key.offset: 4042,
+    key.offset: 4066,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4054,
+    key.offset: 4078,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4061,
+    key.offset: 4085,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4086,
+    key.offset: 4110,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4098,
+    key.offset: 4122,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 4103,
+    key.offset: 4127,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 4105,
+    key.offset: 4129,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 4108,
+    key.offset: 4132,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 4115,
+    key.offset: 4139,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 4117,
+    key.offset: 4141,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Double",
     key.usr: "s:Sd",
-    key.offset: 4120,
+    key.offset: 4144,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4133,
+    key.offset: 4157,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4137,
+    key.offset: 4161,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 4140,
+    key.offset: 4164,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4151,
+    key.offset: 4175,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4155,
+    key.offset: 4179,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Double",
     key.usr: "s:Sd",
-    key.offset: 4158,
+    key.offset: 4182,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4168,
+    key.offset: 4192,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4178,
+    key.offset: 4202,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 4192,
+    key.offset: 4216,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4199,
+    key.offset: 4223,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4203,
+    key.offset: 4227,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 4214,
+    key.offset: 4238,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4221,
+    key.offset: 4245,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4226,
+    key.offset: 4250,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 4235,
+    key.offset: 4259,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 4237,
+    key.offset: 4261,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 4240,
+    key.offset: 4264,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 4250,
+    key.offset: 4274,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4257,
+    key.offset: 4281,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4262,
+    key.offset: 4286,
     key.length: 22
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 4285,
+    key.offset: 4309,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 4287,
+    key.offset: 4311,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 4290,
+    key.offset: 4314,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 4300,
+    key.offset: 4324,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4307,
+    key.offset: 4331,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4312,
+    key.offset: 4336,
     key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 4321,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 4323,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "Int32",
-    key.usr: "s:s5Int32V",
-    key.offset: 4326,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 4333,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 4335,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "Float",
-    key.usr: "s:Sf",
-    key.offset: 4338,
-    key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
@@ -3001,757 +2972,774 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.name: "Double",
-    key.usr: "s:Sd",
+    key.name: "Int32",
+    key.usr: "s:s5Int32V",
     key.offset: 4350,
-    key.length: 6
+    key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 4358,
+    key.offset: 4357,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 4360,
+    key.offset: 4359,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "Float",
+    key.usr: "s:Sf",
+    key.offset: 4362,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 4369,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 4371,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "Double",
+    key.usr: "s:Sd",
+    key.offset: 4374,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 4382,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 4384,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UnsafeMutablePointer",
     key.usr: "s:Sp",
-    key.offset: 4363,
+    key.offset: 4387,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 4384,
+    key.offset: 4408,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 4396,
+    key.offset: 4420,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4403,
+    key.offset: 4427,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4408,
+    key.offset: 4432,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 4425,
+    key.offset: 4449,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 4427,
+    key.offset: 4451,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Float",
     key.usr: "s:Sf",
-    key.offset: 4434,
+    key.offset: 4458,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 4444,
+    key.offset: 4468,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4454,
+    key.offset: 4478,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4459,
+    key.offset: 4483,
     key.length: 26
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 4486,
+    key.offset: 4510,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 4488,
+    key.offset: 4512,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Float",
     key.usr: "s:Sf",
-    key.offset: 4496,
+    key.offset: 4520,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 4506,
+    key.offset: 4530,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4516,
+    key.offset: 4540,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4521,
+    key.offset: 4545,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.ref.enum,
     key.name: "Never",
     key.usr: "s:s5NeverO",
-    key.offset: 4543,
+    key.offset: 4567,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4550,
+    key.offset: 4574,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4555,
+    key.offset: 4579,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.ref.enum,
     key.name: "Never",
     key.usr: "s:s5NeverO",
-    key.offset: 4577,
+    key.offset: 4601,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4584,
+    key.offset: 4608,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4589,
+    key.offset: 4613,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4612,
+    key.offset: 4636,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4617,
+    key.offset: 4641,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4640,
+    key.offset: 4664,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4645,
+    key.offset: 4669,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4668,
+    key.offset: 4692,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4673,
+    key.offset: 4697,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4696,
+    key.offset: 4720,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4701,
+    key.offset: 4725,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4724,
+    key.offset: 4748,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4729,
+    key.offset: 4753,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 4762,
+    key.offset: 4786,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 4764,
+    key.offset: 4788,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 4767,
+    key.offset: 4791,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 4777,
+    key.offset: 4801,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4784,
+    key.offset: 4808,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4793,
+    key.offset: 4817,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4816,
+    key.offset: 4840,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4821,
+    key.offset: 4845,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4841,
+    key.offset: 4865,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4846,
+    key.offset: 4870,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4887,
+    key.offset: 4911,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4892,
+    key.offset: 4916,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4933,
+    key.offset: 4957,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4940,
+    key.offset: 4964,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4945,
+    key.offset: 4969,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4970,
+    key.offset: 4994,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4974,
+    key.offset: 4998,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 4988,
+    key.offset: 5012,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4996,
+    key.offset: 5020,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5000,
+    key.offset: 5024,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5011,
+    key.offset: 5035,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5015,
+    key.offset: 5039,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 5029,
+    key.offset: 5053,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5037,
+    key.offset: 5061,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5041,
+    key.offset: 5065,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5052,
+    key.offset: 5076,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5056,
+    key.offset: 5080,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 5070,
+    key.offset: 5094,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5078,
+    key.offset: 5102,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5087,
+    key.offset: 5111,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5096,
+    key.offset: 5120,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "FooProtocolBase",
     key.usr: "c:objc(pl)FooProtocolBase",
-    key.offset: 5117,
+    key.offset: 5141,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5138,
+    key.offset: 5162,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5144,
+    key.offset: 5168,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5164,
+    key.offset: 5188,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5169,
+    key.offset: 5193,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5197,
+    key.offset: 5221,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5202,
+    key.offset: 5226,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 5223,
+    key.offset: 5247,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 5225,
+    key.offset: 5249,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5235,
+    key.offset: 5259,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooClassBase",
     key.usr: "c:objc(cs)FooClassBase",
-    key.offset: 5244,
+    key.offset: 5268,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5263,
+    key.offset: 5287,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5276,
+    key.offset: 5300,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5288,
+    key.offset: 5312,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 5294,
+    key.offset: 5318,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 5300,
+    key.offset: 5324,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Float",
     key.usr: "s:Sf",
-    key.offset: 5303,
+    key.offset: 5327,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5315,
+    key.offset: 5339,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5320,
+    key.offset: 5344,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5357,
+    key.offset: 5381,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5363,
+    key.offset: 5387,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5368,
+    key.offset: 5392,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5393,
+    key.offset: 5417,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5398,
+    key.offset: 5422,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5418,
+    key.offset: 5442,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5428,
+    key.offset: 5452,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5433,
+    key.offset: 5457,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5453,
+    key.offset: 5477,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5463,
+    key.offset: 5487,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5468,
+    key.offset: 5492,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5489,
+    key.offset: 5513,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5499,
+    key.offset: 5523,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5504,
+    key.offset: 5528,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5524,
+    key.offset: 5548,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5532,
+    key.offset: 5556,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5538,
+    key.offset: 5562,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooClassBase",
     key.usr: "c:objc(cs)FooClassBase",
-    key.offset: 5556,
+    key.offset: 5580,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "FooProtocolDerived",
     key.usr: "c:objc(pl)FooProtocolDerived",
-    key.offset: 5570,
+    key.offset: 5594,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5596,
+    key.offset: 5620,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5600,
+    key.offset: 5624,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 5614,
+    key.offset: 5638,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5625,
+    key.offset: 5649,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5629,
+    key.offset: 5653,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 5643,
+    key.offset: 5667,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5654,
+    key.offset: 5678,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5658,
+    key.offset: 5682,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 5672,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5680,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5691,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 5696,
-    key.length: 16
+    key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5704,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5715,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 5720,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5725,
     key.length: 16
   },
   {
-    key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 5742,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 5744,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "Int32",
-    key.usr: "s:s5Int32V",
-    key.offset: 5747,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5759,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5764,
+    key.offset: 5749,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 5781,
+    key.offset: 5766,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 5783,
+    key.offset: 5768,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 5786,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 5793,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 5799,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "Int32",
-    key.usr: "s:s5Int32V",
-    key.offset: 5802,
+    key.offset: 5771,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5814,
+    key.offset: 5783,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5819,
+    key.offset: 5788,
+    key.length: 16
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 5805,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 5807,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "Int32",
+    key.usr: "s:s5Int32V",
+    key.offset: 5810,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 5817,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 5823,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "Int32",
+    key.usr: "s:s5Int32V",
+    key.offset: 5826,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5838,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5843,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5856,
+    key.offset: 5880,
     key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5862,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5867,
-    key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 5886,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5891,
+    key.length: 13
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5910,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5896,
+    key.offset: 5920,
     key.length: 13
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "Int32",
-    key.usr: "s:s5Int32V",
-    key.offset: 5912,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5919,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5923,
-    key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
@@ -3762,222 +3750,222 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5944,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5951,
+    key.offset: 5943,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5955,
+    key.offset: 5947,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
+    key.offset: 5960,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 5968,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5976,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5983,
+    key.offset: 5975,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5987,
+    key.offset: 5979,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 6000,
+    key.offset: 5992,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6008,
+    key.offset: 6000,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6015,
+    key.offset: 6007,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6019,
+    key.offset: 6011,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "Int32",
+    key.usr: "s:s5Int32V",
+    key.offset: 6024,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 6032,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 6039,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 6043,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UInt32",
     key.usr: "s:s6UInt32V",
-    key.offset: 6032,
+    key.offset: 6056,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6041,
+    key.offset: 6065,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6048,
+    key.offset: 6072,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6052,
+    key.offset: 6076,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UInt64",
     key.usr: "s:s6UInt64V",
-    key.offset: 6065,
+    key.offset: 6089,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6074,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6081,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6085,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.ref.typealias,
-    key.name: "typedef_int_t",
-    key.usr: "c:Foo.h@T@typedef_int_t",
     key.offset: 6098,
-    key.length: 13
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6114,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6121,
+    key.offset: 6105,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6125,
+    key.offset: 6109,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.typealias,
     key.name: "typedef_int_t",
     key.usr: "c:Foo.h@T@typedef_int_t",
-    key.offset: 6138,
+    key.offset: 6122,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6154,
+    key.offset: 6138,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6161,
+    key.offset: 6145,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6165,
+    key.offset: 6149,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.ref.typealias,
+    key.name: "typedef_int_t",
+    key.usr: "c:Foo.h@T@typedef_int_t",
+    key.offset: 6162,
+    key.length: 13
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 6178,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 6185,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 6189,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.typealias,
     key.name: "CChar",
     key.usr: "s:s5CChara",
-    key.offset: 6178,
+    key.offset: 6202,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6186,
+    key.offset: 6210,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6193,
+    key.offset: 6217,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6197,
+    key.offset: 6221,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 6210,
+    key.offset: 6234,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6218,
+    key.offset: 6242,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6225,
+    key.offset: 6249,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6229,
+    key.offset: 6253,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int16",
     key.usr: "s:s5Int16V",
-    key.offset: 6243,
+    key.offset: 6267,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6251,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6258,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6262,
-    key.length: 12
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "Int",
-    key.usr: "s:Si",
-    key.offset: 6276,
+    key.offset: 6275,
     key.length: 3
   },
   {
@@ -3986,430 +3974,432 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.length: 3
   },
   {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 6286,
+    key.length: 12
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "Int",
+    key.usr: "s:Si",
+    key.offset: 6300,
+    key.length: 3
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6289,
+    key.offset: 6306,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 6313,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6293,
+    key.offset: 6317,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 6307,
+    key.offset: 6331,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6315,
+    key.offset: 6339,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6322,
+    key.offset: 6346,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6326,
+    key.offset: 6350,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 6341,
+    key.offset: 6365,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6349,
+    key.offset: 6373,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6356,
+    key.offset: 6380,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6360,
+    key.offset: 6384,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UInt64",
     key.usr: "s:s6UInt64V",
-    key.offset: 6380,
+    key.offset: 6404,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6389,
+    key.offset: 6413,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6396,
+    key.offset: 6420,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6400,
+    key.offset: 6424,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UInt32",
     key.usr: "s:s6UInt32V",
-    key.offset: 6418,
+    key.offset: 6442,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6427,
+    key.offset: 6451,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6434,
+    key.offset: 6458,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6438,
+    key.offset: 6462,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 6457,
+    key.offset: 6481,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6465,
+    key.offset: 6489,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6472,
+    key.offset: 6496,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6476,
+    key.offset: 6500,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 6495,
+    key.offset: 6519,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6503,
+    key.offset: 6527,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6510,
+    key.offset: 6534,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6515,
+    key.offset: 6539,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6535,
+    key.offset: 6559,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6540,
+    key.offset: 6564,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6565,
+    key.offset: 6589,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6572,
+    key.offset: 6596,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6595,
+    key.offset: 6619,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6607,
+    key.offset: 6631,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 6612,
+    key.offset: 6636,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 6614,
+    key.offset: 6638,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 6617,
+    key.offset: 6641,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6629,
+    key.offset: 6653,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6633,
+    key.offset: 6657,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 6636,
+    key.offset: 6660,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6645,
+    key.offset: 6669,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooClassBase",
     key.usr: "c:objc(cs)FooClassBase",
-    key.offset: 6655,
+    key.offset: 6679,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6675,
+    key.offset: 6699,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6680,
+    key.offset: 6704,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6700,
+    key.offset: 6724,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6708,
+    key.offset: 6732,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooClassBase",
     key.usr: "c:objc(cs)FooClassBase",
-    key.offset: 6718,
+    key.offset: 6742,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6738,
+    key.offset: 6762,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6743,
+    key.offset: 6767,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6763,
+    key.offset: 6787,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6773,
+    key.offset: 6797,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6778,
+    key.offset: 6802,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6799,
+    key.offset: 6823,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6807,
+    key.offset: 6831,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooClassBase",
     key.usr: "c:objc(cs)FooClassBase",
-    key.offset: 6817,
+    key.offset: 6841,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6837,
+    key.offset: 6861,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6842,
+    key.offset: 6866,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6862,
+    key.offset: 6886,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6870,
+    key.offset: 6894,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6879,
+    key.offset: 6903,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6898,
+    key.offset: 6922,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6904,
+    key.offset: 6928,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "_InternalProt",
     key.usr: "c:objc(pl)_InternalProt",
-    key.offset: 6928,
+    key.offset: 6952,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6947,
+    key.offset: 6971,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6953,
+    key.offset: 6977,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooClassBase",
     key.usr: "c:objc(cs)FooClassBase",
-    key.offset: 6981,
+    key.offset: 7005,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 7001,
+    key.offset: 7025,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7017,
+    key.offset: 7041,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7021,
+    key.offset: 7045,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 7033,
+    key.offset: 7057,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 7049,
+    key.offset: 7073,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7065,
+    key.offset: 7089,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7069,
+    key.offset: 7093,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 7087,
+    key.offset: 7111,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7103,
+    key.offset: 7127,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7107,
+    key.offset: 7131,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7119,
+    key.offset: 7143,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7129,
+    key.offset: 7153,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7133,
+    key.offset: 7157,
     key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7144,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7154,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7158,
-    key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
@@ -4417,105 +4407,110 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 7178,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 7182,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 7192,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 7202,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7183,
+    key.offset: 7207,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7187,
+    key.offset: 7211,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 7196,
+    key.offset: 7220,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7212,
+    key.offset: 7236,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7216,
+    key.offset: 7240,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 7224,
+    key.offset: 7248,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7233,
+    key.offset: 7257,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7237,
+    key.offset: 7261,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7250,
+    key.offset: 7274,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7256,
+    key.offset: 7280,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooClassBase",
     key.usr: "c:objc(cs)FooClassBase",
-    key.offset: 7280,
+    key.offset: 7304,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 7300,
+    key.offset: 7324,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7312,
+    key.offset: 7336,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 7318,
+    key.offset: 7342,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 7322,
+    key.offset: 7346,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 7325,
+    key.offset: 7349,
     key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7337,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7342,
-    key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
@@ -4525,632 +4520,642 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 7366,
-    key.length: 16
+    key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7390,
+    key.offset: 7385,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7395,
+    key.offset: 7390,
+    key.length: 16
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 7414,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 7419,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7413,
+    key.offset: 7437,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7418,
+    key.offset: 7442,
     key.length: 22
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7448,
+    key.offset: 7472,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7453,
+    key.offset: 7477,
     key.length: 22
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7483,
+    key.offset: 7507,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7488,
+    key.offset: 7512,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7517,
+    key.offset: 7541,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7522,
+    key.offset: 7546,
     key.length: 23
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7553,
+    key.offset: 7577,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7558,
+    key.offset: 7582,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7591,
+    key.offset: 7615,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7596,
+    key.offset: 7620,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7629,
+    key.offset: 7653,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7634,
+    key.offset: 7658,
     key.length: 24
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7666,
+    key.offset: 7690,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7671,
+    key.offset: 7695,
     key.length: 26
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7703,
+    key.offset: 7727,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7709,
+    key.offset: 7733,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7724,
+    key.offset: 7748,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7729,
+    key.offset: 7753,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 7746,
+    key.offset: 7770,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 7748,
+    key.offset: 7772,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooCFType",
     key.usr: "c:Foo.h@T@FooCFTypeRef",
-    key.offset: 7751,
+    key.offset: 7775,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7764,
+    key.offset: 7788,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7769,
+    key.offset: 7793,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 7793,
+    key.offset: 7817,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7804,
+    key.offset: 7828,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7809,
+    key.offset: 7833,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 7825,
+    key.offset: 7849,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7832,
+    key.offset: 7856,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7837,
+    key.offset: 7861,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 7850,
+    key.offset: 7874,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 7857,
+    key.offset: 7881,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7868,
+    key.offset: 7892,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7872,
+    key.offset: 7896,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 7883,
+    key.offset: 7907,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7889,
+    key.offset: 7913,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 7900,
+    key.offset: 7924,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7911,
+    key.offset: 7935,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7916,
+    key.offset: 7940,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 7921,
+    key.offset: 7945,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 7926,
+    key.offset: 7950,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7934,
+    key.offset: 7958,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Hasher",
     key.usr: "s:s6HasherV",
-    key.offset: 7940,
+    key.offset: 7964,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7953,
+    key.offset: 7977,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7960,
+    key.offset: 7984,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.operator,
-    key.offset: 7965,
+    key.offset: 7989,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 7969,
+    key.offset: 7993,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 7971,
+    key.offset: 7995,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7976,
+    key.offset: 8000,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.enum,
     key.name: "ABAuthorizationStatus",
     key.usr: "c:@E@ABAuthorizationStatus",
-    key.offset: 7986,
+    key.offset: 8010,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 8009,
+    key.offset: 8033,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 8011,
+    key.offset: 8035,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8016,
+    key.offset: 8040,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.enum,
     key.name: "ABAuthorizationStatus",
     key.usr: "c:@E@ABAuthorizationStatus",
-    key.offset: 8026,
+    key.offset: 8050,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 8052,
+    key.offset: 8076,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8060,
+    key.offset: 8084,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 8065,
+    key.offset: 8089,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 8077,
+    key.offset: 8101,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 8079,
+    key.offset: 8103,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 8082,
+    key.offset: 8106,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 8092,
+    key.offset: 8116,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8099,
+    key.offset: 8123,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 8106,
+    key.offset: 8130,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Hashable",
     key.usr: "s:SH",
-    key.offset: 8120,
+    key.offset: 8144,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Equatable",
     key.usr: "s:SQ",
-    key.offset: 8130,
+    key.offset: 8154,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "RawRepresentable",
     key.usr: "s:SY",
-    key.offset: 8141,
+    key.offset: 8165,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8165,
+    key.offset: 8189,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 8170,
+    key.offset: 8194,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 8172,
+    key.offset: 8196,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UInt32",
     key.usr: "s:s6UInt32V",
-    key.offset: 8182,
+    key.offset: 8206,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8195,
+    key.offset: 8219,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 8200,
+    key.offset: 8224,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 8209,
+    key.offset: 8233,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UInt32",
     key.usr: "s:s6UInt32V",
-    key.offset: 8219,
+    key.offset: 8243,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8232,
+    key.offset: 8256,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 8236,
+    key.offset: 8260,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UInt32",
     key.usr: "s:s6UInt32V",
-    key.offset: 8246,
+    key.offset: 8270,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 8258,
+    key.offset: 8282,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8269,
+    key.offset: 8293,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 8273,
+    key.offset: 8297,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 8284,
+    key.offset: 8308,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8290,
+    key.offset: 8314,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 8301,
+    key.offset: 8325,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8312,
+    key.offset: 8336,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 8317,
+    key.offset: 8341,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 8322,
+    key.offset: 8346,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 8327,
+    key.offset: 8351,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8335,
+    key.offset: 8359,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Hasher",
     key.usr: "s:s6HasherV",
-    key.offset: 8341,
+    key.offset: 8365,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8354,
+    key.offset: 8378,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8361,
+    key.offset: 8385,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.operator,
-    key.offset: 8366,
+    key.offset: 8390,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 8370,
+    key.offset: 8394,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 8372,
+    key.offset: 8396,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8377,
+    key.offset: 8401,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooSubEnum1",
     key.usr: "c:@E@FooSubEnum1",
-    key.offset: 8387,
+    key.offset: 8411,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 8400,
+    key.offset: 8424,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 8402,
+    key.offset: 8426,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8407,
+    key.offset: 8431,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooSubEnum1",
     key.usr: "c:@E@FooSubEnum1",
-    key.offset: 8417,
+    key.offset: 8441,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 8433,
+    key.offset: 8457,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8441,
+    key.offset: 8465,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 8445,
+    key.offset: 8469,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooSubEnum1",
     key.usr: "c:@E@FooSubEnum1",
-    key.offset: 8459,
+    key.offset: 8483,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8473,
+    key.offset: 8497,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8480,
+    key.offset: 8504,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 8484,
+    key.offset: 8508,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooSubEnum1",
     key.usr: "c:@E@FooSubEnum1",
-    key.offset: 8498,
+    key.offset: 8522,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8512,
+    key.offset: 8536,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8519,
+    key.offset: 8543,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 8523,
+    key.offset: 8547,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 8550,
+    key.offset: 8574,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8556,
+    key.offset: 8580,
     key.length: 3
   }
 ]
@@ -5664,7 +5669,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.usr: "c:@E@FooRuncingOptions",
     key.doc.full_as_xml: "<Enum line=\"1\" column=\"1\"><Name>FooRuncingOptions</Name><USR>c:@E@FooRuncingOptions</USR><Declaration>struct FooRuncingOptions : OptionSet</Declaration><Abstract><Para> Aaa.  FooRuncingOptions.  Bbb.</Para></Abstract></Enum>",
     key.offset: 1527,
-    key.length: 495,
+    key.length: 519,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>FooRuncingOptions</decl.name> : <ref.protocol usr=\"s:s9OptionSetP\">OptionSet</ref.protocol></decl.struct>",
     key.conforms: [
       {
@@ -5739,14 +5744,14 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s9OptionSetPs7ElementQzRszs17FixedWidthInteger8RawValueRpzrlE6insertySb8inserted_x17memberAfterInserttxF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s9OptionSetPs7ElementQzRszs17FixedWidthInteger8RawValueRpzrlE6insertySb8inserted_x17memberAfterInserttxF",
         key.offset: 1817,
-        key.length: 133,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.attribute.builtin><syntaxtype.attribute.name>@_alwaysEmitIntoClient</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>mutating</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>insert</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>newMember</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><tuple>(<tuple.element><tuple.element.argument_label>inserted</tuple.element.argument_label>: <tuple.element.type><ref.struct usr=\"s:Sb\">Bool</ref.struct></tuple.element.type></tuple.element>, <tuple.element><tuple.element.argument_label>memberAfterInsert</tuple.element.argument_label>: <tuple.element.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></tuple.element.type></tuple.element>)</tuple></decl.function.returntype></decl.function.method.instance>",
+        key.length: 157,
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.attribute.builtin><syntaxtype.attribute.name>@export(implementation)</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>mutating</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>insert</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>newMember</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><tuple>(<tuple.element><tuple.element.argument_label>inserted</tuple.element.argument_label>: <tuple.element.type><ref.struct usr=\"s:Sb\">Bool</ref.struct></tuple.element.type></tuple.element>, <tuple.element><tuple.element.argument_label>memberAfterInsert</tuple.element.argument_label>: <tuple.element.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></tuple.element.type></tuple.element>)</tuple></decl.function.returntype></decl.function.method.instance>",
         key.entities: [
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "newMember",
-            key.offset: 1874,
+            key.offset: 1898,
             key.length: 17
           }
         ]
@@ -5757,7 +5762,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s10SetAlgebraPs7ElementQz012ArrayLiteralC0RtzrlE05arrayE0xAFd_tcfc::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s10SetAlgebraPs7ElementQz012ArrayLiteralC0RtzrlE05arrayE0xAFd_tcfc",
         key.doc.full_as_xml: "<Function><Name>init(arrayLiteral:)</Name><USR>s:s10SetAlgebraPs7ElementQz012ArrayLiteralC0RtzrlE05arrayE0xAFd_tcfc::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable init(arrayLiteral: FooRuncingOptions...)</Declaration><CommentParts><Abstract><Para>Creates a set containing the elements of the given array literal.</Para></Abstract><Parameters><Parameter><Name>arrayLiteral</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A list of elements of the new set.</Para></Discussion></Parameter></Parameters><Discussion><Para>Do not call this initializer directly. It is used by the compiler when you use an array literal. Instead, create a new set using an array literal as its value by enclosing a comma-separated list of values in square brackets. You can use an array literal anywhere a set is expected by the type context.</Para><Para>Here, a set of strings is created from an array literal holding only strings:</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let ingredients: Set = [\"cocoa beans\", \"sugar\", \"cocoa butter\", \"salt\"]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[if ingredients.isSuperset(of: [\"sugar\", \"salt\"]) {]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[    print(\"Whatever it is, it's bound to be delicious!\")]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"Whatever it is, it's bound to be delicious!\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></CommentParts></Function>",
-        key.offset: 1956,
+        key.offset: 1980,
         key.length: 64,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>arrayLiteral</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct>...</decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -5765,7 +5770,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "arrayLiteral",
             key.name: "arrayLiteral",
-            key.offset: 1999,
+            key.offset: 2023,
             key.length: 20
           }
         ]
@@ -5775,7 +5780,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   {
     key.kind: source.lang.swift.decl.extension.struct,
     key.doc.full_as_xml: "<Other><Name></Name><Declaration>extension FooRuncingOptions</Declaration><CommentParts><Abstract><Para><codeVoice>OptionSet</codeVoice> requirements for which default implementations are supplied.</Para></Abstract><Discussion><Note><Para>A type conforming to <codeVoice>OptionSet</codeVoice> can implement any of these initializers or methods, and those implementations will be used in lieu of these defaults.</Para></Note></Discussion></CommentParts></Other>",
-    key.offset: 2024,
+    key.offset: 2048,
     key.length: 280,
     key.fully_annotated_decl: "<syntaxtype.keyword>extension</syntaxtype.keyword> <ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct>",
     key.extends: {
@@ -5790,7 +5795,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s9OptionSetPsE5unionyxxF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s9OptionSetPsE5unionyxxF",
         key.doc.full_as_xml: "<Function><Name>union(_:)</Name><USR>s:s9OptionSetPsE5unionyxxF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable func union(_ other: FooRuncingOptions) -&gt; FooRuncingOptions</Declaration><CommentParts><Abstract><Para>Returns a new option set of the elements contained in this set, in the given set, or in both.</Para></Abstract><Parameters><Parameter><Name>other</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>An option set.</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para>A new option set made up of the elements contained in this set, in <codeVoice>other</codeVoice>, or in both.</Para></ResultDiscussion><Discussion><Para>This example uses the <codeVoice>union(_:)</codeVoice> method to add two more shipping options to the default set.</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let defaultShipping = ShippingOptions.standard]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[let memberShipping = defaultShipping.union([.secondDay, .priority])]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(memberShipping.contains(.priority))]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"true\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></CommentParts></Function>",
-        key.offset: 2059,
+        key.offset: 2083,
         key.length: 70,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>union</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>other</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.function.returntype></decl.function.method.instance>",
         key.entities: [
@@ -5798,7 +5803,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "other",
-            key.offset: 2090,
+            key.offset: 2114,
             key.length: 17
           }
         ]
@@ -5809,7 +5814,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s9OptionSetPsE12intersectionyxxF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s9OptionSetPsE12intersectionyxxF",
         key.doc.full_as_xml: "<Function><Name>intersection(_:)</Name><USR>s:s9OptionSetPsE12intersectionyxxF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable func intersection(_ other: FooRuncingOptions) -&gt; FooRuncingOptions</Declaration><CommentParts><Abstract><Para>Returns a new option set with only the elements contained in both this set and the given set.</Para></Abstract><Parameters><Parameter><Name>other</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>An option set.</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para>A new option set with only the elements contained in both this set and <codeVoice>other</codeVoice>.</Para></ResultDiscussion><Discussion><Para>This example uses the <codeVoice>intersection(_:)</codeVoice> method to limit the available shipping options to what can be used with a PO Box destination.</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[// Can only ship standard or priority to PO Boxes]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[let poboxShipping: ShippingOptions = [.standard, .priority]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[let memberShipping: ShippingOptions =]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[        [.standard, .priority, .secondDay]]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered><zCodeLineNumbered><![CDATA[let availableOptions = memberShipping.intersection(poboxShipping)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(availableOptions.contains(.priority))]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"true\"]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(availableOptions.contains(.secondDay))]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"false\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></CommentParts></Function>",
-        key.offset: 2135,
+        key.offset: 2159,
         key.length: 77,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>intersection</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>other</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.function.returntype></decl.function.method.instance>",
         key.entities: [
@@ -5817,7 +5822,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "other",
-            key.offset: 2173,
+            key.offset: 2197,
             key.length: 17
           }
         ]
@@ -5828,7 +5833,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s9OptionSetPsE19symmetricDifferenceyxxF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s9OptionSetPsE19symmetricDifferenceyxxF",
         key.doc.full_as_xml: "<Function><Name>symmetricDifference(_:)</Name><USR>s:s9OptionSetPsE19symmetricDifferenceyxxF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable func symmetricDifference(_ other: FooRuncingOptions) -&gt; FooRuncingOptions</Declaration><CommentParts><Abstract><Para>Returns a new option set with the elements contained in this set or in the given set, but not in both.</Para></Abstract><Parameters><Parameter><Name>other</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>An option set.</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para>A new option set with only the elements contained in either this set or <codeVoice>other</codeVoice>, but not in both.</Para></ResultDiscussion></CommentParts></Function>",
-        key.offset: 2218,
+        key.offset: 2242,
         key.length: 84,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>symmetricDifference</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>other</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.function.returntype></decl.function.method.instance>",
         key.entities: [
@@ -5836,7 +5841,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "other",
-            key.offset: 2263,
+            key.offset: 2287,
             key.length: 17
           }
         ]
@@ -5846,7 +5851,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   {
     key.kind: source.lang.swift.decl.extension.struct,
     key.doc.full_as_xml: "<Other><Name></Name><Declaration>extension FooRuncingOptions</Declaration><CommentParts><Abstract><Para><codeVoice>OptionSet</codeVoice> requirements for which default implementations are supplied when <codeVoice>Element == Self</codeVoice>, which is the default.</Para></Abstract><Discussion><Note><Para>A type conforming to <codeVoice>OptionSet</codeVoice> can implement any of these initializers or methods, and those implementations will be used in lieu of these defaults.</Para></Note></Discussion></CommentParts></Other>",
-    key.offset: 2306,
+    key.offset: 2330,
     key.length: 476,
     key.fully_annotated_decl: "<syntaxtype.keyword>extension</syntaxtype.keyword> <ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct>",
     key.extends: {
@@ -5861,7 +5866,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s9OptionSetPs7ElementQzRszrlE8containsySbxF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s9OptionSetPs7ElementQzRszrlE8containsySbxF",
         key.doc.full_as_xml: "<Function><Name>contains(_:)</Name><USR>s:s9OptionSetPs7ElementQzRszrlE8containsySbxF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable func contains(_ member: FooRuncingOptions) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value that indicates whether a given element is a member of the option set.</Para></Abstract><Parameters><Parameter><Name>member</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>The element to look for in the option set.</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para><codeVoice>true</codeVoice> if the option set contains <codeVoice>member</codeVoice>; otherwise, <codeVoice>false</codeVoice>.</Para></ResultDiscussion><Discussion><Para>This example uses the <codeVoice>contains(_:)</codeVoice> method to check whether next-day shipping is in the <codeVoice>availableOptions</codeVoice> instance.</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let availableOptions = ShippingOptions.express]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[if availableOptions.contains(.nextDay) {]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[    print(\"Next day shipping available\")]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"Next day shipping available\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></CommentParts></Function>",
-        key.offset: 2341,
+        key.offset: 2365,
         key.length: 61,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>contains</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>member</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.method.instance>",
         key.entities: [
@@ -5869,7 +5874,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "member",
-            key.offset: 2376,
+            key.offset: 2400,
             key.length: 17
           }
         ]
@@ -5880,7 +5885,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s9OptionSetPs7ElementQzRszrlE6insertySb8inserted_x17memberAfterInserttxF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s9OptionSetPs7ElementQzRszrlE6insertySb8inserted_x17memberAfterInserttxF",
         key.doc.full_as_xml: "<Function><Name>insert(_:)</Name><USR>s:s9OptionSetPs7ElementQzRszrlE6insertySb8inserted_x17memberAfterInserttxF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@discardableResult\n@inlinable mutating func insert(_ newMember: FooRuncingOptions) -&gt; (inserted: Bool, memberAfterInsert: FooRuncingOptions)</Declaration><CommentParts><Abstract><Para>Adds the given element to the option set if it is not already a member.</Para></Abstract><Parameters><Parameter><Name>newMember</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>The element to insert.</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para><codeVoice>(true, newMember)</codeVoice> if <codeVoice>newMember</codeVoice> was not contained in <codeVoice>self</codeVoice>. Otherwise, returns <codeVoice>(false, oldMember)</codeVoice>, where <codeVoice>oldMember</codeVoice> is the member of the set equal to <codeVoice>newMember</codeVoice>.</Para></ResultDiscussion><Discussion><Para>In the following example, the <codeVoice>.secondDay</codeVoice> shipping option is added to the <codeVoice>freeOptions</codeVoice> option set if <codeVoice>purchasePrice</codeVoice> is greater than 50.0. For the <codeVoice>ShippingOptions</codeVoice> declaration, see the <codeVoice>OptionSet</codeVoice> protocol discussion.</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let purchasePrice = 87.55]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered><zCodeLineNumbered><![CDATA[var freeOptions: ShippingOptions = [.standard, .priority]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[if purchasePrice > 50 {]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[    freeOptions.insert(.secondDay)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(freeOptions.contains(.secondDay))]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"true\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></CommentParts></Function>",
-        key.offset: 2408,
+        key.offset: 2432,
         key.length: 144,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>mutating</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>insert</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>newMember</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><tuple>(<tuple.element><tuple.element.argument_label>inserted</tuple.element.argument_label>: <tuple.element.type><ref.struct usr=\"s:Sb\">Bool</ref.struct></tuple.element.type></tuple.element>, <tuple.element><tuple.element.argument_label>memberAfterInsert</tuple.element.argument_label>: <tuple.element.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></tuple.element.type></tuple.element>)</tuple></decl.function.returntype></decl.function.method.instance>",
         key.entities: [
@@ -5888,7 +5893,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "newMember",
-            key.offset: 2476,
+            key.offset: 2500,
             key.length: 17
           }
         ]
@@ -5899,7 +5904,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s9OptionSetPs7ElementQzRszrlE6removeyxSgxF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s9OptionSetPs7ElementQzRszrlE6removeyxSgxF",
         key.doc.full_as_xml: "<Function><Name>remove(_:)</Name><USR>s:s9OptionSetPs7ElementQzRszrlE6removeyxSgxF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@discardableResult\n@inlinable mutating func remove(_ member: FooRuncingOptions) -&gt; FooRuncingOptions?</Declaration><CommentParts><Abstract><Para>Removes the given element and all elements subsumed by it.</Para></Abstract><Parameters><Parameter><Name>member</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>The element of the set to remove.</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para>The intersection of <codeVoice>[member]</codeVoice> and the set, if the intersection was nonempty; otherwise, <codeVoice>nil</codeVoice>.</Para></ResultDiscussion><Discussion><Para>In the following example, the <codeVoice>.priority</codeVoice> shipping option is removed from the <codeVoice>options</codeVoice> option set. Attempting to remove the same shipping option a second time results in <codeVoice>nil</codeVoice>, because <codeVoice>options</codeVoice> no longer contains <codeVoice>.priority</codeVoice> as a member.</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[var options: ShippingOptions = [.secondDay, .priority]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[let priorityOption = options.remove(.priority)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(priorityOption == .priority)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"true\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(options.remove(.priority))]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"nil\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing><Para>In the next example, the <codeVoice>.express</codeVoice> element is passed to <codeVoice>remove(_:)</codeVoice>. Although <codeVoice>.express</codeVoice> is not a member of <codeVoice>options</codeVoice>, <codeVoice>.express</codeVoice> subsumes the remaining <codeVoice>.secondDay</codeVoice> element of the option set. Therefore, <codeVoice>options</codeVoice> is emptied and the intersection between <codeVoice>.express</codeVoice> and <codeVoice>options</codeVoice> is returned.</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let expressOption = options.remove(.express)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(expressOption == .express)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"false\"]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(expressOption == .secondDay)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"true\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></CommentParts></Function>",
-        key.offset: 2558,
+        key.offset: 2582,
         key.length: 105,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>mutating</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>remove</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>member</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct>?</decl.function.returntype></decl.function.method.instance>",
         key.entities: [
@@ -5907,7 +5912,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "member",
-            key.offset: 2623,
+            key.offset: 2647,
             key.length: 17
           }
         ]
@@ -5918,7 +5923,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s9OptionSetPs7ElementQzRszrlE6update4withxSgx_tF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s9OptionSetPs7ElementQzRszrlE6update4withxSgx_tF",
         key.doc.full_as_xml: "<Function><Name>update(with:)</Name><USR>s:s9OptionSetPs7ElementQzRszrlE6update4withxSgx_tF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@discardableResult\n@inlinable mutating func update(with newMember: FooRuncingOptions) -&gt; FooRuncingOptions?</Declaration><CommentParts><Abstract><Para>Inserts the given element into the set.</Para></Abstract><ResultDiscussion><Para>The intersection of <codeVoice>[newMember]</codeVoice> and the set if the intersection was nonempty; otherwise, <codeVoice>nil</codeVoice>.</Para></ResultDiscussion><Discussion><Para>If <codeVoice>newMember</codeVoice> is not contained in the set but subsumes current members of the set, the subsumed members are returned.</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[var options: ShippingOptions = [.secondDay, .priority]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[let replaced = options.update(with: .express)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(replaced == .secondDay)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"true\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></CommentParts></Function>",
-        key.offset: 2669,
+        key.offset: 2693,
         key.length: 111,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>mutating</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>update</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>with</decl.var.parameter.argument_label> <decl.var.parameter.name>newMember</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct>?</decl.function.returntype></decl.function.method.instance>",
         key.entities: [
@@ -5926,7 +5931,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "with",
             key.name: "newMember",
-            key.offset: 2740,
+            key.offset: 2764,
             key.length: 17
           }
         ]
@@ -5936,7 +5941,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   {
     key.kind: source.lang.swift.decl.extension.struct,
     key.doc.full_as_xml: "<Other><Name></Name><Declaration>extension FooRuncingOptions</Declaration><CommentParts><Abstract><Para><codeVoice>OptionSet</codeVoice> requirements for which default implementations are supplied when <codeVoice>RawValue</codeVoice> conforms to <codeVoice>FixedWidthInteger</codeVoice>, which is the usual case.  Each distinct bit of an option set’s <codeVoice>.rawValue</codeVoice> corresponds to a disjoint value of the <codeVoice>OptionSet</codeVoice>.</Para></Abstract><Discussion><Note><Para>A type conforming to <codeVoice>OptionSet</codeVoice> can implement any of these initializers or methods, and those implementations will be used in lieu of these defaults.</Para></Note><List-Bullet><Item><Para><codeVoice>union</codeVoice> is implemented as a bitwise “or” (<codeVoice>|</codeVoice>) of <codeVoice>rawValue</codeVoice>s</Para></Item><Item><Para><codeVoice>intersection</codeVoice> is implemented as a bitwise “and” (<codeVoice>&amp;</codeVoice>) of <codeVoice>rawValue</codeVoice>s</Para></Item><Item><Para><codeVoice>symmetricDifference</codeVoice> is implemented as a bitwise “exclusive or” (<codeVoice>^</codeVoice>) of <codeVoice>rawValue</codeVoice>s</Para></Item></List-Bullet></Discussion></CommentParts></Other>",
-    key.offset: 2784,
+    key.offset: 2808,
     key.length: 279,
     key.fully_annotated_decl: "<syntaxtype.keyword>extension</syntaxtype.keyword> <ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct>",
     key.extends: {
@@ -5951,7 +5956,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s9OptionSetPss17FixedWidthInteger8RawValueRpzrlExycfc::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s9OptionSetPss17FixedWidthInteger8RawValueRpzrlExycfc",
         key.doc.full_as_xml: "<Function><Name>init()</Name><USR>s:s9OptionSetPss17FixedWidthInteger8RawValueRpzrlExycfc::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable init()</Declaration><CommentParts><Abstract><Para>Creates an empty option set.</Para></Abstract><Discussion><Para>This initializer creates an option set with a raw value of zero.</Para></Discussion></CommentParts></Function>",
-        key.offset: 2819,
+        key.offset: 2843,
         key.length: 17,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>init</syntaxtype.keyword>()</decl.function.constructor>"
       },
@@ -5961,7 +5966,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s9OptionSetPss17FixedWidthInteger8RawValueRpzrlE9formUnionyyxF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s9OptionSetPss17FixedWidthInteger8RawValueRpzrlE9formUnionyyxF",
         key.doc.full_as_xml: "<Function><Name>formUnion(_:)</Name><USR>s:s9OptionSetPss17FixedWidthInteger8RawValueRpzrlE9formUnionyyxF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable mutating func formUnion(_ other: FooRuncingOptions)</Declaration><CommentParts><Abstract><Para>Inserts the elements of another set into this option set.</Para></Abstract><Parameters><Parameter><Name>other</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>An option set.</Para></Discussion></Parameter></Parameters><Discussion><Para>This method is implemented as a <codeVoice>|</codeVoice> (bitwise OR) operation on the two sets’ raw values.</Para></Discussion></CommentParts></Function>",
-        key.offset: 2842,
+        key.offset: 2866,
         key.length: 62,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>mutating</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>formUnion</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>other</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -5969,7 +5974,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "other",
-            key.offset: 2886,
+            key.offset: 2910,
             key.length: 17
           }
         ]
@@ -5980,7 +5985,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s9OptionSetPss17FixedWidthInteger8RawValueRpzrlE16formIntersectionyyxF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s9OptionSetPss17FixedWidthInteger8RawValueRpzrlE16formIntersectionyyxF",
         key.doc.full_as_xml: "<Function><Name>formIntersection(_:)</Name><USR>s:s9OptionSetPss17FixedWidthInteger8RawValueRpzrlE16formIntersectionyyxF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable mutating func formIntersection(_ other: FooRuncingOptions)</Declaration><CommentParts><Abstract><Para>Removes all elements of this option set that are not also present in the given set.</Para></Abstract><Parameters><Parameter><Name>other</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>An option set.</Para></Discussion></Parameter></Parameters><Discussion><Para>This method is implemented as a <codeVoice>&amp;</codeVoice> (bitwise AND) operation on the two sets’ raw values.</Para></Discussion></CommentParts></Function>",
-        key.offset: 2910,
+        key.offset: 2934,
         key.length: 69,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>mutating</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>formIntersection</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>other</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -5988,7 +5993,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "other",
-            key.offset: 2961,
+            key.offset: 2985,
             key.length: 17
           }
         ]
@@ -5999,7 +6004,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s9OptionSetPss17FixedWidthInteger8RawValueRpzrlE23formSymmetricDifferenceyyxF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s9OptionSetPss17FixedWidthInteger8RawValueRpzrlE23formSymmetricDifferenceyyxF",
         key.doc.full_as_xml: "<Function><Name>formSymmetricDifference(_:)</Name><USR>s:s9OptionSetPss17FixedWidthInteger8RawValueRpzrlE23formSymmetricDifferenceyyxF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable mutating func formSymmetricDifference(_ other: FooRuncingOptions)</Declaration><CommentParts><Abstract><Para>Replaces this set with a new set containing all elements contained in either this set or the given set, but not in both.</Para></Abstract><Parameters><Parameter><Name>other</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>An option set.</Para></Discussion></Parameter></Parameters><Discussion><Para>This method is implemented as a <codeVoice>^</codeVoice> (bitwise XOR) operation on the two sets’ raw values.</Para></Discussion></CommentParts></Function>",
-        key.offset: 2985,
+        key.offset: 3009,
         key.length: 76,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>mutating</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>formSymmetricDifference</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>other</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -6007,7 +6012,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "other",
-            key.offset: 3043,
+            key.offset: 3067,
             key.length: 17
           }
         ]
@@ -6017,7 +6022,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   {
     key.kind: source.lang.swift.decl.extension.struct,
     key.doc.full_as_xml: "<Other><Name></Name><Declaration>extension FooRuncingOptions</Declaration><CommentParts><Abstract><Para><codeVoice>SetAlgebra</codeVoice> requirements for which default implementations are supplied.</Para></Abstract><Discussion><Note><Para>A type conforming to <codeVoice>SetAlgebra</codeVoice> can implement any of these initializers or methods, and those implementations will be used in lieu of these defaults.</Para></Note></Discussion></CommentParts></Other>",
-    key.offset: 3065,
+    key.offset: 3089,
     key.length: 667,
     key.fully_annotated_decl: "<syntaxtype.keyword>extension</syntaxtype.keyword> <ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct>",
     key.extends: {
@@ -6045,7 +6050,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
           }
         ],
         key.doc.full_as_xml: "<Function><Name>init(_:)</Name><USR>s:s10SetAlgebraPsEyxqd__ncSTRd__7ElementQyd__ACRtzlufc::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable init&lt;S&gt;(_ sequence: S) where S : Sequence, FooRuncingOptions == S.Element</Declaration><CommentParts><Abstract><Para>Creates a new set from a finite sequence of items.</Para></Abstract><Parameters><Parameter><Name>sequence</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>The elements to use as members of the new set.</Para></Discussion></Parameter></Parameters><Discussion><Para>Use this initializer to create a new set from an existing sequence, like an array or a range:</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let validIndices = Set(0..<7).subtracting([2, 4, 5])]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(validIndices)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"[6, 0, 1, 3]\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></CommentParts></Function>",
-        key.offset: 3100,
+        key.offset: 3124,
         key.length: 84,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>init</syntaxtype.keyword>&lt;<ref.generic_type_param usr=\"s:s10SetAlgebraPsEyxqd__ncSTRd__7ElementQyd__ACRtzlufc1SL_qd__mfp\">S</ref.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>sequence</decl.var.parameter.name>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:s10SetAlgebraPsEyxqd__ncSTRd__7ElementQyd__ACRtzlufc1SL_qd__mfp\">S</ref.generic_type_param></decl.var.parameter.type></decl.var.parameter>) <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:s10SetAlgebraPsEyxqd__ncSTRd__7ElementQyd__ACRtzlufc1SL_qd__mfp\">S</ref.generic_type_param> : <ref.protocol usr=\"s:ST\">Sequence</ref.protocol></decl.generic_type_requirement>, <decl.generic_type_requirement><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct> == <ref.generic_type_param usr=\"s:s10SetAlgebraPsEyxqd__ncSTRd__7ElementQyd__ACRtzlufc1SL_qd__mfp\">S</ref.generic_type_param>.<ref.associatedtype usr=\"s:ST7ElementQa\">Element</ref.associatedtype></decl.generic_type_requirement></decl.function.constructor>",
         key.entities: [
@@ -6053,7 +6058,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "sequence",
-            key.offset: 3131,
+            key.offset: 3155,
             key.length: 1
           }
         ]
@@ -6064,7 +6069,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s10SetAlgebraPsE8subtractyyxF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s10SetAlgebraPsE8subtractyyxF",
         key.doc.full_as_xml: "<Function><Name>subtract(_:)</Name><USR>s:s10SetAlgebraPsE8subtractyyxF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable mutating func subtract(_ other: FooRuncingOptions)</Declaration><CommentParts><Abstract><Para>Removes the elements of the given set from this set.</Para></Abstract><Parameters><Parameter><Name>other</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A set of the same type as the current set.</Para></Discussion></Parameter></Parameters><Discussion><Para>In the following example, the elements of the <codeVoice>employees</codeVoice> set that are also members of the <codeVoice>neighbors</codeVoice> set are removed. In particular, the names <codeVoice>&quot;Bethany&quot;</codeVoice> and <codeVoice>&quot;Eric&quot;</codeVoice> are removed from <codeVoice>employees</codeVoice>.</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[var employees: Set = [\"Alicia\", \"Bethany\", \"Chris\", \"Diana\", \"Eric\"]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[let neighbors: Set = [\"Bethany\", \"Eric\", \"Forlani\", \"Greta\"]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[employees.subtract(neighbors)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(employees)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"[\"Diana\", \"Chris\", \"Alicia\"]\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></CommentParts></Function>",
-        key.offset: 3190,
+        key.offset: 3214,
         key.length: 61,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>mutating</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>subtract</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>other</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -6072,7 +6077,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "other",
-            key.offset: 3233,
+            key.offset: 3257,
             key.length: 17
           }
         ]
@@ -6083,7 +6088,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s10SetAlgebraPsE8isSubset2ofSbx_tF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s10SetAlgebraPsE8isSubset2ofSbx_tF",
         key.doc.full_as_xml: "<Function><Name>isSubset(of:)</Name><USR>s:s10SetAlgebraPsE8isSubset2ofSbx_tF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable func isSubset(of other: FooRuncingOptions) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value that indicates whether the set is a subset of another set.</Para></Abstract><Parameters><Parameter><Name>other</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A set of the same type as the current set.</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para><codeVoice>true</codeVoice> if the set is a subset of <codeVoice>other</codeVoice>; otherwise, <codeVoice>false</codeVoice>.</Para></ResultDiscussion><Discussion><Para>Set <emphasis>A</emphasis> is a subset of another set <emphasis>B</emphasis> if every member of <emphasis>A</emphasis> is also a member of <emphasis>B</emphasis>.</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let employees: Set = [\"Alicia\", \"Bethany\", \"Chris\", \"Diana\", \"Eric\"]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[let attendees: Set = [\"Alicia\", \"Bethany\", \"Diana\"]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(attendees.isSubset(of: employees))]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"true\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></CommentParts></Function>",
-        key.offset: 3257,
+        key.offset: 3281,
         key.length: 61,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>isSubset</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>of</decl.var.parameter.argument_label> <decl.var.parameter.name>other</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.method.instance>",
         key.entities: [
@@ -6091,7 +6096,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "of",
             key.name: "other",
-            key.offset: 3292,
+            key.offset: 3316,
             key.length: 17
           }
         ]
@@ -6102,7 +6107,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s10SetAlgebraPsE10isSuperset2ofSbx_tF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s10SetAlgebraPsE10isSuperset2ofSbx_tF",
         key.doc.full_as_xml: "<Function><Name>isSuperset(of:)</Name><USR>s:s10SetAlgebraPsE10isSuperset2ofSbx_tF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable func isSuperset(of other: FooRuncingOptions) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value that indicates whether the set is a superset of the given set.</Para></Abstract><Parameters><Parameter><Name>other</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A set of the same type as the current set.</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para><codeVoice>true</codeVoice> if the set is a superset of <codeVoice>other</codeVoice>; otherwise, <codeVoice>false</codeVoice>.</Para></ResultDiscussion><Discussion><Para>Set <emphasis>A</emphasis> is a superset of another set <emphasis>B</emphasis> if every member of <emphasis>B</emphasis> is also a member of <emphasis>A</emphasis>.</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let employees: Set = [\"Alicia\", \"Bethany\", \"Chris\", \"Diana\", \"Eric\"]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[let attendees: Set = [\"Alicia\", \"Bethany\", \"Diana\"]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(employees.isSuperset(of: attendees))]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"true\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></CommentParts></Function>",
-        key.offset: 3324,
+        key.offset: 3348,
         key.length: 63,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>isSuperset</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>of</decl.var.parameter.argument_label> <decl.var.parameter.name>other</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.method.instance>",
         key.entities: [
@@ -6110,7 +6115,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "of",
             key.name: "other",
-            key.offset: 3361,
+            key.offset: 3385,
             key.length: 17
           }
         ]
@@ -6121,7 +6126,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s10SetAlgebraPsE10isDisjoint4withSbx_tF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s10SetAlgebraPsE10isDisjoint4withSbx_tF",
         key.doc.full_as_xml: "<Function><Name>isDisjoint(with:)</Name><USR>s:s10SetAlgebraPsE10isDisjoint4withSbx_tF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable func isDisjoint(with other: FooRuncingOptions) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value that indicates whether the set has no members in common with the given set.</Para></Abstract><Parameters><Parameter><Name>other</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A set of the same type as the current set.</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para><codeVoice>true</codeVoice> if the set has no elements in common with <codeVoice>other</codeVoice>; otherwise, <codeVoice>false</codeVoice>.</Para></ResultDiscussion><Discussion><Para>In the following example, the <codeVoice>employees</codeVoice> set is disjoint with the <codeVoice>visitors</codeVoice> set because no name appears in both sets.</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let employees: Set = [\"Alicia\", \"Bethany\", \"Chris\", \"Diana\", \"Eric\"]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[let visitors: Set = [\"Marcia\", \"Nathaniel\", \"Olivia\"]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(employees.isDisjoint(with: visitors))]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"true\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></CommentParts></Function>",
-        key.offset: 3393,
+        key.offset: 3417,
         key.length: 65,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>isDisjoint</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>with</decl.var.parameter.argument_label> <decl.var.parameter.name>other</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.method.instance>",
         key.entities: [
@@ -6129,7 +6134,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "with",
             key.name: "other",
-            key.offset: 3432,
+            key.offset: 3456,
             key.length: 17
           }
         ]
@@ -6140,7 +6145,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s10SetAlgebraPsE11subtractingyxxF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s10SetAlgebraPsE11subtractingyxxF",
         key.doc.full_as_xml: "<Function><Name>subtracting(_:)</Name><USR>s:s10SetAlgebraPsE11subtractingyxxF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable func subtracting(_ other: FooRuncingOptions) -&gt; FooRuncingOptions</Declaration><CommentParts><Abstract><Para>Returns a new set containing the elements of this set that do not occur in the given set.</Para></Abstract><Parameters><Parameter><Name>other</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A set of the same type as the current set.</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para>A new set.</Para></ResultDiscussion><Discussion><Para>In the following example, the <codeVoice>nonNeighbors</codeVoice> set is made up of the elements of the <codeVoice>employees</codeVoice> set that are not elements of <codeVoice>neighbors</codeVoice>:</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let employees: Set = [\"Alicia\", \"Bethany\", \"Chris\", \"Diana\", \"Eric\"]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[let neighbors: Set = [\"Bethany\", \"Eric\", \"Forlani\", \"Greta\"]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[let nonNeighbors = employees.subtracting(neighbors)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(nonNeighbors)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"[\"Diana\", \"Chris\", \"Alicia\"]\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></CommentParts></Function>",
-        key.offset: 3464,
+        key.offset: 3488,
         key.length: 76,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>subtracting</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>other</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.function.returntype></decl.function.method.instance>",
         key.entities: [
@@ -6148,7 +6153,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "other",
-            key.offset: 3501,
+            key.offset: 3525,
             key.length: 17
           }
         ]
@@ -6159,7 +6164,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s10SetAlgebraPsE7isEmptySbvp::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s10SetAlgebraPsE7isEmptySbvp",
         key.doc.full_as_xml: "<Other><Name>isEmpty</Name><USR>s:s10SetAlgebraPsE7isEmptySbvp::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable var isEmpty: Bool { get }</Declaration><CommentParts><Abstract><Para>A Boolean value that indicates whether the set has no elements.</Para></Abstract></CommentParts></Other>",
-        key.offset: 3546,
+        key.offset: 3570,
         key.length: 36,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>isEmpty</decl.name>: <decl.var.type><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -6169,7 +6174,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s10SetAlgebraPsE16isStrictSuperset2ofSbx_tF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s10SetAlgebraPsE16isStrictSuperset2ofSbx_tF",
         key.doc.full_as_xml: "<Function><Name>isStrictSuperset(of:)</Name><USR>s:s10SetAlgebraPsE16isStrictSuperset2ofSbx_tF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable func isStrictSuperset(of other: FooRuncingOptions) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value that indicates whether this set is a strict superset of the given set.</Para></Abstract><Parameters><Parameter><Name>other</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A set of the same type as the current set.</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para><codeVoice>true</codeVoice> if the set is a strict superset of <codeVoice>other</codeVoice>; otherwise, <codeVoice>false</codeVoice>.</Para></ResultDiscussion><Discussion><Para>Set <emphasis>A</emphasis> is a strict superset of another set <emphasis>B</emphasis> if every member of <emphasis>B</emphasis> is also a member of <emphasis>A</emphasis> and <emphasis>A</emphasis> contains at least one element that is <emphasis>not</emphasis> a member of <emphasis>B</emphasis>.</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let employees: Set = [\"Alicia\", \"Bethany\", \"Chris\", \"Diana\", \"Eric\"]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[let attendees: Set = [\"Alicia\", \"Bethany\", \"Diana\"]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(employees.isStrictSuperset(of: attendees))]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"true\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// A set is never a strict superset of itself:]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(employees.isStrictSuperset(of: employees))]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"false\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></CommentParts></Function>",
-        key.offset: 3588,
+        key.offset: 3612,
         key.length: 69,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>isStrictSuperset</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>of</decl.var.parameter.argument_label> <decl.var.parameter.name>other</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.method.instance>",
         key.entities: [
@@ -6177,7 +6182,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "of",
             key.name: "other",
-            key.offset: 3631,
+            key.offset: 3655,
             key.length: 17
           }
         ]
@@ -6188,7 +6193,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s10SetAlgebraPsE14isStrictSubset2ofSbx_tF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s10SetAlgebraPsE14isStrictSubset2ofSbx_tF",
         key.doc.full_as_xml: "<Function><Name>isStrictSubset(of:)</Name><USR>s:s10SetAlgebraPsE14isStrictSubset2ofSbx_tF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable func isStrictSubset(of other: FooRuncingOptions) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value that indicates whether this set is a strict subset of the given set.</Para></Abstract><Parameters><Parameter><Name>other</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A set of the same type as the current set.</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para><codeVoice>true</codeVoice> if the set is a strict subset of <codeVoice>other</codeVoice>; otherwise, <codeVoice>false</codeVoice>.</Para></ResultDiscussion><Discussion><Para>Set <emphasis>A</emphasis> is a strict subset of another set <emphasis>B</emphasis> if every member of <emphasis>A</emphasis> is also a member of <emphasis>B</emphasis> and <emphasis>B</emphasis> contains at least one element that is not a member of <emphasis>A</emphasis>.</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let employees: Set = [\"Alicia\", \"Bethany\", \"Chris\", \"Diana\", \"Eric\"]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[let attendees: Set = [\"Alicia\", \"Bethany\", \"Diana\"]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(attendees.isStrictSubset(of: employees))]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"true\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// A set is never a strict subset of itself:]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(attendees.isStrictSubset(of: attendees))]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"false\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></CommentParts></Function>",
-        key.offset: 3663,
+        key.offset: 3687,
         key.length: 67,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>isStrictSubset</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>of</decl.var.parameter.argument_label> <decl.var.parameter.name>other</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.method.instance>",
         key.entities: [
@@ -6196,7 +6201,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "of",
             key.name: "other",
-            key.offset: 3704,
+            key.offset: 3728,
             key.length: 17
           }
         ]
@@ -6207,7 +6212,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.struct,
     key.name: "FooStruct1",
     key.usr: "c:@S@FooStruct1",
-    key.offset: 3734,
+    key.offset: 3758,
     key.length: 105,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>FooStruct1</decl.name></decl.struct>",
     key.entities: [
@@ -6215,7 +6220,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init()",
         key.usr: "s:So10FooStruct1VABycfc",
-        key.offset: 3759,
+        key.offset: 3783,
         key.length: 6,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>()</decl.function.constructor>"
       },
@@ -6223,7 +6228,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(x:y:)",
         key.usr: "s:So10FooStruct1V1x1yABs5Int32V_Sdtcfc",
-        key.offset: 3771,
+        key.offset: 3795,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>y</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -6231,14 +6236,14 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "x",
             key.name: "x",
-            key.offset: 3781,
+            key.offset: 3805,
             key.length: 5
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "y",
             key.name: "y",
-            key.offset: 3793,
+            key.offset: 3817,
             key.length: 6
           }
         ]
@@ -6247,7 +6252,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "x",
         key.usr: "c:@S@FooStruct1@FI@x",
-        key.offset: 3806,
+        key.offset: 3830,
         key.length: 12,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>x</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type></decl.var.instance>"
       },
@@ -6255,7 +6260,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "y",
         key.usr: "c:@S@FooStruct1@FI@y",
-        key.offset: 3824,
+        key.offset: 3848,
         key.length: 13,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>y</decl.name>: <decl.var.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.type></decl.var.instance>"
       }
@@ -6265,7 +6270,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.typealias,
     key.name: "FooStruct1Pointer",
     key.usr: "c:Foo.h@T@FooStruct1Pointer",
-    key.offset: 3841,
+    key.offset: 3865,
     key.length: 62,
     key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>FooStruct1Pointer</decl.name> = <ref.struct usr=\"s:Sp\">UnsafeMutablePointer</ref.struct>&lt;<ref.struct usr=\"c:@S@FooStruct1\">FooStruct1</ref.struct>&gt;</decl.typealias>",
     key.conforms: [
@@ -6280,7 +6285,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.struct,
     key.name: "FooStruct2",
     key.usr: "c:@S@FooStruct2",
-    key.offset: 3905,
+    key.offset: 3929,
     key.length: 105,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>FooStruct2</decl.name></decl.struct>",
     key.entities: [
@@ -6288,7 +6293,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init()",
         key.usr: "s:So10FooStruct2VABycfc",
-        key.offset: 3930,
+        key.offset: 3954,
         key.length: 6,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>()</decl.function.constructor>"
       },
@@ -6296,7 +6301,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(x:y:)",
         key.usr: "s:So10FooStruct2V1x1yABs5Int32V_Sdtcfc",
-        key.offset: 3942,
+        key.offset: 3966,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>y</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -6304,14 +6309,14 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "x",
             key.name: "x",
-            key.offset: 3952,
+            key.offset: 3976,
             key.length: 5
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "y",
             key.name: "y",
-            key.offset: 3964,
+            key.offset: 3988,
             key.length: 6
           }
         ]
@@ -6320,7 +6325,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "x",
         key.usr: "c:@S@FooStruct2@FI@x",
-        key.offset: 3977,
+        key.offset: 4001,
         key.length: 12,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>x</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type></decl.var.instance>"
       },
@@ -6328,7 +6333,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "y",
         key.usr: "c:@S@FooStruct2@FI@y",
-        key.offset: 3995,
+        key.offset: 4019,
         key.length: 13,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>y</decl.name>: <decl.var.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.type></decl.var.instance>"
       }
@@ -6338,7 +6343,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.typealias,
     key.name: "FooStructTypedef1",
     key.usr: "c:Foo.h@T@FooStructTypedef1",
-    key.offset: 4012,
+    key.offset: 4036,
     key.length: 40,
     key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>FooStructTypedef1</decl.name> = <ref.struct usr=\"c:@S@FooStruct2\">FooStruct2</ref.struct></decl.typealias>"
   },
@@ -6346,7 +6351,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.struct,
     key.name: "FooStructTypedef2",
     key.usr: "c:@SA@FooStructTypedef2",
-    key.offset: 4054,
+    key.offset: 4078,
     key.length: 112,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>FooStructTypedef2</decl.name></decl.struct>",
     key.entities: [
@@ -6354,7 +6359,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init()",
         key.usr: "s:So17FooStructTypedef2aABycfc",
-        key.offset: 4086,
+        key.offset: 4110,
         key.length: 6,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>()</decl.function.constructor>"
       },
@@ -6362,7 +6367,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(x:y:)",
         key.usr: "s:So17FooStructTypedef2a1x1yABs5Int32V_Sdtcfc",
-        key.offset: 4098,
+        key.offset: 4122,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>y</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -6370,14 +6375,14 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "x",
             key.name: "x",
-            key.offset: 4108,
+            key.offset: 4132,
             key.length: 5
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "y",
             key.name: "y",
-            key.offset: 4120,
+            key.offset: 4144,
             key.length: 6
           }
         ]
@@ -6386,7 +6391,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "x",
         key.usr: "c:@SA@FooStructTypedef2@FI@x",
-        key.offset: 4133,
+        key.offset: 4157,
         key.length: 12,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>x</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type></decl.var.instance>"
       },
@@ -6394,7 +6399,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "y",
         key.usr: "c:@SA@FooStructTypedef2@FI@y",
-        key.offset: 4151,
+        key.offset: 4175,
         key.length: 13,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>y</decl.name>: <decl.var.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.type></decl.var.instance>"
       }
@@ -6405,7 +6410,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "FooTypedef1",
     key.usr: "c:Foo.h@T@FooTypedef1",
     key.doc.full_as_xml: "<Typedef file=Foo.h line=\"60\" column=\"13\"><Name>FooTypedef1</Name><USR>c:Foo.h@T@FooTypedef1</USR><Declaration>typealias FooTypedef1 = Int32</Declaration><Abstract><Para> Aaa.  FooTypedef1.  Bbb.</Para></Abstract></Typedef>",
-    key.offset: 4168,
+    key.offset: 4192,
     key.length: 29,
     key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>FooTypedef1</decl.name> = <ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.typealias>",
     key.conforms: [
@@ -6431,7 +6436,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "fooIntVar",
     key.usr: "c:@fooIntVar",
     key.doc.full_as_xml: "<Variable file=Foo.h line=\"63\" column=\"12\"><Name>fooIntVar</Name><USR>c:@fooIntVar</USR><Declaration>var fooIntVar: Int32</Declaration><Abstract><Para> Aaa.  fooIntVar.  Bbb.</Para></Abstract></Variable>",
-    key.offset: 4199,
+    key.offset: 4223,
     key.length: 20,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>fooIntVar</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type></decl.var.global>"
   },
@@ -6440,7 +6445,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "fooFunc1(_:)",
     key.usr: "c:@F@fooFunc1",
     key.doc.full_as_xml: "<Function file=Foo.h line=\"66\" column=\"5\"><Name>fooFunc1</Name><USR>c:@F@fooFunc1</USR><Declaration>func fooFunc1(_ a: Int32) -&gt; Int32</Declaration><Abstract><Para> Aaa.  fooFunc1.  Bbb.</Para></Abstract></Function>",
-    key.offset: 4221,
+    key.offset: 4245,
     key.length: 34,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFunc1</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.function.returntype></decl.function.free>",
     key.entities: [
@@ -6448,7 +6453,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
         key.name: "a",
-        key.offset: 4240,
+        key.offset: 4264,
         key.length: 5
       }
     ]
@@ -6457,14 +6462,14 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fooFunc1AnonymousParam(_:)",
     key.usr: "c:@F@fooFunc1AnonymousParam",
-    key.offset: 4257,
+    key.offset: 4281,
     key.length: 48,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFunc1AnonymousParam</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.function.returntype></decl.function.free>",
     key.entities: [
       {
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
-        key.offset: 4290,
+        key.offset: 4314,
         key.length: 5
       }
     ]
@@ -6473,7 +6478,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fooFunc3(_:_:_:_:)",
     key.usr: "c:@F@fooFunc3",
-    key.offset: 4307,
+    key.offset: 4331,
     key.length: 94,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFunc3</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>b</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Sf\">Float</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>c</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>d</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Sp\">UnsafeMutablePointer</ref.struct>&lt;<ref.struct usr=\"s:s5Int32V\">Int32</ref.struct>&gt;!</decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.function.returntype></decl.function.free>",
     key.entities: [
@@ -6481,28 +6486,28 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
         key.name: "a",
-        key.offset: 4326,
+        key.offset: 4350,
         key.length: 5
       },
       {
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
         key.name: "b",
-        key.offset: 4338,
+        key.offset: 4362,
         key.length: 5
       },
       {
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
         key.name: "c",
-        key.offset: 4350,
+        key.offset: 4374,
         key.length: 6
       },
       {
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
         key.name: "d",
-        key.offset: 4363,
+        key.offset: 4387,
         key.length: 28
       }
     ]
@@ -6511,7 +6516,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fooFuncWithBlock(_:)",
     key.usr: "c:@F@fooFuncWithBlock",
-    key.offset: 4403,
+    key.offset: 4427,
     key.length: 49,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncWithBlock</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>blk</decl.var.parameter.name>: <decl.var.parameter.type>((<decl.var.parameter><decl.var.parameter.type><ref.struct usr=\"s:Sf\">Float</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.function.returntype>)!</decl.var.parameter.type></decl.var.parameter>)</decl.function.free>",
     key.entities: [
@@ -6519,7 +6524,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
         key.name: "blk",
-        key.offset: 4432,
+        key.offset: 4456,
         key.length: 19
       }
     ]
@@ -6528,7 +6533,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fooFuncWithFunctionPointer(_:)",
     key.usr: "c:@F@fooFuncWithFunctionPointer",
-    key.offset: 4454,
+    key.offset: 4478,
     key.length: 60,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncWithFunctionPointer</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>fptr</decl.var.parameter.name>: <decl.var.parameter.type>((<decl.var.parameter><decl.var.parameter.type><ref.struct usr=\"s:Sf\">Float</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.function.returntype>)!</decl.var.parameter.type></decl.var.parameter>)</decl.function.free>",
     key.entities: [
@@ -6536,7 +6541,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
         key.name: "fptr",
-        key.offset: 4494,
+        key.offset: 4518,
         key.length: 19
       }
     ]
@@ -6545,7 +6550,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fooFuncNoreturn1()",
     key.usr: "c:@F@fooFuncNoreturn1",
-    key.offset: 4516,
+    key.offset: 4540,
     key.length: 32,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncNoreturn1</decl.name>() -&gt; <decl.function.returntype><ref.enum usr=\"s:s5NeverO\">Never</ref.enum></decl.function.returntype></decl.function.free>"
   },
@@ -6553,7 +6558,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fooFuncNoreturn2()",
     key.usr: "c:@F@fooFuncNoreturn2",
-    key.offset: 4550,
+    key.offset: 4574,
     key.length: 32,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncNoreturn2</decl.name>() -&gt; <decl.function.returntype><ref.enum usr=\"s:s5NeverO\">Never</ref.enum></decl.function.returntype></decl.function.free>"
   },
@@ -6562,7 +6567,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "fooFuncWithComment1()",
     key.usr: "c:@F@fooFuncWithComment1",
     key.doc.full_as_xml: "<Function file=Foo.h line=\"89\" column=\"6\"><Name>fooFuncWithComment1</Name><USR>c:@F@fooFuncWithComment1</USR><Declaration>func fooFuncWithComment1()</Declaration><Abstract><Para> Aaa.  fooFuncWithComment1.  Bbb. Ccc.</Para></Abstract><Discussion><Para> Ddd.</Para></Discussion></Function>",
-    key.offset: 4584,
+    key.offset: 4608,
     key.length: 26,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncWithComment1</decl.name>()</decl.function.free>"
   },
@@ -6571,7 +6576,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "fooFuncWithComment2()",
     key.usr: "c:@F@fooFuncWithComment2",
     key.doc.full_as_xml: "<Function file=Foo.h line=\"94\" column=\"6\"><Name>fooFuncWithComment2</Name><USR>c:@F@fooFuncWithComment2</USR><Declaration>func fooFuncWithComment2()</Declaration><Abstract><Para>  Aaa.  fooFuncWithComment2.  Bbb.</Para></Abstract></Function>",
-    key.offset: 4612,
+    key.offset: 4636,
     key.length: 26,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncWithComment2</decl.name>()</decl.function.free>"
   },
@@ -6580,7 +6585,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "fooFuncWithComment3()",
     key.usr: "c:@F@fooFuncWithComment3",
     key.doc.full_as_xml: "<Function file=Foo.h line=\"102\" column=\"6\"><Name>fooFuncWithComment3</Name><USR>c:@F@fooFuncWithComment3</USR><Declaration>func fooFuncWithComment3()</Declaration><Abstract><Para> Aaa.  fooFuncWithComment3.  Bbb.</Para></Abstract><Discussion><Para> Ccc.</Para></Discussion></Function>",
-    key.offset: 4640,
+    key.offset: 4664,
     key.length: 26,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncWithComment3</decl.name>()</decl.function.free>"
   },
@@ -6589,7 +6594,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "fooFuncWithComment4()",
     key.usr: "c:@F@fooFuncWithComment4",
     key.doc.full_as_xml: "<Function file=Foo.h line=\"108\" column=\"6\"><Name>fooFuncWithComment4</Name><USR>c:@F@fooFuncWithComment4</USR><Declaration>func fooFuncWithComment4()</Declaration><Abstract><Para> Aaa.  fooFuncWithComment4.  Bbb.</Para></Abstract><Discussion><Para> Ddd.</Para></Discussion></Function>",
-    key.offset: 4668,
+    key.offset: 4692,
     key.length: 26,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncWithComment4</decl.name>()</decl.function.free>"
   },
@@ -6598,7 +6603,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "fooFuncWithComment5()",
     key.usr: "c:@F@fooFuncWithComment5",
     key.doc.full_as_xml: "<Function file=Foo.h line=\"114\" column=\"6\"><Name>fooFuncWithComment5</Name><USR>c:@F@fooFuncWithComment5</USR><Declaration>func fooFuncWithComment5()</Declaration><Abstract><Para> Aaa.  fooFuncWithComment5.  Bbb. Ccc.</Para></Abstract><Discussion><Para> Ddd.</Para></Discussion></Function>",
-    key.offset: 4696,
+    key.offset: 4720,
     key.length: 26,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncWithComment5</decl.name>()</decl.function.free>"
   },
@@ -6607,7 +6612,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "redeclaredInMultipleModulesFunc1(_:)",
     key.usr: "c:@F@redeclaredInMultipleModulesFunc1",
     key.doc.full_as_xml: "<Function file=Foo.h line=\"118\" column=\"5\"><Name>redeclaredInMultipleModulesFunc1</Name><USR>c:@F@redeclaredInMultipleModulesFunc1</USR><Declaration>func redeclaredInMultipleModulesFunc1(_ a: Int32) -&gt; Int32</Declaration><Abstract><Para> Aaa.  redeclaredInMultipleModulesFunc1.  Bbb.</Para></Abstract></Function>",
-    key.offset: 4724,
+    key.offset: 4748,
     key.length: 58,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>redeclaredInMultipleModulesFunc1</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.function.returntype></decl.function.free>",
     key.entities: [
@@ -6615,7 +6620,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
         key.name: "a",
-        key.offset: 4767,
+        key.offset: 4791,
         key.length: 5
       }
     ]
@@ -6625,7 +6630,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "FooProtocolBase",
     key.usr: "c:objc(pl)FooProtocolBase",
     key.doc.full_as_xml: "<Other file=Foo.h line=\"121\" column=\"11\"><Name>FooProtocolBase</Name><USR>c:objc(pl)FooProtocolBase</USR><Declaration>protocol FooProtocolBase</Declaration><Abstract><Para> Aaa.  FooProtocolBase.  Bbb.</Para></Abstract></Other>",
-    key.offset: 4784,
+    key.offset: 4808,
     key.length: 301,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>FooProtocolBase</decl.name></decl.protocol>",
     key.entities: [
@@ -6634,7 +6639,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "fooProtoFunc()",
         key.usr: "c:objc(pl)FooProtocolBase(im)fooProtoFunc",
         key.doc.full_as_xml: "<Function isInstanceMethod=\"1\" file=Foo.h line=\"125\" column=\"1\"><Name>fooProtoFunc</Name><USR>c:objc(pl)FooProtocolBase(im)fooProtoFunc</USR><Declaration>func fooProtoFunc()</Declaration><Abstract><Para> Aaa.  fooProtoFunc.  Bbb. Ccc.</Para></Abstract></Function>",
-        key.offset: 4816,
+        key.offset: 4840,
         key.length: 19,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooProtoFunc</decl.name>()</decl.function.method.instance>"
       },
@@ -6643,7 +6648,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "fooProtoFuncWithExtraIndentation1()",
         key.usr: "c:objc(pl)FooProtocolBase(im)fooProtoFuncWithExtraIndentation1",
         key.doc.full_as_xml: "<Function isInstanceMethod=\"1\" file=Foo.h line=\"129\" column=\"3\"><Name>fooProtoFuncWithExtraIndentation1</Name><USR>c:objc(pl)FooProtocolBase(im)fooProtoFuncWithExtraIndentation1</USR><Declaration>func fooProtoFuncWithExtraIndentation1()</Declaration><Abstract><Para> Aaa.  fooProtoFuncWithExtraIndentation1.  Bbb. Ccc.</Para></Abstract></Function>",
-        key.offset: 4841,
+        key.offset: 4865,
         key.length: 40,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooProtoFuncWithExtraIndentation1</decl.name>()</decl.function.method.instance>"
       },
@@ -6652,7 +6657,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "fooProtoFuncWithExtraIndentation2()",
         key.usr: "c:objc(pl)FooProtocolBase(im)fooProtoFuncWithExtraIndentation2",
         key.doc.full_as_xml: "<Function isInstanceMethod=\"1\" file=Foo.h line=\"135\" column=\"3\"><Name>fooProtoFuncWithExtraIndentation2</Name><USR>c:objc(pl)FooProtocolBase(im)fooProtoFuncWithExtraIndentation2</USR><Declaration>func fooProtoFuncWithExtraIndentation2()</Declaration><Abstract><Para> Aaa.  fooProtoFuncWithExtraIndentation2.  Bbb. Ccc.</Para></Abstract></Function>",
-        key.offset: 4887,
+        key.offset: 4911,
         key.length: 40,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooProtoFuncWithExtraIndentation2</decl.name>()</decl.function.method.instance>"
       },
@@ -6660,7 +6665,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.static,
         key.name: "fooProtoClassFunc()",
         key.usr: "c:objc(pl)FooProtocolBase(cm)fooProtoClassFunc",
-        key.offset: 4933,
+        key.offset: 4957,
         key.length: 31,
         key.fully_annotated_decl: "<decl.function.method.static><syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooProtoClassFunc</decl.name>()</decl.function.method.static>"
       },
@@ -6668,7 +6673,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "fooProperty1",
         key.usr: "c:objc(pl)FooProtocolBase(py)fooProperty1",
-        key.offset: 4970,
+        key.offset: 4994,
         key.length: 35,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>fooProperty1</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -6676,7 +6681,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "fooProperty2",
         key.usr: "c:objc(pl)FooProtocolBase(py)fooProperty2",
-        key.offset: 5011,
+        key.offset: 5035,
         key.length: 35,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>fooProperty2</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -6684,7 +6689,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "fooProperty3",
         key.usr: "c:objc(pl)FooProtocolBase(py)fooProperty3",
-        key.offset: 5052,
+        key.offset: 5076,
         key.length: 31,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>fooProperty3</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.instance>"
       }
@@ -6694,7 +6699,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.protocol,
     key.name: "FooProtocolDerived",
     key.usr: "c:objc(pl)FooProtocolDerived",
-    key.offset: 5087,
+    key.offset: 5111,
     key.length: 49,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>FooProtocolDerived</decl.name> : <ref.protocol usr=\"c:objc(pl)FooProtocolBase\">FooProtocolBase</ref.protocol></decl.protocol>",
     key.conforms: [
@@ -6709,7 +6714,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.class,
     key.name: "FooClassBase",
     key.usr: "c:objc(cs)FooClassBase",
-    key.offset: 5138,
+    key.offset: 5162,
     key.length: 392,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>FooClassBase</decl.name></decl.class>",
     key.entities: [
@@ -6717,7 +6722,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fooBaseInstanceFunc0()",
         key.usr: "c:objc(cs)FooClassBase(im)fooBaseInstanceFunc0",
-        key.offset: 5164,
+        key.offset: 5188,
         key.length: 27,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooBaseInstanceFunc0</decl.name>()</decl.function.method.instance>"
       },
@@ -6725,7 +6730,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fooBaseInstanceFunc1(_:)",
         key.usr: "c:objc(cs)FooClassBase(im)fooBaseInstanceFunc1:",
-        key.offset: 5197,
+        key.offset: 5221,
         key.length: 60,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooBaseInstanceFunc1</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>anObject</decl.var.parameter.name>: <decl.var.parameter.type><syntaxtype.keyword>Any</syntaxtype.keyword>!</decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.class usr=\"c:objc(cs)FooClassBase\">FooClassBase</ref.class>!</decl.function.returntype></decl.function.method.instance>",
         key.entities: [
@@ -6733,7 +6738,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "anObject",
-            key.offset: 5235,
+            key.offset: 5259,
             key.length: 4
           }
         ]
@@ -6742,7 +6747,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init()",
         key.usr: "c:objc(cs)FooClassBase(im)init",
-        key.offset: 5263,
+        key.offset: 5287,
         key.length: 7,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>!()</decl.function.constructor>"
       },
@@ -6750,7 +6755,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(float:)",
         key.usr: "c:objc(cs)FooClassBase(im)initWithFloat:",
-        key.offset: 5276,
+        key.offset: 5300,
         key.length: 33,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>convenience</syntaxtype.keyword> <syntaxtype.keyword>init</syntaxtype.keyword>!(<decl.var.parameter><decl.var.parameter.argument_label>float</decl.var.parameter.argument_label> <decl.var.parameter.name>f</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Sf\">Float</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -6758,7 +6763,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "float",
             key.name: "f",
-            key.offset: 5303,
+            key.offset: 5327,
             key.length: 5
           }
         ]
@@ -6767,7 +6772,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fooBaseInstanceFuncOverridden()",
         key.usr: "c:objc(cs)FooClassBase(im)fooBaseInstanceFuncOverridden",
-        key.offset: 5315,
+        key.offset: 5339,
         key.length: 36,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooBaseInstanceFuncOverridden</decl.name>()</decl.function.method.instance>"
       },
@@ -6775,7 +6780,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.class,
         key.name: "fooBaseClassFunc0()",
         key.usr: "c:objc(cs)FooClassBase(cm)fooBaseClassFunc0",
-        key.offset: 5357,
+        key.offset: 5381,
         key.length: 30,
         key.fully_annotated_decl: "<decl.function.method.class><syntaxtype.keyword>class</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooBaseClassFunc0</decl.name>()</decl.function.method.class>"
       },
@@ -6783,7 +6788,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "_internalMeth1()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
-        key.offset: 5393,
+        key.offset: 5417,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype><syntaxtype.keyword>Any</syntaxtype.keyword>!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -6791,7 +6796,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "_internalMeth2()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth2",
-        key.offset: 5428,
+        key.offset: 5452,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth2</decl.name>() -&gt; <decl.function.returntype><syntaxtype.keyword>Any</syntaxtype.keyword>!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -6799,7 +6804,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "nonInternalMeth()",
         key.usr: "c:objc(cs)FooClassBase(im)nonInternalMeth",
-        key.offset: 5463,
+        key.offset: 5487,
         key.length: 30,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>nonInternalMeth</decl.name>() -&gt; <decl.function.returntype><syntaxtype.keyword>Any</syntaxtype.keyword>!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -6807,7 +6812,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "_internalMeth3()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
-        key.offset: 5499,
+        key.offset: 5523,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype><syntaxtype.keyword>Any</syntaxtype.keyword>!</decl.function.returntype></decl.function.method.instance>"
       }
@@ -6818,7 +6823,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "FooClassDerived",
     key.usr: "c:objc(cs)FooClassDerived",
     key.doc.full_as_xml: "<Other file=Foo.h line=\"158\" column=\"12\"><Name>FooClassDerived</Name><USR>c:objc(cs)FooClassDerived</USR><Declaration>class FooClassDerived : FooClassBase, FooProtocolDerived</Declaration><Abstract><Para> Aaa.  FooClassDerived.  Bbb.</Para></Abstract></Other>",
-    key.offset: 5532,
+    key.offset: 5556,
     key.length: 352,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>FooClassDerived</decl.name> : <ref.class usr=\"c:objc(cs)FooClassBase\">FooClassBase</ref.class>, <ref.protocol usr=\"c:objc(pl)FooProtocolDerived\">FooProtocolDerived</ref.protocol></decl.class>",
     key.inherits: [
@@ -6840,7 +6845,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "fooProperty1",
         key.usr: "c:objc(cs)FooClassDerived(py)fooProperty1",
-        key.offset: 5596,
+        key.offset: 5620,
         key.length: 23,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>fooProperty1</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -6848,7 +6853,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "fooProperty2",
         key.usr: "c:objc(cs)FooClassDerived(py)fooProperty2",
-        key.offset: 5625,
+        key.offset: 5649,
         key.length: 23,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>fooProperty2</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -6856,7 +6861,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "fooProperty3",
         key.usr: "c:objc(cs)FooClassDerived(py)fooProperty3",
-        key.offset: 5654,
+        key.offset: 5678,
         key.length: 31,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>fooProperty3</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -6864,7 +6869,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fooInstanceFunc0()",
         key.usr: "c:objc(cs)FooClassDerived(im)fooInstanceFunc0",
-        key.offset: 5691,
+        key.offset: 5715,
         key.length: 23,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooInstanceFunc0</decl.name>()</decl.function.method.instance>"
       },
@@ -6872,7 +6877,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fooInstanceFunc1(_:)",
         key.usr: "c:objc(cs)FooClassDerived(im)fooInstanceFunc1:",
-        key.offset: 5720,
+        key.offset: 5744,
         key.length: 33,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooInstanceFunc1</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -6880,7 +6885,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "a",
-            key.offset: 5747,
+            key.offset: 5771,
             key.length: 5
           }
         ]
@@ -6889,7 +6894,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fooInstanceFunc2(_:withB:)",
         key.usr: "c:objc(cs)FooClassDerived(im)fooInstanceFunc2:withB:",
-        key.offset: 5759,
+        key.offset: 5783,
         key.length: 49,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooInstanceFunc2</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>withB</decl.var.parameter.argument_label> <decl.var.parameter.name>b</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -6897,14 +6902,14 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "a",
-            key.offset: 5786,
+            key.offset: 5810,
             key.length: 5
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "withB",
             key.name: "b",
-            key.offset: 5802,
+            key.offset: 5826,
             key.length: 5
           }
         ]
@@ -6913,7 +6918,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fooBaseInstanceFuncOverridden()",
         key.usr: "c:objc(cs)FooClassDerived(im)fooBaseInstanceFuncOverridden",
-        key.offset: 5814,
+        key.offset: 5838,
         key.length: 36,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooBaseInstanceFuncOverridden</decl.name>()</decl.function.method.instance>",
         key.inherits: [
@@ -6928,7 +6933,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.class,
         key.name: "fooClassFunc0()",
         key.usr: "c:objc(cs)FooClassDerived(cm)fooClassFunc0",
-        key.offset: 5856,
+        key.offset: 5880,
         key.length: 26,
         key.fully_annotated_decl: "<decl.function.method.class><syntaxtype.keyword>class</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooClassFunc0</decl.name>()</decl.function.method.class>"
       }
@@ -6938,7 +6943,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.typealias,
     key.name: "typedef_int_t",
     key.usr: "c:Foo.h@T@typedef_int_t",
-    key.offset: 5886,
+    key.offset: 5910,
     key.length: 31,
     key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>typedef_int_t</decl.name> = <ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.typealias>",
     key.conforms: [
@@ -6963,7 +6968,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_1",
     key.usr: "c:Foo.h@3836@macro@FOO_MACRO_1",
-    key.offset: 5919,
+    key.offset: 5943,
     key.length: 30,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_1</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -6971,7 +6976,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_2",
     key.usr: "c:Foo.h@3858@macro@FOO_MACRO_2",
-    key.offset: 5951,
+    key.offset: 5975,
     key.length: 30,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_2</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -6979,7 +6984,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_3",
     key.usr: "c:Foo.h@3880@macro@FOO_MACRO_3",
-    key.offset: 5983,
+    key.offset: 6007,
     key.length: 30,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_3</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -6987,7 +6992,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_4",
     key.usr: "c:Foo.h@3944@macro@FOO_MACRO_4",
-    key.offset: 6015,
+    key.offset: 6039,
     key.length: 31,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_4</decl.name>: <decl.var.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -6995,7 +7000,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_5",
     key.usr: "c:Foo.h@3976@macro@FOO_MACRO_5",
-    key.offset: 6048,
+    key.offset: 6072,
     key.length: 31,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_5</decl.name>: <decl.var.type><ref.struct usr=\"s:s6UInt64V\">UInt64</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -7003,7 +7008,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_6",
     key.usr: "c:Foo.h@4018@macro@FOO_MACRO_6",
-    key.offset: 6081,
+    key.offset: 6105,
     key.length: 38,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_6</decl.name>: <decl.var.type><ref.typealias usr=\"c:Foo.h@T@typedef_int_t\">typedef_int_t</ref.typealias></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -7011,7 +7016,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_7",
     key.usr: "c:Foo.h@4059@macro@FOO_MACRO_7",
-    key.offset: 6121,
+    key.offset: 6145,
     key.length: 38,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_7</decl.name>: <decl.var.type><ref.typealias usr=\"c:Foo.h@T@typedef_int_t\">typedef_int_t</ref.typealias></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -7019,7 +7024,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_8",
     key.usr: "c:Foo.h@4100@macro@FOO_MACRO_8",
-    key.offset: 6161,
+    key.offset: 6185,
     key.length: 30,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_8</decl.name>: <decl.var.type><ref.typealias usr=\"s:s5CChara\">CChar</ref.typealias></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -7027,7 +7032,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_9",
     key.usr: "c:Foo.h@4131@macro@FOO_MACRO_9",
-    key.offset: 6193,
+    key.offset: 6217,
     key.length: 30,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_9</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -7035,7 +7040,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_10",
     key.usr: "c:Foo.h@4161@macro@FOO_MACRO_10",
-    key.offset: 6225,
+    key.offset: 6249,
     key.length: 31,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_10</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int16V\">Int16</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -7043,7 +7048,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_11",
     key.usr: "c:Foo.h@4195@macro@FOO_MACRO_11",
-    key.offset: 6258,
+    key.offset: 6282,
     key.length: 29,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_11</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -7051,7 +7056,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_OR",
     key.usr: "c:Foo.h@4228@macro@FOO_MACRO_OR",
-    key.offset: 6289,
+    key.offset: 6313,
     key.length: 31,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_OR</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -7059,7 +7064,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_AND",
     key.usr: "c:Foo.h@4277@macro@FOO_MACRO_AND",
-    key.offset: 6322,
+    key.offset: 6346,
     key.length: 32,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_AND</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -7067,7 +7072,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_BITWIDTH",
     key.usr: "c:Foo.h@4327@macro@FOO_MACRO_BITWIDTH",
-    key.offset: 6356,
+    key.offset: 6380,
     key.length: 38,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_BITWIDTH</decl.name>: <decl.var.type><ref.struct usr=\"s:s6UInt64V\">UInt64</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -7075,7 +7080,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_SIGNED",
     key.usr: "c:Foo.h@4382@macro@FOO_MACRO_SIGNED",
-    key.offset: 6396,
+    key.offset: 6420,
     key.length: 36,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_SIGNED</decl.name>: <decl.var.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -7083,7 +7088,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_REDEF_1",
     key.usr: "c:Foo.h@4593@macro@FOO_MACRO_REDEF_1",
-    key.offset: 6434,
+    key.offset: 6458,
     key.length: 36,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_REDEF_1</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -7091,7 +7096,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_REDEF_2",
     key.usr: "c:Foo.h@4650@macro@FOO_MACRO_REDEF_2",
-    key.offset: 6472,
+    key.offset: 6496,
     key.length: 36,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_REDEF_2</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -7099,7 +7104,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "theLastDeclInFoo()",
     key.usr: "c:@F@theLastDeclInFoo",
-    key.offset: 6510,
+    key.offset: 6534,
     key.length: 23,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>theLastDeclInFoo</decl.name>()</decl.function.free>"
   },
@@ -7107,7 +7112,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "_internalTopLevelFunc()",
     key.usr: "c:@F@_internalTopLevelFunc",
-    key.offset: 6535,
+    key.offset: 6559,
     key.length: 28,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalTopLevelFunc</decl.name>()</decl.function.free>"
   },
@@ -7115,7 +7120,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.struct,
     key.name: "_InternalStruct",
     key.usr: "c:@S@_InternalStruct",
-    key.offset: 6565,
+    key.offset: 6589,
     key.length: 78,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>_InternalStruct</decl.name></decl.struct>",
     key.entities: [
@@ -7123,7 +7128,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init()",
         key.usr: "s:So15_InternalStructVABycfc",
-        key.offset: 6595,
+        key.offset: 6619,
         key.length: 6,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>()</decl.function.constructor>"
       },
@@ -7131,7 +7136,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(x:)",
         key.usr: "s:So15_InternalStructV1xABs5Int32V_tcfc",
-        key.offset: 6607,
+        key.offset: 6631,
         key.length: 16,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -7139,7 +7144,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "x",
             key.name: "x",
-            key.offset: 6617,
+            key.offset: 6641,
             key.length: 5
           }
         ]
@@ -7148,7 +7153,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "x",
         key.usr: "c:@S@_InternalStruct@FI@x",
-        key.offset: 6629,
+        key.offset: 6653,
         key.length: 12,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>x</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type></decl.var.instance>"
       }
@@ -7156,7 +7161,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   },
   {
     key.kind: source.lang.swift.decl.extension.class,
-    key.offset: 6645,
+    key.offset: 6669,
     key.length: 61,
     key.fully_annotated_decl: "<decl.extension.class><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.class usr=\"c:objc(cs)FooClassBase\">FooClassBase</ref.class></decl.name></decl.extension.class>",
     key.extends: {
@@ -7169,7 +7174,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "_internalMeth1()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
-        key.offset: 6675,
+        key.offset: 6699,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype><syntaxtype.keyword>Any</syntaxtype.keyword>!</decl.function.returntype></decl.function.method.instance>"
       }
@@ -7177,7 +7182,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   },
   {
     key.kind: source.lang.swift.decl.extension.class,
-    key.offset: 6708,
+    key.offset: 6732,
     key.length: 97,
     key.fully_annotated_decl: "<decl.extension.class><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.class usr=\"c:objc(cs)FooClassBase\">FooClassBase</ref.class></decl.name></decl.extension.class>",
     key.extends: {
@@ -7190,7 +7195,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "_internalMeth2()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth2",
-        key.offset: 6738,
+        key.offset: 6762,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth2</decl.name>() -&gt; <decl.function.returntype><syntaxtype.keyword>Any</syntaxtype.keyword>!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -7198,7 +7203,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "nonInternalMeth()",
         key.usr: "c:objc(cs)FooClassBase(im)nonInternalMeth",
-        key.offset: 6773,
+        key.offset: 6797,
         key.length: 30,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>nonInternalMeth</decl.name>() -&gt; <decl.function.returntype><syntaxtype.keyword>Any</syntaxtype.keyword>!</decl.function.returntype></decl.function.method.instance>"
       }
@@ -7206,7 +7211,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   },
   {
     key.kind: source.lang.swift.decl.extension.class,
-    key.offset: 6807,
+    key.offset: 6831,
     key.length: 61,
     key.fully_annotated_decl: "<decl.extension.class><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.class usr=\"c:objc(cs)FooClassBase\">FooClassBase</ref.class></decl.name></decl.extension.class>",
     key.extends: {
@@ -7219,7 +7224,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "_internalMeth3()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
-        key.offset: 6837,
+        key.offset: 6861,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype><syntaxtype.keyword>Any</syntaxtype.keyword>!</decl.function.returntype></decl.function.method.instance>"
       }
@@ -7229,7 +7234,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.protocol,
     key.name: "_InternalProt",
     key.usr: "c:objc(pl)_InternalProt",
-    key.offset: 6870,
+    key.offset: 6894,
     key.length: 26,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>_InternalProt</decl.name></decl.protocol>"
   },
@@ -7237,7 +7242,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.class,
     key.name: "ClassWithInternalProt",
     key.usr: "c:objc(cs)ClassWithInternalProt",
-    key.offset: 6898,
+    key.offset: 6922,
     key.length: 47,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>ClassWithInternalProt</decl.name> : <ref.protocol usr=\"c:objc(pl)_InternalProt\">_InternalProt</ref.protocol></decl.class>",
     key.conforms: [
@@ -7252,7 +7257,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.class,
     key.name: "FooClassPropertyOwnership",
     key.usr: "c:objc(cs)FooClassPropertyOwnership",
-    key.offset: 6947,
+    key.offset: 6971,
     key.length: 284,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>FooClassPropertyOwnership</decl.name> : <ref.class usr=\"c:objc(cs)FooClassBase\">FooClassBase</ref.class></decl.class>",
     key.inherits: [
@@ -7267,7 +7272,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "assignable",
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)assignable",
-        key.offset: 7001,
+        key.offset: 7025,
         key.length: 42,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>unowned(unsafe)</syntaxtype.keyword> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>assignable</decl.name>: <decl.var.type>AnyObject!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -7275,7 +7280,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "unsafeAssignable",
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)unsafeAssignable",
-        key.offset: 7049,
+        key.offset: 7073,
         key.length: 48,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>unowned(unsafe)</syntaxtype.keyword> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>unsafeAssignable</decl.name>: <decl.var.type>AnyObject!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -7283,7 +7288,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "retainable",
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)retainable",
-        key.offset: 7103,
+        key.offset: 7127,
         key.length: 20,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>retainable</decl.name>: <decl.var.type><syntaxtype.keyword>Any</syntaxtype.keyword>!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -7291,7 +7296,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "strongRef",
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)strongRef",
-        key.offset: 7129,
+        key.offset: 7153,
         key.length: 19,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>strongRef</decl.name>: <decl.var.type><syntaxtype.keyword>Any</syntaxtype.keyword>!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -7299,7 +7304,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "copyable",
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)copyable",
-        key.offset: 7154,
+        key.offset: 7178,
         key.length: 18,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>copyable</decl.name>: <decl.var.type><syntaxtype.keyword>Any</syntaxtype.keyword>!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -7307,7 +7312,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "weakRef",
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)weakRef",
-        key.offset: 7178,
+        key.offset: 7202,
         key.length: 28,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>weak</syntaxtype.keyword> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>weakRef</decl.name>: <decl.var.type>AnyObject!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -7315,7 +7320,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "scalar",
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)scalar",
-        key.offset: 7212,
+        key.offset: 7236,
         key.length: 17,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>scalar</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       }
@@ -7325,7 +7330,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_NIL",
     key.usr: "c:Foo.h@5439@macro@FOO_NIL",
-    key.offset: 7233,
+    key.offset: 7257,
     key.length: 15,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_NIL</decl.name>: <decl.var.type><tuple>()</tuple></decl.var.type></decl.var.global>",
     key.attributes: [
@@ -7341,7 +7346,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.class,
     key.name: "FooUnavailableMembers",
     key.usr: "c:objc(cs)FooUnavailableMembers",
-    key.offset: 7250,
+    key.offset: 7274,
     key.length: 451,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>FooUnavailableMembers</decl.name> : <ref.class usr=\"c:objc(cs)FooClassBase\">FooClassBase</ref.class></decl.class>",
     key.inherits: [
@@ -7356,7 +7361,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(int:)",
         key.usr: "c:objc(cs)FooUnavailableMembers(cm)unavailableMembersWithInt:",
-        key.offset: 7300,
+        key.offset: 7324,
         key.length: 31,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>convenience</syntaxtype.keyword> <syntaxtype.keyword>init</syntaxtype.keyword>!(<decl.var.parameter><decl.var.parameter.argument_label>int</decl.var.parameter.argument_label> <decl.var.parameter.name>i</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -7364,7 +7369,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "int",
             key.name: "i",
-            key.offset: 7325,
+            key.offset: 7349,
             key.length: 5
           }
         ]
@@ -7373,7 +7378,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "unavailable()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)unavailable",
-        key.offset: 7337,
+        key.offset: 7361,
         key.length: 18,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>unavailable</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -7389,7 +7394,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "swiftUnavailable()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)swiftUnavailable",
-        key.offset: 7361,
+        key.offset: 7385,
         key.length: 23,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>swiftUnavailable</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -7404,7 +7409,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "deprecated()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)deprecated",
-        key.offset: 7390,
+        key.offset: 7414,
         key.length: 17,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>deprecated</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -7420,7 +7425,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityIntroduced()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityIntroduced",
-        key.offset: 7413,
+        key.offset: 7437,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityIntroduced</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -7435,7 +7440,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityDeprecated()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityDeprecated",
-        key.offset: 7448,
+        key.offset: 7472,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityDeprecated</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -7454,7 +7459,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityObsoleted()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityObsoleted",
-        key.offset: 7483,
+        key.offset: 7507,
         key.length: 28,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityObsoleted</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -7470,7 +7475,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityUnavailable()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityUnavailable",
-        key.offset: 7517,
+        key.offset: 7541,
         key.length: 30,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityUnavailable</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -7486,7 +7491,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityIntroducedMsg()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityIntroducedMsg",
-        key.offset: 7553,
+        key.offset: 7577,
         key.length: 32,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityIntroducedMsg</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -7502,7 +7507,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityDeprecatedMsg()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityDeprecatedMsg",
-        key.offset: 7591,
+        key.offset: 7615,
         key.length: 32,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityDeprecatedMsg</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -7521,7 +7526,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityObsoletedMsg()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityObsoletedMsg",
-        key.offset: 7629,
+        key.offset: 7653,
         key.length: 31,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityObsoletedMsg</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -7538,7 +7543,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityUnavailableMsg()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityUnavailableMsg",
-        key.offset: 7666,
+        key.offset: 7690,
         key.length: 33,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityUnavailableMsg</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -7557,7 +7562,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.class,
     key.name: "FooCFType",
     key.usr: "c:Foo.h@T@FooCFTypeRef",
-    key.offset: 7703,
+    key.offset: 7727,
     key.length: 19,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>FooCFType</decl.name></decl.class>"
   },
@@ -7565,14 +7570,14 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "FooCFTypeRelease(_:)",
     key.usr: "c:@F@FooCFTypeRelease",
-    key.offset: 7724,
+    key.offset: 7748,
     key.length: 38,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>FooCFTypeRelease</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.class usr=\"c:Foo.h@T@FooCFTypeRef\">FooCFType</ref.class>!</decl.var.parameter.type></decl.var.parameter>)</decl.function.free>",
     key.entities: [
       {
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
-        key.offset: 7751,
+        key.offset: 7775,
         key.length: 10
       }
     ],
@@ -7589,7 +7594,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.enum,
     key.name: "ABAuthorizationStatus",
     key.usr: "c:@E@ABAuthorizationStatus",
-    key.offset: 7764,
+    key.offset: 7788,
     key.length: 294,
     key.fully_annotated_decl: "<decl.enum><syntaxtype.keyword>enum</syntaxtype.keyword> <decl.name>ABAuthorizationStatus</decl.name> : <ref.struct usr=\"s:Si\">Int</ref.struct></decl.enum>",
     key.inherits: [
@@ -7604,7 +7609,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.enumelement,
         key.name: "notDetermined",
         key.usr: "c:@E@ABAuthorizationStatus@kABAuthorizationStatusNotDetermined",
-        key.offset: 7804,
+        key.offset: 7828,
         key.length: 22,
         key.fully_annotated_decl: "<decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>notDetermined</decl.name> = <syntaxtype.number>0</syntaxtype.number></decl.enumelement>",
         key.attributes: [
@@ -7619,7 +7624,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.enumelement,
         key.name: "restricted",
         key.usr: "c:@E@ABAuthorizationStatus@kABAuthorizationStatusRestricted",
-        key.offset: 7832,
+        key.offset: 7856,
         key.length: 19,
         key.fully_annotated_decl: "<decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>restricted</decl.name> = <syntaxtype.number>1</syntaxtype.number></decl.enumelement>",
         key.attributes: [
@@ -7635,7 +7640,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "hashValue",
         key.usr: "s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::c:@E@ABAuthorizationStatus",
         key.original_usr: "s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp",
-        key.offset: 7857,
+        key.offset: 7881,
         key.length: 37,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>hashValue</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -7644,7 +7649,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "hash(into:)",
         key.usr: "s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@E@ABAuthorizationStatus",
         key.original_usr: "s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF",
-        key.offset: 7900,
+        key.offset: 7924,
         key.length: 47,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>hash</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>into</decl.var.parameter.argument_label> <decl.var.parameter.name>hasher</decl.var.parameter.name>: <syntaxtype.keyword>inout</syntaxtype.keyword> <decl.var.parameter.type><ref.struct usr=\"s:s6HasherV\">Hasher</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -7652,7 +7657,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "into",
             key.name: "hasher",
-            key.offset: 7940,
+            key.offset: 7964,
             key.length: 6
           }
         ]
@@ -7663,7 +7668,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@ABAuthorizationStatus",
         key.original_usr: "s:SQsE2neoiySbx_xtFZ",
         key.doc.full_as_xml: "<Function><Name>!=(_:_:)</Name><USR>s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@ABAuthorizationStatus</USR><Declaration>static func != (lhs: borrowing ABAuthorizationStatus, rhs: borrowing ABAuthorizationStatus) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value indicating whether two values are not equal.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A value to compare.</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>Another value to compare.</Para></Discussion></Parameter></Parameters><Discussion><Para>Inequality is the inverse of equality. For any values <codeVoice>a</codeVoice> and <codeVoice>b</codeVoice>, <codeVoice>a != b</codeVoice> implies that <codeVoice>a == b</codeVoice> is <codeVoice>false</codeVoice>.</Para><Para>This is the default implementation of the not-equal-to operator (<codeVoice>!=</codeVoice>) for any type that conforms to <codeVoice>Equatable</codeVoice>.</Para></Discussion></CommentParts></Function>",
-        key.offset: 7953,
+        key.offset: 7977,
         key.length: 103,
         key.fully_annotated_decl: "<decl.function.operator.infix><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@_preInverseGenerics</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>!= </decl.name>(<decl.var.parameter><decl.var.parameter.name>lhs</decl.var.parameter.name>: <syntaxtype.keyword>borrowing</syntaxtype.keyword> <decl.var.parameter.type><ref.enum usr=\"c:@E@ABAuthorizationStatus\">ABAuthorizationStatus</ref.enum></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>rhs</decl.var.parameter.name>: <syntaxtype.keyword>borrowing</syntaxtype.keyword> <decl.var.parameter.type><ref.enum usr=\"c:@E@ABAuthorizationStatus\">ABAuthorizationStatus</ref.enum></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.operator.infix>",
         key.entities: [
@@ -7671,14 +7676,14 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "lhs",
-            key.offset: 7986,
+            key.offset: 8010,
             key.length: 21
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "rhs",
-            key.offset: 8026,
+            key.offset: 8050,
             key.length: 21
           }
         ]
@@ -7697,7 +7702,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fooSubFunc1(_:)",
     key.usr: "c:@F@fooSubFunc1",
-    key.offset: 8060,
+    key.offset: 8084,
     key.length: 37,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooSubFunc1</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.function.returntype></decl.function.free>",
     key.entities: [
@@ -7705,7 +7710,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
         key.name: "a",
-        key.offset: 8082,
+        key.offset: 8106,
         key.length: 5
       }
     ],
@@ -7715,7 +7720,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.struct,
     key.name: "FooSubEnum1",
     key.usr: "c:@E@FooSubEnum1",
-    key.offset: 8099,
+    key.offset: 8123,
     key.length: 340,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>FooSubEnum1</decl.name> : <ref.protocol usr=\"s:SH\">Hashable</ref.protocol>, <ref.protocol usr=\"s:SQ\">Equatable</ref.protocol>, <ref.protocol usr=\"s:SY\">RawRepresentable</ref.protocol></decl.struct>",
     key.conforms: [
@@ -7740,7 +7745,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(_:)",
         key.usr: "s:So11FooSubEnum1VyABs6UInt32Vcfc",
-        key.offset: 8165,
+        key.offset: 8189,
         key.length: 24,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>rawValue</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -7748,7 +7753,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "rawValue",
-            key.offset: 8182,
+            key.offset: 8206,
             key.length: 6
           }
         ]
@@ -7757,7 +7762,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(rawValue:)",
         key.usr: "s:So11FooSubEnum1V8rawValueABs6UInt32V_tcfc",
-        key.offset: 8195,
+        key.offset: 8219,
         key.length: 31,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>rawValue</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -7765,7 +7770,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "rawValue",
             key.name: "rawValue",
-            key.offset: 8219,
+            key.offset: 8243,
             key.length: 6
           }
         ]
@@ -7774,7 +7779,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "rawValue",
         key.usr: "s:So11FooSubEnum1V8rawValues6UInt32Vvp",
-        key.offset: 8232,
+        key.offset: 8256,
         key.length: 20,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>rawValue</decl.name>: <decl.var.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.type></decl.var.instance>"
       },
@@ -7783,7 +7788,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "hashValue",
         key.usr: "s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::c:@E@FooSubEnum1",
         key.original_usr: "s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp",
-        key.offset: 8258,
+        key.offset: 8282,
         key.length: 37,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>hashValue</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -7792,7 +7797,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "hash(into:)",
         key.usr: "s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@E@FooSubEnum1",
         key.original_usr: "s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF",
-        key.offset: 8301,
+        key.offset: 8325,
         key.length: 47,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>hash</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>into</decl.var.parameter.argument_label> <decl.var.parameter.name>hasher</decl.var.parameter.name>: <syntaxtype.keyword>inout</syntaxtype.keyword> <decl.var.parameter.type><ref.struct usr=\"s:s6HasherV\">Hasher</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -7800,7 +7805,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "into",
             key.name: "hasher",
-            key.offset: 8341,
+            key.offset: 8365,
             key.length: 6
           }
         ]
@@ -7811,7 +7816,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@FooSubEnum1",
         key.original_usr: "s:SQsE2neoiySbx_xtFZ",
         key.doc.full_as_xml: "<Function><Name>!=(_:_:)</Name><USR>s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@FooSubEnum1</USR><Declaration>static func != (lhs: borrowing FooSubEnum1, rhs: borrowing FooSubEnum1) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value indicating whether two values are not equal.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A value to compare.</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>Another value to compare.</Para></Discussion></Parameter></Parameters><Discussion><Para>Inequality is the inverse of equality. For any values <codeVoice>a</codeVoice> and <codeVoice>b</codeVoice>, <codeVoice>a != b</codeVoice> implies that <codeVoice>a == b</codeVoice> is <codeVoice>false</codeVoice>.</Para><Para>This is the default implementation of the not-equal-to operator (<codeVoice>!=</codeVoice>) for any type that conforms to <codeVoice>Equatable</codeVoice>.</Para></Discussion></CommentParts></Function>",
-        key.offset: 8354,
+        key.offset: 8378,
         key.length: 83,
         key.fully_annotated_decl: "<decl.function.operator.infix><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@_preInverseGenerics</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>!= </decl.name>(<decl.var.parameter><decl.var.parameter.name>lhs</decl.var.parameter.name>: <syntaxtype.keyword>borrowing</syntaxtype.keyword> <decl.var.parameter.type><ref.struct usr=\"c:@E@FooSubEnum1\">FooSubEnum1</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>rhs</decl.var.parameter.name>: <syntaxtype.keyword>borrowing</syntaxtype.keyword> <decl.var.parameter.type><ref.struct usr=\"c:@E@FooSubEnum1\">FooSubEnum1</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.operator.infix>",
         key.entities: [
@@ -7819,14 +7824,14 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "lhs",
-            key.offset: 8387,
+            key.offset: 8411,
             key.length: 11
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "rhs",
-            key.offset: 8417,
+            key.offset: 8441,
             key.length: 11
           }
         ]
@@ -7838,7 +7843,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FooSubEnum1X",
     key.usr: "c:@E@FooSubEnum1@FooSubEnum1X",
-    key.offset: 8441,
+    key.offset: 8465,
     key.length: 37,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FooSubEnum1X</decl.name>: <decl.var.type><ref.struct usr=\"c:@E@FooSubEnum1\">FooSubEnum1</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>",
     key.modulename: "Foo.FooSub"
@@ -7847,7 +7852,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FooSubEnum1Y",
     key.usr: "c:@E@FooSubEnum1@FooSubEnum1Y",
-    key.offset: 8480,
+    key.offset: 8504,
     key.length: 37,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FooSubEnum1Y</decl.name>: <decl.var.type><ref.struct usr=\"c:@E@FooSubEnum1\">FooSubEnum1</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>",
     key.modulename: "Foo.FooSub"
@@ -7856,7 +7861,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FooSubUnnamedEnumeratorA1",
     key.usr: "c:@Ea@FooSubUnnamedEnumeratorA1@FooSubUnnamedEnumeratorA1",
-    key.offset: 8519,
+    key.offset: 8543,
     key.length: 42,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FooSubUnnamedEnumeratorA1</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>",
     key.modulename: "Foo.FooSub"


### PR DESCRIPTION
Change instances of `@_alwaysEmitIntoClient` to `@export(implementation)` in the standard library modules.
