### PR TITLE
Duplicate CLongDouble docs over #if and document platform variation

### DIFF
--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -95,16 +95,34 @@ public typealias CDouble = Double
 ///
 /// This type's definition varies by platform,
 /// to match the variable definition of the C `long double` type.
-/// On Apple silicon, `CLongDouble` is a type alias for `Double` (`Float64`).
-/// On Intel, `CLongDouble` is a type alias for `Float80`.
+/// `CLongDouble` is a type alias for `Double` (`Float64)`
+/// on Apple silicon,
+/// on Windows,
+/// on Linux running on IBM System/390,
+/// on Android running on ARM,
+/// and on OpenBSD running on 64-bit ARM.
+/// `CLongDouble` is a type alias for `Float80`
+/// on Apple platforms running on Intel,
+/// on Linux running on Intel,
+/// on OpenBSD running on 64-bit Intel,
+/// and on FreeBSD running on Intel.
 public typealias CLongDouble = Float80
 #else
 /// The C 'long double' type.
 ///
 /// This type's definition varies by platform,
 /// to match the variable definition of the C `long double` type.
-/// On Apple silicon, `CLongDouble` is a type alias for `Double` (`Float64`).
-/// On Intel, `CLongDouble` is a type alias for `Float80`.
+/// `CLongDouble` is a type alias for `Double` (`Float64)`
+/// on Apple silicon,
+/// on Windows,
+/// on Linux running on IBM System/390,
+/// on Android running on ARM,
+/// and on OpenBSD running on 64-bit ARM.
+/// `CLongDouble` is a type alias for `Float80`
+/// on Apple platforms running on Intel,
+/// on Linux running on Intel,
+/// on OpenBSD running on 64-bit Intel,
+/// and on FreeBSD running on Intel.
 public typealias CLongDouble = Double
 #endif
 #elseif os(Windows)

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -95,16 +95,16 @@ public typealias CDouble = Double
 ///
 /// This type's definition varies by platform,
 /// to match the variable definition of the C `long double` type.
-/// On Apple silicon, `CLongLong` is a type alias for `Float80`.
-/// On Intel, `CLongLong` is a type alias for `Double` (`Float64`).
+/// On Apple silicon, `CLongDouble` is a type alias for `Double` (`Float64`).
+/// On Intel, `CLongDouble` is a type alias for `Float80`.
 public typealias CLongDouble = Float80
 #else
 /// The C 'long double' type.
 ///
 /// This type's definition varies by platform,
 /// to match the variable definition of the C `long double` type.
-/// On Apple silicon, `CLongLong` is a type alias for `Float80`.
-/// On Intel, `CLongLong` is a type alias for `Double` (`Float64`).
+/// On Apple silicon, `CLongDouble` is a type alias for `Double` (`Float64`).
+/// On Intel, `CLongDouble` is a type alias for `Float80`.
 public typealias CLongDouble = Double
 #endif
 #elseif os(Windows)

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -86,8 +86,7 @@ public typealias CDouble = Double
 
 // The triple-slash documentation comments below are duplicated to work around
 // a limitation in DocC, where it doesn't apply comments to each branch of the
-// pound-if (rdar://128616139).  The list in the documentation covers only the
-// platforms that Swift officially supports.
+// pound-if (rdar://128616139).
 #if os(anyAppleOS)
 // On Darwin, long double is Float80 on x86, and Double otherwise.
 #if arch(x86_64) || arch(i386)
@@ -127,6 +126,21 @@ public typealias CLongDouble = Double
 #endif
 #elseif os(Windows)
 // On Windows, long double is always Double.
+/// The C 'long double' type.
+///
+/// This type's definition varies by platform,
+/// to match the variable definition of the C `long double` type.
+/// `CLongDouble` is a type alias for `Double` (`Float64)`
+/// on Apple silicon,
+/// on Windows,
+/// on Linux running on IBM System/390,
+/// on Android running on ARM,
+/// and on OpenBSD running on 64-bit ARM.
+/// `CLongDouble` is a type alias for `Float80`
+/// on Apple platforms running on Intel,
+/// on Linux running on Intel,
+/// on OpenBSD running on 64-bit Intel,
+/// and on FreeBSD running on Intel.
 public typealias CLongDouble = Double
 #elseif os(Linux)
 // On Linux/x86, long double is Float80.
@@ -134,22 +148,97 @@ public typealias CLongDouble = Double
 // armv7 should map to Double, but arm64 and ppc64le should map to Float128,
 // which we don't yet have in Swift.
 #if arch(x86_64) || arch(i386)
