### PR TITLE
Use a loop-shaped SIMD debugDescription

### DIFF
--- a/stdlib/public/core/SIMDVectorTypes.swift.gyb
+++ b/stdlib/public/core/SIMDVectorTypes.swift.gyb
@@ -167,9 +167,8 @@ extension SIMD${n} where Scalar: FixedWidthInteger {
 @_unavailableInEmbedded
 extension SIMD${n}: CustomDebugStringConvertible {
   public var debugDescription: String {
-    return "SIMD${n}<\(Scalar.self)>(${', '.join(map(lambda c:
-                       '\\(self['+ str(c) + '])',
-                       range(n)))})"
+    return "SIMD${n}<\(Scalar.self)>("
+      + indices.map({ "\(self[$0])" }).joined(separator: ", ") + ")"
   }
 }
 


### PR DESCRIPTION
SIMD<N>.debugDescription was generated by SIMDVectorTypes.swift.gyb as a single flat interpolation listing every lane:

    "SIMD32<\(Scalar.self)>(\(self[0]), \(self[1]), ... \(self[31]))"

Scalar is only constrained to SIMDScalar (not CustomStringConvertible), so each "\(self[i])" selects the unconstrained appendInterpolation<T> catch-all and SILGen emits N independent copies of the generic formatting path (boxing + swift_dynamicCast + Mirror fallback). The body therefore grew linearly with the lane count -- e.g. at -O the SIMD32 getter reached ~11.7k IR instructions after optimization, and the family spanned SIMD2..SIMD64.

Rewrite it in the same loop shape already used by the SIMD.description protocol-extension getter, which is ~1.2k IR instructions and constant across lane counts:

    "SIMD${n}<\(Scalar.self)>("
      + indices.map({ "\(self[$0])" }).joined(separator: ", ") + ")"

This keeps a single copy of the (still generic) formatting path inside the map closure instead of cloning it per lane. The rendered string is byte-identical to the previous output.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
