### PR TITLE
MemoryLifetimeVerifier: relax the requirement for `inject_enum_addr`

### DIFF
--- a/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
+++ b/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
@@ -762,8 +762,6 @@ void MemoryLifetimeVerifier::checkBlock(SILBasicBlock *block, Bits &bits) {
             // initialization. See initDataflowInBlock().
             requireBitsClear(bits & nonTrivialLocations, IEAI->getOperand(), &I);
             locations.setBits(bits, IEAI->getOperand());
-          } else {
-            requireBitsSet(bits, IEAI->getOperand(), &I);
           }
         }
         requireNoStoreBorrowLocation(IEAI->getOperand(), &I);

--- a/test/SIL/memory_lifetime.sil
+++ b/test/SIL/memory_lifetime.sil
@@ -1027,3 +1027,13 @@ bb0(%0 : $Int):
   dealloc_stack %3
   return %4
 }
+
+sil [ossa] @dead_enum_with_leftover_inject : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $KlassOrBool
+  // DeadStoreElimination may have removed the payload store
+  inject_enum_addr %0, #KlassOrBool.bool!enumelt
+  dealloc_stack %0
+  %r = tuple ()
+  return %r
+}

--- a/test/SIL/memory_lifetime_failures.sil
+++ b/test/SIL/memory_lifetime_failures.sil
@@ -856,7 +856,7 @@ bb0(%0 : @owned $T, %1 : @owned $Inner):
 
 sil @initfn : $@convention(thin) () -> @out T 
 
-// CHECK: SIL memory lifetime failure in @inject_enum_case: memory is not initialized, but should be
+// This is currently not checked
 sil [ossa] @inject_enum_case : $@convention(thin) () -> () {
 bb0:
   %0 = alloc_stack $Optional<T>


### PR DESCRIPTION
DeadStoreElimination may have removed the store to the payload if it is not used afterwards. In this case the `inject_enum_addr` remains. However it's not required that the payload is initialized at this point.
