### PR TITLE
Enable `BorrowingForLoop` and `BorrowingSequence` flags by default

### DIFF
--- a/Runtimes/Overlay/Cxx/CMakeLists.txt
+++ b/Runtimes/Overlay/Cxx/CMakeLists.txt
@@ -33,7 +33,8 @@ target_compile_options(swiftCxx PRIVATE
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -nostdinc++>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature AllowUnsafeAttribute>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature BuiltinModule>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature Lifetimes>")
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature Lifetimes>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature BorrowingSequence>")
 target_link_libraries(swiftCxx PUBLIC
   $<$<BOOL:${SwiftSwiftDirectRuntime_FOUND}>:swiftSwiftDirectRuntime>
   swiftCore)

--- a/Runtimes/Overlay/Cxx/CMakeLists.txt
+++ b/Runtimes/Overlay/Cxx/CMakeLists.txt
@@ -33,8 +33,7 @@ target_compile_options(swiftCxx PRIVATE
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -nostdinc++>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature AllowUnsafeAttribute>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature BuiltinModule>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature Lifetimes>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature BorrowingSequence>")
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature Lifetimes>")
 target_link_libraries(swiftCxx PUBLIC
   $<$<BOOL:${SwiftSwiftDirectRuntime_FOUND}>:swiftSwiftDirectRuntime>
   swiftCore)

--- a/Runtimes/Overlay/cmake/modules/ExperimentalFeatures.cmake
+++ b/Runtimes/Overlay/cmake/modules/ExperimentalFeatures.cmake
@@ -4,4 +4,5 @@ add_compile_options(
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependence>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature InoutLifetimeDependence>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependenceMutableAccessors>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature BorrowingSequence>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-upcoming-feature MemberImportVisibility>")

--- a/Runtimes/Overlay/cmake/modules/ExperimentalFeatures.cmake
+++ b/Runtimes/Overlay/cmake/modules/ExperimentalFeatures.cmake
@@ -4,5 +4,4 @@ add_compile_options(
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependence>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature InoutLifetimeDependence>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependenceMutableAccessors>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature BorrowingSequence>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-upcoming-feature MemberImportVisibility>")

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8703,10 +8703,6 @@ ERROR(noncopyable_cannot_have_read_set_accessor,none,
       "noncopyable %select{variable|subscript}0 cannot provide a read and set accessor",
       (unsigned))
 
-ERROR(borrowingsequence_experimental,none,
-      "'%0' requires -enable-experimental-feature BorrowingSequence",
-      (StringRef))
-
 ERROR(for_loop_sequence_conformance_unavailable,none,
       "for-in loop requires %0 to conform to %1, which is "
       "only available in %2 %3 or newer",

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -590,7 +590,7 @@ EXPERIMENTAL_FEATURE(ImportMacroAliases, true)
 LANGUAGE_FEATURE(BorrowAndMutateAccessors, 507, "borrow and mutate accessors")
 
 /// Enable borrowing for-in loops
-EXPERIMENTAL_FEATURE(BorrowingForLoop, true)
+LANGUAGE_FEATURE(BorrowingForLoop, 0, "borrowing for-in loops")
 
 /// Allow use of @inline(always) attribute
 SUPPRESSIBLE_LANGUAGE_FEATURE(InlineAlways, 496, "@inline(always) attribute")

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -628,7 +628,7 @@ EXPERIMENTAL_FEATURE(Reparenting, true)
 EXPERIMENTAL_FEATURE(UnderscoreOwned, true)
 
 /// Allow access to the Iterable protocols/types outside the stdlib.
-EXPERIMENTAL_FEATURE(BorrowingSequence, true)
+LANGUAGE_FEATURE(BorrowingSequence, 516, "Iterable protocol")
 
 /// Turns some source breaking access control warnings into errors.
 EXPERIMENTAL_FEATURE(StrictAccessControl, true)

--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -990,9 +990,6 @@ static void conformToCxxIterableIfNeeded(
   PrettyStackTraceDecl trace("trying to conform to CxxIterable", decl);
   ASTContext &ctx = decl->getASTContext();
 
-  if (!ctx.LangOpts.hasFeature(Feature::BorrowingSequence))
-    return;
-
   ProtocolDecl *cxxIteratorProto =
       ctx.getProtocol(KnownProtocolKind::UnsafeCxxInputIterator);
   ProtocolDecl *cxxIterableProto =

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -3704,10 +3704,6 @@ FuncDecl *TypeChecker::getForEachIteratorNextFunction(
 bool swift::shouldUseIterable(ASTContext &ctx, Type seqTy,
                                        bool isAsync, SourceLoc loc,
                                        DeclContext *dc) {
-  if (!ctx.LangOpts.hasFeature(Feature::BorrowingForLoop)) {
-    return false;
-  }
-
   if (isAsync || seqTy->isExistentialType()) {
     return false;
   }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2293,33 +2293,6 @@ void TypeResolver::diagnoseGenericArgumentsOnSelf(
   }
 }
 
-/// Diagnose when this is one of the Iterable types, which currently require
-/// an experimental feature to use.
-static void diagnoseIterableType(TypeDecl *typeDecl, SourceLoc loc,
-                             const DeclContext *dc) {
-  if (loc.isInvalid())
-    return;
-
-  if (!typeDecl->isStdlibDecl())
-    return;
-
-  ASTContext &ctx = typeDecl->getASTContext();
-  if (ctx.LangOpts.hasFeature(Feature::BorrowingSequence))
-    return;
-
-  auto nameString = typeDecl->getName().str();
-  if (nameString != "Iterable" && nameString != "BorrowingIteratorProtocol"
-      && nameString != "SpanIterator" && nameString != "BorrowingIteratorAdapter")
-    return;
-
-  // Don't require this in the standard library or _Concurrency library.
-  auto module = dc->getParentModule();
-  if (module->isStdlibModule() || module->getName().str() == "_Concurrency")
-    return;
-
-  ctx.Diags.diagnose(loc, diag::borrowingsequence_experimental, nameString);
-}
-
 NeverNullType
 TypeResolver::resolveUnqualifiedIdentTypeRepr(UnqualifiedIdentTypeRepr *repr,
                                               TypeResolutionOptions options) {
@@ -2422,8 +2395,6 @@ TypeResolver::resolveUnqualifiedIdentTypeRepr(UnqualifiedIdentTypeRepr *repr,
       repr->setInvalid();
       return ErrorType::get(ctx);
     }
-
-    diagnoseIterableType(currentDecl, repr->getLoc(), DC);
 
     repr->setValue(currentDecl, currentDC);
     return current;
@@ -2652,8 +2623,6 @@ TypeResolver::resolveQualifiedIdentTypeRepr(Type parentTy,
     member = memberTypes.back().Member;
     inferredAssocType = memberTypes.back().InferredAssociatedType;
     repr->setValue(member, nullptr);
-
-    diagnoseIterableType(member, repr->getLoc(), DC);
   }
 
   return maybeDiagnoseBadMemberType(member, memberType, inferredAssocType);

--- a/stdlib/public/Cxx/CMakeLists.txt
+++ b/stdlib/public/Cxx/CMakeLists.txt
@@ -26,7 +26,6 @@ add_swift_target_library(swiftCxx STATIC NO_LINK_NAME IS_STDLIB IS_SWIFT_ONLY
     -enable-experimental-feature AllowUnsafeAttribute
     -enable-experimental-feature Lifetimes
     -enable-experimental-feature SuppressedAssociatedTypesWithDefaults
-    -enable-experimental-feature BorrowingSequence
     -strict-memory-safety
     # This module should not pull in the C++ standard library, so we disable it explicitly.
     # For functionality that depends on the C++ stdlib, use C++ stdlib overlay (`swiftstd` module).

--- a/test/Availability/foreach_borrowing.swift
+++ b/test/Availability/foreach_borrowing.swift
@@ -1,9 +1,7 @@
 // RUN: %target-typecheck-verify-swift \
-// RUN:     -enable-experimental-feature BorrowingForLoop \
 // RUN:     -enable-experimental-feature BorrowingSequence \
 // RUN:     -verify-ignore-unrelated
 
-// REQUIRES: swift_feature_BorrowingForLoop
 // REQUIRES: swift_feature_BorrowingSequence
 // REQUIRES: OS=macosx
 

--- a/test/Availability/foreach_borrowing.swift
+++ b/test/Availability/foreach_borrowing.swift
@@ -1,8 +1,6 @@
 // RUN: %target-typecheck-verify-swift \
-// RUN:     -enable-experimental-feature BorrowingSequence \
 // RUN:     -verify-ignore-unrelated
 
-// REQUIRES: swift_feature_BorrowingSequence
 // REQUIRES: OS=macosx
 
 // Tests for the availability check in DesugarForEachStmt.

--- a/test/Interop/Cxx/stdlib/libstdcxx-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/libstdcxx-module-interface.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -print-module -module-to-print=CxxStdlib -source-filename=x -enable-experimental-cxx-interop -module-cache-path %t -enable-experimental-feature ImportCxxMembersLazily -enable-experimental-feature BorrowingSequence > %t/interface.swift
+// RUN: %target-swift-ide-test -print-module -module-to-print=CxxStdlib -source-filename=x -enable-experimental-cxx-interop -module-cache-path %t -enable-experimental-feature ImportCxxMembersLazily > %t/interface.swift
 // RUN: %FileCheck %s -check-prefix=CHECK-STD < %t/interface.swift
 // RUN: %FileCheck %s -check-prefix=CHECK-SIZE-T < %t/interface.swift
 // RUN: %FileCheck %s -check-prefix=CHECK-TO-STRING < %t/interface.swift
@@ -13,7 +13,6 @@
 // The RHS of basic_string's typealias value_type depends on how eagerly/lazily
 // we import type members
 // REQUIRES: swift_feature_ImportCxxMembersLazily
-// REQUIRES: swift_feature_BorrowingSequence
 
 // CHECK-STD: enum std {
 // CHECK-STRING:   struct basic_string<CChar, std{{(.__cxx11)?}}.char_traits<CChar>, std{{(.__cxx11)?}}.allocator<CChar>> : CxxMutableRandomAccessCollection, CxxIterable {

--- a/test/Interop/Cxx/stdlib/msvcprt-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/msvcprt-module-interface.swift
@@ -12,10 +12,10 @@
 // CHECK-STRING:   typealias size_t = size_t
 // CHECK-STRING:   static func to_string(_ _Val: Int32) -> std.string
 // CHECK-STRING:   static func to_wstring(_ _Val: Int32) -> std.wstring
-// CHECK-STRING:   struct basic_string<CChar, std.char_traits<CChar>, std.allocator<CChar>> : CxxMutableRandomAccessCollection {
+// CHECK-STRING:   struct basic_string<CChar, std.char_traits<CChar>, std.allocator<CChar>> : CxxMutableRandomAccessCollection, CxxIterable {
 // CHECK-STRING:     typealias value_type = CChar
 // CHECK-STRING:   }
-// CHECK-STRING:   struct basic_string<CChar16, std.char_traits<CChar16>, std.allocator<CChar16>> : CxxMutableRandomAccessCollection {
+// CHECK-STRING:   struct basic_string<CChar16, std.char_traits<CChar16>, std.allocator<CChar16>> : CxxMutableRandomAccessCollection, CxxIterable {
 // CHECK-STRING:     typealias value_type = UInt16
 // FIXME: why the value type is different from CChar16?
 // CHECK-STRING:   }

--- a/test/Interop/Cxx/stdlib/overlay/custom-borrowing-sequence-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-borrowing-sequence-module-interface.swift
@@ -1,6 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=CustomIterable -source-filename=x -I %S/Inputs -cxx-interoperability-mode=default -module-cache-path %t -enable-experimental-feature BorrowingSequence | %FileCheck %s
-
-// REQUIRES: swift_feature_BorrowingSequence
+// RUN: %target-swift-ide-test -print-module -module-to-print=CustomIterable -source-filename=x -I %S/Inputs -cxx-interoperability-mode=default -module-cache-path %t | %FileCheck %s
 
 // CHECK:     struct SimpleNonCopyableSequence : ~Copyable, CxxIterable {
 // CHECK:       typealias Element = ConstIterator.Pointee

--- a/test/Interop/Cxx/stdlib/overlay/custom-borrowing-sequence.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-borrowing-sequence.swift
@@ -1,6 +1,5 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=default -Xcc -std=c++20 -enable-experimental-feature BorrowingSequence)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=default -Xcc -std=c++20)
 //
-// REQUIRES: swift_feature_BorrowingSequence
 // REQUIRES: executable_test
 // Ubuntu 20.04 ships with an old version of libstdc++, which does not provide
 // std::contiguous_iterator_tag from C++20.

--- a/test/Interop/Cxx/stdlib/overlay/custom-collection-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-collection-module-interface.swift
@@ -1,6 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=CustomSequence -source-filename=x -I %S/Inputs -cxx-interoperability-mode=default -module-cache-path %t -enable-experimental-feature BorrowingSequence | %FileCheck %s
-
-// REQUIRES: swift_feature_BorrowingSequence
+// RUN: %target-swift-ide-test -print-module -module-to-print=CustomSequence -source-filename=x -I %S/Inputs -cxx-interoperability-mode=default -module-cache-path %t | %FileCheck %s
 
 // CHECK: struct SimpleArrayWrapper : CxxRandomAccessCollection, CxxIterable {
 // CHECK:   typealias Element = UnsafePointer<Int32>.Pointee

--- a/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
@@ -1,6 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=CustomIterator -source-filename=x -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature BorrowingSequence | %FileCheck %s
-
-// REQUIRES: swift_feature_BorrowingSequence
+// RUN: %target-swift-ide-test -print-module -module-to-print=CustomIterator -source-filename=x -I %S/Inputs -cxx-interoperability-mode=default | %FileCheck %s
 
 // CHECK: struct ConstIterator : UnsafeCxxInputIterator {
 // CHECK:   func __operatorStar() -> UnsafePointer<Int32>

--- a/test/Interop/Cxx/stdlib/overlay/custom-iterator-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-iterator-typechecker.swift
@@ -6,12 +6,11 @@
 // contiguous iterators.
 //
 // RUN: %if !(LinuxDistribution=ubuntu-20.04 || LinuxDistribution=amzn-2) %{ \
-// RUN:   %target-typecheck-verify-swift -verify-ignore-unrelated -suppress-notes -I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++20 -enable-experimental-feature SuppressedAssociatedTypesWithDefaults -enable-experimental-feature BorrowingSequence -DCPP20 -verify-additional-prefix cpp20- \
+// RUN:   %target-typecheck-verify-swift -verify-ignore-unrelated -suppress-notes -I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++20 -enable-experimental-feature SuppressedAssociatedTypesWithDefaults -DCPP20 -verify-additional-prefix cpp20- \
 // RUN: %}
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -suppress-notes -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature SuppressedAssociatedTypesWithDefaults -enable-experimental-feature BorrowingSequence
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -suppress-notes -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature SuppressedAssociatedTypesWithDefaults
 
 // REQUIRES: swift_feature_SuppressedAssociatedTypesWithDefaults
-// REQUIRES: swift_feature_BorrowingSequence
 
 import CustomIterator
 

--- a/test/Interop/Cxx/stdlib/overlay/custom-sequence-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-sequence-module-interface.swift
@@ -1,6 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=CustomSequence -source-filename=x -I %S/Inputs -cxx-interoperability-mode=default -module-cache-path %t -enable-experimental-feature BorrowingSequence | %FileCheck %s
-
-// REQUIRES: swift_feature_BorrowingSequence
+// RUN: %target-swift-ide-test -print-module -module-to-print=CustomSequence -source-filename=x -I %S/Inputs -cxx-interoperability-mode=default -module-cache-path %t | %FileCheck %s
 
 // CHECK: struct SimpleSequence : CxxConvertibleToCollection, CxxIterable {
 // CHECK:   typealias Element = ConstIterator.Pointee

--- a/test/Interop/Cxx/stdlib/use-std-list-generic.swift
+++ b/test/Interop/Cxx/stdlib/use-std-list-generic.swift
@@ -1,8 +1,7 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -enable-experimental-feature BorrowingSequence)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 // Test iterating through a list using the borrowing iterators (currently behind a feature flag).
 
 // REQUIRES: executable_test
-// REQUIRES: swift_feature_BorrowingSequence
 
 import StdlibUnittest
 import StdList

--- a/test/Interop/Cxx/stdlib/use-std-list.swift
+++ b/test/Interop/Cxx/stdlib/use-std-list.swift
@@ -1,7 +1,6 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -enable-experimental-feature BorrowingSequence)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 // Test iterating through a list using the borrowing iterators (currently behind a feature flag).
 
-// REQUIRES: swift_feature_BorrowingSequence
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/Interop/Cxx/stdlib/use-std-span-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span-typechecker.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop -Xcc -std=c++20 2>&1 -disable-availability-checking -enable-experimental-feature BorrowingSequence
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++20 -enable-experimental-feature BorrowingSequence %if OS_FAMILY=darwin %{ -verify-additional-prefix darwin- %}
 // REQUIRES: std_span
 // REQUIRES: swift_feature_BorrowingSequence
 
@@ -7,6 +7,7 @@ import StdSpan
 func takesSequence<T: Sequence>(_ _: T) {}
 // expected-note@-1 {{where 'T' = 'SpanOfNonCopyable'}}
 
+@available(SwiftStdlib 6.4, *)
 func takesIterable<T: CxxIterable>(_ _: T) where T.Element: ~Copyable {}
 
 func takesSpan<S: CxxMutableSpan>(_ _: S) where S.Element: ~Copyable {}
@@ -15,22 +16,27 @@ let arr: [Int32] = [1, 2, 3]
 arr.withUnsafeBufferPointer { ubpointer in
     let _ = ConstSpanOfInt(ubpointer) // okay
     let _ = ConstSpanOfInt(ubpointer.baseAddress!, ubpointer.count) 
+    // expected-warning@-1 {{'init(_:_:)' is deprecated: use 'init(_:)' instead.}}
 }
 
 arr.withUnsafeBufferPointer { ubpointer in 
     // FIXME: this crashes the compiler once we import span's templated ctors as Swift generics.
     let _ = ConstSpanOfInt(ubpointer.baseAddress, ubpointer.count)
+    // expected-warning@-1 {{'init(_:_:)' is deprecated: use 'init(_:)' instead.}}
 }
 
 let s1 = initSpan()
 for _ in s1 {}
 takesSequence(s1)
-takesIterable(s1)
+if #available(SwiftStdlib 6.4, *) {
+  takesIterable(s1)
+}
 takesSpan(s1)
 
 let s2 = makeSpanOfNonCopyable()
 for _ in s2 {}
-// expected-error@-1 {{for-in loop requires 'SpanOfNonCopyable'}} to conform to 'Sequence'
+// expected-darwin-error@-1 {{conform to 'BorrowingSequence', which is only available in}}
+// expected-darwin-note@-2 {{add 'if #available' version check}}
 takesSequence(s2)
 // expected-error@-1 {{global function 'takesSequence' requires that 'SpanOfNonCopyable'}} conform to 'Sequence'
 takesIterable(s2)

--- a/test/Interop/Cxx/stdlib/use-std-span-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span-typechecker.swift
@@ -1,6 +1,5 @@
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++20 -enable-experimental-feature BorrowingSequence %if OS_FAMILY=darwin %{ -verify-additional-prefix darwin- %}
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++20 %if OS_FAMILY=darwin %{ -verify-additional-prefix darwin- %}
 // REQUIRES: std_span
-// REQUIRES: swift_feature_BorrowingSequence
 
 import StdSpan
 
@@ -35,9 +34,11 @@ takesSpan(s1)
 
 let s2 = makeSpanOfNonCopyable()
 for _ in s2 {}
-// expected-darwin-error@-1 {{conform to 'BorrowingSequence', which is only available in}}
+// expected-darwin-error@-1 {{conform to 'Iterable', which is only available in}}
 // expected-darwin-note@-2 {{add 'if #available' version check}}
 takesSequence(s2)
 // expected-error@-1 {{global function 'takesSequence' requires that 'SpanOfNonCopyable'}} conform to 'Sequence'
 takesIterable(s2)
+// expected-error@-1 {{'takesIterable' is only available}}
+// expected-note@-2 {{add 'if #available' version check}}
 takesSpan(s2)

--- a/test/Interop/Cxx/stdlib/use-std-span-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span-typechecker.swift
@@ -39,6 +39,6 @@ for _ in s2 {}
 takesSequence(s2)
 // expected-error@-1 {{global function 'takesSequence' requires that 'SpanOfNonCopyable'}} conform to 'Sequence'
 takesIterable(s2)
-// expected-error@-1 {{'takesIterable' is only available}}
-// expected-note@-2 {{add 'if #available' version check}}
+// expected-darwin-error@-1 {{'takesIterable' is only available}}
+// expected-darwin-note@-2 {{add 'if #available' version check}}
 takesSpan(s2)

--- a/test/Interop/Cxx/stdlib/use-std-span.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span.swift
@@ -1,10 +1,9 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -enable-experimental-feature BorrowingSequence)
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -Xcc -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG -enable-experimental-feature BorrowingSequence)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -Xcc -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG)
 
 
 // REQUIRES: executable_test
 // REQUIRES: std_span
-// REQUIRES: swift_feature_BorrowingSequence
 
 import StdlibUnittest
 import StdSpan

--- a/test/Interop/Cxx/stdlib/use-std-span.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span.swift
@@ -1,12 +1,9 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -enable-experimental-feature BorrowingSequence)
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -Xcc -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG -enable-experimental-feature BorrowingSequence)
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -enable-experimental-feature BorrowingForLoop -enable-experimental-feature BorrowingSequence)
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -Xcc -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG -enable-experimental-feature BorrowingForLoop -enable-experimental-feature BorrowingSequence)
 
 
 // REQUIRES: executable_test
 // REQUIRES: std_span
