### PR TITLE
[6.4] test/IRGen/builtin_borrow_large.swift is sensitive to stdlib build configuration.

### DIFF
--- a/test/IRGen/builtin_borrow_large.swift
+++ b/test/IRGen/builtin_borrow_large.swift
@@ -2,6 +2,7 @@
 // RUN: %target-swift-frontend -sil-verify-all -enable-experimental-feature Lifetimes -disable-llvm-optzns -disable-availability-checking -emit-ir -verify -module-name main %s
 
 // REQUIRES: swift_feature_Lifetimes
+// REQUIRES: optimized_stdlib
 
 public struct BigPod { var a, b, c, d, e: Int }
 public struct BigArc { var a, b, c, d, e: AnyObject }


### PR DESCRIPTION
Explanation: Cherry-picks a test-only fix to limit a test to run only on optimized stdlib build configurations.

Scope: Test-only fix.

Risk: Low, only alters tests.

Testing: Swift CI

Issue: rdar://181873425

Reviewed by: @rjmccall 