### PR TITLE
:cherries: [6.4] [cxx-interop] Ensure CXXRecordDecl has definition when checking isSwiftClass

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8367,7 +8367,9 @@ static bool isSwiftClassType(const clang::CXXRecordDecl *decl) {
     return false;
 
   // Ensure that the baseclass is swift::RefCountedClass.
-  auto baseDecl = decl;
+  auto baseDecl = decl->getDefinition();
+  if (!baseDecl)
+    return false;
   do {
     if (baseDecl->getNumBases() != 1)
       return false;
@@ -8376,7 +8378,9 @@ static bool isSwiftClassType(const clang::CXXRecordDecl *decl) {
     auto nextBaseDecl = Ty->getAsCXXRecordDecl();
     if (!nextBaseDecl)
       return false;
-    baseDecl = nextBaseDecl;
+    baseDecl = nextBaseDecl->getDefinition();
+    if (!baseDecl)
+      return false;
   } while (baseDecl->getName() != "RefCountedClass");
 
   return true;

--- a/test/Interop/SwiftToCxxToSwift/swift-class-type-with-unreachable-definition.swift
+++ b/test/Interop/SwiftToCxxToSwift/swift-class-type-with-unreachable-definition.swift
@@ -1,0 +1,42 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// This test guards against a compiler crash that occurred when importing
+// a Swift-generated C++ module in which a method returns a Swift type whose
+// definition isn't reachable (only forward-declared) at the import site.
+
+// RUN: %target-swift-frontend -typecheck %t/use.swift \
+// RUN:   -I %t/Inputs -cxx-interoperability-mode=default \
+// RUN:   -disable-availability-checking
+
+//--- Inputs/module.modulemap
+module CxxModule {
+    header "CxxModule.h"
+    requires cplusplus
+}
+
+//--- Inputs/CxxModule.h
+#pragma once
+
+// Mimic the `external_source_symbol` annotation that the Swift->C++ header
+// generator applies to C++ declarations representing Swift declarations.
+#if __has_attribute(external_source_symbol)
+#define SWIFT_SYMBOL(usrValue)                                                 \
+  __attribute__((external_source_symbol(language = "Swift",                    \
+                                        defined_in = "SwiftModule",            \
+                                        generated_declaration, USR = usrValue)))
+#else
+#define SWIFT_SYMBOL(usrValue)
+#endif
+
+// A type that is annotated as a Swift class type but whose definition is
+// unreachable here: it is only forward-declared.
+class SWIFT_SYMBOL("s:11SwiftModule10SwiftClassC") SwiftClass;
+
+class Container {
+public:
+  SwiftClass getSC();
+};
+
+//--- use.swift
+import CxxModule


### PR DESCRIPTION
- **Explanation**: The C++ record definition is required to walk its class inheritance hierarchy in isSwiftClass. Not doing so leads to crash in getNumBases(), since that dereferences the (null) definition data.
- **Scope**: Swift->C++->Swift interop
- **Issues**: rdar://181173830
- **Original PRs**: https://github.com/swiftlang/swift/pull/90534
- **Risk**: Low. This just adds a check that prevents a crash.
- **Testing**: Regression test included.
- **Reviewers**: @Xazax-hun 