### PR TITLE
[Windows] SxS-bind lldb.exe/repl_swift.exe + set SDKROOT for lldb tests

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3289,8 +3289,9 @@ function Test-Compilers([Hashtable] $Platform, [string] $Variant, [switch] $Test
     if ($TestSwift) {
       $Targets += @("SwiftCompilerPlugin", "check-swift")
     }
-    if ($TestLLDB) { $Targets += @("check-lldb") }
-    if ($TestLLDBSwift) { $Targets += @("check-lldb-swift") }
+    $LLDBTargets = @()
+    if ($TestLLDB) { $LLDBTargets += @("check-lldb") }
+    if ($TestLLDBSwift) { $LLDBTargets += @("check-lldb-swift") }
     if ($TestLLDB -or $TestLLDBSwift) {
       # Override test filter for known issues in downstream LLDB
       Load-LitTestOverrides ([IO.Path]::GetFullPath([IO.Path]::Combine($PSScriptRoot, "..", "..", "llvm-project", "lldb", "test", "windows-swift-llvm-lit-test-overrides.txt")))
@@ -3328,7 +3329,7 @@ function Test-Compilers([Hashtable] $Platform, [string] $Variant, [switch] $Test
       }
     }
 
-    if (-not $Targets) {
+    if ((-not $Targets) -and (-not $LLDBTargets)) {
       Write-Warning "Test-Compilers invoked without specifying test target(s)."
     }
 
@@ -3395,7 +3396,9 @@ function Test-Compilers([Hashtable] $Platform, [string] $Variant, [switch] $Test
                                    "sourcekitd-test.exe",
                                    "swift-ide-test.exe",
                                    "swift-plugin-server.exe",
-                                   "swiftc-legacy-driver.exe"
+                                   "swiftc-legacy-driver.exe",
+                                   "lldb.exe",
+                                   "repl_swift.exe"
                                  )
       # SxS only probes the EXE's own directory for the named assembly.
       if (Test-Path (Join-Path $Stage2LibexecSwiftDir "swift-backtrace.exe")) {
@@ -3414,8 +3417,14 @@ function Test-Compilers([Hashtable] $Platform, [string] $Variant, [switch] $Test
     # that load them, otherwise the linker races with memory-mapped DLLs
     # causing LNK1104. Build swift-test-stdlib first to enforce ordering.
     $Targets = @("swift-test-stdlib") + $Targets
-
     Build-CMakeProject @BuildCMakeArgs -BuildTargets $Targets
+
+    if ($LLDBTargets) {
+      Invoke-IsolatingEnvVars {
+        $env:SDKROOT = $SwiftSDK
+        Build-CMakeProject @BuildCMakeArgs -BuildTargets $LLDBTargets
+      }
+    }
   }
 }
 


### PR DESCRIPTION
On Windows the SwiftREPL / expression evaluator failed in two ways during `check-lldb-swift`:

1. `SDKROOT` was never set for the test run, so the REPL's SDK lookup failed with `"error: Error while searching for SDK: HostInfoError"`, polluting stdout and breaking FileCheck. Set `$env:SDKROOT = $SwiftSDK` for the lldb test run.

2. `lldb.exe` and `repl_swift.exe` were not in the SxS Tools list, causing them to resolve the wrong `swiftCore.dll`. Bind `lldb.exe/repl_swift.exe` so they load the correct `swiftCore.dll`, mirroring how the API tests' `_lldb.pyd` gets its runtime via the site-packages copy.

This fixes ~21 SwiftREPL shell tests.