-// REQUIRES: swift_feature_BorrowingForLoop
 // REQUIRES: swift_feature_BorrowingSequence
 
 import StdlibUnittest
@@ -731,8 +728,6 @@ StdSpanTestSuite.test("CxxSpan conforms to CxxIterable")
   expectEqual(counter, 3)
 }
 
-#if hasFeature(BorrowingForLoop)
-
 StdSpanTestSuite.test("CxxSpan of noncopyable conforms to CxxIterable")
 .require(.stdlib_6_4).code {
   guard #available(SwiftStdlib 6.4, *) else { return }
@@ -766,7 +761,5 @@ StdSpanTestSuite.test("Borrowing for loop")
   }
   expectEqual(counter, 3)
 }
-
-#endif
 
 runAllTests()

--- a/test/Interop/Cxx/stdlib/use-std-vector-borrowing-iterators.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector-borrowing-iterators.swift
@@ -1,19 +1,18 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -enable-experimental-feature BorrowingSequence)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6 -Xcc -std=c++20 -enable-experimental-feature BorrowingSequence)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20 -enable-experimental-feature BorrowingSequence)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6 -Xcc -std=c++20)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20)
 
 // Also test this with a bridging header instead of the StdVector module.
 // RUN: %empty-directory(%t2)
 // RUN: cp %S/Inputs/std-vector.h %t2/std-vector-bridging-header.h
-// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-vector-bridging-header.h -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -enable-experimental-feature BorrowingSequence)
-// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-vector-bridging-header.h -cxx-interoperability-mode=swift-6 -Xcc -std=c++20 -enable-experimental-feature BorrowingSequence)
-// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-vector-bridging-header.h -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20 -enable-experimental-feature BorrowingSequence)
+// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-vector-bridging-header.h -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20)
+// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-vector-bridging-header.h -cxx-interoperability-mode=swift-6 -Xcc -std=c++20)
+// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-vector-bridging-header.h -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20)
 
 // Ubuntu 20.04 ships with an old version of libstdc++, which does not provide
 // std::contiguous_iterator_tag from C++20.
 // REQUIRES: OS=macosx || OS=windows-msvc
 
-// REQUIRES: swift_feature_BorrowingSequence
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-enum-back-to-cxx-execution.cpp
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-enum-back-to-cxx-execution.cpp
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -parse-as-library %stdlib_dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies -enable-experimental-feature LifetimeDependence -enable-experimental-feature Lifetimes -enable-experimental-feature BorrowingSequence -enable-experimental-feature Reparenting -enable-experimental-feature AddressableParameters
+// RUN: %target-swift-frontend -parse-as-library %stdlib_dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies -enable-experimental-feature LifetimeDependence -enable-experimental-feature Lifetimes -enable-experimental-feature Reparenting -enable-experimental-feature AddressableParameters
 // RUN: %target-swift-frontend -typecheck %t/use-cxx-types.swift -typecheck -module-name UseCxx -emit-clang-header-path %t/UseCxx.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public
 
 // RUN: %target-interop-build-clangxx -std=c++20 -c %t/use-swift-cxx-types.cpp -I %t -o %t/swift-cxx-execution.o -g
