### PR TITLE
[Diagnostics] Fix indefinite article in performance_deallocating diagnostic

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -365,7 +365,7 @@ ERROR(performance_metadata_type,none,
 ERROR(performance_allocating,none,
       "%0 can cause an allocation", (StringRef))
 ERROR(performance_deallocating,none,
-      "%0 can cause an deallocation", (StringRef))
+      "%0 can cause a deallocation", (StringRef))
 ERROR(performance_deallocating_type,none,
       "%0 a value of type %1 can cause a deallocation", (StringRef, Type))
 ERROR(performance_locking,none,

--- a/test/SILOptimizer/performance-annotations.swift
+++ b/test/SILOptimizer/performance-annotations.swift
@@ -606,9 +606,6 @@ extension G where T == Int {
 }
 
 @_noAllocation
-
 func testUntypedDeallocation(_ p: UnsafeMutableRawPointer) {
-
     p.deallocate() // expected-error {{this code pattern can cause a deallocation}}
-
 }

--- a/test/SILOptimizer/performance-annotations.swift
+++ b/test/SILOptimizer/performance-annotations.swift
@@ -604,3 +604,11 @@ extension G where T == Int {
     }
   }
 }
+
+@_noAllocation
+
+func testUntypedDeallocation(_ p: UnsafeMutableRawPointer) {
+
+    p.deallocate() // expected-error {{this code pattern can cause a deallocation}}
+
+}


### PR DESCRIPTION
Fixes the `performance_deallocating` diagnostic text from “can cause an deallocation” to “can cause a deallocation”.

`deallocation` starts with a consonant sound, and the neighboring `performance_deallocating_type` diagnostic already uses “a deallocation”.

Adds `-verify` coverage in `test/SILOptimizer/performance-annotations.swift` for the corrected diagnostic string.