### PR TITLE
ELF Metadata: Retain the metadata table

### DIFF
--- a/stdlib/public/runtime/SwiftRT-ELF.cpp
+++ b/stdlib/public/runtime/SwiftRT-ELF.cpp
@@ -117,7 +117,7 @@ struct SwiftReflectionSections {
   {static_cast<const void *>(&__start_##name),                                 \
    static_cast<const void *>(&__stop_##name)}
 
-extern "C" __attribute__((__used__, __visibility__("default")))
+extern "C" __attribute__((__used__, __retain__, __visibility__("default")))
 const SwiftReflectionSections __swift5_reflection_sections = {
     SWIFT_REFLECTION_SECTIONS_VERSION,
     SWIFT_REFLECTION_SECTION_BOUNDS(swift5_fieldmd),

--- a/stdlib/public/runtime/SwiftRT-ELF.cpp
+++ b/stdlib/public/runtime/SwiftRT-ELF.cpp
@@ -35,9 +35,9 @@ static const void *__backtraceRef __attribute__((used, retain))
 #define BOUNDS_VISIBILITY __attribute__((__visibility__("hidden"), \
                                          __aligned__(1)))
 
-#define DECLARE_BOUNDS(name)                            \
-  BOUNDS_VISIBILITY extern const char __start_##name;   \
-  BOUNDS_VISIBILITY extern const char __stop_##name;
+#define DECLARE_BOUNDS(name)                                                   \
+  BOUNDS_VISIBILITY extern const char __start_##name __attribute__((weak));    \
+  BOUNDS_VISIBILITY extern const char __stop_##name __attribute__((weak));
 
 #define DECLARE_SWIFT_SECTION(name)             \
   DECLARE_EMPTY_METADATA_SECTION(name, "aR")    \


### PR DESCRIPTION
Adding the retain flag should force lld to not throw away the symbols it depends on.

Started seeing issues with the missing section bound symbols.

```
[2026-07-10T17:56:08.813Z] # | ld: error: undefined hidden symbol: __stop_swift5_typeref
[2026-07-10T17:56:08.813Z] # | >>> referenced by SwiftRT-ELF.cpp
[2026-07-10T17:56:08.813Z] # | >>>               /home/ec2-user/jenkins/workspace/oss-swift-package-freebsd-14/build/buildbot_freebsd/swift-freebsd-x86_64/lib/swift/freebsd/x86_64/swiftrt.o:(swift_image_constructor())
[2026-07-10T17:56:08.813Z] # | >>> referenced by SwiftRT-ELF.cpp
[2026-07-10T17:56:08.813Z] # | >>>               /home/ec2-user/jenkins/workspace/oss-swift-package-freebsd-14/build/buildbot_freebsd/swift-freebsd-x86_64/lib/swift/freebsd/x86_64/swiftrt.o:(__swift5_reflection_sections)
[2026-07-10T17:56:08.813Z] # | 
[2026-07-10T17:56:08.813Z] # | ld: error: undefined hidden symbol: __start_swift5_reflstr
[2026-07-10T17:56:08.813Z] # | >>> referenced by SwiftRT-ELF.cpp
[2026-07-10T17:56:08.813Z] # | >>>               /home/ec2-user/jenkins/workspace/oss-swift-package-freebsd-14/build/buildbot_freebsd/swift-freebsd-x86_64/lib/swift/freebsd/x86_64/swiftrt.o:(swift_image_constructor())
[2026-07-10T17:56:08.813Z] # | >>> referenced by SwiftRT-ELF.cpp
[2026-07-10T17:56:08.813Z] # | >>>               /home/ec2-user/jenkins/workspace/oss-swift-package-freebsd-14/build/buildbot_freebsd/swift-freebsd-x86_64/lib/swift/freebsd/x86_64/swiftrt.o:(__swift5_reflection_sections)
```