### PR TITLE
[Embedded] Add EmbeddedPlatform-backed Threading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -824,8 +824,8 @@ cmake_dependent_option(SWIFT_ENABLE_SOURCEKIT_TESTS
 option(SWIFT_THREADING_PACKAGE
   "Override the threading package used for the build.  This can either be a
    single package name, or a semicolon separated sequence of sdk:package pairs.
-   Valid package names are 'pthreads', 'darwin', 'linux', 'win32', 'c11', 'none'
-   or the empty string for the SDK default.")
+   Valid package names are 'pthreads', 'darwin', 'linux', 'win32', 'c11', 'none',
+   'embedded', or the empty string for the SDK default.")
 
 option(SWIFT_THREADING_HAS_DLSYM
   "Enable the use of the dlsym() function.  This gets used to provide TSan

--- a/include/swift/Threading/Impl.h
+++ b/include/swift/Threading/Impl.h
@@ -35,7 +35,8 @@ struct stack_bounds {
 // Try to autodetect if we aren't told what to do
 #if !SWIFT_THREADING_NONE && !SWIFT_THREADING_DARWIN &&                        \
     !SWIFT_THREADING_LINUX && !SWIFT_THREADING_PTHREADS &&                     \
-    !SWIFT_THREADING_C11 && !SWIFT_THREADING_WIN32
+    !SWIFT_THREADING_C11 && !SWIFT_THREADING_WIN32 &&                          \
+    !SWIFT_THREADING_EMBEDDED
 #ifdef __APPLE__
 #define SWIFT_THREADING_DARWIN 1
 #elif defined(__linux__)
@@ -65,6 +66,8 @@ struct stack_bounds {
 #include "Impl/C11.h"
 #elif SWIFT_THREADING_WIN32
 #include "Impl/Win32.h"
+#elif SWIFT_THREADING_EMBEDDED
+#include "Impl/ThreadEmbeddedImpl.h"
 #else
 #error You need to implement Threading/Impl.h for your threading package.
 #endif

--- a/include/swift/Threading/Impl/ThreadEmbeddedImpl.h
+++ b/include/swift/Threading/Impl/ThreadEmbeddedImpl.h
@@ -63,7 +63,7 @@ inline std::optional<stack_bounds> thread_get_current_stack_bounds() {
 }
 
 struct mutex_handle {
-  uintptr_t storage[8] = {};
+  uintptr_t storage[EMBEDDED_SWIFT_MUTEX_NUM_WORDS] = {};
 };
 
 inline void mutex_init(mutex_handle &handle, bool checked = false) {
@@ -120,8 +120,8 @@ inline void once_impl(once_t &predicate, void (*fn)(void *), void *ctx) {
   ::swift::swift_once(&predicate, fn, ctx);
 }
 
-using tls_key_t = __swift_tls_key_t;
-using tls_dtor_t = void (*)(void *);
+using tls_key_t = swift_tls_key_t;
+using tls_dtor_t = swift_tls_dtor_t;
 
 inline tls_key_t tls_get_key(swift::tls_key key) {
   return static_cast<tls_key_t>(key);

--- a/include/swift/Threading/Impl/ThreadEmbeddedImpl.h
+++ b/include/swift/Threading/Impl/ThreadEmbeddedImpl.h
@@ -1,0 +1,146 @@
+//==--- ThreadEmbeddedImpl.h - Embedded platform threading glue ---- -*-C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Implements the Swift threading abstraction by forwarding to the Embedded
+// Swift platform hooks declared in swift/EmbeddedPlatform.h.
+//
+// This implementation intentionally does not define SWIFT_THREAD_LOCAL. That
+// makes ThreadLocalStorage.h route reserved TLS slots through key-based storage
+// instead of compiling them as ordinary globals.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_THREADING_IMPL_THREADEMBEDDED_H
+#define SWIFT_THREADING_IMPL_THREADEMBEDDED_H
+
+#include <optional>
+#include <stdint.h>
+
+#include "swift/EmbeddedPlatform.h"
+#include "swift/shims/Visibility.h"
+
+#define SWIFT_THREADING_USE_RESERVED_TLS_KEYS 1
+#define SWIFT_THREADING_HAS_LAZY_MUTEX 0
+#define SWIFT_THREADING_HAS_CONDITION_VARIABLE 0
+
+static_assert(SWIFT_TLS_KEY_COUNT ==
+                  static_cast<int>(swift::tls_key::exclusivity) + 1,
+              "EmbeddedPlatform TLS key count must match TLSKeys.h");
+
+namespace swift {
+
+SWIFT_RUNTIME_EXPORT
+void swift_once(intptr_t *predicate, void (*fn)(void *), void *context);
+
+namespace threading_impl {
+
+using once_t = intptr_t;
+using thread_id = uintptr_t;
+
+inline thread_id thread_get_current() {
+  return 0;
+}
+
+inline bool thread_is_main() {
+  return _swift_thread_isMain() != 0;
+}
+
+inline bool threads_same(thread_id a, thread_id b) {
+  return a == b;
+}
+
+inline std::optional<stack_bounds> thread_get_current_stack_bounds() {
+  return {};
+}
+
+struct mutex_handle {
+  uintptr_t storage[8] = {};
+};
+
+inline void mutex_init(mutex_handle &handle, bool checked = false) {
+  _swift_mutex_init(&handle, checked ? SWIFT_MUTEX_CHECKED : SWIFT_MUTEX_NONE);
+}
+
+inline void mutex_destroy(mutex_handle &handle) {
+  _swift_mutex_destroy(&handle);
+}
+
+inline void mutex_lock(mutex_handle &handle) {
+  _swift_mutex_lock(&handle);
+}
+
+inline void mutex_unlock(mutex_handle &handle) {
+  _swift_mutex_unlock(&handle);
+}
+
+inline bool mutex_try_lock(mutex_handle &handle) {
+  return _swift_mutex_tryLock(&handle) != 0;
+}
+
+inline void mutex_unsafe_lock(mutex_handle &handle) {
+  _swift_mutex_lock(&handle);
+}
+
+inline void mutex_unsafe_unlock(mutex_handle &handle) {
+  _swift_mutex_unlock(&handle);
+}
+
+using recursive_mutex_handle = mutex_handle;
+
+inline void recursive_mutex_init(recursive_mutex_handle &handle,
+                                 bool checked = false) {
+  _swift_mutex_init(&handle,
+                    static_cast<swift_mutex_flags_t>(
+                        SWIFT_MUTEX_RECURSIVE |
+                        (checked ? SWIFT_MUTEX_CHECKED : SWIFT_MUTEX_NONE)));
+}
+
+inline void recursive_mutex_destroy(recursive_mutex_handle &handle) {
+  _swift_mutex_destroy(&handle);
+}
+
+inline void recursive_mutex_lock(recursive_mutex_handle &handle) {
+  _swift_mutex_lock(&handle);
+}
+
+inline void recursive_mutex_unlock(recursive_mutex_handle &handle) {
+  _swift_mutex_unlock(&handle);
+}
+
+inline void once_impl(once_t &predicate, void (*fn)(void *), void *ctx) {
+  ::swift::swift_once(&predicate, fn, ctx);
+}
+
+using tls_key_t = __swift_tls_key_t;
+using tls_dtor_t = void (*)(void *);
+
+inline tls_key_t tls_get_key(swift::tls_key key) {
+  return static_cast<tls_key_t>(key);
+}
+
+inline bool tls_init(tls_key_t key, tls_dtor_t dtor) {
+  _swift_tls_init(key, dtor);
+  return true;
+}
+
+inline void *tls_get(tls_key_t key) {
+  return _swift_tls_get(key);
+}
+
+inline void tls_set(tls_key_t key, void *ptr) {
+  _swift_tls_set(key, ptr);
+}
+
+} // namespace threading_impl
+} // namespace swift
+
+#endif // SWIFT_THREADING_IMPL_THREADEMBEDDED_H

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -470,6 +470,9 @@ function(_add_target_variant_c_compile_flags)
 
   string(TOUPPER "${SWIFT_SDK_${CFLAGS_SDK}_THREADING_PACKAGE}" _threading_package)
   list(APPEND result "-DSWIFT_THREADING_${_threading_package}")
+  if(CFLAGS_SDK STREQUAL "embedded" AND _threading_package STREQUAL "EMBEDDED")
+    list(APPEND result "-I${SWIFT_SOURCE_DIR}/stdlib/public/EmbeddedPlatform")
+  endif()
 
   if(SWIFT_STDLIB_OS_VERSIONING)
     list(APPEND result "-DSWIFT_RUNTIME_OS_VERSIONING")

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -375,6 +375,8 @@ if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
 endif()
 
 if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
+  get_threading_package(EMBEDDED "embedded" SWIFT_SDK_embedded_THREADING_PACKAGE)
+
   set(triples)
   foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
     string(REGEX REPLACE "[ \t]+" ";" list "${entry}")

--- a/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
+++ b/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
@@ -118,6 +118,10 @@ typedef void (*__swift_tls_dtor_t)(void * EMBEDDED_SWIFT_NULLABLE);
  */
 #define EMBEDDED_SWIFT_PLATFORM_VERSION_MINOR 1
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 /**
  * The number of pointer-size words that will be used to store a Mutex (as
  * provided by the Synchronization library).
@@ -457,6 +461,10 @@ __swift_ptrdiff_t _swift_thread_isMain(void);
  * function.
  */
 void _swift_exit(__swift_ptrdiff_t code);
+
+#if defined(__cplusplus)
+}
+#endif
 
 #undef EMBEDDED_SWIFT_NAME
 #undef EMBEDDED_SWIFT_OPTION_SET

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2097,9 +2097,9 @@ for host in "${ALL_HOSTS[@]}"; do
                     fi
 
                     case $package in
-                        "" | pthreads | darwin | linux | win32 | c11 | none) ;;
+                        "" | pthreads | darwin | linux | win32 | c11 | none | embedded) ;;
                         *)
-                        echo "build-script: unknown threading package $package for sdk $sdk; must be one of 'pthreads', 'darwin', 'linux', 'win32', 'c11', 'none', or empty for sdk default"
+                        echo "build-script: unknown threading package $package for sdk $sdk; must be one of 'pthreads', 'darwin', 'linux', 'win32', 'c11', 'none', 'embedded', or empty for sdk default"
                         exit 1
                         ;;
                     esac


### PR DESCRIPTION
This PR continues [#90717](https://github.com/swiftlang/swift/pull/90717), which established the EmbeddedPlatform contract for mutexes, reserved TLS, and main-execution-context detection.

It adds `SWIFT_THREADING_EMBEDDED`, a Threading backend that forwards Swift’s existing threading abstraction through those EmbeddedPlatform hooks. This lets runtime and stdlib code continue using `Mutex`, `RecursiveMutex`, `Once`, and thread-local storage through the standard Threading interface, while keeping the platform-dependent implementation in `EmbeddedPlatform.h`.

The backend uses the reserved TLS-key model provided by EmbeddedPlatform, so runtime, stdlib, Concurrency, Observation, and exclusivity TLS values are routed through platform storage rather than compiler-provided `SWIFT_THREAD_LOCAL` globals. It uses the embedded runtime’s existing `swift_once` implementation and forwards checked and recursive mutex behavior through the existing mutex flags.

The build configuration now recognizes `embedded` as a threading package and applies it to Embedded stdlib targets. The backend also explicitly advertises the Threading capabilities it provides: mutexes, recursive mutexes, reserved TLS, and main-context detection, without lazy mutex or condition-variable support.