### PR TITLE
[cxx-interop][test][android] Disable FRT sequence tests on Android armv7

### DIFF
--- a/test/Interop/Cxx/class/method/unsafe-ref-sequence-typechecker.swift
+++ b/test/Interop/Cxx/class/method/unsafe-ref-sequence-typechecker.swift
@@ -4,6 +4,8 @@
 // RUN:   -I %t/Inputs %t/test.swift \
 // RUN:   -cxx-interoperability-mode=default
 
+// XFAIL: OS=linux-androideabi
+
 //--- Inputs/module.modulemap
 module UnsafeRefContainer {
   header "unsafe-ref-container.h"

--- a/test/Interop/Cxx/foreign-reference/frt-sequence-typechecker.swift
+++ b/test/Interop/Cxx/foreign-reference/frt-sequence-typechecker.swift
@@ -2,6 +2,8 @@
 // RUN:   -I %S/Inputs -cxx-interoperability-mode=default \
 // RUN:   -disable-availability-checking -disable-typo-correction
 
+// XFAIL: OS=linux-androideabi
+
 import FrtSequence
 import CxxStdlib
 


### PR DESCRIPTION
These tests depend on std::vector<FRT*> conforming to CxxRandomAccessCollection, which isn't kicking in for some reason.

Supersedes #90323 (disables some additional tests)