### PR TITLE
Sema: Infer availability for property wrapper backing storage variables

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5636,7 +5636,8 @@ void AttributeChecker::checkAvailableAttrs(ArrayRef<AvailableAttr *> attrs) {
     auto attr = availabilityConstraint->getAttr();
     if (auto diag =
             TypeChecker::diagnosticIfDeclCannotBePotentiallyUnavailable(D))
-      diagnose(attr.getParsedAttr()->getLocation(), diag.value());
+      diagnoseAndRemoveAttr(const_cast<AvailableAttr *>(attr.getParsedAttr()),
+                            *diag);
   }
 }
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -3753,6 +3753,9 @@ PropertyWrapperAuxiliaryVariablesRequest::evaluate(Evaluator &evaluator,
     backingVar->overwriteAccess(AccessLevel::Private);
     backingVar->overwriteSetterAccess(AccessLevel::Private);
 
+    // The backing storage must be as available as the wrapped property.
+    AvailabilityInference::applyInferredAvailableAttrs(backingVar, {var});
+
     addMemberToContextIfNeeded(backingVar, dc, var);
   }
 

--- a/test/Availability/availability_script_mode.swift
+++ b/test/Availability/availability_script_mode.swift
@@ -25,7 +25,7 @@ var availableOn50Var: Available50 = .init() // Ok
 // them to be unavailable.
 
 @available(macOS, introduced: 51) // expected-error {{global variable cannot be marked potentially unavailable with '@available' in script mode}}
-var potentiallyUnavailableVar: Available51 = .init()
+var potentiallyUnavailableVar: Available51 = .init() // expected-error {{'Available51' is only available in macOS 51 or newer}} expected-note {{add 'if #available' version check}}
 
 @available(macOS, unavailable) // expected-error {{global variable cannot be marked unavailable with '@available' in script mode}}
 var unavailableOnMacOSVar: UnavailableOnMacOS = .init() // expected-error {{'UnavailableOnMacOS' is unavailable in macOS}}

--- a/test/Availability/availability_stored.swift
+++ b/test/Availability/availability_stored.swift
@@ -38,15 +38,15 @@ struct GoodNestedReferenceStruct {
   }
 }
 
