### PR TITLE
[SwiftMergeFunctions] Don't rewrite call sites with a mismatched type

### DIFF
--- a/lib/LLVMPasses/LLVMMergeFunctions.cpp
+++ b/lib/LLVMPasses/LLVMMergeFunctions.cpp
@@ -1312,6 +1312,20 @@ bool SwiftMergeFunctions::replaceDirectCallers(Function *Old, Function *New,
       AllReplaced = false;
       continue;
     }
+    // The new arguments are appended at the positions defined by the callee's
+    // signature (see the argument-forwarding loops below). This assumes the
+    // call site was emitted with the same signature as the callee definition.
+    // That is not guaranteed: a `@_silgen_name` declaration whose C prototype
+    // omits part of the Swift ABI (e.g. the indirect error result of a large
+    // typed `throws`) produces a call whose function type has fewer parameters
+    // than the definition. Appending the constant to such a call places it in
+    // the wrong argument position, producing a call whose register assignment
+    // disagrees with the merged callee. Fall back to a thunk in that case; the
+    // thunk forwards the definition's own arguments and is therefore correct.
+    if (CI->getFunctionType() != Old->getFunctionType()) {
+      AllReplaced = false;
+      continue;
+    }
     Callers.push_back(CI);
   }
   if (!AllReplaced)

--- a/test/LLVMPasses/merge_func_callsite_type_mismatch.ll
+++ b/test/LLVMPasses/merge_func_callsite_type_mismatch.ll
@@ -1,0 +1,65 @@
+; RUN: %swift-llvm-opt -passes='swift-merge-functions' -swiftmergefunc-threshold=4 %s | %FileCheck %s
+;
+; A call site can legitimately be emitted with a different (shorter) function
+; type than the callee definition. This happens with `@_silgen_name`
+; declarations whose C prototype omits part of the Swift ABI -- e.g. the
+; indirect error result of a function that has a large typed `throws`. Such a
+; call is well-formed: the extra result buffer is only accessed on the throw
+; path, so the caller need not materialize it.
+;
+; SwiftMergeFunctions appends the differing constant as a new parameter at the
+; position defined by the callee. If it rewrote such a mismatched call site, the
+; constant would land in the wrong argument slot -- the merged callee reads it
+; from a different register than the caller passes it in, which crashes at
+; runtime. Verify the pass keeps a thunk with the definition's signature instead
+; of rewriting the mismatched call.
+
+declare void @worker_a(ptr, i64)
+declare void @worker_b(ptr, i64)
+
+; The callers invoke the definitions through a two-parameter type, omitting the
+; trailing %err parameter. They are structurally distinct so they are not
+; merged with each other, which keeps the mismatched *direct* call in place.
+
+; CHECK-LABEL: define i64 @caller_a(
+; CHECK: call i64 @impl_a(ptr %x, i64 %y)
+; CHECK-NOT: Tm(
+define i64 @caller_a(ptr %x, i64 %y) {
+  %r = call i64 @impl_a(ptr %x, i64 %y)
+  ret i64 %r
+}
+
+; CHECK-LABEL: define i64 @caller_b(
+; CHECK: call i64 @impl_b(ptr %x, i64 %y)
+; CHECK-NOT: Tm(
+define i64 @caller_b(ptr %x, i64 %y) {
+  %r = call i64 @impl_b(ptr %x, i64 %y)
+  %s = mul i64 %r, %r
+  ret i64 %s
+}
+
+; The definitions take a trailing %err parameter that models an indirect error
+; result. They differ only by which worker they call, so they are merged. Each
+; original is kept as a thunk that forwards all three of its own parameters plus
+; the worker constant, in the correct position.
+
+; CHECK-LABEL: define internal i64 @impl_a(ptr %p, i64 %imm, ptr %err)
+; CHECK: tail call i64 @impl_aTm(ptr %p, i64 %imm, ptr %err, ptr @worker_a)
+define internal i64 @impl_a(ptr %p, i64 %imm, ptr %err) {
+  %v = load i64, ptr %p, align 8
+  call void @worker_a(ptr %err, i64 %v)
+  %n = add i64 %v, %imm
+  ret i64 %n
+}
+
+; CHECK-LABEL: define internal i64 @impl_b(ptr %p, i64 %imm, ptr %err)
+; CHECK: tail call i64 @impl_aTm(ptr %p, i64 %imm, ptr %err, ptr @worker_b)
+define internal i64 @impl_b(ptr %p, i64 %imm, ptr %err) {
+  %v = load i64, ptr %p, align 8
+  call void @worker_b(ptr %err, i64 %v)
+  %n = add i64 %v, %imm
+  ret i64 %n
+}
+
+; CHECK-LABEL: define internal i64 @impl_aTm(ptr %0, i64 %1, ptr %2, ptr %3)
+; CHECK: call void %3(ptr %2, i64 %v)


### PR DESCRIPTION
SwiftMergeFunctions appends the differing constant as a new parameter at the position defined by the callee, and replaceDirectCallers rebuilds each direct call by forwarding the call site's own arguments and then appending the constant. This assumes the call site's function type matches the callee definition.

That does not hold for a @_silgen_name declaration whose C prototype omits part of the Swift ABI -- for example the indirect error result of a function with a large typed throws. The call site then has fewer parameters than the definition, so the appended constant lands in the wrong argument slot and the merged callee reads it from a different register than the caller passes it in, crashing at runtime.

Skip such call sites so a thunk is emitted instead. The thunk forwards the definition's own arguments and appends the constant in the correct position.