### PR TITLE
[Testing] Split off friendly tests.

### DIFF
--- a/test/Backtracing/Crash.test
+++ b/test/Backtracing/Crash.test
@@ -5,13 +5,9 @@
 // RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/Crash.exe > %t/Crash.out 2>&1
 // RUN: %FileCheck %s --ignore-case < %t/Crash.out
 
-// RUN: ! env %env-SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/Crash.exe > %t/Friendly.out 2>&1
-// RUN: %FileCheck %s --ignore-case --check-prefix FRIENDLY < %t/Friendly.out
-
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 // UNSUPPORTED: asan
-// UNSUPPORTED: remote_run
 // REQUIRES: executable_test
 // REQUIRES: backtracing
 // REQUIRES: OS=macosx || OS=linux-gnu || OS=windows-msvc
@@ -35,59 +31,3 @@
 // CHECK: Images ({{[0-9]+}} omitted):
 
 // CHECK: {{0x[0-9a-f]+}}–{{0x[0-9a-f]+}}{{ +}}{{([0-9a-f]+|<no build ID>)}}{{ +}}Crash.exe{{ +}}{{.*[\\/]}}Crash.exe
-
-// FRIENDLY: *** Program crashed: {{(Bad pointer dereference|Access violation)}} at 0x{{0+}}4 ***
-
-// FRIENDLY: Thread 0 {{(".*" )?}}crashed:
-
-// FRIENDLY: 0 level5() + {{[0-9]+}} in Crash.exe at {{.*[\\/]}}Crash.swift:20:15
-
-// FRIENDLY: 18|   print("About to crash")
-// FRIENDLY-NEXT: 19|   let ptr = UnsafeMutablePointer<Int>(bitPattern: 4)!
-// FRIENDLY-NEXT: 20|   ptr.pointee = 42
-// FRIENDLY-NEXT:   |               ^
-// FRIENDLY-NEXT: 21| }
-// FRIENDLY-NEXT: 22|
-
-// FRIENDLY: 1 level4() + {{[0-9]+}} in Crash.exe at {{.*[\\/]}}Crash.swift:14:3
-
-// FRIENDLY: 12|
-// FRIENDLY-NEXT: 13| func level4() {
-// FRIENDLY-NEXT: 14|   level5()
-// FRIENDLY-NEXT:   |   ^
-// FRIENDLY-NEXT: 15| }
-// FRIENDLY-NEXT: 16|
-
-// FRIENDLY: 2 level3() + {{[0-9]+}} in Crash.exe at {{.*[\\/]}}Crash.swift:10:3
-
-// FRIENDLY: 8|
-// FRIENDLY-NEXT: 9| func level3() {
-// FRIENDLY-NEXT: 10|   level4()
-// FRIENDLY-NEXT:   |   ^
-// FRIENDLY-NEXT: 11| }
-// FRIENDLY-NEXT: 12|
-
-// FRIENDLY: 3 level2() + {{[0-9]+}} in Crash.exe at {{.*[\\/]}}Crash.swift:6:3
-
-// FRIENDLY: 4|
-// FRIENDLY-NEXT: 5| func level2() {
-// FRIENDLY-NEXT: 6|   level3()
-// FRIENDLY-NEXT:   |   ^
-// FRIENDLY-NEXT: 7| }
-// FRIENDLY-NEXT: 8|
-
-// FRIENDLY: 4 level1() + {{[0-9]+}} in Crash.exe at {{.*[\\/]}}Crash.swift:2:3
-
-// FRIENDLY:      1| func level1() {
-// FRIENDLY-NEXT: 2|   level2()
-// FRIENDLY-NEXT:   |   ^
-// FRIENDLY-NEXT: 3| }
-
-// FRIENDLY: 5 static Crash.main() + {{[0-9]+}} in Crash.exe at {{.*[\\/]}}Crash.swift:26:5
-
-// FRIENDLY: 24| struct Crash {
-// FRIENDLY-NEXT: 25|   static func main() {
-// FRIENDLY-NEXT: 26|     level1()
-// FRIENDLY-NEXT:   |     ^
-// FRIENDLY-NEXT: 27|   }
-// FRIENDLY-NEXT: 28| }

--- a/test/Backtracing/CrashAsync.test
+++ b/test/Backtracing/CrashAsync.test
@@ -6,12 +6,10 @@
 // function names.  We test demangling elsewhere, so this is no big deal.
 
 // RUN: not --crash env %env-SWIFT_BACKTRACE=enable=yes,demangle=no,cache=no %target-run %t/CrashAsync 2>&1 | %FileCheck %s
