### PR TITLE
Suppress hidden type exportability diagnostics under serialize abstract type layout for hidden types

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -618,10 +618,10 @@ EXPERIMENTAL_FEATURE(CheckImplementationOnly, true)
 /// report references to implementation-only imported modules.
 EXPERIMENTAL_FEATURE(CheckImplementationOnlyStrict, false)
 
-/// Make @_implementationOnly safe by serializing hidden type layout information
-/// so that clients can correctly manipulate types from @_implementationOnly
-/// imports without access to the defining module.
-EXPERIMENTAL_FEATURE(SafeImplementationOnly, true)
+/// Serialize abstract layout information for hidden types (@_implementationOnly, or
+/// from -internal-import-bridging-header) that contribute to module ABI. The goal
+// is to make leaking such types into module ABI safe, even without library evolution.
+EXPERIMENTAL_FEATURE(SerializeAbstractTypeLayoutForHiddenTypes, true)
 
 /// Check that use sites have the required @_spi import for operators.
 EXPERIMENTAL_FEATURE(EnforceSPIOperatorGroup, true)

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -199,7 +199,7 @@ UNINTERESTING_FEATURE(SameElementRequirements)
 UNINTERESTING_FEATURE(SendingArgsAndResults)
 UNINTERESTING_FEATURE(CheckImplementationOnly)
 UNINTERESTING_FEATURE(CheckImplementationOnlyStrict)
