### PR TITLE
[test] Include visionOS in Float16 availability guard for xrsimulator

### DIFF
--- a/test/PrintAsObjC/unicode-scalar-reference.swift
+++ b/test/PrintAsObjC/unicode-scalar-reference.swift
@@ -19,7 +19,7 @@ func x_referencesRelated(a: CChar32, b: CWideChar) { }
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
     // Actual test of Float16, on supported platforms.
-    @available(watchOS 7.0, *)
+    @available(watchOS 7.0, visionOS 14.0, *)
     @_cdecl("referencesFloat16")
     func y_referencesFloat16(a: Float16, b: CFloat16) { }
 #else


### PR DESCRIPTION
This PR fixes this test failure:
```
FAIL: Swift(xrsimulator-arm64) :: PrintAsObjC/unicode-scalar-reference.swift

# | /Users/ec2-user/jenkins/workspace/oss-swift-package-macos-arm64/swift/test/PrintAsObjC/unicode-scalar-reference.swift:24:10: error: unexpected note produced: add '@available' attribute to enclosing global function
# |     func y_referencesFloat16(a: Float16, b: CFloat16) { }
# |          ^
# | /Users/ec2-user/jenkins/workspace/oss-swift-package-macos-arm64/swift/test/PrintAsObjC/unicode-scalar-reference.swift:24:10: error: unexpected note produced: add '@available' attribute to enclosing global function
# |     func y_referencesFloat16(a: Float16, b: CFloat16) { }
# |          ^
# | /Users/ec2-user/jenkins/workspace/oss-swift-package-macos-arm64/swift/test/PrintAsObjC/unicode-scalar-reference.swift:24:33: error: unexpected error produced: 'Float16' is only available in visionOS 14.0 or newer
# |     func y_referencesFloat16(a: Float16, b: CFloat16) { }
# |                                 ^
# | /Users/ec2-user/jenkins/workspace/oss-swift-package-macos-arm64/swift/test/PrintAsObjC/unicode-scalar-reference.swift:24:45: error: unexpected error produced: 'CFloat16' is only available in visionOS 14.0 or newer
# |     func y_referencesFloat16(a: Float16, b: CFloat16) { }
# |                                             ^
# `-----------------------------
```

The xrsimulator target's visionOS 1.0 floor plus the compiler's iOS→visionOS availability derivation reports `Float16`/`CFloat16` (iOS 14) as requiring visionOS 14.0. Extend the existing `@available(watchOS 7.0, *)` guard on `y_referencesFloat16` to include `visionOS 14.0` so the decl typechecks at the target and the CHECK against `compat.h` still passes on xrsim.