-// RUN: not --crash env %env-SWIFT_BACKTRACE=preset=friendly,enable=yes,demangle=no,cache=no %target-run %t/CrashAsync 2>&1 | %FileCheck %s --check-prefix FRIENDLY
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 // UNSUPPORTED: asan
-// UNSUPPORTED: remote_run
 // REQUIRES: executable_test
 // REQUIRES: backtracing
 // REQUIRES: OS=macosx || OS=linux-gnu
@@ -32,46 +30,3 @@
 // CHECK-NEXT:  9 [async] [thunk]  0x{{[0-9a-f]+}} {{_?}}$sIetH_yts5Error_pIegHrzo_TR{{TQ0_| \+ [0-9]+}} in CrashAsync at {{.*}}/<compiler-generated>
 // CHECK-NEXT: 10 [async] [thunk]  0x{{[0-9a-f]+}} {{_?}}$sIetH_yts5Error_pIegHrzo_TRTA{{TQ0_| \+ [0-9]+}} in CrashAsync at {{.*}}/<compiler-generated>
 // CHECK-NEXT: 11 [async] [system] 0x{{[0-9a-f]+}} {{_?}}_ZL23completeTaskWithClosurePN5swift12AsyncContextEPNS_10SwiftErrorE in libswift_Concurrency.{{dylib|so}}
-
-// FRIENDLY: *** Program crashed: Bad pointer dereference at 0x{{0+}}4 ***
-
-// FRIENDLY: Thread {{[0-9]+( ".*")?}} crashed:
-
-// FRIENDLY: 0 {{_?}}$s10CrashAsync5crashyyF + {{[0-9]+}} in CrashAsync at {{.*}}CrashAsync.swift:4:15
-
-// FRIENDLY:     2| func crash() {
-// FRIENDLY-NEXT:     3|   let ptr = UnsafeMutablePointer<Int>(bitPattern: 4)!
-// FRIENDLY-NEXT:  *  4|   ptr.pointee = 42
-// FRIENDLY-NEXT:       |               ^
-// FRIENDLY-NEXT:     5| }
-// FRIENDLY-NEXT:     6|
-
-// FRIENDLY: 1 {{_?}}$s10CrashAsync5levelyySiYaFTY0_ + {{[0-9]+}} in CrashAsync at {{.*}}CrashAsync.swift:12:5
-
-// FRIENDLY:     10|     await level(n + 1)
-// FRIENDLY-NEXT:     11|   } else {
-// FRIENDLY-NEXT:  *  12|     crash()
-// FRIENDLY-NEXT:       |     ^
-// FRIENDLY-NEXT:     13|   }
-// FRIENDLY-NEXT:     14| }
-
-// FRIENDLY:2 {{_?}}$s10CrashAsync5levelyySiYaFTQ1_ in CrashAsync at {{.*}}CrashAsync.swift:10
-
-// FRIENDLY:     8| func level(_ n: Int) async {
-// FRIENDLY-NEXT:     9|   if n < 5 {
-// FRIENDLY-NEXT:  *  10|     await level(n + 1)
-// FRIENDLY-NEXT:       |     ^
-// FRIENDLY-NEXT:     11|   } else {
-// FRIENDLY-NEXT:     12|     crash()
-
-// FRIENDLY: 3 {{_?}}$s10CrashAsync5levelyySiYaFTQ1_ in CrashAsync at {{.*}}CrashAsync.swift:10
-// FRIENDLY: 4 {{_?}}$s10CrashAsync5levelyySiYaFTQ1_ in CrashAsync at {{.*}}CrashAsync.swift:10
-// FRIENDLY: 5 {{_?}}$s10CrashAsync5levelyySiYaFTQ1_ in CrashAsync at {{.*}}CrashAsync.swift:10
-// FRIENDLY: 6 {{_?}}$s10CrashAsyncAAV4mainyyYaFZ{{TQ0_| \+ [0-9]+}} in CrashAsync at {{.*}}CrashAsync.swift:20
-
-// FRIENDLY:     18| struct CrashAsync {
-// FRIENDLY-NEXT:     19|   static func main() async {
-// FRIENDLY-NEXT:  *  20|     await level(1)
-// FRIENDLY-NEXT:       |     ^
-// FRIENDLY-NEXT:     21|   }
-// FRIENDLY-NEXT:     22| }

