### PR TITLE
[stdlib] Split RigidArray buffer pointer

### DIFF
--- a/stdlib/public/core/RigidArray/RigidArray+Initializers.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Initializers.swift
@@ -19,7 +19,8 @@ extension _RigidArray where Element: ~Copyable {
   @export(implementation)
   @_transparent
   internal init() {
-    unsafe _storage = .init(start: nil, count: 0)
+    unsafe _ptr = ._dangling()
+    _capacity = 0
     _count = 0
   }
   
@@ -29,9 +30,11 @@ extension _RigidArray where Element: ~Copyable {
   internal init(capacity: Int) {
     _precondition(capacity >= 0, "Array capacity must be nonnegative")
     if capacity > 0 {
-      unsafe _storage = .allocate(capacity: capacity)
+      unsafe _ptr = .allocate(capacity: capacity)
+      _capacity = capacity
     } else {
-      unsafe _storage = .init(start: nil, count: 0)
+      unsafe _ptr = ._dangling()
+      _capacity = 0
     }
     _count = 0
   }

--- a/stdlib/public/core/RigidArray/RigidArray.swift
+++ b/stdlib/public/core/RigidArray/RigidArray.swift
@@ -70,13 +70,6 @@ internal struct _RigidArray<Element: ~Copyable>: ~Copyable {
     unsafe _ptr.deinitialize(count: _count)
     unsafe _ptr.deallocate()
   }
-  
-  @export(implementation)
-  internal init(_storage: UnsafeMutableBufferPointer<Element>, count: Int) {
-    unsafe _ptr = _storage.baseAddress._unsafelyUnwrappedUnchecked
-    _capacity = _storage.count
-    _count = count
-  }
 }
 
 @available(SwiftStdlib 6.4, *)
@@ -88,7 +81,10 @@ extension _RigidArray where Element: ~Copyable {
   @export(implementation)
   @_transparent
   internal var _storage: UnsafeMutableBufferPointer<Element> {
-    unsafe UnsafeMutableBufferPointer<Element>(start: _ptr, count: _capacity)
+    unsafe UnsafeMutableBufferPointer<Element>(
+      _uncheckedStart: _ptr,
+      count: _capacity
+    )
   }
 
   /// The maximum number of elements this rigid array can hold.

--- a/stdlib/public/core/RigidArray/RigidArray.swift
+++ b/stdlib/public/core/RigidArray/RigidArray.swift
@@ -53,21 +53,29 @@
 @usableFromInline
 internal struct _RigidArray<Element: ~Copyable>: ~Copyable {
   @usableFromInline
-  internal var _storage: UnsafeMutableBufferPointer<Element>
+  internal var _ptr: UnsafeMutablePointer<Element>
+
+  @usableFromInline
+  internal var _capacity: Int
 
   @usableFromInline
   internal var _count: Int
 
   @export(implementation)
   deinit {
-    unsafe _storage.extracting(0 ..< _count).deinitialize()
-    unsafe _storage.deallocate()
+    if _capacity == 0 {
+      return
+    }
+
+    unsafe _ptr.deinitialize(count: _count)
+    unsafe _ptr.deallocate()
   }
   
   @export(implementation)
   internal init(_storage: UnsafeMutableBufferPointer<Element>, count: Int) {
-    unsafe self._storage = _storage
-    self._count = count
+    unsafe _ptr = _storage.baseAddress._unsafelyUnwrappedUnchecked
+    _capacity = _storage.count
+    _count = count
   }
 }
 
@@ -76,6 +84,13 @@ extension _RigidArray: @unchecked Sendable where Element: Sendable & ~Copyable {
 
 @available(SwiftStdlib 6.4, *)
 extension _RigidArray where Element: ~Copyable {
+  @available(SwiftStdlib 6.4, *)
+  @export(implementation)
+  @_transparent
+  internal var _storage: UnsafeMutableBufferPointer<Element> {
+    unsafe UnsafeMutableBufferPointer<Element>(start: _ptr, count: _capacity)
+  }
+
   /// The maximum number of elements this rigid array can hold.
   ///
   /// - Complexity: O(1)
@@ -83,7 +98,7 @@ extension _RigidArray where Element: ~Copyable {
   @export(implementation)
   @_transparent
   internal var capacity: Int {
-    _assumeNonNegative(unsafe _storage.count)
+    _assumeNonNegative(_capacity)
   }
 
   /// The number of additional elements that can be added to this array without
@@ -251,8 +266,13 @@ extension _RigidArray where Element: ~Copyable {
       capacity: Swift.max(newCapacity, count))
     let i = unsafe newStorage.moveInitialize(fromContentsOf: _items)
     _internalInvariant(i == count)
-    unsafe _storage.deallocate()
-    unsafe _storage = newStorage
+
+    if _capacity != 0 {
+      unsafe _storage.deallocate()
+    }
+
+    unsafe _ptr = newStorage.baseAddress._unsafelyUnwrappedUnchecked
+    _capacity = newStorage.count
   }
 
   /// Ensure that the array has capacity to store the specified number of

--- a/stdlib/public/core/UniqueArray/UniqueArray.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray.swift
@@ -36,11 +36,6 @@
 public struct UniqueArray<Element: ~Copyable>: ~Copyable {
   @usableFromInline
   internal var _storage: _RigidArray<Element>
-
-  @export(implementation)
-  internal init(_storage: consuming _RigidArray<Element>) {
-    self._storage = _storage
-  }
 }
 
 @available(SwiftStdlib 6.4, *)

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -260,6 +260,13 @@ extension UnsafePointer: CustomReflectable where Pointee: ~Copyable {}
 #endif
 
 extension UnsafePointer where Pointee: ~Copyable {
+  @export(implementation)
+  @_transparent
+  internal static func _dangling() -> Self {
+    let align = MemoryLayout<Pointee>.alignment
+    return unsafe Self(bitPattern: align)._unsafelyUnwrappedUnchecked
+  }
+
   /// Deallocates the memory block previously allocated at this pointer.
   ///
   /// This pointer must be a pointer to the start of a previously allocated
@@ -766,6 +773,12 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
 }
 
 extension UnsafeMutablePointer where Pointee: ~Copyable {
+  @export(implementation)
+  @_transparent
+  internal static func _dangling() -> Self {
+    unsafe Self(mutating: ._dangling())
+  }
+
   /// Allocates uninitialized memory for the specified number of instances of
   /// type `Pointee`.
   ///
@@ -819,9 +832,7 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
     Builtin.bindMemory(rawPtr, count._builtinWordValue, Pointee.self)
     return unsafe UnsafeMutablePointer(rawPtr)
   }
-}
 
-extension UnsafeMutablePointer where Pointee: ~Copyable {
   /// Deallocates the memory block previously allocated at this pointer.
   ///
   /// This pointer must be a pointer to the start of a previously allocated

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1316,9 +1316,12 @@ Added: _$ss11_RigidArrayVMn
 Added: _$ss11_RigidArrayVsRi_zrlE6_countSivM
 Added: _$ss11_RigidArrayVsRi_zrlE6_countSivg
 Added: _$ss11_RigidArrayVsRi_zrlE6_countSivs
-Added: _$ss11_RigidArrayVsRi_zrlE8_storageSryxGvM
-Added: _$ss11_RigidArrayVsRi_zrlE8_storageSryxGvg
-Added: _$ss11_RigidArrayVsRi_zrlE8_storageSryxGvs
+Added: _$ss11_RigidArrayVsRi_zrlE4_ptrSpyxGvM
+Added: _$ss11_RigidArrayVsRi_zrlE4_ptrSpyxGvg
+Added: _$ss11_RigidArrayVsRi_zrlE4_ptrSpyxGvs
+Added: _$ss11_RigidArrayVsRi_zrlE9_capacitySivM
+Added: _$ss11_RigidArrayVsRi_zrlE9_capacitySivg
+Added: _$ss11_RigidArrayVsRi_zrlE9_capacitySivs
 Added: _$ss11_RigidArrayVsSHRzRi_zrlE9hashValueSivg
 Added: _$ss11_RigidArrayVyxGSHsSHRzRi_zrlMc
 Added: _$ss11_RigidArrayVyxGSQsSQRzRi_zrlMc
@@ -1342,4 +1345,3 @@ Added: _swift_retainReturningCount
 // String.UTF16View / Substring.UTF16View bulk _copyContents
 Added: _$sSS9UTF16ViewV13_copyContents12initializingAB8IteratorV_SitSrys6UInt16VG_tF
 Added: _$sSs9UTF16ViewV13_copyContents12initializings16IndexingIteratorVyABG_SitSrys6UInt16VG_tF
-

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -1311,9 +1311,12 @@ Added: _$ss11_RigidArrayVMn
 Added: _$ss11_RigidArrayVsRi_zrlE6_countSivM
 Added: _$ss11_RigidArrayVsRi_zrlE6_countSivg
 Added: _$ss11_RigidArrayVsRi_zrlE6_countSivs
-Added: _$ss11_RigidArrayVsRi_zrlE8_storageSryxGvM
-Added: _$ss11_RigidArrayVsRi_zrlE8_storageSryxGvg
-Added: _$ss11_RigidArrayVsRi_zrlE8_storageSryxGvs
+Added: _$ss11_RigidArrayVsRi_zrlE4_ptrSpyxGvM
+Added: _$ss11_RigidArrayVsRi_zrlE4_ptrSpyxGvg
+Added: _$ss11_RigidArrayVsRi_zrlE4_ptrSpyxGvs
+Added: _$ss11_RigidArrayVsRi_zrlE9_capacitySivM
+Added: _$ss11_RigidArrayVsRi_zrlE9_capacitySivg
+Added: _$ss11_RigidArrayVsRi_zrlE9_capacitySivs
 Added: _$ss11_RigidArrayVsSHRzRi_zrlE9hashValueSivg
 Added: _$ss11_RigidArrayVyxGSHsSHRzRi_zrlMc
 Added: _$ss11_RigidArrayVyxGSQsSQRzRi_zrlMc
@@ -1337,4 +1340,3 @@ Added: _swift_retainReturningCount
 // String.UTF16View / Substring.UTF16View bulk _copyContents
 Added: _$sSS9UTF16ViewV13_copyContents12initializingAB8IteratorV_SitSrys6UInt16VG_tF
 Added: _$sSs9UTF16ViewV13_copyContents12initializings16IndexingIteratorVyABG_SitSrys6UInt16VG_tF
-


### PR DESCRIPTION
This changes the internal representation of `RigidArray` from storing a `UnsafeMutableBufferPointer` to an `UnsafeMutablePointer` and `Int` capacity pair. Buffer pointer stores an optional pointer which takes our optional bit away from the entire structure. By storing a non-optional pointer and using a sentinel well aligned value for the lazily allocated case, we can get the optional bit back. If `_capacity == 0` then the pointer value in the structure is not initialized yet. `UniqueArray?` will now correctly be 24 bytes size and 24 bytes stride vs. the current 25 size and 32 stride.