### PR TITLE
[Embedded] Stop forcing position-independent code for -none- triples

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -590,11 +590,18 @@ void importer::getNormalInvocationArguments(
 
   // Swift generates position-independent code by default, so establish `-fPIC`
   // as the baseline for any code Clang emits (e.g. inline functions). `-fPIC`
-  // is not supported on Windows, which is implicitly position-independent. This
-  // is only a default: because the last PIC-related flag wins, a subsequent
-  // `-Xcc -fno-pic` (etc.) overrides it, and the resulting relocation model is
-  // read back from Clang for Swift's own code generation.
-  if (!triple.isOSWindows())
+  //
+  // Embedded Swift targeting a bare-metal ("-none-" OS) triple is an
+  // exception: we let Clang use the target's default relocation model
+  // (typically static) rather than forcing firmware into PIC. Users can still
+  // opt in explicitly with -Xcc -fPIC.
+  //
+  // This is only a default: because the last PIC-related flag wins, a
+  // subsequent `-Xcc -fno-pic` (etc.) overrides it, and the resulting
+  // relocation model is read back from Clang for Swift's own code generation.
+  bool bareMetalEmbedded =
+      LangOpts.hasFeature(Feature::Embedded) && triple.getOSName() == "none";
+  if (!triple.isOSWindows() && !bareMetalEmbedded)
     invocationArgStrs.insert(invocationArgStrs.end(), {"-fPIC"});
 
   // Enable modules.

--- a/test/embedded/disable_pic.swift
+++ b/test/embedded/disable_pic.swift
@@ -1,15 +1,23 @@
-// Position-independent vs. static code generation is controlled entirely by
-// Clang (the relocation model Clang resolves is reused for Swift's own code
-// generation), so `-Xcc -fno-pic` switches Swift to the static relocation
-// model too. Disabling PIC is only permitted in Embedded Swift. The effect is
-// only observable on targets where the static model differs from PIC (e.g.
-// x86_64 ELF); Mach-O is always position-independent.
-
+// The relocation model is controlled entirely by Clang and reused for Swift's
+// own code generation. Two behaviors are exercised here:
+//
+//  * Hosted targets default to position-independent code; `-Xcc -fno-pic`
+//    switches Swift to the static relocation model too. Disabling PIC is only
+//    permitted in Embedded Swift.
+//  * Embedded Swift targeting a bare-metal ("-none-" OS) triple is *not* forced
+//    to be position-independent — it uses the target's default (static)
+//    relocation model, and `-Xcc -fPIC` opts back in.
+//
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: CODEGENERATOR=X86
 
+// Hosted target: PIC by default, overridable with -Xcc -fno-pic.
 // RUN: %target-swift-frontend -target x86_64-unknown-linux-gnu -enable-experimental-feature Embedded -wmo -parse-stdlib %s -module-name main -S -o - | %FileCheck -check-prefix=PIC %s
 // RUN: %target-swift-frontend -target x86_64-unknown-linux-gnu -enable-experimental-feature Embedded -wmo -parse-stdlib -Xcc -fno-pic %s -module-name main -S -o - | %FileCheck -check-prefix=STATIC %s
+
+// Bare-metal target: static by default (PIC is not forced), overridable with -Xcc -fPIC.
+// RUN: %target-swift-frontend -target x86_64-unknown-none-elf -enable-experimental-feature Embedded -wmo -parse-stdlib %s -module-name main -S -o - | %FileCheck -check-prefix=STATIC %s
+// RUN: %target-swift-frontend -target x86_64-unknown-none-elf -enable-experimental-feature Embedded -wmo -parse-stdlib -Xcc -fPIC %s -module-name main -S -o - | %FileCheck -check-prefix=PIC %s
 
 // Disabling PIC without Embedded Swift is rejected.
 // RUN: not %target-swift-frontend -target x86_64-unknown-linux-gnu -parse-stdlib -Xcc -fno-pic %s -module-name main -S -o - 2>&1 | %FileCheck -check-prefix=ERROR %s

--- a/test/embedded/witness-table-crossref.swift
+++ b/test/embedded/witness-table-crossref.swift
@@ -25,8 +25,8 @@ extension X: P {
 
 
 //--- b.swift
-// B-OBJDUMP: R_ARM_REL32 $e4main1XVMf
-// B-OBJDUMP: R_ARM_REL32 $e4main1XVAA1PAAWP
+// B-OBJDUMP: R_ARM_THM_MOVW_ABS_NC $e4main1XVMf
+// B-OBJDUMP: R_ARM_THM_MOVW_ABS_NC $e4main1XVAA1PAAWP
 public func getP() -> any P {
   return X()
 }


### PR DESCRIPTION
For -none- triples in Embedded Swift, stop forcing position-independent code. It can be enabled with -Xcc -fPIC.

Finishes rdar://182555561