### PR TITLE
Enable ClangImporter and Reflection tests that are now passing with Android NDK 28

### DIFF
--- a/test/ClangImporter/availability_android.swift
+++ b/test/ClangImporter/availability_android.swift
@@ -1,9 +1,6 @@
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs/custom-modules -verify-ignore-unknown -target aarch64-unknown-linux-android24 %s
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs/custom-modules -verify-ignore-unknown -target %target-arch-unknown-linux-android24 %s
 
 // REQUIRES: OS=linux-android || OS=linux-androideabi
-
-// Disable this test till we get a LTS NDK on the CI that supports it.
-// REQUIRES: NDK28
 
 import AndroidVersioning
 import Android

--- a/test/Reflection/availability_custom_domains.swift
+++ b/test/Reflection/availability_custom_domains.swift
@@ -18,7 +18,6 @@
 // RUN: %FileCheck %s --check-prefix=CHECK-NEGATIVE --input-file=%t/reflection.txt
 
 // REQUIRES: swift_feature_CustomAvailability
-// UNSUPPORTED: OS=linux-android, OS=linux-androideabi
 
 // Every type/member that should be absent from the reflection dump has
 // "Disabled" or "disabled" in its name.

--- a/test/Reflection/noncopyable_field_typeref.swift
+++ b/test/Reflection/noncopyable_field_typeref.swift
@@ -8,7 +8,6 @@
 
 // rdar://100805115
 // UNSUPPORTED: CPU=arm64e
-// UNSUPPORTED: OS=linux-android
 // UNSUPPORTED: CPU=armv7k && OS=watchos
 
 // RUN: %empty-directory(%t)

--- a/test/Reflection/typeref_decoding_packs.swift
+++ b/test/Reflection/typeref_decoding_packs.swift
@@ -18,9 +18,6 @@
 // RUN: %target-swift-reflection-dump %t/%target-library-name(TypesToReflect) | %FileCheck %s
 // RUN: %target-swift-reflection-dump %t/TypesToReflect | %FileCheck %s
 
-// Fails only with Android NDK 28 because of an lld issue
-// XFAIL: OS=linux-android
-
 // CHECK: FIELDS:
 // CHECK: =======
 // CHECK: TypesToReflect.Packed

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -12,9 +12,6 @@
 // rdar://100558042
 // UNSUPPORTED: CPU=arm64e
 
-// This started failing for Android with #89305, disable until NDK 30 is used.
-// XFAIL: OS=linux-android && CPU=aarch64
-
 // RUN: %target-build-swift -target %target-swift-5.2-abi-triple -Xfrontend -disable-availability-checking %S/Inputs/TypeLowering.swift -parse-as-library -emit-module -emit-library %no-fixup-chains -module-name TypeLowering -o %t/%target-library-name(TypesToReflect)
 // RUN: %target-build-swift -target %target-swift-5.2-abi-triple -Xfrontend -disable-availability-checking %S/Inputs/TypeLowering.swift %S/Inputs/main.swift -emit-module -emit-executable %no-fixup-chains -module-name TypeLowering -o %t/TypesToReflect
 

--- a/test/Reflection/typeref_lowering_packs.swift
+++ b/test/Reflection/typeref_lowering_packs.swift
@@ -16,9 +16,6 @@
 
 // REQUIRES: PTRSIZE=64
 
-// Fails only with Android NDK 28 because of an lld issue
-// XFAIL: OS=linux-android
-
 12TypeLowering6SimpleV
 
 // CHECK: (struct TypeLowering.Simple)


### PR DESCRIPTION
The Reflection tests weren't passing with lld 19.0.1, but are after the ELF changes in #87285.