### PR TITLE
[Embedded PAL] Add EMBEDDED_SWIFT_MUTEX_NUM_WORDS macro definition

### DIFF
--- a/stdlib/public/EmbeddedPlatform/EmbeddedPlatformMultiThreadedDarwin.c
+++ b/stdlib/public/EmbeddedPlatform/EmbeddedPlatformMultiThreadedDarwin.c
@@ -41,9 +41,10 @@ typedef struct {
   } u;
 } swift_darwin_mutex_t;
 
-_Static_assert(sizeof(swift_darwin_mutex_t) <= 8 * sizeof(void *),
+_Static_assert(sizeof(swift_darwin_mutex_t) <= EMBEDDED_SWIFT_MUTEX_NUM_WORDS * sizeof(void *),
                "swift_darwin_mutex_t does not fit in the Embedded Swift "
-               "Platform mutex storage (8 pointer-sized words)");
+               "Platform mutex storage (EMBEDDED_SWIFT_MUTEX_NUM_WORDS "
+               "pointer-sized words)");
 _Static_assert(_Alignof(swift_darwin_mutex_t) <= _Alignof(void *),
                "swift_darwin_mutex_t requires stronger alignment than the "
                "Embedded Swift Platform mutex storage provides");

--- a/stdlib/public/EmbeddedPlatform/EmbeddedPlatformMultiThreadedPOSIX.c
+++ b/stdlib/public/EmbeddedPlatform/EmbeddedPlatformMultiThreadedPOSIX.c
@@ -25,7 +25,7 @@
 #include <pthread.h>
 
 #if __STDC_VERSION__ >= 201112L