@@ -13,7 +13,6 @@
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_LifetimeDependence
 // REQUIRES: swift_feature_Lifetimes
-// REQUIRES: swift_feature_BorrowingSequence
 // REQUIRES: swift_feature_Reparenting
 // REQUIRES: swift_feature_AddressableParameters
 

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx-execution.cpp
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx-execution.cpp
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -parse-as-library %platform-module-dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies -enable-experimental-feature LifetimeDependence -enable-experimental-feature Lifetimes -enable-experimental-feature BorrowingSequence -enable-experimental-feature Reparenting -enable-experimental-feature AddressableParameters
+// RUN: %target-swift-frontend -parse-as-library %platform-module-dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies -enable-experimental-feature LifetimeDependence -enable-experimental-feature Lifetimes -enable-experimental-feature Reparenting -enable-experimental-feature AddressableParameters
 
 // RUN: %target-swift-frontend -typecheck %t/use-cxx-types.swift -typecheck -module-name UseCxx -emit-clang-header-path %t/UseCxx.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public
 
@@ -14,7 +14,6 @@
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_LifetimeDependence
 // REQUIRES: swift_feature_Lifetimes
-// REQUIRES: swift_feature_BorrowingSequence
 // REQUIRES: swift_feature_Reparenting
 // REQUIRES: swift_feature_AddressableParameters
 

