### PR TITLE
[Runtime][Win32] Build debug versions of swifter.o

### DIFF
--- a/Runtimes/Core/runtime/CMakeLists.txt
+++ b/Runtimes/Core/runtime/CMakeLists.txt
@@ -190,6 +190,15 @@ elseif("${SwiftCore_OBJECT_FORMAT}" STREQUAL "coffx")
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/swift/${SwiftCore_PLATFORM_SUBDIR}/${SwiftCore_ARCH_SUBDIR}"
     RENAME swiftrtT.obj)
 
+  add_library(swiftrtTd OBJECT SwiftRT-COFF.cpp)
+  target_compile_definitions(swiftrtTd PRIVATE
+    SWIFT_STATIC_STDLIB _DEBUG _ITERATOR_DEBUG_LEVEL=2)
+  target_link_libraries(swiftrtTd PRIVATE swiftShims)
+  install(FILES $<TARGET_OBJECTS:swiftrtTd>
+    COMPONENT SwiftCore_runtime
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/swift/${SwiftCore_PLATFORM_SUBDIR}/${SwiftCore_ARCH_SUBDIR}"
+    RENAME swiftrtTd.obj)
+
   add_library(swiftrt OBJECT SwiftRT-COFF.cpp)
   target_link_libraries(swiftrt PRIVATE swiftShims)
   install(FILES $<TARGET_OBJECTS:swiftrt>
@@ -197,7 +206,16 @@ elseif("${SwiftCore_OBJECT_FORMAT}" STREQUAL "coffx")
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/swift/${SwiftCore_PLATFORM_SUBDIR}/${SwiftCore_ARCH_SUBDIR}"
     RENAME swiftrt.obj)
 