+/// The C 'long double' type.
+///
+/// This type's definition varies by platform,
+/// to match the variable definition of the C `long double` type.
+/// `CLongDouble` is a type alias for `Double` (`Float64)`
+/// on Apple silicon,
+/// on Windows,
+/// on Linux running on IBM System/390,
+/// on Android running on ARM,
+/// and on OpenBSD running on 64-bit ARM.
+/// `CLongDouble` is a type alias for `Float80`
+/// on Apple platforms running on Intel,
+/// on Linux running on Intel,
+/// on OpenBSD running on 64-bit Intel,
+/// and on FreeBSD running on Intel.
 public typealias CLongDouble = Float80
 #elseif arch(s390x)
 // On s390x '-mlong-double-64' option with size of 64-bits makes the
 // Long Double type equivalent to Double type.
+/// The C 'long double' type.
+///
+/// This type's definition varies by platform,
+/// to match the variable definition of the C `long double` type.
+/// `CLongDouble` is a type alias for `Double` (`Float64)`
+/// on Apple silicon,
+/// on Windows,
+/// on Linux running on IBM System/390,
+/// on Android running on ARM,
+/// and on OpenBSD running on 64-bit ARM.
+/// `CLongDouble` is a type alias for `Float80`
+/// on Apple platforms running on Intel,
+/// on Linux running on Intel,
+/// on OpenBSD running on 64-bit Intel,
+/// and on FreeBSD running on Intel.
 public typealias CLongDouble = Double
 #endif
 #elseif os(Android)
 // On Android, long double is Float128 for AAPCS64, which we don't have yet in
 // Swift (https://github.com/apple/swift/issues/51573); and Double for ARMv7.
 #if arch(arm)
+/// The C 'long double' type.
+///
+/// This type's definition varies by platform,
+/// to match the variable definition of the C `long double` type.
+/// `CLongDouble` is a type alias for `Double` (`Float64)`
+/// on Apple silicon,
+/// on Windows,
+/// on Linux running on IBM System/390,
+/// on Android running on ARM,
+/// and on OpenBSD running on 64-bit ARM.
+/// `CLongDouble` is a type alias for `Float80`
+/// on Apple platforms running on Intel,
+/// on Linux running on Intel,
+/// on OpenBSD running on 64-bit Intel,
+/// and on FreeBSD running on Intel.
 public typealias CLongDouble = Double
 #endif
 #elseif os(OpenBSD)
 #if arch(x86_64)
+/// The C 'long double' type.
+///
+/// This type's definition varies by platform,
+/// to match the variable definition of the C `long double` type.
+/// `CLongDouble` is a type alias for `Double` (`Float64)`
+/// on Apple silicon,
+/// on Windows,
+/// on Linux running on IBM System/390,
+/// on Android running on ARM,
+/// and on OpenBSD running on 64-bit ARM.
+/// `CLongDouble` is a type alias for `Float80`
+/// on Apple platforms running on Intel,
+/// on Linux running on Intel,
+/// on OpenBSD running on 64-bit Intel,
+/// and on FreeBSD running on Intel.
 public typealias CLongDouble = Float80
 #elseif arch(arm64)
+/// The C 'long double' type.
+///
+/// This type's definition varies by platform,
+/// to match the variable definition of the C `long double` type.
+/// `CLongDouble` is a type alias for `Double` (`Float64)`
+/// on Apple silicon,
+/// on Windows,
+/// on Linux running on IBM System/390,
+/// on Android running on ARM,
+/// and on OpenBSD running on 64-bit ARM.
+/// `CLongDouble` is a type alias for `Float80`
+/// on Apple platforms running on Intel,
+/// on Linux running on Intel,
+/// on OpenBSD running on 64-bit Intel,
+/// and on FreeBSD running on Intel.
 public typealias CLongDouble = Double
 #else
 #error("CLongDouble needs to be defined for this OpenBSD architecture")
@@ -158,10 +247,40 @@ public typealias CLongDouble = Double
 // On FreeBSD, long double is Float128 for arm64, which we don't have yet in
 // Swift
 #if arch(x86_64) || arch(i386)
