### PR TITLE
ClangImporter: support reshaping macros on import

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3750,7 +3750,7 @@ void ClangImporter::lookupBridgingHeaderDecls(
       if (filter(macroNode)) {
         auto MI = macroNode.getAsMacro();
         Identifier Name = Impl.getNameImporter().importMacroName(II, MI);
-        if (Decl *imported = Impl.importMacro(Name, macroNode))
+        if (Decl *imported = Impl.importMacro(Name, macroNode, II))
           receiver(imported);
       }
     }
@@ -3828,7 +3828,7 @@ bool ClangImporter::lookupDeclsFromHeader(StringRef Filename,
         ClangNode MacroNode = Info;
         if (filter(MacroNode)) {
           auto Name = Impl.getNameImporter().importMacroName(II, Info);
-          if (auto *Imported = Impl.importMacro(Name, MacroNode))
+          if (auto *Imported = Impl.importMacro(Name, MacroNode, II))
             receiver(Imported);
         }
       });

--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -18,6 +18,7 @@
 #include "ImporterImpl.h"
 #include "SwiftDeclSynthesizer.h"
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/Attr.h"
 #include "swift/AST/DiagnosticsClangImporter.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/ParameterList.h"
@@ -39,6 +40,40 @@
 
 using namespace swift;
 using namespace importer;
+
+static Type importMacroTypeOverride(ClangImporter::Implementation &Impl,
+                                    DeclContext *DC,
+                                    const clang::IdentifierInfo *II,
+                                    const clang::MacroInfo *macro,
+                                    ClangNode ClangN) {
+  if (!II)
+    return Type();
+
+  clang::Sema &S = Impl.getClangSema();
+  auto Info = S.ProcessAPINotes(ClangN.getOwningClangModule(), II,
+                                macro->getDefinitionLoc());
+  if (!Info || Info->getType().empty())
+    return Type();
+
+  if (!S.ParseTypeFromStringCallback)
+    return Type();
+
+  // Resolve the APINotes 'Type:' annotation. Parsing the C type string is left
+  // to Clang's parser (via ParseTypeFromStringCallback); we only trigger it.
+  auto Ty = S.ParseTypeFromStringCallback(Info->getType(), "<API Notes>",
+                                          macro->getDefinitionLoc());
+  if (!Ty.isUsable())
+    return Type();
+
+  clang::QualType QualTy = clang::Sema::GetTypeFromParser(Ty.get());
+  if (QualTy.isNull())
+    return Type();
+
+  return Impl.importTypeIgnoreIUO(
+      QualTy, ImportTypeKind::Value,
+      ImportDiagnosticAdder(Impl, macro, macro->getDefinitionLoc()),
+      isInSystemModule(DC), Bridgeability::None, ImportTypeAttrs());
+}
 
 template <typename T = clang::Expr>
 static const T *
