### PR TITLE
AST: Add new NominalTypeDecl::hasValueTypeDestructor()

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -652,7 +652,7 @@ protected:
     IsDebuggerAlias : 1
   );
 
-  SWIFT_INLINE_BITFIELD(NominalTypeDecl, GenericTypeDecl, 1+1+1,
+  SWIFT_INLINE_BITFIELD(NominalTypeDecl, GenericTypeDecl, 1+1+1+1+1,
     /// Whether we have already added implicitly-defined initializers
     /// to this declaration.
     AddedImplicitInitializers : 1,
@@ -661,7 +661,13 @@ protected:
     HasLazyConformances : 1,
 
     /// Whether this nominal type is having its semantic members resolved.
-    IsComputingSemanticMembers : 1
+    IsComputingSemanticMembers : 1,
+
+    /// Whether we've computed HasDestructor.
+    HasDestructorComputed : 1,
+
+    /// Whether we have a user-defined deinit.
+    HasDestructor : 1
   );
 
   SWIFT_INLINE_BITFIELD_FULL(ProtocolDecl, NominalTypeDecl, 1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+8,
@@ -741,16 +747,17 @@ protected:
     IsActor : 1
   );
 
-  SWIFT_INLINE_BITFIELD(StructDecl, NominalTypeDecl, 1 + 1 + 1,
-                        /// True if this struct has storage for fields that
-                        /// aren't accessible in Swift.
-                        HasUnreferenceableStorage : 1,
-                        /// True if this struct is imported from C++ and does
-                        /// not have trivial value witness functions.
-                        IsCxxNonTrivial : 1,
-                        /// True if this struct is imported from C and has
-                        /// address diversified ptrauth qualified field.
-                        IsNonTrivialPtrAuth : 1);
+  SWIFT_INLINE_BITFIELD(StructDecl, NominalTypeDecl, 1+1+1,
+    /// True if this struct has storage for fields that
+    /// aren't accessible in Swift.
+    HasUnreferenceableStorage : 1,
+    /// True if this struct is imported from C++ and does
+    /// not have trivial value witness functions.
+    IsCxxNonTrivial : 1,
+    /// True if this struct is imported from C and has
+    /// address diversified ptrauth qualified field.
+    IsNonTrivialPtrAuth : 1
+  );
 
   SWIFT_INLINE_BITFIELD(EnumDecl, NominalTypeDecl, 2+1+1,
     /// True if the enum has cases and at least one case has associated values.
@@ -4495,12 +4502,31 @@ protected:
     IterableDeclContext(IterableDeclContextKind::NominalTypeDecl)
   {
     Bits.NominalTypeDecl.AddedImplicitInitializers = false;
-    ExtensionGeneration = 0;
     Bits.NominalTypeDecl.HasLazyConformances = false;
     Bits.NominalTypeDecl.IsComputingSemanticMembers = false;
+    Bits.NominalTypeDecl.HasDestructorComputed = false;
+    Bits.NominalTypeDecl.HasDestructor = false;
+    ExtensionGeneration = 0;
   }
 
   friend class ProtocolType;
+
+  std::optional<bool> getCachedValueTypeDestructor() const {
+    if (isa<StructDecl>(this) || isa<EnumDecl>(this)) {
+      if (Bits.NominalTypeDecl.HasDestructorComputed)
+        return Bits.NominalTypeDecl.HasDestructor;
+
+      return std::nullopt;
+    } else {
+      return false;
+    }
+  }
+
+  void setCachedValueTypeDestructor(bool value) {
+    ASSERT(isa<StructDecl>(this) || isa<EnumDecl>(this));
+    Bits.NominalTypeDecl.HasDestructorComputed = true;
+    Bits.NominalTypeDecl.HasDestructor = value;
+  }
 
 public:
   using GenericTypeDecl::getASTContext;
@@ -4813,7 +4839,11 @@ public:
 
   /// Return the `DestructorDecl` for a struct or enum's `deinit` declaration.
   /// Returns null if the type is a class, or does not have a declared `deinit`.
-  DestructorDecl *getValueTypeDestructor();
+  bool hasValueTypeDestructor() const;
+
+  /// Return the `DestructorDecl` for a struct or enum's `deinit` declaration.
+  /// Returns null if the type is a class, or does not have a declared `deinit`.
+  DestructorDecl *getValueTypeDestructor() const;
 
   /// Does a conformance for a given invertible protocol exist for this
   /// type declaration.

--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -150,14 +150,10 @@ void collectUsesOfValue(SILValue V,
 /// value itself)
 void eraseUsesOfValue(SILValue value);
 
-/// Return true if \p type is a value type (struct/enum) that requires
-/// deinitialization beyond destruction of its members.
-bool hasValueDeinit(SILType type);
-
 /// Return true if \p value has a value type (struct/enum) that requires
 /// deinitialization beyond destruction of its members.
 inline bool hasValueDeinit(SILValue value) {
-  return hasValueDeinit(value->getType());
+  return value->getType().isValueTypeWithDeinit();
 }
 
 /// Gets the concrete value which is stored in an existential box.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6069,16 +6069,39 @@ bool NominalTypeDecl::isStrictlyResilient() const {
   return isResilient() && !getModuleContext()->allowNonResilientAccess();
 }
 
-DestructorDecl *NominalTypeDecl::getValueTypeDestructor() {
-  if (!isa<StructDecl>(this) && !isa<EnumDecl>(this)) {
-    return nullptr;
+bool NominalTypeDecl::hasValueTypeDestructor() const {
+  // Fast path: we already checked.
+  if (auto cached = getCachedValueTypeDestructor())
+    return *cached;
+
+  // Otherwise, do the lookup, which updates the cached bit for next time.
+  return getValueTypeDestructor() != nullptr;
+}
+
+DestructorDecl *NominalTypeDecl::getValueTypeDestructor() const {
+  bool needsUpdate = true;
+
+  if (auto cached = getCachedValueTypeDestructor()) {
+    // Skip everything else if we know we don't have a destructor.
+    if (!*cached)
+      return nullptr;
+
+    needsUpdate = false;
   }
-  
-  auto found = lookupDirect(DeclBaseName::createDestructor());
-  if (found.size() != 1) {
-    return nullptr;
-  }
-  return cast<DestructorDecl>(found[0]);
+
+  NominalTypeDecl *nominalDecl = const_cast<NominalTypeDecl *>(this);
+
+  // We might have a destructor, go check.
+  DestructorDecl *result = nullptr;
+  auto found = nominalDecl->lookupDirect(DeclBaseName::createDestructor());
+  if (found.size() == 1)
+    result = cast<DestructorDecl>(found[0]);
+
+  ASSERT(needsUpdate || result != nullptr && "Where did my destructor go?");
+  if (needsUpdate)
+    nominalDecl->setCachedValueTypeDestructor(result != nullptr);
+
+  return result;
 }
 
 static bool isOriginallyDefinedIn(const Decl *D, const ModuleDecl* MD) {
@@ -6634,7 +6657,6 @@ AssociatedTypeDecl::getOverriddenDecls() const {
   return assocTypes;
 }
 
-namespace {
 static AssociatedTypeDecl *getAssociatedTypeAnchor(
                       const AssociatedTypeDecl *ATD,
                       llvm::SmallSet<const AssociatedTypeDecl *, 8> &searched) {
@@ -6658,7 +6680,6 @@ static AssociatedTypeDecl *getAssociatedTypeAnchor(
   }
 
   return bestAnchor;
-}
 }
 
 AssociatedTypeDecl *AssociatedTypeDecl::getAssociatedTypeAnchor() const {

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -6402,7 +6402,7 @@ EnumImplStrategy::get(TypeConverter &TC, SILType type, EnumDecl *theEnum) {
   unsigned numElements = 0;
   TypeInfoKind tik = Loadable;
   IsFixedSize_t alwaysFixedSize = IsFixedSize;
-  auto triviallyDestroyable = theEnum->getValueTypeDestructor()
+  auto triviallyDestroyable = theEnum->hasValueTypeDestructor()
     ? IsNotTriviallyDestroyable : IsTriviallyDestroyable;
   auto copyable = !theEnum->canBeCopyable()
     ? IsNotCopyable : IsCopyable;
@@ -7095,7 +7095,7 @@ TypeInfo *SinglePayloadEnumImplStrategy::completeFixedLayout(
   auto alignment = payloadTI.getFixedAlignment();
   applyLayoutAttributes(TC.IGM, theEnum, /*fixed*/true, alignment);
 
-  auto deinit = theEnum->getValueTypeDestructor()
+  auto deinit = theEnum->hasValueTypeDestructor()
     ? IsNotTriviallyDestroyable : IsTriviallyDestroyable;
   auto copyable = !theEnum->canBeCopyable()
     ? IsNotCopyable : IsCopyable;
@@ -7134,7 +7134,7 @@ TypeInfo *SinglePayloadEnumImplStrategy::completeDynamicLayout(
   
   auto enumAccessible = IsABIAccessible_t(TC.IGM.isTypeABIAccessible(Type));
 
-  auto deinit = theEnum->getValueTypeDestructor()
+  auto deinit = theEnum->hasValueTypeDestructor()
     ? IsNotTriviallyDestroyable : IsTriviallyDestroyable;
   auto copyable = !theEnum->canBeCopyable()
     ? IsNotCopyable : IsCopyable;
@@ -7174,7 +7174,7 @@ MultiPayloadEnumImplStrategy::completeFixedLayout(TypeConverter &TC,
   Alignment worstAlignment(1);
   auto isCopyable = !theEnum->canBeCopyable()
     ? IsNotCopyable : IsCopyable;
-  auto isTriviallyDestroyable = theEnum->getValueTypeDestructor()
+  auto isTriviallyDestroyable = theEnum->hasValueTypeDestructor()
     ? IsNotTriviallyDestroyable : IsTriviallyDestroyable;
   IsBitwiseTakable_t isBT = IsBitwiseTakableAndBorrowable;
   PayloadSize = 0;
@@ -7342,7 +7342,7 @@ TypeInfo *MultiPayloadEnumImplStrategy::completeDynamicLayout(
   // during initializeMetadata. We can at least glean the best available
   // static information from the payloads.
   Alignment alignment(1);
-  auto td = theEnum->getValueTypeDestructor()
+  auto td = theEnum->hasValueTypeDestructor()
     ? IsNotTriviallyDestroyable : IsTriviallyDestroyable;
   auto bt = IsBitwiseTakableAndBorrowable;
   for (auto &element : ElementsWithPayload) {

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -3640,7 +3640,7 @@ static void emitInitializeRawLayout(IRGenFunction &IGF, SILType likeType,
 
     // PODness comes directly from the like type if we 'movesAsLike'. A custom
     // deinit on the raw layout type however automatically forces non-pod.
-    if (T.getStructOrBoundGenericStruct()->getValueTypeDestructor()) {
+    if (T.getStructOrBoundGenericStruct()->hasValueTypeDestructor()) {
       rawLayoutFlags = IGF.Builder.CreateOr(rawLayoutFlags,
                           IGM.getSize(Size((uint8_t) RawLayoutFlags::IsNonPOD)));
     } else {
@@ -3650,7 +3650,7 @@ static void emitInitializeRawLayout(IRGenFunction &IGF, SILType likeType,
                             IGM.getSize(Size((uint8_t) RawLayoutFlags::IsNonPOD)));
       rawLayoutFlags = IGF.Builder.CreateSelect(isPOD, rawLayoutFlags, isNonPODFlags);
     }
-  } else if (T.getStructOrBoundGenericStruct()->getValueTypeDestructor()) {
+  } else if (T.getStructOrBoundGenericStruct()->hasValueTypeDestructor()) {
     rawLayoutFlags = IGF.Builder.CreateOr(rawLayoutFlags,
                             IGM.getSize(Size((uint8_t) RawLayoutFlags::IsNonPOD)));
   }

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -1447,7 +1447,7 @@ public:
         FieldInfos, NextExplosionIndex, llvmType, TotalStride,
         std::move(SpareBits), TotalAlignment,
         (SwiftDecl &&
-         (SwiftDecl->getValueTypeDestructor() || hasReferenceField))
+         (SwiftDecl->hasValueTypeDestructor() || hasReferenceField))
             ? IsNotTriviallyDestroyable
             : IsTriviallyDestroyable,
         (SwiftDecl && !SwiftDecl->canBeCopyable()) ? IsNotCopyable : IsCopyable,

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -3004,7 +3004,7 @@ static bool tryEmitDeinitCall(IRGenFunction &IGF,
   auto nominal = ty->getAnyNominal();
 
   // We are only concerned with move-only type deinits here.
-  if (!nominal || !nominal->getValueTypeDestructor()) {
+  if (!nominal || !nominal->hasValueTypeDestructor()) {
     return false;
   }
 
@@ -3142,7 +3142,7 @@ IsABIAccessible_t irgen::isTypeABIAccessibleIfFixedSize(IRGenModule &IGM,
   // Check for a deinit. If this type does not define a deinit it is ABI
   // accessible because we can just project onto its sub elements.
   auto nom = ty->getAnyNominal();
-  if (!nom || !nom->getValueTypeDestructor())
+  if (!nom || !nom->hasValueTypeDestructor())
     return IsABIAccessible;
 
   if (IGM.getSILModule().isTypeMetadataAccessible(ty) ||

--- a/lib/IRGen/Outlining.cpp
+++ b/lib/IRGen/Outlining.cpp
@@ -105,7 +105,7 @@ void OutliningMetadataCollector::collectTypeMetadataForDeinit(SILType ty) {
   auto *nominal = ty.getASTType()->getAnyNominal();
   if (!nominal)
     return;
-  if (!nominal->getValueTypeDestructor())
+  if (!nominal->hasValueTypeDestructor())
     return;
   assert(ty.isMoveOnly());
 

--- a/lib/IRGen/StructLayout.cpp
+++ b/lib/IRGen/StructLayout.cpp
@@ -68,7 +68,7 @@ StructLayout::StructLayout(IRGenModule &IGM, std::optional<CanType> type,
     builder.addHeapHeader();
   }
 
-  auto triviallyDestroyable = (decl && decl->getValueTypeDestructor())
+  auto triviallyDestroyable = (decl && decl->hasValueTypeDestructor())
     ? IsNotTriviallyDestroyable : IsTriviallyDestroyable;
   auto copyable = (decl && !decl->canBeCopyable())
     ? IsNotCopyable : IsCopyable;

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -1172,7 +1172,7 @@ bool SILType::isValueTypeWithDeinit() const {
   // Do not look inside an aggregate type that has a user-deinit, for which
   // memberwise-destruction is not equivalent to aggregate destruction.
   if (auto *nominal = getNominalOrBoundGenericNominal()) {
-    return nominal->getValueTypeDestructor() != nullptr;
+    return nominal->hasValueTypeDestructor();
   }
   return false;
 }

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -1732,7 +1732,7 @@ namespace {
                             TypeExpansionKind loweringStyle) const override {
       // A value type with a deinit cannot be memberwise destroyed.
       if (auto *nominal = getLoweredType().getNominalOrBoundGenericNominal()) {
-        if (nominal->getValueTypeDestructor()) {
+        if (nominal->hasValueTypeDestructor()) {
           emitDestroyValue(B, loc, aggValue);
           return;
         }
@@ -2718,7 +2718,7 @@ namespace {
       if (origType.isNoncopyable(structType)) {
         properties.setNonTrivial();
         properties.setLexical(IsLexical);
-        if (D->getValueTypeDestructor()) {
+        if (D->hasValueTypeDestructor()) {
           properties.setCustomDeinit(MayHaveCustomDeinit);
         }
         if (properties.isAddressOnly())
@@ -2831,7 +2831,7 @@ namespace {
       if (origType.isNoncopyable(enumType)) {
         properties.setNonTrivial();
         properties.setLexical(IsLexical);
-        if (D->getValueTypeDestructor()) {
+        if (D->hasValueTypeDestructor()) {
           properties.setCustomDeinit(MayHaveCustomDeinit);
         }
         if (properties.isAddressOnly())

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -1491,7 +1491,7 @@ bool swift::shouldExpand(SILModule &module, SILType ty) {
   //
   // TODO: we could loosen this requirement if all paths lead to a drop_deinit.
   if (auto *nominalTy = ty.getNominalOrBoundGenericNominal()) {
-    if (nominalTy->getValueTypeDestructor())
+    if (nominalTy->hasValueTypeDestructor())
       return false;
   }
 

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -4459,7 +4459,7 @@ public:
                 "ownership kind result?!");
       }
       if (operandTy.getNominalOrBoundGenericNominal()
-          ->getValueTypeDestructor()) {
+          ->hasValueTypeDestructor()) {
         require(
           isa<DropDeinitInst>(lookThroughOwnershipInsts(DSI->getOperand())),
             "a destructure of a move-only-type-with-deinit requires a "
@@ -7011,7 +7011,7 @@ public:
     require(type.isMoveOnly(/*orWrapped=*/false),
             "drop_deinit only allowed for move-only types");
     require(type.getNominalOrBoundGenericNominal()
-            ->getValueTypeDestructor(), "drop_deinit only allowed for "
+            ->hasValueTypeDestructor(), "drop_deinit only allowed for "
             "struct/enum types that define a deinit");
     assert(!type.isTrivial(F) && "a type with a deinit is nontrivial");
 

--- a/lib/SILGen/SILGenLazyConformance.cpp
+++ b/lib/SILGen/SILGenLazyConformance.cpp
@@ -145,7 +145,7 @@ void SILGenModule::useConformancesFromType(SILInstruction *inst, CanType type) {
 
     // If this is an imported noncopyable type with a deinitializer, record it.
     if (decl->hasClangNode() && !decl->canBeCopyable() &&
-        decl->getValueTypeDestructor() &&
+        decl->hasValueTypeDestructor() &&
         importedNontrivialNoncopyableTypes.insert(decl).second) {
       visitImportedNontrivialNoncopyableType(decl);
     }

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -2039,7 +2039,7 @@ shouldEmitPartialMutationError(UseState &useState, PartialMutation::Kind kind,
           (kind == PartialMutation::Kind::Consume) && useState.sawDropDeinit &&
           (nom ==
            useState.address->getType().getNominalOrBoundGenericNominal());
-      if (nom->getValueTypeDestructor() && !isAllowedPartialConsume) {
+      if (nom->hasValueTypeDestructor() && !isAllowedPartialConsume) {
         // If we find one, emit an error since we are going to have to extract
         // through the deinit. Emit a nice error saying what it is. Since we
         // are emitting an error, we do a bit more work and construct the

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -340,15 +340,6 @@ void swift::eraseUsesOfValue(SILValue v) {
   }
 }
 
-bool swift::hasValueDeinit(SILType type) {
-  // Do not look inside an aggregate type that has a user-deinit, for which
-  // memberwise-destruction is not equivalent to aggregate destruction.
-  if (auto *nominal = type.getNominalOrBoundGenericNominal()) {
-    return nominal->getValueTypeDestructor() != nullptr;
-  }
-  return false;
-}
-
 SILValue swift::
 getConcreteValueOfExistentialBox(AllocExistentialBoxInst *existentialBox,
                                   SILInstruction *ignoreUser) {

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1567,7 +1567,7 @@ public:
         diagnosed = true;
 
       // has to have a deinit or else it's pointless.
-      } else if (!nominalDecl->getValueTypeDestructor()) {
+      } else if (!nominalDecl->hasValueTypeDestructor()) {
         ctx.Diags.diagnose(DS->getDiscardLoc(),
                            diag::discard_no_deinit,
                            nominalType)


### PR DESCRIPTION
The old getValueTypeDestructor() would repeat the name lookup every time, which isn't horrendously expensive, but since most call sites just care about the presence of a destructor instead of a pointer to the exact decl, we should just cache this bit instead.