### PR TITLE
[Embedded] Drop dead foreign-String UTF-16 / breadcrumb machinery

### DIFF
--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -154,12 +154,28 @@ extension _StringGuts {
   // Whether we can provide fast access to contiguous UTF-8 code units
   @_transparent
   @inlinable
-  internal var isFastUTF8: Bool { return _fastPath(_object.providesFastUTF8) }
+  internal var isFastUTF8: Bool {
+#if _runtime(_ObjC)
+    return _fastPath(_object.providesFastUTF8)
+#else
+    // A `String` is only ever foreign (non-fast) when it wraps a UTF-16
+    // `NSString`, which requires the Objective-C runtime. Without it every
+    // `String` is small, native, or shared -- all fast UTF-8 -- so folding this
+    // to a compile-time `true` lets the optimizer discard the foreign
+    // fallbacks (and the UTF-16 breadcrumb machinery they reference).
+    return true
+#endif
+  }
 
   // A String which does not provide fast access to contiguous UTF-8 code units
   @inlinable @inline(__always)
   internal var isForeign: Bool {
-     return _slowPath(_object.isForeign)
+#if _runtime(_ObjC)
+    return _slowPath(_object.isForeign)
+#else
+    // See `isFastUTF8`: no Objective-C runtime means no foreign strings.
+    return false
+#endif
   }
 
   @export(implementation) @inline(__always)
@@ -459,6 +475,14 @@ extension _StringGuts {
     // Attempt to recover from mismatched encodings between a string and its
     // index.
 
+#if !_runtime(_ObjC)
+    // Without the Objective-C runtime there is no verbatim `NSString`
+    // bridging, so a `String` is always UTF-8 and an index can never carry a
+    // genuine UTF-16 offset. The transcoding recovery below -- and the UTF-16
+    // `_StringBreadcrumbs` machinery it references -- is therefore unreachable.
+    // Just re-stamp the index's encoding to match `self`.
+    return markEncoding(i)
+#else
     if isUTF8 {
       // Attempt to use an UTF-16 index on a UTF-8 string.
       //
@@ -498,6 +522,7 @@ extension _StringGuts {
       r = r._copyingAlignment(from: i)
     }
     return r._knownUTF16
+#endif
   }
 }
 

--- a/test/embedded/string-utf16-breadcrumbs-dead-strip.swift
+++ b/test/embedded/string-utf16-breadcrumbs-dead-strip.swift
@@ -1,0 +1,60 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -Osize -parse-as-library -enable-experimental-feature Embedded %s -c -o %t/a.o
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/a.o %target-embedded-posix-shim -o %t/a.out -dead_strip %swift_obj_root/lib/swift/embedded/%module-target-triple/libswiftUnicodeDataTables.a
+// RUN: %llvm-nm --defined-only --format=just-symbols --demangle %t/a.out | %FileCheck %s --check-prefix=INCLUDES
+// RUN: %llvm-nm --defined-only --format=just-symbols --demangle %t/a.out | %FileCheck %s --check-prefix=EXCLUDES
+
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx
+// REQUIRES: swift_feature_Embedded
+
+// Embedded Swift has no Objective-C runtime, so a `String` can never be
+// foreign (UTF-16 / `NSString`-backed). The foreign `String.UTF8View`
+// accessors and the UTF-16 `_StringBreadcrumbs` machinery they reach are
+// therefore dead and must not survive `-dead_strip`. `_StringGuts.isFastUTF8`
+// folds to `true` (and `isForeign` to `false`) when `!_runtime(_ObjC)`, and
+// `_slowEnsureMatchingEncoding` -- which every String view index operation
+// reaches via `ensureMatchingEncoding`, and which is the path that
+// incidentally pulled the native UTF-16 breadcrumb machinery into a program
+// that only uses `.utf8` -- is short-circuited there as well. (A program that
+// genuinely uses `String.UTF16View` indexing still links that machinery, as it
+// should.)
+
+@inline(never)
+func makeString(_ bytes: [UInt8]) -> String {
+  String(decoding: bytes, as: UTF8.self)
+}
+
+// A pure UTF-8 byte compare over `String.UTF8View`, sourced from runtime bytes
+// so it cannot be constant-folded away -- the kind of name-lookup comparison an
+// embedded program does over string keys.
+@inline(never)
+func utf8Equal(_ a: String, _ b: String) -> Bool {
+  a.utf8.count == b.utf8.count && a.utf8.elementsEqual(b.utf8)
+}
+
+@main
+struct Main {
+  static func main() {
+    let a = makeString([0x72, 0x75, 0x6e])  // "run"
+    let b = makeString([0x72, 0x75, 0x6e])  // "run"
+    print(utf8Equal(a, b) ? 1 : 0)
+  }
+}
+
+// Positive anchor: the linked executable really has symbols, so the EXCLUDES-NOT
+// checks below are meaningful rather than vacuously passing on empty `nm` output.
+// (`nm --format=just-symbols` yields nothing for a wasm object, which is why this
+// test is restricted to macOS above.)
+// INCLUDES: main
+
+// None of the foreign-String / UTF-16 / breadcrumb machinery may be linked.
+// EXCLUDES-NOT: getUTF16Count
+// EXCLUDES-NOT: createAndLoadBreadcrumbs
+// EXCLUDES-NOT: getBreadcrumb
+// EXCLUDES-NOT: _foreignCount
+// EXCLUDES-NOT: _foreignIndex
+// EXCLUDES-NOT: _foreignDistance
+// EXCLUDES-NOT: _nativeGetOffset
+// EXCLUDES-NOT: _nativeGetIndex
+// EXCLUDES-NOT: _utf16Distance


### PR DESCRIPTION
Embedded Swift has no Objective-C runtime, so a String can never be foreign (UTF-16 / NSString-backed). Yet ~5.5 KB of foreign-String support survived -dead_strip in any Embedded binary using a non-trivial String: the foreign String.UTF8View accessors, and the native String.UTF16View indexing + _StringGuts.getUTF16Count + _StringBreadcrumbs cluster.

Fence both roots at the _StringGuts layer under !_runtime(_ObjC):

- isFastUTF8 folds to true and isForeign to false. The only foreign (providesFastUTF8: false) construction is Cocoa bridging, which is entirely _runtime(_ObjC) / @_unavailableInEmbedded. Folding makes the foreign fallback in every String.UTF8View accessor statically dead.

- _slowEnsureMatchingEncoding returns markEncoding(i). It only exists to recover indices from verbatim-bridged NSStrings (impossible without the ObjC runtime) and is what pulled the native UTF-16 breadcrumb cluster in through ensureMatchingEncoding.

_runtime(_ObjC) is already false for Linux/Windows/WASI too, so those non-Embedded targets shrink as well. The regular macOS/ObjC stdlib is unaffected.
