### PR TITLE
 ClangImporter: import setter for weak/assign readonly-to-readwrite property redeclarations. rdar://181523137

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -6510,9 +6510,15 @@ namespace {
       // different (usually in something like nullability), but for Swift it's
       // an AST invariant that's assumed and asserted elsewhere. If the type is
       // different, just drop the setter, and leave the property as get-only.
+      //
+      // Compare through any reference-storage wrapper: applyPropertyOwnership()
+      // above may have rewritten the original property's type into a
+      // WeakStorageType/UnmanagedStorageType for weak/assign ownership, while
+      // the setter parameter is always the plain referent type.
       assert(setter->getParameters()->size() == 1);
       const ParamDecl *param = setter->getParameters()->get(0);
-      if (!param->getInterfaceType()->isEqual(original->getInterfaceType()))
+      if (!param->getInterfaceType()->isEqual(
+              original->getInterfaceType()->getReferenceStorageReferent()))
         return;
 
       original->setComputedSetter(setter);

--- a/test/ClangImporter/Inputs/custom-modules/RedeclaredProperties/RPFirst.h
+++ b/test/ClangImporter/Inputs/custom-modules/RedeclaredProperties/RPFirst.h
@@ -15,6 +15,10 @@
 @property (readonly, nonnull) id accessorDeclaredFirstAsNullable;
 
 @property (readonly, nullable) id accessorInProto;
+
+@property (readonly, weak, nullable) RPFoo *weakRedeclared;
+@property (readonly, assign, nullable) RPFoo *assignRedeclared;
+@property (readonly, strong, nullable) RPFoo *strongRedeclared;
 @end
 
 @interface RPBase <RPProto>

--- a/test/ClangImporter/Inputs/custom-modules/RedeclaredProperties/RPSecond.h
+++ b/test/ClangImporter/Inputs/custom-modules/RedeclaredProperties/RPSecond.h
@@ -4,6 +4,10 @@
 @property (readwrite, nonnull) RPFoo *typeChangeMoreSpecific;
 @property (readwrite, nonnull) id typeChangeMoreGeneral;
 @property (readwrite, nullable) id accessorInProto;
+
+@property (readwrite, weak, nullable) RPFoo *weakRedeclared;
+@property (readwrite, assign, nullable) RPFoo *assignRedeclared;
+@property (readwrite, strong, nullable) RPFoo *strongRedeclared;
 @end
 
 @interface RPSub : RPBase

--- a/test/ClangImporter/objc_redeclared_properties.swift
+++ b/test/ClangImporter/objc_redeclared_properties.swift
@@ -37,6 +37,12 @@ func test(obj: RPFoo) {
   if let _ = obj.accessorDeclaredFirstAsNullable {} // expected-error {{initializer for conditional binding must have Optional type}}
 
   obj.accessorInProto = nil // okay
+
+  // A readonly weak/assign/strong object property redeclared as readwrite in a
+  // class extension imports with a setter regardless of ownership.
+  obj.weakRedeclared = obj // okay
+  obj.assignRedeclared = obj // okay
+  obj.strongRedeclared = obj // okay
 }
 
 // https://github.com/apple/swift/issues/51011
@@ -60,11 +66,17 @@ func f_51011(obj: RPSub) {
 // CHECK-NEXT:   class func accessorDeclaredFirstAsNullable() -> Any
 // CHECK-NEXT:   var accessorDeclaredFirstAsNullable: Any { get }
 // CHECK-NEXT:   var accessorInProto: Any? { get }
+// CHECK-NEXT:   weak var weakRedeclared: @sil_weak RPFoo? { get }
+// CHECK-NEXT:   unowned(unsafe) var assignRedeclared: @sil_unmanaged RPFoo? { get }
+// CHECK-NEXT:   var strongRedeclared: RPFoo? { get }
 // CHECK-NEXT:   class func nonnullToNullable() -> UnsafeMutablePointer<Int32>
 // CHECK-NEXT:   class func nullableToNonnull() -> UnsafeMutablePointer<Int32>?
 // CHECK-NEXT:   class func typeChangeMoreSpecific() -> Any
 // CHECK-NEXT:   class func typeChangeMoreGeneral() -> RPFoo
 // CHECK-NEXT:   class func accessorInProto() -> Any?
+// CHECK-NEXT:   class func weakRedeclared() -> RPFoo?
+// CHECK-NEXT:   class func assignRedeclared() -> RPFoo?
+// CHECK-NEXT:   class func strongRedeclared() -> RPFoo?
 // CHECK-NEXT:   func accessorInProto() -> Any?
 // CHECK-NEXT: }
 // CHECK-NEXT: class RPBase : RPProto {


### PR DESCRIPTION
When a readonly weak/assign property is redeclared readwrite, the synthesized setter was dropped: applyPropertyOwnership had rewritten the property's type into a reference-storage wrapper (@sil_weak/@sil_unmanaged) while the setter parameter stays the bare referent, so the type-equality guard falsely failed. Compare through getReferenceStorageReferent() so both sides are referent types.

