### PR TITLE
Fix Exclusivity analysis to ignore end_cow_mutation_addr

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
@@ -225,14 +225,25 @@ private func createEndCOWMutationIfNeeded(lifetimeDep: LifetimeDependence, _ con
       return
   }
 
+  // If the mark dependence instruction takes an address base, create the end_cow_mutation_addr on that address
+  // projection rather than the parent address. This narrows address users to the relevant sub-object.
+  let depBase = {
+    if let markDepBase = lifetimeDep.markDepInst?.base {
+      if markDepBase.type.isAddress {
+        return markDepBase
+      }
+    }
+    return lifetimeDep.parentValue
+  }()
+  assert(depBase.type.isAddress)
   guard lifetimeDep.dependentValue.type.mayHaveMutableSpan(in: lifetimeDep.function, context) &&
-    lifetimeDep.parentValue.type.mayHaveOptimizedCOWType(in: lifetimeDep.function) else {
+    depBase.type.mayHaveOptimizedCOWType(in: lifetimeDep.function) else {
     return
   }
 
   for endInstruction in scoped.endInstructions {
     let builder = Builder(before: endInstruction, context)
-    builder.createEndCOWMutationAddr(address: lifetimeDep.parentValue)
+    builder.createEndCOWMutationAddr(address: depBase)
   }
 }
 

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
@@ -225,8 +225,8 @@ private func createEndCOWMutationIfNeeded(lifetimeDep: LifetimeDependence, _ con
       return
   }
 
-  guard lifetimeDep.dependentValue.type.mayHaveMutableSpan(in: lifetimeDep.dependentValue.parentFunction, context) &&
-    lifetimeDep.parentValue.type.mayHaveOptimizedCOWType(in: lifetimeDep.dependentValue.parentFunction) else {
+  guard lifetimeDep.dependentValue.type.mayHaveMutableSpan(in: lifetimeDep.function, context) &&
+    lifetimeDep.parentValue.type.mayHaveOptimizedCOWType(in: lifetimeDep.function) else {
     return
   }
 

--- a/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
@@ -549,6 +549,11 @@ getSingleAddressProjectionUser(SingleValueInstruction *I) {
       SingleUser = inst;
       break;
     }
+    case SILInstructionKind::EndCOWMutationAddrInst: {
+      // Ignore an end_cow_mutation_addr for the purpose finding projection
+      // uses. It only uses the address, it does not produce a new address.
+      continue;
+    }
     default:
       return std::make_pair(nullptr, 0);
     }

--- a/test/SILOptimizer/exclusivity_static_diagnostics.sil
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.sil
@@ -1,4 +1,9 @@
-// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -enforce-exclusivity=unchecked -diagnose-static-exclusivity -verify | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -enforce-exclusivity=unchecked \
+// RUN: -diagnose-static-exclusivity -verify \
+// RUN: -enable-experimental-feature Lifetimes \
+// RUN: | %FileCheck %s
+
+// REQUIRES: swift_feature_Lifetimes
 
 sil_stage raw
 
@@ -1622,4 +1627,32 @@ bb0(%0 : $*Int):
   destroy_value %3 : $@callee_guaranteed () -> ()
   %10 = tuple ()
   return %10 : $()
+}
+
+// -----------------------------------------------------------------------------
+// rdar://181348593 (Exclusivity sub-object analysis is defeated by end_cow_mutation_addr)
+//
+// Check that the inserted end_cow_mutation_addr uses the access to the sub-object ('foo'),
+// not the access to the enclosing aggregate ('self'), so that the sub-object access does not
+// artificially overlap with an access to an unrelated sub-object ('bar').
+
+struct Agg {
+  @_hasStorage var foo: Int { get set }
+  @_hasStorage var bar: Int { get set }
+}
+
+sil hidden [ossa] @run : $@convention(method) (@inout Agg) -> () {
+bb0(%0 : $*Agg):
+  %5 = begin_access [modify] [unknown] %0 : $*Agg
+  %6 = struct_element_addr %5 : $*Agg, #Agg.foo
+
+  %12 = begin_access [read] [unknown] %0 : $*Agg
+  %13 = struct_element_addr %12, #Agg.bar
+  end_access %12
+
+  end_cow_mutation_addr %5
+  end_access %5
+
+  %37 = tuple ()
+  return %37
 }

