### PR TITLE
[RemoteInspection] Thread mangling flavor through TypeRefBuilder

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -1234,7 +1234,7 @@ public:
         return BuiltType();
 
       auto mangling =
-          Demangle::mangleNode(node, Mangle::ManglingFlavor::Default);
+          Demangle::mangleNode(node, Builder.getManglingFlavor());
       if (!mangling.isSuccess())
         return BuiltType();
       auto name = mangling.result();

--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -233,8 +233,10 @@ public:
   explicit ReflectionContext(
       std::shared_ptr<MemoryReader> reader,
       remote::ExternalTypeRefCache *externalCache = nullptr,
-      reflection::DescriptorFinder *descriptorFinder = nullptr)
-      : super(std::move(reader), *this, externalCache, descriptorFinder) {}
+      reflection::DescriptorFinder *descriptorFinder = nullptr,
+      Mangle::ManglingFlavor flavor = Mangle::ManglingFlavor::Default)
+      : super(std::move(reader), *this, externalCache, descriptorFinder,
+              flavor) {}
 
   ReflectionContext(const ReflectionContext &other) = delete;
   ReflectionContext &operator=(const ReflectionContext &other) = delete;

--- a/include/swift/RemoteInspection/TypeRef.h
+++ b/include/swift/RemoteInspection/TypeRef.h
@@ -230,7 +230,9 @@ public:
   Demangle::NodePointer getDemangling(Demangle::Demangler &Dem) const;
 
   /// Build the mangled name from this TypeRef.
-  std::optional<std::string> mangle(Demangle::Demangler &Dem) const;
+  std::optional<std::string>
+  mangle(Demangle::Demangler &Dem,
+         Mangle::ManglingFlavor Flavor = Mangle::ManglingFlavor::Default) const;
 
   bool isConcrete() const;
   bool isConcreteAfterSubstitutions(const GenericArgumentMap &Subs) const;

--- a/include/swift/RemoteInspection/TypeRefBuilder.h
+++ b/include/swift/RemoteInspection/TypeRefBuilder.h
@@ -434,11 +434,11 @@ public:
   TypeRefBuilder(const TypeRefBuilder &other) = delete;
   TypeRefBuilder &operator=(const TypeRefBuilder &other) = delete;
 
-  Mangle::ManglingFlavor getManglingFlavor() {
-    return Mangle::ManglingFlavor::Default;
-  }
+  Mangle::ManglingFlavor getManglingFlavor() { return Flavor; }
 
 private:
+  Mangle::ManglingFlavor Flavor;
+
   Demangle::Demangler Dem;
 
   /// Makes sure dynamically allocated TypeRefs stick around for the life of
@@ -798,7 +798,8 @@ public:
                                                           PointerSize>
           conformanceReader(
               Builder.OpaqueByteReader, Builder.OpaqueStringReader,
-              Builder.OpaquePointerReader, Builder.OpaqueDynamicSymbolResolver);
+              Builder.OpaquePointerReader, Builder.OpaqueDynamicSymbolResolver,
+              Builder.getManglingFlavor());
       for (const auto &section : ReflectionInfos) {
         auto ConformanceBegin = section.Conformance.startAddress();
         auto ConformanceEnd = section.Conformance.endAddress();
@@ -1536,7 +1537,10 @@ public:
 
   // Only for testing. A TypeRefBuilder built this way will not be able to
   // decode records in remote memory.
-  explicit TypeRefBuilder(ForTesting_t) : TC(*this), RDF(*this, nullptr) {}
+  explicit TypeRefBuilder(
+      ForTesting_t,
+      Mangle::ManglingFlavor flavor = Mangle::ManglingFlavor::Default)
+      : Flavor(flavor), TC(*this), RDF(*this, nullptr) {}
 
 private:
   /// Indexes of Reflection Infos we've already processed.
@@ -1616,8 +1620,10 @@ public:
   template <typename Runtime>
   TypeRefBuilder(remote::MetadataReader<Runtime, TypeRefBuilder> &reader,
                  remote::ExternalTypeRefCache *externalCache = nullptr,
-                 DescriptorFinder *externalDescriptorFinder = nullptr)
-      : TC(*this), EDF(externalDescriptorFinder), RDF(*this, externalCache),
+                 DescriptorFinder *externalDescriptorFinder = nullptr,
+                 Mangle::ManglingFlavor flavor = Mangle::ManglingFlavor::Default)
+      : Flavor(flavor), TC(*this), EDF(externalDescriptorFinder),
+        RDF(*this, externalCache),
         PointerSize(sizeof(typename Runtime::StoredPointer)),
         TypeRefDemangler([this, &reader](RemoteRef<char> string,
                                          bool useOpaqueTypeSymbolicReferences)
@@ -2329,16 +2335,19 @@ private:
     StringReader OpaqueStringReader;
     DynamicSymbolResolver OpaqueDynamicSymbolResolver;
     QualifiedContextNameReader<ObjCInteropKind, PointerSize> NameReader;
+    Mangle::ManglingFlavor Flavor;
 
     ProtocolConformanceDescriptorReader(
         ByteReader byteReader, StringReader stringReader,
         PointerReader pointerReader,
-        DynamicSymbolResolver dynamicSymbolResolver)
+        DynamicSymbolResolver dynamicSymbolResolver,
+        Mangle::ManglingFlavor flavor)
         : Error(""), OpaquePointerReader(pointerReader),
           OpaqueByteReader(byteReader), OpaqueStringReader(stringReader),
           OpaqueDynamicSymbolResolver(dynamicSymbolResolver),
           NameReader(byteReader, stringReader, pointerReader,
-                     dynamicSymbolResolver) {}
+                     dynamicSymbolResolver),
+          Flavor(flavor) {}
 
     /// Extract conforming type's name from a Conformance Descriptor
     /// Returns a pair of (mangledTypeName, fullyQualifiedTypeName)
