### PR TITLE
[Embedded] Two multi-threaded implementations of the platform abstraction library

### DIFF
--- a/stdlib/public/EmbeddedPlatform/CMakeLists.txt
+++ b/stdlib/public/EmbeddedPlatform/CMakeLists.txt
@@ -24,6 +24,8 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   add_dependencies(embedded-libraries embedded-single-threaded-shim)
   add_custom_target(embedded-multi-threaded-posix-shim)
   add_dependencies(embedded-libraries embedded-multi-threaded-posix-shim)
+  add_custom_target(embedded-multi-threaded-darwin-shim)
+  add_dependencies(embedded-libraries embedded-multi-threaded-darwin-shim)
 
   foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
     string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
@@ -147,5 +149,40 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     set_property(TARGET embedded-multi-threaded-posix-shim-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
 
     add_dependencies(embedded-multi-threaded-posix-shim embedded-multi-threaded-posix-shim-${mod})
+
+    # The Darwin-specific `os_unfair_lock` shim is only meaningful on Apple
+    # target triples.
+    if("${triple}" MATCHES "-apple-")
+      add_swift_target_library_single(
+        embedded-multi-threaded-darwin-shim-${mod}
+        swiftEmbeddedPlatformMultiThreadedDarwin
+        STATIC
+        IS_FRAGILE
+        PARTIAL_SOURCES_INTENDED
+
+        EmbeddedPlatformMultiThreadedDarwin.c
+
+        C_COMPILE_FLAGS ${extra_c_compile_flags} -I${CMAKE_CURRENT_SOURCE_DIR}/swift
+        MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
+        SDK "embedded"
+        ARCHITECTURE "${mod}"
+        DEPENDS embedded-stdlib-${mod}
+        INSTALL_IN_COMPONENT stdlib
+        )
+      swift_install_in_component(
+        TARGETS embedded-multi-threaded-darwin-shim-${mod}
+        DESTINATION "lib/swift/embedded/${mod}"
+        COMPONENT "stdlib"
+        )
+      swift_install_in_component(
+        FILES "${SWIFTLIB_DIR}/embedded/${mod}/libswiftEmbeddedPlatformMultiThreadedDarwin.a"
+        DESTINATION "lib/swift/embedded/${mod}/"
+        COMPONENT "stdlib"
+        PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+        )
+      set_property(TARGET embedded-multi-threaded-darwin-shim-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
+
+      add_dependencies(embedded-multi-threaded-darwin-shim embedded-multi-threaded-darwin-shim-${mod})
+    endif()
   endforeach()
 endif()

--- a/stdlib/public/EmbeddedPlatform/CMakeLists.txt
+++ b/stdlib/public/EmbeddedPlatform/CMakeLists.txt
@@ -121,7 +121,11 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
 
     # The POSIX pthread-based shim only makes sense on hosted POSIX targets;
     # skip bare-metal and Windows triples that lack a pthread implementation.
-    if(NOT "${triple}" MATCHES "-none-|-windows-")
+    # Also skip Apple targets when the host is not macOS: cross-compiling to
+    # Apple from Linux/Windows without an Apple SDK picks up the host libc's
+    # `<pthread.h>`, which fails.
+    if(NOT "${triple}" MATCHES "-none-|-windows-" AND
+       (NOT "${triple}" MATCHES "-apple-" OR SWIFT_HOST_VARIANT STREQUAL "macosx"))
       add_swift_target_library_single(
         embedded-multi-threaded-posix-shim-${mod}
         swiftEmbeddedPlatformMultiThreadedPOSIX
@@ -155,9 +159,12 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     endif()
 
     # The Darwin-specific `os_unfair_lock` shim is only meaningful on hosted
-    # Apple target triples; bare-metal `-apple-none-*` triples have no OS SDK
-    # and therefore no `<os/lock.h>`.
-    if("${triple}" MATCHES "-apple-" AND NOT "${triple}" MATCHES "-apple-none-")
+    # Apple target triples, and can only be compiled when the host has an
+    # Apple SDK (i.e. macOS). Skip bare-metal `-apple-none-*` triples and
+    # non-macOS hosts.
+    if("${triple}" MATCHES "-apple-" AND
+       NOT "${triple}" MATCHES "-apple-none-" AND
+       SWIFT_HOST_VARIANT STREQUAL "macosx")
       add_swift_target_library_single(
         embedded-multi-threaded-darwin-shim-${mod}
         swiftEmbeddedPlatformMultiThreadedDarwin

--- a/stdlib/public/EmbeddedPlatform/CMakeLists.txt
+++ b/stdlib/public/EmbeddedPlatform/CMakeLists.txt
@@ -119,36 +119,40 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
 
     add_dependencies(embedded-single-threaded-shim embedded-single-threaded-shim-${mod})
 
-    add_swift_target_library_single(
-      embedded-multi-threaded-posix-shim-${mod}
-      swiftEmbeddedPlatformMultiThreadedPOSIX
-      STATIC
-      IS_FRAGILE
-      PARTIAL_SOURCES_INTENDED
+    # The POSIX pthread-based shim only makes sense on hosted POSIX targets;
+    # skip bare-metal and Windows triples that lack a pthread implementation.
+    if(NOT "${triple}" MATCHES "-none-|-windows-")
+      add_swift_target_library_single(
+        embedded-multi-threaded-posix-shim-${mod}
+        swiftEmbeddedPlatformMultiThreadedPOSIX
+        STATIC
+        IS_FRAGILE
+        PARTIAL_SOURCES_INTENDED
 
-      EmbeddedPlatformMultiThreadedPOSIX.c
+        EmbeddedPlatformMultiThreadedPOSIX.c
 
-      C_COMPILE_FLAGS ${extra_c_compile_flags} -I${CMAKE_CURRENT_SOURCE_DIR}/swift
-      MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
-      SDK "embedded"
-      ARCHITECTURE "${mod}"
-      DEPENDS embedded-stdlib-${mod}
-      INSTALL_IN_COMPONENT stdlib
-      )
-    swift_install_in_component(
-      TARGETS embedded-multi-threaded-posix-shim-${mod}
-      DESTINATION "lib/swift/embedded/${mod}"
-      COMPONENT "stdlib"
-      )
-    swift_install_in_component(
-      FILES "${SWIFTLIB_DIR}/embedded/${mod}/libswiftEmbeddedPlatformMultiThreadedPOSIX.a"
-      DESTINATION "lib/swift/embedded/${mod}/"
-      COMPONENT "stdlib"
-      PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-      )
-    set_property(TARGET embedded-multi-threaded-posix-shim-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
+        C_COMPILE_FLAGS ${extra_c_compile_flags} -I${CMAKE_CURRENT_SOURCE_DIR}/swift
+        MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
+        SDK "embedded"
+        ARCHITECTURE "${mod}"
+        DEPENDS embedded-stdlib-${mod}
+        INSTALL_IN_COMPONENT stdlib
+        )
+      swift_install_in_component(
+        TARGETS embedded-multi-threaded-posix-shim-${mod}
+        DESTINATION "lib/swift/embedded/${mod}"
+        COMPONENT "stdlib"
+        )
+      swift_install_in_component(
+        FILES "${SWIFTLIB_DIR}/embedded/${mod}/libswiftEmbeddedPlatformMultiThreadedPOSIX.a"
+        DESTINATION "lib/swift/embedded/${mod}/"
+        COMPONENT "stdlib"
+        PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+        )
+      set_property(TARGET embedded-multi-threaded-posix-shim-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
 
-    add_dependencies(embedded-multi-threaded-posix-shim embedded-multi-threaded-posix-shim-${mod})
+      add_dependencies(embedded-multi-threaded-posix-shim embedded-multi-threaded-posix-shim-${mod})
+    endif()
 
     # The Darwin-specific `os_unfair_lock` shim is only meaningful on Apple
     # target triples.

--- a/stdlib/public/EmbeddedPlatform/CMakeLists.txt
+++ b/stdlib/public/EmbeddedPlatform/CMakeLists.txt
@@ -154,9 +154,10 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       add_dependencies(embedded-multi-threaded-posix-shim embedded-multi-threaded-posix-shim-${mod})
     endif()
 
-    # The Darwin-specific `os_unfair_lock` shim is only meaningful on Apple
-    # target triples.
-    if("${triple}" MATCHES "-apple-")
+    # The Darwin-specific `os_unfair_lock` shim is only meaningful on hosted
+    # Apple target triples; bare-metal `-apple-none-*` triples have no OS SDK
+    # and therefore no `<os/lock.h>`.
+    if("${triple}" MATCHES "-apple-" AND NOT "${triple}" MATCHES "-apple-none-")
       add_swift_target_library_single(
         embedded-multi-threaded-darwin-shim-${mod}
         swiftEmbeddedPlatformMultiThreadedDarwin

--- a/stdlib/public/EmbeddedPlatform/CMakeLists.txt
+++ b/stdlib/public/EmbeddedPlatform/CMakeLists.txt
@@ -22,6 +22,8 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   add_dependencies(embedded-libraries embedded-posix-shim)
   add_custom_target(embedded-single-threaded-shim)
   add_dependencies(embedded-libraries embedded-single-threaded-shim)
+  add_custom_target(embedded-multi-threaded-posix-shim)
+  add_dependencies(embedded-libraries embedded-multi-threaded-posix-shim)
 
   foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
     string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
@@ -56,6 +58,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       swiftEmbeddedPlatformPOSIX
       STATIC
       IS_FRAGILE
+      PARTIAL_SOURCES_INTENDED
 
       EmbeddedPlatformPOSIX.swift
 
@@ -87,6 +90,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       swiftEmbeddedPlatformSingleThreaded
       STATIC
       IS_FRAGILE
+      PARTIAL_SOURCES_INTENDED
 
       EmbeddedPlatformSingleThreaded.swift
 
@@ -112,5 +116,36 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     set_property(TARGET embedded-single-threaded-shim-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
 
     add_dependencies(embedded-single-threaded-shim embedded-single-threaded-shim-${mod})
+
+    add_swift_target_library_single(
+      embedded-multi-threaded-posix-shim-${mod}
+      swiftEmbeddedPlatformMultiThreadedPOSIX
+      STATIC
+      IS_FRAGILE
+      PARTIAL_SOURCES_INTENDED
+
+      EmbeddedPlatformMultiThreadedPOSIX.c
+
+      C_COMPILE_FLAGS ${extra_c_compile_flags} -I${CMAKE_CURRENT_SOURCE_DIR}/swift
+      MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
+      SDK "embedded"
+      ARCHITECTURE "${mod}"
+      DEPENDS embedded-stdlib-${mod}
+      INSTALL_IN_COMPONENT stdlib
+      )
+    swift_install_in_component(
+      TARGETS embedded-multi-threaded-posix-shim-${mod}
+      DESTINATION "lib/swift/embedded/${mod}"
+      COMPONENT "stdlib"
+      )
+    swift_install_in_component(
+      FILES "${SWIFTLIB_DIR}/embedded/${mod}/libswiftEmbeddedPlatformMultiThreadedPOSIX.a"
+      DESTINATION "lib/swift/embedded/${mod}/"
+      COMPONENT "stdlib"
+      PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+      )
+    set_property(TARGET embedded-multi-threaded-posix-shim-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
+
+    add_dependencies(embedded-multi-threaded-posix-shim embedded-multi-threaded-posix-shim-${mod})
   endforeach()
 endif()

--- a/stdlib/public/EmbeddedPlatform/EmbeddedPlatformMultiThreadedDarwin.c
+++ b/stdlib/public/EmbeddedPlatform/EmbeddedPlatformMultiThreadedDarwin.c
@@ -1,0 +1,123 @@
+/*===------ EmbeddedPlatformMultiThreadedDarwin.c ----------------*- C -*-===*
+ *
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2026 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+ *
+ *===----------------------------------------------------------------------===*
+ *
+ * A Darwin-only implementation of the Embedded Swift platform mutex hooks:
+ *
+ *   - The common non-recursive case (with or without the CHECKED flag) uses
+ *     `os_unfair_lock` (see <os/lock.h>), stored fully inline in the
+ *     caller-owned mutex storage.
+ *
+ *   - The RECURSIVE case uses a heap-allocated `pthread_mutex_t` initialized
+ *     with `PTHREAD_MUTEX_RECURSIVE`, since `os_unfair_lock` has no reentrant
+ *     mode and building one on top of it would duplicate what pthreads
+ *     already provides.
+ *
+ *===----------------------------------------------------------------------===*/
+
+#include "swift/EmbeddedPlatform.h"
+
+#include <os/lock.h>
+#include <pthread.h>
+#include <stdint.h>
+
+// Storage layout that we impose on the caller-owned mutex buffer. `flags` is
+// used as the discriminator between the two backends: if it has
+// `SWIFT_MUTEX_RECURSIVE` set, `u.heap` is a heap-allocated
+// `pthread_mutex_t`; otherwise `u.unfair` is an inline `os_unfair_lock`.
+typedef struct {
+  uint32_t flags;
+  union {
+    os_unfair_lock unfair;
+    pthread_mutex_t *heap;
+  } u;
+} swift_darwin_mutex_t;
+
+_Static_assert(sizeof(swift_darwin_mutex_t) <= 8 * sizeof(void *),
+               "swift_darwin_mutex_t does not fit in the Embedded Swift "
+               "Platform mutex storage (8 pointer-sized words)");
+_Static_assert(_Alignof(swift_darwin_mutex_t) <= _Alignof(void *),
+               "swift_darwin_mutex_t requires stronger alignment than the "
+               "Embedded Swift Platform mutex storage provides");
+
+static void trap_if(int failed) {
+  if (failed) {
+#if __has_builtin(__builtin_trap)
+    __builtin_trap();
+#else
+    *(volatile int *)0x11 = 0;
+#endif
+  }
+}
+
+void _swift_mutex_init(void *mutex, swift_mutex_flags_t flags) {
+  swift_darwin_mutex_t *m = (swift_darwin_mutex_t *)mutex;
+  m->flags = (uint32_t)flags;
+
+  if (flags & SWIFT_MUTEX_RECURSIVE) {
+    pthread_mutex_t *heap = (pthread_mutex_t *)_swift_allocate(
+        _Alignof(pthread_mutex_t), sizeof(pthread_mutex_t), SWIFT_ALLOC_NONE);
+    trap_if(heap == NULL);
+
+    pthread_mutexattr_t attr;
+    trap_if(pthread_mutexattr_init(&attr) != 0);
+    trap_if(pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE) != 0);
+    trap_if(pthread_mutex_init(heap, &attr) != 0);
+    (void)pthread_mutexattr_destroy(&attr);
+
+    m->u.heap = heap;
+    return;
+  }
+
+  m->u.unfair = (os_unfair_lock)OS_UNFAIR_LOCK_INIT;
+}
+
+void _swift_mutex_destroy(void *mutex) {
+  swift_darwin_mutex_t *m = (swift_darwin_mutex_t *)mutex;
+  if (m->flags & SWIFT_MUTEX_RECURSIVE) {
+    trap_if(pthread_mutex_destroy(m->u.heap) != 0);
+    _swift_free(m->u.heap, _Alignof(pthread_mutex_t),
+                sizeof(pthread_mutex_t), SWIFT_FREE_NONE);
+    m->u.heap = NULL;
+  }
+  // Non-recursive: `os_unfair_lock` has no destroy step.
+}
+
+void _swift_mutex_lock(void *mutex) {
+  swift_darwin_mutex_t *m = (swift_darwin_mutex_t *)mutex;
+  if (m->flags & SWIFT_MUTEX_RECURSIVE) {
+    trap_if(pthread_mutex_lock(m->u.heap) != 0);
+    return;
+  }
+  os_unfair_lock_lock(&m->u.unfair);
+}
+
+void _swift_mutex_unlock(void *mutex) {
+  swift_darwin_mutex_t *m = (swift_darwin_mutex_t *)mutex;
+  if (m->flags & SWIFT_MUTEX_RECURSIVE) {
+    trap_if(pthread_mutex_unlock(m->u.heap) != 0);
+    return;
+  }
+  if (m->flags & SWIFT_MUTEX_CHECKED) {
+    // Aborts if the current thread does not own the lock, or the lock is
+    // not held at all.
+    os_unfair_lock_assert_owner(&m->u.unfair);
+  }
+  os_unfair_lock_unlock(&m->u.unfair);
+}
+
+__swift_ptrdiff_t _swift_mutex_tryLock(void *mutex) {
+  swift_darwin_mutex_t *m = (swift_darwin_mutex_t *)mutex;
+  if (m->flags & SWIFT_MUTEX_RECURSIVE) {
+    return pthread_mutex_trylock(m->u.heap) == 0 ? 1 : 0;
+  }
+  return os_unfair_lock_trylock(&m->u.unfair) ? 1 : 0;
+}

--- a/stdlib/public/EmbeddedPlatform/EmbeddedPlatformMultiThreadedPOSIX.c
+++ b/stdlib/public/EmbeddedPlatform/EmbeddedPlatformMultiThreadedPOSIX.c
@@ -1,0 +1,82 @@
+/*===------ EmbeddedPlatformMultiThreadedPOSIX.c -----------------*- C -*-===*
+ *
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2026 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+ *
+ *===----------------------------------------------------------------------===*
+ *
+ * A multi-threaded implementation of the Embedded Swift platform mutex hooks
+ * on top of `pthread_mutex_t`. The `pthread_mutex_t` is constructed directly
+ * in the eight pointer-sized words of caller-owned storage that the platform
+ * layer provides — 64 bytes on 64-bit targets, which fits every currently
+ * supported `pthread_mutex_t` (40 bytes on glibc LP64, 56 bytes on Darwin
+ * LP64).
+ *
+ *===----------------------------------------------------------------------===*/
+
+
+#include "swift/EmbeddedPlatform.h"
+
+#include <pthread.h>
+
+#if __STDC_VERSION__ >= 201112L
+_Static_assert(sizeof(pthread_mutex_t) <= 8 * sizeof(void *),
+               "pthread_mutex_t does not fit in the Embedded Swift Platform "
+               "mutex storage (8 pointer-sized words)");
+_Static_assert(_Alignof(pthread_mutex_t) <= _Alignof(void *),
+               "pthread_mutex_t requires stronger alignment than the Embedded "
+               "Swift Platform mutex storage provides");
+#endif
+
+static void trap_if(int failed) {
+  if (failed) {
+#if __has_builtin(__builtin_trap)
+    __builtin_trap();
+#else
+    *(volatile int*)0x11 = 0;
+#endif
+  }
+}
+
+void _swift_mutex_init(void *mutex, swift_mutex_flags_t flags) {
+  int type;
+  if (flags & SWIFT_MUTEX_RECURSIVE) {
+    type = PTHREAD_MUTEX_RECURSIVE;
+  } else if (flags & SWIFT_MUTEX_CHECKED) {
+    type = PTHREAD_MUTEX_ERRORCHECK;
+  } else {
+    type = PTHREAD_MUTEX_NORMAL;
+  }
+
+  if (type == PTHREAD_MUTEX_NORMAL) {
+    trap_if(pthread_mutex_init((pthread_mutex_t *)mutex, NULL) != 0);
+    return;
+  }
+
+  pthread_mutexattr_t attr;
+  trap_if(pthread_mutexattr_init(&attr) != 0);
+  trap_if(pthread_mutexattr_settype(&attr, type) != 0);
+  trap_if(pthread_mutex_init((pthread_mutex_t *)mutex, &attr) != 0);
+  (void)pthread_mutexattr_destroy(&attr);
+}
+
+void _swift_mutex_destroy(void *mutex) {
+  trap_if(pthread_mutex_destroy((pthread_mutex_t *)mutex) != 0);
+}
+
+void _swift_mutex_lock(void *mutex) {
+  trap_if(pthread_mutex_lock((pthread_mutex_t *)mutex) != 0);
+}
+
+void _swift_mutex_unlock(void *mutex) {
+  trap_if(pthread_mutex_unlock((pthread_mutex_t *)mutex) != 0);
+}
+
+__swift_ptrdiff_t _swift_mutex_tryLock(void *mutex) {
+  return pthread_mutex_trylock((pthread_mutex_t *)mutex) == 0 ? 1 : 0;
+}

--- a/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
+++ b/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
@@ -322,8 +322,8 @@ void _swift_setExclusivityTLS(void * EMBEDDED_SWIFT_NULLABLE ptr);
  * Parameters:
  *   - `mutex`: opaque caller-owned mutex storage initialized by this function
  *     and later passed to the other `_swift_mutex_*` functions. The contents
- *     are private to the platform implementation. The storage is at least six
- *     pointer-sized words and has pointer alignment.
+ *     are private to the platform implementation. The storage is at least
+ *     eight pointer-sized words and has pointer alignment.
  *   - `flags`: flags controlling mutex behavior.
  *
  * This function is required when using Synchronization.Mutex.

--- a/stdlib/public/Synchronization/Mutex/EmbeddedImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/EmbeddedImpl.swift
@@ -12,7 +12,7 @@
 
 // Private inline storage for EmbeddedPlatform's opaque mutex hooks.
 @usableFromInline
-internal typealias _SwiftEmbeddedMutex = [6 of UInt]
+internal typealias _SwiftEmbeddedMutex = [8 of UInt]
 
 @_extern(c, "_swift_mutex_init")
 @usableFromInline
@@ -56,7 +56,7 @@ public struct _MutexHandle: ~Copyable {
   @_alwaysEmitIntoClient
   @_transparent
   public init() {
-    storage = _Cell([0, 0, 0, 0, 0, 0])
+    storage = _Cell([0, 0, 0, 0, 0, 0, 0, 0])
     unsafe _swift_mutex_init(UnsafeMutableRawPointer(storage._address), 0)
   }
 

--- a/test/embedded/embedded-platform-multi-threaded-darwin-mutex.swift
+++ b/test/embedded/embedded-platform-multi-threaded-darwin-mutex.swift
@@ -9,6 +9,7 @@
 // REQUIRES: synchronization
 // REQUIRES: OS=macosx
 // REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_embedded_platform
 
 import Synchronization
 

--- a/test/embedded/embedded-platform-multi-threaded-darwin-mutex.swift
+++ b/test/embedded/embedded-platform-multi-threaded-darwin-mutex.swift
@@ -1,0 +1,37 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -parse-as-library -enable-experimental-feature Embedded -disable-availability-checking -wmo %s -c -o %t/main.o
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/main.o %target-embedded-multi-threaded-darwin-shim %target-embedded-posix-shim -o %t/a.out -dead_strip
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: synchronization
+// REQUIRES: OS=macosx
+// REQUIRES: swift_feature_Embedded
+
+import Synchronization
+
+@main
+struct Main {
+  static func main() {
+    let mutex = Mutex(0)
+
+    let first = mutex.withLock { value -> Int in
+      value += 1
+      return value
+    }
+    print(first)
+    // CHECK: 1
+
+    let second = mutex.withLockIfAvailable { value -> Int in
+      value += 41
+      return value
+    }
+    print(second ?? -1)
+    // CHECK: 42
+
+    print("done")
+    // CHECK: done
+  }
+}

--- a/test/embedded/embedded-platform-multi-threaded-posix-mutex.swift
+++ b/test/embedded/embedded-platform-multi-threaded-posix-mutex.swift
@@ -1,0 +1,37 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -parse-as-library -enable-experimental-feature Embedded -disable-availability-checking -wmo %s -c -o %t/main.o
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/main.o %target-embedded-multi-threaded-posix-shim %target-embedded-posix-shim -o %t/a.out -dead_strip
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: synchronization
+// REQUIRES: OS=macosx || OS=linux-gnu || OS=wasip1
+// REQUIRES: swift_feature_Embedded
+
+import Synchronization
+
+@main
+struct Main {
+  static func main() {
+    let mutex = Mutex(0)
+
+    let first = mutex.withLock { value -> Int in
+      value += 1
+      return value
+    }
+    print(first)
+    // CHECK: 1
+
+    let second = mutex.withLockIfAvailable { value -> Int in
+      value += 41
+      return value
+    }
+    print(second ?? -1)
+    // CHECK: 42
+
+    print("done")
+    // CHECK: done
+  }
+}

--- a/test/embedded/embedded-platform-single-threaded-mutex.swift
+++ b/test/embedded/embedded-platform-single-threaded-mutex.swift
@@ -44,7 +44,7 @@ func check(_ condition: Bool) {
 }
 
 func withMutexStorage(_ body: (UnsafeMutableRawPointer) -> Void) {
-  var storage: [6 of UInt] = [0, 0, 0, 0, 0, 0]
+  var storage: [8 of UInt] = [0, 0, 0, 0, 0, 0, 0, 0]
   withUnsafeMutablePointer(to: &storage) {
     body(UnsafeMutableRawPointer($0))
   }

--- a/test/embedded/lit.local.cfg
+++ b/test/embedded/lit.local.cfg
@@ -76,6 +76,10 @@ if 'embedded_stdlib' in config.available_features:
   target_specific_module_triple=next((v for s,v in config.substitutions if s == '%module-target-triple'), None)
   config.substitutions.append(("%target-embedded-single-threaded-shim", f"-L {config.swift_obj_root}/lib/swift/embedded/{target_specific_module_triple}/ -lswiftEmbeddedPlatformSingleThreaded"))
   config.substitutions.append(("%target-embedded-multi-threaded-posix-shim", f"-L {config.swift_obj_root}/lib/swift/embedded/{target_specific_module_triple}/ -lswiftEmbeddedPlatformMultiThreadedPOSIX"))
+  if 'OS=macosx' in config.available_features:
+    config.substitutions.append(("%target-embedded-multi-threaded-darwin-shim", f"-L {config.swift_obj_root}/lib/swift/embedded/{target_specific_module_triple}/ -lswiftEmbeddedPlatformMultiThreadedDarwin"))
+  else:
+    config.substitutions.append(("%target-embedded-multi-threaded-darwin-shim", ""))
 
   if 'swift_embedded_platform' in config.available_features:
     config.substitutions.append(("%target-embedded-posix-shim", f"-L {config.swift_obj_root}/lib/swift/embedded/{target_specific_module_triple}/ -lswiftEmbeddedPlatformPOSIX"))
@@ -85,4 +89,5 @@ if 'embedded_stdlib' in config.available_features:
 else:
   config.substitutions.append(("%target-embedded-single-threaded-shim", ""))
   config.substitutions.append(("%target-embedded-multi-threaded-posix-shim", ""))
+  config.substitutions.append(("%target-embedded-multi-threaded-darwin-shim", ""))
   config.substitutions.append(("%target-embedded-posix-shim", ""))

--- a/test/embedded/lit.local.cfg
+++ b/test/embedded/lit.local.cfg
@@ -75,6 +75,7 @@ else:
 if 'embedded_stdlib' in config.available_features:
   target_specific_module_triple=next((v for s,v in config.substitutions if s == '%module-target-triple'), None)
   config.substitutions.append(("%target-embedded-single-threaded-shim", f"-L {config.swift_obj_root}/lib/swift/embedded/{target_specific_module_triple}/ -lswiftEmbeddedPlatformSingleThreaded"))
+  config.substitutions.append(("%target-embedded-multi-threaded-posix-shim", f"-L {config.swift_obj_root}/lib/swift/embedded/{target_specific_module_triple}/ -lswiftEmbeddedPlatformMultiThreadedPOSIX"))
 
   if 'swift_embedded_platform' in config.available_features:
     config.substitutions.append(("%target-embedded-posix-shim", f"-L {config.swift_obj_root}/lib/swift/embedded/{target_specific_module_triple}/ -lswiftEmbeddedPlatformPOSIX"))
@@ -83,4 +84,5 @@ if 'embedded_stdlib' in config.available_features:
 
 else:
   config.substitutions.append(("%target-embedded-single-threaded-shim", ""))
+  config.substitutions.append(("%target-embedded-multi-threaded-posix-shim", ""))
   config.substitutions.append(("%target-embedded-posix-shim", ""))


### PR DESCRIPTION
Introduce two implementations of the `_swift_mutex_*` entrypoints that were recently introduced into the platform abstraction layer, and on which `Mutex` builds. The two implementations are:

* `swiftEmbeddedPlatformMultiThreadedPOSIX`: implemented on top of `pthread_mutex_t`
* `swiftEmbeddedPlatformMultiThreadedDarwin`: implemented on top of `os_unfair_lock` for non-recursive mutexes and `pthread_mutex_t` for recursive mutexes

As with the single-threaded implementation library, one can link the appropriate multi-threaded library to get multi-threading support.

Both of these are implemented in C so that we can deal with whatever a platform has put into its `<pthread.h>` header.