### PR TITLE
Optimizer: fix an ownership violation caused by SimplifyCFG's jump threading

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Utilities/PhiUpdater.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/PhiUpdater.swift
@@ -163,13 +163,11 @@ public func replacePhiWithIncomingValue(phi: Phi, _ context: some MutatingContex
   if phi.predecessors.isEmpty {
     return false
   }
-  let uniqueIncomingValue = phi.incomingValues.first!
-  if !uniqueIncomingValue.parentFunction.hasOwnership {
-    // For the SSAUpdater it's only required to simplify phis in OSSA.
-    // This avoids that we need to handle cond_br instructions below.
-    return false
-  }
-  if phi.incomingValues.contains(where: { $0 != uniqueIncomingValue }) {
+  guard let uniqueIncomingValue = getUniqueIncomingValue(of: phi, context),
+        // For the SSAUpdater it's only required to simplify phis in OSSA.
+        // This avoids that we need to handle `cond_br` instructions below.
+        uniqueIncomingValue.parentFunction.hasOwnership
+  else {
     return false
   }
   if let borrowedFrom = phi.borrowedFrom {
@@ -187,6 +185,22 @@ public func replacePhiWithIncomingValue(phi: Phi, _ context: some MutatingContex
   }
   block.eraseArgument(at: phi.value.index, context)
   return true
+}
+
+private func getUniqueIncomingValue(of phi: Phi, _ context: some MutatingContext) -> Value? {
+  var uniqueIncomingValue: Value? = nil
+
+  for incomingValue in phi.incomingValues {
+    if incomingValue.lookThroughBorrowedFrom == phi.value {
+      // Ignore self-cycles of phi-terms in loops.
+      continue
+    }
+    if let existingValue = uniqueIncomingValue, incomingValue != existingValue {
+      return nil
+    }
+    uniqueIncomingValue = incomingValue
+  }
+  return uniqueIncomingValue
 }
 
 /// Replaces phis with the unique incoming values if all incoming values are the same.
@@ -272,4 +286,18 @@ let updateBorrowedFromTest = Test("update_borrowed_from") {
   function, arguments, context in
 
   updateBorrowedFrom(in: function, context)
+}
+
+let replacePhisWithIncomingValuesTest = Test("replace_phis_with_incoming_values") {
+  function, arguments, context in
+
+  var phis = [Phi]()
+  for block in function.blocks {
+    for arg in block.arguments {
+      if let phi = Phi(arg) {
+        phis.append(phi)
+      }
+    }
+  }
+  replacePhisWithIncomingValues(phis: phis, context)
 }

--- a/SwiftCompilerSources/Sources/SIL/Utilities/Test.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/Test.swift
@@ -149,6 +149,7 @@ public func registerTests() {
     getAccessBaseTest,
     accessPathTest,
     updateBorrowedFromTest,
+    replacePhisWithIncomingValuesTest,
     borrowIntroducersTest,
     enclosingValuesTest,
     forwardingDefUseTest,

--- a/lib/SILOptimizer/Utils/BasicBlockOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/BasicBlockOptUtils.cpp
@@ -165,6 +165,7 @@ void BasicBlockCloner::updateSSAAfterCloning() {
     }
   }
   updateGuaranteedPhis(pm, updateSSAPhis);
+  replacePhisWithIncomingValues(pm, updateSSAPhis);
 }
 
 void BasicBlockCloner::sinkAddressProjections() {

--- a/test/SILOptimizer/replace_phis_with_incoming_values.sil
+++ b/test/SILOptimizer/replace_phis_with_incoming_values.sil
@@ -1,0 +1,182 @@
+// RUN: %target-sil-opt -test-runner %s | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+
+class C {}
+
+// A single-predecessor phi is trivially replaced by its unique incoming value.
+
+// CHECK-LABEL: sil [ossa] @redundant_owned_phi :
+// CHECK:       bb0(%0 : @owned $C):
+// CHECK-NEXT:    br bb1
+// CHECK:       bb1:
+// CHECK-NEXT:    return %0
+// CHECK:       } // end sil function 'redundant_owned_phi'
+sil [ossa] @redundant_owned_phi : $@convention(thin) (@owned C) -> @owned C {
+bb0(%0 : @owned $C):
+  specify_test "replace_phis_with_incoming_values"
+  br bb1(%0)
+
+bb1(%1 : @owned $C):
+  return %1
+}
+
+// A guaranteed phi with a single unique incoming value from two predecessors
+// is replaced by the borrow it re-borrows.
+
+// CHECK-LABEL: sil [ossa] @redundant_guaranteed_phi :
+// CHECK:         [[B:%.*]] = begin_borrow %0
+// CHECK-NOT:   : @guaranteed $C
+// CHECK:         end_borrow [[B]]
+// CHECK:       } // end sil function 'redundant_guaranteed_phi'
+sil [ossa] @redundant_guaranteed_phi : $@convention(thin) (@owned C) -> () {
+bb0(%0 : @owned $C):
+  specify_test "replace_phis_with_incoming_values"
+  %1 = begin_borrow %0
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3(%1)
+
+bb2:
+  br bb3(%1)
+
+bb3(%3 : @guaranteed $C):
+  %4 = borrowed %3 from (%0)
+  end_borrow %4
+  destroy_value %0
+  %r = tuple ()
+  return %r
+}
+
+// After replacing %5, the incoming values of %9 become identical too, so
+// %9 must be replaced in a second iteration of the fixed-point loop.
+
+// CHECK-LABEL: sil [ossa] @cascading_redundant_phis :
+// CHECK:       bb0(%0 : @owned $C):
+// CHECK-NOT:   : @owned $C):
+// CHECK:         destroy_value %0
+// CHECK:       } // end sil function 'cascading_redundant_phis'
+sil [ossa] @cascading_redundant_phis : $@convention(thin) (@owned C) -> () {
+bb0(%0 : @owned $C):
+  specify_test "replace_phis_with_incoming_values"
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3(%0)
+
+bb2:
+  br bb3(%0)
+
+bb3(%5 : @owned $C):
+  cond_br undef, bb4, bb5
+
+bb4:
+  br bb6(%5)
+
+bb5:
+  br bb6(%5)
+
+bb6(%9 : @owned $C):
+  br bb7(%9)
+
+bb7(%11 : @owned $C):
+  destroy_value %11
+  %r = tuple ()
+  return %r
+}
+
+// A phi that is not redundant (different incoming values) must not be
+// replaced.
+
+// CHECK-LABEL: sil [ossa] @non_redundant_phi :
+// CHECK:       bb3([[A:%.*]] : @owned $C):
+// CHECK-NEXT:    destroy_value [[A]]
+// CHECK:       } // end sil function 'non_redundant_phi'
+sil [ossa] @non_redundant_phi : $@convention(thin) (@owned C, @owned C) -> () {
+bb0(%0 : @owned $C, %1 : @owned $C):
+  specify_test "replace_phis_with_incoming_values"
+  cond_br undef, bb1, bb2
+
+bb1:
+  destroy_value %1
+  br bb3(%0)
+
+bb2:
+  destroy_value %0
+  br bb3(%1)
+
+bb3(%5 : @owned $C):
+  destroy_value %5
+  %r = tuple ()
+  return %r
+}
+
+// The back edge feeds the phi with its own value, which must be ignored
+// when looking for a unique incoming value. The only "real" incoming value
+// is %0, so the phi is redundant and gets replaced by %0.
+
+// CHECK-LABEL: sil [ossa] @phi_self_cycle :
+// CHECK:       bb0(%0 : @owned $C):
+// CHECK-NEXT:    br bb1
+// CHECK:       bb1:
+// CHECK-NEXT:    cond_br undef, bb2, bb3
+// CHECK:       bb2:
+// CHECK-NEXT:    br bb1
+// CHECK:       bb3:
+// CHECK-NEXT:    destroy_value %0
+// CHECK:       } // end sil function 'phi_self_cycle'
+sil [ossa] @phi_self_cycle : $@convention(thin) (@owned C) -> () {
+bb0(%0 : @owned $C):
+  specify_test "replace_phis_with_incoming_values"
+  br bb1(%0)
+
+bb1(%2 : @owned $C):
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb1(%2)
+
+bb3:
+  destroy_value %2
+  %r = tuple ()
+  return %r
+}
+
+// Same as above, but for a guaranteed phi with a borrowed-from instruction.
+// The back edge feeds the phi with its own borrowed-from instruction, which
+// must be ignored (via `lookThroughBorrowedFrom`) when looking for a unique
+// incoming value. The only "real" incoming value is %1, so the phi and its
+// borrowed-from instruction are replaced by %1.
+
+// CHECK-LABEL: sil [ossa] @guaranteed_phi_self_cycle :
+// CHECK:         [[B:%.*]] = begin_borrow %0
+// CHECK-NEXT:    br bb1
+// CHECK:       bb1:
+// CHECK-NEXT:    cond_br undef, bb2, bb3
+// CHECK:       bb2:
+// CHECK-NEXT:    br bb1
+// CHECK:       bb3:
+// CHECK-NEXT:    end_borrow [[B]]
+// CHECK:       } // end sil function 'guaranteed_phi_self_cycle'
+sil [ossa] @guaranteed_phi_self_cycle : $@convention(thin) (@owned C) -> () {
+bb0(%0 : @owned $C):
+  specify_test "replace_phis_with_incoming_values"
+  %1 = begin_borrow %0
+  br bb1(%1)
+
+bb1(%2 : @reborrow $C):
+  %3 = borrowed %2 from (%0)
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb1(%3)
+
+bb3:
+  end_borrow %3
+  destroy_value %0
+  %r = tuple ()
+  return %r
+}

--- a/test/SILOptimizer/simplify_cfg_trivial_jumpthread.sil
+++ b/test/SILOptimizer/simplify_cfg_trivial_jumpthread.sil
@@ -88,6 +88,10 @@ class C {
   init()
 }
 
+class C2 {
+  @_hasStorage final let k: C
+}
+
 // func testThread2(a : Int32) -> Int32 {
 //   enum b = (a ? _true : _false)
 //   if b == _true { return 42 } else { return 17 }
@@ -140,4 +144,107 @@ bb6:
 
 bb7(%19 : $Int64):
   return %19 : $Int64
+}
+
+// Ensure no crash in compiler
+sil [ossa] @eliminate_redundant_ssaupdater_phis : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref $C2
+  %1 = copy_value %0
+  br bb1(%0, %1)
+
+bb1(%3 : @owned $C2, %4 : @owned $C2):
+  cond_br undef, bb2, bb25
+
+bb2:
+  %6 = integer_literal $Builtin.Int1, 0
+  br bb3(%6)
+
+bb3(%8 : $Builtin.Int1):
+  %9 = begin_borrow [lexical] %3
+  cond_br undef, bb4, bb5
+
+bb4:
+  destroy_value %4
+  br bb6
+
+bb5:
+  %13 = ref_element_addr [immutable] %9, #C2.k
+  %14 = load_borrow %13
+  cond_br undef, bb7, bb8
+
+bb6:
+  end_borrow %9
+  destroy_value %3
+  %18 = tuple ()
+  return %18
+
+bb7:
+  destroy_value %4
+  br bb9
+
+bb8:
+  cond_br undef, bb10, bb11
+
+bb9:
+  fix_lifetime %14
+  end_borrow %14
+  br bb6
+
+bb10:
+  br bb13
+
+bb11:
+  cond_br undef, bb12, bb24
+
+bb12:
+  br bb19
+
+bb13:
+  br bb14
+
+bb14:
+  cond_br undef, bb15, bb16
+
+bb15:
+  cond_br undef, bb17, bb18
+
+bb16:
+  end_borrow %14
+  end_borrow %9
+  destroy_value [dead_end] %3
+  destroy_value [dead_end] %4
+  unreachable
+
+bb17:
+  br bb19
+
+bb18:
+  destroy_value %4
+  br bb9
+
+bb19:
+  cond_br undef, bb20, bb21
+
+bb20:
+  cond_br undef, bb22, bb23
+
+bb21:
+  destroy_value %4
+  br bb9
+
+bb22:
+  br bb19
+
+bb23:
+  destroy_value %4
+  br bb9
+
+bb24:
+  destroy_value %4
+  br bb9
+
+bb25:
+  %49 = integer_literal $Builtin.Int1, 0
+  br bb3(%49)
 }


### PR DESCRIPTION
After cloning blocks in jump threading, the SSAUpdater is used to update phi arguments. However, it sometimes inserts redundant phi arguments which split up value livetimes. Those redundant phis have to be removed.
This change fixes two problems:
1. `replacePhisWithIncomingValues` was not called from `updateSSAAfterCloning`
2. `replacePhisWithIncomingValues` needs to handle self-cycles in the phi graph.

Fixes a compiler crash
rdar://180961843
