### PR TITLE
[diagnostics] enqeue child note buffers

### DIFF
--- a/include/swift/AST/DiagnosticBridge.h
+++ b/include/swift/AST/DiagnosticBridge.h
@@ -75,6 +75,8 @@ private:
                             StringRef displayName);
 
   void queueBuffer(SourceManager &sourceMgr, unsigned bufferID);
+
+  void addQueueDiagnostic(const DiagnosticInfo &info, SourceManager &SM);
 };
 } // namespace swift
 

--- a/lib/AST/DiagnosticBridge.cpp
+++ b/lib/AST/DiagnosticBridge.cpp
@@ -28,9 +28,8 @@ using namespace swift;
 #if SWIFT_BUILD_SWIFT_SYNTAX
 
 /// Enqueue a diagnostic with ASTGen's diagnostic rendering.
-static void addQueueDiagnostic(void *queuedDiagnostics,
-                               void *perFrontendState,
-                               const DiagnosticInfo &info, SourceManager &SM) {
+void DiagnosticBridge::addQueueDiagnostic(const DiagnosticInfo &info,
+                                          SourceManager &SM) {
   llvm::SmallString<256> text;
   {
     llvm::raw_svector_ostream out(text);
@@ -62,7 +61,9 @@ static void addQueueDiagnostic(void *queuedDiagnostics,
   // argument to `swift_ASTGen_addQueuedDiagnostic` but that requires
   // bridging of `Note` structure and new serialization.
   for (auto *childNote : info.ChildDiagnosticInfo) {
-    addQueueDiagnostic(queuedDiagnostics, perFrontendState, *childNote, SM);
+    if (childNote->Loc.isValid())
+      queueBuffer(SM, SM.findBufferContainingLoc(childNote->Loc));
+    addQueueDiagnostic(*childNote, SM);
   }
 }
 
@@ -119,7 +120,7 @@ void DiagnosticBridge::enqueueDiagnostic(SourceManager &SM,
     queuedDiagnostics = swift_ASTGen_createQueuedDiagnostics();
 
   queueBuffer(SM, innermostBufferID);
-  addQueueDiagnostic(queuedDiagnostics, perFrontendState, Info, SM);
+  addQueueDiagnostic(Info, SM);
 }
 
 void DiagnosticBridge::flush(llvm::raw_ostream &OS, bool includeTrailingBreak,

--- a/test/Macros/cross_buffer_child_note_rendering.swift
+++ b/test/Macros/cross_buffer_child_note_rendering.swift
@@ -4,7 +4,7 @@
 // RUN: split-file %s %t
 // RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
 
-// RUN: not env %tmpdir=%t %target-swift-frontend -swift-version 5 -typecheck %t/test.swift -load-plugin-library %t/%target-library-name(MacroDefinition) -diagnostic-style=llvm 2>&1 | %PathSanitizingDiff --sanitize-regex "MACROBUFFER=@__swiftmacro\\S*.swift" %t/llvm-render.expected
+// RUN: not env %tmpdir=%t %target-swift-frontend -swift-version 5 -typecheck %t/test.swift -load-plugin-library %t/%target-library-name(MacroDefinition) -diagnostic-style=llvm 2>&1 | %PathSanitizingDiff --sanitize-regex "MACROFILE=@__swiftmacro\\S*.swift" --sanitize-path-regex "MACROPATH=TMP_DIR/swift-generated-sources/MACROFILE" %t/llvm-render.expected
 // RUN: not env %tmpdir=%t %target-swift-frontend -swift-version 5 -typecheck %t/test.swift -load-plugin-library %t/%target-library-name(MacroDefinition) -diagnostic-style=swift 2>&1 | %PathSanitizingDiff %t/swift-syntax-render.expected
 // RUN: %target-swift-frontend -swift-version 5 -typecheck %t/test.swift -load-plugin-library %t/%target-library-name(MacroDefinition) -verify
 
@@ -27,7 +27,7 @@ var foo: Int { 2 }
 TMP_DIR/test.swift:11:5: error: invalid redeclaration of 'foo'
 var foo: Int { 2 }
     ^
-TMP_DIR/swift-generated-sources/MACROBUFFER:13:5: note: 'foo' previously declared here
+MACROPATH:13:5: note: 'foo' previously declared here
 var foo: Int {
     ^
 //--- swift-syntax-render.expected

--- a/test/Macros/cross_buffer_child_note_rendering.swift
+++ b/test/Macros/cross_buffer_child_note_rendering.swift
@@ -1,0 +1,42 @@
+// This test isolates a bug in the swift-syntax diagnostic renderer: a child
+// note whose source location is in a different buffer than its parent
+// diagnostic is silently dropped.
+
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+
+// RUN: not env TMPDIR=%t %target-swift-frontend -swift-version 5 -typecheck %t/test.swift -load-plugin-library %t/%target-library-name(MacroDefinition) -diagnostic-style=llvm 2>&1 | %PathSanitizingDiff --sanitize-regex "MACROBUFFER=@__swiftmacro\\S*.swift" %t/llvm-render.expected
+// RUN: not env TMPDIR=%t %target-swift-frontend -swift-version 5 -typecheck %t/test.swift -load-plugin-library %t/%target-library-name(MacroDefinition) -diagnostic-style=swift 2>&1 | %PathSanitizingDiff %t/swift-syntax-render.expected
+// RUN: env TMPDIR=%t %target-swift-frontend -swift-version 5 -typecheck %t/test.swift -load-plugin-library %t/%target-library-name(MacroDefinition) -verify
+
+//--- test.swift
+@freestanding(declaration, names: named(A), named(B), named(foo), named(addOne))
+macro defineDeclsWithKnownNames() = #externalMacro(module: "MacroDefinition", type: "DefineDeclsWithKnownNamesMacro")
+
+// This expands to a top-level 'var foo: Int' living in a macro expansion buffer.
+// expected-expansion@+3:1{{
+//   expected-note@13{{'foo' previously declared here}}
+// }}
+#defineDeclsWithKnownNames
+
+// expected-error@+1{{invalid redeclaration of 'foo'}}
+var foo: Int { 2 }
+
+//--- llvm-render.expected
+TMP_DIR/test.swift:11:5: error: invalid redeclaration of 'foo'
+var foo: Int { 2 }
+    ^
+TMP_DIR/swift-generated-sources/MACROBUFFER:13:5: note: 'foo' previously declared here
+var foo: Int {
+    ^
+//--- swift-syntax-render.expected
+TMP_DIR/test.swift:11:5: error: invalid redeclaration of 'foo'
+ 9 | 
+10 | // expected-error@+1{{invalid redeclaration of 'foo'}}
+11 | var foo: Int { 2 }
+   |     `- error: invalid redeclaration of 'foo'
+12 | 
+13 | 

--- a/test/Macros/cross_buffer_child_note_rendering.swift
+++ b/test/Macros/cross_buffer_child_note_rendering.swift
@@ -1,7 +1,3 @@
-// This test isolates a bug in the swift-syntax diagnostic renderer: a child
-// note whose source location is in a different buffer than its parent
-// diagnostic is silently dropped.
-
 // REQUIRES: swift_swift_parser
 
 // RUN: %empty-directory(%t)
@@ -11,6 +7,8 @@
 // RUN: not env TMPDIR=%t %target-swift-frontend -swift-version 5 -typecheck %t/test.swift -load-plugin-library %t/%target-library-name(MacroDefinition) -diagnostic-style=llvm 2>&1 | %PathSanitizingDiff --sanitize-regex "MACROBUFFER=@__swiftmacro\\S*.swift" %t/llvm-render.expected
 // RUN: not env TMPDIR=%t %target-swift-frontend -swift-version 5 -typecheck %t/test.swift -load-plugin-library %t/%target-library-name(MacroDefinition) -diagnostic-style=swift 2>&1 | %PathSanitizingDiff %t/swift-syntax-render.expected
 // RUN: env TMPDIR=%t %target-swift-frontend -swift-version 5 -typecheck %t/test.swift -load-plugin-library %t/%target-library-name(MacroDefinition) -verify
+
+// Ensure that child notes in other buffers are rendered properly.
 
 //--- test.swift
 @freestanding(declaration, names: named(A), named(B), named(foo), named(addOne))
@@ -34,6 +32,17 @@ var foo: Int {
     ^
 //--- swift-syntax-render.expected
 TMP_DIR/test.swift:11:5: error: invalid redeclaration of 'foo'
+ 6 | //   expected-note@13{{'foo' previously declared here}}
+ 7 | // }}
+ 8 | #defineDeclsWithKnownNames
+   +--- macro expansion #defineDeclsWithKnownNames ---------------------
+   |11 |   }
+   |12 | }
+   |13 | var foo: Int {
+   |   |     `- note: 'foo' previously declared here
+   |14 |     1
+   |15 | }
+   +--------------------------------------------------------------------
  9 | 
 10 | // expected-error@+1{{invalid redeclaration of 'foo'}}
 11 | var foo: Int { 2 }

--- a/test/Macros/cross_buffer_child_note_rendering.swift
+++ b/test/Macros/cross_buffer_child_note_rendering.swift
@@ -4,9 +4,9 @@
 // RUN: split-file %s %t
 // RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
 
-// RUN: not env TMPDIR=%t %target-swift-frontend -swift-version 5 -typecheck %t/test.swift -load-plugin-library %t/%target-library-name(MacroDefinition) -diagnostic-style=llvm 2>&1 | %PathSanitizingDiff --sanitize-regex "MACROBUFFER=@__swiftmacro\\S*.swift" %t/llvm-render.expected
-// RUN: not env TMPDIR=%t %target-swift-frontend -swift-version 5 -typecheck %t/test.swift -load-plugin-library %t/%target-library-name(MacroDefinition) -diagnostic-style=swift 2>&1 | %PathSanitizingDiff %t/swift-syntax-render.expected
-// RUN: env TMPDIR=%t %target-swift-frontend -swift-version 5 -typecheck %t/test.swift -load-plugin-library %t/%target-library-name(MacroDefinition) -verify
+// RUN: not env %tmpdir=%t %target-swift-frontend -swift-version 5 -typecheck %t/test.swift -load-plugin-library %t/%target-library-name(MacroDefinition) -diagnostic-style=llvm 2>&1 | %PathSanitizingDiff --sanitize-regex "MACROBUFFER=@__swiftmacro\\S*.swift" %t/llvm-render.expected
+// RUN: not env %tmpdir=%t %target-swift-frontend -swift-version 5 -typecheck %t/test.swift -load-plugin-library %t/%target-library-name(MacroDefinition) -diagnostic-style=swift 2>&1 | %PathSanitizingDiff %t/swift-syntax-render.expected
+// RUN: %target-swift-frontend -swift-version 5 -typecheck %t/test.swift -load-plugin-library %t/%target-library-name(MacroDefinition) -verify
 
 // Ensure that child notes in other buffers are rendered properly.
 

--- a/test/Utils/path-sanitizing-regex.test
+++ b/test/Utils/path-sanitizing-regex.test
@@ -1,0 +1,25 @@
+# Tests for the --sanitize-regex option shared by PathSanitizingFileCheck and
+# PathSanitizingDiff. Unlike --sanitize, its SOURCE is treated as a regular
+# expression used verbatim (no path normalization, escaping, or slash-compat
+# substitution).
+
+# RUN: %empty-directory(%t)
+
+# A --sanitize-regex rewrites text matching the regex; the source is used as a
+# regex (here [0-9]+), not as a literal string. --dry-run prints the result.
+# RUN: printf 'value = 12345\n' | %{python} %utils/PathSanitizingFileCheck --sanitize-regex 'NUM=[0-9]+' --dry-run | %raw-FileCheck --check-prefix=REGEX %s
+# REGEX: value = NUM
+
+# The replacement may reference regex capture groups.
+# RUN: printf 'id: abc-999\n' | %{python} %utils/PathSanitizingFileCheck --sanitize-regex 'id: \1-N=id: ([a-z]+)-[0-9]+' --dry-run | %raw-FileCheck --check-prefix=BACKREF %s
+# BACKREF: id: abc-N
+
+# --sanitize-regex composes with a literal --sanitize; literal paths are
+# replaced first, then the regex is applied to the result.
+# RUN: printf 'hash 0xDEADBEEF in /some/build/dir\n' | %{python} %utils/PathSanitizingFileCheck --sanitize BUILD=/some/build/dir --sanitize-regex 'HASH=0x[0-9A-Fa-f]+' --dry-run | %raw-FileCheck --check-prefix=COMBINED %s
+# COMBINED: hash HASH in BUILD
+
+# PathSanitizingDiff applies the same regex sanitization before diffing against
+# the reference file, so a sanitized mismatch becomes a match.
+# RUN: printf 'value = num\n' > %t/expected.txt
+# RUN: printf 'value = 98765\n' | %{python} %utils/PathSanitizingDiff --sanitize-regex 'num=[0-9]+' %t/expected.txt

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -3373,6 +3373,12 @@ run_pathsanitizingdiff = '%s %s --temp-dir %s --sanitize TMP_DIR=%s --sanitize B
         '--enable-windows-compatibility' if kIsWindows else '')
 
 config.substitutions.append(('%PathSanitizingDiff', run_pathsanitizingdiff))
+
+# Name of the environment variable that controls the process's notion of the
+# system temporary directory (as consulted by LLVM's
+# llvm::sys::path::system_temp_directory).
+config.substitutions.append(('%tmpdir', 'TMP' if kIsWindows else 'TMPDIR'))
+
 config.substitutions.append(('%import-libdispatch', getattr(config, 'import_libdispatch', '')))
 # WARNING: the order of components in a substitution name has to be different from the previous one, as lit does
 # a pure string substitution without understanding that these components are grouped together. That is, the following

--- a/utils/swift_path_sanitize.py
+++ b/utils/swift_path_sanitize.py
@@ -13,9 +13,11 @@
 # their input; they only differ in how they compare the sanitized text
 # (FileCheck directives vs. diff against a reference file).
 
+import argparse
 import os
 import platform
 import re
+from enum import Enum
 
 
 # LLVM Lit performs realpath with the config path, so all paths are relative
@@ -32,6 +34,31 @@ def normalize_if_path(s):
         return os.path.abspath(s).replace("\\", "/")
     else:
         return os.path.realpath(s)
+
+
+class SanitizerKind(Enum):
+    REGEX = 1
+    PATH_REGEX = 2
+
+
+class _AppendSanitizeRegex(argparse.Action):
+    """Append ``(kind, value)`` pairs onto a single ordered list.
+
+    Both ``--sanitize-regex`` and ``--sanitize-path-regex`` feed the same
+    destination so that their relative order on the command line is preserved:
+    a later pattern may depend on the replacement performed by an earlier one
+    (e.g. a path regex whose SOURCE references an earlier regex's REPLACEMENT).
+    The ``kind`` records which flag produced each entry.
+    """
+
+    def __init__(self, option_strings, dest, kind, **kwargs):
+        self._kind = kind
+        super().__init__(option_strings, dest, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        items = list(getattr(namespace, self.dest, []))
+        items.append((self._kind, values))
+        setattr(namespace, self.dest, items)
 
 
 def add_shared_arguments(parser):
@@ -56,9 +83,24 @@ def add_shared_arguments(parser):
         "used verbatim: it is not path-normalized, not regex-escaped, and no "
         "slash compatibility substitution is applied to it.",
         metavar="REPLACEMENT=SOURCE",
-        action="append",
+        action=_AppendSanitizeRegex,
+        kind=SanitizerKind.REGEX,
         dest="sanitize_regexes",
-        default=[],
+    )
+
+    parser.add_argument(
+        "--sanitize-path-regex",
+        help="replace text matching the given regex with another string. "
+        "Unlike --sanitize, SOURCE is treated as a regular expression and is "
+        "not path-normalized or regex-escaped. Unlike --sanitize-regex, slash "
+        "compatibility substitution is applied to it, however. If you need to "
+        "use / or \\ for non-path-separator purposes in your regex, split that "
+        "out into a separate --sanitize-regex first and include the REPLACEMENT"
+        " of that pattern in your path's SOURCE pattern.",
+        metavar="REPLACEMENT=SOURCE",
+        action=_AppendSanitizeRegex,
+        kind=SanitizerKind.PATH_REGEX,
+        dest="sanitize_regexes",
     )
 
     parser.add_argument(
@@ -81,6 +123,8 @@ def add_shared_arguments(parser):
         help="Ignore warnings from the Swift runtime",
         action="store_true",
     )
+
+    parser.set_defaults(sanitize_regexes=[])
 
 
 def sanitize(text, args):
@@ -109,11 +153,13 @@ def sanitize(text, args):
         )
 
     # Regex sanitizations are applied after the literal path replacements above
-    # so that they can match already-sanitized text. The source is used
-    # verbatim as a regex, so the caller is responsible for any escaping and
-    # for slash handling.
-    for s in args.sanitize_regexes:
+    # so that they can match already-sanitized text.
+    for kind, s in args.sanitize_regexes:
+        # FIXME: provide a way to escape "=" for use in regex matching
         replacement, pattern = s.split("=", 1)
+        if kind == SanitizerKind.PATH_REGEX and args.enable_windows_compatibility:
+            pattern = pattern.replace("\\", "/")
+            pattern = re.sub(r"/", slashes_re, pattern)
         text = re.sub(pattern, replacement, text)
 
     # Because we force the backtracer on in the tests, we can get runtime

--- a/utils/swift_path_sanitize.py
+++ b/utils/swift_path_sanitize.py
@@ -50,6 +50,18 @@ def add_shared_arguments(parser):
     )
 
     parser.add_argument(
+        "--sanitize-regex",
+        help="replace text matching the given regex with another string. "
+        "Unlike --sanitize, SOURCE is treated as a regular expression and is "
+        "used verbatim: it is not path-normalized, not regex-escaped, and no "
+        "slash compatibility substitution is applied to it.",
+        metavar="REPLACEMENT=SOURCE",
+        action="append",
+        dest="sanitize_regexes",
+        default=[],
+    )
+
+    parser.add_argument(
         "--enable-windows-compatibility",
         help="Enable Windows path compatibility, which checks against both "
         "forward slashes and backward slashes.",
@@ -95,6 +107,14 @@ def sanitize(text, args):
             replacement,
             text,
         )
+
+    # Regex sanitizations are applied after the literal path replacements above
+    # so that they can match already-sanitized text. The source is used
+    # verbatim as a regex, so the caller is responsible for any escaping and
+    # for slash handling.
+    for s in args.sanitize_regexes:
+        replacement, pattern = s.split("=", 1)
+        text = re.sub(pattern, replacement, text)
 
     # Because we force the backtracer on in the tests, we can get runtime
     # warnings about privileged programs.  Suppress those, and also the


### PR DESCRIPTION
Previously we would only enqueue the buffer of top-level diagnostics.
This meant that if a child note had a location in a different buffer,
the diagnostic renderer in swift-syntax would not be able to lookup the
buffer, and would silently not render the child note.

rdar://182892567