### PR TITLE
[6.4] Fix a move checker use-after-free: insert destroy_addr before reinit

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -355,19 +355,44 @@ static void convertMemoryReinitToInitForm(SILInstruction *memInst,
 
 /// Is this a reinit instruction that we know how to convert into its init form.
 static bool isReinitToInitConvertibleInst(SILInstruction *memInst) {
+  SILValue dest;
   switch (memInst->getKind()) {
   default:
     return false;
 
   case SILInstructionKind::CopyAddrInst: {
     auto *cai = cast<CopyAddrInst>(memInst);
-    return !cai->isInitializationOfDest();
+    if (cai->isInitializationOfDest())
+      return false;
+    dest = cai->getDest();
+    break;
   }
   case SILInstructionKind::StoreInst: {
     auto *si = cast<StoreInst>(memInst);
-    return si->getOwnershipQualifier() == StoreOwnershipQualifier::Assign;
+    if (si->getOwnershipQualifier() != StoreOwnershipQualifier::Assign)
+      return false;
+    dest = si->getDest();
+    break;
   }
   }
+
+  // If the store's destination is a begin_access, the reinit can only be
+  // converted into an init if the access exists solely to host this reinit.
+  // When the store is converted to an init, then the begin_access is
+  // considered the beginning of that reinitialization. A destroy_addres can
+  // then be inserted before the access to compensate for the reinit
+  // conversion. If, however, the access includes other reads, then we cannot
+  // hoist the destroy_addr out of the access scope.
+  if (auto *bai = dyn_cast<BeginAccessInst>(dest)) {
+    for (auto *use : bai->getUses()) {
+      auto *user = use->getUser();
+      if (user == memInst || isa<EndAccessInst>(user))
+        continue;
+      return false;
+    }
+  }
+
+  return true;
 }
 
 using ScopeRequiringFinalInit = DiagnosticEmitter::ScopeRequiringFinalInit;
@@ -3658,7 +3683,23 @@ void ExtendUnconsumedLiveness::run() {
     }
     for (auto pair : addressUseState.reinitInsts) {
       if (pair.second.test(element)) {
-        destroys[pair.first] = DestroyKind::Reinit;
+        SILInstruction *reinit = pair.first;
+        // If the reinit stores through a begin_access and will be converted
+        // into an init, record the begin_access as the destroy point rather
+        // than the reinit itself. This keeps the old value's destroy from
+        // being sunk into the access scope (immediately before the reinit);
+        // instead liveness is extended only up to the begin_access.
+        SILInstruction *destroy = reinit;
+        if (isReinitToInitConvertibleInst(reinit)) {
+          SILValue dest;
+          if (auto *si = dyn_cast<StoreInst>(reinit))
+            dest = si->getDest();
+          else if (auto *cai = dyn_cast<CopyAddrInst>(reinit))
+            dest = cai->getDest();
+          if (auto *bai = dyn_cast_or_null<BeginAccessInst>(dest))
+            destroy = bai;
+        }
+        destroys[destroy] = DestroyKind::Reinit;
       }
     }
 

--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
@@ -541,3 +541,43 @@ struct TestBuiltinBorrowInit<T: ~Copyable & ~Escapable>: ~Escapable {
     self.ref = Builtin.makeBorrow(target)
   }
 }
+
+// =============================================================================
+// Reassignment
+// =============================================================================
+
+// Test reassignment of a lifetime-dependent variable to a value that depends on a narrower scope.
+@available(Span 0.1, *)
+struct UniqueArray: ~Copyable {
+  var ptr: UnsafeMutablePointer<Int>
+
+  init() {
+    ptr = .allocate(capacity: 1)
+  }
+
+  var mutableSpan: MutableSpan<Int> {
+    @_lifetime(&self)
+    mutating get {
+      MutableSpan(_unsafeStart: ptr, count: 1)
+    }
+  }
+
+  deinit {
+    ptr.deallocate()
+  }
+}
+
+@available(Span 0.1, *)
+func useSpan(_: borrowing MutableSpan<Int>) {}
+
+@available(Span 0.1, *)
+func testReassignFromNarrowerScope() {
+  var ms = MutableSpan<Int>() // expected-error{{lifetime-dependent variable 'ms' escapes its scope}}
+  useSpan(ms)
+
+  do {
+    var ua = UniqueArray()
+    ms = ua.mutableSpan // expected-note{{it depends on this scoped access to variable 'ua'}}
+  }
+  useSpan(ms) // expected-note{{this use of the lifetime-dependent value is out of scope}}
+}

--- a/test/SILOptimizer/moveonly_addresschecker.sil
+++ b/test/SILOptimizer/moveonly_addresschecker.sil
@@ -1,6 +1,7 @@
-// RUN: %target-sil-opt -sil-print-types -module-name moveonly_addresschecker -sil-move-only-address-checker -enable-experimental-feature MoveOnlyClasses -enable-sil-verify-all %s | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-types -module-name moveonly_addresschecker -sil-move-only-address-checker -enable-experimental-feature MoveOnlyClasses -enable-experimental-feature Lifetimes -enable-sil-verify-all %s | %FileCheck %s
 
 // REQUIRES: swift_feature_MoveOnlyClasses
