### PR TITLE
Speed up unspecialized Set init from sequences

### DIFF
--- a/benchmark/single-source/SetTests.swift
+++ b/benchmark/single-source/SetTests.swift
@@ -91,6 +91,11 @@ func setBox(_ size: Int) {
   setBox = Set(Set(0 ..< size).map(Box.init))
 }
 
+// Inputs for measuring `Set.init` from an array.
+// Large to expose the per-element cost of building the set.
+let initSize = 10_000
+let initArrayInt = Array(0 ..< initSize)
+let initArrayBox = initArrayInt.map(Box.init)
 
 public let benchmarks = [
   // Mnemonic: number after name is percentage of common elements in input sets.
@@ -718,6 +723,26 @@ public let benchmarks = [
     runFunction: { n in run_SetFilterInt100(n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { set(28_000) }),
+  BenchmarkInfo(
+    name: "Set.init.Int",
+    runFunction: { n in run_SetInitInt(initArrayInt, initSize, n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole(initArrayInt) }),
+  BenchmarkInfo(
+    name: "Set.init.Int.Unspecialized",
+    runFunction: { n in run_SetInitUnspecializedInt(initArrayInt, initSize, n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole(initArrayInt) }),
+  BenchmarkInfo(
+    name: "Set.init.Box",
+    runFunction: { n in run_SetInitBox(initArrayBox, initSize, n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole(initArrayBox) }),
+  BenchmarkInfo(
+    name: "Set.init.Box.Unspecialized",
+    runFunction: { n in run_SetInitUnspecializedBox(initArrayBox, initSize, n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole(initArrayBox) }),
 
   // Legacy benchmarks, kept for continuity with previous releases.
   BenchmarkInfo(
@@ -1145,4 +1170,58 @@ func run_SetIsDisjointSeqBox(
         let isDisjoint = a.isDisjoint(with: identity(b))
         check(isDisjoint == r)
     }
+}
+
+// Build a set through a generic boundary the optimizer can't specialize
+// to model the case where Set.init is reached from unspecialized generic
+// code (for example, across a module boundary).
+@inline(never)
+@_semantics("optimize.sil.specialize.generic.never")
+func makeSetUnspecialized<Element: Hashable>(
+  _ elements: Array<Element>) -> Set<Element> {
+  return Set(elements)
+}
+
+@inline(never)
+func run_SetInitInt(
+  _ a: Array<Int>,
+  _ r: Int,
+  _ n: Int) {
+  for _ in 0 ..< n {
+    let set = Set(identity(a))
+    check(set.count == r)
+  }
+}
+
+@inline(never)
+func run_SetInitUnspecializedInt(
+  _ a: Array<Int>,
+  _ r: Int,
+  _ n: Int) {
+  for _ in 0 ..< n {
+    let set = makeSetUnspecialized(identity(a))
+    check(set.count == r)
+  }
+}
+
+@inline(never)
+func run_SetInitBox(
+  _ a: Array<Box<Int>>,
+  _ r: Int,
+  _ n: Int) {
+  for _ in 0 ..< n {
+    let set = Set(identity(a))
+    check(set.count == r)
+  }
+}
+
+@inline(never)
+func run_SetInitUnspecializedBox(
+  _ a: Array<Box<Int>>,
+  _ r: Int,
+  _ n: Int) {
+  for _ in 0 ..< n {
+    let set = makeSetUnspecialized(identity(a))
+    check(set.count == r)
+  }
 }

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -44,6 +44,19 @@ internal struct _NativeSet<Element: Hashable> {
     }
   }
 
+  @inlinable
+  @unsafe
+  internal init(_ buffer: UnsafeBufferPointer<Element>) {
+    self.init(capacity: buffer.count)
+    for index in 0..<buffer.count {
+      let element = unsafe buffer[index]
+      let (bucket, found) = find(element)
+      // Keep only the first occurrence of equal elements.
+      guard !found else { continue }
+      unsafe _unsafeInsertNew(element, at: bucket)
+    }
+  }
+
 #if _runtime(_ObjC)
   @inlinable
   internal init(_ cocoa: __owned __CocoaSet) {

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -44,7 +44,7 @@ internal struct _NativeSet<Element: Hashable> {
     }
   }
 
-  @inlinable
+  @export(implementation)
   @unsafe
   internal init(_ buffer: UnsafeBufferPointer<Element>) {
     self.init(capacity: buffer.count)

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -224,14 +224,9 @@ extension Set: ExpressibleByArrayLiteral {
 
   @export(implementation)
   internal init(_nonEmptyArrayLiteral elements: [Element]) {
-    let native = _NativeSet<Element>(capacity: elements.count)
-    for element in elements {
-      let (bucket, found) = native.find(element)
-      if found {
-        // FIXME: Shouldn't this trap?
-        continue
-      }
-      unsafe native._unsafeInsertNew(element, at: bucket)
+    // FIXME: Duplicate elements are silently dropped. Should we trap instead?
+    let native = elements.withUnsafeBufferPointer { buffer in
+      unsafe _NativeSet(buffer)
     }
     self.init(_native: native)
   }
@@ -702,11 +697,22 @@ extension Set: SetAlgebra {
       // If this sequence is actually a `Set`, then we can quickly
       // adopt its storage and let COW handle uniquing only if necessary.
       self = s
-    } else {
-      self.init(minimumCapacity: sequence.underestimatedCount)
-      for item in sequence {
-        insert(item)
+      return
+    }
+    // Fast path: build directly from the buffer, avoiding the storage-
+    // uniqueness check performed on each `insert` and, when unspecialized,
+    // witness-table dispatch through the `Source` iterator.
+    let native: _NativeSet<Element>? =
+      sequence.withContiguousStorageIfAvailable { buffer in
+        unsafe _NativeSet(buffer)
       }
+    if let native {
+      self.init(_native: native)
+      return
+    }
+    self.init(minimumCapacity: sequence.underestimatedCount)
+    for item in sequence {
+      insert(item)
     }
   }
 

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -211,6 +211,9 @@ extension Set: ExpressibleByArrayLiteral {
   ///     }
   ///     // Prints "Whatever it is, it's bound to be delicious!"
   ///
+  /// - Note: If the array literal contains duplicate elements, only the
+  ///   first occurrence is kept, and subsequent duplicates are ignored.
+  ///
   /// - Parameter elements: A variadic list of elements of the new set.
   @inlinable
   @inline(__always)
@@ -224,7 +227,6 @@ extension Set: ExpressibleByArrayLiteral {
 
   @export(implementation)
   internal init(_nonEmptyArrayLiteral elements: [Element]) {
-    // FIXME: Duplicate elements are silently dropped. Should we trap instead?
     let native = elements.withUnsafeBufferPointer { buffer in
       unsafe _NativeSet(buffer)
     }

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -2842,6 +2842,24 @@ SetTestSuite.test("init(Sequence:)") {
     2020, 2020, 2020, 3030, 3030, 3030
   ])
   expectEqual(s1, s3)
+
+  let s4 = Set(MinimalSequence(elements: [
+    1010, 1010, 2020, 2020, 3030, 3030
+  ]))
+  expectEqual(s1, s4)
+}
+
+SetTestSuite.test("init(Sequence:).ContiguousStorage") {
+  var expected = Set<Int>()
+  expected.insert(1010)
+  expected.insert(2020)
+  expected.insert(3030)
+
+  let withDuplicates = [1010, 1010, 2020, 2020, 3030, 3030]
+  expectEqual(expected, Set(ContiguousArray(withDuplicates)))
+
+  let padded = [9999, 1010, 1010, 2020, 2020, 3030, 3030, 9999]
+  expectEqual(expected, Set(padded[1..<7]))
 }
 
 SetTestSuite.test("init(arrayLiteral:)") {


### PR DESCRIPTION
Building a `Set` from a large array is significantly slower when the surrounding code is not specialized, and notably, even slower than building an `OrderedSet`, whose unspecialized path was tuned in https://github.com/apple/swift-collections/pull/433.

We can apply the same technique used for `OrderedSet`, which avoids the generic `Sequence` iterator's witness-table dispatch by working through a concrete buffer. The fast path in this PR also avoids the storage-uniqueness check performed when calling `insert` for each element, since we know the backing storage is freshly-allocated and has no other references.

For an array of 10,000 elements, benchmarks show a **3.4x** speedup in unspecialized `Set` initialization with `Box<Int>` and a **5.3x** speedup with `Int`. The specialized init benchmarks also show up to a **1.25x** speedup from bypassing the storage-uniqueness check.

Thanks to @dnadoba for finding/documenting the performance gap and for the prior art in https://github.com/apple/swift-collections/pull/433!

Resolves rdar://179514404