### PR TITLE
[test] Generics/inverse_casting_availability.swift is failing on iOS

### DIFF
--- a/test/Generics/inverse_casting_availability.swift
+++ b/test/Generics/inverse_casting_availability.swift
@@ -1,10 +1,11 @@
 // RUN: %target-typecheck-verify-swift \
 // RUN:   -enable-experimental-feature LifetimeDependence  \
-// RUN:   -debug-diagnostic-names -target %target-cpu-apple-macos14.4
+// RUN:   -debug-diagnostic-names -target arm64-apple-macos14.4
 
 // REQUIRES: swift_feature_LifetimeDependence
 
 // REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchOS || OS=xros
+// REQUIRES: SWIFT_STDLIB_ARCH=arm64
 
 protocol P {}
 struct NCG<T: ~Copyable> {}


### PR DESCRIPTION
Switch the -target back to hard coding arm64 and set SWIFT_STDLIB_ARCH=arm64.