### PR TITLE
[RemoteInspection] Record artificial fields as having no extra inhabitants.

### DIFF
--- a/include/swift/RemoteInspection/DescriptorFinder.h
+++ b/include/swift/RemoteInspection/DescriptorFinder.h
@@ -63,11 +63,12 @@ struct FieldRecordBase {
   const bool IsIndirectCase;
   const bool IsVar;
   const bool HasMangledTypeName;
+  const bool IsArtificial;
 
-  FieldRecordBase(bool IsIndirectCase, bool IsVar,
-                       bool HasMangledTypeName)
+  FieldRecordBase(bool IsIndirectCase, bool IsVar, bool HasMangledTypeName,
+                  bool IsArtificial = false)
       : IsIndirectCase(IsIndirectCase), IsVar(IsVar),
-        HasMangledTypeName(HasMangledTypeName) {}
+        HasMangledTypeName(HasMangledTypeName), IsArtificial(IsArtificial) {}
 
   virtual ~FieldRecordBase(){};
 

--- a/include/swift/RemoteInspection/Records.h
+++ b/include/swift/RemoteInspection/Records.h
@@ -111,6 +111,8 @@ public:
   bool isVar() const {
     return Flags.isVar();
   }
+
+  bool isArtificial() const { return Flags.isArtificial(); }
 };
 using FieldRecord = TargetFieldRecord<InProcess>;
 

--- a/include/swift/RemoteInspection/TypeLowering.h
+++ b/include/swift/RemoteInspection/TypeLowering.h
@@ -583,7 +583,8 @@ public:
 
   // Add a field of a record type, such as a struct.
   void addField(const std::string &Name, const TypeRef *TR,
-                remote::TypeInfoProvider *ExternalTypeInfo);
+                remote::TypeInfoProvider *ExternalTypeInfo,
+                bool artificial = false);
 
   const RecordTypeInfo *build();
 

--- a/include/swift/RemoteInspection/TypeRefBuilder.h
+++ b/include/swift/RemoteInspection/TypeRefBuilder.h
@@ -282,13 +282,15 @@ struct FieldTypeInfo {
   const TypeRef *TR;
   bool Indirect;
   bool Generic;
+  bool Artificial;
 
   FieldTypeInfo()
-      : Name(""), Value(0), TR(nullptr), Indirect(false), Generic(false) {}
+      : Name(""), Value(0), TR(nullptr), Indirect(false), Generic(false),
+        Artificial(false) {}
   FieldTypeInfo(const std::string &Name, int Value, const TypeRef *TR,
-                bool Indirect, bool Generic)
-      : Name(Name), Value(Value), TR(TR), Indirect(Indirect), Generic(Generic) {
-  }
+                bool Indirect, bool Generic, bool Artificial = false)
+      : Name(Name), Value(Value), TR(TR), Indirect(Indirect), Generic(Generic),
+        Artificial(Artificial) {}
 
   static FieldTypeInfo forEmptyCase(std::string Name, int Value) {
     return FieldTypeInfo(Name, Value, nullptr, false, false);

--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -1515,20 +1515,25 @@ unsigned RecordTypeInfoBuilder::addField(unsigned fieldSize,
   return offset;
 }
 
-void RecordTypeInfoBuilder::addField(
-    const std::string &Name, const TypeRef *TR,
-    remote::TypeInfoProvider *ExternalTypeInfo) {
+void RecordTypeInfoBuilder::addField(const std::string &Name, const TypeRef *TR,
+                                     remote::TypeInfoProvider *ExternalTypeInfo,
+                                     bool artificial) {
   const TypeInfo *TI = TC.getTypeInfo(TR, ExternalTypeInfo);
   if (TI == nullptr) {
     markInvalid("no TypeInfo for field type", TR);
     return;
   }
 
-  unsigned offset = addField(TI->getSize(),
-                             TI->getAlignment(),
-                             TI->getNumExtraInhabitants(),
-                             TI->getBorrowability(),
-                             TI->isAddressableForDependencies());
+  // An artificial field (e.g. the synthetic "like" field emitted for a
+  // `@_rawLayout` struct) contributes its size and alignment to the record
+  // but not its extra inhabitants: a raw-layout type is laid out as opaque
+  // storage in-process and exposes no extra inhabitants, so mirroring the
+  // like type's extra inhabitants here would disagree with the real ABI.
+  unsigned numExtraInhabitants = artificial ? 0 : TI->getNumExtraInhabitants();
+
+  unsigned offset =
+      addField(TI->getSize(), TI->getAlignment(), numExtraInhabitants,
+               TI->getBorrowability(), TI->isAddressableForDependencies());
   Fields.push_back({Name, offset, -1, TR, *TI});
 }
 
@@ -2518,7 +2523,8 @@ public:
         return nullptr;
 
       for (auto Field : Fields)
-        builder.addField(Field.Name, Field.TR, ExternalTypeInfo);
+        builder.addField(Field.Name, Field.TR, ExternalTypeInfo,
+                         Field.Artificial);
       return builder.build();
     }
     case FieldDescriptorKind::Enum:
@@ -2876,7 +2882,8 @@ const RecordTypeInfo *TypeConverter::getClassInstanceTypeInfo(
                      /*addressableForDependencies=*/false);
 
     for (auto Field : Fields)
-      builder.addField(Field.Name, Field.TR, ExternalTypeInfo);
+      builder.addField(Field.Name, Field.TR, ExternalTypeInfo,
+                       Field.Artificial);
     return builder.build();
   }
   case FieldDescriptorKind::Struct:

