### PR TITLE
[NFC] [SymbolGraphGen] Refactor ExcludeAttrs in declaration fragment options

### DIFF
--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -10,8 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "clang/AST/DeclObjC.h"
-#include "clang/Basic/Module.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Comment.h"
 #include "swift/AST/Decl.h"
@@ -22,6 +20,9 @@
 #include "swift/Basic/Version.h"
 #include "swift/Sema/IDETypeChecking.h"
 #include "swift/SymbolGraphGen/DocumentationCategory.h"
+#include "clang/AST/DeclObjC.h"
+#include "clang/Basic/Module.h"
+#include "llvm/ADT/STLExtras.h"
 
 #include "DeclarationFragmentPrinter.h"
 #include "FormatVersion.h"
@@ -76,46 +77,28 @@ PrintOptions SymbolGraph::getDeclarationFragmentsPrintOptions() const {
 
   Opts.ExclusiveAttrList.clear();
 
-  llvm::StringMap<AnyAttrKind> ExcludeAttrs;
+  const AnyAttrKind AllowedTypeAttrs[] = {
+      TypeAttrKind::Autoclosure, TypeAttrKind::Convention,
+      TypeAttrKind::NoEscape,    TypeAttrKind::Escaping,
+      TypeAttrKind::Inout,       TypeAttrKind::Sendable};
 
 #define TYPE_ATTR(X, C)                                                        \
-  ExcludeAttrs.insert(std::make_pair("TypeAttrKind::" #C, TypeAttrKind::C));
+  if (!llvm::is_contained(AllowedTypeAttrs, TypeAttrKind::C))                  \
+    Opts.ExcludeAttrList.push_back(TypeAttrKind::C);
 #include "swift/AST/TypeAttr.def"
 
-  // Allow the following type attributes:
-  ExcludeAttrs.erase("TypeAttrKind::Autoclosure");
-  ExcludeAttrs.erase("TypeAttrKind::Convention");
-  ExcludeAttrs.erase("TypeAttrKind::NoEscape");
-  ExcludeAttrs.erase("TypeAttrKind::Escaping");
-  ExcludeAttrs.erase("TypeAttrKind::Inout");
-  ExcludeAttrs.erase("TypeAttrKind::Sendable");
-
-  // Don't allow the following decl attributes:
-  // These can be large and are already included elsewhere in
-  // symbol graphs.
-  ExcludeAttrs.insert(
-      std::make_pair("DeclAttrKind::Available", DeclAttrKind::Available));
-  ExcludeAttrs.insert(
-      std::make_pair("DeclAttrKind::Inline", DeclAttrKind::Inline));
-  ExcludeAttrs.insert(
-      std::make_pair("DeclAttrKind::Inlinable", DeclAttrKind::Inlinable));
-  ExcludeAttrs.insert(
-      std::make_pair("DeclAttrKind::Prefix", DeclAttrKind::Prefix));
-  ExcludeAttrs.insert(
-      std::make_pair("DeclAttrKind::Postfix", DeclAttrKind::Postfix));
-  ExcludeAttrs.insert(
-      std::make_pair("DeclAttrKind::Infix", DeclAttrKind::Infix));
-
+  // Don't allow the following decl attributes. These can be large and are
+  // already included elsewhere in symbol graphs.
+  Opts.ExcludeAttrList.push_back(DeclAttrKind::Available);
+  Opts.ExcludeAttrList.push_back(DeclAttrKind::Inline);
+  Opts.ExcludeAttrList.push_back(DeclAttrKind::Inlinable);
+  Opts.ExcludeAttrList.push_back(DeclAttrKind::Prefix);
+  Opts.ExcludeAttrList.push_back(DeclAttrKind::Postfix);
+  Opts.ExcludeAttrList.push_back(DeclAttrKind::Infix);
   // In "emit modules separately" jobs, access modifiers show up as attributes,
   // but we don't want them to be printed in declarations
-  ExcludeAttrs.insert(std::make_pair("DeclAttrKind::AccessControl",
-                                     DeclAttrKind::AccessControl));
-  ExcludeAttrs.insert(
-      std::make_pair("DeclAttrKind::SetterAccess", DeclAttrKind::SetterAccess));
-
-  for (const auto &Entry : ExcludeAttrs) {
-    Opts.ExcludeAttrList.push_back(Entry.getValue());
-  }
+  Opts.ExcludeAttrList.push_back(DeclAttrKind::AccessControl);
+  Opts.ExcludeAttrList.push_back(DeclAttrKind::SetterAccess);
 
   return Opts;
 }


### PR DESCRIPTION
Replace the llvm::StringMap<AnyAttrKind> dance with direct pushes onto Opts.ExcludeAttrList. Type attributes are now filtered against a small allow-list via llvm::is_contained instead of inserting every kind and then erasing the allowed ones by string name. This patch is NFC.