### PR TITLE
[Embedded] Allow enabling @export(interface), LTO, and the platform abstraction layer on a per-triple basis

### DIFF
--- a/lib/LLVMPasses/LLVMARCContract.cpp
+++ b/lib/LLVMPasses/LLVMARCContract.cpp
@@ -271,15 +271,17 @@ bool SwiftARCContractImpl::run() {
 
       auto Kind = classifyInstruction(Inst);
       switch (Kind) {
-      // These instructions should not reach here based on the pass ordering.
-      // i.e. LLVMARCOpt -> LLVMContractOpt.
+      // The *_n forms are normally created by this pass, so we shouldn't
+      // encounter them on input. But IR that defines the runtime entry
+      // points themselves (e.g. EmbeddedRuntime.swift) can contain calls
+      // to them directly, so just leave them alone.
       case RT_RetainN:
       case RT_UnknownObjectRetainN:
       case RT_BridgeRetainN:
       case RT_ReleaseN:
       case RT_UnknownObjectReleaseN:
       case RT_BridgeReleaseN:
-        llvm_unreachable("These are only created by LLVMARCContract !");
+        break;
       // Delete all fix lifetime and end borrow instructions. After llvm-ir they
       // have no use and show up as calls in the final binary.
       case RT_FixLifetime:

--- a/lib/LLVMPasses/LLVMARCOpts.cpp
+++ b/lib/LLVMPasses/LLVMARCOpts.cpp
@@ -89,15 +89,17 @@ static bool canonicalizeInputFunction(Function &F, ARCEntryPointBuilder &B,
       Instruction &Inst = *I++;
 
       switch (classifyInstruction(Inst)) {
-      // These instructions should not reach here based on the pass ordering.
-      // i.e. LLVMARCOpt -> LLVMContractOpt.
+      // The *_n forms are normally only created by LLVMARCContract, which
+      // runs after this pass. But IR that defines the runtime entry points
+      // themselves (e.g. EmbeddedRuntime.swift) can contain calls to them
+      // directly, so just leave them alone.
       case RT_RetainN:
       case RT_UnknownObjectRetainN:
       case RT_BridgeRetainN:
       case RT_ReleaseN:
       case RT_UnknownObjectReleaseN:
       case RT_BridgeReleaseN:
-        llvm_unreachable("These are only created by LLVMARCContract !");
+        break;
       case RT_Unknown:
       case RT_BridgeRelease:
       case RT_AllocObject:
@@ -286,15 +288,17 @@ static bool performLocalReleaseMotion(CallInst &Release, BasicBlock &BB,
     }
 
     switch (classifyInstruction(*BBI)) {
-    // These instructions should not reach here based on the pass ordering.
-    // i.e. LLVMARCOpt -> LLVMContractOpt.
+    // The *_n forms are normally only created by LLVMARCContract, which
+    // runs after this pass. But IR that defines the runtime entry points
+    // themselves (e.g. EmbeddedRuntime.swift) can contain calls to them
+    // directly, so just leave them alone.
     case RT_UnknownObjectRetainN:
     case RT_BridgeRetainN:
     case RT_RetainN:
     case RT_UnknownObjectReleaseN:
     case RT_BridgeReleaseN:
     case RT_ReleaseN:
-        llvm_unreachable("These are only created by LLVMARCContract !");
+        break;
     case RT_NoMemoryAccessed:
       // Skip over random instructions that don't touch memory.  They don't need
       // protection by retain/release.
@@ -436,15 +440,17 @@ static bool performLocalRetainMotion(CallInst &Retain, BasicBlock &BB,
     // can be skipped and is interesting, and a "continue" when it is a retain
     // of the same pointer.
     switch (classifyInstruction(CurInst)) {
-    // These instructions should not reach here based on the pass ordering.
-    // i.e. LLVMARCOpt -> LLVMContractOpt.
+    // The *_n forms are normally only created by LLVMARCContract, which
+    // runs after this pass. But IR that defines the runtime entry points
+    // themselves (e.g. EmbeddedRuntime.swift) can contain calls to them
+    // directly, so just leave them alone.
     case RT_RetainN:
     case RT_UnknownObjectRetainN:
     case RT_BridgeRetainN:
     case RT_ReleaseN:
     case RT_UnknownObjectReleaseN:
     case RT_BridgeReleaseN:
-        llvm_unreachable("These are only created by LLVMARCContract !");
+        break;
     case RT_NoMemoryAccessed:
     case RT_AllocObject:
     case RT_CheckUnowned:
@@ -590,15 +596,17 @@ static DtorKind analyzeDestructor(Value *P) {
     for (Instruction &I : BB) {
       // Note that the destructor may not be in any particular canonical form.
       switch (classifyInstruction(I)) {
-      // These instructions should not reach here based on the pass ordering.
-      // i.e. LLVMARCOpt -> LLVMContractOpt.
+      // The *_n forms are normally only created by LLVMARCContract, which
+      // runs after this pass. But IR that defines the runtime entry points
+      // themselves (e.g. EmbeddedRuntime.swift) can contain calls to them
+      // directly, so just leave them alone.
       case RT_RetainN:
       case RT_UnknownObjectRetainN:
       case RT_BridgeRetainN:
       case RT_ReleaseN:
       case RT_UnknownObjectReleaseN:
       case RT_BridgeReleaseN:
-        llvm_unreachable("These are only created by LLVMARCContract !");
+        break;
       case RT_NoMemoryAccessed:
       case RT_AllocObject:
       case RT_FixLifetime:
@@ -706,15 +714,17 @@ static bool performStoreOnlyObjectElimination(CallInst &Allocation,
 
     // Okay, this is the first time we've seen this instruction, proceed.
     switch (classifyInstruction(*I)) {
-    // These instructions should not reach here based on the pass ordering.
-    // i.e. LLVMARCOpt -> LLVMContractOpt.
+    // The *_n forms are normally only created by LLVMARCContract, which
+    // runs after this pass. But IR that defines the runtime entry points
+    // themselves (e.g. EmbeddedRuntime.swift) can contain calls to them
+    // directly, so just leave them alone.
     case RT_RetainN:
     case RT_UnknownObjectRetainN:
     case RT_BridgeRetainN:
     case RT_ReleaseN:
     case RT_UnknownObjectReleaseN:
     case RT_BridgeReleaseN:
-      llvm_unreachable("These are only created by LLVMARCContract !");
+      break;
     case RT_AllocObject:
       // If this is a different swift_allocObject than we started with, then
       // there is some computation feeding into a size or alignment computation

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -1067,6 +1067,14 @@ bool SILFunction::hasValidLinkageForFragileRef(SerializedKind_t callerSerialized
   if (isExternForwardDeclaration())
     return true;
 
+  // A function exported through the interface-mode contract has its body
+  // emitted as a strong external definition by its owning module, not
+  // inlined into clients. A serialized caller in another module can
+  // reference it by name; the linker resolves the call to the owning
+  // module's definition.
+  if (isNeverEmitIntoClient())
+    return true;
+
   // The call site of this function must have checked that
   // caller.isAnySerialized() is true, as indicated by the
   // function name itself (contains 'ForFragileRef').

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -965,7 +965,22 @@ function(add_swift_target_library_single target name)
     # SWIFT_USE_EMBEDDED_SWIFT_PLATFORM for every embedded library build so
     # that the platform-conditional code paths in the embedded stdlib and
     # related libraries pick up the platform implementations.
+    #
+    # The abstraction layer is on for a given triple when either the
+    # global SWIFT_USE_SWIFT_EMBEDDED_PLATFORM is TRUE, or the triple
+    # matches SWIFT_EMBEDDED_PLATFORM_ABSTRACTION_LAYER_TRIPLE_REGEX.
+    set(_emblib_pal_triple
+      "${SWIFT_SDK_embedded_ARCH_${SWIFTLIB_SINGLE_ARCHITECTURE}_TRIPLE}")
+    set(_emblib_use_pal FALSE)
     if(SWIFT_USE_SWIFT_EMBEDDED_PLATFORM)
+      set(_emblib_use_pal TRUE)
+    elseif(SWIFT_EMBEDDED_PLATFORM_ABSTRACTION_LAYER_TRIPLE_REGEX
+           AND _emblib_pal_triple
+           AND "${_emblib_pal_triple}" MATCHES
+               "${SWIFT_EMBEDDED_PLATFORM_ABSTRACTION_LAYER_TRIPLE_REGEX}")
+      set(_emblib_use_pal TRUE)
+    endif()
+    if(_emblib_use_pal)
       list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS
         "-D" "SWIFT_USE_EMBEDDED_SWIFT_PLATFORM")
     endif()

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1082,17 +1082,58 @@ function(add_swift_target_library_single target name)
       # Flags required to build embedded libraries
       list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS -Xcc;-ffreestanding;-enable-experimental-feature;Embedded)
 
-      # For triples matching SWIFT_EMBEDDED_INTERFACE_LTO_TRIPLE_REGEX, switch
-      # the library's whole-module code generation model to Interface and turn
-      # on LLVM LTO so the library's object files contain real (bitcode) code
-      # instead of being empty stubs.
+      # Two orthogonal per-triple opt-ins gate the departures from the
+      # default embedded stdlib build:
+      #
+      #   SWIFT_EMBEDDED_STDLIB_INTERFACE_CGM_TRIPLE_REGEX
+      #     Build under CodeGenerationModel=interface. The library's
+      #     object files contain real code (not empty stubs) and clients
+      #     reference its strong external symbols. Without this, we stay
+      #     on the default Inlinable model, emit an empty object file,
+      #     and drive `CodeGenerationModel=implementation` — unless the
+      #     caller opts out with NON_EMPTY_OBJECT_FILE.
+      #
+      #   SWIFT_EMBEDDED_STDLIB_LTO_TRIPLE_REGEX
+      #     Compile Swift and C/C++ sources with LLVM LTO
+      #     (`-lto=<type>` / `-flto=<type>`). Applying LTO on top of the
+      #     default empty-object-file build is harmless but produces no
+      #     meaningful bitcode; you almost always want the same triple
+      #     set for both regexes.
       set(_emblib_triple
         "${SWIFT_SDK_embedded_ARCH_${SWIFTLIB_SINGLE_ARCHITECTURE}_TRIPLE}")
-      if(SWIFT_EMBEDDED_INTERFACE_LTO_TRIPLE_REGEX
+
+      set(_emblib_interface_cgm FALSE)
+      if(SWIFT_EMBEDDED_STDLIB_INTERFACE_CGM_TRIPLE_REGEX
          AND _emblib_triple
-         AND "${_emblib_triple}" MATCHES "${SWIFT_EMBEDDED_INTERFACE_LTO_TRIPLE_REGEX}")
+         AND "${_emblib_triple}" MATCHES "${SWIFT_EMBEDDED_STDLIB_INTERFACE_CGM_TRIPLE_REGEX}")
+        set(_emblib_interface_cgm TRUE)
+      endif()
+
+      set(_emblib_lto FALSE)
+      if(SWIFT_EMBEDDED_STDLIB_LTO_TRIPLE_REGEX
+         AND _emblib_triple
+         AND "${_emblib_triple}" MATCHES "${SWIFT_EMBEDDED_STDLIB_LTO_TRIPLE_REGEX}")
+        set(_emblib_lto TRUE)
+      endif()
+
+      if(_emblib_interface_cgm)
         list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS
-          -enable-experimental-feature;CodeGenerationModel=interface
+          -enable-experimental-feature;CodeGenerationModel=interface)
+      else()
+        # Embedded Swift libraries default to producing an empty object
+        # file: they only serve as a swiftmodule for client compilation,
+        # and the client emits the actual code. Libraries that are meant
+        # to be linked in without their swiftmodule ever being imported
+        # (e.g. the EmbeddedPlatform shim archives) must opt out with
+        # NON_EMPTY_OBJECT_FILE so their .a files actually contain code.
+        if(NOT SWIFTLIB_SINGLE_NON_EMPTY_OBJECT_FILE)
+          list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS -Xfrontend;-emit-empty-object-file)
+        endif()
+        list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS -enable-experimental-feature;CodeGenerationModel=implementation)
+      endif()
+
+      if(_emblib_lto)
+        list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS
           "-lto=${SWIFT_EMBEDDED_LTO_TYPE}")
         if("${SWIFT_EMBEDDED_LTO_TYPE}" STREQUAL "llvm-thin")
           list(APPEND SWIFTLIB_SINGLE_C_COMPILE_FLAGS "-flto=thin")
@@ -1103,17 +1144,6 @@ function(add_swift_target_library_single target name)
             "SWIFT_EMBEDDED_LTO_TYPE must be 'llvm-thin' or 'llvm-full' "
             "(got '${SWIFT_EMBEDDED_LTO_TYPE}')")
         endif()
-      else()
-        # Embedded Swift libraries default to producing an empty object file:
-        # they only serve as a swiftmodule for client compilation, and the
-        # client emits the actual code. Libraries that are meant to be linked
-        # in without their swiftmodule ever being imported (e.g. the
-        # EmbeddedPlatform shim archives) must opt out with
-        # NON_EMPTY_OBJECT_FILE so their .a files actually contain code.
-        if(NOT SWIFTLIB_SINGLE_NON_EMPTY_OBJECT_FILE)
-          list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS -Xfrontend;-emit-empty-object-file)
-        endif()
-        list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS -enable-experimental-feature;CodeGenerationModel=implementation)
       endif()
   endif()
 

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1082,16 +1082,39 @@ function(add_swift_target_library_single target name)
       # Flags required to build embedded libraries
       list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS -Xcc;-ffreestanding;-enable-experimental-feature;Embedded)
 
-      # Embedded Swift libraries default to producing an empty object file:
-      # they only serve as a swiftmodule for client compilation, and the
-      # client emits the actual code. Libraries that are meant to be linked
-      # in without their swiftmodule ever being imported (e.g. the
-      # EmbeddedPlatform shim archives) must opt out with
-      # NON_EMPTY_OBJECT_FILE so their .a files actually contain code.
-      if(NOT SWIFTLIB_SINGLE_NON_EMPTY_OBJECT_FILE)
-        list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS -Xfrontend;-emit-empty-object-file)
+      # For triples matching SWIFT_EMBEDDED_INTERFACE_LTO_TRIPLE_REGEX, switch
+      # the library's whole-module code generation model to Interface and turn
+      # on LLVM LTO so the library's object files contain real (bitcode) code
+      # instead of being empty stubs.
+      set(_emblib_triple
+        "${SWIFT_SDK_embedded_ARCH_${SWIFTLIB_SINGLE_ARCHITECTURE}_TRIPLE}")
+      if(SWIFT_EMBEDDED_INTERFACE_LTO_TRIPLE_REGEX
+         AND _emblib_triple
+         AND "${_emblib_triple}" MATCHES "${SWIFT_EMBEDDED_INTERFACE_LTO_TRIPLE_REGEX}")
+        list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS
+          -enable-experimental-feature;CodeGenerationModel=interface
+          "-lto=${SWIFT_EMBEDDED_LTO_TYPE}")
+        if("${SWIFT_EMBEDDED_LTO_TYPE}" STREQUAL "llvm-thin")
+          list(APPEND SWIFTLIB_SINGLE_C_COMPILE_FLAGS "-flto=thin")
+        elseif("${SWIFT_EMBEDDED_LTO_TYPE}" STREQUAL "llvm-full")
+          list(APPEND SWIFTLIB_SINGLE_C_COMPILE_FLAGS "-flto=full")
+        else()
+          message(FATAL_ERROR
+            "SWIFT_EMBEDDED_LTO_TYPE must be 'llvm-thin' or 'llvm-full' "
+            "(got '${SWIFT_EMBEDDED_LTO_TYPE}')")
+        endif()
+      else()
+        # Embedded Swift libraries default to producing an empty object file:
+        # they only serve as a swiftmodule for client compilation, and the
+        # client emits the actual code. Libraries that are meant to be linked
+        # in without their swiftmodule ever being imported (e.g. the
+        # EmbeddedPlatform shim archives) must opt out with
+        # NON_EMPTY_OBJECT_FILE so their .a files actually contain code.
+        if(NOT SWIFTLIB_SINGLE_NON_EMPTY_OBJECT_FILE)
+          list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS -Xfrontend;-emit-empty-object-file)
+        endif()
+        list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS -enable-experimental-feature;CodeGenerationModel=implementation)
       endif()
