### PR TITLE
[AST] Sink distributed `id`/`actorSystem` synthesis into direct lookup 

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -600,6 +600,10 @@ public:
   LLVM_READONLY
   bool isInSwiftinterface() const;
 
+  /// Returns true if the context is in a SourceFile, excluding
+  /// `.swiftinterface` files.
+  bool isInSwiftSourceFile() const;
+
   /// Determine whether this declaration context is generic, meaning that it or
   /// any of its parents have generic parameters.
   bool isGenericContext() const;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6811,13 +6811,6 @@ void NominalTypeDecl::synthesizeSemanticMembersIfNeeded(DeclName member) {
   auto baseName = member.getBaseName();
   auto &Context = getASTContext();
 
-  // For a distributed actor `id` and `actorSystem` can be synthesized without
-  // causing cycles so do them above the cycle guard.
-  if (member.isSimpleName(Context.Id_id))
-    (void)getDistributedActorIDProperty();
-  if (member.isSimpleName(Context.Id_actorSystem))
-    (void)getDistributedActorSystemProperty();
-
   // Silently break cycles here because we can't be sure when and where a
   // request to synthesize will come from yet.
   // FIXME: rdar://56844567

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -429,6 +429,11 @@ bool DeclContext::isInSwiftinterface() const {
   return sf && sf->Kind == SourceFileKind::Interface;
 }
 
+bool DeclContext::isInSwiftSourceFile() const {
+  auto *sf = getParentSourceFile();
+  return sf && sf->Kind != SourceFileKind::Interface;
+}
+
 DeclContext *DeclContext::getModuleScopeContext() const {
   // If the current context is PackageUnit, return the module
   // decl context pointing to the current context. This check

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -1483,10 +1483,8 @@ ValueDecl::isSpecialDistributedActorProperty(bool onlyCheckName) const {
   // The synthesized bit doesn't get preserved by serialization or module
   // interfaces, we only need to check it when compiling a SourceFile though
   // since we'll diagnose any conflicting user-defined versions.
-  if (!isSynthesized() && DC->getParentSourceFile() &&
-      !DC->isInSwiftinterface()) {
+  if (!isSynthesized() && DC->isInSwiftSourceFile())
     return std::nullopt;
-  }
 
   return kind;
 }

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2219,6 +2219,46 @@ NominalTypeDecl::lookupDirect(DeclName name, SourceLoc loc,
                            DirectLookupRequest({this, name, flags}, loc), {});
 }
 
+static void populateMembersForLazyName(DeclName name, NominalTypeDecl *decl,
+                                       MemberLookupTable &Table,
+                                       ASTContext &ctx) {
+  DeclBaseName baseName(name.getBaseName());
+
+  if (isa_and_nonnull<clang::RecordDecl>(decl->getClangDecl())) {
+    // FIXME: This should go through populateLookupTableEntryFromLazyIDCLoader.
+    auto allFound = evaluateOrDefault(
+        ctx.evaluator,
+        ClangRecordMemberLookup({cast<NominalTypeDecl>(decl), name}), {});
+    // Add all the members we found, later we'll combine these with the
+    // existing members.
+    for (auto found : allFound)
+      Table.addMember(found);
+  } else if (!isa_and_nonnull<clang::NamespaceDecl>(decl->getClangDecl())) {
+    populateLookupTableEntryFromLazyIDCLoader(ctx, Table, baseName, decl);
+  }
+  populateLookupTableEntryFromExtensions(ctx, Table, baseName, decl);
+
+  // A `@com` type synthesizes its identity member (a class's `CLSID`, or a
+  // protocol's `IID`, in a metatype extension) the first time the table is
+  // built for that name; covers a name lookup racing member synthesis.
+  // Only for a source-file type: an imported one already carries the
+  // deserialized member, and triggering synthesis (which name-looks-up the
+  // member) would re-enter this very lookup.
+  if (ctx.LangOpts.EnableCOMInterop) {
+    if (auto *PD = dyn_cast<ProtocolDecl>(decl)) {
+      if (baseName == ctx.Id_IID && PD->getAttrs().hasAttribute<COMAttr>() &&
+          PD->getDeclContext()->getParentSourceFile())
+        evaluateOrDefault(ctx.evaluator, SynthesizeCOMInterfaceIDRequest{PD},
+                          nullptr);
+    } else if (auto *CD = dyn_cast<ClassDecl>(decl)) {
+      if (baseName == ctx.Id_CLSID && CD->getAttrs().hasAttribute<COMAttr>() &&
+          CD->getDeclContext()->getParentSourceFile())
+        evaluateOrDefault(ctx.evaluator,
+                          SynthesizeCOMImplementationIDRequest{CD}, nullptr);
+    }
+  }
+}
+
 TinyPtrVector<ValueDecl *>
 DirectLookupRequest::evaluate(Evaluator &evaluator,
                               DirectLookupDescriptor desc) const {
@@ -2245,40 +2285,23 @@ DirectLookupRequest::evaluate(Evaluator &evaluator,
 
   auto &Table = *decl->getLookupTable();
   if (!Table.isLazilyComplete(name.getBaseName())) {
-    DeclBaseName baseName(name.getBaseName());
+    // The lookup table believes it doesn't have a complete accounting of this
+    // name - either because we're never seen it before, or another extension
+    // was registered since the last time we searched. Ask the loaders to give
+    // us a hand.
+    populateMembersForLazyName(name, decl, Table, ctx);
 
-    // A `@com` type synthesizes its identity member (a class's `CLSID`, or a
-    // protocol's `IID`, in a metatype extension) the first time the table is
-    // built for that name; covers a name lookup racing member synthesis.
-    // Only for a source-file type: an imported one already carries the
-    // deserialized member, and triggering synthesis (which name-looks-up the
-    // member) would re-enter this very lookup.
-    if (ctx.LangOpts.EnableCOMInterop) {
-      if (auto *PD = dyn_cast<ProtocolDecl>(decl)) {
-        if (baseName == ctx.Id_IID && PD->getAttrs().hasAttribute<COMAttr>() &&
-            PD->getDeclContext()->getParentSourceFile())
-          evaluateOrDefault(ctx.evaluator, SynthesizeCOMInterfaceIDRequest{PD},
-                            nullptr);
-      } else if (auto *CD = dyn_cast<ClassDecl>(decl)) {
-        if (baseName == ctx.Id_CLSID && CD->getAttrs().hasAttribute<COMAttr>() &&
-            CD->getDeclContext()->getParentSourceFile())
-          evaluateOrDefault(ctx.evaluator,
-                            SynthesizeCOMImplementationIDRequest{CD}, nullptr);
-      }
-    }
-
+    // Bypass the regular member lookup table if we find something in
+    // the original C++ namespace. We don't want to store the C++ decl in the
+    // lookup table as the decl can be referenced  from multiple namespace
+    // declarations due to inline namespaces. We still merge in the other
+    // entries found in the lookup table, to support finding members in
+    // namespace extensions.
+    // FIXME: Can this go through the lazy member loader machinary instead?
     if (isa_and_nonnull<clang::NamespaceDecl>(decl->getClangDecl())) {
       auto allFound = evaluateOrDefault(
           ctx.evaluator, CXXNamespaceMemberLookup({cast<EnumDecl>(decl), name}),
           {});
-      populateLookupTableEntryFromExtensions(ctx, Table, baseName, decl);
-
-      // Bypass the regular member lookup table if we find something in
-      // the original C++ namespace. We don't want to store the C++ decl in the
-      // lookup table as the decl can be referenced  from multiple namespace
-      // declarations due to inline namespaces. We still merge in the other
-      // entries found in the lookup table, to support finding members in
-      // namespace extensions.
       if (!allFound.empty()) {
         auto known = Table.find(name);
         if (known != Table.end()) {
@@ -2290,26 +2313,8 @@ DirectLookupRequest::evaluate(Evaluator &evaluator,
         }
         return allFound;
       }
-    } else if (isa_and_nonnull<clang::RecordDecl>(decl->getClangDecl())) {
-      auto allFound = evaluateOrDefault(
-          ctx.evaluator,
-          ClangRecordMemberLookup({cast<NominalTypeDecl>(decl), name}), {});
-      // Add all the members we found, later we'll combine these with the
-      // existing members.
-      for (auto found : allFound)
-        Table.addMember(found);
-
-      populateLookupTableEntryFromExtensions(ctx, Table, baseName, decl);
-    } else {
-      // The lookup table believes it doesn't have a complete accounting of this
-      // name - either because we're never seen it before, or another extension
-      // was registered since the last time we searched. Ask the loaders to give
-      // us a hand.
-      populateLookupTableEntryFromLazyIDCLoader(ctx, Table, baseName, decl);
-      populateLookupTableEntryFromExtensions(ctx, Table, baseName, decl);
     }
-
-    Table.markLazilyComplete(baseName);
+    Table.markLazilyComplete(name.getBaseName());
   }
 
   DeclName macroExpansionKey = adjustLazyMacroExpansionNameKey(ctx, name);

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2246,18 +2246,20 @@ static void populateMembersForLazyName(DeclName name, NominalTypeDecl *decl,
   // member) would re-enter this very lookup.
   if (ctx.LangOpts.EnableCOMInterop) {
     if (auto *PD = dyn_cast<ProtocolDecl>(decl)) {
-      if (baseName == ctx.Id_IID && PD->getAttrs().hasAttribute<COMAttr>() &&
-          PD->getDeclContext()->getParentSourceFile())
+      if (name.isSimpleName(ctx.Id_IID) &&
+          PD->getAttrs().hasAttribute<COMAttr>() && PD->isInSwiftSourceFile()) {
         evaluateOrDefault(ctx.evaluator, SynthesizeCOMInterfaceIDRequest{PD},
                           nullptr);
+      }
     } else if (auto *CD = dyn_cast<ClassDecl>(decl)) {
-      if (baseName == ctx.Id_CLSID && CD->getAttrs().hasAttribute<COMAttr>() &&
-          CD->getDeclContext()->getParentSourceFile())
+      if (name.isSimpleName(ctx.Id_CLSID) &&
+          CD->getAttrs().hasAttribute<COMAttr>() && CD->isInSwiftSourceFile()) {
         evaluateOrDefault(ctx.evaluator,
                           SynthesizeCOMImplementationIDRequest{CD}, nullptr);
+      }
     }
   }
-  
+
   // Ensure `id` and `actorSystem` are populated for a distributed actor.
   // These have lazily-computed types, so should not create a cycle.
   if (name.isSimpleName(ctx.Id_id) && decl->isInSwiftSourceFile())

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2257,6 +2257,13 @@ static void populateMembersForLazyName(DeclName name, NominalTypeDecl *decl,
                           SynthesizeCOMImplementationIDRequest{CD}, nullptr);
     }
   }
+  
+  // Ensure `id` and `actorSystem` are populated for a distributed actor.
+  // These have lazily-computed types, so should not create a cycle.
+  if (name.isSimpleName(ctx.Id_id) && decl->isInSwiftSourceFile())
+    (void)decl->getDistributedActorIDProperty();
+  if (name.isSimpleName(ctx.Id_actorSystem) && decl->isInSwiftSourceFile())
+    (void)decl->getDistributedActorSystemProperty();
 }
 
 TinyPtrVector<ValueDecl *>

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -1239,8 +1239,7 @@ GetDistributedActorIDPropertyRequest::evaluate(Evaluator &evaluator,
 
   // If we're in a deserialized module or swift interface we expect to be able
   // to find this through name lookup.
-  auto *DC = nominal->getDeclContext();
-  if (!DC->getParentSourceFile() || DC->isInSwiftinterface())
+  if (!nominal->isInSwiftSourceFile())
     return lookupDistributedActorProperty(nominal, C.Id_id);
 
   // ==== Synthesize and add 'id' property to the actor decl
@@ -1290,8 +1289,7 @@ VarDecl *GetDistributedActorSystemPropertyRequest::evaluate(
 
   // If we're in a deserialized module or swift interface we expect to be able
   // to find this through name lookup.
-  auto *DC = nominal->getDeclContext();
-  if (!DC->getParentSourceFile() || DC->isInSwiftinterface())
+  if (!nominal->isInSwiftSourceFile())
     return lookupDistributedActorProperty(nominal, C.Id_actorSystem);
 
   // ==== Synthesize and add 'actorSystem' property to the actor decl

--- a/lib/Sema/TypeCheckCOM.cpp
+++ b/lib/Sema/TypeCheckCOM.cpp
@@ -252,8 +252,7 @@ VarDecl *SynthesizeCOMInterfaceIDRequest::evaluate(Evaluator &evaluator,
   // compiled.  A deserialized module or swiftinterface already carries the
   // synthesized extension, so find its `IID` by name lookup; re-synthesizing
   // would duplicate it, or fabricate a member absent from an older interface.
-  auto *DC = PD->getDeclContext();
-  if (!DC->getParentSourceFile() || DC->isInSwiftinterface())
+  if (!PD->isInSwiftSourceFile())
     return com::lookupCOMInterfaceID(PD);
   return com::synthesizeIIDProperty(PD, ASTContext, attr->IID);
 }
@@ -268,8 +267,7 @@ VarDecl *SynthesizeCOMImplementationIDRequest::evaluate(Evaluator &evaluator,
     return nullptr;
   // Synthesize only for a source-file class; recover the imported member by
   // name lookup (see SynthesizeCOMInterfaceIDRequest).
-  auto *DC = CD->getDeclContext();
-  if (!DC->getParentSourceFile() || DC->isInSwiftinterface())
+  if (!CD->isInSwiftSourceFile())
     return com::lookupCOMImplementationID(CD);
   return com::synthesizeCLSIDProperty(CD, ASTContext, *attr->CLSID);
 }


### PR DESCRIPTION
#90529 reminded me that we should just sink these from `synthesizeSemanticMembersIfNeeded` into `DirectLookupRequest` already since they should be lazy enough for that.