### PR TITLE
[test][Backtracing] Make suite work under remote-run: %env- SWIFT_BACKTRACE, upload .dSYM

### DIFF
--- a/test/Backtracing/Crash.test
+++ b/test/Backtracing/Crash.test
@@ -2,10 +2,10 @@
 // RUN: %target-build-swift %S/Inputs/Crash.swift -parse-as-library -Onone %swift-debug-flags -o %t/Crash.exe
 // RUN: %target-codesign %t/Crash.exe
 
-// RUN: ! env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/Crash.exe > %t/Crash.out 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/Crash.exe > %t/Crash.out 2>&1
 // RUN: %FileCheck %s --ignore-case < %t/Crash.out
 
-// RUN: ! env SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/Crash.exe > %t/Friendly.out 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/Crash.exe > %t/Friendly.out 2>&1
 // RUN: %FileCheck %s --ignore-case --check-prefix FRIENDLY < %t/Friendly.out
 
 // UNSUPPORTED: use_os_stdlib

--- a/test/Backtracing/CrashAsync.swift
+++ b/test/Backtracing/CrashAsync.swift
@@ -5,8 +5,8 @@
 // Demangling is disabled for now because older macOS can't demangle async
 // function names.  We test demangling elsewhere, so this is no big deal.
 
-// RUN: not --crash env SWIFT_BACKTRACE=enable=yes,demangle=no,cache=no %target-run %t/CrashAsync 2>&1 | %FileCheck %s
-// RUN: not --crash env SWIFT_BACKTRACE=preset=friendly,enable=yes,demangle=no,cache=no %target-run %t/CrashAsync 2>&1 | %FileCheck %s --check-prefix FRIENDLY
+// RUN: not --crash env %env-SWIFT_BACKTRACE=enable=yes,demangle=no,cache=no %target-run %t/CrashAsync 2>&1 | %FileCheck %s
+// RUN: not --crash env %env-SWIFT_BACKTRACE=preset=friendly,enable=yes,demangle=no,cache=no %target-run %t/CrashAsync 2>&1 | %FileCheck %s --check-prefix FRIENDLY
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/Backtracing/CrashNoDebug-Win32.test
+++ b/test/Backtracing/CrashNoDebug-Win32.test
@@ -4,10 +4,10 @@
 // RUN: %target-codesign %t/CrashNoDebug.exe
 // RUN: %target-codesign %t/CrashOptNoDebug.exe
 
-// RUN: ! env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashNoDebug.exe > %t/NoDebug.out 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashNoDebug.exe > %t/NoDebug.out 2>&1
 // RUN: %FileCheck %s --ignore-case --check-prefix NODEBUG < %t/NoDebug.out
 
-// RUN: ! env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashOptNoDebug.exe > %t/OptNoDebug.out 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashOptNoDebug.exe > %t/OptNoDebug.out 2>&1
 // RUN: %FileCheck %s --ignore-case --check-prefix OPTNODEBUG < %t/OptNoDebug.out
 
 // UNSUPPORTED: use_os_stdlib

--- a/test/Backtracing/CrashNoDebug.test
+++ b/test/Backtracing/CrashNoDebug.test
@@ -4,10 +4,10 @@
 // RUN: %target-codesign %t/CrashNoDebug.exe
 // RUN: %target-codesign %t/CrashOptNoDebug.exe
 
-// RUN: env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashNoDebug.exe > %t/NoDebug.out 2>&1 || true
+// RUN: env %env-SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashNoDebug.exe > %t/NoDebug.out 2>&1 || true
 // RUN: %FileCheck %s --ignore-case --check-prefix NODEBUG < %t/NoDebug.out
 
-// RUN: env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashOptNoDebug.exe > %t/OptNoDebug.out 2>&1 || true
+// RUN: env %env-SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashOptNoDebug.exe > %t/OptNoDebug.out 2>&1 || true
 // RUN: %FileCheck %s --ignore-case --check-prefix OPTNODEBUG < %t/OptNoDebug.out
 
 // UNSUPPORTED: use_os_stdlib

--- a/test/Backtracing/CrashOpt.test
+++ b/test/Backtracing/CrashOpt.test
@@ -2,7 +2,7 @@
 // RUN: %target-build-swift %S/Inputs/Crash.swift -parse-as-library -O %swift-debug-flags -o %t/CrashOpt.exe
 // RUN: %target-codesign %t/CrashOpt.exe
 
