### PR TITLE
[utils] remote-run: fetch output files even when the remote command fails

### DIFF
--- a/utils/remote-run
+++ b/utils/remote-run
@@ -116,7 +116,9 @@ class CommandRunner(object):
     def mkdirs_remote(self, directories):
         if directories:
             mkdir_command = ['/bin/mkdir', '-p'] + directories
-            self.run_remote(mkdir_command)
+            result = self.run_remote(mkdir_command)
+            if result is not None:
+                _exit_propagating_remote_signal(*result)
 
     def send(self, input_prefix, remote_prefix, local_to_remote_files):
         # Prepare the remote directory structure.
@@ -186,15 +188,13 @@ class CommandRunner(object):
 
             # Process error code
             if remote_proc.returncode:
-                # FIXME: We may still want to fetch the output files to see what
-                # went wrong.
-                _exit_propagating_remote_signal(remote_proc.returncode, stdout, stderr)
+                return (remote_proc.returncode, stdout, stderr)
             else:
                 # Nothing went wrong. Return
                 return
 
         if attempt > 3 and remote_proc is not None:
-            _exit_propagating_remote_signal(remote_proc.returncode, stdout, stderr)
+            return (remote_proc.returncode, stdout, stderr)
 
     def run_rsync(self, invocation, sources):
         attempt = 1
@@ -512,7 +512,9 @@ def main():
     output_dir = posixpath.join(args.remote_dir, args.remote_output_prefix)
 
     if args.output_prefix:
-        runner.run_remote(['/bin/rm', '-rf', output_dir])
+        result = runner.run_remote(['/bin/rm', '-rf', output_dir])
+        if result is not None:
+            _exit_propagating_remote_signal(*result)
 
     dirs = set()
     for output in path_set.outputs:
@@ -535,7 +537,7 @@ def main():
         runner.send(posixpath.dirname(args.output_prefix),
                     output_dir, path_set.existing_nodir_outputs)
 
-    runner.run_remote(argproc.args, envproc.env)
+    run_result = runner.run_remote(argproc.args, envproc.env)
 
     if path_set.outputs:
         runner.fetch(args.output_prefix, output_dir, path_set.outputs)
@@ -543,6 +545,9 @@ def main():
     if path_set.nodir_outputs:
         runner.fetch(posixpath.dirname(args.output_prefix),
                      output_dir, path_set.nodir_outputs)
+
+    if run_result is not None:
+        _exit_propagating_remote_signal(*run_result)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION

`remote-run` is expected to rsync any paths matching `--output-prefix` back to the local machine, but the `run_remote` process exits immediately on a non-zero remote returncode, so the fetch step never runs. This loses any output files a failing remote command had written — the FIXME comment on the offending line called this out explicitly.

Tests that intentionally crash the remote binary and then read a file it produced (e.g. SWIFT_BACKTRACE=...,output-to=%t/crash.log) cannot work under remote-run today for this reason.

This PR refactors `run_remote` so it returns `(returncode, stdout, stderr)` on failure instead of exiting. Callers exit at the appropriate time:

- `mkdirs_remote` and the pre-run `rm -rf output_dir` in `main()` are setup steps — they propagate immediately on failure.
- The main test invocation in `main()` defers, runs both `runner.fetch` calls, then propagates.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
