### PR TITLE
[SIL] Fix non_abi functions missing [serialized] in SILFunctionBuilder

### DIFF
--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -334,6 +334,17 @@ SILFunction *SILFunctionBuilder::getOrCreateFunction(
       // linkage.
       if (isAvailableExternally(fn->getLinkage())) {
         fn->setLinkage(constant.getLinkage(ForDefinition));
+        // PublicNonABI and PackageNonABI functions must be serialized before
+        // the module is serialized. The declaration may have been created
+        // without [serialized] if it was initially emitted as HiddenExternal.
+        if (!mod.isSerialized()) {
+          auto defLinkage = fn->getLinkage();
+          if ((defLinkage == SILLinkage::PublicNonABI ||
+               defLinkage == SILLinkage::PackageNonABI) &&
+              !fn->isAnySerialized()) {
+            fn->setSerializedKind(constant.getSerializedKind());
+          }
+        }
       }
     }
     return fn;
@@ -346,6 +357,14 @@ SILFunction *SILFunctionBuilder::getOrCreateFunction(
   // Don't create a [serialized] function after serialization has happened.
   if (IsSer != IsNotSerialized && mod.isSerialized())
     IsSer = IsNotSerialized;
+
+  // PublicNonABI and PackageNonABI functions must be serialized before the
+  // module is serialized (SIL verifier invariant).
+  if (!mod.isSerialized() && IsSer == IsNotSerialized &&
+      (linkage == SILLinkage::PublicNonABI ||
+       linkage == SILLinkage::PackageNonABI)) {
+    IsSer = IsSerialized;
+  }
 
   Inline_t inlineStrategy = InlineDefault;
   if (constant.isNoinline())

--- a/test/SILGen/always_emit_into_client_attribute.swift
+++ b/test/SILGen/always_emit_into_client_attribute.swift
@@ -76,3 +76,25 @@ package struct PackageContext {
   @_alwaysEmitIntoClient
   package static var v : Int { 1 }
 }
+
+// PublicNonABI functions must always be [serialized] — verify that combining
+// @export(implementation) with other attributes doesn't break this invariant.
+
+// CHECK-LABEL: sil non_abi [serialized] [export_implementation] [always_inline] [ossa] @{{.*}}inlineAlwaysExportImpl
+@inline(always) @export(implementation) public func inlineAlwaysExportImpl() {}
+
+// CHECK-LABEL: sil non_abi [transparent] [serialized] [export_implementation] [ossa] @{{.*}}transparentExportImpl
+@_transparent @export(implementation) public func transparentExportImpl() {}
+
+// Method in a public type: effective access is public, so non_abi [serialized] is required.
+public struct ExportImplPublicContext {
+  // CHECK-LABEL: sil non_abi [serialized] [export_implementation] [always_inline] [ossa] @{{.*}}ExportImplPublicContext{{.*}}1f
+  @inline(always) @export(implementation) public func f() {}
+}
+
+// Method in an internal type: effective access is capped to internal, AEIC is
+// dropped, and the function gets hidden linkage — no [serialized] required.
+internal struct ExportImplInternalContext {
+  // CHECK-LABEL: sil hidden [export_implementation] [always_inline] [ossa] @{{.*}}ExportImplInternalContext{{.*}}1f
+  @inline(always) @export(implementation) func f() {}
+}


### PR DESCRIPTION

**Bug analysis:**

`getDefinitionLinkage() `and `getSerializedKind()` can disagree for `@export(implementation)`  linkage  becomes **PublicNonABI** but serialized kind is **IsNotSerialized** because `getSerializedKind()` caps effective access to internal when the enclosing type is not public, returning early without considering the linkage.

**Solution in this patch**:

Add a consistency check in `getOrCreateFunction()` that forces **[serialized]** on any **PublicNonABI/PackageNonABI** function

Filled bug: https://github.com/swiftlang/swift/issues/90225

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
