### PR TITLE
Sema: Remove TypeMatchResult 

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3146,31 +3146,6 @@ public:
     Error
   };
 
-  class TypeMatchResult {
-    SolutionKind Kind;
-
-  public:
-    inline bool isSuccess() const { return Kind == SolutionKind::Solved; }
-    inline bool isFailure() const { return Kind == SolutionKind::Error; }
-    inline bool isAmbiguous() const { return Kind == SolutionKind::Unsolved; }
-
-    static TypeMatchResult success() {
-      return {SolutionKind::Solved};
-    }
-
-    static TypeMatchResult failure() {
-      return {SolutionKind::Error};
-    }
-
-    static TypeMatchResult ambiguous() {
-      return {SolutionKind::Unsolved};
-    }
-
-    operator SolutionKind() { return Kind; }
-  private:
-    TypeMatchResult(SolutionKind result) : Kind(result) {}
-  };
-
   /// Attempt to repair typing failures and record fixes if needed.
   /// \return true if at least some of the failures has been repaired
   /// successfully, which allows type matcher to continue.
@@ -3179,12 +3154,12 @@ public:
                       SmallVectorImpl<RestrictionOrFix> &conversionsOrFixes,
                       ConstraintLocatorBuilder locator);
 
-  TypeMatchResult
+  SolutionKind
   matchPackTypes(PackType *pack1, PackType *pack2,
                  ConstraintKind kind, TypeMatchOptions flags,
                  ConstraintLocatorBuilder locator);
 
