### PR TITLE
[Utils] Add PathSanitizingDiff, sharing internals with PathSanitizingFileCheck

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -26,6 +26,7 @@ filename =
     ./utils/dev-scripts/split-cmdline,
     ./utils/gyb,
     ./utils/line-directive,
+    ./utils/PathSanitizingDiff,
     ./utils/PathSanitizingFileCheck,
     ./utils/recursive-lipo,
     ./utils/round-trip-syntax-test,

--- a/test/Interop/Cxx/swiftify-import/parameter-type-from-namespace.swift
+++ b/test/Interop/Cxx/swiftify-import/parameter-type-from-namespace.swift
@@ -6,8 +6,7 @@
 // RUN:   -verify -verify-additional-file %t%{fs-sep}namespace.h -Rmacro-expansions -strict-memory-safety -o %t/out.swiftmodule -import-bridging-header %t/bridging.h -eager-macro-checking
 
 // RUN: %target-swift-frontend -plugin-path %swift-plugin-dir -I %t -cxx-interoperability-mode=default %t/namespace.swift -typecheck \
-// RUN:   -dump-source-file-imports -import-bridging-header %t/bridging.h 2>&1 | %FileCheck --dry-run > %t/imports.txt
-// RUN: %diff %t/imports.txt %t/imports.txt.expected
+// RUN:   -dump-source-file-imports -import-bridging-header %t/bridging.h 2>&1 | %PathSanitizingDiff %t/imports.txt.expected
 
 // This test checks that macro expansions can access symbols from namespaces
 // (which are dumped into the __ObjC module) despite not having an implicit
@@ -48,7 +47,6 @@ imports for @__swiftmacro_So3bazO0A5_func15_SwiftifyImportfMp_.swift:
 	_StringProcessing
 	_SwiftConcurrencyShims
 	_Concurrency
-
 //--- bridging.h
 const int FOO = 42; // not used
 

--- a/test/Utils/update-pathsanitizing-diff-tests/Inputs/out.expected.stale
+++ b/test/Utils/update-pathsanitizing-diff-tests/Inputs/out.expected.stale
@@ -1,0 +1,1 @@
+stale line

--- a/test/Utils/update-pathsanitizing-diff-tests/Inputs/scratch.expected
+++ b/test/Utils/update-pathsanitizing-diff-tests/Inputs/scratch.expected
@@ -1,0 +1,3 @@
+// Preserved header.
+//--- out.expected
+new line

--- a/test/Utils/update-pathsanitizing-diff-tests/Inputs/scratch.txt
+++ b/test/Utils/update-pathsanitizing-diff-tests/Inputs/scratch.txt
@@ -1,0 +1,3 @@
+// Preserved header.
+//--- out.expected
+stale line

--- a/test/Utils/update-pathsanitizing-diff-tests/repair-split-file.test
+++ b/test/Utils/update-pathsanitizing-diff-tests/repair-split-file.test
@@ -1,0 +1,34 @@
+# Verify that PathSanitizingDiff writes its sanitized input to an output file in
+# the per-test temporary namespace, and that the update plugin (exercised here
+# through its standalone entry point) uses that output to repair the reference
+# file and the corresponding split-file slice of the test.
+#
+# The %PathSanitizingDiff substitution passes --temp-dir %t automatically. The
+# output is written only on a mismatch. When the temp dir is a directory the
+# output is placed inside it as "<basename>.actual"; otherwise it is a sibling
+# formed by prefixing with the temp dir.
+
+# RUN: %empty-directory(%t)
+# RUN: cp %S/Inputs/scratch.txt %t/scratch.txt
+# RUN: cp %S/Inputs/out.expected.stale %t/out.expected
+# RUN: echo 'new line' > %t/raw.txt
+
+# No output is written when the diff matches (feed the reference to itself).
+# RUN: %PathSanitizingDiff %t/out.expected < %t/out.expected
+# RUN: not ls %t/out.expected.actual
+
+# On a mismatch (wrapped in 'not') the output holds the sanitized would-be
+# result. %t is a directory, so it lands inside it as "out.expected.actual".
+# RUN: not %PathSanitizingDiff %t/out.expected < %t/raw.txt
+# RUN: %diff %t/out.expected.actual %t/raw.txt
+
+# When the temp dir is not a directory the output is a prefixed sibling. Here
+# an explicit --temp-dir overrides the one from the substitution.
+# RUN: not %PathSanitizingDiff --temp-dir %t/nodir %t/out.expected < %t/raw.txt
+# RUN: ls %t/nodir.out.expected.actual
+
+# Repair the test from the output; the reference file and the split-file slice
+# both take on the sanitized result.
+# RUN: %update-pathsanitizing-diff-tests %t/scratch.txt %t/out.expected --temp-dir %t --split-file-dir %t
+# RUN: %diff %t/scratch.txt %S/Inputs/scratch.expected
+# RUN: %diff %t/out.expected %t/raw.txt

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -421,6 +421,7 @@ config.gyb = make_path(config.swift_utils, 'gyb.py')
 config.rth = make_path(config.swift_utils, 'rth') # Resilience test helper
 config.scale_test = make_path(config.swift_utils, 'scale-test')
 config.PathSanitizingFileCheck = make_path(config.swift_utils, 'PathSanitizingFileCheck')
