### PR TITLE
FreeBSD: Re-enable two more reflection tests

### DIFF
--- a/test/AutoDiff/validation-test/reflection.swift
+++ b/test/AutoDiff/validation-test/reflection.swift
@@ -1,10 +1,7 @@
 // REQUIRES: no_asan
-// UNSUPPORTED: OS=linux-android, OS=linux-androideabi, OS=wasip1, OS=emscripten
+// UNSUPPORTED: OS=wasip1, OS=emscripten
 // RUN: %empty-directory(%t)
 import _Differentiation
-
-// Missing the field on FreeBSD (rdar://173266760)
-// XFAIL: OS=freebsd
 
 // RUN: %target-build-swift -Xfrontend -enable-anonymous-context-mangled-names %S/Inputs/AutoDiffTypes.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/%target-library-name(TypesToReflect)
 // RUN: %target-build-swift -Xfrontend -enable-anonymous-context-mangled-names %S/Inputs/AutoDiffTypes.swift %S/Inputs/main.swift -emit-module -emit-executable -module-name TypesToReflect -o %t/TypesToReflect

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -6,9 +6,6 @@
 // XFAIL: OS=windows-msvc
 // RUN: %empty-directory(%t)
 
-// rdar://173266760
-// XFAIL: OS=freebsd
-
 // rdar://100558042
 // UNSUPPORTED: CPU=arm64e
 


### PR DESCRIPTION
After landing the fixed reflection loading machinery, these two tests started unexpectedly passing on FreeBSD.

The AutoDiff reflection test was also marked unsupported on Android and should be working there now too.

Re-enabling both tests on FreeBSD and the Autodiff test on Android.