### PR TITLE
Sema: Fix crash in default witness table checking for associated conformances

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -7683,6 +7683,7 @@ void TypeChecker::inferDefaultWitnesses(ProtocolDecl *proto) {
         findAssociatedTypeDefault(assocType);
     if (!defaultAssocType)
       continue;
+    ASSERT(defaultedAssocDecl);
 
     Type defaultAssocTypeInContext =
       proto->mapTypeIntoEnvironment(defaultAssocType);
@@ -7695,10 +7696,10 @@ void TypeChecker::inferDefaultWitnesses(ProtocolDecl *proto) {
       proto->diagnose(diag::assoc_type_default_conformance_failed,
                       defaultAssocType, assocType,
                       req.getFirstType(), req.getSecondType());
-      defaultedAssocDecl
-          ->diagnose(diag::assoc_type_default_here, assocType, defaultAssocType)
-          .highlight(defaultedAssocDecl->getDefaultDefinitionTypeRepr()
-                         ->getSourceRange());
+      auto diag = defaultedAssocDecl->diagnose(
+          diag::assoc_type_default_here, assocType, defaultAssocType);
+      if (auto *typeRepr = defaultedAssocDecl->getDefaultDefinitionTypeRepr())
+        diag.highlight(typeRepr->getSourceRange());
 
       continue;
     }

--- a/test/decl/protocol/resilient_defaults.swift
+++ b/test/decl/protocol/resilient_defaults.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-library-evolution
+// RUN: %target-typecheck-verify-swift -enable-library-evolution -verify-additional-file Swift.Collection.SubSequence
 
 public struct Wrapper<T: P>: P { }
 extension Wrapper: Q where T: Q { }
@@ -16,3 +16,9 @@ public protocol Q: P where Self.AssocType: Q { }
 
 public protocol R: Q where Self.AssocType: R { }
 // expected-warning@-1{{default type 'Wrapper<Self>' for associated type 'AssocType' does not satisfy constraint 'Self.AssocType': 'R'}}
+
+public struct E {}
+public protocol P1: RandomAccessCollection where SubSequence: P1 {}
+// expected-warning@-1{{default type 'Slice<Self>' for associated type 'SubSequence' does not satisfy constraint 'Self.SubSequence': 'P1'}}
+
+// expected-note@Swift.Collection.SubSequence:2 {{associated type 'SubSequence' has default type 'Slice<Self>' written here}}

--- a/validation-test/compiler_crashers_fixed/TypeChecker-inferDefaultWitnesses-7f4bf9.swift
+++ b/validation-test/compiler_crashers_fixed/TypeChecker-inferDefaultWitnesses-7f4bf9.swift
@@ -1,5 +1,5 @@
 // {"extraArgs":["-enable-library-evolution"],"kind":"typecheck","original":"2f0860f3","signature":"swift::TypeChecker::inferDefaultWitnesses(swift::ProtocolDecl*)","signatureNext":"DeclChecker::visit"}
-// RUN: not --crash %target-swift-frontend -typecheck -enable-library-evolution %s
+// RUN: %target-swift-frontend -typecheck -enable-library-evolution %s
 public
   protocol a: Collection where SubSequence: a
 {


### PR DESCRIPTION
It is possible to state an associated requirement on a protocol such that a default associated type in another protocol no longer satifies this requirement. If the other protocol was from a serialized module, we would crash while getting the TypeRepr for its default type.

Fix this by checking if the TypeRepr is set, and if not set, just emit a note at the associated type declaration without highlighting the default type.

Fixes rdar://180489587.