### PR TITLE
[cxx-interop] Synthesize base-class upcast instead of relying on CxxShim

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5711,60 +5711,14 @@ SourceLoc swift::extractNearestSourceLoc(EscapabilityLookupDescriptor) {
   return SourceLoc();
 }
 
-// Just create a specialized function decl for "__swift_interopStaticCast"
-// using the types base and derived.
-static
-DeclRefExpr *getInteropStaticCastDeclRefExpr(ASTContext &ctx,
-                                             const clang::Module *owningModule,
-                                             Type base, Type derived) {
-  if (base->isForeignReferenceType() && derived->isForeignReferenceType()) {
-    base = base->wrapInPointer(PTK_UnsafePointer);
-    derived = derived->wrapInPointer(PTK_UnsafePointer);
-  }
-
-  // Lookup our static cast helper function in the C++ shim module.
-  auto wrapperModule = ctx.getLoadedModule(ctx.getIdentifier(CXX_SHIM_NAME));
-  assert(wrapperModule &&
-         "CxxShim module is required when using members of a base class. "
-         "Make sure you `import CxxShim`.");
-
-  SmallVector<ValueDecl *, 1> results;
-  ctx.lookupInModule(wrapperModule, "__swift_interopStaticCast", results);
-  assert(
-      results.size() == 1 &&
-      "Did you forget to define a __swift_interopStaticCast helper function?");
-  FuncDecl *staticCastFn = cast<FuncDecl>(results.back());
-
-  // Now we have to force instantiate this. We can't let the type checker do
-  // this yet because it can't infer the "To" type.
-  auto subst =
-      SubstitutionMap::get(staticCastFn->getGenericSignature(), {derived, base},
-                           LookUpConformanceInModule());
-  auto functionTemplate = const_cast<clang::FunctionTemplateDecl *>(
-      cast<clang::FunctionTemplateDecl>(staticCastFn->getClangDecl()));
-  auto spec = ctx.getClangModuleLoader()->instantiateCXXFunctionTemplate(
-      ctx, functionTemplate, subst);
-  auto specializedStaticCastFn =
-      cast<FuncDecl>(ctx.getClangModuleLoader()->importDeclDirectly(spec));
-
-  auto staticCastRefExpr = new (ctx)
-      DeclRefExpr(ConcreteDeclRef(specializedStaticCastFn), DeclNameLoc(),
-                  /*implicit*/ true);
-  staticCastRefExpr->setType(specializedStaticCastFn->getInterfaceType());
-
-  return staticCastRefExpr;
-}
-
 // Create the following expressions:
 // %0 = Builtin.addressof(&self)
 // %1 = Builtin.reinterpretCast<UnsafeMutablePointer<Derived>>(%0)
