### PR TITLE
[6.4][ClangImporter] Don't let imported OS availability suppress a method's async alternative clue. rdar://175355488

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8752,8 +8752,19 @@ void addCompletionHandlerAttribute(Decl *asyncImport,
     if (!afd)
       continue;
 
-    // Only add the attribute to functions that don't already have availability
-    if (afd->getAttrs().hasAttribute<AvailableAttr>())
+    // Skip if the method already carries a rename pointing at its async
+    // alternative (e.g. one synthesized during import); a plain imported OS
+    // availability attribute must not suppress it, or an async
+    // '@objc @implementation' member won't match its completion-handler
+    // requirement and no thunk will be generated.
+    //
+    // Check the attribute syntactically: resolving getAsyncAlternative() here
+    // does name lookup, which re-enters member loading while this nominal is
+    // still importing and corrupts its member lookup table.
+    if (llvm::any_of(afd->getAttrs().getAttributes<AvailableAttr>(),
+                     [](const AvailableAttr *attr) {
+                       return !attr->getRename().empty();
+                     }))
       continue;
 
     llvm::VersionTuple NoVersion;

--- a/test/decl/ext/Inputs/objc_implementation_async_availability.h
+++ b/test/decl/ext/Inputs/objc_implementation_async_availability.h
@@ -1,0 +1,18 @@
+#if __OBJC__
+
+@import Foundation;
+
+@protocol Widget
+@end
+
+@interface WidgetStore : NSObject
+
+// A completion-handler method that also carries an availability attribute. The
+// importer must still expose its async alternative so an async
+// '@objc @implementation' member can match it.
+- (void)fetchWidgetsWithCompletionHandler:(void (^ _Nonnull)(NSArray<id<Widget>> * _Nonnull widgets))completionHandler
+    API_AVAILABLE(macos(10.15), ios(13.0), watchos(6.0), tvos(13.0));
+
+@end
+
+#endif

--- a/test/decl/ext/objc_implementation_async_availability.swift
+++ b/test/decl/ext/objc_implementation_async_availability.swift
@@ -1,0 +1,16 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -import-objc-header %S/Inputs/objc_implementation_async_availability.h -enable-experimental-feature ObjCImplementation -target %target-stable-abi-triple -Xcc -Wno-nullability-completeness
+// REQUIRES: objc_interop
+// REQUIRES: swift_feature_ObjCImplementation
+
+// An imported Objective-C completion-handler method that carries an
+// availability attribute must still expose its async alternative. Otherwise an
+// async member of an '@objc @implementation' extension fails to match the
+// completion-handler requirement, no ObjC thunk is generated, and calling the
+// method through the ObjC runtime crashes with "unrecognized selector".
+
+@objc @implementation extension WidgetStore {
+  @available(SwiftStdlib 5.1, *)
+  public func fetchWidgets() async -> [any Widget] {
+    return []
+  }
+}


### PR DESCRIPTION
- **Explanation**: A completion-handler method carrying an OS availability attribute was skipped when wiring the
  rename attribute that points to its async alternative, so an async `@objc @implementation` member could not match
  its completion-handler requirement and no ObjC thunk was generated. This change checks existing availability attributes more closely to decide whether a synthesized rename attribute is necessary, so the thunk is emitted correctly.
- **Scope**: Async members of `@objc @implementation` extensions whose imported completion-handler counterpart
carries an OS availability attribute.
- **Issues**: rdar://175355488
- **Original PRs**: #90438
- **Risk**: Low. 
- **Testing**: New regression test added
- **Reviewers**: @Xazax-hun @beccadax 