### PR TITLE
IRGen: Adjust to "[CHERI] Allow @llvm.returnaddress to return a pointer in any address space. (#188464)"

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -7244,9 +7244,12 @@ void IRGenSILFunction::visitBeginUnpairedAccessInst(
     if (IGM.Triple.isWasm() || hasBeenInlined(access)) {
       pc = llvm::ConstantPointerNull::get(IGM.Int8PtrTy);
     } else {
-      pc =
-          Builder.CreateIntrinsicCall(llvm::Intrinsic::returnaddress,
-                                      {llvm::ConstantInt::get(IGM.Int32Ty, 0)});
+      pc = Builder.CreateIntrinsicCall(
+          llvm::Intrinsic::returnaddress,
+          // returnaddress is overloaded on the returned pointer type;
+          // `swift_beginAccess` parameter `pc` is a `ptr` in the default
+          // address space.
+          /*typeArgs=*/{IGM.PtrTy}, {llvm::ConstantInt::get(IGM.Int32Ty, 0)});
     }
 
     auto call = Builder.CreateCall(IGM.getBeginAccessFunctionPointer(),


### PR DESCRIPTION
llvm-project changed `@llvm.returnaddress` to return `llvm_anyptr_ty` instead of `ptr`, making it an overloaded intrinsic whose returned pointer type must now be provided as an overload type. Swift emitted the intrinsic call through the no-type-argument `CreateIntrinsicCall` overload, so `DecodeFixedType` read past the empty type array and crashed. Use `ptr` as the return type to preserve behaviour.

See https://github.com/llvm/llvm-project/commit/ca9ac0e24abb63281db6ec7c2d3a262984aa00f6 (https://github.com/llvm/llvm-project/pull/188464).