### PR TITLE
[Backtracing] Improved bounds checking in ImageSource

### DIFF
--- a/stdlib/public/RuntimeModule/Dwarf.swift
+++ b/stdlib/public/RuntimeModule/Dwarf.swift
@@ -1397,7 +1397,8 @@ class DwarfReader<S: DwarfSource & AnyObject> {
         if !shouldFetchIndirect {
           return .stringFromStrTab(offset)
         } else {
-          guard let string = try strSection.fetchString(from: offset) else {
+          let (string, _) = try strSection.fetchString(from: offset)
+          guard let string else {
             throw DwarfError.badString
           }
           return .string(string)
@@ -1427,7 +1428,8 @@ class DwarfReader<S: DwarfSource & AnyObject> {
         if !shouldFetchIndirect {
           return .stringFromLineStrTab(offset)
         } else {
-          guard let string = try lineStrSection.fetchString(from: offset) else {
+          let (string, _) = try lineStrSection.fetchString(from: offset)
+          guard let string else {
             throw DwarfError.badString
           }
           return .string(string)
@@ -1477,8 +1479,8 @@ class DwarfReader<S: DwarfSource & AnyObject> {
                                               as: UInt32.self)))
           }
 
-          guard let string = try strSection.fetchString(from: actualOffset)
-          else {
+          let (string, _) = try strSection.fetchString(from: actualOffset)
+          guard let string else {
             throw DwarfError.badString
           }
           return .string(string)

--- a/stdlib/public/RuntimeModule/Elf.swift
+++ b/stdlib/public/RuntimeModule/Elf.swift
@@ -1565,12 +1565,12 @@ final class ElfImage<SomeElfTraits: ElfTraits> : DwarfSource {
       return nil
     }
 
-    guard let link = try? section.fetchString(from: 0) else {
+    guard let (link, linkCount) = try? section.fetchString(from: 0),
+          let link else {
       return nil
     }
 
-    let nullIndex = ImageSource.Address(link.utf8.count)
-    let crcIndex = (nullIndex + 4) & ~3
+    let crcIndex = (ImageSource.Address(linkCount) + 3) & ~3
 
     guard let unswappedCrc = try? section.fetch(
             from: crcIndex, as: UInt32.self
@@ -1594,13 +1594,12 @@ final class ElfImage<SomeElfTraits: ElfTraits> : DwarfSource {
       return nil
     }
 
-    guard let link = try? section.fetchString(from: 0) else {
+    guard let (link, linkCount) = try? section.fetchString(from: 0),
+          let link else {
       return nil
     }
 
-    let nullIndex = link.utf8.count
-
-    let uuid = [UInt8](section.bytes[(nullIndex + 1)...])
+    let uuid = [UInt8](section.bytes[linkCount...])
 
     return DebugAltLinkInfo(link: link, uuid: uuid)
   }

--- a/stdlib/public/RuntimeModule/ImageSource.swift
+++ b/stdlib/public/RuntimeModule/ImageSource.swift
@@ -434,19 +434,20 @@ extension ImageSource: MemoryReader {
     return bytes.loadUnaligned(fromByteOffset: offset, as: type)
   }
 
-  public func fetchString(from address: Address) throws -> String? {
-    let offset = Int(address)
+  public func fetchString(from address: Address) throws
+    -> (String?, consumedBytes: Int) {
     guard let offset = Int(exactly: address),
             offset >= 0 && offset <= bytes.count else {
       throw ImageSourceError.outOfBoundsRead
     }
-    let len = strnlen(bytes.baseAddress! + offset, bytes.count - offset)
+    let maxLen = bytes.count - offset
+    let len = strnlen(bytes.baseAddress! + offset, maxLen)
     let stringBytes = bytes[offset..<offset+len]
-    return String(decoding: stringBytes, as: UTF8.self)
+    return (String(decoding: stringBytes, as: UTF8.self),
+            consumedBytes: len == maxLen ? maxLen : len + 1)
   }
 
   public func fetchString(from address: Address, length: Int) throws -> String? {
-    let offset = Int(address)
     guard let offset = Int(exactly: address),
             bytes.count >= length &&
             offset >= 0 && offset <= bytes.count - length else {
@@ -499,10 +500,11 @@ struct ImageSourceCursor {
   }
 
   mutating func readString() throws -> String? {
-    guard let result = try source.fetchString(from: pos) else {
+    guard let (result, count) = try? source.fetchString(from: pos),
+          let result else {
       return nil
     }
-    pos += Size(result.utf8.count + 1) // +1 for the NUL
+    pos += Size(count) // +1 for the NUL
     return result
   }
 

--- a/stdlib/public/RuntimeModule/ImageSource.swift
+++ b/stdlib/public/RuntimeModule/ImageSource.swift
@@ -415,9 +415,9 @@ struct ImageSource: CustomStringConvertible {
 extension ImageSource: MemoryReader {
   public func fetch(from address: Address,
                     into buffer: UnsafeMutableRawBufferPointer) throws {
-    let offset = Int(address)
-    guard bytes.count >= buffer.count &&
-            offset <= bytes.count - buffer.count else {
+    guard let offset = Int(exactly: address),
+          bytes.count >= buffer.count &&
+            offset >= 0 && offset <= bytes.count - buffer.count else {
       throw ImageSourceError.outOfBoundsRead
     }
     buffer.copyMemory(from: UnsafeRawBufferPointer(
@@ -426,8 +426,9 @@ extension ImageSource: MemoryReader {
 
   public func fetch<T>(from address: Address, as type: T.Type) throws -> T {
     let size = MemoryLayout<T>.size
-    let offset = Int(address)
-    guard offset <= bytes.count - size else {
+    guard let offset = Int(exactly: address),
+            bytes.count >= size &&
+            offset >= 0 && offset <= bytes.count - size else {
       throw ImageSourceError.outOfBoundsRead
     }
     return bytes.loadUnaligned(fromByteOffset: offset, as: type)
@@ -435,6 +436,10 @@ extension ImageSource: MemoryReader {
 
   public func fetchString(from address: Address) throws -> String? {
     let offset = Int(address)
+    guard let offset = Int(exactly: address),
+            offset >= 0 && offset <= bytes.count else {
+      throw ImageSourceError.outOfBoundsRead
+    }
     let len = strnlen(bytes.baseAddress! + offset, bytes.count - offset)
     let stringBytes = bytes[offset..<offset+len]
     return String(decoding: stringBytes, as: UTF8.self)
@@ -442,6 +447,11 @@ extension ImageSource: MemoryReader {
 
   public func fetchString(from address: Address, length: Int) throws -> String? {
     let offset = Int(address)
+    guard let offset = Int(exactly: address),
+            bytes.count >= length &&
+            offset >= 0 && offset <= bytes.count - length else {
+      throw ImageSourceError.outOfBoundsRead
+    }
     let stringBytes = bytes[offset..<offset+length]
     return String(decoding: stringBytes, as: UTF8.self)
   }

--- a/stdlib/public/RuntimeModule/MemoryReader.swift
+++ b/stdlib/public/RuntimeModule/MemoryReader.swift
@@ -59,7 +59,7 @@ public protocol MemoryReader {
   func fetch<T>(from addr: Address, as: T.Type) throws -> T
 
   /// Fetch a NUL terminated string from the specified location in the source
-  func fetchString(from addr: Address) throws -> String?
+  func fetchString(from addr: Address) throws -> (String?, consumedBytes: Int)
 
   /// Fetch a fixed-length string from the specified location in the source
   func fetchString(from addr: Address, length: Int) throws -> String?
@@ -98,7 +98,7 @@ extension MemoryReader {
     }
   }
 
-  public func fetchString(from addr: Address) throws -> String? {
+  public func fetchString(from addr: Address) throws -> (String?, consumedBytes: Int) {
     var bytes: [UInt8] = []
     var ptr = addr
     while true {
@@ -110,7 +110,7 @@ extension MemoryReader {
       ptr += 1
     }
 
-    return String(decoding: bytes, as: UTF8.self)
+    return (String(decoding: bytes, as: UTF8.self), consumedBytes: bytes.count)
   }
 
   public func fetchString(from addr: Address, length: Int) throws -> String? {
@@ -137,9 +137,12 @@ public struct UnsafeLocalMemoryReader: MemoryReader {
     return ptr.loadUnaligned(fromByteOffset: 0, as: type)
   }
 
-  public func fetchString(from address: Address) throws -> String? {
+  public func fetchString(from address: Address) throws -> (String?, consumedBytes: Int) {
     let ptr = UnsafeRawPointer(bitPattern: UInt(address))!
-    return String(validatingUTF8: ptr.assumingMemoryBound(to: CChar.self))
+    guard let str = String(validatingUTF8: ptr.assumingMemoryBound(to: CChar.self)) else {
+      return (nil, 0)
+    }
+    return (str, consumedBytes: str.utf8.count)
   }
 }
 

--- a/stdlib/public/RuntimeModule/PeCoff.swift
+++ b/stdlib/public/RuntimeModule/PeCoff.swift
@@ -671,7 +671,10 @@ final class PeCoffImage {
                                                as: UInt8.self)
               let age = maybeSwap(try entrySource.fetch(from: 20,
                                                         as: UInt32.self))
-              let pdbFile = try entrySource.fetchString(from: 24)!
+              let (pdbFile, _) = try entrySource.fetchString(from: 24)
+              guard let pdbFile else {
+                break
+              }
 
               self.codeview = PeCodeview(uuid: uuid, age: age, pdbPath: pdbFile)
 


### PR DESCRIPTION
Improve the bounds checks in `ImageSource`. Also improve the handling of bad (non-UTF8, non-NUL-terminated) strings.

rdar://182340608