-  TypeMatchResult
+  SolutionKind
   matchPackExpansionTypes(PackExpansionType *expansion1,
                           PackExpansionType *expansion2,
                           ConstraintKind kind, TypeMatchOptions flags,
@@ -3193,22 +3168,22 @@ public:
   /// Subroutine of \c matchTypes(), which matches up two tuple types.
   ///
   /// \returns the result of performing the tuple-to-tuple conversion.
-  TypeMatchResult matchTupleTypes(TupleType *tuple1, TupleType *tuple2,
-                                  ConstraintKind kind, TypeMatchOptions flags,
-                                  ConstraintLocatorBuilder locator);
+  SolutionKind matchTupleTypes(TupleType *tuple1, TupleType *tuple2,
+                               ConstraintKind kind, TypeMatchOptions flags,
+                               ConstraintLocatorBuilder locator);
 
   /// Match the @Sendable bit between two functions.
-  TypeMatchResult matchFunctionSendability(FunctionType *func1,
-                                           FunctionType *func2,
-                                           ConstraintKind kind,
-                                           TypeMatchOptions flags,
-                                           ConstraintLocatorBuilder locator);
+  SolutionKind matchFunctionSendability(FunctionType *func1,
+                                        FunctionType *func2,
+                                        ConstraintKind kind,
+                                        TypeMatchOptions flags,
+                                        ConstraintLocatorBuilder locator);
 
   /// Subroutine of \c matchTypes(), which matches up two function
   /// types.
-  TypeMatchResult matchFunctionTypes(FunctionType *func1, FunctionType *func2,
-                                     ConstraintKind kind, TypeMatchOptions flags,
-                                     ConstraintLocatorBuilder locator);
+  SolutionKind matchFunctionTypes(FunctionType *func1, FunctionType *func2,
+                                  ConstraintKind kind, TypeMatchOptions flags,
+                                  ConstraintLocatorBuilder locator);
   
   /// Subroutine of \c matchTypes()
   bool matchFunctionIsolations(FunctionType *func1, FunctionType *func2,
@@ -3222,14 +3197,14 @@ public:
 
   /// Subroutine of \c matchTypes(), which matches up a value to a
   /// superclass.
-  TypeMatchResult matchSuperclassTypes(Type type1, Type type2,
-                                       TypeMatchOptions flags,
-                                       ConstraintLocatorBuilder locator);
+  SolutionKind matchSuperclassTypes(Type type1, Type type2,
+                                    TypeMatchOptions flags,
+                                    ConstraintLocatorBuilder locator);
 
   /// Subroutine of \c matchTypes(), which matches up two types that
   /// refer to the same declaration via their generic arguments.
-  TypeMatchResult matchDeepEqualityTypes(Type type1, Type type2,
-                                         ConstraintLocatorBuilder locator);
+  SolutionKind matchDeepEqualityTypes(Type type1, Type type2,
+                                      ConstraintLocatorBuilder locator);
 
   /// Subroutine of \c matchTypes(), which matches up a value to an
   /// existential type.
@@ -3238,23 +3213,23 @@ public:
   /// Usually this uses Subtype, but when matching the instance type of a
   /// metatype with the instance type of an existential metatype, since we
   /// want an actual conformance check.
-  TypeMatchResult matchExistentialTypes(Type type1, Type type2,
-                                        ConstraintKind kind,
-                                        TypeMatchOptions flags,
-                                        ConstraintLocatorBuilder locator);
+  SolutionKind matchExistentialTypes(Type type1, Type type2,
+                                     ConstraintKind kind,
+                                     TypeMatchOptions flags,
+                                     ConstraintLocatorBuilder locator);
 
   /// Subroutine of \c matchTypes(), used to bind a type to a
   /// type variable.
-  TypeMatchResult matchTypesBindTypeVar(
+  SolutionKind matchTypesBindTypeVar(
       TypeVariableType *typeVar, Type type, ConstraintKind kind,
       TypeMatchOptions flags, ConstraintLocatorBuilder locator,
-      llvm::function_ref<TypeMatchResult()> formUnsolvedResult);
+      llvm::function_ref<SolutionKind()> formUnsolvedResult);
 
   /// Matches two function result types for a function application. This is
   /// usually a bind, but also handles e.g IUO unwraps.
-  TypeMatchResult matchFunctionResultTypes(Type expectedResult, Type fnResult,
-                                           TypeMatchOptions flags,
-                                           ConstraintLocatorBuilder locator);
+  SolutionKind matchFunctionResultTypes(Type expectedResult, Type fnResult,
+                                        TypeMatchOptions flags,
+                                        ConstraintLocatorBuilder locator);
 
   enum ImpliedResultConversionKind : unsigned {
     /// Usual subtyping rules apply.
@@ -3291,21 +3266,9 @@ public: // FIXME: public due to statics in CSSimplify.cpp
   /// the specific types being matched.
   ///
   /// \returns the result of attempting to solve this constraint.
-  TypeMatchResult matchTypes(Type type1, Type type2, ConstraintKind kind,
-                             TypeMatchOptions flags,
-                             ConstraintLocatorBuilder locator);
-
-  TypeMatchResult getTypeMatchSuccess() {
-    return TypeMatchResult::success();
-  }
-
-  TypeMatchResult getTypeMatchFailure(ConstraintLocatorBuilder locator) {
-    return TypeMatchResult::failure();
-  }
-
-  TypeMatchResult getTypeMatchAmbiguous() {
-    return TypeMatchResult::ambiguous();
-  }
+  SolutionKind matchTypes(Type type1, Type type2, ConstraintKind kind,
+                          TypeMatchOptions flags,
+                          ConstraintLocatorBuilder locator);
 
 public:
   // Build a disjunction that attempts both T? and T for a particular
@@ -3756,7 +3719,7 @@ public:
   ///
   /// \returns \c None when the result builder cannot be applied at all,
   /// otherwise the result of applying the result builder.
-  std::optional<TypeMatchResult>
+  std::optional<SolutionKind>
   matchResultBuilder(AnyFunctionRef fn, Type builderType, Type bodyResultType,
                      ConstraintKind bodyResultConstraintKind,
                      Type contextualType, ConstraintLocatorBuilder locator);
@@ -3771,7 +3734,7 @@ public:
 
   /// Matches a wrapped or projected value parameter type to its backing
   /// property wrapper type by applying the property wrapper.
-  TypeMatchResult applyPropertyWrapperToParameter(
+  SolutionKind applyPropertyWrapperToParameter(
       Type wrapperType,
       Type paramType,
       ParamDecl *param,

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3134,13 +3134,6 @@ public:
                                               Type initializerType,
                                               Type propertyType);
 
-  /// Propagate constraints in an effort to enforce local
-  /// consistency to reduce the time to solve the system.
-  ///
-  /// \returns true if the system is known to be inconsistent (have no
-  /// solutions).
-  bool propagateConstraints();
-
   /// The result of attempting to resolve a constraint or set of
   /// constraints.
   enum class SolutionKind : char {

--- a/lib/Sema/BindingProducer.cpp
+++ b/lib/Sema/BindingProducer.cpp
@@ -690,6 +690,7 @@ bool TypeVariableBinding::attempt(ConstraintSystem &cs) const {
 
   auto result =
       cs.matchTypes(TypeVar, type, ConstraintKind::Bind, options, srcLocator);
+  ASSERT(result != ConstraintSystem::SolutionKind::Unsolved);
 
   if (result == ConstraintSystem::SolutionKind::Error) {
     if (cs.isDebugMode()) {

--- a/lib/Sema/BindingProducer.cpp
+++ b/lib/Sema/BindingProducer.cpp
@@ -691,7 +691,7 @@ bool TypeVariableBinding::attempt(ConstraintSystem &cs) const {
   auto result =
       cs.matchTypes(TypeVar, type, ConstraintKind::Bind, options, srcLocator);
 
-  if (result.isFailure()) {
+  if (result == ConstraintSystem::SolutionKind::Error) {
     if (cs.isDebugMode()) {
       PrintOptions PO = PrintOptions::forDebugging();
 

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -988,7 +988,7 @@ TypeChecker::applyResultBuilderBodyTransform(FuncDecl *func, Type builderType) {
     auto result = cs.matchResultBuilder(
         func, builderType, resultContextType, resultConstraintKind,
         /*contextualType=*/Type(), cs.getConstraintLocator(func->getBody()));
-    if (!result || result->isFailure())
+    if (!result || (*result == ConstraintSystem::SolutionKind::Error))
       return nullptr;
   }
 
@@ -1097,7 +1097,7 @@ TypeChecker::applyResultBuilderBodyTransform(FuncDecl *func, Type builderType) {
   return nullptr;
 }
 
-std::optional<ConstraintSystem::TypeMatchResult>
+std::optional<ConstraintSystem::SolutionKind>
 ConstraintSystem::matchResultBuilder(AnyFunctionRef fn, Type builderType,
                                      Type bodyResultType,
                                      ConstraintKind bodyResultConstraintKind,
@@ -1114,7 +1114,7 @@ ConstraintSystem::matchResultBuilder(AnyFunctionRef fn, Type builderType,
         IgnoreInvalidResultBuilderBody::create(
             *this, getConstraintLocator(fn.getAbstractClosureExpr())),
         FixImpact::InvalidAST);
-    return getTypeMatchSuccess();
+    return SolutionKind::Solved;
   }
 
   // We have already pre-checked the result builder body. Technically, we
@@ -1132,9 +1132,9 @@ ConstraintSystem::matchResultBuilder(AnyFunctionRef fn, Type builderType,
                         *this, builderType,
                         getConstraintLocator(fn.getAbstractClosureExpr())),
                     FixImpact::InvalidAST))
-        return getTypeMatchFailure(locator);
+        return SolutionKind::Error;
 
-      return getTypeMatchSuccess();
+      return SolutionKind::Solved;
     }
 
     // If the body has a return statement, suppress the transform but
@@ -1156,7 +1156,7 @@ ConstraintSystem::matchResultBuilder(AnyFunctionRef fn, Type builderType,
 
       // If we aren't supposed to attempt fixes, fail.
       if (!shouldAttemptFixes()) {
-        return getTypeMatchFailure(locator);
+        return SolutionKind::Error;
       }
 
       // Record the first unhandled construct as a fix.
@@ -1164,7 +1164,7 @@ ConstraintSystem::matchResultBuilder(AnyFunctionRef fn, Type builderType,
               SkipUnhandledConstructInResultBuilder::create(
                   *this, unsupported, builder, getConstraintLocator(locator)),
               /*impact=*/FixImpact::InvalidAST * 10)) {
-        return getTypeMatchFailure(locator);
+        return SolutionKind::Error;
       }
 
       // If we're solving for code completion and the body contains the code
@@ -1179,7 +1179,7 @@ ConstraintSystem::matchResultBuilder(AnyFunctionRef fn, Type builderType,
         recordTypeVariablesAsHoles(getClosureType(closure));
       }
 
-      return getTypeMatchSuccess();
+      return SolutionKind::Solved;
     }
 
     transformedBody = std::make_pair(transform.getBuilderSelf(), body);
@@ -1210,9 +1210,9 @@ ConstraintSystem::matchResultBuilder(AnyFunctionRef fn, Type builderType,
   recordResultBuilderTransform(fn, std::move(transformInfo));
 
   if (generateConstraints(fn, transformInfo.transformedBody))
-    return getTypeMatchFailure(locator);
+    return SolutionKind::Error;
 
-  return getTypeMatchSuccess();
+  return SolutionKind::Solved;
 }
 
 void ConstraintSystem::recordResultBuilderTransform(AnyFunctionRef fn,

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1921,7 +1921,7 @@ ExpandArrayIntoVarargs::attempt(ConstraintSystem &cs, Type argType,
   auto result = cs.matchTypes(elementType, paramType, ConstraintKind::Subtype,
                               options, builder);
 
-  if (result.isFailure())
+  if (result == ConstraintSystem::SolutionKind::Error)
     return nullptr;
 
   return new (cs.getAllocator())
@@ -2217,7 +2217,7 @@ UnwrapOptionalBaseKeyPathApplication::attempt(ConstraintSystem &cs, Type baseTy,
   auto result =
       cs.matchTypes(nonOptionalTy, rootTy, ConstraintKind::Subtype,
                     ConstraintSystem::TypeMatchFlags::TMF_ApplyingFix, locator);
-  if (result.isFailure())
+  if (result == ConstraintSystem::SolutionKind::Error)
     return nullptr;
 
   return new (cs.getAllocator())

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4370,7 +4370,7 @@ void ConstraintSystem::removePropertyWrapper(Expr *anchor) {
   }
 }
 
-ConstraintSystem::TypeMatchResult
+ConstraintSystem::SolutionKind
 ConstraintSystem::applyPropertyWrapperToParameter(
     Type wrapperType,
     Type paramType,
@@ -4382,16 +4382,16 @@ ConstraintSystem::applyPropertyWrapperToParameter(
     PreparedOverloadBuilder *preparedOverload) {
   Expr *anchor = getAsExpr(calleeLocator->getAnchor());
 
-  auto recordPropertyWrapperFix = [&](ConstraintFix *fix) -> TypeMatchResult {
+  auto recordPropertyWrapperFix = [&](ConstraintFix *fix) -> SolutionKind {
     if (!shouldAttemptFixes())
-      return getTypeMatchFailure(locator);
+      return SolutionKind::Error;
 
     recordAnyTypeVarAsPotentialHole(paramType);
 
     if (recordFix(fix, /*impact=*/FixImpact::Mismatch, preparedOverload))
-      return getTypeMatchFailure(locator);
+      return SolutionKind::Error;
 
-    return getTypeMatchSuccess();
+    return SolutionKind::Solved;
   };
 
   // Incorrect use of projected value argument
@@ -4444,10 +4444,10 @@ ConstraintSystem::applyPropertyWrapperToParameter(
                          { wrapperType, PropertyWrapperInitKind::WrappedValue },
                          preparedOverload);
   } else {
-    return getTypeMatchFailure(locator);
+    return SolutionKind::Error;
   }
 
-  return getTypeMatchSuccess();
+  return SolutionKind::Solved;
 }
 
 struct ResolvedMemberResult::Implementation {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1431,7 +1431,7 @@ shouldOpenExistentialCallArgument(ValueDecl *callee, unsigned paramIdx,
 }
 
 // Match the argument of a call to the parameter.
-static ConstraintSystem::TypeMatchResult matchCallArguments(
+static ConstraintSystem::SolutionKind matchCallArguments(
     ConstraintSystem &cs, FunctionType *contextualType, ArgumentList *argList,
     ArrayRef<AnyFunctionType::Param> args,
     ArrayRef<AnyFunctionType::Param> params, ConstraintKind subKind,
@@ -1542,13 +1542,13 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
         argList->getFirstTrailingClosureIndex(), cs.shouldAttemptFixes(),
         *listener, trailingClosureMatching);
     if (!callArgumentMatch)
-      return cs.getTypeMatchFailure(locator);
+      return ConstraintSystem::SolutionKind::Error;
 
     // If there are different results for both the forward and backward
     // scans, return an ambiguity: the caller will need to build a
     // disjunction.
     if (callArgumentMatch->backwardParameterBindings) {
-      return cs.getTypeMatchAmbiguous();
+      return ConstraintSystem::SolutionKind::Unsolved;
     }
 
     selectedTrailingMatching = callArgumentMatch->trailingClosureMatching;
@@ -1570,7 +1570,7 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
     auto extraArguments = listener->getExtraneousArguments();
     if (!extraArguments.empty()) {
       if (RemoveExtraneousArguments::isMinMaxNameShadowing(cs, locator))
-        return cs.getTypeMatchFailure(locator);
+        return ConstraintSystem::SolutionKind::Error;
 
       // First let's see whether this is a situation where a single
       // parameter is a tuple, but N distinct arguments were passed in.
@@ -1599,7 +1599,7 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
 
         if (cs.recordFix(fix,
                          FixImpact::InvalidReference * extraArguments.size()))
-          return cs.getTypeMatchFailure(locator);
+          return ConstraintSystem::SolutionKind::Error;
       }
     }
   }
@@ -1818,8 +1818,8 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
                                                wrapperArgLabel, subKind,
                                                cs.getConstraintLocator(loc),
                                                calleeLocator)
-                .isFailure()) {
-          return cs.getTypeMatchFailure(loc);
+                == ConstraintSystem::SolutionKind::Error) {
+          return ConstraintSystem::SolutionKind::Error;
         }
         continue;
       }
@@ -1906,10 +1906,10 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
     }
   }
 
-  return cs.getTypeMatchSuccess();
+  return ConstraintSystem::SolutionKind::Solved;
 }
 
-ConstraintSystem::TypeMatchResult
+ConstraintSystem::SolutionKind
 ConstraintSystem::matchFunctionResultTypes(Type expectedResult, Type fnResult,
                                            TypeMatchOptions flags,
                                            ConstraintLocatorBuilder locator) {
@@ -1964,7 +1964,7 @@ ConstraintSystem::matchFunctionResultTypes(Type expectedResult, Type fnResult,
     if (iuoKind == IUOReferenceKind::ReturnValue) {
       buildDisjunctionForImplicitlyUnwrappedOptional(expectedResult, fnResult,
                                                      calleeResultLoc);
-      return getTypeMatchSuccess();
+      return SolutionKind::Solved;
     }
   }
   return matchTypes(expectedResult, fnResult, ConstraintKind::Bind, flags,
@@ -2094,7 +2094,7 @@ private:
 
 }
 
-ConstraintSystem::TypeMatchResult
+ConstraintSystem::SolutionKind
 ConstraintSystem::matchTupleTypes(TupleType *tuple1, TupleType *tuple2,
                                   ConstraintKind kind, TypeMatchOptions flags,
                                   ConstraintLocatorBuilder locator) {
@@ -2170,7 +2170,7 @@ ConstraintSystem::matchTupleTypes(TupleType *tuple1, TupleType *tuple2,
   TupleMatcher matcher(tuple1, tuple2);
 
   if (matcher.match(matchKind, locator))
-    return getTypeMatchFailure(locator);
+    return SolutionKind::Error;
 
   if (matcher.hasLabelMismatch) {
     // If we had a label mismatch, emit a warning. This is something we
@@ -2186,14 +2186,14 @@ ConstraintSystem::matchTupleTypes(TupleType *tuple1, TupleType *tuple2,
     auto result = matchTypes(pair.lhs, pair.rhs, subkind, subflags,
                              locator.withPathElement(
                                     LocatorPathElt::TupleElement(pair.lhsIdx)));
-    if (result.isFailure())
+    if (result == SolutionKind::Error)
       return result;
   }
 
-  return getTypeMatchSuccess();
+  return SolutionKind::Solved;
 }
 
-ConstraintSystem::TypeMatchResult
+ConstraintSystem::SolutionKind
 ConstraintSystem::matchPackTypes(PackType *pack1, PackType *pack2,
                                  ConstraintKind kind, TypeMatchOptions flags,
                                  ConstraintLocatorBuilder locator) {
@@ -2203,17 +2203,17 @@ ConstraintSystem::matchPackTypes(PackType *pack1, PackType *pack2,
                       getASTContext(), isPackExpansionType);
 
   if (matcher.match())
-    return getTypeMatchFailure(locator);
+    return SolutionKind::Error;
 
   for (auto pair : matcher.pairs) {
     auto result = matchTypes(pair.lhs, pair.rhs, kind, subflags,
                              locator.withPathElement(
                                  LocatorPathElt::PackElement(pair.lhsIdx)));
-    if (result.isFailure())
+    if (result == SolutionKind::Error)
       return result;
   }
 
-  return getTypeMatchSuccess();
+  return SolutionKind::Solved;
 }
 
 /// Utility function used when matching a pack expansion type against a
@@ -2354,7 +2354,7 @@ static PackType *replaceTypeVariablesWithFreshPacks(ConstraintSystem &cs,
   return PackType::get(cs.getASTContext(), elts);
 }
 
-ConstraintSystem::TypeMatchResult
+ConstraintSystem::SolutionKind
 ConstraintSystem::matchPackExpansionTypes(PackExpansionType *expansion1,
                                           PackExpansionType *expansion2,
                                           ConstraintKind kind, TypeMatchOptions flags,
@@ -2375,7 +2375,7 @@ ConstraintSystem::matchPackExpansionTypes(PackExpansionType *expansion1,
     if (hasFixFor(getConstraintLocator(shapeLocator))) {
       recordAnyTypeVarAsPotentialHole(pattern1);
       recordAnyTypeVarAsPotentialHole(pattern2);
-      return getTypeMatchSuccess();
+      return SolutionKind::Solved;
     }
   }
 
@@ -2398,7 +2398,7 @@ ConstraintSystem::matchPackExpansionTypes(PackExpansionType *expansion1,
     }
 
     if (!(pattern1 && pattern2)) {
-      return getTypeMatchFailure(locator);
+      return SolutionKind::Error;
     }
   }
 
@@ -2822,7 +2822,7 @@ bool ConstraintSystem::hasPreconcurrencyCallee(
 }
 
 /// Match the throwing specifier of the two function types.
-static ConstraintSystem::TypeMatchResult
+static ConstraintSystem::SolutionKind
 matchFunctionThrowing(ConstraintSystem &cs,
                       FunctionType *func1, FunctionType *func2,
                       ConstraintKind kind,
@@ -2835,7 +2835,7 @@ matchFunctionThrowing(ConstraintSystem &cs,
   Type thrownError1 = func1->getEffectiveThrownErrorTypeOrNever();
   Type thrownError2 = func2->getEffectiveThrownErrorTypeOrNever();
   if (!thrownError1 || !thrownError2)
-    return cs.getTypeMatchSuccess();
+    return ConstraintSystem::SolutionKind::Solved;
 
   // An attempt to erase typed throws into `throws` requires a function
   // conversion and a heap allocation for the error type, so if there is an
@@ -2851,18 +2851,18 @@ matchFunctionThrowing(ConstraintSystem &cs,
   case ThrownErrorSubtyping::DropsThrows: {
     // We need to drop 'throws' to make this work.
     if (!cs.shouldAttemptFixes())
-      return cs.getTypeMatchFailure(locator);
+      return ConstraintSystem::SolutionKind::Error;
 
     auto *fix = DropThrowsAttribute::create(cs, func1, func2,
                                             cs.getConstraintLocator(locator));
     if (cs.recordFix(fix))
-      return cs.getTypeMatchFailure(locator);
+      return ConstraintSystem::SolutionKind::Error;
 
-    return cs.getTypeMatchSuccess();
+    return ConstraintSystem::SolutionKind::Solved;
   }
 
   case ThrownErrorSubtyping::ExactMatch:
-    return cs.getTypeMatchSuccess();
+    return ConstraintSystem::SolutionKind::Solved;
 
   case ThrownErrorSubtyping::Subtype:
     // We know this is going to work, but we might still need to generate a
@@ -2871,10 +2871,10 @@ matchFunctionThrowing(ConstraintSystem &cs,
       // Fall through to the dependent case.
     } else if (kind < ConstraintKind::Subtype) {
       // We aren't allowed to have a subtype, so fail here.
-      return cs.getTypeMatchFailure(locator);
+      return ConstraintSystem::SolutionKind::Error;
     } else {
       // We have a subtype. All set!
-      return cs.getTypeMatchSuccess();
+      return ConstraintSystem::SolutionKind::Solved;
     }
     LLVM_FALLTHROUGH;
 
@@ -2890,28 +2890,28 @@ matchFunctionThrowing(ConstraintSystem &cs,
         subKind, subflags,
         locator.withPathElement(LocatorPathElt::ThrownErrorType()));
     if (result == ConstraintSystem::SolutionKind::Error)
-      return cs.getTypeMatchFailure(locator);
+      return ConstraintSystem::SolutionKind::Error;
 
-    return cs.getTypeMatchSuccess();
+    return ConstraintSystem::SolutionKind::Solved;
   }
 
   case ThrownErrorSubtyping::Mismatch: {
     auto thrownErrorLocator = cs.getConstraintLocator(
         locator.withPathElement(LocatorPathElt::ThrownErrorType()));
     if (!cs.shouldAttemptFixes())
-      return cs.getTypeMatchFailure(thrownErrorLocator);
+      return ConstraintSystem::SolutionKind::Error;
 
     auto *fix = IgnoreThrownErrorMismatch::create(
         cs, thrownError1, thrownError2, thrownErrorLocator);
     if (cs.recordFix(fix))
-      return cs.getTypeMatchFailure(thrownErrorLocator);
+      return ConstraintSystem::SolutionKind::Error;
 
-    return cs.getTypeMatchSuccess();
+    return ConstraintSystem::SolutionKind::Solved;
   }
   }
 }
 
-ConstraintSystem::TypeMatchResult ConstraintSystem::matchFunctionSendability(
+ConstraintSystem::SolutionKind ConstraintSystem::matchFunctionSendability(
     FunctionType *func1, FunctionType *func2, ConstraintKind kind,
     ConstraintSystem::TypeMatchOptions flags,
     ConstraintLocatorBuilder locator) {
@@ -2921,9 +2921,9 @@ ConstraintSystem::TypeMatchResult ConstraintSystem::matchFunctionSendability(
       auto *constraint = Constraint::create(*this, kind, func1, func2,
                                             getConstraintLocator(locator));
       addUnsolvedConstraint(constraint);
-      return getTypeMatchSuccess();
+      return SolutionKind::Solved;
     }
-    return getTypeMatchAmbiguous();
+    return SolutionKind::Unsolved;
   };
 
   // First check to see if we have any sendable dependent function types, if
@@ -2951,10 +2951,10 @@ ConstraintSystem::TypeMatchResult ConstraintSystem::matchFunctionSendability(
     // A @Sendable function can be a subtype of a non-@Sendable function.
     if (kind < ConstraintKind::Subtype || func2Sendable) {
       if (AddSendableAttribute::attempt(*this, kind, func1, func2, locator))
-        return getTypeMatchFailure(locator);
+        return SolutionKind::Error;
     }
   }
-  return getTypeMatchSuccess();
+  return SolutionKind::Solved;
 }
 
 static bool isWitnessMatching(ConstraintLocatorBuilder locator) {
@@ -3211,7 +3211,7 @@ bool ConstraintSystem::matchFunctionLifetimes(
   return true;
 }
 
-ConstraintSystem::TypeMatchResult
+ConstraintSystem::SolutionKind
 ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
                                      ConstraintKind kind, TypeMatchOptions flags,
                                      ConstraintLocatorBuilder locator) {
@@ -3222,9 +3222,9 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
   }
 
   // Match the 'throws' effect.
-  TypeMatchResult throwsResult =
+  SolutionKind throwsResult =
       matchFunctionThrowing(*this, func1, func2, kind, flags, locator);
-  if (throwsResult.isFailure())
+  if (throwsResult == SolutionKind::Error)
     return throwsResult;
 
   // A synchronous function can be a subtype of an 'async' function.
@@ -3232,12 +3232,12 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
     // Cannot drop 'async'.
     if (func1->isAsync() || kind < ConstraintKind::Subtype) {
       if (!shouldAttemptFixes())
-        return getTypeMatchFailure(locator);
+        return SolutionKind::Error;
 
       auto *fix = DropAsyncAttribute::create(*this, func1, func2,
                                              getConstraintLocator(locator));
       if (recordFix(fix))
-        return getTypeMatchFailure(locator);
+        return SolutionKind::Error;
     }
 
     bool forClosureInArgumentPosition =
@@ -3257,7 +3257,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
   auto sendableResult = matchFunctionSendability(
       func1, func2, kind, TMF_GenerateConstraints,
       locator.withPathElement(ConstraintLocator::FunctionSendability));
-  if (sendableResult.isFailure())
+  if (sendableResult == SolutionKind::Error)
     return sendableResult;
 
   // A non-@noescape function type can be a subtype of a @noescape function
@@ -3265,13 +3265,13 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
   if (func1->isNoEscape() != func2->isNoEscape() &&
       (func1->isNoEscape() || kind < ConstraintKind::Subtype)) {
     if (!shouldAttemptFixes())
-      return getTypeMatchFailure(locator);
+      return SolutionKind::Error;
 
     auto *fix = MarkExplicitlyEscaping::create(*this, func1, func2,
                                                getConstraintLocator(locator));
 
     if (recordFix(fix))
-      return getTypeMatchFailure(locator);
+      return SolutionKind::Error;
   }
 
   // () -> sending T can be a subtype of () -> T... but not vis-a-versa.
@@ -3280,14 +3280,14 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
     auto *fix = AllowSendingMismatch::create(*this, func1, func2,
                                              getConstraintLocator(locator));
     if (recordFix(fix))
-      return getTypeMatchFailure(locator);
+      return SolutionKind::Error;
   }
 
   if (!matchFunctionIsolations(func1, func2, kind, flags, locator))
-    return getTypeMatchFailure(locator);
+    return SolutionKind::Error;
 
   if (!matchFunctionLifetimes(func1, func2, locator))
-    return getTypeMatchFailure(locator);
+    return SolutionKind::Error;
 
   // To contextual type increase the score to avoid ambiguity when solver can
   // find more than one viable binding different only in representation e.g.
@@ -3301,7 +3301,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
 
   if (!matchFunctionRepresentations(func1->getExtInfo(), func2->getExtInfo(),
                                     kind, Options)) {
-    return getTypeMatchFailure(locator);
+    return SolutionKind::Error;
   }
 
   // Determine how we match up the input/result types.
@@ -3536,7 +3536,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
         auto *fix = AllowClosureParamDestructuring::create(
             *this, func2, getConstraintLocator(anchor));
         if (recordFix(fix))
-          return getTypeMatchFailure(argumentLocator);
+          return SolutionKind::Error;
 
         implodeParams(func1Params);
       }
@@ -3580,7 +3580,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
     ParamPackMatcher matcher(func1Params, func2Params, getASTContext(),
                              isPackExpansionType);
     if (matcher.match())
-      return getTypeMatchFailure(locator);
+      return SolutionKind::Error;
 
     for (auto pair : matcher.pairs) {
       // Compare the parameter types, taking contravariance into account.
@@ -3589,14 +3589,14 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
                                 ? argumentLocator
                                 : argumentLocator.withPathElement(
                                   LocatorPathElt::TupleElement(pair.lhsIdx))));
-      if (result.isFailure())
+      if (result == SolutionKind::Error)
         return result;
     }
   } else {
     int diff = func1Params.size() - func2Params.size();
     if (diff != 0) {
       if (!shouldAttemptFixes())
-        return getTypeMatchFailure(argumentLocator);
+        return SolutionKind::Error;
 
       auto *loc = getConstraintLocator(locator);
 
@@ -3613,7 +3613,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
 
       auto anchor = simplifyLocatorToAnchor(loc);
       if (!anchor)
-        return getTypeMatchFailure(argumentLocator);
+        return SolutionKind::Error;
 
       // The param diff is in a function type coercion context
       //
@@ -3628,19 +3628,19 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
       if (loc->isForCoercion() && !isExpr<ClosureExpr>(anchor)) {
         auto *fix = ContextualMismatch::create(*this, func1, func2, loc);
         if (recordFix(fix))
-          return getTypeMatchFailure(argumentLocator);
+          return SolutionKind::Error;
       } else {
         // If there are missing arguments, let's add them
         // using parameter as a template.
         if (diff < 0) {
           if (fixMissingArguments(*this, anchor, func1Params, func2Params,
                                   abs(diff), loc))
-            return getTypeMatchFailure(argumentLocator);
+            return SolutionKind::Error;
         } else {
           // If there are extraneous arguments, let's remove
           // them from the list.
           if (fixExtraneousArguments(*this, func2, func1Params, diff, loc))
-            return getTypeMatchFailure(argumentLocator);
+            return SolutionKind::Error;
         }
       }
 
@@ -3679,7 +3679,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
       // Variadic bit must match.
       if (func1Param.isVariadic() != func2Param.isVariadic()) {
         if (!(shouldAttemptFixes() && func2Param.isVariadic()))
-          return getTypeMatchFailure(argumentLocator);
+          return SolutionKind::Error;
 
         auto argType =
             getFixedTypeRecursive(func1Param.getPlainType(), /*wantRValue=*/true);
@@ -3689,7 +3689,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
         if (argType->is<TypeVariableType>()) {
           addUnsolvedConstraint(Constraint::create(
               *this, kind, func1, func2, getConstraintLocator(locator)));
-          return getTypeMatchSuccess();
+          return SolutionKind::Solved;
         }
 
         auto *fix = ExpandArrayIntoVarargs::attempt(
@@ -3698,7 +3698,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
                 i, i, func2Param.getParameterFlags())));
 
         if (!fix || recordFix(fix))
-          return getTypeMatchFailure(argumentLocator);
+          return SolutionKind::Error;
 
         continue;
       }
@@ -3710,7 +3710,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
       // directly building constraint systems.
       if (func1Param.getLabel() != func2Param.getLabel()) {
         if (!shouldAttemptFixes())
-          return getTypeMatchFailure(argumentLocator);
+          return SolutionKind::Error;
 
         // If we are allowed to attempt fixes, let's ignore labeling
         // failures, and create a fix to re-label arguments if types
@@ -3721,14 +3721,14 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
       // "isolated" can be added as a subtype relation, but otherwise must match.
       if (func1Param.isIsolated() != func2Param.isIsolated() &&
           !(func2Param.isIsolated() && subKind >= ConstraintKind::Subtype)) {
-        return getTypeMatchFailure(argumentLocator);
+        return SolutionKind::Error;
       }
 
       // If functions are differentiable, ensure that @noDerivative is not
       // discarded.
       if (func1->isDifferentiable() && func2->isDifferentiable() &&
           func1Param.isNoDerivative() && !func2Param.isNoDerivative()) {
-        return getTypeMatchFailure(argumentLocator);
+        return SolutionKind::Error;
       }
 
       // Do not allow for functions that expect a sending parameter to match
@@ -3738,7 +3738,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
         auto *fix = AllowSendingMismatch::create(
             *this, func1, func2, getConstraintLocator(argumentLocator));
         if (recordFix(fix))
-          return getTypeMatchFailure(argumentLocator);
+          return SolutionKind::Error;
       }
 
       // FIXME: We should check value ownership too, but it's not completely
@@ -3750,7 +3750,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
           (func1Params.size() == 1 ? argumentLocator
                                    : argumentLocator.withPathElement(
                                          LocatorPathElt::TupleElement(i))));
-      if (result.isFailure())
+      if (result == SolutionKind::Error)
         return result;
     }
 
@@ -3761,7 +3761,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
               : ContextualMismatch::create(*this, func1, func2, loc);
 
       if (recordFix(fix))
-        return getTypeMatchFailure(argumentLocator);
+        return SolutionKind::Error;
     }
   }
 
