### PR TITLE
Differentiate explicit submodules for export_as

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -41,6 +41,7 @@
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/StringExtras.h"
 #include "clang/AST/Type.h"
+#include "clang/Basic/Module.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringExtras.h"
@@ -3027,8 +3028,15 @@ namespace {
 
     void visitModuleDecl(ModuleDecl *MD, Label label) {
       printCommon(MD, "module", label);
-      printFlag(MD->isNonSwiftModule(), "non_swift");
       printAttributes(MD);
+      printFlag(MD->isNonSwiftModule(), "non_swift");
+      if (auto clangMod = MD->findUnderlyingClangModule()) {
+        printFlag(clangMod->isSubModule(), "is_submodule");
+        if (clangMod->isSubModule()) {
+          printFieldQuoted(clangMod->getFullModuleName(),
+                           Label::always("clang_full_name"));
+        }
+      }
       printFoot();
     }
 
@@ -6480,6 +6488,13 @@ namespace {
       printCommon("module_type", label);
       printDeclName(T->getModule(), Label::always("module"));
       printFlag(T->getModule()->isNonSwiftModule(), "foreign");
+      if (auto clangMod = T->getModule()->findUnderlyingClangModule()) {
+        printFlag(clangMod->isSubModule(), "is_submodule");
+        if (clangMod->isSubModule()) {
+          printFieldQuoted(clangMod->getFullModuleName(),
+                           Label::always("clang_full_name"));
+        }
+      }
       printFoot();
     }
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -6426,14 +6426,18 @@ class TypePrinter : public TypeVisitor<TypePrinter, void, NonRecursivePrintOptio
     return Options.CurrentModule->getVisibleClangModules(Options.InterfaceContentKind);
   }
 
-  /// If \p TyDecl belongs to a submodule, return the \c ModuleDecl for that
-  /// submodule; otherwise just return the parent module.
+  /// If \p TyDecl belongs to an explicit submodule, return the \c ModuleDecl
+  /// for that submodule; otherwise just return the parent module.
   ModuleDecl *getParentSubModuleOrModule(GenericTypeDecl *TyDecl) {
     // Only clang declarations can belong to a submodule
     if (auto clangNode = TyDecl->getClangNode()) {
       auto importer = TyDecl->getASTContext().getClangModuleLoader();
       if (auto clangMod = importer->getClangOwningModule(clangNode)) {
-        return importer->getWrapperForModule(clangMod);
+        // Explicit submodules are only visible if specifically imported;
+        // everything else has the visibility of its top-level module.
+        if (clangMod->isSubModule() && clangMod->IsExplicit) {
+          return importer->getWrapperForModule(clangMod);
+        }
       }
     }
 

--- a/test/ModuleInterface/export-as-in-swiftinterfaces-submodules.swift
+++ b/test/ModuleInterface/export-as-in-swiftinterfaces-submodules.swift
@@ -35,6 +35,11 @@ module LibraryCore {
   header "LibraryCore/LibraryCore.h"
   export *
 
+  module NonExplicitSubmodule {
+    header "LibraryCore/NonExplicitSubmodule.h"
+    export *
+  }
+
   explicit module * { export * }
 }
 
@@ -49,12 +54,18 @@ module Library {
 //--- LibraryCore/LibraryCore.h
 // This file is re-exported by Library
 #pragma once
+#include "LibraryCore/NonExplicitSubmodule.h"
 struct LibraryCoreType {};
 
 //--- LibraryCore/Submodule.h
 // This file is re-exported by Library.Submodule (which Swift does not respect)
 #pragma once
 struct LibraryCoreSubmoduleType {};
+
+//--- LibraryCore/NonExplicitSubmodule.h
+// This file is re-exported by Library
+#pragma once
+struct LibraryCoreNonExplicitSubmoduleType {};
 
 //--- LibraryCore/ReexportedSubmodule.h
 // This file is re-exported by Library
@@ -89,6 +100,9 @@ public func foo(
   // PUBLIC-SAME: c: Library::LibraryCoreReexportedSubmoduleType
   // PRIVATE-SAME: c: LibraryCore::LibraryCoreReexportedSubmoduleType
   c: LibraryCoreReexportedSubmoduleType,
+  // PUBLIC-SAME: c2: Library::LibraryCoreNonExplicitSubmoduleType
+  // PRIVATE-SAME: c2: Library::LibraryCoreNonExplicitSubmoduleType
+  c2: LibraryCoreNonExplicitSubmoduleType,
   // PUBLIC-SAME: d: Library::LibraryType
   // PRIVATE-SAME: d: Library::LibraryType
   d: LibraryType,
@@ -114,5 +128,8 @@ public func foo(
   b: LibraryCoreSubmoduleType,
   // PUBLIC-SAME: c: Library::LibraryCoreReexportedSubmoduleType
   // PRIVATE-SAME: c: LibraryCore::LibraryCoreReexportedSubmoduleType
-  c: LibraryCoreReexportedSubmoduleType
+  c: LibraryCoreReexportedSubmoduleType,
+  // PUBLIC-SAME: c2: Library::LibraryCoreNonExplicitSubmoduleType
+  // PRIVATE-SAME: c2: LibraryCore::LibraryCoreNonExplicitSubmoduleType
+  c2: LibraryCoreNonExplicitSubmoduleType
 ) {}


### PR DESCRIPTION
ASTPrinter includes logic for private module interfaces which attempts to determine whether the `export_as` name will work to address a clang type. This worked correctly for explicit submodules (those declared with the `explicit` keyword in the module map), but non-explicit submodules don’t restrict visibility in the same way. Substitute the top-level module for these instead.

This PR also includes ASTDumper enhancements for submodules.

Fixes rdar://178351114.
