### PR TITLE
[6.4.x] IRGen: fix async typed throws miscompiles on Wasm

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -667,7 +667,7 @@ namespace {
     void expandCoroutineResult(bool forContinuation);
     void expandCoroutineContinuationParameters();
 
-    void addIndirectThrowingResult();
+    void maybeAddIndirectThrowingResult();
     llvm::Type *getErrorRegisterType();
   };
 } // end anonymous namespace
@@ -2246,28 +2246,40 @@ void SignatureExpansion::expandAsyncReturnType() {
   addErrorResult();
 }
 
-void SignatureExpansion::addIndirectThrowingResult() {
-  if (getSILFuncConventions().funcTy->hasErrorResult() &&
-      getSILFuncConventions().isTypedError()) {
-    auto resultType = getSILFuncConventions().getSILResultType(
-        IGM.getMaximalTypeExpansionContext());
-    auto &ti = IGM.getTypeInfo(resultType);
-    auto &native = ti.nativeReturnValueSchema(IGM);
+/// Does `funcTy`'s entry signature carry a trailing indirect typed-error
+/// pointer? Used by async signature expansion
+/// (maybeAddIndirectThrowingResult) to decide whether to emit the indirect
+/// error slot.
+static bool
+hasIndirectTypedErrorResultSlot(IRGenModule &IGM, CanSILFunctionType funcTy) {
+  if (!funcTy->hasErrorResult())
+    return false;
 
-    auto errorType = getSILFuncConventions().getSILErrorType(
-        IGM.getMaximalTypeExpansionContext());
-    const TypeInfo &errorTI = IGM.getTypeInfo(errorType);
-    auto &nativeError = errorTI.nativeReturnValueSchema(IGM);
+  SILFunctionConventions fnConv(funcTy, IGM.getSILModule());
+  if (!fnConv.isTypedError())
+    return false;
 
-    if (getSILFuncConventions().hasIndirectSILResults() ||
-        getSILFuncConventions().hasIndirectSILErrorResults() ||
-        native.requiresIndirect() ||
-        nativeError.shouldReturnTypedErrorIndirectly()) {
-      addOpaquePointerParameter();
-    }
-  }
+  // getTypeInfo crashes on unbound type parameters without an open generic
+  // context; open one for funcTy's signature (harmless if already nested).
+  GenericContextScope scope(IGM, funcTy->getInvocationGenericSignature());
+  auto resultType =
+      fnConv.getSILResultType(IGM.getMaximalTypeExpansionContext());
+  auto errorType =
+      fnConv.getSILErrorType(IGM.getMaximalTypeExpansionContext());
+  auto &native = IGM.getTypeInfo(resultType).nativeReturnValueSchema(IGM);
+  auto &nativeError = IGM.getTypeInfo(errorType).nativeReturnValueSchema(IGM);
 
+  return fnConv.hasIndirectSILResults() ||
+         fnConv.hasIndirectSILErrorResults() ||
+         native.requiresIndirect() ||
+         nativeError.shouldReturnTypedErrorIndirectly();
 }
+
+void SignatureExpansion::maybeAddIndirectThrowingResult() {
+  if (hasIndirectTypedErrorResultSlot(IGM, FnType))
+    addOpaquePointerParameter();
+}
+
 void SignatureExpansion::expandAsyncEntryType() {
   ResultIRType = IGM.VoidTy;
 
@@ -2313,6 +2325,10 @@ void SignatureExpansion::expandAsyncEntryType() {
     ParamIRTypes.push_back(IGM.SwiftContextPtrTy);
   }
 
+  // Maintaining easy thin/thick compatibility requires the context parameter to
+  // come last, so emit the indirect typed-error result before it.
+  maybeAddIndirectThrowingResult();
+
   // Context is next.
   if (hasSelfContext) {
     auto curLength = ParamIRTypes.size();
@@ -2353,8 +2369,6 @@ void SignatureExpansion::expandAsyncEntryType() {
       ParamIRTypes.push_back(IGM.RefCountedPtrTy);
     }
   }
-
-  addIndirectThrowingResult();
 
   // For now we continue to store the error result in the context to be able to
   // reuse non throwing functions.
@@ -3215,17 +3229,33 @@ public:
       }
     }
 
+    llvm::Value *contextPtr = CurCallee.getSwiftContext();
+    // Args[] is filled back-to-front, and swiftself is the last parameter, so
+    // write the context before the indirect error slot, or at the tail below
+    // if the callee has no indirect typed error.
+    auto maybeAddContextBeforeAsyncTypedError = [&] {
+      if (!contextPtr)
+        return;
+      assert(LastArgWritten > 0);
+      unsigned ctxIdx = --LastArgWritten;
+      Args[ctxIdx] = contextPtr;
+      IGF.IGM.addSwiftSelfAttributes(CurCallee.getMutableAttributes(), ctxIdx);
+      contextPtr = nullptr;
+    };
+
     // Add the indirect typed error result if we have one.
     SILFunctionConventions fnConv(fnType, IGF.getSILModule());
     if (fnType->hasErrorResult() && fnConv.isTypedError()) {
       // The invariant is that this is always zero-initialized, so we
       // don't need to do anything extra here.
       assert(LastArgWritten > 0);
+
       // Return the error indirectly.
       if (fnConv.hasIndirectSILErrorResults()) {
-          // We will set the value later when lowering the arguments.
-          setIndirectTypedErrorResultSlotArgsIndex(--LastArgWritten);
-          Args[LastArgWritten] = nullptr;
+        // We will set the value later when lowering the arguments.
+        maybeAddContextBeforeAsyncTypedError();
+        setIndirectTypedErrorResultSlotArgsIndex(--LastArgWritten);
+        Args[LastArgWritten] = nullptr;
       } else {
         auto silResultTy =
             fnConv.getSILResultType(IGF.IGM.getMaximalTypeExpansionContext());
@@ -3242,13 +3272,14 @@ public:
             fnConv.hasIndirectSILResults()) {
           // Return the error indirectly.
           auto buf = IGF.getCalleeTypedErrorResultSlot(silErrorTy);
+          maybeAddContextBeforeAsyncTypedError();
           Args[--LastArgWritten] = buf.getAddress();
         }
       }
     }
 
