### PR TITLE
[Sema] Warn when a witness has weaker @_effects than its requirement

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7213,6 +7213,14 @@ WARNING(witness_non_objc_storage_optional,none,
       "optional requirement of '@objc' protocol %2",
       (bool, DeclName, Identifier))
 
+WARNING(witness_weaker_effects,none,
+      "%0 provides a weaker '@_effects' guarantee than its protocol "
+      "requirement; add '@%1' to match",
+      (const ValueDecl *, StringRef))
+NOTE(witness_weaker_effects_req,none,
+     "protocol requirement declared '@%0' here",
+     (StringRef))
+
 ERROR(nonobjc_not_allowed,none,
       "declaration is %" OBJC_ATTR_SELECT "0, and cannot be marked '@nonobjc'",
       (unsigned))

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2046,6 +2046,31 @@ checkWitnessAvailability(const ValueDecl *requirement, const ValueDecl *witness,
       .getPrimaryConstraint();
 }
 
+/// Returns the strongest known non-custom `@_effects` guarantee declared on
+/// \p decl, or `EffectsKind::Unspecified` if there is none.
+static EffectsKind getKnownEffectsKind(const ValueDecl *decl) {
+  auto kind = EffectsKind::Unspecified;
+  for (auto *attr : decl->getAttrs().getAttributes<EffectsAttr>()) {
+    auto *effectsAttr = cast<EffectsAttr>(attr);
+    if (effectsAttr->getKind() == EffectsKind::Custom)
+      continue;
+    kind = std::min(kind, effectsAttr->getKind());
+  }
+  return kind;
+}
+
+static StringRef getEffectsAttrSpelling(EffectsKind kind) {
+  switch (kind) {
+  case EffectsKind::ReadNone: return "_effects(readnone)";
+  case EffectsKind::ReadOnly: return "_effects(readonly)";
+  case EffectsKind::ReleaseNone: return "_effects(releasenone)";
+  case EffectsKind::ReadWrite: return "_effects(readwrite)";
+  case EffectsKind::Unspecified: return "_effects(unspecified)";
+  case EffectsKind::Custom: return "_effects";
+  }
+  llvm_unreachable("bad EffectsKind");
+}
+
 RequirementCheck WitnessChecker::checkWitness(ValueDecl *requirement,
                                               const RequirementMatch &match) {
   if (!match.OptionalAdjustments.empty())
@@ -2105,6 +2130,18 @@ RequirementCheck WitnessChecker::checkWitness(ValueDecl *requirement,
     auto conformanceContext = AvailabilityContext::forDeclSignature(DC->getInnermostDeclarationDeclContext());
     if (!conformanceContext.isDeprecated()) {
       return RequirementCheck(CheckKind::DefaultWitnessDeprecated);
+    }
+  }
+
+  if (isa<AbstractFunctionDecl>(requirement) ||
+      isa<AbstractStorageDecl>(requirement)) {
+    auto reqEffects = getKnownEffectsKind(requirement);
+    auto witnessEffects = getKnownEffectsKind(match.Witness);
+    if (reqEffects < EffectsKind::ReadWrite && witnessEffects > reqEffects) {
+      Context.Diags.diagnose(match.Witness, diag::witness_weaker_effects,
+                             match.Witness, getEffectsAttrSpelling(reqEffects));
+      Context.Diags.diagnose(requirement, diag::witness_weaker_effects_req,
+                             getEffectsAttrSpelling(reqEffects));
     }
   }
 

--- a/test/Sema/effects_attr_witness.swift
+++ b/test/Sema/effects_attr_witness.swift
@@ -1,0 +1,17 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P {
+  @_effects(readonly) func foo() // expected-note {{protocol requirement declared '@_effects(readonly)' here}}
+}
+
+struct MissingEffects: P {
+  func foo() {} // expected-warning {{provides a weaker '@_effects' guarantee than its protocol requirement; add '@_effects(readonly)' to match}}
+}
+
+struct MatchingEffects: P {
+  @_effects(readonly) func foo() {} // OK
+}
+
+struct StrongerEffects: P {
+  @_effects(readnone) func foo() {} // OK: readnone is stronger than readonly
+}


### PR DESCRIPTION
If a protocol requirement declares an '@_effects' guarantee (readnone/readonly/ releasenone), a witness that provides a weaker guarantee silently breaks the promise the optimizer relies on. Emit a warning in WitnessChecker::checkWitness so the mismatch is surfaced.

Resolves #51458