### PR TITLE
DeadAccessScopeElimination: don't remove "signed" accesses

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/DeadAccessScopeElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/DeadAccessScopeElimination.swift
@@ -138,7 +138,12 @@ private func process(instruction: Instruction,
   switch instruction {
 
   case let beginAccess as BeginAccessInst:
-    if beginAccess.isDead || beginAccess.isFromLocallyAllocatedClass {
+    if beginAccess.isDead ||
+       (beginAccess.isFromLocallyAllocatedClass &&
+        // "signed" accesses must not be removed, even if there is no conflict, because such
+        // accesses need to do pointer authentication.
+        beginAccess.enforcement != .signed)
+    {
       // Might be removed again later if it turns out to be in a conflicting scope.
       removableScopes.insert(beginAccess)
     }

--- a/test/SILOptimizer/access-scopes-and-ptr-auth.swift
+++ b/test/SILOptimizer/access-scopes-and-ptr-auth.swift
@@ -1,0 +1,24 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-build-swift -O -import-objc-header %t/c-header.h %t/test.swift -Xfrontend -sil-verify-all -emit-sil -o /dev/null
+
+// REQUIRES: CPU=arm64e
+
+//--- c-header.h
+
+struct S {
+    void (*__ptrauth(0, 1, 0xB966) fn)(void);
+};
+
+//--- test.swift
+
+func target() {}
+
+// Check that DeadAccessScopeElimination does not remove the `begin_access [signed]`.
+// This would cause a SILVerifier crash.
+
+public func test(_ out: UnsafeMutablePointer<S>) {
+    let a = [S(fn: target)]
+    out.pointee = a[0]
+}
+

--- a/test/SILOptimizer/dead-access-scope-elimination.sil
+++ b/test/SILOptimizer/dead-access-scope-elimination.sil
@@ -395,3 +395,22 @@ bb0(%arg : @guaranteed $MyClass):
   return %r : $()
 }
 
+// CHECK-LABEL: sil [ossa] @dont_remove_signed_accesses :
+// CHECK:         begin_access
+// CHECK:         end_access
+// CHECK:       } // end sil function 'dont_remove_signed_accesses'
+sil [ossa] @dont_remove_signed_accesses : $@convention(thin) () -> () {
+bb0:
+  %obj = alloc_ref $MyClass
+  %borrow = begin_borrow %obj : $MyClass
+  %addr = ref_element_addr %borrow : $MyClass, #MyClass.x
+  %val = integer_literal $Builtin.Int64, 0
+  %access = begin_access [modify] [signed] %addr : $*Builtin.Int64
+  store %val to [trivial] %access : $*Builtin.Int64
+  end_access %access : $*Builtin.Int64
+  end_borrow %borrow : $MyClass
+  destroy_value %obj : $MyClass
+  %r = tuple ()
+  return %r : $()
+}
+


### PR DESCRIPTION
"signed" accesses must not be removed, even if there is no conflict, because such accesses need to do pointer authentication.

rdar://182204256
