### PR TITLE
[CoroutineAccessors] Emit old ABI only when needed for resilience

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -1461,6 +1461,15 @@ BridgedAccessorDecl BridgedAccessorDecl_createParsed(
     BridgedNullableParameterList cParamList, swift::SourceLoc asyncLoc,
     swift::SourceLoc throwsLoc, BridgedNullableTypeRepr cThrownType);
 
+// When the CoroutineAccessors feature is enabled, rewrite a parsed
+// `_read`/`_modify` accessor to its yielding counterpart, mirroring the C++
+// parser's ParsedAccessors::record.  A no-op for any other accessor kind.  Only
+// valid for accessors parsed from surface source (ASTGen never parses
+// .swiftinterface/.sil, where `_read`/`_modify` are ABI declarations).
+SWIFT_NAME("BridgedAccessorDecl.remapLegacyCoroutineAccessorIfEnabled(self:)")
+void BridgedAccessorDecl_remapLegacyCoroutineAccessorIfEnabled(
+    BridgedAccessorDecl cAccessor);
+
 enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedVarDeclIntroducer {
   BridgedVarDeclIntroducerLet = 0,
   BridgedVarDeclIntroducerVar = 1,

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6571,7 +6571,7 @@ public:
 
   /// Given that CoroutineAccessors is enabled, is _read/_modify required for
   /// ABI stability?
-  bool requiresCorrespondingUnderscoredCoroutineAccessor(
+  bool requiresCorrespondingLegacyCoroutineAccessor(
       AccessorKind kind, AccessorDecl const *decl = nullptr) const;
 
   /// Does this storage require a 'mutate' accessor in its opaque-accessors set?
@@ -8982,6 +8982,11 @@ class AccessorDecl final : public FuncDecl {
 
   AbstractStorageDecl *Storage;
 
+  /// Whether a yield_once_2 coroutine accessor (yielding borrow/mutate) was
+  /// written by the user with the underscored spelling (_read/_modify).  This
+  /// only affects diagnostics; it has no ABI or type-system effect.
+  bool SpelledWithLegacyCoroutineSyntax = false;
+
   AccessorDecl(SourceLoc declLoc, SourceLoc accessorKeywordLoc,
                AccessorKind accessorKind, AbstractStorageDecl *storage,
                bool async, SourceLoc asyncLoc, bool throws, SourceLoc throwsLoc,
@@ -9057,6 +9062,23 @@ public:
 
   AccessorKind getAccessorKind() const {
     return AccessorKind(Bits.AccessorDecl.AccessorKind);
+  }
+
+  /// When the CoroutineAccessors feature is enabled, a `_read`/`_modify`
+  /// accessor is represented as a `yielding borrow`/`yielding mutate`
+  /// (yield_once_2) accessor so that it uses the same ABI, remembering here that
+  /// the user wrote the underscored spelling.  This only affects diagnostics.
+  ///
+  /// Rewrites this accessor's kind from the underscored coroutine accessor
+  /// (Read/Modify) to its yielding counterpart (YieldingBorrow/YieldingMutate),
+  /// recording that it was spelled with the underscored keyword.
+  void changeLegacyCoroutineAccessorToYielding();
+
+  /// Whether this yield_once_2 coroutine accessor was written by the user with
+  /// the underscored spelling (`_read`/`_modify`) rather than the
+  /// `yielding borrow`/`yielding mutate` spelling.
+  bool isSpelledWithLegacyCoroutineSyntax() const {
+    return SpelledWithLegacyCoroutineSyntax;
   }
 
   bool isGetter() const { return getAccessorKind() == AccessorKind::Get; }

--- a/lib/AST/Bridging/DeclBridging.cpp
+++ b/lib/AST/Bridging/DeclBridging.cpp
@@ -144,6 +144,17 @@ BridgedAccessorDecl BridgedAccessorDecl_createParsed(
       cThrownType.unbridged(), cDeclContext.unbridged());
 }
 
+void BridgedAccessorDecl_remapLegacyCoroutineAccessorIfEnabled(
+    BridgedAccessorDecl cAccessor) {
+  auto *accessor = cAccessor.unbridged();
+  if (!accessor->getASTContext().LangOpts.hasFeature(
+          Feature::CoroutineAccessors))
+    return;
+  auto kind = accessor->getAccessorKind();
+  if (kind == AccessorKind::Read || kind == AccessorKind::Modify)
+    accessor->changeLegacyCoroutineAccessorToYielding();
+}
+
 static VarDecl::Introducer unbridged(BridgedVarDeclIntroducer introducer) {
   switch (introducer) {
   case BridgedVarDeclIntroducerLet:

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3502,21 +3502,23 @@ static bool mayReferenceUseCoroutineAccessorOnStorage(
   if (!resilient)
     return true;
 
-  // Without knowing where the storage is referenced, it can't be known that
-  // a coroutine accessor is available.
-  if (!reference) {
-    return false;
-  }
+  // A resilient access may use the new (yield_once_2) coroutine accessor only
+  // if the caller is guaranteed to run at or after the feature's availability.
+  // With a source location, use the (possibly `if #available`-refined)
+  // availability there; without one, fall back to the caller's deployment
+  // target.  If the caller's deployment target predates the feature we must call
+  // the old ABI -- such a target may run against pre-feature frameworks that
+  // only have it -- and the emission policy guarantees that any accessor
+  // reachable from pre-feature code (i.e. itself available before the feature)
+  // has that old ABI, so this can never select a missing symbol.
+  auto callerAvailability =
+      reference ? AvailabilityContext::forLocation(reference->first.Start,
+                                                   reference->second)
+                      .getPlatformRange()
+                : AvailabilityContext::forDeploymentTarget(ctx).getPlatformRange();
+  auto featureAvailability = ctx.getCoroutineAccessorsAvailability();
 
-  // A resilient access to storage may only use a coroutine accessor if the
-  // storage became available no earlier than the feature.
-  auto referenceAvailability = AvailabilityContext::forLocation(
-                                   reference->first.Start, reference->second)
-                                   .getPlatformRange();
-  auto featureAvailability =
-      storage->getASTContext().getCoroutineAccessorsAvailability();
-
-  return referenceAvailability.isContainedIn(featureAvailability);
+  return callerAvailability.isContainedIn(featureAvailability);
 }
 
 static AccessStrategy getOpaqueReadAccessStrategy(

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3724,7 +3724,7 @@ bool AbstractStorageDecl::requiresOpaqueSetter() const {
 bool AbstractStorageDecl::requiresOpaqueReadCoroutine() const {
   ASTContext &ctx = getASTContext();
   if (ctx.LangOpts.hasFeature(Feature::CoroutineAccessors))
-    return requiresCorrespondingUnderscoredCoroutineAccessor(
+    return requiresCorrespondingLegacyCoroutineAccessor(
         AccessorKind::YieldingBorrow);
 
   return getOpaqueReadOwnership() == OpaqueReadOwnership::YieldingBorrow ||
@@ -8041,8 +8041,18 @@ StringRef swift::getAccessorNameForDiagnostic(AccessorKind accessorKind,
 StringRef swift::getAccessorNameForDiagnostic(AccessorDecl *accessor,
                                               bool article,
                                               std::optional<bool> underscored) {
+  auto kind = accessor->getAccessorKind();
+  // A yield_once_2 coroutine accessor that the user spelled with the
+  // underscored keyword (`_read`/`_modify`) should be named with that spelling
+  // in diagnostics rather than as `yielding borrow`/`yielding mutate`.
+  if (accessor->isSpelledWithLegacyCoroutineSyntax()) {
+    if (kind == AccessorKind::YieldingBorrow)
+      kind = AccessorKind::Read;
+    else if (kind == AccessorKind::YieldingMutate)
+      kind = AccessorKind::Modify;
+  }
   return getAccessorNameForDiagnostic(
-      accessor->getAccessorKind(), article,
+      kind, article,
       underscored.value_or(accessor->getASTContext().LangOpts.hasFeature(
           Feature::CoroutineAccessors)));
 }
@@ -11846,6 +11856,22 @@ AccessorDecl *AccessorDecl::createParsed(
   return accessor;
 }
 
+void AccessorDecl::changeLegacyCoroutineAccessorToYielding() {
+  // The yielding counterpart has the same signature (parameters and yielded
+  // type) as the underscored one, so only the kind changes.
+  switch (getAccessorKind()) {
+  case AccessorKind::Read:
+    Bits.AccessorDecl.AccessorKind = unsigned(AccessorKind::YieldingBorrow);
+    break;
+  case AccessorKind::Modify:
+    Bits.AccessorDecl.AccessorKind = unsigned(AccessorKind::YieldingMutate);
+    break;
+  default:
+    llvm_unreachable("not an underscored coroutine accessor");
+  }
+  SpelledWithLegacyCoroutineSyntax = true;
+}
+
 StringRef AccessorDecl::implicitParameterNameFor(AccessorKind kind) {
   switch (kind) {
   case AccessorKind::Set:
@@ -11960,7 +11986,7 @@ bool AccessorDecl::isRequirementWithSynthesizedDefaultImplementation() const {
   if (!requiresNewWitnessTableEntry()) {
     return false;
   }
-  return getStorage()->requiresCorrespondingUnderscoredCoroutineAccessor(
+  return getStorage()->requiresCorrespondingLegacyCoroutineAccessor(
       getAccessorKind(), this);
 }
 

--- a/lib/ASTGen/Sources/ASTGen/Decls.swift
+++ b/lib/ASTGen/Sources/ASTGen/Decls.swift
@@ -462,6 +462,10 @@ extension ASTGenVisitor {
       throwsSpecifierLoc: self.generateSourceLoc(node.effectSpecifiers?.throwsClause),
       thrownType: self.generate(type: node.effectSpecifiers?.thrownError)
     )
+    // With the CoroutineAccessors feature enabled, `_read`/`_modify` are just a
+    // spelling of the yielding accessors; rewrite them to match the C++ parser
+    // (ParsedAccessors::record).  ASTGen only parses surface source.
+    accessor.remapLegacyCoroutineAccessorIfEnabled()
     accessor.asDecl.attachParsedAttrs(attrs)
     if let body = node.body {
       self.withDeclContext(accessor.asDeclContext) {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -8912,6 +8912,35 @@ AccessorDecl *Parser::ParsedAccessors::add(AccessorDecl *accessor) {
 void Parser::ParsedAccessors::record(Parser &P, AbstractStorageDecl *storage,
                                      bool invalid) {
   classify(P, storage, invalid);
+
+  // When the CoroutineAccessors feature is enabled, in *surface source* the
+  // keywords `_read`/`_modify` and `yielding borrow`/`yielding mutate` are just
+  // two spellings of the same coroutine accessor.  Now that classify() has run
+  // its spelling-aware conflict diagnostics on the distinct kinds, rewrite a
+  // written `_read`/`_modify` to its yielding counterpart, remembering the
+  // underscored spelling for later diagnostics.
+  //
+  // The point is to make the accessor's *representation* independent of the
+  // source spelling.  The ABI -- in particular whether the old yield_once
+  // (`_read`/`_modify`) accessor is also emitted for backwards compatibility --
+  // is then determined by a consistent set of rules that do not depend on how
+  // the accessor was spelled; the rewrite does not itself dictate the ABI.
+  //
+  // This applies only to surface source.  In a .swiftinterface or .sil file,
+  // `_read`/`_modify` are ABI-level declarations -- synonyms for the yield_once
+  // accessor -- not surface spellings, so they already denote the correct
+  // accessor and must be taken literally.  (Post-parse, this leaves
+  // AccessorKind::Read/Modify uniformly meaning "the yield_once ABI accessor".)
+  if (P.Context.LangOpts.hasFeature(Feature::CoroutineAccessors) &&
+      P.SF.Kind != SourceFileKind::Interface &&
+      P.SF.Kind != SourceFileKind::SIL) {
+    for (auto *accessor : Accessors) {
+      auto kind = accessor->getAccessorKind();
+      if (kind == AccessorKind::Read || kind == AccessorKind::Modify)
+        accessor->changeLegacyCoroutineAccessorToYielding();
+    }
+  }
+
   storage->setAccessors(LBLoc, Accessors, RBLoc);
 }
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3688,8 +3688,14 @@ static AccessorDecl *
 getRepresentativeAccessorForKeyPath(AbstractStorageDecl *storage) {
   if (storage->requiresOpaqueGetter())
     return storage->getOpaqueAccessor(AccessorKind::Get);
-  assert(storage->requiresOpaqueReadCoroutine());
-  return storage->getOpaqueAccessor(AccessorKind::Read);
+  // Prefer the old read coroutine when it exists (so key paths for storage that
+  // predates the CoroutineAccessors feature keep referring to it); otherwise use
+  // the new yielding-borrow coroutine, which is the only read accessor a
+  // new-only property has.
+  if (storage->requiresOpaqueReadCoroutine())
+    return storage->getOpaqueAccessor(AccessorKind::Read);
+  assert(storage->requiresOpaqueYieldingBorrowCoroutine());
+  return storage->getOpaqueAccessor(AccessorKind::YieldingBorrow);
 }
 
 static CanType buildKeyPathIndicesTuple(ASTContext &C,

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -3654,7 +3654,9 @@ static LValue emitLValueForNonMemberVarDecl(
   auto access = getFormalAccessKind(accessKind);
   auto strategy = var->getAccessStrategy(
       semantics, access, SGF.SGM.M.getSwiftModule(),
-      SGF.F.getResilienceExpansion(), std::nullopt, /*useOldABI=*/false);
+      SGF.F.getResilienceExpansion(),
+      std::make_pair(loc.getSourceRange(), SGF.FunctionDC),
+      /*useOldABI=*/false);
 
   lv.addNonMemberVarComponent(SGF, loc, var, subs, options, accessKind,
                               strategy, formalRValueType, actorIso);
@@ -5029,7 +5031,8 @@ LValue SILGenFunction::emitPropertyLValue(SILLocation loc, ManagedValue base,
 
   AccessStrategy strategy = ivar->getAccessStrategy(
       semantics, getFormalAccessKind(accessKind), SGM.M.getSwiftModule(),
-      F.getResilienceExpansion(), std::nullopt, /*useOldABI=*/false);
+      F.getResilienceExpansion(),
+      std::make_pair(loc.getSourceRange(), FunctionDC), /*useOldABI=*/false);
 
   auto baseAccessKind =
     getBaseAccessKind(SGM, ivar, accessKind, strategy, baseFormalType,
@@ -5791,7 +5794,8 @@ RValue SILGenFunction::emitRValueForStorageLoad(
     bool isBaseGuaranteed) {
   AccessStrategy strategy = storage->getAccessStrategy(
       semantics, AccessKind::Read, SGM.M.getSwiftModule(),
-      F.getResilienceExpansion(), std::nullopt, /*useOldABI=*/false);
+      F.getResilienceExpansion(),
+      std::make_pair(loc.getSourceRange(), FunctionDC), /*useOldABI=*/false);
 
   // If we should call an accessor of some kind, do so.
   if (strategy.getKind() != AccessStrategy::Storage) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -6596,6 +6596,14 @@ findAutoDiffOriginalFunctionDecl(
           if (candidate) {
             maybeAccessorKind = AccessorKind::YieldingMutate;
           }
+        } else if (accessorKind == AccessorKind::Read) {
+          // With the CoroutineAccessors feature, a `_read` is represented as a
+          // `yielding borrow`.  Find it, but keep `maybeAccessorKind` as `Read`
+          // so diagnostics still refer to the `_read` spelling the user wrote.
+          candidate = asd->getOpaqueAccessor(AccessorKind::YieldingBorrow);
+        } else if (accessorKind == AccessorKind::Modify) {
+          // Likewise `_modify` is represented as a `yielding mutate`.
+          candidate = asd->getOpaqueAccessor(AccessorKind::YieldingMutate);
         }
       }
       // Error if candidate is missing the requested accessor.

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -33,6 +33,7 @@
 #include "swift/AST/Expr.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/Initializer.h"
+#include "swift/AST/Module.h"
 #include "swift/AST/NameLookupRequests.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/Pattern.h"
@@ -3067,6 +3068,18 @@ static bool requiresCorrespondingUnderscoredCoroutineAccessorImpl(
       }
     }
   }
+
+  // Unless we're building with library evolution, there is no stable ABI to
+  // preserve: the underscored (yield_once_1) accessor is pure overhead, so emit
+  // only the new (yield_once_2) ABI.  This covers non-resilient modules on every
+  // platform as well as non-ABI-stable builds such as Embedded and the static
+  // (LINUX_STATIC) standard library.  Note this comes *after* the override walk
+  // above: a decl in a non-resilient module overriding a resilient superclass
+  // must still emit the underscored accessor to dispatch through the super's ABI
+  // slot (that recursive call evaluates the super's own module resilience).
+  if (storage->getModuleContext()->getResilienceStrategy() !=
+      ResilienceStrategy::Resilient)
+    return false;
 
   // Non-exported storage has no ABI to keep stable.
   if (isExported(storage) != ExportedLevel::Exported)

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -1063,8 +1063,13 @@ OpaqueReadOwnershipRequest::evaluate(Evaluator &evaluator,
     return OpaqueReadOwnership::YieldingBorrow;
   };
 
-  if (auto *accessorDecl = storage->getAccessor(AccessorKind::Read)) {
-    auto lifetimeDependencies = accessorDecl->getLifetimeDependencies();
+  // A '_read' or 'yielding borrow' coroutine whose yielded value has a scoped
+  // lifetime dependence borrows its source, so the opaque read is a borrow.
+  auto *readAccessor = storage->getAccessor(AccessorKind::Read);
+  if (!readAccessor)
+    readAccessor = storage->getAccessor(AccessorKind::YieldingBorrow);
+  if (readAccessor) {
+    auto lifetimeDependencies = readAccessor->getLifetimeDependencies();
     if (lifetimeDependencies.has_value() && !lifetimeDependencies->empty()) {
       for (auto &lifetimeDependenceInfo : *lifetimeDependencies) {
         if (lifetimeDependenceInfo.hasScopeLifetimeParamIndices()) {
@@ -1075,7 +1080,13 @@ OpaqueReadOwnershipRequest::evaluate(Evaluator &evaluator,
     }
   }
 
-  if (storage->getAccessor(AccessorKind::YieldingBorrow))
+  // A 'yielding borrow' protocol requirement keeps a borrowing opaque read, like
+  // '@_borrowed', so the read-coroutine spellings stay symmetric in a protocol's
+  // witness layout.  Only concrete storage synthesizes a getter for it (see
+  // below); protocol requirement layout is handled separately by the
+  // additive-witness work.
+  if (storage->getAccessor(AccessorKind::YieldingBorrow) &&
+      isa<ProtocolDecl>(storage->getDeclContext()))
     return OpaqueReadOwnership::YieldingBorrow;
 
   if (storage->getAccessor(AccessorKind::Borrow))
@@ -1090,6 +1101,15 @@ OpaqueReadOwnershipRequest::evaluate(Evaluator &evaluator,
   if (storage->getInnermostDeclContext()->mapTypeIntoEnvironment(
         storage->getValueInterfaceType())->isNoncopyable())
     return usesBorrowed(DiagKind::NoncopyableType);
+
+  // A concrete copyable 'yielding borrow' exposes an owned getter -- matching
+  // '_read', whose synthesized getter is part of the shipped ABI -- in addition
+  // to the borrowing coroutine, so a caller can use either.  (A getter alone
+  // would drop the coroutine that the property was written with; the coroutine
+  // alone would lose the getter that a remapped '_read' shipped.)  The getter
+  // delegates to the coroutine, running its full body including the back half.
+  if (storage->getAccessor(AccessorKind::YieldingBorrow))
+    return OpaqueReadOwnership::OwnedOrBorrowed;
 
   return OpaqueReadOwnership::Owned;
 }

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -903,16 +903,22 @@ static void diagnoseReadWriteMutatingnessMismatch(
   bool hasCoroutineAccessorFeature =
       storage->getASTContext().LangOpts.hasFeature(Feature::CoroutineAccessors);
 
+  // Name an accessor for the diagnostic.  When we have the parsed accessor
+  // decl, use it so that a `_read`/`_modify` that was rewritten to its yielding
+  // counterpart is still named with the spelling the user wrote.
+  auto nameForAccessor = [&](AccessorKind kind) -> StringRef {
+    if (auto *decl = storage->getParsedAccessor(kind))
+      return getAccessorNameForDiagnostic(
+          decl, /*article=*/false, /*underscored=*/hasCoroutineAccessorFeature);
+    return getAccessorNameForDiagnostic(
+        kind, /*article=*/false, /*underscored=*/hasCoroutineAccessorFeature);
+  };
+
   auto readerAccessor = directAccessorKindForReadImpl(storage->getReadImpl());
   StringRef readerAccessorName =
-      readerAccessor.has_value()
-          ? getAccessorNameForDiagnostic(
-                *readerAccessor, /*article=*/false,
-                /*underscored=*/hasCoroutineAccessorFeature)
-          : "the inherited accessor";
-  StringRef writerAccessorName =
-      getAccessorNameForDiagnostic(writerAccesor, /*article=*/false,
-                                   /*underscored=*/hasCoroutineAccessorFeature);
+      readerAccessor.has_value() ? nameForAccessor(*readerAccessor)
+                                 : "the inherited accessor";
+  StringRef writerAccessorName = nameForAccessor(writerAccesor);
   unsigned diagnosticForm;
   if (isModifierMutating) {
     // modifier can't be mutating when both the setter is nonmutating and the
@@ -934,7 +940,7 @@ static void diagnoseReadWriteMutatingnessMismatch(
 
   modifyAccessor->diagnose(
       diag::readwriter_mutatingness_differs_from_reader_or_writer_mutatingness,
-      getAccessorNameForDiagnostic(readWriterAccessor, /*article=*/false,
+      getAccessorNameForDiagnostic(modifyAccessor, /*article=*/false,
                                    /*underscored=*/hasCoroutineAccessorFeature),
       isModifierMutating ? SelfAccessKind::Mutating
                          : SelfAccessKind::NonMutating,
@@ -3045,7 +3051,7 @@ RequiresOpaqueAccessorsRequest::evaluate(Evaluator &evaluator,
 ///
 /// The underscored accessor could, however, still be required for ABI
 /// stability.
-static bool requiresCorrespondingUnderscoredCoroutineAccessorImpl(
+static bool requiresCorrespondingLegacyCoroutineAccessorImpl(
     AbstractStorageDecl const *storage, AccessorKind kind,
     AccessorDecl const *decl, AbstractStorageDecl const *derived) {
   auto &ctx = storage->getASTContext();
@@ -3062,7 +3068,7 @@ static bool requiresCorrespondingUnderscoredCoroutineAccessorImpl(
     while ((current = current->getOverriddenDecl())) {
       auto *currentDecl = cast_or_null<AccessorDecl>(
           decl ? decl->getOverriddenDecl() : nullptr);
-      if (requiresCorrespondingUnderscoredCoroutineAccessorImpl(
+      if (requiresCorrespondingLegacyCoroutineAccessorImpl(
               current, kind, currentDecl, derived)) {
         return true;
       }
@@ -3081,8 +3087,16 @@ static bool requiresCorrespondingUnderscoredCoroutineAccessorImpl(
       ResilienceStrategy::Resilient)
     return false;
 
-  // Non-exported storage has no ABI to keep stable.
-  if (isExported(storage) != ExportedLevel::Exported)
+  // Storage that isn't visible outside its module has no ABI to keep stable.
+  // "Visible outside the module" means public/`@usableFromInline` (which
+  // isExported reports as Exported) or package: a separately-compiled module in
+  // the same package can call it across a resilience boundary, so it needs the
+  // stable (underscored) ABI too.
+  if (isExported(storage) != ExportedLevel::Exported &&
+      !storage
+           ->getFormalAccessScope(/*useDC=*/nullptr,
+                                  /*treatUsableFromInlineAsPublic=*/true)
+           .isPackage())
     return false;
 
   // The non-underscored accessor is not present, the underscored accessor
@@ -3128,9 +3142,9 @@ static bool requiresCorrespondingUnderscoredCoroutineAccessorImpl(
   return true;
 }
 
-bool AbstractStorageDecl::requiresCorrespondingUnderscoredCoroutineAccessor(
+bool AbstractStorageDecl::requiresCorrespondingLegacyCoroutineAccessor(
     AccessorKind kind, AccessorDecl const *decl) const {
-  return requiresCorrespondingUnderscoredCoroutineAccessorImpl(
+  return requiresCorrespondingLegacyCoroutineAccessorImpl(
       this, kind, decl,
       /*derived=*/this);
 }
@@ -3146,7 +3160,7 @@ bool RequiresOpaqueModifyCoroutineRequest::evaluate(
     return false;
 
   if (hasModifyFeature && isUnderscored) {
-    return storage->requiresCorrespondingUnderscoredCoroutineAccessor(
+    return storage->requiresCorrespondingLegacyCoroutineAccessor(
         AccessorKind::YieldingMutate);
   }
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -3065,12 +3065,12 @@ RequiresOpaqueAccessorsRequest::evaluate(Evaluator &evaluator,
   return true;
 }
 
-/// When the CoroutineAccessors feature is available, the coroutine accessor
-/// _could_ be required.  That non-underscored accessor would be preferred to
-/// its underscored counterpart accessor.
+/// Do we need to emit a legacy coroutine accessor?
 ///
-/// The underscored accessor could, however, still be required for ABI
-/// stability.
+/// We generally prefer the newer ABI version but need to preserve ABI stability
+/// in many cases.  The details depend on the target platform, build
+/// configuration, whether this is a concrete or protocol type, and when the
+/// property in question became available.
 static bool requiresCorrespondingLegacyCoroutineAccessorImpl(
     AbstractStorageDecl const *storage, AccessorKind kind,
     AccessorDecl const *decl, AbstractStorageDecl const *derived) {
@@ -3078,11 +3078,8 @@ static bool requiresCorrespondingLegacyCoroutineAccessorImpl(
   assert(ctx.LangOpts.hasFeature(Feature::CoroutineAccessors));
   assert(kind == AccessorKind::YieldingMutate || kind == AccessorKind::YieldingBorrow);
 
-  // If any overridden decl requires the underscored version, then this decl
-  // does too.  Otherwise dispatch to the underscored version on a value
-  // statically the super but dynamically this subtype would not dispatch to an
-  // override of the underscored version but rather (incorrectly) the
-  // supertype's implementation.
+  // If any overridden decl emits the legacy version, then this decl must as
+  // well, in order to ensure callers always get the right implementation.
   if (storage == derived) {
     auto *current = storage;
     while ((current = current->getOverriddenDecl())) {
@@ -3095,14 +3092,8 @@ static bool requiresCorrespondingLegacyCoroutineAccessorImpl(
     }
   }
 
-  // Unless we're building with library evolution, there is no stable ABI to
-  // preserve: the underscored (yield_once_1) accessor is pure overhead, so emit
-  // only the new (yield_once_2) ABI.  This covers non-resilient modules on every
-  // platform as well as non-ABI-stable builds such as Embedded and the static
-  // (LINUX_STATIC) standard library.  Note this comes *after* the override walk
-  // above: a decl in a non-resilient module overriding a resilient superclass
-  // must still emit the underscored accessor to dispatch through the super's ABI
-  // slot (that recursive call evaluates the super's own module resilience).
+  // If this module is not resilient, we don't need to preserve a stable ABI,
+  // so emit only the new (yield_once_2) ABI.
   if (storage->getModuleContext()->getResilienceStrategy() !=
       ResilienceStrategy::Resilient)
     return false;
@@ -3119,19 +3110,23 @@ static bool requiresCorrespondingLegacyCoroutineAccessorImpl(
            .isPackage())
     return false;
 
-  // The non-underscored accessor is not present, the underscored accessor
-  // won't be either.
+  // The yielding accessor is not present, so we won't emit a legacy
+  // wrapper either.
   auto *accessor = decl ? decl : storage->getOpaqueAccessor(kind);
   if (!accessor)
     return false;
 
-  // Availability-gated ABI compatibility only matters on targets that support
-  // versioned OS availability: there, a binary built before the feature
-  // shipped may run against a newer, already-built standard library, so the
-  // underscored accessor must stay available.  Targets without versioned
-  // availability (e.g. Linux, embedded) have no such prebuilt binary to stay
-  // compatible with, so always emit only the new ABI.
-  if (!ctx.supportsVersionedAvailability())
+  // For concrete types only: Availability-gated ABI compatibility only matters
+  // on targets that support versioned OS availability: there, a binary built
+  // before the new yielding ABI become available may run against a newer
+  // framework, so the framework must preserve the old ABI accessor.  Targets
+  // without versioned availability (e.g. Linux, embedded) have no prebuilt
+  // binaries to stay compatible with, so always emit only the new ABI.
+  //
+  // (For protocols, witness-table stability requirements get
+  // checked later in this function.)
+  if (!isa<ProtocolDecl>(storage->getDeclContext()) &&
+      !ctx.supportsVersionedAvailability())
     return false;
 
   AvailabilityContext accessorAvailability = [&] {
@@ -3154,13 +3149,13 @@ static bool requiresCorrespondingLegacyCoroutineAccessorImpl(
     return retval;
   }();
   auto featureAvailability = ctx.getCoroutineAccessorsAvailability();
-  // If accessor was introduced only after the feature was, there's no old ABI
-  // to maintain.
+  // If the accessor became available after the new coroutine ABI did,
+  // we will never need the legacy ABI.
   if (accessorAvailability.getPlatformRange().isContainedIn(
           featureAvailability))
     return false;
 
-  // The underscored accessor is required for ABI stability.
+  // The legacy ("underscored") accessor is required for ABI stability.
   return true;
 }
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -3116,17 +3116,20 @@ static bool requiresCorrespondingLegacyCoroutineAccessorImpl(
   if (!accessor)
     return false;
 
-  // For concrete types only: Availability-gated ABI compatibility only matters
-  // on targets that support versioned OS availability: there, a binary built
-  // before the new yielding ABI become available may run against a newer
-  // framework, so the framework must preserve the old ABI accessor.  Targets
-  // without versioned availability (e.g. Linux, embedded) have no prebuilt
-  // binaries to stay compatible with, so always emit only the new ABI.
-  //
-  // (For protocols, witness-table stability requirements get
-  // checked later in this function.)
-  if (!isa<ProtocolDecl>(storage->getDeclContext()) &&
-      !ctx.supportsVersionedAvailability())
+  // Always emit an old-ABI wrapper for protocols.  This ensures that
+  // protocol witness-table layout remains frozen and identical across every
+  // platform and deployment target, so that an old, never-recompiled
+  // conformance or caller can always link against the same slot.
+  if (storage->getDeclContext()->getSelfProtocolDecl())
+    return true;
+
+  // Availability-gated ABI compatibility only matters on targets that support
+  // versioned OS availability: there, a binary built before the new yielding
+  // ABI became available may run against a newer framework, so the framework
+  // must preserve the old ABI accessor.  Targets without versioned
+  // availability (e.g. Linux, embedded) have no prebuilt binaries to stay
+  // compatible with, so always emit only the new ABI.
+  if (!ctx.supportsVersionedAvailability())
     return false;
 
   AvailabilityContext accessorAvailability = [&] {

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -3125,12 +3125,14 @@ static bool requiresCorrespondingLegacyCoroutineAccessorImpl(
   if (!accessor)
     return false;
 
-  // Availability checks are only relevant on targets which support versioned
-  // availability.  Otherwise, since we're building with library evolution,
-  // conservatively assume that the binary must keep ABI compatibility with its
-  // prior versions, and emit the underscored variant.
+  // Availability-gated ABI compatibility only matters on targets that support
+  // versioned OS availability: there, a binary built before the feature
+  // shipped may run against a newer, already-built standard library, so the
+  // underscored accessor must stay available.  Targets without versioned
+  // availability (e.g. Linux, embedded) have no such prebuilt binary to stay
+  // compatible with, so always emit only the new ABI.
   if (!ctx.supportsVersionedAvailability())
-    return true;
+    return false;
 
   AvailabilityContext accessorAvailability = [&] {
     if (storage->getModuleContext()->isMainModule()) {

--- a/test/IRGen/CoroutineAccessorsDebugLoc.swift
+++ b/test/IRGen/CoroutineAccessorsDebugLoc.swift
@@ -1,11 +1,11 @@
 // REQUIRES: swift_feature_CoroutineAccessors
 // RUN: %target-swift-frontend %s -g -c -O -o - -emit-irgen -enable-experimental-feature CoroutineAccessors | %FileCheck %s
 
-// This test checks to made sure that the ReadAccessor s26CoroutineAccessorsDebugLoc1SV3irmSivr that has a call to @llvm.coro.id.retcon.once, also has a debug location set.
+// This test checks to made sure that the yielding borrow accessor s26CoroutineAccessorsDebugLoc1SV3irmSivy (spelled `_read` in source, but using the yield_once_2 ABI since the CoroutineAccessors feature is enabled) that has a call to @llvm.coro.id.retcon.once.dynamic, also has a debug location set.
 
-// CHECK-LABEL: @"$s26CoroutineAccessorsDebugLoc1SV3irmSivr"
-// CHECK: %{{.*}} = call token ({{.*}}) @llvm.coro.id.retcon.once({{.*}}), !dbg ![[DBGLOC:[0-9]+]]
-// CHECK-NEXT: %{{.*}} = call ptr @llvm.coro.begin({{.*}}), !dbg ![[DBGLOC]]
+// CHECK-LABEL: @"$s26CoroutineAccessorsDebugLoc1SV3irmSivy"
+// CHECK: @llvm.coro.id.retcon.once.dynamic({{.*}}), !dbg ![[DBGLOC:[0-9]+]]
+// CHECK-NEXT: @llvm.coro.begin({{.*}}), !dbg ![[DBGLOC]]
 
 public struct S {
 public var o: any AnyObject

--- a/test/IRGen/CoroutineAccessorsDebugLoc.swift
+++ b/test/IRGen/CoroutineAccessorsDebugLoc.swift
@@ -1,7 +1,8 @@
 // REQUIRES: swift_feature_CoroutineAccessors
-// RUN: %target-swift-frontend %s -g -c -O -o - -emit-irgen -enable-experimental-feature CoroutineAccessors | %FileCheck %s
+// RUN: %target-swift-frontend %s -g -c -O -o - -emit-irgen -enable-experimental-feature CoroutineAccessors -enable-callee-allocated-coro-abi | %FileCheck %s
 
 // This test checks to made sure that the yielding borrow accessor s26CoroutineAccessorsDebugLoc1SV3irmSivy (spelled `_read` in source, but using the yield_once_2 ABI since the CoroutineAccessors feature is enabled) that has a call to @llvm.coro.id.retcon.once.dynamic, also has a debug location set.
+// The yield_once_2 ABI is opted into explicitly since it is not the default on every platform.
 
 // CHECK-LABEL: @"$s26CoroutineAccessorsDebugLoc1SV3irmSivy"
 // CHECK: @llvm.coro.id.retcon.once.dynamic({{.*}}), !dbg ![[DBGLOC:[0-9]+]]

--- a/test/IRGen/coroutine_accessors.swift
+++ b/test/IRGen/coroutine_accessors.swift
@@ -373,14 +373,20 @@ public var force_yield_once_convention : () {
     let nothing: () = ()
     yield nothing
   }
+// With the CoroutineAccessors feature enabled, `_read`/`_modify` use the exact
+// same yield_once_2 ABI as `yielding borrow`/`yielding mutate`.  This block is
+// therefore identical to increment_irm_yield_once_2 below: it forwards the
+// caller's coroutine allocator rather than allocating its own frame.
 // CHECK-LABEL: define{{.*}} { ptr, ptr } @increment_irm_yield_once(
-//                  ptr noalias dereferenceable(32) %0
+//                  ptr noalias %0
+// CHECK-SAME:      ptr swiftcoro [[ALLOCATOR:%[^,]+]]
+//                  ptr swiftself captures(none) dereferenceable(16) %2
 // CHECK-SAME:  )
 // CHECK-SAME:  {
 //      :         [[SIZE_32:%[^,]+]] = load i32
 //           :        ptr getelementptr inbounds (
 //           :            %swift.coro_func_pointer
-//           :            $s19coroutine_accessors1SV3irmSivxTwc
+// CHECK:                 $s19coroutine_accessors1SV3irmSivxTwc
 //           :            i32 0
 //           :            i32 1
 //           :        )
@@ -393,7 +399,7 @@ public var force_yield_once_convention : () {
 // CHECK:         [[RAMP:%[^,]+]] = call ptr @llvm.coro.prepare.retcon(ptr @"$s19coroutine_accessors1SV3irmSivx")
 // CHECK:         [[RETVAL:%[^,]+]] = call swiftcc { ptr, ptr } [[RAMP]](
 // CHECK-SAME:         [[FRAME]],
-// CHECK-apple-SAME:         _swift_coro_typed_malloc_allocator
+// CHECK-SAME:         [[ALLOCATOR]]
 // CHECK-SAME:    )
 // CHECK:         [[CONTINUATION:%[^,]+]] = extractvalue { ptr, ptr } [[RETVAL]], 0
 // CHECK:         [[YIELD:%[^,]+]] = extractvalue { ptr, ptr } [[RETVAL]], 1
@@ -402,7 +408,7 @@ public var force_yield_once_convention : () {
 // CHECK-SAME:    )
 // CHECK:         call swiftcc void [[CONTINUATION]](
 // CHECK-SAME:        [[FRAME]],
-// CHECK-apple-SAME:        _swift_coro_typed_malloc_allocator
+// CHECK-SAME:        [[ALLOCATOR]]
 // CHECK-SAME:    )
 // CHECK:         call void @llvm.lifetime.end.p0(i64 -1, ptr [[FRAME]])
 // CHECK:         call void @llvm.coro.alloca.free.frame(token [[ALLOCATION]])

--- a/test/IRGen/coroutine_accessors_past.swift
+++ b/test/IRGen/coroutine_accessors_past.swift
@@ -3,21 +3,28 @@
 // RUN:    %s                     \
 // RUN: | %IRGenFileCheck %s
 
+// Also verify the old `_modify` (yield_once_1) accessor is NOT emitted.
+// RUN: %target-swift-emit-irgen  \
+// RUN:    -enable-experimental-feature CoroutineAccessors  \
+// RUN:    %s                     \
+// RUN: | %FileCheck %s --check-prefix=NO-OLD-ABI
+
 // REQUIRES: swift_feature_CoroutineAccessors
 
 // REQUIRES: OS_FAMILY=darwin || OS=linux-gnu
 // REQUIRES: PTRSIZE=64
 
-// Simple struct available before CoroutineAccessors feature is present:
-
-// We have to emit a `_modify` to support old clients, and
-// a `yielding mutate` so we can migrate to the more efficient form.
+// Simple struct that predates the CoroutineAccessors feature, but built WITHOUT
+// library evolution: there is no stable ABI to preserve, so we emit only the new
+// `yielding mutate` (yield_once_2) accessor and NOT the old `_modify`
+// (yield_once_1) one.  See coroutine_accessors_past_resilient.swift for the
+// library-evolution counterpart, which must keep the old `_modify`.
 
 public struct OhOh {
     public var g: Int = 0
 }
 
-// Verify that we emit a get, set, `_modify`, and `yielding mutate` implementation:
+// Verify that we emit a get, set, and `yielding mutate` implementation:
 
 // Variable initialization expression
 // CHECK: define{{.*}} swiftcc i64 @"$s24coroutine_accessors_past02OhD0V1gSivpfi"() #0
@@ -28,9 +35,8 @@ public struct OhOh {
 // Setter definition
 // CHECK: define{{.*}} swiftcc void @"$s24coroutine_accessors_past02OhD0V1gSivs"(i64 %0, ptr swiftself captures(none) dereferenceable(8) %1) #0
 
-// _modify definition
-// CHECK: define{{.*}} swiftcc { ptr, ptr } @"$s24coroutine_accessors_past02OhD0V1gSivM"(ptr noalias dereferenceable(32) %0, ptr swiftself captures(none) dereferenceable(8) %1) #1
-
 // yielding mutate definition
 // CHECK: define{{.*}} {{(swiftcc|swiftcorocc)}} { ptr, ptr } @"$s24coroutine_accessors_past02OhD0V1gSivx"(ptr noalias %0, ptr{{( swiftcoro)?}} %1, ptr swiftself captures(none) dereferenceable(8) %2) #1
 
+// The old `_modify` (yield_once_1) accessor must not appear anywhere.
+// NO-OLD-ABI-NOT: @"$s24coroutine_accessors_past02OhD0V1gSivM"

--- a/test/IRGen/coroutine_accessors_past_resilient.swift
+++ b/test/IRGen/coroutine_accessors_past_resilient.swift
@@ -1,0 +1,35 @@
+// RUN: %target-swift-emit-irgen  \
+// RUN:    -enable-experimental-feature CoroutineAccessors  \
+// RUN:    -enable-library-evolution  \
+// RUN:    %s                     \
+// RUN: | %IRGenFileCheck %s
+
+// REQUIRES: swift_feature_CoroutineAccessors
+
+// REQUIRES: OS_FAMILY=darwin || OS=linux-gnu
+// REQUIRES: PTRSIZE=64
+
+// The library-evolution counterpart of coroutine_accessors_past.swift.  Here the
+// struct predates the CoroutineAccessors feature AND has a stable ABI to
+// preserve, so we must emit both the old `_modify` (yield_once_1) accessor to
+// support old clients and the new `yielding mutate` (yield_once_2) accessor so
+// clients can migrate to the more efficient form.
+
+public struct OhOh {
+    public var g: Int = 0
+}
+
+// Verify that we emit a get, set, `_modify`, and `yielding mutate` implementation.
+// (Note the resilient signatures pass `self` opaquely by pointer.)
+
+// Getter definition
+// CHECK: define{{.*}} swiftcc i64 @"$s34coroutine_accessors_past_resilient02OhE0V1gSivg"(ptr noalias swiftself captures(none) dereferenceable(8) %0) #{{[0-9]+}}
+
+// Setter definition
+// CHECK: define{{.*}} swiftcc void @"$s34coroutine_accessors_past_resilient02OhE0V1gSivs"(i64 %0, ptr swiftself captures(none) dereferenceable(8) %1) #{{[0-9]+}}
+
+// _modify definition (old yield_once_1 ABI, kept for ABI stability)
+// CHECK: define{{.*}} swiftcc { ptr, ptr } @"$s34coroutine_accessors_past_resilient02OhE0V1gSivM"(ptr noalias dereferenceable(32) %0, ptr swiftself captures(none) dereferenceable(8) %1) #{{[0-9]+}}
+
+// yielding mutate definition (new yield_once_2 ABI)
+// CHECK: define{{.*}} {{(swiftcc|swiftcorocc)}} { ptr, ptr } @"$s34coroutine_accessors_past_resilient02OhE0V1gSivx"(ptr noalias %0, ptr{{( swiftcoro)?}} %1, ptr swiftself captures(none) dereferenceable(8) %2) #{{[0-9]+}}

--- a/test/IRGen/coroutine_accessors_past_resilient.swift
+++ b/test/IRGen/coroutine_accessors_past_resilient.swift
@@ -6,7 +6,9 @@
 
 // REQUIRES: swift_feature_CoroutineAccessors
 
-// REQUIRES: OS_FAMILY=darwin || OS=linux-gnu
+// The old ABI is additively emitted only on an ABI-stable platform; elsewhere
+// there is no prebuilt binary to stay compatible with.
+// REQUIRES: swift_stable_abi
 // REQUIRES: PTRSIZE=64
 
 // The library-evolution counterpart of coroutine_accessors_past.swift.  Here the

--- a/test/IRGen/coroutine_accessors_popless.swift
+++ b/test/IRGen/coroutine_accessors_popless.swift
@@ -7,6 +7,10 @@
 // RUN:     -enable-x86_64-corocc                                           \
 // RUN: | %IRGenFileCheck %s
 
+// This is a non-resilient test case (no -enable-library-evolution above),
+// so it only emits the new yield_once_2 coroutine ABI and never the
+// old yield_once_1 coroutine ABI.
+
 // REQUIRES: CPU=arm64 || CPU=arm64e || CPU=x86_64
 // REQUIRES: swift_feature_CoroutineAccessors
 
@@ -24,6 +28,39 @@
 //           :    ),
 // CHECK-SAME:    i32 0
 // CHECK-SAME:  }>
+
+// CHECK-arm64e-LABEL: _swift_coro_task_alloc.ptrauth = private constant {
+// CHECK-arm64e-SAME:    ptr @_swift_coro_task_alloc,
+// CHECK-arm64e-SAME:    i32 0,
+// CHECK-arm64e-SAME:    i64 ptrtoint (
+// CHECK-arm64e-SAME:      ptr getelementptr inbounds (
+// CHECK-arm64e-SAME:        ptr @_swift_coro_async_allocator,
+// CHECK-arm64e-SAME:        i32 0,
+// CHECK-arm64e-SAME:        i32 1
+// CHECK-arm64e-SAME:      )
+// CHECK-arm64e-SAME:    )
+// CHECK-arm64e-SAME:    i64 24469 }
+// CHECK-arm64e-SAME:  section "llvm.ptrauth"
+// CHECK-arm64e-SAME:  align 8
+// CHECK-arm64e-LABEL: @_swift_coro_task_dealloc.ptrauth = private constant {
+// CHECK-arm64e-SAME:    ptr @_swift_coro_task_dealloc,
+// CHECK-arm64e-SAME:    i32 0,
+// CHECK-arm64e-SAME:    i64 ptrtoint (
+// CHECK-arm64e-SAME:      ptr getelementptr inbounds (
+// CHECK-arm64e-SAME:        ptr @_swift_coro_async_allocator,
+// CHECK-arm64e-SAME:        i32 0,
+// CHECK-arm64e-SAME:        i32 2
+// CHECK-arm64e-SAME:      )
+// CHECK-arm64e-SAME:    )
+// CHECK-arm64e-SAME:    i64 40879 },
+// CHECK-arm64e-SAME:  section "llvm.ptrauth",
+// CHECK-arm64e-SAME:  align 8
+
+// CHECK-LABEL: _swift_coro_async_allocator = linkonce_odr hidden constant %swift.coro_allocator {
+// CHECK-SAME:      i32 1,
+// CHECK-SAME:      _swift_coro_task_alloc
+// CHECK-SAME:      _swift_coro_task_dealloc
+// CHECK-SAME:  }
 
 // CHECK-arm64e-LABEL: _swift_coro_typed_malloc.ptrauth = private constant {
 // CHECK-arm64e-SAME:    ptr @_swift_coro_typed_malloc,
@@ -59,39 +96,6 @@
 // CHECK-apple-SAME:       _swift_coro_typed_malloc
 // CHECK-apple-SAME:       _swift_coro_free
 // CHECK-apple-SAME:  }
-
-// CHECK-arm64e-LABEL: _swift_coro_task_alloc.ptrauth = private constant {
-// CHECK-arm64e-SAME:    ptr @_swift_coro_task_alloc,
-// CHECK-arm64e-SAME:    i32 0,
-// CHECK-arm64e-SAME:    i64 ptrtoint (
-// CHECK-arm64e-SAME:      ptr getelementptr inbounds (
-// CHECK-arm64e-SAME:        ptr @_swift_coro_async_allocator,
-// CHECK-arm64e-SAME:        i32 0,
-// CHECK-arm64e-SAME:        i32 1
-// CHECK-arm64e-SAME:      )
-// CHECK-arm64e-SAME:    )
-// CHECK-arm64e-SAME:    i64 24469 }
-// CHECK-arm64e-SAME:  section "llvm.ptrauth"
-// CHECK-arm64e-SAME:  align 8
-// CHECK-arm64e-LABEL: @_swift_coro_task_dealloc.ptrauth = private constant {
-// CHECK-arm64e-SAME:    ptr @_swift_coro_task_dealloc,
-// CHECK-arm64e-SAME:    i32 0,
-// CHECK-arm64e-SAME:    i64 ptrtoint (
-// CHECK-arm64e-SAME:      ptr getelementptr inbounds (
-// CHECK-arm64e-SAME:        ptr @_swift_coro_async_allocator,
-// CHECK-arm64e-SAME:        i32 0,
-// CHECK-arm64e-SAME:        i32 2
-// CHECK-arm64e-SAME:      )
-// CHECK-arm64e-SAME:    )
-// CHECK-arm64e-SAME:    i64 40879 },
-// CHECK-arm64e-SAME:  section "llvm.ptrauth",
-// CHECK-arm64e-SAME:  align 8
-
-// CHECK-LABEL: _swift_coro_async_allocator = linkonce_odr hidden constant %swift.coro_allocator {
-// CHECK-SAME:      i32 1,
-// CHECK-SAME:      _swift_coro_task_alloc
-// CHECK-SAME:      _swift_coro_task_dealloc
-// CHECK-SAME:  }
 
 // CHECK-LABEL: @_swift_coro_alloc(
 // CHECK-SAME:      ptr [[FRAME:%[^,]+]]
@@ -266,7 +270,7 @@ public var force_yield_once_convention : () {
     let nothing: () = ()
     yield nothing
   }
-// CHECK-LABEL: define{{.*}} { ptr, ptr } @increment_i_yield_once(
+// CHECK-LABEL: define{{.*}} swiftcc { ptr, ptr } @increment_i_yield_once(
 //                  ptr noalias dereferenceable(32) %0
 // CHECK-SAME:  )
 // CHECK-SAME:  {
@@ -299,6 +303,9 @@ public var force_yield_once_convention : () {
 // CHECK:         call void @llvm.lifetime.end.p0(i64 -1, ptr [[FRAME]])
 // CHECK:         call void @llvm.coro.alloca.free.frame(token [[ALLOCATION]])
 // CHECK:       }
+
+  // TODO: `_modify` should use `yield_once_2` with CoroutineAccessors enabled,
+  // the same ABI as `yielding mutate`
   @_silgen_name("increment_i_yield_once")
   _modify {
     increment(&i)
@@ -313,7 +320,7 @@ public var force_yield_once_2_convention : () {
     let nothing: () = ()
     yield nothing
   }
-// CHECK-LABEL: define{{.*}} { ptr, ptr } @increment_i_yield_once_2(
+// CHECK-LABEL: define{{.*}} swiftcorocc { ptr, ptr } @increment_i_yield_once_2(
 //                  ptr noalias %0
 // CHECK-SAME:      ptr swiftcoro [[ALLOCATOR:%[^)]+]]
 // CHECK-SAME:  )

--- a/test/IRGen/coroutine_accessors_popless.swift
+++ b/test/IRGen/coroutine_accessors_popless.swift
@@ -62,41 +62,6 @@
 // CHECK-SAME:      _swift_coro_task_dealloc
 // CHECK-SAME:  }
 
-// CHECK-arm64e-LABEL: _swift_coro_typed_malloc.ptrauth = private constant {
-// CHECK-arm64e-SAME:    ptr @_swift_coro_typed_malloc,
-// CHECK-arm64e-SAME:    i32 0,
-// CHECK-arm64e-SAME:    i64 ptrtoint (
-// CHECK-arm64e-SAME:      ptr getelementptr inbounds (
-// CHECK-arm64e-SAME:        %swift.coro_allocator,
-// CHECK-arm64e-SAME:        ptr @_swift_coro_typed_malloc_allocator,
-// CHECK-arm64e-SAME:        i32 0,
-// CHECK-arm64e-SAME:        i32 1
-// CHECK-arm64e-SAME:      ) to i64
-// CHECK-arm64e-SAME:    ),
-// CHECK-arm64e-SAME:    i64 24469 }
-// CHECK-arm64e-SAME:  section "llvm.ptrauth"
-// CHECK-arm64e-SAME:  align 8
-// CHECK-arm64e-LABEL: _swift_coro_free.ptrauth = private constant {
-// CHECK-arm64e-SAME:    ptr @_swift_coro_free,
-// CHECK-arm64e-SAME:    i32 0,
-// CHECK-arm64e-SAME:    i64 ptrtoint (
-// CHECK-arm64e-SAME:      ptr getelementptr inbounds (
-// CHECK-arm64e-SAME:        %swift.coro_allocator,
-// CHECK-arm64e-SAME:        ptr @_swift_coro_typed_malloc_allocator,
-// CHECK-arm64e-SAME:        i32 0,
-// CHECK-arm64e-SAME:        i32 2
-// CHECK-arm64e-SAME:      ) to i64
-// CHECK-arm64e-SAME:    ),
-// CHECK-arm64e-SAME:    i64 40879 },
-// CHECK-arm64e-SAME:  section "llvm.ptrauth",
-// CHECK-arm64e-SAME:  align 8
-
-// CHECK-apple-LABEL: _swift_coro_typed_malloc_allocator = linkonce_odr hidden constant %swift.coro_allocator {
-// CHECK-apple-SAME:       i32 259,
-// CHECK-apple-SAME:       _swift_coro_typed_malloc
-// CHECK-apple-SAME:       _swift_coro_free
-// CHECK-apple-SAME:  }
-
 // CHECK-LABEL: @_swift_coro_alloc(
 // CHECK-SAME:      ptr [[FRAME:%[^,]+]]
 // CHECK-SAME:      ptr swiftcoro [[ALLOCATOR:%[^,]+]],
@@ -270,8 +235,13 @@ public var force_yield_once_convention : () {
     let nothing: () = ()
     yield nothing
   }
-// CHECK-LABEL: define{{.*}} swiftcc { ptr, ptr } @increment_i_yield_once(
-//                  ptr noalias dereferenceable(32) %0
+// With the CoroutineAccessors feature enabled, `_read`/`_modify` use the exact
+// same yield_once_2 ABI as `yielding borrow`/`yielding mutate`.  This is
+// therefore identical to increment_i_yield_once_2 below: it forwards the
+// caller's coroutine allocator rather than allocating its own frame.
+// CHECK-LABEL: define{{.*}} swiftcorocc { ptr, ptr } @increment_i_yield_once(
+//                  ptr noalias %0
+// CHECK-SAME:      ptr swiftcoro [[ALLOCATOR:%[^)]+]]
 // CHECK-SAME:  )
 // CHECK-SAME:  {
 //      :         [[SIZE_32:%[^,]+]] = load i32
@@ -289,7 +259,7 @@ public var force_yield_once_convention : () {
 // CHECK:         [[RAMP:%[^,]+]] = call ptr @llvm.coro.prepare.retcon(ptr @"$s27coroutine_accessors_popless1iSivx")
 // CHECK:         [[RETVAL:%[^,]+]] = call swiftcorocc { ptr, ptr } [[RAMP]](
 // CHECK-SAME:         [[FRAME]],
-// CHECK-apple-SAME:         _swift_coro_typed_malloc_allocator
+// CHECK-SAME:         [[ALLOCATOR]]
 // CHECK-SAME:    )
 // CHECK:         [[CONTINUATION:%[^,]+]] = extractvalue { ptr, ptr } [[RETVAL]], 0
 // CHECK:         [[YIELD:%[^,]+]] = extractvalue { ptr, ptr } [[RETVAL]], 1
@@ -298,14 +268,12 @@ public var force_yield_once_convention : () {
 // CHECK-SAME:    )
 // CHECK:         call swiftcorocc void [[CONTINUATION]](
 // CHECK-SAME:        [[FRAME]],
-// CHECK-apple-SAME:        _swift_coro_typed_malloc_allocator
+// CHECK-SAME:        [[ALLOCATOR]]
 // CHECK-SAME:    )
 // CHECK:         call void @llvm.lifetime.end.p0(i64 -1, ptr [[FRAME]])
 // CHECK:         call void @llvm.coro.alloca.free.frame(token [[ALLOCATION]])
 // CHECK:       }
 
-  // TODO: `_modify` should use `yield_once_2` with CoroutineAccessors enabled,
-  // the same ABI as `yielding mutate`
   @_silgen_name("increment_i_yield_once")
   _modify {
     increment(&i)

--- a/test/IRGen/default_override.sil
+++ b/test/IRGen/default_override.sil
@@ -9,6 +9,12 @@
 
 // REQUIRES: swift_feature_CoroutineAccessors
 
+// The old (legacy) accessor vtable/default-override slots this test exercises
+// on the concrete resilient class B are additively present only on an
+// ABI-stable platform; elsewhere there is no prebuilt binary to stay
+// compatible with, so only the new accessors exist.
+// REQUIRES: swift_stable_abi
+
 sil_stage canonical
 
 import Builtin

--- a/test/Interpreter/coroutine_accessors_default_implementations.swift
+++ b/test/Interpreter/coroutine_accessors_default_implementations.swift
@@ -45,7 +45,12 @@
 // REQUIRES: executable_test
 
 // This test verifies the backwards compatibility of binaries built against old
-// SDKs running on newer OSes (where CoroutineAccessors has been enabled).
+// SDKs running on newer OSes (where CoroutineAccessors has been enabled).  That
+// scenario only arises on platforms with a stable ABI: class B's old-ABI
+// accessors (referenced directly by the pre-built Executable.o, since `B.i`
+// and `B[_:]` are `@_borrowed` on a non-final open class) are only emitted at
+// all when there's a prebuilt binary to stay compatible with.
+// REQUIRES: swift_stable_abi
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 

--- a/test/ModuleInterface/coroutine_accessors.swift
+++ b/test/ModuleInterface/coroutine_accessors.swift
@@ -29,3 +29,21 @@ public var i: Int {
     yield &_i
   }
 }
+
+// A protocol requirement with coroutine accessors.  The textual form of a
+// requirement is the same with or without the feature (`{ get set }`), so the
+// availability guard's two branches print identically; the subscript
+// requirement is printed without a guard.  This locks in that printing and
+// verifies the interface round-trips.
+// CHECK:      public protocol P {
+// CHECK:        #if compiler(>=5.3) && $CoroutineAccessors
+// CHECK-NEXT:   @_borrowed var value: Swift::Int { get set }
+// CHECK-NEXT:   #else
+// CHECK-NEXT:   @_borrowed var value: Swift::Int { get set }
+// CHECK-NEXT:   #endif
+// CHECK:        @_borrowed subscript(i: Swift::Int) -> Swift::Int { get set }
+// CHECK:      }
+public protocol P {
+  @_borrowed var value: Int { get set }
+  @_borrowed subscript(i: Int) -> Int { get set }
+}

--- a/test/ModuleInterface/coroutine_accessors.swift
+++ b/test/ModuleInterface/coroutine_accessors.swift
@@ -3,24 +3,15 @@
 // RUN:     %s \
 // RUN:     -enable-experimental-feature CoroutineAccessors \
 // RUN:     -module-name Rock
-// RUN: %FileCheck %s < %t.swiftinterface
+// RUN: %FileCheck %s --check-prefixes=CHECK,CHECK-%target-abi-stability < %t.swiftinterface
 // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name Rock
 
 // REQUIRES: swift_feature_CoroutineAccessors
 
+// === A global public computed property ===
+
 var _i: Int = 0
 
-// CHECK:      #if compiler(>=5.3) && $CoroutineAccessors
-// CHECK-NEXT: public var i: Swift::Int {
-// CHECK-NEXT:   yielding borrow
-// CHECK-NEXT:   yielding mutate
-// CHECK-NEXT: }
-// CHECK-NEXT: #else
-// CHECK-NEXT: public var i: Swift::Int {
-// CHECK-NEXT:   _read
-// CHECK-NEXT:   _modify
-// CHECK-NEXT: }
-// CHECK-NEXT: #endif
 public var i: Int {
   yielding borrow {
     yield _i
@@ -30,12 +21,44 @@ public var i: Int {
   }
 }
 
-// A protocol requirement with coroutine accessors.  The textual form of a
-// requirement is the same with or without the feature (`{ get set }`), so the
-// availability guard's two branches print identically; the subscript
-// requirement is printed without a guard.  This locks in that printing and
-// verifies the interface round-trips.
-// CHECK:      public protocol P {
+// New consumers (who understand CoroutineAccessors) will see
+// the new form.
+
+// CHECK:      #if compiler(>=5.3) && $CoroutineAccessors
+// CHECK-NEXT: public var i: Swift::Int {
+// CHECK-NEXT:   yielding borrow
+// CHECK-NEXT:   yielding mutate
+// CHECK-NEXT: }
+// CHECK-NEXT: #else
+
+// Old consumers will get the legacy form, which in this case
+// implies the legacy ABI.
+
+// CHECK-stable-NEXT: public var i: Swift::Int {
+// CHECK-stable-NEXT:   _read
+// CHECK-stable-NEXT:   _modify
+// CHECK-stable-NEXT: }
+
+// On non-ABI-stable platforms, we've stopped emitting the legacy ABI,
+// so this property has no ABI on such platforms.
+
+// CHECK-unstable-NEXT: public var i: Swift::Int {
+// CHECK-unstable-NEXT: }
+// CHECK-NEXT: #endif
+
+
+// === A protocol requirement with (implied) coroutine accessors ===
+
+public protocol P1 {
+  @_borrowed var value: Int { get set }
+  @_borrowed subscript(i: Int) -> Int { get set }
+}
+
+// The requirement is written identically with or without the feature, so the
+// availability guard's two branches print identically.  The subscript
+// prints without a guard.
+
+// CHECK:      public protocol P1 {
 // CHECK:        #if compiler(>=5.3) && $CoroutineAccessors
 // CHECK-NEXT:   @_borrowed var value: Swift::Int { get set }
 // CHECK-NEXT:   #else
@@ -43,7 +66,47 @@ public var i: Int {
 // CHECK-NEXT:   #endif
 // CHECK:        @_borrowed subscript(i: Swift::Int) -> Swift::Int { get set }
 // CHECK:      }
-public protocol P {
-  @_borrowed var value: Int { get set }
-  @_borrowed subscript(i: Int) -> Int { get set }
+
+
+// === A concrete struct type ===
+
+public struct S {
+    public var value: Int {
+        yielding borrow { var t = 0; yield t }
+        yielding mutate { var t = 0; yield &t; print(t) }
+    }
+    public subscript(i: Int) -> Int {
+        yielding borrow { var t = i; yield t }
+        yielding mutate { var t = i; yield &t; print(t) }
+    }
 }
+
+// The property mirrors `var i` above: same guard, same stable/unstable
+// split for the legacy branch.
+
+// CHECK:      public struct S {
+// CHECK:        #if compiler(>=5.3) && $CoroutineAccessors
+// CHECK-NEXT:   public var value: Swift::Int {
+// CHECK-NEXT:     yielding borrow
+// CHECK-NEXT:     yielding mutate
+// CHECK-NEXT:   }
+// CHECK-NEXT:   #else
+// CHECK-stable-NEXT: public var value: Swift::Int {
+// CHECK-stable-NEXT:   _read
+// CHECK-stable-NEXT:   _modify
+// CHECK-stable-NEXT: }
+// CHECK-unstable-NEXT: public var value: Swift::Int {
+// CHECK-unstable-NEXT: }
+// CHECK-NEXT:   #endif
+
+// TODO: Fix this bug
+// Unlike the property, the subscript currently gets no guard:
+// it always prints the new spelling unconditionally, identically on stable
+// and unstable platforms.
+
+// CHECK-NEXT:   public subscript(i: Swift::Int) -> Swift::Int {
+// CHECK-NEXT:     yielding borrow
+// CHECK-NEXT:     yielding mutate
+// CHECK-NEXT:   }
+// CHECK:      }
+

--- a/test/SIL/Parser/default_override.sil
+++ b/test/SIL/Parser/default_override.sil
@@ -5,6 +5,12 @@
 
 // REQUIRES: swift_feature_CoroutineAccessors
 
+// The old (legacy) accessor vtable/default-override slots this test exercises
+// on the concrete resilient class B are additively present only on an
+// ABI-stable platform; elsewhere there is no prebuilt binary to stay
+// compatible with, so only the new accessors exist.
+// REQUIRES: swift_stable_abi
+
 sil_stage canonical
 
 import Builtin

--- a/test/SIL/Parser/default_override_legacy_syntax.sil
+++ b/test/SIL/Parser/default_override_legacy_syntax.sil
@@ -10,6 +10,12 @@
 
 // REQUIRES: swift_feature_CoroutineAccessors
 
+// The old (legacy) accessor vtable/default-override slots this test exercises
+// on the concrete resilient class B are additively present only on an
+// ABI-stable platform; elsewhere there is no prebuilt binary to stay
+// compatible with, so only the new accessors exist.
+// REQUIRES: swift_stable_abi
+
 sil_stage canonical
 
 import Builtin

--- a/test/SIL/Serialization/default_override.sil
+++ b/test/SIL/Serialization/default_override.sil
@@ -7,6 +7,12 @@
 
 // REQUIRES: swift_feature_CoroutineAccessors
 
+// The old (legacy) accessor vtable/default-override slots this test exercises
+// on the concrete resilient class B are additively present only on an
+// ABI-stable platform; elsewhere there is no prebuilt binary to stay
+// compatible with, so only the new accessors exist.
+// REQUIRES: swift_stable_abi
+
 sil_stage canonical
 
 import Builtin

--- a/test/SILGen/coroutine_accessors.swift
+++ b/test/SILGen/coroutine_accessors.swift
@@ -263,27 +263,27 @@ protocol GettableTitle {
   var title: String { get }
 }
 
-// CHECK-LABEL: sil{{.*}} [ossa] @$s19coroutine_accessors17OverridableReaderCAA13GettableTitleA2aDP5titleSSvgTW : {{.*}} {
-// CHECK:       bb0(
-// CHECK-SAME:      [[SELF_ADDR:%[^,]+]] :
-// CHECK-SAME:  ):
-// CHECK:         [[SELF:%[^,]+]] = load_borrow [[SELF_ADDR]]
-// CHECK:         [[GETTER:%[^,]+]] = function_ref @$s19coroutine_accessors17OverridableReaderC5titleSSvg
-// CHECK:         [[RETVAL:%[^,]+]] = apply [[GETTER]]([[SELF]])
-// CHECK:         end_borrow [[SELF]]
-// CHECK:         return [[RETVAL]]
-// CHECK-LABEL: } // end sil function '$s19coroutine_accessors17OverridableReaderCAA13GettableTitleA2aDP5titleSSvgTW'
 // CHECK-LABEL: sil{{.*}} [ossa] @$s19coroutine_accessors17OverridableReaderC5titleSSvg : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF:%[^,]+]] :
 // CHECK-SAME:  ):
-// CHECK:         [[READER:%[^,]+]] = class_method [[SELF]] : $OverridableReader, #OverridableReader.title!yielding_borrow
+// CHECK:         [[READER:%[^,]+]] = function_ref @$s19coroutine_accessors17OverridableReaderC5titleSSvy
 // CHECK:         ([[TITLE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]]]) = begin_apply [[READER]]([[SELF]])
 // CHECK:         [[RETVAL:%[^,]+]] = copy_value [[TITLE]]
 // CHECK:         end_apply [[TOKEN]] as $()
 // CHECK:         dealloc_stack [[ALLOCATION]]
 // CHECK:         return [[RETVAL]]
 // CHECK-LABEL: } // end sil function '$s19coroutine_accessors17OverridableReaderC5titleSSvg'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s19coroutine_accessors17OverridableReaderCAA13GettableTitleA2aDP5titleSSvgTW : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF_ADDR:%[^,]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[SELF:%[^,]+]] = load_borrow [[SELF_ADDR]]
+// CHECK:         [[GETTER:%[^,]+]] = class_method [[SELF]] : $OverridableReader, #OverridableReader.title!getter
+// CHECK:         [[RETVAL:%[^,]+]] = apply [[GETTER]]([[SELF]])
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         return [[RETVAL]]
+// CHECK-LABEL: } // end sil function '$s19coroutine_accessors17OverridableReaderCAA13GettableTitleA2aDP5titleSSvgTW'
 
 // CHECK-LABEL:      sil_vtable C {
 // CHECK-NEXT:   #C.init!allocator

--- a/test/SILGen/coroutine_accessors.swift
+++ b/test/SILGen/coroutine_accessors.swift
@@ -161,6 +161,24 @@ mutating func update(irm newValue: Int) throws -> Int {
 }
 
 public var i_r_m: Int {
+  _read {
+    yield _i
+  }
+  _modify {
+    yield &_i
+  }
+}
+
+// With the CoroutineAccessors feature enabled, `_read`/`_modify` are just a
+// spelling of the yield_once_2 coroutine accessors, so they use the same ABI as
+// `yielding borrow`/`yielding mutate`: the yield_once_2 accessors are the primary
+// implementation and are emitted first, and (because this module is resilient)
+// the old yield_once accessors are also emitted additively.
+
+// CHECK-LABEL: sil {{.*}} @$s19coroutine_accessors1SV5i_r_mSivy : $@yield_once_2 @convention(method) (@guaranteed S) -> @yields Int {
+
+// CHECK-LABEL: sil {{.*}} @$s19coroutine_accessors1SV5i_r_mSivx : $@yield_once_2 @convention(method) (@inout S) -> @yields @inout Int {
+
 // CHECK-LABEL: sil{{.*}} [ossa] @$s19coroutine_accessors1SV5i_r_mSivr :
 // CHECK-SAME:      $@yield_once
 // CHECK-SAME:      @convention(method)
@@ -170,30 +188,7 @@ public var i_r_m: Int {
 // CHECK-SAME:  {
 // CHECK:       } // end sil function '$s19coroutine_accessors1SV5i_r_mSivr'
 
-  _read {
-    yield _i
-  }
-
-// CHECK-LABEL: sil {{.*}}[ossa] @$s19coroutine_accessors1SV5i_r_mSivM :
-// CHECK-SAME:      $@yield_once
-// CHECK-SAME:      @convention(method)
-// CHECK-SAME:      (@inout S)
-// CHECK-SAME:      ->
-// CHECK-SAME:      @yields @inout Int
-// CHECK-SAME:  {
-// CHECK:       } // end sil function '$s19coroutine_accessors1SV5i_r_mSivM'
-  _modify {
-    yield &_i
-  }
-
-// We want to assume that the new coroutine accessor ABI is available at the
-// time we introduce the feature (such that we can use it with deployment target
-// >= that time).
-// Therefore, make sure we emit yielding borrow/mutate entry points when we
-// encounter _read/_modify.
-
-// CHECK-LABEL: sil {{.*}} @$s19coroutine_accessors1SV5i_r_mSivy : $@yield_once_2 @convention(method) (@guaranteed S) -> @yields Int {
-
+// The synthesized setter forwards to the yield_once_2 modify accessor.
 // CHECK-LABEL: sil {{.*}}[ossa] @$s19coroutine_accessors1SV5i_r_mSivs :
 // CHECK-SAME:      $@convention(method)
 // CHECK-SAME:      (Int, @inout S)
@@ -205,24 +200,25 @@ public var i_r_m: Int {
 // CHECK-SAME:      [[SELF:%[^,]+]] :
 // CHECK-SAME:  ):
 // CHECK:         [[SELF_ACCESS:%[^,]+]] = begin_access [modify] [unknown] [[SELF]]
-// CHECK:         [[MODIFY_ACCESSOR:%[^,]+]] = function_ref @$s19coroutine_accessors1SV5i_r_mSivM
+// CHECK:         [[MODIFY_ACCESSOR:%[^,]+]] = function_ref @$s19coroutine_accessors1SV5i_r_mSivx
 // CHECK:         ([[VALUE_ADDRESS:%[^,]+]],
-// CHECK-SAME:     [[TOKEN:%[^)]+]])
+// CHECK-SAME:     [[TOKEN:%[^,]+]],
+// CHECK-SAME:     [[ALLOCATION:%[^)]+]])
 // CHECK-SAME:    = begin_apply [[MODIFY_ACCESSOR]]([[SELF_ACCESS]])
 // CHECK:         assign [[NEW_VALUE:%[^,]+]] to [[VALUE_ADDRESS]]
 // CHECK:         end_apply [[TOKEN]]
 // CHECK:         end_access [[SELF_ACCESS]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
 // CHECK-LABEL:} // end sil function '$s19coroutine_accessors1SV5i_r_mSivs'
 
-// We want to assume that the new coroutine accessor ABI is available at the
-// time we introduce the feature (such that we can use it with deployment target
-// >= that time).
-// Therefore, make sure we emit yielding borrow/mutate entry points when we
-// encounter _read/_modify.
-
-// CHECK-LABEL: sil {{.*}} @$s19coroutine_accessors1SV5i_r_mSivx : $@yield_once_2 @convention(method) (@inout S) -> @yields @inout Int {
-
-} // public var irm
+// CHECK-LABEL: sil {{.*}}[ossa] @$s19coroutine_accessors1SV5i_r_mSivM :
+// CHECK-SAME:      $@yield_once
+// CHECK-SAME:      @convention(method)
+// CHECK-SAME:      (@inout S)
+// CHECK-SAME:      ->
+// CHECK-SAME:      @yields @inout Int
+// CHECK-SAME:  {
+// CHECK:       } // end sil function '$s19coroutine_accessors1SV5i_r_mSivM'
 
 } // public struct S
 

--- a/test/SILGen/coroutine_accessors.swift
+++ b/test/SILGen/coroutine_accessors.swift
@@ -4,7 +4,7 @@
 // RUN:     -enable-callee-allocated-coro-abi               \
 // RUN:     -enable-library-evolution                       \
 // RUN:     -enable-experimental-feature CoroutineAccessors \
-// RUN: | %FileCheck %s
+// RUN: | %FileCheck %s --check-prefixes=CHECK,CHECK-%target-abi-stability
 
 // RUN: %target-swift-emit-silgen -Xllvm -sil-print-types   \
 // RUN:     %s                                              \
@@ -12,10 +12,15 @@
 // RUN:     -enable-library-evolution                       \
 // RUN:     -enable-experimental-feature CoroutineAccessors \
 // RUN:     -enable-experimental-feature CoroutineAccessorsUnwindOnCallerError \
-// RUN: | %FileCheck %s
+// RUN: | %FileCheck %s --check-prefixes=CHECK,CHECK-%target-abi-stability
 
 // REQUIRES: swift_feature_CoroutineAccessors
 // REQUIRES: swift_feature_CoroutineAccessorsUnwindOnCallerError
+
+// The old yield_once `_read`/`_modify` accessors (Sivr/SivM below) are
+// additively emitted for this resilient module's public storage only on an
+// ABI-stable platform (CHECK-stable); elsewhere there is no prebuilt binary to
+// stay compatible with, so only the new yield_once_2 accessors are emitted.
 
 @frozen
 public struct S {
@@ -45,26 +50,26 @@ public var irm: Int {
   yielding mutate {
     yield &_i
   }
-// CHECK-LABEL: sil{{.*}} [ossa] @$s19coroutine_accessors1SV3irmSivr :
-// CHECK-SAME:      $@yield_once
-// CHECK-SAME:      @convention(method)
-// CHECK-SAME:      (@guaranteed S)
-// CHECK-SAME:      ->
-// CHECK-SAME:      @yields Int
-// CHECK-SAME:  {
-// CHECK:       bb0(
-// CHECK:           [[SELF:%[^,]+]] :
-// CHECK:       ):
-// CHECK:         [[READER2:%[^,]+]] = function_ref @$s19coroutine_accessors1SV3irmSivy
-// CHECK:         ([[VALUE_ADDRESS:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READER2]]([[SELF]])
-// CHECK:         end_apply [[TOKEN]]
-// CHECK:         yield [[VALUE_ADDRESS]] : $Int, resume bb1, unwind bb2
-// CHECK:       bb1:
-// CHECK:         dealloc_stack [[ALLOCATION]] : $*Builtin.SILToken
-// CHECK:       bb2:
-// CHECK:         dealloc_stack [[ALLOCATION]] : $*Builtin.SILToken
-// CHECK:         unwind
-// CHECK-LABEL: } // end sil function '$s19coroutine_accessors1SV3irmSivr'
+// CHECK-stable-LABEL: sil{{.*}} [ossa] @$s19coroutine_accessors1SV3irmSivr :
+// CHECK-stable-SAME:      $@yield_once
+// CHECK-stable-SAME:      @convention(method)
+// CHECK-stable-SAME:      (@guaranteed S)
+// CHECK-stable-SAME:      ->
+// CHECK-stable-SAME:      @yields Int
+// CHECK-stable-SAME:  {
+// CHECK-stable:       bb0(
+// CHECK-stable:           [[SELF:%[^,]+]] :
+// CHECK-stable:       ):
+// CHECK-stable:         [[READER2:%[^,]+]] = function_ref @$s19coroutine_accessors1SV3irmSivy
+// CHECK-stable:         ([[VALUE_ADDRESS:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READER2]]([[SELF]])
+// CHECK-stable:         end_apply [[TOKEN]]
+// CHECK-stable:         yield [[VALUE_ADDRESS]] : $Int, resume bb1, unwind bb2
+// CHECK-stable:       bb1:
+// CHECK-stable:         dealloc_stack [[ALLOCATION]] : $*Builtin.SILToken
+// CHECK-stable:       bb2:
+// CHECK-stable:         dealloc_stack [[ALLOCATION]] : $*Builtin.SILToken
+// CHECK-stable:         unwind
+// CHECK-stable-LABEL: } // end sil function '$s19coroutine_accessors1SV3irmSivr'
 
 // CHECK-LABEL: sil {{.*}}[ossa] @$s19coroutine_accessors1SV3irmSivs :
 // CHECK-SAME:      $@convention(method)
@@ -88,35 +93,35 @@ public var irm: Int {
 // CHECK:         dealloc_stack [[ALLOCATION]]
 // CHECK-LABEL:} // end sil function '$s19coroutine_accessors1SV3irmSivs'
 
-// CHECK-LABEL: sil {{.*}}[ossa] @$s19coroutine_accessors1SV3irmSivM :
-// CHECK-SAME:      $@yield_once
-// CHECK-SAME:      @convention(method)
-// CHECK-SAME:      (@inout S)
-// CHECK-SAME:      ->
-// CHECK-SAME:      @yields @inout Int
-// CHECK-SAME:  {
-// CHECK:       bb0(
-// CHECK-SAME:      [[SELF:%[^,]+]] :
-// CHECK-SAME:  ):
-// CHECK:       [[SELF_ACCESS:%[^,]+]] = begin_access [modify] [unknown] [[SELF]]
-// CHECK:       [[MODIFY_ACCESSOR:%[^,]+]] = function_ref @$s19coroutine_accessors1SV3irmSivx
-// CHECK:       ([[VALUE_ADDRESS:%[^,]+]],
-// CHECK-SAME:   [[TOKEN:%[^,]+]],
-// CHECK-SAME:   [[ALLOCATION:%[^)]+]])
-// CHECK-SAME:  = begin_apply [[MODIFY_ACCESSOR]]([[SELF_ACCESS]])
-// CHECK:       yield [[VALUE_ADDRESS]] 
-// CHECK-SAME:      resume [[RESUME_BB:bb[0-9]+]]
-// CHECK-SAME:      unwind [[UNWIND_BB:bb[0-9]+]]
-// CHECK:     [[RESUME_BB]]:
-// CHECK:       end_apply [[TOKEN]]
-// CHECK:       end_access [[SELF_ACCESS]]
-// CHECK:       dealloc_stack [[ALLOCATION]]
-// CHECK:     [[UNWIND_BB]]:
-// CHECK:       end_apply [[TOKEN]]
-// CHECK:       dealloc_stack [[ALLOCATION]]
-// CHECK:       end_access [[SELF_ACCESS]]
-// CHECK:       unwind
-// CHECK-LABEL: } // end sil function '$s19coroutine_accessors1SV3irmSivM'
+// CHECK-stable-LABEL: sil {{.*}}[ossa] @$s19coroutine_accessors1SV3irmSivM :
+// CHECK-stable-SAME:      $@yield_once
+// CHECK-stable-SAME:      @convention(method)
+// CHECK-stable-SAME:      (@inout S)
+// CHECK-stable-SAME:      ->
+// CHECK-stable-SAME:      @yields @inout Int
+// CHECK-stable-SAME:  {
+// CHECK-stable:       bb0(
+// CHECK-stable-SAME:      [[SELF:%[^,]+]] :
+// CHECK-stable-SAME:  ):
+// CHECK-stable:       [[SELF_ACCESS:%[^,]+]] = begin_access [modify] [unknown] [[SELF]]
+// CHECK-stable:       [[MODIFY_ACCESSOR:%[^,]+]] = function_ref @$s19coroutine_accessors1SV3irmSivx
+// CHECK-stable:       ([[VALUE_ADDRESS:%[^,]+]],
+// CHECK-stable-SAME:   [[TOKEN:%[^,]+]],
+// CHECK-stable-SAME:   [[ALLOCATION:%[^)]+]])
+// CHECK-stable-SAME:  = begin_apply [[MODIFY_ACCESSOR]]([[SELF_ACCESS]])
+// CHECK-stable:       yield [[VALUE_ADDRESS]]
+// CHECK-stable-SAME:      resume [[RESUME_BB:bb[0-9]+]]
+// CHECK-stable-SAME:      unwind [[UNWIND_BB:bb[0-9]+]]
+// CHECK-stable:     [[RESUME_BB]]:
+// CHECK-stable:       end_apply [[TOKEN]]
+// CHECK-stable:       end_access [[SELF_ACCESS]]
+// CHECK-stable:       dealloc_stack [[ALLOCATION]]
+// CHECK-stable:     [[UNWIND_BB]]:
+// CHECK-stable:       end_apply [[TOKEN]]
+// CHECK-stable:       dealloc_stack [[ALLOCATION]]
+// CHECK-stable:       end_access [[SELF_ACCESS]]
+// CHECK-stable:       unwind
+// CHECK-stable-LABEL: } // end sil function '$s19coroutine_accessors1SV3irmSivM'
 } // public var irm
 
 // CHECK-LABEL: sil {{.*}}[ossa] @$s19coroutine_accessors1SV6update3irmS2i_tKF :
@@ -172,21 +177,22 @@ public var i_r_m: Int {
 // With the CoroutineAccessors feature enabled, `_read`/`_modify` are just a
 // spelling of the yield_once_2 coroutine accessors, so they use the same ABI as
 // `yielding borrow`/`yielding mutate`: the yield_once_2 accessors are the primary
-// implementation and are emitted first, and (because this module is resilient)
-// the old yield_once accessors are also emitted additively.
+// implementation and are emitted first, and (because this module is resilient
+// and, for Sivr/SivM, on an ABI-stable platform) the old yield_once accessors
+// are also emitted additively.
 
 // CHECK-LABEL: sil {{.*}} @$s19coroutine_accessors1SV5i_r_mSivy : $@yield_once_2 @convention(method) (@guaranteed S) -> @yields Int {
 
 // CHECK-LABEL: sil {{.*}} @$s19coroutine_accessors1SV5i_r_mSivx : $@yield_once_2 @convention(method) (@inout S) -> @yields @inout Int {
 
-// CHECK-LABEL: sil{{.*}} [ossa] @$s19coroutine_accessors1SV5i_r_mSivr :
-// CHECK-SAME:      $@yield_once
-// CHECK-SAME:      @convention(method)
-// CHECK-SAME:      (@guaranteed S)
-// CHECK-SAME:      ->
-// CHECK-SAME:      @yields Int
-// CHECK-SAME:  {
-// CHECK:       } // end sil function '$s19coroutine_accessors1SV5i_r_mSivr'
+// CHECK-stable-LABEL: sil{{.*}} [ossa] @$s19coroutine_accessors1SV5i_r_mSivr :
+// CHECK-stable-SAME:      $@yield_once
+// CHECK-stable-SAME:      @convention(method)
+// CHECK-stable-SAME:      (@guaranteed S)
+// CHECK-stable-SAME:      ->
+// CHECK-stable-SAME:      @yields Int
+// CHECK-stable-SAME:  {
+// CHECK-stable:       } // end sil function '$s19coroutine_accessors1SV5i_r_mSivr'
 
 // The synthesized setter forwards to the yield_once_2 modify accessor.
 // CHECK-LABEL: sil {{.*}}[ossa] @$s19coroutine_accessors1SV5i_r_mSivs :
@@ -211,14 +217,14 @@ public var i_r_m: Int {
 // CHECK:         dealloc_stack [[ALLOCATION]]
 // CHECK-LABEL:} // end sil function '$s19coroutine_accessors1SV5i_r_mSivs'
 
-// CHECK-LABEL: sil {{.*}}[ossa] @$s19coroutine_accessors1SV5i_r_mSivM :
-// CHECK-SAME:      $@yield_once
-// CHECK-SAME:      @convention(method)
-// CHECK-SAME:      (@inout S)
-// CHECK-SAME:      ->
-// CHECK-SAME:      @yields @inout Int
-// CHECK-SAME:  {
-// CHECK:       } // end sil function '$s19coroutine_accessors1SV5i_r_mSivM'
+// CHECK-stable-LABEL: sil {{.*}}[ossa] @$s19coroutine_accessors1SV5i_r_mSivM :
+// CHECK-stable-SAME:      $@yield_once
+// CHECK-stable-SAME:      @convention(method)
+// CHECK-stable-SAME:      (@inout S)
+// CHECK-stable-SAME:      ->
+// CHECK-stable-SAME:      @yields @inout Int
+// CHECK-stable-SAME:  {
+// CHECK-stable:       } // end sil function '$s19coroutine_accessors1SV5i_r_mSivM'
 
 } // public struct S
 

--- a/test/SILGen/coroutine_accessors_availability.swift
+++ b/test/SILGen/coroutine_accessors_availability.swift
@@ -485,6 +485,7 @@ public class DerivedOldFromBaseClassOld : BaseClassOld {
 
 // CHECK-LABEL: sil_vtable [serialized] DerivedOldFromBaseClassOld {
 // CHECK-NEXT:    #BaseClassOld.init!allocator
+// CHECK-NEXT:    #BaseClassOld.i!getter
 // CHECK-NEXT:    #BaseClassOld.i!read
 // CHECK-NEXT:    #BaseClassOld.i!yielding_borrow
 // CHECK-NEXT:    #BaseClassOld.i!setter

--- a/test/SILGen/coroutine_accessors_availability.swift
+++ b/test/SILGen/coroutine_accessors_availability.swift
@@ -224,6 +224,19 @@ public func modifyOldNoninlinableNew(_ n: inout StructOld) {
 public func takeInt(_ i: Int) {
 }
 
+// A resilient global with coroutine accessors that is available before the
+// feature: it has both the old (yield_once) and new (yield_once_2) ABIs, so
+// which one a cross-module caller uses is decided at the call site.
+public var _gStore: Int = 0
+public var gOld: Int {
+  yielding borrow {
+    yield _gStore
+  }
+  yielding mutate {
+    yield &_gStore
+  }
+}
+
 open class BaseClassOld {
   public init(_ i : Int) {
     self._i = i
@@ -363,6 +376,95 @@ func modifyOldOld() {
   var n = getOld()
 
   n.i.increment()
+}
+
+// Global access, read.  Across a resilience boundary the ABI is chosen by the
+// caller: a caller that may run before the feature is available must use the
+// old ABI; one that cannot must use the new.
+@_silgen_name("readGlobalOld")
+func readGlobalOld() -> Int {
+// CHECK-LABEL: sil {{.*}}@readGlobalOld : {{.*}} {
+// Deployment target predates the feature--must use the old read.
+                  // function_ref gOld.read
+// CHECK-OLD:     function_ref @$s7Library4gOldSivr
+// Deployment target postdates the feature--can use read2.
+                  // function_ref gOld.read2
+// CHECK-NEW:     function_ref @$s7Library4gOldSivy
+// CHECK-LABEL: } // end sil function 'readGlobalOld'
+  return gOld
+}
+
+// Global access, modify.
+@_silgen_name("modifyGlobalOld")
+func modifyGlobalOld() {
+// CHECK-LABEL: sil {{.*}}@modifyGlobalOld : {{.*}} {
+                  // function_ref gOld.modify
+// CHECK-OLD:     function_ref @$s7Library4gOldSivM
+                  // function_ref gOld.modify2
+// CHECK-NEW:     function_ref @$s7Library4gOldSivx
+// CHECK-LABEL: } // end sil function 'modifyGlobalOld'
+  gOld.increment()
+}
+
+// Global access from a context that postdates the feature: the new ABI is used
+// regardless of the deployment target.
+@available(SwiftStdlib 9999, *)
+@_silgen_name("readGlobalNew")
+func readGlobalNew() -> Int {
+// CHECK-LABEL: sil {{.*}}@readGlobalNew : {{.*}} {
+                  // function_ref gOld.read2
+// CHECK:         function_ref @$s7Library4gOldSivy
+// CHECK-LABEL: } // end sil function 'readGlobalNew'
+  return gOld
+}
+
+@available(SwiftStdlib 9999, *)
+@_silgen_name("modifyGlobalNew")
+func modifyGlobalNew() {
+// CHECK-LABEL: sil {{.*}}@modifyGlobalNew : {{.*}} {
+                  // function_ref gOld.modify2
+// CHECK:         function_ref @$s7Library4gOldSivx
+// CHECK-LABEL: } // end sil function 'modifyGlobalNew'
+  gOld.increment()
+}
+
+// Class instance property, read.  Dispatched dynamically through the vtable,
+// which carries both ABIs' slots; the caller selects the slot the same way.
+@_silgen_name("readClassOld")
+func readClassOld(_ c: BaseClassOld) -> Int {
+// CHECK-LABEL: sil {{.*}}@readClassOld : {{.*}} {
+// CHECK-OLD:     class_method {{.*}}, #BaseClassOld.i!read
+// CHECK-NEW:     class_method {{.*}}, #BaseClassOld.i!yielding_borrow
+// CHECK-LABEL: } // end sil function 'readClassOld'
+  return c.i
+}
+
+// Class instance property, modify.
+@_silgen_name("modifyClassOld")
+func modifyClassOld(_ c: BaseClassOld) {
+// CHECK-LABEL: sil {{.*}}@modifyClassOld : {{.*}} {
+// CHECK-OLD:     class_method {{.*}}, #BaseClassOld.i!modify
+// CHECK-NEW:     class_method {{.*}}, #BaseClassOld.i!yielding_mutate
+// CHECK-LABEL: } // end sil function 'modifyClassOld'
+  c.i.increment()
+}
+
+@available(SwiftStdlib 9999, *)
+@_silgen_name("readClassNew")
+func readClassNew(_ c: BaseClassOld) -> Int {
+// CHECK-LABEL: sil {{.*}}@readClassNew : {{.*}} {
+// CHECK:         class_method {{.*}}, #BaseClassOld.i!yielding_borrow
+// CHECK-LABEL: } // end sil function 'readClassNew'
+  return c.i
+}
+
+@available(SwiftStdlib 9999, *)
+@_silgen_name("modifyClassNew")
+func modifyClassNew(_ c: BaseClassOld) {
+// CHECK-LABEL: sil {{.*}}@modifyClassNew : {{.*}} {
+// CHECK:         class_method {{.*}}, #BaseClassOld.i!yielding_mutate
+// CHECK-LABEL: } // end sil function 'modifyClassNew'
+  c.i.increment()
 }
 
 public class DerivedOldFromBaseClassOld : BaseClassOld {

--- a/test/SILGen/coroutine_accessors_back_deployment_abi.swift
+++ b/test/SILGen/coroutine_accessors_back_deployment_abi.swift
@@ -19,6 +19,12 @@
 
 // REQUIRES: swift_feature_CoroutineAccessors
 
+// This test asserts that the old ABI is additively emitted for resilient
+// public storage, which only holds on an ABI-stable platform (elsewhere there
+// is no prebuilt binary to stay compatible with, so only the new ABI is
+// emitted).
+// REQUIRES: swift_stable_abi
+
 // UNSUPPORTED: OS=windows-msvc
 // UNSUPPORTED: OS=freebsd
 

--- a/test/SILGen/coroutine_accessors_deserialized_read.swift
+++ b/test/SILGen/coroutine_accessors_deserialized_read.swift
@@ -1,0 +1,61 @@
+// A '_read' accessor read from a .swiftinterface (or any deserialized/SIL input)
+// is NOT remapped to 'yielding borrow' -- it stays a genuine 'Read' accessor.
+// This checks that such an accessor flows correctly through
+// OpaqueReadOwnershipRequest in a feature-ON consumer: it takes the 'Owned'
+// default (so a getter is available) and the read still resolves to the 'read'
+// (yield_once) coroutine the producer exported.
+//
+// The interface is a literal fixture rather than one generated from source: a
+// plain, unguarded '_read' is what a *pre-feature* module shipped, and once
+// CoroutineAccessors is enabled by default it can no longer be produced from
+// source (feature-on printing guards it under '#if $CoroutineAccessors' and a
+// consumer would pick the 'yielding borrow' branch).  Embedding the interface
+// keeps the 'Read'-provenance path tested after the feature is on by default.
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// Build a binary module from the literal interface (feature ON, mirroring the
+// post-switch world), so the '_read' is deserialized and stays a 'Read'
+// accessor.
+// RUN: %target-swift-frontend                                \
+// RUN:     -compile-module-from-interface                    \
+// RUN:     %t/LibOld.swiftinterface                          \
+// RUN:     -o %t/LibOld.swiftmodule                          \
+// RUN:     -module-name LibOld                               \
+// RUN:     -enable-experimental-feature CoroutineAccessors
+
+// A feature-ON client reading the deserialized '_read' property resolves to the
+// 'read' coroutine the producer exported (Sivr, not the remapped Sivy).
+// RUN: %target-swift-emit-silgen                             \
+// RUN:     %t/Client.swift                                   \
+// RUN:     -I %t                                             \
+// RUN:     -module-name Client                               \
+// RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:   | %FileCheck %t/Client.swift
+
+// REQUIRES: swift_feature_CoroutineAccessors
+
+//--- LibOld.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -enable-library-evolution -swift-version 5 -module-name LibOld
+import Swift
+public struct S {
+  public init()
+  public var x: Swift.Int {
+    _read
+  }
+}
+
+//--- Client.swift
+
+import LibOld
+
+@_silgen_name("readX")
+func readX(_ s: S) -> Int {
+// CHECK-LABEL: sil {{.*}}@readX : {{.*}} {
+                  // function_ref S.x.read
+// CHECK:         function_ref @$s6LibOld1SV1xSivr : $@yield_once
+// CHECK-LABEL: } // end sil function 'readX'
+  return s.x
+}

--- a/test/SILGen/coroutine_accessors_deserialized_read.swift
+++ b/test/SILGen/coroutine_accessors_deserialized_read.swift
@@ -35,6 +35,9 @@
 // RUN:   | %FileCheck %t/Client.swift
 
 // REQUIRES: swift_feature_CoroutineAccessors
+// The old-ABI-provenance guarantee this test checks only applies on
+// ABI-stable platforms; non-ABI-stable platforms always call the new ABI.
+// REQUIRES: swift_stable_abi
 
 //--- LibOld.swiftinterface
 // swift-interface-format-version: 1.0

--- a/test/SILGen/coroutine_accessors_emission_matrix.swift
+++ b/test/SILGen/coroutine_accessors_emission_matrix.swift
@@ -1,0 +1,76 @@
+// Emission matrix for coroutine accessors under the CoroutineAccessors feature.
+//
+// Every coroutine accessor emits the new yield_once_2 ABI (vy/vx).  The old
+// yield_once ABI (vr/vM) is additionally emitted iff the storage is visible
+// outside its module (public or package) AND resilient AND available before the
+// feature's availability (SwiftStdlib 9999).  Otherwise only the new ABI is
+// emitted.  This test pins every cell of {public, package, internal} x
+// {resilient, fragile} x {before-feature, at-feature}.
+
+// Resilient: public/package before-feature get old+new; everything else new-only.
+// RUN: %target-swift-emit-silgen %s                          \
+// RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -enable-library-evolution -module-name m -package-name pkg \
+// RUN:   | %FileCheck %s --check-prefix=RESILIENT
+// RUN: %target-swift-emit-silgen %s                          \
+// RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -enable-library-evolution -module-name m -package-name pkg \
+// RUN:   | %FileCheck %s --check-prefix=RES-NEW-ONLY
+
+// Fragile: no stable ABI to preserve, so everything is new-only.
+// RUN: %target-swift-emit-silgen %s                          \
+// RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -module-name m -package-name pkg                  \
+// RUN:   | %FileCheck %s --check-prefix=FRAGILE
+// RUN: %target-swift-emit-silgen %s                          \
+// RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -module-name m -package-name pkg                  \
+// RUN:   | %FileCheck %s --check-prefix=FRAG-NEW-ONLY
+
+// REQUIRES: swift_feature_CoroutineAccessors
+
+public struct S {
+  var _s = 0
+  public var pub: Int { _read { yield _s } _modify { yield &_s } }
+  package var pkg: Int { _read { yield _s } _modify { yield &_s } }
+  internal var int_: Int { _read { yield _s } _modify { yield &_s } }
+}
+
+@available(SwiftStdlib 9999, *)
+public struct S9999 {
+  var _s = 0
+  public var pubNew: Int { _read { yield _s } _modify { yield &_s } }
+  package var pkgNew: Int { _read { yield _s } _modify { yield &_s } }
+}
+
+// The new yield_once_2 accessors are always emitted, in every cell.
+// RESILIENT-DAG: sil{{.*}} @$s1m1SV3pubSivy : $@yield_once_2 @convention
+// RESILIENT-DAG: sil{{.*}} @$s1m1SV3pubSivx : $@yield_once_2 @convention
+// RESILIENT-DAG: sil{{.*}} @$s1m1SV3pkgSivy : $@yield_once_2 @convention
+// RESILIENT-DAG: sil{{.*}} @$s1m1SV3pkgSivx : $@yield_once_2 @convention
+// RESILIENT-DAG: sil{{.*}} @$s1m1SV4int_Sivy : $@yield_once_2 @convention
+// RESILIENT-DAG: sil{{.*}} @$s1m1SV4int_Sivx : $@yield_once_2 @convention
+// RESILIENT-DAG: sil{{.*}} @$s1m5S9999V6pubNewSivy : $@yield_once_2 @convention
+// RESILIENT-DAG: sil{{.*}} @$s1m5S9999V6pkgNewSivy : $@yield_once_2 @convention
+
+// Old yield_once ABI: only public and package, before-feature (pub, pkg).
+// RESILIENT-DAG: sil{{.*}} @$s1m1SV3pubSivr : $@yield_once @convention
+// RESILIENT-DAG: sil{{.*}} @$s1m1SV3pubSivM : $@yield_once @convention
+// RESILIENT-DAG: sil{{.*}} @$s1m1SV3pkgSivr : $@yield_once @convention
+// RESILIENT-DAG: sil{{.*}} @$s1m1SV3pkgSivM : $@yield_once @convention
+
+// ...and NOT for internal, nor for the at-feature (@available 9999) types.
+// RES-NEW-ONLY-NOT: @$s1m1SV4int_Sivr
+// RES-NEW-ONLY-NOT: @$s1m1SV4int_SivM
+// RES-NEW-ONLY-NOT: @$s1m5S9999V6pubNewSivr
+// RES-NEW-ONLY-NOT: @$s1m5S9999V6pubNewSivM
+// RES-NEW-ONLY-NOT: @$s1m5S9999V6pkgNewSivr
+// RES-NEW-ONLY-NOT: @$s1m5S9999V6pkgNewSivM
+
+// Fragile: new ABI present everywhere...
+// FRAGILE-DAG: sil{{.*}} @$s1m1SV3pubSivy : $@yield_once_2 @convention
+// FRAGILE-DAG: sil{{.*}} @$s1m1SV3pkgSivy : $@yield_once_2 @convention
+// FRAGILE-DAG: sil{{.*}} @$s1m5S9999V6pubNewSivy : $@yield_once_2 @convention
+
+// ...and no old ABI anywhere, regardless of visibility or availability.
+// FRAG-NEW-ONLY-NOT: $@yield_once @convention

--- a/test/SILGen/coroutine_accessors_emission_matrix.swift
+++ b/test/SILGen/coroutine_accessors_emission_matrix.swift
@@ -1,11 +1,14 @@
 // Emission matrix for coroutine accessors under the CoroutineAccessors feature.
 //
-// Every coroutine accessor emits the new yield_once_2 ABI (vy/vx).  The old
-// yield_once ABI (vr/vM) is additionally emitted iff the storage is visible
-// outside its module (public or package) AND resilient AND available before the
-// feature's availability (SwiftStdlib 9999).  Otherwise only the new ABI is
-// emitted.  This test pins every cell of {public, package, internal} x
-// {resilient, fragile} x {before-feature, at-feature}.
+// Every coroutine accessor emits the new yield_once_2 ABI (vy/vx).  On an
+// ABI-stable platform, the old yield_once ABI (vr/vM) is additionally emitted
+// iff the storage is visible outside its module (public or package) AND
+// resilient AND available before the feature's availability.  Otherwise only
+// the new ABI is emitted.  This test exercises every combination of {public,
+// package, internal} x {resilient, fragile} x {before-feature, at-feature}.
+// (On a non-ABI-stable platform there is never an old binary to stay compatible
+// with, so only the new ABI is ever emitted -- hence this requires an
+// ABI-stable platform.)
 
 // Resilient: public/package before-feature get old+new; everything else new-only.
 // RUN: %target-swift-emit-silgen %s                          \
@@ -28,6 +31,7 @@
 // RUN:   | %FileCheck %s --check-prefix=FRAG-NEW-ONLY
 
 // REQUIRES: swift_feature_CoroutineAccessors
+// REQUIRES: swift_stable_abi
 
 public struct S {
   var _s = 0
@@ -36,6 +40,8 @@ public struct S {
   internal var int_: Int { _read { yield _s } _modify { yield &_s } }
 }
 
+// SwiftStdlib 9999 availability is guaranteed to be later than the actual
+// permanent availability of the new yielding accessor ABI.
 @available(SwiftStdlib 9999, *)
 public struct S9999 {
   var _s = 0

--- a/test/SILGen/coroutine_accessors_getter_synthesis.swift
+++ b/test/SILGen/coroutine_accessors_getter_synthesis.swift
@@ -7,11 +7,13 @@
 
 // RUN: %target-swift-emit-silgen %s                          \
 // RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -enable-callee-allocated-coro-abi                 \
 // RUN:     -module-name m                                    \
 // RUN:   | %FileCheck %s --check-prefix=GETTER
 
 // RUN: %target-swift-emit-silgen %s                          \
 // RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -enable-callee-allocated-coro-abi                 \
 // RUN:     -enable-library-evolution                         \
 // RUN:     -module-name m                                    \
 // RUN:   | %FileCheck %s --check-prefix=GETTER

--- a/test/SILGen/coroutine_accessors_getter_synthesis.swift
+++ b/test/SILGen/coroutine_accessors_getter_synthesis.swift
@@ -1,0 +1,110 @@
+// Verifies getter synthesis for coroutine-accessor storage: a concrete copyable
+// 'yielding borrow'/'_read' property synthesizes an owned getter (matching the
+// getter that a copyable '_read' has shipped since before the feature), the
+// getter delegates to the coroutine (running its full body), and NO getter is
+// synthesized where one would be invalid (a noncopyable value) or where it must
+// stay absent (a protocol requirement, which stays symmetric with '@_borrowed').
+
+// RUN: %target-swift-emit-silgen %s                          \
+// RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -module-name m                                    \
+// RUN:   | %FileCheck %s --check-prefix=GETTER
+
+// RUN: %target-swift-emit-silgen %s                          \
+// RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -enable-library-evolution                         \
+// RUN:     -module-name m                                    \
+// RUN:   | %FileCheck %s --check-prefix=GETTER
+
+// The getter-delegation and absence checks each get their own FileCheck
+// invocation so a lone CHECK-LABEL / CHECK-NOT scans the whole input.
+// RUN: %target-swift-emit-silgen %s                          \
+// RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -module-name m                                    \
+// RUN:   | %FileCheck %s --check-prefix=DELEGATES
+
+// RUN: %target-swift-emit-silgen %s                          \
+// RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -module-name m                                    \
+// RUN:   | %FileCheck %s --check-prefix=NO-GETTER
+
+// RUN: %target-swift-emit-silgen %s                          \
+// RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -enable-library-evolution                         \
+// RUN:     -module-name m                                    \
+// RUN:   | %FileCheck %s --check-prefix=NO-GETTER
+
+// REQUIRES: swift_feature_CoroutineAccessors
+
+// A concrete copyable 'yielding borrow' property synthesizes an owned getter, in
+// addition to its coroutine, in both resilience modes.
+public struct StructYB {
+  var _s = 0
+  public var i: Int {
+    yielding borrow { yield _s }
+    yielding mutate { yield &_s }
+  }
+}
+// GETTER-DAG: sil{{.*}} @$s1m8StructYBV1iSivg :
+// GETTER-DAG: sil{{.*}} @$s1m8StructYBV1iSivy : $@yield_once_2
+
+open class ClassYB {
+  var _s = 0
+  open var i: Int {
+    yielding borrow { yield _s }
+    yielding mutate { yield &_s }
+  }
+}
+// GETTER-DAG: sil{{.*}} @$s1m7ClassYBC1iSivg :
+// GETTER-DAG: sil{{.*}} @$s1m7ClassYBC1iSivy : $@yield_once_2
+
+var _g = 0
+public var globalYB: Int {
+  yielding borrow { yield _g }
+  yielding mutate { yield &_g }
+}
+// GETTER-DAG: sil{{.*}} @$s1m8globalYBSivg :
+// GETTER-DAG: sil{{.*}} @$s1m8globalYBSivy : $@yield_once_2
+
+// Spelling invariance: the '_read'/'_modify' spelling produces the same getter
+// (the feature remaps it to 'yielding borrow'/'yielding mutate').
+public struct StructRM {
+  var _s = 0
+  public var i: Int {
+    _read { yield _s }
+    _modify { yield &_s }
+  }
+}
+// GETTER-DAG: sil{{.*}} @$s1m8StructRMV1iSivg :
+// GETTER-DAG: sil{{.*}} @$s1m8StructRMV1iSivy : $@yield_once_2
+
+// The synthesized getter delegates to the coroutine, running its full body: the
+// front half up to the yield (begin_apply) and the back half (end_apply).
+// DELEGATES-LABEL: sil{{.*}} @$s1m8StructYBV1iSivg :
+// DELEGATES:         [[CORO:%[^ ]+]] = function_ref @$s1m8StructYBV1iSivy
+// DELEGATES:         ({{.*}}) = begin_apply [[CORO]](
+// DELEGATES:         end_apply
+// DELEGATES-LABEL: } // end sil function '$s1m8StructYBV1iSivg'
+
+// A 'yielding borrow' of a noncopyable value cannot produce an owned copy, so NO
+// getter is synthesized -- only the coroutine(s).
+public struct NCVal: ~Copyable {}
+public struct NCHolder: ~Copyable {
+  var _n = NCVal()
+  public var n: NCVal {
+    yielding borrow { yield _n }
+  }
+}
+// NO-GETTER-NOT: @$s1m8NCHolderV1nAA5NCValVvg
+
+// A protocol requirement stays a borrowing opaque read (no getter requirement),
+// so the '@_borrowed' and 'yielding borrow' spellings keep the same witness
+// layout.  Neither gets a getter requirement.
+public protocol ProtoYB {
+  var i: Int { yielding borrow set }
+}
+public protocol ProtoB {
+  @_borrowed var i: Int { get set }
+}
+// NO-GETTER-NOT: #ProtoYB.i!getter
+// NO-GETTER-NOT: #ProtoB.i!getter

--- a/test/SILGen/coroutine_accessors_lifetime_dependent_getter.swift
+++ b/test/SILGen/coroutine_accessors_lifetime_dependent_getter.swift
@@ -7,12 +7,14 @@
 // RUN: %target-swift-emit-silgen %s                          \
 // RUN:     -enable-experimental-feature CoroutineAccessors   \
 // RUN:     -enable-experimental-feature Lifetimes            \
+// RUN:     -enable-callee-allocated-coro-abi                 \
 // RUN:     -module-name m                                    \
 // RUN:   | %FileCheck %s
 
 // RUN: %target-swift-emit-silgen %s                          \
 // RUN:     -enable-experimental-feature CoroutineAccessors   \
 // RUN:     -enable-experimental-feature Lifetimes            \
+// RUN:     -enable-callee-allocated-coro-abi                 \
 // RUN:     -enable-library-evolution                         \
 // RUN:     -module-name m                                    \
 // RUN:   | %FileCheck %s

--- a/test/SILGen/coroutine_accessors_lifetime_dependent_getter.swift
+++ b/test/SILGen/coroutine_accessors_lifetime_dependent_getter.swift
@@ -1,0 +1,53 @@
+// A 'yielding borrow' whose yielded value has a scoped (borrow) lifetime
+// dependence borrows its source, so -- like a noncopyable value -- it does NOT
+// synthesize an owned getter, even though the value type is copyable.  (Without
+// the scoped-lifetime check this would fall through to the copyable-getter case
+// and synthesize an invalid getter that returns a borrowed value as owned.)
+
+// RUN: %target-swift-emit-silgen %s                          \
+// RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -enable-experimental-feature Lifetimes            \
+// RUN:     -module-name m                                    \
+// RUN:   | %FileCheck %s
+
+// RUN: %target-swift-emit-silgen %s                          \
+// RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -enable-experimental-feature Lifetimes            \
+// RUN:     -enable-library-evolution                         \
+// RUN:     -module-name m                                    \
+// RUN:   | %FileCheck %s
+
+// A lone CHECK-NOT (own invocation) scans the whole input for the absent getter.
+// RUN: %target-swift-emit-silgen %s                          \
+// RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -enable-experimental-feature Lifetimes            \
+// RUN:     -module-name m                                    \
+// RUN:   | %FileCheck %s --check-prefix=NO-GETTER
+
+// RUN: %target-swift-emit-silgen %s                          \
+// RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -enable-experimental-feature Lifetimes            \
+// RUN:     -enable-library-evolution                         \
+// RUN:     -module-name m                                    \
+// RUN:   | %FileCheck %s --check-prefix=NO-GETTER
+
+// REQUIRES: swift_feature_CoroutineAccessors
+// REQUIRES: swift_feature_Lifetimes
+
+public struct NE: ~Escapable {
+  @_lifetime(immortal) public init() {}
+}
+
+public struct Wrapper: ~Escapable {
+  var _ne: NE
+  @_lifetime(copy ne) public init(ne: NE) { self._ne = ne }
+  public var ne: NE {
+    @_lifetime(borrow self)
+    yielding borrow { yield _ne }
+  }
+}
+
+// The yielding_borrow coroutine is emitted, but no getter (a scoped-borrow
+// dependence cannot be handed back as an owned value).
+// CHECK-DAG: sil{{.*}} @$s1m7WrapperV2neAA2NEVvy : $@yield_once_2
+// NO-GETTER-NOT: @$s1m7WrapperV2neAA2NEVvg

--- a/test/SILGen/coroutine_accessors_non_resilient_abi.swift
+++ b/test/SILGen/coroutine_accessors_non_resilient_abi.swift
@@ -1,0 +1,45 @@
+// When the CoroutineAccessors feature is enabled, the old (yield_once_1)
+// `_read`/`_modify` coroutine accessors are emitted *only* to preserve a stable
+// ABI. A module that is not built with library evolution has no stable ABI to
+// keep, so only the new callee-allocated (yield_once_2) accessors are emitted.
+// Under library evolution both the old and new accessors are emitted.
+
+// Non-resilient: the new yield_once_2 accessors are present...
+// RUN: %target-swift-emit-silgen %s                          \
+// RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -module-name main                                 \
+// RUN:   | %FileCheck %s --check-prefix=FRAGILE
+
+// ...and the old yield_once accessors are absent (separate invocation so the
+// CHECK-NOT scans the whole input regardless of accessor emission order).
+// RUN: %target-swift-emit-silgen %s                          \
+// RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -module-name main                                 \
+// RUN:   | %FileCheck %s --check-prefix=NOOLD
+
+// Resilient: both the old and new accessors are present.
+// RUN: %target-swift-emit-silgen %s                          \
+// RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -enable-library-evolution                         \
+// RUN:     -module-name main                                 \
+// RUN:   | %FileCheck %s --check-prefix=RESILIENT
+
+// REQUIRES: swift_feature_CoroutineAccessors
+
+public struct S {
+  var _i: Int = 0
+  public var i: Int {
+    yielding borrow { yield _i }
+    yielding mutate { yield &_i }
+  }
+}
+
+// FRAGILE-DAG: sil {{.*}}Sivy : $@yield_once_2 @convention
+// FRAGILE-DAG: sil {{.*}}Sivx : $@yield_once_2 @convention
+
+// NOOLD-NOT: @yield_once @convention
+
+// RESILIENT-DAG: sil {{.*}}Sivr : $@yield_once @convention
+// RESILIENT-DAG: sil {{.*}}Sivy : $@yield_once_2 @convention
+// RESILIENT-DAG: sil {{.*}}SivM : $@yield_once @convention
+// RESILIENT-DAG: sil {{.*}}Sivx : $@yield_once_2 @convention

--- a/test/SILGen/coroutine_accessors_non_resilient_abi.swift
+++ b/test/SILGen/coroutine_accessors_non_resilient_abi.swift
@@ -15,8 +15,12 @@
 
 // ...and the old yield_once accessors are absent (separate invocation so the
 // CHECK-NOT scans the whole input regardless of accessor emission order).
+// The new accessors' own convention is pinned explicitly: the NOT check below
+// distinguishes old from new by the literal absence of "_2", so it needs the
+// new accessors to actually use the yield_once_2 convention here too.
 // RUN: %target-swift-emit-silgen %s                          \
 // RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -enable-callee-allocated-coro-abi                 \
 // RUN:     -module-name main                                 \
 // RUN:   | %FileCheck %s --check-prefix=NOOLD
 
@@ -31,9 +35,10 @@
 
 // On a non-ABI-stable platform, confirm the old accessors are still absent even
 // under library evolution (separate invocation, as above, so a lone CHECK-NOT
-// scans the whole input).
+// scans the whole input; same reason for pinning the convention explicitly).
 // RUN: %target-swift-emit-silgen %s                          \
 // RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -enable-callee-allocated-coro-abi                 \
 // RUN:     -enable-library-evolution                         \
 // RUN:     -module-name main                                 \
 // RUN:   | %FileCheck %s --check-prefix=NOOLD-RESILIENT-%target-abi-stability

--- a/test/SILGen/coroutine_accessors_non_resilient_abi.swift
+++ b/test/SILGen/coroutine_accessors_non_resilient_abi.swift
@@ -2,11 +2,14 @@
 // `_read`/`_modify` coroutine accessors are emitted *only* to preserve a stable
 // ABI. A module that is not built with library evolution has no stable ABI to
 // keep, so only the new callee-allocated (yield_once_2) accessors are emitted.
-// Under library evolution both the old and new accessors are emitted.
+// Under library evolution, an ABI-stable platform additionally emits the old
+// accessors; a non-ABI-stable platform has no prebuilt binary to stay
+// compatible with, so it still emits only the new accessors.
 
 // Non-resilient: the new yield_once_2 accessors are present...
 // RUN: %target-swift-emit-silgen %s                          \
 // RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -enable-callee-allocated-coro-abi                 \
 // RUN:     -module-name main                                 \
 // RUN:   | %FileCheck %s --check-prefix=FRAGILE
 
@@ -17,12 +20,23 @@
 // RUN:     -module-name main                                 \
 // RUN:   | %FileCheck %s --check-prefix=NOOLD
 
-// Resilient: both the old and new accessors are present.
+// Resilient: the new accessors are always present; the old accessors are
+// additionally present only on an ABI-stable platform.
+// RUN: %target-swift-emit-silgen %s                          \
+// RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -enable-callee-allocated-coro-abi                 \
+// RUN:     -enable-library-evolution                         \
+// RUN:     -module-name main                                 \
+// RUN:   | %FileCheck %s --check-prefixes=RESILIENT,RESILIENT-%target-abi-stability
+
+// On a non-ABI-stable platform, confirm the old accessors are still absent even
+// under library evolution (separate invocation, as above, so a lone CHECK-NOT
+// scans the whole input).
 // RUN: %target-swift-emit-silgen %s                          \
 // RUN:     -enable-experimental-feature CoroutineAccessors   \
 // RUN:     -enable-library-evolution                         \
 // RUN:     -module-name main                                 \
-// RUN:   | %FileCheck %s --check-prefix=RESILIENT
+// RUN:   | %FileCheck %s --check-prefix=NOOLD-RESILIENT-%target-abi-stability
 
 // REQUIRES: swift_feature_CoroutineAccessors
 
@@ -39,7 +53,15 @@ public struct S {
 
 // NOOLD-NOT: @yield_once @convention
 
-// RESILIENT-DAG: sil {{.*}}Sivr : $@yield_once @convention
 // RESILIENT-DAG: sil {{.*}}Sivy : $@yield_once_2 @convention
-// RESILIENT-DAG: sil {{.*}}SivM : $@yield_once @convention
 // RESILIENT-DAG: sil {{.*}}Sivx : $@yield_once_2 @convention
+// RESILIENT-stable-DAG: sil {{.*}}Sivr : $@yield_once @convention
+// RESILIENT-stable-DAG: sil {{.*}}SivM : $@yield_once @convention
+
+// NOOLD-RESILIENT-unstable-NOT: @yield_once @convention
+
+// On an ABI-stable platform this invocation has nothing new to verify (the
+// other RESILIENT invocation above already confirms both ABIs there); just
+// give the "stable" prefix a trivial match so FileCheck doesn't reject an
+// entirely-unmatched --check-prefix.
+// NOOLD-RESILIENT-stable-DAG: sil {{.*}}Sivy : $@yield_once_2 @convention

--- a/test/SILGen/coroutine_accessors_protocol_availability.swift
+++ b/test/SILGen/coroutine_accessors_protocol_availability.swift
@@ -1,0 +1,178 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// Build the resilient protocol library.
+// RUN: %target-swift-frontend                              \
+// RUN:     %t/Library.swift                                \
+// RUN:     -emit-module                                    \
+// RUN:     -enable-library-evolution                       \
+// RUN:     -module-name Library                            \
+// RUN:     -enable-experimental-feature CoroutineAccessors \
+// RUN:     -emit-module-path %t/Library.swiftmodule
+
+// A client that may run before the feature (an old deployment target) binds the
+// old (yield_once) witness slots; a client that cannot (a future deployment
+// target) binds the new (yield_once_2) slots.
+// RUN: %target-swift-emit-silgen                           \
+// RUN:     %t/Client.swift                                 \
+// RUN:     -target %target-swift-5.9-abi-triple            \
+// RUN:     -module-name Client                             \
+// RUN:     -enable-experimental-feature CoroutineAccessors \
+// RUN:     -I %t                                           \
+// RUN: | %FileCheck %t/Client.swift --check-prefixes=CHECK,CHECK-OLD
+
+// RUN: %target-swift-emit-silgen                           \
+// RUN:     %t/Client.swift                                 \
+// TODO: CoroutineAccessors: Change to %target-swift-x.y-abi-triple
+// RUN:     -target %target-future-triple                   \
+// RUN:     -module-name Client                             \
+// RUN:     -enable-experimental-feature CoroutineAccessors \
+// RUN:     -I %t                                           \
+// RUN: | %FileCheck %t/Client.swift --check-prefixes=CHECK,CHECK-NEW
+
+// REQUIRES: swift_stable_abi
+// REQUIRES: swift_feature_CoroutineAccessors
+
+//--- Library.swift
+
+// A resilient protocol whose property requirement is available before the
+// feature.  Because the requirement predates the feature, its witness table
+// carries both the old (read/modify) and the new
+// (yielding_borrow/yielding_mutate) accessor slots.
+public protocol ProtocolOld {
+  @_borrowed var value: Int { get set }
+  @_borrowed subscript(i: Int) -> Int { get set }
+}
+
+//--- Client.swift
+
+import Library
+
+// A conforming type provides witnesses for every required slot.  The
+// conformance's witness table is additive: it lists both ABIs' slots
+// regardless of the deployment target it is compiled for.
+struct SOld: ProtocolOld {
+  var _value: Int = 0
+  var value: Int {
+    yielding borrow {
+      yield _value
+    }
+    yielding mutate {
+      yield &_value
+    }
+  }
+  subscript(i: Int) -> Int {
+    yielding borrow {
+      yield _value
+    }
+    yielding mutate {
+      yield &_value
+    }
+  }
+}
+
+// Generic dispatch, read.  The witness slot the caller binds is chosen the same
+// way as a direct access: by the caller's availability, falling back to its
+// deployment target.
+@_silgen_name("readGenericOld")
+func readGenericOld<T: ProtocolOld>(_ x: T) -> Int {
+// CHECK-LABEL: sil {{.*}}@readGenericOld : {{.*}} {
+// CHECK-OLD:     witness_method {{.*}}#ProtocolOld.value!read
+// CHECK-NEW:     witness_method {{.*}}#ProtocolOld.value!yielding_borrow
+// CHECK-LABEL: } // end sil function 'readGenericOld'
+  return x.value
+}
+
+// Generic dispatch, modify.
+@_silgen_name("modifyGenericOld")
+func modifyGenericOld<T: ProtocolOld>(_ x: inout T) {
+// CHECK-LABEL: sil {{.*}}@modifyGenericOld : {{.*}} {
+// CHECK-OLD:     witness_method {{.*}}#ProtocolOld.value!modify
+// CHECK-NEW:     witness_method {{.*}}#ProtocolOld.value!yielding_mutate
+// CHECK-LABEL: } // end sil function 'modifyGenericOld'
+  x.value += 1
+}
+
+// Existential dispatch, read.
+@_silgen_name("readExistentialOld")
+func readExistentialOld(_ x: any ProtocolOld) -> Int {
+// CHECK-LABEL: sil {{.*}}@readExistentialOld : {{.*}} {
+// CHECK-OLD:     witness_method {{.*}}#ProtocolOld.value!read
+// CHECK-NEW:     witness_method {{.*}}#ProtocolOld.value!yielding_borrow
+// CHECK-LABEL: } // end sil function 'readExistentialOld'
+  return x.value
+}
+
+// Existential dispatch, modify.
+@_silgen_name("modifyExistentialOld")
+func modifyExistentialOld(_ x: inout any ProtocolOld) {
+// CHECK-LABEL: sil {{.*}}@modifyExistentialOld : {{.*}} {
+// CHECK-OLD:     witness_method {{.*}}#ProtocolOld.value!modify
+// CHECK-NEW:     witness_method {{.*}}#ProtocolOld.value!yielding_mutate
+// CHECK-LABEL: } // end sil function 'modifyExistentialOld'
+  x.value += 1
+}
+
+// A caller in a context that postdates the feature uses the new ABI even at an
+// old deployment target.  Unlike the deployment-target fallback used for
+// references with no source location, a member access through a protocol
+// carries its reference location, so it is refined by the caller's own
+// availability.
+@available(SwiftStdlib 9999, *)
+@_silgen_name("readGenericNew")
+func readGenericNew<T: ProtocolOld>(_ x: T) -> Int {
+// CHECK-LABEL: sil {{.*}}@readGenericNew : {{.*}} {
+// CHECK:         witness_method {{.*}}#ProtocolOld.value!yielding_borrow
+// CHECK-LABEL: } // end sil function 'readGenericNew'
+  return x.value
+}
+
+@available(SwiftStdlib 9999, *)
+@_silgen_name("modifyExistentialNew")
+func modifyExistentialNew(_ x: inout any ProtocolOld) {
+// CHECK-LABEL: sil {{.*}}@modifyExistentialNew : {{.*}} {
+// CHECK:         witness_method {{.*}}#ProtocolOld.value!yielding_mutate
+// CHECK-LABEL: } // end sil function 'modifyExistentialNew'
+  x.value += 1
+}
+
+// Subscript requirements dispatch through the witness table the same way.
+@_silgen_name("readSubscriptOld")
+func readSubscriptOld<T: ProtocolOld>(_ x: T) -> Int {
+// CHECK-LABEL: sil {{.*}}@readSubscriptOld : {{.*}} {
+// CHECK-OLD:     witness_method {{.*}}#ProtocolOld.subscript!read
+// CHECK-NEW:     witness_method {{.*}}#ProtocolOld.subscript!yielding_borrow
+// CHECK-LABEL: } // end sil function 'readSubscriptOld'
+  return x[0]
+}
+
+@_silgen_name("modifySubscriptOld")
+func modifySubscriptOld(_ x: inout any ProtocolOld) {
+// CHECK-LABEL: sil {{.*}}@modifySubscriptOld : {{.*}} {
+// CHECK-OLD:     witness_method {{.*}}#ProtocolOld.subscript!modify
+// CHECK-NEW:     witness_method {{.*}}#ProtocolOld.subscript!yielding_mutate
+// CHECK-LABEL: } // end sil function 'modifySubscriptOld'
+  x[0] += 1
+}
+
+@available(SwiftStdlib 9999, *)
+@_silgen_name("readSubscriptNew")
+func readSubscriptNew<T: ProtocolOld>(_ x: T) -> Int {
+// CHECK-LABEL: sil {{.*}}@readSubscriptNew : {{.*}} {
+// CHECK:         witness_method {{.*}}#ProtocolOld.subscript!yielding_borrow
+// CHECK-LABEL: } // end sil function 'readSubscriptNew'
+  return x[0]
+}
+
+// The conformance carries both ABIs' witness slots (emitted after the
+// functions, so these checks come last).
+// CHECK-LABEL: sil_witness_table {{.*}}SOld: ProtocolOld module Client {
+// CHECK-DAG:     method #ProtocolOld.value!read:
+// CHECK-DAG:     method #ProtocolOld.value!yielding_borrow:
+// CHECK-DAG:     method #ProtocolOld.value!modify:
+// CHECK-DAG:     method #ProtocolOld.value!yielding_mutate:
+// CHECK-DAG:     method #ProtocolOld.subscript!read:
+// CHECK-DAG:     method #ProtocolOld.subscript!yielding_borrow:
+// CHECK-DAG:     method #ProtocolOld.subscript!modify:
+// CHECK-DAG:     method #ProtocolOld.subscript!yielding_mutate:
+// CHECK:       }

--- a/test/SILGen/coroutine_accessors_read_synthesis.swift
+++ b/test/SILGen/coroutine_accessors_read_synthesis.swift
@@ -30,9 +30,11 @@
 
 // On a non-ABI-stable platform, confirm the old accessors are still absent even
 // under library evolution (separate invocation so a lone CHECK-NOT scans the
-// whole input).
+// whole input).  The NOT check below distinguishes old from new by the literal
+// absence of "_2", so the new accessors' own convention must be pinned here too.
 // RUN: %target-swift-emit-silgen %s                          \
 // RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -enable-callee-allocated-coro-abi                 \
 // RUN:     -enable-library-evolution                         \
 // RUN:     -module-name m                                    \
 // RUN:   | %FileCheck %s --check-prefix=NO-OLD-ABI-RESILIENT-%target-abi-stability

--- a/test/SILGen/coroutine_accessors_read_synthesis.swift
+++ b/test/SILGen/coroutine_accessors_read_synthesis.swift
@@ -1,0 +1,77 @@
+// With the CoroutineAccessors feature enabled, `_read`/`_modify` and
+// `yielding borrow`/`yielding mutate` are two spellings of the same coroutine
+// accessor and produce the *same* ABI.  This test uses the `_read`/`_modify`
+// spelling; coroutine_accessors_yielding_synthesis.swift is the identical test
+// with the `yielding borrow`/`yielding mutate` spelling.  The two should emit
+// the same accessors in every case.
+//
+// The new yield_once_2 accessors are the primary implementation; the old
+// yield_once accessors are emitted only additively when the module is resilient.
+
+// RUN: %target-swift-emit-silgen %s                          \
+// RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -module-name m                                    \
+// RUN:   | %FileCheck %s --check-prefix=FRAGILE
+
+// RUN: %target-swift-emit-silgen %s                          \
+// RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -module-name m                                    \
+// RUN:   | %FileCheck %s --check-prefix=NO-OLD-ABI
+
+// RUN: %target-swift-emit-silgen %s                          \
+// RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -enable-library-evolution                         \
+// RUN:     -module-name m                                    \
+// RUN:   | %FileCheck %s --check-prefix=RESILIENT
+
+// REQUIRES: swift_feature_CoroutineAccessors
+
+public struct StructRM {
+  var _s = 0
+  public var i: Int {
+    _read { yield _s }
+    _modify { yield &_s }
+  }
+}
+
+open class ClassRM {
+  var _s = 0
+  open var i: Int {
+    _read { yield _s }
+    _modify { yield &_s }
+  }
+}
+
+var _g = 0
+public var globalRM: Int {
+  _read { yield _g }
+  _modify { yield &_g }
+}
+
+// The new yield_once_2 accessors are always emitted (they are the primary
+// implementation), including for the non-resilient module-scope global.
+// FRAGILE-DAG:   sil{{.*}} @$s1m8StructRMV1iSivy : $@yield_once_2
+// FRAGILE-DAG:   sil{{.*}} @$s1m8StructRMV1iSivx : $@yield_once_2
+// FRAGILE-DAG:   sil{{.*}} @$s1m7ClassRMC1iSivy : $@yield_once_2
+// FRAGILE-DAG:   sil{{.*}} @$s1m7ClassRMC1iSivx : $@yield_once_2
+// FRAGILE-DAG:   sil{{.*}} @$s1m8globalRMSivy : $@yield_once_2
+// FRAGILE-DAG:   sil{{.*}} @$s1m8globalRMSivx : $@yield_once_2
+
+// Non-resilient: no old yield_once accessors at all (new ABI only), even though
+// the property was written with `_read`/`_modify`.
+// NO-OLD-ABI-NOT: @$s1m8StructRMV1iSivr
+// NO-OLD-ABI-NOT: @$s1m8StructRMV1iSivM
+// NO-OLD-ABI-NOT: @$s1m7ClassRMC1iSivr
+// NO-OLD-ABI-NOT: @$s1m7ClassRMC1iSivM
+// NO-OLD-ABI-NOT: @$s1m8globalRMSivr
+// NO-OLD-ABI-NOT: @$s1m8globalRMSivM
+
+// Resilient: old yield_once accessors are additively emitted alongside the new.
+// RESILIENT-DAG: sil{{.*}} @$s1m8StructRMV1iSivy : $@yield_once_2
+// RESILIENT-DAG: sil{{.*}} @$s1m8StructRMV1iSivr : $@yield_once @convention
+// RESILIENT-DAG: sil{{.*}} @$s1m8StructRMV1iSivx : $@yield_once_2
+// RESILIENT-DAG: sil{{.*}} @$s1m8StructRMV1iSivM : $@yield_once @convention
+// RESILIENT-DAG: sil{{.*}} @$s1m8globalRMSivy : $@yield_once_2
+// RESILIENT-DAG: sil{{.*}} @$s1m8globalRMSivr : $@yield_once @convention
+// RESILIENT-DAG: sil{{.*}} @$s1m8globalRMSivx : $@yield_once_2
+// RESILIENT-DAG: sil{{.*}} @$s1m8globalRMSivM : $@yield_once @convention

--- a/test/SILGen/coroutine_accessors_read_synthesis.swift
+++ b/test/SILGen/coroutine_accessors_read_synthesis.swift
@@ -6,10 +6,13 @@
 // the same accessors in every case.
 //
 // The new yield_once_2 accessors are the primary implementation; the old
-// yield_once accessors are emitted only additively when the module is resilient.
+// yield_once accessors are additionally emitted only when the module is
+// resilient AND built for an ABI-stable platform (there is no prebuilt binary
+// to stay compatible with otherwise).
 
 // RUN: %target-swift-emit-silgen %s                          \
 // RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -enable-callee-allocated-coro-abi                 \
 // RUN:     -module-name m                                    \
 // RUN:   | %FileCheck %s --check-prefix=FRAGILE
 
@@ -20,9 +23,19 @@
 
 // RUN: %target-swift-emit-silgen %s                          \
 // RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -enable-callee-allocated-coro-abi                 \
 // RUN:     -enable-library-evolution                         \
 // RUN:     -module-name m                                    \
-// RUN:   | %FileCheck %s --check-prefix=RESILIENT
+// RUN:   | %FileCheck %s --check-prefixes=RESILIENT,RESILIENT-%target-abi-stability
+
+// On a non-ABI-stable platform, confirm the old accessors are still absent even
+// under library evolution (separate invocation so a lone CHECK-NOT scans the
+// whole input).
+// RUN: %target-swift-emit-silgen %s                          \
+// RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -enable-library-evolution                         \
+// RUN:     -module-name m                                    \
+// RUN:   | %FileCheck %s --check-prefix=NO-OLD-ABI-RESILIENT-%target-abi-stability
 
 // REQUIRES: swift_feature_CoroutineAccessors
 
@@ -66,12 +79,21 @@ public var globalRM: Int {
 // NO-OLD-ABI-NOT: @$s1m8globalRMSivr
 // NO-OLD-ABI-NOT: @$s1m8globalRMSivM
 
-// Resilient: old yield_once accessors are additively emitted alongside the new.
+// Resilient: old yield_once accessors are additively emitted alongside the new,
+// but only on an ABI-stable platform.
 // RESILIENT-DAG: sil{{.*}} @$s1m8StructRMV1iSivy : $@yield_once_2
-// RESILIENT-DAG: sil{{.*}} @$s1m8StructRMV1iSivr : $@yield_once @convention
 // RESILIENT-DAG: sil{{.*}} @$s1m8StructRMV1iSivx : $@yield_once_2
-// RESILIENT-DAG: sil{{.*}} @$s1m8StructRMV1iSivM : $@yield_once @convention
 // RESILIENT-DAG: sil{{.*}} @$s1m8globalRMSivy : $@yield_once_2
-// RESILIENT-DAG: sil{{.*}} @$s1m8globalRMSivr : $@yield_once @convention
 // RESILIENT-DAG: sil{{.*}} @$s1m8globalRMSivx : $@yield_once_2
-// RESILIENT-DAG: sil{{.*}} @$s1m8globalRMSivM : $@yield_once @convention
+// RESILIENT-stable-DAG: sil{{.*}} @$s1m8StructRMV1iSivr : $@yield_once @convention
+// RESILIENT-stable-DAG: sil{{.*}} @$s1m8StructRMV1iSivM : $@yield_once @convention
+// RESILIENT-stable-DAG: sil{{.*}} @$s1m8globalRMSivr : $@yield_once @convention
+// RESILIENT-stable-DAG: sil{{.*}} @$s1m8globalRMSivM : $@yield_once @convention
+
+// NO-OLD-ABI-RESILIENT-unstable-NOT: @yield_once @convention
+
+// On an ABI-stable platform this invocation has nothing new to verify (the
+// other RESILIENT invocation above already confirms both ABIs there); just
+// give the "stable" prefix a trivial match so FileCheck doesn't reject an
+// entirely-unmatched --check-prefix.
+// NO-OLD-ABI-RESILIENT-stable-DAG: sil{{.*}} @$s1m8StructRMV1iSivy : $@yield_once_2

--- a/test/SILGen/coroutine_accessors_yielding_synthesis.swift
+++ b/test/SILGen/coroutine_accessors_yielding_synthesis.swift
@@ -1,0 +1,74 @@
+// Companion to coroutine_accessors_read_synthesis.swift, using the
+// `yielding borrow`/`yielding mutate` spelling instead of `_read`/`_modify`.
+// Comparing the two reveals the residual spelling-dependent ABI gap: with this
+// spelling the new yield_once_2 accessors are the *written* ones (always
+// present), and the old yield_once_1 accessors appear only additively when the
+// module is resilient.
+
+// RUN: %target-swift-emit-silgen %s                          \
+// RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -module-name m                                    \
+// RUN:   | %FileCheck %s --check-prefix=FRAGILE
+
+// RUN: %target-swift-emit-silgen %s                          \
+// RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -module-name m                                    \
+// RUN:   | %FileCheck %s --check-prefix=NO-OLD-ABI
+
+// RUN: %target-swift-emit-silgen %s                          \
+// RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -enable-library-evolution                         \
+// RUN:     -module-name m                                    \
+// RUN:   | %FileCheck %s --check-prefix=RESILIENT
+
+// REQUIRES: swift_feature_CoroutineAccessors
+
+public struct StructYY {
+  var _s = 0
+  public var i: Int {
+    yielding borrow { yield _s }
+    yielding mutate { yield &_s }
+  }
+}
+
+open class ClassYY {
+  var _s = 0
+  open var i: Int {
+    yielding borrow { yield _s }
+    yielding mutate { yield &_s }
+  }
+}
+
+var _g = 0
+public var globalYY: Int {
+  yielding borrow { yield _g }
+  yielding mutate { yield &_g }
+}
+
+// The new yield_once_2 accessors are always emitted (they are the written
+// accessors) -- including for the non-resilient module-scope global, unlike the
+// `_read` spelling where that global gets *no* opaque coroutines.
+// FRAGILE-DAG:   sil{{.*}} @$s1m8StructYYV1iSivy : $@yield_once_2
+// FRAGILE-DAG:   sil{{.*}} @$s1m8StructYYV1iSivx : $@yield_once_2
+// FRAGILE-DAG:   sil{{.*}} @$s1m7ClassYYC1iSivy : $@yield_once_2
+// FRAGILE-DAG:   sil{{.*}} @$s1m7ClassYYC1iSivx : $@yield_once_2
+// FRAGILE-DAG:   sil{{.*}} @$s1m8globalYYSivy : $@yield_once_2
+// FRAGILE-DAG:   sil{{.*}} @$s1m8globalYYSivx : $@yield_once_2
+
+// Non-resilient: no old yield_once_1 accessors at all (new ABI only).
+// NO-OLD-ABI-NOT: @$s1m8StructYYV1iSivr
+// NO-OLD-ABI-NOT: @$s1m8StructYYV1iSivM
+// NO-OLD-ABI-NOT: @$s1m7ClassYYC1iSivr
+// NO-OLD-ABI-NOT: @$s1m7ClassYYC1iSivM
+// NO-OLD-ABI-NOT: @$s1m8globalYYSivr
+// NO-OLD-ABI-NOT: @$s1m8globalYYSivM
+
+// Resilient: old yield_once_1 accessors are additively emitted alongside the new.
+// RESILIENT-DAG: sil{{.*}} @$s1m8StructYYV1iSivy : $@yield_once_2
+// RESILIENT-DAG: sil{{.*}} @$s1m8StructYYV1iSivr : $@yield_once @convention
+// RESILIENT-DAG: sil{{.*}} @$s1m8StructYYV1iSivx : $@yield_once_2
+// RESILIENT-DAG: sil{{.*}} @$s1m8StructYYV1iSivM : $@yield_once @convention
+// RESILIENT-DAG: sil{{.*}} @$s1m8globalYYSivy : $@yield_once_2
+// RESILIENT-DAG: sil{{.*}} @$s1m8globalYYSivr : $@yield_once @convention
+// RESILIENT-DAG: sil{{.*}} @$s1m8globalYYSivx : $@yield_once_2
+// RESILIENT-DAG: sil{{.*}} @$s1m8globalYYSivM : $@yield_once @convention

--- a/test/SILGen/coroutine_accessors_yielding_synthesis.swift
+++ b/test/SILGen/coroutine_accessors_yielding_synthesis.swift
@@ -25,9 +25,11 @@
 
 // On a non-ABI-stable platform, confirm the old accessors are still absent even
 // under library evolution (separate invocation so a lone CHECK-NOT scans the
-// whole input).
+// whole input).  The NOT check below distinguishes old from new by the literal
+// absence of "_2", so the new accessors' own convention must be pinned here too.
 // RUN: %target-swift-emit-silgen %s                          \
 // RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -enable-callee-allocated-coro-abi                 \
 // RUN:     -enable-library-evolution                         \
 // RUN:     -module-name m                                    \
 // RUN:   | %FileCheck %s --check-prefix=NO-OLD-ABI-RESILIENT-%target-abi-stability

--- a/test/SILGen/coroutine_accessors_yielding_synthesis.swift
+++ b/test/SILGen/coroutine_accessors_yielding_synthesis.swift
@@ -3,10 +3,11 @@
 // Comparing the two reveals the residual spelling-dependent ABI gap: with this
 // spelling the new yield_once_2 accessors are the *written* ones (always
 // present), and the old yield_once_1 accessors appear only additively when the
-// module is resilient.
+// module is resilient AND built for an ABI-stable platform.
 
 // RUN: %target-swift-emit-silgen %s                          \
 // RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -enable-callee-allocated-coro-abi                 \
 // RUN:     -module-name m                                    \
 // RUN:   | %FileCheck %s --check-prefix=FRAGILE
 
@@ -17,9 +18,19 @@
 
 // RUN: %target-swift-emit-silgen %s                          \
 // RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -enable-callee-allocated-coro-abi                 \
 // RUN:     -enable-library-evolution                         \
 // RUN:     -module-name m                                    \
-// RUN:   | %FileCheck %s --check-prefix=RESILIENT
+// RUN:   | %FileCheck %s --check-prefixes=RESILIENT,RESILIENT-%target-abi-stability
+
+// On a non-ABI-stable platform, confirm the old accessors are still absent even
+// under library evolution (separate invocation so a lone CHECK-NOT scans the
+// whole input).
+// RUN: %target-swift-emit-silgen %s                          \
+// RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -enable-library-evolution                         \
+// RUN:     -module-name m                                    \
+// RUN:   | %FileCheck %s --check-prefix=NO-OLD-ABI-RESILIENT-%target-abi-stability
 
 // REQUIRES: swift_feature_CoroutineAccessors
 
@@ -63,12 +74,21 @@ public var globalYY: Int {
 // NO-OLD-ABI-NOT: @$s1m8globalYYSivr
 // NO-OLD-ABI-NOT: @$s1m8globalYYSivM
 
-// Resilient: old yield_once_1 accessors are additively emitted alongside the new.
+// Resilient: old yield_once_1 accessors are additively emitted alongside the
+// new, but only on an ABI-stable platform.
 // RESILIENT-DAG: sil{{.*}} @$s1m8StructYYV1iSivy : $@yield_once_2
-// RESILIENT-DAG: sil{{.*}} @$s1m8StructYYV1iSivr : $@yield_once @convention
 // RESILIENT-DAG: sil{{.*}} @$s1m8StructYYV1iSivx : $@yield_once_2
-// RESILIENT-DAG: sil{{.*}} @$s1m8StructYYV1iSivM : $@yield_once @convention
 // RESILIENT-DAG: sil{{.*}} @$s1m8globalYYSivy : $@yield_once_2
-// RESILIENT-DAG: sil{{.*}} @$s1m8globalYYSivr : $@yield_once @convention
 // RESILIENT-DAG: sil{{.*}} @$s1m8globalYYSivx : $@yield_once_2
-// RESILIENT-DAG: sil{{.*}} @$s1m8globalYYSivM : $@yield_once @convention
+// RESILIENT-stable-DAG: sil{{.*}} @$s1m8StructYYV1iSivr : $@yield_once @convention
+// RESILIENT-stable-DAG: sil{{.*}} @$s1m8StructYYV1iSivM : $@yield_once @convention
+// RESILIENT-stable-DAG: sil{{.*}} @$s1m8globalYYSivr : $@yield_once @convention
+// RESILIENT-stable-DAG: sil{{.*}} @$s1m8globalYYSivM : $@yield_once @convention
+
+// NO-OLD-ABI-RESILIENT-unstable-NOT: @yield_once @convention
+
+// On an ABI-stable platform this invocation has nothing new to verify (the
+// other RESILIENT invocation above already confirms both ABIs there); just
+// give the "stable" prefix a trivial match so FileCheck doesn't reject an
+// entirely-unmatched --check-prefix.
+// NO-OLD-ABI-RESILIENT-stable-DAG: sil{{.*}} @$s1m8StructYYV1iSivy : $@yield_once_2

--- a/test/SILGen/default_override.swift
+++ b/test/SILGen/default_override.swift
@@ -17,6 +17,12 @@
 // REQUIRES: swift_feature_CoroutineAccessors
 // REQUIRES: swift_feature_BuiltinModule
 
+// This test is about the default-override forwarding thunks that bridge the
+// old and new coroutine-accessor ABIs across a resilience boundary for `open`
+// members; that bridge only exists where the old ABI is emitted at all, which
+// only happens on an ABI-stable platform.
+// REQUIRES: swift_stable_abi
+
 import Builtin
 
 public enum Open {}

--- a/test/SILGen/read_requirements.swift
+++ b/test/SILGen/read_requirements.swift
@@ -338,7 +338,7 @@ public struct ImplCStored : ~Copyable & P3 {
 }
 
 @frozen
-public struct ImplAUnderscoredCoroutineAccessors : ~Copyable & P1 {
+public struct ImplALegacyCoroutineAccessors : ~Copyable & P1 {
   var _i: U
   public var ubgs: U {
     _read {
@@ -348,102 +348,23 @@ public struct ImplAUnderscoredCoroutineAccessors : ~Copyable & P1 {
       yield &_i
     }
   }
-// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsV4ubgsAA1UVvr : {{.*}} {
-// CHECK:       bb0(
-// CHECK-SAME:      [[SELF:%[^:]+]]
-// CHECK-SAME:  ):
-// CHECK:         [[COPY_UNCHECKED:%[^,]+]] = copy_value [[SELF]]
-// CHECK:         [[COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[COPY_UNCHECKED]]
-// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[COPY]]
-// CHECK:         [[VALUE:%[^,]+]] = struct_extract [[BORROW]]
-// CHECK:             #ImplAUnderscoredCoroutineAccessors._i
-// CHECK:         yield [[VALUE]] : $U
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
-// CHECK:       [[SUCCESS]]:
-// CHECK:         end_borrow [[BORROW]]
-// CHECK:         destroy_value [[COPY]]
-// CHECK:         return
-// CHECK:       [[FAILURE]]:
-// CHECK:         end_borrow [[BORROW]]
-// CHECK:         destroy_value [[COPY]]
-// CHECK:         unwind
-// CHECK-LABEL: } // end sil function '$s17read_requirements34ImplAUnderscoredCoroutineAccessorsV4ubgsAA1UVvr'
-// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsV4ubgsAA1UVvy : {{.*}} {
-// CHECK:       bb0(
-// CHECK-SAME:      [[SELF:%[^:]+]]
-// CHECK-SAME:  ):
-// CHECK:         [[SELF_COPY_UNCHECKED:%[^,]+]] = copy_value [[SELF]]
-// CHECK:         [[SELF_COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[SELF_COPY_UNCHECKED]]
-// CHECK:         [[SELF_BORROW:%[^,]+]] = begin_borrow [[SELF_COPY]]
-// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsV4ubgsAA1UVvr
-// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF_BORROW]])
-// CHECK:         [[VALUE_COPY_UNCHECKED:%[^,]+]] = copy_value [[VALUE]]
-// CHECK:         [[VALUE_COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[VALUE_COPY_UNCHECKED]]
-// CHECK:         [[VALUE_BORROW:%[^,]+]] = begin_borrow [[VALUE_COPY]]
-// CHECK:         yield [[VALUE_BORROW]]
-// CHECK-SAME:        resume [[SUCCESS:bb[0-9]+]]
-// CHECK-SAME:        unwind [[FAILURE:bb[0-9]+]]
-// CHECK:       [[SUCCESS]]:
-// CHECK:         end_borrow [[VALUE_BORROW]]
-// CHECK:         destroy_value [[VALUE_COPY]]
-// CHECK:         end_apply [[TOKEN]]
-// CHECK:         end_borrow [[SELF_BORROW]]
-// CHECK:         destroy_value [[SELF_COPY]]
-// CHECK:         return
-// CHECK:       [[FAILURE]]:
-// CHECK:         end_borrow [[VALUE_BORROW]]
-// CHECK:         destroy_value [[VALUE_COPY]]
-// CHECK:         end_apply [[TOKEN]]
-// CHECK:         end_borrow [[SELF_BORROW]]
-// CHECK:         destroy_value [[SELF_COPY]]
-// CHECK:         unwind
-// CHECK-LABEL: } // end sil function '$s17read_requirements34ImplAUnderscoredCoroutineAccessorsV4ubgsAA1UVvy'
-// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvrTW : {{.*}} {
-// CHECK:       bb0(
-// CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
-// CHECK-SAME:  ):
-// CHECK:         [[SELF:%[^,]+]] = load_borrow [[SELF_ADDR]]
-// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsV4ubgsAA1UVvr
-// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF]])
-// CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
-// CHECK:       [[SUCCESS]]:
-// CHECK:         end_apply [[TOKEN]]
-// CHECK:         end_borrow [[SELF]]
-// CHECK:         return
-// CHECK:       [[FAILURE]]:
-// CHECK:         abort_apply [[TOKEN]]
-// CHECK:         end_borrow [[SELF]]
-// CHECK:         unwind
-// CHECK-LABEL: } // end sil function '$s17read_requirements34ImplAUnderscoredCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvrTW'
-// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvyTW : {{.*}} {
-// CHECK:       bb0(
-// CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
-// CHECK-SAME:  ):
-// CHECK:         [[SELF:%[^,]+]] = load_borrow [[SELF_ADDR]]
-// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsV4ubgsAA1UVvy
-// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[SELF]])
-// CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
-// CHECK:       [[SUCCESS]]:
-// CHECK:         end_apply [[TOKEN]]
-// CHECK:         dealloc_stack [[ALLOCATION]]
-// CHECK:         end_borrow [[SELF]]
-// CHECK:         return
-// CHECK:       [[FAILURE]]:
-// CHECK:         end_apply [[TOKEN]]
-// CHECK:         dealloc_stack [[ALLOCATION]]
-// CHECK:         end_borrow [[SELF]]
-// CHECK:         unwind
-// CHECK-LABEL: } // end sil function '$s17read_requirements34ImplAUnderscoredCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvyTW'
+// With the CoroutineAccessors feature enabled, `_read`/`_modify` use the same
+// yield_once_2 ABI as `yielding borrow`/`yielding mutate`, so this type emits
+// the same accessors as ImplACoroutineAccessors above (modulo the mangled type
+// name), which verify the bodies in full.  Here we confirm the accessor set and
+// forwarding: the yield_once_2 vy/vx are the primary implementations and, because
+// this type predates the feature, the additive yield_once vr/vM forward to them.
+// CHECK-LABEL: sil{{.*}} @$s17read_requirements29ImplALegacyCoroutineAccessorsV4ubgsAA1UVvy : $@yield_once_2 @convention
+// CHECK-LABEL: sil{{.*}} @$s17read_requirements29ImplALegacyCoroutineAccessorsV4ubgsAA1UVvx : $@yield_once_2 @convention
+// CHECK-LABEL: sil{{.*}} @$s17read_requirements29ImplALegacyCoroutineAccessorsV4ubgsAA1UVvr : $@yield_once @convention
+// CHECK:         function_ref @$s17read_requirements29ImplALegacyCoroutineAccessorsV4ubgsAA1UVvy
+// CHECK-LABEL: sil{{.*}} @$s17read_requirements29ImplALegacyCoroutineAccessorsV4ubgsAA1UVvM : $@yield_once @convention
+// CHECK:         function_ref @$s17read_requirements29ImplALegacyCoroutineAccessorsV4ubgsAA1UVvx
 }
 
 @frozen
 @available(SwiftStdlib 9999, *)
-public struct ImplBUnderscoredCoroutineAccessors : ~Copyable & P2 {
+public struct ImplBLegacyCoroutineAccessors : ~Copyable & P2 {
   var _i: U
   public var urs: U {
     _read {
@@ -453,180 +374,32 @@ public struct ImplBUnderscoredCoroutineAccessors : ~Copyable & P2 {
       yield &_i
     }
   }
-// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsV3ursAA1UVvr : {{.*}} {
-// CHECK:       bb0(
-// CHECK-SAME:      [[SELF:%[^:]+]]
-// CHECK-SAME:  ):
-// CHECK:         [[COPY_UNCHECKED:%[^,]+]] = copy_value [[SELF]]
-// CHECK:         [[COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[COPY_UNCHECKED]]
-// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[COPY]]
-// CHECK:         [[VALUE:%[^,]+]] = struct_extract [[BORROW]]
-// CHECK-SAME:        #ImplBUnderscoredCoroutineAccessors._i
-// CHECK:         yield [[VALUE]]
-// CHECK-SAME:        resume [[SUCCESS:bb[0-9]+]]
-// CHECK-SAME:        unwind [[FAILURE:bb[0-9]+]]
-// CHECK:       [[SUCCESS]]:
-// CHECK:         end_borrow [[BORROW]]
-// CHECK:         destroy_value [[COPY]]
-// CHECK:         return
-// CHECK:       [[FAILURE]]:
-// CHECK:         end_borrow [[BORROW]]
-// CHECK:         destroy_value [[COPY]]
-// CHECK:         unwind
-// CHECK-LABEL: } // end sil function '$s17read_requirements34ImplBUnderscoredCoroutineAccessorsV3ursAA1UVvr'
-// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsV3ursAA1UVvy : {{.*}} {
-// CHECK:       bb0(
-// CHECK-SAME:      [[SELF:%[^:]+]]
-// CHECK-SAME:  ):
-// CHECK:         [[SELF_COPY_UNCHECKED:%[^,]+]] = copy_value [[SELF]]
-// CHECK:         [[SELF_COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[SELF_COPY_UNCHECKED]]
-// CHECK:         [[SELF_BORROW:%[^,]+]] = begin_borrow [[SELF_COPY]]
-// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsV3ursAA1UVvr
-// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF_BORROW]])
-// CHECK:         [[VALUE_COPY_UNCHECKED:%[^,]+]] = copy_value [[VALUE]]
-// CHECK:         [[VALUE_COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[VALUE_COPY_UNCHECKED]]
-// CHECK:         [[VALUE_BORROW:%[^,]+]] = begin_borrow [[VALUE_COPY]]
-// CHECK:         yield [[VALUE_BORROW]]
-// CHECK-SAME:        resume [[SUCCESS:bb[0-9]+]]
-// CHECK-SAME:        unwind [[FAILURE:bb[0-9]+]]
-// CHECK:       [[SUCCESS]]:
-// CHECK:         end_borrow [[VALUE_BORROW]]
-// CHECK:         destroy_value [[VALUE_COPY]]
-// CHECK:         end_apply [[TOKEN]]
-// CHECK:         end_borrow [[SELF_BORROW]]
-// CHECK:         destroy_value [[SELF_COPY]]
-// CHECK:         return
-// CHECK:       [[FAILURE]]:
-// CHECK:         end_borrow [[VALUE_BORROW]]
-// CHECK:         destroy_value [[VALUE_COPY]]
-// CHECK:         end_apply [[TOKEN]]
-// CHECK:         end_borrow [[SELF_BORROW]]
-// CHECK:         destroy_value [[SELF_COPY]]
-// CHECK:         unwind
-// CHECK-LABEL: } // end sil function '$s17read_requirements34ImplBUnderscoredCoroutineAccessorsV3ursAA1UVvy'
-// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvyTW : {{.*}} {
-// CHECK:       bb0(
-// CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
-// CHECK-SAME:  ):
-// CHECK:         [[SELF:%[^,]+]] = load_borrow [[SELF_ADDR]]
-// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsV3ursAA1UVvy
-// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[SELF]])
-// CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
-// CHECK:       [[SUCCESS]]:
-// CHECK:         end_apply [[TOKEN]]
-// CHECK:         dealloc_stack [[ALLOCATION]]
-// CHECK:         end_borrow [[SELF]]
-// CHECK:         return
-// CHECK:       [[FAILURE]]:
-// CHECK:         end_apply [[TOKEN]]
-// CHECK:         dealloc_stack [[ALLOCATION]]
-// CHECK:         end_borrow [[SELF]]
-// CHECK:         unwind
-// CHECK-LABEL: } // end sil function '$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvyTW'
+// ImplB is introduced at the feature's own availability, so there is no old ABI
+// to preserve: only the yield_once_2 accessors are emitted, no yield_once vr/vM.
+// CHECK-LABEL: sil{{.*}} @$s17read_requirements29ImplBLegacyCoroutineAccessorsV3ursAA1UVvy : $@yield_once_2 @convention
+// CHECK-LABEL: sil{{.*}} @$s17read_requirements29ImplBLegacyCoroutineAccessorsV3ursAA1UVvx : $@yield_once_2 @convention
+// CHECK-NOT:   @$s17read_requirements29ImplBLegacyCoroutineAccessorsV3ursAA1UVvr :
+// CHECK-NOT:   @$s17read_requirements29ImplBLegacyCoroutineAccessorsV3ursAA1UVvM :
 }
 
 @frozen
 @available(SwiftStdlib 6.0, *)
-public struct ImplCUnderscoredCoroutineAccessors : ~Copyable & P3 {
+public struct ImplCLegacyCoroutineAccessors : ~Copyable & P3 {
   var _i: U
   public var ur: U {
     _read {
       yield _i
     }
   }
-// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements34ImplCUnderscoredCoroutineAccessorsV2urAA1UVvr : {{.*}} {
-// CHECK:       bb0(
-// CHECK-SAME:      [[SELF:%[^:]+]]
-// CHECK-SAME:  ):
-// CHECK:         [[COPY_UNCHECKED:%[^,]+]] = copy_value [[SELF]]
-// CHECK:         [[COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[COPY_UNCHECKED]]
-// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[COPY]]
-// CHECK:         [[VALUE:%[^,]+]] = struct_extract [[BORROW]]
-// CHECK-SAME:        #ImplCUnderscoredCoroutineAccessors._i
-// CHECK:         yield [[VALUE]]
-// CHECK-SAME:        resume [[SUCCESS:bb[0-9]+]]
-// CHECK-SAME:        unwind [[FAILURE:bb[0-9]+]]
-// CHECK:       [[SUCCESS]]:
-// CHECK:         end_borrow [[BORROW]]
-// CHECK:         destroy_value [[COPY]]
-// CHECK:         return
-// CHECK:       [[FAILURE]]:
-// CHECK:         end_borrow [[BORROW]]
-// CHECK:         destroy_value [[COPY]]
-// CHECK:         unwind
-// CHECK-LABEL: } // end sil function '$s17read_requirements34ImplCUnderscoredCoroutineAccessorsV2urAA1UVvr'
-// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements34ImplCUnderscoredCoroutineAccessorsV2urAA1UVvy : {{.*}} {
-// CHECK:       bb0(
-// CHECK-SAME:      [[SELF:%[^:]+]]
-// CHECK-SAME:  ):
-// CHECK:         [[SELF_COPY_UNCHECKED:%[^,]+]] = copy_value [[SELF]]
-// CHECK:         [[SELF_COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[SELF_COPY_UNCHECKED]]
-// CHECK:         [[SELF_BORROW:%[^,]+]] = begin_borrow [[SELF_COPY]]
-// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements34ImplCUnderscoredCoroutineAccessorsV2urAA1UVvr
-// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF_BORROW]])
-// CHECK:         [[VALUE_COPY_UNCHECKED:%[^,]+]] = copy_value [[VALUE]]
-// CHECK:         [[VALUE_COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[VALUE_COPY_UNCHECKED]]
-// CHECK:         [[VALUE_BORROW:%[^,]+]] = begin_borrow [[VALUE_COPY]]
-// CHECK:         yield [[VALUE_BORROW]]
-// CHECK-SAME:        resume [[SUCCESS:bb[0-9]+]]
-// CHECK-SAME:        unwind [[FAILURE:bb[0-9]+]]
-// CHECK:       [[SUCCESS]]:
-// CHECK:         end_borrow [[VALUE_BORROW]]
-// CHECK:         destroy_value [[VALUE_COPY]]
-// CHECK:         end_apply [[TOKEN]]
-// CHECK:         end_borrow [[SELF_BORROW]]
-// CHECK:         destroy_value [[SELF_COPY]]
-// CHECK:         return
-// CHECK:       [[FAILURE]]:
-// CHECK:         end_borrow [[VALUE_BORROW]]
-// CHECK:         destroy_value [[VALUE_COPY]]
-// CHECK:         end_apply [[TOKEN]]
-// CHECK:         end_borrow [[SELF_BORROW]]
-// CHECK:         destroy_value [[SELF_COPY]]
-// CHECK:         unwind
-// CHECK-LABEL: } // end sil function '$s17read_requirements34ImplCUnderscoredCoroutineAccessorsV2urAA1UVvy'
-// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements34ImplCUnderscoredCoroutineAccessorsVAA2P3A2aDP2urAA1UVvrTW : {{.*}} {
-// CHECK:       bb0(
-// CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
-// CHECK:       ):
-// CHECK:         [[SELF:%[^,]+]] = load_borrow [[SELF_ADDR]]
-// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements34ImplCUnderscoredCoroutineAccessorsV2urAA1UVvr
-// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF]])
-// CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
-// CHECK:       [[SUCCESS]]:
-// CHECK:         end_apply [[TOKEN]]
-// CHECK:         end_borrow [[SELF]]
-// CHECK:         return
-// CHECK:       [[FAILURE]]:
-// CHECK:         abort_apply [[TOKEN]]
-// CHECK:         end_borrow [[SELF]]
-// CHECK:         unwind
-// CHECK-LABEL: } // end sil function '$s17read_requirements34ImplCUnderscoredCoroutineAccessorsVAA2P3A2aDP2urAA1UVvrTW'
-// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements34ImplCUnderscoredCoroutineAccessorsVAA2P3A2aDP2urAA1UVvyTW : {{.*}} {
-// CHECK:       bb0(
-// CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
-// CHECK-SAME:  ):
-// CHECK:         [[SELF:%[^,]+]] = load_borrow [[SELF_ADDR]]
-// CHECK:         [[READ2ER:%[^,]+]] = function_ref @$s17read_requirements34ImplCUnderscoredCoroutineAccessorsV2urAA1UVvy
-// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[SELF]])
-// CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
-// CHECK:       [[SUCCESS]]:
-// CHECK:         end_apply [[TOKEN]]
-// CHECK:         dealloc_stack [[ALLOCATION]]
-// CHECK:         end_borrow [[SELF]]
-// CHECK:         return
-// CHECK:       [[FAILURE]]:
-// CHECK:         end_apply [[TOKEN]]
-// CHECK:         dealloc_stack [[ALLOCATION]]
-// CHECK:         end_borrow [[SELF]]
-// CHECK:         unwind
-// CHECK-LABEL: } // end sil function '$s17read_requirements34ImplCUnderscoredCoroutineAccessorsVAA2P3A2aDP2urAA1UVvyTW'
+// With the CoroutineAccessors feature enabled, `_read` uses the same yield_once_2
+// ABI as `yielding borrow`, so this type emits the same accessors as
+// ImplCCoroutineAccessors above (modulo the mangled type name), which verify the
+// body in full.  Here we confirm the accessor set and forwarding: the
+// yield_once_2 vy is the primary implementation and, because this type predates
+// the feature, the additive yield_once vr forwards to it.
+// CHECK-LABEL: sil{{.*}} @$s17read_requirements29ImplCLegacyCoroutineAccessorsV2urAA1UVvy : $@yield_once_2 @convention
+// CHECK-LABEL: sil{{.*}} @$s17read_requirements29ImplCLegacyCoroutineAccessorsV2urAA1UVvr : $@yield_once @convention
+// CHECK:         function_ref @$s17read_requirements29ImplCLegacyCoroutineAccessorsV2urAA1UVvy
 }
 
 struct ImplACoroutineAccessors : ~Copyable & P1 {
@@ -1469,35 +1242,35 @@ public struct ImplCUnsafeAddressors : P3 {
 // CHECK-SAME:      : @$s17read_requirements11ImplCStoredVAA2P3A2aDP2urAA1UVvyTW
 // CHECK-NEXT:  }
 
-// CHECK-LABEL: sil_witness_table{{.*}} ImplAUnderscoredCoroutineAccessors: P1 module read_requirements {
+// CHECK-LABEL: sil_witness_table{{.*}} ImplALegacyCoroutineAccessors: P1 module read_requirements {
 // CHECK-NEXT:    method #P1.ubgs!read
-// CHECK-SAME:        : @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvrTW
+// CHECK-SAME:        : @$s17read_requirements29ImplALegacyCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvrTW
 // CHECK-NEXT:    method #P1.ubgs!yielding_borrow
-// CHECK-SAME:      : @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvyTW
+// CHECK-SAME:      : @$s17read_requirements29ImplALegacyCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvyTW
 // CHECK-NEXT:    method #P1.ubgs!setter
-// CHECK-SAME:        : @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvsTW
+// CHECK-SAME:        : @$s17read_requirements29ImplALegacyCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvsTW
 // CHECK-NEXT:    method #P1.ubgs!modify
-// CHECK-SAME:        : @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvMTW
+// CHECK-SAME:        : @$s17read_requirements29ImplALegacyCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvMTW
 // CHECK-NEXT:    method #P1.ubgs!yielding_mutate
-// CHECK-SAME:      : @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvxTW
+// CHECK-SAME:      : @$s17read_requirements29ImplALegacyCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvxTW
 // CHECK-NEXT:  }
 
-// CHECK-LABEL: sil_witness_table{{.*}} ImplBUnderscoredCoroutineAccessors: P2 module read_requirements {
+// CHECK-LABEL: sil_witness_table{{.*}} ImplBLegacyCoroutineAccessors: P2 module read_requirements {
 // CHECK-unstable:    method #P2.urs!read
 // CHECK-NEXT:    method #P2.urs!yielding_borrow
-// CHECK-SAME:      : @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvyTW
+// CHECK-SAME:      : @$s17read_requirements29ImplBLegacyCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvyTW
 // CHECK-NEXT:    method #P2.urs!setter
-// CHECK-SAME:        : @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvsTW
+// CHECK-SAME:        : @$s17read_requirements29ImplBLegacyCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvsTW
 // CHECK-unstable:    method #P2.urs!modify
 // CHECK-NEXT:    method #P2.urs!yielding_mutate
-// CHECK-SAME:      : @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvxTW
+// CHECK-SAME:      : @$s17read_requirements29ImplBLegacyCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvxTW
 // CHECK-NEXT:  }
 
-// CHECK-LABEL: sil_witness_table{{.*}} ImplCUnderscoredCoroutineAccessors: P3 module read_requirements {
+// CHECK-LABEL: sil_witness_table{{.*}} ImplCLegacyCoroutineAccessors: P3 module read_requirements {
 // CHECK-NEXT:    method #P3.ur!read
-// CHECK-SAME:        : @$s17read_requirements34ImplCUnderscoredCoroutineAccessorsVAA2P3A2aDP2urAA1UVvrTW
+// CHECK-SAME:        : @$s17read_requirements29ImplCLegacyCoroutineAccessorsVAA2P3A2aDP2urAA1UVvrTW
 // CHECK-NEXT:    method #P3.ur!yielding_borrow
-// CHECK-SAME:      : @$s17read_requirements34ImplCUnderscoredCoroutineAccessorsVAA2P3A2aDP2urAA1UVvyTW
+// CHECK-SAME:      : @$s17read_requirements29ImplCLegacyCoroutineAccessorsVAA2P3A2aDP2urAA1UVvyTW
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplACoroutineAccessors: P1 module read_requirements {

--- a/test/SILGen/read_requirements.swift
+++ b/test/SILGen/read_requirements.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -Xllvm -sil-print-types %s -enable-callee-allocated-coro-abi -enable-library-evolution -enable-experimental-feature CoroutineAccessors
+
 // RUN: %target-swift-emit-silgen -Xllvm -sil-print-types   \
 // RUN:     %s                                              \
 // RUN:     -enable-callee-allocated-coro-abi               \
@@ -34,6 +35,12 @@ public struct U : ~Copyable {}
 public protocol P1 : ~Copyable {
   @_borrowed
   var ubgs: U { get set }
+
+// A `{ get set }` protocol requirement builds default yielding_borrow/yielding_mutate
+// thunks that dispatch to conformer-provided _read/_modify implementations.
+// New conformers override these with the real implementations and provide
+// _read/_modify thunks.
+
 // CHECK-LABEL: sil {{.*}} [ossa] @$s17read_requirements2P1P4ubgsAA1UVvy : {{.*}} {
 // CHECK:      bb0(
 // CHECK-SAME:     [[SELF_UNCHECKED:%[^:]+]]
@@ -45,8 +52,8 @@ public protocol P1 : ~Copyable {
 // CHECK:        [[VALUE_COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[VALUE_COPY_UNCHECKED]]
 // CHECK:        [[VALUE_BORROW:%[^,]+]] = begin_borrow [[VALUE_COPY]]
 // CHECK:        yield [[VALUE_BORROW:%[^,]+]]
-// CHECK:            resume [[SUCCESS:bb[0-9]+]]
-// CHECK:            unwind [[FAILURE:bb[0-9]+]]
+// CHECK-SAME:            resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:            unwind [[FAILURE:bb[0-9]+]]
 // CHECK:      [[SUCCESS]]:
 // CHECK:        end_borrow [[VALUE_BORROW]]
 // CHECK:        destroy_value [[VALUE_COPY]]
@@ -68,8 +75,8 @@ public protocol P1 : ~Copyable {
 // CHECK:         ([[VALUE_UNCHECKED:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[MODIFIER]]<Self>([[SELF_ACCESS]])
 // CHECK:         [[VALUE:%[^,]+]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[VALUE_UNCHECKED]]
 // CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:             unwind [[FAILURE:bb[0-9]+]]
 // CHECK:       [[SUCCESS]]:
 // CHECK:         end_apply [[TOKEN]]
 // CHECK:         end_access [[SELF_ACCESS]]
@@ -79,12 +86,33 @@ public protocol P1 : ~Copyable {
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements2P1P4ubgsAA1UVvx'
 }
+
 @available(SwiftStdlib 9999, *)
 public protocol P2 : ~Copyable {
   var urs: U { yielding borrow set }
+
+// A `{ yielding borrow set }` protocol requirement builds default
+// yielding_borrow/yielding_mutate thunks that dispatch to conformer-provided
+// _read/_modify implementations.
+// New conformers override these with the real implementations and provide
+// _read/_modify thunks.
+
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements2P2P3ursAA1UVvy : $@yield_once_2
+
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements2P2P3ursAA1UVvx : $@yield_once_2    
 }
+
+
 @available(SwiftStdlib 6.0, *)
 public protocol P3 : ~Copyable {
+  var ur: U { yielding borrow }
+
+// A `{ yielding borrow }` protocol requirement builds a default
+// yielding_borrow thunks that dispatches to conformer-provided
+// _read implementations.
+// New conformers override these with the real implementations and provide
+// _read thunks.
+
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements2P3P2urAA1UVvy : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF_UNCHECKED:%[^:]+]]
@@ -96,8 +124,8 @@ public protocol P3 : ~Copyable {
 // CHECK:         [[VALUE:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[VALUE_COPY]]
 // CHECK:         [[VALUE_BORROW:%[^,]+]] = begin_borrow [[VALUE]]
 // CHECK:         yield [[VALUE_BORROW:%[^,]+]]
-// CHECK:             resume [[BASIC_BLOCK1:bb[0-9]+]]
-// CHECK:             unwind [[BASIC_BLOCK2:bb[0-9]+]]
+// CHECK-SAME:             resume [[BASIC_BLOCK1:bb[0-9]+]]
+// CHECK-SAME:             unwind [[BASIC_BLOCK2:bb[0-9]+]]
 // CHECK:       [[BASIC_BLOCK1]]:
 // CHECK:         end_borrow [[VALUE_BORROW]]
 // CHECK:         destroy_value [[VALUE]]
@@ -108,33 +136,43 @@ public protocol P3 : ~Copyable {
 // CHECK:         end_apply [[TOKEN]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements2P3P2urAA1UVvy'
-  var ur: U { yielding borrow }
 }
 
 @frozen
 public struct ImplAStored : ~Copyable & P1 {
   public var ubgs: U
-// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplAStoredV4ubgsAA1UVvr : {{.*}} {
-// CHECK:       bb0(
-// CHECK-SAME:      [[SELF:%[^:]+]]
-// CHECK-SAME:  ):
-// CHECK:         [[COPY_UNCHECKED:%[^,]+]] = copy_value [[SELF]]
-// CHECK:         [[COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[COPY_UNCHECKED]]
-// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[COPY]]
-// CHECK:         [[VALUE:%[^,]+]] = struct_extract [[BORROW]]
-// CHECK-SAME:        #ImplAStored.ubgs
-// CHECK:         yield [[VALUE]]
-// CHECK-SAME:        resume [[SUCCESS:bb[0-9]+]]
-// CHECK-SAME:        unwind [[FAILURE:bb[0-9]+]]
-// CHECK:       [[SUCCESS]]:
-// CHECK:         end_borrow [[BORROW]]
-// CHECK:         destroy_value [[COPY]]
-// CHECK:         return
-// CHECK:       [[FAILURE]]:
-// CHECK:         end_borrow [[BORROW]]
-// CHECK:         destroy_value [[COPY]]
-// CHECK:         unwind
-// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplAStoredV4ubgsAA1UVvr'
+// ImplAStored is a plain stored property, so it doesn't naturally need the
+// legacy `!read` accessor -- it exists only as an on-demand witness for P1's
+// unconditionally-required slot.  On an ABI-stable platform it's emitted
+// eagerly, right before yielding_borrow, so this exhaustive check is
+// stable-only.  On a non-ABI-stable platform it's deferred until right after
+// the witness thunk that needs it instead; its existence there is still
+// verified, just not by this exhaustive FileCheck block: the witness thunk's
+// own check below requires a function_ref to it, and the -sil-verify-all RUN
+// line above would fail if it had no body.
+
+// CHECK-stable-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplAStoredV4ubgsAA1UVvr : {{.*}} {
+// CHECK-stable:       bb0(
+// CHECK-stable-SAME:      [[SELF:%[^:]+]]
+// CHECK-stable-SAME:  ):
+// CHECK-stable:         [[COPY_UNCHECKED:%[^,]+]] = copy_value [[SELF]]
+// CHECK-stable:         [[COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[COPY_UNCHECKED]]
+// CHECK-stable:         [[BORROW:%[^,]+]] = begin_borrow [[COPY]]
+// CHECK-stable:         [[VALUE:%[^,]+]] = struct_extract [[BORROW]]
+// CHECK-stable-SAME:        #ImplAStored.ubgs
+// CHECK-stable:         yield [[VALUE]]
+// CHECK-stable-SAME:        resume [[SUCCESS:bb[0-9]+]]
+// CHECK-stable-SAME:        unwind [[FAILURE:bb[0-9]+]]
+// CHECK-stable:       [[SUCCESS]]:
+// CHECK-stable:         end_borrow [[BORROW]]
+// CHECK-stable:         destroy_value [[COPY]]
+// CHECK-stable:         return
+// CHECK-stable:       [[FAILURE]]:
+// CHECK-stable:         end_borrow [[BORROW]]
+// CHECK-stable:         destroy_value [[COPY]]
+// CHECK-stable:         unwind
+// CHECK-stable-LABEL: } // end sil function '$s17read_requirements11ImplAStoredV4ubgsAA1UVvr'
+
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplAStoredV4ubgsAA1UVvy : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF:%[^:]+]]
@@ -156,6 +194,7 @@ public struct ImplAStored : ~Copyable & P1 {
 // CHECK:         destroy_value [[COPY]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements11ImplAStoredV4ubgsAA1UVvy'
+
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplAStoredVAA2P1A2aDP4ubgsAA1UVvrTW : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
@@ -175,6 +214,12 @@ public struct ImplAStored : ~Copyable & P1 {
 // CHECK:         end_borrow [[SELF]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements11ImplAStoredVAA2P1A2aDP4ubgsAA1UVvrTW'
+
+// Annoyingly, on a non-ABI-stable platform !read is emitted in a different
+// order.  Just check the signature exists here.
+
+// CHECK-unstable-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplAStoredV4ubgsAA1UVvr : {{.*}} {
+
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplAStoredVAA2P1A2aDP4ubgsAA1UVvyTW : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF_ADDR:%[^,]+]] :
@@ -183,8 +228,8 @@ public struct ImplAStored : ~Copyable & P1 {
 // CHECK:         [[READ2ER:%[^,]+]] = function_ref @$s17read_requirements11ImplAStoredV4ubgsAA1UVvy
 // CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[SELF]])
 // CHECK:         yield [[VALUE:%[^,]+]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:             unwind [[FAILURE:bb[0-9]+]]
 // CHECK:       bb1:
 // CHECK:         end_apply [[TOKEN]]
 // CHECK:         dealloc_stack [[ALLOCATION]]
@@ -203,6 +248,7 @@ public struct ImplAStored : ~Copyable & P1 {
 public struct ImplBStored : ~Copyable & P2 {
   var dummy: ()
   public var urs: U
+
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplBStoredV3ursAA1UVvy : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF:%[^:]+]]
@@ -214,8 +260,8 @@ public struct ImplBStored : ~Copyable & P2 {
 // CHECK:         [[VALUE:%[^,]+]] = struct_extract [[BORROW]]
 // CHECK-SAME:        #ImplBStored.urs
 // CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:             unwind [[FAILURE:bb[0-9]+]]
 // CHECK:       [[SUCCESS]]:
 // CHECK:         end_borrow [[BORROW]]
 // CHECK:         destroy_value [[COPY]]
@@ -225,6 +271,7 @@ public struct ImplBStored : ~Copyable & P2 {
 // CHECK:         destroy_value [[COPY]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements11ImplBStoredV3ursAA1UVvy'
+
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvyTW : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
@@ -233,8 +280,8 @@ public struct ImplBStored : ~Copyable & P2 {
 // CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements11ImplBStoredV3ursAA1UVvy
 // CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[SELF]])
 // CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:             unwind [[FAILURE:bb[0-9]+]]
 // CHECK:       [[SUCCESS]]:
 // CHECK:         end_apply [[TOKEN]]
 // CHECK:         dealloc_stack [[ALLOCATION]]
@@ -253,27 +300,38 @@ public struct ImplBStored : ~Copyable & P2 {
 public struct ImplCStored : ~Copyable & P3 {
   var dummy: ()
   public var ur: U
-// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplCStoredV2urAA1UVvr : {{.*}} {
-// CHECK:       bb0(
-// CHECK-SAME:      [[SELF:%[^:]+]]
-// CHECK-SAME:  ):
-// CHECK:         [[COPY_UNCHECKED:%[^,]+]] = copy_value [[SELF]]
-// CHECK:         [[COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[COPY_UNCHECKED]]
-// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[COPY]]
-// CHECK:         [[VALUE:%[^,]+]] = struct_extract [[BORROW]]
-// CHECK-SAME:        #ImplCStored.ur
-// CHECK:         yield [[VALUE]]
-// CHECK-SAME:        resume [[SUCCESS:bb[0-9]+]]
-// CHECK-SAME:        unwind [[FAILURE:bb[0-9]+]]
-// CHECK:       [[SUCCESS]]:
-// CHECK:         end_borrow [[BORROW]]
-// CHECK:         destroy_value [[COPY]]
-// CHECK:         return
-// CHECK:       [[FAILURE]]:
-// CHECK:         end_borrow [[BORROW]]
-// CHECK:         destroy_value [[COPY]]
-// CHECK:         unwind
-// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplCStoredV2urAA1UVvr'
+// ImplCStored is a plain stored property, so it doesn't naturally need the
+// legacy `!read` accessor -- it exists only as an on-demand witness for P3's
+// unconditionally-required slot.  On an ABI-stable platform it's emitted
+// eagerly, right before yielding_borrow, so this exhaustive check is
+// stable-only.  On a non-ABI-stable platform it's deferred until right after
+// the witness thunk that needs it instead; its existence there is still
+// verified, just not by this exhaustive FileCheck block: the witness thunk's
+// own check below requires a function_ref to it, and the -sil-verify-all RUN
+// line above would fail if it had no body.
+
+// CHECK-stable-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplCStoredV2urAA1UVvr : {{.*}} {
+// CHECK-stable:       bb0(
+// CHECK-stable-SAME:      [[SELF:%[^:]+]]
+// CHECK-stable-SAME:  ):
+// CHECK-stable:         [[COPY_UNCHECKED:%[^,]+]] = copy_value [[SELF]]
+// CHECK-stable:         [[COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[COPY_UNCHECKED]]
+// CHECK-stable:         [[BORROW:%[^,]+]] = begin_borrow [[COPY]]
+// CHECK-stable:         [[VALUE:%[^,]+]] = struct_extract [[BORROW]]
+// CHECK-stable-SAME:        #ImplCStored.ur
+// CHECK-stable:         yield [[VALUE]]
+// CHECK-stable-SAME:        resume [[SUCCESS:bb[0-9]+]]
+// CHECK-stable-SAME:        unwind [[FAILURE:bb[0-9]+]]
+// CHECK-stable:       [[SUCCESS]]:
+// CHECK-stable:         end_borrow [[BORROW]]
+// CHECK-stable:         destroy_value [[COPY]]
+// CHECK-stable:         return
+// CHECK-stable:       [[FAILURE]]:
+// CHECK-stable:         end_borrow [[BORROW]]
+// CHECK-stable:         destroy_value [[COPY]]
+// CHECK-stable:         unwind
+// CHECK-stable-LABEL: } // end sil function '$s17read_requirements11ImplCStoredV2urAA1UVvr'
+
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplCStoredV2urAA1UVvy : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF:%[^:]+]]
@@ -295,6 +353,7 @@ public struct ImplCStored : ~Copyable & P3 {
 // CHECK:         destroy_value [[COPY]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements11ImplCStoredV2urAA1UVvy'
+
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplCStoredVAA2P3A2aDP2urAA1UVvrTW : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
@@ -303,8 +362,8 @@ public struct ImplCStored : ~Copyable & P3 {
 // CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements11ImplCStoredV2urAA1UVvr
 // CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF]])
 // CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:             unwind [[FAILURE:bb[0-9]+]]
 // CHECK:       [[SUCCESS]]:
 // CHECK:         end_apply [[TOKEN]]
 // CHECK:         end_borrow [[SELF]]
@@ -314,6 +373,11 @@ public struct ImplCStored : ~Copyable & P3 {
 // CHECK:         end_borrow [[SELF]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements11ImplCStoredVAA2P3A2aDP2urAA1UVvrTW'
+
+// On a non-ABI-stable platform !read is deferred to exactly this point --
+// confirm at least its signature, since the exhaustive check above is
+// stable-only.
+// CHECK-unstable-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplCStoredV2urAA1UVvr : {{.*}} {
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplCStoredVAA2P3A2aDP2urAA1UVvyTW : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
@@ -322,8 +386,8 @@ public struct ImplCStored : ~Copyable & P3 {
 // CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements11ImplCStoredV2urAA1UVvy
 // CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[SELF]])
 // CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:             unwind [[FAILURE:bb[0-9]+]]
 // CHECK:       [[SUCCESS]]:
 // CHECK:         end_apply [[TOKEN]]
 // CHECK:         dealloc_stack [[ALLOCATION]]
@@ -428,8 +492,8 @@ struct ImplACoroutineAccessors : ~Copyable & P1 {
 // CHECK:         [[VALUE:%[^,]+]] = struct_extract [[BORROW]]
 // CHECK:             #ImplACoroutineAccessors._i
 // CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:             unwind [[FAILURE:bb[0-9]+]]
 // CHECK:       [[SUCCESS]]:
 // CHECK:         end_borrow [[BORROW]]
 // CHECK:         destroy_value [[COPY]]
@@ -471,8 +535,8 @@ struct ImplACoroutineAccessors : ~Copyable & P1 {
 // CHECK:         [[VALUE_COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[VALUE_COPY_UNCHECKED]]
 // CHECK:         [[VALUE_BORROW:%[^,]+]] = begin_borrow [[VALUE_COPY]]
 // CHECK:         yield [[VALUE_BORROW]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:             unwind [[FAILURE:bb[0-9]+]]
 // CHECK:       [[SUCCESS]]:
 // CHECK:         end_borrow [[VALUE_BORROW]]
 // CHECK:         destroy_value [[VALUE_COPY]]
@@ -498,8 +562,8 @@ struct ImplACoroutineAccessors : ~Copyable & P1 {
 // CHECK:         [[READ2ER:%[^,]+]] = function_ref @$s17read_requirements23ImplACoroutineAccessorsV4ubgsAA1UVvy
 // CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[SELF]])
 // CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:             unwind [[FAILURE:bb[0-9]+]]
 // CHECK:       [[SUCCESS]]:
 // CHECK:         end_apply [[TOKEN]]
 // CHECK:         dealloc_stack [[ALLOCATION]]
@@ -535,8 +599,8 @@ public struct ImplBCoroutineAccessors : ~Copyable & P2 {
 // CHECK:         [[VALUE:%[^,]+]] = struct_extract [[BORROW]] : $ImplBCoroutineAccessors
 // CHECK:             #ImplBCoroutineAccessors._i
 // CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:             unwind [[FAILURE:bb[0-9]+]]
 // CHECK:       [[SUCCESS]]:
 // CHECK:         end_borrow [[BORROW]]
 // CHECK:         destroy_value [[COPY]]
@@ -554,8 +618,8 @@ public struct ImplBCoroutineAccessors : ~Copyable & P2 {
 // CHECK:         [[READ2ER:%[^,]+]] = function_ref @$s17read_requirements23ImplBCoroutineAccessorsV3ursAA1UVvy
 // CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[SELF]])
 // CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:             unwind [[FAILURE:bb[0-9]+]]
 // CHECK:       [[SUCCESS]]:
 // CHECK:         end_apply [[TOKEN]]
 // CHECK:         dealloc_stack [[ALLOCATION]]
@@ -588,8 +652,8 @@ public struct ImplCCoroutineAccessors : ~Copyable & P3 {
 // CHECK:         [[VALUE:%[^,]+]] = struct_extract [[BORROW]]
 // CHECK-SAME:        #ImplCCoroutineAccessors._i
 // CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:             unwind [[FAILURE:bb[0-9]+]]
 // CHECK:       [[SUCCESS]]:
 // CHECK:         end_borrow [[BORROW]]
 // CHECK:         destroy_value [[COPY]]
@@ -599,38 +663,47 @@ public struct ImplCCoroutineAccessors : ~Copyable & P3 {
 // CHECK:         destroy_value [[COPY]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements23ImplCCoroutineAccessorsV2urAA1UVvy'
-// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements23ImplCCoroutineAccessorsV2urAA1UVvr : {{.*}} {
-// CHECK:       bb0(
-// CHECK-SAME:      [[SELF:%[^:]+]]
-// CHECK-SAME:  ):
-// CHECK:         [[COPY_UNCHECKED:%[^,]+]] = copy_value [[SELF:%[^,]+]]
-// CHECK:         [[COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[COPY_UNCHECKED]]
-// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[COPY]]
-// CHECK:         [[READ2ER:%[^,]+]] = function_ref @$s17read_requirements23ImplCCoroutineAccessorsV2urAA1UVvy
-// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[BORROW]])
-// CHECK:         [[VALUE_COPY_UNCHECKED:%[^,]+]] = copy_value [[VALUE:%[^,]+]]
-// CHECK:         [[VALUE_COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[VALUE_COPY_UNCHECKED]]
-// CHECK:         [[VALUE_BORROW:%[^,]+]] = begin_borrow [[VALUE_COPY]]
-// CHECK:         yield [[VALUE_BORROW]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
-// CHECK:       [[SUCCESS]]:
-// CHECK:         end_borrow [[VALUE_BORROW]]
-// CHECK:         destroy_value [[VALUE_COPY]]
-// CHECK:         end_apply [[TOKEN]]
-// CHECK:         dealloc_stack [[ALLOCATION]]
-// CHECK:         end_borrow [[BORROW]]
-// CHECK:         destroy_value [[COPY]]
-// CHECK:         return
-// CHECK:       [[FAILURE]]:
-// CHECK:         end_borrow [[VALUE_BORROW]]
-// CHECK:         destroy_value [[VALUE_COPY]]
-// CHECK:         end_apply [[TOKEN]]
-// CHECK:         dealloc_stack [[ALLOCATION]]
-// CHECK:         end_borrow [[BORROW]]
-// CHECK:         destroy_value [[COPY]]
-// CHECK:         unwind
-// CHECK-LABEL: } // end sil function '$s17read_requirements23ImplCCoroutineAccessorsV2urAA1UVvr'
+// ImplCCoroutineAccessors writes `ur` using `yielding borrow`, so `!yield`
+// (vy) is the primary implementation and this `!read` (vr) is only an
+// on-demand witness for P3's unconditionally-required legacy slot.  On an
+// ABI-stable platform it's emitted eagerly, right after vy, so this
+// exhaustive check is stable-only.  On a non-ABI-stable platform it's
+// deferred until right after the witness thunk that needs it instead; its
+// existence there is still verified, just not by this exhaustive FileCheck
+// block: the witness thunk's own check below requires a function_ref to it,
+// and the -sil-verify-all RUN line above would fail if it had no body.
+// CHECK-stable-LABEL: sil{{.*}} [ossa] @$s17read_requirements23ImplCCoroutineAccessorsV2urAA1UVvr : {{.*}} {
+// CHECK-stable:       bb0(
+// CHECK-stable-SAME:      [[SELF:%[^:]+]]
+// CHECK-stable-SAME:  ):
+// CHECK-stable:         [[COPY_UNCHECKED:%[^,]+]] = copy_value [[SELF:%[^,]+]]
+// CHECK-stable:         [[COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[COPY_UNCHECKED]]
+// CHECK-stable:         [[BORROW:%[^,]+]] = begin_borrow [[COPY]]
+// CHECK-stable:         [[READ2ER:%[^,]+]] = function_ref @$s17read_requirements23ImplCCoroutineAccessorsV2urAA1UVvy
+// CHECK-stable:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[BORROW]])
+// CHECK-stable:         [[VALUE_COPY_UNCHECKED:%[^,]+]] = copy_value [[VALUE:%[^,]+]]
+// CHECK-stable:         [[VALUE_COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[VALUE_COPY_UNCHECKED]]
+// CHECK-stable:         [[VALUE_BORROW:%[^,]+]] = begin_borrow [[VALUE_COPY]]
+// CHECK-stable:         yield [[VALUE_BORROW]]
+// CHECK-stable-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-stable-SAME:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-stable:       [[SUCCESS]]:
+// CHECK-stable:         end_borrow [[VALUE_BORROW]]
+// CHECK-stable:         destroy_value [[VALUE_COPY]]
+// CHECK-stable:         end_apply [[TOKEN]]
+// CHECK-stable:         dealloc_stack [[ALLOCATION]]
+// CHECK-stable:         end_borrow [[BORROW]]
+// CHECK-stable:         destroy_value [[COPY]]
+// CHECK-stable:         return
+// CHECK-stable:       [[FAILURE]]:
+// CHECK-stable:         end_borrow [[VALUE_BORROW]]
+// CHECK-stable:         destroy_value [[VALUE_COPY]]
+// CHECK-stable:         end_apply [[TOKEN]]
+// CHECK-stable:         dealloc_stack [[ALLOCATION]]
+// CHECK-stable:         end_borrow [[BORROW]]
+// CHECK-stable:         destroy_value [[COPY]]
+// CHECK-stable:         unwind
+// CHECK-stable-LABEL: } // end sil function '$s17read_requirements23ImplCCoroutineAccessorsV2urAA1UVvr'
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements23ImplCCoroutineAccessorsVAA2P3A2aDP2urAA1UVvrTW : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
@@ -650,6 +723,10 @@ public struct ImplCCoroutineAccessors : ~Copyable & P3 {
 // CHECK:         end_borrow [[SELF]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements23ImplCCoroutineAccessorsVAA2P3A2aDP2urAA1UVvrTW'
+// On a non-ABI-stable platform !read is deferred to exactly this point --
+// confirm at least its signature, since the exhaustive check above is
+// stable-only.
+// CHECK-unstable-LABEL: sil{{.*}} [ossa] @$s17read_requirements23ImplCCoroutineAccessorsV2urAA1UVvr : {{.*}} {
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements23ImplCCoroutineAccessorsVAA2P3A2aDP2urAA1UVvyTW : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
@@ -658,8 +735,8 @@ public struct ImplCCoroutineAccessors : ~Copyable & P3 {
 // CHECK:         [[READ2ER:%[^,]+]] = function_ref @$s17read_requirements23ImplCCoroutineAccessorsV2urAA1UVvy
 // CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[SELF]])
 // CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:             unwind [[FAILURE:bb[0-9]+]]
 // CHECK:       [[SUCCESS]]:
 // CHECK:         end_apply [[TOKEN]]
 // CHECK:         dealloc_stack [[ALLOCATION]]
@@ -695,25 +772,34 @@ public struct ImplAGetSet : P1 {
 // CHECK:         [[VALUE:%[^,]+]] = apply [[_I_GETTER]]([[SELF]])
 // CHECK:         return [[VALUE]]
 // CHECK-LABEL: } // end sil function '$s17read_requirements11ImplAGetSetV4ubgsAA1UVvg'
-// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplAGetSetV4ubgsAA1UVvr : {{.*}} {
-// CHECK:       bb0(
-// CHECK-SAME:      [[SELF:%[^:]+]] :
-// CHECK-SAME:  ):
-// CHECK:         [[GETTER:%[^,]+]] = function_ref @$s17read_requirements11ImplAGetSetV4ubgsAA1UVvg
-// CHECK:         [[VALUE:%[^,]+]] = apply [[GETTER]]([[SELF]])
-// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[VALUE]]
-// CHECK:         yield [[BORROW]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
-// CHECK:       [[SUCCESS]]:
-// CHECK:         end_borrow [[BORROW]]
-// CHECK:         destroy_value [[VALUE]]
-// CHECK:         return
-// CHECK:       [[FAILURE]]:
-// CHECK:         end_borrow [[BORROW]]
-// CHECK:         destroy_value [[VALUE]]
-// CHECK:         unwind
-// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplAGetSetV4ubgsAA1UVvr'
+// ImplAGetSet implements `ubgs` with a plain get/set, so it doesn't naturally
+// need the legacy `!read` accessor -- it exists only as an on-demand witness
+// for P1's unconditionally-required slot.  On an ABI-stable platform it's
+// emitted eagerly, right after the getter, so this exhaustive check is
+// stable-only.  On a non-ABI-stable platform it's deferred until right after
+// the witness thunk that needs it instead; its existence there is still
+// verified, just not by this exhaustive FileCheck block: the witness thunk's
+// own check below requires a function_ref to it, and the -sil-verify-all RUN
+// line above would fail if it had no body.
+// CHECK-stable-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplAGetSetV4ubgsAA1UVvr : {{.*}} {
+// CHECK-stable:       bb0(
+// CHECK-stable-SAME:      [[SELF:%[^:]+]] :
+// CHECK-stable-SAME:  ):
+// CHECK-stable:         [[GETTER:%[^,]+]] = function_ref @$s17read_requirements11ImplAGetSetV4ubgsAA1UVvg
+// CHECK-stable:         [[VALUE:%[^,]+]] = apply [[GETTER]]([[SELF]])
+// CHECK-stable:         [[BORROW:%[^,]+]] = begin_borrow [[VALUE]]
+// CHECK-stable:         yield [[BORROW]]
+// CHECK-stable-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-stable-SAME:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-stable:       [[SUCCESS]]:
+// CHECK-stable:         end_borrow [[BORROW]]
+// CHECK-stable:         destroy_value [[VALUE]]
+// CHECK-stable:         return
+// CHECK-stable:       [[FAILURE]]:
+// CHECK-stable:         end_borrow [[BORROW]]
+// CHECK-stable:         destroy_value [[VALUE]]
+// CHECK-stable:         unwind
+// CHECK-stable-LABEL: } // end sil function '$s17read_requirements11ImplAGetSetV4ubgsAA1UVvr'
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplAGetSetV4ubgsAA1UVvy : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF:%[^:]+]] :
@@ -722,8 +808,8 @@ public struct ImplAGetSet : P1 {
 // CHECK:         [[VALUE:%[^,]+]] = apply [[GETTER]]([[SELF]])
 // CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[VALUE]]
 // CHECK:         yield [[BORROW]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:             unwind [[FAILURE:bb[0-9]+]]
 // CHECK:       [[SUCCESS]]:
 // CHECK:         end_borrow [[BORROW]]
 // CHECK:         destroy_value [[VALUE]]
@@ -741,8 +827,8 @@ public struct ImplAGetSet : P1 {
 // CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements11ImplAGetSetV4ubgsAA1UVvr
 // CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF]])
 // CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:             unwind [[FAILURE:bb[0-9]+]]
 // CHECK:       [[SUCCESS]]:
 // CHECK:         end_apply [[TOKEN]]
 // CHECK:         return
@@ -750,6 +836,10 @@ public struct ImplAGetSet : P1 {
 // CHECK:         abort_apply [[TOKEN]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements11ImplAGetSetVAA2P1A2aDP4ubgsAA1UVvrTW'
+// On a non-ABI-stable platform !read is deferred to exactly this point --
+// confirm at least its signature, since the exhaustive check above is
+// stable-only.
+// CHECK-unstable-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplAGetSetV4ubgsAA1UVvr : {{.*}} {
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplAGetSetVAA2P1A2aDP4ubgsAA1UVvyTW : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
@@ -758,8 +848,8 @@ public struct ImplAGetSet : P1 {
 // CHECK:         [[READ2ER:%[^,]+]] = function_ref @$s17read_requirements11ImplAGetSetV4ubgsAA1UVvy
 // CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[SELF]])
 // CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:             unwind [[FAILURE:bb[0-9]+]]
 // CHECK:       [[SUCCESS]]:
 // CHECK:         end_apply [[TOKEN]]
 // CHECK:         dealloc_stack [[ALLOCATION]]
@@ -802,8 +892,8 @@ public struct ImplBGetSet : P2 {
 // CHECK:         [[VALUE:%[^,]+]] = apply [[GETTER]]([[SELF]])
 // CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[VALUE]]
 // CHECK:         yield [[BORROW]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:             unwind [[FAILURE:bb[0-9]+]]
 // CHECK:       [[SUCCESS]]:
 // CHECK:         end_borrow [[BORROW]]
 // CHECK:         destroy_value [[VALUE]]
@@ -821,8 +911,8 @@ public struct ImplBGetSet : P2 {
 // CHECK:         [[READ2ER:%[^,]+]] = function_ref @$s17read_requirements11ImplBGetSetV3ursAA1UVvy
 // CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[SELF]])
 // CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:             unwind [[FAILURE:bb[0-9]+]]
 // CHECK:       [[SUCCESS]]:
 // CHECK:         end_apply [[TOKEN]]
 // CHECK:         dealloc_stack [[ALLOCATION]]
@@ -854,25 +944,34 @@ public struct ImplCGetSet : P3 {
 // CHECK:         [[VALUE:%[^,]+]] = apply [[_I_GETTER]]([[SELF]])
 // CHECK:         return [[VALUE]]
 // CHECK-LABEL: } // end sil function '$s17read_requirements11ImplCGetSetV2urAA1UVvg'
-// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplCGetSetV2urAA1UVvr : {{.*}} {
-// CHECK:       bb0(
-// CHECK-SAME:      [[SELF:%[^:]+]] :
-// CHECK-SAME:  ):
-// CHECK:         [[GETTER:%[^,]+]] = function_ref @$s17read_requirements11ImplCGetSetV2urAA1UVvg
-// CHECK:         [[VALUE:%[^,]+]] = apply [[GETTER]]([[SELF]])
-// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[VALUE]]
-// CHECK:         yield [[BORROW]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
-// CHECK:       [[SUCCESS]]:
-// CHECK:         end_borrow [[BORROW]]
-// CHECK:         destroy_value [[VALUE]]
-// CHECK:         return
-// CHECK:       [[FAILURE]]:
-// CHECK:         end_borrow [[BORROW]]
-// CHECK:         destroy_value [[VALUE]]
-// CHECK:         unwind
-// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplCGetSetV2urAA1UVvr'
+// ImplCGetSet implements `ur` with a plain get, so it doesn't naturally need
+// the legacy `!read` accessor -- it exists only as an on-demand witness for
+// P3's unconditionally-required slot.  On an ABI-stable platform it's
+// emitted eagerly, right after the getter, so this exhaustive check is
+// stable-only.  On a non-ABI-stable platform it's deferred until right after
+// the witness thunk that needs it instead; its existence there is still
+// verified, just not by this exhaustive FileCheck block: the witness thunk's
+// own check below requires a function_ref to it, and the -sil-verify-all RUN
+// line above would fail if it had no body.
+// CHECK-stable-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplCGetSetV2urAA1UVvr : {{.*}} {
+// CHECK-stable:       bb0(
+// CHECK-stable-SAME:      [[SELF:%[^:]+]] :
+// CHECK-stable-SAME:  ):
+// CHECK-stable:         [[GETTER:%[^,]+]] = function_ref @$s17read_requirements11ImplCGetSetV2urAA1UVvg
+// CHECK-stable:         [[VALUE:%[^,]+]] = apply [[GETTER]]([[SELF]])
+// CHECK-stable:         [[BORROW:%[^,]+]] = begin_borrow [[VALUE]]
+// CHECK-stable:         yield [[BORROW]]
+// CHECK-stable-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-stable-SAME:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-stable:       [[SUCCESS]]:
+// CHECK-stable:         end_borrow [[BORROW]]
+// CHECK-stable:         destroy_value [[VALUE]]
+// CHECK-stable:         return
+// CHECK-stable:       [[FAILURE]]:
+// CHECK-stable:         end_borrow [[BORROW]]
+// CHECK-stable:         destroy_value [[VALUE]]
+// CHECK-stable:         unwind
+// CHECK-stable-LABEL: } // end sil function '$s17read_requirements11ImplCGetSetV2urAA1UVvr'
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplCGetSetV2urAA1UVvy : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF:%[^:]+]] :
@@ -881,8 +980,8 @@ public struct ImplCGetSet : P3 {
 // CHECK:         [[VALUE:%[^,]+]] = apply [[GETTER]]([[SELF]])
 // CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[VALUE]]
 // CHECK:         yield [[BORROW]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:             unwind [[FAILURE:bb[0-9]+]]
 // CHECK:       [[SUCCESS]]:
 // CHECK:         end_borrow [[BORROW]]
 // CHECK:         destroy_value [[VALUE]]
@@ -900,8 +999,8 @@ public struct ImplCGetSet : P3 {
 // CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements11ImplCGetSetV2urAA1UVvr
 // CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF]])
 // CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:             unwind [[FAILURE:bb[0-9]+]]
 // CHECK:       [[SUCCESS]]:
 // CHECK:         end_apply [[TOKEN]]
 // CHECK:         return
@@ -909,6 +1008,10 @@ public struct ImplCGetSet : P3 {
 // CHECK:         abort_apply [[TOKEN]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements11ImplCGetSetVAA2P3A2aDP2urAA1UVvrTW'
+// On a non-ABI-stable platform !read is deferred to exactly this point --
+// confirm at least its signature, since the exhaustive check above is
+// stable-only.
+// CHECK-unstable-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplCGetSetV2urAA1UVvr : {{.*}} {
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplCGetSetVAA2P3A2aDP2urAA1UVvyTW : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF_ADDR:%[^:]+]] :
@@ -917,8 +1020,8 @@ public struct ImplCGetSet : P3 {
 // CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements11ImplCGetSetV2urAA1UVvy
 // CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[SELF]])
 // CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:             unwind [[FAILURE:bb[0-9]+]]
 // CHECK:       [[SUCCESS]]:
 // CHECK:         end_apply [[TOKEN]]
 // CHECK:         dealloc_stack [[ALLOCATION]]
@@ -952,30 +1055,40 @@ public struct ImplAUnsafeAddressors : P1 {
 // CHECK:             #ImplAUnsafeAddressors.iAddr
 // CHECK:         return [[UNSAFE_POINTER]]
 // CHECK-LABEL: } // end sil function '$s17read_requirements21ImplAUnsafeAddressorsV4ubgsAA1UVvlu'
-// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements21ImplAUnsafeAddressorsV4ubgsAA1UVvr : {{.*}} {
-// CHECK:       bb0(
-// CHECK-SAME:      [[SELF:%[^:]+]] :
-// CHECK-SAME:  ):
-// CHECK:         [[UNSAFE_ADDRESSOR:%[^,]+]] = function_ref @$s17read_requirements21ImplAUnsafeAddressorsV4ubgsAA1UVvlu
-// CHECK:         [[UNSAFE_POINTER:%[^,]+]] = apply [[UNSAFE_ADDRESSOR]]([[SELF]])
-// CHECK:         [[RAW_POINTER:%[^,]+]] = struct_extract [[UNSAFE_POINTER]] : $UnsafePointer<U>, #UnsafePointer._rawValue
-// CHECK:         [[ADDR:%[^,]+]] = pointer_to_address [[RAW_POINTER]]
-// CHECK:         [[MD:%.*]] = mark_dependence [unresolved] [[ADDR]] : $*U on [[SELF]]
-// CHECK:         [[ACCESS_UNCHECKED:%[^,]+]] = begin_access [read] [unsafe] [[MD]]
-// CHECK:         [[ACCESS:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[ACCESS_UNCHECKED]]
-// CHECK:         [[VALUE:%[^,]+]] = load [copy] [[ACCESS]]
-// CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
-// CHECK:       [[SUCCESS]]:
-// CHECK:         destroy_value [[VALUE]]
-// CHECK:         end_access [[ACCESS_UNCHECKED]]
-// CHECK:         return
-// CHECK:       [[FAILURE]]:
-// CHECK:         destroy_value [[VALUE]]
-// CHECK:         end_access [[ACCESS_UNCHECKED]]
-// CHECK:         unwind
-// CHECK-LABEL: } // end sil function '$s17read_requirements21ImplAUnsafeAddressorsV4ubgsAA1UVvr'
+// ImplAUnsafeAddressors implements `ubgs` with unsafeAddress/unsafeMutable-
+// Address, so it doesn't naturally need the legacy `!read` accessor -- it
+// exists only as an on-demand witness for P1's unconditionally-required
+// slot.  On an ABI-stable platform it's emitted eagerly, right after the
+// unsafe addressor, so this exhaustive check is stable-only.  On a
+// non-ABI-stable platform it's deferred until right after the witness thunk
+// that needs it instead; its existence there is still verified, just not by
+// this exhaustive FileCheck block: the witness thunk's own check below
+// requires a function_ref to it, and the -sil-verify-all RUN line above
+// would fail if it had no body.
+// CHECK-stable-LABEL: sil{{.*}} [ossa] @$s17read_requirements21ImplAUnsafeAddressorsV4ubgsAA1UVvr : {{.*}} {
+// CHECK-stable:       bb0(
+// CHECK-stable-SAME:      [[SELF:%[^:]+]] :
+// CHECK-stable-SAME:  ):
+// CHECK-stable:         [[UNSAFE_ADDRESSOR:%[^,]+]] = function_ref @$s17read_requirements21ImplAUnsafeAddressorsV4ubgsAA1UVvlu
+// CHECK-stable:         [[UNSAFE_POINTER:%[^,]+]] = apply [[UNSAFE_ADDRESSOR]]([[SELF]])
+// CHECK-stable:         [[RAW_POINTER:%[^,]+]] = struct_extract [[UNSAFE_POINTER]] : $UnsafePointer<U>, #UnsafePointer._rawValue
+// CHECK-stable:         [[ADDR:%[^,]+]] = pointer_to_address [[RAW_POINTER]]
+// CHECK-stable:         [[MD:%.*]] = mark_dependence [unresolved] [[ADDR]] : $*U on [[SELF]]
+// CHECK-stable:         [[ACCESS_UNCHECKED:%[^,]+]] = begin_access [read] [unsafe] [[MD]]
+// CHECK-stable:         [[ACCESS:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[ACCESS_UNCHECKED]]
+// CHECK-stable:         [[VALUE:%[^,]+]] = load [copy] [[ACCESS]]
+// CHECK-stable:         yield [[VALUE]]
+// CHECK-stable-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-stable-SAME:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-stable:       [[SUCCESS]]:
+// CHECK-stable:         destroy_value [[VALUE]]
+// CHECK-stable:         end_access [[ACCESS_UNCHECKED]]
+// CHECK-stable:         return
+// CHECK-stable:       [[FAILURE]]:
+// CHECK-stable:         destroy_value [[VALUE]]
+// CHECK-stable:         end_access [[ACCESS_UNCHECKED]]
+// CHECK-stable:         unwind
+// CHECK-stable-LABEL: } // end sil function '$s17read_requirements21ImplAUnsafeAddressorsV4ubgsAA1UVvr'
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements21ImplAUnsafeAddressorsV4ubgsAA1UVvy : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF:%[^:]+]] :
@@ -989,8 +1102,8 @@ public struct ImplAUnsafeAddressors : P1 {
 // CHECK:         [[ACCESS:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[ACCESS_UNCHECKED]]
 // CHECK:         [[VALUE:%[^,]+]] = load [copy] [[ACCESS]]
 // CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:             unwind [[FAILURE:bb[0-9]+]]
 // CHECK:       [[SUCCESS]]:
 // CHECK:         destroy_value [[VALUE]]
 // CHECK:         end_access [[ACCESS_UNCHECKED]]
@@ -1008,8 +1121,8 @@ public struct ImplAUnsafeAddressors : P1 {
 // CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements21ImplAUnsafeAddressorsV4ubgsAA1UVvr
 // CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF]])
 // CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:             unwind [[FAILURE:bb[0-9]+]]
 // CHECK:       [[SUCCESS]]:
 // CHECK:         end_apply [[TOKEN]]
 // CHECK:         return
@@ -1017,6 +1130,10 @@ public struct ImplAUnsafeAddressors : P1 {
 // CHECK:         abort_apply [[TOKEN]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements21ImplAUnsafeAddressorsVAA2P1A2aDP4ubgsAA1UVvrTW'
+// On a non-ABI-stable platform !read is deferred to exactly this point --
+// confirm at least its signature, since the exhaustive check above is
+// stable-only.
+// CHECK-unstable-LABEL: sil{{.*}} [ossa] @$s17read_requirements21ImplAUnsafeAddressorsV4ubgsAA1UVvr : {{.*}} {
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements21ImplAUnsafeAddressorsVAA2P1A2aDP4ubgsAA1UVvyTW : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF_ADDR:%[^:]+]] :
@@ -1025,8 +1142,8 @@ public struct ImplAUnsafeAddressors : P1 {
 // CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements21ImplAUnsafeAddressorsV4ubgsAA1UVvy
 // CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[SELF]])
 // CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:             unwind [[FAILURE:bb[0-9]+]]
 // CHECK:       [[SUCCESS]]:
 // CHECK:         end_apply [[TOKEN]]
 // CHECK:         dealloc_stack [[ALLOCATION]]
@@ -1075,8 +1192,8 @@ public struct ImplBUnsafeAddressors : P2 {
 // CHECK:         [[ACCESS:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[ACCESS_UNCHECKED]]
 // CHECK:         [[VALUE:%[^,]+]] = load [copy] [[ACCESS]]
 // CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:             unwind [[FAILURE:bb[0-9]+]]
 // CHECK:       [[SUCCESS]]:
 // CHECK:         destroy_value [[VALUE]]
 // CHECK:         end_access [[ACCESS_UNCHECKED]]
@@ -1094,8 +1211,8 @@ public struct ImplBUnsafeAddressors : P2 {
 // CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements21ImplBUnsafeAddressorsV3ursAA1UVvy
 // CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[SELF]])
 // CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:             unwind [[FAILURE:bb[0-9]+]]
 // CHECK:       [[SUCCESS]]:
 // CHECK:         end_apply [[TOKEN]]
 // CHECK:         dealloc_stack [[ALLOCATION]]
@@ -1130,31 +1247,41 @@ public struct ImplCUnsafeAddressors : P3 {
 // CHECK:             #ImplCUnsafeAddressors.iAddr
 // CHECK:         return [[UNSAFE_POINTER]]
 // CHECK-LABEL: } // end sil function '$s17read_requirements21ImplCUnsafeAddressorsV2urAA1UVvlu'
-// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements21ImplCUnsafeAddressorsV2urAA1UVvr : {{.*}} {
-// CHECK:       bb0(
-// CHECK-SAME:      [[SELF:%[^:]+]] :
-// CHECK-SAME:  ):
-// CHECK:         [[UNSAFE_ADDRESSOR:%[^,]+]] = function_ref @$s17read_requirements21ImplCUnsafeAddressorsV2urAA1UVvlu
-// CHECK:         [[UNSAFE_POINTER:%[^,]+]] = apply [[UNSAFE_ADDRESSOR]]([[SELF]])
-// CHECK:         [[RAW_POINTER:%[^,]+]] = struct_extract [[UNSAFE_POINTER]]
-// CHECK:             #UnsafePointer._rawValue
-// CHECK:         [[ADDR:%[^,]+]] = pointer_to_address [[RAW_POINTER]]
-// CHECK:         [[MD:%.*]] = mark_dependence [unresolved] [[ADDR]] : $*U on [[SELF]]
-// CHECK:         [[ACCESS_UNCHECKED:%[^,]+]] = begin_access [read] [unsafe] [[MD]]
-// CHECK:         [[ACCESS:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[ACCESS_UNCHECKED]]
-// CHECK:         [[VALUE:%[^,]+]] = load [copy] [[ACCESS]]
-// CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
-// CHECK:       [[SUCCESS]]:
-// CHECK:         destroy_value [[VALUE]]
-// CHECK:         end_access [[ACCESS_UNCHECKED]]
-// CHECK:         return
-// CHECK:       [[FAILURE]]:
-// CHECK:         destroy_value [[VALUE]]
-// CHECK:         end_access [[ACCESS_UNCHECKED]]
-// CHECK:         unwind
-// CHECK-LABEL: } // end sil function '$s17read_requirements21ImplCUnsafeAddressorsV2urAA1UVvr'
+// ImplCUnsafeAddressors implements `ur` with unsafeAddress/unsafeMutable-
+// Address, so it doesn't naturally need the legacy `!read` accessor -- it
+// exists only as an on-demand witness for P3's unconditionally-required
+// slot.  On an ABI-stable platform it's emitted eagerly, right after the
+// unsafe addressor, so this exhaustive check is stable-only.  On a
+// non-ABI-stable platform it's deferred until right after the witness thunk
+// that needs it instead; its existence there is still verified, just not by
+// this exhaustive FileCheck block: the witness thunk's own check below
+// requires a function_ref to it, and the -sil-verify-all RUN line above
+// would fail if it had no body.
+// CHECK-stable-LABEL: sil{{.*}} [ossa] @$s17read_requirements21ImplCUnsafeAddressorsV2urAA1UVvr : {{.*}} {
+// CHECK-stable:       bb0(
+// CHECK-stable-SAME:      [[SELF:%[^:]+]] :
+// CHECK-stable-SAME:  ):
+// CHECK-stable:         [[UNSAFE_ADDRESSOR:%[^,]+]] = function_ref @$s17read_requirements21ImplCUnsafeAddressorsV2urAA1UVvlu
+// CHECK-stable:         [[UNSAFE_POINTER:%[^,]+]] = apply [[UNSAFE_ADDRESSOR]]([[SELF]])
+// CHECK-stable:         [[RAW_POINTER:%[^,]+]] = struct_extract [[UNSAFE_POINTER]]
+// CHECK-stable:             #UnsafePointer._rawValue
+// CHECK-stable:         [[ADDR:%[^,]+]] = pointer_to_address [[RAW_POINTER]]
+// CHECK-stable:         [[MD:%.*]] = mark_dependence [unresolved] [[ADDR]] : $*U on [[SELF]]
+// CHECK-stable:         [[ACCESS_UNCHECKED:%[^,]+]] = begin_access [read] [unsafe] [[MD]]
+// CHECK-stable:         [[ACCESS:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[ACCESS_UNCHECKED]]
+// CHECK-stable:         [[VALUE:%[^,]+]] = load [copy] [[ACCESS]]
+// CHECK-stable:         yield [[VALUE]]
+// CHECK-stable-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-stable-SAME:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-stable:       [[SUCCESS]]:
+// CHECK-stable:         destroy_value [[VALUE]]
+// CHECK-stable:         end_access [[ACCESS_UNCHECKED]]
+// CHECK-stable:         return
+// CHECK-stable:       [[FAILURE]]:
+// CHECK-stable:         destroy_value [[VALUE]]
+// CHECK-stable:         end_access [[ACCESS_UNCHECKED]]
+// CHECK-stable:         unwind
+// CHECK-stable-LABEL: } // end sil function '$s17read_requirements21ImplCUnsafeAddressorsV2urAA1UVvr'
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements21ImplCUnsafeAddressorsV2urAA1UVvy : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF:%[^:]+]] :
@@ -1169,8 +1296,8 @@ public struct ImplCUnsafeAddressors : P3 {
 // CHECK:         [[ACCESS:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[ACCESS_UNCHECKED]]
 // CHECK:         [[VALUE:%[^,]+]] = load [copy] [[ACCESS]]
 // CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:             unwind [[FAILURE:bb[0-9]+]]
 // CHECK:       [[SUCCESS]]:
 // CHECK:         destroy_value [[VALUE]]
 // CHECK:         end_access [[ACCESS_UNCHECKED]]
@@ -1188,8 +1315,8 @@ public struct ImplCUnsafeAddressors : P3 {
 // CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements21ImplCUnsafeAddressorsV2urAA1UVvr
 // CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF]])
 // CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:             unwind [[FAILURE:bb[0-9]+]]
 // CHECK:       [[SUCCESS]]:
 // CHECK:         end_apply [[TOKEN]]
 // CHECK:         return
@@ -1197,6 +1324,10 @@ public struct ImplCUnsafeAddressors : P3 {
 // CHECK:         abort_apply [[TOKEN]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements21ImplCUnsafeAddressorsVAA2P3A2aDP2urAA1UVvrTW'
+// On a non-ABI-stable platform !read is deferred to exactly this point --
+// confirm at least its signature, since the exhaustive check above is
+// stable-only.
+// CHECK-unstable-LABEL: sil{{.*}} [ossa] @$s17read_requirements21ImplCUnsafeAddressorsV2urAA1UVvr : {{.*}} {
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements21ImplCUnsafeAddressorsVAA2P3A2aDP2urAA1UVvyTW : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF_ADDR:%[^:]+]] :
@@ -1205,8 +1336,8 @@ public struct ImplCUnsafeAddressors : P3 {
 // CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements21ImplCUnsafeAddressorsV2urAA1UVvy
 // CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[SELF]])
 // CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK-SAME:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:             unwind [[FAILURE:bb[0-9]+]]
 // CHECK:       [[SUCCESS]]:
 // CHECK:         end_apply [[TOKEN]]
 // CHECK:         dealloc_stack [[ALLOCATION]]

--- a/test/SILGen/read_requirements.swift
+++ b/test/SILGen/read_requirements.swift
@@ -374,12 +374,18 @@ public struct ImplBLegacyCoroutineAccessors : ~Copyable & P2 {
       yield &_i
     }
   }
-// ImplB is introduced at the feature's own availability, so there is no old ABI
-// to preserve: only the yield_once_2 accessors are emitted, no yield_once vr/vM.
+// ImplB is introduced at the feature's own availability, so on its own its
+// concrete accessor set would skip the legacy ABI (only yield_once_2 vy/vx).
+// But it conforms to P2, whose `!read`/`!modify` witness slots are frozen and
+// required unconditionally with no default implementation (see P2's default
+// witness table above) -- so satisfying the conformance forces the additive
+// yield_once vr/vM here too, forwarding to vy/vx just like ImplA's.
 // CHECK-LABEL: sil{{.*}} @$s17read_requirements29ImplBLegacyCoroutineAccessorsV3ursAA1UVvy : $@yield_once_2 @convention
 // CHECK-LABEL: sil{{.*}} @$s17read_requirements29ImplBLegacyCoroutineAccessorsV3ursAA1UVvx : $@yield_once_2 @convention
-// CHECK-NOT:   @$s17read_requirements29ImplBLegacyCoroutineAccessorsV3ursAA1UVvr :
-// CHECK-NOT:   @$s17read_requirements29ImplBLegacyCoroutineAccessorsV3ursAA1UVvM :
+// CHECK-LABEL: sil{{.*}} @$s17read_requirements29ImplBLegacyCoroutineAccessorsV3ursAA1UVvr : $@yield_once @convention
+// CHECK:         function_ref @$s17read_requirements29ImplBLegacyCoroutineAccessorsV3ursAA1UVvy
+// CHECK-LABEL: sil{{.*}} @$s17read_requirements29ImplBLegacyCoroutineAccessorsV3ursAA1UVvM : $@yield_once @convention
+// CHECK:         function_ref @$s17read_requirements29ImplBLegacyCoroutineAccessorsV3ursAA1UVvx
 }
 
 @frozen
@@ -1225,12 +1231,14 @@ public struct ImplCUnsafeAddressors : P3 {
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplBStored: P2 module read_requirements {
-// CHECK-unstable:    method #P2.urs!read
+// CHECK-NEXT:    method #P2.urs!read
+// CHECK-SAME:      : @$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvrTW
 // CHECK-NEXT:    method #P2.urs!yielding_borrow
 // CHECK-SAME:      : @$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvyTW
 // CHECK-NEXT:    method #P2.urs!setter
 // CHECK-SAME:        : @$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvsTW
-// CHECK-unstable:    method #P2.urs!modify
+// CHECK-NEXT:    method #P2.urs!modify
+// CHECK-SAME:      : @$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvMTW
 // CHECK-NEXT:    method #P2.urs!yielding_mutate
 // CHECK-SAME:      : @$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvxTW
 // CHECK-NEXT:  }
@@ -1256,12 +1264,14 @@ public struct ImplCUnsafeAddressors : P3 {
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplBLegacyCoroutineAccessors: P2 module read_requirements {
-// CHECK-unstable:    method #P2.urs!read
+// CHECK-NEXT:    method #P2.urs!read
+// CHECK-SAME:        : @$s17read_requirements29ImplBLegacyCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvrTW
 // CHECK-NEXT:    method #P2.urs!yielding_borrow
 // CHECK-SAME:      : @$s17read_requirements29ImplBLegacyCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvyTW
 // CHECK-NEXT:    method #P2.urs!setter
 // CHECK-SAME:        : @$s17read_requirements29ImplBLegacyCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvsTW
-// CHECK-unstable:    method #P2.urs!modify
+// CHECK-NEXT:    method #P2.urs!modify
+// CHECK-SAME:        : @$s17read_requirements29ImplBLegacyCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvMTW
 // CHECK-NEXT:    method #P2.urs!yielding_mutate
 // CHECK-SAME:      : @$s17read_requirements29ImplBLegacyCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvxTW
 // CHECK-NEXT:  }
@@ -1287,12 +1297,14 @@ public struct ImplCUnsafeAddressors : P3 {
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplBCoroutineAccessors: P2 module read_requirements {
-// CHECK-unstable:    method #P2.urs!read
+// CHECK-NEXT:    method #P2.urs!read
+// CHECK-SAME:        : @$s17read_requirements23ImplBCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvrTW
 // CHECK-NEXT:    method #P2.urs!yielding_borrow
 // CHECK-SAME:      : @$s17read_requirements23ImplBCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvyTW
 // CHECK-NEXT:    method #P2.urs!setter
 // CHECK-SAME:        : @$s17read_requirements23ImplBCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvsTW
-// CHECK-unstable:    method #P2.urs!modify
+// CHECK-NEXT:    method #P2.urs!modify
+// CHECK-SAME:        : @$s17read_requirements23ImplBCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvMTW
 // CHECK-NEXT:    method #P2.urs!yielding_mutate
 // CHECK-SAME:      : @$s17read_requirements23ImplBCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvxTW
 // CHECK-NEXT:  }
@@ -1318,12 +1330,14 @@ public struct ImplCUnsafeAddressors : P3 {
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplBGetSet: P2 module read_requirements {
-// CHECK-unstable:    method #P2.urs!read
+// CHECK-NEXT:    method #P2.urs!read
+// CHECK-SAME:        : @$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvrTW
 // CHECK-NEXT:  method #P2.urs!yielding_borrow
 // CHECK-SAME:      : @$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvyTW
 // CHECK-NEXT:    method #P2.urs!setter
 // CHECK-SAME:        : @$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvsTW
-// CHECK-unstable:    method #P2.urs!modify
+// CHECK-NEXT:    method #P2.urs!modify
+// CHECK-SAME:        : @$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvMTW
 // CHECK-NEXT:  method #P2.urs!yielding_mutate
 // CHECK-SAME:      : @$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvxTW
 // CHECK-NEXT:  }
@@ -1349,12 +1363,14 @@ public struct ImplCUnsafeAddressors : P3 {
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplBUnsafeAddressors: P2 module read_requirements {
-// CHECK-unstable:    method #P2.urs!read
+// CHECK-NEXT:    method #P2.urs!read
+// CHECK-SAME:        : @$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvrTW
 // CHECK-NEXT:    method #P2.urs!yielding_borrow
 // CHECK-SAME:      : @$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvyTW
 // CHECK-NEXT:    method #P2.urs!setter
 // CHECK-SAME:        : @$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvsTW
-// CHECK-unstable:    method #P2.urs!modify
+// CHECK-NEXT:    method #P2.urs!modify
+// CHECK-SAME:        : @$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvMTW
 // CHECK-NEXT:    method #P2.urs!yielding_mutate
 // CHECK-SAME:      : @$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvxTW
 // CHECK-NEXT:  }
@@ -1378,10 +1394,12 @@ public struct ImplCUnsafeAddressors : P3 {
 
 // CHECK-LABEL: sil_default_witness_table P2 {
 // CHECK-NEXT:    no_default
-// CHECK-unstable-NEXT:  method #P2.urs!yielding_borrow
+// CHECK-NEXT:  method #P2.urs!yielding_borrow
+// CHECK-SAME:      : @$s17read_requirements2P2P3ursAA1UVvy
 // CHECK-NEXT:    no_default
 // CHECK-NEXT:    no_default
-// CHECK-unstable-NEXT:  method #P2.urs!yielding_mutate
+// CHECK-NEXT:  method #P2.urs!yielding_mutate
+// CHECK-SAME:      : @$s17read_requirements2P2P3ursAA1UVvx
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_default_witness_table P3 {

--- a/test/Sema/read_requirements.swift
+++ b/test/Sema/read_requirements.swift
@@ -29,7 +29,7 @@ struct ImplStored : ~Copyable & P {
   var ur: U
 }
 
-struct ImplUnderscoredCoroutineAccessors : ~Copyable & P {
+struct ImplLegacyCoroutineAccessors : ~Copyable & P {
   typealias Property = U
   var _i: U
   var ubgs: U {

--- a/test/attr/attr_objc_noncanonical_accessors.swift
+++ b/test/attr/attr_objc_noncanonical_accessors.swift
@@ -9,12 +9,15 @@
 import Foundation
 
 // Objective-C reaches storage through a getter, and a setter when it is
-// mutable.  An accessor that is not a getter/setter -- a 'borrow'/'yielding
-// borrow' read, or a 'mutate' write -- has no Objective-C entry point, and
-// storage read/written only through one has no getter/setter to expose, so it
-// is not representable in Objective-C.  ('_read'/'_modify' and 'yielding mutate'
-// synthesize an ordinary getter/setter, and '@_borrowed' keeps its explicit
-// getter, so those remain representable.)
+// mutable.  An accessor that is not a getter/setter -- a 'borrow' read, or a
+// 'mutate' write -- has no Objective-C entry point, and storage read/written
+// only through one has no getter/setter to expose, so it is not
+// representable in Objective-C.  ('_read'/'_modify', 'yielding mutate', and a
+// concrete copyable 'yielding borrow' all synthesize an ordinary
+// getter/setter, and '@_borrowed' keeps its explicit getter, so those remain
+// representable.  A 'yielding borrow' protocol requirement keeps a borrowing
+// opaque read with no getter, like '@_borrowed' witness layout, so it is
+// still not representable.)
 
 @objc protocol P {
   var yieldingBorrow: Int { yielding borrow } // expected-error {{'borrow' and 'yielding borrow' accessors are not supported in Objective-C}}
@@ -37,13 +40,16 @@ import Foundation
 @objc class C: NSObject {
   var _storage = 0
 
-  @objc var yieldingBorrow: Int { yielding borrow { yield 0 } } // expected-error {{'borrow' and 'yielding borrow' accessors are not supported in Objective-C}}
+  // A concrete copyable 'yielding borrow' synthesizes an owned getter (like
+  // '_read'), so with a getter present this is representable.
+  @objc var yieldingBorrow: Int { yielding borrow { yield 0 } }
 
   @objc var borrowed: Int { borrow { return _storage } } // expected-error {{'borrow' and 'yielding borrow' accessors are not supported in Objective-C}}
 
   @objc var borrowMutate: Int { borrow { return _storage } mutate { return &_storage } } // expected-error {{'borrow' and 'yielding borrow' accessors are not supported in Objective-C}}
 
-  @objc subscript(i: Int) -> Int { yielding borrow { yield 0 } } // expected-error {{'borrow' and 'yielding borrow' accessors are not supported in Objective-C}}
+  // Likewise for a subscript.
+  @objc subscript(i: Int) -> Int { yielding borrow { yield 0 } }
 
   // A 'yielding mutate' write synthesizes a setter, so with a getter present
   // this is representable.

--- a/validation-test/Evolution/test_coroutine_accessors.swift
+++ b/validation-test/Evolution/test_coroutine_accessors.swift
@@ -3,19 +3,6 @@
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_CoroutineAccessors
 
-// Linux fails with the following removed symbols:
-// Removed Symbols:
-// $s19coroutine_accessors13ResilientEnumO1sSivg
-// $s19coroutine_accessors13ResilientEnumO1sSivpMV
-// $s19coroutine_accessors14ResilientClassC1sSivgTj
-// $s19coroutine_accessors14ResilientClassC1sSivgTq
-// $s19coroutine_accessors14ResilientClassC1sSivpMV
-// $s19coroutine_accessors15ResilientStructV1sSivg
-// $s19coroutine_accessors15ResilientStructV1sSivpMV
-// $s19coroutine_accessors33ResilientStructWithImplicitModifyV1sSivg
-// $s19coroutine_accessors33ResilientStructWithImplicitModifyV1sSivpMV
-// XFAIL: OS=linux-gnu
-
 import StdlibUnittest
 import coroutine_accessors
 


### PR DESCRIPTION
The new coroutine accessors implementation is supporting both a new syntax (`yielding borrow`/`yielding mutate` vs. the legacy `_read`/`_modify` syntax) and a new more efficient ABI.

We originally planned to tie the ABI to the syntax -- new syntax would use the new ABI and old syntax the old one -- but that does not provide any transition path for code to migrate to the new syntax.

Instead, we're going to treat the old and new syntaxes as synonyms with respect to ABI.  Either syntax will produce the same ABI, according to the following rules:

* All coroutine accessors emit a new-ABI (yield_once_2) implementation whenever the feature is enabled.
* An old-ABI (yield_once) implementation is emitted as a thunk forwarding to the new implementation only when required for ABI stability.

Once fully implemented, this last point means that the old ABI will be emitted for resilient properties with sufficiently old availability. The old ABI will NOT be emitted for private properties, non-resilient or static libraries, or for non-ABI-stable platforms.

When calling a property, we generally prefer the new ABI, but will invoke the old ABI whenever stability requires it, including:
* When targeting an ABI stable platform version that predates this feature's permanent enablement.  (Currently, `99.99` to allow testing; this will change to the actual version when the feature is in fact enabled.)

Precisely, this PR makes the following changes:
* Parsing:  legacy and new spellings are treated identically in Swift source code; we literally parse them to the same AST node types.  The only difference is one new bit to distinguish which spelling appeared in source (for diagnostic accuracy).  Note this does not affect parsing of `.sil`/`.swiftinterface` files.  In those, `_read`/`_modify` indicate an old property with the old ABI only; this preserves compatibility with existing SDKs.
* Old coroutine ABI emission: the old ABI is now only emitted when the property is: a) resilient, b) exported (including `package`), c) on an ABI-stable platform, and d) available before CoroutineAccessors is fully enabled.  
* Getter consistency: `yielding borrow` now synthesizes a getter wrapper in all the cases that `_read` has done so.
* Caller ABI selection: Use availability to determine whether to call the old or new ABI.  This required plumbing source location through so that availability annotations can be accurately queried.
* Keypaths:  A bugfix to key path handling to ensure they invoke the correct ABI in all cases.
* Tests:  18 updated tests, 9 new tests.

All of this is still gated behind the CoroutineAccessors feature flag for now.  The flag remains off by default.