### PR TITLE
[Concurrency] Fix escalation while enqueued test

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -239,7 +239,7 @@ static inline void taskInvokeWithExclusionValue(
     concurrency::trace::job_run_end(traceHandle);
 
 #if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
-    swift_dispatch_thread_reset_override_self(dispatchOpaquePriority);
+    swift_dispatch_thread_reset_override_self({dispatchOpaquePriority});
 #endif
 
     assert(ActiveTask::get() == nullptr &&

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -792,8 +792,8 @@ public:
   // StealerExclusion
   AsyncTask::ExclusionValue getStealerExclusionValue() const {
 #if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
-    return AsyncTask::ExclusionValue{(Flags & StealerExclusionMask) >>
-                                     StealerExclusionShift};
+    return AsyncTask::ExclusionValue{static_cast<uint8_t>(
+        (Flags & StealerExclusionMask) >> StealerExclusionShift)};
 #else
     return {0};
 #endif
@@ -1217,7 +1217,7 @@ struct ThreadPriorityManager {
     // so we might need to undo setting the base priority
     if (opaquePriority.isSet()) {
       swift_dispatch_thread_reset_override_self(opaquePriority);
-      opaquePriority = 0;
+      opaquePriority = {0};
     }
   }
 };
@@ -1263,7 +1263,7 @@ inline uint32_t AsyncTask::taskFlagAsRunningWithoutDependency(
     }
   }
 #if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
-  return threadPriorityManager.opaquePriority;
+  return threadPriorityManager.opaquePriority.priority;
 #else
   return 0;
 #endif
@@ -1314,7 +1314,7 @@ inline void AsyncTask::resumeRunningAfterFailedSuspend(
       [&](ActiveTaskStatus oldStatus, ActiveTaskStatus &newStatus) {
 #if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
         threadPriorityManager.overrideIfNeeded(oldStatus.getStoredPriority());
-        assert(threadPriorityManager.opaquePriority == 0);
+        assert(!threadPriorityManager.opaquePriority.isSet());
 #endif
         // Set self as executor and remove escalation bit if any - the task's
         // priority escalation has already been reflected on the thread.
@@ -1432,7 +1432,7 @@ AsyncTask::tryStartRunning(AsyncTask::ExclusionValue allowedExclusionValue,
   }
   SWIFT_TASK_DEBUG_LOG("tryStartRunning succeeds for %p", this);
 #if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
-  return {true, threadPriorityManager.opaquePriority};
+  return {true, threadPriorityManager.opaquePriority.priority};
 #else
   return {true, 0};
 #endif

--- a/test/Concurrency/async_task_priority.swift
+++ b/test/Concurrency/async_task_priority.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift %s -parse-as-library -o %t/async_task_priority
+// RUN: %target-build-swift %s -import-objc-header %S/Inputs/has-dispatch-private.h -parse-as-library -o %t/async_task_priority
 // RUN: %target-codesign %t/async_task_priority
 // RUN: %target-run %t/async_task_priority
 
@@ -341,7 +341,9 @@ actor Test {
         }
 
         // This test will only work properly if Dispatch supports lowering the base priority of a thread rdar://88155873
-        if #available(macOS 9998, iOS 9998, tvOS 9998, watchOS 9998, *) {
+        // If we don't have swift_concurrency_private.h then the runtime doesn't have
+        // full priority escalation, so don't try to test it.
+        if #available(macOS 9998, iOS 9998, tvOS 9998, watchOS 9998, *), HasSwiftConcurrencyPrivateHeader() != 0 {
           tests.test("Task escalation doesn't impact qos_class_self") {
             let task = Task(priority: .utility) {
               let initialQos = DispatchQoS(
@@ -379,7 +381,9 @@ actor Test {
         }
 
         // Requires escalatePriority
-        if #available(SwiftStdlib 6.2, *) {
+        // If we don't have swift_concurrency_private.h then the runtime doesn't have
+        // full priority escalation, so don't try to test it.
+        if #available(SwiftStdlib 6.2, *), HasSwiftConcurrencyPrivateHeader() != 0 {
           // Test that Task stealers are able to escalate a Task which is enqueued but not yet running rdar://160967177
           tests.test("Tasks can be escalated even if they are enqueued but not yet running") {
             // If there are ncpu tasks of a given priority,


### PR DESCRIPTION
Some of the tests in test/Concurrency/async_task_priority.swift don't work without priority escalation being enabled. This causes them to fail when being built for certain targets. This PR adds the guard from test/Concurrency/priority_escalation_thread_qos.swift

rdar://182034655