### PR TITLE
[6.4][IRGen] Emit reflection info for @_rawLayout types.

### DIFF
--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -993,14 +993,37 @@ private:
     B.addInt16(uint16_t(kind));
     B.addInt16(FieldRecordSize);
 
+    // A `@_rawLayout(like: T)` struct has no stored properties, so it would
+    // otherwise emit an empty field descriptor. Generic raw-layout types don't
+    // get an opaque builtin descriptor either (their size depends on the
+    // substituted generic arguments), so remote reflection has no way to
+    // recover their size and would report it as zero. Expose the "like" type
+    // as an artificial field so remote reflection can compute the layout by
+    // substituting the type's generic arguments. In-process reflection is
+    // unaffected: it derives the child count from the nominal type descriptor,
+    // which records no stored properties for a raw-layout type.
+    Type rawLayoutLikeType;
+    if (auto *SD = dyn_cast<StructDecl>(const_cast<NominalTypeDecl *>(NTD))) {
+      if (auto *attr = SD->getAttrs().getAttribute<RawLayoutAttr>()) {
+        if (auto likeType = attr->getResolvedScalarLikeType(SD))
+          rawLayoutLikeType = (*likeType)->mapTypeOutOfEnvironment();
+      }
+    }
+
     // Emit exportable fields, prefixed with a count
-    B.addInt32(countExportableFields(IGM, NTD));
+    B.addInt32(countExportableFields(IGM, NTD) + (rawLayoutLikeType ? 1 : 0));
 
     // Filter to select which fields we'll export FieldDescriptor for.
     forEachField(IGM, NTD, [&](Field field) {
       if (isExportableField(field))
         addField(field);
     });
+
+    if (rawLayoutLikeType) {
+      reflection::FieldRecordFlags flags;
+      flags.setIsArtificial();
+      addField(flags, rawLayoutLikeType, "_rawLayout");
+    }
   }
 
   void addField(const EnumDecl *enumDecl, const EnumElementDecl *decl,

--- a/validation-test/Reflection/reflect_rawLayout.swift
+++ b/validation-test/Reflection/reflect_rawLayout.swift
@@ -1,0 +1,70 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_rawLayout -target %module-target-future -enable-experimental-feature RawLayout
+// RUN: %target-codesign %t/reflect_rawLayout
+
+// RUN: %target-run %target-swift-reflection-test %t/reflect_rawLayout | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// REQUIRES: reflection_test_support
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_RawLayout
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: asan
+
+// A `@_rawLayout(like:)` type has no stored properties, so without the
+// artificial "like" field in its reflection metadata, remote reflection used
+// to compute its size as zero and lay out following fields on top of it.
+// rdar://180673451
+
+import SwiftReflectionTest
+
+@_rawLayout(like: T)
+struct RawCell<T: ~Copyable>: ~Copyable {}
+
+class TestClass {
+    let before: Int = 1
+    let cell: RawCell<Int> = RawCell()
+    let after: Int = 2
+}
+
+let obj = TestClass()
+
+reflect(object: obj)
+
+// The raw-layout field must report the size and stride of its `like` type
+// (Int) rather than zero, and the following field must not overlap it.
+
+// CHECK-64: Reflecting an object.
+// CHECK-64: Type reference:
+// CHECK-64: (class reflect_rawLayout.TestClass)
+
+// CHECK-64: Type info:
+// CHECK-64: (class_instance size=40 alignment=8 stride=40 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:   (field name=before offset=16
+// CHECK-64:   (field name=cell offset=24
+// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:       (field name=_rawLayout offset=0
+// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:           (field name=_value offset=0
+// CHECK-64:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK-64:   (field name=after offset=32
+
+// CHECK-32: Reflecting an object.
+// CHECK-32: Type reference:
+// CHECK-32: (class reflect_rawLayout.TestClass)
+
+// CHECK-32: Type info:
+// CHECK-32: (class_instance
+// CHECK-32:   (field name=before offset={{[0-9]+}}
+// CHECK-32:   (field name=cell offset=[[CELLOFF:[0-9]+]]
+// CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:       (field name=_rawLayout offset=0
+// CHECK-32:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:           (field name=_value offset=0
+// CHECK-32:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK-32:   (field name=after offset={{[0-9]+}}
+
+doneReflecting()
+
+// CHECK-64: Done.
+// CHECK-32: Done.


### PR DESCRIPTION
Cherry-pick https://github.com/swiftlang/swift/pull/90348 to `release/6.4.x`.

Emit fields that match layout-like type so that Remote Mirror can understand the structure.

rdar://180673451