### PR TITLE
[cxx-interop] Propagate availability attrs onto FRT synthesized factory

### DIFF
--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -3116,14 +3116,23 @@ SwiftDeclSynthesizer::synthesizeStaticFactoryForCXXForeignRef(
     }
     synthCxxMethodDecl->setParams(synthParams);
 
-    auto attrInfo = ReturnOwnershipInfo(selectedCtorDecl);
-    if (attrInfo.hasReturnsRetained)
-      synthCxxMethodDecl->addAttr(
-          clang::SwiftAttrAttr::Create(clangCtx, "returns_retained"));
+    if (selectedCtorDecl->hasAttrs()) {
+      auto attrInfo = ReturnOwnershipInfo(selectedCtorDecl);
+      if (attrInfo.hasReturnsRetained)
+        synthCxxMethodDecl->addAttr(
+            clang::SwiftAttrAttr::Create(clangCtx, "returns_retained"));
 
-    if (attrInfo.hasReturnsUnretained)
-      synthCxxMethodDecl->addAttr(
-          clang::SwiftAttrAttr::Create(clangCtx, "returns_unretained"));
+      if (attrInfo.hasReturnsUnretained)
+        synthCxxMethodDecl->addAttr(
+            clang::SwiftAttrAttr::Create(clangCtx, "returns_unretained"));
+
+      for (auto *attr : selectedCtorDecl->getAttrs()) {
+        if (isa<clang::AvailabilityAttr>(attr) ||
+            isa<clang::DeprecatedAttr>(attr) ||
+            isa<clang::UnavailableAttr>(attr))
+          synthCxxMethodDecl->addAttr(attr->clone(clangCtx));
+      }
+    }
 
     std::string swiftInitStr = "init(";
     for (unsigned i = 0; i < ctorParamCount; ++i) {

--- a/test/Interop/Cxx/foreign-reference/Inputs/frt-constructors.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/frt-constructors.h
@@ -148,3 +148,47 @@ FRTMixedConventionCtorsUnretainedByDefault {
 
   FRTMixedConventionCtorsUnretainedByDefault(int, int) : refs(0) {}
 };
+
+struct
+  __attribute__((swift_attr("import_reference")))
+  __attribute__((swift_attr("retain:.retain")))
+  __attribute__((swift_attr("release:.release")))
+FRTUnavailableCtor {
+  mutable int refs = 1;
+  void retain() const { check(); ++refs; }
+  void release() const { --refs; check(); if (refs == 0) delete this; }
+  void check() const { if (refs < 0) __builtin_trap(); }
+
+  __attribute__((swift_attr("returns_retained")))
+  __attribute__((availability(swift, unavailable, message="cannot use this constructor")))
+  FRTUnavailableCtor() : refs(1) {}
+  // expected-note@-1 {{'init()' has been explicitly marked unavailable here}}
+};
+
+struct
+  __attribute__((swift_attr("import_reference")))
+  __attribute__((swift_attr("retain:.retain")))
+  __attribute__((swift_attr("release:.release")))
+FRTMixedAvailabilityCtors {
+  mutable int refs = 1;
+  void retain() const { check(); ++refs; }
+  void release() const { --refs; check(); if (refs == 0) delete this; }
+  void check() const { if (refs < 0) __builtin_trap(); }
+
+  __attribute__((swift_attr("returns_retained")))
+  FRTMixedAvailabilityCtors() : refs(1) {}
+
+  __attribute__((swift_attr("returns_retained")))
+  __attribute__((availability(swift, unavailable, message="cannot construct from an int")))
+  FRTMixedAvailabilityCtors(int) : refs(1) {}
+  // expected-note@-1 {{'init(_:)' has been explicitly marked unavailable here}}
+
+  __attribute__((swift_attr("returns_retained")))
+  __attribute__((unavailable("cannot construct from two ints")))
+  FRTMixedAvailabilityCtors(int, int) : refs(1) {}
+  // expected-note@-1 {{'init(_:_:)' has been explicitly marked unavailable here}}
+
+  __attribute__((swift_attr("returns_retained")))
+  __attribute__((deprecated("don't construct from three ints")))
+  FRTMixedAvailabilityCtors(int, int, int) : refs(1) {}
+};

--- a/test/Interop/Cxx/foreign-reference/frt-constructors-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/frt-constructors-module-interface.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=FRTConstructors -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default -print-implicit-attrs | %FileCheck %s
+
+// A constructor marked `availability(swift, unavailable)` must propagate onto
+// the synthesized foreign reference type initializer, so the imported `init`
+// is `@available(*, unavailable)`.
+
+// CHECK:      class FRTUnavailableCtor {
+// CHECK-NEXT:   @available(*, unavailable, message: "cannot use this constructor")
+// CHECK-NEXT:   init()
+
+// Only the unavailable overload becomes unavailable; the available default
+// initializer must import without any availability attribute.
+// CHECK:      class FRTMixedAvailabilityCtors {
+// CHECK-NEXT:   init(){{$}}
+// CHECK-NEXT:   @available(*, unavailable, message: "cannot construct from an int")
+// CHECK-NEXT:   init(_ __unnamed_param_0: CInt)
+// CHECK-NEXT:   @available(*, unavailable, message: "cannot construct from two ints")
+// CHECK-NEXT:   init(_ __unnamed_param_0: CInt, _ __unnamed_param_1: CInt)
+// CHECK-NEXT:   @available(*, deprecated, message: "don't construct from three ints")
+// CHECK-NEXT:   init(_ __unnamed_param_0: CInt, _ __unnamed_param_1: CInt, _ __unnamed_param_2: CInt)

--- a/test/Interop/Cxx/foreign-reference/frt-constructors-typechecker.swift
+++ b/test/Interop/Cxx/foreign-reference/frt-constructors-typechecker.swift
@@ -1,22 +1,38 @@
-// RUN: %target-typecheck-verify-swift -cxx-interoperability-mode=default -disable-availability-checking -I %S%{fs-sep}Inputs -verify-additional-file %S%{fs-sep}Inputs%{fs-sep}frt-constructors.h
+// RUN: %target-typecheck-verify-swift -cxx-interoperability-mode=default -I %S%{fs-sep}Inputs -verify-additional-file %S%{fs-sep}Inputs%{fs-sep}frt-constructors.h
 
 import FRTConstructors
 
-let _ = FRTImplicitDefaultCtor1() // expected-warning {{cannot infer ownership of foreign reference value}}
-let _ = FRTImplicitDefaultCtor0() // expected-warning {{cannot infer ownership of foreign reference value}}
+@available(SwiftStdlib 5.8, *)
+func ownershipAnnotations() {
+  let _ = FRTImplicitDefaultCtor1() // expected-warning {{cannot infer ownership of foreign reference value}}
+  let _ = FRTImplicitDefaultCtor0() // expected-warning {{cannot infer ownership of foreign reference value}}
 
-let _ = FRTExplicitDefaultCtorNoAnnotation() // expected-warning {{cannot infer ownership of foreign reference value}}
-let _ = FRTExplicitDefaultCtor1()
-let _ = FRTExplicitDefaultCtor0()
+  let _ = FRTExplicitDefaultCtorNoAnnotation() // expected-warning {{cannot infer ownership of foreign reference value}}
+  let _ = FRTExplicitDefaultCtor1()
+  let _ = FRTExplicitDefaultCtor0()
 
-let _ = FRTUserDefaultCtorNoAnnotation() // expected-warning {{cannot infer ownership of foreign reference value}}
-let _ = FRTUserDefaultCtor1()
-let _ = FRTUserDefaultCtor0()
+  let _ = FRTUserDefaultCtorNoAnnotation() // expected-warning {{cannot infer ownership of foreign reference value}}
+  let _ = FRTUserDefaultCtor1()
+  let _ = FRTUserDefaultCtor0()
 
-let _ = FRTMixedConventionCtors()
-let _ = FRTMixedConventionCtors(0)
-let _ = FRTMixedConventionCtors(0, 0) // expected-warning {{cannot infer ownership of foreign reference value}}
+  let _ = FRTMixedConventionCtors()
+  let _ = FRTMixedConventionCtors(0)
+  let _ = FRTMixedConventionCtors(0, 0) // expected-warning {{cannot infer ownership of foreign reference value}}
 
-let _ = FRTMixedConventionCtorsUnretainedByDefault()
-let _ = FRTMixedConventionCtorsUnretainedByDefault(0)
-let _ = FRTMixedConventionCtorsUnretainedByDefault(0, 0)
+  let _ = FRTMixedConventionCtorsUnretainedByDefault()
+  let _ = FRTMixedConventionCtorsUnretainedByDefault(0)
+  let _ = FRTMixedConventionCtorsUnretainedByDefault(0, 0)
+}
+
+@available(SwiftStdlib 5.8, *)
+func ctorWithAvailabilityAttr() {
+  // A constructor marked `availability(swift, unavailable)` makes the synthesized
+  // initializer unavailable in Swift.
+  let _ = FRTUnavailableCtor() // expected-error {{'init()' is unavailable in Swift: cannot use this constructor}}
+
+  // Only the unavailable overload is rejected; the available one still works.
+  let _ = FRTMixedAvailabilityCtors()     // OK
+  let _ = FRTMixedAvailabilityCtors(1)    // expected-error {{'init(_:)' is unavailable in Swift: cannot construct from an int}}
+  let _ = FRTMixedAvailabilityCtors(1, 2) // expected-error {{'init(_:_:)' is unavailable: cannot construct from two ints}}
+  let _ = FRTMixedAvailabilityCtors(1, 2, 3) // expected-warning {{'init(_:_:_:)' is deprecated: don't construct from three ints}}
+}


### PR DESCRIPTION
Synthesized factories for FRTs should inherit the availability attributes from the respective constructor declaration.

rdar://181047261

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
