### PR TITLE
[stdlib] Convert EmbeddedPlatform.h doc comments to DocC syntax

### DIFF
--- a/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
+++ b/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
@@ -119,11 +119,11 @@ typedef unsigned long long __swift_options_t;
  * Determine the version of the platform abstraction layer that the Embedded
  * Swift library was built with.
  *
- * Parameters:
- * - `major`: The value of EMBEDDED_SWIFT_PLATFORM_VERSION_MAJOR that the
- *   Swift standard library was built with.
- * - `minor`: The value of EMBEDDED_SWIFT_PLATFORM_VERSION_MINOR that the
- *   Swift standard library was built with.
+ * - Parameters:
+ *   - major: The value of EMBEDDED_SWIFT_PLATFORM_VERSION_MAJOR that the
+ *     Swift standard library was built with.
+ *   - minor: The value of EMBEDDED_SWIFT_PLATFORM_VERSION_MINOR that the
+ *     Swift standard library was built with.
  *
  * This function is provided by the Swift standard library, and declared here
  * for the convenience of C clients.
@@ -180,19 +180,19 @@ typedef enum EMBEDDED_SWIFT_OPTION_SET: __swift_options_t {
 /**
  * Allocates memory and returns the resulting pointer.
  *
- * Parameters:
- *   - `size`: the minimum number of bytes to allocate.
- *   - `alignment`: the minimum alignment of the resulting pointer, which must
+ * - Parameters:
+ *   - alignment: The minimum alignment of the resulting pointer, which must
  *     be a power of at least as large as `sizeof(void *)`.
- *   - `flags`: flags to control the behavior of the allocation.
+ *   - size: The minimum number of bytes to allocate.
+ *   - flags: Flags to control the behavior of the allocation.
  *
- * Returns the allocated pointer, or NULL on failure.
+ * - Returns: The allocated pointer, or NULL on failure.
  *
  * This function is required when using any Embedded Swift facility that
  * requires memory allocation from the heap, whether explicitly (e.g., via the
  * `allocate` operation on unsafe pointers) or implicitly (e.g., creating a
  * copy-on-write array or an instance of a class type).
- * 
+ *
  * This function can be implemented as a call to `posix_memalign`.
  */
 void * EMBEDDED_SWIFT_NULLABLE _swift_allocate(__swift_size_t alignment, __swift_size_t size, swift_alloc_flags_t flags);
@@ -200,21 +200,21 @@ void * EMBEDDED_SWIFT_NULLABLE _swift_allocate(__swift_size_t alignment, __swift
 /**
  * Deallocates the memory referenced by `ptr`.
  *
- * Parameters:
- *   - `ptr`: The pointer to be deallocated. If it is NULL, the operation does
+ * - Parameters:
+ *   - ptr: The pointer to be deallocated. If it is NULL, the operation does
  *     nothing.
- *   - `size`: the number of allocated bytes, which may be -1 if it is not
- *     known.
- *   - `alignment`: the minimum alignment of the resulting pointer, which must
+ *   - alignment: The minimum alignment of the resulting pointer, which must
  *     be a power of at least as large as `sizeof(void *)`, or be zero to
  *     indicate that the alignment is not known.
- *   - `flags`: flags to control the behavior of the deallocation.
+ *   - size: The number of allocated bytes, which may be -1 if it is not
+ *     known.
+ *   - flags: Flags to control the behavior of the deallocation.
  *
  * This function is required when using any Embedded Swift facility that
  * requires memory allocation from the heap, whether explicitly (e.g., via the
  * `allocate` operation on unsafe pointers) or implicitly (e.g., creating a
  * copy-on-write array or an instance of a class type).
- * 
+ *
  * This function can be implemented as a direct call to `free`.
  */
 void _swift_deallocate(void * EMBEDDED_SWIFT_NONNULL ptr, __swift_size_t alignment, __swift_size_t size, swift_dealloc_flags_t flags);
@@ -222,15 +222,15 @@ void _swift_deallocate(void * EMBEDDED_SWIFT_NONNULL ptr, __swift_size_t alignme
 /**
  * Allocates memory with a given type and returns the resulting pointer.
  *
- * Parameters:
- *   - `size`: the minimum number of bytes to allocate.
- *   - `alignment`: the minimum alignment of the resulting pointer, which must
+ * - Parameters:
+ *   - size: The minimum number of bytes to allocate.
+ *   - alignment: The minimum alignment of the resulting pointer, which must
  *     be a power of at least as large as `sizeof(void *)`.
- *   - `flags`: flags to control the behavior of the allocation.
- *   - `typeId`: an identifier used by a typed allocator to e.g. place the
+ *   - flags: Flags to control the behavior of the allocation.
+ *   - typeId: An identifier used by a typed allocator to e.g. place the
  *     allocation in a particular bucket.
  *
- * Returns the allocated pointer, or NULL on failure.
+ * - Returns: The allocated pointer, or NULL on failure.
  *
  * This function is required when using any Embedded Swift facility that
  * requires typed memory allocation from the heap, e.g. class instance
@@ -245,12 +245,12 @@ void * EMBEDDED_SWIFT_NULLABLE _swift_typedAllocate(
 /**
  * Writes a sequence of UTF-8 code points to standard output.
  *
- * Parameters:
- *   - `chars`: the UTF-8 code points to standard output. It is not
+ * - Parameters:
+ *   - chars: The UTF-8 code points to standard output. It is not
  *     NULL-terminated.
- *   - `count`: the number of UTF-8 code points.
+ *   - count: The number of UTF-8 code points.
  *
- * Returns the number of characters that were written.
+ * - Returns: The number of characters that were written.
  *
  * This function is required when using the Embedded Swift print() facilities.
  *
@@ -264,9 +264,9 @@ __swift_size_t _swift_writeToStandardOutput(
 /**
  * Generates random bytes into the given buffer.
  *
- * Parameters:
- *   - `buffer`: the buffer into which the random bytes should be generated.
- *   - `nbytes`: the number of bytes that should be generated into the buffer.
+ * - Parameters:
+ *   - buffer: The buffer into which the random bytes should be generated.
+ *   - nbytes: The number of bytes that should be generated into the buffer.
  *
  * This function is required when using Swift's SystemRandomNumberGenerator, the
  * default random number generator used for shuffling elements and producing
@@ -284,16 +284,16 @@ void _swift_generateRandom(void * EMBEDDED_SWIFT_NONNULL EMBEDDED_SWIFT_SIZED_BY
 /**
  * Generates random bytes intended for a hashing seed into the given buffer.
  *
- * Parameters:
- *   - `buffer`: the buffer into which the random bytes should be generated.
- *   - `nbytes`: the number of bytes that should be generated into the buffer.
+ * - Parameters:
+ *   - buffer: The buffer into which the random bytes should be generated.
+ *   - nbytes: The number of bytes that should be generated into the buffer.
  *
  * This function is required when using Swift's hashed collections, such as Set
  * and Dictionary, to provide random seeding for the hash functions. Random
  * seeding makes hash values differ from one execute to the next, mitigating
  * against denial-of-service attacks that target a known hash function. The
  * random number generator provided here need not be cryptographically
- * secure. An implementation may choose to provide constant values random than a
+ * secure. An implementation may choose to provide constant values rather than a
  * random seed to make hashing deterministic.
  *
  * This function can be implemented as a direct call to `arc4random_buf`.
@@ -304,9 +304,9 @@ void _swift_generateRandomHashSeed(void * EMBEDDED_SWIFT_NONNULL EMBEDDED_SWIFT_
  * Retrieve a pointer that will be used to retain information needed for Swift's
  * dynamic exclusivity checking.
  *
- * Returns the pointer most recently passed to `_swift_setExclusivityTLS` on
- * this thread. If `_swift_setExclusivityTLS` has not been called on this
- * thread, returns NULL.
+ * - Returns: The pointer most recently passed to `_swift_setExclusivityTLS` on
+ *   this thread. If `_swift_setExclusivityTLS` has not been called on this
+ *   thread, returns NULL.
  *
  * In a single-threaded environment, the `_swift_getExclusivityTLS` and
  * `_swift_setExclusivityTLS` functions can get and set a global variable that
@@ -326,8 +326,8 @@ void * EMBEDDED_SWIFT_NULLABLE _swift_getExclusivityTLS(void);
  * Set the pointer that will be used to retain information needed for Swift's
  * dynamic exclusivity checking.
  *
- * Parameters:
- *   - `ptr`: the pointer to set. A subsequent call to
+ * - Parameters:
+ *   - ptr: The pointer to set. A subsequent call to
  *     `_swift_getExclusivityTLS` on the same thread (without an intervening
  *     call to `_swift_setExclusivityTLS`) shall return `ptr`.
  *
@@ -339,13 +339,13 @@ void _swift_setExclusivityTLS(void * EMBEDDED_SWIFT_NULLABLE ptr);
 /**
  * Initializes a mutex.
  *
- * Parameters:
- *   - `mutex`: opaque caller-owned mutex storage initialized by this function
+ * - Parameters:
+ *   - mutex: Opaque caller-owned mutex storage initialized by this function
  *     and later passed to the other `_swift_mutex_*` functions. The contents
  *     are private to the platform implementation. The storage is at least
  *     EMBEDDED_SWIFT_MUTEX_NUM_WORDS pointer-sized words and has pointer
  *     alignment.
- *   - `flags`: flags controlling mutex behavior.
+ *   - flags: Flags controlling mutex behavior.
  *
  * This function is required when using Synchronization.Mutex.
  */
@@ -354,31 +354,43 @@ void _swift_mutex_init(void * EMBEDDED_SWIFT_NONNULL mutex,
 
 /**
  * Destroys a mutex initialized by `_swift_mutex_init`.
+ *
+ * - Parameters:
+ *   - mutex: The mutex to destroy. Must not be locked.
  */
 void _swift_mutex_destroy(void * EMBEDDED_SWIFT_NONNULL mutex);
 
 /**
  * Acquires a mutex, blocking or spinning until ownership is obtained.
+ *
+ * - Parameters:
+ *   - mutex: The mutex to acquire.
  */
 void _swift_mutex_lock(void * EMBEDDED_SWIFT_NONNULL mutex);
 
 /**
  * Releases a mutex held by the current execution context.
+ *
+ * - Parameters:
+ *   - mutex: The mutex to release.
  */
 void _swift_mutex_unlock(void * EMBEDDED_SWIFT_NONNULL mutex);
 
 /**
  * Attempts to acquire a mutex without blocking.
  *
- * Returns nonzero if the mutex was acquired, or zero if it was not acquired.
+ * - Parameters:
+ *   - mutex: The mutex to attempt to acquire.
+ *
+ * - Returns: Nonzero if the mutex was acquired, or zero if it was not acquired.
  */
 __swift_ptrdiff_t _swift_mutex_tryLock(void * EMBEDDED_SWIFT_NONNULL mutex);
 
 /**
  * Exit the program.
  *
- * Parameters:
- * - `code`: the exit code, which is typically 0 for normal termination.
+ * - Parameters:
+ *   - code: The exit code, which is typically 0 for normal termination.
  *
  * This function must not return.
  *


### PR DESCRIPTION
The doc comments in the Embedded Swift Platform header used an ad hoc "Parameters:" prose format that isn't recognized as structured documentation by DocC's C header support. Convert them to DocC's markdown list syntax (`- Parameters:` / `- Returns:`) so the header's parameter and return-value descriptions render as proper callouts instead of plain paragraphs.

Also fixes a typo in the _swift_generateRandomHashSeed doc comment ("constant values random than" -> "constant values rather than").