### PR TITLE
Sema: warn about Objective-C-callable stub initializers in @objc @implementation

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2137,6 +2137,11 @@ NOTE(objc_implementation_init_turn_required_to_convenience, none,
      "initializer",
      ())
 
+WARNING(objc_implementation_missing_inherited_init,none,
+        "'@objc @implementation' extension does not implement %kind0 inherited "
+        "from its superclass; invoking it from Objective-C will trap at runtime",
+        (const ValueDecl *))
+
 // Fallback diagnostic; super-general by nature.
 ERROR(objc_implementation_member_requires_vtable, none,
       "%kind0 is not valid in an '@objc @implementation' extension because it "

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1318,7 +1318,20 @@ static void addImplicitInheritedConstructorsToClass(ClassDecl *decl) {
 
     if (auto ctor = createDesignatedInitOverride(
                       decl, superclassCtor, kind, ctx)) {
-      decl->getImplementationContext()->addMember(ctor);
+      auto *implCtx = decl->getImplementationContext();
+
+      // In an '@objc @implementation' class a stub initializer is still
+      // reachable from Objective-C (e.g. '[Class new]') and traps at runtime if
+      // it's invoked, so warn the author to implement it. (Non-required
+      // designated inits; required ones are handled by
+      // diagnoseMissingRequiredInitializer above.)
+      if (kind == DesignatedInitKind::Stub &&
+          implCtx->getDecl()->isObjCImplementation())
+        ctx.Diags.diagnose(implCtx->getDecl(),
+                           diag::objc_implementation_missing_inherited_init,
+                           superclassCtor);
+
+      implCtx->addMember(ctor);
     }
   }
 }

--- a/test/decl/ext/Inputs/objc_implementation_inherited_init.h
+++ b/test/decl/ext/Inputs/objc_implementation_inherited_init.h
@@ -1,0 +1,13 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ImplsMissingInit : NSObject
+- (instancetype)initWithValue:(int)value;
+@end
+
+@interface ImplsHasInit : NSObject
+- (instancetype)initWithValue:(int)value;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/test/decl/ext/objc_implementation.swift
+++ b/test/decl/ext/objc_implementation.swift
@@ -17,6 +17,7 @@ protocol EmptySwiftProto {}
   // expected-note@-9 {{missing instance method 'extensionMethod(fromHeader2:)'}} {{none}}
   // expected-note@-10 {{missing property 'readonlyPropertyFromHeader7'}}
   // expected-note@-11 {{add stubs for missing '@implementation' requirements}} {{77-77=\n    @objc(methodFromHeader3:)\n    open func method(fromHeader3 param: Int32) {\n        <#code#>\n    \}\n\n    @objc(methodFromHeader4:)\n    open func method(fromHeader4 param: Int32) {\n        <#code#>\n    \}\n\n    @objc(propertyFromHeader7)\n    open var propertyFromHeader7: Int32\n\n    @objc(propertyFromHeader8)\n    open var propertyFromHeader8: Int32\n\n    @objc(propertyFromHeader9)\n    open var propertyFromHeader9: Int32\n\n    @objc(readonlyPropertyFromHeader7)\n    open let readonlyPropertyFromHeader7: Int32\n\n    @objc(extensionMethodFromHeader2:)\n    open func extensionMethod(fromHeader2 param: Int32) {\n        <#code#>\n    \}\n}}
+  // expected-warning@-12 {{'@objc @implementation' extension does not implement initializer 'init(fromSuperclass2:)' inherited from its superclass; invoking it from Objective-C will trap at runtime}}
 
   func method(fromHeader1: CInt) {
     // OK, provides an implementation for the header's method.

--- a/test/decl/ext/objc_implementation_early_adopter.swift
+++ b/test/decl/ext/objc_implementation_early_adopter.swift
@@ -17,6 +17,7 @@ protocol EmptySwiftProto {}
   // expected-note@-9 {{missing instance method 'extensionMethod(fromHeader2:)'}} {{none}}
   // expected-note@-10 {{missing property 'readonlyPropertyFromHeader7'}}
   // expected-note@-11 {{add stubs for missing '@implementation' requirements}} {{76-76=\n    @objc(methodFromHeader3:)\n    open func method(fromHeader3 param: Int32) {\n        <#code#>\n    \}\n\n    @objc(methodFromHeader4:)\n    open func method(fromHeader4 param: Int32) {\n        <#code#>\n    \}\n\n    @objc(propertyFromHeader7)\n    open var propertyFromHeader7: Int32\n\n    @objc(propertyFromHeader8)\n    open var propertyFromHeader8: Int32\n\n    @objc(propertyFromHeader9)\n    open var propertyFromHeader9: Int32\n\n    @objc(readonlyPropertyFromHeader7)\n    open let readonlyPropertyFromHeader7: Int32\n\n    @objc(extensionMethodFromHeader2:)\n    open func extensionMethod(fromHeader2 param: Int32) {\n        <#code#>\n    \}\n}}
+  // expected-warning@-12 {{'@objc @implementation' extension does not implement initializer 'init(fromSuperclass2:)' inherited from its superclass; invoking it from Objective-C will trap at runtime}}
 
   func method(fromHeader1: CInt) {
     // OK, provides an implementation for the header's method.

--- a/test/decl/ext/objc_implementation_inherited_init.swift
+++ b/test/decl/ext/objc_implementation_inherited_init.swift
@@ -1,0 +1,24 @@
+// RUN: %target-swift-frontend -emit-silgen -verify -import-objc-header %S/Inputs/objc_implementation_inherited_init.h -enable-experimental-feature ObjCImplementation -target %target-stable-abi-triple -Xcc -Wno-nullability-completeness %s
+// REQUIRES: objc_interop
+// REQUIRES: swift_feature_ObjCImplementation
+
+// Declaring a designated initializer suppresses inheritance of NSObject's
+// 'init()', which the compiler turns into a trapping stub. Objective-C callers
+// can still invoke it (e.g. '[ImplsMissingInit new]'), so it must be implemented.
+@objc @implementation extension ImplsMissingInit {
+  // expected-warning@-1 {{'@objc @implementation' extension does not implement initializer 'init()' inherited from its superclass; invoking it from Objective-C will trap at runtime}}
+  init(value: Int32) {
+    super.init()
+  }
+}
+
+// Overriding 'init()' satisfies the requirement: no diagnostic.
+@objc @implementation extension ImplsHasInit {
+  init(value: Int32) {
+    super.init()
+  }
+
+  override init() {
+    super.init()
+  }
+}


### PR DESCRIPTION
Unlike @objc on regular classes, we don't have an opportunity to mark these synthesized trapping inits as unavailable via a generated header. Instead, we should diagnose them from the Swift implementation side.

rdar://178174203