--- a/test/SILOptimizer/lifetime_dependence/dependence_insertion.sil
+++ b/test/SILOptimizer/lifetime_dependence/dependence_insertion.sil
@@ -204,3 +204,63 @@ bb0(%0 : $*Holder):
   %13 = tuple ()
   return %13
 }
+
+// rdar://181348593 (Exclusivity sub-object analysis is defeated by end_cow_mutation_addr)
+//
+// Test that mark_dependence is inserted immediately after the apply whose result depends on an
+// @_addressableForDependencies field, and that the dependence base is the struct_element_addr into that
+// field -- not the enclosing begin_access. Using the enclosing access as the dependence base would extend
+// its scope over the unrelated access to 'Agg.bar' below, causing a spurious exclusivity conflict.
+
+@_addressableForDependencies
+struct Foo {
+  var i: Int
+}
+
+struct Bar {
+  var i: Int
+  func method()
+}
+
+struct Agg {
+  @_hasStorage var foo: Foo { get set }
+  @_hasStorage var bar: Bar { get set }
+}
+
+sil @getDep : $@convention(thin) (@inout Foo) -> @lifetime(borrow address_for_deps 0) @owned NE
+sil @$s3BarV6methodyyF : $@convention(method) (@in_guaranteed Bar) -> ()
+
+// CHECK-LABEL: sil hidden [ossa] @run : $@convention(thin) (@inout Agg) -> () {
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] %0
+// CHECK: [[FOO:%.*]] = struct_element_addr [[ACCESS]], #Agg.foo
+// CHECK: [[NE:%.*]] = apply %{{.*}}([[FOO]]) : $@convention(thin) (@inout Foo) -> @lifetime(borrow address_for_deps 0) @owned NE
+// CHECK: mark_dependence [unresolved] [[NE]] on [[FOO]]
+// CHECK: end_access [[ACCESS]]
+// CHECK-LABEL: } // end sil function 'run'
+sil hidden [ossa] @run : $@convention(thin) (@inout Agg) -> () {
+bb0(%0 : $*Agg):
+  %2 = alloc_box ${ var NE }, var, name "span"
+  %3 = begin_borrow [lexical] [var_decl] %2
+  %4 = project_box %3, 0
+  %5 = begin_access [modify] [unknown] %0
+  %6 = struct_element_addr %5, #Agg.foo
+  %7 = function_ref @getDep : $@convention(thin) (@inout Foo) -> @lifetime(borrow address_for_deps 0) @owned NE
+  %8 = apply %7(%6) : $@convention(thin) (@inout Foo) -> @lifetime(borrow address_for_deps 0) @owned NE
+  store %8 to [init] %4
+  end_access %5
+
+  %11 = begin_access [read] [unknown] %0
+  %12 = struct_element_addr %11, #Agg.bar
+  %13 = alloc_stack $Bar
+  copy_addr %12 to [init] %13
+  end_access %11
+  %16 = function_ref @$s3BarV6methodyyF : $@convention(method) (@in_guaranteed Bar) -> ()
+  %17 = apply %16(%13) : $@convention(method) (@in_guaranteed Bar) -> ()
+  destroy_addr %13
+  dealloc_stack %13
+
+  end_borrow %3
+  destroy_value %2
+  %36 = tuple ()
+  return %36
+}

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_scope_fixup.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_scope_fixup.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend %s -Xllvm -sil-print-types -Xllvm -sil-disable-pass=onone-simplification -emit-sil \
 // RUN: -enable-experimental-feature Lifetimes \
+// RUN: -disable-availability-checking \
 // RUN: | %FileCheck %s
 
 // REQUIRES: swift_feature_Lifetimes
@@ -335,4 +336,25 @@ func testWrite(_ w: inout ArrayWrapper) {
 func testSpanOfBorrowByAddress(_ i: Int) -> Int {
     let span = String(i).utf8.span
     return span.count
+}
+
+// =======================================================================================
+// rdar://181348593 (Exclusivity sub-object analysis is defeated by end_cow_mutation_addr)
+// Create the end_cow_mutation_addr on the sub-object, not the aggregate.
+
+struct AddressOnlyWrapper<T> {
+  var t: T
+
+  func method() {}
+}
+
+struct Agg<T> {
+  var foo: [2 of Int]
+  var bar: AddressOnlyWrapper<T> // instead of `let`
+
+  mutating func testMutableSpanOnSubobject() {
+    var foo = foo.mutableSpan
+    self.bar.method() // no exclusivity conflict: 'foo' and 'bar' are separate sub-objects.
+    foo[0] = 0
+  }
 }

--- a/test/SILOptimizer/lifetime_dependence/scope_fixup.sil
+++ b/test/SILOptimizer/lifetime_dependence/scope_fixup.sil
@@ -1023,3 +1023,90 @@ bb5:
   end_borrow %1
   unreachable
 }
