### PR TITLE
SILGen: addressable buffer scope for borrowing pattern bindings

### DIFF
--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -1446,6 +1446,12 @@ void PatternMatchEmission::bindBorrow(Pattern *pattern, VarDecl *var,
 
   SGF.VarLocs[var] = SILGenFunction::VarLoc(bindValue.getValue(),
                                             SILAccessEnforcement::Unknown);
+
+  // Rewind to the bound value's definition so the buffer's insertion-point
+  // marker dominates it, while its cleanup is still pushed after the value's.
+  SavedInsertionPointRAII savedIP(SGF.B,
+                                  bindValue.getValue()->getDefiningInstruction());
+  SGF.enterLocalVariableAddressableBufferScope(var);
 }
 
 /// Evaluate a guard expression and, if it returns false, branch to

--- a/test/SILGen/addressable_params.swift
+++ b/test/SILGen/addressable_params.swift
@@ -67,3 +67,37 @@ func testAddressableSwitchBinding(e: TestEnum) -> Bool {
         false
     }
 }
+
+// A loadable noncopyable payload bound by a borrowing pattern match and 
+// used as an addressable argument materializes an addressable buffer
+// for the binding. The buffer is allocated dominating the bound value and torn                              
+// down before the value is destroyed. 
+struct AddressableLoadable: ~Copyable {
+    var x: Int
+    @_addressableSelf borrowing func get() -> Int { x }
+}
+
+enum NoncopyableBox: ~Copyable {
+    case some(AddressableLoadable)
+    case none
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s{{.*}}33testAddressableNoncopyableBinding{{.*}} :
+// CHECK:       bb1([[PAYLOAD:%.*]] : @guaranteed $AddressableLoadable):
+// CHECK:         [[COPY:%.*]] = copy_value [[PAYLOAD]]
+// CHECK:         [[BUF:%.*]] = alloc_stack $AddressableLoadable
+// CHECK:         [[BIND:%.*]] = mark_unresolved_non_copyable_value [strict] [no_consume_or_assign] [[COPY]]
+// CHECK:         [[SB:%.*]] = store_borrow [[BIND]] to [[BUF]]
+// CHECK:         [[SBM:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[SB]]
+// CHECK:         apply {{%.*}}([[SBM]])
+// CHECK:         end_borrow [[SB]]
+// CHECK:         dealloc_stack [[BUF]]
+// CHECK:         destroy_value [[BIND]]
+func testAddressableNoncopyableBinding(box: borrowing NoncopyableBox) -> Int {
+    switch box {
+    case .some(let v):
+        return v.get()
+    case .none:
+        return 0
+    }
+}


### PR DESCRIPTION
A noncopyable payload bound by a borrowing pattern match never established an addressable-buffer scope, so referencing the binding as an addressable argument crashed while materializing the buffer. Enter the scope when binding the borrow, anchoring its insertion-point marker before the bound value so a forced alloc_stack dominates it, and pushing the deallocation cleanup after the mark_unresolved value's own cleanup so the buffer's store_borrow is ended before that value is destroyed.

resolves rdar://178851007