@@ -3771,7 +3771,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
                     locator.withPathElement(ConstraintLocator::FunctionResult));
 }
 
-ConstraintSystem::TypeMatchResult
+ConstraintSystem::SolutionKind
 ConstraintSystem::matchSuperclassTypes(Type type1, Type type2,
                                        TypeMatchOptions flags,
                                        ConstraintLocatorBuilder locator) {
@@ -3795,25 +3795,25 @@ ConstraintSystem::matchSuperclassTypes(Type type1, Type type2,
                       subflags, locator);
   }
 
-  return getTypeMatchFailure(locator);
+  return SolutionKind::Error;
 }
 
-static ConstraintSystem::TypeMatchResult matchDeepTypeArguments(
+static ConstraintSystem::SolutionKind matchDeepTypeArguments(
     ConstraintSystem &cs, ConstraintSystem::TypeMatchOptions subflags,
     ArrayRef<Type> args1, ArrayRef<Type> args2,
     ConstraintLocatorBuilder locator,
     llvm::function_ref<void(unsigned)> recordMismatch = [](unsigned) {}) {
   if (args1.size() != args2.size()) {
-    return cs.getTypeMatchFailure(locator);
+    return ConstraintSystem::SolutionKind::Error;
   }
 
-  auto allMatch = cs.getTypeMatchSuccess();
+  auto allMatch = ConstraintSystem::SolutionKind::Solved;
   for (unsigned i = 0, n = args1.size(); i != n; ++i) {
     auto result = cs.matchTypes(
         args1[i], args2[i], ConstraintKind::Bind, subflags,
         locator.withPathElement(LocatorPathElt::GenericArgument(i)));
 
-    if (result.isFailure()) {
+    if (result == ConstraintSystem::SolutionKind::Error) {
       recordMismatch(i);
       allMatch = result;
     }
@@ -3937,7 +3937,7 @@ static bool matchSendableExistentialToAnyInGenericArgumentPosition(
   return true;
 }
 
-ConstraintSystem::TypeMatchResult
+ConstraintSystem::SolutionKind
 ConstraintSystem::matchDeepEqualityTypes(Type type1, Type type2,
                                          ConstraintLocatorBuilder locator) {
   TypeMatchOptions subflags = TMF_GenerateConstraints;
@@ -3950,7 +3950,7 @@ ConstraintSystem::matchDeepEqualityTypes(Type type1, Type type2,
     // It's possible to declare a generic requirement like Self == Self.Iterator
     // where both types are going to be opaque.
     if (!opaque1->getInterfaceType()->isEqual(opaque2->getInterfaceType()))
-      return getTypeMatchFailure(locator);
+      return SolutionKind::Error;
 
     auto args1 = opaque1->getSubstitutions().getReplacementTypes();
     auto args2 = opaque2->getSubstitutions().getReplacementTypes();
@@ -3969,15 +3969,15 @@ ConstraintSystem::matchDeepEqualityTypes(Type type1, Type type2,
       auto anchor = locator.getAnchor();
       // TODO(diagnostics): Only assignments are supported at the moment.
       if (!isExpr<AssignExpr>(anchor))
-        return getTypeMatchFailure(locator);
+        return SolutionKind::Error;
 
       auto *fix = IgnoreAssignmentDestinationType::create(
           *this, type1, type2, getConstraintLocator(locator));
 
       if (recordFix(fix, /*impact=*/FixImpact::Mismatch * numMismatches))
-        return getTypeMatchFailure(locator);
+        return SolutionKind::Error;
 
-      return getTypeMatchSuccess();
+      return SolutionKind::Solved;
     }
 
     return result;
@@ -4003,7 +4003,7 @@ ConstraintSystem::matchDeepEqualityTypes(Type type1, Type type2,
   // `any Sendable` -> `Any`
   if (matchSendableExistentialToAnyInGenericArgumentPosition(*this, type1,
                                                              type2, locator))
-    return getTypeMatchSuccess();
+    return SolutionKind::Solved;
 
   // Handle existential types.
   if (auto *existential1 = type1->getAs<ExistentialType>()) {
@@ -4014,10 +4014,10 @@ ConstraintSystem::matchDeepEqualityTypes(Type type1, Type type2,
         ConstraintKind::Bind, subflags,
         locator.withPathElement(ConstraintLocator::ExistentialConstraintType));
 
-    if (result.isFailure())
+    if (result == SolutionKind::Error)
       return result;
 
-    return getTypeMatchSuccess();
+    return SolutionKind::Solved;
   }
 
   // Arguments of parameterized protocol types have to match on the nose.
@@ -4030,7 +4030,7 @@ ConstraintSystem::matchDeepEqualityTypes(Type type1, Type type2,
                              locator.withPathElement(
                                ConstraintLocator::ParentType));
 
-    if (result.isFailure())
+    if (result == SolutionKind::Error)
       return result;
 
     return matchDeepTypeArguments(*this, subflags,
@@ -4046,11 +4046,11 @@ ConstraintSystem::matchDeepEqualityTypes(Type type1, Type type2,
     auto members1 = pct1->getMembers();
     auto members2 = pct2->getMembers();
     if (members1.size() != members2.size())
-      return getTypeMatchFailure(locator);
+      return SolutionKind::Error;
     if (pct1->getInverses() != pct2->getInverses())
-      return getTypeMatchFailure(locator);
+      return SolutionKind::Error;
     if (pct1->hasExplicitAnyObject() != pct2->hasExplicitAnyObject())
-      return getTypeMatchFailure(locator);
+      return SolutionKind::Error;
     for (unsigned i = 0, e = members1.size(); i < e; ++i) {
       auto member1 = members1[i];
       auto member2 = members2[i];
@@ -4058,11 +4058,11 @@ ConstraintSystem::matchDeepEqualityTypes(Type type1, Type type2,
                           LocatorPathElt::ProtocolCompositionMemberType(i));
       auto result = matchTypes(member1, member2, ConstraintKind::Bind, subflags,
                                subLocator);
-      if (result.isFailure())
+      if (result == SolutionKind::Error)
         return result;
     }
 
-    return getTypeMatchSuccess();
+    return SolutionKind::Solved;
   }
 
   // Handle nominal types that are not directly generic.
@@ -4073,7 +4073,7 @@ ConstraintSystem::matchDeepEqualityTypes(Type type1, Type type2,
            "Mismatched parents of nominal types");
 
     if (!nominal1->getParent())
-      return getTypeMatchSuccess();
+      return SolutionKind::Solved;
 
     // Match up the parents, exactly.
     return matchTypes(nominal1->getParent(), nominal2->getParent(),
@@ -4092,7 +4092,7 @@ ConstraintSystem::matchDeepEqualityTypes(Type type1, Type type2,
                              ConstraintKind::Bind, subflags,
                              locator.withPathElement(
                                                 ConstraintLocator::ParentType));
-    if (result.isFailure())
+    if (result == SolutionKind::Error)
       return result;
   }
 
@@ -4142,10 +4142,10 @@ ConstraintSystem::matchDeepEqualityTypes(Type type1, Type type2,
       if (path.back().is<LocatorPathElt::AnyRequirement>()) {
         if (auto *fix = fixRequirementFailure(*this, type1, type2, locator)) {
           if (recordFix(fix))
-            return getTypeMatchFailure(locator);
+            return SolutionKind::Error;
 
           increaseScore(SK_Fix, loc, mismatches.size());
-          return getTypeMatchSuccess();
+          return SolutionKind::Solved;
         }
       }
     }
@@ -4167,14 +4167,14 @@ ConstraintSystem::matchDeepEqualityTypes(Type type1, Type type2,
         *this, type1, type2, mismatches, loc);
 
     if (!recordFix(fix, impact))
-      return getTypeMatchSuccess();
+      return SolutionKind::Solved;
 
     return result;
   }
   return matchDeepTypeArguments(*this, subflags, args1, args2, locator);
 }
 
-ConstraintSystem::TypeMatchResult
+ConstraintSystem::SolutionKind
 ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
                                         ConstraintKind kind,
                                         TypeMatchOptions flags,
@@ -4186,15 +4186,15 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
       addUnsolvedConstraint(
         Constraint::create(*this, kind, type1, type2,
                            getConstraintLocator(locator)));
-      return getTypeMatchSuccess();
+      return SolutionKind::Solved;
     }
 
-    return getTypeMatchAmbiguous();
+    return SolutionKind::Unsolved;
   }
 
   // FIXME: Feels like a hack.
   if (type1->is<InOutType>())
-    return getTypeMatchFailure(locator);
+    return SolutionKind::Error;
 
   // FIXME; Feels like a hack...nothing actually "conforms" here, and
   // we need to disallow conversions from types containing @noescape
@@ -4207,10 +4207,10 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
       auto *fix = MarkExplicitlyEscaping::create(*this, type1, type2,
                                                  getConstraintLocator(locator));
       if (!recordFix(fix))
-        return getTypeMatchSuccess();
+        return SolutionKind::Solved;
     }
 
-    return getTypeMatchFailure(locator);
+    return SolutionKind::Error;
   }
 
   TypeMatchOptions subflags = getDefaultDecompositionOptions(flags);
@@ -4232,7 +4232,7 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
   }
 
   if (!type2->isExistentialType())
-    return getTypeMatchFailure(locator);
+    return SolutionKind::Error;
 
   auto layout = type2->getExistentialLayout();
 
@@ -4250,24 +4250,24 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
               // more interesting for diagnostics.
               auto req = last->getAs<LocatorPathElt::AnyRequirement>();
               if (!req)
-                return getTypeMatchFailure(locator);
+                return SolutionKind::Error;
 
               // Superclass constraints are never satisfied by existentials,
               // even those that contain the superclass a la `any C & P`.
               if (!type1->isExistentialType() &&
                   (type1->isPlaceholder() ||
                   req->getRequirementKind() == RequirementKind::Superclass))
-                return getTypeMatchSuccess();
+                return SolutionKind::Solved;
 
               auto *fix = fixRequirementFailure(*this, type1, type2, locator);
               if (fix && !recordFix(fix)) {
                 recordFixedRequirement(getConstraintLocator(locator), type2);
-                return getTypeMatchSuccess();
+                return SolutionKind::Solved;
               }
             }
           }
 
