### PR TITLE
[test][Interpreter] Fix objc_implementation_swift_client under remote-run

### DIFF
--- a/test/Interpreter/objc_implementation_swift_client.swift
+++ b/test/Interpreter/objc_implementation_swift_client.swift
@@ -12,7 +12,7 @@
 // RUN: %empty-directory(%t/frameworks/objc_implementation.framework/Headers)
 // RUN: cp %S/Inputs/objc_implementation.modulemap %t/frameworks/objc_implementation.framework/Modules/module.modulemap
 // RUN: cp %S/Inputs/objc_implementation.h %t/frameworks/objc_implementation.framework/Headers
-// RUN: %target-build-swift-dylib(%t/frameworks/objc_implementation.framework/objc_implementation) -emit-module-path %t/frameworks/objc_implementation.framework/Modules/objc_implementation.swiftmodule/%module-target-triple.swiftmodule -module-name objc_implementation -F %t/frameworks -import-underlying-module -Xlinker -install_name -Xlinker %t/frameworks/objc_implementation.framework/objc_implementation %S/objc_implementation.swift -target %target-stable-abi-triple
+// RUN: %target-build-swift-dylib(%t/frameworks/objc_implementation.framework/objc_implementation) -emit-module-path %t/frameworks/objc_implementation.framework/Modules/objc_implementation.swiftmodule/%module-target-triple.swiftmodule -module-name objc_implementation -F %t/frameworks -import-underlying-module -Xlinker -install_name -Xlinker @executable_path/../frameworks/objc_implementation.framework/objc_implementation %S/objc_implementation.swift -target %target-stable-abi-triple
 
 //
 // Execute this file
@@ -20,7 +20,7 @@
 // RUN: %empty-directory(%t/swiftmod)
 // RUN: %target-build-swift %s -module-cache-path %t/swiftmod/mcp -F %t/frameworks -o %t/swiftmod/a.out -module-name main -target %target-stable-abi-triple
 // RUN: %target-codesign %t/swiftmod/a.out
-// RUN: %target-run %t/swiftmod/a.out | %FileCheck %s
+// RUN: %target-run %t/swiftmod/a.out %t/frameworks | %FileCheck %s
 
 //
 // Execute again, without the swiftmodule this time
@@ -29,7 +29,7 @@
 // RUN: %empty-directory(%t/clangmod)
 // RUN: %target-build-swift %s -module-cache-path %t/clangmod/mcp -F %t/frameworks -o %t/clangmod/a.out -module-name main -target %target-stable-abi-triple
 // RUN: %target-codesign %t/clangmod/a.out
-// RUN: %target-run %t/clangmod/a.out | %FileCheck %s
+// RUN: %target-run %t/clangmod/a.out %t/frameworks | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop


### PR DESCRIPTION
This PR fixes two issues that prevented this test from running under remote-run:
* Set the framework's install_name relative to @executable_path so it resolves in both local and remote contexts 
* Pass %t/frameworks as an ignored extra positional arg to a.out so remote-run's argument processor sees it and rsyncs the whole directory tree.