@@ -64,6 +99,7 @@ getTokenSpelling(ClangImporter::Implementation &impl, const clang::Token &tok) {
 static ValueDecl *
 createMacroConstant(ClangImporter::Implementation &Impl,
                     const clang::MacroInfo *macro,
+                    const clang::IdentifierInfo *II,
                     Identifier name,
                     DeclContext *dc,
                     Type type,
@@ -71,6 +107,9 @@ createMacroConstant(ClangImporter::Implementation &Impl,
                     ConstantConvertKind convertKind,
                     bool isStatic,
                     ClangNode ClangN) {
+  if (Type T = importMacroTypeOverride(Impl, dc, II, macro, ClangN))
+    type = T;
+
   Impl.ImportedMacroConstants[macro] = {value, type};
   return SwiftDeclSynthesizer(Impl).createConstant(name, dc, type, value,
                                                    convertKind, isStatic,
@@ -80,6 +119,7 @@ createMacroConstant(ClangImporter::Implementation &Impl,
 static ValueDecl *importNumericLiteral(ClangImporter::Implementation &Impl,
                                        DeclContext *DC,
                                        const clang::MacroInfo *MI,
+                                       const clang::IdentifierInfo *II,
                                        Identifier name,
                                        const clang::Token *signTok,
                                        const clang::Token &tok,
@@ -151,7 +191,7 @@ static ValueDecl *importNumericLiteral(ClangImporter::Implementation &Impl,
           !ctx.getIntBuiltinInitDecl(constantTyNominal)) {
         return nullptr;
       }
-      return createMacroConstant(Impl, MI, name, DC, constantType,
+      return createMacroConstant(Impl, MI, II, name, DC, constantType,
                                  clang::APValue(value),
                                  ConstantConvertKind::None,
                                  /*static*/ false, ClangN);
@@ -179,7 +219,7 @@ static ValueDecl *importNumericLiteral(ClangImporter::Implementation &Impl,
       if (!ctx.getFloatBuiltinInitDecl(constantTyNominal))
         return nullptr;
 
-      return createMacroConstant(Impl, MI, name, DC, constantType,
+      return createMacroConstant(Impl, MI, II, name, DC, constantType,
                                  clang::APValue(value),
                                  ConstantConvertKind::None,
                                  /*static*/ false, ClangN);
@@ -235,6 +275,7 @@ static ValueDecl *importStringLiteral(ClangImporter::Implementation &Impl,
 static ValueDecl *importLiteral(ClangImporter::Implementation &Impl,
                                 DeclContext *DC,
                                 const clang::MacroInfo *MI,
+                                const clang::IdentifierInfo *II,
                                 Identifier name,
                                 const clang::Token &tok,
                                 ClangNode ClangN,
@@ -242,7 +283,8 @@ static ValueDecl *importLiteral(ClangImporter::Implementation &Impl,
   switch (tok.getKind()) {
   case clang::tok::numeric_constant: {
     ValueDecl *importedNumericLiteral = importNumericLiteral(
-        Impl, DC, MI, name, /*signTok*/ nullptr, tok, ClangN, castType);
+        Impl, DC, MI, II, name, /*signTok*/ nullptr, tok, ClangN,
+        castType);
     if (!importedNumericLiteral) {
       Impl.addImportDiagnostic(
           &tok, Diagnostic(diag::macro_not_imported_invalid_numeric_literal),
@@ -382,7 +424,7 @@ getIntegerConstantForMacroToken(ClangImporter::Implementation &impl,
       macroNode = moduleMacro;
     }
     auto importedID = impl.getNameImporter().importMacroName(rawID, macroInfo);
-    (void)impl.importMacro(importedID, macroNode);
+    (void)impl.importMacro(importedID, macroNode, rawID);
 
     auto searcher = impl.ImportedMacroConstants.find(macroInfo);
     if (searcher == impl.ImportedMacroConstants.end()) {
@@ -502,6 +544,7 @@ ValueDecl *importDeclAlias(ClangImporter::Implementation &clang,
 static ValueDecl *importMacro(ClangImporter::Implementation &impl,
                               llvm::SmallSet<StringRef, 4> &visitedMacros,
                               DeclContext *DC, Identifier name,
+                              const clang::IdentifierInfo *II,
                               const clang::MacroInfo *macro, ClangNode ClangN,
                               clang::QualType castType) {
   if (name.empty()) return nullptr;
@@ -598,7 +641,8 @@ static ValueDecl *importMacro(ClangImporter::Implementation &impl,
 
     // If it's a literal token, we might be able to translate the literal.
     if (tok.isLiteral()) {
-      return importLiteral(impl, DC, macro, name, tok, ClangN, castType);
+      return importLiteral(impl, DC, macro, II, name, tok, ClangN,
+                           castType);
     }
 
     if (tok.is(clang::tok::identifier)) {
@@ -632,8 +676,8 @@ static ValueDecl *importMacro(ClangImporter::Implementation &impl,
 
           // FIXME: This was clearly intended to pass the cast type down, but
           // doing so would be a behavior change.
-          return importMacro(impl, visitedMacros, DC, name, macroID, ClangN,
-                             /*castType*/ {});
+          return importMacro(impl, visitedMacros, DC, name, II, macroID,
+                             ClangN, /*castType*/ {});
         }
       }
 
@@ -662,7 +706,7 @@ static ValueDecl *importMacro(ClangImporter::Implementation &impl,
 
     if (isSignToken(first) && second.is(clang::tok::numeric_constant)) {
       ValueDecl *importedNumericLiteral = importNumericLiteral(
-          impl, DC, macro, name, &first, second, ClangN, castType);
+          impl, DC, macro, II, name, &first, second, ClangN, castType);
       if (!importedNumericLiteral) {
         impl.addImportDiagnostic(
             macro, Diagnostic(diag::macro_not_imported, name.str()),
@@ -861,7 +905,8 @@ static ValueDecl *importMacro(ClangImporter::Implementation &impl,
       return nullptr;
     }
 
-    return createMacroConstant(impl, macro, name, DC, resultSwiftType,
+    return createMacroConstant(impl, macro, II, name, DC,
+                               resultSwiftType,
                                clang::APValue(resultValue),
                                ConstantConvertKind::None,
                                /*isStatic=*/false, ClangN);
@@ -905,11 +950,19 @@ static ValueDecl *importMacro(ClangImporter::Implementation &impl,
   return nullptr;
 }
 
-ValueDecl *ClangImporter::Implementation::importMacro(Identifier name,
-                                                      ClangNode macroNode) {
+ValueDecl *ClangImporter::Implementation::importMacro(
+    Identifier name, ClangNode macroNode,
+    const clang::IdentifierInfo *II) {
   const clang::MacroInfo *macro = macroNode.getAsMacro();
   if (!macro)
     return nullptr;
+
+  if (!II) {
+    if (const auto *M = macroNode.getAsModuleMacro())
+      II = M->getName();
+    else
+      II = getClangPreprocessor().getIdentifierInfo(name.str());
+  }
 
   PrettyStackTraceStringAction stackRAII{"importing macro", name.str()};
 
@@ -949,11 +1002,12 @@ ValueDecl *ClangImporter::Implementation::importMacro(Identifier name,
   // result.
 
   DeclContext *DC;
-  if (const clang::Module *module =
-          importer::getClangOwningModule(macroNode, getClangASTContext())) {
+  const clang::Module *Module =
+      importer::getClangOwningModule(macroNode, getClangASTContext());
+  if (Module) {
     // Get the parent module because currently we don't model Clang submodules
     // in Swift.
-    DC = getWrapperForModule(module->getTopLevelModule());
+    DC = getWrapperForModule(Module->getTopLevelModule());
   } else {
     DC = ImportedHeaderUnit;
   }
@@ -961,7 +1015,7 @@ ValueDecl *ClangImporter::Implementation::importMacro(Identifier name,
   llvm::SmallSet<StringRef, 4> visitedMacros;
   visitedMacros.insert(name.str());
   auto valueDecl =
-      ::importMacro(*this, visitedMacros, DC, name, macro, macroNode,
+      ::importMacro(*this, visitedMacros, DC, name, II, macro, macroNode,
                     /*castType*/ {});
 
   // Update the entry for the value we just imported.
@@ -976,6 +1030,27 @@ ValueDecl *ClangImporter::Implementation::importMacro(Identifier name,
     assert(entryIter != llvm::reverse(ImportedMacros[name]).end() &&
            "placeholder not found");
     entryIter->second = valueDecl;
+
+    // If APINotes renamed this macro and we imported it under its original C
+    // name, mark this declaration as unavailable and redirect to the Swift
+    // name, mirroring how renamed Clang declarations are imported. The Swift
+    // name is whatever importMacroName resolves for the original identifier; if
+    // it differs from the name we imported under, this is the renamed-from C
+    // name.
+    Identifier invalid;
+    Identifier imported =
+        getNameImporter().importMacroName(II, macro, Module, &invalid);
+    if (!invalid.empty()) {
+      diagnose(HeaderLoc(macro->getDefinitionLoc()),
+               diag::invalid_swift_name_for_decl, invalid.str(), valueDecl);
+    } else if (!imported.empty() && imported != name) {
+      ASTContext &AST = valueDecl->getASTContext();
+      auto Renamed = AST.AllocateCopy(imported.str());
+      auto Attr =
+          AvailableAttr::createUnavailableInSwift(AST, /*Message=*/StringRef(),
+                                                  Renamed);
+      valueDecl->addAttribute(Attr);
+    }
   }
 
   return valueDecl;

--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -96,6 +96,18 @@ getTokenSpelling(ClangImporter::Implementation &impl, const clang::Token &tok) {
   return tokenSpelling;
 }
 
+static bool applyCUnsignedIntegerCastExpr(llvm::APSInt &Value,
+                                          clang::QualType Ty,
+                                          const clang::ASTContext &C) {
+  if (Ty.isNull() || !Ty->isIntegerType() || Ty->isBooleanType() ||
+      !Ty->isUnsignedIntegerOrEnumerationType())
+    return false;
+
+  Value = Value.extOrTrunc(C.getIntWidth(Ty));
+  Value.setIsUnsigned(true);
+  return true;
+}
+
 static ValueDecl *
 createMacroConstant(ClangImporter::Implementation &Impl,
                     const clang::MacroInfo *macro,
@@ -179,6 +191,8 @@ static ValueDecl *importNumericLiteral(ClangImporter::Implementation &Impl,
           value.flipAllBits();
         }
       }
+      applyCUnsignedIntegerCastExpr(value, castType,
+                                    Impl.getClangASTContext());
 
       // Make sure the destination type actually conforms to the builtin literal
       // protocol or is Bool before attempting to import, otherwise we'll crash
@@ -903,6 +917,16 @@ static ValueDecl *importMacro(ClangImporter::Implementation &impl,
                                Diagnostic(diag::macro_not_imported, name.str()),
                                macro->getDefinitionLoc());
       return nullptr;
+    }
+
+    if (applyCUnsignedIntegerCastExpr(resultValue, castType,
+                                      impl.getClangASTContext())) {
+      resultSwiftType = impl.importTypeIgnoreIUO(
+          castType, ImportTypeKind::Value,
+          ImportDiagnosticAdder(impl, macro, macro->getDefinitionLoc()),
+          isInSystemModule(DC), Bridgeability::None, ImportTypeAttrs());
+      if (!resultSwiftType)
+        return nullptr;
     }
 
     return createMacroConstant(impl, macro, II, name, DC,

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -2618,16 +2618,33 @@ Identifier ImportedName::getBaseIdentifier(ASTContext &ctx) const {
 }
 
 Identifier
-NameImporter::importMacroName(const clang::IdentifierInfo *clangIdentifier,
-                              const clang::MacroInfo *macro) {
+NameImporter::importMacroName(const clang::IdentifierInfo *II,
+                              const clang::MacroInfo *MI,
+                              const clang::Module *M,
+                              Identifier *invalidCustomName) {
+  if (invalidCustomName)
+    *invalidCustomName = Identifier();
+
   // If we're supposed to ignore this macro, return an empty identifier.
-  if (::shouldIgnoreMacro(clangIdentifier->getName(), macro,
-                          getClangPreprocessor()))
+  if (::shouldIgnoreMacro(II->getName(), MI, getClangPreprocessor()))
     return Identifier();
 
-  // No transformation is applied to the name.
-  StringRef name = clangIdentifier->getName();
-  return swiftCtx.getIdentifier(name);
+  // Honor an APINotes 'SwiftName:' override, if one applies. A macro constant
+  // can only be renamed to a simple identifier, so reject function, operator,
+  // and member names, which are meaningless here.
+  if (auto notes = getClangSema().ProcessAPINotes(M, II, MI->getDefinitionLoc())) {
+    if (!notes->SwiftName.empty()) {
+      ParsedDeclName ident = parseDeclName(notes->SwiftName);
+      if (ident && !ident.isOperator() && !ident.IsFunctionName &&
+          !ident.isMember())
+        return swiftCtx.getIdentifier(ident.BaseName);
+      if (invalidCustomName)
+        *invalidCustomName = swiftCtx.getIdentifier(notes->SwiftName);
+    }
+  }
+
+  // Otherwise, no transformation is applied to the name.
+  return swiftCtx.getIdentifier(II->getName());
 }
 
 ImportedName NameImporter::importName(const clang::NamedDecl *decl,

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -461,8 +461,16 @@ public:
       llvm::function_ref<bool(ImportedName, ImportNameVersion)> action);
 
   /// Imports the name of the given Clang macro into Swift.
-  Identifier importMacroName(const clang::IdentifierInfo *clangIdentifier,
-                             const clang::MacroInfo *macro);
+  ///
+  /// If APINotes provides a 'SwiftName:' for the macro, that name is used;
+  /// \p M allows module APINotes sidecars to be consulted in addition to
+  /// location-based notes. If the provided name is not valid for a macro
+  /// constant, it is returned in \p invalidCustomName and the original C name
+  /// is used instead.
+  Identifier importMacroName(const clang::IdentifierInfo *II,
+                             const clang::MacroInfo *MI,
+                             const clang::Module *M = nullptr,
+                             Identifier *invalidCustomName = nullptr);
 
   ASTContext &getContext() { return swiftCtx; }
   const LangOptions &getLangOpts() const { return swiftCtx.LangOpts; }

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1175,7 +1175,8 @@ public:
   ///
   /// \returns The imported declaration, or null if the macro could not be
   /// translated into Swift.
-  ValueDecl *importMacro(Identifier name, ClangNode macroNode);
+  ValueDecl *importMacro(Identifier name, ClangNode macroNode,
+                         const clang::IdentifierInfo *II = nullptr);
 
   /// Map a Clang identifier name to its imported Swift equivalent.
   StringRef getSwiftNameFromClangName(StringRef name);

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -2083,13 +2083,27 @@ void importer::addMacrosToLookupTable(SwiftLookupTable &table,
       }
 
       // Add this entry.
-      auto name = nameImporter.importMacroName(macro.first, info);
+      const clang::Module *Module =
+          moduleMacro ? moduleMacro->getOwningModule() : nullptr;
+      auto name = nameImporter.importMacroName(macro.first, info, Module);
       if (name.empty())
         return;
-      if (moduleMacro)
-        table.addEntry(name, moduleMacro, tu);
-      else
-        table.addEntry(name, info, tu);
+
+      auto addEntry = [&](Identifier entryName) {
+        if (moduleMacro)
+          table.addEntry(entryName, moduleMacro, tu);
+        else
+          table.addEntry(entryName, info, tu);
+      };
+
+      addEntry(name);
+
+      // If APINotes renamed this macro, also register it under its original C
+      // name so that a reference to the old name still resolves (to an
+      // unavailable redirect synthesized in importMacro).
+      auto rawName = nameImporter.getIdentifier(macro.first->getName());
+      if (!rawName.empty() && rawName != name)
+        addEntry(rawName);
     };
 
     ArrayRef<clang::ModuleMacro *> moduleMacros =

--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -280,7 +280,7 @@ const uint16_t SWIFT_LOOKUP_TABLE_VERSION_MAJOR = 1;
 /// Lookup table minor version number.
 ///
 /// When the format changes IN ANY WAY, this number should be incremented.
-const uint16_t SWIFT_LOOKUP_TABLE_VERSION_MINOR = 25; // No more __Unsafe in lookup table
+const uint16_t SWIFT_LOOKUP_TABLE_VERSION_MINOR = 26; // APINotes macro renames
 
 /// A lookup table that maps Swift names to the set of Clang
 /// declarations with that particular name.

--- a/test/APINotes/Inputs/custom-modules/APINotesTest.apinotes
+++ b/test/APINotes/Inputs/custom-modules/APINotesTest.apinotes
@@ -15,6 +15,17 @@ Globals:
     SwiftName: '`class`'
   - Name: ANTGlobalValue5
     SwiftName: '`3test raw`'
+  - Name: APINOTES_TYPED_MACRO
+    Type: APINotesUnsigned
+  - Name: APINOTES_TYPED_MACRO_ALIAS_TARGET
+    Type: APINotesSigned
+  - Name: APINOTES_TYPED_MACRO_ALIAS
+    Type: APINotesUnsigned
+  - Name: APINOTES_RENAMED_MACRO
+    SwiftName: renamedMacroConstant
+  - Name: APINOTES_RETYPED_RENAMED_MACRO
+    SwiftName: retypedRenamedMacroConstant
+    Type: APINotesUnsigned
   - Name: will_be_private
     SwiftPrivate: true
 Tags:

--- a/test/APINotes/Inputs/custom-modules/APINotesTest.h
+++ b/test/APINotes/Inputs/custom-modules/APINotesTest.h
@@ -6,6 +6,13 @@ extern int ANTGlobalValue2;
 extern int ANTGlobalValue3;
 extern int ANTGlobalValue4;
 extern int ANTGlobalValue5;
+typedef unsigned APINotesUnsigned;
+typedef int APINotesSigned;
+#define APINOTES_TYPED_MACRO 42
+#define APINOTES_TYPED_MACRO_ALIAS_TARGET 314
+#define APINOTES_TYPED_MACRO_ALIAS APINOTES_TYPED_MACRO_ALIAS_TARGET
+#define APINOTES_RENAMED_MACRO 17
+#define APINOTES_RETYPED_RENAMED_MACRO 19
 
 struct PointStruct {
   double x, y;

--- a/test/APINotes/Inputs/custom-modules/InvalidMacroNames.apinotes
+++ b/test/APINotes/Inputs/custom-modules/InvalidMacroNames.apinotes
@@ -1,0 +1,8 @@
+Name: InvalidMacroNames
+Globals:
+  - Name: OPERATOR_NAMED_MACRO
+    SwiftName: '+'
+  - Name: FUNCTION_NAMED_MACRO
+    SwiftName: 'functionNamedMacro()'
+  - Name: MEMBER_NAMED_MACRO
+    SwiftName: 'Container.memberNamedMacro'

--- a/test/APINotes/Inputs/custom-modules/InvalidMacroNames.h
+++ b/test/APINotes/Inputs/custom-modules/InvalidMacroNames.h
@@ -1,0 +1,3 @@
+#define OPERATOR_NAMED_MACRO 23 // expected-warning {{custom Swift name '+' ignored because it is not valid for var; imported as 'OPERATOR_NAMED_MACRO' instead}}
+#define FUNCTION_NAMED_MACRO 29 // expected-warning {{custom Swift name 'functionNamedMacro()' ignored because it is not valid for var; imported as 'FUNCTION_NAMED_MACRO' instead}}
+#define MEMBER_NAMED_MACRO 31 // expected-warning {{custom Swift name 'Container.memberNamedMacro' ignored because it is not valid for var; imported as 'MEMBER_NAMED_MACRO' instead}}

--- a/test/APINotes/Inputs/custom-modules/module.modulemap
+++ b/test/APINotes/Inputs/custom-modules/module.modulemap
@@ -4,3 +4,6 @@ module APINotesTest {
 module ObsoletedAPINotesTest {
   header "ObsoletedAPINotesTest.h"
 }
+module InvalidMacroNames {
+  header "InvalidMacroNames.h"
+}

--- a/test/APINotes/basic.swift
+++ b/test/APINotes/basic.swift
@@ -49,6 +49,19 @@ func testSwiftName() {
 
   let d: Double = __will_be_private
 
+  let _: APINotesUnsigned = APINOTES_TYPED_MACRO
+  let _: CInt = APINOTES_TYPED_MACRO // expected-error{{cannot convert value of type 'APINotesUnsigned'}}
+  let _: APINotesSigned = APINOTES_TYPED_MACRO_ALIAS_TARGET
+  let _: APINotesUnsigned = APINOTES_TYPED_MACRO_ALIAS_TARGET // expected-error{{cannot convert value of type 'APINotesSigned'}}
+  let _: APINotesUnsigned = APINOTES_TYPED_MACRO_ALIAS
+  let _: APINotesSigned = APINOTES_TYPED_MACRO_ALIAS // expected-error{{cannot convert value of type 'APINotesUnsigned'}}
+
+  _ = renamedMacroConstant
+  _ = APINOTES_RENAMED_MACRO // expected-error{{'APINOTES_RENAMED_MACRO' has been renamed to 'renamedMacroConstant'}}
+  let _: APINotesUnsigned = retypedRenamedMacroConstant
+  let _: CInt = retypedRenamedMacroConstant // expected-error{{cannot convert value of type 'APINotesUnsigned'}}
+  _ = APINOTES_RETYPED_RENAMED_MACRO // expected-error{{'APINOTES_RETYPED_RENAMED_MACRO' has been renamed to 'retypedRenamedMacroConstant'}}
+
   // From APINotesFrameworkTest.
   jumpTo(x: 0, y: 0, z: 0)
   jumpTo(0, 0, 0) // expected-error{{missing argument labels 'x:y:z:' in call}}

--- a/test/APINotes/macro_constant_values.swift
+++ b/test/APINotes/macro_constant_values.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-frontend -I %S/Inputs/custom-modules -emit-sil -Xllvm -sil-disable-pass=Simplification -Xllvm -sil-print-types -Xllvm -sil-print-debuginfo %s | %FileCheck %s
+
+import APINotesTest
+
+// CHECK-LABEL: // typedMacro()
+func typedMacro() -> APINotesUnsigned {
+  // CHECK: integer_literal $Builtin.Int32, 42
+  // CHECK: struct $UInt32
+  APINOTES_TYPED_MACRO
+}
+
+// CHECK-LABEL: // typedMacroAlias()
+func typedMacroAlias() -> APINotesUnsigned {
+  // CHECK: integer_literal $Builtin.Int32, 314
+  // CHECK: struct $UInt32
+  APINOTES_TYPED_MACRO_ALIAS
+}
+
+// CHECK-LABEL: // renamedMacro()
+func renamedMacro() -> CInt {
+  // CHECK: integer_literal $Builtin.Int32, 17
+  // CHECK: struct $Int32
+  renamedMacroConstant
+}
+
+// CHECK-LABEL: // retypedRenamedMacro()
+func retypedRenamedMacro() -> APINotesUnsigned {
+  // CHECK: integer_literal $Builtin.Int32, 19
+  // CHECK: struct $UInt32
+  retypedRenamedMacroConstant
+}

--- a/test/APINotes/macro_invalid_names.swift
+++ b/test/APINotes/macro_invalid_names.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift -verify-additional-file %/S/Inputs/custom-modules%{fs-sep}InvalidMacroNames.h -I %/S/Inputs/custom-modules
+
+import InvalidMacroNames
+
+_ = OPERATOR_NAMED_MACRO
+_ = FUNCTION_NAMED_MACRO
+_ = MEMBER_NAMED_MACRO

--- a/test/ClangImporter/macro_integer_casts.swift
+++ b/test/ClangImporter/macro_integer_casts.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -verify
+
+import macros
+
+let _: CUnsignedInt = CAST_UNSIGNED_MINUS_ONE
+let _: CUnsignedInt = CAST_UNSIGNED_MINUS_TEN
+let _: TEST_DWORD = CAST_TYPEDEF_UNSIGNED_MINUS_ONE

--- a/test/ClangImporter/macro_literals.swift
+++ b/test/ClangImporter/macro_literals.swift
@@ -116,6 +116,21 @@ func testIntegerArithmetic() {
   _ = DIVIDE_MIXED_TYPES as CLongLong
 }
 
+// CHECK-LABEL: // testCStyleIntegerCasts()
+func testCStyleIntegerCasts() {
+  // CHECK: %[[P0:.*]] = integer_literal $Builtin.Int32, -1, loc {{.*}}
+  // CHECK: %{{.*}} = struct $UInt32 (%[[P0]] : $Builtin.Int32), loc {{.*}}
+  _ = CAST_UNSIGNED_MINUS_ONE as CUnsignedInt
+
+  // CHECK: %[[P1:.*]] = integer_literal $Builtin.Int32, -10, loc {{.*}}
+  // CHECK: %{{.*}} = struct $UInt32 (%[[P1]] : $Builtin.Int32), loc {{.*}}
+  _ = CAST_UNSIGNED_MINUS_TEN as CUnsignedInt
+
+  // CHECK: %[[P2:.*]] = integer_literal $Builtin.Int32, -1, loc {{.*}}
+  // CHECK: %{{.*}} = struct $UInt32 (%[[P2]] : $Builtin.Int32), loc {{.*}}
+  _ = CAST_TYPEDEF_UNSIGNED_MINUS_ONE as TEST_DWORD
+}
+
 // CHECK-LABEL: // testIntegerComparisons()
 func testIntegerComparisons() {
 

--- a/test/Inputs/clang-importer-sdk/usr/include/macros.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/macros.h
@@ -115,6 +115,12 @@
 #define DIVIDE_MIXED_TYPES  (INT64_MAX / UINT32_MAX) // Result = (2^31)LL
 #define DIVIDE_INVALID     (69 / 0) // Should skip. Divide by zero.
 
+typedef unsigned int TEST_DWORD;
+
+#define CAST_UNSIGNED_MINUS_ONE ((unsigned)-1)
+#define CAST_UNSIGNED_MINUS_TEN ((unsigned)-10)
+#define CAST_TYPEDEF_UNSIGNED_MINUS_ONE ((TEST_DWORD)-1)
+
 // Integer Comparisons.
 
 #define EQUAL_FALSE            (99 == 66)


### PR DESCRIPTION
This pull request enhances Swift's ClangImporter to better support macro import customization via APINotes, including macro renaming and type overrides, and ensures that references to renamed macros are handled gracefully. The changes also improve the robustness and flexibility of macro importing by consistently passing through identifier information and module context.

**APINotes-driven macro import improvements:**

* `NameImporter::importMacroName` now supports APINotes-driven renaming of macros (via `SwiftName:`) and type overrides (via `Type:`), and takes the owning module into account to consult module-level APINotes. [[1]](diffhunk://#diff-4d81804099c6a7870b8108299b8a43162f2e593b207244f810db0a926dbf530aL2621-R2640) [[2]](diffhunk://#diff-640400695ee55d5bb056484c94a02b3e1842310907004a5a3fdaeb7cf859f21bL464-R470)
* When a macro is renamed by APINotes, the original C name is registered as an unavailable declaration in Swift that redirects to the new Swift name, ensuring references to the old name are handled correctly. [[1]](diffhunk://#diff-0b5f446c56843e850623911c16dc20cbc5c871dbce68d371465e233b6040373bR1057-R1070) [[2]](diffhunk://#diff-a34910228facd5072374ca4dc4c6b8bf81af7b2aa8350c38d02b3fd7905f8c2eL2086-R2106)

**Macro import API and call site updates:**

* The macro import pipeline (`importMacro`, `importNumericLiteral`, etc.) is refactored to consistently pass the Clang `IdentifierInfo` and owning module, allowing APINotes lookups at all import stages. [[1]](diffhunk://#diff-0062ad3fe872d09412bd3e7c72610b5ad0bd39667ebc00695351ef93c7c6815fL3752-R3752) [[2]](diffhunk://#diff-0062ad3fe872d09412bd3e7c72610b5ad0bd39667ebc00695351ef93c7c6815fL3830-R3830) [[3]](diffhunk://#diff-0b5f446c56843e850623911c16dc20cbc5c871dbce68d371465e233b6040373bR134) [[4]](diffhunk://#diff-0b5f446c56843e850623911c16dc20cbc5c871dbce68d371465e233b6040373bR561) [[5]](diffhunk://#diff-0b5f446c56843e850623911c16dc20cbc5c871dbce68d371465e233b6040373bL952-R1042) [[6]](diffhunk://#diff-5b3ecd3177159be383f776e43234f7f464f65862c512a11c3d101b157768cf12L1171-R1172)

**Macro type override support:**

* Adds support for APINotes `Type:` annotations on macros, parsing and applying custom types during import (including proper handling of unsigned integer casts). [[1]](diffhunk://#diff-0b5f446c56843e850623911c16dc20cbc5c871dbce68d371465e233b6040373bR44-R77) [[2]](diffhunk://#diff-0b5f446c56843e850623911c16dc20cbc5c871dbce68d371465e233b6040373bR99-R124) [[3]](diffhunk://#diff-0b5f446c56843e850623911c16dc20cbc5c871dbce68d371465e233b6040373bR194-R195) [[4]](diffhunk://#diff-0b5f446c56843e850623911c16dc20cbc5c871dbce68d371465e233b6040373bL864-R933)

**Test and diagnostics updates:**

* Updates APINotes test input to cover new macro renaming and type override features.

These enhancements make macro importing from Clang headers into Swift more accurate, customizable, and robust, especially in the presence of APINotes-driven API refinements.