### PR TITLE
[SILOPT][CSE] Process guaranteed OpenExistentialInst

### DIFF
--- a/SwiftCompilerSources/Sources/AST/GenericSignature.swift
+++ b/SwiftCompilerSources/Sources/AST/GenericSignature.swift
@@ -41,6 +41,12 @@ public struct GenericSignature: CustomStringConvertible, NoReflectionChildren {
   }
 }
 
+extension GenericSignature: Equatable {
+  public static func == (lhs: GenericSignature, rhs: GenericSignature) -> Bool {
+    lhs.bridged.impl == rhs.bridged.impl
+  }
+}
+
 public struct CanonicalGenericSignature {
   public let bridged: BridgedCanGenericSignature
 
@@ -52,5 +58,25 @@ public struct CanonicalGenericSignature {
 
   public var genericSignature: GenericSignature {
     GenericSignature(bridged: bridged.getGenericSignature())
+  }
+}
+
+/// The generic environment that a local (opened existential) archetype lives in.
+public struct GenericEnvironment {
+  public let bridged: BridgedGenericEnvironment
+
+  public init(bridged: BridgedGenericEnvironment) {
+    self.bridged = bridged
+  }
+
+  public var genericSignature: GenericSignature {
+    GenericSignature(bridged: bridged.getGenericSignature())
+  }
+
+  /// True if `self` and `other` have identical local-archetype requirements
+  /// (conformances, superclass, layout constraint) and can therefore be
+  /// safely remapped onto one another, e.g. by `Cloner`.
+  public func hasEqualGenericSignature(to other: GenericEnvironment) -> Bool {
+    genericSignature == other.genericSignature
   }
 }

--- a/SwiftCompilerSources/Sources/AST/Type.swift
+++ b/SwiftCompilerSources/Sources/AST/Type.swift
@@ -125,6 +125,11 @@ public struct CanonicalType: TypeProperties, CustomStringConvertible, NoReflecti
   public func subst(with substitutionMap: SubstitutionMap) -> CanonicalType {
     return rawType.subst(with: substitutionMap).canonical
   }
+
+  /// True if this type involves a local archetype defined in `environment`.
+  public func hasLocalArchetype(from environment: GenericEnvironment) -> Bool {
+    bridged.hasLocalArchetypeFromEnvironment(environment.bridged)
+  }
 }
 
 /// Implements the common members of `AST.Type`, `AST.CanonicalType` and `SIL.Type`.
