### PR TITLE
[ASTGen] Update unqualified-lookup validation for new SwiftLexicalLookup API.

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/LexicalLookup.swift
+++ b/lib/ASTGen/Sources/ASTGen/LexicalLookup.swift
@@ -276,7 +276,7 @@ private func sllConsumedResults(
               flags: .placementRearranged
             )
           }
-        } else if let nominalTypeScope = Syntax(parent).asProtocol(SyntaxProtocol.self) as? NominalTypeDeclSyntax,
+        } else if let nominalTypeScope = Syntax(parent).asProtocol(SyntaxProtocol.self) as? NominalTypeDeclScopeSyntax,
           nominalTypeScope.inheritanceClause?.range.contains(lookupToken.position) ?? false
         {
           // If lookup started from nominal type inheritance clause, reverse introduced names.

--- a/lib/ASTGen/Sources/ASTGen/LexicalLookup.swift
+++ b/lib/ASTGen/Sources/ASTGen/LexicalLookup.swift
@@ -73,12 +73,29 @@ public func unqualifiedLookup(
     configuredRegions: configuredRegions
   )
 
-  // Add header to the output
+  // Add header to the output.
+  //
+  // We always call `lookupToken.lookup` with an `identifier` of `nil`,
+  // so we don't filter results by name.
+  //
+  // E.g.
+  //   # | -----> Lookup at token 'B' @ 57:38 (identifier: nil, finishInSequentialScope: false)
+  //   # |      +-------------------------------------------------------------+
+  //   # |      |           ASTScope           |      SwiftLexicalLookup      |
+  //   # |      +------------------------------+------------------------------+
   var consoleOutput =
-    "-----> Lookup started at: \(sourceLocationConverter.location(for: lookupPosition).lineWithColumn) (\"\(lookupToken.text)\") finishInSequentialScope: \(finishInSequentialScope)\n"
+    "-----> Lookup at token '\(lookupToken.text)' @ \(sourceLocationConverter.location(for: lookupPosition).lineWithColumn) (identifier: nil, finishInSequentialScope: \(finishInSequentialScope))\n"
+  let leadingPadding = "     "
   consoleOutput +=
-    "     |" + "ASTScope".addPaddingUpTo(characters: rowCharWidth) + "|"
-    + "SwiftLexicalLookup".addPaddingUpTo(characters: rowCharWidth) + "\n"
+    leadingPadding + "+" + String(repeating: "-", count: rowCharWidth + 1 + rowCharWidth) + "+\n"
+  consoleOutput +=
+    leadingPadding + "|"
+    + "ASTScope".addPaddingUpTo(characters: rowCharWidth) + "|"
+    + "SwiftLexicalLookup".addPaddingUpTo(characters: rowCharWidth) + "|\n"
+  consoleOutput +=
+    leadingPadding + "+"
+    + String(repeating: "-", count: rowCharWidth) + "+"
+    + String(repeating: "-", count: rowCharWidth) + "+\n"
 
   // Flagging pass
   flaggingPass(


### PR DESCRIPTION
Twin PR for https://github.com/swiftlang/swift-syntax/pull/3378.
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
