### PR TITLE
InstructionDeleter: salvage debug info in the right order

### DIFF
--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -112,11 +112,9 @@ transferNodesFromList(llvm::ilist_traits<SILInstruction> &L2,
 /// block and deletes it.
 ///
 void SILInstruction::eraseFromParent() {
-#ifndef NDEBUG
   for (auto result : getResults()) {
-    assert(result->use_empty() && "Uses of SILInstruction remain at deletion.");
+    ASSERT(result->use_empty() && "Uses of SILInstruction remain at deletion.");
   }
-#endif
   getParent()->erase(this);
 }
 

--- a/lib/SILOptimizer/Utils/InstructionDeleter.cpp
+++ b/lib/SILOptimizer/Utils/InstructionDeleter.cpp
@@ -12,6 +12,7 @@
 
 #include "swift/SILOptimizer/Utils/InstructionDeleter.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/SIL/NodeDatastructures.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/Test.h"
 #include "swift/SILOptimizer/Utils/ConstExpr.h"
@@ -232,13 +233,31 @@ void InstructionDeleter::deleteWithUses(SILInstruction *inst, bool fixLifetimes,
   // Cannot fix operand lifetimes in non-ownership SIL.
   assert(!fixLifetimes || inst->getFunction()->hasOwnership());
 
+  // First, salvage debug info...
+  SmallVector<SILInstruction *, 4> toSalvage;
+  toSalvage.push_back(inst);
+  for (unsigned idx = 0; idx < toSalvage.size(); ++idx) {
+    for (SILValue result : toSalvage[idx]->getResults()) {
+      for (Operand *use : result->getUses()) {
+        SILInstruction *user = use->getUser();
+        toSalvage.push_back(user);
+      }
+    }
+  }
+  for (auto inst : llvm::reverse(toSalvage)) {
+    swift::salvageDebugInfo(inst);
+  }
+
+  // ... then collect the instructions to delete.
+  // We need to do that separately, because `salvageDebugInfo` can insert new
+  // `debug_value` uses, which need to be deleted as well.
+
   // Recursively visit all uses while growing toDeleteInsts in def-use order and
   // dropping dead operands.
   SmallVector<SILInstruction *, 4> toDeleteInsts;
   SmallVector<Operand *, 4> toDropUses;
 
   toDeleteInsts.push_back(inst);
-  swift::salvageDebugInfo(inst);
   for (unsigned idx = 0; idx < toDeleteInsts.size(); ++idx) {
     for (SILValue result : toDeleteInsts[idx]->getResults()) {
       // Temporary use vector to avoid iterator invalidation.
@@ -251,7 +270,6 @@ void InstructionDeleter::deleteWithUses(SILInstruction *inst, bool fixLifetimes,
 
         toDeleteInsts.push_back(user);
         toDropUses.push_back(use);
-        swift::salvageDebugInfo(user);
       }
     }
   }

--- a/test/SILOptimizer/let_properties_opts.sil
+++ b/test/SILOptimizer/let_properties_opts.sil
@@ -17,7 +17,7 @@ struct Point {
 
 class HasCenter {
   let centerPoint: Point = Point(x: 0, y: 0)
-  public func getCenter() -> Int64
+  public func getCenter() -> Builtin.Int64
 }
 
 sil hidden [ossa] @$s19let_properties_opts5PointV1x1yACSi_SitcfC : $@convention(method) (Int64, Int64, @thin Point.Type) -> Point {
@@ -51,19 +51,23 @@ bb0(%0 : @guaranteed $HasCenter):
 }
 
 // HasCenter.getCenter()
-// CHECK-LABEL: sil hidden [ossa] @$s19let_properties_opts9HasCenterC9getCenterSiyF : $@convention(method) (@guaranteed HasCenter) -> Int64 {
+// CHECK-LABEL: sil hidden [ossa] @$s19let_properties_opts9HasCenterC9getCenterSiyF :
 // CHECK: [[LIT:%.*]] = integer_literal $Builtin.Int64, 0
 // CHECK: [[INT:%.*]] = struct $Int64 ([[LIT]] : $Builtin.Int64)
 // CHECK: [[PNT:%.*]] = struct $Point ([[INT]] : $Int64, [[INT]] : $Int64)
 // CHECK: [[X:%.*]] = struct_extract [[PNT]] : $Point, #Point.x
-// CHECK: return [[X]] : $Int64
+// CHECK: [[V:%.*]] = struct_extract [[X]] : $Int64, #Int64._value
+// CHECK: return [[V]]
 // CHECK-LABEL: } // end sil function '$s19let_properties_opts9HasCenterC9getCenterSiyF'
-sil hidden [ossa] @$s19let_properties_opts9HasCenterC9getCenterSiyF : $@convention(method) (@guaranteed HasCenter) -> Int64 {
+sil hidden [ossa] @$s19let_properties_opts9HasCenterC9getCenterSiyF : $@convention(method) (@guaranteed HasCenter) -> Builtin.Int64 {
 bb0(%0 : @guaranteed $HasCenter):
   %1 = ref_element_addr %0 : $HasCenter, #HasCenter.centerPoint
   %2 = struct_element_addr %1 : $*Point, #Point.x
-  %3 = load [trivial] %2 : $*Int64
-  return %3 : $Int64
+  %3 = struct_element_addr %2, #Int64._value
+  debug_value %3, var, name "z"
+  debug_value %2, var, name "x"
+  %4 = load [trivial] %3
+  return %4
 }
 
 // HasCenter.init()


### PR DESCRIPTION
`salvageDebugInfo` might create new users. When deleting instructions, including their users, we need to salvage debug info in reverse order.
And afterward we can collect all the instructions to delete.
We need to do that separately, because `salvageDebugInfo` can insert new `debug_value` uses, which need to be deleted as well.

Fixes a compiler crash in LetPropertiesOpt
rdar://181075714