### PR TITLE
[Caching][PrefixMap] Fix module bridging header scanning same prefix

### DIFF
--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -1615,7 +1615,10 @@ void ModuleDependencyScanner::resolveHeaderDependenciesForModule(
   auto extractHeaderContent =
       [&](const SwiftBinaryModuleDependencyStorage &binaryMod)
       -> std::unique_ptr<llvm::MemoryBuffer> {
-    auto header = binaryMod.headerImport;
+    auto header =
+        ReversePrefixMapping
+            ? ReversePrefixMapping->mapToString(binaryMod.headerImport)
+            : binaryMod.headerImport;
     // Check to see if the header input exists on disk.
     auto FS = ScanASTContext.SourceMgr.getFileSystem();
     if (FS->exists(header))

--- a/test/CAS/bridging-header-prefix-map-scan.swift
+++ b/test/CAS/bridging-header-prefix-map-scan.swift
@@ -1,0 +1,48 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %t/source1/test.swift -o %t/deps-1.json -auto-bridging-header-chaining -cache-compile-job -cas-path %t/cas \
+// RUN:   -scanner-prefix-map-paths %t/source1 /^src \
+// RUN:   -scanner-output-dir %t -import-objc-header %t/source1/Bridging.h -I %t/source1
+
+// RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps-1.json -o %t/Test.cmd -b %t/header.cmd
+
+// RUN: %target-swift-frontend-plain @%t/header.cmd /^src/Bridging.h -disable-implicit-swift-modules -O -o %t/bridging.pch
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
+// RUN:   %target-swift-frontend-plain @%t/header.cmd /^src/Bridging.h -disable-implicit-swift-modules -O -o %t/bridging.pch > %t/keys.json
+// RUN: %{python} %S/Inputs/ExtractOutputKey.py %t/keys.json > %t/key
+
+// RUN: %target-swift-frontend-plain -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/Test.cmd /^src/test.swift \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   -import-objc-header /^src/Bridging.h -import-pch %t/bridging.pch -bridging-header-pch-key @%t/key \
+// RUN:   -emit-module -o %t/Test.swiftmodule
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name User -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %t/source2/user.swift -o %t/deps-2.json -auto-bridging-header-chaining -cache-compile-job -cas-path %t/cas \
+// RUN:   -scanner-prefix-map-paths %t/source2 /^src \
+// RUN:   -scanner-output-dir %t -I %t -I %t/source1 2>&1 | %FileCheck %s --check-prefix NO-ERROR --allow-empty
+
+// NO-ERROR-NOT: error:
+
+//--- source1/test.swift
+public func test() {
+    bridge()
+}
+
+//--- source2/user.swift
+import Test
+
+//--- source1/Bridging.h
+#include "A.h"
+
+//--- source1/module.modulemap
+module A {
+  header "A.h"
+  export *
+}
+
+//--- source1/A.h
+void bridge(void);


### PR DESCRIPTION
Fix a bug when both producer and consumer of a swiftmodule uses the same prefix mapping destination, and the swiftmodule contains a bridging header, the dependency scanner will failed to scan the bridging header due to unable to find the source file.

The reason for such error is that if a produced swiftmodule contains a bridging header that is prefix mapped to `/^src/header.h`, and the consumer also contains a prefix mapping of `PATH=/^src`, the clang dependency scanner is going to create a file system that can lookup `PATH/header.h`, which is not the same as the input file on the command-line `/^src/header.h`.

Fix the bug by converting `/^src/header.h` -> `PATH/header.h` to match the other location that performs the same path remapping when generating chained bridging header.

rdar://182950674

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
