### PR TITLE
Add an option to use quoted includes for underlying module headers when printing the generated header

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -641,5 +641,9 @@ NOTE(dependency_scan_unexpected_variant_extra_arg_note, none,
 ERROR(bridging_header_and_pch_internal_mismatch,none,
       "bridging header and precompiled header options mismatch on internal vs. public import", ())
 
+ERROR(clang_header_underlying_module_headers_not_found,none,
+      "could not determine the headers of underlying Clang module '%0' to "
+      "import in the generated Objective-C header", (StringRef))
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -631,6 +631,12 @@ public:
   /// textual imports
   bool EmitClangHeaderWithNonModularIncludes = false;
 
+  /// When non-empty, the generated Objective-C header for a mixed-source module
+  /// imports the underlying Clang module's headers using quoted includes
+  /// spelled relative to this path, instead of assuming a framework-style
+  /// umbrella header named after the module.
+  std::string GeneratedHeaderUnderlyingModuleIncludeBase;
+
   /// All block list configuration files to be honored in this compilation.
   std::vector<std::string> BlocklistConfigFilePaths;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -844,6 +844,11 @@ def emit_clang_header_nonmodular_includes : Flag<["-"], "emit-clang-header-nonmo
   Flags<[FrontendOption, NoInteractiveOption, SupplementaryOutput]>,
   HelpText<"Augment emitted Objective-C header with textual imports for every included modular import">;
 
+def generated_header_underlying_module_include_base : Separate<["-"], "generated-header-underlying-module-include-base">,
+  Flags<[FrontendOption, NoInteractiveOption, ArgumentIsPath]>,
+  MetaVarName<"<path>">,
+  HelpText<"When emitting the generated Objective-C header for a mixed-source module, import the underlying Clang module's headers using quoted includes relative to <path>, instead of assuming a framework-style umbrella header named after the module">;
+
 def emit_clang_header_path : Separate<["-"], "emit-clang-header-path">,
   Flags<[FrontendOption, NoInteractiveOption, ArgumentIsPath,
          SupplementaryOutput, CacheInvariant]>,

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -115,6 +115,11 @@ bool ArgsToFrontendOptionsConverter::convert(
   Opts.EmitClangHeaderWithNonModularIncludes |=
       Args.hasArg(OPT_emit_clang_header_nonmodular_includes);
 
+  Opts.GeneratedHeaderUnderlyingModuleIncludeBase =
+      Args.getLastArgValue(
+              OPT_generated_header_underlying_module_include_base)
+          .str();
+
   Opts.EnableImplicitDynamic |= Args.hasArg(OPT_enable_implicit_dynamic);
 
   if (Args.hasArg(OPT_track_system_dependencies)) {

--- a/lib/PrintAsClang/PrintAsClang.cpp
+++ b/lib/PrintAsClang/PrintAsClang.cpp
@@ -18,6 +18,7 @@
 
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/AttrKind.h"
+#include "swift/AST/DiagnosticsFrontend.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/Basic/Assertions.h"
@@ -553,10 +554,52 @@ writeImports(raw_ostream &out, llvm::SmallPtrSetImpl<ImportModuleTy> &imports,
   }
 
   if (includeUnderlying) {
-    if (bridgingHeader.empty())
-      out << "#import <" << M.getName().str() << '/' << M.getName().str()
-          << ".h>\n\n";
-    else {
+    if (bridgingHeader.empty()) {
+      llvm::StringRef relativeToPath =
+          frontendOpts.GeneratedHeaderUnderlyingModuleIncludeBase;
+      if (relativeToPath.empty()) {
+        // Assume a framework-style umbrella header named after the module.
+        out << "#import <" << M.getName().str() << '/' << M.getName().str()
+            << ".h>\n\n";
+      } else {
+        const clang::Module *underlyingClangModule =
+            M.findUnderlyingClangModule();
+
+        llvm::SmallString<128> basePath = normalizePath(relativeToPath);
+        if (!basePath.ends_with("/"))
+          basePath.append("/");
+        llvm::SmallSet<llvm::SmallString<128>, 10> baseSearchDir;
+        baseSearchDir.insert(basePath);
+
+        llvm::SmallSet<llvm::SmallString<128>, 10> quotedIncludes;
+        if (underlyingClangModule) {
+          llvm::SmallSet<const clang::Module *, 10> visitedUnderlyingModules;
+          collectClangModuleHeaderIncludes(
+              underlyingClangModule, fileManager, quotedIncludes,
+              visitedUnderlyingModules, baseSearchDir,
+              cwd ? StringRef(*cwd) : StringRef());
+        }
+
+        if (quotedIncludes.empty()) {
+          M.getASTContext().Diags.diagnose(
+              SourceLoc(),
+              diag::clang_header_underlying_module_headers_not_found,
+              M.getName().str());
+        } else {
+          SmallVector<llvm::SmallString<128>, 4> sortedIncludes{
+              quotedIncludes.begin(), quotedIncludes.end()};
+          std::sort(sortedIncludes.begin(), sortedIncludes.end(),
+                    [](const llvm::SmallString<128> &lhs,
+                       const llvm::SmallString<128> &rhs) {
+                      return lhs.str() < rhs.str();
+                    });
+          for (const auto &header : sortedIncludes) {
+            out << "#import \"" << header << "\"\n";
+          }
+          out << "\n";
+        }
+      }
+    } else {
       out << "#if defined(__OBJC__)\n";
       out << "#import \"" << bridgingHeader << "\"\n";
       out << "#else\n";

--- a/test/PrintAsObjC/mixed-non-framework-umbrella-dir.swift
+++ b/test/PrintAsObjC/mixed-non-framework-umbrella-dir.swift
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name UmbrellaDirMod -import-underlying-module -I %t/UmbrellaDirMod -parse-as-library %t/use.swift -typecheck -verify -emit-objc-header-path %t/module-relative.h -generated-header-underlying-module-include-base %t/UmbrellaDirMod
+// RUN: %FileCheck %s < %t/module-relative.h
+// RUN: %check-in-clang -I %t/UmbrellaDirMod %t/module-relative.h
+
+// REQUIRES: objc_interop
+
+// CHECK: #import "Headers/First.h"
+// CHECK-NEXT: #import "Headers/Second.h"
+// CHECK-NOT: #import <UmbrellaDirMod/UmbrellaDirMod.h>
+
+//--- UmbrellaDirMod/module.modulemap
+module UmbrellaDirMod {
+  umbrella "Headers"
+  export *
+}
+
+//--- UmbrellaDirMod/Headers/First.h
+typedef int UmbrellaDirModFirst;
+
+//--- UmbrellaDirMod/Headers/Second.h
+typedef int UmbrellaDirModSecond;
+
+//--- use.swift
+import Foundation
+
+public class SomeClass: NSObject {
+  @objc public func getFirst() -> UmbrellaDirModFirst { return 0 }
+  @objc public func getSecond() -> UmbrellaDirModSecond { return 0 }
+}

--- a/test/PrintAsObjC/mixed-non-framework.swift
+++ b/test/PrintAsObjC/mixed-non-framework.swift
@@ -1,0 +1,38 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// Relative to the module directory: the include keeps the "sub/" prefix.
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name MixedNonFramework -import-underlying-module -I %t/MixedNonFramework -parse-as-library %t/use.swift -typecheck -verify -emit-objc-header-path %t/module-relative.h -generated-header-underlying-module-include-base %t/MixedNonFramework
+// RUN: %FileCheck %s < %t/module-relative.h
+// RUN: %check-in-clang -I %t/MixedNonFramework %t/module-relative.h
+
+// Relative to the "sub" directory: the include is just "impl.h".
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name MixedNonFramework -import-underlying-module -I %t/MixedNonFramework -parse-as-library %t/use.swift -typecheck -verify -emit-objc-header-path %t/subdir-relative.h -generated-header-underlying-module-include-base %t/MixedNonFramework/sub
+// RUN: %FileCheck %s --check-prefix=SUBDIR < %t/subdir-relative.h
+// RUN: %check-in-clang -I %t/MixedNonFramework/sub %t/subdir-relative.h
+
+// REQUIRES: objc_interop
+
+// CHECK: #import "sub/impl.h"
+// CHECK-NOT: #import <MixedNonFramework/MixedNonFramework.h>
+
+// SUBDIR: #import "impl.h"
+// SUBDIR-NOT: #import <MixedNonFramework/MixedNonFramework.h>
+
+//--- MixedNonFramework/module.modulemap
+module MixedNonFramework {
+  header "sub/impl.h"
+  export *
+}
+
+//--- MixedNonFramework/sub/impl.h
+typedef int MixedNonFrameworkInt;
+
+//--- use.swift
+import Foundation
+
+public class SomeClass: NSObject {
+  @objc public func getValue() -> MixedNonFrameworkInt {
+    return 0
+  }
+}


### PR DESCRIPTION
Previously, the generated header always used framework-style includes for the underlying module of a mixed source target and assumed it had an umbrella header named after the module. Introduce a new flag, -generated-header-import-underlying-module-headers-using-quoted-includes-relative-to, which causes the generated header to instead use quoted includes relative to a user-specified path. The motivation behind this change is to support mixed source modules in Swift packages, which do not use the framework module layout, but instead generate a module map with either an umbrella header or directory and have a public headers directory which will be in the search paths of dependents.

And yes the new flag name is ridiculous, I'm open to suggestions for something better.