### PR TITLE
[Sema] Check superclass Sendable conformance before diagnosing

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7642,6 +7642,18 @@ bool swift::checkSendableConformance(
   if (classDecl && classDecl->getParentSourceFile()) {
     bool isInherited = isa<InheritedProtocolConformance>(conformance);
 
+    // Workaround: the conformance lookup table may not form an
+    // InheritedProtocolConformance for Sendable when the superclass is
+    // Sendable through @MainActor isolation (the table fix is #90251).
+    // Check the superclass directly so we don't misdiagnose.
+    if (!isInherited) {
+      if (auto superclassTy = classDecl->getSuperclass()) {
+        auto superConf = lookupConformance(superclassTy,
+            conformance->getProtocol(), /*allowMissing=*/false);
+        isInherited = superConf.isConcrete();
+      }
+    }
+
     // A non-final class cannot conform to `Sendable` unless it is protected by
     // global actor isolation.
     if (!classDecl->isSemanticallyFinal() && !isGlobalActorIsolated) {

--- a/test/Concurrency/nonsendable_superclass_objc.swift
+++ b/test/Concurrency/nonsendable_superclass_objc.swift
@@ -1,0 +1,172 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/src)
+// RUN: %empty-directory(%t/sdk)
+// RUN: %empty-directory(%t/sdk/ObjCActorModule)
+// RUN: split-file %s %t/src
+
+// Build ObjC module
+// RUN: %target-clang -fmodules -dynamiclib %t/src/ObjCActorModule.m -I %t/src -o %t/sdk/ObjCActorModule/libObjCActorModule.dylib -lobjc -framework Foundation
+// RUN: cp %t/src/ObjCActorModule.modulemap %t/sdk/ObjCActorModule/module.modulemap
+// RUN: cp %t/src/ObjCActorModule.h %t/sdk/ObjCActorModule/ObjCActorModule.h
+
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -strict-concurrency=complete %t/src/main.swift -emit-sil -o /dev/null -verify -I %t/sdk/ObjCActorModule
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %t/src/main.swift -emit-sil -o /dev/null -verify -verify-additional-prefix swift6- -swift-version 6 -I %t/sdk/ObjCActorModule
+
+// REQUIRES: concurrency
+// REQUIRES: objc_interop
+
+//--- ObjCActorModule.modulemap
+
+module ObjCActorModule {
+  header "ObjCActorModule.h"
+  export *
+}
+
+//--- ObjCActorModule.h
+
+#import <Foundation/Foundation.h>
+
+// Models the UIKit chain: NSObject -> @MainActor UIResponder -> @MainActor UIViewController/UIView
+// The entire chain is @MainActor-isolated with a Sendable root (NSObject).
+
+__attribute__((swift_attr("@MainActor")))
+@interface ObjCResponder : NSObject
+@end
+
+__attribute__((swift_attr("@MainActor")))
+@interface ObjCController : ObjCResponder
+@end
+
+__attribute__((swift_attr("@MainActor")))
+@interface ObjCView : ObjCResponder
+@end
+
+//--- ObjCActorModule.m
+
+#import "ObjCActorModule.h"
+
+@implementation ObjCResponder
+@end
+
+@implementation ObjCController
+@end
+
+@implementation ObjCView
+@end
+
+//--- main.swift
+
+import ObjCActorModule
+
+// ============================================================================
+// Implied Sendable through protocol refinement
+// ============================================================================
+//
+// When Sendable comes through a protocol (e.g. MyDelegate: Sendable),
+// the conformance table builds it as Implied -> NormalProtocolConformance
+// because the superclass's implicit Sendable from @MainActor wasn't in
+// the table yet when the Inherited stage ran.
+//
+// The protocol conformance must be checked BEFORE any code that would
+// trigger eager Sendable derivation on ObjCController (e.g. a
+// requiresSendable() call), because early derivation masks the bug by
+// materializing an InheritedProtocolConformance.
+
+protocol MyDelegate: Sendable {
+  func didDoThing()
+}
+
+@MainActor
+final class MyDelegateController: ObjCController {}
+
+extension MyDelegateController: @preconcurrency MyDelegate {
+  func didDoThing() {}
+}
+
+@MainActor
+protocol MyIsolatedDelegate: Sendable {
+  func didDoThing()
+}
+
+@MainActor
+final class MyIsolatedDelegateController: ObjCController, MyIsolatedDelegate {
+  func didDoThing() {}
+}
+
+// ============================================================================
+// Explicit Sendable on @MainActor classes with @MainActor ObjC superclasses
+// ============================================================================
+//
+// Real-world pattern: @MainActor final classes that inherit from UIView or
+// UIViewController (modeled here as ObjCView / ObjCController) and explicitly
+// declare Sendable. The superclass chain is @MainActor all the way down to
+// NSObject, so the superclass IS Sendable. No diagnostic should fire.
+
+@MainActor
+final class ExplicitSendableView: ObjCView, Sendable {}
+
+@MainActor
+final class ExplicitSendableController: ObjCController, Sendable {}
+
+// Public @MainActor view subclass with explicit Sendable, matching the
+// pattern of public UI component views.
+@MainActor
+public final class PublicExplicitSendableView: ObjCView, Sendable {}
+
+// ============================================================================
+// Non-final @MainActor classes with explicit Sendable
+// ============================================================================
+//
+// A non-final @MainActor class with a Sendable superclass chain is
+// still valid: subclasses inherit @MainActor isolation, so they can't
+// add unsynchronized state. The non-final restriction only applies to
+// non-isolated classes.
+
+@MainActor
+class NonFinalExplicitSendableController: ObjCController, Sendable {}
+
+// ============================================================================
+// Implicit Sendable (no explicit annotation)
+// ============================================================================
+//
+// ObjC defines:
+//   @MainActor ObjCResponder : NSObject
+//   @MainActor ObjCController : ObjCResponder
+//   @MainActor ObjCView : ObjCResponder
+//
+// Swift subclasses inherit @MainActor isolation and should be implicitly
+// Sendable with no diagnostic.
+
+class MyController: ObjCController {} // no diagnostic expected
+class MyView: ObjCView {} // no diagnostic expected
+
+// ============================================================================
+// Verify all of the above are usable as Sendable
+// ============================================================================
+
+func requiresSendable<T: Sendable>(_: T) {}
+func testObjCChainIsSendable(
+  _ r: ObjCResponder,
+  _ c: ObjCController,
+  _ v: ObjCView,
+  _ mc: MyController,
+  _ mv: MyView,
+  _ dc: MyDelegateController,
+  _ ic: MyIsolatedDelegateController,
+  _ ec: ExplicitSendableController,
+  _ ev: ExplicitSendableView,
+  _ pv: PublicExplicitSendableView,
+  _ nf: NonFinalExplicitSendableController
+) {
+  requiresSendable(r)
+  requiresSendable(c)
+  requiresSendable(v)
+  requiresSendable(mc)
+  requiresSendable(mv)
+  requiresSendable(dc)
+  requiresSendable(ic)
+  requiresSendable(ec)
+  requiresSendable(ev)
+  requiresSendable(pv)
+  requiresSendable(nf)
+}


### PR DESCRIPTION
## Summary

When a class declares `Sendable` (explicitly or through a protocol refinement), the diagnostic at the `!isInherited` site in `checkSendableConformance` assumes a non-inherited conformance means the superclass is non-Sendable, but never actually checks.

For `@MainActor` class chains rooted in `NSObject` (e.g. `UIView`, `UIViewController`), the entire superclass chain is Sendable through global actor isolation per [SE-0316](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0316-global-actors.md). The conformance may not be represented as `InheritedProtocolConformance` due to ordering in the conformance lookup table, but the superclass is still Sendable.

This adds a `lookupConformance` check on the superclass before emitting `concurrent_value_nonsendable_superclass`. If the superclass concretely conforms to `Sendable`, the diagnostic is suppressed.

### What this fixes

| Pattern | Example | Diagnostic suppressed |
|---|---|---|
| Explicit `Sendable` on `@MainActor` class with `@MainActor` ObjC superclass | `@MainActor final class Foo: UIView, Sendable` | `concurrent_value_nonsendable_superclass` |
| Non-final `@MainActor` class with explicit `Sendable` | `@MainActor class Foo: UIViewController, Sendable` | `concurrent_value_nonsendable_superclass` |
| `Sendable` via protocol refinement | `protocol P: Sendable {}; class Foo: UIViewController, P` | `concurrent_value_nonsendable_superclass` |
| Implicit `Sendable` (no annotation) | `class Foo: UIViewController` | Already suppressed by existing `isImplicitSendableCheck` guard |

### What this does not fix

This is a diagnostic-site suppression. The conformance lookup table still forms a `NormalProtocolConformance` instead of an `InheritedProtocolConformance` for these cases. That means retroactive conformance and cross-file conformance warnings still fire when users write `extension ImportedSubclass: Sendable {}` on a type whose superclass is already Sendable. Those warnings have source-level workarounds (`@retroactive @unchecked Sendable`) or can be avoided by omitting the explicit conformance and relying on implicit Sendable from `@MainActor`.

The conformance representation fix is tracked in #90251.

### Intended for 6.4 cherry-pick

This is the narrower fix requested in https://github.com/swiftlang/swift/pull/90251#issuecomment-4946431057 for the `release/6.4.x` branch. The full conformance table fix (#90251) targets `main`.

## Test plan

- `nonsendable_superclass_objc.swift`: cross-module test modeling the UIKit chain (`NSObject -> @MainActor ObjCResponder -> @MainActor ObjCController/ObjCView`) with 8 patterns covering implied, explicit final, explicit non-final, and implicit Sendable
- All patterns verify no `concurrent_value_nonsendable_superclass` diagnostic under both `-strict-concurrency=complete` and Swift 6 mode