### PR TITLE
canImport: for a mixed-source module whose Swift side has no module version but the Clang side does, add a note about using _underlyingVersion.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1334,6 +1334,10 @@ GROUPED_WARNING(cannot_find_module_version,ModuleVersionMissing,none,
         "cannot find user version number for%select{| Clang}1 module '%0';"
         " version number ignored", (StringRef, bool))
 
+NOTE(cannot_find_module_version_use_underlying,none,
+     "the underlying Clang module '%0' has version %1; use "
+     "'_underlyingVersion' to check it", (StringRef, llvm::VersionTuple))
+
 GROUPED_WARNING(canimport_missing_module,CanImportMissingModule,none,
         "cannot find module '%0' for canImport check; the directive will"
         " evaluate to false", (StringRef))

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2812,8 +2812,9 @@ bool ASTContext::canImportModuleImpl(
       !(isSourceCanImport && !version.empty()))
     return false;
 
-  auto missingVersion = [this, &loc, &ModuleName, &isUnderlyingVersion,
-                         isSourceCanImport]() -> bool {
+  auto missingVersion =
+      [this, &loc, &ModuleName, &isUnderlyingVersion, isSourceCanImport](
+          const llvm::VersionTuple &underlyingClangVersion) -> bool {
     // The module version could not be parsed from the preferred source for
     // this query. Diagnose (only for source-level `#if canImport` queries) and
     // return `true` to indicate that the unversioned module will satisfy the
@@ -2823,8 +2824,18 @@ bool ASTContext::canImportModuleImpl(
       auto diagLoc = mID.Loc;
       if (mID.Loc.isInvalid())
         diagLoc = loc;
-      Diags.diagnose(diagLoc, diag::cannot_find_module_version, mID.Item.str(),
-                     isUnderlyingVersion);
+      Diags.diagnoseWithNotes(
+          Diags.diagnose(diagLoc, diag::cannot_find_module_version,
+                         mID.Item.str(), isUnderlyingVersion),
+          [&]() {
+            // A `_version` query has no user version to compare against, but
+            // the underlying Clang module does carry one. Attach a note that
+            // points the user at `_underlyingVersion`, which can check it.
+            if (!isUnderlyingVersion && !underlyingClangVersion.empty())
+              Diags.diagnose(diagLoc,
+                             diag::cannot_find_module_version_use_underlying,
+                             mID.Item.str(), underlyingClangVersion);
+          });
     }
     return true;
   };
@@ -2843,7 +2854,7 @@ bool ASTContext::canImportModuleImpl(
     if (!foundComparisonVersion.empty())
       return version <= foundComparisonVersion;
     else
-      return missingVersion();
+      return missingVersion(Found->second.UnderlyingVersion);
   }
 
   // When looking up a module, each module importer will report back
@@ -2948,7 +2959,7 @@ bool ASTContext::canImportModuleImpl(
   const auto &queryVersion =
       isUnderlyingVersion ? underlyingVersionInfo : versionInfo;
   if (queryVersion.getVersion().empty())
-    return missingVersion();
+    return missingVersion(underlyingVersionInfo.getVersion());
 
   return version <= queryVersion.getVersion();
 }

--- a/test/ClangImporter/can_import_version_unversioned_overlay_suggests_underlying.swift
+++ b/test/ClangImporter/can_import_version_unversioned_overlay_suggests_underlying.swift
@@ -1,0 +1,38 @@
+// REQUIRES: VENDOR=apple
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/frameworks)
+// RUN: %empty-directory(%t/overlaydir)
+
+// RUN: cp -rf %S/Inputs/frameworks/Simple.framework %t/frameworks/
+
+// Creates a framework with a Clang module and a .tbd as well as a Swift
+// overlay. The .tbd has a version but the .swiftmodule was built without a
+// user module version. A `_version` query cannot find a user version and the
+// version is ignored, but because the underlying Clang module does carry a
+// version a note points at `_underlyingVersion`, which honors the `.tbd`
+// version.
+
+// RUN: sed -i -e "s/1830\.100/3/g" %t/frameworks/Simple.framework/Simple.tbd
+// RUN: echo "@_exported import Simple" > %t.overlay.swift
+// RUN: echo "public func additional() {}" >> %t.overlay.swift
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -disable-implicit-concurrency-module-import -module-name Simple -F %t/frameworks/ %t.overlay.swift -emit-module-path %t/overlaydir/Simple.swiftmodule
+// RUN: %target-typecheck-verify-swift -disable-implicit-concurrency-module-import -I %t/overlaydir/ -F %t/frameworks
+
+import Simple
+
+func canImportVersion() {
+#if canImport(Simple, _version: 3) // expected-warning {{cannot find user version number for module 'Simple'; version number ignored}} expected-note {{the underlying Clang module 'Simple' has version 3.0.0; use '_underlyingVersion' to check it}}
+  let a = 1  // expected-warning {{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}}
+#endif
+}
+
+func canImportUnderlyingVersion() {
+#if canImport(Simple, _underlyingVersion: 3)
+  let a = 1  // expected-warning {{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}}
+#endif
+
+#if canImport(Simple, _underlyingVersion: 4)
+  let b = 1
+#endif
+}


### PR DESCRIPTION
 rdar://178728677