### PR TITLE
[Embedded] Rename _swift_free to _swift_deallocate

### DIFF
--- a/stdlib/public/EmbeddedPlatform/EmbeddedPlatformMultiThreadedDarwin.c
+++ b/stdlib/public/EmbeddedPlatform/EmbeddedPlatformMultiThreadedDarwin.c
@@ -84,8 +84,8 @@ void _swift_mutex_destroy(void *mutex) {
   swift_darwin_mutex_t *m = (swift_darwin_mutex_t *)mutex;
   if (m->flags & SWIFT_MUTEX_RECURSIVE) {
     trap_if(pthread_mutex_destroy(m->u.heap) != 0);
-    _swift_free(m->u.heap, _Alignof(pthread_mutex_t),
-                sizeof(pthread_mutex_t), SWIFT_FREE_NONE);
+    _swift_deallocate(m->u.heap, _Alignof(pthread_mutex_t),
+                      sizeof(pthread_mutex_t), SWIFT_FREE_NONE);
     m->u.heap = NULL;
   }
   // Non-recursive: `os_unfair_lock` has no destroy step.

--- a/stdlib/public/EmbeddedPlatform/EmbeddedPlatformPOSIX.swift
+++ b/stdlib/public/EmbeddedPlatform/EmbeddedPlatformPOSIX.swift
@@ -43,7 +43,7 @@ public func _swift_allocate(_ alignment: Int, _ size: Int, _ flags: SwiftAllocat
 
 @export(interface)
 @implementation @c
-public func _swift_free(_ pointer: UnsafeMutableRawPointer, _ alignment: Int, _ size: Int, _ flags: SwiftFreeFlags) {
+public func _swift_deallocate(_ pointer: UnsafeMutableRawPointer, _ alignment: Int, _ size: Int, _ flags: SwiftFreeFlags) {
   free(pointer)
 }
 

--- a/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
+++ b/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
@@ -197,7 +197,7 @@ void * EMBEDDED_SWIFT_NULLABLE _swift_allocate(__swift_size_t alignment, __swift
  * 
  * This function can be implemented as a direct call to `free`.
  */
-void _swift_free(void * EMBEDDED_SWIFT_NONNULL ptr, __swift_size_t alignment, __swift_size_t size, swift_free_flags_t flags);
+void _swift_deallocate(void * EMBEDDED_SWIFT_NONNULL ptr, __swift_size_t alignment, __swift_size_t size, swift_free_flags_t flags);
 
 /**
  * Allocates memory with a given type and returns the resulting pointer.

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -137,8 +137,8 @@ public struct HeapObject {
 @_extern(c, "_swift_allocate")
 public func _swift_allocate(_ alignment: Int, _ size: Int, _ flags: CUnsignedLongLong) -> UnsafeMutableRawPointer?
 
-@_extern(c, "_swift_free")
-public func _swift_free(_ p: UnsafeMutableRawPointer, _ alignment: Int, _ size: Int, _ flags: CUnsignedLongLong)
+@_extern(c, "_swift_deallocate")
+public func _swift_deallocate(_ p: UnsafeMutableRawPointer, _ alignment: Int, _ size: Int, _ flags: CUnsignedLongLong)
 
 @_extern(c, "_swift_generateRandom")
 public func _swift_generateRandom(_ buf: UnsafeMutableRawPointer, _ nbytes: Int)
@@ -197,7 +197,7 @@ public func swift_slowAlloc(_ size: Int, _ alignMask: Int) -> UnsafeMutableRawPo
 @c
 public func swift_slowDealloc(_ ptr: UnsafeMutableRawPointer, _ size: Int, _ alignMask: Int) {
 #if SWIFT_USE_EMBEDDED_SWIFT_PLATFORM
-  unsafe _swift_free(ptr, size, alignMask, 0)
+  unsafe _swift_deallocate(ptr, size, alignMask, 0)
 #else
   unsafe free(ptr)
 #endif

--- a/test/embedded/devirt_deinits.swift
+++ b/test/embedded/devirt_deinits.swift
@@ -4,7 +4,6 @@
 // RUN: %target-embedded-link %target-clang-resource-dir-opt %t/a.o %target-embedded-posix-shim -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck -check-prefix CHECK-OUTPUT %S/../SILOptimizer/devirt_deinits.swift
 
-// REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: VENDOR=apple

--- a/test/embedded/embedded-platform-single-threaded-mutex.swift
+++ b/test/embedded/embedded-platform-single-threaded-mutex.swift
@@ -16,7 +16,6 @@
 // RUN: %target-embedded-link %target-clang-resource-dir-opt %t/destroy-locked.o %target-embedded-single-threaded-shim %target-embedded-posix-shim -o %t/destroy-locked.out -dead_strip
 // RUN: %target-not-crash %target-run %t/destroy-locked.out
 
-// REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded

--- a/test/embedded/maccatalyst.swift
+++ b/test/embedded/maccatalyst.swift
@@ -4,7 +4,6 @@
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
-// REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: VENDOR=apple

--- a/test/embedded/synchronization-mutex-single-threaded.swift
+++ b/test/embedded/synchronization-mutex-single-threaded.swift
@@ -3,7 +3,6 @@
 // RUN: %target-embedded-link %target-clang-resource-dir-opt %t/main.o %target-embedded-single-threaded-shim %target-embedded-posix-shim -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out
 
-// REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: synchronization

--- a/test/embedded/synchronization-mutex.swift
+++ b/test/embedded/synchronization-mutex.swift
@@ -7,6 +7,7 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: synchronization
 // REQUIRES: swift_feature_Embedded
+// UNSUPPORTED: OS=wasip1
 
 import Synchronization
 

--- a/test/embedded/synchronization-mutex.swift
+++ b/test/embedded/synchronization-mutex.swift
@@ -3,7 +3,6 @@
 // RUN: %target-embedded-link %target-clang-resource-dir-opt %t/main.o %target-embedded-posix-shim -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s --implicit-check-not=unexpected
 
-// REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: synchronization


### PR DESCRIPTION
Rather than using C-ish naming just for the deallocation, use _swift_deallocate (to pair with _swift_allocate).

Implements rdar://181720516.
