### PR TITLE
Don't forward begin_apply yield addresses past end_apply while transforming large loadable types

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -4396,9 +4396,11 @@ protected:
   }
 
   void visitLoadInst(LoadInst *load) {
+    auto *defInst = load->getOperand()->getDefiningInstruction();
     // Forward the address of the load if its sole user immediately follows the
-    // load instructions.
-    if (isSoleUserOf(load, &*++load->getIterator())) {
+    // load instructions and if it was not the result of a coroutine.
+    if (isSoleUserOf(load, &*++load->getIterator()) &&
+        (!defInst || !isa<BeginApplyInst>(defInst))) {
       assignment.markForDeletion(load);
       assignment.mapValueToAddress(origValue, load->getOperand());
       return;

--- a/test/IRGen/big_types.sil
+++ b/test/IRGen/big_types.sil
@@ -80,14 +80,17 @@ unwind:
 // CHECK-LABEL: sil @use_yield_big : $@convention(thin) () -> () {
 // CHECK:       bb0:
 // CHECK-NEXT:    [[TEMP:%.*]] = alloc_stack $BigStruct
+// CHECK-NEXT:    [[TEMP2:%.*]] = alloc_stack $BigStruct
 // CHECK-NEXT:    // function_ref
 // CHECK-NEXT:    [[CORO:%.*]] = function_ref @test_yield_big : $@yield_once @convention(thin) () -> @yields @in_guaranteed BigStruct
 // CHECK-NEXT:    ([[ADDR:%.*]], [[TOKEN:%.*]]) = begin_apply [[CORO]]()
-// CHECK-NEXT:   copy_addr [take] [[ADDR]] to [init] [[TEMP]] : $*BigStruct
+// CHECK-NEXT:    copy_addr [take] [[ADDR]] to [init] [[TEMP]] : $*BigStruct
+// CHECK-NEXT:    copy_addr [take] [[TEMP]] to [init] [[TEMP2]] : $*BigStruct
 // CHECK-NEXT:    // function_ref
 // CHECK-NEXT:    [[USE:%.*]] = function_ref @use_big_struct : $@convention(thin) (@in_guaranteed BigStruct) -> ()
-// CHECK-NEXT:    apply [[USE]]([[TEMP]])
+// CHECK-NEXT:    apply [[USE]]([[TEMP2]])
 // CHECK-NEXT:    [[RET:%.*]] = end_apply [[TOKEN]] as $()
+// CHECK-NEXT:    dealloc_stack [[TEMP2]] : $*BigStruct
 // CHECK-NEXT:    dealloc_stack [[TEMP]] : $*BigStruct
 // CHECK-NEXT:    return [[RET]] : $()
 sil @use_yield_big : $@convention(thin) () -> () {

--- a/test/IRGen/loadable_by_address_reg2mem.sil
+++ b/test/IRGen/loadable_by_address_reg2mem.sil
@@ -463,3 +463,39 @@ bb2(%7 : $X):
   %13 = tuple ()
   return %13 : $()
 }
+
+struct Big {
+  var x: Int
+  var p: (Int, Int, Int, Int, Int, Int, Int)
+}
+
+struct W {
+  var inner: Big
+}
+
+sil @read_w : $@yield_once @convention(thin) () -> @yields W
+sil @use_big : $@convention(thin) (@in_guaranteed Big) -> ()
+
+// CHECK-LABEL: sil @test_yield_struct_extract
+// CHECK:         [[STK:%.*]] = alloc_stack $W
+// CHECK:         ([[YIELD:%.*]], [[TOKEN:%.*]]) = begin_apply
+// CHECK:         copy_addr [take] [[YIELD]] to [init] [[STK]]
+// CHECK:         struct_element_addr [[STK]]
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:       } // end sil function 'test_yield_struct_extract'
+
+sil @test_yield_struct_extract : $@convention(thin) () -> () {
+bb0:
+  %read = function_ref @read_w : $@yield_once @convention(thin) () -> @yields W
+  (%w, %token) = begin_apply %read() : $@yield_once @convention(thin) () -> @yields W
+  %inner = struct_extract %w, #W.inner
+  %end = end_apply %token as $()
+  %stack = alloc_stack $Big
+  store %inner to %stack : $*Big
+  %use = function_ref @use_big : $@convention(thin) (@in_guaranteed Big) -> ()
+  apply %use(%stack) : $@convention(thin) (@in_guaranteed Big) -> ()
+  dealloc_stack %stack : $*Big
+  %ret = tuple ()
+  return %ret : $()
+}
+


### PR DESCRIPTION
The reg2mem phase of LoadableByAddress has an optimization that forwards a load's source address directly to its user, avoiding a copy. This is unsafe when the source address is a begin_apply yield result, because the yielded address is only valid until end_apply and forwarding it can cause use-after-free.

Skip the forwarding optimization when the load operand is defined by a BeginApplyInst, forcing the copy_addr path which copies the data into a local alloc_stack before end_apply invalidates the coroutine frame.

Fixes rdar://179248073 and https://github.com/swiftlang/swift/issues/89836

