### PR TITLE
[RemoteInspection] Guard null children in DemanglingForTypeRef.

### DIFF
--- a/stdlib/public/RemoteInspection/TypeRef.cpp
+++ b/stdlib/public/RemoteInspection/TypeRef.cpp
@@ -700,6 +700,18 @@ class DemanglingForTypeRef
 public:
   DemanglingForTypeRef(Demangle::Demangler &Dem) : Dem(Dem) {}
 
+  /// Add \p child to \p parent, propagating failure instead of crashing:
+  /// returns false when \p child is null. Demangling a TypeRef reconstructed
+  /// from a remote process can fail on any subterm (corrupt, truncated, or
+  /// newer-version metadata), and Node::addChild asserts and aborts on a null
+  /// child. Callers should return null when this returns false.
+  bool tryAddChild(Demangle::NodePointer parent, Demangle::NodePointer child) {
+    if (!child)
+      return false;
+    parent->addChild(child, Dem);
+    return true;
+  }
+
   Demangle::NodePointer visit(const TypeRef *typeRef) {
     auto node = TypeRefVisitor<DemanglingForTypeRef,
                                 Demangle::NodePointer>::visit(typeRef);
@@ -759,10 +771,16 @@ public:
       genericNodeKind = Node::Kind::BoundGenericOtherNominalType;
     }
     auto unspecializedType = Dem.demangleType(BG->getMangledName());
+    if (!unspecializedType)
+      return nullptr;
 
     auto genericArgsList = Dem.createNode(Node::Kind::TypeList);
-    for (auto param : BG->getGenericParams())
-      genericArgsList->addChild(visit(param), Dem);
+    for (auto param : BG->getGenericParams()) {
+      auto paramNode = visit(param);
+      if (!paramNode)
+        return nullptr;
+      genericArgsList->addChild(paramNode, Dem);
+    }
 
     auto genericNode = Dem.createNode(genericNodeKind);
     genericNode->addChild(unspecializedType, Dem);
@@ -815,7 +833,8 @@ public:
         auto name = Dem.createNode(Node::Kind::TupleElementName, Label);
         tupleElt->addChild(name, Dem);
       }
-      tupleElt->addChild(visit(std::get<1>(LabelElement)), Dem);
+      if (!tryAddChild(tupleElt, visit(std::get<1>(LabelElement))))
+        return nullptr;
       tuple->addChild(tupleElt, Dem);
     }
     return tuple;
@@ -824,14 +843,16 @@ public:
   Demangle::NodePointer visitPackTypeRef(const PackTypeRef *P) {
     auto pack = Dem.createNode(Node::Kind::Pack);
     for (auto Element : P->getElements())
-      pack->addChild(visit(Element), Dem);
+      if (!tryAddChild(pack, visit(Element)))
+        return nullptr;
     return pack;
   }
 
   Demangle::NodePointer visitPackExpansionTypeRef(const PackExpansionTypeRef *PE) {
     auto expansion = Dem.createNode(Node::Kind::PackExpansion);
-    expansion->addChild(visit(PE->getPattern()), Dem);
-    expansion->addChild(visit(PE->getCount()), Dem);
+    if (!tryAddChild(expansion, visit(PE->getPattern())) ||
+        !tryAddChild(expansion, visit(PE->getCount())))
+      return nullptr;
     return expansion;
   }
 
