### PR TITLE
[Sema] Better diagnostic for passing a non-escaping argument to an overloaded @escaping parameter

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5303,6 +5303,10 @@ ERROR(passing_noattrfunc_to_attrfunc,none,
       "passing %select{non-escaping|non-Sendable}0 parameter %1 to function "
       "expecting %select{an '@escaping'|a '@Sendable'}0 closure",
       (unsigned, Identifier))
+NOTE(candidate_expects_escaping_argument,none,
+     "candidate expects %select{an '@escaping'|a '@Sendable'}0 closure for "
+     "parameter #%1, but argument %2 is %select{non-escaping|non-Sendable}0",
+     (unsigned, unsigned, StringRef))
 ERROR(converting_noescape_param_to_generic_type,none,
       "converting non-escaping parameter %0 to generic parameter %1 may allow it to escape",
       (Identifier, Type))

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1218,6 +1218,26 @@ bool ArrayLiteralToDictionaryConversionFailure::diagnoseAsError() {
   return true;
 }
 
+bool AttributedFuncToTypeConversionFailure::diagnoseAsNote() {
+  if (!getToType()->is<FunctionType>())
+    return false;
+
+  auto argApplyInfo = getFunctionArgApplyInfo(getLocator());
+  if (!argApplyInfo)
+    return false;
+
+  auto overload = getCalleeOverloadChoiceIfAvailable(getLocator());
+  if (!(overload && overload->choice.isDecl()))
+    return false;
+
+  SmallString<4> scratch;
+  emitDiagnosticAt(overload->choice.getDecl(),
+                   diag::candidate_expects_escaping_argument, attributeKind,
+                   argApplyInfo->getParamPosition(),
+                   argApplyInfo->getArgDescription(scratch));
+  return true;
+}
+
 bool AttributedFuncToTypeConversionFailure::diagnoseAsError() {
   if (diagnoseParameterUse())
     return true;

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -835,6 +835,7 @@ public:
         attributeKind(attributeKind) {}
 
   bool diagnoseAsError() override;
+  bool diagnoseAsNote() override;
 
 private:
   /// Emit tailored diagnostics for no-escape/non-sendable parameter

--- a/test/attr/attr_escaping.swift
+++ b/test/attr/attr_escaping.swift
@@ -271,3 +271,42 @@ class C_57070 {
     // expected-note@-1{{parameter #1 expects escaping value of type '() -> Void'}}
   }
 }
+
+// https://github.com/swiftlang/swift/issues/90695
+// Note the escaping mismatch on each candidate, not just "no exact matches".
+func overloadedEscaping(_ fn: @escaping () -> Void) {}
+// expected-note@-1{{candidate expects an '@escaping' closure for parameter #1, but argument #1 is non-escaping}}
+func overloadedEscaping(_ fn: @escaping () throws -> Void) {}
+// expected-note@-1{{candidate expects an '@escaping' closure for parameter #1, but argument #1 is non-escaping}}
+
+func testOverloadedEscaping(_ c: () -> Void) {
+  overloadedEscaping(c) // expected-error{{no exact matches in call to global function 'overloadedEscaping'}}
+}
+
+// Overloads that fail differently keep their own note.
+func mixedOverload(_ fn: @escaping () -> Void) {}
+// expected-note@-1{{candidate expects an '@escaping' closure for parameter #1, but argument #1 is non-escaping}}
+func mixedOverload(_ fn: (Int) -> Void) {}
+// expected-note@-1{{candidate has partially matching parameter list ((Int) -> Void)}}
+
+func testMixedOverload(_ c: () -> Void) {
+  mixedOverload(c) // expected-error{{no exact matches in call to global function 'mixedOverload'}}
+}
+
+// Methods and subscripts get the note too (they don't anchor on a DeclRefExpr).
+struct OverloadedEscaping {
+  func method(_ fn: @escaping () -> Void) {}
+  // expected-note@-1{{candidate expects an '@escaping' closure for parameter #1, but argument #1 is non-escaping}}
+  func method(_ fn: @escaping () throws -> Void) {}
+  // expected-note@-1{{candidate expects an '@escaping' closure for parameter #1, but argument #1 is non-escaping}}
+
+  subscript(fn: @escaping () -> Void) -> Int { 0 }
+  // expected-note@-1{{candidate expects an '@escaping' closure for parameter #1, but argument #1 is non-escaping}}
+  subscript(fn: @escaping () throws -> Void) -> Int { 0 }
+  // expected-note@-1{{candidate expects an '@escaping' closure for parameter #1, but argument #1 is non-escaping}}
+}
+
+func testMethodAndSubscript(_ o: OverloadedEscaping, _ c: () -> Void) {
+  o.method(c) // expected-error{{no exact matches in call to instance method 'method'}}
+  _ = o[c] // expected-error{{no exact matches in call to subscript}}
+}


### PR DESCRIPTION
When all the overloads fail just because a non-escaping argument is passed to an escaping parameter, we fell back to a generic "no exact matches" error, with candidate notes that look identical to the argument. Add diagnoseForAmbiguity to the MarkExplicitlyEscaping fix so we report the escaping error once instead.

Resolves #90695