### PR TITLE
Revert "NameLookup: don't inherit non-inheritable factory inits from a superclass extension onto subclasses. rdar://179736474"

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2476,9 +2476,7 @@ static bool isAcceptableLookupResult(const DeclContext *dc, NLOptions options,
   // Filter out designated initializers, if requested.
   if (onlyCompleteObjectInits) {
     if (auto ctor = dyn_cast<ConstructorDecl>(decl)) {
-      // getSelfClassDecl() (not isa<ClassDecl>) so a non-inheritable init in a
-      // class extension (e.g. an imported ObjC category factory) is filtered too.
-      if (ctor->getDeclContext()->getSelfClassDecl() && !ctor->isInheritable())
+      if (isa<ClassDecl>(ctor->getDeclContext()) && !ctor->isInheritable())
         return false;
     } else {
       return false;

--- a/test/ClangImporter/objc_factory_method.swift
+++ b/test/ClangImporter/objc_factory_method.swift
@@ -27,13 +27,6 @@ func testInstanceTypeFactoryMethodInherited() {
   _ = a
 }
 
-func testCategoryFactoryMethodNotInheritedAsInit() {
-  // Category factory init: callable on its own class...
-  _ = NSObjectFactory(flag: 1)
-  // ...but not inherited as an initializer onto a subclass.
-  _ = NSObjectFactorySub(flag: 1) // expected-error{{incorrect argument label in call (have 'flag:', expected 'integer:')}}
-}
-
 func testFactoryWithLaterIntroducedInit() {
     // expected-note @-1 4{{add '@available' attribute to enclosing global function}}
   // Prefer importing more available factory initializer over less

--- a/test/Inputs/clang-importer-sdk/usr/include/AppKit.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/AppKit.h
@@ -120,12 +120,6 @@
 @interface NSObjectFactorySub : NSObjectFactory
 @end
 
-// Fixed-result factory method in a category; must not be inherited as an
-// initializer onto subclasses.
-@interface NSObjectFactory (Extras)
-+(NSObjectFactory *)factoryWithFlag:(NSInteger)flag;
-@end
-
 @interface NSHavingConvenienceFactoryAndLaterConvenienceInit : NSObject
 -(instancetype)initWithStuff:(NSObject *)stuff NS_DESIGNATED_INITIALIZER;
 


### PR DESCRIPTION
Reverts swiftlang/swift#90401

Address: rdar://182329015