### PR TITLE
AST: represent protocol metatype extensions faithfully in the TypeRepr

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -1570,9 +1570,6 @@ void BridgedExtensionDecl_setParsedMembers(BridgedExtensionDecl decl,
                                            BridgedArrayRef members,
                                            BridgedFingerprint fingerprint);
 
-SWIFT_NAME("BridgedExtensionDecl.setIsMetatypeExtension(self:)")
-void BridgedExtensionDecl_setIsMetatypeExtension(BridgedExtensionDecl decl);
-
 SWIFT_NAME(
     "BridgedEnumDecl.createParsed(_:declContext:enumKeywordLoc:name:nameLoc:"
     "genericParamList:inheritedTypes:genericWhereClause:braceRange:)")

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -866,7 +866,7 @@ protected:
     NumPathElements : 8
   );
 
-  SWIFT_INLINE_BITFIELD(ExtensionDecl, Decl, 4+1+1,
+  SWIFT_INLINE_BITFIELD(ExtensionDecl, Decl, 4+1,
     /// An encoding of the default and maximum access level for this extension.
     /// The value 4 corresponds to AccessLevel::Public
     ///
@@ -876,11 +876,7 @@ protected:
     DefaultAndMaxAccessLevel : 4,
 
     /// Whether there is are lazily-loaded conformances for this extension.
-    HasLazyConformances : 1,
-
-    /// Whether this is a `metatype extension` whose members live on the
-    /// protocol metatype and are not inherited by conforming types.
-    IsMetatypeExtension : 1
+    HasLazyConformances : 1
   );
 
   SWIFT_INLINE_BITFIELD(MissingMemberDecl, Decl, 1+2,
@@ -2153,12 +2149,11 @@ public:
   SourceRange getBraces() const { return Braces; }
   void setBraces(SourceRange braces) { Braces = braces; }
 
-  bool isMetatypeExtension() const {
-    return Bits.ExtensionDecl.IsMetatypeExtension;
-  }
-  void setIsMetatypeExtension(bool value = true) {
-    Bits.ExtensionDecl.IsMetatypeExtension = value;
-  }
+  /// Whether this is a protocol metatype extension (`extension P.Protocol`).
+  /// Derived from the extended type representation for parsed extensions, or
+  /// from the extended type (the protocol metatype `(any P).Type`) for a
+  /// deserialized or synthesized extension that has no representation.
+  bool isMetatypeExtension() const;
 
   bool hasBeenBound() const { return ExtendedNominal.getInt(); }
 

--- a/lib/AST/Bridging/DeclBridging.cpp
+++ b/lib/AST/Bridging/DeclBridging.cpp
@@ -342,10 +342,6 @@ void BridgedExtensionDecl_setParsedMembers(BridgedExtensionDecl cDecl,
   setParsedMembers(cDecl.unbridged(), cMembers, cFingerprint);
 }
 
-void BridgedExtensionDecl_setIsMetatypeExtension(BridgedExtensionDecl cDecl) {
-  cDecl.unbridged()->setIsMetatypeExtension();
-}
-
 static ArrayRef<InheritedEntry>
 convertToInheritedEntries(ASTContext &ctx, BridgedArrayRef cInheritedTypes) {
   return ctx.AllocateTransform<InheritedEntry>(

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2057,7 +2057,7 @@ ExtensionDecl::ExtensionDecl(SourceLoc extensionLoc,
 {
   Bits.ExtensionDecl.DefaultAndMaxAccessLevel = 0;
   Bits.ExtensionDecl.HasLazyConformances = false;
-  Bits.ExtensionDecl.IsMetatypeExtension = false;
+
   setTrailingWhereClause(trailingWhereClause);
 }
 
@@ -2080,6 +2080,16 @@ ExtensionDecl *ExtensionDecl::create(ASTContext &ctx, SourceLoc extensionLoc,
     result->setClangNode(clangNode);
 
   return result;
+}
+
+bool ExtensionDecl::isMetatypeExtension() const {
+  // A parsed `extension P.Protocol` keeps its `ProtocolTypeRepr`; recognize the
+  // form from that without forcing type resolution.  Deserialized and
+  // compiler-synthesized extensions have no representation, but their extended
+  // type is the protocol metatype `(any P).Type`, so recognize it from there.
+  if (auto *repr = getExtendedTypeRepr())
+    return isa<ProtocolTypeRepr>(repr);
+  return getExtendedType()->is<MetatypeType>();
 }
 
 void ExtensionDecl::setConformanceLoader(LazyMemberLoader *lazyLoader,

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -3402,13 +3402,18 @@ directReferencesForTypeRepr(Evaluator &evaluator, ASTContext &ctx,
     return result;
   }
 
+  case TypeReprKind::Protocol:
+    // `P.Protocol` refers, for the purpose of extension binding, to the
+    // protocol `P` itself (a protocol metatype extension binds to `P`).
+    return directReferencesForTypeRepr(
+        evaluator, ctx, cast<ProtocolTypeRepr>(typeRepr)->getBase(), dc, options);
+
   case TypeReprKind::Error:
   case TypeReprKind::Function:
   case TypeReprKind::Ownership:
   case TypeReprKind::CompileTimeLiteral:
   case TypeReprKind::ConstValue:
   case TypeReprKind::Metatype:
-  case TypeReprKind::Protocol:
   case TypeReprKind::SILBox:
   case TypeReprKind::Placeholder:
   case TypeReprKind::Pack:

--- a/lib/ASTGen/Sources/ASTGen/Decls.swift
+++ b/lib/ASTGen/Sources/ASTGen/Decls.swift
@@ -310,18 +310,14 @@ extension ASTGenVisitor {
 extension ASTGenVisitor {
   func generate(extensionDecl node: ExtensionDeclSyntax) -> BridgedExtensionDecl {
     let attrs = self.generateDeclAttributes(node, allowStatic: false)
-    // Detect `extension P.Protocol { }` — a protocol metatype extension.
-    // Strip the `.Protocol` so the extension binds to the protocol `P`.
-    let protoMeta = node.extendedType.as(MetatypeTypeSyntax.self)
-        .flatMap { $0.metatypeSpecifier.keywordKind == .Protocol ? $0 : nil }
-    let extendedType = protoMeta.map { self.generate(type: $0.baseType) }
-                    ?? self.generate(type: node.extendedType)
-
+    // `extension P.Protocol { }` (a protocol metatype extension) is recognized
+    // in the `ExtensionDecl` constructor, which strips the `.Protocol` and
+    // marks the extension; ASTGen just forwards the written type.
     let decl = BridgedExtensionDecl.createParsed(
       self.ctx,
       declContext: self.declContext,
       extensionKeywordLoc: self.generateSourceLoc(node.extensionKeyword),
-      extendedType: extendedType,
+      extendedType: self.generate(type: node.extendedType),
       inheritedTypes: self.generate(inheritedTypeList: node.inheritanceClause?.inheritedTypes),
       genericWhereClause: self.generate(genericWhereClause: node.genericWhereClause),
       braceRange: self.generateSourceRange(
@@ -330,10 +326,6 @@ extension ASTGenVisitor {
       )
     )
     decl.asDecl.attachParsedAttrs(attrs.attributes)
-
-    if protoMeta != nil {
-      decl.setIsMetatypeExtension()
-    }
 
     let members = self.withDeclContext(decl.asDeclContext) {
       self.generate(memberBlockItemList: node.memberBlock.members)

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -7565,13 +7565,6 @@ Parser::parseDeclExtension(ParseDeclOptions Flags, DeclAttributes &Attributes) {
                                              trailingWhereClause);
   ext->attachParsedAttrs(Attributes);
 
-  // Detect `extension P.Protocol { }` — a protocol metatype extension.
-  // Strip the `.Protocol` suffix so the extension binds to the protocol `P`.
-  if (auto *PTR = dyn_cast_or_null<ProtocolTypeRepr>(extendedType.getPtrOrNull())) {
-    ext->setIsMetatypeExtension();
-    ext->setExtendedTypeRepr(PTR->getBase());
-  }
-
   if (trailingWhereHadCodeCompletion && CodeCompletionCallbacks)
     CodeCompletionCallbacks->setParsedDecl(ext);
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3104,6 +3104,16 @@ ExtendedTypeRequest::evaluate(Evaluator &eval, ExtensionDecl *ext) const {
     return error();
   }
 
+  // A protocol metatype extension `extension P.Protocol` extends the metatype
+  // of a protocol existential.  Accept it here — the metatype and non-nominal
+  // checks below would otherwise reject it — leaving the extended nominal (the
+  // protocol `P`) to be resolved separately.  Whether such an extension is
+  // permitted (only for `@com` protocols) is enforced during extension
+  // validation.
+  if (auto *metatype = extendedType->getAs<MetatypeType>())
+    if (metatype->getInstanceType()->isExistentialType())
+      return extendedType;
+
   // Hack to allow extending a generic typealias.
   if (auto *unboundGeneric = extendedType->getAs<UnboundGenericType>()) {
     if (auto *aliasDecl = dyn_cast<TypeAliasDecl>(unboundGeneric->getDecl())) {

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3999,8 +3999,10 @@ public:
       return;
     }
 
-    // Validate metatype extension constraints.
-    if (ED->isMetatypeExtension()) {
+    // Validate metatype extension constraints.  Skip when the extended type
+    // did not resolve — e.g. `S.Protocol` on a non-protocol `S`, which has
+    // already been diagnosed as an invalid `.Protocol` spelling.
+    if (ED->isMetatypeExtension() && !extType->hasError()) {
       if (!isCOMMetatypeExtension(ED)) {
         ED->diagnose(diag::metatype_extension_com_only);
         ED->setInvalid();

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -957,6 +957,13 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
   } else if (auto *ext = dyn_cast<ExtensionDecl>(GC)) {
     loc = ext->getLoc();
 
+    // A protocol metatype extension has no generic signature — its members are
+    // static members of the protocol metatype and cannot reference Self.  Bail
+    // before inspecting the extended type, which is the metatype `(any P).Type`
+    // rather than a nominal that requirements could be collected from.
+    if (ext->isMetatypeExtension())
+      return nullptr;
+
     collectAdditionalExtensionRequirements(ext->getExtendedType(), extraReqs);
 
     auto *extendedNominal = ext->getExtendedNominal();
@@ -969,11 +976,6 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
     // Self or its associated types will infer default requirements in
     // ordinary extensions of that protocol, so the signature can differ there.
     if (auto *proto = dyn_cast<ProtocolDecl>(extendedNominal)) {
-      // Metatype extensions have no generic signature.  Their members are
-      // statically dispatched and cannot reference Self.
-      if (ext->isMetatypeExtension())
-        return nullptr;
-
       if (extraReqs.empty() && !ext->getTrailingWhereClause() &&
           proto->getInverseRequirements().empty()) {
         return extendedNominal->getGenericSignatureOfContext();

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5435,15 +5435,13 @@ public:
     DeclID extendedNominalID;
     DeclContextID contextID;
     bool isImplicit;
-    bool isMetatypeExtension;
     GenericSignatureID genericSigID;
     unsigned numConformances, numInherited;
     ArrayRef<uint64_t> data;
 
     decls_block::ExtensionLayout::readRecord(scratch, extendedTypeID,
                                              extendedNominalID, contextID,
-                                             isImplicit, isMetatypeExtension,
-                                             genericSigID,
+                                             isImplicit, genericSigID,
                                              numConformances, numInherited,
                                              data);
 
@@ -5469,7 +5467,8 @@ public:
 
     auto extension = ExtensionDecl::create(ctx, SourceLoc(), nullptr, { },
                                            DC, nullptr);
-    extension->setIsMetatypeExtension(isMetatypeExtension);
+    // `isMetatypeExtension` is not stored: it is derived from the extended type
+    // (the protocol metatype `(any P).Type`), which is restored below.
     declOrOffset = extension;
 
     // Generic parameter lists are written from outermost to innermost.

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,8 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 1011; // widen extension-table dataLength to uint32
+const uint16_t SWIFTMODULE_VERSION_MINOR =
+    1012; // drop metatype extension flag (derived from the extended type)
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -2016,7 +2017,6 @@ namespace decls_block {
     DeclIDField, // extended nominal
     DeclContextIDField, // context decl
     BCFixed<1>,  // implicit flag
-    BCFixed<1>,  // isMetatypeExtension flag
     GenericSignatureIDField,  // generic environment
     BCVBR<4>,    // # of protocol conformances
     BCVBR<4>,    // number of inherited types

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4449,7 +4449,6 @@ public:
                                 S.addDeclRef(extendedNominal),
                                 contextID.getOpaqueValue(),
                                 extension->isImplicit(),
-                                extension->isMetatypeExtension(),
                                 S.addGenericSignatureRef(
                                            extension->getGenericSignature()),
                                 numConformances,

--- a/test/Sema/Inputs/metatype-extension-lib.swift
+++ b/test/Sema/Inputs/metatype-extension-lib.swift
@@ -1,0 +1,13 @@
+import COM
+
+// A @com protocol with a user-written protocol metatype extension.  The
+// extension and its members must round-trip through serialization: the client
+// recovers that this is a metatype extension from the (deserialized) extended
+// type, since the flag is no longer stored.
+@com(interface: "30000000-0000-0000-0000-000000000003")
+public protocol IWidget: IUnknown { }
+
+public extension IWidget.Protocol {
+  var tag: Int { 7 }
+  func describe() -> String { "widget" }
+}

--- a/test/Sema/metatype-extension-cross-module.swift
+++ b/test/Sema/metatype-extension-cross-module.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module-path %t/COM.swiftmodule -module-name COM -enable-experimental-com-interop %S/../Inputs/COM.swift
+// RUN: %target-swift-frontend -emit-module-path %t/Lib.swiftmodule -module-name Lib -enable-experimental-com-interop -I %t %S/Inputs/metatype-extension-lib.swift
+// RUN: %target-typecheck-verify-swift -enable-experimental-com-interop -I %t
+
+// A protocol metatype extension defined in another module round-trips: the
+// deserialized extension is recognized as a metatype extension from its
+// extended type, and its members are reachable on the protocol metatype.
+
+import COM
+import Lib
+
+let _: Int = IWidget.tag
+let _: String = IWidget.describe()

--- a/test/Sema/metatype-extension.swift
+++ b/test/Sema/metatype-extension.swift
@@ -2,9 +2,8 @@
 
 // Protocol metatype extensions are reserved for COM interop: only a protocol
 // marked @com may carry one, and there is no user-facing feature flag that
-// unlocks them for arbitrary protocols. Every metatype extension written on a
-// non-@com type is rejected before any of the other metatype-extension
-// constraints are considered.
+// unlocks them for arbitrary protocols. A metatype extension written on a
+// non-@com *protocol* is rejected as reserved for COM interop.
 
 protocol P {}
 
@@ -17,10 +16,11 @@ extension P.Protocol { // expected-error {{protocol metatype extensions are rese
 protocol Q: P {}
 extension Q.Protocol {} // expected-error {{protocol metatype extensions are reserved for COM interop}}
 
-// --- Metatype extension on non-protocol types is rejected the same way; the
-//     COM-only check runs first.
+// --- `.Protocol` on a non-protocol type is not a protocol metatype at all, so
+//     it is rejected as an invalid metatype spelling before the COM-only rule
+//     is reached.
 struct S {}
-extension S.Protocol {} // expected-error {{protocol metatype extensions are reserved for COM interop}}
+extension S.Protocol {} // expected-error {{cannot use 'Protocol' with non-protocol type 'S'}}
 
 class C {}
-extension C.Protocol {} // expected-error {{protocol metatype extensions are reserved for COM interop}}
+extension C.Protocol {} // expected-error {{cannot use 'Protocol' with non-protocol type 'C'}}


### PR DESCRIPTION
`extension P.Protocol` extends a protocol's metatype, but it was stored as an extension of `P` plus a side `IsMetatypeExtension` bit to recover what was written.  Represent the written type faithfully and derive metatype- extension-ness from it, so the bit — in memory and in the serialized `ExtensionLayout` record — is no longer needed.