### PR TITLE
[DebugInfo] Kill unsalvageable box operands in AllocBoxToStack

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AllocBoxToStack.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AllocBoxToStack.swift
@@ -252,8 +252,14 @@ private struct FunctionSpecializations {
         // In a later iteration those additional uses will be handled.
         (user as! SingleValueInstruction).replace(with: box, context)
       case let debugValue as DebugValueInst:
-        debugValue.operand.set(to: stack, context)
-        debugValue.prependDeref()
+        if debugValue.debugReconstructionBlock != nil {
+          // A box cannot be salvaged.
+          debugValue.killOperand()
+        } else {
+          // A bare debug_value on an alloc_box describes the box content: repoint it to the alloc_stack with a deref.
+          debugValue.operand.set(to: stack, context)
+          debugValue.prependDeref()
+        }
       case let apply as ApplySite:
         specialize(apply: apply, context)
       default:

--- a/test/DebugInfo/allocbox_to_stack.sil
+++ b/test/DebugInfo/allocbox_to_stack.sil
@@ -1,0 +1,52 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -allocbox-to-stack %s | %FileCheck %s
+sil_stage raw
+
+import Builtin
+
+enum Nat {
+  case zero
+  indirect case succ(Nat)
+}
+
+// When an alloc_box is promoted to the stack and a debug_value on the box has
+// a debug reconstruction block, the operand must be killed as unsalvageable.
+
+// CHECK-LABEL: sil [ossa] @box_with_debug_reconstruction_block_indirect_enum
+// CHECK: alloc_stack
+// CHECK-NOT: alloc_box
+// CHECK: debug_value undef : {{.*}}, var, name "x", type $Nat, transform
+sil [ossa] @box_with_debug_reconstruction_block_indirect_enum : $@convention(thin) () -> () {
+bb0:
+  %1 = alloc_box ${ var Nat }
+  debug_value %1 : ${ var Nat }, var, name "x", type $Nat, transform {
+  bb0(%0 : ${ var Nat }):
+    %1 = enum $Nat, #Nat.succ!enumelt, %0 : ${ var Nat }
+    return %1 : $Nat
+  }
+  %1a = project_box %1 : ${ var Nat }, 0
+  %zero = enum $Nat, #Nat.zero!enumelt
+  store %zero to [trivial] %1a : $*Nat
+  destroy_value %1 : ${ var Nat }
+  %r = tuple ()
+  return %r : $()
+}
+
+// When there is no debug reconstruction block, the debug_value should be
+// repointed to the alloc_stack with an op_deref.
+
+// CHECK-LABEL: sil [ossa] @box_without_debug_reconstruction_block
+// CHECK: [[STACK:%[0-9]+]] = alloc_stack
+// CHECK-NOT: alloc_box
+// CHECK: debug_value [[STACK]], var, name "x", expr op_deref
+// CHECK: return
+sil [ossa] @box_without_debug_reconstruction_block : $@convention(thin) () -> () {
+bb0:
+  %1 = alloc_box ${ var Nat }
+  debug_value %1 : ${ var Nat }, var, name "x"
+  %1a = project_box %1 : ${ var Nat }, 0
+  %zero = enum $Nat, #Nat.zero!enumelt
+  store %zero to [trivial] %1a : $*Nat
+  destroy_value %1 : ${ var Nat }
+  %r = tuple ()
+  return %r : $()
+}


### PR DESCRIPTION
If a debug_value on an alloc_box has a debug reconstruction block, it cannot be salvaged by simply changing it to a stack value, as a box type is expected.

Instead, set the operand to undef as it cannot be salvaged.

This fixes a regression when indirect enums were salvaged.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
