### PR TITLE
Fix Emscripten build regressions

### DIFF
--- a/test/embedded/synchronization-mutex.swift
+++ b/test/embedded/synchronization-mutex.swift
@@ -7,7 +7,7 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: synchronization
 // REQUIRES: swift_feature_Embedded
-// UNSUPPORTED: OS=wasip1
+// UNSUPPORTED: OS=wasip1 || OS=emscripten
 
 import Synchronization
 

--- a/test/stdlib/PrintFloat.swift.gyb
+++ b/test/stdlib/PrintFloat.swift.gyb
@@ -17,6 +17,8 @@ import SwiftPrivateLibcExtras
   import Glibc
 #elseif os(WASI)
   import WASILibc
+#elseif os(Emscripten)
+  import EmscriptenLibc
 #elseif canImport(Android)
   import Android
 #elseif os(Windows)

--- a/utils/swift_build_support/swift_build_support/products/emscriptensysroot.py
+++ b/utils/swift_build_support/swift_build_support/products/emscriptensysroot.py
@@ -60,7 +60,7 @@ class EmscriptenSysroot(product.Product):
 
         shell.call([
             sys.executable, embuilder, 'build',
-            'libc', 'libcompiler_rt', 'libc++', 'libc++abi',
+            'libc', 'libclang_rt.builtins', 'libc++', 'libc++abi',
             'crt1', 'libstubs',
             'libdlmalloc',
         ], env=env)
@@ -75,11 +75,11 @@ class EmscriptenSysroot(product.Product):
 
         # When using a prebuilt Emscripten SDK, EmscriptenLLVMRuntimeLibs is
         # skipped, but lit tests still need libclang_rt.builtins.a in the
-        # resource-dir. Create it from embuilder's libcompiler_rt.a.
+        # resource-dir. Create it from embuilder's libclang_rt.builtins.a.
         resource_dir = EmscriptenSysroot.resource_dir_install_path(
             build_root, target_triple)
         builtins_src = os.path.join(
-            sysroot_dst, 'lib', target_triple, 'libcompiler_rt.a')
+            sysroot_dst, 'lib', target_triple, 'libclang_rt.builtins.a')
         builtins_dst_dir = os.path.join(
             resource_dir, 'lib', 'wasm32-unknown-emscripten')
         if os.path.exists(builtins_src):


### PR DESCRIPTION
New version of Emscripten requires `libclang_rt.builtins` unlike the older `libcompiler_rt` component name.

Also fixed a few regressed tests in the test suite.