### PR TITLE
swift-inspect: add support for task names

### DIFF
--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -214,6 +214,8 @@ public:
     std::vector<StoredPointer> WaitingTasks;
     std::vector<StoredPointer> AsyncBacktraceFrames;
     StoredPointer ResumeAsyncContext;
+
+    std::string Name;
   };
 
   struct ActorInfo {
@@ -2031,6 +2033,19 @@ private:
           readObj<ChildFragment<Runtime>>(ChildFragmentAddr);
       if (ChildFragmentObj)
         Info.ParentTask = ChildFragmentObj->Parent;
+    }
+
+    // Read the task's name, if any
+    if (JobFlags.task_hasInitialTaskName() && asyncTaskSize != 0) {
+      RemoteAddress NameFragmentAddr = nameFragmentAddr(AsyncTaskPtr, JobFlags);
+      auto NameFragmentObj = readObj<NameFragment<Runtime>>(NameFragmentAddr);
+      if (NameFragmentObj && NameFragmentObj->Name != 0) {
+        RemoteAddress NameAddr(NameFragmentObj->Name,
+                               RemoteAddress::DefaultAddressSpace);
+        std::string NameStr;
+        if (this->getReader().readString(NameAddr, NameStr))
+          Info.Name = std::move(NameStr);
+      }
     }
 
     // Find all child tasks.

--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorTypes.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorTypes.h
@@ -268,6 +268,8 @@ typedef struct swift_async_task_info {
 
   unsigned AsyncBacktraceFramesCount;
   swift_reflection_ptr_t *AsyncBacktraceFrames;
+
+  const char *Name;
 } swift_async_task_info_t;
 
 typedef struct swift_actor_info {

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -1114,6 +1114,15 @@ swift_reflection_asyncTaskInfo(SwiftReflectionContextRef ContextRef,
     Result.AsyncBacktraceFramesCount = AsyncBacktraceFrames->size();
     Result.AsyncBacktraceFrames = AsyncBacktraceFrames->data();
 
+    if (!TaskInfo.Name.empty()) {
+      auto *TmpName =
+          ContextRef->allocateSubsequentTemporaryObject<std::string>();
+      *TmpName = std::move(TaskInfo.Name);
+      Result.Name = TmpName->c_str();
+    } else {
+      Result.Name = nullptr;
+    }
+
     return Result;
   });
 }

--- a/stdlib/tools/swift-reflection-test/swift-reflection-test.c
+++ b/stdlib/tools/swift-reflection-test/swift-reflection-test.c
@@ -804,6 +804,8 @@ static int reflectAsyncTaskInstance(SwiftReflectionContextRef RC,
     indented_printf(indentLevel, "id %" PRIu64 "\n", TaskInfo.Id);
     indented_printf(indentLevel, "enqueuePriority %u\n",
                     TaskInfo.EnqueuePriority);
+    if (TaskInfo.Name)
+      indented_printf(indentLevel, "name \"%s\"\n", TaskInfo.Name);
     if (TaskInfo.ChildTaskCount > 0) {
       indented_printf(indentLevel, "children = {\n");
 

--- a/test/Concurrency/Reflection/reflect_task.swift
+++ b/test/Concurrency/Reflection/reflect_task.swift
@@ -116,11 +116,24 @@ func testMultipleAsyncLet() async {
   // CHECK: }
 }
 
+func testNamedTask() async {
+  reflectionLog(str: "testNamedTask")
+  // CHECK: testNamedTask
+
+  await Task(name: "hello-task") {
+    await dodgeRaceCondition()
+    reflect(asyncTask: _getCurrentTaskShim())
+    // CHECK: Async task {{0x[0-9a-fA-F]*}}
+    // CHECK: name "hello-task"
+  }.value
+}
+
 @main struct Main {
   static func main() async {
     await testNestedCallsTask()
     await testOneAsyncLet()
     await testMultipleAsyncLet()
+    await testNamedTask()
 
     doneReflecting()
   }

--- a/tools/swift-inspect/Sources/swift-inspect/Operations/DumpConcurrency.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Operations/DumpConcurrency.swift
@@ -71,6 +71,7 @@ fileprivate class ConcurrencyDumper {
     var childTasks: [swift_reflection_ptr_t]
     var asyncBacktrace: [swift_reflection_ptr_t]
     var parent: swift_reflection_ptr_t?
+    var name: String?
   }
 
   struct HeapInfo {
@@ -233,7 +234,8 @@ fileprivate class ConcurrencyDumper {
       allocatorTotalSize: allocatorTotalSize,
       allocatorTotalChunks: allocatorTotalChunks,
       childTasks: children,
-      asyncBacktrace: asyncBacktraceFrames
+      asyncBacktrace: asyncBacktraceFrames,
+      name: reflectionInfo.Name.map { String(cString: $0) }
     )
   }
 
@@ -364,7 +366,8 @@ fileprivate class ConcurrencyDumper {
 
       let flags = decodeTaskFlags(task)
 
-      output("Task \(task.id) - flags=\(flags) enqueuePriority=\(hex: task.enqueuePriority) maxPriority=\(hex: task.maxPriority) address=\(hex: task.address)")
+      let namePart: String = if let name = task.name { #" "\#(name)""# } else { "" }
+      output("Task\(namePart) \(task.id) - flags=\(flags) enqueuePriority=\(hex: task.enqueuePriority) maxPriority=\(hex: task.maxPriority) address=\(hex: task.address)")
       if let thread = taskToThread[swift_addr_t(task.address)] {
         output("current task on thread \(hex: thread)")
       }


### PR DESCRIPTION
I somehow forgot to add the support when adding task names into the runtime, fixing that now!

The change is pretty trivial, if there is a name, read and expose it

resolves rdar://181555959