+/// The C 'long double' type.
+///
+/// This type's definition varies by platform,
+/// to match the variable definition of the C `long double` type.
+/// `CLongDouble` is a type alias for `Double` (`Float64)`
+/// on Apple silicon,
+/// on Windows,
+/// on Linux running on IBM System/390,
+/// on Android running on ARM,
+/// and on OpenBSD running on 64-bit ARM.
+/// `CLongDouble` is a type alias for `Float80`
+/// on Apple platforms running on Intel,
+/// on Linux running on Intel,
+/// on OpenBSD running on 64-bit Intel,
+/// and on FreeBSD running on Intel.
 public typealias CLongDouble = Float80
 #endif
 #elseif $Embedded
 #if arch(x86_64) || arch(i386)
+/// The C 'long double' type.
+///
+/// This type's definition varies by platform,
+/// to match the variable definition of the C `long double` type.
+/// `CLongDouble` is a type alias for `Double` (`Float64)`
+/// on Apple silicon,
+/// on Windows,
+/// on Linux running on IBM System/390,
+/// on Android running on ARM,
+/// and on OpenBSD running on 64-bit ARM.
+/// `CLongDouble` is a type alias for `Float80`
+/// on Apple platforms running on Intel,
+/// on Linux running on Intel,
+/// on OpenBSD running on 64-bit Intel,
+/// and on FreeBSD running on Intel.
 public typealias CLongDouble = Double
 #endif
 #else

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -84,12 +84,27 @@ public typealias CFloat = Float
 /// The C 'double' type.
 public typealias CDouble = Double
 
-/// The C 'long double' type.
+// The triple-slash documentation comments below are duplicated to work around
+// a limitation in DocC, where it doesn't apply comments to each branch of the
+// pound-if (rdar://128616139).  The list in the documentation covers only the
+// platforms that Swift officially supports.
 #if os(anyAppleOS)
 // On Darwin, long double is Float80 on x86, and Double otherwise.
 #if arch(x86_64) || arch(i386)
+/// The C 'long double' type.
+///
+/// This type's definition varies by platform,
+/// to match the variable definition of the C `long double` type.
+/// On Apple silicon, `CLongLong` is a type alias for `Float80`.
+/// On Intel, `CLongLong` is a type alias for `Double` (`Float64`).
 public typealias CLongDouble = Float80
 #else
+/// The C 'long double' type.
+///
+/// This type's definition varies by platform,
+/// to match the variable definition of the C `long double` type.
+/// On Apple silicon, `CLongLong` is a type alias for `Float80`.
+/// On Intel, `CLongLong` is a type alias for `Double` (`Float64`).
 public typealias CLongDouble = Double
 #endif
 #elseif os(Windows)

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -94,7 +94,7 @@ public typealias CDouble = Double
 ///
 /// This type's definition varies by platform,
 /// to match the variable definition of the C `long double` type.
-/// `CLongDouble` is a type alias for `Double` (`Float64)`
+/// `CLongDouble` is a type alias for `Double` (`Float64`)
 /// on Apple silicon,
 /// on Windows,
 /// on Linux running on IBM System/390,
@@ -111,7 +111,7 @@ public typealias CLongDouble = Float80
 ///
 /// This type's definition varies by platform,
 /// to match the variable definition of the C `long double` type.
-/// `CLongDouble` is a type alias for `Double` (`Float64)`
+/// `CLongDouble` is a type alias for `Double` (`Float64`)
 /// on Apple silicon,
 /// on Windows,
 /// on Linux running on IBM System/390,
@@ -130,7 +130,7 @@ public typealias CLongDouble = Double
 ///
 /// This type's definition varies by platform,
 /// to match the variable definition of the C `long double` type.
-/// `CLongDouble` is a type alias for `Double` (`Float64)`
+/// `CLongDouble` is a type alias for `Double` (`Float64`)
 /// on Apple silicon,
 /// on Windows,
 /// on Linux running on IBM System/390,
@@ -152,7 +152,7 @@ public typealias CLongDouble = Double
 ///
 /// This type's definition varies by platform,
 /// to match the variable definition of the C `long double` type.
-/// `CLongDouble` is a type alias for `Double` (`Float64)`
+/// `CLongDouble` is a type alias for `Double` (`Float64`)
 /// on Apple silicon,
 /// on Windows,
 /// on Linux running on IBM System/390,
@@ -171,7 +171,7 @@ public typealias CLongDouble = Float80
 ///
 /// This type's definition varies by platform,
 /// to match the variable definition of the C `long double` type.
-/// `CLongDouble` is a type alias for `Double` (`Float64)`
+/// `CLongDouble` is a type alias for `Double` (`Float64`)
 /// on Apple silicon,
 /// on Windows,
 /// on Linux running on IBM System/390,
