### PR TITLE
[SILParser] Limit some lookups semantically

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -648,6 +648,10 @@ ERROR(sil_witness_method_type_does_not_conform,none,
 ERROR(sil_member_decl_not_found,none, "member not found", ())
 ERROR(sil_named_member_decl_not_found,none,
       "member %0 not found in type %1", (DeclName, Type))
+ERROR(sil_no_named_decl_matching_predicate,none,
+      "no declaration %0 found that is a %select{%error|property or subscript|"
+      "property|stored property}1",
+      (DeclName, unsigned))
 ERROR(sil_member_lookup_bad_type,none,
       "cannot lookup member %0 in non-nominal, non-module type %1",
       (DeclName, Type))

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -1353,6 +1353,50 @@ bool SILParser::parseSILDottedPathWithoutPound(ValueDecl *&Decl,
   return false;
 }
 
+static bool satisfies(ValueDecl *decl,
+                      SILParser::ValueDeclPredicate predicate) {
+  if (!decl)
+    return true;
+
+  switch (predicate) {
+  case SILParser::ValueDeclPredicate::None:
+    return true;
+
+  case SILParser::ValueDeclPredicate::Storage:
+    return isa<AbstractStorageDecl>(decl);
+
+  case SILParser::ValueDeclPredicate::Var:
+    return isa<VarDecl>(decl);
+
+  case SILParser::ValueDeclPredicate::StoredVar: {
+    if (auto prop = dyn_cast<VarDecl>(decl)) {
+      return prop->hasStorage();
+    }
+    return false;
+  }
+
+  }
+  llvm_unreachable("unknown ValueDeclPredicate");
+}
+
+bool SILParser::applyValueDeclPredicate(ValueDeclPredicate predicate,
+                                        ValueDecl *&Decl,
+                                        SmallVectorImpl<ValueDecl *> &values) {
+  if (satisfies(Decl, predicate))
+    return false;
+
+  for (auto value : values) {
+    if (satisfies(value, predicate)) {
+      Decl = value;
+      return false;
+    }
+  }
+
+  P.diagnose(P.PreviousLoc, diag::sil_no_named_decl_matching_predicate,
+             Decl->getName(), unsigned(predicate));
+  return true;
+}
+
 static std::optional<AccessorKind> getAccessorKind(StringRef ident) {
   return llvm::StringSwitch<std::optional<AccessorKind>>(ident)
       .Case("getter", AccessorKind::Get)
@@ -2516,7 +2560,7 @@ SILParser::parseKeyPathPatternComponent(KeyPathPatternComponent &component,
   if (componentKind.str() == "stored_property") {
     ValueDecl *prop;
     CanType ty;
-    if (parseSILDottedPath(prop)
+    if (parseSILDottedPath(prop, ValueDeclPredicate::StoredVar)
         || P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":")
         || P.parseToken(tok::sil_dollar,
                         diag::expected_tok_in_sil_instr, "$")
@@ -2565,7 +2609,7 @@ SILParser::parseKeyPathPatternComponent(KeyPathPatternComponent &component,
           if (P.peekToken().is(tok::pound)) {
             ValueDecl *propertyValueDecl;
             P.consumeToken(tok::pound);
-            if (parseSILDottedPath(propertyValueDecl))
+            if (parseSILDottedPath(propertyValueDecl, ValueDeclPredicate::Var))
               return true;
             idProperty = cast<VarDecl>(propertyValueDecl);
           } else if (parseSILDeclRef(idDecl, /*fnType*/ true))
@@ -2593,7 +2637,7 @@ SILParser::parseKeyPathPatternComponent(KeyPathPatternComponent &component,
         ValueDecl *parsedExternalDecl;
         SmallVector<ParsedSubstitution, 4> parsedSubs;
 
-        if (parseSILDottedPath(parsedExternalDecl)
+        if (parseSILDottedPath(parsedExternalDecl, ValueDeclPredicate::Storage)
             || parseSubstitutions(parsedSubs, patternSig, patternParams))
           return true;
 
@@ -4871,7 +4915,7 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
 
     if (parseAssignOrInitMode(Mode, *this) ||
         parseAssignOrInitAssignments(assignments, *this) ||
-        parseSILDottedPath(Prop) ||
+        parseSILDottedPath(Prop, ValueDeclPredicate::Var) ||
         P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
         parseVerbatim("self") || parseTypedValueRef(Self, B) ||
         P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
@@ -6017,7 +6061,7 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
       SourceLoc NameLoc = P.Tok.getLoc();
       if (parseTypedValueRef(Val, B) ||
           P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-          parseSILDottedPath(FieldV))
+          parseSILDottedPath(FieldV, ValueDeclPredicate::StoredVar))
         return true;
 
       ValueOwnershipKind forwardingOwnership = Val->getOwnershipKind();
@@ -6054,7 +6098,8 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
       if (parseSILOptional(IsImmutable, *this, "immutable") ||
           parseTypedValueRef(Val, B) ||
           P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-          parseSILDottedPath(FieldV) || parseSILDebugLocation(InstLoc, B))
+          parseSILDottedPath(FieldV, ValueDeclPredicate::StoredVar) ||
+          parseSILDebugLocation(InstLoc, B))
         return true;
       if (!FieldV || !isa<VarDecl>(FieldV)) {
         P.diagnose(NameLoc, diag::sil_ref_inst_wrong_field);
@@ -7929,7 +7974,7 @@ bool SILParserState::parseSILProperty(Parser &P) {
   
   ValueDecl *VD;
   
-  if (SP.parseSILDottedPath(VD))
+  if (SP.parseSILDottedPath(VD, SILParser::ValueDeclPredicate::Storage))
     return true;
   
   GenericParamList *patternParams;

--- a/lib/SIL/Parser/SILParser.h
+++ b/lib/SIL/Parser/SILParser.h
@@ -299,11 +299,23 @@ public:
   }
   /// @}
 
+  enum class ValueDeclPredicate {
+    None,
+    Storage,
+    Var,
+    StoredVar
+  };
+  bool applyValueDeclPredicate(ValueDeclPredicate predicate,
+                               ValueDecl *&Decl,
+                               SmallVectorImpl<ValueDecl *> &values);
+
   bool parseSILDottedPath(ValueDecl *&Decl,
                           SmallVectorImpl<ValueDecl *> &values);
-  bool parseSILDottedPath(ValueDecl *&Decl) {
+  bool parseSILDottedPath(ValueDecl *&Decl, ValueDeclPredicate predicate) {
     SmallVector<ValueDecl *, 4> values;
-    return parseSILDottedPath(Decl, values);
+    if (parseSILDottedPath(Decl, values))
+      return true;
+    return applyValueDeclPredicate(predicate, Decl, values);
   }
   bool parseSILDottedPathWithoutPound(ValueDecl *&Decl,
                                       SmallVectorImpl<ValueDecl *> &values);

--- a/test/SIL/Parser/errors.sil
+++ b/test/SIL/Parser/errors.sil
@@ -59,3 +59,8 @@ bb0:
   return %0 : $()
 }
 
+sil @not_stored_property : $@convention(thin) (@owned Array<Int>) -> () {
+bb0(%0 : $Array<Int>):
+  %1 = struct_extract %0 : $Array<Int>, #Array.count // expected-error {{no declaration 'count' found that is a stored property}}
+}
+


### PR DESCRIPTION
Modify one of the `parseSILDottedPath()` overloads to better handle multiple results where some satisfy the instruction’s requirements but others do not. For instance, if the lookup for `struct_extract` finds a stored property and another member, the SIL parser will reject the non-stored property.

This is not intended to be comprehensive; it just fixes specific instructions that are known to break in a PR I’m working on.