### PR TITLE
[Concurrency] Enable flow isolation for property-isolated types

### DIFF
--- a/lib/SILOptimizer/Mandatory/FlowIsolation.cpp
+++ b/lib/SILOptimizer/Mandatory/FlowIsolation.cpp
@@ -464,8 +464,27 @@ public:
     //
     auto funcIsolation = rafi->getFunction()->getActorIsolation();
     if (funcIsolation.isActorIsolated()) {
-      // If our value is Non-Sendable, then we can rely on region isolation.
-      if (SILIsolationInfo::isNonSendable(i->get())) {
+      VarDecl *accessedProperty = nullptr;
+      if (auto *seai = dyn_cast<StructElementAddrInst>(i->getUser())) {
+        accessedProperty = seai->getField();
+      } else if (auto *reai = dyn_cast<RefElementAddrInst>(i->getUser())) {
+        accessedProperty = reai->getField();
+      }
+
+      // A property projection's operand is the base value, so its region
+      // isolation may not describe the isolation of the projected storage.
+      if (accessedProperty) {
+        auto propertyIsolation = swift::getActorIsolation(accessedProperty);
+        if (propertyIsolation.isActorIsolated() &&
+            propertyIsolation == funcIsolation) {
+          LLVM_DEBUG(llvm::dbgs()
+                     << "isolated use that is safe b/c property is isolated "
+                        "to same as constructor. Op Num: "
+                     << i->getOperandNumber() << ". User: " << *i->getUser());
+          return;
+        }
+      } else if (SILIsolationInfo::isNonSendable(i->get())) {
+        // If our value is Non-Sendable, then we can rely on region isolation.
         if (auto iso = isolationInfoCache.getIsolationInfoAtInst(i->getUser(),
                                                                  i->get())) {
           if (iso->isActorIsolated() &&
@@ -478,32 +497,13 @@ public:
           }
         }
       } else {
-        // If our operand was Sendable, we may have our traversal at a
-        // projection. See if we can find a VarDecl for it.
-        if (auto *svi = dyn_cast<SingleValueInstruction>(i->getUser());
-            llvm::isa_and_present<StructElementAddrInst, RefElementAddrInst>(
-                svi)) {
-          Projection proj(svi);
-          if (auto *decl = proj.getVarDecl(svi->getOperand(0)->getType())) {
-            if (auto declIsolation = swift::getActorIsolation(decl);
-                declIsolation && declIsolation.isActorIsolated() &&
-                declIsolation == funcIsolation) {
-              LLVM_DEBUG(llvm::dbgs()
-                         << "isolated use that is safe b/c value is "
-                            "isolated to same as constructor. Op Num: "
-                         << i->getOperandNumber()
-                         << ". User: " << *i->getUser());
-              return;
-            }
-          }
-        }
-
         // If we are passing self to a partial_apply or a function, we could end
         // up here. In that case, we want to look at the use in terms of whether
         // or not the partial_apply or function has a callee that is isolated to
         // our function.
         if (ApplySite as = ApplySite::isa(i->getUser())) {
-          if (auto *calleeFunction = as.getCalleeFunction(); calleeFunction &&
+          if (auto *calleeFunction = as.getCalleeFunction();
+              calleeFunction &&
               (calleeFunction->getActorIsolation().isNonisolatedNonsending() ||
                calleeFunction->getActorIsolation() == funcIsolation)) {
             LLVM_DEBUG(llvm::dbgs()

--- a/lib/SILOptimizer/Mandatory/FlowIsolation.cpp
+++ b/lib/SILOptimizer/Mandatory/FlowIsolation.cpp
@@ -803,6 +803,10 @@ void BlockInfo::diagnoseAll(FunctionInfo &info, bool forDeinit,
 /// \returns true iff the access is concurrency-safe in a nonisolated context
 /// without an await.
 static bool accessIsConcurrencySafe(SILInstruction *inst, VarDecl *var) {
+  // Nonisolated storage remains accessible after self has escaped.
+  if (!getActorIsolation(var).isActorIsolated())
+    return true;
+
   // must be accessible from nonisolated.
   return isLetAccessibleAnywhere(
       inst->getFunction()->getModule().getSwiftModule(), var);

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -191,10 +191,14 @@ bool swift::usesFlowSensitiveIsolation(AbstractFunctionDecl *fn) {
                                                     cast<ConstructorDecl>(fn));
   }
 
-  // Otherwise, the type must be isolated to a global actor.
+  // Otherwise, the type or one of its stored properties must be isolated to a
+  // global actor.
   auto nominalIso = getActorIsolation(nominal);
-  if (!nominalIso.isGlobalActor())
-    return false;
+  if (!nominalIso.isGlobalActor()) {
+    return llvm::any_of(nominal->getStoredProperties(), [](VarDecl *property) {
+      return getActorIsolation(property).isGlobalActor();
+    });
+  }
 
   // if it's a deinit, then it's flow-isolated.
   if (isa<DestructorDecl>(fn))

--- a/test/Concurrency/flow_isolation_property.swift
+++ b/test/Concurrency/flow_isolation_property.swift
@@ -16,6 +16,11 @@ nonisolated final class PropertyIsolatedSendable: Sendable {
   }
 }
 
+@globalActor
+actor AnotherActor {
+  static let shared = AnotherActor()
+}
+
 nonisolated final class MixedIsolation {
   @MainActor var isolated: Int
   var nonisolated: Int
@@ -28,6 +33,26 @@ nonisolated final class MixedIsolation {
 
     self.nonisolated += 1
     self.isolated += 1 // expected-error {{cannot access property 'isolated' here in nonisolated initializer}}
+  }
+
+  @MainActor init(mainActor: ()) {
+    self.isolated = 0
+    self.nonisolated = 0
+
+    escape()
+
+    self.nonisolated += 1
+    self.isolated += 1
+  }
+
+  @AnotherActor init(anotherActor: ()) {
+    self.isolated = 0
+    self.nonisolated = 0
+
+    escape() // expected-note {{after calling instance method 'escape()', only global actor 'AnotherActor'-isolated properties of 'self' can be accessed from this init}}
+
+    self.nonisolated += 1
+    self.isolated += 1 // expected-error {{cannot access property 'isolated' here in global actor 'AnotherActor'-isolated initializer}}
   }
 
   nonisolated func escape() {}

--- a/test/Concurrency/flow_isolation_property.swift
+++ b/test/Concurrency/flow_isolation_property.swift
@@ -1,0 +1,34 @@
+// RUN: %target-swift-frontend -strict-concurrency=complete -swift-version 6 -parse-as-library -emit-sil -verify %s -o /dev/null
+
+nonisolated final class PropertyIsolatedSendable: Sendable {
+  @MainActor var value: Int
+
+  nonisolated init() async {
+    self.value = 37
+    self.value += 5
+
+    let task = Task { @MainActor () -> Void in // expected-note {{after making a copy of 'self', only nonisolated properties of 'self' can be accessed from this init}}
+      self.value += 1
+    }
+
+    self.value -= 1 // expected-error {{cannot access property 'value' here in nonisolated initializer}}
+    _ = await task.value
+  }
+}
+
+nonisolated final class MixedIsolation {
+  @MainActor var isolated: Int
+  var nonisolated: Int
+
+  nonisolated init() {
+    self.isolated = 0
+    self.nonisolated = 0
+
+    escape() // expected-note {{after calling instance method 'escape()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    self.nonisolated += 1
+    self.isolated += 1 // expected-error {{cannot access property 'isolated' here in nonisolated initializer}}
+  }
+
+  nonisolated func escape() {}
+}


### PR DESCRIPTION
- **Explanation**:

Enable flow-sensitive isolation for types with global-actor-isolated stored properties while preserving access to nonisolated storage after `self` escapes.

- **Scope**:

Update flow-isolation eligibility and access classification, and add a focused concurrency regression test.

- **Issues**:

Resolves https://github.com/swiftlang/swift/issues/90623.

- **Risk**:

Low. The analysis is limited to types with global-actor-isolated storage, and existing nonisolated storage behavior is preserved.

- **Testing**:

`Concurrency/flow_isolation_*.swift` — 8 tests passed. On macOS arm64.