### PR TITLE
[6.4][CSSimplify] Passing a closure with captures to `@autoclosure` parame…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1692,7 +1692,8 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
         //    func f<T>(_: @autoclosure () -> T) {}
         //
         //    f { } // OK
-        if (isExpr<ClosureExpr>(argExpr)) {
+        //    f { [v] in } // OK
+        if (isExpr<ClosureExpr>(argExpr) || isExpr<CaptureListExpr>(argExpr)) {
           cs.increaseScore(SK_FunctionToAutoClosureConversion, loc);
         }
 

--- a/test/Constraints/issue-90628.swift
+++ b/test/Constraints/issue-90628.swift
@@ -1,0 +1,26 @@
+// RUN: %target-typecheck-verify-swift
+
+// https://github.com/swiftlang/swift/issues/90628
+
+protocol P {}
+
+@resultBuilder
+struct Builder {
+  static func buildBlock<T: P>(_: T) {}
+}
+
+func overloaded<T>(_: @autoclosure () -> T) {}
+func overloaded<T>(@Builder _: () -> T) {}
+
+struct S : P {
+}
+
+struct Test {
+  func test() {
+    overloaded { [self] in
+      getS()
+    }
+  }
+
+  func getS() -> S { .init() }
+}


### PR DESCRIPTION
…ter should incur score increase

- Explanation:
  
  The score should be increased both for regular closures and the ones with captures uniformly.

- Main branch PR: https://github.com/swiftlang/swift/pull/90640

- Resolves: https://github.com/swiftlang/swift/issues/90628, rdar://182121110

- Risk: Very low. This is a narrow change for closures with captures passed to `@autoclosure` parameters, the change allows more valid code to compile. Shouldn't cause any new ambiguities because the score is distinct and very narrowly applied.

- Reviewed By: @hamishknight  

- Testing: Added new test-cases to the suite.

(cherry picked from commit c911c20be48e11b9d9252d08fcd8a5d312a994e6)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
