### PR TITLE
[6.4][Sema] Check superclass Sendable conformance before diagnosing NonSen…

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7634,6 +7634,18 @@ bool swift::checkSendableConformance(
   if (classDecl && classDecl->getParentSourceFile()) {
     bool isInherited = isa<InheritedProtocolConformance>(conformance);
 
+    // Workaround: the conformance lookup table may not form an
+    // InheritedProtocolConformance for Sendable when the superclass is
+    // Sendable through @MainActor isolation (the table fix is #90251).
+    // Check the superclass directly so we don't misdiagnose.
+    if (!isInherited) {
+      if (auto superclassTy = classDecl->getSuperclass()) {
+        auto superConf = lookupConformance(superclassTy,
+            conformance->getProtocol(), /*allowMissing=*/false);
+        isInherited = superConf.isConcrete();
+      }
+    }
+
     // A non-final class cannot conform to `Sendable` unless it is protected by
     // global actor isolation.
     if (!classDecl->isSemanticallyFinal() && !isGlobalActorIsolated) {

--- a/test/Concurrency/nonsendable_superclass_objc.swift
+++ b/test/Concurrency/nonsendable_superclass_objc.swift
@@ -1,0 +1,172 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/src)
+// RUN: %empty-directory(%t/sdk)
+// RUN: %empty-directory(%t/sdk/ObjCActorModule)
+// RUN: split-file %s %t/src
+
+// Build ObjC module
+// RUN: %target-clang -fmodules -dynamiclib %t/src/ObjCActorModule.m -I %t/src -o %t/sdk/ObjCActorModule/libObjCActorModule.dylib -lobjc -framework Foundation
+// RUN: cp %t/src/ObjCActorModule.modulemap %t/sdk/ObjCActorModule/module.modulemap
+// RUN: cp %t/src/ObjCActorModule.h %t/sdk/ObjCActorModule/ObjCActorModule.h
+
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -strict-concurrency=complete %t/src/main.swift -emit-sil -o /dev/null -verify -I %t/sdk/ObjCActorModule
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %t/src/main.swift -emit-sil -o /dev/null -verify -verify-additional-prefix swift6- -swift-version 6 -I %t/sdk/ObjCActorModule
+
+// REQUIRES: concurrency
+// REQUIRES: objc_interop
+
+//--- ObjCActorModule.modulemap
+
+module ObjCActorModule {
+  header "ObjCActorModule.h"
+  export *
+}
+
+//--- ObjCActorModule.h
+
+#import <Foundation/Foundation.h>
+
+// Models the UIKit chain: NSObject -> @MainActor UIResponder -> @MainActor UIViewController/UIView
+// The entire chain is @MainActor-isolated with a Sendable root (NSObject).
+
+__attribute__((swift_attr("@MainActor")))
+@interface ObjCResponder : NSObject
+@end
+
+__attribute__((swift_attr("@MainActor")))
+@interface ObjCController : ObjCResponder
+@end
+
+__attribute__((swift_attr("@MainActor")))
+@interface ObjCView : ObjCResponder
+@end
+
+//--- ObjCActorModule.m
+
+#import "ObjCActorModule.h"
+
+@implementation ObjCResponder
+@end
+
+@implementation ObjCController
+@end
+
+@implementation ObjCView
+@end
+
+//--- main.swift
+
+import ObjCActorModule
+
+// ============================================================================
+// Implied Sendable through protocol refinement
+// ============================================================================
+//
+// When Sendable comes through a protocol (e.g. MyDelegate: Sendable),
+// the conformance table builds it as Implied -> NormalProtocolConformance
+// because the superclass's implicit Sendable from @MainActor wasn't in
+// the table yet when the Inherited stage ran.
+//
+// The protocol conformance must be checked BEFORE any code that would
+// trigger eager Sendable derivation on ObjCController (e.g. a
+// requiresSendable() call), because early derivation masks the bug by
+// materializing an InheritedProtocolConformance.
+
+protocol MyDelegate: Sendable {
+  func didDoThing()
+}
+
+@MainActor
+final class MyDelegateController: ObjCController {}
+
+extension MyDelegateController: @preconcurrency MyDelegate {
+  func didDoThing() {}
+}
+
+@MainActor
+protocol MyIsolatedDelegate: Sendable {
+  func didDoThing()
+}
+
+@MainActor
+final class MyIsolatedDelegateController: ObjCController, MyIsolatedDelegate {
+  func didDoThing() {}
+}
+
+// ============================================================================
+// Explicit Sendable on @MainActor classes with @MainActor ObjC superclasses
+// ============================================================================
+//
+// Real-world pattern: @MainActor final classes that inherit from UIView or
+// UIViewController (modeled here as ObjCView / ObjCController) and explicitly
+// declare Sendable. The superclass chain is @MainActor all the way down to
+// NSObject, so the superclass IS Sendable. No diagnostic should fire.
+
+@MainActor
+final class ExplicitSendableView: ObjCView, Sendable {}
+
+@MainActor
+final class ExplicitSendableController: ObjCController, Sendable {}
+
+// Public @MainActor view subclass with explicit Sendable, matching the
+// pattern of public UI component views.
+@MainActor
+public final class PublicExplicitSendableView: ObjCView, Sendable {}
+
+// ============================================================================
+// Non-final @MainActor classes with explicit Sendable
+// ============================================================================
+//
+// A non-final @MainActor class with a Sendable superclass chain is
+// still valid: subclasses inherit @MainActor isolation, so they can't
+// add unsynchronized state. The non-final restriction only applies to
+// non-isolated classes.
+
+@MainActor
+class NonFinalExplicitSendableController: ObjCController, Sendable {}
+
+// ============================================================================
+// Implicit Sendable (no explicit annotation)
+// ============================================================================
+//
+// ObjC defines:
+//   @MainActor ObjCResponder : NSObject
+//   @MainActor ObjCController : ObjCResponder
+//   @MainActor ObjCView : ObjCResponder
+//
+// Swift subclasses inherit @MainActor isolation and should be implicitly
+// Sendable with no diagnostic.
+
+class MyController: ObjCController {} // no diagnostic expected
+class MyView: ObjCView {} // no diagnostic expected
+
+// ============================================================================
+// Verify all of the above are usable as Sendable
+// ============================================================================
+
+func requiresSendable<T: Sendable>(_: T) {}
+func testObjCChainIsSendable(
+  _ r: ObjCResponder,
+  _ c: ObjCController,
+  _ v: ObjCView,
+  _ mc: MyController,
+  _ mv: MyView,
+  _ dc: MyDelegateController,
+  _ ic: MyIsolatedDelegateController,
+  _ ec: ExplicitSendableController,
+  _ ev: ExplicitSendableView,
+  _ pv: PublicExplicitSendableView,
+  _ nf: NonFinalExplicitSendableController
+) {
+  requiresSendable(r)
+  requiresSendable(c)
+  requiresSendable(v)
+  requiresSendable(mc)
+  requiresSendable(mv)
+  requiresSendable(dc)
+  requiresSendable(ic)
+  requiresSendable(ec)
+  requiresSendable(ev)
+  requiresSendable(pv)
+  requiresSendable(nf)
+}


### PR DESCRIPTION
  - **Explanation**: 
    When a class declares `Sendable` (explicitly or through a protocol refinement), `checkSendableConformance` checks whether the conformance is `InheritedProtocolConformance` to decide if the superclass is Sendable. However, the conformance lookup table
  may not form an `InheritedProtocolConformance` for Sendable when the superclass is Sendable through `@MainActor` isolation, due to ordering in the table. This causes false `concurrent_value_nonsendable_superclass` diagnostics on classes like
  `@MainActor final class Foo: UIView, Sendable`.

    This fix adds a `lookupConformance` check on the superclass to update `isInherited` before the diagnostic site. If the superclass concretely conforms to `Sendable`, the conformance is treated as inherited and the diagnostic is suppressed.

  - **Scope**:
    Diagnostic-only change. No effect on code generation, ABI, or runtime behavior. Suppresses false warnings that become build failures under `-warnings-as-errors`. Cannot break existing code; only suppresses diagnostics that should not have fired.

  - **Issues**: rdar://182129282

  - **Original PRs**:
    https://github.com/swiftlang/swift/pull/90631

  - **Risk**:
    Low. The change adds a single `lookupConformance` guard before an existing diagnostic. The conformance table fix (#90251) targets main separately. This is a targeted workaround for 6.4 that does not change the conformance representation.

  - **Testing**:
    - New test `nonsendable_superclass_objc.swift`: cross-module test modeling the UIKit chain (`NSObject -> @MainActor ObjCResponder -> @MainActor ObjCController/ObjCView`) with 8 patterns covering implied, explicit final, explicit non-final, and
  implicit Sendable
    - All patterns verified under both `-strict-concurrency=complete` and Swift 6 mode
    - Existing test `sendable_conformance_checking_cross_file_isolated_objc.swift` passes without modification

  - **Reviewers**:
    @xedin reviewing on #90631