-_Static_assert(sizeof(pthread_mutex_t) <= 8 * sizeof(void *),
+_Static_assert(sizeof(pthread_mutex_t) <= EMBEDDED_SWIFT_MUTEX_NUM_WORDS * sizeof(void *),
                "pthread_mutex_t does not fit in the Embedded Swift Platform "
                "mutex storage (8 pointer-sized words)");
 _Static_assert(_Alignof(pthread_mutex_t) <= _Alignof(void *),

--- a/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
+++ b/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
@@ -96,6 +96,20 @@ typedef unsigned long long __swift_options_t;
 #define EMBEDDED_SWIFT_PLATFORM_VERSION_MINOR 1
 
 /**
+ * The number of pointer-size words that will be used to store a Mutex (as
+ * provided by the Synchronization library).
+ *
+ * This needs to be large enough to accommodate any implementation of Mutex that
+ * can be implemented for that given platform (e.g., via the `_swift_mutex_*`
+ * functions). It can be defined externally (via `-D` on the command line for
+ * Clang, `-Xcc -D` for Swift) to a different value, but that value must be
+ * consistent throughout the build to prevent ABI mismatches.
+ */
+#ifndef EMBEDDED_SWIFT_MUTEX_NUM_WORDS
+#define EMBEDDED_SWIFT_MUTEX_NUM_WORDS (__swift_ptrdiff_t)8
+#endif
+
+/**
  * Determine the version of the platform abstraction layer that the Embedded
  * Swift library was built with.
  *
@@ -323,7 +337,8 @@ void _swift_setExclusivityTLS(void * EMBEDDED_SWIFT_NULLABLE ptr);
  *   - `mutex`: opaque caller-owned mutex storage initialized by this function
  *     and later passed to the other `_swift_mutex_*` functions. The contents
  *     are private to the platform implementation. The storage is at least
- *     eight pointer-sized words and has pointer alignment.
+ *     EMBEDDED_SWIFT_MUTEX_NUM_WORDS pointer-sized words and has pointer
+ *     alignment.
  *   - `flags`: flags controlling mutex behavior.
  *
  * This function is required when using Synchronization.Mutex.

--- a/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
+++ b/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
@@ -106,7 +106,13 @@ typedef unsigned long long __swift_options_t;
  * consistent throughout the build to prevent ABI mismatches.
  */
 #ifndef EMBEDDED_SWIFT_MUTEX_NUM_WORDS
+#if defined(__APPLE__) && __SIZEOF_POINTER__ == 4
+// On 32-bit Apple targets (e.g., watchOS armv7k / arm64_32) `pthread_mutex_t`
+// is 40 bytes, which doesn't fit in 8 four-byte words.
+#define EMBEDDED_SWIFT_MUTEX_NUM_WORDS (__swift_ptrdiff_t)12
+#else
 #define EMBEDDED_SWIFT_MUTEX_NUM_WORDS (__swift_ptrdiff_t)8
+#endif
 #endif
 
 /**

--- a/stdlib/public/Synchronization/CMakeLists.txt
+++ b/stdlib/public/Synchronization/CMakeLists.txt
@@ -171,6 +171,11 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   add_custom_target(embedded-synchronization)
   add_dependencies(embedded-libraries embedded-synchronization)
 
+  set(_embedded_synchronization_swift_flags
+    ${SWIFT_SYNCHRNOIZATION_SWIFT_FLAGS}
+    -internal-import-bridging-header ${CMAKE_CURRENT_SOURCE_DIR}/../EmbeddedPlatform/swift/EmbeddedPlatform.h
+    -enable-experimental-feature LiteralExpressions)
+
   # wasm32 builds the full Synchronization library plus its wasm-specific
   # mutex implementation.
   add_embedded_swift_target_library(
@@ -181,7 +186,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     ${SWIFT_SYNCHRONIZATION_WASM_SOURCES}
 
     GYB_SOURCES ${SWIFT_SYNCHRONIZATION_GYB_SOURCES}
-    SWIFT_COMPILE_FLAGS ${SWIFT_SYNCHRNOIZATION_SWIFT_FLAGS}
+    SWIFT_COMPILE_FLAGS ${_embedded_synchronization_swift_flags}
     ONLY_ARCH_REGEX "^wasm32$"
     INSTALL_IN_COMPONENT stdlib
   )
@@ -198,7 +203,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     Mutex/Mutex.swift
 
     GYB_SOURCES ${SWIFT_SYNCHRONIZATION_GYB_SOURCES}
-    SWIFT_COMPILE_FLAGS ${SWIFT_SYNCHRNOIZATION_SWIFT_FLAGS}
+    SWIFT_COMPILE_FLAGS ${_embedded_synchronization_swift_flags}
     SKIP_ARCH_REGEX "^wasm32$" "^avr$"
     INSTALL_IN_COMPONENT stdlib
   )

--- a/stdlib/public/Synchronization/Mutex/EmbeddedImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/EmbeddedImpl.swift
@@ -56,7 +56,7 @@ public struct _MutexHandle: ~Copyable {
   @_alwaysEmitIntoClient
   @_transparent
   public init() {
-    storage = _Cell([0, 0, 0, 0, 0, 0, 0, 0])
+    storage = _Cell(.init(repeating: 0))
     unsafe _swift_mutex_init(UnsafeMutableRawPointer(storage._address), 0)
   }
 

--- a/stdlib/public/Synchronization/Mutex/EmbeddedImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/EmbeddedImpl.swift
@@ -12,7 +12,7 @@
 
 // Private inline storage for EmbeddedPlatform's opaque mutex hooks.
 @usableFromInline
-internal typealias _SwiftEmbeddedMutex = [8 of UInt]
+internal typealias _SwiftEmbeddedMutex = [(EMBEDDED_SWIFT_MUTEX_NUM_WORDS) of UInt]
 
 @_extern(c, "_swift_mutex_init")
 @usableFromInline


### PR DESCRIPTION
Introduce EMBEDDED_SWIFT_MUTEX_NUM_WORDS to capture the number of words
that will be allocated within Synchronization.Mutex to store a platform
mutex. The previously-picked value is too small for some platforms
(32-bit watchOS needs at least 11) and is being copied into sources in
several different places. Centralizing that value let's us customize
it further, both in the platform header and through the command line.

Use this to customize for 32-bit Apple targets, where `pthread_mutex_t` is 10 words. Fixes rdar://181952065