-struct BadReferenceStruct1 {
+struct BadReferenceStruct1 { // expected-note {{add '@available' attribute to enclosing struct}}
   // expected-error@+1 {{stored properties cannot be marked potentially unavailable with '@available'}}
   @available(macOS 50, *)
-  var x: NewStruct
-  
+  var x: NewStruct // expected-error {{'NewStruct' is only available in macOS 50 or newer}}
+
   // expected-error@+1 {{stored properties cannot be marked potentially unavailable with '@available'}}
   @available(macOS 50, *)
-  @NewPropertyWrapper var y: Int
-  
+  @NewPropertyWrapper var y: Int // expected-error {{stored properties cannot be marked potentially unavailable with '@available'}}
+
   // expected-error@+1 {{stored properties cannot be marked potentially unavailable with '@available'}}
   @available(macOS 50, *)
   lazy var z: Int = 42
@@ -56,12 +56,12 @@ struct BadReferenceStruct1 {
 struct BadReferenceStruct2 {
   // expected-error@+1 {{stored properties cannot be marked potentially unavailable with '@available'}}
   @available(macOS 50, *)
-  var x: NewStruct
-  
+  var x: NewStruct // expected-error {{'NewStruct' is only available in macOS 50 or newer}}
+
   // expected-error@+1 {{stored properties cannot be marked potentially unavailable with '@available'}}
   @available(macOS 50, *)
-  @NewPropertyWrapper var y: Int
-  
+  @NewPropertyWrapper var y: Int // expected-error {{stored properties cannot be marked potentially unavailable with '@available'}}
+
   // expected-error@+1 {{stored properties cannot be marked potentially unavailable with '@available'}}
   @available(macOS 50, *)
   lazy var z: Int = 42
@@ -71,11 +71,11 @@ struct BadReferenceStruct2 {
 public struct PublicStruct {
   // expected-error@+1 {{stored properties cannot be marked potentially unavailable with '@available'}}
   @available(macOS 50, *)
-  public var x: NewStruct
+  public var x: NewStruct // expected-error {{'NewStruct' is only available in macOS 50 or newer}}
 
   // expected-error@+1 {{stored properties cannot be marked potentially unavailable with '@available'}}
   @available(macOS 50, *)
-  @NewPropertyWrapper public var y: Int
+  @NewPropertyWrapper public var y: Int // expected-error {{stored properties cannot be marked potentially unavailable with '@available'}}
 
   // expected-error@+1 {{stored properties cannot be marked potentially unavailable with '@available'}}
   @available(macOS 50, *)

--- a/test/Availability/availability_versions.swift
+++ b/test/Availability/availability_versions.swift
@@ -398,7 +398,7 @@ class SubOfClassWithPotentiallyUnavailableInitializer : SuperWithWithPotentially
 // Properties
 
 class ClassWithPotentiallyUnavailableProperties {
-    // expected-note@-1 4{{add '@available' attribute to enclosing class}}
+    // expected-note@-1 3{{add '@available' attribute to enclosing class}}
 
   var nonLazyAvailableOn10_9Stored: Int = 9
 
@@ -414,20 +414,19 @@ class ClassWithPotentiallyUnavailableProperties {
 
   @available(OSX, introduced: 10.9)
   lazy var availableOn10_9Stored: Int = 9
-  
+
   @available(OSX, introduced: 51) // expected-error {{stored properties cannot be marked potentially unavailable with '@available'}}
   lazy var availableOn51Stored : Int = 10
 
   @available(OSX, introduced: 10.9)
   var availableOn10_9Computed: Int {
     get {
-      let _: Int = availableOn51Stored // expected-error {{'availableOn51Stored' is only available in macOS 51 or newer}}
-          // expected-note@-1 {{add 'if #available' version check}}
-      
+      let _: Int = availableOn51Stored
+
       if #available(OSX 51, *) {
         let _: Int = availableOn51Stored
       }
-      
+
       return availableOn10_9Stored
     }
     set(newVal) {
@@ -512,15 +511,13 @@ class ClassWithReferencesInInitializers {
 }
 
 func accessPotentiallyUnavailableProperties(_ o: ClassWithPotentiallyUnavailableProperties) {
-      // expected-note@-1 17{{add '@available' attribute to enclosing global function}}
+      // expected-note@-1 15{{add '@available' attribute to enclosing global function}}
   // Stored properties
   let _: Int = o.availableOn10_9Stored
-  let _: Int = o.availableOn51Stored // expected-error {{'availableOn51Stored' is only available in macOS 51 or newer}}
-      // expected-note@-1 {{add 'if #available' version check}}
-  
+  let _: Int = o.availableOn51Stored
+
   o.availableOn10_9Stored = 9
-  o.availableOn51Stored = 10 // expected-error {{'availableOn51Stored' is only available in macOS 51 or newer}}
-      // expected-note@-1 {{add 'if #available' version check}}
+  o.availableOn51Stored = 10
 
   // Computed Properties
   let _: Int = o.availableOn10_9Computed
@@ -625,13 +622,16 @@ enum CompassPoint {
   @available(OSX, introduced: 52)
   case West
 
+  @available(OSX, introduced: 52)
+  case NorthWest
+
   case WithAvailableByEnumPayload(p : EnumIntroducedOn51)
 
   // expected-error@+1 {{enum cases with associated values cannot be marked potentially unavailable with '@available'}}
   @available(OSX, introduced: 52)
   case WithAvailableByEnumElementPayload(p : EnumIntroducedOn52)
 
-  // expected-error@+1 2{{enum cases with associated values cannot be marked potentially unavailable with '@available'}}
+  // expected-error@+1 {{enum cases with associated values cannot be marked potentially unavailable with '@available'}}
   @available(OSX, introduced: 52)
   case WithAvailableByEnumElementPayload1(p : EnumIntroducedOn52), WithAvailableByEnumElementPayload2(p : EnumIntroducedOn52)
 
@@ -647,7 +647,7 @@ enum CompassPoint {
 func functionTakingEnumIntroducedOn52(_ e: EnumIntroducedOn52) { }
 
 func useEnums() {
-      // expected-note@-1 2{{add '@available' attribute to enclosing global function}}
+      // expected-note@-1 3{{add '@available' attribute to enclosing global function}}
   let _: CompassPoint = .North // expected-error {{'CompassPoint' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
@@ -668,7 +668,7 @@ func useEnums() {
     switch (point) {
       case .North, .South, .East:
         markUsed("NSE")
-      case .West: // We do not expect an error here
+      case .West, .NorthWest: // We do not expect an error here
         markUsed("W")
 
       case .WithPotentiallyUnavailablePayload(_):
@@ -686,7 +686,8 @@ func useEnums() {
         markUsed("WithAvailableByEnumElementPayload2")
       case .WithAvailableByEnumElementPayload(let p):
         markUsed("WithAvailableByEnumElementPayload")
-        functionTakingEnumIntroducedOn52(p)
+        functionTakingEnumIntroducedOn52(p) // expected-error {{'functionTakingEnumIntroducedOn52' is only available in macOS 52 or newer}}
+        // expected-note@-1 {{add 'if #available' version check}}
     }
   }
 }
@@ -719,7 +720,7 @@ func switchStatements(point: CompassPoint) {
   // Multiple case label items that share the same availability still allow
   // refinement to that common availability.
   switch point {
-  case .WithAvailableByEnumElementPayload1(_), .WithAvailableByEnumElementPayload2(_):
+  case .West, .NorthWest:
     _ = globalFuncAvailableOn52()
   default:
     break
@@ -752,7 +753,7 @@ func switchStatements(point: CompassPoint) {
     case .West:
       _ = globalFuncAvailableOn52() // expected-error {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
-    case .WithAvailableByEnumElementPayload1(_):
+    case .NorthWest:
       _ = globalFuncAvailableOn52()
     default:
       break

--- a/test/Availability/property_wrapper_accessors_availability.swift
+++ b/test/Availability/property_wrapper_accessors_availability.swift
@@ -307,3 +307,14 @@ class Subclass: Base<Item> {
     didSet {}
   }
 }
+
+struct HasDeprecatedWrappedProperty {
+  @available(*, deprecated)
+  @UnrestrictedProjection var value: Int
+
+  func use() {
+    _ = value  // expected-warning {{'value' is deprecated}}
+    _ = $value // expected-warning {{'$value' is deprecated}}
+    _ = _value // expected-warning {{'_value' is deprecated}}
+  }
+}

--- a/validation-test/Sema/SwiftUI/rdar106575142.swift
+++ b/validation-test/Sema/SwiftUI/rdar106575142.swift
@@ -19,15 +19,3 @@ extension S {
     }
   }
 }
-
-@available(*, unavailable)
-extension S {
-  class NestedAlwaysUnavailable {
-    @Published var x: Int = 0
-    @Binding var y: Bool
-
-    init(y: Binding<Bool>) {
-      _y = y
-    }
-  }
-}


### PR DESCRIPTION
The synthesized `_foo` backing storage variable for a property with an attached property wrapper was not picking up any inferred availability from the wrapped property. As a result, `@available(*, deprecated)` on the wrapped property did not produce a warning when `_foo` was referenced.

Resolves rdar://80277462 and https://github.com/swiftlang/swift/issues/57231.