### PR TITLE
AST,Sema: synthesize `IUnknown`, `ISwiftObject` conformances

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2230,6 +2230,12 @@ ERROR(attr_com_protocol_unexpected_arg, none,
       "'@com' on a protocol must only have 'interface:'; '%0' is not allowed", (StringRef))
 ERROR(attr_com_class_unexpected_iid, none,
       "'@com' on a class must not have 'interface:'; use 'implementation:' instead", ())
+ERROR(attr_com_explicit_iswiftobject, none,
+      "'ISwiftObject' conformance is compiler-managed and cannot be declared explicitly", ())
+NOTE(attr_com_iswiftobject_implied, none,
+     "'@com' automatically provides 'ISwiftObject' conformance", ())
+ERROR(com_module_missing_type, none,
+      "type '%0' not found in the 'COM' module", (StringRef))
 
 // @_staticExclusiveOnly
 ERROR(attr_static_exclusive_only_disabled,none,

--- a/lib/AST/ConformanceLookup.cpp
+++ b/lib/AST/ConformanceLookup.cpp
@@ -773,6 +773,19 @@ LookupConformanceRequest::evaluate(Evaluator &evaluator,
       } else {
         return ProtocolConformanceRef::forMissingOrInvalid(type, protocol);
       }
+    } else if (protocol->isSpecificProtocol(KnownProtocolKind::IUnknown) ||
+               protocol->isSpecificProtocol(KnownProtocolKind::ISwiftObject)) {
+      // Synthesize COM protocol conformances for @com classes.
+      auto KP = protocol->isSpecificProtocol(KnownProtocolKind::IUnknown)
+                    ? KnownProtocolKind::IUnknown
+                    : KnownProtocolKind::ISwiftObject;
+      ImplicitKnownProtocolConformanceRequest request{nominal, KP};
+      if (auto conformance = evaluateOrDefault(ctx.evaluator, request, nullptr)) {
+        conformances.clear();
+        conformances.push_back(conformance);
+      } else {
+        return ProtocolConformanceRef::forMissingOrInvalid(type, protocol);
+      }
     } else {
       // Was unable to infer the missing conformance.
       return ProtocolConformanceRef::forMissingOrInvalid(type, protocol);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7880,7 +7880,8 @@ void ProtocolDecl::computeKnownProtocolKind() const {
       !module->getName().is("_Differentiation") &&
       !module->getName().is("_Concurrency") &&
       !module->getName().is("Distributed") && 
-      !module->getName().is("Cxx")) {
+      !module->getName().is("Cxx") &&
+      !module->getName().is("COM")) {
     const_cast<ProtocolDecl *>(this)->Bits.ProtocolDecl.KnownProtocol = 1;
     return;
   }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2487,7 +2487,7 @@ void AttributeChecker::visitCOMAttr(COMAttr *attr) {
       attr->setInvalid();
       return;
     }
-  } else if (isa<ClassDecl>(D)) {
+  } else if (auto *CD = dyn_cast<ClassDecl>(D)) {
     if (!attr->IID.empty()) {
       diagnose(attr->getLocation(), diag::attr_com_class_unexpected_iid);
       attr->setInvalid();
@@ -2500,9 +2500,26 @@ void AttributeChecker::visitCOMAttr(COMAttr *attr) {
       attr->setInvalid();
       return;
     }
-  }
 
-  // TODO(compnerd) ensure that `ISwiftObject` is not conformed to.
+    const ProtocolDecl *ISO = Ctx.getProtocol(KnownProtocolKind::ISwiftObject);
+    if (!ISO) {
+      diagnose(SourceLoc(), diag::com_module_missing_type, "ISwiftObject");
+      return;
+    }
+
+    bool AnyObject = false;
+    InvertibleProtocolSet inverses;
+    auto inherited =
+        getDirectlyInheritedNominalTypeDecls(CD, inverses, AnyObject);
+    const auto &entry =
+        llvm::find_if(inherited, [ISO](const auto &E) { return E.Item == ISO; });
+    if (entry != inherited.end()) {
+      diagnose(entry->Loc, diag::attr_com_explicit_iswiftobject);
+      diagnose(attr->getLocation(), diag::attr_com_iswiftobject_implied);
+      attr->setInvalid();
+      return;
+    }
+  }
 }
 
 void AttributeChecker::visitExposeAttr(ExposeAttr *attr) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3147,6 +3147,47 @@ ExtendedTypeRequest::evaluate(Evaluator &eval, ExtensionDecl *ext) const {
   return extendedType;
 }
 
