### PR TITLE
[cxx-interop] Make ForeignReferenceTypeInfo request cached again

### DIFF
--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -405,9 +405,11 @@ class ForeignReferenceTypeInfoRequest
     : public SimpleRequest<ForeignReferenceTypeInfoRequest,
                            ForeignReferenceTypeInfo(
                                ForeignReferenceTypeInfoDescriptor),
-                           RequestFlags::Uncached> {
+                           RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
+
+  bool isCached() const { return true; }
 
   SourceLoc getNearestLoc() const { return SourceLoc(); };
 

--- a/include/swift/ClangImporter/ClangImporterTypeIDZone.def
+++ b/include/swift/ClangImporter/ClangImporterTypeIDZone.def
@@ -28,7 +28,7 @@ SWIFT_REQUEST(ClangImporter, ObjCInterfaceAndImplementationRequest,
               ObjCInterfaceAndImplementation(Decl *), SeparatelyCached,
               NoLocationInfo)
 SWIFT_REQUEST(ClangImporter, ForeignReferenceTypeInfoRequest,
-              ForeignReferenceTypeInfo(ForeignReferenceTypeInfoDescriptor), Uncached,
+              ForeignReferenceTypeInfo(ForeignReferenceTypeInfoDescriptor), Cached,
               NoLocationInfo)
 SWIFT_REQUEST(ClangImporter, CxxRecordSemantics,
               CxxRecordSemanticsKind(CxxRecordSemanticsDescriptor), Cached,


### PR DESCRIPTION
Caching on the ForeignReferenceTypeInfo request was disabled in #88727 because the request was being invoked by IsSafeUseOfCxxDecl during the name import phase. Since name importing can run in Clang sub-instances that build the Swift lookup tables for each submodule, sub-instances going away left stale cache entries whose keys could collide with new Clang allocations.

Now that #89897 has moved IsSafeUseOfCxxDecl out of the name importing phase, it is safe to re-enable caching on ForeignReferenceTypeInfo.

rdar://181618400