### PR TITLE
AST: fold the metatype-extension check into a DeclContext helper

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -339,6 +339,11 @@ public:
   /// Returns whether this context is an extension constrained to a class type.
   bool isClassConstrainedProtocolExtension() const;
 
+  /// Returns whether this context is a protocol metatype extension
+  /// (`extension P.Protocol { ... }`), i.e. an \c ExtensionDecl whose members
+  /// attach to the extended protocol's metatype.
+  bool isMetatypeExtension() const;
+
   /// Determines whether this context is itself a local scope in a
   /// code block.  A context that appears in such a scope, like a
   /// local type declaration, does not itself become a local context.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9614,20 +9614,14 @@ Type DeclContext::getSelfInterfaceType() const {
     if (auto *builtinTupleDecl = dyn_cast<BuiltinTupleDecl>(nominalDecl))
       return builtinTupleDecl->getTupleSelfType(dyn_cast<ExtensionDecl>(this));
 
-    if (isa<ProtocolDecl>(nominalDecl)) {
+    if (auto *proto = dyn_cast<ProtocolDecl>(nominalDecl)) {
       // For metatype extensions, Self is the metatype of the existential
       // type.  Members are instance members of the metatype, so their self
       // parameter has type (any P).Type.
       for (auto *dc = this; dc; dc = dc->getParent()) {
-        if (auto *ext = dyn_cast<ExtensionDecl>(dc)) {
-          if (ext->isMetatypeExtension()) {
-            auto existentialTy =
-                ExistentialType::get(nominalDecl->getDeclaredInterfaceType());
-            return MetatypeType::get(existentialTy);
-          }
-          break;
-        }
-        if (isa<NominalTypeDecl>(dc))
+        if (dc->isMetatypeExtension())
+          return MetatypeType::get(proto->getDeclaredExistentialType());
+        if (isa<ExtensionDecl>(dc) || isa<NominalTypeDecl>(dc))
           break;
       }
 

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -92,6 +92,12 @@ ProtocolDecl *DeclContext::getExtendedProtocolDecl() const {
   return nullptr;
 }
 
+bool DeclContext::isMetatypeExtension() const {
+  if (auto *ED = dyn_cast<ExtensionDecl>(this))
+    return ED->isMetatypeExtension();
+  return false;
+}
+
 VarDecl *DeclContext::getNonLocalVarDecl() const {
   if (auto *init = dyn_cast<PatternBindingInitializer>(this)) {
     if (auto binding = init->getBinding()) {

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2799,10 +2799,9 @@ QualifiedLookupRequest::evaluate(Evaluator &eval, const DeclContext *DC,
 
       // Metatype extension members are only visible when looking up directly
       // on the protocol, not when reached via a conforming type.
-      if (auto *ext = dyn_cast<ExtensionDecl>(decl->getDeclContext())) {
-        if (ext->isMetatypeExtension() && !llvm::is_contained(typeDecls, current))
-          continue;
-      }
+      if (decl->getDeclContext()->isMetatypeExtension() &&
+          !llvm::is_contained(typeDecls, current))
+        continue;
 
       if (isAcceptableLookupResult(DC, options, decl, onlyCompleteObjectInits,
                                    requireImport))

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1058,9 +1058,8 @@ namespace {
       // representational issues.  Metatype extension instance members are
       // bound directly since the metatype value is the instance.
       if (!baseIsInstance && member->isInstanceMember()) {
-        if (auto *ext = dyn_cast<ExtensionDecl>(member->getDeclContext()))
-          if (ext->isMetatypeExtension())
-            return false;
+        if (member->getDeclContext()->isMetatypeExtension())
+          return false;
         return true;
       }
 
@@ -1875,8 +1874,7 @@ namespace {
       }
 
       const bool isMetatypeExtMember =
-          isa<ExtensionDecl>(member->getDeclContext()) &&
-          cast<ExtensionDecl>(member->getDeclContext())->isMetatypeExtension();
+          member->getDeclContext()->isMetatypeExtension();
       const bool isUnboundInstanceMember =
           (!baseIsInstance && member->isInstanceMember() &&
            !isMetatypeExtMember);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -191,9 +191,8 @@ bool constraints::doesMemberRefApplyCurriedSelf(Type baseTy,
     assert(baseTy);
     if (isa<AbstractFunctionDecl>(decl) &&
         baseTy->getRValueType()->is<AnyMetatypeType>()) {
-      if (auto *ext = dyn_cast<ExtensionDecl>(decl->getDeclContext()))
-        if (ext->isMetatypeExtension())
-          return true;
+      if (decl->getDeclContext()->isMetatypeExtension())
+        return true;
       return false;
     }
   }
@@ -10758,10 +10757,9 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
 
     // Metatype extension members are only accessible on the protocol
     // metatype itself, not on conforming types.
-    if (auto *ext = dyn_cast<ExtensionDecl>(decl->getDeclContext())) {
-      if (ext->isMetatypeExtension() && !instanceTy->isExistentialType())
-        return;
-    }
+    if (decl->getDeclContext()->isMetatypeExtension() &&
+        !instanceTy->isExistentialType())
+      return;
 
     // See if we have an instance method, instance member or static method,
     // and check if it can be accessed on our base type.
@@ -10771,11 +10769,9 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
         // Metatype extension instance members are instance members of the
         // metatype type itself.  They are accessed directly on the protocol
         // metatype value (e.g. P.value), not on an instance of the protocol.
-        if (auto *ext = dyn_cast<ExtensionDecl>(decl->getDeclContext())) {
-          if (ext->isMetatypeExtension()) {
-            result.addViable(candidate);
-            return;
-          }
+        if (decl->getDeclContext()->isMetatypeExtension()) {
+          result.addViable(candidate);
+          return;
         }
 
         // `AnyObject` has special semantics, so let's just let it be.
@@ -10860,8 +10856,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
 
       /* We're OK */
     } else if (instanceTy->isExistentialType() &&
-               isa<ExtensionDecl>(decl->getDeclContext()) &&
-               cast<ExtensionDecl>(decl->getDeclContext())->isMetatypeExtension()) {
+               decl->getDeclContext()->isMetatypeExtension()) {
       // Metatype extension members are directly accessible on the
       // protocol metatype without requiring Self to be bound.
     } else if (hasStaticMembers && baseObjTy->is<MetatypeType>() &&

--- a/lib/Sema/OpenedExistentials.cpp
+++ b/lib/Sema/OpenedExistentials.cpp
@@ -532,10 +532,8 @@ swift::isMemberAvailableOnExistential(Type baseTy, const ValueDecl *member) {
   }
 
   // Metatype extension members are non-generic and don't reference Self.
-  if (auto *ext = dyn_cast<ExtensionDecl>(dc)) {
-    if (ext->isMetatypeExtension())
-      return ExistentialMemberAccessLimitation::None;
-  }
+  if (dc->isMetatypeExtension())
+    return ExistentialMemberAccessLimitation::None;
 
   auto &ctx = member->getASTContext();
   auto existentialSig = ctx.getOpenedExistentialSignature(baseTy);

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -638,11 +638,9 @@ void TypeChecker::performTypoCorrection(DeclContext *DC, DeclRefKind refKind,
       return;
 
     // Metatype extension members are not visible on conforming types.
-    if (auto *ext = dyn_cast<ExtensionDecl>(decl->getDeclContext())) {
-      if (ext->isMetatypeExtension() && baseTypeOrNull &&
-          !baseTypeOrNull->isExistentialType())
-        return;
-    }
+    if (decl->getDeclContext()->isMetatypeExtension() && baseTypeOrNull &&
+        !baseTypeOrNull->isExistentialType())
+      return;
 
     const auto candidateName = decl->getName();
 

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -2014,8 +2014,7 @@ ConstraintSystem::getTypeOfMemberReferencePre(
                                   preparedOverload);
         }
       }
-    } else if (auto *ext = dyn_cast<ExtensionDecl>(outerDC);
-               ext && ext->isMetatypeExtension()) {
+    } else if (outerDC->isMetatypeExtension()) {
       // Metatype extension members do not require existential opening.
       // The member belongs to the protocol metatype itself, not a
       // conforming type.


### PR DESCRIPTION
The `dyn_cast<ExtensionDecl>(dc)` / `->isMetatypeExtension()` dance was repeated across name lookup, the constraint solver, and existential member handling.  Introduce `DeclContext::isMetatypeExtension()` — which returns false for any context that is not a metatype extension — and adopt it at the sites that only need the predicate.