### PR TITLE
Optimizer: Add EagerMaterialization pass to hoist temporary R-values out of loops

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
@@ -26,6 +26,7 @@ swift_compiler_sources(Optimizer
   DeinitDevirtualizer.swift
   DestroyHoisting.swift
   DiagnoseInfiniteRecursion.swift
+  EagerMaterialization.swift
   EmbeddedWitnessCallSpecialization.swift
   InitializeStaticGlobals.swift
   KillInvalidDebugValues.swift

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/EagerMaterialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/EagerMaterialization.swift
@@ -1,0 +1,191 @@
+//===--- EagerMaterialization.swift ----------------------------------------==//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import AST
+import SIL
+
+/// Eagerly materialize values that are stored locally inside loops.
+///
+/// If a value is stored to a local alloc_stack within an inner loop, but the
+/// value itself is available before/outside the loop, store the value to a
+/// stack allocation at the point that it becomes available. Replace the store
+/// with a copy_addr from this "eager" temporary allocation. This transformation
+/// enables transformations like TempRValueElimination to eliminate repeated
+/// stores to the stack within loops.
+///
+/// ```
+/// bb0:
+///   br bb1
+/// bb1:
+///   cond_br %cond, bb2, bb3
+/// bb2:
+///   %temp = alloc_stack $T
+///   store %val to [init] %temp
+///   ...
+///   dealloc_stack %temp
+///   br bb1
+/// bb3:
+///   ...
+/// ```
+/// ->
+/// ```
+/// bb0:
+///   %eager = alloc_stack $T
+///   store %val to [init] %eager
+///   br bb1
+/// bb1:
+///   cond_br %cond, bb2, bb3
+/// bb2:
+///   %temp = alloc_stack $T
+///   copy_addr %eager to [init] %temp
+///   ...
+///   dealloc_stack %temp
+///   br bb1
+/// bb3:
+///   ...
+/// ```
+///
+let eagerMaterialization = FunctionPass(name: "eager-materialization") {
+  (function: Function, context: FunctionPassContext) in
+
+  var materialization = EagerMaterialization(for: function, context)
+  defer { materialization.deinitialize() }
+  materialization.materialize()
+}
+
+private struct EagerMaterialization {
+
+  let context: FunctionPassContext
+  var visited: BasicBlockSet
+  var function: Function
+  // The stack allocations created to eagerly materialize values, that must be
+  // deallocated in reverse order at the end of the function.
+  var allocStacks: [AllocStackInst]
+  var materializedAddresses: [HashableValue: Value]
+  let allocBuilder: Builder
+
+  init(for function: Function, _ context: FunctionPassContext) {
+    self.context = context
+    self.visited = BasicBlockSet(context)
+    self.function = function
+    self.allocStacks = []
+    self.materializedAddresses = [:]
+    self.allocBuilder = Builder(atBeginOf: function.entryBlock, context)
+  }
+
+  /// Perform eager materialization for each top-level loop.
+  mutating func materialize() {
+    for loop in context.loopTree.loops {
+      materialize(in: loop)
+    }
+  }
+
+  /// Perform eager materialization, in a post-order DFS over the loop tree.
+  /// This order ensures that each block is visited while processing the
+  /// innermost loop it is part of.
+  private mutating func materialize(in loop: Loop) {
+    for inner in loop.innerLoops {
+      materialize(in: inner)
+    }
+
+    for block in loop.loopBlocks where !visited.contains(block) {
+      defer { visited.insert(block) }
+
+      // Eager materialization introduces additional copies of the value, so it
+      // is only possible when the value is trivial, and adding a new store
+      // would not cause it to be consumed.
+      for case let store as StoreInst in block.instructions
+      where store.storeOwnership == .trivial {
+
+        // Eagerly materialize only when the stored value exists outside the
+        // block's innermost loop, and the destination address is a stack
+        // allocation within the innermost loop. These are prime candidates for
+        // TempRValueElimination.
+        guard let destInst = store.destination.definingInstruction,
+          case let alloc as AllocStackInst = destInst,
+          loop.contains(block: alloc.parentBlock)
+        else {
+          continue
+        }
+
+        let storedValue = store.source
+
+        if loop.contains(block: storedValue.parentBlock) {
+          continue
+        }
+
+        // Materialize the stored value into an address and replace the store
+        // with a copy_addr.
+        let address = getMaterializedAddress(of: storedValue)
+        Builder(after: store, context).createCopyAddr(
+          from: address, to: store.destinationAddress, initializeDest: true)
+
+        context.erase(instruction: store)
+      }
+    }
+  }
+
+  /// Get a materialized address for the supplied value.
+  private mutating func getMaterializedAddress(of value: Value) -> Value {
+    if let address = materializedAddresses[value.hashable] {
+      return address
+    }
+
+    // Allocate the address for the value in the entry block, and store it there
+    // at the earliest point where the value and address are both available.
+    assert(value.type.isObject, "Only values with object type should be stored on the stack.")
+    let alloc = allocBuilder.createAllocStack(value.type)
+    allocStacks.append(alloc)
+    materializedAddresses[value.hashable] = alloc
+    let insertionPoint = getStoreInsertionPoint(for: value, after: alloc)
+    Builder(before: insertionPoint, context).createStore(
+      source: value, destination: alloc, ownership: .trivial)
+
+    return alloc
+  }
+
+  /// Given a value that we need to eagerly materialize, find a point where we
+  /// can insert a store. Returns an instruction we can insert the store before.
+  /// The insertion point must be after the supplied alloc_stack (which must be
+  /// in the entry block).
+  private func getStoreInsertionPoint(for value: Value, after alloc: AllocStackInst) -> Instruction
+  {
+    precondition(alloc.parentBlock == alloc.parentFunction.entryBlock)
+
+    let nextInstruction = value.nextInstruction
+
+    if nextInstruction.parentBlock != alloc.parentBlock {
+      // The nextInstruction is in a non-entry block, so it must be after the alloc_stack.
+      return nextInstruction
+    }
+
+    // We must insert the store after the allocation and the point where the value is introduced.
+    if alloc.strictlyDominatesInBlock(nextInstruction) {
+      return nextInstruction
+    }
+    // alloc_stack is not a TermInst so next! is safe.
+    return alloc.next!
+
+  }
+
+  public mutating func deinitialize() {
+    for block in function.blocks
+    where block.isReachableExitBlock {
+      let deallocBuilder = Builder(before: block.terminator, context)
+      for alloc in allocStacks.reversed() {
+        deallocBuilder.createDeallocStack(alloc)
+      }
+    }
+
+    visited.deinitialize()
+  }
+}

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/EagerMaterialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/EagerMaterialization.swift
@@ -178,8 +178,9 @@ private struct EagerMaterialization {
   }
 
   public mutating func deinitialize() {
+    let dea = context.deadEndBlocks
     for block in function.blocks
-    where block.isReachableExitBlock {
+        where block.isReachableExitBlock && !dea.isDeadEnd(block) {
       let deallocBuilder = Builder(before: block.terminator, context)
       for alloc in allocStacks.reversed() {
         deallocBuilder.createDeallocStack(alloc)

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -121,6 +121,7 @@ private func registerSwiftPasses() {
   registerPass(loopInvariantCodeMotionPass, { loopInvariantCodeMotionPass.run($0) })
   registerPass(killInvalidDebugValuesPass, { killInvalidDebugValuesPass.run($0) })
   registerPass(packSpecialization, { packSpecialization.run($0) })
+  registerPass(eagerMaterialization, { eagerMaterialization.run($0) })
 
   // Instruction passes
   registerForSILCombine(BeginBorrowInst.self,      { run(BeginBorrowInst.self, $0) })

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -154,6 +154,8 @@ PASS(DeadObjectElimination, "dead-object-elimination",
      "Removes dead object, stack and array allocations")
 PASS(MandatoryDeadObjectElimination, "mandatory-dead-object-elimination",
      "Removes dead stack allocations")
+PASS(EagerMaterialization, "eager-materialization",
+     "Eagerly stack-allocate values so copies stored in loops can be eliminated")
 
 PASS(ClosureSpecialization, "closure-specialization",
      "Specialize functions with closure arguments")

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -607,6 +607,7 @@ void addFunctionPasses(SILPassPipelinePlan &P,
   P.addEarlyCodeMotion();
   P.addReleaseHoisting();
   P.addARCSequenceOpts();
+  P.addEagerMaterialization();
   P.addTempRValueElimination();
 
   P.addSimplifyCFG();

--- a/test/SILOptimizer/eager_materialization.sil
+++ b/test/SILOptimizer/eager_materialization.sil
@@ -90,6 +90,8 @@ bb3:
   return %result
 }
 
+sil [ossa] @noreturn : $@convention(thin) () -> Never
+
 // CHECK-LABEL: sil [ossa] @materialize_no_dead_end_dealloc : $@convention(thin) () -> () {
 // CHECK:       bb0:
 // CHECK-NEXT:    [[EAGER_ALLOC:%[0-9]+]] = alloc_stack $A
@@ -103,14 +105,10 @@ bb3:
 // CHECK-NEXT:    [[LOCAL_ALLOC:%[0-9]+]] = alloc_stack $A
 // CHECK-NEXT:    copy_addr [[EAGER_ALLOC]] to [init] [[LOCAL_ALLOC]]
 // CHECK-NEXT:    dealloc_stack [[LOCAL_ALLOC]]
-// CHECK:       bb3:
-// CHECK-NEXT:    cond_br undef, bb4, bb5
 // CHECK:       bb4:
-// CHECK-NEXT:    [[RESULT:%[0-9]+]] = tuple ()
-// CHECK-NEXT:    dealloc_stack [[EAGER_ALLOC]]
-// CHECK-NEXT:    return [[RESULT]]
+// CHECK-NOT:     dealloc_stack
 // CHECK:       bb5:
-// CHECK-NEXT:    unreachable
+// CHECK-NOT:     dealloc_stack
 // CHECK-LABEL: } // end sil function 'materialize_no_dead_end_dealloc'
 sil [ossa] @materialize_no_dead_end_dealloc : $@convention(thin) () -> () {
 bb0:
@@ -131,8 +129,10 @@ bb3:
   cond_br undef, bb4, bb5
 
 bb4:
-  %result = tuple ()
-  return %result
+  %noreturn = function_ref @noreturn : $@convention(thin) () -> Never
+  apply %noreturn() : $@convention(thin) () -> Never
+  %deadResult = tuple ()
+  return %deadResult
 
 bb5:
   unreachable

--- a/test/SILOptimizer/eager_materialization.sil
+++ b/test/SILOptimizer/eager_materialization.sil
@@ -1,0 +1,475 @@
+// RUN: %target-sil-opt %s -module-name A -eager-materialization | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+struct A {
+  let v: InlineArray<4, Builtin.Word>
+}
+
+class B {
+  let v: InlineArray<4, Builtin.Word>
+}
+
+sil [ossa] @get_a : $@convention(thin) () -> A
+sil [ossa] @get_a_ptr : $@convention(thin) () -> UnsafePointer<A>
+
+// Type A is trivial, so it is a candidate for store hoisting
+//
+// CHECK-LABEL: sil [ossa] @materialize_a : $@convention(thin) () -> () {
+// CHECK:       bb0:
+// CHECK-NEXT:    [[EAGER_ALLOC:%[0-9]+]] = alloc_stack $A
+// CHECK:         function_ref @get_a
+// CHECK-NEXT:    [[A_VALUE:%[0-9]+]] = apply
+// CHECK-NEXT:    store [[A_VALUE]] to [trivial] [[EAGER_ALLOC]]
+// CHECK-NEXT:    br bb1
+// CHECK:       bb1:
+// CHECK-NEXT:    cond_br undef, bb2, bb3
+// CHECK:       bb2:
+// CHECK-NEXT:    [[LOCAL_ALLOC:%[0-9]+]] = alloc_stack $A
+// CHECK-NEXT:    copy_addr [[EAGER_ALLOC]] to [init] [[LOCAL_ALLOC]]
+// CHECK-NEXT:    dealloc_stack [[LOCAL_ALLOC]]
+// CHECK:       bb3:
+// CHECK:         [[RESULT:%[0-9]+]] = tuple ()
+// CHECK-NEXT:    dealloc_stack [[EAGER_ALLOC]]
+// CHECK-NEXT:    return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'materialize_a'
+sil [ossa] @materialize_a : $@convention(thin) () -> () {
+bb0:
+  %get_a = function_ref @get_a : $@convention(thin) () -> A
+  %a = apply %get_a() : $@convention(thin) () -> A
+  br bb1
+
+bb1:
+  cond_br undef, bb2, bb3
+
+bb2:
+  %stk = alloc_stack $A
+  store %a to [trivial] %stk
+  dealloc_stack %stk
+  br bb1
+
+bb3:
+  %result = tuple ()
+  return %result
+}
+
+// CHECK-LABEL: sil [ossa] @materialize_a_parameter : $@convention(thin) (A) -> () {
+// CHECK:       bb0(%0 : $A):
+// CHECK-NEXT:    [[EAGER_ALLOC:%[0-9]+]] = alloc_stack $A
+// CHECK-NEXT:    store %0 to [trivial] [[EAGER_ALLOC]]
+// CHECK-NEXT:    br bb1
+// CHECK:       bb1:
+// CHECK-NEXT:    cond_br undef, bb2, bb3
+// CHECK:       bb2:
+// CHECK-NEXT:    [[LOCAL_ALLOC:%[0-9]+]] = alloc_stack $A
+// CHECK-NEXT:    copy_addr [[EAGER_ALLOC]] to [init] [[LOCAL_ALLOC]]
+// CHECK-NEXT:    dealloc_stack [[LOCAL_ALLOC]]
+// CHECK:       bb3:
+// CHECK:         [[RESULT:%[0-9]+]] = tuple ()
+// CHECK-NEXT:    dealloc_stack [[EAGER_ALLOC]]
+// CHECK-NEXT:    return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'materialize_a_parameter'
+sil [ossa] @materialize_a_parameter : $@convention(thin) (A) -> () {
+bb0(%0 : $A):
+  br bb1
+
+bb1:
+  cond_br undef, bb2, bb3
+
+bb2:
+  %stk = alloc_stack $A
+  store %0 to [trivial] %stk
+  dealloc_stack %stk
+  br bb1
+
+bb3:
+  %result = tuple ()
+  return %result
+}
+
+// CHECK-LABEL: sil [ossa] @materialize_no_dead_end_dealloc : $@convention(thin) () -> () {
+// CHECK:       bb0:
+// CHECK-NEXT:    [[EAGER_ALLOC:%[0-9]+]] = alloc_stack $A
+// CHECK:         function_ref @get_a
+// CHECK-NEXT:    [[A_VALUE:%[0-9]+]] = apply
+// CHECK-NEXT:    store [[A_VALUE]] to [trivial] [[EAGER_ALLOC]]
+// CHECK-NEXT:    br bb1
+// CHECK:       bb1:
+// CHECK-NEXT:    cond_br undef, bb2, bb3
+// CHECK:       bb2:
+// CHECK-NEXT:    [[LOCAL_ALLOC:%[0-9]+]] = alloc_stack $A
+// CHECK-NEXT:    copy_addr [[EAGER_ALLOC]] to [init] [[LOCAL_ALLOC]]
+// CHECK-NEXT:    dealloc_stack [[LOCAL_ALLOC]]
+// CHECK:       bb3:
+// CHECK-NEXT:    cond_br undef, bb4, bb5
+// CHECK:       bb4:
+// CHECK-NEXT:    [[RESULT:%[0-9]+]] = tuple ()
+// CHECK-NEXT:    dealloc_stack [[EAGER_ALLOC]]
+// CHECK-NEXT:    return [[RESULT]]
+// CHECK:       bb5:
+// CHECK-NEXT:    unreachable
+// CHECK-LABEL: } // end sil function 'materialize_no_dead_end_dealloc'
+sil [ossa] @materialize_no_dead_end_dealloc : $@convention(thin) () -> () {
+bb0:
+  %get_a = function_ref @get_a : $@convention(thin) () -> A
+  %a = apply %get_a() : $@convention(thin) () -> A
+  br bb1
+
+bb1:
+  cond_br undef, bb2, bb3
+
+bb2:
+  %stk = alloc_stack $A
+  store %a to [trivial] %stk
+  dealloc_stack %stk
+  br bb1
+
+bb3:
+  cond_br undef, bb4, bb5
+
+bb4:
+  %result = tuple ()
+  return %result
+
+bb5:
+  unreachable
+}
+
+// CHECK-LABEL: sil [ossa] @materialize_nested_loop : $@convention(thin) (A) -> () {
+// CHECK:       bb0(%0 : $A):
+// CHECK-NEXT:    [[EAGER_ALLOC:%[0-9]+]] = alloc_stack $A
+// CHECK-NEXT:    store %0 to [trivial] [[EAGER_ALLOC]]
+// CHECK-NEXT:    br bb1
+// CHECK:       bb4:
+// CHECK-NEXT:    [[LOCAL_ALLOC:%[0-9]+]] = alloc_stack $A
+// CHECK-NEXT:    copy_addr [[EAGER_ALLOC]] to [init] [[LOCAL_ALLOC]]
+// CHECK-NEXT:    dealloc_stack [[LOCAL_ALLOC]]
+// CHECK:       bb6:
+// CHECK:         [[RESULT:%[0-9]+]] = tuple ()
+// CHECK-NEXT:    dealloc_stack [[EAGER_ALLOC]]
+// CHECK-NEXT:    return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'materialize_nested_loop'
+sil [ossa] @materialize_nested_loop : $@convention(thin) (A) -> () {
+bb0(%0 : $A):
+  br bb1
+
+bb1:
+  cond_br undef, bb2, bb6
+
+bb2:
+  br bb3
+
+bb3:
+  cond_br undef, bb4, bb5
+
+bb4:
+  %stk = alloc_stack $A
+  store %0 to [trivial] %stk
+  dealloc_stack %stk
+  br bb3
+
+bb5:
+  br bb1
+
+bb6:
+  %result = tuple ()
+  return %result
+}
+
+// CHECK-LABEL: sil [ossa] @materialize_nested_loop_local : $@convention(thin) () -> () {
+// CHECK:       bb0:
+// CHECK-NEXT:    [[EAGER_ALLOC:%[0-9]+]] = alloc_stack $A
+// CHECK-NEXT:    br bb1
+// CHECK:       bb2:
+// CHECK:         [[GET_A:%[0-9]+]] = function_ref @get_a
+// CHECK-NEXT:    [[A_VALUE:%[0-9]+]] = apply [[GET_A]]
+// CHECK:       bb4:
+// CHECK-NEXT:    [[LOCAL_ALLOC:%[0-9]+]] = alloc_stack $A
+// CHECK-NEXT:    copy_addr [[EAGER_ALLOC]] to [init] [[LOCAL_ALLOC]]
+// CHECK-NEXT:    dealloc_stack [[LOCAL_ALLOC]]
+// CHECK:       bb6:
+// CHECK:         [[RESULT:%[0-9]+]] = tuple ()
+// CHECK-NEXT:    dealloc_stack [[EAGER_ALLOC]]
+// CHECK-NEXT:    return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'materialize_nested_loop_local'
+sil [ossa] @materialize_nested_loop_local : $@convention(thin) () -> () {
+bb0:
+  br bb1
+
+bb1:
+  cond_br undef, bb2, bb6
+
+bb2:
+  %get_a = function_ref @get_a : $@convention(thin) () -> A
+  %a = apply %get_a() : $@convention(thin) () -> A
+  br bb3
+
+bb3:
+  cond_br undef, bb4, bb5
+
+bb4:
+  %stk = alloc_stack $A
+  store %a to [trivial] %stk
+  dealloc_stack %stk
+  br bb3
+
+bb5:
+  br bb1
+
+bb6:
+  %result = tuple ()
+  return %result
+}
+
+// When the same value is stored in multiple loops, reuse it
+// CHECK-LABEL: sil [ossa] @materialize_reuse : $@convention(thin) (A) -> () {
+// CHECK:       bb0(%0 : $A):
+// CHECK-NEXT:    [[EAGER_ALLOC:%[0-9]+]] = alloc_stack $A
+// CHECK-NEXT:    store %0 to [trivial] [[EAGER_ALLOC]]
+// CHECK-NEXT:    br bb1
+// CHECK:       bb2:
+// CHECK-NEXT:    [[LOCAL_ALLOC:%[0-9]+]] = alloc_stack $A
+// CHECK-NEXT:    copy_addr [[EAGER_ALLOC]] to [init] [[LOCAL_ALLOC]]
+// CHECK-NEXT:    dealloc_stack [[LOCAL_ALLOC]]
+// CHECK:       bb5:
+// CHECK-NEXT:    [[LOCAL_ALLOC4:%[0-9]+]] = alloc_stack $A
+// CHECK-NEXT:    copy_addr [[EAGER_ALLOC]] to [init] [[LOCAL_ALLOC4]]
+// CHECK-NEXT:    dealloc_stack [[LOCAL_ALLOC4]]
+// CHECK:       bb6:
+// CHECK:         [[RESULT:%[0-9]+]] = tuple ()
+// CHECK-NEXT:    dealloc_stack [[EAGER_ALLOC]]
+// CHECK-NEXT:    return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'materialize_reuse'
+sil [ossa] @materialize_reuse : $@convention(thin) (A) -> () {
+bb0(%0 : $A):
+  br bb1
+
+bb1:
+  cond_br undef, bb2, bb3
+
+bb2:
+  %stk = alloc_stack $A
+  store %0 to [trivial] %stk
+  dealloc_stack %stk
+  br bb1
+
+bb3:
+  br bb4
+
+bb4:
+  cond_br undef, bb5, bb6
+
+bb5:
+  %stk4 = alloc_stack $A
+  store %0 to [trivial] %stk4
+  dealloc_stack %stk4
+  br bb4
+
+bb6:
+  %result = tuple ()
+  return %result
+}
+
+// CHECK-LABEL: sil [ossa] @materialize_multi : $@convention(thin) () -> () {
+// CHECK:       bb0:
+// CHECK-NEXT:    [[EAGER_ALLOC:%[0-9]+]] = alloc_stack $A
+// CHECK-NEXT:    [[EAGER_ALLOC2:%[0-9]+]] = alloc_stack $A
+// CHECK:         function_ref @get_a
+// CHECK-NEXT:    [[A_VALUE:%[0-9]+]] = apply
+// CHECK-NEXT:    store [[A_VALUE]] to [trivial] [[EAGER_ALLOC]]
+// CHECK-NEXT:    [[A_VALUE2:%[0-9]+]] = apply
+// CHECK-NEXT:    store [[A_VALUE2]] to [trivial] [[EAGER_ALLOC2]]
+// CHECK-NEXT:    br bb1
+// CHECK:       bb1:
+// CHECK-NEXT:    cond_br undef, bb2, bb3
+// CHECK:       bb2:
+// CHECK-NEXT:    [[LOCAL_ALLOC:%[0-9]+]] = alloc_stack $A
+// CHECK-NEXT:    copy_addr [[EAGER_ALLOC]] to [init] [[LOCAL_ALLOC]]
+// CHECK-NEXT:    dealloc_stack [[LOCAL_ALLOC]]
+// CHECK-NEXT:    [[LOCAL_ALLOC2:%[0-9]+]] = alloc_stack $A
+// CHECK-NEXT:    copy_addr [[EAGER_ALLOC2]] to [init] [[LOCAL_ALLOC2]]
+// CHECK-NEXT:    dealloc_stack [[LOCAL_ALLOC2]]
+// CHECK:       bb3:
+// CHECK:         [[RESULT:%[0-9]+]] = tuple ()
+// CHECK-NEXT:    dealloc_stack [[EAGER_ALLOC2]]
+// CHECK-NEXT:    dealloc_stack [[EAGER_ALLOC]]
+// CHECK-NEXT:    return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'materialize_multi'
+sil [ossa] @materialize_multi : $@convention(thin) () -> () {
+bb0:
+  %get_a = function_ref @get_a : $@convention(thin) () -> A
+  %a1 = apply %get_a() : $@convention(thin) () -> A
+  %a2 = apply %get_a() : $@convention(thin) () -> A
+  br bb1
+
+bb1:
+  cond_br undef, bb2, bb3
+
+bb2:
+  %stk = alloc_stack $A
+  store %a1 to [trivial] %stk
+  dealloc_stack %stk
+  %stk2 = alloc_stack $A
+  store %a2 to [trivial] %stk2
+  dealloc_stack %stk2
+  br bb1
+
+bb3:
+  %result = tuple ()
+  return %result
+}
+
+// Don't materialize eagerly if the value is not used in a loop.
+//
+// CHECK-LABEL: sil [ossa] @no_materialize_no_loop : $@convention(thin) () -> () {
+// CHECK:       bb0:
+// CHECK-NOT:     alloc_stack InlineArray<512, Int>
+// CHECK:       bb1:
+// CHECK-NEXT:    [[ALLOC:%[0-9]+]] = alloc_stack $A
+// CHECK-NEXT:    store {{.*}} to [trivial] [[ALLOC]]
+// CHECK:       bb2:
+// CHECK-NOT:     dealloc_stack
+// CHECK-LABEL: } // end sil function 'no_materialize_no_loop'
+sil [ossa] @no_materialize_no_loop : $@convention(thin) () -> () {
+bb0:
+  %get_a = function_ref @get_a : $@convention(thin) () -> A
+  %a = apply %get_a() : $@convention(thin) () -> A
+  br bb1
+
+bb1:
+  %stk = alloc_stack $A
+  store %a to [trivial] %stk
+  dealloc_stack %stk
+  br bb2
+
+bb2:
+  %result = tuple ()
+  return %result
+}
+
+// Don't materialize eagerly if the value becomes available in the same loop:
+// this would not enable other passes to eliminate the allocation & store inside
+// the loop.
+//
+// CHECK-LABEL: sil [ossa] @no_materialize_same_loop : $@convention(thin) () -> () {
+// CHECK:       bb0:
+// CHECK-NOT:     alloc_stack InlineArray<512, Int>
+// CHECK:       bb1:
+// CHECK-NEXT:    cond_br undef, bb2, bb3
+// CHECK:       bb2:
+// CHECK-NEXT:    alloc_stack $A
+// CHECK:       bb3:
+// CHECK-NOT:     dealloc_stack
+// CHECK-LABEL: } // end sil function 'no_materialize_same_loop'
+sil [ossa] @no_materialize_same_loop : $@convention(thin) () -> () {
+bb0:
+  br bb1
+
+bb1:
+  cond_br undef, bb2, bb3
+
+bb2:
+  %stk = alloc_stack $A
+  %get_a = function_ref @get_a : $@convention(thin) () -> A
+  %a = apply %get_a() : $@convention(thin) () -> A
+  store %a to [trivial] %stk
+  dealloc_stack %stk
+  br bb1
+
+bb3:
+  %result = tuple ()
+  return %result
+}
+
+// Don't materialize eagerly if the destination address of the store is not an
+// alloc_stack: this would not enable other passes to eliminate the store inside
+// the loop.
+//
+// CHECK-LABEL: sil [ossa] @no_materialize_non_stack_dest : $@convention(thin) () -> () {
+// CHECK-NOT:     alloc_stack $A
+// CHECK-LABEL: } // end sil function 'no_materialize_non_stack_dest'
+sil [ossa] @no_materialize_non_stack_dest : $@convention(thin) () -> () {
+bb0:
+  br bb1
+
+bb1:
+  cond_br undef, bb2, bb3
+
+bb2:
+  %get_a = function_ref @get_a : $@convention(thin) () -> A
+  %a = apply %get_a() : $@convention(thin) () -> A
+  %get_a_ptr = function_ref @get_a_ptr : $@convention(thin) () -> UnsafePointer<A>
+  %a_ptr = apply %get_a_ptr() : $@convention(thin) () -> UnsafePointer<A>
+  %rawval = struct_extract %a_ptr, #UnsafePointer._rawValue
+  %addr = pointer_to_address %rawval to [strict] $*A
+  store %a to [trivial] %addr
+  br bb1
+
+bb3:
+  %result = tuple ()
+  return %result
+}
+
+// Don't materialize eagerly if the destination alloc_stack is outside the loop:
+// this would not enable other passes to eliminate the store inside the loop.
+//
+// CHECK-LABEL: sil [ossa] @no_materialize_alloc_outside_loop : $@convention(thin) () -> () {
+// CHECK:       bb2:
+// CHECK-NEXT:    store
+// CHECK-LABEL: } // end sil function 'no_materialize_alloc_outside_loop'
+sil [ossa] @no_materialize_alloc_outside_loop : $@convention(thin) () -> () {
+bb0:
+  %stk = alloc_stack $A
+  %get_a = function_ref @get_a : $@convention(thin) () -> A
+  %a = apply %get_a() : $@convention(thin) () -> A
+  br bb1
+
+bb1:
+  cond_br undef, bb2, bb3
+
+bb2:
+  store %a to [trivial] %stk
+  br bb1
+
+bb3:
+  %result = tuple ()
+  dealloc_stack %stk
+  return %result
+}
+
+// Type B is non-trivial, so it cannot be hoisted
+// CHECK-LABEL: sil [ossa] @no_materialize_nontrivial : $@convention(thin) (@guaranteed B) -> () {
+// CHECK:       bb0(%0 : @guaranteed $B):
+// CHECK-NOT:     alloc_stack $B
+// CHECK-NEXT:    br bb1
+// CHECK:       bb1:
+// CHECK-NEXT:    cond_br undef, bb2, bb3
+// CHECK:       bb2:
+// CHECK-NEXT:    [[LOCAL_ALLOC:%[0-9]+]] = alloc_stack $B
+// CHECK-NEXT:    [[BORROW:%[0-9]+]] = store_borrow %0 to [[LOCAL_ALLOC]]
+// CHECK-NEXT:    end_borrow [[BORROW]]
+// CHECK-NEXT:    dealloc_stack [[LOCAL_ALLOC]]
+// CHECK:       bb3:
+// CHECK-NOT:     dealloc_stack
+// CHECK-LABEL: } // end sil function 'no_materialize_nontrivial'
+sil [ossa] @no_materialize_nontrivial : $@convention(thin) (@guaranteed B) -> () {
+bb0(%0 : @guaranteed $B):
+  br bb1
+
+bb1:
+  cond_br undef, bb2, bb3
+
+bb2:
+  %stk = alloc_stack $B
+  %borrow = store_borrow %0 to %stk
+  end_borrow %borrow
+  dealloc_stack %stk
+  br bb1
+
+bb3:
+  %result = tuple ()
+  return %result
+}

--- a/test/SILOptimizer/inline_arrays.swift
+++ b/test/SILOptimizer/inline_arrays.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend  -primary-file %s -O -disable-availability-checking -module-name=test -emit-sil | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-OPT
 
 // REQUIRES: swift_stdlib_no_asserts, optimized_stdlib
+// REQUIRES: PTRSIZE=64
 
 // CHECK-LABEL: sil @$s4test0A9Subscriptys5UInt8Vs11InlineArrayVy$255_ADGz_SitF :
 // CHECK-OPT:      [[S:%.*]] = struct_element_addr %0, #InlineArray._storage
@@ -64,3 +65,79 @@ public struct S {
   }
 }
 
+// rdar://172132077 (Iterating over InlineArray copies the full array per iteration)
+
+// CHECK-LABEL: sil @$s4test0A3Sum1aSis11InlineArrayVy$511_SiG_tF : $@convention(thin) (InlineArray<512, Int>) -> Int {
+// CHECK:       bb0(%0 : $InlineArray<512, Int>):
+// CHECK:         [[ALLOC:%[0-9]+]] = alloc_stack $InlineArray<512, Int>
+// CHECK:         store %0 to [[ALLOC]]
+// CHECK:         [[VECTOR:%[0-9]+]] = struct_element_addr [[ALLOC]], #InlineArray._storage
+// CHECK:         [[VECTOR_BASE:%[0-9]+]] = vector_base_addr [[VECTOR]]
+// CHECK:       bb1([[SUM:%[0-9]+]] : $Builtin.Int64, [[INDEX:%[0-9]+]] : $Builtin.Int64):
+// CHECK-NOT:     alloc_stack $InlineArray<512, Int>
+// CHECK:         [[INDEX_ADDR:%[0-9]+]] = index_addr [stack_protection] [projection] [[VECTOR_BASE]]
+// CHECK:         [[VALUE_ADDR:%[0-9]+]] = struct_element_addr [[INDEX_ADDR]], #Int._value
+// CHECK:         load [[VALUE_ADDR]]
+// CHECK:       bb2:
+// CHECK-NEXT:    br bb1
+// CHECK:       bb3:
+// CHECK-NEXT:    dealloc_stack [[ALLOC]]
+// CHECK-NEXT:    return
+// CHECK:       } // end sil function '$s4test0A3Sum1aSis11InlineArrayVy$511_SiG_tF'
+public func testSum(a: InlineArray<512, Int>) -> Int {
+  var sum = 0
+  for i in a.indices {
+    sum += a[i]
+  }
+  return sum
+}
+
+// CHECK-LABEL: sil @$s4test0A9BorrowSum1aSis11InlineArrayVy$511_SiG_tF : $@convention(thin) (InlineArray<512, Int>) -> Int {
+// CHECK:       bb0(%0 : @noImplicitCopy $InlineArray<512, Int>):
+// CHECK:         [[ALLOC:%[0-9]+]] = alloc_stack $InlineArray<512, Int>
+// CHECK:         store %0 to [[ALLOC]]
+// CHECK:         [[VECTOR:%[0-9]+]] = struct_element_addr [[ALLOC]], #InlineArray._storage
+// CHECK:         [[VECTOR_BASE:%[0-9]+]] = vector_base_addr [[VECTOR]]
+// CHECK:       bb1([[SUM:%[0-9]+]] : $Builtin.Int64, [[INDEX:%[0-9]+]] : $Builtin.Int64):
+// CHECK-NOT:     alloc_stack $InlineArray<512, Int>
+// CHECK:         [[INDEX_ADDR:%[0-9]+]] = index_addr [stack_protection] [projection] [[VECTOR_BASE]]
+// CHECK:         [[VALUE_ADDR:%[0-9]+]] = struct_element_addr [[INDEX_ADDR]], #Int._value
+// CHECK:         load [[VALUE_ADDR]]
+// CHECK:       bb2:
+// CHECK-NEXT:    br bb1
+// CHECK:       bb3:
+// CHECK-NEXT:    dealloc_stack [[ALLOC]]
+// CHECK-NEXT:    return
+// CHECK:       } // end sil function '$s4test0A9BorrowSum1aSis11InlineArrayVy$511_SiG_tF'
+public func testBorrowSum(a: borrowing InlineArray<512, Int>) -> Int {
+  var sum = 0
+  for i in a.indices {
+    sum += a[i]
+  }
+  return sum
+}
+
+// CHECK-LABEL: sil @$s4test0A11BorrowEqualySbs11InlineArrayVy$31_SiG_AEtF : $@convention(thin) (InlineArray<32, Int>, InlineArray<32, Int>) -> Bool {
+// CHECK:       bb0(%0 : @noImplicitCopy $InlineArray<32, Int>, %1 : @noImplicitCopy $InlineArray<32, Int>):
+// CHECK-NEXT:    [[LHS_ALLOC:%[0-9]+]] = alloc_stack $InlineArray<32, Int>
+// CHECK-NEXT:    store %0 to [[LHS_ALLOC]]
+// CHECK-NEXT:    [[RHS_ALLOC:%[0-9]+]] = alloc_stack $InlineArray<32, Int>
+// CHECK-NEXT:    store %1 to [[RHS_ALLOC]]
+// CHECK:       bb1({{.*}}):
+// CHECK-NOT:     = alloc_stack
+// CHECK:       bb2:
+// CHECK-NOT:     = alloc_stack
+// CHECK-NOT:     store %0
+// CHECK-NOT:     store %1
+// CHECK:       bb6({{.*}}):
+// CHECK:         dealloc_stack [[RHS_ALLOC]]
+// CHECK:         dealloc_stack [[LHS_ALLOC]]
+// CHECK:       } // end sil function '$s4test0A11BorrowEqualySbs11InlineArrayVy$31_SiG_AEtF'
+public func testBorrowEqual(_ lhs: borrowing [32 of Int], _ rhs: borrowing [32 of Int]) -> Bool {
+    for i in 0..<32 {
+        guard lhs[i] == rhs[i] else {
+            return false
+        }
+    }
+    return true
+}


### PR DESCRIPTION
Eagerly materialize values that are stored to stack allocations inside loops, by storing them to stack allocations outside the loop.

If a value is stored to a local `alloc_stack` within an inner loop, but the value itself is available before the loop, store the value to a stack allocation at the point that it becomes available. Replace the store with a `copy_addr` from this "eager" temporary allocation. This transformation enables optimisations like TempRValueElimination to eliminate repeated stores to the stack within loops.

Fixes rdar://172132077: the temporary stack allocations are hoisted out of the loop in both the included examples.
There is still one temporary allocation and store per InlineArray, but eliminating this is outside the scope of this pass.
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
