### PR TITLE
fix: reject inout params in parameter pack closures at compile time

### DIFF
--- a/include/swift/AST/PackExpansionMatcher.h
+++ b/include/swift/AST/PackExpansionMatcher.h
@@ -65,6 +65,17 @@ protected:
 public:
   SmallVector<MatchedPair, 4> pairs;
 
+  /// Check whether two parameter flags are compatible for pack matching.
+  /// Ownership conversions (e.g. borrowing <-> consuming) are valid and
+  /// should not break matching; only truly incompatible flags (inout,
+  /// variadic, autoclosure) must differ.
+  static bool areFlagsCompatible(ParameterTypeFlags lhs,
+                                 ParameterTypeFlags rhs) {
+    return lhs.isInOut() == rhs.isInOut() &&
+           lhs.isVariadic() == rhs.isVariadic() &&
+           lhs.isAutoClosure() == rhs.isAutoClosure();
+  }
+
   [[nodiscard]] bool match() {
     ArrayRef<Element> lhsElts(lhsElements);
     ArrayRef<Element> rhsElts(rhsElements);
@@ -84,7 +95,8 @@ public:
       if (getElementLabel(lhsElt) != getElementLabel(rhsElt))
         break;
 
-      if (getElementFlags(lhsElt) != getElementFlags(rhsElt))
+      if (!areFlagsCompatible(getElementFlags(lhsElt),
+                               getElementFlags(rhsElt)))
         break;
 
       auto lhsType = getElementType(lhsElt);
@@ -109,7 +121,8 @@ public:
       auto lhsElt = lhsElts[lhsIdx];
       auto rhsElt = rhsElts[rhsIdx];
 
-      if (getElementFlags(lhsElt) != getElementFlags(rhsElt))
+      if (!areFlagsCompatible(getElementFlags(lhsElt),
+                               getElementFlags(rhsElt)))
         break;
 
       if (getElementLabel(lhsElt) != getElementLabel(rhsElt))
@@ -153,7 +166,7 @@ public:
           if (!getElementLabel(rhsElt).empty())
             return true;
 
-          if (getElementFlags(rhsElt) != lhsFlags)
+          if (!areFlagsCompatible(getElementFlags(rhsElt), lhsFlags))
             return true;
 
           rhsTypes.push_back(getElementType(rhsElt));
@@ -180,7 +193,7 @@ public:
           if (!getElementLabel(lhsElt).empty())
             return true;
 
-          if (getElementFlags(lhsElt) != rhsFlags)
+          if (!areFlagsCompatible(getElementFlags(lhsElt), rhsFlags))
             return true;
 
           lhsTypes.push_back(getElementType(lhsElt));

--- a/include/swift/AST/PackExpansionMatcher.h
+++ b/include/swift/AST/PackExpansionMatcher.h
@@ -84,7 +84,8 @@ public:
       if (getElementLabel(lhsElt) != getElementLabel(rhsElt))
         break;
 
-      // FIXME: Check flags
+      if (getElementFlags(lhsElt) != getElementFlags(rhsElt))
+        break;
 
       auto lhsType = getElementType(lhsElt);
       auto rhsType = getElementType(rhsElt);
@@ -93,8 +94,6 @@ public:
           IsPackExpansionType(rhsType)) {
         break;
       }
-
-      // FIXME: Check flags
 
       pairs.emplace_back(lhsType, rhsType, lhsIdx, rhsIdx);
       ++prefixLength;
@@ -110,7 +109,8 @@ public:
       auto lhsElt = lhsElts[lhsIdx];
       auto rhsElt = rhsElts[rhsIdx];
 
-      // FIXME: Check flags
+      if (getElementFlags(lhsElt) != getElementFlags(rhsElt))
+        break;
 
       if (getElementLabel(lhsElt) != getElementLabel(rhsElt))
         break;
@@ -146,17 +146,20 @@ public:
         unsigned lhsIdx = prefixLength;
         unsigned rhsIdx = prefixLength;
 
+        auto lhsFlags = getElementFlags(lhsElts[0]);
+
         SmallVector<Type, 2> rhsTypes;
         for (auto rhsElt : rhsElts) {
           if (!getElementLabel(rhsElt).empty())
             return true;
 
-          // FIXME: Check rhs flags
+          if (getElementFlags(rhsElt) != lhsFlags)
+            return true;
+
           rhsTypes.push_back(getElementType(rhsElt));
         }
         auto rhs = createPackBinding(rhsTypes);
 
-        // FIXME: Check lhs flags
         pairs.emplace_back(lhsType, rhs, lhsIdx, rhsIdx);
         return false;
       }
@@ -170,17 +173,20 @@ public:
         unsigned lhsIdx = prefixLength;
         unsigned rhsIdx = prefixLength;
 
+        auto rhsFlags = getElementFlags(rhsElts[0]);
+
         SmallVector<Type, 2> lhsTypes;
         for (auto lhsElt : lhsElts) {
           if (!getElementLabel(lhsElt).empty())
             return true;
 
-          // FIXME: Check lhs flags
+          if (getElementFlags(lhsElt) != rhsFlags)
+            return true;
+
           lhsTypes.push_back(getElementType(lhsElt));
         }
         auto lhs = createPackBinding(lhsTypes);
 
-        // FIXME: Check rhs flags
         pairs.emplace_back(lhs, rhsType, lhsIdx, rhsIdx);
         return false;
       }

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -894,3 +894,14 @@ do {
     S { x }.foo() // Make sure we can pick the right 'foo' here.
   }
 }
+
+// rdar://90195 - inout parameter cannot be passed to parameter pack closure
+do {
+  func hi<each T>(_: (repeat each T) -> Void) {}
+  func foo(_: inout Int) {}
+  hi(foo) // expected-error {{cannot convert value of type '(inout Int) -> Void' to expected argument type '(repeat each T) -> Void'}}
+
+  // Valid: non-inout function should still work with pack closure
+  func bar(_: Int) {}
+  hi(bar) // okay
+}


### PR DESCRIPTION
Fixes #90195. Added parameter flag compatibility check to PackExpansionMatcher — limits to inout/autoclosure/variadic, preserves ownership conversions.