### PR TITLE
[DebugInfo] Keep debug_values as undef in DeadArgumentTransform

### DIFF
--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -141,11 +141,6 @@ bool canDeleteDeadMoveOnlyOwnedDestructureInst(SILInstruction *inst);
 /// free the object.
 bool isIntermediateRelease(SILInstruction *inst, EpilogueARCFunctionInfo *erfi);
 
-/// Recursively collect all the uses and transitive uses of the
-/// instruction.
-void collectUsesOfValue(SILValue V,
-                        llvm::SmallPtrSetImpl<SILInstruction *> &Insts);
-
 /// Recursively erase all of the uses of the value (but not the
 /// value itself)
 void eraseUsesOfValue(SILValue value);

--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
@@ -224,7 +224,8 @@ FunctionSignatureTransformDescriptor::createOptimizedSILFunctionName() {
 /// Collect all archetypes used by a function.
 static bool usesGenerics(SILFunction *F,
                          ArrayRef<SILParameterInfo> InterfaceParams,
-                         ArrayRef<SILResultInfo> InterfaceResults) {
+                         ArrayRef<SILResultInfo> InterfaceResults,
+                         llvm::SmallVector<DebugValueInst *> &DebugUses) {
   CanSILFunctionType FTy = F->getLoweredFunctionType();
   auto HasGenericSignature = FTy->getInvocationGenericSignature() != nullptr;
   if (!HasGenericSignature)
@@ -262,16 +263,16 @@ static bool usesGenerics(SILFunction *F,
     return UsesGenerics;
 
   for (auto &BB : *F) {
-    for (auto &I : BB) {
-      for (auto Arg : BB.getArguments()) {
-        if (&BB != &*F->begin()) {
-          // Scan types of all BB arguments. Ignore the entry BB, because
-          // it is handled in a special way.
-           Arg->getType().getASTType().visit(FindArchetypesAndGenericTypes);
-           if (UsesGenerics)
-             return UsesGenerics;
-        }
+    for (auto Arg : BB.getArguments()) {
+      if (&BB != &*F->begin()) {
+        // Scan types of all BB arguments. Ignore the entry BB, because
+        // it is handled in a special way.
+         Arg->getType().getASTType().visit(FindArchetypesAndGenericTypes);
+         if (UsesGenerics)
+           return UsesGenerics;
       }
+    }
+    for (auto &I : BB) {
       // Scan types of all operands.
       for (auto &Op : I.getAllOperands()) {
         Op.get()->getType().getASTType().visit(FindArchetypesAndGenericTypes);
@@ -299,6 +300,17 @@ static bool usesGenerics(SILFunction *F,
       // Scan the result type of the instruction.
       for (auto V : I.getResults()) {
         V->getType().getASTType().visit(FindArchetypesAndGenericTypes);
+      }
+
+      if (auto *DVI = dyn_cast<DebugValueInst>(&I)) {
+        if (std::optional<SILType> VarType = DVI->getVarInfo()->Type)
+          VarType->getASTType().visit(FindArchetypesAndGenericTypes);
+
+        // If there are only debug uses of the generic, don't keep it.
+        if (UsesGenerics) {
+          UsesGenerics = false;
+          DebugUses.push_back(DVI);
+        }
       }
 
       if (UsesGenerics)
@@ -396,7 +408,9 @@ FunctionSignatureTransformDescriptor::createOptimizedSILFunctionType() {
     // callee at the LLVM IR level.
     // TODO: Implement a more precise analysis, so that we can eliminate only
     // those generic parameters which are not used.
-    UsesGenerics = usesGenerics(F, InterfaceParams, InterfaceResults);
+    llvm::SmallVector<DebugValueInst *> DebugUses;
+    UsesGenerics = usesGenerics(F, InterfaceParams, InterfaceResults,
+                                DebugUses);
 
     // The set of used archetypes is complete now.
     if (!UsesGenerics) {
@@ -412,6 +426,24 @@ FunctionSignatureTransformDescriptor::createOptimizedSILFunctionType() {
                  for (auto Result : InterfaceResults) {
                    Result.getInterfaceType().dump(llvm::dbgs());
                  });
+
+      // If there are only debug uses of the generics, rewrite them.
+      // They cannot use the removed generic type in any way (fragment,
+      // var type, and operand type).
+      // The variable is replaced with an empty tuple as a placeholder, as in
+      // this case, the whole type is removed and there's no other way to
+      // represent that.
+      auto VoidTy = SILType::getEmptyTupleType(F->getASTContext());
+      SILValue Undef = SILUndef::get(F, VoidTy);
+      for (auto *DVI : DebugUses) {
+        SILDebugVariable VarInfo = DVI->getCompleteVarInfo();
+        VarInfo.Type = VoidTy;
+        VarInfo.DIExpr = {};
+
+        SILBuilder Builder(DVI, DVI->getDebugScope());
+        Builder.createDebugValue(DVI->getLoc(), Undef, VarInfo);
+        DVI->eraseFromParent();
+      }
     }
   }
 

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -312,28 +312,37 @@ void swift::recursivelyDeleteTriviallyDeadInstructions(
   recursivelyDeleteTriviallyDeadInstructions(ai, force, callbacks);
 }
 
-void swift::collectUsesOfValue(SILValue v,
-                               llvm::SmallPtrSetImpl<SILInstruction *> &insts) {
+/// Recursively collect non-debug uses of a value
+static void
+collectNonDebugUsesOfValue(SILValue v,
+                           llvm::SmallPtrSetImpl<SILInstruction *> &insts) {
   for (auto ui = v->use_begin(), E = v->use_end(); ui != E; ++ui) {
     auto *user = ui->getUser();
+    
+    // Debug values should not be removed.
+    if (isa<DebugValueInst>(user))
+      continue;
+    
     // Instruction has been processed.
     if (!insts.insert(user).second)
       continue;
 
     // Collect the users of this instruction.
     for (auto result : user->getResults())
-      collectUsesOfValue(result, insts);
+      collectNonDebugUsesOfValue(result, insts);
   }
 }
 
 void swift::eraseUsesOfValue(SILValue v) {
   llvm::SmallPtrSet<SILInstruction *, 4> insts;
   // Collect the uses.
-  collectUsesOfValue(v, insts);
+  collectNonDebugUsesOfValue(v, insts);
   // Erase the uses, we can have instructions that become dead because
   // of the removal of these instructions, leave to DCE to cleanup.
   // Its not safe to do recursively delete here as some of the SILInstruction
   // maybe tracked by this set.
+  // Debug uses will have their operand changed to undef without being erased.
+  v->replaceAllUsesWithUndef();
   for (auto inst : insts) {
     inst->replaceAllUsesOfAllResultsWithUndef();
     inst->eraseFromParent();

--- a/test/DebugInfo/deadargsignatureopt.sil
+++ b/test/DebugInfo/deadargsignatureopt.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all -dead-arg-signature-opt %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -dead-arg-signature-opt -function-signature-opts %s | %FileCheck %s
 
 // Test that debug_value instructions referencing dead arguments are preserved
 // (with undef operand) in the specialized function.
@@ -35,4 +35,32 @@ bb0:
   %1 = function_ref @one_arg_dead : $@convention(method) (Int32, Int32, @thin Int32.Type) -> Bool
   %2 = partial_apply %1(%0) : $@convention(method) (Int32, Int32, @thin Int32.Type) -> Bool
   return %2 : $@callee_owned (Int32, Int32) -> Bool
+}
+
+// Test that when a generic function has a dead self argument whose type carries
+// the generic parameter, and only debug_value instructions reference that type,
+// the optimization removes the generic signature and rewrites the debug_value
+// to use Void.
+
+class Foo<T> {}
+
+// CHECK-LABEL: sil shared @$s11generic_barTf4d_n : $@convention(thin) () -> () {
+// CHECK:         debug_value undef : $(), let, name "self"
+// CHECK:         return
+// CHECK-LABEL: } // end sil function '$s11generic_barTf4d_n'
+sil @generic_bar : $@convention(method) <T> (@guaranteed Foo<T>) -> () {
+bb0(%0 : $Foo<T>):
+  debug_value %0 : $Foo<T>, let, name "self", type $Foo<T>
+  %t = tuple ()
+  return %t : $()
+}
+
+sil @call_generic_bar : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref $Foo<Int>
+  %1 = function_ref @generic_bar : $@convention(method) <T> (@guaranteed Foo<T>) -> ()
+  %2 = apply %1<Int>(%0) : $@convention(method) <T> (@guaranteed Foo<T>) -> ()
+  strong_release %0 : $Foo<Int>
+  %t = tuple ()
+  return %t : $()
 }

--- a/test/DebugInfo/deadargsignatureopt.sil
+++ b/test/DebugInfo/deadargsignatureopt.sil
@@ -1,0 +1,38 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -dead-arg-signature-opt %s | %FileCheck %s
+
+// Test that debug_value instructions referencing dead arguments are preserved
+// (with undef operand) in the specialized function.
+// TODO: The debug_values for function arguments should also be kept in the
+// thunk (the original function), not only the specialized one.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+// CHECK-LABEL: sil shared @$s12one_arg_deadTf4nnd_n
+// CHECK:       bb0(%0 : $Int32, %1 : $Int32):
+// CHECK:         debug_value %0, let, name "lhs"
+// CHECK:         debug_value %1, let, name "rhs"
+// CHECK:         debug_value undef : $@thin Int32.Type, let, name "self"
+// CHECK:         return
+// CHECK-LABEL: } // end sil function '$s12one_arg_deadTf4nnd_n'
+sil @one_arg_dead : $@convention(method) (Int32, Int32, @thin Int32.Type) -> Bool {
+bb0(%0 : $Int32, %1 : $Int32, %2 : $@thin Int32.Type):
+  debug_value %0 : $Int32, let, name "lhs"
+  debug_value %1 : $Int32, let, name "rhs"
+  debug_value %2 : $@thin Int32.Type, let, name "self"
+  %5 = struct_extract %0 : $Int32, #Int32._value
+  %6 = struct_extract %1 : $Int32, #Int32._value
+  %7 = builtin "cmp_slt_Int32"(%5 : $Builtin.Int32, %6 : $Builtin.Int32) : $Builtin.Int1
+  %8 = struct $Bool (%7 : $Builtin.Int1)
+  return %8 : $Bool
+}
+
+sil @partial_apply_one_arg_dead : $@convention(thin) () -> @owned @callee_owned (Int32, Int32) -> Bool {
+bb0:
+  %0 = metatype $@thin Int32.Type
+  %1 = function_ref @one_arg_dead : $@convention(method) (Int32, Int32, @thin Int32.Type) -> Bool
+  %2 = partial_apply %1(%0) : $@convention(method) (Int32, Int32, @thin Int32.Type) -> Bool
+  return %2 : $@callee_owned (Int32, Int32) -> Bool
+}


### PR DESCRIPTION
Rather than erasing the debug values, they must be kept as undef, as there is no way to salvage a removed argument.

This affects a function optimised by FunctionSignatureOpts for the dead argument case.
Note that the thunk left by FunctionSignatureOpts is still missing its argument debug_values, this will be fixed by a future PR.

Example:
```swift
@inline(never)
func foo(a: Int, b: Bool) {
    assert(b)
    print(a)
}

foo(a: 42, b: true)
foo(a: 8129, b: true)
foo(a: -6, b: true)
```

Before, within the specialized foo, only `a` was shown within LLDB as being an argument.
After, both `a` and `b` are shown as arguments, with `b` being shown as optimized out.
The thunk still shows no argument.

This decreases the variables lost by FunctionSignatureOpts by 27% with the detection from #90860 applied.

At the DWARF level, increases the amount of variables by 0.2% in the standard library