### PR TITLE
[Test] Use -target %target-swift-5.1-abi-triple on three concurrency tests.

### DIFF
--- a/test/Concurrency/default_mainactor_isolation_cross_module.swift
+++ b/test/Concurrency/default_mainactor_isolation_cross_module.swift
@@ -14,14 +14,14 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t/Lib.swiftinterface) -module-name Lib
 
 // Build the client using module
-// RUN: %target-swift-frontend -typecheck -verify -language-mode 6 -load-plugin-library %t/%target-library-name(MacroDefinition) -default-isolation MainActor -module-name Client -I %t %t/src/Client.swift
-// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unrelated -language-mode 6 -load-plugin-library %t/%target-library-name(MacroDefinition) -default-isolation MainActor -module-name ClientWithMacro -I %t %t/src/ClientWithMacro.swift
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -typecheck -verify -language-mode 6 -load-plugin-library %t/%target-library-name(MacroDefinition) -default-isolation MainActor -module-name Client -I %t %t/src/Client.swift
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -typecheck -verify -verify-ignore-unrelated -language-mode 6 -load-plugin-library %t/%target-library-name(MacroDefinition) -default-isolation MainActor -module-name ClientWithMacro -I %t %t/src/ClientWithMacro.swift
 
 // RUN: rm %t/Lib.swiftmodule
 
 // Re-build the client using interface
-// RUN: %target-swift-frontend -typecheck -verify -language-mode 6 -load-plugin-library %t/%target-library-name(MacroDefinition) -default-isolation MainActor -module-name Client -I %t %t/src/Client.swift
-// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unrelated -language-mode 6 -load-plugin-library %t/%target-library-name(MacroDefinition) -default-isolation MainActor -module-name ClientWithMacro -I %t %t/src/ClientWithMacro.swift
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -typecheck -verify -language-mode 6 -load-plugin-library %t/%target-library-name(MacroDefinition) -default-isolation MainActor -module-name Client -I %t %t/src/Client.swift
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -typecheck -verify -verify-ignore-unrelated -language-mode 6 -load-plugin-library %t/%target-library-name(MacroDefinition) -default-isolation MainActor -module-name ClientWithMacro -I %t %t/src/ClientWithMacro.swift
 
 // REQUIRES: swift_swift_parser, executable_test, concurrency
 

--- a/test/Interpreter/objc_sending_execution.swift
+++ b/test/Interpreter/objc_sending_execution.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 //
 // RUN: %target-clang -fobjc-arc %S/Inputs/objc_sending_execution.m -c -o %t/objc_sending_execution.o
-// RUN: %target-build-swift -import-objc-header %S/Inputs/objc_sending_execution.h -Xlinker %t/objc_sending_execution.o %s -o %t/a.out
+// RUN: %target-build-swift -target %target-swift-5.1-abi-triple -import-objc-header %S/Inputs/objc_sending_execution.h -Xlinker %t/objc_sending_execution.o %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out
 
@@ -12,7 +12,7 @@
 // RUN: %empty-directory(%t)
 //
 // RUN: %target-clang -O3 -fobjc-arc %S/Inputs/objc_sending_execution.m -c -o %t/objc_sending_execution.o
-// RUN: %target-build-swift -O -import-objc-header %S/Inputs/objc_sending_execution.h -Xlinker %t/objc_sending_execution.o %s -o %t/a.out
+// RUN: %target-build-swift -target %target-swift-5.1-abi-triple -O -import-objc-header %S/Inputs/objc_sending_execution.h -Xlinker %t/objc_sending_execution.o %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out
 

--- a/test/stdlib/Result+asyncInit.swift
+++ b/test/stdlib/Result+asyncInit.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift(-target %target-swift-5.1-abi-triple)
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 


### PR DESCRIPTION
These tests could fail if the default target was too old. Fixes:

test/Concurrency/default_mainactor_isolation_cross_module.swift
test/Interpreter/objc_sending_execution.swift
test/stdlib/Result+asyncInit.swift

rdar://181060053