### PR TITLE
[Sema] Reject global actor annotations on class base types and enum raw types

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6487,6 +6487,14 @@ ERROR(global_actor_arg,none,
       (Type))
 ERROR(global_actor_non_final_class,none,
       "non-final class %0 cannot be a global actor", (DeclName))
+ERROR(global_actor_on_non_protocol_inheritance,none,
+      "global actor %0 cannot apply to %select{superclass|raw type}1 %2",
+      (Type, bool, Type))
+NOTE(global_actor_on_non_protocol_inheritance_explanation,none,
+     "inheritance from a %select{superclass|raw type}0 cannot be isolated",
+     (bool))
+NOTE(global_actor_on_non_protocol_inheritance_remove,none,
+     "remove %0", (Type))
 
 GROUPED_WARNING(global_actor_shared_non_let_witness,
                 UnstableGlobalActorShared,none,

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3779,11 +3779,28 @@ TypeResolver::resolveAttributedType(TypeRepr *repr, TypeResolutionOptions option
     return false;
   };
 
-  // If we're in an inheritance clause, check for a global actor.
+  // If we're in an inheritance clause, check for a global actor. Global
+  // actor annotations are only meaningful on protocol conformances, as part
+  // of SE-0466 isolated conformances; they have no effect on a class base
+  // type or an enum's raw type; reject them there.
   if (options.is(TypeResolverContext::Inherited)) {
     CustomAttr *customAttr = nullptr;
-    (void)resolveGlobalActor(repr->getLoc(), options,
-                             customAttr, attrs);
+    Type globalActorType =
+        resolveGlobalActor(repr->getLoc(), options, customAttr, attrs);
+    if (customAttr && !ty->hasError() && !ty->isConstraintType()) {
+      bool isRawType = isa_and_nonnull<EnumDecl>(getDeclContext()->getAsDecl());
+      diagnoseInvalid(repr, customAttr->getLocation(),
+                      diag::global_actor_on_non_protocol_inheritance,
+                      globalActorType, isRawType, ty);
+      diagnose(customAttr->getLocation(),
+               diag::global_actor_on_non_protocol_inheritance_explanation,
+               isRawType);
+      diagnose(customAttr->getLocation(),
+               diag::global_actor_on_non_protocol_inheritance_remove,
+               globalActorType)
+          .fixItRemove(customAttr->getRangeWithAt());
+      ty = ErrorType::get(getASTContext());
+    }
   }
 
   if (handleInheritedOnly(claim<UncheckedTypeAttr>(attrs)) ||

--- a/test/Concurrency/isolated_conformance.swift
+++ b/test/Concurrency/isolated_conformance.swift
@@ -353,3 +353,36 @@ class ComputedGetSetWitness: HasMutableVar {
     set { }
   }
 }
+
+// ----------------------------------------------------------------------------
+// Global actor annotations are only meaningful on protocol conformances;
+// they have no effect on a class base type or an enum's raw type.
+// ----------------------------------------------------------------------------
+
+class PlainBase {}
+
+class RejectSuperclassAnnotation: @MainActor PlainBase {}
+// expected-error@-1{{global actor 'MainActor' cannot apply to superclass 'PlainBase'}}
+// expected-note@-2{{inheritance from a superclass cannot be isolated}}
+// expected-note@-3{{remove 'MainActor'}}
+
+class RejectSuperclassAnnotationCustomActor: @SomeGlobalActor PlainBase {}
+// expected-error@-1{{global actor 'SomeGlobalActor' cannot apply to superclass 'PlainBase'}}
+// expected-note@-2{{inheritance from a superclass cannot be isolated}}
+// expected-note@-3{{remove 'SomeGlobalActor'}}
+
+// The protocol conformance is still fine; only the superclass annotation
+// is rejected.
+class RejectSuperclassAnnotationWithConformance: @MainActor PlainBase, P {
+  // expected-error@-1{{global actor 'MainActor' cannot apply to superclass 'PlainBase'}}
+  // expected-note@-2{{inheritance from a superclass cannot be isolated}}
+  // expected-note@-3{{remove 'MainActor'}}
+  nonisolated func f() { }
+}
+
+enum RejectRawTypeAnnotation: @MainActor Int {
+// expected-error@-1{{global actor 'MainActor' cannot apply to raw type 'Int'}}
+// expected-note@-2{{inheritance from a raw type cannot be isolated}}
+// expected-note@-3{{remove 'MainActor'}}
+  case a
+}


### PR DESCRIPTION
## Summary

Global actor annotations like `@MainActor` in an inheritance clause are only meaningful on protocol conformances ([SE-0466](https://swiftlang.github.io/swift-evolution/#?proposal=SE-0466) isolated conformances). `resolveAttributedType` parsed the attribute in the inherited-clause path but never validated that the annotated type was actually a protocol/protocol composition, so it was silently accepted — and had no effect — on class base types and enum raw types:

```swift
class Derived: @MainActor Base {}       // was accepted silently, now an error
enum E: @MainActor Int { case a }       // was accepted silently, now an error
class Derived: @MainActor P {}          // still valid (SE-0466 isolated conformance)
```

Both the class base type and enum raw type cases go through the same `TypeResolverContext::Inherited` path (`InheritedTypeRequest` sets that context for any `NominalTypeDecl`), so a single check in `resolveAttributedType` covers both.

The diagnostic includes an explanatory note and a note with a fix-it to remove the attribute.

Resolves #86693.

## Relationship to #90085

This picks up where #90085 left off — that PR stalled after review feedback from @a-viv-a on 2026-06-25 went unaddressed for about a month. This PR addresses that feedback directly:
- Uses `%select` in the diagnostic so the same message covers both the superclass and enum-raw-type cases (rather than adding a second diagnostic).
- Adds an explanatory note ("inheritance from a superclass/raw type cannot be isolated") plus a separate note carrying the fix-it, rather than attaching the fix-it to the error itself.
- Adds enum raw-type test coverage (`enum E: @MainActor Int { case a }`), not just the class case.
- Folds new tests into the existing `test/Concurrency/isolated_conformance.swift` instead of adding a new test file, per review feedback.

## Testing

Added test cases to `test/Concurrency/isolated_conformance.swift` covering:
- A plain class superclass annotation (`@MainActor`)
- A custom global actor on a superclass (`@SomeGlobalActor`)
- A class with both a rejected superclass annotation and a valid protocol conformance in the same inheritance clause
- An enum raw type annotation (`@MainActor Int`)

## Caveat

I don't have a local CMake/Ninja build environment set up for this checkout, so I was not able to build the compiler or run `test/Concurrency/isolated_conformance.swift` through `lit`/`utils/run-test` locally. I verified the change carefully against the existing code paths and diagnostic-printing conventions (e.g. confirming `Type` diagnostic arguments are auto-quoted by `DiagnosticEngine`, and that `TypeResolverContext::Inherited` is shared between class and enum inherited-type resolution), but I'd appreciate CI / a maintainer double-checking the exact diagnostic text and fix-it output.
