### PR TITLE
Sema: Add stack trace descriptions to import resolution and binding

### DIFF
--- a/lib/AST/PrettyStackTrace.cpp
+++ b/lib/AST/PrettyStackTrace.cpp
@@ -119,6 +119,10 @@ void swift::printDeclDescription(llvm::raw_ostream &out, const Decl *D,
       out << "extension of " << extendedTy;
       hasPrintedName = true;
     }
+  } else if (auto *ID = dyn_cast<ImportDecl>(D)) {
+    out << "import of ";
+    ID->getImportPath().print(out);
+    hasPrintedName = true;
   }
 
   if (!hasPrintedName)

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -28,6 +28,7 @@
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/Statistic.h"
 #include "swift/ClangImporter/ClangModule.h"
+#include "swift/AST/PrettyStackTrace.h"
 #include "swift/Subsystems.h"
 #include "swift/SymbolGraphGen/DocumentationCategory.h"
 #include "clang/Basic/Module.h"
@@ -347,6 +348,8 @@ void swift::performImportResolutionForClangMacroBuffer(
 //===----------------------------------------------------------------------===//
 
 void ImportResolver::visitImportDecl(ImportDecl *ID) {
+  PrettyStackTraceDecl debugStack("resolving", ID);
+
   assert(unboundImports.empty());
 
   // `CxxStdlib` is the only accepted spelling of the C++ stdlib module name.
@@ -380,6 +383,7 @@ void ImportResolver::bindPendingImports() {
 
 void ImportResolver::bindImport(UnboundImport &&I) {
   auto ID = I.getImportDecl();
+  PrettyStackTraceDecl debugStack("binding", ID.getPtrOrNull());
 
   if (!I.checkNotTautological(SF)) {
     // No need to process this import further.


### PR DESCRIPTION
Use PrettyStackTrace utilities to make crashes during import resolution and binding more debuggable. The output looks like this:

```
1.	Swift version ...
2.	Compiling with effective version ...
3.	While resolving import import of SwiftConcurrencyInternalShims (at ...)
4.	While binding import import of SwiftConcurrencyInternalShims (at ...)
```
