### PR TITLE
SIL: reimplement SSAUpdater in pure Swift

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/DeadObjectElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/DeadObjectElimination.swift
@@ -638,6 +638,7 @@ private struct UseCollector : AddressDefUseWalker {
     var ssaUpdater = SSAUpdater(type: accesses.valueType,
                                 ownership: isTrivial ? .none : .owned,
                                 context)
+    defer { ssaUpdater.deinitialize() }
 
     // Prevent any phi arguments to be created "before" the allocation
     let undef = Undef.get(type: accesses.valueType, context)

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LetPropertyLowering.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LetPropertyLowering.swift
@@ -100,6 +100,8 @@ private func insertEndInitInstructions(
   _ context: FunctionPassContext
 ) {
   var ssaUpdater = SSAUpdater(type: markUninitialized.type, ownership: .owned, context)
+  defer { ssaUpdater.deinitialize() }
+
   ssaUpdater.addAvailableValue(markUninitialized, in: markUninitialized.parentBlock)
 
   for endInst in initRegion.ends {
@@ -121,8 +123,6 @@ private func insertEndInitInstructions(
       use.set(to: ssaUpdater.getValue(atEndOf: use.instruction.parentBlock), context)
     }
   }
-  // This peephole optimization is required to avoid ownership errors.
-  replacePhisWithIncomingValues(phis: ssaUpdater.insertedPhis, context)
 }
 
 private func constructLetInitRegion(

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
@@ -778,7 +778,8 @@ private extension MovableInstructions {
       ownership: phiOwnership,
       context
     )
-    
+    defer { ssaUpdater.deinitialize() }
+
     // Set all stored values as available values in the ssaUpdater.
     for case let storeInst as StoreInst in loadsAndStores where storeInst.storesTo(accessPath) {
       ssaUpdater.addAvailableValue(storeInst.source, in: storeInst.parentBlock)
@@ -839,8 +840,8 @@ private extension MovableInstructions {
       }
       
       // If we didn't see a store in this block yet, get the current value from the ssaUpdater.
-      let rootVal = currentVal ?? ssaUpdater.getValue(inMiddleOf: block)
-      
+      let rootVal = currentVal ?? ssaUpdater.getValue(atBeginOf: block)
+
       if loadInst.operand.value.accessPath == accessPath {
         if loadInst.loadOwnership == .copy {
           let builder = Builder(before: loadInst, context)
@@ -877,7 +878,7 @@ private extension MovableInstructions {
       let builder = Builder(before: exitBlock.instructions.first!, context)
       
       builder.createStore(
-        source: ssaUpdater.getValue(inMiddleOf: exitBlock),
+        source: ssaUpdater.getValue(atBeginOf: exitBlock),
         destination: initialAddr,
         ownership: firstStore.storeOwnership
       )

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/RedundantLoadElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/RedundantLoadElimination.swift
@@ -346,6 +346,7 @@ private extension LoadingInstruction {
 
 private func replace(load: LoadingInstruction, with availableValues: [AvailableValue], _ context: FunctionPassContext) {
   var ssaUpdater = SSAUpdater(type: load.type, ownership: load.ownership, context)
+  defer { ssaUpdater.deinitialize() }
 
   for availableValue in availableValues.replaceCopyAddrsWithLoadsAndStores(context) {
     let block = availableValue.instruction.parentBlock
@@ -373,7 +374,7 @@ private func replace(load: LoadingInstruction, with availableValues: [AvailableV
     //     store %3 to %addr   // another available value
     //     cond_br bb1, bb2
     //
-    newValue = ssaUpdater.getValue(inMiddleOf: load.parentBlock)
+    newValue = ssaUpdater.getValue(atBeginOf: load.parentBlock)
   }
 
   let originalLoad = load.materializeLoadForReplacement(context)

--- a/SwiftCompilerSources/Sources/SIL/Utilities/SSAUpdater.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/SSAUpdater.swift
@@ -12,50 +12,239 @@
 
 import SILBridging
 
-/// Utility for updating SSA for a set of SIL instructions defined in multiple blocks.
+/// Utility for constructing SSA form for a value which is redefined in multiple basic blocks,
+/// inserting phi arguments (block arguments fed by `br` instructions) wherever control flow
+/// merges values coming from different definitions.
+///
+/// Usage:
+/// 1. Register the values that are already available at the end of certain blocks via
+///    `addAvailableValue`.
+/// 2. Query the value that is visible at the end of, or at the beginning of, some block via
+///    `getValue(atEndOf:)` or `getValue(atBeginOf:)`. Missing values are constructed on demand by
+///    inserting phi arguments where needed.
+///
+/// All available values must be registered with `addAvailableValue` before the first `getValue`
+/// call that could reach the corresponding block.
+///
 public struct SSAUpdater<Context: MutatingContext> {
-  let context: Context
+  private let context: Context
+  private let type: Type
+  private let ownership: Ownership
 
+  /// All blocks between available-value blocks (exclusive) and getValue blocks (inclusive)
+  private var liverange: BasicBlockWorklist
+
+  /// Values for blocks which are explicitly set via `addAvailableValue`
+  private var availableValues = Dictionary<BasicBlock, Value>()
+
+  private var computedValuesAtBeginOfBlocks = Dictionary<BasicBlock, Value>()
+
+  /// The phi arguments which were inserted so far by `getValue`, in the order they were created.
+  public var insertedPhis = [Phi]()
+
+  /// Creates a new SSA-updater for values of `type` with the given `ownership`.
+  ///
+  /// All values that are constructed or merged by this updater (available values passed to
+  /// `addAvailableValue` and inserted phi arguments) must have this `type` and `ownership`.
   public init(type: Type, ownership: Ownership, _ context: Context) {
     self.context = context
-    context._bridged.SSAUpdater_initialize(type.bridged, ownership._bridged)
+    self.type = type
+    self.ownership = ownership
+    self.liverange = BasicBlockWorklist(context)
   }
 
+  public mutating func deinitialize() {
+    liverange.deinitialize()
+  }
+
+  /// Registers `value` as the available value at the *end* of `block`.
+  ///
+  /// Must be called before any `getValue` call which could reach `block` in its search for
+  /// available values, i.e. before `block` is included in the liverange of a query.
   public mutating func addAvailableValue(_ value: Value, in block: BasicBlock) {
-    context._bridged.SSAUpdater_addAvailableValue(block.bridged, value.bridged)
+    precondition(!liverange.hasBeenPushed(block), "added an available value after a value has been queried")
+    availableValues[block] = value
   }
 
-  /// Construct SSA for a value that is live at the *end* of a basic block.
+  /// Returns the value that is live at the *end* of `block`, i.e. the value seen by a use in a
+  /// successor block.
+  ///
+  /// If `block` has a registered available value, that value is returned directly. Otherwise
+  /// this falls back to `getValue(atBeginOf:)`.
   public mutating func getValue(atEndOf block: BasicBlock) -> Value {
-    context.notifyInstructionsChanged()
-    return context._bridged.SSAUpdater_getValueAtEndOfBlock(block.bridged).value
-  }
-
-  /// Construct SSA for a value that is live in the *middle* of a block.
-  /// This handles the case where the use is before a definition of the value in the same block.
-  ///
-  ///   bb1:
-  ///     %1 = def
-  ///     br bb2
-  ///   bb2:
-  ///       = use(?)
-  ///    %2 = def
-  ///    cond_br bb2, bb3
-  ///
-  /// In this case we need to insert a phi argument in bb2, merging %1 and %2.
-  public mutating func getValue(inMiddleOf block: BasicBlock) -> Value {
-    context.notifyInstructionsChanged()
-    return context._bridged.SSAUpdater_getValueInMiddleOfBlock(block.bridged).value
-  }
-
-  public var insertedPhis: [Phi] {
-    var phis = [Phi]()
-    let numPhis = context._bridged.SSAUpdater_getNumInsertedPhis()
-    phis.reserveCapacity(numPhis)
-    for idx in 0..<numPhis {
-      phis.append(Phi(context._bridged.SSAUpdater_getInsertedPhi(idx).value)!)
+    if let value = availableValues[block] {
+      return value
     }
-    return phis
+    return getValue(atBeginOf: block)
+  }
+
+  /// Returns the value that is live at the *beginning* of `block`, constructing SSA form for it.
+  ///
+  /// If `block` is not reachable from any available value along some path (e.g. it's the
+  /// function's entry block, or an unreachable block), that path contributes `Undef`.
+  ///
+  public mutating func getValue(atBeginOf block: BasicBlock) -> Value {
+    let numExistingPhis = insertedPhis.count
+
+    // Walk backwards from `block` along predecessors to find the (already computed or available)
+    // values that reach `block`.
+    // and returns the (possibly newly inserted phi) value which is visible at
+    // the beginning of `block`.
+    //
+    let blocksInLiverange = computeLiverange(startingAt: block)
+
+    // Populate values for all blocks in the liverange and insert phi arguments in blocks
+    // where control flow merges different values.
+    while propagateValuesThrough(blocks: blocksInLiverange) {
+    }
+
+    for i in (numExistingPhis ..< insertedPhis.count) {
+      addBranchArguments(for: insertedPhis[i])
+    }
+
+    return computedValuesAtBeginOfBlocks[block]!
+  }
+
+  /// Collects all blocks which need a computed value in order to determine the value at
+  /// `startBlock`, by walking backwards from `startBlock` along predecessors, stopping at blocks
+  /// which already have an available or computed value.
+  private mutating func computeLiverange(startingAt startBlock: BasicBlock) -> [BasicBlock] {
+    var blocksInLiverange = [BasicBlock]()
+
+    liverange.pushIfNotVisited(startBlock)
+    while let block = liverange.pop() {
+      blocksInLiverange.append(block)
+      for pred in block.predecessors where availableValues[pred] == nil {
+        liverange.pushIfNotVisited(pred)
+      }
+    }
+    return blocksInLiverange
+  }
+
+  /// Computes the value at the beginning of each block in `blocks`, deriving it from the
+  /// (already available or already computed) values at the end of its predecessors, inserting a
+  /// phi argument whenever predecessors disagree.
+  ///
+  /// This must be called repeatedly until it returns `false`, because a block's value can depend
+  /// on a not yet computed value of a not yet processed block (e.g. in a loop). Returns whether
+  /// any block's value changed in this call, i.e. whether another call is needed to reach a
+  /// fixed point.
+  private mutating func propagateValuesThrough(blocks: [BasicBlock]) -> Bool {
+    var changed = false
+
+    // The `blocks` contains block in backward control flow order. We want to propagate values in
+    // forward order. Therefore we have to reverse the list.
+    for block in blocks.reversed() {
+      if let existingValue = computedValuesAtBeginOfBlocks[block] {
+        if existingValue.isPhi(in: block) {
+          // Avoid creating another phi if we already have one created in this block.
+          continue
+        }
+        guard let value = deriveValueFromPredecessors(of: block) else {
+          assert(block.predecessors.isEmpty, "should have a predecessor value here, except for the entry block")
+          continue
+        }
+        if value != existingValue {
+          assert(Phi(value) != nil, "a mismatching value can only be a phi argument")
+          // `existingValue` can be stale: it may have been computed before a phi was inserted
+          // further up the control flow graph, and so far that phi has only been propagated into
+          // some of `block`'s predecessors. Any block that merely forwarded `existingValue`
+          // (instead of deriving a phi of its own) must be invalidated as well, so it gets
+          // recomputed from the now-current predecessor values on the next iteration instead of
+          // continuing to reference the stale one.
+          clearValues(value: existingValue, startingAt: block)
+
+          computedValuesAtBeginOfBlocks[block] = value
+          changed = true
+        }
+      } else {
+        if block.predecessors.isEmpty {
+          // The liverange computation can only reach the function entry (or an unreachable block)
+          // if an available value is missing on some path. This is a corner case.
+          let undef = Undef.get(type: type, context)
+          computedValuesAtBeginOfBlocks[block] = undef
+        } else if let value = deriveValueFromPredecessors(of: block) {
+          computedValuesAtBeginOfBlocks[block] = value
+          changed = true
+        }
+      }
+    }
+    return changed
+  }
+
+  /// Returns the single value which reaches `block` from all of its predecessors, inserting a
+  /// new phi argument in `block` if predecessors disagree. Returns `nil` if no predecessor has
+  /// a value yet (which means `block` cannot yet be resolved in this fixed-point iteration).
+  private mutating func deriveValueFromPredecessors(of block: BasicBlock) -> Value? {
+    var uniqueValue: Value?
+    for predecessor in block.predecessors {
+      if let v = getComputedValue(atEndOf: predecessor) {
+        if let previous = uniqueValue {
+          if previous != v {
+            let phiArg = block.addArgument(type: type, ownership: ownership, context)
+            insertedPhis.append(Phi(phiArg)!)
+            return phiArg
+          }
+        } else {
+          uniqueValue = v
+        }
+      }
+    }
+    return uniqueValue
+  }
+
+  /// Returns the value at the end of `block`: either its available value, or its already
+  /// computed value at the beginning of the block.
+  private func getComputedValue(atEndOf block: BasicBlock) -> Value? {
+    if let availableValue = availableValues[block] {
+      return availableValue
+    }
+    return computedValuesAtBeginOfBlocks[block]
+  }
+
+  /// Removes the cached value of `startBlock` and, transitively, of all successors whose cached
+  /// value is exactly `value` (i.e. blocks which merely forwarded `value` rather than deriving a
+  /// phi of their own), so they get recomputed from their (now possibly different) predecessor
+  /// values in the next `propagateValuesThrough` iteration.
+  private mutating func clearValues(value: Value, startingAt startBlock: BasicBlock) {
+    var worklist = BasicBlockWorklist(context)
+    defer { worklist.deinitialize() }
+
+    worklist.pushIfNotVisited(startBlock)
+    while let block = worklist.pop() {
+      if let v = computedValuesAtBeginOfBlocks[block], v == value {
+        // Don't clear the block which _defines_ `value` as its own phi. Such a block doesn't
+        // merely forward `value`, it is its definition. This can happen if `value` is a loop-header
+        // phi and the successor walk reaches the header again via a back-edge. Clearing it would
+        // drop the genuine phi and cause a duplicate phi to be inserted on the next iteration.
+        if value.isPhi(in: block) {
+          continue
+        }
+        computedValuesAtBeginOfBlocks.removeValue(forKey: block)
+        worklist.pushIfNotVisited(contentsOf: block.successors)
+      }
+    }
+  }
+
+  /// Rewrites each `br` predecessor of `phi`'s block to also pass the value that is live at the
+  /// end of that predecessor, making `phi` an actual SIL phi argument.
+  private func addBranchArguments(for phi: Phi) {
+    var previousPredVal: Value? = nil
+    var diff = false
+    for pred in phi.predecessors {
+      let oldBranch = pred.terminator as! BranchInst
+      let builder = Builder(before: oldBranch, context)
+      let predVal = getComputedValue(atEndOf: pred)!
+      if predVal != phi.value {
+        if let previousPredVal, predVal != previousPredVal {
+          diff = true
+        }
+        previousPredVal = predVal
+      }
+      builder.createBranch(to: oldBranch.targetBlock, arguments: Array(oldBranch.operands.values) + [predVal])
+      context.erase(instruction: oldBranch)
+    }
+    assert(diff, "inserted a phi argument for identical input values")
   }
 }
 
@@ -137,6 +326,10 @@ public struct InstructionBasedSSAUpdater<Context: MutatingContext> {
     self.ssaUpdater = SSAUpdater(type: type, ownership: ownership, context)
   }
 
+  public mutating func deinitialize() {
+    ssaUpdater.deinitialize()
+  }
+
   /// Registers `value` as available for uses which are dominated by `instruction` within its block.
   public mutating func addAvailableValue(_ value: Value, after instruction: Instruction) {
     let block = instruction.parentBlock
@@ -156,15 +349,62 @@ public struct InstructionBasedSSAUpdater<Context: MutatingContext> {
     {
       return value
     }
-    return ssaUpdater.getValue(inMiddleOf: instruction.parentBlock)
+    return ssaUpdater.getValue(atBeginOf: instruction.parentBlock)
   }
 
+  /// The phi arguments which were inserted so far by `getValue`, in the order they were created.
   public var insertedPhis: [Phi] { ssaUpdater.insertedPhis }
+}
+
+private extension Value {
+  func isPhi(in block: BasicBlock) -> Bool {
+    if let arg = self as? Argument, arg.parentBlock == block {
+      return true
+    }
+    return false
+  }
 }
 
 //===----------------------------------------------------------------------===//
 //                               Unit Tests
 //===----------------------------------------------------------------------===//
+
+let ssaUpdaterTest = Test("ssa_updater") {
+  function, arguments, context in
+
+  // Available values are all `integer_literal` instructions, defined at their use points.
+  // Then all `undef` operands are replaced by the value at that point.
+
+  let availableValues = getTestAvailableValues(in: function)
+
+  guard let firstValue = availableValues.first else {
+    return
+  }
+
+  var ssaUpdater = SSAUpdater(type: firstValue.type, ownership: firstValue.ownership, context)
+  defer { ssaUpdater.deinitialize() }
+
+  var availableValuesInBlocks = Dictionary<BasicBlock, IntegerLiteralInst>()
+
+  for v in availableValues {
+    ssaUpdater.addAvailableValue(v, in: v.parentBlock)
+    availableValuesInBlocks[v.parentBlock] = v
+  }
+
+  for block in function.blocks {
+    for inst in block.instructions {
+      for op in inst.operands where op.value is Undef && op.value.type == firstValue.type {
+        let v: Value
+        if let available = availableValuesInBlocks[block], available.strictlyDominatesInBlock(inst) {
+          v = ssaUpdater.getValue(atEndOf: block)
+        } else {
+          v = ssaUpdater.getValue(atBeginOf: block)
+        }
+        op.set(to: v, context)
+      }
+    }
+  }
+}
 
 let instructionBasedSSAUpdaterTest = Test("instruction_based_ssa_updater") {
   function, arguments, context in
@@ -172,6 +412,30 @@ let instructionBasedSSAUpdaterTest = Test("instruction_based_ssa_updater") {
   // Available values are all `integer_literal` instructions, defined at their use points.
   // Then all `undef` operands are replaced by the value at that point.
 
+  let availableValues = getTestAvailableValues(in: function)
+
+  guard let firstValue = availableValues.first else {
+    return
+  }
+
+  var ssaUpdater = InstructionBasedSSAUpdater(type: firstValue.type, ownership: firstValue.ownership, context)
+  defer { ssaUpdater.deinitialize() }
+
+  for v in availableValues {
+    for user in v.users {
+      ssaUpdater.addAvailableValue(v, after: user)
+    }
+  }
+
+  for inst in function.instructions {
+    for op in inst.operands where op.value is Undef && op.value.type == firstValue.type {
+      let v = ssaUpdater.getValue(before: inst)
+      op.set(to: v, context)
+    }
+  }
+}
+
+private func getTestAvailableValues(in function: Function) -> [IntegerLiteralInst] {
   var availableValues = [IntegerLiteralInst]()
 
   for inst in function.instructions {
@@ -182,25 +446,5 @@ let instructionBasedSSAUpdaterTest = Test("instruction_based_ssa_updater") {
 
   availableValues.sort(by: { $0.value! < $1.value! })
 
-  guard let firstValue = availableValues.first else {
-    return
-  }
-
-  var ssaUpdater = InstructionBasedSSAUpdater(type: firstValue.type, ownership: firstValue.ownership, context)
-
-  for v in availableValues {
-    for user in v.users {
-      ssaUpdater.addAvailableValue(v, after: user)
-    }
-  }
-
-  for inst in function.instructions {
-    for op in inst.operands {
-      if op.value is Undef {
-        let v = ssaUpdater.getValue(before: inst)
-        op.set(to: v, context)
-      }
-    }
-  }
+  return availableValues
 }
-

--- a/SwiftCompilerSources/Sources/SIL/Utilities/Test.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/Test.swift
@@ -152,6 +152,7 @@ public func registerTests() {
     replacePhisWithIncomingValuesTest,
     borrowIntroducersTest,
     enclosingValuesTest,
+    ssaUpdaterTest,
     instructionBasedSSAUpdaterTest,
     forwardingDefUseTest,
     forwardingUseDefTest,

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -1645,15 +1645,6 @@ struct BridgedContext {
   static BRIDGED_INLINE void copyInstructionBefore(BridgedInstruction inst, BridgedInstruction beforeInst);
   static BRIDGED_INLINE void salvageDebugInfo(BridgedInstruction inst);
 
-    // SSAUpdater
-
-  BRIDGED_INLINE void SSAUpdater_initialize(BridgedType type, BridgedValue::Ownership ownership) const;
-  BRIDGED_INLINE void SSAUpdater_addAvailableValue(BridgedBasicBlock block, BridgedValue value) const;
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedValue SSAUpdater_getValueAtEndOfBlock(BridgedBasicBlock block) const;
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedValue SSAUpdater_getValueInMiddleOfBlock(BridgedBasicBlock block) const;
-  BRIDGED_INLINE SwiftInt SSAUpdater_getNumInsertedPhis() const;
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedValue SSAUpdater_getInsertedPhi(SwiftInt idx) const;
-
   // Sets
 
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedBasicBlockSet allocBasicBlockSet() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -3537,30 +3537,6 @@ OptionalBridgedFunction BridgedContext::lookupStdlibFunction(BridgedStringRef na
   return {context->lookupStdlibFunction(name.unbridged())};
 }
 
-void BridgedContext::SSAUpdater_initialize(BridgedType type, BridgedValue::Ownership ownership) const {
-  context->initializeSSAUpdater(context->getFunction(), type.unbridged(), BridgedValue::unbridge(ownership));
-}
-
-void BridgedContext::SSAUpdater_addAvailableValue(BridgedBasicBlock block, BridgedValue value) const {
-  context->SSAUpdater_addAvailableValue(block.unbridged(), value.getSILValue());
-}
-
-BridgedValue BridgedContext::SSAUpdater_getValueAtEndOfBlock(BridgedBasicBlock block) const {
-  return {context->SSAUpdater_getValueAtEndOfBlock(block.unbridged())};
-}
-
-BridgedValue BridgedContext::SSAUpdater_getValueInMiddleOfBlock(BridgedBasicBlock block) const {
-  return {context->SSAUpdater_getValueInMiddleOfBlock(block.unbridged())};
-}
-
-SwiftInt BridgedContext::SSAUpdater_getNumInsertedPhis() const {
-  return (SwiftInt)context->SSAUpdater_getInsertedPhis().size();
-}
-
-BridgedValue BridgedContext::SSAUpdater_getInsertedPhi(SwiftInt idx) const {
-  return {context->SSAUpdater_getInsertedPhis()[idx]};
-}
-
 BridgedBasicBlockSet BridgedContext::allocBasicBlockSet() const {
   return {context->allocBlockSet()};
 }

--- a/include/swift/SIL/SILContext.h
+++ b/include/swift/SIL/SILContext.h
@@ -20,8 +20,6 @@
 
 namespace swift {
 
-class SILSSAUpdater;
-
 /// The abstract base class for the C++ implementation of Context in SwiftCompilerSources.
 /// Referenced in BridgedContext.
 ///
@@ -70,9 +68,6 @@ protected:
 
   int numClonersAllocated = 0;
 
-  SILSSAUpdater *ssaUpdater = nullptr;
-  SmallVector<SILPhiArgument *, 4> insertedPhisBySSAUpdater;
-
   /// Change notifications, collected during a pass run.
   NotificationKind changeNotifications = NotificationKind::Nothing;
 
@@ -119,14 +114,6 @@ public:
   virtual void moveFunctionBody(SILFunction *sourceFn, SILFunction *destFn) = 0;
 
   virtual SILFunction *lookupStdlibFunction(StringRef name) = 0;
-
-  // The SILSSAUpdater is implemented in the Optimizer. Therefore all the APIs need to take
-  // the indirection through virtual functions to SwiftPassInvocation.
-  virtual void initializeSSAUpdater(SILFunction *function, SILType type, ValueOwnershipKind ownership) = 0;
-  virtual void SSAUpdater_addAvailableValue(SILBasicBlock *block, SILValue value) = 0;
-  virtual SILValue SSAUpdater_getValueAtEndOfBlock(SILBasicBlock *block) = 0;
-  virtual SILValue SSAUpdater_getValueInMiddleOfBlock(SILBasicBlock *block) = 0;
-  ArrayRef<SILPhiArgument*> SSAUpdater_getInsertedPhis() { return insertedPhisBySSAUpdater; }
 };
 
 } // namespace swift

--- a/include/swift/SILOptimizer/PassManager/PassManager.h
+++ b/include/swift/SILOptimizer/PassManager/PassManager.h
@@ -107,11 +107,6 @@ public:
 
   SILFunction *lookupStdlibFunction(StringRef name) override;
 
-  void initializeSSAUpdater(SILFunction *function, SILType type, ValueOwnershipKind ownership) override;
-  void SSAUpdater_addAvailableValue(SILBasicBlock *block, SILValue value) override;
-  SILValue SSAUpdater_getValueAtEndOfBlock(SILBasicBlock *block) override;
-  SILValue SSAUpdater_getValueInMiddleOfBlock(SILBasicBlock *block) override;
-
   /// Called by the pass manager before the pass starts running.
   void startModulePassRun(SILModuleTransform *transform);
 

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -1534,12 +1534,6 @@ void SwiftPassInvocation::finishedFunctionPassRun() {
 
   updateAnalysis();
 
-  insertedPhisBySSAUpdater.clear();
-  if (ssaUpdater) {
-    delete ssaUpdater;
-    ssaUpdater = nullptr;
-  }
-
   function = nullptr;
   transform = nullptr;
   silCombiner = nullptr;
@@ -1642,23 +1636,4 @@ SILFunction *SwiftPassInvocation::lookupStdlibFunction(StringRef name) {
   SILDeclRef declRef(decl, SILDeclRef::Kind::Func);
   SILOptFunctionBuilder funcBuilder(*getTransform());
   return funcBuilder.getOrCreateFunction(SILLocation(decl), declRef, NotForDefinition);
-}
-
-void SwiftPassInvocation::initializeSSAUpdater(SILFunction *function, SILType type, ValueOwnershipKind ownership) {
-  insertedPhisBySSAUpdater.clear();
-  if (!ssaUpdater)
-    ssaUpdater = new SILSSAUpdater(&insertedPhisBySSAUpdater);
-  ssaUpdater->initialize(function, type, ownership);
-}
-
-void SwiftPassInvocation::SSAUpdater_addAvailableValue(SILBasicBlock *block, SILValue value) {
-  ssaUpdater->addAvailableValue(block, value);
-}
-
-SILValue SwiftPassInvocation::SSAUpdater_getValueAtEndOfBlock(SILBasicBlock *block) {
-  return ssaUpdater->getValueAtEndOfBlock(block);
-}
-
-SILValue SwiftPassInvocation::SSAUpdater_getValueInMiddleOfBlock(SILBasicBlock *block) {
-  return ssaUpdater->getValueInMiddleOfBlock(block);
 }

--- a/test/SILOptimizer/dead-object-elimination.sil
+++ b/test/SILOptimizer/dead-object-elimination.sil
@@ -5779,3 +5779,49 @@ bb0(%0 : @owned $Builtin.NativeObject):
   return %r
 }
 
+// CHECK-LABEL: sil [ossa] @cleanup_inserted_phis :
+// CHECK:         %1 = begin_borrow %0
+// CHECK:       bb9:
+// CHECK:         end_borrow %1
+// CHECK:         destroy_value %0
+// CHECK-LABEL: } // end sil function 'cleanup_inserted_phis'
+sil [ossa] @cleanup_inserted_phis : $@convention(thin) (@owned Kl) -> () {
+bb0(%0 : @owned $Kl):
+  %1 = alloc_stack $Kl
+  store %0 to [init] %1
+  %3 = load_borrow %1
+  fix_lifetime %3
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3
+
+bb2:
+  cond_br undef, bb5, bb6
+
+bb3:
+  br bb4
+
+bb4:
+  br bb9
+
+bb5:
+  br bb9
+
+bb6:
+  cond_br undef, bb7, bb8
+
+bb7:
+  br bb3
+
+bb8:
+  br bb4
+
+bb9:
+  end_borrow %3
+  %15 = load [take] %1
+  destroy_value %15
+  dealloc_stack %1
+  %18 = tuple ()
+  return %18
+}

--- a/test/SILOptimizer/ssa-updater.sil
+++ b/test/SILOptimizer/ssa-updater.sil
@@ -15,6 +15,10 @@ sil @c2 : $@convention(thin) (@guaranteed C) -> @owned C
 sil @use_int64 : $@convention(thin) (Builtin.Int64) -> ()
 sil @use_two_int64 : $@convention(thin) (Builtin.Int64, Builtin.Int64) -> ()
 
+//===----------------------------------------------------------------------===//
+//                      C++ SSAUpdater tests
+//===----------------------------------------------------------------------===//
+
 // CHECK-LABEL: sil [ossa] @reuse_phi_arg1 :
 // CHECK:       bb17([[P:%.*]] : @owned $C):
 // CHECK:         apply {{%[0-9]+}}([[P]])
@@ -183,6 +187,266 @@ bb23:
   br bb3
 
 }
+
+//===----------------------------------------------------------------------===//
+//                      Swift SSAUpdater tests
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: sil @single_block :
+// CHECK:       bb0:
+// CHECK-NEXT:    fix_lifetime undef
+// CHECK-NEXT:    [[L1:%.*]] = integer_literal $Builtin.Int64, 1
+// CHECK-NEXT:    return [[L1]]
+// CHECK:       } // end sil function 'single_block'
+sil @single_block : $@convention(thin) () -> Builtin.Int64 {
+bb0:
+  specify_test "ssa_updater"
+  fix_lifetime undef : $Builtin.Int64
+  %1 = integer_literal $Builtin.Int64, 1
+  return undef : $Builtin.Int64
+}
+
+// CHECK-LABEL: sil @simple_phi :
+// CHECK:       bb0:
+// CHECK-NEXT:    fix_lifetime undef
+// CHECK:       bb1:
+// CHECK-NEXT:    fix_lifetime undef
+// CHECK-NEXT:    [[L1:%.*]] = integer_literal $Builtin.Int64, 1
+// CHECK-NEXT:    fix_lifetime [[L1]]
+// CHECK-NEXT:    br bb3([[L1]])
+// CHECK:       bb2:
+// CHECK:         [[L2:%.*]] = integer_literal $Builtin.Int64, 2
+// CHECK-NEXT:    br bb3([[L2]])
+// CHECK:       bb3([[PHI:%.*]] : $Builtin.Int64):
+// CHECK-NEXT:    return [[PHI]]
+// CHECK:       } // end sil function 'simple_phi'
+sil @simple_phi : $@convention(thin) () -> Builtin.Int64 {
+bb0:
+  specify_test "ssa_updater"
+  fix_lifetime undef : $Builtin.Int64
+  cond_br undef, bb1, bb2
+
+bb1:
+  fix_lifetime undef : $Builtin.Int64
+  %1 = integer_literal $Builtin.Int64, 1
+  fix_lifetime undef : $Builtin.Int64
+  br bb3
+
+bb2:
+  %2 = integer_literal $Builtin.Int64, 2
+  br bb3
+
+bb3:
+  return undef : $Builtin.Int64
+}
+
+// CHECK-LABEL: sil @two_phis :
+// CHECK:       bb0:
+// CHECK-NEXT:    [[L1:%.*]] = integer_literal $Builtin.Int64, 1
+// CHECK:       bb1:
+// CHECK-NEXT:    br bb6([[L1]])
+// CHECK:       bb3:
+// CHECK-NEXT:    br bb5([[L1]])
+// CHECK:       bb4:
+// CHECK-NEXT:    [[L2:%.*]] = integer_literal $Builtin.Int64, 2
+// CHECK-NEXT:    br bb5([[L2]])
+// CHECK:       bb5([[PHI1:%.*]] : $Builtin.Int64):
+// CHECK-NEXT:    br bb6([[PHI1]])
+// CHECK:       bb6([[PHI2:%.*]] : $Builtin.Int64):
+// CHECK-NEXT:    return [[PHI2]]
+// CHECK:       } // end sil function 'two_phis'
+sil @two_phis : $@convention(thin) () -> Builtin.Int64 {
+bb0:
+  specify_test "ssa_updater"
+  %1 = integer_literal $Builtin.Int64, 1
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb6
+
+bb2:
+  cond_br undef, bb3, bb4
+
+bb3:
+  br bb5
+
+bb4:
+  %2 = integer_literal $Builtin.Int64, 2
+  br bb5
+
+bb5:
+  br bb6
+
+bb6:
+  return undef : $Builtin.Int64
+}
+
+// CHECK-LABEL: sil @phi_and_second_use :
+// CHECK:       bb1:
+// CHECK:         [[L1:%.*]] = integer_literal $Builtin.Int64, 1
+// CHECK:       bb2:
+// CHECK-NEXT:    fix_lifetime [[L1]]
+// CHECK:       bb3:
+// CHECK-NEXT:    br bb5([[L1]])
+// CHECK:       bb4:
+// CHECK-NEXT:    [[L2:%.*]] = integer_literal $Builtin.Int64, 2
+// CHECK-NEXT:    br bb5([[L2]])
+// CHECK:       bb5([[PHI:%.*]] : $Builtin.Int64):
+// CHECK:       bb6:
+// CHECK-NEXT:    return [[PHI]]
+// CHECK:       } // end sil function 'phi_and_second_use'
+sil @phi_and_second_use : $@convention(thin) () -> Builtin.Int64 {
+bb0:
+  specify_test "ssa_updater"
+  cond_br undef, bb1, bb4
+
+bb1:
+  %1 = integer_literal $Builtin.Int64, 1
+  cond_br undef, bb2, bb3
+
+bb2:
+  fix_lifetime undef : $Builtin.Int64
+  unreachable
+
+bb3:
+  br bb5
+
+bb4:
+  %2 = integer_literal $Builtin.Int64, 2
+  br bb5
+
+bb5:
+  br bb6
+
+bb6:
+  return undef : $Builtin.Int64
+}
+
+// CHECK-LABEL: sil @loop_with_value_in_loop :
+// CHECK:       bb0:
+// CHECK:         [[L1:%.*]] = integer_literal $Builtin.Int64, 1
+// CHECK-NEXT:    br bb1([[L1]])
+// CHECK:       bb1([[PHI:%.*]] : $Builtin.Int64):
+// CHECK:       bb2:
+// CHECK-NEXT:    [[L2:%.*]] = integer_literal $Builtin.Int64, 2
+// CHECK-NEXT:    br bb1([[L2]])
+// CHECK:       bb3:
+// CHECK:       bb4:
+// CHECK-NEXT:    return [[PHI]]
+// CHECK:       } // end sil function 'loop_with_value_in_loop'
+sil @loop_with_value_in_loop : $@convention(thin) () -> Builtin.Int64 {
+bb0:
+  specify_test "ssa_updater"
+  %1 = integer_literal $Builtin.Int64, 1
+  br bb1
+
+bb1:
+  cond_br undef, bb2, bb3
+
+bb2:
+  %2 = integer_literal $Builtin.Int64, 2
+  br bb1
+
+bb3:
+  br bb4
+
+bb4:
+  return undef : $Builtin.Int64
+}
+
+// CHECK-LABEL: sil @loop_with_value_in_loop2 :
+// CHECK:       bb0:
+// CHECK:         [[L1:%.*]] = integer_literal $Builtin.Int64, 1
+// CHECK-NEXT:    br bb1([[L1]])
+// CHECK:       bb1([[PHI:%.*]] : $Builtin.Int64):
+// CHECK-NEXT:    fix_lifetime [[PHI]]
+// CHECK:       bb2:
+// CHECK-NEXT:    fix_lifetime [[PHI]]
+// CHECK-NEXT:    [[L2:%.*]] = integer_literal $Builtin.Int64, 2
+// CHECK-NEXT:    fix_lifetime [[L2]]
+// CHECK-NEXT:    br bb1([[L2]])
+// CHECK:       bb3:
+// CHECK-NEXT:    fix_lifetime [[PHI]]
+// CHECK:       bb4:
+// CHECK-NEXT:    return [[PHI]]
+// CHECK:       } // end sil function 'loop_with_value_in_loop2'
+sil @loop_with_value_in_loop2 : $@convention(thin) () -> Builtin.Int64 {
+bb0:
+  specify_test "ssa_updater"
+  %1 = integer_literal $Builtin.Int64, 1
+  br bb1
+
+bb1:
+  fix_lifetime undef : $Builtin.Int64
+  cond_br undef, bb2, bb3
+
+bb2:
+  fix_lifetime undef : $Builtin.Int64
+  %2 = integer_literal $Builtin.Int64, 2
+  fix_lifetime undef : $Builtin.Int64
+  br bb1
+
+bb3:
+  fix_lifetime undef : $Builtin.Int64
+  br bb4
+
+bb4:
+  return undef : $Builtin.Int64
+}
+
+// CHECK-LABEL: sil @loop_without_value_in_loop :
+// CHECK:       bb0:
+// CHECK:         [[L1:%.*]] = integer_literal $Builtin.Int64, 1
+// CHECK:       bb1:
+// CHECK:         return [[L1]]
+// CHECK:       } // end sil function 'loop_without_value_in_loop'
+sil @loop_without_value_in_loop : $@convention(thin) () -> Builtin.Int64 {
+bb0:
+  specify_test "ssa_updater"
+  %1 = integer_literal $Builtin.Int64, 1
+  br bb1
+
+bb1:
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb1
+
+bb3:
+  br bb4
+
+bb4:
+  return undef : $Builtin.Int64
+}
+
+// CHECK-LABEL: sil @entry_block_revisited :
+// CHECK:       bb1:
+// CHECK-NEXT:    br bb3(undef : $Builtin.Int64)
+// CHECK:       bb2
+// CHECK-NEXT:    [[L1:%.*]] = integer_literal $Builtin.Int64, 1
+// CHECK-NEXT:    br bb3([[L1]])
+// CHECK:       bb3([[PHI:%.*]] : $Builtin.Int64):
+// CHECK-NEXT:    return [[PHI]]
+// CHECK:       } // end sil function 'entry_block_revisited'
+sil @entry_block_revisited : $@convention(thin) () -> Builtin.Int64 {
+bb0:
+  specify_test "ssa_updater"
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3
+
+bb2:
+  %1 = integer_literal $Builtin.Int64, 1
+  br bb3
+
+bb3:
+  return undef : $Builtin.Int64
+}
+
+//===----------------------------------------------------------------------===//
+//                  Swift InstructionBasedSSAUpdater tests
+//===----------------------------------------------------------------------===//
 
 // CHECK-LABEL: sil @ib_ssa_updater :
 // CHECK:         [[L1:%.*]] = integer_literal $Builtin.Int64, 1


### PR DESCRIPTION
Replace the C++-bridged SSAUpdater with a pure-Swift, worklist-based fixed-point implementation, removing the corresponding bridging APIs and the C++ SILSSAUpdater dependency from SwiftPassInvocation.

The problem of the C++ SSAUpdater was that it sometimes inserts unnesessary phi arguments. This doesn't matter in LLVM and in non-OSSA. But it is a problem in OSSA because it breaks lifetimes into parts at block boundaries. We were working around this with the `replacePhisWithIncomingValues` utility. However, this is not ideal and it didn't work in the new DeadObjectElimination pass, because it left SIL in a bogus state within the pass.

This is fixed with the new implementation: phi arguments are only inserted if really necessary, i.e. not breaking OSSA lifetimes where it's not expected.

It turned out that the new implementation is much simpler than the C++ implementation (using LLVM's generic SSAUpdater utility). It has only a fraction of lines of code compared to the old implementation. So the rewrite is a net win on that side, too.

Also, rename `getValue(inMiddleOf:)` to `getValue(atBeginOf:)` to better reflect its semantics, and make `insertedPhis` a stored property. `SSAUpdater` and `InstructionBasedSSAUpdater` now own a `BasicBlockWorklist` and must be explicitly deinitialized, so update all callers accordingly.

Fixes a crash in DeadObjectElimination
rdar://182126561
