### PR TITLE
[utils] Add an add-worktree utility

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -15,6 +15,7 @@ filename =
     ./test/Driver/Inputs/fake-toolchain/ld,
 
     ./utils/80+-check,
+    ./utils/add-worktree,
     ./utils/backtrace-check,
     ./utils/build-script,
     ./utils/check-incremental,

--- a/utils/add-worktree
+++ b/utils/add-worktree
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from build_swift.build_swift.constants import SWIFT_SOURCE_ROOT
+
+from update_checkout.update_checkout.cli_arguments import CliArguments
+from update_checkout.update_checkout.git_command import Git, iter_git_repositories
+from update_checkout.update_checkout.parallel_runner import ParallelRunner
+from update_checkout.update_checkout.runner_arguments import RunnerArguments
+from update_checkout.update_checkout.update_checkout import (
+    SCRIPT_DIR,
+    SkippedReason,
+    get_scheme_map,
+    merge_config,
+    output_prefix,
+    update_all_repositories,
+    validate_config,
+)
+
+
+@dataclass
+class AddWorktreeRunnerArguments(RunnerArguments):
+    worktree_dir: Path
+
+
+class AddWorktreeCliArguments(argparse.Namespace):
+    worktree_dir: Path
+    source_root: Path
+    scheme: Optional[str]
+    llvm_branch: Optional[str]
+    swift_branch: Optional[str]
+    configs: List[str]
+    n_processes: int
+    verbose: bool
+
+    @staticmethod
+    def parse_args() -> "AddWorktreeCliArguments":
+        parser = argparse.ArgumentParser(
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            description="""
+Create a set of Git worktrees for the Swift project. A detached worktree is
+created inside the worktree directory for each repository found in the source
+root, so they can be built independently of the primary checkout.
+
+If '--scheme' is passed, 'update-checkout' is then invoked on the worktrees to
+switch them to the branches of the given branch-scheme. '--llvm-branch' and
+'--swift-branch' check out (or create) a branch in the 'llvm-project' and
+'swift' worktrees respectively.
+    """,
+        )
+        parser.add_argument(
+            "worktree_dir",
+            help="The directory in which to create the worktrees.",
+            type=Path,
+        )
+        parser.add_argument(
+            "--source-root",
+            help="The root directory of the primary checkout to create worktrees "
+            "from.",
+            default=SWIFT_SOURCE_ROOT,
+            type=Path,
+        )
+        parser.add_argument(
+            "--scheme",
+            help="Switch the worktrees to the specified branch-scheme by running "
+            "update-checkout on them.",
+            metavar="BRANCH-SCHEME",
+        )
+        parser.add_argument(
+            "--llvm-branch",
+            help="Check out this branch in the 'llvm-project' worktree, creating it "
+            "if it does not already exist.",
+            metavar="BRANCH",
+        )
+        parser.add_argument(
+            "--swift-branch",
+            help="Check out this branch in the 'swift' worktree, creating it if it "
+            "does not already exist.",
+            metavar="BRANCH",
+        )
+        parser.add_argument(
+            "--config",
+            help="""The update-checkout configuration file to use when '--scheme'
+            is passed. Can be specified multiple times, each config will be merged
+            together with a 'last-wins' strategy.""",
+            action="append",
+            default=[],
+            dest="configs",
+        )
+        parser.add_argument(
+            "-j",
+            "--jobs",
+            type=int,
+            help="Number of threads to run at once",
+            default=0,
+            dest="n_processes",
+        )
+        parser.add_argument(
+            "-v",
+            "--verbose",
+            help="Increases the script's verbosity.",
+            action="store_true",
+        )
+
+        return parser.parse_args(namespace=AddWorktreeCliArguments())
+
+
+def create_worktree(pool_args: AddWorktreeRunnerArguments):
+    """Creates a detached worktree for a single repository.
+
+    Args:
+        pool_args (AddWorktreeRunnerArguments): arguments for the repository to process.
+    """
+
+    repo_name = pool_args.repo_name
+    prefix = output_prefix(repo_name)
+    primary_repo_path = pool_args.source_root.joinpath(repo_name)
+    worktree_repo_path = pool_args.worktree_dir.joinpath(repo_name)
+
+    if worktree_repo_path.exists():
+        if pool_args.verbose:
+            print(f"{prefix}Worktree already exists at '{worktree_repo_path}'")
+        return
+
+    Git.run(
+        primary_repo_path,
+        ["worktree", "add", "--detach", str(worktree_repo_path)],
+        echo=pool_args.verbose,
+        prefix=prefix,
+    )
+
+
+def create_all_worktrees(args: AddWorktreeCliArguments) -> int:
+    """Creates a detached worktree for every repository in the source root.
+
+    Args:
+        args (AddWorktreeCliArguments): the parsed command-line arguments.
+
+    Returns:
+        int: the number of repositories that failed to create a worktree.
+    """
+
+    pool_args = [
+        AddWorktreeRunnerArguments(
+            repo_name=repo_path.name,
+            output_prefix="Creating a worktree for",
+            source_root=args.source_root,
+            verbose=args.verbose,
+            worktree_dir=args.worktree_dir,
+        )
+        for repo_path in iter_git_repositories(args.source_root)
+    ]
+
+    if not pool_args:
+        print(f"No Git repositories found in '{args.source_root}'.")
+        return 1
+
+    results = ParallelRunner(create_worktree, pool_args, args.n_processes).run()
+    return ParallelRunner.check_results(results, "WORKTREE")
+
+
+def update_worktrees_to_scheme(args: AddWorktreeCliArguments, scheme_name: str) -> int:
+    """Switches the worktrees to a branch-scheme by invoking update-checkout.
+
+    Args:
+        args (AddWorktreeCliArguments): the parsed command-line arguments.
+        scheme_name (str): name of the branch-scheme to switch to.
+
+    Returns:
+        int: the number of repositories that failed to update.
+    """
+
+    configs = args.configs
+    if not configs:
+        configs = [str(SCRIPT_DIR.parent.joinpath("update-checkout-config.json"))]
+    config: Dict[str, Any] = {}
+    for config_path in configs:
+        with open(config_path) as f:
+            config = merge_config(config, json.load(f))
+    validate_config(config)
+    scheme_map = get_scheme_map(config, scheme_name)
+
+    # update_all_repositories expects a populated update-checkout argument
+    # namespace. Only the fields it reads are set here.
+    update_args = CliArguments()
+    update_args.source_root = args.worktree_dir
+    update_args.skip_repository_list = []
+    update_args.match_timestamp = False
+    update_args.tag = None
+    update_args.reset_to_remote = False
+    update_args.clean = False
+    update_args.stash = False
+    update_args.skip_history = False
+    update_args.partial_clone = False
+    update_args.verbose = args.verbose
+    update_args.n_processes = args.n_processes
+
+    skipped_repositories, results = update_all_repositories(
+        update_args, config, scheme_name, scheme_map, {}
+    )
+    SkippedReason.print_skipped_repositories(skipped_repositories, "update")
+    return ParallelRunner.check_results(results, "UPDATE")
+
+
+def checkout_branch_in_repo(
+    worktree_dir: Path, repo_name: str, branch: str, verbose: bool
+) -> int:
+    """Checks out a branch in a repository worktree, creating it if needed.
+
+    Args:
+        worktree_dir (Path): the directory containing the worktrees.
+        repo_name (str): name of the repository to check out the branch in.
+        branch (str): name of the branch to check out or create.
+        verbose (bool): whether to echo the executed commands.
+
+    Returns:
+        int: 0 on success, 1 if the repository worktree does not exist.
+    """
+
+    prefix = output_prefix(repo_name)
+    repo_path = worktree_dir.joinpath(repo_name)
+    if not repo_path.is_dir():
+        print(f"{prefix}No worktree at '{repo_path}' to check out '{branch}'")
+        return 1
+
+    existing_branch, _, _ = Git.run(repo_path, ["branch", "--list", branch])
+    if existing_branch:
+        checkout_args = ["checkout", branch]
+    else:
+        checkout_args = ["checkout", "-b", branch]
+    Git.run(repo_path, checkout_args, echo=verbose, prefix=prefix)
+    return 0
+
+
+def print_cleanup_hint(args: AddWorktreeCliArguments):
+    """Prints instructions for removing the created worktrees.
+
+    Args:
+        args (AddWorktreeCliArguments): the parsed command-line arguments.
+    """
+
+    print(
+        "To remove these worktrees, delete the worktree directory and prune:\n"
+        f"  rm -rf {args.worktree_dir}\n"
+        f"  for repo in {args.source_root}/*; do "
+        'git -C "$repo" worktree prune; done'
+    )
+
+
+def main() -> int:
+    args = AddWorktreeCliArguments.parse_args()
+    args.worktree_dir = args.worktree_dir.resolve()
+    args.worktree_dir.mkdir(parents=True, exist_ok=True)
+
+    fail_count = create_all_worktrees(args)
+
+    if fail_count == 0 and args.scheme:
+        fail_count += update_worktrees_to_scheme(args, args.scheme)
+
+    if fail_count == 0 and args.llvm_branch:
+        fail_count += checkout_branch_in_repo(
+            args.worktree_dir, "llvm-project", args.llvm_branch, args.verbose
+        )
+
+    if fail_count == 0 and args.swift_branch:
+        fail_count += checkout_branch_in_repo(
+            args.worktree_dir, "swift", args.swift_branch, args.verbose
+        )
+
+    if fail_count > 0:
+        print("add-worktree failed, fix errors and try again")
+    else:
+        print("add-worktree succeeded")
+        print_cleanup_hint(args)
+    return fail_count
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/utils/update_checkout/tests/test_add_worktree.py
+++ b/utils/update_checkout/tests/test_add_worktree.py
@@ -1,0 +1,259 @@
+import json
+import os
+
+from . import scheme_mock
+
+
+ADD_WORKTREE_PATH = os.path.abspath(
+    os.path.join(
+        scheme_mock.CURRENT_FILE_DIR,
+        os.path.pardir,
+        os.path.pardir,
+        "add-worktree",
+    )
+)
+
+
+class AddWorktreeTestCase(scheme_mock.SchemeMockTestCase):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.worktree_dir = os.path.join(self.workspace, "worktrees")
+
+    def clone_source_root(self):
+        self.call(self.base_args + ["--clone"])
+
+    def head_commit(self, repo_path):
+        return self.call(["git", "rev-parse", "HEAD"], cwd=repo_path).strip()
+
+    def is_detached(self, repo_path):
+        ref = self.call(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=repo_path
+        ).strip()
+        return ref == "HEAD"
+
+    def test_creates_detached_worktrees(self):
+        self.clone_source_root()
+        self.call(
+            [ADD_WORKTREE_PATH, "--source-root", self.source_root, self.worktree_dir]
+        )
+
+        for repo in self.repo_names:
+            worktree_path = os.path.join(self.worktree_dir, repo)
+            self.assertTrue(os.path.isdir(worktree_path))
+            # A worktree's '.git' is a file, not a directory.
+            self.assertTrue(os.path.isfile(os.path.join(worktree_path, ".git")))
+            self.assertTrue(self.is_detached(worktree_path))
+            self.assertEqual(
+                self.head_commit(worktree_path),
+                self.head_commit(os.path.join(self.source_root, repo)),
+            )
+
+    def test_idempotent(self):
+        self.clone_source_root()
+        command = [
+            ADD_WORKTREE_PATH,
+            "--source-root",
+            self.source_root,
+            self.worktree_dir,
+        ]
+        self.call(command)
+        # A second run must not fail even though the worktrees already exist.
+        output = self.call(command)
+        self.assertIn("add-worktree succeeded", output)
+
+    def test_scheme_switch_detaches_on_collision(self):
+        self.clone_source_root()
+        # The scheme's branches match the primary checkout's branches, so every
+        # worktree collides on checkout and must fall back to a detached HEAD.
+        output = self.call(
+            [
+                ADD_WORKTREE_PATH,
+                "--source-root",
+                self.source_root,
+                "--config",
+                self.config_path,
+                "--scheme",
+                "main",
+                self.worktree_dir,
+            ]
+        )
+        self.assertIn("add-worktree succeeded", output)
+        for repo in self.repo_names:
+            self.assertTrue(self.is_detached(os.path.join(self.worktree_dir, repo)))
+
+
+class AddWorktreeSchemeTestCase(scheme_mock.SchemeMockTestCase):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.worktree_dir = os.path.join(self.workspace, "worktrees")
+
+    def setUp(self):
+        super().setUp()
+
+        # Advance 'main' so the primary checkout and the target scheme end up at
+        # different commits, letting us prove the scheme actually moves the
+        # worktree.
+        local_repo1 = os.path.join(self.local_path, "repo1")
+        self.call(["git", "commit", "--allow-empty", "-m", "second"], cwd=local_repo1)
+        self.call(["git", "push", "origin", "main"], cwd=local_repo1)
+        self.call(self.base_args + ["--clone"])
+
+        remote_repo1 = self.remote_path(repo_name="repo1")
+        commits = self.call(["git", "rev-list", "main"], cwd=remote_repo1).split()
+        self.old_commit = commits[-1]
+
+        self.scheme_name = "commit-scheme"
+        self.add_branch_scheme(
+            self.scheme_name,
+            {
+                "aliases": [self.scheme_name],
+                "repos": {"repo1": self.old_commit, "repo2": "main"},
+            },
+        )
+        with open(self.config_path, "w") as f:
+            json.dump(self.config, f)
+
+    def test_scheme_switches_commit(self):
+        self.call(
+            [
+                ADD_WORKTREE_PATH,
+                "--source-root",
+                self.source_root,
+                "--config",
+                self.config_path,
+                "--scheme",
+                self.scheme_name,
+                self.worktree_dir,
+            ]
+        )
+
+        worktree_repo1 = os.path.join(self.worktree_dir, "repo1")
+        current_commit = self.call(
+            ["git", "rev-parse", "HEAD"], cwd=worktree_repo1
+        ).strip()
+        self.assertEqual(current_commit, self.old_commit)
+
+
+class AddWorktreeBranchTestCase(scheme_mock.SchemeMockTestCase):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.worktree_dir = os.path.join(self.workspace, "worktrees")
+
+        # '--llvm-branch' and '--swift-branch' operate on repositories named
+        # 'llvm-project' and 'swift', so add them to the mock configuration.
+        for repo_name in ["llvm-project", "swift"]:
+            self.config["repos"][repo_name] = {"remote": {"id": repo_name}}
+            self.config["branch-schemes"]["main"]["repos"][repo_name] = "main"
+
+    def current_branch(self, repo_path):
+        return self.call(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=repo_path
+        ).strip()
+
+    def test_creates_and_checks_out_branches(self):
+        self.call(self.base_args + ["--clone"])
+        command = [
+            ADD_WORKTREE_PATH,
+            "--source-root",
+            self.source_root,
+            "--llvm-branch",
+            "my-llvm",
+            "--swift-branch",
+            "my-swift",
+            self.worktree_dir,
+        ]
+        self.call(command)
+
+        self.assertEqual(
+            self.current_branch(os.path.join(self.worktree_dir, "llvm-project")),
+            "my-llvm",
+        )
+        self.assertEqual(
+            self.current_branch(os.path.join(self.worktree_dir, "swift")),
+            "my-swift",
+        )
+        # A repository without a requested branch stays detached.
+        self.assertEqual(
+            self.current_branch(os.path.join(self.worktree_dir, "repo1")),
+            "HEAD",
+        )
+
+        # A second run checks out the now-existing branches rather than failing.
+        output = self.call(command)
+        self.assertIn("add-worktree succeeded", output)
+        self.assertEqual(
+            self.current_branch(os.path.join(self.worktree_dir, "swift")),
+            "my-swift",
+        )
+
+
+class AddWorktreeSharedSchemeTestCase(scheme_mock.SchemeMockTestCase):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.worktree_dir_a = os.path.join(self.workspace, "worktrees-a")
+        self.worktree_dir_b = os.path.join(self.workspace, "worktrees-b")
+
+    def setUp(self):
+        super().setUp()
+
+        # Create a 'feature' branch on each remote that the primary checkout
+        # will not have checked out, so the scheme's branch differs from the
+        # primary's branch. This lets the first worktree claim the branch while
+        # a second worktree must fall back to a detached HEAD.
+        for repo_name in self.repo_names:
+            local_repo = os.path.join(self.local_path, repo_name)
+            self.call(["git", "checkout", "-b", "feature"], cwd=local_repo)
+            self.call(["git", "commit", "--allow-empty", "-m", "F"], cwd=local_repo)
+            self.call(["git", "push", "origin", "feature"], cwd=local_repo)
+            self.call(["git", "checkout", "main"], cwd=local_repo)
+
+        self.scheme_name = "feature-scheme"
+        self.add_branch_scheme(
+            self.scheme_name,
+            {
+                "aliases": [self.scheme_name],
+                "repos": {repo: "feature" for repo in self.repo_names},
+            },
+        )
+        with open(self.config_path, "w") as f:
+            json.dump(self.config, f)
+
+        # Populate the primary checkout on 'main', not 'feature'.
+        self.call(self.base_args + ["--clone"])
+
+    def current_branch(self, repo_path):
+        return self.call(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=repo_path
+        ).strip()
+
+    def head_commit(self, repo_path):
+        return self.call(["git", "rev-parse", "HEAD"], cwd=repo_path).strip()
+
+    def test_second_worktree_detaches_from_scheme_branch(self):
+        scheme_args = [
+            ADD_WORKTREE_PATH,
+            "--source-root",
+            self.source_root,
+            "--config",
+            self.config_path,
+            "--scheme",
+            self.scheme_name,
+        ]
+
+        # The first worktree claims the scheme's branch.
+        self.call(scheme_args + [self.worktree_dir_a])
+        repo1_a = os.path.join(self.worktree_dir_a, "repo1")
+        self.assertEqual(self.current_branch(repo1_a), "feature")
+
+        # The second worktree can't check out a branch already used by the
+        # first, so it falls back to a detached HEAD at the same commit and
+        # still succeeds.
+        output = self.call(scheme_args + [self.worktree_dir_b])
+        self.assertIn("add-worktree succeeded", output)
+        repo1_b = os.path.join(self.worktree_dir_b, "repo1")
+        self.assertEqual(self.current_branch(repo1_b), "HEAD")
+        self.assertEqual(self.head_commit(repo1_a), self.head_commit(repo1_b))

