### PR TITLE
[synthesize-interface] Show @unsafe in textual interface when -strict-memory-safety is set

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -484,6 +484,10 @@ public:
   /// Empty means allow all.
   std::vector<AnyAttrKind> ExclusiveAttrList;
 
+  /// List of attribute kinds that should always be printed, even when they
+  /// would otherwise be hidden because they are implicit or user-inaccessible.
+  std::vector<AnyAttrKind> AlwaysIncludeAttrList;
+
   /// List of decls that should be printed even if they are implicit and \c SkipImplicit is set to true.
   std::vector<const Decl*> TreatAsExplicitDeclList;
 
@@ -710,6 +714,13 @@ public:
       return std::none_of(ExclusiveAttrList.begin(), ExclusiveAttrList.end(),
                           [K](AnyAttrKind other) { return other == K; });
     return false;
+  }
+
+  /// Whether the given attribute kind should be printed even if it would
+  /// otherwise be suppressed for being implicit or user-inaccessible.
+  bool alwaysIncludeAttrKind(AnyAttrKind K) const {
+    return std::any_of(AlwaysIncludeAttrList.begin(), AlwaysIncludeAttrList.end(),
+                       [K](AnyAttrKind other) { return other == K; });
   }
 
   bool excludeAttr(const DeclAttribute *DA) const;

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -825,6 +825,16 @@ void DeclAttributes::print(ASTPrinter &Printer, const PrintOptions &Options,
   auto *SF = D ? D->getDeclContext()->getParentSourceFile() : nullptr;
 
   for (auto DA : llvm::reverse(FlattenedAttrs)) {
+    AttributeVector &which = DA->isDeclModifier() ? modifiers :
+                             isa<BackDeployedAttr>(DA) ? backDeployedAttributes :
+                             DA->isLongAttribute() ? longAttributes :
+                             attributes;
+
+    if (Options.alwaysIncludeAttrKind(DA->getKind())) {
+      which.push_back(DA);
+      continue;
+    }
+
     // Don't skip implicit custom attributes. Custom attributes like global
     // actor isolation have critical semantic meaning and should never be
     // suppressed. Other custom attrs that can be suppressed, like macros,
@@ -889,10 +899,6 @@ void DeclAttributes::print(ASTPrinter &Printer, const PrintOptions &Options,
       }
     }
 
-    AttributeVector &which = DA->isDeclModifier() ? modifiers :
-                             isa<BackDeployedAttr>(DA) ? backDeployedAttributes :
-                             DA->isLongAttribute() ? longAttributes :
-                             attributes;
     which.push_back(DA);
   }
 

--- a/lib/DriverTool/swift_synthesize_interface_main.cpp
+++ b/lib/DriverTool/swift_synthesize_interface_main.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/SearchPathOptions.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/LLVMInitialize.h"
+#include "swift/Basic/Feature.h"
 #include "swift/Basic/LangOptions.h"
 #include "swift/Basic/Version.h"
 #include "swift/Driver/PluginPaths.h"
@@ -396,6 +397,14 @@ int swift_synthesize_interface_main(ArrayRef<const char *> Args,
     printOpts.AccessFilter = *MinAccessLevel;
     if (printOpts.AccessFilter < AccessLevel::Public)
       printOpts.PrintAccess = true;
+  }
+
+  // Under strict memory safety, print @unsafe even though the attribute is
+  // normally implicit and hidden.
+  if (Invocation.getLangOptions().hasFeature(Feature::StrictMemorySafety,
+                                             /*allowMigration=*/true)) {
+    printOpts.AlwaysIncludeAttrList.push_back(DeclAttrKind::Unsafe);
+    printOpts.AlwaysIncludeAttrList.push_back(DeclAttrKind::Safe);
   }
 
   swift::OptionSet<swift::ide::ModuleTraversal> traversalOpts = std::nullopt;

--- a/test/SynthesizeInterfaceTool/strict-memory-safety.swift
+++ b/test/SynthesizeInterfaceTool/strict-memory-safety.swift
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// By default, the `@unsafe` attribute that ClangImporter attaches is implicit
+/// and hidden, so it is not printed.
+// RUN: %target-swift-synthesize-interface -module-name CxxUnions -I %t/Inputs -cxx-interoperability-mode=default | %FileCheck %s --implicit-check-not=@unsafe
+
+/// With -strict-memory-safety, unsafe declarations (e.g. C++ union field
+/// accessors) are marked `@unsafe`.
+// RUN: %target-swift-synthesize-interface -module-name CxxUnions -I %t/Inputs -cxx-interoperability-mode=default -strict-memory-safety | %FileCheck %s --check-prefix=UNSAFE
+
+//--- Inputs/module.modulemap
+module CxxUnions {
+  requires cplusplus
+  header "cxx-unions.h"
+}
+
+//--- Inputs/cxx-unions.h
+#pragma once
+
+union Value {
+  int number;
+  float decimal;
+};
+
+// CHECK: public struct Value {
+// CHECK:     public var number: CInt
+// CHECK:     public var decimal: CFloat
+
+// UNSAFE: public struct Value {
+// UNSAFE:     @unsafe public var number: CInt
+// UNSAFE:     @unsafe public var decimal: CFloat


### PR DESCRIPTION
These are important for understanding the shape of the C++ interface that one is interacting with.

rdar://182315398