### PR TITLE
[VariableNameUtils] Carry decls through the inferrer's name path

### DIFF
--- a/include/swift/SILOptimizer/Utils/VariableNameUtils.h
+++ b/include/swift/SILOptimizer/Utils/VariableNameUtils.h
@@ -25,6 +25,8 @@
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/StackList.h"
 
+#include <variant>
+
 namespace swift {
 
 class VariableNameInferrer {
@@ -39,6 +41,31 @@ public:
   };
 
   using Options = OptionSet<Flag>;
+
+  /// One element of the path the inferrer accumulates as it walks. Each
+  /// component records the \c subject it is naming (a textual \c StringRef
+  /// for sources without a recoverable decl, e.g. a debug_value's name
+  /// attribute or a tuple-element index; a \c ValueDecl* when one is
+  /// available, e.g. for the callee of an \c apply or a stored property
+  /// being projected). Consumers that only need a rendered string call
+  /// \c text(); consumers that want decl-aware diagnostics (\c %kind etc.)
+  /// can match on the variant directly.
+  struct InferredNameComponent {
+    std::variant<StringRef, ValueDecl *> subject;
+
+    /// Source location associated with this component (e.g., a let-binding's
+    /// decl loc or an apply's call loc). Used for diagnostic anchoring.
+    SourceLoc providingLoc;
+
+    InferredNameComponent(StringRef name, SourceLoc loc)
+        : subject(name), providingLoc(loc) {}
+    InferredNameComponent(ValueDecl *decl, SourceLoc loc)
+        : subject(decl), providingLoc(loc) {}
+
+    /// Render this component as the textual fragment used to build the
+    /// joined name path. Used by \c drainVariableNamePath.
+    StringRef getStringRef() const;
+  };
 
 private:
   /// A two phase stack data structure. The first phase only allows for two
@@ -129,7 +156,7 @@ private:
   ///
   /// Has to be a small vector since we push/pop the last segment start. This
   /// lets us speculate when processing phis.
-  VariableNamePathArray<StringRef, 4> variableNamePath;
+  VariableNamePathArray<InferredNameComponent, 4> variableNamePath;
 
   /// The root value of our string.
   ///
@@ -144,6 +171,14 @@ private:
   /// than the root variable's location (which for a stored property accessed
   /// in an init can be on the `init` keyword, far from the access).
   SourceLoc firstNameProvidingLoc;
+
+  /// The leaf component's \c ValueDecl, if any. Captured by
+  /// \c drainVariableNamePath right before it consumes the path so callers
+  /// can recover decl-kind-aware info after a successful inference. Null
+  /// when no path was pushed or when the leaf component was a bare
+  /// \c StringRef (e.g. a tuple-element index, or a debug_value's name
+  /// attribute that didn't carry a decl).
+  ValueDecl *leafDecl = nullptr;
 
   /// The final string we computed.
   SmallString<64> &resultingString;
@@ -246,9 +281,37 @@ public:
   static std::optional<std::pair<Identifier, SourceLoc>>
   inferNameAndFirstPathComponent(SILValue value);
 
+  /// Result of \c inferNameAndLeafDecl. Carries the joined+interned name,
+  /// the first-name-providing source location (see \c firstNameProvidingLoc),
+  /// and the leaf-most component's \c ValueDecl when one was recorded by
+  /// the walk (otherwise \c leafDecl is null).
+  struct InferredNameAndLeafDecl {
+    Identifier name;
+    SourceLoc declLoc;
+    ValueDecl *leafDecl;
+  };
+
+  /// Like \c inferNameAndFirstPathComponent, but also returns the leaf
+  /// component's \c ValueDecl when the inferrer recorded one (e.g. the
+  /// callee \c FuncDecl for a value that originates from an apply, or the
+  /// stored-property \c VarDecl for a struct-extract chain). Diagnostic
+  /// consumers can check \c leafDecl to pick a \c %kind-bearing variant
+  /// rather than printing the leaf's basename as if it were a bare value
+  /// identifier.
+  static std::optional<InferredNameAndLeafDecl>
+  inferNameAndLeafDecl(SILValue value);
+
   /// Returns the source location whose name was first pushed onto the name
   /// path during the walk. See \c firstNameProvidingLoc for details.
   SourceLoc getFirstNameProvidingLoc() const { return firstNameProvidingLoc; }
+
+  /// Returns the leaf-most component's \c ValueDecl if \c drainVariableNamePath
+  /// has run on a non-empty path whose leaf was a decl, otherwise null.
+  /// Useful for diagnostics that want decl-kind-aware rendering (\c %kind)
+  /// rather than treating the inferred name as a bare value identifier
+  /// (e.g. a function called inline whose function_ref leaked through name
+  /// inference as if it were a variable name).
+  ValueDecl *getLeafDecl() const { return leafDecl; }
 
   /// Given a specific decl \p d, come up with a name for it.
   ///
@@ -271,9 +334,30 @@ private:
   /// as the first name-providing source location if none has been recorded
   /// yet.
   void pushPathComponent(StringRef name, SourceLoc providingLoc) {
-    variableNamePath.push_back(name);
+    variableNamePath.push_back({name, providingLoc});
     if (firstNameProvidingLoc.isInvalid())
       firstNameProvidingLoc = providingLoc;
+  }
+
+  /// Decl-bearing overload of \c pushPathComponent: preserves \p decl in the
+  /// component's \c subject so consumers (e.g. \c %kind diagnostics) can
+  /// recover decl-kind-aware rendering. \c getStringRef() falls back to the
+  /// decl's base-name text for callers that only want a string.
+  void pushPathComponent(ValueDecl *decl, SourceLoc providingLoc) {
+    variableNamePath.push_back({decl, providingLoc});
+    if (firstNameProvidingLoc.isInvalid())
+      firstNameProvidingLoc = providingLoc;
+  }
+
+  /// Convenience overloads that take a \c SILLocation and extract its
+  /// \c SourceLoc. Most callers have a SILLocation in hand (e.g. from
+  /// \c getLoc()) and would otherwise repeat \c .getSourceLoc() at every
+  /// call site.
+  void pushPathComponent(StringRef name, SILLocation providingLoc) {
+    pushPathComponent(name, providingLoc.getSourceLoc());
+  }
+  void pushPathComponent(ValueDecl *decl, SILLocation providingLoc) {
+    pushPathComponent(decl, providingLoc.getSourceLoc());
   }
 
   /// Finds the SILValue that either provides the direct debug information or

--- a/lib/SILOptimizer/Utils/VariableNameUtils.cpp
+++ b/lib/SILOptimizer/Utils/VariableNameUtils.cpp
@@ -392,31 +392,44 @@ struct VariableNameInferrer::CallResultNamer {
     return v;
   }
 
-  /// The user-facing name of the function/method invoked by \p call, or an
-  /// empty StringRef if one cannot be determined. Looks through an
-  /// immediately-invoked partial_apply to the underlying function reference.
-  StringRef getCalleeName(FullApplySite call) const {
+  /// User-facing name of the function/method invoked by \p call. Returns
+  /// the name's textual rendering and (when one can be determined) the
+  /// invoked \c ValueDecl, so callers can push the decl directly through
+  /// \c pushPathComponent and preserve decl-kind-aware rendering. Returns
+  /// an empty \c StringRef if no name can be determined; \c decl is null
+  /// when only a SIL function name (with no AST decl) is available.
+  /// Looks through an immediately-invoked partial_apply to the underlying
+  /// function reference.
+  struct CalleeNameAndDecl {
+    StringRef name;
+    ValueDecl *decl = nullptr;
+  };
+  CalleeNameAndDecl getCalleeNameAndDecl(FullApplySite call) const {
     SILValue callee = stripCalleeConversions(call.getCallee());
     while (auto *pai = dyn_cast<PartialApplyInst>(callee))
       callee = stripCalleeConversions(pai->getCallee());
 
     // A dynamically dispatched method (class_method, witness_method, ...): use
     // the referenced member's name (which also handles accessors).
-    if (auto *mi = dyn_cast<MethodInst>(callee))
-      return getNameFromDecl(mi->getMember().getDecl());
+    if (auto *mi = dyn_cast<MethodInst>(callee)) {
+      auto *decl = mi->getMember().getDecl();
+      if (auto *vd = dyn_cast_or_null<ValueDecl>(decl))
+        return {getNameFromDecl(decl), vd};
+      return {getNameFromDecl(decl), nullptr};
+    }
 
     // A direct call: prefer the referenced function's own decl name.
     if (auto *f = dyn_cast<FunctionRefBaseInst>(callee)) {
       auto *fn = f->getInitiallyReferencedFunction();
       if (auto declRef = fn->getDeclRef())
         if (auto *decl = declRef.getDecl())
-          return getNameFromDecl(decl);
+          return {getNameFromDecl(decl), decl};
       // Fall back to the SILFunction's name (e.g. for SIL-only declarations
       // that carry no AST decl).
-      return fn->getName();
+      return {fn->getName(), nullptr};
     }
 
-    return StringRef();
+    return {};
   }
 
   /// The self value associated with \p call, if any: either the call's own
@@ -441,13 +454,16 @@ struct VariableNameInferrer::CallResultNamer {
   /// self value so the walk continues into it -- producing 'self.member'.
   /// Returns SILValue() if there is no name or no self.
   SILValue nameThroughSelf(FullApplySite call) {
-    auto name = getCalleeName(call);
-    if (name.empty())
+    auto cnd = getCalleeNameAndDecl(call);
+    if (cnd.name.empty())
       return SILValue();
     auto self = getCalleeSelfValue(call);
     if (!self)
       return SILValue();
-    owner.pushPathComponent(name, call.getLoc().getSourceLoc());
+    if (cnd.decl)
+      owner.pushPathComponent(cnd.decl, call.getLoc());
+    else
+      owner.pushPathComponent(cnd.name, call.getLoc());
     return self;
   }
 };
@@ -474,8 +490,7 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
     if (auto *use = getAnyDebugUse(searchValue)) {
       if (auto debugVar = DebugVarCarryingInst(use->getUser())) {
         assert(debugVar.getKind() == DebugVarCarryingInst::Kind::DebugValue);
-        pushPathComponent(debugVar.getName(),
-                          searchValue.getLoc().getSourceLoc());
+        pushPathComponent(debugVar.getName(), searchValue.getLoc());
 
         // We return the value, not the debug_info.
         return searchValue;
@@ -498,8 +513,7 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
             if (auto debugVar = DebugVarCarryingInst(debugUse->getUser())) {
               assert(debugVar.getKind() ==
                      DebugVarCarryingInst::Kind::DebugValue);
-              pushPathComponent(debugVar.getName(),
-                                searchValue.getLoc().getSourceLoc());
+              pushPathComponent(debugVar.getName(), searchValue.getLoc());
 
               // We return the value, not the debug_info.
               return searchValue;
@@ -513,8 +527,7 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
       if (auto *debugUse = getAnyDebugUse(bbi)) {
         if (auto debugVar = DebugVarCarryingInst(debugUse->getUser())) {
           assert(debugVar.getKind() == DebugVarCarryingInst::Kind::DebugValue);
-          pushPathComponent(debugVar.getName(),
-                            searchValue.getLoc().getSourceLoc());
+          pushPathComponent(debugVar.getName(), searchValue.getLoc());
 
           // We return the value, not the debug_info.
           return searchValue;
@@ -542,13 +555,12 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
       }
 
       pushPathComponent(DebugVarCarryingInst(allocInst).getName(),
-                        allocInst->getLoc().getSourceLoc());
+                        allocInst->getLoc());
       return allocInst;
     }
 
     if (auto *abi = dyn_cast<AllocBoxInst>(searchValue)) {
-      pushPathComponent(DebugVarCarryingInst(abi).getName(),
-                        abi->getLoc().getSourceLoc());
+      pushPathComponent(DebugVarCarryingInst(abi).getName(), abi->getLoc());
       return abi;
     }
 
@@ -561,7 +573,7 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
 
     if (auto *globalAddrInst = dyn_cast<GlobalAddrInst>(searchValue)) {
       pushPathComponent(VarDeclCarryingInst(globalAddrInst).getName(),
-                        globalAddrInst->getLoc().getSourceLoc());
+                        globalAddrInst->getLoc());
       return globalAddrInst;
     }
 
@@ -571,50 +583,45 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
     }
 
     if (auto *rei = dyn_cast<RefElementAddrInst>(searchValue)) {
-      pushPathComponent(VarDeclCarryingInst(rei).getName(),
-                        rei->getLoc().getSourceLoc());
+      pushPathComponent(rei->getField(), rei->getLoc());
       searchValue = rei->getOperand();
       continue;
     }
 
     if (auto *sei = dyn_cast<StructExtractInst>(searchValue)) {
-      pushPathComponent(getNameFromDecl(sei->getField()),
-                        sei->getLoc().getSourceLoc());
+      pushPathComponent(sei->getField(), sei->getLoc());
       searchValue = sei->getOperand();
       continue;
     }
 
     if (auto *uedi = dyn_cast<UncheckedEnumDataInst>(searchValue)) {
-      pushPathComponent(getNameFromDecl(uedi->getElement()),
-                        uedi->getLoc().getSourceLoc());
+      pushPathComponent(uedi->getElement(), uedi->getLoc());
       searchValue = uedi->getOperand();
       continue;
     }
 
     if (auto *tei = dyn_cast<TupleExtractInst>(searchValue)) {
       pushPathComponent(getStringRefForIndex(tei->getFieldIndex()),
-                        tei->getLoc().getSourceLoc());
+                        tei->getLoc());
       searchValue = tei->getOperand();
       continue;
     }
 
     if (auto *sei = dyn_cast<StructElementAddrInst>(searchValue)) {
-      pushPathComponent(getNameFromDecl(sei->getField()),
-                        sei->getLoc().getSourceLoc());
+      pushPathComponent(sei->getField(), sei->getLoc());
       searchValue = sei->getOperand();
       continue;
     }
 
     if (auto *tei = dyn_cast<TupleElementAddrInst>(searchValue)) {
       pushPathComponent(getStringRefForIndex(tei->getFieldIndex()),
-                        tei->getLoc().getSourceLoc());
+                        tei->getLoc());
       searchValue = tei->getOperand();
       continue;
     }
 
     if (auto *utedai = dyn_cast<UncheckedEnumDataAddrInstBase>(searchValue)) {
-      pushPathComponent(getNameFromDecl(utedai->getElement()),
-                        utedai->getLoc().getSourceLoc());
+      pushPathComponent(utedai->getElement(), utedai->getLoc());
       searchValue = utedai->getEnum();
       continue;
     }
