### PR TITLE
[test] Switch two objc tests back to hard-coded arm64 target cpu.

### DIFF
--- a/test/Concurrency/dynamic_checks_for_func_refs_in_preconcurrency_apis_objc.swift
+++ b/test/Concurrency/dynamic_checks_for_func_refs_in_preconcurrency_apis_objc.swift
@@ -1,6 +1,7 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -target %target-cpu-apple-macosx10.15 -enable-upcoming-feature DynamicActorIsolation -Xllvm -sil-print-types -emit-silgen -verify %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -target arm64-apple-macosx10.15 -enable-upcoming-feature DynamicActorIsolation -Xllvm -sil-print-types -emit-silgen -verify %s | %FileCheck %s
 // REQUIRES: objc_interop
 // REQUIRES: swift_feature_DynamicActorIsolation
+// REQUIRES: SWIFT_STDLIB_ARCH=arm64
 
 import Foundation
 

--- a/test/PrintAsObjC/availability_any_apple_os_objc.swift
+++ b/test/PrintAsObjC/availability_any_apple_os_objc.swift
@@ -1,8 +1,9 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -emit-objc-header-path %t/anyAppleOS.h -target %target-cpu-apple-macos26 -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -emit-objc-header-path %t/anyAppleOS.h -target arm64-apple-macos26 -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/anyAppleOS.h
 
 // REQUIRES: objc_interop
+// REQUIRES: SWIFT_STDLIB_ARCH=arm64
 
 import Foundation
 


### PR DESCRIPTION
Follow-up to #90155: these two tests lack the OS=macosx guard the other %target-cpu-apple-macos tests have.

rdar://181306994
rdar://181307021
