### PR TITLE
[CoroutineAccessors+Embedded] Make them work together

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2207,27 +2207,11 @@ void IRGenModule::emitVTableStubs() {
     const SILFunction &F = *I;
     if (! F.isExternallyUsedSymbol())
       continue;
-    
+
     if (!stub) {
-      // Create a single stub function which calls swift_deletedMethodError().
-      // Use linkonce_odr hidden to merge these symbols, except on
-      // COFF where the linker cannot merge them.
-      bool canLinkOnce = !Module.getTargetTriple().isOSBinFormatCOFF();
-      auto linkage = canLinkOnce ? llvm::GlobalValue::LinkOnceODRLinkage
-                                 : llvm::GlobalValue::InternalLinkage;
-      stub = llvm::Function::Create(llvm::FunctionType::get(VoidTy, false),
-                                    linkage, "_swift_dead_method_stub",
-                                    &Module);
-      ApplyIRLinkage(canLinkOnce ? IRLinkage::InternalLinkOnceODR
-                                 : IRLinkage::Internal)
-          .to(stub, /* nonAliasedDefinition */ false);
-      stub->setAttributes(constructInitialAttributes());
-      stub->setCallingConv(DefaultCC);
-      auto *entry = llvm::BasicBlock::Create(getLLVMContext(), "entry", stub);
-      auto *errorFunc = getDeletedMethodErrorFn();
-      llvm::CallInst::Create(getDeletedMethodErrorFnType(),
-                             errorFunc, ArrayRef<llvm::Value *>(), "", entry);
-      new llvm::UnreachableInst(getLLVMContext(), entry);
+      // Get (creating if necessary) a single stub function which calls
+      // swift_deletedMethodError().
+      stub = getOrCreateDeadMethodErrorStub();
     }
 
     // For each eliminated method symbol create an alias to the stub.
@@ -2242,11 +2226,11 @@ void IRGenModule::emitVTableStubs() {
       auto *fnPtr = emitAsyncFunctionPointer(*this, stub, entity, asyncLayout.getSize());
       alias = fnPtr;
     } else if (F.getLoweredFunctionType()->isCalleeAllocatedCoroutine()) {
-      // TODO: We cannot directly create a pointer to
-      // `swift_deletedCalleeAllocatedCoroutineMethodError` to workaround a
-      // linker crash. Instead use the stub, which calls
-      // swift_deletedMethodError. This works because swift_deletedMethodError
-      // takes no parameters and simply aborts the program.
+      // There is no dedicated dead-method error symbol for callee-allocated
+      // coroutines; point a coro function pointer (named for the eliminated
+      // function) at the shared stub, which calls swift_deletedMethodError.
+      // This works because swift_deletedMethodError takes no parameters and
+      // simply aborts the program.
       auto entity = LinkEntity::forSILFunction(const_cast<SILFunction *>(&F));
       auto *cfp = emitCoroFunctionPointer(*this, stub, entity);
       alias = cfp;

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -8202,6 +8202,27 @@ llvm::GlobalValue *irgen::emitCoroFunctionPointer(IRGenModule &IGM,
       IGM.defineCoroFunctionPointer(entity, builder.finishAndCreateFuture()));
 }
 
+// Same as above, but can be used for synthetic functions that
+// don't have a matching SIL function.
+llvm::Constant *irgen::emitLocalCoroFunctionPointer(IRGenModule &IGM,
+                                                    llvm::Function *function,
+                                                    llvm::StringRef name) {
+  ConstantInitBuilder initBuilder(IGM);
+  ConstantStructBuilder builder(
+      initBuilder.beginStruct(IGM.CoroFunctionPointerTy));
+  builder.addCompactFunctionReference(function);
+  builder.addInt32(0);
+  auto *typeId = IGM.getMallocTypeId(function);
+  ASSERT(typeId->getIntegerType() == IGM.Int64Ty);
+  builder.addInt64(typeId->getLimitedValue());
+  // Internal linkage: each module that needs it gets its own copy, so there is
+  // no external symbol to resolve.
+  auto *var = builder.finishAndCreateGlobal(name, IGM.getPointerAlignment(),
+                                            /*constant*/ true,
+                                            llvm::GlobalValue::InternalLinkage);
+  return var;
+}
+
 static FormalLinkage getExistentialShapeLinkage(CanGenericSignature genSig,
                                                 CanType shapeType) {
   auto typeLinkage = getTypeLinkage(shapeType);

--- a/lib/IRGen/GenMeta.h
+++ b/lib/IRGen/GenMeta.h
@@ -321,6 +321,14 @@ namespace irgen {
                                              LinkEntity entity,
                                              Size size = Size(0));
 
+  /// Emit a private (internal) coro function pointer, named \p name,
+  /// referencing \p function.  Unlike emitCoroFunctionPointer, this does not
+  /// require a LinkEntity that maps back to a SIL function, so it can be used
+  /// for synthesized stubs such as the dead-method error stub.
+  llvm::Constant *emitLocalCoroFunctionPointer(IRGenModule &IGM,
+                                               llvm::Function *function,
+                                               llvm::StringRef name);
+
   /// Determine whether the given opaque type requires a witness table for the
   /// given requirement.
   ///

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1206,10 +1206,51 @@ llvm::Constant *IRGenModule::getDeletedAsyncMethodErrorAsyncFunctionPointer() {
 
 llvm::Constant *IRGenModule::
     getDeletedCalleeAllocatedCoroutineMethodErrorCoroFunctionPointer() {
-  return getAddrOfLLVMVariableOrGOTEquivalent(
-             LinkEntity::forKnownCoroFunctionPointer(
-                 "swift_deletedCalleeAllocatedCoroutineMethodError"))
-      .getValue();
+  // A callee-allocated (yield_once_2) coroutine accessor method that is removed
+  // by dead-method elimination still needs its vtable/witness slot filled with
+  // a trapping coro function pointer.  Emit a local one targeting the shared
+  // dead-method stub (which calls swift_deletedMethodError), mirroring how
+  // emitVTableStubs() fills eliminated coroutine function symbols.
+  //
+  // This deliberately avoids a dedicated runtime symbol: such a symbol would
+  // have to be provided by libswiftCore, which does not exist in Embedded
+  // Swift, and a by-name reference to it there would be unresolved.  Emitting
+  // the stub locally works uniformly for all targets.
+  if (!DeletedCalleeAllocatedCoroutineMethodErrorCoroFP) {
+    auto *stub = getOrCreateDeadMethodErrorStub();
+    DeletedCalleeAllocatedCoroutineMethodErrorCoroFP =
+        emitLocalCoroFunctionPointer(*this, stub, "_swift_dead_method_coro_stub");
+  }
+  return DeletedCalleeAllocatedCoroutineMethodErrorCoroFP;
+}
+
+/// Get (creating if necessary) a single local stub function which calls
+/// swift_deletedMethodError().  Used to fill dead-method vtable/witness slots.
+llvm::Function *IRGenModule::getOrCreateDeadMethodErrorStub() {
+  if (DeadMethodErrorStub)
+    return DeadMethodErrorStub;
+
+  // Use linkonce_odr hidden to merge these symbols, except on COFF where the
+  // linker cannot merge them.
+  bool canLinkOnce = !Module.getTargetTriple().isOSBinFormatCOFF();
+  auto linkage = canLinkOnce ? llvm::GlobalValue::LinkOnceODRLinkage
+                             : llvm::GlobalValue::InternalLinkage;
+  auto *stub = llvm::Function::Create(llvm::FunctionType::get(VoidTy, false),
+                                      linkage, "_swift_dead_method_stub",
+                                      &Module);
+  ApplyIRLinkage(canLinkOnce ? IRLinkage::InternalLinkOnceODR
+                             : IRLinkage::Internal)
+      .to(stub, /* nonAliasedDefinition */ false);
+  stub->setAttributes(constructInitialAttributes());
+  stub->setCallingConv(DefaultCC);
+  auto *entry = llvm::BasicBlock::Create(getLLVMContext(), "entry", stub);
+  auto *errorFunc = getDeletedMethodErrorFn();
+  llvm::CallInst::Create(getDeletedMethodErrorFnType(), errorFunc,
+                         ArrayRef<llvm::Value *>(), "", entry);
+  new llvm::UnreachableInst(getLLVMContext(), entry);
+
+  DeadMethodErrorStub = stub;
+  return stub;
 }
 
 static bool isReturnAttribute(llvm::Attribute::AttrKind Attr);

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1633,6 +1633,15 @@ private:                                                                       \
 
   llvm::Constant *FixLifetimeFn = nullptr;
 
+  /// A local stub function that simply calls swift_deletedMethodError(),
+  /// used to fill dead-method vtable/witness slots (see emitVTableStubs()).
+  llvm::Function *DeadMethodErrorStub = nullptr;
+  llvm::Function *getOrCreateDeadMethodErrorStub();
+  /// A Coroutine Function Pointer wrapping the above, suited for
+  /// filling vtable/witness slots that point to "callee-allocated"
+  /// (new ABI) coroutines.
+  llvm::Constant *DeletedCalleeAllocatedCoroutineMethodErrorCoroFP = nullptr;
+
   mutable std::optional<SpareBitVector> HeapPointerSpareBits;
 
   //--- Generic ---------------------------------------------------------------

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -172,9 +172,13 @@ func _rethrowsViaClosure(_ fn: () throws -> ()) rethrows {
   try fn()
 }
 
+// July 2026:  The compiler no longer emits references to this
+// symbol (the compiler instead synthesizes an equivalent symbol that
+// also works with Embedded Swift).
+// It is retained purely to preserve compatibility with binaries that
+// used the experimental version of CoroutineAccessors.
 @available(SwiftStdlib 9999, *)
 @usableFromInline internal var swift_deletedCalleeAllocatedCoroutineMethodError: () {
-  // TODO: CoroutineAccessors: Change to read from _read.
   @_silgen_name("swift_deletedCalleeAllocatedCoroutineMethodError")
   _read {
     fatalError("Fatal error: Call of deleted method")

--- a/test/embedded/coroutine_accessor_deleted_method.swift
+++ b/test/embedded/coroutine_accessor_deleted_method.swift
@@ -1,0 +1,49 @@
+// When a callee-allocated (yield_once_2) coroutine accessor is removed by
+// dead-method elimination, its vtable slot is filled with a locally-emitted
+// stub coro function pointer (rather than a shared runtime symbol, which would
+// be unresolved in Embedded Swift).  Verify that the metadata references the
+// stub and that a full link+run works, both in Embedded Swift and outside it.
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature Embedded -enable-experimental-feature CoroutineAccessors -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature Embedded -enable-experimental-feature CoroutineAccessors -c -o %t/main.o
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/main.o %target-embedded-posix-shim -o %t/a.out -dead_strip
+// RUN: %target-run %t/a.out | %FileCheck %s --check-prefix=CHECK-OUT
+
+// Also works outside of Embedded, though dead-method elimination only runs here
+// under optimization (Embedded always runs it):
+// RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature CoroutineAccessors -O -wmo -emit-ir | %FileCheck %s
+// RUN: %target-build-swift %s -parse-as-library -enable-experimental-feature CoroutineAccessors -O -wmo -o %t/a.desktop.out
+// RUN: %target-run %t/a.desktop.out | %FileCheck %s --check-prefix=CHECK-OUT
+
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_CoroutineAccessors
+
+public class C {
+  var _storage: Int = 42
+
+  // Never accessed below, so its coroutine accessors are dead-eliminated and
+  // their vtable slots are filled with the dead-method coro stub.
+  var value: Int {
+    yielding borrow { yield _storage }
+    yielding mutate { yield &_storage }
+  }
+
+  func use() { print("storage=\(_storage)") }
+}
+
+@main
+struct Main {
+  static func main() {
+    let c = C()
+    c.use()
+  }
+}
+
+// The dead coroutine accessor slot references the locally emitted stub rather
+// than an undefined external runtime symbol.
+// CHECK: @_swift_dead_method_coro_stub
+
+// CHECK-OUT: storage=42

--- a/test/embedded/coroutine_accessor_deleted_method.swift
+++ b/test/embedded/coroutine_accessor_deleted_method.swift
@@ -11,10 +11,12 @@
 // RUN: %target-run %t/a.out | %FileCheck %s --check-prefix=CHECK-OUT
 
 // Also works outside of Embedded, though dead-method elimination only runs here
-// under optimization (Embedded always runs it):
+// under optimization (Embedded always runs it).  The full non-embedded link+run
+// is skipped on wasm, where the SDK lacks non-embedded static-executable link
+// args (the -emit-ir check below still exercises the stub there).
 // RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature CoroutineAccessors -O -wmo -emit-ir | %FileCheck %s
-// RUN: %target-build-swift %s -parse-as-library -enable-experimental-feature CoroutineAccessors -O -wmo -o %t/a.desktop.out
-// RUN: %target-run %t/a.desktop.out | %FileCheck %s --check-prefix=CHECK-OUT
+// RUN: %if !CPU=wasm32 %{ %target-build-swift %s -parse-as-library -enable-experimental-feature CoroutineAccessors -O -wmo -o %t/a.desktop.out %}
+// RUN: %if !CPU=wasm32 %{ %target-run %t/a.desktop.out | %FileCheck %s --check-prefix=CHECK-OUT %}
 
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib


### PR DESCRIPTION
When coroutine accessors are optimized away, the empty slots have to be filled with something.  The original CoroutineAccessors implementation used a symbol provided by the standard library, but this didn't work with Embedded Swift.  So let's have the compiler synthesize the equivalent function and insert calls to that instead.

We leave the old symbol in the stdlib to support early adopters who may have used the experimental CoroutineAccessors feature before this change was made.

Resolves: rdar://181528316