### PR TITLE
[test] Add explicit rounding-rule coverage for rounded(.up)/.down

### DIFF
--- a/test/SILOptimizer/fp_rounding.swift
+++ b/test/SILOptimizer/fp_rounding.swift
@@ -3,7 +3,7 @@
 
 // This is an end-to-end test to ensure that the optimizer can propagate
 // resilient enum cases (FloatingPointRoundingRule) and produces optimal
-// code for Float.rounded().
+// code for Float.rounded(), including when an explicit rounding rule is passed.
 
 // CHECK-LABEL: sil @{{.*}}propagate_roundingmode
 // CHECK:      bb0:
@@ -27,4 +27,31 @@ public func propagate_roundingmode() -> Int {
 // CHECK:   return [[F]]
 public func round_floating_point(_ x: Float) -> Float {
   return x.rounded()
+}
+
+// CHECK-LABEL: sil @{{.*}}round_up
+// CHECK: bb0({{.*}}):
+// CHECK:   [[R:%[0-9]+]] = builtin "int_ceil{{.*}}"
+// CHECK:   [[F:%[0-9]+]] = struct $Double ([[R]]
+// CHECK:   return [[F]]
+public func round_up(_ x: Double) -> Double {
+  return x.rounded(.up)
+}
+
+// CHECK-LABEL: sil @{{.*}}round_down
+// CHECK: bb0({{.*}}):
+// CHECK:   [[R:%[0-9]+]] = builtin "int_floor{{.*}}"
+// CHECK:   [[F:%[0-9]+]] = struct $Double ([[R]]
+// CHECK:   return [[F]]
+public func round_down(_ x: Double) -> Double {
+  return x.rounded(.down)
+}
+
+// CHECK-LABEL: sil @{{.*}}round_towardZero
+// CHECK: bb0({{.*}}):
+// CHECK:   [[R:%[0-9]+]] = builtin "int_trunc{{.*}}"
+// CHECK:   [[F:%[0-9]+]] = struct $Double ([[R]]
+// CHECK:   return [[F]]
+public func round_towardZero(_ x: Double) -> Double {
+  return x.rounded(.towardZero)
 }


### PR DESCRIPTION
fp_rounding.swift only checked x.rounded() and a standalone constant switch. Add end-to-end checks that rounded(.up), rounded(.down) and rounded(.towardZero) fold to a single int_ceil/int_floor builtin.
 
Resolves #51255