### PR TITLE
[NFC][Concurrency] Update task cancellation documentation

### DIFF
--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -244,7 +244,7 @@ extension Task where Success == Never, Failure == Never {
   /// Cancellation may be suppressed by an active task cancellation shield
   /// (``withTaskCancellationShield(operation:)-(()->Value)``). 
   /// If cancellation has been suppressed by an active task cancellation shield, 
-  /// reading `isCancelled` on a cancelled task returns false.
+  /// reading `isCancelled` on a cancelled task returns `false`.
   /// 
   /// - SeeAlso: ``checkCancellation()``
   /// - SeeAlso: ``withTaskCancellationShield(operation:)-(()->Value)``

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -242,9 +242,10 @@ extension Task where Success == Never, Failure == Never {
   /// ### Interaction with Task Cancellation Shields
   ///
   /// Cancellation may be suppressed by an active task cancellation shield
-  /// (``withTaskCancellationShield(operation:)-(()->Value)``), which may cause `isCancelled`
-  /// to return `false` even though the task has been cancelled externally.
-  ///
+  /// (``withTaskCancellationShield(operation:)-(()->Value)``). 
+  /// If cancellation has been suppressed by an active task cancellation shield, 
+  /// reading `isCancelled` on a cancelled task returns false.
+  /// 
   /// - SeeAlso: ``checkCancellation()``
   /// - SeeAlso: ``withTaskCancellationShield(operation:)-(()->Value)``
   public static var isCancelled: Bool {
@@ -267,7 +268,7 @@ extension Task where Success == Never, Failure == Never {
   /// ### Interaction with Task Cancellation Shields
   ///
   /// Cancellation may be suppressed by an active task cancellation shield
-  /// (``withTaskCancellationShield(operation:)-(()->Value)``), which may cause `checkCancellation()`
+  /// (``withTaskCancellationShield(operation:)-(()->Value)``).
   /// If cancellation has been suppressed by an active task cancellation shield,
   /// calling `checkCancellation()` on a cancelled task doesn't throw an error.
   ///

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -268,7 +268,8 @@ extension Task where Success == Never, Failure == Never {
   ///
   /// Cancellation may be suppressed by an active task cancellation shield
   /// (``withTaskCancellationShield(operation:)-(()->Value)``), which may cause `checkCancellation()`
-  /// not to throw even though the task has been cancelled externally.
+  /// If cancellation has been suppressed by an active task cancellation shield,
+  /// calling `checkCancellation()` on a cancelled task doesn't throw an error.
   ///
   /// - SeeAlso: ``Task/isCancelled-type.property``
   /// - SeeAlso: ``withTaskCancellationShield(operation:)-(()->Value)``

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -264,7 +264,14 @@ extension Task where Success == Never, Failure == Never {
   ///
   /// The error is always an instance of `CancellationError`.
   ///
-  /// - SeeAlso: `isCancelled()`
+  /// ### Interaction with Task Cancellation Shields
+  ///
+  /// Cancellation may be suppressed by an active task cancellation shield
+  /// (``withTaskCancellationShield(operation:)-(()->Value)``), which may cause `checkCancellation()`
+  /// not to throw even though the task has been cancelled externally.
+  ///
+  /// - SeeAlso: ``Task/isCancelled-type.property``
+  /// - SeeAlso: ``withTaskCancellationShield(operation:)-(()->Value)``
   @_unavailableInEmbedded
   public static func checkCancellation() throws {
     if Task<Never, Never>.isCancelled {
@@ -275,7 +282,7 @@ extension Task where Success == Never, Failure == Never {
 
 /// An error that indicates a task was canceled.
 ///
-/// This error is also thrown automatically by `Task.checkCancellation()`,
+/// This error is also thrown automatically by ``checkCancellation()``,
 /// if the current task has been canceled.
 @available(SwiftStdlib 5.1, *)
 public struct CancellationError: Error {

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -219,7 +219,7 @@ extension Task {
   /// - SeeAlso: ```Task/isCancelled-type.property``
   /// - SeeAlso: ``Task/checkCancellation()``
   /// - SeeAlso: ``Task/hasActiveCancellationShield``
-  /// - SeeAlso: ``withTaskCancellationShield(operation:)-(()->Value)``
+  /// - SeeAlso: ``withTaskCancellationShield(operation:)-2lzl8``
   @_transparent
   public var isCancelled: Bool {
     // This is @available(SwiftStdlib 6.4, *) but can't use SwiftStdlib in transparent function
@@ -245,7 +245,7 @@ extension Task where Success == Never, Failure == Never {
   /// reading `isCancelled` on a cancelled task returns `false`.
   /// 
   /// - SeeAlso: ``checkCancellation()``
-  /// - SeeAlso: ``withTaskCancellationShield(operation:)-(()->Value)``
+  /// - SeeAlso: ``withTaskCancellationShield(operation:)-2lzl8``
   public static var isCancelled: Bool {
     unsafe withUnsafeCurrentTask { task in
       if #available(SwiftStdlib 6.4, *) {
@@ -269,7 +269,7 @@ extension Task where Success == Never, Failure == Never {
   /// calling `checkCancellation()` on a cancelled task doesn't throw an error.
   ///
   /// - SeeAlso: ``Task/isCancelled-type.property``
-  /// - SeeAlso: ``withTaskCancellationShield(operation:)-(()->Value)``
+  /// - SeeAlso: ``withTaskCancellationShield(operation:)-2lzl8``
   @_unavailableInEmbedded
   public static func checkCancellation() throws {
     if Task<Never, Never>.isCancelled {
@@ -493,7 +493,7 @@ public func withTaskCancellationShield<Value, Failure>(
 @available(SwiftStdlib 6.4, *)
 extension Task where Success == Never, Failure == Never {
   /// Checks if the current task is executing in a scope with a task cancellation shield activated by the
-  /// ``withTaskCancellationShield(operation:)-(()->Value)`` function.
+  /// ``withTaskCancellationShield(operation:)-2lzl8`` function.
   ///
   /// An active task cancellation shield prevents a task's ability to observe if it was cancelled,
   /// i.e. the ``Task/isCancelled-type.property`` property will always return `false` when the task is executing
@@ -507,7 +507,7 @@ extension Task where Success == Never, Failure == Never {
   /// Cancellation shields are not automatically inherited by child tasks; each child task must install
   /// its own shield if needed if it, independently, wanted to ignore cancellation during a specific scope.
   ///
-  /// - SeeAlso: ``withTaskCancellationShield(operation:)-(()->Value)``
+  /// - SeeAlso: ``withTaskCancellationShield(operation:)-2lzl8``
   /// - SeeAlso: ``UnsafeCurrentTask/hasActiveCancellationShield``
   @available(SwiftStdlib 6.4, *)
   @export(implementation)

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -241,8 +241,6 @@ extension Task where Success == Never, Failure == Never {
   ///
   /// ### Interaction with Task Cancellation Shields
   ///
-  /// Cancellation may be suppressed by an active task cancellation shield
-  /// (``withTaskCancellationShield(operation:)-(()->Value)``). 
   /// If cancellation has been suppressed by an active task cancellation shield, 
   /// reading `isCancelled` on a cancelled task returns `false`.
   /// 
@@ -267,8 +265,6 @@ extension Task where Success == Never, Failure == Never {
   ///
   /// ### Interaction with Task Cancellation Shields
   ///
-  /// Cancellation may be suppressed by an active task cancellation shield
-  /// (``withTaskCancellationShield(operation:)-(()->Value)``).
   /// If cancellation has been suppressed by an active task cancellation shield,
   /// calling `checkCancellation()` on a cancelled task doesn't throw an error.
   ///


### PR DESCRIPTION
Adds documentation explaining the interaction between the new `withTaskCancellationShield` API and `checkCancellation()`.