### PR TITLE
[PrintAsClang] Add variadic template scaffolding for C++ existential interop

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -531,6 +531,9 @@ EXPERIMENTAL_FEATURE(ImportCxxMembersLazily, true)
 /// superclass.
 EXPERIMENTAL_FEATURE(ForeignReferenceTypeInheritance, true)
 
+/// Enable C++ existential wrappers for Swift protocol types.
+EXPERIMENTAL_FEATURE(CxxExistentialInterop, false)
+
 /// `yielding borrow`/`yielding mutate` single-yield coroutine accessors
 // TODO: When this is turned on by default, take care of:
 // * "TODO" around line 8100 of lib/Parse/ParseDecl.cpp

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -481,6 +481,7 @@ UNINTERESTING_FEATURE(AssumeResilientCxxTypes)
 UNINTERESTING_FEATURE(ImportNonPublicCxxMembers)
 UNINTERESTING_FEATURE(ImportCxxMembersLazily)
 UNINTERESTING_FEATURE(ForeignReferenceTypeInheritance)
+UNINTERESTING_FEATURE(CxxExistentialInterop)
 UNINTERESTING_FEATURE(CoroutineAccessorsUnwindOnCallerError)
 UNINTERESTING_FEATURE(AllowRuntimeSymbolDeclarations)
 

--- a/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
+++ b/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
@@ -228,6 +228,210 @@ void printPrimitiveGenericTypeTraits(raw_ostream &os, ASTContext &astContext,
   }
 }
 
