### PR TITLE
AST: Rename `AvailabilityConstraint` to `AvailabilityRestriction`

### DIFF
--- a/include/swift/AST/AvailabilityContext.h
+++ b/include/swift/AST/AvailabilityContext.h
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 //
 // This file defines the AvailabilityContext data structure, which summarizes
-// availability constraints for a specific scope.
+// availability restrictions for a specific scope.
 //
 //===----------------------------------------------------------------------===//
 
@@ -33,7 +33,7 @@ class AvailabilityScope;
 class Decl;
 class DeclContext;
 
-/// An `AvailabilityContext` summarizes the availability constraints for a
+/// An `AvailabilityContext` summarizes the availability restrictions for a
 /// specific scope, such as within a declaration or at a particular source
 /// location in a function body. This context is sufficient to determine whether
 /// a declaration is available or not in that scope.

--- a/include/swift/AST/AvailabilityContextStorage.h
+++ b/include/swift/AST/AvailabilityContextStorage.h
@@ -23,7 +23,7 @@
 
 namespace swift {
 
-class DeclAvailabilityConstraints;
+class DeclAvailabilityRestrictions;
 
 /// A wrapper for storing an `AvailabilityDomain` and its associated information
 /// in `AvailabilityContext::Storage`.

--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -347,8 +347,8 @@ public:
                             const ASTContext &ctx) const;
 
   /// Returns true for a domain that is permanently always available, and
-  /// therefore availability constraints in the domain are effectively the same
-  /// as constraints in the `*` domain. This is used to diagnose unnecessary
+  /// therefore availability restrictions in the domain are effectively the same
+  /// as restrictions in the `*` domain. This is used to diagnose unnecessary
   /// `@available` attributes and `if #available` statements.
   bool isPermanentlyAlwaysEnabled() const;
 

--- a/include/swift/AST/AvailabilityRestriction.h
+++ b/include/swift/AST/AvailabilityRestriction.h
@@ -1,4 +1,4 @@
-//===--- AvailabilityConstraint.h - Swift Availability Constraints ------*-===//
+//===--- AvailabilityRestriction.h - Swift Availability Restrictions ----*-===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -10,12 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file defines the AvailabilityConstraint class.
+// This file defines the AvailabilityRestriction class.
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SWIFT_AST_AVAILABILITY_CONSTRAINT_H
-#define SWIFT_AST_AVAILABILITY_CONSTRAINT_H
+#ifndef SWIFT_AST_AVAILABILITY_RESTRICTION_H
+#define SWIFT_AST_AVAILABILITY_RESTRICTION_H
 
 #include "swift/AST/Attr.h"
 #include "swift/AST/AvailabilityDomain.h"
@@ -33,15 +33,15 @@ class Decl;
 
 /// Represents the reason a declaration is considered not available in a
 /// specific `AvailabilityContext`.
-class AvailabilityConstraint {
+class AvailabilityRestriction {
 public:
   /// The reason that a declaration is not available in a context. Broadly, the
   /// declaration may either be "unintroduced" or "unavailable" depending on its
   /// `@available` attributes. A declaration that is unintroduced can become
-  /// available if availability constraints are added to the context. For
+  /// available if availability restrictions are added to the context. For
   /// unavailable declarations, on the other hand, either changing the
   /// deployment target or making the context itself unavailable are necessary
-  /// to satisfy the constraint.
+  /// to satisfy the restriction.
   ///
   /// For example, take the following declaration `f()`:
   ///
@@ -49,7 +49,7 @@ public:
   ///     func f() { ... }
   ///
   /// In contexts that may run on earlier OSes, references to `f()` yield
-  /// an `Unintroduced` constraint:
+  /// an `Unintroduced` restriction:
   ///
   ///     @available(macOS 10.15, *)
   ///     func g() {
@@ -64,7 +64,7 @@ public:
   ///
   /// On the other hand, in contexts where deployment target is high enough to
   /// make `f()` obsolete, references to it yield an `UnavailableObsolete`
-  /// constraint:
+  /// restriction:
   ///
   ///     // compiled with -target arm64-apple-macos14
   ///     func h() {
@@ -78,7 +78,7 @@ public:
   ///                                           UnavailableObsolete
   ///
   /// References to declarations that are unavailable in all versions of a
-  /// domain generate `UnavailableUnconditional` constraints unless the context
+  /// domain generate `UnavailableUnconditional` restrictions unless the context
   /// is also unavailable under the same conditions:
   ///
   ///     @available(macOS, unavailable)
@@ -117,36 +117,36 @@ public:
 
     /// The declaration has not yet been introduced, e.g. because of
     /// `@available(macOS 14, *)` in a context that may run on macOS 13 or
-    /// later. The constraint may be satisfied adding an `@available` attribute
-    /// or an `if #available(...)` query with sufficient introduction
-    /// constraints to the context.
+    /// later. The restriction may be satisfied adding an `@available`
+    /// attribute or an `if #available(...)` query with sufficient introduction
+    /// restrictions to the context.
     Unintroduced,
   };
 
 private:
   llvm::PointerIntPair<SemanticAvailableAttr, 2, Reason> attrAndReason;
 
-  AvailabilityConstraint(Reason reason, SemanticAvailableAttr attr)
+  AvailabilityRestriction(Reason reason, SemanticAvailableAttr attr)
       : attrAndReason(attr, reason) {};
 
 public:
-  static AvailabilityConstraint
+  static AvailabilityRestriction
   unavailableUnconditionally(SemanticAvailableAttr attr) {
-    return AvailabilityConstraint(Reason::UnavailableUnconditionally, attr);
+    return AvailabilityRestriction(Reason::UnavailableUnconditionally, attr);
   }
 
-  static AvailabilityConstraint
+  static AvailabilityRestriction
   unavailableObsolete(SemanticAvailableAttr attr) {
-    return AvailabilityConstraint(Reason::UnavailableObsolete, attr);
+    return AvailabilityRestriction(Reason::UnavailableObsolete, attr);
   }
 
-  static AvailabilityConstraint
+  static AvailabilityRestriction
   unavailableUnintroduced(SemanticAvailableAttr attr) {
-    return AvailabilityConstraint(Reason::UnavailableUnintroduced, attr);
+    return AvailabilityRestriction(Reason::UnavailableUnintroduced, attr);
   }
 
-  static AvailabilityConstraint unintroduced(SemanticAvailableAttr attr) {
-    return AvailabilityConstraint(Reason::Unintroduced, attr);
+  static AvailabilityRestriction unintroduced(SemanticAvailableAttr attr) {
+    return AvailabilityRestriction(Reason::Unintroduced, attr);
   }
 
   Reason getReason() const { return attrAndReason.getInt(); }
@@ -154,7 +154,7 @@ public:
     return static_cast<SemanticAvailableAttr>(attrAndReason.getPointer());
   }
 
-  /// Returns true if the constraint cannot be satisfied using a runtime
+  /// Returns true if the restriction cannot be satisfied using a runtime
   /// availability query (`if #available(...)`).
   bool isUnavailable() const {
     switch (getReason()) {
@@ -167,12 +167,12 @@ public:
     }
   }
 
-  /// Returns the domain that the constraint applies to.
+  /// Returns the domain that the restriction applies to.
   AvailabilityDomain getDomain() const { return getAttr().getDomain(); }
 
   /// Returns the domain and range (remapped if necessary) in which the
-  /// constraint must be satisfied. How the range should be interpreted depends
-  /// on the reason for the constraint.
+  /// restriction must be satisfied. How the range should be interpreted
+  /// depends on the reason for the restriction.
   AvailabilityDomainAndRange getDomainAndRange(const ASTContext &ctx) const;
 
   /// Returns the domain and range to use in availability fix-its. This may be
@@ -181,46 +181,46 @@ public:
   AvailabilityDomainAndRange
   getFixItDomainAndRange(const ASTContext &ctx) const;
 
-  /// Some availability constraints are active for type-checking but cannot
+  /// Some availability restrictions are active for type-checking but cannot
   /// be translated directly into an `if #available(...)` runtime query.
   bool isActiveForRuntimeQueries(const ASTContext &ctx) const;
 
   void print(raw_ostream &os) const;
 };
 