--- a/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -parse-as-library %platform-module-dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr-or-stdlib -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies -enable-experimental-feature LifetimeDependence  -enable-experimental-feature Lifetimes -enable-experimental-feature BorrowingSequence -enable-experimental-feature Reparenting -enable-experimental-feature AddressableParameters
+// RUN: %target-swift-frontend -parse-as-library %platform-module-dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr-or-stdlib -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies -enable-experimental-feature LifetimeDependence  -enable-experimental-feature Lifetimes -enable-experimental-feature Reparenting -enable-experimental-feature AddressableParameters
 // RUN: %FileCheck %s < %t/Swift.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/Swift.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -Wno-unused-private-field -Wno-unused-function -Wc++98-compat-extra-semi)
@@ -7,7 +7,6 @@
 
 // REQUIRES: swift_feature_LifetimeDependence
 // REQUIRES: swift_feature_Lifetimes
-// REQUIRES: swift_feature_BorrowingSequence
 // REQUIRES: swift_feature_Reparenting
 // REQUIRES: swift_feature_AddressableParameters
 

--- a/test/Interpreter/foreach_borrowing.swift
+++ b/test/Interpreter/foreach_borrowing.swift
@@ -6,11 +6,9 @@
 // cited below, where the stdlib symbols will not be present, to avoid crashes.
 // Make sure to update this test accordingly when a more appropriate tool is added.
 
