### PR TITLE
[CSDiagnostics] Diagnose generic argument mismatch associated with a …

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -45,6 +45,7 @@
 #include "swift/Basic/SourceLoc.h"
 #include "swift/ClangImporter/ClangImporterRequests.h"
 #include "swift/Parse/Lexer.h"
+#include "swift/Sema/ConstraintLocator.h"
 #include "swift/Sema/ConstraintSystem.h"
 #include "swift/Sema/IDETypeChecking.h"
 #include "swift/Sema/TypeVariableType.h"
@@ -963,6 +964,8 @@ bool GenericArgumentsMismatchFailure::diagnoseAsError() {
   while (!path.empty()) {
     auto last = path.back();
     if (last.is<LocatorPathElt::OptionalInjection>() ||
+        last.is<LocatorPathElt::OpenedGeneric>() ||
+        last.is<LocatorPathElt::AnyRequirement>() ||
         last.is<LocatorPathElt::GenericType>() ||
         last.is<LocatorPathElt::GenericArgument>()) {
       path = path.drop_back();

--- a/validation-test/Sema/type_checker_crashers_fixed/issue-84884.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/issue-84884.swift
@@ -16,7 +16,7 @@ extension Proto {
   func overload() -> some Proto<S1> where Assoc == S1 {
     Generic()
   }
-  func overload() -> some Proto<S1> where Assoc == Generic<Generic<S1>> {
+  func overload() -> some Proto<S1> where Assoc == Generic<Generic<S1>> { // expected-note {{'overload()' declared here}}
     Generic()
   }
 }
@@ -27,8 +27,7 @@ struct Struct: Proto {
 }
 
 func test() {
-  // FIXME: This used to crash, but it still produces a bogus diagnostic.
   let _ = Generic.foo(Generic.bar(Struct(0).overload()))
-  // expected-error@-1 {{failed to produce diagnostic for expression; please submit a bug report}}
+  // expected-error@-1 {{referencing instance method 'overload()' on 'Struct' requires the types 'S2' and 'S1' be equivalent}}
 }
 


### PR DESCRIPTION
…requirement

Look through `open generic` and any requirement locator path elements to get to the `member` or `unresolved member` elements. If a generic argument mismatch occurs in a requirement context (i.e. `where A == S<Int>` but `A := S<String>`) the failure should be associated with the member this requirement belongs to.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
