### PR TITLE
IRGen: Adjust to "[IR] Remove size argument from lifetime intrinsics (#150248)"

### DIFF
--- a/lib/IRGen/IRBuilder.h
+++ b/lib/IRGen/IRBuilder.h
@@ -295,20 +295,18 @@ public:
   
   using IRBuilderBase::CreateLifetimeStart;
   llvm::CallInst *CreateLifetimeStart(Address buf, Size size) {
-    return CreateLifetimeStart(buf,
-                   llvm::ConstantInt::get(Context, APInt(64, size.getValue())));
+    return CreateLifetimeStart(buf.getAddress());
   }
   llvm::CallInst *CreateLifetimeStart(Address buf, llvm::ConstantInt *size) {
-    return CreateLifetimeStart(buf.getAddress(), size);
+    return CreateLifetimeStart(buf.getAddress());
   }
   
   using IRBuilderBase::CreateLifetimeEnd;
   llvm::CallInst *CreateLifetimeEnd(Address buf, Size size) {
-    return CreateLifetimeEnd(buf,
-                   llvm::ConstantInt::get(Context, APInt(64, size.getValue())));
+    return CreateLifetimeEnd(buf.getAddress());
   }
   llvm::CallInst *CreateLifetimeEnd(Address buf, llvm::ConstantInt *size) {
-    return CreateLifetimeEnd(buf.getAddress(), size);
+    return CreateLifetimeEnd(buf.getAddress());
   }
 
   // We're intentionally not allowing direct use of


### PR DESCRIPTION
The `llvm.lifetime.start/end` intrinsics and
`llvm::IRBuilder::CreateLifetimeStart/CreateLifetimeEnd` no longer accept a size, and it is now implied by the underlying alloca. Remove the extra argument from the forwarding calls, but keep our own `CreateLifetimeStart/CreateLifetimeEnd` as is for now to keep rebranch closer to main.

See https://github.com/llvm/llvm-project/commit/c23b4fbdbb70f04e637b488416d8e42449bfa1fb (https://github.com/llvm/llvm-project/pull/150248).