### PR TITLE
COM: introduce the concept of a COM model

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -332,6 +332,17 @@ namespace swift {
     /// Enable COM interop code generation and build configuration options.
     bool EnableCOMInterop = false;
 
+    /// The COM interop model, selecting an environment's conventions. Today it
+    /// picks the root type an `@com` class conforms to; other conventions (byte
+    /// order, ref-counting) attach here as they are implemented. Empty exactly
+    /// when interop is off; defaulted from the target otherwise, and the user
+    /// may override it. `ISwiftObject` is compiler-managed under every model.
+    enum class COMInteropModel {
+      Microsoft,      ///< Microsoft COM: `IUnknown` root.
+      CoreFoundation, ///< CoreFoundation CFPlugIn: `IUnknown` root.
+    };
+    std::optional<COMInteropModel> COMModel = std::nullopt;
+
     /// Enable C++ interop code generation and build configuration
     /// options. Disabled by default because there is no way to control the
     /// language mode of clang on a per-header or even per-module basis. Also

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -440,6 +440,10 @@ let Flags = [FrontendOption, NoDriverOption, HelpHidden, ModuleInterfaceOption] 
   def enable_com_interop
     : Flag<["-"], "enable-experimental-com-interop">,
       HelpText<"Enable COM interop code generation and configuration directives">;
+
+  def com_interop_model
+    : Joined<["-"], "com-interop-model=">,
+      HelpText<"Select the COM interop model: 'microsoft' or 'corefoundation'">;
 }
 
 // HIDDEN FLAGS

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1682,6 +1682,26 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   Opts.UseStaticStandardLibrary = Args.hasArg(OPT_use_static_resource_dir);
   Opts.EnableCOMInterop = Args.hasArg(OPT_enable_com_interop);
+  // A COM interop model is in effect exactly when interop is enabled: default
+  // it from the target, then honor an explicit override.
+  if (Opts.EnableCOMInterop) {
+    Opts.COMModel = Target.isOSDarwin()
+                        ? LangOptions::COMInteropModel::CoreFoundation
+                        : LangOptions::COMInteropModel::Microsoft;
+    if (const Arg *A = Args.getLastArg(OPT_com_interop_model)) {
+      std::optional<LangOptions::COMInteropModel> model =
+          llvm::StringSwitch<decltype(model)>(A->getValue())
+              .Case("microsoft", LangOptions::COMInteropModel::Microsoft)
+              .Case("corefoundation",
+                    LangOptions::COMInteropModel::CoreFoundation)
+              .Default(std::nullopt);
+      if (model)
+        Opts.COMModel = *model;
+      else
+        Diags.diagnose(SourceLoc(), diag::error_unsupported_option_argument,
+                       A->getOption().getPrefixedName(), A->getValue());
+    }
+  }
   Opts.EnableObjCInterop =
       Args.hasFlag(OPT_enable_objc_interop, OPT_disable_objc_interop,
                    Target.isOSDarwin() && !Opts.hasFeature(Feature::Embedded));

--- a/lib/Sema/TypeCheckCOM.cpp
+++ b/lib/Sema/TypeCheckCOM.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "TypeCheckCOM.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ArgumentList.h"
 #include "swift/AST/Attr.h"
@@ -18,19 +19,62 @@
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/ImportCache.h"
+#include "swift/AST/KnownProtocols.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/Pattern.h"
+#include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/Stmt.h"
 #include "swift/AST/StorageImpl.h"
 #include "swift/AST/SynthesizedDeclBuilder.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/LangOptions.h"
 #include "swift/Basic/UUID.h"
 #include "llvm/ADT/StringExtras.h"
 
 using namespace swift;
