### PR TITLE
[6.4] 🌸 Differentiate explicit submodules for export_as

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -6481,14 +6481,18 @@ class TypePrinter : public TypeVisitor<TypePrinter, void, NonRecursivePrintOptio
     return Options.CurrentModule->getVisibleClangModules(Options.InterfaceContentKind);
   }
 
-  /// If \p TyDecl belongs to a submodule, return the \c ModuleDecl for that
-  /// submodule; otherwise just return the parent module.
+  /// If \p TyDecl belongs to an explicit submodule, return the \c ModuleDecl
+  /// for that submodule; otherwise just return the parent module.
   ModuleDecl *getParentSubModuleOrModule(GenericTypeDecl *TyDecl) {
     // Only clang declarations can belong to a submodule
     if (auto clangNode = TyDecl->getClangNode()) {
       auto importer = TyDecl->getASTContext().getClangModuleLoader();
       if (auto clangMod = importer->getClangOwningModule(clangNode)) {
-        return importer->getWrapperForModule(clangMod);
+        // Explicit submodules are only visible if specifically imported;
+        // everything else has the visibility of its top-level module.
+        if (clangMod->isSubModule() && clangMod->IsExplicit) {
+          return importer->getWrapperForModule(clangMod);
+        }
       }
     }
 

--- a/test/ModuleInterface/export-as-in-swiftinterfaces-submodules.swift
+++ b/test/ModuleInterface/export-as-in-swiftinterfaces-submodules.swift
@@ -35,6 +35,11 @@ module LibraryCore {
   header "LibraryCore/LibraryCore.h"
   export *
 
+  module NonExplicitSubmodule {
+    header "LibraryCore/NonExplicitSubmodule.h"
+    export *
+  }
+
   explicit module * { export * }
 }
 
@@ -49,12 +54,18 @@ module Library {
 //--- LibraryCore/LibraryCore.h
 // This file is re-exported by Library
 #pragma once
+#include "LibraryCore/NonExplicitSubmodule.h"
 struct LibraryCoreType {};
 
 //--- LibraryCore/Submodule.h
 // This file is re-exported by Library.Submodule (which Swift does not respect)
 #pragma once
 struct LibraryCoreSubmoduleType {};
+
+//--- LibraryCore/NonExplicitSubmodule.h
+// This file is re-exported by Library
+#pragma once
+struct LibraryCoreNonExplicitSubmoduleType {};
 
 //--- LibraryCore/ReexportedSubmodule.h
 // This file is re-exported by Library
@@ -89,6 +100,9 @@ public func foo(
   // PUBLIC-SAME: c: Library::LibraryCoreReexportedSubmoduleType
   // PRIVATE-SAME: c: LibraryCore::LibraryCoreReexportedSubmoduleType
   c: LibraryCoreReexportedSubmoduleType,
+  // PUBLIC-SAME: c2: Library::LibraryCoreNonExplicitSubmoduleType
+  // PRIVATE-SAME: c2: Library::LibraryCoreNonExplicitSubmoduleType
+  c2: LibraryCoreNonExplicitSubmoduleType,
   // PUBLIC-SAME: d: Library::LibraryType
   // PRIVATE-SAME: d: Library::LibraryType
   d: LibraryType,
@@ -114,5 +128,8 @@ public func foo(
   b: LibraryCoreSubmoduleType,
   // PUBLIC-SAME: c: Library::LibraryCoreReexportedSubmoduleType
   // PRIVATE-SAME: c: LibraryCore::LibraryCoreReexportedSubmoduleType
-  c: LibraryCoreReexportedSubmoduleType
+  c: LibraryCoreReexportedSubmoduleType,
+  // PUBLIC-SAME: c2: Library::LibraryCoreNonExplicitSubmoduleType
+  // PRIVATE-SAME: c2: LibraryCore::LibraryCoreNonExplicitSubmoduleType
+  c2: LibraryCoreNonExplicitSubmoduleType
 ) {}


### PR DESCRIPTION
- **Explanation**: Tweaks logic to determine whether to use a module's `export_as` name to qualify a declaration in a private module interface file. Previously, special rules were applied to all declarations in submodules; now they are only applied to `explicit` submodules, which better matches name visibility rules.
- **Scope**: Projects which emit a `.private.swiftinterface` file which references a clang type in a submodule of a module with `export_as`.
- **Issues**: rdar://178351114
- **Original PRs**: #90484 (ASTDumper changes from that PR are not included in this cherry pick)
- **Risk**: Low. `export_as` is a niche feature mostly used to refactor very complicated Objective-C frameworks in the workflows of large engineering organizations, and is usually not shipped.
- **Testing**: Unit test changes included. Normal qualification processes should tell us if this causes regressions.
- **Reviewers**: @tshortli 