### PR TITLE
[CSSimplify] Don't ignore type mismatches in "destination" of a mutat…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5954,13 +5954,6 @@ bool ConstraintSystem::repairFailures(
 
         ConstraintFix *fix = nullptr;
         if (result == SolutionKind::Error) {
-          // If this is a "destination" argument to a mutating operator
-          // like `+=`, let's consider it contextual and only attempt
-          // to fix type mismatch on the "source" right-hand side of
-          // such operators.
-          if (isOperatorArgument(loc) && argConv->getArgIdx() == 0)
-            break;
-
           fix = AllowArgumentMismatch::create(*this, lhs, rhs, loc);
         } else {
           fix = AllowInOutConversion::create(*this, lhs, rhs, loc);
@@ -15934,7 +15927,26 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
                : SolutionKind::Solved;
   }
 
-  case FixKind::AllowArgumentTypeMismatch:
+  case FixKind::AllowArgumentTypeMismatch: {
+    auto *loc = fix->getLocator();
+    // If this is a "destination" argument to a mutating operator
+    // like `+=`, let's give it a higher impact to make sure that
+    // if a different overload choice has a mismatch at the "source"
+    // it would always be preferred instead of causing an ambiguity
+    // since `inout` doesn't support conversions and only the "source"
+    // can be fixed.
+    if (auto argLoc = loc->findLast<LocatorPathElt::ApplyArgToParam>()) {
+      if (argLoc->getArgIdx() == 0 && isOperatorArgument(loc) &&
+          loc->isLastElement<LocatorPathElt::LValueConversion>()) {
+        return recordFix(fix, FixImpact::TypeMismatch + 1)
+                   ? SolutionKind::Error
+                   : SolutionKind::Solved;
+      }
+    }
+
+    LLVM_FALLTHROUGH;
+  }
+
   case FixKind::IgnoreDefaultExprTypeMismatch: {
     auto impact = FixImpact::TypeMismatch;
     // If there are any other argument mismatches already detected for this

--- a/test/Constraints/lvalues.swift
+++ b/test/Constraints/lvalues.swift
@@ -310,3 +310,30 @@ func test_invalid_inout_with_restrictions(lhs: inout any BinaryInteger, rhs: any
   var other: (any BinaryInteger)? = nil
   other = &rhs // expected-error {{'&' may only be used to pass an argument to inout parameter}}
 }
+
+func test_invalid_inout_base_of_mutating_operator() {
+  @propertyWrapper
+  struct FakeState<Value> {
+    final class Box { var value: Value; init(_ value: Value) { self.value = value } }
+    private let box: Box
+    init(wrappedValue: Value) { box = Box(wrappedValue) }
+    var wrappedValue: Value {
+      get { box.value }
+      nonmutating set { box.value = newValue }
+    }
+  }
+
+  struct Test {
+    @FakeState var member: Any
+
+    func test() {
+      member += 1 // expected-error {{cannot convert value of type 'Any' to expected argument type 'Int'}}
+    }
+
+    func local(p: inout Any) {
+      var v: Any = 4
+      v += 1 // expected-error {{cannot convert value of type 'Any' to expected argument type 'Int'}}
+      p += 1 // expected-error {{cannot convert value of type 'Any' to expected argument type 'Int'}}
+    }
+  }
+}


### PR DESCRIPTION
…ing operator

If argument is l-value but the underlying types didn't line up let's record a fix but make it a higher impact than a "source" to make sure that an overload that has a mismatch on the other side ("source" side) is always preferred because it supports convertions and easier to fix comparing to `inout` parameter.

Resolves: rdar://139217343

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
