### PR TITLE
[cxx-interop] Register synthesized C++ default-argument thunks in lookup table

### DIFF
--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -204,6 +204,26 @@ public:
   /// Imports a clang decl directly, rather than looking up its name.
   virtual Decl *importDeclDirectly(const clang::NamedDecl *decl) = 0;
 
+  /// Register a Clang declaration synthesized by the importer so that it is
+  /// discoverable by Swift name lookup and so that it can be resolved when
+  /// a cross-reference to it is deserialized (e.g., during SIL cross-module
+  /// optimization).
+  ///
+  /// Declarations are added to the SwiftLookupTable for the \a anchorDecl
+  /// as well as the one for its owning module, to handle the case where a C++
+  /// namespace spans across multiple Clang modules.
+  ///
+  /// Also mark \a synthesizedDecl as always-visible.
+  ///
+  /// \param synthesizedDecl The synthesized Clang function to register.
+  /// \param anchorDecl The Clang declaration whose SwiftLookupTable(s)
+  /// the declaration should be registered in. Pass the enclosing record for a
+  /// synthesized member, or \p synthesizedDecl itself for a translation-unit
+  /// -level thunk.
+  virtual void
+  registerSynthesizedClangDecl(clang::FunctionDecl *synthesizedDecl,
+                               const clang::Decl *anchorDecl) = 0;
+
   /// Returns a decl that was imported earlier or null if it was not found in
   /// the cache.
   virtual Decl *lookupImportedDecl(const clang::NamedDecl *decl) = 0;

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -690,6 +690,9 @@ public:
   /// Imports a clang decl directly, rather than looking up it's name.
   Decl *importDeclDirectly(const clang::NamedDecl *decl) override;
 
+  void registerSynthesizedClangDecl(clang::FunctionDecl *synthesizedDecl,
+                                    const clang::Decl *anchorDecl) override;
+
   /// Returns a decl that was imported earlier or null if it was not found in
   /// the cache.
   virtual Decl *lookupImportedDecl(const clang::NamedDecl *decl) override;

--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -401,23 +401,6 @@ static FuncDecl *getPlusEqualOperator(NominalTypeDecl *decl) {
   return dyn_cast_or_null<FuncDecl>(result);
 }
 
