### PR TITLE
CopyToBorrowOptimization: put `debug_value` in the correct place when converting `store` to `store_borrow`

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CopyToBorrowOptimization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CopyToBorrowOptimization.swift
@@ -247,6 +247,11 @@ private struct Uses {
         } else {
           Builder(before: destroy, context).createEndBorrow(of: storeBorrow)
         }
+      case let debugValue as DebugValueInst:
+        if debugValue.parentBlock != storeBorrow.parentBlock || !storeBorrow.strictlyDominatesInBlock(debugValue) {
+          debugValue.move(before: storeBorrow.next!, context)
+        }
+        fallthrough
       default:
         use.set(to: storeBorrow, context)
       }

--- a/test/SILOptimizer/copy-to-borrow-optimization.sil
+++ b/test/SILOptimizer/copy-to-borrow-optimization.sil
@@ -2376,6 +2376,7 @@ bb0(%0 : @guaranteed $Outer):
 // CHECK-LABEL: sil [ossa] @store_to_store_borrow :
 // CHECK:         %2 = alloc_stack $C
 // CHECK-NEXT:    %3 = store_borrow %0 to %2
+// CHECK-NEXT:    debug_value %3
 // CHECK-NEXT:    apply undef(%3)
 // CHECK-NEXT:    load [copy] %3
 // CHECK-NEXT:    copy_addr %3 to %1
@@ -2387,6 +2388,37 @@ sil [ossa] @store_to_store_borrow : $@convention(thin) (@guaranteed C, @inout C)
 bb0(%0 : @guaranteed $C, %1 : $*C):
   %2 = copy_value %0
   %3 = alloc_stack $C
+  debug_value %3, var, name "x"
+  store %2 to [init] %3
+  %4 = apply undef(%3) : $@convention(thin) (@in_guaranteed C) -> ()
+  %5 = load [copy] %3
+  copy_addr %3 to %1
+  debug_value %3
+  destroy_addr %3
+  dealloc_stack %3
+  return %5
+}
+
+// CHECK-LABEL: sil [ossa] @store_to_store_borrow_multi_bb :
+// CHECK:         %2 = alloc_stack $C
+// CHECK:       bb1:
+// CHECK-NEXT:    %4 = store_borrow %0 to %2
+// CHECK-NEXT:    debug_value %4
+// CHECK-NEXT:    apply undef(%4)
+// CHECK-NEXT:    load [copy] %4
+// CHECK-NEXT:    copy_addr %4 to %1
+// CHECK-NEXT:    debug_value %4
+// CHECK-NEXT:    end_borrow %4
+// CHECK-NEXT:    dealloc_stack %2
+// CHECK-LABEL: } // end sil function 'store_to_store_borrow_multi_bb'
+sil [ossa] @store_to_store_borrow_multi_bb : $@convention(thin) (@guaranteed C, @inout C) -> @owned C {
+bb0(%0 : @guaranteed $C, %1 : $*C):
+  %2 = copy_value %0
+  %3 = alloc_stack $C
+  debug_value %3, var, name "x"
+  br bb1
+
+bb1:
   store %2 to [init] %3
   %4 = apply undef(%3) : $@convention(thin) (@in_guaranteed C) -> ()
   %5 = load [copy] %3


### PR DESCRIPTION
Fixes a dominance violation in case a `debug_value` is located before the initial store `store` to a stack location.
