### PR TITLE
stdlib: unwrap `std{in,out,err}` via the CPP

### DIFF
--- a/stdlib/public/Platform/Platform.swift
+++ b/stdlib/public/Platform/Platform.swift
@@ -79,15 +79,15 @@ public var stdout: OpaquePointer { return OpaquePointer(_swift_stdlib_stdout()) 
 public var stderr: OpaquePointer { return OpaquePointer(_swift_stdlib_stderr()) }
 #elseif os(Windows)
 public var stdin: UnsafeMutablePointer<FILE> {
-  return unsafe __acrt_iob_func(0)
+  return _swift_stdlib_stdin()
 }
 
 public var stdout: UnsafeMutablePointer<FILE> {
-  return unsafe __acrt_iob_func(1)
+  return _swift_stdlib_stdout()
 }
 
 public var stderr: UnsafeMutablePointer<FILE> {
-  return unsafe __acrt_iob_func(2)
+  return _swift_stdlib_stderr()
 }
 
 public var STDIN_FILENO: Int32 {

--- a/stdlib/public/SwiftShims/swift/shims/LibcOverlayShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/LibcOverlayShims.h
@@ -134,6 +134,20 @@ static inline void *_swift_stdlib_stderr(void) {
 }
 #endif
 
+#if defined(_WIN32)
+static inline FILE *_swift_stdlib_stdin(void) {
+  return stdin;
+}
+
+static inline FILE *_swift_stdlib_stdout(void) {
+  return stdout;
+}
+
+static inline FILE *_swift_stdlib_stderr(void) {
+  return stderr;
+}
+#endif
+
 #if __has_feature(nullability)
 #pragma clang assume_nonnull end
 #endif


### PR DESCRIPTION
Rather than rewriting the macro expansion manually, add a small shim to unwrap the "complex" macro until such time that the ClangImporter is able to import them.