### PR TITLE
[Embedded] Re-enable readLine

### DIFF
--- a/stdlib/public/core/InputStream.swift
+++ b/stdlib/public/core/InputStream.swift
@@ -28,7 +28,6 @@ import SwiftShims
 ///   or character combinations are preserved. The default is `true`.
 /// - Returns: The string of characters read from standard input. If EOF has
 ///   already been reached when `readLine()` is called, the result is `nil`.
-@_unavailableInEmbedded
 public func readLine(strippingNewline: Bool = true) -> String? {
   var utf8Start: UnsafeMutablePointer<UInt8>?
   let utf8Count = unsafe swift_stdlib_readLine_stdin(&utf8Start)

--- a/test/embedded/unicode-dead-strip4.swift
+++ b/test/embedded/unicode-dead-strip4.swift
@@ -7,6 +7,20 @@
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_feature_Extern
 
+@_extern(c, "getline")
+func getline(
+  _ linePointer: UnsafeMutablePointer<UnsafeMutablePointer<UInt8>?>?,
+  _ linecapp: UnsafeMutablePointer<UInt>?,
+  _ stream: UnsafeRawPointer?
+) -> Int
+
+@c
+func swift_stdlib_readLine_stdin(_ linePointer: UnsafeMutablePointer<UnsafeMutablePointer<UInt8>?>?) -> Int {
+  return getline(linePointer, nil, nil)
+}
+
+
+
 @main
 struct Main {
   static func main() {
@@ -20,6 +34,10 @@ struct Main {
     print(b1 ?? false)
     print(b2 ?? false)
     print(b3 ?? false)
+
+    if let value = readLine(), let b4 = Bool(value) {
+      print(b4)
+    }
 
     let bi: StaticBigInt = 17
     print(bi.debugDescription)


### PR DESCRIPTION
readLine still needs proper support from the platform abstraction layer, but some examples are using it. Bring it back in its earlier form.
