### PR TITLE
[Literal Expressions] Fold references to static properties in literal expressions

### DIFF
--- a/lib/Sema/LiteralExpressionFolding.cpp
+++ b/lib/Sema/LiteralExpressionFolding.cpp
@@ -125,8 +125,8 @@ static ConcreteDeclRef getIntTypeBuiltinInit(Type type, ASTContext &ctx) {
 
 /// Check if the type is a signed integer type
 static bool isSignedIntegerType(Type type) {
-  return type->isInt() || type->isInt128() || type->isInt64() || type->isInt32() ||
-         type->isInt16() || type->isInt8();
+  return type->isInt() || type->isInt128() || type->isInt64() ||
+         type->isInt32() || type->isInt16() || type->isInt8();
 }
 
 /// A move-only value that's either a `FoldingError` or some parameterized type
@@ -231,6 +231,7 @@ private:
     ASTContext &Ctx;
     llvm::DenseMap<Expr *, FoldingErrorOr<ConstantValuePtr>>
         ConstValuesOrErrors;
+
   public:
     ConstantWalker(ASTContext &ctx) : Ctx(ctx) {}
 
@@ -262,7 +263,9 @@ private:
         return tryFoldParenExpr(parenExpr);
       if (auto *declRefExpr = dyn_cast<DeclRefExpr>(expr))
         return foldDeclRefExpr(declRefExpr);
-      
+      if (auto *memberRefExpr = dyn_cast<MemberRefExpr>(expr))
+        return foldMemberRefExpr(memberRefExpr);
+
       return FoldingError(IllegalConstError::Default, expr->getLoc());
     }
 
@@ -270,7 +273,7 @@ private:
     tryFoldLiteralExpression(const LiteralExpr *expr) {
       if (auto *intLiteralExpr = dyn_cast<IntegerLiteralExpr>(expr))
         return foldIntegerLiteralExpr(intLiteralExpr);
-      
+
       return FoldingError(IllegalConstError::Default, expr->getLoc());
     }
 