-    llvm::Value *contextPtr = CurCallee.getSwiftContext();
-    // Add the data pointer if we have one.
+    // Add the data pointer if we have one. (Skipped when the typed-error
+    // branch above already placed it ahead of the indirect error slot.)
     if (contextPtr) {
       assert(LastArgWritten > 0);
       Args[--LastArgWritten] = contextPtr;

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -1158,7 +1158,7 @@ public:
     return substType->getParameters()[index];
   }
 
-  llvm::Value *getContext() { return origParams.claimNext(); }
+  virtual llvm::Value *getContext() { return origParams.claimNext(); }
 
   virtual llvm::Value *getDynamicFunctionPointer() = 0;
   virtual llvm::Value *getDynamicFunctionContext() = 0;
@@ -1408,6 +1408,10 @@ public:
     addArgument(explosion);
   }
 
+  // swiftself is the last parameter of the async entry signature, so
+  // takeLast() returns it.
+  llvm::Value *getContext() override { return origParams.takeLast(); }
+
   void forwardErrorResult() override {
     // The error result pointer is already in the appropriate position but the
     // type error address is not.
@@ -1425,8 +1429,9 @@ public:
           errorSchema.shouldReturnTypedErrorIndirectly() ||
           outConv.hasIndirectSILResults() ||
           outConv.hasIndirectSILErrorResults()) {
-        auto *typedErrorResultPtr = origParams.claimNext();
-        args.add(typedErrorResultPtr);
+        // The indirect error slot is now last, since getContext() already
+        // took swiftself.
+        args.add(origParams.takeLast());
       }
     }
   }

