### PR TITLE
[6.4][Diagnostics] Fix missing diagnostic for init as value

### DIFF
--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -1593,6 +1593,12 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
+  // May have overloaded methods being partially applied, causing ambiguity that
+  // does not currently impact diagnostic produced
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
+    return diagnose(*commonFixes.front().first);
+  }
+
   static AllowInvalidPartialApplication *create(bool isWarning,
                                                 ConstraintSystem &cs,
                                                 ConstraintLocator *locator);

--- a/test/expr/postfix/init/unqualified.swift
+++ b/test/expr/postfix/init/unqualified.swift
@@ -7,7 +7,7 @@ class Aaron {
     func foo() {
       // Make sure we recover and assume 'self.init'.
       // expected-error@+2 {{initializer expression requires explicit access; did you mean to prepend it with 'self.'?}} {{11-11=self.}}
-      // expected-error@+1 {{failed to produce diagnostic for expression}}
+      // expected-error@+1 {{cannot reference 'self.init' initializer delegation as function value}}
       _ = init
     }
   }
@@ -48,7 +48,7 @@ class Theodosia: Aaron {
 
     // Make sure we recover and assume 'self.init'.
     // expected-error@+2 {{initializer expression requires explicit access; did you mean to prepend it with 'self.'?}} {{22-22=self.}}
-    // expected-error@+1 {{failed to produce diagnostic for expression}}
+    // expected-error@+1 {{cannot reference 'self.init' initializer delegation as function value}}
     func foo() { _ = init }
   }
 


### PR DESCRIPTION
This is a cherry pick of #90335

Explanation:
This addresses an issue in diagnostics that selects a diagnostic for init bound to a value in the presence of overloaded inits, which previously failed to produce a diagnostic.
Scope:
This can only impact diagnostics and turns a please submit bug report into an actionable diagnostic. It will not impact any correct code.
Issues:
Original PRs:
https://github.com/swiftlang/swift/pull/90335
Risk:
Low risk as it only changes diagnostics behaviour and not correctly compiling code.
Testing:
Has passed CI testing
Reviewers:
hamishknight, xedin