### PR TITLE
[DebugInfo] Call salvageDebugInfo correctly from Swift-side erase

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBeginCOWMutation.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBeginCOWMutation.swift
@@ -88,7 +88,7 @@ private extension BeginCOWMutationInst {
       let endCOW = use.instruction as! EndCOWMutationInst
       endCOW.replace(with: instance, context)
     }
-    context.erase(instructionIncludingDebugUses: self)
+    context.erase(instruction: self)
     return true
   }
 
@@ -105,8 +105,8 @@ private extension BeginCOWMutationInst {
     }
 
     instanceResult.uses.replaceAll(with: endCOW.instance, context)
-    context.erase(instructionIncludingDebugUses: self)
-    context.erase(instructionIncludingDebugUses: endCOW)
+    context.erase(instruction: self)
+    context.erase(instruction: endCOW)
     return true
   }
 }

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyDestructure.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyDestructure.swift
@@ -154,7 +154,7 @@ private extension DestructureInstruction {
 
     context.erase(instruction: self)
     if canEraseConstructure {
-      context.erase(instructionIncludingDebugUses: constructure)
+      context.erase(instruction: constructure)
     }
   }
 

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyRefCasts.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyRefCasts.swift
@@ -150,7 +150,7 @@ private extension UnaryInstruction {
         }
     }
     if canEraseInst {
-      context.erase(instructionIncludingDebugUses: inst)
+      context.erase(instruction: inst)
     }
     return true
   }

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifySwitchEnum.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifySwitchEnum.swift
@@ -58,7 +58,7 @@ extension SwitchEnumInst : OnoneSimplifiable {
     }
 
     if canEraseEnumInst {
-      context.erase(instructionIncludingDebugUses: enumInst)
+      context.erase(instruction: enumInst)
     }
   }
 }

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyTuple.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyTuple.swift
@@ -70,6 +70,6 @@ private func tryReplaceDestructConstructPair(destruct: MultipleValueInstruction 
   construct.uses.replaceAll(with: destruct.operand.value, context)
 
   if everyResultUsedOnce {
-    context.erase(instructionIncludingDebugUses: construct)
+    context.erase(instruction: construct)
   }
 }

--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
@@ -186,7 +186,7 @@ private func optimize(function: Function, _ context: FunctionPassContext, _ modu
 
       case let iem as InitExistentialMetatypeInst:
         if iem.uses.ignoreDebugUses.isEmpty {
-          context.erase(instructionIncludingDebugUses: iem)
+          context.erase(instruction: iem)
         }
 
       case let fri as FunctionRefInst:
@@ -283,7 +283,7 @@ private func removeUnusedMetatypeInstructions(in function: Function, _ context: 
   for inst in function.instructions {
     if let mt = inst as? MetatypeInst,
        mt.isTriviallyDeadIgnoringDebugUses {
-      context.erase(instructionIncludingDebugUses: mt)
+      context.erase(instruction: mt)
     }
   }
 }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -893,7 +893,7 @@ extension FunctionPassContext {
   func removeTriviallyDeadInstructionsIgnoringDebugUses(in function: Function) {
     for inst in function.reversedInstructions {
       if inst.isTriviallyDeadIgnoringDebugUses {
-        erase(instructionIncludingDebugUses: inst)
+        erase(instruction: inst)
       }
     }
   }
@@ -944,7 +944,7 @@ extension SimplifyContext {
     second.replace(with: replacement, self)
 
     if canEraseFirst {
-      erase(instructionIncludingDebugUses: first)
+      erase(instruction: first)
     }
   }
 }

--- a/SwiftCompilerSources/Sources/SIL/Context.swift
+++ b/SwiftCompilerSources/Sources/SIL/Context.swift
@@ -218,13 +218,6 @@ extension MutatingContext {
     }
   }
 
-  // This function doesn't do what its name implies, it's equivalent to erase(instruction:).
-  public func erase(instructionIncludingDebugUses inst: Instruction) {
-    precondition(inst.results.allSatisfy { $0.uses.ignoreDebugUses.isEmpty })
-    // Erase calls salvageDebugInfo which will rewrite all debug uses.
-    erase(instruction: inst)
-  }
-
   public func erase(block: BasicBlock) {
     _bridged.eraseBlock(block.bridged)
   }

--- a/SwiftCompilerSources/Sources/SIL/Context.swift
+++ b/SwiftCompilerSources/Sources/SIL/Context.swift
@@ -172,8 +172,8 @@ extension MutatingContext {
   }
 
   /// Removes and deletes `instruction`.
