### PR TITLE
Sema: diagnose Self and associated types in a protocol metatype extension

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2243,6 +2243,11 @@ ERROR(metatype_extension_com_only, none,
       "protocol metatype extensions are reserved for COM interop", ())
 ERROR(metatype_extension_non_protocol, none,
       "metatype extension can only extend a protocol, not %0", (Type))
+ERROR(metatype_extension_self, none,
+      "'Self' cannot be referenced in a protocol metatype extension", ())
+ERROR(metatype_extension_associated_type, none,
+      "associated type %0 cannot be referenced in a protocol metatype extension",
+      (DeclName))
 
 // @_staticExclusiveOnly
 ERROR(attr_static_exclusive_only_disabled,none,

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2311,6 +2311,21 @@ TypeResolver::resolveUnqualifiedIdentTypeRepr(UnqualifiedIdentTypeRepr *repr,
   auto *DC = getDeclContext();
   auto id = repr->getNameRef();
 
+  // A protocol metatype extension has no generic signature and its members are
+  // static members of the protocol metatype, so they cannot reference 'Self'.
+  // Diagnose before name lookup binds it to the protocol's 'Self', which would
+  // leave the member's interface type carrying an unanchored type parameter.
+  if (id.isSimpleName(ctx.Id_Self)) {
+    if (auto *typeDC = DC->getInnermostTypeContext()) {
+      if (typeDC->isMetatypeExtension()) {
+        if (!options.contains(TypeResolutionFlags::SilenceDiagnostics))
+          diagnose(repr->getLoc(), diag::metatype_extension_self);
+        repr->setInvalid();
+        return ErrorType::get(ctx);
+      }
+    }
+  }
+
   // In SIL mode, we bind generic parameters here, since name lookup
   // won't find them.
   if (silContext && silContext->GenericParams) {
@@ -2347,6 +2362,22 @@ TypeResolver::resolveUnqualifiedIdentTypeRepr(UnqualifiedIdentTypeRepr *repr,
   for (const auto &entry : globals) {
     auto *foundDC = entry.getDeclContext();
     auto *typeDecl = cast<TypeDecl>(entry.getValueDecl());
+
+    // As with 'Self' above, a member of a protocol metatype extension cannot
+    // reference the extended protocol's associated types: doing so would root
+    // the member's interface type at an unanchored 'Self'.  Diagnose before
+    // resolving the reference, which would otherwise assert while substituting.
+    if (isa<AssociatedTypeDecl>(typeDecl)) {
+      if (auto *typeDC = DC->getInnermostTypeContext()) {
+        if (typeDC->isMetatypeExtension()) {
+          if (!options.contains(TypeResolutionFlags::SilenceDiagnostics))
+            diagnose(repr->getLoc(), diag::metatype_extension_associated_type,
+                     typeDecl->getName());
+          repr->setInvalid();
+          return ErrorType::get(ctx);
+        }
+      }
+    }
 
     // Compute the type of the found declaration when referenced from this
     // location.

--- a/test/Sema/metatype-extension-self.swift
+++ b/test/Sema/metatype-extension-self.swift
@@ -1,0 +1,43 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module-path %t/COM.swiftmodule -module-name COM -enable-experimental-com-interop %S/../Inputs/COM.swift
+// RUN: %target-typecheck-verify-swift -enable-experimental-com-interop -I %t
+
+import COM
+
+@com(interface: "10000000-0000-0000-0000-000000000001")
+protocol IWidget: IUnknown { }
+
+@com(interface: "20000000-0000-0000-0000-000000000002")
+protocol IGizmo: IUnknown { associatedtype Element }
+
+// A protocol metatype extension has no generic signature, and its members are
+// static members of the protocol metatype.  They cannot reference 'Self' or the
+// extended protocol's associated types: either would leave a member's interface
+// type carrying a type parameter with no environment to map it into.  Both are
+// diagnosed rather than left to crash while forming the interface type.
+extension IWidget.Protocol {
+  func retSelf() -> Self { fatalError() }
+  // expected-error@-1 {{'Self' cannot be referenced in a protocol metatype extension}}
+
+  func paramSelf(_ x: Self) { }
+  // expected-error@-1 {{'Self' cannot be referenced in a protocol metatype extension}}
+
+  var propSelf: Self { fatalError() }
+  // expected-error@-1 {{'Self' cannot be referenced in a protocol metatype extension}}
+
+  func selfMetatype() -> Self.Type { fatalError() }
+  // expected-error@-1 {{'Self' cannot be referenced in a protocol metatype extension}}
+
+  // Members that do not reference 'Self' are fine, including ones with their
+  // own generic parameters.
+  func ok() -> Int { 42 }
+  func generic<U>(_ x: U) -> U { x }
+}
+
+extension IGizmo.Protocol {
+  func retAssoc() -> Element { fatalError() }
+  // expected-error@-1 {{associated type 'Element' cannot be referenced in a protocol metatype extension}}
+
+  func paramAssoc(_ x: Element) { }
+  // expected-error@-1 {{associated type 'Element' cannot be referenced in a protocol metatype extension}}
+}


### PR DESCRIPTION
A protocol metatype extension has no generic signature, and its members are static members of the protocol metatype — they cannot reference `Self` or the extended protocol's associated types.  Either resolves to a type parameter (the protocol's `Self`, or a dependent member rooted at it), leaving the member's interface type carrying a parameter with no environment to map it into; that asserted in `mapTypeIntoEnvironment` for `Self`, and while substituting the associated type's context for the latter.

Diagnose both during unqualified type resolution and recover with an error type: `Self` before name lookup binds it to the protocol's own, and an associated type before it is resolved.  Members that reference neither — including ones with their own generic parameters — are unaffected.

This was something that Slava Pestov brought up in code review, and this should close that gap.