### PR TITLE
[Embedded] Support key paths in Embedded Swift

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
@@ -110,8 +110,13 @@ private struct FunctionChecker {
         break
       }
 
-    case is KeyPathInst:
-      throw Diagnostic(.embedded_swift_keypath, at: instruction.location)
+    case let kpi as KeyPathInst:
+      if !context.options.hasFeature(.EmbeddedKeyPaths) ||
+          !kpi.supportedInEmbeddedSwift {
+        throw Diagnostic(.embedded_swift_keypath, at: instruction.location)
+      }
+
+      break
 
     case is CheckedCastAddrBranchInst,
          is UnconditionalCheckedCastAddrInst:

--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
@@ -111,7 +111,7 @@ private struct FunctionChecker {
       }
 
     case let kpi as KeyPathInst:
-      guard let context.options.hasFeature(.EmbeddedKeyPaths), kpi.supportedInEmbeddedSwift else {
+      guard context.options.hasFeature(.EmbeddedKeyPaths), kpi.supportedInEmbeddedSwift else {
         throw Diagnostic(.embedded_swift_keypath, at: instruction.location)
       }
 

--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
@@ -111,12 +111,9 @@ private struct FunctionChecker {
       }
 
     case let kpi as KeyPathInst:
-      if !context.options.hasFeature(.EmbeddedKeyPaths) ||
-          !kpi.supportedInEmbeddedSwift {
+      guard let context.options.hasFeature(.EmbeddedKeyPaths), kpi.supportedInEmbeddedSwift else {
         throw Diagnostic(.embedded_swift_keypath, at: instruction.location)
       }
-
-      break
 
     case is CheckedCastAddrBranchInst,
          is UnconditionalCheckedCastAddrInst:

--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
@@ -130,6 +130,15 @@ private func optimize(function: Function, _ context: FunctionPassContext, _ modu
         specializeVTable(for: cast.type, instruction: cast)
       case let cast as UncheckedRefCastInst:
         specializeVTable(for: cast.type, instruction: cast)
+      case let kpi as KeyPathInst:
+        // In embedded Swift, IRGen may emit a `keypath` inst as an immortal
+        // static object of a specific concrete `KeyPath` subclass (chosen
+        // per the pattern's mutability/root kind).  IRGen requests the
+        // class's metadata when emitting the object, which requires a
+        // specialized vtable — force it here before IRGen runs.
+        if let classType = kpi.staticInstanceClassType {
+          specializeVTable(for: classType, instruction: kpi)
+        }
       case let classMethod as ClassMethodInst:
         if context.options.enableEmbeddedSwift {
           _ = context.specializeClassMethodInst(classMethod)

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
@@ -62,6 +62,10 @@ private struct VTableSpecializer {
       if baseTypesOfMethods[entry.implementation] == nil {
         baseTypesOfMethods[entry.implementation] = classType
       }
+      // Ensure the SIL body of every vtable entry is loaded from the
+      // defining module.
+      _ = context.loadFunction(function: entry.implementation,
+                               loadCalleesRecursively: true)
     }
 
     if classType.isGenericAtAnyLevel {

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -1350,7 +1350,20 @@ final public class KeyPathInst : SingleValueInstruction {
   }
 
   public var supportedInEmbeddedSwift: Bool {
-    bridged.KeyPathInst_getNumComponents() <= 1 && !type.hasArchetype
+    // The `EmbeddedSwiftDiagnostics` pass uses this predicate to decide
+    // whether to reject a `keypath` inst with `err_embedded_swift_keypath`.
+    // A pattern is supported iff IRGen can turn it into a static immortal
+    // instance, so gate this on the same predicate IRGen consults.
+    return staticInstanceClassType != nil
+  }
+
+  /// If this key path will be statically instantiated in Embedded Swift,
+  /// returns the concrete key path class type (`KeyPath<Root, Value>` /
+  /// `WritableKeyPath<Root, Value>` / `ReferenceWritableKeyPath<Root,
+  /// Value>`) that IRGen will use as the object's isa.  Nil if the key path
+  /// isn't statically instantiable.
+  public var staticInstanceClassType: Type? {
+    return bridged.KeyPathInst_getStaticInstanceClassType().typeOrNil
   }
 
   public override func visitReferencedFunctions(_ cl: (Function) -> ()) {

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -1349,6 +1349,10 @@ final public class KeyPathInst : SingleValueInstruction {
     bridged.KeyPathInst_hasPattern()
   }
 
+  public var supportedInEmbeddedSwift: Bool {
+    bridged.KeyPathInst_getNumComponents() <= 1 && !type.hasArchetype
+  }
+
   public override func visitReferencedFunctions(_ cl: (Function) -> ()) {
     var results = BridgedInstruction.KeyPathFunctionResults()
     for componentIdx in 0..<bridged.KeyPathInst_getNumComponents() {

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -605,6 +605,9 @@ EXPERIMENTAL_FEATURE(StandaloneSwiftAvailability, true)
 /// Allow enabling dynamic exclusivity in Embedded Swift.
 EXPERIMENTAL_FEATURE(EmbeddedDynamicExclusivity, true)
 
+/// Allow enabling dynamic keypaths in Embedded Swift.
+EXPERIMENTAL_FEATURE(EmbeddedKeyPaths, true)
+
 /// Emit typed allocation calls in Embedded Swift.
 EXPERIMENTAL_FEATURE(TypedAllocation, true)
 

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -936,6 +936,14 @@ struct BridgedInstruction {
   BRIDGED_INLINE bool KeyPathInst_hasPattern() const;
   BRIDGED_INLINE SwiftInt KeyPathInst_getNumComponents() const;
   BRIDGED_INLINE void KeyPathInst_getReferencedFunctions(SwiftInt componentIdx, KeyPathFunctionResults * _Nonnull results) const;
+  /// If this `keypath_inst` will be emitted as a statically-instantiated
+  /// immortal object in Embedded Swift, returns the concrete key path class
+  /// type (`KeyPath<Root, Value>` / `WritableKeyPath<Root, Value>` /
+  /// `ReferenceWritableKeyPath<Root, Value>`) picked by IRGen for the
+  /// object's isa.  Callers (Swift-side embedded passes) use this to force
+  /// specialization of that class's vtable before IRGen runs.  Returns an
+  /// invalid type if the key path isn't statically instantiable.
+  SWIFT_IMPORT_UNSAFE BridgedType KeyPathInst_getStaticInstanceClassType() const;
   BRIDGED_INLINE void GlobalAddrInst_clearToken() const;
   BRIDGED_INLINE bool GlobalValueInst_isBare() const;
   BRIDGED_INLINE void GlobalValueInst_setIsBare() const;

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -4438,6 +4438,13 @@ public:
 
   SubstitutionMap getSubstitutions() const { return Substitutions; }
 
+  /// If this `keypath_inst` can be emitted as a statically-instantiated
+  /// immortal instance in Embedded Swift, returns the concrete key path
+  /// class SILType (e.g. `$KeyPath<Foo, Bar>`, `$WritableKeyPath<Foo,
+  /// Bar>`, or `$ReferenceWritableKeyPath<Foo, Bar>`) that IRGen would use
+  /// as the object's isa.  Returns an invalid SILType otherwise.
+  SILType getStaticInstanceClassType() const;
+
   void dropReferencedPattern();
   
   ~KeyPathInst();

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -4167,7 +4167,7 @@ public:
   void visitReferencedFunctionsAndMethods(
       std::function<void (SILFunction *)> functionCallBack,
       std::function<void (SILDeclRef)> methodCallBack) const;
-    
+
   void incrementRefCounts() const;
   void decrementRefCounts() const;
 

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -176,6 +176,7 @@ UNINTERESTING_FEATURE(KeyPathWithMethodMembers)
 UNINTERESTING_FEATURE(ImportMacroAliases)
 UNINTERESTING_FEATURE(NoExplicitNonIsolated)
 UNINTERESTING_FEATURE(EmbeddedDynamicExclusivity)
+UNINTERESTING_FEATURE(EmbeddedKeyPaths)
 UNINTERESTING_FEATURE(TypedAllocation)
 
 static bool usesFeatureUnderscoreOwned(Decl *D) {

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -1435,6 +1435,196 @@ static NominalTypeDecl *pickStaticKeyPathClass(IRGenModule &IGM,
   return nominal;
 }
 
+namespace {
+/// Per-component decision data driving the static-instance emitter.
+///
+/// The `emitStaticKeyPathInstance` fast path serializes a single
+/// `KeyPathPatternComponent` into a fixed on-disk layout.  This POD is the
+/// bridge between the "figure out what to emit" phase and the "assemble the
+/// constant" phase.  It speaks in *semantic* fields — the kind of
+/// component, its offset (for stored/tuple), its getter/setter SIL
+/// references (for computed) — leaving `KeyPathComponentHeader` as the
+/// sole authority on the ABI bit layout of the header word.
+struct StaticKeyPathComponentLayout {
+  enum class Kind {
+    /// Struct member or tuple element — same encoding
+    /// (`_SwiftKeyPathComponentHeader_StructTag`), with `isLet` false for
+    /// tuple elements (there is no `let` tuple element).
+    StructOrTuple,
+    /// Class member (`_SwiftKeyPathComponentHeader_ClassTag`).
+    Class,
+    /// Get-only or settable computed property, or unapplied method
+    /// (`_SwiftKeyPathComponentHeader_ComputedTag`).  See `computedKind`
+    /// for the get-only vs settable-mutating vs settable-nonmutating split.
+    Computed,
+  };
+
+  Kind kind;
+
+  /// For `StructOrTuple` / `Class`: whether the property is `let`.  Drives
+  /// the header's `StoredMutableFlag` bit.  Always `false` for tuple
+  /// elements.  Unused for `Computed`.
+  bool isLet = false;
+
+  /// For `StructOrTuple` / `Class`: byte offset of the field within its
+  /// container.  The emitter picks between inline-in-header and
+  /// out-of-line-trailing-word encoding via
+  /// `KeyPathComponentHeader::offsetCanBeInline`.  Unused for `Computed`.
+  uint32_t offset = 0;
+
+  /// For `Computed`: whether the component is get-only (also used for
+  /// `Method`), settable-mutating (struct default), or settable-
+  /// nonmutating (class default, or `nonmutating set` on a struct).
+  /// Unused for stored components.
+  KeyPathComponentHeader::ComputedPropertyKind computedKind =
+      KeyPathComponentHeader::GetOnly;
+
+  /// For `Computed`: the getter SIL function pointer.  Used both as the
+  /// component's `id` (unsigned identity) and as the ptr-auth-signed
+  /// getter slot.  Null for stored components.
+  llvm::Constant *getter = nullptr;
+
+  /// For `Computed`: the setter SIL function pointer, when
+  /// `computedKind != GetOnly`.  Null otherwise.
+  llvm::Constant *setter = nullptr;
+};
+} // end anonymous namespace
+
+/// Compute the per-component layout of a single embedded-Swift static
+/// key path component, driving off its `Kind`.
+///
+/// This is the sole place the switch-over-`Kind` lives on the IRGen side
+/// (mirroring the class-picking switch in `KeyPathInst::
+/// getStaticInstanceClassType()`); the actual constant assembler in
+/// `emitStaticKeyPathInstance` is then straight-line and format-only,
+/// turning the semantic fields into `KeyPathComponentHeader` bits at
+/// emission time via `encodeStaticKeyPathComponentHeader`.
+static StaticKeyPathComponentLayout
+computeStaticKeyPathComponentLayout(IRGenModule &IGM,
+                                    const KeyPathPatternComponent &comp,
+                                    CanType rootTy) {
+  StaticKeyPathComponentLayout layout;
+  auto rootSILTy =
+      SILType::getPrimitiveObjectType(rootTy->getCanonicalType());
+
+  switch (comp.getKind()) {
+  case KeyPathPatternComponent::Kind::StoredProperty: {
+    auto *property = cast<VarDecl>(comp.getStoredPropertyDecl());
+    layout.isLet = property->isLet();
+
+    if (rootTy->getStructOrBoundGenericStruct()) {
+      layout.kind = StaticKeyPathComponentLayout::Kind::StructOrTuple;
+      auto *fixedOffset =
+          emitPhysicalStructMemberFixedOffset(IGM, rootSILTy, property);
+      assert(fixedOffset &&
+             "embedded stored-property key path must have a fixed offset");
+      layout.offset = static_cast<uint32_t>(
+          cast<llvm::ConstantInt>(fixedOffset)->getValue().getZExtValue());
+    } else if (rootTy->getClassOrBoundGenericClass()) {
+      layout.kind = StaticKeyPathComponentLayout::Kind::Class;
+      auto *fixedOffset = tryEmitConstantClassFragilePhysicalMemberOffset(
+          IGM, rootSILTy, property);
+      assert(fixedOffset &&
+             "embedded class-ivar key path must have a fixed offset");
+      layout.offset = static_cast<uint32_t>(
+          cast<llvm::ConstantInt>(fixedOffset)->getValue().getZExtValue());
+    } else {
+      llvm_unreachable("stored-property key path on unsupported base");
+    }
+    return layout;
+  }
+  case KeyPathPatternComponent::Kind::TupleElement: {
+    assert(rootTy->is<TupleType>() && "tuple-element key path on non-tuple");
+    layout.kind = StaticKeyPathComponentLayout::Kind::StructOrTuple;
+    // Tuple elements are always mutable at the language level (no `let`
+    // tuple element).  The runtime reads them with the struct-tag
+    // discriminator (see `_projectReadOnly`), so we encode them the same
+    // way as struct members.
+    layout.isLet = false;
+    auto elementOffset =
+        getFixedTupleElementOffset(IGM, rootSILTy, comp.getTupleIndex());
+    assert(elementOffset &&
+           "embedded tuple-element key path must have a fixed offset");
+    layout.offset = static_cast<uint32_t>(elementOffset->getValue());
+    return layout;
+  }
+  case KeyPathPatternComponent::Kind::GettableProperty:
+  case KeyPathPatternComponent::Kind::SettableProperty:
+  case KeyPathPatternComponent::Kind::Method: {
+    layout.kind = StaticKeyPathComponentLayout::Kind::Computed;
+    bool settable =
+        comp.getKind() == KeyPathPatternComponent::Kind::SettableProperty;
+    bool mutating = settable && comp.isComputedSettablePropertyMutating();
+
+    if (!settable) {
+      // `Method` and `GettableProperty` both encode as a computed get-only
+      // component: the pattern's "getter" is the method's implementation
+      // for `Method`, and the property's getter for `GettableProperty`.
+      layout.computedKind = KeyPathComponentHeader::GetOnly;
+    } else if (mutating) {
+      layout.computedKind = KeyPathComponentHeader::SettableMutating;
+    } else {
+      layout.computedKind = KeyPathComponentHeader::SettableNonmutating;
+    }
+
+    layout.getter = IGM.getAddrOfSILFunction(
+        comp.getComputedPropertyForGettable(), NotForDefinition);
+    if (settable) {
+      layout.setter = IGM.getAddrOfSILFunction(
+          comp.getComputedPropertyForSettable(), NotForDefinition);
+    }
+    return layout;
+  }
+  default:
+    llvm_unreachable("caller should have filtered other kinds");
+  }
+}
+
+/// Encode a `StaticKeyPathComponentLayout` into the pair of words the
+/// runtime expects: the `RawKeyPathComponent.Header` word, and (for
+/// stored/tuple components whose offset doesn't fit in the header
+/// payload) a trailing 32-bit out-of-line offset word.  This is the sole
+/// place the semantic layout maps onto `KeyPathComponentHeader` bits.
+static std::pair<KeyPathComponentHeader, std::optional<uint32_t>>
+encodeStaticKeyPathComponentHeader(
+    const StaticKeyPathComponentLayout &layout) {
+  switch (layout.kind) {
+  case StaticKeyPathComponentLayout::Kind::StructOrTuple:
+    if (KeyPathComponentHeader::offsetCanBeInline(layout.offset)) {
+      return {KeyPathComponentHeader::forStructComponentWithInlineOffset(
+                  layout.isLet, layout.offset),
+              std::nullopt};
+    }
+    return {KeyPathComponentHeader::forStructComponentWithOutOfLineOffset(
+                layout.isLet),
+            layout.offset};
+
+  case StaticKeyPathComponentLayout::Kind::Class:
+    if (KeyPathComponentHeader::offsetCanBeInline(layout.offset)) {
+      return {KeyPathComponentHeader::forClassComponentWithInlineOffset(
+                  layout.isLet, layout.offset),
+              std::nullopt};
+    }
+    return {KeyPathComponentHeader::forClassComponentWithOutOfLineOffset(
+                layout.isLet),
+            layout.offset};
+
+  case StaticKeyPathComponentLayout::Kind::Computed:
+    // Static instantiation: use the getter function pointer as the
+    // property identity.  The runtime uses a method descriptor pointer
+    // (class), a struct field index, or the getter function pointer
+    // (struct); embedded Swift never emits method descriptors, so a
+    // unique-per-property pointer is a simpler common encoding here.  The
+    // id field is not ptr-auth signed at runtime (see
+    // `RawKeyPathComponent._computedIDValue`), so we store it raw.
+    return {KeyPathComponentHeader::forComputedProperty(
+                layout.computedKind, KeyPathComponentHeader::Pointer,
+                /*hasArguments=*/false, KeyPathComponentHeader::Resolved),
+            std::nullopt};
+  }
+  llvm_unreachable("unhandled StaticKeyPathComponentLayout::Kind");
+}
+
 llvm::Constant *IRGenModule::emitStaticKeyPathInstance(KeyPathInst *KPI) {
   assert(canEmitStaticKeyPathInstance(KPI) &&
          "callers must check canEmitStaticKeyPathInstance() first");
@@ -1460,139 +1650,20 @@ llvm::Constant *IRGenModule::emitStaticKeyPathInstance(KeyPathInst *KPI) {
           ->getCanonicalType();
   llvm::Constant *metadata = getAddrOfTypeMetadata(concreteKeyPathTy);
 
-  // Compute the component header word, an optional out-of-line offset word
-  // (stored/tuple components), and an optional list of pointer-sized fields
-  // to lay out after a component-level `pointerAlignmentSkew` (computed
-  // components: id, getter, [setter]).
-  auto rootSILTy =
-      SILType::getPrimitiveObjectType(rootTy->getCanonicalType());
-
-  uint32_t componentHeaderWord = 0;
+  // Compute the per-component layout (semantic form) and encode it into
+  // the header word + optional out-of-line offset word.  For identity
+  // (no components) both are absent.
+  std::optional<StaticKeyPathComponentLayout> compLayout;
+  std::optional<KeyPathComponentHeader> componentHeader;
   std::optional<uint32_t> outOfLineOffsetWord;
-  llvm::Constant *computedGetterFn = nullptr;
-  llvm::Constant *computedSetterFn = nullptr;
-  bool computedSetterIsMutating = false;
-
   if (hasComponent) {
-    const auto &comp = components[0];
-    switch (comp.getKind()) {
-    case KeyPathPatternComponent::Kind::StoredProperty: {
-      auto *property = cast<VarDecl>(comp.getStoredPropertyDecl());
-      bool isLet = property->isLet();
-
-      if (rootTy->getStructOrBoundGenericStruct()) {
-        auto *fixedOffset =
-            emitPhysicalStructMemberFixedOffset(*this, rootSILTy, property);
-        assert(fixedOffset &&
-               "embedded stored-property key path must have a fixed offset");
-        auto offset =
-            cast<llvm::ConstantInt>(fixedOffset)->getValue().getZExtValue();
-        if (KeyPathComponentHeader::offsetCanBeInline(offset)) {
-          componentHeaderWord =
-              KeyPathComponentHeader::forStructComponentWithInlineOffset(
-                  isLet, offset)
-                  .getData();
-        } else {
-          componentHeaderWord =
-              KeyPathComponentHeader::forStructComponentWithOutOfLineOffset(
-                  isLet)
-                  .getData();
-          outOfLineOffsetWord = static_cast<uint32_t>(offset);
-        }
-      } else if (rootTy->getClassOrBoundGenericClass()) {
-        auto *offset = tryEmitConstantClassFragilePhysicalMemberOffset(
-            *this, rootSILTy, property);
-        assert(offset &&
-               "embedded class-ivar key path must have a fixed offset");
-        auto offsetValue =
-            cast<llvm::ConstantInt>(offset)->getValue().getZExtValue();
-        if (KeyPathComponentHeader::offsetCanBeInline(offsetValue)) {
-          componentHeaderWord =
-              KeyPathComponentHeader::forClassComponentWithInlineOffset(
-                  isLet, offsetValue)
-                  .getData();
-        } else {
-          componentHeaderWord =
-              KeyPathComponentHeader::forClassComponentWithOutOfLineOffset(
-                  isLet)
-                  .getData();
-          outOfLineOffsetWord = static_cast<uint32_t>(offsetValue);
-        }
-      } else {
-        llvm_unreachable("stored-property key path on unsupported base");
-      }
-      break;
-    }
-    case KeyPathPatternComponent::Kind::TupleElement: {
-      assert(rootTy->is<TupleType>() && "tuple-element key path on non-tuple");
-      auto elementOffset =
-          getFixedTupleElementOffset(*this, rootSILTy, comp.getTupleIndex());
-      assert(elementOffset &&
-             "embedded tuple-element key path must have a fixed offset");
-      auto offset = elementOffset->getValue();
-      // Tuple elements are always mutable at the language level (no `let`
-      // tuple element).  We encode them with the struct-tag discriminator
-      // because that's how the runtime reads them (see `_projectReadOnly`).
-      if (KeyPathComponentHeader::offsetCanBeInline(offset)) {
-        componentHeaderWord =
-            KeyPathComponentHeader::forStructComponentWithInlineOffset(
-                /*isLet=*/false, offset)
-                .getData();
-      } else {
-        componentHeaderWord =
-            KeyPathComponentHeader::forStructComponentWithOutOfLineOffset(
-                /*isLet=*/false)
-                .getData();
-        outOfLineOffsetWord = static_cast<uint32_t>(offset);
-      }
-      break;
-    }
-    case KeyPathPatternComponent::Kind::GettableProperty:
-    case KeyPathPatternComponent::Kind::SettableProperty:
-    case KeyPathPatternComponent::Kind::Method: {
-      bool settable =
-          comp.getKind() == KeyPathPatternComponent::Kind::SettableProperty;
-      bool mutating = settable && comp.isComputedSettablePropertyMutating();
-
-      KeyPathComponentHeader::ComputedPropertyKind componentKind;
-      if (!settable) {
-        // `Method` and `GettableProperty` both encode as a computed
-        // get-only component: the pattern's "getter" is the method's
-        // implementation for `Method`, and the property's getter for
-        // `GettableProperty`.
-        componentKind = KeyPathComponentHeader::GetOnly;
-      } else if (mutating) {
-        componentKind = KeyPathComponentHeader::SettableMutating;
-      } else {
-        componentKind = KeyPathComponentHeader::SettableNonmutating;
-      }
-
-      // Static instantiation: use the getter function pointer as the
-      // property identity.  The runtime uses a method descriptor pointer
-      // (class), a struct field index, or the getter function pointer
-      // (struct), but embedded Swift never emits method descriptors, so a
-      // unique-per-property pointer is a simpler common encoding here.  The
-      // id field is not ptr-auth signed at runtime (see
-      // `RawKeyPathComponent._computedIDValue`), so we store it raw.
-      componentHeaderWord =
-          KeyPathComponentHeader::forComputedProperty(
-              componentKind, KeyPathComponentHeader::Pointer,
-              /*hasArguments=*/false, KeyPathComponentHeader::Resolved)
-              .getData();
-
-      auto *getter = comp.getComputedPropertyForGettable();
-      computedGetterFn = getAddrOfSILFunction(getter, NotForDefinition);
-      if (settable) {
-        auto *setter = comp.getComputedPropertyForSettable();
-        computedSetterFn = getAddrOfSILFunction(setter, NotForDefinition);
-        computedSetterIsMutating = mutating;
-      }
-      break;
-    }
-    default:
-      llvm_unreachable("caller should have filtered other kinds");
-    }
+    compLayout = computeStaticKeyPathComponentLayout(
+        *this, components[0], rootTy->getCanonicalType());
+    std::tie(componentHeader, outOfLineOffsetWord) =
+        encodeStaticKeyPathComponentHeader(*compLayout);
   }
+  bool isComputed = compLayout && compLayout->kind ==
+                                      StaticKeyPathComponentLayout::Kind::Computed;
 
   auto ptrSize = getPointerSize().getValue();
   uint64_t pointerAlignmentSkewBytes = ptrSize - 4;
@@ -1609,10 +1680,10 @@ llvm::Constant *IRGenModule::emitStaticKeyPathInstance(KeyPathInst *KPI) {
     componentBytes = 4; // component header
     if (outOfLineOffsetWord)
       componentBytes += 4;
-    if (computedGetterFn) {
+    if (isComputed) {
       componentBytes += pointerAlignmentSkewBytes;
       componentBytes += ptrSize * 2; // id + getter
-      if (computedSetterFn)
+      if (compLayout->setter)
         componentBytes += ptrSize; // setter
     }
   }
@@ -1675,12 +1746,12 @@ llvm::Constant *IRGenModule::emitStaticKeyPathInstance(KeyPathInst *KPI) {
         llvm::ArrayType::get(Int8Ty, pointerAlignmentSkewBytes)));
 
   if (hasComponent) {
-    fields.addInt32(componentHeaderWord);
+    fields.addInt32(componentHeader->getData());
 
     if (outOfLineOffsetWord)
       fields.addInt32(*outOfLineOffsetWord);
 
-    if (computedGetterFn) {
+    if (isComputed) {
       if (pointerAlignmentSkewBytes != 0)
         fields.add(llvm::ConstantAggregateZero::get(
             llvm::ArrayType::get(Int8Ty, pointerAlignmentSkewBytes)));
@@ -1688,18 +1759,18 @@ llvm::Constant *IRGenModule::emitStaticKeyPathInstance(KeyPathInst *KPI) {
       // The computed id — an unsigned pointer that uniquely identifies the
       // property.  We use the getter as the identity.
       fields.add(
-          llvm::ConstantExpr::getBitCast(computedGetterFn, Int8PtrTy));
+          llvm::ConstantExpr::getBitCast(compLayout->getter, Int8PtrTy));
 
       // Address-discriminated ptr-auth signing for getter and setter.
       auto schema = getOptions().PointerAuth.KeyPaths;
-      fields.addSignedPointer(computedGetterFn, schema,
+      fields.addSignedPointer(compLayout->getter, schema,
                               PointerAuthEntity::Special::KeyPathGetter);
-      if (computedSetterFn) {
+      if (compLayout->setter) {
         auto setterAuth =
-            computedSetterIsMutating
+            compLayout->computedKind == KeyPathComponentHeader::SettableMutating
                 ? PointerAuthEntity::Special::KeyPathMutatingSetter
                 : PointerAuthEntity::Special::KeyPathNonmutatingSetter;
-        fields.addSignedPointer(computedSetterFn, schema, setterAuth);
+        fields.addSignedPointer(compLayout->setter, schema, setterAuth);
       }
     }
   }

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -1637,11 +1637,12 @@ llvm::Constant *IRGenModule::emitStaticKeyPathInstance(KeyPathInst *KPI) {
     return cached->second;
 
   auto components = pattern->getComponents();
-  bool hasComponent = !components.empty();
+  auto numComponents = components.size();
 
   auto keyPathTy = KPI->getKeyPathType();
   auto rootTy = keyPathTy->getGenericArgs()[0];
   auto valueTy = keyPathTy->getGenericArgs()[1];
+  auto subs = KPI->getSubstitutions();
 
   // Compute the concrete key-path class and get its metadata.
   NominalTypeDecl *keyPathClass = pickStaticKeyPathClass(*this, KPI);
@@ -1651,47 +1652,107 @@ llvm::Constant *IRGenModule::emitStaticKeyPathInstance(KeyPathInst *KPI) {
   llvm::Constant *metadata = getAddrOfTypeMetadata(concreteKeyPathTy);
 
   // Compute the per-component layout (semantic form) and encode it into
-  // the header word + optional out-of-line offset word.  For identity
-  // (no components) both are absent.
-  std::optional<StaticKeyPathComponentLayout> compLayout;
-  std::optional<KeyPathComponentHeader> componentHeader;
-  std::optional<uint32_t> outOfLineOffsetWord;
-  if (hasComponent) {
-    compLayout = computeStaticKeyPathComponentLayout(
-        *this, components[0], rootTy->getCanonicalType());
-    std::tie(componentHeader, outOfLineOffsetWord) =
-        encodeStaticKeyPathComponentHeader(*compLayout);
+  // the header word + optional out-of-line offset word for each
+  // component.  Also collect the intermediate type metadata pointer
+  // between successive components — the runtime walker reads this to
+  // determine the type of the intermediate value in the non-embedded
+  // case; the embedded walker skips over it.  For a chain of N
+  // components, there are N components emitted and (N - 1) intermediate
+  // type pointers.
+  struct StepInfo {
+    KeyPathComponentHeader header{
+        KeyPathComponentHeader::forOptionalForce()}; // arbitrary default
+    std::optional<uint32_t> outOfLineOffsetWord;
+    bool isComputed = false;
+    // Fields relevant to computed components (only possible when
+    // numComponents == 1).
+    KeyPathComponentHeader::ComputedPropertyKind computedKind =
+        KeyPathComponentHeader::GetOnly;
+    llvm::Constant *getter = nullptr;
+    llvm::Constant *setter = nullptr;
+    // Metadata pointer for the intermediate type following this
+    // component; null for the last component.
+    llvm::Constant *nextTypeMetadata = nullptr;
+  };
+  SmallVector<StepInfo, 4> steps;
+  steps.reserve(numComponents);
+
+  CanType currentRoot = rootTy->getCanonicalType();
+  for (size_t i = 0; i < numComponents; ++i) {
+    const auto &comp = components[i];
+    auto layout =
+        computeStaticKeyPathComponentLayout(*this, comp, currentRoot);
+    auto [hdr, offsetWord] = encodeStaticKeyPathComponentHeader(layout);
+
+    StepInfo step;
+    step.header = hdr;
+    step.outOfLineOffsetWord = offsetWord;
+    step.isComputed =
+        layout.kind == StaticKeyPathComponentLayout::Kind::Computed;
+    step.computedKind = layout.computedKind;
+    step.getter = layout.getter;
+    step.setter = layout.setter;
+
+    // Advance to the next root by substituting the component's declared
+    // component type.  The intermediate type metadata is emitted between
+    // this component and the next one.
+    CanType nextType =
+        comp.getComponentType().subst(subs)->getCanonicalType();
+    if (i + 1 < numComponents) {
+      step.nextTypeMetadata = getAddrOfTypeMetadata(nextType);
+    }
+    steps.push_back(step);
+    currentRoot = nextType;
   }
-  bool isComputed = compLayout && compLayout->kind ==
-                                      StaticKeyPathComponentLayout::Kind::Computed;
 
   auto ptrSize = getPointerSize().getValue();
   uint64_t pointerAlignmentSkewBytes = ptrSize - 4;
 
-  // Compute the buffer header word.  `size` is the size of the component
-  // buffer in bytes, excluding the buffer header itself (i.e. size of the
-  // component's header + body).  For identity (no components), that's zero.
+  // Compute the buffer size (bytes of the component buffer's `data`
+  // area, excluding the buffer header itself but including the initial
+  // 4-byte pointer-alignment skew that separates the header word from
+  // the first component header).
   //
-  // For computed components the body is: pointerAlignmentSkew (4 on 64-bit)
-  // + id (pointer) + getter (pointer) + optional setter (pointer).  This
-  // matches `RawKeyPathComponent.bodySize` for `.computed` in KeyPath.swift.
+  // Layout inside `data` (matching `KeyPathBuffer.next()`):
+  //
+  //   comp[0] header (i32)
+  //   comp[0] body (0 or 4 bytes: out-of-line offset, or computed tail)
+  //   [ pad to pointer alignment ]
+  //   intermediate type metadata (ptrSize)     — only if there's a next
+  //   comp[1] header (i32)
+  //   comp[1] body
+  //   ...
+  //   comp[N-1] header (i32)
+  //   comp[N-1] body
+  //
+  // For computed components (single-component patterns only) the body is
+  // `pointerAlignmentSkew + id + getter + [setter]`.
   uint32_t componentBytes = 0;
-  if (hasComponent) {
-    componentBytes = 4; // component header
-    if (outOfLineOffsetWord)
+  for (size_t i = 0; i < numComponents; ++i) {
+    const auto &step = steps[i];
+    componentBytes += 4; // component header
+    if (step.outOfLineOffsetWord)
       componentBytes += 4;
-    if (isComputed) {
+    if (step.isComputed) {
       componentBytes += pointerAlignmentSkewBytes;
       componentBytes += ptrSize * 2; // id + getter
-      if (compLayout->setter)
+      if (step.setter)
         componentBytes += ptrSize; // setter
+    }
+    if (step.nextTypeMetadata) {
+      // Pad up to pointer alignment before the intermediate type ptr.
+      uint32_t pad =
+          static_cast<uint32_t>((ptrSize - (componentBytes % ptrSize)) %
+                                ptrSize);
+      componentBytes += pad;
+      componentBytes += static_cast<uint32_t>(ptrSize);
     }
   }
   KeyPathBufferHeader bufHdr(componentBytes,
                              /*trivial=*/true,
                              /*hasReferencePrefix=*/false);
   uint32_t bufferHeaderWord = bufHdr.getData();
-  if (hasComponent)
+  if (numComponents == 1)
     bufferHeaderWord |= _SwiftKeyPathBufferHeader_IsSingleComponentFlag;
 
   // Assemble the constant.
@@ -1700,19 +1761,24 @@ llvm::Constant *IRGenModule::emitStaticKeyPathInstance(KeyPathInst *KPI) {
   //     [ padding_bytes x i8 ],
   //     i32 bufferHeaderWord,
   //     [ pointer_alignment_skew_bytes x i8 ],       // buffer-level skew
-  //     i32 componentHeaderWord,
-  //     [ i32 outOfLineOffsetWord ],                 // stored/tuple only
-  //     [ pointer_alignment_skew_bytes x i8 ],       // component-level skew,
-  //                                                  //   computed only
-  //     ptr computedId,                              // computed only
-  //     ptr computedGetter,                          // computed only, signed
-  //     [ ptr computedSetter ] }                     // computed settable
+  //     <for each component i>:
+  //       i32 componentHeaderWord,
+  //       [ i32 outOfLineOffsetWord ],               // stored/tuple only
+  //       <if computed (single-component only)>:
+  //         [ pointer_alignment_skew_bytes x i8 ]
+  //         ptr computedId
+  //         ptr computedGetter (ptr-auth signed)
+  //         [ ptr computedSetter ]                    // settable only
+  //       <if i + 1 < N>:
+  //         [ pad up to pointer alignment ]
+  //         ptr nextTypeMetadata
+  //   }
   //
   // The getter/setter pointer fields are address-discriminated ptr-auth
   // signed (schema `PointerAuth.KeyPaths`) with the standard KeyPath
-  // getter/nonmutating-setter/mutating-setter discriminators.  The id field
-  // is stored raw because the runtime treats it as an opaque identity value
-  // (`RawKeyPathComponent._computedIDValue`).
+  // getter/nonmutating-setter/mutating-setter discriminators.  The id
+  // field is stored raw because the runtime treats it as an opaque
+  // identity value (`RawKeyPathComponent._computedIDValue`).
   uint64_t bodySize = 2 * ptrSize; // isa + refcount
   uint64_t paddingBytes = (16 - (bodySize % 16)) % 16;
 
@@ -1745,35 +1811,64 @@ llvm::Constant *IRGenModule::emitStaticKeyPathInstance(KeyPathInst *KPI) {
     fields.add(llvm::ConstantAggregateZero::get(
         llvm::ArrayType::get(Int8Ty, pointerAlignmentSkewBytes)));
 
-  if (hasComponent) {
-    fields.addInt32(componentHeader->getData());
+  // Track running byte position within the component buffer so we can
+  // insert the correct pad before each intermediate type-metadata
+  // pointer.  The pointer-alignment skew above is not part of `data`.
+  uint32_t bytesInData = 0;
 
-    if (outOfLineOffsetWord)
-      fields.addInt32(*outOfLineOffsetWord);
+  for (size_t i = 0; i < numComponents; ++i) {
+    const auto &step = steps[i];
+    fields.addInt32(step.header.getData());
+    bytesInData += 4;
 
-    if (isComputed) {
-      if (pointerAlignmentSkewBytes != 0)
+    if (step.outOfLineOffsetWord) {
+      fields.addInt32(*step.outOfLineOffsetWord);
+      bytesInData += 4;
+    }
+
+    if (step.isComputed) {
+      // Only reachable when numComponents == 1 (multi-component chains
+      // reject computed components in `getStaticInstanceClassType`).
+      if (pointerAlignmentSkewBytes != 0) {
         fields.add(llvm::ConstantAggregateZero::get(
             llvm::ArrayType::get(Int8Ty, pointerAlignmentSkewBytes)));
+        bytesInData += pointerAlignmentSkewBytes;
+      }
+      fields.add(llvm::ConstantExpr::getBitCast(step.getter, Int8PtrTy));
+      bytesInData += ptrSize;
 
-      // The computed id — an unsigned pointer that uniquely identifies the
-      // property.  We use the getter as the identity.
-      fields.add(
-          llvm::ConstantExpr::getBitCast(compLayout->getter, Int8PtrTy));
-
-      // Address-discriminated ptr-auth signing for getter and setter.
       auto schema = getOptions().PointerAuth.KeyPaths;
-      fields.addSignedPointer(compLayout->getter, schema,
+      fields.addSignedPointer(step.getter, schema,
                               PointerAuthEntity::Special::KeyPathGetter);
-      if (compLayout->setter) {
+      bytesInData += ptrSize;
+
+      if (step.setter) {
         auto setterAuth =
-            compLayout->computedKind == KeyPathComponentHeader::SettableMutating
+            step.computedKind == KeyPathComponentHeader::SettableMutating
                 ? PointerAuthEntity::Special::KeyPathMutatingSetter
                 : PointerAuthEntity::Special::KeyPathNonmutatingSetter;
-        fields.addSignedPointer(compLayout->setter, schema, setterAuth);
+        fields.addSignedPointer(step.setter, schema, setterAuth);
+        bytesInData += ptrSize;
       }
     }
+
+    if (step.nextTypeMetadata) {
+      // Pad up to pointer alignment before writing the intermediate
+      // type metadata pointer.
+      uint32_t pad =
+          static_cast<uint32_t>((ptrSize - (bytesInData % ptrSize)) %
+                                ptrSize);
+      if (pad != 0) {
+        fields.add(llvm::ConstantAggregateZero::get(
+            llvm::ArrayType::get(Int8Ty, pad)));
+        bytesInData += pad;
+      }
+      fields.add(llvm::ConstantExpr::getBitCast(step.nextTypeMetadata,
+                                                Int8PtrTy));
+      bytesInData += ptrSize;
+    }
   }
+  (void)bytesInData; // used for arithmetic above only
 
   auto *global = fields.finishAndCreateGlobal(
       "keypath", Alignment(16), /*constant*/ true,

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -567,6 +567,9 @@ getInitializerForComputedComponent(IRGenModule &IGM,
 static llvm::Constant *
 emitMetadataTypeRefForKeyPath(IRGenModule &IGM, CanType type,
                               CanGenericSignature sig) {
+  if (IGM.isEmbeddedWithExistentials())
+    return IGM.getAddrOfTypeMetadata(type);
+
   // Produce a mangled name for the type.
   auto constant = IGM.getTypeRef(type, sig, MangledTypeRefRole::Metadata).first;
   

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -1379,3 +1379,343 @@ std::pair<llvm::Value *, llvm::Value *> irgen::emitKeyPathArgument(
 
   return std::make_pair(argsBuf.getAddress(), argsBufSize);
 }
+
+//===----------------------------------------------------------------------===//
+// Static key path instantiation for Embedded Swift.
+//===----------------------------------------------------------------------===//
+//
+// Instead of emitting a runtime pattern and calling `swift_getKeyPath`, in
+// Embedded Swift we can emit the fully-instantiated key path object directly
+// as an immortal constant global.  This is possible when every property of
+// the key path is known statically at IRGen time:
+//
+//   - The key path type has no unspecialized generic arguments.
+//   - The pattern doesn't capture any values.
+//   - Every component is one of the kinds we support here.
+//   - The key path has zero or one components.
+//
+// The emitted object layout mirrors what the non-embedded Swift-side
+// `AnyKeyPath._create` produces at runtime:
+//
+//     ┌──────────────────────────┐
+//     │ isa (metadata pointer)   │  ─── object header
+//     │ refcount = -1            │      (immortal)
+//     ├──────────────────────────┤
+//     │ [ padding to 16-byte     │  ─── in non-embedded builds this
+//     │   alignment ]            │      contains _kvcKeyPathStringPtr;
+//     │                          │      in embedded there is no such
+//     │                          │      field, so the padding is just
+//     │                          │      what's needed to reach the
+//     │                          │      _SixteenAligned tail alignment.
+//     ├──────────────────────────┤
+//     │ KeyPathBuffer.Header : i32 │  ─── tail buffer (Int32 elements)
+//     │ RawKeyPathComponent      │
+//     │   .Header : i32          │
+//     │ [ out-of-line offset :   │
+//     │   i32, if the offset     │
+//     │   doesn't fit inline ]   │
+//     └──────────────────────────┘
+
+bool IRGenModule::canEmitStaticKeyPathInstance(KeyPathInst *KPI) {
+  // Only in embedded Swift.
+  if (!Context.LangOpts.hasFeature(Feature::Embedded))
+    return false;
+
+  return (bool)KPI->getStaticInstanceClassType();
+}
+
+/// Pick the concrete `KeyPath` subclass this keypath instruction resolves
+/// to at runtime.
+static NominalTypeDecl *pickStaticKeyPathClass(IRGenModule &IGM,
+                                               KeyPathInst *KPI) {
+  auto silTy = KPI->getStaticInstanceClassType();
+  assert(silTy && "caller should have checked canEmitStaticKeyPathInstance");
+  auto *nominal = silTy.getNominalOrBoundGenericNominal();
+  assert(nominal && "static key path type must be a nominal class");
+  return nominal;
+}
+
+llvm::Constant *IRGenModule::emitStaticKeyPathInstance(KeyPathInst *KPI) {
+  assert(canEmitStaticKeyPathInstance(KPI) &&
+         "callers must check canEmitStaticKeyPathInstance() first");
+
+  auto *pattern = KPI->getPattern();
+
+  // Multiple `keypath_inst`s referring to the same pattern share one global.
+  auto cached = StaticKeyPathInstances.find(pattern);
+  if (cached != StaticKeyPathInstances.end())
+    return cached->second;
+
+  auto components = pattern->getComponents();
+  bool hasComponent = !components.empty();
+
+  auto keyPathTy = KPI->getKeyPathType();
+  auto rootTy = keyPathTy->getGenericArgs()[0];
+  auto valueTy = keyPathTy->getGenericArgs()[1];
+
+  // Compute the concrete key-path class and get its metadata.
+  NominalTypeDecl *keyPathClass = pickStaticKeyPathClass(*this, KPI);
+  auto concreteKeyPathTy =
+      BoundGenericType::get(keyPathClass, Type(), {rootTy, valueTy})
+          ->getCanonicalType();
+  llvm::Constant *metadata = getAddrOfTypeMetadata(concreteKeyPathTy);
+
+  // Compute the component header word, an optional out-of-line offset word
+  // (stored/tuple components), and an optional list of pointer-sized fields
+  // to lay out after a component-level `pointerAlignmentSkew` (computed
+  // components: id, getter, [setter]).
+  auto rootSILTy =
+      SILType::getPrimitiveObjectType(rootTy->getCanonicalType());
+
+  uint32_t componentHeaderWord = 0;
+  std::optional<uint32_t> outOfLineOffsetWord;
+  llvm::Constant *computedGetterFn = nullptr;
+  llvm::Constant *computedSetterFn = nullptr;
+  bool computedSetterIsMutating = false;
+
+  if (hasComponent) {
+    const auto &comp = components[0];
+    switch (comp.getKind()) {
+    case KeyPathPatternComponent::Kind::StoredProperty: {
+      auto *property = cast<VarDecl>(comp.getStoredPropertyDecl());
+      bool isLet = property->isLet();
+
+      if (rootTy->getStructOrBoundGenericStruct()) {
+        auto *fixedOffset =
+            emitPhysicalStructMemberFixedOffset(*this, rootSILTy, property);
+        assert(fixedOffset &&
+               "embedded stored-property key path must have a fixed offset");
+        auto offset =
+            cast<llvm::ConstantInt>(fixedOffset)->getValue().getZExtValue();
+        if (KeyPathComponentHeader::offsetCanBeInline(offset)) {
+          componentHeaderWord =
+              KeyPathComponentHeader::forStructComponentWithInlineOffset(
+                  isLet, offset)
+                  .getData();
+        } else {
+          componentHeaderWord =
+              KeyPathComponentHeader::forStructComponentWithOutOfLineOffset(
+                  isLet)
+                  .getData();
+          outOfLineOffsetWord = static_cast<uint32_t>(offset);
+        }
+      } else if (rootTy->getClassOrBoundGenericClass()) {
+        auto *offset = tryEmitConstantClassFragilePhysicalMemberOffset(
+            *this, rootSILTy, property);
+        assert(offset &&
+               "embedded class-ivar key path must have a fixed offset");
+        auto offsetValue =
+            cast<llvm::ConstantInt>(offset)->getValue().getZExtValue();
+        if (KeyPathComponentHeader::offsetCanBeInline(offsetValue)) {
+          componentHeaderWord =
+              KeyPathComponentHeader::forClassComponentWithInlineOffset(
+                  isLet, offsetValue)
+                  .getData();
+        } else {
+          componentHeaderWord =
+              KeyPathComponentHeader::forClassComponentWithOutOfLineOffset(
+                  isLet)
+                  .getData();
+          outOfLineOffsetWord = static_cast<uint32_t>(offsetValue);
+        }
+      } else {
+        llvm_unreachable("stored-property key path on unsupported base");
+      }
+      break;
+    }
+    case KeyPathPatternComponent::Kind::TupleElement: {
+      assert(rootTy->is<TupleType>() && "tuple-element key path on non-tuple");
+      auto elementOffset =
+          getFixedTupleElementOffset(*this, rootSILTy, comp.getTupleIndex());
+      assert(elementOffset &&
+             "embedded tuple-element key path must have a fixed offset");
+      auto offset = elementOffset->getValue();
+      // Tuple elements are always mutable at the language level (no `let`
+      // tuple element).  We encode them with the struct-tag discriminator
+      // because that's how the runtime reads them (see `_projectReadOnly`).
+      if (KeyPathComponentHeader::offsetCanBeInline(offset)) {
+        componentHeaderWord =
+            KeyPathComponentHeader::forStructComponentWithInlineOffset(
+                /*isLet=*/false, offset)
+                .getData();
+      } else {
+        componentHeaderWord =
+            KeyPathComponentHeader::forStructComponentWithOutOfLineOffset(
+                /*isLet=*/false)
+                .getData();
+        outOfLineOffsetWord = static_cast<uint32_t>(offset);
+      }
+      break;
+    }
+    case KeyPathPatternComponent::Kind::GettableProperty:
+    case KeyPathPatternComponent::Kind::SettableProperty:
+    case KeyPathPatternComponent::Kind::Method: {
+      bool settable =
+          comp.getKind() == KeyPathPatternComponent::Kind::SettableProperty;
+      bool mutating = settable && comp.isComputedSettablePropertyMutating();
+
+      KeyPathComponentHeader::ComputedPropertyKind componentKind;
+      if (!settable) {
+        // `Method` and `GettableProperty` both encode as a computed
+        // get-only component: the pattern's "getter" is the method's
+        // implementation for `Method`, and the property's getter for
+        // `GettableProperty`.
+        componentKind = KeyPathComponentHeader::GetOnly;
+      } else if (mutating) {
+        componentKind = KeyPathComponentHeader::SettableMutating;
+      } else {
+        componentKind = KeyPathComponentHeader::SettableNonmutating;
+      }
+
+      // Static instantiation: use the getter function pointer as the
+      // property identity.  The runtime uses a method descriptor pointer
+      // (class), a struct field index, or the getter function pointer
+      // (struct), but embedded Swift never emits method descriptors, so a
+      // unique-per-property pointer is a simpler common encoding here.  The
+      // id field is not ptr-auth signed at runtime (see
+      // `RawKeyPathComponent._computedIDValue`), so we store it raw.
+      componentHeaderWord =
+          KeyPathComponentHeader::forComputedProperty(
+              componentKind, KeyPathComponentHeader::Pointer,
+              /*hasArguments=*/false, KeyPathComponentHeader::Resolved)
+              .getData();
+
+      auto *getter = comp.getComputedPropertyForGettable();
+      computedGetterFn = getAddrOfSILFunction(getter, NotForDefinition);
+      if (settable) {
+        auto *setter = comp.getComputedPropertyForSettable();
+        computedSetterFn = getAddrOfSILFunction(setter, NotForDefinition);
+        computedSetterIsMutating = mutating;
+      }
+      break;
+    }
+    default:
+      llvm_unreachable("caller should have filtered other kinds");
+    }
+  }
+
+  auto ptrSize = getPointerSize().getValue();
+  uint64_t pointerAlignmentSkewBytes = ptrSize - 4;
+
+  // Compute the buffer header word.  `size` is the size of the component
+  // buffer in bytes, excluding the buffer header itself (i.e. size of the
+  // component's header + body).  For identity (no components), that's zero.
+  //
+  // For computed components the body is: pointerAlignmentSkew (4 on 64-bit)
+  // + id (pointer) + getter (pointer) + optional setter (pointer).  This
+  // matches `RawKeyPathComponent.bodySize` for `.computed` in KeyPath.swift.
+  uint32_t componentBytes = 0;
+  if (hasComponent) {
+    componentBytes = 4; // component header
+    if (outOfLineOffsetWord)
+      componentBytes += 4;
+    if (computedGetterFn) {
+      componentBytes += pointerAlignmentSkewBytes;
+      componentBytes += ptrSize * 2; // id + getter
+      if (computedSetterFn)
+        componentBytes += ptrSize; // setter
+    }
+  }
+  KeyPathBufferHeader bufHdr(componentBytes,
+                             /*trivial=*/true,
+                             /*hasReferencePrefix=*/false);
+  uint32_t bufferHeaderWord = bufHdr.getData();
+  if (hasComponent)
+    bufferHeaderWord |= _SwiftKeyPathBufferHeader_IsSingleComponentFlag;
+
+  // Assemble the constant.
+  //
+  //   { { metadata_ptr, refcount_intptr },
+  //     [ padding_bytes x i8 ],
+  //     i32 bufferHeaderWord,
+  //     [ pointer_alignment_skew_bytes x i8 ],       // buffer-level skew
+  //     i32 componentHeaderWord,
+  //     [ i32 outOfLineOffsetWord ],                 // stored/tuple only
+  //     [ pointer_alignment_skew_bytes x i8 ],       // component-level skew,
+  //                                                  //   computed only
+  //     ptr computedId,                              // computed only
+  //     ptr computedGetter,                          // computed only, signed
+  //     [ ptr computedSetter ] }                     // computed settable
+  //
+  // The getter/setter pointer fields are address-discriminated ptr-auth
+  // signed (schema `PointerAuth.KeyPaths`) with the standard KeyPath
+  // getter/nonmutating-setter/mutating-setter discriminators.  The id field
+  // is stored raw because the runtime treats it as an opaque identity value
+  // (`RawKeyPathComponent._computedIDValue`).
+  uint64_t bodySize = 2 * ptrSize; // isa + refcount
+  uint64_t paddingBytes = (16 - (bodySize % 16)) % 16;
+
+  // Reuse the immortal-refcount constant from `emitConstantObject`.
+  if (!swiftImmortalRefCount) {
+    // = HeapObject.immortalRefCount | HeapObject.doNotFreeBit
+    // (all-ones on both 32-bit and 64-bit).
+    swiftImmortalRefCount = llvm::ConstantInt::get(IntPtrTy, -1);
+  }
+
+  auto *ObjectHeaderTy = RefCountedStructTy;
+  auto *objectHeader = llvm::ConstantStruct::get(
+      ObjectHeaderTy,
+      {llvm::ConstantExpr::getBitCast(metadata,
+                                      ObjectHeaderTy->getElementType(0)),
+       swiftImmortalRefCount});
+
+  ConstantInitBuilder initBuilder(*this);
+  auto fields = initBuilder.beginStruct();
+
+  fields.add(objectHeader);
+
+  if (paddingBytes != 0)
+    fields.add(llvm::ConstantAggregateZero::get(
+        llvm::ArrayType::get(Int8Ty, paddingBytes)));
+
+  fields.addInt32(bufferHeaderWord);
+
+  if (pointerAlignmentSkewBytes != 0)
+    fields.add(llvm::ConstantAggregateZero::get(
+        llvm::ArrayType::get(Int8Ty, pointerAlignmentSkewBytes)));
+
+  if (hasComponent) {
+    fields.addInt32(componentHeaderWord);
+
+    if (outOfLineOffsetWord)
+      fields.addInt32(*outOfLineOffsetWord);
+
+    if (computedGetterFn) {
+      if (pointerAlignmentSkewBytes != 0)
+        fields.add(llvm::ConstantAggregateZero::get(
+            llvm::ArrayType::get(Int8Ty, pointerAlignmentSkewBytes)));
+
+      // The computed id — an unsigned pointer that uniquely identifies the
+      // property.  We use the getter as the identity.
+      fields.add(
+          llvm::ConstantExpr::getBitCast(computedGetterFn, Int8PtrTy));
+
+      // Address-discriminated ptr-auth signing for getter and setter.
+      auto schema = getOptions().PointerAuth.KeyPaths;
+      fields.addSignedPointer(computedGetterFn, schema,
+                              PointerAuthEntity::Special::KeyPathGetter);
+      if (computedSetterFn) {
+        auto setterAuth =
+            computedSetterIsMutating
+                ? PointerAuthEntity::Special::KeyPathMutatingSetter
+                : PointerAuthEntity::Special::KeyPathNonmutatingSetter;
+        fields.addSignedPointer(computedSetterFn, schema, setterAuth);
+      }
+    }
+  }
+
+  auto *global = fields.finishAndCreateGlobal(
+      "keypath", Alignment(16), /*constant*/ true,
+      llvm::GlobalValue::PrivateLinkage);
+
+  // Cast to the concrete key path class pointer type so callers can use it
+  // as a Swift class reference.
+  auto &keyPathTI = getTypeInfo(getLoweredType(KPI->getKeyPathType()));
+  auto *keyPathPtrTy = keyPathTI.getStorageType();
+  auto *result = llvm::ConstantExpr::getBitCast(global, keyPathPtrTy);
+
+  StaticKeyPathInstances[pattern] = result;
+  return result;
+}
+
+//===----------------------------------------------------------------------===//

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1251,6 +1251,16 @@ public:
                                    ForDefinition_t forDefinition);
   llvm::Constant *getAddrOfKeyPathPattern(KeyPathPattern *pattern,
                                           SILLocation diagLoc);
+  /// In embedded Swift, statically instantiate a key path object as an
+  /// immortal constant global instead of calling `swift_getKeyPath` at
+  /// runtime.  Returns a bitcast pointer to the key path class, or null if
+  /// this instruction's pattern isn't statically instantiable.
+  llvm::Constant *emitStaticKeyPathInstance(KeyPathInst *KPI);
+  /// True if `KPI` can be emitted as a static immortal constant in the
+  /// current compilation.  Currently limited to Embedded Swift, keypaths
+  /// with a single StoredProperty component, no substitutions, and no
+  /// captured operands.
+  bool canEmitStaticKeyPathInstance(KeyPathInst *KPI);
   llvm::Constant *getAddrOfOpaqueTypeDescriptor(OpaqueTypeDecl *opaqueType,
                                                 ConstantInit forDefinition);
   llvm::Constant *
@@ -1446,6 +1456,10 @@ private:
   llvm::DenseMap<ProtocolDecl *, llvm::Constant *> ObjCProtocolSymRefs;
   llvm::SmallVector<ProtocolDecl*, 4> LazyObjCProtocolDefinitions;
   llvm::DenseMap<KeyPathPattern*, llvm::GlobalVariable*> KeyPathPatterns;
+  /// Cache of statically-instantiated key path objects (embedded Swift).
+  /// Keyed by the (uniqued) `KeyPathPattern *` so multiple `keypath_inst`s
+  /// referring to the same pattern share one immortal global.
+  llvm::DenseMap<KeyPathPattern*, llvm::Constant*> StaticKeyPathInstances;
 
   /// Uniquing key for a fixed type layout record.
   struct FixedLayoutKey {

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -8116,6 +8116,19 @@ void IRGenSILFunction::visitFunctionExtractIsolationInst(
 }
 
 void IRGenSILFunction::visitKeyPathInst(swift::KeyPathInst *I) {
+  // In embedded Swift, key paths whose pattern is fully-known at compile
+  // time (no substitutions, no captured operands, only supported component
+  // kinds) get emitted as immortal constant globals rather than being
+  // instantiated at runtime through `swift_getKeyPath` (which isn't
+  // available in embedded builds anyway).
+  if (IGM.canEmitStaticKeyPathInstance(I)) {
+    llvm::Constant *staticInstance = IGM.emitStaticKeyPathInstance(I);
+    Explosion e;
+    e.add(staticInstance);
+    setLoweredExplosion(I, e);
+    return;
+  }
+
   auto pattern = IGM.getAddrOfKeyPathPattern(I->getPattern(), I->getLoc());
   // Build up the argument vector to instantiate the pattern here.
   std::optional<StackAddress> dynamicArgsBuf;

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -7319,6 +7319,12 @@ void IRGenSILFunction::visitBeginUnpairedAccessInst(
     return;
 
   case SILAccessEnforcement::Dynamic: {
+    // In Embedded Swift, suppress the swift_beginAccess call if dynamic
+    // exclusivity is not enabled.
+    if (getSILModule().getOptions().EmbeddedSwift &&
+        !getSILModule().getOptions().EnforceExclusivityDynamic)
+      return;
+
     llvm::Value *scratch = getLoweredAddress(access->getBuffer()).getAddress();
 
     llvm::Value *pointer =
@@ -7445,6 +7451,12 @@ void IRGenSILFunction::visitEndUnpairedAccessInst(EndUnpairedAccessInst *i) {
     return;
 
   case SILAccessEnforcement::Dynamic: {
+    // In Embedded Swift, suppress the swift_endAccess call if dynamic
+    // exclusivity is not enabled.
+    if (getSILModule().getOptions().EmbeddedSwift &&
+        !getSILModule().getOptions().EnforceExclusivityDynamic)
+      return;
+
     auto scratch = getLoweredAddress(i->getBuffer()).getAddress();
 
     auto call =

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -3500,31 +3500,31 @@ SILType KeyPathInst::getStaticInstanceClassType() const {
     return SILType();
   auto components = pattern->getComponents();
 
-  // The Embedded Swift runtime can only support zero or one component,
-  // because it can't reason about intermediate steps.
-  if (components.size() > 1)
-    return SILType();
-
   auto keyPathTy = getKeyPathType();
   auto rootTy = keyPathTy->getGenericArgs()[0]->getCanonicalType();
   auto valueTy = keyPathTy->getGenericArgs()[1]->getCanonicalType();
   auto &ctx = getModule().getASTContext();
 
-  NominalTypeDecl *keyPathClass = nullptr;
-
   // Identity key path (0 components) — matches the runtime walker's
   // starting `capability = .value` in
   // `_getKeyPathClassAndInstanceSizeFromPattern`.
   if (components.empty()) {
-    keyPathClass = ctx.getWritableKeyPathDecl();
-  } else {
+    auto identityTy = BoundGenericType::get(ctx.getWritableKeyPathDecl(),
+                                            /*parent=*/swift::Type(),
+                                            {rootTy, valueTy})
+                          ->getCanonicalType();
+    return SILType::getPrimitiveObjectType(identityTy);
+  }
+
+  // Single-component patterns: allow the full set of supported component
+  // kinds (stored, tuple, gettable/settable computed, method).
+  if (components.size() == 1) {
     const auto &comp = components[0];
+    NominalTypeDecl *keyPathClass = nullptr;
     switch (comp.getKind()) {
     case KeyPathPatternComponent::Kind::StoredProperty: {
       auto *property = cast<VarDecl>(comp.getStoredPropertyDecl());
       if (property->isLet()) {
-        // `let` properties are read-only regardless of whether the root
-        // is a struct or a class.
         keyPathClass = ctx.getKeyPathDecl();
       } else if (rootTy->getClassOrBoundGenericClass()) {
         keyPathClass = ctx.getReferenceWritableKeyPathDecl();
@@ -3534,27 +3534,16 @@ SILType KeyPathInst::getStaticInstanceClassType() const {
       break;
     }
     case KeyPathPatternComponent::Kind::TupleElement:
-      // Tuple elements are always mutable.
       keyPathClass = ctx.getWritableKeyPathDecl();
       break;
     case KeyPathPatternComponent::Kind::GettableProperty:
     case KeyPathPatternComponent::Kind::SettableProperty:
     case KeyPathPatternComponent::Kind::Method: {
-      // Reject captured subscript indices and external decl references —
-      // they'd require additional pattern-instantiation state we don't
-      // handle statically yet.
+      // Reject captured subscript indices and external decl references.
       if (!comp.getArguments().empty() || comp.getExternalDecl())
         return SILType();
-      // The pattern's getter/setter may themselves be generic (e.g. when
-      // the key path was written against a generic type that was later
-      // specialized in a wrapper call).  We currently only take their
-      // addresses via `getAddrOfSILFunction`, which doesn't apply
-      // substitutions, so bail out rather than emit a reference to an
-      // unspecialized accessor that has no LLVM definition.
-      //
-      // `Method` and `GettableProperty` components only have a getter (the
-      // Method's implementation), so we don't need to consult the setter
-      // there.  `SettableProperty` components have both.
+      // Bail on generic accessors — we take their addresses via
+      // `getAddrOfSILFunction`, which doesn't apply substitutions.
       if (comp.getComputedPropertyForGettable()->isGeneric())
         return SILType();
       if (comp.getKind() == KeyPathPatternComponent::Kind::SettableProperty &&
@@ -3563,16 +3552,11 @@ SILType KeyPathInst::getStaticInstanceClassType() const {
 
       if (comp.getKind() == KeyPathPatternComponent::Kind::SettableProperty &&
           comp.isComputedSettablePropertyMutating()) {
-        // Mutating setter (struct default) → WritableKeyPath.
         keyPathClass = ctx.getWritableKeyPathDecl();
       } else if (comp.getKind() ==
                  KeyPathPatternComponent::Kind::SettableProperty) {
-        // Nonmutating setter (class default, or `nonmutating set` on a
-        // struct) → ReferenceWritableKeyPath.
         keyPathClass = ctx.getReferenceWritableKeyPathDecl();
       } else {
-        // Get-only computed properties and unapplied method key paths are
-        // both read-only.
         keyPathClass = ctx.getKeyPathDecl();
       }
       break;
@@ -3582,9 +3566,59 @@ SILType KeyPathInst::getStaticInstanceClassType() const {
     case KeyPathPatternComponent::Kind::OptionalWrap:
       return SILType();
     }
+    assert(keyPathClass && "unhandled component kind above?");
+    auto concreteTy = BoundGenericType::get(keyPathClass,
+                                            /*parent=*/swift::Type(),
+                                            {rootTy, valueTy})
+                          ->getCanonicalType();
+    return SILType::getPrimitiveObjectType(concreteTy);
   }
 
-  assert(keyPathClass && "unhandled component kind above?");
+  // Multi-component chains: every component must be a fixed-offset
+  // stored-property or tuple-element access.  Walk the chain and pick the
+  // most specialized `KeyPath` subclass:
+  //   * start as WritableKeyPath (mirroring `capability = .value`)
+  //   * any `let` demotes permanently to KeyPath
+  //   * crossing a class boundary (component root is a class type) while
+  //     still writable promotes WritableKeyPath → ReferenceWritableKeyPath
+  NominalTypeDecl *keyPathClass = ctx.getWritableKeyPathDecl();
+  auto subs = getSubstitutions();
+  CanType currentRoot = rootTy;
+
+  for (const auto &comp : components) {
+    bool rootIsClass = (bool)currentRoot->getClassOrBoundGenericClass();
+
+    switch (comp.getKind()) {
+    case KeyPathPatternComponent::Kind::StoredProperty: {
+      auto *property = cast<VarDecl>(comp.getStoredPropertyDecl());
+      if (property->isLet()) {
+        keyPathClass = ctx.getKeyPathDecl();
+      } else if (rootIsClass &&
+                 keyPathClass == ctx.getWritableKeyPathDecl()) {
+        keyPathClass = ctx.getReferenceWritableKeyPathDecl();
+      }
+      break;
+    }
+    case KeyPathPatternComponent::Kind::TupleElement:
+      // Tuple elements are always mutable; no let-demote.  They don't
+      // introduce a class boundary either (tuples live inline in their
+      // parent).
+      break;
+    default:
+      // Computed / method / optional components aren't representable in
+      // an embedded multi-component chain, because the runtime walker
+      // only knows how to advance by a fixed offset or dereference a
+      // class reference.
+      return SILType();
+    }
+
+    // Advance to the next root type by substituting the pattern
+    // component's declared component type into the KP's substitution
+    // map.
+    currentRoot =
+        comp.getComponentType().subst(subs)->getCanonicalType();
+  }
+
   auto concreteTy =
       BoundGenericType::get(keyPathClass, /*parent=*/swift::Type(),
                             {rootTy, valueTy})

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -3482,6 +3482,116 @@ KeyPathPattern *KeyPathInst::getPattern() const {
   return Pattern;
 }
 
+SILType KeyPathInst::getStaticInstanceClassType() const {
+  // The concrete `keypath_inst` type must be fully substituted: no
+  // archetypes.
+  if (getKeyPathType()->hasArchetype())
+    return SILType();
+  if (getSubstitutions().getRecursiveProperties().hasArchetype())
+    return SILType();
+
+  // Captured operands would require dynamic materialization (indices
+  // copied from arguments).
+  if (!getAllOperands().empty())
+    return SILType();
+
+  auto *pattern = getPattern();
+  if (!pattern)
+    return SILType();
+  auto components = pattern->getComponents();
+
+  // The Embedded Swift runtime can only support zero or one component,
+  // because it can't reason about intermediate steps.
+  if (components.size() > 1)
+    return SILType();
+
+  auto keyPathTy = getKeyPathType();
+  auto rootTy = keyPathTy->getGenericArgs()[0]->getCanonicalType();
+  auto valueTy = keyPathTy->getGenericArgs()[1]->getCanonicalType();
+  auto &ctx = getModule().getASTContext();
+
+  NominalTypeDecl *keyPathClass = nullptr;
+
+  // Identity key path (0 components) — matches the runtime walker's
+  // starting `capability = .value` in
+  // `_getKeyPathClassAndInstanceSizeFromPattern`.
+  if (components.empty()) {
+    keyPathClass = ctx.getWritableKeyPathDecl();
+  } else {
+    const auto &comp = components[0];
+    switch (comp.getKind()) {
+    case KeyPathPatternComponent::Kind::StoredProperty: {
+      auto *property = cast<VarDecl>(comp.getStoredPropertyDecl());
+      if (property->isLet()) {
+        // `let` properties are read-only regardless of whether the root
+        // is a struct or a class.
+        keyPathClass = ctx.getKeyPathDecl();
+      } else if (rootTy->getClassOrBoundGenericClass()) {
+        keyPathClass = ctx.getReferenceWritableKeyPathDecl();
+      } else {
+        keyPathClass = ctx.getWritableKeyPathDecl();
+      }
+      break;
+    }
+    case KeyPathPatternComponent::Kind::TupleElement:
+      // Tuple elements are always mutable.
+      keyPathClass = ctx.getWritableKeyPathDecl();
+      break;
+    case KeyPathPatternComponent::Kind::GettableProperty:
+    case KeyPathPatternComponent::Kind::SettableProperty:
+    case KeyPathPatternComponent::Kind::Method: {
+      // Reject captured subscript indices and external decl references —
+      // they'd require additional pattern-instantiation state we don't
+      // handle statically yet.
+      if (!comp.getArguments().empty() || comp.getExternalDecl())
+        return SILType();
+      // The pattern's getter/setter may themselves be generic (e.g. when
+      // the key path was written against a generic type that was later
+      // specialized in a wrapper call).  We currently only take their
+      // addresses via `getAddrOfSILFunction`, which doesn't apply
+      // substitutions, so bail out rather than emit a reference to an
+      // unspecialized accessor that has no LLVM definition.
+      //
+      // `Method` and `GettableProperty` components only have a getter (the
+      // Method's implementation), so we don't need to consult the setter
+      // there.  `SettableProperty` components have both.
+      if (comp.getComputedPropertyForGettable()->isGeneric())
+        return SILType();
+      if (comp.getKind() == KeyPathPatternComponent::Kind::SettableProperty &&
+          comp.getComputedPropertyForSettable()->isGeneric())
+        return SILType();
+
+      if (comp.getKind() == KeyPathPatternComponent::Kind::SettableProperty &&
+          comp.isComputedSettablePropertyMutating()) {
+        // Mutating setter (struct default) → WritableKeyPath.
+        keyPathClass = ctx.getWritableKeyPathDecl();
+      } else if (comp.getKind() ==
+                 KeyPathPatternComponent::Kind::SettableProperty) {
+        // Nonmutating setter (class default, or `nonmutating set` on a
+        // struct) → ReferenceWritableKeyPath.
+        keyPathClass = ctx.getReferenceWritableKeyPathDecl();
+      } else {
+        // Get-only computed properties and unapplied method key paths are
+        // both read-only.
+        keyPathClass = ctx.getKeyPathDecl();
+      }
+      break;
+    }
+    case KeyPathPatternComponent::Kind::OptionalChain:
+    case KeyPathPatternComponent::Kind::OptionalForce:
+    case KeyPathPatternComponent::Kind::OptionalWrap:
+      return SILType();
+    }
+  }
+
+  assert(keyPathClass && "unhandled component kind above?");
+  auto concreteTy =
+      BoundGenericType::get(keyPathClass, /*parent=*/swift::Type(),
+                            {rootTy, valueTy})
+          ->getCanonicalType();
+  return SILType::getPrimitiveObjectType(concreteTy);
+}
+
 void KeyPathInst::dropReferencedPattern() {
   for (auto component : Pattern->getComponents()) {
     component.decrementRefCounts();

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -607,6 +607,11 @@ bool BridgedInstruction::maySynchronize() const {
   return ::maySynchronize(unbridged());
 }
 
+BridgedType
+BridgedInstruction::KeyPathInst_getStaticInstanceClassType() const {
+  return getAs<swift::KeyPathInst>()->getStaticInstanceClassType();
+}
+
 //===----------------------------------------------------------------------===//
 //                               BridgedBuilder
 //===----------------------------------------------------------------------===//

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -629,6 +629,22 @@ SILGenModule::getKeyPathProjectionCoroutine(bool isReadAccess,
   auto fn = M.lookUpFunction(functionName);
   if (fn) return fn;
 
+  // In embedded Swift the projection entry points are provided by
+  // `_read`/`_modify` accessors on `KeyPath`/`WritableKeyPath`/
+  // `ReferenceWritableKeyPath` (see KeyPath.swift).  Those accessors are
+  // class methods, so we must (a) emit our external declaration with
+  // `@convention(method)` so the SIL deserializer accepts the accessor as the
+  // body, and (b) pass `Root` as `@in_guaranteed` even for the writable
+  // modify variant since Swift subscripts cannot take `inout` parameters.
+  //
+  // In non-embedded Swift the entry points are thin coroutines implemented in
+  // the C++ runtime (see stdlib/public/runtime/KeyPaths.cpp) whose ABI is
+  // fixed, so we keep `@convention(thin)` and the original base convention.
+  bool isEmbedded = getASTContext().LangOpts.hasFeature(Feature::Embedded);
+  if (isEmbedded && typeKind == KPTK_WritableKeyPath && !isReadAccess) {
+    isBaseInout = false;
+  }
+
   auto sig = keyPathDecl->getGenericSignature().getCanonicalSignature();
   auto rootType = sig.getGenericParams()[0]->getCanonicalType();
   auto valueType = sig.getGenericParams()[1]->getCanonicalType();
@@ -652,7 +668,11 @@ SILGenModule::getKeyPathProjectionCoroutine(bool isReadAccess,
                     : ParameterConvention::Indirect_In_Guaranteed },
   };
 
-  auto extInfo = SILFunctionType::ExtInfo::getThin();
+  auto extInfo =
+      isEmbedded
+          ? SILFunctionType::ExtInfo::getThin().withRepresentation(
+                SILFunctionTypeRepresentation::Method)
+          : SILFunctionType::ExtInfo::getThin();
 
   auto functionTy = SILFunctionType::get(sig, extInfo,
                                          SILCoroutineKind::YieldOnce,

--- a/stdlib/public/core/EmbeddedCasting.swift
+++ b/stdlib/public/core/EmbeddedCasting.swift
@@ -149,6 +149,17 @@ enum MetadataKind: Equatable {
   static let lastEnumerated = 0x7FF
 }
 
+@_silgen_name("swift_isClassType")
+@used
+public func swift_isClassType(metadata: UnsafeRawPointer) -> Bool {
+  if let kind = unsafe MetadataKind(metadata: metadata) {
+    return kind == .class
+  }
+
+  return false
+}
+
+
 func projectHeapObject(_ exist: UnsafeRawPointer) -> UnsafeRawPointer{
   return unsafe exist.assumingMemoryBound(to: UnsafeRawPointer.self).pointee
 }

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -2562,6 +2562,23 @@ func _getAtKeyPath<Root, Value>(
   return keyPath._projectReadOnly(from: root)
 }
 
+// SILGen emits calls to `swift_readAtKeyPath`, `swift_modifyAtWritableKeyPath`
+// and `swift_modifyAtReferenceWritableKeyPath` for key path subscript accesses
+// (see `getKeyPathProjectionCoroutine` in lib/SILGen/SILGen.cpp).
+//
+// In non-embedded Swift these are thin yield-once coroutine ramp functions
+// whose ABI is fixed; they live in the C++ runtime (see
+// stdlib/public/runtime/KeyPaths.cpp) and call back into the Swift `_impl`
+// helpers below.
+//
+// In embedded Swift the C++ runtime is not compiled in.  Instead, the entry
+// points are provided directly by `_read`/`_modify` accessors on
+// `KeyPath`/`WritableKeyPath`/`ReferenceWritableKeyPath`, emitted with
+// `@convention(method)`; SILGen selects that convention when the `Embedded`
+// feature is enabled.
+
+#if !hasFeature(Embedded)
+
 // The release that ends the access scope is guaranteed to happen
 // immediately at the end_apply call because the continuation is a
 // runtime call with a manual release (access scopes cannot be extended).
@@ -2592,6 +2609,71 @@ func _modifyAtReferenceWritableKeyPath_impl<Root, Value>(
 ) -> (UnsafeMutablePointer<Value>, AnyObject?) {
   return unsafe keyPath._projectMutableAddress(from: root)
 }
+
+#else // hasFeature(Embedded)
+
+extension KeyPath {
+  @unsafe
+  @usableFromInline
+  internal subscript(_borrowedProjection root: Root) -> Value {
+    @_silgen_name("swift_readAtKeyPath")
+    _read {
+      yield _projectReadOnly(from: root)
+    }
+  }
+}
+
+extension WritableKeyPath {
+  @unsafe
+  @usableFromInline
+  internal subscript(_mutableProjection root: Root) -> Value {
+    get { return _projectReadOnly(from: root) }
+    // FIXME: Unlike the non-embedded C++ ramp function's opaque
+    // continuation, this accessor's `.resume` is Swift-visible IR.
+    // The ARC optimizer can hoist `owner`'s release past `end_apply`,
+    // which in turn extends the exclusivity access scope. This needs
+    // to be solved (e.g. via an opaque release barrier) before the
+    // `EmbeddedDynamicExclusivity` feature can be safely combined
+    // with keypath-driven modifies through class-stored properties.
+    @_silgen_name("swift_modifyAtWritableKeyPath")
+    _modify {
+      if type(of: self).kind == .reference {
+        let refKP = unsafe _unsafeUncheckedDowncast(
+          self, to: ReferenceWritableKeyPath<Root, Value>.self)
+        let (addr, owner) = unsafe refKP._projectMutableAddress(from: root)
+        defer { _fixLifetime(owner) }
+        yield unsafe &addr.pointee
+      } else {
+        let (addr, owner) = unsafe _withUnprotectedUnsafePointer(to: root) {
+          unsafe _projectMutableAddress(from: $0)
+        }
+        defer { _fixLifetime(owner) }
+        yield unsafe &addr.pointee
+      }
+    }
+  }
+}
+
+extension ReferenceWritableKeyPath {
+  @unsafe
+  @usableFromInline
+  internal subscript(_referenceMutableProjection root: Root) -> Value {
+    get { return _projectReadOnly(from: root) }
+    // FIXME: Same caveat as `WritableKeyPath._mutableProjection` above:
+    // `owner`'s release lives in a Swift-visible `.resume` and can be
+    // extended past `end_apply` by ARC, extending the access scope.
+    // Needs an opaque release barrier before `EmbeddedDynamicExclusivity`
+    // combined with keypath modify chains can be trusted.
+    @_silgen_name("swift_modifyAtReferenceWritableKeyPath")
+    _modify {
+      let (addr, owner) = unsafe _projectMutableAddress(from: root)
+      defer { _fixLifetime(owner) }
+      yield unsafe &addr.pointee
+    }
+  }
+}
+
+#endif
 
 @_silgen_name("swift_setAtWritableKeyPath")
 public // COMPILER_INTRINSIC

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -53,11 +53,15 @@ public class AnyKeyPath: _AppendKeyPath {
     return _rootAndValueType.value
   }
 
+#if !hasFeature(Embedded)
   /// Used to store the offset from the root to the value
   /// in the case of a pure struct KeyPath.
   /// It's a regular kvcKeyPathStringPtr otherwise.
+  ///
+  /// With Embedded Swift, there is no KVC keypath string, and each key path has
+  /// 0 or 1 components, so there is no need for this field.
   internal final var _kvcKeyPathStringPtr: UnsafePointer<CChar>?
-  
+
   /*
   The following pertains to 32-bit architectures only.
   We assume everything is a valid pointer to a potential
@@ -73,7 +77,6 @@ public class AnyKeyPath: _AppendKeyPath {
   of AnyKeyPath by 8 bytes.
   TODO: Find a better method of refactoring this variable if possible.
   */
-
   final func assignOffsetToStorage(offset: Int) {
     let maximumOffsetOn32BitArchitecture = 4094
 
@@ -137,7 +140,8 @@ public class AnyKeyPath: _AppendKeyPath {
       return unsafe String(validatingCString: ptr)
     }
   }
-  
+#endif
+
   // MARK: Implementation details
   
   // Prevent normal initialization. We use tail allocation via
@@ -190,14 +194,15 @@ public class AnyKeyPath: _AppendKeyPath {
       Int32.self
     )
 
+#if !hasFeature(Embedded)
     unsafe result._kvcKeyPathStringPtr = nil
+#endif
     let base = UnsafeMutableRawPointer(Builtin.projectTailElems(result,
                                                                 Int32.self))
     unsafe body(UnsafeMutableRawBufferPointer(start: base, count: bytes))
     return result
   }
   
-  @_unavailableInEmbedded
   final internal func withBuffer<T>(_ f: (KeyPathBuffer) throws -> T) rethrows -> T {
     defer { _fixLifetime(self) }
     
@@ -207,7 +212,6 @@ public class AnyKeyPath: _AppendKeyPath {
 
   @usableFromInline // Exposed as public API by MemoryLayout<Root>.offset(of:)
   internal var _storedInlineOffset: Int? {
-    #if !$Embedded
     return unsafe withBuffer {
       var buffer = unsafe $0
 
@@ -230,16 +234,16 @@ public class AnyKeyPath: _AppendKeyPath {
       }
       fatalError()
     }
-    #else
-    // compiler optimizes _storedInlineOffset into a direct offset computation,
-    // and in embedded Swift we don't allow runtime keypaths, so this fatalError
-    // is unreachable at runtime
-    fatalError()
-    #endif
   }
+
+#if hasFeature(Embedded)
+  @usableFromInline
+  internal func _projectReadOnlyAsAny(fromAny root: Any) -> Any? {
+    _abstract()
+  }
+#endif
 }
 
-@_unavailableInEmbedded
 extension AnyKeyPath: Hashable {
   /// The hash value.
   final public var hashValue: Int {
@@ -315,7 +319,14 @@ extension AnyKeyPath: Hashable {
 
 /// A partially type-erased key path, from a concrete root type to any
 /// resulting value type.
-public class PartialKeyPath<Root>: AnyKeyPath { }
+public class PartialKeyPath<Root>: AnyKeyPath {
+#if hasFeature(Embedded)
+  @usableFromInline
+  internal func _projectReadOnlyAsAny(from root: Root) -> Any {
+    _abstract()
+  }
+#endif
+}
 
 // MARK: Concrete implementations
 internal enum KeyPathKind { case readOnly, value, reference }
@@ -366,18 +377,21 @@ public class KeyPath<Root, Value>: PartialKeyPath<Root> {
   }
   
   @usableFromInline
-  @_unavailableInEmbedded
   internal final func _projectReadOnly(from root: Root) -> Value {
     let (rootType, valueType) = Self._rootAndValueType
 
+#if !hasFeature(Embedded)
     // One performance improvement is to skip right to Value
     // if this keypath traverses through structs only.
+    // In Embedded Swift, we only allow single-component key paths, so this
+    // optimization isn't worthwhile.
     if let offset = getOffsetFromStorage() {
       return unsafe _withUnprotectedUnsafeBytes(of: root) {
         let pointer = unsafe $0.baseAddress._unsafelyUnwrappedUnchecked + offset
         return unsafe pointer.assumingMemoryBound(to: Value.self).pointee
       }
     }
+#endif
 
     return unsafe withBuffer {
       var buffer = unsafe $0
@@ -401,6 +415,9 @@ public class KeyPath<Root, Value>: PartialKeyPath<Root> {
         }
       }
 
+#if hasFeature(Embedded)
+      fatalError("Multi-component key path is not permitted in Embedded Swift")
+#else
       let maxSize = unsafe buffer.maxSize
       let roundedMaxSize = 1 &<< (Int.bitWidth &- maxSize.leadingZeroBitCount)
 
@@ -471,15 +488,28 @@ public class KeyPath<Root, Value>: PartialKeyPath<Root> {
         }
         fatalError()
       }
+#endif
     }
   }
-  
+
+#if hasFeature(Embedded)
+  @usableFromInline
+  internal override func _projectReadOnlyAsAny(from root: Root) -> Any {
+    return _projectReadOnly(from: root)
+  }
+
+  @usableFromInline
+  internal override func _projectReadOnlyAsAny(fromAny root: Any) -> Any? {
+    guard let typedRoot = root as? Root else {
+      return nil
+    }
+
+    return _projectReadOnlyAsAny(from: typedRoot)
+  }
+#endif
+
   deinit {
-    #if !$Embedded
     unsafe withBuffer { unsafe $0.destroy() }
-    #else
-    fatalError() // unreachable, keypaths in embedded Swift are compile-time
-    #endif
   }
 }
 
@@ -492,13 +522,13 @@ public class WritableKeyPath<Root, Value>: KeyPath<Root, Value> {
   // `base` is assumed to be undergoing a formal access for the duration of the
   // call, so must not be mutated by an alias
   @usableFromInline
-  @_unavailableInEmbedded
   internal func _projectMutableAddress(from base: UnsafePointer<Root>)
       -> (pointer: UnsafeMutablePointer<Value>, owner: AnyObject?) {
    
     // One performance improvement is to skip right to Value
     // if this keypath traverses through structs only.
           
+#if !hasFeature(Embedded)
     // Don't declare "p" above this if-statement; it may slow things down.
     if let offset = getOffsetFromStorage()
     {
@@ -506,6 +536,7 @@ public class WritableKeyPath<Root, Value>: KeyPath<Root, Value> {
       return unsafe (pointer: UnsafeMutablePointer(
         mutating: p.assumingMemoryBound(to: Value.self)), owner: nil)
     }
+#endif
     var p = unsafe UnsafeRawPointer(base)
     var type: Any.Type = Root.self
     var keepAlive: AnyObject?
@@ -541,6 +572,9 @@ public class WritableKeyPath<Root, Value>: KeyPath<Root, Value> {
                 owner: keepAlive)
       }
 
+#if hasFeature(Embedded)
+      fatalError("Multi-component key path is not permitted in Embedded Swift")
+#else
       while true {
         let (rawComponent, optNextType) = unsafe buffer.next()
         let nextType = optNextType ?? Value.self
@@ -566,6 +600,7 @@ public class WritableKeyPath<Root, Value>: KeyPath<Root, Value> {
       let typedPointer = unsafe p.assumingMemoryBound(to: Value.self)
       return unsafe (pointer: UnsafeMutablePointer(mutating: typedPointer),
               owner: keepAlive)
+#endif
     }
   }
 }
@@ -580,7 +615,6 @@ public class ReferenceWritableKeyPath<
   internal final override class var kind: Kind { return .reference }
   
   @usableFromInline
-  @_unavailableInEmbedded
   internal final func _projectMutableAddress(from origBase: Root)
       -> (pointer: UnsafeMutablePointer<Value>, owner: AnyObject?) {
     var keepAlive: AnyObject?
@@ -606,6 +640,9 @@ public class ReferenceWritableKeyPath<
         return unsafe UnsafeMutablePointer(mutating: p)
       }
 
+#if hasFeature(Embedded)
+      fatalError("Multi-component key path is not permitted in Embedded Swift")
+#else
       // 16 is the max alignment allowed on practically every platform we deploy
       // to.
       let base: Any = unsafe _withUnprotectedUnsafeTemporaryAllocation(
@@ -698,6 +735,7 @@ public class ReferenceWritableKeyPath<
         }
       }
       return _openExistential(base, do: unsafe formalMutation(_:))
+#endif
     }
     
     return unsafe (address, keepAlive)
@@ -745,7 +783,6 @@ internal struct ComputedPropertyID: Hashable {
   }
 }
 
-@_unavailableInEmbedded
 @safe
 internal struct ComputedAccessorsPtr {
 #if INTERNAL_CHECKS_ENABLED
@@ -828,7 +865,6 @@ internal struct ComputedAccessorsPtr {
   }
 }
 
-@_unavailableInEmbedded
 @unsafe
 internal struct ComputedArgumentWitnessesPtr {
   internal let _value: UnsafeRawPointer
@@ -905,7 +941,6 @@ internal struct ComputedArgumentWitnessesPtr {
   }
 }
 
-@_unavailableInEmbedded
 @safe
 internal enum KeyPathComponent {
   @unsafe
@@ -955,7 +990,6 @@ internal enum KeyPathComponent {
   case optionalWrap
 }
 
-@_unavailableInEmbedded
 extension KeyPathComponent: @unsafe Hashable {
   internal static func ==(a: KeyPathComponent, b: KeyPathComponent) -> Bool {
     switch (a, b) {
@@ -1107,7 +1141,6 @@ internal final class ClassHolder<ProjectionType> {
 }
 
 // A class that triggers writeback to a pointer when destroyed.
-@_unavailableInEmbedded
 @unsafe
 internal final class MutatingWritebackBuffer<CurValue, NewValue> {
   internal let previous: AnyObject?
@@ -1137,7 +1170,6 @@ internal final class MutatingWritebackBuffer<CurValue, NewValue> {
 }
 
 // A class that triggers writeback to a non-mutated value when destroyed.
-@_unavailableInEmbedded
 @unsafe
 internal final class NonmutatingWritebackBuffer<CurValue, NewValue> {
   internal let previous: AnyObject?
@@ -1186,11 +1218,9 @@ internal enum KeyPathComputedIDResolution {
   case functionCall
 }
 
-@_unavailableInEmbedded
 internal struct ComputedArgumentSize {
   var value: UInt
 
-  @_unavailableInEmbedded
   static var sizeMask: UInt {
 #if _pointerBitWidth(_64)
     0x3FFF_FFFF_FFFF_FFFF
@@ -1202,7 +1232,6 @@ internal struct ComputedArgumentSize {
 #endif
   }
 
-  @_unavailableInEmbedded
   static var paddingMask: UInt {
 #if _pointerBitWidth(_64)
     0x4000_0000_0000_0000
@@ -1214,7 +1243,6 @@ internal struct ComputedArgumentSize {
 #endif
   }
 
-  @_unavailableInEmbedded
   static var paddingShift: UInt {
 #if _pointerBitWidth(_64)
     62
@@ -1226,7 +1254,6 @@ internal struct ComputedArgumentSize {
 #endif
   }
 
-  @_unavailableInEmbedded
   static var alignmentMask: UInt {
 #if _pointerBitWidth(_64)
     0x8000_0000_0000_0000
@@ -1238,7 +1265,6 @@ internal struct ComputedArgumentSize {
 #endif
   }
 
-  @_unavailableInEmbedded
   static var alignmentShift: UInt {
 #if _pointerBitWidth(_64)
     63
@@ -1293,7 +1319,6 @@ internal struct ComputedArgumentSize {
   // argument had less than or equal to the platform's pointer alignment. The
   // only valid values of this on 64 bit are 16 and 0, while on 32 it is 16, 8,
   // and 0. Top bit on 64 bit platforms and top 2 bits on 32 bit platforms.
-  @_unavailableInEmbedded
   var alignment: Int {
     get {
       let mask = value & Self.alignmentMask
@@ -1343,7 +1368,6 @@ internal struct ComputedArgumentSize {
   }
 }
 
-@_unavailableInEmbedded
 @safe
 internal struct RawKeyPathComponent {
   @safe internal var header: Header
@@ -2287,7 +2311,6 @@ internal func _pop<T : BitwiseCopyable>(from: inout UnsafeRawBufferPointer,
   return unsafe result
 }
   
-@_unavailableInEmbedded
 @unsafe
 internal struct KeyPathBuffer {
   internal var data: UnsafeRawBufferPointer
@@ -2478,26 +2501,31 @@ internal struct KeyPathBuffer {
 // MARK: Library intrinsics for projecting key paths.
 
 @_silgen_name("swift_getAtPartialKeyPath")
-@_unavailableInEmbedded
 public // COMPILER_INTRINSIC
 func _getAtPartialKeyPath<Root>(
   root: Root,
   keyPath: PartialKeyPath<Root>
 ) -> Any {
+#if hasFeature(Embedded)
+  return keyPath._projectReadOnlyAsAny(from: root)
+#else
   func open<Value>(_: Value.Type) -> Any {
     return unsafe _getAtKeyPath(root: root,
       keyPath: unsafeDowncast(keyPath, to: KeyPath<Root, Value>.self))
   }
   return _openExistential(type(of: keyPath).valueType, do: open)
+#endif
 }
 
 @_silgen_name("swift_getAtAnyKeyPath")
-@_unavailableInEmbedded
 public // COMPILER_INTRINSIC
 func _getAtAnyKeyPath<RootValue>(
   root: RootValue,
   keyPath: AnyKeyPath
 ) -> Any? {
+#if hasFeature(Embedded)
+  return keyPath._projectReadOnlyAsAny(fromAny: root)
+#else
   let (keyPathRoot, keyPathValue) = type(of: keyPath)._rootAndValueType
   func openRoot<KeyPathRoot>(_: KeyPathRoot.Type) -> Any? {
     guard let rootForKeyPath = root as? KeyPathRoot else {
@@ -2510,10 +2538,10 @@ func _getAtAnyKeyPath<RootValue>(
     return _openExistential(keyPathValue, do: openValue)
   }
   return _openExistential(keyPathRoot, do: openRoot)
+#endif
 }
 
 @_silgen_name("swift_getAtKeyPath")
-@_unavailableInEmbedded
 public // COMPILER_INTRINSIC
 func _getAtKeyPath<Root, Value>(
   root: Root,
@@ -2526,7 +2554,6 @@ func _getAtKeyPath<Root, Value>(
 // immediately at the end_apply call because the continuation is a
 // runtime call with a manual release (access scopes cannot be extended).
 @_silgen_name("_swift_modifyAtWritableKeyPath_impl")
-@_unavailableInEmbedded
 public // runtime entrypoint
 func _modifyAtWritableKeyPath_impl<Root, Value>(
   root: inout Root,
@@ -2546,7 +2573,6 @@ func _modifyAtWritableKeyPath_impl<Root, Value>(
 // immediately at the end_apply call because the continuation is a
 // runtime call with a manual release (access scopes cannot be extended).
 @_silgen_name("_swift_modifyAtReferenceWritableKeyPath_impl")
-@_unavailableInEmbedded
 public // runtime entrypoint
 func _modifyAtReferenceWritableKeyPath_impl<Root, Value>(
   root: Root,
@@ -2556,7 +2582,6 @@ func _modifyAtReferenceWritableKeyPath_impl<Root, Value>(
 }
 
 @_silgen_name("swift_setAtWritableKeyPath")
-@_unavailableInEmbedded
 public // COMPILER_INTRINSIC
 func _setAtWritableKeyPath<Root, Value>(
   root: inout Root,
@@ -2580,7 +2605,6 @@ func _setAtWritableKeyPath<Root, Value>(
 }
 
 @_silgen_name("swift_setAtReferenceWritableKeyPath")
-@_unavailableInEmbedded
 public // COMPILER_INTRINSIC
 func _setAtReferenceWritableKeyPath<Root, Value>(
   root: Root,
@@ -2854,16 +2878,19 @@ extension _AppendKeyPath /* where Self == ReferenceWritableKeyPath<T,U> */ {
 /// only structs to get to the final value, and all other types.
 /// This is done for performance reasons.
 /// Other type information may be handled in the future to improve performance.
+@_unavailableInEmbedded
 internal func _processOffsetForAppendedKeyPath(
   appendedKeyPath: inout AnyKeyPath,
   root: AnyKeyPath,
   leaf: AnyKeyPath
 ) {
+#if !hasFeature(Embedded)
   if let rootOffset = root.getOffsetFromStorage(),
     let leafOffset = leaf.getOffsetFromStorage()
   {
     appendedKeyPath.assignOffsetToStorage(offset: rootOffset + leafOffset)
   }
+#endif
 }
 
 @usableFromInline
@@ -2977,6 +3004,7 @@ internal func calculateAppendedKeyPathSize(
   // KVC-compatible.
   let appendedKVCLength: Int, rootKVCLength: Int, leafKVCLength: Int
 
+#if !hasFeature(Embedded)
   if root.getOffsetFromStorage() == nil, leaf.getOffsetFromStorage() == nil,
     let rootPtr = unsafe root._kvcKeyPathStringPtr,
     let leafPtr = unsafe leaf._kvcKeyPathStringPtr {
@@ -2989,6 +3017,11 @@ internal func calculateAppendedKeyPathSize(
     leafKVCLength = 0
     appendedKVCLength = 0
   }
+#else
+  rootKVCLength = 0
+  leafKVCLength = 0
+  appendedKVCLength = 0
+#endif
 
   // Immediately following is the tail-allocated space for the KVC string.
   let totalResultSize = MemoryLayout<Int32>._roundingUpToAlignment(result &+ appendedKVCLength)
@@ -3129,6 +3162,7 @@ internal func _appendingKeyPaths<
                      "did not fill entire result buffer")
       }
 
+#if !hasFeature(Embedded)
       // Build the KVC string if there is one.
       if root.getOffsetFromStorage() == nil,
         leaf.getOffsetFromStorage() == nil {
@@ -3151,6 +3185,7 @@ internal func _appendingKeyPaths<
             .storeBytes(of: 0 /* '\0' */, as: CChar.self)
         }
       }
+#endif
       return unsafe unsafeDowncast(result, to: Result.self)
     }
   }
@@ -3265,6 +3300,7 @@ public func _swift_getKeyPath(pattern: UnsafeMutableRawPointer,
   let kvcStringBase = unsafe patternPtr.advanced(by: 12)
   let kvcStringOffset = unsafe kvcStringBase.load(as: Int32.self)
 
+#if !hasFeature(Embedded)
   if kvcStringOffset == 0 {
     // Null pointer.
     unsafe instance._kvcKeyPathStringPtr = nil
@@ -3276,6 +3312,8 @@ public func _swift_getKeyPath(pattern: UnsafeMutableRawPointer,
   if unsafe instance._kvcKeyPathStringPtr == nil, let offset = pureStructOffset {
     instance.assignOffsetToStorage(offset: Int(offset))
   }
+#endif
+
   // If we can cache this instance as a shared instance, do so.
   if let oncePtr = unsafe oncePtr {
     // Try to replace a null pointer in the cache variable with the instance
@@ -4793,7 +4831,6 @@ fileprivate func dynamicLibraryAddress<Base, Leaf>(
 #endif
 
 @available(SwiftStdlib 5.8, *)
-@_unavailableInEmbedded
 extension AnyKeyPath: CustomDebugStringConvertible {
   
 #if SWIFT_ENABLE_REFLECTION

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -2148,6 +2148,7 @@ internal struct RawKeyPathComponent {
       )
 
     case .optionalChain:
+#if !hasFeature(Embedded)
       _internalInvariant(CurValue.self == Optional<NewValue>.self,
                    "should be unwrapping optional value")
       _internalInvariant(_isOptional(LeafValue.self),
@@ -2174,8 +2175,12 @@ internal struct RawKeyPathComponent {
           tag._value
         )
       }
+#else
+      fatalError("Embedded Swift does not allow optionals in key paths")
+#endif
 
     case .optionalForce:
+#if !hasFeature(Embedded)
       _internalInvariant(CurValue.self == Optional<NewValue>.self,
                    "should be unwrapping optional value")
 
@@ -2190,8 +2195,12 @@ internal struct RawKeyPathComponent {
       }
 
       _preconditionFailure("unwrapped nil optional")
+#else
+      fatalError("Embedded Swift does not allow optionals in key paths")
+#endif
 
     case .optionalWrap:
+#if !hasFeature(Embedded)
       _internalInvariant(NewValue.self == Optional<CurValue>.self,
                    "should be wrapping optional value")
 
@@ -2201,6 +2210,9 @@ internal struct RawKeyPathComponent {
       Builtin.injectEnumTag(&new, tag._value)
 
       unsafe pointer.initialize(to: new)
+#else
+      fatalError("Embedded Swift does not allow optionals in key paths")
+#endif
     }
   }
 

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -416,7 +416,33 @@ public class KeyPath<Root, Value>: PartialKeyPath<Root> {
       }
 
 #if hasFeature(Embedded)
-      fatalError("Multi-component key path is not permitted in Embedded Swift")
+      // Multi-component key paths in Embedded Swift are always chains of
+      // fixed-offset stored / tuple components (enforced by the IRGen
+      // static-instance emitter — see `KeyPathInst::
+      // getStaticInstanceClassType`).  Walk them with byte-level pointer
+      // arithmetic, without generic dispatch on `Any.Type`.  Class-typed
+      // intermediates stay alive because the outer container (the root
+      // value, or an outer class we've already walked through) still
+      // holds a strong reference to them for the duration of `root`'s
+      // lifetime.
+      return unsafe withUnsafePointer(to: root) { rootPtr in
+        var current = unsafe UnsafeRawPointer(rootPtr)
+        while unsafe !buffer.data.isEmpty {
+          let (rawComponent, _) = unsafe buffer.next()
+          switch unsafe rawComponent.value {
+          case .struct(let offset):
+            unsafe current = unsafe current.advanced(by: offset)
+          case .class(let offset):
+            let obj = unsafe current.load(as: AnyObject.self)
+            unsafe current = unsafe UnsafeRawPointer(
+              Builtin.bridgeToRawPointer(obj)).advanced(by: offset)
+          default:
+            fatalError(
+              "Embedded Swift multi-component key path must be stored/tuple")
+          }
+        }
+        return unsafe current.load(as: Value.self)
+      }
 #else
       let maxSize = unsafe buffer.maxSize
       let roundedMaxSize = 1 &<< (Int.bitWidth &- maxSize.leadingZeroBitCount)
@@ -573,12 +599,30 @@ public class WritableKeyPath<Root, Value>: KeyPath<Root, Value> {
       }
 
 #if hasFeature(Embedded)
-      fatalError("Multi-component key path is not permitted in Embedded Swift")
+      // Multi-component walker for chains of fixed-offset stored/tuple
+      // components.  All writable-KP chains projected here are pure struct
+      // / tuple (no class jump), because a chain that crosses a class
+      // boundary is a `ReferenceWritableKeyPath`.  So we can walk with
+      // plain pointer arithmetic — no writeback / keep-alive needed.
+      while true {
+        let (rawComponent, optNextType) = unsafe buffer.next()
+        switch unsafe rawComponent.value {
+        case .struct(let offset):
+          unsafe p = unsafe p.advanced(by: offset)
+        default:
+          fatalError(
+            "Embedded Swift WritableKeyPath chain must be stored struct/tuple")
+        }
+        if optNextType == nil { break }
+      }
+      let typedPointer = unsafe p.assumingMemoryBound(to: Value.self)
+      return unsafe (pointer: UnsafeMutablePointer(mutating: typedPointer),
+              owner: keepAlive)
 #else
       while true {
         let (rawComponent, optNextType) = unsafe buffer.next()
         let nextType = optNextType ?? Value.self
-        
+
         func project<CurValue>(_: CurValue.Type) {
           func project2<NewValue>(_: NewValue.Type) {
             unsafe p = unsafe rawComponent._projectMutableAddress(p,
@@ -590,7 +634,7 @@ public class WritableKeyPath<Root, Value>: KeyPath<Root, Value> {
           _openExistential(nextType, do: project2)
         }
         _openExistential(type, do: project)
-        
+
         if optNextType == nil { break }
         type = nextType
       }
@@ -641,7 +685,37 @@ public class ReferenceWritableKeyPath<
       }
 
 #if hasFeature(Embedded)
-      fatalError("Multi-component key path is not permitted in Embedded Swift")
+      // Multi-component walker for chains of fixed-offset stored/tuple
+      // components (enforced by the IRGen static-instance emitter).  A
+      // `ReferenceWritableKeyPath` chain crosses at least one class
+      // boundary, so `keepAlive` will be set to the last class we
+      // dereferenced — that class owns the heap storage the returned
+      // pointer points into.
+      var origBase2 = origBase
+      let final: UnsafeMutablePointer<Value> =
+        unsafe withUnsafeMutableBytes(of: &origBase2) { baseBytes in
+          var p = unsafe UnsafeRawPointer(baseBytes.baseAddress
+              ._unsafelyUnwrappedUnchecked)
+          while true {
+            let (rawComponent, optNextType) = unsafe buffer.next()
+            switch unsafe rawComponent.value {
+            case .struct(let offset):
+              unsafe p = unsafe p.advanced(by: offset)
+            case .class(let offset):
+              let obj = unsafe p.load(as: AnyObject.self)
+              keepAlive = obj
+              unsafe p = unsafe UnsafeRawPointer(
+                Builtin.bridgeToRawPointer(obj)).advanced(by: offset)
+            default:
+              fatalError(
+                "Embedded Swift RWK chain must be stored struct/tuple/class")
+            }
+            if optNextType == nil { break }
+          }
+          let typed = unsafe p.assumingMemoryBound(to: Value.self)
+          return unsafe UnsafeMutablePointer(mutating: typed)
+        }
+      return unsafe final
 #else
       // 16 is the max alignment allowed on practically every platform we deploy
       // to.

--- a/stdlib/public/runtime/KeyPaths.cpp
+++ b/stdlib/public/runtime/KeyPaths.cpp
@@ -60,6 +60,17 @@ KeyPathGenericWitnessTable swift_keyPathGenericWitnessTable = {
 /****************************************************************************/
 /** Projection functions ****************************************************/
 /****************************************************************************/
+//
+// `swift_readAtKeyPath`, `swift_modifyAtWritableKeyPath`, and
+// `swift_modifyAtReferenceWritableKeyPath` are the thin yield-once coroutine
+// ramp functions used to project through a key path.  Their ABI is fixed for
+// non-embedded Swift, so we keep them here as small C++ adapters that call
+// into Swift-side `_impl` helpers (see KeyPath.swift).
+//
+// In embedded Swift the C++ runtime is not compiled in and these entry points
+// are instead provided by `_read`/`_modify` accessors emitted with
+// `@convention(method)`; SILGen selects the right convention based on the
+// enabled feature set (see `SILGenModule::getKeyPathProjectionCoroutine`).
 
 namespace {
   struct AddrAndOwner {

--- a/test/embedded/exclusivity-builtins.swift
+++ b/test/embedded/exclusivity-builtins.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend -emit-ir %s -enforce-exclusivity=checked -enable-experimental-feature Embedded -disable-experimental-feature EmbeddedDynamicExclusivity -module-name exclusivity_builtins -parse-stdlib -parse-as-library  -enforce-exclusivity=unchecked | %FileCheck %s
 
 // REQUIRES: swift_feature_Embedded
-// REQUIRES: swift_feature_EmbeddedDynamicExclusivity
 
 @_silgen_name("marker1")
 func marker1() -> ()

--- a/test/embedded/exclusivity-builtins.swift
+++ b/test/embedded/exclusivity-builtins.swift
@@ -1,0 +1,45 @@
+// RUN: %target-swift-frontend -emit-ir %s -enforce-exclusivity=checked -enable-experimental-feature Embedded -disable-experimental-feature EmbeddedDynamicExclusivity -module-name exclusivity_builtins -parse-stdlib -parse-as-library  -enforce-exclusivity=unchecked | %FileCheck %s
+
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_EmbeddedDynamicExclusivity
+
+@_silgen_name("marker1")
+func marker1() -> ()
+
+@_silgen_name("marker2")
+func marker2() -> ()
+
+@_silgen_name("marker3")
+func marker3() -> ()
+
+public struct MyClass {
+  var i: Builtin.Int32
+}
+
+// CHECK-LABEL: define {{.*}}swiftcc void @"$e20exclusivity_builtins11beginAccessyyBp_BpAA7MyClassVmtF"(ptr %0, ptr %1)
+// CHECK-NOT:   call void @swift_beginAccess
+// CHECK: ret void
+
+@used
+public func beginAccess(_ address: Builtin.RawPointer, _ scratch: Builtin.RawPointer, _ ty1: MyClass.Type) {
+  marker1()
+  Builtin.beginUnpairedModifyAccess(address, scratch, ty1);
+}
+
+// CHECK-LABEL: define {{.*}}swiftcc void @"$e20exclusivity_builtins9endAccessyyBpF"(ptr{{.*}})
+// CHECK-NOT:   call void @swift_endAccess
+// CHECK: ret void
+@used
+public func endAccess(_ address: Builtin.RawPointer) {
+  marker2()
+  Builtin.endUnpairedAccess(address)
+}
+
+// CHECK-LABEL: define {{.*}}swiftcc void @"$e20exclusivity_builtins10readAccessyyBp_AA7MyClassVmtF"(ptr %0)
+// CHECK-NOT:   call void @swift_beginAccess
+// CHECK: ret void
+@used
+public func readAccess(_ address: Builtin.RawPointer, _ ty1: MyClass.Type) {
+  marker3()
+  Builtin.performInstantaneousReadAccess(address, ty1);
+}

--- a/test/embedded/keypaths-exec.swift
+++ b/test/embedded/keypaths-exec.swift
@@ -345,3 +345,122 @@ do {
   }
   print(box.value == 777 ? "OK!" : "FAIL") // CHECK: OK!
 }
+
+// -----------------------------------------------------------------------------
+// Multi-component chains of fixed-offset stored/tuple components.  These
+// exercise the walker that iterates through more than one component in a
+// single key path — supported in Embedded Swift when every step is a
+// struct/tuple field or a class ivar (i.e. resolves to a fixed offset).
+// -----------------------------------------------------------------------------
+
+// Nested struct chain (2 components, pure struct/tuple, all `var`) →
+// WritableKeyPath.
+struct Inner {
+  var a: Int32
+  var b: Int32
+}
+struct Outer {
+  var name: Int8
+  var inner: Inner
+}
+
+do {
+  var o = Outer(name: 1, inner: Inner(a: 10, b: 20))
+  let kpA: WritableKeyPath<Outer, Int32> = \.inner.a
+  let kpB: WritableKeyPath<Outer, Int32> = \.inner.b
+
+  // Read.
+  print(o[keyPath: kpA] == 10 && o[keyPath: kpB] == 20 ? "OK!" : "FAIL") // CHECK: OK!
+  print(getValueIn(o, keyPath: kpA) == 10 ? "OK!" : "FAIL") // CHECK: OK!
+
+  // Write.
+  o[keyPath: kpA] = 111
+  setValueIn(&o, Int32(222), keyPath: kpB)
+  print(o.inner.a == 111 && o.inner.b == 222 ? "OK!" : "FAIL") // CHECK: OK!
+}
+
+// Longer chain: 3 stored struct fields.
+struct L1 { var lower: L2 }
+struct L2 { var lowest: L3 }
+struct L3 { var value: Int32 }
+
+do {
+  var l = L1(lower: L2(lowest: L3(value: 100)))
+  let kp: WritableKeyPath<L1, Int32> = \.lower.lowest.value
+  print(l[keyPath: kp] == 100 ? "OK!" : "FAIL") // CHECK: OK!
+  l[keyPath: kp] = 999
+  print(l.lower.lowest.value == 999 ? "OK!" : "FAIL") // CHECK: OK!
+}
+
+// Chain with a `let` intermediate → read-only KeyPath (all `let` on any
+// component demotes to KeyPath).
+struct LetChainOuter {
+  let inner: LetChainInner
+}
+struct LetChainInner {
+  var v: Int32
+}
+
+do {
+  let o = LetChainOuter(inner: LetChainInner(v: 42))
+  let kp: KeyPath<LetChainOuter, Int32> = \.inner.v
+  print(o[keyPath: kp] == 42 ? "OK!" : "FAIL") // CHECK: OK!
+  print(getValueIn(o, keyPath: kp) == 42 ? "OK!" : "FAIL") // CHECK: OK!
+}
+
+// Chain crossing a class boundary → ReferenceWritableKeyPath.  Writing
+// through the KP mutates the class instance, which is observed via an
+// independent reference.
+final class ClassBox {
+  var value: Int32 = 0
+}
+struct HasClassField {
+  var boxed: ClassBox
+}
+
+do {
+  let box = ClassBox()
+  var hcf = HasClassField(boxed: box)
+  let kp: ReferenceWritableKeyPath<HasClassField, Int32> = \.boxed.value
+
+  print(hcf[keyPath: kp] == 0 ? "OK!" : "FAIL") // CHECK: OK!
+  hcf[keyPath: kp] = 55
+  print(box.value == 55 ? "OK!" : "FAIL") // CHECK: OK!
+  // The KP mutates the class, so an alias observes the write.
+  print(hcf.boxed.value == 55 ? "OK!" : "FAIL") // CHECK: OK!
+}
+
+// Chain that starts at a class root and dives into a struct ivar:
+// class → struct field → struct field.  Because the root is a class,
+// this is ReferenceWritableKeyPath.
+final class RootClass {
+  var stuff = Inner(a: 1, b: 2)
+}
+
+do {
+  let rc = RootClass()
+  let kpA: ReferenceWritableKeyPath<RootClass, Int32> = \.stuff.a
+  let kpB: ReferenceWritableKeyPath<RootClass, Int32> = \.stuff.b
+
+  print(rc[keyPath: kpA] == 1 && rc[keyPath: kpB] == 2 ? "OK!" : "FAIL") // CHECK: OK!
+
+  rc[keyPath: kpA] = 100
+  rc[keyPath: kpB] = 200
+  print(rc.stuff.a == 100 && rc.stuff.b == 200 ? "OK!" : "FAIL") // CHECK: OK!
+}
+
+// Chain into a tuple element (mixed struct + tuple), read + write.
+struct HasTuple {
+  var pair: (Int32, Int64)
+}
+
+do {
+  var ht = HasTuple(pair: (7, 8))
+  let kp0: WritableKeyPath<HasTuple, Int32> = \.pair.0
+  let kp1: WritableKeyPath<HasTuple, Int64> = \.pair.1
+
+  print(ht[keyPath: kp0] == 7 && ht[keyPath: kp1] == 8 ? "OK!" : "FAIL") // CHECK: OK!
+  ht[keyPath: kp0] = 70
+  ht[keyPath: kp1] = 80
+  print(ht.pair.0 == 70 && ht.pair.1 == 80 ? "OK!" : "FAIL") // CHECK: OK!
+}

--- a/test/embedded/keypaths-exec.swift
+++ b/test/embedded/keypaths-exec.swift
@@ -1,10 +1,36 @@
-// RUN: %target-run-simple-swift(   -enable-experimental-feature Embedded -wmo -Xfrontend -disable-access-control -runtime-compatibility-version none %target-embedded-posix-shim -enable-experimental-feature EmbeddedKeyPaths) | %FileCheck %s
-// RUN: %target-run-simple-swift(-O -enable-experimental-feature Embedded -wmo -Xfrontend -disable-access-control -runtime-compatibility-version none %target-embedded-posix-shim -enable-experimental-feature EmbeddedKeyPaths) | %FileCheck %s
+// RUN: %target-run-simple-swift(   -enable-experimental-feature Embedded -wmo -Xfrontend -disable-access-control -runtime-compatibility-version none %target-embedded-posix-shim -enable-experimental-feature EmbeddedKeyPaths -enable-experimental-feature KeyPathWithMethodMembers) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -enable-experimental-feature Embedded -wmo -Xfrontend -disable-access-control -runtime-compatibility-version none %target-embedded-posix-shim -enable-experimental-feature EmbeddedKeyPaths -enable-experimental-feature KeyPathWithMethodMembers) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_feature_EmbeddedKeyPaths
+// REQUIRES: swift_feature_KeyPathWithMethodMembers
+
+// -----------------------------------------------------------------------------
+// Generic wrappers
+// -----------------------------------------------------------------------------
+
+@inline(never)
+public func getValueIn<Root, Value>(_ root: Root, keyPath: KeyPath<Root, Value>) -> Value {
+  return root[keyPath: keyPath]
+}
+
+@inline(never)
+public func setValueIn<Root, Value>(_ root: inout Root, _ value: Value,
+                                    keyPath: WritableKeyPath<Root, Value>) {
+  root[keyPath: keyPath] = value
+}
+
+@inline(never)
+public func setValueIn<Root: AnyObject, Value>(_ root: Root, _ value: Value,
+                                               keyPath: ReferenceWritableKeyPath<Root, Value>) {
+  root[keyPath: keyPath] = value
+}
+
+// -----------------------------------------------------------------------------
+// Stored properties: read and write through a mutating generic wrapper.
+// -----------------------------------------------------------------------------
 
 struct MyStruct {
   var x: Int8
@@ -12,12 +38,226 @@ struct MyStruct {
   var z: Int32
 }
 
-@inline(never)
-public func getValueIn<Root, Value>(_ root: Root, keyPath: KeyPath<Root, Value>) -> Value {
-  return root[keyPath: keyPath]
+var ms = MyStruct(x: 17, y: 25, z: 42)
+print(getValueIn(ms, keyPath: \.x) == 17 ? "OK!" : "FAIL") // CHECK: OK!
+print(getValueIn(ms, keyPath: \.y) == 25 ? "OK!" : "FAIL") // CHECK: OK!
+print(getValueIn(ms, keyPath: \.z) == 42 ? "OK!" : "FAIL") // CHECK: OK!
+
+setValueIn(&ms, Int8(-8),    keyPath: \.x)
+setValueIn(&ms, Int16(1000), keyPath: \.y)
+setValueIn(&ms, Int32(9999), keyPath: \.z)
+print(ms.x == -8 && ms.y == 1000 && ms.z == 9999 ? "OK!" : "FAIL") // CHECK: OK!
+
+// A `let` field: readable via KeyPath, cannot be written.
+struct WithLet {
+  let a: Int32 = 111
+  var b: Int32 = 222
+}
+let wl = WithLet()
+print(getValueIn(wl, keyPath: \.a) == 111 ? "OK!" : "FAIL") // CHECK: OK!
+print(getValueIn(wl, keyPath: \.b) == 222 ? "OK!" : "FAIL") // CHECK: OK!
+
+// -----------------------------------------------------------------------------
+// Class ivars: reference-writable key path through generic wrapper.
+// The generic setter takes the class instance (not `inout`) and mutates
+// through the strong reference, so the same object is observed by other
+// aliases.
+// -----------------------------------------------------------------------------
+
+final class Cell {
+  var value: Int32 = 0
+  var count: Int32 = 100
 }
 
-let ms = MyStruct(x: 17, y: 25, z: 42)
-print(getValueIn(ms, keyPath: \.x)) // CHECK: 17
-print(getValueIn(ms, keyPath: \.y)) // CHECK: 25
-print(getValueIn(ms, keyPath: \.z)) // CHECK: 42
+let cell = Cell()
+setValueIn(cell, Int32(88),  keyPath: \Cell.value)
+setValueIn(cell, Int32(200), keyPath: \Cell.count)
+print(cell.value == 88 && cell.count == 200 ? "OK!" : "FAIL") // CHECK: OK!
+
+let aliased = cell
+print(getValueIn(aliased, keyPath: \Cell.value) == 88 ? "OK!" : "FAIL") // CHECK: OK!
+
+// -----------------------------------------------------------------------------
+// Identity key path: read + write on a bare value type.
+// -----------------------------------------------------------------------------
+
+var identity: Int32 = 5
+print(getValueIn(identity, keyPath: \.self) == 5 ? "OK!" : "FAIL") // CHECK: OK!
+setValueIn(&identity, Int32(9), keyPath: \.self)
+print(identity == 9 ? "OK!" : "FAIL") // CHECK: OK!
+
+// -----------------------------------------------------------------------------
+// Tuple key paths: labeled + positional, read + write.
+// -----------------------------------------------------------------------------
+
+var pair: (Int32, Int64) = (11, 22)
+print(getValueIn(pair, keyPath: \.0) == 11 ? "OK!" : "FAIL") // CHECK: OK!
+print(getValueIn(pair, keyPath: \.1) == 22 ? "OK!" : "FAIL") // CHECK: OK!
+setValueIn(&pair, Int32(-1), keyPath: \.0)
+setValueIn(&pair, Int64(-2), keyPath: \.1)
+print(pair.0 == -1 && pair.1 == -2 ? "OK!" : "FAIL") // CHECK: OK!
+
+var labeled: (a: Int32, b: Int32) = (a: 3, b: 4)
+setValueIn(&labeled, Int32(30), keyPath: \.a)
+setValueIn(&labeled, Int32(40), keyPath: \.b)
+print(labeled.a == 30 && labeled.b == 40 ? "OK!" : "FAIL") // CHECK: OK!
+
+// -----------------------------------------------------------------------------
+// Computed properties: get-only, mutating set, nonmutating set on struct.
+// -----------------------------------------------------------------------------
+
+// Get-only computed → `KeyPath<Root, Value>`.
+struct GetOnly {
+  var underlying: Int32 = 5
+  var doubled: Int32 { underlying &* 2 }
+}
+var go = GetOnly(underlying: 21)
+print(getValueIn(go, keyPath: \.doubled) == 42 ? "OK!" : "FAIL") // CHECK: OK!
+
+// Settable + mutating computed → `WritableKeyPath<Root, Value>`.
+struct MutatingSet {
+  var storage: Int32 = 0
+  var scaled: Int32 {
+    get { storage &* 3 }
+    set { storage = newValue / 3 }
+  }
+}
+var mset = MutatingSet(storage: 0)
+setValueIn(&mset, Int32(30), keyPath: \.scaled)
+print(mset.storage == 10 ? "OK!" : "FAIL") // CHECK: OK!
+print(getValueIn(mset, keyPath: \.scaled) == 30 ? "OK!" : "FAIL") // CHECK: OK!
+
+// Settable + nonmutating on a struct → `ReferenceWritableKeyPath<Root, Value>`.
+// The setter mutates external state; the struct value itself isn't touched.
+// The `Root: AnyObject` generic wrapper doesn't apply here (struct root), so
+// apply the key path directly to cover this shape.
+var externalSideChannel: Int32 = 0
+struct NonmutatingOnStruct {
+  var canary: Int32 = 7
+  var externallyStored: Int32 {
+    get { externalSideChannel }
+    nonmutating set { externalSideChannel = newValue }
+  }
+}
+let nms = NonmutatingOnStruct()
+let nmsKP: ReferenceWritableKeyPath<NonmutatingOnStruct, Int32> = \.externallyStored
+nms[keyPath: nmsKP] = 1234
+print(externalSideChannel == 1234 ? "OK!" : "FAIL") // CHECK: OK!
+print(nms[keyPath: nmsKP] == 1234 ? "OK!" : "FAIL") // CHECK: OK!
+
+// -----------------------------------------------------------------------------
+// Writeback semantics: a read through a `WritableKeyPath` must NOT invoke
+// the setter.  This exercises the `_read` vs `_modify` split in the
+// embedded stdlib's key path subscript accessors.
+// -----------------------------------------------------------------------------
+
+var mutatingSetCount: Int32 = 0
+var nonmutatingSetCount: Int32 = 0
+var externalStorage: Int32 = 246
+
+struct WritebackCounter {
+  var canary: Int32 = 0
+
+  var mutating: Int32 {
+    get { externalStorage }
+    set {
+      mutatingSetCount &+= 1
+      externalStorage = newValue
+    }
+  }
+
+  var nonmutating: Int32 {
+    get { externalStorage }
+    nonmutating set {
+      nonmutatingSetCount &+= 1
+      externalStorage = newValue
+    }
+  }
+}
+
+do {
+  var wc = WritebackCounter()
+  wc = WritebackCounter()  // suppress "never mutated" note
+
+  let wkp: WritableKeyPath<WritebackCounter, Int32> = \.mutating
+  let rkp: ReferenceWritableKeyPath<WritebackCounter, Int32> = \.nonmutating
+
+  mutatingSetCount = 0
+  nonmutatingSetCount = 0
+
+  _ = getValueIn(wc, keyPath: wkp)
+  _ = getValueIn(wc, keyPath: rkp)
+  _ = wc[keyPath: wkp]
+  _ = wc[keyPath: rkp]
+
+  print(mutatingSetCount == 0 && nonmutatingSetCount == 0 ? "OK!" : "FAIL") // CHECK: OK!
+
+  // Now write through each and check the setter fires exactly once.
+  setValueIn(&wc, Int32(300), keyPath: wkp)
+  print(mutatingSetCount == 1 && externalStorage == 300 ? "OK!" : "FAIL") // CHECK: OK!
+
+  // `rkp` on a struct root: the `setValueIn(_:AnyObject, ...)` overload can't
+  // apply, so use the subscript directly.
+  wc[keyPath: rkp] = 400
+  print(nonmutatingSetCount == 1 && externalStorage == 400 ? "OK!" : "FAIL") // CHECK: OK!
+}
+
+// -----------------------------------------------------------------------------
+// Generic-root specialization: a keypath created inside a generic function,
+// then specialized at each call site.  Exercises the "no archetypes in the
+// substitution map" static-instance guard.
+// -----------------------------------------------------------------------------
+
+struct Box<T> {
+  var value: T
+}
+
+@inline(never)
+func kpValue<T>(_: T.Type) -> WritableKeyPath<Box<T>, T> {
+  return \Box<T>.value
+}
+
+do {
+  var b = Box<Int>(value: 7)
+  setValueIn(&b, 99, keyPath: kpValue(Int.self))
+  print(b.value == 99 ? "OK!" : "FAIL") // CHECK: OK!
+
+  var b2 = Box<Int32>(value: -1)
+  setValueIn(&b2, Int32(1000), keyPath: kpValue(Int32.self))
+  print(b2.value == 1000 ? "OK!" : "FAIL") // CHECK: OK!
+}
+
+// -----------------------------------------------------------------------------
+// Method key path (`\Root.method`) — the projected value is an unapplied
+// closure `(Root) -> Value`.  Read via the generic wrapper, then invoke it.
+// -----------------------------------------------------------------------------
+
+struct HasMethod {
+  var base: Int32
+  func doubled() -> Int32 { base &* 2 }
+  func plus(_ x: Int32) -> Int32 { base &+ x }
+}
+
+do {
+  let hm = HasMethod(base: 21)
+  let fn0 = getValueIn(hm, keyPath: \HasMethod.doubled)
+  print(fn0() == 42 ? "OK!" : "FAIL") // CHECK: OK!
+
+  let fn1 = getValueIn(hm, keyPath: \HasMethod.plus)
+  print(fn1(100) == 121 ? "OK!" : "FAIL") // CHECK: OK!
+}
+
+// -----------------------------------------------------------------------------
+// Same-shape key paths used many times: the emitted immortal global is
+// shared across calls, and each use projects independently.
+// -----------------------------------------------------------------------------
+
+do {
+  let kp: WritableKeyPath<MyStruct, Int32> = \.z
+  var a = MyStruct(x: 0, y: 0, z: 1)
+  var b = MyStruct(x: 0, y: 0, z: 2)
+  setValueIn(&a, Int32(10), keyPath: kp)
+  setValueIn(&b, Int32(20), keyPath: kp)
+  print(a.z == 10 && b.z == 20 ? "OK!" : "FAIL") // CHECK: OK!
+  print(getValueIn(a, keyPath: kp) + getValueIn(b, keyPath: kp) == 30 ? "OK!" : "FAIL") // CHECK: OK!
+}

--- a/test/embedded/keypaths-exec.swift
+++ b/test/embedded/keypaths-exec.swift
@@ -1,0 +1,23 @@
+// RUN: %target-run-simple-swift(   -enable-experimental-feature Embedded -wmo -Xfrontend -disable-access-control -runtime-compatibility-version none %target-embedded-posix-shim -enable-experimental-feature EmbeddedKeyPaths) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -enable-experimental-feature Embedded -wmo -Xfrontend -disable-access-control -runtime-compatibility-version none %target-embedded-posix-shim -enable-experimental-feature EmbeddedKeyPaths) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_EmbeddedKeyPaths
+
+struct MyStruct {
+  var x: Int8
+  var y: Int16
+  var z: Int32
+}
+
+@inline(never)
+public func getValueIn<Root, Value>(_ root: Root, keyPath: KeyPath<Root, Value>) -> Value {
+  return root[keyPath: keyPath]
+}
+
+let ms = MyStruct(x: 17, y: 25, z: 42)
+print(getValueIn(ms, keyPath: \.x)) // CHECK: 17
+print(getValueIn(ms, keyPath: \.y)) // CHECK: 25
+print(getValueIn(ms, keyPath: \.z)) // CHECK: 42

--- a/test/embedded/keypaths-exec.swift
+++ b/test/embedded/keypaths-exec.swift
@@ -261,3 +261,87 @@ do {
   print(a.z == 10 && b.z == 20 ? "OK!" : "FAIL") // CHECK: OK!
   print(getValueIn(a, keyPath: kp) + getValueIn(b, keyPath: kp) == 30 ? "OK!" : "FAIL") // CHECK: OK!
 }
+
+// -----------------------------------------------------------------------------
+// `UnsafePointer(to:)` / `UnsafeMutablePointer(to:)`: turn a `KeyPath` or
+// `WritableKeyPath` into a raw byte offset via `_storedInlineOffset` and
+// GEP through the pointer.  Returns `nil` for computed properties.
+// -----------------------------------------------------------------------------
+
+struct Sample {
+  var head: Int8      // offset 0
+  var mid:  Int32     // offset 4 (Int32 alignment)
+  var tail: Int64     // offset 8
+  var computed: Int32 { mid &* 10 }
+}
+
+do {
+  var s = Sample(head: 1, mid: 2, tail: 3)
+
+  // Read-only pointer through immutable base.
+  withUnsafePointer(to: s) { p in
+    let pHead = p.pointer(to: \Sample.head)!
+    let pMid  = p.pointer(to: \Sample.mid)!
+    let pTail = p.pointer(to: \Sample.tail)!
+    print(pHead.pointee == 1 && pMid.pointee == 2 && pTail.pointee == 3
+          ? "OK!" : "FAIL") // CHECK: OK!
+
+    // Offsets are consistent with `MemoryLayout.offset(of:)`.
+    let baseAddr = UInt(bitPattern: p)
+    print(UInt(bitPattern: pMid)  &- baseAddr == 4 ? "OK!" : "FAIL") // CHECK: OK!
+    print(UInt(bitPattern: pTail) &- baseAddr == 8 ? "OK!" : "FAIL") // CHECK: OK!
+  }
+
+  // Mutating pointer: write a new value through the pointer, observe it
+  // in the original struct.
+  withUnsafeMutablePointer(to: &s) { p in
+    let pMid = p.pointer(to: \Sample.mid)!
+    pMid.pointee = 555
+  }
+  print(s.mid == 555 ? "OK!" : "FAIL") // CHECK: OK!
+
+  // Computed properties don't have a stored inline offset — the API
+  // returns nil rather than trapping.
+  withUnsafePointer(to: s) { p in
+    let pComputed = p.pointer(to: \Sample.computed)
+    print(pComputed == nil ? "OK!" : "FAIL") // CHECK: OK!
+  }
+}
+
+// A `let` field still has a stored offset: readable via
+// `UnsafePointer.pointer(to:)` because the API takes `KeyPath`, not
+// `WritableKeyPath`.
+do {
+  let wl = WithLet()
+  withUnsafePointer(to: wl) { p in
+    let pa = p.pointer(to: \WithLet.a)!
+    let pb = p.pointer(to: \WithLet.b)!
+    print(pa.pointee == 111 && pb.pointee == 222 ? "OK!" : "FAIL") // CHECK: OK!
+  }
+}
+
+// Tuples: the embedded static-instance emitter treats tuple elements the
+// same as struct fields, so `pointer(to:)` should work here too.
+do {
+  var t: (Int32, Int64) = (100, 200)
+  withUnsafeMutablePointer(to: &t) { p in
+    let p0 = p.pointer(to: \.0)!
+    let p1 = p.pointer(to: \.1)!
+    print(p0.pointee == 100 && p1.pointee == 200 ? "OK!" : "FAIL") // CHECK: OK!
+    p0.pointee = -1
+    p1.pointee = -2
+  }
+  print(t.0 == -1 && t.1 == -2 ? "OK!" : "FAIL") // CHECK: OK!
+}
+
+// Generic-struct specialization: the same `pointer(to:)` on a `Box<Int>`
+// specialization goes through the substitution-map-aware static-instance
+// path.
+do {
+  var box = Box<Int>(value: 42)
+  withUnsafeMutablePointer(to: &box) { p in
+    let pv = p.pointer(to: kpValue(Int.self))!
+    pv.pointee = 777
+  }
+  print(box.value == 777 ? "OK!" : "FAIL") // CHECK: OK!
+}

--- a/test/embedded/keypaths-static.swift
+++ b/test/embedded/keypaths-static.swift
@@ -1,0 +1,260 @@
+// Verify that in Embedded Swift, `keypath` insts for qualifying single-
+// component patterns are emitted as immortal constant globals rather than
+// through the `swift_getKeyPath` runtime call.
+//
+// Covers the currently-supported cases (phases 1-3):
+//   * struct stored property, `var` and `let`
+//   * generic-struct stored property under specialization
+//   * identity key path (0 components)
+//   * tuple element
+//   * computed properties on structs (get-only and settable mutating)
+//   * class ivar (emitted as computed settable_property in SIL)
+
+// RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded -enable-experimental-feature EmbeddedKeyPaths -enable-experimental-feature KeyPathWithMethodMembers -wmo -o - | %FileCheck -check-prefix=CHECK-IR %s
+// RUN: %target-run-simple-swift(-O -enable-experimental-feature Embedded -enable-experimental-feature EmbeddedKeyPaths -enable-experimental-feature KeyPathWithMethodMembers -wmo -runtime-compatibility-version none %target-embedded-posix-shim) | %FileCheck -check-prefix=CHECK-OUT %s
+
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_EmbeddedKeyPaths
+// REQUIRES: swift_feature_KeyPathWithMethodMembers
+
+public struct S {
+  var a: Int32
+  var b: Int32
+}
+
+// Static WritableKeyPath for a `var` struct field.
+@inline(never)
+public func kpS() -> WritableKeyPath<S, Int32> {
+  return \S.b
+}
+
+// Static read-only KeyPath for a `let` struct field.
+public struct SLet {
+  let a: Int32
+  let b: Int32
+}
+
+@inline(never)
+public func kpSLet() -> KeyPath<SLet, Int32> {
+  return \SLet.b
+}
+
+// A key path built inside a generic function, then specialized.  The
+// `keypath` inst emitted by SILGen still carries a substitution map
+// (mapping the generic parameter to the concrete type); the static-instance
+// emitter has to consult the concrete SIL type of the instruction rather
+// than the pattern's generic types.
+public struct Box<T> {
+  var value: T
+}
+
+@inline(never)
+public func kpBoxGeneric<T>(_: T.Type) -> WritableKeyPath<Box<T>, T> {
+  return \Box<T>.value
+}
+
+@inline(never)
+public func kpBoxInt() -> WritableKeyPath<Box<Int>, Int> {
+  return kpBoxGeneric(Int.self)
+}
+
+// Identity key path (0 components): the runtime always picks
+// `WritableKeyPath` for the concrete class regardless of the declared type.
+@inline(never)
+public func kpIdentity() -> WritableKeyPath<Int, Int> {
+  return \Int.self
+}
+
+// Tuple-element key paths — single `TupleElement` component encoded with the
+// same `structTag` discriminator that the runtime uses.
+public typealias Pair = (Int32, Int64)
+
+@inline(never)
+public func kpTuple0() -> WritableKeyPath<Pair, Int32> {
+  return \.0
+}
+
+@inline(never)
+public func kpTuple1() -> WritableKeyPath<Pair, Int64> {
+  return \.1
+}
+
+// Class ivar via computed getter/setter — always emits as `settable_property`
+// in SIL, so it exercises the computed-component path (phase 3), not the
+// stored-property path.
+public class Cell {
+  public var value: Int32 = 0
+}
+
+@inline(never)
+public func kpCell() -> ReferenceWritableKeyPath<Cell, Int32> {
+  return \Cell.value
+}
+
+// Struct with explicit computed property — mutating setter → WritableKeyPath.
+public struct Wrap {
+  var storage: Int32 = 0
+  public var doubled: Int32 {
+    get { storage &* 2 }
+    set { storage = newValue / 2 }
+  }
+}
+
+@inline(never)
+public func kpWrapDoubled() -> WritableKeyPath<Wrap, Int32> {
+  return \Wrap.doubled
+}
+
+// Struct with get-only computed property → read-only KeyPath.
+public struct Ro {
+  public var v: Int32 { 7 }
+}
+
+@inline(never)
+public func kpRoV() -> KeyPath<Ro, Int32> {
+  return \Ro.v
+}
+
+// Instance-method key path — encoded as a get-only computed component
+// whose "getter" returns the bound closure.  Same shape as a get-only
+// computed property in memory, so no setter slot.
+public struct HasMethod {
+  public func doThing() -> Int { 42 }
+}
+
+@inline(never)
+public func kpMethod() -> KeyPath<HasMethod, () -> Int> {
+  return \HasMethod.doThing
+}
+
+// CHECK-IR-NOT: swift_getKeyPath
+//
+// FileCheck the concrete shape of the emitted immortal globals.  Each key
+// path is emitted as a private constant whose isa points at the picked
+// concrete `KeyPath` subclass's metadata, whose refcount is -1 (immortal),
+// and whose tail buffer encodes the component list.
+//
+// Buffer-header word bits (`_SwiftKeyPathBufferHeader_*`):
+//   0x8000_0000 TrivialFlag
+//   0x4000_0000 HasReferencePrefixFlag
+//   0x2000_0000 IsSingleComponentFlag
+//   0x00FF_FFFF SizeMask (bytes of components, including per-component skew)
+//
+// Component-header word bits (`_SwiftKeyPathComponentHeader_*`):
+//   discriminator (bits 24-30): 1=StructTag, 2=ComputedTag, 3=ClassTag
+//   0x0080_0000 StoredMutableFlag / ComputedMutatingFlag
+//   0x0040_0000 ComputedSettableFlag
+//   payload (low 24 bits): stored inline offset, or computed id-resolution bits
+//
+// Values are shown as unsigned decimal to match FileCheck-friendly output.
+
+//
+// `\S.b` — var struct field at offset 4 → WritableKeyPath.
+// Buffer header 0xA0000004 = -1610612732 (trivial + singleComponent + size=4)
+// Comp   header 0x01800004 =    25165828 (structTag + mutable + offset=4)
+//
+// CHECK-IR-DAG: @keypath{{[.0-9]*}} = private constant { %swift.refcounted, i32, [4 x i8], i32 } { %swift.refcounted { ptr {{.*}}"$es15WritableKeyPathCy4main1SVs5Int32VGMf"{{.*}}, i64 -1 }, i32 -1610612732, [4 x i8] zeroinitializer, i32 25165828 }
+
+//
+// `\SLet.b` — let struct field at offset 4 → KeyPath (read-only).
+// Buffer header 0xA0000004 = -1610612732
+// Comp   header 0x01000004 =    16777220 (structTag + offset=4, no mutable bit)
+//
+// CHECK-IR-DAG: @keypath{{[.0-9]*}} = private constant { %swift.refcounted, i32, [4 x i8], i32 } { %swift.refcounted { ptr {{.*}}"$es7KeyPathCy4main4SLetVs5Int32VGMf"{{.*}}, i64 -1 }, i32 -1610612732, [4 x i8] zeroinitializer, i32 16777220 }
+
+//
+// `\Box<Int>.value` — specialization of generic `\Box<T>.value`
+// (T = Int → offset 0 in the specialized layout).
+// Comp header 0x01800000 = 25165824 (structTag + mutable + offset=0)
+//
+// CHECK-IR-DAG: @keypath{{[.0-9]*}} = private constant { %swift.refcounted, i32, [4 x i8], i32 } { %swift.refcounted { ptr {{.*}}"$es15WritableKeyPathCy4main3BoxVySiGSiGMf"{{.*}}, i64 -1 }, i32 -1610612732, [4 x i8] zeroinitializer, i32 25165824 }
+
+//
+// `\Int.self` — identity: no component, so no IsSingleComponent flag and
+// size=0 in the buffer header.
+// Buffer header 0x80000000 = -2147483648 (trivial only)
+//
+// CHECK-IR-DAG: @keypath{{[.0-9]*}} = private constant { %swift.refcounted, i32, [4 x i8] } { %swift.refcounted { ptr {{.*}}"$es15WritableKeyPathCyS2iGMf"{{.*}}, i64 -1 }, i32 -2147483648, [4 x i8] zeroinitializer }
+
+//
+// `\Pair.0` — tuple element at offset 0 → WritableKeyPath, structTag +
+// mutable + offset=0 → 0x01800000.
+//
+// CHECK-IR-DAG: @keypath{{[.0-9]*}} = private constant { %swift.refcounted, i32, [4 x i8], i32 } { %swift.refcounted { ptr {{.*}}"$es15WritableKeyPathCys5Int32V_s5Int64VtADGMf"{{.*}}, i64 -1 }, i32 -1610612732, [4 x i8] zeroinitializer, i32 25165824 }
+
+//
+// `\Pair.1` — tuple element at offset 8 (Int32 then Int64 aligned) →
+// WritableKeyPath, structTag + mutable + offset=8 → 0x01800008 = 25165832.
+//
+// CHECK-IR-DAG: @keypath{{[.0-9]*}} = private constant { %swift.refcounted, i32, [4 x i8], i32 } { %swift.refcounted { ptr {{.*}}"$es15WritableKeyPathCys5Int32V_s5Int64VtAFGMf"{{.*}}, i64 -1 }, i32 -1610612732, [4 x i8] zeroinitializer, i32 25165832 }
+
+//
+// `\Cell.value` — class settable computed → ReferenceWritableKeyPath.
+// Buffer size = 4 (comp header) + 4 (skew) + 8 (id) + 8 (getter) + 8 (setter) = 32.
+// Buffer header 0xA0000020 = -1610612704 (trivial + singleComponent + size=32).
+// Comp   header 0x02400000 = 37748736 (computedTag + settable, non-mutating).
+// The id field is the raw getter pointer; the getter and setter fields are
+// (address-discriminated) ptr-auth-signed on arm64e — the layout still
+// contains three ptr slots regardless.
+//
+// CHECK-IR-DAG: @keypath{{[.0-9]*}} = private constant { %swift.refcounted, i32, [4 x i8], i32, [4 x i8], ptr, ptr, ptr } { %swift.refcounted { ptr {{.*}}"$es24ReferenceWritableKeyPathCy4main4CellCs5Int32VGMf"{{.*}}, i64 -1 }, i32 -1610612704, [4 x i8] zeroinitializer, i32 37748736, [4 x i8] zeroinitializer, ptr @"$e4main4CellC5values5Int32VvpACTK", ptr @"$e4main4CellC5values5Int32VvpACTK", ptr @"$e4main4CellC5values5Int32VvpACTk" }
+
+//
+// `\Wrap.doubled` — struct settable mutating computed → WritableKeyPath.
+// Comp header 0x02C00000 = 46137344 (computedTag + settable + mutating).
+//
+// CHECK-IR-DAG: @keypath{{[.0-9]*}} = private constant { %swift.refcounted, i32, [4 x i8], i32, [4 x i8], ptr, ptr, ptr } { %swift.refcounted { ptr {{.*}}"$es15WritableKeyPathCy4main4WrapVs5Int32VGMf"{{.*}}, i64 -1 }, i32 -1610612704, [4 x i8] zeroinitializer, i32 46137344, [4 x i8] zeroinitializer, ptr @"$e4main4WrapV7doubleds5Int32VvpACTK", ptr @"$e4main4WrapV7doubleds5Int32VvpACTK", ptr @"$e4main4WrapV7doubleds5Int32VvpACTk" }
+
+//
+// `\Ro.v` — get-only struct computed → KeyPath.
+// Buffer size = 4 (comp header) + 4 (skew) + 8 (id) + 8 (getter) = 24.
+// Buffer header 0xA0000018 = -1610612712 (trivial + singleComponent + size=24).
+// Comp   header 0x02000000 = 33554432 (computedTag + getOnly).  Only two ptr
+// slots (id, getter) — no setter.
+//
+// CHECK-IR-DAG: @keypath{{[.0-9]*}} = private constant { %swift.refcounted, i32, [4 x i8], i32, [4 x i8], ptr, ptr } { %swift.refcounted { ptr {{.*}}"$es7KeyPathCy4main2RoVs5Int32VGMf"{{.*}}, i64 -1 }, i32 -1610612712, [4 x i8] zeroinitializer, i32 33554432, [4 x i8] zeroinitializer, ptr @"$e4main2RoV1vs5Int32VvpACTK", ptr @"$e4main2RoV1vs5Int32VvpACTK" }
+
+//
+// `\HasMethod.doThing` — instance method → same shape as a get-only
+// computed component (no setter), value type is `() -> Int`.
+//
+// CHECK-IR-DAG: @keypath{{[.0-9]*}} = private constant { %swift.refcounted, i32, [4 x i8], i32, [4 x i8], ptr, ptr } { %swift.refcounted { ptr {{.*}}"$es7KeyPathCy4main9HasMethodVSiycGMf"{{.*}}, i64 -1 }, i32 -1610612712, [4 x i8] zeroinitializer, i32 33554432, [4 x i8] zeroinitializer, ptr @"$e4main9HasMethodV7doThingSiyFACTkmu", ptr @"$e4main9HasMethodV7doThingSiyFACTkmu" }
+
+
+// Runtime behavior: applying the keypath yields the right offset / value.
+var s = S(a: 1, b: 2)
+s[keyPath: kpS()] = 42
+print(s.b == 42 ? "OK!" : "FAIL") // CHECK-OUT: OK!
+
+let sl = SLet(a: 3, b: 4)
+print(sl[keyPath: kpSLet()] == 4 ? "OK!" : "FAIL") // CHECK-OUT: OK!
+
+var box = Box<Int>(value: 7)
+box[keyPath: kpBoxInt()] = 99
+print(box.value == 99 ? "OK!" : "FAIL") // CHECK-OUT: OK!
+
+var identityValue = 123
+identityValue[keyPath: kpIdentity()] = 456
+print(identityValue == 456 ? "OK!" : "FAIL") // CHECK-OUT: OK!
+
+var pair: Pair = (11, 22)
+pair[keyPath: kpTuple0()] = 111
+pair[keyPath: kpTuple1()] = 222
+print(pair.0 == 111 && pair.1 == 222 ? "OK!" : "FAIL") // CHECK-OUT: OK!
+
+let cell = Cell()
+cell[keyPath: kpCell()] = 88
+print(cell.value == 88 ? "OK!" : "FAIL") // CHECK-OUT: OK!
+
+var wrap = Wrap(storage: 0)
+wrap[keyPath: kpWrapDoubled()] = 20
+print(wrap.storage == 10 && wrap[keyPath: kpWrapDoubled()] == 20 ? "OK!" : "FAIL") // CHECK-OUT: OK!
+
+let ro = Ro()
+print(ro[keyPath: kpRoV()] == 7 ? "OK!" : "FAIL") // CHECK-OUT: OK!
+
+let hm = HasMethod()
+let fn = hm[keyPath: kpMethod()]
+print(fn() == 42 ? "OK!" : "FAIL") // CHECK-OUT: OK!

--- a/test/embedded/keypaths5.swift
+++ b/test/embedded/keypaths5.swift
@@ -1,0 +1,47 @@
+// RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded -enable-experimental-feature EmbeddedKeyPaths -wmo -o - | %FileCheck %s
+
+// REQUIRES: optimized_stdlib
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_EmbeddedKeyPaths
+
+public struct MyStruct {
+  var x: Int32
+  var y: Int32
+
+  var max: Int32 {
+    x > y ? x : y
+  }
+}
+
+@inline(never)
+public func getValueIn<Root, Value>(_ root: Root, keyPath: KeyPath<Root, Value>) -> Value {
+  return root[keyPath: keyPath]
+}
+
+@inline(never)
+public func getValueAsAnyIn<Root>(_ root: Root, keyPath: PartialKeyPath<Root>) -> Any {
+  return root[keyPath: keyPath]
+}
+
+@inline(never)
+public func getValueAsAnyIn<Root>(anyRoot root: Root, keyPath: AnyKeyPath) -> Any? {
+  return root[keyPath: keyPath]
+}
+
+public func getKeyPaths(ms: MyStruct) {
+  _ = getValueIn(ms, keyPath: \.x)
+  _ = getValueAsAnyIn(ms, keyPath: \.x)
+  _ = getValueAsAnyIn(anyRoot: ms, keyPath: \MyStruct.x)
+}
+
+// CHECK-LABEL: define linkonce_odr hidden swiftcc i32 @"$e9keypaths510getValueIn_7keyPathq_x_s03KeyF0Cyxq_Gtr0_lFAA8MyStructV_s5Int32VTg5"
+// CHECK-NOT: ret void
+// CHECK: call swiftcc i32 @"$e18swift_getAtKeyPath9keypaths58MyStructV_s5Int32VTg5"
+
+// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$e9keypaths515getValueAsAnyIn_7keyPathypx_s010PartialKeyH0CyxGtlFAA8MyStructV_Tg5"
+// CHECK-NOT: ret void
+// CHECK: call swiftcc void @"$e25swift_getAtPartialKeyPath9keypaths58MyStructV_Tg5"
+
+// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$e9keypaths515getValueAsAnyIn7anyRoot7keyPathypSgx_s0e3KeyJ0CtlFAA8MyStructV_Tg5"
+// CHECK-NOT: ret void
+// CHECK: call swiftcc void @"$e21swift_getAtAnyKeyPath9keypaths58MyStructV_Tg5"

--- a/test/embedded/keypaths5.swift
+++ b/test/embedded/keypaths5.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded -enable-experimental-feature EmbeddedKeyPaths -wmo -o - | %FileCheck %s
+// RUN: %target-swift-emit-sil %s -enable-experimental-feature Embedded -enable-experimental-feature EmbeddedKeyPaths -wmo -o - | %FileCheck -check-prefix=CHECK-SIL %s
+// RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded -enable-experimental-feature EmbeddedKeyPaths -wmo -o - | %FileCheck -check-prefix=CHECK-IR %s
 
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
@@ -28,20 +29,35 @@ public func getValueAsAnyIn<Root>(anyRoot root: Root, keyPath: AnyKeyPath) -> An
   return root[keyPath: keyPath]
 }
 
+@inline(never)
+public func updateValueIn<Root, Value>(_ root: inout Root, keyPath: WritableKeyPath<Root, Value>, body: (inout Value) -> Void) {
+  body(&root[keyPath: keyPath])
+}
+
 public func getKeyPaths(ms: MyStruct) {
   _ = getValueIn(ms, keyPath: \.x)
   _ = getValueAsAnyIn(ms, keyPath: \.x)
   _ = getValueAsAnyIn(anyRoot: ms, keyPath: \MyStruct.x)
 }
 
-// CHECK-LABEL: define linkonce_odr hidden swiftcc i32 @"$e9keypaths510getValueIn_7keyPathq_x_s03KeyF0Cyxq_Gtr0_lFAA8MyStructV_s5Int32VTg5"
-// CHECK-NOT: ret void
-// CHECK: call swiftcc i32 @"$e18swift_getAtKeyPath9keypaths58MyStructV_s5Int32VTg5"
+public func updateKeyPaths(ms: MyStruct) {
+  var ms = ms
 
-// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$e9keypaths515getValueAsAnyIn_7keyPathypx_s010PartialKeyH0CyxGtlFAA8MyStructV_Tg5"
-// CHECK-NOT: ret void
-// CHECK: call swiftcc void @"$e25swift_getAtPartialKeyPath9keypaths58MyStructV_Tg5"
+  updateValueIn(&ms, keyPath: \.x) { $0 += 1 }
+}
 
-// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$e9keypaths515getValueAsAnyIn7anyRoot7keyPathypSgx_s0e3KeyJ0CtlFAA8MyStructV_Tg5"
-// CHECK-NOT: ret void
-// CHECK: call swiftcc void @"$e21swift_getAtAnyKeyPath9keypaths58MyStructV_Tg5"
+// CHECK-IR-LABEL: define linkonce_odr hidden swiftcc i32 @"$e9keypaths510getValueIn_7keyPathq_x_s03KeyF0Cyxq_Gtr0_lFAA8MyStructV_s5Int32VTg5"
+// CHECK-IR-NOT: ret void
+// CHECK-IR: call swiftcc i32 @"$e18swift_getAtKeyPath9keypaths58MyStructV_s5Int32VTg5"
+
+// CHECK-IR-LABEL: define linkonce_odr hidden swiftcc void @"$e9keypaths515getValueAsAnyIn_7keyPathypx_s010PartialKeyH0CyxGtlFAA8MyStructV_Tg5"
+// CHECK-IR-NOT: ret void
+// CHECK-IR: call swiftcc void @"$e25swift_getAtPartialKeyPath9keypaths58MyStructV_Tg5"
+
+// CHECK-IR-LABEL: define linkonce_odr hidden swiftcc void @"$e9keypaths515getValueAsAnyIn7anyRoot7keyPathypSgx_s0e3KeyJ0CtlFAA8MyStructV_Tg5"
+// CHECK-IR-NOT: ret void
+// CHECK-IR: call swiftcc void @"$e21swift_getAtAnyKeyPath9keypaths58MyStructV_Tg5"
+
+// CHECK-SIL-LABEL: sil shared [noinline] @$e9keypaths513updateValueIn_7keyPath4bodyyxz_s011WritableKeyF0Cyxq_Gyq_zXEtr0_lFAA8MyStructV_s5Int32VTg5 : $@convention(thin) (@inout MyStruct, @guaranteed WritableKeyPath<MyStruct, Int32>, @guaranteed @noescape @callee_guaranteed @substituted <τ_0_0> (@inout τ_0_0) -> () for <Int32>) -> () {
+// CHECK-SIL-NOT: return
+// CHECK-SIL: function_ref @$e29swift_modifyAtWritableKeyPath9keypaths58MyStructV_s5Int32VTg5 : $@yield_once @convention(method) (MyStruct, @guaranteed WritableKeyPath<MyStruct, Int32>) -> @yields @inout Int32


### PR DESCRIPTION
Implementation of key paths in Embedded Swift with the following restrictions:
* Subscript and method key paths cannot capture arguments and must be the only component in the keypath
* The "appending" operations are prohibited

Key paths in Embedded Swift are always emitted as immortal, static instances of the appropriate `KeyPath` subclass. Most of the implementation of the key path types and operations in the standard library is shared with non-Embedded Swift, although we slim the layout down slightly (since there is not KVC path string) and have to avoid ever opening existentials.

Implements rdar://175202589.
