### PR TITLE
[6.4][Completion] don't crash on parameter packs in addCallArgumentPatterns. rdar://173724381

### DIFF
--- a/lib/IDE/CodeCompletionStringBuilder.cpp
+++ b/lib/IDE/CodeCompletionStringBuilder.cpp
@@ -449,7 +449,10 @@ bool CodeCompletionStringBuilder::addCallArgumentPatterns(
     ArrayRef<const ParamDecl *> declParams, const DeclContext *DC,
     GenericSignature genericSig, DefaultArgumentOutputMode defaultArgsMode,
     bool includeDefaultValues) {
-  assert(declParams.empty() || typeParams.size() == declParams.size());
+  // 'declParams' may be empty, or shorter than 'typeParams': a variadic generic
+  // parameter pack is a single 'ParamDecl' that expands to multiple substituted
+  // function type parameters, and error recovery can leave the decl and its type
+  // disagreeing. Index 'declParams' defensively rather than in lockstep.
 
   bool modifiedBuilder = false;
   bool needComma = false;
@@ -466,7 +469,7 @@ bool CodeCompletionStringBuilder::addCallArgumentPatterns(
     SmallString<32> Scratch;
     StringRef defaultValue;
 
-    if (!declParams.empty()) {
+    if (i < declParams.size()) {
       const ParamDecl *PD = declParams[i];
       hasDefault =
           PD->isDefaultArgument() && !isNonDesirableImportedDefaultArg(PD);

--- a/validation-test/IDE/crashers/CodeCompletionResultBuilder-takeResult-8c98fb.swift
+++ b/validation-test/IDE/crashers/CodeCompletionResultBuilder-takeResult-8c98fb.swift
@@ -1,0 +1,7 @@
+// {"kind":"complete","original":"94a984af","signature":"swift::ide::CodeCompletionResultBuilder::takeResult()","signatureAssert":"Abort: function verifyUSRToDeclReconstruction: Reconstructed declaration shouldn't be null","signatureNext":"CompletionLookup::addEnumElementRef"}
+// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+enum a<each b> {
+  case (repeat each b)
+}
+a<
+>#^^#

--- a/validation-test/IDE/crashers/CodeCompletionStringBuilder-addCallArgumentPatterns-8c98fb.swift
+++ b/validation-test/IDE/crashers/CodeCompletionStringBuilder-addCallArgumentPatterns-8c98fb.swift
@@ -1,7 +1,0 @@
-// {"kind":"complete","original":"94a984af","signature":"swift::ide::CodeCompletionStringBuilder::addCallArgumentPatterns(llvm::ArrayRef<swift::AnyFunctionType::Param>, llvm::ArrayRef<swift::ParamDecl const*>, swift::DeclContext const*, swift::GenericSignature, swift::ide::DefaultArgumentOutputMode, bool)","signatureAssert":"Assertion failed: (declParams.empty() || typeParams.size() == declParams.size()), function addCallArgumentPatterns","signatureNext":"CompletionLookup::addEnumElementRef"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
-enum a<each b> {
-  case (repeat each b)
-}
-a<
->#^^#

--- a/validation-test/IDE/crashers_fixed/CodeCompletionStringBuilder-addCallArgumentPatterns-09a6a1.swift
+++ b/validation-test/IDE/crashers_fixed/CodeCompletionStringBuilder-addCallArgumentPatterns-09a6a1.swift
@@ -1,4 +1,4 @@
 // {"kind":"complete","signature":"swift::ide::CodeCompletionStringBuilder::addCallArgumentPatterns(llvm::ArrayRef<swift::AnyFunctionType::Param>, llvm::ArrayRef<swift::ParamDecl const*>, swift::DeclContext const*, swift::GenericSignature, swift::ide::DefaultArgumentOutputMode, bool)","signatureAssert":"Assertion failed: (declParams.empty() || typeParams.size() == declParams.size()), function addCallArgumentPatterns","signatureNext":"CompletionLookup::addFunctionCallPattern"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 func a<each b>( repeat each b)c == a(
 #^COMPLETE^# d

--- a/validation-test/IDE/crashers_fixed/CodeCompletionStringBuilder-addCallArgumentPatterns-37b7e6.swift
+++ b/validation-test/IDE/crashers_fixed/CodeCompletionStringBuilder-addCallArgumentPatterns-37b7e6.swift
@@ -1,4 +1,4 @@
 // {"kind":"complete","original":"5f46ab99","signature":"swift::ide::CodeCompletionStringBuilder::addCallArgumentPatterns(llvm::ArrayRef<swift::AnyFunctionType::Param>, llvm::ArrayRef<swift::ParamDecl const*>, swift::DeclContext const*, swift::GenericSignature, swift::ide::DefaultArgumentOutputMode, bool)","signatureAssert":"Assertion failed: (declParams.empty() || typeParams.size() == declParams.size()), function addCallArgumentPatterns","signatureNext":"CompletionLookup::addMethodCall"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 struct a < each b {
 c(repeat each b) { let d = a< >(let _ d#^^#

--- a/validation-test/IDE/crashers_fixed/CodeCompletionStringBuilder-addCallArgumentPatterns-647512.swift
+++ b/validation-test/IDE/crashers_fixed/CodeCompletionStringBuilder-addCallArgumentPatterns-647512.swift
@@ -1,5 +1,5 @@
 // {"kind":"complete","original":"b2c0bc09","signature":"swift::ide::CodeCompletionStringBuilder::addCallArgumentPatterns(llvm::ArrayRef<swift::AnyFunctionType::Param>, llvm::ArrayRef<swift::ParamDecl const*>, swift::DeclContext const*, swift::GenericSignature, swift::ide::DefaultArgumentOutputMode, bool)","signatureAssert":"Assertion failed: (declParams.empty() || typeParams.size() == declParams.size()), function addCallArgumentPatterns","signatureNext":"CompletionLookup::addConstructorCall"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 struct a<b, each c {
   init(repeat each c) {
     a < b

--- a/validation-test/IDE/crashers_fixed/CodeCompletionStringBuilder-addCallArgumentPatterns-bf4c99.swift
+++ b/validation-test/IDE/crashers_fixed/CodeCompletionStringBuilder-addCallArgumentPatterns-bf4c99.swift
@@ -1,5 +1,5 @@
 // {"kind":"complete","original":"882aa4dc","signature":"swift::ide::CodeCompletionStringBuilder::addCallArgumentPatterns(llvm::ArrayRef<swift::AnyFunctionType::Param>, llvm::ArrayRef<swift::ParamDecl const*>, swift::DeclContext const*, swift::GenericSignature, swift::ide::DefaultArgumentOutputMode, bool)","signatureAssert":"Assertion failed: (declParams.empty() || typeParams.size() == declParams.size()), function addCallArgumentPatterns","signatureNext":"CompletionLookup::addSubscriptCall"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 struct a<each b {
 subscript(repeat each b) {
 a< >()#^^#

--- a/validation-test/IDE/crashers_fixed/CodeCompletionStringBuilder-addCallArgumentPatterns-e985ae.swift
+++ b/validation-test/IDE/crashers_fixed/CodeCompletionStringBuilder-addCallArgumentPatterns-e985ae.swift
@@ -1,0 +1,8 @@
+// {"kind":"complete","original":"78722387","signature":"swift::ide::CodeCompletionStringBuilder::addCallArgumentPatterns(llvm::ArrayRef<swift::AnyFunctionType::Param>, llvm::ArrayRef<swift::ParamDecl const*>, swift::DeclContext const*, swift::GenericSignature, swift::ide::DefaultArgumentOutputMode, bool)","signatureAssert":"Assertion failed: (declParams.empty() || typeParams.size() == declParams.size()), function addCallArgumentPatterns","signatureNext":"CompletionLookup::addSubscriptCallPattern"}
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+struct a
+  struct b {
+    subscript<each c>(repeat each c)  a
+    func d(e: b) {
+      (e[#^^#
+      0


### PR DESCRIPTION
  - **Explanation**: Makes `CodeCompletionStringBuilder::addCallArgumentPatterns` index the `declParams` array
  defensively instead of assuming it is either empty or exactly as long as `typeParams`. A variadic generic parameter
  pack is a single `ParamDecl` that expands to several substituted function-type parameters, so the two arrays can
  legitimately differ in length — and error recovery can leave them inconsistent. Drops the `typeParams.size() ==
  declParams.size()` assertion and replaces the `!declParams.empty()` guard with a per-index `i < declParams.size()`
  bounds check, avoiding an out-of-bounds access during code completion.
  - **Scope**: SourceKit / sourcekitd code completion only.
  - **Issues**: rdar://173724381
  - **Original PRs**: #90741
  - **Risk**: Low. 
  - **Testing**: Existing tests updated
  - **Reviewers**: @hamishknight