### PR TITLE
[IRGen] Don't emit inverted protocol flags when targeting earlier than 5.8.

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1473,6 +1473,17 @@ namespace {
       if (!nominal)
         return result;
 
+      // GenericContextDescriptorFlags must be zero for descriptors that might
+      // be seen by a pre-5.8 runtime, so omit this on pre-5.8 targets unless
+      // we're building the runtime itself.
+      auto deploymentAvailability =
+          AvailabilityRange::forDeploymentTarget(IGM.Context);
+      if (!IGM.Context.LangOpts.DisableAvailabilityChecking &&
+          !deploymentAvailability.isContainedIn(
+              IGM.Context.getSwift58Availability()) &&
+          !IGM.getSwiftModule()->isStdlibModule())
+        return result;
+
       auto checkProtocol = [&](InvertibleProtocolKind kind) {
         switch (nominal->canConformTo(kind)) {
         case TypeDecl::CanBeInvertible::Never:

--- a/test/Interpreter/moveonly_reflection.swift
+++ b/test/Interpreter/moveonly_reflection.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift %s -o %t/exe
+// RUN: %target-build-swift %s -target %target-swift-5.8-abi-triple -o %t/exe
 // RUN: %target-codesign %t/exe
 // RUN: %target-run %t/exe > %t/output.txt
 // RUN: %FileCheck %s < %t/output.txt

--- a/test/stdlib/NoncopyableComparable.swift
+++ b/test/stdlib/NoncopyableComparable.swift
@@ -9,7 +9,9 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-// RUN: %target-run-simple-swift(-enable-experimental-feature Lifetimes)
+// The emission of runtime metadata for inverted requirements needs a 5.8+
+// target, so build the test targeting 5.8 and mark the tests as requiring 5.8.
+// RUN: %target-run-simple-swift(-target %target-swift-5.8-abi-triple -enable-experimental-feature Lifetimes)
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_Lifetimes
 
@@ -64,7 +66,7 @@ extension InlineArray where Element: Comparable & ~Copyable {
 	}
 }
 
-NoncopyableComparableTests.test("comparing noncopyables") {
+NoncopyableComparableTests.test("comparing noncopyables").require(.stdlib_5_8).code {
   let a = Noncopyable(wrapped: 0)
   let b = Noncopyable(wrapped: 1)
   let c = Noncopyable(wrapped: 2)
@@ -96,7 +98,7 @@ NoncopyableComparableTests.test("comparing noncopyables") {
   expectFalse(array.inReverseOrder())
 }
 
-NoncopyableComparableTests.test("comparing nonescapables") {
+NoncopyableComparableTests.test("comparing nonescapables").require(.stdlib_5_8).code {
   let a = Noncopyable<Nonescapable>(wrapped: .init(wrapped: 0))
   let b = Noncopyable<Nonescapable>(wrapped: .init(wrapped: 1))
   let c = Noncopyable<Nonescapable>(wrapped: .init(wrapped: 2))

--- a/test/stdlib/NoncopyableEquatable.swift
+++ b/test/stdlib/NoncopyableEquatable.swift
@@ -9,7 +9,9 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-// RUN: %target-run-simple-swift(-enable-experimental-feature Lifetimes)
+// The emission of runtime metadata for inverted requirements needs a 5.8+
+// target, so build the test targeting 5.8 and mark the tests as requiring 5.8.
+// RUN: %target-run-simple-swift(-target %target-swift-5.8-abi-triple -enable-experimental-feature Lifetimes)
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_Lifetimes
 
@@ -57,7 +59,7 @@ extension InlineArray where Element: Equatable & ~Copyable {
   }
 }
 
-NoncopyableEquatableTests.test("equating noncopyables") {  
+NoncopyableEquatableTests.test("equating noncopyables").require(.stdlib_5_8).code {
   // TODO: update StdLibUnitTest to work with ~Copyable Equtable
   
   let a = Noncopyable(wrapping: 1)
@@ -96,7 +98,7 @@ NoncopyableEquatableTests.test("equating noncopyables") {
   expectNil(array.firstIndex(of: .init(wrapping: 3)))
 }
 
-NoncopyableEquatableTests.test("equating nonescapables") {  
+NoncopyableEquatableTests.test("equating nonescapables").require(.stdlib_5_8).code {
   let nc1 = Noncopyable<Nonescapable>(wrapping: .init(wrapped: 1))
   let nc2 = Noncopyable<Nonescapable>(wrapping: .init(wrapped: 1))
   let nc3 = Noncopyable<Nonescapable>(wrapping: .init(wrapped: 2))

--- a/test/stdlib/NoncopyableHashable.swift
+++ b/test/stdlib/NoncopyableHashable.swift
@@ -9,7 +9,9 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-// RUN: %target-run-simple-swift(-enable-experimental-feature Lifetimes)
+// The emission of runtime metadata for inverted requirements needs a 5.8+
+// target, so build the test targeting 5.8 and mark the tests as requiring 5.8.
+// RUN: %target-run-simple-swift(-target %target-swift-5.8-abi-triple -enable-experimental-feature Lifetimes)
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_Lifetimes
 
@@ -61,7 +63,7 @@ extension InlineArray where Element: Hashable & ~Copyable {
   }
 }
 
-NoncopyableHashableTests.test("hashing noncopyables") {
+NoncopyableHashableTests.test("hashing noncopyables").require(.stdlib_5_8).code {
   let a = Noncopyable(wrapping: 1)
   let b = Noncopyable(wrapping: 2)
   let c = Noncopyable(wrapping: 1)
@@ -87,7 +89,7 @@ NoncopyableHashableTests.test("hashing noncopyables") {
   
 }
 
-NoncopyableHashableTests.test("hashing nonescapables") {  
+NoncopyableHashableTests.test("hashing nonescapables").require(.stdlib_5_8).code {
   let nc1 = Noncopyable<Nonescapable>(wrapping: .init(wrapped: 1))
   let nc2 = Noncopyable<Nonescapable>(wrapping: .init(wrapped: 1))
   let nc3 = Noncopyable<Nonescapable>(wrapping: .init(wrapped: 2))


### PR DESCRIPTION
The older runtimes treat this as a size field that must always be zero. Omit the info entirely if targeting those older runtimes.

rdar://181742116