### PR TITLE
AST: Diagnose uses of non-type members of universally unavailable extensions

### DIFF
--- a/lib/AST/AvailabilityConstraint.cpp
+++ b/lib/AST/AvailabilityConstraint.cpp
@@ -302,22 +302,27 @@ activePlatformDomainForDecl(const Decl *decl) {
   return activeDomain;
 }
 
+/// Generates availability constraints that restrict the use of \p origDecl
+/// based on the attributes attached to \p sourceDecl (these declarations may be
+/// different since \p origDecl may inherit attributes from another declaration
+/// lexically).
 static void getAvailabilityConstraintsForDecl(
-    llvm::SmallVector<AvailabilityConstraint, 4> &constraints, const Decl *decl,
+    llvm::SmallVector<AvailabilityConstraint, 4> &constraints,
+    const Decl *targetDecl, const Decl *sourceDecl,
     const AvailabilityContext &context, AvailabilityConstraintFlags flags) {
-  auto &ctx = decl->getASTContext();
-  auto activePlatformDomain = activePlatformDomainForDecl(decl);
+  auto &ctx = sourceDecl->getASTContext();
+  auto activePlatformDomain = activePlatformDomainForDecl(sourceDecl);
   bool includeAllDomains =
       flags.contains(AvailabilityConstraintFlag::IncludeAllDomains);
 
-  for (auto attr : decl->getSemanticAvailableAttrs(includeAllDomains)) {
+  for (auto attr : sourceDecl->getSemanticAvailableAttrs(includeAllDomains)) {
     auto domain = attr.getDomain();
     if (!includeAllDomains && domain.isPlatform() && activePlatformDomain &&
         !activePlatformDomain->contains(domain))
       continue;
 
     if (auto constraint =
-            getAvailabilityConstraintForAttr(decl, attr, context, flags))
+            getAvailabilityConstraintForAttr(targetDecl, attr, context, flags))
       addConstraint(constraints, *constraint, ctx);
   }
 }
