### PR TITLE
Reparenting: fixes for reparented extension having differing availability

### DIFF
--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -1508,7 +1508,16 @@ bool LinkEntity::isWeakImported(ModuleDecl *module) const {
     if (baseProto->isWeakImported(module))
       return true;
 
-    return cast<ProtocolDecl>(getDecl())->isWeakImported(module);
+    // The base protocol may be available, yet reached through a @reparented
+    // extension that is itself less available than the base protocol.
+    // That extension's availability defines when the base protocol's
+    // relationship was established.
+    auto *sourceProto = cast<ProtocolDecl>(getDecl());
+    for (auto [newBase, ext, index] : sourceProto->getReparentingProtocols())
+      if (newBase == baseProto && ext->isWeakImported(module))
+        return true;
+
+    return sourceProto->isWeakImported(module);
   }
 
   case Kind::TypeMetadata:

--- a/lib/SIL/Utils/DynamicCasts.cpp
+++ b/lib/SIL/Utils/DynamicCasts.cpp
@@ -119,6 +119,16 @@ classifyDynamicCastToProtocol(SILFunction *function, CanType source, CanType tar
     if (!matchesActorIsolation(conformance, function))
       return DynamicCastFeasibility::MaySucceed;
 
+    // The compile-time conformance may be provided by a @reparented
+    // extension whose availability isn't the same as the availability of
+    // the resilient-parent protocol itself. In that case, if the deployment
+    // target is older than the extension, the cast may not succeed.
+    //
+    // For now, conservatively say that all casts to resilient-parent protocols
+    // are not statically optimizable.
+    if (TargetProtocol->getAttrs().hasAttribute<ReparentableAttr>())
+      return DynamicCastFeasibility::MaySucceed;
+
     return DynamicCastFeasibility::WillSucceed;
   }
 

--- a/test/IRGen/Inputs/reparentable_availability_lib.swift
+++ b/test/IRGen/Inputs/reparentable_availability_lib.swift
@@ -1,0 +1,8 @@
+@reparentable public protocol RP {}
+
+public protocol P: RP {
+  func doP()
+}
+
+@available(macOS 14, *)
+extension P: @reparented RP {}

--- a/test/IRGen/reparentable_availability.swift
+++ b/test/IRGen/reparentable_availability.swift
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -enable-experimental-feature Reparenting -enable-library-evolution -emit-module %S/Inputs/reparentable_availability_lib.swift -o %t
+
+// A conformance to P references the base conformance descriptor for P: RP,
+// but because of the availability of the @reparented extension, that
+// conformance descriptor is only available in macOS 14, so it should be
+// weak-linked when targeting platforms older than that.
+
+// OLD: @"$s{{.*}}1PPAA2RPTb" = extern_weak global
+// RUN: %target-swift-frontend -module-name output -enable-experimental-feature Reparenting -target %target-cpu-apple-macosx13 -emit-ir -parse-as-library %s -I %t | %FileCheck %s --check-prefix=OLD
+
+// NEW: @"$s{{.*}}1PPAA2RPTb" = external global
+// RUN: %target-swift-frontend -module-name output -enable-experimental-feature Reparenting -target %target-cpu-apple-macosx14 -emit-ir -parse-as-library %s -I %t | %FileCheck %s --check-prefix=NEW
+
+// REQUIRES: OS=macosx
+// REQUIRES: swift_feature_Reparenting
+
+import reparentable_availability_lib
+
+public struct C: P {
+  public func doP() {}
+}

--- a/test/SILOptimizer/cast_folding_reparentable.swift
+++ b/test/SILOptimizer/cast_folding_reparentable.swift
@@ -1,0 +1,37 @@
+// RUN: %target-swift-frontend -O -Xllvm -sil-print-types -Xllvm -sil-disable-pass=function-signature-opts -emit-sil -enable-experimental-feature Reparenting %s | %FileCheck %s
+
+// REQUIRES: swift_feature_Reparenting
+
+// A cast to a resilient-parent (@reparentable) protocol must never be folded
+// statically: a @reparented extension can introduce the inheritance edge at an
+// availability newer than the deployment target, so the conformance is not
+// guaranteed to exist at runtime. This holds regardless of how the source
+// conforms or what the deployment target is.
+
+@reparentable
+public protocol RP {}
+
+public protocol Child: RP {}
+extension Child: @reparented RP {}
+
+public final class C: Child {}
+
+// The cast to RP is kept: it is not statically foldable.
+// CHECK-LABEL: sil [noinline] @$s25cast_folding_reparentable0A4ToRPySbAA1CCF :
+// CHECK: checked_cast_addr_br {{.*}} C in {{.*}} to any RP
+// CHECK: } // end sil function '$s25cast_folding_reparentable0A4ToRPySbAA1CCF'
+@inline(never)
+public func castToRP(_ x: C) -> Bool {
+  return x is RP
+}
+
+// Casting to an ordinary protocol still folds, even one that inherits from a
+// @reparentable protocol: only casts whose target is itself @reparentable are
+// pessimized.
+// CHECK-LABEL: sil [noinline] @$s25cast_folding_reparentable0A7ToChildySbAA1CCF :
+// CHECK-NOT: checked_cast
+// CHECK: integer_literal $Builtin.Int1, -1
+@inline(never)
+public func castToChild(_ x: C) -> Bool {
+  return x is Child
+}


### PR DESCRIPTION
There are two issues that can come up when the @reparented extension has availability different than the resilient-parent protocol itself:

- The base conformance descriptor was accidentally not being weak-linked based on that extension, whose availability defines when the parent-child relationship was established.
- Dynamic casts may be accidentally constant-folded, despite the availability of the parent-child relationship not existing for the given deployment target.

resolves rdar://175354629&181953862