### PR TITLE
[IRGen] Force layout string value witnesses off in embedded mode

### DIFF
--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -897,6 +897,11 @@ void addStride(ConstantStructBuilder &B, const TypeInfo *TI, IRGenModule &IGM) {
 } // end anonymous namespace
 
 bool irgen::layoutStringsEnabled(IRGenModule &IGM, bool diagnose) {
+  // Layout string value witnesses are not available in embedded mode
+  if (IGM.Context.LangOpts.hasFeature(Feature::Embedded)) {
+    return false;
+  }
+
   if (!IGM.isLayoutStringValueWitnessesFeatureAvailable(IGM.Context)) {
     return false;
   }

--- a/test/embedded/existential-any-layout-strings.swift
+++ b/test/embedded/existential-any-layout-strings.swift
@@ -1,0 +1,18 @@
+// Reproducer for rdar://182139366
+//
+// Ensure that layout string value witnesses are ignored in embedded mode
+
+// RUN: %target-swift-frontend -module-name foo -emit-ir %s -parse-as-library -enable-experimental-feature Embedded -enable-experimental-feature LayoutStringValueWitnesses -enable-layout-string-value-witnesses | %FileCheck %s
+
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_LayoutStringValueWitnesses
+
+// Referencing `Any` as a first-class type forces emission of its type
+// metadata, which in embedded mode emits its value witness table.
+public func anyMetatype() -> Any.Type {
+  return Any.self
+}
+
+// CHECK: define {{.*}}anyMetatype


### PR DESCRIPTION
rdar://182139366

Layout string value witnesses are not availabled in embedded mode, so they have to be forced off, otherwise we will run into compiler crashes or linking issues.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