-// RUN: env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashOpt.exe > %t/Optimized.out 2>&1 || true
+// RUN: env %env-SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashOpt.exe > %t/Optimized.out 2>&1 || true
 // RUN: %FileCheck %s --ignore-case --check-prefix OPTIMIZED < %t/Optimized.out
 
 // UNSUPPORTED: use_os_stdlib

--- a/test/Backtracing/CrashOpt.test
+++ b/test/Backtracing/CrashOpt.test
@@ -2,7 +2,7 @@
 // RUN: %target-build-swift %S/Inputs/Crash.swift -parse-as-library -O %swift-debug-flags -o %t/CrashOpt.exe
 // RUN: %target-codesign %t/CrashOpt.exe
 
-// RUN: env %env-SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashOpt.exe > %t/Optimized.out 2>&1 || true
+// RUN: env %env-SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashOpt.exe %t/CrashOpt.exe.dSYM > %t/Optimized.out 2>&1 || true
 // RUN: %FileCheck %s --ignore-case --check-prefix OPTIMIZED < %t/Optimized.out
 
 // UNSUPPORTED: use_os_stdlib

--- a/test/Backtracing/CrashOutputFile.test
+++ b/test/Backtracing/CrashOutputFile.test
@@ -2,9 +2,9 @@
 // RUN: %empty-directory(%t/crashlogs)
 // RUN: %target-build-swift %S/Inputs/Crash.swift -parse-as-library -Onone -g -o %t/CrashOutputFile.exe
 // RUN: %target-codesign %t/CrashOutputFile.exe
-// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no,output-to=%t/crash.log %target-run %t/CrashOutputFile.exe 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no,output-to=%t/crash.log %target-run %t/CrashOutputFile.exe %t/CrashOutputFile.exe.dSYM 2>&1
 // RUN: %FileCheck --ignore-case %s < %t/crash.log
-// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no,output-to=%t/crashlogs %target-run %t/CrashOutputFile.exe 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no,output-to=%t/crashlogs %target-run %t/CrashOutputFile.exe %t/CrashOutputFile.exe.dSYM 2>&1
 // RUN: cat %t/crashlogs/* | %FileCheck --ignore-case %s
 
 // UNSUPPORTED: use_os_stdlib

--- a/test/Backtracing/CrashOutputFile.test
+++ b/test/Backtracing/CrashOutputFile.test
@@ -2,9 +2,9 @@
 // RUN: %empty-directory(%t/crashlogs)
 // RUN: %target-build-swift %S/Inputs/Crash.swift -parse-as-library -Onone -g -o %t/CrashOutputFile.exe
 // RUN: %target-codesign %t/CrashOutputFile.exe
-// RUN: ! env SWIFT_BACKTRACE=enable=yes,cache=no,output-to=%t/crash.log %target-run %t/CrashOutputFile.exe 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no,output-to=%t/crash.log %target-run %t/CrashOutputFile.exe 2>&1
 // RUN: %FileCheck --ignore-case %s < %t/crash.log
-// RUN: ! env SWIFT_BACKTRACE=enable=yes,cache=no,output-to=%t/crashlogs %target-run %t/CrashOutputFile.exe 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no,output-to=%t/crashlogs %target-run %t/CrashOutputFile.exe 2>&1
 // RUN: cat %t/crashlogs/* | %FileCheck --ignore-case %s
 
 // UNSUPPORTED: use_os_stdlib

--- a/test/Backtracing/CrashStatic.swift
+++ b/test/Backtracing/CrashStatic.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -parse-as-library %import-static-libdispatch -Onone -static-stdlib -g -o %t/CrashStatic
 // RUN: %target-codesign %t/CrashStatic
-// RUN: not --crash env SWIFT_BACKTRACE=enable=yes,cache=no,swift-backtrace=%backtracer %target-run %t/CrashStatic 2>&1 | %FileCheck %s
+// RUN: not --crash env %env-SWIFT_BACKTRACE=enable=yes,cache=no,swift-backtrace=%backtracer %target-run %t/CrashStatic 2>&1 | %FileCheck %s
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/Backtracing/CrashWithThreadsLinux.swift
+++ b/test/Backtracing/CrashWithThreadsLinux.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -Onone -g -o %t/CrashWithThreads
 // RUN: %target-codesign %t/CrashWithThreads
