### PR TITLE
tests: require an optimized stdlib for two tests

### DIFF
--- a/test/ClangImporter/macro_literals.swift
+++ b/test/ClangImporter/macro_literals.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -sil-disable-pass=Simplification -Xllvm -sil-print-types -Xllvm -sil-print-debuginfo -emit-sil %s | %FileCheck %s
 
+// REQUIRES: optimized_stdlib
+
 import macros
 
 // CHECK-LABEL: // testBitwiseOperations()

--- a/test/Constraints/keypath_dynamic_member_lookup.swift
+++ b/test/Constraints/keypath_dynamic_member_lookup.swift
@@ -2,6 +2,8 @@
 // RUN: %target-swift-frontend -Xllvm -sil-print-types -emit-sil -Xllvm -sil-disable-pass=simplification -solver-disable-enumerate-supertypes %s | %FileCheck %s
 // RUN: %target-swift-frontend -Xllvm -sil-print-types -emit-sil -Xllvm -sil-disable-pass=simplification -solver-enable-enumerate-supertypes %s | %FileCheck %s
 
+// REQUIRES: optimized_stdlib
+
 struct Point {
   let x: Int
   var y: Int


### PR DESCRIPTION
With the new DeadObjectElimination pass, the check lines in the test do not support an non-optimized stdlib anymore.

rdar://182117583
rdar://182117336