-  install(TARGETS swiftrtT swiftrt
+  add_library(swiftrtd OBJECT SwiftRT-COFF.cpp)
+  target_compile_definitions(swiftrtd PRIVATE
+    _DEBUG _ITERATOR_DEBUG_LEVEL=2)
+  target_link_libraries(swiftrtd PRIVATE swiftShims)
+  install(FILES $<TARGET_OBJECTS:swiftrtd>
+    COMPONENT SwiftCore_runtime
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/swift/${SwiftCore_PLATFORM_SUBDIR}/${SwiftCore_ARCH_SUBDIR}"
+    RENAME swiftrtd.obj)
+
+  install(TARGETS swiftrtT swiftrtTd swiftrt swiftrtd
     EXPORT SwiftCoreTargets
     COMPONENT SwiftCore_runtime)
 elseif(NOT "${SwiftCore_OBJECT_FORMAT}" STREQUAL "x")

--- a/lib/Driver/WindowsToolChains.cpp
+++ b/lib/Driver/WindowsToolChains.cpp
@@ -152,7 +152,12 @@ toolchains::Windows::constructInvocation(const DynamicLinkJobAction &job,
     SmallString<128> swiftrtPath = SharedResourceDirPath;
     llvm::sys::path::append(swiftrtPath,
                             swift::getMajorArchitectureName(getTriple()));
-    llvm::sys::path::append(swiftrtPath, "swiftrt.obj");
+    bool isDebug = false;
+    if (context.OI.RuntimeVariant) {
+      isDebug = *context.OI.RuntimeVariant == MSVCRuntime::MultiThreadedDebug ||
+                *context.OI.RuntimeVariant == MSVCRuntime::MultiThreadedDebugDLL;
+    }
+    llvm::sys::path::append(swiftrtPath, isDebug ? "swiftrtd.obj" : "swiftrt.obj");
     Arguments.push_back(context.Args.MakeArgString(swiftrtPath));
   }
 

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -202,6 +202,18 @@ add_swift_target_library(swiftImageRegistrationObjectCOFF
                   SWIFT_COMPILE_FLAGS ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
                   INSTALL_IN_COMPONENT none)
 
+add_swift_target_library(swiftImageRegistrationObjectCOFFDebug
+                  OBJECT_LIBRARY IS_STDLIB IS_STDLIB_CORE
+                  SwiftRT-COFF.cpp
+                  C_COMPILE_FLAGS
+                    ${SWIFT_RUNTIME_CORE_CXX_FLAGS}
+                    ${swift_enable_backtracing}
+                    -D_DEBUG -D_ITERATOR_DEBUG_LEVEL=2
+                  LINK_FLAGS ${SWIFT_RUNTIME_CORE_LINK_FLAGS}
+                  TARGET_SDKS ${COFF_SDKS}
+                  SWIFT_COMPILE_FLAGS ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
+                  INSTALL_IN_COMPONENT none)
+
 add_swift_target_library(swiftImageRegistrationObjectWASM
                   OBJECT_LIBRARY IS_STDLIB IS_STDLIB_CORE
                   SwiftRT-WASM.cpp
@@ -246,9 +258,33 @@ foreach(sdk ${SWIFT_SDKS})
                                   "${static_runtime_registrar}"
                                 DEPENDS
                                   "${swiftrtObject}")
+
+      set(runtime_registrars
+          "${shared_runtime_registrar}")
+
+      if(sdk STREQUAL "WINDOWS")
+        set(swiftrtdObject ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/swiftImageRegistrationObjectCOFFDebug-${arch_suffix}.dir/${swiftrtSourceName}${CMAKE_C_OUTPUT_EXTENSION})
+        set(shared_debug_runtime_registrar "${SWIFTLIB_DIR}/${arch_subdir}/swiftrtd${extension}")
+        set(static_debug_runtime_registrar "${SWIFTSTATICLIB_DIR}/${arch_subdir}/swiftrtd${extension}")
+
+        add_custom_command_target(swiftImageRegistrationDebug-${arch_suffix}
+                                  COMMAND
+                                    "${CMAKE_COMMAND}" -E copy "${swiftrtdObject}" "${shared_debug_runtime_registrar}"
+                                  COMMAND
+                                    "${CMAKE_COMMAND}" -E copy "${swiftrtdObject}" "${static_debug_runtime_registrar}"
+                                  OUTPUT
+                                    "${shared_debug_runtime_registrar}"
+                                    "${static_debug_runtime_registrar}"
+                                  DEPENDS
+                                    "${swiftrtdObject}")
+
+        list(APPEND runtime_registrars
+             "${shared_debug_runtime_registrar}")
+      endif()
+
       if(SWIFT_BUILD_DYNAMIC_STDLIB AND NOT SWIFT_SDK_${sdk}_STATIC_ONLY)
         swift_install_in_component(FILES
-                                     "${shared_runtime_registrar}"
+                                     ${runtime_registrars}
                                    DESTINATION
                                      "lib/swift/${arch_subdir}"
                                    COMPONENT

--- a/test/Driver/windows-libc-options.swift
+++ b/test/Driver/windows-libc-options.swift
@@ -11,6 +11,7 @@
 
 // -- check flags for /MDd
 // RUN: %swiftc_driver -target x86_64-unknown-windows-msvc -libc MDd -c %s -### 2>&1 | %FileCheck %s -check-prefix CHECK-MDd
+// CHECK-MDd: swiftrtd.obj
 // CHECK-MDd: -autolink-library oldnames -autolink-library msvcrtd -Xcc -D_MT -Xcc -D_DLL
 
 // -- check flags for /MT
@@ -20,6 +21,7 @@
 
 // -- check flags for /MTd
 // RUN: %swiftc_driver -target x86_64-unknown-windows-msvc -libc MTd -c %s -### 2>&1 | %FileCheck %s -check-prefix CHECK-MTd
+// CHECK-MTd: swiftrtd.obj
 // CHECK-MTd: -autolink-library oldnames -autolink-library libcmtd -Xcc -D_MT
 // CHECK-MTd-NOT: -D_DLL
 

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3307,11 +3307,15 @@ function Test-Compilers([Hashtable] $Platform, [string] $Variant, [switch] $Test
 
       # Runtime dependencies of repl_swift.exe.  The Stage2-compiled swiftCore.dll
       # already lives in $CompilerCache\bin and is what repl_swift.exe is linked
-      # against, so only swiftrt.obj needs to be staged from the SDK here.
+      # against, so only swiftrt.obj and swiftrtd.obj need to be staged from the SDK here.
       New-Item -ItemType Directory -Force "$CompilerCache\$SwiftRTSubdir" | Out-Null
       Write-Host "Copying '$SwiftSDK\usr\$SwiftRTSubdir\$($Platform.Architecture.LLVMName)\swiftrt.obj' to '$CompilerCache\$SwiftRTSubdir'"
       Copy-Item `
         -Path "$SwiftSDK\usr\$SwiftRTSubdir\$($Platform.Architecture.LLVMName)\swiftrt.obj" `
+        -Destination "$CompilerCache\$SwiftRTSubdir"
+      Write-Host "Copying '$SwiftSDK\usr\$SwiftRTSubdir\$($Platform.Architecture.LLVMName)\swiftrtd.obj' to '$CompilerCache\$SwiftRTSubdir'"
+      Copy-Item `
+        -Path "$SwiftSDK\usr\$SwiftRTSubdir\$($Platform.Architecture.LLVMName)\swiftrtd.obj" `
         -Destination "$CompilerCache\$SwiftRTSubdir"
       $TestingDefines += @{
         LLDB_INCLUDE_TESTS = "YES";


### PR DESCRIPTION
This pull request resolves issue #87468 by introducing debug versions of swiftrt.obj (swiftrtd.obj). It updates the core runtime build scripts to compile these debug objects with _ITERATOR_DEBUG_LEVEL=2 and adjusts the Windows toolchain driver to appropriately link them during debug builds, ensuring ABI stability across configurations.