@@ -350,53 +353,78 @@ private:
     }
 
     FoldingErrorOr<ConstantValuePtr> foldDeclRefExpr(const DeclRefExpr *expr) {
-      if (const VarDecl *varDecl = dyn_cast<VarDecl>(expr->getDecl())) {
-        // Reject `let` bindings that are part of the module's ABI surface:
-        // package/public/open by access, and `internal` bindings marked
-        // `@usableFromInline` (or `@inlinable`), whose value an inlinable
-        // function could fold into client binaries. Return `UpstreamError` to
-        // suppress the generic "not a literal expression" follow-up. A `var`
-        // falls through to the opaque-decl-ref path, its correct diagnostic.
-        if (!varDecl->hasClangNode() && varDecl->isLet()) {
-          auto access = varDecl->getFormalAccess();
-          if (access >= AccessLevel::Package) {
-            Ctx.Diags.diagnose(expr->getLoc(), diag::const_public_let_ref,
-                               access);
-            return FoldingError(IllegalConstError::UpstreamError,
-                                expr->getLoc());
-          }
-
-          // Safe here: the package/public/open cases returned above, so the
-          // formal access is below public as `isUsableFromInline()` asserts.
-          if (varDecl->isUsableFromInline()) {
-            Ctx.Diags.diagnose(expr->getLoc(),
-                               diag::const_usable_from_inline_let_ref);
-            return FoldingError(IllegalConstError::UpstreamError,
-                                expr->getLoc());
-          }
-        }
-
-        // For other `@const` or `@section` values, we expect
-        // their initializer to be foldable. For other values which
-        // have a default value, we attempt to fold the
-        // corresponding initializer expression.
-        if (varDecl->isConstValue() || varDecl->hasInitialValue())
-          if (auto initExpr = varDecl->getParentInitializer())
-            return tryFoldDeclRefInitializerExpr(initExpr, expr->getLoc());
-
-        // Clang constants are imported as a ValueDecl
-        // with simple getter returning a literal value.
-        if (varDecl->hasClangNode() && !varDecl->isDynamic() &&
-            !varDecl->isObjC() &&
-            varDecl->getImplInfo().getReadImpl() == ReadImplKind::Get)
-          if (auto accessor = varDecl->getAccessor(AccessorKind::Get))
-            if (auto singleRetStmt = dyn_cast<ReturnStmt>(
-                    accessor->getBody()->getSingleActiveStatement()))
-              return tryFoldDeclRefInitializerExpr(singleRetStmt->getResult(),
-                                                   expr->getLoc());
-      }
+      if (const VarDecl *varDecl = dyn_cast<VarDecl>(expr->getDecl()))
+        return foldVarDeclRef(varDecl, expr->getLoc());
 
       return FoldingError(IllegalConstError::OpaqueDeclRef, expr->getLoc());
+    }
+
+    FoldingErrorOr<ConstantValuePtr>
+    foldMemberRefExpr(const MemberRefExpr *expr) {
+      // A reference to a type's static property (e.g. `MyType.count`)
+      // type-checks to a `MemberRefExpr` rather than a `DeclRefExpr`. Fold it
+      // by looking through to the referenced declaration, just like a direct
+      // reference.
+      if (const VarDecl *varDecl =
+              dyn_cast<VarDecl>(expr->getMember().getDecl()))
+        if (varDecl->isStatic())
+          return foldVarDeclRef(varDecl, expr->getLoc());
+
+      return FoldingError(IllegalConstError::OpaqueDeclRef, expr->getLoc());
+    }
+
+    /// Fold a reference to variable/property \p varDecl occurring at
+    /// \p referenceLoc, shared by the `DeclRefExpr` and `MemberRefExpr` paths.
+    FoldingErrorOr<ConstantValuePtr> foldVarDeclRef(const VarDecl *varDecl,
+                                                    SourceLoc referenceLoc) {
+      // Reject `let` bindings that are part of the module's ABI surface:
+      // package/public/open by access, and `internal` bindings marked
+      // `@usableFromInline` (or `@inlinable`), whose value an inlinable
+      // function could fold into client binaries. Return `UpstreamError` to
+      // suppress the generic "not a literal expression" follow-up. A `var`
+      // falls through to the opaque-decl-ref path, its correct diagnostic.
+      if (!varDecl->hasClangNode() && varDecl->isLet()) {
+        auto access = varDecl->getFormalAccess();
+        if (access >= AccessLevel::Package) {
+          Ctx.Diags.diagnose(referenceLoc, diag::const_public_let_ref, access);
+          return FoldingError(IllegalConstError::UpstreamError, referenceLoc);
+        }
+
+        // Safe here: the package/public/open cases returned above, so the
+        // formal access is below public as `isUsableFromInline()` asserts.
+        if (varDecl->isUsableFromInline()) {
+          Ctx.Diags.diagnose(referenceLoc,
+                             diag::const_usable_from_inline_let_ref);
+          return FoldingError(IllegalConstError::UpstreamError, referenceLoc);
+        }
+      }
+
+      // Only fold a reference that is guaranteed to resolve to this exact
+      // declaration, and hence this exact value, at runtime: guard against
+      // `dynamic` members and `class` properties.
+      if (varDecl->isDynamic() || varDecl->isSyntacticallyOverridable())
+        return FoldingError(IllegalConstError::OpaqueDeclRef, referenceLoc);
+
+      // For other `@const` or `@section` values, we expect
+      // their initializer to be foldable. For other values which
+      // have a default value, we attempt to fold the
+      // corresponding initializer expression.
+      if (varDecl->isConstValue() || varDecl->hasInitialValue())
+        if (auto initExpr = varDecl->getParentInitializer())
+          return tryFoldDeclRefInitializerExpr(initExpr, referenceLoc);
+
+      // Clang constants are imported as a ValueDecl
+      // with simple getter returning a literal value.
+      if (varDecl->hasClangNode() && !varDecl->isDynamic() &&
+          !varDecl->isObjC() &&
+          varDecl->getImplInfo().getReadImpl() == ReadImplKind::Get)
+        if (auto accessor = varDecl->getAccessor(AccessorKind::Get))
+          if (auto singleRetStmt = dyn_cast<ReturnStmt>(
+                  accessor->getBody()->getSingleActiveStatement()))
+            return tryFoldDeclRefInitializerExpr(singleRetStmt->getResult(),
+                                                 referenceLoc);
+
+      return FoldingError(IllegalConstError::OpaqueDeclRef, referenceLoc);
     }
 
     FoldingErrorOr<ConstantValuePtr>
@@ -488,10 +516,8 @@ private:
       // The stdlib shift operators take `where RHS : BinaryInteger`, so the
       // RHS does not share signedness or bit width with the LHS. The true
       // bitwise operators `& | ^` do operate on two `Self` values.
