### PR TITLE
[DebugInfo] Salvage convert_function correctly

### DIFF
--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -1845,6 +1845,11 @@ bool swift::tryEliminateOnlyOwnershipUsedForwardingInst(
     return false;
   }
 
+  // Rewrite debug uses separately (they might need salvaging logic).
+  // Note: We know that `forwardingInst` is salvageable as this function is
+  // only called with convert_function instructions.
+  salvageDebugInfo(forwardingInst);
+
   // Now that we know we can perform our transform, set all uses of
   // forwardingInst to be used of its operand and then delete \p forwardingInst.
   auto newValue = singleFwdOp->get();
@@ -2287,7 +2292,7 @@ void swift::salvageDebugInfo(SILInstruction *I) {
     salvageUnaryInst(cast<SingleValueInstruction>(I));
 
   if (isa<UpcastInst>(I) || isa<UncheckedRefCastInst>(I) ||
-      isa<ConvertEscapeToNoEscapeInst>(I))
+      isa<ConvertEscapeToNoEscapeInst>(I) || isa<ConvertFunctionInst>(I))
     salvageUnaryInst(cast<SingleValueInstruction>(I));
 
   if (isa<StructElementAddrInst>(I) || isa<TupleElementAddrInst>(I) ||

--- a/test/DebugInfo/salvage_convert_function.sil
+++ b/test/DebugInfo/salvage_convert_function.sil
@@ -1,0 +1,29 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -sil-combine | %FileCheck %s
+
+// Test that convert_function is correctly salvaged into a debug
+// reconstruction block by tryEliminateOnlyOwnershipUsedForwardingInst
+// in SILCombine's visitConvertFunctionInst.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+// CHECK-LABEL: sil @test_salvage_convert_function
+// CHECK: bb0(%0 :
+// CHECK:   debug_value %0, let, name "fn", transform {
+// CHECK:   bb0(%0 :
+// CHECK:     %1 = convert_function %0 to $@callee_guaranteed () -> (@out Any, @error any Error)
+// CHECK:     return %1
+// CHECK:   }
+// CHECK:   strong_release %0
+// CHECK:   return
+// CHECK-LABEL: } // end sil function 'test_salvage_convert_function'
+sil @test_salvage_convert_function : $@convention(thin) (@guaranteed @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <Any>) -> () {
+bb0(%0 : $@callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <Any>):
+  %1 = convert_function %0 : $@callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <Any> to $@callee_guaranteed () -> (@out Any, @error any Error)
+  debug_value %1 : $@callee_guaranteed () -> (@out Any, @error any Error), let, name "fn"
+  strong_release %1 : $@callee_guaranteed () -> (@out Any, @error any Error)
+  %r = tuple ()
+  return %r : $()
+}

--- a/test/DebugInfo/salvage_convert_function_tuple_fragment.swift
+++ b/test/DebugInfo/salvage_convert_function_tuple_fragment.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend %s -O -emit-sil -g | %FileCheck %s
+
+// Fixed crasher: iterating over a tuple array containing a
+// () throws -> Any closure caused a verifier failure because
+// tryEliminateOnlyOwnershipUsedForwardingInst RAUW'ed instead of salvaging.
+
+// CHECK: debug_value {{%[0-9]+}}, let, name "$element", {{.*}}op_tuple_fragment:{{.*}}:1, transform {
+// CHECK-NEXT: // %0
+// CHECK-NEXT: bb0(%0 :
+// CHECK-NEXT:   %1 = convert_function %0 to $@callee_guaranteed () -> (@out Any, @error any Error)
+// CHECK-NEXT:   return %1
+// CHECK-NEXT: }
+
+func test() {
+    let a: [(Int, () throws -> Any)] = [(0, { 1 })]
+    for (_, f) in a {
+        _ = try! f()
+    }
+}
+
+test()


### PR DESCRIPTION
The debug uses of the convert_function instruction being replaced with values of a different type is a problem, as the debug value incorrectly changes type (fixes a regression, the crasher has been added as a Swift test).

Instead, call salvageDebugInfo and implement salvaging convert_function instructions (which is just a bitcast salvaged as unary).

The convert_function salvage also addresses 0.01% of missing salvages in the source compatibility test suite.
Decreases the amount of variables lost by SILCombine in the stdlib by 0.15%.