### PR TITLE
🍒 [windows][arm64] use lld-link to build SwiftSyntax

### DIFF
--- a/lib/CompilerSwiftSyntax/CMakeLists.txt
+++ b/lib/CompilerSwiftSyntax/CMakeLists.txt
@@ -57,6 +57,18 @@ foreach(lib ${compiler_swiftsyntax_libs})
   target_compile_options(${lib} PRIVATE "SHELL:-module-link-name ${lib}")
 endforeach()
 
+# FIXME(https://github.com/swiftlang/swift/issues/90100): On Windows ARM64 the
+# MSVC linker 'link.exe' aborts with LNK1322 (Cortex-A53 erratum #843419
+# hazard) while linking SyntaxVisitor.swift.obj. Link swift-syntax with
+# lld-link, which emits the hazard workaround.
+if(SWIFT_HOST_VARIANT_SDK STREQUAL "WINDOWS" AND
+   SWIFT_HOST_VARIANT_ARCH STREQUAL "aarch64" AND
+   NOT LLVM_ENABLE_LTO)
+  foreach(lib ${compiler_swiftsyntax_libs})
+    target_link_options(${lib} PRIVATE "-use-ld=lld-link")
+  endforeach()
+endif()
+
 swift_install_in_component(TARGETS ${compiler_swiftsyntax_libs}
   ARCHIVE DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/host/compiler" COMPONENT compiler-swift-syntax-lib
   LIBRARY DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/host/compiler" COMPONENT compiler-swift-syntax-lib

--- a/lib/SwiftSyntax/CMakeLists.txt
+++ b/lib/SwiftSyntax/CMakeLists.txt
@@ -54,6 +54,18 @@ set(SWIFT_SYNTAX_MODULES
   SwiftLibraryPluginProvider
 )
 
+# FIXME(https://github.com/swiftlang/swift/issues/90100): On Windows ARM64 the
+# MSVC linker 'link.exe' aborts with LNK1322 (Cortex-A53 erratum #843419
+# hazard) while linking SyntaxVisitor.swift.obj. Link swift-syntax with
+# lld-link, which emits the hazard workaround.
+if(SWIFT_HOST_VARIANT_SDK STREQUAL "WINDOWS" AND
+   SWIFT_HOST_VARIANT_ARCH STREQUAL "aarch64" AND
+   NOT LLVM_ENABLE_LTO)
+  foreach(module ${SWIFT_SYNTAX_MODULES})
+    target_link_options(${module} PRIVATE "-use-ld=lld-link")
+  endforeach()
+endif()
+
 # Install shared runtime libraries
 if(CMAKE_SYSTEM_NAME MATCHES Windows)
   swift_install_in_component(TARGETS ${SWIFT_SYNTAX_MODULES}


### PR DESCRIPTION
- **Explanation**:
	When building for ARM64 Windows, SwiftSyntax does not build with the version of MSVC the bots use due to `Cortex-A53 MPCore processor bug #843419`. This is a bug in `link.exe`. `lld-link` does not have that bug. This patch uses `lld-link` to build SwiftSyntax on arm64 Windows to fix this build issue.
- **Scope**:
	This impacts the ARM64 Windows Toolchain and more specifically the linker used for SwiftSyntax.
- **Issues**:
  - rdar://180580474
- **Original PRs**:
  - https://github.com/swiftlang/swift/pull/90101
- **Risk**:
  Low, we are swapping linkers for a module of the compiler.
- **Testing**:
  Tested at desk.
- **Reviewers**:
  - @compnerd