--- a/test/Backtracing/CrashWithThunk.test
+++ b/test/Backtracing/CrashWithThunk.test
@@ -3,13 +3,10 @@
 // RUN: %target-codesign %t/CrashWithThunk.exe
 // RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashWithThunk.exe %t/CrashWithThunk.exe.dSYM > %t/CrashWithThunk.out 2>&1
 // RUN: %FileCheck --ignore-case %s < %t/CrashWithThunk.out
-// RUN: ! env %env-SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/CrashWithThunk.exe %t/CrashWithThunk.exe.dSYM > %t/Friendly.out 2>&1
-// RUN %FileCheck %s --ignore-case --check-prefix FRIENDLY < %t/Friendly.out
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 // UNSUPPORTED: asan
-// UNSUPPORTED: remote_run
 // REQUIRES: executable_test
 // REQUIRES: backtracing
 // REQUIRES: OS=macosx || OS=linux-gnu || OS=windows-msvc
@@ -29,25 +26,3 @@
 // CHECK: Images ({{[0-9]+}} omitted):
 
 // CHECK: {{0x[0-9a-f]+}}–{{0x[0-9a-f]+}}{{ +}}{{[0-9a-f]+|<no build ID>}}{{ +}}CrashWithThunk.exe{{ +}}{{.*[\\/]}}CrashWithThunk.exe
-
-// FRIENDLY: *** Program crashed: {{(Bad pointer dereference|Access violation)}} at 0x{{0+}}4 ***
-
-// FRIENDLY: Thread 0 {{(".*" )?}}crashed:
-
-// FRIENDLY: 0 crash() + {{[0-9]+}} in CrashWithThunk.exe at {{.*[\\/]}}CrashWithThunk.swift:8:15
-
-// FRIENDLY:  6|   print("I'm going to crash here")
-// FRIENDLY-NEXT:  7|   let ptr = UnsafeMutablePointer<Int>(bitPattern: 4)!
-// FRIENDLY-NEXT:  8|   ptr.pointee = 42
-// FRIENDLY-NEXT:   |               ^
-// FRIENDLY-NEXT:  9| }
-// FRIENDLY-NEXT: 10|
-
-// FRIENDLY: 1 static CrashWithThunk.main() + {{[0-9]+}} in CrashWithThunk.exe at {{.*[\\/]}}CrashWithThunk.swift:16:9
-
-// FRIENDLY: 14|     let foo = Foo(value: crash)
-// FRIENDLY-NEXT: 15|
-// FRIENDLY-NEXT: 16|     foo.value()
-// FRIENDLY-NEXT:   |         ^
-// FRIENDLY-NEXT: 17|   }
-// FRIENDLY-NEXT: 18| }

--- a/test/Backtracing/Overflow.test
+++ b/test/Backtracing/Overflow.test
@@ -3,12 +3,9 @@
 // RUN: %target-codesign %t/Overflow.exe
 // RUN: ! env %env-SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/Overflow.exe %t/Overflow.exe.dSYM > %t/Overflow.out 2>&1
 // RUN: %FileCheck %s --ignore-case < %t/Overflow.out
-// RUN: ! env %env-SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/Overflow.exe %t/Overflow.exe.dSYM > %t/Friendly.out 2>&1
-// RUN: %FileCheck %s --ignore-case --check-prefix FRIENDLY < %t/Friendly.out
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
-// UNSUPPORTED: remote_run
 // REQUIRES: executable_test
 // REQUIRES: backtracing
 // REQUIRES: OS=macosx || OS=linux-gnu || OS=windows-msvc
@@ -32,54 +29,4 @@
 // CHECK: Images ({{[0-9]+}} omitted):
 
 // CHECK: {{0x[0-9a-f]+}}–{{0x[0-9a-f]+}}{{ +}}{{[0-9a-f]+|<no build ID>}}{{ +}}Overflow.exe{{ +}}{{.*[\\/]}}Overflow.exe