+static void printSwiftExistentialTypeMethodDefs(raw_ostream &os) {
+  os << "#if defined(SWIFT_CXX_EXISTENTIAL_INTEROP) && "
+        "defined(__cpp_concepts) && __cpp_concepts >= 202002L\n";
+  os << "// Out-of-line SwiftExistentialType methods.\n";
+  os << "// Needs the complete VWT declared above.\n\n";
+
+  // Template prefix for all out-of-line definitions.
+  const char *tmplPrefix = "template <typename... Tags>\n"
+    "  requires ((ProtocolTag<Tags> || MarkerTag<Tags> || InverseTag<Tags>) "
+    "&& ...)\n";
+  const char *cls = "SwiftExistentialType<Tags...>";
+
+  // _getVWT
+  os << tmplPrefix;
+  os << "SWIFT_INLINE_PRIVATE_HELPER\n";
+  os << "const ValueWitnessTable *_Nonnull\n";
+  os << cls << "::_getVWT() const noexcept {\n";
+  os << "  auto *vwTableAddr = "
+        "reinterpret_cast<ValueWitnessTable **>(_type) - 1;\n";
+  os << "#ifdef __arm64e__\n";
+  os << "  return reinterpret_cast<ValueWitnessTable *>(\n";
+  os << "      ptrauth_auth_data(\n";
+  os << "          reinterpret_cast<void *>(*vwTableAddr),\n";
+  os << "          ptrauth_key_process_independent_data,\n";
+  os << "          ptrauth_blend_discriminator(vwTableAddr, "
+     << SpecialPointerAuthDiscriminators::ValueWitnessTable << ")));\n";
+  os << "#else\n";
+  os << "  return *vwTableAddr;\n";
+  os << "#endif\n";
+  os << "}\n\n";
+
+  // _initializeWithCopy
+  os << tmplPrefix;
+  os << "SWIFT_INLINE_PRIVATE_HELPER\n";
+  os << "void\n";
+  os << cls << "::_initializeWithCopy(\n";
+  os << "    const " << cls << " &src) noexcept {\n";
+  os << "  _type = src._type;\n";
+  os << "  _getVWT()->initializeBufferWithCopyOfBuffer(\n";
+  os << "      _buffer, const_cast<void **>(src._buffer), _type);\n";
+  os << "  if constexpr (ExistentialTagTraits<Tags...>::NumWitnessTables > 0)\n";
+  os << "    for (size_t i = 0; i < ExistentialTagTraits<Tags...>::NumWitnessTables; ++i)\n";
+  os << "      this->_witnessTables[i] = src._witnessTables[i];\n";
+  os << "}\n\n";
+
+  // _initializeWithValue
+  os << tmplPrefix;
+  os << "SWIFT_INLINE_PRIVATE_HELPER\n";
+  os << "void\n";
+  os << cls << "::_initializeWithValue(\n";
+  os << "    const void *_Nonnull src) noexcept {\n";
+  os << "  auto *vwt = _getVWT();\n";
+  os << "  if (!(vwt->flags & "
+     << TargetValueWitnessFlags<uint64_t>::IsNonInline << ")) {\n";
+  os << "    vwt->initializeWithCopy(\n";
+  os << "        reinterpret_cast<char *>(_buffer),\n";
+  os << "        const_cast<char *>(\n";
+  os << "            reinterpret_cast<const char *>(src)),\n";
+  os << "        _type);\n";
+  os << "  } else {\n";
+  os << "    auto box = swift_allocBox(_type);\n";
+  os << "    _buffer[0] = box.object;\n";
+  os << "    vwt->initializeWithCopy(\n";
+  os << "        reinterpret_cast<char *>(box.buffer),\n";
+  os << "        const_cast<char *>(\n";
+  os << "            reinterpret_cast<const char *>(src)),\n";
+  os << "        _type);\n";
+  os << "  }\n";
+  os << "}\n\n";
+
+  // _projectValue
+  os << tmplPrefix;
+  os << "SWIFT_INLINE_PRIVATE_HELPER\n";
+  os << "void *_Nonnull\n";
+  os << cls << "::_projectValue() const noexcept {\n";
+  os << "  auto *vwTable = _getVWT();\n";
+  os << "  if (!(vwTable->flags & "
+     << TargetValueWitnessFlags<uint64_t>::IsNonInline << "))\n";
+  os << "    return const_cast<void **>(_buffer);\n";
+  os << "  return swift_projectBox(_buffer[0]);\n";
+  os << "}\n\n";
+
+  // _destroyValue
+  os << tmplPrefix;
+  os << "SWIFT_INLINE_PRIVATE_HELPER\n";
+  os << "void\n";
+  os << cls << "::_destroyValue() noexcept {\n";
+  os << "  auto *vwt = _getVWT();\n";
+  os << "  if (!(vwt->flags & "
+     << TargetValueWitnessFlags<uint64_t>::IsNonInline << ")) {\n";
+  os << "    vwt->destroy(reinterpret_cast<char *>(_buffer), _type);\n";
+  os << "  } else {\n";
+  os << "    vwt->destroy(\n";
+  os << "        reinterpret_cast<char *>(swift_projectBox(_buffer[0])),\n";
+  os << "        _type);\n";
+  os << "    swift_release(_buffer[0]);\n";
+  os << "  }\n";
+  os << "}\n\n";
+
+  // Copy constructor
+  os << tmplPrefix;
+  os << "SWIFT_INLINE_THUNK\n";
+  os << cls << "::" << "SwiftExistentialType(\n";
+  os << "    const " << cls << " &other) noexcept\n";
+  os << "    requires(ExistentialTagTraits<Tags...>::IsCopyable)\n";
+  os << "    : _type(other._type) {\n";
+  os << "  _getVWT()->initializeBufferWithCopyOfBuffer(\n";
+  os << "      _buffer, const_cast<void **>(other._buffer), _type);\n";
+  os << "  if constexpr (ExistentialTagTraits<Tags...>::NumWitnessTables > 0)\n";
+  os << "    for (size_t i = 0; i < ExistentialTagTraits<Tags...>::NumWitnessTables; ++i)\n";
+  os << "      this->_witnessTables[i] = other._witnessTables[i];\n";
+  os << "}\n\n";
+
+  // Move constructor. Uses copy semantics; C++ move is non-consuming.
+  os << tmplPrefix;
+  os << "SWIFT_INLINE_THUNK\n";
+  os << cls << "::" << "SwiftExistentialType(\n";
+  os << "    " << cls << " &&other) noexcept\n";
+  os << "    : _type(other._type) {\n";
+  os << "  _getVWT()->initializeBufferWithCopyOfBuffer(\n";
+  os << "      _buffer, other._buffer, _type);\n";
+  os << "  if constexpr (ExistentialTagTraits<Tags...>::NumWitnessTables > 0)\n";
+  os << "    for (size_t i = 0; i < ExistentialTagTraits<Tags...>::NumWitnessTables; ++i)\n";
+  os << "      this->_witnessTables[i] = other._witnessTables[i];\n";
+  os << "}\n\n";
+
+  // Copy assignment
+  os << tmplPrefix;
+  os << "SWIFT_INLINE_THUNK\n";
+  os << cls << " &\n";
+  os << cls << "::operator=(\n";
+  os << "    const " << cls << " &other) noexcept\n";
+  os << "    requires(ExistentialTagTraits<Tags...>::IsCopyable) {\n";
+  os << "  if (this != &other) {\n";
+  os << "    _destroyValue();\n";
+  os << "    _type = other._type;\n";
+  os << "    _getVWT()->initializeBufferWithCopyOfBuffer(\n";
+  os << "        _buffer, const_cast<void **>(other._buffer), _type);\n";
+  os << "    if constexpr (ExistentialTagTraits<Tags...>::NumWitnessTables > 0)\n";
+  os << "      for (size_t i = 0; i < ExistentialTagTraits<Tags...>::NumWitnessTables; ++i)\n";
+  os << "        this->_witnessTables[i] = other._witnessTables[i];\n";
+  os << "  }\n";
+  os << "  return *this;\n";
+  os << "}\n\n";
+
+  // Move assignment (copy semantics)
+  os << tmplPrefix;
+  os << "SWIFT_INLINE_THUNK\n";
+  os << cls << " &\n";
+  os << cls << "::operator=(\n";
+  os << "    " << cls << " &&other) noexcept {\n";
+  os << "  if (this != &other) {\n";
+  os << "    _destroyValue();\n";
+  os << "    _type = other._type;\n";
+  os << "    _getVWT()->initializeBufferWithCopyOfBuffer(\n";
+  os << "        _buffer, other._buffer, _type);\n";
+  os << "    if constexpr (ExistentialTagTraits<Tags...>::NumWitnessTables > 0)\n";
+  os << "      for (size_t i = 0; i < ExistentialTagTraits<Tags...>::NumWitnessTables; ++i)\n";
+  os << "        this->_witnessTables[i] = other._witnessTables[i];\n";
+  os << "  }\n";
+  os << "  return *this;\n";
+  os << "}\n\n";
+
+  // Destructor
+  os << tmplPrefix;
+  os << "SWIFT_INLINE_THUNK\n";
+  os << cls << "::~SwiftExistentialType() noexcept {\n";
+  os << "  _destroyValue();\n";
+  os << "}\n\n";
+
+  // Implicit conversion to Any (SwiftExistentialType<>)
+  os << tmplPrefix;
+  os << "SWIFT_INLINE_THUNK\n";
+  os << cls << "::operator SwiftExistentialType<>() const noexcept\n";
+  os << "    requires(sizeof...(Tags) > 0 && ExistentialTagTraits<Tags...>::IsCopyable) {\n";
+  os << "  SwiftExistentialType<> result(\n";
+  os << "      typename SwiftExistentialType<>::uninit_t{});\n";
+  os << "  result._type = _type;\n";
+  os << "  _getVWT()->initializeBufferWithCopyOfBuffer(\n";
+  os << "      result._buffer, const_cast<void **>(_buffer), _type);\n";
+  os << "  return result;\n";
+  os << "}\n\n";
+
+  // SwiftClassExistentialType: implicit conversion to Any
+  const char *clsTmplPrefix = "template <typename... Tags>\n"
+    "  requires ((ProtocolTag<Tags> || MarkerTag<Tags> || InverseTag<Tags>) "
+    "&& ...)\n";
+  const char *clsCls = "SwiftClassExistentialType<Tags...>";
+  os << clsTmplPrefix;
+  os << "SWIFT_INLINE_THUNK\n";
+  os << clsCls << "::operator SwiftExistentialType<>() const noexcept {\n";
+  os << "  SwiftExistentialType<> result(\n";
+  os << "      typename SwiftExistentialType<>::uninit_t{});\n";
+  os << "  result._type = swift_getObjectType(\n";
+  os << "      reinterpret_cast<void *_Nonnull>(_value));\n";
+  os << "  result._buffer[0] = reinterpret_cast<void *_Nonnull>(_value);\n";
+  os << "  if (_value) swift_retain(\n";
+  os << "      reinterpret_cast<void *_Nonnull>(_value));\n";
+  os << "  return result;\n";
+  os << "}\n\n";
+
+  os << "#endif // SWIFT_CXX_EXISTENTIAL_INTEROP && __cpp_concepts\n\n";
+}
+
 void swift::printSwiftToClangCoreScaffold(SwiftToClangInteropContext &ctx,
                                           ASTContext &astContext,
                                           PrimitiveTypeMapping &typeMapping,
@@ -247,6 +451,9 @@ void swift::printSwiftToClangCoreScaffold(SwiftToClangInteropContext &ctx,
                                                 /*isCForwardDefinition=*/true);
               });
               os << "\n";
