### PR TITLE
[Diagnostics] Diagnose noncopyable conversions to AnyObject

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -328,6 +328,8 @@ ERROR(cannot_convert_initializer_value_anyobject,none,
       "value of type %0 expected to be instance of class or "
       "class-constrained type",
       (Type, Type))
+ERROR(cannot_convert_noncopyable_value_to_anyobject,none,
+      "value of noncopyable type %0 cannot be converted to %1", (Type, Type))
 ERROR(cannot_convert_initializer_value_nil,none,
       "'nil' cannot initialize specified type %0", (Type))
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3866,14 +3866,21 @@ ContextualFailure::getDiagnosticFor(ContextualTypePurpose context,
 
 bool NonClassTypeToAnyObjectConversionFailure::diagnoseAsError() {
   auto locator = getLocator();
-  if (locator->isForContextualType()) {
-    return ContextualFailure::diagnoseAsError();
-  }
-
   auto fromType = getFromType();
   auto toType = getToType();
   assert(fromType);
   assert(toType);
+
+  if (fromType->isNoncopyable()) {
+    emitDiagnostic(diag::cannot_convert_noncopyable_value_to_anyobject,
+                   fromType, toType);
+    return true;
+  }
+
+  if (locator->isForContextualType()) {
+    return ContextualFailure::diagnoseAsError();
+  }
+
   if (locator->isLastElement<LocatorPathElt::ApplyArgToParam>()) {
     ArgumentMismatchFailure failure(getSolution(), fromType, toType, locator);
     return failure.diagnoseAsError();

--- a/test/Generics/inverse_copyable_requirement.swift
+++ b/test/Generics/inverse_copyable_requirement.swift
@@ -160,14 +160,14 @@ func checkCasting(_ b: any Box, _ mo: borrowing MO, _ a: Any) {
 
   let _: Sendable = MO() // expected-error {{value of type 'MO' does not conform to specified type 'Copyable'}}
   let _: Copyable = mo // expected-error {{value of type 'MO' does not conform to specified type 'Copyable'}}
-  let _: AnyObject = MO() // expected-error {{value of type 'MO' expected to be instance of class or class-constrained type}}
+  let _: AnyObject = MO() // expected-error {{value of noncopyable type 'MO' cannot be converted to 'AnyObject'}}
   let _: Any = mo // expected-error {{value of type 'MO' does not conform to specified type 'Copyable'}}
 
   _ = MO() as P // expected-error {{cannot convert value of type 'MO' to type 'any P' in coercion}}
   _ = MO() as any P // expected-error {{cannot convert value of type 'MO' to type 'any P' in coercion}}
   _ = MO() as Any // expected-error {{cannot convert value of type 'MO' to type 'Any' in coercion}}
   _ = MO() as MO
-  _ = MO() as AnyObject // expected-error {{value of type 'MO' expected to be instance of class or class-constrained type}}
+  _ = MO() as AnyObject // expected-error {{value of noncopyable type 'MO' cannot be converted to 'AnyObject'}}
   _ = 5 as MO // expected-error {{cannot convert value of type 'Int' to type 'MO' in coercion}}
   _ = a as MO // expected-error {{cannot convert value of type 'Any' to type 'MO' in coercion}}
   _ = b as MO // expected-error {{cannot convert value of type 'any Box' to type 'MO' in coercion}}


### PR DESCRIPTION
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

A noncopyable value cannot be converted to `AnyObject`, but the compiler
currently diagnoses the conversion as requiring a class or class-constrained
type. That diagnostic is misleading because copyable value types can be
converted to `AnyObject`.

Emit a dedicated diagnostic for this case:

```swift
struct NC: ~Copyable {}

_ = NC() as AnyObject
// error: value of noncopyable type 'NC' cannot be converted to 'AnyObject'
```


The check is performed in NonClassTypeToAnyObjectConversionFailure, before dispatching contextual conversion diagnostics. This covers both contextual initialization and explicit as AnyObject coercions while preserving the existing behavior for copyable values.

The existing inverse Copyable requirement test now verifies both conversion forms.

Resolves #90688