### PR TITLE
AST: Represent deprecation as a kind of `AvailabilityRestriction`

### DIFF
--- a/include/swift/AST/AvailabilityContext.h
+++ b/include/swift/AST/AvailabilityContext.h
@@ -137,6 +137,14 @@ public:
   restrictionForDecl(const Decl *decl,
                      AvailabilityRestrictionFlags flags = std::nullopt);
 
+  /// Returns the strongest availability restriction that must be satisfied to
+  /// use \p decl from this context, or nullopt if there is no such
+  /// restriction. Unlike `restrictionForDecl()`, deprecation restrictions are
+  /// not returned since deprecation does not prevent use of a declaration.
+  std::optional<AvailabilityRestriction>
+  unsatisfiedRestrictionForDecl(
+      const Decl *decl, AvailabilityRestrictionFlags flags = std::nullopt);
+
   /// Returns the availability restriction in \p domain that limits use of \p
   /// decl from this context, or nullopt if use of \p decl is not restricted.
   std::optional<AvailabilityRestriction>

--- a/include/swift/AST/AvailabilityRestriction.h
+++ b/include/swift/AST/AvailabilityRestriction.h
@@ -121,10 +121,16 @@ public:
     /// attribute or an `if #available(...)` query with sufficient introduction
     /// restrictions to the context.
     Unintroduced,
+
+    /// The declaration is deprecated, e.g. because of
+    /// `@available(macOS, deprecated: 12.0)`. Unlike the other reasons, a
+    /// deprecation restriction does not prevent use of the declaration; it
+    /// only causes a warning to be emitted.
+    Deprecated,
   };
 
 private:
-  llvm::PointerIntPair<SemanticAvailableAttr, 2, Reason> attrAndReason;
+  llvm::PointerIntPair<SemanticAvailableAttr, 3, Reason> attrAndReason;
 
   AvailabilityRestriction(Reason reason, SemanticAvailableAttr attr)
       : attrAndReason(attr, reason) {};
@@ -149,6 +155,10 @@ public:
     return AvailabilityRestriction(Reason::Unintroduced, attr);
   }
 
+  static AvailabilityRestriction deprecated(SemanticAvailableAttr attr) {
+    return AvailabilityRestriction(Reason::Deprecated, attr);
+  }
+
   Reason getReason() const { return attrAndReason.getInt(); }
   SemanticAvailableAttr getAttr() const {
     return static_cast<SemanticAvailableAttr>(attrAndReason.getPointer());
@@ -163,9 +173,13 @@ public:
     case Reason::UnavailableUnintroduced:
       return true;
     case Reason::Unintroduced:
+    case Reason::Deprecated:
       return false;
     }
   }
+
+  /// Returns true if the restriction represents deprecation of the declaration.
+  bool isDeprecated() const { return getReason() == Reason::Deprecated; }
 
   /// Returns the domain that the restriction applies to.
   AvailabilityDomain getDomain() const { return getAttr().getDomain(); }
@@ -228,6 +242,10 @@ enum class AvailabilityRestrictionFlag : uint8_t {
   /// is also universally unavailable. If this flag is set, though, those
   /// references are allowed.
   AllowUniversallyUnavailableInCompatibleContexts = 1 << 2,
+
+  /// Return restrictions for `@available` attributes indicating deprecation in
+  /// a future deployment target.
+  IncludeSoftDeprecation = 1 << 3,
 };
 using AvailabilityRestrictionFlags = OptionSet<AvailabilityRestrictionFlag>;
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1389,6 +1389,13 @@ public:
     return getClangNodeImpl().getAsMacro();
   }
 
+  /// Returns true if there is a Clang decl from which this declaration was
+  /// synthesized and that declaration was annotated as deprecated. This is
+  /// useful for distinguishing whether the source declaration was deprecated
+  /// independently of the availability of imported Swift declaration, which
+  /// may be different according to ClangImporter rules.
+  bool isClangDeclDeprecated() const;
+
   /// If this is the Swift implementation of a declaration imported from ObjC,
   /// returns the imported declaration. (If there are several, only the main
   /// class body will be returned.) Otherwise return \c nullptr.

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -331,51 +331,24 @@ Decl::getActiveAvailableAttrForCurrentPlatform() const {
 }
 
 std::optional<SemanticAvailableAttr> Decl::getDeprecatedAttr() const {
-  auto &ctx = getASTContext();
-  std::optional<SemanticAvailableAttr> result;
-  auto bestActive = getActiveAvailableAttrForCurrentPlatform();
-
-  for (auto attr : getSemanticAvailableAttrs(/*includingInactive=*/false)) {
-    if (attr.isPlatformSpecific() && (!bestActive || attr != bestActive))
-      continue;
-
-    // Unconditional deprecated.
-    if (attr.isUnconditionallyDeprecated())
-      return attr;
-
-    auto deprecatedRange = attr.getDeprecatedRange(ctx);
-    if (!deprecatedRange)
-      continue;
-
-    // We treat the declaration as deprecated if it is deprecated on
-    // all deployment targets.
-    auto deploymentRange = attr.getDomain().getDeploymentRange(ctx);
-    if (deploymentRange && deploymentRange->isContainedIn(*deprecatedRange))
-      result.emplace(attr);
+  auto context = AvailabilityContext::forDeploymentTarget(getASTContext());
+  if (auto restriction = context.restrictionForDecl(this)) {
+    if (restriction->isDeprecated())
+      return restriction->getAttr();
   }
-  return result;
+
+  return std::nullopt;
 }
 
 std::optional<SemanticAvailableAttr> Decl::getSoftDeprecatedAttr() const {
-  auto &ctx = getASTContext();
-  std::optional<SemanticAvailableAttr> result;
-  auto bestActive = getActiveAvailableAttrForCurrentPlatform();
-
-  for (auto attr : getSemanticAvailableAttrs(/*includingInactive=*/false)) {
-    if (attr.isPlatformSpecific() && (!bestActive || attr != bestActive))
-      continue;
-
-    auto deprecatedRange = attr.getDeprecatedRange(ctx);
-    if (!deprecatedRange)
-      continue;
-
-    // We treat the declaration as soft-deprecated if it is deprecated in a
-    // future version.
-    auto deploymentRange = attr.getDomain().getDeploymentRange(ctx);
-    if (!deploymentRange || !deploymentRange->isContainedIn(*deprecatedRange))
-      result.emplace(attr);
+  auto context = AvailabilityContext::forDeploymentTarget(getASTContext());
+  if (auto restriction = context.restrictionForDecl(
+          this, AvailabilityRestrictionFlag::IncludeSoftDeprecation)) {
+    if (restriction->isDeprecated())
+      return restriction->getAttr();
   }
-  return result;
+
+  return std::nullopt;
 }
 
 std::optional<SemanticAvailableAttr> Decl::getNoAsyncAttr() const {

--- a/lib/AST/AvailabilityContext.cpp
+++ b/lib/AST/AvailabilityContext.cpp
@@ -365,7 +365,6 @@ void AvailabilityContext::constrainWithDeclAndPlatformRange(
   bool isConstrained = false;
   auto platformRange = storage->platformRange;
   bool isDeprecated = storage->isDeprecated;
-  isConstrained |= constrainBool(isDeprecated, decl->isDeprecated());
 
   // Compute the availability restrictions for the decl when used in this
   // context and then map those restrictions to domain infos. The result will
@@ -391,6 +390,9 @@ void AvailabilityContext::constrainWithDeclAndPlatformRange(
           declDomainInfos.push_back({domain, *introducedRange});
         }
       }
+      break;
+    case AvailabilityRestriction::Reason::Deprecated:
+      isConstrained |= constrainBool(isDeprecated, true);
       break;
     }
   }
@@ -437,6 +439,15 @@ AvailabilityContext::restrictionForDecl(const Decl *decl,
 }
 
 std::optional<AvailabilityRestriction>
+AvailabilityContext::unsatisfiedRestrictionForDecl(
+    const Decl *decl, AvailabilityRestrictionFlags flags) {
+  auto restriction = restrictionForDecl(decl, flags);
+  if (restriction && restriction->isDeprecated())
+    return std::nullopt;
+  return restriction;
+}
+
+std::optional<AvailabilityRestriction>
 AvailabilityContext::restrictionForDeclInDomain(
     const Decl *decl, AvailabilityDomain domain,
     AvailabilityRestrictionFlags flags) {
@@ -473,6 +484,20 @@ static bool restrictionIsStronger(const AvailabilityRestriction &lhs,
     // Pick the smaller introduced range.
     return lhs.getAttr().getIntroduced().value_or(llvm::VersionTuple()) >
            rhs.getAttr().getIntroduced().value_or(llvm::VersionTuple());
+
+  case AvailabilityRestriction::Reason::Deprecated:
+    // Prefer an unconditionally deprecation attribute over one that specifies a
+    // version. If both are unconditionally deprecated keep the first. If both
+    // specify a version, pick the earlier version. Fall back to last-wins.
+    if (lhs.getAttr().isUnconditionallyDeprecated() &&
+        rhs.getAttr().isUnconditionallyDeprecated())
+      return false;
+    if (lhs.getAttr().isUnconditionallyDeprecated())
+      return true;
+    if (rhs.getAttr().isUnconditionallyDeprecated())
+      return false;
+    return lhs.getAttr().getDeprecated().value() <
+           rhs.getAttr().getDeprecated().value();
   }
 }
 

--- a/lib/AST/AvailabilityDomain.cpp
+++ b/lib/AST/AvailabilityDomain.cpp
@@ -12,6 +12,7 @@
 
 #include "swift/AST/AvailabilityDomain.h"
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/AvailabilityContext.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/Module.h"
@@ -557,15 +558,12 @@ bool IsCustomAvailabilityDomainPermanentlyEnabled::evaluate(
   if (!domainDecl)
     return false;
 
-  if (auto deprecatedAttr = domainDecl->getDeprecatedAttr()) {
-    if (deprecatedAttr->getDomain().isUniversal())
-      return true;
-  }
-
-  if (auto unavailableAttr = domainDecl->getUnavailableAttr()) {
-    if (unavailableAttr->getDomain().isUniversal())
-      return true;
-  }
+  auto deploymentAvailability =
+      AvailabilityContext::forDeploymentTarget(domainDecl->getASTContext());
+  auto restriction = deploymentAvailability.restrictionForDecl(domainDecl);
+  if (restriction)
+    if (restriction->isUnavailable() || restriction->isDeprecated())
+      return restriction->getDomain().isUniversal();
 
   return false;
 }

--- a/lib/AST/AvailabilityRestriction.cpp
+++ b/lib/AST/AvailabilityRestriction.cpp
@@ -26,6 +26,8 @@ AvailabilityRestriction::getDomainAndRange(const ASTContext &ctx) const {
   case Reason::UnavailableUnintroduced:
   case Reason::Unintroduced:
     return getAttr().getIntroducedDomainAndRange(ctx).value();
+  case Reason::Deprecated:
+    return getAttr().getDeprecatedDomainAndRange(ctx).value();
   }
 }
 
