### PR TITLE
[DiagnosticVerifier] improvements to -verify-child-notes

### DIFF
--- a/include/swift/Frontend/DiagnosticVerifier.h
+++ b/include/swift/Frontend/DiagnosticVerifier.h
@@ -178,11 +178,13 @@ private:
   bool parseTargetBufferName(StringRef &MatchStart, StringRef &Out, size_t &TextStartIdx);
   unsigned parseExpectedDiagInfo(unsigned BufferID, StringRef MatchStart,
                                  unsigned &PrevExpectedContinuationLine,
-                                 ExpectedDiagnosticInfo &Expected);
+                                 ExpectedDiagnosticInfo &Expected,
+                                 bool InExpansion = false);
   void parseNestedExpectedDiagInfoBlock(
       unsigned BufferID, StringRef MatchStartIn,
       unsigned &PrevExpectedContinuationLine,
-      std::vector<ExpectedDiagnosticInfo> &NestedDiagsOut, size_t &End);
+      std::vector<ExpectedDiagnosticInfo> &NestedDiagsOut, size_t &End,
+      bool InExpansion = false);
   void
   verifyDiagnostics(std::vector<ExpectedDiagnosticInfo> &ExpectedDiagnostics,
                     unsigned BufferID, std::optional<size_t> ParentID);

--- a/include/swift/Frontend/DiagnosticVerifier.h
+++ b/include/swift/Frontend/DiagnosticVerifier.h
@@ -19,6 +19,7 @@
 #define SWIFT_FRONTEND_DIAGNOSTIC_VERIFIER_H
 
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/Support/SourceMgr.h"
@@ -220,11 +221,37 @@ private:
   };
 
   /// Map from location marker names to their buffer and line number.
-  /// Populated by scanForMarkers() before parsing expected diagnostics.
+  /// Populated by scanForMarkers() before parsing expected diagnostics. Plain
+  /// '// #name' markers are recorded with their resolved location. Expansion-
+  /// relative '// #name@N' markers are recorded with a sentinel buffer of 0
+  /// until the enclosing expected-expansion block is parsed and
+  /// processExpansionMarkerDefinitions() binds them.
   llvm::StringMap<MarkerLocation> LocationMarkers;
 
-  /// Scan the buffer for location marker definitions (// #name).
+  /// Definition sites (pointing at the '#') of expansion-relative markers
+  /// ("// #name@N") seen inside an expected-expansion block in the buffer being
+  /// verified. These are recorded whether or not the marker bound successfully.
+  /// Used to diagnose such markers that appear outside any expansion block.
+  llvm::SmallPtrSet<const char *, 4> ExpansionMarkerLocs;
+
+  /// Scan the buffer for location marker definitions ('// #name' and
+  /// '// #name@N') and register them in LocationMarkers.
   void scanForMarkers(unsigned BufferID);