--- a/stdlib/public/RemoteInspection/TypeRefBuilder.cpp
+++ b/stdlib/public/RemoteInspection/TypeRefBuilder.cpp
@@ -461,7 +461,7 @@ class FieldRecordImpl : public FieldRecordBase {
 public:
   FieldRecordImpl(RemoteRef<const FieldRecord> FR, TypeRefBuilder &Builder)
       : FieldRecordBase(FR->isIndirectCase(), FR->isVar(),
-                             FR->hasMangledTypeName()),
+                        FR->hasMangledTypeName(), FR->isArtificial()),
         Field(FR), Builder(Builder) {}
 
   ~FieldRecordImpl() override {}
@@ -560,7 +560,7 @@ bool TypeRefBuilder::getFieldTypeRefs(
     bool IsIndirect = FD.isEnum() && Field->IsIndirectCase;
 
     auto FieldTI = FieldTypeInfo(FieldName.str(), FieldValue, Substituted,
-                                 IsIndirect, IsGeneric);
+                                 IsIndirect, IsGeneric, Field->IsArtificial);
     Fields.push_back(FieldTI);
   }
   return true;

--- a/validation-test/Reflection/reflect_rawLayout.swift
+++ b/validation-test/Reflection/reflect_rawLayout.swift
@@ -64,6 +64,53 @@ reflect(object: obj)
 // CHECK-32:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-32:   (field name=after offset={{[0-9]+}}
 
+// A `@_rawLayout` type has no extra inhabitants, even when its `like` type
+// does. Optional therefore cannot pack its tag into the payload and must add a
+// separate tag byte. Remote reflection must not inherit the `like` type's extra
+// inhabitants through the artificial field, or it would compute a too-small
+// Optional and lay the following field on top of the tag.
+class TestClassOptional {
+  let before = 1
+  let cell: RawCell<UnsafePointer<UInt8>>? = nil
+  let after = 2
+}
+
+reflect(object: TestClassOptional())
+
+// CHECK-64: Reflecting an object.
+// CHECK-64: Type reference:
+// CHECK-64: (class reflect_rawLayout.TestClassOptional)
+// CHECK-64: Type info:
+// CHECK-64: (class_instance size=48 alignment=8 stride=48 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:   (field name=before offset=16
+// CHECK-64:   (field name=cell offset=24
+// CHECK-64:     (single_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:       (case name=some index=0 offset=0
+// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:           (field name=_rawLayout offset=0
+// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1
+// CHECK-64:               (field name=_rawValue offset=0
+// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))))))
+// CHECK-64:       (case name=none index=1)))
+// CHECK-64:   (field name=after offset=40
+
+// CHECK-32: Reflecting an object.
+// CHECK-32: Type reference:
+// CHECK-32: (class reflect_rawLayout.TestClassOptional)
+// CHECK-32: Type info:
+// CHECK-32: (class_instance
+// CHECK-32:   (field name=before offset={{[0-9]+}}
+// CHECK-32:   (field name=cell offset={{[0-9]+}}
+// CHECK-32:     (single_payload_enum {{.*}}num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:       (case name=some index=0 offset=0
+// CHECK-32:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:           (field name=_rawLayout offset=0
+// CHECK-32:             (struct {{.*}}bitwise_takable=1
+// CHECK-32:               (field name=_rawValue offset=0
+// CHECK-32:                 (builtin {{.*}})))))
+// CHECK-32:       (case name=none index=1)))
+// CHECK-32:   (field name=after offset={{[0-9]+}}
+
 doneReflecting()
 
 // CHECK-64: Done.


### PR DESCRIPTION
This fixes an incorrect size/layout computation when a @_rawLayout type is used as an enum payload e.g. Mutex<UnsafePointer<...>>?. The @_rawLayout type does not inherit XIs from the laid-out-like type. RemoteInspection didn't account for this, and as a result would place the enum tag within the Mutex's payload, which doesn't match the actual code which uses a separate tag byte.

rdar://181509024