@@ -43,6 +45,9 @@ AvailabilityRestriction::getFixItDomainAndRange(const ASTContext &ctx) const {
     case Reason::Unintroduced:
       return AvailabilityDomainAndRange(
           attrDomain, AvailabilityRange(getAttr().getIntroduced().value()));
+    case Reason::Deprecated:
+      return AvailabilityDomainAndRange(
+          attrDomain, AvailabilityRange(getAttr().getDeprecated().value()));
     }
   }
   return getDomainAndRange(ctx);
@@ -76,6 +81,10 @@ void AvailabilityRestriction::print(llvm::raw_ostream &os) const {
   case Reason::Unintroduced:
     os << "introduced";
     version = getAttr().getIntroduced();
+    break;
+  case Reason::Deprecated:
+    os << "deprecated";
+    version = getAttr().getDeprecated();
     break;
   }
 
@@ -152,6 +161,11 @@ static bool canIgnoreRestrictionInUnavailableContexts(
   case AvailabilityRestriction::Reason::UnavailableObsolete:
   case AvailabilityRestriction::Reason::UnavailableUnintroduced:
     return domain.isVersioned();
+
+  case AvailabilityRestriction::Reason::Deprecated:
+    // Filtering of deprecation restrictions is done by
+    // getDeprecationRestrictionForAttr().
+    return false;
   }
 }
 
@@ -178,6 +192,44 @@ shouldIgnoreRestrictionInContext(const Decl *decl,
     domain = targetDomain;
 
   return context.isUnavailableForDomain(domain);
+}
+
+static std::optional<AvailabilityRestriction>
+getDeprecationRestrictionForAttr(const Decl *decl,
+                                 const SemanticAvailableAttr &attr,
+                                 const AvailabilityContext &context,
+                                 std::optional<AvailabilityRange> availableRange,
+                                 const AvailabilityRestrictionFlags flags) {
+  bool includeSoftDeprecation =
+      flags.contains(AvailabilityRestrictionFlag::IncludeSoftDeprecation);
+
+  if (context.isDeprecated())
+    return std::nullopt;
+
+  if (context.isUnavailable() && isa<TypeDecl>(decl))
+    return std::nullopt;
+
+  // Don't diagnose deprecation in contexts that are unreachable for the
+  // deprecated domain.
+  if (availableRange && availableRange->isKnownUnreachable())
+    return std::nullopt;
+
+  if (attr.isUnconditionallyDeprecated())
+    return AvailabilityRestriction::deprecated(attr);
+
+  auto &ctx = decl->getASTContext();
+  if (auto deprecatedRange = attr.getDeprecatedRange(ctx)) {
+    // When IncludeSoftDeprecation is specified, decls deprecated in a future
+    // deployment target are diagnosed too.
+    if (includeSoftDeprecation)
+      return AvailabilityRestriction::deprecated(attr);
+
+    auto deploymentRange = attr.getDomain().getDeploymentRange(ctx);
+    if (deploymentRange && deploymentRange->isContainedIn(*deprecatedRange))
+      return AvailabilityRestriction::deprecated(attr);
+  }
+
+  return std::nullopt;
 }
 
 std::optional<AvailabilityRestriction> swift::getAvailabilityRestrictionForAttr(
@@ -215,6 +267,11 @@ std::optional<AvailabilityRestriction> swift::getAvailabilityRestrictionForAttr(
                    ? AvailabilityRestriction::unintroduced(attr)
                    : AvailabilityRestriction::unavailableUnintroduced(attr);
     }
+
+    // Is the decl deprecated in this context?
+    if (auto deprecation = getDeprecationRestrictionForAttr(
+            decl, attr, context, availableRange, flags))
+      return deprecation;
 
     return std::nullopt;
   };