-  /// If `salvageDebugInfo` is true, compensating `debug_value` instructions are inserted for certain
-  /// kind of instructions.
+  /// If `salvageDebugInfo` is true, `debug_value` users of the instructions will be rewritten
+  /// Otherwise, the instruction must not have any uses at this point.
   public func erase(instruction: Instruction, salvageDebugInfo: Bool = true) {
     if !instruction.isInStaticInitializer {
       verifyIsTransforming(function: instruction.parentFunction)
@@ -195,18 +195,21 @@ extension MutatingContext {
     _bridged.eraseInstruction(instruction.bridged, salvageDebugInfo)
   }
 
-  public func erase(instructionIncludingAllUsers inst: Instruction, salvageDebugInfo: Bool = true) {
+  /// Removes and deletes `inst` and all its users.
+  /// `debug_value` users of any deleted instruction will be rewritten.
+  public func erase(instructionIncludingAllUsers inst: Instruction) {
     if inst.isDeleted {
       return
     }
     for result in inst.results {
       // salvageDebugInfo may create new `debug_value` users, which are inserted at the begin of the
       // use-list. Therefore we cannot iterate with a `for use in result.uses`.
-      while let use = result.uses.first {
-        erase(instructionIncludingAllUsers: use.instruction, salvageDebugInfo: salvageDebugInfo)
+      // Debug users must not be deleted before salvageDebugInfo is called later.
+      while let use = result.uses.ignoreDebugUses.first {
+        erase(instructionIncludingAllUsers: use.instruction)
       }
     }
-    erase(instruction: inst, salvageDebugInfo: salvageDebugInfo)
+    erase(instruction: inst)
   }
 
   public func erase<S: Sequence>(instructions: S) where S.Element: Instruction {
@@ -215,10 +218,11 @@ extension MutatingContext {
     }
   }
 
+  // This function doesn't do what its name implies, it's equivalent to erase(instruction:).
   public func erase(instructionIncludingDebugUses inst: Instruction) {
     precondition(inst.results.allSatisfy { $0.uses.ignoreDebugUses.isEmpty })
-    salvageDebugInfo(of: inst)
-    erase(instructionIncludingAllUsers: inst)
+    // Erase calls salvageDebugInfo which will rewrite all debug uses.
+    erase(instruction: inst)
   }
 
   public func erase(block: BasicBlock) {

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -736,11 +736,14 @@ void SwiftPassInvocation::eraseInstruction(SILInstruction *inst, bool salvageDeb
   if (silCombiner) {
     silCombiner->eraseInstFromFunction(*inst, /*addOperandsToWorklist=*/ true, salvageDebugInfo);
   } else {
-    if (salvageDebugInfo) {
-      swift::salvageDebugInfo(inst);
-    }
     if (inst->isStaticInitializerInst()) {
+      // Ignore salvageDebugInfo: Static initializers can't have debug values.
       inst->getParent()->erase(inst, *getPassManager()->getModule());
+    } else if (salvageDebugInfo) {
+      swift::salvageDebugInfo(inst);
+      // Erase debug instructions left behind by salvageDebugInfo.
+      // TODO: Change this back to eraseFromParent when salvageDebugInfo is complete.
+      swift::eraseFromParentWithDebugInsts(inst);
     } else {
       inst->eraseFromParent();
     }

--- a/test/DebugInfo/sil_combine.sil
+++ b/test/DebugInfo/sil_combine.sil
@@ -208,6 +208,35 @@ bb0(%0 : $Int64, %1 : $Int64):
   return %e : $Int64
 }
 
+class Klass {}
+
+struct KlassStruct {
+  @_hasStorage var k: Klass { get set }
+  @_hasStorage var x: Int64 { get set }
+  init(k: Klass, x: Int64)
+}
+
+// When SimplifyStruct removes an owned struct with begin_borrow/struct_extract
+// uses via erase(instructionIncludingAllUsers:), debug uses must be salvaged.
+//
+// CHECK-LABEL: sil [ossa] @salvage_struct_erase_including_all_users
+// CHECK-NOT:     struct $KlassStruct
+// CHECK:         debug_value %0 : $Klass, let, name "s", type $KlassStruct, expr op_fragment:#KlassStruct.k
+// CHECK:         debug_value %1 : $Int64, let, name "s", type $KlassStruct, expr op_fragment:#KlassStruct.x
+// CHECK:         destroy_value %0 : $Klass
+// CHECK:         return %1 : $Int64
+// CHECK:       } // end sil function 'salvage_struct_erase_including_all_users'
+sil [ossa] @salvage_struct_erase_including_all_users : $@convention(thin) (@owned Klass, Int64) -> Int64 {
+bb0(%0 : @owned $Klass, %1 : $Int64):
+  %s = struct $KlassStruct (%0 : $Klass, %1 : $Int64)
+  debug_value %s : $KlassStruct, let, name "s"
+  %b = begin_borrow %s : $KlassStruct
+  %e = struct_extract %b : $KlassStruct, #KlassStruct.x
+  end_borrow %b : $KlassStruct
+  destroy_value %s : $KlassStruct
+  return %e : $Int64
+}
+
 // This test verifies that splitAggregateLoad in CanonicalizeInstruction.cpp
 // salvages debug info attached to the loaded aggregate in optimized builds.
 //

--- a/test/SILOptimizer/simplify_destroy_value.sil
+++ b/test/SILOptimizer/simplify_destroy_value.sil
@@ -353,6 +353,11 @@ bb0(%0 : @owned $D):
 
 // CHECK-LABEL:      sil [ossa] @dont_remove_with_debug_user :
 // CHECK:            bb0
+// CHECK-O-NEXT:       debug_value %0, let, name "x", transform {
+// CHECK-O:              bb0(%0 : $D):
+// CHECK-O-NEXT:           %1 = upcast %0 to $C
+// CHECK-O-NEXT:           return %1
+// CHECK-O-NEXT:       }
 // CHECK-O-NEXT:       destroy_value %0
 // CHECK-O-NEXT:       tuple
 // CHECK-ONONE-NEXT:   %1 = upcast

--- a/test/SILOptimizer/simplify_end_lifetime.sil
+++ b/test/SILOptimizer/simplify_end_lifetime.sil
@@ -237,6 +237,11 @@ bb3:
 // CHECK-LABEL: sil [ossa] @debug_user :
 // CHECK:       bb0(%0 : @owned $D):
 // CHECK-NEXT:    end_lifetime %0
+// CHECK-NEXT:    debug_value %0, let, name "x", transform {
+// CHECK:           bb0(%0 : $D):
+// CHECK-NEXT:        %1 = upcast %0 to $C
+// CHECK-NEXT:        return %1
+// CHECK-NEXT:    }
 // CHECK-NEXT:    tuple
 // CHECK:       } // end sil function 'debug_user'
 sil [ossa] @debug_user : $@convention(thin) (@owned D) -> () {

--- a/test/SILOptimizer/simplify_struct.sil
+++ b/test/SILOptimizer/simplify_struct.sil
@@ -14,7 +14,10 @@ struct Outer {
 
 // CHECK-LABEL: sil [ossa] @simple_delay_struct :
 // CHECK:       bb0
+// CHECK-NEXT:    debug_value %0, var, name "x", type $S, expr op_fragment:#S.a
+// CHECK-NEXT:    debug_value %1, var, name "x", type $S, expr op_fragment:#S.b
 // CHECK-NEXT:    [[B:%.*]] = begin_borrow %0
+// TODO: begin_borrow should get salvaged too.
 // CHECK-NEXT:    fix_lifetime [[B]]
 // CHECK-NEXT:    fix_lifetime %1
 // CHECK-NEXT:    end_borrow [[B]]
@@ -24,9 +27,9 @@ struct Outer {
 sil [ossa] @simple_delay_struct : $@convention(thin) (@owned String, Int) -> () {
 bb0(%0 : @owned $String, %1 : $Int):
   %2 = struct $S (%0, %1)
-  debug_value %2, name "x"
+  debug_value %2, var, name "x"
   %3 = begin_borrow %2
-  debug_value %3, name "x"
+  debug_value %3, var, name "y"
   %4 = struct_extract %3, #S.a
   %5 = struct_extract %3, #S.b
   fix_lifetime %4
@@ -39,6 +42,8 @@ bb0(%0 : @owned $String, %1 : $Int):
 
 // CHECK-LABEL: sil [ossa] @destructure_of_copy :
 // CHECK:       bb0(%0 : @owned $String, %1 : $Int):
+// CHECK-NEXT:    debug_value %0, var, name "x", type $S, expr op_fragment:#S.a
+// CHECK-NEXT:    debug_value %1, var, name "x", type $S, expr op_fragment:#S.b
 // CHECK-NEXT:    br bb1
 // CHECK:       bb1:
 // CHECK-NEXT:    [[C:%.*]] = copy_value %0


### PR DESCRIPTION
With salvageDebugInfo set to true, the `erase(instructionIncludingAllUsers:)` function was deleting debug uses before calling `erase(instruction:)` which would call `salvageDebugInfo`.

Instead, don't delete debug uses before calling `erase(instruction:)` and `salvageDebugInfo`.
`erase(instruction:)` now also always deletes debug users that `salvageDebugInfo` failed to salvage or left behind.

When `salvageDebugInfo` is completed, all debug users will be rewritten by it, leaving nothing behind, but this will require removing fragments and supporting multiple operands in debug_value. For now, `eraseFromParentWithDebugInsts ` must be called after salvageDebugInfo.

This decreases the amount of lost variables in the stdlib in SILCombine by **11%** (**5.1%** less lost variables in total). Increases variables with location in DWARF by 0.3%.