### PR TITLE
build-script: Default --llvm-enable-index-store off and cover launcher route

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -339,11 +339,13 @@ def apply_default_arguments(toolchain, args):
     if ninja_required and toolchain.ninja is None:
         args.build_ninja = True
 
-    # Force --llvm-enable-index-store off when --sccache is in use. sccache
-    # can't cache compilations that emit -index-store-path side outputs, so
-    # leaving the index store enabled forces a cache miss on every
-    # translation unit.
-    if args.sccache:
+    # Force --llvm-enable-index-store off when a compiler-cache launcher is in
+    # use. sccache (and other caching wrappers) can't cache compilations that
+    # emit -index-store-path side outputs, so leaving the index store enabled
+    # forces a cache miss on every translation unit. --sccache is translated
+    # into --cmake-c-launcher/--cmake-cxx-launcher later on, but a launcher can
+    # also be passed explicitly, so cover both spellings here.
+    if args.sccache or args.cmake_c_launcher or args.cmake_cxx_launcher:
         args.llvm_enable_index_store = False
 
     # Enable test colors if we're on a tty.

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -1528,13 +1528,14 @@ def create_argument_parser():
            help='enable building llvm using modules')
 
     option('--llvm-enable-index-store', toggle_true('llvm_enable_index_store'),
-           default=True,
+           default=False,
            help='emit -index-store-path while building LLVM/Clang and Swift '
                 'host tools (gated on the host compiler accepting the flag, '
-                'so it is a no-op for older compilers). Defaults to ON, but '
-                'is forced OFF when --sccache is in use (sccache cannot '
-                'cache the index-store side outputs and would otherwise '
-                'miss on every translation unit).')
+                'so it is a no-op for older compilers). Defaults to OFF. It '
+                'is also forced OFF when --sccache or an explicit '
+                '--cmake-c-launcher/--cmake-cxx-launcher is in use (compiler '
+                'caches cannot cache the index-store side outputs and would '
+                'otherwise miss on every translation unit).')
 
     option('--llvm-targets-to-build', store,
            default='X86;ARM;AArch64;PowerPC;SystemZ;Mips;RISCV;WebAssembly;AVR;BPF',

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -259,7 +259,7 @@ EXPECTED_DEFAULTS = {
     'llvm_build_variant': 'RelWithDebInfo',
     'llvm_cmake_options': [],
     'llvm_enable_modules': False,
-    'llvm_enable_index_store': True,
+    'llvm_enable_index_store': False,
     'llvm_include_tests': True,
     'llvm_ninja_targets': [],
     'llvm_ninja_targets_for_cross_compile_hosts': [],


### PR DESCRIPTION
Change the default of --llvm-enable-index-store from ON to OFF. Emitting -index-store-path defeats compiler caches (sccache et al.), which cannot cache the index-store side outputs and therefore miss on every translation unit. Making it opt-in keeps the common cached-build path fast and only pays the index-store cost when a developer explicitly asks for it.

Also broaden the force-off guard so it fires for an explicit --cmake-c-launcher/--cmake-cxx-launcher, not just --sccache. --sccache is translated into those launcher options later in the build, but a caching wrapper can also be passed directly as a launcher; that route previously left args.sccache false and leaked -index-store-path through, causing the very cache misses the guard was meant to prevent.

Update the option help text and the expected-options test to match the new default.

rdar://182557788
