### PR TITLE
[6.4] Require an optimized stdlib to run CodableTests.swift

### DIFF
--- a/test/stdlib/CodableTests.swift
+++ b/test/stdlib/CodableTests.swift
@@ -13,6 +13,7 @@
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 // UNSUPPORTED: back_deployment_runtime
+// REQUIRES: optimized_stdlib
 
 import Foundation
 import CoreGraphics


### PR DESCRIPTION
**Explanation:** This test is a frequent cause of timeouts when run with a non-optimized stdlib. For now, we restrict it to require an optimized stdlib to run.
**Original PRs:** https://github.com/swiftlang/swift/pull/90475
**Scope:** Test change only (and only disabling the test in specific conditions).
**Issues:** rdar://178043375
**Risk:** Low. We are disabling a test configuration, so there's a small possibility that this could allow a bug to slip through that would have otherwise been discovered (e.g. if a compiler change introduced a miscompile only in non-release builds).
**Testing:** N/A
**Reviewers:** @Catfish-Man 