+namespace {
+ProtocolConformance *deriveImplicitCOMConformance(NominalTypeDecl *NTD,
+                                                  KnownProtocolKind KP) {
+  const auto *CD = dyn_cast<ClassDecl>(NTD);
+  if (CD == nullptr)
+    return nullptr;
+
+  if (!CD->getAttrs().hasAttribute<COMAttr>())
+    return nullptr;
+
+  ASTContext &context = NTD->getASTContext();
+  auto *protocol = context.getProtocol(KP);
+  if (protocol == nullptr)
+    return nullptr;
+
+  // Ensure that `ISwiftObject` is always compiler managed.
+  if (KP == KnownProtocolKind::ISwiftObject) {
+    llvm::SmallVector<ProtocolConformance *, 2> conformances;
+    NTD->lookupConformance(protocol, conformances);
+    if (!conformances.empty()) {
+      context.Diags.diagnose(CD->getLoc(), diag::attr_com_explicit_iswiftobject);
+      if (auto *A = CD->getAttrs().getAttribute<COMAttr>())
+        context.Diags.diagnose(A->getLocation(),
+                               diag::attr_com_iswiftobject_implied);
+      return conformances.front();
+    }
+  }
+
+  auto conformance =
+      context.getNormalConformance(NTD->getDeclaredInterfaceType(), protocol,
+                                   NTD->getLoc(), /*inheritedTypeRepr=*/nullptr,
+                                   /*conformanceDC=*/NTD,
+                                   ProtocolConformanceState::Complete,
+                                   ProtocolConformanceOptions());
+  conformance->setSourceKindAndImplyingConformance(ConformanceEntryKind::Synthesized,
+                                                   nullptr);
+  NTD->registerProtocolConformance(conformance, /*synthesized=*/true);
+  return conformance;
+}
+}
+
 //----------------------------------------------------------------------------//
 // ImplicitKnownProtocolConformanceRequest
 //----------------------------------------------------------------------------//
@@ -3159,6 +3200,9 @@ ImplicitKnownProtocolConformanceRequest::evaluate(Evaluator &evaluator,
     return deriveImplicitSendableConformance(evaluator, nominal);
   case KnownProtocolKind::BitwiseCopyable:
     return deriveImplicitBitwiseCopyableConformance(nominal);
+  case KnownProtocolKind::IUnknown:
+  case KnownProtocolKind::ISwiftObject:
+    return deriveImplicitCOMConformance(nominal, kp);
   default:
     llvm_unreachable("non-implicitly derived KnownProtocol");
   }

--- a/test/Inputs/COM.swift
+++ b/test/Inputs/COM.swift
@@ -1,0 +1,23 @@
+public struct GUID {
+  public var data1: UInt32
+  public var data2: UInt16
+  public var data3: UInt16
+  public var data4: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)
+
+  public init(data1: UInt32, data2: UInt16, data3: UInt16,
+              data4: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)) {
+    self.data1 = data1
+    self.data2 = data2
+    self.data3 = data3
+    self.data4 = data4
+  }
+}
+
+public typealias IID = GUID
+public typealias CLSID = GUID
+
+@com(interface: "00000000-0000-0000-C000-000000000046")
+public protocol IUnknown: AnyObject { }
+
+@com(interface: "8e369447-5188-5ada-b9ec-8fcb732d226b")
+public protocol ISwiftObject: IUnknown { }

--- a/test/Parse/COM.swift
+++ b/test/Parse/COM.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend -parse -verify -enable-experimental-com-interop %s
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -enable-experimental-com-interop -emit-module -module-name COM -emit-module-path %t/COM.swiftmodule %S/../Inputs/COM.swift
+// RUN: %target-swift-frontend -enable-experimental-com-interop -parse -verify %s -I %t
 
 @com(interface: "00000000-0000-0000-C000-000000000046")
 protocol IUnknown: AnyObject { }

