### PR TITLE
[test][Backtracing] Locate swift-backtrace on remote-run targets

### DIFF
--- a/test/Backtracing/CrashWithThreadsMac.swift
+++ b/test/Backtracing/CrashWithThreadsMac.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -Onone -g -o %t/CrashWithThreads
 // RUN: %target-codesign %t/CrashWithThreads
-// RUN: not --crash env SWIFT_BACKTRACE=enable=yes,cache=no,swift-backtrace=%backtracer %target-run %t/CrashWithThreads 2>&1 | %FileCheck -vv %s -dump-input-filter=all
-// RUN: not --crash env SWIFT_BACKTRACE=enable=yes,cache=no,swift-backtrace=%backtracer,threads=all %target-run %t/CrashWithThreads 2>&1 | %FileCheck -vv %s -dump-input-filter=all
+// RUN: not --crash env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashWithThreads 2>&1 | %FileCheck -vv %s -dump-input-filter=all
+// RUN: not --crash env SWIFT_BACKTRACE=enable=yes,cache=no,threads=all %target-run %t/CrashWithThreads 2>&1 | %FileCheck -vv %s -dump-input-filter=all
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2573,6 +2573,11 @@ def configure_remote_run():
                      os.path.dirname(local_swift_reflection_test),
                      'bin/')
 
+        if os.path.exists(backtracer_path):
+            upload_files([backtracer_path],
+                         os.path.dirname(backtracer_path),
+                         'stdlib/bin/')
+
         print("Contents of {0} on {1} after upload:".format(
             remote_lib_dir, remote_run_host))
         subprocess.check_call(


### PR DESCRIPTION
Backtracing tests using `SWIFT_BACKTRACE=enable=yes` fail under `remote-run` with:
```
swift runtime: unable to locate swift-backtrace; disabling backtracing.
```

In this PR:
  1. **`test/lit.cfg`** — under `remote-run`, upload `swift-backtrace` to `<tmp>/stdlib/bin/`, which matches a search path of the runtime.
  2. **`test/Backtracing/CrashWithThreadsMac.swift`** — drop the hardcoded `swift-backtrace=%backtracer` override. Locally this was redundant (the default lookup finds the same binary); under `remote-run` it was actively harmful, forcing the runtime to try a build-host path that doesn't exist on the remote.