### PR TITLE
Make new equatable/hashable conformances use StdlibDeploymentTarget

### DIFF
--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -247,10 +247,10 @@ extension CollectionOfOne where Element: Hashable {
   }
 }
 
-@available(SwiftStdlib 6.4, *)
+@available(StdlibDeploymentTarget 6.4, *)
 extension CollectionOfOne: Equatable where Element: Equatable {}
 
-@available(SwiftStdlib 6.4, *)
+@available(StdlibDeploymentTarget 6.4, *)
 extension CollectionOfOne: Hashable where Element: Hashable {}
 
 extension CollectionOfOne: ConvertibleToBytes

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1715,7 +1715,7 @@ extension Dictionary.Keys {
   }
 }
 
-@available(SwiftStdlib 6.4, *)
+@available(StdlibDeploymentTarget 6.4, *)
 extension Dictionary.Keys: Hashable {}
 
 extension Dictionary.Values {

--- a/stdlib/public/core/EmptyCollection.swift
+++ b/stdlib/public/core/EmptyCollection.swift
@@ -199,5 +199,5 @@ extension EmptyCollection {
   }
 }
 
-@available(SwiftStdlib 6.4, *)
+@available(StdlibDeploymentTarget 6.4, *)
 extension EmptyCollection: Hashable {}


### PR DESCRIPTION
These have no dependency outside the stdlib, so do not need to use SwiftStdlib 6.4
