### PR TITLE
Mark [Mutable]Ref availability StdlibDeploymentTarget, not SwiftStdlib

### DIFF
--- a/stdlib/public/core/MutableRef.swift
+++ b/stdlib/public/core/MutableRef.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// A safe mutable reference allowing in-place mutation to an exclusive value.
-@available(SwiftStdlib 6.4, *)
+@available(StdlibDeploymentTarget 6.4, *)
 @frozen
 @safe
 public struct MutableRef<Value: ~Copyable>: ~Copyable, ~Escapable {
@@ -21,7 +21,7 @@ public struct MutableRef<Value: ~Copyable>: ~Copyable, ~Escapable {
   /// Initializes an instance of `MutableRef` with the given mutable value. This
   /// creates a mutable reference to that value preventing writes to the
   /// original value while this mutable reference is still active.
-  @available(SwiftStdlib 6.4, *)
+  @available(StdlibDeploymentTarget 6.4, *)
   @export(implementation)
   @_lifetime(&value)
   @_transparent
@@ -37,7 +37,7 @@ public struct MutableRef<Value: ~Copyable>: ~Copyable, ~Escapable {
   ///                      instance of type `Value`.
   /// - Parameter owner: The owning instance that this `MutableRef` instance's
   ///                    lifetime is based on.
-  @available(SwiftStdlib 6.4, *)
+  @available(StdlibDeploymentTarget 6.4, *)
   @unsafe
   @export(implementation)
   @_lifetime(&owner)
@@ -50,14 +50,14 @@ public struct MutableRef<Value: ~Copyable>: ~Copyable, ~Escapable {
   }
 }
 
-@available(SwiftStdlib 6.4, *)
+@available(StdlibDeploymentTarget 6.4, *)
 extension MutableRef: @unchecked Sendable where Value: Sendable & ~Copyable {}
 
-@available(SwiftStdlib 6.4, *)
+@available(StdlibDeploymentTarget 6.4, *)
 extension MutableRef where Value: ~Copyable {
   /// Dereferences the mutable reference allowing for in-place reads and writes
   /// to the underlying value.
-  @available(SwiftStdlib 6.4, *)
+  @available(StdlibDeploymentTarget 6.4, *)
   @export(implementation)
   @_transparent
   public var value: Value {

--- a/stdlib/public/core/Ref.swift
+++ b/stdlib/public/core/Ref.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// A safe reference allowing in-place reads to a shared value.
-@available(SwiftStdlib 6.4, *)
+@available(StdlibDeploymentTarget 6.4, *)
 @frozen
 public struct Ref<Value: ~Copyable>: Copyable, ~Escapable {
   @usableFromInline
@@ -20,7 +20,7 @@ public struct Ref<Value: ~Copyable>: Copyable, ~Escapable {
   /// Initializes an instance of `Ref` with the given borrowed value. This
   /// creates a constant reference to that value preventing writes on the 
   /// original value while this reference is still active.
-  @available(SwiftStdlib 6.4, *)
+  @available(StdlibDeploymentTarget 6.4, *)
   @export(implementation)
   @_lifetime(borrow value)
   @_transparent
@@ -36,7 +36,7 @@ public struct Ref<Value: ~Copyable>: Copyable, ~Escapable {
   ///                            type `Value`.
   /// - Parameter owner: The owning instance that this `Ref` instance's
   ///                    lifetime is based on.
-  @available(SwiftStdlib 6.4, *)
+  @available(StdlibDeploymentTarget 6.4, *)
   @unsafe
   @export(implementation)
   @_lifetime(borrow owner)
@@ -49,17 +49,17 @@ public struct Ref<Value: ~Copyable>: Copyable, ~Escapable {
   }
 }
 
-@available(SwiftStdlib 6.4, *)
+@available(StdlibDeploymentTarget 6.4, *)
 extension Ref: @unchecked Sendable where Value: Sendable & ~Copyable {}
 
-@available(SwiftStdlib 6.4, *)
+@available(StdlibDeploymentTarget 6.4, *)
 extension Ref: BitwiseCopyable {}
 
-@available(SwiftStdlib 6.4, *)
+@available(StdlibDeploymentTarget 6.4, *)
 extension Ref where Value: ~Copyable {
   /// Dereferences the constant reference allowing for in-place reads to the
   /// underlying value.
-  @available(SwiftStdlib 6.4, *)
+  @available(StdlibDeploymentTarget 6.4, *)
   @export(implementation)
   @_transparent
   public var value: Value {


### PR DESCRIPTION
There's no dependency on anything else that forces us to use SwiftStdlib, so these should be StdlibDeploymentTarget.