### PR TITLE
[cmake][shared-build] Add build dependency on libc++ from stdlib

### DIFF
--- a/stdlib/public/Cxx/std/CMakeLists.txt
+++ b/stdlib/public/Cxx/std/CMakeLists.txt
@@ -28,6 +28,17 @@ if(NOT DEFINED SWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT OR NOT SWIFT_BUILD_
   set(swift_cxxstdlib_dependencies _Builtin_float)
 endif()
 
+# If we have a shared build folder, we need to depend on libc++
+# generation to be able to build the libc++ module.
+#
+# libc++ is built via LLVM_ENABLE_RUNTIMES, i.e. in a nested CMake sub-build, so
+# its own `cxx` target is never visible in this scope. Mirror what
+# lldb/test/CMakeLists.txt does and depend on the top-level `runtimes` instead.
+set(_cxxstdlib_extra_deps "")
+if(LLVM_ENABLE_RUNTIMES AND "libcxx" IN_LIST LLVM_ENABLE_RUNTIMES)
+  list(APPEND _cxxstdlib_extra_deps runtimes)
+endif()
+
 #
 # C++ Standard Library Overlay.
 #
@@ -73,4 +84,4 @@ add_swift_target_library(swiftCxxStdlib STATIC NO_LINK_NAME IS_STDLIB IS_SWIFT_O
     INSTALL_IN_COMPONENT compiler
     INSTALL_BINARY_SWIFTMODULE NON_DARWIN_ONLY
     INSTALL_WITH_SHARED
-    DEPENDS libstdcxx-modulemap libcxxshim_modulemap CxxStdlib-apinotes)
+    DEPENDS libstdcxx-modulemap libcxxshim_modulemap CxxStdlib-apinotes ${_cxxstdlib_extra_deps})


### PR DESCRIPTION
When building in a shared build folder, the libc++ module needs to be available for building the C++ overlay in Swift. This patch just adds a dependency on runtimes (which builds libc++). When building with build-script in different folders, the target doesn't exist and this patch won't change existing behavior.