-
-// FRIENDLY: *** Swift runtime failure: arithmetic overflow ***
-
-// FRIENDLY: Thread 0 {{(".*" )?}}crashed:
-
-// FRIENDLY: 0 level5() + {{[0-9]+}} in Overflow.exe at {{.*[\\/]}}Overflow.swift:22:5
-
-// FRIENDLY: 20|   print("About to overflow")
-// FRIENDLY-NEXT: 21|
-// FRIENDLY-NEXT: 22|   x -= 1
-// FRIENDLY-NEXT:   |     ^
-// FRIENDLY-NEXT: 23| }
-
-// FRIENDLY: 1 level4() + {{[0-9]+}} in Overflow.exe at {{.*[\\/]}}Overflow.swift:16:3
-
-// FRIENDLY: 14|
-// FRIENDLY-NEXT: 15| func level4() {
-// FRIENDLY-NEXT: 16|   level5()
-// FRIENDLY-NEXT:   |   ^
-// FRIENDLY-NEXT: 17| }
-// FRIENDLY-NEXT: 18|
-
-// FRIENDLY: 2 level3() + {{[0-9]+}} in Overflow.exe at {{.*[\\/]}}Overflow.swift:12:3
-
-// FRIENDLY: 10|
-// FRIENDLY-NEXT: 11| func level3() {
-// FRIENDLY-NEXT: 12|   level4()
-// FRIENDLY-NEXT:   |   ^
-// FRIENDLY-NEXT: 13| }
-// FRIENDLY-NEXT: 14|
-
-// FRIENDLY: 3 level2() + {{[0-9]+}} in Overflow.exe at {{.*[\\/]}}Overflow.swift:8:3
-
-// FRIENDLY:  6|
-// FRIENDLY-NEXT:  7| func level2() {
-// FRIENDLY-NEXT:  8|   level3()
-// FRIENDLY-NEXT:   |   ^
-// FRIENDLY-NEXT:  9| }
-// FRIENDLY-NEXT: 10|
-
-// FRIENDLY: 4 level1() + {{[0-9]+}} in Overflow.exe at {{.*[\\/]}}Overflow.swift:4:3
-
-// FRIENDLY: 2|
-// FRIENDLY-NEXT: 3| func level1() {
-// FRIENDLY-NEXT: 4|   level2()
-// FRIENDLY-NEXT:  |   ^
-// FRIENDLY-NEXT: 5| }
-// FRIENDLY-NEXT: 6|
-
-// FRIENDLY: 5 static Overflow.main() + {{[0-9]+}} in Overflow.exe at {{.*[\\/]}}Overflow.swift
 

--- a/test/Backtracing/StackOverflow.test
+++ b/test/Backtracing/StackOverflow.test
@@ -5,13 +5,10 @@
 // RUN: %FileCheck %s < %t/StackOverflow.out
 // RUN: ! env %env-SWIFT_BACKTRACE=limit=18,top=6,enable=yes,cache=no %target-run %t/stack-overflow.exe %t/stack-overflow.exe.dSYM > %t/Limited.out 2>&1
 // RUN: %FileCheck %s --check-prefix LIMITED < %t/Limited.out
-// RUN: ! env %env-SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/stack-overflow.exe %t/stack-overflow.exe.dSYM > %t/Friendly.out 2>&1
-// RUN: %FileCheck %s --check-prefix FRIENDLY < %t/Friendly.out
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 // UNSUPPORTED: asan
-// UNSUPPORTED: remote_run
 // REQUIRES: executable_test
 // REQUIRES: backtracing
 // REQUIRES: OS=macosx || OS=linux-gnu || OS=windows-msvc
@@ -119,90 +116,3 @@
 // LIMITED: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} static StackOverflow.main() + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:11:5
 // LIMITED-NEXT: {{[0-9]+}} [ra] [system] 0x{{[0-9a-f]+}} static StackOverflow.$main() + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}<compiler-generated>
 // LIMITED-NEXT: {{[0-9]+}} [ra] [system] 0x{{[0-9a-f]+}} main + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift
-
-// FRIENDLY: *** Program crashed: {{(Bad pointer dereference|Stack overflow)}} at 0x{{[0-9a-f]+}} ***
-
-// FRIENDLY: Thread 0 {{(".*" )?}}crashed:
-
-// FRIENDLY: {{[ ]}}0 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift
-
-// SKIP-FRIENDLY:      1│ func recurse(_ level: Int) {
-// SKIP-FRIENDLY-NEXT:       │ ▲
-// SKIP-FRIENDLY-NEXT:     2│   if level % 100000 == 0 {
-
-// FRIENDLY:    1 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-
-// SKIP-FRIENDLY:     2│   if level % 100000 == 0 {
-// SKIP-FRIENDLY-NEXT:     3│     print(level)
-// SKIP-FRIENDLY-NEXT:     4│   }
-// SKIP-FRIENDLY-NEXT:     5│   recurse(level + 1)
-// SKIP-FRIENDLY-NEXT:      │   ▲
-// SKIP-FRIENDLY-NEXT:     6│ }
-
-// FRIENDLY:     2 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:     3 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:     4 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:     5 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:     6 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:     7 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:     8 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:     9 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    10 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    11 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    12 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    13 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    14 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    15 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    16 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    17 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    18 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    19 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    20 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    21 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    22 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    23 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    24 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    25 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    26 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    27 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    28 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    29 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    30 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    31 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    32 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    33 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    34 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    35 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    36 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    37 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    38 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    39 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    40 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    41 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    42 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    43 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    44 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    45 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:    46 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT:   ...
-// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
-
-// N.B. There can be platform differences surrounding the exact frame counts
-
-// FRIENDLY: {{[0-9]+}} static StackOverflow.main() + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:11:5
-
-// FRIENDLY:           9| struct StackOverflow {
-// FRIENDLY-NEXT:     10|   static func main() {
-// FRIENDLY-NEXT:     11|     recurse(1)
-// FRIENDLY-NEXT:       |     ^
-// FRIENDLY-NEXT:     12|   }
-// FRIENDLY-NEXT:     13| }

