### PR TITLE
[6.4][Diagnostics] Diagnostic improvements for literal collection element mismatches

### DIFF
--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -324,6 +324,9 @@ public:
   /// Whether the locator in question is for a pattern match.
   bool isForPatternMatch() const;
 
+  /// Whether this locator identifies an element type of a collection literal.
+  bool isForCollectionElement() const;
+
   /// Returns true if \p locator is ending with either of the following
   ///  - Member
   ///  - Member -> KeyPathDynamicMember

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6606,6 +6606,9 @@ bool ConstraintSystem::repairFailures(
       return true;
     }
 
+    if (hasAnyRestriction())
+      return false;
+
     if (isExpr<ArrayExpr>(anchor) || isExpr<DictionaryExpr>(anchor)) {
       // If we could record a generic arguments mismatch instead of this fix,
       // don't record a ContextualMismatch here.
@@ -15955,6 +15958,19 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
     if (fix->getKind() == FixKind::IgnoreCollectionElementContextualMismatch) {
       if (type2->isAny() || type2->isAnyHashable())
         ++impact;
+    }
+
+    if (fix->getKind() == FixKind::IgnoreCollectionElementContextualMismatch &&
+        locator->isForCollectionElement()) {
+      auto *collection = castToExpr<CollectionExpr>(locator->getAnchor());
+      // If the literal is passed to a call or subscript or used in a nested
+      // position, let's attempt to prefer a fix for a contextual mismatch.
+      // For example, `test([1])` if none of the overloads match it's better
+      // to prefer an argument type  mismatch over a collection element type
+      // mismatch because that points to an ambiguity with the `test` instead
+      // of the collection literal.
+      if (getSemanticsProvidingParentExpr(collection))
+        impact = 4;
     }
 
     if (recordFix(fix, impact))

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6626,6 +6626,24 @@ bool ConstraintSystem::repairFailures(
         return true;
       }
 
+      if (loc->directlyAt<ArrayExpr>() && lhs->isArray() &&
+          (rhs->isInlineArray() || rhs->is_InlineArray())) {
+        auto literalCount = castToExpr<ArrayExpr>(anchor)->getNumElements();
+        if (auto inlineCount = rhs->castTo<BoundGenericStructType>()
+                                   ->getGenericArgs()[0]
+                                   ->getAs<IntegerType>()) {
+          if (inlineCount->getValue() != literalCount) {
+            conversionsOrFixes.push_back(
+                AllowInlineArrayLiteralCountMismatch::create(
+                    *this, inlineCount,
+                    IntegerType::get(std::to_string(literalCount),
+                                     /*isNegative=*/false, getASTContext()),
+                    loc));
+            return true;
+          }
+        }
+      }
+
       conversionsOrFixes.push_back(CollectionElementContextualMismatch::create(
           *this, lhs, rhs, getConstraintLocator(locator)));
       break;
@@ -16012,6 +16030,10 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
     return SolutionKind::Solved;
   }
 
+  case FixKind::AllowInlineArrayLiteralCountMismatch:
+    return recordFix(fix, /*impact=*/2) ? SolutionKind::Error
+                                        : SolutionKind::Solved;
+
   case FixKind::UseSubscriptOperator:
   case FixKind::ExplicitlyEscaping:
   case FixKind::MarkGlobalActorFunction:
@@ -16047,7 +16069,6 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::IgnoreInvalidPlaceholder:
   case FixKind::IgnoreOutOfPlaceThenStmt:
   case FixKind::IgnoreMissingEachKeyword:
-  case FixKind::AllowInlineArrayLiteralCountMismatch:
   case FixKind::TooManyDynamicMemberLookups:
   case FixKind::IgnoreNonMetatypeDynamicType:
   case FixKind::IgnoreIsolatedConformance:

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -771,6 +771,11 @@ bool ConstraintLocator::isForPatternMatch() const {
   return getPatternMatch() != nullptr;
 }
 
