### PR TITLE
Sema: Suppress memberwise init synthesis if init accessors are unavailable

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2818,6 +2818,14 @@ ERROR(spi_only_imports_not_enabled, none,
       "'@_spiOnly' requires setting the frontend flag '-experimental-spi-only-imports'",
       ())
 
+ERROR(cannot_synthesize_memberwise_init,none,
+      "cannot automatically synthesize memberwise initializer for %0",
+      (const StructDecl *))
+NOTE(unavailable_init_accessor_prevent_memberwise_init_synthesis,none,
+     "%select{potentially |}0unavailable %kind1 with init accessor prevents "
+     "automatic synthesis of memberwise initializer",
+     (bool, const VarDecl *))
+
 WARNING(warn_use_of_compat_memberwise_init,Deprecation,
         "synthesized memberwise initializer no longer includes "
         "%select{private properties with initial values|%1}0; uses of it "
@@ -8743,9 +8751,6 @@ ERROR(init_accessor_invalid_member_ref,none,
       "refer to instance properties listed in 'initializes' and "
       "'accesses' attributes",
       (DeclNameRef))
-ERROR(cannot_synthesize_memberwise_due_to_property_init_order,none,
-      "cannot synthesize memberwise initializer",
-      ())
 NOTE(out_of_order_access_in_init_accessor,none,
      "init accessor for %0 cannot access stored property %1 because it "
      "is called before %1 is initialized",

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1531,6 +1531,17 @@ bool HasMemberwiseInitRequest::evaluate(Evaluator &evaluator, StructDecl *decl,
   llvm::SmallPtrSet<VarDecl *, 4> initializedProperties;
   llvm::SmallVector<std::pair<VarDecl *, Identifier>> invalidOrderings;
 
+  llvm::SmallVector<std::pair<VarDecl *, AvailabilityRestriction>>
+      availabilityRestrictions;
+
+  // Synthesized memberwise intializers are available at the intersection of the
+  // availability of the struct containing the initializer and the deployment
+  // target (since they have at most 'internal' accessibility and therefore
+  // cannot be invoked by module clients).
+  auto structAvailability = AvailabilityContext::forDeclSignature(decl);
+  structAvailability.constrainWithContext(
+      AvailabilityContext::forDeploymentTarget(ctx), ctx);
+
   if (enumerateCurrentPropertiesAndAuxiliaryVars(decl, [&](VarDecl *var) {
         if (var->isStatic())
           return true;
@@ -1541,9 +1552,17 @@ bool HasMemberwiseInitRequest::evaluate(Evaluator &evaluator, StructDecl *decl,
         if (!var->isMemberwiseInitialized(initKind, /*preferDeclared=*/true))
           return true;
 
-        // Check whether use of init accessors results in access to
-        // uninitialized properties.
         if (auto *initAccessor = var->getAccessor(AccessorKind::Init)) {
+          // Check whether the property has stronger availability restrictions
+          // than the initializer.
+          if (!var->hasStorage()) {
+            if (auto restriction =
+                    structAvailability.unsatisfiedRestrictionForDecl(var)) {
+              availabilityRestrictions.push_back({var, *restriction});
+              return true;
+            }
+          }
+
           // Make sure that all properties accessed by init accessor
           // are previously initialized.
           for (auto *property : initAccessor->getAccessedProperties()) {
@@ -1578,12 +1597,8 @@ bool HasMemberwiseInitRequest::evaluate(Evaluator &evaluator, StructDecl *decl,
       }))
     return false;
 
-  if (invalidOrderings.empty())
-    return !initializedProperties.empty();
-
-  {
-    ctx.Diags.diagnose(
-        decl, diag::cannot_synthesize_memberwise_due_to_property_init_order);
+  if (!invalidOrderings.empty()) {
+    ctx.Diags.diagnose(decl, diag::cannot_synthesize_memberwise_init, decl);
 
     for (const auto &invalid : invalidOrderings) {
       auto *accessor = invalid.first->getAccessor(AccessorKind::Init);
@@ -1591,9 +1606,24 @@ bool HasMemberwiseInitRequest::evaluate(Evaluator &evaluator, StructDecl *decl,
                          diag::out_of_order_access_in_init_accessor,
                          invalid.first->getName(), invalid.second);
     }
+
+    return false;
   }
 
-  return false;
+  if (!availabilityRestrictions.empty()) {
+    ctx.Diags.diagnose(decl, diag::cannot_synthesize_memberwise_init, decl);
+
+    for (const auto &[var, restriction] : availabilityRestrictions) {
+      ctx.Diags.diagnose(
+          var->getLoc(),
+          diag::unavailable_init_accessor_prevent_memberwise_init_synthesis,
+          restriction.isUnavailable(), var);
+    }
+
+    return false;
+  }
+
+  return !initializedProperties.empty();
 }
 
 ConstructorDecl *

--- a/test/Availability/availability_stored.swift
+++ b/test/Availability/availability_stored.swift
@@ -92,6 +92,8 @@ struct BadReferenceStruct1 { // expected-note 3 {{add '@available' attribute to 
     init { _ = newValue }
     get { x }
   }
+
+  init() { fatalError() } // To suppress memberwise initializer
 }
 
 @available(macOS 40, *)
@@ -133,6 +135,8 @@ struct BadReferenceStruct2 {
     init { _ = newValue }
     get { x }
   }
+
+  init() { fatalError() } // To suppress memberwise initializer
 }
 
 @available(macOS 40, *)
@@ -174,6 +178,8 @@ public struct PublicStruct {
     init { _ = newValue }
     get { x }
   }
+
+  init() { fatalError() } // To suppress memberwise initializer
 }
 
 // The same behavior should hold for enum elements with payloads.
@@ -207,4 +213,38 @@ public enum PublicReferenceEnum {
   // expected-error@+1 {{enum cases with associated values cannot be marked potentially unavailable with '@available'}}
   @available(macOS 50, *)
   case x(NewStruct)
+}
+
+struct SuppressedMemberwiseInit { // expected-error {{cannot automatically synthesize memberwise initializer for 'SuppressedMemberwiseInit'}}
+  @available(macOS 50, *)
+  var computedWithInit: NewStruct { // expected-note {{potentially unavailable property 'computedWithInit' with init accessor prevents automatic synthesis of memberwise initializer}}
+    init { _ = newValue }
+    get { NewStruct() }
+  }
+}
+
+@available(macOS 40, *)
+struct SuppressedMemberwiseInitLater { // expected-error {{cannot automatically synthesize memberwise initializer for 'SuppressedMemberwiseInitLater'}}
+  // Ok, as available as struct.
+  @available(macOS 40, *)
+  var computedWithInit: Int {
+    init { _ = newValue }
+    get { 0 }
+  }
+
+  @available(macOS 50, *)
+  var newComputedWithInit: NewStruct { // expected-note {{potentially unavailable property 'newComputedWithInit' with init accessor prevents automatic synthesis of memberwise initializer}}
+    init { _ = newValue }
+    get { NewStruct() }
+  }
+}
+
+@available(macOS, unavailable)
+struct HasMemberwiseInitUnavailableMacOS {
+  // Ok, struct is unavailable
+  @available(macOS 50, *)
+  var computedWithInit: NewStruct {
+    init { _ = newValue }
+    get { NewStruct() }
+  }
 }

--- a/test/Availability/availability_stored_unavailable.swift
+++ b/test/Availability/availability_stored_unavailable.swift
@@ -23,6 +23,9 @@ var spiAvailableMacOSGlobal: SPIAvailableMacOSStruct = .init()
 @available(*, unavailable)
 var universallyUnavailableGlobal: UniversallyUnavailableStruct = .init()
 
+@available(*, deprecated)
+struct DeprecatedStruct {}
+
 // Computed globals have no initial value to execute eagerly, so they are safe
 // to mark unavailable.
 @available(macOS, unavailable)
@@ -52,6 +55,12 @@ struct GoodAvailableStruct {
     init { _ = newValue }
     get { UnavailableMacOSStruct() }
   }
+
+  // Ok, deprecation is advisory.
+  @available(*, deprecated)
+  var deprecated: DeprecatedStruct
+
+  init() { fatalError() } // To suppress memberwise initializer
 }
 
 @available(macOS, unavailable)
@@ -129,6 +138,12 @@ struct BadStruct {
     init { _ = newValue }
     get { UniversallyUnavailableStruct() } // expected-error {{'UniversallyUnavailableStruct' is unavailable}}
   }
+
+  // Ok, deprecation is advisory.
+  @available(*, deprecated)
+  var deprecated: DeprecatedStruct
+
+  init() { fatalError() } // To suppress memberwise initializer
 }
 
 enum GoodAvailableEnum {
@@ -137,4 +152,62 @@ enum GoodAvailableEnum {
 
   @_spi_available(macOS, introduced: 10.9)
   case spiAvailableMacOS(SPIAvailableMacOSStruct)
+
+  // Ok, deprecation is advisory.
+  @available(*, deprecated)
+  case deprecated(DeprecatedStruct)
+}
+
+struct SuppressedMemberwiseInit { // expected-error {{cannot automatically synthesize memberwise initializer for 'SuppressedMemberwiseInit'}}
+  // Ok, computed properties without init accessors don't affect memberwise init.
+  @available(macOS, unavailable)
+  var computedUnavailableMacOS: UnavailableMacOSStruct {
+    get { UnavailableMacOSStruct() }
+    set { _ = newValue }
+  }
+
+  @available(macOS, unavailable)
+  var computedUnavailableMacOSWithInit: UnavailableMacOSStruct { // expected-note {{unavailable property 'computedUnavailableMacOSWithInit' with init accessor prevents automatic synthesis of memberwise initializer}}
+    init { _ = newValue }
+    get { UnavailableMacOSStruct() }
+  }
+
+  @available(*, unavailable)
+  var computedUniversallyUnavailableWithInit: UniversallyUnavailableStruct { // expected-note {{unavailable property 'computedUniversallyUnavailableWithInit' with init accessor prevents automatic synthesis of memberwise initializer}}
+    init { _ = newValue }
+    get { UniversallyUnavailableStruct() }
+  }
+
+  // Ok, deprecation is advisory.
+  @available(*, deprecated)
+  var deprecatedWithInit: DeprecatedStruct {
+    init { _ = newValue }
+    get { DeprecatedStruct() }
+  }
+}
+
+@available(macOS, unavailable)
+struct SuppressedMemberwiseInitUnavailableMacOS { // expected-error {{cannot automatically synthesize memberwise initializer for 'SuppressedMemberwiseInitUnavailableMacOS'}}
+  // Ok, as available as struct.
+  @available(macOS, unavailable)
+  var computedUnavailableMacOSWithInit: UnavailableMacOSStruct {
+    init { _ = newValue }
+    get { UnavailableMacOSStruct() }
+  }
+
+  @available(*, unavailable)
+  var computedUniversallyUnavailableWithInit: UniversallyUnavailableStruct { // expected-note {{unavailable property 'computedUniversallyUnavailableWithInit' with init accessor prevents automatic synthesis of memberwise initializer}}
+    init { _ = newValue }
+    get { UniversallyUnavailableStruct() }
+  }
+}
+
+@available(macOS, unavailable)
+struct HasMemberwiseInitUnavailableMacOS {
+  // Ok, as available as struct.
+  @available(macOS, unavailable)
+  var computedUnavailableMacOSWithInit: UnavailableMacOSStruct {
+    init { _ = newValue }
+    get { UnavailableMacOSStruct() }
+  }
 }

--- a/test/decl/memberwise_init_compat_diag.swift
+++ b/test/decl/memberwise_init_compat_diag.swift
@@ -122,7 +122,7 @@ extension H {
 // We don't currently support accessing a property declared later.
 // NOTE: If this restriction is lifted, `emitImplicitValueConstructor` needs
 // updating to ensure we initialize `d` before `b`.
-struct I { // expected-error {{cannot synthesize memberwise initializer}}
+struct I { // expected-error {{cannot automatically synthesize memberwise initializer}}
   var a: Int
   var b: Int
   private var c: Int = 0 {

--- a/test/decl/var/init_accessors.swift
+++ b/test/decl/var/init_accessors.swift
@@ -405,7 +405,7 @@ func test_memberwise_ordering() {
 
   _ = Test1(_b: 42, a: 0) // Ok
 
-  struct Test2 { // expected-error {{cannot synthesize memberwise initializer}}
+  struct Test2 { // expected-error {{cannot automatically synthesize memberwise initializer for 'Test2'}}
     var _a: Int
 
     var a: Int {


### PR DESCRIPTION
When some of a struct's members have init accessors with availability restrictions, the compiler was synthesizing a memberwise initializer without also giving the same availability restrictions to it. This could result in runtime crashes or a failure to link depending on the nature of the availability restrictions. The developer should be required to write explicit initializers for these structs since the compiler cannot guess how to handle the initial values for unavailable properties.

Resolves rdar://174185479.