--- a/test/Backtracing/WithSourceCode/CrashAsyncFriendly.test
+++ b/test/Backtracing/WithSourceCode/CrashAsyncFriendly.test
@@ -1,0 +1,59 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %S/../Inputs/CrashAsync.swift -parse-as-library -Onone -g -o %t/CrashAsync
+// RUN: %target-codesign %t/CrashAsync
+
+// Demangling is disabled for now because older macOS can't demangle async
+// function names.  We test demangling elsewhere, so this is no big deal.
+
+// RUN: not --crash env %env-SWIFT_BACKTRACE=preset=friendly,enable=yes,demangle=no,cache=no %target-run %t/CrashAsync 2>&1 | %FileCheck %s --check-prefix FRIENDLY
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: asan
+// UNSUPPORTED: remote_run
+// REQUIRES: executable_test
+// REQUIRES: backtracing
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+// FRIENDLY: *** Program crashed: Bad pointer dereference at 0x{{0+}}4 ***
+
+// FRIENDLY: Thread {{[0-9]+( ".*")?}} crashed:
+
+// FRIENDLY: 0 {{_?}}$s10CrashAsync5crashyyF + {{[0-9]+}} in CrashAsync at {{.*}}CrashAsync.swift:4:15
+
+// FRIENDLY:     2| func crash() {
+// FRIENDLY-NEXT:     3|   let ptr = UnsafeMutablePointer<Int>(bitPattern: 4)!
+// FRIENDLY-NEXT:  *  4|   ptr.pointee = 42
+// FRIENDLY-NEXT:       |               ^
+// FRIENDLY-NEXT:     5| }
+// FRIENDLY-NEXT:     6|
+
+// FRIENDLY: 1 {{_?}}$s10CrashAsync5levelyySiYaFTY0_ + {{[0-9]+}} in CrashAsync at {{.*}}CrashAsync.swift:12:5
+
+// FRIENDLY:     10|     await level(n + 1)
+// FRIENDLY-NEXT:     11|   } else {
+// FRIENDLY-NEXT:  *  12|     crash()
+// FRIENDLY-NEXT:       |     ^
+// FRIENDLY-NEXT:     13|   }
+// FRIENDLY-NEXT:     14| }
+
+// FRIENDLY:2 {{_?}}$s10CrashAsync5levelyySiYaFTQ1_ in CrashAsync at {{.*}}CrashAsync.swift:10
+
+// FRIENDLY:     8| func level(_ n: Int) async {
+// FRIENDLY-NEXT:     9|   if n < 5 {
+// FRIENDLY-NEXT:  *  10|     await level(n + 1)
+// FRIENDLY-NEXT:       |     ^
+// FRIENDLY-NEXT:     11|   } else {
+// FRIENDLY-NEXT:     12|     crash()
+
+// FRIENDLY: 3 {{_?}}$s10CrashAsync5levelyySiYaFTQ1_ in CrashAsync at {{.*}}CrashAsync.swift:10
+// FRIENDLY: 4 {{_?}}$s10CrashAsync5levelyySiYaFTQ1_ in CrashAsync at {{.*}}CrashAsync.swift:10
+// FRIENDLY: 5 {{_?}}$s10CrashAsync5levelyySiYaFTQ1_ in CrashAsync at {{.*}}CrashAsync.swift:10
+// FRIENDLY: 6 {{_?}}$s10CrashAsyncAAV4mainyyYaFZ{{TQ0_| \+ [0-9]+}} in CrashAsync at {{.*}}CrashAsync.swift:20
+
+// FRIENDLY:     18| struct CrashAsync {
+// FRIENDLY-NEXT:     19|   static func main() async {
+// FRIENDLY-NEXT:  *  20|     await level(1)
+// FRIENDLY-NEXT:       |     ^
+// FRIENDLY-NEXT:     21|   }
+// FRIENDLY-NEXT:     22| }

