### PR TITLE
Use mutate accessor directly for opaque ReadWrite access

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3557,6 +3557,8 @@ static AccessStrategy getOpaqueReadWriteAccessStrategy(
     return AccessStrategy::getAccessor(AccessorKind::YieldingMutate, dispatch);
   if (storage->requiresOpaqueModifyCoroutine())
     return AccessStrategy::getAccessor(AccessorKind::Modify, dispatch);
+  if (storage->requiresOpaqueMutateAccessor())
+    return AccessStrategy::getAccessor(AccessorKind::Mutate, dispatch);
   return AccessStrategy::getMaterializeToTemporary(
       getOpaqueReadAccessStrategy(storage, dispatch, nullptr,
                                   ResilienceExpansion::Minimal, location,

--- a/test/SILGen/Inputs/opaque_readwrite_borrow_mutate.swift
+++ b/test/SILGen/Inputs/opaque_readwrite_borrow_mutate.swift
@@ -1,0 +1,41 @@
+public class Klass {
+  public init() {}
+}
+
+public struct NonTrivial {
+  public var k = Klass()
+
+  public init() {}
+
+  public mutating func mutateInPlace() {}
+}
+
+public struct Wrapper {
+  var _value: NonTrivial
+
+  public init(_ value: NonTrivial) { _value = value }
+
+  public var value: NonTrivial {
+    borrow { return _value }
+    mutate { return &_value }
+  }
+}
+
+public struct NC: ~Copyable {
+  var x: Int = 0
+
+  public init() {}
+
+  public mutating func mutateInPlace() {}
+}
+
+public struct NCWrapper: ~Copyable {
+  var _value: NC
+
+  public init(_ value: consuming NC) { _value = value }
+
+  public var value: NC {
+    borrow { return _value }
+    mutate { return &_value }
+  }
+}

--- a/test/SILGen/opaque_readwrite_borrow_mutate.swift
+++ b/test/SILGen/opaque_readwrite_borrow_mutate.swift
@@ -1,0 +1,64 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -enable-library-evolution -emit-module -module-name Lib -o %t %S/Inputs/opaque_readwrite_borrow_mutate.swift
+// RUN: %target-swift-frontend -I %t -module-name main -emit-silgen %s | %FileCheck %s
+
+// A ReadWrite access to a resilient property with borrow/mutate accessors uses
+// the mutate accessor directly.
+
+import Lib
+
+// CHECK-LABEL: sil [ossa] @$s4main13mutateInPlaceyy3Lib7WrapperVzF :
+// CHECK: bb0([[REG0:%.*]] : $*Wrapper):
+// CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unknown] [[REG0]]
+// CHECK-NOT: copy_addr
+// CHECK:   [[MUTATE_FN:%.*]] = function_ref @$s3Lib7WrapperV5valueAA10NonTrivialVvz : $@convention(method) (@inout Wrapper) -> @inout NonTrivial
+// CHECK:   [[INOUT_REF:%.*]] = apply [[MUTATE_FN]]([[ACCESS]]) : $@convention(method) (@inout Wrapper) -> @inout NonTrivial
+// CHECK:   [[MUTATE_IN_PLACE_FN:%.*]] = function_ref @$s3Lib10NonTrivialV13mutateInPlaceyyF : $@convention(method) (@inout NonTrivial) -> ()
+// CHECK:   apply [[MUTATE_IN_PLACE_FN]]([[INOUT_REF]]) : $@convention(method) (@inout NonTrivial) -> ()
+// CHECK:   end_access [[ACCESS]]
+// CHECK: }
+public func mutateInPlace(_ w: inout Wrapper) {
+  w.value.mutateInPlace()
+}
+
+// CHECK-LABEL: sil [ossa] @$s4main11assignValueyy3Lib7WrapperVzF :
+// CHECK: bb0([[REG0:%.*]] : $*Wrapper):
+// CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unknown] [[REG0]]
+// CHECK:   [[MUTATE_FN:%.*]] = function_ref @$s3Lib7WrapperV5valueAA10NonTrivialVvz : $@convention(method) (@inout Wrapper) -> @inout NonTrivial
+// CHECK:   [[INOUT_REF:%.*]] = apply [[MUTATE_FN]]([[ACCESS]]) : $@convention(method) (@inout Wrapper) -> @inout NonTrivial
+// CHECK:   end_access [[ACCESS]]
+// CHECK: }
+public func assignValue(_ w: inout Wrapper) {
+  w.value = NonTrivial()
+}
+
+// CHECK-LABEL: sil [ossa] @$s4main9readValueyy3Lib7WrapperVF :
+// CHECK: bb0([[REG0:%.*]] : $*Wrapper):
+// CHECK:   [[BORROW_FN:%.*]] = function_ref @$s3Lib7WrapperV5valueAA10NonTrivialVvb : $@convention(method) (@in_guaranteed Wrapper) -> @guaranteed_address NonTrivial
+// CHECK:   apply [[BORROW_FN]]([[REG0]]) : $@convention(method) (@in_guaranteed Wrapper) -> @guaranteed_address NonTrivial
+// CHECK: }
+public func readValue(_ w: Wrapper) {
+  _ = w.value
+}
+
+// CHECK-LABEL: sil [ossa] @$s4main15ncMutateInPlaceyy3Lib9NCWrapperVzF :
+// CHECK: bb0([[REG0:%.*]] : $*NCWrapper):
+// CHECK-NOT: copy_addr
+// CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unknown]
+// CHECK:   [[MUTATE_FN:%.*]] = function_ref @$s3Lib9NCWrapperV5valueAA2NCVvz : $@convention(method) (@inout NCWrapper) -> @inout NC
+// CHECK:   [[INOUT_REF:%.*]] = apply [[MUTATE_FN]]([[ACCESS]]) : $@convention(method) (@inout NCWrapper) -> @inout NC
+// CHECK:   [[MUTATE_IN_PLACE_FN:%.*]] = function_ref @$s3Lib2NCV13mutateInPlaceyyF : $@convention(method) (@inout NC) -> ()
+// CHECK:   end_access [[ACCESS]]
+// CHECK: }
+public func ncMutateInPlace(_ w: inout NCWrapper) {
+  w.value.mutateInPlace()
+}
+
+// CHECK-LABEL: sil [ossa] @$s4main11ncReadValueyy3Lib9NCWrapperVF :
+// CHECK: bb0([[REG0:%.*]] : $*NCWrapper):
+// CHECK:   [[BORROW_FN:%.*]] = function_ref @$s3Lib9NCWrapperV5valueAA2NCVvb : $@convention(method) (@in_guaranteed NCWrapper) -> @guaranteed_address NC
+// CHECK:   apply [[BORROW_FN]]
+// CHECK: }
+public func ncReadValue(_ w: borrowing NCWrapper) {
+  _ = w.value
+}

--- a/test/Serialization/borrow_accessor_protocol_client.swift
+++ b/test/Serialization/borrow_accessor_protocol_client.swift
@@ -65,14 +65,11 @@ public func mutate(_ s: inout NonTrivial) {
 // CHECK: bb0([[REG0:%.*]] : $*any P):
 // CHECK:   [[REG2:%.*]] = begin_access [modify] [unknown] [[REG0]]
 // CHECK:   [[REG3:%.*]] = open_existential_addr mutable_access [[REG2]] to $*@opened("{{.*}}", any P) Self
-// CHECK:   [[REG4:%.*]] = alloc_stack $NonTrivial
-// CHECK:   [[REG5:%.*]] = witness_method $@opened("{{.*}}", any P) Self, #P.id!borrow : <Self where Self : borrow_accessor_protocol.P> (Self) -> () -> borrow_accessor_protocol.NonTrivial, [[REG3:%.*]] : $*@opened("{{.*}}", any P) Self : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @guaranteed_address NonTrivial
-// CHECK:   [[REG6:%.*]] = apply [[REG5]]<@opened("{{.*}}", any P) Self>([[REG3]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @guaranteed_address NonTrivial
-// CHECK:   copy_addr [[REG6]] to [init] [[REG4]]
-// CHECK:   [[REG8:%.*]] = function_ref @$s31borrow_accessor_protocol_client6mutateyy0a1_b1_C010NonTrivialVzF : $@convention(thin) (@inout NonTrivial) -> ()
-// CHECK:   [[REG9:%.*]] = apply [[REG8]]([[REG4]]) : $@convention(thin) (@inout NonTrivial) -> ()
-// CHECK:   [[REG10:%.*]] = witness_method $@opened("{{.*}}", any P) Self, #P.id!mutate : <Self where Self : borrow_accessor_protocol.P> (inout Self) -> () -> borrow_accessor_protocol.NonTrivial, [[REG3:%.*]] : $*@opened("{{.*}}", any P) Self : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@inout τ_0_0) -> @inout NonTrivial
-// CHECK:   [[REG11:%.*]] = apply [[REG10]]<@opened("{{.*}}", any P) Self>([[REG3]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@inout τ_0_0) -> @inout NonTrivial
+// CHECK:   [[REG4:%.*]] = witness_method $@opened("{{.*}}", any P) Self, #P.id!mutate : <Self where Self : borrow_accessor_protocol.P> (inout Self) -> () -> borrow_accessor_protocol.NonTrivial, [[REG3:%.*]] : $*@opened("{{.*}}", any P) Self : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@inout τ_0_0) -> @inout NonTrivial
+// CHECK:   [[REG5:%.*]] = apply [[REG4]]<@opened("{{.*}}", any P) Self>([[REG3]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@inout τ_0_0) -> @inout NonTrivial
+// CHECK:   [[REG6:%.*]] = function_ref @$s31borrow_accessor_protocol_client6mutateyy0a1_b1_C010NonTrivialVzF : $@convention(thin) (@inout NonTrivial) -> ()
+// CHECK:   [[REG7:%.*]] = apply [[REG6]]([[REG5]]) : $@convention(thin) (@inout NonTrivial) -> ()
+// CHECK:   end_access [[REG2]]
 // CHECK: }
 public func bar(_ p: inout P) {
   mutate(&p.id)
@@ -81,12 +78,11 @@ public func bar(_ p: inout P) {
 // CHECK: sil [ossa] @$s31borrow_accessor_protocol_client3baryy0a1_b1_C02S1VzF :
 // CHECK: bb0([[REG0:%.*]] : $*S1):
 // CHECK:   [[REG2:%.*]] = begin_access [modify] [unknown] [[REG0]]
-// CHECK:   [[REG3:%.*]] = alloc_stack $NonTrivial
-// CHECK:   [[REG4:%.*]] = function_ref @$s24borrow_accessor_protocol2S1V2idAA10NonTrivialVvb : $@convention(method) (@in_guaranteed S1) -> @guaranteed_address NonTrivial
-// CHECK:   [[REG5:%.*]] = apply [[REG4]]([[REG2]]) : $@convention(method) (@in_guaranteed S1) -> @guaranteed_address NonTrivial
-// CHECK:   copy_addr [[REG5]] to [init] [[REG3]]
-// CHECK:   [[REG7:%.*]] = function_ref @$s31borrow_accessor_protocol_client6mutateyy0a1_b1_C010NonTrivialVzF : $@convention(thin) (@inout NonTrivial) -> ()
-// CHECK:   [[REG8:%.*]] = apply [[REG7]]([[REG3]]) : $@convention(thin) (@inout NonTrivial) -> ()
+// CHECK:   [[REG3:%.*]] = function_ref @$s24borrow_accessor_protocol2S1V2idAA10NonTrivialVvz : $@convention(method) (@inout S1) -> @inout NonTrivial
+// CHECK:   [[REG4:%.*]] = apply [[REG3]]([[REG2]]) : $@convention(method) (@inout S1) -> @inout NonTrivial
+// CHECK:   [[REG5:%.*]] = function_ref @$s31borrow_accessor_protocol_client6mutateyy0a1_b1_C010NonTrivialVzF : $@convention(thin) (@inout NonTrivial) -> ()
+// CHECK:   [[REG6:%.*]] = apply [[REG5]]([[REG4]]) : $@convention(thin) (@inout NonTrivial) -> ()
+// CHECK:   end_access [[REG2]]
 // CHECK: }
 public func bar(_ s1: inout S1) {
   mutate(&s1.id)
@@ -178,15 +174,11 @@ public func bar(_ q: inout Q) {
 // CHECK: sil [ossa] @$s31borrow_accessor_protocol_client3baryy0a1_b1_C02S5VzF : $@convention(thin) (@inout S5) -> () {
 // CHECK: bb0([[REG0:%.*]] : $*S5):
 // CHECK:   [[REG2:%.*]] = begin_access [modify] [unknown] [[REG0]]
-// CHECK:   [[REG3:%.*]] = alloc_stack $NonTrivial
-// CHECK:   [[REG4:%.*]] = function_ref @$s24borrow_accessor_protocol2S5V2idAA10NonTrivialVvb : $@convention(method) (@in_guaranteed S5) -> @guaranteed_address NonTrivial
-// CHECK:   [[REG5:%.*]] = apply [[REG4]]([[REG2]]) : $@convention(method) (@in_guaranteed S5) -> @guaranteed_address NonTrivial
-// CHECK:   copy_addr [[REG5]] to [init] [[REG3]]
-// CHECK:   [[REG7:%.*]] = function_ref @$s31borrow_accessor_protocol_client6mutateyy0a1_b1_C010NonTrivialVzF : $@convention(thin) (@inout NonTrivial) -> ()
-// CHECK:   [[REG8:%.*]] = apply [[REG7]]([[REG3]]) : $@convention(thin) (@inout NonTrivial) -> ()
-// CHECK:   [[REG9:%.*]] = function_ref @$s24borrow_accessor_protocol2S5V2idAA10NonTrivialVvz : $@convention(method) (@inout S5) -> @inout NonTrivial
-// CHECK:   [[REG10:%.*]] = apply [[REG9]]([[REG2]]) : $@convention(method) (@inout S5) -> @inout NonTrivial
-// CHECK:   copy_addr [take] [[REG3]] to [[REG10]]
+// CHECK:   [[REG3:%.*]] = function_ref @$s24borrow_accessor_protocol2S5V2idAA10NonTrivialVvz : $@convention(method) (@inout S5) -> @inout NonTrivial
+// CHECK:   [[REG4:%.*]] = apply [[REG3]]([[REG2]]) : $@convention(method) (@inout S5) -> @inout NonTrivial
+// CHECK:   [[REG5:%.*]] = function_ref @$s31borrow_accessor_protocol_client6mutateyy0a1_b1_C010NonTrivialVzF : $@convention(thin) (@inout NonTrivial) -> ()
+// CHECK:   [[REG6:%.*]] = apply [[REG5]]([[REG4]]) : $@convention(thin) (@inout NonTrivial) -> ()
+// CHECK:   end_access [[REG2]]
 // CHECK: }
 public func bar(_ s5: inout S5) {
   mutate(&s5.id)


### PR DESCRIPTION
getOpaqueReadWriteAccessStrategy was missing a check for requiresOpaqueMutateAccessor(), causing ReadWrite accesses to resilient properties with borrow/mutate accessors to fall through to MaterializeToTemporary. This produced a borrow + copy + mutate writeback sequence instead of calling the mutate accessor directly.

Resolves rdar://182526391
