### PR TITLE
[IRGen] Use per-file linkage for outlined value functions that reference file-private types.

### DIFF
--- a/lib/IRGen/Outlining.cpp
+++ b/lib/IRGen/Outlining.cpp
@@ -31,6 +31,7 @@
 #include "swift/Basic/Assertions.h"
 #include "swift/IRGen/GenericRequirement.h"
 #include "swift/IRGen/Linking.h"
+#include "swift/SIL/FormalLinkage.h"
 #include "swift/SIL/SILModule.h"
 
 using namespace swift;
@@ -86,6 +87,19 @@ void OutliningMetadataCollector::collectTypeMetadataForLayout(SILType ty) {
   // non ABI accessible field/element types.
   if (isa<FixedTypeInfo>(ti) || !ti.isABIAccessible()) {
     return;
+  }
+
+  // A file-private/private nominal's metadata is only accessible from its
+  // defining file, so this outlined function's collected signature (and body)
+  // differs between that file -- which inlines the value operation using the
+  // type's metadata, collected here -- and any other file, which falls back to
+  // the enclosing type's value witness. Record that so the function is emitted
+  // with per-file private linkage instead of shared linkonce_odr, otherwise the
+  // two signatures would merge under one mangled name.  See
+  // getOrCreateOutlined{Destroy,CopyAddrHelper}Function.
+  if (auto *nominal = astType->getAnyNominal()) {
+    if (getDeclLinkage(nominal) == FormalLinkage::Private)
+      SignatureDependsOnFilePrivateType = true;
   }
 
   // If the type is a legal formal type, add it as a formal type.
@@ -504,8 +518,15 @@ llvm::Constant *IRGenModule::getOrCreateOutlinedCopyAddrHelperFunction(
   // The default hidden linkonce_odr might lead to linking an implementation
   // from another file that head a different expansion/different
   // signature/different implementation.
+  //
+  // Likewise, a file-private/private type in the layout is only metadata-
+  // accessible from its defining file, so the collected metadata signature (and
+  // body) differs between that file and any other, which would otherwise merge
+  // under the shared mangled name. In both cases, fall back to per-file private
+  // linkage so each file gets its own self-consistent copy.
   if (getTypeProperties(T, TypeExpansionContext::minimal())
-        .isTypeExpansionSensitive()) {
+          .isTypeExpansionSensitive() ||
+      collector.signatureDependsOnFilePrivateType()) {
     linkage = &privateLinkage;
   }
 
@@ -577,8 +598,15 @@ llvm::Constant *IRGenModule::getOrCreateOutlinedDestroyFunction(
   // The default hidden linkonce_odr might lead to linking an implementation
   // from another file that head a different expansion/different
   // signature/different implementation.
+  //
+  // Likewise, a file-private/private type in the layout is only metadata-
+  // accessible from its defining file, so the collected metadata signature (and
+  // body) differs between that file and any other, which would otherwise merge
+  // under the shared mangled name. In both cases, fall back to per-file
+  // private linkage so each file gets its own self-consistent copy.
   if (getTypeProperties(T, TypeExpansionContext::minimal())
-        .isTypeExpansionSensitive()) {
+          .isTypeExpansionSensitive() ||
+      collector.signatureDependsOnFilePrivateType()) {
     linkage = &privateLinkage;
   }
 

--- a/lib/IRGen/Outlining.h
+++ b/lib/IRGen/Outlining.h
@@ -116,6 +116,18 @@ public:
                                  Explosion &params) const;
   void materialize();
 
+  /// Whether the collected metadata (and therefore the outlined function's
+  /// signature/body) depends on a type whose metadata is only accessible from
+  /// its defining file -- i.e. a file-private/private nominal.  Such a function
+  /// must not be shared across files via linkonce_odr, because the defining
+  /// file can access the private type's metadata (and inline using it) while
+  /// other files fall back to the enclosing type's value witness, producing a
+  /// different signature under the same mangled name.  See
+  /// getOrCreateOutlined{Destroy,CopyAddrHelper}Function.
+  bool signatureDependsOnFilePrivateType() const {
+    return SignatureDependsOnFilePrivateType;
+  }
+
 private:
   void collectTypeMetadataForLayout(SILType ty);
   void collectTypeMetadataForDeinit(SILType ty);
@@ -300,6 +312,7 @@ private:
     }
   };
   State state;
+  bool SignatureDependsOnFilePrivateType = false;
   bool hasFinished() const {
     return state == State::Kind::Empty || state == State::Kind::Collected;
   }

