### PR TITLE
[unittests] Fix misaligned fake pointer in TaskStatus.cpp.

### DIFF
--- a/unittests/runtime/TaskStatus.cpp
+++ b/unittests/runtime/TaskStatus.cpp
@@ -89,7 +89,7 @@ static SerialExecutorRef createFakeExecutor(uintptr_t value) {
 
 TEST(TaskStatusTest, basicTasks) {
   AsyncTask *createdTask = nullptr;
-  auto createdExecutor = createFakeExecutor(1234);
+  auto createdExecutor = createFakeExecutor(1024);
   bool hasRun = false;
 
   struct Storage { int value; };
@@ -134,6 +134,6 @@ TEST(TaskStatusTest, cancellation_simple) {
     swift_task_cancel(task);
     EXPECT_TRUE(swift_task_isCancelled(task));
   }, [&](AsyncTask *task) {
-    swift_job_run(task, createFakeExecutor(1234));
+    swift_job_run(task, createFakeExecutor(1024));
   });
 }


### PR DESCRIPTION
As specified [here](https://github.com/swiftlang/swift/blob/5d2053eadafdc0b8c4aa6254aa2d171b54ee2f61/include/swift/ABI/Actor.h#L33), `DefaultActor` instances must be 16-byte aligned. So when the fake value 1234 in these tests is cast to a `DefaultActor *`, it trips some of our automated UBSan test runs.

Use 1024 for the fake value instead: a nice round number that ought to be aligned enough for anybody.