+
+  /// Handle location marker definitions found inside an expected-expansion
+  /// block whose interior text is \p BlockText. A plain "// #name" is banned;
+  /// an expansion-relative "// #name@N" is bound to line N of the expansion
+  /// buffer \p ExpansionBufferID (0 if the expansion was not produced).
+  void processExpansionMarkerDefinitions(StringRef BlockText,
+                                         unsigned ExpansionBufferID);
+
+  /// Resolve '@#marker' references in \p Diags (and their children) whose
+  /// resolution was deferred because the marker is a '// #name@N' whose
+  /// enclosing expected-expansion block is parsed later in the file than the
+  /// reference. References whose marker could not be bound (e.g. the expansion
+  /// was not produced) are dropped; undefined markers are diagnosed earlier,
+  /// during parsing.
+  void resolveDeferredMarkers(std::vector<ExpectedDiagnosticInfo> &Diags);
 
   /// Check whether any location marker is defined at the given buffer and line.
   bool hasMarkerAtLine(unsigned BufferID, unsigned Line) const;

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -256,6 +256,11 @@ struct ExpectedDiagnosticInfo {
   // This diagnostic has been matched, but contains unmatched child notes
   bool HasBeenFound = false;
 
+  // If a '@#marker' reference names a '// #name@N' marker whose enclosing
+  // expected-expansion block has not been parsed yet, its resolution is
+  // deferred until every block's markers have been bound.
+  StringRef DeferredMarkerName;
+
   ExpectedDiagnosticInfo(const char *ExpectedStart,
                          const char *ClassificationStart,
                          const char *ClassificationEnd,
@@ -785,7 +790,9 @@ bool DiagnosticVerifier::parseTargetBufferName(StringRef &MatchStart,
 
 static void forEachMarkerDefinition(
     StringRef Text,
-    llvm::function_ref<void(const char *HashLoc, StringRef Name)> Callback);
+    llvm::function_ref<void(const char *HashLoc, StringRef Name,
+                            std::optional<unsigned> ExpansionLine)>
+        Callback);
 
 void DiagnosticVerifier::parseNestedExpectedDiagInfoBlock(
     unsigned BufferID, StringRef MatchStartIn,
@@ -874,6 +881,7 @@ unsigned DiagnosticVerifier::parseExpectedDiagInfo(
   int LineOffset = 0;
   bool AbsoluteLine = false;
   bool RelativeLine = false;
+  bool IsMarkerRef = false;
 
   if (TextStartIdx > 0 && MatchStart[0] == '@') {
     if (MatchStart[1] != '#' && MatchStart[1] != '+' && MatchStart[1] != '-' && MatchStart[1] != ':' && (MatchStart[1] < '0' || MatchStart[1] > '9')) {
@@ -913,21 +921,35 @@ unsigned DiagnosticVerifier::parseExpectedDiagInfo(
       }
 
       StringRef MarkerName = MatchStart.slice(NameStart, NameEnd);
+      IsMarkerRef = true;
       auto It = LocationMarkers.find(MarkerName);
       if (It == LocationMarkers.end()) {
+        // The marker is not defined anywhere in the file -- neither a plain
+        // '// #name' nor an expansion-relative '// #name@N' (both of which are
+        // registered by scanForMarkers() before any directive is parsed). It
+        // will never resolve, so diagnose it now rather than deferring.
         addError(MatchStart.data() + 1,
                  "use of undefined location marker '#" + MarkerName + "'");
         return 0;
       }
-
-      LineOffset = It->second.Line;
-      AbsoluteLine = true;
-      // A `@#marker` names an exact location, so pin its buffer. This matters
-      // for a diagnostic inside an expansion whose child note points back into
-      // the outer file: the marker's buffer differs from the expansion buffer
-      // the parent is verified against. When the marker is in the buffer being
-      // parsed this is a no-op at verification time.
-      Expected.TargetBufferID = It->second.BufferID;
+      if (It->second.BufferID != 0) {
+        LineOffset = It->second.Line;
+        AbsoluteLine = true;
+        // A `@#marker` names an exact location, so pin its buffer. This matters
+        // for a diagnostic inside an expansion whose child note points back
+        // into the outer file: the marker's buffer differs from the expansion
+        // buffer the parent is verified against. When the marker is in the
+        // buffer being parsed this is a no-op at verification time.
+        Expected.TargetBufferID = It->second.BufferID;
+      } else {
+        // A known expansion-relative marker ('// #name@N') whose enclosing
+        // expected-expansion block has not been parsed yet -- it appears later
+        // in the file than this reference, so its buffer location is still
+        // unresolved (sentinel buffer 0). Defer resolution until every directive
+        // has been parsed; resolveDeferredMarkers() binds it afterwards.
+        Expected.DeferredMarkerName = MarkerName;
+        AbsoluteLine = true;
+      }
 
       // Extract the remainder after the marker name (e.g. ":col" or empty)
       // and let the shared column-parsing code below handle it.
@@ -957,7 +979,7 @@ unsigned DiagnosticVerifier::parseExpectedDiagInfo(
 
     size_t ColonIndex = Offs.find(':');
     // Check whether a line offset was provided (not applicable for markers).
-    if (!LineOffset && ColonIndex != 0) {
+    if (!IsMarkerRef && ColonIndex != 0) {
       StringRef LineOffs = Offs.slice(0, ColonIndex);
       if (LineOffs.getAsInteger(10, LineOffset)) {
         addError(MatchStart.data(), "expected line offset before '{{'");
@@ -1010,6 +1032,18 @@ unsigned DiagnosticVerifier::parseExpectedDiagInfo(
     MatchStart = MatchStart.substr(TextStartIdx);
   }
 
+  if (AbsoluteLine)
+    Expected.LineNo = 0;
+  else if (PrevExpectedContinuationLine)
+    Expected.LineNo = PrevExpectedContinuationLine;
+  else
+    Expected.LineNo =
+        SM.getLineAndColumnInBuffer(BufferStartLoc.getAdvancedLoc(
+                                        MatchStart.data() - InputFile.data()),
+                                    BufferID)
+            .first;
+  Expected.LineNo += LineOffset;
+
   size_t End = StringRef::npos;
   if (Expected.Classification == DiagnosticKindExpansion) {
     parseNestedExpectedDiagInfoBlock(BufferID, MatchStart,
@@ -1023,16 +1057,12 @@ unsigned DiagnosticVerifier::parseExpectedDiagInfo(
       return 0;
     }
 
-    // A location marker defined inside an expansion block would name a physical
-    // line in the outer buffer, not a location in the virtual expansion buffer
-    // the nested diagnostics are verified against. Ban this footgun.
-    forEachMarkerDefinition(
-        MatchStart.slice(2, End),
-        [&](const char *HashLoc, StringRef MarkerName) {
-          addError(HashLoc,
-                   "location marker '#" + MarkerName +
-                       "' cannot be defined inside expected-expansion");
-        });
+    SourceLoc ExpansionLoc =
+        SM.getLocForLineCol(BufferID, Expected.LineNo, *Expected.ColumnNo);
+    // The buffer this expansion expands to, if it was produced (0 otherwise).
+    unsigned ExpansionBufferID = Expansions.lookup(ExpansionLoc);
+    processExpansionMarkerDefinitions(MatchStart.slice(2, End),
+                                      ExpansionBufferID);
   } else {
     End = MatchStart.find("}}");
     if (End == StringRef::npos) {
@@ -1047,17 +1077,6 @@ unsigned DiagnosticVerifier::parseExpectedDiagInfo(
   Expected.MessageRange = MatchStart.slice(2, End);
   Expected.MessageStr =
       Lexer::getEncodedStringSegment(Expected.MessageRange, Buf).str();
-  if (AbsoluteLine)
-    Expected.LineNo = 0;
-  else if (PrevExpectedContinuationLine)
-    Expected.LineNo = PrevExpectedContinuationLine;
-  else
-    Expected.LineNo =
-        SM.getLineAndColumnInBuffer(BufferStartLoc.getAdvancedLoc(
-                                        MatchStart.data() - InputFile.data()),
-                                    BufferID)
-            .first;
-  Expected.LineNo += LineOffset;
 
   // Check if the next expected diagnostic should be in the same line.
   StringRef AfterEnd = MatchStart.substr(End + strlen("}}"));
@@ -1657,9 +1676,13 @@ DiagnosticVerifier::reportAndEraseUnexpected(
 /// underscores. Nothing else may appear in the comment after the marker name
 /// (except trailing whitespace). This prevents false positives from comments
 /// like "// #available(...)" or stack traces containing "// #10 0x...".
+///
+/// For the extended form "// #name@N" \p ExpansionLine is set to N.
 static void forEachMarkerDefinition(
     StringRef Text,
-    llvm::function_ref<void(const char *HashLoc, StringRef Name)> Callback) {
+    llvm::function_ref<void(const char *HashLoc, StringRef Name,
+                            std::optional<unsigned> ExpansionLine)>
+        Callback) {
   for (size_t Pos = Text.find("//"); Pos != StringRef::npos;
        Pos = Text.find("//", Pos + 2)) {
     size_t Cur = Pos + 2;
@@ -1680,15 +1703,33 @@ static void forEachMarkerDefinition(
     if (NameEnd == NameStart)
       continue;
 
-    // Only trailing whitespace is allowed after the marker name until EOL.
+    // An optional '@N' suffix binds the marker to line N of the expansion.
     size_t Rest = NameEnd;
+    std::optional<unsigned> ExpansionLine;
+    if (Rest < Text.size() && Text[Rest] == '@') {
+      size_t NumStart = Rest + 1;
+      size_t NumEnd = NumStart;
+      while (NumEnd < Text.size() && Text[NumEnd] >= '0' && Text[NumEnd] <= '9')
+        ++NumEnd;
+      // '@' not followed by a line number: not a marker definition.
+      if (NumEnd == NumStart)
+        continue;
+      unsigned Line;
+      if (Text.slice(NumStart, NumEnd).getAsInteger(10, Line))
+        continue;
+      ExpansionLine = Line;
+      Rest = NumEnd;
+    }
+
+    // Only trailing whitespace is allowed after the marker until EOL.
     while (Rest < Text.size() && (Text[Rest] == ' ' || Text[Rest] == '\t'))
       ++Rest;
     if (Rest < Text.size() && Text[Rest] != '\n' && Text[Rest] != '\r' &&
         Text[Rest] != '\0')
       continue;
 
-    Callback(Text.data() + HashPos, Text.slice(NameStart, NameEnd));
+    Callback(Text.data() + HashPos, Text.slice(NameStart, NameEnd),
+             ExpansionLine);
   }
 }
 
@@ -1698,7 +1739,21 @@ void DiagnosticVerifier::scanForMarkers(unsigned BufferID) {
   const SourceLoc BufferStartLoc = SM.getLocForBufferStart(BufferID);
 
   forEachMarkerDefinition(
-      InputFile, [&](const char *HashLoc, StringRef MarkerName) {
+      InputFile, [&](const char *HashLoc, StringRef MarkerName,
+                     std::optional<unsigned> ExpansionLine) {
+        // An expansion-relative marker ('// #name@N') cannot be bound to a
+        // location yet: its expansion buffer is only known once the enclosing
+        // expected-expansion block is parsed. Register the name now with a
+        // sentinel buffer of 0, to be filled in later.
+        if (ExpansionLine) {
+          auto Result = LocationMarkers.try_emplace(
+              MarkerName, MarkerLocation{/*BufferID=*/0, /*Line=*/0});
+          if (!Result.second)
+            addError(HashLoc,
+                     "location marker '#" + MarkerName + "' already defined");
+          return;
+        }
+
         unsigned Line = SM.getLineAndColumnInBuffer(
                               BufferStartLoc.getAdvancedLoc(HashLoc -
                                                             InputFile.data()),
@@ -1713,6 +1768,84 @@ void DiagnosticVerifier::scanForMarkers(unsigned BufferID) {
         }
       });
 }
+
+/// Handle location marker definitions found inside an expected-expansion block.
+void DiagnosticVerifier::processExpansionMarkerDefinitions(
+    StringRef BlockText, unsigned ExpansionBufferID) {
+  forEachMarkerDefinition(
+      BlockText, [&](const char *HashLoc, StringRef MarkerName,
+                     std::optional<unsigned> ExpansionLine) {
+        if (!ExpansionLine) {
+          // A plain '// #name' names a physical line in the outer buffer, not a
+          // location in the virtual expansion buffer the nested diagnostics are
+          // verified against. Ban this footgun; use '// #name@N' instead.
+          addError(HashLoc, "location marker '#" + MarkerName +
+                                "' inside expected-expansion must use '#" +
+                                MarkerName + "@LineNo' syntax");
+          return;
+        }
+
+        // Record the definition site so that a '#name@N' marker appearing
+        // outside any expansion block can be diagnosed. This is done regardless
+        // of whether the binding below succeeds, since being inside an
+        // expansion block is a syntactic fact independent of bind success.
+        ExpansionMarkerLocs.insert(HashLoc);
+
+        // '// #name@N' binds the marker to line N of the expansion buffer. If
+        // the expansion was not produced we cannot bind it; the separate
+        // "expected expansion not produced" error covers that case.
+        if (!ExpansionBufferID)
+          return;
+
+        if (SM.getLocForLineCol(ExpansionBufferID, *ExpansionLine, 1)
+                .isInvalid()) {
+          addError(HashLoc, "line " + Twine(*ExpansionLine) +
+                                " does not exist in the expansion buffer");
+          return;
+        }
+
+        // The name was registered by scanForMarkers() before parsing; bind it
+        // to its expansion-buffer location now that the buffer is known. A
+        // non-sentinel entry here means a duplicate definition (already
+        // diagnosed by the pre-scan), so leave the first binding in place rather
+        // than clobbering it.
+        MarkerLocation &MarkerLoc = LocationMarkers[MarkerName];
+        if (MarkerLoc.BufferID == 0)
+          MarkerLoc = {ExpansionBufferID, *ExpansionLine};
+      });
+}
+
+/// Resolve deferred '@#marker' references now that every expansion block's
+/// markers have been bound.
+void DiagnosticVerifier::resolveDeferredMarkers(
+    std::vector<ExpectedDiagnosticInfo> &Diags) {
+  for (auto It = Diags.begin(); It != Diags.end();) {
+    auto &D = *It;
+    if (!D.DeferredMarkerName.empty()) {
+      // Only markers that are known to exist are ever deferred (undefined ones
+      // are diagnosed during parsing), so the name is guaranteed to be present.
+      auto Marker = LocationMarkers.find(D.DeferredMarkerName);
+      ASSERT(Marker != LocationMarkers.end() &&
+             "deferred reference to an unknown marker");
+      if (Marker->second.BufferID == 0) {
+        // The '// #name@N' definition could not be bound -- e.g. its expansion
+        // was not produced, its line does not exist, or it appeared outside any
+        // expansion. Each of those is diagnosed at the definition site, so just
+        // drop this dependent expected diagnostic instead of adding a confusing
+        // "undefined marker" error or a spurious "not produced" error.
+        It = Diags.erase(It);
+        continue;
+      }
+      D.LineNo = Marker->second.Line;
+      D.TargetBufferID = Marker->second.BufferID;
+      D.DeferredMarkerName = StringRef();
+    }
+    resolveDeferredMarkers(D.ExpectedChildNotes);
+    resolveDeferredMarkers(D.NestedDiags);
+    ++It;
+  }
+}
+
 
 bool DiagnosticVerifier::hasMarkerAtLine(unsigned BufferID,
                                          unsigned Line) const {
@@ -1748,6 +1881,7 @@ bool DiagnosticVerifier::verifyDeferredMarkerDiagnostics() {
 /// ones.
 DiagnosticVerifier::Result DiagnosticVerifier::verifyFile(unsigned BufferID) {
   Errors.clear();
+  ExpansionMarkerLocs.clear();
   using llvm::SMLoc;
 
   StringRef InputFile = SM.getEntireTextForBuffer(BufferID);
@@ -1782,6 +1916,19 @@ DiagnosticVerifier::Result DiagnosticVerifier::verifyFile(unsigned BufferID) {
       ExpectedDiagnostics.push_back(Expected);
     PrevMatchEnd = Expected.ExpectedEnd;
   }
+
+  resolveDeferredMarkers(ExpectedDiagnostics);
+  forEachMarkerDefinition(
+      InputFile, [&](const char *HashLoc, StringRef MarkerName,
+                     std::optional<unsigned> ExpansionLine) {
+        if (!ExpansionLine)
+          return;
+        if (ExpansionMarkerLocs.count(HashLoc))
+          return;
+        addError(HashLoc, "location marker '#" + MarkerName + "@" +
+                              Twine(*ExpansionLine) +
+                              "' is only allowed inside expected-expansion");
+      });
 
   verifyDiagnostics(ExpectedDiagnostics, BufferID,
                     /*ParentDiagnostic=*/std::nullopt);

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -783,10 +783,15 @@ bool DiagnosticVerifier::parseTargetBufferName(StringRef &MatchStart,
   return true;
 }
 
+static void forEachMarkerDefinition(
+    StringRef Text,
+    llvm::function_ref<void(const char *HashLoc, StringRef Name)> Callback);
+
 void DiagnosticVerifier::parseNestedExpectedDiagInfoBlock(
     unsigned BufferID, StringRef MatchStartIn,
     unsigned &PrevExpectedContinuationLine,
-    std::vector<ExpectedDiagnosticInfo> &NestedDiagsOut, size_t &End) {
+    std::vector<ExpectedDiagnosticInfo> &NestedDiagsOut, size_t &End,
+    bool InExpansion) {
   size_t NestedMatch = MatchStartIn.find("expected-");
   if (NestedMatch == StringRef::npos) {
     End = MatchStartIn.find("}}");
@@ -799,7 +804,8 @@ void DiagnosticVerifier::parseNestedExpectedDiagInfoBlock(
                                           DiagnosticKind(-1));
     unsigned NestedCount =
         parseExpectedDiagInfo(BufferID, NestedMatchStartIn,
-                              PrevExpectedContinuationLine, NestedExpected);
+                              PrevExpectedContinuationLine, NestedExpected,
+                              InExpansion);
 
     size_t PrevMatchEnd = NestedMatch + 1;
     if (NestedCount > 0) {
@@ -828,7 +834,7 @@ void DiagnosticVerifier::parseNestedExpectedDiagInfoBlock(
 unsigned DiagnosticVerifier::parseExpectedDiagInfo(
     unsigned BufferID, StringRef MatchStartIn,
     unsigned &PrevExpectedContinuationLine,
-    ExpectedDiagnosticInfo &Expected) {
+    ExpectedDiagnosticInfo &Expected, bool InExpansion) {
   const SourceLoc BufferStartLoc = SM.getLocForBufferStart(BufferID);
   StringRef InputFile = SM.getEntireTextForBuffer(BufferID);
 
@@ -867,6 +873,7 @@ unsigned DiagnosticVerifier::parseExpectedDiagInfo(
                                   *ExpectedClassification);
   int LineOffset = 0;
   bool AbsoluteLine = false;
+  bool RelativeLine = false;
 
   if (TextStartIdx > 0 && MatchStart[0] == '@') {
     if (MatchStart[1] != '#' && MatchStart[1] != '+' && MatchStart[1] != '-' && MatchStart[1] != ':' && (MatchStart[1] < '0' || MatchStart[1] > '9')) {
@@ -915,19 +922,27 @@ unsigned DiagnosticVerifier::parseExpectedDiagInfo(
 
       LineOffset = It->second.Line;
       AbsoluteLine = true;
-      if (It->second.BufferID != BufferID)
-        Expected.TargetBufferID = It->second.BufferID;
+      // A `@#marker` names an exact location, so pin its buffer. This matters
+      // for a diagnostic inside an expansion whose child note points back into
+      // the outer file: the marker's buffer differs from the expansion buffer
+      // the parent is verified against. When the marker is in the buffer being
+      // parsed this is a no-op at verification time.
+      Expected.TargetBufferID = It->second.BufferID;
 
       // Extract the remainder after the marker name (e.g. ":col" or empty)
       // and let the shared column-parsing code below handle it.
       Offs = MatchStart.slice(NameEnd, TextStartIdx).rtrim();
     } else if (MatchStart[1] == '+') {
+      RelativeLine = true;
       Offs = MatchStart.slice(2, TextStartIdx).rtrim();
     } else {
       Offs = MatchStart.slice(1, TextStartIdx).rtrim();
       if (Offs[0] >= '0' && Offs[0] <= '9')
         AbsoluteLine = true;
+      else if (Offs[0] == '-')
+        RelativeLine = true;
     }
+    ASSERT(!RelativeLine || !AbsoluteLine);
 
     size_t SpaceIndex = Offs.find(' ');
     if (SpaceIndex != StringRef::npos && SpaceIndex < TextStartIdx) {
@@ -962,6 +977,13 @@ unsigned DiagnosticVerifier::parseExpectedDiagInfo(
     }
   }
 
+  if (InExpansion && RelativeLine) {
+    addError(DiagnosticLoc,
+             "relative line offsets are not allowed inside expected-expansion; "
+             "use an absolute line number or a '@#marker' reference");
+    return 0;
+  }
+
   if (Expected.Classification == DiagnosticKindExpansion && !Expected.ColumnNo.has_value()) {
     addError(DiagnosticLoc, "expected-expansion requires column location");
     return 0;
@@ -992,13 +1014,25 @@ unsigned DiagnosticVerifier::parseExpectedDiagInfo(
   if (Expected.Classification == DiagnosticKindExpansion) {
     parseNestedExpectedDiagInfoBlock(BufferID, MatchStart,
                                      PrevExpectedContinuationLine,
-                                     Expected.NestedDiags, End);
+                                     Expected.NestedDiags, End,
+                                     /*InExpansion=*/true);
 
     if (End == StringRef::npos) {
       addError(DiagnosticLoc,
                "didn't find '}}' to match '{{' in expected-expansion");
       return 0;
     }
+
+    // A location marker defined inside an expansion block would name a physical
+    // line in the outer buffer, not a location in the virtual expansion buffer
+    // the nested diagnostics are verified against. Ban this footgun.
+    forEachMarkerDefinition(
+        MatchStart.slice(2, End),
+        [&](const char *HashLoc, StringRef MarkerName) {
+          addError(HashLoc,
+                   "location marker '#" + MarkerName +
+                       "' cannot be defined inside expected-expansion");
+        });
   } else {
     End = MatchStart.find("}}");
     if (End == StringRef::npos) {
@@ -1184,7 +1218,8 @@ unsigned DiagnosticVerifier::parseExpectedDiagInfo(
     Expected.ChildrenMarkerStartLoc = ExtraChecks.data();
     ExtraChecks = ExtraChecks.substr(StringRef("{{children:").size());
     parseNestedExpectedDiagInfoBlock(
-        BufferID, ExtraChecks, PrevExpectedContinuationLine, Expected.ExpectedChildNotes, End);
+        BufferID, ExtraChecks, PrevExpectedContinuationLine,
+        Expected.ExpectedChildNotes, End, InExpansion);
 
     if (End == StringRef::npos) {
       addError(Expected.ChildrenMarkerStartLoc,
@@ -1613,34 +1648,33 @@ DiagnosticVerifier::reportAndEraseUnexpected(
   return CapturedDiagnostics.erase(DiagIter);
 }
 
-/// Scan the buffer for location marker definitions of the form "// #name".
-/// A marker definition is a comment whose only content is "#name", e.g.:
+/// Invoke \p Callback for each location marker definition of the form "// #name"
+/// found in \p Text. \p HashLoc points at the '#' and \p Name is the marker
+/// name. A marker definition is a comment whose only content is "#name", e.g.:
 ///   code // #marker1
 ///   // #marker2
 /// The marker name consists of alphanumeric characters, hyphens, or
 /// underscores. Nothing else may appear in the comment after the marker name
 /// (except trailing whitespace). This prevents false positives from comments
 /// like "// #available(...)" or stack traces containing "// #10 0x...".
-void DiagnosticVerifier::scanForMarkers(unsigned BufferID) {
-  StringRef InputFile = SM.getEntireTextForBuffer(BufferID);
-  const SourceLoc BufferStartLoc = SM.getLocForBufferStart(BufferID);
-
-  for (size_t Pos = InputFile.find("//"); Pos != StringRef::npos;
-       Pos = InputFile.find("//", Pos + 2)) {
+static void forEachMarkerDefinition(
+    StringRef Text,
+    llvm::function_ref<void(const char *HashLoc, StringRef Name)> Callback) {
+  for (size_t Pos = Text.find("//"); Pos != StringRef::npos;
+       Pos = Text.find("//", Pos + 2)) {
     size_t Cur = Pos + 2;
-    while (Cur < InputFile.size() && (InputFile[Cur] == ' ' ||
-                                       InputFile[Cur] == '\t'))
+    while (Cur < Text.size() && (Text[Cur] == ' ' || Text[Cur] == '\t'))
       ++Cur;
 
-    if (Cur >= InputFile.size() || InputFile[Cur] != '#')
+    if (Cur >= Text.size() || Text[Cur] != '#')
       continue;
 
     size_t HashPos = Cur;
     size_t NameStart = HashPos + 1;
     size_t NameEnd = NameStart;
-    while (NameEnd < InputFile.size() &&
-           (isalnum(InputFile[NameEnd]) || InputFile[NameEnd] == '_' ||
-            InputFile[NameEnd] == '-'))
+    while (NameEnd < Text.size() &&
+           (isalnum(Text[NameEnd]) || Text[NameEnd] == '_' ||
+            Text[NameEnd] == '-'))
       ++NameEnd;
 
     if (NameEnd == NameStart)
@@ -1648,26 +1682,36 @@ void DiagnosticVerifier::scanForMarkers(unsigned BufferID) {
 
     // Only trailing whitespace is allowed after the marker name until EOL.
     size_t Rest = NameEnd;
-    while (Rest < InputFile.size() && (InputFile[Rest] == ' ' ||
-                                        InputFile[Rest] == '\t'))
+    while (Rest < Text.size() && (Text[Rest] == ' ' || Text[Rest] == '\t'))
       ++Rest;
-    if (Rest < InputFile.size() && InputFile[Rest] != '\n' &&
-        InputFile[Rest] != '\r' && InputFile[Rest] != '\0')
+    if (Rest < Text.size() && Text[Rest] != '\n' && Text[Rest] != '\r' &&
+        Text[Rest] != '\0')
       continue;
 
-    StringRef MarkerName = InputFile.slice(NameStart, NameEnd);
-    unsigned Line =
-        SM.getLineAndColumnInBuffer(
-              BufferStartLoc.getAdvancedLoc(HashPos), BufferID)
-            .first;
-
-    auto Result =
-        LocationMarkers.try_emplace(MarkerName, MarkerLocation{BufferID, Line});
-    if (!Result.second) {
-      addError(InputFile.data() + HashPos,
-               "location marker '#" + MarkerName + "' already defined");
-    }
+    Callback(Text.data() + HashPos, Text.slice(NameStart, NameEnd));
   }
+}
+
+/// Scan the buffer for location marker definitions and register them.
+void DiagnosticVerifier::scanForMarkers(unsigned BufferID) {
+  StringRef InputFile = SM.getEntireTextForBuffer(BufferID);
+  const SourceLoc BufferStartLoc = SM.getLocForBufferStart(BufferID);
+
+  forEachMarkerDefinition(
+      InputFile, [&](const char *HashLoc, StringRef MarkerName) {
+        unsigned Line = SM.getLineAndColumnInBuffer(
+                              BufferStartLoc.getAdvancedLoc(HashLoc -
+                                                            InputFile.data()),
+                              BufferID)
+                            .first;
+
+        auto Result = LocationMarkers.try_emplace(
+            MarkerName, MarkerLocation{BufferID, Line});
+        if (!Result.second) {
+          addError(HashLoc,
+                   "location marker '#" + MarkerName + "' already defined");
+        }
+      });
 }
 
 bool DiagnosticVerifier::hasMarkerAtLine(unsigned BufferID,

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -345,7 +345,7 @@ findDiagnostic(std::vector<CapturedDiagnosticInfo> &CapturedDiagnostics,
       continue;
 
     // Verify the parent.
-    if (ParentID && I->ParentID != ParentID) {
+    if (I->ParentID != ParentID) {
       continue;
     }
 
@@ -2100,6 +2100,7 @@ static void createDiagnosticInfo(const DiagnosticInfo &Info,
                                  SourceManager &DiagSM,
                                  SourceManager &VerifierSM,
                                  bool VerifyChildNotes,
+                                 bool IgnoreMacroLocationNote,
                                  std::optional<size_t> ParentID,
                                  std::vector<CapturedDiagnosticInfo> &Out) {
   ASSERT(!Info.IsChildNote ||
@@ -2121,18 +2122,26 @@ static void createDiagnosticInfo(const DiagnosticInfo &Info,
   for (const auto &category : Info.CategoryChain)
     groupNames.emplace_back(category.Name.str());
 
+  SmallVector<const DiagnosticInfo *, 8> ChildNotes;
+  if (VerifyChildNotes) {
+    for (auto &ChildInfo : Info.ChildDiagnosticInfo) {
+      if (IgnoreMacroLocationNote &&
+          ChildInfo->ID == diag::in_macro_expansion.ID)
+        continue;
+      ChildNotes.push_back(ChildInfo);
+    }
+  }
+
   DiagLoc loc(DiagSM, VerifierSM, Info.Loc);
   const size_t Idx = Out.size();
   Out.emplace_back(
       message, loc.bufferID, Info.Kind, loc.sourceLoc, loc.line, loc.column,
       fixIts, llvm::sys::path::stem(Info.getCategoryDocumentationURL()).str(),
-      std::move(groupNames), Idx, ParentID,
-      VerifyChildNotes && !Info.ChildDiagnosticInfo.empty());
+      std::move(groupNames), Idx, ParentID, !ChildNotes.empty());
 
-  if (VerifyChildNotes) {
-    for (const DiagnosticInfo *ChildInfo : Info.ChildDiagnosticInfo)
-      createDiagnosticInfo(*ChildInfo, DiagSM, VerifierSM, VerifyChildNotes,
-                           Idx, Out);
+  for (const DiagnosticInfo *ChildInfo : ChildNotes) {
+    createDiagnosticInfo(*ChildInfo, DiagSM, VerifierSM, VerifyChildNotes,
+                         IgnoreMacroLocationNote, Idx, Out);
   }
 }
 
@@ -2155,7 +2164,8 @@ void DiagnosticVerifier::handleDiagnostic(SourceManager &SM,
     // Already added with parent diagnostic
     return;
 
-  createDiagnosticInfo(Info, SM, this->SM, VerifyChildNotes, std::nullopt,
+  createDiagnosticInfo(Info, SM, this->SM, VerifyChildNotes,
+                       IgnoreMacroLocationNote, std::nullopt,
                        CapturedDiagnostics);
 }
 

--- a/test/Frontend/DiagnosticVerifier/expansion-marker-inside-unproduced.swift
+++ b/test/Frontend/DiagnosticVerifier/expansion-marker-inside-unproduced.swift
@@ -1,0 +1,12 @@
+// A '// #name@N' marker defined inside an expansion block lives inside that
+// block regardless of whether the expansion is actually produced, so it
+// shouldn't be reported as misplaced.
+
+// RUN: not %target-typecheck-verify-swift 2>&1 | %FileCheck %s --implicit-check-not "only allowed inside"
+
+// CHECK: :[[@LINE+1]]:4: error: expected expansion not produced
+// expected-expansion@+3:14{{
+//   expected-error@1{{oops}}
+//   #inBlock@2
+// }}
+func inBlockUnproduced() {}

--- a/test/Frontend/DiagnosticVerifier/expansion-relative-line.swift
+++ b/test/Frontend/DiagnosticVerifier/expansion-relative-line.swift
@@ -1,0 +1,74 @@
+// Relative line offsets (`@+N` / `@-N`) are rejected on diagnostics and child
+// notes nested inside an expansion block: a nested line is an absolute line
+// within the virtual expansion buffer. Relative locations in the virtual buffer
+// would refer to the outer buffer instead. This is more confusing to read than
+// it should be, so we ban this footgun. Instead a location outside the
+// expansion can be referred to using the `@#marker` syntax.
+//
+// For the same reason a location marker may not be *defined* inside an
+// expansion block (a `// #name` there would name a physical line in the outer
+// buffer, not a location in the virtual buffer).
+//
+// No macro is actually loaded, so the expansions themselves are reported as "not
+// produced"; that noise is irrelevant to what is under test here.
+
+// RUN: not %target-typecheck-verify-swift -verify-child-notes 2>&1 | %FileCheck %s --implicit-check-not "relative line offsets" --implicit-check-not "cannot be defined inside"
+
+func anchor() {} // #site
+
+// CHECK: :[[@LINE+2]]:{{[0-9]+}}: error: relative line offsets are not allowed inside {{expect}}ed-expansion
+// expected-expansion@+3:14{{
+//   expected-error@+1{{cannot use relative location using +}}
+// }}
+func usePlus() {}
+
+// CHECK: :[[@LINE+2]]:{{[0-9]+}}: error: relative line offsets are not allowed inside
+// expected-expansion@+3:14{{
+//   expected-error@-1{{cannot use relative location using -}}
+// }}
+func useMinus() {}
+
+// CHECK: :[[@LINE+2]]:{{[0-9]+}}: error: relative line offsets are not allowed inside
+// expected-expansion@+3:14{{
+//   expected-error@+0{{+0 is still relative}}
+// }}
+func usePlusZero() {}
+
+// CHECK: :[[@LINE+2]]:{{[0-9]+}}: error: relative line offsets are not allowed inside
+// expected-expansion@+3:14{{
+//   expected-error@-0{{-0 is still relative}}
+// }}
+func useMinusZero() {}
+
+// CHECK: :[[@LINE+3]]:{{[0-9]+}}: error: relative line offsets are not allowed inside
+// expected-expansion@+5:14{{
+//   expected-error@2{{oops}} {{children:
+//     expected-note@-1{{a child note nested inside an expansion may not use a relative offset either}}
+//   }}
+// }}
+func childRelative() {}
+
+// expected-expansion@+5:14{{
+//   expected-error@2{{oops}} {{children:
+//     expected-note@#site{{child}}
+//   }}
+// }}
+func accepted() {}
+
+// expected-error@+3{{oops}} {{children:
+//   expected-note@+2{{this does not count as nested since it doesn't have a separate buffer}}
+// }}
+func accepted2() {}
+
+// CHECK: :[[@LINE+2]]:{{[0-9]+}}: error: location marker '#trailingMarker' cannot be defined inside
+// expected-expansion@+3:14{{
+//   expected-error@1{{oops}} // #trailingMarker
+// }}
+func markerTrailing() {}
+
+// CHECK: :[[@LINE+3]]:{{[0-9]+}}: error: location marker '#ownLineMarker' cannot be defined inside
+// expected-expansion@+4:14{{
+//   expected-error@1{{oops}}
+//   // #ownLineMarker
+// }}
+func markerOwnLine() {}

--- a/test/Frontend/DiagnosticVerifier/expansion-relative-line.swift
+++ b/test/Frontend/DiagnosticVerifier/expansion-relative-line.swift
@@ -12,35 +12,39 @@
 // No macro is actually loaded, so the expansions themselves are reported as "not
 // produced"; that noise is irrelevant to what is under test here.
 
-// RUN: not %target-typecheck-verify-swift -verify-child-notes 2>&1 | %FileCheck %s --implicit-check-not "relative line offsets" --implicit-check-not "cannot be defined inside"
+// RUN: not %target-typecheck-verify-swift -verify-child-notes 2>&1 | %FileCheck %s --implicit-check-not "relative line offsets" --implicit-check-not "cannot be defined inside" --sanitize TEST=%s --match-full-lines
+// Duplicate-marker definitions are diagnosed by the pre-scan and printed before
+// the per-file diagnostics, so they are checked with a separate prefix whose
+// matches are independent of the ordering above.
+// RUN: not %target-typecheck-verify-swift -verify-child-notes 2>&1 | %FileCheck %s --check-prefix=CHECK-DUP --sanitize TEST=%s --match-full-lines
 
 func anchor() {} // #site
 
-// CHECK: :[[@LINE+2]]:{{[0-9]+}}: error: relative line offsets are not allowed inside {{expect}}ed-expansion
+// CHECK: TEST:[[@LINE+2]]:{{[0-9]+}}: error: relative line offsets are not allowed inside [[EXP:expected.expansion]]; use an absolute line number or a '@#marker' reference
 // expected-expansion@+3:14{{
 //   expected-error@+1{{cannot use relative location using +}}
 // }}
 func usePlus() {}
 
-// CHECK: :[[@LINE+2]]:{{[0-9]+}}: error: relative line offsets are not allowed inside
+// CHECK: TEST:[[@LINE+2]]:{{[0-9]+}}: error: relative line offsets are not allowed inside [[EXP]]; use an absolute line number or a '@#marker' reference
 // expected-expansion@+3:14{{
 //   expected-error@-1{{cannot use relative location using -}}
 // }}
 func useMinus() {}
 
-// CHECK: :[[@LINE+2]]:{{[0-9]+}}: error: relative line offsets are not allowed inside
+// CHECK: TEST:[[@LINE+2]]:{{[0-9]+}}: error: relative line offsets are not allowed inside [[EXP]]; use an absolute line number or a '@#marker' reference
 // expected-expansion@+3:14{{
 //   expected-error@+0{{+0 is still relative}}
 // }}
 func usePlusZero() {}
 
-// CHECK: :[[@LINE+2]]:{{[0-9]+}}: error: relative line offsets are not allowed inside
+// CHECK: TEST:[[@LINE+2]]:{{[0-9]+}}: error: relative line offsets are not allowed inside [[EXP]]; use an absolute line number or a '@#marker' reference
 // expected-expansion@+3:14{{
 //   expected-error@-0{{-0 is still relative}}
 // }}
 func useMinusZero() {}
 
-// CHECK: :[[@LINE+3]]:{{[0-9]+}}: error: relative line offsets are not allowed inside
+// CHECK: TEST:[[@LINE+3]]:{{[0-9]+}}: error: relative line offsets are not allowed inside [[EXP]]; use an absolute line number or a '@#marker' reference
 // expected-expansion@+5:14{{
 //   expected-error@2{{oops}} {{children:
 //     expected-note@-1{{a child note nested inside an expansion may not use a relative offset either}}
@@ -60,15 +64,42 @@ func accepted() {}
 // }}
 func accepted2() {}
 
-// CHECK: :[[@LINE+2]]:{{[0-9]+}}: error: location marker '#trailingMarker' cannot be defined inside
+// CHECK: TEST:[[@LINE+2]]:{{[0-9]+}}: error: location marker '#trailingMarker' inside [[EXP]] must use '#trailingMarker@LineNo' syntax
 // expected-expansion@+3:14{{
 //   expected-error@1{{oops}} // #trailingMarker
 // }}
 func markerTrailing() {}
 
-// CHECK: :[[@LINE+3]]:{{[0-9]+}}: error: location marker '#ownLineMarker' cannot be defined inside
+// CHECK: TEST:[[@LINE+3]]:{{[0-9]+}}: error: location marker '#ownLineMarker' inside [[EXP]] must use '#ownLineMarker@LineNo' syntax
 // expected-expansion@+4:14{{
 //   expected-error@1{{oops}}
 //   // #ownLineMarker
 // }}
 func markerOwnLine() {}
+
+// CHECK: TEST:[[@LINE+1]]:{{[0-9]+}}: error: location marker '#outsideMarker@3' is only allowed inside [[EXP]]
+// #outsideMarker@3
+func markerOutside() {}
+
+// CHECK: TEST:[[@LINE+2]]:{{[0-9]+}}: error: use of undefined location marker '#nope'
+// expected-expansion@+3:14{{
+//   expected-error@#nope{{oops}}
+// }}
+func undefinedMarkerRef() {}
+
+func dupAnchor() {} // #dupPlain
+// CHECK-DUP: TEST:[[@LINE+3]]:{{[0-9]+}}: error: location marker '#dupPlain' already defined
+// expected-expansion@+3:14{{
+//   expected-error@1{{oops}}
+//   #dupPlain@2
+// }}
+func dupPlainInside() {}
+
+// CHECK: TEST:[[@LINE+1]]:{{[0-9]+}}: error: location marker '#dupExp@3' is only allowed inside [[EXP]]
+// #dupExp@3
+// CHECK-DUP: TEST:[[@LINE+3]]:{{[0-9]+}}: error: location marker '#dupExp' already defined
+// expected-expansion@+3:14{{
+//   expected-error@1{{oops}}
+//   #dupExp@2
+// }}
+func dupExpInside() {}

--- a/test/Frontend/DiagnosticVerifier/expansion-remarks.swift
+++ b/test/Frontend/DiagnosticVerifier/expansion-remarks.swift
@@ -10,6 +10,9 @@
 
 // RUN: %target-swift-frontend-verify -swift-version 5 -verify-child-notes -typo-correction-limit 10 -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/cross-buffer-location-positive.swift
 // RUN: not %target-swift-frontend-verify -swift-version 5 -verify-child-notes -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/cross-buffer-location-negative.swift 2>&1 | %FileCheck %t/cross-buffer-location-negative.swift --implicit-check-not error: --implicit-check-not warning:
+// RUN: not %target-swift-frontend-verify -swift-version 5 -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/cross-buffer-location-badline.swift 2>&1 | %FileCheck --check-prefix=CHECK-BADLINE %t/cross-buffer-location-badline.swift
+// RUN: not %target-swift-frontend-verify -swift-version 5 -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/cross-buffer-location-wrongline.swift 2>&1 | %FileCheck --check-prefix=CHECK-WRONGLINE %t/cross-buffer-location-wrongline.swift
+// RUN: not %target-swift-frontend-verify -swift-version 5 -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/cross-buffer-location-dup.swift 2>&1 | %FileCheck --check-prefix=CHECK-DUP %t/cross-buffer-location-dup.swift
 
 //--- main.swift
 @attached(peer, names: overloaded)
@@ -66,12 +69,15 @@ func foo() {}
 //   expected-note@1 2{{'x' declared here}} {{children:
 //     expected-note@#here{{in expansion of macro 'unstringifyPeer' on global function 'foo()' here}}
 //   }}
-//   expected-error@2{{cannot find 'a' in scope; did you mean 'x'?}} {{children:
+//   #aLine@2
+//   expected-error@#bLine{{cannot find 'b' in scope; did you mean 'x'?}} {{children:
 //     expected-note@#here{{in expansion of macro 'unstringifyPeer' on global function 'foo()' here}}
 //   }}
-//   expected-error@3{{cannot find 'b' in scope; did you mean 'x'?}} {{children:
-//     expected-note@#here{{in expansion of macro 'unstringifyPeer' on global function 'foo()' here}}
-//   }}
+//   #bLine@3
+// }}
+// Refer to location inside expansion from outside of it:
+// expected-error@#aLine{{cannot find 'a' in scope; did you mean 'x'?}} {{children:
+//   expected-note@#here{{in expansion of macro 'unstringifyPeer' on global function 'foo()' here}}
 // }}
 
 //--- cross-buffer-location-negative.swift
@@ -84,10 +90,58 @@ macro unstringifyPeer(_ s: String) =
 // CHECK: :[[@LINE+1]]:1: error: unexpected child note produced: in expansion of macro 'unstringifyPeer' on global function 'foo()' here
 @unstringifyPeer("func foo(_ y: Int) {\nqqq()\n}") // #here2
 func foo() {}
-// expected-expansion@-1:14{{
+// expected-error@#asdf {{missing error}}
+// expected-expansion@-2:14{{
 //   CHECK: :[[@LINE+1]]:6: note: for parent matched here
 //   expected-error@2{{cannot find 'qqq' in scope}} {{children:
+//     CHECK: :[[@LINE-4]]:4: error: expected error not produced
 //     CHECK: :[[@LINE+1]]:8: error: expected note not produced
 //     expected-note@#here2{{WRONG MESSAGE}}
 //   }}
+//   #asdf@2
+// }}
+
+//--- cross-buffer-location-badline.swift
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+// The expansion buffer only spans four lines, so '@99' names a line that does
+// not exist.
+@unstringifyPeer("func foo(_ x: Int) {\na = 2\nb = x\n}")
+func foo() {}
+// expected-expansion@-1:14{{
+//   CHECK-BADLINE: :[[@LINE+1]]:{{[0-9]+}}: error: line 99 does not exist in the expansion buffer
+//   #bad@99
+//   expected-error@2{{cannot find 'a' in scope}}
+//   expected-error@3{{cannot find 'b' in scope}}
+// }}
+
+//--- cross-buffer-location-wrongline.swift
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+@unstringifyPeer("func foo(_ x: Int) {\na = 2\nb = x\n}")
+func foo() {}
+// expected-expansion@-1:14{{
+//   #wrong@3
+//   expected-error@2{{cannot find 'a' in scope}}
+//   expected-error@3{{cannot find 'b' in scope}}
+// }}
+// CHECK-WRONGLINE: :[[@LINE+1]]:4: error: expected error not produced
+// expected-error@#wrong{{cannot find 'a' in scope; did you mean 'x'?}}
+
+//--- cross-buffer-location-dup.swift
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+@unstringifyPeer("func foo(_ x: Int) {\na = 2\nb = x\n}") // #dup
+func foo() {}
+// expected-expansion@-1:14{{
+//   CHECK-DUP: :[[@LINE+1]]:{{[0-9]+}}: error: location marker '#dup' already defined
+//   #dup@2
+//   expected-error@2{{cannot find 'a' in scope}}
+//   expected-error@3{{cannot find 'b' in scope}}
 // }}

--- a/test/Frontend/DiagnosticVerifier/expansion-remarks.swift
+++ b/test/Frontend/DiagnosticVerifier/expansion-remarks.swift
@@ -14,6 +14,10 @@
 // RUN: not %target-swift-frontend-verify -swift-version 5 -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/cross-buffer-location-wrongline.swift 2>&1 | %FileCheck --check-prefix=CHECK-WRONGLINE %t/cross-buffer-location-wrongline.swift
 // RUN: not %target-swift-frontend-verify -swift-version 5 -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/cross-buffer-location-dup.swift 2>&1 | %FileCheck --check-prefix=CHECK-DUP %t/cross-buffer-location-dup.swift
 
+// RUN: %target-swift-frontend-verify -swift-version 5 -verify-ignore-macro-note -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/ignore-macro-note.swift
+// RUN: %target-swift-frontend-verify -swift-version 5 -verify-ignore-macro-note -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/ignore-macro-note.swift -verify-child-notes
+// RUN: not %target-swift-frontend-verify -swift-version 5 -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/ignore-macro-note.swift 2>&1 | %FileCheck --check-prefix=DISABLED %t/ignore-macro-note.swift
+
 //--- main.swift
 @attached(peer, names: overloaded)
 macro unstringifyPeer(_ s: String) =
@@ -144,4 +148,16 @@ func foo() {}
 //   #dup@2
 //   expected-error@2{{cannot find 'a' in scope}}
 //   expected-error@3{{cannot find 'b' in scope}}
+// }}
+
+//--- ignore-macro-note.swift
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+// DISABLED: ignore-macro-note.swift:[[@LINE+1]]:1: error: unexpected note produced: in expansion of macro 'unstringifyPeer' on global function 'foo()' here
+@unstringifyPeer("func foo(_ x: Int) {\nlet a = 2\n}")
+func foo() {}
+// expected-expansion@-1:14{{
+//   expected-warning@2{{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}}
 // }}

--- a/test/Frontend/DiagnosticVerifier/expansion-remarks.swift
+++ b/test/Frontend/DiagnosticVerifier/expansion-remarks.swift
@@ -8,6 +8,9 @@
 // RUN: %target-swift-frontend-verify -swift-version 5 -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -Rmacro-expansions -typecheck %t/main.swift
 // RUN: not %target-swift-frontend-verify -swift-version 5 -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -Rmacro-expansions -typecheck %t/empty-no-expansion.swift 2>&1 | %FileCheck --check-prefix=CHECK-MISSING %t/empty-no-expansion.swift
 
+// RUN: %target-swift-frontend-verify -swift-version 5 -verify-child-notes -typo-correction-limit 10 -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/cross-buffer-location-positive.swift
+// RUN: not %target-swift-frontend-verify -swift-version 5 -verify-child-notes -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/cross-buffer-location-negative.swift 2>&1 | %FileCheck %t/cross-buffer-location-negative.swift --implicit-check-not error: --implicit-check-not warning:
+
 //--- main.swift
 @attached(peer, names: overloaded)
 macro unstringifyPeer(_ s: String) =
@@ -48,3 +51,43 @@ func bar() {
 // expected-expansion@+2:14{{
 // }}
 func qux() {}
+
+//--- cross-buffer-location-positive.swift
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+@unstringifyPeer("func foo(_ x: Int) {\na = 2\nb = x\n}") // #here
+func foo() {}
+// Every diagnostic emitted inside the expansion carries the same "in expansion
+// of macro" child note, whose location is the '@unstringifyPeer' attribute in
+// this (outer) file.
+// expected-expansion@-4:14{{
+//   expected-note@1 2{{'x' declared here}} {{children:
+//     expected-note@#here{{in expansion of macro 'unstringifyPeer' on global function 'foo()' here}}
+//   }}
+//   expected-error@2{{cannot find 'a' in scope; did you mean 'x'?}} {{children:
+//     expected-note@#here{{in expansion of macro 'unstringifyPeer' on global function 'foo()' here}}
+//   }}
+//   expected-error@3{{cannot find 'b' in scope; did you mean 'x'?}} {{children:
+//     expected-note@#here{{in expansion of macro 'unstringifyPeer' on global function 'foo()' here}}
+//   }}
+// }}
+
+//--- cross-buffer-location-negative.swift
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+// The child note message is wrong, so the real child note is reported as
+// unexpected and the expected child note is not produced.
+// CHECK: :[[@LINE+1]]:1: error: unexpected child note produced: in expansion of macro 'unstringifyPeer' on global function 'foo()' here
+@unstringifyPeer("func foo(_ y: Int) {\nqqq()\n}") // #here2
+func foo() {}
+// expected-expansion@-1:14{{
+//   CHECK: :[[@LINE+1]]:6: note: for parent matched here
+//   expected-error@2{{cannot find 'qqq' in scope}} {{children:
+//     CHECK: :[[@LINE+1]]:8: error: expected note not produced
+//     expected-note@#here2{{WRONG MESSAGE}}
+//   }}
+// }}

--- a/test/Frontend/DiagnosticVerifier/verify-child-notes-negative.swift
+++ b/test/Frontend/DiagnosticVerifier/verify-child-notes-negative.swift
@@ -19,6 +19,16 @@ struct NoParent {}
 // CHECK: [[@LINE-1]]:{{[0-9]+}}: error: unexpected error produced: invalid redeclaration of 'NoParent'
 // CHECK: [[@LINE-3]]:{{[0-9]+}}: note: with child note: 'NoParent' previously declared here
 
+// A top-level note directive outside a children block must not match a child
+// note; the child note is left unmatched (reported against its parent) while
+// the outer directive is reported as missing.
+struct TopLevelNote {}
+// expected-note@-1 {{'TopLevelNote' previously declared here}}
+struct TopLevelNote {} // expected-error {{invalid redeclaration of 'TopLevelNote'}}
+// CHECK: [[@LINE-3]]:{{[0-9]+}}: error: unexpected child note produced: 'TopLevelNote' previously declared here
+// CHECK: [[@LINE-2]]:{{[0-9]+}}: note: for parent matched here
+// CHECK: [[@LINE-4]]:{{[0-9]+}}: error: expected note not produced
+
 enum WithNone { case none }
 
 func testAmbiguous1(_ x: WithNone?) {


### PR DESCRIPTION
This fixes a couple of bugs in -verify-child-notes, and adds a version of `#marker` for use in expansion directives: `#marker@N`. This is important for -verify-child-notes since child notes can be in different buffers than their parent diagnostic, but with -verify-child-notes the directive ends up having to be in the same location as the parent directive. This syntax allows referring to the location of a child note inside a macro expansion.