### PR TITLE
Sema: Remove deprecation checking special case in favor of `@diagnose`

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1679,9 +1679,6 @@ static void diagnoseIfDeprecated(SourceRange ReferenceRange,
     }
   }
 
-  if (shouldIgnoreDeprecationOfConcurrencyDecl(DeprecatedDecl, ReferenceDC))
-    return;
-
   auto Domain = Attr->getDomain();
   auto DeprecatedRange = Attr->getDeprecatedRange(Context).value();
   auto Message = Attr->getMessage();

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1703,41 +1703,6 @@ void swift::tryDiagnoseExecutorConformance(ASTContext &C,
   }
 }
 
-bool swift::shouldIgnoreDeprecationOfConcurrencyDecl(const Decl *decl,
-                                                     DeclContext *declContext) {
-  auto &ctx = decl->getASTContext();
-  auto concurrencyModule = ctx.getLoadedModule(ctx.Id_Concurrency);
-
-  // Only suppress these diagnostics in the implementation of _Concurrency.
-  if (declContext->getParentModule() != concurrencyModule)
-    return false;
-
-  // Only suppress deprecation diagnostics for decls defined in _Concurrency.
-  if (decl->getDeclContext()->getParentModule() != concurrencyModule)
-    return false;
-
-  auto *legacyJobDecl = ctx.getJobDecl();
-  auto *unownedJobDecl = ctx.getUnownedJobDecl();
-
-  if (decl == legacyJobDecl)
-    return true;
-
-  if (auto *funcDecl = dyn_cast<FuncDecl>(decl)) {
-    auto enqueueDeclName =
-        DeclName(ctx, DeclBaseName(ctx.Id_enqueue), {Identifier()});
-
-    if (funcDecl->getName() == enqueueDeclName &&
-        funcDecl->getParameters()->size() == 1) {
-      auto paramTy = funcDecl->getParameters()->front()->getInterfaceType();
-      if (paramTy->isEqual(legacyJobDecl->getDeclaredInterfaceType()) ||
-          paramTy->isEqual(unownedJobDecl->getDeclaredInterfaceType()))
-        return true;
-    }
-  }
-
-  return false;
-}
-
 /// Determine whether this is the main actor type.
 static bool isMainActor(Type type) {
   if (auto nominal = type->getAnyNominal())

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -349,14 +349,6 @@ void diagnoseMissingExplicitSendable(NominalTypeDecl *nominal);
 /// Warn about deprecated `Executor.enqueue` implementations.
 void tryDiagnoseExecutorConformance(ASTContext &C, const NominalTypeDecl *nominal, ProtocolDecl *proto);
 
-/// Whether to suppress deprecation diagnostics for \p decl in \p declContext
-/// because \p decl is a deprecated decl from the `_Concurrency` module and is
-/// being referenced from the implementation of the `_Concurrency` module. This
-/// prevents unaddressable warnings in the standard library build. Ideally, a
-/// language feature would obviate the need for this.
-bool shouldIgnoreDeprecationOfConcurrencyDecl(const Decl *decl,
-                                              DeclContext *declContext);
-
 // Get a concrete reference to a declaration
 ConcreteDeclRef getDeclRefInContext(ValueDecl *value);
 

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -498,11 +498,13 @@ extension Executor {
   }
 
   @inlinable
+  @diagnose(DeprecatedDeclaration, as: ignored)
   public func enqueue(_ job: consuming ExecutorJob) {
     self.enqueue(Job(job))
   }
 
   @inlinable
+  @diagnose(DeprecatedDeclaration, as: ignored)
   public func enqueue(_ job: consuming Job) {
     self.enqueue(UnownedJob(job))
   }

--- a/stdlib/public/Concurrency/ExecutorImpl.swift
+++ b/stdlib/public/Concurrency/ExecutorImpl.swift
@@ -68,6 +68,7 @@ internal func getMainExecutor() -> UnownedSerialExecutor {
 @available(SwiftStdlib 6.2, *)
 @_silgen_name("swift_task_enqueueMainExecutorImpl")
 @diagnose(UselessAvailabilityCheck, as: ignored)
+@diagnose(DeprecatedDeclaration, as: ignored)
 internal func enqueueOnMainExecutor(job unownedJob: UnownedJob) {
   #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
   if #available(StdlibDeploymentTarget 6.3, *) {

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -71,6 +71,7 @@ public struct UnownedJob: Sendable {
   #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
   /// Create an `UnownedJob` whose lifetime must be managed carefully until it is run exactly once.
   @available(StdlibDeploymentTarget 5.9, *)
+  @diagnose(DeprecatedDeclaration, as: ignored)
   public init(_ job: __owned Job) { // must remain '__owned' in order to not break ABI
     self.context = job.context
   }
@@ -253,6 +254,7 @@ public struct Job: Sendable, ~Copyable {
 }
 
 @available(SwiftStdlib 5.9, *)
+@diagnose(DeprecatedDeclaration, as: ignored)
 extension Job {
 
   /// Run this job on the passed in executor.
@@ -295,6 +297,7 @@ public struct ExecutorJob: Sendable, ~Copyable {
     self.context = job._context
   }
 
+  @diagnose(DeprecatedDeclaration, as: ignored)
   public init(_ job: __owned Job) {
     self.context = job.context
   }


### PR DESCRIPTION
In https://github.com/swiftlang/swift/pull/70912, a special case was added to availability checking to suppress deprecation diagnostics that would be emitted about references to the `_Concurrency.Job` declaration when building the `_Concurrency` module itself. Preserving binary compatibility necessitated the references and therefore the warnings were unhelpful. However, now that we can suppress unwanted deprecation diagnostics with `@diagnose` it is no longer necessary to hard code this exception into the compiler.