--- a/lib/IRGen/GenThunk.cpp
+++ b/lib/IRGen/GenThunk.cpp
@@ -142,6 +142,17 @@ void IRGenThunk::prepareArguments() {
 
   SILFunctionConventions conv(origTy, IGF.getSILModule());
 
+  // swiftself is the last parameter here (any witness metadata was popped
+  // above), so claim it now so the typed-error claim below lands on the
+  // indirect error slot.
+  bool claimedAsyncContext = false;
+  if (isAsync &&
+      (origTy->getRepresentation() == SILFunctionTypeRepresentation::Thick ||
+       irgen::hasSelfContextParameter(origTy))) {
+    selfValue = original.takeLast();
+    claimedAsyncContext = true;
+  }
+
   if (origTy->hasErrorResult()) {
     typedErrorIndirectErrorSlot = nullptr;
 
@@ -188,7 +199,8 @@ void IRGenThunk::prepareArguments() {
     original.transferInto(params, 1);
   }
 
-  selfValue = original.takeLast();
+  if (!claimedAsyncContext)
+    selfValue = original.takeLast();
 
   // Prepare indirect results, if any.
   SILType directResultType = conv.getSILResultType(expansionContext);

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1793,6 +1793,8 @@ public:
   llvm::Value *getCallerErrorResultArgument() override {
     llvm_unreachable("should not be used");
   }
+  // Claimed lazily off the back; emitEntryPointArgumentsNativeCC binds the
+  // context first so this lands on the indirect error slot.
   llvm::Value *getCallerTypedErrorResultArgument() override {
     return allParamValues.takeLast();
   }
@@ -2212,6 +2214,40 @@ static void emitEntryPointArgumentsNativeCC(IRGenSILFunction &IGF,
   }
 
   SILFunctionConventions fnConv(funcTy, IGF.getSILModule());
+
+  // Bind the self/context parameter, the last parameter of the async entry
+  // signature. Factored out so async binds it before popping the error result
+  // and the sync path after; returns true if it bound or claimed the context.
+  auto bindContextParameter = [&]() -> bool {
+    if (hasSelfContextParameter(funcTy)) {
+      SILArgument *selfParam = params.back();
+      params = params.drop_back();
+      bindParameter(
+          IGF, *emission, 0, selfParam,
+          fnConv.getSILArgumentType(fnConv.getNumSILArguments() - 1,
+                                    IGF.IGM.getMaximalTypeExpansionContext()),
+          [&](unsigned startIndex, unsigned size) {
+            assert(size == 1);
+            Explosion selfTemp;
+            selfTemp.add(emission->getContext());
+            return selfTemp;
+          });
+    } else if ((!funcTy->isAsync() && funcTy->hasErrorResult()) ||
+               funcTy->getRepresentation() ==
+                   SILFunctionTypeRepresentation::Thick) {
+      // Even without a 'self', an error result (sync) or a thick context still
+      // occupies a context slot here.
+      llvm::Value *contextPtr = emission->getContext();
+      (void)contextPtr;
+      assert(contextPtr->getType() == IGF.IGM.RefCountedPtrTy);
+    } else {
+      return false;
+    }
+    return true;
+  };
+
+  bool boundContextParameter = false;
+
   if (funcTy->isAsync()) {
     emitAsyncFunctionEntry(IGF, getAsyncContextLayout(IGF.IGM, IGF.CurSILFn),
                            LinkEntity::forSILFunction(IGF.CurSILFn),
@@ -2224,6 +2260,8 @@ static void emitEntryPointArgumentsNativeCC(IRGenSILFunction &IGF,
       // Remap the entry block.
       IGF.LoweredBBs[&*IGF.CurSILFn->begin()] = LoweredBB(IGF.Builder.GetInsertBlock(), {});
     }
+    // Bind the context before the error result is popped below.
+    boundContextParameter = bindContextParameter();
   }
 
   // Bind the error result by popping it off the parameter list.
@@ -2270,37 +2308,12 @@ static void emitEntryPointArgumentsNativeCC(IRGenSILFunction &IGF,
     }
   }
 
-  SILFunctionConventions conv(funcTy, IGF.getSILModule());
+  // Sync path: bind the context after the error result (async bound it above).
+  if (!funcTy->isAsync())
+    boundContextParameter = bindContextParameter();
 
-  // The 'self' argument might be in the context position, which is
-  // now the end of the parameter list.  Bind it now.
-  if (hasSelfContextParameter(funcTy)) {
-    SILArgument *selfParam = params.back();
-    params = params.drop_back();
-
-    bindParameter(
-        IGF, *emission, 0, selfParam,
-        conv.getSILArgumentType(conv.getNumSILArguments() - 1,
-                                IGF.IGM.getMaximalTypeExpansionContext()),
-        [&](unsigned startIndex, unsigned size) {
-          assert(size == 1);
-          Explosion selfTemp;
-          selfTemp.add(emission->getContext());
-          return selfTemp;
-        });
-
-    // Even if we don't have a 'self', if we have an error result, we
-    // should have a placeholder argument here.
-    //
-    // For async functions, there will be a thick context within the async
-    // context whenever there is no self context.
-  } else if ((!funcTy->isAsync() && funcTy->hasErrorResult()) ||
-             funcTy->getRepresentation() ==
-                 SILFunctionTypeRepresentation::Thick) {
-    llvm::Value *contextPtr = emission->getContext();
-    (void)contextPtr;
-    assert(contextPtr->getType() == IGF.IGM.RefCountedPtrTy);
-  } else if (isKeyPathAccessorRepresentation(funcTy->getRepresentation())) {
+  if (!boundContextParameter &&
+      isKeyPathAccessorRepresentation(funcTy->getRepresentation())) {
     auto genericEnv = IGF.CurSILFn->getGenericEnvironment();
     SmallVector<GenericRequirement, 4> requirements;
     CanGenericSignature genericSig;
@@ -2346,7 +2359,7 @@ static void emitEntryPointArgumentsNativeCC(IRGenSILFunction &IGF,
         componentArgsBuf = allParamValues.takeLast();
         bindParameter(
             IGF, *emission, baseIndexOfIndicesArguments + i, indicesArg,
-            conv.getSILArgumentType(baseIndexOfIndicesArguments + i,
+            fnConv.getSILArgumentType(baseIndexOfIndicesArguments + i,
                                     IGF.IGM.getMaximalTypeExpansionContext()),
             [&](unsigned startIndex, unsigned size) {
               assert(size == 1);
@@ -2372,9 +2385,9 @@ static void emitEntryPointArgumentsNativeCC(IRGenSILFunction &IGF,
   // Map the remaining SIL parameters to LLVM parameters.
   unsigned i = 0;
   for (SILArgument *param : params) {
-    auto argIdx = conv.getSILArgIndexOfFirstParam() + i;
+    auto argIdx = fnConv.getSILArgIndexOfFirstParam() + i;
     bindParameter(IGF, *emission, i, param,
-                  conv.getSILArgumentType(
+                  fnConv.getSILArgumentType(
                       argIdx, IGF.IGM.getMaximalTypeExpansionContext()),
                   [&](unsigned index, unsigned size) {
                     return emission->getArgumentExplosion(index, size);

--- a/test/IRGen/async_typed_throws_wasm.swift
+++ b/test/IRGen/async_typed_throws_wasm.swift
@@ -1,0 +1,74 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -parse-as-library \
+// RUN:   -disable-availability-checking | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -parse-as-library \
+// RUN:   -disable-availability-checking -enable-library-evolution | %FileCheck %s --check-prefix=RESILIENT
+
+// REQUIRES: concurrency
+// REQUIRES: OS=wasip1
+
+struct LargeErr: Error {
+  var tag: Int
+  var pad: (Int, Int, Int, Int)
+}
+
+struct LargeResult {
+  var tag: Int
+  var pad: (Int, Int, Int, Int, Int, Int, Int, Int)
+}
+
+protocol PAsync {
+  associatedtype Failure: Error
+  associatedtype Output
+  func boom() async throws(Failure) -> Output
+}
+
+struct ImplPAsync: PAsync {
+  typealias Failure = LargeErr
+  typealias Output = LargeResult
+  func boom() async throws(LargeErr) -> LargeResult {
+    throw LargeErr(tag: 1, pad: (0, 0, 0, 0))
+  }
+}
+
+func run<T, Failure: Error>(
+  _ body: () async throws(Failure) -> T
+) async -> Result<T, Failure> {
+  do { return .success(try await body()) }
+  catch { return .failure(error) }
+}
+
+func runWitness<T: PAsync>(_ x: T) async -> Result<T.Output, T.Failure> {
+  do { return .success(try await x.boom()) }
+  catch { return .failure(error) }
+}
+
+@main
+struct Main {
+  static func main() async {
+    let r = await run { () async throws(LargeErr) -> LargeResult in
+      throw LargeErr(tag: 2, pad: (0, 0, 0, 0))
+    }
+    _ = r
+    let w = await runWitness(ImplPAsync())
+    _ = w
+  }
+}
+
+// Witness thunk: trailing pair [indirect error, swiftself], then Self + WT.
+// CHECK-LABEL: define internal {{(swifttailcc|swiftcc)}} void @"$s{{[^"]+}}P4boom6OutputQzyYa7FailureQzYKFTW"
+// CHECK-SAME: (ptr noalias{{[^,]*}} %{{[0-9]+}}, ptr swiftasync %{{[0-9]+}}, ptr %{{[0-9]+}}, ptr noalias{{[^,]*}} swiftself{{[^,]*}} %{{[0-9]+}}, ptr %{{[0-9_a-zA-Z]+}}, ptr %{{[0-9_a-zA-Z]+}})
+
+// Thin closure literal: indirect result, swiftasync, indirect error. No swiftself.
+// CHECK-LABEL: define internal {{(swifttailcc|swiftcc)}} void @"$s{{[^"]+}}fU_"
+// CHECK-SAME: (ptr noalias{{[^,]*}} %{{[0-9]+}}, ptr swiftasync %{{[0-9]+}}, ptr %{{[0-9]+}})
+
+// The witness thunk must NOT use the old [..., swiftself, indirect error, Self, WT]
+// layout (3 trailing ptrs after swiftself); the pair puts exactly 2 (Self + WT).
+// CHECK-NOT: define internal {{(swifttailcc|swiftcc)}} void @"$s{{[^"]+}}P4boom6OutputQzyYa7FailureQzYKFTW"({{[^)]*}}swiftself{{[^,]*}}, ptr %{{[0-9]+}}, ptr %{{[0-9_a-zA-Z]+}}, ptr %{{[0-9_a-zA-Z]+}})
+
+// Dispatch thunk (Tj) for the protocol requirement, emitted under library
+// evolution. The entry carries [indirect error, swiftself] and the thunk must
+// forward them in the same order (identity, not swapped).
+// RESILIENT-LABEL: define{{.*}} {{(swifttailcc|swiftcc)}} void @"$s{{[^"]+}}PAsyncP4boom6OutputQzyYa7FailureQzYKFTj"
+// RESILIENT-SAME: (ptr noalias{{[^,]*}} %{{[0-9]+}}, ptr swiftasync %{{[0-9]+}}, ptr %[[IE:[0-9]+]], ptr noalias{{[^,]*}} swiftself{{[^,]*}} %[[SS:[0-9]+]], ptr %{{[0-9_a-zA-Z]+}}, ptr %{{[0-9_a-zA-Z]+}})
+// RESILIENT: call {{(swifttailcc|swiftcc)}} void %{{[0-9]+}}(ptr noalias{{[^,]*}} %{{[0-9]+}}, ptr swiftasync %{{[0-9]+}}, ptr %[[IE]], ptr noalias{{[^,]*}} swiftself{{[^,]*}} %[[SS]], ptr %{{[0-9_a-zA-Z]+}}, ptr %{{[0-9_a-zA-Z]+}})

--- a/test/IRGen/typed_throws.sil
+++ b/test/IRGen/typed_throws.sil
@@ -391,8 +391,8 @@ entry(%0: $*T):
 
 sil @try_apply_helper_generic_async : $@convention(thin) @async <T> (@in T) -> (@out T, @error_indirect T)
 
-// CHECK: define{{.*}} internal swifttailcc void @"$s30try_apply_helper_generic_asyncTA"(ptr noalias %0, ptr swiftasync %1, ptr swiftself %2, ptr %3)
-// CHECK: call { ptr, ptr } (i32, ptr, ptr, ...) @llvm.coro.suspend.async.sl_p0p0s({{.*}}, ptr @try_apply_helper_generic_async, ptr %0, {{.*}}, ptr %T, ptr %3)
+// CHECK: define{{.*}} internal swifttailcc void @"$s30try_apply_helper_generic_asyncTA"(ptr noalias %0, ptr swiftasync %1, ptr %2, ptr swiftself %3)
+// CHECK: call { ptr, ptr } (i32, ptr, ptr, ...) @llvm.coro.suspend.async.sl_p0p0s({{.*}}, ptr @try_apply_helper_generic_async, ptr %0, {{.*}}, ptr %T, ptr %2)
 sil @partial_apply_test_generic_async : $@convention(thin) @async <T> (@in T) -> @owned @callee_guaranteed @async () -> (@out T, @error_indirect T) {
 entry(%0: $*T):
   %f = function_ref @try_apply_helper_generic_async : $@convention(thin) @async <T> (@in T) -> (@out T, @error_indirect T)
@@ -436,7 +436,7 @@ bb6:
 // CHECK: define{{.*}} swifttailcc void @apply_closure_generic_async(ptr swiftasync %0, ptr %1, ptr %2, ptr %T, ptr %V)
 // CHECK: [[RES:%.*]] = call swiftcc ptr @swift_task_alloc
 // CHECK: [[ERR:%.*]] = call swiftcc ptr @swift_task_alloc
-// CHECK: call { ptr, ptr } (i32, ptr, ptr, ...) @llvm.coro.suspend.async.sl_p0p0s(i32 256, ptr {{.*}}, ptr @__swift_async_resume_project_context, ptr @apply_closure_generic_async.0, ptr {{%[0-9]+}},{{( i64 [0-9]+,)?}} ptr [[RES]], ptr {{%[0-9]+}}, ptr %2, ptr [[ERR]])
+// CHECK: call { ptr, ptr } (i32, ptr, ptr, ...) @llvm.coro.suspend.async.sl_p0p0s(i32 256, ptr {{.*}}, ptr @__swift_async_resume_project_context, ptr @apply_closure_generic_async.0, ptr {{%[0-9]+}},{{( i64 [0-9]+,)?}} ptr [[RES]], ptr {{%[0-9]+}}, ptr [[ERR]], ptr %2)
 
 sil @apply_closure_generic_async : $@convention(thin) @async <T, V> (@guaranteed @callee_guaranteed @async () ->(@out T, @error_indirect V)) -> () {
 entry(%0 : $@callee_guaranteed @async () -> (@out T, @error_indirect V)):

--- a/test/IRGen/typed_throws.swift
+++ b/test/IRGen/typed_throws.swift
@@ -302,7 +302,7 @@ protocol AsyncGenProto<A> {
 }
 
 // CHECK: define internal swifttailcc void @"$s12typed_throws23callAsyncIndirectResult1p1xxAA0D8GenProto_px1ARts_XP_SitYaAA10SmallErrorVYKlFTY0_"(ptr swiftasync %0)
-// CHECK:   musttail call swifttailcc void {{%.*}}(ptr noalias {{%.*}}, ptr swiftasync {{%.*}}, i64 {{%.*}}, ptr noalias swiftself {{%.*}}, ptr %swifterror, ptr {{%.*}}, ptr {{%.*}})
+// CHECK:   musttail call swifttailcc void {{%.*}}(ptr noalias {{%.*}}, ptr swiftasync {{%.*}}, i64 {{%.*}}, ptr %swifterror, ptr noalias swiftself {{%.*}}, ptr {{%.*}}, ptr {{%.*}})
 // CHECK:   ret void
 // CHECK: }
 @inline(never)

--- a/test/IRGen/typed_throws_abi.swift
+++ b/test/IRGen/typed_throws_abi.swift
@@ -3691,7 +3691,7 @@ protocol PAsync {
     // CHECK: }
     func f4(_ b: Bool) async throws(Empty) -> (Int, Int, Int, Int)
 
-    // CHECK: define hidden swifttailcc void @"$s16typed_throws_abi6PAsyncP2f5ySi_S4itSbYaAA5EmptyVYKFTj"(ptr noalias captures(none) %0, ptr swiftasync %1, i1 %2, ptr noalias swiftself %3, ptr %4, ptr %5, ptr %6)
+    // CHECK: define hidden swifttailcc void @"$s16typed_throws_abi6PAsyncP2f5ySi_S4itSbYaAA5EmptyVYKFTj"(ptr noalias captures(none) %0, ptr swiftasync %1, i1 %2, ptr %3, ptr noalias swiftself %4, ptr %5, ptr %6)
     // CHECK:   %swifterror = alloca swifterror ptr
     // CHECK:   [[CORO:%.*]] = call ptr @llvm.coro.begin(token {{%.*}}, ptr null)
     // CHECK:   store ptr null, ptr %swifterror
@@ -3772,7 +3772,7 @@ protocol PAsync {
     // CHECK: }
     func g4(_ b: Bool) async throws(OneWord) -> (Int, Int, Int, Int)
 
-    // CHECK: define hidden swifttailcc void @"$s16typed_throws_abi6PAsyncP2g5ySi_S4itSbYaAA7OneWordVYKFTj"(ptr noalias captures(none) %0, ptr swiftasync %1, i1 %2, ptr noalias swiftself %3, ptr %4, ptr %5, ptr %6)
+    // CHECK: define hidden swifttailcc void @"$s16typed_throws_abi6PAsyncP2g5ySi_S4itSbYaAA7OneWordVYKFTj"(ptr noalias captures(none) %0, ptr swiftasync %1, i1 %2, ptr %3, ptr noalias swiftself %4, ptr %5, ptr %6)
     // CHECK:   %swifterror = alloca swifterror ptr
     // CHECK:   [[CORO:%.*]] = call ptr @llvm.coro.begin(token {{%.*}}, ptr null)
     // CHECK:   store ptr null, ptr %swifterror
@@ -3853,7 +3853,7 @@ protocol PAsync {
     // CHECK: }
     func h4(_ b: Bool) async throws(TwoWords) -> (Int, Int, Int, Int)
 
-    // CHECK: define hidden swifttailcc void @"$s16typed_throws_abi6PAsyncP2h5ySi_S4itSbYaAA8TwoWordsVYKFTj"(ptr noalias captures(none) %0, ptr swiftasync %1, i1 %2, ptr noalias swiftself %3, ptr %4, ptr %5, ptr %6)
+    // CHECK: define hidden swifttailcc void @"$s16typed_throws_abi6PAsyncP2h5ySi_S4itSbYaAA8TwoWordsVYKFTj"(ptr noalias captures(none) %0, ptr swiftasync %1, i1 %2, ptr %3, ptr noalias swiftself %4, ptr %5, ptr %6)
     // CHECK:   %swifterror = alloca swifterror ptr
     // CHECK:   [[CORO:%.*]] = call ptr @llvm.coro.begin(token {{%.*}}, ptr null)
     // CHECK:   store ptr null, ptr %swifterror
@@ -3934,7 +3934,7 @@ protocol PAsync {
     // CHECK: }
     func i4(_ b: Bool) async throws(ThreeWords) -> (Int, Int, Int, Int)
 
-    // CHECK: define hidden swifttailcc void @"$s16typed_throws_abi6PAsyncP2i5ySi_S4itSbYaAA10ThreeWordsVYKFTj"(ptr noalias captures(none) %0, ptr swiftasync %1, i1 %2, ptr noalias swiftself %3, ptr %4, ptr %5, ptr %6)
+    // CHECK: define hidden swifttailcc void @"$s16typed_throws_abi6PAsyncP2i5ySi_S4itSbYaAA10ThreeWordsVYKFTj"(ptr noalias captures(none) %0, ptr swiftasync %1, i1 %2, ptr %3, ptr noalias swiftself %4, ptr %5, ptr %6)
     // CHECK:   %swifterror = alloca swifterror ptr
     // CHECK:   [[CORO:%.*]] = call ptr @llvm.coro.begin(token {{%.*}}, ptr null)
     // CHECK:   store ptr null, ptr %swifterror

--- a/test/IRGen/typed_throws_thunks.swift
+++ b/test/IRGen/typed_throws_thunks.swift
@@ -23,7 +23,7 @@ public protocol P {
 }
 
 extension P {
- // CHECK-LABEL: define{{.*}} swifttailcc void @"$s19typed_throws_thunks1PP1g4bodyyyy7FailureQzYKXE_tYaAGYKFTj"(ptr swiftasync %0, ptr %1, ptr %2, ptr noalias swiftself %3, ptr %4, ptr %5, ptr %6)
+ // CHECK-LABEL: define{{.*}} swifttailcc void @"$s19typed_throws_thunks1PP1g4bodyyyy7FailureQzYKXE_tYaAGYKFTj"(ptr swiftasync %0, ptr %1, ptr %2, ptr %3, ptr noalias swiftself %4, ptr %5, ptr %6)
  // CHECK-NOT: ret
  // CHECK:  call { ptr, ptr } (i32, ptr, ptr, ...) @llvm.coro.suspend.async.sl_p0p0s({{.*}}, ptr %1, ptr %2, ptr %3, ptr %4, ptr %5, ptr %6)
   public func g(body: () throws(Failure) -> Void) async throws(Failure) {

--- a/test/Interpreter/async_typed_throws_default_impl.swift
+++ b/test/Interpreter/async_typed_throws_default_impl.swift
@@ -1,0 +1,44 @@
+// RUN: %target-run-simple-swift(-target %target-swift-5.1-abi-triple -parse-as-library)
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+
+struct Failure: Error, Equatable { var value = 1 }
+
+extension Sequence {
+  var async: AsyncLazySequence<Self> { AsyncLazySequence(self) }
+}
+public struct AsyncLazySequence<S: Sequence>: AsyncSequence {
+  public typealias Element = S.Element
+  public struct Iterator: AsyncIteratorProtocol {
+    var it: S.Iterator
+    init(_ i: S.Iterator) { it = i }
+    public mutating func next() async -> S.Element? { it.next() }
+  }
+  let s: S
+  init(_ x: S) { s = x }
+  public func makeAsyncIterator() -> Iterator { Iterator(s.makeIterator()) }
+}
+extension AsyncSequence where Element: Equatable {
+  func failOn(_ error: Error, at x: Element) -> AsyncThrowingMapSequence<Self, Element> {
+    map { (v: Element) throws -> Element in if v == x { throw error }; return v }
+  }
+  func containsByDraining(_ search: Element) async rethrows -> Bool {
+    for try await e in self { if e == search { return true } }
+    return false
+  }
+}
+
+@main struct Main {
+  static func main() async {
+    var threw = false
+    do {
+      _ = try await [1, 2, 3].async.failOn(Failure(value: 42), at: 2)
+                                   .containsByDraining(99)
+    } catch {
+      threw = (error as? Failure) == Failure(value: 42)
+    }
+    // CHECK: propagated: true
+    print("propagated: \(threw)")
+  }
+}

--- a/test/Interpreter/async_typed_throws_wasm.swift
+++ b/test/Interpreter/async_typed_throws_wasm.swift
@@ -1,0 +1,311 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -parse-as-library -Onone %s -o %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+// REQUIRES: OS=wasip1
+
+enum SmallErr: Error { case boom }
+
+struct LargeErr: Error {
+  var tag: Int
+  var pad: (Int, Int, Int, Int)
+}
+
+struct LargeResult {
+  var tag: Int
+  var pad: (Int, Int, Int, Int, Int, Int, Int, Int)
+}
+
+func run<T, Failure: Error>(
+  _ body: () async throws(Failure) -> T
+) async -> Result<T, Failure> {
+  do { return .success(try await body()) }
+  catch { return .failure(error) }
+}
+
+func runIdent(_ body: () async -> String) async -> String {
+  await body()
+}
+
+// For shape h: closure loaded from storage rather than a literal.
+enum StoredClosure {
+  static let boomClosure: () async throws(SmallErr) -> String = {
+    throw SmallErr.boom
+  }
+}
+
+// For shape j: witness-method async typed-throws.
+protocol AsyncBoom {
+  associatedtype Failure: Error
+  func boom() async throws(Failure) -> String
+}
+
+struct BoomThrower: AsyncBoom {
+  typealias Failure = SmallErr
+  func boom() async throws(SmallErr) -> String { throw .boom }
+}
+
+func invokeWitness<T: AsyncBoom>(_ x: T) async -> Result<String, T.Failure> {
+  do { return .success(try await x.boom()) }
+  catch { return .failure(error) }
+}
+
+// For shape k: Thick self-context (actor method invoking a typed-throws closure).
+actor BoomActor {
+  func run() async -> Result<String, SmallErr> {
+    do {
+      return .success(try await { () async throws(SmallErr) -> String in
+        throw SmallErr.boom
+      }())
+    } catch {
+      return .failure(error)
+    }
+  }
+}
+
+// For shape q: witness-method x LargeErr.
+protocol LargeAsync {
+  func boom() async throws(LargeErr) -> String
+}
+struct LargeBoom: LargeAsync {
+  func boom() async throws(LargeErr) -> String {
+    throw LargeErr(tag: 11, pad: (0, 0, 0, 0))
+  }
+}
+func invokeLarge<T: LargeAsync>(_ x: T) async -> Result<String, LargeErr> {
+  do { return .success(try await x.boom()) }
+  catch { return .failure(error) }
+}
+
+// For shape r: actor cross-isolation with large typed error.
+actor LargeActor {
+  func bang() async throws(LargeErr) -> String {
+    throw LargeErr(tag: 13, pad: (0, 0, 0, 0))
+  }
+}
+
+// For shape s: @MainActor + async typed-throws with large error.
+@MainActor
+func mainLargeErr() async throws(LargeErr) -> String {
+  throw LargeErr(tag: 17, pad: (0, 0, 0, 0))
+}
+
+// For shape t: replica of the stdlib Result.init(catching:) initializer,
+// with Failure inferred as `any Error` from an untyped-throws closure.
+enum MyResult<Success: ~Copyable, Failure: Error>: ~Copyable {
+  case success(Success)
+  case failure(Failure)
+}
+extension MyResult: Copyable where Success: Copyable {}
+
+extension MyResult where Success: ~Copyable {
+  @_alwaysEmitIntoClient
+  nonisolated(nonsending) init(
+    catching body: nonisolated(nonsending) () async throws(Failure) -> Success
+  ) async {
+    do {
+      self = .success(try await body())
+    } catch {
+      self = .failure(error)
+    }
+  }
+}
+
+@main
+struct Main {
+  static func main() async {
+    // a: untyped throws (baseline repro).
+    let a = await run { () async throws -> String in throw SmallErr.boom }
+    switch a {
+    case .success(let s): print("a-ok: \(s)")
+    case .failure(let e): print("a-err: \(e)")
+    }
+    // CHECK: a-err: boom
+
+    // b: typed throws, small error enum.
+    let b = await run { () async throws(SmallErr) -> String in
+      throw SmallErr.boom
+    }
+    switch b {
+    case .success(let s): print("b-ok: \(s)")
+    case .failure(let e): print("b-err: \(e)")
+    }
+    // CHECK-NEXT: b-err: boom
+
+    // c: typed throws, large error struct (indirect error).
+    let c = await run { () async throws(LargeErr) -> String in
+      throw LargeErr(tag: 42, pad: (0, 0, 0, 0))
+    }
+    switch c {
+    case .success(let s): print("c-ok: \(s)")
+    case .failure(let e): print("c-err: tag=\(e.tag)")
+    }
+    // CHECK-NEXT: c-err: tag=42
+
+    // d: success path, no throws taken.
+    let d = await run { () async throws -> String in "yay" }
+    switch d {
+    case .success(let s): print("d-ok: \(s)")
+    case .failure(let e): print("d-err: \(e)")
+    }
+    // CHECK-NEXT: d-ok: yay
+
+    // e: non-throwing closure (no indirect-error slot).
+    let e = await runIdent { () async -> String in "noerror" }
+    print("e-ok: \(e)")
+    // CHECK-NEXT: e-ok: noerror
+
+    // f: generic typed-throws via an explicit type argument.
+    let f: Result<String, SmallErr> = await run {
+      () async throws(SmallErr) -> String in throw SmallErr.boom
+    }
+    switch f {
+    case .success(let s): print("f-ok: \(s)")
+    case .failure(let e): print("f-err: \(e)")
+    }
+    // CHECK-NEXT: f-err: boom
+
+    // g: closure value from a phi/block argument.
+    let cond = Bool.random()
+    let g: Result<String, SmallErr> = await run {
+      () async throws(SmallErr) -> String in
+        if cond { throw SmallErr.boom } else { throw SmallErr.boom }
+    }
+    switch g {
+    case .success(let s): print("g-ok: \(s)")
+    case .failure(let e): print("g-err: \(e)")
+    }
+    // CHECK-NEXT: g-err: boom
+
+    // h: closure loaded from a stored global.
+    let h: Result<String, SmallErr> = await run(StoredClosure.boomClosure)
+    switch h {
+    case .success(let s): print("h-ok: \(s)")
+    case .failure(let e): print("h-err: \(e)")
+    }
+    // CHECK-NEXT: h-err: boom
+
+    // i: closure result used across basic blocks.
+    var iResult: Result<String, SmallErr>?
+    let iClosure: () async throws(SmallErr) -> String = {
+      throw SmallErr.boom
+    }
+    if Bool.random() || true {
+      iResult = await run(iClosure)
+    }
+    switch iResult! {
+    case .success(let s): print("i-ok: \(s)")
+    case .failure(let e): print("i-err: \(e)")
+    }
+    // CHECK-NEXT: i-err: boom
+
+    // j: witness-method typed-throws.
+    let j = await invokeWitness(BoomThrower())
+    switch j {
+    case .success(let s): print("j-ok: \(s)")
+    case .failure(let e): print("j-err: \(e)")
+    }
+    // CHECK-NEXT: j-err: boom
+
+    // k: thick self-context (actor isolation).
+    let k = await BoomActor().run()
+    switch k {
+    case .success(let s): print("k-ok: \(s)")
+    case .failure(let e): print("k-err: \(e)")
+    }
+    // CHECK-NEXT: k-err: boom
+
+    // l: large indirect result + indirect error.
+    let l: Result<LargeResult, LargeErr> = await run {
+      () async throws(LargeErr) -> LargeResult in
+        throw LargeErr(tag: 99, pad: (0, 0, 0, 0))
+    }
+    switch l {
+    case .success(let r): print("l-ok: tag=\(r.tag)")
+    case .failure(let e): print("l-err: tag=\(e.tag)")
+    }
+    // CHECK-NEXT: l-err: tag=99
+
+    // m: negative case: async non-throwing (no indirect-error slot).
+    let m = await runIdent { () async -> String in "no-error" }
+    print("m-ok: \(m)")
+    // CHECK-NEXT: m-ok: no-error
+
+    // n: control-flow-driven capture; success and error paths must not
+    // conflate the context and error slots.
+    let capture = Int.random(in: 1...10)
+    let nClosure: () async throws(SmallErr) -> String = {
+      if capture > 0 { return "ok-\(capture)" } else { throw SmallErr.boom }
+    }
+    let nResult = await run(nClosure)
+    switch nResult {
+    case .success(let s): print("n-ok: \(s.hasPrefix("ok-"))")
+    case .failure(let err): print("n-err: \(err)")
+    }
+    // CHECK-NEXT: n-ok: true
+
+    // o: typed throws returning Void (indirect error, Void result).
+    let oResult: Result<Void, SmallErr> = await run {
+      () async throws(SmallErr) -> Void in throw SmallErr.boom
+    }
+    switch oResult {
+    case .success: print("o-ok")
+    case .failure(let err): print("o-err: \(err)")
+    }
+    // CHECK-NEXT: o-err: boom
+
+    // p: multiple indirect results + typed error.
+    let pResult: Result<(LargeResult, LargeResult), LargeErr> = await run {
+      () async throws(LargeErr) -> (LargeResult, LargeResult) in
+        throw LargeErr(tag: 7, pad: (0, 0, 0, 0))
+    }
+    switch pResult {
+    case .success(let pair): print("p-ok: \(pair.0.tag)")
+    case .failure(let err): print("p-err: tag=\(err.tag)")
+    }
+    // CHECK-NEXT: p-err: tag=7
+
+    // q: witness-method + large error; Self+WT trail the
+    // [indirect error, swiftself] pair.
+    let qResult = await invokeLarge(LargeBoom())
+    switch qResult {
+    case .success(let s): print("q-ok: \(s)")
+    case .failure(let err): print("q-err: tag=\(err.tag)")
+    }
+    // CHECK-NEXT: q-err: tag=11
+
+    // r: actor cross-isolation with a large typed error (hop thunk).
+    let rResult: Result<String, LargeErr>
+    do { rResult = .success(try await LargeActor().bang()) }
+    catch { rResult = .failure(error) }
+    switch rResult {
+    case .success(let s): print("r-ok: \(s)")
+    case .failure(let err): print("r-err: tag=\(err.tag)")
+    }
+    // CHECK-NEXT: r-err: tag=13
+
+    // s: @MainActor hop with a large typed error.
+    let sResult: Result<String, LargeErr>
+    do { sResult = .success(try await mainLargeErr()) }
+    catch { sResult = .failure(error) }
+    switch sResult {
+    case .success(let s): print("s-ok: \(s)")
+    case .failure(let err): print("s-err: tag=\(err.tag)")
+    }
+    // CHECK-NEXT: s-err: tag=17
+
+    // t: Result.init(catching:) replica; Failure inferred as any Error.
+    func asyncThrowing() async throws -> String {
+      throw SmallErr.boom
+    }
+    let t = await MyResult { try await asyncThrowing() }
+    switch t {
+    case .success(let s): print("t-ok: \(s)")
+    case .failure(let e): print("t-err: \(e)")
+    }
+    // CHECK-NEXT: t-err: boom
+  }
+}

--- a/test/stdlib/Result+asyncInit.swift
+++ b/test/stdlib/Result+asyncInit.swift
@@ -1,0 +1,68 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+
+import StdlibUnittest
+import Swift
+
+let ResultAsyncInitTests = TestSuite("ResultAsyncInit")
+
+fileprivate enum Err: Error, Equatable {
+  case err
+  case derr
+}
+
+fileprivate let string = "string"
+
+fileprivate extension Result {
+  var success: Success? {
+    switch self {
+    case let .success(success):
+      return success
+    case .failure:
+      return nil
+    }
+  }
+
+  var failure: Failure? {
+    switch self {
+    case .success:
+      return nil
+    case let .failure(failure):
+      return failure
+    }
+  }
+}
+
+ResultAsyncInitTests.test("Async Initialization") {
+  func asyncThrowing() async throws -> String {
+    throw Err.err
+  }
+
+  func asyncNotThrowing() async throws -> String {
+    return string
+  }
+
+  let result1 = await Result { try await asyncThrowing() }
+  let result2 = await Result { try await asyncNotThrowing() }
+
+  expectEqual(result1.failure as? Err, Err.err)
+  expectEqual(result2.success, string)
+
+  do {
+    _ = try result1.get()
+  } catch let error as Err {
+    expectEqual(error, Err.err)
+  } catch {
+    expectUnreachable()
+  }
+
+  do {
+    let unwrapped = try result2.get()
+    expectEqual(unwrapped, string)
+  } catch {
+    expectUnreachable()
+  }
+}
+
+await runAllTestsAsync()


### PR DESCRIPTION
Cherry-pick of #89715, merged as 4c990823cd75089d08cca692b25cbb2d939f1974

**Explanation**: On wasm32 the WebAssembly backend pads the `swiftself` and `swifterror` parameters, which left the indirect typed-error pointer and the `swiftself`/context slot at different LLVM-IR positions for Thin versus Thick async callers; caller and callee then disagreed on which trailing pointer held the typed-error slot and miscompiled async typed-throws calls (#89155: `Result.init(catching:) async` trapped in a value-witness copy on Wasm).

With this change `SignatureExpansion::expandAsyncEntryType` now emits `addIndirectThrowingResult` before the `swiftself`/context slot, so the trailing pair is always `[ind_error, swiftself]` and Thin and Thick agree on the position regardless of parameter padding. The result-shape decision moves behind one gate, `hasTrailingAsyncErrorContextPair` (`GenCall.h`), consumed by the three sites that read these slots positionally: `AsyncCallEmission::setFromCallee`, `AsyncPartialApplicationForwarderEmission`, and `AsyncNativeCCEntryPointArgumentEmission::mapAsyncParameters` (the last also pre-extracts the witness-method Self/witness-table that trail the pair).

**Scope**: IRGen async typed-throws lowering only; while resulting LLVM IR has different ordering of parameters, non-Wasm native codegen is unchanged.
**Risk**: Low. Non-Wasm codegen is unchanged (the reorder only moves IR operands; `swiftself`/`swifterror` stay register-pinned by attribute). The only calling-convention change is on Wasm, which was already miscompiling.
**Testing**:  New execution test reproduces #89155 on Wasm; IRGen tests updated to pin the new parameter order.
**Issue**: https://github.com/swiftlang/swift/issues/89320, rdar://177615931
**Reviewed by**: @drexin @kateinoigakukun @rjmccall
