### PR TITLE
[Concurrency] Multithreaded global executor for wasm32-unknown-wasip1-threads

### DIFF
--- a/Runtimes/Core/Concurrency/wasi.cmake
+++ b/Runtimes/Core/Concurrency/wasi.cmake
@@ -1,0 +1,19 @@
+# The multithreaded default executor for wasm32-unknown-wasip1-threads: a pool
+# of wasi-threads worker threads (WASIGlobalExecutor.cpp) fronted by the Swift
+# executors in WASIExecutor.swift. Only meaningful for the threads triple —
+# real threads and a runtime that is not single-threaded.
+if(NOT WASI)
+  message(SEND_ERROR "The wasi global executor is only supported when targeting WASI")
+endif()
+if(NOT SwiftCore_THREADING_PACKAGE STREQUAL "PTHREADS")
+  message(SEND_ERROR "The wasi global executor requires SwiftCore_THREADING_PACKAGE=PTHREADS (wasm32-unknown-wasip1-threads)")
+endif()
+if(SwiftCore_SINGLE_THREADED_CONCURRENCY)
+  message(SEND_ERROR "Cannot enable the wasi global executor with SwiftCore_SINGLE_THREADED_CONCURRENCY")
+endif()
+
+target_sources(swift_Concurrency PRIVATE
+  WASIGlobalExecutor.cpp
+  ExecutorImpl.swift
+  WASIExecutor.swift
+  PlatformExecutorWASI.swift)

