### PR TITLE
[6.3][Concurrency] Fix `nonisolated(nonsending)` conversion stripping to a…

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5068,7 +5068,8 @@ ActorIsolationChecker::determineClosureIsolation(AbstractClosureExpr *closure,
     // isolated parameters. If our closure is nonisolated and we have a
     // conversion to nonisolated(nonsending), then we should respect that.
     if (auto *explicitClosure = dyn_cast<ClosureExpr>(closure);
-        isIsolationBoundary || !normalIsolation.isGlobalActor()) {
+        explicitClosure &&
+        (isIsolationBoundary || !normalIsolation.isGlobalActor())) {
       if (auto *fce = dyn_cast_or_null<FunctionConversionExpr>(context)) {
         auto expectedIsolation =
             fce->getType()->castTo<FunctionType>()->getIsolation();

--- a/test/Concurrency/attr_execution/conversions.swift
+++ b/test/Concurrency/attr_execution/conversions.swift
@@ -161,3 +161,19 @@ func testNonSendableDiagnostics(
   let _: @MyActor () async -> NonSendable = globalActor2
   // expected-error@-1 {{cannot convert value actor-isolated to 'MainActor' to specified type actor-isolated to 'MyActor'}}
 }
+
+do {
+  func parallelMap<E, T>(
+    _: nonisolated(nonsending) @Sendable @escaping (E) async throws -> T
+  ) async rethrows {
+  }
+
+  struct Test {
+    init(x: Int) async throws {}
+
+    func test() async throws {
+      try await parallelMap(Self.init(x:))
+      // expected-warning@-1 {{converting non-Sendable function value to 'nonisolated(nonsending) @Sendable (Int) async throws -> Test' may introduce data races}}
+    }
+  }
+}


### PR DESCRIPTION
…pply only to explicit closures

- Explanation:

  Add a missing `nullptr` check to the condition that attempts to apply `nonisolated(nonsending)` directly onto a closure, this should only be done for explicit closures. This is a problem only in 6.3, newer complers have this checking completely reworked.

- Resolves: rdar://181859790

- Main branch PR: Not needed. This is 6.3 only issue.

- Risk: Very low. The change adds a missing `nullptr` check, this only affects code that uses nonisolated autoclosures that are converted into  a function value with `nonisolated(nonsending)` isolation.

- Reviewed By: N/A 

- Testing: Added new test-cases to the suite.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
