### PR TITLE
PassManager: let `-Xllvm -sil-print-pass-md5` write its output to a file

### DIFF
--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -37,8 +37,11 @@
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/GraphWriter.h"
 #include "llvm/Support/ManagedStatic.h"
+#include "llvm/Support/raw_ostream.h"
 #include <fstream>
 
 #ifndef SWIFT_ENABLE_SWIFT_IN_SWIFT
@@ -59,9 +62,32 @@ llvm::cl::opt<bool> SILPrintPassTime(
     "sil-print-pass-time", llvm::cl::init(false),
     llvm::cl::desc("Print the execution time of each SIL pass"));
 
-llvm::cl::opt<bool> SILPrintPassMD5(
-    "sil-print-pass-md5", llvm::cl::init(false),
-    llvm::cl::desc("Print the MD5 of the SIL after each pass"));
+llvm::cl::opt<std::string> SILPrintPassMD5(
+    "sil-print-pass-md5", llvm::cl::init(""),
+    llvm::cl::value_desc("filename"),
+    llvm::cl::desc("Write the MD5 of the SIL after each pass to the given file "
+                   "(\"-\" for stdout). Empty disables the output."));
+
+/// Returns the stream that `-sil-print-pass-md5` output is written to.
+///
+/// The file is opened lazily on first use (truncating) and reused for the rest
+/// of the compilation, so all pass pipelines write to the same file. A file
+/// name of "-" writes to stdout. Writing to the file directly (rather than to
+/// stdout) keeps this diagnostic output out of the compiler's stdout/stderr,
+/// which lets tools like utils/check-incremental collect it without having to
+/// redirect (and without hiding "real" compiler diagnostics).
+static llvm::raw_ostream &getSILPrintPassMD5Stream() {
+  static std::unique_ptr<llvm::raw_fd_ostream> stream = [] {
+    std::error_code EC;
+    auto s = std::make_unique<llvm::raw_fd_ostream>(SILPrintPassMD5, EC,
+                                                    llvm::sys::fs::OF_Text);
+    if (EC)
+      llvm::report_fatal_error(llvm::Twine("-sil-print-pass-md5: cannot open '") +
+                               SILPrintPassMD5 + "': " + EC.message());
+    return s;
+  }();
+  return *stream;
+}
 
 llvm::cl::opt<unsigned> SILMinPassTime(
     "sil-min-pass-time", llvm::cl::init(0),
@@ -771,14 +797,15 @@ void SILPassManager::runPassOnFunction(unsigned TransIdx, SILFunction *F) {
                    << " #" << NumPassesRun << " @" << F->getName() << "\n";
     }
   }
-  if (SILPrintPassMD5 && CurrentPassHasInvalidated) {
+  if (!SILPrintPassMD5.empty() && CurrentPassHasInvalidated) {
     MD5Stream md5Stream;
     F->print(md5Stream);
     llvm::MD5::MD5Result result;
     md5Stream.final(result);
 
-    dumpPassInfo("MD5", TransIdx, F, /*skipNewline=*/ true, llvm::outs());
-    llvm::outs() << " = " << result << "\n";
+    llvm::raw_ostream &os = getSILPrintPassMD5Stream();
+    dumpPassInfo("MD5", TransIdx, F, /*skipNewline=*/ true, os);
+    os << " = " << result << "\n";
   }
 
   if (numRepeats > 1)
@@ -977,14 +1004,15 @@ void SILPassManager::runModulePass(unsigned TransIdx) {
                    << " #" << NumPassesRun << "\n";
     }
   }
