### PR TITLE
IRGen: Adjust to "Reapply [ConstantInt] Disable implicit truncation in ConstantInt::get() (#171456)"

### DIFF
--- a/lib/IRGen/GenArray.cpp
+++ b/lib/IRGen/GenArray.cpp
@@ -342,8 +342,8 @@ public:
                                        Address src, SILType T,
                                        bool isOutlined) const override {
     if (ArraySize == 0)
-      return llvm::ConstantInt::get(IGF.IGM.Int32Ty, -1);
-      
+      return llvm::ConstantInt::getAllOnesValue(IGF.IGM.Int32Ty);
+
     auto firstElementAddr
       = IGF.Builder.CreateElementBitCast(src, Element.getStorageType());
 

--- a/lib/IRGen/GenCast.cpp
+++ b/lib/IRGen/GenCast.cpp
@@ -811,8 +811,9 @@ void irgen::emitScalarExistentialDowncast(
     fastLookupIndex  = getFastLookupIndex(IGF.IGM, srcInstanceType, layout.getProtocols()[0]);
   }
   if (fastLookupIndex.has_value()) {
-    llvm::Value *indices[] = {
-         llvm::ConstantInt::get(IGF.IGM.Int32Ty, -(int)fastLookupIndex.value() - MetadataAdjustmentIndex::Class - 1)};
+    llvm::Value *indices[] = {llvm::ConstantInt::getSigned(
+        IGF.IGM.Int32Ty, -(int)fastLookupIndex.value() -
+                             int(MetadataAdjustmentIndex::Class) - 1)};
     auto addr = IGF.Builder.CreateGEP(IGF.IGM.WitnessTablePtrTy, metadataValue, indices);
     auto wt = IGF.Builder.CreateLoad(Address(
         addr, IGF.IGM.TypeMetadataPtrTy, IGF.IGM.getPointerAlignment()));

--- a/lib/IRGen/GenConcurrency.cpp
+++ b/lib/IRGen/GenConcurrency.cpp
@@ -1080,7 +1080,7 @@ llvm::Value *irgen::clearImplicitIsolatedActorBits(IRGenFunction &IGF,
   auto *bitMask =
       IGF.getOptions().HasAArch64TBI
           ? llvm::ConstantInt::get(IGF.IGM.IntPtrTy, 0xCFFFFFFFFFFFFFFFull)
-          : llvm::ConstantInt::get(IGF.IGM.IntPtrTy, -4);
+          : llvm::ConstantInt::getSigned(IGF.IGM.IntPtrTy, -4);
   auto *result = IGF.Builder.CreateAnd(cast, bitMask);
   return IGF.Builder.CreateBitOrPointerCast(result, value->getType());
 }

--- a/lib/IRGen/GenConstant.cpp
+++ b/lib/IRGen/GenConstant.cpp
@@ -470,7 +470,8 @@ llvm::Constant *irgen::emitConstantObject(IRGenModule &IGM, ObjectInst *OI,
       if (IGM.Context.LangOpts.hasFeature(Feature::Embedded)) {
         // = HeapObject.immortalRefCount | HeapObject.doNotFreeBit
         // 0xffff_ffff on 32-bit, 0xffff_ffff_ffff_ffff on 64-bit
-        IGM.swiftImmortalRefCount = llvm::ConstantInt::get(IGM.IntPtrTy, -1);
+        IGM.swiftImmortalRefCount =
+            llvm::ConstantInt::getAllOnesValue(IGM.IntPtrTy);
       } else {
         IGM.swiftImmortalRefCount = llvm::ConstantExpr::getPtrToInt(
             new llvm::GlobalVariable(IGM.Module, IGM.Int8Ty,

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -5745,8 +5745,9 @@ namespace {
                                tag);
       auto isExtraInhabitant = IGF.Builder.CreateICmpULT(index,
                               llvm::ConstantInt::get(IGF.IGM.Int32Ty, xiCount));
-      return IGF.Builder.CreateSelect(isExtraInhabitant,
-                            index, llvm::ConstantInt::get(IGM.Int32Ty, -1));
+      return IGF.Builder.CreateSelect(
+          isExtraInhabitant, index,
+          llvm::ConstantInt::getAllOnesValue(IGM.Int32Ty));
     }
 
     void storeExtraInhabitant(IRGenFunction &IGF,

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -917,7 +917,7 @@ emitKeyPathComponent(IRGenModule &IGM,
         auto &protoInfo = IGM.getProtocolInfo(methodProto,
                                               ProtocolInfoKind::Full);
         auto index = protoInfo.getFunctionIndex(declRef);
-        idValue = llvm::ConstantInt::get(IGM.SizeTy, -index.getValue());
+        idValue = llvm::ConstantInt::getSigned(IGM.SizeTy, -index.getValue());
         idResolution = KeyPathComponentHeader::Resolved;
       }
       break;

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1068,7 +1068,8 @@ namespace {
         auto address =
           B.getAddrOfCurrentPosition(IGM.ProtocolRequirementStructTy);
         int offset = WitnessTableFirstRequirementOffset;
-        auto firstReqAdjustment = llvm::ConstantInt::get(IGM.Int32Ty, -offset);
+        auto firstReqAdjustment =
+            llvm::ConstantInt::getSigned(IGM.Int32Ty, -offset);
         address = llvm::ConstantExpr::getGetElementPtr(
             IGM.ProtocolRequirementStructTy, address, firstReqAdjustment);
 
@@ -3613,7 +3614,7 @@ static void emitInitializeRawLayoutOld(IRGenFunction &IGF, SILType likeType,
   // If we don't have a count, then we're the 'like:' variant and we need to
   // pass '-1' to the runtime call.
   if (!count) {
-    count = llvm::ConstantInt::get(IGF.IGM.Int32Ty, -1);
+    count = llvm::ConstantInt::getAllOnesValue(IGF.IGM.Int32Ty);
   }
 
   // Call swift_initRawStructMetadata().

--- a/lib/IRGen/GenPack.cpp
+++ b/lib/IRGen/GenPack.cpp
@@ -223,8 +223,8 @@ llvm::Value *irgen::maskMetadataPackPointer(IRGenFunction &IGF,
   // If the pack is on the heap, the LSB is set, so mask it off.
   patternPack =
       IGF.Builder.CreatePtrToInt(patternPack, IGF.IGM.SizeTy);
-  patternPack =
-      IGF.Builder.CreateAnd(patternPack, llvm::ConstantInt::get(IGF.IGM.SizeTy, -2));
+  patternPack = IGF.Builder.CreateAnd(
+      patternPack, llvm::ConstantInt::getSigned(IGF.IGM.SizeTy, -2));
   patternPack =
       IGF.Builder.CreateIntToPtr(patternPack, IGF.IGM.TypeMetadataPtrPtrTy);
   return patternPack;
@@ -271,8 +271,8 @@ static llvm::Value *loadWitnessTableAtIndex(IRGenFunction &IGF,
   // If the pack is on the heap, the LSB is set, so mask it off.
   wtablePack =
       IGF.Builder.CreatePtrToInt(wtablePack, IGF.IGM.SizeTy);
-  wtablePack =
-      IGF.Builder.CreateAnd(wtablePack, llvm::ConstantInt::get(IGF.IGM.SizeTy, -2));
+  wtablePack = IGF.Builder.CreateAnd(
+      wtablePack, llvm::ConstantInt::getSigned(IGF.IGM.SizeTy, -2));
   wtablePack =
       IGF.Builder.CreateIntToPtr(wtablePack, IGF.IGM.WitnessTablePtrPtrTy);
 

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -386,7 +386,7 @@ FixedTypeInfo::getSpareBitExtraInhabitantIndex(IRGenFunction &IGF,
   
   // If we had a valid value, return -1. Otherwise, return the index.
   auto phi = IGF.Builder.CreatePHI(IGF.IGM.Int32Ty, 2);
-  phi->addIncoming(llvm::ConstantInt::get(IGF.IGM.Int32Ty, -1), origBB);
+  phi->addIncoming(llvm::ConstantInt::getAllOnesValue(IGF.IGM.Int32Ty), origBB);
   phi->addIncoming(idx, spareBB);
   
   return phi;


### PR DESCRIPTION
`ConstantInt::get/getSigned` no longer implicitly truncate the value to the type width by default; they now assert (via the `APInt` constructor) that the `uint64_t` value, when interpreted as having the given signedness, fits in the given bit width. IRGen was calling the unsigned overload with negative values (e.g. -1, -offset), which will hit those asserts if the requested bit width < 64. Switch these calls to `ConstantInt::getSigned/getAllOnesValue` to satisfy the assertions and also correctly extend the value if the bit width > 64.

See https://github.com/llvm/llvm-project/commit/a83c89495ba6fe0134dcaa02372c320cc7ff0dbf (https://github.com/llvm/llvm-project/pull/171456).