@@ -629,8 +636,7 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
         // inferred name produces confusing diagnostics like
         // "'negotiator.some' cannot be returned".
         if (!e->getType().getOptionalObjectType())
-          pushPathComponent(getNameFromDecl(e->getElement()),
-                            e->getLoc().getSourceLoc());
+          pushPathComponent(e->getElement(), e->getLoc());
         searchValue = e->getOperand();
         continue;
       }
@@ -640,7 +646,7 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
             searchValue->getDefiningInstruction())) {
       pushPathComponent(
           getStringRefForIndex(*dti->getIndexOfResult(searchValue)),
-          dti->getLoc().getSourceLoc());
+          dti->getLoc());
       searchValue = dti->getOperand();
       continue;
     }
@@ -648,16 +654,15 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
     if (auto *dsi = dyn_cast_or_null<DestructureStructInst>(
             searchValue->getDefiningInstruction())) {
       unsigned index = *dsi->getIndexOfResult(searchValue);
-      pushPathComponent(
-          getNameFromDecl(dsi->getStructDecl()->getStoredProperties()[index]),
-          dsi->getLoc().getSourceLoc());
+      pushPathComponent(dsi->getStructDecl()->getStoredProperties()[index],
+                        dsi->getLoc());
       searchValue = dsi->getOperand();
       continue;
     }
 
     if (auto *fArg = dyn_cast<SILFunctionArgument>(searchValue)) {
       if (auto *decl = fArg->getDecl()) {
-        pushPathComponent(decl->getBaseName().userFacingName(), decl->getLoc());
+        pushPathComponent(decl, decl->getLoc());
         return fArg;
       }
     }
