### PR TITLE
Sema: Ban unavailable computed properties with initial values

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7537,13 +7537,21 @@ ERROR(availability_global_script_no_unavailable,
       none, "global variable cannot be marked unavailable "
       "with '@available' in script mode", ())
 
-ERROR(availability_stored_property_no_potential,
-      none, "stored properties cannot be marked potentially unavailable with "
-      "'@available'", ())
+#define NO_AVAILABLE_ON_PROPERTY_SELECT "select{" \
+      "stored properties|" \
+      "computed property with initial value}"
 
-ERROR(availability_stored_property_no_unavailable,
-      none, "stored properties cannot be marked unavailable with '@available'",
-      ())
+ERROR(availability_stored_property_no_potential, none,
+      "%" NO_AVAILABLE_ON_PROPERTY_SELECT "0 "
+      "cannot be marked potentially unavailable with '@available'",
+      (unsigned))
+
+ERROR(availability_stored_property_no_unavailable, none,
+      "%" NO_AVAILABLE_ON_PROPERTY_SELECT "0 "
+      "cannot be marked unavailable with '@available'",
+      (unsigned))
+
+#undef NO_AVAILABLE_ON_PROPERTY_SELECT
 
 ERROR(availability_enum_element_no_potential,
       none, "enum cases with associated values cannot be marked potentially unavailable with "

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5971,6 +5971,25 @@ Type TypeChecker::checkReferenceOwnershipAttr(VarDecl *var, Type type,
   return ReferenceStorageType::get(type, ownershipKind, var->getASTContext());
 }
 
+// The raw values of this enum must be kept in sync with the select clause
+// in diag::availability_stored_property_no_potential and
+// diag::availability_stored_property_no_unavailable.
+enum NoAvailableAttrDiagnosticPropertyKind : unsigned {
+  StoredProperty,
+  ComputedPropertyWithInitialValue,
+};
+
+static std::optional<NoAvailableAttrDiagnosticPropertyKind>
+getPropertyKindForAvailableAttrDiagnostic(const VarDecl *VD) {
+  if (VD->hasStorageOrWrapsStorage())
+    return StoredProperty;
+
+  if (VD->hasInitialValue())
+    return ComputedPropertyWithInitialValue;
+
+  return std::nullopt;
+}
+
 std::optional<Diagnostic>
 TypeChecker::diagnosticIfDeclCannotBePotentiallyUnavailable(const Decl *D) {
   auto *DC = D->getDeclContext();
@@ -5986,7 +6005,8 @@ TypeChecker::diagnosticIfDeclCannotBePotentiallyUnavailable(const Decl *D) {
   }
 
   if (auto *VD = dyn_cast<VarDecl>(D)) {
-    if (!VD->hasStorageOrWrapsStorage())
+    auto disallowedKind = ::getPropertyKindForAvailableAttrDiagnostic(VD);
+    if (!disallowedKind)
       return std::nullopt;
 
     // Do not permit potential availability of script-mode global variables;
@@ -5998,7 +6018,8 @@ TypeChecker::diagnosticIfDeclCannotBePotentiallyUnavailable(const Decl *D) {
     // Globals and statics are lazily initialized, so they are safe
     // for potential unavailability.
     if (!VD->isStatic() && !DC->isModuleScopeContext())
-      return diag::availability_stored_property_no_potential;
+      return Diagnostic(diag::availability_stored_property_no_potential,
+                        unsigned(*disallowedKind));
 
   } else if (auto *EED = dyn_cast<EnumElementDecl>(D)) {
     // An enum element with an associated value cannot be potentially
@@ -6060,7 +6081,8 @@ TypeChecker::diagnosticIfDeclCannotBeUnavailable(const Decl *D,
   }
 
   if (auto *VD = dyn_cast<VarDecl>(D)) {
-    if (!VD->hasStorageOrWrapsStorage())
+    auto disallowedKind = ::getPropertyKindForAvailableAttrDiagnostic(VD);
+    if (!disallowedKind)
       return std::nullopt;
 
     if (parentIsUnavailable(D))
@@ -6084,7 +6106,8 @@ TypeChecker::diagnosticIfDeclCannotBeUnavailable(const Decl *D,
     // Globals and statics are lazily initialized, so they are safe for
     // unavailability.
     if (!VD->isStatic() && !D->getDeclContext()->isModuleScopeContext())
-      return diag::availability_stored_property_no_unavailable;
+      return Diagnostic(diag::availability_stored_property_no_unavailable,
+                        unsigned(*disallowedKind));
   }
 
   return std::nullopt;

--- a/test/Availability/availability_script_mode.swift
+++ b/test/Availability/availability_script_mode.swift
@@ -32,3 +32,21 @@ var unavailableOnMacOSVar: UnavailableOnMacOS = .init() // expected-error {{'Una
 
 @available(*, unavailable) // expected-error {{global variable cannot be marked unavailable with '@available' in script mode}}
 var unconditionallyUnavailableVar: UnavailableUnconditionally = .init() // expected-error {{'UnavailableUnconditionally' is unavailable}}
+
+// Computed globals have no initial value to execute eagerly, so they are safe
+// to mark unavailable in script mode.
+
+@available(macOS, introduced: 51)
+var computedPotentiallyUnavailableVar: Available51 {
+  Available51()
+}
+
+@available(macOS, unavailable)
+var computedUnavailableOnMacOSVar: UnavailableOnMacOS {
+  UnavailableOnMacOS()
+}
+
+@available(*, unavailable)
+var computedUnconditionallyUnavailableVar: UnavailableUnconditionally {
+  UnavailableUnconditionally()
+}

--- a/test/Availability/availability_stored.swift
+++ b/test/Availability/availability_stored.swift
@@ -27,6 +27,22 @@ struct GoodReferenceStruct {
   var x: NewStruct
   @NewPropertyWrapper var y: Int
   lazy var z: Int = 42
+  var computed: NewStruct {
+    get { x }
+    set { x = newValue }
+  }
+  var computedWithInit: NewStruct {
+    init { _ = newValue }
+    get { x }
+  }
+  var computedWithInitialValue: NewStruct = .init() {
+    init { _ = newValue }
+    get { x }
+  }
+  var computedWithImplicitInitialValue: NewStruct? {
+    init { _ = newValue }
+    get { x }
+  }
 }
 
 @available(macOS 50, *)
@@ -38,7 +54,7 @@ struct GoodNestedReferenceStruct {
   }
 }
 
-struct BadReferenceStruct1 { // expected-note {{add '@available' attribute to enclosing struct}}
+struct BadReferenceStruct1 { // expected-note 3 {{add '@available' attribute to enclosing struct}}
   // expected-error@+1 {{stored properties cannot be marked potentially unavailable with '@available'}}
   @available(macOS 50, *)
   var x: NewStruct // expected-error {{'NewStruct' is only available in macOS 50 or newer}}
@@ -50,6 +66,32 @@ struct BadReferenceStruct1 { // expected-note {{add '@available' attribute to en
   // expected-error@+1 {{stored properties cannot be marked potentially unavailable with '@available'}}
   @available(macOS 50, *)
   lazy var z: Int = 42
+
+  @available(macOS 50, *)
+  var computed: NewStruct {
+    get { x }
+    set { x = newValue }
+  }
+
+  @available(macOS 50, *)
+  var computedWithInit: NewStruct {
+    init { _ = newValue }
+    get { x }
+  }
+
+  // expected-error@+1 {{computed property with initial value cannot be marked potentially unavailable with '@available'}}
+  @available(macOS 50, *)
+  var computedWithInitialValue: NewStruct = .init() { // expected-error {{'NewStruct' is only available in macOS 50 or newer}}
+    init { _ = newValue }
+    get { x }
+  }
+
+  // expected-error@+1 {{computed property with initial value cannot be marked potentially unavailable with '@available'}}
+  @available(macOS 50, *)
+  var computedWithImplicitInitialValue: NewStruct? { // expected-error {{'NewStruct' is only available in macOS 50 or newer}}
+    init { _ = newValue }
+    get { x }
+  }
 }
 
 @available(macOS 40, *)
@@ -65,6 +107,32 @@ struct BadReferenceStruct2 {
   // expected-error@+1 {{stored properties cannot be marked potentially unavailable with '@available'}}
   @available(macOS 50, *)
   lazy var z: Int = 42
+
+  @available(macOS 50, *)
+  var computed: NewStruct {
+    get { x }
+    set { x = newValue }
+  }
+
+  @available(macOS 50, *)
+  var computedWithInit: NewStruct {
+    init { _ = newValue }
+    get { x }
+  }
+
+  // expected-error@+1 {{computed property with initial value cannot be marked potentially unavailable with '@available'}}
+  @available(macOS 50, *)
+  var computedWithInitialValue: NewStruct = .init() { // expected-error {{'NewStruct' is only available in macOS 50 or newer}}
+    init { _ = newValue }
+    get { x }
+  }
+
+  // expected-error@+1 {{computed property with initial value cannot be marked potentially unavailable with '@available'}}
+  @available(macOS 50, *)
+  var computedWithImplicitInitialValue: NewStruct? { // expected-error {{'NewStruct' is only available in macOS 50 or newer}}
+    init { _ = newValue }
+    get { x }
+  }
 }
 
 @available(macOS 40, *)
@@ -80,6 +148,32 @@ public struct PublicStruct {
   // expected-error@+1 {{stored properties cannot be marked potentially unavailable with '@available'}}
   @available(macOS 50, *)
   public lazy var z: Int = 42
+
+  @available(macOS 50, *)
+  public var computed: NewStruct {
+    get { x }
+    set { x = newValue }
+  }
+
+  @available(macOS 50, *)
+  public var computedWithInit: NewStruct {
+    init { _ = newValue }
+    get { x }
+  }
+
+  // expected-error@+1 {{computed property with initial value cannot be marked potentially unavailable with '@available'}}
+  @available(macOS 50, *)
+  public var computedWithInitialValue: NewStruct = .init() { // expected-error {{'NewStruct' is only available in macOS 50 or newer}}
+    init { _ = newValue }
+    get { x }
+  }
+
+  // expected-error@+1 {{computed property with initial value cannot be marked potentially unavailable with '@available'}}
+  @available(macOS 50, *)
+  public var computedWithImplicitInitialValue: NewStruct? { // expected-error {{'NewStruct' is only available in macOS 50 or newer}}
+    init { _ = newValue }
+    get { x }
+  }
 }
 
 // The same behavior should hold for enum elements with payloads.

--- a/test/Availability/availability_stored_unavailable.swift
+++ b/test/Availability/availability_stored_unavailable.swift
@@ -3,14 +3,14 @@
 // REQUIRES: OS=macosx
 
 @available(macOS, unavailable)
-struct UnavailableMacOSStruct {} // expected-note 2 {{'UnavailableMacOSStruct' has been explicitly marked unavailable here}}
+struct UnavailableMacOSStruct {} // expected-note 4 {{'UnavailableMacOSStruct' has been explicitly marked unavailable here}}
 
 @available(iOS, introduced: 8.0)
 @_spi_available(macOS, introduced: 10.9)
 public struct SPIAvailableMacOSStruct {}
 
 @available(*, unavailable)
-public struct UniversallyUnavailableStruct {} // expected-note {{'UniversallyUnavailableStruct' has been explicitly marked unavailable here}}
+public struct UniversallyUnavailableStruct {} // expected-note 3 {{'UniversallyUnavailableStruct' has been explicitly marked unavailable here}}
 
 // Ok, initialization of globals is lazy and boxed.
 @available(macOS, unavailable)
@@ -22,6 +22,14 @@ var spiAvailableMacOSGlobal: SPIAvailableMacOSStruct = .init()
 
 @available(*, unavailable)
 var universallyUnavailableGlobal: UniversallyUnavailableStruct = .init()
+
+// Computed globals have no initial value to execute eagerly, so they are safe
+// to mark unavailable.
+@available(macOS, unavailable)
+var computedUnavailableMacOSGlobal: UnavailableMacOSStruct { .init() }
+
+@available(*, unavailable)
+var computedUniversallyUnavailableGlobal: UniversallyUnavailableStruct { .init() }
 
 struct GoodAvailableStruct {
   // Ok, computed property.
@@ -37,6 +45,13 @@ struct GoodAvailableStruct {
   // Ok, initialization of static vars is lazy and boxed.
   @available(macOS, unavailable)
   static var staticUnavailableMacOS: UnavailableMacOSStruct = .init()
+
+  // Ok, an init accessor without an initial value has no initialization to run.
+  @available(macOS, unavailable)
+  var unavailableMacOSComputedWithInit: UnavailableMacOSStruct {
+    init { _ = newValue }
+    get { UnavailableMacOSStruct() }
+  }
 }
 
 @available(macOS, unavailable)
@@ -47,6 +62,13 @@ struct GoodUnavailableMacOSStruct {
   // Ok, the container is unavailable.
   @available(macOS, unavailable)
   var unavailableMacOSExplicit: UnavailableMacOSStruct = .init()
+
+  // Ok, the container is unavailable.
+  @available(macOS, unavailable)
+  var unavailableMacOSComputedWithInitialValue: UnavailableMacOSStruct = .init() {
+    init { _ = newValue }
+    get { UnavailableMacOSStruct() }
+  }
 }
 
 @available(macOS, unavailable)
@@ -82,6 +104,31 @@ struct BadStruct {
   // expected-error@+1 {{stored properties cannot be marked unavailable with '@available'}}
   @available(*, unavailable)
   var universallyUnavailable: UniversallyUnavailableStruct = .init() // expected-error {{'UniversallyUnavailableStruct' is unavailable}}
+
+  // Ok, pure computed property.
+  @available(macOS, unavailable)
+  var computedUnavailableMacOS: UnavailableMacOSStruct { .init() }
+
+  // Ok, init accessor without an initial value.
+  @available(macOS, unavailable)
+  var computedUnavailableMacOSWithInit: UnavailableMacOSStruct {
+    init { _ = newValue }
+    get { UnavailableMacOSStruct() }
+  }
+
+  // expected-error@+1 {{computed property with initial value cannot be marked unavailable with '@available'}}
+  @available(macOS, unavailable)
+  var computedUnavailableMacOSWithInitialValue: UnavailableMacOSStruct = .init() { // expected-error {{'UnavailableMacOSStruct' is unavailable in macOS}}
+    init { _ = newValue }
+    get { UnavailableMacOSStruct() } // expected-error {{'UnavailableMacOSStruct' is unavailable in macOS}}
+  }
+
+  // expected-error@+1 {{computed property with initial value cannot be marked unavailable with '@available'}}
+  @available(*, unavailable)
+  var computedUniversallyUnavailableWithInitialValue: UniversallyUnavailableStruct = .init() { // expected-error {{'UniversallyUnavailableStruct' is unavailable}}
+    init { _ = newValue }
+    get { UniversallyUnavailableStruct() } // expected-error {{'UniversallyUnavailableStruct' is unavailable}}
+  }
 }
 
 enum GoodAvailableEnum {


### PR DESCRIPTION
A computed property with an init accessor may also have an initial value, which is executed at instance initialization time just like the initial value of a stored property. These properties cannot be allowed to be unavailable or potentially unavailable because the compiler does not know how to safely generate the code to execute the initial value expressions.

Resolves rdar://174187778.
