### PR TITLE
[DebugInfo] Salvage other bitcast instructions

### DIFF
--- a/lib/SIL/IR/ValueOwnership.cpp
+++ b/lib/SIL/IR/ValueOwnership.cpp
@@ -764,6 +764,10 @@ ValueOwnershipKind ValueBase::getOwnershipKind() const {
     if (!f)
       return OwnershipKind::None;
 
+    // Debug reconstruction blocks don't participate in the ownership system.
+    if (block->isDebugReconstructionBlock())
+      return OwnershipKind::None;
+
     // Now that we know that we do have a block/function, check if we have
     // ownership.
     if (!f->hasOwnership())

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -2317,7 +2317,8 @@ void swift::salvageDebugInfo(SILInstruction *I) {
   if (isa<AddressToPointerInst>(I) || isa<PointerToAddressInst>(I))
     salvageUnaryInst(cast<SingleValueInstruction>(I));
 
-  if (isa<UpcastInst>(I) || isa<UncheckedRefCastInst>(I))
+  if (isa<UpcastInst>(I) || isa<UncheckedRefCastInst>(I) ||
+      isa<ConvertEscapeToNoEscapeInst>(I))
     salvageUnaryInst(cast<SingleValueInstruction>(I));
 
   if (isa<StructElementAddrInst>(I) || isa<TupleElementAddrInst>(I) ||

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -2166,8 +2166,14 @@ static void salvagePackElementSetDebugInfo(PackElementSetInst *PESI) {
 // TODO: whenever a debug_value is inserted at a new location, check that no
 // other debug_value instructions exist between the old and new location for
 // the same variable.
+//
+// TODO: Kill all debug uses when the salvage fails.
 void swift::salvageDebugInfo(SILInstruction *I) {
   if (!I)
+    return;
+
+  // Instructions with type dependent operands cannot be salvaged.
+  if (I->getNumTypeDependentOperands() != 0)
     return;
 
   if (auto *SI = dyn_cast<StoreInst>(I)) {
@@ -2309,6 +2315,9 @@ void swift::salvageDebugInfo(SILInstruction *I) {
     salvageDestructureInst(I);
 
   if (isa<AddressToPointerInst>(I) || isa<PointerToAddressInst>(I))
+    salvageUnaryInst(cast<SingleValueInstruction>(I));
+
+  if (isa<UpcastInst>(I) || isa<UncheckedRefCastInst>(I))
     salvageUnaryInst(cast<SingleValueInstruction>(I));
 
   if (isa<StructElementAddrInst>(I) || isa<TupleElementAddrInst>(I) ||

--- a/test/DebugInfo/salvage_convert_escape_to_noescape_ossa.sil
+++ b/test/DebugInfo/salvage_convert_escape_to_noescape_ossa.sil
@@ -1,0 +1,23 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -copy-propagation %s | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+// CHECK-LABEL: sil [ossa] @salvage_convert_escape_to_noescape_ossa
+// CHECK: bb0(%0 : @guaranteed $@callee_guaranteed () -> ()):
+// CHECK:   debug_value %0, let, name "fn", transform {
+// CHECK:   bb0(%0 : $@callee_guaranteed () -> ()):
+// CHECK:     %1 = convert_escape_to_noescape %0 to $@noescape @callee_guaranteed () -> ()
+// CHECK:     return %1
+// CHECK:   }
+// CHECK:   return
+sil [ossa] @salvage_convert_escape_to_noescape_ossa : $@convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> () {
+bb0(%0 : @guaranteed $@callee_guaranteed () -> ()):
+  %1 = convert_escape_to_noescape %0 to $@noescape @callee_guaranteed () -> ()
+  debug_value %1, let, name "fn"
+  destroy_value %1
+  %r = tuple ()
+  return %r : $()
+}

--- a/test/DebugInfo/salvage_upcast.sil
+++ b/test/DebugInfo/salvage_upcast.sil
@@ -1,0 +1,42 @@
+// RUN: %target-sil-opt -sil-verify-all -sil-combine %s | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+class Base {}
+class Derived : Base {}
+
+// CHECK-LABEL: sil @salvage_upcast
+// CHECK: bb0(%0 : $Derived):
+// CHECK:   debug_value %0, let, name "obj", transform {
+// CHECK:   bb0(%0 : $Derived):
+// CHECK:     %1 = upcast %0 to $Base
+// CHECK:     return %1
+// CHECK:   }
+// CHECK:   return
+sil @salvage_upcast : $@convention(thin) (@guaranteed Derived) -> () {
+bb0(%0 : $Derived):
+  %1 = upcast %0 : $Derived to $Base
+  debug_value %1 : $Base, let, name "obj"
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @salvage_unchecked_ref_cast
+// CHECK: bb0(%0 : $Base):
+// CHECK:   debug_value %0, let, name "cast", transform {
+// CHECK:   bb0(%0 : $Base):
+// CHECK:     %1 = unchecked_ref_cast %0 to $Derived
+// CHECK:     return %1
+// CHECK:   }
+// CHECK:   return
+sil @salvage_unchecked_ref_cast : $@convention(thin) (@guaranteed Base) -> () {
+bb0(%0 : $Base):
+  %1 = unchecked_ref_cast %0 : $Base to $Derived
+  debug_value %1 : $Derived, let, name "cast"
+  %r = tuple ()
+  return %r : $()
+}
+

--- a/test/DebugInfo/salvage_upcast.sil
+++ b/test/DebugInfo/salvage_upcast.sil
@@ -40,3 +40,19 @@ bb0(%0 : $Base):
   return %r : $()
 }
 
+// CHECK-LABEL: sil @salvage_convert_escape_to_noescape
+// CHECK: bb0(%0 : $@callee_guaranteed () -> ()):
+// CHECK:   debug_value %0, let, name "fn", transform {
+// CHECK:   bb0(%0 : $@callee_guaranteed () -> ()):
+// CHECK:     %1 = convert_escape_to_noescape %0 to $@noescape @callee_guaranteed () -> ()
+// CHECK:     return %1
+// CHECK:   }
+// CHECK:   return
+sil @salvage_convert_escape_to_noescape : $@convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> () {
+bb0(%0 : $@callee_guaranteed () -> ()):
+  %1 = convert_escape_to_noescape %0 : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
+  debug_value %1 : $@noescape @callee_guaranteed () -> (), let, name "fn"
+  %r = tuple ()
+  return %r : $()
+}
+


### PR DESCRIPTION
`upcast` (0.73%) and `unchecked_ref_cast` (0.10%) instructions are simple bitcasts between reference types at IRGen
`convert_escape_to_noescape` (0.10%) is a simple bit cast between function types

In total, addresses 0.93% of missing salvages in the Source Compatibility Test Suite.

Also fixes a crash when salvaging instructions with type-dependent operands that appeared with these new salvages