@@ -192,7 +192,7 @@ public typealias CLongDouble = Double
 ///
 /// This type's definition varies by platform,
 /// to match the variable definition of the C `long double` type.
-/// `CLongDouble` is a type alias for `Double` (`Float64)`
+/// `CLongDouble` is a type alias for `Double` (`Float64`)
 /// on Apple silicon,
 /// on Windows,
 /// on Linux running on IBM System/390,
@@ -211,7 +211,7 @@ public typealias CLongDouble = Double
 ///
 /// This type's definition varies by platform,
 /// to match the variable definition of the C `long double` type.
-/// `CLongDouble` is a type alias for `Double` (`Float64)`
+/// `CLongDouble` is a type alias for `Double` (`Float64`)
 /// on Apple silicon,
 /// on Windows,
 /// on Linux running on IBM System/390,
@@ -228,7 +228,7 @@ public typealias CLongDouble = Float80
 ///
 /// This type's definition varies by platform,
 /// to match the variable definition of the C `long double` type.
-/// `CLongDouble` is a type alias for `Double` (`Float64)`
+/// `CLongDouble` is a type alias for `Double` (`Float64`)
 /// on Apple silicon,
 /// on Windows,
 /// on Linux running on IBM System/390,
@@ -251,7 +251,7 @@ public typealias CLongDouble = Double
 ///
 /// This type's definition varies by platform,
 /// to match the variable definition of the C `long double` type.
-/// `CLongDouble` is a type alias for `Double` (`Float64)`
+/// `CLongDouble` is a type alias for `Double` (`Float64`)
 /// on Apple silicon,
 /// on Windows,
 /// on Linux running on IBM System/390,
@@ -270,7 +270,7 @@ public typealias CLongDouble = Float80
 ///
 /// This type's definition varies by platform,
 /// to match the variable definition of the C `long double` type.
-/// `CLongDouble` is a type alias for `Double` (`Float64)`
+/// `CLongDouble` is a type alias for `Double` (`Float64`)
 /// on Apple silicon,
 /// on Windows,
 /// on Linux running on IBM System/390,

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -84,15 +84,15 @@ public typealias CFloat = Float
 /// The C 'double' type.
 public typealias CDouble = Double
 
-// The triple-slash documentation comments below are duplicated to work around
-// a limitation in DocC, where it doesn't apply comments to each branch of the
-// pound-if (rdar://128616139).
+// Because CLongDouble varies by platform, its documentation comments are
+// repeated so they appear before each declaration.  The documentation can't
+// appear just once here, before the #if.  (rdar://128616139)
 #if os(anyAppleOS)
 // On Darwin, long double is Float80 on x86, and Double otherwise.
 #if arch(x86_64) || arch(i386)
 /// The C 'long double' type.
 ///
-/// This type's definition varies by platform,
+/// This type's definition varies by platform
 /// to match the variable definition of the C `long double` type.
 /// `CLongDouble` is a type alias for `Double` (`Float64`)
 /// on Apple silicon,
@@ -101,15 +101,15 @@ public typealias CDouble = Double
 /// on Android running on ARM,
 /// and on OpenBSD running on 64-bit ARM.
 /// `CLongDouble` is a type alias for `Float80`
-/// on Apple platforms running on Intel,
-/// on Linux running on Intel,
-/// on OpenBSD running on 64-bit Intel,
-/// and on FreeBSD running on Intel.
+/// on Apple platforms running on Intel-based processors,
+/// on Linux running on Intel-based processors,
+/// on OpenBSD running on 64-bit Intel-based processors,
+/// and on FreeBSD running on Intel-based processors.
 public typealias CLongDouble = Float80
 #else
 /// The C 'long double' type.
 ///
-/// This type's definition varies by platform,
+/// This type's definition varies by platform
 /// to match the variable definition of the C `long double` type.
 /// `CLongDouble` is a type alias for `Double` (`Float64`)
 /// on Apple silicon,
@@ -118,17 +118,17 @@ public typealias CLongDouble = Float80
 /// on Android running on ARM,
 /// and on OpenBSD running on 64-bit ARM.
 /// `CLongDouble` is a type alias for `Float80`
