### PR TITLE
[Embedded] Pass -plugin-path when importing the EmbeddedPlatform header

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -397,6 +397,19 @@ else()
   add_subdirectory(Cxx/libstdcxx)
 endif()
 
+# Directory containing the freshly-built compiler plugins (SwiftMacros, etc.).
+# Stdlib modules that use a compiler-plugin macro -- e.g. `@DebugDescription`,
+# or `_SwiftifyImport` synthesized from Clang bounds-safety annotations in a
+# bridging header -- must pass this via `-plugin-path` so the compiler uses the
+# just-built plugin instead of falling back to a stale one from the host
+# toolchain. Computed once here and inherited by the stdlib subdirectories
+# below (core, EmbeddedPlatform, Synchronization, ...).
+if("${SWIFT_NATIVE_SWIFT_TOOLS_PATH}" STREQUAL "")
+  set(SWIFT_HOST_PLUGINS_DIR "${CMAKE_BINARY_DIR}/lib/swift/host/plugins")
+else()
+  set(SWIFT_HOST_PLUGINS_DIR "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/../lib/swift/host/plugins")
+endif()
+
 if(SWIFT_BUILD_STDLIB)
   # These must be kept in dependency order so that any referenced targets
   # exist at the time we look for them in add_swift_*.

--- a/stdlib/public/EmbeddedPlatform/CMakeLists.txt
+++ b/stdlib/public/EmbeddedPlatform/CMakeLists.txt
@@ -27,8 +27,18 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   add_custom_target(embedded-multi-threaded-darwin-shim)
   add_dependencies(embedded-libraries embedded-multi-threaded-darwin-shim)
 
+  # The bridging header annotates its C declarations with Clang bounds-safety
+  # attributes (EMBEDDED_SWIFT_COUNTED_BY / EMBEDDED_SWIFT_SIZED_BY, i.e.
+  # __counted_by / __sized_by). The ClangImporter expands those into the
+  # `_SwiftifyImport` macro, which is provided by the SwiftMacros compiler
+  # plugin. Point the compiler at the freshly-built plugin directory
+  # (`SWIFT_HOST_PLUGINS_DIR`, computed in stdlib/public/CMakeLists.txt) so it
+  # doesn't fall back to a stale plugin from the host toolchain (which may
+  # predate `SwiftifyImportMacro`). Unlike `core`, this sibling directory does
+  # not inherit `core`'s `-plugin-path`, so add it here.
   set(_embedded_platform_swift_flags
     ${swift_stdlib_compile_flags}
+    "-plugin-path" "${SWIFT_HOST_PLUGINS_DIR}"
     "-import-bridging-header" ${CMAKE_CURRENT_SOURCE_DIR}/swift/EmbeddedPlatform.h
     -enable-experimental-feature Extern
     -enable-experimental-feature AllowRuntimeSymbolDeclarations

--- a/stdlib/public/Synchronization/CMakeLists.txt
+++ b/stdlib/public/Synchronization/CMakeLists.txt
@@ -171,8 +171,15 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   add_custom_target(embedded-synchronization)
   add_dependencies(embedded-libraries embedded-synchronization)
 
+  # The EmbeddedPlatform bridging header annotates C declarations with Clang
+  # bounds-safety attributes (__counted_by / __sized_by), which the importer
+  # expands via the `_SwiftifyImport` macro from the SwiftMacros compiler
+  # plugin. Point at the freshly-built plugin directory (`SWIFT_HOST_PLUGINS_DIR`,
+  # computed in stdlib/public/CMakeLists.txt) so we don't fall back to a stale
+  # plugin from the host toolchain.
   set(_embedded_synchronization_swift_flags
     ${SWIFT_SYNCHRNOIZATION_SWIFT_FLAGS}
+    "-plugin-path" "${SWIFT_HOST_PLUGINS_DIR}"
     -internal-import-bridging-header ${CMAKE_CURRENT_SOURCE_DIR}/../EmbeddedPlatform/swift/EmbeddedPlatform.h
     -enable-experimental-feature LiteralExpressions)
 

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -380,16 +380,9 @@ list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "BorrowAnd
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "BorrowInout")
 list(APPEND swift_stdlib_compile_flags "-strict-memory-safety")
 
-if("${SWIFT_NATIVE_SWIFT_TOOLS_PATH}" STREQUAL "")
-  set(swift_bin_dir "${CMAKE_BINARY_DIR}/bin")
-  set(swift_lib_dir "${CMAKE_BINARY_DIR}/lib")
-else()
-  set(swift_bin_dir "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}")
-  set(swift_lib_dir "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/../lib")
-endif()
-
-# For `@DebugDescription`.
-list(APPEND swift_stdlib_compile_flags "-plugin-path" "${swift_lib_dir}/swift/host/plugins")
+# For `@DebugDescription`. `SWIFT_HOST_PLUGINS_DIR` is computed once in
+# stdlib/public/CMakeLists.txt.
+list(APPEND swift_stdlib_compile_flags "-plugin-path" "${SWIFT_HOST_PLUGINS_DIR}")
 
 set(swift_core_incorporate_object_libraries)
 list(APPEND swift_core_incorporate_object_libraries swiftRuntimeCore)

--- a/utils/check-incremental
+++ b/utils/check-incremental
@@ -104,8 +104,7 @@ def main():
 
     new_args += [
       '-Xllvm', '-print-no-uuids',
-      '-Xllvm', '-sil-print-pass-md5',
-      '-Xfrontend', '-disable-safe-interop-wrappers']
+      '-Xllvm', '-sil-print-pass-md5']
 
     if EMIT_IR:
       new_args += [


### PR DESCRIPTION
The EmbeddedPlatform bridging header annotates its C declarations with Clang bounds-safety attributes (EMBEDDED_SWIFT_COUNTED_BY / EMBEDDED_SWIFT_SIZED_BY, i.e. __counted_by / __sized_by). The ClangImporter expands those into the `_SwiftifyImport` macro, provided by the SwiftMacros compiler plugin. Without an explicit `-plugin-path`, swiftc falls back to a plugin from the host toolchain, which may predate `SwiftifyImportMacro` and fail with:

  error: type 'SwiftMacros.SwiftifyImportMacro' could not be found in library
  plugin '.../usr/lib/swift/host/plugins/libSwiftMacros.dylib'
  (from macro '_SwiftifyImport')

Compute the freshly-built plugin directory once as SWIFT_HOST_PLUGINS_DIR in stdlib/public/CMakeLists.txt and pass it via -plugin-path from the modules that import EmbeddedPlatform.h: core (which already had it via a generic, now-removed swift_lib_dir), EmbeddedPlatform, and Synchronization.

rdar://178439806