-/// Register a synthesized declaration in the lookup tables and mark it as
-/// always visible. Declarations are added to two lookup tables (the one for
-/// the record's context and the one for its owning module) to handle the case
-/// where a C++ namespace spans across multiple Clang modules.
-static void registerSynthesizedDecl(ClangImporter::Implementation &impl,
-                                    const clang::CXXRecordDecl *classDecl,
-                                    clang::FunctionDecl *decl) {
-  impl.synthesizedAndAlwaysVisibleDecls.insert(decl);
-  auto *lookupTable1 = impl.findLookupTable(classDecl);
-  addEntryToLookupTable(*lookupTable1, decl, impl.getNameImporter());
-  auto *owningModule =
-      importer::getClangOwningModule(classDecl, classDecl->getASTContext());
-  auto *lookupTable2 = impl.findLookupTable(owningModule);
-  if (lookupTable1 != lookupTable2)
-    addEntryToLookupTable(*lookupTable2, decl, impl.getNameImporter());
-}
-
 static clang::FunctionDecl *
 instantiateTemplatedOperator(ClangImporter::Implementation &impl,
                              const clang::CXXRecordDecl *classDecl,
@@ -446,7 +429,7 @@ instantiateTemplatedOperator(ClangImporter::Implementation &impl,
                                           best)) {
   case clang::OR_Success: {
     if (auto clangCallee = best->Function) {
-      registerSynthesizedDecl(impl, classDecl, clangCallee);
+      impl.registerSynthesizedClangDecl(clangCallee, classDecl);
       return clangCallee;
     }
     break;
@@ -532,7 +515,7 @@ static bool synthesizeCXXOperator(ClangImporter::Implementation &impl,
 
   equalEqualDecl->setBody(createClangReturnStmt(clangCtx, underlyingCall));
 
-  registerSynthesizedDecl(impl, classDecl, equalEqualDecl);
+  impl.registerSynthesizedClangDecl(equalEqualDecl, classDecl);
   return true;
 }
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5074,6 +5074,26 @@ ClangImporter::Implementation::findLookupTable(const clang::Decl *decl) {
   return findLookupTable(owningModule);
 }
 
+void ClangImporter::Implementation::registerSynthesizedClangDecl(
+    clang::FunctionDecl *synthesizedDecl, const clang::Decl *anchorDecl) {
+  synthesizedAndAlwaysVisibleDecls.insert(synthesizedDecl);
+
+  auto *contextTable = findLookupTable(anchorDecl);
+  if (contextTable)
+    addEntryToLookupTable(*contextTable, synthesizedDecl, getNameImporter());
+
+  auto *owningModule =
+      importer::getClangOwningModule(anchorDecl, anchorDecl->getASTContext());
+  auto *moduleTable = findLookupTable(owningModule);
+  if (moduleTable && moduleTable != contextTable)
+    addEntryToLookupTable(*moduleTable, synthesizedDecl, getNameImporter());
+}
+
+void ClangImporter::registerSynthesizedClangDecl(
+    clang::FunctionDecl *synthesizedDecl, const clang::Decl *anchorDecl) {
+  Impl.registerSynthesizedClangDecl(synthesizedDecl, anchorDecl);
+}
+
 bool ClangImporter::Implementation::forEachLookupTable(
        llvm::function_ref<bool(SwiftLookupTable &table)> fn) {
   // Visit the bridging header's lookup table.

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1908,6 +1908,14 @@ public:
   /// Find the lookup table that should contain the given Clang declaration.
   SwiftLookupTable *findLookupTable(const clang::Decl *decl);
 
+  /// Register a Clang declaration synthesized by the importer so that it is
+  /// discoverable by Swift name lookup and resolvable when a cross-reference
+  /// to it is deserialized. Marks it always-visible and adds it to the lookup
+  /// table(s) for \p anchorDecl (and its owning module, to handle
+  /// namespace-spanning C++ declarations).
+  void registerSynthesizedClangDecl(clang::FunctionDecl *synthesizedDecl,
+                                    const clang::Decl *anchorDecl);
+
   /// Visit each of the lookup tables in some deterministic order.
   ///
   /// \param fn Invoke the given visitor for each table. If the

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -2650,6 +2650,9 @@ synthesizeDefaultArgumentBody(AbstractFunctionDecl *afd, void *context) {
   defaultArgFuncDecl->setAccess(clang::AccessSpecifier::AS_public);
   defaultArgFuncDecl->setBody(defaultArgReturnStmt);
 
+  ctx.getClangModuleLoader()->registerSynthesizedClangDecl(defaultArgFuncDecl,
+                                                           defaultArgFuncDecl);
+
   // Import `func __cxx__defaultArg_XYZ() -> ParamTY` into Swift.
   auto defaultArgGenerator = dyn_cast_or_null<FuncDecl>(
       ctx.getClangModuleLoader()->importDeclDirectly(defaultArgFuncDecl));

--- a/test/Interop/Cxx/function/default-argument-cross-module-cmo-crash.swift
+++ b/test/Interop/Cxx/function/default-argument-cross-module-cmo-crash.swift
@@ -1,0 +1,54 @@
+// Reproducer for a SIL cross-module deserialization crash with C++ interop.
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// Producer: build Lib.swiftmodule with C++ interop and default CMO so that the
+// synthesized C++ default-argument thunk is serialized into its SIL.
+// RUN: %target-build-swift -O -wmo -Xfrontend -enable-default-cmo \
+// RUN:   -cxx-interoperability-mode=default -parse-as-library \
+// RUN:   -emit-module -emit-module-path %t/Lib.swiftmodule -module-name Lib \
+// RUN:   -I %t/Inputs %t/Lib.swift -c -o %t/lib.o
+
+// Consumer: compiling Main synthesizes the same thunk and, via
+// MandatorySILLinker, must deserialize Lib's serialized copy of it.
+// RUN: %target-build-swift -O -wmo -Xfrontend -enable-default-cmo \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   -module-name Main -I %t -I %t/Inputs %t/Main.swift -emit-sil
+
+//--- Inputs/module.modulemap
+module CxxLib {
+  header "cxxlib.h"
+  requires cplusplus
+  export *
+}
+
+//--- Inputs/cxxlib.h
+#pragma once
+
+// A free C++ function with a single defaulted parameter. Omitting `m` at a
+// Swift callsite triggers synthesis of __cxx__defaultArg_0__Z4make...
+inline int make(int m = 0) {
+  (void)m;
+  return 0;
+}
+
+//--- Lib.swift
+import CxxLib
+
+// Omitting the default synthesizes the thunk. With default CMO this function's
+// SIL (referencing the thunk, whose parent is recorded as __ObjC) is serialized
+// into Lib.swiftmodule.
+public func go() -> Int32 {
+  return make()
+}
+
+//--- Main.swift
+import CxxLib
+import Lib
+
+// Main does not reference anything in Lib; importing Lib loads its serialized
+// thunk body, and calling make() here synthesizes the same thunk symbol.
+public func run() -> Int32 {
+  return make()
+}


### PR DESCRIPTION
The importer synthesizes a `__cxx__defaultArg_*` thunk (parented to the
Clang TU) for defaulted C++ parameters. Under default CMO, producer SIL
cross-references it with parent module `__ObjC`. Since the thunk was
never added to a SwiftLookupTable, a consumer deserializing that SIL
couldn't resolve the xref and crashed. Register it at synthesis time via
registerSynthesizedClangDecl, as is already done for operators like `==`.

rdar://178264621