-      list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS -enable-experimental-feature;CodeGenerationModel=implementation)
   endif()
 
   # Define availability macros.

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -146,6 +146,18 @@ option(SWIFT_USE_SWIFT_EMBEDDED_PLATFORM
        "Whether to build the Embedded Swift standard library using the hooks in swift/EmbeddedPlatform.h"
        FALSE)
 
+set(SWIFT_EMBEDDED_INTERFACE_LTO_TRIPLE_REGEX "" CACHE STRING
+    "If non-empty, embedded Swift target triples matching this regex are
+built using the Interface code-generation model with LLVM LTO. The
+resulting libraries' object files contain real code (rather than the
+empty/stub objects produced for the default Inlinable model). All other
+embedded triples build as before.")
+
+set(SWIFT_EMBEDDED_LTO_TYPE "llvm-full" CACHE STRING
+    "LTO type for embedded Swift libraries selected by
+SWIFT_EMBEDDED_INTERFACE_LTO_TRIPLE_REGEX. Either 'llvm-thin' or
+'llvm-full'.")
+
 set(SWIFT_EMBEDDED_STDLIB_EXTRA_TARGET_TRIPLES "" CACHE STRING
     "List of extra target triples to build the embedded Swift standard library for")
 

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -146,20 +146,29 @@ option(SWIFT_USE_SWIFT_EMBEDDED_PLATFORM
        "Whether to build the Embedded Swift standard library using the hooks in swift/EmbeddedPlatform.h"
        FALSE)
 
+set(SWIFT_EMBEDDED_PLATFORM_ABSTRACTION_LAYER_TRIPLE_REGEX "" CACHE STRING
+    "If non-empty, embedded Swift target triples matching this regex are
+    built using the platform abstraction layer (hooks in
+    swift/EmbeddedPlatform.h). This is the per-triple analogue of
+    SWIFT_USE_SWIFT_EMBEDDED_PLATFORM (which turns the abstraction layer on
+    for every embedded triple); the two are OR'd together, so a triple
+    uses the abstraction layer when either the global option is TRUE or the
+    regex matches.")
+
 set(SWIFT_EMBEDDED_STDLIB_INTERFACE_CGM_TRIPLE_REGEX "" CACHE STRING
     "If non-empty, embedded Swift target triples matching this regex are
-built using the Interface code-generation model. Their libraries' object
-files contain real code (rather than the empty/stub objects produced for
-the default Inlinable model), and clients reference the library's strong
-external symbols instead of re-emitting `linkonce_odr` copies.")
+    built using the Interface code-generation model. Their libraries' object
+    files contain real code (rather than the empty/stub objects produced for
+    the default Inlinable model), and clients reference the library's strong
+    external symbols instead of re-emitting `linkonce_odr` copies.")
 
 set(SWIFT_EMBEDDED_STDLIB_LTO_TRIPLE_REGEX "" CACHE STRING
     "If non-empty, embedded Swift target triples matching this regex are
-compiled with LLVM LTO (-lto=<type>). This is orthogonal to
-SWIFT_EMBEDDED_STDLIB_INTERFACE_CGM_TRIPLE_REGEX — enabling LTO on
-triples that still use the default (empty-object-file) code-generation
-model is harmless but produces no meaningful bitcode; you almost always
-want to select the same triple set for both.")
+    compiled with LLVM LTO (-lto=<type>). This is orthogonal to
+    SWIFT_EMBEDDED_STDLIB_INTERFACE_CGM_TRIPLE_REGEX — enabling LTO on
+    triples that still use the default (empty-object-file) code-generation
+    model is harmless but produces no meaningful bitcode; you almost always
+    want to select the same triple set for both.")
 
 set(SWIFT_EMBEDDED_LTO_TYPE "llvm-full" CACHE STRING
     "LTO type for embedded Swift libraries selected by

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -146,16 +146,24 @@ option(SWIFT_USE_SWIFT_EMBEDDED_PLATFORM
        "Whether to build the Embedded Swift standard library using the hooks in swift/EmbeddedPlatform.h"
        FALSE)
 
-set(SWIFT_EMBEDDED_INTERFACE_LTO_TRIPLE_REGEX "" CACHE STRING
+set(SWIFT_EMBEDDED_STDLIB_INTERFACE_CGM_TRIPLE_REGEX "" CACHE STRING
     "If non-empty, embedded Swift target triples matching this regex are
-built using the Interface code-generation model with LLVM LTO. The
-resulting libraries' object files contain real code (rather than the
-empty/stub objects produced for the default Inlinable model). All other
-embedded triples build as before.")
+built using the Interface code-generation model. Their libraries' object
+files contain real code (rather than the empty/stub objects produced for
+the default Inlinable model), and clients reference the library's strong
+external symbols instead of re-emitting `linkonce_odr` copies.")
+
+set(SWIFT_EMBEDDED_STDLIB_LTO_TRIPLE_REGEX "" CACHE STRING
+    "If non-empty, embedded Swift target triples matching this regex are
+compiled with LLVM LTO (-lto=<type>). This is orthogonal to
+SWIFT_EMBEDDED_STDLIB_INTERFACE_CGM_TRIPLE_REGEX — enabling LTO on
+triples that still use the default (empty-object-file) code-generation
+model is harmless but produces no meaningful bitcode; you almost always
+want to select the same triple set for both.")
 
 set(SWIFT_EMBEDDED_LTO_TYPE "llvm-full" CACHE STRING
     "LTO type for embedded Swift libraries selected by
-SWIFT_EMBEDDED_INTERFACE_LTO_TRIPLE_REGEX. Either 'llvm-thin' or
+SWIFT_EMBEDDED_STDLIB_LTO_TRIPLE_REGEX. Either 'llvm-thin' or
 'llvm-full'.")
 
 set(SWIFT_EMBEDDED_STDLIB_EXTRA_TARGET_TRIPLES "" CACHE STRING

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -347,7 +347,12 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
       endif()
     endif()
 
-    if(SWIFT_USE_SWIFT_EMBEDDED_PLATFORM)
+    # Enable the embedded platform abstraction layer when either the
+    # global option is on, or this triple matches the per-triple regex.
+    if(SWIFT_USE_SWIFT_EMBEDDED_PLATFORM
+       OR (SWIFT_EMBEDDED_PLATFORM_ABSTRACTION_LAYER_TRIPLE_REGEX
+           AND "${triple}" MATCHES
+               "${SWIFT_EMBEDDED_PLATFORM_ABSTRACTION_LAYER_TRIPLE_REGEX}"))
       list(APPEND extra_c_compile_flags "-DSWIFT_USE_EMBEDDED_SWIFT_PLATFORM=1")
     endif()
 

--- a/stdlib/public/core/EmbeddedPrint.swift
+++ b/stdlib/public/core/EmbeddedPrint.swift
@@ -28,6 +28,7 @@ func putchar(_: CInt) -> CInt
 #endif
 
 
+@usableFromInline
 internal func writeChars(_ chars: UnsafeBufferPointer<UInt8>) {
 #if SWIFT_USE_EMBEDDED_SWIFT_PLATFORM
   _ = unsafe _swift_writeToStandardOutput(chars.baseAddress, chars.count)

--- a/test/Misc/verify-swift-feature-testing.test-sh
+++ b/test/Misc/verify-swift-feature-testing.test-sh
@@ -37,9 +37,11 @@ EXCEPTIONAL_FILES = [
     pathlib.Path("test/embedded/linkage/diamond.swift"),
     pathlib.Path("test/embedded/linkage/diamond_embedded_exist.swift"),
     pathlib.Path("test/embedded/linkage/export_interface_vars.swift"),
-    pathlib.Path("test/embedded/linkage/silgen_name_var_interface_emission.swift"),
+    pathlib.Path("test/embedded/linkage/extern_c_body_in_other_module.swift"),
+    pathlib.Path("test/embedded/linkage/extern_c_thunk_no_interface_model.swift"),
     pathlib.Path("test/embedded/linkage/interface.swift"),
     pathlib.Path("test/embedded/linkage/leaf_application.swift"),
+    pathlib.Path("test/embedded/linkage/silgen_name_var_interface_emission.swift"),
     pathlib.Path("test/embedded/serialization.swift"),
     # Uses a script that hides usage of the CoroutineAccessor feature.
     pathlib.Path("validation-test/Evolution/test_coroutine_accessors.swift"),

--- a/test/Misc/verify-swift-feature-testing.test-sh
+++ b/test/Misc/verify-swift-feature-testing.test-sh
@@ -31,6 +31,7 @@ EXCEPTIONAL_FILES = [
     pathlib.Path("test/Concurrency/approachable_concurrency.swift"),
     # Uses the pseudo-feature CodeGenerationModel=
     pathlib.Path("test/Frontend/code-generation-model-feature.swift"),
+    pathlib.Path("test/embedded/arc-opt-runtime-helpers.swift"),
     pathlib.Path("test/embedded/linkage/c.swift"),
     pathlib.Path("test/embedded/linkage/cxx.swift"),
     pathlib.Path("test/embedded/linkage/diamond.swift"),

--- a/test/embedded/arc-opt-runtime-helpers.swift
+++ b/test/embedded/arc-opt-runtime-helpers.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -emit-ir -O -wmo -parse-as-library \
+// RUN:   -enable-experimental-feature Embedded \
+// RUN:   -enable-experimental-feature CodeGenerationModel=interface \
+// RUN:   %s -o - | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_CodeGenerationModel
+
+public final class C { public var x: Int = 0 }
+
+public func use(_ a: C, _ b: C) -> Int {
+  return a.x &+ b.x
+}
+
+// CHECK: define {{.*}} @"$e{{.*}}3useySiAA1CC_AEtF" 

--- a/test/embedded/concurrency-deleted-method.swift
+++ b/test/embedded/concurrency-deleted-method.swift
@@ -15,6 +15,7 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx || OS=wasip1
 // REQUIRES: swift_feature_Embedded
+// REQUIRES: embedded_stdlib_default_codegen
 
 import _Concurrency
 

--- a/test/embedded/concurrency-non-symbols.swift
+++ b/test/embedded/concurrency-non-symbols.swift
@@ -2,6 +2,7 @@
 
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: optimized_stdlib
+// REQUIRES: embedded_stdlib_default_codegen
 
 // Check for symbols that we explicitly don't want in the Embedded Swift
 // concurrency library.

--- a/test/embedded/dependencies-no-allocations.swift
+++ b/test/embedded/dependencies-no-allocations.swift
@@ -34,6 +34,7 @@ putchar
 // REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_feature_Extern
+// REQUIRES: embedded_stdlib_default_codegen
 // UNSUPPORTED: OS=linux-gnu && CPU=aarch64
 
 @_extern(c, "putchar")

--- a/test/embedded/dependencies-print.swift
+++ b/test/embedded/dependencies-print.swift
@@ -36,6 +36,7 @@ putchar
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
+// REQUIRES: embedded_stdlib_default_codegen
 // UNSUPPORTED: OS=linux-gnu && CPU=aarch64
 
 print("Hello Embedded Swift!") // CHECK: Hello Embedded Swift!

--- a/test/embedded/dependencies-random.swift
+++ b/test/embedded/dependencies-random.swift
@@ -57,6 +57,7 @@ putchar
 
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_feature_Extern
+// REQUIRES: embedded_stdlib_default_codegen
 
 @_extern(c, "putchar")
 @discardableResult

--- a/test/embedded/dependencies.swift
+++ b/test/embedded/dependencies.swift
@@ -38,6 +38,7 @@ putchar
 // REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_feature_Extern
+// REQUIRES: embedded_stdlib_default_codegen
 // UNSUPPORTED: OS=linux-gnu && CPU=aarch64
 
 @_extern(c, "putchar")

--- a/test/embedded/embedded-platform-multi-threaded-darwin-mutex.swift
+++ b/test/embedded/embedded-platform-multi-threaded-darwin-mutex.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend -parse-as-library -enable-experimental-feature Embedded -disable-availability-checking -wmo %s -c -o %t/main.o
-// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/main.o %target-embedded-multi-threaded-darwin-shim -o %t/a.out -dead_strip
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/main.o %target-embedded-multi-threaded-darwin-shim %target-embedded-synchronization -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test

--- a/test/embedded/embedded-platform-multi-threaded-posix-mutex.swift
+++ b/test/embedded/embedded-platform-multi-threaded-posix-mutex.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend -parse-as-library -enable-experimental-feature Embedded -disable-availability-checking -wmo %s -c -o %t/main.o
-// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/main.o %target-embedded-multi-threaded-posix-shim -o %t/a.out -dead_strip
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/main.o %target-embedded-multi-threaded-posix-shim %target-embedded-synchronization -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test

--- a/test/embedded/exclusivity_runtime.swift
+++ b/test/embedded/exclusivity_runtime.swift
@@ -29,6 +29,7 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_feature_EmbeddedDynamicExclusivity
+// REQUIRES: embedded_stdlib_default_codegen
 
 // UNSUPPORTED: OS=wasip1
 // UNSUPPORTED: OS=emscripten

--- a/test/embedded/linkage/extern_c_body_in_other_module.swift
+++ b/test/embedded/linkage/extern_c_body_in_other_module.swift
@@ -9,7 +9,16 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
+// Default code generation model
 // RUN: %target-swift-frontend -c -emit-module -o %t/Provider.o %t/Provider.swift -enable-experimental-feature Embedded -enable-experimental-feature CAttribute -parse-as-library
+// RUN: %target-swift-frontend -c -I %t -emit-module -o %t/Consumer.o %t/Consumer.swift -enable-experimental-feature Embedded -enable-experimental-feature Extern -parse-as-library
+// RUN: %target-swift-frontend -c -I %t -emit-module -o %t/Application.o %t/Application.swift -enable-experimental-feature Embedded -enable-experimental-feature Extern -parse-as-library
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/Provider.o %t/Consumer.o %t/Application.o -o %t/Application
+// RUN: %target-run %t/Application | %FileCheck %s
+
+// Provider built in the "interface" code-generation model — exercises the
+// SIL Linker on a cross-module reference whose body lives in another module.
+// RUN: %target-swift-frontend -c -I %t -emit-module -o %t/Provider.o %t/Provider.swift -enable-experimental-feature Embedded -enable-experimental-feature CAttribute -enable-experimental-feature CodeGenerationModel=interface -parse-as-library
 // RUN: %target-swift-frontend -c -I %t -emit-module -o %t/Consumer.o %t/Consumer.swift -enable-experimental-feature Embedded -enable-experimental-feature Extern -parse-as-library
 // RUN: %target-swift-frontend -c -I %t -emit-module -o %t/Application.o %t/Application.swift -enable-experimental-feature Embedded -enable-experimental-feature Extern -parse-as-library
 // RUN: %target-embedded-link %target-clang-resource-dir-opt %t/Provider.o %t/Consumer.o %t/Application.o -o %t/Application

--- a/test/embedded/linkage/extern_c_thunk_no_interface_model.swift
+++ b/test/embedded/linkage/extern_c_thunk_no_interface_model.swift
@@ -1,0 +1,29 @@
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_Extern
+
+// RUN: %target-swift-frontend -emit-sil %s -parse-as-library -enable-experimental-feature Embedded -enable-experimental-feature Extern -enable-experimental-feature CodeGenerationModel=interface | %FileCheck %s
+
+@_extern(c, "abort")
+internal func _abort()
+
+@_silgen_name("_named_internal_helper")
+internal func _namedInternalHelper() {
+  // Body present.
+}
+
+public func use() {
+  _abort()
+  _namedInternalHelper()
+}
+
+// @_extern(c) function has hidden_external linkage
+// CHECK-DAG: sil hidden_external {{.*}}[asmname "abort"] @{{.*}}_abortyyFTo
+
+// The @_silgen_name-with-body keeps its access-level-derived linkage.
+// CHECK-DAG: sil hidden {{.*}}@_named_internal_helper
+
+// The body-less stub must *not* appear as a non-external definition
+// — the body comes from outside Swift.
+// CHECK-NOT: sil hidden {{.*}}_abortyyFTo
+// CHECK-NOT: sil private{{.*}}_abortyyFTo

--- a/test/embedded/lit.local.cfg
+++ b/test/embedded/lit.local.cfg
@@ -98,10 +98,16 @@ if 'embedded_stdlib' in config.available_features:
     config.substitutions.append(("%target-embedded-multi-threaded-darwin-shim", f"-L {_embedded_lib_dir}/ -lswiftEmbeddedPlatformMultiThreadedDarwin"))
   else:
     config.substitutions.append(("%target-embedded-multi-threaded-darwin-shim", ""))
+  # Synchronization opts in the same way: the archive is empty under the
+  # default code-generation model but carries real code under interface-LTO,
+  # so tests that `import Synchronization` must have `libswiftSynchronization.a`
+  # on the link line for both configurations to link.
+  config.substitutions.append(("%target-embedded-synchronization", f"-L {_embedded_lib_dir}/ -lswiftSynchronization"))
 else:
   config.substitutions.append(("%target-embedded-single-threaded-shim", ""))
   config.substitutions.append(("%target-embedded-multi-threaded-posix-shim", ""))
   config.substitutions.append(("%target-embedded-multi-threaded-darwin-shim", ""))
+  config.substitutions.append(("%target-embedded-synchronization", ""))
 
 # (7) `%target-embedded-link` is the convenience wrapper that bundles
 # `%target-clang`, the embedded stdlib, and the POSIX shim — prefer it over

--- a/test/embedded/synchronization-mutex-single-threaded.swift
+++ b/test/embedded/synchronization-mutex-single-threaded.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -parse-as-library -enable-experimental-feature Embedded -disable-availability-checking -wmo %s -c -o %t/main.o
-// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/main.o %target-embedded-single-threaded-shim -o %t/a.out -dead_strip
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/main.o %target-embedded-single-threaded-shim %target-embedded-synchronization -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out
 
 // REQUIRES: executable_test

--- a/test/embedded/synchronization-mutex.swift
+++ b/test/embedded/synchronization-mutex.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -parse-as-library -enable-experimental-feature Embedded -disable-availability-checking -wmo %s -c -o %t/main.o
-// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/main.o -o %t/a.out -dead_strip
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/main.o %target-embedded-synchronization -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s --implicit-check-not=unexpected
 
 // REQUIRES: executable_test

--- a/test/embedded/synchronization.swift
+++ b/test/embedded/synchronization.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-run-simple-swift(-parse-as-library -enable-experimental-feature Embedded -disable-availability-checking -wmo %target-embedded-posix-shim) | %FileCheck %s
+// RUN: %target-run-simple-swift(-parse-as-library -enable-experimental-feature Embedded -disable-availability-checking -wmo %target-embedded-posix-shim %target-embedded-synchronization) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib

--- a/test/embedded/throw-trap-stdlib.swift
+++ b/test/embedded/throw-trap-stdlib.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend -emit-ir %s -enable-experimental-feature Embedded -throws-as-traps | %FileCheck %s
 
 // REQUIRES: swift_feature_Embedded
+// REQUIRES: embedded_stdlib_default_codegen
 
 public func test() {
   withUnsafeTemporaryAllocation(byteCount: MemoryLayout<Int>.size, alignment: MemoryLayout<Int>.alignment) { p in

--- a/test/embedded/wasm/mutex.swift
+++ b/test/embedded/wasm/mutex.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -wmo) | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -wmo %target-embedded-synchronization) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: OS=wasip1

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2372,6 +2372,22 @@ config.substitutions.append(('%module-target-triple',
                              target_specific_module_triple))
 config.substitutions.append(('%module-target-future', target_future))
 
+# Mirror the build-time choice between the two embedded code-generation
+# models (interface-LTO vs the default Inlinable model). Tests sensitive
+# to that choice can use `REQUIRES:` / `UNSUPPORTED:` against
+# `embedded_stdlib_default_codegen` or `embedded_stdlib_interface_lto`,
+# or gate individual RUN lines with `%if`. The decision is owned by CMake
+# (`SWIFT_EMBEDDED_INTERFACE_LTO_TRIPLE_REGEX`); we just match it here.
+import re as _re_for_embedded_codegen
+_interface_lto_regex = getattr(
+    config, 'swift_embedded_interface_lto_triple_regex', '')
+if (target_specific_module_triple and _interface_lto_regex
+    and _re_for_embedded_codegen.fullmatch(_interface_lto_regex,
+                                            target_specific_module_triple)):
+  config.available_features.add('embedded_stdlib_interface_lto')
+else:
+  config.available_features.add('embedded_stdlib_default_codegen')
+
 # Add 'target-sdk-name' as the name for platform-specific directories
 config.substitutions.append(('%target-sdk-name', config.target_sdk_name))
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2373,20 +2373,27 @@ config.substitutions.append(('%module-target-triple',
 config.substitutions.append(('%module-target-future', target_future))
 
 # Mirror the build-time choice between the two embedded code-generation
-# models (interface-LTO vs the default Inlinable model). Tests sensitive
-# to that choice can use `REQUIRES:` / `UNSUPPORTED:` against
-# `embedded_stdlib_default_codegen` or `embedded_stdlib_interface_lto`,
-# or gate individual RUN lines with `%if`. The decision is owned by CMake
-# (`SWIFT_EMBEDDED_INTERFACE_LTO_TRIPLE_REGEX`); we just match it here.
+# models and the LTO opt-in. Tests sensitive to those can use `REQUIRES:`
+# / `UNSUPPORTED:` against `embedded_stdlib_default_codegen`,
+# `embedded_stdlib_interface_cgm`, or `embedded_stdlib_lto`, or gate
+# individual RUN lines with `%if`. The decisions are owned by CMake
+# (`SWIFT_EMBEDDED_STDLIB_INTERFACE_CGM_TRIPLE_REGEX` and
+# `SWIFT_EMBEDDED_STDLIB_LTO_TRIPLE_REGEX`); we just match them here.
 import re as _re_for_embedded_codegen
-_interface_lto_regex = getattr(
-    config, 'swift_embedded_interface_lto_triple_regex', '')
-if (target_specific_module_triple and _interface_lto_regex
-    and _re_for_embedded_codegen.search(_interface_lto_regex,
+_interface_cgm_regex = getattr(
+    config, 'swift_embedded_stdlib_interface_cgm_triple_regex', '')
+_lto_regex = getattr(
+    config, 'swift_embedded_stdlib_lto_triple_regex', '')
+if (target_specific_module_triple and _interface_cgm_regex
+    and _re_for_embedded_codegen.search(_interface_cgm_regex,
                                         target_specific_module_triple)):
-  config.available_features.add('embedded_stdlib_interface_lto')
+  config.available_features.add('embedded_stdlib_interface_cgm')
 else:
   config.available_features.add('embedded_stdlib_default_codegen')
+if (target_specific_module_triple and _lto_regex
+    and _re_for_embedded_codegen.search(_lto_regex,
+                                        target_specific_module_triple)):
+  config.available_features.add('embedded_stdlib_lto')
 
 # Add 'target-sdk-name' as the name for platform-specific directories
 config.substitutions.append(('%target-sdk-name', config.target_sdk_name))

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2395,6 +2395,19 @@ if (target_specific_module_triple and _lto_regex
                                         target_specific_module_triple)):
   config.available_features.add('embedded_stdlib_lto')
 
+# `swift_embedded_platform` may already have been set at site-cfg time
+# (SWIFT_USE_SWIFT_EMBEDDED_PLATFORM globally on). If not, mirror the
+# per-triple SWIFT_EMBEDDED_PLATFORM_ABSTRACTION_LAYER_TRIPLE_REGEX here
+# so tests see the same feature whenever the current triple's stdlib
+# was built with the abstraction layer.
+_pal_regex = getattr(
+    config, 'swift_embedded_platform_abstraction_layer_triple_regex', '')
+if ('swift_embedded_platform' not in config.available_features
+    and target_specific_module_triple and _pal_regex
+    and _re_for_embedded_codegen.search(_pal_regex,
+                                        target_specific_module_triple)):
+  config.available_features.add('swift_embedded_platform')
+
 # Add 'target-sdk-name' as the name for platform-specific directories
 config.substitutions.append(('%target-sdk-name', config.target_sdk_name))
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2382,8 +2382,8 @@ import re as _re_for_embedded_codegen
 _interface_lto_regex = getattr(
     config, 'swift_embedded_interface_lto_triple_regex', '')
 if (target_specific_module_triple and _interface_lto_regex
-    and _re_for_embedded_codegen.fullmatch(_interface_lto_regex,
-                                            target_specific_module_triple)):
+    and _re_for_embedded_codegen.search(_interface_lto_regex,
+                                        target_specific_module_triple)):
   config.available_features.add('embedded_stdlib_interface_lto')
 else:
   config.available_features.add('embedded_stdlib_default_codegen')

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -187,6 +187,9 @@ config.swift_enable_dispatch = "@SWIFT_ENABLE_DISPATCH@" == "TRUE"
 config.swift_stdlib_enable_objc_interop = "@SWIFT_STDLIB_ENABLE_OBJC_INTEROP@" == "TRUE"
 if '@SWIFT_USE_SWIFT_EMBEDDED_PLATFORM@' == 'TRUE':
   config.available_features.add('swift_embedded_platform')
+# Per-triple opt-in for the embedded platform abstraction layer,
+# derived in `test/lit.cfg`.
+config.swift_embedded_platform_abstraction_layer_triple_regex = "@SWIFT_EMBEDDED_PLATFORM_ABSTRACTION_LAYER_TRIPLE_REGEX@"
 # Configured in DarwinSDKs.cmake
 config.freestanding_sdk_name = "@SWIFT_SDK_FREESTANDING_LIB_SUBDIR@"
 

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -174,10 +174,11 @@ if "@SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING@" == "TRUE":
     config.available_features.add('embedded_stdlib_cross_compiling')
 
 # Regex of target triples whose embedded standard library is built in
-# interface-LTO mode. Empty means none. Mirrored into a per-test feature by
-# `test/embedded/lit.local.cfg` (`embedded_stdlib_default_codegen` /
-# `embedded_stdlib_interface_lto`).
-config.swift_embedded_interface_lto_triple_regex = "@SWIFT_EMBEDDED_INTERFACE_LTO_TRIPLE_REGEX@"
+# interface CGM or with LTO. Empty means none. Mirrored into per-test
+# features by `test/lit.cfg` (`embedded_stdlib_default_codegen` /
+# `embedded_stdlib_interface_cgm` / `embedded_stdlib_lto`).
+config.swift_embedded_stdlib_interface_cgm_triple_regex = "@SWIFT_EMBEDDED_STDLIB_INTERFACE_CGM_TRIPLE_REGEX@"
+config.swift_embedded_stdlib_lto_triple_regex = "@SWIFT_EMBEDDED_STDLIB_LTO_TRIPLE_REGEX@"
 
 config.swift_freestanding_is_darwin = "@SWIFT_FREESTANDING_IS_DARWIN@" == "TRUE"
 config.swift_stdlib_use_relative_protocol_witness_tables = "@SWIFT_STDLIB_USE_RELATIVE_PROTOCOL_WITNESS_TABLES@" == "TRUE"

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -173,6 +173,12 @@ if "@SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB@" == "TRUE":
 if "@SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING@" == "TRUE":
     config.available_features.add('embedded_stdlib_cross_compiling')
 
+# Regex of target triples whose embedded standard library is built in
+# interface-LTO mode. Empty means none. Mirrored into a per-test feature by
+# `test/embedded/lit.local.cfg` (`embedded_stdlib_default_codegen` /
+# `embedded_stdlib_interface_lto`).
+config.swift_embedded_interface_lto_triple_regex = "@SWIFT_EMBEDDED_INTERFACE_LTO_TRIPLE_REGEX@"
+
 config.swift_freestanding_is_darwin = "@SWIFT_FREESTANDING_IS_DARWIN@" == "TRUE"
 config.swift_stdlib_use_relative_protocol_witness_tables = "@SWIFT_STDLIB_USE_RELATIVE_PROTOCOL_WITNESS_TABLES@" == "TRUE"
 config.swift_stdlib_use_use_fragile_resilient_protocol_witness_tables = "@SWIFT_STDLIB_USE_FRAGILE_RESILIENT_PROTOCOL_WITNESS_TABLES@" == "TRUE"


### PR DESCRIPTION
Introduce three new CMake configuration options for the embedded swift build that allow one to control how the embedded Swift libraries are built. Each of these is a regular expression that matches a triple, which makes it easier to customize. The new options are:

* `SWIFT_EMBEDDED_PLATFORM_ABSTRACTION_LAYER_TRIPLE_REGEX`: for enabling the platform abstraction layer
* `SWIFT_EMBEDDED_STDLIB_INTERFACE_CGM_TRIPLE_REGEX`: for enabling the `CodeGeneration=interface` model (i.e., `@export(interface)` by default) that builds more like non-Embedded Swift, where we eagerly emit code for anything we can (i.e., not generics)
* `SWIFT_EMBEDDED_STDLIB_LTO_TRIPLE_REGEX`: for enabling LTO

Roll these out as options for all of the embedded libraries, although it's not yet enabled anywhere by default. Implements rdar://182143581
