### PR TITLE
[NFC] Musl/Android/WASI stdio globals as UnsafeMutablePointer<FILE>!

### DIFF
--- a/stdlib/public/Platform/Android.swift
+++ b/stdlib/public/Platform/Android.swift
@@ -13,6 +13,10 @@
 @_exported import SwiftAndroid // Clang module
 import SwiftOverlayShims
 
+// FILE is opaque on Android (bionic) - the underlying `struct __sFILE` is
+// not exposed in a way that Clang can import into Swift, so use OpaquePointer.
+// Client code that needs to interoperate with <stdio.h> functions can bridge
+// via `typealias File = OpaquePointer` under `#if os(Android)`.
 nonisolated(unsafe) public var stdin: OpaquePointer {
   OpaquePointer(_swift_stdlib_stdin())
 }

--- a/stdlib/public/Platform/Musl.swift.gyb
+++ b/stdlib/public/Platform/Musl.swift.gyb
@@ -71,14 +71,16 @@ public let ${prefix}_TRUE_MIN = ${type}.leastNonzeroMagnitude
 % end
 %end
 
-// FILE is an opaque type on Musl (struct _IO_FILE is only forward-declared),
-// so these are OpaquePointers rather than UnsafeMutablePointer<FILE>.
-nonisolated(unsafe) public var stdin: OpaquePointer {
-  OpaquePointer(_swift_stdlib_stdin())
+// `struct _IO_FILE` is only forward-declared in Musl's <stdio.h>, but Swift
+// still imports pointers to it as `UnsafeMutablePointer<FILE>`, and every
+// stdio function in the same overlay (fputs, setvbuf, etc.) is imported
+// with that signature.
+nonisolated(unsafe) public var stdin: UnsafeMutablePointer<FILE>! {
+  _swift_stdlib_stdin().assumingMemoryBound(to: FILE.self)
 }
-nonisolated(unsafe) public var stdout: OpaquePointer {
-  OpaquePointer(_swift_stdlib_stdout())
+nonisolated(unsafe) public var stdout: UnsafeMutablePointer<FILE>! {
+  _swift_stdlib_stdout().assumingMemoryBound(to: FILE.self)
 }
-nonisolated(unsafe) public var stderr: OpaquePointer {
-  OpaquePointer(_swift_stdlib_stderr())
+nonisolated(unsafe) public var stderr: UnsafeMutablePointer<FILE>! {
+  _swift_stdlib_stderr().assumingMemoryBound(to: FILE.self)
 }

--- a/stdlib/public/Platform/WASILibc.swift.gyb
+++ b/stdlib/public/Platform/WASILibc.swift.gyb
@@ -65,9 +65,10 @@ public let ${prefix}_TRUE_MIN = ${type}.leastNonzeroMagnitude
 
 public let MAP_FAILED: UnsafeMutableRawPointer! = UnsafeMutableRawPointer(bitPattern: -1)
 
-// FILE is an opaque type on WASI libc (struct _IO_FILE is only
-// forward-declared), so these are OpaquePointers rather than
-// UnsafeMutablePointer<FILE>.
+// FILE is opaque on WASI libc - the underlying `struct _IO_FILE` is only
+// forward-declared, so use OpaquePointer. Client code that needs to
+// interoperate with <stdio.h> functions can bridge via `typealias File =
+// OpaquePointer` under `#if os(WASI)`.
 nonisolated(unsafe) public var stdin: OpaquePointer {
   OpaquePointer(_swift_stdlib_stdin())
 }

--- a/test/stdlib/StdioSendable.swift
+++ b/test/stdlib/StdioSendable.swift
@@ -51,3 +51,18 @@ nonisolated func useFromNonisolatedContext() {
     _ = stdout
     _ = stderr
 }
+
+// Make sure we can pass stdout/stderr to `FILE *` parameters of stdio functions
+// imported from the same overlay.
+//
+// On Android and WASI `FILE *` imports as OpaquePointer, so those platforms
+// require a bridging typealias at each call site (see swift-inspect for the
+// pattern). This check therefore runs only where FILE is a nominal type.
+#if !os(Android) && !os(WASI)
+func passToStdioFunctions() {
+    setvbuf(stdout, nil, _IOLBF, 0)
+    setvbuf(stderr, nil, _IOLBF, 0)
+    fflush(stdout)
+    fputs("hi", stderr)
+}
+#endif


### PR DESCRIPTION
swift-backtrace was using `setvbuf(stdout, nil, _IOLBF, 0)` which failed under `x86_64-swift-linux-musl` after the recent changes in https://github.com/swiftlang/swift/pull/89891

We need to match the way those funcs are imported, so those variables must be `UnsafeMutablePointer<FILE>!`

Also adds a test actually using those globals so we won't regress randomly.

Resolves rdar://182172802 