### PR TITLE
[test] Fix a few more tests that require arm64 just-built modules

### DIFF
--- a/test/APIJSON/availability.swift
+++ b/test/APIJSON/availability.swift
@@ -1,4 +1,5 @@
 // REQUIRES: objc_interop, OS=macosx
+// REQUIRES: SWIFT_STDLIB_ARCH=arm64
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/ModuleCache)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %s -typecheck -parse-as-library -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5 -emit-api-descriptor-path %t/api.json -target arm64-apple-macos12 -library-level api

--- a/test/APIJSON/library-level.swift
+++ b/test/APIJSON/library-level.swift
@@ -1,4 +1,5 @@
 // REQUIRES: objc_interop, OS=macosx
+// REQUIRES: SWIFT_STDLIB_ARCH=arm64
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/ModuleCache)
 

--- a/test/APIJSON/originally-defined-in.swift
+++ b/test/APIJSON/originally-defined-in.swift
@@ -1,4 +1,5 @@
 // REQUIRES: objc_interop, OS=macosx
+// REQUIRES: SWIFT_STDLIB_ARCH=arm64
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/ModuleCache)
 // RUN: split-file %s %t

--- a/test/APIJSON/spi.swift
+++ b/test/APIJSON/spi.swift
@@ -1,4 +1,5 @@
 // REQUIRES: objc_interop, OS=macosx
+// REQUIRES: SWIFT_STDLIB_ARCH=arm64
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/ModuleCache)
 

--- a/test/Interop/CxxToSwiftToObjcxx/bridge-cxx-types-to-objcxx.swift
+++ b/test/Interop/CxxToSwiftToObjcxx/bridge-cxx-types-to-objcxx.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %s -module-name UseCxxTy -typecheck -verify -emit-clang-header-path %t/UseCxxTy.h -I %t -I %S/Inputs -enable-experimental-cxx-interop -clang-header-expose-decls=all-public -target arm64-apple-macosx13.3
+// RUN: %target-swift-frontend %s -module-name UseCxxTy -typecheck -verify -emit-clang-header-path %t/UseCxxTy.h -I %t -I %S/Inputs -enable-experimental-cxx-interop -clang-header-expose-decls=all-public -target %target-cpu-apple-macosx13.3
 // RUN: %FileCheck %s < %t/UseCxxTy.h
 
 // REQUIRES: OS=macosx

--- a/test/Interop/SwiftToCxx/core/embedded-swift.swift
+++ b/test/Interop/SwiftToCxx/core/embedded-swift.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -module-name Core -target arm64-apple-macos15.0 -enable-experimental-feature Embedded -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/core.h
+// RUN: %target-swift-frontend %s -module-name Core -target %target-cpu-apple-macos15.0 -enable-experimental-feature Embedded -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/core.h
 // RUN: %FileCheck %s < %t/core.h
 
 // REQUIRES: OS=macosx

--- a/test/Interop/SwiftToCxx/stdlib/string/string-conversions-embedded.cpp
+++ b/test/Interop/SwiftToCxx/stdlib/string/string-conversions-embedded.cpp
@@ -1,13 +1,13 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %S/string-conversions.cpp %t
 
-// RUN: %target-swift-frontend -enable-experimental-feature Embedded %t/print-string.swift -target arm64-apple-macos15.0 -module-name Stringer -enable-experimental-cxx-interop -typecheck -verify -emit-clang-header-path %t/Stringer.h
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded %t/print-string.swift -target %target-cpu-apple-macos15.0 -module-name Stringer -enable-experimental-cxx-interop -typecheck -verify -emit-clang-header-path %t/Stringer.h
 
 // Verify the generated header uses embedded mangling ($e prefix, not $s).
 // RUN: %FileCheck %s --check-prefix=CHECK-HEADER < %t/Stringer.h
 
 // Verify the generated header compiles as valid C++.
