### PR TITLE
[android] Remove redundant `__ANDROID__` checks when `__linux__` is defined

### DIFF
--- a/stdlib/public/CommandLineSupport/CommandLine.cpp
+++ b/stdlib/public/CommandLineSupport/CommandLine.cpp
@@ -636,7 +636,7 @@ void _swift_stdlib_withExecutablePath(
 
 #if defined(__APPLE__)
 // Implemented in Swift on Darwin so it can be back-deployed.
-#elif defined(__linux__) || defined(__ANDROID__)
+#elif defined(__linux__)
 static ExecutablePath getExecutablePath(void) {
   size_t byteCount = PATH_MAX;
   while (true) {

--- a/stdlib/public/SwiftShims/swift/shims/LibcShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/LibcShims.h
@@ -104,7 +104,7 @@ static inline __swift_size_t _swift_stdlib_malloc_size(const void *ptr) {
   extern __swift_size_t malloc_size(const void *);
   return malloc_size(ptr);
 }
-#elif defined(__linux__) || defined(__CYGWIN__) || defined(__ANDROID__) \
+#elif defined(__linux__) || defined(__CYGWIN__) \
    || defined(__HAIKU__) || defined(__FreeBSD__) || defined(__wasi__)
 #define HAS_MALLOC_SIZE 1
 static inline __swift_size_t _swift_stdlib_malloc_size(const void *ptr) {


### PR DESCRIPTION
Linux is [a core component of Android and is always defined](https://android.googlesource.com/platform/bionic/+/HEAD/docs/defines.md).