@@ -334,7 +339,7 @@ swift::getAvailabilityConstraintsForDecl(const Decl *decl,
 
   decl = decl->getAbstractSyntaxDeclForAttributes();
 
-  getAvailabilityConstraintsForDecl(constraints, decl, context, flags);
+  getAvailabilityConstraintsForDecl(constraints, decl, decl, context, flags);
 
   // For requirements of reparentable protocols, add constraints from the
   // enclosing protocol itself. We don't need to do this for ordinary protocols
@@ -343,7 +348,8 @@ swift::getAvailabilityConstraintsForDecl(const Decl *decl,
   // already carries the same or stricter constraints than its ancestors.
   if (auto *proto = decl->getDeclContext()->getSelfProtocolDecl()) {
     if (proto->getAttrs().hasAttribute<ReparentableAttr>())
-      getAvailabilityConstraintsForDecl(constraints, proto, context, flags);
+      getAvailabilityConstraintsForDecl(constraints, decl, proto, context,
+                                        flags);
   }
 
   if (flags.contains(AvailabilityConstraintFlag::SkipEnclosingExtension))
@@ -361,7 +367,8 @@ swift::getAvailabilityConstraintsForDecl(const Decl *decl,
 
   auto parent = decl->parentDeclForAvailability();
   if (auto extension = dyn_cast_or_null<ExtensionDecl>(parent))
-    getAvailabilityConstraintsForDecl(constraints, extension, context, flags);
+    getAvailabilityConstraintsForDecl(constraints, decl, extension, context,
+                                      flags);
 
   return constraints;
 }

--- a/test/attr/attr_availability_transitive.swift
+++ b/test/attr/attr_availability_transitive.swift
@@ -219,7 +219,9 @@ struct ExtendMe {}
 
 @available(*, unavailable)
 extension ExtendMe {
-  func never_available_extension_available_method() {} // expected-note {{has been explicitly marked unavailable here}}
+  func never_available_extension_available_method() {} // expected-note * {{has been explicitly marked unavailable here}}
+
+  typealias AvailableAliasInNeverAvailableExtension = Self // expected-note * {{'AvailableAliasInNeverAvailableExtension' has been explicitly marked unavailable here}}
 
   func never_available_extension_available_method( // expected-note * {{add '@available' attribute to enclosing instance method}}
     _: AlwaysAvailable,
@@ -275,7 +277,9 @@ extension ExtendMe {
 
 @available(swift, obsoleted: 4)
 extension ExtendMe {
-  func unavailable_in_swift4_extension_available_method() {} // expected-note {{'unavailable_in_swift4_extension_available_method()' was obsoleted in Swift 4}}
+  func unavailable_in_swift4_extension_available_method() {} // expected-note * {{'unavailable_in_swift4_extension_available_method()' was obsoleted in Swift 4}}
+
+  typealias AvailableAliasInSwift4ObsoletedExtension = Self // expected-note * {{'AvailableAliasInSwift4ObsoletedExtension' was obsoleted in Swift 4}}
 
   @available(*, unavailable)
   func unavailable_in_swift4_extension_never_available_method(
@@ -293,7 +297,9 @@ extension ExtendMe {
 
 @available(swift, introduced: 99)
 extension ExtendMe {
-  func available_in_future_swift_extension_available_method() {} // expected-note {{'available_in_future_swift_extension_available_method()' was introduced in Swift 99}}
+  func available_in_future_swift_extension_available_method() {} // expected-note * {{'available_in_future_swift_extension_available_method()' was introduced in Swift 99}}
+
+  typealias AvailableAliasInSwift99Extension = Self // expected-note * {{'AvailableAliasInSwift99Extension' was introduced in Swift 99}}
 
   @available(*, unavailable)
   func available_in_future_swift_extension_never_available_method(
@@ -309,7 +315,24 @@ extension ExtendMe {
   }
 }
 
-func available_func_call_extension_methods(_ e: ExtendMe) {
+func available_func_call_extension_methods(
+  _ e: ExtendMe,
+  _: ExtendMe.AvailableAliasInNeverAvailableExtension, // expected-error {{'AvailableAliasInNeverAvailableExtension' is unavailable}}
+  _: ExtendMe.AvailableAliasInSwift4ObsoletedExtension, // expected-error {{'AvailableAliasInSwift4ObsoletedExtension' is unavailable}}
+  _: ExtendMe.AvailableAliasInSwift99Extension, // expected-error {{'AvailableAliasInSwift99Extension' is unavailable in Swift}}
+) {
+  e.never_available_extension_available_method() // expected-error {{'never_available_extension_available_method()' is unavailable}}
+  e.unavailable_in_swift4_extension_available_method() //  expected-error {{'unavailable_in_swift4_extension_available_method()' is unavailable}}
+  e.available_in_future_swift_extension_available_method() //  expected-error {{'available_in_future_swift_extension_available_method()' is unavailable}}
+}
+
+@available(*, unavailable)
+func unavailable_func_call_extension_methods(
+  _ e: ExtendMe,
+  _: ExtendMe.AvailableAliasInNeverAvailableExtension,
+  _: ExtendMe.AvailableAliasInSwift4ObsoletedExtension,
+  _: ExtendMe.AvailableAliasInSwift99Extension,
+) {
   e.never_available_extension_available_method() // expected-error {{'never_available_extension_available_method()' is unavailable}}
   e.unavailable_in_swift4_extension_available_method() //  expected-error {{'unavailable_in_swift4_extension_available_method()' is unavailable}}
   e.available_in_future_swift_extension_available_method() //  expected-error {{'available_in_future_swift_extension_available_method()' is unavailable}}

--- a/test/decl/ext/objc_implementation_direct_to_storage.swift
+++ b/test/decl/ext/objc_implementation_direct_to_storage.swift
@@ -1,11 +1,12 @@
-// RUN: %target-typecheck-verify-swift -Xcc -fmodule-map-file=%S/Inputs/objc_implementation_private.modulemap -enable-experimental-feature ObjCImplementation -target %target-stable-abi-triple -debug-diagnostic-names
+// RUN: %target-typecheck-verify-swift -Xcc -fmodule-map-file=%S/Inputs/objc_implementation_private.modulemap -enable-experimental-feature ObjCImplementation -target %target-stable-abi-triple
 // REQUIRES: objc_interop
 // REQUIRES: swift_feature_ObjCImplementation
+// REQUIRES: OS=macosx
 
 import objc_implementation_internal
 
 // FIXME: [availability] An implementation that is less available than the interface it implements should be diagnosed
-@available(*, unavailable)
+@available(macOS, unavailable)
 @objc @implementation extension ObjCPropertyTest {
   let prop1: Int32
 


### PR DESCRIPTION
Non-type declarations that are universally unavailable should always be diagnosed, regardless of whether the use context is also universally unavailable. The logic for suppressing diagnostics about uses of unavailable declarations in equivalently unavailable contexts accidentally admitted uses of members of universally unavailable extensions specifically, though. Fix this by differentiating the declaration that is being used versus the declaration that is the source of the availability constraints.
