### PR TITLE
[Utils] add child note and nested macro support to update-verify-tests

### DIFF
--- a/test/Utils/update-verify-tests/child-notes.swift
+++ b/test/Utils/update-verify-tests/child-notes.swift
@@ -1,0 +1,128 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// The second RUN of each pair re-verifies the updated file to prove the tool
+// produced a file that actually passes verification; the %diff locks the exact
+// formatting against the .expected golden.
+
+// RUN: not %target-swift-frontend-verify -verify-child-notes -typecheck %t/add.swift 2>&1 | %update-verify-tests
+// RUN: %target-swift-frontend-verify -verify-child-notes -typecheck %t/add.swift
+// RUN: %diff %t/add.swift %t/add.swift.expected
+
+// RUN: not %target-swift-frontend-verify -verify-child-notes -typecheck %t/new-parent.swift 2>&1 | %update-verify-tests
+// RUN: %target-swift-frontend-verify -verify-child-notes -typecheck %t/new-parent.swift
+// RUN: %diff %t/new-parent.swift %t/new-parent.swift.expected
+
+// RUN: not %target-swift-frontend-verify -verify-child-notes -typecheck %t/fix.swift 2>&1 | %update-verify-tests
+// RUN: %target-swift-frontend-verify -verify-child-notes -typecheck %t/fix.swift
+// RUN: %diff %t/fix.swift %t/fix.swift.expected
+
+// RUN: not %target-swift-frontend-verify -verify-child-notes -typecheck %t/partial.swift 2>&1 | %update-verify-tests
+// RUN: %target-swift-frontend-verify -verify-child-notes -typecheck %t/partial.swift
+// RUN: %diff %t/partial.swift %t/partial.swift.expected
+
+// RUN: not %target-swift-frontend-verify -verify-child-notes -typecheck %t/remove.swift 2>&1 | %update-verify-tests
+// RUN: %target-swift-frontend-verify -verify-child-notes -typecheck %t/remove.swift
+// RUN: %diff %t/remove.swift %t/remove.swift.expected
+
+// RUN: not %target-swift-frontend-verify -verify-child-notes -typecheck %t/no-notes.swift 2>&1 | %update-verify-tests
+// RUN: %target-swift-frontend-verify -verify-child-notes -typecheck %t/no-notes.swift
+// RUN: %diff %t/no-notes.swift %t/no-notes.swift.expected
+
+// RUN: not %target-swift-frontend-verify -verify-child-notes -typecheck %t/note-relocated.swift 2>&1 | %update-verify-tests
+// RUN: %target-swift-frontend-verify -verify-child-notes -typecheck %t/note-relocated.swift
+// RUN: %diff %t/note-relocated.swift %t/note-relocated.swift.expected
+
+// RUN: not %target-swift-frontend-verify -typecheck %t/flag-disabled.swift 2>&1 | %update-verify-tests
+// RUN: %target-swift-frontend-verify -typecheck %t/flag-disabled.swift
+// RUN: %diff %t/flag-disabled.swift %t/flag-disabled.swift.expected
+
+//--- add.swift
+struct A {}
+struct A {} // expected-error {{invalid redeclaration of 'A'}}
+
+//--- add.swift.expected
+struct A {}
+struct A {} // expected-error {{invalid redeclaration of 'A'}} {{children:
+//   expected-note@-2{{'A' previously declared here}}
+// }}
+
+//--- new-parent.swift
+struct B {}
+struct B {}
+
+//--- new-parent.swift.expected
+struct B {}
+// expected-error@+3{{invalid redeclaration of 'B'}} {{children:
+//   expected-note@-2{{'B' previously declared here}}
+// }}
+struct B {}
+
+//--- fix.swift
+struct C {}
+struct C {} // expected-error {{invalid redeclaration of 'C'}} {{children:
+//   expected-note@-2 {{wrong message}}
+// }}
+
+//--- fix.swift.expected
+struct C {}
+struct C {} // expected-error {{invalid redeclaration of 'C'}} {{children:
+//   expected-note@-2{{'C' previously declared here}}
+// }}
+
+//--- partial.swift
+struct D {}
+struct D {} // expected-error {{invalid redeclaration of 'D'}} {{children:
+//   expected-note@-2{{'D' previously declared here}}
+//   expected-note@-3{{stale extra note}}
+// }}
+
+//--- partial.swift.expected
+struct D {}
+struct D {} // expected-error {{invalid redeclaration of 'D'}} {{children:
+//   expected-note@-2{{'D' previously declared here}}
+// }}
+
+//--- remove.swift
+struct E {}
+struct F {} // expected-error {{invalid redeclaration of 'E'}} {{children:
+//   expected-note@-2 {{'E' previously declared here}}
+// }}
+
+//--- remove.swift.expected
+struct E {}
+struct F {}
+
+//--- no-notes.swift
+let x: Int = "hello" // expected-error {{cannot convert value of type 'String' to specified type 'Int'}} {{children:
+//   expected-note@-1 {{this note does not exist}}
+// }}
+
+//--- no-notes.swift.expected
+let x: Int = "hello" // expected-error {{cannot convert value of type 'String' to specified type 'Int'}}
+
+//--- note-relocated.swift
+struct G {}
+// expected-note@-1 {{'G' previously declared here}}
+struct G {} // expected-error {{invalid redeclaration of 'G'}}
+undefinedName()
+
+//--- note-relocated.swift.expected
+struct G {}
+struct G {} // expected-error {{invalid redeclaration of 'G'}} {{children:
+//   expected-note@-2{{'G' previously declared here}}
+// }}
+// expected-error@+1{{cannot find 'undefinedName' in scope}}
+undefinedName()
+
+//--- flag-disabled.swift
+struct H {}
+struct H {} // expected-error {{invalid redeclaration of 'H'}} {{children:
+//   expected-note@-2 {{'H' previously declared here}}
+// }}
+
+//--- flag-disabled.swift.expected
+// expected-note@+1{{'H' previously declared here}}
+struct H {}
+struct H {} // expected-error {{invalid redeclaration of 'H'}}
+

