### PR TITLE
[cxx-interop] Match the embedded Clang's no-builtin flag

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1577,6 +1577,13 @@ void IRGenModule::constructInitialFnAttributes(
     Attrs.addAttribute("stack-protector-buffer-size", llvm::utostr(8));
   }
 
+  // When the Clang configuration disables builtins Clang stamps
+  // its functions with the "no-builtins" attribute. Mirror that on
+  // the Swift side (otherwise the mismatch prevents function inlining.)
+  if (getClangASTContext().getLangOpts().NoBuiltin) {
+    Attrs.addAttribute("no-builtins");
+  }
+
   // Mark as 'nounwind' to avoid referencing exception personality symbols, this
   // is okay even with C++ interop on because the landinpads are trapping.
   if (Context.LangOpts.hasFeature(Feature::Embedded)) {

--- a/test/IRGen/clang_no_builtin_attr.swift
+++ b/test/IRGen/clang_no_builtin_attr.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -module-name test -emit-ir %s -Xcc -fno-builtin | %FileCheck %s
+// RUN: %target-swift-frontend -module-name test -emit-ir %s | %FileCheck %s --check-prefix=NEGATIVE
+
+// CHECK: define {{.*}}swiftcc void @"$s4test3fooyyF"() [[ATTRS:#[0-9]+]]
+public func foo() {}
+
+// CHECK: [[ATTRS]] = {{{.*}}"no-builtins"
+
+// Without -fno-builtin, the attribute must not be added.
+// NEGATIVE-NOT: "no-builtins"


### PR DESCRIPTION
Some targets imply `-fno-builtin` on the Clang side but they did not in the Swift side. As a result, function inlining between the two were disabled due the the attribute mismatch. This patch makes sure that Swift and Clang agrees on whether this attribute needs to be emitted to make sure inlinig works across language boundaries.

rdar://180652621
