### PR TITLE
[SIL]: Refactor getCalleeOrigin to look through more instructions

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -2848,11 +2848,8 @@ public:
   const Operand *getCalleeOperand() const { return &getAllOperands()[Callee]; }
   SILValue getCallee() const { return getCalleeOperand()->get(); }
 
-  /// Gets the origin of the callee by looking through function type conversions
-  /// until we find a function_ref, partial_apply, or unrecognized value.
-  ///
-  /// This is defined out of line to work around incomplete definition
-  /// issues. It is at the bottom of the file.
+  /// Gets the callee's origin by looking through instructions handled by
+  /// `getSingleValueCopyOrCast`.
   SILValue getCalleeOrigin() const;
 
   /// Gets the referenced function by looking through partial apply,
@@ -12103,38 +12100,6 @@ public:
   ArrayRef<Operand> getAllOperands() const { return {}; }
   MutableArrayRef<Operand> getAllOperands() { return {}; }
 };
-
-// This is defined out of line to work around the fact that this depends on
-// PartialApplyInst being defined, but PartialApplyInst is a subclass of
-// ApplyInstBase, so we can not place ApplyInstBase after it.
-template <class Impl, class Base>
-SILValue ApplyInstBase<Impl, Base, false>::getCalleeOrigin() const {
-  SILValue Callee = getCallee();
-  while (true) {
-    if (auto *TTTFI = dyn_cast<ThinToThickFunctionInst>(Callee)) {
-      Callee = TTTFI->getCallee();
-      continue;
-    }
-    if (auto *CFI = dyn_cast<ConvertFunctionInst>(Callee)) {
-      Callee = CFI->getOperand();
-      continue;
-    }
-    if (auto *CETN = dyn_cast<ConvertEscapeToNoEscapeInst>(Callee)) {
-      Callee = CETN->getOperand();
-      continue;
-    }
-    // convert_escape_to_noescape's are within a borrow scope.
-    if (auto *beginBorrow = dyn_cast<BeginBorrowInst>(Callee)) {
-      Callee = beginBorrow->getOperand();
-      continue;
-    }
-    if (auto *copy = dyn_cast<CopyValueInst>(Callee)) {
-      Callee = copy->getOperand();
-      continue;
-    }
-    return Callee;
-  }
-}
 
 template <class Impl, class Base>
 bool ApplyInstBase<Impl, Base, false>::isCalleeDynamicallyReplaceable() const {

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -2353,6 +2353,49 @@ SILModule &SILInstructionContext::getModule() {
   return storage.get<SILFunction *>()->getModule();
 }
 
+// Defined here rather than in the header to avoid import cycles with
+// `getSingleValueCopyOrCast`.
+template <class Impl, class Base>
+SILValue ApplyInstBase<Impl, Base, false>::getCalleeOrigin() const {
+  SILValue Callee = getCallee();
+
+  while (auto *inst = Callee.getDefiningInstruction()) {
+    auto *copyOrCast = getSingleValueCopyOrCast(inst);
+    if (!copyOrCast)
+      break;
+
+    Callee = copyOrCast->getOperand(0);
+  }
+
+  return Callee;
+}
+
+template SILValue
+ApplyInstBase<ApplyInst, SingleValueInstruction, false>::getCalleeOrigin()
+    const;
+template SILValue ApplyInstBase<PartialApplyInst, SingleValueInstruction,
+                                false>::getCalleeOrigin() const;
+template SILValue ApplyInstBase<BeginApplyInst, MultipleValueInstruction,
+                                false>::getCalleeOrigin() const;
+template SILValue
+ApplyInstBase<TryApplyInst, TryApplyInstBase, false>::getCalleeOrigin() const;
+
+namespace swift::test {
+// Arguments:
+//   - instruction: the apply site whose callee origin to compute
+// Dumps:
+//   - the apply site
+//   - its callee origin
+static FunctionTest ApplyCalleeOriginTest(
+    "apply_callee_origin", [](auto &function, auto &arguments, auto &test) {
+      auto *inst = arguments.takeInstruction();
+      auto apply = ApplySite::isa(inst);
+      llvm::outs() << "Apply: ";
+      inst->print(llvm::outs());
+      llvm::outs() << "Callee origin: " << apply.getCalleeOrigin();
+    });
+} // end namespace swift::test
+
 template <class Impl, class Base>
 SILDeclRef ApplyInstBase<Impl, Base, false>::getCalleeDeclRef() const {
   SILValue origin = getCalleeOrigin();

--- a/test/SIL/Instruction/apply_callee_origin.sil
+++ b/test/SIL/Instruction/apply_callee_origin.sil
@@ -1,0 +1,31 @@
+// RUN: %target-sil-opt -test-runner %s -o /dev/null 2>&1 | %FileCheck %s
+
+sil_stage raw
+
+class NS {}
+
+sil @makeNS : $@convention(thin) (@guaranteed NS) -> @owned NS
+
+// CHECK-LABEL: begin running test {{.*}} on closure_move_value
+// CHECK:         Callee origin: {{.*}}= partial_apply
+// CHECK-LABEL: end running test {{.*}} on closure_move_value
+sil [ossa] @closure_move_value : $@convention(thin) (@guaranteed NS) -> () {
+entry(%0 : @guaranteed $NS):
+  specify_test "apply_callee_origin %call"
+
+  %f = function_ref @makeNS : $@convention(thin) (@guaranteed NS) -> @owned NS
+  %arg = copy_value %0
+  %pa = partial_apply [callee_guaranteed] %f(%arg) : $@convention(thin) (@guaranteed NS) -> @owned NS
+  %mv = move_value [lexical] [var_decl] %pa
+  %b1 = begin_borrow %mv
+  %cp = copy_value %b1
+  %b2 = begin_borrow %cp
+  %call = apply %b2() : $@callee_guaranteed () -> @owned NS
+  end_borrow %b2
+  destroy_value %call
+  destroy_value %cp
+  end_borrow %b1
+  destroy_value %mv
+  %ret = tuple ()
+  return %ret
+}


### PR DESCRIPTION
Previously ApplySite::getCalleeOrigin had bespoke lookthrough handling to derive the "origin" of its callee. This change replaces the old implementation with a search that uses the shared utility `getSingleValueCopyOrCast` instead.

The method definition was moved to SILInstruction.cpp to avoid cyclic import issues. A new FunctionTest was added for the method.