+
+// rdar://181348593 (Exclusivity sub-object analysis is defeated by end_cow_mutation_addr)
+//
+// Check that the inserted end_cow_mutation_addr uses the access to the sub-object ('foo'),
+// not the access to the enclosing aggregate ('self'), so that the sub-object access does not
+// artificially overlap with an access to an unrelated sub-object ('bar').
+
+struct Bar<T> {
+  @_hasStorage var t: T { get set }
+  func method()
+  init(t: T)
+}
+
+struct Agg<T> {
+  @_hasStorage var foo: [2 of Int] { get set }
+  @_hasStorage var bar: [2 of Bar<T>] { get set }
+}
+
+sil @get_mutable_span_int : $@convention(thin) (@inout InlineArray<2, Int>) -> @lifetime(borrow address_for_deps 0) @owned MutableSpan<Int>
+sil @get_mutable_span_bar : $@convention(thin) <τ_0_0> (@inout InlineArray<2, Bar<τ_0_0>>) -> @lifetime(borrow address_for_deps 0) @owned MutableSpan<Bar<τ_0_0>>
+sil @bar_method : $@convention(method) <τ_0_0> (@in_guaranteed Bar<τ_0_0>) -> ()
+sil @use_span_int : $@convention(thin) (@inout MutableSpan<Int>) -> ()
+sil @use_span_bar : $@convention(thin) <τ_0_0> (@inout MutableSpan<Bar<τ_0_0>>) -> ()
+
+// CHECK-LABEL: sil hidden [ossa] @test_no_end_cow : $@convention(method) <T> (@inout Agg<T>) -> () {
+// CHECK: bb0([[SELF:%.*]] :
+// CHECK:   [[FOO_ACCESS:%.*]] = begin_access [modify] [unknown] [[SELF]]
+// CHECK:   [[FOO:%.*]] = struct_element_addr [[FOO_ACCESS]], #Agg.foo
+// CHECK:   apply %{{.*}}([[FOO]]) : $@convention(thin) (@inout InlineArray<2, Int>) -> @lifetime(borrow address_for_deps 0) @owned MutableSpan<Int>
+// CHECK-NOT: end_cow_mutation_addr
+// CHECK:   end_access [[FOO_ACCESS]]
+// CHECK-LABEL: } // end sil function 'test_no_end_cow'
+sil hidden [ossa] @test_no_end_cow : $@convention(method) <T> (@inout Agg<T>) -> () {
+bb0(%0 : $*Agg<T>):
+  %2 = alloc_box ${ var MutableSpan<Int> }, var, name "foo"
+  %3 = begin_borrow [lexical] [var_decl] %2
+  %4 = project_box %3, 0
+  %5 = begin_access [modify] [unknown] %0 : $*Agg<T>
+  %6 = struct_element_addr %5 : $*Agg<T>, #Agg.foo
+  %7 = function_ref @get_mutable_span_int : $@convention(thin) (@inout InlineArray<2, Int>) -> @lifetime(borrow address_for_deps 0) @owned MutableSpan<Int>
+  %8 = apply %7(%6) : $@convention(thin) (@inout InlineArray<2, Int>) -> @lifetime(borrow address_for_deps 0) @owned MutableSpan<Int>
+  %9 = mark_dependence [unresolved] %8 on %6
+  store %9 to [init] %4
+  end_access %5
+
+  %28 = begin_access [modify] [unknown] %4 : $*MutableSpan<Int>
+  %30 = function_ref @use_span_int : $@convention(thin) (@inout MutableSpan<Int>) -> ()
+  %31 = apply %30(%28) : $@convention(thin) (@inout MutableSpan<Int>) -> ()
+  end_access %28
+
+  end_borrow %3
+  destroy_value %2
+  %37 = tuple ()
+  return %37
+}
+
+// CHECK-LABEL: sil hidden [ossa] @test_end_cow_subobject : $@convention(method) <T> (@inout Agg<T>) -> () {
+// CHECK: bb0([[SELF:%.*]] :
+// CHECK:   [[BAR_ACCESS:%.*]] = begin_access [modify] [unknown] [[SELF]]
+// CHECK:   [[BAR:%.*]] = struct_element_addr [[BAR_ACCESS]], #Agg.bar
+// CHECK:   apply %{{.*}}([[BAR]]) : $@convention(thin) <τ_0_0> (@inout InlineArray<2, Bar<τ_0_0>>) -> @lifetime(borrow address_for_deps 0) @owned MutableSpan<Bar<τ_0_0>>
+// CHECK:   end_cow_mutation_addr [[BAR]]
+// CHECK:   end_access [[BAR_ACCESS]]
+// CHECK-LABEL: } // end sil function 'test_end_cow_subobject'
+sil hidden [ossa] @test_end_cow_subobject : $@convention(method) <T> (@inout Agg<T>) -> () {
+bb0(%0 : $*Agg<T>):
+  %2 = alloc_box $<τ_0_0> { var MutableSpan<Bar<τ_0_0>> } <T>, var, name "foo"
+  %3 = begin_borrow [lexical] [var_decl] %2
+  %4 = project_box %3, 0
+  %5 = begin_access [modify] [unknown] %0 : $*Agg<T>
+  %6 = struct_element_addr %5 : $*Agg<T>, #Agg.bar
+  %7 = function_ref @get_mutable_span_bar : $@convention(thin) <T> (@inout InlineArray<2, Bar<T>>) -> @lifetime(borrow address_for_deps 0) @owned MutableSpan<Bar<T>>
+  %8 = apply %7<T>(%6) : $@convention(thin) <τ_0_0> (@inout InlineArray<2, Bar<τ_0_0>>) -> @lifetime(borrow address_for_deps 0) @owned MutableSpan<Bar<τ_0_0>>
+  %9 = mark_dependence [unresolved] %8 on %6
+  store %9 to [init] %4
+  end_access %5
+
+  %28 = begin_access [modify] [unknown] %4 : $*MutableSpan<Bar<T>>
+  %30 = function_ref @use_span_bar : $@convention(thin) <τ_0_0> (@inout MutableSpan<Bar<τ_0_0>>) -> ()
+  %31 = apply %30<T>(%28) : $@convention(thin) <τ_0_0> (@inout MutableSpan<Bar<τ_0_0>>) -> ()
+  end_access %28
+
+  end_borrow %3
+  destroy_value %2
+  %37 = tuple ()
+  return %37
+}


