### PR TITLE
SIL: Add a PrettyStackTrace entry during deserializeAndPushToWorklist().

### DIFF
--- a/lib/SIL/IR/Linker.cpp
+++ b/lib/SIL/IR/Linker.cpp
@@ -52,11 +52,6 @@
 
 #define DEBUG_TYPE "sil-linker"
 #include "Linker.h"
-#include "llvm/ADT/Statistic.h"
-#include "llvm/ADT/FoldingSet.h"
-#include "llvm/ADT/SmallString.h"
-#include "llvm/ADT/StringSwitch.h"
-#include "llvm/Support/Debug.h"
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SubstitutionMap.h"
@@ -64,7 +59,13 @@
 #include "swift/Basic/CodeGenerationModel.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/SIL/FormalLinkage.h"
+#include "swift/SIL/PrettyStackTrace.h"
 #include "swift/Serialization/SerializedSILLoader.h"
+#include "llvm/ADT/FoldingSet.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/Statistic.h"
+#include "llvm/ADT/StringSwitch.h"
+#include "llvm/Support/Debug.h"
 #include <functional>
 
 using namespace swift;
@@ -77,6 +78,8 @@ STATISTIC(NumFuncLinked, "Number of SIL functions linked");
 //===----------------------------------------------------------------------===//
 
 void SILLinkerVisitor::deserializeAndPushToWorklist(SILFunction *F) {
+  PrettyStackTraceSILFunction trace("deserializing", F);
+
   ASSERT(F->isExternalDeclaration());
 
   LLVM_DEBUG(llvm::dbgs() << "Imported function: "


### PR DESCRIPTION
Make assertion failures during SIL linking more actionable by including the details of the function in the stack trace.