-          return getTypeMatchFailure(locator);
+          return SolutionKind::Error;
         }
       } else {
         // Subtype relation to AnyObject also allows class-bound
@@ -4295,19 +4295,19 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
               if (fixLoc->directlyAt<AssignExpr>()) {
                 auto *fix = IgnoreAssignmentDestinationType::create(
                     *this, type1, type2, fixLoc);
-                return recordFix(fix) ? getTypeMatchFailure(locator)
-                                      : getTypeMatchSuccess();
+                return recordFix(fix) ? SolutionKind::Error
+                                      : SolutionKind::Solved;
               }
 
               auto *fix = AllowNonClassTypeToConvertToAnyObject::create(
                   *this, type1, fixLoc);
 
-              return recordFix(fix) ? getTypeMatchFailure(locator)
-                                    : getTypeMatchSuccess();
+              return recordFix(fix) ? SolutionKind::Error
+                                    : SolutionKind::Solved;
             }
           }
 
-          return getTypeMatchFailure(locator);
+          return SolutionKind::Error;
         }
       }
 
@@ -4319,7 +4319,7 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
     auto result = matchTypes(type1, layout.explicitSuperclass,
                              ConstraintKind::Subtype,
                              subflags, locator);
-    if (result.isFailure())
+    if (result == SolutionKind::Error)
       return result;
   }
 