-// RUN: not --crash env SWIFT_BACKTRACE=enable=yes,cache=no,swift-backtrace=%backtracer %target-run %t/CrashWithThreads 2>&1 | %FileCheck -vv %s -dump-input-filter=all
-// RUN: not --crash env SWIFT_BACKTRACE=enable=yes,cache=no,swift-backtrace=%backtracer,threads=all %target-run %t/CrashWithThreads 2>&1 | %FileCheck -vv %s -dump-input-filter=all
+// RUN: not --crash env %env-SWIFT_BACKTRACE=enable=yes,cache=no,swift-backtrace=%backtracer %target-run %t/CrashWithThreads 2>&1 | %FileCheck -vv %s -dump-input-filter=all
+// RUN: not --crash env %env-SWIFT_BACKTRACE=enable=yes,cache=no,swift-backtrace=%backtracer,threads=all %target-run %t/CrashWithThreads 2>&1 | %FileCheck -vv %s -dump-input-filter=all
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/Backtracing/CrashWithThreadsMac.swift
+++ b/test/Backtracing/CrashWithThreadsMac.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -Onone -g -o %t/CrashWithThreads
 // RUN: %target-codesign %t/CrashWithThreads
-// RUN: not --crash env %env-SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashWithThreads 2>&1 | %FileCheck -vv %s -dump-input-filter=all
-// RUN: not --crash env %env-SWIFT_BACKTRACE=enable=yes,cache=no,threads=all %target-run %t/CrashWithThreads 2>&1 | %FileCheck -vv %s -dump-input-filter=all
+// RUN: not --crash env %env-SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashWithThreads %t/CrashWithThreads.dSYM 2>&1 | %FileCheck -vv %s -dump-input-filter=all
+// RUN: not --crash env %env-SWIFT_BACKTRACE=enable=yes,cache=no,threads=all %target-run %t/CrashWithThreads %t/CrashWithThreads.dSYM 2>&1 | %FileCheck -vv %s -dump-input-filter=all
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/Backtracing/CrashWithThreadsMac.swift
+++ b/test/Backtracing/CrashWithThreadsMac.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -Onone -g -o %t/CrashWithThreads
 // RUN: %target-codesign %t/CrashWithThreads
-// RUN: not --crash env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashWithThreads 2>&1 | %FileCheck -vv %s -dump-input-filter=all
-// RUN: not --crash env SWIFT_BACKTRACE=enable=yes,cache=no,threads=all %target-run %t/CrashWithThreads 2>&1 | %FileCheck -vv %s -dump-input-filter=all
+// RUN: not --crash env %env-SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashWithThreads 2>&1 | %FileCheck -vv %s -dump-input-filter=all
+// RUN: not --crash env %env-SWIFT_BACKTRACE=enable=yes,cache=no,threads=all %target-run %t/CrashWithThreads 2>&1 | %FileCheck -vv %s -dump-input-filter=all
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/Backtracing/CrashWithThunk.test
+++ b/test/Backtracing/CrashWithThunk.test
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %S/Inputs/CrashWithThunk.swift -parse-as-library -Onone %swift-debug-flags -o %t/CrashWithThunk.exe
 // RUN: %target-codesign %t/CrashWithThunk.exe
-// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashWithThunk.exe > %t/CrashWithThunk.out 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashWithThunk.exe %t/CrashWithThunk.exe.dSYM > %t/CrashWithThunk.out 2>&1
 // RUN: %FileCheck --ignore-case %s < %t/CrashWithThunk.out
-// RUN: ! env %env-SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/CrashWithThunk.exe > %t/Friendly.out 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/CrashWithThunk.exe %t/CrashWithThunk.exe.dSYM > %t/Friendly.out 2>&1
 // RUN %FileCheck %s --ignore-case --check-prefix FRIENDLY < %t/Friendly.out
 
 // UNSUPPORTED: use_os_stdlib

--- a/test/Backtracing/CrashWithThunk.test
+++ b/test/Backtracing/CrashWithThunk.test
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %S/Inputs/CrashWithThunk.swift -parse-as-library -Onone %swift-debug-flags -o %t/CrashWithThunk.exe
 // RUN: %target-codesign %t/CrashWithThunk.exe