--- a/test/Utils/update-verify-tests/expansion.swift
+++ b/test/Utils/update-verify-tests/expansion.swift
@@ -62,6 +62,57 @@
 // RUN: %target-swift-frontend-verify -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/empty-expansion-for-prefix.swift -Rmacro-expansions
 // RUN: %diff %t/empty-expansion-for-prefix.swift %t/empty-expansion-for-prefix.swift.expected
 
+// A diagnostic emitted inside a macro expansion may carry a child note whose
+// own location is inside the same expansion buffer (e.g. a redeclaration's
+// "previously declared here" note). update-verify-tests can synthesize such a
+// note using an absolute '@n' line, just like the other diagnostics inside an
+// expansion. The outward "in expansion of macro" child note that every
+// in-expansion diagnostic also carries is dropped with -verify-ignore-macro-note
+// so only the synthesizable inward note remains.
+// RUN: not %target-swift-frontend-verify -verify-child-notes -verify-ignore-macro-note -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/accept-child-note.swift 2>%t/output.txt
+// RUN: %update-verify-tests < %t/output.txt
+// RUN: %target-swift-frontend-verify -verify-child-notes -verify-ignore-macro-note -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/accept-child-note.swift
+// RUN: %diff %t/accept-child-note.swift %t/accept-child-note.swift.expected
+
+// Without -verify-ignore-macro-note, that outward "in expansion of macro" note
+// is verified too. It points back into the outer file and is only expressible
+// with '@#marker' syntax, which update-verify-tests cannot synthesize, so it
+// must fail with a clear message rather than emit a directive the verifier
+// would reject.
+// RUN: not %target-swift-frontend-verify -verify-child-notes -typo-correction-limit 10 -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/reject-child-notes.swift 2>%t/output.txt
+// RUN: not %update-verify-tests < %t/output.txt | %FileCheck --check-prefix CHECK-CHILD-NOTES %s
+
+// CHECK-CHILD-NOTES: cannot synthesize a child note that points out of a macro expansion
+
+// The mirror image: a diagnostic *outside* an expansion (in the outer file)
+// whose child note lives *inside* the expansion buffer. Referencing into the
+// expansion likewise needs '@#marker' syntax, which update-verify-tests cannot
+// synthesize, so this too must fail with a clear message.
+// RUN: not %target-swift-frontend-verify -verify-child-notes -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/reject-child-note-inward.swift 2>%t/output.txt
+// RUN: not %update-verify-tests < %t/output.txt | %FileCheck --check-prefix CHECK-CHILD-NOTES-INWARD %s
+
+// CHECK-CHILD-NOTES-INWARD: cannot synthesize a child note that points into a macro expansion
+
+// A parent diagnostic in one expansion whose child note lives in a different
+// expansion.
+// RUN: not %target-swift-frontend-verify -verify-child-notes -verify-ignore-macro-note -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/reject-child-note-cross.swift 2>%t/output.txt
+// RUN: not %update-verify-tests < %t/output.txt | %FileCheck --check-prefix CHECK-CHILD-NOTES-CROSS %s
+// RUN: not %target-swift-frontend-verify -verify-child-notes -verify-ignore-macro-note -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/reject-child-note-cross-matched.swift 2>%t/output.txt
+// RUN: not %update-verify-tests < %t/output.txt | %FileCheck --check-prefix CHECK-CHILD-NOTES-CROSS %s
+
+// CHECK-CHILD-NOTES-CROSS: cannot synthesize a child note that lives in a different macro expansion
+
+// A diagnostic inside a nested expansion.
+// Its child notes are anchored via a chain of "in expansion from here" notes
+// whose innermost entry lives in the intermediate expansion buffer, not the
+// outer file. Here the inner diagnostics are addressable with
+// absolute '@n' lines inside their own expansion block, so the doubly-nested
+// expansion is synthesized and round-trips.
+// RUN: not %target-swift-frontend-verify -verify-child-notes -verify-ignore-macro-note -typo-correction-limit 10 -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/nested-child-note.swift 2>%t/output.txt
+// RUN: %update-verify-tests < %t/output.txt
+// RUN: %target-swift-frontend-verify -verify-child-notes -verify-ignore-macro-note -typo-correction-limit 10 -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/nested-child-note.swift
+// RUN: %diff %t/nested-child-note.swift %t/nested-child-note.swift.expected
+
 //--- single.swift
 @attached(peer, names: overloaded)
 macro unstringifyPeer(_ s: String) =
@@ -377,4 +428,135 @@ func foo() {}
 //   expected-hjkl-remark@2{{hjkl}}
 // }}
 func foo() {}
