### PR TITLE
[CS] Avoid binding pattern to hole before `if`/`switch` expression 

### DIFF
--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -509,6 +509,9 @@ public:
   /// that represents a generic parameter.
   bool forGenericParameter() const;
 
+  /// Whether the binding set is for a named or `_` pattern decl.
+  bool isForPatternDecl() const;
+
   /// Whether the binding set has changed after construction, in which
   /// case we must recompute it on the next call to determineBestBindings().
   bool isDirty() const {

--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -324,6 +324,9 @@ public:
   /// Whether the locator in question is for a pattern match.
   bool isForPatternMatch() const;
 
+  /// Whether the locator is for a named or `_` pattern decl.
+  bool isForPatternDecl() const;
+
   /// Whether this locator identifies an element type of a collection literal.
   bool isForCollectionElement() const;
 

--- a/lib/Sema/BindingProducer.cpp
+++ b/lib/Sema/BindingProducer.cpp
@@ -548,7 +548,7 @@ TypeVariableBinding::fixForHole(ConstraintSystem &cs) const {
   }
 
   if (auto pattern = dstLocator->getPatternMatch()) {
-    if (dstLocator->isLastElement<LocatorPathElt::PatternDecl>()) {
+    if (dstLocator->isForPatternDecl()) {
       // If this is the pattern in a for loop, and we have a mismatch of the
       // element type, then we don't have any useful contextual information
       // for the pattern, and can just bind to a hole without needing to penalize

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -298,6 +298,10 @@ bool BindingSet::forGenericParameter() const {
   return bool(TypeVar->getImpl().getGenericParameter());
 }
 
+bool BindingSet::isForPatternDecl() const {
+  return TypeVar->getImpl().getLocator()->isForPatternDecl();
+}
+
 bool BindingSet::canBeNil() const {
   for (const auto &literal : Literals) {
     if (literal.getProtocol()->isSpecificProtocol(
@@ -2572,7 +2576,7 @@ bool BindingSet::favoredOverDisjunction(Constraint *disjunction) const {
 
 bool BindingSet::favoredOverConjunction(Constraint *conjunction) const {
   if (CS.shouldAttemptFixes() && isHole()) {
-    if (forClosureResult() || forGenericParameter())
+    if (forClosureResult() || forGenericParameter() || isForPatternDecl())
       return false;
   }
 

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -771,6 +771,10 @@ bool ConstraintLocator::isForPatternMatch() const {
   return getPatternMatch() != nullptr;
 }
 
+bool ConstraintLocator::isForPatternDecl() const {
+  return isLastElement<LocatorPathElt::PatternDecl>();
+}
+
 bool ConstraintLocator::isForCollectionElement() const {
   return isExpr<CollectionExpr>(getAnchor()) && getPath().size() == 1 &&
          isLastElement<LocatorPathElt::TupleElement>();

--- a/test/Constraints/if_expr.swift
+++ b/test/Constraints/if_expr.swift
@@ -729,3 +729,20 @@ _ = {
     1
   }
 }
+
+func testTuplePattern(_ cond: Bool, x: Int, y: Int?) {
+  let _ = if cond { (x, x) } else { (y, y) }
+  let _ = if cond { (y, y) } else { (x, x) }
+  let (_, _) = if cond { (y, y) } else { (x, x) }
+  let (a, b) = if cond { (y, y) } else { (x, x) }
+
+  // FIXME: We ought to be able to join here, the fact that the contextual type
+  // isn't a top-level type variable means we allow the inferred type to propagate
+  // across branches. We either ought to be consistently substituting fresh
+  // type variables, or unifying the behavior when there is no contextual type
+  // at all.
+  let (_, _) = if cond { (x, x) } else { (y, y) }
+  // expected-error@-1 {{cannot convert value of type '(Int?, Int?)' to specified type '(Int, Int)'}}
+  let (c, d) = if cond { (x, x) } else { (y, y) }
+  // expected-error@-1 {{cannot convert value of type '(Int?, Int?)' to specified type '(Int, Int)'}}
+}

--- a/test/Constraints/switch_expr.swift
+++ b/test/Constraints/switch_expr.swift
@@ -844,3 +844,11 @@ _ = {
     1
   }
 }
+
+// https://github.com/swiftlang/swift/issues/85353
+func testOptionalMismatch(_ e: E, optStr: String?, i: Int) -> String? {
+  switch e {
+  case .e, .f: optStr
+  case .g: i // expected-error {{cannot convert value of type 'Int' to specified type 'String'}}
+  }
+}


### PR DESCRIPTION
Make sure we don't attempt to prematurely turn a pattern decl pattern into a hole before we've had a chance to solve the conjunction for an `if`/`switch` expression. This ensures we at least produce a contextual mismatch diagnostic instead of failing to produce a diagnostic. We still need to more generally fix the joining behavior here, but that's future work.

rdar://175100252