### PR TITLE
[6.4.x] AST: Add the `VariableNeverMutated` warning group

### DIFF
--- a/include/swift/AST/DiagnosticGroups.def
+++ b/include/swift/AST/DiagnosticGroups.def
@@ -109,6 +109,7 @@ GROUP(NoUseUnstructuredThrowingTask,none,"no-use-throwing-unstructured-task")
 GROUP(UseAnyAppleOSAvailability,DefaultIgnoreWarnings,"use-any-apple-os-availability")
 GROUP(UselessAvailabilityCheck,none,"useless-availability-check")
 GROUP(UselessConditionalStatement,none,"useless-conditional-statement")
+GROUP(VariableNeverMutated,none,"variable-never-mutated")
 GROUP(WeakMutability,none,"weak-mutability")
 GROUP(OldSuppressedAssociatedTypes,none,"old-suppressed-associatedtypes")
 
@@ -122,6 +123,8 @@ GROUP_LINK(RegionIsolation,SendingRisksDataRace)
 GROUP_LINK(StrictLanguageFeatures, UnrecognizedStrictLanguageFeatures)
 
 GROUP_LINK(UnnecessaryEffectMarker,UnnecessaryUnsafe)
+
+GROUP_LINK(VariableNeverMutated,WeakMutability)
 
 #define UNDEFINE_DIAGNOSTIC_GROUPS_MACROS
 #include "swift/AST/DefineDiagnosticGroupsMacros.h"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7691,11 +7691,11 @@ GROUPED_WARNING(variable_never_used, NoUsage, NoUsage,
 GROUPED_WARNING(immutable_value_never_used_but_assigned, NoUsage, NoUsage,
         "immutable value %0 was never used; consider removing it",
         (Identifier))
-WARNING(variable_never_mutated, none,
+GROUPED_WARNING(variable_never_mutated, VariableNeverMutated, none,
         "variable %0 was never mutated; "
         "consider %select{removing 'var' to make it|changing to 'let'}1 constant",
         (Identifier, bool))
-WARNING(variable_tuple_elt_never_mutated, none,
+GROUPED_WARNING(variable_tuple_elt_never_mutated, VariableNeverMutated, none,
         "variable %0 was never mutated; "
         "consider changing the pattern to 'case (..., let %1, ...)'",
         (Identifier, StringRef))

--- a/test/SourceKit/Macros/diags.swift.response
+++ b/test/SourceKit/Macros/diags.swift.response
@@ -206,6 +206,9 @@
             }
           ]
         }
+      ],
+      key.educational_note_paths: [
+        "https://docs.swift.org/compiler/documentation/diagnostics/variable-never-mutated"
       ]
     },
     {

--- a/test/decl/var/usage.swift
+++ b/test/decl/var/usage.swift
@@ -6,7 +6,7 @@
 
 func basicTests() -> Int {
   let x = 42 // expected-warning {{immutable value 'x' was never used; consider replacing with assignment to '_' or removing it}} {{3-8=_}}
-  var y = 12 // expected-warning {{variable 'y' was never mutated; consider changing to 'let' constant}} {{3-6=let}}
+  var y = 12 // expected-warning {{variable 'y' was never mutated; consider changing to 'let' constant}} {{group-name=VariableNeverMutated}} {{3-6=let}}
   _ = 42 // ok
   _ = 42 // ok
   return y
@@ -566,7 +566,7 @@ func testUselessCastWithInvalidParam(foo: Any?) -> Int {
 
 // https://github.com/swiftlang/swift/issues/72811
 func testEnumeratedForLoop(a: [Int]) {
-  for var (b, c) in a.enumerated() {  // expected-warning {{variable 'b' was never mutated; consider changing the pattern to 'case (..., let b, ...)'}}
+  for var (b, c) in a.enumerated() {  // expected-warning {{variable 'b' was never mutated; consider changing the pattern to 'case (..., let b, ...)'}} {{group-name=VariableNeverMutated}}
     c = b
     let _ = c
   }

--- a/userdocs/diagnostics/diagnostic-groups.md
+++ b/userdocs/diagnostics/diagnostic-groups.md
@@ -66,6 +66,7 @@ Or upgrade all warnings except deprecated declaration to errors:
 - <doc:use-any-apple-os-availability>
 - <doc:useless-availability-check>
 - <doc:useless-conditional-statement>
+- <doc:variable-never-mutated>
 
 
 ## Topics
@@ -133,3 +134,4 @@ Or upgrade all warnings except deprecated declaration to errors:
 - <doc:useless-availability-check>
 - <doc:useless-conditional-statement>
 - <doc:existential-member-access-limitations>
+- <doc:variable-never-mutated>

--- a/userdocs/diagnostics/variable-never-mutated.md
+++ b/userdocs/diagnostics/variable-never-mutated.md
@@ -1,0 +1,38 @@
+# Variable never mutated (VariableNeverMutated)
+
+Warnings that identify local `var` bindings which are never mutated after
+initialization and could instead be declared with `let`.
+
+## Overview
+
+When a variable is introduced with `var` but never reassigned or otherwise
+mutated, it can be declared with `let` instead to explicitly indicate that the
+variable is constant.
+
+## Example
+
+```swift
+func swap(_ a: inout Int, _ b: inout Int) {
+  var temp = a // warning: variable 'temp' was never mutated; consider changing to 'let' constant
+  a = b
+  b = temp
+}
+```
+
+The fix is to change `var` to `let`:
+
+```swift
+func swap(_ a: inout Int, _ b: inout Int) {
+  let temp = a
+  a = b
+  b = temp
+}
+```
+
+## Sub-groups
+
+The `VariableNeverMutated` group contains the following sub-group, which can
+also be enabled or controlled independently:
+
+- <doc:weak-mutability>: Warns when a `weak var` binding is never mutated and
+  could be a `weak let` instead.


### PR DESCRIPTION
- **Explanation:** Adds a diagnostic group for `variable '...' was never mutated` diagnostics
- **Scope:** Affects code with variables that have unnecessary mutability.
- **Issue/Radar:** rdar://180637746
- **Original PR:** https://github.com/swiftlang/swift/pull/90435
- **Risk:** Very low. Adding a new diagnostic group to existing warnings should have no effect on existing code.
- **Testing:** Updated existing compiler tests to verify that `variable '...' was never mutated` diagnostics are associated with the expected group.
- **Reviewer:**