### PR TITLE
Add -sil-view-dom and -sil-view-dom-only flags to view dominator trees

### DIFF
--- a/docs/DebuggingTheCompiler.md
+++ b/docs/DebuggingTheCompiler.md
@@ -306,6 +306,17 @@ A short (non-exhaustive) list of SIL printing options:
 NOTE: This may emit a lot of text to stderr, so be sure to pipe the
 output to a file.
 
+* `-Xllvm -sil-view-dom=<pass_count>`: Open a graphical view of the dominator
+  tree for the function at the given pass count. The graph shows the full
+  contents of each basic block.
+
+* `-Xllvm -sil-view-dom-only=<pass_count>`: Like `-sil-view-dom`, but the
+  graph shows only basic block labels without their contents.
+
+  NOTE: These flags use `llvm::ViewGraph`, which on macOS relies on the
+  `open` program. `.dot` files must be associated with a dot viewer such as
+  Graphviz for the graph to display.
+
 ### Getting CommandLine for swift stdlib from Ninja to enable dumping stdlib SIL
 
 If one builds swift using ninja and wants to dump the SIL of the

--- a/include/swift/SIL/Dominance.h
+++ b/include/swift/SIL/Dominance.h
@@ -18,7 +18,9 @@
 #ifndef SWIFT_SIL_DOMINANCE_H
 #define SWIFT_SIL_DOMINANCE_H
 
+#include "llvm/ADT/DepthFirstIterator.h"
 #include "llvm/Support/GenericDomTree.h"
+#include "llvm/Support/GraphWriter.h"
 #include "swift/Basic/ScopedTracking.h"
 #include "swift/SIL/CFG.h"
 
@@ -284,6 +286,74 @@ template <> struct GraphTraits<const swift::DominanceInfoNode *> {
   static NodeRef getEntryNode(NodeRef N) { return N; }
   static inline ChildIteratorType child_begin(NodeRef N) { return N->begin(); }
   static inline ChildIteratorType child_end(NodeRef N) { return N->end(); }
+};
+
+template <>
+struct DOTGraphTraits<swift::DominanceInfo *> : public DefaultDOTGraphTraits {
+  DOTGraphTraits(bool isSimple = false) : DefaultDOTGraphTraits(isSimple) {}
+
+  static std::string getGraphName(swift::DominanceInfo *DI) {
+    return "Dominator Tree for SIL Function";
+  }
+
+  std::string getNodeLabel(swift::DominanceInfoNode *Node,
+                           swift::DominanceInfo *DI) {
+    if (!Node)
+      return "<<null>>";
+
+    swift::SILBasicBlock *BB = Node->getBlock();
+    if (!BB)
+      return "<<entry root>>";
+
+    std::string Str;
+    raw_string_ostream OS(Str);
+
+    if (isSimple()) {
+      BB->printAsOperand(OS, false);
+    } else {
+      OS << *BB;
+    }
+
+    return OS.str();
+  }
+};
+
+template <>
+struct GraphTraits<swift::DominanceInfo *>
+    : public GraphTraits<swift::DominanceInfoNode *> {
+  typedef swift::DominanceInfoNode *NodeRef;
+  typedef df_iterator<NodeRef> nodes_iterator;
+
+  static NodeRef getEntryNode(swift::DominanceInfo *DI) {
+    return DI->getRootNode();
+  }
+
+  static nodes_iterator nodes_begin(swift::DominanceInfo *DI) {
+    if (DI->getRootNode())
+      return df_begin(DI->getRootNode());
+    return df_end(static_cast<NodeRef>(nullptr));
+  }
+
+  static nodes_iterator nodes_end(swift::DominanceInfo *DI) {
+    if (DI->getRootNode())
+      return df_end(DI->getRootNode());
+    return df_end(static_cast<NodeRef>(nullptr));
+  }
+
+  static unsigned size(swift::DominanceInfo *DI) {
+    unsigned count = 0;
+    std::function<void(swift::DominanceInfoNode *)> countNodes =
+        [&](swift::DominanceInfoNode *N) {
+          count++;
+          for (auto I = N->begin(), E = N->end(); I != E; ++I)
+            countNodes(*I);
+        };
+
+    if (DI->getRootNode())
+      countNodes(DI->getRootNode());
+
+    return count;
+  }
 };
 
 } // end namespace llvm

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -1836,6 +1836,11 @@ public:
   /// Like ViewCFG, but the graph does not show the contents of basic blocks.
   void viewCFGOnly() const;
 
