### PR TITLE
[Debug Info] Give each inlined polymorphic function its own DISubprogram

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -3351,7 +3351,22 @@ llvm::DIScope *IRGenDebugInfoImpl::getOrCreateScope(const SILDebugScope *DS) {
     if (!FnScope)
       SILFn->setDebugScope(DS);
 
-    auto CachedScope = ScopeCache.find(FnScope);
+    // A polymorphic function can be inlined more than once with different type
+    // substitutions -- most notably once per element of a parameter-pack
+    // expansion, where a single generic specialization is inlined several times
+    // with different concrete types. DWARF stores a parameter's type in the
+    // (single) abstract DISubprogram, so instances that substitute different
+    // concrete types for the same parameter cannot share one subprogram: their
+    // differently-typed (and differently-sized) parameters would otherwise
+    // collide on a single abstract variable. Give each such inlined instance
+    // its own DISubprogram, keyed by its own inlined scope rather than by the
+    // function's canonical scope.
+    bool DistinctInlinedInstance =
+        DS != FnScope && DS->InlinedCallSite &&
+        SILFn->getLoweredFunctionType()->isPolymorphic();
+
+    const SILDebugScope *CacheKey = DistinctInlinedInstance ? DS : FnScope;
+    auto CachedScope = ScopeCache.find(CacheKey);
     if (CachedScope != ScopeCache.end())
       return cast<llvm::DIScope>(CachedScope->second);
 
@@ -3364,7 +3379,11 @@ llvm::DIScope *IRGenDebugInfoImpl::getOrCreateScope(const SILDebugScope *DS) {
         SILFn->isGeneric();
     if (!SILFn->getName().empty() && !SILFn->isZombie() && !genericInEmbedded)
       Fn = IGM.getAddrOfSILFunction(SILFn, NotForDefinition);
-    auto *SP = emitFunction(*SILFn, Fn);
+    auto *SP =
+        DistinctInlinedInstance
+            ? emitFunction(DS, Fn, SILFn->getRepresentation(),
+                           SILFn->getLoweredType(), SILFn->getDeclContext())
+            : emitFunction(*SILFn, Fn);
 
     // Cache it.
     ScopeCache[DS] = llvm::TrackingMDNodeRef(SP);

--- a/test/DebugInfo/variadic-generics-inlined-method.swift
+++ b/test/DebugInfo/variadic-generics-inlined-method.swift
@@ -1,0 +1,57 @@
+// RUN: %target-swift-frontend -emit-ir %s -g -O -parse-as-library -module-name a \
+// RUN:    -o - | %FileCheck %s
+
+// A generic method that is force-inlined once per element of a parameter-pack
+// expansion is inlined multiple times from a single generic specialization,
+// each time with different concrete type arguments (here 'self' is 'Box<Int>'
+// for one instance and 'Box<String>' for another). Those two instances must not
+// be collapsed onto a single abstract DISubprogram
+
+struct Box<Value> {
+  var value: Value
+
+  @inline(__always)
+  func transform<Result>(_ body: (Value) -> Result) -> Result {
+    return body(value)
+  }
+}
+
+@inline(__always)
+func packEngine<each T, each R>(
+  _ items: (repeat Box<each T>),
+  _ logics: repeat (each T) -> each R
+) -> (repeat each R) {
+  return (repeat (each items).transform(each logics))
+}
+
+// The inputs are read from opaque globals so both inlined instances (and hence
+// both 'self' descriptions) survive optimization instead of being folded away.
+public var seed = 21
+public var text = "debug"
+
+// CHECK: define {{.*}} @"$s1a3runSi_SityF"
+public func run() -> (Int, Int) {
+  let input = (Box(value: seed), Box(value: text))
+  return packEngine(input, { $0 &* 2 }, { $0.count })
+}
+
+// The two inlined instances of the 'transform' specialization each get their
+// own 'self' variable, in their own DISubprogram, describing the concrete type
+// they were inlined with -- one 'Box<Int>' and one 'Box<String>' -- rather than
+// collapsing onto a single shared 'self'.
+
+// CHECK-DAG: ![[TRANSFORM_INT:[0-9]+]] = distinct !DISubprogram(name: "transform", {{.*}}DISPFlagDefinition
+// CHECK-DAG: !DILocalVariable(name: "self", arg: 2, scope: ![[TRANSFORM_INT]], {{.*}}type: ![[SELF_INT:[0-9]+]]
+// CHECK-DAG: ![[SELF_INT]] = !DIDerivedType(tag: DW_TAG_const_type, baseType: ![[LAYOUT_INT:[0-9]+]])
+// CHECK-DAG: ![[LAYOUT_INT]] = !DICompositeType(tag: DW_TAG_structure_type, {{.*}}elements: ![[MEMBERS_INT:[0-9]+]]
+// CHECK-DAG: ![[MEMBERS_INT]] = !{![[MEMBER_INT:[0-9]+]]}
+// CHECK-DAG: ![[MEMBER_INT]] = !DIDerivedType(tag: DW_TAG_member, {{.*}}baseType: ![[BOX_INT:[0-9]+]]
+// CHECK-DAG: ![[BOX_INT]] = !DICompositeType(tag: DW_TAG_structure_type, name: "$s1a3BoxVySiGD"
+
+// CHECK-DAG: ![[TRANSFORM_STR:[0-9]+]] = distinct !DISubprogram(name: "transform", {{.*}}DISPFlagDefinition
+// CHECK-DAG: !DILocalVariable(name: "self", arg: 2, scope: ![[TRANSFORM_STR]], {{.*}}type: ![[SELF_STR:[0-9]+]]
+// CHECK-DAG: ![[SELF_STR]] = !DIDerivedType(tag: DW_TAG_const_type, baseType: ![[LAYOUT_STR:[0-9]+]])
+// CHECK-DAG: ![[LAYOUT_STR]] = !DICompositeType(tag: DW_TAG_structure_type, {{.*}}elements: ![[MEMBERS_STR:[0-9]+]]
+// CHECK-DAG: ![[MEMBERS_STR]] = !{![[MEMBER_STR:[0-9]+]]}
+// CHECK-DAG: ![[MEMBER_STR]] = !DIDerivedType(tag: DW_TAG_member, {{.*}}baseType: ![[BOX_STR:[0-9]+]]
+// CHECK-DAG: ![[BOX_STR]] = !DICompositeType(tag: DW_TAG_structure_type, name: "$s1a3BoxVySSGD"


### PR DESCRIPTION
A parameter-pack expansion can force-inline the *same* generic specialization of a function several times, each time bound to different concrete types. The debug-info emitter collapsed all of those inlined instances onto a single abstract DISubprogram, which cannot represent per-instance parameter type.

For example, in the program below

    struct Box<Value> {
        var value: Value

        @inline(__always)
        func transform<Result>(_ body: (Value) -> Result) -> Result {
            let processed = body(value)
            return processed
        }
    }

    @inline(__always)
    func packEngine<each T, each R>(
        _ items: (repeat Box<each T>),
        _ logics: repeat (each T) -> each R
    ) -> (repeat each R) {
        return (repeat (each items).transform(each logics))
    }

    let input = (Box(value: 21), Box(value: "debug"), Box(value: 2.0))
    let results = packEngine(input, { $0 * 2 }, { $0.count }, { $0 > 1.0 })

    if results.0 != 42 || results.1 != 5 || results.2 != true {
        fatalError()
    }

the optimizer produces a single (still generic) specialization of `Box.transform` and inlines it once per pack element. Both inlined instances share one parent SILFunction but bind `self` to differently sized concrete types:

    --- sil_scopes: one specialization (...TG5) inlined twice ---
    sil_scope 16  parent=$s4demo3BoxV9transformyqd__qd__xXElFXe_XeTi5Si_SSQP_Si_SiQPTG5  inlined_at 15

    sil_scope 21  parent=$s4demo3BoxV9transformyqd__qd__xXElFXe_XeTi5Si_SSQP_Si_SiQPTG5  inlined_at 20

    --- debug_value for `self` ---
    debug_value undef : $Builtin.Int64, let, (name "self", loc "demo.swift":4:8), argno 2, type $Box<Int>,    expr op_fragment:#Box.value:op_fragment:#Int._value, transform {
    debug_value %55,                    let, (name "self", loc "demo.swift":4:8), argno 2, type $Box<String>, expr op_fragment:#Box.value:op_fragment:#String._guts, loc "demo.swift":9:12, scope 21

`getOrCreateScope()` keys the DISubprogram by the function's canonical scope, so both instances get the same abstract DISubprogram. DWARF stores a parameter's type once, in that abstract subprogram, so its `self` variable ends up with the type of whichever instance was emitted first (`Box<Int>`, 64 bits). When the `Box<String>` instance (`{i64, ptr}`, 128 bits) is then described, IRGen emits a fragment wider than the variable's type and trips an assert:

    Assertion failed: (SizeInBits < getSizeInBits(Var) && "piece covers entire var"), function emitVariableDeclaration, file IRGenDebugInfo.cpp, line 3894.
    3.	While evaluating request IRGenRequest(IR Generation for file "demo.swift")
    4.	While emitting IR SIL function "@$s4demo3runSi_SityF".

In `getOrCreateScope()`, when a *polymorphic* function appears as an inlined scope (`DS->InlinedCallSite` set), key its DISubprogram by that inlined scope rather than by the function's canonical scope, so each inlined specialization gets its own subprogram.

DWARF with this patch applies looks like this:

    0x0000007a: DW_TAG_subprogram
                  DW_AT_linkage_name ("...9transformyqd__qd__xXElF")
                      // demo.Box.transform<A>((A) -> A1) -> A1
                  DW_AT_name ("transform")
                  DW_AT_type (... "$sqd__D")   // A1
      DW_TAG_formal_parameter  DW_AT_type ("$sxqd__Ignr_D") // (A) -> A1
      DW_TAG_formal_parameter  DW_AT_type ("demo::Box")     // self

    0x000000a2: DW_TAG_subprogram
                  DW_AT_linkage_name ("...9transformyqd__qd__xXElFXe_XeTi5")
                  ... (same two formal_parameters)

    0x000000b6: DW_TAG_subprogram
                  DW_AT_linkage_name ("...9transformyqd__qd__xXElFXe_XeTi5Si_SSQP_Si_SiQPTG5")
                  ... (same two formal_parameters)

    => 3 distinct `transform` DW_TAG_subprogram DIEs

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
