### PR TITLE
[6.4] SILGen: fix init accessor emission in same-type constrained extension

### DIFF
--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -326,9 +326,11 @@ emitApplyOfInitAccessor(SILGenFunction &SGF, SILLocation loc,
   arguments.push_back(SGF.B.createMetatype(loc, SGF.getLoweredType(metatypeTy)));
 
   SubstitutionMap subs;
-  if (auto *env =
-          accessor->getDeclContext()->getGenericEnvironmentOfContext()) {
-    subs = env->getForwardingSubstitutionMap();
+  if (fnType->getInvocationGenericSignature()) {
+    if (auto *env =
+            accessor->getDeclContext()->getGenericEnvironmentOfContext()) {
+      subs = env->getForwardingSubstitutionMap();
+    }
   }
 
   (void)SGF.B.createApply(loc, accessorRef, subs, arguments, ApplyOptions());

--- a/test/SILGen/init_accessor_constrained_extension_memberwise.swift
+++ b/test/SILGen/init_accessor_constrained_extension_memberwise.swift
@@ -1,0 +1,55 @@
+// RUN: %target-swift-emit-silgen -module-name main %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -module-name main %s > /dev/null
+
+struct Wrapper<T> {}
+
+extension Wrapper where T == Any {
+  struct Inner {
+    var _flag: Bool
+    var flag: Bool {
+      @storageRestrictions(initializes: _flag)
+      init { _flag = newValue }
+      get { _flag }
+    }
+  }
+}
+_ = Wrapper<Any>.Inner.init
+
+// CHECK-LABEL: sil hidden [ossa] @$s4main7WrapperVAAypRszlE5InnerV4flagAEyyp_GSb_tcfC : $@convention(method) (Bool, @thin Wrapper<Any>.Inner.Type) -> Wrapper<Any>.Inner
+// CHECK: [[REF:%.*]] = function_ref @$s4main7WrapperVAAypRszlE5InnerV4flagSbvi : $@convention(thin) (Bool, @thin Wrapper<Any>.Inner.Type) -> @out Bool
+// CHECK: apply [[REF]]({{.*}}) : $@convention(thin) (Bool, @thin Wrapper<Any>.Inner.Type) -> @out Bool
+
+extension Wrapper where T == Int {
+  struct InnerInt {
+    var _flag: Bool
+    var flag: Bool {
+      @storageRestrictions(initializes: _flag)
+      init { _flag = newValue }
+      get { _flag }
+    }
+  }
+}
+_ = Wrapper<Int>.InnerInt.init
+
+// CHECK-LABEL: sil hidden [ossa] @$s4main7WrapperVAASiRszlE8InnerIntV4flagAEySi_GSb_tcfC : $@convention(method) (Bool, @thin Wrapper<Int>.InnerInt.Type) -> Wrapper<Int>.InnerInt
+// CHECK: [[INT_REF:%.*]] = function_ref @$s4main7WrapperVAASiRszlE8InnerIntV4flagSbvi : $@convention(thin) (Bool, @thin Wrapper<Int>.InnerInt.Type) -> @out Bool
+// CHECK: apply [[INT_REF]]({{.*}}) : $@convention(thin) (Bool, @thin Wrapper<Int>.InnerInt.Type) -> @out Bool
+
+// A genuinely generic extension keeps substitutions on the init-accessor apply.
+struct Box<T> {}
+
+extension Box {
+  struct Inner {
+    var _value: T
+    var value: T {
+      @storageRestrictions(initializes: _value)
+      init { _value = newValue }
+      get { _value }
+    }
+  }
+}
+_ = Box<Int>.Inner.init
+
+// CHECK-LABEL: sil hidden [ossa] @$s4main3BoxV5InnerV5valueAEyx_Gx_tcfC : $@convention(method) <T> (@in T, @thin Box<T>.Inner.Type) -> @out Box<T>.Inner
+// CHECK: [[GENERIC_REF:%.*]] = function_ref @$s4main3BoxV5InnerV5valuexvi : $@convention(thin) <τ_0_0> (@in τ_0_0, @thin Box<τ_0_0>.Inner.Type) -> @out τ_0_0
+// CHECK: apply [[GENERIC_REF]]<T>({{.*}}) : $@convention(thin) <τ_0_0> (@in τ_0_0, @thin Box<τ_0_0>.Inner.Type) -> @out τ_0_0


### PR DESCRIPTION
**Explanation**: A regression from Swift 6.4 that breaks uses of `@State` in extensions of constrained generics, including the `SwiftUIBackports` package.

 ApplyInst had an assertion raised to run in release builds in https://github.com/swiftlang/swift/pull/88160 that ensures the substitution map is empty if there is no invocation generic signature. There's no invocation signature when there is a same-type constraint to a concrete type.

**Scope**: This is truly a bug in init accessor application emission. Init accessors have become more heavily exercised ever since SwiftUI's `@State` macro has started to use them.

**Issues**: rdar://182431108 / https://github.com/swiftlang/swift/issues/90734

**Original PRs**: https://github.com/swiftlang/swift/pull/90784

**Risk**: Low. This is a targeted and simple fix. The fix is spiritually the same as in https://github.com/swiftlang/swift/pull/88402 so it's a proven remedy.

**Testing**: A new test was added for this case.

**Reviewers**: Joe