### PR TITLE
[Diagnostic] remove tautological error message

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10719,7 +10719,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
             instanceTy->isAnyObject()
                 ? candidate
                 : OverloadChoice::getDecl(instanceTy, decl,
-                                          FunctionRefInfo::singleBaseNameApply());
+                                          functionRefInfo);
 
         const bool invalidMethodRef = isa<FuncDecl>(decl) && !hasInstanceMethods;
         const bool invalidMemberRef = !isa<FuncDecl>(decl) && !hasInstanceMembers;

--- a/test/Constraints/unapplied_method_in_property_init.swift
+++ b/test/Constraints/unapplied_method_in_property_init.swift
@@ -11,12 +11,12 @@ struct S {
   // expected-swift6-error@-2 {{cannot use instance member 'foo' within property initializer; property initializers run before 'self' is available}}
 
   let x2: ((S) -> S).Type = type(of: bar)
-  // expected-error@-1 {{cannot use instance member 'bar' within property initializer; property initializers run before 'self' is available}}
+  // expected-swift5-error@-1 {{cannot convert value of type '((S) -> (S) -> S).Type' to specified type '((S) -> S).Type'}}
+  // expected-swift6-error@-2 {{cannot use instance member 'bar' within property initializer; property initializers run before 'self' is available}}
 
-  // FIXME: https://github.com/swiftlang/swift/issues/89920
+  // https://github.com/swiftlang/swift/issues/89920
   let y1: (S) -> S = foo
-  // expected-error@-1 {{cannot convert value of type '(main.S) -> main.S' to specified type '(main.S) -> main.S'}}
-  // expected-error@-2 {{cannot use instance member 'foo' within property initializer; property initializers run before 'self' is available}}
+  // expected-error@-1 {{cannot use instance member 'foo' within property initializer; property initializers run before 'self' is available}}
 
   let y2: (S) -> S = bar
   // expected-error@-1 {{cannot use instance member 'bar' within property initializer; property initializers run before 'self' is available}}


### PR DESCRIPTION
In simplify, we were not using the provided function apply depth to  pass to resolve overload in all circumstances but setting a default that did not apply when the function is provided as an argument.

By changing this to the given function apply depth, this corrects behaviour in resolve overload and record overload to remove labels when appropriate and thus not produce error messages with the same function type appearing twice in conversion fixes.

Resolves #89920