-// %2 = __swift_interopStaticCast<UnsafeMutablePointer<Base>?>(%1)
-// %3 = %2!
-// return %3.pointee
-static
-MemberRefExpr *getSelfInteropStaticCast(FuncDecl *funcDecl,
-                                        NominalTypeDecl *baseStruct,
-                                        NominalTypeDecl *derivedStruct) {
+// %2 = __swift_interopStaticCast_...(%1) // UnsafeMutablePointer<Base>
+// return %2.pointee
+static MemberRefExpr *getSelfInteropStaticCast(FuncDecl *funcDecl,
+                                               NominalTypeDecl *baseStruct,
+                                               NominalTypeDecl *derivedStruct) {
   auto &ctx = funcDecl->getASTContext();
 
   auto mutableSelf = [&ctx](FuncDecl *funcDecl) {
@@ -5810,15 +5764,30 @@ MemberRefExpr *getSelfInteropStaticCast(FuncDecl *funcDecl,
                           Argument::unlabeled(rawSelfPointer));
   selfPointer->setType(derivedPtrType);
 
-  auto staticCastRefExpr = getInteropStaticCastDeclRefExpr(
-      ctx, baseStruct->getClangDecl()->getOwningModule(),
-      baseStruct->getSelfInterfaceType()->wrapInPointer(
-          PTK_UnsafeMutablePointer),
-      derivedStruct->getSelfInterfaceType()->wrapInPointer(
-          PTK_UnsafeMutablePointer));
+  auto *baseRecord =
+      dyn_cast_or_null<clang::CXXRecordDecl>(baseStruct->getClangDecl());
+  auto *derivedRecord =
+      dyn_cast_or_null<clang::CXXRecordDecl>(derivedStruct->getClangDecl());
+  if (!baseRecord || !derivedRecord)
+    return nullptr;
+
+  // Synthesize call to __swift_interopStaticCast_...(), which is just a wrapper
+  // around C++ static_cast() to upcast from derived to base.
+  auto *importer = static_cast<ClangImporter *>(ctx.getClangModuleLoader());
+  FuncDecl *castFn =
+      SwiftDeclSynthesizer(importer).makeBaseClassPointerCastFunction(
+          derivedRecord, baseRecord);
+  if (!castFn)
+    return nullptr;
+
+  auto *staticCastRefExpr =
+      new (ctx) DeclRefExpr(ConcreteDeclRef(castFn), DeclNameLoc(),
+                            /*implicit*/ true);
+  staticCastRefExpr->setType(castFn->getInterfaceType());
+
   auto *argList = ArgumentList::forImplicitUnlabeled(ctx, {selfPointer});
   auto casted = CallExpr::createImplicit(ctx, staticCastRefExpr, argList);
-  // This will be "Optional<UnsafeMutablePointer<Base>>"
+  // This will be "UnsafeMutablePointer<Base>" (non-optional)
   casted->setType(cast<FunctionType>(staticCastRefExpr->getType().getPointer())
                       ->getResult());
   casted->setThrows(nullptr);
@@ -6294,10 +6263,9 @@ synthesizeBaseClassFieldAddressGetterBody(AbstractFunctionDecl *afd,
 // For setters we have to pass self as a pointer and then emit an assign:
 //   %0 = Builtin.addressof(&self)
 //   %1 = Builtin.reinterpretCast<UnsafeMutablePointer<Derived>>(%0)
-//   %2 = __swift_interopStaticCast<UnsafeMutablePointer<Base>?>(%1)
-//   %3 = %2!
-//   %4 = %3.pointee
-//   assign newValue to %4
+//   %2 = __swift_interopStaticCast_...(%1) // UnsafeMutablePointer<Base>
+//   %3 = %2.pointee
+//   assign newValue to %3
 static std::pair<BraceStmt *, bool>
 synthesizeBaseClassFieldSetterBody(AbstractFunctionDecl *afd, void *context) {
   auto setterDecl = cast<AccessorDecl>(afd);
@@ -6311,6 +6279,13 @@ synthesizeBaseClassFieldSetterBody(AbstractFunctionDecl *afd, void *context) {
 
   auto *pointeePropertyRefExpr =
       getSelfInteropStaticCast(setterDecl, baseStruct, derivedStruct);
+  if (!pointeePropertyRefExpr) {
+    ctx.Diags.diagnose(SourceLoc(), diag::failed_base_method_call_synthesis,
+                       setterDecl, baseStruct);
+    auto body = BraceStmt::create(ctx, SourceLoc(), {}, SourceLoc(),
+                                  /*implicit=*/true);
+    return {body, /*isTypeChecked=*/true};
+  }
 
   Expr *storedRef = nullptr;
   if (auto subscript = dyn_cast<SubscriptDecl>(baseClassVar)) {

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -778,6 +778,13 @@ private:
   llvm::DenseMap<NominalTypeDecl *, FuncDecl *> importedOperatorBoolCache;
 
 public:
+  /// Cache of synthesized derived-to-base pointer upcast functions,
+  /// keyed by the (derived, base) C++ record pair.
+  llvm::DenseMap<
+      std::pair<const clang::CXXRecordDecl *, const clang::CXXRecordDecl *>,
+      FuncDecl *>
+      synthesizedBaseCastFunctions;
+
   llvm::DenseMap<const clang::ParmVarDecl*, FuncDecl*> defaultArgGenerators;
 
   bool isDefaultArgSafeToImport(const clang::ParmVarDecl *param);

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -3170,6 +3170,92 @@ SwiftDeclSynthesizer::synthesizeStaticFactoryForCXXForeignRef(
   return synthesizedFactories;
 }
 
+FuncDecl *SwiftDeclSynthesizer::makeBaseClassPointerCastFunction(
+    const clang::CXXRecordDecl *derivedClass,
+    const clang::CXXRecordDecl *baseClass) {
+  auto key = std::make_pair(derivedClass->getCanonicalDecl(),
+                            baseClass->getCanonicalDecl());
+  auto &cache = ImporterImpl.synthesizedBaseCastFunctions;
+
+  if (auto [it, inserted] = cache.try_emplace(key, nullptr); !inserted)
+    return it->second;
+
+  auto &clangCtx = ImporterImpl.getClangASTContext();
+  auto &clangSema = ImporterImpl.getClangSema();
+  ASTContext &ctx = ImporterImpl.SwiftContext;
+
+  clang::SourceLocation loc = derivedClass->getLocation();
+  clang::DeclContext *TUDC = clangCtx.getTranslationUnitDecl();
+
+  clang::Sema::SFINAETrap trap(clangSema);
+
+  // Build `Derived * _Nonnull` and `Base * _Nonnull`, and the function type.
+  clang::QualType derivedTy = clangCtx.getRecordType(derivedClass),
+                  baseTy = clangCtx.getRecordType(baseClass);
+
+  clang::QualType derivedPtrTy = clangCtx.getPointerType(derivedTy),
+                  basePtrTy = clangCtx.getPointerType(baseTy);
+
+  if (clangSema.CheckImplicitNullabilityTypeSpecifier(
+          derivedPtrTy, clang::NullabilityKind::NonNull, loc, /*isParam=*/true,
+          /*OverrideExisting=*/true))
+    return nullptr;
+  if (clangSema.CheckImplicitNullabilityTypeSpecifier(
+          basePtrTy, clang::NullabilityKind::NonNull, loc, /*isParam=*/false,
+          /*OverrideExisting=*/true))
+    return nullptr;
+
+  clang::QualType funcTy = clangCtx.getFunctionType(
+      basePtrTy, {derivedPtrTy}, clang::FunctionProtoType::ExtProtoInfo());
+
+  // Build a deterministic, unique name from the mangled canonical types of the
+  // derived and base classes, to avoid collisions in the SwiftLookupTable.
+  clang::DeclarationName declName;
+  {
+    std::string funcName;
+    llvm::raw_string_ostream os(funcName);
+    std::unique_ptr<clang::ItaniumMangleContext> mangler{
+        clang::ItaniumMangleContext::create(clangCtx,
+                                            clangCtx.getDiagnostics())};
+    os << "__swift_interopStaticCast_";
+    mangler->mangleCanonicalTypeName(derivedTy, os);
+    os << "_to_";
+    mangler->mangleCanonicalTypeName(baseTy, os);
+
+    declName = clang::DeclarationName(&clangCtx.Idents.get(os.str()));
+  }
+
+  auto *castDecl = createClangFunctionDecl(clangCtx, TUDC, declName, funcTy);
+
+  auto *paramDecl =
+      createClangParmVarDecl(clangCtx, castDecl, nullptr, derivedPtrTy);
+  auto *paramRefExpr = createClangDeclRefExpr(clangCtx, paramDecl, derivedPtrTy,
+                                              clang::VK_LValue);
+  castDecl->setParams({paramDecl});
+
+  // Synthesize `return static_cast<Base *>(from);`. Using a real static_cast
+  // is required because a base subobject may live at a non-zero offset within
+  // the derived object (multiple/virtual inheritance).
+  auto castResult = clangSema.BuildCXXNamedCast(
+      loc, clang::tok::kw_static_cast,
+      clangCtx.getTrivialTypeSourceInfo(basePtrTy), paramRefExpr,
+      clang::SourceRange(), clang::SourceRange());
+  if (!castResult.isUsable())
+    return nullptr;
+
+  castDecl->setBody(createClangReturnStmt(clangCtx, castResult.get()));
+
+  ImporterImpl.registerSynthesizedClangDecl(castDecl, derivedClass);
+
+  auto *importedFn = dyn_cast_or_null<FuncDecl>(
+      ctx.getClangModuleLoader()->importDeclDirectly(castDecl));
+
+  // N.B. we need to do another lookup here because the import above may have
+  // invalidated the iterator from the beginning of this function.
+  cache[key] = importedFn;
+  return importedFn;
+}
+
 static std::pair<BraceStmt *, bool>
 synthesizeAvailabilityDomainPredicateBody(AbstractFunctionDecl *afd,
                                           void *context) {

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -352,6 +352,21 @@ public:
   synthesizeStaticFactoryForCXXForeignRef(
       const clang::CXXRecordDecl *cxxRecordDecl);
 
+  /// Synthesize (and import) a C++ function that performs a `static_cast` from
+  /// a pointer to \p derivedClass to a pointer to \p baseClass, i.e.
+  ///
+  /// \code
+  /// static Base * _Nonnull __swift_interopStaticCast_...(
+  ///     Derived * _Nonnull from) {
+  ///   return static_cast<Base *>(from);
+  /// }
+  /// \endcode
+  ///
+  /// Returns `nullptr` on failure; result is cached per (derived, base) pair.
+  FuncDecl *
+  makeBaseClassPointerCastFunction(const clang::CXXRecordDecl *derivedClass,
+                                   const clang::CXXRecordDecl *baseClass);
+
   /// Look for an explicitly-provided "destroy" operation. If one exists
   /// and the type has been imported as noncopyable, add an explicit `deinit`
   /// that calls that destroy operation.

--- a/stdlib/public/Cxx/cxxshim/libcxxshim.h
+++ b/stdlib/public/Cxx/cxxshim/libcxxshim.h
@@ -1,4 +1,6 @@
-template <class From, class To>
-To _Nonnull __swift_interopStaticCast(From _Nonnull from) {
-  return static_cast<To>(from);
-}
+// This header (and thus the CxxShim module) is intentionally empty, and is
+// retained for toolchain compatibility and possible future use.
+//
+// It previously defined utilities used for forward interop, but those have been
+// moved into the compiler since this module is not implicitly imported and
+// thus absent when emitting module interfaces.

--- a/test/Interop/Cxx/class/inheritance/inherited-field-setter-missing-cxxshim.swift
+++ b/test/Interop/Cxx/class/inheritance/inherited-field-setter-missing-cxxshim.swift
@@ -1,0 +1,36 @@
+// Regression test for a SILGen crash when the synthesized accessor of an
+// inherited C++ base class data member is emitted while CxxShim is not loaded,
+// which was historically needed to provide the upcast used by those accessors.
+// Emitting a module interface disables the implicit CxxShim import.
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -emit-module %t/main.swift -module-name Test \
+// RUN:     -I %t/Inputs -cxx-interoperability-mode=default -swift-version 5 \
+// RUN:     -emit-module-interface-path %t/Test.swiftinterface \
+// RUN:     -o %t/Test.swiftmodule
+
+// RUN: %target-swift-frontend -emit-silgen %t/main.swift -module-name Test \
+// RUN:     -I %t/Inputs -cxx-interoperability-mode=default -swift-version 5 \
+// RUN: | %FileCheck %s
+
+//--- Inputs/module.modulemap
+module Minimal {
+  header "minimal.hpp"
+  requires cplusplus
+}
+
+//--- Inputs/minimal.hpp
+#pragma once
+
+struct Base { double value; };
+struct Derived : public Base {};
+
+//--- main.swift
+import Minimal
+
+// Assigning through the inherited data member forces SILGen to emit the
+// synthesized Derived.value setter.
+func writeThroughInheritedField(_ d: inout Derived) { d.value = 1.0 }
+
+// CHECK: function_ref @{{.*}}__swift_interopStaticCast_{{.*}}Derived{{.*}}_to_{{.*}}Base{{.*}} : $@convention(c) (UnsafeMutablePointer<Derived>) -> UnsafeMutablePointer<Base>


### PR DESCRIPTION
The synthesized setter for an inherited C++ base class member upcasts self from the derived to the base struct via __swift_interopStaticCast, a templated function from the CxxShim module. CxxShim is not implicitly imported when emitting a module interface, so the compiler crashed instead of handling its absence.

Synthesize the static_cast wrapper directly in ClangImporter so the upcast no longer depends on CxxShim, which also fixes the crash.

This patch removes the need for CxxShim (which is now just empty) in the toolchain, but keeps it around in case this infrastructure is needed for future work.

rdar://182545495