### PR TITLE
Fix illegal bounds check elimination for pre increment acess functions

### DIFF
--- a/lib/SILOptimizer/LoopTransforms/BoundsCheckOpts.cpp
+++ b/lib/SILOptimizer/LoopTransforms/BoundsCheckOpts.cpp
@@ -843,6 +843,9 @@ public:
 
   /// Returns true if the loop iterates from 0 until count of \p selfValue.
   bool isZeroToCount(SILValue selfValue) {
+    if (preIncrement) {
+      return false;
+    }
     return getZeroToCountOfSelf(Ind->Start, Ind->End) == selfValue;
   }
 

--- a/test/SILOptimizer/abcopts.sil
+++ b/test/SILOptimizer/abcopts.sil
@@ -1352,12 +1352,15 @@ bb3:
 
 
 // RANGECHECK-LABEL: sil @hoist_new_ind_pattern4 :
+// RANGECHECK: [[CB:%.*]] = function_ref @checkbounds2 : $@convention(method) (Int32, Bool, @owned Array<Int>) -> _DependenceToken
 // RANGECHECK: [[MINUS1:%.*]] = integer_literal $Builtin.Int1, -1
 // RANGECHECK: [[TRUE:%.*]] = struct $Bool ([[MINUS1]] : $Builtin.Int1)
 // RANGECHECK: [[ZERO:%.*]] = integer_literal $Builtin.Int32, 0
 // RANGECHECK: [[INTZERO:%.*]] = struct $Int32 ([[ZERO]] : $Builtin.Int32)
-// RANGECHECK: [[CB:%.*]] = function_ref @checkbounds2 : $@convention(method) (Int32, Bool, @owned Array<Int>) -> _DependenceToken
 // RANGECHECK: apply [[CB]]([[INTZERO]], [[TRUE]], %0) : $@convention(method) (Int32, Bool, @owned Array<Int>) -> _DependenceToken
+// RANGECHECK: apply [[CB]]
+// RANGECHECK: apply [[CB]]
+// RANGECHECK: bb1
 // RANGECHECK-NOT: apply [[CB]]
 // RANGECHECK-LABEL: } // end sil function 'hoist_new_ind_pattern4'
 //   for i in 0..<a.count

--- a/test/SILOptimizer/span_bounds_check_tests.swift
+++ b/test/SILOptimizer/span_bounds_check_tests.swift
@@ -378,3 +378,18 @@ public func span_different_self_sum(p: borrowing Span<Int>, q: borrowing Span<In
     return a &+ b
 }
 
+// Bounds check should be hoisted but not eliminated for preincrement patterns
+// SIL optimizer optimizes the loop but keeps bounds checks
+
+// CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A21_hoist_dont_eliminate0A0Sis4SpanVySiG_tF :
+// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-SIL-LABEL: } // end sil function '$s23span_bounds_check_tests0A21_hoist_dont_eliminate0A0Sis4SpanVySiG_tF'
+public func span_hoist_dont_eliminate(span: Span<Int>) -> Int {
+  var sum = 0
+  for i in 0...span.count {
+    sum &+= span[i]
+  }
+  return sum
+}
+


### PR DESCRIPTION
During bounds check optimization, we check whether the preheader has a condition that checks whether the induction variable ranges from `0...count`. If so, we eliminate the bounds checks within the loop.

However, this is invalid for preIncrement access patterns, which access the bounds checked storage with `induction variable + 1` access patterns.