### PR TITLE
NFC: Undef SWIFT_REFLECTION_SECTION

### DIFF
--- a/include/swift/RemoteInspection/ELFReflectionSections.def
+++ b/include/swift/RemoteInspection/ELFReflectionSections.def
@@ -22,3 +22,5 @@ SWIFT_REFLECTION_SECTION(swift5_typeref,               TypeReference)
 SWIFT_REFLECTION_SECTION(swift5_reflstr,               ReflectionString)
 SWIFT_REFLECTION_SECTION(swift5_protocol_conformances, Conformance)
 SWIFT_REFLECTION_SECTION(swift5_mpenum,                MultiPayloadEnum)
+
+#undef SWIFT_REFLECTION_SECTION

--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -594,7 +594,6 @@ public:
     enum : unsigned {
 #define SWIFT_REFLECTION_SECTION(Name, Field) idx_##Name,
 #include "ELFReflectionSections.def"
-#undef SWIFT_REFLECTION_SECTION
       kELFReflectionSectionCount
     };
 
@@ -605,7 +604,6 @@ public:
   sections[idx_##Name] = readTableSection(idx_##Name);                         \
   populated |= bool(sections[idx_##Name]);
 #include "ELFReflectionSections.def"
-#undef SWIFT_REFLECTION_SECTION
 
     if (!populated)
       return std::nullopt;
@@ -614,7 +612,6 @@ public:
 #define SWIFT_REFLECTION_SECTION(Name, Field)                                  \
   {sections[idx_##Name].contents, sections[idx_##Name].size},
 #include "ELFReflectionSections.def"
-#undef SWIFT_REFLECTION_SECTION
         PotentialModuleNames,
     };
 


### PR DESCRIPTION
Undefining the SWIFT_REFLECTION_SECTION macro after including `ELFReflectionSections.def`.

This is follow-up to feedback on the PR that added the sections file. -- https://github.com/swiftlang/swift/pull/87285