### PR TITLE
AST: Move availability restriction queries onto AvailabilityContext

### DIFF
--- a/include/swift/AST/AvailabilityContext.h
+++ b/include/swift/AST/AvailabilityContext.h
@@ -20,6 +20,7 @@
 
 #include "swift/AST/AvailabilityDomain.h"
 #include "swift/AST/AvailabilityRange.h"
+#include "swift/AST/AvailabilityRestriction.h"
 #include "swift/AST/PlatformKindUtils.h"
 #include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
@@ -128,6 +129,25 @@ public:
   void
   constrainWithDeclAndPlatformRange(const Decl *decl,
                                     const AvailabilityRange &platformRange);
+
+  /// Returns the strongest availability restriction that limits use of \p decl
+  /// when it is referenced from this context, or nullopt if use of \p decl is
+  /// not restricted.
+  std::optional<AvailabilityRestriction>
+  restrictionForDecl(const Decl *decl,
+                     AvailabilityRestrictionFlags flags = std::nullopt);
+
+  /// Returns the availability restriction in \p domain that limits use of \p
+  /// decl from this context, or nullopt if use of \p decl is not restricted.
+  std::optional<AvailabilityRestriction>
+  restrictionForDeclInDomain(const Decl *decl, AvailabilityDomain domain,
+                             AvailabilityRestrictionFlags flags = std::nullopt);
+
+  /// Returns the set of availability restrictions that limit use of \p decl
+  /// when it is referenced from this context.
+  DeclAvailabilityRestrictions
+  allRestrictionsForDecl(const Decl *decl,
+                         AvailabilityRestrictionFlags flags = std::nullopt);
 
   /// Returns true if `other` is as available or is more available.
   bool isContainedIn(const AvailabilityContext other) const;

--- a/include/swift/AST/AvailabilityRestriction.h
+++ b/include/swift/AST/AvailabilityRestriction.h
@@ -231,22 +231,11 @@ enum class AvailabilityRestrictionFlag : uint8_t {
 };
 using AvailabilityRestrictionFlags = OptionSet<AvailabilityRestrictionFlag>;
 
-/// Returns the set of availability restrictions that restricts use of \p decl
-/// when it is referenced from the given context. In other words, it is the
-/// collection of `@available` attributes with unsatisfied conditions.
-DeclAvailabilityRestrictions getAvailabilityRestrictionsForDecl(
-    const Decl *decl, const AvailabilityContext &context,
-    AvailabilityRestrictionFlags flags = std::nullopt);
-
-/// Returns the availability restriction that restricts use of \p decl
-/// in \p domain when it is referenced from the given context. In other words,
-/// it is the unsatisfied `@available` attribute  that applies to \p domain in
-/// the given context.
-std::optional<AvailabilityRestriction>
-getAvailabilityRestrictionForDeclInDomain(
-    const Decl *decl, const AvailabilityContext &context,
-    AvailabilityDomain domain,
-    AvailabilityRestrictionFlags flags = std::nullopt);
+/// Returns the `AvailabilityRestriction` that describes how \p attr restricts
+/// use of \p decl in \p context or `std::nullopt` if there is no restriction.
+std::optional<AvailabilityRestriction> getAvailabilityRestrictionForAttr(
+    const SemanticAvailableAttr &attr, const Decl *decl,
+    const AvailabilityContext &context, AvailabilityRestrictionFlags flags);
 
 /// Computes the set of restrictions that indicate whether a decl is "runtime
 /// unavailable" (can never be reached at runtime) and adds the domain for each

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -20,7 +20,6 @@
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/Attr.h"
 #include "swift/AST/AvailabilityContext.h"
-#include "swift/AST/AvailabilityRestriction.h"
 #include "swift/AST/Builtins.h"
 #include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/Comment.h"
