### PR TITLE
[docs] list some commands for Apple Silicon macOS tests

### DIFF
--- a/docs/ContinuousIntegration.md
+++ b/docs/ContinuousIntegration.md
@@ -83,8 +83,9 @@ Platform     | Comment | Check Status
 ------------ | ------- | ------------
 All supported platforms     | @swift-ci Please test                         | Swift Test Linux Platform (smoke test)<br>Swift Test macOS Platform (smoke test)<br>Swift Test Linux Platform<br>Swift Test macOS Platform<br>
 All supported platforms     | @swift-ci Please clean test                   | Swift Test Linux Platform (smoke test)<br>Swift Test macOS Platform (smoke test)<br>Swift Test Linux Platform<br>Swift Test macOS Platform<br>
-macOS platform               | @swift-ci Please test macOS platform           | Swift Test macOS Platform (smoke test)<br>Swift Test macOS Platform
-macOS platform               | @swift-ci Please clean test macOS platform     | Swift Test macOS Platform (smoke test)<br>Swift Test macOS Platform
+macOS platform               | @swift-ci Please test macOS platform           | Swift Test macOS Platform (smoke test)<br>Swift Test macOS Platform<br>Swift Test macOS Platform (arm64)
+macOS platform (Apple Silicon) | @swift-ci Please test macOS arm64           | Swift Test macOS Platform (arm64)
+macOS platform               | @swift-ci Please clean test macOS platform     | Swift Test macOS Platform (smoke test)<br>Swift Test macOS Platform<br>Swift Test macOS Platform (arm64)
 macOS platform               | @swift-ci Please benchmark                    | Swift Benchmark on macOS Platform (many runs - rigorous)
 macOS platform               | @swift-ci Please smoke benchmark              | Swift Benchmark macOS Platform (few runs - soundness)
 Linux platform               | @swift-ci Please test Linux platform          | Swift Test Linux Platform (smoke test)<br>Swift Test Linux Platform


### PR DESCRIPTION
Add more information to the document "ContinuousIntegration.md", especially how to initiate PR testing on an Apple Silicon macOS test runner.