### PR TITLE
[Embedded] Add mutex flags and recursive support

### DIFF
--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1491,17 +1491,15 @@ static void swift_task_enqueueTaskOnExecutorImpl(AsyncTask *task,
 
 namespace continuationChecking {
 
+#if !SWIFT_CONCURRENCY_EMBEDDED
 enum class State : uint8_t { Uninitialized, On, Off };
 
-#if !SWIFT_CONCURRENCY_EMBEDDED
 static std::atomic<State> CurrentState;
-#endif
 
 static LazyMutex ActiveContinuationsLock;
 static Lazy<std::unordered_set<AsyncTask *>> ActiveContinuations;
 
 static bool isEnabled() {
-#if !SWIFT_CONCURRENCY_EMBEDDED
   auto state = CurrentState.load(std::memory_order_relaxed);
   if (state == State::Uninitialized) {
     bool enabled =
@@ -1510,12 +1508,11 @@ static bool isEnabled() {
     CurrentState.store(state, std::memory_order_relaxed);
   }
   return state == State::On;
-#else
-  return false;
-#endif
 }
+#endif
 
 static void init(AsyncTask *task) {
+#if !SWIFT_CONCURRENCY_EMBEDDED
   if (!isEnabled())
     return;
 
@@ -1527,9 +1524,11 @@ static void init(AsyncTask *task) {
         0,
         "Initializing continuation for task %p that was already initialized.\n",
         task);
+#endif
 }
 
 static void willResume(AsyncTask *task) {
+#if !SWIFT_CONCURRENCY_EMBEDDED
   if (!isEnabled())
     return;
 
@@ -1541,6 +1540,7 @@ static void willResume(AsyncTask *task) {
         "Resuming continuation for task %p that is not awaited "
         "(may have already been resumed).\n",
         task);
+#endif
 }
 
 } // namespace continuationChecking

--- a/stdlib/public/EmbeddedPlatform/EmbeddedPlatformSingleThreaded.swift
+++ b/stdlib/public/EmbeddedPlatform/EmbeddedPlatformSingleThreaded.swift
@@ -12,38 +12,43 @@
 
 fileprivate struct SingleThreadedMutex {
   var checked: Bool
-  var locked: Bool
+  var recursive: Bool
+  var lockCount: UInt
 }
 
 @implementation @c
 public func _swift_mutex_init(
   _ mutex: UnsafeMutableRawPointer,
-  _ checked: Int
+  _ flags: SwiftMutexFlags
 ) {
   let storage = mutex.assumingMemoryBound(to: SingleThreadedMutex.self)
   storage.pointee = SingleThreadedMutex(
-    checked: checked != 0,
-    locked: false)
+    checked: flags.contains(.checked),
+    recursive: flags.contains(.recursive),
+    lockCount: 0)
 }
 
 @implementation @c
 public func _swift_mutex_destroy(_ mutex: UnsafeMutableRawPointer) {
   let storage = mutex.assumingMemoryBound(to: SingleThreadedMutex.self)
-  if storage.pointee.checked && storage.pointee.locked {
+  if storage.pointee.checked && storage.pointee.lockCount != 0 {
     fatalError("destroying a locked mutex")
   }
 
-  storage.pointee = SingleThreadedMutex(checked: false, locked: false)
+  storage.pointee = SingleThreadedMutex(
+    checked: false,
+    recursive: false,
+    lockCount: 0)
 }
 
 @implementation @c
 public func _swift_mutex_lock(_ mutex: UnsafeMutableRawPointer) {
   let storage = mutex.assumingMemoryBound(to: SingleThreadedMutex.self)
   if storage.pointee.checked {
-    if storage.pointee.locked {
+    if storage.pointee.lockCount != 0 && !storage.pointee.recursive {
       fatalError("locking an already locked mutex")
     }
-    storage.pointee.locked = true
+    storage.pointee.lockCount += 1
   }
 }
 
@@ -51,10 +56,10 @@ public func _swift_mutex_lock(_ mutex: UnsafeMutableRawPointer) {
 public func _swift_mutex_unlock(_ mutex: UnsafeMutableRawPointer) {
   let storage = mutex.assumingMemoryBound(to: SingleThreadedMutex.self)
   if storage.pointee.checked {
-    if !storage.pointee.locked {
+    if storage.pointee.lockCount == 0 {
       fatalError("unlocking an unlocked mutex")
     }
-    storage.pointee.locked = false
+    storage.pointee.lockCount -= 1
   }
 }
 
@@ -62,10 +67,10 @@ public func _swift_mutex_unlock(_ mutex: UnsafeMutableRawPointer) {
 public func _swift_mutex_tryLock(_ mutex: UnsafeMutableRawPointer) -> Int {
   let storage = mutex.assumingMemoryBound(to: SingleThreadedMutex.self)
   if storage.pointee.checked {
-    if storage.pointee.locked {
+    if storage.pointee.lockCount != 0 && !storage.pointee.recursive {
       return 0
     }
-    storage.pointee.locked = true
+    storage.pointee.lockCount += 1
   }
   return 1
 }

--- a/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
+++ b/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
@@ -93,7 +93,7 @@ typedef unsigned long long __swift_options_t;
  * entrypoints might be optional, where the entrypoint is needed only when
  * certain Swift functionality is used.
  */
-#define EMBEDDED_SWIFT_PLATFORM_VERSION_MINOR 0
+#define EMBEDDED_SWIFT_PLATFORM_VERSION_MINOR 1
 
 /**
  * Determine the version of the platform abstraction layer that the Embedded
@@ -136,6 +136,26 @@ typedef enum EMBEDDED_SWIFT_OPTION_SET: __swift_options_t {
    */
   SWIFT_FREE_NONE EMBEDDED_SWIFT_NAME(none) = 0,
 } swift_free_flags_t EMBEDDED_SWIFT_NAME(SwiftFreeFlags);
+
+/**
+ * Options provided to the Swift mutex initialization function.
+ */
+typedef enum EMBEDDED_SWIFT_OPTION_SET: __swift_options_t {
+  /**
+   * No options.
+   */
+  SWIFT_MUTEX_NONE EMBEDDED_SWIFT_NAME(none) = 0,
+
+  /**
+   * Diagnose mutex misuse when the platform can do so cheaply.
+   */
+  SWIFT_MUTEX_CHECKED EMBEDDED_SWIFT_NAME(checked) = 0x01,
+
+  /**
+   * Allow the same execution context to acquire the mutex recursively.
+   */
+  SWIFT_MUTEX_RECURSIVE EMBEDDED_SWIFT_NAME(recursive) = 0x02
+} swift_mutex_flags_t EMBEDDED_SWIFT_NAME(SwiftMutexFlags);
 
 /**
  * Allocates memory and returns the resulting pointer.
@@ -297,20 +317,19 @@ void * EMBEDDED_SWIFT_NULLABLE _swift_getExclusivityTLS(void);
 void _swift_setExclusivityTLS(void * EMBEDDED_SWIFT_NULLABLE ptr);
 
 /**
- * Initializes a non-recursive mutex.
+ * Initializes a mutex.
  *
  * Parameters:
  *   - `mutex`: opaque caller-owned mutex storage initialized by this function
  *     and later passed to the other `_swift_mutex_*` functions. The contents
  *     are private to the platform implementation. The storage is at least six
  *     pointer-sized words and has pointer alignment.
- *   - `checked`: nonzero if the platform should diagnose mutex misuse when it
- *     can do so cheaply.
+ *   - `flags`: flags controlling mutex behavior.
  *
  * This function is required when using Synchronization.Mutex.
  */
 void _swift_mutex_init(void * EMBEDDED_SWIFT_NONNULL mutex,
-                       __swift_ptrdiff_t checked);
+                       swift_mutex_flags_t flags);
 
 /**
  * Destroys a mutex initialized by `_swift_mutex_init`.
@@ -318,18 +337,17 @@ void _swift_mutex_init(void * EMBEDDED_SWIFT_NONNULL mutex,
 void _swift_mutex_destroy(void * EMBEDDED_SWIFT_NONNULL mutex);
 
 /**
- * Acquires a non-recursive mutex, blocking or spinning until ownership is
- * obtained.
+ * Acquires a mutex, blocking or spinning until ownership is obtained.
  */
 void _swift_mutex_lock(void * EMBEDDED_SWIFT_NONNULL mutex);
 
 /**
- * Releases a non-recursive mutex held by the current execution context.
+ * Releases a mutex held by the current execution context.
  */
 void _swift_mutex_unlock(void * EMBEDDED_SWIFT_NONNULL mutex);
 
 /**
- * Attempts to acquire a non-recursive mutex without blocking.
+ * Attempts to acquire a mutex without blocking.
  *
  * Returns nonzero if the mutex was acquired, or zero if it was not acquired.
  */

--- a/stdlib/public/Synchronization/Mutex/EmbeddedImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/EmbeddedImpl.swift
@@ -18,7 +18,7 @@ internal typealias _SwiftEmbeddedMutex = [6 of UInt]
 @usableFromInline
 internal func _swift_mutex_init(
   _ mutex: UnsafeMutableRawPointer,
-  _ checked: Int
+  _ flags: CUnsignedLongLong
 )
 
 @_extern(c, "_swift_mutex_destroy")

--- a/test/embedded/embedded-platform-single-threaded-mutex.swift
+++ b/test/embedded/embedded-platform-single-threaded-mutex.swift
@@ -23,7 +23,7 @@
 // REQUIRES: swift_feature_Extern
 
 @_extern(c, "_swift_mutex_init")
-func _swift_mutex_init(_: UnsafeMutableRawPointer, _: Int)
+func _swift_mutex_init(_: UnsafeMutableRawPointer, _: CUnsignedLongLong)
 
 @_extern(c, "_swift_mutex_destroy")
 func _swift_mutex_destroy(_: UnsafeMutableRawPointer)
@@ -50,29 +50,32 @@ func withMutexStorage(_ body: (UnsafeMutableRawPointer) -> Void) {
   }
 }
 
+let checked: CUnsignedLongLong = 0x01
+let recursive: CUnsignedLongLong = 0x02
+
 @main
 struct Main {
   static func main() {
 #if LOCK_LOCKED
     withMutexStorage { mutex in
-      _swift_mutex_init(mutex, 1)
+      _swift_mutex_init(mutex, checked)
       _swift_mutex_lock(mutex)
       _swift_mutex_lock(mutex)
     }
 #elseif UNLOCK_UNLOCKED
     withMutexStorage { mutex in
-      _swift_mutex_init(mutex, 1)
+      _swift_mutex_init(mutex, checked)
       _swift_mutex_unlock(mutex)
     }
 #elseif DESTROY_LOCKED
     withMutexStorage { mutex in
-      _swift_mutex_init(mutex, 1)
+      _swift_mutex_init(mutex, checked)
       _swift_mutex_lock(mutex)
       _swift_mutex_destroy(mutex)
     }
 #else
     withMutexStorage { mutex in
-      _swift_mutex_init(mutex, 1)
+      _swift_mutex_init(mutex, checked)
       check(_swift_mutex_tryLock(mutex) != 0)
       check(_swift_mutex_tryLock(mutex) == 0)
       _swift_mutex_unlock(mutex)
@@ -83,7 +86,7 @@ struct Main {
 
       _swift_mutex_destroy(mutex)
 
-      _swift_mutex_init(mutex, 1)
+      _swift_mutex_init(mutex, checked)
       check(_swift_mutex_tryLock(mutex) != 0)
       _swift_mutex_unlock(mutex)
       _swift_mutex_destroy(mutex)
@@ -93,6 +96,17 @@ struct Main {
       _swift_mutex_init(mutex, 0)
       _swift_mutex_lock(mutex)
       check(_swift_mutex_tryLock(mutex) != 0)
+      _swift_mutex_unlock(mutex)
+      _swift_mutex_unlock(mutex)
+      _swift_mutex_destroy(mutex)
+    }
+
+    withMutexStorage { mutex in
+      _swift_mutex_init(mutex, checked | recursive)
+      _swift_mutex_lock(mutex)
+      _swift_mutex_lock(mutex)
+      check(_swift_mutex_tryLock(mutex) != 0)
+      _swift_mutex_unlock(mutex)
       _swift_mutex_unlock(mutex)
       _swift_mutex_unlock(mutex)
       _swift_mutex_destroy(mutex)

--- a/test/embedded/synchronization-mutex.swift
+++ b/test/embedded/synchronization-mutex.swift
@@ -21,11 +21,11 @@ func mutexWord(
 @_cdecl("_swift_mutex_init")
 public func test_swift_mutex_init(
   _ mutex: UnsafeMutableRawPointer,
-  _ checked: Int
+  _ flags: CUnsignedLongLong
 ) {
   print("mutex.init")
-  if checked != 0 {
-    print("unexpected checked mutex")
+  if flags != 0 {
+    print("unexpected mutex flags")
   }
   mutexWord(mutex).pointee = 0x51
 }


### PR DESCRIPTION
Add SwiftMutexFlags to the EmbeddedPlatform mutex hook so callers can request checked and recursive mutex behavior without introducing a separate recursive mutex entrypoint.

Update the single-threaded EmbeddedPlatform implementation to track recursive lock depth, update the embedded Synchronization mutex hook declaration to match the flags-shaped ABI, and extend the embedded mutex tests to cover recursive checked behavior.

Also avoid compiling the continuation-checking LazyMutex state in embedded Concurrency builds, where unchecked-continuation tracking is disabled.

This is a follow-up from conversations in #89707.