### PR TITLE
[6.4] [CS] Avoid attempting unwrap member constraint for subscript dynamic member

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11679,7 +11679,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
       return success();
     };
 
-    if (baseObjTy->getOptionalObjectType()) {
+    if (auto unwrapTy = baseObjTy->getOptionalObjectType()) {
       // If the base type was an optional, look through it.
 
       // If the base type is optional because we haven't chosen to force an
@@ -11696,8 +11696,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
       // Let's check whether the problem is related to optionality of base
       // type, or there is no member with a given name.
       result =
-          performMemberLookup(kind, member, baseObjTy->getOptionalObjectType(),
-                              functionRefInfo, locator,
+          performMemberLookup(kind, member, unwrapTy, functionRefInfo, locator,
                               /*includeInaccessibleMembers*/ true);
 
       if (result.OverallResult == MemberLookupResult::Unsolved)
@@ -11707,6 +11706,21 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
       // let's fallback to a "not such member" fix.
       if (result.ViableCandidates.empty() && result.UnviableCandidates.empty())
         return fixMissingMember(origBaseTy, memberTy, locator);
+
+      // If we have a subscript dynamic member we can't attempt the member
+      // constraint since the applicable function won't be on the correct
+      // type var. Just unconditionally record the fix since we know we at
+      // least have a candidate.
+      if (locator->isSubscriptMemberRef() &&
+          unwrapTy->getMetatypeInstanceType()
+              ->hasDynamicMemberLookupAttribute()) {
+        if (recordFix(UnwrapOptionalBase::create(*this, member, baseObjTy,
+                                                 locator))) {
+          return SolutionKind::Error;
+        }
+        recordTypeVariablesAsHoles(memberTy);
+        return SolutionKind::Solved;
+      }
 
       bool baseIsKeyPathRootType = [&]() {
         auto keyPathComponent =
@@ -11741,9 +11755,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
       addDisjunctionConstraint(optionalities, locator);
 
       // Look through one level of optional.
-      addValueMemberConstraint(baseObjTy->getOptionalObjectType(), member,
-                               innerTV, useDC, functionRefInfo,
-                               outerAlternatives, locator);
+      addValueMemberConstraint(unwrapTy, member, innerTV, useDC,
+                               functionRefInfo, outerAlternatives, locator);
       return SolutionKind::Solved;
     }
 

--- a/test/Constraints/keypath_dynamic_member_lookup.swift
+++ b/test/Constraints/keypath_dynamic_member_lookup.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend -Xllvm -sil-print-types -emit-sil -verify -Xllvm -sil-disable-pass=simplification %s | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -DDIAGS
+// RUN: %target-swift-frontend -Xllvm -sil-print-types -emit-sil -Xllvm -sil-disable-pass=simplification %s | %FileCheck %s
 
 struct Point {
   let x: Int
@@ -651,6 +652,46 @@ struct SingleLens<T> {
 
 func testRecursiveSingleSubscript(_ x: SingleLens<SingleLens<SingleLens<SingleLens<[Int]>>>>) {
   _ = x[0]
+}
+
+@dynamicMemberLookup
+struct MetaLens<T> {
+  static subscript<U>(dynamicMember keyPath: KeyPath<T, U>) -> U { fatalError() }
+}
+
+func testOptionalBase(_ x: Lens<[Int]>?, _ y: Lens<Int>?, _ z: Int?, _ m: MetaLens<[Int]>.Type?, _ i: Lens<[Int]>!) {
+#if DIAGS
+  // Make sure we tell the user to unwrap the optional since we know Lens has a
+  // subscript.
+  _ = x[0]
+  // expected-error@-1 {{value of optional type 'Lens<[Int]>?' must be unwrapped to refer to member 'subscript' of wrapped base type 'Lens<[Int]>'}}
+  // expected-note@-2 {{chain the optional using '?' to access member 'subscript' only for non-'nil' base values}}
+  // expected-note@-3 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+
+  // The dynamic member won't match here, but the unwrap fix is still better than
+  // "no subscripts".
+  _ = y[0]
+  // expected-error@-1 {{value of optional type 'Lens<Int>?' must be unwrapped to refer to member 'subscript' of wrapped base type 'Lens<Int>'}}
+  // expected-note@-2 {{chain the optional using '?' to access member 'subscript' only for non-'nil' base values}}
+  // expected-note@-3 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+
+  _ = m[0]
+  // expected-error@-1 {{value of optional type 'MetaLens<[Int]>.Type?' must be unwrapped to refer to member 'subscript' of wrapped base type 'MetaLens<[Int]>.Type'}}
+  // expected-note@-2 {{chain the optional using '?' to access member 'subscript' only for non-'nil' base values}}
+  // expected-note@-3 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+
+  // No candidates at all.
+  _ = z[0] // expected-error {{value of type 'Int?' has no subscripts}}
+#endif
+
+  _ = x?[0]
+  _ = x![0]
+  _ = m?[0]
+  _ = m![0]
+
+  _ = i[0]
+  _ = i?[0]
+  _ = i![0]
 }
 
 // Make sure that coerceCallArguments doesn't crash when arity of the subscript doesn't match

--- a/validation-test/compiler_crashers_fixed/ConstraintSystem-bindOverloadType-788743.swift
+++ b/validation-test/compiler_crashers_fixed/ConstraintSystem-bindOverloadType-788743.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"swift::constraints::ConstraintSystem::bindOverloadType(swift::constraints::SelectedOverload const&, swift::Type, swift::constraints::ConstraintLocator*, swift::DeclContext*)","signatureAssert":"Assertion failed: (constraints.size() == 1), function bindOverloadType","signatureNext":"ConstraintSystem::resolveOverload"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 @dynamicMemberLookup struct a<b > {
   subscript <c>(dynamicMember d: WritableKeyPath<b, c>) -> a
   let binding = {


### PR DESCRIPTION
*6.4 cherry-pick of #90388*

- Explanation: Fixes a compiler crash that could occur when attempting to use a dynamic member subscript on an optional value that needs to be unwrapped
- Scope: Affects diagnostics for invalid subscript dynamic member use on optional value
- Issue: rdar://88777888
- Risk: Low, only affects invalid code and is fairly straightforward, adds an extra condition that causes us to skip attempting a new member constraint
- Testing: Added tests to test suite
- Reviewer: Pavel Yaskevich