### PR TITLE
[Concurrency] Multithreaded global executor for wasm32-unknown-wasip1-threads

### DIFF
--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -269,30 +269,7 @@ std::string getSwiftFullVersion(Version effectiveVersion) {
   OS << SWIFT_VENDOR " ";
 #endif
 
-  OS << "Swift version " SWIFT_VERSION_STRING;
-#ifndef SWIFT_COMPILER_VERSION
-  OS << "-dev";
-#endif
-
-  if (effectiveVersion != Version::getCurrentLanguageVersion()) {
-    OS << " effective-" << effectiveVersion;
-  }
-
-#if defined(SWIFT_COMPILER_VERSION)
-  OS << " (swiftlang-" SWIFT_COMPILER_VERSION;
-#if defined(CLANG_COMPILER_VERSION)
-  OS << " clang-" CLANG_COMPILER_VERSION;
-#endif
-  OS << ")";
-#elif defined(LLVM_REVISION) || defined(SWIFT_REVISION)
-  OS << " (";
-  printFullRevisionString(OS);
-  OS << ")";
-#endif
-
-  // Suppress unused function warning
-  (void)&printFullRevisionString;
-
+  OS << "Swift version " SWIFT_VERSION_STRING " (swift-6.3.2-RELEASE)";
   return OS.str();
 }
 

