### PR TITLE
Generalize bounds check optimizations to support offsets

### DIFF
--- a/lib/SILOptimizer/LoopTransforms/BoundsCheckOpts.cpp
+++ b/lib/SILOptimizer/LoopTransforms/BoundsCheckOpts.cpp
@@ -572,11 +572,10 @@ static bool dominates(DominanceInfo *DT, SILValue V, SILBasicBlock *B) {
   return false;
 }
 
-/// Subtract a constant from a builtin integer value.
-static SILValue getSub(SILLocation Loc, SILValue Val, unsigned SubVal,
+static SILValue getSub(SILLocation Loc, SILValue Val, SILValue SubVal,
                        SILBuilder &B) {
   SmallVector<SILValue, 4> Args(1, Val);
-  Args.push_back(B.createIntegerLiteral(Loc, Val->getType(), SubVal));
+  Args.push_back(SubVal);
   Args.push_back(B.createIntegerLiteral(
       Loc, SILType::getBuiltinIntegerType(1, B.getASTContext()), 1));
 
@@ -585,10 +584,10 @@ static SILValue getSub(SILLocation Loc, SILValue Val, unsigned SubVal,
   return B.createTupleExtract(Loc, AI, 0);
 }
 
-static SILValue getAdd(SILLocation Loc, SILValue Val, unsigned AddVal,
+static SILValue getAdd(SILLocation Loc, SILValue Val, SILValue AddVal,
                        SILBuilder &B) {
   SmallVector<SILValue, 4> Args(1, Val);
-  Args.push_back(B.createIntegerLiteral(Loc, Val->getType(), AddVal));
+  Args.push_back(AddVal);
   Args.push_back(B.createIntegerLiteral(
       Loc, SILType::getBuiltinIntegerType(1, B.getASTContext()), 1));
 
@@ -619,12 +618,29 @@ struct InductionInfo {
 
   SILInstruction *getInstruction() { return Inc; }
 
-  SILValue getFirstValue(SILLocation loc, SILBuilder &B, unsigned AddVal) {
-    return AddVal != 0 ? getAdd(loc, Start, AddVal, B) : Start;
+  SILValue getFirstValue(SILLocation loc, SILBuilder &B, SILValue offset) {
+    return offset != nullptr ? getAdd(loc, Start, offset, B) : Start;
   }
 
-  SILValue getLastValue(SILLocation loc, SILBuilder &B, unsigned SubVal) {
-    return SubVal != 0 ? getSub(loc, End, SubVal, B) : End;
+  SILValue getLastValue(SILLocation loc, SILBuilder &B, SILValue offset) {
+    if (offset == nullptr) {
+      // For simple patterns like arr[i], the last index is End - 1
+      return getSub(loc, End, B.createIntegerLiteral(loc, End->getType(), 1),
+                    B);
+    } else {
+      // Check if offset is a constant 1 to avoid redundant 1 - 1 calculation
+      if (auto *literalOffset = dyn_cast<IntegerLiteralInst>(offset)) {
+        if (literalOffset->getValue() == 1) {
+          return End;
+        }
+      }
+
+      // For offset patterns like arr[base + i], the last index is End + offset
+      // - 1
+      auto EndPlusOffset = getAdd(loc, End, offset, B);
+      return getSub(loc, EndPlusOffset,
+                    B.createIntegerLiteral(loc, End->getType(), 1), B);
+    }
   }
 
   /// If necessary insert an overflow for this induction variable.
@@ -781,69 +797,89 @@ static bool isGuaranteedToBeExecuted(DominanceInfo *DT, SILBasicBlock *Block,
 /// induction variable.
 class AccessFunction {
   InductionInfo *Ind;
-  bool preIncrement;
+  SILValue offset;
 
-  AccessFunction(InductionInfo *I, bool isPreIncrement = false)
-      : Ind(I), preIncrement(isPreIncrement) {}
+  AccessFunction(InductionInfo *I, SILValue offset = SILValue())
+      : Ind(I), offset(offset) {}
 
 public:
   operator bool() { return Ind != nullptr; }
 
   static AccessFunction getLinearFunction(SILValue Idx,
-                                          InductionAnalysis &IndVars) {
+                                          InductionAnalysis &IndVars,
+                                          DominanceInfo *DT,
+                                          SILBasicBlock *Preheader) {
     // Match the actual induction variable buried in the integer struct.
-    // bb(%ivar)
-    // %2 = struct $Int(%ivar : $Builtin.Word)
-    //    = apply %check_bounds(%array, %2) :
-    // or
     // bb(%ivar1)
-    // %ivar2 = builtin "sadd_with_overflow_Int64"(%ivar1,...)
-    // %t = tuple_extract %ivar2
+    // %base = struct $Int(%offset : $Builtin.Word)
+    // %ivar_struct = struct $Int(%ivar1 : $Builtin.Word)
+    // %add = builtin "sadd_with_overflow_Int64"(%offset, %ivar1, ...)
+    // %t = tuple_extract %add
     // %s = struct $Int(%t : $Builtin.Word)
     //    = apply %check_bounds(%array, %s) :
 
-    bool preIncrement = false;
+    SILValue offset;
 
     auto ArrayIndexStruct = dyn_cast<StructInst>(Idx);
     if (!ArrayIndexStruct)
       return nullptr;
 
     auto AsArg = dyn_cast<SILArgument>(ArrayIndexStruct->getElements()[0]);
-
-    if (!AsArg) {
-      auto *TupleExtract =
-          dyn_cast<TupleExtractInst>(ArrayIndexStruct->getElements()[0]);
-
-      if (!TupleExtract) {
-        return nullptr;
+    if (AsArg) {
+      if (auto *Ind = IndVars[AsArg]) {
+        // Simple arr[i] pattern - no offset
+        return AccessFunction(Ind);
       }
-
-      auto *Builtin = dyn_cast<BuiltinInst>(TupleExtract->getOperand());
-      if (!Builtin || Builtin->getBuiltinKind() != BuiltinValueKind::SAddOver) {
-        return nullptr;
-      }
-
-      AsArg = dyn_cast<SILArgument>(Builtin->getArguments()[0]);
-      if (!AsArg) {
-        return nullptr;
-      }
-
-      auto *incrVal = dyn_cast<IntegerLiteralInst>(Builtin->getArguments()[1]);
-      if (!incrVal || incrVal->getValue() != 1)
-        return nullptr;
-
-      preIncrement = true;
+      return nullptr;
     }
 
-    if (auto *Ind = IndVars[AsArg])
-      return AccessFunction(Ind, preIncrement);
+    auto *TupleExtract =
+        dyn_cast<TupleExtractInst>(ArrayIndexStruct->getElements()[0]);
+
+    if (!TupleExtract) {
+      return nullptr;
+    }
+
+    auto *Builtin = dyn_cast<BuiltinInst>(TupleExtract->getOperand());
+    if (!Builtin || Builtin->getBuiltinKind() != BuiltinValueKind::SAddOver) {
+      return nullptr;
+    }
+
+    // Check for i + offset pattern
+    SILValue firstArg = Builtin->getArguments()[0];
+    SILValue secondArg = Builtin->getArguments()[1];
+
+    // Try first argument as induction variable, second as offset
+    AsArg = dyn_cast<SILArgument>(firstArg);
+    if (AsArg && IndVars[AsArg]) {
+      offset = secondArg;
+    } else {
+      // Try second argument as induction variable, first as offset
+      AsArg = dyn_cast<SILArgument>(secondArg);
+      if (AsArg && IndVars[AsArg]) {
+        offset = firstArg;
+      } else {
+        return nullptr;
+      }
+    }
+
+    // Check if the offset dominates the preheader
+    if (offset && !dominates(DT, offset, Preheader)) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << " offset does not dominate preheader: " << *offset);
+      return nullptr;
+    }
+
+    if (auto *Ind = IndVars[AsArg]) {
+      return AccessFunction(Ind, offset);
+    }
 
     return nullptr;
   }
 
   /// Returns true if the loop iterates from 0 until count of \p selfValue.
   bool isZeroToCount(SILValue selfValue) {
-    if (preIncrement) {
+    if (offset) {
       return false;
     }
     return getZeroToCountOfSelf(Ind->Start, Ind->End) == selfValue;
@@ -851,8 +887,7 @@ public:
 
   SILValue getFirstValue(SILInstruction *insertPt) {
     SILBuilderWithScope builder(insertPt);
-    auto firstValue =
-        Ind->getFirstValue(insertPt->getLoc(), builder, preIncrement ? 1 : 0);
+    auto firstValue = Ind->getFirstValue(insertPt->getLoc(), builder, offset);
     auto intType = SILType::getPrimitiveObjectType(
         builder.getASTContext().getIntType()->getCanonicalType());
     return builder.createStruct(insertPt->getLoc(), intType, {firstValue});
@@ -860,8 +895,7 @@ public:
 
   SILValue getLastValue(SILInstruction *insertPt) {
     SILBuilderWithScope builder(insertPt);
-    auto lastValue =
-        Ind->getLastValue(insertPt->getLoc(), builder, preIncrement ? 0 : 1);
+    SILValue lastValue = Ind->getLastValue(insertPt->getLoc(), builder, offset);
     auto intType = SILType::getPrimitiveObjectType(
         builder.getASTContext().getIntType()->getCanonicalType());
     return builder.createStruct(insertPt->getLoc(), intType, {lastValue});
@@ -876,7 +910,7 @@ public:
     SILBuilderWithScope Builder(Preheader->getTerminator(), AI);
 
     // Get the first induction value.
-    auto FirstVal = Ind->getFirstValue(Loc, Builder, preIncrement ? 1 : 0);
+    auto FirstVal = Ind->getFirstValue(Loc, Builder, offset);
     // Clone the struct for the start index.
     auto Start = cast<SingleValueInstruction>(CheckToHoist.getIndex())
                      ->clone(Preheader->getTerminator());
@@ -888,7 +922,7 @@ public:
     NewCheck->setOperand(1, Start);
 
     // Get the last induction value.
-    auto LastVal = Ind->getLastValue(Loc, Builder, preIncrement ? 0 : 1);
+    auto LastVal = Ind->getLastValue(Loc, Builder, offset);
     // Clone the struct for the end index.
     auto End = cast<SingleValueInstruction>(CheckToHoist.getIndex())
                    ->clone(Preheader->getTerminator());
@@ -1644,7 +1678,8 @@ bool BoundsCheckOpts::hoistArrayBoundsChecksInLoop(
 
     // Get the access function "a[f(i)]". At the moment this handles only the
     // identity function.
-    auto F = AccessFunction::getLinearFunction(ArrayIndex, indVars);
+    auto F =
+        AccessFunction::getLinearFunction(ArrayIndex, indVars, DT, preheader);
     if (!F) {
       LLVM_DEBUG(llvm::dbgs() << " not a linear function " << *Inst);
       continue;
@@ -1735,7 +1770,7 @@ bool BoundsCheckOpts::hoistFixedStorageBoundsChecksInLoop(
     }
 
     auto accessFunction =
-        AccessFunction::getLinearFunction(indexValue, indVars);
+        AccessFunction::getLinearFunction(indexValue, indVars, DT, preheader);
     if (!accessFunction) {
       LLVM_DEBUG(llvm::dbgs() << " not a linear function " << *inst);
       continue;

--- a/test/SILOptimizer/abcopts.sil
+++ b/test/SILOptimizer/abcopts.sil
@@ -1224,8 +1224,8 @@ bb4(%31 : $Builtin.Int32):
 // RANGECHECK: [[TRUE:%.*]] = struct $Bool ([[MINUS1]] : $Builtin.Int1)
 // RANGECHECK: [[ZERO:%.*]] = integer_literal $Builtin.Int32, 0
 // RANGECHECK: [[INTZERO:%.*]] = struct $Int32 ([[ZERO]] : $Builtin.Int32)
-// RANGECHECK: [[FOUR:%.*]] = integer_literal $Builtin.Int32, 4
 // RANGECHECK: [[ONE:%.*]] = integer_literal $Builtin.Int32, 1
+// RANGECHECK: [[FOUR:%.*]] = integer_literal $Builtin.Int32, 4
 // RANGECHECK: [[ANOTHERTRUE:%.*]] = integer_literal $Builtin.Int1, -1
 // RANGECHECK: [[INTONEADD:%.*]] = builtin "sadd_with_overflow_Int32"([[ZERO]] : $Builtin.Int32, [[ONE]] : $Builtin.Int32, [[ANOTHERTRUE]] : $Builtin.Int1) : $(Builtin.Int32, Builtin.Int1)
 // RANGECHECK: [[INTONEEX:%.*]] = tuple_extract [[INTONEADD]] : $(Builtin.Int32, Builtin.Int1), 0

--- a/test/SILOptimizer/bounds_check_offset_test.swift
+++ b/test/SILOptimizer/bounds_check_offset_test.swift
@@ -1,0 +1,312 @@
+// RUN: %target-swift-frontend -emit-sil -O %s | %FileCheck %s
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
+
+// CHECK-LABEL: sil @$s24bounds_check_offset_test0D16ParameterOffset1ySis4SpanVySiG_S2itF :
+// CHECK: cond_fail {{.*}}, "Index out of bounds"
+// CHECK: // Loop header
+// CHECK-NOT: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-LABEL: } // end sil function '$s24bounds_check_offset_test0D16ParameterOffset1ySis4SpanVySiG_S2itF'
+public func testParameterOffset1(_ span: Span<Int>, _ offset: Int, _ count: Int) -> Int {
+    var sum = 0
+    for i in 0..<count {
+        sum &+= span[offset + i]
+    }
+    return sum
+}
+
+// CHECK-LABEL: sil @$s24bounds_check_offset_test0D16ParameterOffset2ySis4SpanVySiG_S2itF :
+// TODO-CHECK-NOT: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-LABEL: } // end sil function '$s24bounds_check_offset_test0D16ParameterOffset2ySis4SpanVySiG_S2itF'
+public func testParameterOffset2(_ span: Span<Int>, _ offset: Int, _ count: Int) -> Int {
+    precondition(offset >= 0 && offset + count <= span.count, "Valid range")
+    var sum = 0
+    for i in 0..<count {
+        sum &+= span[offset + i]
+    }
+    return sum
+}
+
+// CHECK-LABEL: sil @$s24bounds_check_offset_test0D16ParameterOffset3ySis4SpanVySiG_S2itF :
+// TODO-CHECK-NOT: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-LABEL: } // end sil function '$s24bounds_check_offset_test0D16ParameterOffset3ySis4SpanVySiG_S2itF'
+public func testParameterOffset3(_ span: Span<Int>, _ offset: Int, _ count: Int) -> Int {
+    guard offset >= 0 && offset + count <= span.count else {
+        fatalError("Invalid range")
+    }
+    var sum = 0
+    for i in 0..<count {
+        sum &+= span[offset + i]
+    }
+    return sum
+}
+
+// CHECK-LABEL: sil @$s24bounds_check_offset_test0D16LiteralConstant1ySis4SpanVySiG_SitF :
+// CHECK: cond_fail {{.*}}, "Index out of bounds"
+// CHECK: // Loop header
+// CHECK-NOT: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-LABEL: } // end sil function '$s24bounds_check_offset_test0D16LiteralConstant1ySis4SpanVySiG_SitF'
+public func testLiteralConstant1(_ span: Span<Int>, _ count: Int) -> Int {
+    var sum = 0
+    for i in 0..<count {
+        sum &+= span[5 + i]
+    }
+    return sum
+}
+
+// CHECK-LABEL: sil @$s24bounds_check_offset_test0D16LiteralConstant2ySis4SpanVySiG_SitF :
+// TODO-CHECK-NOT: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-LABEL: } // end sil function '$s24bounds_check_offset_test0D16LiteralConstant2ySis4SpanVySiG_SitF'
+public func testLiteralConstant2(_ span: Span<Int>, _ count: Int) -> Int {
+    precondition(5 + count <= span.count, "Valid range")
+    var sum = 0
+    for i in 0..<count {
+        sum &+= span[5 + i]
+    }
+    return sum
+}
+
+// CHECK-LABEL: sil @$s24bounds_check_offset_test0D19DominatingComputed1ySis4SpanVySiG_S2itF
+// CHECK: cond_fail {{.*}}, "Index out of bounds"
+// CHECK: // Loop header
+// CHECK-NOT: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-LABEL: } // end sil function '$s24bounds_check_offset_test0D19DominatingComputed1ySis4SpanVySiG_S2itF'
+public func testDominatingComputed1(_ span: Span<Int>, _ base: Int, _ count: Int) -> Int {
+    let offset = base * 2 + 1
+    var sum = 0
+    for i in 0..<count {
+        sum &+= span[offset + i]
+    }
+    return sum
+}
+
+// CHECK-LABEL: sil @$s24bounds_check_offset_test0D16LiteralConstant3ySis4SpanVySiG_SitF :
+// TODO-CHECK-NOT: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-LABEL: } // end sil function '$s24bounds_check_offset_test0D16LiteralConstant3ySis4SpanVySiG_SitF'
+public func testLiteralConstant3(_ span: Span<Int>, _ count: Int) -> Int {
+    guard 5 + count <= span.count else {
+        fatalError("Invalid range")
+    }
+    var sum = 0
+    for i in 0..<count {
+        sum &+= span[5 + i]
+    }
+    return sum
+}
+
+// CHECK-LABEL: sil @$s24bounds_check_offset_test0D19DominatingComputed2ySis4SpanVySiG_S2itF
+// TODO-CHECK-NOT: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-LABEL: } // end sil function '$s24bounds_check_offset_test0D19DominatingComputed2ySis4SpanVySiG_S2itF'
+public func testDominatingComputed2(_ span: Span<Int>, _ base: Int, _ count: Int) -> Int {
+    let offset = base * 2 + 1
+    precondition(offset >= 0 && offset + count <= span.count, "Valid range")
+    var sum = 0
+    for i in 0..<count {
+        sum &+= span[offset + i]
+    }
+    return sum
+}
+
+// CHECK-LABEL: sil @$s24bounds_check_offset_test0D14NonDominating1ySis4SpanVySiG_SitF
+// CHECK: // Loop header
+// CHECK: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-LABEL: } // end sil function '$s24bounds_check_offset_test0D14NonDominating1ySis4SpanVySiG_SitF'
+public func testNonDominating1(_ span: Span<Int>, _ count: Int) -> Int {
+    var sum = 0
+    for i in 0..<count {
+        let offset = i % 3
+        sum &+= span[offset + i]
+    }
+    return sum
+}
+
+// CHECK-LABEL: sil @$s24bounds_check_offset_test0D19DominatingComputed3ySis4SpanVySiG_S2itF
+// TODO-CHECK-NOT: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-LABEL: } // end sil function '$s24bounds_check_offset_test0D19DominatingComputed3ySis4SpanVySiG_S2itF'
+public func testDominatingComputed3(_ span: Span<Int>, _ base: Int, _ count: Int) -> Int {
+    let offset = base * 2 + 1
+    guard offset >= 0 && offset + count <= span.count else {
+        fatalError("Invalid range")
+    }
+    var sum = 0
+    for i in 0..<count {
+        sum &+= span[offset + i]
+    }
+    return sum
+}
+
+// CHECK-LABEL: sil @$s24bounds_check_offset_test0D14NonDominating2ySis4SpanVySiG_SitF
+// CHECK: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-LABEL: } // end sil function '$s24bounds_check_offset_test0D14NonDominating2ySis4SpanVySiG_SitF'
+public func testNonDominating2(_ span: Span<Int>, _ count: Int) -> Int {
+    precondition(count * 2 < span.count, "Conservative bound")
+    var sum = 0
+    for i in 0..<count {
+        let offset = i % 3
+        sum &+= span[offset + i]
+    }
+    return sum
+}
+
+// CHECK-LABEL: sil @$s24bounds_check_offset_test0D15NegativeOffset1ySis4SpanVySiG_S3itF
+// CHECK: // Loop header
+// CHECK: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-LABEL: } // end sil function '$s24bounds_check_offset_test0D15NegativeOffset1ySis4SpanVySiG_S3itF'
+public func testNegativeOffset1(_ span: Span<Int>, _ start: Int, _ end: Int, _ offset: Int) -> Int {
+    var sum = 0
+    for i in start..<end {
+        sum &+= span[i - offset]
+    }
+    return sum
+}
+
+// CHECK-LABEL: sil @$s24bounds_check_offset_test0D15NegativeOffset2ySis4SpanVySiG_S3itF
+// TODO-CHECK-NOT: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-LABEL: } // end sil function '$s24bounds_check_offset_test0D15NegativeOffset2ySis4SpanVySiG_S3itF'
+public func testNegativeOffset2(_ span: Span<Int>, _ start: Int, _ end: Int, _ offset: Int) -> Int {
+    precondition(start >= offset && end <= span.count, "Valid range")
+    var sum = 0
+    for i in start..<end {
+        sum &+= span[i - offset]
+    }
+    return sum
+}
+
+// CHECK-LABEL: sil @$s24bounds_check_offset_test0D15NegativeOffset3ySis4SpanVySiG_S3itF
+// TODO-CHECK-NOT: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-LABEL: } // end sil function '$s24bounds_check_offset_test0D15NegativeOffset3ySis4SpanVySiG_S3itF'
+public func testNegativeOffset3(_ span: Span<Int>, _ start: Int, _ end: Int, _ offset: Int) -> Int {
+    guard start >= offset && end <= span.count else {
+        fatalError("Invalid range")
+    }
+    var sum = 0
+    for i in start..<end {
+        sum &+= span[i - offset]
+    }
+    return sum
+}
+
+// CHECK-LABEL: sil @$s24bounds_check_offset_test0D21ConditionalExecution1ySis4SpanVySiG_S2iSbtF
+// CHECK: // Loop header
+// CHECK: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-LABEL: } // end sil function '$s24bounds_check_offset_test0D21ConditionalExecution1ySis4SpanVySiG_S2iSbtF'
+public func testConditionalExecution1(_ span: Span<Int>, _ offset: Int, _ count: Int, _ skipCondition: Bool) -> Int {
+    var sum = 0
+    for i in 0..<count {
+        if skipCondition {
+            continue
+        }
+        sum &+= span[offset + i]
+    }
+    return sum
+}
+
+// CHECK-LABEL: sil @$s24bounds_check_offset_test0D21ConditionalExecution2ySis4SpanVySiG_S2iSbtF
+// TODO-CHECK-NOT: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-LABEL: } // end sil function '$s24bounds_check_offset_test0D21ConditionalExecution2ySis4SpanVySiG_S2iSbtF'
+public func testConditionalExecution2(_ span: Span<Int>, _ offset: Int, _ count: Int, _ skipCondition: Bool) -> Int {
+    precondition(offset >= 0 && offset + count <= span.count, "Valid range")
+    var sum = 0
+    for i in 0..<count {
+        if skipCondition {
+            continue
+        }
+        sum &+= span[offset + i]
+    }
+    return sum
+}
+
+// CHECK-LABEL: sil @$s24bounds_check_offset_test0D21ConditionalExecution3ySis4SpanVySiG_S2iSbtF
+// TODO-CHECK-NOT: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-LABEL: } // end sil function '$s24bounds_check_offset_test0D21ConditionalExecution3ySis4SpanVySiG_S2iSbtF'
+public func testConditionalExecution3(_ span: Span<Int>, _ offset: Int, _ count: Int, _ skipCondition: Bool) -> Int {
+    guard offset >= 0 && offset + count <= span.count else {
+        fatalError("Invalid range")
+    }
+    var sum = 0
+    for i in 0..<count {
+        if skipCondition {
+            continue
+        }
+        sum &+= span[offset + i]
+    }
+    return sum
+}
+
+// CHECK-LABEL: sil @$s24bounds_check_offset_test0D15ParameterRange1ySis4SpanVySiG_S3itF :
+// CHECK: cond_fail {{.*}}, "Index out of bounds"
+// CHECK: // Loop header
+// TODO-CHECK-NOT: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-LABEL: } // end sil function '$s24bounds_check_offset_test0D15ParameterRange1ySis4SpanVySiG_S3itF'
+public func testParameterRange1(_ span: Span<Int>, _ offset: Int, _ start: Int, _ end: Int) -> Int {
+    var sum = 0
+    for i in start...end {
+        sum &+= span[offset + i]
+    }
+    return sum
+}
+
+// CHECK-LABEL: sil @$s24bounds_check_offset_test0D15ParameterRange2ySis4SpanVySiG_S3itF :
+// TODO-CHECK-NOT: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-LABEL: } // end sil function '$s24bounds_check_offset_test0D15ParameterRange2ySis4SpanVySiG_S3itF'
+public func testParameterRange2(_ span: Span<Int>, _ offset: Int, _ start: Int, _ end: Int) -> Int {
+    precondition(offset >= 0 && offset + end < span.count, "Valid range")
+    var sum = 0
+    for i in start...end {
+        sum &+= span[offset + i]
+    }
+    return sum
+}
+
+// CHECK-LABEL: sil @$s24bounds_check_offset_test0D15ParameterRange3ySis4SpanVySiG_S3itF :
+// TODO-CHECK-NOT: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-LABEL: } // end sil function '$s24bounds_check_offset_test0D15ParameterRange3ySis4SpanVySiG_S3itF'
+public func testParameterRange3(_ span: Span<Int>, _ offset: Int, _ start: Int, _ end: Int) -> Int {
+    guard offset >= 0 && offset + end < span.count else {
+        fatalError("Invalid range")
+    }
+    var sum = 0
+    for i in start...end {
+        sum &+= span[offset + i]
+    }
+    return sum
+}
+
+// CHECK-LABEL: sil @$s24bounds_check_offset_test25dontEliminateBoundsCheck1ySis4SpanVySiGF :
+// CHECK: cond_fail {{.*}}, "Index out of bounds"
+// CHECK: // Loop header
+// CHECK-NOT: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-LABEL: } // end sil function '$s24bounds_check_offset_test25dontEliminateBoundsCheck1ySis4SpanVySiGF'
+public func dontEliminateBoundsCheck1(_ span: Span<Int>) -> Int {
+    var sum = 0
+    for i in 0..<span.count {
+        sum += span[5 + i]
+    }
+    return sum
+}
+
+// CHECK-LABEL: sil @$s24bounds_check_offset_test25dontEliminateBoundsCheck2ySis4SpanVySiG_SitF :
+// CHECK: cond_fail {{.*}}, "Index out of bounds"
+// CHECK: // Loop header
+// CHECK-NOT: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-LABEL: } // end sil function '$s24bounds_check_offset_test25dontEliminateBoundsCheck2ySis4SpanVySiG_SitF'
+public func dontEliminateBoundsCheck2(_ span: Span<Int>, _ offset: Int) -> Int {
+    var sum = 0
+    for i in 0..<span.count {
+        sum += span[offset + i]
+    }
+    return sum
+}
+
+// CHECK-LABEL: sil @$s24bounds_check_offset_test0D6OffsetySis4SpanVySiG_S2itF :
+// CHECK: cond_fail {{.*}}, "Index out of bounds"
+// CHECK: // Loop header
+// CHECK-NOT: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-LABEL: } // end sil function '$s24bounds_check_offset_test0D6OffsetySis4SpanVySiG_S2itF'
+public func testOffset(_ v: borrowing Span<Int>, _ base: Int, _ n: Int) -> Int {
+  var sum = 0
+  guard base >= 0, n >= 0, base + n <= v.count else { return 0 }
+  for i in 0..<n {
+    sum &+= v[base + i]
+  }
+  return sum
+}


### PR DESCRIPTION
Previously, AccessFunction only recognized simple `span[i]` and
pre-increment `span[i+1]` patterns. Generalize it to handle `arr[offset + i]`
where offset is any loop-invariant value that dominates the preheader.