-// RUN: %target-run-simple-swift(-enable-experimental-feature BorrowingForLoop \
-// RUN: -Xfrontend -disable-availability-checking) \
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking) \
 // RUN: %s | %FileCheck %s
 
-// REQUIRES: swift_feature_BorrowingForLoop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/Interpreter/foreach_borrowing_typed_throws.swift
+++ b/test/Interpreter/foreach_borrowing_typed_throws.swift
@@ -1,11 +1,7 @@
-// RUN: %target-run-simple-swift(-enable-experimental-feature BorrowingForLoop \
-// RUN: -enable-experimental-feature BorrowingSequence \
-// RUN: -enable-experimental-feature Lifetimes \
+// RUN: %target-run-simple-swift(-enable-experimental-feature Lifetimes \
 // RUN: -Xfrontend -disable-availability-checking) \
 // RUN: %s | %FileCheck %s
 
-// REQUIRES: swift_feature_BorrowingForLoop
-// REQUIRES: swift_feature_BorrowingSequence
 // REQUIRES: swift_feature_Lifetimes
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib

--- a/test/Profiler/coverage_foreach_borrowing.swift
+++ b/test/Profiler/coverage_foreach_borrowing.swift
@@ -1,7 +1,5 @@
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -suppress-warnings -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_foreach_borrowing -enable-experimental-feature BorrowingForLoop %s | %FileCheck %s
-// RUN: %target-swift-frontend -profile-generate -profile-coverage-mapping -emit-ir -enable-experimental-feature BorrowingForLoop %s
-
-// REQUIRES: swift_feature_BorrowingForLoop
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -suppress-warnings -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_foreach_borrowing %s | %FileCheck %s
+// RUN: %target-swift-frontend -profile-generate -profile-coverage-mapping -emit-ir %s
 
 // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_foreach_borrowing.forEachBasic
 @available(SwiftStdlib 6.4, *)