@@ -2429,7 +2438,7 @@ private:
           typeName = nodeToString(typeRoot);
 
           auto typeMangling =
-              Demangle::mangleNode(typeRoot, Mangle::ManglingFlavor::Default);
+              Demangle::mangleNode(typeRoot, Flavor);
           if (!typeMangling.isSuccess())
             mangledTypeName = "";
           else

--- a/stdlib/public/RemoteInspection/TypeRef.cpp
+++ b/stdlib/public/RemoteInspection/TypeRef.cpp
@@ -1344,7 +1344,8 @@ Demangle::NodePointer TypeRef::getDemangling(Demangle::Demangler &Dem) const {
   return DemanglingForTypeRef(Dem).visit(this);
 }
 
-std::optional<std::string> TypeRef::mangle(Demangle::Demangler &Dem) const {
+std::optional<std::string> TypeRef::mangle(Demangle::Demangler &Dem,
+                                           Mangle::ManglingFlavor Flavor) const {
   NodePointer node = getDemangling(Dem);
   if (!node)
     return {};
@@ -1356,7 +1357,7 @@ std::optional<std::string> TypeRef::mangle(Demangle::Demangler &Dem) const {
   auto global = Dem.createNode(Node::Kind::Global);
   global->addChild(node, Dem);
 
-  auto mangling = mangleNode(global, Mangle::ManglingFlavor::Default);
+  auto mangling = mangleNode(global, Flavor);
   if (!mangling.isSuccess())
     return {};
   return mangling.result();

--- a/stdlib/public/RemoteInspection/TypeRefBuilder.cpp
+++ b/stdlib/public/RemoteInspection/TypeRefBuilder.cpp
@@ -187,7 +187,7 @@ TypeRefBuilder::ReflectionTypeDescriptorFinder::normalizeReflectionName(
           reflectionNameRemoteAddress, std::optional<std::string>()));
       return {};
     default:
-      auto mangling = mangleNode(node, Mangle::ManglingFlavor::Default);
+      auto mangling = mangleNode(node, Builder.getManglingFlavor());
       if (!mangling.isSuccess()) {
         NormalizedReflectionNameCache.insert(std::make_pair(
             reflectionNameRemoteAddress, std::optional<std::string>()));


### PR DESCRIPTION
Previously TypeRefBuilder::getManglingFlavor() unconditionally returned Mangle::ManglingFlavor::Default, so remangling type nodes always produced regular ($s) mangled names even for Embedded Swift ($e) types.

Receive a ManglingFlavor in the TypeRefBuilder constructors, store it, and return it from getManglingFlavor(). Thread the flavor along to every place that previously hardcoded Default. Also propagate the flavor through ReflectionContext's constructor so callers can supply it.

Assisted-by: claude
