### PR TITLE
[Sema] Allow memberwise initializers in same-file extensions

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -37,6 +37,7 @@
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/Defer.h"
+#include "swift/Basic/Range.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/Sema/ConstraintSystem.h"
 #include "llvm/ADT/SmallString.h"
@@ -208,12 +209,11 @@ enum class ImplicitConstructorKind {
   Memberwise,
 };
 
-static ParamDecl *createMemberwiseInitParameter(DeclContext *DC,
-                                                SourceLoc paramLoc,
-                                                VarDecl *var) {
-  auto &ctx = var->getASTContext();
+/// Compute the interface type of the parameter that a memberwise
+/// initializer would have for the given property.
+static Type getMemberwiseParamInterfaceType(VarDecl *var,
+                                            bool &isAutoClosure) {
   auto varInterfaceType = var->getValueInterfaceType();
-  bool isAutoClosure = false;
 
   if (var->getAttrs().hasAttribute<LazyAttr>()) {
     // If var is a lazy property, its value is provided for the underlying
@@ -253,6 +253,17 @@ static ParamDecl *createMemberwiseInitParameter(DeclContext *DC,
       varInterfaceType = FunctionType::get({}, varInterfaceType, extInfo);
     }
   }
+
+  return varInterfaceType;
+}
+
+static ParamDecl *createMemberwiseInitParameter(DeclContext *DC,
+                                                SourceLoc paramLoc,
+                                                VarDecl *var) {
+  auto &ctx = var->getASTContext();
+  bool isAutoClosure = false;
+  auto varInterfaceType = getMemberwiseParamInterfaceType(var, isAutoClosure);
+  Type resultBuilderType = var->getResultBuilderType();
 
   // Create the parameter.
   auto *arg = new (ctx) ParamDecl(SourceLoc(), paramLoc, var->getName(),
@@ -584,6 +595,71 @@ static bool hasClangImplementation(const NominalTypeDecl *decl) {
 static bool isInMainBody(ValueDecl *member, NominalTypeDecl *ty) {
   return member->getDeclContext() ==
               ty->getImplementationContext()->getAsGenericContext();
+}
+
+/// True if an explicit initializer declared in an unconstrained extension of
+/// \p decl within the same source file has the given argument labels and
+/// parameter types. Such an initializer would be a redeclaration of a
+/// synthesized initializer with that signature, so it takes the synthesized
+/// initializer's place instead.
+static bool hasExtensionInitMatching(NominalTypeDecl *decl,
+                                     ArrayRef<Identifier> argumentLabels,
+                                     ArrayRef<Type> paramTypes) {
+  auto *sourceFile = decl->getParentSourceFile();
+
+  for (auto *member : decl->lookupDirect(DeclBaseName::createConstructor())) {
+    if (member->isImplicit())
+      continue;
+
+    // Initializers in the main body suppress synthesis entirely; here we
+    // only look for ones in extensions in the same source file. For a
+    // deserialized type there is no source file, but a matching initializer
+    // in a same-module extension can only have come from the same file, or
+    // the module would not have compiled.
+    auto *ext = dyn_cast<ExtensionDecl>(member->getDeclContext());
+    if (!ext || ext->getParentModule() != decl->getParentModule())
+      continue;
+    if (sourceFile && ext->getParentSourceFile() != sourceFile)
+      continue;
+
+    // An initializer in a constrained extension has a different generic
+    // signature, so it can coexist with the synthesized initializer.
+    if (ext->isConstrainedExtension())
+      continue;
+
+    if (!ABIRoleInfo(member).providesAPI())
+      continue;
+
+    auto *ctor = cast<ConstructorDecl>(member);
+    if (ctor->getName().getArgumentNames() != argumentLabels)
+      continue;
+
+    auto *methodTy = ctor->getMethodInterfaceType()->getAs<AnyFunctionType>();
+    if (!methodTy)
+      continue;
+
+    auto params = methodTy->getParams();
+    if (params.size() != paramTypes.size())
+      continue;
+
+    auto matches = [&]() -> bool {
+      for (auto i : indices(params)) {
+        // inout and variadic parameters change the signature enough that
+        // the initializer is a valid overload of the synthesized one.
+        if (params[i].isInOut() || params[i].isVariadic())
+          return false;
+
+        if (params[i].getPlainType()->getCanonicalType() !=
+            paramTypes[i]->getCanonicalType())
+          return false;
+      }
+      return true;
+    };
+    if (matches())
+      return true;
+  }
+
+  return false;
 }
 
 static void
@@ -1525,6 +1601,22 @@ bool HasMemberwiseInitRequest::evaluate(Evaluator &evaluator, StructDecl *decl,
       return false;
   }
 
+  // If an explicit initializer declared in a same-file extension has the
+  // signature the memberwise initializer would have, it takes the place of
+  // the memberwise initializer rather than conflicting with it.
+  {
+    SmallVector<Identifier, 8> argumentLabels;
+    SmallVector<Type, 8> paramTypes;
+    for (auto *var : decl->getMemberwiseInitProperties(initKind)) {
+      argumentLabels.push_back(var->getName());
+      bool isAutoClosure = false;
+      paramTypes.push_back(getMemberwiseParamInterfaceType(var, isAutoClosure));
+    }
+    if (!argumentLabels.empty() &&
+        hasExtensionInitMatching(decl, argumentLabels, paramTypes))
+      return false;
+  }
+
   std::multimap<VarDecl *, VarDecl *> initializedViaAccessor;
   decl->collectPropertiesInitializableByInitAccessors(initializedViaAccessor);
 
@@ -1750,6 +1842,14 @@ HasDefaultInitRequest::evaluate(Evaluator &evaluator,
   // If the user has already defined a designated initializer, then don't
   // synthesize a default init.
   if (hasUserDefinedDesignatedInit(evaluator, decl))
+    return false;
+
+  // If an explicit zero-argument initializer is declared in a same-file
+  // extension of a struct, it takes the place of the default initializer
+  // rather than conflicting with it.
+  if (isa<StructDecl>(decl) &&
+      hasExtensionInitMatching(decl, /*argumentLabels=*/{},
+                               /*paramTypes=*/{}))
     return false;
 
   // Regardless of whether all of the properties are initialized or

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -37,7 +37,6 @@
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/Defer.h"
-#include "swift/Basic/Range.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/Sema/ConstraintSystem.h"
 #include "llvm/ADT/SmallString.h"
@@ -209,11 +208,12 @@ enum class ImplicitConstructorKind {
   Memberwise,
 };
 
-/// Compute the interface type of the parameter that a memberwise
-/// initializer would have for the given property.
-static Type getMemberwiseParamInterfaceType(VarDecl *var,
-                                            bool &isAutoClosure) {
+static ParamDecl *createMemberwiseInitParameter(DeclContext *DC,
+                                                SourceLoc paramLoc,
+                                                VarDecl *var) {
+  auto &ctx = var->getASTContext();
   auto varInterfaceType = var->getValueInterfaceType();
+  bool isAutoClosure = false;
 
   if (var->getAttrs().hasAttribute<LazyAttr>()) {
     // If var is a lazy property, its value is provided for the underlying
@@ -253,17 +253,6 @@ static Type getMemberwiseParamInterfaceType(VarDecl *var,
       varInterfaceType = FunctionType::get({}, varInterfaceType, extInfo);
     }
   }
-
-  return varInterfaceType;
-}
-
-static ParamDecl *createMemberwiseInitParameter(DeclContext *DC,
-                                                SourceLoc paramLoc,
-                                                VarDecl *var) {
-  auto &ctx = var->getASTContext();
-  bool isAutoClosure = false;
-  auto varInterfaceType = getMemberwiseParamInterfaceType(var, isAutoClosure);
-  Type resultBuilderType = var->getResultBuilderType();
 
   // Create the parameter.
   auto *arg = new (ctx) ParamDecl(SourceLoc(), paramLoc, var->getName(),
@@ -598,15 +587,15 @@ static bool isInMainBody(ValueDecl *member, NominalTypeDecl *ty) {
 }
 
 /// True if an explicit initializer declared in an unconstrained extension of
-/// \p decl within the same source file has the given argument labels and
-/// parameter types. Such an initializer would be a redeclaration of a
-/// synthesized initializer with that signature, so it takes the synthesized
-/// initializer's place instead.
-static bool hasExtensionInitMatching(NominalTypeDecl *decl,
-                                     ArrayRef<Identifier> argumentLabels,
-                                     ArrayRef<Type> paramTypes) {
+/// \p decl within the same source file would conflict with the initializer
+/// that would be implicitly synthesized. Such an initializer takes the
+/// synthesized initializer's place instead.
+static bool hasExtensionInitMatching(
+    NominalTypeDecl *decl, ImplicitConstructorKind ICK,
+    std::optional<MemberwiseInitKind> memberwiseKind) {
   auto *sourceFile = decl->getParentSourceFile();
 
+  SmallVector<ConstructorDecl *, 2> candidates;
   for (auto *member : decl->lookupDirect(DeclBaseName::createConstructor())) {
     if (member->isImplicit())
       continue;
@@ -630,35 +619,22 @@ static bool hasExtensionInitMatching(NominalTypeDecl *decl,
     if (!ABIRoleInfo(member).providesAPI())
       continue;
 
-    auto *ctor = cast<ConstructorDecl>(member);
-    if (ctor->getName().getArgumentNames() != argumentLabels)
-      continue;
+    candidates.push_back(cast<ConstructorDecl>(member));
+  }
+  if (candidates.empty())
+    return false;
 
-    auto *methodTy = ctor->getMethodInterfaceType()->getAs<AnyFunctionType>();
-    if (!methodTy)
-      continue;
-
-    auto params = methodTy->getParams();
-    if (params.size() != paramTypes.size())
-      continue;
-
-    auto matches = [&]() -> bool {
-      for (auto i : indices(params)) {
-        // inout and variadic parameters change the signature enough that
-        // the initializer is a valid overload of the synthesized one.
-        if (params[i].isInOut() || params[i].isVariadic())
-          return false;
-
-        if (params[i].getPlainType()->getCanonicalType() !=
-            paramTypes[i]->getCanonicalType())
-          return false;
-      }
-      return true;
-    };
-    if (matches())
+  // Compare the candidates against the initializer that would be synthesized
+  // using the same rules as redeclaration checking.
+  auto &ctx = decl->getASTContext();
+  auto *synthesized = createImplicitConstructor(decl, ICK, memberwiseKind, ctx);
+  for (auto *ctor : candidates) {
+    if (conflicting(ctx, ctor->getOverloadSignature(),
+                    ctor->getOverloadSignatureType(),
+                    synthesized->getOverloadSignature(),
+                    synthesized->getOverloadSignatureType()))
       return true;
   }
-
   return false;
 }
 
@@ -1601,21 +1577,12 @@ bool HasMemberwiseInitRequest::evaluate(Evaluator &evaluator, StructDecl *decl,
       return false;
   }
 
-  // If an explicit initializer declared in a same-file extension has the
-  // signature the memberwise initializer would have, it takes the place of
-  // the memberwise initializer rather than conflicting with it.
-  {
-    SmallVector<Identifier, 8> argumentLabels;
-    SmallVector<Type, 8> paramTypes;
-    for (auto *var : decl->getMemberwiseInitProperties(initKind)) {
-      argumentLabels.push_back(var->getName());
-      bool isAutoClosure = false;
-      paramTypes.push_back(getMemberwiseParamInterfaceType(var, isAutoClosure));
-    }
-    if (!argumentLabels.empty() &&
-        hasExtensionInitMatching(decl, argumentLabels, paramTypes))
-      return false;
-  }
+  // If an explicit initializer declared in a same-file extension would
+  // conflict with the memberwise initializer, it takes the memberwise
+  // initializer's place.
+  if (hasExtensionInitMatching(decl, ImplicitConstructorKind::Memberwise,
+                               initKind))
+    return false;
 
   std::multimap<VarDecl *, VarDecl *> initializedViaAccessor;
   decl->collectPropertiesInitializableByInitAccessors(initializedViaAccessor);
@@ -1844,12 +1811,12 @@ HasDefaultInitRequest::evaluate(Evaluator &evaluator,
   if (hasUserDefinedDesignatedInit(evaluator, decl))
     return false;
 
-  // If an explicit zero-argument initializer is declared in a same-file
-  // extension of a struct, it takes the place of the default initializer
-  // rather than conflicting with it.
+  // If an explicit initializer declared in a same-file extension of a struct
+  // would conflict with the default initializer, it takes the default
+  // initializer's place.
   if (isa<StructDecl>(decl) &&
-      hasExtensionInitMatching(decl, /*argumentLabels=*/{},
-                               /*paramTypes=*/{}))
+      hasExtensionInitMatching(decl, ImplicitConstructorKind::Default,
+                               /*memberwiseKind=*/std::nullopt))
     return false;
 
   // Regardless of whether all of the properties are initialized or

--- a/test/decl/init/Inputs/synthesized_init_extension_other.swift
+++ b/test/decl/init/Inputs/synthesized_init_extension_other.swift
@@ -1,0 +1,5 @@
+public struct CrossFileMemberwise {
+  public var x: Int
+}
+
+public struct CrossFileEmpty {}

--- a/test/decl/init/basic_init.swift
+++ b/test/decl/init/basic_init.swift
@@ -37,7 +37,9 @@ struct InitStruct {
   let foo: Int
 }
 extension InitStruct {
-  init(foo: Int) {} // expected-error{{invalid redeclaration of synthesized memberwise 'init(foo:)'}}
+  // A matching initializer in a same-file extension takes the place of the
+  // synthesized memberwise initializer.
+  init(foo: Int) { self.foo = foo }
 }
 
 // <rdar://problem/17564699> QoI: Structs should get convenience initializers

--- a/test/decl/init/synthesized_init_extension.swift
+++ b/test/decl/init/synthesized_init_extension.swift
@@ -1,0 +1,109 @@
+// RUN: %target-typecheck-verify-swift %S/Inputs/synthesized_init_extension_other.swift
+
+// https://github.com/swiftlang/swift/issues/90519
+// An explicit initializer declared in a same-file extension takes the place
+// of the synthesized memberwise or default initializer it would otherwise
+// conflict with.
+
+public struct Empty {}
+
+extension Empty {
+  public init() {}
+}
+
+public struct Memberwise {
+  public var x: Int
+  public var y: String
+}
+
+extension Memberwise {
+  public init(x: Int, y: String) {
+    self.x = x
+    self.y = y
+  }
+}
+
+func useSuppressed() {
+  let _ = Empty()
+  let _ = Memberwise(x: 1, y: "two")
+}
+
+// An initializer with a different signature keeps the synthesized memberwise
+// initializer around.
+struct KeepsMemberwise {
+  var x: Int
+}
+
+extension KeepsMemberwise {
+  init(string: String) {
+    self.init(x: Int(string) ?? 0)
+  }
+}
+
+// Same labels but different parameter types overload the memberwise
+// initializer rather than replacing it.
+struct KeepsMemberwiseOverload {
+  var x: Int
+}
+
+extension KeepsMemberwiseOverload {
+  init(x: String) {
+    self.init(x: Int(x) ?? 0)
+  }
+}
+
+func useKeepsMemberwise() {
+  let _ = KeepsMemberwise(x: 1)
+  let _ = KeepsMemberwise(string: "2")
+  let _ = KeepsMemberwiseOverload(x: 1)
+  let _ = KeepsMemberwiseOverload(x: "2")
+}
+
+struct Generic<T> {
+  var value: T
+}
+
+extension Generic {
+  init(value: T) {
+    self.value = value
+  }
+}
+
+// An initializer in a constrained extension has a different signature and
+// coexists with the synthesized memberwise initializer.
+struct Constrained<T> {
+  var value: T
+}
+
+extension Constrained where T == Int {
+  init(value: Int) {
+    self.value = value
+  }
+}
+
+func useGeneric() {
+  let _ = Generic(value: 1)
+  let _ = Constrained(value: "hi")
+}
+
+// A failable or throwing initializer still takes the synthesized
+// initializer's place, since it would still conflict.
+struct FailableThrowingEmpty {}
+
+extension FailableThrowingEmpty {
+  init?() throws {}
+}
+
+func useFailableThrowing() throws {
+  let _: FailableThrowingEmpty? = try FailableThrowingEmpty()
+}
+
+// An initializer in an extension in a different file still conflicts.
+
+extension CrossFileMemberwise {
+  init(x: Int) { self.x = x } // expected-error {{invalid redeclaration of synthesized initializer 'init(x:)'}}
+}
+
+extension CrossFileEmpty {
+  init() {} // expected-error {{invalid redeclaration of synthesized initializer 'init()'}}
+}

--- a/test/decl/init/synthesized_init_extension.swift
+++ b/test/decl/init/synthesized_init_extension.swift
@@ -86,6 +86,18 @@ func useGeneric() {
   let _ = Constrained(value: "hi")
 }
 
+// An async initializer does not conflict with the synthesized initializer,
+// so both coexist as overloads.
+struct AsyncOverload {}
+
+extension AsyncOverload {
+  init() async {}
+}
+
+func useAsyncOverload() {
+  let _ = AsyncOverload()
+}
+
 // A failable or throwing initializer still takes the synthesized
 // initializer's place, since it would still conflict.
 struct FailableThrowingEmpty {}

--- a/test/decl/init/synthesized_init_extension.swift
+++ b/test/decl/init/synthesized_init_extension.swift
@@ -110,6 +110,46 @@ func useFailableThrowing() throws {
   let _: FailableThrowingEmpty? = try FailableThrowingEmpty()
 }
 
+// An initializer in the base declaration suppresses synthesis entirely, so an
+// extension initializer has nothing to take the place of and remains an
+// ordinary initializer, exactly as before.
+struct BaseDeclInit {
+  var x: Int
+  init(anything: Int) { self.x = anything }
+}
+
+extension BaseDeclInit {
+  init(x: Int) { self.x = x }
+}
+
+struct BaseDeclInitDefault {
+  var x = 0
+  init(y: Int) { self.x = y }
+}
+
+extension BaseDeclInitDefault {
+  init() { self.x = -1 }
+}
+
+func useBaseDeclInit() {
+  let _ = BaseDeclInit(anything: 1)
+  let _ = BaseDeclInit(x: 1)
+  let _ = BaseDeclInitDefault(y: 1)
+  let _ = BaseDeclInitDefault()
+  let _ = BaseDeclInitDefault(x: 1) // expected-error {{incorrect argument label in call (have 'x:', expected 'y:')}}
+}
+
+// Two explicit initializers with the same signature still conflict with each
+// other as usual.
+struct BaseDeclInitConflict {
+  var x: Int
+  init(x: Int) { self.x = x } // expected-note {{'init(x:)' previously declared here}}
+}
+
+extension BaseDeclInitConflict {
+  init(x: Int) { self.x = x } // expected-error {{invalid redeclaration of 'init(x:)'}}
+}
+
 // An initializer in an extension in a different file still conflicts.
 
 extension CrossFileMemberwise {


### PR DESCRIPTION
A `public` initializer that matches Swift's synthesized memberwise initializer is currently forbidden as an invalid redeclaration, making it impossible to extend macro-generated types to publicize an initializer that matches the synthesized one. Lift this restriction to allow memberwise initializers to be defined in same-file extensions.

Resolves https://github.com/swiftlang/swift/issues/90519.