### PR TITLE
[Swiftify] restrict runtime test to the just-built stdlib (NFC)

### DIFF
--- a/test/Interop/C/swiftify-import/trap-source-location.swift
+++ b/test/Interop/C/swiftify-import/trap-source-location.swift
@@ -1,5 +1,6 @@
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize_none
+// UNSUPPORTED: back_deployment_runtime || use_os_stdlib
 
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t


### PR DESCRIPTION
Running the test on an older stdlib may result in an older macro implementation being invoked, resulting in different behavior. For this test, not all versions of the macro actually trap.

rdar://182252042