### PR TITLE
Optimizer: add the CopySinking pass

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
@@ -19,6 +19,7 @@ swift_compiler_sources(Optimizer
   ComputeEscapeEffects.swift
   ComputeSideEffects.swift
   CondFailOptimization.swift
+  CopySinking.swift
   CopyToBorrowOptimization.swift
   DeadAccessScopeElimination.swift
   DeadObjectElimination.swift

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CopySinking.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CopySinking.swift
@@ -1,0 +1,257 @@
+//===--- CopySinking.swift -------------------------------------------------==//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SIL
+
+/// Sinks copy instructions (`copy_value`, `load [copy]`) across control flow:
+///
+/// 1. Sinks copies over phi nodes:
+///
+/// ```
+///   bb1:
+///     %1 = copy_value %0
+///     br bb3(%1)
+///   bb2:
+///     %2 = copy_value %0
+///     br bb3(%2)
+///   bb3(%3 : @owned):
+///     // uses of %3
+/// ```
+/// ->
+/// ```
+///   bb1:
+///     br bb3(%0)
+///   bb2:
+///     br bb3(%0)
+///   bb3(%3 : @guaranteed):
+///     %4 = copy_value %3
+///     // uses of %4
+/// ```
+///
+/// 2. Sinks copies over terminator instructions (switch_enum, checked_cast_br):
+///
+/// ```
+///   %1 = copy_value %0
+///   switch_enum %1, case A: bb1, case B: bb2
+///   bb1(%2 : @owned):
+///     // uses of %2
+///   bb2(%3 : @owned):
+///     // uses of %3
+/// ```
+/// ->
+/// ```
+///   switch_enum %0, case A: bb1, case B: bb2
+///   bb1(%2 : @guaranteed):
+///     %4 = copy_value %2
+///     // uses of %4
+///   bb2(%3 : @guaranteed):
+///     %5 = copy_value %3
+///     // uses of %5
+/// ```
+///
+/// 3. Also handles `load [copy]` which is replaced by `load_borrow`:
+///
+/// ```
+///   %1 = load [copy] %addr
+///   switch_enum %1, case A: bb1, case B: bb2
+///   bb1(%2 : @owned):
+///     // uses of %2
+///   bb2(%3 : @owned):
+///     // uses of %3
+/// ```
+/// ->
+/// ```
+///   %1 = load_borrow %addr
+///   switch_enum %1, case A: bb1, case B: bb2
+///   bb1(%2 : @guaranteed):
+///     %4 = copy_value %2
+///     // uses of %4
+///     end_borrow %1
+///   bb2(%3 : @guaranteed):
+///     %5 = copy_value %3
+///     // uses of %5
+///     end_borrow %1
+/// ```
+///
+/// The optimization can be done if:
+/// * The `copy_value` or `load [copy]` has a single use.
+/// * The source operand has guaranteed ownership.
+/// * The borrow scope can be extended or is already valid across the control flow.
+/// * For loads: no writes to the loaded address occur before the terminator.
+///
+/// The optimization has several benefits:
+/// * In case of phi-nodes, it reduces the number of `copy_value` instructions which is good for code size
+/// * Also, if the copies are the only instructions in the predecessor block, the predecessor blocks
+///   become empty which allows simplification of the control flow.
+/// * In case of `switch_enum`, the copy of an enum payload is much simpler than the copy of the whole enum.
+/// * It's more likely that a sunk `copy_value` can be eliminated eventually.
+///
+let copySinking = FunctionPass(name: "copy-sinking") {
+  (function: Function, context: FunctionPassContext) in
+
+  if !function.hasOwnership {
+    return
+  }
+
+  var changed = false
+
+  for block in function.blocks {
+    if !context.continueWithNextSubpassRun(for: block.terminator) {
+      return
+    }
+    for arg in block.arguments {
+      if let phi = Phi(arg) {
+        if trySinkCopiesOverPhi(phi: phi, context) {
+          changed = true
+        }
+      }
+    }
+    switch block.terminator {
+    case let switchEnum as SwitchEnumInst:
+      if trySinkCopiesOver(terminator: switchEnum, context) {
+        changed = true
+      }
+    case let cast as CheckedCastBranchInst:
+      guard cast.preservesReferenceCounts else {
+        break
+      }
+      if trySinkCopiesOver(terminator: cast, context) {
+        changed = true
+      }
+    default:
+      break
+    }
+  }
+
+  if changed {
+    updateBorrowedFrom(in: function, context)
+  }
+}
+
+private func trySinkCopiesOverPhi(phi: Phi, _ context: FunctionPassContext) -> Bool {
+  for incomingOp in phi.incomingOperands {
+    guard let copy = incomingOp.value as? CopyValueInst,
+          copy.uses.isSingleUse,
+          copy.fromValue.ownership == .guaranteed,
+          isContainedInBorrowScope(from: copy, to: incomingOp.instruction, context)
+    else {
+      return false
+    }
+  }
+
+  for incomingOp in phi.incomingOperands {
+    let copy = incomingOp.value as! CopyValueInst
+    copy.replace(with: copy.fromValue, context)
+  }
+
+  phi.value.set(ownership: .guaranteed, context)
+  let newCopy = Builder(atBeginOf: phi.value.parentBlock, context).createCopyValue(operand: phi.value)
+  phi.value.uses.ignore(user: newCopy).replaceAll(with: newCopy, context)
+
+  return true
+}
+
+private func trySinkCopiesOver(terminator: ForwardingInstruction & UnaryInstruction & TermInst,
+                               _ context: FunctionPassContext) -> Bool
+{
+  switch terminator.operand.value {
+  case let copy as CopyValueInst:
+    guard copy.uses.isSingleUse,
+          copy.fromValue.ownership == .guaranteed,
+          extendBorrowScope(from: copy, to: terminator, context)
+    else {
+      return false
+    }
+
+    terminator.setForwardingOwnership(to: .guaranteed, context)
+    copy.replace(with: copy.fromValue, context)
+
+    for succ in terminator.successors {
+      if let arg = succ.arguments.first, arg.ownership == .owned {
+        arg.set(ownership: .guaranteed, context)
+        let newCopy = Builder(atBeginOf: succ, context).createCopyValue(operand: arg)
+        arg.uses.ignore(user: newCopy).replaceAll(with: newCopy, context)
+      }
+    }
+    return true
+
+  case let load as LoadInst:
+    guard load.uses.isSingleUse,
+          load.loadOwnership == .copy,
+          !mayWrite(toAddressOf: load, before: terminator, context)
+    else {
+      return false
+    }
+
+    terminator.setForwardingOwnership(to: .guaranteed, context)
+    let loadBorrow = Builder(before: load, context).createLoadBorrow(fromAddress: load.address)
+    load.replace(with: loadBorrow, context)
+
+    for succ in terminator.successors {
+      let builder = Builder(atBeginOf: succ, context)
+      if let arg = succ.arguments.first, arg.ownership == .owned {
+        arg.set(ownership: .guaranteed, context)
+        let newCopy = builder.createCopyValue(operand: arg)
+        arg.uses.ignore(user: newCopy).replaceAll(with: newCopy, context)
+      }
+      builder.createEndBorrow(of: loadBorrow)
+    }
+    return true
+
+  default:
+    return false
+  }
+}
+
+private func isContainedInBorrowScope(from copy: CopyValueInst,
+                                      to toInstruction: Instruction,
+                                      _ context: FunctionPassContext) -> Bool
+{
+  var liveRange = InstructionRange(begin: copy, context)
+  defer { liveRange.deinitialize() }
+
+  liveRange.insert(toInstruction)
+  return liveRange.isFullyContainedIn(scopeOf: copy.fromValue)
+}
+
+
+private func extendBorrowScope(from copy: CopyValueInst,
+                               to terminator: TermInst,
+                               _ context: FunctionPassContext) -> Bool
+{
+  var liveRange = InstructionRange(begin: copy, context)
+  defer { liveRange.deinitialize() }
+
+  liveRange.insert(contentsOf: terminator.successors.map { $0.instructions.first! })
+
+  return extendBorrowScope(of: copy.fromValue, toOverlap: liveRange, context)
+}
+
+private func mayWrite(toAddressOf load: LoadInst,
+                      before endInstruction: Instruction,
+                      _ context: FunctionPassContext) -> Bool
+{
+  let aliasAnalysis = context.aliasAnalysis
+  var worklist = InstructionWorklist(context)
+  defer { worklist.deinitialize() }
+
+  worklist.pushPredecessors(of: endInstruction, ignoring: load)
+
+  while let inst = worklist.pop() {
+    if inst.mayWrite(toAddress: load.address, aliasAnalysis) {
+      return true
+    }
+    worklist.pushPredecessors(of: inst, ignoring: load)
+  }
+  return false
+}
+

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -84,6 +84,7 @@ private func registerSwiftPasses() {
   registerPass(constantCapturePropagation, { constantCapturePropagation.run($0) })
   registerPass(computeEscapeEffects, { computeEscapeEffects.run($0) })
   registerPass(computeSideEffects, { computeSideEffects.run($0) })
+  registerPass(copySinking, { copySinking.run($0) })
   registerPass(condFailOptimization, { condFailOptimization.run($0) })
   registerPass(diagnoseInfiniteRecursion, { diagnoseInfiniteRecursion.run($0) })
   registerPass(destroyHoisting, { destroyHoisting.run($0) })

--- a/SwiftCompilerSources/Sources/SIL/Argument.swift
+++ b/SwiftCompilerSources/Sources/SIL/Argument.swift
@@ -37,6 +37,11 @@ public class Argument : Value, Hashable {
     bridged.setReborrow(reborrow)
   }
 
+  public func set(ownership: Ownership, _ context: some MutatingContext) {
+    context.notifyInstructionsChanged()
+    bridged.setOwnership(ownership._bridged)
+  }
+
   public var isLexical: Bool { false }
 
   public var decl: ValueDecl? { bridged.getDecl().getAs(ValueDecl.self) }

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -1047,6 +1047,7 @@ struct BridgedArgument {
   BRIDGED_INLINE bool FunctionArgument_isLexical() const;
   BRIDGED_INLINE bool FunctionArgument_isClosureCapture() const;
   BRIDGED_INLINE void setReborrow(bool reborrow) const;
+  BRIDGED_INLINE void setOwnership(BridgedValue::Ownership ownership) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE OptionalBridgedDeclObj getDecl() const;
   BRIDGED_INLINE void copyFlags(BridgedArgument fromArgument) const;
 };

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -685,6 +685,16 @@ void BridgedArgument::setReborrow(bool reborrow) const {
   getArgument()->setReborrow(reborrow);
 }
 
+void BridgedArgument::setOwnership(BridgedValue::Ownership ownership) const {
+  auto *arg = getArgument();
+  switch (ownership) {
+    case BridgedValue::Ownership::Unowned:    arg->setOwnershipKind(swift::OwnershipKind::Unowned);    break;
+    case BridgedValue::Ownership::Owned:      arg->setOwnershipKind(swift::OwnershipKind::Owned);      break;
+    case BridgedValue::Ownership::Guaranteed: arg->setOwnershipKind(swift::OwnershipKind::Guaranteed); break;
+    case BridgedValue::Ownership::None:       arg->setOwnershipKind(swift::OwnershipKind::None);       break;
+  }
+}
+
 bool BridgedArgument::FunctionArgument_isLexical() const {
   return llvm::cast<swift::SILFunctionArgument>(getArgument())->getLifetime().isLexical();
 }

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -61,6 +61,8 @@
 
 PASS(AllocBoxToStack, "allocbox-to-stack",
      "stack promotion of box objects")
+PASS(CopySinking, "copy-sinking",
+     "Sinks copy instructions over terminator instructions")
 PASS(CopyToBorrowOptimization, "copy-to-borrow-optimization",
      "Convert load [copy] instructions to load_borrow and remove copies of borrowed values")
 PASS(AssumeSingleThreaded, "sil-assume-single-threaded",

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -593,6 +593,7 @@ void addFunctionPasses(SILPassPipelinePlan &P,
   // Optimize copies created during RLE.
   P.addSemanticARCOpts();
   P.addCopyToBorrowOptimization();
+  P.addCopySinking();
 
   P.addCOWOpts();
   P.addPerformanceConstantPropagation();

--- a/test/SILOptimizer/assemblyvision_remark/basic.swift
+++ b/test/SILOptimizer/assemblyvision_remark/basic.swift
@@ -156,7 +156,6 @@ func lookThroughRefCast(x: Klass) -> SubKlass {
 
 func lookThroughEnum(x: Klass?) -> Klass {
     return x! // expected-remark {{retain of type 'Klass'}}
-              // expected-note @-2:22 {{of 'x.some'}}
 }
 
 func castAsQuestion(x: Klass) -> SubKlass? {
@@ -219,7 +218,6 @@ func inoutKlassTuplePairArgument(x: inout (Klass, Klass)) -> Klass {
 
 func inoutKlassOptionalArgument(x: inout Klass?) -> Klass {
     return x! // expected-remark {{retain of type 'Klass'}}
-              // expected-note @-2 {{of 'x.some'}}
 }
 
 func inoutKlassBangCastArgument(x: inout Klass) -> SubKlass {

--- a/test/SILOptimizer/copy-sinking.sil
+++ b/test/SILOptimizer/copy-sinking.sil
@@ -1,0 +1,250 @@
+// RUN: %target-sil-opt -copy-sinking %s | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+
+class C {}
+
+class SubKlass : C {}
+
+// CHECK-LABEL: sil [ossa] @sink_over_enum :
+// CHECK:         switch_enum %0
+// CHECK:       bb2([[P:%.*]] : @guaranteed $C):
+// CHECK-NEXT:    [[C:%.*]] = copy_value [[P]]
+// CHECK-NEXT:    return [[C]]
+// CHECK:       } // end sil function 'sink_over_enum'
+sil [ossa] @sink_over_enum : $@convention(thin) (@guaranteed Optional<C>) -> @owned C {
+bb0(%0 : @guaranteed $Optional<C>):
+  %2 = copy_value %0
+  switch_enum %2, case #Optional.some!enumelt: bb2, case #Optional.none!enumelt: bb1
+
+bb1:
+  %4 = integer_literal $Builtin.Int1, -1
+  cond_fail %4, "Unexpectedly found nil while unwrapping an Optional value"
+  unreachable
+
+bb2(%7 : @owned $C):
+  return %7
+}
+
+// CHECK-LABEL: sil [ossa] @sink_over_checked_cast :
+// CHECK:         checked_cast_br C in %0 to SubKlass, bb1, bb2
+// CHECK:       bb1([[S:%.*]] : @guaranteed $SubKlass):
+// CHECK-NEXT:    [[C1:%.*]] = copy_value [[S]]
+// CHECK-NEXT:    enum $Optional<SubKlass>, #Optional.some!enumelt, [[C1]]
+// CHECK:       bb2([[B:%.*]] : @guaranteed $C):
+// CHECK-NEXT:    [[C2:%.*]] = copy_value [[B]]
+// CHECK-NEXT:    destroy_value [[C2]]
+// CHECK:       } // end sil function 'sink_over_checked_cast'
+sil [ossa] @sink_over_checked_cast : $@convention(thin) (@guaranteed C) -> @owned Optional<SubKlass> {
+bb0(%0 : @guaranteed $C):
+  %2 = copy_value %0
+  checked_cast_br C in %2 to SubKlass, bb1, bb2
+
+bb1(%4 : @owned $SubKlass):
+  %5 = enum $Optional<SubKlass>, #Optional.some!enumelt, %4
+  br bb3(%5)
+
+
+bb2(%7 : @owned $C):
+  destroy_value %7
+  %9 = enum $Optional<SubKlass>, #Optional.none!enumelt
+  br bb3(%9)
+
+bb3(%11 : @owned $Optional<SubKlass>):
+  return %11
+}
+
+// CHECK-LABEL: sil [ossa] @sink_over_phi :
+// CHECK:       bb1:
+// CHECK-NEXT:    br bb3(%0)
+// CHECK:       bb2:
+// CHECK-NEXT:    br bb3(%0)
+// CHECK:       bb3([[P:%.*]] : @guaranteed $C):
+// CHECK-NEXT:    [[BF:%.*]] = borrowed [[P]] from (%0)
+// CHECK-NEXT:    [[C:%.*]] = copy_value [[BF]]
+// CHECK-NEXT:    return [[C]]
+// CHECK:       } // end sil function 'sink_over_phi'
+sil [ossa] @sink_over_phi : $@convention(thin) (@guaranteed C) -> @owned C {
+bb0(%0 : @guaranteed $C):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %2 = copy_value %0
+  br bb3(%2)
+
+bb2:
+  %4 = copy_value %0
+  br bb3(%4)
+
+
+bb3(%6 : @owned $C):
+  return %6
+}
+
+// CHECK-LABEL: sil [ossa] @sink_load_over_enum :
+// CHECK:         %1 = load_borrow %0
+// CHECK-NEXT:    switch_enum %1
+// CHECK:       bb1:
+// CHECK-NEXT:    end_borrow %1
+// CHECK:       bb2([[P:%.*]] : @guaranteed $C):
+// CHECK-NEXT:    [[C:%.*]] = copy_value [[P]]
+// CHECK-NEXT:    end_borrow %1
+// CHECK-NEXT:    return [[C]]
+// CHECK:       } // end sil function 'sink_load_over_enum'
+sil [ossa] @sink_load_over_enum : $@convention(thin) (@inout Optional<C>) -> @owned C {
+bb0(%0 : $*Optional<C>):
+  %2 = load [copy] %0
+  switch_enum %2, case #Optional.some!enumelt: bb2, case #Optional.none!enumelt: bb1
+
+bb1:
+  %4 = integer_literal $Builtin.Int1, -1
+  cond_fail %4, "Unexpectedly found nil while unwrapping an Optional value"
+  unreachable
+
+bb2(%7 : @owned $C):
+  return %7
+}
+
+// CHECK-LABEL: sil [ossa] @sink_load_over_enum_modified_address :
+// CHECK:         %1 = load [copy] %0
+// CHECK:       bb2([[P:%.*]] : @owned $C):
+// CHECK-NEXT:    return [[P]]
+// CHECK:       } // end sil function 'sink_load_over_enum_modified_address'
+sil [ossa] @sink_load_over_enum_modified_address : $@convention(thin) (@inout Optional<C>) -> @owned C {
+bb0(%0 : $*Optional<C>):
+  %2 = load [copy] %0
+  %3 = apply undef(%0) : $@convention(thin) (@inout Optional<C>) -> ()
+  switch_enum %2, case #Optional.some!enumelt: bb2, case #Optional.none!enumelt: bb1
+
+bb1:
+  %4 = integer_literal $Builtin.Int1, -1
+  cond_fail %4, "Unexpectedly found nil while unwrapping an Optional value"
+  unreachable
+
+bb2(%7 : @owned $C):
+  return %7
+}
+
+// CHECK-LABEL: sil [ossa] @sink_over_enum_extend_scope :
+// CHECK:         %1 = begin_borrow %0
+// CHECK-NEXT:    switch_enum %1
+// CHECK:       bb1:
+// CHECK-NEXT:    end_borrow %1
+// CHECK:       bb2([[P:%.*]] : @guaranteed $C):
+// CHECK-NEXT:    [[C:%.*]] = copy_value [[P]]
+// CHECK-NEXT:    end_borrow %1
+// CHECK:       } // end sil function 'sink_over_enum_extend_scope'
+sil [ossa] @sink_over_enum_extend_scope : $@convention(thin) (@owned Optional<C>) -> @owned C {
+bb0(%0 : @owned $Optional<C>):
+  %1 = begin_borrow %0
+  %2 = copy_value %1
+  end_borrow %1
+  switch_enum %2, case #Optional.some!enumelt: bb2, case #Optional.none!enumelt: bb1
+
+bb1:
+  destroy_value [dead_end] %0
+  %4 = integer_literal $Builtin.Int1, -1
+  cond_fail %4, "Unexpectedly found nil while unwrapping an Optional value"
+  unreachable
+
+bb2(%7 : @owned $C):
+  destroy_value %0
+  return %7
+}
+
+// CHECK-LABEL: sil [ossa] @sink_over_phi_wrong_liverange :
+// CHECK:       bb1:
+// CHECK-NEXT:    copy_value
+// CHECK:       bb2:
+// CHECK-NEXT:    copy_value
+// CHECK:       } // end sil function 'sink_over_phi_wrong_liverange'
+sil [ossa] @sink_over_phi_wrong_liverange : $@convention(thin) (@owned C) -> @owned C {
+bb0(%0 : @owned $C):
+  %1 = begin_borrow %0
+  cond_br undef, bb1, bb2
+
+bb1:
+  %2 = copy_value %1
+  end_borrow %1
+  br bb3(%2)
+
+bb2:
+  %4 = copy_value %1
+  end_borrow %1
+  br bb3(%4)
+
+
+bb3(%6 : @owned $C):
+  destroy_value %0
+  return %6
+}
+
+// CHECK-LABEL: sil [ossa] @sink_over_enum_no_single_copy_use :
+// CHECK:         copy_value
+// CHECK:         switch_enum
+// CHECK:       } // end sil function 'sink_over_enum_no_single_copy_use'
+sil [ossa] @sink_over_enum_no_single_copy_use : $@convention(thin) (@guaranteed Optional<C>) -> @owned C {
+bb0(%0 : @guaranteed $Optional<C>):
+  %2 = copy_value %0
+  fix_lifetime %2
+  switch_enum %2, case #Optional.some!enumelt: bb2, case #Optional.none!enumelt: bb1
+
+bb1:
+  %4 = integer_literal $Builtin.Int1, -1
+  cond_fail %4, "Unexpectedly found nil while unwrapping an Optional value"
+  unreachable
+
+bb2(%7 : @owned $C):
+  return %7
+}
+
+// CHECK-LABEL: sil [ossa] @sink_over_phi_no_single_copy_use :
+// CHECK:       bb1:
+// CHECK-NEXT:    copy_value
+// CHECK:       bb2:
+// CHECK-NEXT:    copy_value
+// CHECK:       } // end sil function 'sink_over_phi_no_single_copy_use'
+sil [ossa] @sink_over_phi_no_single_copy_use : $@convention(thin) (@guaranteed C) -> @owned C {
+bb0(%0 : @guaranteed $C):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %2 = copy_value %0
+  fix_lifetime %2
+  br bb3(%2)
+
+bb2:
+  %4 = copy_value %0
+  br bb3(%4)
+
+
+bb3(%6 : @owned $C):
+  return %6
+}
+
+// CHECK-LABEL: sil [ossa] @cast_does_not_preserve_ownership :
+// CHECK:         %1 = copy_value %0
+// CHECK-NEXT:    checked_cast_br AnyObject in %1 to C
+// CHECK:       } // end sil function 'cast_does_not_preserve_ownership'
+sil [ossa] @cast_does_not_preserve_ownership : $@convention(thin) (@guaranteed AnyObject) -> @owned C {
+bb0(%0 : @guaranteed $AnyObject):
+  %1 = copy_value %0
+  checked_cast_br AnyObject in %1 to C, bb1, bb2
+
+bb1(%3 : @owned $C):
+  br bb3(%3)
+
+
+bb2(%5 : @owned $AnyObject):
+  destroy_value %5
+  unreachable
+
+bb3(%8 : @owned $C):
+  return %8
+}
+
+


### PR DESCRIPTION
This is the OSSA variant of RetainSinking:
The optimization sinks copy instructions (`copy_value`, `load [copy]`) across control flow:

1. Sinks copies over phi nodes:

```
  bb1:
    %1 = copy_value %0
    br bb3(%1)
  bb2:
    %2 = copy_value %0
    br bb3(%2)
  bb3(%3 : @owned):
    // uses of %3
```
->
```
  bb1:
    br bb3(%0)
  bb2:
    br bb3(%0)
  bb3(%3 : @guaranteed):
    %4 = copy_value %3
    // uses of %4
```

2. Sinks copies over terminator instructions (switch_enum, checked_cast_br):

```
  %1 = copy_value %0
  switch_enum %1, case A: bb1, case B: bb2
  bb1(%2 : @owned):
    // uses of %2
  bb2(%3 : @owned):
    // uses of %3
```
->
```
  switch_enum %0, case A: bb1, case B: bb2
  bb1(%2 : @guaranteed):
    %4 = copy_value %2
    // uses of %4
  bb2(%3 : @guaranteed):
    %5 = copy_value %3
    // uses of %5
```

3. Also handles `load [copy]` which is replaced by `load_borrow`:

```
  %1 = load [copy] %addr
  switch_enum %1, case A: bb1, case B: bb2
  bb1(%2 : @owned):
    // uses of %2
  bb2(%3 : @owned):
    // uses of %3
```
->
```
  %1 = load_borrow %addr
  switch_enum %1, case A: bb1, case B: bb2
  bb1(%2 : @guaranteed):
    %4 = copy_value %2
    // uses of %4
    end_borrow %1
  bb2(%3 : @guaranteed):
    %5 = copy_value %3
    // uses of %5
    end_borrow %1
```

The optimization can be done if:
* The `copy_value` or `load [copy]` has a single use.
* The source operand has guaranteed ownership.
* The borrow scope can be extended or is already valid across the control flow.
* For loads: no writes to the loaded address occur before the terminator.

The optimization has several benefits:
* In case of phi-nodes, it reduces the number of `copy_value` instructions which is good for code size
* Also, if the copies are the only instructions in the predecessor block, the predecessor blocks
  become empty which allows simplification of the control flow.
* In case of `switch_enum`, the copy of an enum payload is much simpler than the copy of the whole enum.
* It's more likely that a sunk `copy_value` can be eliminated eventually.