@@ -690,8 +695,11 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
       bool isBeginApply = isa<BeginApplyInst>(fas.getInstruction());
       if (isBeginApply ||
           options.contains(Flag::InferSelfThroughAllAccessors)) {
-        if (auto name = namer.getCalleeName(fas); !name.empty()) {
-          pushPathComponent(name, fas.getLoc().getSourceLoc());
+        if (auto cnd = namer.getCalleeNameAndDecl(fas); !cnd.name.empty()) {
+          if (cnd.decl)
+            pushPathComponent(cnd.decl, fas.getLoc());
+          else
+            pushPathComponent(cnd.name, fas.getLoc());
 
           // If there is a self value (directly, or captured by a
           // partial_apply), continue into it to produce 'self.member'.
@@ -740,8 +748,11 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
         // recover the global variable's name from the callee (the addressor's
         // AccessorDecl points back to the VarDecl via getStorage()).
         auto fas = FullApplySite(addressorInvocation);
-        if (auto name = namer.getCalleeName(fas); !name.empty()) {
-          pushPathComponent(name, fas.getLoc().getSourceLoc());
+        if (auto cnd = namer.getCalleeNameAndDecl(fas); !cnd.name.empty()) {
+          if (cnd.decl)
+            pushPathComponent(cnd.decl, fas.getLoc());
+          else
+            pushPathComponent(cnd.name, fas.getLoc());
           return searchValue;
         }
       }
@@ -809,13 +820,27 @@ StringRef VariableNameInferrer::getNameFromDecl(Decl *d) {
   return UnknownDeclString;
 }
 
+StringRef VariableNameInferrer::InferredNameComponent::getStringRef() const {
+  if (auto *str = std::get_if<StringRef>(&subject))
+    return *str;
+  return VariableNameInferrer::getNameFromDecl(std::get<ValueDecl *>(subject));
+}
+
 void VariableNameInferrer::drainVariableNamePath() {
   if (variableNamePath.empty())
     return;
 
+  // The leaf-most component is the first one pushed during the walk (the
+  // deepest projection / the access we started from). Stash its decl so a
+  // post-walk consumer can recover decl-kind-aware info (e.g. to feed
+  // %kind in a diagnostic when the leaf is a function called inline).
+  auto components = variableNamePath.getData();
+  if (auto *d = std::get_if<ValueDecl *>(&components.front().subject))
+    leafDecl = *d;
+
   // Walk backwards, constructing our string.
   while (true) {
-    resultingString += variableNamePath.pop_back_val();
+    resultingString += variableNamePath.pop_back_val().getStringRef();
 
     if (variableNamePath.empty())
       return;
@@ -867,6 +892,22 @@ VariableNameInferrer::inferNameAndFirstPathComponent(SILValue value) {
            inferrer.getFirstNameProvidingLoc()}};
 }
 
+std::optional<VariableNameInferrer::InferredNameAndLeafDecl>
+VariableNameInferrer::inferNameAndLeafDecl(SILValue value) {
+  auto *fn = value->getFunction();
+  if (!fn)
+    return {};
+  VariableNameInferrer::Options options;
+  options |= VariableNameInferrer::Flag::InferSelfThroughAllAccessors;
+  SmallString<64> resultingName;
+  VariableNameInferrer inferrer(fn, options, resultingName);
+  if (!inferrer.inferByWalkingUsesToDefs(value))
+    return {};
+  return InferredNameAndLeafDecl{
+      fn->getASTContext().getIdentifier(resultingName),
+      inferrer.getFirstNameProvidingLoc(), inferrer.getLeafDecl()};
+}
+
 //===----------------------------------------------------------------------===//
 //                                MARK: Tests
 //===----------------------------------------------------------------------===//
@@ -893,5 +934,34 @@ static FunctionTest VariableNameInferrerTests(
         return;
       }
       llvm::outs() << "Name: '" << finalString << "'\nRoot: " << rootValue;
+    });
+
+// Arguments:
+// - SILValue: value to emit a name + leaf decl for.
+// Dumps:
+// - The inferred name
+// - The leaf-most ValueDecl's user-facing base name and descriptive kind,
+//   or "<none>" when the walk landed on a StringRef-only leaf (e.g. a
+//   debug_value's name attribute that didn't carry a decl).
+static FunctionTest VariableNameInferrerLeafDeclTests(
+    "variable_name_inference_leaf_decl",
+    [](auto &function, auto &arguments, auto &test) {
+      auto value = arguments.takeValue();
+      llvm::outs() << "Input Value: " << *value;
+      auto result = VariableNameInferrer::inferNameAndLeafDecl(value);
+      if (!result) {
+        llvm::outs() << "Name: 'unknown'\nLeaf decl: <none>\n";
+        return;
+      }
+      llvm::outs() << "Name: '" << result->name.str() << "'\n";
+      if (result->leafDecl) {
+        auto kind = Decl::getDescriptiveKindName(
+            result->leafDecl->getDescriptiveKind());
+        llvm::outs() << "Leaf decl: '"
+                     << VariableNameInferrer::getNameFromDecl(result->leafDecl)
+                     << "' kind: '" << kind << "'\n";
+      } else {
+        llvm::outs() << "Leaf decl: <none>\n";
+      }
     });
 } // namespace swift::test