--- a/test/SILGen/foreach_borrowing.swift
+++ b/test/SILGen/foreach_borrowing.swift
@@ -1,19 +1,14 @@
-// RUN: %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -Xllvm -sil-print-types -g -Xllvm -sil-print-debuginfo-verbose -enable-experimental-feature BorrowingForLoop -enable-experimental-feature BorrowingSequence %s
+// RUN: %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -Xllvm -sil-print-types -g -Xllvm -sil-print-debuginfo-verbose %s
 
-// RUN: not --crash %target-swift-emit-sil -sil-verify-all -enable-sil-opaque-values -enable-experimental-feature BorrowingForLoop -enable-experimental-feature BorrowingSequence -o /dev/null %s
+// RUN: not --crash %target-swift-emit-sil -sil-verify-all -enable-sil-opaque-values -o /dev/null %s
 
 // RUN: %target-swift-emit-silgen -Xllvm -sil-print-types \
 // RUN:     -g -Xllvm -sil-print-debuginfo-verbose \
-// RUN:     -enable-experimental-feature BorrowingSequence \
 // RUN:     %s | %FileCheck %s --check-prefixes=CHECK,CHECK-ADDR
 // RUN: %target-swift-emit-silgen -Xllvm -sil-print-types \
 // RUN:     -g -Xllvm -sil-print-debuginfo-verbose \
-// RUN:     -enable-experimental-feature BorrowingForLoop \
-// RUN:     -enable-experimental-feature BorrowingSequence \
 // RUN:     -enable-sil-opaque-values \
 // RUN:     %s | %FileCheck %s --check-prefixes=CHECK,CHECK-OPAQUE
