### PR TITLE
[SourceKit] Replace some dispatch queues with mutexes

### DIFF
--- a/tools/SourceKit/include/SourceKit/Support/Concurrency.h
+++ b/tools/SourceKit/include/SourceKit/Support/Concurrency.h
@@ -124,15 +124,9 @@ public:
                                                 isStackDeep));
   }
 
-  void dispatchBarrierSync(void *Context, DispatchFn Fn,
-                           bool isStackDeep = false) {
-    Impl::dispatchBarrierSync(ImplObj, DispatchData(Context, Fn, isStackDeep));
-  }
-  template <typename Callable>
-  void dispatchBarrierSync(Callable &&Fn, bool isStackDeep = false) {
-    Impl::dispatchBarrierSync(ImplObj, DispatchData(std::forward<Callable>(Fn),
-                                                    isStackDeep));
-  }
+  // NOTE: We don't expose dispatchBarrierSync here since there's a libdispatch
+  // bug that can result in a deadlock for `dispatch_sync` +
+  // `dispatch_barrier_sync`.
 
   static void dispatchOnMain(void *Context, DispatchFn Fn,
                              bool isStackDeep = false) {
@@ -227,7 +221,6 @@ private:
     static void dispatch(Ty Obj, const DispatchData &Fn);
     static void dispatchSync(Ty Obj, const DispatchData &Fn);
     static void dispatchBarrier(Ty Obj, const DispatchData &Fn);
-    static void dispatchBarrierSync(Ty Obj, const DispatchData &Fn);
     static void dispatchOnMain(const DispatchData &Fn);
     static void dispatchConcurrent(Priority Prio, const DispatchData &Fn);
     static void suspend(Ty Obj);

--- a/tools/SourceKit/lib/Support/Concurrency-libdispatch.cpp
+++ b/tools/SourceKit/lib/Support/Concurrency-libdispatch.cpp
@@ -159,15 +159,6 @@ void WorkQueue::Impl::dispatchBarrier(Ty Obj, const DispatchData &Fn) {
   dispatch_barrier_async_f(queue, Context, CFn);
 }
 
-void WorkQueue::Impl::dispatchBarrierSync(Ty Obj, const DispatchData &Fn) {
-  void *Context;
-  WorkQueue::DispatchFn CFn;
-  std::tie(Context, CFn) = toCFunction(Fn.getContext(), Fn.getFunction(),
-                                       Fn.isStackDeep());
-  dispatch_queue_t queue = dispatch_queue_t(Obj);
-  dispatch_barrier_sync_f(queue, Context, CFn);
-}
-
 void WorkQueue::Impl::dispatchOnMain(const DispatchData &Fn) {
   void *Context;
   WorkQueue::DispatchFn CFn;

--- a/tools/SourceKit/lib/Support/UIDRegistry.cpp
+++ b/tools/SourceKit/lib/Support/UIDRegistry.cpp
@@ -26,7 +26,7 @@ class UIDRegistryImpl {
   typedef llvm::StringMap<void *, llvm::BumpPtrAllocator> HashTableTy;
   typedef llvm::StringMapEntry<void *> EntryTy;
   HashTableTy HashTable;
-  WorkQueue Queue{ WorkQueue::Dequeuing::Concurrent, "UIDRegistryImpl" };
+  std::mutex HashTableMtx;
 
 public:
 
@@ -86,21 +86,9 @@ void UIdent::print(llvm::raw_ostream &OS) const {
 void *UIDRegistryImpl::get(StringRef Str) {
   assert(!Str.empty());
   assert(!Str.contains(' '));
-  EntryTy *Ptr = 0;
-  Queue.dispatchSync([&]{
-    HashTableTy::iterator It = HashTable.find(Str);
-    if (It != HashTable.end())
-      Ptr = &(*It);
-  });
 
-  if (Ptr == 0) {
-    Queue.dispatchBarrierSync([&]{
-      EntryTy &Entry = *HashTable.insert(std::make_pair(Str, nullptr)).first;
-      Ptr = &Entry;
-    });
-  }
-
-  return Ptr;
+  std::lock_guard<std::mutex> lock(HashTableMtx);
+  return &(*HashTable.try_emplace(Str, nullptr).first);
 }
 
 StringRef UIDRegistryImpl::getName(void *Ptr) {

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -282,69 +282,57 @@ void EditorDiagConsumer::handleDiagnostic(SourceManager &SM,
 
 SwiftEditorDocumentRef
 SwiftEditorDocumentFileMap::getByUnresolvedName(StringRef FilePath) {
-  SwiftEditorDocumentRef EditorDoc;
+  std::lock_guard<std::mutex> lock(DocsMtx);
+  auto It = Docs.find(FilePath);
+  if (It != Docs.end())
+    return It->second.DocRef;
 
-  Queue.dispatchSync([&]{
-    auto It = Docs.find(FilePath);
-    if (It != Docs.end())
-      EditorDoc = It->second.DocRef;
-   });
-
-  return EditorDoc;
+  return nullptr;
 }
 
 SwiftEditorDocumentRef
 SwiftEditorDocumentFileMap::findByPath(StringRef FilePath, bool IsRealpath) {
-  SwiftEditorDocumentRef EditorDoc;
-
   std::string Scratch;
   if (!IsRealpath) {
     Scratch = SwiftLangSupport::resolvePathSymlinks(FilePath);
     FilePath = Scratch;
   }
-  Queue.dispatchSync([&]{
-    for (auto &Entry : Docs) {
-      if (Entry.getKey() == FilePath ||
-          Entry.getValue().ResolvedPath == FilePath) {
-        EditorDoc = Entry.getValue().DocRef;
-        break;
-      }
-    }
-  });
 
-  return EditorDoc;
+  std::lock_guard<std::mutex> lock(DocsMtx);
+  for (auto &Entry : Docs) {
+    if (Entry.getKey() == FilePath ||
+        Entry.getValue().ResolvedPath == FilePath) {
+      return Entry.getValue().DocRef;
+    }
+  }
+  return nullptr;
 }
 
 bool SwiftEditorDocumentFileMap::getOrUpdate(
     StringRef FilePath, SwiftLangSupport &LangSupport,
     SwiftEditorDocumentRef &EditorDoc) {
 
-  bool found = false;
-
   std::string ResolvedPath = SwiftLangSupport::resolvePathSymlinks(FilePath);
-  Queue.dispatchBarrierSync([&]{
-    DocInfo &Doc = Docs[FilePath];
-    if (!Doc.DocRef) {
-      Doc.DocRef = EditorDoc;
-      Doc.ResolvedPath = ResolvedPath;
-    } else {
-      EditorDoc = Doc.DocRef;
-      found = true;
-    }
-  });
 
-  return found;
+  std::lock_guard<std::mutex> lock(DocsMtx);
+  DocInfo &Doc = Docs[FilePath];
+  if (!Doc.DocRef) {
+    Doc.DocRef = EditorDoc;
+    Doc.ResolvedPath = ResolvedPath;
+    return false;
+  }
+  EditorDoc = Doc.DocRef;
+  return true;
 }
 
 SwiftEditorDocumentRef SwiftEditorDocumentFileMap::remove(StringRef FilePath) {
-  SwiftEditorDocumentRef Removed;
-  Queue.dispatchBarrierSync([&]{
-    auto I = Docs.find(FilePath);
-    if (I != Docs.end()) {
-      Removed = I->second.DocRef;
-      Docs.erase(I);
-    }
-  });
+  std::lock_guard<std::mutex> lock(DocsMtx);
+  auto I = Docs.find(FilePath);
+  if (I == Docs.end())
+    return nullptr;
+
+  auto Removed = I->second.DocRef;
+  Docs.erase(I);
   return Removed;
 }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -136,8 +136,7 @@ public:
 typedef IntrusiveRefCntPtr<SwiftEditorDocument> SwiftEditorDocumentRef;
 
 class SwiftEditorDocumentFileMap {
-  WorkQueue Queue{ WorkQueue::Dequeuing::Concurrent,
-                   "sourcekit.swift.EditorDocFileMap" };
+  std::mutex DocsMtx;
   struct DocInfo {
     SwiftEditorDocumentRef DocRef;
     std::string ResolvedPath;

--- a/tools/SourceKit/tools/sourcekitd/bin/XPC/Service/XPCService.cpp
+++ b/tools/SourceKit/tools/sourcekitd/bin/XPC/Service/XPCService.cpp
@@ -64,7 +64,7 @@ namespace {
 class SKUIDToUIDMap {
   typedef llvm::DenseMap<void *, UIdent> MapTy;
   MapTy Map;
-  WorkQueue Queue{ WorkQueue::Dequeuing::Concurrent, "UIDMap" };
+  std::mutex MapMtx;
 
 public:
   UIdent get(sourcekitd_uid_t SKDUID);
@@ -440,18 +440,11 @@ int main(int argc, const char *argv[]) {
 }
 
 UIdent SKUIDToUIDMap::get(sourcekitd_uid_t SKDUID) {
-  UIdent UID;
-  Queue.dispatchSync([&]{
-    MapTy::iterator It = Map.find(SKDUID);
-    if (It != Map.end())
-      UID = It->second;
-  });
-
-  return UID;
+  std::lock_guard<std::mutex> lock(MapMtx);
+  return Map.lookup(SKDUID);
 }
 
 void SKUIDToUIDMap::set(sourcekitd_uid_t SKDUID, UIdent UID) {
-  Queue.dispatchBarrier([=]{
-    this->Map[SKDUID] = UID;
-  });
+  std::lock_guard<std::mutex> lock(MapMtx);
+  Map[SKDUID] = UID;
 }


### PR DESCRIPTION
These are unnecessary given how short the critical sections are, and in the case of `dispatchBarrierSync`, can result in a deadlock due to an apparent libdispatch bug (rdar://181437785). Replace them mutexes instead.

rdar://174790920