### PR TITLE
Require an optimized stdlib to run CodableTests.swift

### DIFF
--- a/test/stdlib/CodableTests.swift
+++ b/test/stdlib/CodableTests.swift
@@ -13,6 +13,7 @@
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 // UNSUPPORTED: back_deployment_runtime
+// REQUIRES: optimized_stdlib
 
 import Foundation
 import CoreGraphics


### PR DESCRIPTION
This is a frequent cause of timeouts, so disable it in non-optimized CI runs for now.

Resolves rdar://178043375