### PR TITLE
[6.4] Remove tautology referencing error message

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10677,7 +10677,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
             instanceTy->isAnyObject()
                 ? candidate
                 : OverloadChoice::getDecl(instanceTy, decl,
-                                          FunctionRefInfo::singleBaseNameApply());
+                                          functionRefInfo);
 
         const bool invalidMethodRef = isa<FuncDecl>(decl) && !hasInstanceMethods;
         const bool invalidMemberRef = !isa<FuncDecl>(decl) && !hasInstanceMembers;

--- a/test/Constraints/unapplied_method_in_property_init.swift
+++ b/test/Constraints/unapplied_method_in_property_init.swift
@@ -11,12 +11,12 @@ struct S {
   // expected-swift6-error@-2 {{cannot use instance member 'foo' within property initializer; property initializers run before 'self' is available}}
 
   let x2: ((S) -> S).Type = type(of: bar)
-  // expected-error@-1 {{cannot use instance member 'bar' within property initializer; property initializers run before 'self' is available}}
+  // expected-swift5-error@-1 {{cannot convert value of type '((S) -> (S) -> S).Type' to specified type '((S) -> S).Type'}}
+  // expected-swift6-error@-2 {{cannot use instance member 'bar' within property initializer; property initializers run before 'self' is available}}
 
-  // FIXME: https://github.com/swiftlang/swift/issues/89920
+  // https://github.com/swiftlang/swift/issues/89920
   let y1: (S) -> S = foo
-  // expected-error@-1 {{cannot convert value of type '(main.S) -> main.S' to specified type '(main.S) -> main.S'}}
-  // expected-error@-2 {{cannot use instance member 'foo' within property initializer; property initializers run before 'self' is available}}
+  // expected-error@-1 {{cannot use instance member 'foo' within property initializer; property initializers run before 'self' is available}}
 
   let y2: (S) -> S = bar
   // expected-error@-1 {{cannot use instance member 'bar' within property initializer; property initializers run before 'self' is available}}


### PR DESCRIPTION
This is a cherry pick of https://github.com/swiftlang/swift/pull/90382

Explanation:
This addresses an issue in diagnostics that changes how an already selected overloaded method will be considered and displayed, based on the application depth of the ast rather than a default depth that had been in use (and sometimes was incorrect).
Scope:
This can only impact diagnostics and clarifies diagnostics that previously reported messages such as expected type A given type A. It will not impact any correct code.
Issues:
https://github.com/swiftlang/swift/issues/89920
Original PRs:
https://github.com/swiftlang/swift/pull/90382
Risk:
Low risk as it only changes diagnostics behaviour and not correctly compiling code.
Testing:
Has passed CI testing
Reviewers:
hamishknight, xedin