+
+ProtocolConformance *
+swift::com::deriveImplicitConformance(NominalTypeDecl *NTD,
+                                      KnownProtocolKind KP) {
+  const auto *CD = dyn_cast<ClassDecl>(NTD);
+  if (CD == nullptr)
+    return nullptr;
+
+  if (!CD->getAttrs().hasAttribute<COMAttr>())
+    return nullptr;
+
+  ASTContext &context = NTD->getASTContext();
+  auto *protocol = context.getProtocol(KP);
+  if (protocol == nullptr)
+    return nullptr;
+
+  // Ensure that `ISwiftObject` is always compiler managed.
+  if (KP == KnownProtocolKind::ISwiftObject) {
+    llvm::SmallVector<ProtocolConformance *, 2> conformances;
+    NTD->lookupConformance(protocol, conformances);
+    if (!conformances.empty()) {
+      context.Diags.diagnose(CD->getLoc(), diag::attr_com_explicit_iswiftobject);
+      if (auto *A = CD->getAttrs().getAttribute<COMAttr>())
+        context.Diags.diagnose(A->getLocation(),
+                               diag::attr_com_iswiftobject_implied);
+      return conformances.front();
+    }
+  }
+
+  auto conformance =
+      context.getNormalConformance(NTD->getDeclaredInterfaceType(), protocol,
+                                   NTD->getLoc(), /*inheritedTypeRepr=*/nullptr,
+                                   /*conformanceDC=*/NTD,
+                                   ProtocolConformanceState::Complete,
+                                   ProtocolConformanceOptions());
+  conformance->setSourceKindAndImplyingConformance(ConformanceEntryKind::Synthesized,
+                                                   nullptr);
+  NTD->registerProtocolConformance(conformance, /*synthesized=*/true);
+  return conformance;
+}
 
 namespace {
 namespace com {

--- a/lib/Sema/TypeCheckCOM.cpp
+++ b/lib/Sema/TypeCheckCOM.cpp
@@ -34,50 +34,26 @@
 #include "swift/Basic/UUID.h"
 #include "llvm/ADT/StringExtras.h"
 
-using namespace swift;
-
-ProtocolConformance *
-swift::com::deriveImplicitConformance(NominalTypeDecl *NTD,
-                                      KnownProtocolKind KP) {
-  const auto *CD = dyn_cast<ClassDecl>(NTD);
-  if (CD == nullptr)
-    return nullptr;
-
-  if (!CD->getAttrs().hasAttribute<COMAttr>())
-    return nullptr;
-
-  ASTContext &context = NTD->getASTContext();
-  auto *protocol = context.getProtocol(KP);
-  if (protocol == nullptr)
-    return nullptr;
-
-  // Ensure that `ISwiftObject` is always compiler managed.
-  if (KP == KnownProtocolKind::ISwiftObject) {
-    llvm::SmallVector<ProtocolConformance *, 2> conformances;
-    NTD->lookupConformance(protocol, conformances);
-    if (!conformances.empty()) {
-      context.Diags.diagnose(CD->getLoc(), diag::attr_com_explicit_iswiftobject);
-      if (auto *A = CD->getAttrs().getAttribute<COMAttr>())
-        context.Diags.diagnose(A->getLocation(),
-                               diag::attr_com_iswiftobject_implied);
-      return conformances.front();
-    }
-  }
-
-  auto conformance =
-      context.getNormalConformance(NTD->getDeclaredInterfaceType(), protocol,
-                                   NTD->getLoc(), /*inheritedTypeRepr=*/nullptr,
-                                   /*conformanceDC=*/NTD,
-                                   ProtocolConformanceState::Complete,
-                                   ProtocolConformanceOptions());
-  conformance->setSourceKindAndImplyingConformance(ConformanceEntryKind::Synthesized,
-                                                   nullptr);
-  NTD->registerProtocolConformance(conformance, /*synthesized=*/true);
-  return conformance;
-}
 
 namespace {
 namespace com {
+
+using namespace swift;
+
+/// The protocol an `@com` class conforms to as its COM root under \p model, or
+/// none when no model is in effect.
+std::optional<KnownProtocolKind>
+getRootProtocol(std::optional<LangOptions::COMInteropModel> model) {
+  if (!model)
+    return std::nullopt;
+
+  switch (*model) {
+  case LangOptions::COMInteropModel::Microsoft:
+  case LangOptions::COMInteropModel::CoreFoundation:
+    return KnownProtocolKind::IUnknown;
+  }
+  llvm_unreachable("unhandled COMInteropModel");
+}
 
 /// Look up a type by name from the \c COM module.  Emits a diagnostic on
 /// failure.
@@ -284,6 +260,58 @@ VarDecl *lookupCOMImplementationID(ClassDecl *CD) {
 }
 }
 
+namespace swift {
+ProtocolConformance *
+com::deriveImplicitConformance(NominalTypeDecl *NTD, KnownProtocolKind KP) {
+  const auto *CD = dyn_cast<ClassDecl>(NTD);
+  if (CD == nullptr)
+    return nullptr;
+
+  if (!CD->getAttrs().hasAttribute<COMAttr>())
+    return nullptr;
+
+  ASTContext &context = NTD->getASTContext();
+  auto *protocol = context.getProtocol(KP);
+  if (protocol == nullptr)
+    return nullptr;
+
+  // Synthesize the COM root conformance the interop model selects.
+  // `ISwiftObject` is compiler-managed and synthesized regardless.
+  llvm::SmallVector<KnownProtocolKind, 2> supported;
+  if (auto RP = ::com::getRootProtocol(context.LangOpts.COMModel))
+    supported = { *RP, KnownProtocolKind::ISwiftObject };
+  else
+    supported = { KnownProtocolKind::ISwiftObject };
+
+  if (llvm::none_of(supported,
+                    [KP](const KnownProtocolKind P) { return KP == P; }))
+    return nullptr;
+
+  // Ensure that `ISwiftObject` is always compiler managed.
+  if (KP == KnownProtocolKind::ISwiftObject) {
+    llvm::SmallVector<ProtocolConformance *, 2> conformances;
+    NTD->lookupConformance(protocol, conformances);
+    if (!conformances.empty()) {
+      context.Diags.diagnose(CD->getLoc(), diag::attr_com_explicit_iswiftobject);
+      if (const swift::COMAttr *A = CD->getAttrs().getAttribute<COMAttr>())
+        context.Diags.diagnose(A->getLocation(),
+                               diag::attr_com_iswiftobject_implied);
+      return conformances.front();
+    }
+  }
+
+  auto conformance =
+      context.getNormalConformance(NTD->getDeclaredInterfaceType(), protocol,
+                                   NTD->getLoc(), /*inheritedTypeRepr=*/nullptr,
+                                   /*conformanceDC=*/NTD,
+                                   ProtocolConformanceState::Complete,
+                                   ProtocolConformanceOptions());
+  conformance->setSourceKindAndImplyingConformance(ConformanceEntryKind::Synthesized,
+                                                   nullptr);
+  NTD->registerProtocolConformance(conformance, /*synthesized=*/true);
+  return conformance;
+}
+
 VarDecl *SynthesizeCOMInterfaceIDRequest::evaluate(Evaluator &evaluator,
                                                    ProtocolDecl *PD) const {
   auto &ASTContext = PD->getASTContext();
@@ -297,8 +325,8 @@ VarDecl *SynthesizeCOMInterfaceIDRequest::evaluate(Evaluator &evaluator,
   // synthesized extension, so find its `IID` by name lookup; re-synthesizing
   // would duplicate it, or fabricate a member absent from an older interface.
   if (!PD->isInSwiftSourceFile())
-    return com::lookupCOMInterfaceID(PD);
-  return com::synthesizeIIDProperty(PD, ASTContext, attr->IID);
+    return ::com::lookupCOMInterfaceID(PD);
+  return ::com::synthesizeIIDProperty(PD, ASTContext, attr->IID);
 }
 
 VarDecl *SynthesizeCOMImplementationIDRequest::evaluate(Evaluator &evaluator,
@@ -312,6 +340,7 @@ VarDecl *SynthesizeCOMImplementationIDRequest::evaluate(Evaluator &evaluator,
   // Synthesize only for a source-file class; recover the imported member by
   // name lookup (see SynthesizeCOMInterfaceIDRequest).
   if (!CD->isInSwiftSourceFile())
-    return com::lookupCOMImplementationID(CD);
-  return com::synthesizeCLSIDProperty(CD, ASTContext, *attr->CLSID);
+    return ::com::lookupCOMImplementationID(CD);
+  return ::com::synthesizeCLSIDProperty(CD, ASTContext, *attr->CLSID);
+}
 }

--- a/lib/Sema/TypeCheckCOM.h
+++ b/lib/Sema/TypeCheckCOM.h
@@ -1,0 +1,31 @@
+//===--- TypeCheckCOM.h - Type checking for COM interop -------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SEMA_TYPECHECKCOM_H
+#define SWIFT_SEMA_TYPECHECKCOM_H
+
+#include <cstdint>
+
+namespace swift {
+class NominalTypeDecl;
+class ProtocolConformance;
+enum class KnownProtocolKind : uint8_t;
+
+namespace com {
+/// Produce an implicit conformance of \p NTD to the COM protocol \p KP if it
+/// is valid to do so.
+ProtocolConformance *
+deriveImplicitConformance(NominalTypeDecl *NTD, KnownProtocolKind KP);
+}
+} // end namespace swift
+
+#endif // SWIFT_SEMA_TYPECHECKCOM_H

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -21,6 +21,7 @@
 #include "TypeCheckAccess.h"
 #include "TypeCheckAvailability.h"
 #include "TypeCheckBitwise.h"
+#include "TypeCheckCOM.h"
 #include "TypeCheckConcurrency.h"
 #include "TypeCheckInvertible.h"
 #include "TypeCheckObjC.h"
@@ -3156,47 +3157,6 @@ ExtendedTypeRequest::evaluate(Evaluator &eval, ExtensionDecl *ext) const {
   return extendedType;
 }
 
-namespace {
-ProtocolConformance *deriveImplicitCOMConformance(NominalTypeDecl *NTD,
-                                                  KnownProtocolKind KP) {
-  const auto *CD = dyn_cast<ClassDecl>(NTD);
-  if (CD == nullptr)
-    return nullptr;
-
-  if (!CD->getAttrs().hasAttribute<COMAttr>())
-    return nullptr;
-
-  ASTContext &context = NTD->getASTContext();
-  auto *protocol = context.getProtocol(KP);
-  if (protocol == nullptr)
-    return nullptr;
-
-  // Ensure that `ISwiftObject` is always compiler managed.
-  if (KP == KnownProtocolKind::ISwiftObject) {
-    llvm::SmallVector<ProtocolConformance *, 2> conformances;
-    NTD->lookupConformance(protocol, conformances);
-    if (!conformances.empty()) {
-      context.Diags.diagnose(CD->getLoc(), diag::attr_com_explicit_iswiftobject);
-      if (auto *A = CD->getAttrs().getAttribute<COMAttr>())
-        context.Diags.diagnose(A->getLocation(),
-                               diag::attr_com_iswiftobject_implied);
-      return conformances.front();
-    }
-  }
-
-  auto conformance =
-      context.getNormalConformance(NTD->getDeclaredInterfaceType(), protocol,
-                                   NTD->getLoc(), /*inheritedTypeRepr=*/nullptr,
-                                   /*conformanceDC=*/NTD,
-                                   ProtocolConformanceState::Complete,
-                                   ProtocolConformanceOptions());
-  conformance->setSourceKindAndImplyingConformance(ConformanceEntryKind::Synthesized,
-                                                   nullptr);
-  NTD->registerProtocolConformance(conformance, /*synthesized=*/true);
-  return conformance;
-}
-}
-
 //----------------------------------------------------------------------------//
 // ImplicitKnownProtocolConformanceRequest
 //----------------------------------------------------------------------------//
@@ -3211,7 +3171,7 @@ ImplicitKnownProtocolConformanceRequest::evaluate(Evaluator &evaluator,
     return deriveImplicitBitwiseCopyableConformance(nominal);
   case KnownProtocolKind::IUnknown:
   case KnownProtocolKind::ISwiftObject:
-    return deriveImplicitCOMConformance(nominal, kp);
+    return com::deriveImplicitConformance(nominal, kp);
   default:
     llvm_unreachable("non-implicitly derived KnownProtocol");
   }

--- a/test/Sema/COM-interop-model.swift
+++ b/test/Sema/COM-interop-model.swift
@@ -1,0 +1,6 @@
+// RUN: not %target-swift-frontend -typecheck -enable-experimental-com-interop -com-interop-model=bogus %s 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -typecheck -enable-experimental-com-interop -com-interop-model=none %s 2>&1 | %FileCheck %s -check-prefix NONE
+
+// The initial models are `microsoft` and `corefoundation`; `none` is not one.
+// CHECK: unsupported argument 'bogus' to option '-com-interop-model='
+// NONE: unsupported argument 'none' to option '-com-interop-model='

--- a/test/Sema/COMSynthesis.swift
+++ b/test/Sema/COMSynthesis.swift
@@ -1,6 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module-path %t/COM.swiftmodule -module-name COM -enable-experimental-com-interop %S/../Inputs/COM.swift
-// RUN: %target-typecheck-verify-swift -enable-experimental-com-interop -I %t
+// RUN: %target-typecheck-verify-swift -enable-experimental-com-interop -com-interop-model=microsoft -I %t
+// RUN: %target-typecheck-verify-swift -enable-experimental-com-interop -com-interop-model=corefoundation -I %t
+
+// Both interop models root at `IUnknown`, so the synthesized root conformance
+// is the same under either; run both to pin that portability.
 
 import COM
 


### PR DESCRIPTION
This pull request introduces support for selecting a COM interop model in Swift, allowing users to choose between Microsoft and CoreFoundation conventions for COM interop. It adds a new compiler option to specify the model, sets a default based on the target platform, and centralizes the logic for synthesizing implicit COM protocol conformances. The changes also include new and updated tests to verify correct behavior and error handling.

**COM Interop Model Selection and Configuration**
* Added a new `COMInteropModel` enum to `LangOptions`, with options for `Microsoft` and `CoreFoundation`, and made the selected model available as `COMModel` when COM interop is enabled. (`include/swift/Basic/LangOptions.h`)
* Introduced the `-com-interop-model=` compiler flag, allowing users to select the COM interop model (`microsoft` or `corefoundation`). (`include/swift/Option/FrontendOptions.td`)
* Updated compiler invocation logic to default the COM interop model based on the target (Darwin uses `corefoundation`, others use `microsoft`), and to handle user overrides and invalid arguments with diagnostics. (`lib/Frontend/CompilerInvocation.cpp`)

**Centralization and Refactoring of Implicit Conformance Logic**
* Moved and refactored the logic for synthesizing implicit COM protocol conformances (including handling for `ISwiftObject`) into a new `com::deriveImplicitConformance` function, declared in a new header `TypeCheckCOM.h` and used throughout the codebase. [[1]](diffhunk://#diff-3a4e1a1efa35de9c07d2c1ba68dad17b37db38dc0564542028e89c478b0c0d9aR263-R314) [[2]](diffhunk://#diff-97161581d820ff7379644ce1be882ca14c07f128351a9a69bc75a05c50328d0bR1-R31) [[3]](diffhunk://#diff-5a9439f8a77b136c97b430596bfc4263de54fbf7c0616656bbfa75ff2d10d145L3159-L3199) [[4]](diffhunk://#diff-5a9439f8a77b136c97b430596bfc4263de54fbf7c0616656bbfa75ff2d10d145L3214-R3174)
* Updated includes and usage in `TypeCheckDecl.cpp` and `TypeCheckCOM.cpp` to use the new centralized function. [[1]](diffhunk://#diff-3a4e1a1efa35de9c07d2c1ba68dad17b37db38dc0564542028e89c478b0c0d9aR13) [[2]](diffhunk://#diff-3a4e1a1efa35de9c07d2c1ba68dad17b37db38dc0564542028e89c478b0c0d9aR22-R57) [[3]](diffhunk://#diff-5a9439f8a77b136c97b430596bfc4263de54fbf7c0616656bbfa75ff2d10d145R24)

**Testing and Validation**
* Added new tests to verify that unsupported values for `-com-interop-model=` are diagnosed as errors. (`test/Sema/COM-interop-model.swift`)
* Updated `COMSynthesis.swift` test to run under both `microsoft` and `corefoundation` models, ensuring that synthesized root conformances are consistent across models. (`test/Sema/COMSynthesis.swift`)