### PR TITLE
[docs] Document -sil-print-pass-name and sibling pass-tracing flags

### DIFF
--- a/docs/DebuggingTheCompiler.md
+++ b/docs/DebuggingTheCompiler.md
@@ -280,6 +280,18 @@ A short (non-exhaustive) list of SIL printing options:
   modifies a function and print the entire module if a module pass modifies
   the SILModule.
 
+* `-Xllvm -sil-print-pass-name`: Print the name (and index and function) of
+  each pass as it runs, without dumping any SIL. Also reports passes that were
+  skipped or disabled. Useful for seeing the sequence of passes the pass
+  manager runs.
+
+* `-Xllvm -sil-print-pass-time`: Print the wall-clock time each pass takes.
+  Filter out short passes with `-Xllvm -sil-print-pass-time-threshold=$MS`,
+  which suppresses any pass that runs for fewer than `$MS` milliseconds.
+
+* `-Xllvm -sil-print-pass-md5`: Print an MD5 of the module after each pass that
+  invalidated analyses. Useful for spotting which pass changed the SIL.
+
 * `-Xllvm -sil-print-around=$PASS_NAME`: Print the SIL before and after a pass
   with name `$PASS_NAME` runs on a function or module.
   By default it prints the whole module. To print only specific functions, add


### PR DESCRIPTION
Add DebuggingTheCompiler.md entries for the SILPassManager flags that report pass execution without dumping SIL:

  - -sil-print-pass-name: name/index/function of each pass as it runs (plus skipped/disabled passes)
  - -sil-print-pass-time: wall-clock time per pass, with the -sil-print-pass-time-threshold filter
  - -sil-print-pass-md5: MD5 of the module after each invalidating pass

These sit alongside the existing -sil-print-all family but answer the distinct question of which pass ran when, rather than what the SIL is.
