### PR TITLE
Early out of removeAll(where:) when the element is not found.

### DIFF
--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -1164,7 +1164,7 @@ extension RangeReplaceableCollection where Self: MutableCollection {
     where shouldBeRemoved: (Element) throws -> Bool
   ) rethrows {
     let suffixStart = try _halfStablePartition(isSuffixElement: shouldBeRemoved)
-    removeSubrange(suffixStart...)
+    if suffixStart != endIndex { removeSubrange(suffixStart...) }
   }
 }
 


### PR DESCRIPTION
If the element isn't there, there's nothing to be done, and we do not need to modify the collection or reverify any invariants.

Addresses rdar://179947621