### PR TITLE
[Embedded] Support CoroutineAccessors in no-allocations embedded

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
@@ -147,9 +147,11 @@ private struct FunctionChecker {
       }
 
     case let ba as BeginApplyInst:
-      // Whether a coroutine call allocates under -no-allocations depends on the
-      // callee-allocated (yield_once_2) frame's allocator kind, which is only
-      // known in IRGen; that check is emitted there (see visitBeginApplyInst).
+      // The old yield_once_1 coroutine uses a heap-allocated frame, so it
+      // cannot be used in no-allocations mode.
+      if context.options.noAllocations && !ba.isCalleeAllocated {
+        throw Diagnostic(.embedded_swift_allocating_coroutine, at: instruction.location)
+      }
       try checkApply(apply: ba)
 
     case let pai as PartialApplyInst:

--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
@@ -147,9 +147,9 @@ private struct FunctionChecker {
       }
 
     case let ba as BeginApplyInst:
-      if context.options.noAllocations {
-        throw Diagnostic(.embedded_swift_allocating_coroutine, at: instruction.location)
-      }
+      // Whether a coroutine call allocates under -no-allocations depends on the
+      // callee-allocated (yield_once_2) frame's allocator kind, which is only
+      // known in IRGen; that check is emitted there (see visitBeginApplyInst).
       try checkApply(apply: ba)
 
     case let pai as PartialApplyInst:

--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
@@ -204,6 +204,9 @@ private struct FunctionChecker {
         Violation(.embedded_swift_allocating_coroutine, in: instruction)
       )
 
+      // Whether a coroutine call allocates under -no-allocations depends on the
+      // callee-allocated (yield_once_2) frame's allocator kind, which is only
+      // known in IRGen; that check is emitted there (see visitBeginApplyInst).
       try checkApply(apply: ba)
 
     case let pai as PartialApplyInst:

--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
@@ -204,9 +204,15 @@ private struct FunctionChecker {
         Violation(.embedded_swift_allocating_coroutine, in: instruction)
       )
 
-      // Whether a coroutine call allocates under -no-allocations depends on the
-      // callee-allocated (yield_once_2) frame's allocator kind, which is only
-      // known in IRGen; that check is emitted there (see visitBeginApplyInst).
+      // The old yield_once_1 coroutine uses a heap-allocated frame, so it
+      // cannot be used in no-allocations mode.
+      if context.options.noAllocations && !ba.isCalleeAllocated {
+        throw Diagnostic(.embedded_swift_allocating_coroutine, at: instruction.location)
+      }
+
+      // For yield_once_2, whether it allocates on the heap or the stack
+      // depends on the provided allocator, which is only
+      // known in IRGen; so we'll check there (see visitBeginApplyInst).
       try checkApply(apply: ba)
 
     case let pai as PartialApplyInst:

--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
@@ -200,19 +200,16 @@ private struct FunctionChecker {
       )
 
     case let ba as BeginApplyInst:
-      try diagnoseHeapAllocation(
-        Violation(.embedded_swift_allocating_coroutine, in: instruction)
-      )
-
       // The old yield_once_1 coroutine uses a heap-allocated frame, so it
       // cannot be used in no-allocations mode.
