### PR TITLE
[Concurrency] Remove dead `sys/syscall.h` include from Actor.cpp

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -74,10 +74,6 @@
 #include <unwind.h>
 #endif
 
-#if defined(__ELF__)
-#include <sys/syscall.h>
-#endif
-
 #if defined(_WIN32)
 #include <io.h>
 #endif


### PR DESCRIPTION
`Actor.cpp` includes `<sys/syscall.h>` under `#if defined(__ELF__)`, but the file does not use `syscall()` or any `SYS_*` constant. It is also the only file under `stdlib/public/Concurrency` that includes this header.

On freestanding ELF targets whose libc does not provide `<sys/syscall.h>`, such as riscv32 bare-metal targets using Picolibc, this unused include is the only thing preventing the translation unit from compiling:

```text
Actor.cpp:78:10: fatal error: 'sys/syscall.h' file not found
```

The include happens to resolve in the toolchain’s own embedded builds only because non-Darwin targets are currently compiled against the macOS SDK, which provides the header. Removing the unused include therefore has no effect on supported platforms.

The last use that required this header was replaced with `Thread::onMainThread()` during the Threading library rework in 14a4bd45b6b164e82679570b2fe649128c0dd8e6. The include should have been removed as part of that change.