-/// Represents a set of availability constraints that restrict use of a
-/// declaration in a particular context. There can only be one active constraint
-/// for a given `AvailabilityDomain`, but there may be multiple active
-/// constraints from separate domains.
-class DeclAvailabilityConstraints {
-  using Storage = llvm::SmallVector<AvailabilityConstraint, 4>;
-  Storage constraints;
+/// Represents a set of availability restrictions that apply to use of a
+/// declaration in a particular context. There can only be one active
+/// restriction for a given `AvailabilityDomain`, but there may be multiple
+/// active restrictions from separate domains.
+class DeclAvailabilityRestrictions {
+  using Storage = llvm::SmallVector<AvailabilityRestriction, 4>;
+  Storage restrictions;
 
 public:
-  DeclAvailabilityConstraints() {}
-  DeclAvailabilityConstraints(const Storage &&constraints)
-      : constraints(constraints) {}
+  DeclAvailabilityRestrictions() {}
+  DeclAvailabilityRestrictions(const Storage &&restrictions)
+      : restrictions(restrictions) {}
 
-  /// Returns the strongest availability constraint or `std::nullopt` if empty.
-  std::optional<AvailabilityConstraint> getPrimaryConstraint() const;
+  /// Returns the strongest availability restriction or `std::nullopt` if empty.
+  std::optional<AvailabilityRestriction> getPrimaryRestriction() const;
 
   using const_iterator = Storage::const_iterator;
-  const_iterator begin() const { return constraints.begin(); }
-  const_iterator end() const { return constraints.end(); }
+  const_iterator begin() const { return restrictions.begin(); }
+  const_iterator end() const { return restrictions.end(); }
 
   void print(raw_ostream &os) const;
 };
 
-enum class AvailabilityConstraintFlag : uint8_t {
-  /// By default, the availability constraints for the members of extensions
-  /// include the constraints for `@available` attributes that were written on
+enum class AvailabilityRestrictionFlag : uint8_t {
+  /// By default, the availability restrictions for the members of extensions
+  /// include the restrictions for `@available` attributes that were written on
   /// the enclosing extension, since these members can be referred to without
   /// referencing the extension. When this flag is specified, though, only the
   /// attributes directly attached to the declaration are considered.
   SkipEnclosingExtension = 1 << 0,
 
-  /// Include constraints for all domains, regardless of whether they are active
-  /// or relevant to type checking.
+  /// Include restrictions for all domains, regardless of whether they are
+  /// active or relevant to type checking.
   IncludeAllDomains = 1 << 1,
 
   /// By default, non-type declarations that are universally unavailable are
@@ -229,29 +229,30 @@ enum class AvailabilityConstraintFlag : uint8_t {
   /// references are allowed.
   AllowUniversallyUnavailableInCompatibleContexts = 1 << 2,
 };
-using AvailabilityConstraintFlags = OptionSet<AvailabilityConstraintFlag>;
+using AvailabilityRestrictionFlags = OptionSet<AvailabilityRestrictionFlag>;
 
-/// Returns the set of availability constraints that restricts use of \p decl
+/// Returns the set of availability restrictions that restricts use of \p decl
 /// when it is referenced from the given context. In other words, it is the
 /// collection of `@available` attributes with unsatisfied conditions.
-DeclAvailabilityConstraints getAvailabilityConstraintsForDecl(
+DeclAvailabilityRestrictions getAvailabilityRestrictionsForDecl(
     const Decl *decl, const AvailabilityContext &context,
-    AvailabilityConstraintFlags flags = std::nullopt);
+    AvailabilityRestrictionFlags flags = std::nullopt);
 
-/// Returns the availability constraints that restricts use of \p decl
+/// Returns the availability restriction that restricts use of \p decl
 /// in \p domain when it is referenced from the given context. In other words,
 /// it is the unsatisfied `@available` attribute  that applies to \p domain in
 /// the given context.
-std::optional<AvailabilityConstraint> getAvailabilityConstraintForDeclInDomain(
+std::optional<AvailabilityRestriction>
+getAvailabilityRestrictionForDeclInDomain(
     const Decl *decl, const AvailabilityContext &context,
     AvailabilityDomain domain,
-    AvailabilityConstraintFlags flags = std::nullopt);
+    AvailabilityRestrictionFlags flags = std::nullopt);
 
-/// Computes the set of constraints that indicate whether a decl is "runtime
+/// Computes the set of restrictions that indicate whether a decl is "runtime
 /// unavailable" (can never be reached at runtime) and adds the domain for each
-/// of those constraints to the \p domains vector.
+/// of those restrictions to the \p domains vector.
 void getRuntimeUnavailableDomains(
-    const DeclAvailabilityConstraints &constraints,
+    const DeclAvailabilityRestrictions &restrictions,
     llvm::SmallVectorImpl<AvailabilityDomain> &domains, const ASTContext &ctx);
 
 } // end namespace swift
@@ -260,15 +261,15 @@ namespace llvm {
 
 inline llvm::raw_ostream &
 operator<<(llvm::raw_ostream &os,
-           const swift::AvailabilityConstraint &constraint) {
-  constraint.print(os);
+           const swift::AvailabilityRestriction &restriction) {
+  restriction.print(os);
   return os;
 }
 
 inline llvm::raw_ostream &
 operator<<(llvm::raw_ostream &os,
-           const swift::DeclAvailabilityConstraints &constraints) {
-  constraints.print(os);
+           const swift::DeclAvailabilityRestrictions &restrictions) {
+  restrictions.print(os);
   return os;
 }
 

--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -53,7 +53,7 @@ class ConcreteDeclRef;
 class PackConformance;
 class ProtocolConformance;
 class Requirement;
-class AvailabilityConstraint;
+class AvailabilityRestriction;
 enum class EffectKind : uint8_t;
 
 /// A ProtocolConformanceRef is a handle to a protocol conformance which
@@ -172,10 +172,11 @@ public:
       llvm::function_ref<bool(ProtocolConformanceRef)> body
   ) const;
 
-  /// Returns the availability constraint that restricts use of this conformance
-  /// in the given context, or \c nullopt if the conformance is available.
-  std::optional<AvailabilityConstraint>
-  getAvailabilityConstraint(DeclContext *dc, SourceLoc loc) const;
+  /// Returns the availability restriction that restricts use of this
+  /// conformance in the given context, or \c nullopt if the conformance is
+  /// available.
+  std::optional<AvailabilityRestriction>
+  getAvailabilityRestriction(DeclContext *dc, SourceLoc loc) const;
 
   using OpaqueValue = void*;
   OpaqueValue getOpaqueValue() const { return Union.getOpaqueValue(); }

--- a/include/swift/AST/RequirementMatch.h
+++ b/include/swift/AST/RequirementMatch.h
@@ -12,7 +12,7 @@
 #ifndef SWIFT_AST_REQUIREMENTMATCH_H
 #define SWIFT_AST_REQUIREMENTMATCH_H
 
-#include "swift/AST/AvailabilityConstraint.h"
+#include "swift/AST/AvailabilityRestriction.h"
 #include "swift/AST/RequirementEnvironment.h"
 #include "swift/AST/Type.h"
 #include "swift/AST/Types.h"
@@ -261,7 +261,7 @@ class RequirementCheck {
 
     /// Storage for `CheckKind::Availability`.
     struct {
-      AvailabilityConstraint constraint;
+      AvailabilityRestriction restriction;
       AvailabilityContext requiredContext;
     } Availability;
   };
@@ -276,10 +276,10 @@ public:
   RequirementCheck(AccessScope requiredAccessScope, bool forSetter)
       : Kind(CheckKind::Access), Access{requiredAccessScope, forSetter} {}
 
-  RequirementCheck(AvailabilityConstraint constraint,
+  RequirementCheck(AvailabilityRestriction restriction,
                    AvailabilityContext requiredContext)
       : Kind(CheckKind::Availability),
-        Availability{constraint, requiredContext} {}
+        Availability{restriction, requiredContext} {}
 
   CheckKind getKind() const { return Kind; }
 
@@ -292,7 +292,7 @@ public:
   /// True if the witness is less available than the requirement.
   bool isLessAvailable() const {
     return (Kind == CheckKind::Availability)
-               ? !Availability.constraint.isUnavailable()
+               ? !Availability.restriction.isUnavailable()
                : false;
   }
 
@@ -303,11 +303,11 @@ public:
     return Access.requiredScope;
   }
 
-  /// The availability constraint that would fail if the witness were accessed
+  /// The availability restriction that would fail if the witness were accessed
   /// from contexts in which the requirement is available.
-  AvailabilityConstraint getAvailabilityConstraint() const {
+  AvailabilityRestriction getAvailabilityRestriction() const {
     ASSERT(Kind == CheckKind::Availability);
-    return Availability.constraint;
+    return Availability.restriction;
   }
 
   /// The required availability range for checks that failed due to the witness

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -15,13 +15,12 @@
 
 #include "swift/AST/ASTPrinter.h"
 #include "FeatureSet.h"
-#include "swift/AST/InlinableText.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/Attr.h"
-#include "swift/AST/AvailabilityConstraint.h"
 #include "swift/AST/AvailabilityContext.h"
+#include "swift/AST/AvailabilityRestriction.h"
 #include "swift/AST/Builtins.h"
 #include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/Comment.h"
@@ -34,6 +33,7 @@
 #include "swift/AST/GenericParamList.h"
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/ImportCache.h"
+#include "swift/AST/InlinableText.h"
 #include "swift/AST/MacroDefinition.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/NameLookup.h"
@@ -209,10 +209,10 @@ static bool shouldSkipDeclInPublicInterface(const Decl *D) {
   if (!SF)
     return false;
 
-  auto constraints = getAvailabilityConstraintsForDecl(
+  auto restrictions = getAvailabilityRestrictionsForDecl(
       D, AvailabilityContext::forDeploymentTarget(ctx));
   llvm::SmallVector<AvailabilityDomain, 4> unavailableDomains;
-  getRuntimeUnavailableDomains(constraints, unavailableDomains, ctx);
+  getRuntimeUnavailableDomains(restrictions, unavailableDomains, ctx);
 
   for (auto domain : unavailableDomains) {
     if (auto *domainDecl = domain.getDecl()) {

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -16,11 +16,11 @@
 
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Attr.h"
-#include "swift/AST/AvailabilityConstraint.h"
 #include "swift/AST/AvailabilityContext.h"
 #include "swift/AST/AvailabilityDomain.h"
 #include "swift/AST/AvailabilityInference.h"
 #include "swift/AST/AvailabilityRange.h"
+#include "swift/AST/AvailabilityRestriction.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DeclExportabilityVisitor.h"
 // FIXME: [availability] Remove this when possible
@@ -423,10 +423,10 @@ bool Decl::isUnavailableInCurrentSwiftVersion() const {
 
 std::optional<SemanticAvailableAttr> Decl::getUnavailableAttr() const {
   auto context = AvailabilityContext::forDeploymentTarget(getASTContext());
-  if (auto constraint = getAvailabilityConstraintsForDecl(this, context)
-                            .getPrimaryConstraint()) {
-    if (constraint->isUnavailable())
-      return constraint->getAttr();
+  if (auto restriction = getAvailabilityRestrictionsForDecl(this, context)
+                             .getPrimaryRestriction()) {
+    if (restriction->isUnavailable())
+      return restriction->getAttr();
   }
 
   return std::nullopt;
@@ -478,23 +478,23 @@ computeDeclRuntimeAvailability(const Decl *decl) {
   auto rootTargetDomains = getRootTargetDomains(ctx);
   auto remainingTargetDomains = rootTargetDomains;
 
-  AvailabilityConstraintFlags flags;
+  AvailabilityRestrictionFlags flags;
 
   // Semantic availability was already computed separately for any enclosing
   // extension.
-  flags |= AvailabilityConstraintFlag::SkipEnclosingExtension;
+  flags |= AvailabilityRestrictionFlag::SkipEnclosingExtension;
 
   // FIXME: [availability] Replace IncludeAllDomains with a RuntimeAvailability
-  // flag that includes the target variant constraints and keeps all constraints
-  // from active platforms.
-  flags |= AvailabilityConstraintFlag::IncludeAllDomains;
+  // flag that includes the target variant restrictions and keeps all
+  // restrictions from active platforms.
+  flags |= AvailabilityRestrictionFlag::IncludeAllDomains;
 
-  auto constraints = getAvailabilityConstraintsForDecl(
+  auto restrictions = getAvailabilityRestrictionsForDecl(
       decl, AvailabilityContext::forInliningTarget(ctx), flags);
 
-  // First, collect the unavailable domains from the constraints.
+  // First, collect the unavailable domains from the restrictions.
   llvm::SmallVector<AvailabilityDomain, 8> unavailableDomains;
-  getRuntimeUnavailableDomains(constraints, unavailableDomains, ctx);
+  getRuntimeUnavailableDomains(restrictions, unavailableDomains, ctx);
 
   // Check whether there are any available attributes that would make the
   // decl available in descendants of the unavailable domains.
@@ -812,7 +812,7 @@ SemanticAvailableAttr::getIntroducedDomainAndRange(
     return std::nullopt;
 
   // For version-less domains, an attribute that does not indicate some other
-  // kind of unconditional availability constraint implicitly specifies that
+  // kind of unconditional availability restriction implicitly specifies that
   // the decl is available in all versions of the domain.
   switch (attr->getKind()) {
   case AvailableAttr::Kind::Default:

--- a/lib/AST/AvailabilityContext.cpp
+++ b/lib/AST/AvailabilityContext.cpp
@@ -12,8 +12,8 @@
 
 #include "swift/AST/AvailabilityContext.h"
 #include "swift/AST/ASTContext.h"
-#include "swift/AST/AvailabilityConstraint.h"
 #include "swift/AST/AvailabilityContextStorage.h"
+#include "swift/AST/AvailabilityRestriction.h"
 #include "swift/AST/AvailabilityScope.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Module.h"
@@ -367,24 +367,24 @@ void AvailabilityContext::constrainWithDeclAndPlatformRange(
   bool isDeprecated = storage->isDeprecated;
   isConstrained |= constrainBool(isDeprecated, decl->isDeprecated());
 
-  // Compute the availability constraints for the decl when used in this context
-  // and then map those constraints to domain infos. The result will be merged
-  // into the existing domain infos for this context.
+  // Compute the availability restrictions for the decl when used in this
+  // context and then map those restrictions to domain infos. The result will
+  // be merged into the existing domain infos for this context.
   llvm::SmallVector<DomainInfo, 4> declDomainInfos;
-  AvailabilityConstraintFlags flags =
-      AvailabilityConstraintFlag::SkipEnclosingExtension;
-  auto constraints =
-      swift::getAvailabilityConstraintsForDecl(decl, *this, flags);
-  for (auto constraint : constraints) {
-    auto attr = constraint.getAttr();
+  AvailabilityRestrictionFlags flags =
+      AvailabilityRestrictionFlag::SkipEnclosingExtension;
+  auto restrictions =
+      swift::getAvailabilityRestrictionsForDecl(decl, *this, flags);
+  for (auto restriction : restrictions) {
+    auto attr = restriction.getAttr();
     auto domain = attr.getDomain();
-    switch (constraint.getReason()) {
-    case AvailabilityConstraint::Reason::UnavailableUnconditionally:
-    case AvailabilityConstraint::Reason::UnavailableObsolete:
-    case AvailabilityConstraint::Reason::UnavailableUnintroduced:
+    switch (restriction.getReason()) {
+    case AvailabilityRestriction::Reason::UnavailableUnconditionally:
+    case AvailabilityRestriction::Reason::UnavailableObsolete:
+    case AvailabilityRestriction::Reason::UnavailableUnintroduced:
       declDomainInfos.push_back(DomainInfo::unavailable(domain));
       break;
-    case AvailabilityConstraint::Reason::Unintroduced:
+    case AvailabilityRestriction::Reason::Unintroduced:
       if (auto introducedRange = attr.getIntroducedRange(ctx)) {
         if (domain.isActivePlatform(ctx)) {
           isConstrained |= constrainRange(platformRange, *introducedRange);

--- a/lib/AST/AvailabilityRestriction.cpp
+++ b/lib/AST/AvailabilityRestriction.cpp
@@ -1,4 +1,4 @@
-//===--- AvailabilityConstraint.cpp - Swift Availability Constraints ------===//
+//===--- AvailabilityRestriction.cpp - Swift Availability Restrictions ----===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/AST/AvailabilityConstraint.h"
+#include "swift/AST/AvailabilityRestriction.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/AvailabilityContext.h"
 #include "swift/AST/Decl.h"
@@ -18,7 +18,7 @@
 using namespace swift;
 
 AvailabilityDomainAndRange
-AvailabilityConstraint::getDomainAndRange(const ASTContext &ctx) const {
+AvailabilityRestriction::getDomainAndRange(const ASTContext &ctx) const {
   switch (getReason()) {
   case Reason::UnavailableUnconditionally:
   case Reason::UnavailableObsolete:
@@ -30,7 +30,7 @@ AvailabilityConstraint::getDomainAndRange(const ASTContext &ctx) const {
 }
 
 AvailabilityDomainAndRange
-AvailabilityConstraint::getFixItDomainAndRange(const ASTContext &ctx) const {
+AvailabilityRestriction::getFixItDomainAndRange(const ASTContext &ctx) const {
   auto attrDomain = getAttr().getDomain();
   if (attrDomain.contains(
           AvailabilityDomain::forPlatform(PlatformKind::anyAppleOS))) {
@@ -48,7 +48,7 @@ AvailabilityConstraint::getFixItDomainAndRange(const ASTContext &ctx) const {
   return getDomainAndRange(ctx);
 }
 
-bool AvailabilityConstraint::isActiveForRuntimeQueries(
+bool AvailabilityRestriction::isActiveForRuntimeQueries(
     const ASTContext &ctx) const {
   if (getAttr().getPlatform() == PlatformKind::none)
     return true;
@@ -58,8 +58,8 @@ bool AvailabilityConstraint::isActiveForRuntimeQueries(
                                  /*forRuntimeQuery=*/true);
 }
 
-void AvailabilityConstraint::print(llvm::raw_ostream &os) const {
-  os << "AvailabilityConstraint(";
+void AvailabilityRestriction::print(llvm::raw_ostream &os) const {
+  os << "AvailabilityRestriction(";
   getAttr().getDomain().print(os);
   os << ", ";
 
@@ -84,70 +84,70 @@ void AvailabilityConstraint::print(llvm::raw_ostream &os) const {
   os << ")";
 }
 
-static bool constraintIsStronger(const AvailabilityConstraint &lhs,
-                                 const AvailabilityConstraint &rhs) {
+static bool restrictionIsStronger(const AvailabilityRestriction &lhs,
+                                  const AvailabilityRestriction &rhs) {
   DEBUG_ASSERT(lhs.getDomain() == rhs.getDomain());
 
-  // If the constraints have matching domains but different reasons, the
-  // constraint with the lowest reason is "strongest".
+  // If the restrictions have matching domains but different reasons, the
+  // restriction with the lowest reason is "strongest".
   if (lhs.getReason() != rhs.getReason())
     return lhs.getReason() < rhs.getReason();
 
   switch (lhs.getReason()) {
-  case AvailabilityConstraint::Reason::UnavailableUnconditionally:
+  case AvailabilityRestriction::Reason::UnavailableUnconditionally:
     // Just keep the first.
     return false;
 
-  case AvailabilityConstraint::Reason::UnavailableObsolete:
+  case AvailabilityRestriction::Reason::UnavailableObsolete:
     // Pick the larger obsoleted range.
     return lhs.getAttr().getObsoleted().value() <
            rhs.getAttr().getObsoleted().value();
 
-  case AvailabilityConstraint::Reason::UnavailableUnintroduced:
-  case AvailabilityConstraint::Reason::Unintroduced:
+  case AvailabilityRestriction::Reason::UnavailableUnintroduced:
+  case AvailabilityRestriction::Reason::Unintroduced:
     // Pick the smaller introduced range.
     return lhs.getAttr().getIntroduced().value_or(llvm::VersionTuple()) >
            rhs.getAttr().getIntroduced().value_or(llvm::VersionTuple());
   }
 }
 
-void addConstraint(llvm::SmallVector<AvailabilityConstraint, 4> &constraints,
-                   const AvailabilityConstraint &constraint,
-                   const ASTContext &ctx) {
+void addRestriction(llvm::SmallVector<AvailabilityRestriction, 4> &restrictions,
+                    const AvailabilityRestriction &restriction,
+                    const ASTContext &ctx) {
 
   auto iter = llvm::find_if(
-      constraints, [&constraint](AvailabilityConstraint &existing) {
-        return constraint.getDomain() == existing.getDomain();
+      restrictions, [&restriction](AvailabilityRestriction &existing) {
+        return restriction.getDomain() == existing.getDomain();
       });
 
-  // There's no existing constraint for the same domain so just add it.
-  if (iter == constraints.end()) {
-    constraints.emplace_back(constraint);
+  // There's no existing restriction for the same domain so just add it.
+  if (iter == restrictions.end()) {
+    restrictions.emplace_back(restriction);
     return;
   }
 
-  if (constraintIsStronger(constraint, *iter)) {
-    constraints.erase(iter);
-    constraints.emplace_back(constraint);
+  if (restrictionIsStronger(restriction, *iter)) {
+    restrictions.erase(iter);
+    restrictions.emplace_back(restriction);
   }
 }
 
-std::optional<AvailabilityConstraint>
-DeclAvailabilityConstraints::getPrimaryConstraint() const {
-  std::optional<AvailabilityConstraint> result;
+std::optional<AvailabilityRestriction>
+DeclAvailabilityRestrictions::getPrimaryRestriction() const {
+  std::optional<AvailabilityRestriction> result;
 
-  auto isStrongerConstraint = [](const AvailabilityConstraint &lhs,
-                                 const AvailabilityConstraint &rhs) {
-    // Constraint reasons are defined in descending order of strength.
+  auto isStrongerRestriction = [](const AvailabilityRestriction &lhs,
+                                  const AvailabilityRestriction &rhs) {
+    // Restriction reasons are defined in descending order of strength.
     if (lhs.getReason() != rhs.getReason())
       return lhs.getReason() < rhs.getReason();
 
     if (lhs.getDomain() != rhs.getDomain()) {
-      // Constraints in the universal domain are the strongest.
+      // Restrictions in the universal domain are the strongest.
       if (rhs.getDomain().isUniversal())
         return true;
 
-      // Otherwise, pick the constraint from the broader domain.
+      // Otherwise, pick the restriction from the broader domain.
       if (lhs.getDomain() != rhs.getDomain())
         return rhs.getDomain().contains(lhs.getDomain());
     }
@@ -155,72 +155,72 @@ DeclAvailabilityConstraints::getPrimaryConstraint() const {
     return false;
   };
 
-  // Pick the strongest constraint.
-  for (auto const &constraint : constraints) {
-    if (!result || isStrongerConstraint(constraint, *result))
-      result.emplace(constraint);
+  // Pick the strongest restriction.
+  for (auto const &restriction : restrictions) {
+    if (!result || isStrongerRestriction(restriction, *result))
+      result.emplace(restriction);
   }
 
   return result;
 }
 
-void DeclAvailabilityConstraints::print(llvm::raw_ostream &os) const {
+void DeclAvailabilityRestrictions::print(llvm::raw_ostream &os) const {
   os << "{\n";
   llvm::interleave(
-      constraints,
-      [&os](const AvailabilityConstraint &constraint) {
-        os << "  " << constraint;
+      restrictions,
+      [&os](const AvailabilityRestriction &restriction) {
+        os << "  " << restriction;
       },
       [&os] { os << ",\n"; });
   os << "\n}";
 }
 
-static bool canIgnoreConstraintInUnavailableContexts(
-    const Decl *decl, const AvailabilityConstraint &constraint,
-    const AvailabilityConstraintFlags flags) {
-  auto domain = constraint.getDomain();
+static bool canIgnoreRestrictionInUnavailableContexts(
+    const Decl *decl, const AvailabilityRestriction &restriction,
+    const AvailabilityRestrictionFlags flags) {
+  auto domain = restriction.getDomain();
 
   // Always reject uses of universally unavailable declarations, regardless
   // of context, since there are no possible compilation configurations in
   // which they are available. However, make an exception for types and
   // conformances, which can sometimes be awkward to avoid references to.
-  if (!flags.contains(AvailabilityConstraintFlag::
-                      AllowUniversallyUnavailableInCompatibleContexts)) {
+  if (!flags.contains(AvailabilityRestrictionFlag::
+                          AllowUniversallyUnavailableInCompatibleContexts)) {
     if (!isa<TypeDecl>(decl) && !isa<ExtensionDecl>(decl)) {
       if (domain.isUniversal() || domain.isSwiftLanguageMode())
         return false;
     }
   }
 
-  switch (constraint.getReason()) {
-  case AvailabilityConstraint::Reason::UnavailableUnconditionally:
+  switch (restriction.getReason()) {
+  case AvailabilityRestriction::Reason::UnavailableUnconditionally:
     return true;
 
-  case AvailabilityConstraint::Reason::Unintroduced:
-  case AvailabilityConstraint::Reason::UnavailableObsolete:
-  case AvailabilityConstraint::Reason::UnavailableUnintroduced:
+  case AvailabilityRestriction::Reason::Unintroduced:
+  case AvailabilityRestriction::Reason::UnavailableObsolete:
+  case AvailabilityRestriction::Reason::UnavailableUnintroduced:
     return domain.isVersioned();
   }
 }
 
 static bool
-shouldIgnoreConstraintInContext(const Decl *decl,
-                                const AvailabilityConstraint &constraint,
-                                const AvailabilityContext &context,
-                                const AvailabilityConstraintFlags flags) {
+shouldIgnoreRestrictionInContext(const Decl *decl,
+                                 const AvailabilityRestriction &restriction,
+                                 const AvailabilityContext &context,
+                                 const AvailabilityRestrictionFlags flags) {
   if (!context.isUnavailable())
     return false;
 
-  if (!canIgnoreConstraintInUnavailableContexts(decl, constraint, flags))
+  if (!canIgnoreRestrictionInUnavailableContexts(decl, restriction, flags))
     return false;
 
-  // If the constraint's domain is a superset of the compilation's target
+  // If the restriction's domain is a superset of the compilation's target
   // availability domain, use the more specific target availability domain
   // instead. This allows declarations that are @available(macOS, unavailable)
   // to be used in contexts that are @available(macOSApplicationExtension,
   // unavailable), for example.
   auto &ctx = decl->getASTContext();
-  auto domain = constraint.getDomain();
+  auto domain = restriction.getDomain();
   auto targetDomain = ctx.getTargetAvailabilityDomain();
   if (domain.isSupersetOf(targetDomain))
     domain = targetDomain;
@@ -228,17 +228,17 @@ shouldIgnoreConstraintInContext(const Decl *decl,
   return context.isUnavailableForDomain(domain);
 }
 
-/// Returns the `AvailabilityConstraint` that describes how \p attr restricts
+/// Returns the `AvailabilityRestriction` that describes how \p attr restricts
 /// use of \p decl in \p context or `std::nullopt` if there is no restriction.
-static std::optional<AvailabilityConstraint>
-getAvailabilityConstraintForAttr(const Decl *decl,
-                                 const SemanticAvailableAttr &attr,
-                                 const AvailabilityContext &context,
-                                 const AvailabilityConstraintFlags flags) {
-  auto getConstraint = [&]() -> std::optional<AvailabilityConstraint> {
+static std::optional<AvailabilityRestriction>
+getAvailabilityRestrictionForAttr(const Decl *decl,
+                                  const SemanticAvailableAttr &attr,
+                                  const AvailabilityContext &context,
+                                  const AvailabilityRestrictionFlags flags) {
+  auto getRestriction = [&]() -> std::optional<AvailabilityRestriction> {
     // Is the decl unconditionally unavailable?
     if (attr.isUnconditionallyUnavailable())
-      return AvailabilityConstraint::unavailableUnconditionally(attr);
+      return AvailabilityRestriction::unavailableUnconditionally(attr);
 
     auto &ctx = decl->getASTContext();
     auto domain = attr.getDomain();
@@ -257,26 +257,26 @@ getAvailabilityConstraintForAttr(const Decl *decl,
     if (auto obsoletedRange = attr.getObsoletedRange(ctx)) {
       if (availableRange && !availableRange->isKnownUnreachable() &&
           availableRange->isContainedIn(*obsoletedRange))
-        return AvailabilityConstraint::unavailableObsolete(attr);
+        return AvailabilityRestriction::unavailableObsolete(attr);
     }
 
     // Is the decl not yet introduced in this context?
     if (auto introducedRange = attr.getIntroducedRange(ctx)) {
       if (!availableRange || !availableRange->isContainedIn(*introducedRange))
         return domainSupportsRefinement
-                   ? AvailabilityConstraint::unintroduced(attr)
-                   : AvailabilityConstraint::unavailableUnintroduced(attr);
+                   ? AvailabilityRestriction::unintroduced(attr)
+                   : AvailabilityRestriction::unavailableUnintroduced(attr);
     }
 
     return std::nullopt;
   };
 
-  auto constraint = getConstraint();
-  if (constraint &&
-      shouldIgnoreConstraintInContext(decl, *constraint, context, flags))
+  auto restriction = getRestriction();
+  if (restriction &&
+      shouldIgnoreRestrictionInContext(decl, *restriction, context, flags))
     return std::nullopt;
 
-  return constraint;
+  return restriction;
 }
 
 /// Returns the most specific platform domain from the availability attributes
@@ -302,18 +302,18 @@ activePlatformDomainForDecl(const Decl *decl) {
   return activeDomain;
 }
 
-/// Generates availability constraints that restrict the use of \p origDecl
+/// Generates availability restrictions that apply to the use of \p origDecl
 /// based on the attributes attached to \p sourceDecl (these declarations may be
 /// different since \p origDecl may inherit attributes from another declaration
 /// lexically).
-static void getAvailabilityConstraintsForDecl(
-    llvm::SmallVector<AvailabilityConstraint, 4> &constraints,
+static void getAvailabilityRestrictionsForDecl(
+    llvm::SmallVector<AvailabilityRestriction, 4> &restrictions,
     const Decl *targetDecl, const Decl *sourceDecl,
-    const AvailabilityContext &context, AvailabilityConstraintFlags flags) {
+    const AvailabilityContext &context, AvailabilityRestrictionFlags flags) {
   auto &ctx = sourceDecl->getASTContext();
   auto activePlatformDomain = activePlatformDomainForDecl(sourceDecl);
   bool includeAllDomains =
-      flags.contains(AvailabilityConstraintFlag::IncludeAllDomains);
+      flags.contains(AvailabilityRestrictionFlag::IncludeAllDomains);
 
   for (auto attr : sourceDecl->getSemanticAvailableAttrs(includeAllDomains)) {
     auto domain = attr.getDomain();
@@ -321,39 +321,39 @@ static void getAvailabilityConstraintsForDecl(
         !activePlatformDomain->contains(domain))
       continue;
 
-    if (auto constraint =
-            getAvailabilityConstraintForAttr(targetDecl, attr, context, flags))
-      addConstraint(constraints, *constraint, ctx);
+    if (auto restriction =
+            getAvailabilityRestrictionForAttr(targetDecl, attr, context, flags))
+      addRestriction(restrictions, *restriction, ctx);
   }
 }
 
-DeclAvailabilityConstraints
-swift::getAvailabilityConstraintsForDecl(const Decl *decl,
-                                         const AvailabilityContext &context,
-                                         AvailabilityConstraintFlags flags) {
-  llvm::SmallVector<AvailabilityConstraint, 4> constraints;
+DeclAvailabilityRestrictions
+swift::getAvailabilityRestrictionsForDecl(const Decl *decl,
+                                          const AvailabilityContext &context,
+                                          AvailabilityRestrictionFlags flags) {
+  llvm::SmallVector<AvailabilityRestriction, 4> restrictions;
 
   // Generic parameters are always available.
   if (isa<GenericTypeParamDecl>(decl))
-    return DeclAvailabilityConstraints();
+    return DeclAvailabilityRestrictions();
 
   decl = decl->getAbstractSyntaxDeclForAttributes();
 
-  getAvailabilityConstraintsForDecl(constraints, decl, decl, context, flags);
+  getAvailabilityRestrictionsForDecl(restrictions, decl, decl, context, flags);
 
-  // For requirements of reparentable protocols, add constraints from the
+  // For requirements of reparentable protocols, add restrictions from the
   // enclosing protocol itself. We don't need to do this for ordinary protocols
   // because of the rule that a protocol P cannot inherit from Q if Q is less
   // available than P. Thus, the availability of the most derived protocol
-  // already carries the same or stricter constraints than its ancestors.
+  // already carries the same or stricter restrictions than its ancestors.
   if (auto *proto = decl->getDeclContext()->getSelfProtocolDecl()) {
     if (proto->getAttrs().hasAttribute<ReparentableAttr>())
-      getAvailabilityConstraintsForDecl(constraints, decl, proto, context,
-                                        flags);
+      getAvailabilityRestrictionsForDecl(restrictions, decl, proto, context,
+                                         flags);
   }
 
-  if (flags.contains(AvailabilityConstraintFlag::SkipEnclosingExtension))
-    return constraints;
+  if (flags.contains(AvailabilityRestrictionFlag::SkipEnclosingExtension))
+    return restrictions;
 
   // If decl is an extension member, query the attributes of the extension, too.
   //
@@ -363,30 +363,30 @@ swift::getAvailabilityConstraintsForDecl(const Decl *decl,
   // protocol is directly or indirectly adopted, no matter its availability
   // and the availability of other categories. rdar://problem/53956555
   if (decl->getClangNode())
-    return constraints;
+    return restrictions;
 
   auto parent = decl->parentDeclForAvailability();
   if (auto extension = dyn_cast_or_null<ExtensionDecl>(parent))
-    getAvailabilityConstraintsForDecl(constraints, decl, extension, context,
-                                      flags);
+    getAvailabilityRestrictionsForDecl(restrictions, decl, extension, context,
+                                       flags);
 
-  return constraints;
+  return restrictions;
 }
 
-std::optional<AvailabilityConstraint>
-swift::getAvailabilityConstraintForDeclInDomain(
+std::optional<AvailabilityRestriction>
+swift::getAvailabilityRestrictionForDeclInDomain(
     const Decl *decl, const AvailabilityContext &context,
-    AvailabilityDomain domain, AvailabilityConstraintFlags flags) {
-  auto constraints = getAvailabilityConstraintsForDecl(decl, context, flags);
-  for (auto const &constraint : constraints) {
-    if (constraint.getDomain().isRelated(domain))
-      return constraint;
+    AvailabilityDomain domain, AvailabilityRestrictionFlags flags) {
+  auto restrictions = getAvailabilityRestrictionsForDecl(decl, context, flags);
+  for (auto const &restriction : restrictions) {
+    if (restriction.getDomain().isRelated(domain))
+      return restriction;
   }
 
   return std::nullopt;
 }
 
-/// Returns true if unsatisfied `@available(..., unavailable)` constraints for
+/// Returns true if unsatisfied `@available(..., unavailable)` restrictions for
 /// \p domain make code unreachable at runtime
 static bool
 domainCanBeUnconditionallyUnavailableAtRuntime(AvailabilityDomain domain,
@@ -421,7 +421,7 @@ domainCanBeUnconditionallyUnavailableAtRuntime(AvailabilityDomain domain,
   }
 }
 
-/// Returns true if unsatisfied introduction constraints for \p domain make
+/// Returns true if unsatisfied introduction restrictions for \p domain make
 /// code unreachable at runtime.
 static bool
 domainIsUnavailableAtRuntimeIfUnintroduced(AvailabilityDomain domain,
@@ -449,25 +449,25 @@ domainIsUnavailableAtRuntimeIfUnintroduced(AvailabilityDomain domain,
   }
 }
 
-static bool constraintIndicatesRuntimeUnavailability(
-    const AvailabilityConstraint &constraint, const ASTContext &ctx) {
-  auto domain = constraint.getDomain();
-  switch (constraint.getReason()) {
-  case AvailabilityConstraint::Reason::UnavailableUnconditionally:
+static bool restrictionIndicatesRuntimeUnavailability(
+    const AvailabilityRestriction &restriction, const ASTContext &ctx) {
+  auto domain = restriction.getDomain();
+  switch (restriction.getReason()) {
+  case AvailabilityRestriction::Reason::UnavailableUnconditionally:
     return domainCanBeUnconditionallyUnavailableAtRuntime(domain, ctx);
-  case AvailabilityConstraint::Reason::UnavailableObsolete:
-  case AvailabilityConstraint::Reason::UnavailableUnintroduced:
+  case AvailabilityRestriction::Reason::UnavailableObsolete:
+  case AvailabilityRestriction::Reason::UnavailableUnintroduced:
     return false;
-  case AvailabilityConstraint::Reason::Unintroduced:
+  case AvailabilityRestriction::Reason::Unintroduced:
     return domainIsUnavailableAtRuntimeIfUnintroduced(domain, ctx);
   }
 }
 
 void swift::getRuntimeUnavailableDomains(
-    const DeclAvailabilityConstraints &constraints,
+    const DeclAvailabilityRestrictions &restrictions,
     llvm::SmallVectorImpl<AvailabilityDomain> &domains, const ASTContext &ctx) {
-  for (auto constraint : constraints) {
-    if (constraintIndicatesRuntimeUnavailability(constraint, ctx))
-      domains.push_back(constraint.getDomain());
+  for (auto restriction : restrictions) {
+    if (restrictionIndicatesRuntimeUnavailability(restriction, ctx))
+      domains.push_back(restriction.getDomain());
   }
 }

--- a/lib/AST/AvailabilityScope.cpp
+++ b/lib/AST/AvailabilityScope.cpp
@@ -17,7 +17,7 @@
 #include "swift/AST/AvailabilityScope.h"
 
 #include "swift/AST/ASTContext.h"
-#include "swift/AST/AvailabilityConstraint.h"
+#include "swift/AST/AvailabilityRestriction.h"
 #include "swift/AST/AvailabilitySpec.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/MacroDeclaration.h"
@@ -445,9 +445,9 @@ AvailabilityScope::getExplicitAvailabilityRange(AvailabilityDomain domain,
 
   case Reason::Decl: {
     auto decl = Node.getAsDecl();
-    if (auto constraint = swift::getAvailabilityConstraintForDeclInDomain(
+    if (auto restriction = swift::getAvailabilityRestrictionForDeclInDomain(
             decl, AvailabilityContext::forAlwaysAvailable(ctx), domain))
-      return constraint->getAttr().getIntroducedRange(ctx);
+      return restriction->getAttr().getIntroducedRange(ctx);
 
     return std::nullopt;
   }

--- a/lib/AST/AvailabilityScopeBuilder.cpp
+++ b/lib/AST/AvailabilityScopeBuilder.cpp
@@ -18,8 +18,8 @@
 
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTWalker.h"
-#include "swift/AST/AvailabilityConstraint.h"
 #include "swift/AST/AvailabilityInference.h"
+#include "swift/AST/AvailabilityRestriction.h"
 #include "swift/AST/AvailabilitySpec.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DeclExportabilityVisitor.h"
@@ -471,9 +471,9 @@ private:
       return true;
 
     // Check whether the decl is unavailable relative to the current context.
-    if (auto constraint = getAvailabilityConstraintsForDecl(decl, context)
-                              .getPrimaryConstraint()) {
-      if (constraint->isUnavailable())
+    if (auto restriction = getAvailabilityRestrictionsForDecl(decl, context)
+                               .getPrimaryRestriction()) {
+      if (restriction->isUnavailable())
         return true;
     }
 

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -27,10 +27,10 @@ add_swift_host_library(swiftAST STATIC
   Attr.cpp
   AutoDiff.cpp
   Availability.cpp
-  AvailabilityConstraint.cpp
   AvailabilityContext.cpp
   AvailabilityDomain.cpp
   AvailabilityQuery.cpp
+  AvailabilityRestriction.cpp
   AvailabilityScope.cpp
   AvailabilityScopeBuilder.cpp
   AvailabilitySpec.cpp

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -14,8 +14,8 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/AccessScope.h"
-#include "swift/AST/AvailabilityConstraint.h"
 #include "swift/AST/AvailabilityContext.h"
+#include "swift/AST/AvailabilityRestriction.h"
 #include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/DeclExportabilityVisitor.h"
 #include "swift/AST/DiagnosticsSema.h"
@@ -1833,6 +1833,6 @@ bool DeclContext::isAlwaysAvailableConformanceContext() const {
   // target.
   auto &ctx = getASTContext();
   auto deploymentTarget = AvailabilityContext::forDeploymentTarget(ctx);
-  auto constraints = getAvailabilityConstraintsForDecl(ext, deploymentTarget);
-  return !constraints.getPrimaryConstraint();
+  auto restrictions = getAvailabilityRestrictionsForDecl(ext, deploymentTarget);
+  return !restrictions.getPrimaryRestriction();
 }

--- a/lib/AST/ProtocolConformanceRef.cpp
+++ b/lib/AST/ProtocolConformanceRef.cpp
@@ -18,8 +18,8 @@
 #include "swift/AST/ProtocolConformanceRef.h"
 #include "AbstractConformance.h"
 #include "swift/AST/ASTContext.h"
-#include "swift/AST/AvailabilityConstraint.h"
 #include "swift/AST/AvailabilityContext.h"
+#include "swift/AST/AvailabilityRestriction.h"
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/GenericEnvironment.h"
@@ -404,9 +404,9 @@ bool ProtocolConformanceRef::forEachIsolatedConformance(
   return false;
 }
 
-std::optional<AvailabilityConstraint>
-ProtocolConformanceRef::getAvailabilityConstraint(DeclContext *dc,
-                                                  SourceLoc loc) const {
+std::optional<AvailabilityRestriction>
+ProtocolConformanceRef::getAvailabilityRestriction(DeclContext *dc,
+                                                   SourceLoc loc) const {
   // FIXME: Missing logic for pack conformances which is not currently needed.
   // See diagnoseConformanceAvailability for implementation guidance.
   if (!isConcrete())
@@ -414,19 +414,19 @@ ProtocolConformanceRef::getAvailabilityConstraint(DeclContext *dc,
 
   auto availability = AvailabilityContext::forLocation(loc, dc);
   // Conformance declarations can be more available than the protocols they
-  // involve due to source compatibility exceptions. Thus, it is important to 
-  // verify that neither pose a constraint in the given context when checking 
+  // involve due to source compatibility exceptions. Thus, it is important to
+  // verify that neither pose a restriction in the given context when checking
   // for availability of a conformance.
-  if (auto constraint =
-          getAvailabilityConstraintsForDecl(getProtocol(), availability)
-              .getPrimaryConstraint())
-    return constraint;
+  if (auto restriction =
+          getAvailabilityRestrictionsForDecl(getProtocol(), availability)
+              .getPrimaryRestriction())
+    return restriction;
 
   auto *conformanceDC = getConcrete()->getRootConformance()->getDeclContext();
-  if (auto constraint = getAvailabilityConstraintsForDecl(
-                            conformanceDC->getAsDecl(), availability)
-                            .getPrimaryConstraint())
-    return constraint;
+  if (auto restriction = getAvailabilityRestrictionsForDecl(
+                             conformanceDC->getAsDecl(), availability)
+                             .getPrimaryRestriction())
+    return restriction;
 
   return std::nullopt;
 }

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1311,7 +1311,7 @@ ResultBuilderOpSupport TypeChecker::checkBuilderOpSupport(
 
   auto isUnavailable = [&](Decl *D) -> bool {
     auto loc = extractNearestSourceLoc(dc);
-    return getUnsatisfiedAvailabilityConstraint(D, dc, loc).has_value();
+    return getUnsatisfiedAvailabilityRestriction(D, dc, loc).has_value();
   };
 
   bool foundMatch = false;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3034,8 +3034,8 @@ bool ContextualFailure::diagnoseKeyPathLiteralMutabilityMismatch() const {
       continue;
 
     if (auto *setter = storageDecl->getOpaqueAccessor(AccessorKind::Set)) {
-      if (getUnsatisfiedAvailabilityConstraint(setter, S.getDC(),
-                                               component.getLoc())) {
+      if (getUnsatisfiedAvailabilityRestriction(setter, S.getDC(),
+                                                component.getLoc())) {
         auto where =
             ExportContext::forFunctionBody(S.getDC(), component.getLoc());
         return diagnoseDeclAvailability(setter, component.getLoc(),

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -690,7 +690,7 @@ public:
   bool diagnoseAsNote() override;
 
   /// If the type of a key path literal is read-only due to setter
-  /// availability constraints but the context requires a writable
+  /// availability restrictions but the context requires a writable
   /// key path, let's produce a tailed availability diagnostic that
   /// points to the offending setter.
   bool diagnoseKeyPathLiteralMutabilityMismatch() const;

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -2351,9 +2351,9 @@ private:
       if (!nominal)
         return false;
 
-      auto constraint = getUnsatisfiedAvailabilityConstraint(
+      auto restriction = getUnsatisfiedAvailabilityRestriction(
           nominal, context.getAsDeclContext(), loc);
-      if (constraint && !constraint->isUnavailable()) {
+      if (restriction && !restriction->isUnavailable()) {
         auto &ctx = getASTContext();
         ctx.Diags.diagnose(loc,
                            diag::result_builder_missing_limited_availability,

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4819,7 +4819,7 @@ bool ConstraintSystem::isDeclUnavailable(const Decl *D,
       loc = getLoc(anchor);
   }
 
-  auto result = getUnsatisfiedAvailabilityConstraint(D, DC, loc).has_value();
+  auto result = getUnsatisfiedAvailabilityRestriction(D, DC, loc).has_value();
   const_cast<ConstraintSystem *>(this)->UnavailableDecls.insert(
       std::make_pair(std::make_pair(D, locator), result));
   return result;
@@ -5019,7 +5019,7 @@ bool ConstraintSystem::isReadOnlyKeyPathComponent(
   // If the setter is unavailable, then the keypath ought to be read-only
   // in this context.
   if (auto setter = storage->getOpaqueAccessor(AccessorKind::Set)) {
-    if (getUnsatisfiedAvailabilityConstraint(setter, DC, referenceLoc))
+    if (getUnsatisfiedAvailabilityRestriction(setter, DC, referenceLoc))
       return true;
   }
 

--- a/lib/Sema/DerivedConformance/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceRawRepresentable.cpp
@@ -20,7 +20,7 @@
 #include "TypeCheckAvailability.h"
 #include "TypeCheckDecl.h"
 #include "TypeChecker.h"
-#include "swift/AST/AvailabilityConstraint.h"
+#include "swift/AST/AvailabilityRestriction.h"
 #include "swift/AST/AvailabilitySpec.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Expr.h"
@@ -244,30 +244,32 @@ checkAvailability(const EnumElementDecl *elt,
                   AvailabilityContext availabilityContext,
                   std::optional<RuntimeVersionCheck> &versionCheck) {
   auto &C = elt->getASTContext();
-  auto constraint = getAvailabilityConstraintsForDecl(elt, availabilityContext)
-                        .getPrimaryConstraint();
+  auto restriction =
+      getAvailabilityRestrictionsForDecl(elt, availabilityContext)
+          .getPrimaryRestriction();
 
   // Is it always available?
-  if (!constraint)
+  if (!restriction)
     return true;
 
   // Is it never available?
-  if (constraint->isUnavailable())
+  if (restriction->isUnavailable())
     return false;
 
-  // Some constraints are active for type checking but can't translate to
+  // Some restrictions are active for type checking but can't translate to
   // runtime restrictions.
-  if (!constraint->isActiveForRuntimeQueries(C))
+  if (!restriction->isActiveForRuntimeQueries(C))
     return true;
 
-  auto domainAndRange = constraint->getDomainAndRange(C);
+  auto domainAndRange = restriction->getDomainAndRange(C);
 
-  // Only platform version constraints are supported currently.
+  // Only platform version restrictions are supported currently.
   // FIXME: [availability] Support non-platform domain availability checks
   if (!domainAndRange.getDomain().isPlatform())
     return true;
 
-  // It's conditionally available; create a version constraint and return true.
+  // It's conditionally available; create a version restriction and return
+  // true.
   versionCheck.emplace(domainAndRange.getDomain().getPlatformKind(),
                        domainAndRange.getRange().getRawMinimumVersion());
   return true;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2240,17 +2240,17 @@ static std::optional<std::pair<SemanticAvailableAttr, const Decl *>>
 getSemanticAvailableRangeDeclAndAttr(const Decl *decl,
                                      AvailabilityDomain domain) {
   auto &ctx = decl->getASTContext();
-  AvailabilityConstraintFlags flags =
-      AvailabilityConstraintFlag::SkipEnclosingExtension;
-  if (auto constraint = swift::getAvailabilityConstraintForDeclInDomain(
+  AvailabilityRestrictionFlags flags =
+      AvailabilityRestrictionFlag::SkipEnclosingExtension;
+  if (auto restriction = swift::getAvailabilityRestrictionForDeclInDomain(
           decl, AvailabilityContext::forAlwaysAvailable(ctx), domain, flags)) {
-    switch (constraint->getReason()) {
-    case AvailabilityConstraint::Reason::UnavailableUnconditionally:
-    case AvailabilityConstraint::Reason::UnavailableObsolete:
+    switch (restriction->getReason()) {
+    case AvailabilityRestriction::Reason::UnavailableUnconditionally:
+    case AvailabilityRestriction::Reason::UnavailableObsolete:
       break;
-    case AvailabilityConstraint::Reason::UnavailableUnintroduced:
-    case AvailabilityConstraint::Reason::Unintroduced:
-      return std::make_pair(constraint->getAttr(), decl);
+    case AvailabilityRestriction::Reason::UnavailableUnintroduced:
+    case AvailabilityRestriction::Reason::Unintroduced:
+      return std::make_pair(restriction->getAttr(), decl);
     }
   }
 
@@ -5639,7 +5639,7 @@ void AttributeChecker::checkAvailableAttrs(ArrayRef<AvailableAttr *> attrs) {
   if (Ctx.LangOpts.DisableAvailabilityChecking)
     return;
 
-  // Compute availability constraints for the decl, relative to its parent
+  // Compute availability restrictions for the decl, relative to its parent
   // declaration or to the deployment target.
   auto availabilityContext = AvailabilityContext::forDeploymentTarget(Ctx);
   if (auto parent = D->parentDeclForAvailability()) {
@@ -5647,16 +5647,16 @@ void AttributeChecker::checkAvailableAttrs(ArrayRef<AvailableAttr *> attrs) {
     availabilityContext.constrainWithContext(parentAvailability, Ctx);
   }
 
-  auto availabilityConstraint =
-      getAvailabilityConstraintsForDecl(D, availabilityContext)
-          .getPrimaryConstraint();
-  if (!availabilityConstraint)
+  auto availabilityRestriction =
+      getAvailabilityRestrictionsForDecl(D, availabilityContext)
+          .getPrimaryRestriction();
+  if (!availabilityRestriction)
     return;
 
   // If the decl is unavailable relative to its parent and it's not a
   // declaration that is allowed to be unavailable, diagnose.
-  if (availabilityConstraint->isUnavailable()) {
-    auto attr = availabilityConstraint->getAttr();
+  if (availabilityRestriction->isUnavailable()) {
+    auto attr = availabilityRestriction->getAttr();
     if (auto diag = TypeChecker::diagnosticIfDeclCannotBeUnavailable(D, attr)) {
       diagnoseAndRemoveAttr(const_cast<AvailableAttr *>(attr.getParsedAttr()),
                             *diag);
@@ -5666,8 +5666,8 @@ void AttributeChecker::checkAvailableAttrs(ArrayRef<AvailableAttr *> attrs) {
 
   // If the decl is potentially unavailable relative to its parent and it's
   // not a declaration that is allowed to be potentially unavailable, diagnose.
-  if (!availabilityConstraint->isUnavailable()) {
-    auto attr = availabilityConstraint->getAttr();
+  if (!availabilityRestriction->isUnavailable()) {
+    auto attr = availabilityRestriction->getAttr();
     if (auto diag =
             TypeChecker::diagnosticIfDeclCannotBePotentiallyUnavailable(D))
       diagnoseAndRemoveAttr(const_cast<AvailableAttr *>(attr.getParsedAttr()),

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -25,8 +25,8 @@
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/AbstractLayout.h"
-#include "swift/AST/AvailabilityConstraint.h"
 #include "swift/AST/AvailabilityDomain.h"
+#include "swift/AST/AvailabilityRestriction.h"
 #include "swift/AST/AvailabilityScope.h"
 #include "swift/AST/AvailabilitySpec.h"
 #include "swift/AST/ClangModuleLoader.h"
@@ -58,7 +58,7 @@ using namespace swift;
 /// Emit a diagnostic for references to declarations that have been
 /// marked as unavailable, either through "unavailable" or "obsoleted:".
 static bool diagnoseExplicitUnavailability(
-    SourceLoc loc, const AvailabilityConstraint &constraint,
+    SourceLoc loc, const AvailabilityRestriction &restriction,
     const RootProtocolConformance *rootConf, const ExtensionDecl *ext,
     const ExportContext &where,
     bool warnIfConformanceUnavailablePreSwift6 = false,
@@ -67,8 +67,9 @@ static bool diagnoseExplicitUnavailability(
 /// Emit a diagnostic for references to declarations that have been
 /// marked as unavailable, either through "unavailable" or "obsoleted:".
 static bool diagnoseExplicitUnavailability(
-    const ValueDecl *D, SourceRange R, const AvailabilityConstraint &constraint,
-    const ExportContext &Where, DeclAvailabilityFlags Flags,
+    const ValueDecl *D, SourceRange R,
+    const AvailabilityRestriction &restriction, const ExportContext &Where,
+    DeclAvailabilityFlags Flags,
     llvm::function_ref<void(InFlightDiagnostic &, StringRef)>
         attachRenameFixIts);
 
@@ -1798,17 +1799,17 @@ void swift::diagnoseOverrideOfUnavailableDecl(ValueDecl *override,
     return;
   }
 
-  // FIXME: [availability] Take an unsatisfied constraint as input instead of
+  // FIXME: [availability] Take an unsatisfied restriction as input instead of
   // recomputing it.
   ExportContext where = ExportContext::forDeclSignature(override);
-  auto constraint =
-      getAvailabilityConstraintsForDecl(base, where.getAvailability())
-          .getPrimaryConstraint();
-  if (!constraint)
+  auto restriction =
+      getAvailabilityRestrictionsForDecl(base, where.getAvailability())
+          .getPrimaryRestriction();
+  if (!restriction)
     return;
 
   diagnoseExplicitUnavailability(
-      base, override->getLoc(), *constraint, where,
+      base, override->getLoc(), *restriction, where,
       /*Flags*/ std::nullopt,
       [&override, &ctx](InFlightDiagnostic &diag, StringRef rename) {
         ParsedDeclName parsedName = parseDeclName(rename);
@@ -1841,19 +1842,21 @@ void swift::diagnoseOverrideOfUnavailableDecl(ValueDecl *override,
 
 /// Emit a diagnostic for references to declarations that have been
 /// marked as unavailable, either through "unavailable" or "obsoleted:".
-static bool diagnoseExplicitUnavailability(
-    const ValueDecl *D, SourceRange R, const AvailabilityConstraint &constraint,
-    const ExportContext &Where, const Expr *call, DeclAvailabilityFlags Flags) {
+static bool
+diagnoseExplicitUnavailability(const ValueDecl *D, SourceRange R,
+                               const AvailabilityRestriction &restriction,
+                               const ExportContext &Where, const Expr *call,
+                               DeclAvailabilityFlags Flags) {
   return diagnoseExplicitUnavailability(
-      D, R, constraint, Where, Flags,
+      D, R, restriction, Where, Flags,
       [=](InFlightDiagnostic &diag, StringRef rename) {
         fixItAvailableAttrRename(diag, R, D, rename, call);
       });
 }
 
-bool shouldHideDomainNameForConstraintDiagnostic(
-    const AvailabilityConstraint &constraint) {
-  switch (constraint.getDomain().getKind()) {
+bool shouldHideDomainNameForRestrictionDiagnostic(
+    const AvailabilityRestriction &restriction) {
+  switch (restriction.getDomain().getKind()) {
   case AvailabilityDomain::Kind::Universal:
   case AvailabilityDomain::Kind::Embedded:
   case AvailabilityDomain::Kind::Custom:
@@ -1863,25 +1866,25 @@ bool shouldHideDomainNameForConstraintDiagnostic(
   case AvailabilityDomain::Kind::Platform:
     return false;
   case AvailabilityDomain::Kind::SwiftLanguageMode:
-    switch (constraint.getReason()) {
-    case AvailabilityConstraint::Reason::UnavailableUnconditionally:
-    case AvailabilityConstraint::Reason::UnavailableUnintroduced:
+    switch (restriction.getReason()) {
+    case AvailabilityRestriction::Reason::UnavailableUnconditionally:
+    case AvailabilityRestriction::Reason::UnavailableUnintroduced:
       return false;
-    case AvailabilityConstraint::Reason::Unintroduced:
-    case AvailabilityConstraint::Reason::UnavailableObsolete:
+    case AvailabilityRestriction::Reason::Unintroduced:
+    case AvailabilityRestriction::Reason::UnavailableObsolete:
       return true;
     }
   }
 }
 
 bool diagnoseExplicitUnavailability(SourceLoc loc,
-                                    const AvailabilityConstraint &constraint,
+                                    const AvailabilityRestriction &restriction,
                                     const RootProtocolConformance *rootConf,
                                     const ExtensionDecl *ext,
                                     const ExportContext &where,
                                     bool warnIfConformanceUnavailablePreSwift6,
                                     bool preconcurrency) {
-  if (!constraint.isUnavailable())
+  if (!restriction.isUnavailable())
     return false;
 
   // Invertible protocols are never unavailable.
@@ -1893,8 +1896,8 @@ bool diagnoseExplicitUnavailability(SourceLoc loc,
 
   auto type = rootConf->getType();
   auto proto = rootConf->getProtocol()->getDeclaredInterfaceType();
-  auto domainAndRange = constraint.getDomainAndRange(ctx);
-  auto attr = constraint.getAttr();
+  auto domainAndRange = restriction.getDomainAndRange(ctx);
+  auto attr = restriction.getAttr();
 
   // Downgrade unavailable Sendable conformance diagnostics where
   // appropriate.
@@ -1904,52 +1907,52 @@ bool diagnoseExplicitUnavailability(SourceLoc loc,
   EncodedDiagnosticMessage EncodedMessage(attr.getMessage());
   diags
       .diagnose(loc, diag::conformance_availability_unavailable, type, proto,
-                shouldHideDomainNameForConstraintDiagnostic(constraint),
+                shouldHideDomainNameForRestrictionDiagnostic(restriction),
                 domainAndRange.getDomain(), EncodedMessage.Message)
       .limitBehaviorWithPreconcurrency(behavior, preconcurrency)
       .warnUntilLanguageModeIf(warnIfConformanceUnavailablePreSwift6,
                                LanguageMode::v6);
 
-  switch (constraint.getReason()) {
-  case AvailabilityConstraint::Reason::UnavailableUnconditionally:
+  switch (restriction.getReason()) {
+  case AvailabilityRestriction::Reason::UnavailableUnconditionally:
     diags
         .diagnose(ext, diag::conformance_availability_marked_unavailable, type,
                   proto)
         .highlight(attr.getParsedAttr()->getRange());
     break;
-  case AvailabilityConstraint::Reason::UnavailableUnintroduced:
+  case AvailabilityRestriction::Reason::UnavailableUnintroduced:
     diags.diagnose(ext, diag::conformance_availability_introduced_in_version,
                    type, proto, domainAndRange.getDomain(),
                    domainAndRange.getRange());
     break;
-  case AvailabilityConstraint::Reason::UnavailableObsolete:
+  case AvailabilityRestriction::Reason::UnavailableObsolete:
     diags
         .diagnose(ext, diag::conformance_availability_obsoleted, type, proto,
                   domainAndRange.getDomain(), domainAndRange.getRange())
         .highlight(attr.getParsedAttr()->getRange());
     break;
-  case AvailabilityConstraint::Reason::Unintroduced:
-    llvm_unreachable("unexpected constraint");
+  case AvailabilityRestriction::Reason::Unintroduced:
+    llvm_unreachable("unexpected restriction");
   }
   return true;
 }
 
-std::optional<AvailabilityConstraint>
-swift::getUnsatisfiedAvailabilityConstraint(const Decl *decl,
-                                            const DeclContext *referenceDC,
-                                            SourceLoc referenceLoc) {
-  AvailabilityConstraintFlags flags;
+std::optional<AvailabilityRestriction>
+swift::getUnsatisfiedAvailabilityRestriction(const Decl *decl,
+                                             const DeclContext *referenceDC,
+                                             SourceLoc referenceLoc) {
+  AvailabilityRestrictionFlags flags;
 
   // In implicit code, allow references to universally unavailable declarations
   // as long as the context is also universally unavailable.
   if (referenceLoc.isInvalid())
-    flags |= AvailabilityConstraintFlag::
+    flags |= AvailabilityRestrictionFlag::
         AllowUniversallyUnavailableInCompatibleContexts;
 
-  return getAvailabilityConstraintsForDecl(
+  return getAvailabilityRestrictionsForDecl(
              decl, AvailabilityContext::forLocation(referenceLoc, referenceDC),
              flags)
-      .getPrimaryConstraint();
+      .getPrimaryRestriction();
 }
 
 /// Check if this is a subscript declaration inside String or
@@ -2276,14 +2279,15 @@ static void checkFunctionConversionAvailability(Type srcType, Type destType,
 }
 
 bool diagnoseExplicitUnavailability(
-    const ValueDecl *D, SourceRange R, const AvailabilityConstraint &constraint,
-    const ExportContext &Where, DeclAvailabilityFlags Flags,
+    const ValueDecl *D, SourceRange R,
+    const AvailabilityRestriction &restriction, const ExportContext &Where,
+    DeclAvailabilityFlags Flags,
     llvm::function_ref<void(InFlightDiagnostic &, StringRef)>
         attachRenameFixIts) {
-  if (!constraint.isUnavailable())
+  if (!restriction.isUnavailable())
     return false;
 
-  auto Attr = constraint.getAttr();
+  auto Attr = restriction.getAttr();
   if (Attr.getDomain().isSwiftLanguageMode() && !Attr.isVersionSpecific()) {
     if (shouldAllowReferenceToUnavailableInSwiftDeclaration(D, Where))
       return false;
@@ -2292,7 +2296,7 @@ bool diagnoseExplicitUnavailability(
   SourceLoc Loc = R.Start;
   ASTContext &ctx = D->getASTContext();
   auto &diags = ctx.Diags;
-  auto domainAndRange = constraint.getDomainAndRange(ctx);
+  auto domainAndRange = restriction.getDomainAndRange(ctx);
 
   // TODO: Consider removing this.
   // ObjC keypaths components weren't checked previously, so errors are demoted
@@ -2333,32 +2337,32 @@ bool diagnoseExplicitUnavailability(
     EncodedDiagnosticMessage EncodedMessage(message);
     diags
         .diagnose(Loc, diag::availability_decl_unavailable, D,
-                  shouldHideDomainNameForConstraintDiagnostic(constraint),
+                  shouldHideDomainNameForRestrictionDiagnostic(restriction),
                   domainAndRange.getDomain(), EncodedMessage.Message)
         .highlight(R)
         .limitBehavior(limit);
   }
 
   auto sourceRange = Attr.getParsedAttr()->getRange();
-  switch (constraint.getReason()) {
-  case AvailabilityConstraint::Reason::UnavailableUnconditionally:
+  switch (restriction.getReason()) {
+  case AvailabilityRestriction::Reason::UnavailableUnconditionally:
     diags.diagnose(D, diag::availability_marked_unavailable, D)
         .highlight(sourceRange);
     break;
-  case AvailabilityConstraint::Reason::UnavailableUnintroduced:
+  case AvailabilityRestriction::Reason::UnavailableUnintroduced:
     diags
         .diagnose(D, diag::availability_introduced_in_version, D,
                   domainAndRange.getDomain(), domainAndRange.getRange())
         .highlight(sourceRange);
     break;
-  case AvailabilityConstraint::Reason::UnavailableObsolete:
+  case AvailabilityRestriction::Reason::UnavailableObsolete:
     diags
         .diagnose(D, diag::availability_obsoleted, D,
                   domainAndRange.getDomain(), domainAndRange.getRange())
         .highlight(sourceRange);
     break;
-  case AvailabilityConstraint::Reason::Unintroduced:
-    llvm_unreachable("unexpected constraint");
+  case AvailabilityRestriction::Reason::Unintroduced:
+    llvm_unreachable("unexpected restriction");
     break;
   }
   return true;
@@ -3148,12 +3152,12 @@ bool swift::diagnoseDeclAvailability(const ValueDecl *D, SourceRange R,
   auto *DC = Where.getDeclContext();
   auto &ctx = DC->getASTContext();
 
-  auto constraint =
-      getAvailabilityConstraintsForDecl(D, Where.getAvailability())
-          .getPrimaryConstraint();
+  auto restriction =
+      getAvailabilityRestrictionsForDecl(D, Where.getAvailability())
+          .getPrimaryRestriction();
 
-  if (constraint) {
-    if (diagnoseExplicitUnavailability(D, R, *constraint, Where, call, Flags))
+  if (restriction) {
+    if (diagnoseExplicitUnavailability(D, R, *restriction, Where, call, Flags))
       return true;
   }
 
@@ -3186,11 +3190,11 @@ bool swift::diagnoseDeclAvailability(const ValueDecl *D, SourceRange R,
     return false;
 
   // Diagnose (and possibly signal) for potential unavailability
-  if (!constraint || constraint->isUnavailable())
+  if (!restriction || restriction->isUnavailable())
     return false;
 
-  auto domainAndRange = constraint->getDomainAndRange(ctx);
-  auto fixItDomainAndRange = constraint->getFixItDomainAndRange(ctx);
+  auto domainAndRange = restriction->getDomainAndRange(ctx);
+  auto fixItDomainAndRange = restriction->getFixItDomainAndRange(ctx);
   auto domain = domainAndRange.getDomain();
   auto requiredRange = domainAndRange.getRange();
 
@@ -3571,20 +3575,20 @@ swift::diagnoseConformanceAvailability(SourceLoc loc,
       return true;
     }
 
-    auto constraint =
-        getAvailabilityConstraintsForDecl(ext, where.getAvailability())
-            .getPrimaryConstraint();
-    if (constraint) {
-      if (diagnoseExplicitUnavailability(loc, *constraint, rootConf, ext, where,
-                                         warnIfConformanceUnavailablePreSwift6,
-                                         preconcurrency)) {
+    auto restriction =
+        getAvailabilityRestrictionsForDecl(ext, where.getAvailability())
+            .getPrimaryRestriction();
+    if (restriction) {
+      if (diagnoseExplicitUnavailability(
+              loc, *restriction, rootConf, ext, where,
+              warnIfConformanceUnavailablePreSwift6, preconcurrency)) {
         maybeEmitAssociatedTypeNote();
         return true;
       }
 
       // Diagnose (and possibly signal) for potential unavailability
-      auto domainAndRange = constraint->getDomainAndRange(ctx);
-      auto fixItDomainAndRange = constraint->getFixItDomainAndRange(ctx);
+      auto domainAndRange = restriction->getDomainAndRange(ctx);
+      auto fixItDomainAndRange = restriction->getFixItDomainAndRange(ctx);
       if (diagnosePotentialUnavailability(
               rootConf, ext, loc, DC, domainAndRange, fixItDomainAndRange)) {
         maybeEmitAssociatedTypeNote();

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -14,8 +14,8 @@
 #define SWIFT_SEMA_TYPE_CHECK_AVAILABILITY_H
 
 #include "swift/AST/Attr.h"
-#include "swift/AST/AvailabilityConstraint.h"
 #include "swift/AST/AvailabilityContext.h"
+#include "swift/AST/AvailabilityRestriction.h"
 #include "swift/AST/DeclContext.h"
 #include "swift/AST/DeclExportabilityVisitor.h"
 #include "swift/AST/Identifier.h"
@@ -260,9 +260,9 @@ void diagnoseOverrideOfUnavailableDecl(ValueDecl *override,
 
 /// Checks whether a declaration should be considered unavailable when referred
 /// to at the given source location in the given decl context and, if so,
-/// returns a result that describes the unsatisfied constraint.
+/// returns a result that describes the unsatisfied restriction.
 /// Returns `std::nullopt` if the declaration is available.
-std::optional<AvailabilityConstraint> getUnsatisfiedAvailabilityConstraint(
+std::optional<AvailabilityRestriction> getUnsatisfiedAvailabilityRestriction(
     const Decl *decl, const DeclContext *referenceDC, SourceLoc referenceLoc);
 
 /// Diagnose uses of the runtime support of the given type, such as

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -22,8 +22,8 @@
 #include "TypeCheckUnsafe.h"
 #include "TypeChecker.h"
 #include "swift/AST/ASTVisitor.h"
-#include "swift/AST/AvailabilityConstraint.h"
 #include "swift/AST/AvailabilityRange.h"
+#include "swift/AST/AvailabilityRestriction.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/GenericSignature.h"
@@ -252,14 +252,15 @@ static bool isUnavailableInAllVersions(ValueDecl *decl) {
   ASTContext &ctx = decl->getASTContext();
 
   auto deploymentContext = AvailabilityContext::forDeploymentTarget(ctx);
-  auto constraints = getAvailabilityConstraintsForDecl(decl, deploymentContext);
-  for (auto constraint : constraints) {
-    switch (constraint.getReason()) {
-    case AvailabilityConstraint::Reason::UnavailableUnconditionally:
-    case AvailabilityConstraint::Reason::UnavailableUnintroduced:
+  auto restrictions =
+      getAvailabilityRestrictionsForDecl(decl, deploymentContext);
+  for (auto restriction : restrictions) {
+    switch (restriction.getReason()) {
+    case AvailabilityRestriction::Reason::UnavailableUnconditionally:
+    case AvailabilityRestriction::Reason::UnavailableUnintroduced:
       return true;
-    case AvailabilityConstraint::Reason::UnavailableObsolete:
-    case AvailabilityConstraint::Reason::Unintroduced:
+    case AvailabilityRestriction::Reason::UnavailableObsolete:
+    case AvailabilityRestriction::Reason::Unintroduced:
       break;
     }
   }
@@ -1840,7 +1841,7 @@ enum class OverrideAvailability {
   Ignored,
 };
 
-static std::pair<OverrideAvailability, std::optional<AvailabilityConstraint>>
+static std::pair<OverrideAvailability, std::optional<AvailabilityRestriction>>
 getOverrideAvailability(ValueDecl *override, ValueDecl *base) {
   auto &ctx = override->getASTContext();
 
@@ -1857,32 +1858,32 @@ getOverrideAvailability(ValueDecl *override, ValueDecl *base) {
 
   // In order to maintain source compatibility, universally unavailable decls
   // are allowed to override universally unavailable bases.
-  AvailabilityConstraintFlags flags;
-  flags |= AvailabilityConstraintFlag::
+  AvailabilityRestrictionFlags flags;
+  flags |= AvailabilityRestrictionFlag::
       AllowUniversallyUnavailableInCompatibleContexts;
 
-  if (auto constraint =
-          getAvailabilityConstraintsForDecl(override, baseAvailability, flags)
-              .getPrimaryConstraint()) {
-    if (constraint->isUnavailable())
-      return {OverrideAvailability::OverrideUnavailable, constraint};
+  if (auto restriction =
+          getAvailabilityRestrictionsForDecl(override, baseAvailability, flags)
+              .getPrimaryRestriction()) {
+    if (restriction->isUnavailable())
+      return {OverrideAvailability::OverrideUnavailable, restriction};
 
-    return {OverrideAvailability::OverrideLessAvailable, constraint};
+    return {OverrideAvailability::OverrideLessAvailable, restriction};
   }
 
   // Check whether the base is unavailable from the perspective of the override.
   auto overrideAvailability = AvailabilityContext::forDeclSignature(override);
-  if (auto baseConstraint =
-          getAvailabilityConstraintsForDecl(base, overrideAvailability, flags)
-              .getPrimaryConstraint()) {
-    if (baseConstraint->isUnavailable())
-      return {OverrideAvailability::BaseUnavailable, baseConstraint};
+  if (auto baseRestriction =
+          getAvailabilityRestrictionsForDecl(base, overrideAvailability, flags)
+              .getPrimaryRestriction()) {
+    if (baseRestriction->isUnavailable())
+      return {OverrideAvailability::BaseUnavailable, baseRestriction};
   }
 
   return {OverrideAvailability::Compatible, std::nullopt};
 }
 
-static std::pair<OverrideAvailability, std::optional<AvailabilityConstraint>>
+static std::pair<OverrideAvailability, std::optional<AvailabilityRestriction>>
 checkOverrideAvailability(ValueDecl *override, ValueDecl *base) {
   auto &ctx = override->getASTContext();
   if (ctx.LangOpts.DisableAvailabilityChecking)

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -39,10 +39,10 @@ using namespace swift;
 /// be kept in sync with importEnumCaseAlias in the ClangImporter library.
 static EnumElementDecl *extractEnumElement(DeclContext *DC, SourceLoc UseLoc,
                                            const VarDecl *constant) {
-  if (auto constraint =
-          getUnsatisfiedAvailabilityConstraint(constant, DC, UseLoc)) {
+  if (auto restriction =
+          getUnsatisfiedAvailabilityRestriction(constant, DC, UseLoc)) {
     // Only diagnose explicit unavailability.
-    if (constraint->isUnavailable())
+    if (restriction->isUnavailable())
       diagnoseDeclAvailability(constant, UseLoc, nullptr,
                                ExportContext::forFunctionBody(DC, UseLoc));
   }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1994,7 +1994,7 @@ static bool checkWitnessAccess(DeclContext *dc,
   return false;
 }
 
-static std::optional<AvailabilityConstraint>
+static std::optional<AvailabilityRestriction>
 checkWitnessAvailability(const ValueDecl *requirement, const ValueDecl *witness,
                          const DeclContext *dc,
                          AvailabilityContext &requiredContext) {
@@ -2038,12 +2038,12 @@ checkWitnessAvailability(const ValueDecl *requirement, const ValueDecl *witness,
 
   // In order to maintain source compatibility, universally unavailable decls
   // are allowed to witness universally unavailable requirements.
-  AvailabilityConstraintFlags flags;
-  flags |= AvailabilityConstraintFlag::
+  AvailabilityRestrictionFlags flags;
+  flags |= AvailabilityRestrictionFlag::
       AllowUniversallyUnavailableInCompatibleContexts;
 
-  return getAvailabilityConstraintsForDecl(witness, requiredContext, flags)
-      .getPrimaryConstraint();
+  return getAvailabilityRestrictionsForDecl(witness, requiredContext, flags)
+      .getPrimaryRestriction();
 }
 
 RequirementCheck WitnessChecker::checkWitness(ValueDecl *requirement,
@@ -4709,7 +4709,7 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
               ASTContext &ctx = witness->getASTContext();
               auto &diags = ctx.Diags;
               auto diagLoc = getLocForDiagnosingWitness(conformance, witness);
-              auto attr = check.getAvailabilityConstraint().getAttr();
+              auto attr = check.getAvailabilityRestriction().getAttr();
               auto domain = attr.getDomain();
               auto requiredRange =
                   check.getRequiredAvailabilityContext().getAvailabilityRange(
@@ -4738,7 +4738,7 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
              check](NormalProtocolConformance *conformance) {
               auto &diags = witness->getASTContext().Diags;
               auto diagLoc = getLocForDiagnosingWitness(conformance, witness);
-              auto attr = check.getAvailabilityConstraint().getAttr();
+              auto attr = check.getAvailabilityRestriction().getAttr();
               EncodedDiagnosticMessage EncodedMessage(attr.getMessage());
               diags.diagnose(diagLoc, diag::witness_unavailable, witness,
                              conformance->getProtocol(),

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -3775,9 +3775,9 @@ public:
     ASSERT(!seqConformanceRef.isInvalid() || seqType->isExistentialType());
 
     if (!ctx.LangOpts.DisableAvailabilityChecking) {
-      if (auto constraint = seqConformanceRef.getAvailabilityConstraint(
+      if (auto restriction = seqConformanceRef.getAvailabilityRestriction(
               dc, stmt->getForLoc())) {
-        emitDiagnosticsForUnavailableConformance(seqType, constraint.value());
+        emitDiagnosticsForUnavailableConformance(seqType, restriction.value());
         return nullptr;
       }
     }
@@ -3799,13 +3799,12 @@ public:
   }
 
 private:
-  void
-  emitDiagnosticsForUnavailableConformance(Type seqType,
-                                           AvailabilityConstraint constraint) {
+  void emitDiagnosticsForUnavailableConformance(
+      Type seqType, AvailabilityRestriction restriction) {
     auto loc = stmt->getForLoc();
     auto protoDecl = seqConformanceRef.getProtocol();
 
-    auto domainAndRange = constraint.getDomainAndRange(ctx);
+    auto domainAndRange = restriction.getDomainAndRange(ctx);
     auto domain = domainAndRange.getDomain();
     auto range = domainAndRange.getRange();
     if (domain.isVersioned() && range.hasMinimumVersion()) {
@@ -3813,7 +3812,7 @@ private:
                          seqType, protoDecl,
                          domain.getNameForAttributePrinting(),
                          range.getVersionString());
-      fixAvailability(loc, dc, constraint.getFixItDomainAndRange(ctx), ctx);
+      fixAvailability(loc, dc, restriction.getFixItDomainAndRange(ctx), ctx);
     } else {
       ctx.Diags.diagnose(
           loc, diag::for_loop_sequence_conformance_unavailable_unconditionally,


### PR DESCRIPTION
For many Swift compiler engineers the term "constraint" evokes an association with the constraint solver subsystem. While availability of declarations can play a role sometimes when solving a constraint system, the type that was named `AvailabilityConstraint` is not really a constraint in the constraint system sense, so it seems best to rename it to avoid confusion.
