### PR TITLE
[Tests] NFC: Add more tests for override isolation change

### DIFF
--- a/test/Concurrency/assume_mainactor.swift
+++ b/test/Concurrency/assume_mainactor.swift
@@ -299,6 +299,17 @@ class SubKlass: Klass {
   // CHECK: // SubKlass.init()
   // CHECK-NEXT: // Isolation: nonisolated
   // CHECK-NEXT: sil hidden [ossa] @$s16assume_mainactor8SubKlassCACycfc : $@convention(method) (@owned SubKlass) -> @owned SubKlass {
+
+  // Implicit deinit
+  // CHECK: // SubKlass.deinit
+  // CHECK-NEXT: // Isolation: global_actor. type: MainActor
+  // CHECK-NEXT: sil hidden [ossa] @$s16assume_mainactor8SubKlassCfd : $@convention(method) (@guaranteed SubKlass) -> @owned Builtin.NativeObject {
+
+  // Implicit deallocating deinit
+  // CHECK: // SubKlass.__deallocating_deinit
+  // CHECK-NEXT: // Isolation: nonisolated
+  // CHECK-NEXT: sil hidden [ossa] @$s16assume_mainactor8SubKlassCfD : $@convention(method) (@owned SubKlass) -> () {
+  // CHECK: swift_task_deinitOnExecutor
 }
 
 class NonisolatedBase {
@@ -331,4 +342,35 @@ class OverrideSub: NonisolatedBase {
   // CHECK-NEXT: // Isolation: nonisolated
   // CHECK-NEXT: sil hidden [ossa] @$s16assume_mainactor11OverrideSubCyS2icis : $@convention(method) (Int, Int, @guaranteed OverrideSub) -> () {
   override subscript(i: Int) -> Int { get { 0 } set {} }
+}
+
+class MainActorBase {
+  func method() {}
+}
+
+// Overridden methods should remain MainActor.
+class MainActorSub: MainActorBase {
+  // CHECK: // MainActorSub.method()
+  // CHECK-NEXT: // Isolation: global_actor. type: MainActor
+  // CHECK-NEXT: sil hidden [ossa] @$s16assume_mainactor12MainActorSubC6methodyyF : $@convention(method) (@guaranteed MainActorSub) -> () {
+  override func method() {}
+}
+
+@CustomActor
+class CustomActorBase {
+  func isolatedMethod() {}
+  nonisolated func nonisolatedMethod() {}
+}
+
+// Overrides inherit the superclass's global actor, not the MainActor default.
+class CustomActorSub: CustomActorBase {
+  // CHECK: // CustomActorSub.isolatedMethod()
+  // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+  // CHECK-NEXT: sil hidden [ossa] @$s16assume_mainactor14CustomActorSubC14isolatedMethodyyF : $@convention(method) (@guaranteed CustomActorSub) -> () {
+  override func isolatedMethod() {}
+
+  // CHECK: // CustomActorSub.nonisolatedMethod()
+  // CHECK-NEXT: // Isolation: nonisolated
+  // CHECK-NEXT: sil hidden [ossa] @$s16assume_mainactor14CustomActorSubC17nonisolatedMethodyyF : $@convention(method) (@guaranteed CustomActorSub) -> () {
+  override func nonisolatedMethod() {}
 }

--- a/test/Concurrency/assume_mainactor_objc.swift
+++ b/test/Concurrency/assume_mainactor_objc.swift
@@ -1,0 +1,33 @@
+// RUN: %target-swift-frontend -swift-version 5 -emit-silgen -default-isolation MainActor %s | %FileCheck %s
+// RUN: %target-swift-frontend -swift-version 5 -strict-concurrency=complete -emit-silgen -default-isolation MainActor %s | %FileCheck %s
+// RUN: %target-swift-frontend -swift-version 6 -emit-silgen -default-isolation MainActor %s | %FileCheck %s
+// RUN: %target-swift-frontend -swift-version 6 -emit-sil -default-isolation MainActor %s -verify
+
+// assume_mainactor.swift with objc_interop
+// Please keep this file to FileCheck of isolation under -default-isolation MainActor, and only test objc interop specific things.
+// This test is able to check Swift 5 because it doesn't interact with mode dependent inits...
+
+// REQUIRES: concurrency
+// REQUIRES: objc_interop
+
+import Foundation
+
+class SwiftClass {
+  // CHECK: // SwiftClass.__isolated_deallocating_deinit
+  // CHECK-NEXT: // Isolation: global_actor. type: MainActor
+}
+
+class ObjCSub: NSObject {
+  // CHECK: // ObjCSub.init()
+  // CHECK-NEXT: // Isolation: global_actor. type: MainActor
+  // CHECK-NEXT: sil hidden [ossa] @$s21assume_mainactor_objc7ObjCSubCACycfc : $@convention(method) (@owned ObjCSub) -> @owned ObjCSub {
+
+  // Deinit has no isolation due to NSObject deinit being nonisolated.
+  // CHECK: // ObjCSub.__deallocating_deinit
+  // CHECK-NEXT: // Isolation: nonisolated
+  // CHECK-NEXT: sil hidden [ossa] @$s21assume_mainactor_objc7ObjCSubCfD : $@convention(method) (@owned ObjCSub) -> () {
+
+  // CHECK-NOT: __isolated_deallocating_deinit
+  // CHECK-NOT: swift_task_deinitOnExecutor
+  // CHECK: } // end sil function '$s21assume_mainactor_objc7ObjCSubCfD'
+}


### PR DESCRIPTION
Add regression tests for changed behavior (`NSObject` subclass + `-default-isolation MainActor`) discovered while investigating a cherry pick for rdar://161815393, as well as some override cases that weren't covered.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
