### PR TITLE
Fixes for the embedded platform layer

### DIFF
--- a/lib/SILOptimizer/UtilityPasses/Link.cpp
+++ b/lib/SILOptimizer/UtilityPasses/Link.cpp
@@ -138,8 +138,14 @@ linkEmbeddedRuntimeFunctionByName(#NAME, EFFECT, StringRef(#CC) == "C_CC");    \
     // -enforce-exclusivity=unchecked mode.
     if (!M.getOptions().EnforceExclusivityDynamic && exclusivity) return;
 
-    // Swift Runtime functions are all expected to be SILLinkage::PublicExternal
-    linkUsedFunctionByName(name, SILLinkage::PublicExternal, byAsmName);
+    // Swift Runtime functions are all expected to be SILLinkage::PublicExternal.
+    // The exception is entries looked up by their C name (`@_extern(c)` shims
+    // in the stdlib), whose Swift-level access level is an implementation
+    // detail and can be internal (giving them HiddenExternal linkage).
+    std::optional<SILLinkage> expectedLinkage;
+    if (!byAsmName)
+      expectedLinkage = SILLinkage::PublicExternal;
+    linkUsedFunctionByName(name, expectedLinkage, byAsmName);
   }
 
   void linkEmbeddedRuntimeWitnessTables() {

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -1005,7 +1005,7 @@ public func swift_getPlatformLayerVersion(
   _ minor: UnsafeMutablePointer<Int>
 ) {
   unsafe major.pointee = 1 // EMBEDDED_SWIFT_PLATFORM_VERSION_MAJOR
-  unsafe minor.pointee = 0 // EMBEDDED_SWIFT_PLATFORM_VERSION_MINOR
+  unsafe minor.pointee = 1 // EMBEDDED_SWIFT_PLATFORM_VERSION_MINOR
 }
 #endif
 

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -225,7 +225,7 @@ public func swift_allocObjectTyped(metadata: Builtin.RawPointer, requiredSize: I
   let object = unsafe p.assumingMemoryBound(to: HeapObject.self)
   unsafe _swift_embedded_set_heap_object_metadata_pointer(object, UnsafeMutablePointer<ClassMetadata>(metadata))
   unsafe object.pointee.refcount = 1
-  return unsafe p._rawValue
+  return p._rawValue
 #else
   swift_allocObject(metadata: metadata, requiredSize: requiredSize, requiredAlignmentMask: requiredAlignmentMask)
 #endif

--- a/test/embedded/dependencies-concurrency-custom-executor.swift
+++ b/test/embedded/dependencies-concurrency-custom-executor.swift
@@ -10,9 +10,6 @@
 // RUN: comm -13 %t/allowed-dependencies_macos.txt %t/actual-dependencies.txt > %t/extra.txt
 // RUN: test ! -s %t/extra.txt
 
-// Expects the POSIX-based dependencies, not the Embedded Swift platform ones.
-// XFAIL: swift_embedded_platform
-
 //--- allowed-dependencies_macos.txt
 ___assert_rtn
 ___stack_chk_fail

--- a/test/embedded/dependencies-concurrency.swift
+++ b/test/embedded/dependencies-concurrency.swift
@@ -9,9 +9,6 @@
 // RUN: comm -13 %t/allowed-dependencies.txt %t/actual-dependencies.txt > %t/extra.txt
 // RUN: test ! -s %t/extra.txt
 
-// Expects the POSIX-based dependencies, not the Embedded Swift platform ones.
-// XFAIL: swift_embedded_platform
-
 //--- allowed-dependencies.txt
 ___assert_rtn
 ___error

--- a/test/embedded/dependencies-concurrency2.swift
+++ b/test/embedded/dependencies-concurrency2.swift
@@ -9,9 +9,6 @@
 // RUN: comm -13 %t/allowed-dependencies.txt %t/actual-dependencies.txt > %t/extra.txt
 // RUN: test ! -s %t/extra.txt
 
-// Expects the POSIX-based dependencies, not the Embedded Swift platform ones.
-// XFAIL: swift_embedded_platform
-
 //--- allowed-dependencies.txt
 ___assert_rtn
 ___stack_chk_fail


### PR DESCRIPTION
Introduce a couple of small fixes for building and testing with the embedded platform layer enabled:
* Relax a SIL linker check when looking up C symbols
* Update the minor version in swift_getPlatformLayerVersion
* Re-enable some tests that are now passing with the embedded platform layer enabled