@@ -4332,7 +4332,7 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
 
       case SolutionKind::Error: {
         if (!shouldAttemptFixes())
-          return getTypeMatchFailure(locator);
+          return SolutionKind::Error;
 
         SmallVector<LocatorPathElt, 4> path;
         auto anchor = locator.getLocatorParts(path);
@@ -4367,14 +4367,14 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
                 auto fix = ForceOptional::create(*this, type1, proto,
                                                  getConstraintLocator(locator));
                 if (recordFix(fix))
-                  return getTypeMatchFailure(locator);
+                  return SolutionKind::Error;
                 break;
               }
             }
             auto fix = AllowArgumentMismatch::create(
                   *this, type1, proto, getConstraintLocator(anchor, path));
             if (recordFix(fix, FixImpact::TypeMismatch))
-              return getTypeMatchFailure(locator);
+              return SolutionKind::Error;
             break;
           }
 
@@ -4383,7 +4383,7 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
             auto *fix = CollectionElementContextualMismatch::create(
                 *this, type1, type2, getConstraintLocator(anchor, path));
             if (recordFix(fix, FixImpact::TypeMismatch))
-              return getTypeMatchFailure(locator);
+              return SolutionKind::Error;
             break;
           }
 
@@ -4395,23 +4395,23 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
           // Once either reacher locators or better diagnostic presentation for
           // nested type failures is available this check could be removed.
           if (last.is<LocatorPathElt::FunctionResult>())
-            return getTypeMatchFailure(locator);
+            return SolutionKind::Error;
 
           // If instance types didn't line up correctly, let's produce a
           // diagnostic which mentions them together with their metatypes.
           if (last.is<LocatorPathElt::InstanceType>())
-            return getTypeMatchFailure(locator);
+            return SolutionKind::Error;
 
         } else { // There are no elements in the path
           if (!(isExpr<AssignExpr>(anchor) || isExpr<CoerceExpr>(anchor)))
-            return getTypeMatchFailure(locator);
+            return SolutionKind::Error;
         }
 
         if (isExpr<CoerceExpr>(anchor)) {
           auto *fix = ContextualMismatch::create(
               *this, type1, type2, getConstraintLocator(anchor, path));
           if (recordFix(fix))
-            return getTypeMatchFailure(locator);
+            return SolutionKind::Error;
           break;
         }
 
@@ -4420,7 +4420,7 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
             *this, type1, proto, getConstraintLocator(anchor, path));
 
         if (recordFix(fix))
-          return getTypeMatchFailure(locator);
+          return SolutionKind::Error;
 
         break;
       }
@@ -4463,7 +4463,7 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
               auto result = matchTypes(fromReq.second, argType,
                                        ConstraintKind::Bind,
                                        subflags, locator);
-              if (result.isFailure())
+              if (result == SolutionKind::Error)
                 return result;
 
               found = true;
@@ -4472,7 +4472,7 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
           }
 
           if (!found)
-            return getTypeMatchFailure(locator);
+            return SolutionKind::Error;
         }
       } else {
         // The source type is a concrete type.
@@ -4493,20 +4493,20 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
               continue;
             }
 
-            return TypeMatchResult::failure();
+            return SolutionKind::Error;
           }
 
           auto result = matchTypes(req.getFirstType(), req.getSecondType(),
                                    ConstraintKind::Bind,
                                    subflags, locator);
-          if (result.isFailure())
+          if (result == SolutionKind::Error)
             return result;
         }
       }
     }
   }
 
