### PR TITLE
update KVOKeyPaths.swift for pre-Swift 5.1 (NFC)

### DIFF
--- a/test/stdlib/KVOKeyPaths.swift
+++ b/test/stdlib/KVOKeyPaths.swift
@@ -3,7 +3,7 @@
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out > %t/output.txt
 // RUN: %FileCheck %s < %t/output.txt
-// RUN: grep "check-prefix=CHECK-51" %t/output.txt && %FileCheck %s --check-prefix=CHECK-51 < %t/output.txt
+// RUN: not grep "check-prefix=CHECK-51" %t/output.txt || %FileCheck %s --check-prefix=CHECK-51 < %t/output.txt
 // REQUIRES: executable_test
 
 // REQUIRES: objc_interop


### PR DESCRIPTION
After being updated to be compatible with lit's internal shell, this test was accidentally broken when running versions older than Swift 5.1: the grep on line 6 would search for the Swift 5.1+ specific output and fail. This inverts the logic so that the test checks for either the absence of the Swift 5.1+ specific output, or if it's present runs FileCheck.

rdar://163728601