+              if (astContext.LangOpts.hasFeature(
+                      Feature::CxxExistentialInterop))
+                printSwiftExistentialTypeMethodDefs(os);
             });
         os << "\n";
         // C++ only supports inline variables from C++17.

--- a/lib/PrintAsClang/_SwiftCxxInteroperability.h
+++ b/lib/PrintAsClang/_SwiftCxxInteroperability.h
@@ -21,6 +21,9 @@
 
 #include <cstdint>
 #include <stdlib.h>
+#if __cplusplus >= 202002L
+#include <type_traits>
+#endif
 #if defined(_WIN32)
 #include <malloc.h>
 #endif
@@ -92,6 +95,9 @@ namespace _impl {
 extern "C" void *_Nonnull swift_retain(void *_Nonnull) noexcept;
 
 extern "C" void swift_release(void *_Nonnull) noexcept;
+
+extern "C" SWIFT_CALL void *_Nonnull swift_getObjectType(
+    void *_Nonnull object) noexcept;
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wreserved-identifier"
@@ -237,7 +243,243 @@ public:
   }
 };
 
+#if defined(SWIFT_CXX_EXISTENTIAL_INTEROP) && defined(__cpp_concepts) && __cpp_concepts >= 202002L
+
+// Forward-declared; defined after VWT in the generated scaffolding.
+struct ValueWitnessTable;
+
+struct BoxPair {
+  void *_Nonnull object;
+  void *_Nonnull buffer;
+};
+extern "C" BoxPair swift_allocBox(void *_Nonnull type) noexcept;
+extern "C" void *_Nonnull swift_projectBox(void *_Nonnull object) noexcept;
+
+// --- Tag concepts for existential type parameters ---
+
+/// A protocol tag has a WitnessTable typedef (generated per-protocol).
+template <typename T>
+concept ProtocolTag = requires { typename T::WitnessTable; };
+
+/// A marker protocol tag has IsMarker but no WitnessTable.
+template <typename T>
+concept MarkerTag = requires { T::IsMarker; } && !ProtocolTag<T>;
+
+/// Inverse tags for ~Copyable and ~Escapable.
+struct NonCopyable {};
+struct NonEscapable {};
+template <typename T>
+concept InverseTag = std::is_same_v<T, NonCopyable> ||
+                     std::is_same_v<T, NonEscapable>;
+
+template <typename T, typename... Pack>
+concept ContainedIn = (std::is_same_v<T, Pack> || ...);
+
+// --- Shared tag traits ---
+
+template <typename... Tags>
+struct ExistentialTagTraits {
+  static constexpr size_t NumWitnessTables =
+      (0 + ... + (ProtocolTag<Tags> ? 1 : 0));
+  static constexpr bool IsCopyable =
+      !(... || std::is_same_v<Tags, NonCopyable>);
+};
+
+// --- Opaque existential container ---
+
+/// C++ wrapper for a Swift opaque existential container.
+/// Layout: [value buffer: 3 words][type metadata][witness tables...]
+template <typename... Tags>
+  requires ((ProtocolTag<Tags> || MarkerTag<Tags> || InverseTag<Tags>) && ...)
+class SwiftExistentialType {
+  using Traits = ExistentialTagTraits<Tags...>;
+
+  template <typename... U>
+    requires ((ProtocolTag<U> || MarkerTag<U> || InverseTag<U>) && ...)
+  friend class SwiftExistentialType;
+  template <typename... U>
+    requires ((ProtocolTag<U> || MarkerTag<U> || InverseTag<U>) && ...)
+  friend class SwiftClassExistentialType;
+
+  // Defined out-of-line; needs complete VWT and arm64e ptrauth.
+  SWIFT_INLINE_PRIVATE_HELPER const ValueWitnessTable *_Nonnull
+  _getVWT() const noexcept;
+
+  // Defined out-of-line; needs complete VWT.
+  SWIFT_INLINE_PRIVATE_HELPER void _destroyValue() noexcept;
+
+public:
+  // Defined out-of-line; needs complete VWT.
+  SWIFT_INLINE_THUNK SwiftExistentialType(
+      const SwiftExistentialType &other) noexcept
+      requires(Traits::IsCopyable);
+  SWIFT_INLINE_THUNK SwiftExistentialType(
+      SwiftExistentialType &&other) noexcept;
+  SWIFT_INLINE_THUNK SwiftExistentialType &
+  operator=(const SwiftExistentialType &other) noexcept
+      requires(Traits::IsCopyable);
+  SWIFT_INLINE_THUNK SwiftExistentialType &
+  operator=(SwiftExistentialType &&other) noexcept;
+  SWIFT_INLINE_THUNK ~SwiftExistentialType() noexcept;
+
+  /// Implicit conversion to Any (drops witness tables).
+  SWIFT_INLINE_THUNK operator SwiftExistentialType<>() const noexcept
+      requires(sizeof...(Tags) > 0 && Traits::IsCopyable);
+
+protected:
+  struct uninit_t {};
+  SWIFT_INLINE_THUNK SwiftExistentialType(uninit_t) noexcept {}
+
+  // Defined out-of-line; needs complete VWT.
+  SWIFT_INLINE_PRIVATE_HELPER void
+  _initializeWithCopy(const SwiftExistentialType &src) noexcept;
+
+  // Defined out-of-line; needs complete VWT. _type must be set first.
+  SWIFT_INLINE_PRIVATE_HELPER void
+  _initializeWithValue(const void *_Nonnull src) noexcept;
+
+  // Defined out-of-line; needs complete VWT.
+  SWIFT_INLINE_PRIVATE_HELPER void *_Nonnull
+  _projectValue() const noexcept;
+
+  template <size_t EntryOffset, uint16_t PtrAuthDisc, typename FnTy>
+  SWIFT_INLINE_PRIVATE_HELPER FnTy _loadWitness(
+      const void *_Nonnull wt) const {
+    struct slot {
+      FnTy __ptrauth_swift_protocol_witness_function_pointer(PtrAuthDisc) fn;
+    };
+    auto *s = reinterpret_cast<const slot *>(
+        reinterpret_cast<const void *const *>(wt) + EntryOffset);
+    return s->fn;
+  }
+
+  void *_Nonnull _buffer[3];
+  void *_Nonnull _type;
+  const void *_Nonnull
+      _witnessTables[Traits::NumWitnessTables > 0 ? Traits::NumWitnessTables
+                                                  : 1];
+};
+
+// --- Class-bound existential container ---
+
+/// C++ wrapper for a Swift class-bound existential container.
+/// Layout: [class pointer][witness tables...]
+template <typename... Tags>
+  requires ((ProtocolTag<Tags> || MarkerTag<Tags> || InverseTag<Tags>) && ...)
+class SwiftClassExistentialType {
+  using Traits = ExistentialTagTraits<Tags...>;
+
+  template <typename... U>
+    requires ((ProtocolTag<U> || MarkerTag<U> || InverseTag<U>) && ...)
+  friend class SwiftExistentialType;
+  template <typename... U>
+    requires ((ProtocolTag<U> || MarkerTag<U> || InverseTag<U>) && ...)
+  friend class SwiftClassExistentialType;
+
+public:
+  SWIFT_INLINE_THUNK SwiftClassExistentialType(
+      const SwiftClassExistentialType &other) noexcept
+      : _value(other._value) {
+    if (_value) swift_retain(reinterpret_cast<void *_Nonnull>(_value));
+    if constexpr (Traits::NumWitnessTables > 0) {
+      for (size_t i = 0; i < Traits::NumWitnessTables; ++i)
+        this->_witnessTables[i] = other._witnessTables[i];
+    }
+  }
+  SWIFT_INLINE_THUNK SwiftClassExistentialType(
+      SwiftClassExistentialType &&other) noexcept
+      : _value(other._value) {
+    other._value = nullptr;
+    if constexpr (Traits::NumWitnessTables > 0) {
+      for (size_t i = 0; i < Traits::NumWitnessTables; ++i)
+        this->_witnessTables[i] = other._witnessTables[i];
+    }
+  }
+  SWIFT_INLINE_THUNK SwiftClassExistentialType &
+  operator=(const SwiftClassExistentialType &other) noexcept {
+    if (this != &other) {
+      auto *old = _value;
+      _value = other._value;
+      if (_value) swift_retain(reinterpret_cast<void *_Nonnull>(_value));
+      if (old) swift_release(reinterpret_cast<void *_Nonnull>(old));
+      if constexpr (Traits::NumWitnessTables > 0) {
+        for (size_t i = 0; i < Traits::NumWitnessTables; ++i)
+          this->_witnessTables[i] = other._witnessTables[i];
+      }
+    }
+    return *this;
+  }
+  SWIFT_INLINE_THUNK SwiftClassExistentialType &
+  operator=(SwiftClassExistentialType &&other) noexcept {
+    if (this != &other) {
+      if (_value) swift_release(reinterpret_cast<void *_Nonnull>(_value));
+      _value = other._value;
+      other._value = nullptr;
+      if constexpr (Traits::NumWitnessTables > 0) {
+        for (size_t i = 0; i < Traits::NumWitnessTables; ++i)
+          this->_witnessTables[i] = other._witnessTables[i];
+      }
+    }
+    return *this;
+  }
+  SWIFT_INLINE_THUNK ~SwiftClassExistentialType() noexcept {
+    if (_value) swift_release(reinterpret_cast<void *_Nonnull>(_value));
+  }
+
+  /// Implicit conversion to Any (repacks from class-bound to opaque layout).
+  SWIFT_INLINE_THUNK operator SwiftExistentialType<>() const noexcept;
+
+protected:
+  struct uninit_t {};
+  SWIFT_INLINE_THUNK SwiftClassExistentialType(uninit_t) noexcept
+      : _value(nullptr) {}
+
+  SWIFT_INLINE_PRIVATE_HELPER void
+  _initializeWithCopy(const SwiftClassExistentialType &src) noexcept {
+    _value = src._value;
+    if (_value) swift_retain(reinterpret_cast<void *_Nonnull>(_value));
+    if constexpr (Traits::NumWitnessTables > 0) {
+      for (size_t i = 0; i < Traits::NumWitnessTables; ++i)
+        this->_witnessTables[i] = src._witnessTables[i];
+    }
+  }
+
+  SWIFT_INLINE_PRIVATE_HELPER void *_Nonnull
+  _projectValue() const noexcept {
+    return reinterpret_cast<void *_Nonnull>(_value);
+  }
+
+  SWIFT_INLINE_PRIVATE_HELPER void *_Nonnull
+  _getType() const noexcept {
+    return swift_getObjectType(
+        reinterpret_cast<void *_Nonnull>(_value));
+  }
+
+  template <size_t EntryOffset, uint16_t PtrAuthDisc, typename FnTy>
+  SWIFT_INLINE_PRIVATE_HELPER FnTy _loadWitness(
+      const void *_Nonnull wt) const {
+    struct slot {
+      FnTy __ptrauth_swift_protocol_witness_function_pointer(PtrAuthDisc) fn;
+    };
+    auto *s = reinterpret_cast<const slot *>(
+        reinterpret_cast<const void *const *>(wt) + EntryOffset);
+    return s->fn;
+  }
+
+  void *_Nullable _value;
+  const void *_Nonnull
+      _witnessTables[Traits::NumWitnessTables > 0 ? Traits::NumWitnessTables
+                                                  : 1];
+};
+
+#endif // SWIFT_CXX_EXISTENTIAL_INTEROP && __cpp_concepts
+
 } // namespace _impl