+  /// View the dominator tree of this function.
+  void viewDomTree() const;
+  /// Like viewDomTree, but the graph does not show the contents of basic
+  /// blocks.
+  void viewDomTreeOnly() const;
 };
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -954,6 +954,7 @@ struct DOTGraphTraits<SILFunction *> : public DefaultDOTGraphTraits {
     return "";
   }
 };
+
 } // namespace llvm
 #endif
 
@@ -983,6 +984,23 @@ void SILFunction::viewCFGOnly() const {
   viewCFGHelper(this, /*skipBBContents=*/true);
 }
 
+static void viewDomTreeHelper(const SILFunction *f, bool shortNames) {
+#ifndef NDEBUG
+  auto *nonConstF = const_cast<SILFunction *>(f);
+  DominanceInfo domInfo(nonConstF);
+
+  llvm::ViewGraph(&domInfo, "domtree_" + f->getName().str(),
+                  /*ShortNames=*/shortNames);
+#endif
+}
+
+void SILFunction::viewDomTree() const {
+  viewDomTreeHelper(this, /*shortNames=*/false);
+}
+
+void SILFunction::viewDomTreeOnly() const {
+  viewDomTreeHelper(this, /*shortNames=*/true);
+}
 
 bool SILFunction::hasDynamicSelfMetadata() const {
   auto paramTypes =

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -210,6 +210,16 @@ static llvm::cl::opt<bool> SILPrintEverySubpass(
     llvm::cl::desc("Print the function before every subpass run of passes that "
                    "have multiple subpasses"));
 
+static llvm::cl::opt<std::string> SILViewDom(
+    "sil-view-dom", llvm::cl::init(""),
+    llvm::cl::desc("View the dominator tree of a function at a given pass "
+                   "count"));
+
+static llvm::cl::opt<std::string> SILViewDomOnly(
+    "sil-view-dom-only", llvm::cl::init(""),
+    llvm::cl::desc("View the dominator tree of a function (basic block names "
+                   "only) at a given pass count"));
+
 static bool isInPrintFunctionList(SILFunction *F) {
   for (const std::string &printFnName : SILPrintFunction) {
     if (printFnName == F->getName())
@@ -818,6 +828,23 @@ void SILPassManager::runPassOnFunction(unsigned TransIdx, SILFunction *F) {
       runSwiftFunctionVerification(F);
     }
   }
+
+  // View the dominator tree at the specified pass count.
+  auto viewDomAtPassCount = [&](StringRef option, bool shortNames) {
+    unsigned passCount;
+    if (option.getAsInteger(10, passCount))
+      return;
+    if (NumPassesRun == passCount) {
+      if (shortNames)
+        F->viewDomTreeOnly();
+      else
+        F->viewDomTree();
+    }
+  };
+  if (!SILViewDom.empty())
+    viewDomAtPassCount(SILViewDom, /*shortNames=*/false);
+  else if (!SILViewDomOnly.empty())
+    viewDomAtPassCount(SILViewDomOnly, /*shortNames=*/true);
 
   ++NumPassesRun;
 }


### PR DESCRIPTION
Add viewDomTree()/viewDomTreeOnly() utilities on SILFunction along with GraphTraits/DOTGraphTraits for DominanceInfo to enable viewing graphical dominator trees.