--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -208,6 +208,22 @@ if("${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "singlethreaded"
   message(SEND_ERROR "Cannot enable the single-threaded global executor without enabling SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY")
 endif()
 
+if("${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "wasi")
+  # The WASI thread-pool executor is only meaningful for the wasi-threads
+  # triple: it needs real threads (the pthreads threading package) and a
+  # runtime that is not compiled single-threaded, or every worker looks like
+  # the main thread to the actor runtime.
+  if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "WASI")
+    message(SEND_ERROR "The wasi global executor is only supported when targeting WASI (CMAKE_SYSTEM_NAME is \"${CMAKE_SYSTEM_NAME}\")")
+  endif()
+  if(NOT "${SWIFT_THREADING_PACKAGE}" STREQUAL "pthreads")
+    message(SEND_ERROR "The wasi global executor requires SWIFT_THREADING_PACKAGE=pthreads (wasm32-unknown-wasip1-threads), not \"${SWIFT_THREADING_PACKAGE}\"")
+  endif()
+  if(SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY)
+    message(SEND_ERROR "Cannot enable the wasi global executor with SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY")
+  endif()
+endif()
+
 if(SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY)
   if(SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY)
     message(SEND_ERROR "Cannot use the single-threaded concurrency with task-to-thread concurrency model")

--- a/stdlib/cmake/modules/StdlibOptions.cmake
+++ b/stdlib/cmake/modules/StdlibOptions.cmake
@@ -241,7 +241,7 @@ endif() # SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY
 
 set(SWIFT_CONCURRENCY_GLOBAL_EXECUTOR
     "${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR_default}" CACHE STRING
-    "Build the concurrency library to use the given global executor (options: none, dispatch, singlethreaded, hooked)")
+    "Build the concurrency library to use the given global executor (options: none, dispatch, singlethreaded, hooked, wasi)")
 
 option(SWIFT_STDLIB_OS_VERSIONING
        "Build stdlib with availability based on OS versions (Darwin only)."

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -49,7 +49,8 @@ if("${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "dispatch")
   endif()
 elseif("${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "singlethreaded" OR
        "${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "hooked" OR
-       "${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "none")
+       "${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "none" OR
+       "${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "wasi")
   list(APPEND SWIFT_RUNTIME_CONCURRENCY_C_FLAGS
     "-DSWIFT_CONCURRENCY_ENABLE_DISPATCH=0")
 else()
@@ -208,6 +209,17 @@ elseif("${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "singlethreaded")
     ExecutorImpl.swift
     PlatformExecutorCooperative.swift
     )
+elseif("${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "wasi")
+  # Multithreaded default executor for wasm32-unknown-wasip1-threads: a pool of
+  # wasi-threads worker threads (WASIGlobalExecutor.cpp) fronted by the Swift
+  # executors in PlatformExecutorWASI.swift.
+  set(SWIFT_RUNTIME_CONCURRENCY_EXECUTOR_SOURCES
+    WASIGlobalExecutor.cpp
+  )
+  set(SWIFT_RUNTIME_CONCURRENCY_NONEMBEDDED_SWIFT_SOURCES
+    ExecutorImpl.swift
+    PlatformExecutorWASI.swift
+  )
 else()
   set(SWIFT_RUNTIME_CONCURRENCY_NONEMBEDDED_SWIFT_SOURCES
     ExecutorImpl.swift
@@ -218,6 +230,7 @@ endif()
 set(LLVM_OPTIONAL_SOURCES
   DispatchGlobalExecutor.cpp
   CooperativeGlobalExecutor.cpp
+  WASIGlobalExecutor.cpp
   DispatchGlobalExecutor.cpp
   CFExecutor.cpp
 )

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -225,6 +225,7 @@ elseif("${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "wasi")
   )
   set(SWIFT_RUNTIME_CONCURRENCY_NONEMBEDDED_SWIFT_SOURCES
     ExecutorImpl.swift
+    WASIExecutor.swift
     PlatformExecutorWASI.swift
   )
 else()

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -49,7 +49,8 @@ if("${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "dispatch")
   endif()
 elseif("${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "singlethreaded" OR
        "${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "hooked" OR
-       "${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "none")
+       "${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "none" OR
+       "${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "wasi")
   list(APPEND SWIFT_RUNTIME_CONCURRENCY_C_FLAGS
     "-DSWIFT_CONCURRENCY_ENABLE_DISPATCH=0")
 else()
@@ -215,6 +216,17 @@ elseif("${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "singlethreaded")
     ExecutorImpl.swift
     PlatformExecutorCooperative.swift
     )
+elseif("${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "wasi")
+  # Multithreaded default executor for wasm32-unknown-wasip1-threads: a pool of
+  # wasi-threads worker threads (WASIGlobalExecutor.cpp) fronted by the Swift
+  # executors in PlatformExecutorWASI.swift.
+  set(SWIFT_RUNTIME_CONCURRENCY_EXECUTOR_SOURCES
+    WASIGlobalExecutor.cpp
+  )
+  set(SWIFT_RUNTIME_CONCURRENCY_NONEMBEDDED_SWIFT_SOURCES
+    ExecutorImpl.swift
+    PlatformExecutorWASI.swift
+  )
 else()
   set(SWIFT_RUNTIME_CONCURRENCY_NONEMBEDDED_SWIFT_SOURCES
     ExecutorImpl.swift
@@ -225,6 +237,7 @@ endif()
 set(LLVM_OPTIONAL_SOURCES
   DispatchGlobalExecutor.cpp
   CooperativeGlobalExecutor.cpp
+  WASIGlobalExecutor.cpp
   DispatchGlobalExecutor.cpp
   CFExecutor.cpp
 )

--- a/stdlib/public/Concurrency/ExecutorBridge.swift
+++ b/stdlib/public/Concurrency/ExecutorBridge.swift
@@ -138,6 +138,35 @@ internal func _dispatchEnqueueWithDeadline(_ global: CBool,
 @_silgen_name("swift_dispatchAssertMainQueue")
 internal func _dispatchAssertMainQueue()
 
+#if os(WASI)
+// The wasm32-unknown-wasip1-threads thread-pool executors
+// (WASIGlobalExecutor.cpp / WASIExecutor.swift).
+
+@available(StdlibDeploymentTarget 6.3, *)
+@_silgen_name("swift_wasiEnqueueGlobal")
+internal func _wasiEnqueueGlobal(_ job: UnownedJob)
+
+@available(StdlibDeploymentTarget 6.3, *)
+@_silgen_name("swift_wasiEnqueueGlobalWithDelay")
+internal func _wasiEnqueueGlobalWithDelay(_ sec: CLongLong,
+                                          _ nsec: CLongLong,
+                                          _ clock: CInt,
+                                          _ job: UnownedJob)
+
+@available(StdlibDeploymentTarget 6.3, *)
+@_silgen_name("swift_wasiEnqueueMain")
+internal func _wasiEnqueueMain(_ job: UnownedJob)
+
+/// Blocks until the main queue has a job, then dequeues it.
+@available(StdlibDeploymentTarget 6.3, *)
+@_silgen_name("swift_wasiWaitForMainJob")
+internal func _wasiWaitForMainJob() -> UnownedJob
+
+@available(StdlibDeploymentTarget 6.3, *)
+@_silgen_name("swift_wasiIsMainThread")
+internal func _wasiIsMainThread() -> Bool
+#endif
+
 @_silgen_name("swift_createDefaultExecutorsOnce")
 func _createDefaultExecutorsOnce()
 

--- a/stdlib/public/Concurrency/PlatformExecutorWASI.swift
+++ b/stdlib/public/Concurrency/PlatformExecutorWASI.swift
@@ -1,0 +1,137 @@
+//===--- PlatformExecutorWASI.swift ---------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// The default executors for `wasm32-unknown-wasip1-threads`.
+//
+// Unlike the single-threaded WebAssembly build (which uses the cooperative
+// executor), the threads triple has shared memory, atomics and `thread_spawn`,
+// so the global/default executor can fan `Task`, `TaskGroup` and `async let`
+// work out across a pool of worker threads. These types are thin wrappers over
+// the C helpers in `WASIGlobalExecutor.cpp`, mirroring how `DispatchExecutor`
+// wraps libdispatch on Darwin and Linux.
+//
+//===----------------------------------------------------------------------===//
+
+// This file is only added to the build for the wasi-threads triple (see the
+// `wasi` branch of the `SWIFT_CONCURRENCY_GLOBAL_EXECUTOR` selection in
+// `CMakeLists.txt`); the `os(WASI)` guard is belt-and-suspenders.
+#if os(WASI)
+
+import Swift
+
+// .. Main executor ...........................................................
+
+/// The main-thread executor: a serial queue drained by the thread that runs
+/// the async `main`. Worker threads wake it when they resume a `@MainActor`
+/// continuation.
+@available(StdlibDeploymentTarget 6.3, *)
+final class WASIMainExecutor: RunLoopExecutor, @unchecked Sendable {
+  public init() {}
+
+  public func run() throws {
+    _wasiDrainMain()
+  }
+
+  public func stop() {
+    fatalError("WASIMainExecutor cannot be stopped")
+  }
+}
+
+@available(StdlibDeploymentTarget 6.3, *)
+extension WASIMainExecutor: SerialExecutor {
+  public func enqueue(_ job: consuming ExecutorJob) {
+    _wasiEnqueueMain(UnownedJob(job))
+  }
+
+  public func checkIsolated() {
+    // The runtime performs its own main-actor isolation checking; there is no
+    // cheap "am I the main thread" probe to assert against on WASI.
+  }
+}
+
+@available(StdlibDeploymentTarget 6.3, *)
+extension WASIMainExecutor: MainExecutor {}
+
+// .. Global (default) executor ...............................................
+
+/// The concurrent default executor: jobs are handed to a pool of wasi-threads
+/// worker threads.
+@available(StdlibDeploymentTarget 6.3, *)
+final class WASIGlobalExecutor: TaskExecutor, SchedulingExecutor,
+                                @unchecked Sendable {
+  public init() {}
+
+  public func enqueue(_ job: consuming ExecutorJob) {
+    _wasiEnqueueGlobal(UnownedJob(job))
+  }
+
+  public func enqueue<C: Clock>(_ job: consuming ExecutorJob,
+                                at instant: C.Instant,
+                                tolerance: C.Duration? = nil,
+                                clock: C) {
+    // Schedule relative to the supplied clock; the backend only needs the delay
+    // in nanoseconds (it waits on a monotonic deadline).
+    let delay = clock.now.duration(to: instant)
+    _wasiEnqueueGlobalWithDelay(_nanoseconds(from: delay, clock: clock),
+                                UnownedJob(job))
+  }
+}
+
+@available(StdlibDeploymentTarget 6.3, *)
+fileprivate func _nanoseconds<C: Clock>(from duration: C.Duration,
+                                        clock: C) -> Int64 {
+  let swiftDuration: Swift.Duration
+  if clock is ContinuousClock {
+    swiftDuration = duration as! ContinuousClock.Duration
+  } else if clock is SuspendingClock {
+    swiftDuration = duration as! SuspendingClock.Duration
+  } else {
+    // Best effort for other clocks: treat the duration as already in seconds.
+    return 0
+  }
+  let (seconds, attoseconds) = swiftDuration.components
+  if seconds < 0 || (seconds == 0 && attoseconds < 0) {
+    return 0
+  }
+  let ns = seconds &* 1_000_000_000 &+ (attoseconds / 1_000_000_000)
+  return ns
+}
+
+// .. Factory .................................................................
+
+@_spi(ExperimentalCustomExecutors)
+@available(StdlibDeploymentTarget 6.3, *)
+public struct PlatformExecutorFactory: ExecutorFactory {
+  public static let mainExecutor: any MainExecutor = WASIMainExecutor()
+  public static let defaultExecutor: any TaskExecutor = WASIGlobalExecutor()
+}
+
+// .. C runtime helpers (WASIGlobalExecutor.cpp) ..............................
+
+@available(StdlibDeploymentTarget 6.3, *)
+@_silgen_name("swift_wasiEnqueueGlobal")
+internal func _wasiEnqueueGlobal(_ job: UnownedJob)
+
+@available(StdlibDeploymentTarget 6.3, *)
+@_silgen_name("swift_wasiEnqueueGlobalWithDelay")
+internal func _wasiEnqueueGlobalWithDelay(_ delayNanoseconds: Int64,
+                                          _ job: UnownedJob)
+
+@available(StdlibDeploymentTarget 6.3, *)
+@_silgen_name("swift_wasiEnqueueMain")
+internal func _wasiEnqueueMain(_ job: UnownedJob)
+
+@available(StdlibDeploymentTarget 6.3, *)
+@_silgen_name("swift_wasiDrainMain")
+internal func _wasiDrainMain()
+
+#endif // os(WASI)

--- a/stdlib/public/Concurrency/PlatformExecutorWASI.swift
+++ b/stdlib/public/Concurrency/PlatformExecutorWASI.swift
@@ -2,136 +2,25 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-//
-// The default executors for `wasm32-unknown-wasip1-threads`.
-//
-// Unlike the single-threaded WebAssembly build (which uses the cooperative
-// executor), the threads triple has shared memory, atomics and `thread_spawn`,
-// so the global/default executor can fan `Task`, `TaskGroup` and `async let`
-// work out across a pool of worker threads. These types are thin wrappers over
-// the C helpers in `WASIGlobalExecutor.cpp`, mirroring how `DispatchExecutor`
-// wraps libdispatch on Darwin and Linux.
-//
-//===----------------------------------------------------------------------===//
 
-// This file is only added to the build for the wasi-threads triple (see the
-// `wasi` branch of the `SWIFT_CONCURRENCY_GLOBAL_EXECUTOR` selection in
-// `CMakeLists.txt`); the `os(WASI)` guard is belt-and-suspenders.
 #if os(WASI)
 
 import Swift
 
-// .. Main executor ...........................................................
-
-/// The main-thread executor: a serial queue drained by the thread that runs
-/// the async `main`. Worker threads wake it when they resume a `@MainActor`
-/// continuation.
-@available(StdlibDeploymentTarget 6.3, *)
-final class WASIMainExecutor: RunLoopExecutor, @unchecked Sendable {
-  public init() {}
-
-  public func run() throws {
-    _wasiDrainMain()
-  }
-
-  public func stop() {
-    fatalError("WASIMainExecutor cannot be stopped")
-  }
-}
-
-@available(StdlibDeploymentTarget 6.3, *)
-extension WASIMainExecutor: SerialExecutor {
-  public func enqueue(_ job: consuming ExecutorJob) {
-    _wasiEnqueueMain(UnownedJob(job))
-  }
-
-  public func checkIsolated() {
-    // The runtime performs its own main-actor isolation checking; there is no
-    // cheap "am I the main thread" probe to assert against on WASI.
-  }
-}
-
-@available(StdlibDeploymentTarget 6.3, *)
-extension WASIMainExecutor: MainExecutor {}
-
-// .. Global (default) executor ...............................................
-
-/// The concurrent default executor: jobs are handed to a pool of wasi-threads
-/// worker threads.
-@available(StdlibDeploymentTarget 6.3, *)
-final class WASIGlobalExecutor: TaskExecutor, SchedulingExecutor,
-                                @unchecked Sendable {
-  public init() {}
-
-  public func enqueue(_ job: consuming ExecutorJob) {
-    _wasiEnqueueGlobal(UnownedJob(job))
-  }
-
-  public func enqueue<C: Clock>(_ job: consuming ExecutorJob,
-                                at instant: C.Instant,
-                                tolerance: C.Duration? = nil,
-                                clock: C) {
-    // Schedule relative to the supplied clock; the backend only needs the delay
-    // in nanoseconds (it waits on a monotonic deadline).
-    let delay = clock.now.duration(to: instant)
-    _wasiEnqueueGlobalWithDelay(_nanoseconds(from: delay, clock: clock),
-                                UnownedJob(job))
-  }
-}
-
-@available(StdlibDeploymentTarget 6.3, *)
-fileprivate func _nanoseconds<C: Clock>(from duration: C.Duration,
-                                        clock: C) -> Int64 {
-  let swiftDuration: Swift.Duration
-  if clock is ContinuousClock {
-    swiftDuration = duration as! ContinuousClock.Duration
-  } else if clock is SuspendingClock {
-    swiftDuration = duration as! SuspendingClock.Duration
-  } else {
-    // Best effort for other clocks: treat the duration as already in seconds.
-    return 0
-  }
-  let (seconds, attoseconds) = swiftDuration.components
-  if seconds < 0 || (seconds == 0 && attoseconds < 0) {
-    return 0
-  }
-  let ns = seconds &* 1_000_000_000 &+ (attoseconds / 1_000_000_000)
-  return ns
-}
-
-// .. Factory .................................................................
-
+// The default executors for wasm32-unknown-wasip1-threads: the thread-pool
+// executors in WASIExecutor.swift.
 @_spi(ExperimentalCustomExecutors)
 @available(StdlibDeploymentTarget 6.3, *)
 public struct PlatformExecutorFactory: ExecutorFactory {
   public static let mainExecutor: any MainExecutor = WASIMainExecutor()
   public static let defaultExecutor: any TaskExecutor = WASIGlobalExecutor()
 }
-
-// .. C runtime helpers (WASIGlobalExecutor.cpp) ..............................
-
-@available(StdlibDeploymentTarget 6.3, *)
-@_silgen_name("swift_wasiEnqueueGlobal")
-internal func _wasiEnqueueGlobal(_ job: UnownedJob)
-
-@available(StdlibDeploymentTarget 6.3, *)
-@_silgen_name("swift_wasiEnqueueGlobalWithDelay")
-internal func _wasiEnqueueGlobalWithDelay(_ delayNanoseconds: Int64,
-                                          _ job: UnownedJob)
-
-@available(StdlibDeploymentTarget 6.3, *)
-@_silgen_name("swift_wasiEnqueueMain")
-internal func _wasiEnqueueMain(_ job: UnownedJob)
-
-@available(StdlibDeploymentTarget 6.3, *)
-@_silgen_name("swift_wasiDrainMain")
-internal func _wasiDrainMain()
 
 #endif // os(WASI)

--- a/stdlib/public/Concurrency/WASIExecutor.swift
+++ b/stdlib/public/Concurrency/WASIExecutor.swift
@@ -1,0 +1,129 @@
+//===--- WASIExecutor.swift -----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// The executors for `wasm32-unknown-wasip1-threads`.
+//
+// Unlike the single-threaded WebAssembly build (which uses the cooperative
+// executor), the threads triple has shared memory, atomics and `thread_spawn`,
+// so the default executor fans `Task`, `TaskGroup` and `async let` work out
+// across a pool of worker threads. These types are thin wrappers over the C
+// helpers in `WASIGlobalExecutor.cpp` (declared in ExecutorBridge.swift),
+// mirroring how `DispatchExecutor` wraps libdispatch on Darwin and Linux.
+//
+//===----------------------------------------------------------------------===//
+
+// Only compiled for the `wasi` global executor (stdlib/public/Concurrency/
+// CMakeLists.txt); the guard keeps a stray build from producing an empty
+// module with no `PlatformExecutorFactory`.
+#if os(WASI)
+
+import Swift
+
+// .. Main executor ...........................................................
+
+/// The main-thread executor: a serial queue drained by the thread that runs
+/// the async `main`. Worker threads wake it when they resume a `@MainActor`
+/// continuation.
+@available(StdlibDeploymentTarget 6.3, *)
+final class WASIMainExecutor: RunLoopExecutor, @unchecked Sendable {
+  var running = false
+
+  public init() {}
+
+  /// Drain the main queue forever. The loop lives here rather than in C so
+  /// every job runs with this executor as the active one (a `@MainActor`
+  /// function calling a `nonisolated async` function then hops to the pool
+  /// instead of running inline, and main-actor isolation checks take the
+  /// executor fast path).
+  public func run() throws {
+    if running {
+      fatalError("WASIMainExecutor does not support recursion")
+    }
+    running = true
+    while true {
+      let job = unsafe _wasiWaitForMainJob()
+      unsafe ExecutorJob(job).runSynchronously(on: asUnownedSerialExecutor())
+    }
+  }
+
+  public func stop() {
+    fatalError("WASIMainExecutor cannot be stopped")
+  }
+}
+
+@available(StdlibDeploymentTarget 6.3, *)
+extension WASIMainExecutor: SerialExecutor {
+  public func enqueue(_ job: consuming ExecutorJob) {
+    _wasiEnqueueMain(UnownedJob(job))
+  }
+
+  public func isIsolatingCurrentContext() -> Bool? {
+    // The threads triple builds with the pthreads threading package, so the
+    // runtime can tell the main thread apart from a pool worker.
+    _wasiIsMainThread()
+  }
+
+  public func checkIsolated() {
+    if !_wasiIsMainThread() {
+      fatalError("Incorrect actor executor assumption; expected the main "
+                 + "executor, but this code is running on a WASI thread-pool "
+                 + "worker")
+    }
+  }
+}
+
+@available(StdlibDeploymentTarget 6.3, *)
+extension WASIMainExecutor: MainExecutor {}
+
+// .. Global (default) executor ...............................................
+
+/// The concurrent default executor: jobs are handed to a pool of wasi-threads
+/// worker threads (`SWIFT_WASI_EXECUTOR_THREADS` overrides the pool size).
+@available(StdlibDeploymentTarget 6.3, *)
+final class WASIGlobalExecutor: TaskExecutor, SchedulingExecutor,
+                                @unchecked Sendable {
+  public init() {}
+
+  public func enqueue(_ job: consuming ExecutorJob) {
+    _wasiEnqueueGlobal(UnownedJob(job))
+  }
+
+  // The runtime schedules through the `after:` form (`enqueue(_:at:...)` is
+  // derived by the protocol default); `tolerance` is accepted but not used —
+  // the pool wakes at the deadline.
+  public func enqueue<C: Clock>(_ job: consuming ExecutorJob,
+                                after delay: C.Duration,
+                                tolerance: C.Duration? = nil,
+                                clock: C) {
+    let (clockID, seconds, nanoseconds) = _wasiDelayComponents(delay, clock: clock)
+    _wasiEnqueueGlobalWithDelay(CLongLong(seconds), CLongLong(nanoseconds),
+                                clockID.rawValue, UnownedJob(job))
+  }
+}
+
+/// The delay as (seconds, nanoseconds) on a clock the backend knows.
+@available(StdlibDeploymentTarget 6.3, *)
+fileprivate func _wasiDelayComponents<C: Clock>(_ delay: C.Duration, clock: C)
+  -> (clockID: _ClockID, seconds: Int64, nanoseconds: Int64) {
+  if let continuousClock = clock as? ContinuousClock {
+    let (seconds, nanoseconds) =
+      continuousClock.durationComponents(for: delay as! ContinuousClock.Duration)
+    return (.continuous, seconds, nanoseconds)
+  } else if let suspendingClock = clock as? SuspendingClock {
+    let (seconds, nanoseconds) =
+      suspendingClock.durationComponents(for: delay as! SuspendingClock.Duration)
+    return (.suspending, seconds, nanoseconds)
+  }
+  fatalError("Sorry, cannot schedule on an unknown clock")
+}
+
+#endif // os(WASI)

--- a/stdlib/public/Concurrency/WASIGlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/WASIGlobalExecutor.cpp
@@ -1,0 +1,290 @@
+//===--- WASIGlobalExecutor.cpp - WebAssembly global executor -------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// A multithreaded global executor for `wasm32-unknown-wasip1-threads`.
+//
+// The single-threaded WebAssembly build uses the cooperative executor, which
+// drains every job on the thread that started the program: `Task`, `TaskGroup`
+// and `async let` therefore never run in parallel. On the wasi-threads triple
+// (shared memory + atomics + `thread_spawn`) we can do better.
+//
+// This file provides the C helpers that `PlatformExecutorWASI.swift` calls:
+//
+//   * `swift_wasiEnqueueGlobal`  - hand a job to a pool of worker threads.
+//   * `swift_wasiEnqueueGlobalWithDelay` / `...WithDeadline` - schedule a job
+//     to run on the pool once a deadline elapses.
+//   * `swift_wasiEnqueueMain`    - hand a job to the main thread's queue.
+//   * `swift_wasiDrainMain`      - run the main thread's queue forever (the
+//     body of `MainExecutor.run()` for the async `main`).
+//
+// The main-thread queue and the concurrent pool each guard their job queue
+// with a mutex and a condition variable, so a worker thread that resumes a
+// `@MainActor` continuation can wake the blocked main thread (the liveness
+// property the single-threaded cooperative run loop cannot provide across
+// threads).
+//
+// The design mirrors DispatchGlobalExecutor.cpp (which backs the Swift
+// executors on Darwin/Linux with libdispatch); here the backing is raw
+// pthreads via the C++ standard threading facilities, which wasi-libc provides
+// for the threads triple.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/shims/Visibility.h"
+
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+#include <errno.h>
+
+#include "swift/Basic/PriorityQueue.h"
+#include "swift/Runtime/Heap.h"
+
+#include "ExecutorImpl.h"
+
+using namespace swift;
+
+namespace {
+
+// Intrusive linkage: reuse the job's first scheduler-private word as the "next"
+// pointer, exactly as the cooperative and dispatch executors do.
+struct JobQueueTraits {
+  static SwiftJob *&storage(SwiftJob *cur) {
+    return reinterpret_cast<SwiftJob *&>(cur->schedulerPrivate[0]);
+  }
+
+  static SwiftJob *getNext(SwiftJob *job) { return storage(job); }
+  static void setNext(SwiftJob *job, SwiftJob *next) { storage(job) = next; }
+
+  enum { prioritiesCount = SwiftJobPriorityBucketCount };
+  static int getPriorityIndex(SwiftJob *job) {
+    return swift_priority_getBucketIndex(swift_job_getPriority(job));
+  }
+};
+using JobPriorityQueue = PriorityQueue<SwiftJob *, JobQueueTraits>;
+
+using JobDeadline = std::chrono::time_point<std::chrono::steady_clock>;
+
+// The deadline of a delayed job is stashed in its second scheduler-private
+// word. On wasm32 a pointer is 4 bytes while `JobDeadline` (a steady_clock
+// time_point) is 8, so it does not fit inline and must be heap-indirected;
+// the two specializations pick the right strategy at compile time (matching
+// CooperativeGlobalExecutor.cpp).
+template <bool = (sizeof(JobDeadline) <= sizeof(void *) &&
+                  alignof(JobDeadline) <= alignof(void *))>
+struct JobDeadlineStorage;
+
+/// The deadline fits in schedulerPrivate.
+template <>
+struct JobDeadlineStorage<true> {
+  static JobDeadline &storage(SwiftJob *job) {
+    return reinterpret_cast<JobDeadline &>(job->schedulerPrivate[1]);
+  }
+  static JobDeadline get(SwiftJob *job) { return storage(job); }
+  static void set(SwiftJob *job, JobDeadline deadline) {
+    new (static_cast<void *>(&storage(job))) JobDeadline(deadline);
+  }
+  static void destroy(SwiftJob *job) { storage(job).~JobDeadline(); }
+};
+
+/// The deadline does not fit in schedulerPrivate; store it out of line.
+template <>
+struct JobDeadlineStorage<false> {
+  static JobDeadline *&storage(SwiftJob *job) {
+    return reinterpret_cast<JobDeadline *&>(job->schedulerPrivate[1]);
+  }
+  static JobDeadline get(SwiftJob *job) { return *storage(job); }
+  static void set(SwiftJob *job, JobDeadline deadline) {
+    storage(job) = swift_cxx_newObject<JobDeadline>(deadline);
+  }
+  static void destroy(SwiftJob *job) { swift_cxx_deleteObject(storage(job)); }
+};
+
+// A concurrent global executor: N worker threads draining a shared, priority-
+// ordered ready queue, plus a deadline-ordered list of delayed jobs.
+class WASIConcurrentExecutor {
+  std::mutex Mutex;
+  std::condition_variable Ready;
+  JobPriorityQueue ReadyQueue;
+  SwiftJob *DelayedQueue = nullptr; // singly linked, earliest deadline first
+  bool Started = false;
+
+  static unsigned workerCount() {
+    // `hardware_concurrency()` is unreliable under WASI (wasi-libc has no CPU
+    // count API and typically reports 1), which would collapse the pool to a
+    // single worker and serialize everything. Treat 0/1 as "unknown" and fall
+    // back to a small fixed pool so async work actually runs in parallel; the
+    // host maps these guest threads onto real OS threads.
+    unsigned n = std::thread::hardware_concurrency();
+    return n > 1 ? n : 4;
+  }
+
+  void insertDelayed(SwiftJob *newJob, JobDeadline deadline) {
+    SwiftJob **position = &DelayedQueue;
+    while (auto cur = *position) {
+      if (deadline < JobDeadlineStorage<>::get(cur)) {
+        JobQueueTraits::setNext(newJob, cur);
+        *position = newJob;
+        return;
+      }
+      position = &JobQueueTraits::storage(cur);
+    }
+    JobQueueTraits::setNext(newJob, nullptr);
+    *position = newJob;
+  }
+
+  // Move any delayed jobs whose deadline has passed into the ready queue.
+  // Returns the next unexpired deadline, if the delayed list is non-empty.
+  bool promoteReadyDelayedJobs(JobDeadline &nextDeadline) {
+    auto now = std::chrono::steady_clock::now();
+    while (DelayedQueue &&
+           JobDeadlineStorage<>::get(DelayedQueue) <= now) {
+      auto job = DelayedQueue;
+      DelayedQueue = JobQueueTraits::getNext(job);
+      JobDeadlineStorage<>::destroy(job);
+      ReadyQueue.enqueue(job);
+    }
+    if (DelayedQueue) {
+      nextDeadline = JobDeadlineStorage<>::get(DelayedQueue);
+      return true;
+    }
+    return false;
+  }
+
+  void workerLoop() {
+    std::unique_lock<std::mutex> lock(Mutex);
+    while (true) {
+      JobDeadline nextDeadline;
+      bool haveDelayed = promoteReadyDelayedJobs(nextDeadline);
+
+      if (auto job = ReadyQueue.dequeue()) {
+        lock.unlock();
+        swift_job_run(job, swift_executor_generic());
+        lock.lock();
+        continue;
+      }
+
+      if (haveDelayed) {
+        Ready.wait_until(lock, nextDeadline);
+      } else {
+        Ready.wait(lock);
+      }
+    }
+  }
+
+  void startIfNeeded() {
+    if (Started)
+      return;
+    Started = true;
+    unsigned n = workerCount();
+    // The workers are daemons: they loop forever draining the queue and are
+    // never joined. Detach them so that tearing down this (process-lifetime)
+    // executor at exit does not std::terminate on a still-joinable thread.
+    for (unsigned i = 0; i < n; ++i)
+      std::thread([this] { workerLoop(); }).detach();
+  }
+
+public:
+  void enqueue(SwiftJob *job) {
+    std::lock_guard<std::mutex> lock(Mutex);
+    startIfNeeded();
+    ReadyQueue.enqueue(job);
+    Ready.notify_one();
+  }
+
+  void enqueueAfter(SwiftJob *job, JobDeadline deadline) {
+    std::lock_guard<std::mutex> lock(Mutex);
+    startIfNeeded();
+    JobDeadlineStorage<>::set(job, deadline);
+    insertDelayed(job, deadline);
+    // A new, possibly-earlier deadline changes how long a worker should sleep.
+    Ready.notify_all();
+  }
+};
+
+// The main-thread executor: a single serial queue drained by the thread that
+// runs the async `main`. Worker threads enqueue `@MainActor` continuations here
+// and wake the main thread through `MainReady`.
+class WASIMainExecutor {
+  std::mutex Mutex;
+  std::condition_variable MainReady;
+  JobPriorityQueue Queue;
+
+public:
+  void enqueue(SwiftJob *job) {
+    std::lock_guard<std::mutex> lock(Mutex);
+    Queue.enqueue(job);
+    MainReady.notify_one();
+  }
+
+  SWIFT_RUNTIME_ATTRIBUTE_NORETURN void drain() {
+    std::unique_lock<std::mutex> lock(Mutex);
+    while (true) {
+      if (auto job = Queue.dequeue()) {
+        lock.unlock();
+        swift_job_run(job, swift_executor_generic());
+        lock.lock();
+        continue;
+      }
+      MainReady.wait(lock);
+    }
+  }
+};
+
+WASIConcurrentExecutor GlobalExecutor;
+WASIMainExecutor MainExecutor;
+
+JobDeadline deadlineFromNanoseconds(long long nanoseconds) {
+  if (nanoseconds < 0)
+    nanoseconds = 0;
+  return std::chrono::steady_clock::now() +
+         std::chrono::duration_cast<JobDeadline::duration>(
+             std::chrono::nanoseconds(nanoseconds));
+}
+
+} // end anonymous namespace
+
+extern "C" SWIFT_CC(swift) void swift_wasiEnqueueGlobal(SwiftJob *job) {
+  assert(job && "no job provided");
+  GlobalExecutor.enqueue(job);
+}
+
+extern "C" SWIFT_CC(swift)
+void swift_wasiEnqueueGlobalWithDelay(long long delayNanoseconds,
+                                      SwiftJob *job) {
+  assert(job && "no job provided");
+  GlobalExecutor.enqueueAfter(job, deadlineFromNanoseconds(delayNanoseconds));
+}
+
+extern "C" SWIFT_CC(swift)
+void swift_wasiEnqueueGlobalWithDeadline(long long sec, long long nsec,
+                                         long long /*tsec*/,
+                                         long long /*tnsec*/, int clock,
+                                         SwiftJob *job) {
+  assert(job && "no job provided");
+  SwiftTime now = swift_time_now(clock);
+  long long delta =
+      (sec - now.seconds) * 1000000000ll + nsec - now.nanoseconds;
+  GlobalExecutor.enqueueAfter(job, deadlineFromNanoseconds(delta));
+}
+
+extern "C" SWIFT_CC(swift) void swift_wasiEnqueueMain(SwiftJob *job) {
+  assert(job && "no job provided");
+  MainExecutor.enqueue(job);
+}
+
+extern "C" SWIFT_RUNTIME_ATTRIBUTE_NORETURN SWIFT_CC(swift)
+void swift_wasiDrainMain() {
+  MainExecutor.drain();
+}

--- a/stdlib/public/Concurrency/WASIGlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/WASIGlobalExecutor.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -10,47 +10,55 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// A multithreaded global executor for `wasm32-unknown-wasip1-threads`.
+// The C half of the multithreaded executors for `wasm32-unknown-wasip1-threads`
+// (the Swift half is WASIExecutor.swift).
 //
 // The single-threaded WebAssembly build uses the cooperative executor, which
 // drains every job on the thread that started the program: `Task`, `TaskGroup`
-// and `async let` therefore never run in parallel. On the wasi-threads triple
-// (shared memory + atomics + `thread_spawn`) we can do better.
+// and `async let` therefore never run in parallel. The wasi-threads triple has
+// shared memory, atomics and `wasi_thread_spawn`, so here the default executor
+// is a pool of worker threads, and the main executor is a serial queue drained
+// by the thread that runs the async `main`.
 //
-// This file provides the C helpers that `PlatformExecutorWASI.swift` calls:
+// Note that this is the one place where the Concurrency runtime itself spawns
+// OS threads: on Darwin/Linux the pool belongs to libdispatch, which the WASI
+// SDK does not have. Threads come from `pthread_create` (wasi-libc maps it to
+// `wasi_thread_spawn`) with an explicit stack size, and are never joined.
 //
-//   * `swift_wasiEnqueueGlobal`  - hand a job to a pool of worker threads.
-//   * `swift_wasiEnqueueGlobalWithDelay` / `...WithDeadline` - schedule a job
-//     to run on the pool once a deadline elapses.
-//   * `swift_wasiEnqueueMain`    - hand a job to the main thread's queue.
-//   * `swift_wasiDrainMain`      - run the main thread's queue forever (the
-//     body of `MainExecutor.run()` for the async `main`).
+// Entry points, all `SWIFT_CC(swift)` and declared in ExecutorBridge.swift:
 //
-// The main-thread queue and the concurrent pool each guard their job queue
-// with a mutex and a condition variable, so a worker thread that resumes a
-// `@MainActor` continuation can wake the blocked main thread (the liveness
-// property the single-threaded cooperative run loop cannot provide across
-// threads).
+//   * `swift_wasiEnqueueGlobal(job)` — hand a job to the pool.
+//   * `swift_wasiEnqueueGlobalWithDelay(sec, nsec, clock, job)` — schedule a
+//     job on the pool once a delay (on the given clock) elapses.
+//   * `swift_wasiEnqueueMain(job)` — hand a job to the main-thread queue.
+//   * `swift_wasiWaitForMainJob()` — block until the main queue has a job and
+//     dequeue it; the Swift `WASIMainExecutor.run()` loop runs it with the
+//     real main executor reference (executor tracking stays correct).
+//   * `swift_wasiIsMainThread()` — the isolation probe behind
+//     `WASIMainExecutor.isIsolatingCurrentContext()`.
 //
-// The design mirrors DispatchGlobalExecutor.cpp (which backs the Swift
-// executors on Darwin/Linux with libdispatch); here the backing is raw
-// pthreads via the C++ standard threading facilities, which wasi-libc provides
-// for the threads triple.
+// Both queues are guarded by a `swift::ConditionVariable` (which carries its
+// own mutex), so a worker that resumes a `@MainActor` continuation can wake the
+// blocked main thread — the cross-thread liveness the cooperative run loop
+// cannot provide.
 //
 //===----------------------------------------------------------------------===//
 
 #include "swift/shims/Visibility.h"
 
 #include <chrono>
-#include <condition_variable>
-#include <mutex>
-#include <thread>
+#include <climits>
 
-#include <errno.h>
+#include <pthread.h>
+#include <unistd.h>
 
 #include "swift/Basic/PriorityQueue.h"
-#include "swift/Runtime/Heap.h"
+#include "swift/Runtime/Concurrency.h"
+#include "swift/Runtime/EnvironmentVariables.h"
+#include "swift/Threading/ConditionVariable.h"
+#include "swift/Threading/Thread.h"
 
+#include "Error.h"
 #include "ExecutorImpl.h"
 
 using namespace swift;
@@ -74,13 +82,34 @@ struct JobQueueTraits {
 };
 using JobPriorityQueue = PriorityQueue<SwiftJob *, JobQueueTraits>;
 
-using JobDeadline = std::chrono::time_point<std::chrono::steady_clock>;
+/// A deadline expressed as nanoseconds on the suspending clock — the same
+/// monotonic timebase `swift_get_time(swift_clock_id_suspending, ...)`
+/// reports (matching CooperativeGlobalExecutor.cpp).
+using JobDeadline = long long;
 
-// The deadline of a delayed job is stashed in its second scheduler-private
-// word. On wasm32 a pointer is 4 bytes while `JobDeadline` (a steady_clock
-// time_point) is 8, so it does not fit inline and must be heap-indirected;
-// the two specializations pick the right strategy at compile time (matching
-// CooperativeGlobalExecutor.cpp).
+static constexpr JobDeadline NSEC_PER_SEC_LL = 1000000000ll;
+
+/// Read the current time on the suspending clock as a nanosecond count.
+static JobDeadline currentSuspendingNanos() {
+  long long seconds, nanoseconds;
+  swift_get_time(&seconds, &nanoseconds, swift_clock_id_suspending);
+  return seconds * NSEC_PER_SEC_LL + nanoseconds;
+}
+
+/// `base + delta`, saturating instead of wrapping (a delay of centuries must
+/// stay in the future, not fire immediately).
+static JobDeadline saturatingAdd(JobDeadline base, JobDeadline delta) {
+  if (delta > 0 && base > LLONG_MAX - delta)
+    return LLONG_MAX;
+  if (delta < 0 && base < LLONG_MIN - delta)
+    return LLONG_MIN;
+  return base + delta;
+}
+
+/// The deadline of a delayed job lives in its second scheduler-private word.
+/// On wasm32 a pointer is 4 bytes while `JobDeadline` is 8, so it does not
+/// fit inline and must be heap-indirected; the two specializations pick the
+/// right strategy at compile time (matching CooperativeGlobalExecutor.cpp).
 template <bool = (sizeof(JobDeadline) <= sizeof(void *) &&
                   alignof(JobDeadline) <= alignof(void *))>
 struct JobDeadlineStorage;
@@ -93,9 +122,9 @@ struct JobDeadlineStorage<true> {
   }
   static JobDeadline get(SwiftJob *job) { return storage(job); }
   static void set(SwiftJob *job, JobDeadline deadline) {
-    new (static_cast<void *>(&storage(job))) JobDeadline(deadline);
+    storage(job) = deadline;
   }
-  static void destroy(SwiftJob *job) { storage(job).~JobDeadline(); }
+  static void destroy(SwiftJob *) {}
 };
 
 /// The deadline does not fit in schedulerPrivate; store it out of line.
@@ -111,24 +140,40 @@ struct JobDeadlineStorage<false> {
   static void destroy(SwiftJob *job) { swift_cxx_deleteObject(storage(job)); }
 };
 
-// A concurrent global executor: N worker threads draining a shared, priority-
-// ordered ready queue, plus a deadline-ordered list of delayed jobs.
-class WASIConcurrentExecutor {
-  std::mutex Mutex;
-  std::condition_variable Ready;
+/// Stack size for the pool's worker threads. wasi-libc's default pthread
+/// stack is small (musl-derived), and wasm has no guard page: overflowing an
+/// auxiliary thread's stack silently corrupts linear memory instead of
+/// trapping. Swift async frames plus generic-metadata instantiation need
+/// room, so ask for a few MiB — wasi-libc honours `pthread_attr_setstacksize`.
+static constexpr size_t WorkerStackSize = 4 * 1024 * 1024;
+
+/// Upper bound on the pool: each worker owns a stack and TLS block in linear
+/// memory, spawned eagerly on the first enqueue, so a host that reports many
+/// cores must not turn into that many wasm threads.
+static constexpr unsigned MaxWorkerCount = 16;
+
+/// The pool size: `SWIFT_WASI_EXECUTOR_THREADS` when set (>0); otherwise the
+/// online CPU count when wasi-libc reports a real one, else 4. (wasi-libc does
+/// implement `sysconf(_SC_NPROCESSORS_ONLN)`, but it returns a fixed value —
+/// WASI has no CPU-count API to back it — so 0/1 is treated as "unknown".)
+static unsigned workerCount() {
+#if SWIFT_STDLIB_HAS_ENVIRON
+  unsigned configured = runtime::environment::SWIFT_WASI_EXECUTOR_THREADS();
+  if (configured > 0)
+    return configured > MaxWorkerCount ? MaxWorkerCount : configured;
+#endif
+  long online = sysconf(_SC_NPROCESSORS_ONLN);
+  unsigned n = online > 1 ? static_cast<unsigned>(online) : 4;
+  return n > MaxWorkerCount ? MaxWorkerCount : n;
+}
+
+/// The default (global) executor: worker threads draining a shared, priority-
+/// ordered ready queue, plus a deadline-ordered list of delayed jobs.
+class WASIThreadPool {
+  ConditionVariable Ready;     // guards everything below
   JobPriorityQueue ReadyQueue;
   SwiftJob *DelayedQueue = nullptr; // singly linked, earliest deadline first
   bool Started = false;
-
-  static unsigned workerCount() {
-    // `hardware_concurrency()` is unreliable under WASI (wasi-libc has no CPU
-    // count API and typically reports 1), which would collapse the pool to a
-    // single worker and serialize everything. Treat 0/1 as "unknown" and fall
-    // back to a small fixed pool so async work actually runs in parallel; the
-    // host maps these guest threads onto real OS threads.
-    unsigned n = std::thread::hardware_concurrency();
-    return n > 1 ? n : 4;
-  }
 
   void insertDelayed(SwiftJob *newJob, JobDeadline deadline) {
     SwiftJob **position = &DelayedQueue;
@@ -144,12 +189,11 @@ class WASIConcurrentExecutor {
     *position = newJob;
   }
 
-  // Move any delayed jobs whose deadline has passed into the ready queue.
-  // Returns the next unexpired deadline, if the delayed list is non-empty.
+  /// Move every delayed job whose deadline has passed into the ready queue.
+  /// Returns true (and the next unexpired deadline) if delayed jobs remain.
   bool promoteReadyDelayedJobs(JobDeadline &nextDeadline) {
-    auto now = std::chrono::steady_clock::now();
-    while (DelayedQueue &&
-           JobDeadlineStorage<>::get(DelayedQueue) <= now) {
+    auto now = currentSuspendingNanos();
+    while (DelayedQueue && JobDeadlineStorage<>::get(DelayedQueue) <= now) {
       auto job = DelayedQueue;
       DelayedQueue = JobQueueTraits::getNext(job);
       JobDeadlineStorage<>::destroy(job);
@@ -163,128 +207,159 @@ class WASIConcurrentExecutor {
   }
 
   void workerLoop() {
-    std::unique_lock<std::mutex> lock(Mutex);
+    Ready.lock();
     while (true) {
       JobDeadline nextDeadline;
       bool haveDelayed = promoteReadyDelayedJobs(nextDeadline);
 
       if (auto job = ReadyQueue.dequeue()) {
-        lock.unlock();
+        Ready.unlock();
+        // Pool jobs run under the generic executor, exactly as the Dispatch
+        // global queue's do; the main queue is what carries a real executor.
         swift_job_run(job, swift_executor_generic());
-        lock.lock();
+        Ready.lock();
         continue;
       }
 
       if (haveDelayed) {
-        Ready.wait_until(lock, nextDeadline);
+        auto remaining = nextDeadline - currentSuspendingNanos();
+        if (remaining > 0)
+          Ready.wait(std::chrono::nanoseconds(remaining));
       } else {
-        Ready.wait(lock);
+        Ready.wait();
       }
     }
   }
 
+  static void *workerEntry(void *self) {
+    static_cast<WASIThreadPool *>(self)->workerLoop();
+    return nullptr;
+  }
+
+  /// Spawn the workers (once, on the first enqueue). Precondition: locked.
   void startIfNeeded() {
     if (Started)
       return;
     Started = true;
+
+    pthread_attr_t attr;
+    pthread_attr_init(&attr);
+    pthread_attr_setstacksize(&attr, WorkerStackSize);
+    // Never joined: the workers are process-lifetime daemons.
+    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+
     unsigned n = workerCount();
-    // The workers are daemons: they loop forever draining the queue and are
-    // never joined. Detach them so that tearing down this (process-lifetime)
-    // executor at exit does not std::terminate on a still-joinable thread.
-    for (unsigned i = 0; i < n; ++i)
-      std::thread([this] { workerLoop(); }).detach();
+    for (unsigned i = 0; i < n; ++i) {
+      pthread_t thread;
+      int error = pthread_create(&thread, &attr, workerEntry, this);
+      if (error != 0) {
+        // The host refused another thread (thread limit, out of memory). At
+        // least one worker is needed for any job to ever run; beyond that,
+        // run with the smaller pool.
+        if (i == 0)
+          swift_Concurrency_fatalError(
+              0, "swift_wasiEnqueueGlobal: pthread_create failed (%d): the "
+                 "WASI thread pool could not start\n", error);
+        break;
+      }
+    }
+    pthread_attr_destroy(&attr);
   }
 
 public:
   void enqueue(SwiftJob *job) {
-    std::lock_guard<std::mutex> lock(Mutex);
+    Ready.lock();
     startIfNeeded();
     ReadyQueue.enqueue(job);
-    Ready.notify_one();
+    Ready.unlock();
+    Ready.signal();
   }
 
   void enqueueAfter(SwiftJob *job, JobDeadline deadline) {
-    std::lock_guard<std::mutex> lock(Mutex);
+    Ready.lock();
     startIfNeeded();
     JobDeadlineStorage<>::set(job, deadline);
     insertDelayed(job, deadline);
-    // A new, possibly-earlier deadline changes how long a worker should sleep.
-    Ready.notify_all();
+    Ready.unlock();
+    // A new, possibly-earlier deadline changes how long a worker may sleep.
+    Ready.broadcast();
   }
 };
 
-// The main-thread executor: a single serial queue drained by the thread that
-// runs the async `main`. Worker threads enqueue `@MainActor` continuations here
-// and wake the main thread through `MainReady`.
-class WASIMainExecutor {
-  std::mutex Mutex;
-  std::condition_variable MainReady;
+/// The main executor's queue: serial, drained by the thread that runs the
+/// async `main` (see `WASIMainExecutor.run()`). Workers enqueue `@MainActor`
+/// continuations here and wake the main thread.
+class WASIMainQueue {
+  ConditionVariable Ready;
   JobPriorityQueue Queue;
 
 public:
   void enqueue(SwiftJob *job) {
-    std::lock_guard<std::mutex> lock(Mutex);
+    Ready.lock();
     Queue.enqueue(job);
-    MainReady.notify_one();
+    Ready.unlock();
+    Ready.signal();
   }
 
-  SWIFT_RUNTIME_ATTRIBUTE_NORETURN void drain() {
-    std::unique_lock<std::mutex> lock(Mutex);
-    while (true) {
-      if (auto job = Queue.dequeue()) {
-        lock.unlock();
-        swift_job_run(job, swift_executor_generic());
-        lock.lock();
-        continue;
-      }
-      MainReady.wait(lock);
-    }
+  /// Block until a job is available, then hand it over.
+  SwiftJob *waitForJob() {
+    Ready.lock();
+    SwiftJob *job;
+    while (!(job = Queue.dequeue()))
+      Ready.wait();
+    Ready.unlock();
+    return job;
   }
 };
 
-WASIConcurrentExecutor GlobalExecutor;
-WASIMainExecutor MainExecutor;
+/// Both are process-lifetime and deliberately leaked: detached workers block
+/// on the pool's condition variable, and the runtime's other executors do the
+/// same; a static destructor at `exit()` would tear the primitives down under
+/// threads that still use them.
+WASIThreadPool &threadPool() {
+  static WASIThreadPool *pool = new WASIThreadPool();
+  return *pool;
+}
 
-JobDeadline deadlineFromNanoseconds(long long nanoseconds) {
-  if (nanoseconds < 0)
-    nanoseconds = 0;
-  return std::chrono::steady_clock::now() +
-         std::chrono::duration_cast<JobDeadline::duration>(
-             std::chrono::nanoseconds(nanoseconds));
+WASIMainQueue &mainQueue() {
+  static WASIMainQueue *queue = new WASIMainQueue();
+  return *queue;
 }
 
 } // end anonymous namespace
 
 extern "C" SWIFT_CC(swift) void swift_wasiEnqueueGlobal(SwiftJob *job) {
   assert(job && "no job provided");
-  GlobalExecutor.enqueue(job);
+  threadPool().enqueue(job);
 }
 
 extern "C" SWIFT_CC(swift)
-void swift_wasiEnqueueGlobalWithDelay(long long delayNanoseconds,
+void swift_wasiEnqueueGlobalWithDelay(long long sec, long long nsec, int clock,
                                       SwiftJob *job) {
   assert(job && "no job provided");
-  GlobalExecutor.enqueueAfter(job, deadlineFromNanoseconds(delayNanoseconds));
-}
-
-extern "C" SWIFT_CC(swift)
-void swift_wasiEnqueueGlobalWithDeadline(long long sec, long long nsec,
-                                         long long /*tsec*/,
-                                         long long /*tnsec*/, int clock,
-                                         SwiftJob *job) {
-  assert(job && "no job provided");
-  SwiftTime now = swift_time_now(clock);
-  long long delta =
-      (sec - now.seconds) * 1000000000ll + nsec - now.nanoseconds;
-  GlobalExecutor.enqueueAfter(job, deadlineFromNanoseconds(delta));
+  // The delay was measured on `clock`; the queue's timebase is the suspending
+  // clock. Both are monotonic and advance at the same rate while the program
+  // runs, so a delay converts directly (the cooperative executor re-anchors
+  // the same way).
+  (void)clock;
+  JobDeadline delta = sec > LLONG_MAX / NSEC_PER_SEC_LL
+                          ? LLONG_MAX
+                          : sec * NSEC_PER_SEC_LL;
+  delta = saturatingAdd(delta, nsec);
+  if (delta < 0)
+    delta = 0;
+  threadPool().enqueueAfter(job, saturatingAdd(currentSuspendingNanos(), delta));
 }
 
 extern "C" SWIFT_CC(swift) void swift_wasiEnqueueMain(SwiftJob *job) {
   assert(job && "no job provided");
-  MainExecutor.enqueue(job);
+  mainQueue().enqueue(job);
 }
 
-extern "C" SWIFT_RUNTIME_ATTRIBUTE_NORETURN SWIFT_CC(swift)
-void swift_wasiDrainMain() {
-  MainExecutor.drain();
+extern "C" SWIFT_CC(swift) SwiftJob *swift_wasiWaitForMainJob() {
+  return mainQueue().waitForJob();
+}
+
+extern "C" SWIFT_CC(swift) bool swift_wasiIsMainThread() {
+  return Thread::onMainThread();
 }

--- a/stdlib/public/runtime/EnvironmentVariables.def
+++ b/stdlib/public/runtime/EnvironmentVariables.def
@@ -84,6 +84,11 @@ VARIABLE(SWIFT_DEBUG_CONCURRENCY_ENABLE_COOPERATIVE_QUEUES, boolean, true,
 VARIABLE(SWIFT_DEBUG_ENABLE_TASK_REGISTRY, boolean, true,
          "Enable the global live-task tracking registry.")
 
+VARIABLE(SWIFT_WASI_EXECUTOR_THREADS, uint32, 0,
+         "Number of worker threads in the wasm32-unknown-wasip1-threads global "
+         "executor's pool (0 = automatic: the online CPU count when the host "
+         "reports one, else 4; capped at 16).")
+
 #ifndef NDEBUG
 
 VARIABLE(SWIFT_DEBUG_ENABLE_PROTOCOL_CONFORMANCES_LOOKUP_LOG,

--- a/test/Concurrency/Runtime/wasi_threads_global_executor.swift
+++ b/test/Concurrency/Runtime/wasi_threads_global_executor.swift
@@ -1,0 +1,66 @@
+// RUN: %target-run-simple-swift(-parse-as-library) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+// REQUIRES: OS=wasip1
+// REQUIRES: wasi_threads
+
+// The wasm32-unknown-wasip1-threads global executor: work fans out across a
+// pool of wasi threads (child tasks observe more than one thread), `@MainActor`
+// continuations resumed from the pool land back on the main thread, and
+// delayed jobs go through the pool's timer list.
+
+import WASILibc
+
+@inline(never)
+func currentThreadID() -> UInt {
+  return UInt(bitPattern: Int(bitPattern: pthread_self()))
+}
+
+nonisolated func spin(_ iterations: Int) -> Int {
+  var x = 0
+  for i in 0..<iterations { x = (x &+ i) & 0xffff }
+  return x
+}
+
+@MainActor var mainThreadID = currentThreadID()
+
+@main struct Main {
+  static func main() async {
+    let main = await mainThreadID
+
+    // Enough CPU-bound children to keep several workers busy at once.
+    let threads = await withTaskGroup(of: (UInt, Int).self) { group in
+      for _ in 0..<32 {
+        group.addTask { (currentThreadID(), spin(200_000)) }
+      }
+      var seen = Set<UInt>()
+      for await (thread, _) in group { seen.insert(thread) }
+      return seen
+    }
+    // CHECK: ran on the main thread: false
+    print("ran on the main thread: \(threads.contains(main))")
+    // CHECK: parallel: true
+    print("parallel: \(threads.count > 1)")
+
+    // A continuation resumed from a pool worker returns to the main thread.
+    let resumedOn: UInt = await withCheckedContinuation { continuation in
+      Task.detached {
+        _ = spin(1000)
+        continuation.resume(returning: currentThreadID())
+      }
+    }
+    // CHECK: resumed from a worker: true
+    print("resumed from a worker: \(resumedOn != main)")
+    // CHECK: back on main: true
+    print("back on main: \(currentThreadID() == main)")
+
+    // Delayed scheduling goes through the pool's timer list.
+    let clock = ContinuousClock()
+    let start = clock.now
+    try? await Task.sleep(for: .milliseconds(50))
+    // CHECK: slept: true
+    print("slept: \(clock.now - start >= .milliseconds(45))")
+  }
+}

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -276,6 +276,9 @@ if kIsWASI:
   if run_os == 'wasip1-threads':
       run_os = 'wasip1'
       run_environment = 'threads'
+      # The wasi-threads stdlib: multithreaded Swift Concurrency (the `wasi`
+      # global executor) on top of the pthreads threading package.
+      config.available_features.add('wasi_threads')
 
 lto_flags = ""
 use_just_built_liblto = ""

--- a/utils/swift_build_support/swift_build_support/helpers/wasmstdlibhelpers.py
+++ b/utils/swift_build_support/swift_build_support/helpers/wasmstdlibhelpers.py
@@ -113,7 +113,10 @@ def build_stdlib(args, toolchain, source_dir, build_dir, host_target,
     opts.define('SWIFT_STDLIB_HAS_ASLR:BOOL', 'FALSE')
     opts.define('SWIFT_STDLIB_INSTALL_PARENT_MODULE_FOR_SHIMS:BOOL', 'FALSE')
     opts.define('SWIFT_RUNTIME_CRASH_REPORTER_CLIENT:BOOL', 'FALSE')
-    opts.define('SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY:BOOL', 'TRUE')
+    # SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY is a per-product decision
+    # (TRUE for the single-threaded targets, FALSE for wasip1-threads): each
+    # product defines it in its `_append_threading_options`. Defining it here
+    # would win, since CMake keeps the last -D on the command line.
     opts.define('SWIFT_ENABLE_DISPATCH:BOOL', 'FALSE')
     opts.define('SWIFT_STDLIB_SUPPORTS_BACKTRACE_REPORTING:BOOL', 'FALSE')
     opts.define('SWIFT_STDLIB_HAS_DLADDR:BOOL', 'FALSE')

--- a/utils/swift_build_support/swift_build_support/products/emscriptenstdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/emscriptenstdlib.py
@@ -80,6 +80,10 @@ class EmscriptenStdlib(cmake_product.CMakeProduct):
                              ' ' + ' '.join(test_driver_options))
 
         cmake_options.define('SWIFT_THREADING_PACKAGE:STRING', 'none')
+        # No threads: Swift Concurrency runs on the single-threaded
+        # cooperative executor.
+        cmake_options.define(
+            'SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY:BOOL', 'TRUE')
         # Emscripten keeps compatibility headers (e.g. xlocale.h) in a
         # separate include/compat directory that emcc adds automatically.
         # Since we use raw clang, we need to add it ourselves.

--- a/utils/swift_build_support/swift_build_support/products/wasistdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/wasistdlib.py
@@ -193,3 +193,14 @@ class WASIThreadsStdlib(WASIStdlib):
                              '-Xcc;-mthread-model;-Xcc;posix;'
                              '-Xcc;-pthread;-Xcc;-ftls-model=local-exec')
         cmake_options.define('SWIFT_ENABLE_WASI_THREADS:BOOL', 'TRUE')
+        # The threads triple has real OS threads (shared memory + atomics +
+        # thread_spawn), so Swift Concurrency should use a multithreaded global
+        # executor rather than the single-threaded cooperative one the plain
+        # wasip1 stdlib inherits. Disable the single-threaded default and select
+        # the WASI thread-pool executor (stdlib/public/Concurrency/
+        # PlatformExecutorWASI.swift + WASIGlobalExecutor.cpp). This is what lets
+        # Task / TaskGroup / async let fan out across wasi threads.
+        cmake_options.define(
+            'SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY:BOOL', 'FALSE')
+        cmake_options.define(
+            'SWIFT_CONCURRENCY_GLOBAL_EXECUTOR:STRING', 'wasi')

--- a/utils/swift_build_support/swift_build_support/products/wasistdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/wasistdlib.py
@@ -185,3 +185,14 @@ class WASIThreadsStdlib(WASIStdlib):
                              '-Xcc;-mthread-model;-Xcc;posix;'
                              '-Xcc;-pthread;-Xcc;-ftls-model=local-exec')
         cmake_options.define('SWIFT_ENABLE_WASI_THREADS:BOOL', 'TRUE')
+        # The threads triple has real OS threads (shared memory + atomics +
+        # thread_spawn), so Swift Concurrency should use a multithreaded global
+        # executor rather than the single-threaded cooperative one the plain
+        # wasip1 stdlib inherits. Disable the single-threaded default and select
+        # the WASI thread-pool executor (stdlib/public/Concurrency/
+        # PlatformExecutorWASI.swift + WASIGlobalExecutor.cpp). This is what lets
+        # Task / TaskGroup / async let fan out across wasi threads.
+        cmake_options.define(
+            'SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY:BOOL', 'FALSE')
+        cmake_options.define(
+            'SWIFT_CONCURRENCY_GLOBAL_EXECUTOR:STRING', 'wasi')

--- a/utils/swift_build_support/swift_build_support/products/wasistdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/wasistdlib.py
@@ -97,6 +97,10 @@ class WASIStdlib(cmake_product.CMakeProduct):
 
     def _append_threading_options(self, cmake_options):
         cmake_options.define('SWIFT_THREADING_PACKAGE:STRING', 'none')
+        # No threads: Swift Concurrency runs on the single-threaded
+        # cooperative executor.
+        cmake_options.define(
+            'SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY:BOOL', 'TRUE')
 
     def test(self, host_target):
         self._test(host_target, 'wasm32-wasip1')
@@ -194,11 +198,12 @@ class WASIThreadsStdlib(WASIStdlib):
                              '-Xcc;-pthread;-Xcc;-ftls-model=local-exec')
         cmake_options.define('SWIFT_ENABLE_WASI_THREADS:BOOL', 'TRUE')
         # The threads triple has real OS threads (shared memory + atomics +
-        # thread_spawn), so Swift Concurrency should use a multithreaded global
+        # thread_spawn), so Swift Concurrency uses a multithreaded global
         # executor rather than the single-threaded cooperative one the plain
-        # wasip1 stdlib inherits. Disable the single-threaded default and select
-        # the WASI thread-pool executor (stdlib/public/Concurrency/
-        # PlatformExecutorWASI.swift + WASIGlobalExecutor.cpp). This is what lets
+        # wasip1 stdlib uses: a runtime that is NOT single-threaded (so the
+        # actor runtime can tell pool workers from the main thread) plus the
+        # WASI thread-pool executor (stdlib/public/Concurrency/
+        # WASIExecutor.swift + WASIGlobalExecutor.cpp). This is what lets
         # Task / TaskGroup / async let fan out across wasi threads.
         cmake_options.define(
             'SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY:BOOL', 'FALSE')


### PR DESCRIPTION
Closing this in favour of a split, so the two problems it tangled together can land on their own timelines:

1. **The wasi-threads stdlib is compiled single-threaded.** `SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY=TRUE` from the shared wasm helper overrides the threads product's `FALSE` (CMake keeps the last `-D`), so `isExecutingOnMainThread()` in `Actor.cpp` returns `true` on every worker thread and the actor runtime treats any thread as the main actor. That is an in-tree bug no package can work around, and it does not need the executor to be fixed. It is now its own small PR: **#92018** — the per-product define, the cooperative executor kept explicitly for the threads triple (flipping the flag alone is rejected at configure time and would otherwise default the executor to `hooked`), the configure guard relaxed for runtimes that have a threading package, and a test that a worker-thread `MainActor.assumeIsolated` now traps.

2. **The thread pool itself.** Nothing in it needs to be in the stdlib: `pthread_create` is reachable from a package, `ExecutorJob.runSynchronously(on:)` is public, and `ExecutorFactory` / `DefaultExecutorFactory` conformances can be declared anywhere (on WASI the stdlib is statically linked, so the usual `@_spi(ExperimentalCustomExecutors)` concerns about ABI and back-deployment do not apply). I have opened **swiftlang/swift-platform-executors#30** to ask whether that repo wants it and under what name; the implementation here (`WASIThreadPool` / `WASIMainQueue`, the Swift main run loop with `runSynchronously`, the pthread-backed isolation checks) ports over as a package contribution, with the runtime tests (peak concurrency, worker→main continuation, delayed scheduling) becoming real package tests that run under wasmtime.

After (1), the default for wasip1-threads stays the cooperative executor — a correctness fix with no behaviour change — and parallelism becomes something an app opts into with `typealias DefaultExecutorFactory = …`.

Thanks to everyone who looked at this; the design discussion moves to the issue above.
