### PR TITLE
[6.4] CrossModuleOptimization: disable CMO for functions with opaque result types

### DIFF
--- a/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
+++ b/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
@@ -536,6 +536,14 @@ bool CrossModuleOptimization::canSerializeFunction(
   if (!function->isDefinition() || function->isAvailableExternally())
     return false;
 
+  CanSILFunctionType fnTy = function->getLoweredFunctionType();
+  for (auto &result : fnTy->getResults()) {
+    if (result.getInterfaceType()->hasOpaqueArchetype()) {
+      // We don't support functions with opaque result types, yet.
+      return false;
+    }
+  }
+
   // Avoid a stack overflow in case of a very deeply nested call graph.
   if (maxDepth <= 0)
     return false;
@@ -564,7 +572,7 @@ bool CrossModuleOptimization::canSerializeFunction(
   if (!conservative) {
     // The basic heuristic: serialize all generic functions, because it makes a
     // huge difference if generic functions can be specialized or not.
-    if (function->getLoweredFunctionType()->isPolymorphic())
+    if (fnTy->isPolymorphic())
       skipSizeLimitCheck = true;
     if (function->getLinkage() == SILLinkage::Shared)
       skipSizeLimitCheck = true;

--- a/test/SILOptimizer/cmo_and_opaque_result_types.swift
+++ b/test/SILOptimizer/cmo_and_opaque_result_types.swift
@@ -1,0 +1,24 @@
+// RUN: %target-swift-frontend -emit-sil -o /dev/null %s -O -cross-module-optimization -sil-verify-all
+
+// REQUIRES: OS=macosx
+
+import SwiftUI
+
+public struct Stroke {}
+
+public struct AnyInsettableShape: InsettableShape {
+  public func path(in rect: CGRect) -> Path { Path() }
+  public func inset(by amount: CGFloat) -> some InsettableShape { self }
+}
+
+private struct StrokeModifier<S>: ViewModifier {
+  var stroke: Stroke
+  var shape: S
+  func body(content: Content) -> some View {}
+}
+
+extension View {
+  public func stroke(_ stroke: Stroke, shape: InsettableShape) -> some View {
+    modifier(StrokeModifier(stroke: stroke, shape: shape))
+  }
+}


### PR DESCRIPTION
* **Explanation**: Fixes a compiler crash. After setting the "serialized" flag on functions with opaque result types, the type gets lowered differently and the SILVerifier complains about mismatching types for function arguments.
* **Risk**: Low. It's a small change which makes cross-module-optimization more conservative 
* **Testing**: by lit tests
* **Issue**: https://github.com/swiftlang/swift/issues/90373, rdar://181277383
* **Reviewers**: @jckarter
* **Main branch PR**: https://github.com/swiftlang/swift/pull/90535