-/// on Apple platforms running on Intel,
-/// on Linux running on Intel,
-/// on OpenBSD running on 64-bit Intel,
-/// and on FreeBSD running on Intel.
+/// on Apple platforms running on Intel-based processors,
+/// on Linux running on Intel-based processors,
+/// on OpenBSD running on 64-bit Intel-based processors,
+/// and on FreeBSD running on Intel-based processors.
 public typealias CLongDouble = Double
 #endif
 #elseif os(Windows)
 // On Windows, long double is always Double.
 /// The C 'long double' type.
 ///
-/// This type's definition varies by platform,
+/// This type's definition varies by platform
 /// to match the variable definition of the C `long double` type.
 /// `CLongDouble` is a type alias for `Double` (`Float64`)
 /// on Apple silicon,
@@ -137,10 +137,10 @@ public typealias CLongDouble = Double
 /// on Android running on ARM,
 /// and on OpenBSD running on 64-bit ARM.
 /// `CLongDouble` is a type alias for `Float80`
-/// on Apple platforms running on Intel,
-/// on Linux running on Intel,
-/// on OpenBSD running on 64-bit Intel,
-/// and on FreeBSD running on Intel.
+/// on Apple platforms running on Intel-based processors,
+/// on Linux running on Intel-based processors,
+/// on OpenBSD running on 64-bit Intel-based processors,
+/// and on FreeBSD running on Intel-based processors.
 public typealias CLongDouble = Double
 #elseif os(Linux)
 // On Linux/x86, long double is Float80.
@@ -150,7 +150,7 @@ public typealias CLongDouble = Double
 #if arch(x86_64) || arch(i386)
 /// The C 'long double' type.
 ///
-/// This type's definition varies by platform,
+/// This type's definition varies by platform
 /// to match the variable definition of the C `long double` type.
 /// `CLongDouble` is a type alias for `Double` (`Float64`)
 /// on Apple silicon,
@@ -159,17 +159,17 @@ public typealias CLongDouble = Double
 /// on Android running on ARM,
 /// and on OpenBSD running on 64-bit ARM.
 /// `CLongDouble` is a type alias for `Float80`
-/// on Apple platforms running on Intel,
-/// on Linux running on Intel,
-/// on OpenBSD running on 64-bit Intel,
-/// and on FreeBSD running on Intel.
+/// on Apple platforms running on Intel-based processors,
+/// on Linux running on Intel-based processors,
+/// on OpenBSD running on 64-bit Intel-based processors,
+/// and on FreeBSD running on Intel-based processors.
 public typealias CLongDouble = Float80
 #elseif arch(s390x)
 // On s390x '-mlong-double-64' option with size of 64-bits makes the
 // Long Double type equivalent to Double type.
 /// The C 'long double' type.
 ///
-/// This type's definition varies by platform,
+/// This type's definition varies by platform
 /// to match the variable definition of the C `long double` type.
 /// `CLongDouble` is a type alias for `Double` (`Float64`)
 /// on Apple silicon,
@@ -178,10 +178,10 @@ public typealias CLongDouble = Float80
 /// on Android running on ARM,
 /// and on OpenBSD running on 64-bit ARM.
 /// `CLongDouble` is a type alias for `Float80`
-/// on Apple platforms running on Intel,
-/// on Linux running on Intel,
-/// on OpenBSD running on 64-bit Intel,
-/// and on FreeBSD running on Intel.
+/// on Apple platforms running on Intel-based processors,
+/// on Linux running on Intel-based processors,
+/// on OpenBSD running on 64-bit Intel-based processors,
+/// and on FreeBSD running on Intel-based processors.
 public typealias CLongDouble = Double
 #endif
 #elseif os(Android)
@@ -190,7 +190,7 @@ public typealias CLongDouble = Double
 #if arch(arm)
 /// The C 'long double' type.
 ///
-/// This type's definition varies by platform,
+/// This type's definition varies by platform
 /// to match the variable definition of the C `long double` type.
 /// `CLongDouble` is a type alias for `Double` (`Float64`)
 /// on Apple silicon,
@@ -199,17 +199,17 @@ public typealias CLongDouble = Double
 /// on Android running on ARM,
 /// and on OpenBSD running on 64-bit ARM.
 /// `CLongDouble` is a type alias for `Float80`
-/// on Apple platforms running on Intel,
-/// on Linux running on Intel,
-/// on OpenBSD running on 64-bit Intel,
-/// and on FreeBSD running on Intel.
+/// on Apple platforms running on Intel-based processors,
+/// on Linux running on Intel-based processors,
+/// on OpenBSD running on 64-bit Intel-based processors,
+/// and on FreeBSD running on Intel-based processors.
 public typealias CLongDouble = Double
 #endif
 #elseif os(OpenBSD)
 #if arch(x86_64)
 /// The C 'long double' type.
 ///