+bool ConstraintLocator::isForCollectionElement() const {
+  return isExpr<CollectionExpr>(getAnchor()) && getPath().size() == 1 &&
+         isLastElement<LocatorPathElt::TupleElement>();
+}
+
 bool ConstraintLocator::isMemberRef() const {
   if (isLastElement<LocatorPathElt::Member>()) {
     return true;

--- a/test/Constraints/binding_order.swift
+++ b/test/Constraints/binding_order.swift
@@ -36,8 +36,7 @@ do {
   let _ = Array<any Command>([Cut(), Copy(), Paste()])
   // expected-error@-1 {{no exact matches in call to initializer}}
   let _ = Array<(any Command)?>([Cut(), Copy(), Paste()])
-  // expected-error@-1 {{cannot convert value of type '[Any]' to expected argument type '[(any Command)?]'}}
-  // expected-note@-2 {{arguments to generic parameter 'Element' ('Any' and '(any Command)?') are expected to be equal}}
+  // expected-error@-1 {{no exact matches in call to initializer}}
   let _ = Array<any Command.Type>([Cut.self, Copy.self, Paste.self])
   let _ = Array<(any Command.Type)?>([Cut.self, Copy.self, Paste.self])
 
@@ -50,8 +49,7 @@ do {
 
   var commands3: [(any Command)?] = [Undo(), Cut()]
   commands3.append(contentsOf: [Copy(), Paste()])
-  // expected-error@-1 {{cannot convert value of type '[Any]' to expected argument type '[(any Command)?]'}}
-  // expected-note@-2 {{arguments to generic parameter 'Element' ('Any' and '(any Command)?') are expected to be equal}}
+  // expected-error@-1 {{no exact matches in call to instance method 'append'}}
 
   var commands4: [(any Command.Type)?] = [Undo.self, Cut.self]
   commands4.append(contentsOf: [Copy.self, Paste.self])
@@ -68,14 +66,14 @@ do {
   func perform4<S: Sequence>(_: S) where S.Element == Any.Type? {}
   perform4([Undo.self, Cut.self, Copy.self])
 
-  // expected-error@+1 {{failed to produce diagnostic for expression; please submit a bug report}}
   let _: [Int: any Command] = Dictionary(
     uniqueKeysWithValues: [Undo(), Cut(), Copy(), Paste()].map { ($0.name, $0) })
-
-  // expected-error@+1 {{failed to produce diagnostic for expression; please submit a bug report}}
+  // expected-error@-1 {{no exact matches in call to instance method 'map'}}
+  
   let _: [Int: (any Command)?] = Dictionary(
     uniqueKeysWithValues: [Undo(), Cut(), Copy(), Paste()].map { ($0.name, $0) })
-
+// expected-error@-1 {{no exact matches in call to instance method 'map'}}
+  
   let _: [Int: any Command.Type] = Dictionary(
     uniqueKeysWithValues: [Undo.self, Cut.self, Copy.self, Paste.self].map { ($0.id, $0) })
 
@@ -107,7 +105,7 @@ do {
     let _: [any Command] = [a, b].map { $0 }
     // expected-error@-1 {{cannot convert value of type 'Super' to closure result type 'any Command'}}
     let _: [any Command] = [a, b].flatMap { [$0] }
-    // expected-error@-1 {{cannot convert value of type 'Super' to expected element type 'any Command'}}
+    // expected-error@-1 {{cannot convert value of type '[Super]' to closure result type '(any Command)?'}}
 
     #if SALVAGE
     let _: [any Command] = [[a], [b]].flatMap { $0 }

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -1082,11 +1082,9 @@ let explicitUnboundResult1 = { () -> Array in [0] }
 let explicitUnboundResult2: (Array<Bool>) -> Array<Int> = {
   (arr: Array) -> Array in [0]
 }
-// FIXME: Should we prioritize the contextual result type and infer Array<Int>
-// rather than using a type variable in these cases?
-// expected-error@+1 {{unable to infer closure type without a type annotation}}
+
 let explicitUnboundResult3: (Array<Bool>) -> Array<Int> = {
-  (arr: Array) -> Array in [true]
+  (arr: Array) -> Array in [true]  // expected-error {{declared closure result 'Array<Bool>' is incompatible with contextual type 'Array<Int>'}}
 }
 
 // rdar://problem/71525503 - Assertion failed: (!shouldHaveDirectCalleeOverload(call) && "Should we have resolved a callee for this?")

--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -223,8 +223,7 @@ func rdar46459603() {
   // expected-error@-2 {{cannot convert value of type '[E]' to expected argument type 'Dictionary<String, E>.Values'}}
 
   _ = [arr.values] == [[e]]
-  // expected-error@-1 {{referencing operator function '==' on 'Array' requires that 'E' conform to 'Equatable'}} expected-note@-1 {{binary operator '==' cannot be synthesized for enums with associated values}}
-  // expected-error@-2 {{cannot convert value of type 'Dictionary<String, E>.Values' to expected element type '[E]'}}
+  // expected-error@-1 {{binary operator '==' cannot be applied to operands of type '[Dictionary<String, E>.Values]' and '[[E]]'}}
 }
 
 // https://github.com/apple/swift/issues/53233

--- a/test/Constraints/overload.swift
+++ b/test/Constraints/overload.swift
@@ -421,3 +421,13 @@ do {
     return row
   }
 }
+
+do {
+  struct S {}
+
+  func test(of: [String]) {} // expected-note {{candidate expects value of type '[String]' for parameter #1 (got '[S.Type]')}}
+  func test(of: [Int]) {} // expected-note {{candidate expects value of type '[Int]' for parameter #1 (got '[S.Type]')}}
+
+  test(of: [S.self]) // expected-error {{no exact matches in call to local function 'test'}}
+}
+

--- a/test/LiteralExpressions/IntegerGenericErrors.swift
+++ b/test/LiteralExpressions/IntegerGenericErrors.swift
@@ -60,7 +60,7 @@ let nestedMismatch: InlineArray<2, InlineArray<(1 + 1), Int>> = [[1, 2], [3, 4, 
 // expected-error@-1 {{cannot convert value of type '[Int]' to expected element type 'InlineArray<2, Int>'}}
 
 let nestedMismatch2: [(1 + 1) of [(2 + 1) of Int]] = [[1, 2, 3], [4, 5]]
-// expected-error@-1 {{cannot convert value of type '[Int]' to expected element type '[3 of Int]'}}
+// expected-error@-1 {{expected '3' elements in inline array literal, but got '2'}}
 
 let divZero: InlineArray<(1/0), Int>
 // expected-error@-1 {{division by zero}}

--- a/test/Sema/inlinearray.swift
+++ b/test/Sema/inlinearray.swift
@@ -18,8 +18,8 @@ let _: [_ of _] = ["", "", ""] // Ok, InlineArray<3, String>
 
 let _: [3 of [3 of Int]] = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 let _: [3 of [3 of Int]] = [[1, 2], [3, 4, 5, 6]]
-// expected-error@-1 {{expected '3' elements in inline array literal, but got '2'}}
-// expected-error@-2 2 {{cannot convert value of type '[Int]' to expected element type '[3 of Int]'}}
+// expected-error@-1 2 {{expected '3' elements in inline array literal, but got '2'}}
+// expected-error@-2 {{expected '3' elements in inline array literal, but got '4'}}
 
 let _ = [3 of [3 of Int]](repeating: [1, 2]) // expected-error {{expected '3' elements in inline array literal, but got '2'}}
 let _ = [3 of [_ of Int]](repeating: [1, 2])

--- a/test/Sema/inlinearray.swift
+++ b/test/Sema/inlinearray.swift
@@ -18,8 +18,8 @@ let _: [_ of _] = ["", "", ""] // Ok, InlineArray<3, String>
 
 let _: [3 of [3 of Int]] = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 let _: [3 of [3 of Int]] = [[1, 2], [3, 4, 5, 6]]
-// expected-error@-1 {{'3' elements in inline array literal, but got '2'}}
-// expected-error@-2 2{{cannot convert value of type '[Int]' to expected element type '[3 of Int]'}}
+// expected-error@-1 {{expected '3' elements in inline array literal, but got '2'}}
+// expected-error@-2 2 {{cannot convert value of type '[Int]' to expected element type '[3 of Int]'}}
 
 let _ = [3 of [3 of Int]](repeating: [1, 2]) // expected-error {{expected '3' elements in inline array literal, but got '2'}}
 let _ = [3 of [_ of Int]](repeating: [1, 2])
@@ -56,8 +56,8 @@ takeVectorOf2Int([1, 2, 3]) // expected-error {{expected '2' elements in inline 
 
 takeVectorOf2Int(["hello"]) // expected-error {{cannot convert value of type '[String]' to expected argument type 'InlineArray<2, Int>'}}
 
-takeVectorOf2Int(["hello", "world"]) // expected-error {{cannot convert value of type 'String' to expected element type 'Int'}}
-                                     // expected-error@-1 {{cannot convert value of type 'String' to expected element type 'Int'}}
+takeVectorOf2Int(["hello", "world"])
+// expected-error@-1 {{cannot convert value of type '[String]' to expected argument type 'InlineArray<2, Int>'}}
 
 takeVectorOf2Int(["hello", "world", "!"]) // expected-error {{cannot convert value of type '[String]' to expected argument type 'InlineArray<2, Int>'}}
 
@@ -65,7 +65,7 @@ func takeSugarVectorOf2<T>(_: [2 of T], ty: T.Type = T.self) {}
 takeSugarVectorOf2([1, 2])
 takeSugarVectorOf2(["hello"]) // expected-error {{expected '2' elements in inline array literal, but got '1'}}
 takeSugarVectorOf2(["hello"], ty: Int.self) // expected-error {{cannot convert value of type '[String]' to expected argument type '[2 of Int]'}}
-takeSugarVectorOf2(["hello", "hi"], ty: Int.self) // expected-error 2{{cannot convert value of type 'String' to expected element type 'Int'}}
+takeSugarVectorOf2(["hello", "hi"], ty: Int.self) // expected-error {{cannot convert value of type '[String]' to expected argument type '[2 of Int]'}}
 
 
 struct X {
@@ -161,10 +161,12 @@ func testPointerConversion() {
 func acceptPointer(_ pointer: UnsafeMutablePointer<Int>) {}
 
 // rdar://152143989
-struct Test3<let count1: Int> {
+struct Test3<let count1: Int> { // expected-note {{'count1' declared as parameter to type 'Test3'}}
   init(value1: InlineArray<count1, Int>) {}
 }
 struct Test1<T> { init(test2: T) {} }
 
 let _ = Test1<Test3>(test2: Test3(value1: ["x"]))
-// expected-error@-1 {{cannot convert value of type 'String' to expected element type 'Int'}}
+// expected-error@-1 {{cannot convert value of type '[String]' to expected argument type 'InlineArray<count1, Int>'}}
+// expected-error@-2 {{generic parameter 'count1' could not be inferred}}
+// expected-note@-3 {{explicitly specify the generic arguments to fix this issue}}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -756,13 +756,12 @@ func invalidDictionaryLiteral() {
   var g = [1: "one", 2: ;] // expected-error {{expected value in dictionary literal}}
 }
 
-
+// Other overloads of `joined(separator:)` have multiple issues - argument is a String and element of the base should be `String` of conform to `StringProtocol`.
 [4].joined(separator: [1])
-// expected-error@-1 {{no exact matches in call to instance method 'joined'}}
-// There is one more note here - candidate requires that 'Int' conform to 'Sequence' (requirement specified as 'Self.Element' : 'Sequence') pointing to Sequence extension
+// expected-error@-1 {{referencing instance method 'joined(separator:)' on 'Sequence' requires that 'Int' conform to 'Sequence'}}
 
 [4].joined(separator: [[[1]]])
-// expected-error@-1 {{cannot convert value of type 'Int' to expected element type 'String'}}
+// expected-error@-1 {{referencing instance method 'joined(separator:)' on 'Sequence' requires that 'Int' conform to 'StringProtocol'}}
 // expected-error@-2 {{cannot convert value of type '[[[Int]]]' to expected argument type 'String'}}
 
 //===----------------------------------------------------------------------===//

--- a/validation-test/compiler_crashers_fixed/Constraint-Constraint-74f270.swift
+++ b/validation-test/compiler_crashers_fixed/Constraint-Constraint-74f270.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"2889e412","signature":"swift::constraints::Constraint::Constraint(swift::constraints::ConstraintKind, swift::constraints::ConversionRestrictionKind, swift::Type, swift::Type, swift::constraints::ConstraintLocator*, llvm::SmallPtrSetImpl<swift::TypeVariableType*>&)","signatureAssert":"Assertion failed: (isAdmissibleType(first)), function Constraint","signatureNext":"Constraint::createRestricted"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 protocol a {
   associatedtype b
   associatedtype c


### PR DESCRIPTION
- Explanation:

  Improves diagnostics when there is a contextual mismatch with a type of a collection literal element.

  - Increase score of collection element contextual mismatch

     If a collection literal is passed into some context (call, subscript
     etc.), let's attempt to prioritize a possible contextual mismatch
     over the one anchored on the element itself since that's usually a
     consequence of a previous overload selection decision.

  - Record a tailored for inline array arity mismatch with a literal

- Main branch PR: https://github.com/swiftlang/swift/pull/90587

- Resolves: rdar://128327616

- Risk: Very low. The changes affect only diagnostics and should have no effect on valid code.

- Reviewed By: @hamishknight  

- Testing: Added new test-cases to the suite.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
