### PR TITLE
[Embedded] Respect PIC-related options passed to Clang via -Xcc

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -590,6 +590,8 @@ ERROR(no_allocations_without_embedded,none,
       "-no-allocations is only applicable with embedded Swift.", ())
 ERROR(min_ptr_value_without_embedded,none,
       "-min-valid-pointer-value is only applicable with embedded Swift.", ())
+ERROR(non_pic_without_embedded,none,
+      "position-independent code can only be disabled with embedded Swift.", ())
 ERROR(no_swift_sources_with_embedded,none,
       "embedded swift cannot be enabled in a compiler built without Swift sources", ())
 WARNING(embedded_dynamic_exclusivity_staging,none,

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1657,7 +1657,15 @@ std::unique_ptr<ClangImporter> ClangImporter::create(
     // model is decided by Clang (and can be influenced via -Xcc, e.g.
     // -fno-pic), so validate the resolved model here rather than at the flag
     // level.
-    if (CGO.RelocationModel != llvm::Reloc::PIC_ &&
+    //
+    // This only applies where Swift requests PIC as the baseline, i.e.
+    // non-Windows targets (see the `-fPIC` injection in
+    // getNormalInvocationArguments). Windows is implicitly
+    // position-independent and legitimately resolves to a non-PIC relocation
+    // model on some architectures (e.g. 32-bit x86/ARM), so it must not be
+    // diagnosed.
+    if (!ctx.LangOpts.Target.isOSWindows() &&
+        CGO.RelocationModel != llvm::Reloc::PIC_ &&
         !ctx.LangOpts.hasFeature(Feature::Embedded)) {
       ctx.Diags.diagnose(SourceLoc(), diag::non_pic_without_embedded);
       return nullptr;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -588,8 +588,12 @@ void importer::getNormalInvocationArguments(
     invocationArgStrs.insert(invocationArgStrs.end(), {"-D__swift_embedded__"});
   }
 
-  // Enable Position Independence.  `-fPIC` is not supported on Windows, which
-  // is implicitly position independent.
+  // Swift generates position-independent code by default, so establish `-fPIC`
+  // as the baseline for any code Clang emits (e.g. inline functions). `-fPIC`
+  // is not supported on Windows, which is implicitly position-independent. This
+  // is only a default: because the last PIC-related flag wins, a subsequent
+  // `-Xcc -fno-pic` (etc.) overrides it, and the resulting relocation model is
+  // read back from Clang for Swift's own code generation.
   if (!triple.isOSWindows())
     invocationArgStrs.insert(invocationArgStrs.end(), {"-fPIC"});
 
@@ -1648,6 +1652,16 @@ std::unique_ptr<ClangImporter> ClangImporter::create(
     // source locations (rdar://100172217).
     CGO.CoverageMapping = false;
 
+    // Non-PIC code generation is only supported in Embedded Swift, which does
+    // not depend on the position-independent Swift runtime. The relocation
+    // model is decided by Clang (and can be influenced via -Xcc, e.g.
+    // -fno-pic), so validate the resolved model here rather than at the flag
+    // level.
+    if (CGO.RelocationModel != llvm::Reloc::PIC_ &&
+        !ctx.LangOpts.hasFeature(Feature::Embedded)) {
+      ctx.Diags.diagnose(SourceLoc(), diag::non_pic_without_embedded);
+      return nullptr;
+    }
   }
 
   // Set up PCH content CASID.

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -1195,9 +1195,13 @@ swift::createTargetMachine(const IRGenOptions &Opts, ASTContext &Ctx,
   // Use the relocation model that Clang resolved for this target. This keeps
   // Swift's code generation consistent with any C/C++ code Clang emits into the
   // module, and lets `-Xcc` PIC flags (e.g. -fno-pic) affect Swift's model too.
-  auto *clangImporter =
-      static_cast<ClangImporter *>(Ctx.getClangModuleLoader());
-  Reloc::Model relocModel = clangImporter->getCodeGenOpts().RelocationModel;
+  // If there is no Clang importer, fall back to Swift's default: PIC
+  // everywhere except Windows, which is implicitly position-independent.
+  Reloc::Model relocModel =
+      EffectiveTriple.isOSWindows() ? Reloc::Static : Reloc::PIC_;
+  if (auto *clangImporter =
+          static_cast<ClangImporter *>(Ctx.getClangModuleLoader()))
+    relocModel = clangImporter->getCodeGenOpts().RelocationModel;
 
   // Create a target machine.
   llvm::TargetMachine *TargetMachine = Target->createTargetMachine(

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -1192,9 +1192,16 @@ swift::createTargetMachine(const IRGenOptions &Opts, ASTContext &Ctx,
   if (EffectiveTriple.isArch64Bit() && EffectiveTriple.isWindowsCygwinEnvironment())
     cmodel = CodeModel::Large;
 
+  // Use the relocation model that Clang resolved for this target. This keeps
+  // Swift's code generation consistent with any C/C++ code Clang emits into the
+  // module, and lets `-Xcc` PIC flags (e.g. -fno-pic) affect Swift's model too.
+  auto *clangImporter =
+      static_cast<ClangImporter *>(Ctx.getClangModuleLoader());
+  Reloc::Model relocModel = clangImporter->getCodeGenOpts().RelocationModel;
+
   // Create a target machine.
   llvm::TargetMachine *TargetMachine = Target->createTargetMachine(
-      EffectiveTriple, CPU, targetFeatures, TargetOpts, Reloc::PIC_,
+      EffectiveTriple, CPU, targetFeatures, TargetOpts, relocModel,
       cmodel, OptLevel);
   if (!TargetMachine) {
     Ctx.Diags.diagnose(SourceLoc(), diag::no_llvm_target,

--- a/lib/Immediate/SwiftMaterializationUnit.cpp
+++ b/lib/Immediate/SwiftMaterializationUnit.cpp
@@ -39,11 +39,13 @@
 #include "swift/AST/SILGenRequests.h"
 #include "swift/AST/TBDGenRequests.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/ClangImporter/ClangImporter.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/Immediate/SwiftMaterializationUnit.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/Subsystems.h"
+#include "clang/Basic/CodeGenOptions.h"
 
 #define DEBUG_TYPE "swift-immediate"
 
@@ -153,8 +155,13 @@ SwiftJIT::CreateLLJIT(CompilerInstance &CI) {
   auto &Ctx = CI.getASTContext();
   std::tie(TargetOpt, CPU, Features, Triple) =
       getIRTargetOptions(IRGenOpts, Ctx);
+  // Use the relocation model that Clang resolved for this target, consistent
+  // with the AOT code path in IRGen::createTargetMachine.
+  auto *clangImporter =
+      static_cast<ClangImporter *>(Ctx.getClangModuleLoader());
   auto JTMB = llvm::orc::JITTargetMachineBuilder(llvm::Triple(Triple))
-                  .setRelocationModel(llvm::Reloc::PIC_)
+                  .setRelocationModel(
+                      clangImporter->getCodeGenOpts().RelocationModel)
                   .setOptions(std::move(TargetOpt))
                   .setCPU(std::move(CPU))
                   .addFeatures(Features)

--- a/lib/Immediate/SwiftMaterializationUnit.cpp
+++ b/lib/Immediate/SwiftMaterializationUnit.cpp
@@ -156,12 +156,17 @@ SwiftJIT::CreateLLJIT(CompilerInstance &CI) {
   std::tie(TargetOpt, CPU, Features, Triple) =
       getIRTargetOptions(IRGenOpts, Ctx);
   // Use the relocation model that Clang resolved for this target, consistent
-  // with the AOT code path in IRGen::createTargetMachine.
-  auto *clangImporter =
-      static_cast<ClangImporter *>(Ctx.getClangModuleLoader());
+  // with the AOT code path in IRGen::createTargetMachine. If there is no Clang
+  // importer, fall back to Swift's default: PIC everywhere except Windows,
+  // which is implicitly position-independent.
+  llvm::Reloc::Model relocModel = llvm::Triple(Triple).isOSWindows()
+                                      ? llvm::Reloc::Static
+                                      : llvm::Reloc::PIC_;
+  if (auto *clangImporter =
+          static_cast<ClangImporter *>(Ctx.getClangModuleLoader()))
+    relocModel = clangImporter->getCodeGenOpts().RelocationModel;
   auto JTMB = llvm::orc::JITTargetMachineBuilder(llvm::Triple(Triple))
-                  .setRelocationModel(
-                      clangImporter->getCodeGenOpts().RelocationModel)
+                  .setRelocationModel(relocModel)
                   .setOptions(std::move(TargetOpt))
                   .setCPU(std::move(CPU))
                   .addFeatures(Features)

--- a/test/embedded/disable_pic.swift
+++ b/test/embedded/disable_pic.swift
@@ -1,0 +1,33 @@
+// Position-independent vs. static code generation is controlled entirely by
+// Clang (the relocation model Clang resolves is reused for Swift's own code
+// generation), so `-Xcc -fno-pic` switches Swift to the static relocation
+// model too. Disabling PIC is only permitted in Embedded Swift. The effect is
+// only observable on targets where the static model differs from PIC (e.g.
+// x86_64 ELF); Mach-O is always position-independent.
+
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: CODEGENERATOR=X86
+
+// RUN: %target-swift-frontend -target x86_64-unknown-linux-gnu -enable-experimental-feature Embedded -wmo -parse-stdlib %s -module-name main -S -o - | %FileCheck -check-prefix=PIC %s
+// RUN: %target-swift-frontend -target x86_64-unknown-linux-gnu -enable-experimental-feature Embedded -wmo -parse-stdlib -Xcc -fno-pic %s -module-name main -S -o - | %FileCheck -check-prefix=STATIC %s
+
+// Disabling PIC without Embedded Swift is rejected.
+// RUN: not %target-swift-frontend -target x86_64-unknown-linux-gnu -parse-stdlib -Xcc -fno-pic %s -module-name main -S -o - 2>&1 | %FileCheck -check-prefix=ERROR %s
+
+public var g: Builtin.Int64 = Builtin.zeroInitializer()
+
+public func readG() -> Builtin.Int64 {
+  return g
+}
+
+// The global is zero-initialized from top-level code. In PIC mode the store
+// addresses the global RIP-relative; in the static relocation model it uses an
+// absolute address.
+
+// PIC-LABEL: {{^}}main:
+// PIC:         movq $0, ($e4main1gBi64_vp)(%rip)
+
+// STATIC-LABEL: {{^}}main:
+// STATIC:         movq $0, ($e4main1gBi64_vp){{$}}
+
+// ERROR: position-independent code can only be disabled with embedded Swift


### PR DESCRIPTION
Clang has a set of different command-line flags that affect the code relocation model, as well as various defaulting rules based on the target triple. Respect the code relocation model that Clang chooses rather than forcing PIC in all Swift code.

This makes it possible to disable PIC for Swift builds using `-Xcc -fno-PIC`. We only allow this for Embedded Swift, because non-Embedded Swift generates metadata that depends on GOT entries in a number of places.
