### PR TITLE
[Tests][Backtracing] Add missing `executable_test` requirement.

### DIFF
--- a/test/Backtracing/DwarfReader.swift
+++ b/test/Backtracing/DwarfReader.swift
@@ -4,6 +4,7 @@
 
 // REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: backtracing
+// REQUIRES: executable_test
 
 @_spi(DwarfTest) import Runtime
 #if canImport(Darwin)

--- a/test/Backtracing/ElfReader.swift
+++ b/test/Backtracing/ElfReader.swift
@@ -7,6 +7,7 @@
 
 // REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: backtracing
+// REQUIRES: executable_test
 
 @_spi(ElfTest) import Runtime
 #if canImport(Darwin)


### PR DESCRIPTION
A couple of the backtracing tests failed because we tried to run them when they won't work.

rdar://179544186
