### PR TITLE
Revert test fix to attr_availability_async_rename.swift

### DIFF
--- a/test/attr/attr_availability_async_rename.swift
+++ b/test/attr/attr_availability_async_rename.swift
@@ -86,6 +86,7 @@ func defaultedParamsEnd4(newArg: Int, arg: Int = 0) async { }
 @available(macOS, introduced: 12, renamed: "manyAttrsOld()")
 @available(*, renamed: "manyAttrsNew()")
 @available(*, renamed: "manyAttrsNewOther()")
+@available(macOS, deprecated: 12, renamed: "manyAttrsOld()")
 @available(*, deprecated)
 func manyAttrs(completionHandler: @escaping () -> Void) { }
 
@@ -285,7 +286,8 @@ func asyncContext(t: HandlerTest) async {
   // expected-warning@+1{{consider using asynchronous alternative function}}
   defaultedParamsEnd4(arg: 1) { }
   // expected-warning@+3{{consider using asynchronous alternative function}}
-  // expected-warning@+2{{'manyAttrs(completionHandler:)' is deprecated}}
+  // expected-warning@+2{{'manyAttrs(completionHandler:)' was deprecated in macOS 12: renamed to 'manyAttrsOld()'}}{{group-name=DeprecatedDeclaration}}
+  // expected-note@+1{{use 'manyAttrsOld()' instead}}
   manyAttrs() { }
   // expected-warning@+1{{consider using asynchronous alternative function}}
   macOSOnly() { }


### PR DESCRIPTION
Reverts #90689. I override-merged it to fix CI testing, but it broke smoke testing, so out it goes.

This reverts commit 23ff467b126077d1ec6b6da9b46426de90f0bc5c.