### PR TITLE
Sema: diagnose `Interface.IID` on a generic metatype cleanly

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -150,6 +150,10 @@ ERROR(could_not_use_instance_member_on_type,none,
       "%select{| of type %2}3 cannot be used on"
       "%select{| instance of nested}3 type %0",
       (Type, DeclNameRef, Type, bool))
+ERROR(metatype_extension_member_on_conforming_type,none,
+      "metatype extension member %1 cannot be used on conforming type %0; "
+      "it is only available on the protocol metatype",
+      (Type, const ValueDecl *))
 GROUPED_ERROR(could_not_use_member_on_existential,ExistentialMemberAccess,none,
       "member %1 cannot be used on value of type %0; consider using a"
       " generic constraint instead",

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -141,6 +141,10 @@ enum class FixKind : uint8_t {
   /// Allow access to type member on instance or instance member on type
   AllowTypeOrInstanceMember,
 
+  /// Allow access to a protocol metatype extension member through the
+  /// metatype of a conforming type.
+  AllowMetatypeExtensionMemberOnConformingType,
+
   /// Allow expressions where 'mutating' method is only partially applied,
   /// which means either not applied at all e.g. `Foo.bar` or only `Self`
   /// is applied e.g. `foo.bar` or `Foo.bar(&foo)`.
@@ -1616,6 +1620,35 @@ public:
 
   static bool classof(const ConstraintFix *fix) {
     return fix->getKind() == FixKind::AllowTypeOrInstanceMember;
+  }
+};
+
+class AllowMetatypeExtensionMemberOnConformingType final
+    : public AllowInvalidMemberRef {
+  AllowMetatypeExtensionMemberOnConformingType(
+      ConstraintSystem &cs, Type baseType, ValueDecl *member, DeclNameRef name,
+      ConstraintLocator *locator)
+      : AllowInvalidMemberRef(
+            cs, FixKind::AllowMetatypeExtensionMemberOnConformingType,
+            baseType, member, name, locator) {
+    ASSERT(member);
+  }
+
+public:
+  std::string getName() const override {
+    return "allow access to protocol metatype extension member on conforming "
+           "type";
+  }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  static AllowMetatypeExtensionMemberOnConformingType *
+  create(ConstraintSystem &cs, Type baseType, ValueDecl *member,
+         DeclNameRef usedName, ConstraintLocator *locator);
+
+  static bool classof(const ConstraintFix *fix) {
+    return fix->getKind() ==
+           FixKind::AllowMetatypeExtensionMemberOnConformingType;
   }
 };
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -666,6 +666,10 @@ struct MemberLookupResult {
     /// This is a static/class member being accessed through an instance.
     UR_TypeMemberOnInstance,
 
+    /// This is a member of a protocol metatype extension being accessed
+    /// through the metatype of a conforming type.
+    UR_MetatypeExtensionMemberOnConformingType,
+
     /// This is a mutating member, being used on an rvalue.
     UR_MutatingMemberOnRValue,
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -5245,6 +5245,16 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
   return false;
 }
 
+bool InvalidMetatypeExtensionMemberRefFailure::diagnoseAsError() {
+  auto baseType = resolveType(BaseType)->getWithoutSpecifierType();
+  baseType = baseType->getMetatypeInstanceType();
+
+  emitDiagnostic(diag::metatype_extension_member_on_conforming_type, baseType,
+                 Member)
+      .highlight(getSourceRange());
+  return true;
+}
+
 bool PartialApplicationFailure::diagnoseAsError() {
   auto *anchor = castToExpr<UnresolvedDotExpr>(getRawAnchor());
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1396,6 +1396,26 @@ public:
   bool diagnoseAsError() override;
 };
 
+/// Diagnose a member of a protocol metatype extension referenced through the
+/// metatype of a conforming type. Such members belong to the protocol metatype
+/// itself and are not inherited by conforming types.
+class InvalidMetatypeExtensionMemberRefFailure final
+    : public MemberReferenceFailure {
+  Type BaseType;
+  ValueDecl *Member;
+
+public:
+  InvalidMetatypeExtensionMemberRefFailure(
+      const Solution &solution, Type baseType, ValueDecl *member,
+      ConstraintLocator *locator)
+      : MemberReferenceFailure(solution, locator),
+        BaseType(baseType->getRValueType()), Member(member) {
+    ASSERT(member);
+  }
+
+  bool diagnoseAsError() override;
+};
+
 class PartialApplicationFailure final : public FailureDiagnostic {
   enum RefKind : unsigned {
     MutatingMethod,

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1041,6 +1041,22 @@ AllowTypeOrInstanceMember::create(ConstraintSystem &cs, Type baseType,
       AllowTypeOrInstanceMember(cs, baseType, member, usedName, locator);
 }
 
+bool AllowMetatypeExtensionMemberOnConformingType::diagnose(
+    const Solution &solution, bool asNote) const {
+  InvalidMetatypeExtensionMemberRefFailure failure(
+      solution, getBaseType(), getMember(), getLocator());
+  return failure.diagnose(asNote);
+}
+
+AllowMetatypeExtensionMemberOnConformingType *
+AllowMetatypeExtensionMemberOnConformingType::create(
+    ConstraintSystem &cs, Type baseType, ValueDecl *member,
+    DeclNameRef usedName, ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      AllowMetatypeExtensionMemberOnConformingType(
+          cs, baseType, member, usedName, locator);
+}
+
 bool AllowInvalidPartialApplication::diagnose(const Solution &solution,
                                               bool asNote) const {
   PartialApplicationFailure failure(isWarning, solution, getLocator());

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10780,10 +10780,15 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
     };
 
     // Metatype extension members are only accessible on the protocol
-    // metatype itself, not on conforming types.
+    // metatype itself, not on conforming types. Keep the declaration as an
+    // unviable candidate so diagnostics can explain that distinction.
     if (decl->getDeclContext()->isMetatypeExtension() &&
-        !instanceTy->isExistentialType())
+        !instanceTy->isExistentialType()) {
+      result.addUnviable(
+          candidate,
+          MemberLookupResult::UR_MetatypeExtensionMemberOnConformingType);
       return;
+    }
 
     // See if we have an instance method, instance member or static method,
     // and check if it can be accessed on our base type.
@@ -11450,6 +11455,12 @@ static ConstraintFix *fixMemberRef(
                        cs, baseTy, choice.getDecl(), memberName, locator)
                  : nullptr;
     }
+
+    case MemberLookupResult::UR_MetatypeExtensionMemberOnConformingType:
+      return choice.isDecl()
+                 ? AllowMetatypeExtensionMemberOnConformingType::create(
+                       cs, baseTy, choice.getDecl(), memberName, locator)
+                 : nullptr;
 
     case MemberLookupResult::UR_WrongModule:
       ASSERT(choice.isDecl());
@@ -16184,6 +16195,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::RemoveUnwrap:
   case FixKind::DefineMemberBasedOnUse:
   case FixKind::AllowTypeOrInstanceMember:
+  case FixKind::AllowMetatypeExtensionMemberOnConformingType:
   case FixKind::AllowInvalidPartialApplication:
   case FixKind::AllowInvalidInitRef:
   case FixKind::AllowClosureParameterDestructuring:

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -2036,15 +2036,24 @@ ConstraintSystem::getTypeOfMemberReferencePre(
   bool skipProtocolSelfConstraint =
       isDynamicLookup || isRequirementOrWitness(locator);
 
+  // This candidate is only selected in diagnostic mode. Its self type is the
+  // protocol existential, which cannot be bound to a conforming archetype;
+  // suppress that constraint so the recorded fix can diagnose the reference.
+  bool isInvalidMetatypeExtensionMemberRef =
+      outerDC->isMetatypeExtension() && !baseObjTy->isExistentialType() &&
+      hasFixFor(locator,
+                FixKind::AllowMetatypeExtensionMemberOnConformingType);
+
   Type selfObjTy = openedParams.front().getPlainType()->getMetatypeInstanceType();
-  if (outerDC->getSelfProtocolDecl()) {
+  if (outerDC->getSelfProtocolDecl() &&
+      !isInvalidMetatypeExtensionMemberRef) {
     // For a protocol, substitute the base object directly. We don't need a
     // conformance constraint because we wouldn't have found the declaration
     // if it didn't conform.
     addConstraint(ConstraintKind::Bind, baseOpenedTy, selfObjTy,
                   getConstraintLocator(locator), /*isFavored=*/false,
                   preparedOverload);
-  } else if (!isDynamicLookup) {
+  } else if (!isDynamicLookup && !isInvalidMetatypeExtensionMemberRef) {
     addSelfConstraint(*this, baseOpenedTy, selfObjTy, locator, preparedOverload);
   }
 

--- a/test/Sema/metatype-extension-generic-member.swift
+++ b/test/Sema/metatype-extension-generic-member.swift
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module-path %t/COM.swiftmodule -module-name COM -enable-experimental-com-interop %S/../Inputs/COM.swift
+// RUN: %target-typecheck-verify-swift -enable-experimental-com-interop -I %t
+
+// A synthesized metatype-extension member (`IID`) is reachable on a concrete
+// interface metatype but not on a generic one: the member lives on `(any P).Type`
+// and a generic parameter's metatype is not existential.  The generic access
+// must explain that a metatype-extension member is not inherited by a
+// conforming type; it previously reached the constraint solver's
+// inaccessible-member fallback and emitted "failed to produce diagnostic for
+// expression" instead.
+
+import COM
+
+@com(interface: "10000000-0000-0000-0000-000000000001")
+protocol IWidget: IUnknown { }
+
+// Concrete access is fine.
+func concrete() {
+  _ = IWidget.IID
+}
+
+// Generic access is diagnosed cleanly.
+func generic<Interface: IUnknown>(_: Interface.Type) {
+  _ = Interface.IID
+  // expected-error@-1 {{metatype extension member 'IID' cannot be used on conforming type 'Interface'; it is only available on the protocol metatype}}
+}


### PR DESCRIPTION
Reading a metatype-extension member off a non-existential metatype (e.g. `Interface.IID` for a generic `Interface`) produced "failed to produce diagnostic for expression" rather than a real error.  Normal lookup excludes the member correctly, but the inaccessible-member diagnostic fallback did not honor the same metatype-extension visibility rule -- it found the member, took an inaccessible-member fix, and left an unsatisfiable `Self` binding behind.  Skip metatype-extension members on a non-existential base there too, so the standard missing-member diagnostic fires.