### PR TITLE
stdlib: Pair hermetic seal at link with the selected stdlib LTO mode

### DIFF
--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -652,6 +652,13 @@ function(_compile_swift_files
 
   if(SWIFT_STDLIB_EXPERIMENTAL_HERMETIC_SEAL_AT_LINK)
     list(APPEND swift_flags "-experimental-hermetic-seal-at-link")
+    if(SWIFT_STDLIB_ENABLE_LTO STREQUAL "full")
+      list(APPEND swift_flags "-lto=llvm-full")
+    elseif(SWIFT_STDLIB_ENABLE_LTO STREQUAL "thin")
+      list(APPEND swift_flags "-lto=llvm-thin")
+    else()
+      message(FATAL_ERROR "SWIFT_STDLIB_EXPERIMENTAL_HERMETIC_SEAL_AT_LINK requires SWIFT_STDLIB_ENABLE_LTO to be 'full' or 'thin', but got: '${SWIFT_STDLIB_ENABLE_LTO}'")
+    endif()
   endif()
 
   list(APPEND swift_flags "-enable-experimental-feature" "SuppressedAssociatedTypesWithDefaults")


### PR DESCRIPTION
`-experimental-hermetic-seal-at-link` is only meaningful when the Swift frontend is also emitting LLVM LTO information.  The driver enforces this by requiring either `-lto=llvm-full` or `-lto=llvm-thin`.

The stdlib CMake plumbing could enable
`SWIFT_STDLIB_EXPERIMENTAL_HERMETIC_SEAL_AT_LINK` without appending the corresponding frontend LTO flag.  That causes Swift Core compilation to fail immediately with the driver's requirement diagnostic, even when `SWIFT_STDLIB_ENABLE_LTO` is set in the build configuration.

When hermetic sealing is requested for stdlib compilation, derive the frontend LTO flag from `SWIFT_STDLIB_ENABLE_LTO`:

  * `full` -> `-lto=llvm-full`
  * `thin` -> `-lto=llvm-thin`

This keeps the stdlib build configuration internally consistent and makes hermetic full-LTO SDK builds reproducible without manually editing frontend command lines.

Hermetic sealing is the switch that lets the optimizer treat the linked program as a closed world.  Without it, full LTO can still leave Swift runtime records and dispatch targets conservatively live.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