-      bool isShift =
-          operatorIdentifier.is("<<") || operatorIdentifier.is(">>");
-      assert(isShift ||
-             lhsVal->getIsSigned() == rhsVal->getIsSigned());
+      bool isShift = operatorIdentifier.is("<<") || operatorIdentifier.is(">>");
+      assert(isShift || lhsVal->getIsSigned() == rhsVal->getIsSigned());
 
       APInt result;
       if (operatorIdentifier.is("&"))

--- a/test/LiteralExpressions/StaticPropertyReferences.swift
+++ b/test/LiteralExpressions/StaticPropertyReferences.swift
@@ -1,0 +1,69 @@
+// Literal expressions may reference a type's `static let` properties. The
+// reference folds through to the property's initializer, subject to the same
+// look-through and ABI-surface restrictions as a direct variable reference.
+
+// REQUIRES: swift_feature_LiteralExpressions
+// RUN: %target-swift-frontend -typecheck -dump-ast %s -disable-availability-checking -enable-experimental-feature LiteralExpressions -verify | %FileCheck %s
+
+// A `static let` whose initializer is itself a chain of static references folds
+// to its literal value.
+enum InvaderGrid {
+  static let rows = 3
+  static let cols = 11
+  static let count = rows * cols
+}
+
+struct GameState {
+  var invaderAlive: [(InvaderGrid.count) of Bool]
+  // CHECK-LABEL: (pattern_named type="[33 of Bool]" "invaderAlive")
+}
+
+// The explicit `InlineArray<...>` spelling folds the same way as the `of` sugar.
+let explicit: InlineArray<(InvaderGrid.count), Bool> = .init(repeating: false)
+// CHECK-LABEL: (pattern_named type="InlineArray<33, Bool>" "explicit")
+
+// A static reference may be combined with operators.
+let arith: [(InvaderGrid.count + 2) of Int] = .init(repeating: 0)
+// CHECK-LABEL: (pattern_named type="[35 of Int]" "arith")
+
+// A static property may reference a static property of another type.
+enum Dim { static let n = 4 }
+enum Layout { static let total = Dim.n * 2 }
+let cross: [(Layout.total) of Int] = .init(repeating: 0)
+// CHECK-LABEL: (pattern_named type="[8 of Int]" "cross")
+
+// A `static let` that is part of the module's ABI surface is rejected, just
+// like a publicly visible top-level `let`.
+public enum Public {
+  public static let size = 4096
+}
+let publicRef: [(Public.size) of UInt8] = .init(repeating: 0)
+// expected-error@-1 {{reference to a public 'let' binding is not permitted in a literal expression}}
+// expected-error@-2 {{generic value must be an integer literal expression}}
+
+// A reference is only foldable if it is guaranteed to resolve to this exact
+// declaration, and hence this exact value, at runtime. A `class` property is
+// dispatched through the metatype and may be overridden by a subclass, so it is
+// not foldable even when the base declaration has a literal value.
+class Overridable {
+  class var shared: Int { 4 }
+}
+let overridable: [(Overridable.shared) of Int] = .init(repeating: 0)
+// expected-error@-1 {{unable to resolve variable reference in a literal expression}}
+// expected-error@-2 {{generic value must be an integer literal expression}}
+
+final class NotOverridable {
+  class var shared: Int { 4 }
+}
+let notOverridable: [(NotOverridable.shared) of Int] = .init(repeating: 0)
+// expected-error@-1 {{unable to resolve variable reference in a literal expression}}
+// expected-error@-2 {{generic value must be an integer literal expression}}
+
+// A `dynamic` member can be replaced at runtime via `@_dynamicReplacement`, so
+// even an immutable `static let` with a literal initializer is not foldable.
+struct Replaceable {
+  dynamic static let value = 8
+}
+let replaceable: [(Replaceable.value) of Int] = .init(repeating: 0)
+// expected-error@-1 {{unable to resolve variable reference in a literal expression}}
+// expected-error@-2 {{generic value must be an integer literal expression}}


### PR DESCRIPTION
The LiteralExpressions folder only handled direct `DeclRefExpr`s, so a static-property access like `MyType.count` (a `MemberRefExpr`) failed  with "not supported in a literal expression" and couldn't be used as e.g. an integer generic argument. 
Add a `MemberRefExpr` case that folds through to the property's initializer, reusing the variable-reference logic (same ABI-surface guards). Only `static` members fold.

```swift
enum InvaderGrid { static let count = 33 }
struct GameState {
  var invaderAlive: [(InvaderGrid.count) of Bool]  // ✅ no longer an error
}
```
