### PR TITLE
[DebugInfo] Fix alloc_pack salvage type for single-element pack

### DIFF
--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -2131,7 +2131,7 @@ static void salvagePackElementSetDebugInfo(PackElementSetInst *PESI) {
   TupleType *tupleType = nullptr;
 
   if (packType.getElementTypes().size() == 1) {
-    silType = PESI->getFunction()->getLoweredType(packType.getElementType(0));
+    silType = packType->getSILElementType(0).getObjectType();
   } else {
     llvm::SmallVector<TupleTypeElt, 4> tupleElements;
     for (const auto &elementType : packType.getElementTypes()) {

--- a/test/DebugInfo/salvage_pack_simplification.sil
+++ b/test/DebugInfo/salvage_pack_simplification.sil
@@ -1,0 +1,33 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -simplification %s | %FileCheck %s
+
+// When alloc_pack is simplified to alloc_stack in a generic context, the
+// salvaged debug_value must have an op_deref and the correct object type.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+sil @use : $@convention(thin) <T> (@in_guaranteed T) -> Int
+
+// CHECK-LABEL: sil @test_pack_debug_value_salvage
+// CHECK: [[STACK:%[0-9]+]] = alloc_stack $Value
+// CHECK: debug_value [[STACK]], let, name "items", argno 1, expr op_deref
+// CHECK-NOT: type $*
+// CHECK: return
+sil @test_pack_debug_value_salvage : $@convention(thin) <Value> (@in_guaranteed Value) -> Int {
+bb0(%0 : $*Value):
+  %pack = alloc_pack $Pack{Value}
+  %stack = alloc_stack $Value
+  copy_addr %0 to [init] %stack
+  %idx = scalar_pack_index 0 of $Pack{Value}
+  pack_element_set %stack into %idx of %pack
+  debug_value %pack, let, name "items", argno 1, expr op_deref
+  %get = pack_element_get %idx of %pack as $*Value
+  %fn = function_ref @use : $@convention(thin) <T> (@in_guaranteed T) -> Int
+  %result = apply %fn<Value>(%get) : $@convention(thin) <T> (@in_guaranteed T) -> Int
+  destroy_addr %stack
+  dealloc_stack %stack
+  dealloc_pack %pack
+  return %result : $Int
+}

--- a/test/DebugInfo/salvage_pack_simplification.swift
+++ b/test/DebugInfo/salvage_pack_simplification.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -g -O -emit-ir %s -o /dev/null
+
+// alloc_pack simplification must produce well-typed debug_value when a
+// single-element pack is eliminated, rather than assert
+
+@inline(__always)
+func scrub<each T>(_ items: repeat each T) -> Int {
+    var tally = 0
+    func increment<U>(_ u: U) {
+        tally += 1
+    }
+    repeat increment(each items)
+    return tally
+}
+
+@inline(__always)
+func generate<Value>(_ seed: Value) -> Int {
+    return scrub(seed)
+}
+
+let x = generate(42)


### PR DESCRIPTION
In the single element case, the debug_value would be created with an address type as the variable value, which causes a type-chain verification failure.
