### PR TITLE
[test][Frontend] load-pass-plugin: build plugin for host arch

### DIFF
--- a/test/Frontend/load-pass-plugin.swift
+++ b/test/Frontend/load-pass-plugin.swift
@@ -4,7 +4,7 @@
 // CHECK-UNABLE-LOAD: error: unable to load plugin 'nonexistent.dylib': 'Could not load library{{.*}}'
 
 // RUN: %empty-directory(%t)
-// RUN: %target-clangxx %S/Inputs/TestPlugin.cpp -std=c++17 -stdlib=libc++ \
+// RUN: %clangxx %S/Inputs/TestPlugin.cpp -std=c++17 -stdlib=libc++ \
 // RUN:     -isysroot %sdk -I %llvm_src_root/include -I %llvm_obj_root/include -L %llvm_obj_root/lib \
 // RUN:     -Wl,-hidden-lLLVMSupport -Wl,-undefined -Wl,dynamic_lookup -Wl,-flat_namespace \
 // RUN:     -dynamiclib -o %t/libTestPlugin.dylib


### PR DESCRIPTION
The pass plugin is dlopen'd into the swift-frontend process, which runs at host arch, not target arch. The test currently compiles the plugin for target arch, breaking the test in a cross-compile configuration.
Use %clangxx so the plugin's process arch always matches the swift-frontend it will be loaded into.