+// REQUIRES: swift_feature_Lifetimes
 
 sil_stage raw
 
@@ -332,8 +333,8 @@ bb0(%arg : @owned $Klass):
 // CHECK-LABEL: sil [ossa] @classSimpleNonConsumingUseTest : $@convention(thin) (@owned Klass, @owned Klass) -> () {
 // CHECK: [[STACK:%.*]] = alloc_stack [lexical] $Klass, var, name "x2"
 // CHECK: store {{%.*}} to [init] [[STACK]]
-// CHECK: [[ACCESS:%.*]] = begin_access [modify] [static] [[STACK]]
 // CHECK: destroy_addr [[STACK]]
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [static] [[STACK]]
 // CHECK: store {{%.*}} to [init] [[ACCESS]]
 // CHECK: end_access [[ACCESS]]
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [static] [[STACK]]
@@ -900,3 +901,84 @@ bb4(%reborrow : @reborrow $Optional<@callee_guaranteed () -> ()>, %maybe : @owne
   %retval = tuple ()
   return %retval : $()
 }
+
+// Reassigning a move-only 'var' with a value that is lifetime-dependent on
+// another access. The old value's destroy_addr must be hoisted out of the
+// reinitializing modify access scope (rather than sunk inside it, immediately
+// before the reinit), and the reinit must be rewritten to an init.
+// rdar://161667945
+struct UniqueArray : ~Copyable {
+  @_hasStorage var ptr: UnsafeMutablePointer<Int> { get set }
+  init()
+  var mutableSpan: MutableSpan<Int> {
+    @_lifetime(&self)
+    mutating get
+  }
+  deinit
+}
+
+sil @$s4test11UniqueArrayV11mutableSpans07MutableE0VySiGvg : $@convention(method) (@inout UniqueArray) -> @lifetime(borrow 0) @owned MutableSpan<Int>
+sil @$s4test11UniqueArrayVACycfC : $@convention(method) (@thin UniqueArray.Type) -> @owned UniqueArray
+sil @$s4test7useSpanyys07MutableC0VySiGF : $@convention(thin) (@guaranteed MutableSpan<Int>) -> ()
+sil @$ss11MutableSpanVsRi_zrlEAByxGycfC : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (@thin MutableSpan<τ_0_0>.Type) -> @lifetime(immortal) @owned MutableSpan<τ_0_0>
+
+// CHECK-LABEL: sil hidden [ossa] @reinitMutableSpanThroughModifyAccess : $@convention(thin) () -> () {
+// CHECK:   [[MS:%.*]] = alloc_stack [lexical] [var_decl] $MutableSpan<Int>, var, name "ms"
+// CHECK:   store {{%.*}} to [init] [[MS]]
+// CHECK:   [[READ:%.*]] = begin_access [read] [static] [[MS]]
+// CHECK:   load_borrow [[READ]]
+// CHECK:   end_access [[READ]]
+// The old value of 'ms' is destroyed after the borrowing getter's access ends
+// and before the reinitializing modify access begins -- not sunk inside it.
+// CHECK:   destroy_addr [[MS]]
+// CHECK:   [[REINIT:%.*]] = begin_access [modify] [static] [[MS]]
+// CHECK-NOT:   destroy_addr
+// CHECK:   store {{%.*}} to [init] [[REINIT]]
+// CHECK:   end_access [[REINIT]]
+// CHECK-LABEL: } // end sil function 'reinitMutableSpanThroughModifyAccess'
+sil hidden [ossa] @reinitMutableSpanThroughModifyAccess : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack [lexical] [var_decl] $MutableSpan<Int>, var, name "ms", type $MutableSpan<Int>
+  %1 = mark_unresolved_non_copyable_value [consumable_and_assignable] %0
+  %2 = metatype $@thin MutableSpan<Int>.Type
+  // function_ref MutableSpan<>.init()
+  %3 = function_ref @$ss11MutableSpanVsRi_zrlEAByxGycfC : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (@thin MutableSpan<τ_0_0>.Type) -> @lifetime(immortal) @owned MutableSpan<τ_0_0>
+  %4 = apply %3<Int>(%2) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (@thin MutableSpan<τ_0_0>.Type) -> @lifetime(immortal) @owned MutableSpan<τ_0_0>
+  store %4 to [init] %1
+  %6 = begin_access [read] [static] %1
+  %7 = load [copy] %6
+  // function_ref useSpan(_:)
+  %8 = function_ref @$s4test7useSpanyys07MutableC0VySiGF : $@convention(thin) (@guaranteed MutableSpan<Int>) -> ()
+  %9 = apply %8(%7) : $@convention(thin) (@guaranteed MutableSpan<Int>) -> ()
+  destroy_value %7
+  end_access %6
+  %12 = alloc_stack [lexical] [var_decl] $UniqueArray, var, name "ua", type $UniqueArray
+  %13 = mark_unresolved_non_copyable_value [consumable_and_assignable] %12
+  %14 = metatype $@thin UniqueArray.Type
+  // function_ref UniqueArray.init()
+  %15 = function_ref @$s4test11UniqueArrayVACycfC : $@convention(method) (@thin UniqueArray.Type) -> @owned UniqueArray
+  %16 = apply %15(%14) : $@convention(method) (@thin UniqueArray.Type) -> @owned UniqueArray
+  store %16 to [init] %13
+  %18 = begin_access [modify] [static] %13
+  // function_ref UniqueArray.mutableSpan.getter
+  %19 = function_ref @$s4test11UniqueArrayV11mutableSpans07MutableE0VySiGvg : $@convention(method) (@inout UniqueArray) -> @lifetime(borrow 0) @owned MutableSpan<Int>
+  %20 = apply %19(%18) : $@convention(method) (@inout UniqueArray) -> @lifetime(borrow 0) @owned MutableSpan<Int>
+  %21 = mark_dependence [unresolved] %20 on %18
+  end_access %18
+  %23 = begin_access [modify] [static] %1
+  store %21 to [assign] %23
+  end_access %23
+  destroy_addr %13
+  dealloc_stack %12
+  %28 = begin_access [read] [static] %1
+  %29 = load [copy] %28
+  // function_ref useSpan(_:)
+  %30 = function_ref @$s4test7useSpanyys07MutableC0VySiGF : $@convention(thin) (@guaranteed MutableSpan<Int>) -> ()
+  %31 = apply %30(%29) : $@convention(thin) (@guaranteed MutableSpan<Int>) -> ()
+  destroy_value %29
+  end_access %28
+  destroy_addr %1
+  dealloc_stack %0
+  %36 = tuple ()
+  return %36 : $()
+} // end sil function 'reinitMutableSpanThroughModifyAccess'

