### PR TITLE
OSSACanonicalizeGuaranteed: don't convert owned to guaranteed values if this is not possible

### DIFF
--- a/lib/SILOptimizer/Utils/OSSACanonicalizeGuaranteed.cpp
+++ b/lib/SILOptimizer/Utils/OSSACanonicalizeGuaranteed.cpp
@@ -290,7 +290,8 @@ bool OSSACanonicalizeGuaranteed::visitBorrowScopeUses(SILValue innerValue,
 
       case OperandOwnership::GuaranteedForwarding:
       case OperandOwnership::ForwardingConsume:
-        if (OSSACanonicalizeGuaranteed::isRewritableOSSAForward(user)) {
+        if (OSSACanonicalizeGuaranteed::isRewritableOSSAForward(user) &&
+            canOpcodeForwardInnerGuaranteedValues(use)) {
           if (!visitor.visitForwardingUse(use)) {
             return false;
           }

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -119,6 +119,11 @@ struct CopyableStruct {
   var guts: AnyObject
 }
 
+struct MoveOnlyData<T> : ~Copyable {
+  @_hasStorage let value: T { get }
+  deinit
+}
+
 //////////////////////
 // Simple DCE Tests //
 //////////////////////
@@ -5753,3 +5758,14 @@ bb5:
   return %44
 }
 
+// Just check that SILCombine doesn't produce illegal SIL.
+sil [ossa] @dont_convert_operand_of_drop_deinit_to_guaranteed : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%2 : @guaranteed $Klass):
+  %28 = copy_value %2
+  %33 = struct $MoveOnlyData<Klass> (%28)
+  %62 = drop_deinit %33
+  %63 = destructure_struct %62
+  destroy_value %63
+  %r = tuple ()
+  return %r
+}


### PR DESCRIPTION
Add a check if an operand of an instruction can be converted from owned to guaranteed.

Fixes a SIL verifier check caused by SILCombine (where OSSACanonicalizeGuaranteed is used)