--- a/test/IRGen/enum_resilience.swift
+++ b/test/IRGen/enum_resilience.swift
@@ -372,5 +372,9 @@ private enum ProtGenEnumWithSize<T: Prot> {
     case c2(s2: Size)
 }
 
-// CHECK-LABEL: define linkonce_odr hidden ptr @"$s15enum_resilience19ProtGenEnumWithSize33_59077B69D65A4A3BEE0C93708067D5F0LLOyxGAA0C0RzlWOh"(ptr
+// The outlined destroy of a file-private generic enum uses per-file private
+// linkage (not shared linkonce_odr): the enum's metadata is only accessible
+// from its defining file, so the collected signature would otherwise differ
+// across files under the same mangled name (rdar://176512369).
+// CHECK-LABEL: define private ptr @"$s15enum_resilience19ProtGenEnumWithSize33_59077B69D65A4A3BEE0C93708067D5F0LLOyxGAA0C0RzlWOh"(ptr
 // CHECK:   ret ptr %0

--- a/test/IRGen/private_nested_enum_outlined_destroy.swift
+++ b/test/IRGen/private_nested_enum_outlined_destroy.swift
@@ -1,0 +1,82 @@
+// RUN: %target-swift-frontend -emit-ir %s -module-name test -enable-library-evolution -Onone | %FileCheck %s
+
+// rdar://176512369: The outlined destroy of a type whose layout contains a
+// file-private nested type (here Entry.Target) must use per-file `private`
+// linkage rather than shared `linkonce_odr`.
+//
+// Only this file can access Target's metadata, so here the helper is emitted
+// with an extra Target-metadata parameter and inlines the enum destroy using
+// it. A different file cannot access Target, treats it as non-ABI-accessible,
+// and emits a differently-shaped helper that falls back to the enclosing type's
+// value witness. Sharing one mangled symbol between those two signatures let a
+// caller pass Entry's struct metadata where Target's enum metadata was expected
+// -> swift_getEnumCaseMultiPayload misread -> crash. Per-file private linkage
+// keeps each file's copy self-consistent.
+
+// CHECK: define private ptr @"$s4test5EntryVyxGSglWOh"(
+// CHECK-SAME: %"Entry<Value>.Target"
+
+// Conversely, when the nested type is only *internal* its metadata is
+// accessible module-wide, so every file collects the same signature and the
+// outlined destroy stays shared linkonce_odr.  This pins that the change above
+// is scoped to file-private types.
+// CHECK: define linkonce_odr hidden ptr @"$s4test9OpenEntryVyxGSglWOh"(
+// CHECK-SAME: %"OpenEntry<Value>.Target"
+
+public final class C1 { public init() {} }
+public final class C2 { public init() {} }
+
+public struct Entry<Value> {
+  fileprivate enum Target {
+    case a(C1, C2)
+    case b(Value)
+  }
+  var value: Value
+  fileprivate var target: Target
+  public init(_ value: Value, _ c1: C1, _ c2: C2) {
+    self.value = value
+    self.target = .a(c1, c2)
+  }
+  public var first: C1? {
+    switch target { case .a(let c, _): return c; default: return nil }
+  }
+}
+
+public final class Location<Value> {
+  var entries: [Entry<Value>]
+  public init(_ e: [Entry<Value>]) { entries = e }
+  // Destroys an Optional<Entry<Value>> in this file, forcing emission of the
+  // outlined destroy helper whose linkage the CHECK above pins down.
+  func firstFocused() -> Entry<Value>? {
+    var m: Entry<Value>? = nil
+    for e in entries { if e.first != nil { m = e; break } }
+    return m
+  }
+}
+
+// Control: same shape but with an *internal* (not file-private) nested enum.
+public struct OpenEntry<Value> {
+  enum Target {
+    case a(C1, C2)
+    case b(Value)
+  }
+  var value: Value
+  var target: Target
+  public init(_ value: Value, _ c1: C1, _ c2: C2) {
+    self.value = value
+    self.target = .a(c1, c2)
+  }
+  public var first: C1? {
+    switch target { case .a(let c, _): return c; default: return nil }
+  }
+}
+
+public final class OpenLocation<Value> {
+  var entries: [OpenEntry<Value>]
+  public init(_ e: [OpenEntry<Value>]) { entries = e }
+  func firstFocused() -> OpenEntry<Value>? {
+    var m: OpenEntry<Value>? = nil
+    for e in entries { if e.first != nil { m = e; break } }
+    return m
+  }
+}


### PR DESCRIPTION
We may generate a different body for these functions when their type references a file-private type, depending on whether the file-private type is in the same file or not. We must not coalesce one in the same file with ones in other files, so the one in the same file shouldn't be linkonce_odr.

rdar://176512369