-// RUN: ! env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashWithThunk.exe > %t/CrashWithThunk.out 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashWithThunk.exe > %t/CrashWithThunk.out 2>&1
 // RUN: %FileCheck --ignore-case %s < %t/CrashWithThunk.out
-// RUN: ! env SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/CrashWithThunk.exe > %t/Friendly.out 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/CrashWithThunk.exe > %t/Friendly.out 2>&1
 // RUN %FileCheck %s --ignore-case --check-prefix FRIENDLY < %t/Friendly.out
 
 // UNSUPPORTED: use_os_stdlib

--- a/test/Backtracing/EarlyMessage.swift
+++ b/test/Backtracing/EarlyMessage.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -parse-as-library -Onone -g -o %t/EarlyMessage.exe
 // RUN: %target-codesign %t/EarlyMessage.exe
-// RUN: ! env SWIFT_BACKTRACE=enable=yes,cache=no,warnings=suppressed %target-run %t/EarlyMessage.exe > %t/EarlyMessage.out 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no,warnings=suppressed %target-run %t/EarlyMessage.exe > %t/EarlyMessage.out 2>&1
 // RUN: %FileCheck %s < %t/EarlyMessage.out
 
 // UNSUPPORTED: use_os_stdlib

--- a/test/Backtracing/FatalError.swift
+++ b/test/Backtracing/FatalError.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -parse-as-library -Onone -g -o %t/FatalError
 // RUN: %target-codesign %t/FatalError
-// RUN: not --crash env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/FatalError 2>&1 | %FileCheck %s
+// RUN: not --crash env %env-SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/FatalError 2>&1 | %FileCheck %s
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/Backtracing/JSON.swift
+++ b/test/Backtracing/JSON.swift
@@ -1,18 +1,18 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -parse-as-library -module-name JSONTest -Onone -g -o %t/json.exe
 // RUN: %target-codesign %t/json.exe
-// RUN: ! env SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash.json %target-run %t/json.exe 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash.json %target-run %t/json.exe 2>&1
 // RUN: %validate-json %t/crash.json | %FileCheck %s --check-prefixes CHECK,UNSANITIZED,DEMANGLED,IMAGES,OMITTEDIMAGES,SYMBOLICATED,CAPTUREDMEM
 
 // Also check that we generate valid JSON with various different options set.
 
-// RUN: ! env SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash2.json,threads=crashed %target-run %t/json.exe 2>&1
-// RUN: ! env SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash3.json,registers=all %target-run %t/json.exe 2>&1
-// RUN: ! env SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash4.json,sanitize=yes %target-run %t/json.exe 2>&1
-// RUN: ! env SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash5.json,images=none %target-run %t/json.exe 2>&1
-// RUN: ! env SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash6.json,images=all %target-run %t/json.exe 2>&1
-// RUN: ! env SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash7.json,symbolicate=off %target-run %t/json.exe 2>&1
-// RUN: ! env SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash8.json,demangle=no %target-run %t/json.exe 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash2.json,threads=crashed %target-run %t/json.exe 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash3.json,registers=all %target-run %t/json.exe 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash4.json,sanitize=yes %target-run %t/json.exe 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash5.json,images=none %target-run %t/json.exe 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash6.json,images=all %target-run %t/json.exe 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash7.json,symbolicate=off %target-run %t/json.exe 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash8.json,demangle=no %target-run %t/json.exe 2>&1
 // RUN: %validate-json %t/crash2.json| %FileCheck %s --check-prefixes CHECK,UNSANITIZED,DEMANGLED,IMAGES,OMITTEDIMAGES,SYMBOLICATED,CAPTUREDMEM
 // RUN: %validate-json %t/crash3.json| %FileCheck %s --check-prefixes CHECK,UNSANITIZED,DEMANGLED,IMAGES,OMITTEDIMAGES,SYMBOLICATED,CAPTUREDMEM
 // RUN: %validate-json %t/crash4.json| %FileCheck %s --check-prefixes CHECK,SANITIZED,DEMANGLED,IMAGES,OMITTEDIMAGES,SYMBOLICATED