--- a/test/SILOptimizer/variable_name_inference.sil
+++ b/test/SILOptimizer/variable_name_inference.sil
@@ -13,6 +13,7 @@ class Klass {
 class ContainsKlass {
   var computedKlass: Klass { get }
   final var klass: Klass
+  func getOtherKlass() -> Klass
 
   init()
 }
@@ -20,6 +21,16 @@ class ContainsKlass {
 struct KlassPair {
   var lhs: Klass
   var rhs: Klass
+}
+
+struct Inner {
+  var a: Klass
+  var b: Klass
+}
+
+struct Outer {
+  var inner: Inner
+  var other: Klass
 }
 
 class KlassWithKlassPair {
@@ -31,6 +42,9 @@ class MyError {}
 class C {}
 
 sil @getKlass : $@convention(thin) () -> @owned Klass
+sil @getPair : $@convention(thin) () -> @owned KlassPair
+sil @getOuter : $@convention(thin) () -> @owned Outer
+sil @getTuple : $@convention(thin) () -> @owned (Klass, Klass)
 sil @getContainsKlass : $@convention(thin) () -> @owned ContainsKlass
 sil @useIndirect : $@convention(thin) <T> (@in_guaranteed T) -> ()
 sil @sideEffect : $@convention(thin) () -> ()
@@ -55,6 +69,11 @@ enum FirstSecondThirdEnum<T> {
 case first
 case second(T)
 case third(FakeOptional<T>)
+}
+
+enum Choice {
+case first
+case second(Klass)
 }
 
 //===----------------------------------------------------------------------===//
@@ -1252,6 +1271,312 @@ bb0:
   destroy_value %6 : $Klass
   end_borrow %4b : $ContainsKlass
   destroy_value %4 : $ContainsKlass
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+//===----------------------------------------------------------------------===//
+//                  MARK: Tests for inferNameAndLeafDecl
+//===----------------------------------------------------------------------===//
+
+// A struct_extract of a stored property pushes the field's VarDecl through
+// the path component. The leaf-most decl on the joined name path is the
+// projected field.
+//
+// CHECK-LABEL: begin running test {{[0-9]+}} of {{[0-9]+}} on test_struct_extract_field: variable_name_inference_leaf_decl with: @trace[0]
+// CHECK: Input Value:   %{{[0-9]+}} = struct_extract %{{[0-9]+}} : $KlassPair, #KlassPair.lhs
+// CHECK: Name: 'kp.lhs'
+// CHECK: Leaf decl: 'lhs'
+// CHECK: end running test {{[0-9]+}} of {{[0-9]+}} on test_struct_extract_field: variable_name_inference_leaf_decl with: @trace[0]
+sil [ossa] @test_struct_extract_field : $@convention(thin) () -> () {
+bb0:
+  specify_test "variable_name_inference_leaf_decl @trace[0]"
+  %0 = function_ref @getPair : $@convention(thin) () -> @owned KlassPair
+  %1 = apply %0() : $@convention(thin) () -> @owned KlassPair
+  debug_value %1 : $KlassPair, let, name "kp"
+  %borrow = begin_borrow %1 : $KlassPair
+  %2 = struct_extract %borrow : $KlassPair, #KlassPair.lhs
+  debug_value [trace] %2 : $Klass
+  end_borrow %borrow : $KlassPair
+  destroy_value %1 : $KlassPair
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// The address-domain projection (struct_element_addr) pushes the same
+// VarDecl, so the leaf decl matches.
+//
+// CHECK-LABEL: begin running test {{[0-9]+}} of {{[0-9]+}} on test_struct_element_addr_field: variable_name_inference_leaf_decl with: @trace[0]
+// CHECK: Input Value:   %{{[0-9]+}} = struct_element_addr %{{[0-9]+}} : $*KlassPair, #KlassPair.rhs
+// CHECK: Name: 'kp.rhs'
+// CHECK: Leaf decl: 'rhs'
+// CHECK: end running test {{[0-9]+}} of {{[0-9]+}} on test_struct_element_addr_field: variable_name_inference_leaf_decl with: @trace[0]
+sil [ossa] @test_struct_element_addr_field : $@convention(thin) () -> () {
+bb0:
+  specify_test "variable_name_inference_leaf_decl @trace[0]"
+  %0 = alloc_stack $KlassPair, var, name "kp"
+  %1 = function_ref @getPair : $@convention(thin) () -> @owned KlassPair
+  %2 = apply %1() : $@convention(thin) () -> @owned KlassPair
+  store %2 to [init] %0 : $*KlassPair
+  %3 = struct_element_addr %0 : $*KlassPair, #KlassPair.rhs
+  debug_value [trace] %3 : $*Klass
+  destroy_addr %0 : $*KlassPair
+  dealloc_stack %0 : $*KlassPair
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// An unchecked_enum_data on a non-Optional enum pushes the case's
+// EnumElementDecl. The leaf decl is that case.
+//
+// CHECK-LABEL: begin running test {{[0-9]+}} of {{[0-9]+}} on test_unchecked_enum_data_case: variable_name_inference_leaf_decl with: @trace[0]
+// CHECK: Input Value:   %{{[0-9]+}} = unchecked_enum_data %{{[0-9]+}} : $Choice, #Choice.second!enumelt
+// CHECK: Name: 'choice.second'
+// CHECK: Leaf decl: 'second'
+// CHECK: end running test {{[0-9]+}} of {{[0-9]+}} on test_unchecked_enum_data_case: variable_name_inference_leaf_decl with: @trace[0]
+sil [ossa] @test_unchecked_enum_data_case : $@convention(thin) () -> () {
+bb0:
+  specify_test "variable_name_inference_leaf_decl @trace[0]"
+  %0 = function_ref @getKlass : $@convention(thin) () -> @owned Klass
+  %1 = apply %0() : $@convention(thin) () -> @owned Klass
+  %2 = enum $Choice, #Choice.second!enumelt, %1 : $Klass
+  debug_value %2 : $Choice, let, name "choice"
+  %3 = unchecked_enum_data %2 : $Choice, #Choice.second!enumelt
+  debug_value [trace] %3 : $Klass
+  destroy_value %3 : $Klass
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// A value whose only naming source is a debug_value `name` attribute
+// carries a StringRef leaf, not a decl. inferNameAndLeafDecl returns a
+// name but no leaf decl.
+//
+// CHECK-LABEL: begin running test {{[0-9]+}} of {{[0-9]+}} on test_debug_value_name_no_leaf_decl: variable_name_inference_leaf_decl with: @trace[0]
+// CHECK: Input Value:   %{{[0-9]+}} = apply %{{[0-9]+}}() : $@convention(thin) () -> @owned Klass
+// CHECK: Name: 'MyName'
+// CHECK: Leaf decl: <none>
+// CHECK: end running test {{[0-9]+}} of {{[0-9]+}} on test_debug_value_name_no_leaf_decl: variable_name_inference_leaf_decl with: @trace[0]
+sil [ossa] @test_debug_value_name_no_leaf_decl : $@convention(thin) () -> () {
+bb0:
+  specify_test "variable_name_inference_leaf_decl @trace[0]"
+  %0 = function_ref @getKlass : $@convention(thin) () -> @owned Klass
+  %1 = apply %0() : $@convention(thin) () -> @owned Klass
+  debug_value [trace] %1 : $Klass
+  debug_value %1 : $Klass, let, name "MyName"
+  destroy_value %1 : $Klass
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// Apply of a class method: CallResultNamer pushes the method's FuncDecl
+// through the path component. The leaf decl is that FuncDecl.
+//
+// CHECK-LABEL: begin running test {{[0-9]+}} of {{[0-9]+}} on test_apply_result_method: variable_name_inference_leaf_decl with: @trace[0]
+// CHECK: Input Value:   %{{[0-9]+}} = apply %{{[0-9]+}}(%{{[0-9]+}}) : $@convention(method) (@guaranteed ContainsKlass) -> @owned Klass
+// CHECK: Name: 'obj.getOtherKlass'
+// CHECK: Leaf decl: 'getOtherKlass'
+// CHECK: end running test {{[0-9]+}} of {{[0-9]+}} on test_apply_result_method: variable_name_inference_leaf_decl with: @trace[0]
+sil [ossa] @test_apply_result_method : $@convention(thin) () -> () {
+bb0:
+  specify_test "variable_name_inference_leaf_decl @trace[0]"
+  %0 = function_ref @getContainsKlass : $@convention(thin) () -> @owned ContainsKlass
+  %1 = apply %0() : $@convention(thin) () -> @owned ContainsKlass
+  debug_value %1 : $ContainsKlass, let, name "obj"
+  %borrow = begin_borrow %1 : $ContainsKlass
+  %method = class_method %borrow : $ContainsKlass, #ContainsKlass.getOtherKlass : (ContainsKlass) -> () -> Klass, $@convention(method) (@guaranteed ContainsKlass) -> @owned Klass
+  %result = apply %method(%borrow) : $@convention(method) (@guaranteed ContainsKlass) -> @owned Klass
+  debug_value [trace] %result : $Klass
+  end_borrow %borrow : $ContainsKlass
+  destroy_value %result : $Klass
+  destroy_value %1 : $ContainsKlass
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// Apply of a computed-property getter: CallResultNamer pushes the
+// AccessorDecl. The leaf decl is that AccessorDecl; the rendered name
+// (via getNameFromDecl) is the storage's user-facing identifier.
+//
+// CHECK-LABEL: begin running test {{[0-9]+}} of {{[0-9]+}} on test_apply_result_computed_property_getter: variable_name_inference_leaf_decl with: @trace[0]
+// CHECK: Input Value:   %{{[0-9]+}} = apply %{{[0-9]+}}(%{{[0-9]+}}) : $@convention(method) (@guaranteed ContainsKlass) -> @owned Klass
+// CHECK: Name: 'obj.computedKlass'
+// CHECK: Leaf decl: 'computedKlass' kind: 'getter' 
+// CHECK: end running test {{[0-9]+}} of {{[0-9]+}} on test_apply_result_computed_property_getter: variable_name_inference_leaf_decl with: @trace[0]
+sil [ossa] @test_apply_result_computed_property_getter : $@convention(thin) () -> () {
+bb0:
+  specify_test "variable_name_inference_leaf_decl @trace[0]"
+  %0 = function_ref @getContainsKlass : $@convention(thin) () -> @owned ContainsKlass
+  %1 = apply %0() : $@convention(thin) () -> @owned ContainsKlass
+  debug_value %1 : $ContainsKlass, let, name "obj"
+  %borrow = begin_borrow %1 : $ContainsKlass
+  %getter = class_method %borrow : $ContainsKlass, #ContainsKlass.computedKlass!getter : (ContainsKlass) -> () -> Klass, $@convention(method) (@guaranteed ContainsKlass) -> @owned Klass
+  %result = apply %getter(%borrow) : $@convention(method) (@guaranteed ContainsKlass) -> @owned Klass
+  debug_value [trace] %result : $Klass
+  end_borrow %borrow : $ContainsKlass
+  destroy_value %result : $Klass
+  destroy_value %1 : $ContainsKlass
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// A chain of struct_extracts reports the *deepest* projection as the leaf
+// decl, not the outermost one: the leaf-most component is the first pushed
+// during the use->def walk. Here the walk sees `.a` before `.inner`, so the
+// leaf decl is 'a' even though the joined name is 'o.inner.a'.
+//
+// CHECK-LABEL: begin running test {{[0-9]+}} of {{[0-9]+}} on test_nested_struct_extract: variable_name_inference_leaf_decl with: @trace[0]
+// CHECK: Input Value:   %{{[0-9]+}} = struct_extract %{{[0-9]+}} : $Inner, #Inner.a
+// CHECK: Name: 'o.inner.a'
+// CHECK: Leaf decl: 'a' kind: 'property'
+// CHECK: end running test {{[0-9]+}} of {{[0-9]+}} on test_nested_struct_extract: variable_name_inference_leaf_decl with: @trace[0]
+sil [ossa] @test_nested_struct_extract : $@convention(thin) () -> () {
+bb0:
+  specify_test "variable_name_inference_leaf_decl @trace[0]"
+  %0 = function_ref @getOuter : $@convention(thin) () -> @owned Outer
+  %1 = apply %0() : $@convention(thin) () -> @owned Outer
+  debug_value %1 : $Outer, let, name "o"
+  %borrow = begin_borrow %1 : $Outer
+  %2 = struct_extract %borrow : $Outer, #Outer.inner
+  %3 = struct_extract %2 : $Inner, #Inner.a
+  debug_value [trace] %3 : $Klass
+  end_borrow %borrow : $Outer
+  destroy_value %1 : $Outer
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// destructure_struct pushes the projected field's VarDecl, matching
+// struct_extract. The leaf decl is that stored property.
+//
+// CHECK-LABEL: begin running test {{[0-9]+}} of {{[0-9]+}} on test_destructure_struct_field: variable_name_inference_leaf_decl with: @trace[0]
+// CHECK: Name: 'kp.lhs'
+// CHECK: Leaf decl: 'lhs' kind: 'property'
+// CHECK: end running test {{[0-9]+}} of {{[0-9]+}} on test_destructure_struct_field: variable_name_inference_leaf_decl with: @trace[0]
+sil [ossa] @test_destructure_struct_field : $@convention(thin) () -> () {
+bb0:
+  specify_test "variable_name_inference_leaf_decl @trace[0]"
+  %0 = function_ref @getPair : $@convention(thin) () -> @owned KlassPair
+  %1 = apply %0() : $@convention(thin) () -> @owned KlassPair
+  debug_value %1 : $KlassPair, let, name "kp"
+  (%lhs, %rhs) = destructure_struct %1 : $KlassPair
+  debug_value [trace] %lhs : $Klass
+  destroy_value %lhs : $Klass
+  destroy_value %rhs : $Klass
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// unchecked_take_enum_data_addr (the address-domain enum projection) pushes
+// the case's EnumElementDecl, matching the unchecked_enum_data value form.
+//
+// CHECK-LABEL: begin running test {{[0-9]+}} of {{[0-9]+}} on test_unchecked_take_enum_data_addr_case: variable_name_inference_leaf_decl with: @trace[0]
+// CHECK: Input Value:   %{{[0-9]+}} = unchecked_take_enum_data_addr %{{[0-9]+}} : $*Choice, #Choice.second!enumelt
+// CHECK: Name: 'choice.second'
+// CHECK: Leaf decl: 'second' kind: 'enum case'
+// CHECK: end running test {{[0-9]+}} of {{[0-9]+}} on test_unchecked_take_enum_data_addr_case: variable_name_inference_leaf_decl with: @trace[0]
+sil [ossa] @test_unchecked_take_enum_data_addr_case : $@convention(thin) () -> () {
+bb0:
+  specify_test "variable_name_inference_leaf_decl @trace[0]"
+  %0 = alloc_stack $Choice, var, name "choice"
+  %1 = function_ref @getKlass : $@convention(thin) () -> @owned Klass
+  %2 = apply %1() : $@convention(thin) () -> @owned Klass
+  %3 = enum $Choice, #Choice.second!enumelt, %2 : $Klass
+  store %3 to [init] %0 : $*Choice
+  %4 = unchecked_take_enum_data_addr %0 : $*Choice, #Choice.second!enumelt
+  debug_value [trace] %4 : $*Klass
+  destroy_addr %4 : $*Klass
+  dealloc_stack %0 : $*Choice
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// A tuple projection names the component by positional index, which is a
+// bare StringRef (not a decl). inferNameAndLeafDecl returns the name but no
+// leaf decl.
+//
+// CHECK-LABEL: begin running test {{[0-9]+}} of {{[0-9]+}} on test_tuple_extract_index_no_leaf_decl: variable_name_inference_leaf_decl with: @trace[0]
+// CHECK: Input Value:   %{{[0-9]+}} = tuple_extract %{{[0-9]+}} : $(Klass, Klass), 1
+// CHECK: Name: 'pair.1'
+// CHECK: Leaf decl: <none>
+// CHECK: end running test {{[0-9]+}} of {{[0-9]+}} on test_tuple_extract_index_no_leaf_decl: variable_name_inference_leaf_decl with: @trace[0]
+sil [ossa] @test_tuple_extract_index_no_leaf_decl : $@convention(thin) () -> () {
+bb0:
+  specify_test "variable_name_inference_leaf_decl @trace[0]"
+  %0 = function_ref @getTuple : $@convention(thin) () -> @owned (Klass, Klass)
+  %1 = apply %0() : $@convention(thin) () -> @owned (Klass, Klass)
+  debug_value %1 : $(Klass, Klass), let, name "pair"
+  %borrow = begin_borrow %1 : $(Klass, Klass)
+  %2 = tuple_extract %borrow : $(Klass, Klass), 1
+  debug_value [trace] %2 : $Klass
+  end_borrow %borrow : $(Klass, Klass)
+  destroy_value %1 : $(Klass, Klass)
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// ref_element_addr (a class stored-property projection) pushes the field's
+// VarDecl, matching struct_extract/struct_element_addr on a struct stored
+// property. The joined name is unchanged; the leaf decl is that property.
+//
+// CHECK-LABEL: begin running test {{[0-9]+}} of {{[0-9]+}} on test_ref_element_addr_field: variable_name_inference_leaf_decl with: @trace[0]
+// CHECK: Input Value:   %{{[0-9]+}} = ref_element_addr %{{[0-9]+}} : $ContainsKlass, #ContainsKlass.klass
+// CHECK: Name: 'obj.klass'
+// CHECK: Leaf decl: 'klass' kind: 'property'
+// CHECK: end running test {{[0-9]+}} of {{[0-9]+}} on test_ref_element_addr_field: variable_name_inference_leaf_decl with: @trace[0]
+sil [ossa] @test_ref_element_addr_field : $@convention(thin) () -> () {
+bb0:
+  specify_test "variable_name_inference_leaf_decl @trace[0]"
+  %0 = function_ref @getContainsKlass : $@convention(thin) () -> @owned ContainsKlass
+  %1 = apply %0() : $@convention(thin) () -> @owned ContainsKlass
+  debug_value %1 : $ContainsKlass, let, name "obj"
+  %borrow = begin_borrow %1 : $ContainsKlass
+  %2 = ref_element_addr %borrow : $ContainsKlass, #ContainsKlass.klass
+  debug_value [trace] %2 : $*Klass
+  end_borrow %borrow : $ContainsKlass
+  destroy_value %1 : $ContainsKlass
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// A value named only by an alloc_stack's var decl carries a StringRef leaf,
+// so there is a name but no leaf decl.
+//
+// CHECK-LABEL: begin running test {{[0-9]+}} of {{[0-9]+}} on test_alloc_stack_no_leaf_decl: variable_name_inference_leaf_decl with: @trace[0]
+// CHECK: Name: 'localVar'
+// CHECK: Leaf decl: <none>
+// CHECK: end running test {{[0-9]+}} of {{[0-9]+}} on test_alloc_stack_no_leaf_decl: variable_name_inference_leaf_decl with: @trace[0]
+sil [ossa] @test_alloc_stack_no_leaf_decl : $@convention(thin) () -> () {
+bb0:
+  specify_test "variable_name_inference_leaf_decl @trace[0]"
+  %0 = alloc_stack $Klass, var, name "localVar"
+  %1 = function_ref @getKlass : $@convention(thin) () -> @owned Klass
+  %2 = apply %1() : $@convention(thin) () -> @owned Klass
+  store %2 to [init] %0 : $*Klass
+  debug_value [trace] %0 : $*Klass
+  destroy_addr %0 : $*Klass
+  dealloc_stack %0 : $*Klass
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// An apply of a direct free-function callee names the result after the
+// callee. Here the callee `getKlass` is a SIL-only declaration with no AST
+// decl, so getCalleeNameAndDecl yields a SIL function name but a null decl:
+// the name is 'getKlass' and there is no leaf decl.
+//
+// CHECK-LABEL: begin running test {{[0-9]+}} of {{[0-9]+}} on test_sil_only_callee_no_leaf_decl: variable_name_inference_leaf_decl with: @trace[0]
+// CHECK: Input Value:   %{{[0-9]+}} = apply %{{[0-9]+}}() : $@convention(thin) () -> @owned Klass
+// CHECK: Name: 'getKlass'
+// CHECK: Leaf decl: <none>
+// CHECK: end running test {{[0-9]+}} of {{[0-9]+}} on test_sil_only_callee_no_leaf_decl: variable_name_inference_leaf_decl with: @trace[0]
+sil [ossa] @test_sil_only_callee_no_leaf_decl : $@convention(thin) () -> () {
+bb0:
+  specify_test "variable_name_inference_leaf_decl @trace[0]"
+  %0 = function_ref @getKlass : $@convention(thin) () -> @owned Klass
+  %1 = apply %0() : $@convention(thin) () -> @owned Klass
+  debug_value [trace] %1 : $Klass
+  destroy_value %1 : $Klass
   %9999 = tuple ()
   return %9999 : $()
 }


### PR DESCRIPTION
Diagnostic consumers that want to know whether a name component came from a decl — e.g. to feed %kind for a function called inline rather than printing the function's basename as if it were a bare value identifier — previously had no way to recover that. The inferrer's path array stored bare StringRefs, which only carry a textual rendering.

Wrap each component as an InferredNameComponent { variant<StringRef, ValueDecl *> subject; SourceLoc providingLoc; }. When the path walk lands on a decl-bearing source — apply callee, struct field, enum case, SIL function argument — it now pushes the ValueDecl* through the component rather than pre-extracting the decl's text. drainVariableNamePath renders either alternative through a getStringRef() helper and captures the leaf-most decl as the path is consumed, and inferNameAndLeafDecl() surfaces that decl to decl-kind-aware consumers.

Output of the existing string-only callers is unchanged.
