### PR TITLE
Revert "[DebugInfo] Re-enable type chain verifier"

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AllocBoxToStack.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AllocBoxToStack.swift
@@ -253,7 +253,6 @@ private struct FunctionSpecializations {
         (user as! SingleValueInstruction).replace(with: box, context)
       case let debugValue as DebugValueInst:
         debugValue.operand.set(to: stack, context)
-        debugValue.prependDeref()
       case let apply as ApplySite:
         specialize(apply: apply, context)
       default:

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -602,14 +602,6 @@ void DebugValueInst::killOperand(SILType operandType) {
   }
 
   SILType origType = operandType ? operandType : getOperand()->getType();
-
-  // Non-undef debug_values on alloc_box are allowed and fixed by IRGen to
-  // refer to the project_box. Undef debug_values, however, should always
-  // have the type of the variable.
-  if (!operandType)
-    if (auto *abi = dyn_cast<AllocBoxInst>(getOperand()))
-      origType = abi->getAddressType().getObjectType();
-
   bool addressOnly = !origType.isLoadableOrOpaque(*getFunction());
 
   // For address-only types, keep the address type and prependDeref flag.

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -87,6 +87,11 @@ static llvm::cl::opt<bool> VerifyDIHoles("verify-di-holes", llvm::cl::init(
 #endif
                                                                 ));
 
+// Verify the type chain of debug_value instructions. Disabled by default
+// while we fix all root causes.
+static llvm::cl::opt<bool> VerifyDebugValueExpr("verify-debug-value-expr",
+                                                llvm::cl::init(false));
+
 static llvm::cl::opt<bool> SkipConvertEscapeToNoescapeAttributes(
     "verify-skip-convert-escape-to-noescape-attributes", llvm::cl::init(false));
 
@@ -1965,7 +1970,9 @@ public:
     }
 
     // Type chain: SSA operand -> DebugBB -> deref -> fragments -> vartype
