### PR TITLE
[benchmark] Exit with an error if the stdlib is built with asserts

### DIFF
--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -742,6 +742,16 @@ public func main() async {
       }
     }
   case .run:
+    // A stdlib built with internal checks (assertions) does not give meaningful
+    // benchmark results, so refuse to run against one.
+    if _isStdlibInternalChecksEnabled() {
+      fatalError("""
+        Benchmarks must not be run against a standard library built with internal \
+        checks (assertions) enabled: the results are not meaningful.
+
+        Build and benchmark against a standard library built without assertions.
+        """)
+    }
     if !config.allowNondeterministicHashing && !Hasher.isDeterministic {
       fatalError("""
         Benchmark runs require deterministic hashing to be enabled.


### PR DESCRIPTION
A standard library built with internal checks (assertions) does not give meaningful benchmark results. Refuse to run against one, mirroring the existing deterministic-hashing check.

Resolves #51879