### PR TITLE
[Caching][Diagnostics] Fix batch prefix mapped diagnostics

### DIFF
--- a/lib/Frontend/CachedDiagnostics.cpp
+++ b/lib/Frontend/CachedDiagnostics.cpp
@@ -142,7 +142,7 @@ struct DiagnosticSerializer {
     // has references to input files to find subconsumer.
     auto addInputToSourceMgr = [&](const InputFile &Input) {
       auto Path = remapFilePath(Input.getFileName());
-      SrcMgr.getExternalSourceBufferID(Path);
+      SrcMgr.getExternalSourceBufferID(Input.getFileName());
 
       // Fetch the source buffer from original SourceManager and create a
       // serialized file from it.

--- a/test/CAS/cached_diagnostics_remap_batch.swift
+++ b/test/CAS/cached_diagnostics_remap_batch.swift
@@ -1,0 +1,31 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Check path remapping.
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   %t/sub/test.swift %t/sub/foo.swift %t/bar.swift -o %t/deps.json -cache-compile-job -cas-path %t/cas -scanner-prefix-map-paths %t/sub /^test
+
+// RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps.json -o %t/MyApp.cmd
+
+// RUN: %target-swift-frontend-plain -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd -cache-replay-prefix-map /^test %t/sub \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   -c -o %t/test.o -primary-file /^test/test.swift /^test/foo.swift  %t/bar.swift 2>&1 | %FileCheck %s --check-prefix=TEST
+
+// RUN: %target-swift-frontend-plain -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd -cache-replay-prefix-map /^test %t/sub \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   -c -o %t/foo.o -o %t/bar.o -serialize-diagnostics-path %t/foo.diag -serialize-diagnostics-path %t/bar.diag \
+// RUN:   /^test/test.swift -primary-file /^test/foo.swift -primary-file %t/bar.swift 2>&1 | %FileCheck %s --check-prefix=FOO
+
+// TEST: TMP_DIR{{/|\\}}sub{{/|\\}}test.swift:1:10: warning: this is a warning
+// FOO: TMP_DIR{{/|\\}}sub{{/|\\}}foo.swift:1:10: warning: foo warning
+// FOO: TMP_DIR{{/|\\}}bar.swift:1:10: warning: bar warning
+
+//--- /sub/test.swift
+#warning("this is a warning")
+
+//--- /sub/foo.swift
+#warning("foo warning")
+
+//--- bar.swift
+#warning("bar warning")


### PR DESCRIPTION
Fix a bug that the source manager used to figure out the subconsumer inside the FileSpecificDiagnosticConsumer is not setup correctly when prefix mapping is used. This will cause a compiler crash if there are some sources are prefix mapped and some sources are not.

Now correctly setup the source manager to use the original file path so the subconsumer lookup will be successful.

rdar://182330387

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
