### PR TITLE
[6.4.x] DebugInfo: test "different type but same scope" crash

### DIFF
--- a/test/embedded/multi-module-debug-scope-crash.swift
+++ b/test/embedded/multi-module-debug-scope-crash.swift
@@ -1,0 +1,31 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library -O
+// RUN: %target-swift-frontend -c -I %t %t/Main.swift -enable-experimental-feature Embedded -O -o /dev/null
+
+// REQUIRES: OS=macosx || OS=linux-gnu || OS=wasip1
+// REQUIRES: swift_feature_Embedded
+
+//--- MyModule.swift
+
+public struct ParseContainerStack {
+    var stack: [Int] = [0]
+    public init() {}
+    public mutating func run() {
+        let i = stack.first
+        if let i {
+            _ = i
+            for _ in 0..<stack.count { }
+        }
+    }
+}
+
+//--- Main.swift
+
+import MyModule
+
+public func test() {
+    var s = ParseContainerStack()
+    s.run()
+}


### PR DESCRIPTION
Cherry-pick of #89969, merged as 719fef5457a12689bdf3f7513b52d8c50e1029e5

**Explanation**: Add a regression test for a recently fixed compiler crash.
**Scope**: Test-only, `test/embedded/multi-module-debug-scope-crash.swift`.
**Risk**: None.
**Testing**: Covers the "two variables with different type but same scope" DebugInfo crash.
**Issue**: rdar://179727895, https://github.com/swiftlang/swift/issues/89962
**Reviewer**: @Snowy1803