--- a/test/Backtracing/JSON.swift
+++ b/test/Backtracing/JSON.swift
@@ -1,18 +1,18 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -parse-as-library -module-name JSONTest -Onone -g -o %t/json.exe
 // RUN: %target-codesign %t/json.exe
-// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash.json %target-run %t/json.exe 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash.json %target-run %t/json.exe %t/json.exe.dSYM 2>&1
 // RUN: %validate-json %t/crash.json | %FileCheck %s --check-prefixes CHECK,UNSANITIZED,DEMANGLED,IMAGES,OMITTEDIMAGES,SYMBOLICATED,CAPTUREDMEM
 
 // Also check that we generate valid JSON with various different options set.
 
-// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash2.json,threads=crashed %target-run %t/json.exe 2>&1
-// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash3.json,registers=all %target-run %t/json.exe 2>&1
-// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash4.json,sanitize=yes %target-run %t/json.exe 2>&1
-// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash5.json,images=none %target-run %t/json.exe 2>&1
-// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash6.json,images=all %target-run %t/json.exe 2>&1
-// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash7.json,symbolicate=off %target-run %t/json.exe 2>&1
-// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash8.json,demangle=no %target-run %t/json.exe 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash2.json,threads=crashed %target-run %t/json.exe %t/json.exe.dSYM 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash3.json,registers=all %target-run %t/json.exe %t/json.exe.dSYM 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash4.json,sanitize=yes %target-run %t/json.exe %t/json.exe.dSYM 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash5.json,images=none %target-run %t/json.exe %t/json.exe.dSYM 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash6.json,images=all %target-run %t/json.exe %t/json.exe.dSYM 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash7.json,symbolicate=off %target-run %t/json.exe %t/json.exe.dSYM 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash8.json,demangle=no %target-run %t/json.exe %t/json.exe.dSYM 2>&1
 // RUN: %validate-json %t/crash2.json| %FileCheck %s --check-prefixes CHECK,UNSANITIZED,DEMANGLED,IMAGES,OMITTEDIMAGES,SYMBOLICATED,CAPTUREDMEM
 // RUN: %validate-json %t/crash3.json| %FileCheck %s --check-prefixes CHECK,UNSANITIZED,DEMANGLED,IMAGES,OMITTEDIMAGES,SYMBOLICATED,CAPTUREDMEM
 // RUN: %validate-json %t/crash4.json| %FileCheck %s --check-prefixes CHECK,SANITIZED,DEMANGLED,IMAGES,OMITTEDIMAGES,SYMBOLICATED

--- a/test/Backtracing/JSONAsync.swift
+++ b/test/Backtracing/JSONAsync.swift
@@ -2,7 +2,7 @@
 // RUN: %target-build-swift %s -parse-as-library -Onone -g -o %t/JSONAsync
 // RUN: %target-codesign %t/JSONAsync
 
-// RUN: env %env-SWIFT_BACKTRACE=enable=yes,demangle=no,cache=no,format=json,output-to=%t/crash.json %target-run %t/JSONAsync 2>&1 || true
+// RUN: env %env-SWIFT_BACKTRACE=enable=yes,demangle=no,cache=no,format=json,output-to=%t/crash.json %target-run %t/JSONAsync %t/JSONAsync.dSYM 2>&1 || true
 // RUN: %validate-json %t/crash.json | %FileCheck %s
 
 // UNSUPPORTED: use_os_stdlib

--- a/test/Backtracing/JSONAsync.swift
+++ b/test/Backtracing/JSONAsync.swift
@@ -2,7 +2,7 @@
 // RUN: %target-build-swift %s -parse-as-library -Onone -g -o %t/JSONAsync
 // RUN: %target-codesign %t/JSONAsync
 
-// RUN: env SWIFT_BACKTRACE=enable=yes,demangle=no,cache=no,format=json,output-to=%t/crash.json %target-run %t/JSONAsync 2>&1 || true
+// RUN: env %env-SWIFT_BACKTRACE=enable=yes,demangle=no,cache=no,format=json,output-to=%t/crash.json %target-run %t/JSONAsync 2>&1 || true
 // RUN: %validate-json %t/crash.json | %FileCheck %s
 
 // UNSUPPORTED: use_os_stdlib

--- a/test/Backtracing/Overflow.test
+++ b/test/Backtracing/Overflow.test
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %S/Inputs/Overflow.swift -parse-as-library -Onone %swift-debug-flags -o %t/Overflow.exe
 // RUN: %target-codesign %t/Overflow.exe