-UNINTERESTING_FEATURE(SafeImplementationOnly)
+UNINTERESTING_FEATURE(SerializeAbstractTypeLayoutForHiddenTypes)
 UNINTERESTING_FEATURE(EnforceSPIOperatorGroup)
 
 static bool usesFeatureCAttribute(Decl *decl) {

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -934,6 +934,8 @@ void UnboundImport::validateResilience(NullablePtr<ModuleDecl> topLevelModule,
         inFlight.fixItReplace(import.implementationOnlyRange, "internal");
       }
     } else if (!ctx.LangOpts.hasFeature(Feature::CheckImplementationOnly) &&
+               !ctx.LangOpts.hasFeature(
+                   Feature::SerializeAbstractTypeLayoutForHiddenTypes) &&
                !shouldSuppressNonResilientImplementationOnlyImportDiagnostic(
             targetName.str(), importerName.str())) {
       ctx.Diags.diagnose(import.importLoc,

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -238,6 +238,42 @@ bool ExportContext::mustOnlyReferenceExportedDecls() const {
   return Exported || FragileKind.kind != FragileFunctionKind::None;
 }
 
+static bool shouldSuppressExportabilityDiagnosticsForHiddenTypes(
+    const ASTContext &ctx, DisallowedOriginKind originKind,
+    ExportedLevel exportedLevel) {
+
+  // Without library evolution, hidden types that do not participate in the
+  // public API of a module may still affect its ABI. These diagnostics warn
+  // about scenarios where a hidden type affects module ABI. However, having
+  // differing diagnostics depending on whether library evolution is enabled is
+  // not a long term solution, and SerializeAbstractTypeLayoutForHiddenTypes is
+  // intended to replace these diagnostics. When enabled, we will detect when a
+  // hidden type contributes to module ABI and encode information about the type
+  // in the module interface, rather than diagnosing the leak.
+
+  if (!ctx.LangOpts.hasFeature(
+          Feature::SerializeAbstractTypeLayoutForHiddenTypes))
+    return false;
+
+  if (exportedLevel != ExportedLevel::ImplicitlyExported)
+    return false;
+
+  switch (originKind) {
+    case DisallowedOriginKind::ImplementationOnly:
+    case DisallowedOriginKind::ImplementationOnlyMemoryLayout:
+    case DisallowedOriginKind::InternalBridgingHeaderImport:
+      return true;
+    case DisallowedOriginKind::None:
+    case DisallowedOriginKind::NonPublicImport:
+    case DisallowedOriginKind::SPIOnly:
+    case DisallowedOriginKind::SPIImported:
+    case DisallowedOriginKind::SPILocal:
+    case DisallowedOriginKind::MissingImport:
+    case DisallowedOriginKind::FragileCxxAPI:
+      return false;
+  }
+}
+
 DiagnosticBehavior
 ExportContext::behaviorForReferenceToOrigin(const ValueDecl *D,
                                             DisallowedOriginKind originKind)
@@ -248,6 +284,12 @@ const {
   // If we can capture the layouts of hidden types, suppress
   // diagnostic.
   if (encapsulatedAsHiddenStoredProperty(D, originKind))
+    return DiagnosticBehavior::Ignore;
+
+  auto &ctx = DC->getASTContext();
+
+  if (shouldSuppressExportabilityDiagnosticsForHiddenTypes(
+          ctx, originKind, getExportedLevel()))
     return DiagnosticBehavior::Ignore;
 
   // Exportability checks for non-library-evolution mode have less restrictions
@@ -295,7 +337,6 @@ const {
 
   // Exportability checking for non-library-evolution was introduced late,
   // downgrade errors to warnings by default.
-  auto &ctx = DC->getASTContext();
   if (getExportedLevel() == ExportedLevel::ImplicitlyExported &&
       originKind != DisallowedOriginKind::ImplementationOnlyMemoryLayout &&
       !ctx.LangOpts.hasFeature(Feature::CheckImplementationOnly) &&

--- a/test/ClangImporter/InternalBridgingHeader/exportability_checking_objc.swift
+++ b/test/ClangImporter/InternalBridgingHeader/exportability_checking_objc.swift
@@ -23,7 +23,16 @@
 // RUN:   -internal-import-bridging-header %t/objc-bridging-header.h \
 // RUN:   -swift-version 6 -enable-library-evolution
 
+// Test SerializeAbstractTypeLayoutForHiddenTypes suppresses these exportability diagnostics
+// as if library evolution was enabled.
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %t/main.swift \
+// RUN:   -verify -verify-ignore-unrelated -verify-ignore-unknown \
+// RUN:   -internal-import-bridging-header %t/objc-bridging-header.h \
+// RUN:   -swift-version 6 \
+// RUN:   -enable-experimental-feature SerializeAbstractTypeLayoutForHiddenTypes
+
 // REQUIRES: objc_interop
+// REQUIRES: swift_feature_SerializeAbstractTypeLayoutForHiddenTypes
 
 //--- objc-bridging-header.h
 #import <Foundation.h>

--- a/test/ClangImporter/InternalBridgingHeader/implementation_only_checking.swift
+++ b/test/ClangImporter/InternalBridgingHeader/implementation_only_checking.swift
@@ -13,6 +13,11 @@
 // Test library-evolution differences.
 // RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -internal-import-bridging-header %S/../Inputs/c-bridging-header.h -sdk %clang-importer-sdk -verify-ignore-unknown -swift-version 5 -enable-library-evolution
 
+// Verify with SerializeAbstractTypeLayoutForHiddenTypes enabled, diagnostics are silenced, as if library evolution was enabled
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -internal-import-bridging-header %S/../Inputs/c-bridging-header.h -sdk %clang-importer-sdk -verify-ignore-unknown -swift-version 5 -enable-experimental-feature SerializeAbstractTypeLayoutForHiddenTypes
+
+// REQUIRES: swift_feature_SerializeAbstractTypeLayoutForHiddenTypes
+
 @inlinable
 public func f() -> Any {
   return red

--- a/test/Sema/hidden-memory-layout.swift
+++ b/test/Sema/hidden-memory-layout.swift
@@ -21,6 +21,12 @@
 // RUN:   -verify-additional-prefix opt-in- \
 // RUN:   -enable-experimental-feature CheckImplementationOnly
 
+/// SerializeAbstractTypeLayoutForHiddenTypes suppresses implicitly exported
+/// ABI-surface diagnostics.
+// RUN: %target-swift-frontend -emit-module -verify -verify-ignore-unrelated %s -I %t \
+// RUN:   -swift-version 6 \
+// RUN:   -enable-experimental-feature SerializeAbstractTypeLayoutForHiddenTypes
+
 /// Embedded
 /// Will also show errors in non-never-emit-into-client functions.
 
@@ -63,6 +69,7 @@
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_feature_CheckImplementationOnly
 // REQUIRES: swift_feature_CheckImplementationOnlyStrict
+// REQUIRES: swift_feature_SerializeAbstractTypeLayoutForHiddenTypes
 // REQUIRES: embedded_stdlib_cross_compiling
 
 @_implementationOnly import directs
@@ -104,16 +111,20 @@ private class HiddenClass {
 // expected-note @-1 2 {{class 'HiddenClass' is not '@usableFromInline' or public}}
 // expected-note @-2 1 {{initializer 'init()' is not '@usableFromInline' or public}}
 // expected-note @-3 3 {{type declared here}}
-// expected-note @-4 7 {{class declared here}}
+// expected-note @-4 2 {{class declared here}}
+// expected-not-opt-in-note @-5 5 {{class declared here}}
+// expected-opt-in-note @-6 5 {{class declared here}}
 }
 
 @_implementationOnly
 private struct HiddenLayout {
 // expected-note @-1 4 {{struct 'HiddenLayout' is not '@usableFromInline' or public}}
 // expected-note @-2 3 {{initializer 'init()' is not '@usableFromInline' or public}}
-// expected-note @-3 9 {{struct declared here}}
-// expected-note @-4 4 {{type declared here}}
-// expected-embedded-note @-5 2 {{struct declared here}}
+// expected-note @-3 3 {{struct declared here}}
+// expected-not-opt-in-note @-4 6 {{struct declared here}}
+// expected-opt-in-note @-5 6 {{struct declared here}}
+// expected-note @-6 4 {{type declared here}}
+// expected-embedded-note @-7 2 {{struct declared here}}
 }
 
 public enum ExposedEnumPublic {
@@ -131,10 +142,12 @@ private enum ExposedEnumPrivate {
 
 @_implementationOnly
 private enum HiddenEnum {
-// expected-note @-1 6 {{enum declared here}}
-// expected-note @-2 2 {{enum 'HiddenEnum' is not '@usableFromInline' or public}}
-// expected-note @-3 2 {{type declared here}}
-// expected-embedded-note @-4 2 {{enum declared here}}
+// expected-note @-1 2 {{enum declared here}}
+// expected-not-opt-in-note @-2 4 {{enum declared here}}
+// expected-opt-in-note @-3 4 {{enum declared here}}
+// expected-note @-4 2 {{enum 'HiddenEnum' is not '@usableFromInline' or public}}
+// expected-note @-5 2 {{type declared here}}
+// expected-embedded-note @-6 2 {{enum declared here}}
   case A
 // expected-note @-1 {{enum case 'A' is not '@usableFromInline' or public}}
   case B
@@ -156,9 +169,11 @@ private protocol ExposedProtocolPrivate {
 @_implementationOnly
 private protocol HiddenProtocol {
 // expected-note @-1 {{protocol 'HiddenProtocol' is not '@usableFromInline' or public}}
-// expected-note @-2 9 {{protocol declared here}}
-// expected-note @-3 4 {{type declared here}}
-// expected-embedded-note @-4 2 {{protocol declared here}}
+// expected-note @-2 3 {{protocol declared here}}
+// expected-not-opt-in-note @-3 6 {{protocol declared here}}
+// expected-opt-in-note @-4 6 {{protocol declared here}}
+// expected-note @-5 4 {{type declared here}}
+// expected-embedded-note @-6 2 {{protocol declared here}}
 }
 
 @_spi(S) public struct SPIStruct {}
@@ -383,18 +398,21 @@ public struct ExposedLayoutPublicUser: ProtocolFromDirect {
   private var aa: ExposedLayoutInternal
   private var b: ExposedLayoutPrivate
   private var c: HiddenLayout
-  // expected-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenLayout' is marked '@_implementationOnly'}}
+  // expected-opt-in-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenLayout' is marked '@_implementationOnly'}}
+  // expected-not-opt-in-error @-2 {{cannot use struct 'HiddenLayout' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenLayout' is marked '@_implementationOnly'}}
 
   private var ca: ExposedClassPublic
   private var cb: ExposedClassInternal
   private var cc: ExposedClassPrivate
   private var cd: HiddenClass
-  // expected-error @-1 {{cannot use class 'HiddenClass' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenClass' is marked '@_implementationOnly'}}
+  // expected-opt-in-error @-1 {{cannot use class 'HiddenClass' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenClass' is marked '@_implementationOnly'}}
+  // expected-not-opt-in-error @-2 {{cannot use class 'HiddenClass' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenClass' is marked '@_implementationOnly'}}
 
   private var d: ExposedEnumPublic
   private var e: ExposedEnumPrivate
   private var f: HiddenEnum
-  // expected-error @-1 {{cannot use enum 'HiddenEnum' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenEnum' is marked '@_implementationOnly'}}
+  // expected-opt-in-error @-1 {{cannot use enum 'HiddenEnum' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenEnum' is marked '@_implementationOnly'}}
+  // expected-not-opt-in-error @-2 {{cannot use enum 'HiddenEnum' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenEnum' is marked '@_implementationOnly'}}
 
   private var pp: ProtocolFromDirect
   // expected-opt-in-error @-1 {{cannot use protocol 'ProtocolFromDirect' in a property declaration member of a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
@@ -404,7 +422,8 @@ public struct ExposedLayoutPublicUser: ProtocolFromDirect {
   private var h: ExposedProtocolInternal
   private var i: ExposedProtocolPrivate
   private var j: HiddenProtocol
-  // expected-error @-1 {{cannot use protocol 'HiddenProtocol' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenProtocol' is marked '@_implementationOnly'}}
+  // expected-opt-in-error @-1 {{cannot use protocol 'HiddenProtocol' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenProtocol' is marked '@_implementationOnly'}}
+  // expected-not-opt-in-error @-2 {{cannot use protocol 'HiddenProtocol' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenProtocol' is marked '@_implementationOnly'}}
 
   private func privateFunc(h: HiddenLayout) {}
   // expected-embedded-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
@@ -433,24 +452,28 @@ internal struct ExposedLayoutInternalUser: ProtocolFromDirect {
   private var aa: ExposedLayoutInternal
   private var b: ExposedLayoutPrivate
   private var c: HiddenLayout
-  // expected-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenLayout' is marked '@_implementationOnly'}}
+  // expected-opt-in-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenLayout' is marked '@_implementationOnly'}}
+  // expected-not-opt-in-error @-2 {{cannot use struct 'HiddenLayout' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenLayout' is marked '@_implementationOnly'}}
 
   private var ca: ExposedClassPublic
   private var cb: ExposedClassInternal
   private var cc: ExposedClassPrivate
   private var cd: HiddenClass
-  // expected-error @-1 {{cannot use class 'HiddenClass' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenClass' is marked '@_implementationOnly'}}
+  // expected-opt-in-error @-1 {{cannot use class 'HiddenClass' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenClass' is marked '@_implementationOnly'}}
+  // expected-not-opt-in-error @-2 {{cannot use class 'HiddenClass' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenClass' is marked '@_implementationOnly'}}
 
   private var d: ExposedEnumPublic
   private var e: ExposedEnumPrivate
   private var f: HiddenEnum
-  // expected-error @-1 {{cannot use enum 'HiddenEnum' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenEnum' is marked '@_implementationOnly'}}
+  // expected-opt-in-error @-1 {{cannot use enum 'HiddenEnum' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenEnum' is marked '@_implementationOnly'}}
+  // expected-not-opt-in-error @-2 {{cannot use enum 'HiddenEnum' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenEnum' is marked '@_implementationOnly'}}
 
   private var g: ExposedProtocolPublic
   private var h: ExposedProtocolInternal
   private var i: ExposedProtocolPrivate
   private var j: HiddenProtocol
-  // expected-error @-1 {{cannot use protocol 'HiddenProtocol' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenProtocol' is marked '@_implementationOnly'}}
+  // expected-opt-in-error @-1 {{cannot use protocol 'HiddenProtocol' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenProtocol' is marked '@_implementationOnly'}}
+  // expected-not-opt-in-error @-2 {{cannot use protocol 'HiddenProtocol' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenProtocol' is marked '@_implementationOnly'}}
 
   private func privateFunc(h: HiddenLayout) {}
   // expected-embedded-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
@@ -476,24 +499,28 @@ private struct ExposedLayoutPrivateUser: ProtocolFromDirect {
   private var aa: ExposedLayoutInternal
   private var b: ExposedLayoutPrivate
   private var c: HiddenLayout
-  // expected-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenLayout' is marked '@_implementationOnly'}}
+  // expected-opt-in-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenLayout' is marked '@_implementationOnly'}}
+  // expected-not-opt-in-error @-2 {{cannot use struct 'HiddenLayout' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenLayout' is marked '@_implementationOnly'}}
 
   private var ca: ExposedClassPublic
   private var cb: ExposedClassInternal
   private var cc: ExposedClassPrivate
   private var cd: HiddenClass
-  // expected-error @-1 {{cannot use class 'HiddenClass' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenClass' is marked '@_implementationOnly'}}
+  // expected-opt-in-error @-1 {{cannot use class 'HiddenClass' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenClass' is marked '@_implementationOnly'}}
+  // expected-not-opt-in-error @-2 {{cannot use class 'HiddenClass' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenClass' is marked '@_implementationOnly'}}
 
   private var d: ExposedEnumPublic
   private var e: ExposedEnumPrivate
   private var f: HiddenEnum
-  // expected-error @-1 {{cannot use enum 'HiddenEnum' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenEnum' is marked '@_implementationOnly'}}
+  // expected-opt-in-error @-1 {{cannot use enum 'HiddenEnum' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenEnum' is marked '@_implementationOnly'}}
+  // expected-not-opt-in-error @-2 {{cannot use enum 'HiddenEnum' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenEnum' is marked '@_implementationOnly'}}
 
   private var g: ExposedProtocolPublic
   private var h: ExposedProtocolInternal
   private var i: ExposedProtocolPrivate
   private var j: HiddenProtocol
-  // expected-error @-1 {{cannot use protocol 'HiddenProtocol' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenProtocol' is marked '@_implementationOnly'}}
+  // expected-opt-in-error @-1 {{cannot use protocol 'HiddenProtocol' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenProtocol' is marked '@_implementationOnly'}}
+  // expected-not-opt-in-error @-2 {{cannot use protocol 'HiddenProtocol' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenProtocol' is marked '@_implementationOnly'}}
 
   private func privateFunc(h: HiddenLayout) {}
   // expected-embedded-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
@@ -575,20 +602,23 @@ internal enum InternalEnumUser: ProtocolFromDirect {
     case e(ExposedLayoutPublic)
     case c(ExposedLayoutInternal)
     case d(ExposedLayoutPrivate) // expected-error {{enum case in an internal enum uses a private type}}
-    case b(HiddenLayout) // expected-error {{cannot use struct 'HiddenLayout' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenLayout' is marked '@_implementationOnly'}}
-    // expected-error @-1 {{enum case in an internal enum uses a private type}}
+    case b(HiddenLayout) // expected-opt-in-error {{cannot use struct 'HiddenLayout' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenLayout' is marked '@_implementationOnly'}}
+    // expected-not-opt-in-error @-1 {{cannot use struct 'HiddenLayout' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenLayout' is marked '@_implementationOnly'}}
+    // expected-error @-2 {{enum case in an internal enum uses a private type}}
 
     case ce(ExposedClassPublic)
     case cc(ExposedClassInternal)
     case cd(ExposedClassPrivate) // expected-error {{enum case in an internal enum uses a private type}}
-    case cb(HiddenClass) // expected-error {{cannot use class 'HiddenClass' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenClass' is marked '@_implementationOnly'}}
-    // expected-error @-1 {{enum case in an internal enum uses a private type}}
+    case cb(HiddenClass) // expected-opt-in-error {{cannot use class 'HiddenClass' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenClass' is marked '@_implementationOnly'}}
+    // expected-not-opt-in-error @-1 {{cannot use class 'HiddenClass' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenClass' is marked '@_implementationOnly'}}
+    // expected-error @-2 {{enum case in an internal enum uses a private type}}
 
     case f(ExposedProtocolPublic)
     case g(ExposedProtocolInternal)
     case h(ExposedProtocolPrivate) // expected-error {{enum case in an internal enum uses a private type}}
-    case i(HiddenProtocol) // expected-error {{cannot use protocol 'HiddenProtocol' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenProtocol' is marked '@_implementationOnly'}}
-    // expected-error @-1 {{enum case in an internal enum uses a private type}}
+    case i(HiddenProtocol) // expected-opt-in-error {{cannot use protocol 'HiddenProtocol' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenProtocol' is marked '@_implementationOnly'}}
+    // expected-not-opt-in-error @-1 {{cannot use protocol 'HiddenProtocol' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenProtocol' is marked '@_implementationOnly'}}
+    // expected-error @-2 {{enum case in an internal enum uses a private type}}
 
     case ta(TA)
     // expected-opt-in-error @-1 {{'TA' aliases 'directs.StructFromDirect' and cannot be used in an associated value of an enum not marked '@_implementationOnly' because 'directs' has been imported as implementation-only}}
@@ -604,17 +634,20 @@ private enum PrivateEnumUser: ProtocolFromDirect {
     case e(ExposedLayoutPublic)
     case c(ExposedLayoutInternal)
     case d(ExposedLayoutPrivate)
-    case b(HiddenLayout) // expected-error {{cannot use struct 'HiddenLayout' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenLayout' is marked '@_implementationOnly'}}
+    case b(HiddenLayout) // expected-opt-in-error {{cannot use struct 'HiddenLayout' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenLayout' is marked '@_implementationOnly'}}
+    // expected-not-opt-in-error @-1 {{cannot use struct 'HiddenLayout' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenLayout' is marked '@_implementationOnly'}}
 
     case ce(ExposedClassPublic)
     case cc(ExposedClassInternal)
     case cd(ExposedClassPrivate)
-    case cb(HiddenClass) // expected-error {{cannot use class 'HiddenClass' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenClass' is marked '@_implementationOnly'}}
+    case cb(HiddenClass) // expected-opt-in-error {{cannot use class 'HiddenClass' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenClass' is marked '@_implementationOnly'}}
+    // expected-not-opt-in-error @-1 {{cannot use class 'HiddenClass' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenClass' is marked '@_implementationOnly'}}
 
     case f(ExposedProtocolPublic)
     case g(ExposedProtocolInternal)
     case h(ExposedProtocolPrivate)
-    case i(HiddenProtocol) // expected-error {{cannot use protocol 'HiddenProtocol' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenProtocol' is marked '@_implementationOnly'}}
+    case i(HiddenProtocol) // expected-opt-in-error {{cannot use protocol 'HiddenProtocol' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenProtocol' is marked '@_implementationOnly'}}
+    // expected-not-opt-in-error @-1 {{cannot use protocol 'HiddenProtocol' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenProtocol' is marked '@_implementationOnly'}}
 
     case ta(TA)
     // expected-opt-in-error @-1 {{'TA' aliases 'directs.StructFromDirect' and cannot be used in an associated value of an enum not marked '@_implementationOnly' because 'directs' has been imported as implementation-only}}
@@ -770,20 +803,23 @@ open class OpenClassUser: ProtocolFromDirect {
   private var b: ExposedLayoutPrivate
   @_implementationOnly
   private var c: HiddenLayout
-  // expected-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration member of an open class; 'HiddenLayout' is marked '@_implementationOnly'}}
+  // expected-opt-in-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration member of an open class; 'HiddenLayout' is marked '@_implementationOnly'}}
+  // expected-not-opt-in-error @-2 {{cannot use struct 'HiddenLayout' in a property declaration member of an open class; 'HiddenLayout' is marked '@_implementationOnly'}}
 
   private var d: ExposedEnumPublic
   private var e: ExposedEnumPrivate
   @_implementationOnly
   private var f: HiddenEnum
-  // expected-error @-1 {{cannot use enum 'HiddenEnum' in a property declaration member of an open class; 'HiddenEnum' is marked '@_implementationOnly'}}
+  // expected-opt-in-error @-1 {{cannot use enum 'HiddenEnum' in a property declaration member of an open class; 'HiddenEnum' is marked '@_implementationOnly'}}
+  // expected-not-opt-in-error @-2 {{cannot use enum 'HiddenEnum' in a property declaration member of an open class; 'HiddenEnum' is marked '@_implementationOnly'}}
 
   private var g: ExposedProtocolPublic
   private var h: ExposedProtocolInternal
   private var i: ExposedProtocolPrivate
   @_implementationOnly
   private var j: HiddenProtocol
-  // expected-error @-1 {{cannot use protocol 'HiddenProtocol' in a property declaration member of an open class; 'HiddenProtocol' is marked '@_implementationOnly'}}
+  // expected-opt-in-error @-1 {{cannot use protocol 'HiddenProtocol' in a property declaration member of an open class; 'HiddenProtocol' is marked '@_implementationOnly'}}
+  // expected-not-opt-in-error @-2 {{cannot use protocol 'HiddenProtocol' in a property declaration member of an open class; 'HiddenProtocol' is marked '@_implementationOnly'}}
 
   private var importedInit: PublicProto = StructFromDirect()
   // expected-embedded-error @-1 {{struct 'StructFromDirect' cannot be used in an embedded function not marked '@export(interface)' because 'directs' was imported implementation-only}}

--- a/test/Sema/implementation-only-import-conformances-non-library-evolution.swift
+++ b/test/Sema/implementation-only-import-conformances-non-library-evolution.swift
@@ -13,7 +13,14 @@
 // RUN:  -swift-version 6 -verify-additional-prefix opt-in- \
 // RUN:  -enable-experimental-feature CheckImplementationOnly
 
+/// SerializeAbstractTypeLayoutForHiddenTypes suppresses implicitly exported
+/// ABI-surface diagnostics.
+// RUN: %target-typecheck-verify-swift -I %t \
+// RUN:  -swift-version 6 \
+// RUN:  -enable-experimental-feature SerializeAbstractTypeLayoutForHiddenTypes
+
 // REQUIRES: swift_feature_CheckImplementationOnly
+// REQUIRES: swift_feature_SerializeAbstractTypeLayoutForHiddenTypes
 
 import NormalLibrary
 @_implementationOnly import BADLibrary // expected-not-opt-in-warning {{safely use '@_implementationOnly' without library evolution by setting '-enable-experimental-feature CheckImplementationOnly' for 'main'}}
@@ -91,11 +98,13 @@ struct InternalInferredAssociatedTypeImpl {
 extension InternalInferredAssociatedTypeImpl: PublicAssociatedTypeProto {}
 // expected-not-opt-in-warning @-1 {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as implementation-only}}
 // expected-opt-in-error @-2 {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as implementation-only}}
-// expected-note @-3 {{in associated type 'Self.Assoc' (inferred as 'NormalStruct')}}
+// expected-not-opt-in-note @-3 {{in associated type 'Self.Assoc' (inferred as 'NormalStruct')}}
+// expected-opt-in-note @-4 {{in associated type 'Self.Assoc' (inferred as 'NormalStruct')}}
 extension InternalInferredAssociatedTypeImpl: UFIAssociatedTypeProto {}
 // expected-not-opt-in-warning @-1 {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as implementation-only}}
 // expected-opt-in-error @-2 {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as implementation-only}}
-// expected-note @-3 {{in associated type 'Self.Assoc' (inferred as 'NormalStruct')}}
+// expected-not-opt-in-note @-3 {{in associated type 'Self.Assoc' (inferred as 'NormalStruct')}}
+// expected-opt-in-note @-4 {{in associated type 'Self.Assoc' (inferred as 'NormalStruct')}}
 
 extension InternalInferredAssociatedTypeImpl: InternalAssociatedTypeProto {} // okay
 
@@ -106,11 +115,13 @@ internal struct PublicExplicitAssociatedTypeImpl {
 extension PublicExplicitAssociatedTypeImpl: PublicAssociatedTypeProto {}
 // expected-not-opt-in-warning @-1 {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as implementation-only}}
 // expected-opt-in-error @-2 {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as implementation-only}}
-// expected-note@-3 {{in associated type 'Self.Assoc' (inferred as 'NormalStruct')}}
+// expected-not-opt-in-note@-3 {{in associated type 'Self.Assoc' (inferred as 'NormalStruct')}}
+// expected-opt-in-note@-4 {{in associated type 'Self.Assoc' (inferred as 'NormalStruct')}}
 
 extension PublicExplicitAssociatedTypeImpl: UFIAssociatedTypeProto {}
 // expected-not-opt-in-warning @-1 {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as implementation-only}}
 // expected-opt-in-error @-2 {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as implementation-only}}
-// expected-note@-3 {{in associated type 'Self.Assoc' (inferred as 'NormalStruct')}}
+// expected-not-opt-in-note@-3 {{in associated type 'Self.Assoc' (inferred as 'NormalStruct')}}
+// expected-opt-in-note@-4 {{in associated type 'Self.Assoc' (inferred as 'NormalStruct')}}
 
 extension PublicExplicitAssociatedTypeImpl: InternalAssociatedTypeProto {} // okay

--- a/test/Sema/implementation-only-import-from-non-resilient.swift
+++ b/test/Sema/implementation-only-import-from-non-resilient.swift
@@ -8,11 +8,11 @@
 // RUN:   -enable-library-evolution -swift-version 5
 
 /// Build a client with and without library-evolution.
-// RUN: %target-swift-frontend -typecheck %t/client-non-resilient.swift -I %t -verify
+// RUN: %target-swift-frontend -typecheck %t/client-non-resilient.swift -I %t \
+// RUN:   -verify -verify-additional-prefix default-
 // RUN: %target-swift-frontend -typecheck %t/client-non-resilient.swift -I %t -verify \
+// RUN:   -verify-additional-prefix default- \
 // RUN:   -warnings-as-errors -Wwarning ImplementationOnlyDeprecated
-// RUN: %target-swift-frontend -typecheck %t/client-resilient.swift -I %t -verify \
-// RUN:   -enable-library-evolution -swift-version 5
 
 /// Some imports are exempt.
 // RUN: %target-swift-frontend -emit-module %t/empty.swift \
@@ -20,6 +20,15 @@
 // RUN:   -enable-library-evolution -swift-version 5
 // RUN: %target-swift-frontend -typecheck %t/Crypto.swift -I %t -verify \
 // RUN:   -module-name Crypto
+
+// Verify SerializeAbstractTypeLayoutForHiddenTypes suppresses diagnostics warning about @_implementationOnly use without library-evolution or CheckImplementationOnly
+// RUN: %target-swift-frontend -typecheck %t/client-non-resilient.swift -I %t \
+// RUN:   -verify \
+// RUN:   -enable-experimental-feature SerializeAbstractTypeLayoutForHiddenTypes
+// RUN: %target-swift-frontend -typecheck %t/client-resilient.swift -I %t -verify \
+// RUN:   -enable-library-evolution -swift-version 5
+
+// REQUIRES: swift_feature_SerializeAbstractTypeLayoutForHiddenTypes
 
 //--- module.modulemap
 module ClangModuleA {
@@ -41,12 +50,12 @@ module ClangModuleB {
 //--- empty.swift
 
 //--- client-non-resilient.swift
-@_implementationOnly import SwiftModuleA // expected-warning {{safely use '@_implementationOnly' without library evolution by setting '-enable-experimental-feature CheckImplementationOnly' for 'main'}}
-@_implementationOnly import SwiftModuleA // expected-warning {{safely use '@_implementationOnly' without library evolution by setting '-enable-experimental-feature CheckImplementationOnly' for 'main'}}
+@_implementationOnly import SwiftModuleA // expected-default-warning {{safely use '@_implementationOnly' without library evolution by setting '-enable-experimental-feature CheckImplementationOnly' for 'main'}}
+@_implementationOnly import SwiftModuleA // expected-default-warning {{safely use '@_implementationOnly' without library evolution by setting '-enable-experimental-feature CheckImplementationOnly' for 'main'}}
 import SwiftModuleB
 
-@_implementationOnly import ClangModuleA // expected-warning {{safely use '@_implementationOnly' without library evolution by setting '-enable-experimental-feature CheckImplementationOnly' for 'main'}}
-@_implementationOnly import ClangModuleA.Submodule // expected-warning {{safely use '@_implementationOnly' without library evolution by setting '-enable-experimental-feature CheckImplementationOnly' for 'main'}}
+@_implementationOnly import ClangModuleA // expected-default-warning {{safely use '@_implementationOnly' without library evolution by setting '-enable-experimental-feature CheckImplementationOnly' for 'main'}}
+@_implementationOnly import ClangModuleA.Submodule // expected-default-warning {{safely use '@_implementationOnly' without library evolution by setting '-enable-experimental-feature CheckImplementationOnly' for 'main'}}
 import ClangModuleB
 
 //--- client-resilient.swift


### PR DESCRIPTION
This PR makes two changes:

1.) Renames the feature SafeImplementationOnly to SerializeAbstractTypeLayoutForHiddenTypes

Previously, this feature only controlled emission of abstract type layout information for @_implemenationOnly imported types that contribute to module ABI. However, it turns out there are more kinds of "hidden types". In particular, those defined in a header included with `-internal-import-bridging-header`. We rename the feature to reflect that we handle all kinds of hidden types.

2.) We disable all diagnostics that warn about leaking hidden types when SerializeAbstractTypeLayoutForHiddenTypes is enabled. It was decided that the long term direction for hidden types that leak into module ABI should not be to diagnose them, [but rather to encode abstract layout information for them](https://forums.swift.org/t/pitch-allow-non-resilient-modules-to-hide-dependencies-to-clients/75737). This is because diagnosing them would only be required without library evolution, and thus would create code that can only be written with library evolution enabled.

Thus we disable these diagnostics as we work towards SerializeAbstractTypeLayoutForHiddenTypes encoding abstract type layout. In future commits, this will replace https://github.com/swiftlang/swift/pull/88833, which similarly disables diagnostics for specific cases of hidden types leaking from `-internal-import-briding-header`.

