### PR TITLE
[StdlibUnittest] support test suite sharding

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -1033,12 +1033,22 @@ class _ParentProcess {
 
   internal var _runTestsInProcess: Bool
   internal var _filter: String?
+  internal let _shardCount: Int?
+  internal let _shardIndex: Int
   internal var _args: [String]
 
-  init(runTestsInProcess: Bool, args: [String], filter: String?) {
+  init(
+    runTestsInProcess: Bool,
+    args: [String],
+    filter: String?,
+    shardCount: Int? = nil,
+    shardIndex: Int = 0
+  ) {
     self._runTestsInProcess = runTestsInProcess
     self._filter = filter
     self._args = args
+    self._shardCount = shardCount
+    self._shardIndex = shardIndex
   }
 
   func _spawnChild() {
@@ -1569,6 +1579,14 @@ class _ParentProcess {
 
             continue
           }
+          if let shardCount = _shardCount,
+             shardCount > 1,
+             (fullTestName.hashValue % shardCount).magnitude != _shardIndex {
+            // This is deterministic across test runs only if
+            // SWIFT_DETERMINISTIC_HASHING is set to 1, and
+            // our lit test harness does set it.
+            continue
+          }
 
           switch runOneTest(
             fullTestName: fullTestName,
@@ -1644,6 +1662,14 @@ class _ParentProcess {
           if let filter = _filter,
              findSubstring(fullTestName, filter) == nil {
 
+            continue
+          }
+          if let shardCount = _shardCount,
+             shardCount > 1,
+             (fullTestName.hashValue % shardCount).magnitude != _shardIndex {
+            // This is deterministic across test runs only if
+            // SWIFT_DETERMINISTIC_HASHING is set to 1, and
+            // our lit test harness does set it.
             continue
           }
 
@@ -1768,6 +1794,8 @@ public func runAllTests() {
   } else {
     var runTestsInProcess: Bool = !platformSupportsChildProcesses
     var filter: String?
+    var shardCount: Int?
+    var shardIndex: Int = 0
     var args = [String]()
     var i = 0
     i += 1 // Skip the name of the executable.
@@ -1783,6 +1811,16 @@ public func runAllTests() {
         i += 2
         continue
       }
+      if arg == "--stdlib-unittest-shard-count" {
+        shardCount = Int(CommandLine.arguments[i + 1])
+        i += 2
+        continue
+      }
+      if arg == "--stdlib-unittest-shard-index" {
+        shardIndex = Int(CommandLine.arguments[i + 1]) ?? 0
+        i += 2
+        continue
+      }
       if arg == "--help" {
         let message =
 "optional arguments:\n" +
@@ -1791,7 +1829,9 @@ public func runAllTests() {
 "                        Useful for running under a debugger.\n" +
 "--stdlib-unittest-filter FILTER-STRING\n" +
 "                        only run tests whose names contain FILTER-STRING as\n" +
-"                        a substring."
+"                        a substring.\n" +
+"--stdlib-unittest-shard-count N / --stdlib-unittest-shard-index I\n" +
+"                        run only the I-th of N disjoint shards of the tests.\n"
         print(message)
         return
       }
@@ -1803,7 +1843,9 @@ public func runAllTests() {
     }
 
     let parent = _ParentProcess(
-      runTestsInProcess: runTestsInProcess, args: args, filter: filter)
+      runTestsInProcess: runTestsInProcess, args: args, filter: filter,
+      shardCount: shardCount, shardIndex: shardIndex
+    )
     parent.run()
   }
 }
@@ -1838,6 +1880,8 @@ public func runAllTestsAsync() async {
   } else {
     var runTestsInProcess: Bool = !platformSupportsChildProcesses
     var filter: String?
+    var shardCount: Int?
+    var shardIndex: Int = 0
     var args = [String]()
     var i = 0
     i += 1 // Skip the name of the executable.
@@ -1853,6 +1897,16 @@ public func runAllTestsAsync() async {
         i += 2
         continue
       }
+      if arg == "--stdlib-unittest-shard-count" {
+        shardCount = Int(CommandLine.arguments[i + 1])
+        i += 2
+        continue
+      }
+      if arg == "--stdlib-unittest-shard-index" {
+        shardIndex = Int(CommandLine.arguments[i + 1]) ?? 0
+        i += 2
+        continue
+      }
       if arg == "--help" {
         let message =
 "optional arguments:\n" +
@@ -1861,7 +1915,9 @@ public func runAllTestsAsync() async {
 "                        Useful for running under a debugger.\n" +
 "--stdlib-unittest-filter FILTER-STRING\n" +
 "                        only run tests whose names contain FILTER-STRING as\n" +
-"                        a substring."
+"                        a substring.\n" +
+"--stdlib-unittest-shard-count N / --stdlib-unittest-shard-index I\n" +
+"                        run only the I-th of N disjoint shards of the tests.\n"
         print(message)
         return
       }
@@ -1873,7 +1929,8 @@ public func runAllTestsAsync() async {
     }
 
     let parent = _ParentProcess(
-      runTestsInProcess: runTestsInProcess, args: args, filter: filter)
+      runTestsInProcess: runTestsInProcess, args: args, filter: filter,
+      shardCount: shardCount, shardIndex: shardIndex)
     await parent.runAsync()
   }
 }

--- a/validation-test/StdlibUnittest/Shard.swift
+++ b/validation-test/StdlibUnittest/Shard.swift
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -o %t/Shard
+// RUN: %target-codesign %t/Shard
+
+// Each shard prints a disjoint subset; the union must equal the full run.
+// RUN: %target-run %t/Shard --stdlib-unittest-shard-count 2 --stdlib-unittest-shard-index 0 > %t/s0.txt
+// RUN: %target-run %t/Shard --stdlib-unittest-shard-count 2 --stdlib-unittest-shard-index 1 > %t/s1.txt
+// RUN: %target-run %t/Shard > %t/all.txt
+
+// Shard 0 and shard 1 are disjoint. Their union is the full set of test cases.
+// RUN: grep '^\[ *OK *\]' %t/s0.txt | sort > %t/s0.names
+// RUN: grep '^\[ *OK *\]' %t/s1.txt | sort > %t/s1.names
+// RUN: grep '^\[ *OK *\]' %t/all.txt | sort > %t/all.names
+// RUN: cat %t/s0.names %t/s1.names | sort > %t/union.names
+// RUN: diff %t/union.names %t/all.names
+// RUN: comm -12 %t/s0.names %t/s1.names > %t/dup.names
+// RUN: test ! -s %t/dup.names
+
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+let ShardTests = TestSuite("Shard")
+for i in 0..<20 {
+  ShardTests.test("case\(i)") { expectEqual(i, i) }
+}
+runAllTests()


### PR DESCRIPTION
We have some validation tests that take a very long time to run with remote device testing, due to the large number of test cases they involve (especially `expectCrash()` tests). In some configurations, this leads to timeouts even though steady progress is being made. This PR adds an option to `StdlibUnittest` to run a deterministically-determined subset of the test cases. This will allow us to run large test suites in stages, rather than having to manually split them up.

Addresses rdar://180485726 (part 1)