### PR DESCRIPTION
Fixes rdar://181348593 (Exclusivity sub-object analysis is defeated by end_cow_mutation_addr)

- **[NFC] LifetimeDependenceUtils; minor cleanup for clarity**


- **Fix Exclusivity analysis to ignore end_cow_mutation_addr.**
  AccessSummary looks at uses of the begin_access to see if only a single
  sub-object is access. Ignore an end_cow_mutation_addr on the accessed address,
  because it has no effect on exclusivity. We now attempt to insert
  end_cow_mutation_addr on the address projection but AccessSummaryAnalysis should
  still be able to handle it.
  

- **Test for access enforcement: ignore end_cow_mutation_addr.**
  

- **Fix LifetimeDependenceScopeFixup: insert end_cow_mutation on field**
  Insert end_cow_mutation_addr on the projection address rather than the parent
  address. This keep the address users narrow to the relevant subobject. It also
  avoids introducing unnecessary end_cow_mutation_addr instructions when the field
  that the mutable span depends on does not have potential CoW storage.
  

- **Test LifetimeDependenceInsertion: dependence on a sub-object.**
  The mark_dependence should be on the sub-object, not the parent object, to avoid
  exclusivity violations.
  

- **Test LifetimeDependenceScopeFixup: sub-object exclusivity.**
  Scope extension will cause an exclusivity violation here unless
  
  (a) it inserts the end_cow_mutation_addr on the sub-object rather than the
  parent object.
  
  or (b) access enforcement ignores the end_cow_mutation_addr.
  
  Both fixes are correct.
  

- **Test LifetimeDependenceScopeFixup: end_cow_mutation_addr insertion.**
  Scope extension should insert the end_cow_mutation_addr on the sub-object rather
  than the parent object.
  