### PR TITLE
AST,Sema: add protocol metatype extensions

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -1570,6 +1570,9 @@ void BridgedExtensionDecl_setParsedMembers(BridgedExtensionDecl decl,
                                            BridgedArrayRef members,
                                            BridgedFingerprint fingerprint);
 
+SWIFT_NAME("BridgedExtensionDecl.setIsMetatypeExtension(self:)")
+void BridgedExtensionDecl_setIsMetatypeExtension(BridgedExtensionDecl decl);
+
 SWIFT_NAME(
     "BridgedEnumDecl.createParsed(_:declContext:enumKeywordLoc:name:nameLoc:"
     "genericParamList:inheritedTypes:genericWhereClause:braceRange:)")

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -866,7 +866,7 @@ protected:
     NumPathElements : 8
   );
 
-  SWIFT_INLINE_BITFIELD(ExtensionDecl, Decl, 4+1,
+  SWIFT_INLINE_BITFIELD(ExtensionDecl, Decl, 4+1+1,
     /// An encoding of the default and maximum access level for this extension.
     /// The value 4 corresponds to AccessLevel::Public
     ///
@@ -876,7 +876,11 @@ protected:
     DefaultAndMaxAccessLevel : 4,
 
     /// Whether there is are lazily-loaded conformances for this extension.
-    HasLazyConformances : 1
+    HasLazyConformances : 1,
+
+    /// Whether this is a `metatype extension` whose members live on the
+    /// protocol metatype and are not inherited by conforming types.
+    IsMetatypeExtension : 1
   );
 
   SWIFT_INLINE_BITFIELD(MissingMemberDecl, Decl, 1+2,
@@ -2149,6 +2153,13 @@ public:
   SourceRange getBraces() const { return Braces; }
   void setBraces(SourceRange braces) { Braces = braces; }
 
+  bool isMetatypeExtension() const {
+    return Bits.ExtensionDecl.IsMetatypeExtension;
+  }
+  void setIsMetatypeExtension(bool value = true) {
+    Bits.ExtensionDecl.IsMetatypeExtension = value;
+  }
+
   bool hasBeenBound() const { return ExtendedNominal.getInt(); }
 
   void setExtendedNominal(NominalTypeDecl *n) {
@@ -2185,6 +2196,7 @@ public:
   /// Repr would not be available if the extension was been loaded
   /// from a serialized module.
   TypeRepr *getExtendedTypeRepr() const { return ExtendedTypeRepr; }
+  void setExtendedTypeRepr(TypeRepr *repr) { ExtendedTypeRepr = repr; }
                               
   /// Retrieve the set of protocols that this type inherits (i.e,
   /// explicitly conforms to).

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2237,6 +2237,11 @@ NOTE(attr_com_iswiftobject_implied, none,
 ERROR(com_module_missing_type, none,
       "type '%0' not found in the 'COM' module", (StringRef))
 
+ERROR(metatype_extension_com_only, none,
+      "protocol metatype extensions are reserved for COM interop", ())
+ERROR(metatype_extension_non_protocol, none,
+      "metatype extension can only extend a protocol, not %0", (Type))
+
 // @_staticExclusiveOnly
 ERROR(attr_static_exclusive_only_disabled,none,
       "attribute requires '-enable-experimental feature StaticExclusiveOnly'", ())

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -3347,9 +3347,15 @@ public:
         return;
 
       // If this function is generic or is within a generic context, it should
-      // have an interface type.
-      if (AFD->isGenericContext() !=
-          AFD->getInterfaceType()->is<GenericFunctionType>()) {
+      // have an interface type.  Metatype extension members are an exception:
+      // they live in a protocol extension but have no generic signature.
+      bool isInMetatypeExt = false;
+      if (auto *ext = dyn_cast<ExtensionDecl>(AFD->getDeclContext()))
+        isInMetatypeExt = ext->isMetatypeExtension();
+
+      if (!isInMetatypeExt &&
+          AFD->isGenericContext() !=
+              AFD->getInterfaceType()->is<GenericFunctionType>()) {
         Out << "Functions in generic context must have an interface type\n";
         AFD->dump(Out);
         abort();
@@ -3357,8 +3363,9 @@ public:
 
       // If the function has a generic interface type, it should also have a
       // generic signature.
-      if (AFD->isGenericContext() !=
-          (!AFD->getGenericSignature().isNull())) {
+      if (!isInMetatypeExt &&
+          AFD->isGenericContext() !=
+              (!AFD->getGenericSignature().isNull())) {
         Out << "Functions in generic context must have a generic signature\n";
         AFD->dump(Out);
         abort();

--- a/lib/AST/Bridging/DeclBridging.cpp
+++ b/lib/AST/Bridging/DeclBridging.cpp
@@ -342,6 +342,10 @@ void BridgedExtensionDecl_setParsedMembers(BridgedExtensionDecl cDecl,
   setParsedMembers(cDecl.unbridged(), cMembers, cFingerprint);
 }
 
+void BridgedExtensionDecl_setIsMetatypeExtension(BridgedExtensionDecl cDecl) {
+  cDecl.unbridged()->setIsMetatypeExtension();
+}
+
 static ArrayRef<InheritedEntry>
 convertToInheritedEntries(ASTContext &ctx, BridgedArrayRef cInheritedTypes) {
   return ctx.AllocateTransform<InheritedEntry>(

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2057,6 +2057,7 @@ ExtensionDecl::ExtensionDecl(SourceLoc extensionLoc,
 {
   Bits.ExtensionDecl.DefaultAndMaxAccessLevel = 0;
   Bits.ExtensionDecl.HasLazyConformances = false;
+  Bits.ExtensionDecl.IsMetatypeExtension = false;
   setTrailingWhereClause(trailingWhereClause);
 }
 
@@ -9614,6 +9615,22 @@ Type DeclContext::getSelfInterfaceType() const {
       return builtinTupleDecl->getTupleSelfType(dyn_cast<ExtensionDecl>(this));
 
     if (isa<ProtocolDecl>(nominalDecl)) {
+      // For metatype extensions, Self is the metatype of the existential
+      // type.  Members are instance members of the metatype, so their self
+      // parameter has type (any P).Type.
+      for (auto *dc = this; dc; dc = dc->getParent()) {
+        if (auto *ext = dyn_cast<ExtensionDecl>(dc)) {
+          if (ext->isMetatypeExtension()) {
+            auto existentialTy =
+                ExistentialType::get(nominalDecl->getDeclaredInterfaceType());
+            return MetatypeType::get(existentialTy);
+          }
+          break;
+        }
+        if (isa<NominalTypeDecl>(dc))
+          break;
+      }
+
       auto *genericParams = nominalDecl->getGenericParams();
       return genericParams->getParams().front()
           ->getDeclaredInterfaceType();

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2797,6 +2797,13 @@ QualifiedLookupRequest::evaluate(Evaluator &eval, const DeclContext *DC,
       if (options.contains(NLFlags::OnlyMacros) && !isa<MacroDecl>(decl))
         continue;
 
+      // Metatype extension members are only visible when looking up directly
+      // on the protocol, not when reached via a conforming type.
+      if (auto *ext = dyn_cast<ExtensionDecl>(decl->getDeclContext())) {
+        if (ext->isMetatypeExtension() && !llvm::is_contained(typeDecls, current))
+          continue;
+      }
+
       if (isAcceptableLookupResult(DC, options, decl, onlyCompleteObjectInits,
                                    requireImport))
         decls.push_back(decl);

--- a/lib/ASTGen/Sources/ASTGen/Decls.swift
+++ b/lib/ASTGen/Sources/ASTGen/Decls.swift
@@ -310,11 +310,18 @@ extension ASTGenVisitor {
 extension ASTGenVisitor {
   func generate(extensionDecl node: ExtensionDeclSyntax) -> BridgedExtensionDecl {
     let attrs = self.generateDeclAttributes(node, allowStatic: false)
+    // Detect `extension P.Protocol { }` — a protocol metatype extension.
+    // Strip the `.Protocol` so the extension binds to the protocol `P`.
+    let protoMeta = node.extendedType.as(MetatypeTypeSyntax.self)
+        .flatMap { $0.metatypeSpecifier.keywordKind == .Protocol ? $0 : nil }
+    let extendedType = protoMeta.map { self.generate(type: $0.baseType) }
+                    ?? self.generate(type: node.extendedType)
+
     let decl = BridgedExtensionDecl.createParsed(
       self.ctx,
       declContext: self.declContext,
       extensionKeywordLoc: self.generateSourceLoc(node.extensionKeyword),
-      extendedType: self.generate(type: node.extendedType),
+      extendedType: extendedType,
       inheritedTypes: self.generate(inheritedTypeList: node.inheritanceClause?.inheritedTypes),
       genericWhereClause: self.generate(genericWhereClause: node.genericWhereClause),
       braceRange: self.generateSourceRange(
@@ -323,6 +330,10 @@ extension ASTGenVisitor {
       )
     )
     decl.asDecl.attachParsedAttrs(attrs.attributes)
+
+    if protoMeta != nil {
+      decl.setIsMetatypeExtension()
+    }
 
     let members = self.withDeclContext(decl.asDeclContext) {
       self.generate(memberBlockItemList: node.memberBlock.members)

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -7564,6 +7564,14 @@ Parser::parseDeclExtension(ParseDeclOptions Flags, DeclAttributes &Attributes) {
                                              CurDeclContext,
                                              trailingWhereClause);
   ext->attachParsedAttrs(Attributes);
+
+  // Detect `extension P.Protocol { }` — a protocol metatype extension.
+  // Strip the `.Protocol` suffix so the extension binds to the protocol `P`.
+  if (auto *PTR = dyn_cast_or_null<ProtocolTypeRepr>(extendedType.getPtrOrNull())) {
+    ext->setIsMetatypeExtension();
+    ext->setExtendedTypeRepr(PTR->getBase());
+  }
+
   if (trailingWhereHadCodeCompletion && CodeCompletionCallbacks)
     CodeCompletionCallbacks->setParsedDecl(ext);
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1055,9 +1055,14 @@ namespace {
 
       // Unbound instance method references always build a thunk, even if
       // we apply the arguments (eg, SomeClass.method(self)(a)), to avoid
-      // representational issues.
-      if (!baseIsInstance && member->isInstanceMember())
+      // representational issues.  Metatype extension instance members are
+      // bound directly since the metatype value is the instance.
+      if (!baseIsInstance && member->isInstanceMember()) {
+        if (auto *ext = dyn_cast<ExtensionDecl>(member->getDeclContext()))
+          if (ext->isMetatypeExtension())
+            return false;
         return true;
+      }
 
       // Bound member references that are '@objc optional' or found via dynamic
       // lookup are always represented via DynamicMemberRefExpr instead of a
@@ -1869,8 +1874,12 @@ namespace {
         return forceUnwrapIfExpected(ref, memberLocator);
       }
 
+      const bool isMetatypeExtMember =
+          isa<ExtensionDecl>(member->getDeclContext()) &&
+          cast<ExtensionDecl>(member->getDeclContext())->isMetatypeExtension();
       const bool isUnboundInstanceMember =
-          (!baseIsInstance && member->isInstanceMember());
+          (!baseIsInstance && member->isInstanceMember() &&
+           !isMetatypeExtMember);
       const bool needsCurryThunk =
           shouldBuildCurryThunk(choice, baseIsInstance);
 
@@ -1934,7 +1943,11 @@ namespace {
       }
 
       auto isDynamic = choice.getKind() == OverloadChoiceKind::DeclViaDynamic;
-      if (baseIsInstance) {
+      if (isMetatypeExtMember) {
+        // For metatype extension members, the metatype value IS the instance.
+        // The base is already the right type; just coerce to an rvalue.
+        base = cs.coerceToRValue(base);
+      } else if (baseIsInstance) {
         // Convert the base to the appropriate container type, turning it
         // into an lvalue if required.
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -184,12 +184,17 @@ bool constraints::doesMemberRefApplyCurriedSelf(Type baseTy,
          "Expected a member reference");
 
   // For a reference to an instance method on a metatype, we want to keep the
-  // curried self.
+  // curried self.  Metatype extension instance members are an exception: the
+  // metatype value IS self, so the curried self is applied.
   if (decl->isInstanceMember()) {
     assert(baseTy);
     if (isa<AbstractFunctionDecl>(decl) &&
-        baseTy->getRValueType()->is<AnyMetatypeType>())
+        baseTy->getRValueType()->is<AnyMetatypeType>()) {
+      if (auto *ext = dyn_cast<ExtensionDecl>(decl->getDeclContext()))
+        if (ext->isMetatypeExtension())
+          return true;
       return false;
+    }
   }
 
   // Otherwise the reference applies self.
@@ -10757,11 +10762,28 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
       }
     };
 
+    // Metatype extension members are only accessible on the protocol
+    // metatype itself, not on conforming types.
+    if (auto *ext = dyn_cast<ExtensionDecl>(decl->getDeclContext())) {
+      if (ext->isMetatypeExtension() && !instanceTy->isExistentialType())
+        return;
+    }
+
     // See if we have an instance method, instance member or static method,
     // and check if it can be accessed on our base type.
 
     if (decl->isInstanceMember()) {
       if (baseObjTy->is<AnyMetatypeType>()) {
+        // Metatype extension instance members are instance members of the
+        // metatype type itself.  They are accessed directly on the protocol
+        // metatype value (e.g. P.value), not on an instance of the protocol.
+        if (auto *ext = dyn_cast<ExtensionDecl>(decl->getDeclContext())) {
+          if (ext->isMetatypeExtension()) {
+            result.addViable(candidate);
+            return;
+          }
+        }
+
         // `AnyObject` has special semantics, so let's just let it be.
         // Otherwise adjust base type and reference kind to make it
         // look as if lookup was done on the instance, that helps
@@ -10843,6 +10865,11 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
                     ->hasTypeParameter()) {
 
       /* We're OK */
+    } else if (instanceTy->isExistentialType() &&
+               isa<ExtensionDecl>(decl->getDeclContext()) &&
+               cast<ExtensionDecl>(decl->getDeclContext())->isMetatypeExtension()) {
+      // Metatype extension members are directly accessible on the
+      // protocol metatype without requiring Self to be bound.
     } else if (hasStaticMembers && baseObjTy->is<MetatypeType>() &&
                instanceTy->isExistentialType()) {
       // Static member lookup on protocol metatype in generic context

--- a/lib/Sema/OpenedExistentials.cpp
+++ b/lib/Sema/OpenedExistentials.cpp
@@ -531,6 +531,12 @@ swift::isMemberAvailableOnExistential(Type baseTy, const ValueDecl *member) {
     return ExistentialMemberAccessLimitation::None;
   }
 
+  // Metatype extension members are non-generic and don't reference Self.
+  if (auto *ext = dyn_cast<ExtensionDecl>(dc)) {
+    if (ext->isMetatypeExtension())
+      return ExistentialMemberAccessLimitation::None;
+  }
+
   auto &ctx = member->getASTContext();
   auto existentialSig = ctx.getOpenedExistentialSignature(baseTy);
 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2229,6 +2229,17 @@ static void dumpGenericSignature(ASTContext &ctx, GenericContext *GC) {
 }
 
 namespace {
+
+/// A metatype extension is a COM construct when it extends a COM interface
+/// — a protocol marked @com. The @com marker, not derivation from IUnknown,
+/// is the key: COM-model frameworks like IOKit use QI/AddRef/Release without
+/// deriving from a shared IUnknown, so keying on the marker (which the Clang
+/// importer can also apply to imported interfaces) is what makes this correct.
+static bool isCOMMetatypeExtension(const ExtensionDecl *ED) {
+  auto *proto = dyn_cast_or_null<ProtocolDecl>(ED->getExtendedNominal());
+  return proto && proto->getAttrs().hasAttribute<COMAttr>();
+}
+
 class DeclChecker : public DeclVisitor<DeclChecker> {
 public:
   ASTContext &Ctx;
@@ -3985,6 +3996,20 @@ public:
         visit(Member);
 
       return;
+    }
+
+    // Validate metatype extension constraints.
+    if (ED->isMetatypeExtension()) {
+      if (!isCOMMetatypeExtension(ED)) {
+        ED->diagnose(diag::metatype_extension_com_only);
+        ED->setInvalid();
+        return;
+      }
+      if (!isa<ProtocolDecl>(nominal)) {
+        ED->diagnose(diag::metatype_extension_non_protocol, extType);
+        ED->setInvalid();
+        return;
+      }
     }
 
     if (!extType->hasError()) {

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -969,6 +969,11 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
     // Self or its associated types will infer default requirements in
     // ordinary extensions of that protocol, so the signature can differ there.
     if (auto *proto = dyn_cast<ProtocolDecl>(extendedNominal)) {
+      // Metatype extensions have no generic signature.  Their members are
+      // statically dispatched and cannot reference Self.
+      if (ext->isMetatypeExtension())
+        return nullptr;
+
       if (extraReqs.empty() && !ext->getTrailingWhereClause() &&
           proto->getInverseRequirements().empty()) {
         return extendedNominal->getGenericSignatureOfContext();

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -672,6 +672,13 @@ void TypeChecker::performTypoCorrection(DeclContext *DC, DeclRefKind refKind,
     if (!isPlausibleTypo(refKind, corrections.WrittenName, decl))
       return;
 
+    // Metatype extension members are not visible on conforming types.
+    if (auto *ext = dyn_cast<ExtensionDecl>(decl->getDeclContext())) {
+      if (ext->isMetatypeExtension() && baseTypeOrNull &&
+          !baseTypeOrNull->isExistentialType())
+        return;
+    }
+
     const auto candidateName = decl->getName();
 
     // Don't waste time computing edit distances that are more than

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -2014,6 +2014,11 @@ ConstraintSystem::getTypeOfMemberReferencePre(
                                   preparedOverload);
         }
       }
+    } else if (auto *ext = dyn_cast<ExtensionDecl>(outerDC);
+               ext && ext->isMetatypeExtension()) {
+      // Metatype extension members do not require existential opening.
+      // The member belongs to the protocol metatype itself, not a
+      // conforming type.
     } else {
       // Open the existential.
       auto openedArchetype =
@@ -2029,7 +2034,8 @@ ConstraintSystem::getTypeOfMemberReferencePre(
   assert(openedParams.size() == 1);
 
   bool isDynamicLookup = (choice.getKind() == OverloadChoiceKind::DeclViaDynamic);
-  bool skipProtocolSelfConstraint = isDynamicLookup || isRequirementOrWitness(locator);
+  bool skipProtocolSelfConstraint =
+      isDynamicLookup || isRequirementOrWitness(locator);
 
   Type selfObjTy = openedParams.front().getPlainType()->getMetatypeInstanceType();
   if (outerDC->getSelfProtocolDecl()) {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5435,13 +5435,15 @@ public:
     DeclID extendedNominalID;
     DeclContextID contextID;
     bool isImplicit;
+    bool isMetatypeExtension;
     GenericSignatureID genericSigID;
     unsigned numConformances, numInherited;
     ArrayRef<uint64_t> data;
 
     decls_block::ExtensionLayout::readRecord(scratch, extendedTypeID,
                                              extendedNominalID, contextID,
-                                             isImplicit, genericSigID,
+                                             isImplicit, isMetatypeExtension,
+                                             genericSigID,
                                              numConformances, numInherited,
                                              data);
 
@@ -5467,6 +5469,7 @@ public:
 
     auto extension = ExtensionDecl::create(ctx, SourceLoc(), nullptr, { },
                                            DC, nullptr);
+    extension->setIsMetatypeExtension(isMetatypeExtension);
     declOrOffset = extension;
 
     // Generic parameter lists are written from outermost to innermost.
@@ -5512,7 +5515,7 @@ public:
     }
 
 #ifndef NDEBUG
-    if (outerParams) {
+    if (outerParams && !extension->isMetatypeExtension()) {
       unsigned paramCount = 0;
       for (auto *paramList = outerParams;
            paramList != nullptr;

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -59,7 +59,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
 const uint16_t SWIFTMODULE_VERSION_MINOR =
-    1009; // serialize conditionally-addressable lifetime dependence indices
+    1010; // metatype extension flag
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -2017,6 +2017,7 @@ namespace decls_block {
     DeclIDField, // extended nominal
     DeclContextIDField, // context decl
     BCFixed<1>,  // implicit flag
+    BCFixed<1>,  // isMetatypeExtension flag
     GenericSignatureIDField,  // generic environment
     BCVBR<4>,    // # of protocol conformances
     BCVBR<4>,    // number of inherited types

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4449,6 +4449,7 @@ public:
                                 S.addDeclRef(extendedNominal),
                                 contextID.getOpaqueValue(),
                                 extension->isImplicit(),
+                                extension->isMetatypeExtension(),
                                 S.addGenericSignatureRef(
                                            extension->getGenericSignature()),
                                 numConformances,

--- a/test/Sema/metatype-extension-disabled.swift
+++ b/test/Sema/metatype-extension-disabled.swift
@@ -1,0 +1,10 @@
+// RUN: %target-typecheck-verify-swift
+
+// Protocol metatype extensions are an ad-hoc COM-interop construct. There is no
+// user-facing feature flag that enables them on an arbitrary protocol; only a
+// protocol marked @com may carry one. A bare metatype extension on a
+// non-@com protocol is therefore always rejected.
+
+protocol P {}
+
+extension P.Protocol {} // expected-error {{protocol metatype extensions are reserved for COM interop}}

--- a/test/Sema/metatype-extension.swift
+++ b/test/Sema/metatype-extension.swift
@@ -1,0 +1,26 @@
+// RUN: %target-typecheck-verify-swift
+
+// Protocol metatype extensions are reserved for COM interop: only a protocol
+// marked @com may carry one, and there is no user-facing feature flag that
+// unlocks them for arbitrary protocols. Every metatype extension written on a
+// non-@com type is rejected before any of the other metatype-extension
+// constraints are considered.
+
+protocol P {}
+
+extension P.Protocol { // expected-error {{protocol metatype extensions are reserved for COM interop}}
+  var value: Int { 42 }
+  func greet() -> String { "hello" }
+}
+
+// --- Refinement of a plain protocol is still not a COM interface.
+protocol Q: P {}
+extension Q.Protocol {} // expected-error {{protocol metatype extensions are reserved for COM interop}}
+
+// --- Metatype extension on non-protocol types is rejected the same way; the
+//     COM-only check runs first.
+struct S {}
+extension S.Protocol {} // expected-error {{protocol metatype extensions are reserved for COM interop}}
+
+class C {}
+extension C.Protocol {} // expected-error {{protocol metatype extensions are reserved for COM interop}}


### PR DESCRIPTION
Protocol metatype extensions attach members to a protocol's metatype (`extension P.Protocol { ... }`), letting metadata be associated with a protocol type. Members of such an extension may be non-static, so the metadata can be an instance-level accessor on the metatype rather than a static one. This is what carries a COM interface's IID: it lives as a member of the interface's metatype.

Metatype extensions are not a user-facing feature. Every metatype extension passes through a single validation funnel, which admits one only when it extends a protocol marked `@com` and otherwise diagnoses `metatype_extension_com_only`. Keying on the `@com` marker — not on derivation from `IUnknown` — is what makes this correct for COM-model frameworks such as IOKit, whose interfaces use QI/AddRef/Release without a shared `IUnknown` base and are marked `@com` by the Clang importer. No experimental feature unlocks metatype extensions for any other use; `-enable-experimental-feature ProtocolMetatypeExtensions` is not a recognized option. The parser sets the metatype-extension bit unconditionally, leaving the funnel as the sole arbiter of what is allowed.