### PR TITLE
[6.4] Sema: Fix crash in default witness table checking for associated conformances

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -7692,10 +7692,10 @@ void TypeChecker::inferDefaultWitnesses(ProtocolDecl *proto) {
       proto->diagnose(diag::assoc_type_default_conformance_failed,
                       defaultAssocType, assocType,
                       req.getFirstType(), req.getSecondType());
-      defaultedAssocDecl
-          ->diagnose(diag::assoc_type_default_here, assocType, defaultAssocType)
-          .highlight(defaultedAssocDecl->getDefaultDefinitionTypeRepr()
-                         ->getSourceRange());
+      auto diag = defaultedAssocDecl->diagnose(
+          diag::assoc_type_default_here, assocType, defaultAssocType);
+      if (auto *typeRepr = defaultedAssocDecl->getDefaultDefinitionTypeRepr())
+        diag.highlight(typeRepr->getSourceRange());
 
       continue;
     }

--- a/test/decl/protocol/resilient_defaults.swift
+++ b/test/decl/protocol/resilient_defaults.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-library-evolution
+// RUN: %target-typecheck-verify-swift -enable-library-evolution -verify-additional-file Swift.Collection.SubSequence
 
 public struct Wrapper<T: P>: P { }
 extension Wrapper: Q where T: Q { }
@@ -16,3 +16,9 @@ public protocol Q: P where Self.AssocType: Q { }
 
 public protocol R: Q where Self.AssocType: R { }
 // expected-warning@-1{{default type 'Wrapper<Self>' for associated type 'AssocType' does not satisfy constraint 'Self.AssocType': 'R'}}
+
+public struct E {}
+public protocol P1: RandomAccessCollection where SubSequence: P1 {}
+// expected-warning@-1{{default type 'Slice<Self>' for associated type 'SubSequence' does not satisfy constraint 'Self.SubSequence': 'P1'}}
+
+// expected-note@Swift.Collection.SubSequence:2 {{associated type 'SubSequence' has default type 'Slice<Self>' written here}}


### PR DESCRIPTION
6.4 cherry-pick of https://github.com/swiftlang/swift/pull/90368

* **Description:** It is possible to state an associated requirement on a protocol such that a default associated type in another protocol no longer satifies this requirement. If the other protocol was from a serialized module, we would crash while getting the TypeRepr for its default type.

* **Origination:** Long time.

* **Risk:** None. The main PR also adds an ASSERT(), but here I'm just adding a null check to prevent an unconditional pointer dereference otherwise.

* **Radar:** Fixes rdar://180489587.

* **Reviewed by:** @hamishknight 