-  if (SILPrintPassMD5 && CurrentPassHasInvalidated) {
+  if (!SILPrintPassMD5.empty() && CurrentPassHasInvalidated) {
     MD5Stream md5Stream;
     Mod->print(md5Stream);
     llvm::MD5::MD5Result result;
     md5Stream.final(result);
 
-    dumpPassInfo("MD5", TransIdx, /*function=*/ nullptr, /*skipNewline=*/ true, llvm::outs());
-    llvm::outs() << " = " << result << "\n";
+    llvm::raw_ostream &os = getSILPrintPassMD5Stream();
+    dumpPassInfo("MD5", TransIdx, /*function=*/ nullptr, /*skipNewline=*/ true, os);
+    os << " = " << result << "\n";
   }
 
   // If this pass invalidated anything, print and verify.
@@ -1055,13 +1083,14 @@ void SILPassManager::execute() {
     printModule(Mod, Options.EmitVerboseSIL);
   }
 
-  if (SILPrintPassMD5) {
+  if (!SILPrintPassMD5.empty()) {
     MD5Stream md5Stream;
     Mod->print(md5Stream);
     llvm::MD5::MD5Result result;
     md5Stream.final(result);
 
-    llvm::outs() << "Initial " << StageName << " MD5 = " << result << "\n";
+    getSILPrintPassMD5Stream()
+        << "Initial " << StageName << " MD5 = " << result << "\n";
   }
 
   // Run the transforms by alternating between function transforms and

--- a/test/SILOptimizer/pass_printer.swift
+++ b/test/SILOptimizer/pass_printer.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -Xllvm -sil-print-before=definite-init -emit-sil %s -o /dev/null 2>&1 | %FileCheck --check-prefix=BEFORE %s
 // RUN: %target-swift-frontend -Xllvm -sil-print-after=definite-init -emit-sil %s -o /dev/null 2>&1 | %FileCheck --check-prefix=AFTER %s
 // RUN: %target-swift-frontend -Xllvm -sil-disable-pass=definite-init -Xllvm -sil-print-pass-name -emit-sil %s -o /dev/null 2>&1 | %FileCheck --check-prefix=DISABLE %s
-// RUN: %target-swift-frontend -Xllvm -sil-print-pass-md5 -emit-sil %s -o /dev/null 2>&1 | %FileCheck --check-prefix=MD5 %s
+// RUN: %target-swift-frontend -Xllvm -sil-print-pass-md5=- -emit-sil %s -o /dev/null 2>&1 | %FileCheck --check-prefix=MD5 %s
 
 // BEFORE: SIL function before #{{[0-9]+}}, stage  Mandatory Diagnostic Passes + Enabling Optimization Passes, pass {{[0-9]+}}: DefiniteInitialization (definite-init)
 // AFTER: SIL function after #{{[0-9]+}}, stage  Mandatory Diagnostic Passes + Enabling Optimization Passes, pass {{[0-9]+}}: DefiniteInitialization  (definite-init)

--- a/utils/check-incremental
+++ b/utils/check-incremental
@@ -35,11 +35,12 @@ def compile_and_stat(compile_args, output_file):
     compilation has finished.
     """
 
-    logFile = open(output_file + ".log", "w")
-
-    subprocess.check_call(compile_args, stdout=logFile)
-
-    logFile.close()
+    # The compiler writes its `-sil-print-pass-md5` output directly to
+    # ``output_file + ".log"`` (see the `-sil-print-pass-md5=` argument added in
+    # main()), so we don't redirect stdout/stderr here. That keeps the
+    # compiler's stdout/stderr going to the console, so "real" diagnostics stay
+    # visible in the CI log.
+    subprocess.check_call(compile_args)
 
     md5 = subprocess.check_output(["md5", "-q", output_file],
                                   universal_newlines=True)
@@ -104,7 +105,7 @@ def main():
 
     new_args += [
       '-Xllvm', '-print-no-uuids',
-      '-Xllvm', '-sil-print-pass-md5']
+      '-Xllvm', '-sil-print-pass-md5=' + output_file + '.log']
 
     if EMIT_IR:
       new_args += [


### PR DESCRIPTION
Change `-sil-print-pass-md5` from a boolean flag into an option that takes a file name (`-sil-print-pass-md5=<file>`). The pass manager now writes the per-pass MD5 output to that file directly instead of to stdout.

This makes `utils/check-incremental` more robust.
It previously relied on redirecting the compiler's stdout into a log file, but when the driver run the frontend through its buffered task queue -- which happens whenever a compilation has more than one frontend job, e.g. a bridging-header PCH job plus the compile -- it re-emits the frontend's output on the driver's stderr. The MD5 output therefore escaped the redirection, leaked into the CI log, and left the log file empty so the "log differences" diff had nothing to compare.

Letting the compiler write the file itself sidesteps stream redirection entirely and keeps the compiler's stdout/stderr free for "real" diagnostics, which should stay visible in the CI log. `check-incremental` now passes `-sil-print-pass-md5=<output>.log` and no longer redirects stdout/stderr.
