### PR TITLE
Test: Fix `attr_availability_async_rename.swift`

### DIFF
--- a/test/attr/attr_availability_async_rename.swift
+++ b/test/attr/attr_availability_async_rename.swift
@@ -86,7 +86,6 @@ func defaultedParamsEnd4(newArg: Int, arg: Int = 0) async { }
 @available(macOS, introduced: 12, renamed: "manyAttrsOld()")
 @available(*, renamed: "manyAttrsNew()")
 @available(*, renamed: "manyAttrsNewOther()")
-@available(macOS, deprecated: 12, renamed: "manyAttrsOld()")
 @available(*, deprecated)
 func manyAttrs(completionHandler: @escaping () -> Void) { }
 
@@ -286,8 +285,7 @@ func asyncContext(t: HandlerTest) async {
   // expected-warning@+1{{consider using asynchronous alternative function}}
   defaultedParamsEnd4(arg: 1) { }
   // expected-warning@+3{{consider using asynchronous alternative function}}
-  // expected-warning@+2{{'manyAttrs(completionHandler:)' was deprecated in macOS 12: renamed to 'manyAttrsOld()'}}{{group-name=DeprecatedDeclaration}}
-  // expected-note@+1{{use 'manyAttrsOld()' instead}}
+  // expected-warning@+2{{'manyAttrs(completionHandler:)' is deprecated}}
   manyAttrs() { }
   // expected-warning@+1{{consider using asynchronous alternative function}}
   macOSOnly() { }


### PR DESCRIPTION
Resolves rdar://182260555.
