### PR TITLE
[Concurrency] Fix comment for swift_task_getSelfOrStealerForEnqueue

### DIFF
--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -1488,20 +1488,21 @@ public:
 /// intrusively linked somewhere due to stealers.
 ///
 /// Why the enqueue must happen after the lock is dropped
-/// ----------------------------------------------------- The Task Status
-/// Lock is a hybrid lock: an "is-locked" bit in the ActiveTaskStatus word
-/// plus a real mutex in the task's private storage. On unlock, the bit is
-/// cleared via CAS *before* the mutex is released (see withStatusRecordLock
-/// in TaskStatus.cpp). During that window, any thread that observes the
-/// ActiveTaskStatus with the bit clear is free to make forward progress
-/// on the Task using lock-free CAS paths. If we called swift_task_enqueue
-/// while still under the lock, another thread could pick the Task up off
-/// the target executor, run it to completion, and attempt to dispose of it
-/// before this thread had finished releasing the mutex, leaving us operating
-/// on a freed task. Splitting "decide what to enqueue" (which requires the
-/// ActiveTaskStatus to be quiescent) from the actual enqueue avoids that
-/// race — the caller does the mutation under the lock and then hands the
-/// returned Job off to swift_task_enqueue only after the lock is released.
+/// -----------------------------------------------------
+/// The Task Status Lock is a hybrid lock: an "is-locked" bit in the
+/// ActiveTaskStatus word plus a real mutex in the task's private storage.
+/// On unlock, the bit is cleared via CAS *before* the mutex is released
+/// (see withStatusRecordLock in TaskStatus.cpp). During that window,
+/// any thread that observes the ActiveTaskStatus with the bit clear
+/// is free to make forward progress on the Task using lock-free CAS
+/// paths. If we called swift_task_enqueue while still under the lock,
+/// another thread could pick the Task up off the target executor, run it
+/// to completion, and attempt to dispose of it before this thread had
+/// finished releasing the mutex, leaving us operating on a freed task.
+/// Splitting "decide what to enqueue" (which requires the ActiveTaskStatus
+/// to be quiescent) from the actual enqueue avoids that race — the
+/// caller does the mutation under the lock and then hands the returned
+/// Job off to swift_task_enqueue only after the lock is released.
 ///
 /// The escalate path (swift_executor_escalate) is exempted
 /// from having to drop the lock first because its caller must


### PR DESCRIPTION
When justifying the new comment for swift_task_getSelfOrStealerForEnqueue (61a50895d297, rdar://182117528, #90701), I accidentally messed up the word wrapping slightly. This is a small fix-up for just that comment.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
