### PR TITLE
[Embedded] Derive BridgeObject retain and release masks from ABI constants

### DIFF
--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -116,14 +116,8 @@ public struct HeapObject {
 #endif
 
 #if _pointerBitWidth(_64)
-#if os(Android) && arch(arm64)
-  // Android AArch64 stores the high spare bits in the second-highest byte.
   static let immortalObjectPointerBit = _bridgeObjectTaggedPointerBits
   static let bridgeObjectToPlainObjectMask = ~_objectPointerSpareBits
-#else
-  static let immortalObjectPointerBit = UInt(0x8000_0000_0000_0000)
-  static let bridgeObjectToPlainObjectMask = UInt(0x8fff_ffff_ffff_fff8)
-#endif
 #elseif _pointerBitWidth(_32)
   static let bridgeObjectToPlainObjectMask = UInt(0xffff_ffff)
 #elseif _pointerBitWidth(_16)

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -116,11 +116,14 @@ public struct HeapObject {
 #endif
 
 #if _pointerBitWidth(_64)
+#if os(Android) && arch(arm64)
+  // Android AArch64 stores the high spare bits in the second-highest byte.
+  static let immortalObjectPointerBit = _bridgeObjectTaggedPointerBits
+  static let bridgeObjectToPlainObjectMask = ~_objectPointerSpareBits
+#else
   static let immortalObjectPointerBit = UInt(0x8000_0000_0000_0000)
-#endif
-
-#if _pointerBitWidth(_64)
   static let bridgeObjectToPlainObjectMask = UInt(0x8fff_ffff_ffff_fff8)
+#endif
 #elseif _pointerBitWidth(_32)
   static let bridgeObjectToPlainObjectMask = UInt(0xffff_ffff)
 #elseif _pointerBitWidth(_16)

--- a/test/embedded/stdlib-strings-interpolation.swift
+++ b/test/embedded/stdlib-strings-interpolation.swift
@@ -2,7 +2,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu || OS=wasip1
+// REQUIRES: OS=macosx || OS=linux-gnu || OS=wasip1 || OS=linux-android
 // REQUIRES: swift_feature_Embedded
 
 @main


### PR DESCRIPTION
## Description

Fix Embedded Swift BridgeObject retain and release on AArch64 Android.

The embedded runtime hardcoded 64-bit pointer masks that assume the BridgeObject tag and String discriminator occupy the highest byte. This holds for x86_64 and normal AArch64, but not for AArch64 Android, which reserves the highest byte for pointer tagging and stores those bits in the second-highest byte instead.

As a result, runtime-created small strings could be passed to `swift_release_n` as invalid pointers such as `0x00e0000000000000`, causing a segmentation fault when loading the reference count.

## Changes

For 64-bit targets, derive the masks from the platform ABI constants instead of hardcoding them:

- `immortalObjectPointerBit` uses `_bridgeObjectTaggedPointerBits`.
- `bridgeObjectToPlainObjectMask` uses the complement of `_objectPointerSpareBits`.

These constants are already defined correctly per platform, so no `#if` per target is needed. This is a no-op on x86_64 and normal AArch64 (the derived values match the existing constants for reachable objects) and produces the correct shifted layout on AArch64 Android.

The existing Embedded Swift string interpolation test is also enabled for `OS=linux-android`.

## Validation

Built the Embedded Swift standard library for `aarch64-unknown-linux-android` and ran it on an arm64 Android emulator, without optimization, with `-O`, and with `-Osize`, covering:

- Small and heap-backed strings
- String interpolation and concatenation
- Unicode strings
- Arrays and dictionaries with string keys
- Class allocation and deinitialization

The existing `stdlib-strings-interpolation.swift` test passes on Android with its expected output.

cc @rauhul
