### PR TITLE
[android] Switch compiling Swift source in stdlib and the test suite to target triples with the API level specified

### DIFF
--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -387,6 +387,7 @@ macro(configure_sdk_unix name architectures)
     if("${prefix}" STREQUAL "ANDROID")
       swift_android_sysroot(android_sysroot)
       set(SWIFT_SDK_ANDROID_ARCH_${arch}_PATH "${android_sysroot}")
+      set(SWIFT_SDK_ANDROID_TEST_DEPLOYMENT_VERSION "${SWIFT_ANDROID_API_LEVEL}")
 
       if("${arch}" STREQUAL "armv7")
         set(SWIFT_SDK_ANDROID_ARCH_${arch}_NDK_TRIPLE "arm-linux-androideabi")

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -2732,11 +2732,6 @@ function(add_swift_target_library name)
         list(APPEND swiftlib_link_flags_all "-Wl,-z,max-page-size=16384")
       endif()
 
-      # This is a Android-specific hack till we transition the stdlib fully to versioned triples.
-      if(sdk STREQUAL "ANDROID" AND name STREQUAL "swiftSwiftReflectionTest")
-        list(APPEND swiftlib_swift_compile_flags_all "-target" "${SWIFT_SDK_ANDROID_ARCH_${arch}_TRIPLE}${SWIFT_ANDROID_API_LEVEL}")
-      endif()
-
       if (SWIFTLIB_BACK_DEPLOYMENT_LIBRARY)
         set(back_deployment_library_option BACK_DEPLOYMENT_LIBRARY ${SWIFTLIB_BACK_DEPLOYMENT_LIBRARY})
       else()

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -270,6 +270,11 @@ function(_add_target_variant_swift_compile_flags
     if(target_variant)
       list(APPEND result "-target-variant" "${target_variant}")
     endif()
+  elseif("${sdk}" STREQUAL "ANDROID")
+    get_target_triple(target target_variant "${sdk}" "${arch}"
+    DEPLOYMENT_VERSION "${SWIFT_ANDROID_API_LEVEL}")
+
+    list(APPEND result "-target" "${target}")
   else()
     list(APPEND result
         "-target" "${SWIFT_SDK_${sdk}_ARCH_${arch}_TRIPLE}")

--- a/test/IRGen/availability_android.swift
+++ b/test/IRGen/availability_android.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -target %target-triple24 -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK-24
-// RUN: %target-swift-frontend -target %target-triple28 -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK-28
+// RUN: %target-swift-frontend -target %target-arch-unknown-linux-android24 -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK-24
+// RUN: %target-swift-frontend -target %target-arch-unknown-linux-android28 -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK-28
 
 // CHECK-24-LABEL: define{{.*}}$s20availability_android0A5CheckyyF
 // CHECK-24: call swiftcc i1 @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"(
@@ -7,7 +7,7 @@
 // CHECK-28-LABEL: define{{.*}}$s20availability_android0A5CheckyyF
 // CHECK-28-NOT: call swiftcc i1 @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"(
 
-// REQUIRES: OS=linux-android
+// REQUIRES: OS=linux-android, OS=linux-androideabi
 
 public func availabilityCheck() {
   if #available(Android 28, *) {

--- a/test/Interop/Cxx/class/invalid-members/stdlib-containers-of-incomplete.swift
+++ b/test/Interop/Cxx/class/invalid-members/stdlib-containers-of-incomplete.swift
@@ -30,9 +30,6 @@
 //
 // REQUIRES: swift_feature_ImportCxxMembersLazily
 
-// Requires specifying the Android API when compiling
-// XFAIL: OS=linux-android, OS=linux-androideabi
-
 //--- Inputs/module.modulemap
 module StdContain {
   header "std-contain-incomplete.h"

--- a/test/Reflection/noncopyable_field_typeref.swift
+++ b/test/Reflection/noncopyable_field_typeref.swift
@@ -9,6 +9,7 @@
 // rdar://100805115
 // UNSUPPORTED: CPU=arm64e
 // UNSUPPORTED: CPU=armv7k && OS=watchos
+// XFAIL: OS=linux-android, OS=linux-androideabi
 
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -target %module-target-future %s -parse-as-library -emit-module -emit-library -module-name NoncopyableFields -o %t/%target-library-name(NoncopyableFields)

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2080,8 +2080,7 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
     config.target_build_swift = ' '.join([
         config.swiftc,
         '-target', config.variant_triple,
-        '-sdk', config.variant_sdk, '-Xclang-linker',
-        '--target={}{}'.format(config.variant_triple, config.android_api_level),
+        '-sdk', config.variant_sdk,
         '-tools-directory', tools_directory,
         config.resource_dir_opt, mcp_opt, config.swift_test_options,
         config.swift_driver_test_options, swift_execution_tests_extra_flags])
@@ -2134,8 +2133,7 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
         config.swiftc,
         '-target', config.variant_triple,
         '-toolchain-stdlib-rpath',
-        '-sdk', config.variant_sdk, '-Xclang-linker',
-        '--target={}{}'.format(config.variant_triple, config.android_api_level),
+        '-sdk', config.variant_sdk,
         '-tools-directory', tools_directory,
         config.resource_dir_opt, mcp_opt,
         config.swift_driver_test_options])


### PR DESCRIPTION
We were already doing this for the C/C++ source in the stdlib and linking against the Android libc with the API level given, resolves #85522.