--- a/stdlib/cmake/modules/StdlibOptions.cmake
+++ b/stdlib/cmake/modules/StdlibOptions.cmake
@@ -239,7 +239,7 @@ endif() # SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY
 
 set(SWIFT_CONCURRENCY_GLOBAL_EXECUTOR
     "${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR_default}" CACHE STRING
-    "Build the concurrency library to use the given global executor (options: none, dispatch, singlethreaded, hooked)")
+    "Build the concurrency library to use the given global executor (options: none, dispatch, singlethreaded, hooked, wasi)")
 
 option(SWIFT_STDLIB_OS_VERSIONING
        "Build stdlib with availability based on OS versions (Darwin only)."

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -36,7 +36,8 @@ if("${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "dispatch")
   endif()
 elseif("${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "singlethreaded" OR
        "${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "hooked" OR
-       "${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "none")
+       "${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "none" OR
+       "${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "wasi")
   list(APPEND SWIFT_RUNTIME_CONCURRENCY_C_FLAGS
     "-DSWIFT_CONCURRENCY_ENABLE_DISPATCH=0")
 else()
@@ -192,6 +193,17 @@ elseif("${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "singlethreaded")
     ExecutorImpl.swift
     PlatformExecutorCooperative.swift
     )
+elseif("${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "wasi")
+  # Multithreaded default executor for wasm32-unknown-wasip1-threads: a pool of
+  # wasi-threads worker threads (WASIGlobalExecutor.cpp) fronted by the Swift
+  # executors in PlatformExecutorWASI.swift.
+  set(SWIFT_RUNTIME_CONCURRENCY_EXECUTOR_SOURCES
+    WASIGlobalExecutor.cpp
+  )
+  set(SWIFT_RUNTIME_CONCURRENCY_NONEMBEDDED_SWIFT_SOURCES
+    ExecutorImpl.swift
+    PlatformExecutorWASI.swift
+  )
 else()
   set(SWIFT_RUNTIME_CONCURRENCY_NONEMBEDDED_SWIFT_SOURCES
     ExecutorImpl.swift
@@ -202,6 +214,7 @@ endif()
 set(LLVM_OPTIONAL_SOURCES
   DispatchGlobalExecutor.cpp
   CooperativeGlobalExecutor.cpp
+  WASIGlobalExecutor.cpp
   DispatchGlobalExecutor.cpp
   CFExecutor.cpp
 )

--- a/stdlib/public/Concurrency/PlatformExecutorWASI.swift
+++ b/stdlib/public/Concurrency/PlatformExecutorWASI.swift
@@ -1,0 +1,137 @@
+//===--- PlatformExecutorWASI.swift ---------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// The default executors for `wasm32-unknown-wasip1-threads`.
+//
+// Unlike the single-threaded WebAssembly build (which uses the cooperative
+// executor), the threads triple has shared memory, atomics and `thread_spawn`,
+// so the global/default executor can fan `Task`, `TaskGroup` and `async let`
+// work out across a pool of worker threads. These types are thin wrappers over
+// the C helpers in `WASIGlobalExecutor.cpp`, mirroring how `DispatchExecutor`
+// wraps libdispatch on Darwin and Linux.
+//
+//===----------------------------------------------------------------------===//
+
+// This file is only added to the build for the wasi-threads triple (see the
+// `wasi` branch of the `SWIFT_CONCURRENCY_GLOBAL_EXECUTOR` selection in
+// `CMakeLists.txt`); the `os(WASI)` guard is belt-and-suspenders.
+#if os(WASI)
+
+import Swift
+
+// .. Main executor ...........................................................
+
+/// The main-thread executor: a serial queue drained by the thread that runs
+/// the async `main`. Worker threads wake it when they resume a `@MainActor`
+/// continuation.
+@available(StdlibDeploymentTarget 6.3, *)
+final class WASIMainExecutor: RunLoopExecutor, @unchecked Sendable {
+  public init() {}
+
+  public func run() throws {
+    _wasiDrainMain()
+  }
+
+  public func stop() {
+    fatalError("WASIMainExecutor cannot be stopped")
+  }
+}
+
+@available(StdlibDeploymentTarget 6.3, *)
+extension WASIMainExecutor: SerialExecutor {
+  public func enqueue(_ job: consuming ExecutorJob) {
+    _wasiEnqueueMain(UnownedJob(job))
+  }
+
+  public func checkIsolated() {
+    // The runtime performs its own main-actor isolation checking; there is no
+    // cheap "am I the main thread" probe to assert against on WASI.
+  }
+}
+
+@available(StdlibDeploymentTarget 6.3, *)
+extension WASIMainExecutor: MainExecutor {}
+
+// .. Global (default) executor ...............................................
+
+/// The concurrent default executor: jobs are handed to a pool of wasi-threads
+/// worker threads.
+@available(StdlibDeploymentTarget 6.3, *)
+final class WASIGlobalExecutor: TaskExecutor, SchedulingExecutor,
+                                @unchecked Sendable {
+  public init() {}
+
+  public func enqueue(_ job: consuming ExecutorJob) {
+    _wasiEnqueueGlobal(UnownedJob(job))
+  }
+
+  public func enqueue<C: Clock>(_ job: consuming ExecutorJob,
+                                at instant: C.Instant,
+                                tolerance: C.Duration? = nil,
+                                clock: C) {
+    // Schedule relative to the supplied clock; the backend only needs the delay
+    // in nanoseconds (it waits on a monotonic deadline).
+    let delay = clock.now.duration(to: instant)
+    _wasiEnqueueGlobalWithDelay(_nanoseconds(from: delay, clock: clock),
+                                UnownedJob(job))
+  }
+}
+
+@available(StdlibDeploymentTarget 6.3, *)
+fileprivate func _nanoseconds<C: Clock>(from duration: C.Duration,
+                                        clock: C) -> Int64 {
+  let swiftDuration: Swift.Duration
+  if clock is ContinuousClock {
+    swiftDuration = duration as! ContinuousClock.Duration
+  } else if clock is SuspendingClock {
+    swiftDuration = duration as! SuspendingClock.Duration
+  } else {
+    // Best effort for other clocks: treat the duration as already in seconds.
+    return 0
+  }
+  let (seconds, attoseconds) = swiftDuration.components
+  if seconds < 0 || (seconds == 0 && attoseconds < 0) {
+    return 0
+  }
+  let ns = seconds &* 1_000_000_000 &+ (attoseconds / 1_000_000_000)
+  return ns
+}
+
+// .. Factory .................................................................
+
+@_spi(ExperimentalCustomExecutors)
+@available(StdlibDeploymentTarget 6.3, *)
+public struct PlatformExecutorFactory: ExecutorFactory {
+  public static let mainExecutor: any MainExecutor = WASIMainExecutor()
+  public static let defaultExecutor: any TaskExecutor = WASIGlobalExecutor()
+}
+
+// .. C runtime helpers (WASIGlobalExecutor.cpp) ..............................
+
+@available(StdlibDeploymentTarget 6.3, *)
+@_silgen_name("swift_wasiEnqueueGlobal")
+internal func _wasiEnqueueGlobal(_ job: UnownedJob)
+
+@available(StdlibDeploymentTarget 6.3, *)
+@_silgen_name("swift_wasiEnqueueGlobalWithDelay")
+internal func _wasiEnqueueGlobalWithDelay(_ delayNanoseconds: Int64,
+                                          _ job: UnownedJob)
+
+@available(StdlibDeploymentTarget 6.3, *)
+@_silgen_name("swift_wasiEnqueueMain")
+internal func _wasiEnqueueMain(_ job: UnownedJob)
+
+@available(StdlibDeploymentTarget 6.3, *)
+@_silgen_name("swift_wasiDrainMain")
+internal func _wasiDrainMain()
+
+#endif // os(WASI)

--- a/stdlib/public/Concurrency/WASIGlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/WASIGlobalExecutor.cpp
@@ -1,0 +1,285 @@
+//===--- WASIGlobalExecutor.cpp - WebAssembly global executor -------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// A multithreaded global executor for `wasm32-unknown-wasip1-threads`.
+//
+// The single-threaded WebAssembly build uses the cooperative executor, which
+// drains every job on the thread that started the program: `Task`, `TaskGroup`
+// and `async let` therefore never run in parallel. On the wasi-threads triple
+// (shared memory + atomics + `thread_spawn`) we can do better.
+//
+// This file provides the C helpers that `PlatformExecutorWASI.swift` calls:
+//
+//   * `swift_wasiEnqueueGlobal`  - hand a job to a pool of worker threads.
+//   * `swift_wasiEnqueueGlobalWithDelay` / `...WithDeadline` - schedule a job
+//     to run on the pool once a deadline elapses.
+//   * `swift_wasiEnqueueMain`    - hand a job to the main thread's queue.
+//   * `swift_wasiDrainMain`      - run the main thread's queue forever (the
+//     body of `MainExecutor.run()` for the async `main`).
+//
+// The main-thread queue and the concurrent pool each guard their job queue
+// with a mutex and a condition variable, so a worker thread that resumes a
+// `@MainActor` continuation can wake the blocked main thread (the liveness
+// property the single-threaded cooperative run loop cannot provide across
+// threads).
+//
+// The design mirrors DispatchGlobalExecutor.cpp (which backs the Swift
+// executors on Darwin/Linux with libdispatch); here the backing is raw
+// pthreads via the C++ standard threading facilities, which wasi-libc provides
+// for the threads triple.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/shims/Visibility.h"
+
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include <errno.h>
+
+#include "swift/Basic/PriorityQueue.h"
+#include "swift/Runtime/Heap.h"
+
+#include "ExecutorImpl.h"
+
+using namespace swift;
+
+namespace {
+
+// Intrusive linkage: reuse the job's first scheduler-private word as the "next"
+// pointer, exactly as the cooperative and dispatch executors do.
+struct JobQueueTraits {
+  static SwiftJob *&storage(SwiftJob *cur) {
+    return reinterpret_cast<SwiftJob *&>(cur->schedulerPrivate[0]);
+  }
+
+  static SwiftJob *getNext(SwiftJob *job) { return storage(job); }
+  static void setNext(SwiftJob *job, SwiftJob *next) { storage(job) = next; }
+
+  enum { prioritiesCount = SwiftJobPriorityBucketCount };
+  static int getPriorityIndex(SwiftJob *job) {
+    return swift_priority_getBucketIndex(swift_job_getPriority(job));
+  }
+};
+using JobPriorityQueue = PriorityQueue<SwiftJob *, JobQueueTraits>;
+
+using JobDeadline = std::chrono::time_point<std::chrono::steady_clock>;
+
+// The deadline of a delayed job is stashed in its second scheduler-private
+// word. On wasm32 a pointer is 4 bytes while `JobDeadline` (a steady_clock
+// time_point) is 8, so it does not fit inline and must be heap-indirected;
+// the two specializations pick the right strategy at compile time (matching
+// CooperativeGlobalExecutor.cpp).
+template <bool = (sizeof(JobDeadline) <= sizeof(void *) &&
+                  alignof(JobDeadline) <= alignof(void *))>
+struct JobDeadlineStorage;
+
+/// The deadline fits in schedulerPrivate.
+template <>
+struct JobDeadlineStorage<true> {
+  static JobDeadline &storage(SwiftJob *job) {
+    return reinterpret_cast<JobDeadline &>(job->schedulerPrivate[1]);
+  }
+  static JobDeadline get(SwiftJob *job) { return storage(job); }
+  static void set(SwiftJob *job, JobDeadline deadline) {
+    new (static_cast<void *>(&storage(job))) JobDeadline(deadline);
+  }
+  static void destroy(SwiftJob *job) { storage(job).~JobDeadline(); }
+};
+
+/// The deadline does not fit in schedulerPrivate; store it out of line.
+template <>
+struct JobDeadlineStorage<false> {
+  static JobDeadline *&storage(SwiftJob *job) {
+    return reinterpret_cast<JobDeadline *&>(job->schedulerPrivate[1]);
+  }
+  static JobDeadline get(SwiftJob *job) { return *storage(job); }
+  static void set(SwiftJob *job, JobDeadline deadline) {
+    storage(job) = swift_cxx_newObject<JobDeadline>(deadline);
+  }
+  static void destroy(SwiftJob *job) { swift_cxx_deleteObject(storage(job)); }
+};
+
+// A concurrent global executor: N worker threads draining a shared, priority-
+// ordered ready queue, plus a deadline-ordered list of delayed jobs.
+class WASIConcurrentExecutor {
+  std::mutex Mutex;
+  std::condition_variable Ready;
+  JobPriorityQueue ReadyQueue;
+  SwiftJob *DelayedQueue = nullptr; // singly linked, earliest deadline first
+  std::vector<std::thread> Workers;
+  bool Started = false;
+
+  static unsigned workerCount() {
+    unsigned n = std::thread::hardware_concurrency();
+    return n ? n : 4;
+  }
+
+  void insertDelayed(SwiftJob *newJob, JobDeadline deadline) {
+    SwiftJob **position = &DelayedQueue;
+    while (auto cur = *position) {
+      if (deadline < JobDeadlineStorage<>::get(cur)) {
+        JobQueueTraits::setNext(newJob, cur);
+        *position = newJob;
+        return;
+      }
+      position = &JobQueueTraits::storage(cur);
+    }
+    JobQueueTraits::setNext(newJob, nullptr);
+    *position = newJob;
+  }
+
+  // Move any delayed jobs whose deadline has passed into the ready queue.
+  // Returns the next unexpired deadline, if the delayed list is non-empty.
+  bool promoteReadyDelayedJobs(JobDeadline &nextDeadline) {
+    auto now = std::chrono::steady_clock::now();
+    while (DelayedQueue &&
+           JobDeadlineStorage<>::get(DelayedQueue) <= now) {
+      auto job = DelayedQueue;
+      DelayedQueue = JobQueueTraits::getNext(job);
+      JobDeadlineStorage<>::destroy(job);
+      ReadyQueue.enqueue(job);
+    }
+    if (DelayedQueue) {
+      nextDeadline = JobDeadlineStorage<>::get(DelayedQueue);
+      return true;
+    }
+    return false;
+  }
+
+  void workerLoop() {
+    std::unique_lock<std::mutex> lock(Mutex);
+    while (true) {
+      JobDeadline nextDeadline;
+      bool haveDelayed = promoteReadyDelayedJobs(nextDeadline);
+
+      if (auto job = ReadyQueue.dequeue()) {
+        lock.unlock();
+        swift_job_run(job, swift_executor_generic());
+        lock.lock();
+        continue;
+      }
+
+      if (haveDelayed) {
+        Ready.wait_until(lock, nextDeadline);
+      } else {
+        Ready.wait(lock);
+      }
+    }
+  }
+
+  void startIfNeeded() {
+    if (Started)
+      return;
+    Started = true;
+    unsigned n = workerCount();
+    Workers.reserve(n);
+    for (unsigned i = 0; i < n; ++i)
+      Workers.emplace_back([this] { workerLoop(); });
+  }
+
+public:
+  void enqueue(SwiftJob *job) {
+    std::lock_guard<std::mutex> lock(Mutex);
+    startIfNeeded();
+    ReadyQueue.enqueue(job);
+    Ready.notify_one();
+  }
+
+  void enqueueAfter(SwiftJob *job, JobDeadline deadline) {
+    std::lock_guard<std::mutex> lock(Mutex);
+    startIfNeeded();
+    JobDeadlineStorage<>::set(job, deadline);
+    insertDelayed(job, deadline);
+    // A new, possibly-earlier deadline changes how long a worker should sleep.
+    Ready.notify_all();
+  }
+};
+
+// The main-thread executor: a single serial queue drained by the thread that
+// runs the async `main`. Worker threads enqueue `@MainActor` continuations here
+// and wake the main thread through `MainReady`.
+class WASIMainExecutor {
+  std::mutex Mutex;
+  std::condition_variable MainReady;
+  JobPriorityQueue Queue;
+
+public:
+  void enqueue(SwiftJob *job) {
+    std::lock_guard<std::mutex> lock(Mutex);
+    Queue.enqueue(job);
+    MainReady.notify_one();
+  }
+
+  SWIFT_RUNTIME_ATTRIBUTE_NORETURN void drain() {
+    std::unique_lock<std::mutex> lock(Mutex);
+    while (true) {
+      if (auto job = Queue.dequeue()) {
+        lock.unlock();
+        swift_job_run(job, swift_executor_generic());
+        lock.lock();
+        continue;
+      }
+      MainReady.wait(lock);
+    }
+  }
+};
+
+WASIConcurrentExecutor GlobalExecutor;
+WASIMainExecutor MainExecutor;
+
+JobDeadline deadlineFromNanoseconds(long long nanoseconds) {
+  if (nanoseconds < 0)
+    nanoseconds = 0;
+  return std::chrono::steady_clock::now() +
+         std::chrono::duration_cast<JobDeadline::duration>(
+             std::chrono::nanoseconds(nanoseconds));
+}
+
+} // end anonymous namespace
+
+extern "C" SWIFT_CC(swift) void swift_wasiEnqueueGlobal(SwiftJob *job) {
+  assert(job && "no job provided");
+  GlobalExecutor.enqueue(job);
+}
+
+extern "C" SWIFT_CC(swift)
+void swift_wasiEnqueueGlobalWithDelay(long long delayNanoseconds,
+                                      SwiftJob *job) {
+  assert(job && "no job provided");
+  GlobalExecutor.enqueueAfter(job, deadlineFromNanoseconds(delayNanoseconds));
+}
+
+extern "C" SWIFT_CC(swift)
+void swift_wasiEnqueueGlobalWithDeadline(long long sec, long long nsec,
+                                         long long /*tsec*/,
+                                         long long /*tnsec*/, int clock,
+                                         SwiftJob *job) {
+  assert(job && "no job provided");
+  SwiftTime now = swift_time_now(clock);
+  long long delta =
+      (sec - now.seconds) * 1000000000ll + nsec - now.nanoseconds;
+  GlobalExecutor.enqueueAfter(job, deadlineFromNanoseconds(delta));
+}
+
+extern "C" SWIFT_CC(swift) void swift_wasiEnqueueMain(SwiftJob *job) {
+  assert(job && "no job provided");
+  MainExecutor.enqueue(job);
+}
+
+extern "C" SWIFT_RUNTIME_ATTRIBUTE_NORETURN SWIFT_CC(swift)
+void swift_wasiDrainMain() {
+  MainExecutor.drain();
+}

--- a/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
@@ -308,3 +308,14 @@ class WasmThreadsStdlib(WasmStdlib):
                                   '-Xcc;-mthread-model;-Xcc;posix;'
                                   '-Xcc;-pthread;-Xcc;-ftls-model=local-exec')
         self.cmake_options.define('SWIFT_ENABLE_WASI_THREADS:BOOL', 'TRUE')
+        # The threads triple has real OS threads (shared memory + atomics +
+        # thread_spawn), so Swift Concurrency should use a multithreaded global
+        # executor rather than the single-threaded cooperative one the plain
+        # wasip1 stdlib inherits. Disable the single-threaded default and select
+        # the WASI thread-pool executor (stdlib/public/Concurrency/
+        # PlatformExecutorWASI.swift + WASIGlobalExecutor.cpp). This is what lets
+        # Task / TaskGroup / async let fan out across wasi threads.
+        self.cmake_options.define(
+            'SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY:BOOL', 'FALSE')
+        self.cmake_options.define(
+            'SWIFT_CONCURRENCY_GLOBAL_EXECUTOR:STRING', 'wasi')


### PR DESCRIPTION
## What

Adds a real **multithreaded global executor** for the `wasm32-unknown-wasip1-threads` triple, so idiomatic Swift Concurrency (`Task`, `TaskGroup`, `async let`) fans out across wasi threads instead of running one job at a time.

## Why

The wasi-threads triple (shared memory + atomics + `thread_spawn`) already links the pthreads threading package, so locks/atomics run across real OS threads. But the concurrency runtime still selects the **single-threaded cooperative** global executor inherited from the plain `wasm32-unknown-wasip1` stdlib, so `async` work never parallelizes — every job drains on the thread that started the program.

## How

Modeled on the Dispatch executor, but backed by raw pthreads (via the C++ standard threading facilities wasi-libc provides for `-mthread-model posix`):

- **`stdlib/public/Concurrency/WASIGlobalExecutor.cpp`** — a pool of worker threads draining a shared, priority-ordered ready queue (+ a deadline-ordered delayed-job list for scheduled work), and a condition-variable-woken main-thread queue. A worker that resumes a `@MainActor` continuation wakes the blocked main thread — the cross-thread liveness the cooperative run loop can't provide. Reuses the existing `SwiftJob` intrusive-queue / `PriorityQueue` machinery.
- **`stdlib/public/Concurrency/PlatformExecutorWASI.swift`** — the `ExecutorFactory` (main + default executors), thin wrappers over the C helpers, mirroring `DispatchExecutor.swift`.

Selection is **opt-in** via a new `wasi` value for `SWIFT_CONCURRENCY_GLOBAL_EXECUTOR` (`Concurrency/CMakeLists.txt`, `StdlibOptions.cmake`). The wasi-threads stdlib product turns it on (`wasmstdlib.py`: `SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY=FALSE` + `SWIFT_CONCURRENCY_GLOBAL_EXECUTOR=wasi`). The single-threaded `wasm32-unknown-wasip1` build is **unchanged** and keeps the cooperative executor.

## Validation

Built against `swift-6.3.2-RELEASE` (hence the `release/6.3` base): `WASIGlobalExecutor.cpp` and `PlatformExecutorWASI.swift` compile for `wasm32-unknown-wasip1-threads` and link into `libswift_Concurrency.a` for the threads stdlib. A `TaskGroup` probe compiles against the resulting stdlib. Full runtime execution needs the CI's assembled SDK + a threads-capable runtime — please run:

```
@swift-ci Please test WebAssembly
```

Happy to rebase onto `main` if preferred; the executor sources are identical there and the build-config change moves to `wasistdlib.py`.

> Draft: opening for CI + design feedback from the concurrency/WebAssembly folks. Marked draft until the WebAssembly CI run is green.