### PR TITLE
Fix the demangler and mangler to allow 64-bit generic value parameters

### DIFF
--- a/include/swift/Basic/Mangler.h
+++ b/include/swift/Basic/Mangler.h
@@ -82,9 +82,9 @@ protected:
   /// A helpful little wrapper for an integer value that should be mangled
   /// in a particular, compressed value.
   class Index {
-    unsigned N;
+    uint64_t N;
   public:
-    explicit Index(unsigned n) : N(n) {}
+    explicit Index(uint64_t n) : N(n) {}
     friend llvm::raw_ostream &operator<<(llvm::raw_ostream &out, Index n) {
       if (n.N != 0) out << (n.N - 1);
       return (out << '_');

--- a/include/swift/Demangling/Demangler.h
+++ b/include/swift/Demangling/Demangler.h
@@ -534,8 +534,8 @@ protected:
 
   NodePointer demangleOperator();
 
-  int demangleNatural();
-  int demangleIndex();
+  long demangleNatural();
+  long demangleIndex();
   NodePointer demangleIndexAsNode();
   NodePointer demangleDependentConformanceIndex();
   NodePointer demangleIdentifier();

--- a/include/swift/Demangling/Demangler.h
+++ b/include/swift/Demangling/Demangler.h
@@ -534,8 +534,8 @@ protected:
 
   NodePointer demangleOperator();
 
-  long demangleNatural();
-  long demangleIndex();
+  int64_t demangleNatural();
+  int64_t demangleIndex();
   NodePointer demangleIndexAsNode();
   NodePointer demangleDependentConformanceIndex();
   NodePointer demangleIdentifier();

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -1148,15 +1148,15 @@ recur:
   }
 }
 
-int Demangler::demangleNatural() {
+long Demangler::demangleNatural() {
   if (!isDigit(peekChar()))
     return -1000;
-  int num = 0;
+  long num = 0;
   while (true) {
     char c = peekChar();
     if (!isDigit(c))
       return num;
-    int newNum = (10 * num) + (c - '0');
+    long newNum = (10 * num) + (c - '0');
     if (newNum < num)
       return -1000;
     num = newNum;
@@ -1164,17 +1164,17 @@ int Demangler::demangleNatural() {
   }
 }
 
-int Demangler::demangleIndex() {
+long Demangler::demangleIndex() {
   if (nextIf('_'))
     return 0;
-  int num = demangleNatural();
+  long num = demangleNatural();
   if (num >= 0 && nextIf('_'))
     return num + 1;
   return -1000;
 }
 
 NodePointer Demangler::demangleIndexAsNode() {
-  int Idx = demangleIndex();
+  long Idx = demangleIndex();
   if (Idx >= 0)
     return createNode(Node::Kind::Number, Idx);
   return nullptr;

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -1148,15 +1148,15 @@ recur:
   }
 }
 
-long Demangler::demangleNatural() {
+int64_t Demangler::demangleNatural() {
   if (!isDigit(peekChar()))
     return -1000;
-  long num = 0;
+  int64_t num = 0;
   while (true) {
     char c = peekChar();
     if (!isDigit(c))
       return num;
-    long newNum = (10 * num) + (c - '0');
+    int64_t newNum = (10 * num) + (c - '0');
     if (newNum < num)
       return -1000;
     num = newNum;
@@ -1164,17 +1164,17 @@ long Demangler::demangleNatural() {
   }
 }
 
-long Demangler::demangleIndex() {
+int64_t Demangler::demangleIndex() {
   if (nextIf('_'))
     return 0;
-  long num = demangleNatural();
+  int64_t num = demangleNatural();
   if (num >= 0 && nextIf('_'))
     return num + 1;
   return -1000;
 }
 
 NodePointer Demangler::demangleIndexAsNode() {
-  long Idx = demangleIndex();
+  int64_t Idx = demangleIndex();
   if (Idx >= 0)
     return createNode(Node::Kind::Number, Idx);
   return nullptr;

--- a/test/Demangle/demangle-types.test
+++ b/test/Demangle/demangle-types.test
@@ -7,3 +7,12 @@ MULTI-NODE-ERROR: <<invalid type>>
 RUN: %swift-demangle -type SSIeAghrx_ | %FileCheck %s --check-prefix=PARSE-ERROR
 PARSE-ERROR: <<invalid type>>
 
+RUN: %swift-demangle -type '$2147483648_' | %FileCheck %s --check-prefix=LARGE-INT
+LARGE-INT: 2147483649
+
+RUN: %swift-demangle -type '$n2147483648_' | %FileCheck %s --check-prefix=LARGE-NEG-INT
+LARGE-NEG-INT: -2147483649
+
+RUN: %swift-demangle -type '$9223372036854775806_' | %FileCheck %s --check-prefix=INT64-MAX
+INT64-MAX: 9223372036854775807
+

--- a/test/Interpreter/value_generics.64.swift
+++ b/test/Interpreter/value_generics.64.swift
@@ -1,0 +1,25 @@
+// RUN: %target-run-simple-swift(-Xfrontend  -disable-availability-checking) | %FileCheck %s
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// REQUIRES: executable_test
+// REQUIRES: PTRSIZE=64
+
+struct A<let N: Int> {
+  func foo() {
+    print(N)
+  }
+}
+
+// CHECK: 2147483649
+A<2_147_483_649>().foo()
+
+// CHECK: -2147483649
+A< -2_147_483_649>().foo()
+
+// CHECK: 4294967296
+A<4_294_967_296>().foo()
+
+// CHECK: 9223372036854775807
+A<9_223_372_036_854_775_807>().foo()


### PR DESCRIPTION
This PR resolves #90739. See that issue for details on what these changes are aimed at fixing.

Currently this is not ready to be merged pending 2 things I'm unsure about:

## Demangling

The changes to the demangler are potentially problematic for existing code that uses `demangleNatural`, `demangleIndex` and `demangleIndexAsNode`. It seems a bunch of that code assumes the return value is an `int` or may rely on that. By changing the return values to `long` I'm not sure if there are broader implications. It compiles fine and the repro case works fine but maybe it could cause other issues? So I wasn't sure what exactly would be the best solution and wanted to get a baseline PR open to have a discussion.

Some other ideas I've thought of:

1. Making identical copies of `demangleNatural` and `demangleIndex` that process `long` values. These would be named something like `demangleLongNatural` and `demangleLongIndex` and then `demangleIntegerType` would be updated to use `demangleLongIndex`.
2. Similar to the above but templating `demangleNatural` and `demangleIndex` to have a templated type that's either `int` or `long` which would be used for the processed and returned type. Same solution as above but more DRY. All calls to those functions in the demangler, except in `demangleIntegerType `, would use the `int` specialization. `demangleIntegerType ` would use the `long` specialization.

## Tests

I don't know where I should add tests to. Looking back at the [original PR](https://github.com/swiftlang/swift/pull/75518/) for value generics I don't understand which of the files in `tests/` would make sense to add to for 64-bit value generics.