@@ -857,6 +878,8 @@ public:
     for (const auto &param : F->getParameters()) {
       auto flags = param.getFlags();
       auto input = visit(param.getType());
+      if (!input)
+        return nullptr;
 
       auto wrapInput = [&](Node::Kind kind) {
         auto parent = Dem.createNode(kind);
@@ -946,6 +969,8 @@ public:
     parameters->addChild(paramType, Dem);
 
     NodePointer resultTy = visit(F->getResult());
+    if (!resultTy)
+      return nullptr;
     NodePointer result = Dem.createNode(Node::Kind::ReturnType);
     result->addChild(resultTy, Dem);
 
@@ -963,6 +988,8 @@ public:
     if (auto globalActor = F->getGlobalActor()) {
       auto node = Dem.createNode(Node::Kind::GlobalActorFunctionType);
       auto globalActorNode = visit(globalActor);
+      if (!globalActorNode)
+        return nullptr;
       node->addChild(globalActorNode, Dem);
       funcNode->addChild(node, Dem);
     } else if (F->getExtFlags().isIsolatedAny()) {
@@ -998,6 +1025,8 @@ public:
       if (auto thrownError = F->getThrownError()) {
         auto node = Dem.createNode(Node::Kind::TypedThrowsAnnotation);
         auto thrownErrorNode = visit(thrownError);
+        if (!thrownErrorNode)
+          return nullptr;
         node->addChild(thrownErrorNode, Dem);
         funcNode->addChild(node, Dem);
       } else {
@@ -1020,7 +1049,8 @@ public:
   visitProtocolCompositionTypeRef(const ProtocolCompositionTypeRef *PC) {
     auto type_list = Dem.createNode(Node::Kind::TypeList);
     for (auto protocol : PC->getProtocols())
-      type_list->addChild(visit(protocol), Dem);
+      if (!tryAddChild(type_list, visit(protocol)))
+        return nullptr;
 
     auto proto_list = Dem.createNode(Node::Kind::ProtocolList);
     proto_list->addChild(type_list, Dem);
@@ -1029,7 +1059,8 @@ public:
     if (auto superclass = PC->getSuperclass()) {
       node = Dem.createNode(Node::Kind::ProtocolListWithClass);
       node->addChild(proto_list, Dem);
-      node->addChild(visit(superclass), Dem);
+      if (!tryAddChild(node, visit(superclass)))
+        return nullptr;
     } else if (PC->hasExplicitAnyObject()) {
       node = Dem.createNode(Node::Kind::ProtocolListWithAnyObject);
       node->addChild(proto_list, Dem);
@@ -1040,11 +1071,16 @@ public:
   Demangle::NodePointer
   visitConstrainedExistentialTypeRef(const ConstrainedExistentialTypeRef *CET) {
     auto node = Dem.createNode(Node::Kind::ConstrainedExistential);
-    node->addChild(visit(CET->getBase()), Dem);
+    if (!tryAddChild(node, visit(CET->getBase())))
+      return nullptr;
     auto constraintList =
         Dem.createNode(Node::Kind::ConstrainedExistentialRequirementList);
-    for (auto req : CET->getRequirements())
-      constraintList->addChild(visitTypeRefRequirement(req), Dem);
+    for (auto req : CET->getRequirements()) {
+      // Some requirement kinds are not represented; skip them rather than
+      // failing the whole demangling.
+      if (auto reqNode = visitTypeRefRequirement(req))
+        constraintList->addChild(reqNode, Dem);
+    }
     node->addChild(constraintList, Dem);
     return node;
   }
@@ -1052,11 +1088,16 @@ public:
   Demangle::NodePointer visitSymbolicExtendedExistentialTypeRef(
       const SymbolicExtendedExistentialTypeRef *SEET) {
     auto node = Dem.createNode(Node::Kind::ConstrainedExistential);
-    node->addChild(visit(SEET->getProtocol()), Dem);
+    if (!tryAddChild(node, visit(SEET->getProtocol())))
+      return nullptr;
     auto constraintList =
         Dem.createNode(Node::Kind::ConstrainedExistentialRequirementList);
-    for (auto req : SEET->getRequirements())
-      constraintList->addChild(visitTypeRefRequirement(req), Dem);
+    for (auto req : SEET->getRequirements()) {
+      // Some requirement kinds are not represented; skip them rather than
+      // failing the whole demangling.
+      if (auto reqNode = visitTypeRefRequirement(req))
+        constraintList->addChild(reqNode, Dem);
+    }
     node->addChild(constraintList, Dem);
     // FIXME: This is lossy. We're dropping the Arguments here.
     return node;
@@ -1068,14 +1109,16 @@ public:
     auto repr = Dem.createNode(Node::Kind::MetatypeRepresentation,
                                M->wasAbstract() ? "@thick" : "@thin");
     node->addChild(repr, Dem);
-    node->addChild(visit(M->getInstanceType()), Dem);
+    if (!tryAddChild(node, visit(M->getInstanceType())))
+      return nullptr;
     return node;
   }
 
   Demangle::NodePointer
   visitExistentialMetatypeTypeRef(const ExistentialMetatypeTypeRef *EM) {
     auto node = Dem.createNode(Node::Kind::Metatype);
-    node->addChild(visit(EM->getInstanceType()), Dem);
+    if (!tryAddChild(node, visit(EM->getInstanceType())))
+      return nullptr;
     return node;
   }
 
@@ -1092,6 +1135,8 @@ public:
 
     auto node = Dem.createNode(Node::Kind::DependentMemberType);
     auto Base = visit(DM->getBase());
+    if (!Base)
+      return nullptr;
     node->addChild(Base, Dem);
 
     auto MemberId = Dem.createNode(Node::Kind::Identifier, DM->getMember());
@@ -1106,8 +1151,8 @@ public:
       auto AssocTy = Dem.createNode(Node::Kind::DependentAssociatedTypeRef);
       AssocTy->addChild(MemberId, Dem);
       auto Proto = Dem.demangleType(MangledProtocol);
-      assert(Proto && "Failed to demangle");
-      assert(Proto->getKind() == Node::Kind::Type && "Protocol type is not a type?!");
+      if (!Proto || Proto->getKind() != Node::Kind::Type)
+        return nullptr;
       AssocTy->addChild(Proto, Dem);
       node->addChild(AssocTy, Dem);
     }
@@ -1139,14 +1184,16 @@ public:
   Demangle::NodePointer visit##Name##StorageTypeRef(                           \
       const Name##StorageTypeRef *US) {                                        \
     auto node = Dem.createNode(Node::Kind::Name);                              \
-    node->addChild(visit(US->getType()), Dem);                                 \
+    if (!tryAddChild(node, visit(US->getType())))                             \
+      return nullptr;                                                          \
     return node;                                                               \
   }
 #include "swift/AST/ReferenceStorage.def"
 
   Demangle::NodePointer visitSILBoxTypeRef(const SILBoxTypeRef *SB) {
     auto node = Dem.createNode(Node::Kind::SILBoxType);
-    node->addChild(visit(SB->getBoxedType()), Dem);
+    if (!tryAddChild(node, visit(SB->getBoxedType())))
+      return nullptr;
     return node;
   }
 
@@ -1158,20 +1205,23 @@ public:
     }
     case RequirementKind::Conformance: {
       auto r = Dem.createNode(Node::Kind::DependentGenericConformanceRequirement);
-      r->addChild(visit(req.getFirstType()), Dem);
-      r->addChild(visit(req.getSecondType()), Dem);
+      if (!tryAddChild(r, visit(req.getFirstType())) ||
+          !tryAddChild(r, visit(req.getSecondType())))
+        return nullptr;
       return r;
     }
     case RequirementKind::Superclass: {
       auto r = Dem.createNode(Node::Kind::DependentGenericConformanceRequirement);
-      r->addChild(visit(req.getFirstType()), Dem);
-      r->addChild(visit(req.getSecondType()), Dem);
+      if (!tryAddChild(r, visit(req.getFirstType())) ||
+          !tryAddChild(r, visit(req.getSecondType())))
+        return nullptr;
       return r;
     }
     case RequirementKind::SameType: {
       auto r = Dem.createNode(Node::Kind::DependentGenericSameTypeRequirement);
-      r->addChild(visit(req.getFirstType()), Dem);
-      r->addChild(visit(req.getSecondType()), Dem);
+      if (!tryAddChild(r, visit(req.getFirstType())) ||
+          !tryAddChild(r, visit(req.getSecondType())))
+        return nullptr;
       return r;
     }
     case RequirementKind::Layout:
@@ -1188,7 +1238,8 @@ public:
       auto field =
           Dem.createNode(f.isMutable() ? Node::Kind::SILBoxMutableField
                                        : Node::Kind::SILBoxImmutableField);
-      field->addChild(visit(f.getType()), Dem);
+      if (!tryAddChild(field, visit(f.getType())))
+        return nullptr;
       layout->addChild(field, Dem);
     }
     node->addChild(layout, Dem);
@@ -1218,7 +1269,8 @@ public:
     node->addChild(signature, Dem);
     auto list = Dem.createNode(Node::Kind::TypeList);
     for (auto &subst : SB->getSubstitutions())
-      list->addChild(visit(subst.second), Dem);
+      if (!tryAddChild(list, visit(subst.second)))
+        return nullptr;
     node->addChild(list, Dem);
     return node;
   }
@@ -1272,15 +1324,17 @@ public:
   Demangle::NodePointer visitBuiltinFixedArrayTypeRef(const BuiltinFixedArrayTypeRef *BA) {
     auto ba = Dem.createNode(Node::Kind::BuiltinFixedArray);
 
-    ba->addChild(visit(BA->getSizeType()), Dem);
-    ba->addChild(visit(BA->getElementType()), Dem);
+    if (!tryAddChild(ba, visit(BA->getSizeType())) ||
+        !tryAddChild(ba, visit(BA->getElementType())))
+      return nullptr;
 
     return ba;
   }
   Demangle::NodePointer visitBuiltinBorrowTypeRef(const BuiltinBorrowTypeRef *BA) {
     auto ba = Dem.createNode(Node::Kind::BuiltinBorrow);
 
-    ba->addChild(visit(BA->getReferentType()), Dem);
+    if (!tryAddChild(ba, visit(BA->getReferentType())))
+      return nullptr;
 
     return ba;
   }

--- a/unittests/Reflection/TypeRef.cpp
+++ b/unittests/Reflection/TypeRef.cpp
@@ -12,6 +12,7 @@
 
 #include "swift/RemoteInspection/TypeRefBuilder.h"
 #include "swift/Remote/MetadataReader.h"
+#include "swift/Demangling/Demangler.h"
 #include "gtest/gtest.h"
 
 using namespace swift;
@@ -531,6 +532,62 @@ TEST(TypeRefTest, NestedTypes) {
 
   EXPECT_TRUE(Child->isConcreteAfterSubstitutions(Subs));
   EXPECT_EQ(SubstChild, Child->subst(Builder, Subs));
+}
+
+// A BoundGenericTypeRef whose mangled name fails to demangle must not crash
+// when demangled back into a node tree; getDemangling() should fail gracefully
+// by returning null. Remote Mirror can encounter such names when inspecting
+// corrupt or foreign process memory (rdar://181289066).
+TEST(TypeRefTest, DemangleBoundGenericInvalidMangledName) {
+  TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
+  Demangle::Demangler Dem;
+
+  auto Int = Builder.createNominalType(TypeRefDecl("Si"), /*parent*/ nullptr);
+  std::vector<const TypeRef *> Args{Int};
+
+  // An empty mangled name does not demangle to a type.
+  auto BG = Builder.createBoundGenericType(TypeRefDecl(""), Args,
+                                           /*parent*/ nullptr);
+
+  EXPECT_EQ(nullptr, BG->getDemangling(Dem));
+}
+
+// A BoundGenericTypeRef with a generic argument that fails to demangle must
+// likewise fail gracefully rather than crash (rdar://181289066).
+TEST(TypeRefTest, DemangleBoundGenericInvalidArgument) {
+  TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
+  Demangle::Demangler Dem;
+
+  // A nominal argument with an empty mangled name does not demangle.
+  auto BadArg = Builder.createNominalType(TypeRefDecl(""), /*parent*/ nullptr);
+  std::vector<const TypeRef *> Args{BadArg};
+
+  auto BG = Builder.createBoundGenericType(TypeRefDecl("Si"), Args,
+                                           /*parent*/ nullptr);
+
+  EXPECT_EQ(nullptr, BG->getDemangling(Dem));
+}
+
+// The remaining container visitors in DemanglingForTypeRef must also propagate
+// a failed sub-demangling as null rather than tripping Node::addChild's
+// assertion (rdar://181289066).
+TEST(TypeRefTest, DemangleContainersWithInvalidElement) {
+  TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
+  Demangle::Demangler Dem;
+
+  // A nominal with an empty mangled name does not demangle.
+  auto BadArg = Builder.createNominalType(TypeRefDecl(""), /*parent*/ nullptr);
+
+  // Labels must match the element count so the element is actually visited.
+  StringRef Labels[] = {StringRef()};
+  auto Tuple = Builder.createTupleType({BadArg}, Labels);
+  EXPECT_EQ(nullptr, Tuple->getDemangling(Dem));
+
+  auto Meta = Builder.createMetatypeType(BadArg, std::nullopt);
+  EXPECT_EQ(nullptr, Meta->getDemangling(Dem));
+
+  auto ExistentialMeta = Builder.createExistentialMetatypeType(BadArg);
+  EXPECT_EQ(nullptr, ExistentialMeta->getDemangling(Dem));
 }
 
 TEST(TypeRefTest, DeriveSubstitutions) {


### PR DESCRIPTION
RemoteInspection needs to be robust against corrupt manglings found in the target process, so fail gracefully instead of asserting.

Add a tryAddChild helper that propagates failure as null, and use it at every site that added the result of visit(), visitTypeRefRequirement(), or demangleType() without a check.

rdar://181289066