### PR TITLE
[SILOptimizer] Fold Builtin.Int1 comparisons with boolean constants

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBuiltin.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBuiltin.swift
@@ -50,9 +50,13 @@ extension BuiltinInst : OnoneSimplifiable, SILCombineSimplifiable {
            .IsPOD:
         optimizeArgumentToThinMetatype(argument: 0, context)
       case .ICMP_EQ:
-        constantFoldIntegerEquality(isEqual: true, context)
+        if !simplifyInt1Comparison(context) {
+          constantFoldIntegerEquality(isEqual: true, context)
+        }
       case .ICMP_NE:
-        constantFoldIntegerEquality(isEqual: false, context)
+        if !simplifyInt1Comparison(context) {
+          constantFoldIntegerEquality(isEqual: false, context)
+        }
       case .Xor:
         simplifyNegation(context)
       default:
@@ -256,6 +260,38 @@ private extension BuiltinInst {
       return true
     }
     return false
+  }
+
+  /// Replaces a comparison of a `Builtin.Int1` with a boolean constant
+  /// ```
+  ///   %2 = integer_literal $Builtin.Int1, 0
+  ///   %3 = builtin "cmp_ne_Int1"(%1, %2) : $Builtin.Int1
+  /// ```
+  /// with the value itself (`%1` here), or with its negation
+  /// `builtin "xor_Int1"(%1, -1)` for `cmp_eq_Int1(%1, 0)`.
+  func simplifyInt1Comparison(_ context: SimplifyContext) -> Bool {
+    let value = arguments[0]
+    guard value.type.isBuiltinInteger(withFixedWidth: 1),
+          !(value is IntegerLiteralInst),
+          let literal = arguments[1] as? IntegerLiteralInst,
+          let constant = literal.value,
+          constant == 0 || constant == -1
+    else {
+      return false
+    }
+
+    let isEqual = (id == .ICMP_EQ)
+    let constantIsTrue = (constant == -1)
+    if isEqual == constantIsTrue {
+      replace(with: value, context)
+    } else {
+      let builder = Builder(before: self, context)
+      let allOnes = builder.createBoolLiteral(true)
+      let negated = builder.createBuiltinBinaryFunction(name: "xor",
+          operandType: value.type, resultType: type, arguments: [value, allOnes])
+      replace(with: negated, context)
+    }
+    return true
   }
 
   /// Replaces a builtin "xor", which negates its operand comparison

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -2824,9 +2824,7 @@ bb0(%0 : $Builtin.NativeObject):
 
 // CHECK-LABEL: sil @test_cmp_xor_canonicalization
 // CHECK:bb0([[ARG:%.*]] : $Builtin.Int1
