### PR TITLE
Sema: Add iteration limit for associated type inference

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3370,6 +3370,11 @@ ERROR(ambiguous_associated_type_from_parameterized_protocols,none,
      (const AssociatedTypeDecl *, const ProtocolDecl *))
 NOTE(associated_type_candidate_from_parameterized_protocol,none,
      "candidate inferred from parameterized protocol here", ())
+ERROR(associated_type_inference_too_complex,none,
+     "the compiler is unable to infer the associated types in this "
+     "conformance of %0 to %1 in reasonable time",
+     (Type, const ProtocolDecl *))
+
 NOTE(protocol_witness_exact_match,none,
      "candidate exactly matches%0", (StringRef))
 NOTE(protocol_witness_non_sendable,none,

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -653,6 +653,9 @@ namespace swift {
     /// Enables dumping type witness systems from associated type inference.
     bool DumpTypeWitnessSystems = false;
 
+    /// Maximum iteration count for associated type inference.
+    unsigned AssociatedTypeInferenceIterations = 1000000;
+
     /// Enables dumping macro expansions.
     bool DumpMacroExpansions = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -553,6 +553,10 @@ def max_substitution_count : Joined<["-"], "max-substitution-count=">,
   Flags<[FrontendOption, HelpHidden, DoesNotAffectIncrementalBuild]>,
   HelpText<"Set the maximum step count for type substitution operations">;
 
+def max_associated_type_inference_iterations : Joined<["-"], "max-associated-type-inference-iterations=">,
+  Flags<[FrontendOption, HelpHidden, DoesNotAffectIncrementalBuild]>,
+  HelpText<"Maximum number of iterations to attempt in the type witness solver">;
+
 def dump_type_witness_systems : Flag<["-"], "dump-type-witness-systems">,
   HelpText<"Enables dumping type witness systems from associated type inference">;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1888,6 +1888,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   Opts.DumpTypeWitnessSystems = Args.hasArg(OPT_dump_type_witness_systems);
 
+  setUnsignedIntegerArgument(OPT_max_associated_type_inference_iterations,
+                             Opts.AssociatedTypeInferenceIterations);
+
   for (auto &block: FrontendOpts.BlocklistConfigFilePaths)
     Opts.BlocklistConfigFilePaths.push_back(block);
   if (const Arg *A = Args.getLastArg(options::OPT_concurrency_model)) {

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -1191,12 +1191,15 @@ class AssociatedTypeInference {
   Type failedDefaultedWitness;
   CheckTypeWitnessResult failedDefaultedResult = CheckTypeWitnessResult::forSuccess();
 
-  // Which type witness was missing?
+  /// Which type witness was missing?
   AssociatedTypeDecl *missingTypeWitness = nullptr;
 
-  // Was there a conflict in type witness deduction?
+  /// Was there a conflict in type witness deduction?
   std::optional<TypeWitnessConflict> typeWitnessConflict;
   unsigned numTypeWitnessesBeforeConflict = 0;
+
+  /// Number of iterations remaining before we give up.
+  unsigned RemainingIterations = 0;
 
 public:
   AssociatedTypeInference(ASTContext &ctx,
@@ -1292,13 +1295,16 @@ private:
       ArrayRef<AssociatedTypeDecl *> unresolvedAssocTypes, unsigned reqDepth);
 
   /// Top-level operation to find solutions for the given unresolved
-  /// associated types.
-  void findSolutions(
+  /// associated types. Returns true if the problem instance is too complex.
+  [[nodiscard]]
+  bool findSolutions(
                  ArrayRef<AssociatedTypeDecl *> unresolvedAssocTypes,
                  SmallVectorImpl<InferredTypeWitnessesSolution> &solutions);
 
   /// Explore the solution space to find both viable and non-viable solutions.
-  void findSolutionsRec(
+  /// Returns true if the problem instance is too complex.
+  [[nodiscard]]
+  bool findSolutionsRec(
          ArrayRef<AssociatedTypeDecl *> unresolvedAssocTypes,
          SmallVectorImpl<InferredTypeWitnessesSolution> &solutions,
          SmallVectorImpl<InferredTypeWitnessesSolution> &nonViableSolutions,
@@ -1336,6 +1342,10 @@ private:
                 ArrayRef<AssociatedTypeDecl *> unresolvedAssocTypes,
                 SmallVectorImpl<InferredTypeWitnessesSolution> &solutions);
 
+  /// Emit a diagnostic that associated type inference reached the iteration
+  /// limit.
+  void diagnoseTooComplex();
+
 public:
   /// Describes a mapping from associated type declarations to their
   /// type witnesses (as interface types).
@@ -1353,7 +1363,9 @@ public:
 AssociatedTypeInference::AssociatedTypeInference(
     ASTContext &ctx, NormalProtocolConformance *conformance)
     : ctx(ctx), conformance(conformance), proto(conformance->getProtocol()),
-      dc(conformance->getDeclContext()), adoptee(conformance->getType()) {}
+      dc(conformance->getDeclContext()), adoptee(conformance->getType()) {
+  RemainingIterations = ctx.LangOpts.AssociatedTypeInferenceIterations;
+}
 
 namespace {
 
@@ -3369,7 +3381,8 @@ AssociatedTypeDecl *AssociatedTypeInference::inferAbstractTypeWitnesses(
   return nullptr;
 }
 
-void AssociatedTypeInference::findSolutions(
+/// Returns true if the problem instance was too complex.
+bool AssociatedTypeInference::findSolutions(
                    ArrayRef<AssociatedTypeDecl *> unresolvedAssocTypes,
                    SmallVectorImpl<InferredTypeWitnessesSolution> &solutions) {
   FrontendStatsTracer StatsTracer(getASTContext().Stats,
@@ -3377,8 +3390,14 @@ void AssociatedTypeInference::findSolutions(
 
   SmallVector<InferredTypeWitnessesSolution, 4> nonViableSolutions;
   SmallVector<std::pair<ValueDecl *, ValueDecl *>, 4> valueWitnesses;
-  findSolutionsRec(unresolvedAssocTypes, solutions, nonViableSolutions,
-                   valueWitnesses, 0, 0, 0);
+  bool tooComplex
+      = findSolutionsRec(unresolvedAssocTypes, solutions, nonViableSolutions,
+                         valueWitnesses, 0, 0, 0);
+
+  if (tooComplex) {
+    LLVM_DEBUG(llvm::dbgs() << "=== Iteration limit reached\n");
+    return true;
+  }
 
   for (auto solution : solutions) {
     LLVM_DEBUG(llvm::dbgs() << "=== Valid solution:\n";);
@@ -3389,9 +3408,13 @@ void AssociatedTypeInference::findSolutions(
     LLVM_DEBUG(llvm::dbgs() << "=== Invalid solution:\n";);
     LLVM_DEBUG(solution.dump(llvm::dbgs()));
   }
+
+  return false;
 }
 
-void AssociatedTypeInference::findSolutionsRec(
+/// Explore the solution space to find both viable and non-viable solutions.
+/// Returns true if the problem instance is too complex.
+bool AssociatedTypeInference::findSolutionsRec(
           ArrayRef<AssociatedTypeDecl *> unresolvedAssocTypes,
           SmallVectorImpl<InferredTypeWitnessesSolution> &solutions,
           SmallVectorImpl<InferredTypeWitnessesSolution> &nonViableSolutions,
@@ -3399,12 +3422,19 @@ void AssociatedTypeInference::findSolutionsRec(
           unsigned numTypeWitnesses,
           unsigned numValueWitnessesInProtocolExtensions,
           unsigned reqDepth) {
+  // The problem is NP-hard so we have to give up at some point if we haven't
+  // yet found all the solutions.
+  if (RemainingIterations == 0)
+    return true;
+
+  --RemainingIterations;
+
   // If this solution is going to be worse than what we've already recorded,
-  // give up now.
+  // skip it.
   if (!solutions.empty() &&
       solutions.front().NumValueWitnessesInProtocolExtensions
           < numValueWitnessesInProtocolExtensions) {
-    return;
+    return false;
   }
 
   using TypeWitnessesScope = decltype(typeWitnesses)::ScopeTy;
@@ -3442,7 +3472,7 @@ void AssociatedTypeInference::findSolutionsRec(
 
           LLVM_DEBUG(llvm::dbgs() << std::string(valueWitnesses.size(), '+')
                      << "+ Recorded an erroneous type witness\n";);
-          return;
+          return false;
         }
       }
     }
@@ -3458,7 +3488,7 @@ void AssociatedTypeInference::findSolutionsRec(
 
       LLVM_DEBUG(llvm::dbgs() << std::string(valueWitnesses.size(), '+')
                  << "+ Failed to infer abstract witnesses\n";);
-      return;
+      return false;
     }
 
     ++NumSolutionStates;
@@ -3466,7 +3496,7 @@ void AssociatedTypeInference::findSolutionsRec(
     if (simplifyCurrentTypeWitnesses()) {
       LLVM_DEBUG(llvm::dbgs() << std::string(valueWitnesses.size(), '+')
                  << "+ Unsubstituted witnesses remain\n";);
-      return;
+      return false;
     }
 
     /// Check the current set of type witnesses.
@@ -3500,11 +3530,11 @@ void AssociatedTypeInference::findSolutionsRec(
         LLVM_DEBUG(llvm::dbgs() << std::string(valueWitnesses.size(), '+')
                    << "+ Duplicate invalid solution found\n";);
         ++NumDuplicateSolutionStates;
-        return;
+        return false;
       }
 
       nonViableSolutions.push_back(std::move(solution));
-      return;
+      return false;
     }
 
     // For valid solutions, we want to find the best solution if one exists.
@@ -3519,7 +3549,7 @@ void AssociatedTypeInference::findSolutionsRec(
       LLVM_DEBUG(llvm::dbgs() << std::string(valueWitnesses.size(), '+')
                  << "+ Solution is worse than some existing solution\n";);
       ++NumDuplicateSolutionStates;
-      return;
+      return false;
     }
 
     // If any existing solutions are clearly worse than this solution,
@@ -3537,7 +3567,7 @@ void AssociatedTypeInference::findSolutionsRec(
 
     solutions.push_back(std::move(solution));
 
-    return;
+    return false;
   }
 
   // Iterate over the potential witnesses for this requirement,
@@ -3559,12 +3589,17 @@ void AssociatedTypeInference::findSolutionsRec(
       if (!isa<TypeDecl>(inferredReq.first))
         ++numValueWitnessesInProtocolExtensions;
       valueWitnesses.push_back({inferredReq.first, nullptr});
-      findSolutionsRec(unresolvedAssocTypes, solutions, nonViableSolutions,
-                       valueWitnesses, numTypeWitnesses,
-                       numValueWitnessesInProtocolExtensions, reqDepth + 1);
+      bool tooComplex
+        = findSolutionsRec(unresolvedAssocTypes, solutions, nonViableSolutions,
+                           valueWitnesses, numTypeWitnesses,
+                           numValueWitnessesInProtocolExtensions, reqDepth + 1);
       valueWitnesses.pop_back();
       if (!isa<TypeDecl>(inferredReq.first))
         --numValueWitnessesInProtocolExtensions;
+
+      if (tooComplex)
+        return true;
+
       continue;
     }
 
@@ -3587,10 +3622,14 @@ void AssociatedTypeInference::findSolutionsRec(
         typeWitnesses.insert(typeWitness.first, {typeWitness.second, reqDepth});
 
         valueWitnesses.push_back({inferredReq.first, witnessReq.Witness});
-        findSolutionsRec(unresolvedAssocTypes, solutions, nonViableSolutions,
-                         valueWitnesses, numTypeWitnesses,
-                         numValueWitnessesInProtocolExtensions, reqDepth + 1);
+        bool tooComplex
+            = findSolutionsRec(unresolvedAssocTypes, solutions, nonViableSolutions,
+                               valueWitnesses, numTypeWitnesses,
+                               numValueWitnessesInProtocolExtensions, reqDepth + 1);
         valueWitnesses.pop_back();
+
+        if (tooComplex)
+          return true;
       }
 
       continue;
@@ -3688,10 +3727,16 @@ void AssociatedTypeInference::findSolutionsRec(
       continue;
 
     // Recurse
-    findSolutionsRec(unresolvedAssocTypes, solutions, nonViableSolutions,
-                     valueWitnesses, numTypeWitnesses,
-                     numValueWitnessesInProtocolExtensions, reqDepth + 1);
+    bool tooComplex
+        = findSolutionsRec(unresolvedAssocTypes, solutions, nonViableSolutions,
+                           valueWitnesses, numTypeWitnesses,
+                           numValueWitnessesInProtocolExtensions, reqDepth + 1);
+
+    if (tooComplex)
+      return true;
   }
+
+  return false;
 }
 
 static Comparison compareDeclsForInference(DeclContext *DC, ValueDecl *decl1,
@@ -4233,6 +4278,15 @@ bool AssociatedTypeInference::diagnoseAmbiguousSolutions(
   return false;
 }
 
+void AssociatedTypeInference::diagnoseTooComplex() {
+  ctx.addDelayedConformanceDiag(conformance, true,
+    [](NormalProtocolConformance *conformance) {
+      conformance->getDeclContext()->getAsDecl()
+          ->diagnose(diag::associated_type_inference_too_complex,
+                     conformance->getType(), conformance->getProtocol());
+    });
+}
+
 auto AssociatedTypeInference::solve() -> std::optional<InferredTypeWitnesses> {
   LLVM_DEBUG(llvm::dbgs() << "============ Start " << conformance->getType()
                           << ": " << conformance->getProtocol()->getName()
@@ -4301,7 +4355,23 @@ auto AssociatedTypeInference::solve() -> std::optional<InferredTypeWitnesses> {
 
   // Compute the set of solutions.
   SmallVector<InferredTypeWitnessesSolution, 4> solutions;
-  findSolutions(unresolvedAssocTypes.getArrayRef(), solutions);
+  bool tooComplex
+      = findSolutions(unresolvedAssocTypes.getArrayRef(), solutions);
+
+  // If we exceeded the iteration limit, diagnose and immediately give up.
+  //
+  // We intentionally don't even look at any of the solutions we found,
+  // because we can't be sure we've found them all.
+  if (tooComplex) {
+    diagnoseTooComplex();
+
+    // Save the missing type witnesses for later diagnosis.
+    for (auto assocType : unresolvedAssocTypes) {
+      ctx.addDelayedMissingWitness(conformance, {assocType, {}});
+    }
+
+    return std::nullopt;
+  }
 
   // Go make sure that type declarations that would act as witnesses
   // did not get injected while we were performing checks above. This

--- a/test/AssociatedTypeInference/iteration_limit.swift
+++ b/test/AssociatedTypeInference/iteration_limit.swift
@@ -1,0 +1,122 @@
+// RUN: %target-typecheck-verify-swift
+
+/// If this test case ever starts to be type checked successfully because of
+/// optimizations in associated type inference, you will need to change it
+/// in some way to make it too complex again. If you are unable to construct
+/// a test case that still takes too long with your new optimization,
+/// congratulations, you found a proof that P = NP.
+
+protocol P {
+  associatedtype A: Error
+  // expected-note@-1 {{protocol requires nested type 'A'}}
+
+  func f1() throws(A)
+  func f2() throws(A)
+  func f3() throws(A)
+  func f4() throws(A)
+  func f5() throws(A)
+  func f6() throws(A)
+  func f7() throws(A)
+  func f8() throws(A)
+  func f9() throws(A)
+  func f10() throws(A)
+  func f11() throws(A)
+  func f12() throws(A)
+  func f13() throws(A)
+  func f14() throws(A)
+  func f15() throws(A)
+  func f16() throws(A)
+  func f17() throws(A)
+  func f18() throws(A)
+  func f19() throws(A)
+  func f20() throws(A)
+  func f21() throws(A)
+  func f22() throws(A)
+  func f23() throws(A)
+  func f24() throws(A)
+  func f25() throws(A)
+  func f26() throws(A)
+  func f27() throws(A)
+  func f28() throws(A)
+  func f29() throws(A)
+  func f30() throws(A)
+  func f31() throws(A)
+  func f32() throws(A)
+}
+
+extension P {
+  func f1() throws(A) {}
+  func f2() throws(A) {}
+  func f3() throws(A) {}
+  func f4() throws(A) {}
+  func f5() throws(A) {}
+  func f6() throws(A) {}
+  func f7() throws(A) {}
+  func f8() throws(A) {}
+  func f9() throws(A) {}
+  func f10() throws(A) {}
+  func f11() throws(A) {}
+  func f12() throws(A) {}
+  func f13() throws(A) {}
+  func f14() throws(A) {}
+  func f15() throws(A) {}
+  func f16() throws(A) {}
+  func f17() throws(A) {}
+  func f18() throws(A) {}
+  func f19() throws(A) {}
+  func f20() throws(A) {}
+  func f21() throws(A) {}
+  func f22() throws(A) {}
+  func f23() throws(A) {}
+  func f24() throws(A) {}
+  func f25() throws(A) {}
+  func f26() throws(A) {}
+  func f27() throws(A) {}
+  func f28() throws(A) {}
+  func f29() throws(A) {}
+  func f30() throws(A) {}
+  func f31() throws(A) {}
+  func f32() throws(A) {}
+}
+
+protocol Q {}
+
+extension Q {
+  func f1() throws(any Error) {}
+  func f2() throws(any Error) {}
+  func f3() throws(any Error) {}
+  func f4() throws(any Error) {}
+  func f5() throws(any Error) {}
+  func f6() throws(any Error) {}
+  func f7() throws(any Error) {}
+  func f8() throws(any Error) {}
+  func f9() throws(any Error) {}
+  func f10() throws(any Error) {}
+  func f11() throws(any Error) {}
+  func f12() throws(any Error) {}
+  func f13() throws(any Error) {}
+  func f14() throws(any Error) {}
+  func f15() throws(any Error) {}
+  func f16() throws(any Error) {}
+  func f17() throws(any Error) {}
+  func f18() throws(any Error) {}
+  func f19() throws(any Error) {}
+  func f20() throws(any Error) {}
+  func f21() throws(any Error) {}
+  func f22() throws(any Error) {}
+  func f23() throws(any Error) {}
+  func f24() throws(any Error) {}
+  func f25() throws(any Error) {}
+  func f26() throws(any Error) {}
+  func f27() throws(any Error) {}
+  func f28() throws(any Error) {}
+  func f29() throws(any Error) {}
+  func f30() throws(any Error) {}
+  func f31() throws(any Error) {}
+  func f32() throws(any Error) {}
+}
+
+struct S: P, Q {}
+// expected-error@-1 {{type 'S' does not conform to protocol 'P'}}
+// expected-error@-2 {{the compiler is unable to infer the associated types in this conformance of 'S' to 'P' in reasonable time}}
+// expected-note@-3 {{add stubs for conformance}}


### PR DESCRIPTION
As described in the Swift generics book, associated type inference is NP-hard. This is the first report I've seen where this bites in the wild.

We could still accept the test case with a smarter analysis, but for now, let's diagnose instead of taking a very long time.

I'm setting the limit to a million iterations by default, which makes the test case fail in about a second. Hopefully we don't have to increase this in practice. The `-max-associated-type-inference-iterations=` command line flag can be used to change the limit.

Fixes rdar://problem/168299799.