-    require(inst->isExprTypeValid(), "debug_value type chain should hold");
+    if (VerifyDebugValueExpr)
+      require(inst->isExprTypeValid(),
+              "debug_value type chain should hold");
   }
 
   void checkInstructionsDebugInfo(SILInstruction *inst) {

--- a/test/Concurrency/silisolationinfo_inference.sil
+++ b/test/Concurrency/silisolationinfo_inference.sil
@@ -1356,7 +1356,7 @@ bb0(%0 : @guaranteed $MainActorIsolatedStruct):
 sil [ossa] @test_nonisolated_unsafe_field_override_struct_addr : $@convention(thin) (@in_guaranteed MainActorIsolatedStruct) -> () {
 bb0(%0 : $*MainActorIsolatedStruct):
   specify_test "sil_isolation_info_inference @trace[0]"
-  debug_value %0 : $*MainActorIsolatedStruct, let, name "self", expr op_deref
+  debug_value %0 : $*MainActorIsolatedStruct, let, name "self"
   %1 = struct_element_addr %0 : $*MainActorIsolatedStruct, #MainActorIsolatedStruct.nsNonisolatedUnsafe
   debug_value [trace] %1
   %9999 = tuple ()
@@ -1370,7 +1370,7 @@ bb0(%0 : $*MainActorIsolatedStruct):
 sil [ossa] @test_nonisolated_unsafe_field_override_generic_struct_addr : $@convention(thin) <T> (@in_guaranteed MainActorIsolatedGenericStruct<T>) -> () {
 bb0(%0 : $*MainActorIsolatedGenericStruct<T>):
   specify_test "sil_isolation_info_inference @trace[0]"
-  debug_value %0 : $*MainActorIsolatedGenericStruct<T>, let, name "self", expr op_deref
+  debug_value %0 : $*MainActorIsolatedGenericStruct<T>, let, name "self"
   %1 = struct_element_addr %0 : $*MainActorIsolatedGenericStruct<T>, #MainActorIsolatedGenericStruct.nsNonisolatedUnsafe
   debug_value [trace] %1
   %9999 = tuple ()
@@ -1384,7 +1384,7 @@ bb0(%0 : $*MainActorIsolatedGenericStruct<T>):
 sil [ossa] @test_nonisolated_unsafe_field_override_nonisolated_generic_struct_addr : $@convention(thin) <T> (@in_guaranteed NonisolatedGenericStruct<T>) -> () {
 bb0(%0 : $*NonisolatedGenericStruct<T>):
   specify_test "sil_isolation_info_inference @trace[0]"
-  debug_value %0 : $*NonisolatedGenericStruct<T>, let, name "self", expr op_deref
+  debug_value %0 : $*NonisolatedGenericStruct<T>, let, name "self"
   %1 = struct_element_addr %0 : $*NonisolatedGenericStruct<T>, #NonisolatedGenericStruct.nsNonisolatedUnsafe
   debug_value [trace] %1
   %9999 = tuple ()

--- a/test/DebugInfo/irgen_box_debug_value.sil
+++ b/test/DebugInfo/irgen_box_debug_value.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -disable-debugger-shadow-copies -g -emit-irgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -verify-debug-value-expr -disable-debugger-shadow-copies -g -emit-irgen %s | %FileCheck %s
 sil_stage canonical
 
 import Swift

--- a/test/SIL/Parser/debug_transform_block.sil
+++ b/test/SIL/Parser/debug_transform_block.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -sil-print-types %s | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-types -verify-debug-value-expr %s | %FileCheck %s
 sil_stage canonical
 
 import Builtin

--- a/test/SIL/verifier_failures_debug_transform.sil
+++ b/test/SIL/verifier_failures_debug_transform.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -sil-print-types -verify-continue-on-failure -o /dev/null %s 2>&1 | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-types -verify-debug-value-expr -verify-continue-on-failure -o /dev/null %s 2>&1 | %FileCheck %s
 
 // REQUIRES: asserts
 

--- a/test/SILOptimizer/copy-to-borrow-optimization.sil
+++ b/test/SILOptimizer/copy-to-borrow-optimization.sil
@@ -2376,11 +2376,11 @@ bb0(%0 : @guaranteed $Outer):
 // CHECK-LABEL: sil [ossa] @store_to_store_borrow :
 // CHECK:         %2 = alloc_stack $C
 // CHECK-NEXT:    %3 = store_borrow %0 to %2
-// CHECK-NEXT:    debug_value %3, var, name "x", expr op_deref
+// CHECK-NEXT:    debug_value %3
 // CHECK-NEXT:    apply undef(%3)
 // CHECK-NEXT:    load [copy] %3
 // CHECK-NEXT:    copy_addr %3 to %1
-// CHECK-NEXT:    debug_value %3, expr op_deref
+// CHECK-NEXT:    debug_value %3
 // CHECK-NEXT:    end_borrow %3
 // CHECK-NEXT:    dealloc_stack %2
 // CHECK-LABEL: } // end sil function 'store_to_store_borrow'
@@ -2388,12 +2388,12 @@ sil [ossa] @store_to_store_borrow : $@convention(thin) (@guaranteed C, @inout C)
 bb0(%0 : @guaranteed $C, %1 : $*C):
   %2 = copy_value %0
   %3 = alloc_stack $C
-  debug_value %3, var, name "x", expr op_deref
+  debug_value %3, var, name "x"
   store %2 to [init] %3
   %4 = apply undef(%3) : $@convention(thin) (@in_guaranteed C) -> ()
   %5 = load [copy] %3
   copy_addr %3 to %1
-  debug_value %3, expr op_deref
+  debug_value %3
   destroy_addr %3
   dealloc_stack %3
   return %5
@@ -2403,11 +2403,11 @@ bb0(%0 : @guaranteed $C, %1 : $*C):
 // CHECK:         %2 = alloc_stack $C
 // CHECK:       bb1:
 // CHECK-NEXT:    %4 = store_borrow %0 to %2
-// CHECK-NEXT:    debug_value %4, var, name "x", expr op_deref
+// CHECK-NEXT:    debug_value %4
 // CHECK-NEXT:    apply undef(%4)
 // CHECK-NEXT:    load [copy] %4
 // CHECK-NEXT:    copy_addr %4 to %1
-// CHECK-NEXT:    debug_value %4, expr op_deref
+// CHECK-NEXT:    debug_value %4
 // CHECK-NEXT:    end_borrow %4
 // CHECK-NEXT:    dealloc_stack %2
 // CHECK-LABEL: } // end sil function 'store_to_store_borrow_multi_bb'
@@ -2415,7 +2415,7 @@ sil [ossa] @store_to_store_borrow_multi_bb : $@convention(thin) (@guaranteed C, 
 bb0(%0 : @guaranteed $C, %1 : $*C):
   %2 = copy_value %0
   %3 = alloc_stack $C
-  debug_value %3, var, name "x", expr op_deref
+  debug_value %3, var, name "x"
   br bb1
 
 bb1:
@@ -2423,7 +2423,7 @@ bb1:
   %4 = apply undef(%3) : $@convention(thin) (@in_guaranteed C) -> ()
   %5 = load [copy] %3
   copy_addr %3 to %1
-  debug_value %3, expr op_deref
+  debug_value %3
   destroy_addr %3
   dealloc_stack %3
   return %5

--- a/test/SILOptimizer/let_properties_opts.sil
+++ b/test/SILOptimizer/let_properties_opts.sil
@@ -64,8 +64,8 @@ bb0(%0 : @guaranteed $HasCenter):
   %1 = ref_element_addr %0 : $HasCenter, #HasCenter.centerPoint
   %2 = struct_element_addr %1 : $*Point, #Point.x
   %3 = struct_element_addr %2, #Int64._value
-  debug_value %3, var, name "z", expr op_deref
-  debug_value %2, var, name "x", expr op_deref
+  debug_value %3, var, name "z"
+  debug_value %2, var, name "x"
   %4 = load [trivial] %3
   return %4
 }

--- a/test/SILOptimizer/mark_weak_var_as_sendable.sil
+++ b/test/SILOptimizer/mark_weak_var_as_sendable.sil
@@ -382,7 +382,7 @@ bb0(%arg : @owned $C):
 // CHECK: } // end sil function 'chained_callee'
 sil [ossa] @chained_callee : $@convention(thin) (@guaranteed { var @sil_weak Optional<C> }) -> () {
 bb0(%0 : @closureCapture @guaranteed ${ var @sil_weak Optional<C> }):
-  debug_value %0, var, name "c", argno 1
+  debug_value %0, var, name "c", argno 1, expr op_deref
   %2 = function_ref @simple_callee : $@convention(thin) (@guaranteed { var @sil_weak Optional<C> }) -> ()
   %1 = copy_value %0
   %3 = partial_apply [callee_guaranteed] %2(%1) : $@convention(thin) (@guaranteed { var @sil_weak Optional<C> }) -> ()

--- a/test/SILOptimizer/moveonly_type_eliminator.sil
+++ b/test/SILOptimizer/moveonly_type_eliminator.sil
@@ -613,7 +613,7 @@ sil [ossa] @existential_metatype : $@convention(thin) (@guaranteed any Error) ->
 bb0(%x : @guaranteed $any Error):
   %y = copyable_to_moveonlywrapper [guaranteed] %x : $any Error
   %em = existential_metatype $@thick any Error.Type, %y : $@moveOnly (any Error)
-  debug_value %em : $@thick any Error.Type, var, name "s", argno 1
+  debug_value %em : $@thick any Error.Type, var, name "s", argno 1, expr op_deref
   return %em : $@thick any Error.Type
 }
 


### PR DESCRIPTION
Reverts swiftlang/swift#90016 because it introduces some regressions.