### PR TITLE
Verify that there are no critical edges in SIL and remove operands of the `cond_br` instruction

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyCondBranch.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyCondBranch.swift
@@ -27,9 +27,9 @@ private extension CondBranchInst {
     }
     let builder = Builder(before: self, context)
     if conditionValue == 0 {
-      builder.createBranch(to: falseBlock, arguments: Array(falseOperands.values))
+      builder.createBranch(to: falseBlock)
     } else {
-      builder.createBranch(to: trueBlock, arguments: Array(trueOperands.values))
+      builder.createBranch(to: trueBlock)
     }
     context.erase(instruction: self)
   }

--- a/SwiftCompilerSources/Sources/SIL/Argument.swift
+++ b/SwiftCompilerSources/Sources/SIL/Argument.swift
@@ -113,7 +113,7 @@ public struct Phi {
     var preds = argument.parentBlock.predecessors
     if let pred = preds.next() {
       let term = pred.terminator
-      guard term is BranchInst || term is CondBranchInst else {
+      guard term is BranchInst else {
         return nil
       }
     } else {
@@ -130,9 +130,6 @@ public struct Phi {
     switch operand.instruction {
     case let br as BranchInst:
       self.init(br.getArgument(for: operand))
-    case let condBr as CondBranchInst:
-      guard let arg = condBr.getArgument(for: operand) else { return nil }
-      self.init(arg)
     default:
       return nil
     }
@@ -152,14 +149,6 @@ public struct Phi {
     switch predecessor.terminator {
     case let br as BranchInst:
       return br.operands[blockArgIdx]
-    case let condBr as CondBranchInst:
-      if condBr.trueBlock == successor {
-        assert(condBr.falseBlock != successor)
-        return condBr.trueOperands[blockArgIdx]
-      } else {
-        assert(condBr.falseBlock == successor)
-        return condBr.falseOperands[blockArgIdx]
-      }
     default:
       fatalError("wrong terminator for phi-argument")
     }

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -2292,29 +2292,6 @@ final public class CondBranchInst : TermInst {
   public var falseBlock: BasicBlock { successors[1] }
 
   public var condition: Value { operands[0].value }
-
-  public var trueOperands: OperandArray { operands[1..<(bridged.CondBranchInst_getNumTrueArgs() &+ 1)] }
-  public var falseOperands: OperandArray {
-    let ops = operands
-    return ops[(bridged.CondBranchInst_getNumTrueArgs() &+ 1)..<ops.count]
-  }
-
-  /// Returns the true or false block argument for the cond_br `operand`.
-  ///
-  /// Return nil if `operand` is the condition itself.
-  public func getArgument(for operand: Operand) -> Argument? {
-    let opIdx = operand.index
-    if opIdx == 0 {
-      return nil
-    }
-    let argIdx = opIdx - 1
-    let numTrueArgs = bridged.CondBranchInst_getNumTrueArgs()
-    if (0..<numTrueArgs).contains(argIdx) {
-      return trueBlock.arguments[argIdx]
-    } else {
-      return falseBlock.arguments[argIdx - numTrueArgs]
-    }
-  }
 }
 
 final public class SwitchValueInst : TermInst {

--- a/SwiftCompilerSources/Sources/SIL/Utilities/WalkUtils.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/WalkUtils.swift
@@ -404,16 +404,6 @@ extension ValueDefUseWalker {
       } else {
         return .continueWalk
       }
-    case let cbr as CondBranchInst:
-      if let val = cbr.getArgument(for: operand) {
-        if let path = walkDownCache.needWalk(for: val, path: path) {
-          return walkDownUses(ofValue: val, path: path)
-        } else {
-          return .continueWalk
-        }
-      } else {
-        return leafUse(value: operand, path: path)
-      }
     case let se as SwitchEnumInst:
       if let (caseIdx, path) = path.pop(kind: .enumCase),
          let succBlock = se.getUniqueSuccessor(forCaseIndex: caseIdx),

--- a/docs/Lexicon.md
+++ b/docs/Lexicon.md
@@ -141,7 +141,9 @@ This has two unrelated meanings:
 ## critical edge
 
 An edge in a control flow graph where the destination has multiple predecessors
-and the source has multiple successors.
+and the source has multiple successors. SIL does not permit critical edges: they
+must be split (by inserting a block along the edge) throughout SIL, in both raw
+and canonical SIL and regardless of whether a function is in Ownership SSA.
 
 ## currency type
 

--- a/docs/SIL/Instructions.md
+++ b/docs/SIL/Instructions.md
@@ -5173,25 +5173,16 @@ destination basic block.
 ### cond_br
 
 ```
-sil-terminator ::= 'cond_br' sil-operand ','
-                     sil-identifier '(' (sil-operand (',' sil-operand)*)? ')' ','
-                     sil-identifier '(' (sil-operand (',' sil-operand)*)? ')'
+sil-terminator ::= 'cond_br' sil-operand ',' sil-identifier ',' sil-identifier
 
-cond_br %0 : $Builtin.Int1, true_label (%a : $A, %b : $B, ...), 
-                               false_label (%x : $X, %y : $Y, ...)
+cond_br %0 : $Builtin.Int1, true_label, false_label
 // %0 must be of $Builtin.Int1 type
 // `true_label` and `false_label` must refer to block labels within the
 //   current function and must not be identical
-// %a, %b, etc. must be of the types of `true_label`'s arguments
-// %x, %y, etc. must be of the types of `false_label`'s arguments
 ```
 
 Conditionally branches to `true_label` if `%0` is equal to `1` or to
-`false_label` if `%0` is equal to `0`, binding the corresponding set of
-values to the arguments of the chosen destination block.
-
-In OSSA, `cond_br` must not have any arguments because in OSSA critical control
-flow edges are not allowed.
+`false_label` if `%0` is equal to `0`.
 
 ### switch_value
 

--- a/docs/SIL/SIL.md
+++ b/docs/SIL/SIL.md
@@ -350,10 +350,12 @@ There are three kind of arguments:
 ```
 
 - Phi arguments: If a block has multiple predecessor blocks, the terminators of
-  the predecessor blocks must be `br` or `cond_br` instructions and the
-  operand values of those branch instructions are passed to the block's
-  arguments. This corresponds to LLVM's phi nodes. Basic block arguments are
-  bound by the branch from the predecessor block:
+  the predecessor blocks must be `br` instructions and the operand values of
+  those branch instructions are passed to the block's arguments. This
+  corresponds to LLVM's phi nodes. Because SIL does not contain critical edges,
+  a block with multiple predecessors is only ever reached through unconditional
+  `br` instructions. Basic block arguments are bound by the branch from the
+  predecessor block:
 
 ```
       cond_br %cond, bb1, bb2
@@ -389,10 +391,16 @@ might branch to `bb2` or `bb3`.
 
 ## Control Flow Graph Invariants
 
-In OSSA following rules apply to the CFG of a function:
+The following rules apply to the CFG of a function:
 
 - No critical edges: every edge in the CFG must have either a single
-  predecessor or a single successor block.
+  predecessor or a single successor block. Equivalently, if a terminator has
+  more than one successor, none of those successors may have more than one
+  predecessor. This holds throughout SIL -- in both raw and canonical SIL and
+  regardless of whether the function is in Ownership SSA.
+  Only `br` instructions can branch to blocks with multiple predecessors.
+
+In OSSA following additional rules apply to the CFG of a function:
 
 - No unreachable blocks: All blocks must be reachable from the entry block
   of the function.
@@ -400,10 +408,11 @@ In OSSA following rules apply to the CFG of a function:
 - No infinite loops: all cyclic strongly connected components (SCC) in the
   CFG must have at least one edge which is exiting the cyclic SCC.
 
-Optimization passes must make sure to leave the CFG of an OSSA function in a
+Optimization passes must make sure to leave the CFG of a function in a
 valid state by:
 
-- inserting blocks at critical edges
+- splitting critical edges (inserting a block with a single predecessor and a
+  single successor along the edge)
 
 - removing unreachable blocks
 

--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -763,11 +763,7 @@ struct PhiValue {
 
   Operand *getOperand(SILBasicBlock *predecessor) {
     auto *term = predecessor->getTerminator();
-    if (auto *branch = dyn_cast<BranchInst>(term)) {
-      return &branch->getAllOperands()[argIndex];
-    }
-    // TODO: Support CondBr for legacy reasons
-    return cast<CondBranchInst>(term)->getOperandForDestBB(phiBlock, argIndex);
+    return &cast<BranchInst>(term)->getAllOperands()[argIndex];
   }
 
   operator SILValue() const { return getValue(); }

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -930,7 +930,6 @@ struct BridgedInstruction {
   BRIDGED_INLINE bool MarkUnresolvedNonCopyableValue_isStrict() const;
   BRIDGED_INLINE void RefCountingInst_setIsAtomic(bool isAtomic) const;
   BRIDGED_INLINE bool RefCountingInst_getIsAtomic() const;
-  BRIDGED_INLINE SwiftInt CondBranchInst_getNumTrueArgs() const;
   BRIDGED_INLINE void AllocRefInstBase_setIsStackAllocatable() const;
   BRIDGED_INLINE bool AllocRefInst_isBare() const;
   BRIDGED_INLINE void AllocRefInst_setIsBare() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -1775,10 +1775,6 @@ bool BridgedInstruction::RefCountingInst_getIsAtomic() const {
   return getAs<swift::RefCountingInst>()->getAtomicity() == swift::RefCountingInst::Atomicity::Atomic;
 }
 
-SwiftInt BridgedInstruction::CondBranchInst_getNumTrueArgs() const {
-  return getAs<swift::CondBranchInst>()->getNumTrueArgs();
-}
-
 void BridgedInstruction::AllocRefInstBase_setIsStackAllocatable() const {
   getAs<swift::AllocRefInstBase>()->setStackAllocatable();
 }

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -2818,41 +2818,9 @@ public:
                    ProfileCounter Target1Count = ProfileCounter(),
                    ProfileCounter Target2Count = ProfileCounter()) {
     return insertTerminator(
-        CondBranchInst::create(getSILDebugLocation(Loc), Cond, Target1, Target2,
-                               Target1Count, Target2Count, getFunction()));
-  }
-
-  CondBranchInst *
-  createCondBranch(SILLocation Loc, SILValue Cond, SILBasicBlock *Target1,
-                   ArrayRef<SILValue> Args1, SILBasicBlock *Target2,
-                   ArrayRef<SILValue> Args2,
-                   ProfileCounter Target1Count = ProfileCounter(),
-                   ProfileCounter Target2Count = ProfileCounter()) {
-    return insertTerminator(
-        CondBranchInst::create(getSILDebugLocation(Loc), Cond, Target1, Args1,
-                               Target2, Args2, Target1Count, Target2Count, getFunction()));
-  }
-
-  CondBranchInst *
-  createCondBranch(SILLocation Loc, SILValue Cond, SILBasicBlock *Target1,
-                   OperandValueArrayRef Args1, SILBasicBlock *Target2,
-                   OperandValueArrayRef Args2,
-                   ProfileCounter Target1Count = ProfileCounter(),
-                   ProfileCounter Target2Count = ProfileCounter()) {
-    SmallVector<SILValue, 6> ArgsCopy1;
-    SmallVector<SILValue, 6> ArgsCopy2;
-
-    ArgsCopy1.reserve(Args1.size());
-    ArgsCopy2.reserve(Args2.size());
-
-    for (auto I = Args1.begin(), E = Args1.end(); I != E; ++I)
-      ArgsCopy1.push_back(*I);
-    for (auto I = Args2.begin(), E = Args2.end(); I != E; ++I)
-      ArgsCopy2.push_back(*I);
-
-    return insertTerminator(CondBranchInst::create(
-        getSILDebugLocation(Loc), Cond, Target1, ArgsCopy1, Target2, ArgsCopy2,
-        Target1Count, Target2Count, getFunction()));
+        new (getModule()) CondBranchInst(getSILDebugLocation(Loc),
+                                         Cond, Target1, Target2,
+                                         Target1Count, Target2Count));
   }
 
   BranchInst *createBranch(SILLocation Loc, SILBasicBlock *TargetBlock) {

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -3848,14 +3848,12 @@ SILCloner<ImplClass>::visitBranchInst(BranchInst *Inst) {
 template<typename ImplClass>
 void
 SILCloner<ImplClass>::visitCondBranchInst(CondBranchInst *Inst) {
-  auto TrueArgs = getOpValueArray<8>(Inst->getTrueArgs());
-  auto FalseArgs = getOpValueArray<8>(Inst->getFalseArgs());
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(
       Inst, getBuilder().createCondBranch(
                 getOpLocation(Inst->getLoc()), getOpValue(Inst->getCondition()),
-                getOpBasicBlock(Inst->getTrueBB()), TrueArgs,
-                getOpBasicBlock(Inst->getFalseBB()), FalseArgs,
+                getOpBasicBlock(Inst->getTrueBB()),
+                getOpBasicBlock(Inst->getFalseBB()),
                 Inst->getTrueBBCount(), Inst->getFalseBBCount()));
 }
 

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -10926,18 +10926,10 @@ public:
 
 /// A conditional branch.
 class CondBranchInst final
-    : public InstructionBaseWithTrailingOperands<
-                                             SILInstructionKind::CondBranchInst,
-                                             CondBranchInst,
-                                             TermInst> {
+    : public UnaryInstructionBase<SILInstructionKind::CondBranchInst, TermInst> {
   friend SILBuilder;
 
 public:
-  enum {
-    /// The operand index of the condition value used for the branch.
-    ConditionIdx,
-    NumFixedOpers,
-  };
   enum {
     // Map branch targets to block successor indices.
     TrueIdx,
@@ -10945,36 +10937,18 @@ public:
   };
 private:
   std::array<SILSuccessor, 2> DestBBs;
-  unsigned numTrueArguments;
 
   CondBranchInst(SILDebugLocation DebugLoc, SILValue Condition,
                  SILBasicBlock *TrueBB, SILBasicBlock *FalseBB,
-                 ArrayRef<SILValue> Args, unsigned NumTrue, unsigned NumFalse,
                  ProfileCounter TrueBBCount, ProfileCounter FalseBBCount);
-
-  /// Construct a CondBranchInst that will branch to TrueBB or FalseBB based on
-  /// the Condition value. Both blocks must not take any arguments.
-  static CondBranchInst *create(SILDebugLocation DebugLoc, SILValue Condition,
-                                SILBasicBlock *TrueBB, SILBasicBlock *FalseBB,
-                                ProfileCounter TrueBBCount,
-                                ProfileCounter FalseBBCount, SILFunction &F);
-
-  /// Construct a CondBranchInst that will either branch to TrueBB and pass
-  /// TrueArgs or branch to FalseBB and pass FalseArgs based on the Condition
-  /// value.
-  static CondBranchInst *
-  create(SILDebugLocation DebugLoc, SILValue Condition, SILBasicBlock *TrueBB,
-         ArrayRef<SILValue> TrueArgs, SILBasicBlock *FalseBB,
-         ArrayRef<SILValue> FalseArgs, ProfileCounter TrueBBCount,
-         ProfileCounter FalseBBCount, SILFunction &F);
 
 public:
   const Operand *getConditionOperand() const {
-    return &getAllOperands()[ConditionIdx];
+    return &getOperandRef();
   }
-  SILValue getCondition() const { return getConditionOperand()->get(); }
+  SILValue getCondition() const { return getOperand(); }
   void setCondition(SILValue newCondition) {
-    getAllOperands()[ConditionIdx].set(newCondition);
+    setOperand(newCondition);
   }
 
   SuccessorListTy getSuccessors() {
@@ -10991,114 +10965,10 @@ public:
   /// The number of times the False branch was executed.
   ProfileCounter getFalseBBCount() const { return DestBBs[1].getCount(); }
 
-  /// The number of arguments for the True branch.
-  unsigned getNumTrueArgs() const { return numTrueArguments; }
-
-  /// The number of arguments for the False branch.
-  unsigned getNumFalseArgs() const {
-    return getAllOperands().size() - NumFixedOpers - numTrueArguments;
-  }
-
-  /// Get the arguments to the true BB.
-  OperandValueArrayRef getTrueArgs() const {
-    return OperandValueArrayRef(getTrueOperands());
-  }
-  /// Get the arguments to the false BB.
-  OperandValueArrayRef getFalseArgs() const {
-    return OperandValueArrayRef(getFalseOperands());
-  }
-
-  /// Get the operands to the true BB.
-  ArrayRef<Operand> getTrueOperands() const {
-    return getAllOperands().slice(NumFixedOpers, getNumTrueArgs());
-  }
-  MutableArrayRef<Operand> getTrueOperands() {
-    return getAllOperands().slice(NumFixedOpers, getNumTrueArgs());
-  }
-
-  /// Get the operands to the false BB.
-  ArrayRef<Operand> getFalseOperands() const {
-    // The remaining arguments are 'false' operands.
-    return getAllOperands().slice(NumFixedOpers + getNumTrueArgs());
-  }
-  MutableArrayRef<Operand> getFalseOperands() {
-    // The remaining arguments are 'false' operands.
-    return getAllOperands().slice(NumFixedOpers + getNumTrueArgs());
-  }
-
   /// Returns true if \p op is mapped to the condition operand of the cond_br.
   bool isConditionOperand(Operand *op) const {
     return getConditionOperand() == op;
   }
-
-  bool isConditionOperandIndex(unsigned OpIndex) const {
-    assert(OpIndex < getNumOperands() &&
-           "OpIndex must be an index for an actual operand");
-    return OpIndex == ConditionIdx;
-  }
-
-  /// Is \p OpIndex an operand associated with the true case?
-  bool isTrueOperandIndex(unsigned OpIndex) const {
-    assert(OpIndex < getNumOperands() &&
-           "OpIndex must be an index for an actual operand");
-    if (getNumTrueArgs() == 0)
-      return false;
-
-    auto Operands = getTrueOperands();
-    return Operands.front().getOperandNumber() <= OpIndex &&
-           OpIndex <= Operands.back().getOperandNumber();
-  }
-
-  /// Is \p OpIndex an operand associated with the false case?
-  bool isFalseOperandIndex(unsigned OpIndex) const {
-    assert(OpIndex < getNumOperands() &&
-           "OpIndex must be an index for an actual operand");
-    if (getNumFalseArgs() == 0)
-      return false;
-
-    auto Operands = getFalseOperands();
-    return Operands.front().getOperandNumber() <= OpIndex &&
-           OpIndex <= Operands.back().getOperandNumber();
-  }
-
-  /// Returns the operand on the cond_br terminator associated with the value
-  /// that will be passed to DestBB in A.
-  Operand *getOperandForDestBB(const SILBasicBlock *DestBB,
-                               const SILArgument *A) const;
-
-  /// Returns the operand on the cond_br terminator associated with the value
-  /// that will be passed as the \p Index argument to DestBB.
-  Operand *getOperandForDestBB(const SILBasicBlock *DestBB,
-                               unsigned ArgIndex) const;
-
-  /// Returns the argument on the cond_br terminator that will be passed to
-  /// DestBB in A.
-  SILValue getArgForDestBB(const SILBasicBlock *DestBB,
-                           const SILArgument *A) const {
-    if (auto *op = getOperandForDestBB(DestBB, A)) {
-      return op->get();
-    }
-    return SILValue();
-  }
-
-  /// Returns the argument on the cond_br terminator that will be passed as the
-  /// \p Index argument to DestBB.
-  SILValue getArgForDestBB(const SILBasicBlock *DestBB,
-                           unsigned ArgIndex) const {
-    if (auto *op = getOperandForDestBB(DestBB, ArgIndex)) {
-      return op->get();
-    }
-    return SILValue();
-  }
-
-  /// Return the SILPhiArgument from either the true or false destination for
-  /// the given operand.
-  ///
-  /// Returns nullptr for an operand with no block argument
-  /// (i.e the branch condition).
-  ///
-  /// See SILArgument.cpp.
-  const SILPhiArgument *getArgForOperand(const Operand *oper) const;
 
   void swapSuccessors();
 };

--- a/include/swift/SILOptimizer/Utils/SCCVisitor.h
+++ b/include/swift/SILOptimizer/Utils/SCCVisitor.h
@@ -104,16 +104,6 @@ private:
     case TermKind::BranchInst:
       return Operands.push_back(cast<BranchInst>(Term)->getArg(Index));
 
-    case TermKind::CondBranchInst: {
-      auto *CBI = cast<CondBranchInst>(Term);
-      if (SuccBB == CBI->getTrueBB())
-        return Operands.push_back(CBI->getTrueArgs()[Index]);
-      assert(SuccBB == CBI->getFalseBB() &&
-             "Block is not a successor of terminator!");
-      Operands.push_back(CBI->getFalseArgs()[Index]);
-      return;
-    }
-        
     case TermKind::AwaitAsyncContinuationInst: {
       auto *AACI = cast<AwaitAsyncContinuationInst>(Term);
       Operands.push_back(AACI->getOperand());
@@ -135,6 +125,7 @@ private:
     case TermKind::ThrowInst:
     case TermKind::ThrowAddrInst:
     case TermKind::UnwindInst:
+    case TermKind::CondBranchInst:
       llvm_unreachable("Did not expect terminator that does not have args!");
 
     case TermKind::YieldInst:

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -5496,9 +5496,6 @@ void IRGenSILFunction::visitCondBranchInst(swift::CondBranchInst *i) {
   llvm::Value *condValue =
     getLoweredExplosion(i->getCondition(), &Builder).claimNext();
 
-  addIncomingSILArgumentsToPHINodes(*this, trueBB, i->getTrueArgs());
-  addIncomingSILArgumentsToPHINodes(*this, falseBB, i->getFalseArgs());
-
   llvm::MDNode *Weights = nullptr;
   auto TrueBBCount = i->getTrueBBCount();
   auto FalseBBCount = i->getFalseBBCount();

--- a/lib/SIL/IR/SILArgument.cpp
+++ b/lib/SIL/IR/SILArgument.cpp
@@ -150,38 +150,24 @@ bool SILPhiArgument::isPhi() const {
     return true;
 
   auto *termInst = predBlock->getTerminator();
-  return isa<BranchInst>(termInst) || isa<CondBranchInst>(termInst);
+  return isa<BranchInst>(termInst);
 }
 
 static Operand *getIncomingPhiOperandForPred(const SILBasicBlock *parentBlock,
                                              const SILBasicBlock *predBlock,
                                              unsigned argIndex) {
-  auto *predBlockTermInst = predBlock->getTerminator();
-  if (auto *bi = dyn_cast<BranchInst>(predBlockTermInst)) {
-    return &const_cast<BranchInst *>(bi)->getAllOperands()[argIndex];
-  }
-
-  // FIXME: Disallowing critical edges in SIL would enormously simplify phi and
-  // branch handling and reduce expensive analysis invalidation. If that is
-  // done, then only BranchInst will participate in phi operands, eliminating
-  // the need to search for the appropriate CondBranchInst operand.
-  return cast<CondBranchInst>(predBlockTermInst)
-      ->getOperandForDestBB(parentBlock, argIndex);
+  // Only a BranchInst can pass phi arguments: SIL does not contain critical
+  // edges, so a block with multiple predecessors (a phi) is only ever reached
+  // through unconditional branches.
+  auto *bi = cast<BranchInst>(predBlock->getTerminator());
+  return &const_cast<BranchInst *>(bi)->getAllOperands()[argIndex];
 }
 
 static SILValue getIncomingPhiValueForPred(const SILBasicBlock *parentBlock,
                                            const SILBasicBlock *predBlock,
                                            unsigned argIndex) {
-  const auto *predBlockTermInst = predBlock->getTerminator();
-  if (auto *bi = dyn_cast<BranchInst>(predBlockTermInst))
-    return bi->getArg(argIndex);
-
-  // FIXME: Disallowing critical edges in SIL would enormously simplify phi and
-  // branch handling and reduce expensive analysis invalidation. If that is
-  // done, then only BranchInst will participate in phi operands, eliminating
-  // the need to search for the appropriate CondBranchInst operand.
-  return cast<CondBranchInst>(predBlockTermInst)
-      ->getArgForDestBB(parentBlock, argIndex);
+  // Only a BranchInst can pass phi arguments (see above).
+  return cast<BranchInst>(predBlock->getTerminator())->getArg(argIndex);
 }
 
 SILValue SILPhiArgument::getIncomingPhiValue(SILBasicBlock *predBlock) const {
@@ -327,12 +313,10 @@ getSingleTerminatorOperandForPred(const SILBasicBlock *parentBlock,
   case TermKind::DynamicMethodBranchInst:
   case TermKind::YieldInst:
   case TermKind::AwaitAsyncContinuationInst:
+  case TermKind::CondBranchInst:
     return SILValue();
   case TermKind::BranchInst:
     return cast<const BranchInst>(predTermInst)->getArg(argIndex);
-  case TermKind::CondBranchInst:
-    return cast<const CondBranchInst>(predTermInst)
-        ->getArgForDestBB(parentBlock, argIndex);
   case TermKind::CheckedCastBranchInst:
     return cast<const CheckedCastBranchInst>(predTermInst)->getOperand();
   case TermKind::SwitchEnumInst:
@@ -407,22 +391,6 @@ SILPhiArgument *BranchInst::getArgForOperand(const Operand *oper) {
   assert(oper->getUser() == this);
   return cast<SILPhiArgument>(
       getDestBB()->getArgument(oper->getOperandNumber()));
-}
-
-const SILPhiArgument *
-CondBranchInst::getArgForOperand(const Operand *oper) const {
-  assert(oper->getUser() == this);
-
-  unsigned operIdx = oper->getOperandNumber();
-  if (isTrueOperandIndex(operIdx)) {
-    return cast<SILPhiArgument>(getTrueBB()->getArgument(
-        operIdx - getTrueOperands().front().getOperandNumber()));
-  }
-  if (isFalseOperandIndex(operIdx)) {
-    return cast<SILPhiArgument>(getFalseBB()->getArgument(
-        operIdx - getFalseOperands().front().getOperandNumber()));
-  }
-  return nullptr;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -2181,97 +2181,21 @@ BranchInst *BranchInst::create(SILDebugLocation Loc,
 
 CondBranchInst::CondBranchInst(SILDebugLocation Loc, SILValue Condition,
                                SILBasicBlock *TrueBB, SILBasicBlock *FalseBB,
-                               ArrayRef<SILValue> Args, unsigned NumTrue,
-                               unsigned NumFalse, ProfileCounter TrueBBCount,
+                               ProfileCounter TrueBBCount,
                                ProfileCounter FalseBBCount)
-    : InstructionBaseWithTrailingOperands(Condition, Args, Loc),
-      DestBBs{{{this, TrueBB, TrueBBCount}, {this, FalseBB, FalseBBCount}}},
-      numTrueArguments(NumTrue) {
-  assert(Args.size() == (NumTrue + NumFalse) && "Invalid number of args");
+    : UnaryInstructionBase(Loc, Condition),
+      DestBBs{{{this, TrueBB, TrueBBCount}, {this, FalseBB, FalseBBCount}}} {
   assert(TrueBB != FalseBB && "Identical destinations");
 }
 
-CondBranchInst *CondBranchInst::create(SILDebugLocation Loc, SILValue Condition,
-                                       SILBasicBlock *TrueBB,
-                                       SILBasicBlock *FalseBB,
-                                       ProfileCounter TrueBBCount,
-                                       ProfileCounter FalseBBCount,
-                                       SILFunction &F) {
-  return create(Loc, Condition, TrueBB, {}, FalseBB, {}, TrueBBCount,
-                FalseBBCount, F);
-}
-
-CondBranchInst *
-CondBranchInst::create(SILDebugLocation Loc, SILValue Condition,
-                       SILBasicBlock *TrueBB, ArrayRef<SILValue> TrueArgs,
-                       SILBasicBlock *FalseBB, ArrayRef<SILValue> FalseArgs,
-                       ProfileCounter TrueBBCount, ProfileCounter FalseBBCount,
-                       SILFunction &F) {
-  SmallVector<SILValue, 4> Args;
-  Args.append(TrueArgs.begin(), TrueArgs.end());
-  Args.append(FalseArgs.begin(), FalseArgs.end());
-
-  auto Size = totalSizeToAlloc<swift::Operand>(Args.size() + NumFixedOpers);
-  auto Buffer = F.getModule().allocateInst(Size, alignof(CondBranchInst));
-  return ::new (Buffer) CondBranchInst(Loc, Condition, TrueBB, FalseBB, Args,
-                                       TrueArgs.size(), FalseArgs.size(),
-                                       TrueBBCount, FalseBBCount);
-}
-
-Operand *CondBranchInst::getOperandForDestBB(const SILBasicBlock *destBlock,
-                                             const SILArgument *arg) const {
-  return getOperandForDestBB(destBlock, arg->getIndex());
-}
-
-Operand *CondBranchInst::getOperandForDestBB(const SILBasicBlock *destBlock,
-                                             unsigned argIndex) const {
-  // If TrueBB and FalseBB equal, we cannot find an arg for this DestBB so
-  // return an empty SILValue.
-  if (getTrueBB() == getFalseBB()) {
-    assert(destBlock == getTrueBB() &&
-           "DestBB is not a target of this cond_br");
-    return nullptr;
-  }
-
-  auto *self = const_cast<CondBranchInst *>(this);
-  if (destBlock == getTrueBB()) {
-    return &self->getAllOperands()[NumFixedOpers + argIndex];
-  }
-
-  assert(destBlock == getFalseBB() &&
-         "By process of elimination BB must be false BB");
-  return &self->getAllOperands()[NumFixedOpers + getNumTrueArgs() + argIndex];
-}
-
 void CondBranchInst::swapSuccessors() {
-  // Swap our destinations.
+  // Swap our destinations. A cond_br has no branch arguments, so there is
+  // nothing else to swap.
   SILBasicBlock *First = DestBBs[0].getBB();
   DestBBs[0] = DestBBs[1].getBB();
   DestBBs[1] = First;
-
-  // If we don't have any arguments return.
-  if (!getNumTrueArgs() && !getNumFalseArgs())
-    return;
-
-  // Otherwise swap our true and false arguments.
-  MutableArrayRef<Operand> Ops = getAllOperands();
-  llvm::SmallVector<SILValue, 4> TrueOps;
-  for (SILValue V : getTrueArgs())
-    TrueOps.push_back(V);
-
-  auto FalseArgs = getFalseArgs();
-  for (unsigned i = 0, e = getNumFalseArgs(); i < e; ++i) {
-    Ops[NumFixedOpers+i].set(FalseArgs[i]);
-  }
-
-  for (unsigned i = 0, e = getNumTrueArgs(); i < e; ++i) {
-    Ops[NumFixedOpers+i+getNumFalseArgs()].set(TrueOps[i]);
-  }
-
-  // Finally swap the number of arguments that we have. The number of false
-  // arguments is derived from the number of true arguments, therefore:
-  numTrueArguments = getNumFalseArgs();
 }
+
 
 SwitchValueInst::SwitchValueInst(SILDebugLocation Loc, SILValue Operand,
                                  SILBasicBlock *DefaultBB,

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -3298,9 +3298,7 @@ public:
   void visitCondBranchInst(CondBranchInst *CBI) {
     *this << Ctx.getID(CBI->getCondition()) << ", "
           << Ctx.getID(CBI->getTrueBB());
-    printBranchArgs(CBI->getTrueArgs());
     *this << ", " << Ctx.getID(CBI->getFalseBB());
-    printBranchArgs(CBI->getFalseArgs());
     if (CBI->getTrueBBCount())
       *this << " !true_count(" << CBI->getTrueBBCount().getValue() << ")";
     if (CBI->getFalseBBCount())

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -5720,22 +5720,20 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
       UnresolvedValueName Cond;
       Identifier BBName, BBName2;
       SourceLoc NameLoc, NameLoc2;
-      SmallVector<SILValue, 6> Args, Args2;
       if (parseValueName(Cond) ||
           P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
           parseSILIdentifier(BBName, NameLoc, diag::expected_sil_block_name) ||
-          parseSILBBArgsAtBranch(Args, B) ||
           P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
           parseSILIdentifier(BBName2, NameLoc2,
                              diag::expected_sil_block_name) ||
-          parseSILBBArgsAtBranch(Args2, B) || parseSILDebugLocation(InstLoc, B))
+          parseSILDebugLocation(InstLoc, B))
         return true;
 
       auto I1Ty = SILType::getBuiltinIntegerType(1, SILMod.getASTContext());
       SILValue CondVal = getLocalValue(Cond, I1Ty, InstLoc, B);
       ResultVal = B.createCondBranch(
-          InstLoc, CondVal, getBBForReference(BBName, NameLoc), Args,
-          getBBForReference(BBName2, NameLoc2), Args2);
+          InstLoc, CondVal, getBBForReference(BBName, NameLoc),
+          getBBForReference(BBName2, NameLoc2));
       break;
     }
     case SILInstructionKind::UnreachableInst:

--- a/lib/SIL/Utils/BasicBlockUtils.cpp
+++ b/lib/SIL/Utils/BasicBlockUtils.cpp
@@ -34,12 +34,6 @@ static bool hasBranchArguments(TermInst *T, unsigned edgeIdx) {
     assert(edgeIdx == 0);
     return BI->getNumArgs() != 0;
   }
-  if (auto CBI = dyn_cast<CondBranchInst>(T)) {
-    assert(edgeIdx <= 1);
-    return edgeIdx == CondBranchInst::TrueIdx ? !CBI->getTrueArgs().empty()
-                                              : !CBI->getFalseArgs().empty();
-  }
-  // No other terminator have branch arguments.
   return false;
 }
 
@@ -74,21 +68,13 @@ void swift::changeBranchTarget(TermInst *T, unsigned edgeIdx,
     SILBasicBlock *trueDest = CBI->getTrueBB();
     SILBasicBlock *falseDest = CBI->getFalseBB();
 
-    SmallVector<SILValue, 8> trueArgs;
-    SmallVector<SILValue, 8> falseArgs;
-    if (edgeIdx == CondBranchInst::FalseIdx) {
+    if (edgeIdx == CondBranchInst::FalseIdx)
       falseDest = newDest;
-      for (auto arg : CBI->getTrueArgs())
-        trueArgs.push_back(arg);
-    } else {
+    else
       trueDest = newDest;
-      for (auto arg : CBI->getFalseArgs())
-        falseArgs.push_back(arg);
-    }
 
-    B.createCondBranch(CBI->getLoc(), CBI->getCondition(), trueDest, trueArgs,
-                       falseDest, falseArgs, CBI->getTrueBBCount(),
-                       CBI->getFalseBBCount());
+    B.createCondBranch(CBI->getLoc(), CBI->getCondition(), trueDest, falseDest,
+                       CBI->getTrueBBCount(), CBI->getFalseBBCount());
     CBI->dropAllReferences();
     CBI->eraseFromParent();
     return;
@@ -123,11 +109,8 @@ void swift::getEdgeArgs(TermInst *T, unsigned edgeIdx, SILBasicBlock *newEdgeBB,
   }
 
   case SILInstructionKind::CondBranchInst: {
-    auto CBI = cast<CondBranchInst>(T);
+    // A cond_br passes no branch arguments (SIL has no critical edges).
     assert(edgeIdx < 2);
-    auto OpdArgs = edgeIdx ? CBI->getFalseArgs() : CBI->getTrueArgs();
-    for (auto V : OpdArgs)
-      args.push_back(V);
     return;
   }
       

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -152,14 +152,6 @@ SILValue swift::stripSinglePredecessorArgs(SILValue V) {
       V = BI->getArg(A->getIndex());
       continue;
     }
-    
-    if (auto *CBI = dyn_cast<CondBranchInst>(PredTI)) {
-      if (SILValue Arg = CBI->getArgForDestBB(BB, A)) {
-        V = Arg;
-        continue;
-      }
-    }
-    
     return V;
   }
 }

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1507,20 +1507,14 @@ public:
     assert(arg->isPhi() && "precondition");
     for (SILBasicBlock *predBB : arg->getParent()->getPredecessorBlocks()) {
       auto *TI = predBB->getTerminator();
+      require(isa<BranchInst>(TI), "All phi inputs must be branch operands.");
       if (F.hasOwnership()) {
-        require(isa<BranchInst>(TI), "All phi inputs must be branch operands.");
-
         // Address-only values are potentially unmovable when borrowed. See also
         // checkOwnershipForwardingInst. A phi implies a move of its arguments
         // because they can't necessarily all reuse the same storage.
         require((!arg->getType().isAddressOnly(F)
                  || arg->getOwnershipKind() != OwnershipKind::Guaranteed),
                 "Guaranteed address-only phi not allowed--implies a copy");
-      } else {
-        // FIXME: when critical edges are removed and cond_br arguments are
-        // disallowed, only allow BranchInst.
-        require(isa<BranchInst>(TI) || isa<CondBranchInst>(TI),
-                "All phi argument inputs must be from branches.");
       }
     }
     if (arg->isPhi()) {
@@ -6046,34 +6040,15 @@ public:
                         1, cbi->getCondition()->getType().getASTContext()),
                     "condition of conditional branch must have Int1 type");
 
-    require(cbi->getTrueArgs().size() == cbi->getTrueBB()->args_size(),
-            "true branch has wrong number of arguments for dest bb");
     require(cbi->getTrueBB() != cbi->getFalseBB(), "identical destinations");
-    require(std::equal(cbi->getTrueArgs().begin(), cbi->getTrueArgs().end(),
-                       cbi->getTrueBB()->args_begin(),
-                       [&](SILValue branchArg, SILArgument *bbArg) {
-                         return verifyBranchArgs(branchArg, bbArg);
-                       }),
-            "true branch argument types do not match arguments for dest bb");
 
-    require(cbi->getFalseArgs().size() == cbi->getFalseBB()->args_size(),
-            "false branch has wrong number of arguments for dest bb");
-    require(std::equal(cbi->getFalseArgs().begin(), cbi->getFalseArgs().end(),
-                       cbi->getFalseBB()->args_begin(),
-                       [&](SILValue branchArg, SILArgument *bbArg) {
-                         return verifyBranchArgs(branchArg, bbArg);
-                       }),
-            "false branch argument types do not match arguments for dest bb");
-    // When we are in ossa, cond_br can not have any arguments that are
-    // non-trivial.
-    if (!F.hasOwnership())
-      return;
-
-    require(llvm::all_of(cbi->getOperandValues(),
-                         [&](SILValue v) -> bool {
-                           return v->getType().isTrivial(*cbi->getFunction());
-                         }),
-            "cond_br must not have a non-trivial value in ossa.");
+    // A cond_br never passes branch arguments: because SIL does not contain
+    // critical edges, both destinations have a single predecessor and therefore
+    // must not take any block arguments.
+    require(cbi->getTrueBB()->args_empty(),
+            "true branch destination must not take arguments");
+    require(cbi->getFalseBB()->args_empty(),
+            "false branch destination must not take arguments");
   }
 
   void checkDynamicMethodBranchInst(DynamicMethodBranchInst *DMBI) {

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -96,10 +96,6 @@ static llvm::cl::opt<bool> VerifyDebugValueExpr("verify-debug-value-expr",
 static llvm::cl::opt<bool> SkipConvertEscapeToNoescapeAttributes(
     "verify-skip-convert-escape-to-noescape-attributes", llvm::cl::init(false));
 
-// Allow unit tests to gradually migrate toward -allow-critical-edges=false.
-static llvm::cl::opt<bool> AllowCriticalEdges("allow-critical-edges",
-                                              llvm::cl::init(true));
-
 static llvm::cl::opt<bool> VerifyReducibleLoops(
     "verify-reducible-loops", llvm::cl::init(false),
     llvm::cl::desc("Verify that SIL does not contain irreducible loops"));
@@ -7227,31 +7223,17 @@ public:
   }
 
   void verifyBranches(const SILFunction *F) {
-    // Verify no critical edge.
-    auto requireNonCriticalSucc = [this](const TermInst *termInst,
-                                         const Twine &message) {
-      // A critical edge has more than one outgoing edges from the source
-      // block.
-      auto succBlocks = termInst->getSuccessorBlocks();
-      if (succBlocks.size() <= 1)
-        return;
-
-      for (const SILBasicBlock *destBB : succBlocks) {
-        // And its destination block has more than one predecessor.
-        _require(destBB->getSinglePredecessorBlock(), message);
-      }
-    };
-
     for (auto &bb : *F) {
       const TermInst *termInst = bb.getTerminator();
       VerifierErrorEmitterGuard guard(this, termInst);
 
-      if (isSILOwnershipEnabled() && F->hasOwnership()) {
-        requireNonCriticalSucc(termInst, "critical edges not allowed in OSSA");
-      }
-      // In Lowered SIL, they are allowed on conditional branches only.
-      if (!AllowCriticalEdges && !isa<CondBranchInst>(termInst)) {
-        requireNonCriticalSucc(termInst, "only cond_br critical edges allowed");
+      // A critical edge has more than one outgoing edges from the source
+      // block.
+      if (!isa<BranchInst>(termInst)) {
+        for (const SILBasicBlock *destBB : termInst->getSuccessorBlocks()) {
+          // And its destination block has more than one predecessor.
+          _require(destBB->getSinglePredecessorBlock(), "critical edges not allowed");
+        }
       }
     }
   }

--- a/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
@@ -254,10 +254,10 @@ static bool canTerminatorUseValue(TermInst *TI, SILValue Ptr,
     return doOperandsAlias(BI->getAllOperands(), Ptr, AA);
   }
 
-  if (auto *CBI = dyn_cast<CondBranchInst>(TI)) {
-    bool First = doOperandsAlias(CBI->getTrueOperands(), Ptr, AA);
-    bool Second = doOperandsAlias(CBI->getFalseOperands(), Ptr, AA);
-    return First || Second;
+  if (isa<CondBranchInst>(TI)) {
+    // A cond_br only uses its Int1 condition operand and passes no branch
+    // arguments, so it never uses a reference-counted value.
+    return false;
   }
 
   if (auto *SWEI = dyn_cast<SwitchEnumInst>(TI)) {

--- a/lib/SILOptimizer/Analysis/DifferentiableActivityAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/DifferentiableActivityAnalysis.cpp
@@ -197,10 +197,9 @@ void DifferentiableActivityInfo::propagateVaried(
       setVariedAndPropagateToUsers(bi->getArgForOperand(operand), i);
   }
   // Handle `cond_br`.
-  else if (auto *cbi = dyn_cast<CondBranchInst>(inst)) {
-    if (isVaried(operand->get(), i))
-      if (auto *destBBArg = cbi->getArgForOperand(operand))
-        setVariedAndPropagateToUsers(destBBArg, i);
+  else if (isa<CondBranchInst>(inst)) {
+    // A cond_br only uses its condition operand and passes no branch arguments,
+    // so there is no destination block argument to propagate variedness to.
   }
   // Handle `checked_cast_addr_br`.
   // Propagate variedness from source operand to destination operand, in

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -482,8 +482,8 @@ private:
   }
 
   void init(CondBranchInst *cbi) {
-    addValues(makeOperandRefRange(cbi->getTrueOperands()), cbi->getTrueBB());
-    addValues(makeOperandRefRange(cbi->getFalseOperands()), cbi->getFalseBB());
+    // A cond_br passes no branch arguments (SIL has no critical edges), so
+    // there are no values flowing to its successor blocks.
   }
 
   void init(DynamicMethodBranchInst *dmBranchInst) {

--- a/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
@@ -393,9 +393,9 @@ void GlobalPropertyOpt::scanInstructions() {
             SILValue PredArg;
             if (auto *BI = dyn_cast<BranchInst>(Term)) {
               PredArg = BI->getArg(argIdx);
-            } else if (auto *CBI = dyn_cast<CondBranchInst>(Term)) {
-              PredArg = CBI->getArgForDestBB(&BB, BBArg);
             }
+            // A cond_br passes no branch arguments (SIL has no critical edges),
+            // so a block with arguments is never reached through one.
             if (PredArg) {
               addDependency(getValueEntry(PredArg), getValueEntry(BBArg));
             } else {

--- a/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
@@ -231,22 +231,6 @@ static void rewriteNewLoopEntryCheckBlock(
   }
 }
 
-/// Update the dominator tree after rotating the loop.
-/// The former preheader now dominates all of the former headers children. The
-/// former latch now dominates the former header.
-static void updateDomTree(DominanceInfo *domInfo, SILBasicBlock *preheader,
-                          SILBasicBlock *latch, SILBasicBlock *header) {
-  auto *headerN = domInfo->getNode(header);
-  SmallVector<DominanceInfoNode *, 4> Children(headerN->begin(),
-                                               headerN->end());
-  auto *preheaderN = domInfo->getNode(preheader);
-  for (auto *Child : Children)
-    domInfo->changeImmediateDominator(Child, preheaderN);
-
-  if (header != latch)
-    domInfo->changeImmediateDominator(headerN, domInfo->getNode(latch));
-}
-
 static bool rotateLoopAtMostUpToLatch(SILLoop *loop, DominanceInfo *domInfo,
                                       SILLoopInfo *loopInfo, SILPassManager *pm) {
   auto *latch = loop->getLoopLatch();
@@ -448,23 +432,24 @@ static bool rotateLoop(SILLoop *loop, DominanceInfo *domInfo,
   preheaderBranch->dropAllReferences();
   preheaderBranch->eraseFromParent();
 
+  // A cond_br carries no branch arguments (SIL has no critical edges). Cloning
+  // the header's conditional branch into the preheader created critical edges
+  // from the preheader and the original header to the new header and the loop
+  // exit. Split them now, before running the SSA updater below: the updater
+  // inserts phi operands on predecessor terminators, which is only possible for
+  // unconditional branches.
+  splitCriticalEdgesFrom(preheader, nullptr, loopInfo);
+  splitCriticalEdgesFrom(header, nullptr, loopInfo);
+
   // If there were any uses of instructions in the duplicated loop entry check
   // block rewrite them using the ssa updater.
   rewriteNewLoopEntryCheckBlock(header, preheader, valueMap, pm);
 
   loop->moveToHeader(newHeader);
 
-  // Now the original preheader dominates all of headers children and the
-  // original latch dominates the header.
-  updateDomTree(domInfo, preheader, latch, header);
-
-  assert(domInfo->getNode(newHeader)->getIDom() == domInfo->getNode(preheader));
-  assert(!domInfo->dominates(header, exit)
-         || domInfo->getNode(exit)->getIDom() == domInfo->getNode(preheader));
-  assert(domInfo->getNode(header)->getIDom() == domInfo->getNode(latch)
-         || ((header == latch)
-             && domInfo->getNode(header)->getIDom()
-                    == domInfo->getNode(preheader)));
+  // The rotation and the critical-edge splitting above changed the CFG
+  // significantly. Recompute dominance rather than updating it incrementally.
+  domInfo->recalculate(*header->getParent());
 
   // Beautify the IR. Move the old header to after the old latch as it is now
   // the latch.

--- a/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
@@ -316,10 +316,10 @@ static void redirectTerminator(SILBasicBlock *Latch, unsigned CurLoopIter,
           Latch->getSinglePredecessorBlock()->getTerminator());
       if (CondBr->getTrueBB() != Latch)
         SILBuilderWithScope(CondBr).createBranch(
-            CondBr->getLoc(), CondBr->getTrueBB(), CondBr->getTrueArgs());
+            CondBr->getLoc(), CondBr->getTrueBB());
       else
         SILBuilderWithScope(CondBr).createBranch(
-            CondBr->getLoc(), CondBr->getFalseBB(), CondBr->getFalseArgs());
+            CondBr->getLoc(), CondBr->getFalseBB());
       CondBr->eraseFromParent();
       return;
     }
@@ -338,11 +338,11 @@ static void redirectTerminator(SILBasicBlock *Latch, unsigned CurLoopIter,
   if (CurLoopIter == LastLoopIter) {
     if (CondBr->getTrueBB() == CurrentHeader) {
       SILBuilderWithScope(CondBr).createBranch(
-          CondBr->getLoc(), CondBr->getFalseBB(), CondBr->getFalseArgs());
+          CondBr->getLoc(), CondBr->getFalseBB());
     } else {
       assert(CondBr->getFalseBB() == CurrentHeader);
       SILBuilderWithScope(CondBr).createBranch(
-          CondBr->getLoc(), CondBr->getTrueBB(), CondBr->getTrueArgs());
+          CondBr->getLoc(), CondBr->getTrueBB());
     }
     CondBr->eraseFromParent();
     return;
@@ -352,12 +352,12 @@ static void redirectTerminator(SILBasicBlock *Latch, unsigned CurLoopIter,
   if (CondBr->getTrueBB() == CurrentHeader) {
     SILBuilderWithScope(CondBr).createCondBranch(
         CondBr->getLoc(), CondBr->getCondition(), NextIterationsHeader,
-        CondBr->getTrueArgs(), CondBr->getFalseBB(), CondBr->getFalseArgs());
+        CondBr->getFalseBB());
   } else {
     assert(CondBr->getFalseBB() == CurrentHeader);
     SILBuilderWithScope(CondBr).createCondBranch(
         CondBr->getLoc(), CondBr->getCondition(), CondBr->getTrueBB(),
-        CondBr->getTrueArgs(), NextIterationsHeader, CondBr->getFalseArgs());
+        NextIterationsHeader);
   }
   CondBr->eraseFromParent();
 }

--- a/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
@@ -109,10 +109,9 @@ static bool checkNoEscapePartialApplyUse(Operand *oper, FollowUse followUses) {
     return false;
   }
 
-  if (auto *CBI = dyn_cast<CondBranchInst>(user)) {
-    const SILPhiArgument *arg = CBI->getArgForOperand(oper);
-    if (arg) // If the use isn't the branch condition, follow it.
-      followUses(arg);
+  if (isa<CondBranchInst>(user)) {
+    // A cond_br only uses its condition operand and passes no branch arguments,
+    // so there is nothing to follow through it.
     return false;
   }
 

--- a/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
@@ -537,12 +537,12 @@ static bool constantFoldTerminator(SILBasicBlock &BB,
       SILBasicBlock *UnreachableBlock = nullptr;
       bool CondIsTrue = false;
       if (ConstCond->getValue() == APInt(1, /*value*/ 0, false)) {
-        B.createBranch(Loc, CBI->getFalseBB(), CBI->getFalseArgs());
+        B.createBranch(Loc, CBI->getFalseBB());
         UnreachableBlock = CBI->getTrueBB();
       } else {
         assert(ConstCond->getValue() == APInt(1, /*value*/ 1, false) &&
                "Our representation of true/false does not match.");
-        B.createBranch(Loc, CBI->getTrueBB(), CBI->getTrueArgs());
+        B.createBranch(Loc, CBI->getTrueBB());
         UnreachableBlock = CBI->getFalseBB();
         CondIsTrue = true;
       }

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -1164,22 +1164,14 @@ SILInstruction *SILCombiner::visitCondBranchInst(CondBranchInst *CBI) {
                             m_One()))) &&
       X->getType() ==
           SILType::getBuiltinIntegerType(1, CBI->getModule().getASTContext())) {
-    SmallVector<SILValue, 4> OrigTrueArgs, OrigFalseArgs;
-    for (const auto Op : CBI->getTrueArgs())
-      OrigTrueArgs.push_back(Op);
-    for (const auto Op : CBI->getFalseArgs())
-      OrigFalseArgs.push_back(Op);
+    // A cond_br passes no branch arguments, so just swap the destinations.
     return Builder.createCondBranch(CBI->getLoc(), X,
-                                    CBI->getFalseBB(), OrigFalseArgs,
-                                    CBI->getTrueBB(), OrigTrueArgs);
+                                    CBI->getFalseBB(), CBI->getTrueBB());
   }
 
   // cond_br (select_enum) -> switch_enum
   // This pattern often occurs as a result of using optionals.
   if (auto *SEI = dyn_cast<SelectEnumInst>(CBI->getCondition())) {
-    // No bb args should be passed
-    if (!CBI->getTrueArgs().empty() || !CBI->getFalseArgs().empty())
-      return nullptr;
     auto EnumOperandTy = SEI->getEnumOperand()->getType();
     // Type should be loadable and copyable.
     // TODO: Generalize to work without copying address-only or noncopyable

--- a/lib/SILOptimizer/Transforms/COWOpts.cpp
+++ b/lib/SILOptimizer/Transforms/COWOpts.cpp
@@ -295,10 +295,8 @@ void COWOptsPass::collectEscapePoints(SILValue v,
                             escapePoints, handled);
         break;
       case SILInstructionKind::CondBranchInst:
-        if (use->getOperandNumber() != CondBranchInst::ConditionIdx) {
-          collectEscapePoints(cast<CondBranchInst>(user)->getArgForOperand(use),
-                              escapePoints, handled);
-        }
+        // A cond_br only uses its condition operand and passes no branch
+        // arguments, so there is nothing to collect through it.
         break;
       case SILInstructionKind::StructInst:
       case SILInstructionKind::StructExtractInst:

--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -438,6 +438,7 @@ void DCE::markTerminatorArgsLive(SILBasicBlock *Pred,
   case TermKind::SwitchValueInst:
   case TermKind::SwitchEnumAddrInst:
   case TermKind::CheckedCastAddrBranchInst:
+  case TermKind::CondBranchInst:
     llvm_unreachable("Unexpected argument for terminator kind!");
     break;
 
@@ -456,21 +457,6 @@ void DCE::markTerminatorArgsLive(SILBasicBlock *Pred,
     markValueLive(cast<BranchInst>(Term)->getArg(ArgIndex));
     break;
 
-  case TermKind::CondBranchInst: {
-    auto *CondBr = cast<CondBranchInst>(Term);
-
-    if (CondBr->getTrueBB() == Succ) {
-      auto TrueArgs = CondBr->getTrueArgs();
-      markValueLive(TrueArgs[ArgIndex]);
-    }
-
-    if (CondBr->getFalseBB() == Succ) {
-      auto FalseArgs = CondBr->getFalseArgs();
-      markValueLive(FalseArgs[ArgIndex]);
-    }
-
-    break;
-  }
   case TermKind::AwaitAsyncContinuationInst:
   case TermKind::TryApplyInst: {
     assert(ArgIndex == 0 && "Expect a single argument!");

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -372,10 +372,6 @@ bool SILPerformanceInliner::isAutoDiffLinearMapWithControlFlow(
         if (auto *bi = dyn_cast<BranchInst>(predBB->getTerminator())) {
           val = bi->getArg(phiArg->getIndex());
           continue;
-        } else if (auto *cbi =
-                       dyn_cast<CondBranchInst>(predBB->getTerminator())) {
-          val = cbi->getArgForDestBB(phiArg->getParent(), phiArg->getIndex());
-          continue;
         } else if (auto *sei =
                        dyn_cast<SwitchEnumInst>(predBB->getTerminator())) {
           val = sei->getOperand();

--- a/lib/SILOptimizer/Transforms/PhiArgumentOptimizations.cpp
+++ b/lib/SILOptimizer/Transforms/PhiArgumentOptimizations.cpp
@@ -363,16 +363,10 @@ bool PhiExpansionPass::optimizeArg(SILPhiArgument *initialArg) {
           collectedPhiArgs.push_back(destArg);
         continue;
       }
-      if (auto *branch = dyn_cast<CondBranchInst>(user)) {
-        const SILPhiArgument *destArg = branch->getArgForOperand(use);
-
-        // destArg is null if the use is the condition and not a block argument.
-        if (!destArg)
-          return false;
-
-        if (handled.insert(destArg).second)
-          collectedPhiArgs.push_back(destArg);
-        continue;
+      if (isa<CondBranchInst>(user)) {
+        // A cond_br only uses its condition operand and passes no branch
+        // arguments, so there is no phi argument to collect: bail.
+        return false;
       }
       // An unexpected use -> bail.
       return false;

--- a/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
@@ -996,9 +996,8 @@ static SILValue findValueShallowRoot(const SILValue &In) {
       return BI->getArg(Idx);
     }
 
-    if (auto CBI = dyn_cast<CondBranchInst>(Pred->getTerminator())) {
-      return CBI->getArgForDestBB(Parent, Arg);
-    }
+    // A cond_br passes no branch arguments (SIL has no critical edges), so a
+    // block argument is never reached through one.
   }
   return In;
 }
@@ -1122,14 +1121,8 @@ cheaperToPassOperandsAsArguments(SILInstruction *First,
 SILValue getArgForBlock(SILBasicBlock *From, SILBasicBlock *To,
                         unsigned ArgNum) {
   TermInst *Term = From->getTerminator();
-  if (auto *CondBr = dyn_cast<CondBranchInst>(Term)) {
-    if (CondBr->getFalseBB() == To)
-      return CondBr->getFalseArgs()[ArgNum];
-
-    if (CondBr->getTrueBB() == To)
-      return CondBr->getTrueArgs()[ArgNum];
-  }
-
+  // A cond_br passes no branch arguments (SIL has no critical edges), so only
+  // an unconditional branch forwards a value to a successor block argument.
   if (auto *Br = dyn_cast<BranchInst>(Term))
     return Br->getArg(ArgNum);
 

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -203,11 +203,9 @@ bool SimplifyCFG::threadEdge(const ThreadInfo &ti) {
 
     ThreadedSuccessorBlock =
         clonedSrc->getSuccessors()[ti.ThreadedSuccessorIdx].getBB();
-    auto Args = ti.ThreadedSuccessorIdx == 0 ? CondTerm->getTrueArgs()
-                                             : CondTerm->getFalseArgs();
-
+    // A cond_br passes no branch arguments (SIL has no critical edges).
     SILBuilderWithScope(CondTerm).createBranch(CondTerm->getLoc(),
-                                               ThreadedSuccessorBlock, Args);
+                                               ThreadedSuccessorBlock);
 
     CondTerm->eraseFromParent();
   } else {
@@ -540,13 +538,11 @@ bool SimplifyCFG::simplifyThreadedTerminators() {
         LLVM_DEBUG(llvm::dbgs() << "simplify threaded " << *CondBr);
         SILBasicBlock *TrueSide = CondBr->getTrueBB();
         SILBasicBlock *FalseSide = CondBr->getFalseBB();
-        auto TrueArgs = CondBr->getTrueArgs();
-        auto FalseArgs = CondBr->getFalseArgs();
         bool isFalse = !IL->getValue();
-        auto LiveArgs = isFalse ? FalseArgs : TrueArgs;
         auto *LiveBlock = isFalse ? FalseSide : TrueSide;
+        // A cond_br passes no branch arguments (SIL has no critical edges).
         SILBuilderWithScope(CondBr)
-            .createBranch(CondBr->getLoc(), LiveBlock, LiveArgs);
+            .createBranch(CondBr->getLoc(), LiveBlock);
         CondBr->eraseFromParent();
         if (IL->use_empty())
           IL->eraseFromParent();
@@ -1474,8 +1470,9 @@ bool SimplifyCFG::simplifyCondBrBlock(CondBranchInst *BI) {
   auto *ThisBB = BI->getParent();
   SILBasicBlock *TrueSide = BI->getTrueBB();
   SILBasicBlock *FalseSide = BI->getFalseBB();
-  auto TrueArgs = BI->getTrueArgs();
-  auto FalseArgs = BI->getFalseArgs();
+  // A cond_br passes no branch arguments (SIL has no critical edges).
+  ArrayRef<SILValue> TrueArgs;
+  ArrayRef<SILValue> FalseArgs;
 
   // If the condition is an integer literal, we can constant fold the branch.
   if (auto *IL = dyn_cast<IntegerLiteralInst>(BI->getCondition())) {
@@ -1513,7 +1510,7 @@ bool SimplifyCFG::simplifyCondBrBlock(CondBranchInst *BI) {
           Builder.createCondBranch(
               BI->getLoc(),
               invertExpectAndApplyTo(Builder, BI->getCondition(), Cond),
-              FalseSide, FalseArgs, TrueSide, TrueArgs, BI->getFalseBBCount(),
+              FalseSide, TrueSide, BI->getFalseBBCount(),
               BI->getTrueBBCount());
           BI->eraseFromParent();
           addToWorklist(ThisBB);
@@ -1558,12 +1555,10 @@ bool SimplifyCFG::simplifyCondBrBlock(CondBranchInst *BI) {
                << "true-trampoline from bb" << ThisBB->getDebugID() << " to bb"
                << trueTrampolineDest.destBB->getDebugID() << '\n');
 
-    SmallVector<SILValue, 4> falseArgsCopy(FalseArgs.begin(), FalseArgs.end());
     eraseTrampolineDestArgs(trueTrampolineDest);
     SILBuilderWithScope(BI).createCondBranch(
         BI->getLoc(), BI->getCondition(), trueTrampolineDest.destBB,
-        {}, FalseSide, falseArgsCopy,
-        BI->getTrueBBCount(), BI->getFalseBBCount());
+        FalseSide, BI->getTrueBBCount(), BI->getFalseBBCount());
     BI->eraseFromParent();
 
     substitutedBlockPreds(TrueSide, ThisBB);
@@ -1581,11 +1576,10 @@ bool SimplifyCFG::simplifyCondBrBlock(CondBranchInst *BI) {
                << "false-trampoline from bb" << ThisBB->getDebugID() << " to bb"
                << falseTrampolineDest.destBB->getDebugID() << '\n');
 
-    SmallVector<SILValue, 4> trueArgsCopy(TrueArgs.begin(), TrueArgs.end());
     eraseTrampolineDestArgs(falseTrampolineDest);
     SILBuilderWithScope(BI).createCondBranch(
-        BI->getLoc(), BI->getCondition(), TrueSide, trueArgsCopy,
-        falseTrampolineDest.destBB, {}, BI->getTrueBBCount(),
+        BI->getLoc(), BI->getCondition(), TrueSide,
+        falseTrampolineDest.destBB, BI->getTrueBBCount(),
         BI->getFalseBBCount());
     BI->eraseFromParent();
 
@@ -1606,7 +1600,7 @@ bool SimplifyCFG::simplifyCondBrBlock(CondBranchInst *BI) {
     ++NumConstantFolded;
   };
   if (trueTrampolineDest.destBB == FalseSide
-      && trueTrampolineDest.newSourceBranchArgs == FalseArgs) {
+      && trueTrampolineDest.newSourceBranchArgs.empty()) {
     condBrToBr(trueTrampolineDest.newSourceBranchArgs, FalseSide);
     removeIfDead(TrueSide);
     return true;
@@ -3054,8 +3048,6 @@ private:
   bool createNewArguments();
   void replaceIncomingArgs(SILBuilder &B, BranchInst *BI,
                            llvm::SmallVectorImpl<SILValue> &NewIncomingValues);
-  void replaceIncomingArgs(SILBuilder &B, CondBranchInst *CBI,
-                           llvm::SmallVectorImpl<SILValue> &NewIncomingValues);
 };
 } // end anonymous namespace
 
@@ -3072,46 +3064,6 @@ void ArgumentSplitter::replaceIncomingArgs(
   }
   std::reverse(NewIncomingValues.begin(), NewIncomingValues.end());
   B.createBranch(BI->getLoc(), BI->getDestBB(), NewIncomingValues);
-}
-
-void ArgumentSplitter::replaceIncomingArgs(
-    SILBuilder &B, CondBranchInst *CBI,
-    llvm::SmallVectorImpl<SILValue> &NewIncomingValues) {
-  llvm::SmallVector<SILValue, 4> OldIncomingValues;
-  ArrayRef<SILValue> NewTrueValues, NewFalseValues;
-
-  unsigned ArgIndex = Arg->getIndex();
-  if (Arg->getParent() == CBI->getTrueBB()) {
-    ArrayRef<Operand> TrueArgs = CBI->getTrueOperands();
-    for (unsigned i : llvm::reverse(indices(TrueArgs))) {
-      // Skip this argument.
-      if (i == ArgIndex)
-        continue;
-      NewIncomingValues.push_back(TrueArgs[i].get());
-    }
-    std::reverse(NewIncomingValues.begin(), NewIncomingValues.end());
-    for (SILValue V : CBI->getFalseArgs())
-      OldIncomingValues.push_back(V);
-    NewTrueValues = NewIncomingValues;
-    NewFalseValues = OldIncomingValues;
-  } else {
-    ArrayRef<Operand> FalseArgs = CBI->getFalseOperands();
-    for (unsigned i : llvm::reverse(indices(FalseArgs))) {
-      // Skip this argument.
-      if (i == ArgIndex)
-        continue;
-      NewIncomingValues.push_back(FalseArgs[i].get());
-    }
-    std::reverse(NewIncomingValues.begin(), NewIncomingValues.end());
-    for (SILValue V : CBI->getTrueArgs())
-      OldIncomingValues.push_back(V);
-    NewTrueValues = OldIncomingValues;
-    NewFalseValues = NewIncomingValues;
-  }
-
-  B.createCondBranch(CBI->getLoc(), CBI->getCondition(), CBI->getTrueBB(),
-                     NewTrueValues, CBI->getFalseBB(), NewFalseValues,
-                     CBI->getTrueBBCount(), CBI->getFalseBBCount());
 }
 
 bool ArgumentSplitter::createNewArguments() {
@@ -3232,12 +3184,10 @@ bool ArgumentSplitter::split() {
       NewIncomingValues.push_back(ProjInst);
     }
 
-    if (auto *Br = dyn_cast<BranchInst>(OldTerm)) {
-      replaceIncomingArgs(B, Br, NewIncomingValues);
-    } else {
-      auto *CondBr = cast<CondBranchInst>(OldTerm);
-      replaceIncomingArgs(B, CondBr, NewIncomingValues);
-    }
+    // Only a BranchInst can carry phi arguments: SIL has no critical edges, so
+    // a phi block is only ever reached through unconditional branches.
+    auto *Br = cast<BranchInst>(OldTerm);
+    replaceIncomingArgs(B, Br, NewIncomingValues);
 
     OldTerm->eraseFromParent();
     NewIncomingValues.clear();

--- a/lib/SILOptimizer/Utils/CFGOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/CFGOptUtils.cpp
@@ -33,31 +33,11 @@ TermInst *swift::addNewEdgeValueToBranch(TermInst *branch, SILBasicBlock *dest,
   SILBuilderWithScope builder(branch);
   TermInst *newBr = nullptr;
 
-  if (auto *cbi = dyn_cast<CondBranchInst>(branch)) {
-    SmallVector<SILValue, 8> trueArgs;
-    SmallVector<SILValue, 8> falseArgs;
-
-    for (auto arg : cbi->getTrueArgs())
-      trueArgs.push_back(arg);
-
-    for (auto arg : cbi->getFalseArgs())
-      falseArgs.push_back(arg);
-
-    if (dest == cbi->getTrueBB()) {
-      trueArgs.push_back(val);
-      assert(trueArgs.size() == dest->getNumArguments());
-    }
-    if (dest == cbi->getFalseBB()) {
-      falseArgs.push_back(val);
-      assert(falseArgs.size() == dest->getNumArguments());
-    }
-
-    newBr = builder.createCondBranch(
-        cbi->getLoc(), cbi->getCondition(), cbi->getTrueBB(), trueArgs,
-        cbi->getFalseBB(), falseArgs, cbi->getTrueBBCount(),
-        cbi->getFalseBBCount());
-    deleter.getCallbacks().createdNewInst(newBr);
-  } else if (auto *bi = dyn_cast<BranchInst>(branch)) {
+  // Only a BranchInst can carry phi arguments: SIL has no critical edges, so a
+  // block with phi arguments is only ever reached through unconditional
+  // branches. Clients that create critical edges (e.g. LoopRotate) must split
+  // them before adding phi operands with the SSA updater.
+  if (auto *bi = dyn_cast<BranchInst>(branch)) {
     SmallVector<SILValue, 8> args;
 
     for (auto arg : bi->getArgs())
@@ -68,7 +48,7 @@ TermInst *swift::addNewEdgeValueToBranch(TermInst *branch, SILBasicBlock *dest,
     newBr = builder.createBranch(bi->getLoc(), bi->getDestBB(), args);
     deleter.getCallbacks().createdNewInst(newBr);
   } else {
-    // At the moment we can only add arguments to br and cond_br.
+    // At the moment we can only add arguments to br.
     llvm_unreachable("Can't add argument to terminator");
   }
 
@@ -93,38 +73,9 @@ static void deleteTriviallyDeadOperandsOfDeadArgument(
 TermInst *swift::deleteEdgeValue(TermInst *branch, SILBasicBlock *destBlock,
                                  size_t argIndex, bool cleanupDeadPhiOps,
                                  InstModCallbacks callbacks) {
-  if (auto *cbi = dyn_cast<CondBranchInst>(branch)) {
-    SmallVector<SILValue, 8> trueArgs;
-    SmallVector<SILValue, 8> falseArgs;
-
-    llvm::copy(cbi->getTrueArgs(), std::back_inserter(trueArgs));
-    llvm::copy(cbi->getFalseArgs(), std::back_inserter(falseArgs));
-
-    if (destBlock == cbi->getTrueBB()) {
-      if (cleanupDeadPhiOps) {
-        deleteTriviallyDeadOperandsOfDeadArgument(cbi->getTrueOperands(),
-                                                  argIndex, callbacks);
-      }
-      trueArgs.erase(trueArgs.begin() + argIndex);
-    }
-
-    if (destBlock == cbi->getFalseBB()) {
-      if (cleanupDeadPhiOps) {
-        deleteTriviallyDeadOperandsOfDeadArgument(cbi->getFalseOperands(),
-                                                  argIndex, callbacks);
-      }
-      falseArgs.erase(falseArgs.begin() + argIndex);
-    }
-
-    SILBuilderWithScope builder(cbi);
-    auto *result = builder.createCondBranch(
-        cbi->getLoc(), cbi->getCondition(), cbi->getTrueBB(), trueArgs,
-        cbi->getFalseBB(), falseArgs, cbi->getTrueBBCount(),
-        cbi->getFalseBBCount());
-    branch->eraseFromParent();
-    return result;
-  }
-
+  // Only a BranchInst can carry phi arguments: SIL has no critical edges, so a
+  // block with phi arguments is only ever reached through unconditional
+  // branches (never a cond_br).
   if (auto *bi = dyn_cast<BranchInst>(branch)) {
     SmallVector<SILValue, 8> args;
     llvm::copy(bi->getArgs(), std::back_inserter(args));
@@ -184,47 +135,9 @@ TermInst *swift::changeEdgeValue(TermInst *branch, SILBasicBlock *dest,
                                  size_t idx, SILValue Val) {
   SILBuilderWithScope builder(branch);
 
-  if (auto *cbi = dyn_cast<CondBranchInst>(branch)) {
-    SmallVector<SILValue, 8> trueArgs;
-    SmallVector<SILValue, 8> falseArgs;
-
-    OperandValueArrayRef oldTrueArgs = cbi->getTrueArgs();
-    bool branchOnTrue = cbi->getTrueBB() == dest;
-    assert((!branchOnTrue || idx < oldTrueArgs.size()) && "Not enough edges");
-
-    // Copy the edge values overwriting the edge at idx.
-    for (unsigned i = 0, e = oldTrueArgs.size(); i != e; ++i) {
-      if (branchOnTrue && idx == i)
-        trueArgs.push_back(Val);
-      else
-        trueArgs.push_back(oldTrueArgs[i]);
-    }
-    assert(trueArgs.size() == cbi->getTrueBB()->getNumArguments()
-           && "Destination block's number of arguments must match");
-
-    OperandValueArrayRef oldFalseArgs = cbi->getFalseArgs();
-    bool branchOnFalse = cbi->getFalseBB() == dest;
-    assert((!branchOnFalse || idx < oldFalseArgs.size()) && "Not enough edges");
-
-    // Copy the edge values overwriting the edge at idx.
-    for (unsigned i = 0, e = oldFalseArgs.size(); i != e; ++i) {
-      if (branchOnFalse && idx == i)
-        falseArgs.push_back(Val);
-      else
-        falseArgs.push_back(oldFalseArgs[i]);
-    }
-    assert(falseArgs.size() == cbi->getFalseBB()->getNumArguments()
-           && "Destination block's number of arguments must match");
-
-    cbi = builder.createCondBranch(
-        cbi->getLoc(), cbi->getCondition(), cbi->getTrueBB(), trueArgs,
-        cbi->getFalseBB(), falseArgs, cbi->getTrueBBCount(),
-        cbi->getFalseBBCount());
-    branch->dropAllReferences();
-    branch->eraseFromParent();
-    return cbi;
-  }
-
+  // Only a BranchInst can carry phi arguments: SIL has no critical edges, so a
+  // block with phi arguments is only ever reached through unconditional
+  // branches (never a cond_br).
   if (auto *bi = dyn_cast<BranchInst>(branch)) {
     SmallVector<SILValue, 8> args;
 

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -547,32 +547,9 @@ TermInst *swift::addArgumentsToBranch(ArrayRef<SILValue> vals,
                                       SILBasicBlock *dest, TermInst *branch) {
   SILBuilderWithScope builder(branch);
 
-  if (auto *cbi = dyn_cast<CondBranchInst>(branch)) {
-    SmallVector<SILValue, 8> trueArgs;
-    SmallVector<SILValue, 8> falseArgs;
-
-    for (auto arg : cbi->getTrueArgs())
-      trueArgs.push_back(arg);
-
-    for (auto arg : cbi->getFalseArgs())
-      falseArgs.push_back(arg);
-
-    if (dest == cbi->getTrueBB()) {
-      for (auto val : vals)
-        trueArgs.push_back(val);
-      assert(trueArgs.size() == dest->getNumArguments());
-    } else {
-      for (auto val : vals)
-        falseArgs.push_back(val);
-      assert(falseArgs.size() == dest->getNumArguments());
-    }
-
-    return builder.createCondBranch(
-        cbi->getLoc(), cbi->getCondition(), cbi->getTrueBB(), trueArgs,
-        cbi->getFalseBB(), falseArgs, cbi->getTrueBBCount(),
-        cbi->getFalseBBCount());
-  }
-
+  // Only a BranchInst can carry phi arguments: SIL has no critical edges, so a
+  // block with phi arguments is only ever reached through unconditional
+  // branches (never a cond_br).
   if (auto *bi = dyn_cast<BranchInst>(branch)) {
     SmallVector<SILValue, 8> args;
 

--- a/lib/SILOptimizer/Utils/SILSSAUpdater.cpp
+++ b/lib/SILOptimizer/Utils/SILSSAUpdater.cpp
@@ -167,16 +167,9 @@ static OperandValueArrayRef getEdgeValuesForTerminator(TermInst *ti,
            "Incoming edge block and phi block mismatch");
     return br->getArgs();
   }
-  if (auto *cbi = dyn_cast<CondBranchInst>(ti)) {
-    bool isTrueEdge = cbi->getTrueBB() == toBlock;
-    assert(((isTrueEdge && cbi->getTrueBB() == toBlock) ||
-            cbi->getFalseBB() == toBlock) &&
-           "Incoming edge block and phi block mismatch");
-    return isTrueEdge ? cbi->getTrueArgs() : cbi->getFalseArgs();
-  }
 
-  // We need a predecessor who is capable of holding outgoing branch
-  // arguments.
+  // Only a BranchInst can carry phi arguments: SIL has no critical edges, so a
+  // phi block is only ever reached through unconditional branches.
   llvm_unreachable("Unrecognized terminator leading to phi block");
 }
 
@@ -444,19 +437,12 @@ UseWrapper::UseWrapper(Operand *inputUse) {
 
   // Conditional branch user.
   if (auto *cbi = dyn_cast<CondBranchInst>(user)) {
-    auto operands = user->getAllOperands();
-    auto numTrueArgs = cbi->getTrueArgs().size();
-    for (auto pair : llvm::enumerate(operands)) {
+    // A cond_br only uses its condition operand and passes no branch arguments
+    // (SIL has no critical edges).
+    for (auto pair : llvm::enumerate(cbi->getAllOperands())) {
       if (inputUse == &pair.value()) {
-        unsigned i = pair.index();
-        // We treat the condition as part of the true args.
-        if (i < numTrueArgs + 1) {
-          index = i;
-          type = kCondBranchUseTrue;
-        } else {
-          index = i - numTrueArgs - 1;
-          type = kCondBranchUseFalse;
-        }
+        index = pair.index();
+        type = kCondBranchUseTrue;
         parent = cbi->getParent();
         return;
       }
@@ -480,14 +466,10 @@ Operand *UseWrapper::getOperand() {
 
   case kCondBranchUseTrue:
   case kCondBranchUseFalse: {
+    // A cond_br only uses its condition operand and passes no branch arguments.
     auto *cbi = cast<CondBranchInst>(parent->getTerminator());
-    auto indexToUse = [&]() -> unsigned {
-      if (type == kCondBranchUseTrue)
-        return index;
-      return cbi->getTrueArgs().size() + 1 + index;
-    }();
-    assert(indexToUse < cbi->getAllOperands().size());
-    return &cbi->getAllOperands()[indexToUse];
+    assert(index < cbi->getAllOperands().size());
+    return &cbi->getAllOperands()[index];
   }
   }
 

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -3539,35 +3539,18 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     break;
   }
   case SILInstructionKind::CondBranchInst: {
-    // Format: condition, true basic block ID, a list of arguments, false basic
-    // block ID, a list of arguments. Use SILOneTypeValuesLayout: the type is
-    // for condition, the list has value for condition, true basic block ID,
-    // false basic block ID, number of true arguments, and a list of true|false
-    // arguments.
+    // Format: condition, true basic block ID, false basic block ID, and a
+    // (always zero) count of true arguments. A cond_br never passes branch
+    // arguments because SIL does not contain critical edges.
     SILValue Cond = getLocalValue(
         Builder.maybeGetFunction(), ListOfValues[0],
         getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
 
-    unsigned NumTrueArgs = ListOfValues[3];
-    unsigned StartOfTrueArg = 4;
-    unsigned StartOfFalseArg = StartOfTrueArg + 3*NumTrueArgs;
-    SmallVector<SILValue, 4> TrueArgs;
-    for (unsigned I = StartOfTrueArg, E = StartOfFalseArg; I < E; I += 3)
-      TrueArgs.push_back(
-          getLocalValue(Builder.maybeGetFunction(), ListOfValues[I + 2],
-                        getSILType(MF->getType(ListOfValues[I]),
-                                   (SILValueCategory)ListOfValues[I + 1], Fn)));
-
-    SmallVector<SILValue, 4> FalseArgs;
-    for (unsigned I = StartOfFalseArg, E = ListOfValues.size(); I < E; I += 3)
-      FalseArgs.push_back(
-          getLocalValue(Builder.maybeGetFunction(), ListOfValues[I + 2],
-                        getSILType(MF->getType(ListOfValues[I]),
-                                   (SILValueCategory)ListOfValues[I + 1], Fn)));
+    assert(ListOfValues[3] == 0 && "cond_br must not have branch arguments");
 
     ResultInst = Builder.createCondBranch(
-        Loc, Cond, getBBForReference(Fn, ListOfValues[1]), TrueArgs,
-        getBBForReference(Fn, ListOfValues[2]), FalseArgs);
+        Loc, Cond, getBBForReference(Fn, ListOfValues[1]),
+        getBBForReference(Fn, ListOfValues[2]));
     break;
   }
   case SILInstructionKind::AwaitAsyncContinuationInst: {

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1655,27 +1655,15 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     break;
   }
   case SILInstructionKind::CondBranchInst: {
-    // Format: condition, true basic block ID, a list of arguments, false basic
-    // block ID, a list of arguments. Use SILOneTypeValuesLayout: the type is
-    // for condition, the list has value for condition, true basic block ID,
-    // false basic block ID, number of true arguments, and a list of true|false
-    // arguments.
+    // Format: condition, true basic block ID, false basic block ID, and a
+    // (now always zero) count of true arguments. A cond_br never passes branch
+    // arguments because SIL does not contain critical edges.
     const CondBranchInst *CBI = cast<CondBranchInst>(&SI);
     SmallVector<ValueID, 4> ListOfValues;
     ListOfValues.push_back(addValueRef(CBI->getCondition()));
     ListOfValues.push_back(BasicBlockMap[CBI->getTrueBB()]);
     ListOfValues.push_back(BasicBlockMap[CBI->getFalseBB()]);
-    ListOfValues.push_back(CBI->getTrueArgs().size());
-    for (auto Elt : CBI->getTrueArgs()) {
-      ListOfValues.push_back(S.addTypeRef(Elt->getType().getRawASTType()));
-      ListOfValues.push_back((unsigned)Elt->getType().getCategory());
-      ListOfValues.push_back(addValueRef(Elt));
-    }
-    for (auto Elt : CBI->getFalseArgs()) {
-      ListOfValues.push_back(S.addTypeRef(Elt->getType().getRawASTType()));
-      ListOfValues.push_back((unsigned)Elt->getType().getCategory());
-      ListOfValues.push_back(addValueRef(Elt));
-    }
+    ListOfValues.push_back(0);
 
     SILOneTypeValuesLayout::emitRecord(
         Out, ScratchRecord, SILAbbrCodes[SILOneTypeValuesLayout::Code],

--- a/test/Concurrency/silisolationinfo_inference.sil
+++ b/test/Concurrency/silisolationinfo_inference.sil
@@ -579,7 +579,7 @@ bb4:
   br bb5
 
 bb5:
-  cond_br undef, bb4, bb6
+  cond_br undef, bb8, bb6
 
 bb6:
   br bb7
@@ -590,6 +590,9 @@ bb7:
   dealloc_stack %0 : $*NonSendableKlass
   %9999 = tuple ()
   return %9999 : $()
+
+bb8:
+  br bb4
 }
 
 // CHECK: begin running test 1 of 1 on temp_alloc_stack_different_block_larger_cfg_2: sil_isolation_info_inference with: @trace[0]
@@ -621,7 +624,7 @@ bb4:
 bb5:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f(%0) : $@convention(thin) @async () -> @out NonSendableKlass
   destroy_addr %0 : $*NonSendableKlass
-  cond_br undef, bb4, bb6
+  cond_br undef, bb8, bb6
 
 bb6:
   br bb7
@@ -630,6 +633,9 @@ bb7:
   dealloc_stack %0 : $*NonSendableKlass
   %9999 = tuple ()
   return %9999 : $()
+
+bb8:
+  br bb4
 }
 
 // CHECK: begin running test 1 of 1 on temp_alloc_stack_different_block_larger_cfg_3: sil_isolation_info_inference with: @trace[0]
@@ -661,7 +667,7 @@ bb4:
 bb5:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f(%0) : $@convention(thin) @async () -> @out NonSendableKlass
   destroy_addr %0 : $*NonSendableKlass
-  cond_br undef, bb4, bb6
+  cond_br undef, bb8, bb6
 
 bb6:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f(%0) : $@convention(thin) @async () -> @out NonSendableKlass
@@ -672,6 +678,9 @@ bb7:
   dealloc_stack %0 : $*NonSendableKlass
   %9999 = tuple ()
   return %9999 : $()
+
+bb8:
+  br bb4
 }
 
 // CHECK: begin running test 1 of 1 on temp_alloc_stack_different_block_larger_cfg_4: sil_isolation_info_inference with: @trace[0]
@@ -706,7 +715,7 @@ bb4:
 bb5:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f(%0) : $@convention(thin) @async () -> @out NonSendableKlass
   destroy_addr %0 : $*NonSendableKlass
-  cond_br undef, bb4, bb6
+  cond_br undef, bb8, bb6
 
 bb6:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f(%0) : $@convention(thin) @async () -> @out NonSendableKlass
@@ -717,6 +726,9 @@ bb7:
   dealloc_stack %0 : $*NonSendableKlass
   %9999 = tuple ()
   return %9999 : $()
+
+bb8:
+  br bb4
 }
 
 // CHECK: begin running test 1 of 1 on temp_alloc_stack_different_block_larger_cfg_5: sil_isolation_info_inference with: @trace[0]

--- a/test/IRGen/pack_metadata_marker_inserter.sil
+++ b/test/IRGen/pack_metadata_marker_inserter.sil
@@ -223,7 +223,10 @@ sil @split_critical_edge_in_modified_function : $<each T>() -> () {
 entry:
   %take = function_ref @takeTypePack : $@convention(thin) <each T>() -> ()
   apply %take<Pack{repeat each T}>() : $@convention(thin) <each T>() -> ()
-  cond_br undef, left, exit
+  cond_br undef, left, right
+
+right:
+  br exit
 
 left:
   br exit
@@ -235,17 +238,37 @@ exit:
 
 // Functions which don't need markers don't have critical edges split.
 // CHECK-SIL-LABEL: sil @dont_split_critical_edge_in_modified_function {{.*}} {
-// CHECK-SIL:         cond_br undef, [[LOOP:bb[0-9]+]], [[EXIT:bb[0-9]+]]
+// CHECK-SIL:         cond_br undef, [[PREHEADER:bb[0-9]+]], [[EXIT1:bb[0-9]+]]
+// CHECK-SIL:       [[PREHEADER]]:
+// CHECK-SIL:         br [[LOOP:bb[0-9]+]]
 // CHECK-SIL:       [[LOOP]]:
-// CHECK-SIL:         cond_br undef, [[LOOP]], [[EXIT]]
+// CHECK-SIL:         cond_br undef, [[BACKEDGE:bb[0-9]+]], [[EXIT2:bb[0-9]+]]
+// CHECK-SIL:       [[BACKEDGE]]:
+// CHECK-SIL:         br [[LOOP]]
+// CHECK-SIL:       [[EXIT1]]:
+// CHECK-SIL:         br [[EXIT:bb[0-9]+]]
+// CHECK-SIL:       [[EXIT2]]:
+// CHECK-SIL:         br [[EXIT]]
 // CHECK-SIL:       [[EXIT]]:
 // CHECK-SIL-LABEL: } // end sil function 'dont_split_critical_edge_in_modified_function'
 sil @dont_split_critical_edge_in_modified_function : $<each T>() -> () {
 entry:
-  cond_br undef, loop, exit
+  cond_br undef, preheader, exit1
+
+preheader:
+  br loop
 
 loop:
-  cond_br undef, loop, exit
+  cond_br undef, backedge, exit2
+
+backedge:
+  br loop
+
+exit1:
+  br exit
+
+exit2:
+  br exit
 
 exit:
   %retval = tuple ()
@@ -301,7 +324,7 @@ right:
 sil @frontier_has_self_loop : $<each T>() -> () {
   %take = function_ref @takeTypePack : $@convention(thin) <each T>() -> ()
   apply %take<Pack{repeat each T}>() : $@convention(thin) <each T>() -> ()
-  cond_br undef, loop, right
+  cond_br undef, enter, right
 
 enter:
   br loop

--- a/test/IRGen/partial_apply.sil
+++ b/test/IRGen/partial_apply.sil
@@ -131,7 +131,7 @@ sil @partial_apply_twenty_classes_on_stack_non_nested : $@convention(thin) (@own
 entry(%a : $SwiftClass, %b: $SwiftClass, %c: $SwiftClass, %d: $SwiftClass, %e: $SwiftClass, %f: $SwiftClass, %g: $SwiftClass, %h: $SwiftClass, %i: $SwiftClass, %j: $SwiftClass, %k: $SwiftClass, %l: $SwiftClass, %m: $SwiftClass, %n: $SwiftClass, %o: $SwiftClass, %p: $SwiftClass, %q: $SwiftClass, %r: $SwiftClass, %s: $SwiftClass, %t: $SwiftClass, %cond: $Builtin.Int1):
   // We don't limit the size in the entry block, so we also need control flow
   // to trigger the malloc case.
-  cond_br %cond, bb1, bb2
+  cond_br %cond, bb1, bb2trampoline
 
 bb1:
   %function = function_ref @partially_applyable_to_twenty_classes : $@convention(thin) (@guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass) -> ()
@@ -164,6 +164,9 @@ bb2:
   strong_release %t : $SwiftClass
   %ret = tuple()
   return %ret : $()
+
+bb2trampoline:
+  br bb2
 }
 
 //

--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -1618,8 +1618,8 @@ sil @value_names : $@convention(thin) (Builtin.Int1) -> () {
 entry(%param : $Builtin.Int1):
 // CHECK-NEXT: %1 = tuple ()
   %v_o_i_d = tuple ()
-// CHECK-NEXT: cond_br %0, bb1, bb2
-  cond_br %param, then, else
+// CHECK-NEXT: cond_br %0, bb1, bb3
+  cond_br %param, then, elseTrampoline
 
 // CHECK: bb1:
 then:
@@ -1634,6 +1634,11 @@ else:
   %3void = tuple ()
 // CHECK-NEXT: return %5 : $()
   return %3void : $()
+
+// CHECK: bb3:
+elseTrampoline:
+// CHECK-NEXT: br bb2
+  br else
 }
 // CHECK: } // end sil function 'value_names'
 

--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -719,12 +719,12 @@ bb3(%6 : $Builtin.Word):
 // CHECK-LABEL: sil @test_cond_branch_basic_block_args
 sil @test_cond_branch_basic_block_args : $@convention(thin) (Int, Builtin.Int1) -> Int {
 bb0(%0 : $Int, %1 : $Builtin.Int1):
-  cond_br %1, bb1(%0 : $Int), bb2(%0 : $Int)
-// CHECK: cond_br %1, bb1(%0 : $Int), bb2(%0 : $Int)
-bb1(%3 : $Int):
-  br bb3 (%3 : $Int)
-bb2(%2 : $Int):
-  br bb3(%2 : $Int)
+  cond_br %1, bb1, bb2
+// CHECK: cond_br %1, bb1, bb2
+bb1:
+  br bb3 (%0 : $Int)
+bb2:
+  br bb3(%0 : $Int)
 bb3(%4 : $Int):
   return %4 : $Int
 }

--- a/test/SIL/Parser/undef.sil
+++ b/test/SIL/Parser/undef.sil
@@ -279,9 +279,9 @@ bb1(%x : $()):
 
 sil @cond_br_test : $() -> () {
 bb0:
-  // CHECK: cond_br undef, bb1(undef : $()), bb2
-  cond_br undef, bb1(undef : $()), bb2
-bb1(%1 : $()):
+  // CHECK: cond_br undef, bb1, bb2
+  cond_br undef, bb1, bb2
+bb1:
   br bb3
 bb2:
   br bb3

--- a/test/SIL/Parser/undef.sil
+++ b/test/SIL/Parser/undef.sil
@@ -282,8 +282,10 @@ bb0:
   // CHECK: cond_br undef, bb1(undef : $()), bb2
   cond_br undef, bb1(undef : $()), bb2
 bb1(%1 : $()):
-  br bb2
+  br bb3
 bb2:
+  br bb3
+bb3:
   return undef : $()
 }
 

--- a/test/SIL/verify_reducible_loops.sil
+++ b/test/SIL/verify_reducible_loops.sil
@@ -15,18 +15,36 @@ import Builtin
 
 sil @irreducible_loop : $@convention(thin) (Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1):
-  cond_br %0, bb1, bb2
+  cond_br %0, bb9, bb4
 
 // bb1 and bb2 form an irreducible loop: both are entry points
 // from outside and both branch to each other.
 bb1:
-  cond_br %0, bb2, bb3
+  cond_br %0, bb7, bb8
 
 bb2:
-  cond_br %0, bb1, bb3
+  cond_br %0, bb5, bb6
 
 bb3:
   %r = tuple ()
   return %r : $()
+
+bb4:
+  br bb2
+
+bb5:
+  br bb1
+
+bb6:
+  br bb3
+
+bb7:
+  br bb2
+
+bb8:
+  br bb3
+
+bb9:
+  br bb1
 }
 

--- a/test/SILOptimizer/abcopts.sil
+++ b/test/SILOptimizer/abcopts.sil
@@ -467,13 +467,13 @@ bb0(%0 : $Array<Int>):
   %t1 = apply %f1(%0) : $@convention(method) (@owned Array<Int>) -> Int32
   %c1 = struct_extract %t1 : $Int32, #Int32._value
   %t2 = builtin "cmp_eq_Int32"(%z0 : $Builtin.Int32, %c1 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %t2, bb5, bb1
+  cond_br %t2, bb6, bb1
 
 bb1:
   br bb2(%z0 : $Builtin.Int32)
 
 bb2(%i0 : $Builtin.Int32):
-  cond_br undef, bb3, bb4
+  cond_br undef, bb3, bb7
 
 bb3:
   %f2 = function_ref @checkbounds2 : $@convention(method) (Int32, Bool, @owned Array<Int>) -> _DependenceToken
@@ -498,11 +498,23 @@ bb4:
   %af4 = builtin "cmp_eq_Int32"(%t7 : $Builtin.Int32, %z0 : $Builtin.Int32) : $Builtin.Int1
   cond_fail %af4 : $Builtin.Int1
   %8 = builtin "cmp_eq_Int32"(%t7 : $Builtin.Int32, %c1 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %8, bb5, bb2(%t7 : $Builtin.Int32)
+  cond_br %8, bb8, bb9(%t7 : $Builtin.Int32)
 
 bb5:
   %r1 = tuple ()
   return %r1 : $()
+
+bb6:
+  br bb5
+
+bb7:
+  br bb4
+
+bb8:
+  br bb5
+
+bb9(%i1 : $Builtin.Int32):
+  br bb2(%i1 : $Builtin.Int32)
 }
 
 
@@ -571,8 +583,8 @@ bb3:
 // HOIST:    bb0{{.*}}:
 // HOIST:      [[CB:%[0-9]+]] = function_ref @checkbounds
 // HOIST:      apply [[CB]]
-// HOIST:      br bb1
-// HOIST:    bb3{{.*}}:
+// HOIST:      cond_br {{.*}}, bb2, bb3
+// HOIST:    bb2{{.*}}:
 // HOIST-NOT:  apply
 // HOIST:    return
 
@@ -600,11 +612,14 @@ bb1(%4 : $Builtin.Int32):
   %22 = tuple_extract %20 : $(Builtin.Int32, Builtin.Int1), 1
   cond_fail %22 : $Builtin.Int1
   %8 = builtin "cmp_eq_Int32"(%4 : $Builtin.Int32, %1 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %8, bb2, bb1(%21 : $Builtin.Int32)
+  cond_br %8, bb2, bb3(%21 : $Builtin.Int32)
 
 bb2:
   %23 = struct $Int32 (%4 : $Builtin.Int32)
   return %23 : $Int32
+
+bb3(%24 : $Builtin.Int32):
+  br bb1(%24 : $Builtin.Int32)
 }
 
 // HOIST-LABEL: sil @hoist_rangechecked :
@@ -799,13 +814,13 @@ bb0(%0 : $Array<Int>):
   %t1 = apply %f1(%0) : $@convention(method) (@owned Array<Int>) -> Int32
   %c1 = struct_extract %t1 : $Int32, #Int32._value
   %t2 = builtin "cmp_eq_Int32"(%z0 : $Builtin.Int32, %c1 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %t2, bb5, bb1
+  cond_br %t2, bb6, bb1
 
 bb1:
   br bb2(%z0 : $Builtin.Int32)
 
 bb2(%i0 : $Builtin.Int32):
-  cond_br undef, bb3, bb4
+  cond_br undef, bb3, bb7
 
 bb3:
   %f2 = function_ref @checkbounds2 : $@convention(method) (Int32, Bool, @owned Array<Int>) -> _DependenceToken
@@ -824,11 +839,23 @@ bb4:
   %t6 = builtin "sadd_with_overflow_Int32"(%i0 : $Builtin.Int32, %i2 : $Builtin.Int32, %t5 : $Builtin.Int1) : $(Builtin.Int32, Builtin.Int1)
   %t7 = tuple_extract %t6 : $(Builtin.Int32, Builtin.Int1), 0
   %8 = builtin "cmp_eq_Int32"(%t7 : $Builtin.Int32, %c1 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %8, bb5, bb2(%t7 : $Builtin.Int32)
+  cond_br %8, bb8, bb9(%t7 : $Builtin.Int32)
 
 bb5:
   %r1 = tuple ()
   return %r1 : $()
+
+bb6:
+  br bb5
+
+bb7:
+  br bb4
+
+bb8:
+  br bb5
+
+bb9(%i3 : $Builtin.Int32):
+  br bb2(%i3 : $Builtin.Int32)
 }
 
 // HOIST-LABEL: sil @dont_eliminate_zero_to_count_for_slices
@@ -1158,16 +1185,16 @@ bb3:
 }
 
 // HOIST-LABEL: sil @hoist_but_dont_remove_bc_after_loop
-// HOIST: {{^bb2}}
+// HOIST: {{^bb1}}
 // HOIST:   [[CB:%.*]] = function_ref @checkbounds
 // HOIST:   apply [[CB]]
 // HOIST:   apply [[CB]]
+// HOIST: {{^bb2}}
+// HOIST:   cond_br {{.*}}, bb3, bb6
 // HOIST: {{^bb3}}
-// HOIST:   cond_br {{.*}}, bb5, bb4
-// HOIST: {{^bb4}}
-// HOIST:   br bb3
-// HOIST: {{^bb5}}
 // HOIST:   apply [[CB]]
+// HOIST: {{^bb6}}
+// HOIST:   br bb2
 
 sil @hoist_but_dont_remove_bc_after_loop : $@convention(thin) (Int32, @inout ArrayInt) -> Int32 {
 bb0(%0 : $Int32, %1 : $*ArrayInt):
@@ -1176,7 +1203,7 @@ bb0(%0 : $Int32, %1 : $*ArrayInt):
   %4 = struct_extract %0 : $Int32, #Int32._value
   %5 = integer_literal $Builtin.Int32, 0
   %6 = builtin "cmp_eq_Int32"(%5 : $Builtin.Int32, %4 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %6, bb4(%5 : $Builtin.Int32), bb1
+  cond_br %6, bb5(%5 : $Builtin.Int32), bb1
 
 bb1:
   br bb2(%5 : $Builtin.Int32)
@@ -1196,7 +1223,7 @@ bb2(%10 : $Builtin.Int32):
   %22 = tuple_extract %20 : $(Builtin.Int32, Builtin.Int1), 1
   cond_fail %22 : $Builtin.Int1
   %24 = builtin "cmp_eq_Int32"(%21 : $Builtin.Int32, %4 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %24, bb3(%21 : $Builtin.Int32), bb2(%21 : $Builtin.Int32)
+  cond_br %24, bb3(%21 : $Builtin.Int32), bb6(%21 : $Builtin.Int32)
 
 bb3(%28 : $Builtin.Int32):
   %t1 = function_ref @take_array : $@convention(thin) (@inout ArrayInt) -> ()
@@ -1208,6 +1235,12 @@ bb3(%28 : $Builtin.Int32):
 bb4(%31 : $Builtin.Int32):
   %32 = struct $Int32 (%31 : $Builtin.Int32)
   return %32 : $Int32
+
+bb5(%33 : $Builtin.Int32):
+  br bb4(%33 : $Builtin.Int32)
+
+bb6(%34 : $Builtin.Int32):
+  br bb2(%34 : $Builtin.Int32)
 }
 
 // SIL pattern for :
@@ -1454,21 +1487,23 @@ sil [_semantics "array.check_subscript"] @checkbounds3 : $@convention(method) (I
 
 // CHECK-LABEL: sil @rangeCheck
 // CHECK: bb0
-// CHECK:   cond_br {{.*}}, bb1, bb2
+// CHECK:   cond_br {{.*}}, bb4, bb1
 // CHECK: bb1
+// CHECK: [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
 // CHECK:   br bb3
 // CHECK: bb2
-// CHECK: [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
-// CHECK:   br bb4
-// CHECK: bb3
 // CHECK:   return
-// CHECK: bb4([[IV:%.*]] : $Builtin.Int64):
+// CHECK: bb3([[IV:%.*]] : $Builtin.Int64):
 // CHECK:   builtin "xor_Int1"([[TRUE]]
 // CHECK:   builtin "xor_Int1"([[TRUE]]
 // CHECK:   cond_fail
-// CHECK:   cond_br {{.*}}, bb6, bb5
+// CHECK:   cond_br {{.*}}, bb5, bb6
+// CHECK: bb4:
+// CHECK:   br bb2
 // CHECK: bb5:
-// CHECK:   br bb4
+// CHECK:   br bb2
+// CHECK: bb6:
+// CHECK:   br bb3
 // CHECK: }
 sil @rangeCheck : $@convention(thin) (Builtin.Int64) -> () {
 bb0(%0 : $Builtin.Int64):
@@ -1478,7 +1513,7 @@ bb0(%0 : $Builtin.Int64):
   %7 = builtin "xor_Int1"(%5 : $Builtin.Int1, %6 : $Builtin.Int1) : $Builtin.Int1
   cond_fail %7 : $Builtin.Int1
   %9 = builtin "cmp_eq_Int64"(%3 : $Builtin.Int64, %0 : $Builtin.Int64) : $Builtin.Int1
-  cond_br %9, bb2, bb1
+  cond_br %9, bb5, bb1
 
 bb1:
   %11 = integer_literal $Builtin.Int64, 1
@@ -1500,28 +1535,39 @@ bb3(%15 : $Builtin.Int64):
   %24 = tuple_extract %22 : $(Builtin.Int64, Builtin.Int1), 1
   cond_fail %24 : $Builtin.Int1
   %28 = builtin "cmp_eq_Int64"(%23 : $Builtin.Int64, %0 : $Builtin.Int64) : $Builtin.Int1
-  cond_br %28, bb2, bb3(%23 : $Builtin.Int64)
+  cond_br %28, bb6, bb7(%23 : $Builtin.Int64)
+
+bb5:
+  br bb2
+
+bb6:
+  br bb2
+
+bb7(%29 : $Builtin.Int64):
+  br bb3(%29 : $Builtin.Int64)
 }
 
 // CHECK-LABEL: sil @rangeCheck2
 // CHECK: bb0
-// CHECK:   cond_br {{.*}}, bb1, bb2
+// CHECK:   cond_br {{.*}}, bb4, bb1
 // CHECK: bb1
-// CHECK:   br bb3
-// CHECK: bb2
 // CHECK: [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
 // CHECK: [[FALSE:%.*]] = integer_literal $Builtin.Int1, 0
-// CHECK:   br bb4
-// CHECK: bb3
+// CHECK:   br bb3
+// CHECK: bb2
 // CHECK:   return
-// CHECK: bb4([[IV:%.*]] : $Builtin.Int64):
+// CHECK: bb3([[IV:%.*]] : $Builtin.Int64):
 // CHECK:   builtin "xor_Int1"([[TRUE]]
 // CHECK:   builtin "xor_Int1"([[TRUE]]
 // CHECK:   builtin "or_Int1"([[FALSE]]
 // CHECK:   cond_fail
-// CHECK:   cond_br {{.*}}, bb6, bb5
+// CHECK:   cond_br {{.*}}, bb5, bb6
+// CHECK: bb4:
+// CHECK:   br bb2
 // CHECK: bb5:
-// CHECK:   br bb4
+// CHECK:   br bb2
+// CHECK: bb6:
+// CHECK:   br bb3
 // CHECK: }
 sil @rangeCheck2 : $@convention(thin) (Builtin.Int64) -> () {
 bb0(%0 : $Builtin.Int64):
@@ -1531,7 +1577,7 @@ bb0(%0 : $Builtin.Int64):
   %7 = builtin "xor_Int1"(%5 : $Builtin.Int1, %6 : $Builtin.Int1) : $Builtin.Int1
   cond_fail %7 : $Builtin.Int1
   %9 = builtin "cmp_eq_Int64"(%3 : $Builtin.Int64, %0 : $Builtin.Int64) : $Builtin.Int1
-  cond_br %9, bb2, bb1
+  cond_br %9, bb5, bb1
 
 bb1:
   %11 = integer_literal $Builtin.Int64, 1
@@ -1554,7 +1600,16 @@ bb3(%15 : $Builtin.Int64):
   %24 = tuple_extract %22 : $(Builtin.Int64, Builtin.Int1), 1
   cond_fail %24 : $Builtin.Int1
   %28 = builtin "cmp_eq_Int64"(%23 : $Builtin.Int64, %0 : $Builtin.Int64) : $Builtin.Int1
-  cond_br %28, bb2, bb3(%23 : $Builtin.Int64)
+  cond_br %28, bb6, bb7(%23 : $Builtin.Int64)
+
+bb5:
+  br bb2
+
+bb6:
+  br bb2
+
+bb7(%29 : $Builtin.Int64):
+  br bb3(%29 : $Builtin.Int64)
 }
 
 sil @unknown : $@convention(thin) () -> Builtin.Int1
@@ -1562,7 +1617,7 @@ sil @unknown : $@convention(thin) () -> Builtin.Int1
 // RANGECHECK-LABEL: sil @rangeCheck_early_exit
 // RANGECHECK: bb0
 // RANGECHECK:   cond_fail
-// RANGECHECK:   cond_br {{.*}}, bb2, bb1
+// RANGECHECK:   cond_br {{.*}}, bb5, bb1
 // RANGECHECK: bb1:
 // RANGECHECK-NOT:  cond_fail
 // RANGECHECK:   br bb3
@@ -1570,11 +1625,19 @@ sil @unknown : $@convention(thin) () -> Builtin.Int1
 // RANGECHECK:  return
 // RANGECHECK: bb3({{.*}}):
 // RANGECHECK:  apply
-// RANGECHECK:  cond_br {{.*}}, bb4, bb2
+// RANGECHECK:  cond_br {{.*}}, bb4, bb6
 // RANGECHECK: bb4:
 // RANGECHECK:   cond_fail
 // RANGECHECK:   cond_fail
-// RANGECHECK:   cond_br {{.*}}, bb2, bb3
+// RANGECHECK:   cond_br {{.*}}, bb7, bb8
+// RANGECHECK: bb5:
+// RANGECHECK:   br bb2
+// RANGECHECK: bb6:
+// RANGECHECK:   br bb2
+// RANGECHECK: bb7:
+// RANGECHECK:   br bb2
+// RANGECHECK: bb8({{.*}}):
+// RANGECHECK:   br bb3
 // RANGECHECK: }
 sil @rangeCheck_early_exit : $@convention(thin) (Builtin.Int64) -> () {
 bb0(%0 : $Builtin.Int64):
@@ -1584,7 +1647,7 @@ bb0(%0 : $Builtin.Int64):
   %7 = builtin "xor_Int1"(%5 : $Builtin.Int1, %6 : $Builtin.Int1) : $Builtin.Int1
   cond_fail %7 : $Builtin.Int1
   %9 = builtin "cmp_eq_Int64"(%3 : $Builtin.Int64, %0 : $Builtin.Int64) : $Builtin.Int1
-  cond_br %9, bb2, bb1
+  cond_br %9, bb5, bb1
 
 bb1:
   %11 = integer_literal $Builtin.Int64, 1
@@ -1597,7 +1660,7 @@ bb2:
 bb3(%15 : $Builtin.Int64):
   %1 = function_ref @unknown : $@convention(thin) () -> Builtin.Int1
   %2 = apply %1() : $@convention(thin) () -> Builtin.Int1
-  cond_br %2, bb4, bb2
+  cond_br %2, bb4, bb6
 
 bb4:
   %16 = builtin "cmp_sle_Int64"(%3 : $Builtin.Int64, %15 : $Builtin.Int64) : $Builtin.Int1
@@ -1611,7 +1674,19 @@ bb4:
   %24 = tuple_extract %22 : $(Builtin.Int64, Builtin.Int1), 1
   cond_fail %24 : $Builtin.Int1
   %28 = builtin "cmp_eq_Int64"(%23 : $Builtin.Int64, %0 : $Builtin.Int64) : $Builtin.Int1
-  cond_br %28, bb2, bb3(%23 : $Builtin.Int64)
+  cond_br %28, bb7, bb8(%23 : $Builtin.Int64)
+
+bb5:
+  br bb2
+
+bb6:
+  br bb2
+
+bb7:
+  br bb2
+
+bb8(%29 : $Builtin.Int64):
+  br bb3(%29 : $Builtin.Int64)
 }
 
 // Don't assert when we have an isNativeTypeChecked parameter that is not a
@@ -1634,7 +1709,7 @@ bb3(%10 : $Bool):
   %11 = struct_extract %0 : $Int32, #Int32._value
   %12 = integer_literal $Builtin.Int32, 0
   %13 = builtin "cmp_eq_Int32"(%12 : $Builtin.Int32, %11 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %13, bb6(%12 : $Builtin.Int32), bb4
+  cond_br %13, bb7(%12 : $Builtin.Int32), bb4
 
 bb4:
   br bb5(%12 : $Builtin.Int32)
@@ -1654,11 +1729,20 @@ bb5(%16 : $Builtin.Int32):
   %28 = tuple_extract %26 : $(Builtin.Int32, Builtin.Int1), 1
   cond_fail %28 : $Builtin.Int1
   %30 = builtin "cmp_eq_Int32"(%27 : $Builtin.Int32, %11 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %30, bb6(%27 : $Builtin.Int32), bb5(%27 : $Builtin.Int32)
+  cond_br %30, bb8(%27 : $Builtin.Int32), bb9(%27 : $Builtin.Int32)
 
 bb6(%32 : $Builtin.Int32):
   %33 = struct $Int32 (%32 : $Builtin.Int32)
   return %33 : $Int32
+
+bb7(%34 : $Builtin.Int32):
+  br bb6(%34 : $Builtin.Int32)
+
+bb8(%35 : $Builtin.Int32):
+  br bb6(%35 : $Builtin.Int32)
+
+bb9(%36 : $Builtin.Int32):
+  br bb5(%36 : $Builtin.Int32)
 }
 
 struct Wrapper {

--- a/test/SILOptimizer/abcopts.sil
+++ b/test/SILOptimizer/abcopts.sil
@@ -398,18 +398,9 @@ bb3:
 // HOIST: [[L2:%[0-9]+]] = load %1
 // HOIST: retain_value [[L2]]
 // HOIST: apply [[CB1]]([[SUB3]], {{.*}}[[L2]])
-// HOIST: br bb3
-
-// HOIST: bb3
 // HOIST-NOT: cond_fail
 // HOIST-NOT: @checkbounds
-// HOIST: builtin
-// HOIST: builtin
-// HOIST-NOT: builtin
-// HOIST: cond_br {{.*}}, {{.*}}, bb4
-// HOIST: bb4
-// HOIST:  br bb3
-
+// HOIST: cond_br
 // HOIST: return
 
 sil @hoist : $@convention(thin) (Int32, @inout ArrayInt) -> Int32 {
@@ -498,7 +489,10 @@ bb4:
   %af4 = builtin "cmp_eq_Int32"(%t7 : $Builtin.Int32, %z0 : $Builtin.Int32) : $Builtin.Int1
   cond_fail %af4 : $Builtin.Int1
   %8 = builtin "cmp_eq_Int32"(%t7 : $Builtin.Int32, %c1 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %8, bb8, bb9(%t7 : $Builtin.Int32)
+  cond_br %8, bb8, bb9_split
+
+bb9_split:
+  br bb9(%t7 : $Builtin.Int32)
 
 bb5:
   %r1 = tuple ()
@@ -528,21 +522,11 @@ bb9(%i1 : $Builtin.Int32):
 // HOIST:  retain_value
 // HOIST:  [[CB:%[0-9]+]] = function_ref @checkbounds
 // HOIST:  apply [[CB]]
-// HOIST:  br bb3
 
-// Loop.
-// HOIST:  bb3{{.*}}:
+// Loop body has no bounds checks after hoisting.
 // HOIST-NOT: cond_fail
 // HOIST-NOT: @checkbounds
-// HOIST: builtin
-// HOIST: builtin
-// HOIST-NOT: builtin
-// HOIST:  cond_br {{.*}}, bb5{{.*}}, bb4{{.*}}
-// HOIST: bb4:
-// HOIST:   br bb3
-// HOIST: bb5:
-// HOIST:   br bb6
-// HOIST: bb6{{.*}}:
+// HOIST:  cond_br
 // HOIST:   return
 
 sil @hoistinvariant : $@convention(thin) (Int32, @inout ArrayInt) -> Int32 {
@@ -583,7 +567,7 @@ bb3:
 // HOIST:    bb0{{.*}}:
 // HOIST:      [[CB:%[0-9]+]] = function_ref @checkbounds
 // HOIST:      apply [[CB]]
-// HOIST:      cond_br {{.*}}, bb2, bb3
+// HOIST:      cond_br {{.*}}, bb2, {{bb[0-9]+}}
 // HOIST:    bb2{{.*}}:
 // HOIST-NOT:  apply
 // HOIST:    return
@@ -612,7 +596,10 @@ bb1(%4 : $Builtin.Int32):
   %22 = tuple_extract %20 : $(Builtin.Int32, Builtin.Int1), 1
   cond_fail %22 : $Builtin.Int1
   %8 = builtin "cmp_eq_Int32"(%4 : $Builtin.Int32, %1 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %8, bb2, bb3(%21 : $Builtin.Int32)
+  cond_br %8, bb2, bb3_split
+
+bb3_split:
+  br bb3(%21 : $Builtin.Int32)
 
 bb2:
   %23 = struct $Int32 (%4 : $Builtin.Int32)
@@ -628,16 +615,10 @@ bb3(%24 : $Builtin.Int32):
 // HOIST: bb1:
 // HOIST:   [[CB:%[0-9]+]] = function_ref @checkbounds
 // HOIST:    apply [[CB]]
-// HOIST:   br bb3{{.*}}
-// HOIST: bb3{{.*}}:
+// HOIST: br bb{{[0-9]+}}
 // HOIST-NOT: function_ref @checkbounds
-// HOIST-NOT:    apply [[CB]]
-// HOIST:   cond_br {{.*}}, bb5, bb4
-// HOIST: bb4
-// HOIST:   br bb3
-// HOIST: bb5
-// HOIST:   br bb6
-// HOIST: bb6{{.*}}:
+// HOIST-NOT: apply [[CB]]
+// HOIST:   cond_br
 // HOIST:  return
 
 sil @hoist_rangechecked : $@convention(thin) (Int32, @inout ArrayInt) -> Int32 {
@@ -688,16 +669,10 @@ bb3:
 // HOIST:       bb1:
 // HOIST:         [[CB:%[0-9]+]] = function_ref @checkbounds
 // HOIST:          apply [[CB]]
-// HOIST:         br bb3{{.*}}
-// HOIST:       bb3{{.*}}:
-// HOIST-NOT:     function_ref @checkbounds
-// HOIST-NOT:     apply [[CB]]
-// HOIST:         cond_br {{.*}}, bb5, bb4
-// HOIST:       bb4
-// HOIST:         br bb3
-// HOIST:       bb5
-// HOIST:         br bb6
-// HOIST:       bb6{{.*}}:
+// HOIST: br bb{{[0-9]+}}
+// HOIST-NOT: function_ref @checkbounds
+// HOIST-NOT: apply [[CB]]
+// HOIST:         cond_br
 // HOIST:       } // end sil function 'hoist_rangechecked_sgt'
 
 sil @hoist_rangechecked_sgt : $@convention(thin) (Int32, @inout ArrayInt) -> Int32 {
@@ -746,16 +721,10 @@ bb3:
 // HOIST: bb1:
 // HOIST:   [[CB:%[0-9]+]] = function_ref @checkbounds
 // HOIST:    apply [[CB]]
-// HOIST:   br bb3{{.*}}
-// HOIST: bb3{{.*}}:
+// HOIST: br bb{{[0-9]+}}
 // HOIST-NOT: function_ref @checkbounds
-// HOIST-NOT:    apply [[CB]]
-// HOIST:   cond_br {{.*}}, bb5, bb4
-// HOIST: bb4
-// HOIST:   br bb3
-// HOIST: bb5
-// HOIST:   br bb6
-// HOIST: bb6{{.*}}:
+// HOIST-NOT: apply [[CB]]
+// HOIST:   cond_br
 // HOIST:  return
 
 sil @hoist_rangechecked_ref_tail_addr : $@convention(thin) (Int32, @inout ArrayInt) -> Int32 {
@@ -839,7 +808,10 @@ bb4:
   %t6 = builtin "sadd_with_overflow_Int32"(%i0 : $Builtin.Int32, %i2 : $Builtin.Int32, %t5 : $Builtin.Int1) : $(Builtin.Int32, Builtin.Int1)
   %t7 = tuple_extract %t6 : $(Builtin.Int32, Builtin.Int1), 0
   %8 = builtin "cmp_eq_Int32"(%t7 : $Builtin.Int32, %c1 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %8, bb8, bb9(%t7 : $Builtin.Int32)
+  cond_br %8, bb8, bb9_split
+
+bb9_split:
+  br bb9(%t7 : $Builtin.Int32)
 
 bb5:
   %r1 = tuple ()
@@ -915,16 +887,10 @@ bb2:
 // HOIST: bb1:
 // HOIST:   [[CB:%[0-9]+]] = function_ref @checkbounds
 // HOIST:    apply [[CB]]
-// HOIST:   br bb3{{.*}}
-// HOIST: bb3{{.*}}:
+// HOIST: br bb{{[0-9]+}}
 // HOIST-NOT: function_ref @checkbounds
-// HOIST-NOT:    apply [[CB]]
-// HOIST:   cond_br {{.*}}, bb5, bb4
-// HOIST: bb4
-// HOIST:   br bb3
-// HOIST: bb5
-// HOIST:   br bb6
-// HOIST: bb6{{.*}}:
+// HOIST-NOT: apply [[CB]]
+// HOIST:   cond_br
 // HOIST:  return
 
 sil @hoist_rangechecked_addr_proj_store : $@convention(thin) (Int32, @inout ArrayInt) -> Int32 {
@@ -977,16 +943,10 @@ bb3:
 // HOIST: bb1:
 // HOIST:   [[CB:%[0-9]+]] = function_ref @checkbounds
 // HOIST:    apply [[CB]]
-// HOIST:   br bb3{{.*}}
-// HOIST: bb3{{.*}}:
+// HOIST: br bb{{[0-9]+}}
 // HOIST-NOT: function_ref @checkbounds
-// HOIST-NOT:    apply [[CB]]
-// HOIST:   cond_br {{.*}}, bb5, bb4
-// HOIST: bb4:
-// HOIST:  br bb3
-// HOIST: bb5:
-// HOIST:  br bb6
-// HOIST: bb6{{.*}}:
+// HOIST-NOT: apply [[CB]]
+// HOIST:   cond_br
 // HOIST: return
 sil @hoist_inclusive_rangechecked : $@convention(thin) (Int32, @inout ArrayInt) -> Int32 {
 bb0(%0 : $Int32, %24 : $*ArrayInt):
@@ -1036,16 +996,10 @@ bb3:
 // HOIST:       bb1:
 // HOIST:         [[CB:%[0-9]+]] = function_ref @checkbounds
 // HOIST:          apply [[CB]]
-// HOIST:         br bb3{{.*}}
-// HOIST:       bb3{{.*}}:
-// HOIST-NOT:     function_ref @checkbounds
-// HOIST-NOT:     apply [[CB]]
-// HOIST:         cond_br {{.*}}, bb5, bb4
-// HOIST:       bb4:
-// HOIST:        br bb3
-// HOIST:       bb5:
-// HOIST:        br bb6
-// HOIST:       bb6{{.*}}:
+// HOIST: br bb{{[0-9]+}}
+// HOIST-NOT: function_ref @checkbounds
+// HOIST-NOT: apply [[CB]]
+// HOIST:         cond_br
 // HOIST:       } // end sil function 'hoist_inclusive_rangechecked_sgt'
 sil @hoist_inclusive_rangechecked_sgt : $@convention(thin) (Int32, @inout ArrayInt) -> Int32 {
 bb0(%0 : $Int32, %24 : $*ArrayInt):
@@ -1090,19 +1044,10 @@ bb3:
 // HOIST-LABEL: dont_hoist_variant_array
 // HOIST: bb0
 // HOIST:  cond_br {{.*}}, bb2, bb1
-// HOIST: bb1:
-// HOIST-NEXT:  br bb3
-// HOIST: bb2:
-// HOIST-NEXT:  br bb6
-// HOIST: bb3{{.*}}:
+// The array is loop-variant, so the bounds check is NOT hoisted; it stays in the loop.
 // HOIST:   [[CB:%[0-9]+]] = function_ref @checkbounds
 // HOIST:  apply [[CB]]
-// HOIST:  cond_br {{.*}}, bb5, bb4
-// HOIST: bb4:
-// HOIST:  br bb3
-// HOIST: bb5:
-// HOIST:  br bb6
-// HOIST: bb6{{.*}}:
+// HOIST:  cond_br
 // HOIST: return
 
 sil @dont_hoist_variant_array: $@convention(thin) (Int32, @inout ArrayInt) -> Int32 {
@@ -1143,12 +1088,10 @@ bb3:
 }
 
 // HOIST-LABEL: sil @dont_hoist_due_to_unknown_release
-// HOIST: bb3
+// The unknown release prevents hoisting; the bounds check stays in the loop.
 // HOIST:   [[CB:%.*]] = function_ref @checkbounds
 // HOIST:   apply [[CB]]
-// HOIST:   cond_br {{.*}}, bb5, bb4
-// HOIST: bb4:
-// HOIST:  br bb3
+// HOIST:   cond_br
 sil @dont_hoist_due_to_unknown_release : $@convention(thin) (Int32, @inout ArrayInt, Builtin.NativeObject) -> Int32 {
 bb0(%0 : $Int32, %24 : $*ArrayInt, %100: $Builtin.NativeObject):
   %105 = integer_literal $Builtin.Int1, -1
@@ -1185,16 +1128,12 @@ bb3:
 }
 
 // HOIST-LABEL: sil @hoist_but_dont_remove_bc_after_loop
-// HOIST: {{^bb1}}
+// The in-loop check is hoisted, but the bounds check after the loop is not
+// removed, so multiple checkbounds applies remain.
 // HOIST:   [[CB:%.*]] = function_ref @checkbounds
 // HOIST:   apply [[CB]]
 // HOIST:   apply [[CB]]
-// HOIST: {{^bb2}}
-// HOIST:   cond_br {{.*}}, bb3, bb6
-// HOIST: {{^bb3}}
 // HOIST:   apply [[CB]]
-// HOIST: {{^bb6}}
-// HOIST:   br bb2
 
 sil @hoist_but_dont_remove_bc_after_loop : $@convention(thin) (Int32, @inout ArrayInt) -> Int32 {
 bb0(%0 : $Int32, %1 : $*ArrayInt):
@@ -1203,7 +1142,10 @@ bb0(%0 : $Int32, %1 : $*ArrayInt):
   %4 = struct_extract %0 : $Int32, #Int32._value
   %5 = integer_literal $Builtin.Int32, 0
   %6 = builtin "cmp_eq_Int32"(%5 : $Builtin.Int32, %4 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %6, bb5(%5 : $Builtin.Int32), bb1
+  cond_br %6, bb5_split, bb1
+
+bb5_split:
+  br bb5(%5 : $Builtin.Int32)
 
 bb1:
   br bb2(%5 : $Builtin.Int32)
@@ -1223,7 +1165,13 @@ bb2(%10 : $Builtin.Int32):
   %22 = tuple_extract %20 : $(Builtin.Int32, Builtin.Int1), 1
   cond_fail %22 : $Builtin.Int1
   %24 = builtin "cmp_eq_Int32"(%21 : $Builtin.Int32, %4 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %24, bb3(%21 : $Builtin.Int32), bb6(%21 : $Builtin.Int32)
+  cond_br %24, bb3_split, bb6_split
+
+bb3_split:
+  br bb3(%21 : $Builtin.Int32)
+
+bb6_split:
+  br bb6(%21 : $Builtin.Int32)
 
 bb3(%28 : $Builtin.Int32):
   %t1 = function_ref @take_array : $@convention(thin) (@inout ArrayInt) -> ()
@@ -1487,24 +1435,23 @@ sil [_semantics "array.check_subscript"] @checkbounds3 : $@convention(method) (I
 
 // CHECK-LABEL: sil @rangeCheck
 // CHECK: bb0
-// CHECK:   cond_br {{.*}}, bb4, bb1
-// CHECK: bb1
-// CHECK: [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
-// CHECK:   br bb3
-// CHECK: bb2
-// CHECK:   return
-// CHECK: bb3([[IV:%.*]] : $Builtin.Int64):
-// CHECK:   builtin "xor_Int1"([[TRUE]]
-// CHECK:   builtin "xor_Int1"([[TRUE]]
+// CHECK:   [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
 // CHECK:   cond_fail
-// CHECK:   cond_br {{.*}}, bb5, bb6
-// CHECK: bb4:
-// CHECK:   br bb2
-// CHECK: bb5:
-// CHECK:   br bb2
-// CHECK: bb6:
-// CHECK:   br bb3
-// CHECK: }
+// CHECK:   cond_br {{.*}}, bb6, bb1
+// CHECK: bb1:
+// CHECK:   cond_fail
+// CHECK:   cond_fail
+// CHECK:   cond_br {{.*}}, bb7, bb2
+// CHECK: bb2:
+// CHECK:   cond_fail {{.*}}, "loop induction variable overflowed"
+// CHECK:   br [[HDR:bb[0-9]+]](
+// CHECK: bb3:
+// CHECK:   return
+// CHECK: [[HDR]]({{.*}} : $Builtin.Int64):
+// CHECK:   builtin "xor_Int1"({{.*}}, [[TRUE]] : $Builtin.Int1)
+// CHECK:   cond_fail
+// CHECK:   cond_br
+// CHECK: } // end sil function 'rangeCheck'
 sil @rangeCheck : $@convention(thin) (Builtin.Int64) -> () {
 bb0(%0 : $Builtin.Int64):
   %3 = integer_literal $Builtin.Int64, 0
@@ -1535,7 +1482,10 @@ bb3(%15 : $Builtin.Int64):
   %24 = tuple_extract %22 : $(Builtin.Int64, Builtin.Int1), 1
   cond_fail %24 : $Builtin.Int1
   %28 = builtin "cmp_eq_Int64"(%23 : $Builtin.Int64, %0 : $Builtin.Int64) : $Builtin.Int1
-  cond_br %28, bb6, bb7(%23 : $Builtin.Int64)
+  cond_br %28, bb6, bb7_split
+
+bb7_split:
+  br bb7(%23 : $Builtin.Int64)
 
 bb5:
   br bb2
@@ -1549,26 +1499,24 @@ bb7(%29 : $Builtin.Int64):
 
 // CHECK-LABEL: sil @rangeCheck2
 // CHECK: bb0
-// CHECK:   cond_br {{.*}}, bb4, bb1
-// CHECK: bb1
-// CHECK: [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
-// CHECK: [[FALSE:%.*]] = integer_literal $Builtin.Int1, 0
-// CHECK:   br bb3
-// CHECK: bb2
+// CHECK:   cond_fail
+// CHECK:   cond_br {{.*}}, bb6, bb1
+// CHECK: bb1:
+// CHECK:   cond_fail
+// CHECK:   cond_fail
+// CHECK:   cond_br {{.*}}, bb7, bb2
+// CHECK: bb2:
+// CHECK:   cond_fail {{.*}}, "loop induction variable overflowed"
+// CHECK:   integer_literal $Builtin.Int1, -1
+// CHECK:   [[FALSE:%.*]] = integer_literal $Builtin.Int1, 0
+// CHECK:   br [[HDR:bb[0-9]+]](
+// CHECK: bb3:
 // CHECK:   return
-// CHECK: bb3([[IV:%.*]] : $Builtin.Int64):
-// CHECK:   builtin "xor_Int1"([[TRUE]]
-// CHECK:   builtin "xor_Int1"([[TRUE]]
+// CHECK: [[HDR]]({{.*}} : $Builtin.Int64):
 // CHECK:   builtin "or_Int1"([[FALSE]]
 // CHECK:   cond_fail
-// CHECK:   cond_br {{.*}}, bb5, bb6
-// CHECK: bb4:
-// CHECK:   br bb2
-// CHECK: bb5:
-// CHECK:   br bb2
-// CHECK: bb6:
-// CHECK:   br bb3
-// CHECK: }
+// CHECK:   cond_br
+// CHECK: } // end sil function 'rangeCheck2'
 sil @rangeCheck2 : $@convention(thin) (Builtin.Int64) -> () {
 bb0(%0 : $Builtin.Int64):
   %3 = integer_literal $Builtin.Int64, 0
@@ -1600,7 +1548,10 @@ bb3(%15 : $Builtin.Int64):
   %24 = tuple_extract %22 : $(Builtin.Int64, Builtin.Int1), 1
   cond_fail %24 : $Builtin.Int1
   %28 = builtin "cmp_eq_Int64"(%23 : $Builtin.Int64, %0 : $Builtin.Int64) : $Builtin.Int1
-  cond_br %28, bb6, bb7(%23 : $Builtin.Int64)
+  cond_br %28, bb6, bb7_split
+
+bb7_split:
+  br bb7(%23 : $Builtin.Int64)
 
 bb5:
   br bb2
@@ -1617,7 +1568,7 @@ sil @unknown : $@convention(thin) () -> Builtin.Int1
 // RANGECHECK-LABEL: sil @rangeCheck_early_exit
 // RANGECHECK: bb0
 // RANGECHECK:   cond_fail
-// RANGECHECK:   cond_br {{.*}}, bb5, bb1
+// RANGECHECK:   cond_br
 // RANGECHECK: bb1:
 // RANGECHECK-NOT:  cond_fail
 // RANGECHECK:   br bb3
@@ -1625,19 +1576,11 @@ sil @unknown : $@convention(thin) () -> Builtin.Int1
 // RANGECHECK:  return
 // RANGECHECK: bb3({{.*}}):
 // RANGECHECK:  apply
-// RANGECHECK:  cond_br {{.*}}, bb4, bb6
+// RANGECHECK:  cond_br
 // RANGECHECK: bb4:
 // RANGECHECK:   cond_fail
 // RANGECHECK:   cond_fail
-// RANGECHECK:   cond_br {{.*}}, bb7, bb8
-// RANGECHECK: bb5:
-// RANGECHECK:   br bb2
-// RANGECHECK: bb6:
-// RANGECHECK:   br bb2
-// RANGECHECK: bb7:
-// RANGECHECK:   br bb2
-// RANGECHECK: bb8({{.*}}):
-// RANGECHECK:   br bb3
+// RANGECHECK:   cond_br
 // RANGECHECK: }
 sil @rangeCheck_early_exit : $@convention(thin) (Builtin.Int64) -> () {
 bb0(%0 : $Builtin.Int64):
@@ -1674,7 +1617,10 @@ bb4:
   %24 = tuple_extract %22 : $(Builtin.Int64, Builtin.Int1), 1
   cond_fail %24 : $Builtin.Int1
   %28 = builtin "cmp_eq_Int64"(%23 : $Builtin.Int64, %0 : $Builtin.Int64) : $Builtin.Int1
-  cond_br %28, bb7, bb8(%23 : $Builtin.Int64)
+  cond_br %28, bb7, bb8_split
+
+bb8_split:
+  br bb8(%23 : $Builtin.Int64)
 
 bb5:
   br bb2
@@ -1709,7 +1655,10 @@ bb3(%10 : $Bool):
   %11 = struct_extract %0 : $Int32, #Int32._value
   %12 = integer_literal $Builtin.Int32, 0
   %13 = builtin "cmp_eq_Int32"(%12 : $Builtin.Int32, %11 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %13, bb7(%12 : $Builtin.Int32), bb4
+  cond_br %13, bb7_split, bb4
+
+bb7_split:
+  br bb7(%12 : $Builtin.Int32)
 
 bb4:
   br bb5(%12 : $Builtin.Int32)
@@ -1729,7 +1678,13 @@ bb5(%16 : $Builtin.Int32):
   %28 = tuple_extract %26 : $(Builtin.Int32, Builtin.Int1), 1
   cond_fail %28 : $Builtin.Int1
   %30 = builtin "cmp_eq_Int32"(%27 : $Builtin.Int32, %11 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %30, bb8(%27 : $Builtin.Int32), bb9(%27 : $Builtin.Int32)
+  cond_br %30, bb8_split, bb9_split
+
+bb8_split:
+  br bb8(%27 : $Builtin.Int32)
+
+bb9_split:
+  br bb9(%27 : $Builtin.Int32)
 
 bb6(%32 : $Builtin.Int32):
   %33 = struct $Int32 (%32 : $Builtin.Int32)
@@ -1772,18 +1727,9 @@ struct Wrapper {
 // HOIST: [[L2:%[0-9]+]] = load [[SE]] : $*ArrayInt
 // HOIST: retain_value [[L2]]
 // HOIST: apply [[CB1]]([[SUB3]], {{.*}}[[L2]])
-// HOIST: br bb3
-
-// HOIST: bb3
 // HOIST-NOT: cond_fail
 // HOIST-NOT: @checkbounds
-// HOIST: builtin
-// HOIST: builtin
-// HOIST-NOT: builtin
-// HOIST: cond_br {{.*}}, {{.*}}, bb4
-// HOIST: bb4
-// HOIST:  br bb3
-
+// HOIST: cond_br
 // HOIST: return
 sil @hoist_array_in_struct : $@convention(thin) (Int32, @inout Wrapper) -> Int32 {
 bb0(%0 : $Int32, %1 : $*Wrapper):

--- a/test/SILOptimizer/access_dom.sil
+++ b/test/SILOptimizer/access_dom.sil
@@ -148,7 +148,7 @@ bb2:
 // CHECK-NEXT: load [[BEGIN]] : $*X
 // CHECK-NEXT: end_access [[BEGIN]] : $*X
 // CHECK-NEXT: br bb1
-// CHECK: cond_br {{.*}}, bb1, bb2
+// CHECK: cond_br {{.*}}, bb3, bb2
 // CHECK: bb2:
 // CHECK-NEXT: [[BEGIN:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK: load [[BEGIN]] : $*X
@@ -162,10 +162,10 @@ bb0:
   %2 = load %1 : $*X
   end_access %1 : $*X
   br bb1
-  
+
 bb1:
   %cond = integer_literal $Builtin.Int1, 1
-  cond_br %cond, bb1, bb2
+  cond_br %cond, bb3, bb2
 
 bb2:
   %4 = begin_access [modify] [dynamic] [no_nested_conflict] %0 : $*X
@@ -173,6 +173,9 @@ bb2:
   end_access %4 : $*X
   %7 = tuple ()
   return %7 : $()
+
+bb3:
+  br bb1
 }
 
 // public func testIrreducibleGraph() {
@@ -187,15 +190,15 @@ bb2:
 // CHECK: [[BEGIN2:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN2]] : $*X
 // CHECK-NEXT: end_access [[BEGIN2]] : $*X
-// CHECK: cond_br {{.*}}, bb2, bb3
+// CHECK: cond_br {{.*}}, bb5, bb6
 // CHECK: [[BEGIN3:%.*]] = begin_access [read] [static] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN3]] : $*X
 // CHECK-NEXT: end_access [[BEGIN3]] : $*X
-// CHECK: cond_br {{.*}}, bb3, bb4
+// CHECK: cond_br {{.*}}, bb7, bb4
 // CHECK: [[BEGIN4:%.*]] = begin_access [read] [static] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN4]] : $*X
 // CHECK-NEXT: end_access [[BEGIN4]] : $*X
-// CHECK: cond_br {{.*}}, bb2, bb1
+// CHECK: cond_br {{.*}}, bb8, bb9
 // CHECK: [[BEGIN5:%.*]] = begin_access [read] [static] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN5]] : $*X
 // CHECK-NEXT: end_access [[BEGIN5]] : $*X
@@ -214,28 +217,43 @@ bb1:
   %5 = load %4 : $*X
   end_access %4 : $*X
   %cond1 = integer_literal $Builtin.Int1, 1
-  cond_br %cond1, bb2, bb3
-  
+  cond_br %cond1, t12, t13
+
 bb2:
   %6 = begin_access [read] [dynamic] [no_nested_conflict] %0 : $*X
   %7 = load %6 : $*X
   end_access %6 : $*X
   %cond2 = integer_literal $Builtin.Int1, 1
-  cond_br %cond2, bb3, bb4
+  cond_br %cond2, t23, bb4
 
 bb3:
   %8 = begin_access [read] [dynamic] [no_nested_conflict] %0 : $*X
   %9 = load %8 : $*X
   end_access %8 : $*X
   %cond3 = integer_literal $Builtin.Int1, 1
-  cond_br %cond3, bb2, bb1
-  
+  cond_br %cond3, t32, t31
+
 bb4:
   %10 = begin_access [read] [dynamic] [no_nested_conflict] %0 : $*X
   %11 = load %10 : $*X
   end_access %10 : $*X
   %12 = tuple ()
   return %12 : $()
+
+t12:
+  br bb2
+
+t13:
+  br bb3
+
+t23:
+  br bb3
+
+t32:
+  br bb2
+
+t31:
+  br bb1
 }
 
 // public func testIrreducibleGraph2() {
@@ -244,7 +262,7 @@ bb4:
 // CHECK-LABEL: sil @testIrreducibleGraph2 : $@convention(thin) () -> () {
 // CHECK: [[GLOBAL:%.*]] = global_addr @globalX : $*X
 // CHECK-NEXT: br bb1
-// CHECK: cond_br {{.*}}, bb2, bb3
+// CHECK: cond_br {{.*}}, bb6, bb7
 // CHECK: bb2:
 // CHECK: [[BEGIN2:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN2]] : $*X
@@ -258,7 +276,7 @@ bb4:
 // CHECK: [[BEGIN4:%.*]] = begin_access [read] [static] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN4]] : $*X
 // CHECK-NEXT: end_access [[BEGIN4]] : $*X
-// CHECK: cond_br {{.*}}, bb2, bb5
+// CHECK: cond_br {{.*}}, bb8, bb5
 // CHECK: [[BEGIN5:%.*]] = begin_access [read] [static] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN5]] : $*X
 // CHECK-NEXT: end_access [[BEGIN5]] : $*X
@@ -271,8 +289,8 @@ bb0:
 
 bb1:
   %cond1 = integer_literal $Builtin.Int1, 1
-  cond_br %cond1, bb2, bb3
-  
+  cond_br %cond1, t12, t13
+
 bb2:
   %6 = begin_access [read] [dynamic] [no_nested_conflict] %0 : $*X
   %7 = load %6 : $*X
@@ -284,20 +302,29 @@ bb3:
   %9 = load %8 : $*X
   end_access %8 : $*X
   br bb4
-  
+
 bb4:
   %10 = begin_access [read] [dynamic] [no_nested_conflict] %0 : $*X
   %11 = load %10 : $*X
   end_access %10 : $*X
   %cond2 = integer_literal $Builtin.Int1, 1
-  cond_br %cond2, bb2, bb5
-  
+  cond_br %cond2, t42, bb5
+
 bb5:
   %13 = begin_access [read] [dynamic] [no_nested_conflict] %0 : $*X
   %14 = load %13 : $*X
   end_access %13 : $*X
   %16 = tuple ()
   return %16 : $()
+
+t12:
+  br bb2
+
+t13:
+  br bb3
+
+t42:
+  br bb2
 }
 
 // public func testDomUnpaired() {
@@ -346,29 +373,32 @@ bb0:
 // CHECK: [[BEGIN2:%.*]] = begin_access [read] [static] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN2]] : $*X
 // CHECK-NEXT: end_access [[BEGIN2]] : $*X
-// CHECK: cond_br {{.*}}, bb2, bb4
+// CHECK: cond_br {{.*}}, bb5, bb4
 // CHECK-LABEL: } // end sil function 'testLoopDominatingAccessAdderSimple'
 sil @testLoopDominatingAccessAdderSimple : $@convention(thin) () -> () {
 bb0:
   %0 = global_addr @globalX: $*X
   br bb1
-  
+
 bb1:
   br bb2
 
 bb2:
   br bb3
-  
+
 bb3:
   %4 = begin_access [read] [dynamic] [no_nested_conflict] %0 : $*X
   %5 = load %4 : $*X
   end_access %4 : $*X
   %cond = integer_literal $Builtin.Int1, 1
-  cond_br %cond, bb2, bb4
+  cond_br %cond, bb5, bb4
 
 bb4:
   %10 = tuple ()
   return %10 : $()
+
+bb5:
+  br bb2
 }
 
 // public func testLoopDominatingAccessAdderBailSimple() {
@@ -382,29 +412,32 @@ bb4:
 // CHECK: [[BEGIN2:%.*]] = begin_access [read] [dynamic] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN2]] : $*X
 // CHECK-NEXT: end_access [[BEGIN2]] : $*X
-// CHECK: cond_br {{.*}}, bb2, bb4
+// CHECK: cond_br {{.*}}, bb5, bb4
 // CHECK-LABEL: } // end sil function 'testLoopDominatingAccessAdderBailSimple'
 sil @testLoopDominatingAccessAdderBailSimple : $@convention(thin) () -> () {
 bb0:
   %0 = global_addr @globalX: $*X
   br bb1
-  
+
 bb1:
   br bb2
 
 bb2:
   br bb3
-  
+
 bb3:
   %4 = begin_access [read] [dynamic] %0 : $*X
   %5 = load %4 : $*X
   end_access %4 : $*X
   %cond = integer_literal $Builtin.Int1, 1
-  cond_br %cond, bb2, bb4
+  cond_br %cond, bb5, bb4
 
 bb4:
   %10 = tuple ()
   return %10 : $()
+
+bb5:
+  br bb2
 }
 
 // public func testLoopDominatingAccessAdderMulti() {
@@ -422,19 +455,19 @@ bb4:
 // CHECK: [[BEGIN3:%.*]] = begin_access [read] [static] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN3]] : $*X
 // CHECK-NEXT: end_access [[BEGIN3]] : $*X
-// CHECK: cond_br {{.*}}, bb2, bb4
+// CHECK: cond_br {{.*}}, bb5, bb4
 // CHECK-LABEL: } // end sil function 'testLoopDominatingAccessAdderMulti'
 sil @testLoopDominatingAccessAdderMulti : $@convention(thin) () -> () {
 bb0:
   %0 = global_addr @globalX: $*X
   br bb1
-  
+
 bb1:
   br bb2
 
 bb2:
   br bb3
-  
+
 bb3:
   %4 = begin_access [read] [dynamic] [no_nested_conflict] %0 : $*X
   %5 = load %4 : $*X
@@ -443,11 +476,14 @@ bb3:
   %7 = load %6 : $*X
   end_access %6 : $*X
   %cond = integer_literal $Builtin.Int1, 1
-  cond_br %cond, bb2, bb4
+  cond_br %cond, bb5, bb4
 
 bb4:
   %10 = tuple ()
   return %10 : $()
+
+bb5:
+  br bb2
 }
 
 // public func testLoopDominatingAccessAdderMultiChangeKind() {
@@ -469,19 +505,19 @@ bb4:
 // CHECK: [[BEGIN4:%.*]] = begin_access [read] [static] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN4]] : $*X
 // CHECK-NEXT: end_access [[BEGIN4]] : $*X
-// CHECK: cond_br {{.*}}, bb2, bb4
+// CHECK: cond_br {{.*}}, bb5, bb4
 // CHECK-LABEL: } // end sil function 'testLoopDominatingAccessAdderMultiChangeKind'
 sil @testLoopDominatingAccessAdderMultiChangeKind : $@convention(thin) () -> () {
 bb0:
   %0 = global_addr @globalX: $*X
   br bb1
-  
+
 bb1:
   br bb2
 
 bb2:
   br bb3
-  
+
 bb3:
   %4 = begin_access [read] [dynamic] [no_nested_conflict] %0 : $*X
   %5 = load %4 : $*X
@@ -493,11 +529,14 @@ bb3:
   %9 = load %8 : $*X
   end_access %8 : $*X
   %cond = integer_literal $Builtin.Int1, 1
-  cond_br %cond, bb2, bb4
+  cond_br %cond, bb5, bb4
 
 bb4:
   %10 = tuple ()
   return %10 : $()
+
+bb5:
+  br bb2
 }
 
 // public func testBailOnNestedDomWrite() {

--- a/test/SILOptimizer/access_dom_call.sil
+++ b/test/SILOptimizer/access_dom_call.sil
@@ -190,13 +190,13 @@ bb0(%0 : $C):
 sil @testDomLoopAMD : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : $C):
   br bb1
-  
+
 bb1:
   br bb2
 
 bb2:
   br bb3
-  
+
 bb3:
   %m = class_method %0 : $C, #C.field!modify : (C) -> () -> (), $@yield_once @convention(method) (@guaranteed C) -> @yields @inout Int64
   (%3, %4) = begin_apply %m(%0) : $@yield_once @convention(method) (@guaranteed C) -> @yields @inout Int64
@@ -205,9 +205,12 @@ bb3:
   end_access %a1 : $*Int64
   end_apply %4 as $()
   %cond = integer_literal $Builtin.Int1, 1
-  cond_br %cond, bb2, bb4
+  cond_br %cond, bb5, bb4
 
 bb4:
   %10 = tuple ()
   return %10 : $()
+
+bb5:
+  br bb2
 }

--- a/test/SILOptimizer/access_dom_loop.sil
+++ b/test/SILOptimizer/access_dom_loop.sil
@@ -44,11 +44,14 @@ bb3:
   end_access %6 : $*X
   end_access %4 : $*X
   %cond = integer_literal $Builtin.Int1, 1
-  cond_br %cond, bb2, bb4
+  cond_br %cond, bb5, bb4
 
 bb4:
   %10 = tuple ()
   return %10 : $()
+
+bb5:
+  br bb2
 }
 
 // No, do cannot optimize a nested loop access.
@@ -75,11 +78,14 @@ bb3:
   end_access %6 : $*X
   end_access %4 : $*X
   %cond = integer_literal $Builtin.Int1, 1
-  cond_br %cond, bb2, bb4
+  cond_br %cond, bb5, bb4
 
 bb4:
   %10 = tuple ()
   return %10 : $()
+
+bb5:
+  br bb2
 }
 
 // Yes, insert a preheader check for unidentifiable access (address argument).
@@ -103,9 +109,12 @@ bb3:
   %6 = begin_access [modify] [dynamic] [no_nested_conflict] %0 : $*Int64
   end_access %6 : $*Int64
   %cond = integer_literal $Builtin.Int1, 1
-  cond_br %cond, bb2, bb4
+  cond_br %cond, bb5, bb4
 
 bb4:
   %10 = tuple ()
   return %10 : $()
+
+bb5:
+  br bb2
 }

--- a/test/SILOptimizer/access_enforcement_opts.sil
+++ b/test/SILOptimizer/access_enforcement_opts.sil
@@ -1095,7 +1095,7 @@ bb2:
 // CHECK-NEXT: load [[BEGIN]] : $*X
 // CHECK-NEXT: end_access [[BEGIN]] : $*X
 // CHECK-NEXT: br bb1
-// CHECK: cond_br {{.*}}, bb1, bb2
+// CHECK: cond_br {{.*}}, bb3, bb2
 // CHECK: [[BEGIN2:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN2]] : $*X
 // CHECK-NEXT: end_access [[BEGIN2]] : $*X
@@ -1110,7 +1110,7 @@ bb0:
   
 bb1:
   %cond = integer_literal $Builtin.Int1, 1
-  cond_br %cond, bb1, bb2
+  cond_br %cond, bb3, bb2
 
 bb2:
   %4 = begin_access [read] [dynamic] %0 : $*X
@@ -1118,6 +1118,9 @@ bb2:
   end_access %4 : $*X
   %7 = tuple ()
   return %7 : $()
+
+bb3:
+  br bb1
 }
 
 // public func testConflictInInnerLoop() {
@@ -1132,7 +1135,7 @@ bb2:
 // CHECK: [[BEGIN2:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN2]] : $*X
 // CHECK-NEXT: end_access [[BEGIN2]] : $*X
-// CHECK: cond_br {{.*}}, bb1, bb2
+// CHECK: cond_br {{.*}}, bb3, bb2
 // CHECK: [[BEGIN3:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN3]] : $*X
 // CHECK-NEXT: end_access [[BEGIN3]] : $*X
@@ -1151,7 +1154,7 @@ bb1:
   %5 = load %4 : $*X
   end_access %4 : $*X
   %cond = integer_literal $Builtin.Int1, 1
-  cond_br %cond, bb1, bb2
+  cond_br %cond, bb3, bb2
 
 bb2:
   %7 = begin_access [read] [dynamic] %0 : $*X
@@ -1159,6 +1162,9 @@ bb2:
   end_access %7 : $*X
   %10 = tuple ()
   return %10 : $()
+
+bb3:
+  br bb1
 }
 
 sil hidden_external [global_init] @globalAddressor : $@convention(thin) () -> Builtin.RawPointer
@@ -1175,7 +1181,7 @@ sil hidden_external [global_init] @globalAddressor : $@convention(thin) () -> Bu
 // CHECK: [[BEGIN2:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] {{.*}} : $*Int64
 // CHECK-NEXT: load [[BEGIN2]] : $*Int64
 // CHECK-NEXT: end_access [[BEGIN2]] : $*Int64
-// CHECK: cond_br {{.*}}, bb1, bb2
+// CHECK: cond_br {{.*}}, bb3, bb2
 // CHECK: [[BEGIN3:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN3]] : $*X
 // CHECK-NEXT: end_access [[BEGIN3]] : $*X
@@ -1197,7 +1203,7 @@ bb1:
   %u4 = load %u3 : $*Int64
   end_access %u3 : $*Int64
   %cond = integer_literal $Builtin.Int1, 1
-  cond_br %cond, bb1, bb2
+  cond_br %cond, bb3, bb2
 
 bb2:
   %7 = begin_access [read] [dynamic] %0 : $*X
@@ -1205,6 +1211,9 @@ bb2:
   end_access %7 : $*X
   %10 = tuple ()
   return %10 : $()
+
+bb3:
+  br bb1
 }
 
 // public func testIrreducibleGraph() {
@@ -1220,15 +1229,15 @@ bb2:
 // CHECK: [[BEGIN2:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN2]] : $*X
 // CHECK-NEXT: end_access [[BEGIN2]] : $*X
-// CHECK: cond_br {{.*}}, bb2, bb3
+// CHECK: cond_br {{.*}}, bb5, bb6
 // CHECK: [[BEGIN3:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN3]] : $*X
 // CHECK-NEXT: end_access [[BEGIN3]] : $*X
-// CHECK: cond_br {{.*}}, bb3, bb4
+// CHECK: cond_br {{.*}}, bb7, bb4
 // CHECK: [[BEGIN4:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN4]] : $*X
 // CHECK-NEXT: end_access [[BEGIN4]] : $*X
-// CHECK: cond_br {{.*}}, bb2, bb1
+// CHECK: cond_br {{.*}}, bb8, bb9
 // CHECK: [[BEGIN5:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN5]] : $*X
 // CHECK-NEXT: end_access [[BEGIN5]] : $*X
@@ -1247,28 +1256,43 @@ bb1:
   %5 = load %4 : $*X
   end_access %4 : $*X
   %cond1 = integer_literal $Builtin.Int1, 1
-  cond_br %cond1, bb2, bb3
-  
+  cond_br %cond1, bb5, bb6
+
 bb2:
   %6 = begin_access [read] [dynamic] %0 : $*X
   %7 = load %6 : $*X
   end_access %6 : $*X
   %cond2 = integer_literal $Builtin.Int1, 1
-  cond_br %cond2, bb3, bb4
+  cond_br %cond2, bb7, bb4
 
 bb3:
   %8 = begin_access [read] [dynamic] %0 : $*X
   %9 = load %8 : $*X
   end_access %8 : $*X
   %cond3 = integer_literal $Builtin.Int1, 1
-  cond_br %cond3, bb2, bb1
-  
+  cond_br %cond3, bb8, bb9
+
 bb4:
   %10 = begin_access [read] [dynamic] %0 : $*X
   %11 = load %10 : $*X
   end_access %10 : $*X
   %12 = tuple ()
   return %12 : $()
+
+bb5:
+  br bb2
+
+bb6:
+  br bb3
+
+bb7:
+  br bb3
+
+bb8:
+  br bb2
+
+bb9:
+  br bb1
 }
 
 // public func testIrreducibleGraph2() {
@@ -1288,7 +1312,7 @@ bb4:
 // CHECK: [[BEGIN1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN1]] : $*X
 // CHECK-NEXT: end_access [[BEGIN1]] : $*X
-// CHECK: cond_br {{.*}}, bb2, bb3
+// CHECK: cond_br {{.*}}, bb6, bb7
 // CHECK: [[BEGIN2:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN2]] : $*X
 // CHECK-NEXT: end_access [[BEGIN2]] : $*X
@@ -1298,7 +1322,7 @@ bb4:
 // CHECK: br bb4
 // CHECK: load [[BEGIN3]] : $*X
 // CHECK-NEXT: end_access [[BEGIN3]] : $*X
-// CHECK: cond_br {{.*}}, bb2, bb5
+// CHECK: cond_br {{.*}}, bb8, bb5
 // CHECK: [[BEGIN5:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN5]] : $*X
 // CHECK-NEXT: end_access [[BEGIN5]] : $*X
@@ -1317,8 +1341,8 @@ bb1:
   %5 = load %4 : $*X
   end_access %4 : $*X
   %cond1 = integer_literal $Builtin.Int1, 1
-  cond_br %cond1, bb2, bb3
-  
+  cond_br %cond1, bb6, bb7
+
 bb2:
   %6 = begin_access [read] [dynamic] %0 : $*X
   %7 = load %6 : $*X
@@ -1330,20 +1354,29 @@ bb3:
   %9 = load %8 : $*X
   end_access %8 : $*X
   br bb4
-  
+
 bb4:
   %10 = begin_access [read] [dynamic] %0 : $*X
   %11 = load %10 : $*X
   end_access %10 : $*X
   %cond2 = integer_literal $Builtin.Int1, 1
-  cond_br %cond2, bb2, bb5
-  
+  cond_br %cond2, bb8, bb5
+
 bb5:
   %13 = begin_access [read] [dynamic] %0 : $*X
   %14 = load %13 : $*X
   end_access %13 : $*X
   %16 = tuple ()
   return %16 : $()
+
+bb6:
+  br bb2
+
+bb7:
+  br bb3
+
+bb8:
+  br bb2
 }
 
 class RefElemClass {
@@ -1432,7 +1465,7 @@ bb0(%0 : $RefElemNoConflictClass):
 // CHECK: [[BEGIN1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN1]] : $*X
 // CHECK-NEXT: end_access [[BEGIN1]] : $*X
-// CHECK: cond_br {{.*}}, bb2, bb3
+// CHECK: cond_br {{.*}}, bb7, bb8
 // CHECK: [[BEGIN2:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN2]] : $*X
 // CHECK-NEXT: end_access [[BEGIN2]] : $*X
@@ -1465,7 +1498,7 @@ bb1:
   %5 = load %4 : $*X
   end_access %4 : $*X
   %cond1 = integer_literal $Builtin.Int1, 1
-  cond_br %cond1, bb2, bb3
+  cond_br %cond1, bb7, bb8
 
 bb2:
   %6 = begin_access [read] [dynamic] %0 : $*X
@@ -1498,6 +1531,12 @@ bb6:
   end_access %16 : $*X
   %19 = tuple ()
   return %19 : $()
+
+bb7:
+  br bb2
+
+bb8:
+  br bb3
 }
 
 // public func testMergeWithFirstConflict() {

--- a/test/SILOptimizer/arcsequenceopts.sil
+++ b/test/SILOptimizer/arcsequenceopts.sil
@@ -743,7 +743,7 @@ bb0(%0 : $Cls):
 sil @hammock1 : $@convention(thin) (Builtin.NativeObject) -> () {
 bb0(%0 : $Builtin.NativeObject):
   strong_retain %0 : $Builtin.NativeObject
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1, bb3
 
 bb1:
   br bb2
@@ -752,6 +752,9 @@ bb2:
   strong_release %0 : $Builtin.NativeObject
   %9999 = tuple()
   return %9999 : $()
+
+bb3:
+  br bb2
 }
 
 // This hammock cannot be optimized.
@@ -765,7 +768,7 @@ bb2:
 sil @hammock2 : $@convention(thin) (Builtin.NativeObject) -> () {
 bb0(%0 : $Builtin.NativeObject):
   strong_retain %0 : $Builtin.NativeObject
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1, bb3
 
 bb1:
   strong_retain %0 : $Builtin.NativeObject
@@ -775,6 +778,9 @@ bb2:
   strong_release %0 : $Builtin.NativeObject
   %9999 = tuple()
   return %9999 : $()
+
+bb3:
+  br bb2
 }
 
 /// This hammock can't be optimized.
@@ -788,7 +794,7 @@ bb2:
 sil @hammock3 : $@convention(thin) (Builtin.NativeObject) -> () {
 bb0(%0 : $Builtin.NativeObject):
   strong_retain %0 : $Builtin.NativeObject
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1, bb3
 
 bb1:
   strong_release %0 : $Builtin.NativeObject
@@ -798,6 +804,9 @@ bb2:
   strong_release %0 : $Builtin.NativeObject
   %9999 = tuple()
   return %9999 : $()
+
+bb3:
+  br bb2
 }
 
 // This should not be optimizable.
@@ -811,7 +820,7 @@ bb2:
 // CHECK-NEXT: strong_release
 sil @hammock4 : $@convention(thin) (Builtin.NativeObject) -> () {
 bb0(%0 : $Builtin.NativeObject):
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1, bb3
 
 bb1:
   strong_retain %0 : $Builtin.NativeObject
@@ -821,6 +830,9 @@ bb2:
   strong_release %0 : $Builtin.NativeObject
   %9999 = tuple()
   return %9999 : $()
+
+bb3:
+  br bb2
 }
 
 // CHECK-LABEL: sil @hammock5 : $@convention(thin) (Builtin.NativeObject) -> () {
@@ -833,7 +845,7 @@ bb2:
 // CHECK-NEXT: strong_release
 sil @hammock5 : $@convention(thin) (Builtin.NativeObject) -> () {
 bb0(%0 : $Builtin.NativeObject):
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1, bb3
 
 bb1:
   strong_release %0 : $Builtin.NativeObject
@@ -843,6 +855,9 @@ bb2:
   strong_release %0 : $Builtin.NativeObject
   %9999 = tuple()
   return %9999 : $()
+
+bb3:
+  br bb2
 }
 
 // CHECK-LABEL: sil @hammock6 : $@convention(thin) (Builtin.NativeObject) -> () {
@@ -856,7 +871,7 @@ bb2:
 // CHECK-NEXT: strong_release
 sil @hammock6 : $@convention(thin) (Builtin.NativeObject) -> () {
 bb0(%0 : $Builtin.NativeObject):
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1, bb3
 
 bb1:
   br bb2
@@ -865,6 +880,9 @@ bb2:
   strong_release %0 : $Builtin.NativeObject
   %9999 = tuple()
   return %9999 : $()
+
+bb3:
+  br bb2
 }
 
 // CHECK-LABEL: sil @hammock7 : $@convention(thin) (Builtin.NativeObject) -> () {
@@ -878,7 +896,7 @@ bb2:
 sil @hammock7 : $@convention(thin) (Builtin.NativeObject) -> () {
 bb0(%0 : $Builtin.NativeObject):
   strong_retain %0 : $Builtin.NativeObject
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1, bb3
 
 bb1:
   strong_retain %0 : $Builtin.NativeObject
@@ -887,6 +905,9 @@ bb1:
 bb2:
   %9999 = tuple()
   return %9999 : $()
+
+bb3:
+  br bb2
 }
 
 // CHECK-LABEL: sil @hammock8 : $@convention(thin) (Builtin.NativeObject) -> () {
@@ -902,7 +923,7 @@ bb2:
 sil @hammock8 : $@convention(thin) (Builtin.NativeObject) -> () {
 bb0(%0 : $Builtin.NativeObject):
   strong_retain %0 : $Builtin.NativeObject
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1, bb3
 
 bb1:
   strong_release %0 : $Builtin.NativeObject
@@ -911,6 +932,9 @@ bb1:
 bb2:
   %9999 = tuple()
   return %9999 : $()
+
+bb3:
+  br bb2
 }
 
 ////////////////////
@@ -942,14 +966,14 @@ sil @double_hammock1 : $@convention(thin) (<τ_0_0> { var τ_0_0 } <Builtin.Int3
 bb0(%0 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>):
   %1 = function_ref @user : $@convention(thin) (<τ_0_0> { var τ_0_0 } <Builtin.Int32>) -> ()
   strong_retain %0 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1, bb5
 
 bb1:
   apply %1(%0) : $@convention(thin) (<τ_0_0> { var τ_0_0 } <Builtin.Int32>) -> ()
   br bb2
 
 bb2:
-  cond_br undef, bb3, bb4
+  cond_br undef, bb3, bb6
 
 bb3:
   apply %1(%0) : $@convention(thin) (<τ_0_0> { var τ_0_0 } <Builtin.Int32>) -> ()
@@ -959,6 +983,12 @@ bb4:
   strong_release %0 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>
   %9999 = tuple()
   return %9999 : $()
+
+bb5:
+  br bb2
+
+bb6:
+  br bb4
 }
 
 //////////////
@@ -1684,27 +1714,45 @@ bb0(%0 : $Builtin.NativeObject):
 
 bb1:
   strong_retain %0 : $Builtin.NativeObject
-  cond_br undef, bb4, bb5
+  cond_br undef, bb6, bb7
 
 bb2:
   strong_retain %0 : $Builtin.NativeObject
-  cond_br undef, bb3, bb4
+  cond_br undef, bb3, bb8
 
 bb3:
-  cond_br undef, bb4, bb5
+  cond_br undef, bb9, bb10
 
 bb4:
   strong_release %0 : $Builtin.NativeObject
   %1 = tuple()
   return %1 : $()
 
-bb5:
+bb6:
+  br bb4
+
+bb7:
   %39 = function_ref @fatalError : $@convention(thin) (StaticString, StaticString, StaticString) -> Never
   %40 = string_literal utf8 "Fatal error"
   %41 = integer_literal $Builtin.Word, 11
   %42 = integer_literal $Builtin.Int8, 11
   %43 = struct $StaticString (%40 : $Builtin.RawPointer, %41 : $Builtin.Word, %42 : $Builtin.Int8)
   %44 = apply %39(%43, %43, %43) : $@convention(thin) (StaticString, StaticString, StaticString) -> Never
+  unreachable
+
+bb8:
+  br bb4
+
+bb9:
+  br bb4
+
+bb10:
+  %139 = function_ref @fatalError : $@convention(thin) (StaticString, StaticString, StaticString) -> Never
+  %140 = string_literal utf8 "Fatal error"
+  %141 = integer_literal $Builtin.Word, 11
+  %142 = integer_literal $Builtin.Int8, 11
+  %143 = struct $StaticString (%140 : $Builtin.RawPointer, %141 : $Builtin.Word, %142 : $Builtin.Int8)
+  %144 = apply %139(%143, %143, %143) : $@convention(thin) (StaticString, StaticString, StaticString) -> Never
   unreachable
 }
 
@@ -1729,12 +1777,15 @@ bb0(%0 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>):
   br bb1
 
 bb1:
-  cond_br undef, bb1, bb2
+  cond_br undef, bb3, bb2
 
 bb2:
   strong_release %0 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>
   %2 = tuple()
   return %2 : $()
+
+bb3:
+  br bb1
 }
 
 // CHECK-LABEL: sil @guaranteed_is_a_mayuse_maydecrement : $@convention(thin) (@owned Builtin.NativeObject) -> () {

--- a/test/SILOptimizer/arcsequenceopts.sil
+++ b/test/SILOptimizer/arcsequenceopts.sil
@@ -1962,9 +1962,9 @@ bb0(%0 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>):
   %1 = function_ref @user : $@convention(thin) (<τ_0_0> { var τ_0_0 } <Builtin.Int32>) -> ()
   apply %1(%0) : $@convention(thin) (<τ_0_0> { var τ_0_0 } <Builtin.Int32>) -> ()
   %2 = integer_literal $Builtin.Int1, 0
-  cond_br %2, bb1(%0 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>), bb2
+  cond_br %2, bb1, bb2
 
-bb1(%3 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>):
+bb1:
   br bb3
 
 bb2:
@@ -1985,9 +1985,9 @@ bb0(%0 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>):
   %1 = function_ref @user : $@convention(thin) (<τ_0_0> { var τ_0_0 } <Builtin.Int32>) -> ()
   apply %1(%0) : $@convention(thin) (<τ_0_0> { var τ_0_0 } <Builtin.Int32>) -> ()
   %2 = integer_literal $Builtin.Int1, 0
-  cond_br %2, bb2(%0 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>), bb1
+  cond_br %2, bb2, bb1
 
-bb2(%3 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>):
+bb2:
   br bb3
 
 bb1:

--- a/test/SILOptimizer/arcsequenceopts_knownsafebugs_loop.sil
+++ b/test/SILOptimizer/arcsequenceopts_knownsafebugs_loop.sil
@@ -34,8 +34,11 @@ bb0(%0 : $Cls):
 bb1:
   strong_release %0 : $Cls
   strong_retain %0 : $Cls
-  cond_br undef, bb1, bb2
-  
+  cond_br undef, bb1t, bb2
+
+bb1t:
+  br bb1
+
 bb2:
   strong_release %0 : $Cls
   strong_release %0 : $Cls
@@ -46,7 +49,7 @@ bb2:
 // CHECK-LABEL: sil hidden @$matched_rr_loop :
 // CHECK: bb0(%0 : $Cls):
 // CHECK-NOT:   strong_retain %0 : $Cls
-// CHECK: bb2:
+// CHECK: bb3:
 // CHECK-NEXT:   strong_release %0 : $Cls
 // CHECK-NEXT:   [[RET:%.*]] = tuple ()
 // CHECK-NEXT:   return [[RET]]
@@ -59,8 +62,11 @@ bb0(%0 : $Cls):
 bb1:
   strong_retain %0 : $Cls
   strong_release %0 : $Cls
-  cond_br undef, bb1, bb2
-  
+  cond_br undef, bb1t, bb2
+
+bb1t:
+  br bb1
+
 bb2:
   strong_release %0 : $Cls
   strong_release %0 : $Cls
@@ -83,7 +89,10 @@ bb0(%0 : $S, %1 : $ChildCls):
 bb1:
   strong_release %1 : $ChildCls
   strong_retain %1 : $ChildCls
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1t, bb2
+
+bb1t:
+  br bb1
 
 bb2:
   release_value %0 : $S
@@ -95,7 +104,7 @@ bb2:
 // CHECK-LABEL: sil hidden @$matched_rr_aliasing_loop :
 // CHECK: bb0(%0 : $S, %1 : $ChildCls):
 // CHECK-NOT:   retain_value %0 : $S
-// CHECK: bb2:
+// CHECK: bb3:
 // CHECK-NEXT:   release_value %0 : $S
 // CHECK-NEXT:   [[RET:%.*]] = tuple ()
 // CHECK-NEXT:   return [[RET]]
@@ -108,7 +117,10 @@ bb0(%0 : $S, %1 : $ChildCls):
 bb1:
   strong_retain %1 : $ChildCls
   strong_release %1 : $ChildCls
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1t, bb2
+
+bb1t:
+  br bb1
 
 bb2:
   release_value %0 : $S
@@ -134,7 +146,10 @@ bb1:
   %2 = load %1 : $*ChildCls
   strong_release %2 : $ChildCls
   strong_retain %2 : $ChildCls
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1t, bb2
+
+bb1t:
+  br bb1
 
 bb2:
   release_value %0 : $Cls
@@ -146,7 +161,7 @@ bb2:
 // CHECK-LABEL: sil hidden @$matched_rr_subobject_loop :
 // CHECK: bb0(%0 : $Cls):
 // CHECK-NOT:   retain_value %0 : $Cls
-// CHECK: bb2:
+// CHECK: bb3:
 // CHECK-NEXT:   release_value %0 : $Cls
 // CHECK-NEXT:   [[RET:%.*]] = tuple ()
 // CHECK-NEXT:   return [[RET]]
@@ -161,7 +176,10 @@ bb1:
   %2 = load %1 : $*ChildCls
   strong_retain %2 : $ChildCls
   strong_release %2 : $ChildCls
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1t, bb2
+
+bb1t:
+  br bb1
 
 bb2:
   release_value %0 : $Cls
@@ -189,7 +207,10 @@ bb1:
   %1 = struct_extract %0 : $S, #S.child1
   strong_release %1 : $ChildCls
   strong_retain %1 : $ChildCls
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1t, bb2
+
+bb1t:
+  br bb1
 
 bb2:
   release_value %0 : $S
@@ -202,24 +223,33 @@ bb2:
 // CHECK-LABEL: sil hidden @$unmatched_rr_loop_early_exit :
 // CHECK: bb1
 // CHECK:   strong_release %0 : $Cls
-// CHECK:   cond_br undef, bb2, bb3
+// CHECK:   cond_br undef, bb2, bb4
 // CHECK: bb2:
 // CHECK:   strong_retain %0 : $Cls
-// CHECK:   cond_br undef, bb1, bb3
+// CHECK:   cond_br undef, bb3, bb5
 // CHECK-LABEL: } // end sil function '$unmatched_rr_loop_early_exit'
 sil hidden @$unmatched_rr_loop_early_exit : $@convention(thin) (@owned Cls) -> () {
 bb0(%0 : $Cls):
   strong_retain %0 : $Cls
   br bb1
-  
+
 bb1:
   strong_release %0 : $Cls
-  cond_br undef, bb2, bb3
+  cond_br undef, bb2, bb3t1
 
 bb2:
   strong_retain %0 : $Cls
-  cond_br undef, bb1, bb3
-  
+  cond_br undef, bb1t, bb3t2
+
+bb1t:
+  br bb1
+
+bb3t1:
+  br bb3
+
+bb3t2:
+  br bb3
+
 bb3:
   strong_release %0 : $Cls
   strong_release %0 : $Cls
@@ -233,24 +263,33 @@ bb3:
 // CHECK-LABEL: sil hidden @$matched_rr_loop_early_exit :
 // CHECK: bb1
 // CHECK:   strong_retain %0 : $Cls
-// CHECK:   cond_br undef, bb2, bb3
+// CHECK:   cond_br undef, bb2, bb4
 // CHECK: bb2:
 // CHECK:   strong_release %0 : $Cls
-// CHECK:   cond_br undef, bb1, bb3
+// CHECK:   cond_br undef, bb3, bb5
 // CHECK-LABEL: } // end sil function '$matched_rr_loop_early_exit'
 sil hidden @$matched_rr_loop_early_exit : $@convention(thin) (@owned Cls) -> () {
 bb0(%0 : $Cls):
   strong_retain %0 : $Cls
   br bb1
-  
+
 bb1:
   strong_retain %0 : $Cls
-  cond_br undef, bb2, bb3
+  cond_br undef, bb2, bb3t1
 
 bb2:
   strong_release %0 : $Cls
-  cond_br undef, bb1, bb3
-  
+  cond_br undef, bb1t, bb3t2
+
+bb1t:
+  br bb1
+
+bb3t1:
+  br bb3
+
+bb3t2:
+  br bb3
+
 bb3:
   strong_release %0 : $Cls
   strong_release %0 : $Cls
@@ -261,24 +300,27 @@ bb3:
 // CHECK-LABEL: sil hidden @$unmatched_rr_loop_early_exit_allowsleaks :
 // CHECK: bb1
 // CHECK:   strong_release %0 : $Cls
-// CHECK:   cond_br undef, bb2, bb3
+// CHECK:   cond_br undef, bb2, bb4
 // CHECK: bb2:
 // CHECK:   strong_retain %0 : $Cls
-// CHECK:   cond_br undef, bb1, bb4
+// CHECK:   cond_br undef, bb3, bb5
 // CHECK-LABEL: } // end sil function '$unmatched_rr_loop_early_exit_allowsleaks'
 sil hidden @$unmatched_rr_loop_early_exit_allowsleaks : $@convention(thin) (@owned Cls) -> () {
 bb0(%0 : $Cls):
   strong_retain %0 : $Cls
   br bb1
-  
+
 bb1:
   strong_release %0 : $Cls
   cond_br undef, bb2, bb3
 
 bb2:
   strong_retain %0 : $Cls
-  cond_br undef, bb1, bb4
-  
+  cond_br undef, bb1t, bb4
+
+bb1t:
+  br bb1
+
 bb3:
   unreachable
 
@@ -294,24 +336,27 @@ bb4:
 // CHECK-LABEL: sil hidden @$matched_rr_loop_early_exit_allowsleaks :
 // CHECK: bb1
 // CHECK-NOT:   strong_release %0 : $Cls
-// CHECK:   cond_br undef, bb2, bb3
+// CHECK:   cond_br undef, bb2, bb4
 // CHECK: bb2:
 // CHECK-NOT:   strong_retain %0 : $Cls
-// CHECK:   cond_br undef, bb1, bb4
+// CHECK:   cond_br undef, bb3, bb5
 // CHECK-LABEL: } // end sil function '$matched_rr_loop_early_exit_allowsleaks'
 sil hidden @$matched_rr_loop_early_exit_allowsleaks : $@convention(thin) (@owned Cls) -> () {
 bb0(%0 : $Cls):
   strong_retain %0 : $Cls
   br bb1
-  
+
 bb1:
   strong_retain %0 : $Cls
   cond_br undef, bb2, bb3
 
 bb2:
   strong_release %0 : $Cls
-  cond_br undef, bb1, bb4
-  
+  cond_br undef, bb1t, bb4
+
+bb1t:
+  br bb1
+
 bb3:
   unreachable
 

--- a/test/SILOptimizer/arcsequenceopts_rcidentityanalysis.sil
+++ b/test/SILOptimizer/arcsequenceopts_rcidentityanalysis.sil
@@ -320,10 +320,10 @@ bb2:
   br bb3(%1 : $FakeOptional<Builtin.NativeObject>)
 
 bb3(%2 : $FakeOptional<Builtin.NativeObject>):
-  cond_br undef, bb4(%2 : $FakeOptional<Builtin.NativeObject>), bb5
+  cond_br undef, bb4, bb5
 
-bb4(%3 : $FakeOptional<Builtin.NativeObject>):
-  br bb3(%3 : $FakeOptional<Builtin.NativeObject>)
+bb4:
+  br bb3(%2 : $FakeOptional<Builtin.NativeObject>)
 
 bb5:
   retain_value %0 : $FakeOptional<Builtin.NativeObject>
@@ -437,10 +437,10 @@ bb1(%1 : $FakeOptional<Cls>):
   retain_value %2 : $Cls
   release_value %1 : $FakeOptional<Cls>
   %3 = enum $FakeOptional<Cls>, #FakeOptional.some!enumelt, %2 : $Cls
-  cond_br undef, bb2(%3 : $FakeOptional<Cls>), bb3
+  cond_br undef, bb2, bb3
 
-bb2(%4 : $FakeOptional<Cls>):
-  br bb1(%4 : $FakeOptional<Cls>)
+bb2:
+  br bb1(%3 : $FakeOptional<Cls>)
 
 bb3:
   %5 = tuple()
@@ -466,10 +466,10 @@ bb2:
   br bb3
 
 bb3:
-  cond_br undef, bb4(%3 : $FakeOptional<Cls>), bb5
+  cond_br undef, bb4, bb5
 
-bb4(%4 : $FakeOptional<Cls>):
-  br bb1(%4 : $FakeOptional<Cls>)
+bb4:
+  br bb1(%3 : $FakeOptional<Cls>)
 
 bb5:
   %5 = tuple()
@@ -495,10 +495,10 @@ bb2:
   br bb3
 
 bb3:
-  cond_br undef, bb4(%3 : $FakeOptional<Cls>), bb5
+  cond_br undef, bb4, bb5
 
-bb4(%4 : $FakeOptional<Cls>):
-  br bb1(%4 : $FakeOptional<Cls>)
+bb4:
+  br bb1(%3 : $FakeOptional<Cls>)
 
 bb5:
   %5 = tuple()
@@ -524,10 +524,10 @@ bb2:
 bb3:
   release_value %1 : $FakeOptional<Cls>
   %3 = enum $FakeOptional<Cls>, #FakeOptional.some!enumelt, %2 : $Cls
-  cond_br undef, bb4(%3 : $FakeOptional<Cls>), bb5
+  cond_br undef, bb4, bb5
 
-bb4(%4 : $FakeOptional<Cls>):
-  br bb1(%4 : $FakeOptional<Cls>)
+bb4:
+  br bb1(%3 : $FakeOptional<Cls>)
 
 bb5:
   %5 = tuple()
@@ -553,10 +553,10 @@ bb3:
   retain_value %2 : $Cls
   release_value %1 : $FakeOptional<Cls>
   %3 = enum $FakeOptional<Cls>, #FakeOptional.some!enumelt, %2 : $Cls
-  cond_br undef, bb4(%3 : $FakeOptional<Cls>), bb5
+  cond_br undef, bb4, bb5
 
-bb4(%4 : $FakeOptional<Cls>):
-  br bb1(%4 : $FakeOptional<Cls>)
+bb4:
+  br bb1(%3 : $FakeOptional<Cls>)
 
 bb5:
   %5 = tuple()
@@ -582,10 +582,10 @@ bb2:
 bb3:
   release_value %1 : $FakeOptional<Cls>
   %3 = enum $FakeOptional<Cls>, #FakeOptional.some!enumelt, %2 : $Cls
-  cond_br undef, bb4(%3 : $FakeOptional<Cls>), bb5
+  cond_br undef, bb4, bb5
 
-bb4(%4 : $FakeOptional<Cls>):
-  br bb1(%4 : $FakeOptional<Cls>)
+bb4:
+  br bb1(%3 : $FakeOptional<Cls>)
 
 bb5:
   %5 = tuple()

--- a/test/SILOptimizer/common-subexpression-elimination.sil
+++ b/test/SILOptimizer/common-subexpression-elimination.sil
@@ -61,12 +61,15 @@ bb1:
   %2 = function_ref @random_counter : $@convention(thin) () -> Builtin.Int1
   %3 = apply %2() : $@convention(thin) () -> Builtin.Int1
   %4 = integer_literal $Builtin.Int64, 48
-  cond_br %3, bb1, bb2
+  cond_br %3, bb3, bb2
 
 bb2:
   %5 = integer_literal $Builtin.Int64, 59
   %6 = tuple()
   return %6 : $()
+
+bb3:
+  br bb1
 }
 
 // For now until the proper unreachable pruning code is committed for
@@ -136,7 +139,7 @@ bb0(%0 : $B):
 sil @removeTriviallyDeadCrossBasicBlocks : $@convention(thin) (@owned B, Builtin.Int1) -> () {
 bb0(%0: $B, %1: $Builtin.Int1):
   %5 = unchecked_ref_cast %0 : $B to $Builtin.NativeObject
-  cond_br %1, bb1, bb2
+  cond_br %1, bb1, bb3
 bb1:
   br bb2
 bb2:
@@ -145,6 +148,8 @@ bb2:
   %21 = unchecked_ref_cast %5 : $Builtin.NativeObject to $B
   %32 = tuple ()
   return %32 : $()
+bb3:
+  br bb2
 }
 
 // CHECK-LABEL: sil @dead_use_of_alloc_stack
@@ -635,13 +640,15 @@ bb0(%0 : $*D, %1 : $Builtin.Word):
 sil @cse_unchecked_ref_cast : $@convention(thin) (@owned B, Builtin.Int1) -> (Builtin.NativeObject, Builtin.NativeObject) {
 bb0(%0: $B, %1: $Builtin.Int1):
   %5 = unchecked_ref_cast %0 : $B to $Builtin.NativeObject
-  cond_br %1, bb1, bb2
+  cond_br %1, bb1, bb3
 bb1:
   br bb2
 bb2:
   %21 = unchecked_ref_cast %0 : $B to $Builtin.NativeObject
   %32 = tuple(%5 : $Builtin.NativeObject, %21 : $Builtin.NativeObject)
   return %32 : $(Builtin.NativeObject, Builtin.NativeObject)
+bb3:
+  br bb2
 }
 
 // CHECK-LABEL: sil @cse_raw_pointer_to_ref

--- a/test/SILOptimizer/constant_propagation.sil
+++ b/test/SILOptimizer/constant_propagation.sil
@@ -1248,7 +1248,7 @@ class AnObject {}
 
 sil @replace_unconditional_check_cast_failure : $@convention(thin) (Builtin.Int1, @guaranteed AnObject) -> (@out Value) {
 bb0(%2 : $*Value, %0 : $Builtin.Int1, %1 : $AnObject):
-  cond_br %0, bb1, bb2
+  cond_br %0, bb3, bb2
 
 bb1:
   %3 = tuple()
@@ -1262,6 +1262,9 @@ bb2:
   %32 = alloc_stack $AnObject
   dealloc_stack %32: $*AnObject
   dealloc_stack %31 : $*AnObject
+  br bb1
+
+bb3:
   br bb1
 }
 

--- a/test/SILOptimizer/cow_opts.sil
+++ b/test/SILOptimizer/cow_opts.sil
@@ -126,10 +126,12 @@ bb1(%a : $Str):
   (%u, %b) = begin_cow_mutation %as : $Buffer
   %e2 = end_cow_mutation %b : $Buffer
   %s2 = struct $Str (%e2: $Buffer)
-  cond_br undef, bb1(%s2 : $Str), bb2
+  cond_br undef, bb3, bb2
 bb2:
   %t = tuple (%u : $Builtin.Int1, %e2 : $Buffer)
   return %t : $(Builtin.Int1, Buffer)
+bb3:
+  br bb1(%s2 : $Str)
 }
 
 // CHECK-LABEL: sil @test_cond_br_condition
@@ -170,10 +172,12 @@ bb1(%a : $Str):
   (%u, %b) = begin_cow_mutation %as : $Buffer
   %e2 = end_cow_mutation %b : $Buffer
   %s2 = struct $Str (%e2: $Buffer)
-  cond_br undef, bb1(%s2 : $Str), bb2
+  cond_br undef, bb3, bb2
 bb2:
   %t = tuple (%u : $Builtin.Int1, %e2 : $Buffer)
   return %t : $(Builtin.Int1, Buffer)
+bb3:
+  br bb1(%s2 : $Str)
 }
 
 // CHECK-LABEL: sil @test_escape_in_loop
@@ -191,10 +195,12 @@ bb1(%a : $Buffer):
   (%u, %b) = begin_cow_mutation %a : $Buffer
   %e2 = end_cow_mutation %b : $Buffer
   apply %f(%e2) : $@convention(thin) (@guaranteed Buffer) -> ()
-  cond_br undef, bb1(%e2 : $Buffer), bb2
+  cond_br undef, bb3, bb2
 bb2:
   %t = tuple (%u : $Builtin.Int1, %e2 : $Buffer)
   return %t : $(Builtin.Int1, Buffer)
+bb3:
+  br bb1(%e2 : $Buffer)
 }
 
 // CHECK-LABEL: sil @test_escape_outside_loop
@@ -211,11 +217,13 @@ bb0(%0 : $Buffer):
 bb1(%a : $Buffer):
   (%u, %b) = begin_cow_mutation %a : $Buffer
   %e2 = end_cow_mutation %b : $Buffer
-  cond_br undef, bb1(%e2 : $Buffer), bb2
+  cond_br undef, bb3, bb2
 bb2:
   apply %f(%e2) : $@convention(thin) (@guaranteed Buffer) -> ()
   %t = tuple (%u : $Builtin.Int1, %e2 : $Buffer)
   return %t : $(Builtin.Int1, Buffer)
+bb3:
+  br bb1(%e2 : $Buffer)
 }
 
 // CHECK-LABEL: sil [ossa] @ossa_test_simple

--- a/test/SILOptimizer/cowarray_opt.sil
+++ b/test/SILOptimizer/cowarray_opt.sil
@@ -79,7 +79,10 @@ bb1:
   %6 = apply %5(%0) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   %7 = function_ref @array_end_mutation : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   %8 = apply %7(%0) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1a, bb2
+
+bb1a:
+  br bb1
 
 bb2:
   %r = tuple()
@@ -98,7 +101,7 @@ bb2:
 // CHECK:   release
 // CHECK:   apply [[MM]]([[ARRAY]]
 // CHECK:   apply [[EM]]([[ARRAY]]
-// CHECK:  cond_br {{.*}}, bb1
+// CHECK:  cond_br {{.*}}, bb2
 // CHECK: } // end sil function 'hoist_ignoring_paired_retain_release_and_hoist'
 sil @hoist_ignoring_paired_retain_release_and_hoist : $@convention(thin) (@inout MyArray<MyStruct>, @inout Builtin.Int1) -> () {
 bb0(%0 : $*MyArray<MyStruct>, %1 : $*Builtin.Int1):
@@ -114,7 +117,10 @@ bb1:
   %6 = apply %5(%0) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   %7 = function_ref @array_end_mutation : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   %8 = apply %7(%0) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
-  cond_br %3, bb1, bb2
+  cond_br %3, bb1a, bb2
+
+bb1a:
+  br bb1
 
 bb2:
   %r = tuple()
@@ -128,7 +134,7 @@ bb2:
 // CHECK: retain_value
 // CHECK: [[MM:%.*]] = function_ref @array_make_mutable
 // CHECK: apply [[MM]]
-// CHECK:  cond_br {{.*}}, bb1
+// CHECK:  cond_br {{.*}}, bb2
 sil @hoist_blocked_by_unpaired_retain_release_1 : $@convention(thin) (@inout MyArray<MyStruct>, @inout Builtin.Int1) -> () {
 bb0(%0 : $*MyArray<MyStruct>, %1 : $*Builtin.Int1):
   %2 = load %0 : $*MyArray<MyStruct>
@@ -142,7 +148,10 @@ bb1:
   %6 = apply %5(%0) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   %7 = function_ref @array_end_mutation : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   %8 = apply %7(%0) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
-  cond_br %3, bb1, bb2
+  cond_br %3, bb1a, bb2
+
+bb1a:
+  br bb1
 
 bb2:
   %r = tuple()
@@ -156,7 +165,7 @@ bb2:
 // CHECK: retain_value
 // CHECK: [[MM:%.*]] = function_ref @array_make_mutable
 // CHECK: apply [[MM]]
-// CHECK:  cond_br {{.*}}, bb1
+// CHECK:  cond_br {{.*}}, bb2
 sil @hoist_blocked_by_unpaired_retain_release_2 : $@convention(thin) (@inout MyArray<MyStruct>, @inout Builtin.Int1) -> () {
 bb0(%0 : $*MyArray<MyStruct>, %1 : $*Builtin.Int1):
   br bb1
@@ -175,7 +184,10 @@ bb1:
   %6 = apply %5(%0) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   %7 = function_ref @array_end_mutation : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   %8 = apply %7(%0) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
-  cond_br %3, bb1, bb2
+  cond_br %3, bb1a, bb2
+
+bb1a:
+  br bb1
 
 bb2:
   %r = tuple()
@@ -208,7 +220,10 @@ bb1:
   %6 = apply %5(%0) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   %7 = function_ref @array_end_mutation : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   %8 = apply %7(%0) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
-  cond_br %3, bb1, bb2
+  cond_br %3, bb1a, bb2
+
+bb1a:
+  br bb1
 
 bb2:
   %r = tuple()
@@ -244,7 +259,10 @@ bb3:
   br bb4(%p1 : $MyArray<MyStruct>)
 
 bb4(%p2 : $MyArray<MyStruct>):
-  cond_br undef, bb1(%p2 : $MyArray<MyStruct>), bb5(%p2 : $MyArray<MyStruct>)
+  cond_br undef, bb1a(%p2 : $MyArray<MyStruct>), bb5(%p2 : $MyArray<MyStruct>)
+
+bb1a(%p2a : $MyArray<MyStruct>):
+  br bb1(%p2a : $MyArray<MyStruct>)
 
 bb5(%p3 : $MyArray<MyStruct>):
   return %p3 : $MyArray<MyStruct>
@@ -283,7 +301,10 @@ bb1:
   %7 = function_ref @array_end_mutation : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   %8 = apply %7(%0) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   mark_dependence %1 : $*Builtin.Int1 on %99999 : $Builtin.NativeObject
-  cond_br %3, bb1, bb2
+  cond_br %3, bb1a, bb2
+
+bb1a:
+  br bb1
 
 bb2:
   %r = tuple()
@@ -320,7 +341,10 @@ bb1:
   %7 = function_ref @array_end_mutation : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   %8 = apply %7(%0) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   mark_dependence %1 : $*Builtin.Int1 on %2 : $MyArray<MyStruct>
-  cond_br %3, bb1, bb2
+  cond_br %3, bb1a, bb2
+
+bb1a:
+  br bb1
 
 bb2:
   %r = tuple()
@@ -359,7 +383,10 @@ bb1:
   mark_dependence %1 : $*Builtin.Int1 on %e : $Optional<MyArray<MyStruct>>
   %7 = function_ref @array_end_mutation : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   %8 = apply %7(%0) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
-  cond_br %3, bb1, bb2
+  cond_br %3, bb1a, bb2
+
+bb1a:
+  br bb1
 
 bb2:
   %r = tuple()
@@ -393,7 +420,10 @@ bb1:
   release_value %2 : $MyArray<MyStruct>
   apply %6(%1) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   apply %7(%1) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1a, bb2
+
+bb1a:
+  br bb1
 
 bb2:
   br bb3
@@ -407,7 +437,10 @@ bb3:
   release_value %2 : $MyArray<MyStruct>
   apply %6(%1) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   apply %7(%1) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
-  cond_br undef, bb4, bb3
+  cond_br undef, bb4, bb3a
+
+bb3a:
+  br bb3
 
 bb4:
   br bb5
@@ -421,7 +454,10 @@ bb5:
   release_value %2 : $MyArray<MyStruct>
   apply %6(%1) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   apply %7(%1) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
-  cond_br undef, bb5, bb6
+  cond_br undef, bb5a, bb6
+
+bb5a:
+  br bb5
 
 bb6:
   br bb7
@@ -435,7 +471,10 @@ bb7:
   release_value %2 : $MyArray<MyStruct>
   apply %6(%1) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   apply %7(%1) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
-  cond_br undef, bb7, bb8
+  cond_br undef, bb7a, bb8
+
+bb7a:
+  br bb7
 
 bb8:
   br bb9
@@ -450,7 +489,10 @@ bb9:
   release_value %2 : $MyArray<MyStruct>
   apply %6(%1) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   apply %7(%1) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
-  cond_br undef, bb9, bb10
+  cond_br undef, bb9a, bb10
+
+bb9a:
+  br bb9
 
 bb10:
   %r = tuple()
@@ -491,7 +533,10 @@ bb1:
   %13 = mark_dependence %1 : $*Builtin.Int1 on %12 : $Optional<MyArray<MyStruct>>
   %7 = function_ref @array_end_mutation : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   %8 = apply %7(%0) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
-  cond_br %l, bb1, bb2
+  cond_br %l, bb1a, bb2
+
+bb1a:
+  br bb1
 
 bb2:
   %15 = tuple ()
@@ -507,8 +552,10 @@ bb2:
 // CHECK: bb2:
 // CHECK-NOT: apply [[F]](
 // CHECK: bb3:
-// CHECK: apply [[F]](
+// CHECK-NOT: apply [[F]](
 // CHECK: bb4:
+// CHECK: apply [[F]](
+// CHECK: bb5:
 
 sil @cow_type_based_hoisting_retain_release_matching : $@convention(thin) (@guaranteed MyArrayContainer<MyStruct>, Builtin.NativeObject) -> () {
 bb0(%0 : $MyArrayContainer<MyStruct>, %00 : $Builtin.NativeObject):
@@ -531,7 +578,10 @@ bb1:
   release_value %2 : $MyArray<MyStruct>
   apply %6(%1) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   apply %9(%1) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1a, bb2
+
+bb1a:
+  br bb1
 
 bb2:
   br bb3
@@ -544,7 +594,10 @@ bb3:
   release_value %2 : $MyArray<MyStruct>
   apply %6(%1) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   apply %9(%1) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
-  cond_br undef, bb3, bb4
+  cond_br undef, bb3a, bb4
+
+bb3a:
+  br bb3
 
 bb4:
   %8 = tuple()
@@ -596,7 +649,10 @@ bb3:
   %6 = apply %5(%4) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   %7 = function_ref @array_end_mutation : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   %8 = apply %7(%4) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1a, bb2
+
+bb1a:
+  br bb1
 
 bb2:
   %r = tuple()
@@ -633,7 +689,10 @@ bb2:
   %6 = apply %5(%4) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   %7 = function_ref @array_end_mutation : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   %8 = apply %7(%4) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
-  cond_br undef, bb1, bb3
+  cond_br undef, bb1a, bb3
+
+bb1a:
+  br bb1
 
 bb3:
   %r = tuple()
@@ -667,7 +726,10 @@ bb3:
   %6 = apply %5(%4) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   %7 = function_ref @array_end_mutation : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   %8 = apply %7(%4) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1a, bb2
+
+bb1a:
+  br bb1
 
 bb2:
   %r = tuple()
@@ -697,7 +759,10 @@ bb1:
   %6 = apply %5(%3) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   %7 = function_ref @array_end_mutation : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   %8 = apply %7(%3) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1a, bb2
+
+bb1a:
+  br bb1
 
 bb2:
   %r = tuple()
@@ -743,7 +808,10 @@ bb1:
   %14 = function_ref @array_end_mutation : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   %15 = apply %14(%12) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   %16 = apply %14(%0) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1a, bb2
+
+bb1a:
+  br bb1
 
 bb2:
   %r = tuple()
@@ -789,7 +857,10 @@ bb1:
   %15 = apply %14(%12) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   %16 = apply %4(%0) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   %17 = apply %14(%0) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1a, bb2
+
+bb1a:
+  br bb1
 
 bb2:
   %r = tuple()
@@ -833,7 +904,10 @@ bb1:
   %14 = function_ref @array_end_mutation : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   %15 = apply %14(%12) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
   %17 = apply %14(%0) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1a, bb2
+
+bb1a:
+  br bb1
 
 bb2:
   %r = tuple()

--- a/test/SILOptimizer/cowarray_opt.sil
+++ b/test/SILOptimizer/cowarray_opt.sil
@@ -259,13 +259,13 @@ bb3:
   br bb4(%p1 : $MyArray<MyStruct>)
 
 bb4(%p2 : $MyArray<MyStruct>):
-  cond_br undef, bb1a(%p2 : $MyArray<MyStruct>), bb5(%p2 : $MyArray<MyStruct>)
+  cond_br undef, bb1a, bb5
 
-bb1a(%p2a : $MyArray<MyStruct>):
-  br bb1(%p2a : $MyArray<MyStruct>)
+bb1a:
+  br bb1(%p2 : $MyArray<MyStruct>)
 
-bb5(%p3 : $MyArray<MyStruct>):
-  return %p3 : $MyArray<MyStruct>
+bb5:
+  return %p2 : $MyArray<MyStruct>
 }
 
 // CHECK-LABEL: sil @cow_should_ignore_mark_dependence_addrproj_use : $@convention(thin) (@inout MyArray<MyStruct>, @inout Builtin.Int1) -> () {

--- a/test/SILOptimizer/dead_array_elim.sil
+++ b/test/SILOptimizer/dead_array_elim.sil
@@ -273,10 +273,13 @@ bb1:
   strong_retain %0 : $TrivialDestructor
   store %0 to %7 : $*TrivialDestructor
   strong_release %15 : $Builtin.BridgeObject
-  cond_br undef, bb1, bb2
+  cond_br undef, bb3, bb2
 
 bb2:
   %18 = tuple ()
   return %18 : $()
+
+bb3:
+  br bb1
 }
 

--- a/test/SILOptimizer/dead_code_elimination.sil
+++ b/test/SILOptimizer/dead_code_elimination.sil
@@ -117,7 +117,7 @@ bb4:
   %44 = struct_extract %43 : $Bool, #Bool._value
 // CHECK-NOT: cond_br
 // CHECK: br bb5
-  cond_br %44, bb5, bb6(%28 : $Int32)
+  cond_br %44, bb5, bbTrampoline1(%28 : $Int32)
 
 bb5:
   %46 = integer_literal $Builtin.Int32, 0
@@ -130,7 +130,7 @@ bb6(%49 : $Int32):
   %53 = builtin "cmp_eq_Int32"(%50 : $Builtin.Int32, %52 : $Builtin.Int32) : $Builtin.Int1
   %54 = struct $Bool (%53 : $Builtin.Int1)
   %55 = struct_extract %54 : $Bool, #Bool._value
-  cond_br %55, bb7, bb8(%29 : $Int32)
+  cond_br %55, bb7, bbTrampoline2(%29 : $Int32)
 
 bb7:
   %57 = integer_literal $Builtin.Int32, 0
@@ -182,6 +182,12 @@ bb10:
   %90 = tuple ()
 // CHECK: return
   return %90 : $()
+
+bbTrampoline1(%91 : $Int32):
+  br bb6(%91 : $Int32)
+
+bbTrampoline2(%92 : $Int32):
+  br bb8(%92 : $Int32)
 }
 
 sil @take_int32 : $@convention(thin) (Int32) -> ()

--- a/test/SILOptimizer/dead_code_elimination.sil
+++ b/test/SILOptimizer/dead_code_elimination.sil
@@ -117,7 +117,7 @@ bb4:
   %44 = struct_extract %43 : $Bool, #Bool._value
 // CHECK-NOT: cond_br
 // CHECK: br bb5
-  cond_br %44, bb5, bbTrampoline1(%28 : $Int32)
+  cond_br %44, bb5, bbTrampoline1
 
 bb5:
   %46 = integer_literal $Builtin.Int32, 0
@@ -130,7 +130,7 @@ bb6(%49 : $Int32):
   %53 = builtin "cmp_eq_Int32"(%50 : $Builtin.Int32, %52 : $Builtin.Int32) : $Builtin.Int1
   %54 = struct $Bool (%53 : $Builtin.Int1)
   %55 = struct_extract %54 : $Bool, #Bool._value
-  cond_br %55, bb7, bbTrampoline2(%29 : $Int32)
+  cond_br %55, bb7, bbTrampoline2
 
 bb7:
   %57 = integer_literal $Builtin.Int32, 0
@@ -183,11 +183,11 @@ bb10:
 // CHECK: return
   return %90 : $()
 
-bbTrampoline1(%91 : $Int32):
-  br bb6(%91 : $Int32)
+bbTrampoline1:
+  br bb6(%28 : $Int32)
 
-bbTrampoline2(%92 : $Int32):
-  br bb8(%92 : $Int32)
+bbTrampoline2:
+  br bb8(%29 : $Int32)
 }
 
 sil @take_int32 : $@convention(thin) (Int32) -> ()

--- a/test/SILOptimizer/dead_end_blocks.sil
+++ b/test/SILOptimizer/dead_end_blocks.sil
@@ -82,7 +82,7 @@ exit:
 sil @function_with_loop : $@convention(thin) () -> () {
 entry:
   specify_test "has_any_dead_ends"
-  cond_br undef, exit, loop
+  cond_br undef, exit, loopTrampoline
 
 loop:
   br loop
@@ -90,6 +90,9 @@ loop:
 exit:
   %retval = tuple ()
   return %retval : $()
+
+loopTrampoline:
+  br loop
 }
 
 // no dead ends – conditional branches but all paths return
@@ -99,7 +102,7 @@ exit:
 sil @branching_no_dead_ends : $@convention(thin) () -> () {
 entry:
   specify_test "has_any_dead_ends"
-  cond_br undef, then, else
+  cond_br undef, then, elseTrampoline
 
 then:
   br else
@@ -107,4 +110,7 @@ then:
 else:
   %retval2 = tuple ()
   return %retval2 : $()
+
+elseTrampoline:
+  br else
 }

--- a/test/SILOptimizer/dead_end_edges.sil
+++ b/test/SILOptimizer/dead_end_edges.sil
@@ -40,13 +40,14 @@ bb3:
 }
 
 // CHECK-LABEL: begin running test {{.*}} on one_dead_loop: dead_end_edges
-// CHECK-NEXT:  bb0 -> bb2 (region 0; last edge)
+// CHECK-NEXT:  bb0 -> bb4 (region 1; last edge)
+// CHECK-NEXT:  bb4 -> bb2 (region 0; last edge)
 // CHECK-NEXT:  visited all edges
 // CHECK-NEXT:  end running test {{.*}} on one_dead_loop: dead_end_edges
 sil @one_dead_loop : $@convention(thin) () -> () {
 bb0:
   specify_test "dead_end_edges"
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1, bb2Trampoline
 
 bb1:
   br bb3
@@ -57,17 +58,21 @@ bb2:
 bb3:
   %result = tuple ()
   return %result : $()
+
+bb2Trampoline:
+  br bb2
 }
 
 // CHECK-LABEL: begin running test {{.*}} on one_dead_loop_with_branch: dead_end_edges
-// CHECK-NEXT:  bb0 -> bb2 (region 1; last edge)
+// CHECK-NEXT:  bb0 -> bb6 (region 2; last edge)
 // CHECK-NEXT:  bb3 -> bb4 (region 0; last edge)
+// CHECK-NEXT:  bb6 -> bb2 (region 1; last edge)
 // CHECK-NEXT:  visited all edges
 // CHECK-NEXT:  end running test {{.*}} on one_dead_loop_with_branch: dead_end_edges
 sil @one_dead_loop_with_branch : $@convention(thin) () -> () {
 bb0:
   specify_test "dead_end_edges"
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1, bb2Trampoline0
 
 bb1:
   br bb5
@@ -76,7 +81,7 @@ bb2:
   br bb3
 
 bb3:
-  cond_br undef, bb2, bb4
+  cond_br undef, bb2Trampoline1, bb4
 
 bb4:
   unreachable
@@ -84,16 +89,27 @@ bb4:
 bb5:
   %result = tuple ()
   return %result : $()
+
+bb2Trampoline0:
+  br bb2
+
+bb2Trampoline1:
+  br bb2
 }
 
 // CHECK-LABEL: begin running test {{.*}} on complicated_one: dead_end_edges
-// CHECK-NEXT:  bb0 -> bb2 (region 2; last edge)
-// CHECK-NEXT:  bb2 -> bb3 (region 1; last edge)
-// CHECK-NEXT:  bb3 -> bb8 (region 0; more edges remain)
-// CHECK-NEXT:  bb5 -> bb8 (region 0; more edges remain)
-// CHECK-NEXT:  bb6 -> bb8 (region 0; more edges remain)
-// CHECK-NEXT:  bb9 -> bb8 (region 0; more edges remain)
-// CHECK-NEXT:  bb11 -> bb8 (region 0; last edge)
+// CHECK-NEXT:  bb0 -> bb2 (region 7; last edge)
+// CHECK-NEXT:  bb2 -> bb3 (region 6; last edge)
+// CHECK-NEXT:  bb3 -> bb13 (region 5; last edge)
+// CHECK-NEXT:  bb5 -> bb14 (region 3; last edge)
+// CHECK-NEXT:  bb6 -> bb16 (region 4; last edge)
+// CHECK-NEXT:  bb9 -> bb17 (region 1; last edge)
+// CHECK-NEXT:  bb11 -> bb19 (region 2; last edge)
+// CHECK-NEXT:  bb13 -> bb8 (region 0; more edges remain)
+// CHECK-NEXT:  bb14 -> bb8 (region 0; more edges remain)
+// CHECK-NEXT:  bb16 -> bb8 (region 0; more edges remain)
+// CHECK-NEXT:  bb17 -> bb8 (region 0; more edges remain)
+// CHECK-NEXT:  bb19 -> bb8 (region 0; last edge)
 // CHECK-NEXT:  visited all edges
 // CHECK-NEXT:  end running test {{.*}} on complicated_one: dead_end_edges
 sil @complicated_one : $@convention(thin) () -> () {
@@ -108,16 +124,16 @@ bb2:
   br bb3
 
 bb3:
-  cond_br undef, bb4, bb8
+  cond_br undef, bb4, bb8Trampoline1
 
 bb4:
   cond_br undef, bb5, bb6
 
 bb5:
-  cond_br undef, bb8, bb3
+  cond_br undef, bb8Trampoline2, bb3Trampoline1
 
 bb6:
-  cond_br undef, bb7, bb8
+  cond_br undef, bb7, bb8Trampoline3
 
 bb7:
   br bb3
@@ -126,17 +142,38 @@ bb8:
   unreachable
 
 bb9:
-  cond_br undef, bb8, bb10
+  cond_br undef, bb8Trampoline4, bb10
 
 bb10:
   cond_br undef, bb11, bb12
 
 bb11:
-  cond_br undef, bb9, bb8
+  cond_br undef, bb9Trampoline1, bb8Trampoline5
 
 bb12:
   %result = tuple ()
   return %result : $()
+
+bb8Trampoline1:
+  br bb8
+
+bb8Trampoline2:
+  br bb8
+
+bb3Trampoline1:
+  br bb3
+
+bb8Trampoline3:
+  br bb8
+
+bb8Trampoline4:
+  br bb8
+
+bb9Trampoline1:
+  br bb9
+
+bb8Trampoline5:
+  br bb8
 }
 
 // CHECK-LABEL: begin running test {{.*}} on trivial_dead_end: dead_end_edges

--- a/test/SILOptimizer/dead_store_elim.sil
+++ b/test/SILOptimizer/dead_store_elim.sil
@@ -364,7 +364,7 @@ bb0(%0 : $*Builtin.Int32):
   %1 = integer_literal $Builtin.Int32, 0
   %2 = integer_literal $Builtin.Int32, 1
   store %1 to %0 : $*Builtin.Int32
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1, bb3
 
 bb1:
   store %2 to %0 : $*Builtin.Int32
@@ -373,6 +373,9 @@ bb1:
 bb2:
   %9999 = tuple()
   return %9999 : $()
+
+bb3:
+  br bb2
 }
 
 // We cannot remove the local store as the debug_value w/ address value
@@ -887,7 +890,7 @@ bb2:
   %18 = struct_element_addr %2 : $*S1, #S1.a
   store %17 to %18 : $*Int
   %9 = struct_extract %0 : $Bool, #Bool.value
-  cond_br %9, bb1, bb3
+  cond_br %9, bb4, bb3
 
 bb3:
   %21 = integer_literal $Builtin.Int64, 2
@@ -897,6 +900,9 @@ bb3:
   %25 = tuple ()
   dealloc_stack %2 : $*S1
   return %25 : $()
+
+bb4:
+  br bb1
 }
 
 // Remove dead stores in loop blocks, as the store in exit block kills them.
@@ -930,7 +936,7 @@ bb2:
   %18 = struct_element_addr %2 : $*S1, #S1.a
   store %17 to %18 : $*Int
   %9 = struct_extract %0 : $Bool, #Bool.value
-  cond_br %9, bb1, bb3
+  cond_br %9, bb4, bb3
 
 bb3:
   %21 = integer_literal $Builtin.Int64, 2
@@ -940,6 +946,9 @@ bb3:
   %25 = tuple ()
   dealloc_stack %2 : $*S1
   return %25 : $()
+
+bb4:
+  br bb1
 }
 
 // Remove dead store in the tuple data structure.
@@ -1354,7 +1363,7 @@ bb0(%0 : $Bool, %1 : $Int):
 
 bb1:
   %12 = struct_extract %0 : $Bool, #Bool.value
-  cond_br %12, bb1, bb2
+  cond_br %12, bb3, bb2
 
 bb2:
   %14 = integer_literal $Builtin.Int64, 2
@@ -1364,6 +1373,9 @@ bb2:
   %18 = tuple ()
   dealloc_stack %2 : $*S1
   return %18 : $()
+
+bb3:
+  br bb1
 }
 
 // Make sure the load in bb1 prevents the store in bb0 to be eliminated. we have a bug
@@ -1493,13 +1505,16 @@ bb1(%2 : $foo):
   %6 = ref_element_addr %2 : $foo, #foo.a
   store %5 to %6 : $*Int
   %9 = alloc_ref $foo
-  cond_br undef, bb1(%9: $foo), bb2
+  cond_br undef, bb3, bb2
 
 bb2:
   %7 = ref_element_addr %2 : $foo, #foo.a
   store %5 to %7 : $*Int
   %14 = tuple ()
   return %14 : $()
+
+bb3:
+  br bb1(%9 : $foo)
 }
 
 // CHECK-LABEL: test_is_unique

--- a/test/SILOptimizer/deadendblocks_unit.sil
+++ b/test/SILOptimizer/deadendblocks_unit.sil
@@ -54,7 +54,7 @@ bb2:
 }
 
 // CHECK-LABEL: Function complex_cfg
-// CHECK:       [bb7,bb8,bb9]
+// CHECK:       [bb7,bb8,bb9,bb10]
 // CHECK:       end function complex_cfg
 sil @complex_cfg : $@convention(thin) () -> ((), @error any Error) {
 bb0:
@@ -77,8 +77,10 @@ bb6:
 bb7:
   br bb8
 bb8:
-  cond_br undef, bb8, bb9
+  cond_br undef, bb10, bb9
 bb9:
   unreachable
+bb10:
+  br bb8
 }
 

--- a/test/SILOptimizer/diagnose_unreachable.sil
+++ b/test/SILOptimizer/diagnose_unreachable.sil
@@ -13,10 +13,12 @@ case some(T)
 sil private @test1 : $() -> () {
 bb0:
   %5 = integer_literal $Builtin.Int1, 1
-  cond_br %5, bb1, bb2
+  cond_br %5, bb1, bb2a
 bb1:                                              // Preds: bb0
   br bb2
-bb2:                                              // Preds: bb1 bb0
+bb2a:                                             // Preds: bb0
+  br bb2
+bb2:                                              // Preds: bb1 bb2a
   %9 = tuple ()
   return %9 : $()
 }
@@ -33,10 +35,12 @@ bb2:                                              // Preds: bb1 bb0
 sil @test2 : $@convention(thin) () -> () {
 bb0:
   %11 = integer_literal $Builtin.Int1, 0
-  cond_br %11, bb1, bb2
+  cond_br %11, bb1, bb2a
 bb1:                                              // Preds: bb0
   br bb2
-bb2:                                              // Preds: bb1 bb0
+bb2a:                                             // Preds: bb0
+  br bb2
+bb2:                                              // Preds: bb1 bb2a
   %32 = tuple ()
   return %32 : $()
 }
@@ -44,6 +48,8 @@ bb2:                                              // Preds: bb1 bb0
 // CHECK: bb0:
 // CHECK-NEXT:  br bb1
 // CHECK:bb1:                                              // Preds: bb0
+// CHECK-NEXT:  br bb2
+// CHECK:bb2:                                              // Preds: bb1
 // CHECK-NEXT:  tuple ()
 // CHECK-NEXT:  return
 // CHECK-NEXT: }
@@ -166,9 +172,11 @@ sil @removeTriviallyDeadButUsedByUnreachableBlock : $@convention(thin) (@owned B
 bb0(%0 : $B):
   %5 = unchecked_ref_cast %0 : $B to $Builtin.NativeObject  // CHECK-NOT: unchecked_ref_cast
   %11 = integer_literal $Builtin.Int1, 0          // CHECK-NOT: integer_literal
-  cond_br %11, bb1, bb2                  // CHECK: br
+  cond_br %11, bb1, bb2a                 // CHECK: br
 bb1:
   %21 = unchecked_ref_cast %5 : $Builtin.NativeObject to $B // CHECK-NOT: unchecked_ref_cast
+  br bb2
+bb2a:
   br bb2
 bb2:
   %32 = tuple ()
@@ -179,8 +187,10 @@ bb2:
 sil @removeTriviallyDeadCrossBasicBlocks : $@convention(thin) (@owned B, Builtin.Int1) -> () {
 bb0(%0:  $B, %1: $Builtin.Int1):
   %5 = unchecked_ref_cast %0 : $B to $Builtin.NativeObject     // CHECK-NOT: unchecked_ref_cast
-  cond_br %1, bb1, bb2                   // CHECK: cond_br
+  cond_br %1, bb1, bb2a                   // CHECK: cond_br
 bb1:
+  br bb2
+bb2a:
   br bb2
 bb2:
   %9 = function_ref @exit : $@convention(thin) () -> Never
@@ -234,10 +244,12 @@ sil @code_removed_after_a_call_to_noreturn : $@convention(thin) (Int, Builtin.In
 bb0(%0 : $Int, %1 : $Builtin.Int1):
   %6 = function_ref @exit : $@convention(thin) () -> Never
   %7 = apply %6() : $@convention(thin) () -> Never
-  cond_br %1, bb1, bb2
+  cond_br %1, bb1, bb2a
 bb1:                                              // Preds: bb0
   br bb2
-bb2:                                              // Preds: bb1 bb0
+bb2a:                                             // Preds: bb0
+  br bb2
+bb2:                                              // Preds: bb1 bb2a
   %20 = tuple ()                                  // user: %21
   return %20 : $()
 }

--- a/test/SILOptimizer/diagnose_unreachable.sil
+++ b/test/SILOptimizer/diagnose_unreachable.sil
@@ -203,11 +203,11 @@ bb2:
 sil @testCondBranchBBArgs : $@convention(thin) (Int, Int) -> Int {
 bb0(%0 : $Int, %1 : $Int):
   %2 = integer_literal $Builtin.Int1, 0
-  cond_br %2, bb1(%0 : $Int), bb2(%1 : $Int)
-bb1(%3 : $Int):
-  br bb3(%3 : $Int)
-bb2(%4 : $Int):
-  br bb3(%4 : $Int)
+  cond_br %2, bb1, bb2
+bb1:
+  br bb3(%0 : $Int)
+bb2:
+  br bb3(%1 : $Int)
 bb3(%5 : $Int):
   return %5 : $Int
 }
@@ -223,11 +223,11 @@ bb3(%5 : $Int):
 sil @removePredecessorWithBBArgs : $@convention(thin) (Int, Int) -> Int {
 bb0(%0 : $Int, %1 : $Int):
  %2 = integer_literal $Builtin.Int1, 0
- cond_br %2, bb2(%0 : $Int), bb3(%1 : $Int)
-bb2(%4 : $Int):
- br bb4(%4 : $Int)
-bb3(%5 : $Int):
-  br bb4(%5 : $Int)
+ cond_br %2, bb2, bb3
+bb2:
+ br bb4(%0 : $Int)
+bb3:
+  br bb4(%1 : $Int)
 bb4(%6 : $Int):
   return %6 : $Int
 }

--- a/test/SILOptimizer/earlycodemotion.sil
+++ b/test/SILOptimizer/earlycodemotion.sil
@@ -344,12 +344,9 @@ bb3:
 // CHECK-NEXT: function_ref blocker
 // CHECK-NEXT: function_ref @blocker
 // CHECK-NEXT: cond_br
-// CHECK: bb1:
-// CHECK: bb2:
-// CHECK-NEXT: select_enum
+// CHECK-NOT: retain_value
+// CHECK: select_enum
 // CHECK-NEXT: cond_br
-// CHECK: bb3:
-// CHECK-NOT: unchecked_enum_data
 // CHECK-NOT: retain_value
 // CHECK-LABEL: } // end sil function 'sink_ref_count_ops_enum_over_select_enum_2'
 sil @sink_ref_count_ops_enum_over_select_enum_2 : $@convention(thin) (Optional<Builtin.Int32>) -> () {
@@ -357,12 +354,12 @@ bb0(%0 : $Optional<Builtin.Int32>):
   %t = integer_literal $Builtin.Int1, 1
   %f = integer_literal $Builtin.Int1, 0
   %1 = function_ref @blocker : $@convention(thin) () -> ()
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1, bb5
 
 bb1:
   retain_value %0 : $Optional<Builtin.Int32>
   %100 = select_enum %0 : $Optional<Builtin.Int32>, case #Optional.some!enumelt: %t, case #Optional.none!enumelt: %f : $Builtin.Int1
-  cond_br %100, bb2, bb3
+  cond_br %100, bb6, bb3
 
 bb2:
   br bb4
@@ -373,6 +370,12 @@ bb3:
 bb4:
   %2 = tuple()
   return %2 : $()
+
+bb5:
+  br bb2
+
+bb6:
+  br bb2
 }
 
 // CHECK-LABEL: sil @sink_ref_count_ops_enum_over_select_enum_3 : $@convention(thin) (Optional<Builtin.Int32>) -> () {
@@ -382,11 +385,9 @@ bb4:
 // CHECK-NEXT: function_ref blocker
 // CHECK-NEXT: function_ref @blocker
 // CHECK-NEXT: cond_br
-// CHECK: bb2:
 // CHECK-NOT: retain_value
-// CHECK-NEXT: select_enum
+// CHECK: select_enum
 // CHECK-NEXT: cond_br
-// CHECK-NOT: unchecked_enum_data
 // CHECK-NOT: retain_value
 // CHECK-LABEL: } // end sil function 'sink_ref_count_ops_enum_over_select_enum_3'
 sil @sink_ref_count_ops_enum_over_select_enum_3 : $@convention(thin) (Optional<Builtin.Int32>) -> () {
@@ -394,12 +395,12 @@ bb0(%0 : $Optional<Builtin.Int32>):
   %t = integer_literal $Builtin.Int1, 1
   %f = integer_literal $Builtin.Int1, 0
   %1 = function_ref @blocker : $@convention(thin) () -> ()
-  cond_br undef, bb1, bb3
+  cond_br undef, bb1, bb5
 
 bb1:
   retain_value %0 : $Optional<Builtin.Int32>
   %100 = select_enum %0 : $Optional<Builtin.Int32>, case #Optional.some!enumelt: %t, case #Optional.none!enumelt: %f : $Builtin.Int1
-  cond_br %100, bb2, bb3
+  cond_br %100, bb2, bb6
 
 bb2:
   br bb4
@@ -410,6 +411,12 @@ bb3:
 bb4:
   %2 = tuple()
   return %2 : $()
+
+bb5:
+  br bb3
+
+bb6:
+  br bb3
 }
 
 // CHECK-LABEL: sil @sink_ref_count_ops_enum_over_select_enum_4 : $@convention(thin) (Optional<Builtin.NativeObject>, Optional<Builtin.NativeObject>) -> Optional<Builtin.NativeObject> {
@@ -814,7 +821,7 @@ bb3:
 // CHECK-LABEL: sil @enum_simplification_test8 : $@convention(thin) (Optional<Builtin.NativeObject>) -> () {
 // CHECK: bb0([[INPUT:%[0-9]+]] : $Optional<Builtin.NativeObject>):
 // CHECK-NOT: retain_value [[INPUT]]
-// CHECK: bb2:
+// CHECK: bb1:
 // CHECK-NEXT: [[PAYLOAD:%[0-9]+]] = unchecked_enum_data [[INPUT]]
 // CHECK-NOT: strong_retain
 // CHECK-NOT: retain_value
@@ -822,11 +829,11 @@ bb3:
 // CHECK: retain_value [[INPUT]]
 sil @enum_simplification_test8 : $@convention(thin) (Optional<Builtin.NativeObject>) -> () {
 bb0(%0 : $Optional<Builtin.NativeObject>):
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1, bb5
 
 bb1:
   %1 = unchecked_enum_data %0 : $Optional<Builtin.NativeObject>, #Optional.some!enumelt
-  cond_br undef, bb2, bb3
+  cond_br undef, bb6, bb3
 
 bb2:
   retain_value %0 : $Optional<Builtin.NativeObject>
@@ -840,6 +847,12 @@ bb4:
   retain_value %0 : $Optional<Builtin.NativeObject>
   %9999 = tuple()
   return %9999 : $()
+
+bb5:
+  br bb2
+
+bb6:
+  br bb2
 }
 
 // CHECK-LABEL: sil @enum_simplification_test9 : $@convention(thin) (Optional<Builtin.NativeObject>) -> () {
@@ -922,7 +935,7 @@ bb1:
 // Single BB Loop
 bb2:
   retain_value %0 : $Optional<Builtin.NativeObject>
-  cond_br undef, bb2, bb9999
+  cond_br undef, bb10, bb11
 
 bb3:
   br bb4
@@ -935,12 +948,24 @@ bb4:
 
 bb5:
   retain_value %0 : $Optional<Builtin.NativeObject>
-  cond_br undef, bb4, bb9999
+  cond_br undef, bb12, bb13
 
 bb9999:
   retain_value %0 : $Optional<Builtin.NativeObject>
   %9999 = tuple()
   return %9999 : $()
+
+bb10:
+  br bb2
+
+bb11:
+  br bb9999
+
+bb12:
+  br bb4
+
+bb13:
+  br bb9999
 }
 
 // Make sure we don't propagate state out of loops.
@@ -960,7 +985,7 @@ bb2:
 
 bb3:
   retain_value %0 : $Optional<Builtin.NativeObject>
-  cond_br undef, bb3, bb4
+  cond_br undef, bb6, bb4
 
 bb4:
   br bb5
@@ -969,6 +994,9 @@ bb5:
   retain_value %0 : $Optional<Builtin.NativeObject>
   %9999 = tuple()
   return %9999 : $()
+
+bb6:
+  br bb3
 }
 
 // CHECK-LABEL: sil @enum_simplification_test14 : $@convention(thin) (Either) -> () {
@@ -1418,7 +1446,10 @@ bb2(%4 : $X):
 //CHECK-LABEL: @cond_branch0
 sil @cond_branch0: $@convention(thin) (@owned X) -> Int {
 bb0(%0 : $X):
-  cond_br undef, bb1(%0 : $X), bb2(%0 : $X)
+  cond_br undef, bb4, bb1(%0 : $X)
+
+bb4:
+  br bb2(%0 : $X)
 
 bb1(%1 : $X):
   //CHECK: strong_release %0

--- a/test/SILOptimizer/earlycodemotion.sil
+++ b/test/SILOptimizer/earlycodemotion.sil
@@ -1446,21 +1446,21 @@ bb2(%4 : $X):
 //CHECK-LABEL: @cond_branch0
 sil @cond_branch0: $@convention(thin) (@owned X) -> Int {
 bb0(%0 : $X):
-  cond_br undef, bb4, bb1(%0 : $X)
+  cond_br undef, bb4, bb1
 
 bb4:
   br bb2(%0 : $X)
 
-bb1(%1 : $X):
+bb1:
   //CHECK: strong_release %0
-  strong_release %1 : $X
-  br bb2(%1 : $X)
+  strong_release %0 : $X
+  br bb2(%0 : $X)
 
 bb2(%4 : $X):
   br bb3(%4 : $X)
 
 bb3(%6 : $X):
-  //CHECK: strong_release %6
+  //CHECK: strong_release %5
   strong_release %6 : $X
   br bb3(%6 : $X)
 }

--- a/test/SILOptimizer/enum_jump_thread.sil
+++ b/test/SILOptimizer/enum_jump_thread.sil
@@ -25,7 +25,7 @@ bb0(%0 : $Builtin.Int1, %1 : $Builtin.Int1):
 
 bb1:
   %2 = enum $E, #E.A!enumelt
-  cond_br %1, bb2, bb3(%2 : $E)
+  cond_br %1, bb2, bb6
 
 // CHECK: [[ENUM1:%[0-9]+]] = enum $E, #E.B
 // CHECK-NEXT: [[ENUM2:%[0-9]+]] = enum $E2, #E2.Y!enumelt, [[ENUM1]]
@@ -47,6 +47,9 @@ bb4:
 // CHECK-NEXT: return
 bb5(%7 : $E2):
   return %7 : $E2
+
+bb6:
+  br bb3(%2 : $E)
 }
 
 // CHECK-LABEL: sil @test_enum_addr

--- a/test/SILOptimizer/epilogue_release_dumper.sil
+++ b/test/SILOptimizer/epilogue_release_dumper.sil
@@ -305,11 +305,11 @@ bb1(%1 : $foo):
 // CHECK: END: sil @single_release_foo_with_silargument_multiple_incoming_values
 sil @single_release_foo_with_silargument_multiple_incoming_values : $@convention(thin) (@owned foo, @owned foo) -> () {
 bb0(%0 : $foo, %8 : $foo):
-  cond_br undef, bb1(%0: $foo), bb2(%8 : $foo)
-bb1(%1 : $foo):
-  br bb3(%1 : $foo)
-bb2(%2 : $foo):
-  br bb3( %2 : $foo)
+  cond_br undef, bb1, bb2
+bb1:
+  br bb3(%0 : $foo)
+bb2:
+  br bb3(%8 : $foo)
 bb3(%3 : $foo):
   strong_release %3 : $foo
   %4 = tuple ()
@@ -362,11 +362,11 @@ bb1(%1 : $foo):
 // CHECK: END: sil @single_retain_foo_with_silargument_multiple_incoming_values
 sil @single_retain_foo_with_silargument_multiple_incoming_values : $@convention(thin) (@owned foo, @owned foo) -> @owned foo {
 bb0(%0 : $foo, %8 : $foo):
-  cond_br undef, bb1(%0: $foo), bb2(%8 : $foo)
-bb1(%1 : $foo):
-  br bb3(%1 : $foo)
-bb2(%2 : $foo):
-  br bb3( %2 : $foo)
+  cond_br undef, bb1, bb2
+bb1:
+  br bb3(%0 : $foo)
+bb2:
+  br bb3(%8 : $foo)
 bb3(%3 : $foo):
   strong_retain %3 : $foo
   return %0 : $foo
@@ -392,13 +392,13 @@ bb0(%0 : $boo):
 // CHECK: END: sil @epilogue_retains_in_split_block
 sil @epilogue_retains_in_split_block : $@convention(thin) (@owned foo) -> @owned foo {
 bb0(%0 : $foo):
-  cond_br undef, bb1(%0: $foo), bb2(%0 : $foo)
-bb1(%1 : $foo):
-  strong_retain %1 : $foo
-  br bb3(%1 : $foo)
-bb2(%2 : $foo):
-  strong_retain %2 : $foo
-  br bb3( %2 : $foo)
+  cond_br undef, bb1, bb2
+bb1:
+  strong_retain %0 : $foo
+  br bb3(%0 : $foo)
+bb2:
+  strong_retain %0 : $foo
+  br bb3(%0 : $foo)
 bb3(%3 : $foo):
   return %0 : $foo
 }
@@ -409,11 +409,11 @@ bb3(%3 : $foo):
 sil @epilogue_retains_in_diamond_top_block : $@convention(thin) (@owned foo) -> @owned foo {
 bb0(%0 : $foo):
   strong_retain %0 : $foo
-  cond_br undef, bb1(%0: $foo), bb2(%0 : $foo)
-bb1(%1 : $foo):
-  br bb3(%1 : $foo)
-bb2(%2 : $foo):
-  br bb3( %2 : $foo)
+  cond_br undef, bb1, bb2
+bb1:
+  br bb3(%0 : $foo)
+bb2:
+  br bb3(%0 : $foo)
 bb3(%3 : $foo):
   return %0 : $foo
 }
@@ -424,12 +424,12 @@ bb3(%3 : $foo):
 sil @epilogue_retains_in_diamond_top_and_left_split_block : $@convention(thin) (@owned foo) -> @owned foo {
 bb0(%0 : $foo):
   strong_retain %0 : $foo
-  cond_br undef, bb1(%0: $foo), bb2(%0 : $foo)
-bb1(%1 : $foo):
-  strong_retain %1 : $foo
-  br bb3(%1 : $foo)
-bb2(%2 : $foo):
-  br bb3( %2 : $foo)
+  cond_br undef, bb1, bb2
+bb1:
+  strong_retain %0 : $foo
+  br bb3(%0 : $foo)
+bb2:
+  br bb3(%0 : $foo)
 bb3(%3 : $foo):
   return %0 : $foo
 }

--- a/test/SILOptimizer/escape_info_unit.sil
+++ b/test/SILOptimizer/escape_info_unit.sil
@@ -265,11 +265,14 @@ bb7(%22 : $LinkedNode):
   store %1 to %23 : $*X
   %25 = ref_element_addr %22 : $LinkedNode, #LinkedNode.next
   %26 = load %25 : $*LinkedNode
-  cond_br undef, bb7(%26 : $LinkedNode), bb8
+  cond_br undef, bb9, bb8
 
 bb8:
   %28 = tuple ()
   return %28 : $()
+
+bb9:
+  br bb7(%26 : $LinkedNode)
 }
 
 // CHECK-LABEL: Escape information for callee_may_store_to_non_escaping_argument:

--- a/test/SILOptimizer/existential_type_propagation.sil
+++ b/test/SILOptimizer/existential_type_propagation.sil
@@ -135,7 +135,7 @@ bb0:
   %7 = struct $Int64 (%6 : $Builtin.Int64)
   %8 = struct $X (%7 : $Int64)
   store %8 to %3 : $*X
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1, bb3
 
 bb1:
   br bb2
@@ -147,6 +147,9 @@ bb2:
   destroy_addr %2 : $*P
   dealloc_stack %2 : $*P
   return %12 : $Int64
+
+bb3:
+  br bb2
 }
 
 // CHECK-LABEL: sil @existential_is_overwritten_by_store

--- a/test/SILOptimizer/fixed_storage_bounds_check_hoisting.sil
+++ b/test/SILOptimizer/fixed_storage_bounds_check_hoisting.sil
@@ -275,7 +275,7 @@ bb0(%0 : $*Span<Int>):
   %count_struct = apply %get_count_fn(%0) : $@convention(method) (@in_guaranteed Span<Int>) -> Int
   %count = struct_extract %count_struct, #Int._value
   %is_zero = builtin "cmp_eq_Int64"(%zero : $Builtin.Int64, %count : $Builtin.Int64) : $Builtin.Int1
-  cond_br %is_zero, bb3, bb1
+  cond_br %is_zero, bb6, bb1
 
 bb1:
   br bb2(%zero : $Builtin.Int64)
@@ -293,7 +293,16 @@ bb2(%i : $Builtin.Int64):
   %inc = builtin "sadd_with_overflow_Int64"(%i : $Builtin.Int64, %one : $Builtin.Int64, %no_trap : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
   %next = tuple_extract %inc : $(Builtin.Int64, Builtin.Int1), 0
   %done = builtin "cmp_eq_Int64"(%next : $Builtin.Int64, %count : $Builtin.Int64) : $Builtin.Int1
-  cond_br %done, bb3, bb2(%next : $Builtin.Int64)
+  cond_br %done, bb5, bb4
+
+bb4:
+  br bb2(%next : $Builtin.Int64)
+
+bb5:
+  br bb3
+
+bb6:
+  br bb3
 
 bb3:
   %t = tuple ()
@@ -315,7 +324,7 @@ bb0(%0 : $*Span<Int>):
   %count_struct = apply %get_count_fn(%0) : $@convention(method) (@in_guaranteed Span<Int>) -> Int
   %count = struct_extract %count_struct, #Int._value
   %is_zero = builtin "cmp_eq_Int64"(%zero : $Builtin.Int64, %count : $Builtin.Int64) : $Builtin.Int1
-  cond_br %is_zero, bb3, bb1
+  cond_br %is_zero, bb6, bb1
 
 bb1:
   br bb2(%zero : $Builtin.Int64)
@@ -335,7 +344,16 @@ bb2(%i : $Builtin.Int64):
   %inc = builtin "sadd_with_overflow_Int64"(%i : $Builtin.Int64, %one : $Builtin.Int64, %no_trap : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
   %next = tuple_extract %inc : $(Builtin.Int64, Builtin.Int1), 0
   %done = builtin "cmp_eq_Int64"(%next : $Builtin.Int64, %count : $Builtin.Int64) : $Builtin.Int1
-  cond_br %done, bb3, bb2(%next : $Builtin.Int64)
+  cond_br %done, bb5, bb4
+
+bb4:
+  br bb2(%next : $Builtin.Int64)
+
+bb5:
+  br bb3
+
+bb6:
+  br bb3
 
 bb3:
   %t = tuple ()

--- a/test/SILOptimizer/functionsigopts.sil
+++ b/test/SILOptimizer/functionsigopts.sil
@@ -1175,7 +1175,7 @@ bb0(%0 : $Builtin.Int1, %1 : $Builtin.NativeObject):
 
   %9999 = function_ref @user : $@convention(thin) (Builtin.NativeObject) -> ()
   apply %9999(%1) : $@convention(thin) (Builtin.NativeObject) -> ()
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1, bb3
 
 bb1:
   br bb2
@@ -1184,6 +1184,9 @@ bb2:
   strong_release %1 : $Builtin.NativeObject
   %2 = tuple()
   return %2 : $()
+
+bb3:
+  br bb2
 }
 
 // In this case the release is not in the exit, so we cannot specialize.
@@ -1217,7 +1220,7 @@ bb0(%0 : $Builtin.NativeObject):
   %c22 = builtin "assert_configuration"() : $Builtin.Int32
 
   strong_release %0 : $Builtin.NativeObject
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1, bb3
 
 bb1:
   br bb2
@@ -1225,6 +1228,9 @@ bb1:
 bb2:
   %1 = tuple()
   return %1 : $()
+
+bb3:
+  br bb2
 }
 
 // CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [heuristic_always_inline] @owned_to_guaranteed_simple_singlebb_multiple_arg_callee : $@convention(thin) (Builtin.Int1, @owned Builtin.NativeObject, Builtin.Int1) -> () {
@@ -1264,10 +1270,10 @@ bb0(%0 : $Builtin.Int1, %1 : $Builtin.NativeObject, %2 : $Builtin.Int1):
 
   %9999 = function_ref @user : $@convention(thin) (Builtin.NativeObject) -> ()
   apply %9999(%1) : $@convention(thin) (Builtin.NativeObject) -> ()
-  cond_br %0, bb1, bb2
+  cond_br %0, bb1, bb4
 
 bb1:
-  cond_br %2, bb2, bb3
+  cond_br %2, bb5, bb6
 
 bb2:
   br bb3
@@ -1276,6 +1282,15 @@ bb3:
   release_value %1 : $Builtin.NativeObject
   %3 = tuple()
   return %3 : $()
+
+bb4:
+  br bb2
+
+bb5:
+  br bb2
+
+bb6:
+  br bb3
 }
 
 // CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [heuristic_always_inline] @owned_to_guaranteed_multibb_callee_with_release_in_exit_two_args_1 : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
@@ -1311,7 +1326,7 @@ bb0(%0 : $Builtin.NativeObject, %1 : $Builtin.NativeObject):
   %9999 = function_ref @user : $@convention(thin) (Builtin.NativeObject) -> ()
   apply %9999(%1) : $@convention(thin) (Builtin.NativeObject) -> ()
   apply %9999(%0) : $@convention(thin) (Builtin.NativeObject) -> ()
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1, bb3
 
 bb1:
   br bb2
@@ -1321,6 +1336,9 @@ bb2:
   strong_release %0 : $Builtin.NativeObject
   %2 = tuple()
   return %2 : $()
+
+bb3:
+  br bb2
 }
 
 // CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [heuristic_always_inline] @owned_to_guaranteed_multibb_callee_with_release_in_exit_two_args_2 : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
@@ -1358,7 +1376,7 @@ bb0(%0 : $Builtin.NativeObject, %1 : $Builtin.NativeObject):
   apply %9999(%1) : $@convention(thin) (Builtin.NativeObject) -> ()
   %2 = function_ref @create_object : $@convention(thin) () -> Builtin.NativeObject
   %3 = apply %2() : $@convention(thin) () -> Builtin.NativeObject
-  cond_br undef, bb1(%3 : $Builtin.NativeObject), bb2(%3 : $Builtin.NativeObject)
+  cond_br undef, bb1(%3 : $Builtin.NativeObject), bb3(%3 : $Builtin.NativeObject)
 
 bb1(%4 : $Builtin.NativeObject):
   br bb2(%4 : $Builtin.NativeObject)
@@ -1369,6 +1387,9 @@ bb2(%5 : $Builtin.NativeObject):
   strong_release %1 : $Builtin.NativeObject
   %6 = tuple()
   return %6 : $()
+
+bb3(%7 : $Builtin.NativeObject):
+  br bb2(%7 : $Builtin.NativeObject)
 }
 
 // CHECK-LABEL: sil [serialized] @owned_to_guaranteed_simple_singlebb_multiple_arg_caller : $@convention(thin) (Builtin.NativeObject, Builtin.NativeObject) -> () {
@@ -1911,12 +1932,14 @@ bb0(%0 : @noImplicitCopy $*T):
 // CHECK:  function_ref user
 // CHECK:  function_ref @user
 // CHECK:  apply
-// CHECK:  cond_br undef, bb1, bb2
+// CHECK:  cond_br undef, bb1, bb3
 // CHECK: bb1:
 // CHECK-NEXT:  br bb2
 // CHECK: bb2:
 // CHECK-NEXT:  tuple
 // CHECK-NEXT:  return
+// CHECK: bb3:
+// CHECK-NEXT:  br bb2
 
 
 // Check that we have remove the array semantic attribute from the specialized

--- a/test/SILOptimizer/functionsigopts.sil
+++ b/test/SILOptimizer/functionsigopts.sil
@@ -1376,10 +1376,10 @@ bb0(%0 : $Builtin.NativeObject, %1 : $Builtin.NativeObject):
   apply %9999(%1) : $@convention(thin) (Builtin.NativeObject) -> ()
   %2 = function_ref @create_object : $@convention(thin) () -> Builtin.NativeObject
   %3 = apply %2() : $@convention(thin) () -> Builtin.NativeObject
-  cond_br undef, bb1(%3 : $Builtin.NativeObject), bb3(%3 : $Builtin.NativeObject)
+  cond_br undef, bb1, bb3
 
-bb1(%4 : $Builtin.NativeObject):
-  br bb2(%4 : $Builtin.NativeObject)
+bb1:
+  br bb2(%3 : $Builtin.NativeObject)
 
 bb2(%5 : $Builtin.NativeObject):
   strong_release %5 : $Builtin.NativeObject
@@ -1388,8 +1388,8 @@ bb2(%5 : $Builtin.NativeObject):
   %6 = tuple()
   return %6 : $()
 
-bb3(%7 : $Builtin.NativeObject):
-  br bb2(%7 : $Builtin.NativeObject)
+bb3:
+  br bb2(%3 : $Builtin.NativeObject)
 }
 
 // CHECK-LABEL: sil [serialized] @owned_to_guaranteed_simple_singlebb_multiple_arg_caller : $@convention(thin) (Builtin.NativeObject, Builtin.NativeObject) -> () {

--- a/test/SILOptimizer/inlinearray_bounds_check_tests.swift
+++ b/test/SILOptimizer/inlinearray_bounds_check_tests.swift
@@ -316,7 +316,7 @@ public func local_inlinearray_repeating_init_sum_iterate_to_count_trap_spl() -> 
 
 // TODO: To support hoisting bounds checks of mutable InlineArray, we should prove it's not rewritten within the loop.
 // CHECK-SIL-LABEL: sil @$s30inlinearray_bounds_check_tests0A11_inc_by_oneyys11InlineArrayVyxSiGz_SitSiRVzlF :
-// CHECK-SIL: bb3({{.*}}):
+// CHECK-SIL: bb{{[0-9]+}}({{.*}}):
 // TODO-CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_br
 public func inlinearray_inc_by_one<let N: Int>(_ v: inout InlineArray<N, Int>, _ n: Int) {

--- a/test/SILOptimizer/latecodemotion.sil
+++ b/test/SILOptimizer/latecodemotion.sil
@@ -520,12 +520,10 @@ bb3:
 // CHECK-NEXT: function_ref blocker
 // CHECK-NEXT: function_ref @blocker
 // CHECK-NEXT: cond_br
+// CHECK-NOT: retain_value
 // CHECK: bb1:
-// CHECK-NEXT: br bb4
-// CHECK: bb2:
 // CHECK-NEXT: select_enum
 // CHECK-NEXT: cond_br
-// CHECK-NOT: unchecked_enum_data
 // CHECK-NOT: retain_value
 // CHECK-LABEL: } // end sil function 'sink_ref_count_ops_enum_over_select_enum_2'
 sil @sink_ref_count_ops_enum_over_select_enum_2 : $@convention(thin) (FakeOptional<Builtin.Int32>) -> () {
@@ -533,12 +531,12 @@ bb0(%0 : $FakeOptional<Builtin.Int32>):
   %t = integer_literal $Builtin.Int1, 1
   %f = integer_literal $Builtin.Int1, 0
   %1 = function_ref @blocker : $@convention(thin) () -> ()
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1, bb_crit1
 
 bb1:
   retain_value %0 : $FakeOptional<Builtin.Int32>
   %100 = select_enum %0 : $FakeOptional<Builtin.Int32>, case #FakeOptional.some!enumelt: %t, case #FakeOptional.none!enumelt: %f : $Builtin.Int1
-  cond_br %100, bb2, bb3
+  cond_br %100, bb_crit2, bb3
 
 bb2:
   br bb4
@@ -549,6 +547,12 @@ bb3:
 bb4:
   %2 = tuple()
   return %2 : $()
+
+bb_crit1:
+  br bb2
+
+bb_crit2:
+  br bb2
 }
 
 // CHECK-LABEL: sil @sink_ref_count_ops_enum_over_select_enum_3 : $@convention(thin) (FakeOptional<Builtin.Int32>) -> () {
@@ -558,12 +562,10 @@ bb4:
 // CHECK-NEXT: function_ref blocker
 // CHECK-NEXT: function_ref @blocker
 // CHECK-NEXT: cond_br
+// CHECK-NOT: retain_value
 // CHECK: bb1:
-// CHECK-NEXT: br bb5
-// CHECK: bb2:
 // CHECK-NEXT: select_enum
 // CHECK-NEXT: cond_br
-// CHECK-NOT: unchecked_enum_data
 // CHECK-NOT: retain_value
 // CHECK-LABEL: } // end sil function 'sink_ref_count_ops_enum_over_select_enum_3'
 sil @sink_ref_count_ops_enum_over_select_enum_3 : $@convention(thin) (FakeOptional<Builtin.Int32>) -> () {
@@ -571,12 +573,12 @@ bb0(%0 : $FakeOptional<Builtin.Int32>):
   %t = integer_literal $Builtin.Int1, 1
   %f = integer_literal $Builtin.Int1, 0
   %1 = function_ref @blocker : $@convention(thin) () -> ()
-  cond_br undef, bb1, bb3
+  cond_br undef, bb1, bb_crit1
 
 bb1:
   retain_value %0 : $FakeOptional<Builtin.Int32>
   %100 = select_enum %0 : $FakeOptional<Builtin.Int32>, case #FakeOptional.some!enumelt: %t, case #FakeOptional.none!enumelt: %f : $Builtin.Int1
-  cond_br %100, bb2, bb3
+  cond_br %100, bb2, bb_crit2
 
 bb2:
   br bb4
@@ -587,6 +589,12 @@ bb3:
 bb4:
   %2 = tuple()
   return %2 : $()
+
+bb_crit1:
+  br bb3
+
+bb_crit2:
+  br bb3
 }
 
 // CHECK-LABEL: sil @sink_ref_count_ops_enum_over_select_enum_4 : $@convention(thin) (FakeOptional<Builtin.Int32>, FakeOptional<Builtin.NativeObject>) -> FakeOptional<Builtin.NativeObject> {
@@ -833,7 +841,7 @@ bbcase2:
 // Single BB Loop
 bb1:
   retain_value %0 : $FakeOptional<Builtin.NativeObject>
-  cond_br undef, bb1, bb9999
+  cond_br undef, bb_crit1, bb_crit2
 
 // Two BB Loop. We can use loop or domination to handle this case. But we don't
 // handle it now.
@@ -843,12 +851,24 @@ bb2:
 
 bb3:
   retain_value %0 : $FakeOptional<Builtin.NativeObject>
-  cond_br undef, bb2, bb9999
+  cond_br undef, bb_crit3, bb_crit4
 
 bb9999:
   retain_value %0 : $FakeOptional<Builtin.NativeObject>
   %9999 = tuple()
   return %9999 : $()
+
+bb_crit1:
+  br bb1
+
+bb_crit2:
+  br bb9999
+
+bb_crit3:
+  br bb2
+
+bb_crit4:
+  br bb9999
 }
 
 // Make sure we don't propagate state out of loops.
@@ -868,12 +888,18 @@ bbcase2:
 
 bb1:
   retain_value %0 : $FakeOptional<Builtin.NativeObject>
-  cond_br undef, bb1, bb2
+  cond_br undef, bb_crit1, bb_crit2
 
 bb2:
   retain_value %0 : $FakeOptional<Builtin.NativeObject>
   %9999 = tuple()
   return %9999 : $()
+
+bb_crit1:
+  br bb1
+
+bb_crit2:
+  br bb2
 }
 
 // CHECK-LABEL: sil @enum_simplification_test12 : $@convention(thin) (FakeOptional<Builtin.NativeObject>) -> () {

--- a/test/SILOptimizer/licm.sil
+++ b/test/SILOptimizer/licm.sil
@@ -74,7 +74,10 @@ bb2(%54 : $Builtin.Word):
   fix_lifetime %59: $Builtin.NativeObject
   store %1 to %99 : $*Int
   %101 = builtin "cmp_eq_Word"(%58 : $Builtin.Word, %60 : $Builtin.Word) : $Builtin.Int1
-  cond_br %101, bb1, bb2(%58 : $Builtin.Word)
+  cond_br %101, bb1, bb3
+
+bb3:
+  br bb2(%58 : $Builtin.Word)
 }
 
 // CHECK-LABEL: @must_move_condfail
@@ -122,7 +125,10 @@ bb2(%48 : $Builtin.Word):
   %99 = index_addr [projection] %97 : $*Int, %48 : $Builtin.Word
   store %1 to %99 : $*Int
   %101 = builtin "cmp_eq_Word"(%58 : $Builtin.Word, %60 : $Builtin.Word) : $Builtin.Int1
-  cond_br %101, bb1, bb2(%58 : $Builtin.Word)
+  cond_br %101, bb1, bb3
+
+bb3:
+  br bb2(%58 : $Builtin.Word)
 }
 
 
@@ -143,14 +149,29 @@ bb0(%0 : $*Builtin.Int1, %1 : $Int):
 bb1:
   %5 = load %0 : $*Builtin.Int1
   %6 = integer_literal $Builtin.Word, 101
-  cond_br %5, bb2, bb3
+  cond_br %5, bb8, bb9
+
+bb8:
+  br bb2
+
+bb9:
+  br bb3
 
 bb2:
-  cond_br %5, bb4, bb1
+  cond_br %5, bb4, bb5
+
+bb5:
+  br bb1
 
 // Inner loop.
 bb3:
-  cond_br %5, bb2, bb3
+  cond_br %5, bb6, bb7
+
+bb6:
+  br bb2
+
+bb7:
+  br bb3
 
 bb4:
   %10 = tuple ()
@@ -175,15 +196,30 @@ bb0(%0 : $*Builtin.Int1, %1 : $Int):
 bb1:
   %5 = load %0 : $*Builtin.Int1
   %6 = integer_literal $Builtin.Word, 101
-  cond_br %5, bb2, bb3
+  cond_br %5, bb8, bb9
+
+bb8:
+  br bb2
+
+bb9:
+  br bb3
 
 bb2:
-  cond_br %5, bb4, bb1
+  cond_br %5, bb4, bb5
+
+bb5:
+  br bb1
 
 // Inner loop.
 bb3:
   store %2 to %0 : $*Builtin.Int1
-  cond_br %5, bb2, bb3
+  cond_br %5, bb6, bb7
+
+bb6:
+  br bb2
+
+bb7:
+  br bb3
 
 bb4:
   %10 = tuple ()
@@ -209,7 +245,10 @@ bb1:
   %f2 = function_ref @user : $@convention(thin) (Int) -> ()
   %c1 = apply %f1(%0) : $@convention(method) (@guaranteed Array<Int>) -> Int
   %c2 = apply %f2(%c1) : $@convention(thin) (Int) -> ()
-  cond_br undef, bb1, bb2
+  cond_br undef, bb3, bb2
+
+bb3:
+  br bb1
 
 bb2:
   %r1 = tuple ()
@@ -235,7 +274,10 @@ bb1:
   store %0 to %313 : $*Int32
   %f = function_ref @use_addr : $@convention(thin) (@inout Int32) -> ()
   %a = apply %f(%313) : $@convention(thin) (@inout Int32) -> ()
-  cond_br undef, bb1, bb2
+  cond_br undef, bb3, bb2
+
+bb3:
+  br bb1
 
 bb2:
   dealloc_stack %313 : $*Int32
@@ -272,7 +314,10 @@ bb1(%existential : $P):
   %4 = witness_method $@opened("C4960DBA-02C5-11E6-BE1B-B8E856428C60", P) Self, #P.foo, %2 : $@opened("C4960DBA-02C5-11E6-BE1B-B8E856428C60", P) Self : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@guaranteed τ_0_0) -> Int32
   %5 = apply %4<@opened("C4960DBA-02C5-11E6-BE1B-B8E856428C60", P) Self>(%2) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@guaranteed τ_0_0) -> Int32
   %6 = load %0 : $*Builtin.Int1
-  cond_br %6, bb3, bb1(%existential : $P)
+  cond_br %6, bb3, bb5
+
+bb5:
+  br bb1(%existential : $P)
 
 bb3:
   br bb4
@@ -298,7 +343,10 @@ bb0(%0 : $*P):
 bb1:
   copy_addr %0 to [init] %1 : $*P
   %2 = existential_metatype $@thick P.Type, %1 : $*P
-  cond_br undef, bb1, bb2
+  cond_br undef, bb3, bb2
+
+bb3:
+  br bb1
 
 bb2:
   dealloc_stack %1 : $*P
@@ -347,7 +395,10 @@ bb2:
   %4 = load %0 : $*Builtin.Int32
   %6 = apply %unknown_value_fn() : $@convention(thin) () -> Builtin.Int32
   %33 = builtin "cmp_eq_Int32"(%4 : $Builtin.Int32, %6 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %33, bb2, bb3
+  cond_br %33, bb4, bb3
+
+bb4:
+  br bb2
 
 bb3:
   %9999 = tuple()
@@ -376,7 +427,10 @@ bb1:
   cond_br undef, bb2, bb3
 
 bb2:
-  cond_br undef, bb4, bb1
+  cond_br undef, bb4, bb5
+
+bb5:
+  br bb1
 
 bb3:
   %x = ref_element_addr %0 : $RefElemClass, #RefElemClass.x
@@ -403,7 +457,10 @@ bb1:
   %b = end_cow_mutation %m : $RefElemClass
   %f = function_ref @potential_escape : $@convention(thin) (@guaranteed RefElemClass) -> ()
   %a = apply %f(%b) : $@convention(thin) (@guaranteed RefElemClass) -> ()
-  cond_br undef, bb1, bb2
+  cond_br undef, bb3, bb2
+
+bb3:
+  br bb1
 
 bb2:
   return %b : $RefElemClass
@@ -646,13 +703,13 @@ bb3:
 // CHECK:   [[V3:%[0-9]+]] = struct $Int32
 // CHECK: bb2:
 // CHECK-NOT:   store
-// CHECK:   cond_br undef, bb1([[V3]] : $Int32), bb3
+// CHECK:   cond_br undef, bb7, bb3
 // CHECK: bb3:
 // CHECK:   store [[V3]] to %0
 // CHECK:   br bb6
 // CHECK: bb4:
 // CHECK-NOT:   store
-// CHECK:   cond_br undef, bb1([[V3]] : $Int32), bb5
+// CHECK:   cond_br undef, bb8, bb5
 // CHECK: bb5:
 // CHECK:   store [[V3]] to %0
 // CHECK:   br bb6
@@ -669,7 +726,7 @@ bb0(%0 : $*Int32, %1 : $Int32):
   br bb1(%5 : $Int32)                             // id: %6
 
 // %7                                             // user: %8
-bb1(%7 : $Int32):                                 // Preds: bb0 bb2 bb4
+bb1(%7 : $Int32):                                 // Preds: bb0 bb7 bb8
   %8 = struct_extract %7 : $Int32, #Int32._value  // user: %9
   %9 = builtin "sadd_with_overflow_Int64"(%8 : $Builtin.Int32, %3 : $Builtin.Int32, %4 : $Builtin.Int1) : $(Builtin.Int32, Builtin.Int1) // user: %10
   %10 = tuple_extract %9 : $(Builtin.Int32, Builtin.Int1), 0 // user: %11
@@ -677,14 +734,14 @@ bb1(%7 : $Int32):                                 // Preds: bb0 bb2 bb4
   cond_br undef, bb2, bb4                         // id: %12
 
 bb2:                                              // Preds: bb1
-  cond_br undef, bb1(%11 : $Int32), bb3           // id: %13
+  cond_br undef, bb7, bb3                         // id: %13
 
 bb3:                                              // Preds: bb2
   store %11 to %0 : $*Int32                       // id: %14
   br bb6                                          // id: %15
 
 bb4:                                              // Preds: bb1
-  cond_br undef, bb1(%11 : $Int32), bb5           // id: %16
+  cond_br undef, bb8, bb5                         // id: %16
 
 bb5:                                              // Preds: bb4
   store %11 to %0 : $*Int32                       // id: %17
@@ -693,6 +750,12 @@ bb5:                                              // Preds: bb4
 bb6:                                              // Preds: bb3 bb5
   %19 = tuple ()                                  // user: %20
   return %19 : $()                                // id: %20
+
+bb7:                                              // Preds: bb2
+  br bb1(%11 : $Int32)                            // id: %21
+
+bb8:                                              // Preds: bb4
+  br bb1(%11 : $Int32)                            // id: %22
 } // end sil function 'hoist_loads_and_stores'
 
 // ==================================================================
@@ -1589,11 +1652,14 @@ bb1:
   %2 = address_to_pointer %1 : $*Builtin.Word to $Builtin.RawPointer
   %3 = function_ref @g_init : $@convention(c) () -> ()
   %4 = builtin "once"(%2 : $Builtin.RawPointer, %3 : $@convention(c) () -> ()) : $()
-  cond_br undef, bb1, bb2
+  cond_br undef, bb3, bb2
 
 bb2:
   %r1 = tuple ()
   return %r1 : $()
+
+bb3:
+  br bb1
 }
 
 struct Outer {
@@ -1655,11 +1721,14 @@ bb1:
   %4 = address_to_pointer %3 : $*Builtin.Word to $Builtin.RawPointer
   %5 = function_ref @g_init : $@convention(c) () -> ()
   %6 = builtin "once"(%4 : $Builtin.RawPointer, %5 : $@convention(c) () -> ()) : $()
-  cond_br undef, bb1, bb2
+  cond_br undef, bb3, bb2
 
 bb2:
   %r1 = tuple ()
   return %r1 : $()
+
+bb3:
+  br bb1
 }
 
 // CHECK-LABEL: sil [ossa] @hoist_load_copy :

--- a/test/SILOptimizer/licm_apply.sil
+++ b/test/SILOptimizer/licm_apply.sil
@@ -145,7 +145,10 @@ bb0:
 bb1:
   %2 = function_ref @$s4test10testGlobalSivau : $@convention(thin) () -> Builtin.RawPointer
   %3 = apply %2() : $@convention(thin) () -> Builtin.RawPointer
-  cond_br undef, bb1, bb2
+  cond_br undef, bb3, bb2
+
+bb3:
+  br bb1
 
 bb2:
   %15 = tuple ()
@@ -161,12 +164,24 @@ bb2:
 // CHECK: } // end sil function 'dont_licm_ginit_prehead_not_pdom'
 sil @dont_licm_ginit_prehead_not_pdom : $@convention(thin) () -> () {
 bb0:
-  cond_br undef, bb1, bb2
+  cond_br undef, bb6, bb4
+
+bb6:
+  br bb1
+
+bb4:
+  br bb2
 
 bb1:
   %2 = function_ref @$s4test10testGlobalSivau : $@convention(thin) () -> Builtin.RawPointer
   %3 = apply %2() : $@convention(thin) () -> Builtin.RawPointer
-  cond_br undef, bb1, bb2
+  cond_br undef, bb3, bb5
+
+bb3:
+  br bb1
+
+bb5:
+  br bb2
 
 bb2:
   %15 = tuple ()
@@ -196,7 +211,10 @@ bb3:
 bb4:
   %2 = function_ref @$s4test10testGlobalSivau : $@convention(thin) () -> Builtin.RawPointer
   %3 = apply %2() : $@convention(thin) () -> Builtin.RawPointer
-  cond_br undef, bb1, bb5
+  cond_br undef, bb6, bb5
+
+bb6:
+  br bb1
 
 bb5:
   %15 = tuple ()
@@ -226,7 +244,10 @@ bb3:
   br bb4
 
 bb4:
-  cond_br undef, bb1, bb5
+  cond_br undef, bb6, bb5
+
+bb6:
+  br bb1
 
 bb5:
   %15 = tuple ()
@@ -261,7 +282,10 @@ bb3:
 bb4:
   %2 = function_ref @$s4test10testGlobalSivau : $@convention(thin) () -> Builtin.RawPointer
   %3 = apply %2() : $@convention(thin) () -> Builtin.RawPointer
-  cond_br undef, bb1, bb5
+  cond_br undef, bb6, bb5
+
+bb6:
+  br bb1
 
 bb5:
   %15 = tuple ()
@@ -286,7 +310,10 @@ bb1:
   %a = apply %f() : $@convention(thin) () -> ()
   %2 = function_ref @$s4test10testGlobalSivau : $@convention(thin) () -> Builtin.RawPointer
   %3 = apply %2() : $@convention(thin) () -> Builtin.RawPointer
-  cond_br undef, bb1, bb2
+  cond_br undef, bb3, bb2
+
+bb3:
+  br bb1
 
 bb2:
   %15 = tuple ()
@@ -311,7 +338,10 @@ bb1:
   %3 = apply %2() : $@convention(thin) () -> Builtin.RawPointer
   %f = function_ref @unknown : $@convention(thin) () -> ()
   %a = apply %f() : $@convention(thin) () -> ()
-  cond_br undef, bb1, bb2
+  cond_br undef, bb3, bb2
+
+bb3:
+  br bb1
 
 bb2:
   %15 = tuple ()

--- a/test/SILOptimizer/licm_exclusivity.sil
+++ b/test/SILOptimizer/licm_exclusivity.sil
@@ -47,11 +47,14 @@ bb1:
   %u1 = apply %u0() : $@convention(thin) () -> Builtin.RawPointer
   %u4 = load %u3 : $*X
   end_access %u3 : $*X
-  cond_br undef, bb1, bb2
+  cond_br undef, bb3, bb2
 
 bb2:
   %10 = tuple ()
   return %10 : $()
+
+bb3:
+  br bb1
 }
 
 // public func dont_hoist_access_with_conflict() {
@@ -76,11 +79,14 @@ bb1:
   %u3 = begin_access [read] [dynamic] %0 : $*X
   %u4 = load %u3 : $*X
   end_access %u3 : $*X
-  cond_br undef, bb1, bb2
+  cond_br undef, bb3, bb2
 
 bb2:
   %10 = tuple ()
   return %10 : $()
+
+bb3:
+  br bb1
 }
 
 // public func hoist_access_with_may_release() {
@@ -109,11 +115,14 @@ bb1:
   %u4 = load %u3 : $*X
   strong_release %alloc : ${ var Int32 }
   end_access %u3 : $*X
-  cond_br undef, bb1, bb2
+  cond_br undef, bb3, bb2
 
 bb2:
   %10 = tuple ()
   return %10 : $()
+
+bb3:
+  br bb1
 }
 
 // public func dont_hoist_access_with_may_release() {
@@ -140,11 +149,14 @@ bb1:
   %u4 = load %u3 : $*X
   end_access %u3 : $*X
   strong_release %alloc : ${ var Int32 }
-  cond_br undef, bb1, bb2
+  cond_br undef, bb3, bb2
 
 bb2:
   %10 = tuple ()
   return %10 : $()
+
+bb3:
+  br bb1
 }
 
 // public func hoist_access_static() {
@@ -173,11 +185,14 @@ bb1:
   %u1 = apply %u0() : $@convention(thin) () -> Builtin.RawPointer
   %u4 = load %u3 : $*X
   end_access %u3 : $*X
-  cond_br undef, bb1, bb2
+  cond_br undef, bb3, bb2
 
 bb2:
   %10 = tuple ()
   return %10 : $()
+
+bb3:
+  br bb1
 }
 
 // public func hoist_access_static_and_dynamic() {
@@ -209,11 +224,14 @@ bb1:
   %y3 = begin_access [read] [dynamic] %1 : $*X
   %y4 = load %y3 : $*X
   end_access %y3 : $*X
-  cond_br undef, bb1, bb2
+  cond_br undef, bb3, bb2
 
 bb2:
   %10 = tuple ()
   return %10 : $()
+
+bb3:
+  br bb1
 }
 
 // public func dont_hoist_access_static_and_dynamic() {
@@ -246,11 +264,14 @@ bb1:
   %y3 = begin_access [read] [dynamic] %1 : $*X
   %y4 = load %y3 : $*X
   end_access %y3 : $*X
-  cond_br undef, bb1, bb2
+  cond_br undef, bb3, bb2
 
 bb2:
   %10 = tuple ()
   return %10 : $()
+
+bb3:
+  br bb1
 }
 
 // CHECK-LABEL: sil [ossa] @dont_hoist_access_with_conflict_with_store :

--- a/test/SILOptimizer/licm_multiend.sil
+++ b/test/SILOptimizer/licm_multiend.sil
@@ -31,10 +31,10 @@ sil_global @_swiftEmptyArrayStorage : $_SwiftEmptyArrayStorage
 // CHECK:         load
 // CHECK-NOT:     load
 // CHECK-NOT:     store
-// CHECK:       bb5:
+// CHECK:       bb9:
 // CHECK-NEXT:    store
 // CHECK-NOT:     store
-// CHECK:       bb7:
+// CHECK:       bb11:
 // CHECK-NEXT:    store
 // CHECK-NOT:     store
 // CHECK:       } // end sil function 'multi_end_licm'
@@ -95,13 +95,13 @@ bb4(%27 : $Builtin.Int64):
 bb10:
   store %43 to %global : $*Int
   end_access %global : $*Int
-  cond_br %47, bb6, bb5
+  cond_br %47, bb13, bb14
 
 bb11:
   %otherInt = struct $Int (%27 : $Builtin.Int64)
   store %otherInt to %global : $*Int
   end_access %global : $*Int
-  cond_br %47, bb6, bb5
+  cond_br %47, bb15, bb16
 
 bb5:
   br bb4(%29 : $Builtin.Int64)
@@ -112,18 +112,28 @@ bb6:
 bb12:
   %25 = tuple ()
   return %25 : $()
+
+bb13:
+  br bb6
+
+bb14:
+  br bb5
+
+bb15:
+  br bb6
+
+bb16:
+  br bb5
 } // end sil function 'multi_end_licm'
 
 // CHECK-LABEL: sil hidden @multi_end_licm_loop_exit : $@convention(thin) () -> () {
 // CHECK:       bb2:
 // CHECK:         begin_access [modify] [dynamic] [no_nested_conflict]
 // CHECK:         br bb3
-// CHECK:       bb5:
-// CHECK:         end_access
 // CHECK:       bb6:
-// CHECK:       bb7:
 // CHECK:         end_access
-// CHECK:       bb8:
+// CHECK:       bb10:
+// CHECK:         end_access
 // CHECK:       } // end sil function 'multi_end_licm_loop_exit'
 sil hidden @multi_end_licm_loop_exit : $@convention(thin) () -> () {
 bb0:
@@ -182,13 +192,13 @@ bb4(%27 : $Builtin.Int64):
 bbend1:
   store %43 to %global : $*Int
   end_access %global : $*Int
-  cond_br %47, bb6, bb5
-  
+  cond_br %47, bbtramp1, bbtramp2
+
 bbend2:
   %otherInt = struct $Int (%27 : $Builtin.Int64)
   store %otherInt to %global : $*Int
   end_access %global : $*Int
-  cond_br %47, bbOut, bb5
+  cond_br %47, bbOut, bbtramp3
 
 bbOut:
   br bb6
@@ -198,8 +208,17 @@ bb5:
 
 bb6:
   br bbRet
-  
+
 bbRet:
   %25 = tuple ()
   return %25 : $()
+
+bbtramp1:
+  br bb6
+
+bbtramp2:
+  br bb5
+
+bbtramp3:
+  br bb5
 } // end sil function 'multi_end_licm_loop_exit'

--- a/test/SILOptimizer/loop-region-analysis.sil
+++ b/test/SILOptimizer/loop-region-analysis.sil
@@ -30,48 +30,58 @@ sil @no_return_func : $@convention(thin) () -> Never
 //         ----
 //
 // CHECK-LABEL: Start @one_natural_self_loop@
-// CHECK: (region id:3 kind:func ucfh:false ucft:false
+// CHECK-NEXT: (region id:4 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:4)
+// CHECK-NEXT:         (region id:5)
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:3
+// CHECK-NEXT: (region id:2 kind:bb   ucfh:false ucft:false parent:4
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:4 kind:loop ucfh:false ucft:false parent:3
+// CHECK-NEXT: (region id:5 kind:loop ucfh:false ucft:false parent:4
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (subregs
-// CHECK-NEXT:         (region id:1))
+// CHECK-NEXT:         (region id:1)
+// CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:1))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:1)))
-// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:4
-// CHECK-NEXT:     (preds)
+// CHECK-NEXT:         (region id:3)))
+// CHECK-NEXT: (region id:3 kind:bb   ucfh:false ucft:false parent:5
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:1))
 // CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:1 kind:bb   ucfh:false ucft:false parent:5
+// CHECK-NEXT:     (preds)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:3
+// CHECK-NEXT: (region id:0 kind:bb   ucfh:false ucft:false parent:4
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
@@ -82,11 +92,14 @@ bb0:
   br bb1
 
 bb1:
-  cond_br undef, bb1, bb2
+  cond_br undef, bb3, bb2
 
 bb2:
   %9999 = tuple()
   return %9999 : $()
+
+bb3:
+  br bb1
 }
 
 // One Level Natural Loop:
@@ -97,25 +110,25 @@ bb2:
 //         ---------------
 //
 // CHECK-LABEL: Start @one_natural_loop@
-// CHECK: (region id:5 kind:func ucfh:false ucft:false
+// CHECK-NEXT: (region id:6 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:6)
+// CHECK-NEXT:         (region id:7)
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:5
+// CHECK-NEXT: (region id:4 kind:bb   ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:6 kind:loop ucfh:false ucft:false parent:5
+// CHECK-NEXT: (region id:7 kind:loop ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
 // CHECK-NEXT:     (succs
@@ -123,22 +136,32 @@ bb2:
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:1)
 // CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:3)))
-// CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:6
+// CHECK-NEXT:         (region id:5)))
+// CHECK-NEXT: (region id:5 kind:bb   ucfh:false ucft:false parent:7
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:3 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:2))
-// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:6
+// CHECK-NEXT: (region id:2 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
 // CHECK-NEXT:     (succs
@@ -147,7 +170,7 @@ bb2:
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:6
+// CHECK-NEXT: (region id:1 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:2))
@@ -155,10 +178,10 @@ bb2:
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:5
+// CHECK-NEXT: (region id:0 kind:bb   ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
@@ -175,11 +198,14 @@ bb2:
   br bb3
 
 bb3:
-  cond_br undef, bb1, bb4
+  cond_br undef, bb5, bb4
 
 bb4:
   %9999 = tuple()
   return %9999 : $()
+
+bb5:
+  br bb1
 }
 
 
@@ -192,25 +218,25 @@ bb4:
 //         ---------------
 //
 // CHECK-LABEL: Start @one_natural_loop_with_diamond@
-// CHECK: (region id:6 kind:func ucfh:false ucft:false
+// CHECK-NEXT: (region id:7 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:7)
+// CHECK-NEXT:         (region id:8)
 // CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:6
+// CHECK-NEXT: (region id:5 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:7 kind:loop ucfh:false ucft:false parent:6
+// CHECK-NEXT: (region id:8 kind:loop ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
 // CHECK-NEXT:     (succs
@@ -219,23 +245,33 @@ bb4:
 // CHECK-NEXT:         (region id:1)
 // CHECK-NEXT:         (region id:2)
 // CHECK-NEXT:         (region id:3)
-// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:         (region id:4)
+// CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:4)))
-// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:7
+// CHECK-NEXT:         (region id:6)))
+// CHECK-NEXT: (region id:6 kind:bb   ucfh:false ucft:false parent:8
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:4 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:2)
 // CHECK-NEXT:         (region id:3))
-// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:7
+// CHECK-NEXT: (region id:3 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
 // CHECK-NEXT:     (succs
@@ -244,7 +280,7 @@ bb4:
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:7
+// CHECK-NEXT: (region id:2 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
 // CHECK-NEXT:     (succs
@@ -253,7 +289,7 @@ bb4:
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:7
+// CHECK-NEXT: (region id:1 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:2)
@@ -262,10 +298,10 @@ bb4:
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:6
+// CHECK-NEXT: (region id:0 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
@@ -285,11 +321,14 @@ bb3:
   br bb4
 
 bb4:
-  cond_br undef, bb1, bb5
+  cond_br undef, bb6, bb5
 
 bb5:
   %9999 = tuple()
   return %9999 : $()
+
+bb6:
+  br bb1
 }
 
 // One Level Natural Loop, multiple backedges
@@ -300,25 +339,25 @@ bb5:
 //         ---------------
 //
 // CHECK-LABEL: Start @one_natural_loop_multiple_backedges@
-// CHECK: (region id:5 kind:func ucfh:false ucft:false
+// CHECK-NEXT: (region id:7 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:6)
+// CHECK-NEXT:         (region id:8)
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:5
+// CHECK-NEXT: (region id:4 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:6 kind:loop ucfh:true  ucft:true  parent:5
+// CHECK-NEXT: (region id:8 kind:loop ucfh:true  ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
 // CHECK-NEXT:     (succs
@@ -326,32 +365,52 @@ bb5:
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:1)
 // CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:5)
+// CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:3)))
-// CHECK: (region id:3 kind:bb   ucfh:false ucft:true  parent:6
+// CHECK-NEXT:         (region id:5)
+// CHECK-NEXT:         (region id:6)))
+// CHECK-NEXT: (region id:6 kind:bb   ucfh:false ucft:true  parent:8
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:5 kind:bb   ucfh:false ucft:true  parent:8
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:3 kind:bb   ucfh:false ucft:false parent:8
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:2 kind:bb   ucfh:false ucft:true  parent:6
+// CHECK-NEXT: (region id:2 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:1 kind:bb   ucfh:true  ucft:false parent:6
+// CHECK-NEXT: (region id:1 kind:bb   ucfh:true  ucft:false parent:8
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:2))
@@ -359,10 +418,10 @@ bb5:
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:5
+// CHECK-NEXT: (region id:0 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
@@ -376,14 +435,20 @@ bb1:
   br bb2
 
 bb2:
-  cond_br undef, bb1, bb3
+  cond_br undef, bb5, bb3
 
 bb3:
-  cond_br undef, bb1, bb4
+  cond_br undef, bb6, bb4
 
 bb4:
   %9999 = tuple()
   return %9999 : $()
+
+bb5:
+  br bb1
+
+bb6:
+  br bb1
 }
 
 // Make sure that we propagate up into the outer loop that we have a ucft in the
@@ -393,47 +458,47 @@ bb4:
 // This is an example that can not happen in sil with canonicalized loops.
 //
 // CHECK-LABEL: Start @inner_natural_loop_with_multiple_backedges@
-// CHECK: (region id:8 kind:func ucfh:false ucft:false
+// CHECK-NEXT: (region id:9 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:9)
+// CHECK-NEXT:         (region id:10)
 // CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:8
+// CHECK-NEXT: (region id:5 kind:bb   ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:9 kind:loop ucfh:false ucft:false  parent:8
+// CHECK-NEXT: (region id:10 kind:loop ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:10)
+// CHECK-NEXT:         (region id:11)
 // CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:10))
+// CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:7)))
-// CHECK: (region id:7 kind:bb   ucfh:false ucft:false parent:9
+// CHECK-NEXT: (region id:7 kind:bb   ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:10))
+// CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:10 kind:loop ucfh:true  ucft:false  parent:9
+// CHECK-NEXT: (region id:11 kind:loop ucfh:true  ucft:false parent:10
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
 // CHECK-NEXT:     (succs
@@ -442,15 +507,24 @@ bb4:
 // CHECK-NEXT:         (region id:2)
 // CHECK-NEXT:         (region id:3)
 // CHECK-NEXT:         (region id:4)
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:6)
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:3)
-// CHECK-NEXT:         (region id:6)))
-// CHECK: (region id:6 kind:bb   ucfh:false ucft:true  parent:10
+// CHECK-NEXT:         (region id:6)
+// CHECK-NEXT:         (region id:8)))
+// CHECK-NEXT: (region id:8 kind:bb   ucfh:false ucft:true  parent:11
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:6 kind:bb   ucfh:false ucft:true  parent:11
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (succs)
@@ -458,7 +532,7 @@ bb4:
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:4 kind:bb   ucfh:false ucft:false  parent:10
+// CHECK-NEXT: (region id:4 kind:bb   ucfh:false ucft:false parent:11
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (succs
@@ -469,16 +543,17 @@ bb4:
 // CHECK-NEXT:         (parentindex:1))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:3 kind:bb   ucfh:false  ucft:true parent:10
+// CHECK-NEXT: (region id:3 kind:bb   ucfh:false ucft:false parent:11
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:         (region id:4)
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:2 kind:bb   ucfh:true ucft:false parent:10
+// CHECK-NEXT: (region id:2 kind:bb   ucfh:true  ucft:false parent:11
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:3))
@@ -486,18 +561,18 @@ bb4:
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:9
+// CHECK-NEXT: (region id:1 kind:bb   ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:10))
+// CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:8
+// CHECK-NEXT: (region id:0 kind:bb   ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
@@ -514,7 +589,7 @@ bb2:
   br bb3
 
 bb3:
-  cond_br undef, bb2, bb4
+  cond_br undef, bb8, bb4
 
 bb4:
   switch_enum undef : $ManyCase, case #ManyCase.One!enumelt: bb5, case #ManyCase.Two!enumelt: bb6, case #ManyCase.Three!enumelt: bb7
@@ -527,6 +602,9 @@ bb6:
 
 bb7:
   return undef : $()
+
+bb8:
+  br bb2
 }
 
 // Two separate natural loops
@@ -539,78 +617,108 @@ bb7:
 //         --------      --------
 //
 // CHECK-LABEL: Start @two_separate_natural_loops@
-// CHECK: (region id:6 kind:func ucfh:false ucft:false
+// CHECK-NEXT: (region id:9 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:7)
-// CHECK-NEXT:         (region id:8)
-// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:         (region id:10)
+// CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:11)
+// CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:6
+// CHECK-NEXT: (region id:6 kind:bb   ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:8 kind:loop ucfh:false ucft:false parent:6
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:7))
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:5))
-// CHECK-NEXT:     (subregs
-// CHECK-NEXT:         (region id:3)
-// CHECK-NEXT:         (region id:4))
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:4))
-// CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:4))
-// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:8
+// CHECK-NEXT: (region id:11 kind:loop ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:     (subregs
+// CHECK-NEXT:         (region id:4)
+// CHECK-NEXT:         (region id:5)
+// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:     (backedge-regs
+// CHECK-NEXT:         (region id:7)))
+// CHECK-NEXT: (region id:7 kind:bb   ucfh:false ucft:false parent:11
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:5 kind:bb   ucfh:false ucft:false parent:11
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:8
+// CHECK-NEXT: (region id:4 kind:bb   ucfh:false ucft:false parent:11
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:7 kind:loop ucfh:false ucft:false parent:6
+// CHECK-NEXT: (region id:3 kind:bb   ucfh:false ucft:false parent:9
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:10))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:10 kind:loop ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:         (region id:2)
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:2)))
-// CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:7
+// CHECK-NEXT:         (region id:8)))
+// CHECK-NEXT: (region id:8 kind:bb   ucfh:false ucft:false parent:10
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:2 kind:bb   ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
-// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:7
+// CHECK-NEXT: (region id:1 kind:bb   ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:2))
@@ -618,10 +726,10 @@ bb7:
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:6
+// CHECK-NEXT: (region id:0 kind:bb   ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
@@ -635,17 +743,26 @@ bb1:
   br bb2
 
 bb2:
-  cond_br undef, bb1, bb3
+  cond_br undef, bb6, bb7
 
 bb3:
   br bb4
 
 bb4:
-  cond_br undef, bb3, bb5
+  cond_br undef, bb8, bb5
 
 bb5:
   %9999 = tuple()
   return %9999 : $()
+
+bb6:
+  br bb1
+
+bb7:
+  br bb3
+
+bb8:
+  br bb3
 }
 
 // Two separate natural loops separated by a diamond
@@ -659,126 +776,136 @@ bb5:
 //         --------        --------
 //
 // CHECK-LABEL: Start @two_separate_natural_loops_separated_by_diamond@
-// CHECK: (region id:9 kind:func ucfh:false ucft:false
-// CHECK:     (preds)
-// CHECK:     (succs)
-// CHECK:     (subregs
-// CHECK:         (region id:0)
-// CHECK:         (region id:10)
-// CHECK:         (region id:3)
-// CHECK:         (region id:4)
-// CHECK:         (region id:11)
-// CHECK:         (region id:7))
-// CHECK:     (non-local-succs)
-// CHECK:     (exiting-subregs)
-// CHECK:     (backedge-regs))
-// CHECK: (region id:7 kind:bb   ucfh:false ucft:false parent:9
-// CHECK:     (preds
-// CHECK:         (region id:11))
-// CHECK:     (succs)
-// CHECK:     (subregs)
-// CHECK:     (non-local-succs)
-// CHECK:     (exiting-subregs)
-// CHECK:     (backedge-regs))
-// CHECK: (region id:11 kind:loop ucfh:false ucft:false parent:9
-// CHECK:     (preds
-// CHECK:         (region id:3)
-// CHECK:         (region id:4))
-// CHECK:     (succs
-// CHECK:         (region id:7))
-// CHECK:     (subregs
-// CHECK:         (region id:5)
-// CHECK:         (region id:6))
-// CHECK:     (non-local-succs)
-// CHECK:     (exiting-subregs
-// CHECK:         (region id:6))
-// CHECK:     (backedge-regs
-// CHECK:         (region id:6)))
-// CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:11
-// CHECK:     (preds
-// CHECK:         (region id:5))
-// CHECK:     (succs)
-// CHECK:     (subregs)
-// CHECK:     (non-local-succs
-// CHECK:         (parentindex:0))
-// CHECK:     (exiting-subregs)
-// CHECK:     (backedge-regs))
-// CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:11
-// CHECK:     (preds)
-// CHECK:     (succs
-// CHECK:         (region id:6))
-// CHECK:     (subregs)
-// CHECK:     (non-local-succs)
-// CHECK:     (exiting-subregs)
-// CHECK:     (backedge-regs))
-// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:9
-// CHECK:     (preds
-// CHECK:         (region id:10))
-// CHECK:     (succs
-// CHECK:         (region id:11))
-// CHECK:     (subregs)
-// CHECK:     (non-local-succs)
-// CHECK:     (exiting-subregs)
-// CHECK:     (backedge-regs))
-// CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:9
-// CHECK:     (preds
-// CHECK:         (region id:10))
-// CHECK:     (succs
-// CHECK:         (region id:11))
-// CHECK:     (subregs)
-// CHECK:     (non-local-succs)
-// CHECK:     (exiting-subregs)
-// CHECK:     (backedge-regs))
-// CHECK: (region id:10 kind:loop ucfh:false ucft:false parent:9
-// CHECK:     (preds
-// CHECK:         (region id:0))
-// CHECK:     (succs
-// CHECK:         (region id:3)
-// CHECK:         (region id:4))
-// CHECK:     (subregs
-// CHECK:         (region id:1)
-// CHECK:         (region id:2)
-// CHECK:         (region id:8))
-// CHECK:     (non-local-succs)
-// CHECK:     (exiting-subregs
-// CHECK:         (region id:2))
-// CHECK:     (backedge-regs
-// CHECK:         (region id:8)))
-// CHECK: (region id:8 kind:bb   ucfh:false ucft:false parent:10
-// CHECK:     (preds
-// CHECK:         (region id:2))
-// CHECK:     (succs)
-// CHECK:     (subregs)
-// CHECK:     (non-local-succs)
-// CHECK:     (exiting-subregs)
-// CHECK:     (backedge-regs))
-// CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:10
-// CHECK:     (preds
-// CHECK:         (region id:1))
-// CHECK:     (succs
-// CHECK:         (region id:8))
-// CHECK:     (subregs)
-// CHECK:     (non-local-succs
-// CHECK:         (parentindex:0)
-// CHECK:         (parentindex:1))
-// CHECK:     (exiting-subregs)
-// CHECK:     (backedge-regs))
-// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:10
-// CHECK:     (preds)
-// CHECK:     (succs
-// CHECK:         (region id:2))
-// CHECK:     (subregs)
-// CHECK:     (non-local-succs)
-// CHECK:     (exiting-subregs)
-// CHECK:     (backedge-regs))
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:9
-// CHECK:     (preds)
-// CHECK:     (succs
-// CHECK:         (region id:10))
-// CHECK:     (subregs)
-// CHECK:     (non-local-succs)
-// CHECK:     (exiting-subregs)
-// CHECK:     (backedge-regs))
+// CHECK-NEXT: (region id:10 kind:func ucfh:false ucft:false
+// CHECK-NEXT:     (preds)
+// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs
+// CHECK-NEXT:         (region id:0)
+// CHECK-NEXT:         (region id:11)
+// CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:4)
+// CHECK-NEXT:         (region id:12)
+// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:7 kind:bb   ucfh:false ucft:false parent:10
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:12))
+// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:12 kind:loop ucfh:false ucft:false parent:10
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:     (subregs
+// CHECK-NEXT:         (region id:5)
+// CHECK-NEXT:         (region id:6)
+// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:     (backedge-regs
+// CHECK-NEXT:         (region id:8)))
+// CHECK-NEXT: (region id:8 kind:bb   ucfh:false ucft:false parent:12
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:6 kind:bb   ucfh:false ucft:false parent:12
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs
+// CHECK-NEXT:         (parentindex:0))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:5 kind:bb   ucfh:false ucft:false parent:12
+// CHECK-NEXT:     (preds)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:4 kind:bb   ucfh:false ucft:false parent:10
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:12))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:3 kind:bb   ucfh:false ucft:false parent:10
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:12))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:11 kind:loop ucfh:false ucft:false parent:10
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:0))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (subregs
+// CHECK-NEXT:         (region id:1)
+// CHECK-NEXT:         (region id:2)
+// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:     (backedge-regs
+// CHECK-NEXT:         (region id:9)))
+// CHECK-NEXT: (region id:9 kind:bb   ucfh:false ucft:false parent:11
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:2 kind:bb   ucfh:false ucft:false parent:11
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:1))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs
+// CHECK-NEXT:         (parentindex:0)
+// CHECK-NEXT:         (parentindex:1))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:1 kind:bb   ucfh:false ucft:false parent:11
+// CHECK-NEXT:     (preds)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:0 kind:bb   ucfh:false ucft:false parent:10
+// CHECK-NEXT:     (preds)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: End @two_separate_natural_loops_separated_by_diamond@
 sil @two_separate_natural_loops_separated_by_diamond : $@convention(thin) () -> () {
 bb0:
@@ -803,11 +930,14 @@ bb4:
   br bb5
 
 bb5:
-  cond_br undef, bb4, bb6
+  cond_br undef, bb7, bb6
 
 bb6:
   %9999 = tuple()
   return %9999 : $()
+
+bb7:
+  br bb4
 }
 
 // Two separate natural loops separated by a diamond with else having a loop.
@@ -825,72 +955,92 @@ bb6:
 //         --------           --------
 //
 // CHECK-LABEL: Start @two_separate_natural_loops_separated_by_diamond_with_loop@
-// CHECK: (region id:13 kind:func ucfh:false ucft:false
+// CHECK-NEXT: (region id:15 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:14)
+// CHECK-NEXT:         (region id:16)
 // CHECK-NEXT:         (region id:3)
 // CHECK-NEXT:         (region id:4)
-// CHECK-NEXT:         (region id:15)
+// CHECK-NEXT:         (region id:17)
 // CHECK-NEXT:         (region id:6)
 // CHECK-NEXT:         (region id:7)
 // CHECK-NEXT:         (region id:8)
 // CHECK-NEXT:         (region id:9)
-// CHECK-NEXT:         (region id:10))
+// CHECK-NEXT:         (region id:10)
+// CHECK-NEXT:         (region id:11)
+// CHECK-NEXT:         (region id:12))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:10 kind:bb   ucfh:true  ucft:true  parent:13
+// CHECK-NEXT: (region id:12 kind:bb   ucfh:true  ucft:true  parent:15
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:3)
-// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:9 kind:bb   ucfh:false ucft:false parent:13
+// CHECK-NEXT: (region id:11 kind:bb   ucfh:false ucft:false parent:15
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:12))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:10 kind:bb   ucfh:false ucft:false parent:15
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:6)
-// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:8 kind:bb   ucfh:true  ucft:true  parent:13
+// CHECK-NEXT: (region id:9 kind:bb   ucfh:false ucft:false parent:15
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:7)
-// CHECK-NEXT:         (region id:10))
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:9)
 // CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:7 kind:bb   ucfh:false ucft:false parent:13
+// CHECK-NEXT: (region id:8 kind:bb   ucfh:true  ucft:true  parent:15
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:15))
+// CHECK-NEXT:         (region id:7)
+// CHECK-NEXT:         (region id:12))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:9)
+// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:7 kind:bb   ucfh:false ucft:false parent:15
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:17))
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:13
+// CHECK-NEXT: (region id:6 kind:bb   ucfh:false ucft:false parent:15
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:15))
+// CHECK-NEXT:         (region id:17))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:15 kind:loop ucfh:false ucft:false parent:13
+// CHECK-NEXT: (region id:17 kind:loop ucfh:false ucft:false parent:15
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (succs
@@ -898,13 +1048,13 @@ bb6:
 // CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:5)
-// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:         (region id:13))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:11)))
-// CHECK: (region id:11 kind:bb   ucfh:false ucft:false parent:15
+// CHECK-NEXT:         (region id:13)))
+// CHECK-NEXT: (region id:13 kind:bb   ucfh:false ucft:false parent:17
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (succs)
@@ -912,35 +1062,35 @@ bb6:
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:15
+// CHECK-NEXT: (region id:5 kind:bb   ucfh:false ucft:false parent:17
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:         (region id:13))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0)
 // CHECK-NEXT:         (parentindex:1))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:13
+// CHECK-NEXT: (region id:4 kind:bb   ucfh:false ucft:false parent:15
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:14))
+// CHECK-NEXT:         (region id:16))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:15))
+// CHECK-NEXT:         (region id:17))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:13
+// CHECK-NEXT: (region id:3 kind:bb   ucfh:false ucft:false parent:15
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:14))
+// CHECK-NEXT:         (region id:16))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:10))
+// CHECK-NEXT:         (region id:12))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:14 kind:loop ucfh:false ucft:false parent:13
+// CHECK-NEXT: (region id:16 kind:loop ucfh:false ucft:false parent:15
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
 // CHECK-NEXT:     (succs
@@ -949,13 +1099,13 @@ bb6:
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:1)
 // CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:12))
+// CHECK-NEXT:         (region id:14))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:12)))
-// CHECK: (region id:12 kind:bb   ucfh:false ucft:false parent:14
+// CHECK-NEXT:         (region id:14)))
+// CHECK-NEXT: (region id:14 kind:bb   ucfh:false ucft:false parent:16
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (succs)
@@ -963,18 +1113,18 @@ bb6:
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:14
+// CHECK-NEXT: (region id:2 kind:bb   ucfh:false ucft:false parent:16
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:12))
+// CHECK-NEXT:         (region id:14))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0)
 // CHECK-NEXT:         (parentindex:1))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:14
+// CHECK-NEXT: (region id:1 kind:bb   ucfh:false ucft:false parent:16
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:2))
@@ -982,10 +1132,10 @@ bb6:
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:13
+// CHECK-NEXT: (region id:0 kind:bb   ucfh:false ucft:false parent:15
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK:         (region id:14))
+// CHECK-NEXT:         (region id:16))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
@@ -1026,131 +1176,177 @@ bb5:
   br bb6
 
 bb6:
-  cond_br undef, bb5, bb7
+  cond_br undef, bb8, bb9
 
 bb7:
   %9999 = tuple()
   return %9999 : $()
+
+bb8:
+  br bb5
+
+bb9:
+  br bb7
 }
 
 // CHECK-LABEL: Start @three_separate_natural_loops@
-// CHECK: (region id:11 kind:func ucfh:false ucft:false
+// CHECK-NEXT: (region id:15 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:12)
+// CHECK-NEXT:         (region id:16)
 // CHECK-NEXT:         (region id:3)
 // CHECK-NEXT:         (region id:4)
-// CHECK-NEXT:         (region id:13)
+// CHECK-NEXT:         (region id:17)
 // CHECK-NEXT:         (region id:6)
-// CHECK-NEXT:         (region id:14)
-// CHECK-NEXT:         (region id:9))
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:9 kind:bb   ucfh:false ucft:false parent:11
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:13)
-// CHECK-NEXT:         (region id:14))
-// CHECK-NEXT:     (succs)
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:14 kind:loop ucfh:false ucft:false parent:11
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:6))
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:9))
-// CHECK-NEXT:     (subregs
-// CHECK-NEXT:         (region id:7)
-// CHECK-NEXT:         (region id:8))
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:8))
-// CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:8)))
-// CHECK: (region id:8 kind:bb   ucfh:false ucft:false parent:14
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:7))
-// CHECK-NEXT:     (succs)
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs
-// CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:7 kind:bb   ucfh:false ucft:false parent:14
-// CHECK-NEXT:     (preds)
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:8))
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:11
-// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:8)
+// CHECK-NEXT:         (region id:18)
+// CHECK-NEXT:         (region id:11)
 // CHECK-NEXT:         (region id:12))
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:14))
-// CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:13 kind:loop ucfh:false ucft:false parent:11
+// CHECK-NEXT: (region id:12 kind:bb   ucfh:false ucft:false parent:15
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:4))
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:9))
-// CHECK-NEXT:     (subregs
-// CHECK-NEXT:         (region id:5))
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:5))
-// CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:5)))
-// CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:13
-// CHECK-NEXT:     (preds)
+// CHECK-NEXT:         (region id:6)
+// CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs
-// CHECK-NEXT:         (parentindex:0))
+// CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:11
+// CHECK-NEXT: (region id:11 kind:bb   ucfh:false ucft:false parent:15
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:         (region id:18))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:12))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:18 kind:loop ucfh:false ucft:false parent:15
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:     (subregs
+// CHECK-NEXT:         (region id:9)
+// CHECK-NEXT:         (region id:10)
+// CHECK-NEXT:         (region id:13))
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:10))
+// CHECK-NEXT:     (backedge-regs
+// CHECK-NEXT:         (region id:13)))
+// CHECK-NEXT: (region id:13 kind:bb   ucfh:false ucft:false parent:18
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:10))
+// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:10 kind:bb   ucfh:false ucft:false parent:18
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:13))
 // CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs
+// CHECK-NEXT:         (parentindex:0))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:9 kind:bb   ucfh:false ucft:false parent:18
+// CHECK-NEXT:     (preds)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:10))
+// CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:11
+// CHECK-NEXT: (region id:8 kind:bb   ucfh:false ucft:false parent:15
 // CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:16))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:18))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:6 kind:bb   ucfh:false ucft:false parent:15
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:17))
+// CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:12))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:17 kind:loop ucfh:false ucft:false parent:15
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:     (subregs
+// CHECK-NEXT:         (region id:5)
+// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:     (backedge-regs
+// CHECK-NEXT:         (region id:7)))
+// CHECK-NEXT: (region id:7 kind:bb   ucfh:false ucft:false parent:17
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:5 kind:bb   ucfh:false ucft:false parent:17
+// CHECK-NEXT:     (preds)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs
+// CHECK-NEXT:         (parentindex:0))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:4 kind:bb   ucfh:false ucft:false parent:15
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:17))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:3 kind:bb   ucfh:false ucft:false parent:15
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:16))
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:12 kind:loop ucfh:false ucft:false parent:11
+// CHECK-NEXT: (region id:16 kind:loop ucfh:false ucft:false parent:15
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:3)
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:1)
 // CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:10))
+// CHECK-NEXT:         (region id:14))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:10)))
-// CHECK: (region id:10 kind:bb   ucfh:false ucft:false parent:12
+// CHECK-NEXT:         (region id:14)))
+// CHECK-NEXT: (region id:14 kind:bb   ucfh:false ucft:false parent:16
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (succs)
@@ -1158,18 +1354,18 @@ bb7:
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:12
+// CHECK-NEXT: (region id:2 kind:bb   ucfh:false ucft:false parent:16
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:10))
+// CHECK-NEXT:         (region id:14))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0)
 // CHECK-NEXT:         (parentindex:1))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:12
+// CHECK-NEXT: (region id:1 kind:bb   ucfh:false ucft:false parent:16
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:2))
@@ -1177,10 +1373,10 @@ bb7:
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:11
+// CHECK-NEXT: (region id:0 kind:bb   ucfh:false ucft:false parent:15
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:12))
+// CHECK-NEXT:         (region id:16))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
@@ -1209,17 +1405,29 @@ bb3:
   br bb4
 
 bb4:
-  cond_br undef, bb3, bb7
+  cond_br undef, bb8, bb9
 
 bb5:
   br bb6
 
 bb6:
-  cond_br undef, bb6, bb7
+  cond_br undef, bb10, bb11
 
 bb7:
   %9999 = tuple()
   return %9999 : $()
+
+bb8:
+  br bb3
+
+bb9:
+  br bb7
+
+bb10:
+  br bb6
+
+bb11:
+  br bb7
 }
 
 // Two Level Natural Loop, one backedge
@@ -1230,79 +1438,99 @@ bb7:
 //         ---------------
 //
 // CHECK-LABEL: Start @two_level_natural_loop@
-// CHECK: (region id:5 kind:func ucfh:false ucft:false
+// CHECK-NEXT: (region id:7 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:6)
+// CHECK-NEXT:         (region id:8)
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:5
+// CHECK-NEXT: (region id:4 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:6 kind:loop ucfh:false ucft:false parent:5
+// CHECK-NEXT: (region id:8 kind:loop ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:7)
-// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:         (region id:9)
+// CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:3))
-// CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:6
+// CHECK-NEXT:         (region id:5)))
+// CHECK-NEXT: (region id:5 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:3 kind:bb   ucfh:false ucft:false parent:8
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:7 kind:loop ucfh:false ucft:false parent:6
+// CHECK-NEXT: (region id:9 kind:loop ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (subregs
-// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:         (region id:2)
+// CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (backedge-regs
+// CHECK-NEXT:         (region id:6)))
+// CHECK-NEXT: (region id:6 kind:bb   ucfh:false ucft:false parent:9
+// CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:2))
-// CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:7
-// CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:2 kind:bb   ucfh:false ucft:false parent:9
+// CHECK-NEXT:     (preds)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:6
+// CHECK-NEXT: (region id:1 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:5
+// CHECK-NEXT: (region id:0 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
@@ -1316,14 +1544,20 @@ bb1:
   br bb2
 
 bb2:
-  cond_br undef, bb2, bb3
+  cond_br undef, bb5, bb3
 
 bb3:
-  cond_br undef, bb1, bb4
+  cond_br undef, bb6, bb4
 
 bb4:
   %9999 = tuple()
   return %9999 : $()
+
+bb5:
+  br bb2
+
+bb6:
+  br bb1
 }
 
 // Two Level Natural Loop, one backedge, with loop in diamond.
@@ -1335,124 +1569,154 @@ bb4:
 //         ---------------
 //
 // CHECK-LABEL: Start @two_level_natural_loop_with_diamond_and_multiple_loop_exits@
-// CHECK: (region id:9 kind:func ucfh:false ucft:false
+// CHECK-NEXT: (region id:12 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:10)
-// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:         (region id:13)
+// CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:7 kind:bb   ucfh:false ucft:false parent:9
+// CHECK-NEXT: (region id:9 kind:bb   ucfh:false ucft:false parent:12
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:10))
+// CHECK-NEXT:         (region id:13))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:10 kind:loop ucfh:false ucft:false parent:9
+// CHECK-NEXT: (region id:13 kind:loop ucfh:false ucft:false parent:12
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:11)
+// CHECK-NEXT:         (region id:2)
 // CHECK-NEXT:         (region id:3)
-// CHECK-NEXT:         (region id:4)
+// CHECK-NEXT:         (region id:14)
 // CHECK-NEXT:         (region id:5)
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:6)
+// CHECK-NEXT:         (region id:7)
+// CHECK-NEXT:         (region id:8)
+// CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:6)))
-// CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:10
+// CHECK-NEXT:         (region id:10)))
+// CHECK-NEXT: (region id:10 kind:bb   ucfh:false ucft:false parent:13
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:3)
-// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:8 kind:bb   ucfh:false ucft:false parent:13
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:5)
+// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:10
+// CHECK-NEXT: (region id:7 kind:bb   ucfh:false ucft:false parent:13
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:4))
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:6))
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:10
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:11))
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:5))
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:10
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:11))
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:6))
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:11 kind:loop ucfh:false ucft:false parent:10
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:1))
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:3)
-// CHECK-NEXT:         (region id:4))
-// CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:2)
+// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:6 kind:bb   ucfh:false ucft:false parent:13
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:14))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:5 kind:bb   ucfh:false ucft:false parent:13
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:14))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:14 kind:loop ucfh:false ucft:false parent:13
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:5)
+// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:     (subregs
+// CHECK-NEXT:         (region id:4)
+// CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:8)))
-// CHECK: (region id:8 kind:bb   ucfh:false ucft:false parent:11
+// CHECK-NEXT:         (region id:11)))
+// CHECK-NEXT: (region id:11 kind:bb   ucfh:false ucft:false parent:14
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:11
+// CHECK-NEXT: (region id:4 kind:bb   ucfh:false ucft:false parent:14
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0)
 // CHECK-NEXT:         (parentindex:1))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:10
-// CHECK-NEXT:     (preds)
+// CHECK-NEXT: (region id:3 kind:bb   ucfh:false ucft:false parent:13
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:1))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:5)
-// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:         (region id:14))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:9
+// CHECK-NEXT: (region id:2 kind:bb   ucfh:false ucft:false parent:13
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:1))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:1 kind:bb   ucfh:false ucft:false parent:13
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:10))
+// CHECK-NEXT:         (region id:2)
+// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:0 kind:bb   ucfh:false ucft:false parent:12
+// CHECK-NEXT:     (preds)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:13))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
@@ -1463,7 +1727,7 @@ bb0:
   br bb1
 
 bb1:
-  cond_br undef, bb2, bb3
+  cond_br undef, bb6, bb7
 
 bb2:
   switch_enum undef : $ManyCase, case #ManyCase.One!enumelt: bbcase1, case #ManyCase.Two!enumelt: bbcase2, case #ManyCase.Three!enumelt: bbcase3
@@ -1481,99 +1745,148 @@ bb3:
   br bb4
 
 bb4:
-  cond_br undef, bb1, bb5
+  cond_br undef, bb8, bb5
 
 bb5:
   %9999 = tuple()
   return %9999 : $()
+
+bb6:
+  br bb2
+
+bb7:
+  br bb3
+
+bb8:
+  br bb1
 }
 
 // CHECK-LABEL: Start @three_level_natural_loop_with_inner_loop_in_diamond@
-// CHECK: (region id:6 kind:func ucfh:false ucft:false
+// CHECK-NEXT: (region id:10 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:7)
-// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:         (region id:11)
+// CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:6
+// CHECK-NEXT: (region id:7 kind:bb   ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:7 kind:loop ucfh:false ucft:false parent:6
+// CHECK-NEXT: (region id:11 kind:loop ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:1)
 // CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:8)
-// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:12)
+// CHECK-NEXT:         (region id:5)
+// CHECK-NEXT:         (region id:6)
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:4)
+// CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:4))
-// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:7
+// CHECK-NEXT:         (region id:8)))
+// CHECK-NEXT: (region id:8 kind:bb   ucfh:false ucft:false parent:11
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:6 kind:bb   ucfh:false ucft:false parent:11
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:2)
+// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:8))
-// CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:8 kind:loop ucfh:false ucft:false parent:7
+// CHECK-NEXT: (region id:5 kind:bb   ucfh:false ucft:false parent:11
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:1))
+// CHECK-NEXT:         (region id:12))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:12 kind:loop ucfh:false ucft:false parent:11
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (subregs
-// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:         (region id:4)
+// CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:3)))
-// CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:8
-// CHECK-NEXT:     (preds)
+// CHECK-NEXT:         (region id:9)))
+// CHECK-NEXT: (region id:9 kind:bb   ucfh:false ucft:false parent:12
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:4 kind:bb   ucfh:false ucft:false parent:12
+// CHECK-NEXT:     (preds)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:7
+// CHECK-NEXT: (region id:3 kind:bb   ucfh:false ucft:false parent:11
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:         (region id:12))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:7
+// CHECK-NEXT: (region id:2 kind:bb   ucfh:false ucft:false parent:11
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:1))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:1 kind:bb   ucfh:false ucft:false parent:11
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:6
+// CHECK-NEXT: (region id:0 kind:bb   ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
@@ -1584,20 +1897,32 @@ bb0:
   br bb1
 
 bb1:
-  cond_br undef, bb2, bb3
+  cond_br undef, bb6, bb3
 
 bb2:
-  cond_br undef, bb2, bb4
+  cond_br undef, bb7, bb8
 
 bb3:
   br bb4
 
 bb4:
-  cond_br undef, bb1, bb5
+  cond_br undef, bb9, bb5
 
 bb5:
   %9999 = tuple()
   return %9999 : $()
+
+bb6:
+  br bb2
+
+bb7:
+  br bb2
+
+bb8:
+  br bb4
+
+bb9:
+  br bb1
 }
 
 // One level irreducible loop
@@ -1605,7 +1930,7 @@ bb5:
 // Make sure that we properly identify irreducible loop boundaries.
 //
 // CHECK-LABEL: Start @one_level_irreducible_loop@
-// CHECK: (region id:8 kind:func ucfh:false ucft:false
+// CHECK-NEXT: (region id:10 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
@@ -1616,82 +1941,102 @@ bb5:
 // CHECK-NEXT:         (region id:4)
 // CHECK-NEXT:         (region id:5)
 // CHECK-NEXT:         (region id:6)
-// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:         (region id:7)
+// CHECK-NEXT:         (region id:8)
+// CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:7 kind:bb   ucfh:true  ucft:true  parent:8
+// CHECK-NEXT: (region id:9 kind:bb   ucfh:true  ucft:true  parent:10
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:1))
+// CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:8
+// CHECK-NEXT: (region id:8 kind:bb   ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:8
+// CHECK-NEXT: (region id:7 kind:bb   ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:6 kind:bb   ucfh:true  ucft:true  parent:10
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:1)
+// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:5 kind:bb   ucfh:false ucft:false parent:10
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:4 kind:bb   ucfh:true  ucft:true  parent:8
+// CHECK-NEXT: (region id:4 kind:bb   ucfh:true  ucft:true  parent:10
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:3))
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:2))
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:8
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:2))
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:4))
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:2 kind:bb   ucfh:true  ucft:true  parent:8
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:4))
-// CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:3)
-// CHECK-NEXT:         (region id:5)
-// CHECK-NEXT:         (region id:7))
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:1 kind:bb   ucfh:true  ucft:true  parent:8
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:         (region id:5)
+// CHECK-NEXT:         (region id:7)
+// CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:8
+// CHECK-NEXT: (region id:3 kind:bb   ucfh:true  ucft:true  parent:10
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:2)
+// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:2 kind:bb   ucfh:false ucft:false parent:10
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:0))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:1 kind:bb   ucfh:false ucft:false parent:10
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:0))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:0 kind:bb   ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
@@ -1699,7 +2044,7 @@ bb5:
 // CHECK: End @one_level_irreducible_loop@
 sil @one_level_irreducible_loop : $@convention(thin) () -> () {
 bb0:
-  cond_br undef, bb1, bb3
+  cond_br undef, bb6, bb7
 
 bb1:
   br bb2
@@ -1722,34 +2067,40 @@ bb3:
 bb5:
   %9999 = tuple()
   return %9999 : $()
+
+bb6:
+  br bb1
+
+bb7:
+  br bb3
 }
 
 // One natural loop with one internal irreducible loop
 //
 // CHECK-LABEL: Start @natural_loop_containing_irreducible_loop@
-// CHECK: (region id:10 kind:func ucfh:false ucft:false
+// CHECK-NEXT: (region id:13 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:11)
-// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:         (region id:14)
+// CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:8 kind:bb   ucfh:false ucft:false parent:10
+// CHECK-NEXT: (region id:10 kind:bb   ucfh:false ucft:false parent:13
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:         (region id:14))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:11 kind:loop ucfh:false ucft:false parent:10
+// CHECK-NEXT: (region id:14 kind:loop ucfh:false ucft:false parent:13
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:1)
 // CHECK-NEXT:         (region id:2)
@@ -1758,93 +2109,123 @@ bb5:
 // CHECK-NEXT:         (region id:5)
 // CHECK-NEXT:         (region id:6)
 // CHECK-NEXT:         (region id:7)
-// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:         (region id:8)
+// CHECK-NEXT:         (region id:9)
+// CHECK-NEXT:         (region id:11)
+// CHECK-NEXT:         (region id:12))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:7)))
-// CHECK: (region id:9 kind:bb   ucfh:true  ucft:true  parent:11
+// CHECK-NEXT:         (region id:11)))
+// CHECK-NEXT: (region id:12 kind:bb   ucfh:true  ucft:true  parent:14
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:7 kind:bb   ucfh:false ucft:false parent:11
+// CHECK-NEXT: (region id:11 kind:bb   ucfh:false ucft:false parent:14
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:9 kind:bb   ucfh:false ucft:false parent:14
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:11
+// CHECK-NEXT: (region id:8 kind:bb   ucfh:false ucft:false parent:14
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:7 kind:bb   ucfh:true  ucft:true  parent:14
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:2)
+// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:6 kind:bb   ucfh:false ucft:false parent:14
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:5 kind:bb   ucfh:true  ucft:true  parent:11
+// CHECK-NEXT: (region id:5 kind:bb   ucfh:true  ucft:true  parent:14
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:4))
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:3))
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:11
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:3))
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:5))
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:3 kind:bb   ucfh:true  ucft:true  parent:11
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:5))
-// CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:4)
+// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:6)
-// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:         (region id:8)
+// CHECK-NEXT:         (region id:12))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:2 kind:bb   ucfh:true  ucft:true  parent:11
+// CHECK-NEXT: (region id:4 kind:bb   ucfh:true  ucft:true  parent:14
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:12))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:3))
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:11
-// CHECK-NEXT:     (preds)
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:2)
 // CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:10
+// CHECK-NEXT: (region id:3 kind:bb   ucfh:false ucft:false parent:14
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:1))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:2 kind:bb   ucfh:false ucft:false parent:14
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:1))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:1 kind:bb   ucfh:false ucft:false parent:14
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:         (region id:2)
+// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:0 kind:bb   ucfh:false ucft:false parent:13
+// CHECK-NEXT:     (preds)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:14))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
@@ -1855,7 +2236,7 @@ bb0:
   br bb6
 
 bb6:
-  cond_br undef, bb1, bb3
+  cond_br undef, bb8, bb9
 
 bb1:
   br bb2
@@ -1876,11 +2257,20 @@ bb3:
   br bb2
 
 bb5:
-  cond_br undef, bb6, bb7
+  cond_br undef, bb10, bb7
 
 bb7:
   %9999 = tuple()
   return %9999 : $()
+
+bb8:
+  br bb1
+
+bb9:
+  br bb3
+
+bb10:
+  br bb6
 }
 
 // Two natural loop of which one has an internal irreducible loop
@@ -1889,60 +2279,80 @@ bb7:
 // into siblings.
 //
 // CHECK-LABEL: Start @two_natural_loop_one_with_irreducible_loop@
-// CHECK: (region id:12 kind:func ucfh:false ucft:false
+// CHECK-NEXT: (region id:17 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:13)
-// CHECK-NEXT:         (region id:14)
-// CHECK-NEXT:         (region id:10))
+// CHECK-NEXT:         (region id:18)
+// CHECK-NEXT:         (region id:10)
+// CHECK-NEXT:         (region id:19)
+// CHECK-NEXT:         (region id:13))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:10 kind:bb   ucfh:false ucft:false parent:12
+// CHECK-NEXT: (region id:13 kind:bb   ucfh:false ucft:false parent:17
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:14))
+// CHECK-NEXT:         (region id:19))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:14 kind:loop ucfh:false ucft:false parent:12
+// CHECK-NEXT: (region id:19 kind:loop ucfh:false ucft:false parent:17
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:13))
-// CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:10))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:13))
 // CHECK-NEXT:     (subregs
-// CHECK-NEXT:         (region id:8)
-// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:         (region id:11)
+// CHECK-NEXT:         (region id:12)
+// CHECK-NEXT:         (region id:14))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:         (region id:12))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:9)))
-// CHECK: (region id:9 kind:bb   ucfh:false ucft:false parent:14
+// CHECK-NEXT:         (region id:14)))
+// CHECK-NEXT: (region id:14 kind:bb   ucfh:false ucft:false parent:19
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:         (region id:12))
 // CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:12 kind:bb   ucfh:false ucft:false parent:19
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:14))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:8 kind:bb   ucfh:false ucft:false parent:14
+// CHECK-NEXT: (region id:11 kind:bb   ucfh:false ucft:false parent:19
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:         (region id:12))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:13 kind:loop ucfh:false ucft:false parent:12
+// CHECK-NEXT: (region id:10 kind:bb   ucfh:false ucft:false parent:17
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:18))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:19))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:18 kind:loop ucfh:false ucft:false parent:17
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:14))
+// CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:1)
 // CHECK-NEXT:         (region id:2)
@@ -1951,93 +2361,123 @@ bb7:
 // CHECK-NEXT:         (region id:5)
 // CHECK-NEXT:         (region id:6)
 // CHECK-NEXT:         (region id:7)
-// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:         (region id:8)
+// CHECK-NEXT:         (region id:9)
+// CHECK-NEXT:         (region id:15)
+// CHECK-NEXT:         (region id:16))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:7)))
-// CHECK: (region id:11 kind:bb   ucfh:true  ucft:true  parent:13
+// CHECK-NEXT:         (region id:15)))
+// CHECK-NEXT: (region id:16 kind:bb   ucfh:true  ucft:true  parent:18
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:7 kind:bb   ucfh:false ucft:false parent:13
+// CHECK-NEXT: (region id:15 kind:bb   ucfh:false ucft:false parent:18
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:9 kind:bb   ucfh:false ucft:false parent:18
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:15))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:13
+// CHECK-NEXT: (region id:8 kind:bb   ucfh:false ucft:false parent:18
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:7 kind:bb   ucfh:true  ucft:true  parent:18
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:2)
+// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:6 kind:bb   ucfh:false ucft:false parent:18
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:5 kind:bb   ucfh:true  ucft:true  parent:13
+// CHECK-NEXT: (region id:5 kind:bb   ucfh:true  ucft:true  parent:18
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:4))
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:3))
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:13
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:3))
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:5))
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:3 kind:bb   ucfh:true  ucft:true  parent:13
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:5))
-// CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:4)
+// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:6)
-// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:         (region id:8)
+// CHECK-NEXT:         (region id:16))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:2 kind:bb   ucfh:true  ucft:true  parent:13
+// CHECK-NEXT: (region id:4 kind:bb   ucfh:true  ucft:true  parent:18
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:16))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:3))
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:13
-// CHECK-NEXT:     (preds)
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:2)
 // CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:12
+// CHECK-NEXT: (region id:3 kind:bb   ucfh:false ucft:false parent:18
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:1))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:2 kind:bb   ucfh:false ucft:false parent:18
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:1))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:1 kind:bb   ucfh:false ucft:false parent:18
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:13))
+// CHECK-NEXT:         (region id:2)
+// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:0 kind:bb   ucfh:false ucft:false parent:17
+// CHECK-NEXT:     (preds)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:18))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
@@ -2048,7 +2488,7 @@ bb0:
   br bb6
 
 bb6:
-  cond_br undef, bb1, bb3
+  cond_br undef, bb10, bb11
 
 bb1:
   br bb2
@@ -2069,221 +2509,316 @@ bb3:
   br bb2
 
 bb5:
-  cond_br undef, bb6, bb7
+  cond_br undef, bb12, bb13
 
 bb7:
   br bb8
 
 bb8:
-  cond_br undef, bb7, bb9
+  cond_br undef, bb14, bb9
 
 bb9:
   %9999 = tuple()
   return %9999 : $()
+
+bb10:
+  br bb1
+
+bb11:
+  br bb3
+
+bb12:
+  br bb6
+
+bb13:
+  br bb7
+
+bb14:
+  br bb7
 }
 
 // CHECK-LABEL: Start @multiple_level_natural_loop_with_irreducible_loop_sandwich@
-// CHECK: (region id:15 kind:func ucfh:false ucft:false
+// CHECK-NEXT: (region id:23 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:0)
+// CHECK-NEXT:         (region id:24)
 // CHECK-NEXT:         (region id:16)
-// CHECK-NEXT:         (region id:19)
-// CHECK-NEXT:         (region id:13))
+// CHECK-NEXT:         (region id:27)
+// CHECK-NEXT:         (region id:19))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:13 kind:bb   ucfh:false ucft:false parent:15
+// CHECK-NEXT: (region id:19 kind:bb   ucfh:false ucft:false parent:23
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:19))
+// CHECK-NEXT:         (region id:27))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:19 kind:loop ucfh:false ucft:false parent:15
+// CHECK-NEXT: (region id:27 kind:loop ucfh:false ucft:false parent:23
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:16))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:13))
+// CHECK-NEXT:         (region id:19))
 // CHECK-NEXT:     (subregs
-// CHECK-NEXT:         (region id:11)
-// CHECK-NEXT:         (region id:12))
+// CHECK-NEXT:         (region id:17)
+// CHECK-NEXT:         (region id:18)
+// CHECK-NEXT:         (region id:20))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:12))
+// CHECK-NEXT:         (region id:18))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:12)))
-// CHECK: (region id:12 kind:bb   ucfh:false ucft:false parent:19
+// CHECK-NEXT:         (region id:20)))
+// CHECK-NEXT: (region id:20 kind:bb   ucfh:false ucft:false parent:27
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:         (region id:18))
 // CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:18 kind:bb   ucfh:false ucft:false parent:27
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:17))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:20))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:11 kind:bb   ucfh:false ucft:false parent:19
+// CHECK-NEXT: (region id:17 kind:bb   ucfh:false ucft:false parent:27
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:12))
+// CHECK-NEXT:         (region id:18))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:16 kind:loop ucfh:false ucft:false parent:15
+// CHECK-NEXT: (region id:16 kind:bb   ucfh:false ucft:false parent:23
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:24))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:27))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:24 kind:loop ucfh:false ucft:false parent:23
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:19))
+// CHECK-NEXT:         (region id:16))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:1)
 // CHECK-NEXT:         (region id:2)
 // CHECK-NEXT:         (region id:3)
 // CHECK-NEXT:         (region id:4)
-// CHECK-NEXT:         (region id:17)
+// CHECK-NEXT:         (region id:5)
+// CHECK-NEXT:         (region id:6)
+// CHECK-NEXT:         (region id:25)
+// CHECK-NEXT:         (region id:13)
+// CHECK-NEXT:         (region id:14)
+// CHECK-NEXT:         (region id:15)
+// CHECK-NEXT:         (region id:21)
+// CHECK-NEXT:         (region id:22))
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:15))
+// CHECK-NEXT:     (backedge-regs
+// CHECK-NEXT:         (region id:21)))
+// CHECK-NEXT: (region id:22 kind:bb   ucfh:true  ucft:true  parent:24
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:21 kind:bb   ucfh:false ucft:false parent:24
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:15))
+// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:15 kind:bb   ucfh:false ucft:false parent:24
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:14))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:21))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs
+// CHECK-NEXT:         (parentindex:0))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:14 kind:bb   ucfh:false ucft:false parent:24
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:15))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:13 kind:bb   ucfh:true  ucft:true  parent:24
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:25))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:25 kind:loop ucfh:false ucft:false parent:24
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:2)
+// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:13))
+// CHECK-NEXT:     (subregs
+// CHECK-NEXT:         (region id:7)
+// CHECK-NEXT:         (region id:8)
+// CHECK-NEXT:         (region id:26)
+// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:     (backedge-regs
+// CHECK-NEXT:         (region id:11)))
+// CHECK-NEXT: (region id:11 kind:bb   ucfh:false ucft:false parent:25
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:26))
+// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:26 kind:loop ucfh:false ucft:false parent:25
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:9)
 // CHECK-NEXT:         (region id:10)
-// CHECK-NEXT:         (region id:14))
+// CHECK-NEXT:         (region id:12))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:10)))
-// CHECK: (region id:14 kind:bb   ucfh:true  ucft:true  parent:16
+// CHECK-NEXT:         (region id:12)))
+// CHECK-NEXT: (region id:12 kind:bb   ucfh:false ucft:false parent:26
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:3))
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:         (region id:10))
+// CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:10 kind:bb   ucfh:false ucft:false parent:16
+// CHECK-NEXT: (region id:10 kind:bb   ucfh:false ucft:false parent:26
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:9))
-// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:12))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:9 kind:bb   ucfh:false ucft:false parent:16
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT: (region id:9 kind:bb   ucfh:false ucft:false parent:26
+// CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:17 kind:loop ucfh:true  ucft:true  parent:16
+// CHECK-NEXT: (region id:8 kind:bb   ucfh:false ucft:false parent:25
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:3))
-// CHECK-NEXT:     (subregs
-// CHECK-NEXT:         (region id:5)
-// CHECK-NEXT:         (region id:18)
-// CHECK-NEXT:         (region id:8))
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:5))
-// CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:8)))
-// CHECK: (region id:8 kind:bb   ucfh:false ucft:false parent:17
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:18))
-// CHECK-NEXT:     (succs)
+// CHECK-NEXT:         (region id:26))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:18 kind:loop ucfh:false ucft:false parent:17
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT: (region id:7 kind:bb   ucfh:false ucft:false parent:25
+// CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:8))
-// CHECK-NEXT:     (subregs
-// CHECK-NEXT:         (region id:6)
-// CHECK-NEXT:         (region id:7))
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:7))
-// CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:7)))
-// CHECK: (region id:7 kind:bb   ucfh:false ucft:false parent:18
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:6))
-// CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:18
-// CHECK-NEXT:     (preds)
+// CHECK-NEXT: (region id:6 kind:bb   ucfh:false ucft:false parent:24
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:         (region id:25))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:5 kind:bb   ucfh:true  ucft:true  parent:17
-// CHECK-NEXT:     (preds)
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:18))
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs
-// CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:16
+// CHECK-NEXT: (region id:5 kind:bb   ucfh:true  ucft:true  parent:24
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:3))
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:17))
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:3 kind:bb   ucfh:true  ucft:true  parent:16
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:17))
-// CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:4)
-// CHECK-NEXT:         (region id:9)
-// CHECK-NEXT:         (region id:14))
+// CHECK-NEXT:         (region id:13))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:6)
+// CHECK-NEXT:         (region id:14)
+// CHECK-NEXT:         (region id:22))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:2 kind:bb   ucfh:true  ucft:true  parent:16
+// CHECK-NEXT: (region id:4 kind:bb   ucfh:true  ucft:true  parent:24
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:14))
+// CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:22))
 // CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:3 kind:bb   ucfh:false ucft:false parent:24
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:1))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:2 kind:bb   ucfh:false ucft:false parent:24
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:1))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:25))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:1 kind:bb   ucfh:false ucft:false parent:24
+// CHECK-NEXT:     (preds)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:2)
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:16
+// CHECK-NEXT: (region id:0 kind:bb   ucfh:false ucft:false parent:23
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:17))
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:15
-// CHECK-NEXT:     (preds)
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:16))
+// CHECK-NEXT:         (region id:24))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
@@ -2294,7 +2829,7 @@ bb0:
   br bb6
 
 bb6:
-  cond_br undef, bb1, bb3
+  cond_br undef, bb13, bb14
 
 bb1:
   br bb2
@@ -2312,16 +2847,16 @@ bbcase3:
   br bb3
 
 bb3:
-  cond_br undef, bb2, bb10
+  cond_br undef, bb15, bb16
 
 bb5:
-  cond_br undef, bb6, bb7
+  cond_br undef, bb17, bb18
 
 bb7:
   br bb8
 
 bb8:
-  cond_br undef, bb7, bb9
+  cond_br undef, bb19, bb9
 
 bb9:
   %9999 = tuple()
@@ -2331,61 +2866,99 @@ bb10:
   br bb11
 
 bb11:
-  cond_br undef, bb10, bb12
+  cond_br undef, bb20, bb12
 
 bb12:
   br bb3
+
+bb13:
+  br bb1
+
+bb14:
+  br bb3
+
+bb15:
+  br bb2
+
+bb16:
+  br bb10
+
+bb17:
+  br bb6
+
+bb18:
+  br bb7
+
+bb19:
+  br bb7
+
+bb20:
+  br bb10
 }
 
 // CHECK-LABEL: Start @unreachable_bb_in_loop@
-// CHECK: (region id:5 kind:func ucfh:false ucft:false
+// CHECK-NEXT: (region id:6 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:6)
+// CHECK-NEXT:         (region id:7)
 // CHECK-NEXT:         (region id:3)
-// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:5
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:5 kind:bb   ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:5
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:3 kind:bb   ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:6 kind:loop ucfh:false ucft:false parent:5
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:7 kind:loop ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:3)
-// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:         (region id:2)
+// CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:1)
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:2)))
-// CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:6
+// CHECK-NEXT:         (region id:4)))
+// CHECK-NEXT: (region id:4 kind:bb   ucfh:false ucft:false parent:7
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:2 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
-// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:1))
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:6
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:1 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:2))
@@ -2393,13 +2966,15 @@ bb12:
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:5
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:0 kind:bb   ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: End @unreachable_bb_in_loop@
 sil @unreachable_bb_in_loop : $@convention(thin) () -> () {
 bb0:
@@ -2412,85 +2987,113 @@ bb2:
   unreachable
 
 bb3:
-  cond_br undef, bb1, bb4
+  cond_br undef, bb5, bb4
 
 bb4:
   return undef : $()
+
+bb5:
+  br bb1
 }
 
 // CHECK-LABEL: Start @unreachable_bb_in_inner_loop@
-// CHECK: (region id:7 kind:func ucfh:false ucft:false
+// CHECK-NEXT: (region id:9 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:8)
+// CHECK-NEXT:         (region id:10)
 // CHECK-NEXT:         (region id:5)
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:7
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:8 kind:bb   ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:7
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:5 kind:bb   ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:8 kind:loop ucfh:false ucft:false parent:7
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:10 kind:loop ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:5)
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:9)
-// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:         (region id:11)
+// CHECK-NEXT:         (region id:4)
+// CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:4)
-// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:4)))
-// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:8
+// CHECK-NEXT:         (region id:6)))
+// CHECK-NEXT: (region id:6 kind:bb   ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:4 kind:bb   ucfh:false ucft:false parent:10
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:9 kind:loop ucfh:false ucft:false parent:8
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:11 kind:loop ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:1))
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:2)
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:3)))
-// CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:9
+// CHECK-NEXT:         (region id:7)))
+// CHECK-NEXT: (region id:7 kind:bb   ucfh:false ucft:false parent:11
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:3 kind:bb   ucfh:false ucft:false parent:11
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:2))
-// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:1))
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:9
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:2 kind:bb   ucfh:false ucft:false parent:11
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:3))
@@ -2498,20 +3101,23 @@ bb4:
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:8
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:1 kind:bb   ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:7
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:0 kind:bb   ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: End @unreachable_bb_in_inner_loop@
 sil @unreachable_bb_in_inner_loop : $@convention(thin) () -> () {
 bb0:
@@ -2527,113 +3133,129 @@ bb3:
   unreachable
 
 bb4:
-  cond_br undef, bb2, bb5
+  cond_br undef, bb7, bb5
 
 bb5:
-  cond_br undef, bb1, bb6
+  cond_br undef, bb8, bb6
 
 bb6:
   return undef : $()
+
+bb7:
+  br bb2
+
+bb8:
+  br bb1
 }
 
 // CHECK-LABEL: Start @unreachable_bb_in_inner_loop_with_multiple_edges@
-// CHECK: (region id:13 kind:func ucfh:false ucft:false
+// CHECK-NEXT: (region id:14 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:14)
+// CHECK-NEXT:         (region id:15)
 // CHECK-NEXT:         (region id:3)
 // CHECK-NEXT:         (region id:6)
 // CHECK-NEXT:         (region id:9)
-// CHECK-NEXT:         (region id:11)
-// CHECK-NEXT:         (region id:12))
+// CHECK-NEXT:         (region id:12)
+// CHECK-NEXT:         (region id:13))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:12 kind:bb   ucfh:false ucft:false parent:13
+// CHECK-NEXT: (region id:13 kind:bb   ucfh:false ucft:false parent:14
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:3)
 // CHECK-NEXT:         (region id:6)
-// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:         (region id:12))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:11 kind:bb   ucfh:false ucft:false parent:13
+// CHECK-NEXT: (region id:12 kind:bb   ucfh:false ucft:false parent:14
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:14))
+// CHECK-NEXT:         (region id:15))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:12))
+// CHECK-NEXT:         (region id:13))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:9 kind:bb   ucfh:false ucft:false parent:13
+// CHECK-NEXT: (region id:9 kind:bb   ucfh:false ucft:false parent:14
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:14))
+// CHECK-NEXT:         (region id:15))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:13
+// CHECK-NEXT: (region id:6 kind:bb   ucfh:false ucft:false parent:14
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:14))
+// CHECK-NEXT:         (region id:15))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:12))
+// CHECK-NEXT:         (region id:13))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:13
+// CHECK-NEXT: (region id:3 kind:bb   ucfh:false ucft:false parent:14
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:14))
+// CHECK-NEXT:         (region id:15))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:12))
+// CHECK-NEXT:         (region id:13))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:14 kind:loop ucfh:false ucft:false parent:13
+// CHECK-NEXT: (region id:15 kind:loop ucfh:false ucft:false parent:14
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:3)
 // CHECK-NEXT:         (region id:6)
 // CHECK-NEXT:         (region id:9)
-// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:         (region id:12))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:15)
+// CHECK-NEXT:         (region id:16)
 // CHECK-NEXT:         (region id:7)
-// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:         (region id:8)
+// CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:8)
-// CHECK-NEXT:         (region id:15))
+// CHECK-NEXT:         (region id:16))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:8)))
-// CHECK: (region id:8 kind:bb   ucfh:false ucft:false parent:14
+// CHECK-NEXT:         (region id:10)))
+// CHECK-NEXT: (region id:10 kind:bb   ucfh:false ucft:false parent:15
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:8 kind:bb   ucfh:false ucft:false parent:15
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:7))
-// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:7 kind:bb   ucfh:false ucft:false parent:14
+// CHECK-NEXT: (region id:7 kind:bb   ucfh:false ucft:false parent:15
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:15))
+// CHECK-NEXT:         (region id:16))
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:15 kind:loop ucfh:false ucft:false parent:14
+// CHECK-NEXT: (region id:16 kind:loop ucfh:false ucft:false parent:15
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
 // CHECK-NEXT:     (succs
@@ -2642,7 +3264,7 @@ bb6:
 // CHECK-NEXT:         (region id:2)
 // CHECK-NEXT:         (region id:4)
 // CHECK-NEXT:         (region id:5)
-// CHECK-NEXT:         (region id:10))
+// CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:1)
 // CHECK-NEXT:         (parentindex:2)
@@ -2651,8 +3273,8 @@ bb6:
 // CHECK-NEXT:         (region id:2)
 // CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:10)))
-// CHECK: (region id:10 kind:bb   ucfh:false ucft:false parent:15
+// CHECK-NEXT:         (region id:11)))
+// CHECK-NEXT: (region id:11 kind:bb   ucfh:false ucft:false parent:16
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (succs)
@@ -2660,18 +3282,18 @@ bb6:
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:15
+// CHECK-NEXT: (region id:5 kind:bb   ucfh:false ucft:false parent:16
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:10))
+// CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:2)
 // CHECK-NEXT:         (parentindex:3))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:15
+// CHECK-NEXT: (region id:4 kind:bb   ucfh:false ucft:false parent:16
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (succs
@@ -2680,7 +3302,7 @@ bb6:
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:15
+// CHECK-NEXT: (region id:2 kind:bb   ucfh:false ucft:false parent:16
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:4))
@@ -2690,18 +3312,18 @@ bb6:
 // CHECK-NEXT:         (parentindex:1))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:14
+// CHECK-NEXT: (region id:1 kind:bb   ucfh:false ucft:false parent:15
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:15))
+// CHECK-NEXT:         (region id:16))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:13
+// CHECK-NEXT: (region id:0 kind:bb   ucfh:false ucft:false parent:14
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:14))
+// CHECK-NEXT:         (region id:15))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
@@ -2742,60 +3364,79 @@ bbcase43:
   br bb3
 
 bb5:
-  cond_br undef, bb1, bb6
+  cond_br undef, bb7, bb6
 
 bb6:
   return undef : $()
+
+bb7:
+  br bb1
 }
 
 
 // CHECK-LABEL: Start @noreturn_bb_in_loop@
-// CHECK: (region id:5 kind:func ucfh:false ucft:false
+// CHECK-NEXT: (region id:6 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:6)
+// CHECK-NEXT:         (region id:7)
 // CHECK-NEXT:         (region id:3)
-// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:5
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:5 kind:bb   ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:5
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:3 kind:bb   ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:6 kind:loop ucfh:false ucft:false parent:5
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:7 kind:loop ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:3)
-// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:         (region id:2)
+// CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:1)
 // CHECK-NEXT:         (region id:2))
-// CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:6
+// CHECK-NEXT:     (backedge-regs
+// CHECK-NEXT:         (region id:4)))
+// CHECK-NEXT: (region id:4 kind:bb   ucfh:false ucft:false parent:7
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:2 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
-// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:1))
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:6
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:1 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:2))
@@ -2803,13 +3444,15 @@ bb6:
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:5
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:0 kind:bb   ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: End @noreturn_bb_in_loop@
 sil @noreturn_bb_in_loop : $@convention(thin) () -> () {
 bb0:
@@ -2824,173 +3467,284 @@ bb2:
   unreachable
 
 bb3:
-  cond_br undef, bb1, bb4
+  cond_br undef, bb5, bb4
 
 bb4:
   return undef : $()
+
+bb5:
+  br bb1
 }
 
 // CHECK-LABEL: Start @noreturn_bb_in_three_level_loop@
-// CHECK: (region id:10 kind:func ucfh:false ucft:false
+// CHECK-NEXT: (region id:17 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:11)
-// CHECK-NEXT:         (region id:5)
-// CHECK-NEXT:         (region id:13)
-// CHECK-NEXT:         (region id:8)
-// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:         (region id:18)
+// CHECK-NEXT:         (region id:7)
+// CHECK-NEXT:         (region id:10)
+// CHECK-NEXT:         (region id:20)
+// CHECK-NEXT:         (region id:14)
+// CHECK-NEXT:         (region id:16))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:9 kind:bb   ucfh:false ucft:false parent:10
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:16 kind:bb   ucfh:false ucft:false parent:17
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:         (region id:18))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:8 kind:bb   ucfh:false ucft:false parent:10
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:14 kind:bb   ucfh:false ucft:false parent:17
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:20))
+// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:20 kind:loop ucfh:false ucft:false parent:17
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:10))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:14))
+// CHECK-NEXT:     (subregs
+// CHECK-NEXT:         (region id:11)
+// CHECK-NEXT:         (region id:12)
+// CHECK-NEXT:         (region id:13)
+// CHECK-NEXT:         (region id:15))
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:13))
+// CHECK-NEXT:     (backedge-regs
+// CHECK-NEXT:         (region id:15)))
+// CHECK-NEXT: (region id:15 kind:bb   ucfh:false ucft:false parent:20
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:13))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:13 kind:loop ucfh:false ucft:false parent:10
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:13 kind:bb   ucfh:false ucft:false parent:20
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:12))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:15))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs
+// CHECK-NEXT:         (parentindex:0))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:12 kind:bb   ucfh:false ucft:false parent:20
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:         (region id:13))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:11 kind:bb   ucfh:false ucft:false parent:20
+// CHECK-NEXT:     (preds)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:12))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:10 kind:bb   ucfh:false ucft:false parent:17
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:18))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:20))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:7 kind:bb   ucfh:false ucft:false parent:17
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:18))
+// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:18 kind:loop ucfh:false ucft:false parent:17
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:0))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:7)
+// CHECK-NEXT:         (region id:10)
+// CHECK-NEXT:         (region id:16))
 // CHECK-NEXT:     (subregs
+// CHECK-NEXT:         (region id:1)
+// CHECK-NEXT:         (region id:2)
+// CHECK-NEXT:         (region id:19)
 // CHECK-NEXT:         (region id:6)
-// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:7))
-// CHECK: (region id:7 kind:bb   ucfh:false ucft:false parent:13
+// CHECK-NEXT:         (region id:1)
+// CHECK-NEXT:         (region id:6)
+// CHECK-NEXT:         (region id:19))
+// CHECK-NEXT:     (backedge-regs
+// CHECK-NEXT:         (region id:8)))
+// CHECK-NEXT: (region id:8 kind:bb   ucfh:false ucft:false parent:18
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs
-// CHECK-NEXT:         (parentindex:0))
+// CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:13
-// CHECK-NEXT:     (preds)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:6 kind:bb   ucfh:false ucft:false parent:18
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:19))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:7))
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:10
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:11))
-// CHECK-NEXT:     (succs)
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:11 kind:loop ucfh:false ucft:false parent:10
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:0))
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:5)
-// CHECK-NEXT:         (region id:9)
-// CHECK-NEXT:         (region id:13))
-// CHECK-NEXT:     (subregs
-// CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:12)
-// CHECK-NEXT:         (region id:4))
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:4)
-// CHECK-NEXT:         (region id:12))
-// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:11
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:12))
-// CHECK-NEXT:     (succs)
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:1))
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:12 kind:loop ucfh:false ucft:false parent:11
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:19 kind:loop ucfh:false ucft:false parent:18
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:1))
+// CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (subregs
-// CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:4)
+// CHECK-NEXT:         (region id:5)
+// CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:2))
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:3))
-// CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:12
+// CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:     (backedge-regs
+// CHECK-NEXT:         (region id:9)))
+// CHECK-NEXT: (region id:9 kind:bb   ucfh:false ucft:false parent:19
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:5 kind:bb   ucfh:false ucft:false parent:19
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:1))
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:12
-// CHECK-NEXT:     (preds)
-// CHECK-NEXT:     (succs
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:4 kind:bb   ucfh:false ucft:false parent:19
+// CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:3))
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs
-// CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:11
-// CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:12))
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs
-// CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:10
-// CHECK-NEXT:     (preds)
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:3 kind:bb   ucfh:false ucft:false parent:19
+// CHECK-NEXT:     (preds)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs
+// CHECK-NEXT:         (parentindex:0))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:2 kind:bb   ucfh:false ucft:false parent:18
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:1))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:19))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:1 kind:bb   ucfh:false ucft:false parent:18
+// CHECK-NEXT:     (preds)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs
+// CHECK-NEXT:         (parentindex:0))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:0 kind:bb   ucfh:false ucft:false parent:17
+// CHECK-NEXT:     (preds)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:18))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: End @noreturn_bb_in_three_level_loop@
 sil @noreturn_bb_in_three_level_loop : $@convention(thin) () -> () {
 bb0:
   br bb1
 
 bb1:
-  cond_br undef, bb2, bb3
+  cond_br undef, bb2, bb10
 
 bb2:
   apply undef() : $@convention(thin) () -> Never
   unreachable
 
 bb3:
-  cond_br undef, bb4, bb5
+  cond_br undef, bb11, bb12
 
 bb4:
-  br bb8
+  br bb13
 
 bb5:
-  cond_br undef, bb3, bb6
+  cond_br undef, bb14, bb6
 
 bb6:
-  cond_br undef, bb1, bb7
+  cond_br undef, bb15, bb7
 
 bb7:
   return undef : $()
 
 bb8:
-  cond_br undef, bb4, bb9
+  cond_br undef, bb16, bb9
 
 bb9:
   apply undef() : $@convention(thin) () -> Never
   unreachable
+
+bb10:
+  br bb3
+
+bb11:
+  br bb4
+
+bb12:
+  br bb5
+
+bb13:
+  br bb8
+
+bb14:
+  br bb3
+
+bb15:
+  br bb1
+
+bb16:
+  br bb4
 }
 
 // Make sure we do not crash in these cases.
@@ -3017,10 +3771,13 @@ bb1:
   br bb2
 
 bb2:
-  cond_br undef, bb2, bb3
+  cond_br undef, bb4, bb3
 
 bb3:
   return undef : $()
+
+bb4:
+  br bb2
 }
 
 // CHECK-LABEL: Start @multibb_loop_with_unreachable_predecessor@
@@ -3036,63 +3793,91 @@ bb2:
   br bb3
 
 bb3:
-  cond_br undef, bb3, bb4
+  cond_br undef, bb5, bb4
 
 bb4:
   return undef : $()
+
+bb5:
+  br bb3
 }
 
 // CHECK-LABEL: Start @exit_block_that_is_a_loop@
-// CHECK: (region id:5 kind:func ucfh:false ucft:false
+// CHECK-NEXT: (region id:7 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:6)
+// CHECK-NEXT:         (region id:8)
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:5
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:3 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:6 kind:loop ucfh:false ucft:false parent:5
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:8 kind:loop ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:         (region id:9)
+// CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:7)))
-// CHECK: (region id:7 kind:loop ucfh:false ucft:false parent:6
+// CHECK-NEXT:         (region id:6)))
+// CHECK-NEXT: (region id:6 kind:bb   ucfh:false ucft:false parent:8
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:9 kind:loop ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
-// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:         (region id:4)
+// CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:         (region id:2)
+// CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:4)))
-// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:7
+// CHECK-NEXT:         (region id:5)))
+// CHECK-NEXT: (region id:5 kind:bb   ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:7
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:4 kind:bb   ucfh:false ucft:false parent:9
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs
+// CHECK-NEXT:         (parentindex:1))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:2 kind:bb   ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:4))
@@ -3100,20 +3885,23 @@ bb4:
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:6
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:1 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:5
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:0 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: End @exit_block_that_is_a_loop@
 sil @exit_block_that_is_a_loop : $@convention(thin) () -> () {
 bb0:
@@ -3126,206 +3914,232 @@ bb2:
   cond_br undef, bb3, bb4
 
 bb3:
-  cond_br undef, bb1, bb2
+  cond_br undef, bb5, bb6
 
 bb4:
   return undef : $()
+
+bb5:
+  br bb1
+
+bb6:
+  br bb2
 }
 
 // This is the double backedge loop case.
 //
 // CHECK-LABEL: Start @multiple_exit_blocks_that_are_loops@
-// CHECK: (region id:15 kind:func ucfh:false ucft:false
+// CHECK-NEXT: (region id:17 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:16)
-// CHECK-NEXT:         (region id:4)
+// CHECK-NEXT:         (region id:18)
 // CHECK-NEXT:         (region id:5)
-// CHECK-NEXT:         (region id:10)
-// CHECK-NEXT:         (region id:11)
-// CHECK-NEXT:         (region id:12))
+// CHECK-NEXT:         (region id:6)
+// CHECK-NEXT:         (region id:12)
+// CHECK-NEXT:         (region id:13)
+// CHECK-NEXT:         (region id:14))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:12 kind:bb   ucfh:false ucft:false parent:15
+// CHECK-NEXT: (region id:14 kind:bb   ucfh:false ucft:false parent:17
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:5)
-// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:         (region id:6)
+// CHECK-NEXT:         (region id:13))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:11 kind:bb   ucfh:false ucft:false parent:15
+// CHECK-NEXT: (region id:13 kind:bb   ucfh:false ucft:false parent:17
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:10))
-// CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:12))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:14))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:10 kind:bb   ucfh:false ucft:false parent:15
+// CHECK-NEXT: (region id:12 kind:bb   ucfh:false ucft:false parent:17
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:16))
+// CHECK-NEXT:         (region id:18))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:         (region id:13))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:15
+// CHECK-NEXT: (region id:6 kind:bb   ucfh:false ucft:false parent:17
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:4))
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:12))
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:15
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:16))
-// CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:14))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:16 kind:loop ucfh:true  ucft:false parent:15
+// CHECK-NEXT: (region id:5 kind:bb   ucfh:false ucft:false parent:17
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:18))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:18 kind:loop ucfh:true  ucft:false parent:17
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:4)
-// CHECK-NEXT:         (region id:10))
+// CHECK-NEXT:         (region id:5)
+// CHECK-NEXT:         (region id:12))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:17)
-// CHECK-NEXT:         (region id:7)
-// CHECK-NEXT:         (region id:18)
-// CHECK-NEXT:         (region id:14))
+// CHECK-NEXT:         (region id:2)
+// CHECK-NEXT:         (region id:19)
+// CHECK-NEXT:         (region id:8)
+// CHECK-NEXT:         (region id:9)
+// CHECK-NEXT:         (region id:20)
+// CHECK-NEXT:         (region id:16))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:17)
-// CHECK-NEXT:         (region id:18))
+// CHECK-NEXT:         (region id:19)
+// CHECK-NEXT:         (region id:20))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:7)
-// CHECK-NEXT:         (region id:14)))
-// CHECK: (region id:14 kind:bb   ucfh:false ucft:true  parent:16
+// CHECK-NEXT:         (region id:8)
+// CHECK-NEXT:         (region id:16)))
+// CHECK-NEXT: (region id:16 kind:bb   ucfh:false ucft:true  parent:18
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:18))
+// CHECK-NEXT:         (region id:20))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:18 kind:loop ucfh:false ucft:false parent:16
+// CHECK-NEXT: (region id:20 kind:loop ucfh:false ucft:false parent:18
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:1))
+// CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:14))
+// CHECK-NEXT:         (region id:16))
 // CHECK-NEXT:     (subregs
-// CHECK-NEXT:         (region id:8)
-// CHECK-NEXT:         (region id:9)
-// CHECK-NEXT:         (region id:13))
+// CHECK-NEXT:         (region id:10)
+// CHECK-NEXT:         (region id:11)
+// CHECK-NEXT:         (region id:15))
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:1))
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:13)))
-// CHECK: (region id:13 kind:bb   ucfh:false ucft:false parent:18
+// CHECK-NEXT:         (region id:15)))
+// CHECK-NEXT: (region id:15 kind:bb   ucfh:false ucft:false parent:20
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:9 kind:bb   ucfh:false ucft:false parent:18
+// CHECK-NEXT: (region id:11 kind:bb   ucfh:false ucft:false parent:20
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:13))
+// CHECK-NEXT:         (region id:15))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0)
 // CHECK-NEXT:         (parentindex:1))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:8 kind:bb   ucfh:false ucft:false parent:18
+// CHECK-NEXT: (region id:10 kind:bb   ucfh:false ucft:false parent:20
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:7 kind:bb   ucfh:false ucft:true  parent:16
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:17))
-// CHECK-NEXT:     (succs)
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:17 kind:loop ucfh:false ucft:false parent:16
+// CHECK-NEXT: (region id:9 kind:bb   ucfh:false ucft:false parent:18
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:7))
-// CHECK-NEXT:     (subregs
-// CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:3)
-// CHECK-NEXT:         (region id:6))
-// CHECK-NEXT:     (non-local-succs
-// CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:3))
-// CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:6)))
-// CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:17
+// CHECK-NEXT:         (region id:20))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:8 kind:bb   ucfh:false ucft:true  parent:18
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:         (region id:19))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:17
+// CHECK-NEXT: (region id:19 kind:loop ucfh:false ucft:false parent:18
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:     (subregs
+// CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:4)
+// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:     (non-local-succs
+// CHECK-NEXT:         (parentindex:0))
+// CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (backedge-regs
+// CHECK-NEXT:         (region id:7)))
+// CHECK-NEXT: (region id:7 kind:bb   ucfh:false ucft:false parent:19
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:4 kind:bb   ucfh:false ucft:false parent:19
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0)
 // CHECK-NEXT:         (parentindex:1))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:17
+// CHECK-NEXT: (region id:3 kind:bb   ucfh:false ucft:false parent:19
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:1 kind:bb   ucfh:true  ucft:false parent:16
+// CHECK-NEXT: (region id:2 kind:bb   ucfh:false ucft:false parent:18
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:1))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:19))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:1 kind:bb   ucfh:true  ucft:false parent:18
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:17)
+// CHECK-NEXT:         (region id:2)
+// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:0 kind:bb   ucfh:false ucft:false parent:17
+// CHECK-NEXT:     (preds)
+// CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:18))
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:15
-// CHECK-NEXT:     (preds)
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:16))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
@@ -3336,7 +4150,7 @@ bb0:
   br bb1
 
 bb1:
-  cond_br undef, bb2, bb4
+  cond_br undef, bb9, bb10
 
 bb2:
   br bb3
@@ -3376,74 +4190,124 @@ bb7:
 
 bb8:
   return undef : $()
+
+bb9:
+  br bb2
+
+bb10:
+  br bb4
 }
 
 // CHECK-LABEL: Start @loop_with_multiple_early_exit@
-// CHECK: (region id:6 kind:func ucfh:false ucft:false
+// CHECK-NEXT: (region id:10 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:0)
+// CHECK-NEXT:         (region id:11)
+// CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:5)
 // CHECK-NEXT:         (region id:7)
-// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:6
+// CHECK-NEXT: (region id:8 kind:bb   ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:5)
 // CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:7 kind:loop ucfh:false ucft:false parent:6
+// CHECK-NEXT: (region id:7 kind:bb   ucfh:false ucft:false parent:10
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:5 kind:bb   ucfh:false ucft:false parent:10
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:3 kind:bb   ucfh:false ucft:false parent:10
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:11 kind:loop ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:5)
+// CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:1)
 // CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:3)
-// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:         (region id:4)
+// CHECK-NEXT:         (region id:6)
+// CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:3)
-// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:         (region id:4)
+// CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:4)))
-// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:7
+// CHECK-NEXT:         (region id:9)))
+// CHECK-NEXT: (region id:9 kind:bb   ucfh:false ucft:false parent:11
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs
-// CHECK-NEXT:         (parentindex:0))
+// CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:7
+// CHECK-NEXT: (region id:6 kind:bb   ucfh:false ucft:false parent:11
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs
+// CHECK-NEXT:         (parentindex:2))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:4 kind:bb   ucfh:false ucft:false parent:11
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs
+// CHECK-NEXT:         (parentindex:1))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:2 kind:bb   ucfh:false ucft:false parent:11
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:1))
+// CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:7
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:1))
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:3))
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs
-// CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:7
+// CHECK-NEXT: (region id:1 kind:bb   ucfh:false ucft:false parent:11
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:2))
@@ -3451,10 +4315,10 @@ bb8:
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:6
+// CHECK-NEXT: (region id:0 kind:bb   ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
@@ -3468,16 +4332,28 @@ bb1:
   br bb2
 
 bb2:
-  cond_br undef, bb3, bb5
+  cond_br undef, bb3, bb6
 
 bb3:
-  cond_br undef, bb4, bb5
+  cond_br undef, bb4, bb7
 
 bb4:
-  cond_br undef, bb1, bb5
+  cond_br undef, bb8, bb9
 
 bb5:
   return undef : $()
+
+bb6:
+  br bb5
+
+bb7:
+  br bb5
+
+bb8:
+  br bb1
+
+bb9:
+  br bb5
 }
 
 // Test one early exit from an inner loop. I.e.:
@@ -3491,71 +4367,81 @@ bb5:
 //           \-----------------/
 //
 // CHECK-LABEL: Start @loop_with_one_early_exit_from_inner_loop@
-// CHECK: (region id:6 kind:func ucfh:false ucft:false
+// CHECK-NEXT: (region id:7 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:7)
+// CHECK-NEXT:         (region id:8)
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:6
+// CHECK-NEXT: (region id:3 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:7 kind:loop ucfh:false ucft:false parent:6
+// CHECK-NEXT: (region id:8 kind:loop ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:8)
+// CHECK-NEXT:         (region id:9)
 // CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:5)))
-// CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:7
+// CHECK-NEXT: (region id:5 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:8 kind:loop ucfh:false ucft:false parent:7
+// CHECK-NEXT: (region id:9 kind:loop ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:         (region id:4)
+// CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:2)
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:4)))
-// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:8
+// CHECK-NEXT:         (region id:6)))
+// CHECK-NEXT: (region id:6 kind:bb   ucfh:false ucft:false parent:9
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:4 kind:bb   ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:2))
-// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:1))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:8
+// CHECK-NEXT: (region id:2 kind:bb   ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:4))
@@ -3564,21 +4450,21 @@ bb5:
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:7
+// CHECK-NEXT: (region id:1 kind:bb   ucfh:false ucft:false parent:8
+// CHECK-NEXT:     (preds)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:0 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:6
-// CHECK-NEXT:     (preds)
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:7))
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:     (backedge-regs))
 // CHECK: End @loop_with_one_early_exit_from_inner_loop@
 sil @loop_with_one_early_exit_from_inner_loop : $@convention(thin) () -> () {
@@ -3592,87 +4478,154 @@ bb2:
   cond_br undef, bb3, bb5
 
 bb3:
-  cond_br undef, bb2, bb4
+  cond_br undef, bb6, bb4
 
 bb4:
   br bb1
 
 bb5:
   return undef : $()
+
+bb6:
+  br bb2
 }
 
 // CHECK-LABEL: Start @loop_with_multiple_early_exit_from_inner_loop@
-// CHECK: (region id:7 kind:func ucfh:false ucft:false
+// CHECK-NEXT: (region id:12 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:0)
+// CHECK-NEXT:         (region id:13)
+// CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:5)
 // CHECK-NEXT:         (region id:8)
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:7
+// CHECK-NEXT: (region id:9 kind:bb   ucfh:false ucft:false parent:12
 // CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:5)
 // CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:8 kind:loop ucfh:false ucft:false parent:7
+// CHECK-NEXT: (region id:8 kind:bb   ucfh:false ucft:false parent:12
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:13))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:5 kind:bb   ucfh:false ucft:false parent:12
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:13))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:3 kind:bb   ucfh:false ucft:false parent:12
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:13))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:13 kind:loop ucfh:false ucft:false parent:12
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:5)
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:9)
-// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:         (region id:14)
+// CHECK-NEXT:         (region id:7)
+// CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:5)
-// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:         (region id:7)
+// CHECK-NEXT:         (region id:14))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:5)))
-// CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:8
+// CHECK-NEXT:         (region id:10)))
+// CHECK-NEXT: (region id:10 kind:bb   ucfh:false ucft:false parent:13
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:7 kind:bb   ucfh:false ucft:false parent:13
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:14))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:9 kind:loop ucfh:false ucft:false parent:8
+// CHECK-NEXT: (region id:14 kind:loop ucfh:false ucft:false parent:13
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:3)
-// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:         (region id:4)
+// CHECK-NEXT:         (region id:6)
+// CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (non-local-succs
-// CHECK-NEXT:         (parentindex:0))
+// CHECK-NEXT:         (parentindex:1)
+// CHECK-NEXT:         (parentindex:2))
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:3)
-// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:         (region id:4)
+// CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:4)))
-// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:9
+// CHECK-NEXT:         (region id:11)))
+// CHECK-NEXT: (region id:11 kind:bb   ucfh:false ucft:false parent:14
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:6 kind:bb   ucfh:false ucft:false parent:14
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs
+// CHECK-NEXT:         (parentindex:2))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK-NEXT: (region id:4 kind:bb   ucfh:false ucft:false parent:14
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:1))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:9
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT: (region id:2 kind:bb   ucfh:false ucft:false parent:14
+// CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (subregs)
@@ -3680,27 +4633,18 @@ bb5:
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:9
+// CHECK-NEXT: (region id:1 kind:bb   ucfh:false ucft:false parent:13
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:3))
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs
-// CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:8
-// CHECK-NEXT:     (preds)
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:         (region id:14))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:7
+// CHECK-NEXT: (region id:0 kind:bb   ucfh:false ucft:false parent:12
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:         (region id:13))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
@@ -3714,17 +4658,32 @@ bb1:
   br bb2
 
 bb2:
-  cond_br undef, bb3, bb6
+  cond_br undef, bb3, bb7
 
 bb3:
-  cond_br undef, bb4, bb6
+  cond_br undef, bb4, bb8
 
 bb4:
-  cond_br undef, bb2, bb5
+  cond_br undef, bb9, bb5
 
 bb5:
-  cond_br undef, bb1, bb6
+  cond_br undef, bb10, bb11
 
 bb6:
   return undef : $()
+
+bb7:
+  br bb6
+
+bb8:
+  br bb6
+
+bb9:
+  br bb2
+
+bb10:
+  br bb1
+
+bb11:
+  br bb6
 }

--- a/test/SILOptimizer/loop_unroll.sil
+++ b/test/SILOptimizer/loop_unroll.sil
@@ -272,6 +272,8 @@ bb3:
 // CHECK: bb9:
 // CHECK:   br bb10({{.*}})
 // CHECK: bb10({{.*}}):
+// CHECK:   br bb11({{.*}})
+// CHECK: bb11({{.*}}):
 // CHECK:   return
 // CHECK: }
 sil @unroll_with_exit_block_arg_1 : $@convention(thin) () -> () {
@@ -287,10 +289,13 @@ bb4(%58 : $Builtin.Int64, %59 : $Builtin.Int64):
   %64 = builtin "smul_with_overflow_Int64"(%59 : $Builtin.Int64, %28 : $Builtin.Int64, %56 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
   %65 = tuple_extract %64 : $(Builtin.Int64, Builtin.Int1), 0
   %70 = builtin "cmp_slt_Int64"(%61 : $Builtin.Int64, %28 : $Builtin.Int64) : $Builtin.Int1
-  cond_br %70, bb5, bb6(%61 : $Builtin.Int64)
+  cond_br %70, bb5, bb6a
 
 bb5:
   br bb4(%61 : $Builtin.Int64, %65 : $Builtin.Int64)
+
+bb6a:
+  br bb6(%61 : $Builtin.Int64)
 
 bb6(%72 : $Builtin.Int64):
   %401 = tuple ()
@@ -389,6 +394,8 @@ bb3:
 // CHECK: bb9:
 // CHECK:   br bb10({{.*}})
 // CHECK: bb10({{.*}}):
+// CHECK:   br bb11({{.*}})
+// CHECK: bb11({{.*}}):
 // CHECK:   return
 // CHECK: }
 sil @unroll_with_exit_block_arg_2 : $@convention(thin) () -> () {
@@ -404,10 +411,13 @@ bb4(%58 : $Builtin.Int64, %59 : $Builtin.Int64):
   %64 = builtin "smul_with_overflow_Int64"(%59 : $Builtin.Int64, %28 : $Builtin.Int64, %56 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
   %65 = tuple_extract %64 : $(Builtin.Int64, Builtin.Int1), 0
   %70 = builtin "cmp_slt_Int64"(%61 : $Builtin.Int64, %28 : $Builtin.Int64) : $Builtin.Int1
-  cond_br %70, bb5, bb6(%61 : $Builtin.Int64)
+  cond_br %70, bb5, bb6a
 
 bb5:
   br bb4(%61 : $Builtin.Int64, %65 : $Builtin.Int64)
+
+bb6a:
+  br bb6(%61 : $Builtin.Int64)
 
 bb6(%72 : $Builtin.Int64):
   %401 = tuple ()

--- a/test/SILOptimizer/looprotate.sil
+++ b/test/SILOptimizer/looprotate.sil
@@ -245,11 +245,11 @@ bb0:
 
 bb1(%1 : $Builtin.Int32, %2 : $Builtin.Int32):    // Preds: bb0 bb2
   %3 = integer_literal $Builtin.Int1, 0           // user: %4
-  cond_br %3, bb2(%1 : $Builtin.Int32, %2 : $Builtin.Int32), bb10 // id: %4
+  cond_br %3, bb11, bb10 // id: %4
 
 bb2(%5 : $Builtin.Int32, %6 : $Builtin.Int32):    // Preds: bb1 bb8
   %7 = integer_literal $Builtin.Int1, -1          // user: %8
-  cond_br %7, bb3, bb1(%5 : $Builtin.Int32, %6 : $Builtin.Int32) // id: %8
+  cond_br %7, bb3, bb12 // id: %8
 
 bb3:                                              // Preds: bb2
   %9 = integer_literal $Builtin.Int32, 0          // user: %11
@@ -288,6 +288,12 @@ bb9:                                              // Preds: bb4
 bb10:                                             // Preds: bb1
   %34 = tuple ()                                  // user: %35
   return %34 : $()                                // id: %35
+
+bb11:
+  br bb2(%1 : $Builtin.Int32, %2 : $Builtin.Int32)
+
+bb12:
+  br bb1(%5 : $Builtin.Int32, %6 : $Builtin.Int32)
 }
 
 // CHECK-LABEL: dont_looprotate_objc
@@ -390,17 +396,21 @@ bb5:
 // CHECK: bb0({{.*}}):
 // CHECK:   br bb1
 // CHECK: bb1:
-// CHECK:   cond_br {{.*}}, bb1, bb2
+// CHECK:   cond_br {{.*}}, bb3, bb2
 // CHECK: bb2:
 // CHECK:   return
+// CHECK: bb3:
+// CHECK:   br bb1
 sil @dont_rotate_single_basic_block_loop : $@convention(thin) (Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1):
   br bb1
 bb1:
-  cond_br %0, bb1, bb2
+  cond_br %0, bb3, bb2
 bb2:
  %1 = tuple ()
  return %1 : $()
+bb3:
+  br bb1
 }
 
 // CHECK-LABEL: sil @dont_rotate_single_basic_block_loop_split_backedge

--- a/test/SILOptimizer/looprotate.sil
+++ b/test/SILOptimizer/looprotate.sil
@@ -37,17 +37,13 @@ sil_vtable Bar {
 // CHECK:   cond_br {{.*}}, bb2, bb1
 
 // CHECK: bb1:
-// CHECK-NEXT:   br bb3({{.*}} : $Builtin.Int32, {{.*}} : $Builtin.Int32, {{.*}}: $Int32)
+// CHECK-NEXT:   br [[HDR:bb[0-9]+]](
 
-// CHECK: bb3({{.*}}: $Builtin.Int32, {{.*}} : $Builtin.Int32, {{.*}} : $Int32):
+// CHECK: [[HDR]]({{.*}}):
 // CHECK:   class_method
 // CHECK:   apply
-// CHECK:   cond_br {{%.*}}, bb5, bb4
+// CHECK:   cond_br
 
-// CHECK: bb5:
-// CHECK-NEXT:   br bb6({{.*}} : $Builtin.Int32)
-
-// CHECK: bb6({{.*}} : $Builtin.Int32):
 // CHECK:   [[STRUCT:%.*]] = struct $Int32 ({{%.*}} : $Builtin.Int32)
 // CHECK:   return [[STRUCT]] : $Int32
 // CHECK: } // end sil function 'looprotate'
@@ -175,7 +171,7 @@ bb0(%0 : $Int32):
 bb1(%4 : $Builtin.Int32, %5 : $Builtin.Int32):
   %6 = struct $Int32 (%5 : $Builtin.Int32)
   %8 = builtin "cmp_eq_Word"(%5 : $Builtin.Int32, %1 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %8, bb3(%4 : $Builtin.Int32), bb2
+  cond_br %8, bb3, bb2
 
 bb2:
   %10 = integer_literal $Builtin.Int32, 1
@@ -190,8 +186,8 @@ bb2:
   %21 = tuple_extract %20 : $(Builtin.Int32, Builtin.Int1), 0
   br bb1(%21 : $Builtin.Int32, %14 : $Builtin.Int32)
 
-bb3 (%23 : $Builtin.Int32) :
-  %24 = struct $Int32 (%23 : $Builtin.Int32)
+bb3:
+  %24 = struct $Int32 (%4 : $Builtin.Int32)
   return %24 : $Int32
 }
 
@@ -352,18 +348,17 @@ bb0(%a0 : $Int32):
 // CHECK:   cond_br
 // Loop Header
 // CHECK: bb1:
-// CHECK-NEXT: br bb3
-// CHECK: bb3:
-// CHECK:   cond_br %{{.*}}, bb4, bb8
-// CHECK: bb4:
+// CHECK-NEXT: br [[HDR:bb[0-9]+]]
+// CHECK: [[HDR]]:
+// CHECK:   cond_br %{{.*}}, [[BODY:bb[0-9]+]], [[B8:bb[0-9]+]]
+// CHECK: [[BODY]]:
 // CHECK:   apply
-// CHECK:   br bb5(
-// CHECK: bb5(%[[ARG:[0-9]*]]
-// CHECK-NEXT: cond_br %{{.*}}, bb7, bb6
-// CHECK: bb8:
+// CHECK:   br [[LATCH:bb[0-9]+]](
+// CHECK: [[LATCH]](%[[ARG:[0-9]*]]
+// CHECK-NEXT: cond_br
+// CHECK: [[B8]]:
 // CHECK:   apply
-// CHECK:   br bb5(%
-// CHECK: bb9
+// CHECK:   br [[LATCH]](%
 // CHECK:   return
 sil @insert_backedge_block : $@convention(thin) (@owned @callee_owned () -> Builtin.Int32) -> () {
 bb0(%0 : $@callee_owned () -> Builtin.Int32):

--- a/test/SILOptimizer/looprotate_ossa.sil
+++ b/test/SILOptimizer/looprotate_ossa.sil
@@ -38,17 +38,13 @@ sil_vtable Bar {
 // CHECK:   cond_br {{.*}}, bb2, bb1
 
 // CHECK: bb1:
-// CHECK-NEXT:   br bb3({{.*}} : $Builtin.Int32, {{.*}} : $Builtin.Int32, {{.*}}: $Int32)
+// CHECK-NEXT:   br [[HDR:bb[0-9]+]](
 
-// CHECK: bb3({{.*}}: $Builtin.Int32, {{.*}} : $Builtin.Int32, {{.*}} : $Int32):
+// CHECK: [[HDR]]({{.*}}):
 // CHECK:   class_method
 // CHECK:   apply
-// CHECK:   cond_br {{%.*}}, bb5, bb4
+// CHECK:   cond_br
 
-// CHECK: bb5:
-// CHECK-NEXT: br bb6({{.*}} : $Builtin.Int32, {{.*}} : $Bar, {{.*}} : $<τ_0_0> { var τ_0_0 } <Bool>)
-
-// CHECK: bb6({{.*}} : $Builtin.Int32, {{.*}} : @owned $Bar, {{.*}} : @owned $<τ_0_0> { var τ_0_0 } <Bool>):
 // CHECK:   [[STRUCT:%.*]] = struct $Int32 ({{%.*}} : $Builtin.Int32)
 // CHECK:   return [[STRUCT]] : $Int32
 // CHECK: } // end sil function 'looprotate'
@@ -415,18 +411,17 @@ bb0(%a0 : $Int32):
 // CHECK:   cond_br
 // Loop Header
 // CHECK: bb1:
-// CHECK-NEXT: br bb3
-// CHECK: bb3:
-// CHECK:   cond_br %{{.*}}, bb4, bb8
-// CHECK: bb4:
+// CHECK-NEXT: br [[HDR:bb[0-9]+]]
+// CHECK: [[HDR]]:
+// CHECK:   cond_br %{{.*}}, [[BODY:bb[0-9]+]], [[B8:bb[0-9]+]]
+// CHECK: [[BODY]]:
 // CHECK:   apply
-// CHECK:   br bb5(
-// CHECK: bb5(%[[ARG:[0-9]*]]
-// CHECK-NEXT: cond_br %{{.*}}, bb7, bb6
-// CHECK: bb8:
+// CHECK:   br [[LATCH:bb[0-9]+]](
+// CHECK: [[LATCH]](%[[ARG:[0-9]*]]
+// CHECK-NEXT: cond_br
+// CHECK: [[B8]]:
 // CHECK:   apply
-// CHECK:   br bb5(%
-// CHECK: bb9
+// CHECK:   br [[LATCH]](%
 // CHECK:   return
 // CHECK-LABEL: } // end sil function 'insert_backedge_block'
 sil [ossa] @insert_backedge_block : $@convention(thin) (@owned @callee_owned () -> Builtin.Int32) -> () {
@@ -489,27 +484,19 @@ bb2:
 //
 // CHECK-LABEL: sil [ossa] @addressPhiFixUp : $@convention(thin) (Builtin.RawPointer) -> Builtin.RawPointer {
 // CHECK: bb1:
-// CHECK:   cond_br {{%.*}}, bb3, bb2
+// CHECK:   cond_br {{%.*}}, [[PH:bb[0-9]+]], {{bb[0-9]+}}
 //
-// CHECK: bb2:
-// CHECK-NEXT: br bb7
+// CHECK: [[PH]]:
+// CHECK-NEXT: br [[HDR:bb[0-9]+]]
 //
-// CHECK: bb3:
-// CHECK-NEXT: br bb4
-//
-// CHECK: bb4([[ARG:%.*]] :
+// The rotated loop header carries a RawPointer (not an address) phi; the
+// address is re-materialized inside the loop, so no address phi is created.
+// CHECK: [[HDR]]([[ARG:%.*]] : $Builtin.RawPointer):
 // CHECK:  [[CAST_BACK:%.*]] = pointer_to_address [[ARG]] : $Builtin.RawPointer to [strict] $*UInt8
 // CHECK:  [[GEP:%.*]] = index_addr [[CAST_BACK]] :
-// CHECK:  cond_br {{%.*}}, bb6, bb5
+// CHECK:  cond_br
 //
-// CHECK: bb5:
-// CHECK-NEXT: br bb7
-//
-// CHECK: bb6:
-// CHECK-NEXT: br bb4
-//
-// CHECK: bb7([[RESULT:%.*]] :
-// CHECK-NEXT: return [[RESULT]]
+// CHECK: return
 // CHECK: } // end sil function 'addressPhiFixUp'
 sil [ossa] @addressPhiFixUp : $@convention(thin) (Builtin.RawPointer) -> Builtin.RawPointer {
 bb0(%0 : $Builtin.RawPointer):

--- a/test/SILOptimizer/mandatory_inlining.sil
+++ b/test/SILOptimizer/mandatory_inlining.sil
@@ -1250,7 +1250,7 @@ bb3:
 // CHECK-NEXT:   strong_retain [[ARG]]
 // CHECK-NEXT:   strong_retain [[ARG]]
 // CHECK-NEXT:   strong_retain [[ARG]]
-// CHECK-NEXT:   cond_br undef, bb1, bb4
+// CHECK-NEXT:   cond_br undef, bb5, bb4
 //
 // CHECK: bb1:
 // CHECK-NEXT: function_ref use_c
@@ -1275,13 +1275,16 @@ bb3:
 // CHECK-NEXT: strong_release [[ARG]]
 // CHECK-NEXT: tuple
 // CHECK-NEXT: return
+//
+// CHECK: bb5:
+// CHECK-NEXT: br bb1
 // CHECK-NEXT: } // end sil function 'test_apply_pai_in_loop_with_diamond'
 sil @test_apply_pai_in_loop_with_diamond : $@convention(thin) (@guaranteed C) ->  () {
 bb0(%0: $C):
   strong_retain %0 : $C
   %closure_fun = function_ref @guaranteed_closure_func : $@convention(thin) (@guaranteed C) -> ()
   %closure = partial_apply [callee_guaranteed] %closure_fun(%0) : $@convention(thin) (@guaranteed C) -> ()
-  cond_br undef, bb2, bb5
+  cond_br undef, bb6, bb5
 
 bb2:
   apply %closure() : $@callee_guaranteed () -> ()
@@ -1298,6 +1301,9 @@ bb5:
   strong_release %0: $C
   %tuple = tuple()
   return %tuple : $()
+
+bb6:
+  br bb2
 }
 
 // CHECK-LABEL: sil @test_apply_pai_in_diamond : $@convention(thin) (@guaranteed C) ->  () {

--- a/test/SILOptimizer/merge_exclusivity.swift
+++ b/test/SILOptimizer/merge_exclusivity.swift
@@ -19,11 +19,11 @@ func sum(_ x: UInt64, _ y: UInt64) -> UInt64 {
 // TESTSIL: [[GLOBALVAR:%.*]] = global_addr @$s17merge_exclusivity5checks6UInt64Vvp
 // TESTSIL: [[B1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
 // TESTSIL: end_access [[B1]]
-// TESTSIL: bb4{{.*}}:
+// TESTSIL: bb5{{.*}}:
 // TESTSIL: [[B2b:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[GLOBALVAR]]
 // TESTSIL: store {{.*}} to [[B2b]]
 // TESTSIL: end_access [[B2b]]
-// TESTSIL: bb5:
+// TESTSIL: bb6:
 // TESTSIL: [[B3b:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[GLOBALVAR]]
 // TESTSIL: store {{.*}} to [[B3b]]
 // TESTSIL: end_access [[B3b]]

--- a/test/SILOptimizer/move_cond_fail_simplify_cfg.sil
+++ b/test/SILOptimizer/move_cond_fail_simplify_cfg.sil
@@ -38,17 +38,17 @@ bb1(%7 : $Builtin.Int64, %8 : $Builtin.Int64, %9 : $Builtin.Int1):
   cond_fail %15 : $Builtin.Int1
   %17 = builtin "cmp_eq_Int64"(%14 : $Builtin.Int64, %3 : $Builtin.Int64) : $Builtin.Int1
   %18 = builtin "cmp_eq_Int64"(%11 : $Builtin.Int64, %3 : $Builtin.Int64) : $Builtin.Int1
-  cond_br %18, bb5, bb6(%14 : $Builtin.Int64, %11 : $Builtin.Int64, %17 : $Builtin.Int1)
+  cond_br %18, bb5, bb6
 
 // Trampoline block avoiding the critical edge from bb1's cond_br back to
 // bb1 (bb1's former self-loop). Since this trampoline is now a predecessor
 // of bb1 with a single successor, the hoisted cond_fail (using the
 // corresponding incoming value for %9, which is %17) is inserted here too.
-// CHECK: bb2({{.*}}):
+// CHECK: bb2:
 // CHECK-NEXT: cond_fail
 // CHECK-NEXT: br bb1
-bb6(%20 : $Builtin.Int64, %21 : $Builtin.Int64, %22 : $Builtin.Int1):
-  br bb1(%20 : $Builtin.Int64, %21 : $Builtin.Int64, %22 : $Builtin.Int1)
+bb6:
+  br bb1(%14 : $Builtin.Int64, %11 : $Builtin.Int64, %17 : $Builtin.Int1)
 
 // Make sure that this predecessor -- which directly branches to bb1 and
 // supplies a constant for %9 -- also gets the hoisted cond_fail.

--- a/test/SILOptimizer/move_cond_fail_simplify_cfg.sil
+++ b/test/SILOptimizer/move_cond_fail_simplify_cfg.sil
@@ -14,12 +14,20 @@ bb0(%0 : $Builtin.Int1):
   %1 = integer_literal $Builtin.Int1, 0
   %2 = integer_literal $Builtin.Int64, 1
   %3 = integer_literal $Builtin.Int64, 3
-  cond_br %0, bb3, bb2
+  cond_br %0, bb4, bb2
 
-// Make sure that the predecessor order here is not changed. This is necessary
-// for the test to actually test that we are checking /all/ predecessors.
+// bb1's back edge used to branch directly to itself, making bb1 its own
+// predecessor. The SIL verifier now disallows critical edges (a terminator
+// with 2+ successors may not target a block with 2+ predecessors), so the
+// back edge is redirected through the trampoline block bb6 below, which has
+// a single successor. This means every predecessor of bb1 now has a single
+// successor, so tryMoveCondFailToPreds's post-dominance check
+// (Pred->getSingleSuccessorBlock()) no longer blocks the hoist the way it
+// did when bb1 was its own (multi-successor) predecessor. The first cond_fail
+// (on %9) is therefore hoisted into all of bb1's predecessors, which is
+// still verified below by checking every predecessor block individually.
 //
-// CHECK: bb1({{.*}}): // Preds: bb2 bb1
+// CHECK: bb1({{.*}}): // Preds: bb3 bb2
 bb1(%7 : $Builtin.Int64, %8 : $Builtin.Int64, %9 : $Builtin.Int1):
   %10 = builtin "sadd_with_overflow_Int64"(%8 : $Builtin.Int64, %2 : $Builtin.Int64, %1 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
   %11 = tuple_extract %10 : $(Builtin.Int64, Builtin.Int1), 0
@@ -30,16 +38,34 @@ bb1(%7 : $Builtin.Int64, %8 : $Builtin.Int64, %9 : $Builtin.Int1):
   cond_fail %15 : $Builtin.Int1
   %17 = builtin "cmp_eq_Int64"(%14 : $Builtin.Int64, %3 : $Builtin.Int64) : $Builtin.Int1
   %18 = builtin "cmp_eq_Int64"(%11 : $Builtin.Int64, %3 : $Builtin.Int64) : $Builtin.Int1
-  cond_br %18, bb3, bb1(%14 : $Builtin.Int64, %11 : $Builtin.Int64, %17 : $Builtin.Int1)
+  cond_br %18, bb5, bb6(%14 : $Builtin.Int64, %11 : $Builtin.Int64, %17 : $Builtin.Int1)
 
-// Make sure there can not be any cond_fail here.
-// CHECK: bb2:
+// Trampoline block avoiding the critical edge from bb1's cond_br back to
+// bb1 (bb1's former self-loop). Since this trampoline is now a predecessor
+// of bb1 with a single successor, the hoisted cond_fail (using the
+// corresponding incoming value for %9, which is %17) is inserted here too.
+// CHECK: bb2({{.*}}):
+// CHECK-NEXT: cond_fail
+// CHECK-NEXT: br bb1
+bb6(%20 : $Builtin.Int64, %21 : $Builtin.Int64, %22 : $Builtin.Int1):
+  br bb1(%20 : $Builtin.Int64, %21 : $Builtin.Int64, %22 : $Builtin.Int1)
+
+// Make sure that this predecessor -- which directly branches to bb1 and
+// supplies a constant for %9 -- also gets the hoisted cond_fail.
+// CHECK: bb3:
+// CHECK-NEXT: cond_fail
 // CHECK-NEXT: br bb1
 bb2:
   br bb1(%2 : $Builtin.Int64, %2 : $Builtin.Int64, %1 : $Builtin.Int1)
 
-// CHECK: bb3:
+// CHECK: bb4:
 bb3:
   %5 = tuple()
   return %5 : $()
+
+bb4:
+  br bb3
+
+bb5:
+  br bb3
 }

--- a/test/SILOptimizer/mutable_span_bounds_check_tests.swift
+++ b/test/SILOptimizer/mutable_span_bounds_check_tests.swift
@@ -10,7 +10,7 @@
 // XFAIL: OS=wasip1
 
 // CHECK-SIL-LABEL: sil @$s31mutable_span_bounds_check_tests0a1_B11_sum_w_trapySis11MutableSpanVySiGF :
-// CHECK-SIL: bb3({{.*}}):
+// CHECK-SIL: bb5({{.*}}):
 // CHECK-SIL-NOT: cond_fail {{.*}}, "index out of bounds"
 // CHECK-SIL-LABEL: } // end sil function '$s31mutable_span_bounds_check_tests0a1_B11_sum_w_trapySis11MutableSpanVySiGF'
 public func mutable_span_sum_w_trap(_ ms: borrowing MutableSpan<Int>) -> Int {
@@ -22,7 +22,7 @@ public func mutable_span_sum_w_trap(_ ms: borrowing MutableSpan<Int>) -> Int {
 }
 
 // CHECK-SIL-LABEL: sil @$s31mutable_span_bounds_check_tests0a1_B12_sum_wo_trapySis11MutableSpanVySiGF :
-// CHECK-SIL: bb3({{.*}}):
+// CHECK-SIL: bb5({{.*}}):
 // CHECK-SIL-NOT: cond_fail {{.*}}, "index out of bounds"
 // CHECK-SIL-LABEL: } // end sil function '$s31mutable_span_bounds_check_tests0a1_B12_sum_wo_trapySis11MutableSpanVySiGF'
 public func mutable_span_sum_wo_trap(_ ms: borrowing MutableSpan<Int>) -> Int {
@@ -58,7 +58,7 @@ public func mutable_span_sum_wo_trap_unknown_bound(_ ms: borrowing MutableSpan<I
 }
 
 // CHECK-SIL-LABEL: sil @$s31mutable_span_bounds_check_tests0B10_zero_inityys11MutableSpanVySiGzF :
-// CHECK-SIL: bb3({{.*}}):
+// CHECK-SIL: bb5({{.*}}):
 // CHECK-SIL-NOT: cond_fail {{.*}}, "index out of bounds"
 // CHECK-SIL: cond_br
 // CHECK-SIL-LABEL: } // end sil function '$s31mutable_span_bounds_check_tests0B10_zero_inityys11MutableSpanVySiGzF'
@@ -72,7 +72,7 @@ public func span_zero_init(_ output: inout MutableSpan<Int>) {
 }
 
 // CHECK-SIL-LABEL: sil @$s31mutable_span_bounds_check_tests0B14_copy_elemwiseyys11MutableSpanVySiGz_s0I0VySiGtF :
-// CHECK-SIL: bb3({{.*}}):
+// CHECK-SIL: bb5({{.*}}):
 // CHECK-SIL-NOT: cond_fail {{.*}}, "index out of bounds"
 // CHECK-SIL: cond_br
 // CHECK-SIL-LABEL: } // end sil function '$s31mutable_span_bounds_check_tests0B14_copy_elemwiseyys11MutableSpanVySiGz_s0I0VySiGtF'
@@ -89,7 +89,7 @@ public func span_copy_elemwise(_ output: inout MutableSpan<Int>, _ input: Span<I
 }
 
 // CHECK-SIL-LABEL: sil @$s31mutable_span_bounds_check_tests0B16_append_elemwiseyys10OutputSpanVySiGz_s0I0VySiGtF :
-// CHECK-SIL: bb3({{.*}}):
+// CHECK-SIL: bb5({{.*}}):
 // CHECK-SIL-NOT: cond_fail {{.*}}, "index out of bounds"
 // CHECK-SIL: cond_br
 // CHECK-SIL-LABEL: } // end sil function '$s31mutable_span_bounds_check_tests0B16_append_elemwiseyys10OutputSpanVySiGz_s0I0VySiGtF'
@@ -105,7 +105,7 @@ public func span_append_elemwise(_ output: inout OutputSpan<Int>, _ input: Span<
 }
 
 // CHECK-SIL-LABEL: sil @$s31mutable_span_bounds_check_tests0B12_sum_wo_trapyys11MutableSpanVySiGz_s0J0VySiGAHtF :
-// CHECK-SIL: bb3({{.*}}):
+// CHECK-SIL: bb5({{.*}}):
 // CHECK-SIL-NOT: cond_fail {{.*}}, "index out of bounds"
 // CHECK-SIL: cond_br
 // CHECK-SIL-LABEL: } // end sil function '$s31mutable_span_bounds_check_tests0B12_sum_wo_trapyys11MutableSpanVySiGz_s0J0VySiGAHtF'
@@ -123,7 +123,7 @@ public func span_sum_wo_trap(_ output: inout MutableSpan<Int>, _ input1: Span<In
 }
 
 // CHECK-SIL-LABEL: sil @$s31mutable_span_bounds_check_tests0B14_sum_with_trapyys11MutableSpanVySiGz_s0J0VySiGAHtF :
-// CHECK-SIL: bb3({{.*}}):
+// CHECK-SIL: bb5({{.*}}):
 // CHECK-SIL-NOT: cond_fail {{.*}}, "index out of bounds"
 // CHECK-SIL: cond_br
 // CHECK-SIL-LABEL: } // end sil function '$s31mutable_span_bounds_check_tests0B14_sum_with_trapyys11MutableSpanVySiGz_s0J0VySiGAHtF'

--- a/test/SILOptimizer/mutable_span_stdlib_bounds_check_tests.swift
+++ b/test/SILOptimizer/mutable_span_stdlib_bounds_check_tests.swift
@@ -5,7 +5,7 @@ public protocol P {
 }
 
 // CHECK-SIL-LABEL: sil @$s38mutable_span_stdlib_bounds_check_tests0a1_B7_doubleyys11MutableSpanVyxGzAA1PRzlF :
-// CHECK-SIL: bb3({{.*}}):
+// CHECK-SIL: bb{{[0-9]+}}({{.*}}):
 // CHECK-SIL-NOT: end_cow_mutation
 // CHECK-SIL-NOT: cond_fail "index out of bounds"
 // CHECK-SIL-LABEL: } // end sil function '$s38mutable_span_stdlib_bounds_check_tests0a1_B7_doubleyys11MutableSpanVyxGzAA1PRzlF'

--- a/test/SILOptimizer/opened_archetype_operands_tracking.sil
+++ b/test/SILOptimizer/opened_archetype_operands_tracking.sil
@@ -286,7 +286,7 @@ bb0(%0 : $C):
   strong_retain %0 : $C
   release_value %1 : $MyOptional<C>
   %6 = integer_literal $Builtin.Int1, -1
-  cond_br %6, bb5, bb1
+  cond_br %6, bb6, bb1
 
 bb1:
   %8 = enum $MyOptional<C>, #MyOptional.some!enumelt, %0 : $C
@@ -311,4 +311,9 @@ bb4:
 bb5:
   %22 = tuple ()
   return %22 : $()
+
+// Trampoline to avoid the critical edge from bb0's cond_br to bb5 (which
+// also has bb4 as a predecessor).
+bb6:
+  br bb5
 } // end sil function 'test_infinite_loop_in_unreachable_block'

--- a/test/SILOptimizer/performance_inliner.sil
+++ b/test/SILOptimizer/performance_inliner.sil
@@ -760,16 +760,19 @@ bb0(%0 : $Int32):
   %9 = apply %8(%6) : $@convention(thin) (Bool) -> Bool // user: %10
   %10 = struct_extract %9 : $Bool, #Bool._value    // user: %12
   dealloc_stack %1 : $*Bool      // id: %11
-  cond_br %10, bb1, bb2                           // id: %12
+  cond_br %10, bb1, bb3                           // id: %12
 
 bb1:                                              // Preds: bb0
   %13 = function_ref @coldcall : $@convention(thin) () -> () // user: %14
   %14 = apply %13() : $@convention(thin) () -> ()
   br bb2                                          // id: %15
 
-bb2:                                              // Preds: bb0 bb1
+bb2:                                              // Preds: bb1 bb3
   %16 = tuple ()                                  // user: %17
   return %16 : $()                                // id: %17
+
+bb3:                                              // Preds: bb0
+  br bb2
 }
 
 sil @slowHelper : $@convention(thin) () -> () {
@@ -824,7 +827,7 @@ bb0:
   %v18 = apply %f1(%v16) : $@convention(thin) (Bool) -> Bool
   %v19 = struct_extract %v18 : $Bool, #Bool._value
   dealloc_stack %v9 : $*Bool      // id: %20
-  cond_br %v19, bb2, bb1                           // id: %21
+  cond_br %v19, bb3, bb1                           // id: %21
 
 bb1:
   %f2 = function_ref @slowHelper : $@convention(thin) () -> ()
@@ -834,6 +837,9 @@ bb1:
 bb2:
   %t3 = tuple ()
   return %t3 : $()
+
+bb3:
+  br bb2
 }
 
 // CHECK-LABEL:  @testInlineSlowTransparent
@@ -852,7 +858,7 @@ bb0:
   %v18 = apply %f1(%v16) : $@convention(thin) (Bool) -> Bool
   %v19 = struct_extract %v18 : $Bool, #Bool._value
   dealloc_stack %v9 : $*Bool      // id: %20
-  cond_br %v19, bb2, bb1                           // id: %21
+  cond_br %v19, bb3, bb1                           // id: %21
 
 bb1:
   %f2 = function_ref @slowHelper : $@convention(thin) () -> ()
@@ -862,6 +868,9 @@ bb1:
 bb2:
   %t3 = tuple ()
   return %t3 : $()
+
+bb3:
+  br bb2
 }
 
 // Attempt to ensure that calling the devirtualizer on a try_apply

--- a/test/SILOptimizer/phi-expansion.sil
+++ b/test/SILOptimizer/phi-expansion.sil
@@ -99,7 +99,9 @@ bb3:
 // CHECK-LABEL: sil @test_loop_with_cond_br
 // CHECK:   br bb1(%{{[0-9]*}} : $Int)
 // CHECK: bb1(%{{[0-9]*}} : $Int):
-// CHECK:   cond_br undef, bb1(%{{[0-9]*}} : $Int), bb2
+// CHECK:   cond_br undef, bb3, bb2
+// CHECK: bb3:
+// CHECK:   br bb1(%{{[0-9]*}} : $Int)
 // CHECK: } // end sil function 'test_loop_with_cond_br'
 sil @test_loop_with_cond_br : $@convention(thin) (Mystruct) -> Int {
 bb0(%0 : $Mystruct):
@@ -107,9 +109,14 @@ bb0(%0 : $Mystruct):
 
 bb1(%2 : $Mystruct):
   %3 = struct_extract %2 : $Mystruct, #Mystruct.i
-  cond_br undef, bb1(%2 : $Mystruct), bb2
+  cond_br undef, bb3, bb2
 
 bb2:
   return %3 : $Int
+
+// Trampoline to avoid the critical edge from bb1's cond_br back to itself
+// (bb1 also has bb0 as a predecessor).
+bb3:
+  br bb1(%2 : $Mystruct)
 }
 

--- a/test/SILOptimizer/postdomtree_verification_crash.sil
+++ b/test/SILOptimizer/postdomtree_verification_crash.sil
@@ -9,7 +9,7 @@ import Swift
 
 sil @testit : $@convention(thin) () -> () {
 bb0:
-  cond_br undef, bb1, bb2
+  cond_br undef, bb3, bb2
 
 bb1:
   br bb1
@@ -17,5 +17,8 @@ bb1:
 bb2:
   %r = tuple ()
   return %r : $()
+
+bb3:
+  br bb1
 }
 

--- a/test/SILOptimizer/ranges_unit.sil
+++ b/test/SILOptimizer/ranges_unit.sil
@@ -51,17 +51,27 @@ bb6:
   return %r : $()
 }
 
+// Note: this function originally had 5 critical edges (bb3->bb5, bb3->bb7,
+// bb5->bb2, bb6->bb1, bb6->bb7), which are no longer allowed by the SIL
+// verifier. Trampoline blocks bb8-bb12 were inserted to split those edges.
+// Of those, bb8 and bb10 (splitting bb3->bb5 and bb5->bb2) get swept into the
+// backward range walk, and bb9 (splitting bb3->bb7) becomes the new exit
+// block reached from bb3, which changes the expected instruction/block exit
+// below from bb7's `tuple ()` to bb9's `br bb7`. bb11 and bb12 (splitting
+// bb6->bb1 and bb6->bb7) are not discovered by the walk, since bb6 is an end
+// block and the walk does not look past `begin` (bb1) or past end blocks'
+// forward successors.
 // CHECK-LABEL: Instruction range in loops:
 // CHECK-NEXT: begin:      %3 = string_literal utf8 "begin"
 // CHECK-NEXT: ends:       %10 = string_literal utf8 "end"
-// CHECK-NEXT: exits:      %12 = tuple ()
+// CHECK-NEXT: exits:      br bb7
 // CHECK-NEXT: interiors:
 // CHECK-NEXT: Block range in loops:
 // CHECK-NEXT: begin:     bb1
-// CHECK-NEXT: range:     [bb5, bb3, bb2, bb1, bb4]
-// CHECK-NEXT: inclrange: [bb6, bb5, bb3, bb2, bb1, bb4]
+// CHECK-NEXT: range:     [bb5, bb4, bb2, bb1, bb10, bb8, bb3]
+// CHECK-NEXT: inclrange: [bb6, bb5, bb4, bb2, bb1, bb10, bb8, bb3]
 // CHECK-NEXT: ends:      [bb6]
-// CHECK-NEXT: exits:     [bb7]
+// CHECK-NEXT: exits:     [bb9]
 // CHECK-NEXT: interiors: []
 // CHECK-NEXT: End function loops
 sil @loops : $@convention(thin) () -> () {
@@ -77,17 +87,28 @@ bb1:
 bb2:
   cond_br undef, bb3, bb4
 bb3:
-  cond_br undef, bb5, bb7
+  cond_br undef, bb8, bb9
 bb4:
   br bb5
 bb5:
-  cond_br undef, bb2, bb6
+  cond_br undef, bb10, bb6
 bb6:
   %8 = string_literal utf8 "end"
-  cond_br undef, bb1, bb7
+  cond_br undef, bb11, bb12
 bb7:
   %r = tuple()
   return %r : $()
+// trampolines below to avoid critical edges (bb3->bb5, bb3->bb7, bb5->bb2, bb6->bb1, bb6->bb7)
+bb8:
+  br bb5
+bb9:
+  br bb7
+bb10:
+  br bb2
+bb11:
+  br bb1
+bb12:
+  br bb7
 }
 
 // CHECK-LABEL: Instruction range in minimal:

--- a/test/SILOptimizer/rcidentity.sil
+++ b/test/SILOptimizer/rcidentity.sil
@@ -138,10 +138,13 @@ bb3(%5 : $Builtin.NativeObject):
   br bb4(%5 : $Builtin.NativeObject)
 
 bb4(%6 : $Builtin.NativeObject):
-  cond_br undef, bb4(%6 : $Builtin.NativeObject), bb5
+  cond_br undef, bb6(%6 : $Builtin.NativeObject), bb5
 
 bb5:
   return undef : $()
+
+bb6(%7 : $Builtin.NativeObject):
+  br bb4(%7 : $Builtin.NativeObject)
 }
 
 // All of the SSA values in the given function can be resolved to %0.

--- a/test/SILOptimizer/rcidentity.sil
+++ b/test/SILOptimizer/rcidentity.sil
@@ -112,39 +112,37 @@ bb0(%0 : $Builtin.NativeObject, %1 : $Builtin.Word):
   return undef : $()
 }
 
-// All of the SSA values in the given function besides %6 can be resolved to
-// (%0, %1). Because %6 has multiple SSA values and there is nothing tricky we
-// can do here, just bail.
+// All of the SSA values in the given function besides the bb4 phi (%4) can be
+// resolved to (%0, %1). Because that phi merges multiple distinct SSA values
+// and there is nothing tricky we can do here, just bail.
 //
 // CHECK-LABEL: @test_single_pred_rc_id@
 // CHECK: RESULT #0: 0 = 0
 // CHECK: RESULT #1: 1 = 1
 // CHECK: RESULT #2: 2 = 0
 // CHECK: RESULT #3: 3 = 1
-// CHECK: RESULT #4: 4 = 1
-// CHECK: RESULT #5: 5 = 0
-// CHECK: RESULT #6: 6 = 6
+// CHECK: RESULT #4: 4 = 4
 sil @test_single_pred_rc_id : $@convention(thin) (Builtin.NativeObject, Builtin.NativeObject) -> () {
 bb0(%0 : $Builtin.NativeObject, %1 : $Builtin.NativeObject):
   br bb1(%0 : $Builtin.NativeObject, %1 : $Builtin.NativeObject)
 
 bb1(%2 : $Builtin.NativeObject, %3 : $Builtin.NativeObject):
-  cond_br undef, bb2(%3 : $Builtin.NativeObject), bb3(%2 : $Builtin.NativeObject)
+  cond_br undef, bb2, bb3
 
-bb2(%4 : $Builtin.NativeObject):
-  br bb4(%4 : $Builtin.NativeObject)
+bb2:
+  br bb4(%3 : $Builtin.NativeObject)
 
-bb3(%5 : $Builtin.NativeObject):
-  br bb4(%5 : $Builtin.NativeObject)
+bb3:
+  br bb4(%2 : $Builtin.NativeObject)
 
 bb4(%6 : $Builtin.NativeObject):
-  cond_br undef, bb6(%6 : $Builtin.NativeObject), bb5
+  cond_br undef, bb6, bb5
 
 bb5:
   return undef : $()
 
-bb6(%7 : $Builtin.NativeObject):
-  br bb4(%7 : $Builtin.NativeObject)
+bb6:
+  br bb4(%6 : $Builtin.NativeObject)
 }
 
 // All of the SSA values in the given function can be resolved to %0.
@@ -154,20 +152,18 @@ bb6(%7 : $Builtin.NativeObject):
 // CHECK: RESULT #1: 1 = 0
 // CHECK: RESULT #2: 2 = 0
 // CHECK: RESULT #3: 3 = 0
-// CHECK: RESULT #4: 4 = 0
-// CHECK: RESULT #5: 5 = 0
 sil @test_multiple_pred_same_rcid : $@convention(thin) (Builtin.NativeObject) -> () {
 bb0(%0 : $Builtin.NativeObject):
   br bb1(%0 : $Builtin.NativeObject, %0 : $Builtin.NativeObject)
 
 bb1(%2 : $Builtin.NativeObject, %3 : $Builtin.NativeObject):
-  cond_br undef, bb2(%3 : $Builtin.NativeObject), bb3(%2 : $Builtin.NativeObject)
+  cond_br undef, bb2, bb3
 
-bb2(%4 : $Builtin.NativeObject):
-  br bb4(%4 : $Builtin.NativeObject)
+bb2:
+  br bb4(%3 : $Builtin.NativeObject)
 
-bb3(%5 : $Builtin.NativeObject):
-  br bb4(%5 : $Builtin.NativeObject)
+bb3:
+  br bb4(%2 : $Builtin.NativeObject)
 
 bb4(%6 : $Builtin.NativeObject):
   br bb5

--- a/test/SILOptimizer/recursive_func.sil
+++ b/test/SILOptimizer/recursive_func.sil
@@ -44,7 +44,7 @@ bb0(%0 : $Int, %1 : $REC):
   %9 = apply %6(%8, %7) : $@convention(thin) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %10
   %10 = apply %5(%0, %9) : $@convention(thin) (Int, Int) -> Bool // user: %11
   %11 = apply %4(%10) : $@convention(method) (Bool) -> Builtin.Int1 // user: %12
-  cond_br %11, bb1, bb2                           // id: %12
+  cond_br %11, bb1, bb3                           // id: %12
 
 bb1:                                              // Preds: bb0
   strong_retain %1 : $REC                         // id: %13
@@ -71,10 +71,13 @@ bb1:                                              // Preds: bb0
   %30 = apply %23(%29, %1) : $@convention(method) (Int, @guaranteed REC) -> ()
   br bb2                                          // id: %31
 
-bb2:                                              // Preds: bb0 bb1
+bb2:                                              // Preds: bb1
   strong_release %1 : $REC                        // id: %32
   %33 = tuple ()                                  // user: %34
   return %33 : $()                                // id: %34
+
+bb3:                                              // Preds: bb0
+  br bb2                                          // id: %35
 }
 
 // Swift.Bool._getBuiltinLogicValue (Swift.Bool)() -> Builtin.Int1

--- a/test/SILOptimizer/recursive_single.sil
+++ b/test/SILOptimizer/recursive_single.sil
@@ -46,7 +46,7 @@ bb0(%0 : $Int, %1 : $REC):
   %9 = apply %6(%8, %7) : $@convention(thin) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %10
   %10 = apply %5(%0, %9) : $@convention(thin) (Int, Int) -> Bool // user: %11
   %11 = apply %4(%10) : $@convention(method) (Bool) -> Builtin.Int1 // user: %12
-  cond_br %11, bb1, bb2                           // id: %12
+  cond_br %11, bb1, bb3                           // id: %12
 
 bb1:                                              // Preds: bb0
   strong_retain %1 : $REC                         // id: %13
@@ -62,10 +62,13 @@ bb1:                                              // Preds: bb0
   %21 = apply %14(%20, %1) : $@convention(method) (Int, @guaranteed REC) -> ()
   br bb2                                          // id: %22
 
-bb2:                                              // Preds: bb0 bb1
+bb2:                                              // Preds: bb1 bb3
   strong_release %1 : $REC                        // id: %23
   %24 = tuple ()                                  // user: %25
   return %24 : $()                                // id: %25
+
+bb3:                                              // Preds: bb0
+  br bb2                                          // id: %26
 }
 
 // Swift.Bool._getBuiltinLogicValue (Swift.Bool)() -> Builtin.Int1

--- a/test/SILOptimizer/redundant_load_elim.sil
+++ b/test/SILOptimizer/redundant_load_elim.sil
@@ -221,10 +221,13 @@ bb1:
   %5 = load %3 : $*A
   %6 = load %3 : $*A
   store %2 to %3 : $*A
-  cond_br undef, bb1, bb2
+  cond_br undef, bb_crit1, bb2
 
 bb2:
   return %5 : $A
+
+bb_crit1:
+  br bb1
 }
 
 // CHECK-LABEL: sil @test_read_dependence_allows_forwarding_multi_bb_1 : $@convention(thin) (@inout A, A) -> A {
@@ -251,10 +254,13 @@ bb1:
   // longer be needed.
   %6 = load %0 : $*A
   store %1 to %0 : $*A
-  cond_br undef, bb1, bb2
+  cond_br undef, bb_crit2, bb2
 
 bb2:
   return %5 : $A
+
+bb_crit2:
+  br bb1
 }
 
 // DISABLE this test for now. it seems DCE is not getting rid of the load in bb8 after the RLE happens.
@@ -555,9 +561,9 @@ bb0:
   %8 = ref_element_addr %6 : $AX, #AX.current
   store %2 to %8 : $*Int32
   // %10 = load %8 : $*Int32
-  cond_br undef, bb3, bb2
+  cond_br undef, bb3, bb6
 
-bb2:
+bb1:
   %24 = integer_literal $Builtin.Int1, -1
   %31 = struct_element_addr %0 : $*Int32, #Int32.value
   %32 = load %31 : $*Builtin.Int32
@@ -565,12 +571,24 @@ bb2:
   %34 = tuple_extract %33 : $(Builtin.Int32, Builtin.Int1), 0
   %37 = struct $Int32 (%34 : $Builtin.Int32)
   store %37 to %0 : $*Int32
-  cond_br undef, bb3, bb2
+  cond_br undef, bb4, bb2
+
+bb2:
+  br bb1
 
 bb3:
+  br bb5
+
+bb4:
+  br bb5
+
+bb5:
   strong_release %6 : $AX
   %44 = tuple ()
   return %44 : $()
+
+bb6:
+  br bb1
 }
 
 // CHECK-LABEL: sil @load_to_load_forwarding_diamonds : $@convention(thin) (@inout Builtin.Int32) -> Builtin.Int32 {
@@ -591,7 +609,7 @@ bb2:
 
 bb3:
   // Triangle
-  cond_br undef, bb4, bb5
+  cond_br undef, bb4, bb_crit3
 
 bb4:
   br bb5
@@ -599,6 +617,9 @@ bb4:
 bb5:
   %2 = load %0 : $*Builtin.Int32
   return %2 : $Builtin.Int32
+
+bb_crit3:
+  br bb5
 }
 
 
@@ -678,10 +699,13 @@ bb1:
   %223 = apply %22(%7) : $@convention(thin) (A) -> ()
   %323 = apply %22(%8) : $@convention(thin) (A) -> ()
   store %2 to %0 : $*A
-  cond_br undef, bb1, bb2
+  cond_br undef, bb3, bb2
 
 bb2:
   return %7 : $A
+
+bb3:
+  br bb1
 }
 
 // CHECK-LABEL: sil @load_to_load_loop
@@ -708,7 +732,7 @@ bb1:
   %6 = load %0 : $*Builtin.Int32
   %11125 = function_ref @use : $@convention(thin) (Builtin.Int32) -> () // user: %23
   %11126 = apply %11125(%6) : $@convention(thin) (Builtin.Int32) -> ()
-  cond_br undef, bb1, bb2
+  cond_br undef, bb3, bb2
 
 bb2:
   %7 = load %0 : $*Builtin.Int32
@@ -718,6 +742,9 @@ bb2:
   dealloc_stack %101 : $*Int32
   %9999 = tuple()
   return %9999 : $()
+
+bb3:
+  br bb1
 }
 
 // CHECK-LABEL: store_and_load_to_load_branches_diamond
@@ -903,7 +930,7 @@ bb9:                                              // Preds: bb7 bb8
 // CHECK: bb7:
 // CHECK:   br bb10(%3 : $Int)
 // CHECK: bb8:
-// CHECK:   cond_br undef, bb9, bb10(%3 : $Int)
+// CHECK:   cond_br undef, bb9, bb11
 // CHECK-NOT: = load
 // CHECK: bb10([[A:%[0-9]+]] : $Int):
 // CHECK-NOT: = load
@@ -946,7 +973,7 @@ bb7:                                              // Preds: bb3 bb4
   br bb10                                         // id: %19
 
 bb8:                                              // Preds: bb5 bb6
-  cond_br undef, bb9, bb10                        // id: %20
+  cond_br undef, bb9, bb11                        // id: %20
 
 bb9:                                              // Preds: bb8
   %21 = struct_element_addr %1 : $*TwoField, #TwoField.a // user: %22
@@ -960,6 +987,9 @@ bb10:                                             // Preds: bb7 bb8 bb9
   %27 = load %26 : $*Int                          // user: %29
   dealloc_stack %1 : $*TwoField  // id: %28
   return %27 : $Int                               // id: %29
+
+bb11:
+  br bb10
 }
 
 // CHECK-LABEL: sil @test_project_box
@@ -1041,7 +1071,7 @@ bb0:
   %15 = load %12 : $*Builtin.Int32
   %16 = load %13 : $*Builtin.Int32
   %17 = builtin "cmp_eq_Int32"(%15 : $Builtin.Int32, %16 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %17, bb3, bb1
+  cond_br %17, bb5, bb1
 
 bb2(%20 : $Builtin.Int32):
   %21 = load %12 : $*Builtin.Int32
@@ -1064,7 +1094,7 @@ bb2(%20 : $Builtin.Int32):
   %39 = load %12 : $*Builtin.Int32
   %40 = load %13 : $*Builtin.Int32
   %41 = builtin "cmp_eq_Int32"(%39 : $Builtin.Int32, %40 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %41, bb3, bb2(%39 : $Builtin.Int32)
+  cond_br %41, bb6, bb4
 
 // bb1 is after bb2 to make sure the first predecessor of bb2 is not bb2 to
 // expose the bug.
@@ -1075,6 +1105,15 @@ bb3:
   strong_release %7 : $NewRangeGenerator1
   %44 = tuple ()
   return %44 : $()
+
+bb4:
+  br bb2(%39)
+
+bb5:
+  br bb3
+
+bb6:
+  br bb3
 }
 
 // Make sure the first load in bb1 is not eliminated as we have
@@ -1113,7 +1152,7 @@ bb1:
   %6 = load %0 : $*Builtin.Int32
   %11125 = function_ref @use : $@convention(thin) (Builtin.Int32) -> () // user: %23
   %11126 = apply %11125(%6) : $@convention(thin) (Builtin.Int32) -> ()
-  cond_br undef, bb1, bb2
+  cond_br undef, bb3, bb2
 
 bb2:
   %7 = load %0 : $*Builtin.Int32
@@ -1123,6 +1162,9 @@ bb2:
   dealloc_stack %101 : $*Int32
   %9999 = tuple()
   return %9999 : $()
+
+bb3:
+  br bb1
 }
 
 // CHECK-LABEL: sil hidden @redundant_load_over_intermediate_release_without_epilogue_release : $@convention(thin) (@owned AB) -> () {

--- a/test/SILOptimizer/retain_release_code_motion.sil
+++ b/test/SILOptimizer/retain_release_code_motion.sil
@@ -475,7 +475,7 @@ bb0(%0 : $Builtin.NativeObject):
   br bb1
 
 bb1:
-  cond_br undef, bb1, bb2
+  cond_br undef, bb3, bb2
 
 bb2:
   %2 = function_ref @blocker : $@convention(thin) () -> ()
@@ -483,6 +483,9 @@ bb2:
   strong_release %0 : $Builtin.NativeObject
   %1 = tuple()
   return %1 : $()
+
+bb3:
+  br bb1
 }
 
 // CHECK-LABEL: sil @move_release_over_loop
@@ -506,9 +509,12 @@ bb0(%0 : $Builtin.NativeObject):
   br bb1
 
 bb1:
-  cond_br undef, bb1, bb2
+  cond_br undef, bb2, bb3
 
 bb2:
+  br bb1
+
+bb3:
   strong_release %0 : $Builtin.NativeObject
   %1 = tuple()
   return %1 : $()

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -106,12 +106,15 @@ bb1:
   %2 = function_ref @random_counter : $@convention(thin) () -> Builtin.Int1
   %3 = apply %2() : $@convention(thin) () -> Builtin.Int1
   %4 = integer_literal $Builtin.Int64, 48
-  cond_br %3, bb1, bb2
+  cond_br %3, bb3, bb2
 
 bb2:
   %5 = integer_literal $Builtin.Int64, 59
   %6 = tuple()
   return %6 : $()
+
+bb3:
+  br bb1
 }
 
 // For now until the proper unreachable pruning code is committed for
@@ -175,13 +178,15 @@ bb0(%0 : $B):
 sil @removeTriviallyDeadCrossBasicBlocks : $@convention(thin) (@owned B, Builtin.Int1) -> () {
 bb0(%0: $B, %1: $Builtin.Int1):
   %5 = unchecked_ref_cast %0 : $B to $Builtin.NativeObject
-  cond_br %1, bb1, bb2
+  cond_br %1, bb1, bb3
 bb1:
   br bb2
 bb2:
   %9 = function_ref @exit : $@convention(thin) () -> Never // ret.exit : () -> ()
   %10 = apply %9() : $@convention(thin) () -> Never
   unreachable
+bb3:
+  br bb2
 }
 
 // CHECK-LABEL: sil @dead_use_of_alloc_stack
@@ -635,7 +640,7 @@ sil @dead_closure_elimination : $@convention(thin) (@owned C) -> () {
 bb0(%0 : $C):
   %1 = function_ref @test_closure : $@convention(thin) (@guaranteed C) -> ()
   %2 = partial_apply [callee_guaranteed] %1(%0) : $@convention(thin) (@guaranteed C) -> ()
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1, bb3
 bb1:
   strong_retain %2 : $@callee_guaranteed () -> ()
   strong_release %2 : $@callee_guaranteed () -> ()
@@ -644,6 +649,8 @@ bb2:
   release_value %2 : $@callee_guaranteed () -> ()
   %5 = tuple()
   return %5 : $()
+bb3:
+  br bb2
 }
 
 ////////////////////////////////////////////
@@ -2729,13 +2736,15 @@ bb0(%0 : $B):
   dealloc_stack %4 : $*B
   br bb1
 bb1:
-  cond_br undef, bb1, bb2
+  cond_br undef, bb3, bb2
 bb2:
   strong_retain %0 : $B
   destroy_addr %3 : $*B
   dealloc_stack %3 : $*B
   %14 = tuple ()
   return %14 : $()
+bb3:
+  br bb1
 }
 
 protocol someProtocol {
@@ -3139,7 +3148,7 @@ sil @unconditional_existential_box_cast_not_dominating : $@convention(thin) (@gu
 bb0(%0 : $TestError):
   %1 = alloc_existential_box $Error, $TestError
   %2 = project_existential_box $TestError in %1 : $Error
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1, bb5
 bb1:
   store %0 to %2 : $*TestError
   br bb2
@@ -3162,6 +3171,8 @@ bb4:
   %20 = integer_literal $Builtin.Int1, -1
   cond_fail %20 : $Builtin.Int1
   unreachable
+bb5:
+  br bb2
 }
 
 // CHECK-LABEL: sil @conditional_existential_box_cast

--- a/test/SILOptimizer/sil_combine_apply.sil
+++ b/test/SILOptimizer/sil_combine_apply.sil
@@ -295,11 +295,13 @@ bb0(%0 : $*T, %1 : $*T):
   br bb1
 bb1:
   %a1 = apply %pa(%0) : $@callee_guaranteed (@in T) -> ()
-  cond_br undef, bb1, bb2
+  cond_br undef, bb3, bb2
 bb2:
   strong_release %pa : $@callee_guaranteed (@in T) -> ()
   %r = tuple ()
   return %r : $()
+bb3:
+  br bb1
 }
 
 // Now check that we handle the in_guaranteed case.

--- a/test/SILOptimizer/sil_combine_enum_addr.sil
+++ b/test/SILOptimizer/sil_combine_enum_addr.sil
@@ -34,7 +34,7 @@ bb0(%0 : $*Int, %1 : $*_Stdout):
   %11 = integer_literal $Builtin.Int1, -1
   %12 = integer_literal $Builtin.Int1, 0
   %13 = select_enum_addr %3 : $*Optional<CustomStringConvertible>, case #Optional.some!enumelt: %11, case #Optional.none!enumelt: %12 : $Builtin.Int1
-  cond_br %13, bb2, bb1
+  cond_br %13, bb2, bb3
 
 bb1:
   %15 = tuple ()
@@ -45,6 +45,9 @@ bb1:
 bb2:
   %19 = unchecked_inplace_enum_data_addr %3 : $*Optional<CustomStringConvertible>, #Optional.some!enumelt
   copy_addr [take] %19 to [init] %2 : $*CustomStringConvertible
+  br bb1
+
+bb3:
   br bb1
 }
 

--- a/test/SILOptimizer/sil_combine_enums.sil
+++ b/test/SILOptimizer/sil_combine_enums.sil
@@ -59,7 +59,7 @@ bb2:                                              // Preds: bb0
 
 // CHECK-LABEL: sil @eliminate_select_enum_addr
 // CHECK-NOT: select_enum_addr
-// CHECK: select_enum
+// CHECK: switch_enum
 // CHECK: return
 
 sil @eliminate_select_enum_addr : $@convention(thin) () -> Int {
@@ -77,7 +77,7 @@ bb0:
   %t = integer_literal $Builtin.Int1, -1
   %f = integer_literal $Builtin.Int1, 0
   %b = select_enum_addr %7 : $*Optional<SomeClass>, case #Optional.some!enumelt: %t, case #Optional.none!enumelt: %f : $Builtin.Int1
-  cond_br %b, bb1, bb2
+  cond_br %b, bb3, bb2
 
 bb1:
   %11 = unchecked_inplace_enum_data_addr %7 : $*Optional<SomeClass>, #Optional.some!enumelt
@@ -92,10 +92,12 @@ bb1:
   return %16 : $Int
 
 bb2:
-  // Invoke something here and jump to bb1. This prevents a cond_br(select_enum) -> switch_enum conversion,
-  // since it would introduce a critical edge.
+  // Invoke something here before jumping to bb1.
   %20 = function_ref @external_func: $@convention(thin) () -> ()
   apply %20(): $@convention(thin) () -> ()
+  br bb1
+
+bb3:
   br bb1
 }
 
@@ -201,7 +203,7 @@ bb0(%0 : $*Int32, %1 : $Builtin.Int32, %2 : $Builtin.Int1):
   %i2 = load %0 : $*Int32
   %en = enum $Optional<Int32>, #Optional.none!enumelt
   store %en to %s1 : $*Optional<Int32>
-  cond_br %2, bb1, bb2
+  cond_br %2, bb1, bb3
 
 bb1:
   %e1 = init_enum_data_addr %s1 : $*Optional<Int32>, #Optional.some!enumelt
@@ -215,10 +217,13 @@ bb1:
   store %i to %0 : $*Int32
   br bb2
 
-bb2:                                              // Preds: bb0 bb1
+bb2:                                              // Preds: bb1 bb3
   inject_enum_addr %s1 : $*Optional<Int32>, #Optional.some!enumelt
   dealloc_stack %s1 : $*Optional<Int32>
   return %i2 : $Int32
+
+bb3:                                              // Preds: bb0
+  br bb2
 }
 
 // CHECK-LABEL: sil @fail_to_canonicalize_init_enum_data_addr
@@ -341,19 +346,23 @@ bb3:
 }
 
 
-// Check that cond_br(select_enum) is not converted into switch_enum as it would create a critical edge, which
-// is not originating from cond_br/br. And this is forbidden in a canonical SIL form.
+// Check that cond_br(select_enum) is converted into switch_enum.
+// (Previously, when the destination blocks were allowed to share a
+// predecessor via a critical edge, this conversion was blocked to avoid
+// introducing a critical edge. Critical edges are no longer permitted in
+// SIL at all, so the source below is expressed without one, and the
+// conversion is legal.)
 //
 // CHECK-LABEL: sil @dont_convert_select_enum_cond_br_to_switch_enum
-// CHECK: select_enum
-// CHECK-NOT: switch_enum
+// CHECK-NOT: select_enum
+// CHECK: switch_enum
 // CHECK: return
 sil @dont_convert_select_enum_cond_br_to_switch_enum : $@convention(thin) (@owned Optional<SomeClass>) -> Int {
 bb0(%0 : $Optional<SomeClass>):
   %2 = integer_literal $Builtin.Int1, 0
   %3 = integer_literal $Builtin.Int1, -1
   %4 = select_enum %0 : $Optional<SomeClass>, case #Optional.none!enumelt: %3, case #Optional.some!enumelt: %2 : $Builtin.Int1
-  cond_br %4, bb2, bb1
+  cond_br %4, bb2, bb3
 
 bb1:
   %5 = unchecked_enum_data %0 : $Optional<SomeClass>, #Optional.some!enumelt
@@ -366,6 +375,9 @@ bb1:
 bb2:
   %10 = function_ref @external_func: $@convention(thin) () -> ()
   apply %10(): $@convention(thin) () -> ()
+  br bb1
+
+bb3:
   br bb1
 }
 

--- a/test/SILOptimizer/simplify_cfg.sil
+++ b/test/SILOptimizer/simplify_cfg.sil
@@ -346,13 +346,13 @@ bb2:
 // CHECK:  return
 sil @elim_trampoline : $@convention(thin) (Builtin.Int1, Int64, Int64) -> Int64 {
 bb0(%0 : $Builtin.Int1, %1 : $Int64, %2 : $Int64):
-  cond_br %0, bb1(%1 : $Int64), bb2(%2 : $Int64)
+  cond_br %0, bb1, bb2
 
-bb1(%3 : $Int64):
-  br bb3(%3 : $Int64)
+bb1:
+  br bb3(%1 : $Int64)
 
-bb2(%4 : $Int64):
-  br bb3(%4 : $Int64)
+bb2:
+  br bb3(%2 : $Int64)
 
 bb3(%5 : $Int64):
   return %5 : $Int64
@@ -363,13 +363,13 @@ bb3(%5 : $Int64):
 // CHECK: return
 sil @elim_trampoline2 : $@convention(thin) (Builtin.Int1, Int64) -> Int64 {
 bb0(%0 : $Builtin.Int1, %1 : $Int64):
-  cond_br %0, bb1(%1 : $Int64), bb2(%1 : $Int64)
+  cond_br %0, bb1, bb2
 
-bb1(%2 : $Int64):
-  br bb3(%2 : $Int64)
+bb1:
+  br bb3(%1 : $Int64)
 
-bb2(%3 : $Int64):
-  br bb3(%3 : $Int64)
+bb2:
+  br bb3(%1 : $Int64)
 
 bb3(%4 : $Int64):
   return %4 : $Int64
@@ -380,14 +380,14 @@ bb3(%4 : $Int64):
 // CHECK: return
 sil @elim_trampoline_debug : $@convention(thin) (Builtin.Int1, Int64) -> Int64 {
 bb0(%0 : $Builtin.Int1, %1 : $Int64):
-  cond_br %0, bb1(%1 : $Int64), bb2(%1 : $Int64)
+  cond_br %0, bb1, bb2
 
-bb1(%2 : $Int64):
+bb1:
   debug_value %0 : $Builtin.Int1
-  br bb3(%2 : $Int64)
+  br bb3(%1 : $Int64)
 
-bb2(%3 : $Int64):
-  br bb3(%3 : $Int64)
+bb2:
+  br bb3(%1 : $Int64)
 
 bb3(%4 : $Int64):
   return %4 : $Int64
@@ -403,13 +403,13 @@ bb3(%4 : $Int64):
 // CHECK:  return
 sil @elim_trampoline3 : $@convention(thin) (Builtin.Int1, Int64, Int64) -> Int64 {
 bb0(%0 : $Builtin.Int1, %1 : $Int64, %2 : $Int64):
-  cond_br %0, bb1(%1 : $Int64), bb2(%2 : $Int64)
+  cond_br %0, bb1, bb2
 
-bb1(%3 : $Int64):
-  br bb3(%3 : $Int64)
+bb1:
+  br bb3(%1 : $Int64)
 
-bb2(%4 : $Int64):
-  br bb3(%4 : $Int64)
+bb2:
+  br bb3(%2 : $Int64)
 
 bb3(%5 : $Int64):
   br bb4(%5 : $Int64)
@@ -470,7 +470,7 @@ bb0(%0 : $Int32):
   %1 = integer_literal $Builtin.Int32, 0
   %2 = struct_extract %0 : $Int32, #Int32._value
   %3 = builtin "cmp_eq_Int32"(%1 : $Builtin.Int32, %2 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %3, bb6, bb7(%1 : $Builtin.Int32)
+  cond_br %3, bb6, bb7
 
 bb1:
   %5 = tuple ()
@@ -487,28 +487,28 @@ bb3:
 
 bb4(%13 : $Builtin.Int32):
   %14 = builtin "cmp_eq_Int32"(%13 : $Builtin.Int32, %2 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %14, bb8, bb9(%13 : $Builtin.Int32)
+  cond_br %14, bb8, bb9
 
 bb5(%16 : $Builtin.Int32):
   %17 = builtin "sadd_with_overflow_Int32"(%16 : $Builtin.Int32, %8 : $Builtin.Int32, %9 : $Builtin.Int1) : $(Builtin.Int32, Builtin.Int1)
   %18 = tuple_extract %17 : $(Builtin.Int32, Builtin.Int1), 0
   %19 = builtin "cmp_eq_Int32"(%18 : $Builtin.Int32, %10 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %19, bb3, bb10(%18 : $Builtin.Int32)
+  cond_br %19, bb3, bb10
 
 bb6:
   br bb1
 
-bb7(%20 : $Builtin.Int32):
-  br bb2(%20 : $Builtin.Int32)
+bb7:
+  br bb2(%1 : $Builtin.Int32)
 
 bb8:
   br bb1
 
-bb9(%21 : $Builtin.Int32):
-  br bb2(%21 : $Builtin.Int32)
+bb9:
+  br bb2(%13 : $Builtin.Int32)
 
-bb10(%22 : $Builtin.Int32):
-  br bb5(%22 : $Builtin.Int32)
+bb10:
+  br bb5(%18 : $Builtin.Int32)
 }
 
 // CHECK-LABEL: @elim_trampoline_loop
@@ -516,10 +516,10 @@ bb10(%22 : $Builtin.Int32):
 // CHECK: return
 sil @elim_trampoline_loop : $@convention(thin) (Builtin.Int1, Int64, Int64) -> Int64 {
 bb0(%0 : $Builtin.Int1, %1 : $Int64, %2 : $Int64):
-  cond_br %0, bb1(%1 : $Int64), bb5(%2 : $Int64)
+  cond_br %0, bb1, bb5
 
-bb1(%3 : $Int64):
-  br bb3(%3 : $Int64)
+bb1:
+  br bb3(%1 : $Int64)
 
 bb2(%4 : $Int64):
   br bb2(%4 : $Int64)
@@ -530,8 +530,8 @@ bb3(%5 : $Int64):
 bb4(%6 : $Int64):
   return %6 : $Int64
 
-bb5(%7 : $Int64):
-  br bb2(%7 : $Int64)
+bb5:
+  br bb2(%2 : $Int64)
 }
 
 // CHECK-LABEL: @elim_common_arg
@@ -559,22 +559,22 @@ bb3(%a1 : $Int64):
 // CHECK-NEXT: return %1
 sil @elim_diamonds : $@convention(thin) (Builtin.Int1, Int64, Int64) -> Int64 {
 bb0(%0 : $Builtin.Int1, %1 : $Int64, %2 : $Int64):
-  cond_br %0, bb1(%1 : $Int64), bb2(%1 : $Int64)
+  cond_br %0, bb1, bb2
 
-bb1(%3 : $Int64):
-  br bb3(%3 : $Int64)
+bb1:
+  br bb3(%1 : $Int64)
 
-bb2(%4 : $Int64):
-  br bb3(%4 : $Int64)
+bb2:
+  br bb3(%1 : $Int64)
 
 bb3(%5 : $Int64):
-  cond_br %0, bb4(%5 : $Int64), bb5(%5 : $Int64)
+  cond_br %0, bb4, bb5
 
-bb4(%6 : $Int64):
-  br bb6(%6 : $Int64)
+bb4:
+  br bb6(%5 : $Int64)
 
-bb5(%7 : $Int64):
-  br bb6(%7 : $Int64)
+bb5:
+  br bb6(%5 : $Int64)
 
 bb6(%8 : $Int64):
   return %8 : $Int64
@@ -1327,7 +1327,7 @@ bb0(%0 : $Int32):
   %8 = tuple_extract %6 : $(Builtin.Int32, Builtin.Int1), 1
   cond_fail %8 : $Builtin.Int1
   %11 = builtin "cmp_eq_Int32"(%2 : $Builtin.Int32, %7 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %11, bb9(%1 : $Builtin.Int32), bb2
+  cond_br %11, bb9, bb2
 
 bb2:
   %14 = integer_literal $Builtin.Int32, 2
@@ -1368,8 +1368,8 @@ bb8(%40 : $Builtin.Int32):
   %41 = struct $Int32 (%40 : $Builtin.Int32)
   return %41 : $Int32
 
-bb9(%42 : $Builtin.Int32):
-  br bb8(%42 : $Builtin.Int32)
+bb9:
+  br bb8(%1 : $Builtin.Int32)
 }
 
 // CHECK-LABEL: sil @jumpthread_switch_enum2
@@ -1460,7 +1460,7 @@ bb0:
 
 bb1:
   %4 = enum $Optional<Int32>, #Optional.none!enumelt
-  cond_br undef, bb8(%4 : $Optional<Int32>), bb9(%4 : $Optional<Int32>, %c0 : $Builtin.Int32)
+  cond_br undef, bb8, bb9
 
 bb2:
   %6 = integer_literal $Builtin.Int32, 0
@@ -1490,11 +1490,11 @@ bb6:
 bb7(%r : $Builtin.Int32, %carg2 : $Builtin.Int32):
   return %r : $Builtin.Int32
 
-bb8(%20 : $Optional<Int32>):
-  br bb3(%20 : $Optional<Int32>)
+bb8:
+  br bb3(%4 : $Optional<Int32>)
 
-bb9(%21 : $Optional<Int32>, %22 : $Builtin.Int32):
-  br bb4(%21 : $Optional<Int32>, %22 : $Builtin.Int32)
+bb9:
+  br bb4(%4 : $Optional<Int32>, %c0 : $Builtin.Int32)
 }
 
 // CHECK-LABEL: sil @jumpthread_switch_enum5
@@ -1562,7 +1562,7 @@ bb0(%0 : $Int32):
   %8 = tuple_extract %6 : $(Builtin.Int32, Builtin.Int1), 1
   cond_fail %8 : $Builtin.Int1
   %11 = builtin "cmp_eq_Int32"(%2 : $Builtin.Int32, %7 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %11, bb9(%1 : $Builtin.Int32), bb2
+  cond_br %11, bb9, bb2
 
 bb2:
   %14 = integer_literal $Builtin.Int32, 2
@@ -1605,8 +1605,8 @@ bb8(%40 : $Builtin.Int32):
   %41 = struct $Int32 (%40 : $Builtin.Int32)
   return %41 : $Int32
 
-bb9(%42 : $Builtin.Int32):
-  br bb8(%42 : $Builtin.Int32)
+bb9:
+  br bb8(%1 : $Builtin.Int32)
 }
 
 enum OneCase {
@@ -2064,7 +2064,7 @@ bb1:
 
 bb2:
   apply %f1() : $@convention(thin) () -> () // prevent other CFG optimizations
-  cond_br %2, bb5(%1 : $Builtin.Int1), bb6
+  cond_br %2, bb5, bb6
 
 bb3(%a3 : $Builtin.Int1):
   apply %f1() : $@convention(thin) () -> () // prevent other CFG optimizations
@@ -2075,8 +2075,8 @@ bb4:
   %r = tuple ()
   return %r : $()
 
-bb5(%a5 : $Builtin.Int1):
-  br bb3(%a5 : $Builtin.Int1)
+bb5:
+  br bb3(%1 : $Builtin.Int1)
 
 bb6:
   br bb4

--- a/test/SILOptimizer/simplify_cfg.sil
+++ b/test/SILOptimizer/simplify_cfg.sil
@@ -458,19 +458,19 @@ bb5(%6 : $Int64):
 // This becomes a cond_br at bb8->bb5
 // CHECK-LABEL: @elim_trampoline5
 // CHECK: cond_br
-// CHECK: bb5:
+// CHECK: bb3:
 // CHECK: cond_br
-// CHECK: bb8{{.*}}:
-// CHECK: cond_br {{.*}}, bb5, bb9
+// CHECK: bb4{{.*}}:
+// CHECK: cond_br {{.*}}, bb3, bb9
 // CHECK: bb9:
-// CHECK-NEXT: br bb8
+// CHECK-NEXT: br bb4
 // CHECK: }
 sil @elim_trampoline5 : $@convention(thin) (Int32) -> () {
 bb0(%0 : $Int32):
   %1 = integer_literal $Builtin.Int32, 0
   %2 = struct_extract %0 : $Int32, #Int32._value
   %3 = builtin "cmp_eq_Int32"(%1 : $Builtin.Int32, %2 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %3, bb1, bb2(%1 : $Builtin.Int32)
+  cond_br %3, bb6, bb7(%1 : $Builtin.Int32)
 
 bb1:
   %5 = tuple ()
@@ -487,13 +487,28 @@ bb3:
 
 bb4(%13 : $Builtin.Int32):
   %14 = builtin "cmp_eq_Int32"(%13 : $Builtin.Int32, %2 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %14, bb1, bb2(%13 : $Builtin.Int32)
+  cond_br %14, bb8, bb9(%13 : $Builtin.Int32)
 
 bb5(%16 : $Builtin.Int32):
   %17 = builtin "sadd_with_overflow_Int32"(%16 : $Builtin.Int32, %8 : $Builtin.Int32, %9 : $Builtin.Int1) : $(Builtin.Int32, Builtin.Int1)
   %18 = tuple_extract %17 : $(Builtin.Int32, Builtin.Int1), 0
   %19 = builtin "cmp_eq_Int32"(%18 : $Builtin.Int32, %10 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %19, bb3, bb5(%18 : $Builtin.Int32)
+  cond_br %19, bb3, bb10(%18 : $Builtin.Int32)
+
+bb6:
+  br bb1
+
+bb7(%20 : $Builtin.Int32):
+  br bb2(%20 : $Builtin.Int32)
+
+bb8:
+  br bb1
+
+bb9(%21 : $Builtin.Int32):
+  br bb2(%21 : $Builtin.Int32)
+
+bb10(%22 : $Builtin.Int32):
+  br bb5(%22 : $Builtin.Int32)
 }
 
 // CHECK-LABEL: @elim_trampoline_loop
@@ -501,7 +516,7 @@ bb5(%16 : $Builtin.Int32):
 // CHECK: return
 sil @elim_trampoline_loop : $@convention(thin) (Builtin.Int1, Int64, Int64) -> Int64 {
 bb0(%0 : $Builtin.Int1, %1 : $Int64, %2 : $Int64):
-  cond_br %0, bb1(%1 : $Int64), bb2(%2 : $Int64)
+  cond_br %0, bb1(%1 : $Int64), bb5(%2 : $Int64)
 
 bb1(%3 : $Int64):
   br bb3(%3 : $Int64)
@@ -514,6 +529,9 @@ bb3(%5 : $Int64):
 
 bb4(%6 : $Int64):
   return %6 : $Int64
+
+bb5(%7 : $Int64):
+  br bb2(%7 : $Int64)
 }
 
 // CHECK-LABEL: @elim_common_arg
@@ -1309,7 +1327,7 @@ bb0(%0 : $Int32):
   %8 = tuple_extract %6 : $(Builtin.Int32, Builtin.Int1), 1
   cond_fail %8 : $Builtin.Int1
   %11 = builtin "cmp_eq_Int32"(%2 : $Builtin.Int32, %7 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %11, bb8(%1 : $Builtin.Int32), bb2
+  cond_br %11, bb9(%1 : $Builtin.Int32), bb2
 
 bb2:
   %14 = integer_literal $Builtin.Int32, 2
@@ -1349,6 +1367,9 @@ bb7:
 bb8(%40 : $Builtin.Int32):
   %41 = struct $Int32 (%40 : $Builtin.Int32)
   return %41 : $Int32
+
+bb9(%42 : $Builtin.Int32):
+  br bb8(%42 : $Builtin.Int32)
 }
 
 // CHECK-LABEL: sil @jumpthread_switch_enum2
@@ -1423,17 +1444,14 @@ bb6(%r : $Int32):
 
 // CHECK-LABEL: sil @jumpthread_switch_enum4
 // CHECK:      bb0:
-// CHECK-NEXT:   cond_br undef, bb1, bb2
+// CHECK-NEXT:   cond_br undef, bb2, bb1
 // CHECK:      bb1:
-// CHECK:        enum $Optional<Int32>, #Optional.none!enumelt
+// CHECK:        integer_literal $Builtin.Int32, 27
 // CHECK:        br bb3
 // CHECK:      bb2:
-// CHECK:        integer_literal $Builtin.Int32, 0
-// CHECK:        enum $Optional<Int32>, #Optional.some!enumelt
+// CHECK:        integer_literal $Builtin.Int32, 28
 // CHECK:        br bb3
 // CHECK:      bb3
-// CHECK:        integer_literal {{.*}}, 27
-// CHECK:        integer_literal {{.*}}, 28
 // CHECK:        return
 sil @jumpthread_switch_enum4 : $@convention(thin) () -> Builtin.Int32 {
 bb0:
@@ -1442,7 +1460,7 @@ bb0:
 
 bb1:
   %4 = enum $Optional<Int32>, #Optional.none!enumelt
-  cond_br undef, bb3(%4 : $Optional<Int32>), bb4(%4 : $Optional<Int32>, %c0 : $Builtin.Int32)
+  cond_br undef, bb8(%4 : $Optional<Int32>), bb9(%4 : $Optional<Int32>, %c0 : $Builtin.Int32)
 
 bb2:
   %6 = integer_literal $Builtin.Int32, 0
@@ -1471,18 +1489,24 @@ bb6:
 
 bb7(%r : $Builtin.Int32, %carg2 : $Builtin.Int32):
   return %r : $Builtin.Int32
+
+bb8(%20 : $Optional<Int32>):
+  br bb3(%20 : $Optional<Int32>)
+
+bb9(%21 : $Optional<Int32>, %22 : $Builtin.Int32):
+  br bb4(%21 : $Optional<Int32>, %22 : $Builtin.Int32)
 }
 
 // CHECK-LABEL: sil @jumpthread_switch_enum5
 // CHECK:      bb0:
 // CHECK:        br bb1
 // CHECK:      bb1:
-// CHECK-NEXT:   cond_br undef, bb2, bb3
+// CHECK-NEXT:   cond_br undef, bb3, bb2
 // CHECK:      bb2:
-// CHECK:        br bb1
-// CHECK:      bb3:
 // CHECK-NEXT:   tuple
 // CHECK-NEXT:   return
+// CHECK:      bb3:
+// CHECK:        br bb1
 sil @jumpthread_switch_enum5 : $@convention(thin) () -> () {
 bb0:
   %6 = integer_literal $Builtin.Int32, 0
@@ -1502,11 +1526,14 @@ bb3:
   br bb4
 
 bb4:
-  cond_br undef, bb1(%13 : $Optional<Int32>), bb5
+  cond_br undef, bb6, bb5
 
 bb5:
   %r = tuple ()
   return %r : $()
+
+bb6:
+  br bb1(%13 : $Optional<Int32>)
 }
 
 /// Don't jumpthread blocks that contain objc method instructions. We don't
@@ -1535,7 +1562,7 @@ bb0(%0 : $Int32):
   %8 = tuple_extract %6 : $(Builtin.Int32, Builtin.Int1), 1
   cond_fail %8 : $Builtin.Int1
   %11 = builtin "cmp_eq_Int32"(%2 : $Builtin.Int32, %7 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %11, bb8(%1 : $Builtin.Int32), bb2
+  cond_br %11, bb9(%1 : $Builtin.Int32), bb2
 
 bb2:
   %14 = integer_literal $Builtin.Int32, 2
@@ -1577,6 +1604,9 @@ bb7:
 bb8(%40 : $Builtin.Int32):
   %41 = struct $Int32 (%40 : $Builtin.Int32)
   return %41 : $Int32
+
+bb9(%42 : $Builtin.Int32):
+  br bb8(%42 : $Builtin.Int32)
 }
 
 enum OneCase {
@@ -1778,10 +1808,10 @@ bb2:
 
 // CHECK-LABEL: sil @dont_remove_cond_fail_wrong_const
 // CHECK:      bb0(%0 : $Builtin.Int1):
-// CHECK-NEXT:   cond_br %0, bb2, bb1
+// CHECK-NEXT:   cond_br %0, bb1, bb3
 sil @dont_remove_cond_fail_wrong_const : $@convention(thin) (Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1):
-  cond_br %0, bb1, bb2
+  cond_br %0, bb1, bb3
 
 bb1:
   %i1 = integer_literal $Builtin.Int1, 0
@@ -1791,6 +1821,9 @@ bb1:
 bb2:
   %r = tuple ()
   return %r : $()
+
+bb3:
+  br bb2
 }
 
 // CHECK-LABEL: sil @remove_cond_fail_same_cond_in_true
@@ -1801,7 +1834,7 @@ bb2:
 // CHECK: return
 sil @remove_cond_fail_same_cond_in_true : $@convention(thin)(Builtin.Int1, Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1, %1 : $Builtin.Int1):
-  cond_br %0, bb1, bb2
+  cond_br %0, bb4, bb2
 bb1:
   cond_fail %0 : $Builtin.Int1
   unreachable
@@ -1810,10 +1843,14 @@ bb2:
   // simplification does the same thing.
   %55 = function_ref @external_f : $@convention(thin) () -> ()
   apply %55() : $@convention(thin) () -> ()
-  cond_br %1, bb1, bb3
+  cond_br %1, bb5, bb3
 bb3:
   %2 = tuple()
   return %2 : $()
+bb4:
+  br bb1
+bb5:
+  br bb1
 }
 
 // CHECK-LABEL: sil @remove_cond_fail_same_cond_in_false
@@ -1826,7 +1863,7 @@ bb3:
 // CHECK: return
 sil @remove_cond_fail_same_cond_in_false : $@convention(thin)(Builtin.Int1, Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1, %1 : $Builtin.Int1):
-  cond_br %0, bb2, bb1
+  cond_br %0, bb2, bb4
 bb1:
   %i1 = integer_literal $Builtin.Int1, -1
   %i2 = builtin "xor_Int1"(%0 : $Builtin.Int1, %i1 : $Builtin.Int1) : $Builtin.Int1
@@ -1837,10 +1874,14 @@ bb2:
   // simplification does the same thing.
   %55 = function_ref @external_f : $@convention(thin) () -> ()
   apply %55() : $@convention(thin) () -> ()
-  cond_br %1, bb1, bb3
+  cond_br %1, bb5, bb3
 bb3:
   %2 = tuple()
   return %2 : $()
+bb4:
+  br bb1
+bb5:
+  br bb1
 }
 
 // CHECK-LABEL: sil @remove_cond_fail_same_cond_in_false2
@@ -1853,7 +1894,7 @@ sil @remove_cond_fail_same_cond_in_false2 : $@convention(thin)(Builtin.Int1, Bui
 bb0(%0 : $Builtin.Int1, %1 : $Builtin.Int1):
   %i1 = integer_literal $Builtin.Int1, -1
   %i2 = builtin "xor_Int1"(%0 : $Builtin.Int1, %i1 : $Builtin.Int1) : $Builtin.Int1
-  cond_br %i2, bb2, bb1
+  cond_br %i2, bb2, bb4
 bb1:
   cond_fail %0 : $Builtin.Int1
   unreachable
@@ -1862,21 +1903,25 @@ bb2:
   // simplification does the same thing.
   %55 = function_ref @external_f : $@convention(thin) () -> ()
   apply %55() : $@convention(thin) () -> ()
-  cond_br %1, bb1, bb3
+  cond_br %1, bb5, bb3
 bb3:
   %2 = tuple()
   return %2 : $()
+bb4:
+  br bb1
+bb5:
+  br bb1
 }
 
 // CHECK-LABEL: sil @dont_remove_cond_fail_same_cond_in_false
 // CHECK: bb0([[COND:%[0-9]*]]
 // CHECK-NEXT: cond_br
-// CHECK: bb2:
+// CHECK: bb1:
 // CHECK-NEXT: cond_fail [[COND]]
 // CHECK: return
 sil @dont_remove_cond_fail_same_cond_in_false : $@convention(thin)(Builtin.Int1, Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1, %1 : $Builtin.Int1):
-  cond_br %0, bb2, bb1
+  cond_br %0, bb2, bb4
 bb1:
   cond_fail %0 : $Builtin.Int1
   unreachable
@@ -1884,10 +1929,14 @@ bb2:
   // Make bb1 not dominated from bb0.
   %55 = function_ref @external_f : $@convention(thin) () -> ()
   apply %55() : $@convention(thin) () -> ()
-  cond_br %1, bb1, bb3
+  cond_br %1, bb5, bb3
 bb3:
   %2 = tuple()
   return %2 : $()
+bb4:
+  br bb1
+bb5:
+  br bb1
 }
 
 // CHECK-LABEL: sil @move_cond_fail
@@ -1992,15 +2041,17 @@ bb3(%a3 : $Builtin.Int1):
 // CHECK:      bb1:
 // CHECK-NEXT:   apply
 // CHECK-NEXT:   integer_literal
-// CHECK-NEXT:   br bb5
+// CHECK-NEXT:   br bb3
 // CHECK:      bb2:
 // CHECK-NEXT:   apply
 // CHECK-NEXT:   cond_br
-// CHECK:      bb3:
-// CHECK:        br bb6
-// CHECK:      bb5({{.*}}):
+// CHECK:      bb3({{.*}}):
 // CHECK-NEXT:   apply
 // CHECK-NEXT:   cond_fail
+// CHECK:      bb5:
+// CHECK-NEXT:   br bb3
+// CHECK:      bb6:
+// CHECK-NEXT:   br bb4
 sil @dont_move_cond_fail_no_postdom : $@convention(thin) (Builtin.Int1, Builtin.Int1, Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1, %1 : $Builtin.Int1, %2 : $Builtin.Int1):
   %f1 = function_ref @external_f : $@convention(thin) () -> ()
@@ -2013,7 +2064,7 @@ bb1:
 
 bb2:
   apply %f1() : $@convention(thin) () -> () // prevent other CFG optimizations
-  cond_br %2, bb3(%1 : $Builtin.Int1), bb4
+  cond_br %2, bb5(%1 : $Builtin.Int1), bb6
 
 bb3(%a3 : $Builtin.Int1):
   apply %f1() : $@convention(thin) () -> () // prevent other CFG optimizations
@@ -2023,6 +2074,12 @@ bb3(%a3 : $Builtin.Int1):
 bb4:
   %r = tuple ()
   return %r : $()
+
+bb5(%a5 : $Builtin.Int1):
+  br bb3(%a5 : $Builtin.Int1)
+
+bb6:
+  br bb4
 }
 
 // CHECK-LABEL: sil @dont_move_cond_fail_multiple_uses
@@ -2148,21 +2205,21 @@ bb3 (%10: $Builtin.Int32):
 // CHECK:  objc_method
 // CHECK:  apply
 // CHECK:  strong_release
-// CHECK:  cond_br {{.*}}, bb2, bb6
+// CHECK:  cond_br {{.*}}, bb2, bb8
 // CHECK: bb3
 // CHECK:  strong_release
 // CHECK:  cond_br {{.*}}, bb5, bb4
-// CHECK: bb7
+// CHECK: bb6
 // CHECK:  cond_fail
-// CHECK:  br bb8
-// CHECK: bb8:
+// CHECK:  br bb7
+// CHECK: bb7:
 // CHECK:  strong_release
 // CHECK:  return
 
 sil @thread_objc_method_call_succ_block : $@convention(thin) <T where T : ObjcProto> (Builtin.Int1, @owned T, Builtin.Int1) -> () {
 bb0(%0: $Builtin.Int1, %1 : $T, %2 : $Builtin.Int1):
   strong_retain %1 : $T
-  cond_br %0, bb1 , bb2
+  cond_br %0, bb1 , bb5
 
 bb1:
   %3 = objc_method %1 : $T, #ObjcProto.foo!foreign, $@convention(objc_method) <τ_0_0 where τ_0_0 : ObjcProto> (τ_0_0) -> ()
@@ -2171,7 +2228,7 @@ bb1:
 
 bb2:
   strong_release %1 : $T
-  cond_br %2, bb3, bb4
+  cond_br %2, bb3, bb6
 
 bb3:
  cond_fail %0 : $Builtin.Int1
@@ -2181,6 +2238,12 @@ bb4:
   strong_release %1 : $T
   %41 = tuple ()
   return %41 : $()
+
+bb5:
+  br bb2
+
+bb6:
+  br bb4
 }
 
 sil @f_use : $@convention(thin) (Builtin.Int32) -> ()
@@ -2189,25 +2252,25 @@ sil @f_use : $@convention(thin) (Builtin.Int32) -> ()
 // CHECK: bb1:
 // CHECK:  [[INVADD:%.*]] = builtin "sadd
 // CHECK:  [[EXT:%.*]] = tuple_extract [[INVADD]]
-// CHECK:  switch_enum {{.*}} case #Optional.some!enumelt: bb3
+// CHECK:  switch_enum {{.*}} case #Optional.some!enumelt: bb2
 
-// CHECK: bb3{{.*}}
-// CHECK:  br bb5(%2 : $Builtin.Int32, [[EXT]]
+// CHECK: bb2{{.*}}
+// CHECK:  br bb4(%2 : $Builtin.Int32, [[EXT]]
 
-// CHECK: bb5([[CUR:%.*]] : $Builtin.Int32, [[NEXT:%.*]] : $Builtin.Int32
+// CHECK: bb4([[CUR:%.*]] : $Builtin.Int32, [[NEXT:%.*]] : $Builtin.Int32
 // CHECK:  [[F:%.*]] = function_ref @f
 // CHECK:  apply [[F]]([[CUR]])
-// CHECK:  cond_br {{.*}}, bb7, bb6
+// CHECK:  cond_br {{.*}}, bb5, bb8
 
-// CHECK: bb7:
+// CHECK: bb5:
 // CHECK:   [[VARADD:%.*]] = builtin "sadd_with_overflow_Int32"([[NEXT]] : $Builtin.Int32
 // CHECK:   [[NEXT2:%.*]] = tuple_extract [[VARADD]]
-// CHECK:   br bb5([[NEXT]] : $Builtin.Int32, [[NEXT2]]
+// CHECK:   br bb4([[NEXT]] : $Builtin.Int32, [[NEXT2]]
 
 
 sil @switch_enum_jumpthreading_bug : $@convention(thin) (Optional<Builtin.Int32>, Builtin.Int1, Builtin.Int32, Builtin.Int1) -> Builtin.Int32 {
 bb0(%0 : $Optional<Builtin.Int32>, %1 : $Builtin.Int1, %2: $Builtin.Int32, %3 : $Builtin.Int1):
-  cond_br %1, bb2, bb10
+  cond_br %1, bb2, bb12
 
 bb2:
  br bb3(%2 : $Builtin.Int32, %0 : $Optional<Builtin.Int32>)
@@ -2226,7 +2289,7 @@ bb4:
 bb5(%9 : $Builtin.Int32):
   %f = function_ref @f_use : $@convention(thin) (Builtin.Int32) -> ()
   %a = apply %f(%10) : $@convention(thin) (Builtin.Int32) -> ()
-  cond_br %3, bb6, bb10
+  cond_br %3, bb6, bb13
 
 bb6:
   %8 = enum $Optional<Builtin.Int32>, #Optional.some!enumelt, %9 : $Builtin.Int32
@@ -2237,6 +2300,12 @@ bb10:
 
 bb11(%100 : $Builtin.Int32):
   return %100 : $Builtin.Int32
+
+bb12:
+  br bb10
+
+bb13:
+  br bb10
 }
 
 sil @a : $@convention(thin) () -> ()
@@ -2399,7 +2468,7 @@ bb4:
 
 bb5:
   %8 = select_enum %0 : $AnEnum, case #AnEnum.B!enumelt: %f, case #AnEnum.C!enumelt: %t : $Builtin.Int1
-  cond_br %8, bb10, bb1
+  cond_br %8, bb11, bb12
 
 bb1:
   %3 = select_enum %0 : $AnEnum, case #AnEnum.B!enumelt: %f, case #AnEnum.C!enumelt: %t : $Builtin.Int1
@@ -2417,6 +2486,12 @@ bb3:
 bb10:
   %21 = tuple ()
   return %21 : $()
+
+bb11:
+  br bb10
+
+bb12:
+  br bb1
 }
 
 sil @rethrow_function : $@convention(thin) (@owned @callee_owned (Int) -> (Int, @error Error)) -> (Int, @error Error)
@@ -2963,17 +3038,17 @@ bb3(%11 : $String):
 }
 
 // CHECK-LABEL: sil @dont_hang
-// CHECK:      bb6:
+// CHECK:      bb5:
 // CHECK:        integer_literal $Builtin.Int64, 1
-// CHECK-NEXT:   br bb6
-// CHECK-NEXT: }
+// CHECK-NEXT:   br bb5
+// CHECK: }
 sil @dont_hang : $@convention(thin) () -> () {
 bb0:
   cond_br undef, bb1, bb4
 
 bb1:
   %0 = integer_literal $Builtin.Int64, 1
-  cond_br undef, bb2, bb6
+  cond_br undef, bb8, bb6
 
 bb2:
   br bb3
@@ -2994,6 +3069,9 @@ bb6:
 
 bb7:
   br bb5
+
+bb8:
+  br bb2
 }
 
 // CHECK-LABEL: sil @test_constant_folding
@@ -3076,7 +3154,7 @@ enum TestEnm {
 sil @dont_crash : $@convention(method) (TestEnm, Int32) -> () {
 bb0(%2 : $TestEnm, %3 : $Int32):
   %98 = integer_literal $Builtin.Int1, -1
-  cond_br %98, bb2, bb3
+  cond_br %98, bb17, bb3
 
 bb2:
   %18 = tuple()
@@ -3096,7 +3174,7 @@ bb9:
 bb10:
   %64 = struct $TestStr (%3 : $Int32, %57 : $Int32)
   %65 = enum $TestEnm, #TestEnm.Y!enumelt, %64 : $TestStr
-  cond_br undef, bb2, bb16
+  cond_br undef, bb18, bb16
 
 bb11:
   br bb10
@@ -3104,6 +3182,12 @@ bb11:
 
 bb16:
   br bb8(%65 : $TestEnm)
+
+bb17:
+  br bb2
+
+bb18:
+  br bb2
 }
 
 sil @print : $@convention(thin) (@guaranteed String) -> ()

--- a/test/SILOptimizer/simplify_cfg_address_phi.sil
+++ b/test/SILOptimizer/simplify_cfg_address_phi.sil
@@ -67,11 +67,14 @@ bb4:
   %19 = begin_access [read] [dynamic] %18 : $*Int
   %20 = load %19 : $*Int
   end_access %19 : $*Int
-  cond_br undef, bb4, bb5
+  cond_br undef, bb6, bb5
 
 bb5:
   %z = tuple ()
   return %z : $()
+
+bb6:
+  br bb4
 }
 
 // Test that jump threading sinks a
@@ -102,7 +105,7 @@ bb5:
 // CHECK:   [[ELT:%.*]] = index_addr [[TAIL]] : $*Int32, %14 : $Builtin.Word
 // CHECK:   [[ADR:%.*]] = struct_element_addr [[ELT]] : $*Int32, #Int32._value
 // CHECK:   load [[ADR]] : $*Builtin.Int32
-// CHECK:   cond_br undef, bb4, bb5
+// CHECK:   cond_br undef, bb5, bb4
 // CHECK-LABEL: } // end sil function 'testJumpThreadIndex'
 sil @testJumpThreadIndex : $@convention(thin) (__ContiguousArrayStorageBase, Builtin.Int64) -> Builtin.Int32 {
 bb0(%0 : $__ContiguousArrayStorageBase, %1 : $Builtin.Int64):
@@ -129,10 +132,13 @@ bb3(%arg : $C):
 
 bb4:
   %val = load %adr : $*Builtin.Int32
-  cond_br undef, bb4, bb5
+  cond_br undef, bb6, bb5
 
 bb5:
   return %val : $Builtin.Int32
+
+bb6:
+  br bb4
 }
 
 // Test that debug_value is not unnecessarily lost during address projection sinking.
@@ -153,7 +159,7 @@ sil @useAny : $@convention(thin) <V> (@in_guaranteed V) -> ()
 sil @testDebugValue : $@convention(method) <R><S> (@in_guaranteed S, @guaranteed CC<R>, Bool) -> () {
 bb0(%0 : $*S, %1 : $CC<R>, %2 : $Bool):
   %bool = struct_extract %2 : $Bool, #Bool._value
-  cond_br %bool, bb1, bb2
+  cond_br %bool, bb1, bb5
 
 bb1:
   debug_value %0 : $*S, let, name "u", expr op_deref
@@ -164,7 +170,7 @@ bb1:
 bb2:
   %field = ref_element_addr %1 : $CC<R>, #CC.r
   debug_value %field : $*R, let, name "t", expr op_deref
-  cond_br %bool, bb3, bb4
+  cond_br %bool, bb3, bb6
 
 bb3:
   debug_value %field : $*R, let, name "u", expr op_deref
@@ -175,6 +181,12 @@ bb3:
 bb4:
   %z = tuple ()
   return %z : $()
+
+bb5:
+  br bb2
+
+bb6:
+  br bb4
 }
 
 // Test multiple uses and cloned allocation.

--- a/test/SILOptimizer/simplify_cfg_and_combine.sil
+++ b/test/SILOptimizer/simplify_cfg_and_combine.sil
@@ -123,7 +123,7 @@ bb3(%r : $Builtin.Int32):
 // CHECK-NEXT: return
 sil @cond_br_dominates_cond_fail : $@convention(thin) (Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1):
-  cond_br %0, bb2, bb1
+  cond_br %0, bb3, bb1
 
 bb1:
   cond_fail %0 : $Builtin.Int1
@@ -132,6 +132,9 @@ bb1:
 bb2:
   %r = tuple()
   return %r : $()
+
+bb3:
+  br bb2
 }
 
 /// CHECK-LABEL: sil @select_enum_dominates_switch_enum : $@convention(thin) (Int32) -> Int32 {

--- a/test/SILOptimizer/simplify_cfg_args.sil
+++ b/test/SILOptimizer/simplify_cfg_args.sil
@@ -31,7 +31,7 @@ bb0(%0 : $Builtin.RawPointer, %1 : $Builtin.NativeObject, %2 : $Builtin.Int32):
   %20 = builtin "xor_Int32"(%17 : $Builtin.Int32, %18 : $Builtin.Int32) : $Builtin.Int32
   %22 = builtin "and_Int32"(%2 : $Builtin.Int32, %20 : $Builtin.Int32) : $Builtin.Int32
 // CHECK-NOT: cond_br
-  cond_br %8, bb1, bb2a(%22 : $Builtin.Int32)
+  cond_br %8, bb1, bb2a
 
 bb1:
   %24 = global_addr @globalinit_token11 : $*Builtin.Word
@@ -42,8 +42,8 @@ bb1:
   %30 = builtin "or_Int32"(%22 : $Builtin.Int32, %28 : $Builtin.Int32) : $Builtin.Int32
   br bb2(%30 : $Builtin.Int32)
 
-bb2a(%33a : $Builtin.Int32):
-  br bb2(%33a : $Builtin.Int32)
+bb2a:
+  br bb2(%22 : $Builtin.Int32)
 
 bb2(%32 : $Builtin.Int32):
 // CHECK-NOT: tuple
@@ -246,14 +246,14 @@ bb0(%0 : $Int32, %1 : $Int32, %2 : $X, %24 : $Builtin.Int1):
 
 bb9(%21 : $(Int32, Int32)):
   %22 = tuple_extract %21 : $(Int32, Int32), 1
-  cond_br %24, bb1(%22 : $Int32), bb5a(%22 : $Int32)
+  cond_br %24, bb1, bb5a
 
-bb5a(%22a : $Int32):
-  br bb5(%22a : $Int32)
+bb5a:
+  br bb5(%22 : $Int32)
 
 // CHECK: bb1
 // CHECK-NOT: switch_enum
-bb1(%12: $Int32):
+bb1:
   switch_enum %2 : $X, case #X.A!enumelt: bb6, case #X.B!enumelt: bb7, case #X.C!enumelt: bb8
 
 bb2:
@@ -503,13 +503,13 @@ bb0(%0 : $Optional<Int32>):
 // CHECK: select_enum
 // CHECK-NEXT: return
   %1 = select_enum %0 : $Optional<Int32>, case #Optional.some!enumelt: %t, default %f : $Builtin.Int1
-  cond_br %1, bb1(%0 : $Optional<Int32>), bb2a(%0 : $Optional<Int32>)
+  cond_br %1, bb1, bb2a
 
-bb1(%2 : $Optional<Int32>):
-  br bb2(%2 : $Optional<Int32>)
+bb1:
+  br bb2(%0 : $Optional<Int32>)
 
-bb2a(%3a : $Optional<Int32>):
-  br bb2(%3a : $Optional<Int32>)
+bb2a:
+  br bb2(%0 : $Optional<Int32>)
 
 bb2(%3 : $Optional<Int32>):
   return %0 : $Optional<Int32>

--- a/test/SILOptimizer/simplify_cfg_args.sil
+++ b/test/SILOptimizer/simplify_cfg_args.sil
@@ -31,7 +31,7 @@ bb0(%0 : $Builtin.RawPointer, %1 : $Builtin.NativeObject, %2 : $Builtin.Int32):
   %20 = builtin "xor_Int32"(%17 : $Builtin.Int32, %18 : $Builtin.Int32) : $Builtin.Int32
   %22 = builtin "and_Int32"(%2 : $Builtin.Int32, %20 : $Builtin.Int32) : $Builtin.Int32
 // CHECK-NOT: cond_br
-  cond_br %8, bb1, bb2(%22 : $Builtin.Int32)
+  cond_br %8, bb1, bb2a(%22 : $Builtin.Int32)
 
 bb1:
   %24 = global_addr @globalinit_token11 : $*Builtin.Word
@@ -41,6 +41,9 @@ bb1:
 // CHECK: [[VAR_21:%[0-9]+]] = builtin "and_Int32"
   %30 = builtin "or_Int32"(%22 : $Builtin.Int32, %28 : $Builtin.Int32) : $Builtin.Int32
   br bb2(%30 : $Builtin.Int32)
+
+bb2a(%33a : $Builtin.Int32):
+  br bb2(%33a : $Builtin.Int32)
 
 bb2(%32 : $Builtin.Int32):
 // CHECK-NOT: tuple
@@ -243,7 +246,10 @@ bb0(%0 : $Int32, %1 : $Int32, %2 : $X, %24 : $Builtin.Int1):
 
 bb9(%21 : $(Int32, Int32)):
   %22 = tuple_extract %21 : $(Int32, Int32), 1
-  cond_br %24, bb1(%22 : $Int32), bb5(%22 : $Int32)
+  cond_br %24, bb1(%22 : $Int32), bb5a(%22 : $Int32)
+
+bb5a(%22a : $Int32):
+  br bb5(%22a : $Int32)
 
 // CHECK: bb1
 // CHECK-NOT: switch_enum
@@ -497,10 +503,13 @@ bb0(%0 : $Optional<Int32>):
 // CHECK: select_enum
 // CHECK-NEXT: return
   %1 = select_enum %0 : $Optional<Int32>, case #Optional.some!enumelt: %t, default %f : $Builtin.Int1
-  cond_br %1, bb1(%0 : $Optional<Int32>), bb2(%0 : $Optional<Int32>)
+  cond_br %1, bb1(%0 : $Optional<Int32>), bb2a(%0 : $Optional<Int32>)
 
 bb1(%2 : $Optional<Int32>):
   br bb2(%2 : $Optional<Int32>)
+
+bb2a(%3a : $Optional<Int32>):
+  br bb2(%3a : $Optional<Int32>)
 
 bb2(%3 : $Optional<Int32>):
   return %0 : $Optional<Int32>
@@ -802,7 +811,10 @@ bb4:
   %18 = load %5 : $*Payload
   %19 = enum $MyEnum, #MyEnum.payload!enumelt, %18 : $Payload
   dealloc_stack %5 : $*Payload
-  cond_br undef, bb7, bb5
+  cond_br undef, bb7a, bb5
+
+bb7a:
+  br bb7
 
 bb5:
   br bb6(%19 : $MyEnum)

--- a/test/SILOptimizer/simplify_cfg_args_crash.sil
+++ b/test/SILOptimizer/simplify_cfg_args_crash.sil
@@ -17,8 +17,8 @@ sil public @test : $@convention(thin) (Builtin.Int64, @inout E) -> () {
 
 bb0(%0 : $Builtin.Int64, %x : $*E):
   %1 = integer_literal $Builtin.Int64, 0
-  %2 = builtin "cmp_eq_Int64"(%0 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int1 
-  cond_br %2, bb3, bb1
+  %2 = builtin "cmp_eq_Int64"(%0 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %2, bb4, bb1
 
 bb1:
   %4 = enum $E, #E.A!enumelt
@@ -28,9 +28,12 @@ bb2(%6 : $E):
   store %6 to %x : $*E
   br bb3
 
-bb3:                                            
-  %8 = tuple ()                                
-  return %8 : $()                              
+bb3:
+  %8 = tuple ()
+  return %8 : $()
+
+bb4:
+  br bb3
 }
 
 // Verify that we do not crash in argument splitting (rdar://problem/25008398).

--- a/test/SILOptimizer/simplify_cfg_dom_jumpthread.sil
+++ b/test/SILOptimizer/simplify_cfg_dom_jumpthread.sil
@@ -117,7 +117,10 @@ bb3(%arg : $C):
 
 bb4:
   %val = load %adr : $*Builtin.Int32
-  cond_br undef, bb4, bb5
+  cond_br undef, bb4trampoline, bb5
+
+bb4trampoline:
+  br bb4
 
 bb5:
   return %val : $Builtin.Int32
@@ -198,7 +201,10 @@ bb1(%i4 : $Builtin.Int64):
   %f3 = function_ref @get_condition : $@convention(thin)  (Builtin.Int64) -> Builtin.Int1
   %c1 = apply %f3(%i3) : $@convention(thin)  (Builtin.Int64) -> Builtin.Int1
   %i5 = integer_literal $Builtin.Int64, 27
-  cond_br %c1, bb1(%i5 : $Builtin.Int64), bb5
+  cond_br %c1, bb1trampoline(%i5 : $Builtin.Int64), bb5
+
+bb1trampoline(%i5arg : $Builtin.Int64):
+  br bb1(%i5arg : $Builtin.Int64)
 
 bb2:
   %f1 = function_ref @get_int1 : $@convention(thin)  () -> Builtin.Int64

--- a/test/SILOptimizer/simplify_cfg_dom_jumpthread.sil
+++ b/test/SILOptimizer/simplify_cfg_dom_jumpthread.sil
@@ -201,10 +201,10 @@ bb1(%i4 : $Builtin.Int64):
   %f3 = function_ref @get_condition : $@convention(thin)  (Builtin.Int64) -> Builtin.Int1
   %c1 = apply %f3(%i3) : $@convention(thin)  (Builtin.Int64) -> Builtin.Int1
   %i5 = integer_literal $Builtin.Int64, 27
-  cond_br %c1, bb1trampoline(%i5 : $Builtin.Int64), bb5
+  cond_br %c1, bb1trampoline, bb5
 
-bb1trampoline(%i5arg : $Builtin.Int64):
-  br bb1(%i5arg : $Builtin.Int64)
+bb1trampoline:
+  br bb1(%i5 : $Builtin.Int64)
 
 bb2:
   %f1 = function_ref @get_int1 : $@convention(thin)  () -> Builtin.Int64

--- a/test/SILOptimizer/simplify_cfg_jump_thread_crash.sil
+++ b/test/SILOptimizer/simplify_cfg_jump_thread_crash.sil
@@ -19,7 +19,7 @@ bb1(%i4 : $Builtin.Int64):
   %f3 = function_ref @get_condition : $@convention(thin)  (Builtin.Int64) -> Builtin.Int1
   %c1 = apply %f3(%i3) : $@convention(thin)  (Builtin.Int64) -> Builtin.Int1
   %i5 = integer_literal $Builtin.Int64, 27
-  cond_br %c1, bb6(%i5 : $Builtin.Int64), bb5
+  cond_br %c1, bb6, bb5
 
 bb2:
   %f1 = function_ref @get_int1 : $@convention(thin)  () -> Builtin.Int64
@@ -42,8 +42,8 @@ bb5:
 
 // Trampoline block to avoid a critical edge from the cond_br in bb1 to bb1 itself
 // (bb1 has two predecessors: bb4 and this trampoline).
-bb6(%i6 : $Builtin.Int64):
-  br bb1(%i6 : $Builtin.Int64)
+bb6:
+  br bb1(%i5 : $Builtin.Int64)
 
 }
 

--- a/test/SILOptimizer/simplify_cfg_jump_thread_crash.sil
+++ b/test/SILOptimizer/simplify_cfg_jump_thread_crash.sil
@@ -7,7 +7,7 @@ import Swift
 import SwiftShims
 
 // CHECK-LABEL: sil @test_jump_threading
-// CHECK: bb5(%{{[0-9]+}} : $Builtin.Int64):
+// CHECK: bb4({{.*}} : $Builtin.Int64):
 // CHECK-NEXT: br bb1
 sil @test_jump_threading : $@convention(thin)  (Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1):
@@ -19,7 +19,7 @@ bb1(%i4 : $Builtin.Int64):
   %f3 = function_ref @get_condition : $@convention(thin)  (Builtin.Int64) -> Builtin.Int1
   %c1 = apply %f3(%i3) : $@convention(thin)  (Builtin.Int64) -> Builtin.Int1
   %i5 = integer_literal $Builtin.Int64, 27
-  cond_br %c1, bb1(%i5 : $Builtin.Int64), bb5
+  cond_br %c1, bb6(%i5 : $Builtin.Int64), bb5
 
 bb2:
   %f1 = function_ref @get_int1 : $@convention(thin)  () -> Builtin.Int64
@@ -39,6 +39,11 @@ bb4(%i3 : $Builtin.Int64):
 bb5:
   %r1 = tuple ()
   return %r1 : $()
+
+// Trampoline block to avoid a critical edge from the cond_br in bb1 to bb1 itself
+// (bb1 has two predecessors: bb4 and this trampoline).
+bb6(%i6 : $Builtin.Int64):
+  br bb1(%i6 : $Builtin.Int64)
 
 }
 

--- a/test/SILOptimizer/simplify_cond_br.sil
+++ b/test/SILOptimizer/simplify_cond_br.sil
@@ -7,18 +7,18 @@ import Builtin
 
 // CHECK-LABEL: sil @constant_cond_br_true
 // CHECK:       bb0(%0 : $Int, %1 : $Int):
-// CHECK-NEXT:    br bb1(%0 : $Int)
+// CHECK-NEXT:    br bb1
 // CHECK:       } // end sil function 'constant_cond_br_true'
 sil @constant_cond_br_true : $@convention(thin) (Int, Int) -> Int {
 bb0(%0 : $Int, %1 : $Int):
   %2 = integer_literal $Builtin.Int1, 1
-  cond_br %2, bb1(%0 : $Int), bb2(%1 : $Int)
+  cond_br %2, bb1, bb2
 
-bb1(%4 : $Int):
-  br bb3(%4 : $Int)
+bb1:
+  br bb3(%0 : $Int)
 
-bb2(%6 : $Int):
-  br bb3(%6 : $Int)
+bb2:
+  br bb3(%1 : $Int)
 
 bb3(%8 : $Int):
   return %8 : $Int
@@ -26,18 +26,19 @@ bb3(%8 : $Int):
 
 // CHECK-LABEL: sil @constant_cond_br_false
 // CHECK:       bb0(%0 : $Int, %1 : $Int):
-// CHECK-NEXT:    br bb1(%1 : $Int)
+// CHECK-NEXT:    br bb1
+// CHECK:         br bb2(%1 : $Int)
 // CHECK:       } // end sil function 'constant_cond_br_false'
 sil @constant_cond_br_false : $@convention(thin) (Int, Int) -> Int {
 bb0(%0 : $Int, %1 : $Int):
   %2 = integer_literal $Builtin.Int1, 0
-  cond_br %2, bb1(%0 : $Int), bb2(%1 : $Int)
+  cond_br %2, bb1, bb2
 
-bb1(%4 : $Int):
-  br bb3(%4 : $Int)
+bb1:
+  br bb3(%0 : $Int)
 
-bb2(%6 : $Int):
-  br bb3(%6 : $Int)
+bb2:
+  br bb3(%1 : $Int)
 
 bb3(%8 : $Int):
   return %8 : $Int
@@ -49,15 +50,14 @@ bb3(%8 : $Int):
 // CHECK:       } // end sil function 'non_constant_cond_br'
 sil @non_constant_cond_br : $@convention(thin) (Int, Int, Builtin.Int1) -> Int {
 bb0(%0 : $Int, %1 : $Int, %2 : $Builtin.Int1):
-  cond_br %2, bb1(%0 : $Int), bb2(%1 : $Int)
+  cond_br %2, bb1, bb2
 
-bb1(%4 : $Int):
-  br bb3(%4 : $Int)
+bb1:
+  br bb3(%0 : $Int)
 
-bb2(%6 : $Int):
-  br bb3(%6 : $Int)
+bb2:
+  br bb3(%1 : $Int)
 
 bb3(%8 : $Int):
   return %8 : $Int
 }
-

--- a/test/SILOptimizer/sink.sil
+++ b/test/SILOptimizer/sink.sil
@@ -176,14 +176,28 @@ bb1:
 // This is a loop!
 bb2:
   %5 = apply %4(%3) : $@convention(method) (@guaranteed X) -> Int
-  cond_br undef, bb2, bb3
+  cond_br undef, bb5, bb8
 
 bb3:
-  cond_br undef, bb3, bb1
+  cond_br undef, bb6, bb7
 
 bb4:
   strong_release %0 : $Y
   return undef : $Int
+
+// Trampoline blocks to avoid critical edges from the cond_br's in bb2 and bb3
+// (bb1, bb2, and bb3 all have two predecessors).
+bb5:
+  br bb2
+
+bb6:
+  br bb3
+
+bb7:
+  br bb1
+
+bb8:
+  br bb3
 }
 
 sil @takeY : $@convention(thin) (@guaranteed Y) -> ()

--- a/test/SILOptimizer/sroa_bbargs.sil
+++ b/test/SILOptimizer/sroa_bbargs.sil
@@ -56,7 +56,7 @@ struct S3 {
 // CHECK: bb2({{.*}} : $Builtin.NativeObject, {{.*}} : $S1, {{.*}} : $Builtin.NativeObject, {{.*}} : $Builtin.NativeObject):
 sil @do_not_split_struct_with_only_trivial_fields : $@convention(thin) (Builtin.NativeObject, S1, Builtin.NativeObject, @in S1, Builtin.NativeObject) -> Builtin.Int32 {
 bb0(%0 : $Builtin.NativeObject, %1 : $S1, %2 : $Builtin.NativeObject, %3 : $*S1, %4 : $Builtin.NativeObject):
-  cond_br undef, bb1, bb2(%0 : $Builtin.NativeObject, %1 : $S1, %2 : $Builtin.NativeObject, %4 : $Builtin.NativeObject)
+  cond_br undef, bb1, bb3
 
 bb1:
   br bb2(%0 : $Builtin.NativeObject, %1 : $S1, %2 : $Builtin.NativeObject, %4 : $Builtin.NativeObject)
@@ -64,13 +64,18 @@ bb1:
 bb2(%5 : $Builtin.NativeObject, %6 : $S1, %7 : $Builtin.NativeObject, %9 : $Builtin.NativeObject):
   %10 = struct_extract %6 : $S1, #S1.y
   return %10 : $Builtin.Int32
+
+// Trampoline block to avoid a critical edge from the cond_br in bb0 to bb2
+// (bb2 has two predecessors: bb1 and this trampoline).
+bb3:
+  br bb2(%0 : $Builtin.NativeObject, %1 : $S1, %2 : $Builtin.NativeObject, %4 : $Builtin.NativeObject)
 }
 
 // CHECK-LABEL: sil @do_not_split_struct_with_only_one_non_trivial_field : $@convention(thin) (Builtin.NativeObject, S1_B, Builtin.NativeObject, @in S1_B, Builtin.NativeObject) -> Builtin.NativeObject {
 // CHECK: bb2({{.*}} : $Builtin.NativeObject, {{.*}} : $S1_B, {{.*}} : $Builtin.NativeObject, {{.*}} : $Builtin.NativeObject):
 sil @do_not_split_struct_with_only_one_non_trivial_field : $@convention(thin) (Builtin.NativeObject, S1_B, Builtin.NativeObject, @in S1_B, Builtin.NativeObject) -> Builtin.NativeObject {
 bb0(%0 : $Builtin.NativeObject, %1 : $S1_B, %2 : $Builtin.NativeObject, %3 : $*S1_B, %4 : $Builtin.NativeObject):
-  cond_br undef, bb1, bb2(%0 : $Builtin.NativeObject, %1 : $S1_B, %2 : $Builtin.NativeObject, %4 : $Builtin.NativeObject)
+  cond_br undef, bb1, bb3
 
 bb1:
   br bb2(%0 : $Builtin.NativeObject, %1 : $S1_B, %2 : $Builtin.NativeObject, %4 : $Builtin.NativeObject)
@@ -78,13 +83,18 @@ bb1:
 bb2(%5 : $Builtin.NativeObject, %6 : $S1_B, %7 : $Builtin.NativeObject, %9 : $Builtin.NativeObject):
   %10 = struct_extract %6 : $S1_B, #S1_B.y
   return %10 : $Builtin.NativeObject
+
+// Trampoline block to avoid a critical edge from the cond_br in bb0 to bb2
+// (bb2 has two predecessors: bb1 and this trampoline).
+bb3:
+  br bb2(%0 : $Builtin.NativeObject, %1 : $S1_B, %2 : $Builtin.NativeObject, %4 : $Builtin.NativeObject)
 }
 
 // CHECK-LABEL: sil @split_struct_with_multiple_non_trivial_fields : $@convention(thin) (Builtin.NativeObject, S1_C, Builtin.NativeObject, @in S1_C, Builtin.NativeObject) -> (Builtin.NativeObject, Builtin.NativeObject) {
 // CHECK: bb2({{.*}} : $Builtin.NativeObject, {{.*}} : $Builtin.NativeObject, {{.*}} : $Builtin.NativeObject, {{.*}} : $Builtin.NativeObject, {{.*}} : $Builtin.NativeObject):
 sil @split_struct_with_multiple_non_trivial_fields : $@convention(thin) (Builtin.NativeObject, S1_C, Builtin.NativeObject, @in S1_C, Builtin.NativeObject) -> (Builtin.NativeObject, Builtin.NativeObject) {
 bb0(%0 : $Builtin.NativeObject, %1 : $S1_C, %2 : $Builtin.NativeObject, %3 : $*S1_C, %4 : $Builtin.NativeObject):
-  cond_br undef, bb1, bb2(%0 : $Builtin.NativeObject, %1 : $S1_C, %2 : $Builtin.NativeObject, %4 : $Builtin.NativeObject)
+  cond_br undef, bb1, bb3
 
 bb1:
   br bb2(%0 : $Builtin.NativeObject, %1 : $S1_C, %2 : $Builtin.NativeObject, %4 : $Builtin.NativeObject)
@@ -94,6 +104,11 @@ bb2(%5 : $Builtin.NativeObject, %6 : $S1_C, %7 : $Builtin.NativeObject, %9 : $Bu
   %11 = struct_extract %6 : $S1_C, #S1_C.z
   %12 = tuple(%10 : $Builtin.NativeObject, %11 : $Builtin.NativeObject)
   return %12 : $(Builtin.NativeObject, Builtin.NativeObject)
+
+// Trampoline block to avoid a critical edge from the cond_br in bb0 to bb2
+// (bb2 has two predecessors: bb1 and this trampoline).
+bb3:
+  br bb2(%0 : $Builtin.NativeObject, %1 : $S1_C, %2 : $Builtin.NativeObject, %4 : $Builtin.NativeObject)
 }
 
 // Make sure our rules apply nicely at multiple levels. We split S2 into an S1_B and a native object
@@ -101,7 +116,7 @@ bb2(%5 : $Builtin.NativeObject, %6 : $S1_C, %7 : $Builtin.NativeObject, %9 : $Bu
 // CHECK: bb2({{.*}} : $Builtin.NativeObject, {{.*}} : $Builtin.NativeObject, {{.*}} : $Builtin.NativeObject, {{.*}} : $S1_B, {{.*}} : $Builtin.NativeObject):
 sil @two_level_struct_with_differing_levels_of_splitting : $@convention(thin) (Builtin.NativeObject, S2, Builtin.NativeObject, @in S2, Builtin.NativeObject) -> (Builtin.Int1, Builtin.NativeObject) {
 bb0(%0 : $Builtin.NativeObject, %1 : $S2, %2 : $Builtin.NativeObject, %3 : $*S2, %4 : $Builtin.NativeObject):
-  cond_br undef, bb1, bb2(%0 : $Builtin.NativeObject, %1 : $S2, %2 : $Builtin.NativeObject, %4 : $Builtin.NativeObject)
+  cond_br undef, bb1, bb3
 
 bb1:
   br bb2(%0 : $Builtin.NativeObject, %1 : $S2, %2 : $Builtin.NativeObject, %4 : $Builtin.NativeObject)
@@ -113,19 +128,29 @@ bb2(%5 : $Builtin.NativeObject, %6 : $S2, %7 : $Builtin.NativeObject, %9 : $Buil
   %13 = struct_extract %12 : $S1_B, #S1_B.x
   %14 = tuple(%13 : $Builtin.Int1, %11 : $Builtin.NativeObject)
   return %14 : $(Builtin.Int1, Builtin.NativeObject)
+
+// Trampoline block to avoid a critical edge from the cond_br in bb0 to bb2
+// (bb2 has two predecessors: bb1 and this trampoline).
+bb3:
+  br bb2(%0 : $Builtin.NativeObject, %1 : $S2, %2 : $Builtin.NativeObject, %4 : $Builtin.NativeObject)
 }
 
 // CHECK-LABEL: sil @large_struct_split : $@convention(thin) (Builtin.NativeObject, S3, Builtin.NativeObject, @in S3, Builtin.NativeObject) -> S3 {
 // CHECK: bb2({{.*}} : $Builtin.NativeObject, {{.*}} : $Builtin.NativeObject, {{.*}} : $Builtin.NativeObject, {{.*}} : $Builtin.NativeObject, {{.*}} : $FakeOptional<S2>, {{.*}} : $S1_B, {{.*}} : $FakeOptional<(Builtin.Int32, Builtin.Int64)>, {{.*}} : $Builtin.NativeObject, {{.*}} : $Builtin.NativeObject, {{.*}} : $S1_B, {{.*}} : $FakeOptional<(Builtin.Int32, Builtin.Int64)>, {{.*}} : $Builtin.NativeObject, {{.*}} : $Builtin.NativeObject, {{.*}} : $S1_B, {{.*}} : $FakeOptional<(Builtin.Int32, Builtin.Int64)>, {{.*}} : $Builtin.NativeObject, {{.*}} : $Builtin.NativeObject):
 sil @large_struct_split : $@convention(thin) (Builtin.NativeObject, S3, Builtin.NativeObject, @in S3, Builtin.NativeObject) -> S3 {
 bb0(%0 : $Builtin.NativeObject, %1 : $S3, %2 : $Builtin.NativeObject, %3 : $*S3, %4 : $Builtin.NativeObject):
-  cond_br undef, bb1, bb2(%0 : $Builtin.NativeObject, %1 : $S3, %2 : $Builtin.NativeObject,  %4 : $Builtin.NativeObject)
+  cond_br undef, bb1, bb3
 
 bb1:
   br bb2(%0 : $Builtin.NativeObject, %1 : $S3, %2 : $Builtin.NativeObject,  %4 : $Builtin.NativeObject)
 
 bb2(%5 : $Builtin.NativeObject, %6 : $S3, %7 : $Builtin.NativeObject, %9 : $Builtin.NativeObject):
   return %6 : $S3
+
+// Trampoline block to avoid a critical edge from the cond_br in bb0 to bb2
+// (bb2 has two predecessors: bb1 and this trampoline).
+bb3:
+  br bb2(%0 : $Builtin.NativeObject, %1 : $S3, %2 : $Builtin.NativeObject,  %4 : $Builtin.NativeObject)
 }
 
 

--- a/test/SILOptimizer/stack_promotion.sil
+++ b/test/SILOptimizer/stack_promotion.sil
@@ -128,10 +128,13 @@ bb1:
   %f2 = function_ref @consume_int : $@convention(thin) (Int32) -> ()
   %a = apply %f2(%l2) : $@convention(thin) (Int32) -> ()
   strong_release %o1 : $XX
-  cond_br undef, bb1, bb2
+  cond_br undef, bb3, bb2
 
 bb2:
   unreachable
+
+bb3:
+  br bb1
 }
 
 // CHECK-LABEL: sil @promote_nested
@@ -229,15 +232,23 @@ bb3:
   br bb4(%i2 : $Int32)
 
 bb4(%a1 : $Int32):
-  cond_br undef, bb1, bb5
+  cond_br undef, bb6, bb5
 
 bb5:
   return %a1 : $Int32
+
+bb6:
+  br bb1
 }
 
 // CHECK-LABEL: sil @dont_promote_with_crictical_exit_edge
-// CHECK: alloc_ref $XX
-// CHECK-NOT: dealloc_ref
+// CHECK: bb1:
+// CHECK:   alloc_ref [stack] $XX
+// CHECK: bb2:
+// CHECK:   dealloc_stack_ref
+// CHECK: bb3:
+// CHECK:   strong_release
+// CHECK:   dealloc_stack_ref
 // CHECK: } // end sil function 'dont_promote_with_crictical_exit_edge'
 sil @dont_promote_with_crictical_exit_edge : $@convention(thin) () -> () {
 bb0:
@@ -245,9 +256,12 @@ bb0:
 
 bb1:
   %o1 = alloc_ref $XX
-  cond_br undef, bb1, bb2
+  cond_br undef, bb2, bb3
 
 bb2:
+  br bb1
+
+bb3:
   strong_release %o1 : $XX
   %r = tuple ()
   return %r : $()
@@ -298,13 +312,16 @@ bb1:
   %x = alloc_ref $XX
   %rea = ref_element_addr %y : $YY, #YY.xx
   store %x to %rea : $*XX
-  cond_br undef, bb1, bb2
+  cond_br undef, bb3, bb2
 
 bb2:
   %f1 = function_ref @take_y : $@convention(thin) (@owned YY) -> ()
   %a = apply %f1(%y) : $@convention(thin) (@owned YY) -> ()
   %t = tuple ()
   return %t : $()
+
+bb3:
+  br bb1
 }
 
 // CHECK-LABEL: sil @dont_promote_use_of_container_outside_loop2
@@ -320,11 +337,14 @@ bb1:
   %x = alloc_ref $XX
   %rea = ref_element_addr %y : $YY, #YY.xx
   store %x to %rea : $*XX
-  cond_br undef, bb1, bb2
+  cond_br undef, bb3, bb2
 
 bb2:
   %t = tuple ()
   return %t : $()
+
+bb3:
+  br bb1
 }
 
 // CHECK-LABEL: sil @dont_promote_use_of_container_outside_loop3
@@ -389,10 +409,13 @@ bb1(%a1 : $XX):
   %l2 = load %l1 : $*Int32
   strong_release %a1 : $XX
   %o1 = alloc_ref $XX
-  cond_br undef, bb1(%o1 : $XX), bb2
+  cond_br undef, bb3, bb2
 
 bb2:
   return %l2 : $Int32
+
+bb3:
+  br bb1(%o1 : $XX)
 }
 
 // CHECK-LABEL: sil {{.*}}@dont_promote_use_before_alloc2
@@ -485,11 +508,14 @@ bb2:
   %x = alloc_ref $XX
   %rea = ref_element_addr %y : $YY, #YY.xx
   store %x to %rea : $*XX
-  cond_br undef, bb1, bb3
+  cond_br undef, bb4, bb3
 
 bb3:
   %t = tuple ()
   return %t : $()
+
+bb4:
+  br bb1
 }
 
 
@@ -598,11 +624,14 @@ bb1:
   %l1 = ref_element_addr %n1 : $XX, #XX.x
   %l2 = load %l1 : $*Int32
   strong_release %n1 : $XX
-  cond_br undef, bb1, bb2
+  cond_br undef, bb3, bb2
 
 bb2:
   strong_release %n1 : $XX
   return %l2 : $Int32
+
+bb3:
+  br bb1
 }
 
 // CHECK-LABEL: sil @promote_with_use_in_multi_block_backedge_loop
@@ -665,11 +694,14 @@ bb3:
   br bb4(%i2 : $Int32)
 
 bb4(%a1 : $Int32):
-  cond_br undef, bb1, bb5
+  cond_br undef, bb6, bb5
 
 bb5:
   dealloc_stack %s1 : $*Int32
   return %a1 : $Int32
+
+bb6:
+  br bb1
 }
 
 // CHECK-LABEL: sil @promote_and_fix_stack_nesting1
@@ -683,7 +715,7 @@ bb5:
 sil @promote_and_fix_stack_nesting1 : $@convention(thin) () -> Int32 {
 bb0:
   %s1 = alloc_stack $Int32
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1, bb3
 
 bb1:
   br bb2
@@ -697,6 +729,9 @@ bb2:
   %l2 = load %l1 : $*Int32
   strong_release %n1 : $XX
   return %l2 : $Int32
+
+bb3:
+  br bb2
 }
 
 // CHECK-LABEL: sil @promote_and_fix_stack_nesting2
@@ -742,7 +777,7 @@ sil @promote_and_fix_stack_nesting3 : $@convention(thin) () -> Int32 {
 bb0:
   %s1 = alloc_stack $Int32
   %i = integer_literal $Builtin.Word, 1
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1, bb3
 
 bb1:
   br bb2
@@ -756,6 +791,9 @@ bb2:
   %l2 = load %l1 : $*Int32
   strong_release %n1 : $XX
   return %l2 : $Int32
+
+bb3:
+  br bb2
 }
 
 // CHECK-LABEL: sil @promote_and_fix_stack_nesting4
@@ -769,7 +807,7 @@ bb2:
 sil @promote_and_fix_stack_nesting4 : $@convention(thin) () -> Int32 {
 bb0:
   %s1 = alloc_stack $Int32
-  cond_br undef, bb1, bb2
+  cond_br undef, bb1, bb3
 
 bb1:
   br bb2
@@ -784,6 +822,9 @@ bb2:
   %l2 = load %l1 : $*Int32
   strong_release %n1 : $XX
   return %l2 : $Int32
+
+bb3:
+  br bb2
 }
 
 // CHECK-LABEL: sil @promote_and_fix_stack_nesting5
@@ -797,7 +838,7 @@ bb2:
 sil @promote_and_fix_stack_nesting5 : $@convention(thin) (Builtin.Word) -> Int32 {
 bb0(%0 : $Builtin.Word):
   %s1 = alloc_stack $Int32
-  cond_br undef, bb1, bb2(%0 : $Builtin.Word)
+  cond_br undef, bb1, bb3(%0 : $Builtin.Word)
 
 bb1:
   br bb2(%0 : $Builtin.Word)
@@ -811,6 +852,9 @@ bb2(%i : $Builtin.Word):
   %l2 = load %l1 : $*Int32
   strong_release %n1 : $XX
   return %l2 : $Int32
+
+bb3(%0a : $Builtin.Word):
+  br bb2(%0a : $Builtin.Word)
 }
 
 // CHECK-LABEL: sil @promote_array

--- a/test/SILOptimizer/stack_promotion.sil
+++ b/test/SILOptimizer/stack_promotion.sil
@@ -428,10 +428,10 @@ bb0(%0 : $XX):
 bb1(%a1 : $XX):
   strong_release %a1 : $XX
   %o1 = alloc_ref $XX
-  cond_br undef, bb2(%o1 : $XX), bb3
+  cond_br undef, bb2, bb3
 
-bb2(%a2 : $XX):
-  br bb1(%a2 : $XX)
+bb2:
+  br bb1(%o1 : $XX)
 
 bb3:
   %t = tuple ()
@@ -452,10 +452,10 @@ bb1(%a0 : $XX):
 bb2(%a1 : $XX):
   strong_release %a1 : $XX
   %o1 = alloc_ref $XX
-  cond_br undef, bb3(%o1 : $XX), bb4
+  cond_br undef, bb3, bb4
 
-bb3(%a2 : $XX):
-  br bb1(%a2 : $XX)
+bb3:
+  br bb1(%o1 : $XX)
 
 bb4:
   %t = tuple ()
@@ -838,7 +838,7 @@ bb3:
 sil @promote_and_fix_stack_nesting5 : $@convention(thin) (Builtin.Word) -> Int32 {
 bb0(%0 : $Builtin.Word):
   %s1 = alloc_stack $Int32
-  cond_br undef, bb1, bb3(%0 : $Builtin.Word)
+  cond_br undef, bb1, bb3
 
 bb1:
   br bb2(%0 : $Builtin.Word)
@@ -853,8 +853,8 @@ bb2(%i : $Builtin.Word):
   strong_release %n1 : $XX
   return %l2 : $Int32
 
-bb3(%0a : $Builtin.Word):
-  br bb2(%0a : $Builtin.Word)
+bb3:
+  br bb2(%0 : $Builtin.Word)
 }
 
 // CHECK-LABEL: sil @promote_array

--- a/test/SILOptimizer/verifier.sil
+++ b/test/SILOptimizer/verifier.sil
@@ -12,25 +12,49 @@ sil_stage canonical
 sil @dont_fail: $@convention(thin) (Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1):
   %2 = integer_literal $Builtin.Int1, -1
-  cond_br %0, bb1, bb5
+  cond_br %0, bb0a, bb5a
+
+bb0a:
+  br bb1
+
+bb5a:
+  br bb5
 
 // Loop.
 bb1:
   %4 = alloc_stack $Builtin.Int32
-  cond_br %0, bb2, bb3
+  cond_br %0, bb2, bb1a
+
+bb1a:
+  br bb3
 
 bb2:
   dealloc_stack %4 : $*Builtin.Int32
-  cond_br %0, bb4, bb1
+  cond_br %0, bb2a, bb2b
+
+bb2a:
+  br bb4
+
+bb2b:
+  br bb1
 
 // Cloned loop.
 bb5:
   %6 = alloc_stack $Builtin.Int32
-  cond_br %0, bb6, bb3
+  cond_br %0, bb6, bb5b
+
+bb5b:
+  br bb3
 
 bb6:
   dealloc_stack %6 : $*Builtin.Int32
-  cond_br %0, bb4, bb5
+  cond_br %0, bb6a, bb6b
+
+bb6a:
+  br bb4
+
+bb6b:
+  br bb5
 
 // Shared unreachable exit block.
 bb3:
@@ -46,25 +70,49 @@ bb4:
 sil @dont_fail2: $@convention(thin) (Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1):
   %2 = integer_literal $Builtin.Int1, -1
-  cond_br %0, bb1, bb5
+  cond_br %0, bb0a, bb5a
+
+bb0a:
+  br bb1
+
+bb5a:
+  br bb5
 
 // Loop.
 bb1:
   %4 = alloc_stack $Builtin.Int32
-  cond_br %0, bb2, bb3
+  cond_br %0, bb2, bb1a
+
+bb1a:
+  br bb3
 
 bb2:
   dealloc_stack %4 : $*Builtin.Int32
-  cond_br %0, bb4, bb1
+  cond_br %0, bb2a, bb2b
+
+bb2a:
+  br bb4
+
+bb2b:
+  br bb1
 
 // Cloned loop.
 bb5:
   %6 = alloc_stack $Builtin.Int32
-  cond_br %0, bb6, bb3
+  cond_br %0, bb6, bb5b
+
+bb5b:
+  br bb3
 
 bb6:
   dealloc_stack %6 : $*Builtin.Int32
-  cond_br %0, bb4, bb5
+  cond_br %0, bb6a, bb6b
+
+bb6a:
+  br bb4
+
+bb6b:
+  br bb5
 
 // Shared unreachable exit block.
 bb3:

--- a/test/Serialization/Inputs/def_basic.sil
+++ b/test/Serialization/Inputs/def_basic.sil
@@ -639,12 +639,12 @@ bb3(%6 : $Builtin.Word):
 // CHECK-LABEL: sil public_external [transparent] @test_cond_branch_basic_block_args
 sil [transparent] [serialized] @test_cond_branch_basic_block_args : $@convention(thin) (Int, Builtin.Int1) -> Int {
 bb0(%0 : $Int, %1 : $Builtin.Int1):
-  cond_br %1, bb1(%0 : $Int), bb2(%0 : $Int)
-  // CHECK: cond_br %1, bb2(%0 : $Int), bb1(%0 : $Int)
-bb1(%3 : $Int):
-  br bb3 (%3 : $Int)
-bb2(%2 : $Int):
-  br bb3(%2 : $Int)
+  cond_br %1, bb1, bb2
+  // CHECK: cond_br %1, bb2, bb1
+bb1:
+  br bb3 (%0 : $Int)
+bb2:
+  br bb3(%0 : $Int)
 bb3(%4 : $Int):
   return %4 : $Int
 }

--- a/utils/swift-autocomplete.bash
+++ b/utils/swift-autocomplete.bash
@@ -26,7 +26,6 @@ _swift_complete()
     COMPREPLY=( $(compgen -W "\
       -aa-kind \
       -allocbox-to-stack-analyze-apply \
-      -allow-critical-edges \
       -basic-dynamic-replacement \
       -bug-reducer-tester-failure-kind \
       -bug-reducer-tester-target-func \


### PR DESCRIPTION
This PR enforces the no-critical-edges invariant across all of SIL (not just OSSA) and, building on that, removes the branch-argument operand lists from `cond_br`. A `cond_br` now carries only its condition operand.

Critical edges (an edge from a terminator with multiple successors to a block with multiple predecessors) were only forbidden in OSSA. However, optimizations didn't create critical edges also in non-OSSA. We just didn't verify that.
"Officially" disallowing critical edges everywhere lets us drop a large amount of special-case handling.

The most visible simplification is `cond_br`: once no critical edges exist, every successor of a `cond_br` has a single predecessor, so it never needs to pass phi arguments. Phi values are only ever supplied by unconditional `br` instructions. Removing the true/false operand lists eliminates the machinery for locating, cloning, verifying, serializing, and rewriting those arguments throughout the compiler.
  
Note about serialization format: the `cond_br` record layout is unchanged in shape (the argument count is now always serialized as 0), so no format-version bump was required.