### PR TITLE
[Concurrency] Reimplement Async{Throwing}Stream's unfolding storage

### DIFF
--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -353,18 +353,16 @@ public struct AsyncStream<Element> {
     unfolding produce: @escaping @Sendable () async -> Element?,
     onCancel: (@Sendable () -> Void)? = nil
   ) {
-    let storage: _AsyncStreamCriticalStorage<Optional<() async -> Element?>>
-      = .create(produce)
-    context = _Context {
+    let unfoldingStorage = _AsyncStreamUnfoldingStorage(
+      produce: produce,
+      onCancel: onCancel
+    )
+
+    self.context = _Context {
       return await withTaskCancellationHandler {
-        guard let result = await storage.value?() else {
-          storage.value = nil
-          return nil
-        }
-        return result
+        return await unfoldingStorage.next()
       } onCancel: {
-        storage.value = nil
-        onCancel?()
+        unfoldingStorage.terminate()
       }
     }
   }

--- a/stdlib/public/Concurrency/AsyncStreamBuffer.swift
+++ b/stdlib/public/Concurrency/AsyncStreamBuffer.swift
@@ -114,7 +114,7 @@ fileprivate struct Disconnected<Value: ~Copyable>: ~Copyable, @unchecked Sendabl
 /// The state machine is single-consumer–based. However, instead of crashing on concurrent iteration,
 /// the consumer that “loses” the race to `next()` is enqueued in a **FIFO queue** and **eventually resumed**.
 ///
-/// Furthermore, when the stream reaches its terminal state and an onTermination closure is set,
+/// Furthermore, when the stream reaches its terminal state and an `onTermination` closure is set,
 /// the closure is invoked **exactly once, after which it is cleared**.
 ///
 /// Once the stream has reached its terminal state, all subsequent consumers will **immediately return nil**,
@@ -633,56 +633,124 @@ extension _AsyncStreamStorage {
   }
 }
 
