### PR TITLE
[cxx-interop] Fine tune lifetime annotation ingestion

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2197,9 +2197,10 @@ namespace {
           .isReference();
     }
 
-    void markReturnsUnsafeNonescapable(AbstractFunctionDecl *fd) {
-      fd->addAttribute(new (Impl.SwiftContext) UnsafeAttr(/*Implicit=*/true));
-
+    // Cache an immortal lifetime dependence for the non-escapable result of
+    // `fd`. This also prevents the implicit single-parameter
+    // lifetime-dependence inference from running for it.
+    void cacheImmortalLifetime(AbstractFunctionDecl *fd) {
       unsigned resultIndex = fd->getParameters()->size();
       if (fd->isInstanceMethod()) {
         ++resultIndex;
@@ -2212,6 +2213,11 @@ namespace {
       Impl.SwiftContext.evaluator.cacheOutput(
           LifetimeDependenceInfoRequest{fd},
           Impl.SwiftContext.AllocateCopy(lifetimeDependencies));
+    }
+
+    void markReturnsUnsafeNonescapable(AbstractFunctionDecl *fd) {
+      fd->addAttribute(new (Impl.SwiftContext) UnsafeAttr(/*Implicit=*/true));
+      cacheImmortalLifetime(fd);
     }
 
     bool
@@ -4483,10 +4489,17 @@ namespace {
         if (importedAsClass(ty, forSelf))
           hasSkippedLifetimeAnnotation = true;
         paramHasAnnotation[idx] = true;
-        if (isEscapable(ty))
+        // 'self' and lvalue/rvalue references borrow the referent's storage.
+        if (forSelf || ty->isReferenceType())
           scopedLifetimeParamIndicesForReturn[idx] = true;
-        else
+        // A non-escapable passed by value: the result inherits its lifetime.
+        else if (!isEscapable(ty))
           inheritLifetimeParamIndicesForReturn[idx] = true;
+        // An escapable/unknown value or pointer passed by value has no
+        // borrowable storage, so we cannot form a scoped lifetime dependency.
+        // Import the API as @unsafe.
+        else
+          hasSkippedLifetimeAnnotation = true;
       };
       auto processLifetimeCaptureBy =
           [&](const clang::LifetimeCaptureByAttr *attr, unsigned idx,
@@ -4569,18 +4582,28 @@ namespace {
                 CxxEscapability::Unknown) == CxxEscapability::NonEscapable)
           lifetimeDependencies.push_back(immortalLifetime);
       }
-      if (lifetimeDependencies.empty()) {
-        if (isNonEscapableAnnotatedType(retType.getTypePtr())) {
-          Impl.addImportDiagnostic(
-              decl,
-              Diagnostic(diag::return_nonescapable_without_lifetimebound,
-                         Impl.SwiftContext.AllocateCopy(retType.getAsString())),
-              decl->getLocation());
-        }
-      } else {
+      bool resultIsNonEscapable =
+          isNonEscapableAnnotatedType(retType.getTypePtr());
+      if (auto *ctordecl = dyn_cast<clang::CXXConstructorDecl>(decl))
+        resultIsNonEscapable = isNonEscapableAnnotatedType(
+            ctordecl->getParent()->getTypeForDecl());
+
+      if (!lifetimeDependencies.empty()) {
         Impl.SwiftContext.evaluator.cacheOutput(
             LifetimeDependenceInfoRequest{result},
             Impl.SwiftContext.AllocateCopy(lifetimeDependencies));
+      } else if (hasSkippedLifetimeAnnotation && resultIsNonEscapable) {
+        // We skipped a lifetime annotation we could not faithfully represent
+        // The API is imported @unsafe (below); give the non-escapable result an
+        // immortal lifetime so the implicit single-parameter inference does not
+        // synthesize a scoped dependency that would be invalid.
+        cacheImmortalLifetime(result);
+      } else if (resultIsNonEscapable) {
+        Impl.addImportDiagnostic(
+            decl,
+            Diagnostic(diag::return_nonescapable_without_lifetimebound,
+                       Impl.SwiftContext.AllocateCopy(retType.getAsString())),
+            decl->getLocation());
       }
 
       if (hasSkippedLifetimeAnnotation) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4489,9 +4489,15 @@ namespace {
         if (importedAsClass(ty, forSelf))
           hasSkippedLifetimeAnnotation = true;
         paramHasAnnotation[idx] = true;
-        // 'self' and lvalue/rvalue references borrow the referent's storage.
-        if (forSelf || ty->isReferenceType())
+        // 'self' and lvalue references borrow the referent's storage.
+        if (forSelf || ty->isLValueReferenceType())
           scopedLifetimeParamIndicesForReturn[idx] = true;
+        // An rvalue reference is imported as 'consuming'; its storage is not
+        // guaranteed to outlive the call, so we cannot form a scoped
+        // dependency on it, nor can the result inherit its lifetime as if it
+        // were passed by value. Import the API as @unsafe.
+        else if (ty->isRValueReferenceType())
+          hasSkippedLifetimeAnnotation = true;
         // A non-escapable passed by value: the result inherits its lifetime.
         else if (!isEscapable(ty))
           inheritLifetimeParamIndicesForReturn[idx] = true;

--- a/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
+++ b/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
@@ -253,6 +253,15 @@ public:
 inline void retainSharedOwnerBox(SharedOwnerBox *) {}
 inline void releaseSharedOwnerBox(SharedOwnerBox *) {}
 
+struct NonTrivialByValue {
+    int data;
+    NonTrivialByValue(const NonTrivialByValue &o) : data(o.data) {}
+    ~NonTrivialByValue() {}
+};
+View fromNonTrivialValue(NonTrivialByValue o [[clang::lifetimebound]]);
+View fromTrivialValue(Owner o [[clang::lifetimebound]]);
+View fromPointer(const int *p [[clang::lifetimebound]]);
+
 // CHECK: sil {{.*}}[clang makeOwner] {{.*}}: $@convention(c) () -> Owner
 // CHECK: sil {{.*}}[clang getView] {{.*}} : $@convention(c) (@in_guaranteed Owner) -> @lifetime(borrow address 0) @owned View
 // CHECK: sil {{.*}}[clang getViewFromFirst] {{.*}} : $@convention(c) (@in_guaranteed Owner, @in_guaranteed Owner) -> @lifetime(borrow address 0) @owned View
@@ -272,6 +281,9 @@ inline void releaseSharedOwnerBox(SharedOwnerBox *) {}
 // CHECK: sil {{.*}}[clang makeAnonUnionNonEscapable] {{.*}} : $@convention(c) (@in_guaranteed Owner) -> @lifetime(borrow address 0) @owned HasAnonUnion<NonEscapable>
 // CHECK: sil {{.*}}[clang makeAnonStructNonEscapable] {{.*}} : $@convention(c) (@in_guaranteed Owner) -> @lifetime(borrow address 0) @owned HasAnonStruct<NonEscapable>
 // CHECK: sil {{.*}}[clang makeNonEscapableHasAnonUnionNonEscapable] {{.*}} : $@convention(c) (@in_guaranteed Owner) -> @lifetime(borrow address 0) @owned NonEscapableHasAnonUnion<NonEscapable>
+// CHECK: sil {{.*}}[clang fromNonTrivialValue] {{.*}} : $@convention(c) (@in{{(_cxx)?}} NonTrivialByValue) -> @lifetime(immortal) @owned View
+// CHECK: sil {{.*}}[clang fromTrivialValue] {{.*}} : $@convention(c) (Owner) -> @lifetime(immortal) @owned View
+// CHECK: sil {{.*}}[clang fromPointer] {{.*}} : $@convention(c) (Optional<UnsafePointer<Int32>>) -> @lifetime(immortal) @owned View
 
 //--- test.swift
 
@@ -311,6 +323,13 @@ func anonymousUnionsAndStructs(_ v: borrowing View) {
     let _ = makeAnonUnionNonEscapable(o)
     let _ = makeAnonStructNonEscapable(o)
     let _ = makeNonEscapableHasAnonUnionNonEscapable(o)
+}
+
+func byValueAndPointerLifetimebound(_ n: NonTrivialByValue, _ o: Owner,
+                                    _ p: UnsafePointer<CInt>) {
+    let _ = fromNonTrivialValue(n)
+    let _ = fromTrivialValue(o)
+    let _ = fromPointer(p)
 }
 
 //--- escaping_scopes.swift

--- a/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
+++ b/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
@@ -262,6 +262,11 @@ View fromNonTrivialValue(NonTrivialByValue o [[clang::lifetimebound]]);
 View fromTrivialValue(Owner o [[clang::lifetimebound]]);
 View fromPointer(const int *p [[clang::lifetimebound]]);
 
+View fromLvalueRefTrivialValue(Owner &o [[clang::lifetimebound]]);
+View fromLvalueRefNonTrivialValue(NonTrivialByValue &o [[clang::lifetimebound]]);
+View fromRvalueRefTrivialValue(Owner &&o [[clang::lifetimebound]]);
+View fromRvalueRefNonTrivialValue(NonTrivialByValue &&o [[clang::lifetimebound]]);
+
 // CHECK: sil {{.*}}[clang makeOwner] {{.*}}: $@convention(c) () -> Owner
 // CHECK: sil {{.*}}[clang getView] {{.*}} : $@convention(c) (@in_guaranteed Owner) -> @lifetime(borrow address 0) @owned View
 // CHECK: sil {{.*}}[clang getViewFromFirst] {{.*}} : $@convention(c) (@in_guaranteed Owner, @in_guaranteed Owner) -> @lifetime(borrow address 0) @owned View
@@ -284,6 +289,10 @@ View fromPointer(const int *p [[clang::lifetimebound]]);
 // CHECK: sil {{.*}}[clang fromNonTrivialValue] {{.*}} : $@convention(c) (@in{{(_cxx)?}} NonTrivialByValue) -> @lifetime(immortal) @owned View
 // CHECK: sil {{.*}}[clang fromTrivialValue] {{.*}} : $@convention(c) (Owner) -> @lifetime(immortal) @owned View
 // CHECK: sil {{.*}}[clang fromPointer] {{.*}} : $@convention(c) (Optional<UnsafePointer<Int32>>) -> @lifetime(immortal) @owned View
+// CHECK: sil {{.*}}[clang fromLvalueRefTrivialValue] {{.*}} : $@convention(c) (@inout Owner) -> @lifetime(borrow address 0) @owned View
+// CHECK: sil {{.*}}[clang fromLvalueRefNonTrivialValue] {{.*}} : $@convention(c) (@inout NonTrivialByValue) -> @lifetime(borrow address 0) @owned View
+// CHECK: sil {{.*}}[clang fromRvalueRefTrivialValue] {{.*}} : $@convention(c) (@in{{(_cxx)?}} Owner) -> @lifetime(immortal) @owned View
+// CHECK: sil {{.*}}[clang fromRvalueRefNonTrivialValue] {{.*}} : $@convention(c) (@in{{(_cxx)?}} NonTrivialByValue) -> @lifetime(immortal) @owned View
 
 //--- test.swift
 
@@ -330,6 +339,16 @@ func byValueAndPointerLifetimebound(_ n: NonTrivialByValue, _ o: Owner,
     let _ = fromNonTrivialValue(n)
     let _ = fromTrivialValue(o)
     let _ = fromPointer(p)
+}
+
+func lvalueRefLifetimebound(_ o: inout Owner, _ n: inout NonTrivialByValue) {
+    let _ = fromLvalueRefTrivialValue(&o)
+    let _ = fromLvalueRefNonTrivialValue(&n)
+}
+
+func rvalueRefLifetimebound(_ o: consuming Owner, _ n: consuming NonTrivialByValue) {
+    let _ = fromRvalueRefTrivialValue(consuming: o)
+    let _ = fromRvalueRefNonTrivialValue(consuming: n)
 }
 
 //--- escaping_scopes.swift


### PR DESCRIPTION
Previously, when the C++ annotation described an inherited lifetime dependence but the annotated parameter was imported as an escapable type we over-approximated the lifetime contracts by creating a new scoped dependence. This, however, is not correct as scoped dependence can change the calling convention in Swift. The new approach just imports these functions with unrepresentable lifetime contracts as unsafe and this avoids some crashes in the compiler due to the mismatched calling conventions.

rdar://181988295
rdar://181988226