--- a/test/Backtracing/WithSourceCode/CrashFriendly.test
+++ b/test/Backtracing/WithSourceCode/CrashFriendly.test
@@ -1,0 +1,71 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %S/../Inputs/Crash.swift -parse-as-library -Onone %swift-debug-flags -o %t/Crash.exe
+// RUN: %target-codesign %t/Crash.exe
+
+// RUN: ! env %env-SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/Crash.exe > %t/Friendly.out 2>&1
+// RUN: %FileCheck %s --ignore-case --check-prefix FRIENDLY < %t/Friendly.out
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: asan
+// UNSUPPORTED: remote_run
+// REQUIRES: executable_test
+// REQUIRES: backtracing
+// REQUIRES: OS=macosx || OS=linux-gnu || OS=windows-msvc
+
+
+// FRIENDLY: *** Program crashed: {{(Bad pointer dereference|Access violation)}} at 0x{{0+}}4 ***
+
+// FRIENDLY: Thread 0 {{(".*" )?}}crashed:
+
+// FRIENDLY: 0 level5() + {{[0-9]+}} in Crash.exe at {{.*[\\/]}}Crash.swift:20:15
+
+// FRIENDLY: 18|   print("About to crash")
+// FRIENDLY-NEXT: 19|   let ptr = UnsafeMutablePointer<Int>(bitPattern: 4)!
+// FRIENDLY-NEXT: 20|   ptr.pointee = 42
+// FRIENDLY-NEXT:   |               ^
+// FRIENDLY-NEXT: 21| }
+// FRIENDLY-NEXT: 22|
+
+// FRIENDLY: 1 level4() + {{[0-9]+}} in Crash.exe at {{.*[\\/]}}Crash.swift:14:3
+
+// FRIENDLY: 12|
+// FRIENDLY-NEXT: 13| func level4() {
+// FRIENDLY-NEXT: 14|   level5()
+// FRIENDLY-NEXT:   |   ^
+// FRIENDLY-NEXT: 15| }
+// FRIENDLY-NEXT: 16|
+
+// FRIENDLY: 2 level3() + {{[0-9]+}} in Crash.exe at {{.*[\\/]}}Crash.swift:10:3
+
+// FRIENDLY: 8|
+// FRIENDLY-NEXT: 9| func level3() {
+// FRIENDLY-NEXT: 10|   level4()
+// FRIENDLY-NEXT:   |   ^
+// FRIENDLY-NEXT: 11| }
+// FRIENDLY-NEXT: 12|
+
+// FRIENDLY: 3 level2() + {{[0-9]+}} in Crash.exe at {{.*[\\/]}}Crash.swift:6:3
+
+// FRIENDLY: 4|
+// FRIENDLY-NEXT: 5| func level2() {
+// FRIENDLY-NEXT: 6|   level3()
+// FRIENDLY-NEXT:   |   ^
+// FRIENDLY-NEXT: 7| }
+// FRIENDLY-NEXT: 8|
+
+// FRIENDLY: 4 level1() + {{[0-9]+}} in Crash.exe at {{.*[\\/]}}Crash.swift:2:3
+
+// FRIENDLY:      1| func level1() {
+// FRIENDLY-NEXT: 2|   level2()
+// FRIENDLY-NEXT:   |   ^
+// FRIENDLY-NEXT: 3| }
+
+// FRIENDLY: 5 static Crash.main() + {{[0-9]+}} in Crash.exe at {{.*[\\/]}}Crash.swift:26:5
+
+// FRIENDLY: 24| struct Crash {
+// FRIENDLY-NEXT: 25|   static func main() {
+// FRIENDLY-NEXT: 26|     level1()
+// FRIENDLY-NEXT:   |     ^
+// FRIENDLY-NEXT: 27|   }
+// FRIENDLY-NEXT: 28| }