@@ -298,6 +355,7 @@ static bool restrictionIndicatesRuntimeUnavailability(
     return domainCanBeUnconditionallyUnavailableAtRuntime(domain, ctx);
   case AvailabilityRestriction::Reason::UnavailableObsolete:
   case AvailabilityRestriction::Reason::UnavailableUnintroduced:
+  case AvailabilityRestriction::Reason::Deprecated:
     return false;
   case AvailabilityRestriction::Reason::Unintroduced:
     return domainIsUnavailableAtRuntimeIfUnintroduced(domain, ctx);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -12779,6 +12779,13 @@ void Decl::setClangNode(ClangNode Node) {
   *(ptr - 1) = Node.getOpaqueValue();
 }
 
+bool Decl::isClangDeclDeprecated() const {
+  if (const clang::Decl *decl = getClangDecl())
+    return decl->isDeprecated();
+
+  return false;
+}
+
 // See swift/Basic/Statistic.h for declaration: this enables tracing Decls, is
 // defined here to avoid too much layering violation / circular linkage
 // dependency.

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -1838,5 +1838,5 @@ bool DeclContext::isAlwaysAvailableConformanceContext() const {
   // target.
   auto &ctx = getASTContext();
   auto deploymentTarget = AvailabilityContext::forDeploymentTarget(ctx);
-  return !deploymentTarget.restrictionForDecl(ext);
+  return !deploymentTarget.unsatisfiedRestrictionForDecl(ext);
 }

--- a/lib/AST/ProtocolConformanceRef.cpp
+++ b/lib/AST/ProtocolConformanceRef.cpp
@@ -416,12 +416,13 @@ ProtocolConformanceRef::getAvailabilityRestriction(DeclContext *dc,
   // involve due to source compatibility exceptions. Thus, it is important to
   // verify that neither pose a restriction in the given context when checking
   // for availability of a conformance.
-  if (auto restriction = availability.restrictionForDecl(getProtocol()))
+  if (auto restriction =
+          availability.unsatisfiedRestrictionForDecl(getProtocol()))
     return restriction;
 
   auto *conformanceDC = getConcrete()->getRootConformance()->getDeclContext();
-  if (auto restriction =
-          availability.restrictionForDecl(conformanceDC->getAsDecl()))
+  if (auto restriction = availability.unsatisfiedRestrictionForDecl(
+          conformanceDC->getAsDecl()))
     return restriction;
 
   return std::nullopt;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -4410,6 +4410,7 @@ findImportedCaseWithMatchingSuffix(Type instanceTy, DeclNameRef name) {
     // Is one more available than the other?
     WORSE(->isUnavailable());
     WORSE(->isDeprecated());
+    WORSE(->isClangDeclDeprecated());
 
     // Does one have a shorter name (so the non-matching prefix is shorter)?
     WORSE(->getName().getBaseName().userFacingName().size());

--- a/lib/Sema/DerivedConformance/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceRawRepresentable.cpp
@@ -243,7 +243,7 @@ checkAvailability(const EnumElementDecl *elt,
                   AvailabilityContext availabilityContext,
                   std::optional<RuntimeVersionCheck> &versionCheck) {
   auto &C = elt->getASTContext();
-  auto restriction = availabilityContext.restrictionForDecl(elt);
+  auto restriction = availabilityContext.unsatisfiedRestrictionForDecl(elt);
 
   // Is it always available?
   if (!restriction)

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2247,6 +2247,7 @@ getSemanticAvailableRangeDeclAndAttr(const Decl *decl,
     switch (restriction->getReason()) {
     case AvailabilityRestriction::Reason::UnavailableUnconditionally:
     case AvailabilityRestriction::Reason::UnavailableObsolete:
+    case AvailabilityRestriction::Reason::Deprecated:
       break;
     case AvailabilityRestriction::Reason::UnavailableUnintroduced:
     case AvailabilityRestriction::Reason::Unintroduced:
@@ -5647,7 +5648,8 @@ void AttributeChecker::checkAvailableAttrs(ArrayRef<AvailableAttr *> attrs) {
     availabilityContext.constrainWithContext(parentAvailability, Ctx);
   }
 
-  auto availabilityRestriction = availabilityContext.restrictionForDecl(D);
+  auto availabilityRestriction =
+      availabilityContext.unsatisfiedRestrictionForDecl(D);
   if (!availabilityRestriction)
     return;
 

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1195,30 +1195,6 @@ static bool diagnosePotentialUnavailability(
   return true;
 }
 
-/// Returns the availability attribute indicating deprecation of the
-/// declaration is deprecated or null otherwise.
-static std::optional<SemanticAvailableAttr> getDeprecated(const Decl *D) {
-  auto &Ctx = D->getASTContext();
-  if (auto Attr = D->getDeprecatedAttr())
-    return Attr;
-
-  if (Ctx.LangOpts.WarnSoftDeprecated) {
-    // When -warn-soft-deprecated is specified, treat any declaration that is
-    // deprecated in the future as deprecated.
-    if (auto Attr = D->getSoftDeprecatedAttr())
-      return Attr;
-  }
-
-  // Treat extensions methods as deprecated if their extension
-  // is deprecated.
-  DeclContext *DC = D->getDeclContext();
-  if (auto *ED = dyn_cast<ExtensionDecl>(DC)) {
-    return getDeprecated(ED);
-  }
-
-  return std::nullopt;
-}
-
 static void fixItAvailableAttrRename(InFlightDiagnostic &diag,
                                      SourceRange referenceRange,
                                      const ValueDecl *renamedDecl,
@@ -1648,84 +1624,63 @@ describeRename(ASTContext &ctx, StringRef newName, const ValueDecl *D,
 }
 
 /// Emits a diagnostic for a reference to a declaration that is deprecated.
-static void diagnoseIfDeprecated(SourceRange ReferenceRange,
-                                 const ExportContext &Where,
-                                 const ValueDecl *DeprecatedDecl,
-                                 const Expr *Call) {
-  auto Attr = getDeprecated(DeprecatedDecl);
-  if (!Attr)
+static void diagnoseIfDeprecated(SourceRange referenceRange,
+                                 const ExportContext &where,
+                                 const ValueDecl *decl,
+                                 const AvailabilityRestriction &restriction,
+                                 const Expr *call) {
+  if (!restriction.isDeprecated())
     return;
 
-  auto Availability = Where.getAvailability();
+  auto *referenceDC = where.getDeclContext();
+  auto &ctx = referenceDC->getASTContext();
 
-  // We match the behavior of clang to not report deprecation warnings
-  // inside declarations that are themselves deprecated on all deployment
-  // targets.
-  if (Availability.isDeprecated())
-    return;
-
-  // Skip diagnosing deprecated types in unavailable contexts.
-  if (Availability.isUnavailable() && isa<TypeDecl>(DeprecatedDecl))
-    return;
-
-  auto *ReferenceDC = Where.getDeclContext();
-  auto &Context = ReferenceDC->getASTContext();
-  if (!Context.LangOpts.DisableAvailabilityChecking) {
-    if (Availability.getPlatformRange().isKnownUnreachable()) {
-      // Suppress a deprecation warning if the availability checking machinery
-      // thinks the reference program location will not execute on any
-      // deployment target for the current platform.
-      return;
-    }
-  }
-
-  auto Domain = Attr->getDomain();
-  auto DeprecatedRange = Attr->getDeprecatedRange(Context).value();
-  auto Message = Attr->getMessage();
-  auto NewName = Attr->getRename();
-  if (Message.empty() && NewName.empty()) {
-    Context.Diags
-        .diagnose(ReferenceRange.Start, diag::availability_deprecated,
-                  DeprecatedDecl, Attr->isPlatformSpecific(), Domain,
-                  DeprecatedRange.hasMinimumVersion(), DeprecatedRange,
+  auto attr = restriction.getAttr();
+  auto domain = attr.getDomain();
+  auto deprecatedRange = attr.getDeprecatedRange(ctx).value();
+  auto message = attr.getMessage();
+  auto rawRename = attr.getRename();
+  if (message.empty() && rawRename.empty()) {
+    ctx.Diags
+        .diagnose(referenceRange.Start, diag::availability_deprecated,
+                  decl, attr.isPlatformSpecific(), domain,
+                  deprecatedRange.hasMinimumVersion(), deprecatedRange,
                   /*message*/ StringRef())
-        .highlight(Attr->getParsedAttr()->getRange());
+        .highlight(attr.getParsedAttr()->getRange());
     return;
   }
 
   SmallString<32> newNameBuf;
   std::optional<ReplacementDeclKind> replacementDeclKind =
-      describeRename(Context, NewName, DeprecatedDecl, newNameBuf);
-  std::string escapedFallback =
-      formatEscapedRename(Context, NewName, DeprecatedDecl);
+      describeRename(ctx, rawRename, decl, newNameBuf);
+  std::string escapedFallback = formatEscapedRename(ctx, rawRename, decl);
   StringRef newName = replacementDeclKind ? newNameBuf.str() : escapedFallback;
 
-  if (!Message.empty()) {
-    EncodedDiagnosticMessage EncodedMessage(Message);
-    Context.Diags
-        .diagnose(ReferenceRange.Start, diag::availability_deprecated,
-                  DeprecatedDecl, Attr->isPlatformSpecific(), Domain,
-                  DeprecatedRange.hasMinimumVersion(), DeprecatedRange,
+  if (!message.empty()) {
+    EncodedDiagnosticMessage EncodedMessage(message);
+    ctx.Diags
+        .diagnose(referenceRange.Start, diag::availability_deprecated,
+                  decl, attr.isPlatformSpecific(), domain,
+                  deprecatedRange.hasMinimumVersion(), deprecatedRange,
                   EncodedMessage.Message)
-        .highlight(Attr->getParsedAttr()->getRange());
+        .highlight(attr.getParsedAttr()->getRange());
   } else {
     unsigned rawReplaceKind = static_cast<unsigned>(
         replacementDeclKind.value_or(ReplacementDeclKind::None));
-    Context.Diags
-        .diagnose(ReferenceRange.Start, diag::availability_deprecated_rename,
-                  DeprecatedDecl, Attr->isPlatformSpecific(), Domain,
-                  DeprecatedRange.hasMinimumVersion(), DeprecatedRange,
+    ctx.Diags
+        .diagnose(referenceRange.Start, diag::availability_deprecated_rename,
+                  decl, attr.isPlatformSpecific(), domain,
+                  deprecatedRange.hasMinimumVersion(), deprecatedRange,
                   replacementDeclKind.has_value(), rawReplaceKind, newName)
-        .highlight(Attr->getParsedAttr()->getRange());
+        .highlight(attr.getParsedAttr()->getRange());
   }
 
-  if (!NewName.empty() && !isa<AccessorDecl>(DeprecatedDecl)) {
-    auto renameDiag = Context.Diags.diagnose(
-                               ReferenceRange.Start,
+  if (!rawRename.empty() && !isa<AccessorDecl>(decl)) {
+    auto renameDiag = ctx.Diags.diagnose(
+                               referenceRange.Start,
                                diag::note_deprecated_rename,
                                newName);
-    fixItAvailableAttrRename(renameDiag, ReferenceRange, DeprecatedDecl,
-                             NewName, Call);
+    fixItAvailableAttrRename(renameDiag, referenceRange, decl, rawRename, call);
   }
 }
 
@@ -1733,54 +1688,38 @@ static void diagnoseIfDeprecated(SourceRange ReferenceRange,
 static bool diagnoseIfDeprecated(SourceLoc loc,
                                  const RootProtocolConformance *rootConf,
                                  const ExtensionDecl *ext,
+                                 const AvailabilityRestriction &restriction,
                                  const ExportContext &where) {
-  auto attr = getDeprecated(ext);
-  if (!attr)
+  if (!restriction.isDeprecated())
     return false;
-
-  auto availability = where.getAvailability();
-
-  // We match the behavior of clang to not report deprecation warnings
-  // inside declarations that are themselves deprecated on all deployment
-  // targets.
-  if (availability.isDeprecated()) {
-    return false;
-  }
 
   auto *dc = where.getDeclContext();
   auto &ctx = dc->getASTContext();
-  if (!ctx.LangOpts.DisableAvailabilityChecking) {
-    if (availability.getPlatformRange().isKnownUnreachable()) {
-      // Suppress a deprecation warning if the availability checking machinery
-      // thinks the reference program location will not execute on any
-      // deployment target for the current platform.
-      return false;
-    }
-  }
 
   auto type = rootConf->getType();
   auto proto = rootConf->getProtocol()->getDeclaredInterfaceType();
 
-  auto domain = attr->getDomain();
-  auto deprecatedRange = attr->getDeprecatedRange(ctx).value();
-  auto message = attr->getMessage();
+  auto attr = restriction.getAttr();
+  auto domain = attr.getDomain();
+  auto deprecatedRange = attr.getDeprecatedRange(ctx).value();
+  auto message = attr.getMessage();
   if (message.empty()) {
     ctx.Diags
         .diagnose(loc, diag::conformance_availability_deprecated, type, proto,
-                  attr->isPlatformSpecific(), domain,
+                  attr.isPlatformSpecific(), domain,
                   deprecatedRange.hasMinimumVersion(), deprecatedRange,
                   /*message*/ StringRef())
-        .highlight(attr->getParsedAttr()->getRange());
+        .highlight(attr.getParsedAttr()->getRange());
     return true;
   }
 
   EncodedDiagnosticMessage encodedMessage(message);
   ctx.Diags
       .diagnose(loc, diag::conformance_availability_deprecated, type, proto,
-                attr->isPlatformSpecific(), domain,
+                attr.isPlatformSpecific(), domain,
                 deprecatedRange.hasMinimumVersion(), deprecatedRange,
                 encodedMessage.Message)
-      .highlight(attr->getParsedAttr()->getRange());
+      .highlight(attr.getParsedAttr()->getRange());
   return true;
 }
 
@@ -1801,7 +1740,7 @@ void swift::diagnoseOverrideOfUnavailableDecl(ValueDecl *override,
   // FIXME: [availability] Take an unsatisfied restriction as input instead of
   // recomputing it.
   ExportContext where = ExportContext::forDeclSignature(override);
-  auto restriction = where.getAvailability().restrictionForDecl(base);
+  auto restriction = where.getAvailability().unsatisfiedRestrictionForDecl(base);
   if (!restriction)
     return;
 
@@ -1869,6 +1808,7 @@ bool shouldHideDomainNameForRestrictionDiagnostic(
       return false;
     case AvailabilityRestriction::Reason::Unintroduced:
     case AvailabilityRestriction::Reason::UnavailableObsolete:
+    case AvailabilityRestriction::Reason::Deprecated:
       return true;
     }
   }
@@ -1929,6 +1869,7 @@ bool diagnoseExplicitUnavailability(SourceLoc loc,
         .highlight(attr.getParsedAttr()->getRange());
     break;
   case AvailabilityRestriction::Reason::Unintroduced:
+  case AvailabilityRestriction::Reason::Deprecated:
     llvm_unreachable("unexpected restriction");
   }
   return true;
@@ -1947,7 +1888,7 @@ swift::getUnsatisfiedAvailabilityRestriction(const Decl *decl,
         AllowUniversallyUnavailableInCompatibleContexts;
 
   return AvailabilityContext::forLocation(referenceLoc, referenceDC)
-      .restrictionForDecl(decl, flags);
+      .unsatisfiedRestrictionForDecl(decl, flags);
 }
 
 /// Check if this is a subscript declaration inside String or
@@ -2357,6 +2298,7 @@ bool diagnoseExplicitUnavailability(
         .highlight(sourceRange);
     break;
   case AvailabilityRestriction::Reason::Unintroduced:
+  case AvailabilityRestriction::Reason::Deprecated:
     llvm_unreachable("unexpected restriction");
     break;
   }
@@ -3134,40 +3076,14 @@ bool swift::diagnoseDeclAvailability(const ValueDecl *D, SourceRange R,
       return true;
   }
 
-  // Keep track if this is an accessor.
-  auto accessor = dyn_cast<AccessorDecl>(D);
-
-  if (accessor) {
-    // If the property/subscript is unconditionally unavailable, don't bother
-    // with any of the rest of this.
-    if (accessor->getStorage()->isUnavailable())
-      return false;
-  }
-
   auto *DC = Where.getDeclContext();
   auto &ctx = DC->getASTContext();
-
-  auto restriction = Where.getAvailability().restrictionForDecl(D);
-
-  if (restriction) {
-    if (diagnoseExplicitUnavailability(D, R, *restriction, Where, call, Flags))
-      return true;
-  }
 
   if (diagnoseDeclAsyncAvailability(D, R, call, Where))
     return true;
 
   if (!Flags.contains(DeclAvailabilityFlag::DisableUnsafeChecking))
     diagnoseDeclUnsafe(const_cast<ValueDecl *>(D), R, call, Where);
-
-  // Make sure not to diagnose an accessor's deprecation if we already
-  // complained about the property/subscript.
-  bool isAccessorWithDeprecatedStorage =
-      accessor && getDeprecated(accessor->getStorage());
-
-  // Diagnose for deprecation
-  if (!isAccessorWithDeprecatedStorage)
-    diagnoseIfDeprecated(R, Where, D, call);
 
   // A reference to a compatibility memberwise initializer should be diagnosed
   // as if it were deprecated if DeprecateCompatMemberwiseInit is enabled.
@@ -3178,14 +3094,50 @@ bool swift::diagnoseDeclAvailability(const ValueDecl *D, SourceRange R,
     }
   }
 
+  auto accessor = dyn_cast<AccessorDecl>(D);
+  AvailabilityRestrictionFlags restrictionFlags;
+  if (ctx.LangOpts.WarnSoftDeprecated)
+    restrictionFlags |= AvailabilityRestrictionFlag::IncludeSoftDeprecation;
+
+  auto getAvailabilityRestriction = [&](const Decl *decl) {
+    return Where.getAvailability().restrictionForDecl(decl, restrictionFlags);
+  };
+  auto restriction = getAvailabilityRestriction(D);
+  if (!restriction)
+    return false;
+
+  if (restriction->isUnavailable()) {
+    if (accessor) {
+      // Make sure not to diagnose an accessor's deprecation if we already
+      // complained about the property/subscript.
+      if (auto parentRestriction =
+              getAvailabilityRestriction(accessor->getStorage()))
+        if (parentRestriction->isUnavailable())
+          return false;
+    }
+    return diagnoseExplicitUnavailability(D, R, *restriction, Where, call,
+                                          Flags);
+  }
+
+  if (restriction->isDeprecated()) {
+    // Make sure not to diagnose an accessor's deprecation if we already
+    // complained about the property/subscript.
+    if (accessor) {
+      if (auto parentRestriction =
+              getAvailabilityRestriction(accessor->getStorage()))
+        if (parentRestriction->isDeprecated())
+          return false;
+    }
+
+    diagnoseIfDeprecated(R, Where, D, *restriction, call);
+    return false;
+  }
+
   if (Flags.contains(DeclAvailabilityFlag::AllowPotentiallyUnavailableProtocol)
         && isa<ProtocolDecl>(D))
     return false;
 
   // Diagnose (and possibly signal) for potential unavailability
-  if (!restriction || restriction->isUnavailable())
-    return false;
-
   auto domainAndRange = restriction->getDomainAndRange(ctx);
   auto fixItDomainAndRange = restriction->getFixItDomainAndRange(ctx);
   auto domain = domainAndRange.getDomain();
@@ -3492,6 +3444,41 @@ static void diagnoseMissingConformance(
                                                preconcurrency);
 }
 
+static bool diagnoseConformanceAvailabilityRestriction(
+    SourceLoc loc, const RootProtocolConformance *rootConf, ExtensionDecl *ext,
+    const AvailabilityRestriction &restriction, const ExportContext &where,
+    bool warnIfConformanceUnavailablePreSwift6, bool preconcurrency,
+    std::function<void(void)> maybeEmitAssociatedTypeNote) {
+  auto *DC = where.getDeclContext();
+  auto &ctx = DC->getASTContext();
+
+  if (restriction.isUnavailable()) {
+    if (diagnoseExplicitUnavailability(loc, restriction, rootConf, ext, where,
+                                       warnIfConformanceUnavailablePreSwift6,
+                                       preconcurrency)) {
+      maybeEmitAssociatedTypeNote();
+      return true;
+    }
+  }
+
+  if (restriction.isDeprecated()) {
+    if (diagnoseIfDeprecated(loc, rootConf, ext, restriction, where))
+      maybeEmitAssociatedTypeNote();
+    return false;
+  }
+
+  // Diagnose (and possibly signal) for potential unavailability
+  auto domainAndRange = restriction.getDomainAndRange(ctx);
+  auto fixItDomainAndRange = restriction.getFixItDomainAndRange(ctx);
+  if (diagnosePotentialUnavailability(rootConf, ext, loc, DC, domainAndRange,
+                                      fixItDomainAndRange)) {
+    maybeEmitAssociatedTypeNote();
+    return true;
+  }
+
+  return false;
+}
+
 bool
 swift::diagnoseConformanceAvailability(SourceLoc loc,
                                        ProtocolConformanceRef conformance,
@@ -3568,32 +3555,17 @@ swift::diagnoseConformanceAvailability(SourceLoc loc,
       return true;
     }
 
-    auto restriction = where.getAvailability().restrictionForDecl(ext);
-    if (restriction) {
-      if (diagnoseExplicitUnavailability(
-              loc, *restriction, rootConf, ext, where,
-              warnIfConformanceUnavailablePreSwift6, preconcurrency)) {
-        maybeEmitAssociatedTypeNote();
-        return true;
-      }
+    AvailabilityRestrictionFlags restrictionFlags;
+    if (ctx.LangOpts.WarnSoftDeprecated)
+      restrictionFlags |= AvailabilityRestrictionFlag::IncludeSoftDeprecation;
 
-      // Diagnose (and possibly signal) for potential unavailability
-      auto domainAndRange = restriction->getDomainAndRange(ctx);
-      auto fixItDomainAndRange = restriction->getFixItDomainAndRange(ctx);
-      if (diagnosePotentialUnavailability(
-              rootConf, ext, loc, DC, domainAndRange, fixItDomainAndRange)) {
-        maybeEmitAssociatedTypeNote();
-        return true;
-      }
-    }
-
-    // Diagnose for deprecation
-    if (diagnoseIfDeprecated(loc, rootConf, ext, where)) {
-      maybeEmitAssociatedTypeNote();
-
-      // Deprecation is just a warning, so keep going with checking the
-      // substitution map below.
-    }
+    auto restriction =
+        where.getAvailability().restrictionForDecl(ext, restrictionFlags);
+    if (restriction && diagnoseConformanceAvailabilityRestriction(
+                           loc, rootConf, ext, *restriction, where,
+                           warnIfConformanceUnavailablePreSwift6, preconcurrency,
+                           maybeEmitAssociatedTypeNote))
+      return true;
   }
 
   // Now, check associated conformances.

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -259,6 +259,7 @@ static bool isUnavailableInAllVersions(ValueDecl *decl) {
       return true;
     case AvailabilityRestriction::Reason::UnavailableObsolete:
     case AvailabilityRestriction::Reason::Unintroduced:
+    case AvailabilityRestriction::Reason::Deprecated:
       break;
     }
   }
@@ -1860,7 +1861,8 @@ getOverrideAvailability(ValueDecl *override, ValueDecl *base) {
   flags |= AvailabilityRestrictionFlag::
       AllowUniversallyUnavailableInCompatibleContexts;
 
-  if (auto restriction = baseAvailability.restrictionForDecl(override, flags)) {
+  if (auto restriction =
+          baseAvailability.unsatisfiedRestrictionForDecl(override, flags)) {
     if (restriction->isUnavailable())
       return {OverrideAvailability::OverrideUnavailable, restriction};
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2042,7 +2042,7 @@ checkWitnessAvailability(const ValueDecl *requirement, const ValueDecl *witness,
   flags |= AvailabilityRestrictionFlag::
       AllowUniversallyUnavailableInCompatibleContexts;
 
-  return requiredContext.restrictionForDecl(witness, flags);
+  return requiredContext.unsatisfiedRestrictionForDecl(witness, flags);
 }
 
 RequirementCheck WitnessChecker::checkWitness(ValueDecl *requirement,

--- a/test/Availability/availability_versions.swift
+++ b/test/Availability/availability_versions.swift
@@ -149,27 +149,55 @@ func globalFuncAvailableOn51Obsoleted52() -> Int { return 51 } // expected-note 
 @available(OSX, unavailable, introduced: 51)
 func globalFuncUnavailableAndIntroducedOn51() -> Int { return 51 } // expected-note 3 {{'globalFuncUnavailableAndIntroducedOn51()' has been explicitly marked unavailable here}}
 
+@available(OSX, deprecated: 11, message: "11")
+@available(OSX, deprecated: 12, message: "12")
+func globalFuncDeprecatedIn11And12() -> Int { return 11 }
+
+@available(OSX, deprecated: 12, message: "12")
+@available(OSX, deprecated: 11, message: "11")
+func globalFuncDeprecatedIn12And11() -> Int { return 11 }
+
+@available(OSX, obsoleted: 51, message: "51")
+@available(OSX, obsoleted: 52, message: "52")
+func globalFuncObsoletedIn51And52() -> Int { return 51 } // expected-note 2 {{'globalFuncObsoletedIn51And52()' was obsoleted in macOS 51}}
+
+@available(OSX, obsoleted: 52, message: "52")
+@available(OSX, obsoleted: 51, message: "51")
+func globalFuncObsoletedIn52And51() -> Int { return 51 }  // expected-note 2 {{'globalFuncObsoletedIn52And51()' was obsoleted in macOS 51}}
+
 let _ = globalFuncDeprecatedAndAvailableOn51() // expected-error {{'globalFuncDeprecatedAndAvailableOn51()' is only available in macOS 51 or newer}}
 // expected-note@-1 {{add 'if #available' version check}}
-// expected-warning@-2 {{'globalFuncDeprecatedAndAvailableOn51()' is deprecated in macOS}}
 let _ = globalFuncAvailableOn51Deprecated52() // expected-error {{'globalFuncAvailableOn51Deprecated52()' is only available in macOS 51 or newer}}
 // expected-note@-1 {{add 'if #available' version check}}
 let _ = globalFuncAvailableOn51Obsoleted52() // expected-error {{'globalFuncAvailableOn51Obsoleted52()' is only available in macOS 51 or newer}}
 // expected-note@-1 {{add 'if #available' version check}}
 let _ = globalFuncUnavailableAndIntroducedOn51() // expected-error {{'globalFuncUnavailableAndIntroducedOn51()' is unavailable in macOS}}
+let _ = globalFuncDeprecatedIn11And12() // expected-warning {{'globalFuncDeprecatedIn11And12()' was deprecated in macOS 11: 11}}
+let _ = globalFuncDeprecatedIn12And11() // expected-warning {{'globalFuncDeprecatedIn12And11()' was deprecated in macOS 11: 11}}
+let _ = globalFuncObsoletedIn51And52()
+let _ = globalFuncObsoletedIn52And51()
 
 if #available(OSX 51, *) {
   let _ = globalFuncDeprecatedAndAvailableOn51() // expected-warning {{'globalFuncDeprecatedAndAvailableOn51()' is deprecated in macOS}}
   let _ = globalFuncAvailableOn51Deprecated52()
   let _ = globalFuncAvailableOn51Obsoleted52()
   let _ = globalFuncUnavailableAndIntroducedOn51() // expected-error {{'globalFuncUnavailableAndIntroducedOn51()' is unavailable in macOS}}
+  let _ = globalFuncDeprecatedIn11And12() // expected-warning {{'globalFuncDeprecatedIn11And12()' was deprecated in macOS 11: 11}}
+  let _ = globalFuncDeprecatedIn12And11() // expected-warning {{'globalFuncDeprecatedIn12And11()' was deprecated in macOS 11: 11}}
+  let _ = globalFuncObsoletedIn51And52() // expected-error {{'globalFuncObsoletedIn51And52()' is unavailable in macOS: 51}}
+  let _ = globalFuncObsoletedIn52And51() // expected-error {{'globalFuncObsoletedIn52And51()' is unavailable in macOS: 51}}
 }
 
 if #available(OSX 52, *) {
   let _ = globalFuncDeprecatedAndAvailableOn51() // expected-warning {{'globalFuncDeprecatedAndAvailableOn51()' is deprecated in macOS}}
+  // FIXME: [availability] Should be diagnosed as deprecated
   let _ = globalFuncAvailableOn51Deprecated52()
   let _ = globalFuncAvailableOn51Obsoleted52() // expected-error {{'globalFuncAvailableOn51Obsoleted52()' is unavailable in macOS}}
   let _ = globalFuncUnavailableAndIntroducedOn51() // expected-error {{'globalFuncUnavailableAndIntroducedOn51()' is unavailable in macOS}}
+  let _ = globalFuncDeprecatedIn11And12() // expected-warning {{'globalFuncDeprecatedIn11And12()' was deprecated in macOS 11: 11}}
+  let _ = globalFuncDeprecatedIn12And11() // expected-warning {{'globalFuncDeprecatedIn12And11()' was deprecated in macOS 11: 11}}
+  let _ = globalFuncObsoletedIn51And52() // expected-error {{'globalFuncObsoletedIn51And52()' is unavailable in macOS: 51}}
+  let _ = globalFuncObsoletedIn52And51() // expected-error {{'globalFuncObsoletedIn52And51()' is unavailable in macOS: 51}}
 }
 
 

--- a/test/SourceKit/DocSupport/doc_clang_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift.response
@@ -7452,7 +7452,6 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.deprecated: "10.1"
           }
         ],
-        key.is_deprecated: 1,
         key.is_unavailable: 1
       },
       {
@@ -7519,7 +7518,6 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.deprecated: "10.1"
           }
         ],
-        key.is_deprecated: 1,
         key.is_unavailable: 1
       },
       {

--- a/test/SourceKit/DocSupport/doc_system_module_underscored.swift.response
+++ b/test/SourceKit/DocSupport/doc_system_module_underscored.swift.response
@@ -1030,7 +1030,8 @@ protocol Other1 {
         key.original_usr: "s:16UnderscoredProto01_aB0PAAE014fromDeprecatedB9ExtensionyyF",
         key.offset: 144,
         key.length: 35,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromDeprecatedProtoExtension</decl.name>()</decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromDeprecatedProtoExtension</decl.name>()</decl.function.method.instance>",
+        key.is_deprecated: 1
       }
     ],
     key.attributes: [
@@ -1168,7 +1169,8 @@ protocol Other1 {
             key.offset: 462,
             key.length: 3
           }
-        ]
+        ],
+        key.is_deprecated: 1
       }
     ],
     key.attributes: [
@@ -1289,7 +1291,8 @@ protocol Other1 {
         key.original_usr: "s:16UnderscoredProto01_aB0PAAE014fromDeprecatedB9ExtensionyyF",
         key.offset: 744,
         key.length: 35,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromDeprecatedProtoExtension</decl.name>()</decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromDeprecatedProtoExtension</decl.name>()</decl.function.method.instance>",
+        key.is_deprecated: 1
       }
     ],
     key.attributes: [

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -794,6 +794,11 @@ class Base {
 
   @available(*, unavailable, renamed: "Base.shinyLabeledArguments()")
   func unavailableHasType() {} // expected-note {{here}}
+
+  @available(*, deprecated)
+  func deprecated() {}
+
+  func notDeprecated() {}
 }
 
 class Sub : Base {
@@ -836,6 +841,11 @@ class Sub : Base {
   override func unavailableTooMany(a: Int) {} // expected-error {{'unavailableTooMany(a:)' has been renamed to 'shinyLabeledArguments(x:b:)'}} {{none}} expected-note {{remove 'override' modifier to declare a new 'unavailableTooMany'}} {{3-12=}}
   override func unavailableNoArgsTooMany() {} // expected-error {{'unavailableNoArgsTooMany()' has been renamed to 'shinyLabeledArguments(x:)'}} {{none}} expected-note {{remove 'override' modifier to declare a new 'unavailableNoArgsTooMany'}} {{3-12=}}
   override func unavailableHasType() {} // expected-error {{'unavailableHasType()' has been replaced by 'Base.shinyLabeledArguments()'}} {{none}} expected-note {{remove 'override' modifier to declare a new 'unavailableHasType'}} {{3-12=}}
+
+  override func deprecated() {}
+
+  @available(*, deprecated)
+  override func notDeprecated() {}
 }
 
 // U: Unnamed, L: Labeled

--- a/test/attr/attr_availability_async_rename.swift
+++ b/test/attr/attr_availability_async_rename.swift
@@ -285,8 +285,9 @@ func asyncContext(t: HandlerTest) async {
   defaultedParamsEnd3(arg: 1) { }
   // expected-warning@+1{{consider using asynchronous alternative function}}
   defaultedParamsEnd4(arg: 1) { }
-  // expected-warning@+2{{consider using asynchronous alternative function}}
-  // expected-warning@+1{{'manyAttrs(completionHandler:)' is deprecated}}{{documentation-file=deprecated-declaration}}
+  // expected-warning@+3{{consider using asynchronous alternative function}}
+  // expected-warning@+2{{'manyAttrs(completionHandler:)' was deprecated in macOS 12: renamed to 'manyAttrsOld()'}}{{group-name=DeprecatedDeclaration}}
+  // expected-note@+1{{use 'manyAttrsOld()' instead}}
   manyAttrs() { }
   // expected-warning@+1{{consider using asynchronous alternative function}}
   macOSOnly() { }

--- a/test/attr/attr_availability_transitive.swift
+++ b/test/attr/attr_availability_transitive.swift
@@ -13,6 +13,9 @@ struct UnavailableInSwift4 {} // expected-note * {{'UnavailableInSwift4' was obs
 @available(swift, introduced: 99)
 struct AvailableInFutureSwift {} // expected-note * {{'AvailableInFutureSwift' was introduced in Swift 99}}
 
+@available(*, deprecated)
+struct Deprecated {}
+
 @discardableResult
 func always() -> AlwaysAvailable {
   AlwaysAvailable()
@@ -36,6 +39,12 @@ func availableInFutureSwift() -> AvailableInFutureSwift { // expected-note * {{'
   AvailableInFutureSwift()
 }
 
+@available(*, deprecated)
+@discardableResult
+func deprecated() -> Deprecated {
+  Deprecated()
+}
+
 // MARK: Global functions
 
 func available_func( // expected-note * {{add '@available' attribute to enclosing global function}}
@@ -43,11 +52,13 @@ func available_func( // expected-note * {{add '@available' attribute to enclosin
   _: NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
   _: UnavailableInSwift4, // expected-error {{'UnavailableInSwift4' is unavailable}}
   _: AvailableInFutureSwift, // expected-error {{'AvailableInFutureSwift' is unavailable}}
+  _: Deprecated, // expected-warning {{'Deprecated' is deprecated}}
 ) {
   always()
   never() // expected-error {{'never()' is unavailable}}
   unavailableInSwift4() // expected-error {{'unavailableInSwift4()' is unavailable}}
   availableInFutureSwift() // expected-error {{'availableInFutureSwift()' is unavailable}}
+  deprecated() // expected-warning {{'deprecated()' is deprecated}}
 }
 
 @available(*, unavailable)
@@ -56,11 +67,13 @@ func never_available_func(
   _: NeverAvailable,
   _: UnavailableInSwift4,
   _: AvailableInFutureSwift,
+  _: Deprecated,
 ) {
   always()
   never() // expected-error {{'never()' is unavailable}}
   unavailableInSwift4() // expected-error {{'unavailableInSwift4()' is unavailable}}
   availableInFutureSwift() // expected-error {{'availableInFutureSwift()' is unavailable in Swift}}
+  deprecated() // expected-warning {{'deprecated()' is deprecated}}
 }
 
 @available(swift, obsoleted: 4)
@@ -69,11 +82,13 @@ func unavailable_in_swift4_func(
   _: NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
   _: UnavailableInSwift4,
   _: AvailableInFutureSwift,
+  _: Deprecated,
 ) {
   always()
   never() // expected-error {{'never()' is unavailable}}
   unavailableInSwift4() // expected-error {{'unavailableInSwift4()' is unavailable}}
   availableInFutureSwift() // expected-error {{'availableInFutureSwift()' is unavailable in Swift}}
+  deprecated() // expected-warning {{'deprecated()' is deprecated}}
 }
 
 @available(swift, introduced: 99)
@@ -82,11 +97,28 @@ func introduced_in_future_swift_func(
   _: NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
   _: UnavailableInSwift4,
   _: AvailableInFutureSwift,
+  _: Deprecated,
 ) {
   always()
   never() // expected-error {{'never()' is unavailable}}
   unavailableInSwift4() // expected-error {{'unavailableInSwift4()' is unavailable}}
   availableInFutureSwift() // expected-error {{'availableInFutureSwift()' is unavailable in Swift}}
+  deprecated() // expected-warning {{'deprecated()' is deprecated}}
+}
+
+@available(*, deprecated)
+func deprecated_func(
+  _: AlwaysAvailable,
+  _: NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
+  _: UnavailableInSwift4, // expected-error {{'UnavailableInSwift4' is unavailable}}
+  _: AvailableInFutureSwift, // expected-error {{'AvailableInFutureSwift' is unavailable}}
+  _: Deprecated,
+) {
+  always()
+  never() // expected-error {{'never()' is unavailable}}
+  unavailableInSwift4() // expected-error {{'unavailableInSwift4()' is unavailable}}
+  availableInFutureSwift() // expected-error {{'availableInFutureSwift()' is unavailable}}
+  deprecated()
 }
 
 // MARK: Global vars
@@ -95,12 +127,14 @@ var always_var: (
   AlwaysAvailable,
   NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
   UnavailableInSwift4, // expected-error {{'UnavailableInSwift4' is unavailable}}
-  AvailableInFutureSwift // expected-error {{'AvailableInFutureSwift' is unavailable}}
+  AvailableInFutureSwift, // expected-error {{'AvailableInFutureSwift' is unavailable}}
+  Deprecated // expected-warning {{'Deprecated' is deprecated}}
 ) = (
   always(),
   never(), // expected-error {{'never()' is unavailable}}
   unavailableInSwift4(), // expected-error {{'unavailableInSwift4()' is unavailable}}
   availableInFutureSwift(), // expected-error {{'availableInFutureSwift()' is unavailable}}
+  deprecated() // expected-warning {{'deprecated()' is deprecated}}
 )
 
 @available(*, unavailable)
@@ -108,12 +142,14 @@ var never_var: (
   AlwaysAvailable,
   NeverAvailable,
   UnavailableInSwift4,
-  AvailableInFutureSwift
+  AvailableInFutureSwift,
+  Deprecated
 ) = (
   always(),
   never(), // expected-error {{'never()' is unavailable}}
   unavailableInSwift4(), // expected-error {{'unavailableInSwift4()' is unavailable}}
   availableInFutureSwift(), // expected-error {{'availableInFutureSwift()' is unavailable in Swift}}
+  deprecated() // expected-warning {{'deprecated()' is deprecated}}
 )
 
 @available(swift, obsoleted: 4)
@@ -121,12 +157,14 @@ var unavailable_in_swift4_var: (
   AlwaysAvailable,
   NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
   UnavailableInSwift4,
-  AvailableInFutureSwift
+  AvailableInFutureSwift,
+  Deprecated
 ) = (
   always(),
   never(), // expected-error {{'never()' is unavailable}}
   unavailableInSwift4(), // expected-error {{'unavailableInSwift4()' is unavailable}}
   availableInFutureSwift(), // expected-error {{'availableInFutureSwift()' is unavailable in Swift}}
+  deprecated() // expected-warning {{'deprecated()' is deprecated}}
 )
 
 @available(swift, introduced: 99)
@@ -134,12 +172,29 @@ var available_in_future_swift_var: (
   AlwaysAvailable,
   NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
   UnavailableInSwift4,
-  AvailableInFutureSwift
+  AvailableInFutureSwift,
+  Deprecated
 ) = (
   always(),
   never(), // expected-error {{'never()' is unavailable}}
   unavailableInSwift4(), // expected-error {{'unavailableInSwift4()' is unavailable}}
   availableInFutureSwift(), // expected-error {{'availableInFutureSwift()' is unavailable in Swift}}
+  deprecated() // expected-warning {{'deprecated()' is deprecated}}
+)
+
+@available(*, deprecated)
+var deprecated_var: (
+  AlwaysAvailable,
+  NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
+  UnavailableInSwift4, // expected-error {{'UnavailableInSwift4' is unavailable}}
+  AvailableInFutureSwift, // expected-error {{'AvailableInFutureSwift' is unavailable}}
+  Deprecated
+) = (
+  always(),
+  never(), // expected-error {{'never()' is unavailable}}
+  unavailableInSwift4(), // expected-error {{'unavailableInSwift4()' is unavailable}}
+  availableInFutureSwift(), // expected-error {{'availableInFutureSwift()' is unavailable}}
+  deprecated()
 )
 
 
@@ -153,32 +208,49 @@ struct AlwaysAvailableContainer {
   // expected-error@-1 {{'UnavailableInSwift4' is unavailable}}
   let available_in_future_swift_var: AvailableInFutureSwift = availableInFutureSwift() // expected-error {{'availableInFutureSwift()' is unavailable}}
   // expected-error@-1 {{'AvailableInFutureSwift' is unavailable}}
+  let deprecated_var: Deprecated = deprecated() // expected-warning {{'deprecated()' is deprecated}}
+  // expected-warning@-1 {{'Deprecated' is deprecated}}
 }
 
 @available(*, unavailable)
-struct NeverAvailableContainer { // expected-note 3 {{'NeverAvailableContainer' has been explicitly marked unavailable here}}
+struct NeverAvailableContainer { // expected-note * {{'NeverAvailableContainer' has been explicitly marked unavailable here}}
   let always_var: AlwaysAvailable = always()
   let never_var: NeverAvailable = never() // expected-error {{'never()' is unavailable}}
   let unavailable_in_swift4_var: UnavailableInSwift4 = unavailableInSwift4() // expected-error {{'unavailableInSwift4()' is unavailable}}
   let available_in_future_swift_var: AvailableInFutureSwift = availableInFutureSwift() // expected-error {{'availableInFutureSwift()' is unavailable in Swift}}
+  let deprecated_var: Deprecated = deprecated() // expected-warning {{'deprecated()' is deprecated}}
 }
 
 @available(swift, obsoleted: 4)
-struct UnavailableInSwift4Container { // expected-note {{'UnavailableInSwift4Container' was obsoleted in Swift 4}}
+struct UnavailableInSwift4Container { // expected-note * {{'UnavailableInSwift4Container' was obsoleted in Swift 4}}
   let always_var: AlwaysAvailable = always()
   let never_var: NeverAvailable = never() // expected-error {{'never()' is unavailable}}
   // expected-error@-1 {{'NeverAvailable' is unavailable}}
   let unavailable_in_swift4_var: UnavailableInSwift4 = unavailableInSwift4() // expected-error {{'unavailableInSwift4()' is unavailable}}
   let available_in_future_swift_var: AvailableInFutureSwift = availableInFutureSwift() // expected-error {{'availableInFutureSwift()' is unavailable in Swift}}
+  let deprecated_var: Deprecated = deprecated() // expected-warning {{'deprecated()' is deprecated}}
 }
 
 @available(swift, introduced: 99)
-struct AvailableInFutureSwiftContainer { // expected-note {{'AvailableInFutureSwiftContainer' was introduced in Swift 99}}
+struct AvailableInFutureSwiftContainer { // expected-note * {{'AvailableInFutureSwiftContainer' was introduced in Swift 99}}
   let always_var: AlwaysAvailable = always()
   let never_var: NeverAvailable = never() // expected-error {{'never()' is unavailable}}
   // expected-error@-1 {{'NeverAvailable' is unavailable}}
   let unavailable_in_swift4_var: UnavailableInSwift4 = unavailableInSwift4()  // expected-error {{'unavailableInSwift4()' is unavailable}}
   let available_in_future_swift_var: AvailableInFutureSwift = availableInFutureSwift()  // expected-error {{'availableInFutureSwift()' is unavailable in Swift}}
+  let deprecated_var: Deprecated = deprecated() // expected-warning {{'deprecated()' is deprecated}}
+}
+
+@available(*, deprecated)
+struct DeprecatedContainer {
+  let always_var: AlwaysAvailable = always()
+  let never_var: NeverAvailable = never() // expected-error {{'never()' is unavailable}}
+  // expected-error@-1 {{'NeverAvailable' is unavailable}}
+  let unavailable_in_swift4_var: UnavailableInSwift4 = unavailableInSwift4() // expected-error {{'unavailableInSwift4()' is unavailable}}
+  // expected-error@-1 {{'UnavailableInSwift4' is unavailable}}
+  let available_in_future_swift_var: AvailableInFutureSwift = availableInFutureSwift() // expected-error {{'availableInFutureSwift()' is unavailable}}
+  // expected-error@-1 {{'AvailableInFutureSwift' is unavailable}}
+  let deprecated_var: Deprecated = deprecated()
 }
 
 // MARK: Extensions
@@ -187,6 +259,7 @@ extension AlwaysAvailableContainer {}
 extension NeverAvailableContainer {} // expected-error {{'NeverAvailableContainer' is unavailable}}
 extension UnavailableInSwift4Container {} // expected-error {{'UnavailableInSwift4Container' is unavailable}}
 extension AvailableInFutureSwiftContainer {} // expected-error {{'AvailableInFutureSwiftContainer' is unavailable}}
+extension DeprecatedContainer {} // expected-warning {{'DeprecatedContainer' is deprecated}}
 
 @available(*, unavailable)
 extension AlwaysAvailableContainer {}
@@ -196,6 +269,8 @@ extension NeverAvailableContainer {}
 extension UnavailableInSwift4Container {}
 @available(*, unavailable)
 extension AvailableInFutureSwiftContainer {}
+@available(*, unavailable)
+extension DeprecatedContainer {}
 
 @available(swift, obsoleted: 4)
 extension AlwaysAvailableContainer {}
@@ -205,6 +280,8 @@ extension NeverAvailableContainer {} // expected-error {{'NeverAvailableContaine
 extension UnavailableInSwift4Container {}
 @available(swift, obsoleted: 4)
 extension AvailableInFutureSwiftContainer {}
+@available(swift, obsoleted: 4)
+extension DeprecatedContainer {}
 
 @available(swift, introduced: 99)
 extension AlwaysAvailableContainer {}
@@ -214,6 +291,19 @@ extension NeverAvailableContainer {} // expected-error {{'NeverAvailableContaine
 extension UnavailableInSwift4Container {}
 @available(swift, introduced: 99)
 extension AvailableInFutureSwiftContainer {}
+@available(swift, introduced: 99)
+extension DeprecatedContainer {}
+
+@available(*, deprecated)
+extension AlwaysAvailableContainer {}
+@available(*, deprecated)
+extension NeverAvailableContainer {} // expected-error {{'NeverAvailableContainer' is unavailable}}
+@available(*, deprecated)
+extension UnavailableInSwift4Container {} // expected-error {{'UnavailableInSwift4Container' is unavailable}}
+@available(*, deprecated)
+extension AvailableInFutureSwiftContainer {} // expected-error {{'AvailableInFutureSwiftContainer' is unavailable}}
+@available(*, deprecated)
+extension DeprecatedContainer {}
 
 struct ExtendMe {}
 
@@ -228,11 +318,13 @@ extension ExtendMe {
     _: NeverAvailable,
     _: UnavailableInSwift4,
     _: AvailableInFutureSwift,
+    _: Deprecated,
   ) {
     always()
     never() // expected-error {{'never()' is unavailable}}
     unavailableInSwift4() // expected-error {{'unavailableInSwift4()' is unavailable}}
     availableInFutureSwift() // expected-error {{'availableInFutureSwift()' is unavailable in Swift}}
+    deprecated() // expected-warning {{'deprecated()' is deprecated}}
   }
 
   @available(*, unavailable)
@@ -241,11 +333,13 @@ extension ExtendMe {
     _: NeverAvailable,
     _: UnavailableInSwift4,
     _: AvailableInFutureSwift,
+    _: Deprecated,
   ) {
     always()
     never() // expected-error {{'never()' is unavailable}}
     unavailableInSwift4() // expected-error {{'unavailableInSwift4()' is unavailable}}
     availableInFutureSwift() // expected-error {{'availableInFutureSwift()' is unavailable in Swift}}
+    deprecated() // expected-warning {{'deprecated()' is deprecated}}
   }
 
   @available(swift, obsoleted: 4)
@@ -254,11 +348,13 @@ extension ExtendMe {
     _: NeverAvailable,
     _: UnavailableInSwift4,
     _: AvailableInFutureSwift,
+    _: Deprecated,
   ) {
     always()
     never() // expected-error {{'never()' is unavailable}}
     unavailableInSwift4() // expected-error {{'unavailableInSwift4()' is unavailable}}
     availableInFutureSwift() // expected-error {{'availableInFutureSwift()' is unavailable in Swift}}
+    deprecated() // expected-warning {{'deprecated()' is deprecated}}
   }
 
   @available(swift, introduced: 99)
@@ -267,11 +363,28 @@ extension ExtendMe {
     _: NeverAvailable,
     _: UnavailableInSwift4,
     _: AvailableInFutureSwift,
+    _: Deprecated,
   ) {
     always()
     never() // expected-error {{'never()' is unavailable}}
     unavailableInSwift4() // expected-error {{'unavailableInSwift4()' is unavailable}}
     availableInFutureSwift() // expected-error {{'availableInFutureSwift()' is unavailable in Swift}}
+    deprecated() // expected-warning {{'deprecated()' is deprecated}}
+  }
+
+  @available(*, deprecated)
+  func never_available_extension_deprecated_method(
+    _: AlwaysAvailable,
+    _: NeverAvailable,
+    _: UnavailableInSwift4,
+    _: AvailableInFutureSwift,
+    _: Deprecated,
+  ) {
+    always()
+    never() // expected-error {{'never()' is unavailable}}
+    unavailableInSwift4() // expected-error {{'unavailableInSwift4()' is unavailable}}
+    availableInFutureSwift() // expected-error {{'availableInFutureSwift()' is unavailable in Swift}}
+    deprecated()
   }
 }
 
@@ -287,11 +400,13 @@ extension ExtendMe {
     _: NeverAvailable,
     _: UnavailableInSwift4,
     _: AvailableInFutureSwift,
+    _: Deprecated,
   ) {
     always()
     never() // expected-error {{'never()' is unavailable}}
     unavailableInSwift4() // expected-error {{'unavailableInSwift4()' is unavailable}}
     availableInFutureSwift() // expected-error {{'availableInFutureSwift()' is unavailable in Swift}}
+    deprecated() // expected-warning {{'deprecated()' is deprecated}}
   }
 }
 
@@ -307,11 +422,35 @@ extension ExtendMe {
     _: NeverAvailable,
     _: UnavailableInSwift4,
     _: AvailableInFutureSwift,
+    _: Deprecated,
   ) {
     always()
     never() // expected-error {{'never()' is unavailable}}
     unavailableInSwift4() // expected-error {{'unavailableInSwift4()' is unavailable}}
     availableInFutureSwift() // expected-error {{'availableInFutureSwift()' is unavailable in Swift}}
+    deprecated() // expected-warning {{'deprecated()' is deprecated}}
+  }
+}
+
+@available(*, deprecated)
+extension ExtendMe {
+  func deprecated_extension_available_method() {} // expected-note * {{'deprecated_extension_available_method()' is deprecated}}
+
+  typealias AvailableAliasInDeprecatedExtension = Self // expected-note * {{'AvailableAliasInDeprecatedExtension' is deprecated}}
+
+  @available(*, unavailable)
+  func deprecated_extension_never_available_method(
+    _: AlwaysAvailable,
+    _: NeverAvailable,
+    _: UnavailableInSwift4,
+    _: AvailableInFutureSwift,
+    _: Deprecated,
+  ) {
+    always()
+    never() // expected-error {{'never()' is unavailable}}
+    unavailableInSwift4() // expected-error {{'unavailableInSwift4()' is unavailable}}
+    availableInFutureSwift() // expected-error {{'availableInFutureSwift()' is unavailable in Swift}}
+    deprecated()
   }
 }
 
@@ -320,10 +459,12 @@ func available_func_call_extension_methods(
   _: ExtendMe.AvailableAliasInNeverAvailableExtension, // expected-error {{'AvailableAliasInNeverAvailableExtension' is unavailable}}
   _: ExtendMe.AvailableAliasInSwift4ObsoletedExtension, // expected-error {{'AvailableAliasInSwift4ObsoletedExtension' is unavailable}}
   _: ExtendMe.AvailableAliasInSwift99Extension, // expected-error {{'AvailableAliasInSwift99Extension' is unavailable in Swift}}
+  _: ExtendMe.AvailableAliasInDeprecatedExtension, // expected-warning {{'AvailableAliasInDeprecatedExtension' is deprecated}}
 ) {
   e.never_available_extension_available_method() // expected-error {{'never_available_extension_available_method()' is unavailable}}
   e.unavailable_in_swift4_extension_available_method() //  expected-error {{'unavailable_in_swift4_extension_available_method()' is unavailable}}
   e.available_in_future_swift_extension_available_method() //  expected-error {{'available_in_future_swift_extension_available_method()' is unavailable}}
+  e.deprecated_extension_available_method() // expected-warning {{'deprecated_extension_available_method()' is deprecated}}
 }
 
 @available(*, unavailable)
@@ -332,8 +473,24 @@ func unavailable_func_call_extension_methods(
   _: ExtendMe.AvailableAliasInNeverAvailableExtension,
   _: ExtendMe.AvailableAliasInSwift4ObsoletedExtension,
   _: ExtendMe.AvailableAliasInSwift99Extension,
+  _: ExtendMe.AvailableAliasInDeprecatedExtension,
 ) {
   e.never_available_extension_available_method() // expected-error {{'never_available_extension_available_method()' is unavailable}}
   e.unavailable_in_swift4_extension_available_method() //  expected-error {{'unavailable_in_swift4_extension_available_method()' is unavailable}}
   e.available_in_future_swift_extension_available_method() //  expected-error {{'available_in_future_swift_extension_available_method()' is unavailable}}
+  e.deprecated_extension_available_method() // expected-warning {{'deprecated_extension_available_method()' is deprecated}}
+}
+
+@available(*, deprecated)
+func deprecated_func_call_extension_methods(
+  _ e: ExtendMe,
+  _: ExtendMe.AvailableAliasInNeverAvailableExtension, // expected-error {{'AvailableAliasInNeverAvailableExtension' is unavailable}}
+  _: ExtendMe.AvailableAliasInSwift4ObsoletedExtension, // expected-error {{'AvailableAliasInSwift4ObsoletedExtension' is unavailable}}
+  _: ExtendMe.AvailableAliasInSwift99Extension, // expected-error {{'AvailableAliasInSwift99Extension' is unavailable in Swift}}
+  _: ExtendMe.AvailableAliasInDeprecatedExtension,
+) {
+  e.never_available_extension_available_method() // expected-error {{'never_available_extension_available_method()' is unavailable}}
+  e.unavailable_in_swift4_extension_available_method() //  expected-error {{'unavailable_in_swift4_extension_available_method()' is unavailable}}
+  e.available_in_future_swift_extension_available_method() //  expected-error {{'available_in_future_swift_extension_available_method()' is unavailable}}
+  e.deprecated_extension_available_method()
 }


### PR DESCRIPTION
Allow `AvailabilityRestriction` to represent deprecation in addition to unavailability. This makes the behavior of deprecation diagnostics more consistent with other availability diagnostics and reduces code duplication. It will also make it easier to improve deprecation diagnostics in the future by making them more context sensitive, instead of always being based on the deployment target.

There are some notable changes in behavior that fall out of this refactoring:

- Declarations can no longer be diagnosed as simultaneously unavailable and deprecated. Unavailability is a stronger restriction on the use of a declaration, so it overrides deprecation.
- Members of deprecated extensions are now considered deprecated more consistently by all parts of the compiler.
- When multiple attributes cause a declaration to be deprecated, the attribute that represents the strongest form of deprecation is picked regardless of the order they were written in source, just like for unavailability (and potential unavailability).