### PR TITLE
MandatoryDestroyHoisting: don't run for de-serialized functions

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/MandatoryDestroyHoisting.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/MandatoryDestroyHoisting.swift
@@ -37,6 +37,13 @@ import SIL
 let mandatoryDestroyHoisting = FunctionPass(name: "mandatory-destroy-hoisting") {
   (function: Function, context: FunctionPassContext) in
 
+  // Swift modules are serialized after the mandatory pipeline. At this point lifetimes
+  // (lexical or not) are fixed. When de-serializing a function in the mandatory pipeline, it means
+  // that for such functions lifetimes are fixed and MandatoryDestroyHoisting must not run.
+  if function.linkage.isExternal {
+    return
+  }
+
   var endAccesses = Stack<EndAccessInst>(context)
   defer { endAccesses.deinitialize() }
   endAccesses.append(contentsOf: function.instructions.compactMap{ $0 as? EndAccessInst })

--- a/test/SILOptimizer/mandatory-destroy-hoisting.sil
+++ b/test/SILOptimizer/mandatory-destroy-hoisting.sil
@@ -556,3 +556,19 @@ bb3:
   %11 = tuple ()
   return %11
 }
+
+// CHECK-LABEL: sil public_external [ossa] @dont_optimize_deserialized_functions :
+// CHECK:         fix_lifetime
+// CHECK-NEXT:    debug_step
+// CHECK-NEXT:    destroy_value %0
+// CHECK-NEXT:    tuple
+// CHECK:       } // end sil function 'dont_optimize_deserialized_functions'
+sil public_external [ossa] @dont_optimize_deserialized_functions : $@convention(thin) (@owned String) -> () {
+bb0(%0 : @owned $String):
+  fix_lifetime %0
+  debug_step
+  destroy_value %0
+  %r = tuple ()
+  return %r
+}
+


### PR DESCRIPTION
Swift modules are serialized after the mandatory pipeline. At this point lifetimes (lexical or not) are fixed. When de-serializing a function in the mandatory pipeline, it means that for such functions lifetimes are fixed and MandatoryDestroyHoisting must not run.
