### PR TITLE
[Abstraction layer header] Leave the EMBEDDED_SWIFT_* macros defined

### DIFF
--- a/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
+++ b/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
@@ -348,11 +348,6 @@ __swift_ptrdiff_t _swift_mutex_tryLock(void * EMBEDDED_SWIFT_NONNULL mutex);
  */
 void _swift_exit(__swift_ptrdiff_t code);
 
-#undef EMBEDDED_SWIFT_SINGLE
-#undef EMBEDDED_SWIFT_SIZED_BY
-#undef EMBEDDED_SWIFT_COUNTED_BY
-#undef EMBEDDED_SWIFT_NULLABLE
-#undef EMBEDDED_SWIFT_NONNULL
 #undef EMBEDDED_SWIFT_NAME
 #undef EMBEDDED_SWIFT_OPTION_SET
 


### PR DESCRIPTION
C clients implementing the platform abstraction layer usually want to copy over the declarations directly to implement them. Leave the EMBEDDED_SWIFT_* macros defined to make this possible.

rdar://181041873.
