### PR TITLE
[SILOptimizer] Fold provably-succeeding casts to `any P<T>`

### DIFF
--- a/lib/SIL/Utils/DynamicCasts.cpp
+++ b/lib/SIL/Utils/DynamicCasts.cpp
@@ -14,6 +14,7 @@
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/ProtocolConformance.h"
+#include "swift/AST/Requirement.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/SIL/SILArgument.h"
@@ -105,13 +106,23 @@ classifyDynamicCastToProtocol(SILFunction *function, CanType source, CanType tar
   if (!TargetProtocol)
     return DynamicCastFeasibility::MaySucceed;
 
-  // If the target is a parameterized protocol type, checkConformance
-  // is insufficient to prove the feasibility of the cast as it does not
-  // check the additional requirements.
-  // FIXME: This is a weak predicate that doesn't take into account
-  // class compositions - since any C & P<T> doesn't work yet anyways.
-  if (isa<ParameterizedProtocolType>(unwrapExistential(target)))
+  // Conformance alone isn't enough for a parameterized target like
+  // `any P<Int>`: the associated-type requirements must hold too. Check them
+  // against the concrete source and only succeed if they provably do.
+  // FIXME: doesn't handle class compositions (`any C & P<T>`).
+  if (auto paramTarget =
+          dyn_cast<ParameterizedProtocolType>(unwrapExistential(target))) {
+    if (auto conformance = checkConformance(source, TargetProtocol)) {
+      if (matchesActorIsolation(conformance, function)) {
+        SmallVector<Requirement, 2> reqs;
+        paramTarget->getRequirements(source, reqs);
+        if (checkRequirementsWithoutContext(reqs) ==
+            CheckRequirementsResult::Success)
+          return DynamicCastFeasibility::WillSucceed;
+      }
+    }
     return DynamicCastFeasibility::MaySucceed;
+  }
 
   // If checkConformance() returns a valid conformance, then all conditional
   // requirements were satisfied.

--- a/test/SILOptimizer/cast_folding_parameterized_protocol.swift
+++ b/test/SILOptimizer/cast_folding_parameterized_protocol.swift
@@ -19,7 +19,8 @@ public func concrete_to_existential<T>(_ x: X, _ yt: Y<T>, _ yi: Y<Int>) {
   use(x as! any P)
   // CHECK: unconditional_checked_cast_addr X in {{%.*}} : $*X to any P<T> in {{%.*}} : $*any P<T>
   use(x as! any P<T>)
-  // CHECK: unconditional_checked_cast_addr X in {{%.*}} : $*X to any P<Int> in {{%.*}} : $*any P<Int>
+  // The concrete source provably satisfies `P<Int>`, so the cast folds to a box.
+  // CHECK: {{%.*}} = init_existential_addr {{%.*}} : $*any P<Int>, $X
   use(x as! any P<Int>)
   // CHECK: unconditional_checked_cast_addr X in {{%.*}} : $*X to any P<String> in {{%.*}} : $*any P<String>
   use(x as! any P<String>)
@@ -28,7 +29,7 @@ public func concrete_to_existential<T>(_ x: X, _ yt: Y<T>, _ yi: Y<Int>) {
 
   // CHECK: {{%.*}} = init_existential_addr {{%.*}} : $*any P, $Y<T>
   use(yt as! any P)
-  // CHECK: unconditional_checked_cast_addr Y<T> in {{%.*}} : $*Y<T> to any P<T> in {{%.*}} : $*any P<T>
+  // CHECK: {{%.*}} = init_existential_addr {{%.*}} : $*any P<T>, $Y<T>
   use(yt as! any P<T>)
   // CHECK: unconditional_checked_cast_addr Y<T> in {{%.*}} : $*Y<T> to any P<Int> in {{%.*}} : $*any P<Int>
   use(yt as! any P<Int>)
@@ -41,7 +42,7 @@ public func concrete_to_existential<T>(_ x: X, _ yt: Y<T>, _ yi: Y<Int>) {
   use(yi as! any P)
   // CHECK: unconditional_checked_cast_addr Y<Int> in {{%.*}} : $*Y<Int> to any P<T> in {{%.*}} : $*any P<T>
   use(yi as! any P<T>)
-  // CHECK: unconditional_checked_cast_addr Y<Int> in {{%.*}} : $*Y<Int> to any P<Int> in {{%.*}} : $*any P<Int>
+  // CHECK: {{%.*}} = init_existential_addr {{%.*}} : $*any P<Int>, $Y<Int>
   use(yi as! any P<Int>)
   // CHECK: unconditional_checked_cast_addr Y<Int> in {{%.*}} : $*Y<Int> to any P<String> in {{%.*}} : $*any P<String>
   use(yi as! any P<String>)


### PR DESCRIPTION
The classifier gave up on parameterized existential targets because conformance alone doesn't check the associated-type requirements. When the source is concrete we can, so `Array<String> as? any Collection<String>` folds instead of calling swift_dynamicCast.

Resolves #62264