### PR TITLE
Frontend: implement autoloading of the `COM` module

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -464,6 +464,9 @@ public:
   /// Whether the CXX module should be implicitly imported.
   bool shouldImportCxx() const;
 
+  /// Whether the COM module should be implicitly imported.
+  bool shouldImportCOM() const;
+
   /// Performs input setup common to these tools:
   /// sil-opt, sil-func-extractor, sil-llvm-gen, and sil-nm.
   /// Return value includes the buffer so caller can keep it alive.
@@ -723,6 +726,9 @@ public:
   /// Whether the CxxShim library can be imported
   /// i.e. if it can be found.
   bool canImportCxxShim() const;
+
+  /// Whether the COM support library can be imported, i.e. if it can be found.
+  bool canImportCOM() const;
 
   /// Whether this compiler instance supports caching.
   bool supportCaching() const;

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1221,6 +1221,15 @@ bool CompilerInvocation::shouldImportCxx() const {
   return true;
 }
 
+bool CompilerInvocation::shouldImportCOM() const {
+  const auto &LangOpts = getLangOptions();
+  const auto &FEOpts = getFrontendOptions();
+
+  return LangOpts.EnableCOMInterop &&
+      !LangOpts.DisableImplicitCOMModuleImport &&
+      FEOpts.InputMode != FrontendOptions::ParseInputMode::SwiftModuleInterface;
+}
+
 /// Implicitly import the SwiftOnoneSupport module in non-optimized
 /// builds. This allows for use of popular specialized functions
 /// from the standard library, which makes the non-optimized builds
@@ -1308,6 +1317,12 @@ bool CompilerInstance::canImportCxxShim() const {
               .DependencyScanningSubInvocation;
 }
 
+bool CompilerInstance::canImportCOM() const {
+  const auto &ASTContext = getASTContext();
+  ImportPath::Module::Builder mod(ASTContext.getIdentifier(COM_MODULE_NAME));
+  return ASTContext.testImportModule(mod.get());
+}
+
 bool CompilerInstance::supportCaching() const {
   if (!Invocation.getCASOptions().EnableCaching)
     return false;
@@ -1390,6 +1405,10 @@ ImplicitImportInfo CompilerInstance::getImplicitImportInfo() const {
     if (canImportCxxShim())
       pushImport(CXX_SHIM_NAME, {ImportFlags::ImplementationOnly});
   }
+
+  if (Invocation.getLangOptions().EnableCOMInterop)
+    if (Invocation.shouldImportCOM() && canImportCOM())
+      pushImport(COM_MODULE_NAME);
 
   imports.ShouldImportUnderlyingModule = frontendOpts.ImportUnderlyingModule;
   if (frontendOpts.ModuleHasBridgingHeader) {


### PR DESCRIPTION
While the COM module is not yet available and we are still building out the infrastructure, we can enable the autoloading of the placeholder COM module. The tests will exercise this subsequently.