### PR TITLE
[cxx-interop] Re-enable `bridge-objc-types-back-to-objcxx-execution.mm`

### DIFF
--- a/test/Interop/ObjCToSwiftToObjCxx/bridge-objc-types-back-to-objcxx-execution.mm
+++ b/test/Interop/ObjCToSwiftToObjCxx/bridge-objc-types-back-to-objcxx-execution.mm
@@ -13,8 +13,6 @@
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 
-// REQUIRES: rdar107657204
-
 //--- header.h
 
 #import <Foundation/Foundation.h>


### PR DESCRIPTION
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