--- a/test/SILOptimizer/moveonly_raw_layout.swift
+++ b/test/SILOptimizer/moveonly_raw_layout.swift
@@ -62,9 +62,10 @@ public func useLock() {
     // CHECK: [[L2:%.*]] = alloc_stack
     // CHECK-NOT: destroy_addr [[L2]] :
     // CHECK: [[F:%.*]] = function_ref @[[INIT]]
-    // CHECK: apply [[F]]([[L2]], 
-    // CHECK: [[L_INOUT:%.*]] = begin_access [modify] [static] [[L]] :
+    // CHECK: apply [[F]]([[L2]],
     // CHECK: destroy_addr [[L]] :
+    // CHECK: [[L_INOUT:%.*]] = begin_access [modify] [static] [[L]] :
+    // CHECK-NOT: destroy_addr [[L]] :
     // CHECK: copy_addr [take] [[L2]] to [init] [[L_INOUT]]
     // CHECK: end_access [[L_INOUT]]
     // CHECK-NOT: destroy_addr [[L2]] :


### PR DESCRIPTION

- **Explanation**: The move-checker generated invalid SIL which could defeat any downstream analysis. In this case, it effectively disabled lifetime analysis resulting in a use-after-free bug.

- **Original PRs**: https://github.com/swiftlang/swift/pull/90483

- **Scope**: Affects the SIL generated for ~Copyable reassignment which can impact downstream diagnostics.

- **Issues**: rdar://161667945 ([nonescapable] [miscompile] Reassignment does not change lifetime constraint of binding)

- **Risk**: Moderate. This changes the SIL output from the move-checker. The change, however, only narrowly affects the cases in which the move checker produced invalid SIL. That invalid SIL could result in missing diagnostics and memory safety problems throughout the optimizer. The risk is simply that downstream passes were previously operating on the invalid SIL for a while and getting lucky. A different SIL pattern could always expose new issues.

- **Testing**: New source and SIL unit tests.

- **Reviewers**: @jckarter 

Details:

Fixes patterns involving MutableSpan reassignment that were previously
miscompiled, compromising memory safety. For example:
```
  var ms = MutableSpan<Int>()
  useSpan(ms)

  do {
    var ua = UniqueArray()
    ms = ua.mutableSpan
  }
  useSpan(ms)
```
This is now correctly diagnosed as:
error: lifetime-dependent variable 'ms' escapes its scope

The move checker previously generated invalid SIL patterns in which destroy_addr
was inside an access scope:
```
  %0 = alloc_stack [lexical] [var_decl] $MutableSpan<Int>, var, name "ms", type $MutableSpan<Int>
  ...
  %access = begin_access [modify] [static] %0
  destroy_addr %0
  store %val to [init] %access
  end_access %access
```
This is obviously invalid SIL, but it was not caught by SIL verification because
we don't yet have access scope verification. See rdar181649181 (Need SIL memory
verification for access scopes).

Fixes rdar://161667945 ([nonescapable] [miscompile] Reassignment does not change
lifetime constraint of binding)

(cherry picked from commit 51467477ef3d1c9c4ef71bad9e6abdbd2df68338)
