### PR TITLE
[Embedded] Inline default implementations into covariant-self witness thunks

### DIFF
--- a/SwiftCompilerSources/Sources/AST/GenericSignature.swift
+++ b/SwiftCompilerSources/Sources/AST/GenericSignature.swift
@@ -36,6 +36,15 @@ public struct GenericSignature: CustomStringConvertible, NoReflectionChildren {
 
   public var isEmpty: Bool { bridged.impl == nil }
 
+  /// Whether every generic parameter in this signature is constrained to a
+  /// concrete type.
+  public var areAllParamsConcrete: Bool { bridged.areAllParamsConcrete() }
+
+  /// Whether every generic parameter in this signature is either constrained
+  /// to a concrete type or class-constrained (the two forms permitted by
+  /// Embedded Swift).
+  public var canBeEmittedInEmbeddedSwift: Bool { bridged.canBeEmittedInEmbeddedSwift() }
+
   public var canonicalSignature: CanonicalGenericSignature {
     CanonicalGenericSignature(bridged: bridged.getCanonicalSignature())
   }

--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
@@ -34,7 +34,7 @@ let mandatoryPerformanceOptimizations = ModulePass(name: "mandatory-performance-
   // For embedded Swift, optimize all the functions (there cannot be any
   // generics, type metadata, etc.)
   if moduleContext.options.enableEmbeddedSwift {
-    worklist.addAllNonGenericFunctions(of: moduleContext)
+    worklist.addAllNonGenericFunctionsAndEmbeddedThunks(of: moduleContext)
   } else {
     worklist.addAllMandatoryRequiredFunctions(of: moduleContext)
   }
@@ -261,7 +261,8 @@ private func inlineAndDevirtualize(apply: FullApplySite, alreadyInlinedFunctions
     return
   }
 
-  if shouldInline(apply: apply, callee: callee, alreadyInlinedFunctions: &alreadyInlinedFunctions) {
+  if shouldInline(apply: apply, callee: callee, alreadyInlinedFunctions: &alreadyInlinedFunctions,
+                  context) {
     if apply.inliningCanInvalidateStackNesting  {
       simplifyCtxt.notifyInvalidatedStackNesting()
     }
@@ -287,17 +288,31 @@ private func removeUnusedMetatypeInstructions(in function: Function, _ context: 
   }
 }
 
-private func shouldInline(apply: FullApplySite, callee: Function, alreadyInlinedFunctions: inout Set<PathFunctionTuple>) -> Bool {
+private func shouldInline(apply: FullApplySite, callee: Function, alreadyInlinedFunctions: inout Set<PathFunctionTuple>,
+                          _ context: FunctionPassContext) -> Bool {
   if let beginApply = apply as? BeginApplyInst,
      !beginApply.canInline
   {
     return false
   }
 
+  // In embedded Swift, a non-final class conforming to a protocol via a
+  // protocol-extension default implementation gets a witness thunk that is
+  // generic over its (class-constrained) conforming type — the covariant-Self
+  // pattern, `<τ : ConcreteClass>`. We want to inline the default impl into
+  // such a thunk to strip the thunk's dependence on the still-generic default
+  // implementation. See the corresponding `return true` below.
+  let isEmbeddedGenericThunkCaller = context.options.enableEmbeddedSwift &&
+                                     apply.parentFunction.thunkKind == .thunk &&
+                                     apply.parentFunction.isGeneric
+
   guard callee.canBeInlinedIntoCaller(withSerializedKind: apply.parentFunction.serializedKind) ||
         // Even if the serialization kind doesn't match, we need to make sure to inline witness method thunks
         // in embedded swift.
         callee.thunkKind == .thunk ||
+        // Likewise, the default implementation we fold into an embedded generic
+        // witness thunk may not share the thunk's serialization kind.
+        isEmbeddedGenericThunkCaller ||
         // Force inlining transparent co-routines. This might be necessary if `-enable-testing` is turned on.
         (apply is BeginApplyInst && callee.isTransparent)
   else {
@@ -336,6 +351,20 @@ private func shouldInline(apply: FullApplySite, callee: Function, alreadyInlined
   if apply.substitutionMap.isEmpty,
      let pathIntoGlobal = apply.resultIsUsedInGlobalInitialization(),
      alreadyInlinedFunctions.insert(PathFunctionTuple(path: pathIntoGlobal, function: callee)).inserted {
+    return true
+  }
+
+  // In Embedded Swift, inline the protocol-extension default implementation
+  // that a generic witness thunk dispatches to, when that default impl's
+  // own generic signature cannot be emitted in embedded Swift (e.g. it is
+  // generic over `<Self : Protocol>`).
+  // Folding it into the thunk removes the reference to the un-emittable generic
+  // callee; the thunk itself stays generic over the class-constrained type,
+  // which IRGen can emit.
+  if isEmbeddedGenericThunkCaller,
+     !callee.genericSignature.isEmpty,
+     !callee.genericSignature.canBeEmittedInEmbeddedSwift,
+     alreadyInlinedFunctions.insert(PathFunctionTuple(path: SmallProjectionPath(), function: callee)).inserted {
     return true
   }
 
@@ -489,6 +518,24 @@ extension FunctionWorklist {
       pushIfNotVisited(f)
     }
     return
+  }
+
+  /// Like `addAllNonGenericFunctions`, but also pulls in generic protocol
+  /// witness thunks whose signature satisfies the embedded-Swift rules.
+  /// These thunks aren't reachable via the usual "specialize callees of
+  /// non-generic functions" traversal, but their bodies may contain calls to
+  /// generic protocol-extension default implementations that MUST be inlined
+  /// away before IRGen sees them (otherwise the still-generic callee trips
+  /// `hasValidSignatureForEmbedded` in IRGen). Optimizing the thunk itself
+  /// gives the inliner a chance to fold in those default-impl calls.
+  mutating func addAllNonGenericFunctionsAndEmbeddedThunks(of moduleContext: ModulePassContext) {
+    for f in moduleContext.functions {
+      if !f.isGeneric {
+        pushIfNotVisited(f)
+      } else if f.thunkKind == .thunk && f.genericSignature.canBeEmittedInEmbeddedSwift {
+        pushIfNotVisited(f)
+      }
+    }
   }
 
   mutating func addCallees(of function: Function, _ context: ModulePassContext) {

--- a/SwiftCompilerSources/Sources/SIL/Type.swift
+++ b/SwiftCompilerSources/Sources/SIL/Type.swift
@@ -146,13 +146,7 @@ public struct Type : TypeProperties, CustomStringConvertible, NoReflectionChildr
   /// such arguments, no metadata is needed, except the isa-pointer of the class.
   public var hasValidSignatureForEmbedded: Bool {
     let genericSignature = invocationGenericSignatureOfFunction
-    for genParam in genericSignature.genericParameters {
-      let mappedParam = genericSignature.mapTypeIntoEnvironment(genParam)
-      if mappedParam.isArchetype && !mappedParam.archetypeRequiresClass {
-        return false
-      }
-    }
-    return true
+    return genericSignature.isEmpty || genericSignature.canBeEmittedInEmbeddedSwift
   }
 
   //===--------------------------------------------------------------------===//

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -3255,6 +3255,8 @@ struct BridgedGenericSignature {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTTypeArray getGenericParams() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType mapTypeIntoEnvironment(BridgedASTType type) const;
   BRIDGED_INLINE BridgedCanGenericSignature getCanonicalSignature() const;
+  BRIDGED_INLINE bool areAllParamsConcrete() const;
+  BRIDGED_INLINE bool canBeEmittedInEmbeddedSwift() const;
 };
 
 struct BridgedCanGenericSignature {

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -1075,6 +1075,14 @@ BridgedGenericSignature::getCanonicalSignature() const {
   return BridgedCanGenericSignature{impl};
 }
 
+bool BridgedGenericSignature::areAllParamsConcrete() const {
+  return unbridged()->areAllParamsConcrete();
+}
+
+bool BridgedGenericSignature::canBeEmittedInEmbeddedSwift() const {
+  return unbridged()->canBeEmittedInEmbeddedSwift();
+}
+
 swift::CanGenericSignature BridgedCanGenericSignature::unbridged() const {
   return swift::GenericSignature(impl).getCanonicalSignature();
 }

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -346,6 +346,12 @@ public:
   /// Check if the generic signature has a parameter pack.
   bool hasParameterPack() const;
 
+  /// Determine whether an entity with the given generic signature can be
+  /// emitted in Embedded Swift.
+  ///
+  /// This captures the restrictions needed to avoid unspecialized generics.
+  bool canBeEmittedInEmbeddedSwift() const;
+
   /// Compute the number of conformance requirements in this signature.
   unsigned getNumConformanceRequirements() const {
     unsigned result = 0;

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -196,6 +196,23 @@ bool GenericSignatureImpl::hasParameterPack() const {
   return false;
 }
 
+bool GenericSignatureImpl::canBeEmittedInEmbeddedSwift() const {
+  for (auto param: getGenericParams()) {
+    // Ignore parameters that are mapped to concrete types.
+    if (isConcreteType(Type(param)))
+      continue;
+
+    // Class-constrained parameters are okay.
+    if (auto layout = getLayoutConstraint(Type(param)))
+      if (layout->isClass())
+        continue;
+
+    return false;
+  }
+
+  return true;
+}
+
 ASTContext &GenericSignature::getASTContext(
                                     ArrayRef<GenericTypeParamType *> params,
                                     ArrayRef<swift::Requirement> requirements) {

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3606,15 +3606,7 @@ llvm::CallBase *swift::irgen::emitCXXConstructorCall(
 //     - a class-bound archetype (class-bound existential)
 bool swift::irgen::hasValidSignatureForEmbedded(SILFunction *f) {
   auto s = f->getLoweredFunctionType()->getInvocationGenericSignature();
-  for (auto genParam : s.getGenericParams()) {
-    auto mappedParam = f->getGenericEnvironment()->mapTypeIntoEnvironment(genParam);
-    if (auto *archeTy = mappedParam->getAs<ArchetypeType>()) {
-      if (archeTy->requiresClass())
-        continue;
-    }
-    return false;
-  }
-  return true;
+  return !s || s->canBeEmittedInEmbeddedSwift();
 }
 
 StackProtectorMode IRGenModule::shouldEmitStackProtector(SILFunction *f) {

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -683,7 +683,7 @@ extension Task where Success == Never, Failure == Never {
   @available(StdlibDeploymentTarget 6.3, *)
   static var unownedDefaultExecutor: UnownedTaskExecutor {
     _createDefaultExecutorsOnce()
-    return unsafe UnownedTaskExecutor(_defaultExecutor!)
+    return unsafe UnownedTaskExecutor(Builtin.buildOrdinaryTaskExecutorRef(_defaultExecutor!))
   }
 }
 

--- a/test/embedded/witness-thunk-default-impl-inlining.swift
+++ b/test/embedded/witness-thunk-default-impl-inlining.swift
@@ -1,0 +1,47 @@
+// RUN: %target-swift-emit-sil %s -enable-experimental-feature Embedded -wmo -module-name main | %FileCheck %s
+
+// REQUIRES: swift_feature_Embedded
+
+// A non-final class that conforms to a protocol via a protocol-extension
+// default implementation gets a witness thunk that is generic over its
+// (class-constrained) conforming type -- the covariant-Self pattern,
+// `<τ : ConcreteClass>`. The default implementation is itself generic over
+// `<Self : Protocol>`, whose signature cannot be emitted in embedded Swift.
+//
+// The mandatory-performance-optimizations pass must inline that default impl
+// into the witness thunk so the thunk no longer references the un-emittable
+// generic callee. This test locks in that inlining (and guards against the
+// inliner failing to fire, or -- for a recursive default impl -- inlining
+// unboundedly and exhausting memory).
+
+public protocol Greeter {
+  func greet() -> Int
+}
+
+extension Greeter {
+  public func greet() -> Int { return 100 }
+}
+
+// Non-final class: its witness thunk is generic over `<τ : Animal>`.
+public class Animal: Greeter {}
+
+// A subclass exercises the covariant-Self aspect (the thunk really is generic,
+// not specialized to the exact class).
+public class Dog: Animal {}
+
+// Use the conformers through an existential so the witness table -- and thus
+// the generic witness thunk -- is live and reaches the optimizer/IRGen.
+@_silgen_name("run")
+public func run(_ g: any Greeter) -> Int {
+  return g.greet()
+}
+
+// The witness thunk for Animal must have the default impl inlined: no
+// `function_ref`/`apply` of the generic default implementation remains, just
+// its folded-in body returning 100.
+
+// CHECK-LABEL: sil {{.*}}@$e4main6AnimalCAA7GreeterA2aDP5greetSiyFTW : $@convention(witness_method: Greeter) <τ_0_0 where τ_0_0 : Animal>
+// CHECK-NOT:     function_ref @$e4main7GreeterPAAE5greetSiyF
+// CHECK-NOT:     apply
+// CHECK:         integer_literal $Builtin.Int{{[0-9]+}}, 100
+// CHECK:       } // end sil function '$e4main6AnimalCAA7GreeterA2aDP5greetSiyFTW'


### PR DESCRIPTION
When a class conforms to a protocol, the witness thunk might have a
covariant Self generic parameter. The presence of this generic
parameter causes problems when the witness thunk calls a default
implementation, because that default implementation is generic.
To avoid this problem, inline the callee into the witness thunk so it
becomes non-generic while retaining dynamic dispatch on the actual
Self type.

This is a longstanding issue with Embedded Swift and classes that
conform to protocols.

Fixes rdar://177527091.