### PR TITLE
[RemoteInspection] Assorted small bounds checks and read-size fixes.

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -2193,7 +2193,7 @@ private:
     if (!Flags.hasTypePacks())
       return 0;
 
-    return getGenSigPackShapeHeader().NumTypePacks;
+    return getGenSigPackShapeHeader().NumPacks;
   }
 
   const TargetGenericContextDescriptorHeader<Runtime> *

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -1440,40 +1440,10 @@ public:
       return ShapeRef(
           address, reinterpret_cast<const ShapeHeader *>(cached->second.get()));
 
-    ExtendedExistentialTypeShapeFlags flags;
-    if (!Reader->readBytes(address, (uint8_t *)&flags, sizeof(flags)))
-      return nullptr;
-
-    // Read the size of the requirement signature.
-    uint64_t descriptorSize;
-    {
-      auto readResult =
-          Reader->readBytes(RemoteAddress(address), sizeof(ShapeHeader));
-      if (!readResult)
-        return nullptr;
-      auto shapeHeader =
-          reinterpret_cast<const ShapeHeader *>(readResult.get());
-
-      // Read the size of the requirement signature.
-      uint64_t reqSigGenericSize = 0;
-      auto flags = shapeHeader->Flags;
-      auto &reqSigHeader = shapeHeader->ReqSigHeader;
-      reqSigGenericSize =
-          reqSigGenericSize + (reqSigHeader.NumParams + 3u & ~3u) +
-          reqSigHeader.NumRequirements *
-              sizeof(TargetGenericRequirementDescriptor<Runtime>);
-      uint64_t typeExprSize =
-          flags.hasTypeExpression() ? sizeof(StoredPointer) : 0;
-      uint64_t suggestedVWSize =
-          flags.hasSuggestedValueWitnesses() ? sizeof(StoredPointer) : 0;
-
-      descriptorSize = sizeof(shapeHeader) + typeExprSize + suggestedVWSize +
-                       reqSigGenericSize;
-    }
-    if (descriptorSize > MaxMetadataSize)
-      return nullptr;
-    auto readResult = Reader->readBytes(RemoteAddress(address), descriptorSize);
-    if (!readResult)
+    MemoryReader::ReadBytesResult readResult;
+    auto descriptorSize =
+        readFullTrailingObjects<ShapeHeader>(address, readResult, 0);
+    if (descriptorSize == 0 || descriptorSize > MaxMetadataSize || !readResult)
       return nullptr;
 
     auto descriptor = reinterpret_cast<const ShapeHeader *>(readResult.get());

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -1604,28 +1604,36 @@ public:
   Demangle::NodePointer
   buildContextManglingForSymbol(StringRef symbol, Demangler &dem) {
     auto demangledSymbol = dem.demangleSymbol(symbol);
+    if (!demangledSymbol)
+      return nullptr;
     if (demangledSymbol->getKind() == Demangle::Node::Kind::Global) {
       demangledSymbol = demangledSymbol->getChild(0);
+      if (!demangledSymbol)
+        return nullptr;
     }
-    
+
     switch (demangledSymbol->getKind()) {
     // Pointers to nominal type or protocol descriptors would demangle to
     // the type they represent.
     case Demangle::Node::Kind::NominalTypeDescriptor:
     case Demangle::Node::Kind::ProtocolDescriptor:
       demangledSymbol = demangledSymbol->getChild(0);
-      assert(demangledSymbol->getKind() == Demangle::Node::Kind::Type);
+      if (!demangledSymbol ||
+          demangledSymbol->getKind() != Demangle::Node::Kind::Type)
+        return nullptr;
       break;
     // Pointers to opaque type descriptors demangle to the name of the opaque
     // type declaration.
     case Demangle::Node::Kind::OpaqueTypeDescriptor:
       demangledSymbol = demangledSymbol->getChild(0);
+      if (!demangledSymbol)
+        return nullptr;
       break;
       // We don't handle pointers to other symbols yet.
     default:
       return nullptr;
     }
-  
+
     return demangledSymbol;
   }
 

