### PR TITLE
[Test] Mark two concurrency testt as requiring the concurrency runtime.

### DIFF
--- a/test/Interpreter/objc_sending_execution.swift
+++ b/test/Interpreter/objc_sending_execution.swift
@@ -18,6 +18,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
+// REQUIRES: concurrency_runtime
 
 import Foundation
 import StdlibUnittest

--- a/test/stdlib/Result+asyncInit.swift
+++ b/test/stdlib/Result+asyncInit.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
 
 // FIXME: wasi-wasm32 traps in Result<T, any Error>'s value-witness copy
 // after returning from the new Result.init(catching:) async.


### PR DESCRIPTION
Add REQUIRES: concurrency_runtime to Result+asyncInit and objc_sending_execution.

rdar://181060053