### PR TITLE
CopyToBorrowOptimization: several improvements

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CopyToBorrowOptimization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CopyToBorrowOptimization.swift
@@ -41,10 +41,18 @@ import SIL
 /// The optimization can be done if:
 /// * In case of a `load`: during the (forward-extended) lifetime of the loaded value the
 ///                       memory location is not changed.
-/// * In case of a `copy_value`: the (guaranteed) lifetime of the source operand extends
+/// * In case of a `copy_value`: the lifetime of the source operand extends - or can be extended to -
 ///                       the lifetime of the copied value.
-/// * All (forward-extended) uses of the load or copy support guaranteed ownership.
+/// * All (forward-extended) uses of the load or copy support guaranteed ownership. This includes stores
+///     to stack locations which can be converted to `store_borrow`.
 /// * The (forward-extended) lifetime of the load or copy ends with `destroy_value`(s).
+///
+/// As an additional related optimization, "dead" `copy_value` instructions are removed:
+/// ```
+///   %2 = copy_value %1
+///   ...                // no deinit barriers here
+///   destroy_value %2   // the only use of %2
+/// ```
 ///
 let copyToBorrowOptimization = FunctionPass(name: "copy-to-borrow-optimization") {
   (function: Function, context: FunctionPassContext) in
@@ -58,11 +66,21 @@ let copyToBorrowOptimization = FunctionPass(name: "copy-to-borrow-optimization")
   for inst in function.instructions {
     switch inst {
     case let load as LoadInst:
+      if !context.continueWithNextSubpassRun(for: load) {
+        return
+      }
       if optimize(load: load, context) {
         changed = true
       }
     case let copy as CopyValueInst:
+      if !context.continueWithNextSubpassRun(for: copy) {
+        return
+      }
       if optimize(copy: copy, context) {
+        changed = true
+        break
+      }
+      if removeDead(copy: copy, context) {
         changed = true
       }
     default:
@@ -95,10 +113,6 @@ private func optimize(load: LoadInst, _ context: FunctionPassContext) -> Bool {
 }
 
 private func optimize(copy: CopyValueInst, _ context: FunctionPassContext) -> Bool {
-  if copy.fromValue.ownership != .guaranteed {
-    return false
-  }
-
   var collectedUses = Uses(context)
   defer { collectedUses.deinitialize() }
   if !collectedUses.collectUses(of: copy) {
@@ -109,11 +123,40 @@ private func optimize(copy: CopyValueInst, _ context: FunctionPassContext) -> Bo
   defer { liverange.deinitialize() }
   liverange.insert(contentsOf: collectedUses.destroys)
 
-  if !liverange.isFullyContainedIn(borrowScopeOf: copy.fromValue.lookThroughForwardingInstructions) {
-    return false
+  if copy.fromValue.ownership == .owned {
+    if !liverange.isFullyContainedIn(scopeOf: copy.fromValue) {
+      return false
+    }
+  } else {
+    guard extendBorrowScope(of: copy.fromValue, toOverlap: liverange, context) else {
+      return false
+    }
   }
 
   remove(copy: copy, collectedUses: collectedUses, liverange: liverange)
+  return true
+}
+
+/// Removes a `copy_value` if the result is only destroyed and there are not deinit-barriers
+/// between the copy and the `destroy_value`s.
+private func removeDead(copy: CopyValueInst, _ context: FunctionPassContext) -> Bool {
+  guard copy.uses.ignoreDebugUses.users.allSatisfy({ $0 is DestroyValueInst }) else {
+    return false
+  }
+  var worklist = InstructionWorklist(context)
+  defer { worklist.deinitialize() }
+
+  for user in copy.users {
+    worklist.pushPredecessors(of: user)
+  }
+  let calleeAnalysis = context.calleeAnalysis
+  while let inst = worklist.pop() {
+    if inst.isDeinitBarrier(calleeAnalysis) {
+      return false
+    }
+    worklist.pushPredecessors(of: inst, ignoring: copy)
+  }
+  context.erase(instructionIncludingAllUsers: copy)
   return true
 }
 
@@ -124,7 +167,7 @@ private struct Uses {
   private(set) var forwardingUses: Stack<Operand>
 
   // All destroys of the load/copy_value and its forwarded values.
-  private(set) var destroys: Stack<DestroyValueInst>
+  private(set) var destroys: Stack<Instruction>
 
   // Exit blocks of the load/copy_value's liverange which don't have a destroy.
   // Those are successor blocks of terminators, like `switch_enum`, which do _not_ forward the value.
@@ -144,7 +187,7 @@ private struct Uses {
 
     // If the load/copy_value is immediately followed by a single `move_value`, use the moved value.
     // Note that `move_value` is _not_ a forwarding instruction.
-    worklist.pushIfNotVisited(initialValue.singleMoveValueUser ?? initialValue)
+    worklist.pushIfNotVisited(initialValue)
 
     while let value = worklist.pop() {
       for use in value.uses.endingLifetime {
@@ -156,12 +199,60 @@ private struct Uses {
           forwardingUses.append(use)
           findNonDestroyingLiverangeExits(of: forwardingInst)
           worklist.pushIfNotVisited(contentsOf: forwardingInst.forwardedResults.lazy.filter { $0.ownership == .owned})
+
+        case let store as StoreInst:
+          assert(use == store.sourceOperand)
+          guard canConvertToStoreBorrow(store: store, destroys: &destroys, context) else {
+            return false
+          }
+          forwardingUses.append(use)
         default:
           return false
         }
       }
     }
     return true
+  }
+
+  func changeOwnedToGuaranteed(outerScope: Value) {
+    for forwardingUse in forwardingUses {
+      switch forwardingUse.instruction {
+      case let store as StoreInst:
+        changeStoreToStoreBorrow(store: store, outerScope: outerScope)
+      default:
+        forwardingUse.changeOwnership(from: .owned, to: .guaranteed, context)
+      }
+    }
+    context.erase(instructions: destroys)
+  }
+
+  private func changeStoreToStoreBorrow(store: StoreInst, outerScope: Value) {
+    let allocStack = store.destination
+    let builder = Builder(before: store, context)
+    let storeBorrow = builder.createStoreBorrow(source: store.source, destination: allocStack)
+
+    for use in allocStack.uses {
+      switch use.instruction {
+      case storeBorrow, is DeallocStackInst:
+        break
+      case let destroy as DestroyAddrInst:
+        if let prev = destroy.previous,
+           let endBorrow = prev as? EndBorrowInst,
+           endBorrow.borrow == outerScope
+        {
+          // If we already inserted new `end_borrow`s for an outer scope we need to make sure that the
+          // `end_borrow`s for the `store_borrow` (= an inner scope) are inserted before the `end_borrow`s
+          // of the outer scope.
+          Builder(before: endBorrow, context).createEndBorrow(of: storeBorrow)
+        } else {
+          Builder(before: destroy, context).createEndBorrow(of: storeBorrow)
+        }
+      default:
+        use.set(to: storeBorrow, context)
+      }
+    }
+    context.erase(instruction: store)
+
   }
 
   private mutating func findNonDestroyingLiverangeExits(of forwardingInst: ForwardingInstruction) {
@@ -186,9 +277,107 @@ private struct Uses {
   }
 }
 
+/// Checks if the `store` stores to an `alloc_stack` and that no other instructions (beside `destroy_addr`)
+/// modify the stack location.
+private func canConvertToStoreBorrow(store: StoreInst,
+                                     destroys: inout Stack<Instruction>,
+                                     _ context: FunctionPassContext) -> Bool
+{
+  guard store.storeOwnership == .initialize,
+        let allocStack = store.destination as? AllocStackInst
+  else {
+    return false
+  }
+
+  var walker = AllocStackUsesWalker(initialStore: store, context)
+  defer { walker.deinitialize() }
+  if walker.walkDownUses(ofAddress: allocStack, path: UnusedWalkingPath()) == .abortWalk {
+    return false
+  }
+
+  guard isDestroyedOnAllPaths(allocStack: allocStack, destroys: walker.destroys, context) else {
+    return false
+  }
+
+  destroys.append(contentsOf: walker.destroys)
+  return true
+}
+
+private func isDestroyedOnAllPaths(allocStack: AllocStackInst,
+                                   destroys: Stack<Instruction>,
+                                   _ context: FunctionPassContext) -> Bool
+{
+  if destroys.isEmpty {
+    return false
+  }
+  var liverange = BasicBlockRange(begin: allocStack.parentBlock, context)
+  defer { liverange.deinitialize() }
+  liverange.insert(contentsOf: destroys.lazy.map(\.parentBlock))
+  return liverange.exits.isEmpty
+}
+
+private struct AllocStackUsesWalker : AddressDefUseWalker {
+  let context: FunctionPassContext
+  let initialStore: StoreInst
+  var destroys: Stack<Instruction>
+
+  init(initialStore: StoreInst, _ context: FunctionPassContext) {
+    self.initialStore = initialStore
+    self.context = context
+    self.destroys = Stack(context)
+  }
+
+  mutating func deinitialize() {
+    self.destroys.deinitialize()
+  }
+
+  mutating func leafUse(address: Operand, path: UnusedWalkingPath) -> WalkResult {
+    switch address.instruction {
+    case let load as LoadInst:
+      if load.loadOwnership == .take {
+        return .abortWalk
+      }
+      return .continueWalk
+    case let store as StoreInst:
+      if store != initialStore {
+        return .abortWalk
+      }
+      return .continueWalk
+    case let copy as SourceDestAddrInstruction:
+      if address == copy.destinationOperand {
+        return .abortWalk
+      }
+      if address == copy.sourceOperand && copy.isTakeOfSource {
+        return .abortWalk
+      }
+      return .continueWalk
+    case let apply as ApplySite:
+      switch apply.convention(of: address) {
+      case .indirectInGuaranteed:
+        if let pa = apply as? PartialApplyInst, !pa.isOnStack {
+          return .abortWalk
+        }
+        return .continueWalk
+      default:
+        return .abortWalk
+      }
+    case let destroy as DestroyAddrInst:
+      if destroy.destroyedAddress == initialStore.destination {
+        destroys.append(destroy)
+        return .continueWalk
+      }
+      return .abortWalk
+    case is DeallocStackInst, is DebugValueInst:
+      return .continueWalk
+    default:
+      return .abortWalk
+    }
+  }
+}
+
 private func mayWrite(
   toAddressOf load: LoadInst,
-  within destroys: Stack<DestroyValueInst>,
+  within destroys: Stack<Instruction>,
   _ context: FunctionPassContext
 ) -> Bool {
   let aliasAnalysis = context.aliasAnalysis
@@ -218,64 +407,32 @@ private extension LoadInst {
     var liverange = InstructionRange(begin: self, ends: collectedUses.destroys, context)
     defer { liverange.deinitialize() }
 
-    replaceMoveWithBorrow(of: self, replacedBy: loadBorrow, liverange: liverange, collectedUses: collectedUses)
     createEndBorrows(for: loadBorrow, atEndOf: liverange, collectedUses: collectedUses)
 
     uses.replaceAll(with: loadBorrow, context)
     context.erase(instruction: self)
 
-    for forwardingUse in collectedUses.forwardingUses {
-      forwardingUse.changeOwnership(from: .owned, to: .guaranteed, context)
-    }
-    context.erase(instructions: collectedUses.destroys)
+    collectedUses.changeOwnedToGuaranteed(outerScope: loadBorrow)
   }
 }
 
 private func remove(copy: CopyValueInst, collectedUses: Uses, liverange: InstructionRange) {
   let context = collectedUses.context
-  replaceMoveWithBorrow(of: copy, replacedBy: copy.fromValue, liverange: liverange, collectedUses: collectedUses)
-  copy.replace(with: copy.fromValue, context)
+  let fromValue = copy.fromValue
 
-  for forwardingUse in collectedUses.forwardingUses {
-    forwardingUse.changeOwnership(from: .owned, to: .guaranteed, context)
+  switch fromValue.ownership {
+  case .owned:
+    let builder = Builder(before: copy, context)
+    let beginBorrow = builder.createBeginBorrow(of: fromValue)
+    copy.replace(with: beginBorrow, context)
+    createEndBorrows(for: beginBorrow, atEndOf: liverange, collectedUses: collectedUses)
+    collectedUses.changeOwnedToGuaranteed(outerScope: beginBorrow)
+  case .guaranteed:
+    copy.replace(with: fromValue, context)
+    collectedUses.changeOwnedToGuaranteed(outerScope: fromValue.lookThroughForwardingInstructions)
+  case .none, .unowned:
+    fatalError("unexpected ownership of copy source")
   }
-  context.erase(instructions: collectedUses.destroys)
-}
-
-// Handle the special case if the `load` or `copy_value` is immediately followed by a single `move_value`.
-// In this case we have to preserve the move's flags by inserting a `begin_borrow` with the same flags.
-// For example:
-//
-//   %1 = load [copy] %0
-//   %2 = move_value [lexical] %1
-//    ...
-//   destroy_value %2
-// ->
-//   %1 = load_borrow %0
-//   %2 = begin_borrow [lexical] %1
-//     ...
-//   end_borrow %2
-//   end_borrow %1
-//
-private func replaceMoveWithBorrow(
-  of value: Value,
-  replacedBy newValue: Value,
-  liverange: InstructionRange,
-  collectedUses: Uses
-) {
-  guard let moveInst = value.singleMoveValueUser else {
-    return
-  }
-  let context = collectedUses.context
-
-  // An inner borrow is needed to keep the flags of the `move_value`.
-  let builder = Builder(before: moveInst, context)
-  let bbi = builder.createBeginBorrow(of: newValue,
-                                      isLexical: moveInst.isLexical,
-                                      hasPointerEscape: moveInst.hasPointerEscape,
-                                      isFromVarDecl: moveInst.isFromVarDecl)
-  moveInst.replace(with: bbi, context)
-  createEndBorrows(for: bbi, atEndOf: liverange, collectedUses: collectedUses)
 }
 
 private func createEndBorrows(for beginBorrow: Value, atEndOf liverange: InstructionRange, collectedUses: Uses) {
@@ -302,51 +459,6 @@ private func createEndBorrows(for beginBorrow: Value, atEndOf liverange: Instruc
       let builder = Builder(before: endInst, context)
       builder.createEndBorrow(of: beginBorrow)
     }
-  }
-}
-
-private extension InstructionRange {
-  func isFullyContainedIn(borrowScopeOf value: Value) -> Bool {
-    guard let beginBorrow = BeginBorrowValue(value.lookThroughForwardingInstructions) else {
-      return false
-    }
-    if case .functionArgument = beginBorrow {
-      // The lifetime of a guaranteed function argument spans over the whole function.
-      return true
-    }
-    for endOp in beginBorrow.scopeEndingOperands {
-      if self.contains(endOp.instruction) {
-        return false
-      }
-    }
-    return true
-  }
-}
-
-private extension Value {
-  var singleMoveValueUser: MoveValueInst? {
-    uses.ignoreDebugUses.singleUse?.instruction as? MoveValueInst
-  }
-
-  var lookThroughForwardingInstructions: Value {
-    if let bfi = definingInstruction as? BorrowedFromInst,
-       !bfi.borrowedPhi.isReborrow,
-       bfi.enclosingValues.count == 1
-    {
-      // Return the single forwarded enclosingValue
-      return bfi.enclosingValues[0]
-    }
-    if let fi = definingInstruction as? ForwardingInstruction,
-       let forwardedOp = fi.singleForwardedOperand
-    {
-       return forwardedOp.value.lookThroughForwardingInstructions
-    } else if let termResult = TerminatorResult(self),
-              let fi = termResult.terminator as? ForwardingInstruction,
-              let forwardedOp = fi.singleForwardedOperand
-    {
-      return forwardedOp.value.lookThroughForwardingInstructions
-    }
-    return self
   }
 }
 

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/CMakeLists.txt
@@ -18,5 +18,6 @@ swift_compiler_sources(Optimizer
   LocalVariableUtils.swift
   OptUtils.swift
   OwnershipLiveness.swift
+  OwnershipUtilities.swift
   Test.swift
 )

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipUtilities.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipUtilities.swift
@@ -1,0 +1,225 @@
+//===--- OwnershipUtilities.swift -----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SIL
+
+extension InstructionRange {
+  /// Returns true if this instruction range is fully contained in the liverange of `value`.
+  public func isFullyContainedIn(scopeOf value: Value) -> Bool {
+    switch value.ownership {
+    case .owned:
+      return value.uses.endingLifetime.allSatisfy {
+        !self.contains($0.instruction)
+      }
+    case .guaranteed:
+      guard let beginBorrow = BeginBorrowValue(value.lookThroughForwardingInstructions) else {
+        return false
+      }
+      if case .functionArgument = beginBorrow {
+        // The lifetime of a guaranteed function argument spans over the whole function.
+        return true
+      }
+      return beginBorrow.scopeEndingOperands.allSatisfy {
+        !self.contains($0.instruction)
+      }
+    case .none, .unowned:
+      return false
+    }
+  }
+}
+
+/// Extends the borrow scope of a guaranteed `value` to ensure it overlaps with a given instruction range.
+///
+/// This function attempts to move `end_borrow` instructions that fall within the specified range
+/// to positions after the range ends, effectively extending the lifetime of the borrowed value
+/// to cover the entire range. This is useful for optimizations where a borrowed value needs
+/// to remain live throughout a specific code region.
+///
+/// Returns true if the borrow scope was successfully extended or already overlaps the range,
+/// returns false if the extension is not possible due to conflicting lifetime constraints.
+///
+func extendBorrowScope(of value: Value,
+                       toOverlap range: InstructionRange,
+                       _ context: FunctionPassContext) -> Bool
+{
+  guard let beginBorrow = BeginBorrowValue(value.lookThroughForwardingInstructions) else {
+    return false
+  }
+  if case .functionArgument = beginBorrow {
+    // The lifetime of a guaranteed function argument spans over the whole function.
+    return true
+  }
+
+  guard var endBorrowsToMove = getEndBorrows(of: beginBorrow, inRange: range, context) else {
+    return false
+  }
+  defer { endBorrowsToMove.deinitialize() }
+
+  if endBorrowsToMove.isEmpty {
+    // The borrow scope already completely overlaps the range. Nothing to do.
+    return true
+  }
+
+  var rangeEndInstructions = InstructionSet(context)
+  defer { rangeEndInstructions.deinitialize() }
+  rangeEndInstructions.insert(contentsOf: range.ends)
+  rangeEndInstructions.insert(contentsOf: range.exits)
+
+  var insertionPoints: Stack<Instruction>
+
+  switch beginBorrow {
+  case .beginBorrow(let bbi):
+    guard let ips = getInsertionPoints(for: bbi, endBorrowsToMove, rangeEndInstructions, context) else {
+      return false
+    }
+    insertionPoints = ips
+
+  case .loadBorrow(let loadBorrow):
+    guard let ips = getInsertionPoints(for: loadBorrow, endBorrowsToMove, rangeEndInstructions, context) else {
+      return false
+    }
+    insertionPoints = ips
+
+  default:
+    return false
+  }
+  defer { insertionPoints.deinitialize() }
+
+  // Move the `end_borrow`s out of the range.
+  //
+  context.erase(instructions: endBorrowsToMove)
+  for insertionPoint in insertionPoints {
+    Builder(before: insertionPoint, context).createEndBorrow(of: beginBorrow.value)
+  }
+  return true
+}
+
+private func getEndBorrows(of beginBorrow: BeginBorrowValue,
+                           inRange range: InstructionRange,
+                           _ context: FunctionPassContext) -> Stack<Instruction>?
+{
+  var endBorrowsToMove = Stack<Instruction>(context)
+
+  for scopeEndingOp in beginBorrow.scopeEndingOperands {
+    if range.contains(scopeEndingOp.instruction) {
+      guard let endBorrow = scopeEndingOp.instruction as? EndBorrowInst else {
+        endBorrowsToMove.deinitialize()
+        return nil
+      }
+      endBorrowsToMove.append(endBorrow)
+    }
+  }
+  return endBorrowsToMove
+}
+
+private func getInsertionPoints(for beginBorrow: BeginBorrowInst,
+                                _ endBorrowsToMove: Stack<Instruction>,
+                                _ rangeEndInstructions: InstructionSet,
+                                _ context: FunctionPassContext) -> Stack<Instruction>?
+{
+  var worklist = InstructionWorklist(context)
+  defer { worklist.deinitialize() }
+  worklist.pushIfNotVisited(contentsOf: endBorrowsToMove.map { $0.next! })
+
+  let enclosingValue = beginBorrow.borrowedValue
+  guard enclosingValue.ownership == .owned else {
+    return nil
+  }
+  var enclosingScopeEnds = InstructionSet(context)
+  defer { enclosingScopeEnds.deinitialize() }
+  enclosingScopeEnds.insert(contentsOf: enclosingValue.uses.endingLifetime.users)
+
+  var insertionPoints = Stack<Instruction>(context)
+
+  while let inst = worklist.pop() {
+    if rangeEndInstructions.contains(inst) {
+      insertionPoints.append(inst)
+    } else {
+      if enclosingScopeEnds.contains(inst) {
+        insertionPoints.deinitialize()
+        return nil
+      }
+      worklist.pushSuccessors(of: inst)
+    }
+  }
+  return insertionPoints
+}
+
+private func getInsertionPoints(for loadBorrow: LoadBorrowInst,
+                                _ endBorrowsToMove: Stack<Instruction>,
+                                _ rangeEndInstructions: InstructionSet,
+                                _ context: FunctionPassContext) -> Stack<Instruction>?
+{
+  var worklist = InstructionWorklist(context)
+  defer { worklist.deinitialize() }
+  worklist.pushIfNotVisited(contentsOf: endBorrowsToMove.map { $0.next! })
+
+  let aliasAnalysis = context.aliasAnalysis
+  var insertionPoints = Stack<Instruction>(context)
+
+  while let inst = worklist.pop() {
+    if rangeEndInstructions.contains(inst) {
+      insertionPoints.append(inst)
+    } else {
+      if inst.mayWrite(toAddress: loadBorrow.address, aliasAnalysis) {
+        insertionPoints.deinitialize()
+        return nil
+      }
+      worklist.pushSuccessors(of: inst)
+    }
+  }
+  return insertionPoints
+}
+
+extension Value {
+  /// Looks through forwarding instructions in the use-def chain and returns the original forwarded value.
+  /// It looks through phi-arguments, terminator instructions and all kind of forwarding instructions
+  /// which forward exactly one (non-trivial) operand.
+  public var lookThroughForwardingInstructions: Value {
+    if let bfi = definingInstruction as? BorrowedFromInst,
+       !bfi.borrowedPhi.isReborrow,
+       bfi.enclosingValues.count == 1
+    {
+      // Return the single forwarded enclosingValue
+      return bfi.enclosingValues[0]
+    }
+    if let fi = definingInstruction as? ForwardingInstruction,
+       let forwardedOp = fi.singleForwardedOperand
+    {
+       return forwardedOp.value.lookThroughForwardingInstructions
+    } else if let termResult = TerminatorResult(self),
+              let fi = termResult.terminator as? ForwardingInstruction,
+              let forwardedOp = fi.singleForwardedOperand
+    {
+      return forwardedOp.value.lookThroughForwardingInstructions
+    }
+    return self
+  }
+}
+
+//===----------------------------------------------------------------------===//
+//                               Unit Tests
+//===----------------------------------------------------------------------===//
+
+let extendBorrowScopeTest = FunctionTest("extend_borrow_scope") {
+    function, arguments, context in
+
+  let borrowValue = arguments.takeValue()
+  let rangeBegin = arguments.takeValue() as! SingleValueInstruction
+  let expectedResult = arguments.takeBool()
+
+  var range = InstructionRange(begin: rangeBegin, ends: rangeBegin.users, context)
+  defer { range.deinitialize() }
+
+  let result = extendBorrowScope(of: borrowValue, toOverlap: range, context)
+  precondition(result == expectedResult)
+}

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/Test.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/Test.swift
@@ -56,6 +56,7 @@ public func registerOptimizerTests() {
     argumentConventionsTest,
     breakInfiniteLoopsTest,
     domtreeTest,
+    extendBorrowScopeTest,
     getAutoDiffSpecializationInfoTest,
     interiorLivenessTest,
     lifetimeComletionTest,

--- a/test/SILOptimizer/copy-to-borrow-optimization.sil
+++ b/test/SILOptimizer/copy-to-borrow-optimization.sil
@@ -50,6 +50,10 @@ final class Klass {
 
 class C {}
 
+struct S {
+  let c: C
+}
+
 class Base {
   @_hasStorage var c: C
 }
@@ -1647,34 +1651,6 @@ bb3:
  unreachable
 }
 
-// CHECK-LABEL: sil [ossa] @promote_moved_from_load_copy : {{.*}} {
-// CHECK:         [[ADDR:%[^,]+]] = alloc_stack $C
-// CHECK:         [[GET_C:%[^,]+]] = function_ref @getC
-// CHECK:         [[STORED:%[^,]+]] = apply [[GET_C]]()
-// CHECK:         store [[STORED]] to [init] [[ADDR]]
-// CHECK:         [[LOADED:%[^,]+]] = load_borrow [[ADDR]]
-// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[LOADED]]
-// CHECK:         end_borrow [[LIFETIME]]
-// CHECK:         end_borrow [[LOADED]]
-// CHECK:         destroy_addr [[ADDR]]
-// CHECK:         dealloc_stack [[ADDR]]
-// CHECK-LABEL: } // end sil function 'promote_moved_from_load_copy'
-sil [ossa] @promote_moved_from_load_copy : $@convention(thin) () -> () {
-bb0:
-  %addr = alloc_stack $C
-  %getC = function_ref @getC : $@convention(thin) () -> (@owned C)
-  %stored = apply %getC() : $@convention(thin) () -> (@owned C)
-  store %stored to [init] %addr : $*C
-  %loaded = load [copy] %addr : $*C
-  debug_value %loaded : $C, let, name "x"
-  %lifetime = move_value [lexical] %loaded : $C
-  destroy_value %lifetime : $C
-  destroy_addr %addr : $*C
-  dealloc_stack %addr : $*C
-  %retval = tuple ()
-  return %retval : $()
-}
-
 // CHECK-LABEL: sil [ossa] @dont_promote_moved_from_load_copy_with_destroy_addr_above_range : {{.*}} {
 // CHECK:         load [copy]
 // CHECK-LABEL: } // end sil function 'dont_promote_moved_from_load_copy_with_destroy_addr_above_range'
@@ -2084,6 +2060,43 @@ bb0(%0 : @guaranteed $NonTrivialStruct):
   return %5
 }
 
+// CHECK-LABEL: sil [ossa] @remove_copy_of_owned_arg :
+// CHECK:         %1 = begin_borrow %0
+// CHECK:         %2 = destructure_struct %1
+// CHECK:         end_borrow %1
+// CHECK-NEXT:    destroy_value %0
+// CHECK-NEXT:    return
+// CHECK:       } // end sil function 'remove_copy_of_owned_arg'
+sil [ossa] @remove_copy_of_owned_arg : $@convention(thin) (@owned NonTrivialStruct) -> @owned Klass {
+bb0(%0 : @owned $NonTrivialStruct):
+  %1 = copy_value %0
+  %2 = destructure_struct %1
+  %3 = begin_borrow %2
+  %4 = ref_element_addr %3, #Klass.base
+  %5 = load [copy] %4 : $*Klass
+  end_borrow %3
+  destroy_value %2
+  destroy_value %0
+  return %5
+}
+
+// CHECK-LABEL: sil [ossa] @dont_remove_copy_of_owned_arg_with_too_short_liverange :
+// CHECK:         %1 = copy_value %0
+// CHECK:         %2 = destructure_struct %1
+// CHECK:       } // end sil function 'dont_remove_copy_of_owned_arg_with_too_short_liverange'
+sil [ossa] @dont_remove_copy_of_owned_arg_with_too_short_liverange : $@convention(thin) (@owned NonTrivialStruct) -> @owned Klass {
+bb0(%0 : @owned $NonTrivialStruct):
+  %1 = copy_value %0
+  %2 = destructure_struct %1
+  %3 = begin_borrow %2
+  %4 = ref_element_addr %3, #Klass.base
+  destroy_value %0
+  %5 = load [copy] %4 : $*Klass
+  end_borrow %3
+  destroy_value %2
+  return %5
+}
+
 // CHECK-LABEL: sil [ossa] @remove_copy_of_borrow :
 // CHECK:         %3 = apply %2(%1)
 // CHECK-NOT:     destroy_value
@@ -2099,10 +2112,11 @@ bb0(%0 : @owned $Klass):
   return %0
 }
 
-// CHECK-LABEL: sil [ossa] @dont_remove_copy_of_borrow :
-// CHECK:         %2 = copy_value %1
-// CHECK:       } // end sil function 'dont_remove_copy_of_borrow'
-sil [ossa] @dont_remove_copy_of_borrow : $@convention(thin) (@owned Klass) -> @owned Klass {
+// CHECK-LABEL: sil [ossa] @extend_outer_scope :
+// CHECK:         %3 = apply %2(%1)
+// CHECK-NEXT:    end_borrow %1
+// CHECK:       } // end sil function 'extend_outer_scope'
+sil [ossa] @extend_outer_scope : $@convention(thin) (@owned Klass) -> @owned Klass {
 bb0(%0 : @owned $Klass):
   %1 = begin_borrow %0
   %2 = copy_value %1
@@ -2110,6 +2124,24 @@ bb0(%0 : @owned $Klass):
   end_borrow %1
   %4 = apply %3(%2) : $@convention(thin) (@guaranteed Klass) -> ()
   destroy_value %2
+  return %0
+}
+
+// CHECK-LABEL: sil [ossa] @extend_forwarded_outer_scope :
+// CHECK-NOT:     copy_value
+// CHECK:         store_borrow
+// CHECK:       } // end sil function 'extend_forwarded_outer_scope'
+sil [ossa] @extend_forwarded_outer_scope : $@convention(thin) (@owned S) -> @owned S {
+bb0(%0 : @owned $S):
+  %1 = begin_borrow %0
+  %2 = struct_extract %1, #S.c
+  %3 = copy_value %2
+  %4 = alloc_stack $C
+  store %3 to [init] %4
+  %6 = apply undef(%4) : $@convention(thin) (@in_guaranteed C) -> ()
+  end_borrow %1
+  destroy_addr %4
+  dealloc_stack %4
   return %0
 }
 
@@ -2137,7 +2169,9 @@ bb3:
 }
 
 // CHECK-LABEL: sil [ossa] @user_in_dead_end_block :
-// CHECK:         %2 = copy_value %1
+// CHECK:         %3 = apply %2(%1)
+// CHECK-NEXT:    end_borrow %1
+// CHECK-NEXT:    destroy_value [dead_end] %0
 // CHECK:       } // end sil function 'user_in_dead_end_block'
 sil [ossa] @user_in_dead_end_block : $@convention(thin) (@owned Klass) -> @owned Klass {
 bb0(%0 : @owned $Klass):
@@ -2153,19 +2187,15 @@ bb0(%0 : @owned $Klass):
 
 // CHECK-LABEL: sil [ossa] @end_borrows_in_liferange_exit_block :
 // CHECK:         %1 = load_borrow %0
-// CHECK:         %2 = begin_borrow [lexical] %1
 // CHECK:       bb1({{.*}} : @guaranteed $C):
-// CHECK-NEXT:    end_borrow %2
 // CHECK-NEXT:    end_borrow %1
 // CHECK:       bb2:
-// CHECK-NEXT:    end_borrow %2
 // CHECK-NEXT:    end_borrow %1
 // CHECK:       } // end sil function 'end_borrows_in_liferange_exit_block'
 sil [ossa] @end_borrows_in_liferange_exit_block : $@convention(thin) (@in_guaranteed Optional<C>) -> () {
 bb0(%0 : $*Optional<C>):
   %1 = load [copy] %0
-  %2 = move_value [lexical] %1
-  switch_enum %2, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
+  switch_enum %1, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
 
 bb1(%4 : @owned $C):
   destroy_value %4
@@ -2342,3 +2372,171 @@ bb0(%0 : @guaranteed $Outer):
   %ret = tuple ()
   return %ret : $()
 }
+
+// CHECK-LABEL: sil [ossa] @store_to_store_borrow :
+// CHECK:         %2 = alloc_stack $C
+// CHECK-NEXT:    %3 = store_borrow %0 to %2
+// CHECK-NEXT:    apply undef(%3)
+// CHECK-NEXT:    load [copy] %3
+// CHECK-NEXT:    copy_addr %3 to %1
+// CHECK-NEXT:    debug_value %3
+// CHECK-NEXT:    end_borrow %3
+// CHECK-NEXT:    dealloc_stack %2
+// CHECK-LABEL: } // end sil function 'store_to_store_borrow'
+sil [ossa] @store_to_store_borrow : $@convention(thin) (@guaranteed C, @inout C) -> @owned C {
+bb0(%0 : @guaranteed $C, %1 : $*C):
+  %2 = copy_value %0
+  %3 = alloc_stack $C
+  store %2 to [init] %3
+  %4 = apply undef(%3) : $@convention(thin) (@in_guaranteed C) -> ()
+  %5 = load [copy] %3
+  copy_addr %3 to %1
+  debug_value %3
+  destroy_addr %3
+  dealloc_stack %3
+  return %5
+}
+
+// CHECK-LABEL: sil [ossa] @store_to_store_borrow_with_borrow_scope :
+// CHECK:         %2 = alloc_stack $C
+// CHECK-NEXT:    %3 = store_borrow %1 to %2
+// CHECK-NEXT:    apply undef(%3)
+// CHECK-NEXT:    end_borrow %3
+// CHECK-NEXT:    dealloc_stack %2
+// CHECK-LABEL: } // end sil function 'store_to_store_borrow_with_borrow_scope'
+sil [ossa] @store_to_store_borrow_with_borrow_scope : $@convention(thin) (@owned C) -> @owned C {
+bb0(%0 : @owned $C):
+  %1 = begin_borrow %0
+  %2 = copy_value %1
+  %3 = alloc_stack $C
+  store %2 to [init] %3
+  %4 = apply undef(%3) : $@convention(thin) (@in_guaranteed C) -> ()
+  destroy_addr %3
+  dealloc_stack %3
+  end_borrow %1
+  return %0
+}
+
+// CHECK-LABEL: sil [ossa] @store_to_store_borrow_extend_scope :
+// CHECK:         %1 = begin_borrow %0
+// CHECK:         %2 = alloc_stack $C
+// CHECK:         %3 = store_borrow %1 to %2
+// CHECK:         %4 = apply undef(%3)
+// CHECK-NEXT:    end_borrow %3
+// CHECK-NEXT:    end_borrow %1
+// CHECK-LABEL: } // end sil function 'store_to_store_borrow_extend_scope'
+sil [ossa] @store_to_store_borrow_extend_scope : $@convention(thin) (@owned C) -> @owned C {
+bb0(%0 : @owned $C):
+  %1 = begin_borrow %0
+  %2 = copy_value %1
+  %3 = alloc_stack $C
+  store %2 to [init] %3
+  %4 = apply undef(%3) : $@convention(thin) (@in_guaranteed C) -> ()
+  end_borrow %1
+  destroy_addr %3
+  dealloc_stack %3
+  return %0
+}
+
+// CHECK-LABEL: sil [ossa] @store_to_store_borrow_right_scope :
+// CHECK-NOT:     copy_value
+// CHECK:         store_borrow
+// CHECK-LABEL: } // end sil function 'store_to_store_borrow_right_scope'
+sil [ossa] @store_to_store_borrow_right_scope : $@convention(thin) (@owned C) -> @owned C {
+bb0(%0 : @owned $C):
+  %1 = begin_borrow %0
+  %2 = copy_value %1
+  %3 = alloc_stack $C
+  store %2 to [init] %3
+  %4 = apply undef(%3) : $@convention(thin) (@in_guaranteed C) -> ()
+  destroy_addr %3
+  end_borrow %1
+  dealloc_stack %3
+  return %0
+}
+
+// CHECK-LABEL: sil [ossa] @store_to_store_borrow_two_destroys :
+// CHECK:         copy_value
+// CHECK-LABEL: } // end sil function 'store_to_store_borrow_two_destroys'
+sil [ossa] @store_to_store_borrow_two_destroys : $@convention(thin) (@owned NativeObjectPair) -> @owned NativeObjectPair {
+bb0(%0 : @owned $NativeObjectPair):
+  %1 = begin_borrow %0
+  %2 = copy_value %1
+  %3 = alloc_stack $NativeObjectPair
+  store %2 to [init] %3
+  %4 = apply undef(%3) : $@convention(thin) (@in_guaranteed NativeObjectPair) -> ()
+  %5 = struct_element_addr %3, #NativeObjectPair.obj1
+  destroy_addr %5
+  end_borrow %1
+  %7 = struct_element_addr %3, #NativeObjectPair.obj2
+  destroy_addr %7
+  dealloc_stack %3
+  return %0
+}
+
+// CHECK-LABEL: sil [ossa] @store_to_store_borrow_double_destroy :
+// CHECK:         copy_value
+// CHECK-LABEL: } // end sil function 'store_to_store_borrow_double_destroy'
+sil [ossa] @store_to_store_borrow_double_destroy : $@convention(thin) (@guaranteed C, @inout C) -> () {
+bb0(%0 : @guaranteed $C, %1 : $*C):
+  %2 = copy_value %0
+  %3 = alloc_stack $C
+  store %2 to [init] %3
+  %4 = apply undef(%3) : $@convention(thin) (@in C) -> ()
+  copy_addr %1 to [init] %3
+  destroy_addr %3
+  dealloc_stack %3
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @copy_of_owned_and_store_borrow :
+// CHECK-NOT:     copy_value
+// CHECK:         store_borrow
+// CHECK-LABEL: } // end sil function 'copy_of_owned_and_store_borrow'
+sil [ossa] @copy_of_owned_and_store_borrow : $@convention(thin) (@owned C) -> @owned C {
+bb0(%0 : @owned $C):
+  %1 = copy_value %0
+  %2 = alloc_stack $C
+  store %1 to [init] %2
+  %4 = apply undef(%2) : $@convention(thin) (@in_guaranteed C) -> ()
+  destroy_addr %2
+  dealloc_stack %2
+  return %0
+}
+
+// CHECK-LABEL: sil [ossa] @missing_destroys_of_copy_to_store :
+// We don't optimize this, yet
+// Check that it does not produce SIL with wrong ownership
+// CHECK-LABEL: } // end sil function 'missing_destroys_of_copy_to_store'
+sil [ossa] @missing_destroys_of_copy_to_store : $@convention(thin) (@owned C) -> @owned C {
+bb0(%0 : @owned $C):
+  %1 = copy_value %0
+  %2 = alloc_stack $C
+  store %1 to [init] %2
+  cond_br undef, bb1, bb2
+
+bb1:
+  %4 = apply undef(%2) : $@convention(thin) (@in_guaranteed C) -> ()
+  destroy_addr %2
+  dealloc_stack %2
+  return %0
+
+bb2:
+  destroy_value [dead_end] %0
+  unreachable
+}
+
+// CHECK-LABEL: sil [ossa] @missing_destroys_of_copy_to_store2 :
+// We don't optimize this, yet
+// Check that it does not produce SIL with wrong ownership
+// CHECK-LABEL: } // end sil function 'missing_destroys_of_copy_to_store2'
+sil [ossa] @missing_destroys_of_copy_to_store2 : $@convention(thin) (@owned C) -> @owned C {
+bb0(%0 : @owned $C):
+  %1 = copy_value %0
+  %2 = alloc_stack $C
+  store %1 to [init] %2
+  destroy_value [dead_end] %0
+  unreachable
+}
+

--- a/test/SILOptimizer/ownership-utils-unit.sil
+++ b/test/SILOptimizer/ownership-utils-unit.sil
@@ -1,10 +1,14 @@
-// RUN: %target-sil-opt -test-runner %s -o /dev/null 2>&1 | %FileCheck %s
+// RUN: %target-sil-opt -test-runner %s | %FileCheck %s
 
 sil_stage canonical
 
 import Builtin
 
 class C {}
+
+struct S {
+  let c: C
+}
 
 enum FakeOptional<T> {
 case none
@@ -71,3 +75,223 @@ exit:
   %retval = tuple ()
   return %retval : $()
 }
+
+sil @make_c : $@convention(thin) (@guaranteed C) -> @owned C
+
+sil @write_to_addr : $@convention(thin) (@inout C) -> ()
+
+// CHECK-LABEL: sil [ossa] @extend_begin_borrow :
+// CHECK:         %1 = begin_borrow %0
+// CHECK:         %3 = apply
+// CHECK:         %4 = tuple ()
+// CHECK-NEXT:    end_borrow %1
+// CHECK-NEXT:    destroy_value %3
+// CHECK:       } // end sil function 'extend_begin_borrow'
+sil [ossa] @extend_begin_borrow : $@convention(thin) (@owned C) -> () {
+bb0(%0 : @owned $C):
+  specify_test "extend_borrow_scope %1 %3 true"
+  %1 = begin_borrow %0
+  %2 = function_ref @make_c : $@convention(thin) (@guaranteed C) -> @owned C
+  %3 = apply %2(%1) : $@convention(thin) (@guaranteed C) -> @owned C
+  end_borrow %1
+  %4 = tuple ()
+  destroy_value %3
+  destroy_value %0
+  return %4
+}
+
+// CHECK-LABEL: sil [ossa] @no_extend_needed :
+// CHECK:         destroy_value %3
+// CHECK-NEXT:    end_borrow %1
+// CHECK:       } // end sil function 'no_extend_needed'
+sil [ossa] @no_extend_needed : $@convention(thin) (@owned C) -> () {
+bb0(%0 : @owned $C):
+  specify_test "extend_borrow_scope %1 %3 true"
+  %1 = begin_borrow %0
+  %2 = function_ref @make_c : $@convention(thin) (@guaranteed C) -> @owned C
+  %3 = apply %2(%1) : $@convention(thin) (@guaranteed C) -> @owned C
+  destroy_value %3
+  end_borrow %1
+  destroy_value %0
+  %4 = tuple ()
+  return %4
+}
+
+// CHECK-LABEL: sil [ossa] @extend_begin_borrow_fail :
+// CHECK:         end_borrow %1
+// CHECK-NEXT:    destroy_value %0
+// CHECK-NEXT:    destroy_value %3
+// CHECK:       } // end sil function 'extend_begin_borrow_fail'
+sil [ossa] @extend_begin_borrow_fail : $@convention(thin) (@owned C) -> () {
+bb0(%0 : @owned $C):
+  specify_test "extend_borrow_scope %1 %3 false"
+  %1 = begin_borrow %0
+  %2 = function_ref @make_c : $@convention(thin) (@guaranteed C) -> @owned C
+  %3 = apply %2(%1) : $@convention(thin) (@guaranteed C) -> @owned C
+  end_borrow %1
+  destroy_value %0
+  destroy_value %3
+  %4 = tuple ()
+  return %4
+}
+
+// CHECK-LABEL: sil [ossa] @extend_function_arg :
+// CHECK:       } // end sil function 'extend_function_arg'
+sil [ossa] @extend_function_arg : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  specify_test "extend_borrow_scope %0 %2 true"
+  %1 = function_ref @make_c : $@convention(thin) (@guaranteed C) -> @owned C
+  %2 = apply %1(%0) : $@convention(thin) (@guaranteed C) -> @owned C
+  destroy_value %2
+  %3 = tuple ()
+  return %3
+}
+
+// CHECK-LABEL: sil [ossa] @extend_load_borrow :
+// CHECK:         %1 = load_borrow %0
+// CHECK:         %3 = apply
+// CHECK:         %4 = tuple ()
+// CHECK-NEXT:    end_borrow %1
+// CHECK-NEXT:    destroy_value %3
+// CHECK:       } // end sil function 'extend_load_borrow'
+sil [ossa] @extend_load_borrow : $@convention(thin) (@in_guaranteed C) -> () {
+bb0(%0 : $*C):
+  specify_test "extend_borrow_scope %1 %3 true"
+  %1 = load_borrow %0
+  %2 = function_ref @make_c : $@convention(thin) (@guaranteed C) -> @owned C
+  %3 = apply %2(%1) : $@convention(thin) (@guaranteed C) -> @owned C
+  end_borrow %1
+  %4 = tuple ()
+  destroy_value %3
+  return %4
+}
+
+// CHECK-LABEL: sil [ossa] @extend_load_borrow_fail :
+// CHECK:         apply 
+// CHECK-NEXT:    end_borrow %1
+// CHECK:       } // end sil function 'extend_load_borrow_fail'
+sil [ossa] @extend_load_borrow_fail : $@convention(thin) (@inout C) -> () {
+bb0(%0 : $*C):
+  specify_test "extend_borrow_scope %1 %3 false"
+  %1 = load_borrow %0
+  %2 = function_ref @make_c : $@convention(thin) (@guaranteed C) -> @owned C
+  %3 = apply %2(%1) : $@convention(thin) (@guaranteed C) -> @owned C
+  end_borrow %1
+  %4 = function_ref @write_to_addr : $@convention(thin) (@inout C) -> ()
+  apply %4(%0) : $@convention(thin) (@inout C) -> ()
+  destroy_value %3
+  %5 = tuple ()
+  return %5
+}
+
+// CHECK-LABEL: sil [ossa] @dont_extend_nested_borrow_scopes :
+// CHECK:       } // end sil function 'dont_extend_nested_borrow_scopes'
+sil [ossa] @dont_extend_nested_borrow_scopes : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  specify_test "extend_borrow_scope %3 %5 false"
+  %1 = begin_borrow %0
+  %2 = struct $S (%1)
+  %3 = begin_borrow %2
+  %5 = apply undef(%3) : $@convention(thin) (@guaranteed S) -> @owned C
+  end_borrow %3
+  end_borrow %1
+  %7 = tuple ()
+  destroy_value %5
+  return %7
+}
+
+// CHECK-LABEL: sil [ossa] @extend_begin_borrow_multi_block1 :
+// CHECK:       bb1:
+// CHECK-NEXT:    debug_step
+// CHECK-NEXT:    end_borrow %1
+// CHECK-NEXT:    destroy_value %3
+// CHECK:       bb2:
+// CHECK-NEXT:    destroy_value %3
+// CHECK-NEXT:    end_borrow %1
+// CHECK:       } // end sil function 'extend_begin_borrow_multi_block1'
+sil [ossa] @extend_begin_borrow_multi_block1 : $@convention(thin) (@owned C) -> () {
+bb0(%0 : @owned $C):
+  specify_test "extend_borrow_scope %1 %3 true"
+  %1 = begin_borrow %0
+  %2 = function_ref @make_c : $@convention(thin) (@guaranteed C) -> @owned C
+  %3 = apply %2(%1) : $@convention(thin) (@guaranteed C) -> @owned C
+  cond_br undef, bb1, bb2
+
+bb1:
+  end_borrow %1
+  debug_step
+  destroy_value %3
+  br bb3
+
+bb2:
+  destroy_value %3
+  end_borrow %1
+  br bb3
+
+bb3:
+  destroy_value %0
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @extend_begin_borrow_multi_block2 :
+// CHECK:       bb1:
+// CHECK-NEXT:    debug_step
+// CHECK-NEXT:    end_borrow %1
+// CHECK-NEXT:    destroy_value %3
+// CHECK:       bb2:
+// CHECK-NEXT:    end_borrow %1
+// CHECK-NEXT:    destroy_value %3
+// CHECK:       } // end sil function 'extend_begin_borrow_multi_block2'
+sil [ossa] @extend_begin_borrow_multi_block2 : $@convention(thin) (@owned C) -> () {
+bb0(%0 : @owned $C):
+  specify_test "extend_borrow_scope %1 %3 true"
+  %1 = begin_borrow %0
+  %2 = function_ref @make_c : $@convention(thin) (@guaranteed C) -> @owned C
+  %3 = apply %2(%1) : $@convention(thin) (@guaranteed C) -> @owned C
+  end_borrow %1
+  cond_br undef, bb1, bb2
+
+bb1:
+  debug_step
+  destroy_value %3
+  br bb3
+
+bb2:
+  destroy_value %3
+  br bb3
+
+bb3:
+  destroy_value %0
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @extend_begin_borrow_multi_block_with_liverange_exit :
+// CHECK:       bb1:
+// CHECK-NEXT:    end_borrow %1
+// CHECK-NEXT:    fix_lifetime %2
+// CHECK:       bb2:
+// CHECK-NEXT:    end_borrow %1
+// CHECK:       } // end sil function 'extend_begin_borrow_multi_block_with_liverange_exit'
+sil [ossa] @extend_begin_borrow_multi_block_with_liverange_exit : $@convention(thin) (@owned C) -> () {
+bb0(%0 : @owned $C):
+  specify_test "extend_borrow_scope %1 %2 true"
+  %1 = begin_borrow %0
+  %2 = integer_literal $Builtin.Int32, 0
+  end_borrow %1
+  cond_br undef, bb1, bb2
+
+bb1:
+  fix_lifetime %2
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  destroy_value %0
+  %r = tuple ()
+  return %r
+}
+


### PR DESCRIPTION
* support `copy_value` with "owned" source operands
* try to extend borrow scopes if necessary to do the optimization
* try to convert `store` to `store_borrow`
* add a peephole to remove "dead" `copy_value` instructions
* support sub-pass bisecting

Fixes a regression in the KeyPathsSmallStruct benchmark
rdar://177347578