### PR TITLE
[ClangImporter] Fix bridging header PCH `OptimizationLevel` mismatch under `-clang-target`

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1624,7 +1624,11 @@ std::unique_ptr<ClangImporter> ClangImporter::create(
     // prefer to set the AST-benign ones here unless they are computed
     // after this point or may var per inputs.
     auto &CGO = importer->getCodeGenOpts();
-    CGO.OptimizationLevel = IRGenOpts->shouldOptimize() ? 3 : 0;
+    // Reflect the Swift optimization mode in the Clang optimization level, but
+    // only raise it: preserving a nonzero level from the cc1 '-O' arguments
+    // keeps '__OPTIMIZE__' defined when Swift itself is not optimizing.
+    if (IRGenOpts->shouldOptimize())
+      CGO.OptimizationLevel = 3;
     CGO.DebugTypeExtRefs = !IRGenOpts->DisableClangModuleSkeletonCUs;
     switch (IRGenOpts->DebugInfoLevel) {
     case IRGenDebugInfoLevel::None:
@@ -1677,6 +1681,13 @@ std::unique_ptr<ClangImporter> ClangImporter::create(
       ctx.Diags.diagnose(SourceLoc(), diag::non_pic_without_embedded);
       return nullptr;
     }
+
+    // With '-clang-target', getCodeGenOpts() is a separate instance used for
+    // Swift IRGen; the Clang invocation is what the bridging-header PCH is
+    // serialized against, so keep its optimization level in lock-step.
+    auto &invocationCGO = importer->Impl.Invocation->getCodeGenOpts();
+    if (&invocationCGO != &CGO && IRGenOpts->shouldOptimize())
+      invocationCGO.OptimizationLevel = 3;
   }
 
   // Set up PCH content CASID.

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -122,6 +122,15 @@ void ClangImporter::getBridgingHeaderOptions(
     break;
   }
 
+  // If the main compilation specifies '-clang-target', forward it so the
+  // bridging header PCH is emitted through the same `ClangImporter::create`
+  // configuration path (and therefore the same `clang::CodeGenOptions`) as the
+  // compilations that later consume the PCH.
+  if (ctx.LangOpts.ClangTarget.has_value()) {
+    swiftArgs.push_back("-clang-target");
+    swiftArgs.push_back(ctx.LangOpts.ClangTarget->str());
+  }
+
   // Add args reported by the scanner.
 
   // Round-trip clang args to canonicalize and clear the options that swift

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -127,6 +127,8 @@ void ClangImporter::getBridgingHeaderOptions(
   // configuration path (and therefore the same `clang::CodeGenOptions`) as the
   // compilations that later consume the PCH.
   if (ctx.LangOpts.ClangTarget.has_value()) {
+    swiftArgs.push_back("-target");
+    swiftArgs.push_back(ctx.LangOpts.Target.str());
     swiftArgs.push_back("-clang-target");
     swiftArgs.push_back(ctx.LangOpts.ClangTarget->str());
   }

--- a/test/ClangImporter/bridging_header_pch_clang_target_optimization.swift
+++ b/test/ClangImporter/bridging_header_pch_clang_target_optimization.swift
@@ -1,0 +1,51 @@
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// Bridging-header PCH emitted by '-emit-pch' and consumed by '-c' must agree on
+// the Clang OptimizationLevel even with '-clang-target'.
+
+// clang-target + -O:
+//
+// PCH round-trip must not report "OptimizationLevel differs in precompiled file".
+// RUN: %target-swift-frontend -emit-pch -o %t/O.pch %t/bridging.h -target %target-cpu-apple-macosx13.0 -clang-target %target-cpu-apple-macosx14.0 -O -module-cache-path %t/mcp-O
+// RUN: %target-swift-frontend -c -primary-file %t/main.swift -import-objc-header %t/O.pch -target %target-cpu-apple-macosx13.0 -clang-target %target-cpu-apple-macosx14.0 -O -module-cache-path %t/mcp-O -module-name repro -o %t/O.o
+
+// no clang-target + -O:
+//
+// RUN: %target-swift-frontend -emit-pch -o %t/plain.pch %t/bridging.h -target %target-cpu-apple-macosx13.0 -O -module-cache-path %t/mcp-plain
+// RUN: %target-swift-frontend -c -primary-file %t/main.swift -import-objc-header %t/plain.pch -target %target-cpu-apple-macosx13.0 -O -module-cache-path %t/mcp-plain -module-name repro -o %t/plain.o
+
+// clang-target, no optimization:
+//
+// RUN: %target-swift-frontend -emit-pch -o %t/noopt.pch %t/bridging.h -target %target-cpu-apple-macosx13.0 -clang-target %target-cpu-apple-macosx14.0 -module-cache-path %t/mcp-noopt
+// RUN: %target-swift-frontend -c -primary-file %t/main.swift -import-objc-header %t/noopt.pch -target %target-cpu-apple-macosx13.0 -clang-target %target-cpu-apple-macosx14.0 -module-cache-path %t/mcp-noopt -module-name repro -o %t/noopt.o
+
+// __OPTIMIZE__ must stay defined for an imported module across these combos.
+//
+// RUN: %target-swift-frontend -c -primary-file %t/mainmod.swift -I %t -module-cache-path %t/mcp-i -target %target-cpu-apple-macosx13.0 -clang-target %target-cpu-apple-macosx14.0 -O -module-name repro -o %t/i.o
+// RUN: %target-swift-frontend -c -primary-file %t/mainmod.swift -I %t -module-cache-path %t/mcp-ii -target %target-cpu-apple-macosx13.0 -clang-target %target-cpu-apple-macosx14.0 -O -Xcc -O2 -module-name repro -o %t/ii.o
+// RUN: %target-swift-frontend -c -primary-file %t/mainmod.swift -I %t -module-cache-path %t/mcp-iii -target %target-cpu-apple-macosx13.0 -clang-target %target-cpu-apple-macosx14.0 -Xcc -O2 -module-name repro -o %t/iii.o
+// RUN: %target-swift-frontend -c -primary-file %t/mainmod.swift -I %t -module-cache-path %t/mcp-iv -target %target-cpu-apple-macosx13.0 -O -module-name repro -o %t/iv.o
+// RUN: %target-swift-frontend -c -primary-file %t/mainmod.swift -I %t -module-cache-path %t/mcp-v -target %target-cpu-apple-macosx13.0 -Xcc -O2 -module-name repro -o %t/v.o
+
+//--- bridging.h
+int repro_add(int a, int b);
+
+//--- main.swift
+public func use() { _ = repro_add(1, 2) }
+
+//--- module.modulemap
+module OptGuard { header "optguard.h" export * }
+
+//--- optguard.h
+#if !defined(__OPTIMIZE__)
+#error "OptGuard compiled without __OPTIMIZE__"
+#endif
+static inline int optguard_fn(void) { return 42; }
+
+//--- mainmod.swift
+import OptGuard
+public func use() { _ = optguard_fn() }

--- a/test/ScanDependencies/PCH-clang-target-opt.swift
+++ b/test/ScanDependencies/PCH-clang-target-opt.swift
@@ -6,15 +6,17 @@
 
 // RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O -module-load-mode prefer-serialized -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -scanner-module-validation %t/test.swift -o %t/deps.json -scanner-output-dir %t -scanner-debug-write-output -import-objc-header %t/Bridging.h -Xcc -O2 -target %target-cpu-apple-macosx10.14 -clang-target %target-cpu-apple-macosx10.14 -I %t
 
-// RUN: %{python} %S/../CAS/Inputs/SwiftDepsExtractor.py %t/deps.json Test bridgingHeader | %FileCheck %s
+// RUN: %{python} %S/../CAS/Inputs/SwiftDepsExtractor.py %t/deps.json Test bridgingHeader | %FileCheck %s -DCPU=%target-cpu
 
 // CHECK:       "commandLine": [
 // CHECK-NEXT:    "-frontend",
 // CHECK-NEXT:    "-emit-pch",
 // CHECK-NEXT:    "-direct-clang-cc1-module-build",
 // CHECK-NEXT:    "-O",
+// CHECK-NEXT:    "-target",
+// CHECK-NEXT:    "[[CPU]]-apple-macosx10.14",
 // CHECK-NEXT:    "-clang-target",
-// CHECK-NEXT:    "arm64-apple-macosx10.14",
+// CHECK-NEXT:    "[[CPU]]-apple-macosx10.14",
 
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:RequiresOptimize > %t/RequiresOptimize.cmd
 // RUN: %swift_frontend_plain @%t/RequiresOptimize.cmd

--- a/test/ScanDependencies/PCH-clang-target-opt.swift
+++ b/test/ScanDependencies/PCH-clang-target-opt.swift
@@ -1,0 +1,41 @@
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O -module-load-mode prefer-serialized -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -scanner-module-validation %t/test.swift -o %t/deps.json -scanner-output-dir %t -scanner-debug-write-output -import-objc-header %t/Bridging.h -Xcc -O2 -target %target-cpu-apple-macosx10.14 -clang-target %target-cpu-apple-macosx10.14 -I %t
+
+// RUN: %{python} %S/../CAS/Inputs/SwiftDepsExtractor.py %t/deps.json Test bridgingHeader | %FileCheck %s
+
+// CHECK:       "commandLine": [
+// CHECK-NEXT:    "-frontend",
+// CHECK-NEXT:    "-emit-pch",
+// CHECK-NEXT:    "-direct-clang-cc1-module-build",
+// CHECK-NEXT:    "-O",
+// CHECK-NEXT:    "-clang-target",
+// CHECK-NEXT:    "arm64-apple-macosx10.14",
+
+// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:RequiresOptimize > %t/RequiresOptimize.cmd
+// RUN: %swift_frontend_plain @%t/RequiresOptimize.cmd
+
+//--- Bridging.h
+#ifndef __OPTIMIZE__
+#error "PCH emitted without __OPTIMIZE__ despite -O2"
+#endif
+
+//--- module.modulemap
+module RequiresOptimize {
+  header "RequiresOptimize.h"
+  export *
+}
+
+//--- RequiresOptimize.h
+#ifndef __OPTIMIZE__
+#error "PCM emitted without __OPTIMIZE__ despite -O2"
+#endif
+void requiresOptimize(void);
+
+//--- test.swift
+import RequiresOptimize
+


### PR DESCRIPTION
`getBridgingHeaderOptions` did not propagate `-target`/`-clang-target` into the scanner-generated bridging header PCH command, so the PCH was emitted without them but consumed with them.

More fundamentally, `ClangImporter::create` set the Clang optimization level on `getCodeGenOpts()`, which is a separate, IRGen-only `clang::CodeGenOptions` when `-clang-target` is set. That left the Clang invocation used to emit and validate the bridging header PCH at the cc1 `-O` level, so a PCH emitted by a non-SIL action (`-emit-pch`) and consumed by a SIL-generating one were validated against different levels, and reading the PCH failed with:
```
error: OptimizationLevel differs in precompiled file ... vs. current file
```

- Forward `-target`/`-clang-target` into the bridging header PCH build when the main compilation specifies `-clang-target`.
- Apply the optimization level to the Clang invocation in all paths, raising only so a cc1 `-O` level is never reset to 0 (which would drop `__OPTIMIZE__`).

rdar://181040353, rdar://181509637, rdar://182316370