-// RUN: %target-interop-build-clangxx -target arm64-apple-macos15.0 -std=gnu++20 -c %t/string-conversions.cpp -I %t -o %t/swift-stdlib-execution.o
+// RUN: %target-interop-build-clangxx -target %target-cpu-apple-macos15.0 -std=gnu++20 -c %t/string-conversions.cpp -I %t -o %t/swift-stdlib-execution.o
 
 // REQUIRES: OS=macosx
 // REQUIRES: executable_test

--- a/test/Macros/macro_unique_name_embedded.swift
+++ b/test/Macros/macro_unique_name_embedded.swift
@@ -10,7 +10,7 @@
 // RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroPlugin) -module-name=MacroPlugin %t/MacroPlugin.swift -g -no-toolchain-stdlib-rpath
 
 // RUN: %target-swift-frontend -typecheck -swift-version 5 -load-plugin-library %t/%target-library-name(MacroPlugin) -module-name TestModule %t/TestModule.swift \
-// RUN:   -enable-experimental-feature Embedded -wmo -target arm64-apple-macos14
+// RUN:   -enable-experimental-feature Embedded -wmo -target %target-cpu-apple-macos14
 
 //--- MacroPlugin.swift
 import SwiftSyntax

--- a/test/ModuleInterface/canonicalized-os-version.swift
+++ b/test/ModuleInterface/canonicalized-os-version.swift
@@ -3,6 +3,7 @@
 // RUN: split-file %s %t
 
 // REQUIRES: OS=macosx || OS=maccatalyst
+// REQUIRES: SWIFT_STDLIB_ARCH=arm64
 
 // First, test that the swift interface with an invalid os version behaves fine.
 // RUN: %target-swift-typecheck-module-from-interface(%t/Modules/Simple.swiftmodule/arm64-apple-macos.swiftinterface) -module-name Simple 

--- a/test/ModuleInterface/relative-interface-path.swift
+++ b/test/ModuleInterface/relative-interface-path.swift
@@ -9,3 +9,4 @@
 // RUN:   relative_path/A.swiftmodule/arm64-apple-macos.swiftinterface -o out/A.swiftmodule -I out
 
 // REQUIRES: OS=macosx
+// REQUIRES: SWIFT_STDLIB_ARCH=arm64

--- a/test/ModuleInterface/relative-resource-path.swift
+++ b/test/ModuleInterface/relative-resource-path.swift
@@ -1,4 +1,5 @@
 // REQUIRES: OS=macosx
+// REQUIRES: SWIFT_STDLIB_ARCH=arm64
 
 // RUN: %empty-directory(%t.relative_resource_path)
 // RUN: %empty-directory(%t.mcp)

--- a/test/SILGen/enum_raw_representable_available_visionos.swift
+++ b/test/SILGen/enum_raw_representable_available_visionos.swift
@@ -8,6 +8,7 @@
 // RUN: %FileCheck %s < %t/output.sil
 
 // REQUIRES: OS=xros
+// REQUIRES: SWIFT_STDLIB_ARCH=arm64
 
 // CHECK-LABEL: // Metasyntactics.init(rawValue:)
 // Ensure that OS version check is generated for the current platform

--- a/test/SILGen/enum_raw_representable_available_visionos_ios.swift
+++ b/test/SILGen/enum_raw_representable_available_visionos_ios.swift
@@ -8,6 +8,7 @@
 // RUN: %FileCheck %s < %t/output.sil
 
 // REQUIRES: OS=xros
+// REQUIRES: SWIFT_STDLIB_ARCH=arm64
 
 // CHECK-LABEL: // Metasyntactics.init(rawValue:)
 // Ensure that no OS version check is generated because the current platform falls under the wildcard '*'

--- a/test/TBD/zippered.swift
+++ b/test/TBD/zippered.swift
@@ -1,4 +1,5 @@
 // REQUIRES: OS=macosx
+// REQUIRES: SWIFT_STDLIB_ARCH=arm64
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 


### PR DESCRIPTION
Reran my last test with a newer Claude Code agent and it found a few more arm64 module using tests that needed updating. (The x86 failures were what prompted the changes, and then I asked Claude Code to find arm64 ones even though those tests were passing on my locally built arm64 modules.)

Assisted-by: Claude Code

rdar://180485531