+
+//--- accept-child-note.swift
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+@unstringifyPeer("func foo(_ x: Int) {}\nfunc foo(_ x: Int) {}")
+func foo() {}
+// expected-expansion@-1:14{{
+//   expected-error@3{{invalid redeclaration of 'foo'}}
+// }}
+
+//--- accept-child-note.swift.expected
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+@unstringifyPeer("func foo(_ x: Int) {}\nfunc foo(_ x: Int) {}")
+func foo() {}
+// expected-expansion@-1:14{{
+//   expected-error@3{{invalid redeclaration of 'foo'}} {{children:
+//     expected-note@1{{'foo' previously declared here}}
+//   }}
+// }}
+
+//--- reject-child-notes.swift
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+@unstringifyPeer("func foo(_ x: Int) {\nqqq()\n}")
+func foo() {}
+// expected-expansion@-1:14{{
+//   expected-error@2{{cannot find 'qqq' in scope}}
+// }}
+
+//--- reject-child-note-inward.swift
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+// The macro peer generates `func foo(_ x: Int)` inside the expansion; the outer
+// redeclaration below is the one diagnosed, so the parent error is in this file
+// but its "previously declared here" child note points inside the expansion.
+@unstringifyPeer("func foo(_ x: Int) {}")
+func foo() {}
+func foo(_ x: Int) {}
+
+//--- reject-child-note-cross.swift
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+// Each peer generates `func foo(_ x: Int)` inside its own expansion; the two
+// generated declarations conflict, so the redeclaration error is in the second
+// expansion while its "previously declared here" child note is in the first.
+@unstringifyPeer("func foo(_ x: Int) {}")
+func foo(_ a: Bool) {}
+
+@unstringifyPeer("func foo(_ x: Int) {}")
+func foo(_ b: String) {}
+
+//--- reject-child-note-cross-matched.swift
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+// As above, but with a parent matcher.
+@unstringifyPeer("func foo(_ x: Int) {}")
+func foo(_ a: Bool) {}
+
+@unstringifyPeer("func foo(_ x: Int) {}")
+func foo(_ b: String) {}
+// expected-expansion@-1:25{{
+//   expected-error@1{{invalid redeclaration of 'foo'}}
+// }}
+
+//--- nested-child-note.swift
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+// hack to make this seem non-recursive
+@attached(peer, names: overloaded)
+macro unstringifyPeer2(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+@unstringifyPeer("""
+func bar(_ y: Int) {
+    @unstringifyPeer2(\"""
+    func foo(_ x: Int) {
+        a = 2
+        b = x
+    }
+    \""")
+    func foo() {}
+    foo(y)
+}
+""")
+func bar() {}
+
+//--- nested-child-note.swift.expected
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+// hack to make this seem non-recursive
+@attached(peer, names: overloaded)
+macro unstringifyPeer2(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+@unstringifyPeer("""
+func bar(_ y: Int) {
+    @unstringifyPeer2(\"""
+    func foo(_ x: Int) {
+        a = 2
+        b = x
+    }
+    \""")
+    func foo() {}
+    foo(y)
+}
+""")
+// expected-expansion@+9:14{{
+//   expected-note@1 2{{did you mean 'y'?}}
+//   expected-expansion@9:6{{
+//     expected-note@1 2{{did you mean 'x'?}}
+//     expected-error@2{{cannot find 'a' in scope}}
+//     expected-error@3{{cannot find 'b' in scope}}
+//   }}
+//   expected-error@10{{argument passed to call that takes no arguments}}
+// }}
+func bar() {}
 

--- a/utils/update_verify_tests/core.py
+++ b/utils/update_verify_tests/core.py
@@ -127,6 +127,16 @@ class Diag:
         # fixits_raw_str as is. A list (possibly empty) means: replace the
         # source fix-its with these exact marker strings.
         self.actual_fixits = None
+        # Child-note (`{{children:...}}`) support, used only under
+        # -verify-child-notes. A parent diag owns a block of child notes:
+        #   `children` holds the child-note Lines (each with an is_child_note
+        #   Diag), and `children_closer` is the Line rendering the `// }}`
+        #   that closes the block. On a child-note diag, `child_of` points
+        #   back at the owning parent Diag and `is_child_note` is True.
+        self.children = []
+        self.children_closer = None
+        self.is_child_note = False
+        self.child_of = None
 
     def decrement_count(self):
         self.count -= 1
@@ -284,6 +294,10 @@ class ExpansionDiagClose:
         self.line = line
         self.parent = None
         self.category = "closing"
+        # Set when this `}}` closes a `{{children:...}}` block instead of an
+        # `expected-expansion`; points at the owning parent Diag.
+        self.child_of = None
+        self.is_child_note = False
 
     def render(self):
         return "//" + self.whitespace + "}}"
@@ -671,6 +685,82 @@ def add_diag(
     return new_diag
 
 
+def _make_children_closer(parent_diag, parent_line):
+    indent = get_indent(parent_line.content)
+    closer_line = Line(indent + "{{DIAG}}\n", len(parent_diag.children) + 1)
+    # Align the closing `}}` with the parent directive (one level shallower
+    # than the child notes it encloses), so a block nested inside an expansion
+    # lines up like the hand-written examples.
+    parent_ws = parent_diag.whitespace_strings or DEFAULT_WHITESPACE
+    close = ExpansionDiagClose(parent_ws.slash, closer_line)
+    close.child_of = parent_diag
+    closer_line.diag = close
+    return closer_line
+
+
+def _ensure_children_block(parent_diag, parent_line):
+    """Make sure `parent_diag` has a `{{children:` opener glued to its line and
+    a `// }}` closer line, synthesizing them if the parent had no block yet."""
+    if "{{children:" not in parent_line.content:
+        content = parent_line.content
+        if content.endswith("\n"):
+            body, nl = content[:-1], "\n"
+        else:
+            body, nl = content, ""
+        parent_line.content = body.rstrip() + " {{children:" + nl
+    if parent_diag.children_closer is None:
+        parent_diag.children_closer = _make_children_closer(
+            parent_diag, parent_line
+        )
+
+
+def add_child_note(
+    parent_diag, parent_line, content, prefix, target_line,
+    absolute_line=None,
+):
+    """Append a new child-note directive to `parent_diag`'s `{{children:...}}`
+    block. `target_line`, when given, is the source Line the note points at, so
+    its `@±N` offset stays correct across line shifts (mirroring add_diag);
+    otherwise the note targets the parent line (best effort for child notes in
+    a foreign buffer, which cannot be addressed by a plain offset).
+
+    `absolute_line`, when given, pins the note at that absolute line with a
+    `@N` location instead of a relative `@±N` offset. This is used for a child
+    note that lives *inside* a macro expansion buffer: like the diagnostics the
+    nested recursion synthesizes there, it must be addressed by an absolute
+    line, since relative offsets are rejected inside an expansion. It is
+    mutually exclusive with `target_line`."""
+    _ensure_children_block(parent_diag, parent_line)
+    indent = get_indent(parent_line.content)
+    child_line = Line(indent + "{{DIAG}}\n", len(parent_diag.children) + 1)
+    # Indent the child note two spaces past its parent directive (mirroring the
+    # nesting add_diag uses inside expansions), so a block whose parent is
+    # itself nested in an expansion still reads as one level deeper.
+    parent_ws = parent_diag.whitespace_strings or DEFAULT_WHITESPACE
+    child_diag = Diag(
+        prefix,
+        content,
+        "note",
+        absolute_line if absolute_line is not None else 0,
+        absolute_line is not None,
+        None,
+        1,
+        child_line,
+        False,
+        Whitespace(slash=parent_ws.slash + "  ", at="", count="", braces=""),
+        False,
+        [],
+    )
+    child_diag.is_child_note = True
+    child_diag.child_of = parent_diag
+    child_line.diag = child_diag
+    if target_line is not None:
+        assert absolute_line is None
+        child_diag.set_target(target_line)
+    add_line(child_line, parent_diag.children)
+    return child_diag
+
+
 def _split_dead_expansion_for_foreign_prefixes(line, lines, prefix):
     """If the dead `expected-expansion` directive at `line` has surviving
     nested entries with foreign prefixes, replace it with one new expansion
@@ -746,6 +836,46 @@ def _split_dead_expansion_for_foreign_prefixes(line, lines, prefix):
     return True
 
 
+def _strip_children_opener(parent_line):
+    """Remove a ` {{children:` opener (and any surrounding blank space) from a
+    parent directive line whose child-note block has been emptied."""
+    content = parent_line.content
+    if content.endswith("\n"):
+        body, nl = content[:-1], "\n"
+    else:
+        body, nl = content, ""
+    idx = body.rfind("{{children:")
+    if idx == -1:
+        return
+    parent_line.content = body[:idx].rstrip() + nl
+
+
+def _collapse_dead_children(parent_diag, prefix):
+    """Drop dead child notes from `parent_diag`'s block and, if the block ends
+    up empty, remove the opener/closer so the parent renders without a
+    `{{children:...}}` block (an empty block is a verifier error). If the
+    parent directive itself is being removed (count 0), drop the whole block:
+    its child notes belonged to a parent that no longer exists, and the
+    verifier does not report them separately."""
+    if not parent_diag.children and parent_diag.children_closer is None:
+        return
+    if parent_diag.count == 0:
+        parent_diag.children = []
+        parent_diag.children_closer = None
+        _strip_children_opener(parent_diag.line)
+        return
+    remove_dead_diags(parent_diag.children, prefix)
+    surviving = [
+        cl
+        for cl in parent_diag.children
+        if cl.diag is None or cl.diag.count != 0
+    ]
+    parent_diag.children = surviving
+    if not surviving:
+        _strip_children_opener(parent_diag.line)
+        parent_diag.children_closer = None
+
+
 def remove_dead_diags(lines, prefix):
     for line in lines.copy():
         if line not in lines:
@@ -753,6 +883,10 @@ def remove_dead_diags(lines, prefix):
             continue
         if not line.diag:
             continue
+        if getattr(line.diag, "children", None) or (
+            getattr(line.diag, "children_closer", None) is not None
+        ):
+            _collapse_dead_children(line.diag, prefix)
         if line.diag.category == "expansion":
             if not line.diag.prefix or line.diag.prefix == prefix:
                 # Whether the verifier already reported this expansion as
@@ -781,12 +915,15 @@ def remove_dead_diags(lines, prefix):
         # formatting (whitespace, original_count_str) survives a content
         # rewrite. Nested expansion diags have no target, so skip.
         took = False
-        if line.diag.target is not None:
+        if line.diag.target is not None and not getattr(
+            line.diag, "is_child_note", False
+        ):
             for other_diag in line.diag.target.targeting_diags:
                 if (
                     other_diag.is_from_source_file
                     or other_diag.count == 0
                     or other_diag.category != line.diag.category
+                    or getattr(other_diag, "is_child_note", False)
                 ):
                     continue
                 if other_diag.is_re or line.diag.is_re:
@@ -814,6 +951,7 @@ def remove_dead_diags(lines, prefix):
                     or other_diag.is_from_source_file
                     or other_diag.count == 0
                     or other_diag.actual_fixits is not None
+                    or getattr(other_diag, "is_child_note", False)
                 ):
                     continue
                 other_diag.actual_fixits = line.diag.actual_fixits
@@ -857,6 +995,56 @@ def expand_expansions(lines):
         i += 1
 
 
+def _child_parent_of(line):
+    """The parent Diag that owns `line` as part of its `{{children:...}}`
+    block, or None. Set for both parsed child-note lines (via the note diag's
+    `child_of`) and for literal lines inside the block (via `_children_literal`,
+    e.g. `@#marker` child notes we don't parse structurally)."""
+    if line.diag is not None:
+        parent = getattr(line.diag, "child_of", None)
+        if parent is not None:
+            return parent
+    return getattr(line, "_children_literal", None)
+
+
+def fold_children(lines):
+    """Pull the lines of every `{{children:...}}` block out of the main line
+    list and into their parent diag's `children`/`children_closer`, mirroring
+    `fold_expansions` for the child-note nesting."""
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        parent = _child_parent_of(line)
+        if parent is None:
+            i += 1
+            continue
+        remove_line(line, lines)
+        if line.diag is not None and line.diag.category == "closing":
+            parent.children_closer = line
+        else:
+            line.line_n = len(parent.children) + 1
+            add_line(line, parent.children)
+
+
+def expand_children(lines):
+    """Re-insert each surviving `{{children:...}}` block's lines after their
+    parent line, mirroring `expand_expansions`."""
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        d = line.diag
+        if d is None or not getattr(d, "children", None):
+            i += 1
+            continue
+        block = list(d.children)
+        if d.children_closer is not None:
+            block.append(d.children_closer)
+        for j, nested in enumerate(block):
+            nested.line_n = line.line_n + j + 1
+            add_line(nested, lines)
+        i += 1 + len(block)
+
+
 def error_refers_to_diag(diag_error, diag, target_line_n):
     if diag_error.col and diag.col() and diag_error.col != diag.col():
         return False
@@ -891,8 +1079,15 @@ def find_other_targeting(lines, orig_lines, is_nested, diag_error, prefix):
 
 
 def update_lines(
-    diag_errors, lines, orig_lines, prefix, filename, nested_context
+    diag_errors, lines, orig_lines, prefix, filename, nested_context,
+    orig_filename=None
 ):
+    # `orig_filename` is the file actually being rewritten (the one `orig_lines`
+    # belong to). It stays constant across the nested-expansion recursion, where
+    # `filename` becomes the expansion buffer's synthetic name. Child notes that
+    # point back into the outer file are resolved against `orig_lines` using it.
+    if orig_filename is None:
+        orig_filename = filename
     for diag_error in diag_errors:
         if not isinstance(diag_error, NotFoundDiag):
             continue
@@ -1005,7 +1200,189 @@ def update_lines(
                 prefix,
                 diag_error.file,
                 diag,
+                orig_filename,
             )
+        elif isinstance(diag_error, ExtraDiag) and diag_error.child_notes:
+            # The whole parent diagnostic was unexpected and carried child
+            # notes; synthesize a `{{children:...}}` block for it.
+            for cfile, cline, ccol, cmsg, cross_expansion in (
+                diag_error.child_notes
+            ):
+                if nested_context is not None:
+                    # The parent diagnostic lives inside a macro expansion. A
+                    # child note whose location is *also* inside the *same*
+                    # expansion buffer is addressable with an absolute `@N` line
+                    # (like the nested diagnostics the recursion synthesizes
+                    # there). A child note that points back into the outer file,
+                    # or into a *different* expansion, is only expressible with
+                    # `@#marker` syntax, which we cannot synthesize
+                    # automatically -- refuse those.
+                    if cfile == orig_filename:
+                        raise KnownException(
+                            "cannot synthesize a child note that points out of "
+                            "a macro expansion into the outer file; add it "
+                            "manually using '@#marker' syntax to reference the "
+                            "location outside the expansion"
+                        )
+                    if cross_expansion:
+                        raise KnownException(
+                            "cannot synthesize a child note that lives in a "
+                            "different macro expansion than its parent; add it "
+                            "manually using '@#marker' syntax to reference the "
+                            "location in the other expansion"
+                        )
+                    add_child_note(
+                        diag, diag.line, cmsg, diag_error.prefix, None,
+                        absolute_line=cline,
+                    )
+                    continue
+                # Top-level parent. A child note located in the file being
+                # updated is targeted at its real source line so its `@±N`
+                # offset stays correct. A child note located inside a macro
+                # expansion buffer would need `@#marker` syntax to reference
+                # into the expansion, which we cannot synthesize automatically
+                # -- refuse (the mirror of the in-expansion parent case above).
+                if cfile != orig_filename:
+                    raise KnownException(
+                        "cannot synthesize a child note that points into a "
+                        "macro expansion; add it manually using '@#marker' "
+                        "syntax to reference the location inside the expansion"
+                    )
+                target = None
+                if 1 <= cline <= len(orig_lines):
+                    target = orig_lines[cline - 1]
+                add_child_note(
+                    diag, diag.line, cmsg, diag_error.prefix, target
+                )
+
+    # Add child notes reported against parents that matched an existing
+    # directive. Done after the pass above so any newly-added parent diags
+    # are already in place. `ExtraChildNote`s are always processed here at the
+    # top level (they are never folded into the nested-expansion recursion), so
+    # the parent directive is located by absolute line into the outer file --
+    # this also covers child notes on a diagnostic emitted inside a macro
+    # expansion, whose parent directive lives in `orig_lines`.
+    for diag_error in diag_errors:
+        if not isinstance(diag_error, ExtraChildNote):
+            continue
+        if not (1 <= diag_error.line <= len(orig_lines)):
+            raise KnownException(
+                f"could not locate parent diagnostic at "
+                f"{diag_error.file}:{diag_error.line} for unexpected child note"
+            )
+        parent_line = orig_lines[diag_error.line - 1]
+        parent_diag = parent_line.diag
+        if parent_diag is None or parent_diag.category in (
+            "closing",
+            "expansion",
+        ):
+            raise KnownException(
+                f"could not find a parent diagnostic directive at "
+                f"{diag_error.file}:{diag_error.line} to attach child note "
+                f"'{diag_error.content}'"
+            )
+        # When the parent diagnostic sits inside a macro expansion, a child
+        # note that is *also* inside the *same* expansion buffer is addressable
+        # with an absolute `@N` line. One that points back into the outer file,
+        # or into a *different* expansion, needs `@#marker` syntax we cannot
+        # generate automatically.
+        if parent_diag.parent is not None:
+            if diag_error.child_file == orig_filename:
+                raise KnownException(
+                    "cannot synthesize a child note that points out of a macro "
+                    "expansion into the outer file; add it manually using "
+                    "'@#marker' syntax to reference the location outside the "
+                    "expansion"
+                )
+            # The child note shares its parent's expansion only if their whole
+            # chains of expansion sites match. (Distinct expansions can share a
+            # synthesized buffer name, and even the same site line within it, so
+            # neither the file name nor a single (file, line) anchor is enough to
+            # tell them apart -- the full chain up to the outer file is.)
+            anchors = diag_error.child_expansion_anchors
+            # A nested expansion: the child note is reached through more than one
+            # expansion site, so its innermost anchor sits in an intermediate
+            # expansion buffer rather than the outer file. Its absolute line is
+            # meaningful only in that buffer, which the simple absolute-line
+            # synthesis here cannot address, so refuse. (A robust implementation
+            # would reconstruct the matched parent directive's own site chain and
+            # compare it against `anchors`; that is not done here.)
+            if len(anchors) > 1:
+                raise KnownException(
+                    "cannot synthesize a child note that lives in a nested "
+                    "macro expansion; add it manually using '@#marker' "
+                    "syntax to reference the location in the expansion"
+                )
+            if anchors:
+                anchor_line = anchors[0][1]
+                if 1 <= anchor_line <= len(orig_lines):
+                    child_site = orig_lines[anchor_line - 1].line_n
+                    parent_site = parent_diag.parent.absolute_target()
+                    if child_site != parent_site:
+                        raise KnownException(
+                            "cannot synthesize a child note that lives in a "
+                            "different macro expansion than its parent; add it "
+                            "manually using '@#marker' syntax to reference the "
+                            "location in the other expansion"
+                        )
+            add_child_note(
+                parent_diag,
+                parent_line,
+                diag_error.content,
+                diag_error.prefix or prefix,
+                None,
+                absolute_line=diag_error.child_line,
+            )
+            continue
+        # A top-level parent whose child note lives inside a macro expansion
+        # buffer would need `@#marker` syntax to reference into the expansion,
+        # which we cannot synthesize automatically (mirror of the case above).
+        if diag_error.child_file != orig_filename:
+            raise KnownException(
+                "cannot synthesize a child note that points into a macro "
+                "expansion; add it manually using '@#marker' syntax to "
+                "reference the location inside the expansion"
+            )
+        target = None
+        if diag_error.child_file == diag_error.file and 1 <= (
+            diag_error.child_line
+        ) <= len(orig_lines):
+            target = orig_lines[diag_error.child_line - 1]
+        add_child_note(
+            parent_diag,
+            parent_line,
+            diag_error.content,
+            diag_error.prefix or prefix,
+            target,
+        )
+
+    # Strip `{{children:...}}` blocks that the verifier rejected because the
+    # invocation lacks -verify-child-notes. The notes they listed resurface as
+    # top-level `unexpected note produced` diagnostics handled above.
+    for diag_error in diag_errors:
+        if not isinstance(diag_error, StripChildrenBlock):
+            continue
+        if not (1 <= diag_error.line <= len(orig_lines)):
+            continue
+        parent_diag = orig_lines[diag_error.line - 1].diag
+        if parent_diag is None or parent_diag.category in (
+            "closing",
+            "expansion",
+        ):
+            continue
+        parent_diag.children = []
+        parent_diag.children_closer = None
+        _strip_children_opener(parent_diag.line)
+
+
+def _opens_children_block(content):
+    """True if `content` (a parsed line, with the diag replaced by `{{DIAG}}`)
+    opens a multi-line `{{children:...}}` block, i.e. the last `{{children:`
+    on the line is not closed by a `}}` before end of line."""
+    idx = content.rfind("{{children:")
+    if idx == -1:
+        return False
+    return "}}" not in content[idx + len("{{children:") :]
 
 
 def update_test_file(filename, diag_errors, prefix, updated_test_files):
@@ -1021,9 +1398,31 @@ def update_test_file(filename, diag_errors, prefix, updated_test_files):
     orig_lines = list(lines)
 
     expansion_context = []
+    children_context = None
     for line in lines:
         dprint(f"parsing line {line.render()}")
         diag = parse_diag(line, filename, prefix, all_prefixes=True)
+        if children_context is not None:
+            # Inside a `{{children:...}}` block: route the closer and the
+            # child-note (or literal) lines to the owning parent rather than
+            # treating them as top-level diags/expansions.
+            if diag and diag.category == "closing":
+                line.diag = diag
+                diag.child_of = children_context
+                children_context = None
+            elif diag:
+                line.diag = diag
+                diag.is_child_note = True
+                diag.child_of = children_context
+            elif line.content.lstrip().startswith("}}"):
+                # A `}}`-first line that didn't parse as a `// }}` closer
+                # (e.g. a C-comment `}}*/` block terminator): treat it as a
+                # literal closer so we don't run past the end of the block.
+                line._children_literal = children_context
+                children_context = None
+            else:
+                line._children_literal = children_context
+            continue
         if diag:
             dprint(f"  parsed diag {diag.render()}")
             line.diag = diag
@@ -1035,13 +1434,22 @@ def update_test_file(filename, diag_errors, prefix, updated_test_files):
                 expansion_context.append(diag)
             elif diag.category == "closing":
                 expansion_context.pop()
+            elif _opens_children_block(line.content):
+                children_context = diag
         else:
             dprint(f"  no diag")
 
+    # Fold `{{children:...}}` blocks before expansions so that child notes
+    # nested inside an `expected-expansion` are pulled onto their parent nested
+    # diagnostic's `children` list first; folding expansions afterwards then
+    # carries that parent diagnostic (with its children attached) into the
+    # expansion's `nested_lines`.
+    fold_children(lines)
     fold_expansions(lines)
     update_lines(diag_errors, lines, orig_lines, prefix, filename, None)
     remove_dead_diags(lines, prefix)
     expand_expansions(lines)
+    expand_children(lines)
     with open(filename, "w") as f:
         for line in lines:
             f.write(line.render())
@@ -1155,6 +1563,73 @@ diag_produced_elsewhere_re = re.compile(
 
 
 """
+Emitted under -verify-child-notes when a matched parent diagnostic has a child
+note that no `{{children:...}}` entry accounted for. Always followed by a
+`note: for parent matched here` pointing at the parent's expected-* directive
+(possibly with intervening `note: in expansion from here` notes if the child
+note originates in a macro expansion).
+ex:
+test.swift:1:8: error: unexpected child note produced: 'A' previously declared here
+struct A {}
+       ^
+test.swift:5:13: note: for parent matched here
+struct A {} // expected-error{{invalid redeclaration of 'A'}} {{children:
+            ^
+"""
+diag_unexpected_child_note_re = re.compile(
+    r"(\S+):(\d+):(\d+): error: unexpected child note produced: (.*)"
+)
+diag_for_parent_matched_re = re.compile(
+    r"(\S+):(\d+):(\d+): note: for parent matched here"
+)
+
+"""
+Emitted under -verify-child-notes as a child note attached to an
+`unexpected <kind> produced` parent (the whole parent diagnostic was
+unexpected, so its child notes are reported as notes on it).
+ex:
+test.swift:2:8: error: unexpected error produced: invalid redeclaration of 'A'
+struct A {}
+       ^
+test.swift:1:8: note: with child note: 'A' previously declared here
+struct A {}
+       ^
+"""
+diag_with_child_note_re = re.compile(
+    r"(\S+):(\d+):(\d+): note: with child note: (.*)"
+)
+
+"""
+Emitted under -verify-child-notes when a `{{children:...}}` entry matched a
+child note that belongs to a different parent. We can't meaningfully re-target
+child notes across parents automatically, so this is surfaced as a hard error.
+ex:
+test.swift:5:13: error: matched child note with different parent
+"""
+diag_matched_wrong_parent_re = re.compile(
+    r"(\S+):(\d+):(\d+): error: matched child note with different parent"
+)
+
+"""
+Emitted for a `{{children:...}}` block when the invocation does NOT pass
+-verify-child-notes: the block is rejected and its child notes are cleared, so
+the actual notes are reported separately as `unexpected note produced` and get
+re-added as top-level `expected-note`s. We respond by stripping the now-invalid
+block off the parent directive; the reported location is the `{{children:`
+marker, i.e. on the parent directive's own line.
+ex:
+test.swift:2:64: error: child diagnostics block requires -verify-child-notes
+struct A {} // expected-error{{invalid redeclaration of 'A'}} {{children:
+                                                              ^
+"""
+diag_children_requires_flag_re = re.compile(
+    r"(\S+):(\d+):(\d+): error: child diagnostics block requires "
+    r"-verify-child-notes"
+)
+
+
+
+"""
 ex:
 test.swift:2:89: error: expected fix-it not seen; actual fix-it seen: {{3-8=_}}
 test.swift:2:89: error: expected fix-it not seen
@@ -1189,9 +1664,78 @@ class ExtraDiag:
         self.category = category
         self.content = content
         self.prefix = prefix
+        # Child notes reported as `note: with child note: ...` attached to
+        # this (wholly unexpected) parent diagnostic, in output order. Each
+        # entry is (file, line, col, content). Applied when the parent diag
+        # directive is synthesized, producing a `{{children:...}}` block.
+        self.child_notes = []
 
     def __str__(self):
         return f"{self.file}:{self.line}:{self.col}: error unexpected {self.category} produced: {self.content}"
+
+
+class ExtraChildNote:
+    """A `unexpected child note produced` reported for a child note whose
+    parent diagnostic *did* match an expected directive. The note must be
+    added to that parent's `{{children:...}}` block (created if absent), so
+    this is bucketed and rendered against the *parent's* file: `file`/`line`/
+    `col` locate the parent directive, while `child_*` record the actual
+    child note's reported location and message."""
+
+    def __init__(
+        self, child_file, child_line, child_col, content, parent_file,
+        parent_line, parent_col, prefix, child_expansion_anchors=None,
+    ):
+        # Route/edit this against the parent directive's file and line.
+        self.file = parent_file
+        self.line = parent_line
+        self.col = parent_col
+        self.category = "note"
+        self.content = content
+        self.child_file = child_file
+        self.child_line = child_line
+        self.child_col = child_col
+        self.prefix = prefix
+        # The full chain of expansion sites the child note lives in, as a list
+        # of (file, line) taken from its consecutive `note: in expansion from
+        # here` notes, ordered innermost first and terminating at the outer
+        # file. Empty if the child note is not in an expansion. A single-element
+        # chain means the child note sits directly in one expansion of the outer
+        # file; a longer chain means it is in a nested expansion. The whole chain
+        # is needed to identify *which* expansion instance the note belongs to:
+        # distinct nested expansions can share a synthesized buffer name (and
+        # even the same site line within it), so only the sequence of outer
+        # sites up to the outer file disambiguates them.
+        self.child_expansion_anchors = child_expansion_anchors or []
+
+    def __str__(self):
+        return (
+            f"{self.child_file}:{self.child_line}:{self.child_col}: "
+            f"unexpected child note '{self.content}' of parent at "
+            f"{self.file}:{self.line}:{self.col}"
+        )
+
+
+class StripChildrenBlock:
+    """A `child diagnostics block requires -verify-child-notes` error: the
+    parent directive at `line` carries a `{{children:...}}` block but the
+    invocation lacks the flag. The block must be removed; the child notes it
+    listed resurface as top-level `unexpected note produced` diagnostics and
+    are re-added as top-level `expected-note`s by the ExtraDiag path."""
+
+    def __init__(self, file, line, col, prefix):
+        self.file = file
+        self.line = line
+        self.col = col
+        self.category = None
+        self.content = None
+        self.prefix = prefix
+
+    def __str__(self):
+        return (
+            f"{self.file}:{self.line}:{self.col}: strip children block "
+            f"(requires -verify-child-notes)"
+        )
 
 
 class NestedDiag:
@@ -1301,6 +1845,74 @@ def check_expectations(tool_output, prefix):
                         prefix,
                     )
                 )
+            elif m := diag_unexpected_child_note_re.match(line):
+                dprint(f"unexpected child note: {line.strip()}")
+                cfile, cline, ccol, cmsg = (
+                    m.group(1),
+                    int(m.group(2)),
+                    int(m.group(3)),
+                    m.group(4),
+                )
+                # The error line is followed by its source+caret, then any
+                # `note: in expansion from here` triples (present when the
+                # child note originates in a macro expansion), then the
+                # required `note: for parent matched here` triple. The
+                # expansion triples form the child note's site chain, ordered
+                # innermost first and ending at the outer file.
+                j = i + 3
+                child_expansion_anchors = []
+                while j < len(tool_output) and (
+                    em := diag_expansion_note_re.match(tool_output[j].strip())
+                ):
+                    child_expansion_anchors.append(
+                        (em.group(1), int(em.group(2)))
+                    )
+                    j += 3
+                pm = (
+                    diag_for_parent_matched_re.match(tool_output[j].strip())
+                    if j < len(tool_output)
+                    else None
+                )
+                if not pm:
+                    raise KnownException(
+                        f"'unexpected child note produced' (line {i+1}) was "
+                        f"not followed by 'for parent matched here'"
+                    )
+                j += 3
+                extra_lines = tool_output[i + 1 : j]
+                dprint(f"extra lines: {extra_lines}")
+                # Appended directly (not via `curr`) so the expansion-note
+                # wrapping below never folds it into a NestedDiag.
+                top_level.append(
+                    ExtraChildNote(
+                        cfile,
+                        cline,
+                        ccol,
+                        cmsg,
+                        pm.group(1),
+                        int(pm.group(2)),
+                        int(pm.group(3)),
+                        prefix,
+                        child_expansion_anchors,
+                    )
+                )
+            elif m := diag_matched_wrong_parent_re.match(line):
+                raise KnownException(
+                    f"child note matched a different parent (line {i+1}); "
+                    f"update-verify-tests cannot re-target child notes "
+                    f"automatically"
+                )
+            elif m := diag_children_requires_flag_re.match(line):
+                dprint(f"children block without flag: {line.strip()}")
+                extra_lines = tool_output[i + 1 : i + 3]
+                top_level.append(
+                    StripChildrenBlock(
+                        m.group(1),
+                        int(m.group(2)),
+                        int(m.group(3)),
+                        prefix,
+                    )
+                )
             # Create two mirroring mismatches when the compiler reports that the category or diagnostic is incorrect.
             # This makes it easier to handle cases where the same diagnostic is mentioned both in an incorrect message/category
             # diagnostic, as well as in an error not produced diagnostic. This can happen for things like 'expected-error 2{{foo}}'
@@ -1391,6 +2003,63 @@ def check_expectations(tool_output, prefix):
                     for e in curr
                 ]
                 i += len(nested_note_lines)
+
+            # `note: with child note: ...` lines trail an `unexpected <kind>
+            # produced` parent (after any expansion notes for the parent's own
+            # location). Attach each as a child note of the underlying
+            # ExtraDiag so a `{{children:...}}` block is synthesized with it.
+            while (
+                curr
+                and i < len(tool_output)
+                and (m := diag_with_child_note_re.match(tool_output[i].strip()))
+            ):
+                dprint(f"with child note: {tool_output[i].strip()}")
+                cfile, cline, ccol, cmsg = (
+                    m.group(1),
+                    int(m.group(2)),
+                    int(m.group(3)),
+                    m.group(4),
+                )
+                i += 3
+                # A child note that originates inside a macro expansion trails
+                # its `with child note:` line with `note: in expansion from
+                # here` triples locating each enclosing expansion site. They
+                # form the child note's site chain, innermost first, ending at
+                # the outer file.
+                child_anchors = []
+                while i < len(tool_output) and (
+                    em := diag_expansion_note_re.match(tool_output[i].strip())
+                ):
+                    child_anchors.append((em.group(1), int(em.group(2))))
+                    i += 3
+                for e in curr:
+                    base = e
+                    # The `NestedDiag`s wrapping the parent locate the parent's
+                    # own expansion sites. They were applied outermost-last, so
+                    # walking from the outside in yields outermost first;
+                    # reverse to get the same innermost-first order as the
+                    # child's chain.
+                    parent_anchors = []
+                    while isinstance(base, NestedDiag):
+                        parent_anchors.append((base.file, base.line))
+                        base = base.nested
+                    parent_anchors.reverse()
+                    if isinstance(base, ExtraDiag):
+                        # The child note shares the parent's expansion only if
+                        # their entire site chains match. Comparing the whole
+                        # chain -- not just the innermost (file, line) -- is
+                        # required because distinct nested expansions can share a
+                        # synthesized buffer name (and even the same site line
+                        # within it); only the sequence of enclosing sites up to
+                        # the outer file distinguishes them. An empty parent
+                        # chain (a top-level parent) never counts as sharing.
+                        same_expansion = (
+                            bool(parent_anchors)
+                            and child_anchors == parent_anchors
+                        )
+                        base.child_notes.append(
+                            (cfile, cline, ccol, cmsg, not same_expansion)
+                        )
             top_level.extend(curr)
 
     except KnownException as e:


### PR DESCRIPTION
This adds support for -verify-child-notes to UVT. One limitation for now is that the script cannot fix child note errors across buffers, since that would require `#markers` to anchor the location, which UVT does not yet support adding. Also adds some awareness of nested macro expansions to help diagnosing when something is in a different buffer.