### PR TITLE
[stdlib] Use uncheckedBounds in a few slicing defaults

### DIFF
--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1030,7 +1030,9 @@ extension Collection where SubSequence == Slice<Self> {
   /// - Complexity: O(1)
   @inlinable
   public subscript(bounds: Range<Index>) -> Slice<Self> {
-    _failEarlyRangeCheck(bounds, bounds: startIndex..<endIndex)
+    // startIndex <= endIndex must hold in a well-formed Collection
+    unsafe _failEarlyRangeCheck(
+      bounds, bounds: Range(uncheckedBounds: (startIndex, endIndex)))
     return Slice(base: self, bounds: bounds)
   }
 }

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -285,13 +285,8 @@ extension MutableCollection {
   @available(*, unavailable)
   @inlinable
   public subscript(bounds: Range<Index>) -> Slice<Self> {
-    get {
-      _failEarlyRangeCheck(bounds, bounds: startIndex..<endIndex)
-      return Slice(base: self, bounds: bounds)
-    }
-    set {
-      _writeBackMutableSlice(&self, bounds: bounds, slice: newValue)
-    }
+    get { fatalError() }
+    set { fatalError() }
   }
 
   // This unavailable default implementation of `subscript(bounds: Range<_>)`
@@ -356,7 +351,8 @@ extension MutableCollection where SubSequence == Slice<Self> {
   @export(implementation)
   public subscript(bounds: Range<Index>) -> Slice<Self> {
     get {
-      _failEarlyRangeCheck(bounds, bounds: startIndex..<endIndex)
+      unsafe _failEarlyRangeCheck(
+        bounds, bounds: Range(uncheckedBounds: (startIndex, endIndex)))
       return Slice(base: self, bounds: bounds)
     }
     set {

--- a/stdlib/public/core/WriteBackMutableSlice.swift
+++ b/stdlib/public/core/WriteBackMutableSlice.swift
@@ -19,7 +19,8 @@ internal func _writeBackMutableSlice<C, Slice_>(
   C.Element == Slice_.Element,
   C.Index == Slice_.Index {
 
-  self_._failEarlyRangeCheck(bounds, bounds: self_.startIndex..<self_.endIndex)
+  unsafe self_._failEarlyRangeCheck(
+    bounds, bounds: Range(uncheckedBounds: (self_.startIndex, self_.endIndex)))
 
   // FIXME(performance): can we use
   // _withUnsafeMutableBufferPointerIfSupported?  Would that create inout


### PR DESCRIPTION
`startIndex..<endIndex` re-checks `startIndex <= endIndex`, which always holds for a well-formed collection. Build the range with uncheckedBounds instead, matching what RandomAccessCollection already does.

Resolves #56222