-      if context.options.noAllocations && !ba.isCalleeAllocated {
-        throw Diagnostic(.embedded_swift_allocating_coroutine, at: instruction.location)
+      if !ba.isCalleeAllocated {
+        try diagnoseHeapAllocation(
+          Violation(.embedded_swift_allocating_coroutine, in: instruction)
+        )
       }
 
       // For yield_once_2, whether it allocates on the heap or the stack
-      // depends on the provided allocator, which is only
-      // known in IRGen; so we'll check there (see visitBeginApplyInst).
+      // depends on the provided allocator, which isn't knowable here.
       try checkApply(apply: ba)
 
     case let pai as PartialApplyInst:

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -15,9 +15,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/ABI/Coro.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticsIRGen.h"
+#include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/ExtInfo.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/IRGenOptions.h"
@@ -4850,6 +4852,23 @@ void IRGenSILFunction::visitYieldInst(swift::YieldInst *i) {
 }
 
 void IRGenSILFunction::visitBeginApplyInst(BeginApplyInst *i) {
+  // In -no-allocations mode, calling a callee-allocated (yield_once_2)
+  // coroutine is only allowed when its frame can be stack-allocated.
+  // Note: We treat Async stack like regular stack for this purpose;
+  // if a no-allocations target can do async, then it presumably has
+  // some way to provide an Async stack.
+  if (IGM.getSILModule().getOptions().NoAllocations &&
+      i->getSubstCalleeType()->isCalleeAllocatedCoroutine()) {
+    auto kind = getDefaultCoroutineAllocatorKind();
+    if (kind &&   // nullopt => inherits from caller
+	*kind != CoroAllocatorKind::Stack && // Explicit Stack usage
+	*kind != CoroAllocatorKind::Async // Explicit Async Stack
+       ) {
+      // We can't use a heap-allocated frame in no-allocations mode
+      IGM.Context.Diags.diagnose(i->getLoc().getSourceLoc(),
+                                 diag::embedded_swift_allocating_coroutine);
+    }
+  }
   visitFullApplySite(i);
 }
 

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -15,11 +15,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/ABI/Coro.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticsIRGen.h"
-#include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/ExtInfo.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/IRGenOptions.h"
@@ -4852,23 +4850,6 @@ void IRGenSILFunction::visitYieldInst(swift::YieldInst *i) {
 }
 
 void IRGenSILFunction::visitBeginApplyInst(BeginApplyInst *i) {
-  // In -no-allocations mode, calling a callee-allocated (yield_once_2)
-  // coroutine is only allowed when its frame can be stack-allocated.
-  // Note: We treat Async stack like regular stack for this purpose;
-  // if a no-allocations target can do async, then it presumably has
-  // some way to provide an Async stack.
-  if (IGM.getSILModule().getOptions().NoAllocations &&
-      i->getSubstCalleeType()->isCalleeAllocatedCoroutine()) {
-    auto kind = getDefaultCoroutineAllocatorKind();
-    if (kind &&   // nullopt => inherits from caller
-	*kind != CoroAllocatorKind::Stack && // Explicit Stack usage
-	*kind != CoroAllocatorKind::Async // Explicit Async Stack
-       ) {
-      // We can't use a heap-allocated frame in no-allocations mode
-      IGM.Context.Diags.diagnose(i->getLoc().getSourceLoc(),
-                                 diag::embedded_swift_allocating_coroutine);
-    }
-  }
   visitFullApplySite(i);
 }
 

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -15,9 +15,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/ABI/Coro.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticsIRGen.h"
+#include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/ExtInfo.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/IRGenOptions.h"
@@ -4882,6 +4884,23 @@ void IRGenSILFunction::visitYieldInst(swift::YieldInst *i) {
 }
 
 void IRGenSILFunction::visitBeginApplyInst(BeginApplyInst *i) {
+  // In -no-allocations mode, calling a callee-allocated (yield_once_2)
+  // coroutine is only allowed when its frame can be stack-allocated.
+  // Note: We treat Async stack like regular stack for this purpose;
+  // if a no-allocations target can do async, then it presumably has
+  // some way to provide an Async stack.
+  if (IGM.getSILModule().getOptions().NoAllocations &&
+      i->getSubstCalleeType()->isCalleeAllocatedCoroutine()) {
+    auto kind = getDefaultCoroutineAllocatorKind();
+    if (kind &&   // nullopt => inherits from caller
+	*kind != CoroAllocatorKind::Stack && // Explicit Stack usage
+	*kind != CoroAllocatorKind::Async // Explicit Async Stack
+       ) {
+      // We can't use a heap-allocated frame in no-allocations mode
+      IGM.Context.Diags.diagnose(i->getLoc().getSourceLoc(),
+                                 diag::embedded_swift_allocating_coroutine);
+    }
+  }
   visitFullApplySite(i);
 }
 

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -15,11 +15,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/ABI/Coro.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticsIRGen.h"
-#include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/ExtInfo.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/IRGenOptions.h"
@@ -4884,23 +4882,6 @@ void IRGenSILFunction::visitYieldInst(swift::YieldInst *i) {
 }
 
 void IRGenSILFunction::visitBeginApplyInst(BeginApplyInst *i) {
-  // In -no-allocations mode, calling a callee-allocated (yield_once_2)
-  // coroutine is only allowed when its frame can be stack-allocated.
-  // Note: We treat Async stack like regular stack for this purpose;
-  // if a no-allocations target can do async, then it presumably has
-  // some way to provide an Async stack.
-  if (IGM.getSILModule().getOptions().NoAllocations &&
-      i->getSubstCalleeType()->isCalleeAllocatedCoroutine()) {
-    auto kind = getDefaultCoroutineAllocatorKind();
-    if (kind &&   // nullopt => inherits from caller
-	*kind != CoroAllocatorKind::Stack && // Explicit Stack usage
-	*kind != CoroAllocatorKind::Async // Explicit Async Stack
-       ) {
-      // We can't use a heap-allocated frame in no-allocations mode
-      IGM.Context.Diags.diagnose(i->getLoc().getSourceLoc(),
-                                 diag::embedded_swift_allocating_coroutine);
-    }
-  }
   visitFullApplySite(i);
 }
 

--- a/test/embedded/no-allocations-coroutine-legacy.swift
+++ b/test/embedded/no-allocations-coroutine-legacy.swift
@@ -1,0 +1,25 @@
+// A yield_once_1 (_read/_modify) coroutine accessor uses a heap-allocated frame,
+// so calling one is rejected under -no-allocations.  (A callee-allocated
+// yield_once_2 accessor is allowed; see no-allocations-coroutine.swift.)
+
+// RUN: not %target-swift-emit-ir %s -enable-experimental-feature Embedded -enable-experimental-feature CoroutineAccessors -no-allocations -wmo 2>&1 | %FileCheck %s
+
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu || OS=wasip1
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_CoroutineAccessors
+
+// CHECK: cannot use co-routines (like accessors) in -no-allocations mode
+
+open class Base {
+  var _i = 42
+  // Dispatched through the class vtable, so the accessor survives inlining.
+  open var i: Int {
+    _read { yield _i }
+    _modify { yield &_i }
+  }
+}
+
+func bump(_ x: inout Int) { x += 1 }
+
+public func f(_ b: Base) { bump(&b.i) }

--- a/test/embedded/no-allocations-coroutine-legacy.swift
+++ b/test/embedded/no-allocations-coroutine-legacy.swift
@@ -9,7 +9,7 @@
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_feature_CoroutineAccessors
 
-// CHECK: cannot use co-routines (like accessors) in -no-allocations mode
+// CHECK: error: coroutine accessor involves heap allocation [#PerformanceHints::HeapAllocation]
 
 open class Base {
   var _i = 42

--- a/test/embedded/no-allocations-coroutine.swift
+++ b/test/embedded/no-allocations-coroutine.swift
@@ -1,0 +1,59 @@
+// A callee-allocated (yield_once_2) coroutine accessor whose frame cannot be
+// stack-allocated is an allocation.  Here the coroutine calling convention is
+// disabled, forcing a heap (Malloc) coroutine-frame allocator, so calling such
+// an accessor is rejected under -no-allocations.  (When the frame can be stack
+// allocated -- the common case -- the call is allowed; see coroutines-and-testing.swift.)
+
+// RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded -enable-experimental-feature CoroutineAccessors -no-allocations -disable-arm64-corocc -disable-x86_64-corocc -wmo -verify -verify-ignore-unknown
+
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu || OS=wasip1
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_CoroutineAccessors
+
+public struct NC: ~Copyable { var x: Int = 0 }
+
+open class Base {
+  var _s = NC()
+  open var s: NC {
+    yielding borrow { yield _s }
+    yielding mutate { yield &_s }
+  }
+}
+
+func bump(_ x: inout NC) { x.x += 1 }
+
+public func f(_ b: Base) {
+  bump(&b.s) // expected-error {{cannot use co-routines (like accessors) in -no-allocations mode}}
+}
+
+// A non-virtual accessor is inlined away before IRGen, leaving no coroutine
+// frame to allocate, so it is allowed even here (the old pre-inlining check
+// rejected it).
+public struct S: ~Copyable {
+  var _x = NC()
+  var x: NC {
+    yielding borrow { yield _x }
+    yielding mutate { yield &_x }
+  }
+}
+
+public func g(_ s: inout S) {
+  bump(&s.x) // no error
+}
+
+// A protocol conformance's coroutine-accessor witness thunk merely forwards its
+// caller's allocator (it doesn't allocate a frame itself), so it must not be
+// diagnosed -- this is the shape that originally regressed.
+public protocol Q {
+  var v: Int { yielding borrow set }
+}
+
+public struct Conformer: Q {
+  var _v = 0
+  public var v: Int {
+    yielding borrow { yield _v }
+    yielding mutate { yield &_v }
+  }
+}
+

--- a/test/embedded/no-allocations-coroutine.swift
+++ b/test/embedded/no-allocations-coroutine.swift
@@ -7,8 +7,11 @@
 
 // RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded -enable-experimental-feature CoroutineAccessors -no-allocations -wmo
 
+// The callee-allocated (yield_once_2) coroutine ABI (which makes coroutine
+// accessors possible in no-allocations mode) is only enabled on Darwin and
+// Linux (see CoroutineAccessorsUseYieldOnce2 in CompilerInvocation).
+// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu || OS=wasip1
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_feature_CoroutineAccessors
 

--- a/test/embedded/no-allocations-coroutine.swift
+++ b/test/embedded/no-allocations-coroutine.swift
@@ -1,35 +1,22 @@
-// A callee-allocated (yield_once_2) coroutine accessor whose frame cannot be
-// stack-allocated is an allocation.  Here the coroutine calling convention is
-// disabled, forcing a heap (Malloc) coroutine-frame allocator, so calling such
-// an accessor is rejected under -no-allocations.  (When the frame can be stack
-// allocated -- the common case -- the call is allowed; see coroutines-and-testing.swift.)
+// A callee-allocated (yield_once_2) coroutine accessor allocates its frame on
+// the caller's stack, so using one is allowed under -no-allocations -- whether
+// it is inlined, dispatched through a class vtable, or reached via a protocol
+// conformance's (forwarding) witness thunk.  (A yield_once_1 accessor, which
+// uses a heap-allocated frame, is still rejected; see
+// no-allocations-coroutine-legacy.swift.)
 
-// RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded -enable-experimental-feature CoroutineAccessors -no-allocations -disable-arm64-corocc -disable-x86_64-corocc -wmo -verify -verify-ignore-unknown
+// RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded -enable-experimental-feature CoroutineAccessors -no-allocations -wmo
 
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx || OS=linux-gnu || OS=wasip1
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_feature_CoroutineAccessors
 
-public struct NC: ~Copyable { var x: Int = 0 }
-
-open class Base {
-  var _s = NC()
-  open var s: NC {
-    yielding borrow { yield _s }
-    yielding mutate { yield &_s }
-  }
-}
+public struct NC: ~Copyable { var x = 0 }
 
 func bump(_ x: inout NC) { x.x += 1 }
 
-public func f(_ b: Base) {
-  bump(&b.s) // expected-error {{cannot use co-routines (like accessors) in -no-allocations mode}}
-}
-
-// A non-virtual accessor is inlined away before IRGen, leaving no coroutine
-// frame to allocate, so it is allowed even here (the old pre-inlining check
-// rejected it).
+// Non-virtual: the accessor is inlined away.
 public struct S: ~Copyable {
   var _x = NC()
   var x: NC {
@@ -37,18 +24,23 @@ public struct S: ~Copyable {
     yielding mutate { yield &_x }
   }
 }
+public func viaStruct(_ s: inout S) { bump(&s.x) }
 
-public func g(_ s: inout S) {
-  bump(&s.x) // no error
+// Virtual (class vtable): the accessor survives inlining.
+open class Base {
+  var _s = NC()
+  open var s: NC {
+    yielding borrow { yield _s }
+    yielding mutate { yield &_s }
+  }
 }
+public func viaClass(_ b: Base) { bump(&b.s) }
 
-// A protocol conformance's coroutine-accessor witness thunk merely forwards its
-// caller's allocator (it doesn't allocate a frame itself), so it must not be
-// diagnosed -- this is the shape that originally regressed.
+// Protocol conformance: the coroutine-accessor witness thunk forwards its
+// caller's allocator.
 public protocol Q {
   var v: Int { yielding borrow set }
 }
-
 public struct Conformer: Q {
   var _v = 0
   public var v: Int {
@@ -56,4 +48,3 @@ public struct Conformer: Q {
     yielding mutate { yield &_v }
   }
 }
-


### PR DESCRIPTION
The -no-allocations check in the EmbeddedSwiftDiagnostics SIL pass rejected *every* begin_apply (coroutine call).  That was correct for the old ABI which always heap-allocated, but the new ABI supports stack allocation.

Move the check to IRGen, where the allocator kind is known and inlining has already run: when considering a non-inlined begin_apply of a callee-allocated coroutine, diagnose when the coroutine allocator kind is a heap allocation. (Permit default/pass-through, explicit Stack allocation, and explicit Async stack allocation.)

This lets stack-allocated and inlined coroutine accessors be used under -no-allocations while rejecting genuine heap allocations.

Resolves rdar://181713977