+
+#if defined(SWIFT_CXX_EXISTENTIAL_INTEROP) && defined(__cpp_concepts) && __cpp_concepts >= 202002L
+/// Swift.Any -- the unconstrained existential type.
+using Any = _impl::SwiftExistentialType<>;
+#endif // SWIFT_CXX_EXISTENTIAL_INTEROP && __cpp_concepts
 
 /// Swift's Int type.
 using Int = ptrdiff_t;

--- a/test/Interop/SwiftToCxx/core/swift-existential-type-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/core/swift-existential-type-in-cxx.swift
@@ -1,0 +1,93 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name Core -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/core.h -enable-experimental-feature CxxExistentialInterop
+// RUN: %FileCheck %s < %t/core.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/core.h)
+
+// REQUIRES: swift_feature_CxxExistentialInterop
+
+
+// Verify that SwiftExistentialType<Tags...> out-of-line method definitions
+// appear in the generated header after the ValueWitnessTable struct.
+// The class template declaration is in _SwiftCxxInteroperability.h (included
+// via #include).
+
+// --- Check the #include of _SwiftCxxInteroperability.h ---
+// CHECK: _SwiftCxxInteroperability.h
+
+// --- Check the out-of-line method definitions in the scaffolding ---
+
+// CHECK-LABEL: // Out-of-line SwiftExistentialType methods.
+
+// CHECK: SwiftExistentialType<Tags...>::_getVWT() const noexcept {
+// CHECK:   auto *vwTableAddr = reinterpret_cast<ValueWitnessTable **>(_type) - 1;
+// CHECK: }
+
+// CHECK: SwiftExistentialType<Tags...>::_initializeWithCopy(
+// CHECK:     const SwiftExistentialType<Tags...> &src) noexcept {
+// CHECK:   _type = src._type;
+// CHECK:   _getVWT()->initializeBufferWithCopyOfBuffer(
+// CHECK: }
+
+// CHECK: SwiftExistentialType<Tags...>::_initializeWithValue(
+// CHECK:     const void *_Nonnull src) noexcept {
+// CHECK:   auto *vwt = _getVWT();
+// CHECK:   if (!(vwt->flags & 131072)) {
+// CHECK:     vwt->initializeWithCopy(
+// CHECK:   } else {
+// CHECK:     auto box = swift_allocBox(_type);
+// CHECK:     _buffer[0] = box.object;
+// CHECK:     vwt->initializeWithCopy(
+// CHECK:   }
+// CHECK: }
+
+// CHECK: SwiftExistentialType<Tags...>::_projectValue() const noexcept {
+// CHECK:   auto *vwTable = _getVWT();
+// CHECK:   if (!(vwTable->flags & 131072))
+// CHECK: }
+
+// CHECK: SwiftExistentialType<Tags...>::SwiftExistentialType(
+// CHECK:     const SwiftExistentialType<Tags...> &other) noexcept
+// CHECK:   _getVWT()->initializeBufferWithCopyOfBuffer(
+// CHECK: }
+
+// CHECK: SwiftExistentialType<Tags...>::SwiftExistentialType(
+// CHECK:     SwiftExistentialType<Tags...> &&other) noexcept
+// CHECK:   _getVWT()->initializeBufferWithCopyOfBuffer(
+// CHECK: }
+
+// CHECK: SwiftExistentialType<Tags...>::operator=(
+// CHECK:     const SwiftExistentialType<Tags...> &other) noexcept
+// CHECK:     _destroyValue();
+// CHECK:     _getVWT()->initializeBufferWithCopyOfBuffer(
+// CHECK: }
+
+// CHECK: SwiftExistentialType<Tags...>::operator=(
+// CHECK:     SwiftExistentialType<Tags...> &&other) noexcept {
+// CHECK:     _destroyValue();
+// CHECK:     _getVWT()->initializeBufferWithCopyOfBuffer(
+// CHECK: }
+
+// CHECK: SwiftExistentialType<Tags...>::~SwiftExistentialType() noexcept {
+// CHECK:   _destroyValue();
+// CHECK: }
+
+// --- Conversion operator to Any (SwiftExistentialType<>) ---
+
+// CHECK: SwiftExistentialType<Tags...>::operator SwiftExistentialType<>() const noexcept
+// CHECK:     requires(sizeof...(Tags) > 0 && Traits::IsCopyable) {
+// CHECK:   SwiftExistentialType<> result(
+// CHECK:       typename SwiftExistentialType<>::uninit_t{});
+// CHECK:   result._type = _type;
+// CHECK:   _getVWT()->initializeBufferWithCopyOfBuffer(
+// CHECK: }
+
+// --- SwiftClassExistentialType conversion operator to Any ---
+
+// CHECK: SwiftClassExistentialType<Tags...>::operator SwiftExistentialType<>() const noexcept {
+// CHECK:   SwiftExistentialType<> result(
+// CHECK:       typename SwiftExistentialType<>::uninit_t{});
+// CHECK:   result._type = swift_getObjectType(
+// CHECK: }
+
+// CHECK: } // namespace _impl