+config.PathSanitizingDiff = make_path(config.swift_utils, 'PathSanitizingDiff')
 config.swift_bin_dir = make_path(config.swift, '..', '..', 'bin')
 config.swift_lib_dir = make_path(config.swift, '..', '..', 'lib')
 config.swift_libexec_dir = make_path(config.swift, '..', '..', 'libexec')
@@ -843,6 +844,9 @@ config.substitutions.append( ('%clang-include-dir', config.clang_include_dir) )
 
 config.update_verify_tests = make_path(config.swift_utils, "update-verify-tests.py")
 config.substitutions.append( ('%update-verify-tests', '%s %s' % (config.python, config.update_verify_tests)) )
+
+config.update_pathsanitizing_diff_tests = make_path(config.swift_utils, "update-pathsanitizing-diff-tests.py")
+config.substitutions.append( ('%update-pathsanitizing-diff-tests', '%s %s' % (config.python, config.update_pathsanitizing_diff_tests)) )
 
 config.update_generated_tests = make_path(config.swift_utils, "update-generated-tests.py")
 config.lit_pythonpath = os.path.dirname(os.path.dirname(lit.__file__))
@@ -3357,6 +3361,18 @@ run_filecheck = '%s %s --allow-unused-prefixes --sanitize TMP_DIR=%s --sanitize 
 
 config.substitutions.append(('%FileCheck', run_filecheck))
 config.substitutions.append(('%raw-FileCheck', shell_quote(config.filecheck)))
+
+run_pathsanitizingdiff = '%s %s --temp-dir %s --sanitize TMP_DIR=%s --sanitize BUILD_DIR=%s --sanitize SOURCE_DIR=%s --ignore-runtime-warnings --use-diff %s %s' % (
+        shell_quote(sys.executable),
+        shell_quote(config.PathSanitizingDiff),
+        shell_quote('%t'),
+        shell_quote('%t'),
+        shell_quote(config.cmake_binary_dir),
+        shell_quote(config.swift_src_root),
+        shell_quote('diff --strip-trailing-cr' if kIsWindows else 'diff'),
+        '--enable-windows-compatibility' if kIsWindows else '')
+
+config.substitutions.append(('%PathSanitizingDiff', run_pathsanitizingdiff))
 config.substitutions.append(('%import-libdispatch', getattr(config, 'import_libdispatch', '')))
 # WARNING: the order of components in a substitution name has to be different from the previous one, as lit does
 # a pure string substitution without understanding that these components are grouped together. That is, the following
@@ -3524,3 +3540,5 @@ if lit_config.update_tests:
     lit_config.test_updaters.append(generate_test_lit_plugin)
     from update_verify_tests.litplugin import uvt_lit_plugin
     lit_config.test_updaters.append(uvt_lit_plugin)
+    from update_pathsanitizing_diff_tests.litplugin import psd_lit_plugin
+    lit_config.test_updaters.append(psd_lit_plugin)