-// CHECK:  [[FALSE:%.*]] = integer_literal $Builtin.Int1, 0
-// CHECK:  [[NE:%.*]] = builtin "cmp_ne_Int1"([[ARG]] : $Builtin.Int1, [[FALSE]]
-// CHECK:  return [[NE]]
+// CHECK:  return [[ARG]]
 
 sil @test_cmp_xor_canonicalization : $@convention(thin) (Builtin.Int1) -> Builtin.Int1 {
 bb0(%0 : $Builtin.Int1):

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -3289,9 +3289,7 @@ bb0(%0 : @owned $Builtin.NativeObject):
 
 // CHECK-LABEL: sil [ossa] @test_cmp_xor_canonicalization :
 // CHECK:bb0([[ARG:%.*]] : $Builtin.Int1
-// CHECK:  [[FALSE:%.*]] = integer_literal $Builtin.Int1, 0
-// CHECK:  [[NE:%.*]] = builtin "cmp_ne_Int1"([[ARG]] : $Builtin.Int1, [[FALSE]]
-// CHECK:  return [[NE]]
+// CHECK:  return [[ARG]]
 // CHECK: } // end sil function 'test_cmp_xor_canonicalization'
 sil [ossa] @test_cmp_xor_canonicalization : $@convention(thin) (Builtin.Int1) -> Builtin.Int1 {
 bb0(%0 : $Builtin.Int1):
@@ -4003,9 +4001,10 @@ bb0:
   return %9 : $AnyObject
 }
 
-// Int1_const == x -> x == Int1_const
+// Int1_const == x -> x == Int1_const -> x == false -> !x
 // CHECK-LABEL: sil [ossa] @canonicalize_bool_eq_checks :
-// CHECK: builtin "cmp_eq_Int1"(%0 : $Builtin.Int1, %1 :
+// CHECK: [[L:%.*]] = integer_literal $Builtin.Int1, -1
+// CHECK: builtin "xor_Int1"(%0 : $Builtin.Int1, [[L]] :
 // CHECK: } // end sil function 'canonicalize_bool_eq_checks'
 sil [ossa] @canonicalize_bool_eq_checks : $@convention(thin) (Builtin.Int1) -> Builtin.Int1 {
 bb0(%0 : $Builtin.Int1):
@@ -4014,9 +4013,9 @@ bb0(%0 : $Builtin.Int1):
   return %2 : $Builtin.Int1
 }
 
-// Int1_const != x -> x != Int1_const
+// Int1_const != x -> x != Int1_const -> x != false -> x
 // CHECK-LABEL: sil [ossa] @canonicalize_bool_ne_checks :
-// CHECK: builtin "cmp_ne_Int1"(%0 : $Builtin.Int1, %1 :
+// CHECK: return %0
 // CHECK: } // end sil function 'canonicalize_bool_ne_checks'
 sil [ossa] @canonicalize_bool_ne_checks : $@convention(thin) (Builtin.Int1) -> Builtin.Int1 {
 bb0(%0 : $Builtin.Int1):

--- a/test/SILOptimizer/simplify_builtin.sil
+++ b/test/SILOptimizer/simplify_builtin.sil
@@ -856,3 +856,70 @@ bb0(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32):
   return %4
 }
 
+// CHECK-LABEL: sil @int1_cmp_ne_false_is_identity :
+// CHECK-NOT:     cmp_ne_Int1
+// CHECK:         return %0
+// CHECK:       } // end sil function 'int1_cmp_ne_false_is_identity'
+sil @int1_cmp_ne_false_is_identity : $@convention(thin) (Builtin.Int1) -> Builtin.Int1 {
+bb0(%0 : $Builtin.Int1):
+  %1 = integer_literal $Builtin.Int1, 0
+  %2 = builtin "cmp_ne_Int1"(%0, %1) : $Builtin.Int1
+  return %2
+}
+
+// CHECK-LABEL: sil @int1_cmp_eq_true_is_identity :
+// CHECK-NOT:     cmp_eq_Int1
+// CHECK:         return %0
+// CHECK:       } // end sil function 'int1_cmp_eq_true_is_identity'
+sil @int1_cmp_eq_true_is_identity : $@convention(thin) (Builtin.Int1) -> Builtin.Int1 {
+bb0(%0 : $Builtin.Int1):
+  %1 = integer_literal $Builtin.Int1, -1
+  %2 = builtin "cmp_eq_Int1"(%0, %1) : $Builtin.Int1
+  return %2
+}
+
+// CHECK-LABEL: sil @int1_cmp_eq_false_is_negation :
+// CHECK-NOT:     cmp_eq_Int1
+// CHECK:         [[L:%.*]] = integer_literal $Builtin.Int1, -1
+// CHECK:         [[X:%.*]] = builtin "xor_Int1"(%0 : $Builtin.Int1, [[L]] : $Builtin.Int1)
+// CHECK:         return [[X]]
+// CHECK:       } // end sil function 'int1_cmp_eq_false_is_negation'
+sil @int1_cmp_eq_false_is_negation : $@convention(thin) (Builtin.Int1) -> Builtin.Int1 {
+bb0(%0 : $Builtin.Int1):
+  %1 = integer_literal $Builtin.Int1, 0
+  %2 = builtin "cmp_eq_Int1"(%0, %1) : $Builtin.Int1
+  return %2
+}
+
+// CHECK-LABEL: sil @int1_cmp_ne_true_is_negation :
+// CHECK-NOT:     cmp_ne_Int1
+// CHECK:         [[L:%.*]] = integer_literal $Builtin.Int1, -1
+// CHECK:         [[X:%.*]] = builtin "xor_Int1"(%0 : $Builtin.Int1, [[L]] : $Builtin.Int1)
+// CHECK:         return [[X]]
+// CHECK:       } // end sil function 'int1_cmp_ne_true_is_negation'
+sil @int1_cmp_ne_true_is_negation : $@convention(thin) (Builtin.Int1) -> Builtin.Int1 {
+bb0(%0 : $Builtin.Int1):
+  %1 = integer_literal $Builtin.Int1, -1
+  %2 = builtin "cmp_ne_Int1"(%0, %1) : $Builtin.Int1
+  return %2
+}
+
+// CHECK-LABEL: sil @no_simplify_wide_integer :
+// CHECK:         builtin "cmp_ne_Int64"
+// CHECK:       } // end sil function 'no_simplify_wide_integer'
+sil @no_simplify_wide_integer : $@convention(thin) (Builtin.Int64) -> Builtin.Int1 {
+bb0(%0 : $Builtin.Int64):
+  %1 = integer_literal $Builtin.Int64, 0
+  %2 = builtin "cmp_ne_Int64"(%0, %1) : $Builtin.Int1
+  return %2
+}
+
+// CHECK-LABEL: sil @no_simplify_non_constant :
+// CHECK:         builtin "cmp_ne_Int1"
+// CHECK:       } // end sil function 'no_simplify_non_constant'
+sil @no_simplify_non_constant : $@convention(thin) (Builtin.Int1, Builtin.Int1) -> Builtin.Int1 {
+bb0(%0 : $Builtin.Int1, %1 : $Builtin.Int1):
+  %2 = builtin "cmp_ne_Int1"(%0, %1) : $Builtin.Int1
+  return %2
+}
+

--- a/validation-test/SILOptimizer/large_string_array.swift.gyb
+++ b/validation-test/SILOptimizer/large_string_array.swift.gyb
@@ -1,9 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %gyb %s > %t/main.swift
 
-// https://github.com/apple/swift/issues/56816
-// UNSUPPORTED: OS=linux-gnu
-
 // The compiler should finish in less than 1 minute. To give some slack,
 // specify a timeout of 5 minutes.
 // If the compiler needs more than 5 minutes, there is probably a real problem.

--- a/validation-test/SILOptimizer/large_string_array_assert_stdlib.swift.gyb
+++ b/validation-test/SILOptimizer/large_string_array_assert_stdlib.swift.gyb
@@ -1,9 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %gyb %s > %t/main.swift
 
-// https://github.com/apple/swift/issues/56816
-// UNSUPPORTED: OS=linux-gnu
-
 // The compiler should finish in less than 1 minute. To give some slack,
 // specify a timeout of 10 minutes.
 // If the compiler needs more than 10 minutes, there is probably a real problem.


### PR DESCRIPTION
`!x` and `x == false` are equivalent on `Bool`, but they lower to different builtins: `!x` becomes `xor_Int1(x, -1)`, while `x == false` becomes `cmp_eq_Int1(x, 0)`. So only the `!x` form optimized well. In the example from the issue, the `x == false` variant fails to eliminate an overflow-checked loop, because that extra comparison on the `Builtin.Int1` result hides the value from the later passes.

Resolves #70655