### PR TITLE
[utils] Add an add-worktree utility

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -15,6 +15,7 @@ filename =
     ./test/Driver/Inputs/fake-toolchain/ld,
 
     ./utils/80+-check,
+    ./utils/add-worktree,
     ./utils/backtrace-check,
     ./utils/build-script,
     ./utils/check-incremental,
@@ -28,6 +29,7 @@ filename =
     ./utils/line-directive,
     ./utils/PathSanitizingFileCheck,
     ./utils/recursive-lipo,
+    ./utils/remove-worktree,
     ./utils/round-trip-syntax-test,
     ./utils/rth,
     ./utils/run-test,

--- a/utils/add-worktree
+++ b/utils/add-worktree
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2026 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from build_swift.build_swift.constants import SWIFT_SOURCE_ROOT
+
+from update_checkout.update_checkout.cli_arguments import CliArguments
+from update_checkout.update_checkout.git_command import Git, iter_git_repositories
+from update_checkout.update_checkout.parallel_runner import ParallelRunner
+from update_checkout.update_checkout.runner_arguments import RunnerArguments
+from update_checkout.update_checkout.update_checkout import (
+    SkippedReason,
+    should_skip_repo,
+    check_missing_clones,
+    get_scheme_map,
+    load_config,
+    output_prefix,
+    update_all_repositories,
+)
+
+
+@dataclass
+class AddWorktreeRunnerArguments(RunnerArguments):
+    worktree_dir: Path
+
+
+class AddWorktreeCliArguments(argparse.Namespace):
+    worktree_dir: Path
+    source_root: Path
+    scheme: Optional[str]
+    configs: List[str]
+    n_processes: int
+    verbose: bool
+    # add-worktree has no --skip-repository flag, but update-checkout's shared
+    # repo-skipping helpers read this, so default it to empty.
+    skip_repository_list: List[str] = []
+
+    @staticmethod
+    def parse_args() -> "AddWorktreeCliArguments":
+        parser = argparse.ArgumentParser(
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            description="Create a set of Git worktrees for the Swift project.",
+        )
+        parser.add_argument(
+            "worktree_dir",
+            help="The directory in which to create the worktrees.",
+            type=Path,
+        )
+        parser.add_argument(
+            "--source-root",
+            help="The root directory of the primary checkout to create worktrees "
+            "from.",
+            default=SWIFT_SOURCE_ROOT,
+            type=Path,
+        )
+        parser.add_argument(
+            "--scheme",
+            help="Switch the worktrees to the specified branch-scheme.",
+            metavar="BRANCH-SCHEME",
+        )
+        parser.add_argument(
+            "--config",
+            help="""The update-checkout configuration file to use when '--scheme'
+            is passed. Can be specified multiple times, each config will be merged
+            together with a 'last-wins' strategy.""",
+            action="append",
+            default=[],
+            dest="configs",
+        )
+        parser.add_argument(
+            "-j",
+            "--jobs",
+            type=int,
+            help="Number of threads to run at once.",
+            default=0,
+            dest="n_processes",
+        )
+        parser.add_argument(
+            "-v",
+            "--verbose",
+            help="Increases the script's verbosity.",
+            action="store_true",
+        )
+
+        return parser.parse_args(namespace=AddWorktreeCliArguments())
+
+
+def create_worktree(pool_args: AddWorktreeRunnerArguments):
+    """Creates a detached worktree for a single repository.
+
+    Args:
+        pool_args (AddWorktreeRunnerArguments): arguments for the repository to process.
+    """
+
+    repo_name = pool_args.repo_name
+    prefix = output_prefix(repo_name)
+    primary_repo_path = pool_args.source_root.joinpath(repo_name)
+    worktree_repo_path = pool_args.worktree_dir.joinpath(repo_name)
+
+    if worktree_repo_path.exists():
+        if pool_args.verbose:
+            print(f"{prefix}Worktree already exists at '{worktree_repo_path}'")
+        return
+
+    Git.run(
+        primary_repo_path,
+        ["worktree", "add", "--detach", str(worktree_repo_path)],
+        echo=pool_args.verbose,
+        prefix=prefix,
+    )
+
+
+def create_worktrees(args: AddWorktreeCliArguments, repo_names: List[str]) -> int:
+    """Creates a detached worktree for each of the named repositories.
+
+    Args:
+        args (AddWorktreeCliArguments): the parsed command-line arguments.
+        repo_names (List[str]): names of the source-root repositories to create
+            worktrees for.
+
+    Returns:
+        int: the number of repositories that failed to create a worktree.
+    """
+
+    if not repo_names:
+        print(f"No repositories to create worktrees for in '{args.source_root}'.")
+        return 1
+
+    pool_args = [
+        AddWorktreeRunnerArguments(
+            repo_name=repo_name,
+            output_prefix="Creating a worktree for",
+            source_root=args.source_root,
+            verbose=args.verbose,
+            worktree_dir=args.worktree_dir,
+        )
+        for repo_name in repo_names
+    ]
+
+    results = ParallelRunner(create_worktree, pool_args, args.n_processes).run()
+    return ParallelRunner.check_results(results, "WORKTREE")
+
+
+def scheme_repo_names(
+    args: AddWorktreeCliArguments, config: Dict[str, Any], scheme_name: str
+) -> Optional[List[str]]:
+    """Returns the source-root repositories that belong to a branch-scheme.
+
+    If a scheme repository is missing from the source root, an error is printed
+    and None is returned, since the resulting worktree tree would be incomplete
+    for that scheme.
+
+    Args:
+        args (AddWorktreeCliArguments): the parsed command-line arguments.
+        config (Dict[str, Any]): the merged update-checkout configuration.
+        scheme_name (str): name of the branch-scheme.
+
+    Returns:
+        List[str] | None: the repository names to create worktrees for, or None
+            if a required repository is missing from the source root.
+    """
+
+    scheme_map = get_scheme_map(config, scheme_name)
+
+    missing = check_missing_clones(args, config, scheme_map)
+    if missing:
+        for repo_name in missing:
+            print(
+                f"Repository '{repo_name}' from the '{scheme_name}' branch-scheme "
+                f"is missing from '{args.source_root}'; clone it first."
+            )
+        return None
+
+    return [
+        repo_name
+        for repo_name in scheme_map
+        if not should_skip_repo(args, config, repo_name)
+    ]
+
+
+def update_worktrees_to_scheme(
+    args: AddWorktreeCliArguments, config: Dict[str, Any], scheme_name: str
+) -> int:
+    """Switches the worktrees to a branch-scheme by invoking update-checkout.
+
+    Args:
+        args (AddWorktreeCliArguments): the parsed command-line arguments.
+        config (Dict[str, Any]): the merged update-checkout configuration.
+        scheme_name (str): name of the branch-scheme to switch to.
+
+    Returns:
+        int: the number of repositories that failed to update.
+    """
+
+    scheme_map = get_scheme_map(config, scheme_name)
+
+    # update_all_repositories expects a populated update-checkout argument
+    # namespace. Only the fields it reads are set here.
+    update_args = CliArguments()
+    update_args.source_root = args.worktree_dir
+    update_args.skip_repository_list = []
+    update_args.match_timestamp = False
+    update_args.tag = None
+    update_args.reset_to_remote = False
+    update_args.clean = False
+    update_args.stash = False
+    update_args.skip_history = False
+    update_args.partial_clone = False
+    update_args.verbose = args.verbose
+    update_args.n_processes = args.n_processes
+
+    skipped_repositories, results = update_all_repositories(
+        update_args, config, scheme_name, scheme_map, {}
+    )
+    SkippedReason.print_skipped_repositories(skipped_repositories, "update")
+    return ParallelRunner.check_results(results, "UPDATE")
+
+
+def main() -> int:
+    args = AddWorktreeCliArguments.parse_args()
+    args.source_root = args.source_root.resolve()
+    args.worktree_dir = args.worktree_dir.resolve()
+    args.worktree_dir.mkdir(parents=True, exist_ok=True)
+
+    # The config selects which repositories belong to the scheme and resolves
+    # their remotes, so load it only when a scheme switch is requested.
+    if args.scheme:
+        config = load_config(args.configs)
+        repo_names = scheme_repo_names(args, config, args.scheme)
+        if repo_names is None:
+            print("add-worktree failed, fix errors and try again")
+            return 1
+    else:
+        repo_names = [path.name for path in iter_git_repositories(args.source_root)]
+
+    fail_count = create_worktrees(args, repo_names)
+
+    if fail_count == 0 and args.scheme:
+        fail_count += update_worktrees_to_scheme(args, config, args.scheme)
+
+    if fail_count > 0:
+        print("add-worktree failed, fix errors and try again")
+    else:
+        print("add-worktree succeeded")
+    return fail_count
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/utils/remove-worktree
+++ b/utils/remove-worktree
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2026 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+from update_checkout.update_checkout.git_command import Git
+from update_checkout.update_checkout.update_checkout import output_prefix
+
+
+class RemoveWorktreeCliArguments(argparse.Namespace):
+    worktree_dir: Path
+    force: bool
+    verbose: bool
+
+    @staticmethod
+    def parse_args() -> "RemoveWorktreeCliArguments":
+        parser = argparse.ArgumentParser(
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            description="""
+Remove a set of Git worktrees created by add-worktree. Each repository worktree
+found in the worktree directory is removed from its own repository.
+
+By default a worktree with uncommitted changes is reported and left in place.
+Pass '--force' to remove worktrees even when they have uncommitted changes.
+    """,
+        )
+        parser.add_argument(
+            "worktree_dir",
+            help="The worktree directory to remove (as passed to add-worktree).",
+            type=Path,
+        )
+        parser.add_argument(
+            "--force",
+            help="Remove worktrees even if they have uncommitted changes.",
+            action="store_true",
+        )
+        parser.add_argument(
+            "-v",
+            "--verbose",
+            help="Increases the script's verbosity.",
+            action="store_true",
+        )
+
+        return parser.parse_args(namespace=RemoveWorktreeCliArguments())
+
+
+def iter_worktrees(worktree_dir: Path):
+    """Yields the path of each Git worktree in a worktree directory.
+
+    A linked worktree has a '.git' file (not a directory) pointing back at its
+    repository, which is how these differ from primary checkouts.
+
+    Args:
+        worktree_dir (Path): the directory containing the worktrees.
+
+    Yields:
+        Path: the path to each immediate subdirectory that is a Git worktree.
+    """
+
+    for path in worktree_dir.iterdir():
+        if path.joinpath(".git").exists():
+            yield path
+
+
+def dirty_paths(worktree_path: Path):
+    """Returns the set of paths with modified or untracked content.
+
+    Args:
+        worktree_path (Path): the worktree to inspect.
+
+    Returns:
+        set[str]: repository-relative paths reported as changed, including
+            submodules whose contents differ.
+    """
+
+    changes, _, _ = Git.run(
+        worktree_path, ["status", "--porcelain", "--ignore-submodules=none"]
+    )
+    paths = set()
+    for line in changes.splitlines():
+        # Porcelain v1 lines are '<status> <path>'. The status code is one or
+        # two non-space characters; strip the line first (Git.run strips the
+        # overall output, which drops the leading space on the first line only)
+        # and split off that code. A rename or copy is '<old> -> <new>'.
+        parts = line.strip().split(None, 1)
+        if len(parts) < 2:
+            continue
+        path = parts[1]
+        if " -> " in path:
+            path = path.split(" -> ")[-1]
+        paths.add(path.strip('"'))
+    return paths
+
+
+def submodule_paths(worktree_path: Path):
+    """Returns the set of submodule paths in a worktree.
+
+    Args:
+        worktree_path (Path): the worktree to inspect.
+
+    Returns:
+        set[str]: repository-relative paths of the worktree's submodules.
+    """
+
+    status, _, _ = Git.run(worktree_path, ["submodule", "status"])
+    paths = set()
+    for line in status.splitlines():
+        # Each line is '<flag><sha> <path> (<describe>)'.
+        fields = line.split()
+        if len(fields) >= 2:
+            paths.add(fields[1])
+    return paths
+
+
+def remove_worktree(worktree_path: Path, force: bool, verbose: bool) -> int:
+    """Removes a single Git worktree.
+
+    Removal always uses `git worktree remove --force` because git refuses to
+    remove a worktree containing submodules otherwise. When `force` is False the
+    worktree is first checked for modified or untracked files and left in place
+    if any are found, so this check is what protects uncommitted work.
+
+    Args:
+        worktree_path (Path): the path to the worktree to remove.
+        force (bool): remove even if the worktree has uncommitted changes.
+        verbose (bool): whether to echo the executed commands.
+
+    Returns:
+        int: 0 on success, 1 if the worktree was skipped or removal failed.
+    """
+
+    prefix = output_prefix(worktree_path.name)
+    if not force:
+        changed = dirty_paths(worktree_path)
+        if changed:
+            # When the only changes are inside submodules, point at the
+            # submodule(s) rather than the worktree so the dirt is easy to
+            # find. Otherwise report the worktree, matching git's own
+            # `worktree remove` wording either way.
+            submodules = submodule_paths(worktree_path)
+            dirty_submodules = sorted(changed & submodules)
+            if dirty_submodules and not (changed - submodules):
+                report_paths = [worktree_path.joinpath(s) for s in dirty_submodules]
+            else:
+                report_paths = [worktree_path]
+            for report_path in report_paths:
+                print(
+                    f"{prefix}'{report_path}' contains modified or untracked "
+                    "files, use --force to delete it"
+                )
+            return 1
+
+    Git.run(
+        worktree_path,
+        ["worktree", "remove", "--force", str(worktree_path)],
+        echo=verbose,
+        prefix=prefix,
+    )
+    return 0
+
+
+def main() -> int:
+    args = RemoveWorktreeCliArguments.parse_args()
+    worktree_dir = args.worktree_dir.resolve()
+
+    if not worktree_dir.is_dir():
+        print(f"No such worktree directory: '{worktree_dir}'")
+        return 1
+
+    fail_count = 0
+    for worktree_path in iter_worktrees(worktree_dir):
+        fail_count += remove_worktree(worktree_path, args.force, args.verbose)
+
+    if fail_count > 0:
+        print("remove-worktree finished with worktrees left in place")
+        return fail_count
+
+    # Every worktree was removed; delete the (now non-worktree) directory and
+    # anything else left inside it.
+    shutil.rmtree(worktree_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/utils/update_checkout/tests/test_add_worktree.py
+++ b/utils/update_checkout/tests/test_add_worktree.py
@@ -1,0 +1,282 @@
+# ===--- test_add_worktree.py ---------------------------------------------===#
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2026 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ===----------------------------------------------------------------------===#
+
+import json
+import os
+import shutil
+
+from . import scheme_mock
+
+
+ADD_WORKTREE_PATH = os.path.abspath(
+    os.path.join(
+        scheme_mock.CURRENT_FILE_DIR,
+        os.path.pardir,
+        os.path.pardir,
+        "add-worktree",
+    )
+)
+
+
+class AddWorktreeTestCase(scheme_mock.SchemeMockTestCase):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.worktree_dir = os.path.join(self.workspace, "worktrees")
+
+    def clone_source_root(self):
+        self.call(self.base_args + ["--clone"])
+
+    def head_commit(self, repo_path):
+        return self.call(["git", "rev-parse", "HEAD"], cwd=repo_path).strip()
+
+    def is_detached(self, repo_path):
+        ref = self.call(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=repo_path
+        ).strip()
+        return ref == "HEAD"
+
+    def test_creates_detached_worktrees(self):
+        self.clone_source_root()
+        self.call(
+            [ADD_WORKTREE_PATH, "--source-root", self.source_root, self.worktree_dir]
+        )
+
+        for repo in self.repo_names:
+            worktree_path = os.path.join(self.worktree_dir, repo)
+            self.assertTrue(os.path.isdir(worktree_path))
+            # A worktree's '.git' is a file, not a directory.
+            self.assertTrue(os.path.isfile(os.path.join(worktree_path, ".git")))
+            self.assertTrue(self.is_detached(worktree_path))
+            self.assertEqual(
+                self.head_commit(worktree_path),
+                self.head_commit(os.path.join(self.source_root, repo)),
+            )
+
+    def test_idempotent(self):
+        self.clone_source_root()
+        command = [
+            ADD_WORKTREE_PATH,
+            "--source-root",
+            self.source_root,
+            self.worktree_dir,
+        ]
+        self.call(command)
+        # A second run must not fail even though the worktrees already exist.
+        output = self.call(command)
+        self.assertIn("add-worktree succeeded", output)
+
+    def test_scheme_switch_detaches_on_collision(self):
+        self.clone_source_root()
+        # The scheme's branches match the primary checkout's branches, so every
+        # worktree collides on checkout and must fall back to a detached HEAD.
+        output = self.call(
+            [
+                ADD_WORKTREE_PATH,
+                "--source-root",
+                self.source_root,
+                "--config",
+                self.config_path,
+                "--scheme",
+                "main",
+                self.worktree_dir,
+            ]
+        )
+        self.assertIn("add-worktree succeeded", output)
+        for repo in self.repo_names:
+            self.assertTrue(self.is_detached(os.path.join(self.worktree_dir, repo)))
+
+
+class AddWorktreeSchemeTestCase(scheme_mock.SchemeMockTestCase):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.worktree_dir = os.path.join(self.workspace, "worktrees")
+
+    def setUp(self):
+        super().setUp()
+
+        # Advance 'main' so the primary checkout and the target scheme end up at
+        # different commits, letting us prove the scheme actually moves the
+        # worktree.
+        local_repo1 = os.path.join(self.local_path, "repo1")
+        self.call(["git", "commit", "--allow-empty", "-m", "second"], cwd=local_repo1)
+        self.call(["git", "push", "origin", "main"], cwd=local_repo1)
+        self.call(self.base_args + ["--clone"])
+
+        remote_repo1 = self.remote_path(repo_name="repo1")
+        commits = self.call(["git", "rev-list", "main"], cwd=remote_repo1).split()
+        self.old_commit = commits[-1]
+
+        self.scheme_name = "commit-scheme"
+        self.add_branch_scheme(
+            self.scheme_name,
+            {
+                "aliases": [self.scheme_name],
+                "repos": {"repo1": self.old_commit, "repo2": "main"},
+            },
+        )
+        with open(self.config_path, "w") as f:
+            json.dump(self.config, f)
+
+    def test_scheme_switches_commit(self):
+        self.call(
+            [
+                ADD_WORKTREE_PATH,
+                "--source-root",
+                self.source_root,
+                "--config",
+                self.config_path,
+                "--scheme",
+                self.scheme_name,
+                self.worktree_dir,
+            ]
+        )
+
+        worktree_repo1 = os.path.join(self.worktree_dir, "repo1")
+        current_commit = self.call(
+            ["git", "rev-parse", "HEAD"], cwd=worktree_repo1
+        ).strip()
+        self.assertEqual(current_commit, self.old_commit)
+
+
+class AddWorktreeSchemeSelectionTestCase(scheme_mock.SchemeMockTestCase):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.worktree_dir = os.path.join(self.workspace, "worktrees")
+
+        # A 'partial' scheme that omits repo2, plus an 'extra' repo that is in
+        # the source root but in no scheme at all.
+        self.config["repos"]["extra"] = {"remote": {"id": "extra"}}
+        self.config["branch-schemes"]["main"]["repos"]["extra"] = "main"
+        self.add_branch_scheme(
+            "partial",
+            {"aliases": ["partial"], "repos": {"repo1": "main"}},
+        )
+
+    def worktree_exists(self, repo):
+        return os.path.exists(os.path.join(self.worktree_dir, repo))
+
+    def test_only_scheme_repos_get_worktrees(self):
+        self.call(self.base_args + ["--clone"])
+        self.call(
+            [
+                ADD_WORKTREE_PATH,
+                "--source-root",
+                self.source_root,
+                "--config",
+                self.config_path,
+                "--scheme",
+                "partial",
+                self.worktree_dir,
+            ]
+        )
+
+        # Only the scheme's repo gets a worktree; repos outside the scheme
+        # (repo2, extra) are not worktree'd even though they exist in the
+        # source root.
+        self.assertTrue(self.worktree_exists("repo1"))
+        self.assertFalse(self.worktree_exists("repo2"))
+        self.assertFalse(self.worktree_exists("extra"))
+
+    def test_missing_scheme_repo_fails(self):
+        self.call(self.base_args + ["--clone"])
+        # 'main' includes repo2; remove it from the source root so a scheme
+        # repository is missing.
+        shutil.rmtree(os.path.join(self.source_root, "repo2"))
+
+        with self.assertRaises(scheme_mock.PrintableSubprocessError) as cm:
+            self.call(
+                [
+                    ADD_WORKTREE_PATH,
+                    "--source-root",
+                    self.source_root,
+                    "--config",
+                    self.config_path,
+                    "--scheme",
+                    "main",
+                    self.worktree_dir,
+                ]
+            )
+        self.assertIn("is missing from", cm.exception.output)
+        # No worktrees were created for the incomplete scheme.
+        self.assertFalse(self.worktree_exists("repo1"))
+
+
+class AddWorktreeSharedSchemeTestCase(scheme_mock.SchemeMockTestCase):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.worktree_dir_a = os.path.join(self.workspace, "worktrees-a")
+        self.worktree_dir_b = os.path.join(self.workspace, "worktrees-b")
+
+    def setUp(self):
+        super().setUp()
+
+        # Create a 'feature' branch on each remote that the primary checkout
+        # will not have checked out, so the scheme's branch differs from the
+        # primary's branch. This lets the first worktree claim the branch while
+        # a second worktree must fall back to a detached HEAD.
+        for repo_name in self.repo_names:
+            local_repo = os.path.join(self.local_path, repo_name)
+            self.call(["git", "checkout", "-b", "feature"], cwd=local_repo)
+            self.call(["git", "commit", "--allow-empty", "-m", "F"], cwd=local_repo)
+            self.call(["git", "push", "origin", "feature"], cwd=local_repo)
+            self.call(["git", "checkout", "main"], cwd=local_repo)
+
+        self.scheme_name = "feature-scheme"
+        self.add_branch_scheme(
+            self.scheme_name,
+            {
+                "aliases": [self.scheme_name],
+                "repos": {repo: "feature" for repo in self.repo_names},
+            },
+        )
+        with open(self.config_path, "w") as f:
+            json.dump(self.config, f)
+
+        # Populate the primary checkout on 'main', not 'feature'.
+        self.call(self.base_args + ["--clone"])
+
+    def current_branch(self, repo_path):
+        return self.call(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=repo_path
+        ).strip()
+
+    def head_commit(self, repo_path):
+        return self.call(["git", "rev-parse", "HEAD"], cwd=repo_path).strip()
+
+    def test_second_worktree_detaches_from_scheme_branch(self):
+        scheme_args = [
+            ADD_WORKTREE_PATH,
+            "--source-root",
+            self.source_root,
+            "--config",
+            self.config_path,
+            "--scheme",
+            self.scheme_name,
+        ]
+
+        # The first worktree claims the scheme's branch.
+        self.call(scheme_args + [self.worktree_dir_a])
+        repo1_a = os.path.join(self.worktree_dir_a, "repo1")
+        self.assertEqual(self.current_branch(repo1_a), "feature")
+
+        # The second worktree can't check out a branch already used by the
+        # first, so it falls back to a detached HEAD at the same commit and
+        # still succeeds.
+        output = self.call(scheme_args + [self.worktree_dir_b])
+        self.assertIn("add-worktree succeeded", output)
+        repo1_b = os.path.join(self.worktree_dir_b, "repo1")
+        self.assertEqual(self.current_branch(repo1_b), "HEAD")
+        self.assertEqual(self.head_commit(repo1_a), self.head_commit(repo1_b))

--- a/utils/update_checkout/tests/test_remove_worktree.py
+++ b/utils/update_checkout/tests/test_remove_worktree.py
@@ -1,0 +1,203 @@
+# ===--- test_remove_worktree.py ------------------------------------------===#
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2026 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ===----------------------------------------------------------------------===#
+
+import os
+
+from . import scheme_mock
+
+
+ADD_WORKTREE_PATH = os.path.abspath(
+    os.path.join(
+        scheme_mock.CURRENT_FILE_DIR,
+        os.path.pardir,
+        os.path.pardir,
+        "add-worktree",
+    )
+)
+
+REMOVE_WORKTREE_PATH = os.path.abspath(
+    os.path.join(
+        scheme_mock.CURRENT_FILE_DIR,
+        os.path.pardir,
+        os.path.pardir,
+        "remove-worktree",
+    )
+)
+
+
+class RemoveWorktreeTestCase(scheme_mock.SchemeMockTestCase):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.worktree_dir = os.path.join(self.workspace, "worktrees")
+
+    def clone_source_root(self):
+        self.call(self.base_args + ["--clone"])
+
+    def create_worktrees(self):
+        self.call(
+            [ADD_WORKTREE_PATH, "--source-root", self.source_root, self.worktree_dir]
+        )
+
+    def add_worktrees(self):
+        self.clone_source_root()
+        self.create_worktrees()
+
+    def dirty(self, repo):
+        with open(os.path.join(self.worktree_dir, repo, "dirty.txt"), "w") as f:
+            f.write("uncommitted\n")
+
+    def add_submodule_worktrees(self, repo):
+        """Sets up worktrees where `repo` contains a populated submodule, and
+        returns the submodule path inside that repo's worktree.
+
+        The submodule must be committed to the source repository before the
+        worktree is created, since the worktree is detached at the source HEAD.
+        git refuses to `worktree remove` a worktree containing submodules unless
+        forced, so this exercises that path.
+        """
+        self.clone_source_root()
+
+        submodule_origin = os.path.join(self.workspace, "submodule-origin")
+        self.call(["git", "init", submodule_origin])
+        self.call(
+            ["git", "-C", submodule_origin, "commit", "--allow-empty", "-m", "sub"]
+        )
+
+        source_repo = os.path.join(self.source_root, repo)
+        # 'protocol.file.allow=always' is required for submodules over file://.
+        self.call(
+            [
+                "git",
+                "-c",
+                "protocol.file.allow=always",
+                "-C",
+                source_repo,
+                "submodule",
+                "add",
+                submodule_origin,
+                "sub",
+            ]
+        )
+        self.call(["git", "-C", source_repo, "commit", "-m", "add submodule"])
+
+        self.create_worktrees()
+
+        worktree_repo = os.path.join(self.worktree_dir, repo)
+        self.call(
+            [
+                "git",
+                "-c",
+                "protocol.file.allow=always",
+                "-C",
+                worktree_repo,
+                "submodule",
+                "update",
+                "--init",
+                "--recursive",
+            ]
+        )
+        return os.path.join(worktree_repo, "sub")
+
+    def worktree_exists(self, repo):
+        return os.path.exists(os.path.join(self.worktree_dir, repo))
+
+    def test_removes_all_worktrees(self):
+        self.add_worktrees()
+
+        self.call([REMOVE_WORKTREE_PATH, self.worktree_dir])
+
+        # Once every worktree is removed, the worktree directory is deleted.
+        self.assertFalse(os.path.exists(self.worktree_dir))
+
+    def test_skips_dirty_without_force(self):
+        self.add_worktrees()
+        self.dirty("repo1")
+
+        # The dirty worktree is reported and left in place (non-zero exit),
+        # while the clean worktrees are still removed.
+        with self.assertRaises(scheme_mock.PrintableSubprocessError) as cm:
+            self.call([REMOVE_WORKTREE_PATH, self.worktree_dir])
+
+        # The report matches git's own `worktree remove` wording.
+        self.assertIn(
+            "contains modified or untracked files, use --force to delete it",
+            cm.exception.output,
+        )
+        self.assertTrue(self.worktree_exists("repo1"))
+        self.assertFalse(self.worktree_exists("repo2"))
+
+    def test_force_removes_dirty_and_tolerates_already_removed(self):
+        self.add_worktrees()
+        self.dirty("repo1")
+
+        # First run removes the clean worktrees and fails on the dirty one.
+        with self.assertRaises(scheme_mock.PrintableSubprocessError):
+            self.call([REMOVE_WORKTREE_PATH, self.worktree_dir])
+
+        # '--force' removes the remaining dirty worktree and tolerates the
+        # worktrees the first run already removed.
+        self.call([REMOVE_WORKTREE_PATH, "--force", self.worktree_dir])
+
+        self.assertFalse(os.path.exists(self.worktree_dir))
+
+    def test_removes_clean_submodule_worktree(self):
+        self.add_submodule_worktrees("repo1")
+
+        # git refuses to remove a submodule worktree without --force, so the
+        # tool always removes with --force internally; a clean one still goes.
+        self.call([REMOVE_WORKTREE_PATH, self.worktree_dir])
+
+        self.assertFalse(os.path.exists(self.worktree_dir))
+
+    def test_skips_dirty_submodule_without_force(self):
+        submodule_path = self.add_submodule_worktrees("repo1")
+
+        # Uncommitted changes inside the submodule must be detected too.
+        with open(os.path.join(submodule_path, "dirty.txt"), "w") as f:
+            f.write("uncommitted\n")
+
+        with self.assertRaises(scheme_mock.PrintableSubprocessError) as cm:
+            self.call([REMOVE_WORKTREE_PATH, self.worktree_dir])
+
+        # When only the submodule is dirty, the report points at the submodule
+        # path rather than the worktree, so the dirt is easy to find.
+        self.assertIn(
+            f"'{os.path.realpath(submodule_path)}' contains modified or "
+            "untracked files",
+            cm.exception.output,
+        )
+        self.assertTrue(self.worktree_exists("repo1"))
+        self.assertFalse(self.worktree_exists("repo2"))
+
+        # '--force' removes the dirty submodule worktree.
+        self.call([REMOVE_WORKTREE_PATH, "--force", self.worktree_dir])
+
+        self.assertFalse(os.path.exists(self.worktree_dir))
+
+    def test_missing_directory_fails(self):
+        missing = os.path.join(self.workspace, "does-not-exist")
+        with self.assertRaises(scheme_mock.PrintableSubprocessError):
+            self.call([REMOVE_WORKTREE_PATH, missing])
+
+    def test_empty_directory_is_removed(self):
+        empty = os.path.join(self.workspace, "empty")
+        os.makedirs(empty)
+        # No worktrees to remove: succeeds and deletes the empty directory.
+        self.call([REMOVE_WORKTREE_PATH, empty])
+        self.assertFalse(os.path.exists(empty))
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/utils/update_checkout/update_checkout/commands/status.py
+++ b/utils/update_checkout/update_checkout/commands/status.py
@@ -9,7 +9,7 @@ from ..cli_arguments import CliArguments
 from ..git_command import (
     Git,
     is_any_repository_locked,
-    is_git_repository,
+    iter_git_repositories,
 )
 
 
@@ -27,9 +27,7 @@ class StatusCommand:
     def __init__(self, args: CliArguments):
         self._args = args
         self._pool_args = []
-        for repo_path in args.source_root.iterdir():
-            if not is_git_repository(repo_path):
-                continue
+        for repo_path in iter_git_repositories(args.source_root):
             repo_name = repo_path.name
 
             my_args = RunnerArguments(

--- a/utils/update_checkout/update_checkout/git_command.py
+++ b/utils/update_checkout/update_checkout/git_command.py
@@ -3,7 +3,7 @@ import re
 import shlex
 import subprocess
 import sys
-from typing import List, Any, Optional, Dict, Set, Tuple
+from typing import List, Any, Iterator, Optional, Dict, Set, Tuple
 
 from .runner_arguments import RunnerArguments
 
@@ -156,6 +156,21 @@ def is_git_repository(path: Path) -> bool:
         return False
     git_dir_path = path.joinpath(".git")
     return git_dir_path.exists() and git_dir_path.is_dir()
+
+
+def iter_git_repositories(source_root: Path) -> Iterator[Path]:
+    """Yields the path of each Git repository in a source root directory.
+
+    Args:
+        source_root (Path): The directory to scan for Git repositories.
+
+    Yields:
+        Path: The path to each immediate subdirectory that is a Git repository.
+    """
+
+    for path in source_root.iterdir():
+        if is_git_repository(path):
+            yield path
 
 
 def is_any_repository_locked(pool_args: List[RunnerArguments]) -> Set[str]:

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -573,33 +573,34 @@ def get_scheme_map(
     return None
 
 
-def _check_missing_clones(
+def check_missing_clones(
     args: CliArguments, config: Dict[str, Any], scheme_map: Dict[str, Any]
-):
+) -> List[str]:
     """
     Verify that all repositories defined in the scheme map are present in the
-    source root directory. If a repository is missing—and not explicitly skipped—
-    the user is prompted to re-run the script with the `--clone` option.
+    source root directory.
 
-    This function also respects per-repository platform restrictions: if the
-    current platform is not listed for a repo, that repo is ignored.
+    This function respects explicitly skipped repositories and platform
+    restrictions: if the repo is skipped or the current platform is not listed
+    for a repo, that repo is ignored.
 
     Args:
         args (CliArguments): Parsed CLI arguments.
         config (Dict[str, Any]): deserialized `update-checkout-config.json`.
-        scheme_map (Dict[str, str] | None): map of repo names to branches to check out.
+        scheme_map (Dict[str, str] | None): map of repo names to branches.
+
+    Returns:
+        List[str]: the names of the scheme's repositories that are not present
+            in the source root.
     """
 
+    missing = []
     for repo in scheme_map:
-        if _should_skip_repo(args, config, repo):
+        if should_skip_repo(args, config, repo):
             continue
-
         if not args.source_root.joinpath(repo).exists():
-            print(
-                "You don't have all swift sources. "
-                "Call this script with --clone to get them."
-            )
-            return
+            missing.append(repo)
+    return missing
 
 
 def _check_git_config(
@@ -621,7 +622,7 @@ def _check_git_config(
     }
 
     for repo in scheme_map:
-        if _should_skip_repo(args, config, repo):
+        if should_skip_repo(args, config, repo):
             continue
 
         repo_path = args.source_root.joinpath(repo)
@@ -645,7 +646,7 @@ def _check_git_config(
                 pass
 
 
-def _should_skip_repo(args: CliArguments, config: Dict[str, Any], repo: str) -> bool:
+def should_skip_repo(args: CliArguments, config: Dict[str, Any], repo: str) -> bool:
     """Check if a repository should be skipped based on platform or skip list."""
     if repo in args.skip_repository_list:
         return True
@@ -1053,6 +1054,28 @@ def validate_config(config: Dict[str, Any]):
                 seen[alias] = scheme_name
 
 
+def load_config(configs: List[str]) -> Dict[str, Any]:
+    """Loads and merges update-checkout configuration files.
+
+    Args:
+        configs (List[str]): configuration file paths. When empty, the
+            update-checkout-config.json shipped alongside update-checkout is
+            used.
+
+    Returns:
+        Dict[str, Any]: the merged, validated configuration.
+    """
+
+    if not configs:
+        configs = [str(SCRIPT_DIR.parent.joinpath("update-checkout-config.json"))]
+    config: Dict[str, Any] = {}
+    for config_path in configs:
+        with open(config_path) as f:
+            config = merge_config(config, json.load(f))
+    validate_config(config)
+    return config
+
+
 def full_target_name(repo_path: Path, remote: str, target: str) -> str:
     branch, _, _ = Git.run(repo_path, ["branch", "--list", target], fatal=True)
     branch = branch.replace("* ", "")
@@ -1118,15 +1141,7 @@ def main() -> int:
             )
             sys.exit(1)
 
-    # Set the default config path if none are specified
-    if not args.configs:
-        default_path = SCRIPT_DIR.parent.joinpath("update-checkout-config.json")
-        args.configs.append(str(default_path))
-    config: Dict[str, Any] = {}
-    for config_path in args.configs:
-        with open(config_path) as f:
-            config = merge_config(config, json.load(f))
-    validate_config(config)
+    config = load_config(args.configs)
 
     cross_repos_pr: Dict[str, str] = {}
     if args.github_comment:
@@ -1185,11 +1200,7 @@ def main() -> int:
                 )
 
                 # Re-read the config after checkout.
-                config = {}
-                for config_path in args.configs:
-                    with open(config_path) as f:
-                        config = merge_config(config, json.load(f))
-                validate_config(config)
+                config = load_config(args.configs)
                 scheme_map = get_scheme_map(config, scheme_name)
 
         if args.dump_hashes:
@@ -1200,7 +1211,11 @@ def main() -> int:
             dump_repo_hashes(args, config, args.dump_hashes_config)
             return 0
 
-        _check_missing_clones(args=args, config=config, scheme_map=scheme_map)
+        if check_missing_clones(args=args, config=config, scheme_map=scheme_map):
+            print(
+                "You don't have all swift sources. "
+                "Call this script with --clone to get them."
+            )
 
         skipped_repositories, update_results = update_all_repositories(
             args, config, scheme_name, scheme_map, cross_repos_pr


### PR DESCRIPTION
Using Git worktrees with Swift can be difficult in a few scenarios.

1. Sometimes I need to make a Swift worktree on a different branch scheme, but I'm also working on llvm in the original scheme so I don't want to switch everything in my existing setup.
2. The Swift worktree fights over the same build directory with the main checkout and every other worktree I have going on. What I really need is a scratch area that Claude can use for testing/experimenting.

Make a new utility called add-worktree that makes worktrees for all of the Swift repos, and optionally changes its branch scheme. Make a companion remove-worktree utility to clean up.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>