--- a/utils/PathSanitizingDiff
+++ b/utils/PathSanitizingDiff
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# utils/PathSanitizingDiff -*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2026 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+import argparse
+import io
+import shlex
+import subprocess
+import sys
+
+import swift_path_sanitize
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="""
+PathSanitizingDiff sanitizes its standard input the same way
+PathSanitizingFileCheck does (replacing paths to the source and build
+directories with path-independent constants), then compares the result
+against a reference file using diff.  It collapses the common two-step
+`PathSanitizingFileCheck --dry-run > out; diff out expected` idiom into a
+single step.""",
+    )
+
+    swift_path_sanitize.add_shared_arguments(parser)
+
+    parser.add_argument(
+        "--use-diff",
+        help="diff command to invoke; may include flags (e.g. "
+        "'diff --strip-trailing-cr')",
+        metavar="COMMAND",
+        action="store",
+        dest="diff_command",
+        default="diff",
+    )
+
+    parser.add_argument(
+        swift_path_sanitize.TEMP_DIR_OPTION,
+        help="the test's temporary location (%%t). When given, the sanitized "
+        "input is written to an output file derived from it on a mismatch "
+        "so the update plugin can repair the reference file/slice.",
+        metavar="PATH",
+        action="store",
+        dest="temp_dir",
+        default=None,
+    )
+
+    args, unknown_args = parser.parse_known_args()
+
+    stdin = io.open(sys.stdin.fileno(), "r", encoding="utf-8", errors="ignore").read()
+
+    stdin = swift_path_sanitize.sanitize(stdin, args)
+
+    # Feed the sanitized text as the first operand (via '-') so that the diff
+    # direction matches the historical `diff <actual> <expected>` ordering,
+    # where the reference file is passed as a positional argument.
+    diff_argv = shlex.split(args.diff_command) + ["-"] + unknown_args
+    p = subprocess.Popen(diff_argv, stdin=subprocess.PIPE)
+    p.communicate(stdin.encode("utf-8"))
+    returncode = p.wait()
+
+    # On a mismatch, persist the sanitized input for the update plugin. The
+    # output is placed in the per-test temporary namespace so parallel tests
+    # cannot collide.
+    if returncode != 0 and args.temp_dir is not None:
+        reference = swift_path_sanitize.reference_path(unknown_args)
+        if reference is not None:
+            output = swift_path_sanitize.output_path(args.temp_dir, reference)
+            with io.open(output, "w", encoding="utf-8") as f:
+                f.write(stdin)
+
+    return returncode
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/utils/PathSanitizingFileCheck
+++ b/utils/PathSanitizingFileCheck
@@ -11,26 +11,11 @@
 
 import argparse
 import io
-import os
-import platform
-import re
 import subprocess
 import sys
 
-# LLVM Lit performs realpath with the config path, so all paths are relative
-# to the real path. Paths that come from CMake (like cmake_binary_dir and
-# swift_src_root), might not do real path. Use realpath to normalize. Because
-# this normalizes Windows paths to use backslashes, we have to replace them
-# back to forward slashes.
-def normalize_if_path(s):
-    # Check dirname for cases like a file named `%t.out.txt`
-    # There won't be a `%t` path, but we still want to match this path substring.
-    if not os.path.exists(s) and not os.path.exists(os.path.dirname(s)):
-        return s
-    if platform.system() == "Windows":
-        return os.path.abspath(s).replace('\\', '/')
-    else:
-        return os.path.realpath(s)
+import swift_path_sanitize
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -40,15 +25,10 @@ PathSanitizingFileCheck is a wrapper around LLVM's FileCheck.  In addition
 to all FileCheck features, PathSanitizingFileCheck can replace given
 strings in the input with other strings.  This feature is used to replace
 paths to the source and build directories with path-independent
-constants.""")
+constants.""",
+    )
 