@@ -267,6 +272,8 @@ extension TypeProperties {
   public var hasArchetype: Bool { rawType.bridged.hasArchetype() }
   public var hasTypeParameter: Bool { rawType.bridged.hasTypeParameter() }
   public var hasLocalArchetype: Bool { rawType.bridged.hasLocalArchetype() }
+  /// True if this type mentions an existential (opened existential) archetype.
+  public var hasExistentialArchetype: Bool { rawType.bridged.hasExistentialArchetype() }
   public var hasDynamicSelf: Bool { rawType.bridged.hasDynamicSelf() }
   public var isEscapable: Bool { rawType.bridged.isEscapable() }
   public var isNoEscape: Bool { rawType.bridged.isNoEscape() }

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CommonSubexpressionElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CommonSubexpressionElimination.swift
@@ -165,11 +165,22 @@ private func processBlock(
       if !context.continueWithNextSubpassRun(for: inst) {
         return false
       }
-      if let ai = inst as? ApplyInst, isOptimizableLazyPropertyGetter(ai) {
+      switch inst {
+      case let ai as ApplyInst where isOptimizableLazyPropertyGetter(ai):
         lazyPropertyGetters.append(ai)
-      } else {
-        tryCSEReplace(inst: inst, with: availInst, context)
+        continue
+      case let openExistential as OpenExistentialRefInst:
+        if !processOpenExistentialRef(
+          openExistential, into: availInst as! OpenExistentialRefInst,
+          map, runsOnHighLevelSil, context
+        ) {
+          map.insert(ref)
+          continue
+        }
+      default:
+        break
       }
+      tryCSEReplace(inst: inst, with: availInst, context)
       continue
     }
 
@@ -334,6 +345,122 @@ private func tryCSEReplace(
   context.erase(instruction: inst)
 }
 
+/// Update SIL basic block's arguments types which refer to opened
+/// archetypes. Replace such types by performing type substitutions
+/// according to the provided type substitution map.
+private func updateBasicBlockArgTypes(
+  _ block: BasicBlock,
+  _ cloner: Cloner<FunctionPassContext>,
+  _ usersToHandle: inout InstructionWorklist,
+  _ context: FunctionPassContext
+) {
+  for index in 0..<block.arguments.count {
+    let arg = block.arguments[index]
+    if !arg.type.hasExistentialArchetype {
+      continue
+    }
+    // Try to apply the archetype remapping to this argument's type. If it
+    // produces a different type, use it as the argument's new type.
+    let oldArgType = arg.type
+    let newArgType = cloner.getOpType(oldArgType)
+    if newArgType == oldArgType {
+      continue
+    }
+    let newArg = block.replacePhiArgumentAndReplaceAllUses(
+      at: index, type: newArgType, ownership: arg.ownership, decl: arg.decl, context
+    )
+    // The old argument's borrowed-from instruction (if any) still refers to
+    // the stale archetype and was not carried over by the replacement above.
+    if newArg.ownership == .guaranteed, let phi = Phi(newArg) {
+      updateGuaranteedPhis(phis: [phi], context)
+    }
+    usersToHandle.pushIfNotVisited(contentsOf: newArg.users)
+  }
+}
+
+/// Handles CSE of guaranteed `open_existential_ref` instructions.
+///
+/// Returns true if uses of open_existential_ref can
+/// be replaced by a dominating instruction.
+private func processOpenExistentialRef(
+  _ openExistential: OpenExistentialRefInst,
+  into dominating: OpenExistentialRefInst,
+  _ map: ScopedHashMap,
+  _ runsOnHighLevelSil: Bool,
+  _ context: FunctionPassContext
+) -> Bool {
+  var usersToHandle = InstructionWorklist(context)
+  defer { usersToHandle.deinitialize() }
+
+  // Collect all direct users that may contain opened archetypes that need to
+  // be replaced.
+  for use in openExistential.uses {
+    usersToHandle.pushIfNotVisited(use.instruction)
+  }
+
+  let oldEnv = openExistential.definedGenericEnvironment
+  let newEnv = dominating.definedGenericEnvironment
+
+  // Use a cloner. It makes copying the instruction and remapping of opened
+  // archetypes trivial.
+  var cloner = Cloner(in: openExistential.parentFunction, context)
+  defer { cloner.deinitialize() }
+  cloner.registerLocalArchetypeRemapping(from: oldEnv, to: newEnv)
+  // This cloner only remaps *types* containing local archetypes; it reuses
+  // SSA operands verbatim unless the operand's own defining instruction is
+  // itself cloned in this session. So direct (non-type-dependent) uses of
+  // `openExistential` must be redirected to `dominating` before any user
+  // gets cloned below. Otherwise a clone whose result type is derived from
+  // its operand's type at construction time (e.g. `copy_value`) would bake
+  // in the stale (old-archetype) type, and a later RAUW of the operand
+  // cannot retroactively fix that already-cached type.
+  openExistential.uses.ignoreTypeDependence.replaceAll(with: dominating, context)
+
+  // Now clone each candidate and replace the opened archetype by the
+  // dominating one.
+  while let user = usersToHandle.pop() {
+    if let term = user as? TermInst {
+      // The current use of the opened archetype is a terminator instruction.
+      // Check if any of the successor blocks use this opened archetype in
+      // the types of their arguments, and if so, replace those uses too.
+      for successor in term.successors where !successor.arguments.isEmpty {
+        updateBasicBlockArgTypes(successor, cloner, &usersToHandle, context)
+      }
+    }
+
+    // Compute if this candidate depends on the old opened archetype. It
+    // always does if it has a type-dependent operand on `openExistential`.
+    var dependsOnOldOpenedArchetype = user.operands.contains {
+      $0.isTypeDependent && $0.value == openExistential
+    }
+
+    // Look for dependencies propagated via the candidate's results.
+    for result in user.results where !result.uses.isEmpty && result.type.hasExistentialArchetype {
+      // Check if the result type depends on this specific opened existential.
+      if result.type.canonicalType.hasLocalArchetype(from: oldEnv) {
+        dependsOnOldOpenedArchetype = true
+        // The users of this candidate are new candidates.
+        usersToHandle.pushIfNotVisited(contentsOf: result.uses.users)
+      }
+    }
+
+    // No need to clone if there is no dependency on the old opened archetype.
+    if !dependsOnOldOpenedArchetype {
+      continue
+    }
+
+    cloner.setInsertionPoint(before: user)
+    let newInst = cloner.clone(instruction: user)
+    // Result types of this candidate's users may be using this archetype.
+    // Thus, we need to try to replace it there too.
+    for (origResult, newResult) in zip(user.results, newInst.results) {
+      origResult.uses.replaceAll(with: newResult, context)
+    }
+    context.erase(instruction: user)
+  }
+  return true
+}
+
 // -----------------------------------------------------------------------
 // getHash — eligibility check and hash computation in one pass
 // -----------------------------------------------------------------------
@@ -397,6 +524,18 @@ private func getHash(
     }
     hasher.combine(ObjectIdentifier(ExistentialMetatypeInst.self))
     hasher.combine(emi.type)
+
+  // Two `open_existential_ref`s of the same existential each define their
+  // own nominally-distinct opened archetype, so unlike the cases above we
+  // cannot hash/compare `x.type`. Merging them rewrites the type of every user
+  // that depends on the specific archetype, which is only attempted for
+  // guaranteed results.
+  case let x as OpenExistentialRefInst:
+    guard x.parentFunction.hasOwnership, x.ownership == .guaranteed else {
+      return nil
+    }
+    hasher.combine(ObjectIdentifier(OpenExistentialRefInst.self))
+    hasher.combine(x.existential.hashable)
 
   // These instructions all use the same hash pattern: kind + result type + operands.
   case let x as UpcastInst: hashTypeOps(x)
@@ -658,6 +797,18 @@ struct InstructionReference: Hashable {
   static func == (lhs: Self, rhs: Self) -> Bool {
     if let lv = lhs.inst as? TypeValueInst, let rv = rhs.inst as? TypeValueInst {
       return lv.type == rv.type && lv.paramType == rv.paramType
+    }
+    // `isIdenticalTo` requires exactly equal result types, but two
+    // `open_existential_ref`s of the same existential always define
+    // distinct opened archetypes as their result type.
+    // Compare the opened existential and, since the two opened archetypes are
+    // nominally distinct, their generic signature (conformances, superclass,
+    // layout constraint) — two opens of the same existential can still be
+    // opened to different constraint sets, and only equal signatures can be
+    // remapped onto one another.
+    if let lo = lhs.inst as? OpenExistentialRefInst, let ro = rhs.inst as? OpenExistentialRefInst {
+      return lo.existential === ro.existential
+        && lo.definedGenericEnvironment.hasEqualGenericSignature(to: ro.definedGenericEnvironment)
     }
     return lhs.inst.isIdenticalTo(rhs.inst)
   }

--- a/SwiftCompilerSources/Sources/SIL/BasicBlock.swift
+++ b/SwiftCompilerSources/Sources/SIL/BasicBlock.swift
@@ -71,10 +71,34 @@ final public class BasicBlock : CustomStringConvertible, HasShortDescription, Ha
   }
 
   public func insertPhiArgument(
-    atPosition: Int, type: Type, ownership: Ownership, _ context: some MutatingContext
+    atPosition: Int, type: Type, ownership: Ownership, decl: ValueDecl? = nil, _ context: some MutatingContext
   ) -> Argument {
     context.notifyInstructionsChanged()
-    return bridged.insertPhiArgument(atPosition, type.bridged, ownership._bridged).argument
+    return bridged.insertPhiArgument(atPosition, type.bridged, ownership._bridged,
+                                     (decl as Decl?).bridged).argument
+  }
+
+  /// Replaces the type of the phi argument at `index` with `type`, rewiring all of its uses
+  /// to the new argument. The argument must not be in the entry block.
+  public func replacePhiArgumentAndReplaceAllUses(
+    at index: Int, type: Type, ownership: Ownership, decl: ValueDecl? = nil,
+    _ context: some MutatingContext
+  ) -> Argument {
+    let oldArgument = arguments[index]
+    let uses = Array(oldArgument.uses)
+    // `eraseArgument` requires the argument to have no uses. Redirect them to a
+    // placeholder of the new type first, then retarget them to the new argument
+    // once it exists.
+    let undef = Undef.get(type: type, context)
+    for use in uses {
+      use.set(to: undef, context)
+    }
+    eraseArgument(at: index, context)
+    let newArgument = insertPhiArgument(atPosition: index, type: type, ownership: ownership, decl: decl, context)
+    for use in uses {
+      use.set(to: newArgument, context)
+    }
+    return newArgument
   }
 
   public func eraseArgument(at index: Int, _ context: some MutatingContext) {

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -1058,6 +1058,11 @@ class InitExistentialRefInst : SingleValueInstruction, UnaryInstruction, InitExi
 final public
 class OpenExistentialRefInst : SingleValueInstruction, UnaryInstruction {
   public var existential: Value { operand.value }
+
+  /// The generic environment that this instruction's opened archetype lives in.
+  public var definedGenericEnvironment: GenericEnvironment {
+    GenericEnvironment(bridged: bridged.OpenExistentialRefInst_getDefinedGenericEnvironment())
+  }
 }
 
 final public

--- a/SwiftCompilerSources/Sources/SIL/Utilities/Cloner.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/Cloner.swift
@@ -52,6 +52,17 @@ public struct Cloner<Context: MutatingContext> {
     self.target = .function(cloneToEmptyFunction)
   }
 
+  /// Clones instructions one at a time within `function`, remapping references to one
+  /// local (opened existential) archetype's generic environment to another, already-existing one.
+  ///
+  /// Unlike the other initializers, this does not clone a region: operands and successor blocks
+  /// of the cloned instruction that are not themselves being cloned are reused unchanged.
+  public init(in function: Function, _ context: Context) {
+    self.bridged = BridgedCloner(function.bridged, context._bridged, true)
+    self.context = context
+    self.target = .function(function)
+  }
+
   public mutating func deinitialize() {
     bridged.destroy(context._bridged)
   }
@@ -163,6 +174,19 @@ public struct Cloner<Context: MutatingContext> {
   public func recordFoldedValue(_ origValue: Value, mappedTo mappedValue: Value) {
     bridged.recordFoldedValue(origValue.bridged, mappedValue.bridged)
   }
+
+  public func registerLocalArchetypeRemapping(from: GenericEnvironment, to: GenericEnvironment) {
+    bridged.registerLocalArchetypeRemapping(from.bridged, to.bridged)
+  }
+
+  public func setInsertionPoint(before instruction: Instruction) {
+    bridged.setInsertionPoint(instruction.bridged)
+  }
+
+  /// Returns `type` with its local archetypes substituted according to the registered remappings.
+  public func getOpType(_ type: Type) -> Type {
+    bridged.getOpType(type.bridged).type
+  }
 }
 
 public struct TypeSubstitutionCloner<Context: MutatingContext> {
@@ -195,3 +219,4 @@ public struct TypeSubstitutionCloner<Context: MutatingContext> {
     bridged.cloneFunctionBody()
   }
 }
+

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -60,6 +60,7 @@ class DiagnosticEngine;
 enum class DifferentiabilityKind : uint8_t;
 class Fingerprint;
 class Identifier;
+class GenericEnvironment;
 class IfConfigClauseRangeInfo;
 class GenericSignature;
 class GenericSignatureImpl;
@@ -94,6 +95,7 @@ class BridgedLangOptions;
 struct BridgedSubstitutionMap;
 struct BridgedGenericSignature;
 struct BridgedCanGenericSignature;
+struct BridgedGenericEnvironment;
 struct BridgedConformance;
 class BridgedParameterList;
 
@@ -3107,6 +3109,7 @@ struct BridgedASTType {
   BRIDGED_INLINE bool isGenericAtAnyLevel() const;
   BRIDGED_INLINE bool hasTypeParameter() const;
   BRIDGED_INLINE bool hasLocalArchetype() const;
+  BRIDGED_INLINE bool hasExistentialArchetype() const;
   BRIDGED_INLINE bool hasDynamicSelf() const;
   BRIDGED_INLINE bool isArchetype() const;
   BRIDGED_INLINE bool archetypeRequiresClass() const;
@@ -3185,6 +3188,7 @@ public:
   BRIDGED_INLINE BridgedCanType(swift::CanType ty);
   BRIDGED_INLINE swift::CanType unbridged() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType getRawType() const;
+  BRIDGED_INLINE bool hasLocalArchetypeFromEnvironment(BridgedGenericEnvironment env) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanGenericSignature
   SILFunctionType_getSubstGenericSignature() const;
 };
@@ -3267,6 +3271,13 @@ struct BridgedFingerprint {
   uint64_t v2;
 
   BRIDGED_INLINE swift::Fingerprint unbridged() const;
+};
+
+struct BridgedGenericEnvironment {
+  swift::GenericEnvironment * _Nonnull env;
+
+  BRIDGED_INLINE swift::GenericEnvironment * _Nonnull unbridged() const;
+  BRIDGED_INLINE BridgedGenericSignature getGenericSignature() const;
 };
 
 enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedPoundKeyword : uint8_t {

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -555,6 +555,10 @@ bool BridgedASTType::hasLocalArchetype() const {
   return unbridged()->hasLocalArchetype();
 }
 
+bool BridgedASTType::hasExistentialArchetype() const {
+  return unbridged()->hasOpenedExistential();
+}
+
 bool BridgedASTType::hasDynamicSelf() const {
   return unbridged()->hasDynamicSelfType();
 }
@@ -872,6 +876,10 @@ BridgedASTType BridgedCanType::getRawType() const {
   return {type};
 }
 
+bool BridgedCanType::hasLocalArchetypeFromEnvironment(BridgedGenericEnvironment env) const {
+  return unbridged()->hasLocalArchetypeFromEnvironment(env.unbridged());
+}
+
 BridgedCanGenericSignature
 BridgedCanType::SILFunctionType_getSubstGenericSignature() const {
   return {swift::CanSILFunctionType(llvm::cast<swift::SILFunctionType>(type))
@@ -1082,6 +1090,18 @@ swift::CanGenericSignature BridgedCanGenericSignature::unbridged() const {
 BridgedGenericSignature
 BridgedCanGenericSignature::getGenericSignature() const {
   return BridgedGenericSignature{impl};
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: BridgedGenericEnvironment
+//===----------------------------------------------------------------------===//
+
+swift::GenericEnvironment * _Nonnull BridgedGenericEnvironment::unbridged() const {
+  return env;
+}
+
+BridgedGenericSignature BridgedGenericEnvironment::getGenericSignature() const {
+  return {unbridged()->getGenericSignature().getPointer()};
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -826,6 +826,7 @@ struct BridgedInstruction {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType InitExistentialAddrInst_getFormalConcreteType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedConformanceArray InitExistentialMetatypeInst_getConformances() const;
   BRIDGED_INLINE bool OpenExistentialAddr_isImmutable() const;
+  BRIDGED_INLINE BridgedGenericEnvironment OpenExistentialRefInst_getDefinedGenericEnvironment() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedGlobalVar GlobalAccessInst_getGlobal() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedGlobalVar AllocGlobalInst_getGlobal() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedFunction FunctionRefBaseInst_getReferencedFunction() const;
@@ -1071,13 +1072,13 @@ struct BridgedBasicBlock {
   BRIDGED_INLINE SwiftInt getNumArguments() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedArgument getArgument(SwiftInt index) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedArgument addBlockArgument(BridgedType type, BridgedValue::Ownership ownership) const;
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedArgument
-  insertPhiArgument(SwiftInt index, BridgedType type,
-                    BridgedValue::Ownership ownership) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedArgument insertPhiArgument(
+      SwiftInt index, BridgedType type, BridgedValue::Ownership ownership,
+      OptionalBridgedDeclObj decl) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedArgument addFunctionArgument(BridgedType type) const;
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedArgument insertFunctionArgument(SwiftInt atPosition, BridgedType type,
-                                                                            BridgedValue::Ownership ownership,
-                                                                            OptionalBridgedDeclObj decl) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedArgument insertFunctionArgument(
+      SwiftInt atPosition, BridgedType type, BridgedValue::Ownership ownership,
+      OptionalBridgedDeclObj decl) const;
   BRIDGED_INLINE void eraseArgument(SwiftInt index) const;
   BRIDGED_INLINE void moveAllInstructionsToBegin(BridgedBasicBlock dest) const;
   BRIDGED_INLINE void moveAllInstructionsToEnd(BridgedBasicBlock dest) const;
@@ -1671,6 +1672,13 @@ struct BridgedCloner {
   BridgedCloner(BridgedGlobalVar var, BridgedContext context);
   BridgedCloner(BridgedInstruction inst, BridgedContext context);
   BridgedCloner(BridgedFunction emptyFunction, BridgedContext context);
+  /// Clones instructions one at a time within `function`, remapping only the
+  /// local archetypes registered via `registerLocalArchetypeRemapping`.
+  /// Unlike the other constructors, operands and successor blocks that are
+  /// not themselves being cloned are reused unchanged, i.e. this does not
+  /// clone a region.
+  BridgedCloner(BridgedFunction function, BridgedContext context,
+                bool forLocalArchetypeRemapping);
   void destroy(BridgedContext context);
   SWIFT_IMPORT_UNSAFE BridgedFunction getCloned() const;
   SWIFT_IMPORT_UNSAFE BridgedBasicBlock getClonedBasicBlock(BridgedBasicBlock originalBasicBlock) const;
@@ -1683,6 +1691,10 @@ struct BridgedCloner {
   void recordFoldedValue(BridgedValue orig, BridgedValue mapped) const;
   BridgedInstruction clone(BridgedInstruction inst) const;
   void setInsertionBlockIfNotSet(BridgedBasicBlock block) const;
+  void setInsertionPoint(BridgedInstruction beforeInst) const;
+  void registerLocalArchetypeRemapping(BridgedGenericEnvironment from,
+                                       BridgedGenericEnvironment to) const;
+  SWIFT_IMPORT_UNSAFE BridgedType getOpType(BridgedType type) const;
 };
 
 struct BridgedTypeSubstCloner {

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -1346,6 +1346,10 @@ bool BridgedInstruction::OpenExistentialAddr_isImmutable() const {
   }
 }
 
+BridgedGenericEnvironment BridgedInstruction::OpenExistentialRefInst_getDefinedGenericEnvironment() const {
+  return {getAs<swift::OpenExistentialRefInst>()->getDefinedOpenedArchetype()->getGenericEnvironment()};
+}
+
 BridgedGlobalVar BridgedInstruction::GlobalAccessInst_getGlobal() const {
   return {getAs<swift::GlobalAccessInst>()->getReferencedGlobal()};
 }
@@ -2143,9 +2147,11 @@ BridgedArgument BridgedBasicBlock::addBlockArgument(BridgedType type, BridgedVal
 
 BridgedArgument
 BridgedBasicBlock::insertPhiArgument(SwiftInt index, BridgedType type,
-                                     BridgedValue::Ownership ownership) const {
+                                     BridgedValue::Ownership ownership,
+                                     OptionalBridgedDeclObj decl) const {
   return {unbridged()->insertPhiArgument(index, type.unbridged(),
-                                         BridgedValue::unbridge(ownership))};
+                                         BridgedValue::unbridge(ownership),
+                                         decl.getAs<swift::ValueDecl>())};
 }
 
 BridgedArgument BridgedBasicBlock::addFunctionArgument(BridgedType type) const {

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -659,6 +659,14 @@ class BridgedClonerImpl : public SILCloner<BridgedClonerImpl> {
   friend class SILCloner<BridgedClonerImpl>;
 
   bool hasFixedLocation;
+
+  /// When true, operands, successor blocks, and locations/scopes are reused
+  /// unchanged (only local archetypes registered via
+  /// `registerLocalArchetypeRemapping` are remapped). Used for cloning
+  /// instructions one at a time within the same function, as opposed to
+  /// cloning a whole region.
+  bool identityMapping = false;
+
   union {
     SILDebugLocation fixedLocation;
     ScopeCloner scopeCloner;
@@ -684,12 +692,29 @@ public:
       hasFixedLocation(false),
       scopeCloner(ScopeCloner(emptyFunction)) {}
 
+  BridgedClonerImpl(SILFunction &function, bool identityMapping)
+      : SILCloner<BridgedClonerImpl>(function), hasFixedLocation(true),
+        identityMapping(identityMapping),
+        fixedLocation(ArtificialUnreachableLocation(), nullptr) {}
+
   ~BridgedClonerImpl() {
     if (hasFixedLocation) {
       fixedLocation.~SILDebugLocation();
     } else {
       scopeCloner.~ScopeCloner();
     }
+  }
+
+  SILValue getMappedValue(SILValue value) {
+    if (identityMapping)
+      return value;
+    return SILCloner<BridgedClonerImpl>::getMappedValue(value);
+  }
+
+  SILBasicBlock *remapBasicBlock(SILBasicBlock *block) {
+    if (identityMapping)
+      return block;
+    return SILCloner<BridgedClonerImpl>::remapBasicBlock(block);
   }
 
   SILValue getClonedValue(SILValue v) {
@@ -704,12 +729,14 @@ public:
   }
 
   SILLocation remapLocation(SILLocation loc) {
-    if (hasFixedLocation)
-      return fixedLocation.getLocation();
-    return loc;
+    if (identityMapping || !hasFixedLocation)
+      return loc;
+    return fixedLocation.getLocation();
   }
 
   const SILDebugScope *remapScope(const SILDebugScope *DS) {
+    if (identityMapping)
+      return DS;
     if (hasFixedLocation)
       return fixedLocation.getScope();
     return scopeCloner.getOrCreateClonedScope(DS);
@@ -765,6 +792,13 @@ BridgedCloner::BridgedCloner(BridgedFunction emptyFunction, BridgedContext conte
   context.context->notifyNewCloner();
 }
 
+BridgedCloner::BridgedCloner(BridgedFunction function, BridgedContext context,
+                             bool forLocalArchetypeRemapping)
+    : cloner(new BridgedClonerImpl(*function.getFunction(),
+                                   forLocalArchetypeRemapping)) {
+  context.context->notifyNewCloner();
+}
+
 void BridgedCloner::destroy(BridgedContext context) {
   delete cloner;
   cloner = nullptr;
@@ -798,6 +832,19 @@ BridgedInstruction BridgedCloner::clone(BridgedInstruction inst) const {
 void BridgedCloner::setInsertionBlockIfNotSet(BridgedBasicBlock block) const {
   if (!cloner->getBuilder().hasValidInsertionPoint())
     cloner->getBuilder().setInsertionPoint(block.unbridged());
+}
+
+void BridgedCloner::setInsertionPoint(BridgedInstruction beforeInst) const {
+  cloner->getBuilder().setInsertionPoint(beforeInst.unbridged());
+}
+
+void BridgedCloner::registerLocalArchetypeRemapping(
+    BridgedGenericEnvironment from, BridgedGenericEnvironment to) const {
+  cloner->registerLocalArchetypeRemapping(from.unbridged(), to.unbridged());
+}
+
+BridgedType BridgedCloner::getOpType(BridgedType type) const {
+  return cloner->getOpType(type.unbridged());
 }
 
 BridgedBasicBlock BridgedCloner::getClonedBasicBlock(BridgedBasicBlock originalBasicBlock) const {

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -1381,6 +1381,22 @@ SILInstruction *SILCombiner::createApplyWithConcreteType(
                                        conformance);
             }
           }
+        } else if (llvm::any_of(
+                       AI.getSubstitutionMap().getReplacementTypes(),
+                       [&](Type replacementTy) {
+                         return replacementTy->getCanonicalType() ==
+                                openedExistential->getType().getASTType();
+                       })) {
+          // Unlike the witness_method case above, this sibling `apply` is
+          // generic over the opened existential's type (e.g. calling a
+          // function constrained on the existential's protocol) rather than
+          // dispatching through a witness table. There's no follow-up
+          // devirtualization that will resolve its generic signature to the
+          // concrete type, so redirecting this operand to the concrete cast
+          // would leave the apply's substitution map referring to the
+          // abstract archetype while its operand provides the concrete
+          // type.
+          continue;
         }
       }
       use->set(uncheckedCast);

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -1210,7 +1210,7 @@ SILInstruction *SILCombiner::createApplyWithConcreteType(
 
   // Transform the parameter arguments.
   SmallVector<ConcreteArgumentCopy, 4> concreteArgCopies;
-  llvm::SmallMapVector<SILValue, SILValue, 4> valuesToReplace;
+  llvm::SmallMapVector<SILValue, const ConcreteExistentialInfo*, 4> valuesToReplace;
   for (unsigned EndIdx = Apply.getNumArguments(); ArgIdx < EndIdx; ++ArgIdx) {
     auto ArgIt = COAIs.find(ArgIdx);
     if (ArgIt == COAIs.end()) {
@@ -1252,7 +1252,7 @@ SILInstruction *SILCombiner::createApplyWithConcreteType(
       NewArgs.push_back(argSub->tempArg);
     } else {
       if (CEI.ConcreteValueNeedsFixup) {
-        valuesToReplace[OAI.OpenedArchetypeValue] = CEI.ConcreteValue;
+        valuesToReplace[OAI.OpenedArchetypeValue] = {&CEI};
       }
       NewArgs.push_back(CEI.ConcreteValue);
     }
@@ -1347,15 +1347,41 @@ SILInstruction *SILCombiner::createApplyWithConcreteType(
     }
   }
   // Replace all uses of the opened existential with the unconditional cast to
-  // concrete type.
+  // concrete type. Another `apply` may share this opened existential (e.g.
+  // when CSE has merged multiple opens of the same existential) and call a
+  // `witness_method` that also depends on it. Redirecting such an instruction's
+  // operand without updating its callee would desynchronize the two: the
+  // callee's generic signature would still expect the abstract opened
+  // archetype while its operand now provides the concrete type. So
+  // devirtualize the sibling's `witness_method` with its operand.
   for (auto &valuePair : valuesToReplace) {
     auto openedExistential = valuePair.first;
-    auto uncheckedCast = valuePair.second;
+    auto uncheckedCast = valuePair.second->ConcreteValue;
+    const ConcreteExistentialInfo &CEI = *valuePair.second;
     SmallVector<Operand *> uses(openedExistential->getNonTypeDependentUses());
     for (auto use : uses) {
       auto *user = use->getUser();
       if (user == cast<SingleValueInstruction>(uncheckedCast)) {
         continue;
+      }
+      if (auto AI = FullApplySite::isa(user)) {
+        if (auto *WMI = dyn_cast<WitnessMethodInst>(AI.getCallee())) {
+          if (WMI->getLookupType() ==
+              openedExistential->getType().getASTType()) {
+            ProtocolConformanceRef conformance =
+                CEI.lookupExistentialConformance(WMI->getLookupProtocol());
+            if (!conformance) {
+              // Can't prove the concrete type satisfies this apply's
+              // requirement.
+              continue;
+            }
+            if (CEI.ConcreteType != WMI->getLookupType() ||
+                conformance != WMI->getConformance()) {
+              replaceWitnessMethodInst(WMI, BuilderCtx, CEI.ConcreteType,
+                                       conformance);
+            }
+          }
+        }
       }
       use->set(uncheckedCast);
     }

--- a/test/SILOptimizer/cse_ossa.sil
+++ b/test/SILOptimizer/cse_ossa.sil
@@ -947,6 +947,190 @@ bb0(%0 : @guaranteed $Proto & Ping):
   return %12 : $Ping
 }
 
+// Check that CSE merges two guaranteed open_existential_ref that open the
+// same existential to the same constraints: only one open_existential_ref
+// survives, and the second's users (which reference its distinct opened
+// archetype) are rewritten via LocalArchetypeCloner to use the first's.
+// CHECK-LABEL: sil [ossa] @cse_open_existential_ref_guaranteed :
+// CHECK: [[OPEN:%.*]] = open_existential_ref %0
+// CHECK: witness_method {{.*}}, #Proto.doThis : {{.*}}, [[OPEN]]
+// CHECK: apply {{%.*}}<{{.*}}>([[OPEN]])
+// CHECK-NOT: open_existential_ref
+// CHECK: witness_method {{.*}}, #Proto.doThat : {{.*}}, [[OPEN]]
+// CHECK: apply {{%.*}}<{{.*}}>([[OPEN]])
+// CHECK-LABEL: } // end sil function 'cse_open_existential_ref_guaranteed'
+sil [ossa] @cse_open_existential_ref_guaranteed : $@convention(thin) (@guaranteed Proto) -> () {
+bb0(%0 : @guaranteed $Proto):
+  %1 = open_existential_ref %0 : $Proto to $@opened("1B68354A-4796-11E6-B7DF-B8E856428C61", Proto) Self
+  %2 = witness_method $@opened("1B68354A-4796-11E6-B7DF-B8E856428C61", Proto) Self, #Proto.doThis, %1 : $@opened("1B68354A-4796-11E6-B7DF-B8E856428C61", Proto) Self : $@convention(witness_method: Proto) <τ_0_0 where τ_0_0 : Proto> (@guaranteed τ_0_0) -> ()
+  %3 = apply %2<@opened("1B68354A-4796-11E6-B7DF-B8E856428C61", Proto) Self>(%1) : $@convention(witness_method: Proto) <τ_0_0 where τ_0_0 : Proto> (@guaranteed τ_0_0) -> ()
+  %4 = open_existential_ref %0 : $Proto to $@opened("2C68354A-4796-11E6-B7DF-B8E856428C62", Proto) Self
+  %5 = witness_method $@opened("2C68354A-4796-11E6-B7DF-B8E856428C62", Proto) Self, #Proto.doThat, %4 : $@opened("2C68354A-4796-11E6-B7DF-B8E856428C62", Proto) Self : $@convention(witness_method: Proto) <τ_0_0 where τ_0_0 : Proto> (@guaranteed τ_0_0) -> ()
+  %6 = apply %5<@opened("2C68354A-4796-11E6-B7DF-B8E856428C62", Proto) Self>(%4) : $@convention(witness_method: Proto) <τ_0_0 where τ_0_0 : Proto> (@guaranteed τ_0_0) -> ()
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// Check that CSE merges two guaranteed open_existential_ref even when the
+// redundant one's result crosses into a successor block argument that has
+// a borrowed_from marker. The borrowed_from's result type is cached from
+// its operand at construction and is never re-derived, so it must be
+// re-cloned when the block argument's type is remapped -- otherwise it is
+// left referencing the erased open_existential_ref's local archetype,
+// orphaning that archetype's GenericEnvironment.
+// CHECK-LABEL: sil [ossa] @cse_open_existential_ref_blockarg :
+// CHECK: [[OPEN:%.*]] = open_existential_ref %0
+// CHECK: br bb1
+// CHECK: bb1:
+// CHECK-NOT: open_existential_ref
+// CHECK: br bb2([[OPEN]]
+// CHECK: bb2([[ARG:%.*]] :
+// CHECK: borrowed [[ARG]]
+// CHECK-LABEL: } // end sil function 'cse_open_existential_ref_blockarg'
+sil [ossa] @cse_open_existential_ref_blockarg : $@convention(thin) (@guaranteed Proto, Builtin.Int1) -> () {
+bb0(%0 : @guaranteed $Proto, %f : $Builtin.Int1):
+  %1 = open_existential_ref %0 : $Proto to $@opened("5B68354A-4796-11E6-B7DF-B8E856428C65", Proto) Self
+  %2 = witness_method $@opened("5B68354A-4796-11E6-B7DF-B8E856428C65", Proto) Self, #Proto.doThis, %1 : $@opened("5B68354A-4796-11E6-B7DF-B8E856428C65", Proto) Self : $@convention(witness_method: Proto) <τ_0_0 where τ_0_0 : Proto> (@guaranteed τ_0_0) -> ()
+  %3 = apply %2<@opened("5B68354A-4796-11E6-B7DF-B8E856428C65", Proto) Self>(%1) : $@convention(witness_method: Proto) <τ_0_0 where τ_0_0 : Proto> (@guaranteed τ_0_0) -> ()
+  br bb1
+
+bb1:
+  %8 = open_existential_ref %0 : $Proto to $@opened("6B68354A-4796-11E6-B7DF-B8E856428C66", Proto) Self
+  br bb2(%8 : $@opened("6B68354A-4796-11E6-B7DF-B8E856428C66", Proto) Self)
+
+bb2(%9 : @guaranteed $@opened("6B68354A-4796-11E6-B7DF-B8E856428C66", Proto) Self):
+  %9b = borrowed %9 from (%0)
+  %10 = witness_method $@opened("6B68354A-4796-11E6-B7DF-B8E856428C66", Proto) Self, #Proto.doThat, %9b : $@opened("6B68354A-4796-11E6-B7DF-B8E856428C66", Proto) Self : $@convention(witness_method: Proto) <τ_0_0 where τ_0_0 : Proto> (@guaranteed τ_0_0) -> ()
+  %11 = apply %10<@opened("6B68354A-4796-11E6-B7DF-B8E856428C66", Proto) Self>(%9b) : $@convention(witness_method: Proto) <τ_0_0 where τ_0_0 : Proto> (@guaranteed τ_0_0) -> ()
+  %15 = tuple ()
+  return %15 : $()
+}
+
+// Check that CSE does not merge open_existential_ref when its result is
+// @owned (not @guaranteed). In OSSA, replacing an owned result would require
+// inserting ownership-fixup copies (OwnershipRAUW), which this pass
+// deliberately avoids -- see the ownership guard in getHash.
+// CHECK-LABEL: sil [ossa] @dont_cse_open_existential_ref_owned :
+// CHECK: open_existential_ref
+// CHECK: open_existential_ref
+// CHECK-LABEL: } // end sil function 'dont_cse_open_existential_ref_owned'
+sil [ossa] @dont_cse_open_existential_ref_owned : $@convention(thin) (@owned Proto) -> () {
+bb0(%0 : @owned $Proto):
+  %1 = copy_value %0 : $Proto
+  %2 = open_existential_ref %0 : $Proto to $@opened("3B68354A-4796-11E6-B7DF-B8E856428C63", Proto) Self
+  %3 = witness_method $@opened("3B68354A-4796-11E6-B7DF-B8E856428C63", Proto) Self, #Proto.doThis, %2 : $@opened("3B68354A-4796-11E6-B7DF-B8E856428C63", Proto) Self : $@convention(witness_method: Proto) <τ_0_0 where τ_0_0 : Proto> (@guaranteed τ_0_0) -> ()
+  %4 = apply %3<@opened("3B68354A-4796-11E6-B7DF-B8E856428C63", Proto) Self>(%2) : $@convention(witness_method: Proto) <τ_0_0 where τ_0_0 : Proto> (@guaranteed τ_0_0) -> ()
+  destroy_value %2 : $@opened("3B68354A-4796-11E6-B7DF-B8E856428C63", Proto) Self
+  %6 = open_existential_ref %1 : $Proto to $@opened("4B68354A-4796-11E6-B7DF-B8E856428C64", Proto) Self
+  %7 = witness_method $@opened("4B68354A-4796-11E6-B7DF-B8E856428C64", Proto) Self, #Proto.doThat, %6 : $@opened("4B68354A-4796-11E6-B7DF-B8E856428C64", Proto) Self : $@convention(witness_method: Proto) <τ_0_0 where τ_0_0 : Proto> (@guaranteed τ_0_0) -> ()
+  %8 = apply %7<@opened("4B68354A-4796-11E6-B7DF-B8E856428C64", Proto) Self>(%6) : $@convention(witness_method: Proto) <τ_0_0 where τ_0_0 : Proto> (@guaranteed τ_0_0) -> ()
+  destroy_value %6 : $@opened("4B68354A-4796-11E6-B7DF-B8E856428C64", Proto) Self
+  %10 = tuple ()
+  return %10 : $()
+}
+
+// Check that CSE merges two guaranteed open_existential_ref whose users are
+// themselves cloned (here, copy_value followed by init_existential_ref, the
+// pattern produced by lowering `===` on an `any AnyObject`-constrained
+// existential). copy_value's result type is cached from its operand's type
+// at construction and never re-derived, so the redundant open_existential_ref's
+// direct uses must be redirected to the surviving one *before* cloning,
+// otherwise the clone keeps a stale reference to the erased archetype while
+// init_existential_ref's ConcreteType field (remapped independently) points
+// at the new one, leaving inconsistent SIL.
+// CHECK-LABEL: sil [ossa] @cse_open_existential_ref_identity :
+// CHECK: [[OPEN:%.*]] = open_existential_ref {{%.*}}
+// CHECK: [[COPY1:%.*]] = copy_value [[OPEN]]
+// CHECK: init_existential_ref [[COPY1]] : $@opened({{.*}}) Self : $@opened({{.*}}) Self, $AnyObject
+// CHECK-NOT: open_existential_ref
+// CHECK: [[COPY2:%.*]] = copy_value [[OPEN]]
+// CHECK: init_existential_ref [[COPY2]] : $@opened({{.*}}) Self : $@opened({{.*}}) Self, $AnyObject
+// CHECK-LABEL: } // end sil function 'cse_open_existential_ref_identity'
+sil [ossa] @cse_open_existential_ref_identity : $@convention(thin) (@guaranteed Proto) -> () {
+bb0(%0 : @guaranteed $Proto):
+  %b = begin_borrow %0
+  %1 = open_existential_ref %b : $Proto to $@opened("7B68354A-4796-11E6-B7DF-B8E856428C67", Proto) Self
+  %2 = copy_value %1 : $@opened("7B68354A-4796-11E6-B7DF-B8E856428C67", Proto) Self
+  %3 = init_existential_ref %2 : $@opened("7B68354A-4796-11E6-B7DF-B8E856428C67", Proto) Self : $@opened("7B68354A-4796-11E6-B7DF-B8E856428C67", Proto) Self, $AnyObject
+  %4 = open_existential_ref %b : $Proto to $@opened("8B68354A-4796-11E6-B7DF-B8E856428C68", Proto) Self
+  %5 = copy_value %4 : $@opened("8B68354A-4796-11E6-B7DF-B8E856428C68", Proto) Self
+  %6 = init_existential_ref %5 : $@opened("8B68354A-4796-11E6-B7DF-B8E856428C68", Proto) Self : $@opened("8B68354A-4796-11E6-B7DF-B8E856428C68", Proto) Self, $AnyObject
+  end_borrow %b
+  destroy_value %3 : $AnyObject
+  destroy_value %6 : $AnyObject
+  %r = tuple ()
+  return %r : $()
+}
+
+// Check that CSE merges two guaranteed open_existential_ref even when one of
+// the redundant one's users is a `copy_value`. Unlike `witness_method`, whose
+// clone visitor independently remaps its result type via getOpType,
+// `copy_value`'s clone visitor just derives its result type from its
+// operand's type at construction time. If the redundant open_existential_ref's
+// uses were only redirected to the dominating one *after* copy_value gets
+// cloned, the clone would bake in the erased archetype's stale type,
+// crashing the verifier once the redundant open_existential_ref is erased.
+// CHECK-LABEL: sil [ossa] @cse_open_existential_ref_copy_value :
+// CHECK: [[OPEN:%.*]] = open_existential_ref %0
+// CHECK: witness_method {{.*}}, #Proto.doThis : {{.*}}, [[OPEN]]
+// CHECK-NOT: open_existential_ref
+// CHECK: [[COPY:%.*]] = copy_value [[OPEN]]
+// CHECK: witness_method {{.*}}, #Proto.doThat : {{.*}}, [[OPEN]]
+// CHECK: apply {{%.*}}<{{.*}}>([[COPY]])
+// CHECK: destroy_value [[COPY]]
+// CHECK-LABEL: } // end sil function 'cse_open_existential_ref_copy_value'
+sil [ossa] @cse_open_existential_ref_copy_value : $@convention(thin) (@guaranteed Proto) -> () {
+bb0(%0 : @guaranteed $Proto):
+  %1 = open_existential_ref %0 : $Proto to $@opened("7B68354A-4796-11E6-B7DF-B8E856428C67", Proto) Self
+  %2 = witness_method $@opened("7B68354A-4796-11E6-B7DF-B8E856428C67", Proto) Self, #Proto.doThis, %1 : $@opened("7B68354A-4796-11E6-B7DF-B8E856428C67", Proto) Self : $@convention(witness_method: Proto) <τ_0_0 where τ_0_0 : Proto> (@guaranteed τ_0_0) -> ()
+  %3 = apply %2<@opened("7B68354A-4796-11E6-B7DF-B8E856428C67", Proto) Self>(%1) : $@convention(witness_method: Proto) <τ_0_0 where τ_0_0 : Proto> (@guaranteed τ_0_0) -> ()
+  br bb1
+
+bb1:
+  %5 = open_existential_ref %0 : $Proto to $@opened("8B68354A-4796-11E6-B7DF-B8E856428C68", Proto) Self
+  %6 = copy_value %5 : $@opened("8B68354A-4796-11E6-B7DF-B8E856428C68", Proto) Self
+  %7 = witness_method $@opened("8B68354A-4796-11E6-B7DF-B8E856428C68", Proto) Self, #Proto.doThat, %5 : $@opened("8B68354A-4796-11E6-B7DF-B8E856428C68", Proto) Self : $@convention(witness_method: Proto) <τ_0_0 where τ_0_0 : Proto> (@guaranteed τ_0_0) -> ()
+  %8 = apply %7<@opened("8B68354A-4796-11E6-B7DF-B8E856428C68", Proto) Self>(%6) : $@convention(witness_method: Proto) <τ_0_0 where τ_0_0 : Proto> (@guaranteed τ_0_0) -> ()
+  destroy_value %6 : $@opened("8B68354A-4796-11E6-B7DF-B8E856428C68", Proto) Self
+  %10 = tuple ()
+  return %10 : $()
+}
+
+// Check that CSE merges two guaranteed open_existential_ref even when the
+// redundant one's result crosses into a successor block argument that has
+// no explicit `borrowed_from` marker of its own (the parser/verifier infers
+// one implicitly for a guaranteed phi). The inferred borrowed_from's result
+// type is cached from the phi's type at construction and is never
+// re-derived, so it must be explicitly refreshed (via updateGuaranteedPhis)
+// when the block argument's type is remapped -- otherwise it is left
+// referencing the erased open_existential_ref's local archetype.
+// CHECK-LABEL: sil [ossa] @cse_open_existential_ref_blockarg_implicit_borrow :
+// CHECK: [[OPEN:%.*]] = open_existential_ref %0
+// CHECK: br bb1
+// CHECK: bb1:
+// CHECK-NOT: open_existential_ref
+// CHECK: br bb2([[OPEN]]
+// CHECK: bb2([[ARG:%.*]] :
+// CHECK: borrowed [[ARG]]
+// CHECK-LABEL: } // end sil function 'cse_open_existential_ref_blockarg_implicit_borrow'
+sil [ossa] @cse_open_existential_ref_blockarg_implicit_borrow : $@convention(thin) (@guaranteed Proto) -> () {
+bb0(%0 : @guaranteed $Proto):
+  %1 = open_existential_ref %0 : $Proto to $@opened("9B68354A-4796-11E6-B7DF-B8E856428C69", Proto) Self
+  %2 = witness_method $@opened("9B68354A-4796-11E6-B7DF-B8E856428C69", Proto) Self, #Proto.doThis, %1 : $@opened("9B68354A-4796-11E6-B7DF-B8E856428C69", Proto) Self : $@convention(witness_method: Proto) <τ_0_0 where τ_0_0 : Proto> (@guaranteed τ_0_0) -> ()
+  %3 = apply %2<@opened("9B68354A-4796-11E6-B7DF-B8E856428C69", Proto) Self>(%1) : $@convention(witness_method: Proto) <τ_0_0 where τ_0_0 : Proto> (@guaranteed τ_0_0) -> ()
+  br bb1
+
+bb1:
+  %8 = open_existential_ref %0 : $Proto to $@opened("AB68354A-4796-11E6-B7DF-B8E856428C6A", Proto) Self
+  br bb2(%8 : $@opened("AB68354A-4796-11E6-B7DF-B8E856428C6A", Proto) Self)
+
+bb2(%9 : @guaranteed $@opened("AB68354A-4796-11E6-B7DF-B8E856428C6A", Proto) Self):
+  %10 = witness_method $@opened("AB68354A-4796-11E6-B7DF-B8E856428C6A", Proto) Self, #Proto.doThat, %9 : $@opened("AB68354A-4796-11E6-B7DF-B8E856428C6A", Proto) Self : $@convention(witness_method: Proto) <τ_0_0 where τ_0_0 : Proto> (@guaranteed τ_0_0) -> ()
+  %11 = apply %10<@opened("AB68354A-4796-11E6-B7DF-B8E856428C6A", Proto) Self>(%9) : $@convention(witness_method: Proto) <τ_0_0 where τ_0_0 : Proto> (@guaranteed τ_0_0) -> ()
+  %15 = tuple ()
+  return %15 : $()
+}
+
 sil [ossa] [global_init] @$s4test10testGlobalSivau : $@convention(thin) () -> Builtin.RawPointer
 
 // CHECK-LABEL: sil [ossa] @cse_global_init :

--- a/test/SILOptimizer/sil_combine_cse_shared_open_existential_ref.sil
+++ b/test/SILOptimizer/sil_combine_cse_shared_open_existential_ref.sil
@@ -197,3 +197,49 @@ bb0(%88 : @owned $View, %77 : @owned $Bar):
   %132 = tuple ()
   return %132 : $()
 }
+
+//===----------------------------------------------------------------------===//
+// Regression test: an `open_existential_ref` is used by two sibling `apply`s
+// of *generic* functions (as opposed to `witness_method`s, as above).
+//
+// SILCombine's existential devirtualization visits one of the two sibling
+// applies first (whichever comes first in program order), proves the
+// existential's concrete type is `LeafNode`, and rewrites that apply's
+// operand and substitutions to the concrete type together. Along the way,
+// it also blindly redirects the *operand* of the other sibling apply to the
+// same concrete-typed value, without updating that apply's substitution
+// map, which still refers to the opened archetype. Because the eligibility
+// check for reprocessing an apply's substitutions inspects the apply's
+// *current* operand type, this other apply's operand type no longer looks
+// like an opened existential, so it's never revisited to fix up its
+// substitutions either. This produced SIL that failed verification:
+// "operand of 'apply' doesn't match function input type".
+//===----------------------------------------------------------------------===//
+
+protocol Taggable : AnyObject {}
+
+class LeafNode : Taggable {}
+
+sil @genericTake : $@convention(thin) <T where T : Taggable> (@guaranteed T) -> ()
+sil @genericPush : $@convention(thin) <T where T : Taggable> (@guaranteed T) -> ()
+
+// CHECK-LABEL: sil [ossa] @siblingGenericApplies :
+// CHECK-NOT: open_existential_ref
+// CHECK: function_ref @genericTake
+// CHECK: apply {{%[0-9]+}}<LeafNode>(%0)
+// CHECK: function_ref @genericPush
+// CHECK: apply {{%[0-9]+}}<LeafNode>(%0)
+// CHECK-NOT: open_existential_ref
+// CHECK-LABEL: } // end sil function 'siblingGenericApplies'
+sil [ossa] @siblingGenericApplies : $@convention(thin) (@owned LeafNode) -> () {
+bb0(%0 : @owned $LeafNode):
+  %4 = init_existential_ref %0 : $LeafNode : $LeafNode, $any Taggable
+  %5 = open_existential_ref %4 to $@opened("11111111-1111-1111-1111-111111111111", any Taggable) Self
+  %6 = function_ref @genericTake : $@convention(thin) <τ_0_0 where τ_0_0 : Taggable> (@guaranteed τ_0_0) -> ()
+  %7 = apply %6<@opened("11111111-1111-1111-1111-111111111111", any Taggable) Self>(%5) : $@convention(thin) <τ_0_0 where τ_0_0 : Taggable> (@guaranteed τ_0_0) -> ()
+  %9 = function_ref @genericPush : $@convention(thin) <τ_0_0 where τ_0_0 : Taggable> (@guaranteed τ_0_0) -> ()
+  %10 = apply %9<@opened("11111111-1111-1111-1111-111111111111", any Taggable) Self>(%5) : $@convention(thin) <τ_0_0 where τ_0_0 : Taggable> (@guaranteed τ_0_0) -> ()
+  destroy_value %5
+  %14 = tuple ()
+  return %14 : $()
+}

--- a/test/SILOptimizer/sil_combine_cse_shared_open_existential_ref.sil
+++ b/test/SILOptimizer/sil_combine_cse_shared_open_existential_ref.sil
@@ -1,0 +1,199 @@
+// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -common-subexpression-elimination -sil-combine | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+//===----------------------------------------------------------------------===//
+// Regression test: CSE merges the four `open_existential_ref`s below (all
+// opening the same existential with `@guaranteed` ownership) into a single
+// shared `open_existential_ref`, which is then used by four sibling `apply`s,
+// each calling a different `witness_method` requirement of `Designable`.
+//
+// SILCombine's existential devirtualization
+// (SILCombiner::createApplyWithConcreteType) then processes the first of
+// those sibling applies, proves the existential's concrete type is `View`,
+// and replaces that apply's operand with a concrete-typed value. Without
+// keeping the other three sibling applies' `witness_method` callees in sync
+// with the now-shared, redirected operand, this produced SIL that failed
+// verification: "operand of 'apply' doesn't match function input type".
+//===----------------------------------------------------------------------===//
+
+enum GradientType {
+  case a
+  case b
+  case c
+}
+
+enum GradientStartPoint {
+  case top
+  case bottom
+}
+
+protocol Designable : AnyObject {
+  var predefinedGradient: GradientType? { get set }
+  var startColor: Int? { get set }
+  var endColor: Int? { get set }
+  var startPoint: GradientStartPoint { get set }
+}
+
+class Base {
+  @_hasStorage var predefinedGradient: GradientType? { get set }
+}
+
+final class Bar : Base, Designable {
+  @_hasStorage var startColor: Int? { get set }
+  @_hasStorage var endColor: Int? { get set }
+  @_hasStorage var startPoint: GradientStartPoint { get set }
+}
+
+final class View : Base, Designable {
+  @_hasStorage var startColor: Int? { get set }
+  @_hasStorage var endColor: Int? { get set }
+  @_hasStorage var startPoint: GradientStartPoint { get set }
+}
+
+sil hidden [ossa] @$s4View18predefinedGradientTW : $@convention(witness_method: Designable) (@guaranteed View) -> Optional<GradientType> {
+bb0(%0 : @guaranteed $View):
+  %0b = upcast %0 : $View to $Base
+  %1 = ref_element_addr %0b, #Base.predefinedGradient
+  %2 = begin_access [read] [dynamic] %1
+  %3 = load [trivial] %2
+  end_access %2
+  return %3 : $Optional<GradientType>
+}
+
+sil hidden [ossa] @$s4View10startColorTW : $@convention(witness_method: Designable) (@guaranteed View) -> Optional<Int> {
+bb0(%0 : @guaranteed $View):
+  %1 = ref_element_addr %0, #View.startColor
+  %2 = begin_access [read] [dynamic] %1
+  %3 = load [trivial] %2
+  end_access %2
+  return %3 : $Optional<Int>
+}
+
+sil hidden [ossa] @$s4View8endColorTW : $@convention(witness_method: Designable) (@guaranteed View) -> Optional<Int> {
+bb0(%0 : @guaranteed $View):
+  %1 = ref_element_addr %0, #View.endColor
+  %2 = begin_access [read] [dynamic] %1
+  %3 = load [trivial] %2
+  end_access %2
+  return %3 : $Optional<Int>
+}
+
+sil hidden [ossa] @$s4View10startPointTW : $@convention(witness_method: Designable) (@guaranteed View) -> GradientStartPoint {
+bb0(%0 : @guaranteed $View):
+  %1 = ref_element_addr %0, #View.startPoint
+  %2 = begin_access [read] [dynamic] %1
+  %3 = load [trivial] %2
+  end_access %2
+  return %3 : $GradientStartPoint
+}
+
+sil hidden [ossa] @$s3Bar18predefinedGradientTW : $@convention(witness_method: Designable) (@guaranteed Bar) -> Optional<GradientType> {
+bb0(%0 : @guaranteed $Bar):
+  %0b = upcast %0 : $Bar to $Base
+  %1 = ref_element_addr %0b, #Base.predefinedGradient
+  %2 = begin_access [read] [dynamic] %1
+  %3 = load [trivial] %2
+  end_access %2
+  return %3 : $Optional<GradientType>
+}
+
+sil hidden [ossa] @$s3Bar10startColorTW : $@convention(witness_method: Designable) (@guaranteed Bar) -> Optional<Int> {
+bb0(%0 : @guaranteed $Bar):
+  %1 = ref_element_addr %0, #Bar.startColor
+  %2 = begin_access [read] [dynamic] %1
+  %3 = load [trivial] %2
+  end_access %2
+  return %3 : $Optional<Int>
+}
+
+sil hidden [ossa] @$s3Bar8endColorTW : $@convention(witness_method: Designable) (@guaranteed Bar) -> Optional<Int> {
+bb0(%0 : @guaranteed $Bar):
+  %1 = ref_element_addr %0, #Bar.endColor
+  %2 = begin_access [read] [dynamic] %1
+  %3 = load [trivial] %2
+  end_access %2
+  return %3 : $Optional<Int>
+}
+
+sil hidden [ossa] @$s3Bar10startPointTW : $@convention(witness_method: Designable) (@guaranteed Bar) -> GradientStartPoint {
+bb0(%0 : @guaranteed $Bar):
+  %1 = ref_element_addr %0, #Bar.startPoint
+  %2 = begin_access [read] [dynamic] %1
+  %3 = load [trivial] %2
+  end_access %2
+  return %3 : $GradientStartPoint
+}
+
+sil_witness_table View: Designable module main {
+  method #Designable.predefinedGradient!getter: @$s4View18predefinedGradientTW
+  method #Designable.startColor!getter: @$s4View10startColorTW
+  method #Designable.endColor!getter: @$s4View8endColorTW
+  method #Designable.startPoint!getter: @$s4View10startPointTW
+}
+
+sil_witness_table Bar: Designable module main {
+  method #Designable.predefinedGradient!getter: @$s3Bar18predefinedGradientTW
+  method #Designable.startColor!getter: @$s3Bar10startColorTW
+  method #Designable.endColor!getter: @$s3Bar8endColorTW
+  method #Designable.startPoint!getter: @$s3Bar10startPointTW
+}
+
+// CHECK-LABEL: sil [ossa] @copyGradient_inlined :
+// CHECK-NOT: = open_existential_ref
+// CHECK-NOT: = witness_method
+// CHECK: function_ref @$s4View18predefinedGradientTW
+// CHECK: apply {{%[0-9]+}}(%0)
+// CHECK: function_ref @$s4View10startColorTW
+// CHECK: apply {{%[0-9]+}}(%0)
+// CHECK: function_ref @$s4View8endColorTW
+// CHECK: apply {{%[0-9]+}}(%0)
+// CHECK: function_ref @$s4View10startPointTW
+// CHECK: apply {{%[0-9]+}}(%0)
+// CHECK-NOT: = open_existential_ref
+// CHECK-NOT: = witness_method
+// CHECK-LABEL: } // end sil function 'copyGradient_inlined'
+sil [ossa] @copyGradient_inlined : $@convention(thin) (@owned View, @owned Bar) -> () {
+bb0(%88 : @owned $View, %77 : @owned $Bar):
+  %89 = init_existential_ref %88 : $View : $View, $any Designable
+  %90 = begin_borrow [lexical] %89
+  %91 = begin_borrow [lexical] %77
+  %94 = open_existential_ref %90 to $@opened("5AA778F6-7F99-11F1-B981-5BD94FC553CE", any Designable) Self
+  %95 = witness_method $@opened("5AA778F6-7F99-11F1-B981-5BD94FC553CE", any Designable) Self, #Designable.predefinedGradient!getter, %94 : $@opened("5AA778F6-7F99-11F1-B981-5BD94FC553CE", any Designable) Self : $@convention(witness_method: Designable) <τ_0_0 where τ_0_0 : Designable> (@guaranteed τ_0_0) -> Optional<GradientType>
+  %96 = apply %95<@opened("5AA778F6-7F99-11F1-B981-5BD94FC553CE", any Designable) Self>(%94) : $@convention(witness_method: Designable) <τ_0_0 where τ_0_0 : Designable> (@guaranteed τ_0_0) -> Optional<GradientType>
+  %97 = upcast %91 to $Base
+  %100 = ref_element_addr %97, #Base.predefinedGradient
+  %101 = begin_access [modify] [dynamic] [no_nested_conflict] %100
+  store %96 to [trivial] %101
+  end_access %101
+  %94b = open_existential_ref %90 to $@opened("5AA778F6-7F99-11F1-B981-5BD94FC553CF", any Designable) Self
+  %104 = witness_method $@opened("5AA778F6-7F99-11F1-B981-5BD94FC553CF", any Designable) Self, #Designable.startColor!getter, %94b : $@opened("5AA778F6-7F99-11F1-B981-5BD94FC553CF", any Designable) Self : $@convention(witness_method: Designable) <τ_0_0 where τ_0_0 : Designable> (@guaranteed τ_0_0) -> Optional<Int>
+  %105 = apply %104<@opened("5AA778F6-7F99-11F1-B981-5BD94FC553CF", any Designable) Self>(%94b) : $@convention(witness_method: Designable) <τ_0_0 where τ_0_0 : Designable> (@guaranteed τ_0_0) -> Optional<Int>
+  %108 = ref_element_addr %91, #Bar.startColor
+  %109 = begin_access [modify] [dynamic] [no_nested_conflict] %108
+  store %105 to [trivial] %109
+  end_access %109
+  %94c = open_existential_ref %90 to $@opened("5AA778F6-7F99-11F1-B981-5BD94FC553D0", any Designable) Self
+  %112 = witness_method $@opened("5AA778F6-7F99-11F1-B981-5BD94FC553D0", any Designable) Self, #Designable.endColor!getter, %94c : $@opened("5AA778F6-7F99-11F1-B981-5BD94FC553D0", any Designable) Self : $@convention(witness_method: Designable) <τ_0_0 where τ_0_0 : Designable> (@guaranteed τ_0_0) -> Optional<Int>
+  %113 = apply %112<@opened("5AA778F6-7F99-11F1-B981-5BD94FC553D0", any Designable) Self>(%94c) : $@convention(witness_method: Designable) <τ_0_0 where τ_0_0 : Designable> (@guaranteed τ_0_0) -> Optional<Int>
+  %116 = ref_element_addr %91, #Bar.endColor
+  %117 = begin_access [modify] [dynamic] [no_nested_conflict] %116
+  store %113 to [trivial] %117
+  end_access %117
+  %94d = open_existential_ref %90 to $@opened("5AA778F6-7F99-11F1-B981-5BD94FC553D1", any Designable) Self
+  %120 = witness_method $@opened("5AA778F6-7F99-11F1-B981-5BD94FC553D1", any Designable) Self, #Designable.startPoint!getter, %94d : $@opened("5AA778F6-7F99-11F1-B981-5BD94FC553D1", any Designable) Self : $@convention(witness_method: Designable) <τ_0_0 where τ_0_0 : Designable> (@guaranteed τ_0_0) -> GradientStartPoint
+  %121 = apply %120<@opened("5AA778F6-7F99-11F1-B981-5BD94FC553D1", any Designable) Self>(%94d) : $@convention(witness_method: Designable) <τ_0_0 where τ_0_0 : Designable> (@guaranteed τ_0_0) -> GradientStartPoint
+  %124 = ref_element_addr %91, #Bar.startPoint
+  %125 = begin_access [modify] [dynamic] [no_nested_conflict] %124
+  store %121 to [trivial] %125
+  end_access %125
+  end_borrow %90
+  end_borrow %91
+  destroy_value %89
+  destroy_value %77
+  %132 = tuple ()
+  return %132 : $()
+}


### PR DESCRIPTION
With the new CSE pass, we observed a couple of performance regressions such as:

```
 ------- Performance (arm64): -Osize -------

 REGRESSION                                      OLD        NEW        DELTA       RATIO
 ReversedBidirectional                           3169.0     3639.0     +14.8%      **0.87x**
```

ReversedBidirectional regresses because the inner loop of AnyBidirectionalCollection iteration opens the same existential index box twice per iteration — once to call _typeID (for the index-type check) and once to call _isEqual (for the loop-termination check). Each opening produces a different opaque archetype identifier, so a literal isIdenticalTo check sees them as distinct.

Reproducer:
```
@inline(never)
public func iterateReversed(_ n: Int) {
  for _ in 1...n {
    let bidirectional = AnyBidirectionalCollection(0..<100_000)
    let reversedBidirectional = bidirectional.reversed()
    for item in reversedBidirectional {
      _ = item
    }
  }
}
```

Resolves rdar://177347578.