### PR TITLE
IRGen: preserve nested-struct padding in constant zeroInitializer

### DIFF
--- a/lib/IRGen/GenConstant.cpp
+++ b/lib/IRGen/GenConstant.cpp
@@ -286,12 +286,26 @@ Explosion irgen::emitConstantValue(IRGenModule &IGM, SILValue operand,
     switch (IGM.getSILModule().getBuiltinInfo(BI->getName()).ID) {
       case BuiltinValueKind::ZeroInitializer: {
         auto &resultTI = cast<LoadableTypeInfo>(IGM.getTypeInfo(BI->getType()));
-        auto schema = resultTI.getSchema();
-        Explosion out;
-        for (auto &elt : schema) {
-          out.add(llvm::Constant::getNullValue(elt.getScalarType()));
+        if (flatten) {
+          // Flattened constants are consumed in schema shape (e.g. by
+          // emitValueInjection when building an enum payload), so emit the
+          // scalar leaves of the type's schema.
+          auto schema = resultTI.getSchema();
+          Explosion out;
+          for (auto &elt : schema) {
+            out.add(llvm::Constant::getNullValue(elt.getScalarType()));
+          }
+          return out;
         }
-        return out;
+        // Emit a zero of the full storage type rather than of the schema.
+        // The storage type contains any explicit padding fields the schema
+        // omits: internal padding in native Swift layouts, and internal or
+        // trailing padding in imported Clang records, whose storage types are
+        // rounded up to the full C size. When such a zero-initialized value is
+        // embedded as a field of a larger constant, using the schema would
+        // drop that padding and shift the following fields to the wrong
+        // offsets (https://github.com/swiftlang/swift/issues/90414).
+        return llvm::Constant::getNullValue(resultTI.getStorageType());
       }
       case BuiltinValueKind::PtrToInt: {
         auto *ptr = emitConstantValue(IGM, args[0]).claimNextConstant();

--- a/test/Interpreter/static_array_of_c_struct_with_nested_padding.swift
+++ b/test/Interpreter/static_array_of_c_struct_with_nested_padding.swift
@@ -1,0 +1,57 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t --leading-lines
+
+// RUN: %target-build-swift -O -wmo %t/main.swift -import-objc-header %t/Types.h -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+
+//--- Types.h
+#include <stdint.h>
+
+// `Nested` needs 4 bytes of trailing padding to round its 12 bytes of fields
+// up to a multiple of its own 8-byte alignment (sizeof: 16). IRGen models that
+// padding as an explicit `[4 x i8]` field in the storage type, but the type's
+// explosion schema lists only the two scalar leaves.
+typedef struct {
+    int64_t a;
+    int32_t b;
+} Nested;
+
+// `Outer` embeds `Nested` as its first field, so `c` starts at offset 16,
+// right after `Nested`'s trailing padding. A schema-based constant emits only
+// `Nested`'s 12 bytes of scalar leaves, dropping that padding and shifting all
+// following fields down by 4 bytes.
+typedef struct {
+    Nested nested;
+    uint32_t c;
+    uint16_t d;
+    uint16_t e;
+    int8_t f;
+    int8_t g;
+    uint8_t h;
+} Outer;
+
+//--- main.swift
+
+func makeOuter(c: UInt32, d: UInt16) -> Outer {
+    Outer(nested: Nested(), c: c, d: d, e: 0, f: 0, g: 0, h: 0)
+}
+
+// A separate, non-inlinable function so the values are actually loaded from the
+// static array rather than constant-folded at the use site.
+@inline(never)
+func consume(_ items: [Outer]) -> (UInt32, UInt16) {
+    (items[0].c, items[0].d)
+}
+
+let items = [
+    makeOuter(c: 72, d: 45),
+    makeOuter(c: 0, d: 30),
+    makeOuter(c: 65, d: 0),
+]
+
+let (c, d) = consume(items)
+print("c=\(c) d=\(d)")
+// CHECK: c=72 d=45


### PR DESCRIPTION
When emitting a compile-time constant `Builtin.zeroInitializer` for a loadable type, `emitConstantValue` expanded the type's explosion *schema*, which lists only the scalar leaves and omits any explicit padding fields the storage type contains — internal padding in native Swift layouts, and internal or trailing padding in imported Clang records, whose storage types are rounded up to the full C size. Embedding such a zero-initialized value into a larger constant dropped that padding and shifted the following fields to the wrong offsets.

With optimizations this miscompiled reads of a compile-time-constant array of such structs (wrong field values), and could crash for dictionaries.

Emit a zero of the full *storage* type instead, which carries the explicit padding fields. The flattened path (enum payloads, nested vectors) keeps using the schema, since flattened constants are consumed in schema shape (e.g. by `emitValueInjection` when building an enum payload).

Verified against a locally built toolchain: the added execution test fails before the change (`c=45 d=0`) and passes after (`c=72 d=45`).

Resolves https://github.com/swiftlang/swift/issues/90414