-    parser.add_argument(
-        "--sanitize",
-        help="replace the given string with another string",
-        metavar="REPLACEMENT=SOURCE",
-        action="append",
-        dest="sanitize_strings",
-        default=[])
+    swift_path_sanitize.add_shared_arguments(parser)
 
     parser.add_argument(
         "--use-filecheck",
@@ -56,70 +36,30 @@ constants.""")
         metavar="PATH",
         action="store",
         dest="file_check_path",
-        default="FileCheck")
-
-    parser.add_argument(
-        "--enable-windows-compatibility",
-        help="Enable Windows path compatibility, which checks against both "
-             "forward slashes and backward slashes.",
-        action="store_true")
-
-    parser.add_argument(
-        "--enable-yaml-compatibility",
-        help="Enable YAML path compatibility. Since YAML double escapes "
-             "backward slashes, we need to check for them escaped. Only "
-             "available if Windows compatibility is enabled.",
-        action="store_true")
+        default="FileCheck",
+    )
 
     parser.add_argument(
         "--dry-run",
         help="Apply the replacements to the input and print the result "
-             "to standard output",
-        action="store_true")
-
-    parser.add_argument(
-        "--ignore-runtime-warnings",
-        help="Ignore warnings from the Swift runtime",
-        action="store_true")
+        "to standard output",
+        action="store_true",
+    )
 
     args, unknown_args = parser.parse_known_args()
 
-    if args.enable_windows_compatibility:
-        if args.enable_yaml_compatibility:
-            slashes_re = r'(/|\\\\|\\\\\\\\)'
-        else:
-            slashes_re = r'(/|\\\\)'
-    else:
-        slashes_re = r'/'
+    stdin = io.open(sys.stdin.fileno(), "r", encoding="utf-8", errors="ignore").read()
 
-    stdin = io.open(sys.stdin.fileno(), 'r', encoding='utf-8', errors='ignore').read()
-
-    for s in sorted(args.sanitize_strings, key=len, reverse=True):
-        replacement, pattern = s.split('=', 1)
-        # Since we want to use pattern as a regex in some platforms, we need
-        # to escape it first, and then replace the escaped slash
-        # literal (r'\\/') for our platform-dependent slash regex.
-        stdin = re.sub(re.sub(r'\\/' if sys.version_info[0] < 3 else r'/',
-                              slashes_re, re.escape(normalize_if_path(pattern))),
-                       replacement, stdin)
-
-    # Because we force the backtracer on in the tests, we can get runtime
-    # warnings about privileged programs.  Suppress those, and also the
-    # warning it might emit if backtracing isn't supported on the test platform.
-    # Additionally, suppress warnings about unknown backtracer options, since
-    # we might want to add new ones to the lit tests and we should ignore
-    # messages from the system copy of the runtime in that case.
-    if args.ignore_runtime_warnings:
-        stdin = re.sub(r'^swift runtime: (backtrace-on-crash is not '
-                       r'supported|unknown) .*\n', "", stdin, flags=re.M)
+    stdin = swift_path_sanitize.sanitize(stdin, args)
 
     if args.dry_run:
         print(stdin)
         return 0
     else:
         p = subprocess.Popen(
-            [args.file_check_path] + unknown_args, stdin=subprocess.PIPE)
-        stdout, stderr = p.communicate(stdin.encode('utf-8'))
+            [args.file_check_path] + unknown_args, stdin=subprocess.PIPE
+        )
+        stdout, stderr = p.communicate(stdin.encode("utf-8"))
         if stdout is not None:
             print(stdout)
         if stderr is not None:
@@ -127,5 +67,5 @@ constants.""")
         return p.wait()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     exit(main())