--- a/utils/update_checkout/update_checkout/commands/status.py
+++ b/utils/update_checkout/update_checkout/commands/status.py
@@ -9,7 +9,7 @@ from ..cli_arguments import CliArguments
 from ..git_command import (
     Git,
     is_any_repository_locked,
-    is_git_repository,
+    iter_git_repositories,
 )
 
 
@@ -27,9 +27,7 @@ class StatusCommand:
     def __init__(self, args: CliArguments):
         self._args = args
         self._pool_args = []
-        for repo_path in args.source_root.iterdir():
-            if not is_git_repository(repo_path):
-                continue
+        for repo_path in iter_git_repositories(args.source_root):
             repo_name = repo_path.name
 
             my_args = RunnerArguments(

--- a/utils/update_checkout/update_checkout/git_command.py
+++ b/utils/update_checkout/update_checkout/git_command.py
@@ -3,7 +3,7 @@ import re
 import shlex
 import subprocess
 import sys
-from typing import List, Any, Optional, Dict, Set, Tuple
+from typing import List, Any, Iterator, Optional, Dict, Set, Tuple
 
 from .runner_arguments import RunnerArguments
 
@@ -156,6 +156,21 @@ def is_git_repository(path: Path) -> bool:
         return False
     git_dir_path = path.joinpath(".git")
     return git_dir_path.exists() and git_dir_path.is_dir()
+
+
+def iter_git_repositories(source_root: Path) -> Iterator[Path]:
+    """Yields the path of each Git repository in a source root directory.
+
+    Args:
+        source_root (Path): The directory to scan for Git repositories.
+
+    Yields:
+        Path: The path to each immediate subdirectory that is a Git repository.
+    """
+
+    for path in source_root.iterdir():
+        if is_git_repository(path):
+            yield path
 
 
 def is_any_repository_locked(pool_args: List[RunnerArguments]) -> Set[str]:


### PR DESCRIPTION
Using Git worktrees with Swift can be difficult in a few scenarios.

1. Sometimes I need to make a Swift worktree on a different branch scheme, but I'm also working on llvm in the original scheme so I don't want to switch everything in my existing setup.
2. The Swift worktree fights over the same build directory with the main checkout and every other worktree I have going on. What I really need is a scratch area that Claude can use for testing/experimenting.

Make a new utility called add-worktree that makes worktrees for all of the Swift repos, optionally changes its branch scheme, and optionally checks out/creates LLVM and/or Swift branches.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>