--- a/test/Backtracing/WithSourceCode/CrashWithThunkFriendly.test
+++ b/test/Backtracing/WithSourceCode/CrashWithThunkFriendly.test
@@ -1,0 +1,35 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %S/../Inputs/CrashWithThunk.swift -parse-as-library -Onone %swift-debug-flags -o %t/CrashWithThunk.exe
+// RUN: %target-codesign %t/CrashWithThunk.exe
+// RUN: ! env %env-SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/CrashWithThunk.exe %t/CrashWithThunk.exe.dSYM > %t/Friendly.out 2>&1
+// RUN: %FileCheck %s --ignore-case --check-prefix FRIENDLY < %t/Friendly.out
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: asan
+// UNSUPPORTED: remote_run
+// REQUIRES: executable_test
+// REQUIRES: backtracing
+// REQUIRES: OS=macosx || OS=linux-gnu || OS=windows-msvc
+
+// FRIENDLY: *** Program crashed: {{(Bad pointer dereference|Access violation)}} at 0x{{0+}}4 ***
+
+// FRIENDLY: Thread 0 {{(".*" )?}}crashed:
+
+// FRIENDLY: 0 crash() + {{[0-9]+}} in CrashWithThunk.exe at {{.*[\\/]}}CrashWithThunk.swift:8:15
+
+// FRIENDLY:  6|   print("I'm going to crash here")
+// FRIENDLY-NEXT:  7|   let ptr = UnsafeMutablePointer<Int>(bitPattern: 4)!
+// FRIENDLY-NEXT:  8|   ptr.pointee = 42
+// FRIENDLY-NEXT:   |               ^
+// FRIENDLY-NEXT:  9| }
+// FRIENDLY-NEXT: 10|
+
+// FRIENDLY: 1 static CrashWithThunk.main() + {{[0-9]+}} in CrashWithThunk.exe at {{.*[\\/]}}CrashWithThunk.swift:16:9
+
+// FRIENDLY: 14|     let foo = Foo(value: crash)
+// FRIENDLY-NEXT: 15|
+// FRIENDLY-NEXT: 16|     foo.value()
+// FRIENDLY-NEXT:   |         ^
+// FRIENDLY-NEXT: 17|   }
+// FRIENDLY-NEXT: 18| }

--- a/test/Backtracing/WithSourceCode/OverflowFriendly.test
+++ b/test/Backtracing/WithSourceCode/OverflowFriendly.test
@@ -1,0 +1,62 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %S/../Inputs/Overflow.swift -parse-as-library -Onone %swift-debug-flags -o %t/Overflow.exe
+// RUN: %target-codesign %t/Overflow.exe
+// RUN: ! env %env-SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/Overflow.exe %t/Overflow.exe.dSYM > %t/Friendly.out 2>&1
+// RUN: %FileCheck %s --ignore-case --check-prefix FRIENDLY < %t/Friendly.out
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: remote_run
+// REQUIRES: executable_test
+// REQUIRES: backtracing
+// REQUIRES: OS=macosx || OS=linux-gnu || OS=windows-msvc
+
+// FRIENDLY: *** Swift runtime failure: arithmetic overflow ***
+
+// FRIENDLY: Thread 0 {{(".*" )?}}crashed:
+
+// FRIENDLY: 0 level5() + {{[0-9]+}} in Overflow.exe at {{.*[\\/]}}Overflow.swift:22:5
+
+// FRIENDLY: 20|   print("About to overflow")
+// FRIENDLY-NEXT: 21|
+// FRIENDLY-NEXT: 22|   x -= 1
+// FRIENDLY-NEXT:   |     ^
+// FRIENDLY-NEXT: 23| }
+
+// FRIENDLY: 1 level4() + {{[0-9]+}} in Overflow.exe at {{.*[\\/]}}Overflow.swift:16:3
+
+// FRIENDLY: 14|
+// FRIENDLY-NEXT: 15| func level4() {
+// FRIENDLY-NEXT: 16|   level5()
+// FRIENDLY-NEXT:   |   ^
+// FRIENDLY-NEXT: 17| }
+// FRIENDLY-NEXT: 18|
+
+// FRIENDLY: 2 level3() + {{[0-9]+}} in Overflow.exe at {{.*[\\/]}}Overflow.swift:12:3
+
+// FRIENDLY: 10|
+// FRIENDLY-NEXT: 11| func level3() {
+// FRIENDLY-NEXT: 12|   level4()
+// FRIENDLY-NEXT:   |   ^
+// FRIENDLY-NEXT: 13| }
+// FRIENDLY-NEXT: 14|
+
+// FRIENDLY: 3 level2() + {{[0-9]+}} in Overflow.exe at {{.*[\\/]}}Overflow.swift:8:3
+
+// FRIENDLY:  6|
+// FRIENDLY-NEXT:  7| func level2() {
+// FRIENDLY-NEXT:  8|   level3()
+// FRIENDLY-NEXT:   |   ^
+// FRIENDLY-NEXT:  9| }
+// FRIENDLY-NEXT: 10|
+
+// FRIENDLY: 4 level1() + {{[0-9]+}} in Overflow.exe at {{.*[\\/]}}Overflow.swift:4:3
+
+// FRIENDLY: 2|
+// FRIENDLY-NEXT: 3| func level1() {
+// FRIENDLY-NEXT: 4|   level2()
+// FRIENDLY-NEXT:  |   ^
+// FRIENDLY-NEXT: 5| }
+// FRIENDLY-NEXT: 6|
+
+// FRIENDLY: 5 static Overflow.main() + {{[0-9]+}} in Overflow.exe at {{.*[\\/]}}Overflow.swift

