### PR TITLE
[6.4] SILGen: Branch out of error borrowing scope before propagating an uncaught error in a `catch` emission.

### DIFF
--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -3904,7 +3904,6 @@ void SILGenFunction::emitSwitchFallthrough(FallthroughStmt *S) {
 void SILGenFunction::emitCatchDispatch(DoCatchStmt *S, ManagedValue exn,
                                        ArrayRef<CaseStmt *> clauses,
                                        JumpDest catchFallthroughDest) {
-
   auto completionHandler = [&](PatternMatchEmission &emission,
                                ArgArray argArray, ClauseRow &row) {
     auto clause = row.getClientData<CaseStmt>();
@@ -4054,6 +4053,14 @@ void SILGenFunction::emitCatchDispatch(DoCatchStmt *S, ManagedValue exn,
   // multiple-entry case blocks.
   emission.emitAddressOnlyAllocations();
 
+  SILBasicBlock *failureBB = nullptr;
+  JumpDest failureDest = JumpDest::invalid();
+
+  if (ThrowDest.isValid()) {
+    failureBB = createBasicBlock();
+    failureDest = JumpDest(failureBB, getCleanupsDepth(), CleanupLocation(S));
+  }
+  
   Scope stmtScope(Cleanups, CleanupLocation(S));
 
   auto consumptionKind = exn.getType().isObject()
@@ -4066,8 +4073,6 @@ void SILGenFunction::emitCatchDispatch(DoCatchStmt *S, ManagedValue exn,
   ConsumableManagedValue subject = {exn.borrow(*this, S), consumptionKind};
 
   auto failure = [&](SILLocation location) {
-    // If we fail to match anything, just rethrow the exception.
-
     // If the throw destination is not valid, then the PatternMatchEmission
     // logic is emitting an unreachable block but didn't prune the failure BB.
     // Mark it as such.
@@ -4076,26 +4081,17 @@ void SILGenFunction::emitCatchDispatch(DoCatchStmt *S, ManagedValue exn,
       return;
     }
 
-    // Since we borrowed exn before sending it to our subcases, we know that it
-    // must be at +1 at this point. That being said, SILGenPattern will
-    // potentially invoke this for each of the catch statements, so we need to
-    // copy before we pass it into the throw.
-    CleanupStateRestorationScope scope(Cleanups);
-    if (exn.hasCleanup()) {
-      scope.pushCleanupState(exn.getCleanup(),
-                             CleanupState::PersistentlyActive);
-    }
-
-    // We may create temporaries while bridging from typed to untyped throws.
-    FullExpr throwScope(Cleanups, CleanupLocation(location));
-    emitThrow(S, exn);
+    // Jump to the failure block, which sits out of the current scope, so
+    // we release the borrow on the original error value and can forward it
+    // to the outer function.
+    Cleanups.emitBranchAndCleanups(failureDest, S);
   };
   // Set up an initial clause matrix.
   ClauseMatrix clauseMatrix(clauseRows);
 
   // Recursively specialize and emit the clause matrix.
   emission.emitDispatch(clauseMatrix, subject, failure);
-  assert(!B.hasValidInsertionPoint());
+  ASSERT(!B.hasValidInsertionPoint());
 
   stmtScope.pop();
 
@@ -4109,4 +4105,21 @@ void SILGenFunction::emitCatchDispatch(DoCatchStmt *S, ManagedValue exn,
       Cleanups.emitBranchAndCleanups(catchFallthroughDest, caseStmt->getBody());
     }
   });
+
+  // Emit the failure block, if it was needed.
+  if (ThrowDest.isValid()) {
+    if (failureBB->pred_empty()) {
+      // Drop the failure block if we didn't use it.
+      failureBB->eraseFromParent();
+    } else {
+      B.emitBlock(failureBB);
+
+      // We may create temporaries while bridging from typed to untyped throws.
+      FullExpr throwScope(Cleanups, CleanupLocation(S));
+      emitThrow(S, exn);
+      ASSERT(!B.hasValidInsertionPoint());
+    }
+  }
+
 }
+

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -187,14 +187,14 @@ func all_together_now(_ flag: Bool) -> Cat {
 // CHECK: [[SWITCH_MATCH_FAIL_BB]]([[SUBERROR:%.*]] : @owned $HomeworkError):
 // CHECK:   destroy_value [[SUBERROR]]
 // CHECK:   end_borrow [[BORROWED_ERROR]]
-// CHECK:   br [[RETHROW_BB:bb[0-9]+]]([[ERROR]] : $any Error)
+// CHECK:   br [[RETHROW_BB:bb[0-9]+]]
 //
 // CHECK: [[CAST_NO_BB]]:
 // CHECK:   end_borrow [[BORROWED_ERROR]]
-// CHECK:   br [[RETHROW_BB]]([[ERROR]] : $any Error)
+// CHECK:   br [[RETHROW_BB]]
 //
-// CHECK: [[RETHROW_BB]]([[ERROR_FOR_RETHROW:%.*]] : @owned $any Error):
-// CHECK:   throw [[ERROR_FOR_RETHROW]]
+// CHECK: [[RETHROW_BB]]:
+// CHECK:   throw [[ERROR]]
 // CHECK: } // end sil function '$s6errors20all_together_now_twoyAA3CatCSgSbKF'
 func all_together_now_two(_ flag: Bool) throws -> Cat? {
   do {
@@ -224,14 +224,14 @@ func all_together_now_two(_ flag: Bool) throws -> Cat? {
 // CHECK: [[SWITCH_MATCH_FAIL_BB]]([[SUBERROR:%.*]] : @owned $HomeworkError):
 // CHECK:   destroy_value [[SUBERROR]]
 // CHECK:   end_borrow [[BORROWED_ERROR]]
-// CHECK:   br [[RETHROW_BB:bb[0-9]+]]([[ERROR]] : $any Error)
+// CHECK:   br [[RETHROW_BB:bb[0-9]+]]
 //
 // CHECK: [[CAST_NO_BB]]:
 // CHECK:   end_borrow [[BORROWED_ERROR]]
-// CHECK:   br [[RETHROW_BB]]([[ERROR]] : $any Error)
+// CHECK:   br [[RETHROW_BB]]
 //
-// CHECK: [[RETHROW_BB]]([[ERROR_FOR_RETHROW:%.*]] : @owned $any Error):
-// CHECK:   throw [[ERROR_FOR_RETHROW]]
+// CHECK: [[RETHROW_BB]]:
+// CHECK:   throw [[ERROR]]
 // CHECK: } // end sil function '$s6errors22all_together_now_threeyAA3CatCSgSbKF'
 func all_together_now_three(_ flag: Bool) throws -> Cat? {
   do {
@@ -274,14 +274,14 @@ func all_together_now_three(_ flag: Bool) throws -> Cat? {
 // CHECK: [[SWITCH_MATCH_FAIL_BB]]([[SUBERROR:%.*]] : @owned $HomeworkError):
 // CHECK:   destroy_value [[SUBERROR]]
 // CHECK:   end_borrow [[BORROWED_ERROR]]
-// CHECK:   br [[RETHROW_BB:bb[0-9]+]]([[ERROR]] : $any Error)
+// CHECK:   br [[RETHROW_BB:bb[0-9]+]]
 //
 // CHECK: [[CAST_NO_BB]]:
 // CHECK:   end_borrow [[BORROWED_ERROR]]
-// CHECK:   br [[RETHROW_BB]]([[ERROR]] : $any Error)
+// CHECK:   br [[RETHROW_BB]]
 //
-// CHECK: [[RETHROW_BB]]([[ERROR_FOR_RETHROW:%.*]] : @owned $any Error):
-// CHECK:   throw [[ERROR_FOR_RETHROW]]
+// CHECK: [[RETHROW_BB]]:
+// CHECK:   throw [[ERROR]]
 // CHECK: } // end sil function '$s6errors21all_together_now_fouryAA3CatCSgSbKF'
 func all_together_now_four(_ flag: Bool) throws -> Cat? {
   do {
@@ -362,7 +362,7 @@ func all_together_now_four(_ flag: Bool) throws -> Cat? {
 // CHECK-NEXT: br [[RETHROW]]
 
 // Rethrow
-// CHECK: [[RETHROW]]([[ERROR:%.*]] : @owned $any Error):
+// CHECK: [[RETHROW]]:
 // CHECK-NEXT: throw [[ERROR]] : $any Error
 func all_together_now_five(_ flag: Bool) throws -> Cat {
   do {

--- a/test/SILGen/typed_throws_reabstraction.swift
+++ b/test/SILGen/typed_throws_reabstraction.swift
@@ -15,6 +15,8 @@ func test2() throws { // Not OK
     // CHECK: bb{{[0-9]+}}:
     // CHECK: bb{{[0-9]+}}:
     // CHECK:      end_borrow [[ERROR_BORROW]]
+    // CHECK-NEXT: br [[FORWARD_ERROR:bb[0-9]+]]
+    // CHECK: [[FORWARD_ERROR]]:
     // CHECK-NEXT: store [[ERROR]] to [init]
     // CHECK-NEXT: throw_addr
 

--- a/validation-test/compiler_crashers/LinearLifetimeChecker-checkValueImpl-c6a49f.swift
+++ b/validation-test/compiler_crashers/LinearLifetimeChecker-checkValueImpl-c6a49f.swift
@@ -1,5 +1,5 @@
 // {"kind":"emit-silgen","original":"776b50d4","signature":"swift::LinearLifetimeChecker::checkValueImpl(swift::SILValue, llvm::ArrayRef<swift::Operand*>, llvm::ArrayRef<swift::Operand*>, swift::LinearLifetimeChecker::ErrorBuilder&, std::__1::optional<llvm::function_ref<void (swift::SILBasicBlock*)>>, std::__1::optional<llvm::function_ref<void (swift::Operand*)>>)","signatureNext":"LinearLifetimeChecker::checkValue"}
-// RUN: not --crash %target-swift-frontend -emit-silgen %s
+// RUN: %target-swift-frontend -emit-silgen %s
 enum a: Error {
   case b(String)
 }


### PR DESCRIPTION
Explanation: Fixes a compiler crash when an untyped-throws function calls into a typed-throws function, catches some errors, but lets some propagate out of the caller.

Scope: Bug fix.

Risk: Low. Replaces a previous hack with a more principled fix.

Reviewed by: @kavon 

Issues: #89787, rdar://179093761

Testing: Swift CI, test case from bug report, compatibility test suite