### PR TITLE
[ASTGen] Adopt renamed Parser.LanguageFeatures

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
+++ b/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
@@ -574,7 +574,7 @@ public func extractInlinableText(
   var parser = Parser(
     textBuffer,
     swiftVersion: Parser.SwiftVersion(from: astContext),
-    experimentalFeatures: Parser.ExperimentalFeatures(from: astContext)
+    languageFeatures: Parser.LanguageFeatures(from: astContext)
   )
   let syntax = SourceFileSyntax.parse(from: &parser)
 

--- a/lib/ASTGen/Sources/ASTGen/SourceFile.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceFile.swift
@@ -72,7 +72,7 @@ public struct ExportedSourceFile {
   }
 }
 
-extension Parser.ExperimentalFeatures {
+extension Parser.LanguageFeatures {
   init(from context: BridgedASTContext?) {
     self = []
     guard let context = context else { return }
@@ -128,7 +128,7 @@ public func parseSourceFile(
   var parser = Parser(
     buffer,
     swiftVersion: Parser.SwiftVersion(from: ctx),
-    experimentalFeatures: Parser.ExperimentalFeatures(from: ctx)
+    languageFeatures: Parser.LanguageFeatures(from: ctx)
   )
 
   let parsed: Syntax


### PR DESCRIPTION
Update for https://github.com/swiftlang/swift-syntax/pull/3377

Update the SwiftParser call sites in ASTGen for the swift-syntax rename of `Parser.ExperimentalFeatures` to `Parser.LanguageFeatures` and the `experimentalFeatures:` argument to `languageFeatures:`.