-/// This type's definition varies by platform,
+/// This type's definition varies by platform
 /// to match the variable definition of the C `long double` type.
 /// `CLongDouble` is a type alias for `Double` (`Float64`)
 /// on Apple silicon,
@@ -218,15 +218,15 @@ public typealias CLongDouble = Double
 /// on Android running on ARM,
 /// and on OpenBSD running on 64-bit ARM.
 /// `CLongDouble` is a type alias for `Float80`
-/// on Apple platforms running on Intel,
-/// on Linux running on Intel,
-/// on OpenBSD running on 64-bit Intel,
-/// and on FreeBSD running on Intel.
+/// on Apple platforms running on Intel-based processors,
+/// on Linux running on Intel-based processors,
+/// on OpenBSD running on 64-bit Intel-based processors,
+/// and on FreeBSD running on Intel-based processors.
 public typealias CLongDouble = Float80
 #elseif arch(arm64)
 /// The C 'long double' type.
 ///
-/// This type's definition varies by platform,
+/// This type's definition varies by platform
 /// to match the variable definition of the C `long double` type.
 /// `CLongDouble` is a type alias for `Double` (`Float64`)
 /// on Apple silicon,
@@ -235,10 +235,10 @@ public typealias CLongDouble = Float80
 /// on Android running on ARM,
 /// and on OpenBSD running on 64-bit ARM.
 /// `CLongDouble` is a type alias for `Float80`
-/// on Apple platforms running on Intel,
-/// on Linux running on Intel,
-/// on OpenBSD running on 64-bit Intel,
-/// and on FreeBSD running on Intel.
+/// on Apple platforms running on Intel-based processors,
+/// on Linux running on Intel-based processors,
+/// on OpenBSD running on 64-bit Intel-based processors,
+/// and on FreeBSD running on Intel-based processors.
 public typealias CLongDouble = Double
 #else
 #error("CLongDouble needs to be defined for this OpenBSD architecture")
@@ -249,7 +249,7 @@ public typealias CLongDouble = Double
 #if arch(x86_64) || arch(i386)
 /// The C 'long double' type.
 ///
-/// This type's definition varies by platform,
+/// This type's definition varies by platform
 /// to match the variable definition of the C `long double` type.
 /// `CLongDouble` is a type alias for `Double` (`Float64`)
 /// on Apple silicon,
@@ -258,17 +258,17 @@ public typealias CLongDouble = Double
 /// on Android running on ARM,
 /// and on OpenBSD running on 64-bit ARM.
 /// `CLongDouble` is a type alias for `Float80`
-/// on Apple platforms running on Intel,
-/// on Linux running on Intel,
-/// on OpenBSD running on 64-bit Intel,
-/// and on FreeBSD running on Intel.
+/// on Apple platforms running on Intel-based processors,
+/// on Linux running on Intel-based processors,
+/// on OpenBSD running on 64-bit Intel-based processors,
+/// and on FreeBSD running on Intel-based processors.
 public typealias CLongDouble = Float80
 #endif
 #elseif $Embedded
 #if arch(x86_64) || arch(i386)
 /// The C 'long double' type.
 ///
-/// This type's definition varies by platform,
+/// This type's definition varies by platform
 /// to match the variable definition of the C `long double` type.
 /// `CLongDouble` is a type alias for `Double` (`Float64`)
 /// on Apple silicon,
@@ -277,10 +277,10 @@ public typealias CLongDouble = Float80
 /// on Android running on ARM,
 /// and on OpenBSD running on 64-bit ARM.
 /// `CLongDouble` is a type alias for `Float80`
-/// on Apple platforms running on Intel,
-/// on Linux running on Intel,
-/// on OpenBSD running on 64-bit Intel,
-/// and on FreeBSD running on Intel.
+/// on Apple platforms running on Intel-based processors,
+/// on Linux running on Intel-based processors,
+/// on OpenBSD running on 64-bit Intel-based processors,
+/// and on FreeBSD running on Intel-based processors.
 public typealias CLongDouble = Double
 #endif
 #else


### PR DESCRIPTION
DocC doesn't associate the doc comment before the `#if` with the declaration inside it.  Without the copy/paste workaround, the doc comment is dropped and `CLongDouble` gets no documentation.

Fixes: rdar://92595826