-// RUN: ! env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/Overflow.exe > %t/Overflow.out 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/Overflow.exe > %t/Overflow.out 2>&1
 // RUN: %FileCheck %s --ignore-case < %t/Overflow.out
-// RUN: ! env SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/Overflow.exe > %t/Friendly.out 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/Overflow.exe > %t/Friendly.out 2>&1
 // RUN: %FileCheck %s --ignore-case --check-prefix FRIENDLY < %t/Friendly.out
 
 // UNSUPPORTED: use_os_stdlib

--- a/test/Backtracing/Overflow.test
+++ b/test/Backtracing/Overflow.test
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %S/Inputs/Overflow.swift -parse-as-library -Onone %swift-debug-flags -o %t/Overflow.exe
 // RUN: %target-codesign %t/Overflow.exe
-// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/Overflow.exe > %t/Overflow.out 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/Overflow.exe %t/Overflow.exe.dSYM > %t/Overflow.out 2>&1
 // RUN: %FileCheck %s --ignore-case < %t/Overflow.out
-// RUN: ! env %env-SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/Overflow.exe > %t/Friendly.out 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/Overflow.exe %t/Overflow.exe.dSYM > %t/Friendly.out 2>&1
 // RUN: %FileCheck %s --ignore-case --check-prefix FRIENDLY < %t/Friendly.out
 
 // UNSUPPORTED: use_os_stdlib

--- a/test/Backtracing/StackOverflow.test
+++ b/test/Backtracing/StackOverflow.test
@@ -1,11 +1,11 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %S/Inputs/StackOverflow.swift -parse-as-library -Onone %swift-debug-flags -o %t/stack-overflow.exe
 // RUN: %target-codesign %t/stack-overflow.exe
-// RUN: ! env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/stack-overflow.exe > %t/StackOverflow.out 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/stack-overflow.exe > %t/StackOverflow.out 2>&1
 // RUN: %FileCheck %s < %t/StackOverflow.out
-// RUN: ! env SWIFT_BACKTRACE=limit=18,top=6,enable=yes,cache=no %target-run %t/stack-overflow.exe > %t/Limited.out 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=limit=18,top=6,enable=yes,cache=no %target-run %t/stack-overflow.exe > %t/Limited.out 2>&1
 // RUN: %FileCheck %s --check-prefix LIMITED < %t/Limited.out
-// RUN: ! env SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/stack-overflow.exe > %t/Friendly.out 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/stack-overflow.exe > %t/Friendly.out 2>&1
 // RUN: %FileCheck %s --check-prefix FRIENDLY < %t/Friendly.out
 
 // UNSUPPORTED: use_os_stdlib

--- a/test/Backtracing/StackOverflow.test
+++ b/test/Backtracing/StackOverflow.test
@@ -1,11 +1,11 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %S/Inputs/StackOverflow.swift -parse-as-library -Onone %swift-debug-flags -o %t/stack-overflow.exe
 // RUN: %target-codesign %t/stack-overflow.exe
-// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/stack-overflow.exe > %t/StackOverflow.out 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/stack-overflow.exe %t/stack-overflow.exe.dSYM > %t/StackOverflow.out 2>&1
 // RUN: %FileCheck %s < %t/StackOverflow.out
-// RUN: ! env %env-SWIFT_BACKTRACE=limit=18,top=6,enable=yes,cache=no %target-run %t/stack-overflow.exe > %t/Limited.out 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=limit=18,top=6,enable=yes,cache=no %target-run %t/stack-overflow.exe %t/stack-overflow.exe.dSYM > %t/Limited.out 2>&1
 // RUN: %FileCheck %s --check-prefix LIMITED < %t/Limited.out
-// RUN: ! env %env-SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/stack-overflow.exe > %t/Friendly.out 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/stack-overflow.exe %t/stack-overflow.exe.dSYM > %t/Friendly.out 2>&1
 // RUN: %FileCheck %s --check-prefix FRIENDLY < %t/Friendly.out
 
 // UNSUPPORTED: use_os_stdlib

