### PR TITLE
[Embedded] Build the embedded stdlib for Android

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -203,7 +203,8 @@ if((NOT SWIFT_HOST_VARIANT STREQUAL "macosx") AND
   (NOT SWIFT_HOST_VARIANT STREQUAL "linux") AND
   (NOT SWIFT_HOST_VARIANT STREQUAL "wasi") AND
   (NOT SWIFT_HOST_VARIANT STREQUAL "emscripten") AND
-  (NOT SWIFT_HOST_VARIANT STREQUAL "windows"))
+  (NOT SWIFT_HOST_VARIANT STREQUAL "windows") AND
+  (NOT SWIFT_HOST_VARIANT STREQUAL "android"))
   set(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB FALSE)
 elseif(BOOTSTRAPPING_MODE STREQUAL "OFF")
   set(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB FALSE)
@@ -329,6 +330,20 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB
       "i686    i686-unknown-windows-msvc   i686-unknown-windows-msvc"
       "x86_64  x86_64-unknown-windows-msvc x86_64-unknown-windows-msvc"
     )
+  elseif (SWIFT_HOST_VARIANT STREQUAL "android")
+    # Normalized module name so clients resolve it, but the compile triple is
+    # pinned to the API level so libc++ uses pthread_cond_timedwait rather than
+    # the API-30-only pthread_cond_clockwait.
+    list(APPEND EMBEDDED_STDLIB_TARGET_TRIPLES
+      "${SWIFT_HOST_VARIANT_ARCH} ${SWIFT_HOST_VARIANT_ARCH}-unknown-linux-android ${SWIFT_HOST_VARIANT_ARCH}-unknown-linux-android${SWIFT_ANDROID_API_LEVEL}"
+    )
+    file(GLOB _swift_android_ndk_sysroots
+      "${SWIFT_ANDROID_NDK_PATH}/toolchains/llvm/prebuilt/*/sysroot")
+    if(_swift_android_ndk_sysroots)
+      list(GET _swift_android_ndk_sysroots 0 _swift_android_ndk_sysroot)
+      list(APPEND SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES
+        "${SWIFT_HOST_VARIANT_ARCH}-unknown-linux-android${SWIFT_ANDROID_API_LEVEL}@${_swift_android_ndk_sysroot}")
+    endif()
   endif()
 endif()
 

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -116,11 +116,14 @@ public struct HeapObject {
 #endif
 
 #if _pointerBitWidth(_64)
+#if os(Android) && arch(arm64)
+  // Android AArch64 stores the high spare bits in the second-highest byte.
+  static let immortalObjectPointerBit = _bridgeObjectTaggedPointerBits
+  static let bridgeObjectToPlainObjectMask = ~_objectPointerSpareBits
+#else
   static let immortalObjectPointerBit = UInt(0x8000_0000_0000_0000)
-#endif
-
-#if _pointerBitWidth(_64)
   static let bridgeObjectToPlainObjectMask = UInt(0x8fff_ffff_ffff_fff8)
+#endif
 #elseif _pointerBitWidth(_32)
   static let bridgeObjectToPlainObjectMask = UInt(0xffff_ffff)
 #elseif _pointerBitWidth(_16)

--- a/test/embedded/stdlib-strings-interpolation.swift
+++ b/test/embedded/stdlib-strings-interpolation.swift
@@ -2,7 +2,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu || OS=wasip1
+// REQUIRES: OS=macosx || OS=linux-gnu || OS=wasip1 || OS=linux-android
 // REQUIRES: swift_feature_Embedded
 
 @main


### PR DESCRIPTION
Allows `android` as an Embedded Swift host variant and adds an `aarch64-unknown-linux-android` embedded triple pointed at the NDK sysroot.

The module name is normalized (`aarch64-unknown-linux-android`) so clients resolve it, while the compile triple is pinned to the SDK's API level so libc++ uses `pthread_cond_timedwait` rather than the API-30-only `pthread_cond_clockwait`.

Depends on #90768 for correct AArch64 Android runtime behavior. Verified by building the Swift Android SDK with the embedded stdlib enabled and running an embedded binary on an arm64 Android emulator.

cc @finagolfin 