--- a/test/Backtracing/WithSourceCode/StackOverflowFriendly.test
+++ b/test/Backtracing/WithSourceCode/StackOverflowFriendly.test
@@ -1,0 +1,104 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %S/../Inputs/StackOverflow.swift -parse-as-library -Onone %swift-debug-flags -o %t/stack-overflow.exe
+// RUN: %target-codesign %t/stack-overflow.exe
+// RUN: ! env %env-SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/stack-overflow.exe %t/stack-overflow.exe.dSYM > %t/Friendly.out 2>&1
+// RUN: %FileCheck %s --check-prefix FRIENDLY < %t/Friendly.out
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: asan
+// UNSUPPORTED: remote_run
+// REQUIRES: executable_test
+// REQUIRES: backtracing
+// REQUIRES: OS=macosx || OS=linux-gnu || OS=windows-msvc
+
+// FIXME: We have to allow all the line numbers below to be off-by-one because
+// of a CoreSymbolication bug.  This also means we have to skip checking the
+// source code output because currently, it's pointing at the wrong line :-(
+
+// FRIENDLY: *** Program crashed: {{(Bad pointer dereference|Stack overflow)}} at 0x{{[0-9a-f]+}} ***
+
+// FRIENDLY: Thread 0 {{(".*" )?}}crashed:
+
+// FRIENDLY: {{[ ]}}0 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift
+
+// SKIP-FRIENDLY:      1│ func recurse(_ level: Int) {
+// SKIP-FRIENDLY-NEXT:       │ ▲
+// SKIP-FRIENDLY-NEXT:     2│   if level % 100000 == 0 {
+
+// FRIENDLY:    1 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+
+// SKIP-FRIENDLY:     2│   if level % 100000 == 0 {
+// SKIP-FRIENDLY-NEXT:     3│     print(level)
+// SKIP-FRIENDLY-NEXT:     4│   }
+// SKIP-FRIENDLY-NEXT:     5│   recurse(level + 1)
+// SKIP-FRIENDLY-NEXT:      │   ▲
+// SKIP-FRIENDLY-NEXT:     6│ }
+
+// FRIENDLY:     2 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:     3 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:     4 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:     5 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:     6 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:     7 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:     8 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:     9 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    10 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    11 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    12 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    13 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    14 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    15 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    16 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    17 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    18 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    19 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    20 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    21 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    22 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    23 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    24 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    25 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    26 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    27 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    28 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    29 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    30 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    31 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    32 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    33 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    34 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    35 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    36 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    37 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    38 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    39 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    40 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    41 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    42 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    43 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    44 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    45 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:    46 recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT:   ...
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:5:3
+
+// N.B. There can be platform differences surrounding the exact frame counts
+
+// FRIENDLY: {{[0-9]+}} static StackOverflow.main() + {{[0-9]+}} in stack-overflow.exe at {{.*[\\/]}}StackOverflow.swift:11:5
+
+// FRIENDLY:           9| struct StackOverflow {
+// FRIENDLY-NEXT:     10|   static func main() {
+// FRIENDLY-NEXT:     11|     recurse(1)
+// FRIENDLY-NEXT:       |     ^
+// FRIENDLY-NEXT:     12|   }
+// FRIENDLY-NEXT:     13| }


### PR DESCRIPTION
rdar://181843264 relates on this, we had disabled all unit tests for remote running for any tests using preset=friendly on the backtracer anywhere in the test. This is because friendly needs access to source code files which are not present when doing remote run. Split unit tests into a bit that can be run remotely like most tests, and a bit that uses preset=friendly that can't.
