### PR TITLE
Adjust to "[ADT] Remove unused DenseMapInfo::getEmptyKey (#201998)"

### DIFF
--- a/include/swift/AST/Builtins.h
+++ b/include/swift/AST/Builtins.h
@@ -132,8 +132,7 @@ public:
 
 /// The information identifying the llvm intrinsic - its id and types.
 class IntrinsicInfo {
-  mutable llvm::AttributeSet FnAttrs =
-      llvm::DenseMapInfo<llvm::AttributeSet>::getEmptyKey();
+  mutable std::optional<llvm::AttributeSet> FnAttrs;
 
 public:
   llvm::Intrinsic::ID ID;

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -584,12 +584,7 @@ private:
 void simple_display(raw_ostream &out, GenericSignature sig);
 
 inline bool CanGenericSignature::isActuallyCanonicalOrNull() const {
-  return getPointer() == nullptr ||
-         getPointer() ==
-             llvm::DenseMapInfo<GenericSignatureImpl *>::getEmptyKey() ||
-         getPointer() ==
-             llvm::DenseMapInfo<GenericSignatureImpl *>::getTombstoneKey() ||
-         getPointer()->isCanonical();
+  return getPointer() == nullptr || getPointer()->isCanonical();
 }
 
 int compareAssociatedTypes(AssociatedTypeDecl *assocType1,

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -8648,10 +8648,7 @@ inline CanType CanType::getNominalParent() const {
 }
 
 inline bool CanType::isActuallyCanonicalOrNull() const {
-  return getPointer() == nullptr ||
-         getPointer() == llvm::DenseMapInfo<TypeBase *>::getEmptyKey() ||
-         getPointer() == llvm::DenseMapInfo<TypeBase *>::getTombstoneKey() ||
-         getPointer()->isCanonical();
+  return getPointer() == nullptr || getPointer()->isCanonical();
 }
 
 inline TupleTypeElt TupleTypeElt::getWithName(Identifier name) const {

--- a/include/swift/Basic/Located.h
+++ b/include/swift/Basic/Located.h
@@ -61,16 +61,6 @@ template<typename T>
 struct DenseMapInfo<swift::Located<T>> {
   using SourceLoc = swift::SourceLoc;
 
-  static inline swift::Located<T> getEmptyKey() {
-    return swift::Located<T>(DenseMapInfo<T>::getEmptyKey(),
-                             DenseMapInfo<SourceLoc>::getEmptyKey());
-  }
-
-  static inline swift::Located<T> getTombstoneKey() {
-    return swift::Located<T>(DenseMapInfo<T>::getTombstoneKey(),
-                             DenseMapInfo<SourceLoc>::getTombstoneKey());
-  }
-
   static unsigned getHashValue(const swift::Located<T> &LocatedVal) {
     return detail::combineHashValue(DenseMapInfo<T>::getHashValue(LocatedVal.Item),
                             DenseMapInfo<SourceLoc>::getHashValue(LocatedVal.Loc));

--- a/include/swift/Remote/RemoteAddress.h
+++ b/include/swift/Remote/RemoteAddress.h
@@ -259,14 +259,14 @@ struct hash<swift::remote::RemoteAddress> {
 namespace llvm {
 template <>
 struct DenseMapInfo<swift::remote::RemoteAddress> {
+  // Do not remove: stdlib/include/llvm/ADT/DenseMap.h still needs this
   static swift::remote::RemoteAddress getEmptyKey() {
-    return swift::remote::RemoteAddress(DenseMapInfo<uint64_t>::getEmptyKey(),
-                                        0);
+    return swift::remote::RemoteAddress(~0ULL, 0);
   }
 
+  // Do not remove: stdlib/include/llvm/ADT/DenseMap.h still needs this.
   static swift::remote::RemoteAddress getTombstoneKey() {
-    return swift::remote::RemoteAddress(
-        DenseMapInfo<uint64_t>::getTombstoneKey(), 0);
+    return swift::remote::RemoteAddress(~0ULL - 1ULL, 0);
   }
 
   static unsigned getHashValue(swift::remote::RemoteAddress address) {

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -49,12 +49,11 @@ bool BuiltinInfo::isReadNone() const {
 
 const llvm::AttributeSet &
 IntrinsicInfo::getOrCreateFnAttributes(ASTContext &Ctx) const {
-  using DenseMapInfo = llvm::DenseMapInfo<llvm::AttributeSet>;
-  if (DenseMapInfo::isEqual(FnAttrs, DenseMapInfo::getEmptyKey())) {
+  if (!FnAttrs) {
     FnAttrs =
         llvm::Intrinsic::getFnAttributes(Ctx.getIntrinsicScratchContext(), ID);
   }
-  return FnAttrs;
+  return FnAttrs.value();
 }
 
 Type swift::getBuiltinType(ASTContext &Context, StringRef Name) {

--- a/lib/IRGen/Address.h
+++ b/lib/IRGen/Address.h
@@ -41,9 +41,6 @@ public:
 
   Address(llvm::Value *addr, llvm::Type *elementType, Alignment align)
       : Addr(addr), ElementType(elementType), Align(align) {
-    if (addr == llvm::DenseMapInfo<llvm::Value *>::getEmptyKey() ||
-        llvm::DenseMapInfo<llvm::Value *>::getTombstoneKey())
-      return;
     assert(addr != nullptr && "building an invalid address");
   }
 


### PR DESCRIPTION
After the `DenseMap` redesign (#201281/#200595) made DenseMap no longer create empty/tombstone buckets, `DenseMapInfo::getEmptyKey` and `DenseMapInfo::getTombstoneKey` were removed.

Stop relying on the removed partial specialisations, but defer the removal of our own specialisations to a post-rebranch date.

See:
- https://github.com/llvm/llvm-project/commit/836bf567e622a2e083a0c850b861b450fc97b915 (https://github.com/llvm/llvm-project/pull/200959).
- https://github.com/llvm/llvm-project/commit/11496fa35dfdf9a84c82d2c6181e54caf7288fce (https://github.com/llvm/llvm-project/pull/201998).