### PR TITLE
[SILOptimizer] Fold optional pointer/reference comparisons into one comparison

### DIFF
--- a/SwiftCompilerSources/Sources/AST/Declarations.swift
+++ b/SwiftCompilerSources/Sources/AST/Declarations.swift
@@ -119,6 +119,9 @@ public class NominalTypeDecl: GenericTypeDecl {
 }
 
 final public class EnumDecl: NominalTypeDecl {
+  public static let optionalNoneCaseIndex = 0
+  public static let optionalSomeCaseIndex = 1
+
   public var rawType: Type? { Type(bridgedOrNil: bridged.Enum_getRawType()) }
 
   public static func create(

--- a/SwiftCompilerSources/Sources/AST/Declarations.swift
+++ b/SwiftCompilerSources/Sources/AST/Declarations.swift
@@ -132,6 +132,9 @@ public class NominalTypeDecl: GenericTypeDecl {
 }
 
 final public class EnumDecl: NominalTypeDecl {
+  public static let optionalNoneCaseIndex = 0
+  public static let optionalSomeCaseIndex = 1
+
   public var rawType: Type? { Type(bridgedOrNil: bridged.Enum_getRawType()) }
 
   public static func create(

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
@@ -935,14 +935,14 @@ private extension EnumInst {
 
   var isOptionalSome: Bool {
     assert(self.type.isOptional)
-    assert(self.caseIndex == Builder.optionalNoneCaseIndex || self.caseIndex == Builder.optionalSomeCaseIndex)
-    return self.caseIndex == Builder.optionalSomeCaseIndex
+    assert(self.caseIndex == EnumDecl.optionalNoneCaseIndex || self.caseIndex == EnumDecl.optionalSomeCaseIndex)
+    return self.caseIndex == EnumDecl.optionalSomeCaseIndex
   }
 
   var isOptionalNone: Bool {
     assert(self.type.isOptional)
-    assert(self.caseIndex == Builder.optionalNoneCaseIndex || self.caseIndex == Builder.optionalSomeCaseIndex)
-    return self.caseIndex == Builder.optionalNoneCaseIndex
+    assert(self.caseIndex == EnumDecl.optionalNoneCaseIndex || self.caseIndex == EnumDecl.optionalSomeCaseIndex)
+    return self.caseIndex == EnumDecl.optionalNoneCaseIndex
   }
 }
 
@@ -1120,7 +1120,7 @@ private func getSuccessorForOptionalSome(arg: Argument) -> BasicBlock? {
     return nil
   }
 
-  return sei.getUniqueSuccessor(forCaseIndex: Builder.optionalSomeCaseIndex)!
+  return sei.getUniqueSuccessor(forCaseIndex: EnumDecl.optionalSomeCaseIndex)!
 }
 
 // If the pullback's basic block has an argument which is a payload tuple of the

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
@@ -1003,14 +1003,14 @@ private extension EnumInst {
 
   var isOptionalSome: Bool {
     assert(self.type.isOptional)
-    assert(self.caseIndex == Builder.optionalNoneCaseIndex || self.caseIndex == Builder.optionalSomeCaseIndex)
-    return self.caseIndex == Builder.optionalSomeCaseIndex
+    assert(self.caseIndex == EnumDecl.optionalNoneCaseIndex || self.caseIndex == EnumDecl.optionalSomeCaseIndex)
+    return self.caseIndex == EnumDecl.optionalSomeCaseIndex
   }
 
   var isOptionalNone: Bool {
     assert(self.type.isOptional)
-    assert(self.caseIndex == Builder.optionalNoneCaseIndex || self.caseIndex == Builder.optionalSomeCaseIndex)
-    return self.caseIndex == Builder.optionalNoneCaseIndex
+    assert(self.caseIndex == EnumDecl.optionalNoneCaseIndex || self.caseIndex == EnumDecl.optionalSomeCaseIndex)
+    return self.caseIndex == EnumDecl.optionalNoneCaseIndex
   }
 }
 
@@ -1188,7 +1188,7 @@ private func getSuccessorForOptionalSome(arg: Argument) -> BasicBlock? {
     return nil
   }
 
-  return sei.getUniqueSuccessor(forCaseIndex: Builder.optionalSomeCaseIndex)!
+  return sei.getUniqueSuccessor(forCaseIndex: EnumDecl.optionalSomeCaseIndex)!
 }
 
 // If the pullback's basic block has an argument which is a payload tuple of the

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CommonSubexpressionElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CommonSubexpressionElimination.swift
@@ -23,6 +23,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import AST
 import SIL
 
 // -----------------------------------------------------------------------
@@ -265,7 +266,7 @@ private func isOptimizableLazyPropertyGetter(_ ai: ApplyInst) -> Bool {
     return false
   }
 
-  guard let someDest = sei.getUniqueSuccessor(forCaseIndex: Builder.optionalSomeCaseIndex) else {
+  guard let someDest = sei.getUniqueSuccessor(forCaseIndex: EnumDecl.optionalSomeCaseIndex) else {
     return false
   }
   return someDest.arguments.count == 1
@@ -295,7 +296,7 @@ private func processLazyPropertyGetters(
     // After inlining the getter, the call block's terminator is the
     // switch_enum from the getter's entry block.
     guard let sei = callBlock.terminator as? SwitchEnumInst,
-      let someDest = sei.getUniqueSuccessor(forCaseIndex: Builder.optionalSomeCaseIndex),
+      let someDest = sei.getUniqueSuccessor(forCaseIndex: EnumDecl.optionalSomeCaseIndex),
       someDest.arguments.count == 1
     else {
       continue
@@ -304,7 +305,7 @@ private func processLazyPropertyGetters(
     let builder = Builder(before: sei, context)
     let ued = builder.createUncheckedEnumData(
       enum: sei.enumOp,
-      caseIndex: Builder.optionalSomeCaseIndex,
+      caseIndex: EnumDecl.optionalSomeCaseIndex,
       resultType: someDest.arguments[0].type
     )
     _ = builder.createBranch(to: someDest, arguments: [ued])

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CommonSubexpressionElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CommonSubexpressionElimination.swift
@@ -23,6 +23,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import AST
 import SIL
 
 // -----------------------------------------------------------------------
@@ -254,7 +255,7 @@ private func isOptimizableLazyPropertyGetter(_ ai: ApplyInst) -> Bool {
     return false
   }
 
-  guard let someDest = sei.getUniqueSuccessor(forCaseIndex: Builder.optionalSomeCaseIndex) else {
+  guard let someDest = sei.getUniqueSuccessor(forCaseIndex: EnumDecl.optionalSomeCaseIndex) else {
     return false
   }
   return someDest.arguments.count == 1
@@ -284,7 +285,7 @@ private func processLazyPropertyGetters(
     // After inlining the getter, the call block's terminator is the
     // switch_enum from the getter's entry block.
     guard let sei = callBlock.terminator as? SwitchEnumInst,
-      let someDest = sei.getUniqueSuccessor(forCaseIndex: Builder.optionalSomeCaseIndex),
+      let someDest = sei.getUniqueSuccessor(forCaseIndex: EnumDecl.optionalSomeCaseIndex),
       someDest.arguments.count == 1
     else {
       continue
@@ -293,7 +294,7 @@ private func processLazyPropertyGetters(
     let builder = Builder(before: sei, context)
     let ued = builder.createUncheckedEnumData(
       enum: sei.enumOp,
-      caseIndex: Builder.optionalSomeCaseIndex,
+      caseIndex: EnumDecl.optionalSomeCaseIndex,
       resultType: someDest.arguments[0].type
     )
     _ = builder.createBranch(to: someDest, arguments: [ued])

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyRefCasts.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyRefCasts.swift
@@ -32,6 +32,12 @@ extension UncheckedRefCastInst : OnoneSimplifiable {
   }
 }
 
+extension RefToRawPointerInst : OnoneSimplifiable {
+  func simplify(_ context: SimplifyContext) {
+    simplifySourceOperandOfRefCast(context)
+  }
+}
+
 private extension CheckedCastBranchInst {
 
   /// Removes the `checked_cast_br` if it is dead:

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifySwitchEnum.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifySwitchEnum.swift
@@ -10,28 +10,41 @@
 //
 //===----------------------------------------------------------------------===//
 
+import AST
 import SIL
 
-// Removes an `enum` - `switch_enum` pair:
-// ```
-//     %1 = enum $E, #someCase, %payload
-//     switch_enum %1, case #someCase: bb1, ...
-//   bb1(%payloadArgument):
-// ```
-// ->
-// ```
-//   br bb1(%payload)
-//   bb1(%payloadArgument):
-// ```
-//
-// Other case blocks of the switch_enum become dead.
-//
 extension SwitchEnumInst : OnoneSimplifiable {
   func simplify(_ context: SimplifyContext) {
+    // First try to fold the `switch_enum` with a statically known `enum` operand into a branch.
+    // Only if that doesn't apply, try to fold an optional pointer comparison.
+    if simplifyToBranch(context) {
+      return
+    }
+    _ = simplifyOptionalPointerComparison(context)
+  }
+}
+
+private extension SwitchEnumInst {
+
+  // Removes an `enum` - `switch_enum` pair:
+  // ```
+  //     %1 = enum $E, #someCase, %payload
+  //     switch_enum %1, case #someCase: bb1, ...
+  //   bb1(%payloadArgument):
+  // ```
+  // ->
+  // ```
+  //   br bb1(%payload)
+  //   bb1(%payloadArgument):
+  // ```
+  //
+  // Other case blocks of the switch_enum become dead.
+  //
+  func simplifyToBranch(_ context: SimplifyContext) -> Bool {
     guard let enumInst = enumOp as? EnumInst,
           let caseBlock = getUniqueSuccessor(forCaseIndex: enumInst.caseIndex) else
     {
-      return
+      return false
     }
 
     let singleUse = context.preserveDebugInfo ? enumInst.uses.singleUse : enumInst.uses.ignoreDebugUses.singleUse
@@ -39,7 +52,7 @@ extension SwitchEnumInst : OnoneSimplifiable {
 
     if !canEraseEnumInst && parentFunction.hasOwnership && enumInst.ownership == .owned {
       // We cannot add more uses to the `enum` instruction without inserting a copy.
-      return
+      return false
     }
 
     let builder = Builder(before: self, context)
@@ -59,6 +72,114 @@ extension SwitchEnumInst : OnoneSimplifiable {
 
     if canEraseEnumInst {
       context.erase(instructionIncludingDebugUses: enumInst)
+    }
+    return true
+  }
+
+  // Replaces a comparison of a non-optional class reference or raw pointer with an optional one,
+  // which is lowered to a `switch_enum` plus a pointer comparison in the payload block, with a
+  // single pointer comparison:
+  // ```
+  //     switch_enum %optional, case #some: bb1, case #none: bb2
+  //   bb1(%payload):
+  //     %pp = ref_to_raw_pointer %payload
+  //     %ap = ref_to_raw_pointer %a
+  //     %c = builtin "cmp_eq_RawPointer"(%ap, %pp)
+  //     br bb3(%c)
+  //   bb2:
+  //     %f = integer_literal $Builtin.Int1, 0
+  //     br bb3(%f)
+  // ```
+  // ->
+  // ```
+  //     %ap = ref_to_raw_pointer %a
+  //     %or = unchecked_ref_cast %optional to $SomeClass
+  //     %op = ref_to_raw_pointer %or
+  //     %c = builtin "cmp_eq_RawPointer"(%ap, %op)
+  //     br bb3(%c)
+  // ```
+  func simplifyOptionalPointerComparison(_ context: SimplifyContext) -> Bool {
+    guard enumOp.type.isOptional, enumOp.ownership != .owned else {
+      return false
+    }
+
+    guard let someBlock = getUniqueSuccessor(forCaseIndex: EnumDecl.optionalSomeCaseIndex),
+          let noneBlock = getUniqueSuccessor(forCaseIndex: EnumDecl.optionalNoneCaseIndex),
+          !someBlock.hasSideEffects, !noneBlock.hasSideEffects,
+          let someBranch = someBlock.terminator as? BranchInst,
+          let noneBranch = noneBlock.terminator as? BranchInst,
+          someBranch.targetBlock == noneBranch.targetBlock,
+          someBranch.operands.count == 1, noneBranch.operands.count == 1,
+          let falseLiteral = noneBranch.operands[0].value as? IntegerLiteralInst,
+          falseLiteral.value == 0,
+          let cmp = someBranch.operands[0].value as? BuiltinInst,
+          cmp.name == "cmp_eq_RawPointer", cmp.arguments.count == 2,
+          let (lhs, rhs) = cmp.comparedUnderlyingPointers
+    else {
+      return false
+    }
+
+    let payload = someBlock.arguments[0]
+    let nonOptional: Value
+    if lhs == payload {
+      nonOptional = rhs
+    } else if rhs == payload {
+      nonOptional = lhs
+    } else {
+      return false
+    }
+    guard nonOptional.type == payload.type, nonOptional.parentBlock != someBlock else {
+      return false
+    }
+
+    let builder = Builder(before: self, context)
+    let rawPointerType = cmp.arguments[0].type
+    let nonOptionalPointer: Value
+    let optionalPointer: Value
+    if payload.type.isHeapObjectReferenceType {
+      guard nonOptional is FunctionArgument else {
+        return false
+      }
+      nonOptionalPointer = builder.createRefToRawPointer(from: nonOptional, to: rawPointerType)
+      let optionalRef = builder.createUncheckedRefCast(from: enumOp, to: payload.type)
+      optionalPointer = builder.createRefToRawPointer(from: optionalRef, to: rawPointerType)
+    } else {
+      nonOptionalPointer = builder.createUncheckedTrivialBitCast(from: nonOptional, to: rawPointerType)
+      optionalPointer = builder.createUncheckedTrivialBitCast(from: enumOp, to: rawPointerType)
+    }
+    let result = builder.createBuiltinBinaryFunction(name: "cmp_eq", operandType: rawPointerType,
+                                                     resultType: cmp.type,
+                                                     arguments: [nonOptionalPointer, optionalPointer])
+    builder.createBranch(to: someBranch.targetBlock, arguments: [result])
+    context.erase(instruction: self)
+    return true
+  }
+}
+
+private extension BasicBlock {
+  var hasSideEffects: Bool {
+    instructions.contains { $0.mayHaveSideEffects || $0.hasUnspecifiedSideEffects }
+  }
+}
+
+private extension BuiltinInst {
+  var comparedUnderlyingPointers: (Value, Value)? {
+    switch (arguments[0], arguments[1]) {
+    case let (lhs as RefToRawPointerInst, rhs as RefToRawPointerInst):
+      guard lhs.parentBlock == parentBlock, rhs.parentBlock == parentBlock else {
+        return nil
+      }
+      return (lhs.operand.value, rhs.operand.value)
+    case let (lhs as StructExtractInst, rhs as StructExtractInst):
+      guard lhs.struct.type == rhs.struct.type, lhs.fieldIndex == rhs.fieldIndex,
+            lhs.struct.type.isTrivial(in: parentFunction),
+            lhs.struct.type.getNominalFields(in: parentFunction)?.count == 1,
+            lhs.parentBlock == parentBlock, rhs.parentBlock == parentBlock else {
+        return nil
+      }
+      return (lhs.struct, rhs.struct)
+    default:
+      return nil
     }
   }
 }

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifySwitchEnum.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifySwitchEnum.swift
@@ -10,30 +10,34 @@
 //
 //===----------------------------------------------------------------------===//
 
+import AST
 import SIL
 
-// Removes an `enum` - `switch_enum` pair:
-// ```
-//     %1 = enum $E, #someCase, %payload
-//     switch_enum %1, case #someCase: bb1, ...
-//   bb1(%payloadArgument):
-// ```
-// ->
-// ```
-//   br bb1(%payload)
-//   bb1(%payloadArgument):
-// ```
-//
-// Other case blocks of the switch_enum become dead.
-//
 extension SwitchEnumInst : OnoneSimplifiable, SILCombineSimplifiable {
   func simplify(_ context: SimplifyContext) {
     if tryFoldWithEnum(context) {
       return
     }
+    if simplifyOptionalPointerComparison(context) {
+      return
+    }
     _ = forwardBorrowToOwned(context)
   }
 
+  // Removes an `enum` - `switch_enum` pair:
+  // ```
+  //     %1 = enum $E, #someCase, %payload
+  //     switch_enum %1, case #someCase: bb1, ...
+  //   bb1(%payloadArgument):
+  // ```
+  // ->
+  // ```
+  //   br bb1(%payload)
+  //   bb1(%payloadArgument):
+  // ```
+  //
+  // Other case blocks of the switch_enum become dead.
+  //
   private func tryFoldWithEnum(_ context: SimplifyContext) -> Bool {
     guard let enumInst = enumOp as? EnumInst,
           let caseBlock = getUniqueSuccessor(forCaseIndex: enumInst.caseIndex) else
@@ -67,6 +71,85 @@ extension SwitchEnumInst : OnoneSimplifiable, SILCombineSimplifiable {
     if canEraseEnumInst {
       context.erase(instruction: enumInst)
     }
+    return true
+  }
+
+  // Replaces a comparison of a non-optional class reference or raw pointer with an optional one,
+  // which is lowered to a `switch_enum` plus a pointer comparison in the payload block, with a
+  // single pointer comparison:
+  // ```
+  //     switch_enum %optional, case #some: bb1, case #none: bb2
+  //   bb1(%payload):
+  //     %pp = ref_to_raw_pointer %payload
+  //     %ap = ref_to_raw_pointer %a
+  //     %c = builtin "cmp_eq_RawPointer"(%ap, %pp)
+  //     br bb3(%c)
+  //   bb2:
+  //     %f = integer_literal $Builtin.Int1, 0
+  //     br bb3(%f)
+  // ```
+  // ->
+  // ```
+  //     %ap = ref_to_raw_pointer %a
+  //     %or = unchecked_ref_cast %optional to $SomeClass
+  //     %op = ref_to_raw_pointer %or
+  //     %c = builtin "cmp_eq_RawPointer"(%ap, %op)
+  //     br bb3(%c)
+  // ```
+  private func simplifyOptionalPointerComparison(_ context: SimplifyContext) -> Bool {
+    guard enumOp.type.isOptional, enumOp.ownership != .owned else {
+      return false
+    }
+
+    guard let someBlock = getUniqueSuccessor(forCaseIndex: EnumDecl.optionalSomeCaseIndex),
+          let noneBlock = getUniqueSuccessor(forCaseIndex: EnumDecl.optionalNoneCaseIndex),
+          !someBlock.hasSideEffects, !noneBlock.hasSideEffects,
+          let someBranch = someBlock.terminator as? BranchInst,
+          let noneBranch = noneBlock.terminator as? BranchInst,
+          someBranch.targetBlock == noneBranch.targetBlock,
+          someBranch.operands.count == 1, noneBranch.operands.count == 1,
+          let falseLiteral = noneBranch.operands[0].value as? IntegerLiteralInst,
+          falseLiteral.value == 0,
+          let cmp = someBranch.operands[0].value as? BuiltinInst,
+          cmp.name == "cmp_eq_RawPointer", cmp.arguments.count == 2,
+          let (lhs, rhs) = cmp.comparedUnderlyingPointers
+    else {
+      return false
+    }
+
+    let payload = someBlock.arguments[0]
+    let nonOptional: Value
+    if lhs == payload {
+      nonOptional = rhs
+    } else if rhs == payload {
+      nonOptional = lhs
+    } else {
+      return false
+    }
+    guard nonOptional.type == payload.type, nonOptional.parentBlock != someBlock else {
+      return false
+    }
+
+    let builder = Builder(before: self, context)
+    let rawPointerType = cmp.arguments[0].type
+    let nonOptionalPointer: Value
+    let optionalPointer: Value
+    if payload.type.isHeapObjectReferenceType {
+      guard nonOptional is FunctionArgument else {
+        return false
+      }
+      nonOptionalPointer = builder.createRefToRawPointer(from: nonOptional, to: rawPointerType)
+      let optionalRef = builder.createUncheckedRefCast(from: enumOp, to: payload.type)
+      optionalPointer = builder.createRefToRawPointer(from: optionalRef, to: rawPointerType)
+    } else {
+      nonOptionalPointer = builder.createUncheckedTrivialBitCast(from: nonOptional, to: rawPointerType)
+      optionalPointer = builder.createUncheckedTrivialBitCast(from: enumOp, to: rawPointerType)
+    }
+    let result = builder.createBuiltinBinaryFunction(name: "cmp_eq", operandType: rawPointerType,
+                                                     resultType: cmp.type,
+                                                     arguments: [nonOptionalPointer, optionalPointer])
+    builder.createBranch(to: someBranch.targetBlock, arguments: [result])
+    context.erase(instruction: self)
     return true
   }
 
@@ -205,5 +288,33 @@ private extension Instruction {
     // If the _exclusive_ block range of the borrow scope includes the switch-block,
     // the `switch_enum` is in the range, because it's the last instruction of that block.
     return scopeBlocks.contains(switchEnum.parentBlock)
+  }
+}
+
+private extension BasicBlock {
+  var hasSideEffects: Bool {
+    instructions.contains { $0.mayHaveSideEffects || $0.hasUnspecifiedSideEffects }
+  }
+}
+
+private extension BuiltinInst {
+  var comparedUnderlyingPointers: (Value, Value)? {
+    switch (arguments[0], arguments[1]) {
+    case let (lhs as RefToRawPointerInst, rhs as RefToRawPointerInst):
+      guard lhs.parentBlock == parentBlock, rhs.parentBlock == parentBlock else {
+        return nil
+      }
+      return (lhs.operand.value, rhs.operand.value)
+    case let (lhs as StructExtractInst, rhs as StructExtractInst):
+      guard lhs.struct.type == rhs.struct.type, lhs.fieldIndex == rhs.fieldIndex,
+            lhs.struct.type.isTrivial(in: parentFunction),
+            lhs.struct.type.getNominalFields(in: parentFunction)?.count == 1,
+            lhs.parentBlock == parentBlock, rhs.parentBlock == parentBlock else {
+        return nil
+      }
+      return (lhs.struct, rhs.struct)
+    default:
+      return nil
+    }
   }
 }

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyUncheckedEnumData.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyUncheckedEnumData.swift
@@ -14,12 +14,34 @@ import SIL
 
 extension UncheckedEnumDataInst : OnoneSimplifiable, SILCombineSimplifiable {
   func simplify(_ context: SimplifyContext) {
-    guard let enumInst = self.enum as? EnumInst else {
+    if let enumInst = self.enum as? EnumInst {
+      if caseIndex == enumInst.caseIndex {
+        context.tryReplaceRedundantInstructionPair(first: enumInst, second: self, with: enumInst.payload!)
+      }
       return
     }
-    if caseIndex != enumInst.caseIndex {
+    replaceWithSwitchEnumPayloadArgument(context)
+  }
+
+  /// Replaces an `unchecked_enum_data` in a `switch_enum` case block with the block's payload
+  /// argument, if it projects the same case of the same enum, e.g.
+  ///
+  ///   switch_enum %e, case #C: bb1
+  /// bb1(%payload):
+  ///   %d = unchecked_enum_data %e, #C
+  /// ->
+  ///   %payload
+  ///
+  private func replaceWithSwitchEnumPayloadArgument(_ context: SimplifyContext) {
+    let block = parentBlock
+    guard let pred = block.singlePredecessor,
+          let switchEnum = pred.terminator as? SwitchEnumInst,
+          switchEnum.enumOp == self.enum,
+          switchEnum.getUniqueCase(forSuccessor: block) == caseIndex,
+          block.arguments.count == 1
+    else {
       return
     }
-    context.tryReplaceRedundantInstructionPair(first: enumInst, second: self, with: enumInst.payload!)
+    self.replace(with: block.arguments[0], context)
   }
 }

--- a/SwiftCompilerSources/Sources/SIL/Builder.swift
+++ b/SwiftCompilerSources/Sources/SIL/Builder.swift
@@ -341,7 +341,12 @@ public struct Builder {
     let cast = bridged.createUpcast(value.bridged, type.bridged)
     return notifyNew(cast.getAs(UpcastInst.self))
   }
-  
+
+  public func createRefToRawPointer(from value: Value, to type: Type) -> RefToRawPointerInst {
+    let cast = bridged.createRefToRawPointer(value.bridged, type.bridged)
+    return notifyNew(cast.getAs(RefToRawPointerInst.self))
+  }
+
   @discardableResult
   public func createCheckedCastAddrBranch(
     source: Value, sourceFormalType: CanonicalType,
@@ -619,15 +624,12 @@ public struct Builder {
     return notifyNew(enumInst.getAs(EnumInst.self))
   }
 
-  public static let optionalNoneCaseIndex = 0
-  public static let optionalSomeCaseIndex = 1
-
   public func createOptionalNone(type: Type) -> EnumInst {
-    return createEnum(caseIndex: Self.optionalNoneCaseIndex, payload: nil, enumType: type)
+    return createEnum(caseIndex: EnumDecl.optionalNoneCaseIndex, payload: nil, enumType: type)
   }
 
   public func createOptionalSome(operand: Value, type: Type) -> EnumInst {
-    return createEnum(caseIndex: Self.optionalSomeCaseIndex, payload: operand, enumType: type)
+    return createEnum(caseIndex: EnumDecl.optionalSomeCaseIndex, payload: operand, enumType: type)
   }
 
   public func createThinToThickFunction(thinFunction: Value, resultType: Type) -> ThinToThickFunctionInst {

--- a/SwiftCompilerSources/Sources/SIL/Builder.swift
+++ b/SwiftCompilerSources/Sources/SIL/Builder.swift
@@ -331,7 +331,12 @@ public struct Builder {
     let cast = bridged.createUpcast(value.bridged, type.bridged)
     return notifyNew(cast.getAs(UpcastInst.self))
   }
-  
+
+  public func createRefToRawPointer(from value: Value, to type: Type) -> RefToRawPointerInst {
+    let cast = bridged.createRefToRawPointer(value.bridged, type.bridged)
+    return notifyNew(cast.getAs(RefToRawPointerInst.self))
+  }
+
   @discardableResult
   public func createCheckedCastAddrBranch(
     source: Value, sourceFormalType: CanonicalType,
@@ -609,15 +614,12 @@ public struct Builder {
     return notifyNew(enumInst.getAs(EnumInst.self))
   }
 
-  public static let optionalNoneCaseIndex = 0
-  public static let optionalSomeCaseIndex = 1
-
   public func createOptionalNone(type: Type) -> EnumInst {
-    return createEnum(caseIndex: Self.optionalNoneCaseIndex, payload: nil, enumType: type)
+    return createEnum(caseIndex: EnumDecl.optionalNoneCaseIndex, payload: nil, enumType: type)
   }
 
   public func createOptionalSome(operand: Value, type: Type) -> EnumInst {
-    return createEnum(caseIndex: Self.optionalSomeCaseIndex, payload: operand, enumType: type)
+    return createEnum(caseIndex: EnumDecl.optionalSomeCaseIndex, payload: operand, enumType: type)
   }
 
   public func createThinToThickFunction(thinFunction: Value, resultType: Type) -> ThinToThickFunctionInst {

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -1337,6 +1337,8 @@ struct BridgedBuilder{
                                                                               BridgedValue index) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createUncheckedRefCast(BridgedValue op,
                                                                                BridgedType type) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createRefToRawPointer(BridgedValue op,
+                                                                              BridgedType type) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createUncheckedAddrCast(BridgedValue op,
                                                                                 BridgedType type) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createUncheckedValueCast(BridgedValue op,

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -1371,6 +1371,8 @@ struct BridgedBuilder{
                                                                               BridgedValue index) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createUncheckedRefCast(BridgedValue op,
                                                                                BridgedType type) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createRefToRawPointer(BridgedValue op,
+                                                                              BridgedType type) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createUncheckedAddrCast(BridgedValue op,
                                                                                 BridgedType type) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createUncheckedValueCast(BridgedValue op,

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -2640,6 +2640,11 @@ BridgedInstruction BridgedBuilder::createUncheckedRefCast(BridgedValue op, Bridg
                                              type.unbridged())};
 }
 
+BridgedInstruction BridgedBuilder::createRefToRawPointer(BridgedValue op, BridgedType type) const {
+  return {unbridged().createRefToRawPointer(regularLoc(), op.getSILValue(),
+                                            type.unbridged())};
+}
+
 BridgedInstruction BridgedBuilder::createUncheckedAddrCast(BridgedValue op, BridgedType type) const {
   return {unbridged().createUncheckedAddrCast(regularLoc(), op.getSILValue(),
                                               type.unbridged())};

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -2797,6 +2797,11 @@ BridgedInstruction BridgedBuilder::createUncheckedRefCast(BridgedValue op, Bridg
                                              type.unbridged())};
 }
 
+BridgedInstruction BridgedBuilder::createRefToRawPointer(BridgedValue op, BridgedType type) const {
+  return {unbridged().createRefToRawPointer(regularLoc(), op.getSILValue(),
+                                            type.unbridged())};
+}
+
 BridgedInstruction BridgedBuilder::createUncheckedAddrCast(BridgedValue op, BridgedType type) const {
   return {unbridged().createUncheckedAddrCast(regularLoc(), op.getSILValue(),
                                               type.unbridged())};

--- a/test/SILOptimizer/optional_pointer_comparison.swift
+++ b/test/SILOptimizer/optional_pointer_comparison.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend -module-name test -primary-file %s -O -emit-sil | %FileCheck %s
+
+public class C {}
+
+// A class reference compared against an optional folds into a single pointer comparison.
+// CHECK-LABEL: sil {{.*}}3cmpySbAA1CC
+// CHECK-NOT:     switch_enum
+// CHECK:         [[A:%.*]] = ref_to_raw_pointer %0
+// CHECK:         [[O:%.*]] = unchecked_trivial_bit_cast %1
+// CHECK:         builtin "cmp_eq_RawPointer"([[A]], [[O]])
+// CHECK:       } // end sil function
+public func cmp(_ a: C, _ b: C?) -> Bool {
+  return a === b
+}
+
+// A raw pointer folds too, now that its payload `unchecked_enum_data` is forwarded.
+// CHECK-LABEL: sil {{.*}}rawPointerCmp
+// CHECK-NOT:     switch_enum
+// CHECK:         [[A:%.*]] = unchecked_trivial_bit_cast %0
+// CHECK:         [[O:%.*]] = unchecked_trivial_bit_cast %1
+// CHECK:         builtin "cmp_eq_RawPointer"([[A]], [[O]])
+// CHECK:       } // end sil function
+public func rawPointerCmp(_ a: UnsafeRawPointer, _ b: UnsafeRawPointer?) -> Bool {
+  return a == b
+}

--- a/test/SILOptimizer/simplify_ref_to_raw_pointer.sil
+++ b/test/SILOptimizer/simplify_ref_to_raw_pointer.sil
@@ -1,0 +1,35 @@
+// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -onone-simplification -simplify-instruction=ref_to_raw_pointer | %FileCheck %s
+
+import Builtin
+import Swift
+
+class Base {}
+class Derived : Base {}
+
+// Look through an `init_existential_ref` to the underlying reference.
+// CHECK-LABEL: sil [ossa] @look_through_init_existential_ref :
+// CHECK:       bb0(%0 : @guaranteed $Base):
+// CHECK-NOT:     init_existential_ref
+// CHECK:         [[R:%.*]] = ref_to_raw_pointer %0 : $Base to $Builtin.RawPointer
+// CHECK:         return [[R]]
+// CHECK:       } // end sil function 'look_through_init_existential_ref'
+sil [ossa] @look_through_init_existential_ref : $@convention(thin) (@guaranteed Base) -> Builtin.RawPointer {
+bb0(%0 : @guaranteed $Base):
+  %1 = init_existential_ref %0 : $Base : $Base, $AnyObject
+  %2 = ref_to_raw_pointer %1 : $AnyObject to $Builtin.RawPointer
+  return %2 : $Builtin.RawPointer
+}
+
+// Look through an `upcast` to the derived reference.
+// CHECK-LABEL: sil [ossa] @look_through_upcast :
+// CHECK:       bb0(%0 : @guaranteed $Derived):
+// CHECK-NOT:     upcast
+// CHECK:         [[R:%.*]] = ref_to_raw_pointer %0 : $Derived to $Builtin.RawPointer
+// CHECK:         return [[R]]
+// CHECK:       } // end sil function 'look_through_upcast'
+sil [ossa] @look_through_upcast : $@convention(thin) (@guaranteed Derived) -> Builtin.RawPointer {
+bb0(%0 : @guaranteed $Derived):
+  %1 = upcast %0 : $Derived to $Base
+  %2 = ref_to_raw_pointer %1 : $Base to $Builtin.RawPointer
+  return %2 : $Builtin.RawPointer
+}

--- a/test/SILOptimizer/simplify_switch_enum_optional_comparison.sil
+++ b/test/SILOptimizer/simplify_switch_enum_optional_comparison.sil
@@ -1,0 +1,253 @@
+// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -onone-simplification -simplify-instruction=switch_enum | %FileCheck %s
+
+import Builtin
+import Swift
+
+class C {}
+
+enum E {
+  case a(C)
+  case b
+}
+
+struct TwoPointers {
+  var p: Builtin.RawPointer
+  var q: Builtin.RawPointer
+}
+
+struct NonCopyablePtr : ~Copyable {
+  var p: Builtin.RawPointer
+}
+
+// A comparison of a non-optional class reference with an optional one folds into a single
+// pointer comparison, removing the `switch_enum`.
+// CHECK-LABEL: sil [ossa] @optional_class_ref_eq :
+// CHECK:       bb0(%0 : @guaranteed $C, %1 : @guaranteed $Optional<C>):
+// CHECK-NOT:     switch_enum
+// CHECK:         [[A:%.*]] = ref_to_raw_pointer %0 : $C to $Builtin.RawPointer
+// CHECK:         [[OR:%.*]] = unchecked_ref_cast %1 : $Optional<C> to $C
+// CHECK:         [[O:%.*]] = ref_to_raw_pointer [[OR]] : $C to $Builtin.RawPointer
+// CHECK:         [[R:%.*]] = builtin "cmp_eq_RawPointer"([[A]] : $Builtin.RawPointer, [[O]] : $Builtin.RawPointer)
+// CHECK:         br bb1([[R]] : $Builtin.Int1)
+// CHECK:       } // end sil function 'optional_class_ref_eq'
+sil [ossa] @optional_class_ref_eq : $@convention(thin) (@guaranteed C, @guaranteed Optional<C>) -> Builtin.Int1 {
+bb0(%0 : @guaranteed $C, %1 : @guaranteed $Optional<C>):
+  switch_enum %1 : $Optional<C>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
+bb1(%3 : @guaranteed $C):
+  %4 = ref_to_raw_pointer %0 : $C to $Builtin.RawPointer
+  %5 = ref_to_raw_pointer %3 : $C to $Builtin.RawPointer
+  %6 = builtin "cmp_eq_RawPointer"(%4 : $Builtin.RawPointer, %5 : $Builtin.RawPointer) : $Builtin.Int1
+  br bb3(%6 : $Builtin.Int1)
+bb2:
+  %8 = integer_literal $Builtin.Int1, 0
+  br bb3(%8 : $Builtin.Int1)
+bb3(%10 : $Builtin.Int1):
+  return %10 : $Builtin.Int1
+}
+
+// The same for a raw pointer (a single-field pointer struct): looking through the single
+// `struct_extract` field is sound, and the trivial value is reinterpreted with a bit-cast.
+// CHECK-LABEL: sil [ossa] @optional_pointer_eq :
+// CHECK:       bb0(%0 : $UnsafeRawPointer, %1 : $Optional<UnsafeRawPointer>):
+// CHECK-NOT:     switch_enum
+// CHECK:         [[A:%.*]] = unchecked_trivial_bit_cast %0 : $UnsafeRawPointer to $Builtin.RawPointer
+// CHECK:         [[O:%.*]] = unchecked_trivial_bit_cast %1 : $Optional<UnsafeRawPointer> to $Builtin.RawPointer
+// CHECK:         [[R:%.*]] = builtin "cmp_eq_RawPointer"([[A]] : $Builtin.RawPointer, [[O]] : $Builtin.RawPointer)
+// CHECK:         br bb1([[R]] : $Builtin.Int1)
+// CHECK:       } // end sil function 'optional_pointer_eq'
+sil [ossa] @optional_pointer_eq : $@convention(thin) (UnsafeRawPointer, Optional<UnsafeRawPointer>) -> Builtin.Int1 {
+bb0(%0 : $UnsafeRawPointer, %1 : $Optional<UnsafeRawPointer>):
+  switch_enum %1 : $Optional<UnsafeRawPointer>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
+bb1(%3 : $UnsafeRawPointer):
+  %4 = struct_extract %0 : $UnsafeRawPointer, #UnsafeRawPointer._rawValue
+  %5 = struct_extract %3 : $UnsafeRawPointer, #UnsafeRawPointer._rawValue
+  %6 = builtin "cmp_eq_RawPointer"(%4 : $Builtin.RawPointer, %5 : $Builtin.RawPointer) : $Builtin.Int1
+  br bb3(%6 : $Builtin.Int1)
+bb2:
+  %8 = integer_literal $Builtin.Int1, 0
+  br bb3(%8 : $Builtin.Int1)
+bb3(%10 : $Builtin.Int1):
+  return %10 : $Builtin.Int1
+}
+
+// Bail out: the `none` case must yield `false` (a non-optional reference is never null).
+// CHECK-LABEL: sil [ossa] @dont_optimize_none_is_true :
+// CHECK:         switch_enum
+// CHECK:       } // end sil function 'dont_optimize_none_is_true'
+sil [ossa] @dont_optimize_none_is_true : $@convention(thin) (@guaranteed C, @guaranteed Optional<C>) -> Builtin.Int1 {
+bb0(%0 : @guaranteed $C, %1 : @guaranteed $Optional<C>):
+  switch_enum %1 : $Optional<C>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
+bb1(%3 : @guaranteed $C):
+  %4 = ref_to_raw_pointer %0 : $C to $Builtin.RawPointer
+  %5 = ref_to_raw_pointer %3 : $C to $Builtin.RawPointer
+  %6 = builtin "cmp_eq_RawPointer"(%4 : $Builtin.RawPointer, %5 : $Builtin.RawPointer) : $Builtin.Int1
+  br bb3(%6 : $Builtin.Int1)
+bb2:
+  %8 = integer_literal $Builtin.Int1, -1
+  br bb3(%8 : $Builtin.Int1)
+bb3(%10 : $Builtin.Int1):
+  return %10 : $Builtin.Int1
+}
+
+// Bail out: a side effect in the payload block prevents removing it.
+// CHECK-LABEL: sil [ossa] @dont_optimize_side_effect :
+// CHECK:         switch_enum
+// CHECK:       } // end sil function 'dont_optimize_side_effect'
+sil [ossa] @dont_optimize_side_effect : $@convention(thin) (@guaranteed C, @guaranteed Optional<C>) -> Builtin.Int1 {
+bb0(%0 : @guaranteed $C, %1 : @guaranteed $Optional<C>):
+  switch_enum %1 : $Optional<C>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
+bb1(%3 : @guaranteed $C):
+  %f = function_ref @use : $@convention(thin) (@guaranteed C) -> ()
+  %a = apply %f(%3) : $@convention(thin) (@guaranteed C) -> ()
+  %4 = ref_to_raw_pointer %0 : $C to $Builtin.RawPointer
+  %5 = ref_to_raw_pointer %3 : $C to $Builtin.RawPointer
+  %6 = builtin "cmp_eq_RawPointer"(%4 : $Builtin.RawPointer, %5 : $Builtin.RawPointer) : $Builtin.Int1
+  br bb3(%6 : $Builtin.Int1)
+bb2:
+  %8 = integer_literal $Builtin.Int1, 0
+  br bb3(%8 : $Builtin.Int1)
+bb3(%10 : $Builtin.Int1):
+  return %10 : $Builtin.Int1
+}
+
+// Bail out: the enum is not an `Optional`, so its memory layout is unknown.
+// CHECK-LABEL: sil [ossa] @dont_optimize_non_optional_enum :
+// CHECK:         switch_enum
+// CHECK:       } // end sil function 'dont_optimize_non_optional_enum'
+sil [ossa] @dont_optimize_non_optional_enum : $@convention(thin) (@guaranteed C, @guaranteed E) -> Builtin.Int1 {
+bb0(%0 : @guaranteed $C, %1 : @guaranteed $E):
+  switch_enum %1 : $E, case #E.a!enumelt: bb1, case #E.b!enumelt: bb2
+bb1(%3 : @guaranteed $C):
+  %4 = ref_to_raw_pointer %0 : $C to $Builtin.RawPointer
+  %5 = ref_to_raw_pointer %3 : $C to $Builtin.RawPointer
+  %6 = builtin "cmp_eq_RawPointer"(%4 : $Builtin.RawPointer, %5 : $Builtin.RawPointer) : $Builtin.Int1
+  br bb3(%6 : $Builtin.Int1)
+bb2:
+  %8 = integer_literal $Builtin.Int1, 0
+  br bb3(%8 : $Builtin.Int1)
+bb3(%10 : $Builtin.Int1):
+  return %10 : $Builtin.Int1
+}
+
+// Bail out: the non-optional operand is not a function argument, so re-materializing a
+// `ref_to_raw_pointer` in front of the `switch_enum` might not be valid.
+// CHECK-LABEL: sil [ossa] @dont_optimize_local_reference :
+// CHECK:         switch_enum
+// CHECK:       } // end sil function 'dont_optimize_local_reference'
+sil [ossa] @dont_optimize_local_reference : $@convention(thin) (@guaranteed Optional<C>) -> Builtin.Int1 {
+bb0(%1 : @guaranteed $Optional<C>):
+  %0 = alloc_ref $C
+  switch_enum %1 : $Optional<C>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
+bb1(%3 : @guaranteed $C):
+  %4 = ref_to_raw_pointer %0 : $C to $Builtin.RawPointer
+  %5 = ref_to_raw_pointer %3 : $C to $Builtin.RawPointer
+  %6 = builtin "cmp_eq_RawPointer"(%4 : $Builtin.RawPointer, %5 : $Builtin.RawPointer) : $Builtin.Int1
+  br bb3(%6 : $Builtin.Int1)
+bb2:
+  %8 = integer_literal $Builtin.Int1, 0
+  br bb3(%8 : $Builtin.Int1)
+bb3(%10 : $Builtin.Int1):
+  destroy_value %0 : $C
+  return %10 : $Builtin.Int1
+}
+
+// Bail out: the some- and none-case branch to different blocks.
+// CHECK-LABEL: sil [ossa] @dont_optimize_different_targets :
+// CHECK:         switch_enum
+// CHECK:       } // end sil function 'dont_optimize_different_targets'
+sil [ossa] @dont_optimize_different_targets : $@convention(thin) (@guaranteed C, @guaranteed Optional<C>) -> Builtin.Int1 {
+bb0(%0 : @guaranteed $C, %1 : @guaranteed $Optional<C>):
+  switch_enum %1 : $Optional<C>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
+bb1(%3 : @guaranteed $C):
+  %4 = ref_to_raw_pointer %0 : $C to $Builtin.RawPointer
+  %5 = ref_to_raw_pointer %3 : $C to $Builtin.RawPointer
+  %6 = builtin "cmp_eq_RawPointer"(%4 : $Builtin.RawPointer, %5 : $Builtin.RawPointer) : $Builtin.Int1
+  br bb3(%6 : $Builtin.Int1)
+bb2:
+  %8 = integer_literal $Builtin.Int1, 0
+  br bb4(%8 : $Builtin.Int1)
+bb3(%10 : $Builtin.Int1):
+  br bb5(%10 : $Builtin.Int1)
+bb4(%12 : $Builtin.Int1):
+  br bb5(%12 : $Builtin.Int1)
+bb5(%14 : $Builtin.Int1):
+  return %14 : $Builtin.Int1
+}
+
+// Bail out: the compared pointers don't come from a handled cast, so we don't look through them.
+// CHECK-LABEL: sil [ossa] @dont_optimize_other_cast :
+// CHECK:         switch_enum
+// CHECK:       } // end sil function 'dont_optimize_other_cast'
+sil [ossa] @dont_optimize_other_cast : $@convention(thin) (UnsafeRawPointer, Optional<UnsafeRawPointer>) -> Builtin.Int1 {
+bb0(%0 : $UnsafeRawPointer, %1 : $Optional<UnsafeRawPointer>):
+  switch_enum %1 : $Optional<UnsafeRawPointer>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
+bb1(%3 : $UnsafeRawPointer):
+  %4 = unchecked_trivial_bit_cast %0 : $UnsafeRawPointer to $Builtin.RawPointer
+  %5 = unchecked_trivial_bit_cast %3 : $UnsafeRawPointer to $Builtin.RawPointer
+  %6 = builtin "cmp_eq_RawPointer"(%4 : $Builtin.RawPointer, %5 : $Builtin.RawPointer) : $Builtin.Int1
+  br bb3(%6 : $Builtin.Int1)
+bb2:
+  %8 = integer_literal $Builtin.Int1, 0
+  br bb3(%8 : $Builtin.Int1)
+bb3(%10 : $Builtin.Int1):
+  return %10 : $Builtin.Int1
+}
+
+// Bail out: `struct_extract` of a multi-field struct would compare the whole struct, not the field.
+// CHECK-LABEL: sil [ossa] @dont_optimize_multifield_struct :
+// CHECK:         switch_enum
+// CHECK:       } // end sil function 'dont_optimize_multifield_struct'
+sil [ossa] @dont_optimize_multifield_struct : $@convention(thin) (TwoPointers, Optional<TwoPointers>) -> Builtin.Int1 {
+bb0(%0 : $TwoPointers, %1 : $Optional<TwoPointers>):
+  switch_enum %1 : $Optional<TwoPointers>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
+bb1(%3 : $TwoPointers):
+  %4 = struct_extract %0 : $TwoPointers, #TwoPointers.p
+  %5 = struct_extract %3 : $TwoPointers, #TwoPointers.p
+  %6 = builtin "cmp_eq_RawPointer"(%4 : $Builtin.RawPointer, %5 : $Builtin.RawPointer) : $Builtin.Int1
+  br bb3(%6 : $Builtin.Int1)
+bb2:
+  %8 = integer_literal $Builtin.Int1, 0
+  br bb3(%8 : $Builtin.Int1)
+bb3(%10 : $Builtin.Int1):
+  return %10 : $Builtin.Int1
+}
+
+// Bail out: `struct_extract` of a non-trivial (`~Copyable`) struct can't be bit-cast to a pointer.
+// CHECK-LABEL: sil [ossa] @dont_optimize_noncopyable_struct :
+// CHECK:         switch_enum
+// CHECK:       } // end sil function 'dont_optimize_noncopyable_struct'
+sil [ossa] @dont_optimize_noncopyable_struct : $@convention(thin) (@guaranteed NonCopyablePtr, @guaranteed Optional<NonCopyablePtr>) -> Builtin.Int1 {
+bb0(%0 : @guaranteed $NonCopyablePtr, %1 : @guaranteed $Optional<NonCopyablePtr>):
+  switch_enum %1 : $Optional<NonCopyablePtr>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
+bb1(%3 : @guaranteed $NonCopyablePtr):
+  %4 = struct_extract %0 : $NonCopyablePtr, #NonCopyablePtr.p
+  %5 = struct_extract %3 : $NonCopyablePtr, #NonCopyablePtr.p
+  %6 = builtin "cmp_eq_RawPointer"(%4 : $Builtin.RawPointer, %5 : $Builtin.RawPointer) : $Builtin.Int1
+  br bb3(%6 : $Builtin.Int1)
+bb2:
+  %8 = integer_literal $Builtin.Int1, 0
+  br bb3(%8 : $Builtin.Int1)
+bb3(%10 : $Builtin.Int1):
+  return %10 : $Builtin.Int1
+}
+
+// Bail out: a conversion in another block could be in a borrow scope ending before the `switch_enum`.
+// CHECK-LABEL: sil [ossa] @dont_optimize_conversion_in_other_block :
+// CHECK:         switch_enum
+// CHECK:       } // end sil function 'dont_optimize_conversion_in_other_block'
+sil [ossa] @dont_optimize_conversion_in_other_block : $@convention(thin) (@guaranteed C, @guaranteed Optional<C>) -> Builtin.Int1 {
+bb0(%0 : @guaranteed $C, %1 : @guaranteed $Optional<C>):
+  %2 = ref_to_raw_pointer %0 : $C to $Builtin.RawPointer
+  switch_enum %1 : $Optional<C>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
+bb1(%4 : @guaranteed $C):
+  %5 = ref_to_raw_pointer %4 : $C to $Builtin.RawPointer
+  %6 = builtin "cmp_eq_RawPointer"(%2 : $Builtin.RawPointer, %5 : $Builtin.RawPointer) : $Builtin.Int1
+  br bb3(%6 : $Builtin.Int1)
+bb2:
+  %8 = integer_literal $Builtin.Int1, 0
+  br bb3(%8 : $Builtin.Int1)
+bb3(%10 : $Builtin.Int1):
+  return %10 : $Builtin.Int1
+}
+
+sil @use : $@convention(thin) (@guaranteed C) -> ()

--- a/test/SILOptimizer/simplify_unchecked_enum_data.sil
+++ b/test/SILOptimizer/simplify_unchecked_enum_data.sil
@@ -120,3 +120,46 @@ bb3:
   return %r : $()
 }
 
+// CHECK-LABEL: sil [ossa] @forward_switch_enum_payload :
+// CHECK:       bb1([[ARG:%.*]] : $Int):
+// CHECK-NOT:     unchecked_enum_data
+// CHECK:         br bb3([[ARG]])
+// CHECK:       } // end sil function 'forward_switch_enum_payload'
+sil [ossa] @forward_switch_enum_payload : $@convention(thin) (Optional<Int>) -> Int {
+bb0(%0 : $Optional<Int>):
+  switch_enum %0 : $Optional<Int>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
+
+bb1(%2 : $Int):
+  %3 = unchecked_enum_data %0 : $Optional<Int>, #Optional.some!enumelt
+  br bb3(%3 : $Int)
+
+bb2:
+  %5 = integer_literal $Builtin.Int64, 0
+  %6 = struct $Int (%5 : $Builtin.Int64)
+  br bb3(%6 : $Int)
+
+bb3(%r : $Int):
+  return %r : $Int
+}
+
+// The `unchecked_enum_data` operand differs from the `switch_enum` operand.
+// CHECK-LABEL: sil [ossa] @dont_forward_different_enum :
+// CHECK:         unchecked_enum_data
+// CHECK:       } // end sil function 'dont_forward_different_enum'
+sil [ossa] @dont_forward_different_enum : $@convention(thin) (Optional<Int>, Optional<Int>) -> Int {
+bb0(%0 : $Optional<Int>, %1 : $Optional<Int>):
+  switch_enum %0 : $Optional<Int>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
+
+bb1(%3 : $Int):
+  %4 = unchecked_enum_data %1 : $Optional<Int>, #Optional.some!enumelt
+  br bb3(%4 : $Int)
+
+bb2:
+  %6 = integer_literal $Builtin.Int64, 0
+  %7 = struct $Int (%6 : $Builtin.Int64)
+  br bb3(%7 : $Int)
+
+bb3(%r : $Int):
+  return %r : $Int
+}
+


### PR DESCRIPTION
Comparing a non-optional pointer or class reference with an optional one is lowered to a switch_enum plus a pointer comparison in the payload block, which becomes two comparisons in the final code. LLVM can't merge them because it doesn't know the non-optional operand is never null.

Resolves #83423