### PR TITLE
[SymbolGraph] Emit symbol graphs after type checking

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -76,6 +76,7 @@
 #include "swift/Serialization/SerializationOptions.h"
 #include "swift/Serialization/SerializedModuleLoader.h"
 #include "swift/Subsystems.h"
+#include "swift/SymbolGraphGen/SymbolGraphGen.h"
 #include "swift/SymbolGraphGen/SymbolGraphOptions.h"
 
 #include "clang/Lex/Preprocessor.h"
@@ -1197,6 +1198,24 @@ static bool shouldEmitIndexData(const CompilerInvocation &Invocation) {
   return FrontendOptions::doesActionRequireSwiftStandardLibrary(action);
 }
 
+static void emitSymbolGraph(const CompilerInstance &Instance) {
+  llvm::PrettyStackTraceFormat trace("While emitting symbol graph");
+  symbolgraphgen::emitSymbolGraphForModule(
+      Instance.getMainModule(),
+      Instance.getInvocation().getSymbolGraphOptions());
+}
+
+static bool shouldEmitSymbolGraph(const CompilerInvocation &Invocation) {
+  const auto &opts = Invocation.getFrontendOptions();
+  if (Invocation.getSymbolGraphOptions().OutputDir.empty())
+    return false;
+  // For module-emitting actions, the symbol graph is produced as part of
+  // serialization. The type-check-only case is handled here.
+  if (opts.RequestedAction != FrontendOptions::ActionType::Typecheck)
+    return false;
+  return opts.InputsAndOutputs.isWholeModule();
+}
+
 /// Perform any actions that must have access to the ASTContext, and need to be
 /// delayed until the Swift compile pipeline has finished. This may be called
 /// before or after LLVM depending on when the ASTContext gets freed.
@@ -1288,6 +1307,10 @@ static void performEndOfPipelineActions(CompilerInstance &Instance) {
 
   if (shouldEmitIndexData(Invocation)) {
     emitIndexData(Instance);
+  }
+
+  if (!ctx.hadError() && shouldEmitSymbolGraph(Invocation)) {
+    emitSymbolGraph(Instance);
   }
 
   // Emit Swiftdeps for every file in the batch.

--- a/test/SymbolGraph/EmitWhileTypeChecking.swift
+++ b/test/SymbolGraph/EmitWhileTypeChecking.swift
@@ -1,0 +1,28 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck -emit-symbol-graph -emit-symbol-graph-dir %t %s -module-name EmitWhileTypeChecking
+// RUN: %FileCheck %s --input-file %t/EmitWhileTypeChecking.symbols.json
+// RUN: %FileCheck %s --input-file %t/EmitWhileTypeChecking.symbols.json --check-prefix PUB
+
+// also try without the trailing slash on `-emit-symbol-graph-dir` and make sure it works
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck -emit-symbol-graph -emit-symbol-graph-dir %t/ %s -module-name EmitWhileTypeChecking
+// RUN: %FileCheck %s --input-file %t/EmitWhileTypeChecking.symbols.json
+// RUN: %FileCheck %s --input-file %t/EmitWhileTypeChecking.symbols.json --check-prefix PUB
+
+// now run with -symbol-graph-minimum-access-level to change the available symbols
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck -emit-symbol-graph -emit-symbol-graph-dir %t %s -module-name EmitWhileTypeChecking -symbol-graph-minimum-access-level private
+// RUN: %FileCheck %s --input-file %t/EmitWhileTypeChecking.symbols.json
+// RUN: %FileCheck %s --input-file %t/EmitWhileTypeChecking.symbols.json --check-prefix PRIV
+
+/// Does a foo.
+public func foo() {}
+
+/// Does a bar.
+func bar() {}
+
+// CHECK: "precise":"s:21EmitWhileTypeChecking3fooyyF"
+// PUB-NOT: "precise":"s:21EmitWhileTypeChecking3baryyF"
+// PRIV: "precise":"s:21EmitWhileTypeChecking3baryyF"


### PR DESCRIPTION
Symbol graphs are currently only produced as part of module serialisation, which requires lowering to SIL and writing a .swiftmodule. This patch decouples symbol graph generation from module gneration by adding an additional emission point so that `-emit-symbol-graph-dir` can be used with `-typecheck`. Module-emitting actions continue to emit during serialisation, so the two paths are mutually exclusive and the symbol graph is not emitted twice.

Some numbers comparing this with the existing symbol graph generation after serialisation (ran with [hyperfine](https://github.com/sharkdp/hyperfine), mean of 20 runs with `-Onone`):

  | Project               | Module       | Files | Serialised | Typecheck | Speedup      |
  |-----------------------|--------------|------:|----------------------:|---------------------:|-------------:|
  | sourcekit-lsp         | SourceKitLSP |    31 |       1.831 ± 0.037 s |        0.837 ± 0.027 s |  2.19 ± 0.08x |
  | swift-syntax          | SwiftParser  |    46 |       3.517 ± 0.025 s |        1.557 ± 0.022 s |  2.26 ± 0.04x |
  | swift-package-manager | PackageModel |    59 |       2.850 ± 0.029 s |        1.188 ± 0.054 s |  2.40 ± 0.11x |
  | swift-build           | SWBUtil      |   100 |       5.259 ± 0.092 s |        2.206 ± 0.068 s |  2.38 ± 0.08x |

Just over twice as fast, I think this is a good win for consumers who want to use symbol graphs without performing a full module build.

rdar://182730576