### PR TITLE
[Sema] Fix 'failed to produce diagnostic' for void function returning array literal member

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -15830,6 +15830,9 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
     if (fix->getKind() == FixKind::IgnoreCollectionElementContextualMismatch) {
       if (type2->isAny() || type2->isAnyHashable())
         ++impact;
+
+      if (simplifyType(type2)->isVoid())
+        impact += 4;
     }
 
     if (recordFix(fix, impact))

--- a/test/Constraints/void_return_array_literal.swift
+++ b/test/Constraints/void_return_array_literal.swift
@@ -1,0 +1,23 @@
+// RUN: %target-typecheck-verify-swift
+
+func voidReturnRandomElement() {
+  return [1, 2, 3].randomElement()! // expected-error {{unexpected non-void return value in void function}}
+  // expected-note@-1 {{did you mean to add a return type?}}
+}
+
+func voidReturnFirst() {
+  return [1, 2, 3].first! // expected-error {{unexpected non-void return value in void function}}
+  // expected-note@-1 {{did you mean to add a return type?}}
+}
+
+func voidReturnLast() {
+  return [1, 2, 3].last! // expected-error {{unexpected non-void return value in void function}}
+  // expected-note@-1 {{did you mean to add a return type?}}
+}
+
+// Typed variable should still work (was never broken).
+func voidReturnTypedVariable() {
+  let a: [Int] = [1, 2, 3]
+  return a.randomElement()! // expected-error {{unexpected non-void return value in void function}}
+  // expected-note@-1 {{did you mean to add a return type?}}
+}


### PR DESCRIPTION
When a void function contains `return [1,2,3].randomElement()!`, the constraint solver produced two solutions with equal fix scores, causing diagnoseAmbiguityWithFixes to fail and fall back to the generic "failed to produce diagnostic" error.

the fix is in simplifyFixConstraint, sum the impact of IgnoreCollectionElementContextualMismatch by 4 when the contextual element type (type2) is Void. This makes the first solution score 5 while second solution score of 1, so findBestSolution picks second solution and the compiler emits "unexpected non-void return value in void function" which would make more sense for in this code context.


Filled bug: https://github.com/swiftlang/swift/issues/90250
