### PR TITLE
[Sema] Add fix-it to declare mutable copy when mutating a function parameter

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -7027,7 +7027,8 @@ public:
   /// If this is a simple 'let' constant, emit a note with a fixit indicating
   /// that it can be rewritten to a 'var'.  This is used in situations where the
   /// compiler detects obvious attempts to mutate a constant.
-  void emitLetToVarNoteIfSimple(DeclContext *UseDC) const;
+  void emitLetToVarNoteIfSimple(DeclContext *UseDC,
+                                SourceLoc failingExprLoc = SourceLoc()) const;
 
   /// Returns true if the name is the self identifier and is implicit.
   bool isSelfParameter() const;

--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -109,6 +109,9 @@ ERROR(func_decl_no_body_expected,PointsToFirstBadToken,
 NOTE(convert_let_to_var,none,
      "change 'let' to 'var' to make it mutable", ())
 
+NOTE(add_var_shadow_to_param,none,
+     "add '%0' to make a mutable copy", (StringRef))
+
 NOTE(note_typo_candidate,none,
      "did you mean '%0'?", (StringRef))
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9187,7 +9187,8 @@ ObjCSelector VarDecl::getDefaultObjCSetterSelector(ASTContext &ctx,
 /// If this is a simple 'let' constant, emit a note with a fixit indicating
 /// that it can be rewritten to a 'var'.  This is used in situations where the
 /// compiler detects obvious attempts to mutate a constant.
-void VarDecl::emitLetToVarNoteIfSimple(DeclContext *UseDC) const {
+void VarDecl::emitLetToVarNoteIfSimple(DeclContext *UseDC,
+                                       SourceLoc failingExprLoc) const {
   // If it isn't a 'let', don't touch it.
   if (!isLet()) return;
 
@@ -9221,8 +9222,27 @@ void VarDecl::emitLetToVarNoteIfSimple(DeclContext *UseDC) const {
     }
   }
 
-  // Besides self, don't suggest mutability for explicit function parameters.
-  if (isa<ParamDecl>(this)) return;
+  // For explicit function parameters, suggest declaring a local mutable copy
+  // just above the failing expression.
+  if (isa<ParamDecl>(this)) {
+    if (failingExprLoc.isValid()) {
+      auto insertLoc =
+          Lexer::getLocForStartOfLine(getASTContext().SourceMgr, failingExprLoc);
+      llvm::SmallString<32> buf;
+      llvm::raw_svector_ostream os(buf);
+      DeclName(getName()).print(os, /*skipEmptyArgumentNames=*/true,
+                                /*escapeIfNeeded=*/true);
+      auto nameStr = buf.str();
+      llvm::SmallString<64> varDecl;
+      (llvm::Twine("var ") + nameStr + " = " + nameStr).toVector(varDecl);
+      auto insertText = (varDecl + "\n").str();
+      getASTContext().Diags
+          .diagnose(failingExprLoc, diag::add_var_shadow_to_param,
+                    varDecl.str())
+          .fixItInsert(insertLoc, insertText);
+    }
+    return;
+  }
 
   // Don't suggest any fixes for capture list elements.
   if (isCaptureList()) return;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2297,7 +2297,7 @@ bool AssignmentFailure::diagnoseAsError() {
 
       // If this is a simple variable marked with a 'let', emit a note to fixit
       // hint it to 'var'.
-      VD->emitLetToVarNoteIfSimple(DC);
+      VD->emitLetToVarNoteIfSimple(DC, Loc);
       return true;
     }
 

--- a/test/Constraints/param_mutation_fixit.swift
+++ b/test/Constraints/param_mutation_fixit.swift
@@ -1,0 +1,19 @@
+// RUN: %target-typecheck-verify-swift
+
+func simpleAssignment(x: Int) {
+    x = 3
+    // expected-error@-1 {{cannot assign to value: 'x' is a 'let' constant}}
+    // expected-note@-2 {{add 'var x = x' to make a mutable copy}} {{1-1=var x = x\n}}
+}
+
+func compoundAssignment(x: Int) {
+    x += 3
+    // expected-error@-1 {{left side of mutating operator isn't mutable: 'x' is a 'let' constant}}
+    // expected-note@-2 {{add 'var x = x' to make a mutable copy}} {{1-1=var x = x\n}}
+}
+
+// Regular let variables should still get the 'let -> var' fix-it, not this one.
+func localLet() {
+    let x = 3  // expected-note {{change 'let' to 'var' to make it mutable}}
+    x = 4  // expected-error {{cannot assign to value: 'x' is a 'let' constant}}
+}


### PR DESCRIPTION
Mutating a function parameter, e.g. `func f(x: Int) { x = 3 }`, would produce an error with no fix-it.

Add a note with a fix-it that inserts `var <name> = <name>` on the line immediately above the failing assignment, pointing at the parameter declaration. The note message shows the exact code to insert, e.g.:

  `note: add 'var name = name' to make a mutable copy`

The fix-it is emitted in `AssignmentFailure::diagnoseAsError`

filled bug:  https://github.com/swiftlang/swift/issues/81308