### PR TITLE
Add optional verification for irreducible loops

### DIFF
--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -37,6 +37,7 @@
 #include "swift/SIL/Dominance.h"
 #include "swift/SIL/DynamicCasts.h"
 #include "swift/SIL/InstructionUtils.h"
+#include "swift/SIL/LoopInfo.h"
 #include "swift/SIL/MemAccessUtils.h"
 #include "swift/SIL/OwnershipLiveness.h"
 #include "swift/SIL/OwnershipUtils.h"
@@ -98,6 +99,11 @@ static llvm::cl::opt<bool> SkipConvertEscapeToNoescapeAttributes(
 // Allow unit tests to gradually migrate toward -allow-critical-edges=false.
 static llvm::cl::opt<bool> AllowCriticalEdges("allow-critical-edges",
                                               llvm::cl::init(true));
+
+static llvm::cl::opt<bool> VerifyReducibleLoops(
+    "verify-reducible-loops", llvm::cl::init(false),
+    llvm::cl::desc("Verify that SIL does not contain irreducible loops"));
+
 extern llvm::cl::opt<bool> SILPrintDebugInfo;
 
 void swift::verificationFailure(
@@ -7572,6 +7578,9 @@ public:
         !mod.getASTContext().hadError()) {
       F->verifyMemoryLifetime(calleeCache, &getDeadEndBlocks());
     }
+
+    if (VerifyReducibleLoops)
+      verifyReducibleLoops(F);
   }
 
   void verify(bool isCompleteOSSA) {
@@ -7579,6 +7588,23 @@ public:
       DEBlocks = std::make_shared<DeadEndBlocks>(const_cast<SILFunction *>(&F));
     }
     visitSILFunction(const_cast<SILFunction*>(&F));
+  }
+
+  void verifyReducibleLoops(SILFunction *func) {
+    llvm::SmallPtrSet<SILBasicBlock *, 32> loopHeaders;
+    findLoopHeaders(*func, loopHeaders);
+
+    SILLoopInfo loopInfo(func, Dominance);
+
+    for (auto *loopHeader : loopHeaders) {
+      auto *loop = loopInfo.getLoopFor(loopHeader);
+      if (!loop) {
+        llvm::errs() << "Irreducible loop detected in function "
+                     << func->getName() << ":\n";
+        loopHeader->dump();
+        require(false, "SIL contains irreducible loop");
+      }
+    }
   }
 };
 } // end anonymous namespace

--- a/test/SIL/verify_reducible_loops.sil
+++ b/test/SIL/verify_reducible_loops.sil
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+// RUN: not --crash %target-sil-opt -verify-reducible-loops %s 2> %t/err.txt
+// RUN: %FileCheck %s < %t/err.txt
+
+// REQUIRES: asserts
+
+// This test contains an irreducible loop and should fail verification
+// when -sil-verify-reducible-loops is enabled.
+
+sil_stage canonical
+
+import Builtin
+
+// CHECK: Irreducible loop detected in function irreducible_loop
+
+sil @irreducible_loop : $@convention(thin) (Builtin.Int1) -> () {
+bb0(%0 : $Builtin.Int1):
+  cond_br %0, bb1, bb2
+
+// bb1 and bb2 form an irreducible loop: both are entry points
+// from outside and both branch to each other.
+bb1:
+  cond_br %0, bb2, bb3
+
+bb2:
+  cond_br %0, bb1, bb3
+
+bb3:
+  %r = tuple ()
+  return %r : $()
+}
+


### PR DESCRIPTION
Add a -verify-reducible-loops flag that ensure SIL functions have reducible loops
