### PR TITLE
utils: staging artifacts requires packaging

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -5661,6 +5661,7 @@ function Build-Installer([Hashtable] $Platform) {
 
 function Copy-BuildArtifactsToStage([Hashtable] $Platform) {
   # Save the installer binary log
+  if (-not $Package) { return }
   Copy-File "$BinaryCache\$($Platform.Triple)\msi\$($Platform.Architecture.VSName)-$([System.IO.Path]::GetFileNameWithoutExtension("bundle\installer.wixproj")).binlog" $Stage
   Copy-File "$BinaryCache\$($Platform.Triple)\installer\Release\$($Platform.Architecture.VSName)\*.cab" $Stage
   Copy-File "$BinaryCache\$($Platform.Triple)\installer\Release\$($Platform.Architecture.VSName)\*.msi" $Stage


### PR DESCRIPTION
If packaging is disabled, there is nothing to stage and exit early.