### PR TITLE
Adjust to some low-risk upstream llvm-project changes

### DIFF
--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -2093,7 +2093,7 @@ void importer::addMacrosToLookupTable(SwiftLookupTable &table,
     };
 
     ArrayRef<clang::ModuleMacro *> moduleMacros =
-        macro.second.getActiveModuleMacros(pp, macro.first);
+        macro.second.getModuleInfo(pp, macro.first).ActiveModuleMacros;
     if (moduleMacros.empty()) {
       // Handle the bridging header case.
       clang::MacroDirective *MD = pp.getLocalMacroDirective(macro.first);

--- a/lib/DriverTool/swift_llvm_opt_main.cpp
+++ b/lib/DriverTool/swift_llvm_opt_main.cpp
@@ -207,7 +207,7 @@ int swift_llvm_opt_main(ArrayRef<const char *> argv, void *MainAddr) {
 
   // Override function attributes based on CPUStr, FeaturesStr, and command line
   // flags.
-  llvm::codegen::setFunctionAttributes(CPUStr, FeaturesStr, *M);
+  llvm::codegen::setFunctionAttributes(*M, CPUStr, FeaturesStr);
 
   if (options.Optimized) {
     IRGenOptions Opts;


### PR DESCRIPTION
Targeting main to minimise the difference between main and rebranch.

Paired with https://github.com/swiftlang/llvm-project/pull/13389.