-
-// REQUIRES: swift_feature_BorrowingSequence
 
 struct NoncopyableInt: ~Copyable {
   var value: Int

--- a/test/SILGen/foreach_borrowing.swift
+++ b/test/SILGen/foreach_borrowing.swift
@@ -4,7 +4,6 @@
 
 // RUN: %target-swift-emit-silgen -Xllvm -sil-print-types \
 // RUN:     -g -Xllvm -sil-print-debuginfo-verbose \
-// RUN:     -enable-experimental-feature BorrowingForLoop \
 // RUN:     -enable-experimental-feature BorrowingSequence \
 // RUN:     %s | %FileCheck %s --check-prefixes=CHECK,CHECK-ADDR
 // RUN: %target-swift-emit-silgen -Xllvm -sil-print-types \
@@ -14,7 +13,6 @@
 // RUN:     -enable-sil-opaque-values \
 // RUN:     %s | %FileCheck %s --check-prefixes=CHECK,CHECK-OPAQUE
 
-// REQUIRES: swift_feature_BorrowingForLoop
 // REQUIRES: swift_feature_BorrowingSequence
 
 struct NoncopyableInt: ~Copyable {

--- a/test/SILGen/foreach_borrowing_typed_throws.swift
+++ b/test/SILGen/foreach_borrowing_typed_throws.swift
@@ -1,12 +1,8 @@
 // RUN: %target-swift-emit-silgen -Xllvm -sil-print-types \
-// RUN:     -enable-experimental-feature BorrowingForLoop \
-// RUN:     -enable-experimental-feature BorrowingSequence \
 // RUN:     -enable-experimental-feature Lifetimes \
 // RUN:     -module-name test \
 // RUN:     %s | %FileCheck %s
 
-// REQUIRES: swift_feature_BorrowingForLoop
-// REQUIRES: swift_feature_BorrowingSequence
 // REQUIRES: swift_feature_Lifetimes
 
 enum IterationError: Error {

--- a/test/SILOptimizer/addressable_lifetime_dependence_specialization.swift
+++ b/test/SILOptimizer/addressable_lifetime_dependence_specialization.swift
@@ -4,7 +4,6 @@
 // Build the library as a separate, library-evolution-enabled module.
 // RUN: %target-swift-frontend -emit-module -parse-as-library -O \
 // RUN:   -enable-library-evolution -disable-availability-checking \
-// RUN:   -enable-experimental-feature BorrowingSequence \
 // RUN:   -enable-experimental-feature Lifetimes \
 // RUN:   -module-name IterableLib %t/library.swift \
 // RUN:   -emit-module-path %t/IterableLib.swiftmodule
@@ -12,7 +11,6 @@
 // Compile the client, dumping the specialized witness thunk across the pipeline.
 // RUN: %target-swift-frontend -emit-sil -O -I %t \
 // RUN:   -disable-availability-checking \
-// RUN:   -enable-experimental-feature BorrowingSequence \
 // RUN:   -enable-experimental-feature Lifetimes \
 // RUN:   -module-name main %t/client.swift \
 // RUN:   -Xllvm '-sil-print-function=$ss11InlineArrayVyxq_G11IterableLib04TestC0ADRi__rlAdEP21makeBorrowingIterator0egH0QzyFTW$3__SiTg5' \
@@ -20,7 +18,6 @@
 // RUN: %FileCheck %s < %t/thunk.sil
 // RUN: %FileCheck %s -check-prefix=NEGATIVE < %t/thunk.sil
 
-// REQUIRES: swift_feature_BorrowingSequence
 // REQUIRES: swift_feature_Lifetimes
 
 // Regression test for rdar://181365820.

--- a/test/Sema/foreach_borrowing.swift
+++ b/test/Sema/foreach_borrowing.swift
@@ -1,8 +1,5 @@
 // RUN: %target-typecheck-verify-swift \
-// RUN:     -enable-experimental-feature BorrowingSequence \
 // RUN:     -verify-ignore-unrelated
-
-// REQUIRES: swift_feature_BorrowingSequence
 
 @available(SwiftStdlib 6.4, *)
 struct DualConformanceSeq: Sequence, Iterable {

--- a/test/Sema/foreach_borrowing.swift
+++ b/test/Sema/foreach_borrowing.swift
@@ -1,9 +1,7 @@
 // RUN: %target-typecheck-verify-swift \
-// RUN:     -enable-experimental-feature BorrowingForLoop \
 // RUN:     -enable-experimental-feature BorrowingSequence \
 // RUN:     -verify-ignore-unrelated
 
-// REQUIRES: swift_feature_BorrowingForLoop
 // REQUIRES: swift_feature_BorrowingSequence
 
 @available(SwiftStdlib 6.4, *)

--- a/test/Sema/foreach_borrowing_typed_throws.swift
+++ b/test/Sema/foreach_borrowing_typed_throws.swift
@@ -1,11 +1,7 @@
 // RUN: %target-typecheck-verify-swift \
-// RUN:     -enable-experimental-feature BorrowingForLoop \
-// RUN:     -enable-experimental-feature BorrowingSequence \
 // RUN:     -enable-experimental-feature Lifetimes \
 // RUN:     -verify-ignore-unrelated
 
-// REQUIRES: swift_feature_BorrowingForLoop
-// REQUIRES: swift_feature_BorrowingSequence
 // REQUIRES: swift_feature_Lifetimes
 
 @available(SwiftStdlib 6.4, *)

--- a/test/stdlib/BorrowingSequence-FeatureFlag.swift
+++ b/test/stdlib/BorrowingSequence-FeatureFlag.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: not %target-swift-emit-ir %s -module-name main -parse-as-library 2>&1 | %FileCheck %s
 // RUN: %target-swift-emit-ir %s -module-name main -parse-as-library -enable-experimental-feature BorrowingSequence
+// RUN: %target-swift-emit-ir %s -module-name main -parse-as-library
 
 // REQUIRES: swift_feature_BorrowingSequence
 
@@ -12,7 +12,3 @@ extension BorrowingIteratorProtocol {}
 
 @available(SwiftStdlib 6.4, *)
 extension BorrowingIteratorAdapter {}
-
-// CHECK: 'Iterable' requires -enable-experimental-feature BorrowingSequence
-// CHECK: 'BorrowingIteratorProtocol' requires -enable-experimental-feature BorrowingSequence
-// CHECK: 'BorrowingIteratorAdapter' requires -enable-experimental-feature BorrowingSequence

--- a/test/stdlib/BorrowingSequence.swift
+++ b/test/stdlib/BorrowingSequence.swift
@@ -10,12 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: %target-run-stdlib-swift(-enable-experimental-feature SuppressedAssociatedTypesWithDefaults -enable-experimental-feature BorrowingSequence -enable-experimental-feature BorrowingForLoop -enable-experimental-feature Lifetimes)
+// RUN: %target-run-stdlib-swift(-enable-experimental-feature SuppressedAssociatedTypesWithDefaults -enable-experimental-feature Lifetimes)
 
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_SuppressedAssociatedTypesWithDefaults
-// REQUIRES: swift_feature_BorrowingSequence
-// REQUIRES: swift_feature_BorrowingForLoop
 // REQUIRES: swift_feature_Lifetimes
 
 import StdlibUnittest


### PR DESCRIPTION
This PR converts these two experimental feature flags to regular language flags – includes #90017.