### PR TITLE
[cxx-interop] Do not import operator bool for unreachable record types

### DIFF
--- a/lib/ClangImporter/ClangLookup.cpp
+++ b/lib/ClangImporter/ClangLookup.cpp
@@ -1033,6 +1033,11 @@ FuncDecl *ClangImporter::Implementation::lookupAndImportOperatorBool(
   auto &Ctx = getClangASTContext();
   auto &Sema = getClangSema();
 
+  if (!Sema.hasReachableDefinition(CXXRecord))
+    // Importing this operator requires reachable receiver object class
+    return nullptr;
+
+  // Look for operator bool() const
   clang::CXXConversionDecl *OpBool = nullptr;
 
   auto Conversions = CXXRecord->getVisibleConversionFunctions();

--- a/lib/ClangImporter/ClangLookup.cpp
+++ b/lib/ClangImporter/ClangLookup.cpp
@@ -1090,6 +1090,7 @@ FuncDecl *ClangImporter::Implementation::lookupAndImportOperatorBool(
   Method->setImplicit();
 
   {
+    clang::Sema::SFINAETrap trap(Sema);
     clang::Sema::SynthesizedFunctionScope Scope(Sema, Method);
 
     auto This = Sema.ActOnCXXThis(Loc);

--- a/test/Interop/Cxx/class/inheritance/operator-bool-crtp-base-crash.swift
+++ b/test/Interop/Cxx/class/inheritance/operator-bool-crtp-base-crash.swift
@@ -1,0 +1,63 @@
+// Regression test for a spurious Clang error when importing a C++ class that
+// inherits `operator bool()`, where the derived class's definition is not
+// reachable from Swift.
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+//
+// RUN: %target-swift-frontend -typecheck -verify -suppress-notes \
+// RUN:   %t/test.swift -I %t/Inputs -module-name Repro \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   -import-objc-header %t/Bridging.h -Xcc -std=c++23 \
+// RUN:   -verify-additional-file %t/Inputs/CxxModule/Unreachable.h
+
+//--- Inputs/CxxModule/module.modulemap
+module CxxModule {
+  umbrella "."
+  requires cplusplus
+
+  // Each header becomes its own auto-generated submodule
+  explicit module * { export * }
+
+  export *
+}
+
+//--- Inputs/CxxModule/ProvidesBool.h
+#pragma once
+
+// Provides operator bool, which triggers some automatic conformances.
+struct ProvidesBool { operator bool() const; };
+
+//--- Inputs/CxxModule/Unreachable.h
+#pragma once
+
+// This header is NEVER #included on the visible bridging path, so none of the
+// definitions here are reachable.
+
+#include <CxxModule/ProvidesBool.h>
+
+// Should not see this error:
+//
+//     cannot convert 'const Unreachable' to 'bool' without a conversion operator
+//
+struct Unreachable : ProvidesBool {};
+
+//--- Inputs/CxxModule/Used.h
+#pragma once
+
+#include <CxxModule/ProvidesBool.h>
+
+// Only a forward declaration; the full definition is not reachable from here.
+struct Unreachable;
+
+struct Used { Unreachable *makeUnreachable() const; };
+
+//--- Bridging.h
+// Imports Used.h (and, transitively, ProvidesBool.h) but NOT Unreachable.h
+#include <CxxModule/Used.h>
+
+//--- test.swift
+
+// Referencing a Used member whose return type is Unreachable imports
+// Unreachable's complete (but unreachable) definition.
+func unrelated(_ s: Used) { _ = s.makeUnreachable() }


### PR DESCRIPTION
ClangImporter synthesizes a shim around operator bool() using Sema:

    bool __convertToBool() const { return static_cast<bool>(*this); }

which is used for the CxxConvertibleToBool protocol conformance.

However, the synthesis procedure can fail when the operator bool()
is reachable (because it is declared in some reachable base class), but
the derived type that inherits operator bool() is unreachable.

That failure produces the following (spurious) error:

    error: cannot convert 'const Foo' to 'bool' without a conversion operator

We observed this happening due to overeager func +/operator + lookup,
but this bug can be reproduced under any scenario where ClangImporter
attempts to import the unreachable derived class. In the regression test
that is part of this patch, we trigger this by returning a pointer to it
(which *should* be opaque per Clang module/C++ semantics).

The fix is to simply gate the __convertToBool() synthesis on whether the
receiver record's definition is reachable, in addition to the existing
check that the operator bool() declaration is reachable.

Also, add a SFINAETrap to the __convertToBool() synthesis so that other
unforeseen Sema failures bail gracefully rather than tank the compilation.

rdar://181622867