### PR TITLE
[cxx-interop] Emit lvalue-to-rvalue conversion in synthesized bit-field getter

### DIFF
--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -1107,11 +1107,14 @@ std::pair<FuncDecl *, FuncDecl *> SwiftDeclSynthesizer::makeBitFieldAccessors(
     cGetterDecl->setParams(cGetterSelf);
 
     auto cGetterSelfExpr =
-        createClangDeclRefExpr(Ctx, cGetterSelf, recordType);
-    auto cGetterExpr = clang::MemberExpr::CreateImplicit(
+        createClangDeclRefExpr(Ctx, cGetterSelf, recordType, clang::VK_LValue);
+    auto cGetterMemberExpr = clang::MemberExpr::CreateImplicit(
         Ctx, cGetterSelfExpr,
-        /*isarrow=*/false, fieldDecl, fieldType, clang::VK_PRValue,
+        /*isarrow=*/false, fieldDecl, fieldType, clang::VK_LValue,
         clang::OK_BitField);
+    auto cGetterExpr = clang::ImplicitCastExpr::Create(
+        Ctx, fieldType, clang::CK_LValueToRValue, cGetterMemberExpr,
+        /*BasePath=*/nullptr, clang::VK_PRValue, clang::FPOptionsOverride());
 
     cGetterDecl->setBody(createClangReturnStmt(Ctx, cGetterExpr));
   }

--- a/test/Interop/Cxx/class/Inputs/bit-fields.h
+++ b/test/Interop/Cxx/class/Inputs/bit-fields.h
@@ -1,0 +1,10 @@
+#ifndef TEST_INTEROP_CXX_CLASS_INPUTS_BIT_FIELDS_H
+#define TEST_INTEROP_CXX_CLASS_INPUTS_BIT_FIELDS_H
+
+struct BitFields {
+  unsigned a : 3;
+  unsigned b : 5;
+  unsigned c : 24;
+};
+
+#endif // TEST_INTEROP_CXX_CLASS_INPUTS_BIT_FIELDS_H

--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -194,3 +194,8 @@ module NoncopyableNonmovableGlobal {
   header "noncopyable-nonmovable-global.h"
   requires cplusplus
 }
+
+module BitFields {
+  header "bit-fields.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/class/bitfield-execution.swift
+++ b/test/Interop/Cxx/class/bitfield-execution.swift
@@ -1,0 +1,40 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -cxx-interoperability-mode=default)
+//
+// REQUIRES: executable_test
+
+import BitFields
+import StdlibUnittest
+
+var BitFieldsTestSuite = TestSuite("BitFields")
+
+BitFieldsTestSuite.test("round-trip through synthesized accessors") {
+  var s = BitFields()
+  s.a = 5
+  s.b = 20
+  s.c = 1_000
+  expectEqual(5, s.a)
+  expectEqual(20, s.b)
+  expectEqual(1_000, s.c)
+}
+
+BitFieldsTestSuite.test("setter truncates to the field width") {
+  var s = BitFields()
+  // `a` is 3 bits wide, so only the low 3 bits are stored.
+  s.a = 0xF
+  expectEqual(0x7, s.a)
+  // `b` is 5 bits wide.
+  s.b = 0xFF
+  expectEqual(0x1F, s.b)
+}
+
+BitFieldsTestSuite.test("adjacent fields are independent") {
+  var s = BitFields()
+  s.a = 0x7
+  s.b = 0x1F
+  s.c = 0
+  expectEqual(0x7, s.a)
+  expectEqual(0x1F, s.b)
+  expectEqual(0, s.c)
+}
+
+runAllTests()

--- a/test/Interop/Cxx/class/bitfield-irgen.swift
+++ b/test/Interop/Cxx/class/bitfield-irgen.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -cxx-interoperability-mode=default -disable-llvm-optzns -O | %FileCheck %s
+
+import BitFields
+
+public func readB(_ s: BitFields) -> UInt32 {
+  return s.b
+}
+
+public func writeB(_ s: inout BitFields, _ v: UInt32) {
+  s.b = v
+}
+
+// CHECK: define {{.*}}$So9BitFieldsV$b$getter
+// CHECK: define {{.*}}$So9BitFieldsV$b$setter

--- a/test/Interop/Cxx/class/bitfield-module-interface.swift
+++ b/test/Interop/Cxx/class/bitfield-module-interface.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=BitFields -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default | %FileCheck %s
+
+// Bit-fields are imported as computed properties backed by synthesized
+// getters and setters.
+
+// CHECK:      struct BitFields {
+// CHECK-NEXT:   init(a: UInt32, b: UInt32, c: UInt32)
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   var a: UInt32
+// CHECK-NEXT:   var b: UInt32
+// CHECK-NEXT:   var c: UInt32
+// CHECK-NEXT: }

--- a/test/Interop/Cxx/class/bitfield-typechecker.swift
+++ b/test/Interop/Cxx/class/bitfield-typechecker.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default
+
+import BitFields
+
+func read(_ s: BitFields) -> UInt32 {
+  return s.a + s.b + s.c
+}
+
+func write(_ s: inout BitFields) {
+  s.a = 1
+  s.b = 2
+  s.c = 3
+}


### PR DESCRIPTION
The getter body previously read the member as a prvalue, which tripped Clang's C++11 constant evaluator assertion and crashed swift-frontend when IR-generating bit-field accessors under -cxx-interoperability-mode.

rdar://158308810