### PR TITLE
[cxx-interop] Import typedefs aliasing NS_OPTIONS/CF_OPTIONS types as the option set

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1593,6 +1593,16 @@ namespace {
           if (auto newtype = importSwiftNewtype(Decl, newtypeAttr, DC, Name))
             return newtype;
 
+      // In C++ interop, a {CF,NS}_OPTIONS type is a Swift-unavailable typedef
+      // paired with an anonymous flag_enum. When another typedef refers to
+      // such a type, map it to the option set struct so the resulting
+      // typealias points at the option set rather than resolving to the
+      // underlying integer type.
+      if (!SwiftType)
+        if (auto optionSetEnum = importer::findOptionSetEnum(
+                desugarIfElaborated(Decl->getUnderlyingType()), Impl))
+          SwiftType = optionSetEnum.getType();
+
       if (!SwiftType) {
         // Note that the code below checks to see if the typedef allows
         // bridging, i.e. if the imported typealias should name a bridged type

--- a/lib/ClangImporter/ImportEnumInfo.cpp
+++ b/lib/ClangImporter/ImportEnumInfo.cpp
@@ -250,6 +250,20 @@ const clang::Type *importer::getUnderlyingType(const clang::EnumDecl *decl) {
 ImportedType importer::findOptionSetEnum(clang::QualType type,
                                          ClangImporter::Implementation &Impl) {
   auto typedefType = dyn_cast<clang::TypedefType>(type);
+
+  if (Impl.SwiftContext.LangOpts.EnableCXXInterop) {
+    // In C++ interop, a {CF,NS}_OPTIONS type is a Swift-unavailable typedef
+    // paired with an anonymous flag_enum. A typedef that aliases such a type,
+    // possibly through several levels, is itself available in Swift, so look
+    // through the alias chain to the underlying Swift-unavailable CF_OPTIONS
+    // typedef.
+    while (typedefType && !Impl.isUnavailableInSwift(typedefType->getDecl())) {
+      auto underlying =
+          desugarIfElaborated(typedefType->getDecl()->getUnderlyingType());
+      typedefType = dyn_cast<clang::TypedefType>(underlying);
+    }
+  }
+
   if (!typedefType || !Impl.isUnavailableInSwift(typedefType->getDecl()))
     // If this isn't a typedef, or it is a typedef that is available in Swift,
     // then this definitely isn't used for {CF,NS}_OPTIONS.

--- a/test/Interop/Cxx/enum/Inputs/cf-options-typedef-alias.h
+++ b/test/Interop/Cxx/enum/Inputs/cf-options-typedef-alias.h
@@ -1,0 +1,21 @@
+#ifndef TEST_INTEROP_CXX_ENUM_INPUTS_CF_OPTIONS_TYPEDEF_ALIAS_H
+#define TEST_INTEROP_CXX_ENUM_INPUTS_CF_OPTIONS_TYPEDEF_ALIAS_H
+
+#include "CFAvailability.h"
+
+typedef NS_OPTIONS(unsigned long, NSPropertyListMutabilityOptions) {
+  NSPropertyListImmutable = 0,
+  NSPropertyListMutableContainers = 1,
+  NSPropertyListMutableContainersAndLeaves = 2,
+};
+
+typedef NSPropertyListMutabilityOptions NSPropertyListReadOptions;
+
+typedef NSPropertyListReadOptions NSPropertyListReadOptions2;
+typedef NSPropertyListReadOptions2 NSPropertyListReadOptions3;
+
+@interface PlistReader
+- (void)readWithOptions:(NSPropertyListReadOptions)options;
+@end
+
+#endif // TEST_INTEROP_CXX_ENUM_INPUTS_CF_OPTIONS_TYPEDEF_ALIAS_H

--- a/test/Interop/Cxx/enum/Inputs/module.modulemap
+++ b/test/Interop/Cxx/enum/Inputs/module.modulemap
@@ -23,6 +23,11 @@ module CenumsNSOptions {
   requires cplusplus
 }
 
+module CFOptionsTypedefAlias {
+  header "cf-options-typedef-alias.h"
+  requires cplusplus
+}
+
 module TypedUntypedEnums {
   header "typed-untyped-enums.h"
   requires cplusplus

--- a/test/Interop/Cxx/enum/c-enums-NS_OPTIONS-typedef-alias.swift
+++ b/test/Interop/Cxx/enum/c-enums-NS_OPTIONS-typedef-alias.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=CFOptionsTypedefAlias -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default %s
+// REQUIRES: objc_interop
+
+import CFOptionsTypedefAlias
+
+// CHECK: struct NSPropertyListMutabilityOptions : OptionSet
+
+// CHECK-NOT: typealias NSPropertyListReadOptions = UInt
+// CHECK: typealias NSPropertyListReadOptions = NSPropertyListMutabilityOptions
+// CHECK: typealias NSPropertyListReadOptions2 = NSPropertyListMutabilityOptions
+// CHECK: typealias NSPropertyListReadOptions3 = NSPropertyListMutabilityOptions
+
+// CHECK: func read(withOptions options: NSPropertyListMutabilityOptions)
+
+func test(_ reader: PlistReader) {
+  let opts: NSPropertyListReadOptions = .mutableContainersAndLeaves
+  let opts3: NSPropertyListReadOptions3 = [.mutableContainers]
+  reader.read(withOptions: opts)
+  reader.read(withOptions: opts3)
+}


### PR DESCRIPTION
In C++ interop the `CF_OPTIONS`/`NS_OPTIONS` macro expands to a Swift-unavailable typedef paired with an anonymous flag_enum that Swift imports as an option set struct named after the typedef.

`findOptionSetEnum()` now follows the typedef alias chain down to that underlying Swift-unavailable typedef, so every use of an alias is imported as the option set struct rather than the underlying integer type.

`VisitTypedefNameDecl()` now maps such an alias to the option set struct so its imported typealias points at the option set instead of the underlying integer type.

rdar://180317577
