### PR TITLE
[SILCloner] Convert debug value op_deref to load on specialization

### DIFF
--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1801,6 +1801,14 @@ SILCloner<ImplClass>::visitDebugValueInst(DebugValueInst *Inst) {
         NewInst->getFunction()->createEmptyDebugReconstructionBlock();
     NewInst->setDebugReconstructionBlock(NewDebugBB);
     asImpl().cloneDebugBasicBlock(SrcDebugBB, NewDebugBB);
+    
+    // Type substitutions may map an address-only (generic) type to something
+    // else, in which case, the op_deref must be converted to a load.
+    if (NewInst->hasDeref()) {
+      auto *ret = cast<ReturnInst>(NewDebugBB->getTerminator());
+      if (ret->getOperand()->getType().isLoadableOrOpaque(*NewInst->getFunction()))
+        NewInst->convertDerefToLoad();
+    }
   }
 
   recordClonedInstruction(Inst, NewInst);

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -5873,6 +5873,12 @@ public:
     return sharedUInt8().DebugValueInst.prependDeref;
   }
 
+  /// Converts the op_deref flag into an explicit load at the end of the
+  /// reconstruction block. This is used after type substitution when an
+  /// address-only generic type becomes loadable, making the deref
+  /// representable as a real load instruction.
+  void convertDerefToLoad();
+
   /// Prepends a deref operator to this debug_value in place.
   /// This must be called when the operand is changed from an object type to
   /// an address type (when moved to the stack, for example).

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -505,6 +505,19 @@ void DebugValueInst::prependDeref() {
   load->setOperand(newArg);
 }
 
+void DebugValueInst::convertDerefToLoad() {
+  ASSERT(hasDeref() && "Must have deref to convert");
+  ASSERT(ReconstructionBlock && "Must have reconstruction block");
+  auto *ret = cast<ReturnInst>(ReconstructionBlock->getTerminator());
+  ASSERT(ret->getOperand()->getType().isLoadableOrOpaque(*getFunction()) &&
+         "Cannot insert load for address-only type");
+  SILBuilder builder(ret);
+  auto *load = builder.createLoad(getLoc(), ret->getOperand(),
+                                  LoadOwnershipQualifier::Unqualified);
+  ret->setOperand(load);
+  sharedUInt8().DebugValueInst.prependDeref = false;
+}
+
 void DebugValueInst::stripDeref() {
   // If we have an undef, nothing to do.
   if (isa<SILUndef>(getOperand()))

--- a/test/DebugInfo/generic_specializer_convert_deref_to_load.sil
+++ b/test/DebugInfo/generic_specializer_convert_deref_to_load.sil
@@ -1,0 +1,44 @@
+// RUN: %target-sil-opt %s -generic-specializer -enable-sil-verify-all | %FileCheck %s
+
+// Test that specializing a generic function with a debug reconstruction block
+// that has op_deref converts the deref to a load when the substituted type
+// is loadable.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+struct MyStruct {
+  @_hasStorage var x: Int64 { get set }
+}
+
+// A generic function with a debug_value that has op_deref and a
+// reconstruction block. This simulates an address-only generic parameter
+// whose debug info has been salvaged.
+sil @process : $@convention(thin) <T> (@in_guaranteed T) -> Int64 {
+bb0(%0 : $*T):
+  debug_value %0 : $*T, let, name "context", expr op_deref, transform {
+  bb0(%a0 : $*T):
+    return %a0 : $*T
+  }
+  %lit = integer_literal $Builtin.Int64, 1
+  %int = struct $Int64 (%lit : $Builtin.Int64)
+  return %int : $Int64
+}
+
+// CHECK-LABEL: sil shared @$s7process4main8MyStructV_Tg5
+// After specialization with T=MyStruct, the deref should be converted to a
+// load in the reconstruction block since MyStruct is loadable.
+// CHECK:         debug_value %{{[0-9]+}}, let, name "context", transform {
+// CHECK:           bb0(%0 : $*MyStruct):
+// CHECK:             %1 = load %0
+// CHECK:             return %1
+// CHECK:         }
+// CHECK-LABEL: } // end sil function '$s7process4main8MyStructV_Tg5'
+sil @caller : $@convention(thin) (@in_guaranteed MyStruct) -> Int64 {
+bb0(%0 : $*MyStruct):
+  %fn = function_ref @process : $@convention(thin) <T> (@in_guaranteed T) -> Int64
+  %result = apply %fn<MyStruct>(%0) : $@convention(thin) <T> (@in_guaranteed T) -> Int64
+  return %result : $Int64
+}

--- a/test/DebugInfo/generic_specializer_convert_deref_to_load.swift
+++ b/test/DebugInfo/generic_specializer_convert_deref_to_load.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend %s -O -emit-sil -g -o /dev/null
+
+// Verify that specializing a generic function with a debug reconstruction block
+// that has op_deref (address-only generic type) correctly converts the deref
+// to a load when the substituted type is loadable.
+
+@inline(__always)
+func process<T>(_ context: T) -> Int {
+    return 1
+}
+
+struct S<U> {
+    var u: U
+    func run() -> Int {
+        return process(u)
+    }
+}
+
+let _ = S(u: 0.5).run()


### PR DESCRIPTION
If a type is mapped from an address-only type, such as a generic, to a known loadable type, the op_deref must be converted to a load for the debug_value to be well formed.

Otherwise, compilation of the added Swift test case would crash with a type chain verifier issue.