### PR TITLE
[Docs] Fix broken cross-references in docs

### DIFF
--- a/docs/CppInteroperability/CppInteroperabilityManifesto.md
+++ b/docs/CppInteroperability/CppInteroperabilityManifesto.md
@@ -279,7 +279,7 @@ func caller() {
 
 To understand the constraints that Swift puts on `inout` parameters, let's take
 a look at the mental model for introduced in the [Ownership
-manifesto](OwnershipManifesto.md) and in [SE-0176 Enforce Exclusive Access to
+manifesto](../OwnershipManifesto.md) and in [SE-0176 Enforce Exclusive Access to
 Memory](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0176-enforce-exclusive-access-to-memory.md).
 When the caller binds a storage reference to an `inout` parameter, it starts a
 non-instantaneous access to the whole value that occupies the storage. This
@@ -1179,7 +1179,7 @@ that return inner pointers on temporaries.
 ### Differences in move semantics between C++ and Swift
 
 Swift's "move" operation will leave the source value uninitialized (see
-[ownership manifesto](OwnershipManifesto.md)); this operation is called a
+[ownership manifesto](../OwnershipManifesto.md)); this operation is called a
 "destructive move". C++ has "non-destructive moves" that leave the source value
 initialized, but in an indeterminate state.
 
@@ -1194,7 +1194,7 @@ but don't have a public copy constructor and a public copy assignment operator
 
 Swift does not have move-only types at the time this document was written
 (January 2020). There is a desire to add them, and a lot of design work has been
-done (see the [Ownership Manifesto](OwnershipManifesto.md)), however, this
+done (see the [Ownership Manifesto](../OwnershipManifesto.md)), however, this
 design has not been proposed yet.
 
 Therefore, we will first discuss mapping move-only C++ classes to Swift before
@@ -1329,7 +1329,7 @@ struct TwoFiles {
 ### Move-only C++ classes: mapping to move-only Swift types (in future Swift versions)
 
 This section is based on the design for move-only Swift types that has not been
-officially proposed yet. See [ownership manifesto](OwnershipManifesto.md) for
+officially proposed yet. See [ownership manifesto](../OwnershipManifesto.md) for
 the design for ownership and move only types that we assume in this section.
 
 Move-only C++ classes correspond to `moveonly` structs in Swift. Semantic

--- a/docs/SIL/Instructions.md
+++ b/docs/SIL/Instructions.md
@@ -2106,7 +2106,7 @@ Checks whether %0 is the address of a unique reference to a memory object.
 Returns 1 if the strong reference count is 1, and 0 if the strong reference
 count is greater than 1.
 
-A discussion of the semantics can be found in the [ARC Optimization](ARC-Optimization.md) document.
+A discussion of the semantics can be found in the [ARC Optimization](ARCOptimization.md) document.
 
 ### begin_cow_mutation
 

--- a/docs/SIL/SIL.md
+++ b/docs/SIL/SIL.md
@@ -247,7 +247,7 @@ For the list of function attributes see [FunctionAttributes](FunctionAttributes.
 Optionally a function can define a list of effects, which describe effects,
 like memory effects or escaping effects for arguments. For details
 see the documentation in
-[Effects.swift](`SwiftCompilerSources/Sources/SIL/Effects.swift`).
+[Effects.swift](../../SwiftCompilerSources/Sources/SIL/Effects.swift).
 
 ```
 effects ::= '[' argument-name ':' argument-effect (',' argument-effect)*]'


### PR DESCRIPTION
Fixes three broken cross-references found by a mechanical link audit (each corrected target verified to exist):

- `docs/CppInteroperability/CppInteroperabilityManifesto.md` — links `OwnershipManifesto.md`, which resolves inside the `CppInteroperability/` directory; the manifesto lives at `docs/OwnershipManifesto.md` → `../OwnershipManifesto.md`
- `docs/SIL/SIL.md` — `[Effects.swift](\`SwiftCompilerSources/Sources/SIL/Effects.swift\`)` has a backtick-wrapped target (renders as literal text) and is missing the path back to the repo root → `../../SwiftCompilerSources/Sources/SIL/Effects.swift`
- `docs/SIL/Instructions.md` — links `ARC-Optimization.md`; the file in the same directory is `ARCOptimization.md` (no hyphen)

Documentation only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)