### PR TITLE
🍒 [6.4][cxx-interop] Update availability guard on CxxIterable

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3825,7 +3825,7 @@ static void printWithSuppressibleFeatureChecks(ASTPrinter &printer,
 
 // Returns true if the given declaration is CxxIterable,
 // CxxBorrowingIterator or an extension of one of these.
-static bool isCxxIterableOrIterator(Decl *decl) {
+static bool isCxxIterableOrBorrowingIterator(Decl *decl) {
   if (auto *ext = dyn_cast<ExtensionDecl>(decl))
     decl = ext->getExtendedNominal();
 
@@ -3903,8 +3903,8 @@ void swift::printWithCompatibilityFeatureChecks(ASTPrinter &printer,
   // compiler is used with an older SDK, the Cxx module interface may reference
   // these Swift stdlib protocols even though they don't exist in the SDK's
   // stdlib. To handle this, we guard them behind a Swift version.
-  if (isCxxIterableOrIterator(decl)) {
-    printer << "#if canImport(Swift, _version: 6.4.0.12)\n";
+  if (isCxxIterableOrBorrowingIterator(decl)) {
+    printer << "#if canImport(Swift, _version: 6.4.0.30)\n";
     printBody();
     printer.printNewline();
     printer << "#endif";


### PR DESCRIPTION
- **Explanation**: During the renaming from `BorrowingSequence` to `Iterable`, the Swift version check introduced in https://github.com/swiftlang/swift/pull/87882 was not updated.
- **Scope**: Changes the swift version printed by `ASTPrinter.cpp` to guard `CxxIterable` and related protocols and extensions.
- **Issues**: rdar://182114249
- **Original PRs**: https://github.com/swiftlang/swift/pull/90660
- **Risk**: Small. It's a small change that only applies to `CxxIterable` and related
- **Testing**: Cannot be tested with unit tests, but verified locally. 
- **Reviewers**: @tshortli @egorzhdan 

(cherry-picked from commit aee5de6daec1e9fe5c8946a57f7e3cd1afbc10cd)