### PR TITLE
[cxx-interop] Add the @cxx attribute surface

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -962,6 +962,12 @@ BridgedCDeclAttr BridgedCDeclAttr_createParsed(BridgedASTContext cContext,
                                                BridgedStringRef cName,
                                                bool underscored);
 
+SWIFT_NAME("BridgedCxxDeclAttr.createParsed(_:atLoc:range:name:)")
+BridgedCxxDeclAttr BridgedCxxDeclAttr_createParsed(BridgedASTContext cContext,
+                                                   swift::SourceLoc atLoc,
+                                                   swift::SourceRange range,
+                                                   BridgedStringRef cName);
+
 SWIFT_NAME("BridgedCustomAttr.createParsed(atLoc:type:declContext:initContext:"
            "argumentList:)")
 BridgedCustomAttr BridgedCustomAttr_createParsed(

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -963,6 +963,12 @@ BridgedCDeclAttr BridgedCDeclAttr_createParsed(BridgedASTContext cContext,
                                                BridgedStringRef cName,
                                                bool underscored);
 
+SWIFT_NAME("BridgedCxxDeclAttr.createParsed(_:atLoc:range:name:)")
+BridgedCxxDeclAttr BridgedCxxDeclAttr_createParsed(BridgedASTContext cContext,
+                                                   swift::SourceLoc atLoc,
+                                                   swift::SourceRange range,
+                                                   BridgedStringRef cName);
+
 SWIFT_NAME("BridgedCustomAttr.createParsed(atLoc:type:declContext:initContext:"
            "argumentList:)")
 BridgedCustomAttr BridgedCustomAttr_createParsed(

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -794,6 +794,35 @@ public:
   }
 };
 
