### PR TITLE
Add SafeImplementationOnly experimental feature flag

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -615,6 +615,11 @@ EXPERIMENTAL_FEATURE(CheckImplementationOnly, true)
 /// report references to implementation-only imported modules.
 EXPERIMENTAL_FEATURE(CheckImplementationOnlyStrict, false)
 
+/// Make @_implementationOnly safe by serializing hidden type layout information
+/// so that clients can correctly manipulate types from @_implementationOnly
+/// imports without access to the defining module.
+EXPERIMENTAL_FEATURE(SafeImplementationOnly, true)
+
 /// Check that use sites have the required @_spi import for operators.
 EXPERIMENTAL_FEATURE(EnforceSPIOperatorGroup, true)
 

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -198,6 +198,7 @@ UNINTERESTING_FEATURE(SameElementRequirements)
 UNINTERESTING_FEATURE(SendingArgsAndResults)
 UNINTERESTING_FEATURE(CheckImplementationOnly)
 UNINTERESTING_FEATURE(CheckImplementationOnlyStrict)
+UNINTERESTING_FEATURE(SafeImplementationOnly)
 UNINTERESTING_FEATURE(EnforceSPIOperatorGroup)
 
 static bool usesFeatureCAttribute(Decl *decl) {


### PR DESCRIPTION
This is the first of many PRs splitting https://github.com/swiftlang/swift/pull/87754 into more easily reviewed pieces. In this PR we just introduce the experimental feature flag.