-final class _AsyncStreamCriticalStorage<Contents>: @unchecked Sendable {
-  var _value: Contents
-  private init(_doNotCallMe: ()) {
-    fatalError("_AsyncStreamCriticalStorage must be initialized by create")
-  }
+/// The state machine backing the unfolding variant of `Async{Throwing}Stream`.
+///
+/// States:
+///
+///   - `producing`: The stream is active and invokes the `produce` closure to produce the next element on consumer demand.
+///   - `terminated`: The stream is in a terminal state and **immediately returns `nil`** on consumer demand.
+///
+/// Transitions:
+///
+/// ```text
+/// Current State   Possible Next State
+/// -------------   -------------------
+/// producing     ->  terminated
+/// terminated    ->  terminated
+/// ```
+///
+/// Behavior:
+/// The state machine is single-consumer–based and invokes the `produce` closure in response to demand.
+/// However, on concurrent iteration, `produce` is invoked concurrently.
+///
+/// The stream reaches its terminal state either when **`produce` returns nil** or
+/// when the **task of an active consumer is cancelled**.
+///
+/// Furthermore, when the stream reaches its terminal state **due to task cancellation** and an `onCancel` closure was set,
+/// the closure is invoked **exactly once, after which it is cleared**.
+@safe
+final class _AsyncStreamUnfoldingStorage<Element, Failure: Error>: @unchecked Sendable {
+  typealias Produce = @Sendable () async throws(Failure) -> Element? // TODO: This needs to have `nonisolated(nonsending)` in order to execute on the caller's actor
+  typealias OnCancel = (@Sendable () -> Void)?
 
-  private func lock() {
-    let ptr =
-      unsafe UnsafeRawPointer(Builtin.projectTailElems(self, UnsafeRawPointer.self))
-    unsafe _lock(ptr)
-  }
-
-  private func unlock() {
-    let ptr =
-      unsafe UnsafeRawPointer(Builtin.projectTailElems(self, UnsafeRawPointer.self))
-    unsafe _unlock(ptr)
-  }
-
-  var value: Contents {
-    get {
-      lock()
-      let contents = _value
-      unlock()
-      return contents
-    }
-
-    set {
-      lock()
-      withExtendedLifetime(_value) {
-        _value = newValue
-        unlock()
-      }
-    }
-  }
-
-  static func create(_ initial: Contents) -> _AsyncStreamCriticalStorage {
-    let minimumCapacity = _lockWordCount()
-    let storage = unsafe Builtin.allocWithTailElems_1(
-      _AsyncStreamCriticalStorage.self,
-      minimumCapacity._builtinWordValue,
-      UnsafeRawPointer.self
+  enum State {
+    case producing(
+      produce: Produce,
+      onCancel: OnCancel
     )
 
-    let state =
-      unsafe UnsafeMutablePointer<Contents>(Builtin.addressof(&storage._value))
-    unsafe state.initialize(to: initial)
-    let ptr = unsafe UnsafeRawPointer(
-      Builtin.projectTailElems(storage, UnsafeRawPointer.self))
-    unsafe _lockInit(ptr)
-    return storage
+    case terminated
+  }
+
+  private let lock: UnsafeMutableRawPointer
+  private var state: State
+
+  init(
+    produce: @escaping Produce,
+    onCancel: OnCancel
+  ) {
+    unsafe self.lock = unsafe UnsafeMutableRawPointer.allocate(
+      byteCount: _lockWordCount() * MemoryLayout<UnsafeRawPointer>.stride,
+      alignment: MemoryLayout<UnsafeRawPointer>.alignment
+    )
+    unsafe _lockInit(self.lock)
+
+    self.state = .producing(
+      produce: produce,
+      onCancel: onCancel
+    )
+  }
+
+  deinit {
+    unsafe self.lock.deallocate()
+  }
+}
+
+extension _AsyncStreamUnfoldingStorage {
+  nonisolated(nonsending) func next() async throws(Failure) -> Element? {
+    let state = withLock { state in
+      return state
+    }
+
+    guard
+      case .producing(let produce, _) = state
+    else { return nil }
+
+    do {
+      switch try await produce() {
+      case .some(let element):
+        return element
+
+      case .none:
+        withLock { state in
+          state = .terminated
+        }
+        return nil
+      }
+    } catch {
+      withLock { state in
+        state = .terminated
+      }
+      throw error
+    }
+  }
+
+  func terminate() {
+    let onCancel = withLock { state in
+      switch state {
+      case .producing(_, let onCancel):
+        state = .terminated
+        return onCancel
+
+      case .terminated:
+        return nil
+      }
+    }
+
+    onCancel?()
+  }
+}
+
+extension _AsyncStreamUnfoldingStorage {
+  @safe
+  private func withLock<Value>(
+    _ body: (inout State) -> Value
+  ) -> Value {
+    unsafe _lock(self.lock)
+
+    defer { unsafe _unlock(self.lock) }
+
+    return body(&self.state)
   }
 }
 #endif

--- a/stdlib/public/Concurrency/AsyncThrowingStream.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingStream.swift
@@ -389,17 +389,16 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
   public init(
     unfolding produce: @escaping @Sendable () async throws -> Element?
   ) where Failure == Error {
-    let storage: _AsyncStreamCriticalStorage<Optional<() async throws -> Element?>>
-      = .create(produce)
-    context = _Context {
+    let unfoldingStorage = _AsyncStreamUnfoldingStorage(
+      produce: produce,
+      onCancel: nil
+    )
+
+    self.context = _Context {
       return try await withTaskCancellationHandler {
-        guard let result = try await storage.value?() else {
-          storage.value = nil
-          return nil
-        }
-        return result
+        return try await unfoldingStorage.next()
       } onCancel: {
-        storage.value = nil
+        unfoldingStorage.terminate()
       }
     }
   }

--- a/test/Concurrency/Runtime/async_stream.swift
+++ b/test/Concurrency/Runtime/async_stream.swift
@@ -1062,6 +1062,33 @@ class NotSendable {}
         await task.value
       }
 
+      tests.test("unfolding init onCancel called once") {
+        nonisolated(unsafe) var counter = 0
+
+        let stream = AsyncStream<Int>(
+          unfolding: { @MainActor in
+            return nil
+          },
+          onCancel: { @Sendable in
+            counter += 1
+          }
+        )
+
+        var iterator = stream.makeAsyncIterator()
+
+        let task = Task { @MainActor in
+          withUnsafeCurrentTask { $0?.cancel() }
+
+          _ = await iterator.next(isolation: #isolation)
+          _ = await iterator.next(isolation: #isolation)
+
+          // Should equal one. onCancel is called once and then cleared
+          expectEqual(counter, 1)
+        }
+
+        await task.value
+      }
+
       tests.test("unfolding init throwing throws from closure") {
         var counter = 0
         let thrownError = SomeError()

--- a/test/Concurrency/Runtime/async_stream.swift
+++ b/test/Concurrency/Runtime/async_stream.swift
@@ -1095,7 +1095,7 @@ class NotSendable {}
         let stream = AsyncThrowingStream<Int, Error>(unfolding: { @MainActor in
           counter += 1
           if counter == 3 { throw thrownError }
-          return counter < 3 ? counter : nil
+          return counter
         })
         var iterator = stream.makeAsyncIterator()
         do {


### PR DESCRIPTION
Replace `_AsyncStreamCriticalStorage`, used in the unfolding-based `Async{Throwing}Stream` variant, with a dedicated, lightweight state machine.

This new implementation changes the following behavior:
* `onCancel`, if set, is now guaranteed to be called at most once.
* If the `unfolding` closure throws an error, the stream terminates.

Resolves: https://github.com/swiftlang/swift/issues/83137.