--- a/utils/python_format.py
+++ b/utils/python_format.py
@@ -45,6 +45,7 @@ _KNOWN_SCRIPT_PATHS = [
     _SWIFT_PATH / "utils/dev-scripts/split-cmdline",
     _SWIFT_PATH / "utils/gyb",
     _SWIFT_PATH / "utils/line-directive",
+    _SWIFT_PATH / "utils/PathSanitizingDiff",
     _SWIFT_PATH / "utils/PathSanitizingFileCheck",
     _SWIFT_PATH / "utils/recursive-lipo",
     _SWIFT_PATH / "utils/round-trip-syntax-test",

--- a/utils/swift_path_sanitize.py
+++ b/utils/swift_path_sanitize.py
@@ -1,0 +1,173 @@
+# utils/swift_path_sanitize.py -*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2026 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+# Shared path-sanitization logic used by the PathSanitizingFileCheck and
+# PathSanitizingDiff front-ends. Both tools apply the same replacements to
+# their input; they only differ in how they compare the sanitized text
+# (FileCheck directives vs. diff against a reference file).
+
+import os
+import platform
+import re
+
+
+# LLVM Lit performs realpath with the config path, so all paths are relative
+# to the real path. Paths that come from CMake (like cmake_binary_dir and
+# swift_src_root), might not do real path. Use realpath to normalize. Because
+# this normalizes Windows paths to use backslashes, we have to replace them
+# back to forward slashes.
+def normalize_if_path(s):
+    # Check dirname for cases like a file named `%t.out.txt`
+    # There won't be a `%t` path, but we still want to match this path substring.
+    if not os.path.exists(s) and not os.path.exists(os.path.dirname(s)):
+        return s
+    if platform.system() == "Windows":
+        return os.path.abspath(s).replace("\\", "/")
+    else:
+        return os.path.realpath(s)
+
+
+def add_shared_arguments(parser):
+    """Register the arguments that control path sanitization.
+
+    These are common to every front-end that sanitizes its input before
+    handing it off to a comparison tool.
+    """
+    parser.add_argument(
+        "--sanitize",
+        help="replace the given string with another string",
+        metavar="REPLACEMENT=SOURCE",
+        action="append",
+        dest="sanitize_strings",
+        default=[],
+    )
+
+    parser.add_argument(
+        "--enable-windows-compatibility",
+        help="Enable Windows path compatibility, which checks against both "
+        "forward slashes and backward slashes.",
+        action="store_true",
+    )
+
+    parser.add_argument(
+        "--enable-yaml-compatibility",
+        help="Enable YAML path compatibility. Since YAML double escapes "
+        "backward slashes, we need to check for them escaped. Only "
+        "available if Windows compatibility is enabled.",
+        action="store_true",
+    )
+
+    parser.add_argument(
+        "--ignore-runtime-warnings",
+        help="Ignore warnings from the Swift runtime",
+        action="store_true",
+    )
+
+
+def sanitize(text, args):
+    """Apply the path replacements described by ``args`` to ``text``.
+
+    ``args`` is the parsed namespace produced by a parser that had
+    ``add_shared_arguments`` applied to it.
+    """
+    if args.enable_windows_compatibility:
+        if args.enable_yaml_compatibility:
+            slashes_re = r"(/|\\\\|\\\\\\\\)"
+        else:
+            slashes_re = r"(/|\\\\)"
+    else:
+        slashes_re = r"/"
+
+    for s in sorted(args.sanitize_strings, key=len, reverse=True):
+        replacement, pattern = s.split("=", 1)
+        # Since we want to use pattern as a regex in some platforms, we need
+        # to escape it first, and then replace the escaped slash
+        # literal (r'\\/') for our platform-dependent slash regex.
+        text = re.sub(
+            re.sub(r"/", slashes_re, re.escape(normalize_if_path(pattern))),
+            replacement,
+            text,
+        )
+
+    # Because we force the backtracer on in the tests, we can get runtime
+    # warnings about privileged programs.  Suppress those, and also the
+    # warning it might emit if backtracing isn't supported on the test platform.
+    # Additionally, suppress warnings about unknown backtracer options, since
+    # we might want to add new ones to the lit tests and we should ignore
+    # messages from the system copy of the runtime in that case.
+    if args.ignore_runtime_warnings:
+        text = re.sub(
+            r"^swift runtime: (backtrace-on-crash is not " r"supported|unknown) .*\n",
+            "",
+            text,
+            flags=re.M,
+        )
+
+    return text
+
+
+# MARK: PathSanitizingDiff utils (shared with the lit plugin)
+
+# Name of the PathSanitizingDiff option (added automatically by the
+# %PathSanitizingDiff lit substitution) that carries the test's temporary
+# location (%t). PathSanitizingDiff writes its sanitized input into an output
+# derived from it so the update plugin can find it.
+TEMP_DIR_OPTION = "--temp-dir"
+
+# Suffix of the output file into which PathSanitizingDiff writes its sanitized
+# input on a mismatch. See output_path for how the full name is formed.
+UPDATE_ACTUAL_SUFFIX = ".actual"
+
+
+def reference_path(args):
+    """Return the reference (expected) file from a PathSanitizingDiff arg list.
+
+    The reference file is passed as the trailing positional argument, so return
+    the last argument that is not an option. Both PathSanitizingDiff and the
+    update plugin rely on this so they agree on the output location.
+    """
+    for arg in reversed(args):
+        if not arg.startswith("-"):
+            return arg
+    return None
+
+
+def temp_dir_from_args(args):
+    """Return the value of the last --temp-dir option in a PathSanitizingDiff
+    arg list, or None if absent. Handles both "--temp-dir X" and
+    "--temp-dir=X" spellings.
+    """
+    result = None
+    expect_value = False
+    for arg in args:
+        if expect_value:
+            result = arg
+            expect_value = False
+        elif arg == TEMP_DIR_OPTION:
+            expect_value = True
+        elif arg.startswith(TEMP_DIR_OPTION + "="):
+            result = arg[len(TEMP_DIR_OPTION) + 1 :]
+    return result
+
+
+def output_path(temp_dir, reference):
+    """Return the path PathSanitizingDiff writes its sanitized input to.
+
+    The output always lives in the per-test temporary namespace so that
+    parallel tests cannot collide, regardless of where the reference file lives:
+      - if temp_dir is a directory, it is placed inside it as
+        "<temp_dir>/<basename(reference)>.actual";
+      - otherwise temp_dir is treated as a path prefix and the output is placed in
+      "<temp_dir>.<basename(reference)>.actual".
+    """
+    name = os.path.basename(reference) + UPDATE_ACTUAL_SUFFIX
+    if os.path.isdir(temp_dir):
+        return os.path.join(temp_dir, name)
+    return temp_dir + "." + name

--- a/utils/update-pathsanitizing-diff-tests.py
+++ b/utils/update-pathsanitizing-diff-tests.py
@@ -1,0 +1,60 @@
+import argparse
+import shlex
+import sys
+
+from swift_path_sanitize import output_path
+from update_pathsanitizing_diff_tests.litplugin import repair_test
+
+"""
+Standalone entry point for repairing a PathSanitizingDiff test from the output
+file that PathSanitizingDiff writes into the per-test temporary namespace. This
+mirrors the lit --update-tests behaviour (see
+update_pathsanitizing_diff_tests.litplugin) so that the update logic can be
+exercised outside lit.
+
+Given the test file, the reference file, the temporary location (%t), and the
+`split-file` output directory, it locates the `<temp-dir>`-derived output (see
+swift_path_sanitize.output_path), overwrites the reference file with it, and
+propagates the content into the matching slice of the test file.
+
+Example usage:
+  python3 update-pathsanitizing-diff-tests.py test.swift %t/out.expected \\
+      --temp-dir %t --split-file-dir %t
+"""
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("test_file", help="The test file to update")
+    parser.add_argument("reference", help="The reference file to update")
+    parser.add_argument(
+        "--temp-dir",
+        required=True,
+        help="The test's temporary location (%%t) PathSanitizingDiff was given",
+    )
+    parser.add_argument(
+        "--split-file-dir",
+        help="Directory the reference file was materialized into by split-file",
+    )
+    args = parser.parse_args()
+
+    # Synthesize the `split-file` command that propagate_split_files scans for,
+    # so the standalone path shares the lit plugin's propagation logic.
+    commands = []
+    if args.split_file_dir:
+        commands = [
+            "split-file %s %s"
+            % (shlex.quote(args.test_file), shlex.quote(args.split_file_dir))
+        ]
+
+    output = output_path(args.temp_dir, args.reference)
+    (err, msg) = repair_test(args.test_file, args.reference, output, commands)
+    if err:
+        print(err, file=sys.stderr)
+        sys.exit(1)
+    if msg:
+        print(msg)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/update_pathsanitizing_diff_tests/litplugin.py
+++ b/utils/update_pathsanitizing_diff_tests/litplugin.py
@@ -1,0 +1,59 @@
+import os
+from swift_path_sanitize import reference_path, output_path, temp_dir_from_args
+from lit_support.split_file import propagate_split_files
+
+"""
+This file provides the `psd_lit_plugin` function, which is invoked on failed RUN
+lines when lit is executed with --update-tests.
+It checks whether the failed command is a PathSanitizingDiff invocation and, if
+so, repairs the test by replacing the reference file with the sanitized program
+output. PathSanitizingDiff writes its sanitized input to an output file in the
+per-test temporary namespace (see PathSanitizingDiff and
+swift_path_sanitize.output_path); this plugin reads that output, overwrites the
+reference file, and, if the reference file originated from `split-file`,
+propagates the new content into the corresponding slice of the test file.
+"""
+
+
+def repair_test(test_path, reference, output, commands):
+    """
+    Repair a PathSanitizingDiff test using the sanitized output previously
+    written to `output`. Overwrites `reference` with the output content and,
+    if `reference` came from `split-file`, propagates the content into the
+    matching slice of `test_path`.
+
+    Returns (error_string, None) on failure.
+    Returns (None, message_string) on success.
+    """
+    if not os.path.exists(output):
+        return (
+            "update-pathsanitizing-diff-test: expected sanitized output at "
+            f"{output} but it was not found",
+            None,
+        )
+
+    with open(output, "r") as f:
+        content = f.read()
+    with open(reference, "w") as f:
+        f.write(content)
+
+    updated_files = propagate_split_files(test_path, [reference], commands)
+    return (
+        None,
+        f"update-pathsanitizing-diff-test: updated {updated_files[0]}",
+    )
+
+
+def psd_lit_plugin(result, test, commands):
+    args = result.command.args
+    if not any(arg.endswith("PathSanitizingDiff") for arg in args):
+        return None
+
+    reference = reference_path(args)
+    temp_dir = temp_dir_from_args(args)
+    if reference is None or temp_dir is None:
+        return None
+
+    output = output_path(temp_dir, reference)
+    err, msg = repair_test(test.getFilePath(), reference, output, commands)
+    return err or msg


### PR DESCRIPTION
Extract the path-sanitization core (path normalization, shared argument definitions, replacement loop, and runtime-warning suppression) into a new swift_path_sanitize module so that both PathSanitizingFileCheck and a new PathSanitizingDiff front-end can share it.

PathSanitizingDiff sanitizes stdin the same way and then compares the result against a reference file using diff, collapsing the `PathSanitizingFileCheck --dry-run > out; diff out expected` pattern into a single step (exposed as the %PathSanitizingDiff lit substitution). Similar to PathSanitizingFileCheck, PathSanitizingDiff takes input on stdin, a positional file argument (which is the reference file, instead of file to check for CHECK directives), and various sanitize options.

Like diff, PathSanitizingDiff tests can be automatically updated to match the current behavior using lit's `--update-tests`, thanks to the accompanying lit plugin.

Migrates a swiftify-import test to demonstrate the new form.

The intention of this tool is to serve as the opposite of FileCheck: instead of selecting a few lines of the file to check, let the user select patterns NOT to match literally, and do check the rest literally. This should make it significantly easier to write tests checking what the raw diagnostics output actually looks like (instead of being limited to only `-verify` tests and some janky FileCheck tests), without having file paths or target dependent output interfere. `-verify` is still going to be the lions share of diagnostic testing, but I think when creating a new non-trivial diagnostic it's probably a good idea to check in a basic test case showing what the actual output looks like. This also makes it easier to find small errors like the source location being on the right line but wrong column etc, which we don't really test for at the moment (`-verify` _can_ do it, but it's rarely used, and good luck eyeballing where column 26 actually is). Since it's easy to auto-update the snapshot test it should be fine to capture lots of detail.