### PR TITLE
[DebugInfo] Fix DeadCodeElimination to call salvageDebugInfo

### DIFF
--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -28,6 +28,7 @@
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/BasicBlockOptUtils.h"
 #include "swift/SILOptimizer/Utils/CFGOptUtils.h"
+#include "swift/SILOptimizer/Utils/DebugOptUtils.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
 #include "swift/SILOptimizer/Utils/OwnershipOptUtils.h"
 #include "llvm/ADT/DenseMap.h"
@@ -635,6 +636,22 @@ void DCE::endLifetimeOfLiveValue(Operand *op, SILInstruction *insertPt) {
 bool DCE::removeDead() {
   bool Changed = false;
 
+  // Salvage debug info before erasing dead instructions. Collect all dead
+  // non-debug instructions, then salvage in reverse order (uses before defs)
+  // so that reconstruction blocks can reference operands still alive.
+  SmallVector<SILInstruction *, 16> toSalvage;
+  for (auto &bb : *F) {
+    for (auto &inst : bb) {
+      if (LiveInstructions.contains(&inst) || isa<BranchInst>(&inst))
+        continue;
+      if (isa<TermInst>(&inst) || isa<DebugValueInst>(&inst))
+        continue;
+      toSalvage.push_back(&inst);
+    }
+  }
+  for (auto *inst : llvm::reverse(toSalvage))
+    salvageDebugInfo(inst);
+
   for (auto &BB : *F) {
     for (unsigned i = 0; i < BB.getArguments().size();) {
       auto *arg = BB.getArgument(i);
@@ -707,6 +724,12 @@ bool DCE::removeDead() {
       auto *Inst = &*I;
       ++I;
       if (LiveInstructions.contains(Inst) || isa<BranchInst>(Inst))
+        continue;
+
+      // Debug values have either already been rewritten by salvageDebugInfo,
+      // or replaceAllUsesOfAllResultsWithUndef will replace the deleted use
+      // with an undef, killing it. They should not be deleted.
+      if (isa<DebugValueInst>(Inst))
         continue;
 
       // We want to replace dead terminators with unconditional branches to

--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -82,14 +82,6 @@ static bool seemsUseful(SILInstruction *I) {
       return true;
   }
 
-  // A debug value should never be marked useful, they are handled specially,
-  // and should not propagate liveness of operands.
-  // For function arguments, without this, the argument is RAUW'ed with undef.
-  // Keeping them alive doesn't cost anything.
-  if (isa<DebugValueInst>(I))
-    return isa<SILFunctionArgument>(I->getOperand(0));
-
-
   // Don't delete allocation instructions in DCE.
   if (isa<AllocRefInst>(I) || isa<AllocRefDynamicInst>(I)) {
     return true;
@@ -664,7 +656,11 @@ bool DCE::removeDead() {
       LLVM_DEBUG(llvm::dbgs() << "Removing dead argument:\n");
       LLVM_DEBUG(arg->dump());
 
-      arg->replaceAllUsesWithUndef();
+      // Function arguments cannot be removed from the signature. Don't
+      // replace their uses with undef: debug_values should keep referencing
+      // the real arg.
+      if (!isa<SILFunctionArgument>(arg))
+        arg->replaceAllUsesWithUndef();
 
       if (!F->hasOwnership() || arg->getOwnershipKind() == OwnershipKind::None) {
         i++;

--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -82,11 +82,12 @@ static bool seemsUseful(SILInstruction *I) {
       return true;
   }
 
-  // Is useful if it's associating with a function argument
-  // If undef, it is useful and it doesn't cost anything.
+  // A debug value should never be marked useful, they are handled specially,
+  // and should not propagate liveness of operands.
+  // For function arguments, without this, the argument is RAUW'ed with undef.
+  // Keeping them alive doesn't cost anything.
   if (isa<DebugValueInst>(I))
-    return isa<SILFunctionArgument>(I->getOperand(0))
-      || isa<SILUndef>(I->getOperand(0));
+    return isa<SILFunctionArgument>(I->getOperand(0));
 
 
   // Don't delete allocation instructions in DCE.

--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -509,13 +509,6 @@ void DCE::propagateLiveness(SILInstruction *I) {
     for (auto &O : I->getAllOperands())
       markValueLive(O.get());
 
-    // Conceptually, the dependency from a debug instruction to its definition
-    // is in reverse direction: Only if its definition is alive, also the
-    // debug_value instruction is alive.
-    for (auto result : I->getResults())
-      for (Operand *DU : getDebugUses(result))
-        markInstructionLive(DU->getUser());
-
     // Handle all other reverse-dependency instructions, like cond_fail,
     // fix_lifetime, destroy_value, etc. Only if the definition is alive, the
     // user itself is alive.

--- a/test/DebugInfo/salvage_dce.sil
+++ b/test/DebugInfo/salvage_dce.sil
@@ -1,8 +1,6 @@
 // RUN: %target-sil-opt %s -dce | %FileCheck %s
 
 // Test that DeadCodeElimination salvages debug info for dead instructions.
-// Note: if the function argument is dead, debug values depending on it will
-// be killed as the operand is replaced by undef.
 
 sil_stage canonical
 
@@ -51,4 +49,25 @@ bb0(%0 : $TwoFields):
   debug_value %2 : $Builtin.Int64, let, name "inner"
   %3 = struct_extract %0 : $TwoFields, #TwoFields.y
   return %3 : $Int64
+}
+
+// Test that salvaging works even when the function argument has no live use.
+// The debug_value should still reference %0 through the reconstruction block.
+// CHECK-LABEL: sil @test_dce_dead_arg
+// CHECK: bb0(%0 : $TwoFields):
+// CHECK:   debug_value %0, let, name "field", transform {
+// CHECK:   bb0(%0 : $TwoFields):
+// CHECK:     %1 = struct_extract %0, #TwoFields.x
+// CHECK:     %2 = struct_extract %1, #Int64._value
+// CHECK:     return %2
+// CHECK:   }
+// CHECK:   [[RET:%[0-9]+]] = integer_literal
+// CHECK:   return [[RET]]
+sil @test_dce_dead_arg : $@convention(thin) (TwoFields) -> Builtin.Int64 {
+bb0(%0 : $TwoFields):
+  %1 = struct_extract %0 : $TwoFields, #TwoFields.x
+  %2 = struct_extract %1 : $Int64, #Int64._value
+  debug_value %2 : $Builtin.Int64, let, name "field"
+  %3 = integer_literal $Builtin.Int64, 42
+  return %3 : $Builtin.Int64
 }

--- a/test/DebugInfo/salvage_dce.sil
+++ b/test/DebugInfo/salvage_dce.sil
@@ -1,0 +1,54 @@
+// RUN: %target-sil-opt %s -dce | %FileCheck %s
+
+// Test that DeadCodeElimination salvages debug info for dead instructions.
+// Note: if the function argument is dead, debug values depending on it will
+// be killed as the operand is replaced by undef.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+struct TwoFields {
+  @_hasStorage var x: Int64 { get set }
+  @_hasStorage var y: Int64 { get set }
+}
+
+
+// CHECK-LABEL: sil @test_dce_struct_extract
+// CHECK: bb0(%0 : $TwoFields):
+// CHECK:   debug_value %0, let, name "field", transform {
+// CHECK:   bb0(%0 : $TwoFields):
+// CHECK:     %1 = struct_extract %0, #TwoFields.x
+// CHECK:     return %1
+// CHECK:   }
+// CHECK:   [[Y:%[0-9]+]] = struct_extract %0, #TwoFields.y
+// CHECK:   debug_value [[Y]], let, name "live"
+// CHECK-NOT: transform
+// CHECK:   return [[Y]]
+sil @test_dce_struct_extract : $@convention(thin) (TwoFields) -> Int64 {
+bb0(%0 : $TwoFields):
+  %1 = struct_extract %0 : $TwoFields, #TwoFields.x
+  debug_value %1 : $Int64, let, name "field"
+  %2 = struct_extract %0 : $TwoFields, #TwoFields.y
+  debug_value %2 : $Int64, let, name "live"
+  return %2 : $Int64
+}
+
+// CHECK-LABEL: sil @test_dce_chain
+// CHECK: bb0(%0 : $TwoFields):
+// CHECK:   debug_value %0, let, name "inner", transform {
+// CHECK:   bb0(%0 : $TwoFields):
+// CHECK:     %1 = struct_extract %0, #TwoFields.x
+// CHECK:     %2 = struct_extract %1, #Int64._value
+// CHECK:     return %2
+// CHECK:   }
+// CHECK:   return
+sil @test_dce_chain : $@convention(thin) (TwoFields) -> Int64 {
+bb0(%0 : $TwoFields):
+  %1 = struct_extract %0 : $TwoFields, #TwoFields.x
+  %2 = struct_extract %1 : $Int64, #Int64._value
+  debug_value %2 : $Builtin.Int64, let, name "inner"
+  %3 = struct_extract %0 : $TwoFields, #TwoFields.y
+  return %3 : $Int64
+}

--- a/test/SILOptimizer/assemblyvision_remark/chacha.swift
+++ b/test/SILOptimizer/assemblyvision_remark/chacha.swift
@@ -35,7 +35,7 @@ public func run_ChaCha(_ N: Int) {
   checkResult(checkedtext)
 
 
-  var plaintext = Array(repeating: UInt8(0), count: 30720)
+  var plaintext = Array(repeating: UInt8(0), count: 30720) // expected-note {{of 'plaintext}}
   for _ in 1...N {
     ChaCha20.encrypt(bytes: &plaintext, key: key, nonce: nonce)
     print(plaintext.first!) // expected-remark @:11 {{heap allocated ref of type '}}

--- a/test/SILOptimizer/cast_folding.swift
+++ b/test/SILOptimizer/cast_folding.swift
@@ -230,9 +230,10 @@ func cast42(_ p: P) -> Bool {
 
 // CHECK-LABEL: sil hidden [noinline] @$s12cast_folding5test0SbyF : $@convention(thin) () -> Bool
 // CHECK: bb0
-// CHECK-NEXT: %0 = integer_literal $Builtin.Int1, -1
-// CHECK-NEXT: %1 = struct $Bool
-// CHECK-NEXT: return %1
+// CHECK-NEXT: debug_value undef
+// CHECK-NEXT: %1 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: %2 = struct $Bool
+// CHECK-NEXT: return %2
 @inline(never)
 func test0() -> Bool {
   return cast0(A())
@@ -241,9 +242,10 @@ func test0() -> Bool {
 
 // CHECK-LABEL: sil hidden [noinline] @$s12cast_folding5test1SbyF : $@convention(thin) () -> Bool
 // CHECK: bb0
-// CHECK-NEXT: %0 = integer_literal $Builtin.Int1, -1
-// CHECK-NEXT: %1 = struct $Bool
-// CHECK-NEXT: return %1
+// CHECK-NEXT: debug_value undef
+// CHECK-NEXT: %1 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: %2 = struct $Bool
+// CHECK-NEXT: return %2
 @inline(never)
 func test1() -> Bool {
   return cast1(A())
@@ -251,9 +253,10 @@ func test1() -> Bool {
 
 // CHECK-LABEL: sil hidden [noinline] @$s12cast_folding5test2SbyF : $@convention(thin) () -> Bool
 // CHECK: bb0
-// CHECK-NEXT: %0 = integer_literal $Builtin.Int1, -1
-// CHECK-NEXT: %1 = struct $Bool
-// CHECK-NEXT: return %1
+// CHECK-NEXT: debug_value undef
+// CHECK-NEXT: %1 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: %2 = struct $Bool
+// CHECK-NEXT: return %2
 @inline(never)
 func test2() -> Bool {
   return cast2(A())
@@ -344,9 +347,10 @@ func test7_2() -> Bool {
 
 // CHECK-LABEL: sil hidden [noinline] @$s12cast_folding5test8SbyF : $@convention(thin) () -> Bool
 // CHECK: bb0
-// CHECK-NEXT: %0 = integer_literal $Builtin.Int1, -1
-// CHECK-NEXT: %1 = struct $Bool
-// CHECK-NEXT: return %1
+// CHECK-NEXT: debug_value undef
+// CHECK-NEXT: %1 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: %2 = struct $Bool
+// CHECK-NEXT: return %2
 @inline(never)
 func test8() -> Bool {
   return cast8(A())
@@ -354,9 +358,10 @@ func test8() -> Bool {
 
 // CHECK-LABEL: sil hidden [noinline] @$s12cast_folding5test9SbyF : $@convention(thin) () -> Bool
 // CHECK: bb0
-// CHECK-NEXT: %0 = integer_literal $Builtin.Int1, -1
-// CHECK-NEXT: %1 = struct $Bool
-// CHECK-NEXT: return %1
+// CHECK-NEXT: debug_value undef
+// CHECK-NEXT: %1 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: %2 = struct $Bool
+// CHECK-NEXT: return %2
 @inline(never)
 func test9() -> Bool {
   return cast9(A())
@@ -364,9 +369,10 @@ func test9() -> Bool {
 
 // CHECK-LABEL: sil hidden [noinline] @$s12cast_folding6test10SbyF : $@convention(thin) () -> Bool
 // CHECK: bb0
-// CHECK-NEXT: %0 = integer_literal $Builtin.Int1, 0
-// CHECK-NEXT: %1 = struct $Bool
-// CHECK-NEXT: return %1
+// CHECK-NEXT: debug_value undef
+// CHECK-NEXT: %1 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: %2 = struct $Bool
+// CHECK-NEXT: return %2
 @inline(never)
 func test10() -> Bool {
   return cast10(A())
@@ -374,9 +380,10 @@ func test10() -> Bool {
 
 // CHECK-LABEL: sil hidden [noinline] @$s12cast_folding6test11SbyF : $@convention(thin) () -> Bool
 // CHECK: bb0
-// CHECK-NEXT: %0 = integer_literal $Builtin.Int1, -1
-// CHECK-NEXT: %1 = struct $Bool
-// CHECK-NEXT: return %1
+// CHECK-NEXT: debug_value undef
+// CHECK-NEXT: %1 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: %2 = struct $Bool
+// CHECK-NEXT: return %2
 @inline(never)
 func test11() -> Bool {
   return cast11(A())
@@ -446,9 +453,10 @@ func test14_2() -> Bool {
 
 // CHECK-LABEL: sil hidden [noinline] @$s12cast_folding8test15_1SbyF : $@convention(thin) () -> Bool
 // CHECK: bb0
-// CHECK-NEXT: %0 = integer_literal $Builtin.Int1, 0
-// CHECK-NEXT: %1 = struct $Bool
-// CHECK-NEXT: return %1
+// CHECK-NEXT: debug_value undef
+// CHECK-NEXT: %1 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: %2 = struct $Bool
+// CHECK-NEXT: return %2
 @inline(never)
 func test15_1() -> Bool {
     return cast15(A())
@@ -466,9 +474,10 @@ func test15_2() -> Bool {
 
 // CHECK-LABEL: sil hidden [noinline] @$s12cast_folding8test16_1SbyF : $@convention(thin) () -> Bool
 // CHECK: bb0
-// CHECK-NEXT: %0 = integer_literal $Builtin.Int1, 0
-// CHECK-NEXT: %1 = struct $Bool
-// CHECK-NEXT: return %1
+// CHECK-NEXT: debug_value undef
+// CHECK-NEXT: %1 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: %2 = struct $Bool
+// CHECK-NEXT: return %2
 @inline(never)
 func test16_1() -> Bool {
     return cast16(A())
@@ -487,9 +496,10 @@ func test16_2() -> Bool {
 
 // CHECK-LABEL: sil hidden [noinline] @$s12cast_folding8test17_1SbyF : $@convention(thin) () -> Bool
 // CHECK: bb0
-// CHECK-NEXT: %0 = integer_literal $Builtin.Int1, 0
-// CHECK-NEXT: %1 = struct $Bool
-// CHECK-NEXT: return %1
+// CHECK-NEXT: debug_value undef
+// CHECK-NEXT: %1 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: %2 = struct $Bool
+// CHECK-NEXT: return %2
 @inline(never)
 func test17_1() -> Bool {
     return cast17(A())
@@ -497,9 +507,10 @@ func test17_1() -> Bool {
 
 // CHECK-LABEL: sil hidden [noinline] @$s12cast_folding8test17_2SbyF : $@convention(thin) () -> Bool
 // CHECK: bb0
-// CHECK-NEXT: %0 = integer_literal $Builtin.Int1, -1
-// CHECK-NEXT: %1 = struct $Bool
-// CHECK-NEXT: return %1
+// CHECK-NEXT: debug_value undef
+// CHECK-NEXT: %1 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: %2 = struct $Bool
+// CHECK-NEXT: return %2
 @inline(never)
 func test17_2() -> Bool {
     return cast17(A() as AnyObject)
@@ -507,9 +518,10 @@ func test17_2() -> Bool {
 
 // CHECK-LABEL: sil hidden [noinline] @$s12cast_folding8test18_1SbyF : $@convention(thin) () -> Bool
 // CHECK: bb0
-// CHECK-NEXT: %0 = integer_literal $Builtin.Int1, 0
-// CHECK-NEXT: %1 = struct $Bool
-// CHECK-NEXT: return %1
+// CHECK-NEXT: debug_value undef : $A, let, name "t", argno 1
+// CHECK-NEXT: %1 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: %2 = struct $Bool
+// CHECK-NEXT: return %2
 @inline(never)
 func test18_1() -> Bool {
     return cast18(A())
@@ -517,9 +529,10 @@ func test18_1() -> Bool {
 
 // CHECK-LABEL: sil hidden [noinline] @$s12cast_folding8test18_2SbyF : $@convention(thin) () -> Bool
 // CHECK: bb0
-// CHECK-NEXT: %0 = integer_literal $Builtin.Int1, -1
-// CHECK-NEXT: %1 = struct $Bool
-// CHECK-NEXT: return %1
+// CHECK-NEXT: debug_value undef : $AnyObject, let, name "t", argno 1
+// CHECK-NEXT: %1 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: %2 = struct $Bool
+// CHECK-NEXT: return %2
 @inline(never)
 func test18_2() -> Bool {
     return cast18(A() as AnyObject)

--- a/test/SILOptimizer/dead_alloc.swift
+++ b/test/SILOptimizer/dead_alloc.swift
@@ -52,6 +52,7 @@ public func deadClassInstance() {
 // CHECK-LABEL: sil @$s10dead_alloc0A13ManagedBufferyyF :
 // CHECK:       bb0:
 // CHECK-NEXT:    debug_value
+// CHECK-NEXT:    debug_value
 // CHECK-NEXT:    tuple
 // CHECK-NEXT:    return
 // CHECK-NEXT:  } // end sil function '$s10dead_alloc0A13ManagedBufferyyF'

--- a/test/SILOptimizer/devirt_inherited_conformance.swift
+++ b/test/SILOptimizer/devirt_inherited_conformance.swift
@@ -163,6 +163,10 @@ public func compareComparable<T:Comparable>(_ x: T, _ y:T) -> Bool {
 // Check that a call of inherited Equatable.== can be devirtualized.
 // CHECK-LABEL: sil @$s28devirt_inherited_conformance17testCompareEqualsSbyF : $@convention(thin) () -> Bool {
 // CHECK: bb0
+// CHECK-NEXT: debug_value undef : $D, let, name "x", argno 1
+// CHECK-NEXT: debug_value undef : $D, let, name "y", argno 2
+// CHECK-NEXT: debug_value undef : $C, let, name "lhs", argno 1
+// CHECK-NEXT: debug_value undef : $C, let, name "rhs", argno 2
 // CHECK-NEXT: integer_literal $Builtin.Int1, -1
 // CHECK-NEXT: struct $Bool
 // CHECK: return
@@ -176,6 +180,10 @@ public func testCompareEquals() -> Bool {
 // Check that a call of inherited Simple.== can be devirtualized.
 // CHECK-LABEL: sil @$s28devirt_inherited_conformance014testCompareMinfF0SbyF : $@convention(thin) () -> Bool {
 // CHECK: bb0
+// CHECK-NEXT: debug_value undef : $D, let, name "x", argno 1
+// CHECK-NEXT: debug_value undef : $D, let, name "y", argno 2
+// CHECK-NEXT: debug_value undef : $C, let, name "lhs", argno 1
+// CHECK-NEXT: debug_value undef : $C, let, name "rhs", argno 2
 // CHECK-NEXT: integer_literal $Builtin.Int1, -1
 // CHECK-NEXT: struct $Bool
 // CHECK: return
@@ -186,6 +194,13 @@ public func testCompareMinMinMin() -> Bool {
 // Check that a call of inherited Comparable.== can be devirtualized.
 // CHECK-LABEL: sil @$s28devirt_inherited_conformance21testCompareComparableSbyF : $@convention(thin) () -> Bool {
 // CHECK: bb0
+// CHECK-NEXT: debug_value undef : $D, let, name "x", argno 1
+// CHECK-NEXT: debug_value undef : $D, let, name "y", argno 2
+// CHECK-NEXT: debug_value undef : $C, let, name "c1", argno 1
+// CHECK-NEXT: debug_value undef : $C, let, name "c2", argno 2
+// CHECK-NEXT: debug_value undef : $C, let, name "self", argno 3
+// CHECK-NEXT: debug_value undef : $C, let, name "lhs", argno 1
+// CHECK-NEXT: debug_value undef : $C, let, name "rhs", argno 2
 // CHECK-NEXT: integer_literal $Builtin.Int1, -1
 // CHECK-NEXT: struct $Bool
 // CHECK: return
@@ -200,6 +215,11 @@ public func BooCall<T:Simple>(_ x:T, _ y:T) -> Bool {
 // Check that a call of inherited Simple.boo can be devirtualized.
 // CHECK-LABEL: sil @$s28devirt_inherited_conformance11testBooCallSbyF : $@convention(thin) () -> Bool {
 // CHECK: bb0
+// CHECK-NEXT: debug_value undef : $D, let, name "x", argno 1
+// CHECK-NEXT: debug_value undef : $D, let, name "y", argno 2
+// CHECK-NEXT: debug_value undef : $C, let, name "c1", argno 1
+// CHECK-NEXT: debug_value undef : $C, let, name "c2", argno 2
+// CHECK-NEXT: debug_value undef : $C, let, name "self", argno 3
 // CHECK-NEXT: integer_literal $Builtin.Int1, 0
 // CHECK-NEXT: struct $Bool
 // CHECK: return

--- a/test/SILOptimizer/sil_combine_protocol_conf.swift
+++ b/test/SILOptimizer/sil_combine_protocol_conf.swift
@@ -151,9 +151,9 @@ public class Other {
 // CHECK: tuple_extract
 // CHECK: cond_fail
 // CHECK: [[R4:%.*]] = ref_element_addr [immutable] %0 : $Other, #Other.s
-// CHECK: [[O4:%.*]] = open_existential_addr immutable_access %36 : $*any MultipleConformanceProtocol to $*@opened("{{.*}}", any MultipleConformanceProtocol) Self
-// CHECK: [[W4:%.*]] = witness_method $@opened("{{.*}}", any MultipleConformanceProtocol) Self, #MultipleConformanceProtocol.foo : <Self where Self : MultipleConformanceProtocol> (Self) -> () -> Int, %37 : $*@opened("{{.*}}", any MultipleConformanceProtocol) Self : $@convention(witness_method: MultipleConformanceProtocol) <τ_0_0 where τ_0_0 : MultipleConformanceProtocol> (@in_guaranteed τ_0_0) -> Int
-// CHECK: apply [[W4]]<@opened("{{.*}}", any MultipleConformanceProtocol) Self>(%37) : $@convention(witness_method: MultipleConformanceProtocol) <τ_0_0 where τ_0_0 : MultipleConformanceProtocol> (@in_guaranteed τ_0_0) -> Int
+// CHECK: [[O4:%.*]] = open_existential_addr immutable_access [[R4]] : $*any MultipleConformanceProtocol to $*@opened("{{.*}}", any MultipleConformanceProtocol) Self
+// CHECK: [[W4:%.*]] = witness_method $@opened("{{.*}}", any MultipleConformanceProtocol) Self, #MultipleConformanceProtocol.foo : <Self where Self : MultipleConformanceProtocol> (Self) -> () -> Int, [[O4]] : $*@opened("{{.*}}", any MultipleConformanceProtocol) Self : $@convention(witness_method: MultipleConformanceProtocol) <τ_0_0 where τ_0_0 : MultipleConformanceProtocol> (@in_guaranteed τ_0_0) -> Int
+// CHECK: apply [[W4]]<@opened("{{.*}}", any MultipleConformanceProtocol) Self>([[O4]]) : $@convention(witness_method: MultipleConformanceProtocol) <τ_0_0 where τ_0_0 : MultipleConformanceProtocol> (@in_guaranteed τ_0_0) -> Int
 // CHECK: struct_extract
 // CHECK: builtin
 // CHECK: tuple_extract


### PR DESCRIPTION
Salvage debug info must be called in reverse order as the debug_value needs to go up the use chain, and all of that before instructions are finally deleted.
Decreases the amount of lost variables in the Source Compatibility Test Suite by **18.6%**.
Decreases the amount of lost variables in the Standard Library by **16.3%**, including **82%** of DCE cases. 