--- a/test/Parse/COMAttr.swift
+++ b/test/Parse/COMAttr.swift
@@ -1,8 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module-path %t/COM.swiftmodule -module-name COM -enable-experimental-com-interop %S/Inputs/COM.swift
+// RUN: %target-swift-frontend -emit-module-path %t/COM.swiftmodule -module-name COM -enable-experimental-com-interop %S/../Inputs/COM.swift
 // RUN: %target-swift-frontend -enable-experimental-com-interop -I %t -dump-ast %s 2>&1 | %FileCheck %s
-
-import COM
 
 @com(interface: "00000000-0000-0000-0000-000000000000")
 protocol IInterface: IUnknown {
@@ -12,47 +10,47 @@ protocol IInterface: IUnknown {
 class CClass1 {
 }
 
-// CHECK:   (class_decl {{.*}} "CClass1" interface_type="CClass1.Type" access=internal non_resilient
+// CHECK-LABEL: "CClass1" interface_type="CClass1.Type" access=internal non_resilient
 // CHECK:     (com_attr {{.*}} threading=apartment)
 
 @com(implementation: "00000000-0000-0000-0000-000000000000")
 class CClass2: IUnknown {
 }
 
-// CHECK:   (class_decl {{.*}} "CClass2" interface_type="CClass2.Type" access=internal non_resilient inherits="IUnknown"
+// CHECK-LABEL: "CClass2" interface_type="CClass2.Type" access=internal non_resilient inherits="IUnknown"
 // CHECK:     (com_attr {{.*}} CLSID="00000000-0000-0000-0000-000000000000" threading=apartment)
 
 @com(implementation: "00000000-0000-0000-0000-000000000000", threading: .free)
 class CClass3: IUnknown {
 }
 
-// CHECK:   (class_decl {{.*}} "CClass3" interface_type="CClass3.Type" access=internal non_resilient inherits="IUnknown"
+// CHECK-LABEL: "CClass3" interface_type="CClass3.Type" access=internal non_resilient inherits="IUnknown"
 // CHECK:     (com_attr {{.*}} CLSID="00000000-0000-0000-0000-000000000000" threading=free)
 
 @com(implementation: "00000000-0000-0000-0000-000000000000", threading: .apartment)
 class CClass4: IUnknown {
 }
 
-// CHECK:   (class_decl {{.*}} "CClass4" interface_type="CClass4.Type" access=internal non_resilient inherits="IUnknown"
+// CHECK-LABEL: "CClass4" interface_type="CClass4.Type" access=internal non_resilient inherits="IUnknown"
 // CHECK:     (com_attr {{.*}} CLSID="00000000-0000-0000-0000-000000000000" threading=apartment)
 
 @com(implementation: "00000000-0000-0000-0000-000000000000", threading: .single)
 class CClass5: IUnknown {
 }
 
-// CHECK:   (class_decl {{.*}} "CClass5" interface_type="CClass5.Type" access=internal non_resilient inherits="IUnknown"
+// CHECK-LABEL: "CClass5" interface_type="CClass5.Type" access=internal non_resilient inherits="IUnknown"
 // CHECK:     (com_attr {{.*}} CLSID="00000000-0000-0000-0000-000000000000" threading=single)
 
 @com(implementation: "00000000-0000-0000-0000-000000000000", threading: .both)
 class CClass6: IUnknown {
 }
 
-// CHECK:   (class_decl {{.*}} "CClass6" interface_type="CClass6.Type" access=internal non_resilient inherits="IUnknown"
+// CHECK-LABEL: "CClass6" interface_type="CClass6.Type" access=internal non_resilient inherits="IUnknown"
 // CHECK:     (com_attr {{.*}} CLSID="00000000-0000-0000-0000-000000000000" threading=both)
 
 @com(implementation: "00000000-0000-0000-0000-000000000000", threading: .neutral)
 class CClass7: IUnknown {
 }
 
-// CHECK:   (class_decl {{.*}} "CClass7" interface_type="CClass7.Type" access=internal non_resilient inherits="IUnknown"
+// CHECK-LABEL: "CClass7" interface_type="CClass7.Type" access=internal non_resilient inherits="IUnknown"
 // CHECK:     (com_attr {{.*}} CLSID="00000000-0000-0000-0000-000000000000" threading=neutral)

--- a/test/Parse/Inputs/COM.swift
+++ b/test/Parse/Inputs/COM.swift
@@ -1,6 +1,0 @@
-
-@com(interface: "00000000-0000-0000-C000-000000000046")
-public protocol IUnknown: AnyObject { }
-
-@com(interface: "8e369447-5188-5ada-b9ec-8fcb732d226b")
-public protocol ISwiftObject: IUnknown { }

--- a/test/Sema/COM-ISwiftObject.swift
+++ b/test/Sema/COM-ISwiftObject.swift
@@ -1,0 +1,28 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module-path %t/COM.swiftmodule -module-name COM -enable-experimental-com-interop %S/../Inputs/COM.swift
+// RUN: %target-typecheck-verify-swift -enable-experimental-com-interop -I %t
+
+import COM
+
+// expected-note@+1 {{'@com' automatically provides 'ISwiftObject' conformance}}
+@com
+class CClass1: ISwiftObject {
+}
+// expected-error@-2 {{'ISwiftObject' conformance is compiler-managed and cannot be declared explicitly}}
+
+// expected-note@+1 {{'@com' automatically provides 'ISwiftObject' conformance}}
+@com(implementation: "00000000-0000-0000-0000-000000000000")
+class CClass2: ISwiftObject {
+}
+// expected-error@-2 {{'ISwiftObject' conformance is compiler-managed and cannot be declared explicitly}}
+
+@com
+class CClass3 {
+}
+
+@com
+class CClass4: IUnknown {
+}
+
+class CClass5: ISwiftObject {
+}

--- a/test/Sema/COM.swift
+++ b/test/Sema/COM.swift
@@ -3,6 +3,16 @@
 @com(interface: "00000000-0000-0000-C000-000000000046")
 protocol IUnknown: AnyObject { }
 
+struct GUID {
+  public init(data1: UInt32, data2: UInt16, data3: UInt16,
+              data4: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)) {
+  }
+}
+
+@com(interface: "8e369447-5188-5ada-b9ec-8fcb732d226b")
+protocol ISwiftObject {
+}
+
 @com(interface: "00000000-0000-0000-0000-000000000000")
 protocol IInterface1: IUnknown { }
 

--- a/test/Sema/COMSynthesis.swift
+++ b/test/Sema/COMSynthesis.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module-path %t/COM.swiftmodule -module-name COM -enable-experimental-com-interop %S/../Inputs/COM.swift
+// RUN: %target-typecheck-verify-swift -enable-experimental-com-interop -I %t
+
+import COM
+
+@com(interface: "00000000-0000-0000-0000-000000000000")
+protocol IProtocol: IUnknown {
+}
+
+@com
+class CClass1 {
+}
+
+// expected-note@+1 {{where 'COMType' = 'CClass4'}}
+func com<COMType: IUnknown>(_ interface: COMType) {
+}
+
+func implicit(_ object: CClass1) {
+  com(object)
+}
+
+@com
+class CClass2: IUnknown {
+}
+
+func explicit(_ object: CClass2) {
+  com(object)
+}
+
+@com(implementation: "00000000-0000-0000-0000-000000000000")
+class CClass3: IProtocol {
+}
+
+func indirect(_ object: CClass3) {
+  com(object)
+}
+
+class CClass4 {
+}
+
+func invalid(_ object: CClass4) {
+  com(object)
+  // expected-error@-1 {{global function 'com' requires that 'CClass4' conform to 'IUnknown'}}
+}

--- a/test/Serialization/COM.swift
+++ b/test/Serialization/COM.swift
@@ -1,5 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -enable-experimental-com-interop -module-name serialization -emit-module-path %t/serialization.swiftmodule %s
+// RUN: %target-swift-frontend -enable-experimental-com-interop -module-name COM -emit-module-path %t/COM.swiftmodule %S/../Inputs/COM.swift
+// RUN: %target-swift-frontend -enable-experimental-com-interop -module-name serialization -emit-module-path %t/serialization.swiftmodule %s -I %t
 // RUN: %llvm-bcanalyzer -dump %t/serialization.swiftmodule | %FileCheck -check-prefix CHECK -implicit-check-not UnknownCode %s
 
 @com(interface: "00000000-0000-0000-C000-000000000046")


### PR DESCRIPTION
Add synthesis of the protocol conformances for the known protocols with `@com`.

`ISwiftObject` may not be explicitly conformed to, it is a purely compiler managed sealed protocol. Generate a diagnostic for the explicit conformance.
