### PR TITLE
IRGen: Emit declarations for all type-scoped ODR DISubprogram definitions

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -3561,17 +3561,13 @@ IRGenDebugInfoImpl::emitFunction(const SILDebugScope *DS, llvm::Function *Fn,
       /*IsLocalToUnit=*/Fn ? Fn->hasInternalLinkage() : true,
       /*IsDefinition=*/true, /*IsOptimized=*/Opts.shouldOptimize());
 
-  // When the function is a method, we want a DW_AT_declaration there.
+  // When the function is scoped inside an ODR-uniqued type, we want a
+  // DW_AT_declaration there.
   // Because there's no good way to cross the CU boundary to insert a nested
   // DISubprogram definition in one CU into a type defined in another CU when
   // doing LTO builds.
-  if (llvm::isa<llvm::DICompositeType>(Scope) &&
-      (Rep == SILFunctionTypeRepresentation::Method ||
-       Rep == SILFunctionTypeRepresentation::ObjCMethod ||
-       Rep == SILFunctionTypeRepresentation::WitnessMethod ||
-       Rep == SILFunctionTypeRepresentation::CXXMethod ||
-       Rep == SILFunctionTypeRepresentation::CFunctionPointer ||
-       Rep == SILFunctionTypeRepresentation::Thin)) {
+  if (auto *CT = llvm::dyn_cast<llvm::DICompositeType>(Scope);
+      CT && CT->getRawIdentifier()) {
     llvm::DISubprogram::DISPFlags SPFlags = llvm::DISubprogram::toSPFlags(
         /*IsLocalToUnit=*/Fn ? Fn->hasInternalLinkage() : true,
         /*IsDefinition=*/false, /*IsOptimized=*/Opts.shouldOptimize());

--- a/test/DebugInfo/keypath.swift
+++ b/test/DebugInfo/keypath.swift
@@ -8,7 +8,9 @@ public struct Gen<Value> {
 
 // This used to assert.
 
-// CHECK: distinct !DISubprogram({{.*}}linkageName: "$sSly7ElementQz5IndexQzcipSMRzSHADRQlxxTK", {{.*}} spFlags: DISPFlagDefinition
+// CHECK-DAG: ![[COLLECTION:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Collection", {{.*}}identifier: "$sSl_pD")
+// CHECK-DAG: ![[SUBSCRIPT_DECL:[0-9]+]] = !DISubprogram({{.*}}linkageName: "$sSly7ElementQz5IndexQzcipSMRzSHADRQlxxTK", scope: ![[COLLECTION]]
+// CHECK-DAG: distinct !DISubprogram({{.*}}linkageName: "$sSly7ElementQz5IndexQzcipSMRzSHADRQlxxTK", scope: ![[COLLECTION]]{{.*}}spFlags: DISPFlagDefinition{{.*}}declaration: ![[SUBSCRIPT_DECL]]
 extension Gen where Value : MutableCollection, Value.Index : Hashable {
     public var dontAssert: Int {
         var i = value.startIndex

--- a/test/DebugInfo/lto-keypath-accessor-declaration.swift
+++ b/test/DebugInfo/lto-keypath-accessor-declaration.swift
@@ -1,0 +1,53 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -g -o - | %FileCheck %s
+
+// Key path getter and setter thunks are scoped inside the DICompositeType of
+// the type whose member they access. LLVM's verifier requires every
+// definition DISubprogram nested inside an ODR-uniqued DICompositeType to
+// reference a matching declaration when ODR type uniquing is enabled, which
+// is the case during LTO. Check that IRGen emits such declarations for key
+// path getter and setter thunks.
+
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -g -o %t.ll
+// RUN: %llvm-link -S %t.ll -o - 2>%t.err | %FileCheck --check-prefix=ODR %s
+// RUN: %FileCheck --allow-empty --check-prefix=ODR-ERR %s < %t.err
+
+// llvm-link enables ODR type uniquing like LTO does. If the emitted debug
+// info violated the ODR verifier rules, llvm-link would strip it and warn.
+// ODR: distinct !DISubprogram({{.*}}declaration:
+// ODR-ERR-NOT: ignoring invalid debug info
+
+public struct S {
+  public var stored: Int = 0
+  public var computed: Int {
+    get { return stored }
+    set { stored = newValue }
+  }
+  public subscript(i: Int) -> Int {
+    get { return stored + i }
+    set { stored = newValue + i }
+  }
+}
+
+public func f() -> [AnyKeyPath] {
+  return [\S.computed, \S.[0]]
+}
+
+// CHECK-DAG: ![[S_DBG:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "S", {{.*}}identifier: "$s4main1SVD"
+
+// Getter and setter thunks for S.computed.
+// CHECK-DAG: distinct !DISubprogram(name: "computed.get", linkageName: "$s4main1SV8computedSivpACTK", scope: ![[S_DBG]],{{.*}} spFlags: DISPFlagDefinition,{{.*}} declaration: ![[PROP_GETTER_DECL:[0-9]+]]
+// CHECK-DAG: ![[PROP_GETTER_DECL]] = !DISubprogram(name: "computed.get", linkageName: "$s4main1SV8computedSivpACTK", scope: ![[S_DBG]]
+// CHECK-DAG: distinct !DISubprogram(name: "computed.set", linkageName: "$s4main1SV8computedSivpACTk", scope: ![[S_DBG]],{{.*}} spFlags: DISPFlagDefinition,{{.*}} declaration: ![[PROP_SETTER_DECL:[0-9]+]]
+// CHECK-DAG: ![[PROP_SETTER_DECL]] = !DISubprogram(name: "computed.set", linkageName: "$s4main1SV8computedSivpACTk", scope: ![[S_DBG]]
+
+// Getter and setter thunks for S.[_: Int].
+// CHECK-DAG: distinct !DISubprogram(name: "subscript.get", linkageName: "$s4main1SVyS2icipACTK", scope: ![[S_DBG]],{{.*}} spFlags: DISPFlagDefinition,{{.*}} declaration: ![[SUB_GETTER_DECL:[0-9]+]]
+// CHECK-DAG: ![[SUB_GETTER_DECL]] = !DISubprogram(name: "subscript.get", linkageName: "$s4main1SVyS2icipACTK", scope: ![[S_DBG]]
+// CHECK-DAG: distinct !DISubprogram(name: "subscript.set", linkageName: "$s4main1SVyS2icipACTk", scope: ![[S_DBG]],{{.*}} spFlags: DISPFlagDefinition,{{.*}} declaration: ![[SUB_SETTER_DECL:[0-9]+]]
+// CHECK-DAG: ![[SUB_SETTER_DECL]] = !DISubprogram(name: "subscript.set", linkageName: "$s4main1SVyS2icipACTk", scope: ![[S_DBG]]
+
+// The key path index equality and hash thunks are scoped inside the module,
+// not inside a composite type, so they must not get a declaration.
+// CHECK-DAG: distinct !DISubprogram(linkageName: "$sSiTH", scope: ![[MODULE:[0-9]+]], file: !{{[0-9]+}}, type: !{{[0-9]+}}, flags: DIFlagArtificial, spFlags: DISPFlagDefinition, unit: !{{[0-9]+}})
+// CHECK-DAG: distinct !DISubprogram(linkageName: "$sSiTh", scope: ![[MODULE]], file: !{{[0-9]+}}, type: !{{[0-9]+}}, flags: DIFlagArtificial, spFlags: DISPFlagDefinition, unit: !{{[0-9]+}})
+// CHECK-DAG: ![[MODULE]] = !DIModule(


### PR DESCRIPTION
When debug type ODR uniquing is enabled (as it is during LTO), LLVM's verifier requires that a definition DISubprogram scoped inside an ODR-uniqued DICompositeType reference a matching declaration:

    // There's no good way to cross the CU boundary to insert a nested
    // DISubprogram definition in one CU into a type defined in another CU.
    auto *CT = dyn_cast_or_null<DICompositeType>(N.getRawScope());
    if (CT && CT->getRawIdentifier() &&
        M.getContext().isODRUniquingDebugTypes())
      CheckDI(N.getDeclaration(), "definition subprograms cannot be "
              "nested within DICompositeType when enabling ODR", &N);

IRGen only emitted such a declaration for a hard-coded list of SIL function representations. Compiler-generated thunks with other representations that are nonetheless scoped inside an ODR-uniqued composite type were emitted as definitions without a declaration. Key path accessor thunks are one example: they are scoped inside the DICompositeType of the type whose member they access, but use the KeyPathAccessor* representations, which were not in the list. Linking such bitcode with full LTO makes the verifier abort the link with:

    definition subprograms cannot be nested within DICompositeType when
    enabling ODR

observed with wasm-ld when LTO-linking Swift-produced bitcode.

Make the IRGen condition match the verifier requirement directly instead of enumerating representations: whenever the debug scope is a DICompositeType with a raw identifier, emit a declaration and reference it from the definition.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
