### PR TITLE
[Sema] Check superclass Sendable conformance before diagnosing NonSendableSuperclass

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7682,6 +7682,17 @@ bool swift::checkSendableConformance(
       // means the superclass is non-`Sendable`. Subclass cannot safely inherit
       // unprotected state.
       if (auto superclassDecl = classDecl->getSuperclassDecl()) {
+        // If the superclass actually conforms to Sendable (e.g. through
+        // @MainActor isolation), skip the diagnostic. The conformance
+        // may not have been inherited due to ordering in the conformance
+        // lookup table, but the superclass is still Sendable.
+        bool superclassConformsToSendable = false;
+        if (auto superclassTy = classDecl->getSuperclass()) {
+          auto superConf = lookupConformance(superclassTy,
+              conformance->getProtocol(), /*allowMissing=*/false);
+          superclassConformsToSendable = superConf.isConcrete();
+        }
+
         // `NSObject` is permitted as a superclass for Objective-C interop.
         // TODO: can `NSObject` be `Sendable` or `~Sendable` instead?
         // Synthesizing a Sendable conformance for global-actor-isolated
@@ -7689,7 +7700,8 @@ bool swift::checkSendableConformance(
         // maintain it for source compatibility. When the conformance
         // is implicit (the user never wrote Sendable), skip the
         // diagnostic entirely.
-        if (!superclassDecl->isNSObject() &&
+        if (!superclassConformsToSendable &&
+            !superclassDecl->isNSObject() &&
             !(isGlobalActorIsolated && isImplicitSendableCheck(check))) {
           // Inheritance checking for global-actor-isolated classes was
           // historically skipped, so we need to downgrade this to a warning to

--- a/test/Concurrency/nonsendable_superclass_objc.swift
+++ b/test/Concurrency/nonsendable_superclass_objc.swift
@@ -1,0 +1,172 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/src)
+// RUN: %empty-directory(%t/sdk)
+// RUN: %empty-directory(%t/sdk/ObjCActorModule)
+// RUN: split-file %s %t/src
+
+// Build ObjC module
+// RUN: %target-clang -fmodules -dynamiclib %t/src/ObjCActorModule.m -I %t/src -o %t/sdk/ObjCActorModule/libObjCActorModule.dylib -lobjc -framework Foundation
+// RUN: cp %t/src/ObjCActorModule.modulemap %t/sdk/ObjCActorModule/module.modulemap
+// RUN: cp %t/src/ObjCActorModule.h %t/sdk/ObjCActorModule/ObjCActorModule.h
+
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -strict-concurrency=complete %t/src/main.swift -emit-sil -o /dev/null -verify -I %t/sdk/ObjCActorModule
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %t/src/main.swift -emit-sil -o /dev/null -verify -verify-additional-prefix swift6- -swift-version 6 -I %t/sdk/ObjCActorModule
+
+// REQUIRES: concurrency
+// REQUIRES: objc_interop
+
+//--- ObjCActorModule.modulemap
+
+module ObjCActorModule {
+  header "ObjCActorModule.h"
+  export *
+}
+
+//--- ObjCActorModule.h
+
+#import <Foundation/Foundation.h>
+
+// Models the UIKit chain: NSObject -> @MainActor UIResponder -> @MainActor UIViewController/UIView
+// The entire chain is @MainActor-isolated with a Sendable root (NSObject).
+
+__attribute__((swift_attr("@MainActor")))
+@interface ObjCResponder : NSObject
+@end
+
+__attribute__((swift_attr("@MainActor")))
+@interface ObjCController : ObjCResponder
+@end
+
+__attribute__((swift_attr("@MainActor")))
+@interface ObjCView : ObjCResponder
+@end
+
+//--- ObjCActorModule.m
+
+#import "ObjCActorModule.h"
+
+@implementation ObjCResponder
+@end
+
+@implementation ObjCController
+@end
+
+@implementation ObjCView
+@end
+
+//--- main.swift
+
+import ObjCActorModule
+
+// ============================================================================
+// Implied Sendable through protocol refinement
+// ============================================================================
+//
+// When Sendable comes through a protocol (e.g. MyDelegate: Sendable),
+// the conformance table builds it as Implied -> NormalProtocolConformance
+// because the superclass's implicit Sendable from @MainActor wasn't in
+// the table yet when the Inherited stage ran.
+//
+// The protocol conformance must be checked BEFORE any code that would
+// trigger eager Sendable derivation on ObjCController (e.g. a
+// requiresSendable() call), because early derivation masks the bug by
+// materializing an InheritedProtocolConformance.
+
+protocol MyDelegate: Sendable {
+  func didDoThing()
+}
+
+@MainActor
+final class MyDelegateController: ObjCController {}
+
+extension MyDelegateController: @preconcurrency MyDelegate {
+  func didDoThing() {}
+}
+
+@MainActor
+protocol MyIsolatedDelegate: Sendable {
+  func didDoThing()
+}
+
+@MainActor
+final class MyIsolatedDelegateController: ObjCController, MyIsolatedDelegate {
+  func didDoThing() {}
+}
+
+// ============================================================================
+// Explicit Sendable on @MainActor classes with @MainActor ObjC superclasses
+// ============================================================================
+//
+// Real-world pattern: @MainActor final classes that inherit from UIView or
+// UIViewController (modeled here as ObjCView / ObjCController) and explicitly
+// declare Sendable. The superclass chain is @MainActor all the way down to
+// NSObject, so the superclass IS Sendable. No diagnostic should fire.
+
+@MainActor
+final class ExplicitSendableView: ObjCView, Sendable {}
+
+@MainActor
+final class ExplicitSendableController: ObjCController, Sendable {}
+
+// Public @MainActor view subclass with explicit Sendable, matching the
+// pattern of public UI component views.
+@MainActor
+public final class PublicExplicitSendableView: ObjCView, Sendable {}
+
+// ============================================================================
+// Non-final @MainActor classes with explicit Sendable
+// ============================================================================
+//
+// A non-final @MainActor class with a Sendable superclass chain is
+// still valid: subclasses inherit @MainActor isolation, so they can't
+// add unsynchronized state. The non-final restriction only applies to
+// non-isolated classes.
+
+@MainActor
+class NonFinalExplicitSendableController: ObjCController, Sendable {}
+
+// ============================================================================
+// Implicit Sendable (no explicit annotation)
+// ============================================================================
+//
+// ObjC defines:
+//   @MainActor ObjCResponder : NSObject
+//   @MainActor ObjCController : ObjCResponder
+//   @MainActor ObjCView : ObjCResponder
+//
+// Swift subclasses inherit @MainActor isolation and should be implicitly
+// Sendable with no diagnostic.
+
+class MyController: ObjCController {} // no diagnostic expected
+class MyView: ObjCView {} // no diagnostic expected
+
+// ============================================================================
+// Verify all of the above are usable as Sendable
+// ============================================================================
+
+func requiresSendable<T: Sendable>(_: T) {}
+func testObjCChainIsSendable(
+  _ r: ObjCResponder,
+  _ c: ObjCController,
+  _ v: ObjCView,
+  _ mc: MyController,
+  _ mv: MyView,
+  _ dc: MyDelegateController,
+  _ ic: MyIsolatedDelegateController,
+  _ ec: ExplicitSendableController,
+  _ ev: ExplicitSendableView,
+  _ pv: PublicExplicitSendableView,
+  _ nf: NonFinalExplicitSendableController
+) {
+  requiresSendable(r)
+  requiresSendable(c)
+  requiresSendable(v)
+  requiresSendable(mc)
+  requiresSendable(mv)
+  requiresSendable(dc)
+  requiresSendable(ic)
+  requiresSendable(ec)
+  requiresSendable(ev)
+  requiresSendable(pv)
+  requiresSendable(nf)
+}


### PR DESCRIPTION
## Summary

When a class declares `Sendable` (explicitly or through a protocol refinement), the diagnostic at the `!isInherited` site in `checkSendableConformance` assumes a non-inherited conformance means the superclass is non-Sendable, but never actually verifies this. For `@MainActor` class chains rooted in `NSObject` (UIView, UIViewController, etc.), the entire superclass chain is Sendable through global actor isolation per SE-0316. The conformance may not be represented as `InheritedProtocolConformance` due to ordering in the conformance lookup table, but the superclass is still Sendable.

The diagnostic emission today is incorrect for these cases, not just overly conservative. Per SE-0316, the superclass IS Sendable, so `concurrent_value_nonsendable_superclass` should not fire at all, not even as a warning. #90288 downgrades this to a warning for global-actor-isolated types, but the warning itself is wrong when the superclass actually conforms to Sendable. This PR adds the missing `lookupConformance` check on the superclass so the diagnostic is only emitted when the superclass genuinely does not conform.

### Patterns fixed

All patterns below model real-world code in large Swift 6 codebases where `@MainActor` classes inherit from UIKit superclasses and declare `Sendable`:

| # | Pattern | Entry Kind |
|---|---------|-----------|
| 1 | `final class: ObjCController` + `@preconcurrency MyDelegate: Sendable` | Implied |
| 2 | `final class: ObjCController, @MainActor MyIsolatedDelegate` (refines Sendable) | Implied |
| 3 | `@MainActor final class: ObjCController, Sendable` | Explicit |
| 4 | `@MainActor class (non-final): ObjCController, Sendable` | Explicit |

### SE justification

Per [SE-0316](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0316-global-actors.md): *"A non-protocol type that is annotated with a global actor implicitly conforms to `Sendable`."* This applies to the entire `@MainActor` chain, so the superclass IS Sendable. Per SE-0316, *"A subclass of a global-actor-annotated class must be isolated to the same global actor"*, so non-final `@MainActor` classes are also safe.

The non-final class diagnostic (`concurrent_value_nonfinal_class`) already correctly exempts `@MainActor` classes at line 7668: `if (!isSemanticallyFinal() && !isGlobalActorIsolated)`.

### Relationship to #90288

This is orthogonal to #90288 (which downgrades the diagnostic to a warning for global-actor-isolated types). #90288 stages the diagnostic; this PR suppresses it for cases where it is genuinely incorrect because the superclass is Sendable.

### Future cleanup

A followup PR will fix the conformance lookup table in `ConformanceLookupTable::getConformance()` to correctly form `InheritedProtocolConformance` when a class's superclass is Sendable. Once the table representation is correct, the `lookupConformance` workaround added here, the `isNSObject()` special case, and the FIXME hack in `getConformingContext` can all be removed.

## Test plan

- Added `test/Concurrency/nonsendable_superclass_objc.swift` covering all 4 fixed patterns plus implicit-Sendable cases (which were never broken) with both `-strict-concurrency=complete` and `-swift-version 6`
- Cross-module ObjC test module models the UIKit chain: `NSObject -> @MainActor ObjCResponder -> @MainActor ObjCController / ObjCView`
- Verified locally that all tests pass with only this change (no ConformanceLookupTable fix)