### PR TITLE
Add llvmDebug utility for LLVM_DEBUG-style logging in SwiftCompilerSources

### DIFF
--- a/SwiftCompilerSources/Sources/Basic/Utils.swift
+++ b/SwiftCompilerSources/Sources/Basic/Utils.swift
@@ -66,6 +66,31 @@ public func debugLog(prefix: Bool = true, _ message: @autoclosure () -> String) 
   Bridged_dbgs().newLine()
 }
 
+/// The Swift equivalent of C++'s `LLVM_DEBUG(llvm::dbgs() << ...)`.
+///
+/// Checks if debugging is enabled for the given type (via `-debug-only=<type>`)
+/// and if so, evaluates and prints the message.
+///
+/// Usage:
+/// ```
+/// private func log(_ message: @autoclosure () -> String) {
+///   llvmDebug("my-pass-name", message())
+/// }
+/// ```
+///
+/// Or directly:
+/// ```
+/// llvmDebug("my-pass", "found \(thing)")
+/// ```
+public func llvmDebug(_ type: StaticString, _ message: @autoclosure () -> String) {
+  if _slowPath(Bridged_isDebugFlagEnabled()) {
+    let ref = BridgedStringRef(data: type.utf8Start, count: type.utf8CodeUnitCount)
+    if Bridged_isCurrentDebugType(ref) {
+      debugLog(message())
+    }
+  }
+}
+
 /// Let's lldb's `po` command not print any "internal" properties of the conforming type.
 ///
 /// This is useful if the `description` already contains all the information of a type instance.

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
@@ -22,12 +22,8 @@
 import AST
 import SIL
 
-private let verbose = false
-
-private func log(prefix: Bool = true, _ message: @autoclosure () -> String) {
-  if verbose {
-    debugLog(prefix: prefix, message())
-  }
+private func log(_ message: @autoclosure () -> String) {
+  llvmDebug("lifetime-dependence-diagnostics", message())
 }
 
 // @noescape functions cannot yet compose other types, but they can be wrapped in an arbitrary number of Optionals.
@@ -49,7 +45,7 @@ extension AST.`Type` {
 let lifetimeDependenceDiagnosticsPass = FunctionPass(
   name: "lifetime-dependence-diagnostics")
 { (function: Function, context: FunctionPassContext) in
-  log(prefix: false, "\n--- Diagnosing lifetime dependence in \(function.name)")
+  log("\n--- Diagnosing lifetime dependence in \(function.name)")
   log("\(function)")
   log("\(function.convention)")
 

--- a/include/swift/Basic/BasicBridging.h
+++ b/include/swift/Basic/BasicBridging.h
@@ -318,6 +318,12 @@ public:
 
 BridgedOStream Bridged_dbgs();
 
+/// Returns true if LLVM debug output is currently enabled
+bool Bridged_isDebugFlagEnabled();
+
+/// Returns true if the given debug type is currently active.
+bool Bridged_isCurrentDebugType(BridgedStringRef type);
+
 //===----------------------------------------------------------------------===//
 // MARK: std::vector<BridgedCharSourceRange>
 //===----------------------------------------------------------------------===//

--- a/lib/Basic/BasicBridging.cpp
+++ b/lib/Basic/BasicBridging.cpp
@@ -49,6 +49,25 @@ BridgedOStream Bridged_dbgs() {
   return BridgedOStream(&llvm::dbgs());
 }
 
+bool Bridged_isDebugFlagEnabled() {
+#ifndef NDEBUG
+  return llvm::DebugFlag;
+#else
+  return false;
+#endif
+}
+
+bool Bridged_isCurrentDebugType(BridgedStringRef type) {
+#ifndef NDEBUG
+  if (!llvm::DebugFlag)
+    return false;
+  std::string typeStr(type.unbridged().data(), type.unbridged().size());
+  return llvm::isCurrentDebugType(typeStr.c_str());
+#else
+  return false;
+#endif
+}
+
 //===----------------------------------------------------------------------===//
 // MARK: BridgedStringRef
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Add a Swift equivalent of C++'s `LLVM_DEBUG(llvm::dbgs() << ...)` that checks `-debug-only=<type>` to conditionally emit debug output from SwiftCompilerSources passes.