@@ -209,8 +208,8 @@ static bool shouldSkipDeclInPublicInterface(const Decl *D) {
   if (!SF)
     return false;
 
-  auto restrictions = getAvailabilityRestrictionsForDecl(
-      D, AvailabilityContext::forDeploymentTarget(ctx));
+  auto restrictions =
+      AvailabilityContext::forDeploymentTarget(ctx).allRestrictionsForDecl(D);
   llvm::SmallVector<AvailabilityDomain, 4> unavailableDomains;
   getRuntimeUnavailableDomains(restrictions, unavailableDomains, ctx);
 

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -20,7 +20,6 @@
 #include "swift/AST/AvailabilityDomain.h"
 #include "swift/AST/AvailabilityInference.h"
 #include "swift/AST/AvailabilityRange.h"
-#include "swift/AST/AvailabilityRestriction.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DeclExportabilityVisitor.h"
 // FIXME: [availability] Remove this when possible
@@ -423,8 +422,7 @@ bool Decl::isUnavailableInCurrentSwiftVersion() const {
 
 std::optional<SemanticAvailableAttr> Decl::getUnavailableAttr() const {
   auto context = AvailabilityContext::forDeploymentTarget(getASTContext());
-  if (auto restriction = getAvailabilityRestrictionsForDecl(this, context)
-                             .getPrimaryRestriction()) {
+  if (auto restriction = context.restrictionForDecl(this)) {
     if (restriction->isUnavailable())
       return restriction->getAttr();
   }
@@ -489,8 +487,9 @@ computeDeclRuntimeAvailability(const Decl *decl) {
   // restrictions from active platforms.
   flags |= AvailabilityRestrictionFlag::IncludeAllDomains;
 
-  auto restrictions = getAvailabilityRestrictionsForDecl(
-      decl, AvailabilityContext::forInliningTarget(ctx), flags);
+  auto restrictions =
+      AvailabilityContext::forInliningTarget(ctx).allRestrictionsForDecl(decl,
+                                                                         flags);
 
   // First, collect the unavailable domains from the restrictions.
   llvm::SmallVector<AvailabilityDomain, 8> unavailableDomains;

--- a/lib/AST/AvailabilityContext.cpp
+++ b/lib/AST/AvailabilityContext.cpp
@@ -373,8 +373,7 @@ void AvailabilityContext::constrainWithDeclAndPlatformRange(
   llvm::SmallVector<DomainInfo, 4> declDomainInfos;
   AvailabilityRestrictionFlags flags =
       AvailabilityRestrictionFlag::SkipEnclosingExtension;
-  auto restrictions =
-      swift::getAvailabilityRestrictionsForDecl(decl, *this, flags);
+  auto restrictions = allRestrictionsForDecl(decl, flags);
   for (auto restriction : restrictions) {
     auto attr = restriction.getAttr();
     auto domain = attr.getDomain();
@@ -429,6 +428,161 @@ bool AvailabilityContext::isContainedIn(const AvailabilityContext other) const {
     return false;
 
   return true;
+}
+
+std::optional<AvailabilityRestriction>
+AvailabilityContext::restrictionForDecl(const Decl *decl,
+                                        AvailabilityRestrictionFlags flags) {
+  return allRestrictionsForDecl(decl, flags).getPrimaryRestriction();
+}
+
+std::optional<AvailabilityRestriction>
+AvailabilityContext::restrictionForDeclInDomain(
+    const Decl *decl, AvailabilityDomain domain,
+    AvailabilityRestrictionFlags flags) {
+  auto restrictions = allRestrictionsForDecl(decl, flags);
+  for (auto const &restriction : restrictions) {
+    if (restriction.getDomain().isRelated(domain))
+      return restriction;
+  }
+
+  return std::nullopt;
+}
+
+static bool restrictionIsStronger(const AvailabilityRestriction &lhs,
+                                  const AvailabilityRestriction &rhs) {
+  DEBUG_ASSERT(lhs.getDomain() == rhs.getDomain());
+
+  // If the restrictions have matching domains but different reasons, the
+  // restriction with the lowest reason is "strongest".
+  if (lhs.getReason() != rhs.getReason())
+    return lhs.getReason() < rhs.getReason();
+
+  switch (lhs.getReason()) {
+  case AvailabilityRestriction::Reason::UnavailableUnconditionally:
+    // Just keep the first.
+    return false;
+
+  case AvailabilityRestriction::Reason::UnavailableObsolete:
+    // Pick the larger obsoleted range.
+    return lhs.getAttr().getObsoleted().value() <
+           rhs.getAttr().getObsoleted().value();
+
+  case AvailabilityRestriction::Reason::UnavailableUnintroduced:
+  case AvailabilityRestriction::Reason::Unintroduced:
+    // Pick the smaller introduced range.
+    return lhs.getAttr().getIntroduced().value_or(llvm::VersionTuple()) >
+           rhs.getAttr().getIntroduced().value_or(llvm::VersionTuple());
+  }
+}
+
+static void
+addRestriction(llvm::SmallVector<AvailabilityRestriction, 4> &restrictions,
+               const AvailabilityRestriction &restriction) {
+  auto iter = llvm::find_if(
+      restrictions, [&restriction](AvailabilityRestriction &existing) {
+        return restriction.getDomain() == existing.getDomain();
+      });
+
+  // There's no existing restriction for the same domain so just add it.
+  if (iter == restrictions.end()) {
+    restrictions.emplace_back(restriction);
+    return;
+  }
+
+  if (restrictionIsStronger(restriction, *iter)) {
+    restrictions.erase(iter);
+    restrictions.emplace_back(restriction);
+  }
+}
+
+/// Returns the most specific platform domain from the availability attributes
+/// attached to \p decl or `std::nullopt` if there are none. Platform specific
+/// `@available` attributes for other platforms should be ignored. For example,
+/// if a declaration has attributes for both iOS and macCatalyst, only the
+/// macCatalyst attributes take effect when compiling for a macCatalyst target.
+static std::optional<AvailabilityDomain>
+activePlatformDomainForDecl(const Decl *decl) {
+  std::optional<AvailabilityDomain> activeDomain;
+  for (auto attr :
+       decl->getSemanticAvailableAttrs(/*includingInactive=*/false)) {
+    auto domain = attr.getDomain();
+    if (!domain.isPlatform())
+      continue;
+
+    if (activeDomain && domain.contains(*activeDomain))
+      continue;
+
+    activeDomain.emplace(domain);
+  }
+
+  return activeDomain;
+}
+
+/// Generates availability restrictions that apply to the use of \p targetDecl
+/// based on the attributes attached to \p sourceDecl (these declarations may be
+/// different since \p targetDecl may inherit attributes from another
+/// declaration lexically).
+static void collectRestrictionsForDecl(
+    llvm::SmallVector<AvailabilityRestriction, 4> &restrictions,
+    const Decl *targetDecl, const Decl *sourceDecl,
+    const AvailabilityContext &context, AvailabilityRestrictionFlags flags) {
+  auto activePlatformDomain = activePlatformDomainForDecl(sourceDecl);
+  bool includeAllDomains =
+      flags.contains(AvailabilityRestrictionFlag::IncludeAllDomains);
+
+  for (auto attr : sourceDecl->getSemanticAvailableAttrs(includeAllDomains)) {
+    auto domain = attr.getDomain();
+    if (!includeAllDomains && domain.isPlatform() && activePlatformDomain &&
+        !activePlatformDomain->contains(domain))
+      continue;
+
+    if (auto restriction =
+            getAvailabilityRestrictionForAttr(attr, targetDecl, context, flags))
+      addRestriction(restrictions, *restriction);
+  }
+}
+
+DeclAvailabilityRestrictions AvailabilityContext::allRestrictionsForDecl(
+    const Decl *decl, AvailabilityRestrictionFlags flags) {
+  llvm::SmallVector<AvailabilityRestriction, 4> restrictions;
+
+  // Generic parameters are always available.
+  if (isa<GenericTypeParamDecl>(decl))
+    return DeclAvailabilityRestrictions();
+
+  decl = decl->getAbstractSyntaxDeclForAttributes();
+
+  collectRestrictionsForDecl(restrictions, decl, decl, *this, flags);
+
+  // For requirements of reparentable protocols, add restrictions from the
+  // enclosing protocol itself. We don't need to do this for ordinary protocols
+  // because of the rule that a protocol P cannot inherit from Q if Q is less
+  // available than P. Thus, the availability of the most derived protocol
+  // already carries the same or stricter restrictions than its ancestors.
+  if (auto *proto = decl->getDeclContext()->getSelfProtocolDecl()) {
+    if (proto->getAttrs().hasAttribute<ReparentableAttr>())
+      collectRestrictionsForDecl(restrictions, decl, proto, *this, flags);
+  }
+
+  if (flags.contains(AvailabilityRestrictionFlag::SkipEnclosingExtension))
+    return restrictions;
+
+  // If decl is an extension member, query the attributes of the extension, too.
+  //
+  // Skip decls imported from Clang, though, as they could be associated to the
+  // wrong extension and inherit unavailability incorrectly. ClangImporter
+  // associates Objective-C protocol members to the first category where the
+  // protocol is directly or indirectly adopted, no matter its availability
+  // and the availability of other categories. rdar://problem/53956555
+  if (decl->getClangNode())
+    return restrictions;
+
+  auto parent = decl->parentDeclForAvailability();
+  if (auto extension = dyn_cast_or_null<ExtensionDecl>(parent))
+    collectRestrictionsForDecl(restrictions, decl, extension, *this, flags);
+
+  return restrictions;
 }
 
 static std::string

--- a/lib/AST/AvailabilityRestriction.cpp
+++ b/lib/AST/AvailabilityRestriction.cpp
@@ -84,54 +84,6 @@ void AvailabilityRestriction::print(llvm::raw_ostream &os) const {
   os << ")";
 }
 
-static bool restrictionIsStronger(const AvailabilityRestriction &lhs,
-                                  const AvailabilityRestriction &rhs) {
-  DEBUG_ASSERT(lhs.getDomain() == rhs.getDomain());
-
-  // If the restrictions have matching domains but different reasons, the
-  // restriction with the lowest reason is "strongest".
-  if (lhs.getReason() != rhs.getReason())
-    return lhs.getReason() < rhs.getReason();
-
-  switch (lhs.getReason()) {
-  case AvailabilityRestriction::Reason::UnavailableUnconditionally:
-    // Just keep the first.
-    return false;
-
-  case AvailabilityRestriction::Reason::UnavailableObsolete:
-    // Pick the larger obsoleted range.
-    return lhs.getAttr().getObsoleted().value() <
-           rhs.getAttr().getObsoleted().value();
-
-  case AvailabilityRestriction::Reason::UnavailableUnintroduced:
-  case AvailabilityRestriction::Reason::Unintroduced:
-    // Pick the smaller introduced range.
-    return lhs.getAttr().getIntroduced().value_or(llvm::VersionTuple()) >
-           rhs.getAttr().getIntroduced().value_or(llvm::VersionTuple());
-  }
-}
-
-void addRestriction(llvm::SmallVector<AvailabilityRestriction, 4> &restrictions,
-                    const AvailabilityRestriction &restriction,
-                    const ASTContext &ctx) {
-
-  auto iter = llvm::find_if(
-      restrictions, [&restriction](AvailabilityRestriction &existing) {
-        return restriction.getDomain() == existing.getDomain();
-      });
-
-  // There's no existing restriction for the same domain so just add it.
-  if (iter == restrictions.end()) {
-    restrictions.emplace_back(restriction);
-    return;
-  }
-
-  if (restrictionIsStronger(restriction, *iter)) {
-    restrictions.erase(iter);
-    restrictions.emplace_back(restriction);
-  }
-}
-
 std::optional<AvailabilityRestriction>
 DeclAvailabilityRestrictions::getPrimaryRestriction() const {
   std::optional<AvailabilityRestriction> result;
@@ -228,13 +180,9 @@ shouldIgnoreRestrictionInContext(const Decl *decl,
   return context.isUnavailableForDomain(domain);
 }
 
-/// Returns the `AvailabilityRestriction` that describes how \p attr restricts
-/// use of \p decl in \p context or `std::nullopt` if there is no restriction.
-static std::optional<AvailabilityRestriction>
-getAvailabilityRestrictionForAttr(const Decl *decl,
-                                  const SemanticAvailableAttr &attr,
-                                  const AvailabilityContext &context,
-                                  const AvailabilityRestrictionFlags flags) {
+std::optional<AvailabilityRestriction> swift::getAvailabilityRestrictionForAttr(
+    const SemanticAvailableAttr &attr, const Decl *decl,
+    const AvailabilityContext &context, AvailabilityRestrictionFlags flags) {
   auto getRestriction = [&]() -> std::optional<AvailabilityRestriction> {
     // Is the decl unconditionally unavailable?
     if (attr.isUnconditionallyUnavailable())
@@ -277,113 +225,6 @@ getAvailabilityRestrictionForAttr(const Decl *decl,
     return std::nullopt;
 
   return restriction;
-}
-
-/// Returns the most specific platform domain from the availability attributes
-/// attached to \p decl or `std::nullopt` if there are none. Platform specific
-/// `@available` attributes for other platforms should be ignored. For example,
-/// if a declaration has attributes for both iOS and macCatalyst, only the
-/// macCatalyst attributes take effect when compiling for a macCatalyst target.
-static std::optional<AvailabilityDomain>
-activePlatformDomainForDecl(const Decl *decl) {
-  std::optional<AvailabilityDomain> activeDomain;
-  for (auto attr :
-       decl->getSemanticAvailableAttrs(/*includingInactive=*/false)) {
-    auto domain = attr.getDomain();
-    if (!domain.isPlatform())
-      continue;
-
-    if (activeDomain && domain.contains(*activeDomain))
-      continue;
-
-    activeDomain.emplace(domain);
-  }
-
-  return activeDomain;
-}
-
-/// Generates availability restrictions that apply to the use of \p origDecl
-/// based on the attributes attached to \p sourceDecl (these declarations may be
-/// different since \p origDecl may inherit attributes from another declaration
-/// lexically).
-static void getAvailabilityRestrictionsForDecl(
-    llvm::SmallVector<AvailabilityRestriction, 4> &restrictions,
-    const Decl *targetDecl, const Decl *sourceDecl,
-    const AvailabilityContext &context, AvailabilityRestrictionFlags flags) {
-  auto &ctx = sourceDecl->getASTContext();
-  auto activePlatformDomain = activePlatformDomainForDecl(sourceDecl);
-  bool includeAllDomains =
-      flags.contains(AvailabilityRestrictionFlag::IncludeAllDomains);
-
-  for (auto attr : sourceDecl->getSemanticAvailableAttrs(includeAllDomains)) {
-    auto domain = attr.getDomain();
-    if (!includeAllDomains && domain.isPlatform() && activePlatformDomain &&
-        !activePlatformDomain->contains(domain))
-      continue;
-
-    if (auto restriction =
-            getAvailabilityRestrictionForAttr(targetDecl, attr, context, flags))
-      addRestriction(restrictions, *restriction, ctx);
-  }
-}
-
-DeclAvailabilityRestrictions
-swift::getAvailabilityRestrictionsForDecl(const Decl *decl,
-                                          const AvailabilityContext &context,
-                                          AvailabilityRestrictionFlags flags) {
-  llvm::SmallVector<AvailabilityRestriction, 4> restrictions;
-
-  // Generic parameters are always available.
-  if (isa<GenericTypeParamDecl>(decl))
-    return DeclAvailabilityRestrictions();
-
-  decl = decl->getAbstractSyntaxDeclForAttributes();
-
-  getAvailabilityRestrictionsForDecl(restrictions, decl, decl, context, flags);
-
-  // For requirements of reparentable protocols, add restrictions from the
-  // enclosing protocol itself. We don't need to do this for ordinary protocols
-  // because of the rule that a protocol P cannot inherit from Q if Q is less
-  // available than P. Thus, the availability of the most derived protocol
-  // already carries the same or stricter restrictions than its ancestors.
-  if (auto *proto = decl->getDeclContext()->getSelfProtocolDecl()) {
-    if (proto->getAttrs().hasAttribute<ReparentableAttr>())
-      getAvailabilityRestrictionsForDecl(restrictions, decl, proto, context,
-                                         flags);
-  }
-
-  if (flags.contains(AvailabilityRestrictionFlag::SkipEnclosingExtension))
-    return restrictions;
-
-  // If decl is an extension member, query the attributes of the extension, too.
-  //
-  // Skip decls imported from Clang, though, as they could be associated to the
-  // wrong extension and inherit unavailability incorrectly. ClangImporter
-  // associates Objective-C protocol members to the first category where the
-  // protocol is directly or indirectly adopted, no matter its availability
-  // and the availability of other categories. rdar://problem/53956555
-  if (decl->getClangNode())
-    return restrictions;
-
-  auto parent = decl->parentDeclForAvailability();
-  if (auto extension = dyn_cast_or_null<ExtensionDecl>(parent))
-    getAvailabilityRestrictionsForDecl(restrictions, decl, extension, context,
-                                       flags);
-
-  return restrictions;
-}
-
-std::optional<AvailabilityRestriction>
-swift::getAvailabilityRestrictionForDeclInDomain(
-    const Decl *decl, const AvailabilityContext &context,
-    AvailabilityDomain domain, AvailabilityRestrictionFlags flags) {
-  auto restrictions = getAvailabilityRestrictionsForDecl(decl, context, flags);
-  for (auto const &restriction : restrictions) {
-    if (restriction.getDomain().isRelated(domain))
-      return restriction;
-  }
-
-  return std::nullopt;
 }
 
 /// Returns true if unsatisfied `@available(..., unavailable)` restrictions for

--- a/lib/AST/AvailabilityScope.cpp
+++ b/lib/AST/AvailabilityScope.cpp
@@ -17,7 +17,6 @@
 #include "swift/AST/AvailabilityScope.h"
 
 #include "swift/AST/ASTContext.h"
-#include "swift/AST/AvailabilityRestriction.h"
 #include "swift/AST/AvailabilitySpec.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/MacroDeclaration.h"
@@ -445,8 +444,8 @@ AvailabilityScope::getExplicitAvailabilityRange(AvailabilityDomain domain,
 
   case Reason::Decl: {
     auto decl = Node.getAsDecl();
-    if (auto restriction = swift::getAvailabilityRestrictionForDeclInDomain(
-            decl, AvailabilityContext::forAlwaysAvailable(ctx), domain))
+    if (auto restriction = AvailabilityContext::forAlwaysAvailable(ctx)
+                               .restrictionForDeclInDomain(decl, domain))
       return restriction->getAttr().getIntroducedRange(ctx);
 
     return std::nullopt;

--- a/lib/AST/AvailabilityScopeBuilder.cpp
+++ b/lib/AST/AvailabilityScopeBuilder.cpp
@@ -19,7 +19,6 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/AvailabilityInference.h"
-#include "swift/AST/AvailabilityRestriction.h"
 #include "swift/AST/AvailabilitySpec.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DeclExportabilityVisitor.h"
@@ -471,8 +470,7 @@ private:
       return true;
 
     // Check whether the decl is unavailable relative to the current context.
-    if (auto restriction = getAvailabilityRestrictionsForDecl(decl, context)
-                               .getPrimaryRestriction()) {
+    if (auto restriction = context.restrictionForDecl(decl)) {
       if (restriction->isUnavailable())
         return true;
     }

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -15,7 +15,6 @@
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/AccessScope.h"
 #include "swift/AST/AvailabilityContext.h"
-#include "swift/AST/AvailabilityRestriction.h"
 #include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/DeclExportabilityVisitor.h"
 #include "swift/AST/DiagnosticsSema.h"
@@ -1833,6 +1832,5 @@ bool DeclContext::isAlwaysAvailableConformanceContext() const {
   // target.
   auto &ctx = getASTContext();
   auto deploymentTarget = AvailabilityContext::forDeploymentTarget(ctx);
-  auto restrictions = getAvailabilityRestrictionsForDecl(ext, deploymentTarget);
-  return !restrictions.getPrimaryRestriction();
+  return !deploymentTarget.restrictionForDecl(ext);
 }

--- a/lib/AST/ProtocolConformanceRef.cpp
+++ b/lib/AST/ProtocolConformanceRef.cpp
@@ -19,7 +19,6 @@
 #include "AbstractConformance.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/AvailabilityContext.h"
-#include "swift/AST/AvailabilityRestriction.h"
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/GenericEnvironment.h"
@@ -417,15 +416,12 @@ ProtocolConformanceRef::getAvailabilityRestriction(DeclContext *dc,
   // involve due to source compatibility exceptions. Thus, it is important to
   // verify that neither pose a restriction in the given context when checking
   // for availability of a conformance.
-  if (auto restriction =
-          getAvailabilityRestrictionsForDecl(getProtocol(), availability)
-              .getPrimaryRestriction())
+  if (auto restriction = availability.restrictionForDecl(getProtocol()))
     return restriction;
 
   auto *conformanceDC = getConcrete()->getRootConformance()->getDeclContext();
-  if (auto restriction = getAvailabilityRestrictionsForDecl(
-                             conformanceDC->getAsDecl(), availability)
-                             .getPrimaryRestriction())
+  if (auto restriction =
+          availability.restrictionForDecl(conformanceDC->getAsDecl()))
     return restriction;
 
   return std::nullopt;

--- a/lib/Sema/DerivedConformance/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceRawRepresentable.cpp
@@ -20,7 +20,6 @@
 #include "TypeCheckAvailability.h"
 #include "TypeCheckDecl.h"
 #include "TypeChecker.h"
-#include "swift/AST/AvailabilityRestriction.h"
 #include "swift/AST/AvailabilitySpec.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Expr.h"
@@ -244,9 +243,7 @@ checkAvailability(const EnumElementDecl *elt,
                   AvailabilityContext availabilityContext,
                   std::optional<RuntimeVersionCheck> &versionCheck) {
   auto &C = elt->getASTContext();
-  auto restriction =
-      getAvailabilityRestrictionsForDecl(elt, availabilityContext)
-          .getPrimaryRestriction();
+  auto restriction = availabilityContext.restrictionForDecl(elt);
 
   // Is it always available?
   if (!restriction)

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2242,8 +2242,8 @@ getSemanticAvailableRangeDeclAndAttr(const Decl *decl,
   auto &ctx = decl->getASTContext();
   AvailabilityRestrictionFlags flags =
       AvailabilityRestrictionFlag::SkipEnclosingExtension;
-  if (auto restriction = swift::getAvailabilityRestrictionForDeclInDomain(
-          decl, AvailabilityContext::forAlwaysAvailable(ctx), domain, flags)) {
+  if (auto restriction = AvailabilityContext::forAlwaysAvailable(ctx)
+                             .restrictionForDeclInDomain(decl, domain, flags)) {
     switch (restriction->getReason()) {
     case AvailabilityRestriction::Reason::UnavailableUnconditionally:
     case AvailabilityRestriction::Reason::UnavailableObsolete:
@@ -5647,9 +5647,7 @@ void AttributeChecker::checkAvailableAttrs(ArrayRef<AvailableAttr *> attrs) {
     availabilityContext.constrainWithContext(parentAvailability, Ctx);
   }
 
-  auto availabilityRestriction =
-      getAvailabilityRestrictionsForDecl(D, availabilityContext)
-          .getPrimaryRestriction();
+  auto availabilityRestriction = availabilityContext.restrictionForDecl(D);
   if (!availabilityRestriction)
     return;
 

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -26,7 +26,6 @@
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/AbstractLayout.h"
 #include "swift/AST/AvailabilityDomain.h"
-#include "swift/AST/AvailabilityRestriction.h"
 #include "swift/AST/AvailabilityScope.h"
 #include "swift/AST/AvailabilitySpec.h"
 #include "swift/AST/ClangModuleLoader.h"
@@ -1802,9 +1801,7 @@ void swift::diagnoseOverrideOfUnavailableDecl(ValueDecl *override,
   // FIXME: [availability] Take an unsatisfied restriction as input instead of
   // recomputing it.
   ExportContext where = ExportContext::forDeclSignature(override);
-  auto restriction =
-      getAvailabilityRestrictionsForDecl(base, where.getAvailability())
-          .getPrimaryRestriction();
+  auto restriction = where.getAvailability().restrictionForDecl(base);
   if (!restriction)
     return;
 
@@ -1949,10 +1946,8 @@ swift::getUnsatisfiedAvailabilityRestriction(const Decl *decl,
     flags |= AvailabilityRestrictionFlag::
         AllowUniversallyUnavailableInCompatibleContexts;
 
-  return getAvailabilityRestrictionsForDecl(
-             decl, AvailabilityContext::forLocation(referenceLoc, referenceDC),
-             flags)
-      .getPrimaryRestriction();
+  return AvailabilityContext::forLocation(referenceLoc, referenceDC)
+      .restrictionForDecl(decl, flags);
 }
 
 /// Check if this is a subscript declaration inside String or
@@ -3152,9 +3147,7 @@ bool swift::diagnoseDeclAvailability(const ValueDecl *D, SourceRange R,
   auto *DC = Where.getDeclContext();
   auto &ctx = DC->getASTContext();
 
-  auto restriction =
-      getAvailabilityRestrictionsForDecl(D, Where.getAvailability())
-          .getPrimaryRestriction();
+  auto restriction = Where.getAvailability().restrictionForDecl(D);
 
   if (restriction) {
     if (diagnoseExplicitUnavailability(D, R, *restriction, Where, call, Flags))
@@ -3575,9 +3568,7 @@ swift::diagnoseConformanceAvailability(SourceLoc loc,
       return true;
     }
 
-    auto restriction =
-        getAvailabilityRestrictionsForDecl(ext, where.getAvailability())
-            .getPrimaryRestriction();
+    auto restriction = where.getAvailability().restrictionForDecl(ext);
     if (restriction) {
       if (diagnoseExplicitUnavailability(
               loc, *restriction, rootConf, ext, where,

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -23,7 +23,6 @@
 #include "TypeChecker.h"
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/AvailabilityRange.h"
-#include "swift/AST/AvailabilityRestriction.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/GenericSignature.h"
@@ -252,8 +251,7 @@ static bool isUnavailableInAllVersions(ValueDecl *decl) {
   ASTContext &ctx = decl->getASTContext();
 
   auto deploymentContext = AvailabilityContext::forDeploymentTarget(ctx);
-  auto restrictions =
-      getAvailabilityRestrictionsForDecl(decl, deploymentContext);
+  auto restrictions = deploymentContext.allRestrictionsForDecl(decl);
   for (auto restriction : restrictions) {
     switch (restriction.getReason()) {
     case AvailabilityRestriction::Reason::UnavailableUnconditionally:
@@ -1862,9 +1860,7 @@ getOverrideAvailability(ValueDecl *override, ValueDecl *base) {
   flags |= AvailabilityRestrictionFlag::
       AllowUniversallyUnavailableInCompatibleContexts;
 
-  if (auto restriction =
-          getAvailabilityRestrictionsForDecl(override, baseAvailability, flags)
-              .getPrimaryRestriction()) {
+  if (auto restriction = baseAvailability.restrictionForDecl(override, flags)) {
     if (restriction->isUnavailable())
       return {OverrideAvailability::OverrideUnavailable, restriction};
 
@@ -1874,8 +1870,7 @@ getOverrideAvailability(ValueDecl *override, ValueDecl *base) {
   // Check whether the base is unavailable from the perspective of the override.
   auto overrideAvailability = AvailabilityContext::forDeclSignature(override);
   if (auto baseRestriction =
-          getAvailabilityRestrictionsForDecl(base, overrideAvailability, flags)
-              .getPrimaryRestriction()) {
+          overrideAvailability.restrictionForDecl(base, flags)) {
     if (baseRestriction->isUnavailable())
       return {OverrideAvailability::BaseUnavailable, baseRestriction};
   }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2042,8 +2042,7 @@ checkWitnessAvailability(const ValueDecl *requirement, const ValueDecl *witness,
   flags |= AvailabilityRestrictionFlag::
       AllowUniversallyUnavailableInCompatibleContexts;
 
-  return getAvailabilityRestrictionsForDecl(witness, requiredContext, flags)
-      .getPrimaryRestriction();
+  return requiredContext.restrictionForDecl(witness, flags);
 }
 
 RequirementCheck WitnessChecker::checkWitness(ValueDecl *requirement,


### PR DESCRIPTION
Expose availability restriction queries as methods on `AvailabilityContext` instead of as free functions that take a context as an input, making query callsites less verbose throughout the compiler.

NFC.
