### PR TITLE
Fix Emscripten build and Wasm test suite issues

### DIFF
--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -621,7 +621,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     add_swift_target_library_single(
       embedded-stdlib-platform-${triple}
       swiftEmscriptenLibc
-      ONLY_SWIFTMODULE
       IS_STDLIB IS_FRAGILE
         ${swift_platform_sources}
         POSIXError.swift

--- a/test/embedded/coroutine_accessor_deleted_method.swift
+++ b/test/embedded/coroutine_accessor_deleted_method.swift
@@ -11,12 +11,10 @@
 // RUN: %target-run %t/a.out | %FileCheck %s --check-prefix=CHECK-OUT
 
 // Also works outside of Embedded, though dead-method elimination only runs here
-// under optimization (Embedded always runs it).  The full non-embedded link+run
-// is skipped on wasm, where the SDK lacks non-embedded static-executable link
-// args (the -emit-ir check below still exercises the stub there).
+// under optimization (Embedded always runs it):
 // RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature CoroutineAccessors -O -wmo -emit-ir | %FileCheck %s
-// RUN: %if !CPU=wasm32 %{ %target-build-swift %s -parse-as-library -enable-experimental-feature CoroutineAccessors -O -wmo -o %t/a.desktop.out %}
-// RUN: %if !CPU=wasm32 %{ %target-run %t/a.desktop.out | %FileCheck %s --check-prefix=CHECK-OUT %}
+// RUN: %target-build-swift %s -parse-as-library -enable-experimental-feature CoroutineAccessors -O -wmo %target-static-resource-dir-opt -o %t/a.desktop.out
+// RUN: %target-run %t/a.desktop.out | %FileCheck %s --check-prefix=CHECK-OUT
 
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib

--- a/test/embedded/lit.local.cfg
+++ b/test/embedded/lit.local.cfg
@@ -71,6 +71,15 @@ elif "OS=macosx" in config.available_features:
 else:
   config.substitutions.append(("%embedded-unicode-tables", f"-Xlinker {config.swift_obj_root}/lib/swift/embedded/{target_triple}/libswiftUnicodeDataTables.a"))
 
+# WASI/Emscripten link non-embedded executables statically, needing
+# static-executable-args.lnk, which exists only under lib/swift_static, not the
+# embedded suite's default lib/swift resource dir.
+if "OS=wasip1" in config.available_features or "OS=emscripten" in config.available_features:
+  config.substitutions.append(("%target-static-resource-dir-opt",
+                               f"-resource-dir {config.swift_obj_root}/lib/swift_static"))
+else:
+  config.substitutions.append(("%target-static-resource-dir-opt", ""))
+
 # (6) Substitutions for linking the embedded standard library and POSIX shim.
 #
 # `libswiftCore.a` is empty under the default code-generation model (clients


### PR DESCRIPTION
`test/embedded/coroutine_accessor_deleted_method.swift` non-embedded build and run lines were skipped on Wasm. WASI and Emscripten link executables statically and need `static-executable-args.lnk`, which the embedded suite's `lib/swift` resource dir lacks. A new `%target-static-resource-dir-opt` substitution points those targets at `lib/swift_static` and is empty elsewhere, so the `CPU=wasm32` guard is dropped.