--- a/test/Backtracing/StaticBacktracer.swift
+++ b/test/Backtracing/StaticBacktracer.swift
@@ -2,7 +2,7 @@
 // RUN: %target-build-swift %s -parse-as-library %import-static-libdispatch -Onone -g -o %t/StaticBacktracer
 // RUN: %target-codesign %t/StaticBacktracer
 // RUN: /usr/bin/ldd %backtracer-static | %FileCheck %s --check-prefix LIBS
-// RUN: not --crash env SWIFT_BACKTRACE=enable=yes,cache=no,swift-backtrace=%backtracer-static %target-run %t/StaticBacktracer 2>&1 | %FileCheck %s
+// RUN: not --crash env %env-SWIFT_BACKTRACE=enable=yes,cache=no,swift-backtrace=%backtracer-static %target-run %t/StaticBacktracer 2>&1 | %FileCheck %s
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/Backtracing/TTYDetection.swift
+++ b/test/Backtracing/TTYDetection.swift
@@ -2,9 +2,9 @@
 // RUN: %target-build-swift %s -parse-as-library -Onone -g -o %t/TTYDetection
 // RUN: %target-codesign %t/TTYDetection
 
-// RUN: not --crash env %env-SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/TTYDetection 2> %t/default-output && cat %t/default-output | %FileCheck %s
-// RUN: not --crash env %env-SWIFT_BACKTRACE=enable=yes,cache=no,output-to=stderr %target-run %t/TTYDetection 2> %t/stderr-output && cat %t/stderr-output | %FileCheck %s --check-prefix STDERR
-// RUN: not --crash env %env-SWIFT_BACKTRACE=enable=yes,cache=no,output-to=stdout %target-run %t/TTYDetection > %t/stdout-output && cat %t/stdout-output | %FileCheck %s --check-prefix STDOUT
+// RUN: not --crash env %env-SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/TTYDetection %t/TTYDetection.dSYM 2> %t/default-output && cat %t/default-output | %FileCheck %s
+// RUN: not --crash env %env-SWIFT_BACKTRACE=enable=yes,cache=no,output-to=stderr %target-run %t/TTYDetection %t/TTYDetection.dSYM 2> %t/stderr-output && cat %t/stderr-output | %FileCheck %s --check-prefix STDERR
+// RUN: not --crash env %env-SWIFT_BACKTRACE=enable=yes,cache=no,output-to=stdout %target-run %t/TTYDetection %t/TTYDetection.dSYM > %t/stdout-output && cat %t/stdout-output | %FileCheck %s --check-prefix STDOUT
 
 
 // UNSUPPORTED: use_os_stdlib

--- a/test/Backtracing/TTYDetection.swift
+++ b/test/Backtracing/TTYDetection.swift
@@ -2,9 +2,9 @@
 // RUN: %target-build-swift %s -parse-as-library -Onone -g -o %t/TTYDetection
 // RUN: %target-codesign %t/TTYDetection
 
-// RUN: not --crash env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/TTYDetection 2> %t/default-output && cat %t/default-output | %FileCheck %s
-// RUN: not --crash env SWIFT_BACKTRACE=enable=yes,cache=no,output-to=stderr %target-run %t/TTYDetection 2> %t/stderr-output && cat %t/stderr-output | %FileCheck %s --check-prefix STDERR
-// RUN: not --crash env SWIFT_BACKTRACE=enable=yes,cache=no,output-to=stdout %target-run %t/TTYDetection > %t/stdout-output && cat %t/stdout-output | %FileCheck %s --check-prefix STDOUT
+// RUN: not --crash env %env-SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/TTYDetection 2> %t/default-output && cat %t/default-output | %FileCheck %s
+// RUN: not --crash env %env-SWIFT_BACKTRACE=enable=yes,cache=no,output-to=stderr %target-run %t/TTYDetection 2> %t/stderr-output && cat %t/stderr-output | %FileCheck %s --check-prefix STDERR
+// RUN: not --crash env %env-SWIFT_BACKTRACE=enable=yes,cache=no,output-to=stdout %target-run %t/TTYDetection > %t/stdout-output && cat %t/stdout-output | %FileCheck %s --check-prefix STDOUT
 
 
 // UNSUPPORTED: use_os_stdlib

--- a/test/Backtracing/TTYDetectionColourLinux.swift
+++ b/test/Backtracing/TTYDetectionColourLinux.swift
@@ -4,7 +4,7 @@
 
 // RUN: %target-build-swift %s -o %t/crash-host
 
