### PR TITLE
api-digester: don't flag added nonisolated in default-isolation modules. rdar://176981306

### DIFF
--- a/lib/APIDigester/ModuleAnalyzerNodes.cpp
+++ b/lib/APIDigester/ModuleAnalyzerNodes.cpp
@@ -1386,8 +1386,20 @@ SDKNodeInitInfo::SDKNodeInitInfo(SDKContext &Ctx, Type Ty, TypeInitInfo Info) :
 
 static std::vector<DeclAttrKind> collectDeclAttributes(Decl *D) {
   std::vector<DeclAttrKind> Results;
-  for (auto *Attr: D->getAttrs())
+  for (auto *Attr: D->getAttrs()) {
+    // A plain `nonisolated` keyword is a no-op under nonisolated default
+    // isolation, so don't record it here -- otherwise the digester flags adding
+    // it as a breaking change. Gated to the main module, where default isolation
+    // is authoritative; imported modules and MainActor default are unaffected.
+    if (auto *niso = dyn_cast<NonisolatedAttr>(Attr)) {
+      auto &Ctx = D->getASTContext();
+      if (niso->getModifier() == NonIsolatedModifier::None &&
+          D->getModuleContext() == Ctx.MainModule &&
+          Ctx.LangOpts.DefaultIsolationBehavior == DefaultIsolation::Nonisolated)
+        continue;
+    }
     Results.push_back(Attr->getKind());
+  }
   if (auto *VD = dyn_cast<ValueDecl>(D)) {
 #define HANDLE(COND, KIND_NAME)                                                                   \
     if (VD->COND && !llvm::is_contained(Results, DeclAttrKind::KIND_NAME))                        \

--- a/test/api-digester/nonisolated-default-isolation.swift
+++ b/test/api-digester/nonisolated-default-isolation.swift
@@ -1,0 +1,27 @@
+// REQUIRES: concurrency
+
+// RUN: %empty-directory(%t)
+
+// Scenario A: default (nonisolated) module isolation. Adding an explicit
+// `nonisolated` keyword is a semantic no-op and must NOT be reported as a
+// breaking change.
+// RUN: echo "public struct S {}"             > %t/Foo-1.swift
+// RUN: echo "public nonisolated struct S {}" > %t/Foo-2.swift
+// RUN: %target-swift-frontend -emit-module %t/Foo-1.swift -module-name Foo -o %t/Foo1.swiftmodule -emit-abi-descriptor-path %t/Foo1.json
+// RUN: %target-swift-frontend -emit-module %t/Foo-2.swift -module-name Foo -o %t/Foo2.swiftmodule -emit-abi-descriptor-path %t/Foo2.json
+// RUN: %api-digester -diagnose-sdk -print-module --input-paths %t/Foo1.json -input-paths %t/Foo2.json -o %t/result-nonisolated.txt
+// RUN: %FileCheck %s --check-prefix=NONISO --allow-empty < %t/result-nonisolated.txt
+
+// NONISO-NOT: is now with nonisolated
+
+// Scenario B: `-default-isolation MainActor`. An unannotated decl is implicitly
+// `@MainActor`, so adding `nonisolated` genuinely changes isolation and must
+// STILL be reported as a breaking change.
+// RUN: echo "public struct T {}"             > %t/Bar-1.swift
+// RUN: echo "public nonisolated struct T {}" > %t/Bar-2.swift
+// RUN: %target-swift-frontend -emit-module %t/Bar-1.swift -module-name Bar -default-isolation MainActor -o %t/Bar1.swiftmodule -emit-abi-descriptor-path %t/Bar1.json
+// RUN: %target-swift-frontend -emit-module %t/Bar-2.swift -module-name Bar -default-isolation MainActor -o %t/Bar2.swiftmodule -emit-abi-descriptor-path %t/Bar2.json
+// RUN: %api-digester -diagnose-sdk -print-module --input-paths %t/Bar1.json -input-paths %t/Bar2.json -o %t/result-mainactor.txt
+// RUN: %FileCheck %s --check-prefix=MAINACTOR < %t/result-mainactor.txt
+
+// MAINACTOR: is now with nonisolated


### PR DESCRIPTION
Adding an explicit nonisolated keyword is a no-op when the module's default isolation is already nonisolated, so skip recording it in the ABI descriptor. This also stays clean against a stale baseline that still records NonisolatedAttr: the attribute then only disappears, and removing nonisolated is both API- and ABI-stable to remove, so it is never diagnosed.