### PR DESCRIPTION
## Summary

Add C++20 variadic template infrastructure for representing Swift protocol existentials in C++ generated headers: `SwiftExistentialType<Tags...>` for opaque existentials and `SwiftClassExistentialType<Tags...>` for class-bound existentials.

Swift's C++ interop can represent concrete types on both sides of the boundary (classes via `RefCountedClass`, structs via value-type wrappers), but there is no C++ representation for Swift protocols. Every `any Protocol` parameter or return type in a Swift API is invisible to C++ callers. @zoecarver [Bridging C++ Templates with Interop](https://forums.swift.org/t/bridging-c-templates-with-interop/55003) pitch established protocol conformance as the bridging mechanism between Swift generics and C++ templates, but addressed only the C++-to-Swift direction. The [August 2022 workgroup meeting](https://forums.swift.org/t/c-interop-workgroup-meeting-notes-august-10th-2022/60314) identified the reverse gap. Protocol existential wrappers fill this gap.

### Design

Following @Xazax-hun [forum feedback](https://forums.swift.org/t/88116/4) and @slavapestov [suggestion](https://forums.swift.org/t/88116/2), the existential container is a variadic class template parameterized by tag structs rather than per-protocol subclass inheritance. `SwiftExistentialType<DrawableTag, ResizableTag>` naturally represents `any Drawable & Resizable`; protocol compositions fall out of the template model without special-casing. Named protocol wrappers like `class Drawable final : public SwiftExistentialType<DrawableTag>` add protocol-specific methods on top.

This is a type-erasure-only approach with no C++ concepts in the user-facing API. C++ functions accept existential wrappers as concrete types (`void f(const Drawable& d)`) or composition base types (`void f(const SwiftExistentialType<DrawableTag, ResizableTag>& x)`). Concepts are used internally only, for tag classification.

Three tag concepts classify template parameters:

- **`ProtocolTag`**: has a `WitnessTable` typedef, contributes 1 witness table slot
- **`MarkerTag`**: has `IsMarker`, zero witness table slots (e.g. `Sendable`)
- **`InverseTag`**: `NonCopyable` / `NonEscapable`, constrains lifecycle

`ExistentialTagTraits<Tags...>` uses fold expressions to compute `NumWitnessTables` and `IsCopyable` at compile time. `_witnessTables` is a direct member of each template class (sized to `max(NumWitnessTables, 1)` to avoid zero-length C arrays). The `ContainedIn<T, Pack...>` concept supports generic subset conversion operators, so any `SwiftExistentialType<A, B>` implicitly converts to `SwiftExistentialType<A>`.

**`SwiftExistentialType<Tags...>`** owns the opaque existential container layout: a 3-word value buffer, type metadata pointer, and witness table array. VWT-delegated lifecycle operations (copy, move, assign, destroy). Copy operations are guarded by `requires(Traits::IsCopyable)` so `~Copyable` protocols correctly delete copy constructors/assignment.

**`SwiftClassExistentialType<Tags...>`** owns the class-bound layout: a single refcounted pointer with witness tables. 16+ bytes vs 40+ bytes for opaque. Recovers type metadata via `swift_getObjectType` instead of storing it inline.

Out-of-line method definitions are emitted via `PrintSwiftToClangCoreScaffold.cpp` because they need the complete `ValueWitnessTable` type. The `_loadWitness` template indexes into a witness table at a compile-time offset with pointer authentication for arm64e protocol method dispatch. `_initializeWithValue` / `_projectValue` handle inline vs. outline (heap-allocated) storage based on the VWT `IsNonInline` flag.

`SwiftExistentialType<>` (empty pack) is aliased as `swift::Any`.

All existential code is gated behind `SWIFT_CXX_EXISTENTIAL_INTEROP` and `__cpp_concepts >= 202002L`. The `CxxExistentialInterop` feature flag must be enabled in the Swift compiler to emit the define. This PR is header-only scaffolding; no per-protocol wrappers are emitted and there is no behavioral change to existing C++ headers.

### Relation to WG21 P4148R0

Jonathan Coe et al.'s [P4148R0 `protocol<T>`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p4148r0.pdf) proposes standard library vocabulary types for structural subtyping in C++. The design here is the nominal-typing counterpart: Swift protocols are nominal, so tag structs carry identity and witness table layout rather than deriving the interface structurally via reflection. The underlying container mechanics (inline buffer, heap fallback, type-erased dispatch) are closely analogous.

### Test coverage

- `swift-existential-type-in-cxx.swift`: verifies out-of-line method definitions appear in the generated header with correct VWT dispatch
- `%check-interop-cxx-header-in-clang`: confirms the generated header compiles under `-Weverything -Werror` in C++14, C++17, and C++20 modes (existential code is only active in C++20)