--- a/include/swift/RemoteInspection/Records.h
+++ b/include/swift/RemoteInspection/Records.h
@@ -34,7 +34,7 @@ class FieldRecordFlags {
   enum : int_type {
     // Is this an indirect enum case?
     IsIndirectCase = 0x1,
-    
+
     // Is this a mutable `var` property?
     IsVar = 0x2,
 

--- a/include/swift/RemoteInspection/Records.h
+++ b/include/swift/RemoteInspection/Records.h
@@ -404,14 +404,14 @@ private:
   //  descriptor isn't large enough to have that field.)
   // Lower 16 bits are flag bits
 
-  int getSizeFlagsIndex() const { return 0; }
+  size_t getSizeFlagsIndex() const { return 0; }
 
   // uint32_t PayloadSpareBitMaskByteOffsetCount;
   // Number of bytes in "payload spare bits", and
   // offset of them within the payload area
   // Only present if `usePayloadSpareBits()`
 
-  int getPayloadSpareBitMaskByteCountIndex() const {
+  size_t getPayloadSpareBitMaskByteCountIndex() const {
     return getSizeFlagsIndex() + 1;
   }
 
@@ -419,8 +419,9 @@ private:
   // Variably-sized bitmask field (padded to a multiple of 4 bytes)
   // Only present if `usePayloadSpareBits()`
 
-  int getPayloadSpareBitsIndex() const {
-    int PayloadSpareBitMaskByteCountFieldSize = usesPayloadSpareBits() ? 1 : 0;
+  size_t getPayloadSpareBitsIndex() const {
+    size_t PayloadSpareBitMaskByteCountFieldSize =
+        usesPayloadSpareBits() ? 1 : 0;
     return getPayloadSpareBitMaskByteCountIndex() + PayloadSpareBitMaskByteCountFieldSize;
   }
 
@@ -464,7 +465,8 @@ public:
   }
 
   uint32_t getPayloadSpareBitMaskByteOffset() const {
-    if (usesPayloadSpareBits()) {
+    if (usesPayloadSpareBits() &&
+        getContentsSizeInWords() > getPayloadSpareBitMaskByteCountIndex()) {
       return contents[getPayloadSpareBitMaskByteCountIndex()] >> 16;
     } else {
       return 0;
@@ -472,18 +474,23 @@ public:
   }
 
   uint32_t getPayloadSpareBitMaskByteCount() const {
-    if (usesPayloadSpareBits()) {
+    if (usesPayloadSpareBits() &&
+        getContentsSizeInWords() > getPayloadSpareBitMaskByteCountIndex()) {
       auto byteCount = contents[getPayloadSpareBitMaskByteCountIndex()] & 0xffff;
-      assert(getContentsSizeInWords() >= 2 + (byteCount + 3) / 4
-            && "Malformed MPEnum reflection record: mask bigger than record");
-      return byteCount;
+      uint32_t maxBytes = (getContentsSizeInWords() - 2) * 4;
+      assert(byteCount <= maxBytes &&
+             "Malformed MPEnum reflection record: mask bigger than record");
+      return byteCount <= maxBytes ? byteCount : maxBytes;
     } else {
       return 0;
     }
   }
 
   const uint8_t *getPayloadSpareBits() const {
-    if (usesPayloadSpareBits()) {
+    // The mask bytes live in contents[2...], only present when the record
+    // declares at least two content words.
+    if (usesPayloadSpareBits() &&
+        getContentsSizeInWords() > getPayloadSpareBitMaskByteCountIndex()) {
       return reinterpret_cast<const uint8_t *>(&contents[getPayloadSpareBitsIndex()]);
     } else {
       return nullptr;

--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -457,10 +457,16 @@ public:
         savedBuffers.push_back(std::move(Buf));
 
         auto Begin = RemoteRef<void>(Addr, BufStart);
-        auto Size = COFFSec->VirtualSize;
+        uint64_t Size = COFFSec->VirtualSize;
 
         // FIXME: This code needs to be cleaned up and updated
         // to make it work for 32 bit platforms.
+        //
+        // The section is bracketed by 8-byte sentinel words at each end, so we
+        // skip the leading sentinel and drop both. If VirtualSize is too small
+        // to contain the sentinels, skip the section.
+        if (Size < 16)
+          return {nullptr, 0};
         Begin = Begin.atByteOffset(8);
         Size -= 16;
 

--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -1584,9 +1584,14 @@ public:
   StoredPointer allocationMetadataPointer(
     MetadataAllocation<Runtime> Allocation) {
     if (Allocation.Tag == GenericMetadataCacheTag) {
+      // Allocation.Size comes from the inspected process and may be smaller
+      // than the entry we're about to overlay. Reject undersized allocations
+      // and read exactly the entry size rather than the reported size.
+      if (Allocation.Size < sizeof(GenericMetadataCacheEntry<StoredPointer>))
+        return 0;
       auto AllocationBytes = getReader().readBytes(
           RemoteAddress(Allocation.Ptr, RemoteAddress::DefaultAddressSpace),
-          Allocation.Size);
+          sizeof(GenericMetadataCacheEntry<StoredPointer>));
       if (!AllocationBytes)
         return 0;
       auto Entry =
@@ -1714,7 +1719,7 @@ public:
       auto PoolPtr = (const char *)PoolBytes.get();
 
       uintptr_t Offset = 0;
-      while (Offset < Trailer->PoolSize) {
+      while (Offset + sizeof(AllocationHeader) <= Trailer->PoolSize) {
         auto AllocationPtr = PoolPtr + Offset;
         auto Header = (const AllocationHeader *)AllocationPtr;
         if (Header->Size == 0)

--- a/include/swift/RemoteInspection/TypeRefBuilder.h
+++ b/include/swift/RemoteInspection/TypeRefBuilder.h
@@ -2326,6 +2326,7 @@ private:
     std::string Error;
     PointerReader OpaquePointerReader;
     ByteReader OpaqueByteReader;
+    StringReader OpaqueStringReader;
     DynamicSymbolResolver OpaqueDynamicSymbolResolver;
     QualifiedContextNameReader<ObjCInteropKind, PointerSize> NameReader;
 
@@ -2334,7 +2335,7 @@ private:
         PointerReader pointerReader,
         DynamicSymbolResolver dynamicSymbolResolver)
         : Error(""), OpaquePointerReader(pointerReader),
-          OpaqueByteReader(byteReader),
+          OpaqueByteReader(byteReader), OpaqueStringReader(stringReader),
           OpaqueDynamicSymbolResolver(dynamicSymbolResolver),
           NameReader(byteReader, stringReader, pointerReader,
                      dynamicSymbolResolver) {}
@@ -2352,7 +2353,29 @@ private:
       // return class name
       if (conformanceDescriptor.getTypeKind() ==
           TypeReferenceKind::DirectObjCClassName) {
-        auto className = conformanceDescriptor.getDirectObjCClassName();
+        // The class name is a RelativeDirectPointer stored in the descriptor's
+        // TypeRef field. We only hold a local copy of the descriptor, so we
+        // must not resolve that relative pointer in place (getDirectObjCClassName
+        // would resolve the stored offset against our local buffer and read out
+        // of bounds). Instead re-derive the field's remote address and issue a
+        // bounded read, the same way the type-descriptor kinds below do.
+        auto nameFieldAddress = conformanceDescriptorAddress.applyRelativeOffset(
+            (int32_t)conformanceDescriptor.getTypeRefDescriptorOffset());
+        auto nameOffsetBytes =
+            OpaqueByteReader(nameFieldAddress, sizeof(int32_t));
+        if (!nameOffsetBytes.get()) {
+          Error = "Failed to read direct ObjC class name field in conformance "
+                  "descriptor.";
+          return std::nullopt;
+        }
+        auto nameOffset = (const int32_t *)nameOffsetBytes.get();
+        auto nameAddress = nameFieldAddress.applyRelativeOffset(*nameOffset);
+        std::string className;
+        if (!OpaqueStringReader(nameAddress, className)) {
+          Error = "Failed to read direct ObjC class name in conformance "
+                  "descriptor.";
+          return std::nullopt;
+        }
         typeName = MANGLING_MODULE_OBJC.str() + std::string(".") + className;
         return std::make_pair(mangledTypeName, typeName);
       }

--- a/include/swift/RemoteInspection/TypeRefBuilder.h
+++ b/include/swift/RemoteInspection/TypeRefBuilder.h
@@ -2145,9 +2145,17 @@ private:
             Demangle::Context Ctx;
             auto demangledRoot =
                 Ctx.demangleSymbolAsNode(symbol->getSymbol().str());
-            assert(demangledRoot->getKind() == Node::Kind::Global);
-            std::string nodeName =
-                nodeToString(demangledRoot->getChild(0)->getChild(0));
+            if (!demangledRoot ||
+                demangledRoot->getKind() != Node::Kind::Global) {
+              Error = "Failed to demangle indirect parent context symbol.";
+              return;
+            }
+            auto globalChild = demangledRoot->getChild(0);
+            if (!globalChild || globalChild->getNumChildren() < 1) {
+              Error = "Failed to demangle indirect parent context symbol.";
+              return;
+            }
+            std::string nodeName = nodeToString(globalChild->getChild(0));
             chain.push_back(
                 ContextNameInfo{nodeName, adjustedParentTargetAddress, false});
           } else {
@@ -2382,11 +2390,19 @@ private:
           Demangle::Context Ctx;
           auto demangledRoot =
               Ctx.demangleSymbolAsNode(symbol->getSymbol().str());
-          assert(demangledRoot->getKind() == Node::Kind::Global);
+          // The symbol name comes from the inspected image and may not
+          // demangle to the expected shape. Guard every dereference rather
+          // than relying on the asserts, which are compiled out in release
+          // builds.
+          if (!demangledRoot || demangledRoot->getKind() != Node::Kind::Global)
+            return std::nullopt;
           auto nomTypeDescriptorRoot = demangledRoot->getChild(0);
-          assert(nomTypeDescriptorRoot->getKind() ==
-                 Node::Kind::NominalTypeDescriptor);
+          if (!nomTypeDescriptorRoot || nomTypeDescriptorRoot->getKind() !=
+                                            Node::Kind::NominalTypeDescriptor)
+            return std::nullopt;
           auto typeRoot = nomTypeDescriptorRoot->getChild(0);
+          if (!typeRoot)
+            return std::nullopt;
           typeName = nodeToString(typeRoot);
 
           auto typeMangling =

--- a/include/swift/RemoteInspection/TypeRefBuilder.h
+++ b/include/swift/RemoteInspection/TypeRefBuilder.h
@@ -105,6 +105,12 @@ public:
                                 std::string Name)
       : OriginalSize(Size), Cur(Cur), Size(Size), Name(Name) {
     if (Size != 0) {
+      if (Size < Self::getMinimumRecordSize()) {
+        // The section is too small to contain even a record header. Treat the
+        // section as empty.
+        this->Size = 0;
+        return;
+      }
       auto NextRecord = this->operator*();
       if (!NextRecord) {
         // NULL record pointer, don't attempt to proceed. Setting size to 0 will
@@ -140,6 +146,12 @@ public:
     Size -= CurSize;
 
     if (Size > 0) {
+      if (Size < Self::getMinimumRecordSize()) {
+        // The trailing bytes are too small to contain even a record header, so
+        // end iteration here.
+        Size = 0;
+        return asImpl();
+      }
       auto NextRecord = this->operator*();
       auto NextSize = Self::getCurrentRecordSize(NextRecord);
       if (NextSize > Size) {
@@ -179,6 +191,13 @@ public:
   }
 
   bool operator!=(const Self &other) const { return !(*this == other); }
+
+  // The minimum number of bytes that must remain in the section for the record
+  // header to be safely read by getCurrentRecordSize() and operator*(). The
+  // default is the full descriptor size; iterators whose descriptor ends in a
+  // flexible array member (so its sizeof is smaller than its readable header)
+  // override this.
+  static uint64_t getMinimumRecordSize() { return sizeof(Descriptor); }
 };
 
 class FieldDescriptorIterator
@@ -247,6 +266,13 @@ public:
   static uint64_t
   getCurrentRecordSize(RemoteRef<MultiPayloadEnumDescriptor> MPER) {
     return MPER->getSizeInBytes();
+  }
+
+  static uint64_t getMinimumRecordSize() {
+    // MultiPayloadEnumDescriptor ends in a flexible `contents` array, so its
+    // sizeof only covers TypeName. getSizeInBytes() reads contents[0], so we
+    // need room for TypeName plus that first content word.
+    return sizeof(MultiPayloadEnumDescriptor) + sizeof(uint32_t);
   }
 };
 using MultiPayloadEnumSection =

--- a/unittests/Reflection/TypeRef.cpp
+++ b/unittests/Reflection/TypeRef.cpp
@@ -628,3 +628,84 @@ TEST(TypeRefTest, DeriveSubstitutions) {
   EXPECT_EQ(SubstOne, ResultOne);
   EXPECT_EQ(SubstTwo, ResultTwo);
 }
+
+// Verify that the MultiPayloadEnumDescriptor spare-bit-mask accessors defend
+// against malformed __swift5_mpenum records supplied by an inspected process,
+// rather than trusting the record's declared mask size.
+// rdar://181865069, rdar://181864074
+TEST(TypeRefTest, MultiPayloadEnumSpareBitMaskBounds) {
+  // Records are laid out as: int32 TypeName; uint32 contents[SizeInWords].
+  //   contents[0] = (SizeInWords << 16) | flags
+  //   contents[1] = (maskByteOffset << 16) | maskByteCount
+  //   contents[2...] = mask bytes
+  auto makeRecord = [](std::vector<uint32_t> &storage, uint32_t sizeInWords,
+                       uint32_t flags,
+                       uint32_t maskByteCount) -> const MultiPayloadEnumDescriptor * {
+    storage.assign(1 + sizeInWords, 0);
+    storage[0] = 0; // TypeName relative pointer (unused here).
+    storage[1] = (sizeInWords << 16) | (flags & 0xffff);
+    if (sizeInWords >= 2)
+      storage[2] = maskByteCount & 0xffff;
+    return reinterpret_cast<const MultiPayloadEnumDescriptor *>(storage.data());
+  };
+
+  // A record claiming a 0xFFFF-byte mask but declaring only two content words
+  // (leaving zero bytes of room for the mask) must clamp the count to 0.
+  {
+    std::vector<uint32_t> storage;
+    auto *desc = makeRecord(storage, /*sizeInWords=*/2, /*flags=*/1,
+                            /*maskByteCount=*/0xFFFF);
+    EXPECT_TRUE(desc->usesPayloadSpareBits());
+    EXPECT_EQ(desc->getPayloadSpareBitMaskByteCount(), 0u);
+    EXPECT_NE(desc->getPayloadSpareBits(), nullptr);
+  }
+
+  // With extra content words the count is clamped to the room the record
+  // actually describes ((SizeInWords - 2) * 4 bytes).
+  {
+    std::vector<uint32_t> storage;
+    auto *desc = makeRecord(storage, /*sizeInWords=*/4, /*flags=*/1,
+                            /*maskByteCount=*/0xFFFF);
+    EXPECT_EQ(desc->getPayloadSpareBitMaskByteCount(), 8u);
+  }
+
+  // A well-formed count is returned unchanged.
+  {
+    std::vector<uint32_t> storage;
+    auto *desc = makeRecord(storage, /*sizeInWords=*/3, /*flags=*/1,
+                            /*maskByteCount=*/4);
+    EXPECT_EQ(desc->getPayloadSpareBitMaskByteCount(), 4u);
+    EXPECT_NE(desc->getPayloadSpareBits(), nullptr);
+  }
+
+  // A record that claims to use spare bits but declares too few words to even
+  // hold the mask-count word must not read contents[1] or hand back a pointer.
+  {
+    std::vector<uint32_t> storage;
+    auto *desc = makeRecord(storage, /*sizeInWords=*/1, /*flags=*/1,
+                            /*maskByteCount=*/0);
+    EXPECT_EQ(desc->getPayloadSpareBitMaskByteCount(), 0u);
+    EXPECT_EQ(desc->getPayloadSpareBitMaskByteOffset(), 0u);
+    EXPECT_EQ(desc->getPayloadSpareBits(), nullptr);
+  }
+}
+
+// A reflection section whose size is smaller than a single record header must
+// terminate iteration immediately rather than reading the header past the end
+// of the section buffer. rdar://181867993
+TEST(TypeRefTest, ReflectionSectionUndersizedRecord) {
+  // Back the section with a generous buffer so the test itself never reads out
+  // of bounds, but tell the section it is only 4 bytes long -- fewer than
+  // sizeof(FieldDescriptor).
+  alignas(16) char buffer[64] = {0};
+  remote::RemoteAddress addr(reinterpret_cast<uintptr_t>(buffer),
+                             remote::RemoteAddress::DefaultAddressSpace);
+  RemoteRef<void> ref(addr, buffer);
+
+  FieldSection section(ref, /*Size=*/4);
+  EXPECT_TRUE(section.begin() == section.end());
+  for (auto record : section) {
+    (void)record;
+    ADD_FAILURE() << "undersized field section should yield no records";
+  }
+}


### PR DESCRIPTION
Use the `TrailingObjects` sizing machinery when reading a `TargetExtendedExistentialTypeShape` instead of computing the size by hand.

Run the `DirectObjCClassName` read through the `StringReader`.

Guard node kind/shape checks and fail gracefully rather than asserting.

Check for COFF sections too small to contain the beginning/end sentinels.

Bounds-check metadata allocation reads.

Guard all reflection section iterators against undersized records.

Validate that `MultiPayloadEnumDescriptor` indexes are within the descriptor.

rdar://181863701
rdar://181864028
rdar://181864074
rdar://181864089
rdar://181865069
rdar://181866827
rdar://181867993
rdar://181868254
rdar://181870347