### PR TITLE
[IRGen] Fix shadow-copy assertion for mixed value/box debug_values

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1053,6 +1053,21 @@ public:
       return Storage;
     }
 
+    // The same variable can be described in one scope by debug_values of
+    // different storage kinds (e.g. a loadable value and, for async code, an
+    // alloc_box projection). Shadow slots are keyed by {ArgNo, Scope, Name} and
+    // reuse one alloca, so a differently-typed store cannot fit it; keep the
+    // existing shadow copy instead. rdar://181840734
+    unsigned ArgNo = VarInfo.ArgNo;
+    auto existingSlot =
+        ShadowStackSlots.lookup({ArgNo, {Scope, VarInfo.Name}});
+    if (!WasMoved && existingSlot.isValid() &&
+        existingSlot.getElementType() != Storage->getType() &&
+        existingSlot.getElementType() !=
+            Storage->stripPointerCasts()->getType()) {
+      return Storage;
+    }
+
     // Emit a shadow copy.
     auto shadow = emitShadowCopy(Storage, Scope, VarInfo, Align, true, WasMoved)
                       .getAddress();

--- a/test/DebugInfo/irgen_box_value_shadow_conflict.sil
+++ b/test/DebugInfo/irgen_box_value_shadow_conflict.sil
@@ -1,0 +1,50 @@
+// RUN: %target-swift-frontend -g -emit-irgen %s | %FileCheck %s
+//
+// The pre-fix failure is an assertion (canAllocaStoreValue / "bad scope?"),
+// which only exists in assertions-enabled builds. On a no-asserts frontend the
+// bug degrades to silently wrong debug info rather than a crash, so gate the
+// crash regression on an asserts build. The reproducer itself is target
+// independent (unlike the original Linux/Android/Wasm-only swift-testing case).
+// REQUIRES: asserts
+//
+// Regression test for rdar://181840734: a single variable described in the
+// same scope both by a loadable value (via a debug_value) and by a box
+// projection (via an alloc_box, as produced for async functions by
+// MovedAsyncVarDebugInfoPropagator) used to trip
+//   IRGenSIL.cpp: emitShadowCopy(...): Assertion `canAllocaStoreValue(...) &&
+//   "bad scope?"'
+// because both shared the {ArgNo, Scope, Name}-keyed shadow-copy alloca but had
+// incompatible storage types (value vs. pointer). Note that shadow copies must
+// be *enabled* here (no -disable-debugger-shadow-copies) to exercise the path.
+
+sil_stage canonical
+
+import Swift
+import Builtin
+
+sil_scope 1 { parent @test_conflict : $@convention(thin) @async (Builtin.Int64) -> () }
+
+// CHECK-LABEL: define {{.*}} @test_conflict
+sil @test_conflict : $@convention(thin) @async (Builtin.Int64) -> () {
+bb0(%0 : $Builtin.Int64):
+  // Describe "k" first as a loadable value: this creates an i64-typed shadow
+  // copy slot for {ArgNo: 0, scope 1, "k"}.
+  debug_value %0 : $Builtin.Int64, var, name "k", scope 1
+
+  // Now describe the *same* variable "k" via a box. Its projection is a
+  // pointer, which no longer fits the i64 shadow slot. Before the fix this
+  // asserted; now IRGen keeps the existing shadow copy and describes the box
+  // projection directly.
+  %1 = alloc_box [moveable_value_debuginfo] ${ var Builtin.Int64 }, var, name "k", scope 1
+  %2 = project_box %1 : ${ var Builtin.Int64 }, 0, scope 1
+  store %0 to %2 : $*Builtin.Int64, scope 1
+
+  %3 = enum $Optional<Builtin.Executor>, #Optional.none!enumelt, scope 1
+  hop_to_executor %3 : $Optional<Builtin.Executor>, scope 1
+
+  strong_release %1 : ${ var Builtin.Int64 }, scope 1
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK: !DILocalVariable(name: "k"


### PR DESCRIPTION
A variable can be described in one debug scope by debug_values of different storage kinds -- e.g. a loadable value and, for async code, an alloc_box projection cloned onto a debug_value by
MovedAsyncVarDebugInfoPropagator. Shadow copies are keyed by {ArgNo, Scope, Name} and reuse a single alloca, so the second, differently-typed store did not fit the slot and tripped emitShadowCopy's "bad scope?" assertion (or stored a wrong-typed value in a no-asserts build).

Detect the pre-existing incompatibly-typed slot and keep it, describing the later debug_value at its own location instead of forcing a conflicting store.

rdar://181840734

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