+/// Defines the @cxx attribute.
+class CxxDeclAttr : public DeclAttribute {
+public:
+  CxxDeclAttr(StringRef Name, SourceLoc AtLoc, SourceRange Range, bool Implicit)
+      : DeclAttribute(DeclAttrKind::CxxDecl, AtLoc, Range, Implicit),
+        Name(Name) {}
+
+  CxxDeclAttr(StringRef Name, bool Implicit)
+      : CxxDeclAttr(Name, SourceLoc(), SourceRange(), Implicit) {}
+
+  /// The C++ function name to match against (empty means use the base
+  /// identifier). This is the C++ source name the importer looks up, it is not
+  /// a mangled symbol. The emitted symbol comes from the matched C++
+  /// declaration's mangling.
+  const StringRef Name;
+
+  static bool classof(const DeclAttribute *DA) {
+    return DA->getKind() == DeclAttrKind::CxxDecl;
+  }
+
+  CxxDeclAttr *clone(ASTContext &ctx) const {
+    return new (ctx) CxxDeclAttr(Name, AtLoc, Range, isImplicit());
+  }
+
+  bool isEquivalent(const CxxDeclAttr *other, Decl *attachedTo) const {
+    return Name == other->Name;
+  }
+};
+
 /// Defines the @_semantics attribute.
 class SemanticsAttr : public DeclAttribute {
 public:

--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -939,7 +939,13 @@ DECL_ATTR(called, Called,
   177)
 DECL_ATTR_FEATURE_REQUIREMENT(Called, CalledAttribute)
 
-LAST_DECL_ATTR(Called)
+DECL_ATTR(cxx, CxxDecl,
+  OnFunc,
+  LongAttribute | ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove | ForbiddenInABIAttr,
+  178)
+DECL_ATTR_FEATURE_REQUIREMENT(CxxDecl, CxxImplementation)
+
+LAST_DECL_ATTR(CxxDecl)
 
 #undef DECL_ATTR_ALIAS
 #undef CONTEXTUAL_DECL_ATTR_ALIAS

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1586,6 +1586,13 @@ ERROR(attr_com_unknown_label, none,
 ERROR(attr_com_unknown_threading_model, none,
       "unknown threading model '%0'; expected 'single', 'apartment', 'free', 'both', or 'neutral'", (StringRef))
 
+// @cxx
+ERROR(attr_expected_cxx_name,none,
+      "expected C++ function name in '%0' attribute", (StringRef))
+ERROR(attr_cxx_operator_name_backticks,none,
+      "C++ operator name in '%0' attribute must be enclosed in backticks",
+      (StringRef))
+
 ERROR(alignment_must_be_positive_integer,none,
       "alignment value must be a positive integer literal", ())
 

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1586,6 +1586,10 @@ ERROR(attr_com_unknown_label, none,
 ERROR(attr_com_unknown_threading_model, none,
       "unknown threading model '%0'; expected 'single', 'apartment', 'free', 'both', or 'neutral'", (StringRef))
 
+// @cxx
+ERROR(attr_cxx_empty_name,none,
+      "C++ function name in 'cxx' attribute cannot be empty", ())
+
 ERROR(alignment_must_be_positive_integer,none,
       "alignment value must be a positive integer literal", ())
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2199,6 +2199,21 @@ ERROR(cdecl_incompatible_with_objc,none,
       "cannot apply both '@c' and '@objc' to %kindonly0",
       (const Decl *))
 
+// @cxx
+ERROR(cxx_attr_requires_cxx_interop,none,
+      "'%0' requires C++ interoperability; enable it with "
+      "'-cxx-interoperability-mode=default' or "
+      "'-enable-experimental-cxx-interop'", (StringRef))
+ERROR(cxx_incompatible_with_objc,none,
+      "cannot apply both '@cxx' and '@objc' to %kindonly0",
+      (const Decl *))
+ERROR(cxx_incompatible_with_cdecl,none,
+      "cannot apply both '@cxx' and '%0' to %kindonly1",
+      (DeclAttribute, const Decl *))
+ERROR(cxx_attr_requires_implementation,none,
+      "'@cxx' must be combined with '@implementation'",
+      ())
+
 // @used and @section
 ERROR(section_empty_name,none,
       "'@section' section name cannot be empty", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2218,6 +2218,21 @@ ERROR(cdecl_incompatible_with_objc,none,
       "cannot apply both '@c' and '@objc' to %kindonly0",
       (const Decl *))
 
+// @cxx
+ERROR(cxx_attr_requires_cxx_interop,none,
+      "'%0' requires C++ interoperability; enable it with "
+      "'-cxx-interoperability-mode=default' or "
+      "'-enable-experimental-cxx-interop'", (StringRef))
+ERROR(cxx_incompatible_with_objc,none,
+      "cannot apply both '@cxx' and '@objc' to %kindonly0",
+      (const Decl *))
+ERROR(cxx_incompatible_with_cdecl,none,
+      "cannot apply both '@cxx' and '%0' to %kindonly1",
+      (DeclAttribute, const Decl *))
+ERROR(cxx_attr_requires_implementation,none,
+      "'@cxx' must be combined with '@implementation'",
+      ())
+
 // @used and @section
 ERROR(section_empty_name,none,
       "'@section' section name cannot be empty", ())

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -539,6 +539,9 @@ EXPERIMENTAL_FEATURE(ImportCxxMembersLazily, true)
 /// superclass.
 EXPERIMENTAL_FEATURE(ForeignReferenceTypeInheritance, true)
 
+/// Enable @cxx @implementation for implementing C++ functions in Swift.
+EXPERIMENTAL_FEATURE(CxxImplementation, true)
+
 /// `yielding borrow`/`yielding mutate` single-yield coroutine accessors
 // TODO: When this is turned on by default, take care of:
 // * "TODO" around line 8100 of lib/Parse/ParseDecl.cpp

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -532,6 +532,9 @@ EXPERIMENTAL_FEATURE(ImportCxxMembersLazily, true)
 /// superclass.
 LANGUAGE_FEATURE(ForeignReferenceTypeInheritance, 0, "foreign reference type inheritance hierarchy")
 
+/// Enable @cxx @implementation for implementing C++ functions in Swift.
+EXPERIMENTAL_FEATURE(CxxImplementation, true)
+
 /// `yielding borrow`/`yielding mutate` single-yield coroutine accessors
 // TODO: When this is turned on by default, take care of:
 // * "TODO" around line 8100 of lib/Parse/ParseDecl.cpp

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -5278,6 +5278,11 @@ public:
     printFieldQuoted(Attr->Name, Label::always("name"));
     printFoot();
   }
+  void visitCxxDeclAttr(CxxDeclAttr *Attr, Label label) {
+    printCommon(Attr, "cxx_decl_attr", label);
+    printFieldQuoted(Attr->Name, Label::always("name"));
+    printFoot();
+  }
   void
   visitClangImporterSynthesizedTypeAttr(ClangImporterSynthesizedTypeAttr *Attr,
                                         Label label) {

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -5283,6 +5283,11 @@ public:
     printFieldQuoted(Attr->Name, Label::always("name"));
     printFoot();
   }
+  void visitCxxDeclAttr(CxxDeclAttr *Attr, Label label) {
+    printCommon(Attr, "cxx_decl_attr", label);
+    printFieldQuoted(Attr->Name, Label::always("name"));
+    printFoot();
+  }
   void
   visitClangImporterSynthesizedTypeAttr(ClangImporterSynthesizedTypeAttr *Attr,
                                         Label label) {

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1326,6 +1326,14 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     break;
   }
 
+  case DeclAttrKind::CxxDecl: {
+    auto Attr = cast<CxxDeclAttr>(this);
+    Printer << "@cxx";
+    if (!Attr->Name.empty())
+      Printer << "(" << identifierEscapingIfNeeded(Attr->Name) << ")";
+    break;
+  }
+
   case DeclAttrKind::Expose: {
     Printer.printAttrName("@_expose");
     auto Attr = cast<ExposeAttr>(this);
@@ -1989,6 +1997,8 @@ StringRef DeclAttribute::getAttrName() const {
     if (cast<CDeclAttr>(this)->Underscored)
       return "_cdecl";
     return "c";
+  case DeclAttrKind::CxxDecl:
+    return "cxx";
   case DeclAttrKind::SwiftNativeObjCRuntimeBase:
     return "_swift_native_objc_runtime_base";
   case DeclAttrKind::Semantics:

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1322,6 +1322,14 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     break;
   }
 
+  case DeclAttrKind::CxxDecl: {
+    auto Attr = cast<CxxDeclAttr>(this);
+    Printer << "@cxx";
+    if (!Attr->Name.empty())
+      Printer << "(\"" << Attr->Name << "\")";
+    break;
+  }
+
   case DeclAttrKind::Expose: {
     Printer.printAttrName("@_expose");
     auto Attr = cast<ExposeAttr>(this);
@@ -1985,6 +1993,8 @@ StringRef DeclAttribute::getAttrName() const {
     if (cast<CDeclAttr>(this)->Underscored)
       return "_cdecl";
     return "c";
+  case DeclAttrKind::CxxDecl:
+    return "cxx";
   case DeclAttrKind::SwiftNativeObjCRuntimeBase:
     return "_swift_native_objc_runtime_base";
   case DeclAttrKind::Semantics:

--- a/lib/AST/Bridging/DeclAttributeBridging.cpp
+++ b/lib/AST/Bridging/DeclAttributeBridging.cpp
@@ -239,6 +239,14 @@ BridgedCDeclAttr BridgedCDeclAttr_createParsed(BridgedASTContext cContext,
                 /*Implicit=*/false, /*Underscored*/ underscored);
 }
 
+BridgedCxxDeclAttr BridgedCxxDeclAttr_createParsed(BridgedASTContext cContext,
+                                                   SourceLoc atLoc,
+                                                   SourceRange range,
+                                                   BridgedStringRef cName) {
+  return new (cContext.unbridged())
+      CxxDeclAttr(cName.unbridged(), atLoc, range, /*Implicit=*/false);
+}
+
 BridgedCustomAttr BridgedCustomAttr_createParsed(
     SourceLoc atLoc, BridgedTypeRepr cType, BridgedDeclContext cDeclContext,
     BridgedNullableCustomAttributeInitializer cInitContext,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5058,13 +5058,15 @@ StringRef ValueDecl::getCDeclName() const {
   if (!abiRole.providesAPI() && abiRole.getCounterpart())
     return abiRole.getCounterpart()->getCDeclName();
 
-  // Handle explicit cdecl attributes.
-  if (auto cdeclAttr = getAttrs().getAttribute<CDeclAttr>()) {
-    if (!cdeclAttr->Name.empty())
-      return cdeclAttr->Name;
-    else
-      return getBaseIdentifier().str();
-  }
+  // Handle explicit @c/@_cdecl and @cxx attributes. Both store an optional
+  // explicit name and fall back to the base identifier when it is empty.
+  auto nameOrBaseIdentifier = [&](StringRef name) -> StringRef {
+    return name.empty() ? getBaseIdentifier().str() : name;
+  };
+  if (auto cdeclAttr = getAttrs().getAttribute<CDeclAttr>())
+    return nameOrBaseIdentifier(cdeclAttr->Name);
+  if (auto cxxAttr = getAttrs().getAttribute<CxxDeclAttr>())
+    return nameOrBaseIdentifier(cxxAttr->Name);
 
   return "";
 }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5002,13 +5002,15 @@ StringRef ValueDecl::getCDeclName() const {
   if (!abiRole.providesAPI() && abiRole.getCounterpart())
     return abiRole.getCounterpart()->getCDeclName();
 
-  // Handle explicit cdecl attributes.
-  if (auto cdeclAttr = getAttrs().getAttribute<CDeclAttr>()) {
-    if (!cdeclAttr->Name.empty())
-      return cdeclAttr->Name;
-    else
-      return getBaseIdentifier().str();
-  }
+  // Handle explicit @c/@_cdecl and @cxx attributes. Both store an optional
+  // explicit name and fall back to the base identifier when it is empty.
+  auto nameOrBaseIdentifier = [&](StringRef name) -> StringRef {
+    return name.empty() ? getBaseIdentifier().str() : name;
+  };
+  if (auto cdeclAttr = getAttrs().getAttribute<CDeclAttr>())
+    return nameOrBaseIdentifier(cdeclAttr->Name);
+  if (auto cxxAttr = getAttrs().getAttribute<CxxDeclAttr>())
+    return nameOrBaseIdentifier(cxxAttr->Name);
 
   return "";
 }

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -488,6 +488,7 @@ UNINTERESTING_FEATURE(ImportNonPublicCxxMembers)
 UNINTERESTING_FEATURE(ImportCxxMembersLazily)
 UNINTERESTING_FEATURE(ImportUnsafeCxxMethodsAsAlwaysUnsafe)
 UNINTERESTING_FEATURE(ForeignReferenceTypeInheritance)
+UNINTERESTING_FEATURE(CxxImplementation)
 UNINTERESTING_FEATURE(CoroutineAccessorsUnwindOnCallerError)
 UNINTERESTING_FEATURE(AllowRuntimeSymbolDeclarations)
 

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -484,6 +484,7 @@ UNINTERESTING_FEATURE(AssumeResilientCxxTypes)
 UNINTERESTING_FEATURE(ImportNonPublicCxxMembers)
 UNINTERESTING_FEATURE(ImportCxxMembersLazily)
 UNINTERESTING_FEATURE(ForeignReferenceTypeInheritance)
+UNINTERESTING_FEATURE(CxxImplementation)
 UNINTERESTING_FEATURE(CoroutineAccessorsUnwindOnCallerError)
 UNINTERESTING_FEATURE(AllowRuntimeSymbolDeclarations)
 

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -140,6 +140,8 @@ extension ASTGenVisitor {
         return handle(self.generateCDeclAttr(attribute: node)?.asDeclAttribute)
       case .COM:
         return handle(self.generateCOMAttr(attribute: node)?.asDeclAttribute)
+      case .CxxDecl:
+        return handle(self.generateCxxDeclAttr(attribute: node)?.asDeclAttribute)
       case .Derivative:
         return handle(self.generateDerivativeAttr(attribute: node)?.asDeclAttribute)
       case .Differentiable:
@@ -598,6 +600,33 @@ extension ASTGenVisitor {
       range: self.generateAttrSourceRange(node),
       name: name ?? "",
       underscored: underscored
+    )
+  }
+
+  func generateCxxDeclAttr(attribute node: AttributeSyntax) -> BridgedCxxDeclAttr? {
+    // The optional identifier argument is the C++ function name the importer
+    // matches against.
+    var name: BridgedStringRef = ""
+    if node.arguments != nil {
+      guard let parsed = self.generateWithLabeledExprListArguments(attribute: node, { args in
+        self.generateConsumingPlainIdentifierAttrOption(args: &args) { (token) -> BridgedStringRef? in
+          var text = token.rawText
+          if text.count > 2 && text.hasPrefix("`") && text.hasSuffix("`") {
+            text = .init(rebasing: text.dropFirst().dropLast())
+          }
+          return text.bridged
+        }
+      }) else {
+        return nil
+      }
+      name = parsed
+    }
+
+    return .createParsed(
+      self.ctx,
+      atLoc: self.generateSourceLoc(node.atSign),
+      range: self.generateAttrSourceRange(node),
+      name: name
     )
   }
 

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -140,6 +140,8 @@ extension ASTGenVisitor {
         return handle(self.generateCDeclAttr(attribute: node)?.asDeclAttribute)
       case .COM:
         return handle(self.generateCOMAttr(attribute: node)?.asDeclAttribute)
+      case .CxxDecl:
+        return handle(self.generateCxxDeclAttr(attribute: node)?.asDeclAttribute)
       case .Derivative:
         return handle(self.generateDerivativeAttr(attribute: node)?.asDeclAttribute)
       case .Differentiable:
@@ -598,6 +600,32 @@ extension ASTGenVisitor {
       range: self.generateAttrSourceRange(node),
       name: name ?? "",
       underscored: underscored
+    )
+  }
+
+  func generateCxxDeclAttr(attribute node: AttributeSyntax) -> BridgedCxxDeclAttr? {
+    // The optional string-literal argument is the C++ function name the
+    // importer matches against.
+    var name: BridgedStringRef = ""
+    if node.arguments != nil {
+      guard let parsed = self.generateWithLabeledExprListArguments(attribute: node, { args in
+        self.generateConsumingSimpleStringLiteralAttrOption(args: &args)
+      }) else {
+        return nil
+      }
+      // An explicit name must not be empty.
+      if parsed.count == 0 {
+        self.diagnose(.emptyCxxAttributeName(node))
+        return nil
+      }
+      name = parsed
+    }
+
+    return .createParsed(
+      self.ctx,
+      atLoc: self.generateSourceLoc(node.atSign),
+      range: self.generateAttrSourceRange(node),
+      name: name
     )
   }
 

--- a/lib/ASTGen/Sources/ASTGen/Diagnostics.swift
+++ b/lib/ASTGen/Sources/ASTGen/Diagnostics.swift
@@ -185,6 +185,13 @@ extension ASTGenDiagnostic {
       message: "argument cannot be an interpolated string literal"
     )
   }
+
+  static func emptyCxxAttributeName(_ attribute: AttributeSyntax) -> Self {
+    Self(
+      node: attribute,
+      message: "C++ function name in 'cxx' attribute cannot be empty"
+    )
+  }
 }
 
 extension ASTGenDiagnostic {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3118,6 +3118,49 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     break;
   }
 
+  case DeclAttrKind::CxxDecl: {
+    StringRef CxxName;
+    if (consumeIfAttributeLParen()) {
+      // The optional identifier argument is the C++ function name the
+      // importer matches against.
+      auto skipToEnd = [&]() {
+        skipUntil(tok::r_paren);
+        consumeIf(tok::r_paren);
+      };
+
+      // A C++ operator name spelled without backticks lexes as Swift's
+      // 'operator' keyword followed by further tokens. Give it a targeted
+      // error.
+      if (Tok.is(tok::kw_operator) &&
+          peekToken().isNot(tok::r_paren, tok::colon)) {
+        diagnose(Loc, diag::attr_cxx_operator_name_backticks, AttrName);
+        skipToEnd();
+        return makeParserSuccess();
+      }
+
+      if (Tok.isNot(tok::identifier) || peekToken().is(tok::colon)) {
+        diagnose(Loc, diag::attr_expected_cxx_name, AttrName);
+        skipToEnd();
+        return makeParserSuccess();
+      }
+      CxxName = Tok.getText();
+      consumeToken(tok::identifier);
+
+      AttrRange = SourceRange(Loc, Tok.getRange().getStart());
+      if (!consumeIf(tok::r_paren)) {
+        diagnose(Loc, diag::attr_expected_rparen, AttrName,
+                 DeclAttribute::isDeclModifier(DK));
+        return makeParserSuccess();
+      }
+    } else {
+      AttrRange = SourceRange(Loc);
+    }
+
+    Attributes.add(new (Context) CxxDeclAttr(CxxName, AtLoc, AttrRange,
+                                             /*Implicit=*/false));
+    break;
+  }
+
   case DeclAttrKind::CDecl: {
     if (AttrName == "c") {
       std::optional<StringRef> CName;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3120,6 +3120,51 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     break;
   }
 
+  case DeclAttrKind::CxxDecl: {
+    StringRef CxxName;
+    if (consumeIfAttributeLParen()) {
+      // The optional string-literal argument is the C++ function name the
+      // importer matches against.
+      auto skipToEnd = [&]() {
+        skipUntil(tok::r_paren);
+        consumeIf(tok::r_paren);
+      };
+      if (Tok.isNot(tok::string_literal)) {
+        diagnose(Loc, diag::attr_expected_string_literal, AttrName);
+        skipToEnd();
+        return makeParserSuccess();
+      }
+      std::optional<StringRef> parsedName =
+          getStringLiteralIfNotInterpolated(Loc, ("'" + AttrName + "'").str());
+      consumeToken(tok::string_literal);
+      if (!parsedName) {
+        skipToEnd();
+        return makeParserSuccess();
+      }
+      CxxName = *parsedName;
+
+      // An explicit name must not be empty.
+      if (CxxName.empty()) {
+        diagnose(Loc, diag::attr_cxx_empty_name);
+        skipToEnd();
+        return makeParserSuccess();
+      }
+
+      AttrRange = SourceRange(Loc, Tok.getRange().getStart());
+      if (!consumeIf(tok::r_paren)) {
+        diagnose(Loc, diag::attr_expected_rparen, AttrName,
+                 DeclAttribute::isDeclModifier(DK));
+        return makeParserSuccess();
+      }
+    } else {
+      AttrRange = SourceRange(Loc);
+    }
+
+    Attributes.add(new (Context) CxxDeclAttr(CxxName, AtLoc, AttrRange,
+                                             /*Implicit=*/false));
+    break;
+  }
+
   case DeclAttrKind::CDecl: {
     if (AttrName == "c") {
       std::optional<StringRef> CName;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -420,6 +420,7 @@ public:
   void visitAvailableAttr(AvailableAttr *attr);
 
   void visitCDeclAttr(CDeclAttr *attr);
+  void visitCxxDeclAttr(CxxDeclAttr *attr);
   void visitCOMAttr(COMAttr *attr);
   void visitExposeAttr(ExposeAttr *attr);
   void visitExternAttr(ExternAttr *attr);
@@ -2482,6 +2483,32 @@ void AttributeChecker::visitCDeclAttr(CDeclAttr *attr) {
   if (D->getAttrs().getAttribute<ObjCAttr>()) {
     diagnose(attr->getLocation(), diag::cdecl_incompatible_with_objc, D);
   }
+}
+
+void AttributeChecker::visitCxxDeclAttr(CxxDeclAttr *attr) {
+  // @cxx requires C++ interop.
+  if (!Ctx.LangOpts.EnableCXXInterop)
+    diagnose(attr->getLocation(), diag::cxx_attr_requires_cxx_interop,
+             attr->getAttrName());
+
+  // Only top-level func decls are currently supported.
+  if (D->getDeclContext()->isTypeContext())
+    diagnose(attr->getLocation(), diag::cdecl_not_at_top_level, attr);
+
+  // Reject using both @cxx and @objc on the same decl.
+  if (D->getAttrs().getAttribute<ObjCAttr>())
+    diagnose(attr->getLocation(), diag::cxx_incompatible_with_objc, D);
+
+  // Reject using both @cxx and @c/@_cdecl on the same decl.
+  if (auto *cAttr = D->getAttrs().getAttribute<CDeclAttr>())
+    diagnose(attr->getLocation(), diag::cxx_incompatible_with_cdecl, cAttr, D);
+
+  // @cxx currently requires @implementation.
+  // AllowInvalid=true so that if @implementation is present but malformed, its
+  // own diagnostics cover the problem.
+  if (!D->getAttrs().getAttribute<ObjCImplementationAttr>(
+          /*AllowInvalid=*/true))
+    diagnose(attr->getLocation(), diag::cxx_attr_requires_implementation);
 }
 
 void AttributeChecker::visitCOMAttr(COMAttr *attr) {

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1605,6 +1605,7 @@ namespace  {
     UNINTERESTING_ATTR(Called)
     UNINTERESTING_ATTR(Concurrent)
     UNINTERESTING_ATTR(Consuming)
+    UNINTERESTING_ATTR(CxxDecl)
     UNINTERESTING_ATTR(Documentation)
     UNINTERESTING_ATTR(Dynamic)
     UNINTERESTING_ATTR(DynamicCallable)

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -6158,6 +6158,14 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
         break;
       }
 
+      case decls_block::CxxDecl_DECL_ATTR: {
+        bool isImplicit;
+        serialization::decls_block::CxxDeclDeclAttrLayout::readRecord(
+            scratch, isImplicit);
+        Attr = new (ctx) CxxDeclAttr(blobData, isImplicit);
+        break;
+      }
+
       case decls_block::Alignment_DECL_ATTR: {
         bool isImplicit;
         unsigned alignment;

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -6143,6 +6143,14 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
         break;
       }
 
+      case decls_block::CxxDecl_DECL_ATTR: {
+        bool isImplicit;
+        serialization::decls_block::CxxDeclDeclAttrLayout::readRecord(
+            scratch, isImplicit);
+        Attr = new (ctx) CxxDeclAttr(blobData, isImplicit);
+        break;
+      }
+
       case decls_block::Alignment_DECL_ATTR: {
         bool isImplicit;
         unsigned alignment;

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 1018; // PlatformKind raw values
+const uint16_t SWIFTMODULE_VERSION_MINOR = 1019; // @cxx attribute
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -2332,6 +2332,12 @@ namespace decls_block {
     BCFixed<1>, // implicit flag
     BCFixed<1>, // underscored flag
     BCBlob      // cname
+  >;
+
+  using CxxDeclDeclAttrLayout = BCRecordLayout<
+    CxxDecl_DECL_ATTR,
+    BCFixed<1>, // implicit flag
+    BCBlob      // cxx name
   >;
 
   using ImplementsDeclAttrLayout = BCRecordLayout<

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 1016; // @unsafe(always)
+const uint16_t SWIFTMODULE_VERSION_MINOR = 1017; // @cxx attribute
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -2332,6 +2332,12 @@ namespace decls_block {
     BCFixed<1>, // implicit flag
     BCFixed<1>, // underscored flag
     BCBlob      // cname
+  >;
+
+  using CxxDeclDeclAttrLayout = BCRecordLayout<
+    CxxDecl_DECL_ATTR,
+    BCFixed<1>, // implicit flag
+    BCBlob      // cxx name
   >;
 
   using ImplementsDeclAttrLayout = BCRecordLayout<

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3141,6 +3141,14 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
+    case DeclAttrKind::CxxDecl: {
+      auto *theAttr = cast<CxxDeclAttr>(DA);
+      auto abbrCode = S.DeclTypeAbbrCodes[CxxDeclDeclAttrLayout::Code];
+      CxxDeclDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
+                                        theAttr->isImplicit(), theAttr->Name);
+      return;
+    }
+
     case DeclAttrKind::SPIAccessControl: {
       auto theAttr = cast<SPIAccessControlAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[SPIAccessControlDeclAttrLayout::Code];

--- a/test/ASTGen/attrs_cxx.swift
+++ b/test/ASTGen/attrs_cxx.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend-dump-parse \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   -enable-experimental-feature CxxImplementation \
+// RUN:   -enable-experimental-feature ParserASTGen \
+// RUN:   | %sanitize-address > %t/astgen.ast
+
+// RUN: %target-swift-frontend-dump-parse \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   -enable-experimental-feature CxxImplementation \
+// RUN:   | %sanitize-address > %t/cpp-parser.ast
+
+// RUN: %diff -u %t/astgen.ast %t/cpp-parser.ast
+
+// REQUIRES: swift_feature_CxxImplementation
+// REQUIRES: swift_feature_ParserASTGen
+
+@cxx
+func foo() {}
+
+@cxx(cxx_bar)
+func bar() {}
+
+@cxx(`class`)
+func keywordName() {}
+
+@cxx(`operator+`)
+func operatorName() {}

--- a/test/ASTGen/attrs_cxx.swift
+++ b/test/ASTGen/attrs_cxx.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend-dump-parse \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   -enable-experimental-feature CxxImplementation \
+// RUN:   -enable-experimental-feature ParserASTGen \
+// RUN:   | %sanitize-address > %t/astgen.ast
+
+// RUN: %target-swift-frontend-dump-parse \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   -enable-experimental-feature CxxImplementation \
+// RUN:   | %sanitize-address > %t/cpp-parser.ast
+
+// RUN: %diff -u %t/astgen.ast %t/cpp-parser.ast
+
+// REQUIRES: swift_feature_CxxImplementation
+// REQUIRES: swift_feature_ParserASTGen
+
+@cxx
+func foo() {}
+
+@cxx("cxx_bar")
+func bar() {}

--- a/test/Interop/Cxx/cxx-impl/attr.swift
+++ b/test/Interop/Cxx/cxx-impl/attr.swift
@@ -1,0 +1,102 @@
+// RUN: %target-typecheck-verify-swift %s \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   -enable-experimental-feature CxxImplementation \
+// RUN:   -disable-objc-interop
+
+// REQUIRES: swift_feature_CxxImplementation
+
+
+// Malformed arguments are rejected.
+
+// expected-error@+1{{expected C++ function name in 'cxx' attribute}}
+@cxx()
+func emptyParens() {}
+
+// The name is a bare identifier, not a string literal.
+// expected-error@+1{{expected C++ function name in 'cxx' attribute}}
+@cxx("cxx_foo")
+func stringName() {}
+
+// A label is not accepted.
+// expected-error@+1{{expected C++ function name in 'cxx' attribute}}
+@cxx(name: "cxx_foo")
+func labeledName() {}
+
+// A name that is a Swift keyword must be enclosed in backticks.
+// expected-error@+1{{expected C++ function name in 'cxx' attribute}}
+@cxx(class)
+func keywordName() {}
+
+// C++ operator names must be enclosed in backticks.
+// expected-error@+1{{C++ operator name in 'cxx' attribute must be enclosed in backticks}}
+@cxx(operator+)
+func plainOperatorName(x: Int32) -> Int32 { return x }
+
+// expected-error@+1{{C++ operator name in 'cxx' attribute must be enclosed in backticks}}
+@cxx(operator())
+func plainCallOperatorName(x: Int32) -> Int32 { return x }
+
+
+// Only top-level func decls are currently supported.
+
+class Foo {
+  // expected-error@+2{{@cxx can only be applied to global functions}}
+  // expected-error@+1{{'@cxx' must be combined with '@implementation'}}
+  @cxx
+  func foo(x: Int32) -> Int32 { return x }
+
+  // expected-error@+2{{@cxx can only be applied to global functions}}
+  // expected-error@+1{{'@cxx' must be combined with '@implementation'}}
+  @cxx
+  static func bar(x: Int32) -> Int32 { return x }
+}
+
+// expected-error@+1{{@cxx may only be used on 'func' declarations}}
+@cxx
+var notAFunction: Int32 = 0
+
+// expected-error@+1{{@cxx may only be used on 'func' declarations}}
+@cxx
+enum NotAFunctionEnum { case a }
+
+var accessorHost: Int32 {
+  // expected-error@+1{{@cxx may only be used on 'func' declarations}}
+  @cxx
+  get { return 0 }
+}
+
+
+// Reject using both @cxx and @objc on the same decl.
+
+// expected-error@+3{{cannot apply both '@cxx' and '@objc' to global function}}
+// expected-error@+2{{'@objc' can only be used with members of classes, '@objc' protocols, and concrete extensions of classes}}
+// expected-error@+1{{'@cxx' must be combined with '@implementation'}}
+@objc @cxx
+func conflictWithObjC(x: Int32) -> Int32 { return x }
+
+
+// Reject using both @cxx and @c/@_cdecl on the same decl.
+
+// expected-error@+2{{cannot apply both '@cxx' and '@c' to global function}}
+// expected-error@+1{{'@cxx' must be combined with '@implementation'}}
+@c @cxx
+func conflictWithC() {}
+
+
+// @cxx requires @implementation.
+
+// expected-error@+1{{'@cxx' must be combined with '@implementation'}}
+@cxx
+func bareCxx(x: Int32) -> Int32 { return x }
+
+// expected-error@+1{{'@cxx' must be combined with '@implementation'}}
+@cxx(cxx_foo)
+func renamed(x: Int32) -> Int32 { return x }
+
+// expected-error@+1{{'@cxx' must be combined with '@implementation'}}
+@cxx(`class`)
+func renamedToKeyword(x: Int32) -> Int32 { return x }
+
+// expected-error@+1{{'@cxx' must be combined with '@implementation'}}
+@cxx(`operator+`)
+func renamedToOperator(x: Int32) -> Int32 { return x }

--- a/test/Interop/Cxx/cxx-impl/attr.swift
+++ b/test/Interop/Cxx/cxx-impl/attr.swift
@@ -1,0 +1,87 @@
+// RUN: %target-typecheck-verify-swift %s \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   -enable-experimental-feature CxxImplementation \
+// RUN:   -disable-objc-interop
+
+// REQUIRES: swift_feature_CxxImplementation
+
+
+// Malformed arguments are rejected.
+
+// expected-error@+1{{expected string literal in 'cxx' attribute}}
+@cxx()
+func emptyParens() {}
+
+// expected-error@+1{{expected string literal in 'cxx' attribute}}
+@cxx(cxx_foo)
+func unquotedName() {}
+
+// The name is a bare string literal; a label is not accepted.
+// expected-error@+1{{expected string literal in 'cxx' attribute}}
+@cxx(name: "cxx_foo")
+func labeledName() {}
+
+// expected-error@+1{{expected string literal in 'cxx' attribute}}
+@cxx(operator())
+func unquotedOperatorName(x: Int32) -> Int32 { return x }
+
+// expected-error@+1{{C++ function name in 'cxx' attribute cannot be empty}}
+@cxx("")
+func emptyName(x: Int32) -> Int32 { return x }
+
+
+// Only top-level func decls are currently supported.
+
+class Foo {
+  // expected-error@+2{{@cxx can only be applied to global functions}}
+  // expected-error@+1{{'@cxx' must be combined with '@implementation'}}
+  @cxx
+  func foo(x: Int32) -> Int32 { return x }
+
+  // expected-error@+2{{@cxx can only be applied to global functions}}
+  // expected-error@+1{{'@cxx' must be combined with '@implementation'}}
+  @cxx
+  static func bar(x: Int32) -> Int32 { return x }
+}
+
+// expected-error@+1{{@cxx may only be used on 'func' declarations}}
+@cxx
+var notAFunction: Int32 = 0
+
+// expected-error@+1{{@cxx may only be used on 'func' declarations}}
+@cxx
+enum NotAFunctionEnum { case a }
+
+var accessorHost: Int32 {
+  // expected-error@+1{{@cxx may only be used on 'func' declarations}}
+  @cxx
+  get { return 0 }
+}
+
+
+// Reject using both @cxx and @objc on the same decl.
+
+// expected-error@+3{{cannot apply both '@cxx' and '@objc' to global function}}
+// expected-error@+2{{'@objc' can only be used with members of classes, '@objc' protocols, and concrete extensions of classes}}
+// expected-error@+1{{'@cxx' must be combined with '@implementation'}}
+@objc @cxx
+func conflictWithObjC(x: Int32) -> Int32 { return x }
+
+
+// Reject using both @cxx and @c/@_cdecl on the same decl.
+
+// expected-error@+2{{cannot apply both '@cxx' and '@c' to global function}}
+// expected-error@+1{{'@cxx' must be combined with '@implementation'}}
+@c @cxx
+func conflictWithC() {}
+
+
+// @cxx requires @implementation.
+
+// expected-error@+1{{'@cxx' must be combined with '@implementation'}}
+@cxx
+func bareCxx(x: Int32) -> Int32 { return x }
+
+// expected-error@+1{{'@cxx' must be combined with '@implementation'}}
+@cxx("cxx_foo")
+func renamed(x: Int32) -> Int32 { return x }

--- a/test/Interop/Cxx/cxx-impl/flags.swift
+++ b/test/Interop/Cxx/cxx-impl/flags.swift
@@ -1,0 +1,20 @@
+// Test that @cxx requires both C++ interoperability and the CxxImplementation
+// experimental feature.
+
+// RUN: not %target-swift-frontend \
+// RUN:   -typecheck %s \
+// RUN:   -enable-experimental-feature CxxImplementation \
+// RUN:   2>&1 | %FileCheck --check-prefix=NO-INTEROP %s
+
+// RUN: not %target-swift-frontend \
+// RUN:   -typecheck %s \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   2>&1 | %FileCheck --check-prefix=NO-FEATURE %s
+
+// REQUIRES: swift_feature_CxxImplementation
+
+@cxx @implementation
+func foo(_ x: Int32) -> Int32 { return x }
+
+// NO-INTEROP: error: 'cxx' requires C++ interoperability; enable it with '-cxx-interoperability-mode=default'
+// NO-FEATURE: error: 'cxx' attribute is only valid when experimental feature CxxImplementation is enabled


### PR DESCRIPTION
Add the experimental @cxx attribute (gated behind the new CxxImplementation feature). A Swift function marked `@cxx @implementation` will provide the implementation of a C++ function declared in an imported header.

This first patch adds the attribute surface only: parsing, AST, printing/dumping, serialization, and the attribute-level Sema checks. Matching against imported C++ declarations, signature checking, and SIL/IRGen lowering follow in subsequent patches.

`@cxx` optionally names the C++ function to match, letting the Swift function be named differently: `@cxx(addImpl)`. The argument is an identifier, following @c and @objc. A name that does not lex as a plain Swift identifier is enclosed in backticks, so every C++ function name remains spellable. The syntax can still grow labeled parameters after the name for overload disambiguation a Swift signature cannot express (e.g. `@cxx(addImpl, const: true)`).

rdar://182750340