### PR TITLE
[6.4.x] Embedded: fix concurrency dynamic isolation linker errors

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -514,6 +514,7 @@ static bool swift_task_isCurrentExecutorWithFlagsImpl(
       return true;
     }
 
+#if !SWIFT_CONCURRENCY_EMBEDDED
     // We cannot use 'complexEquality' as it requires two executor instances,
     // and we do not have a 'current' executor here.
 
@@ -553,6 +554,7 @@ static bool swift_task_isCurrentExecutorWithFlagsImpl(
     }
 
     assert(!options.contains(swift_task_is_current_executor_flag::Assert));
+#endif // !SWIFT_CONCURRENCY_EMBEDDED
     return false;
   }
 
@@ -605,6 +607,7 @@ static bool swift_task_isCurrentExecutorWithFlagsImpl(
     }
   }
 
+#if !SWIFT_CONCURRENCY_EMBEDDED
   // Complex equality means that if two executors of the same type have some
   // special logic to check if they are "actually the same".
   //
@@ -701,6 +704,7 @@ static bool swift_task_isCurrentExecutorWithFlagsImpl(
   // In the end, since 'checkIsolated' could not be used, so we must assume
   // that the executors are not the same context.
   assert(!options.contains(swift_task_is_current_executor_flag::Assert));
+#endif // !SWIFT_CONCURRENCY_EMBEDDED
   return false;
 }
 
@@ -823,6 +827,7 @@ void swift::swift_task_reportUnexpectedExecutor(
       isFatalError ? "error" : "warning", functionIsolation,
       (int)fileLength, file, (int)line, whereExpected);
 
+#if !SWIFT_CONCURRENCY_EMBEDDED
   if (_swift_shouldReportFatalErrorsToDebugger()) {
     RuntimeErrorDetails details = {
         .version = RuntimeErrorDetails::currentVersion,
@@ -841,6 +846,7 @@ void swift::swift_task_reportUnexpectedExecutor(
         isFatalError ? RuntimeErrorFlagFatal : RuntimeErrorFlagNone, message,
         &details);
   }
+#endif
 
 #if defined(_WIN32) && !SWIFT_CONCURRENCY_EMBEDDED
 #define STDERR_FILENO 2

--- a/stdlib/public/Concurrency/ExecutorImpl.cpp
+++ b/stdlib/public/Concurrency/ExecutorImpl.cpp
@@ -80,9 +80,17 @@ swift_task_isIsolatingCurrentContextImpl(
 
 extern "C" SWIFT_CC(swift) bool swift_task_isMainExecutorImpl(
     SerialExecutorRef executor) {
+#if SWIFT_CONCURRENCY_EMBEDDED
+  // In the embedded cooperative executor model the main executor is the generic
+  // executor (mirrors CooperativeGlobalExecutor.cpp's swift_task_isMainExecutorImpl).
+  // Custom SerialExecutor witness tables and the _swift_task_isMainExecutorSwift
+  // bridge are unavailable in embedded mode.
+  return executor.isGeneric();
+#else
   HeapObject *identity = executor.getIdentity();
   return executor.hasSerialExecutorWitnessTable() &&
          _swift_task_isMainExecutorSwift(
              identity, swift_getObjectType(identity),
              executor.getSerialExecutorWitnessTable());
+#endif
 }

--- a/stdlib/public/Concurrency/TaskLocal.cpp
+++ b/stdlib/public/Concurrency/TaskLocal.cpp
@@ -337,6 +337,7 @@ static void swift_task_reportIllegalTaskLocalBindingWithinWithTaskGroupImpl(
       (int)fileLength, file,
       (int)line);
 
+#if !SWIFT_CONCURRENCY_EMBEDDED
   if (_swift_shouldReportFatalErrorsToDebugger()) {
     RuntimeErrorDetails details = {
         .version = RuntimeErrorDetails::currentVersion,
@@ -353,6 +354,7 @@ static void swift_task_reportIllegalTaskLocalBindingWithinWithTaskGroupImpl(
     };
     _swift_reportToDebugger(RuntimeErrorFlagFatal, message, &details);
   }
+#endif
 
 #if defined(_WIN32)
   #define STDERR_FILENO 2

--- a/test/embedded/concurrency-dynamic-isolation-link.swift
+++ b/test/embedded/concurrency-dynamic-isolation-link.swift
@@ -1,0 +1,51 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// Compile LibA as a module (not concurrency-checked — no -swift-version 6)
+// RUN: %target-swift-frontend -emit-module -o %t/LibA.swiftmodule %t/LibA.swift -enable-experimental-feature Embedded -parse-as-library
+
+// Swift 5: compile, link, and run (should succeed — no dynamic isolation check emitted)
+// RUN: %target-swift-frontend -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o %t/a5.o -parse-as-library -swift-version 5
+// RUN: %target-clang %t/a5.o -o %t/a5.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
+// RUN: %target-run %t/a5.out | %FileCheck %s
+
+// Swift 6: compile, link, and run should all succeed. Dynamic isolation checking
+// emits a reference to swift_task_reportUnexpectedExecutor, which pulls in Actor.cpp.o
+// from libswift_Concurrency.a. Actor.cpp.o must not reference full-runtime symbols
+// (like _swift_shouldReportFatalErrorsToDebugger) that are unavailable in embedded mode.
+// RUN: %target-swift-frontend -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o %t/a6.o -parse-as-library -swift-version 6
+// RUN: %target-clang %t/a6.o -o %t/a6.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
+// RUN: %target-run %t/a6.out | %FileCheck %s
+
+// swift_task_reportUnexpectedExecutor should be referenced in Swift 6 (dynamic
+// isolation checking) but not Swift 5. Linking succeeds because Actor.cpp.o
+// (which defines it) no longer pulls in full-runtime symbols in embedded mode.
+// RUN: %llvm-nm --undefined-only %t/a6.o | %FileCheck %s --check-prefix=SWIFT6
+// RUN: %llvm-nm --undefined-only %t/a5.o | %FileCheck %s --check-prefix=SWIFT5
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=wasip1
+// REQUIRES: swift_feature_Embedded
+
+// CHECK: OK
+
+// SWIFT6: swift_task_reportUnexpectedExecutor
+// SWIFT5-NOT: swift_task_reportUnexpectedExecutor
+
+//--- LibA.swift
+import _Concurrency
+public func takeClosure(_ f: @escaping () -> Void) { f() }
+
+//--- Main.swift
+import LibA
+import _Concurrency
+
+@main
+struct App {
+    static func main() async {
+        takeClosure { _ = 42 }
+        print("OK")
+    }
+}


### PR DESCRIPTION
Cherry-pick of #87877, merged as c76c306a762d8c399eb976710182597e8517d41f

**Explanation**: Excludes dynamic-isolation symbols unsupported under Embedded from the Concurrency runtime, fixing undefined-symbol linker errors.
**Scope**: Three `stdlib/public/Concurrency` sources. Additive, no deletions.
**Risk**: Low. Non-Embedded builds are unaffected.
**Testing**: New lit test `test/embedded/concurrency-dynamic-isolation-link.swift`.
**Issue**: rdar://172742911, https://github.com/swiftlang/swift/issues/87903
**Reviewer**: @ktoso