-  return getTypeMatchSuccess();
+  return SolutionKind::Solved;
 }
 
 static bool isStringCompatiblePointerBaseType(ASTContext &ctx,
@@ -4576,11 +4576,11 @@ static bool isBindable(TypeVariableType *typeVar, Type type) {
          !(type->is<TypeVariableType>() || type->is<DependentMemberType>());
 }
 
-ConstraintSystem::TypeMatchResult
+ConstraintSystem::SolutionKind
 ConstraintSystem::matchTypesBindTypeVar(
     TypeVariableType *typeVar, Type origType, ConstraintKind kind,
     TypeMatchOptions flags, ConstraintLocatorBuilder locator,
-    llvm::function_ref<TypeMatchResult()> formUnsolvedResult) {
+    llvm::function_ref<SolutionKind()> formUnsolvedResult) {
   assert(typeVar->is<TypeVariableType>() && "Expected a type variable!");
   assert(!origType->is<TypeVariableType>() && "Expected a non-type variable!");
 
@@ -4593,7 +4593,7 @@ ConstraintSystem::matchTypesBindTypeVar(
       // a particular (full resolved) type, just ignore this binding
       // instead of re-trying it and failing later.
       if (typeVar->getImpl().canBindToHole() && !type->hasTypeVariable())
-        return getTypeMatchSuccess();
+        return SolutionKind::Solved;
 
       // Just like in cases where both sides are dependent member types
       // with resolved base that can't be simplified to a concrete type
@@ -4608,7 +4608,7 @@ ConstraintSystem::matchTypesBindTypeVar(
         // member type never existed.
         increaseScore(SK_Hole, locator);
         recordPotentialHole(typeVar);
-        return getTypeMatchSuccess();
+        return SolutionKind::Solved;
       }
     }
 
@@ -4623,7 +4623,7 @@ ConstraintSystem::matchTypesBindTypeVar(
   // assignment should tread lightly and just fail
   // if it encounters such types.
   if (type->hasError())
-    return getTypeMatchFailure(locator);
+    return SolutionKind::Error;
 
   // Equal constraints allow mixed LValue/RValue bindings, but
   // if we bind a type to a type variable that can bind to
@@ -4667,18 +4667,18 @@ ConstraintSystem::matchTypesBindTypeVar(
   // but we still have an lvalue, fail.
   if (!typeVar->getImpl().canBindToLValue() && type->hasLValueType()) {
     if (shouldAttemptFixes() && fixReferenceMismatch(typeVar, type))
-      return getTypeMatchSuccess();
+      return SolutionKind::Solved;
 
-    return getTypeMatchFailure(locator);
+    return SolutionKind::Error;
   }
 
   // If the left-hand type variable cannot bind to an inout,
   // but we still have an inout, fail.
   if (!typeVar->getImpl().canBindToInOut() && type->is<InOutType>()) {
     if (shouldAttemptFixes() && fixReferenceMismatch(typeVar, type))
-      return getTypeMatchSuccess();
+      return SolutionKind::Solved;
 
-    return getTypeMatchFailure(locator);
+    return SolutionKind::Error;
   }
 
   // If the left-hand type variable cannot bind to a non-escaping type,
@@ -4688,11 +4688,11 @@ ConstraintSystem::matchTypesBindTypeVar(
       auto *fix = MarkExplicitlyEscaping::create(*this, typeVar, type,
                                                  getConstraintLocator(locator));
       if (recordFix(fix))
-        return getTypeMatchFailure(locator);
+        return SolutionKind::Error;
 
       // Allow no-escape function to be bound with recorded fix.
     } else {
-      return getTypeMatchFailure(locator);
+      return SolutionKind::Error;
     }
   }
 
@@ -4701,8 +4701,8 @@ ConstraintSystem::matchTypesBindTypeVar(
       return formUnsolvedResult();
 
     return resolvePackExpansion(typeVar, origType)
-               ? getTypeMatchSuccess()
-               : getTypeMatchFailure(locator);
+               ? SolutionKind::Solved
+               : SolutionKind::Error;
   }
 
   // If we're attempting to bind a PackType or PackArchetypeType to a type
@@ -4711,12 +4711,12 @@ ConstraintSystem::matchTypesBindTypeVar(
   if (!typeVar->getImpl().canBindToPack() &&
       (type->is<PackArchetypeType>() || type->is<PackType>())) {
     if (!shouldAttemptFixes())
-      return getTypeMatchFailure(locator);
+      return SolutionKind::Error;
 
     auto *fix = AllowInvalidPackReference::create(
         *this, type, getConstraintLocator(locator));
     if (recordFix(fix))
-      return getTypeMatchFailure(locator);
+      return SolutionKind::Error;
 
     // Don't allow the invalid pack reference to propagate to other
     // bindings.
@@ -4743,12 +4743,12 @@ ConstraintSystem::matchTypesBindTypeVar(
     if (!(typeVar->getImpl().canBindToPack() && representsParameterList) ||
         getASTContext().isLanguageModeAtLeast(LanguageMode::v6)) {
       if (!shouldAttemptFixes())
-        return getTypeMatchFailure(locator);
+        return SolutionKind::Error;
 
       auto *fix = AllowInvalidPackExpansion::create(
           *this, getConstraintLocator(locator));
       if (recordFix(fix))
-        return getTypeMatchFailure(locator);
+        return SolutionKind::Error;
 
       // Don't allow the pack expansion type to propagate to other
       // bindings.
@@ -4768,7 +4768,7 @@ ConstraintSystem::matchTypesBindTypeVar(
           *this, getConstraintLocator(locator));
 
       if (recordFix(fix))
-        return getTypeMatchFailure(locator);
+        return SolutionKind::Error;
     }
   }
 
@@ -4780,7 +4780,7 @@ ConstraintSystem::matchTypesBindTypeVar(
     // Bind type1 to Void only as a last resort.
     addConstraint(ConstraintKind::Defaultable, typeVar, type,
                   getConstraintLocator(locator));
-    return getTypeMatchSuccess();
+    return SolutionKind::Solved;
   }
 
   // When binding a fixed type to a type variable that cannot contain
@@ -4803,26 +4803,26 @@ ConstraintSystem::matchTypesBindTypeVar(
 
   if (typeVar->getImpl().isClosureType()) {
     return resolveClosure(typeVar, type, locator)
-               ? getTypeMatchSuccess()
-               : getTypeMatchFailure(locator);
+               ? SolutionKind::Solved
+               : SolutionKind::Error;
   }
 
   if (typeVar->getImpl().isTapType()) {
     return resolveTapBody(typeVar, type, locator)
-               ? getTypeMatchSuccess()
-               : getTypeMatchFailure(locator);
+               ? SolutionKind::Solved
+               : SolutionKind::Error;
   }
 
   if (typeVar->getImpl().isKeyPathType()) {
     return resolveKeyPath(typeVar, type, flags, locator)
-               ? getTypeMatchSuccess()
-               : getTypeMatchFailure(locator);
+               ? SolutionKind::Solved
+               : SolutionKind::Error;
   }
 
   assignFixedType(typeVar, type, /*updateState=*/true,
                   /*notifyInference=*/!flags.contains(TMF_BindingTypeVariable));
 
-  return getTypeMatchSuccess();
+  return SolutionKind::Solved;
 }
 
 static ConstraintFix *fixRequirementFailure(ConstraintSystem &cs, Type type1,
@@ -5185,7 +5185,7 @@ repairViaOptionalUnwrap(ConstraintSystem &cs, Type fromType, Type toType,
   auto result =
       cs.matchTypes(fromObjectType, toObjectType, matchKind,
                     ConstraintSystem::TypeMatchFlags::TMF_ApplyingFix, locator);
-  if (!result.isSuccess())
+  if (result != ConstraintSystem::SolutionKind::Solved)
     return false;
 
   conversionsOrFixes.push_back(ForceOptional::create(
@@ -5287,13 +5287,13 @@ static bool repairOutOfOrderArgumentsInBinaryFunction(
                        fnType->getParams()[paramIdx].getParameterFlags()));
   };
 
-  auto matchArgToParam = [&](Type argType, Type paramType, unsigned argIdx) {
-    auto *loc = getReorderedArgumentLocator(argIdx);
+  auto matchArgToParam = [&](Type argType, Type paramType, unsigned argIdx)
+      -> ConstraintSystem::SolutionKind {
     // If argument (and/or parameter) is a generic type let's not even try this
     // fix because it would be impossible to match given types  without delaying
     // until more context becomes available.
     if (argType->hasTypeVariable() || paramType->hasTypeVariable())
-      return cs.getTypeMatchFailure(loc);
+      return ConstraintSystem::SolutionKind::Error;
 
     // FIXME: There is currently no easy way to avoid attempting
     // fixes, matchTypes do not propagate `TMF_ApplyingFix` flag.
@@ -5312,9 +5312,10 @@ static bool repairOutOfOrderArgumentsInBinaryFunction(
           getObjectTypeAndNumUnwraps(paramType);
 
       if (numArgUnwraps > numParamUnwraps)
-        return cs.getTypeMatchFailure(loc);
+        return ConstraintSystem::SolutionKind::Error;
     }
 
+    auto *loc = getReorderedArgumentLocator(argIdx);
     return cs.matchTypes(
         argType, paramType,
         isOperatorRef ? ConstraintKind::OperatorArgumentConversion
@@ -5323,7 +5324,7 @@ static bool repairOutOfOrderArgumentsInBinaryFunction(
   };
 
   auto result = matchArgToParam(argType, paramType, currArgIdx);
-  if (result.isSuccess()) {
+  if (result == ConstraintSystem::SolutionKind::Solved) {
     // Let's check whether other argument matches current parameter type,
     // if it does - it's definitely out-of-order arguments issue.
     auto *otherArgLoc = getReorderedArgumentLocator(otherArgIdx);
@@ -5336,7 +5337,7 @@ static bool repairOutOfOrderArgumentsInBinaryFunction(
     paramType = fnType->getParams()[currArgIdx].getOldType();
 
     result = matchArgToParam(argType, paramType, otherArgIdx);
-    if (result.isSuccess()) {
+    if (result == ConstraintSystem::SolutionKind::Solved) {
       conversionsOrFixes.push_back(MoveOutOfOrderArgument::create(
           cs, otherArgIdx, currArgIdx, {{0}, {1}}, parentLoc));
       return true;
@@ -5444,7 +5445,7 @@ bool ConstraintSystem::repairFailures(
     auto result = matchTypes(resultType, dstType, matchKind,
                              TypeMatchFlags::TMF_ApplyingFix, locator);
 
-    if (result.isSuccess()) {
+    if (result == SolutionKind::Solved) {
       conversionsOrFixes.push_back(
           InsertExplicitCall::create(*this, getConstraintLocator(locator)));
       return true;
@@ -5484,7 +5485,7 @@ bool ConstraintSystem::repairFailures(
       auto result = matchTypes(lhs, rhs->getWithoutSpecifierType(), kind,
                                TMF_ApplyingFix, locator);
 
-      if (result.isSuccess()) {
+      if (result == SolutionKind::Solved) {
         // If left side is a hole, let's not record a fix since hole can
         // assume any type and already represents a problem elsewhere in
         // the expression.
@@ -5532,7 +5533,7 @@ bool ConstraintSystem::repairFailures(
 
     auto result = matchTypes(valueType, rawValue, ConstraintKind::Conversion,
                              TMF_ApplyingFix, locator);
-    return !result.isFailure();
+    return result != SolutionKind::Error;
   };
 
   // Check whether given `rawReprType` does indeed conform to `RawRepresentable`
@@ -5809,7 +5810,7 @@ bool ConstraintSystem::repairFailures(
                                TMF_ApplyingFix, locator);
       
       auto *loc = getConstraintLocator(locator);
-      if (destIsOrCanBindToLValue || result.isFailure()) {
+      if (destIsOrCanBindToLValue || result == SolutionKind::Error) {
         // Let this assignment failure be diagnosed by the
         // AllowTupleTypeMismatch fix already recorded.
         if (hasFixFor(loc, FixKind::AllowTupleTypeMismatch))
@@ -5856,7 +5857,7 @@ bool ConstraintSystem::repairFailures(
             if (!strippedLHS->isEqual(lhs) || !strippedRHS->isEqual(rhs)) {
               auto result = matchTypes(strippedLHS, strippedRHS, matchKind,
                                        flags | TMF_ApplyingFix, locator);
-              if (!result.isFailure()) {
+              if (result != SolutionKind::Error) {
                 increaseScore(SK_MissingSynthesizableConformance, locator);
                 return true;
               }
@@ -5918,7 +5919,7 @@ bool ConstraintSystem::repairFailures(
                                  TMF_ApplyingFix, locator);
 
         ConstraintFix *fix = nullptr;
-        if (result.isFailure()) {
+        if (result == SolutionKind::Error) {
           // If this is a "destination" argument to a mutating operator
           // like `+=`, let's consider it contextual and only attempt
           // to fix type mismatch on the "source" right-hand side of
@@ -6050,7 +6051,7 @@ bool ConstraintSystem::repairFailures(
                                ConstraintKind::BindToPointerType,
                                TypeMatchFlags::TMF_ApplyingFix, locator);
 
-      if (result.isSuccess()) {
+      if (result == SolutionKind::Solved) {
         conversionsOrFixes.push_back(AddAddressOf::create(
             *this, lhs, rhs, getConstraintLocator(locator)));
         break;
@@ -6066,7 +6067,7 @@ bool ConstraintSystem::repairFailures(
                                  ConstraintKind::ArgumentConversion,
                                  TypeMatchFlags::TMF_ApplyingFix, locator);
 
-        if (result.isSuccess()) {
+        if (result == SolutionKind::Solved) {
           conversionsOrFixes.push_back(RemoveAddressOf::create(
               *this, lhs, rhs, getConstraintLocator(locator)));
           break;
@@ -6095,7 +6096,7 @@ bool ConstraintSystem::repairFailures(
               TypeMatchOptions flags;
               return matchTypes(newBase, rhs, ConstraintKind::Subtype, flags,
                                 getConstraintLocator(locator))
-                  .isSuccess();
+                  == SolutionKind::Solved;
             },
             rhs)) {
       conversionsOrFixes.push_back(fix);
@@ -6335,7 +6336,7 @@ bool ConstraintSystem::repairFailures(
                                getDefaultDecompositionOptions(TMF_ApplyingFix),
                                locator);
 
-      if (result.isSuccess()) {
+      if (result == SolutionKind::Solved) {
         conversionsOrFixes.push_back(AllowInOutConversion::create(*this, lhs,
             rhs, getConstraintLocator(locator)));
         break;
@@ -6605,7 +6606,7 @@ bool ConstraintSystem::repairFailures(
           TypeMatchFlags::TMF_ApplyingFix,
           locator.withPathElement(ConstraintLocator::FunctionArgument));
 
-      if (result.isSuccess())
+      if (result == SolutionKind::Solved)
         conversionsOrFixes.push_back(AllowAutoClosurePointerConversion::create(
             *this, lhs, rhs, getConstraintLocator(locator)));
     }
@@ -6809,7 +6810,7 @@ bool ConstraintSystem::repairFailures(
       auto result = matchTypes(lhs->getWithoutSpecifierType(), rhs, matchKind,
                                TMF_ApplyingFix, locator);
 
-      if (result.isSuccess()) {
+      if (result == SolutionKind::Solved) {
         conversionsOrFixes.push_back(
             TreatRValueAsLValue::create(*this, getConstraintLocator(locator)));
       }
@@ -7236,7 +7237,7 @@ ConstraintSystem::getImpliedResultConversionKind(ConstraintLocator *locator) {
   return ImpliedResultConversionKind::None;
 }
 
-ConstraintSystem::TypeMatchResult
+ConstraintSystem::SolutionKind
 ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
                              TypeMatchOptions flags,
                              ConstraintLocatorBuilder locator) {
@@ -7255,7 +7256,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
   // assert (clients should instead use holes), but for now let's bail out of
   // solving.
   if (desugar1->hasError() || desugar2->hasError())
-    return getTypeMatchFailure(locator);
+    return SolutionKind::Error;
 
   // If both sides are dependent members without type variables, it's
   // possible that base type is incorrect e.g. `Foo.Element` where `Foo`
@@ -7266,7 +7267,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
         desugar2->is<DependentMemberType>())) {
     // If the types are obviously equivalent, we're done.
     if (desugar1->isEqual(desugar2) && !isa<InOutType>(desugar2)) {
-      return getTypeMatchSuccess();
+      return SolutionKind::Solved;
     }
   }
 
@@ -7294,10 +7295,10 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
         addUnsolvedConstraint(Constraint::create(
             *this, kind, type1, type2, getConstraintLocator(locator)));
       }
-      return getTypeMatchSuccess();
+      return SolutionKind::Solved;
     }
 
-    return getTypeMatchAmbiguous();
+    return SolutionKind::Unsolved;
   };
 
   auto *typeVar1 = dyn_cast<TypeVariableType>(desugar1);
@@ -7313,7 +7314,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       if (rep1 == rep2) {
         // We already merged these two types, so this constraint is
         // trivially solved.
-        return getTypeMatchSuccess();
+        return SolutionKind::Solved;
       }
     }
 
@@ -7340,7 +7341,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
 
         // Merge the equivalence classes corresponding to these two variables.
         mergeEquivalenceClasses(rep1, rep2, /*updateWorkList=*/true);
-        return getTypeMatchSuccess();
+        return SolutionKind::Solved;
       }
 
       // If type variable represents a key path value type, defer binding it to
@@ -7372,12 +7373,12 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
 
         if (auto *iot = type1->getAs<InOutType>()) {
           if (!rep2->getImpl().canBindToLValue())
-            return getTypeMatchFailure(locator);
+            return SolutionKind::Error;
           assignFixedType(rep2, LValueType::get(iot->getObjectType()));
         } else {
           assignFixedType(rep2, type1);
         }
-        return getTypeMatchSuccess();
+        return SolutionKind::Solved;
       } else if (typeVar1 && !typeVar2) {
         // Simplify the right-hand type and perform the "occurs" check.
         auto rep1 = getRepresentative(typeVar1);
@@ -7387,12 +7388,12 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
 
         if (auto *lvt = type2->getAs<LValueType>()) {
           if (!rep1->getImpl().canBindToInOut())
-            return getTypeMatchFailure(locator);
+            return SolutionKind::Error;
           assignFixedType(rep1, InOutType::get(lvt->getObjectType()));
         } else {
           assignFixedType(rep1, type2);
         }
-        return getTypeMatchSuccess();
+        return SolutionKind::Solved;
       } if (typeVar1 && typeVar2) {
         auto rep1 = getRepresentative(typeVar1);
         auto rep2 = getRepresentative(typeVar2);
@@ -7407,7 +7408,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
             !rep2->getImpl().canBindToLValue()) {
           // Merge the equivalence classes corresponding to these two variables.
           mergeEquivalenceClasses(rep1, rep2, /*updateWorkList=*/true);
-          return getTypeMatchSuccess();
+          return SolutionKind::Solved;
         }
       }
 
@@ -7607,7 +7608,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
 #define BUILTIN_TYPE(id, parent) case TypeKind::id:
 #define TYPE(id, parent)
 #include "swift/AST/TypeNodes.def"
-      return getTypeMatchFailure(locator);
+      return SolutionKind::Error;
 
     // BuiltinGenericType subclasses
     case TypeKind::BuiltinBorrow:
@@ -7615,10 +7616,10 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       auto *fixed1 = cast<BuiltinGenericType>(desugar1);
       auto *fixed2 = cast<BuiltinGenericType>(desugar2);
       if (fixed1->getBuiltinTypeKind() != fixed2->getBuiltinTypeKind()) {
-        return getTypeMatchFailure(locator);
+        return SolutionKind::Error;
       }
 
-      auto result = ConstraintSystem::TypeMatchResult::success();
+      auto result = SolutionKind::Solved;
       for (unsigned i
             : indices(fixed1->getSubstitutions().getReplacementTypes())) {
         result = matchTypes(fixed1->getSubstitutions().getReplacementTypes()[i],
@@ -7626,7 +7627,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
                             ConstraintKind::Bind, subflags,
                             locator.withPathElement(
                                    LocatorPathElt::GenericArgument(i)));
-        if (result.isFailure()) {
+        if (result == SolutionKind::Error) {
           return result;
         }
       }
@@ -7642,7 +7643,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       if (shouldAttemptFixes())
         break;
 
-      return getTypeMatchFailure(locator);
+      return SolutionKind::Error;
     }
 
     case TypeKind::DependentMember: {
@@ -7650,7 +7651,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       // even though they are dependent members, they would be resolved
       // to the same concrete type.
       if (desugar1->isEqual(desugar2))
-        return getTypeMatchSuccess();
+        return SolutionKind::Solved;
 
       if (shouldAttemptFixes()) {
         if (!desugar1->hasTypeVariable() && !desugar2->hasTypeVariable()) {
@@ -7663,9 +7664,9 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
                   : ContextualMismatch::create(*this, type1, type2, loc);
 
           if (!fix || recordFix(fix))
-            return getTypeMatchFailure(locator);
+            return SolutionKind::Error;
 
-          return getTypeMatchSuccess();
+          return SolutionKind::Solved;
         }
       }
 
@@ -7676,7 +7677,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       // This should only happen outside of diagnostic mode, as otherwise the
       // member is replaced by a placeholder in simplifyType.
       if (!desugar1->hasTypeVariable() || !desugar2->hasTypeVariable())
-        return getTypeMatchFailure(locator);
+        return SolutionKind::Error;
 
       // Nothing we can solve yet, since we need to wait until
       // type variables will get resolved.
@@ -7693,14 +7694,14 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
 
       // If two module types or archetypes were not already equal, there's
       // nothing more we can do.
-      return getTypeMatchFailure(locator);
+      return SolutionKind::Error;
     }
 
     case TypeKind::Tuple: {
       // FIXME: TuplePackMatcher doesn't correctly handle matching two
        // abstract contextual tuple types in a generic context.
        if (simplifyType(desugar1)->isEqual(simplifyType(desugar2)))
-         return getTypeMatchSuccess();
+         return SolutionKind::Solved;
 
       // If the tuple has consecutive pack expansions, packs must be
       // resolved before matching.
@@ -7826,7 +7827,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
         // something which could be directly represented in the AST
         // e.g. argument-to-parameter, contextual conversions etc.
         if (!location.trySimplifyToExpr()) {
-          return getTypeMatchFailure(locator);
+          return SolutionKind::Error;
         }
 
         SmallVector<LocatorPathElt, 4> path;
@@ -7907,7 +7908,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
 
       // If matching of the instance types resulted in the failure make sure
       // to give `repairFailure` a chance to run to attempt to fix the issue.
-      if (shouldAttemptFixes() && result.isFailure())
+      if (shouldAttemptFixes() && result == SolutionKind::Error)
         break;
 
       return result;
@@ -7919,7 +7920,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
 
       auto result = matchFunctionTypes(func1, func2, kind, flags, locator);
 
-      if (shouldAttemptFixes() && result.isFailure())
+      if (shouldAttemptFixes() && result == SolutionKind::Error)
         break;
 
       return result;
@@ -7949,7 +7950,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
 
     case TypeKind::LValue:
       if (kind == ConstraintKind::BindParam)
-        return getTypeMatchFailure(locator);
+        return SolutionKind::Error;
       return matchTypes(cast<LValueType>(desugar1)->getObjectType(),
                         cast<LValueType>(desugar2)->getObjectType(),
                         ConstraintKind::Bind, subflags,
@@ -7958,7 +7959,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
     
     case TypeKind::InOut:
       if (kind == ConstraintKind::BindParam)
-        return getTypeMatchFailure(locator);
+        return SolutionKind::Error;
       
       if (kind == ConstraintKind::OperatorArgumentConversion) {
         conversionsOrFixes.push_back(
@@ -8017,7 +8018,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
                          kind, subflags, packLoc);
 
       // Let `repairFailures` attempt to "fix" this.
-      if (shouldAttemptFixes() && result.isFailure())
+      if (shouldAttemptFixes() && result == SolutionKind::Error)
         break;
 
       return result;
@@ -8046,20 +8047,20 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
 
       // If we're asking if two integer types are the same, then we know they
       // aren't.
-      return getTypeMatchFailure(locator);
+      return SolutionKind::Error;
 
     case TypeKind::Hidden:
       // Two HiddenTypes match only if they have the same mangled name.
       if (cast<HiddenType>(desugar1)->getMangledName() ==
           cast<HiddenType>(desugar2)->getMangledName())
         break;
-      return getTypeMatchFailure(locator);
+      return SolutionKind::Error;
     }
   }
 
   if (kind == ConstraintKind::BindToPointerType) {
     if (desugar2->isEqual(getASTContext().TheEmptyTupleType))
-      return getTypeMatchSuccess();
+      return SolutionKind::Solved;
   }
 
   if (kind == ConstraintKind::BindParam) {
@@ -8080,7 +8081,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
     if (type1->is<LValueType>() && !type2->is<InOutType>()) {
       auto result = matchTypes(type1->getWithoutSpecifierType(), type2, kind,
                                subflags, locator);
-      if (result.isSuccess() || !shouldAttemptFixes())
+      if (result == SolutionKind::Solved || !shouldAttemptFixes())
         return result;
     }
   }
@@ -8151,10 +8152,10 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       // These conversions are between concrete types that don't need further
       // resolution, so we can consider them immediately solved.
       auto addSolvedRestrictedConstraint
-        = [&](ConversionRestrictionKind restriction) -> TypeMatchResult {
+        = [&](ConversionRestrictionKind restriction) -> SolutionKind {
           addRestrictedConstraint(ConstraintKind::Subtype, restriction,
                                   type1, type2, locator);
-          return getTypeMatchSuccess();
+          return SolutionKind::Solved;
         };
       
       if (auto meta1 = type1->getAs<MetatypeType>()) {
@@ -8454,7 +8455,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
 
       if (allowConversion) {
         increaseScore(SK_FunctionConversion, locator);
-        return getTypeMatchSuccess();
+        return SolutionKind::Solved;
       }
     }
   }
@@ -8463,10 +8464,10 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
   // means a pack expansion was used where it isn't supported.
   if (type1->is<PackExpansionType>() != type2->is<PackExpansionType>()) {
     if (!shouldAttemptFixes())
-      return getTypeMatchFailure(locator);
+      return SolutionKind::Error;
 
     if (type1->isPlaceholder() || type2->isPlaceholder())
-      return getTypeMatchSuccess();
+      return SolutionKind::Solved;
 
     // If we are applying args, we may be able to emit a tailored fix.
     auto *loc = getConstraintLocator(locator);
@@ -8479,9 +8480,9 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
           if (type1->is<TupleType>() && paramPack->getNumElements() >= 1) {
             if (recordFix(DestructureTupleToMatchPackExpansionParameter::create(
                     *this, paramPack, loc))) {
-              return getTypeMatchFailure(loc);
+              return SolutionKind::Error;
             }
-            return getTypeMatchSuccess();
+            return SolutionKind::Solved;
           }
         }
       }
@@ -8491,7 +8492,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
         if (type1->is<PackExpansionType>() &&
             containsPackExpansionType(tuple)) {
           if (recordFix(AllowInvalidPackExpansion::create(*this, loc))) {
-            return getTypeMatchFailure(loc);
+            return SolutionKind::Error;
           }
           return matchTypes(TupleType::get({type1}, type1->getASTContext()),
                             type2, kind, flags, locator);
@@ -8499,9 +8500,9 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       }
     }
     if (recordFix(AllowInvalidPackExpansion::create(*this, loc)))
-      return getTypeMatchFailure(locator);
+      return SolutionKind::Error;
 
-    return getTypeMatchSuccess();
+    return SolutionKind::Solved;
   }
 
   // Attempt fixes iff it's allowed, both types are concrete and
@@ -8510,12 +8511,12 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
     if (repairFailures(type1, type2, kind, flags, conversionsOrFixes,
                        locator)) {
       if (conversionsOrFixes.empty())
-        return getTypeMatchSuccess();
+        return SolutionKind::Solved;
     }
   }
 
   if (conversionsOrFixes.empty())
-    return getTypeMatchFailure(locator);
+    return SolutionKind::Error;
 
   // Where there is more than one potential conversion, create a disjunction
   // so that we'll explore all of the options.
@@ -8558,37 +8559,23 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
               });
 
     addDisjunctionConstraint(constraints, fixedLocator);
-    return getTypeMatchSuccess();
+    return SolutionKind::Solved;
   }
 
   // For a single potential conversion, directly recurse, so that we
   // don't allocate a new constraint or constraint locator.
 
-  auto formTypeMatchResult = [&](SolutionKind kind) {
-    switch (kind) {
-      case SolutionKind::Error:
-        return getTypeMatchFailure(locator);
-
-      case SolutionKind::Solved:
-        return getTypeMatchSuccess();
-
-      case SolutionKind::Unsolved:
-        return getTypeMatchAmbiguous();
-    }
-    llvm_unreachable("unhandled kind");
-  };
-
   // Handle restrictions.
   if (auto restriction = conversionsOrFixes[0].getRestriction()) {
-    return formTypeMatchResult(simplifyRestrictedConstraint(*restriction, type1,
-                                                            type2, kind,
-                                                            subflags, locator));
+    return simplifyRestrictedConstraint(*restriction, type1,
+                                        type2, kind,
+                                        subflags, locator);
   }
 
   // Handle fixes.
   auto fix = *conversionsOrFixes[0].getFix();
-  return formTypeMatchResult(simplifyFixConstraint(fix, type1, type2, kind,
-                                                   subflags, locator));
+  return simplifyFixConstraint(fix, type1, type2, kind,
+                               subflags, locator);
 }
 
 ConstraintSystem::SolutionKind
@@ -8677,7 +8664,7 @@ ConstraintSystem::simplifyConstructionConstraint(
     ConstraintLocatorBuilder builder(locator);
     if (matchTypes(resultType, desugarValueType, ConstraintKind::Bind, flags,
                    builder.withPathElement(ConstraintLocator::ApplyFunction))
-            .isFailure())
+            == SolutionKind::Error)
       return SolutionKind::Error;
 
     return matchTypes(argType, valueType, ConstraintKind::Conversion,
@@ -8843,14 +8830,14 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifySubclassOfConstraint(
         classType->getClassOrBoundGenericClass()) {
       auto result = matchTypes(type, classType, ConstraintKind::Bind,
                                flags, locator);
-      if (!result.isFailure())
+      if (result != SolutionKind::Error)
         return SolutionKind::Solved;
 
     // Otherwise, ensure the left hand side is a proper subclass of the
     // right hand side.
     } else {
       auto result = matchSuperclassTypes(type, classType, flags, locator);
-      if (!result.isFailure())
+      if (result != SolutionKind::Error)
         return SolutionKind::Solved;
     }
   }
@@ -8910,7 +8897,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
 
   auto result = matchExistentialTypes(type, protocol, kind, flags, locator);
 
-  if (shouldAttemptFixes() && result.isFailure()) {
+  if (shouldAttemptFixes() && result == SolutionKind::Error) {
     auto *loc = getConstraintLocator(locator);
 
     ArrayRef<LocatorPathElt> path = loc->getPath();
@@ -10115,7 +10102,7 @@ ConstraintSystem::simplifyOptionalObjectConstraint(
       if (optionalResultType) {
         if (matchTypes(optionalResultType, second, ConstraintKind::Bind,
                        flags | TMF_ApplyingFix, locator)
-                .isSuccess()) {
+                == SolutionKind::Solved) {
           auto *fix =
               InsertExplicitCall::create(*this, getConstraintLocator(locator));
 
@@ -12413,7 +12400,7 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
                                                     ConstraintKind::Equal,
                                                     getConstraintLocator(closure),
                                                     getConstraintLocator(closure));
-      if (result.isFailure())
+      if (result == SolutionKind::Error)
         return false;
     }
 
@@ -12498,7 +12485,7 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
     if (auto result = matchResultBuilder(
             closure, resultBuilderType, closureType->getResult(),
             ConstraintKind::Conversion, contextualType, locator)) {
-      return result->isSuccess();
+      return (*result) == SolutionKind::Solved;
     }
   }
 
@@ -12904,7 +12891,7 @@ ConstraintSystem::simplifyBridgingConstraint(Type type1,
 
       // Make sure we have the bridged value type.
       if (matchTypes(unwrappedToType, bridgedValueType, ConstraintKind::Bind,
-                     subflags, locator).isFailure())
+                     subflags, locator) == SolutionKind::Error)
         return SolutionKind::Error;
 
       countOptionalInjections();
@@ -13093,21 +13080,21 @@ ConstraintSystem::simplifyKeyPathConstraint(
                       locator.withPathElement(LocatorPathElt::KeyPathValue()));
       }
 
-      return !matchTypes(kpFnTy, paramFnTy, ConstraintKind::Conversion,
+      return matchTypes(kpFnTy, paramFnTy, ConstraintKind::Conversion,
                          subflags, locator)
-                  .isFailure();
+                  != SolutionKind::Error;
     }
 
     assert(contextualRootTy && contextualValueTy);
 
     if (matchTypes(rootTy, contextualRootTy, ConstraintKind::Bind, subflags,
                    locator.withPathElement(ConstraintLocator::KeyPathRoot))
-            .isFailure())
+            == SolutionKind::Error)
       return false;
 
     if (matchTypes(valueTy, contextualValueTy, ConstraintKind::Bind, subflags,
                    locator.withPathElement(ConstraintLocator::KeyPathValue))
-            .isFailure())
+            == SolutionKind::Error)
       return false;
 
     return true;
@@ -13266,7 +13253,7 @@ ConstraintSystem::simplifyKeyPathApplicationConstraint(
     /// Solve for a base whose lvalueness is to be determined.
     auto solveUnknown = [&]() -> ConstraintSystem::SolutionKind {
       if (matchTypes(kpValueTy, valueTy, ConstraintKind::Equal, subflags,
-                     locator).isFailure())
+                     locator) == SolutionKind::Error)
         return SolutionKind::Error;
       return unsolved();
     };
@@ -13713,7 +13700,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyApplicableFnConstraint(
     if (matchFunctionResultTypes(
             func1->getResult(), result2, subflags,
             locator.withPathElement(ConstraintLocator::FunctionResult))
-            .isFailure())
+            == SolutionKind::Error)
       return SolutionKind::Error;
 
     if (unwrapCount == 0)
@@ -13925,14 +13912,14 @@ ConstraintSystem::simplifyDynamicCallableApplicableFnConstraint(
                    ConstraintKind::ArgumentConversion,
                    subflags,
                    locator.withPathElement(
-                     ConstraintLocator::ApplyArgument)).isFailure())
+                     ConstraintLocator::ApplyArgument)) == SolutionKind::Error)
       return SolutionKind::Error;
 
     // The result types are equivalent.
     if (matchFunctionResultTypes(
             func1->getResult(), func2->getResult(), subflags,
             locator.withPathElement(ConstraintLocator::FunctionResult))
-            .isFailure())
+            == SolutionKind::Error)
       return SolutionKind::Error;
 
     return SolutionKind::Solved;
@@ -14629,7 +14616,7 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
         matchTypes(baseType1.getPointer(), baseType2.getPointer(),
                    ConstraintKind::BindToPointerType, subflags, locator);
 
-    if (!(result.isFailure() && shouldAttemptFixes()))
+    if (!(result == SolutionKind::Error && shouldAttemptFixes()))
       return result;
 
     BoundGenericType *ptr1 = nullptr;
@@ -14747,12 +14734,12 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
 
     auto result = matchSuperclassTypes(type1, type2, subflags, locator);
 
-    if (!(shouldAttemptFixes() && result.isFailure()))
+    if (!(shouldAttemptFixes() && result == SolutionKind::Error))
       return result;
 
     return fixContextualFailure(type1, type2, locator)
-               ? getTypeMatchSuccess()
-               : getTypeMatchFailure(locator);
+               ? SolutionKind::Solved
+               : SolutionKind::Error;
   }
 
   // for $< in { <, <c, <oc }:
@@ -14778,12 +14765,12 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
         instanceTy1, instanceTy2, ConstraintKind::ConformsTo, subflags,
         locator.withPathElement(ConstraintLocator::InstanceType));
 
-    if (!(shouldAttemptFixes() && result.isFailure()))
+    if (!(shouldAttemptFixes() && result == SolutionKind::Error))
       return result;
 
     return fixContextualFailure(type1, type2, locator)
-               ? getTypeMatchSuccess()
-               : getTypeMatchFailure(locator);
+               ? SolutionKind::Solved
+               : SolutionKind::Error;
   }
 
   // for $< in { <, <c, <oc }:
@@ -14803,12 +14790,12 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
         matchTypes(superclass1, instance2, ConstraintKind::Subtype, subflags,
                    locator.withPathElement(ConstraintLocator::InstanceType));
 
-    if (!(shouldAttemptFixes() && result.isFailure()))
+    if (!(shouldAttemptFixes() && result == SolutionKind::Error))
       return result;
 
     return fixContextualFailure(type1, type2, locator)
-               ? getTypeMatchSuccess()
-               : getTypeMatchFailure(locator);
+               ? SolutionKind::Solved
+               : SolutionKind::Error;
   }
   // for $< in { <, <c, <oc }:
   //   T $< U ===> T $< U?
@@ -14823,7 +14810,7 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
             type1, generic2->getGenericArgs()[0], matchKind, subflags,
             locator.withPathElement(ConstraintLocator::OptionalInjection));
 
-        if (!(shouldAttemptFixes() && result.isFailure()))
+        if (!(shouldAttemptFixes() && result == SolutionKind::Error))
           return result;
       }
     }
@@ -14852,7 +14839,7 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
               matchKind, subflags,
               locator.withPathElement(LocatorPathElt::GenericArgument(0)));
 
-          if (!(shouldAttemptFixes() && result.isFailure()))
+          if (!(shouldAttemptFixes() && result == SolutionKind::Error))
             return result;
         }
       }
@@ -15050,7 +15037,7 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
     auto result =
         matchTypes(key1, key2, subMatchKind, subflags,
                    locator.withPathElement(LocatorPathElt::GenericArgument(0)));
-    if (result.isFailure())
+    if (result == SolutionKind::Error)
       return result;
 
     switch (matchTypes(


### PR DESCRIPTION
The `simplify*Constraint()` methods return SolutionKind, whereas `matchTypes()` returned a TypeMatchResult. This was just a wrapper around SolutionKind, and it's been like that for years. Let's get rid of TypeMatchResult.