### PR TITLE
[update-checkout][test] Several utils/update_checkout/tests/test_cross_repo_pr.py tests request commit signing

### DIFF
--- a/utils/update_checkout/run_tests.py
+++ b/utils/update_checkout/run_tests.py
@@ -15,6 +15,7 @@ Small script used to easily run the update_checkout module unit tests.
 
 import os
 import shutil
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -31,6 +32,25 @@ if __name__ == "__main__":
     # Create temp directory and export it for the test suite.
     temp_dir = tempfile.mkdtemp()
     os.environ["UPDATE_CHECKOUT_TEST_SUITE_ARENA"] = temp_dir
+
+    # Configure a deterministic local git identity and disable commit signing
+    # for all clones.
+    #
+    # update-checkout's own clones (under `source_root`) do not set these up, so a
+    # test that commits into such a clone needs this to happen first; otherwise the
+    # commit depends on an ambient global identity, which is absent on a pristine
+    # CI worker, and aborts.
+    os.environ["GIT_CONFIG_SYSTEM"] = os.devnull
+    os.environ["GIT_CONFIG_GLOBAL"] = os.path.join(temp_dir, ".gitconfig")
+    subprocess.run(
+        ["git", "config", "--global", "user.name", "swift_test"], check=True
+    )
+    subprocess.run(
+        ["git", "config", "--global", "user.email", "no-reply@swift.org"], check=True
+    )
+    subprocess.run(
+        ["git", "config", "--global", "commit.gpgsign", "false"], check=True
+    )
 
     # Discover all tests for the module.
     module_tests = unittest.defaultTestLoader.discover(MODULE_DIR)

--- a/utils/update_checkout/tests/scheme_mock.py
+++ b/utils/update_checkout/tests/scheme_mock.py
@@ -147,28 +147,6 @@ def get_path_from_url(url: str) -> str:
     return urllib.parse.urlsplit(url).path
 
 
-def configure_git_identity(repo_path):
-    """Configure a deterministic local git identity and disable commit signing
-    for the clone at `repo_path`.
-
-    update-checkout's own clones (under `source_root`) do not set these up, so a
-    test that commits into such a clone must call this first; otherwise the
-    commit depends on an ambient global identity, which is absent on a pristine
-    CI worker, and aborts. The harness's `local_path` clones go through this too,
-    via `setup_mock_remote`.
-    """
-    call_quietly(
-        ["git", "config", "--local", "user.name", "swift_test"], cwd=repo_path
-    )
-    call_quietly(
-        ["git", "config", "--local", "user.email", "no-reply@swift.org"],
-        cwd=repo_path,
-    )
-    call_quietly(
-        ["git", "config", "--local", "commit.gpgsign", "false"], cwd=repo_path
-    )
-
-
 # TODO: Move this to SchemeMockTestCase.
 def setup_mock_remote(test_case, base_dir, base_config, remotes_path, local_path):
     for local_repo_name in base_config["repos"].keys():
@@ -182,7 +160,6 @@ def setup_mock_remote(test_case, base_dir, base_config, remotes_path, local_path
             ["git", "symbolic-ref", "HEAD", "refs/heads/main"], cwd=remote_repo_path
         )
         call_quietly(["git", "clone", "-l", remote_repo_path, local_repo_path])
-        configure_git_identity(local_repo_path)
         call_quietly(
             ["git", "symbolic-ref", "HEAD", "refs/heads/main"], cwd=local_repo_path
         )

--- a/utils/update_checkout/tests/test_stash_clean.py
+++ b/utils/update_checkout/tests/test_stash_clean.py
@@ -43,10 +43,6 @@ class StashAndCleanTestCase(scheme_mock.SchemeMockTestCase):
         update that follows the stash/clean step is a no-op; only the working
         tree is later made dirty. Requires `_clone()` to have run first."""
         repo = self._repo1_path()
-        # update-checkout's own clone of source_root has no git identity (only
-        # the harness's local_path clones get one), so configure it before the
-        # seed commit. See scheme_mock.configure_git_identity.
-        scheme_mock.configure_git_identity(repo)
         with open(os.path.join(repo, "tracked.txt"), "w") as f:
             f.write("committed content\n")
         with open(os.path.join(repo, ".gitignore"), "w") as f:

--- a/utils/update_checkout/tests/test_status_command.py
+++ b/utils/update_checkout/tests/test_status_command.py
@@ -4,7 +4,7 @@ from typing import List
 import unittest
 from pathlib import Path
 
-from .scheme_mock import UPDATE_CHECKOUT_PATH, configure_git_identity
+from .scheme_mock import UPDATE_CHECKOUT_PATH
 
 
 class TestStatusCommand(unittest.TestCase):
@@ -15,7 +15,6 @@ class TestStatusCommand(unittest.TestCase):
 
     def init_repo(self, path: Path, with_changes: bool):
         self.call(args=["git", "init"], cwd=path)
-        configure_git_identity(path)
 
         (path / "file.txt").write_text("initial\n")
         self.call(args=["git", "add", "file.txt"], cwd=path)


### PR DESCRIPTION
Several of the tests in utils/update_checkout/tests/test_cross_repo_pr.py make commits without calling configure_git_identity to suppress commit signing. Most of them could be patched to do so, but test_checkout_stale_pr_merge_ref_during_clone and test_checkout_stale_pr_merge_ref_during_shallow_clone run `call` with both --clone and --github-comment. The latter ends up creating a merge commit to update the stale merge ref, which is what the tests are testing, and that can prompt the user for commit signing.

It would be difficult at best to try to optionally insert the configure_git_identity inside of `call` since it's running `update-checkout` via `subprocess`. Instead, set GIT_CONFIG_GLOBAL in the environment before running tests, and configure that to set the user info and disable commit signing.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>