### PR TITLE
[cxx-interop] Fix CI failure on iOS

### DIFF
--- a/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
+++ b/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
@@ -359,7 +359,7 @@ final class SwiftBoxOwner { var field = NonTrivialOwner() }
 final class SwiftBoxNested { var field = OwnerBox() }
 
 // Foreign reference type base, trivial field.
-@available(macOS 13.3, *)
+@available(SwiftStdlib 5.8, *)
 @_lifetime(borrow x)
 func frtTrivialField(x: SharedTrivialOwner) -> View {
   return x.field.handOutView()
@@ -369,7 +369,7 @@ func frtTrivialField(x: SharedTrivialOwner) -> View {
 }
 
 // Foreign reference type base, non-trivial field.
-@available(macOS 13.3, *)
+@available(SwiftStdlib 5.8, *)
 @_lifetime(borrow x)
 func frtField(x: SharedOwner) -> View {
   return x.field.handOutView()
@@ -379,7 +379,7 @@ func frtField(x: SharedOwner) -> View {
 }
 
 // Foreign reference type base, transitive field access.
-@available(macOS 13.3, *)
+@available(SwiftStdlib 5.8, *)
 @_lifetime(borrow x)
 func frtTransitiveField(x: SharedOwnerBox) -> View {
   return x.field.field.handOutView()


### PR DESCRIPTION
The test used the wrong availability that only worked on macOS but not on other platforms to guard foreign reference types.

rdar://181240559

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
