### PR TITLE
[Stdlib] Adjust UNSUPPORTED lines for FP printing tests

### DIFF
--- a/test/stdlib/PrintFloat.swift.gyb
+++ b/test/stdlib/PrintFloat.swift.gyb
@@ -4,16 +4,8 @@
 // RUN: %target-codesign %t/main.out
 // RUN: %line-directive %t/FloatingPointPrinting.swift -- %target-run %t/main.out
 // REQUIRES: executable_test
-
-// rdar://77087867
-// UNSUPPORTED: CPU=arm64_32 && OS=watchos
-
-// Float printing and parsing on embedded are new features, not
-// yet fully supported on WASM
-// UNSUPPORTED: CPU=wasm32
-
-// rdar://104232602
-// UNSUPPORTED: CPU=x86_64 && (DARWIN_SIMULATOR=ios || DARWIN_SIMULATOR=watchos || DARWIN_SIMULATOR=tvos)
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
 
 import StdlibUnittest
 import SwiftPrivateLibcExtras

--- a/test/stdlib/PrintFloatLocale.swift.gyb
+++ b/test/stdlib/PrintFloatLocale.swift.gyb
@@ -4,15 +4,6 @@
 // RUN: %target-codesign %t/main.out
 // RUN: %line-directive %t/FloatingPointPrinting.swift -- %target-run %t/main.out --locale ru_RU.UTF-8
 // REQUIRES: executable_test
-
-// rdar://77087867
-// UNSUPPORTED: CPU=arm64_32 && OS=watchos
-
-// Float printing and parsing on embedded are new features, not
-// yet fully supported on WASM
-// UNSUPPORTED: CPU=wasm32
-
-// rdar://104232602
-// UNSUPPORTED: CPU=x86_64 && (DARWIN_SIMULATOR=ios || DARWIN_SIMULATOR=watchos || DARWIN_SIMULATOR=tvos)
-
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
 // UNSUPPORTED: freestanding


### PR DESCRIPTION
These tests should always have had UNSUPPORTED markers for `use_os_stdlib` and `back_deployment_runtime` as they are specifically verifying the expected behavior of the current development stdlib, which may have minor differences from previously-shipped versions.  (Most recently, a correction to NaN printing.)

While I'm here, re-enable this on various CPU/OS combinations that were broken in the past.  All of these should work thanks to the extensive rewrites in this area since those blocks were added.  If any of them are still broken, we'll find out soon enough.

Resolves: rdar://181742438
Resolves: rdar://104232602
Resolves: rdar://77087867