### PR TITLE
[test] Re-enable large_string_array SIL tests on Linux

### DIFF
--- a/validation-test/SILOptimizer/large_string_array.swift.gyb
+++ b/validation-test/SILOptimizer/large_string_array.swift.gyb
@@ -1,9 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %gyb %s > %t/main.swift
 
-// https://github.com/apple/swift/issues/56816
-// UNSUPPORTED: OS=linux-gnu
-
 // The compiler should finish in less than 1 minute. To give some slack,
 // specify a timeout of 5 minutes.
 // If the compiler needs more than 5 minutes, there is probably a real problem.

--- a/validation-test/SILOptimizer/large_string_array_assert_stdlib.swift.gyb
+++ b/validation-test/SILOptimizer/large_string_array_assert_stdlib.swift.gyb
@@ -1,9 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %gyb %s > %t/main.swift
 
-// https://github.com/apple/swift/issues/56816
-// UNSUPPORTED: OS=linux-gnu
-
 // The compiler should finish in less than 1 minute. To give some slack,
 // specify a timeout of 10 minutes.
 // If the compiler needs more than 10 minutes, there is probably a real problem.


### PR DESCRIPTION
Re-enables the two `large_string_array` SIL validation tests on Linux
(`large_string_array.swift.gyb` and `large_string_array_assert_stdlib.swift.gyb`).

The static-global initialization optimization these tests check now produces
the expected SIL on Linux, so the `// UNSUPPORTED: OS=linux-gnu` markers are no
longer needed.

Resolves #56816