### PR TITLE
[CSFix] Switch `AllowInlineArrayLiteralCountMismatch` to use numbers …

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -9032,7 +9032,8 @@ ERROR(integer_generic_expr_closure_not_supported,none,
 //===----------------------------------------------------------------------===//
 
 ERROR(inlinearray_literal_incorrect_count,none,
-      "expected %0 elements in inline array literal, but got %1", (Type, Type))
+      "expected %0 elements in inline array literal, but got %1",
+      (unsigned, unsigned))
 
 ERROR(inline_array_type_backwards,none,
       "element count must precede inline array element type", ())

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -3966,11 +3966,13 @@ public:
 };
 
 class AllowInlineArrayLiteralCountMismatch final : public ConstraintFix {
-  Type lhsCount, rhsCount;
+  unsigned lhsCount, rhsCount;
 
-  AllowInlineArrayLiteralCountMismatch(ConstraintSystem &cs, Type lhsCount,
-                                Type rhsCount, ConstraintLocator *locator)
-      : ConstraintFix(cs, FixKind::AllowInlineArrayLiteralCountMismatch, locator),
+  AllowInlineArrayLiteralCountMismatch(ConstraintSystem &cs, unsigned lhsCount,
+                                       unsigned rhsCount,
+                                       ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::AllowInlineArrayLiteralCountMismatch,
+                      locator),
         lhsCount(lhsCount), rhsCount(rhsCount) {}
 
 public:
@@ -3981,7 +3983,7 @@ public:
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static AllowInlineArrayLiteralCountMismatch *
-  create(ConstraintSystem &cs, Type lhsCount, Type rhsCount,
+  create(ConstraintSystem &cs, unsigned lhsCount, unsigned rhsCount,
          ConstraintLocator *locator);
 
   static bool classof(const ConstraintFix *fix) {

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -3380,13 +3380,14 @@ public:
 /// let x: InlineArray<4, Int> = [1, 2] // expected '4' elements but got '2'
 /// \endcode
 class IncorrectInlineArrayLiteralCount final : public FailureDiagnostic {
-  Type lhsCount, rhsCount;
+  unsigned lhsCount, rhsCount;
 
 public:
-  IncorrectInlineArrayLiteralCount(const Solution &solution, Type lhsCount,
-                            Type rhsCount, ConstraintLocator *locator)
-      : FailureDiagnostic(solution, locator), lhsCount(resolveType(lhsCount)),
-        rhsCount(resolveType(rhsCount)) {}
+  IncorrectInlineArrayLiteralCount(const Solution &solution, unsigned lhsCount,
+                                   unsigned rhsCount,
+                                   ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator), lhsCount(lhsCount),
+        rhsCount(rhsCount) {}
 
   bool diagnoseAsError() override;
 };

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2861,8 +2861,9 @@ IgnoreKeyPathSubscriptIndexMismatch::create(ConstraintSystem &cs, Type argType,
 }
 
 AllowInlineArrayLiteralCountMismatch *
-AllowInlineArrayLiteralCountMismatch::create(ConstraintSystem &cs, Type lhsCount,
-                                             Type rhsCount,
+AllowInlineArrayLiteralCountMismatch::create(ConstraintSystem &cs,
+                                             unsigned lhsCount,
+                                             unsigned rhsCount,
                                              ConstraintLocator *locator) {
   return new (cs.getAllocator())
       AllowInlineArrayLiteralCountMismatch(cs, lhsCount, rhsCount, locator);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6696,9 +6696,7 @@ bool ConstraintSystem::repairFailures(
           if (inlineCount->getValue() != literalCount) {
             conversionsOrFixes.push_back(
                 AllowInlineArrayLiteralCountMismatch::create(
-                    *this, inlineCount,
-                    IntegerType::get(std::to_string(literalCount),
-                                     /*isNegative=*/false, getASTContext()),
+                    *this, inlineCount->getValue().getSExtValue(), literalCount,
                     loc));
             return true;
           }
@@ -9249,22 +9247,27 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
       // Attempt to bind the number of elements in the literal with the
       // contextual count. This will diagnose if the literal does not enough
       // or too many elements.
-      auto contextualCount = iaTy->getGenericArgs()[0];
-      auto literalCount = IntegerType::get(
-          std::to_string(arrayLiteral->getNumElements()),
-          /* isNegative */ false,
-          iaTy->getASTContext());
-
-      // If the counts are already equal, '2' == '2', then we're done.
-      if (contextualCount->isEqual(literalCount)) {
+      auto inlineArrayCountParam = iaTy->getGenericArgs()[0];
+      // If our contextual count is not known, e.g., InlineArray<_, Int> = [1, 2],
+      //then just eagerly bind the count to what the literal count is.
+      if (inlineArrayCountParam->isTypeVariableOrMember()) {
+        addConstraint(
+            ConstraintKind::Bind, inlineArrayCountParam,
+            IntegerType::get(std::to_string(arrayLiteral->getNumElements()),
+                             /* isNegative */ false, iaTy->getASTContext()),
+            locator);
         return SolutionKind::Solved;
       }
 
-      // If our contextual count is not known, e.g., InlineArray<_, Int> = [1, 2],
-      // then just eagerly bind the count to what the literal count is.
-      if (contextualCount->isTypeVariableOrMember()) {
-        addConstraint(ConstraintKind::Bind, contextualCount, literalCount,
-                      locator);
+      unsigned inlineArrayCount = 0;
+      if (auto *intCount = inlineArrayCountParam->getAs<IntegerType>()) {
+        inlineArrayCount = intCount->getValue().getZExtValue();
+      } else {
+        return SolutionKind::Error;
+      }
+
+      // If the counts are already equal, '2' == '2', then we're done.
+      if (inlineArrayCount == arrayLiteral->getNumElements()) {
         return SolutionKind::Solved;
       }
 
@@ -9272,9 +9275,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
       if (!shouldAttemptFixes())
         return SolutionKind::Error;
 
-      auto fix = AllowInlineArrayLiteralCountMismatch::create(*this,
-                                                              contextualCount,
-                                                              literalCount, loc);
+      auto fix = AllowInlineArrayLiteralCountMismatch::create(
+          *this, inlineArrayCount, arrayLiteral->getNumElements(), loc);
       return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
     }
   } break;

--- a/test/LiteralExpressions/IntegerGenericErrors.swift
+++ b/test/LiteralExpressions/IntegerGenericErrors.swift
@@ -3,13 +3,13 @@
 // RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature LiteralExpressions
 
 let wrongCount1: InlineArray<(2 + 3), Int> = [1, 2, 3]
-// expected-error@-1 {{expected '5' elements in inline array literal, but got '3'}}
+// expected-error@-1 {{expected 5 elements in inline array literal, but got 3}}
 
 let wrongCount2: InlineArray<(1 << 2), Int> = [1, 2, 3, 4, 5, 6]
-// expected-error@-1 {{expected '4' elements in inline array literal, but got '6'}}
+// expected-error@-1 {{expected 4 elements in inline array literal, but got 6}}
 
 let wrongCount3: [(3 * 2) of Int] = [1, 2, 3]
-// expected-error@-1 {{expected '6' elements in inline array literal, but got '3'}}
+// expected-error@-1 {{expected 6 elements in inline array literal, but got 3}}
 
 let typeMismatch1: InlineArray<(2 + 1), Int> = ["a", "b", "c"]
 // expected-error@-1 {{cannot convert value of type 'String' to expected element type 'Int'}}
@@ -60,7 +60,7 @@ let nestedMismatch: InlineArray<2, InlineArray<(1 + 1), Int>> = [[1, 2], [3, 4, 
 // expected-error@-1 {{cannot convert value of type '[Int]' to expected element type 'InlineArray<2, Int>'}}
 
 let nestedMismatch2: [(1 + 1) of [(2 + 1) of Int]] = [[1, 2, 3], [4, 5]]
-// expected-error@-1 {{expected '3' elements in inline array literal, but got '2'}}
+// expected-error@-1 {{expected 3 elements in inline array literal, but got 2}}
 
 let divZero: InlineArray<(1/0), Int>
 // expected-error@-1 {{division by zero}}

--- a/test/Sema/inlinearray.swift
+++ b/test/Sema/inlinearray.swift
@@ -4,8 +4,8 @@ let a: InlineArray = [1, 2, 3] // Ok, InlineArray<3, Int>
 let b: InlineArray<_, Int> = [1, 2, 3] // Ok, InlineArray<3, Int>
 let c: InlineArray<3, _> = [1, 2, 3] // Ok, InlineArray<3, Int>
 
-let d: InlineArray<2, _> = [1, 2, 3] // expected-error {{expected '2' elements in inline array literal, but got '3'}}
-let e: InlineArray<2, _> = [1] // expected-error {{expected '2' elements in inline array literal, but got '1'}}
+let d: InlineArray<2, _> = [1, 2, 3] // expected-error {{expected 2 elements in inline array literal, but got 3}}
+let e: InlineArray<2, _> = [1] // expected-error {{expected 2 elements in inline array literal, but got 1}}
 
 let f: InlineArray<_, Int> = ["hello"] // expected-error {{cannot convert value of type 'String' to expected element type 'Int'}}
 
@@ -18,41 +18,41 @@ let _: [_ of _] = ["", "", ""] // Ok, InlineArray<3, String>
 
 let _: [3 of [3 of Int]] = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 let _: [3 of [3 of Int]] = [[1, 2], [3, 4, 5, 6]]
-// expected-error@-1 2 {{expected '3' elements in inline array literal, but got '2'}}
-// expected-error@-2 {{expected '3' elements in inline array literal, but got '4'}}
+// expected-error@-1 2 {{expected 3 elements in inline array literal, but got 2}}
+// expected-error@-2 {{expected 3 elements in inline array literal, but got 4}}
 
-let _ = [3 of [3 of Int]](repeating: [1, 2]) // expected-error {{expected '3' elements in inline array literal, but got '2'}}
+let _ = [3 of [3 of Int]](repeating: [1, 2]) // expected-error {{expected 3 elements in inline array literal, but got 2}}
 let _ = [3 of [_ of Int]](repeating: [1, 2])
 
 let _: [Int of 10] = [1, 2] // expected-error {{element count must precede inline array element type}} {{16-18=Int}} {{9-12=10}}
-// expected-error@-1 {{expected '10' elements in inline array literal, but got '2'}}
+// expected-error@-1 {{expected 10 elements in inline array literal, but got 2}}
 
-let _: [4 of _] = [1, 2, 3]   // expected-error {{expected '4' elements in inline array literal, but got '3'}}
-let _: [3 of Int] = [1, 2, 3, 4] // expected-error {{expected '3' elements in inline array literal, but got '4'}}
+let _: [4 of _] = [1, 2, 3]   // expected-error {{expected 4 elements in inline array literal, but got 3}}
+let _: [3 of Int] = [1, 2, 3, 4] // expected-error {{expected 3 elements in inline array literal, but got 4}}
 let _: [3 of String] = [1, 2, 3] // expected-error 3{{cannot convert value of type 'Int' to expected element type 'String'}}
 let _: [3 of String] = [1] // expected-error {{cannot convert value of type 'Int' to expected element type 'String'}}
-// expected-error@-1 {{expected '3' elements in inline array literal, but got '1'}}
+// expected-error@-1 {{expected 3 elements in inline array literal, but got 1}}
 
 func takeVectorOf2<T>(_: InlineArray<2, T>) {}
 
 takeVectorOf2([1, 2]) // Ok
 takeVectorOf2(["hello", "world"]) // Ok
 
-takeVectorOf2([1]) // expected-error {{expected '2' elements in inline array literal, but got '1'}}
+takeVectorOf2([1]) // expected-error {{expected 2 elements in inline array literal, but got 1}}
 
-takeVectorOf2([1, 2, 3]) // expected-error {{expected '2' elements in inline array literal, but got '3'}}
+takeVectorOf2([1, 2, 3]) // expected-error {{expected 2 elements in inline array literal, but got 3}}
 
-takeVectorOf2(["hello"]) // expected-error {{expected '2' elements in inline array literal, but got '1'}}
+takeVectorOf2(["hello"]) // expected-error {{expected 2 elements in inline array literal, but got 1}}
 
-takeVectorOf2(["hello", "world", "!"]) // expected-error {{expected '2' elements in inline array literal, but got '3'}}
+takeVectorOf2(["hello", "world", "!"]) // expected-error {{expected 2 elements in inline array literal, but got 3}}
 
 func takeVectorOf2Int(_: InlineArray<2, Int>) {}
 
 takeVectorOf2Int([1, 2]) // Ok
 
-takeVectorOf2Int([1]) // expected-error {{expected '2' elements in inline array literal, but got '1'}}
+takeVectorOf2Int([1]) // expected-error {{expected 2 elements in inline array literal, but got 1}}
 
-takeVectorOf2Int([1, 2, 3]) // expected-error {{expected '2' elements in inline array literal, but got '3'}}
+takeVectorOf2Int([1, 2, 3]) // expected-error {{expected 2 elements in inline array literal, but got 3}}
 
 takeVectorOf2Int(["hello"]) // expected-error {{cannot convert value of type '[String]' to expected argument type 'InlineArray<2, Int>'}}
 
@@ -63,7 +63,7 @@ takeVectorOf2Int(["hello", "world", "!"]) // expected-error {{cannot convert val
 
 func takeSugarVectorOf2<T>(_: [2 of T], ty: T.Type = T.self) {}
 takeSugarVectorOf2([1, 2])
-takeSugarVectorOf2(["hello"]) // expected-error {{expected '2' elements in inline array literal, but got '1'}}
+takeSugarVectorOf2(["hello"]) // expected-error {{expected 2 elements in inline array literal, but got 1}}
 takeSugarVectorOf2(["hello"], ty: Int.self) // expected-error {{cannot convert value of type '[String]' to expected argument type '[2 of Int]'}}
 takeSugarVectorOf2(["hello", "hi"], ty: Int.self) // expected-error {{cannot convert value of type '[String]' to expected argument type '[2 of Int]'}}
 


### PR DESCRIPTION
…for counts

The code expects the `count`s to be `IntegerType`, let's use `unsigned` representation for matching and diagnostics. This means that the numbers would no longer be printed in quotes as well.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
