### PR TITLE
[Embedded] Build the Synchronization bridging-header PCH in a stable location

### DIFF
--- a/stdlib/public/Synchronization/CMakeLists.txt
+++ b/stdlib/public/Synchronization/CMakeLists.txt
@@ -181,6 +181,13 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     ${SWIFT_SYNCHRNOIZATION_SWIFT_FLAGS}
     "-plugin-path" "${SWIFT_HOST_PLUGINS_DIR}"
     -internal-import-bridging-header ${CMAKE_CURRENT_SOURCE_DIR}/../EmbeddedPlatform/swift/EmbeddedPlatform.h
+    # Precompile the bridging header into a stable, per-module location rather
+    # than a randomly-named temporary directory. Without this the transient PCH
+    # path leaks into the debug info (the DW_AT_LLVM_include_path of the __ObjC
+    # module), which makes the -g output non-deterministic and trips the
+    # check-incremental determinism check. -pch-output-dir gives the PCH a
+    # content-hashed name in this directory, so the recorded path is stable.
+    -pch-output-dir ${CMAKE_CURRENT_BINARY_DIR}/EmbeddedSynchronizationPCH
     -enable-experimental-feature LiteralExpressions)
 
   # wasm32 builds the full Synchronization library plus its wasm-specific


### PR DESCRIPTION
Precompile the EmbeddedPlatform bridging header into a persistent, per-module directory via `-pch-output-dir` instead of letting the driver put it in a randomly-named temporary directory.

When the embedded Synchronization module is built with debug info, the path of the precompiled bridging header is recorded in the debug info. With the PCH living in a temp directory whose name is randomized on every invocation, that path - and therefore the emitted object file - changed on every build, which tripped the utils/check-incremental determinism check for the wasm targets.

`-pch-output-dir` gives the PCH a stable name, so the recorded path is reproducible.

rdar://182613218