### PR TITLE
[cxx-interop] Fix `bridge-objc-types-back-to-objcxx-execution.mm`

### DIFF
--- a/test/Interop/ObjCToSwiftToObjCxx/bridge-objc-types-back-to-objcxx-execution.mm
+++ b/test/Interop/ObjCToSwiftToObjCxx/bridge-objc-types-back-to-objcxx-execution.mm
@@ -8,7 +8,7 @@
 
 // RUN: %target-codesign %t/swift-objc-execution
 // RUN: %target-run %t/swift-objc-execution | %FileCheck %s
-// RUN: %target-run %t/swift-objc-execution | %FileCheck --check-prefix=DESTROY %s
+// RUN: %target-run %t/swift-objc-execution | %FileCheck --check-prefix=DESTROY --implicit-check-not "destroy ObjCKlass" %s
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
@@ -160,7 +160,8 @@ int main() {
   assert(globalCounter == 0);
 // CHECK: create ObjCKlass
 // CHECK-NEXT: OBJClass: 1
-// CHECK-NEXT: create ObjCKlass
+// Original ObjCKlass instance can be released eagerly here.
+// CHECK: create ObjCKlass
 // CHECK: OBJClass: 2
 // CHECK-NEXT: NIL
 // DESTROY: destroy ObjCKlass


### PR DESCRIPTION
Optimizations sometimes reorder the destruction of objects in the test. This makes the test resilient to that.

rdar://182389973

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
