### PR TITLE
[SILVerifier] Add VerifierErrorEmitterGuard to avoid frontend crash

### DIFF
--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -7792,15 +7792,17 @@ void SILVTable::verify(const SILModule &M) const {
       // Note the direction of the compatibility check: the witness
       // function must be compatible with being used as the requirement
       // type.
-      SILVerifier(*entry.getImplementation(), /*calleeCache=*/nullptr,
-                  /*dominanceInfo=*/nullptr,
-                  /*SingleFunction=*/true,
-                  /*checkLinearLifetime=*/false)
-          .requireABICompatibleFunctionTypes(
-              entry.getImplementation()->getLoweredFunctionType(),
-              baseInfo.getSILType().castTo<SILFunctionType>(),
-              "vtable entry for " + baseName + " must be ABI-compatible",
-              *entry.getImplementation());
+      SILVerifier verifier(*entry.getImplementation(), /*calleeCache=*/nullptr,
+                           /*dominanceInfo=*/nullptr,
+                           /*SingleFunction=*/true,
+                           /*checkLinearLifetime=*/false);
+      SILVerifier::VerifierErrorEmitterGuard guard(&verifier,
+                                                   entry.getImplementation());
+      verifier.requireABICompatibleFunctionTypes(
+          entry.getImplementation()->getLoweredFunctionType(),
+          baseInfo.getSILType().castTo<SILFunctionType>(),
+          "vtable entry for " + baseName + " must be ABI-compatible",
+          *entry.getImplementation());
     }
     
     // Validate the entry against its superclass vtable.
@@ -7958,16 +7960,17 @@ void SILDefaultWitnessTable::verify(const SILModule &mod) const {
         entry.getMethodWitness().Requirement.print(os);
       }
 
-      SILVerifier(*witnessFunction, /*calleeCache=*/nullptr,
-                  /*dominanceInfo=*/nullptr,
-                  /*SingleFunction=*/true,
-                  /*checkLinearLifetime=*/false)
-          .requireABICompatibleFunctionTypes(
-              witnessFunction->getLoweredFunctionType(),
-              baseInfo.getSILType().castTo<SILFunctionType>(),
-              "default witness table entry for " + baseName +
-                  " must be ABI-compatible",
-              *witnessFunction);
+      SILVerifier verifier(*witnessFunction, /*calleeCache=*/nullptr,
+                           /*dominanceInfo=*/nullptr,
+                           /*SingleFunction=*/true,
+                           /*checkLinearLifetime=*/false);
+      SILVerifier::VerifierErrorEmitterGuard guard(&verifier, witnessFunction);
+      verifier.requireABICompatibleFunctionTypes(
+          witnessFunction->getLoweredFunctionType(),
+          baseInfo.getSILType().castTo<SILFunctionType>(),
+          "default witness table entry for " + baseName +
+              " must be ABI-compatible",
+          *witnessFunction);
     }
   }
 }

--- a/test/SIL/verifier-fail-vtable-abi.sil
+++ b/test/SIL/verifier-fail-vtable-abi.sil
@@ -1,0 +1,51 @@
+// RUN: not --crash %target-sil-opt -enable-sil-verify-all -module-name=Test %s 2>&1 | %FileCheck %s
+
+// REQUIRES: asserts
+
+// Regression test for a crash in SILVTable::verify where a vtable entry whose
+// implementation is ABI-incompatible with the base slot caused the frontend to
+// abort with "LLVM ERROR: Must have a construct to emit for" instead of
+// emitting the ABI-mismatch diagnostic. The verifier constructed a temporary
+// SILVerifier for the ABI check without installing a VerifierErrorEmitterGuard;
+// when _require failed, emitError had no anchor construct and hit
+// report_fatal_error.
+
+// CHECK: SIL verification failed: vtable entry for #Base.foo{{.*}}must be ABI-compatible
+// CHECK: Differing parameter convention.
+// CHECK-NOT: Must have a construct to emit for
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+class Payload {}
+
+public class Base {
+  func foo(p: Payload)
+}
+
+public class Derived : Base {
+  override func foo(p: Payload)
+}
+
+// Base.foo(p:) — the base slot expects @guaranteed Payload.
+sil @$s4Test4BaseC3foo1pyAA7PayloadC_tF : $@convention(method) (@guaranteed Payload, @guaranteed Base) -> ()
+
+// Derived.foo(p:) — the implementation takes @owned Payload, mismatching the
+// base slot's @guaranteed convention. This is what trips
+// requireABICompatibleFunctionTypes from SILVTable::verify.
+sil @$s4Test7DerivedC3foo1pyAA7PayloadC_tF : $@convention(method) (@owned Payload, @guaranteed Derived) -> () {
+bb0(%0 : $Payload, %1 : $Derived):
+  strong_release %0 : $Payload
+  %r = tuple ()
+  return %r : $()
+}
+
+sil_vtable Base {
+  #Base.foo: (Base) -> (Payload) -> () : @$s4Test4BaseC3foo1pyAA7PayloadC_tF
+}
+
+sil_vtable Derived {
+  #Base.foo: (Base) -> (Payload) -> () : @$s4Test7DerivedC3foo1pyAA7PayloadC_tF [override]
+}


### PR DESCRIPTION
When `SILVTable::verify` or `SILDefaultWitnessTable::verify` detected an ABI-incompatible entry, the frontend aborted with:

LLVM ERROR: Must have a construct to emit for

instead of emitting the intended ABI-mismatch diagnostic. 

Both call sites constructed a temporary SILVerifier and invoked `requireABICompatibleFunctionTypes` on it without installing a `VerifierErrorEmitterGuard`, so when `_require` failed, `ErrorEmitter::emitError` had no anchor construct and hit `report_fatal_error`

Install a guard around each call using the implementation SILFunction as the anchor, mirroring the fix @slavapestov  did in [e4d2af212ed6](https://github.com/swiftlang/swift/commit/e4d2af212ed6).

This lets the verifier print the real "vtable entry for X must be ABI-compatible" diagnostic (and its function dump) before aborting via `verificationFailure`.

Add `test/SIL/verifier-fail-vtable-abi.sil`, a small SIL fixture whose `Derived.foo` implementation is registered as the override for `#Base.foo` with a mismatched ownership convention on its `Payload` parameter (`@owned` vs `@guaranteed`). Without the fix this test hits the fatal-error path; with the fix it emits the expected diagnostic.

cc @rmaz 

[Assisted-by](https://t.ly/Dkjjk): Opus 4.8
