### PR TITLE
[SILOPT][CSE] Fix ownership of forwarding instruction

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CommonSubexpressionElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CommonSubexpressionElimination.swift
@@ -315,6 +315,19 @@ private func tryCSEReplace(
   with availInst: Instruction,
   _ context: FunctionPassContext
 ) {
+  if let availFwd = availInst as? ForwardingInstruction,
+    let instFwd = inst as? ForwardingInstruction,
+    availFwd.forwardingOwnership != instFwd.forwardingOwnership
+  {
+    guard
+      availFwd.forwardingOwnership == .none
+        || instFwd.forwardingOwnership == .none
+    else {
+      // This should never occur. This check is here as a precaution.
+      return
+    }
+    availFwd.setForwardingOwnership(to: .none, context)
+  }
   for (result, availResult) in zip(inst.results, availInst.results) {
     result.uses.replaceAll(with: availResult, context)
   }

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -7358,6 +7358,10 @@ public:
   void visitSILBasicBlock(SILBasicBlock *BB) {
     SILInstructionVisitor::visitSILBasicBlock(BB);
     verifyDebugScopeHoles(BB);
+
+    for (SILInstruction &inst : *BB) {
+      inst.verifyOperandOwnership(&fnConv.silConv);
+    }
   }
 
   void visitBasicBlockArguments(SILBasicBlock *BB) {

--- a/test/SILOptimizer/cse_forwarding_ossa.sil
+++ b/test/SILOptimizer/cse_forwarding_ossa.sil
@@ -2,6 +2,7 @@
 sil_stage canonical
 
 import Builtin
+import Swift
 
 class SuperKlass {}
 
@@ -9,6 +10,14 @@ class Klass : SuperKlass {}
 
 struct NonTrivialStruct {
   var val : Klass
+}
+
+struct StructWithOptionalAnyObject {
+  var x: Optional<AnyObject>
+}
+
+struct StructOfStructWithOptionalAnyObject {
+  var s: StructWithOptionalAnyObject
 }
 
 // CHECK-LABEL: sil [ossa] @cse_copy_upcast1 :
@@ -221,3 +230,20 @@ bb0(%0 : @owned $Klass):
   return %res : $(SuperKlass, SuperKlass)
 }
 
+// Two forwarding instructions with identical operands but different forwarding
+// ownership must not be merged as-is: the surviving instruction has to have 
+// its forwarding ownership set to none to remain valid.
+// CHECK-LABEL: sil [ossa] @cse_forwarding_ownership_mismatch :
+// CHECK: [[S:%.*]] = struct $StructWithOptionalAnyObject ({{%.*}}){{.*}}ownership: none
+// CHECK: apply undef([[S]])
+// CHECK: struct $StructOfStructWithOptionalAnyObject ([[S]])
+// CHECK-LABEL: } // end sil function 'cse_forwarding_ownership_mismatch'
+sil [ossa] @cse_forwarding_ownership_mismatch : $@convention(thin) () -> @owned StructOfStructWithOptionalAnyObject {
+bb0:
+  %0 = enum $Optional<AnyObject>, #Optional.none!enumelt
+  %1 = struct $StructWithOptionalAnyObject (%0), forwarding: @guaranteed
+  %2 = apply undef(%1) : $@convention(thin) (@guaranteed StructWithOptionalAnyObject) -> ()
+  %3 = struct $StructWithOptionalAnyObject (%0)
+  %4 = struct $StructOfStructWithOptionalAnyObject (%3), forwarding: @owned
+  return %4
+}


### PR DESCRIPTION
When two identical forwarding instructions, for example, struct $S (%1), have different ownership: "guaranteed" and "none”, the CSE pass preserves the “guaranteed” ownership, which crashes in SILBuilder.

```
Begin Error in Function: 'cse_forwarding_ownership_mismatch'
Found an operand with a value that is not compatible with the operand's operand ownership kind map.
Value:   %1 = struct $StructWithOptionalAnyObject (%0 : $Optional<AnyObject>), forwarding: @guaranteed // users: %3, %2
Value Ownership Kind: guaranteed
Instruction:
     %1 = struct $StructWithOptionalAnyObject (%0 : $Optional<AnyObject>), forwarding: @guaranteed // users: %3, %2
->   %3 = struct $StructOfStructWithOptionalAnyObject (%1 : $StructWithOptionalAnyObject), forwarding: @owned // user: %4
     return %3 : $StructOfStructWithOptionalAnyObject // id: %4
Constraint: <Constraint Kind:owned LifetimeConstraint:LifetimeEnding>
End Error in Function: 'cse_forwarding_ownership_mismatch'
// cse_forwarding_ownership_mismatch
// Isolation: unspecified
sil [ossa] @cse_forwarding_ownership_mismatch : $@convention(thin) () -> @owned StructOfStructWithOptionalAnyObject {
bb0:
  %0 = enum $Optional<AnyObject>, #Optional.none!enumelt // user: %1; ownership: none
  %1 = struct $StructWithOptionalAnyObject (%0), forwarding: @guaranteed // users: %3, %2
  %2 = apply undef(%1) : $@convention(thin) (@guaranteed StructWithOptionalAnyObject) -> ()
  %3 = struct $StructOfStructWithOptionalAnyObject (%1), forwarding: @owned // user: %4
  return %3                                       // id: %4
} // end sil function 'cse_forwarding_ownership_mismatch'

Found ownership error?!
```

A "none" value can be used wherever a "guaranteed" or "owned" value is expected. In other words: "none" is compatible with "guaranteed" and "owned”. For that reason, 

This PR also adds the check in SILVerifier to ensure we always catch this error since the crash would only happen if the function was cloned afterwards, e.g. when inlined.

```
// repro.sil
sil_stage canonical

import Builtin
import Swift

struct StructWithOptionalAnyObject {
  var x: Optional<AnyObject>
}

struct StructOfStructWithOptionalAnyObject {
  var s: StructWithOptionalAnyObject
}

sil [ossa] @cse_forwarding_ownership_mismatch : $@convention(thin) () -> @owned StructOfStructWithOptionalAnyObject {
bb0:
  %0 = enum $Optional<AnyObject>, #Optional.none!enumelt
  %1 = struct $StructWithOptionalAnyObject (%0), forwarding: @guaranteed
  %2 = apply undef(%1) : $@convention(thin) (@guaranteed StructWithOptionalAnyObject) -> ()
  %3 = struct $StructWithOptionalAnyObject (%0)
  %4 = struct $StructOfStructWithOptionalAnyObject (%3), forwarding: @owned
  return %4
}
```

Run with: sil-opt -sil-combine -common-subexpression-elimination -inline repro.sil

Resolves rdar://181251938.