### PR TITLE
[cxx-interop] Disable upcasting execution test with an older runtime

### DIFF
--- a/test/Interop/Cxx/foreign-reference/upcast.swift
+++ b/test/Interop/Cxx/foreign-reference/upcast.swift
@@ -3,6 +3,10 @@
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_ForeignReferenceTypeInheritance
 
+// Temporarily disable when running with an older runtime (rdar://181060167)
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
 import StdlibUnittest
 import Upcast
 


### PR DESCRIPTION
When running tests against an OS with an older Swift stdlib, such as macOS 10.14.4, we should not run execution tests for FRTs since they aren't fully supported in that runtime version yet.

rdar://181060167

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
