### PR TITLE
[test] New test for objc `Error` derived conformance AST printing

### DIFF
--- a/test/decl/enum/objc_enum_Error_ast.swift
+++ b/test/decl/enum/objc_enum_Error_ast.swift
@@ -1,0 +1,51 @@
+// RUN: %target-swift-frontend -print-ast -module-name main %s | %FileCheck %s
+// REQUIRES: objc_interop
+
+import Foundation
+
+// CHECK-LABEL: enum MyError
+@objc enum MyError: Int, Error {
+  // CHECK: case somethingWrong
+  case somethingWrong = 1
+  // CHECK: case anotherIssue
+  case anotherIssue = 2
+  // CHECK: case terrible
+  case terrible = 7
+
+  // CHECK: internal static var _nsErrorDomain: String {
+  // CHECK-NEXT:   get {
+  // CHECK-NEXT:     return "main.MyError"
+  // CHECK-NEXT:   }
+  // CHECK-NEXT: }
+}
+
+struct ComplexSystem {
+  // CHECK-LABEL: enum ComplexError
+  @objc enum ComplexError: Int, Error {
+    // CHECK: case internalError
+    case internalError = 100
+    // CHECK: case userError
+    case userError = 101
+
+    // CHECK: internal static var _nsErrorDomain: String {
+    // CHECK-NEXT:   get {
+    // CHECK-NEXT:     return "main.ComplexSystem.ComplexError"
+    // CHECK-NEXT:   }
+    // CHECK-NEXT: }
+  }
+}
+
+// CHECK-LABEL: enum TransportError
+@objc private enum TransportError: Int, Error {
+  // CHECK: trafficJam
+  case trafficJam = 1
+
+  // CHECK: strike
+  case strike = 17
+
+  // CHECK: static var _nsErrorDomain: String {
+  // CHECK-NEXT:   get {
+  // CHECK-NEXT:     return String(reflecting: self)
+  // CHECK-NEXT:   }
+  // CHECK-NEXT: }
+}


### PR DESCRIPTION
Currently, there is no test ensuring objectiveC `Error` conformances produce correct `_nsErrorDomain` implementations.
This adds a test ensuring the synthesised AST is correct for a handful of enums.
Both cases are exercised:
- Returning the domain name directly as a string literal (e.g. `"TheModule.TheType"`)
- Returning a string reflecting the type: (`String(reflecting: self)`)