### PR TITLE
[Demangler] Fix DemangleInitRAII not saving IsOldFunctionTypeMangling and Flavor.

### DIFF
--- a/include/swift/Demangling/Demangler.h
+++ b/include/swift/Demangling/Demangler.h
@@ -499,8 +499,10 @@ protected:
     StringRef Words[MaxNumWords];
     StringRef Text;
     size_t Pos;
+    bool IsOldFunctionTypeMangling;
+    Mangle::ManglingFlavor Flavor;
     std::function<SymbolicReferenceResolver_t> SymbolicReferenceResolver;
-    
+
   public:
     DemangleInitRAII(Demangler &Dem, StringRef MangledName,
          std::function<SymbolicReferenceResolver_t> SymbolicReferenceResolver);

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -733,6 +733,8 @@ Demangler::DemangleInitRAII::DemangleInitRAII(Demangler &Dem,
   : Dem(Dem),
     NodeStack(Dem.NodeStack), Substitutions(Dem.Substitutions),
     NumWords(Dem.NumWords), Text(Dem.Text), Pos(Dem.Pos),
+    IsOldFunctionTypeMangling(Dem.IsOldFunctionTypeMangling),
+    Flavor(Dem.Flavor),
     SymbolicReferenceResolver(std::move(Dem.SymbolicReferenceResolver))
 {
   std::copy(Dem.Words, Dem.Words + MaxNumWords, Words);
@@ -742,6 +744,8 @@ Demangler::DemangleInitRAII::DemangleInitRAII(Demangler &Dem,
   Dem.NumWords = 0;
   Dem.Text = MangledName;
   Dem.Pos = 0;
+  Dem.IsOldFunctionTypeMangling = false;
+  Dem.Flavor = ManglingFlavor::Default;
   Dem.SymbolicReferenceResolver = std::move(TheSymbolicReferenceResolver);
 }
 
@@ -753,6 +757,8 @@ Demangler::DemangleInitRAII::~DemangleInitRAII() {
   std::copy(Words, Words + MaxNumWords, Dem.Words);
   Dem.Text = Text;
   Dem.Pos = Pos;
+  Dem.IsOldFunctionTypeMangling = IsOldFunctionTypeMangling;
+  Dem.Flavor = Flavor;
   Dem.SymbolicReferenceResolver = std::move(SymbolicReferenceResolver);
 }
 

--- a/unittests/Basic/DemangleTest.cpp
+++ b/unittests/Basic/DemangleTest.cpp
@@ -135,3 +135,27 @@ TEST(Demangle, WordsArraySavedAcrossNestedDemangle) {
   ASSERT_EQ(argStruct->getKind(), Node::Kind::Structure);
   EXPECT_EQ(argStruct->getChild(1)->getText(), "OtherType");
 }
+
+// Test that DemangleInitRAII saves and restores IsOldFunctionTypeMangling
+// across demangle calls on the same Demangler.
+TEST(Demangle, OldFunctionTypeManglingFlagSavedAcrossDemangle) {
+  // A modern-mangled function type carrying argument labels (a:b:):
+  //   M.f(a: Int, b: Int) -> ()
+  static const char funcType[] = "1M1f1a1bS2i_SitF";
+
+  // Reference tree from a pristine Demangler (flag defaults to false).
+  Demangler fresh;
+  auto expected = fresh.demangleType(funcType);
+  ASSERT_NE(expected, nullptr);
+
+  Demangler dem;
+  // Demangle a Swift-4 ("_T…") symbol first; this sets
+  // IsOldFunctionTypeMangling = true for that job.
+  dem.demangleSymbol("_T0");
+  // The flag must not leak into this modern demangle.
+  auto result = dem.demangleType(funcType);
+  ASSERT_NE(result, nullptr);
+  EXPECT_TRUE(result->isDeepEqualTo(expected))
+      << "IsOldFunctionTypeMangling leaked across DemangleInitRAII";
+}
+


### PR DESCRIPTION
Failing to save these means they could leak across calls if the same demangler is used for multiple strings with different mangling kinds.

rdar://181860534