-// RUN: env SWIFT_BACKTRACE=enable=yes,cache=no,interactive=no %target-run %t/crash-host %t/crash | %FileCheck %s
+// RUN: env %env-SWIFT_BACKTRACE=enable=yes,cache=no,interactive=no %target-run %t/crash-host %t/crash | %FileCheck %s
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/Backtracing/TTYDetectionColourLinux.swift
+++ b/test/Backtracing/TTYDetectionColourLinux.swift
@@ -4,7 +4,7 @@
 
 // RUN: %target-build-swift %s -o %t/crash-host
 
-// RUN: env %env-SWIFT_BACKTRACE=enable=yes,cache=no,interactive=no %target-run %t/crash-host %t/crash | %FileCheck %s
+// RUN: env %env-SWIFT_BACKTRACE=enable=yes,cache=no,interactive=no %target-run %t/crash-host %t/crash %t/crash.dSYM | %FileCheck %s
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/Backtracing/TTYDetectionColourMacOS.swift
+++ b/test/Backtracing/TTYDetectionColourMacOS.swift
@@ -2,7 +2,7 @@
 // RUN: %target-build-swift %s -parse-as-library -Onone -g -o %t/TTYDetection
 // RUN: %target-codesign %t/TTYDetection
 
-// RUN: not env %env-SWIFT_BACKTRACE=enable=yes,cache=no,interactive=no %target-run script -reF %t/script-output %t/TTYDetection && cat %t/script-output | %FileCheck %s
+// RUN: not env %env-SWIFT_BACKTRACE=enable=yes,cache=no,interactive=no %target-run script -reF %t/script-output %t/TTYDetection %t/TTYDetection.dSYM && cat %t/script-output | %FileCheck %s
 
 
 // UNSUPPORTED: use_os_stdlib

--- a/test/Backtracing/TTYDetectionColourMacOS.swift
+++ b/test/Backtracing/TTYDetectionColourMacOS.swift
@@ -2,7 +2,7 @@
 // RUN: %target-build-swift %s -parse-as-library -Onone -g -o %t/TTYDetection
 // RUN: %target-codesign %t/TTYDetection
 
-// RUN: not env SWIFT_BACKTRACE=enable=yes,cache=no,interactive=no %target-run script -reF %t/script-output %t/TTYDetection && cat %t/script-output | %FileCheck %s
+// RUN: not env %env-SWIFT_BACKTRACE=enable=yes,cache=no,interactive=no %target-run script -reF %t/script-output %t/TTYDetection && cat %t/script-output | %FileCheck %s
 
 
 // UNSUPPORTED: use_os_stdlib

--- a/test/Backtracing/Timing.swift
+++ b/test/Backtracing/Timing.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -parse-as-library -Onone -g -o %t/Timing.exe
 // RUN: %target-codesign %t/Timing.exe
-// RUN: ! env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/Timing.exe > %t/Timing.out 2>&1
+// RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/Timing.exe > %t/Timing.out 2>&1
 // RUN: %FileCheck %s < %t/Timing.out
 
 // UNSUPPORTED: use_os_stdlib

--- a/test/Runtime/backtrace.swift
+++ b/test/Runtime/backtrace.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/a.out
-// RUN: env SWIFT_BACKTRACE=enable=no %{python} %S/../Inputs/not.py "%target-run %t/a.out" 2>&1 | %{python} %utils/backtrace-check
+// RUN: env %env-SWIFT_BACKTRACE=enable=no %{python} %S/../Inputs/not.py "%target-run %t/a.out" 2>&1 | %{python} %utils/backtrace-check
 
 // NOTE: not.py is used above instead of "not --crash" because %target-run
 // doesn't pass through the crash, and `not` may not be available when running


### PR DESCRIPTION
This PR contains two independent fixes to make `test/Backtracing/` pass when lit is driven through `remote-run`:
* Prefix `SWIFT_BACKTRACE` with `%env-` so it is forwarded to the remote process under `remote-run`. Under `remote-run`, only variables matching the `%env-` prefix substitution (expands to `REMOTE_RUN_CHILD_`) are forwarded to the remote process.
* Add generated `.dSYM` bundles to the test command so they are rsync'd by `remote-run` alongside test binaries. remote-run` only rsyncs paths that appear on the command line.
