### PR TITLE
[IRGen] Lower `.none == nullptr` optionals to `ptr`

### DIFF
--- a/lib/IRGen/EnumPayload.cpp
+++ b/lib/IRGen/EnumPayload.cpp
@@ -126,6 +126,22 @@ void EnumPayload::insertValue(IRGenModule &IGM,
                               unsigned payloadOffset) {
   auto &DL = IGM.DataLayout;
 
+  // Fast path: a single pointer-typed payload element (the `.none == null`
+  // optional-reference representation) stores the value directly. The integer
+  // scatter machinery below assumes integer payload values, so handle the
+  // pointer element here and keep the value pointer-typed.
+  if (payloadOffset == 0 && PayloadValues.size() == 1) {
+    auto *storedTy = getPayloadType(PayloadValues.front());
+    if (storedTy->isPointerTy() &&
+        DL.getTypeSizeInBits(storedTy) ==
+            DL.getTypeSizeInBits(value->getType())) {
+      if (value->getType() != storedTy)
+        value = builder.CreateBitOrPointerCast(value, storedTy);
+      PayloadValues.front() = value;
+      return;
+    }
+  }
+
   // Create a mask for the value we are going to insert.
   auto type = value->getType();
   auto payloadSize = getAllocSizeInBits(DL);
@@ -138,6 +154,21 @@ void EnumPayload::insertValue(IRGenModule &IGM,
 llvm::Value *EnumPayload::extractValue(IRGenFunction &IGF, llvm::Type *type,
                                        unsigned payloadOffset) const {
   auto &DL = IGF.IGM.DataLayout;
+
+  // Fast path: a single pointer-typed payload element (the `.none == null`
+  // optional-reference representation) yields the value directly. The integer
+  // gather machinery below assumes integer payload values, so handle the
+  // pointer element here.
+  if (payloadOffset == 0 && PayloadValues.size() == 1) {
+    auto *storedTy = getPayloadType(PayloadValues.front());
+    if (storedTy->isPointerTy() &&
+        DL.getTypeSizeInBits(storedTy) == DL.getTypeSizeInBits(type)) {
+      auto *v = forcePayloadValue(PayloadValues.front());
+      if (v->getType() != type)
+        v = IGF.Builder.CreateBitOrPointerCast(v, type);
+      return v;
+    }
+  }
 
   // Create a mask for the value we are going to extract.
   auto payloadSize = getAllocSizeInBits(DL);

--- a/lib/IRGen/EnumPayload.h
+++ b/lib/IRGen/EnumPayload.h
@@ -36,6 +36,11 @@ class EnumPayloadSchema {
   // A size in bits less than 0 indicates that the payload size is
   // dynamic.
   const int64_t BitSize;
+  // If non-empty, the payload is represented by exactly these LLVM element
+  // types instead of the generic width-chunked representation. This lets an
+  // enum carry a payload with a specific scalar type (e.g. `ptr` for a
+  // `.none == null` optional reference) rather than opaque integer words.
+  SmallVector<llvm::Type *, 2> ExplicitTypes;
 public:
   /// Create a new schema with a dynamic size.
   EnumPayloadSchema() : BitSize(-1) {}
@@ -43,6 +48,14 @@ public:
   /// Create a new schema with the given fixed size in bits.
   explicit EnumPayloadSchema(unsigned bits)
     : BitSize(static_cast<int64_t>(bits)) {}
+
+  /// Create a new fixed-size schema described by an explicit list of LLVM
+  /// element types.
+  static EnumPayloadSchema withExplicitTypes(ArrayRef<llvm::Type *> types) {
+    EnumPayloadSchema result(0);
+    result.ExplicitTypes.append(types.begin(), types.end());
+    return result;
+  }
 
   /// Report whether the schema has a fixed size.
   explicit operator bool() const {
@@ -53,6 +66,13 @@ public:
   template<typename TypeFn /* void(llvm::Type *schemaType) */>
   void forEachType(IRGenModule &IGM, TypeFn &&fn) const {
     assert(BitSize >= 0 && "payload size must not be dynamic");
+
+    // If the schema names its element types explicitly, use them as-is.
+    if (!ExplicitTypes.empty()) {
+      for (llvm::Type *type : ExplicitTypes)
+        fn(type);
+      return;
+    }
 
     // Chunk into pointer-sized integer values.
     int64_t bitSize = BitSize;

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -1954,11 +1954,51 @@ namespace {
       return func;
     }
 
-    static EnumPayloadSchema getPreferredPayloadSchema(Element payloadElement) {
+    /// Whether a single-payload enum with the given payload and no-payload
+    /// case count represents its empty case as the all-zero pointer (nullptr).
+    ///
+    /// This is the governing rule for the `.none == null` representation: the
+    /// enum is loadable, the payload is a single bare retainable pointer, there
+    /// is exactly one no-payload case, and the payload has extra inhabitants
+    /// (so the empty case is extra-inhabitant #0, i.e. the zero pointer). It is
+    /// shared between the payload-schema choice and the NullableRefcounted
+    /// copy/destroy decision so the two predicates cannot drift.
+    static bool isNullableRefcountedPayload(IRGenModule &IGM,
+                                            const TypeInfo &payloadTI,
+                                            TypeInfoKind tik,
+                                            unsigned numNoPayloadCases,
+                                            ReferenceCounting *refcounting) {
+      return tik >= TypeInfoKind::Loadable
+          && payloadTI.isSingleRetainablePointer(ResilienceExpansion::Maximal,
+                                                 refcounting)
+          && numNoPayloadCases == 1
+          // FIXME: All single-retainable-pointer types should eventually have
+          // extra inhabitants.
+          && cast<FixedTypeInfo>(payloadTI)
+               .getFixedExtraInhabitantCount(IGM) > 0;
+    }
+
+    static EnumPayloadSchema
+    getPreferredPayloadSchema(IRGenModule &IGM, Element payloadElement,
+                              TypeInfoKind tik, unsigned numNoPayloadCases) {
       // TODO: If the payload type info provides a preferred explosion schema,
       // use it. For now, just use a generic word-chunked schema.
-      if (auto fixedTI = dyn_cast<FixedTypeInfo>(payloadElement.ti))
+      if (auto fixedTI = dyn_cast<FixedTypeInfo>(payloadElement.ti)) {
+        // When the empty case is exactly the zero pointer, represent the
+        // payload as its own pointer type so the enum lowers to `ptr` in LLVM
+        // IR with `.none == null`, rather than an opaque integer word.
+        if (isNullableRefcountedPayload(IGM, *fixedTI, tik, numNoPayloadCases,
+                                        /*refcounting=*/nullptr)) {
+          ExplosionSchema payloadSchema;
+          fixedTI->getSchema(payloadSchema);
+          assert(payloadSchema.size() == 1 && payloadSchema.begin()->isScalar()
+                 && payloadSchema.begin()->getScalarType()->isPointerTy()
+                 && "single retainable pointer should be one scalar pointer");
+          return EnumPayloadSchema::withExplicitTypes(
+              payloadSchema.begin()->getScalarType());
+        }
         return EnumPayloadSchema(fixedTI->getFixedSize().getValueInBits());
+      }
       return EnumPayloadSchema();
     }
 
@@ -1977,7 +2017,8 @@ namespace {
                                     bitwiseTakable, NumElements,
                                     std::move(WithPayload),
                                     std::move(WithNoPayload),
-                                getPreferredPayloadSchema(WithPayload.front())),
+                                getPreferredPayloadSchema(IGM, WithPayload.front(),
+                                                          tik, WithNoPayload.size())),
                                     CopyDestroyKind(Normal),
                                     Refcounting(ReferenceCounting::Native)
     {
@@ -1993,14 +2034,9 @@ namespace {
       // If the payload is a single refcounted pointer and we have a single
       // empty case, then the layout will be a nullable pointer, and we can
       // pass enum values directly into swift_retain/swift_release as-is.
-      } else if (tik >= TypeInfoKind::Loadable
-          && payloadTI.isSingleRetainablePointer(ResilienceExpansion::Maximal,
-                                                 &Refcounting)
-          && ElementsWithNoPayload.size() == 1
-          // FIXME: All single-retainable-pointer types should eventually have
-          // extra inhabitants.
-          && cast<FixedTypeInfo>(payloadTI)
-            .getFixedExtraInhabitantCount(IGM) > 0) {
+      } else if (isNullableRefcountedPayload(IGM, payloadTI, tik,
+                                             ElementsWithNoPayload.size(),
+                                             &Refcounting)) {
         CopyDestroyKind = NullableRefcounted;
       // If the payload's value witnesses can accept the extra inhabitants we
       // use, then we can forward to them instead of checking for empty tags.
@@ -2959,7 +2995,7 @@ namespace {
       case NullableRefcounted: {
         // Bitcast to swift.refcounted*, and hand to swift_release.
         llvm::Value *val = src.claimNext();
-        llvm::Value *ptr = IGF.Builder.CreateIntToPtr(val,
+        llvm::Value *ptr = IGF.Builder.CreateBitOrPointerCast(val,
                                                 getRefcountedPtrType(IGM));
         fixLifetimeOfRefcountedPayload(IGF, ptr);
         return;

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -1121,6 +1121,16 @@ class ClassExistentialTypeInfo final
   const {
     // We always have at least one entry.
     auto *part = In.claimNext();
+
+    // With no stored protocols the optional class existential is a single
+    // retainable pointer, so its `.none == null` optional is lowered to `ptr`;
+    // keep the reference word as a pointer. With witness tables the optional
+    // uses the word-chunked integer payload representation.
+    if (getNumStoredProtocols() == 0) {
+      Out.add(part);
+      return;
+    }
+
     Out.add(IGF.Builder.CreatePtrToInt(part, IGF.IGM.IntPtrTy));
 
     for (unsigned i = 0; i != getNumStoredProtocols(); ++i) {

--- a/lib/IRGen/HeapTypeInfo.h
+++ b/lib/IRGen/HeapTypeInfo.h
@@ -59,11 +59,6 @@ class HeapTypeInfo
     : public SingleScalarTypeInfoWithTypeLayout<Impl, ReferenceTypeInfo> {
   using super = SingleScalarTypeInfoWithTypeLayout<Impl, ReferenceTypeInfo>;
 
-  llvm::Type *getOptionalIntType() const {
-    return llvm::IntegerType::get(this->getStorageType()->getContext(),
-                                  this->getFixedSize().getValueInBits());
-  }
-
 protected:
   using super::asDerived;
 public:
@@ -152,39 +147,29 @@ public:
     llvm::Value *value = IGF.emit##Name##LoadStrong(src, \
                                           this->getStorageType(), \
                                           asDerived().getReferenceCounting()); \
-    if (isOptional) { \
-      out.add(IGF.Builder.CreatePtrToInt(value, getOptionalIntType())); \
-    } else { \
-      out.add(value); \
-    } \
+    /* A loadable optional reference is a nullable pointer (.none == null), */ \
+    /* so its representation is the pointer itself. */ \
+    (void)isOptional; \
+    out.add(value); \
   } \
   void name##TakeStrong(IRGenFunction &IGF, Address src, \
                          Explosion &out, bool isOptional) const override { \
     llvm::Value *value = IGF.emit##Name##TakeStrong(src, \
                                           this->getStorageType(), \
                                           asDerived().getReferenceCounting()); \
-    if (isOptional) { \
-      out.add(IGF.Builder.CreatePtrToInt(value, getOptionalIntType())); \
-    } else { \
-      out.add(value); \
-    } \
+    (void)isOptional; \
+    out.add(value); \
   } \
   void name##Init(IRGenFunction &IGF, Explosion &in, \
                   Address dest, bool isOptional) const override { \
     llvm::Value *value = in.claimNext(); \
-    if (isOptional) { \
-      assert(value->getType() == getOptionalIntType()); \
-      value = IGF.Builder.CreateIntToPtr(value, this->getStorageType()); \
-    } \
+    (void)isOptional; \
     IGF.emit##Name##Init(value, dest, asDerived().getReferenceCounting()); \
   } \
   void name##Assign(IRGenFunction &IGF, Explosion &in, \
                     Address dest, bool isOptional) const override { \
     llvm::Value *value = in.claimNext(); \
-    if (isOptional) { \
-      assert(value->getType() == getOptionalIntType()); \
-      value = IGF.Builder.CreateIntToPtr(value, this->getStorageType()); \
-    } \
+    (void)isOptional; \
     IGF.emit##Name##Assign(value, dest, asDerived().getReferenceCounting()); \
   }
 #define ALWAYS_LOADABLE_CHECKED_REF_STORAGE_HELPER(Name, name)                 \

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -6494,9 +6494,14 @@ IRGenSILFunction::visitDereferenceBorrowAddrInst(DereferenceBorrowAddrInst *i) {
     /* Semantically we are just passing through the input parameter but as a   \
      */                                                                        \
     /* strong reference... at LLVM IR level these type differences don't */    \
-    /* matter. So just set the lowered explosion appropriately. */             \
+    /* matter. A loadable optional reference that lowers to a nullable */      \
+    /* pointer already matches the referent, so it can be forwarded as-is. */  \
+    /* An optional with a multi-word payload (e.g. a class existential with */ \
+    /* witness tables) still uses the word-chunked integer enum payload, so */ \
+    /* convert the pointer words back to integers to match it. */              \
     Explosion output = getLoweredExplosion(i->getOperand());                   \
-    if (isOptional) {                                                          \
+    if (isOptional && !ti.isSingleRetainablePointer(                           \
+                          ResilienceExpansion::Maximal, nullptr)) {            \
       auto values = output.claimAll();                                         \
       output.reset();                                                          \
       for (auto value : values) {                                              \
@@ -6522,9 +6527,14 @@ IRGenSILFunction::visitDereferenceBorrowAddrInst(DereferenceBorrowAddrInst *i) {
     /* Semantically we are just passing through the input parameter but as a   \
      */                                                                        \
     /* strong reference... at LLVM IR level these type differences don't */    \
-    /* matter. So just set the lowered explosion appropriately. */             \
+    /* matter. A loadable optional reference that lowers to a nullable */      \
+    /* pointer already matches the referent, so it can be forwarded as-is. */  \
+    /* An optional with a multi-word payload (e.g. a class existential with */ \
+    /* witness tables) still uses the word-chunked integer enum payload, so */ \
+    /* convert the pointer words back to integers to match it. */              \
     Explosion output = getLoweredExplosion(i->getOperand());                   \
-    if (isOptional) {                                                          \
+    if (isOptional && !ti.isSingleRetainablePointer(                           \
+                          ResilienceExpansion::Maximal, nullptr)) {            \
       auto values = output.claimAll();                                         \
       output.reset();                                                          \
       for (auto value : values) {                                              \

--- a/test/DebugInfo/iuo_arg.swift
+++ b/test/DebugInfo/iuo_arg.swift
@@ -18,7 +18,7 @@ class MyClass {
 	{
     // Test that image is in an alloca, but not an indirect location.
     // CHECK: #dbg_declare(ptr %[[ALLOCA:.*]], ![[IMAGE:.*]], !DIExpression()
-    // CHECK: store {{(i32|i64)}} %0, ptr %[[ALLOCA]], align
+    // CHECK: store ptr %0, ptr %[[ALLOCA]], align
     // CHECK: ![[IMAGE]] = !DILocalVariable(name: "image", arg: 1
     // CHECK-NOT:                           flags:
     // CHECK-SAME:                          line: [[@LINE-7]]

--- a/test/DebugInfo/returnlocation.swift
+++ b/test/DebugInfo/returnlocation.swift
@@ -185,7 +185,7 @@ public class Class1 {
     print("hello")
     // CHECK_INIT: call {{.*}}@"$ss5print_9separator10terminatoryypd_S2StF"{{.*}}, !dbg ![[PRINTLOC:[0-9]+]]
     // FIXME: ret has an incorrect line number because it is generated with "isHiddenFromDebugInfo"
-    // CHECK_INIT: ret i{{32|64}} 0, !dbg ![[LINE_0:[0-9]+]]
+    // CHECK_INIT: ret ptr null, !dbg ![[LINE_0:[0-9]+]]
     // CHECK_INIT-DAG: [[PRINTLOC]] = !DILocation(line: [[@LINE-4]]
     // CHECK_INIT-DAG: [[LINE_0]] = !DILocation(line: 0
     return nil

--- a/test/Distributed/distributed_actor_accessor_thunks_64bit.swift
+++ b/test/Distributed/distributed_actor_accessor_thunks_64bit.swift
@@ -253,7 +253,7 @@ public distributed actor MyOtherActor {
 // CHECK: [[ARG_0_SIZE:%.*]] = and i64 {{.*}}, -16
 // CHECK-NEXT: [[ARG_0_BUF:%.*]] = call swiftcc ptr @swift_task_alloc(i64 [[ARG_0_SIZE]])
 
-// CHECK: [[NATIVE_ENUM_VAL:%.*]] = load i64, ptr [[ARG_0_BUF]]
+// CHECK: [[NATIVE_ENUM_VAL:%.*]] = load ptr, ptr [[ARG_0_BUF]]
 
 // CHECK: [[ARG_1_SIZE:%.*]] = and i64 {{.*}}, -16
 // CHECK-NEXT: [[ARG_1_BUF:%.*]] = call swiftcc ptr @swift_task_alloc(i64 [[ARG_1_SIZE]])
@@ -263,12 +263,12 @@ public distributed actor MyOtherActor {
 
 /// Call distributed thunk with extracted arguments.
 
-// CHECK: [[THUNK_RESULT:%.*]] = call { ptr, i64, ptr } (i32, ptr, ptr, ...) @llvm.coro.suspend.async.sl_p0i64p0s({{.*}}, ptr {{.*}}, i64 [[NATIVE_ENUM_VAL]], i64 [[NATIVE_INT_VAL]], ptr {{.*}})
-// CHECK-NEXT: [[TASK_REF:%.*]] = extractvalue { ptr, i64, ptr } [[THUNK_RESULT]], 0
+// CHECK: [[THUNK_RESULT:%.*]] = call { ptr, ptr, ptr } (i32, ptr, ptr, ...) @llvm.coro.suspend.async.sl_p0p0p0s({{.*}}, ptr {{.*}}, ptr [[NATIVE_ENUM_VAL]], i64 [[NATIVE_INT_VAL]], ptr {{.*}})
+// CHECK-NEXT: [[TASK_REF:%.*]] = extractvalue { ptr, ptr, ptr } [[THUNK_RESULT]], 0
 // CHECK-NEXT: [[CALLER_ASYNC_CTXT:%.*]] = load ptr, ptr [[TASK_REF]]
 // CHECK-NEXT:  store ptr [[CALLER_ASYNC_CTXT]], ptr
-// CHECK: [[ENUM_RESULT:%.*]] = extractvalue { ptr, i64, ptr } [[THUNK_RESULT]], 1
-// CHECK: store i64 [[ENUM_RESULT]], ptr [[RESULT_BUFF]]
+// CHECK: [[ENUM_RESULT:%.*]] = extractvalue { ptr, ptr, ptr } [[THUNK_RESULT]], 1
+// CHECK: store ptr [[ENUM_RESULT]], ptr [[RESULT_BUFF]]
 
 // CHECK: {{.*}} = call i1 (ptr, i1, ...) @llvm.coro.end.async({{.*}}, ptr {{.*}}, ptr {{.*}})
 

--- a/test/IRGen/autorelease.sil
+++ b/test/IRGen/autorelease.sil
@@ -20,11 +20,9 @@ bb0(%0 : @owned $C?):
   return %0 : $C?
 }
 
-// CHECK:      define{{( dllexport| protected)?}} swiftcc [[INT]] @foo([[INT]] %0) {{.*}} {
-// CHECK:        [[T0:%.*]] = inttoptr [[INT]] %0 to ptr
-// CHECK-NEXT:   [[T1:%.*]] = tail call ptr @llvm.objc.autoreleaseReturnValue(ptr [[T0]])
-// CHECK-NEXT:   [[T2:%.*]] = ptrtoint ptr [[T1]] to [[INT]]
-// CHECK-NEXT:   ret [[INT]] [[T2]]
+// CHECK:      define{{( dllexport| protected)?}} swiftcc ptr @foo(ptr %0) {{.*}} {
+// CHECK:        [[T1:%.*]] = tail call ptr @llvm.objc.autoreleaseReturnValue(ptr %0)
+// CHECK-NEXT:   ret ptr [[T1]]
 
 sil [ossa] @bar : $@convention(thin) (@owned C?) -> @owned C? {
 bb0(%0 : @owned $C?):
@@ -33,65 +31,49 @@ bb0(%0 : @owned $C?):
   return %2 : $C?
 }
 
-// x86_64:    define{{( dllexport| protected)?}} swiftcc i64 @bar(i64 %0)
-// x86_64:      [[T0:%.*]] = call swiftcc i64 @foo(i64 %0)
-// x86_64-NEXT: [[T1:%.*]] = inttoptr i64 [[T0]] to ptr
-// x86_64-NEXT: [[T2:%.*]] = notail call ptr @llvm.objc.retainAutoreleasedReturnValue(ptr [[T1]])
-// x86_64-NEXT: [[T3:%.*]] = ptrtoint ptr [[T2]] to i64
-// x86_64-NEXT: ret i64 [[T3]]
+// x86_64:    define{{( dllexport| protected)?}} swiftcc ptr @bar(ptr %0)
+// x86_64:      [[T0:%.*]] = call swiftcc ptr @foo(ptr %0)
+// x86_64-NEXT: [[T2:%.*]] = notail call ptr @llvm.objc.retainAutoreleasedReturnValue(ptr [[T0]])
+// x86_64-NEXT: ret ptr [[T2]]
 
-// arm64:    define{{( dllexport| protected)?}} swiftcc i64 @bar(i64 %0)
-// arm64:      [[T0:%.*]] = call swiftcc i64 @foo(i64 %0)
+// arm64:    define{{( dllexport| protected)?}} swiftcc ptr @bar(ptr %0)
+// arm64:      [[T0:%.*]] = call swiftcc ptr @foo(ptr %0)
 // arm64-NEXT: call void asm sideeffect "mov
-// arm64-NEXT: [[T1:%.*]] = inttoptr i64 [[T0]] to ptr
-// arm64-NEXT: [[T2:%.*]] = call ptr @llvm.objc.retainAutoreleasedReturnValue(ptr [[T1]])
-// arm64-NEXT: [[T3:%.*]] = ptrtoint ptr [[T2]] to i64
-// arm64-NEXT: ret i64 [[T3]]
+// arm64-NEXT: [[T2:%.*]] = call ptr @llvm.objc.retainAutoreleasedReturnValue(ptr [[T0]])
+// arm64-NEXT: ret ptr [[T2]]
 
-// arm64e:    define{{( dllexport| protected)?}} swiftcc i64 @bar(i64 %0)
-// arm64e:      [[T0:%.*]] = call swiftcc i64 @foo(i64 %0)
+// arm64e:    define{{( dllexport| protected)?}} swiftcc ptr @bar(ptr %0)
+// arm64e:      [[T0:%.*]] = call swiftcc ptr @foo(ptr %0)
 // arm64e-NEXT: call void asm sideeffect "mov
-// arm64e-NEXT: [[T1:%.*]] = inttoptr i64 [[T0]] to ptr
-// arm64e-NEXT: [[T2:%.*]] = call ptr @llvm.objc.retainAutoreleasedReturnValue(ptr [[T1]])
-// arm64e-NEXT: [[T3:%.*]] = ptrtoint ptr [[T2]] to i64
-// arm64e-NEXT: ret i64 [[T3]]
+// arm64e-NEXT: [[T2:%.*]] = call ptr @llvm.objc.retainAutoreleasedReturnValue(ptr [[T0]])
+// arm64e-NEXT: ret ptr [[T2]]
 
-// aarch64:    define{{( dllexport| protected)?}} swiftcc i64 @bar(i64 %0)
-// aarch64:      [[T0:%.*]] = call swiftcc i64 @foo(i64 %0)
+// aarch64:    define{{( dllexport| protected)?}} swiftcc ptr @bar(ptr %0)
+// aarch64:      [[T0:%.*]] = call swiftcc ptr @foo(ptr %0)
 // aarch64-NEXT: call void asm sideeffect "mov
-// aarch64-NEXT: [[T1:%.*]] = inttoptr i64 [[T0]] to ptr
-// aarch64-NEXT: [[T2:%.*]] = call ptr @llvm.objc.retainAutoreleasedReturnValue(ptr [[T1]])
-// aarch64-NEXT: [[T3:%.*]] = ptrtoint ptr [[T2]] to i64
-// aarch64-NEXT: ret i64 [[T3]]
+// aarch64-NEXT: [[T2:%.*]] = call ptr @llvm.objc.retainAutoreleasedReturnValue(ptr [[T0]])
+// aarch64-NEXT: ret ptr [[T2]]
 
-// i386:    define{{( dllexport| protected)?}} swiftcc i32 @bar(i32 %0)
-// i386:      [[T0:%.*]] = call swiftcc i32 @foo(i32 %0)
-// i386-NEXT: [[T1:%.*]] = inttoptr i32 [[T0]] to ptr
-// i386-NEXT: [[T2:%.*]] = call ptr @llvm.objc.retainAutoreleasedReturnValue(ptr [[T1]])
-// i386-NEXT: [[T3:%.*]] = ptrtoint ptr [[T2]] to i32
-// i386-NEXT: ret i32 [[T3]]
+// i386:    define{{( dllexport| protected)?}} swiftcc ptr @bar(ptr %0)
+// i386:      [[T0:%.*]] = call swiftcc ptr @foo(ptr %0)
+// i386-NEXT: [[T2:%.*]] = call ptr @llvm.objc.retainAutoreleasedReturnValue(ptr [[T0]])
+// i386-NEXT: ret ptr [[T2]]
 
-// armv7:    define{{( dllexport| protected)?}} swiftcc i32 @bar(i32 %0)
-// armv7:      [[T0:%.*]] = call swiftcc i32 @foo(i32 %0)
+// armv7:    define{{( dllexport| protected)?}} swiftcc ptr @bar(ptr %0)
+// armv7:      [[T0:%.*]] = call swiftcc ptr @foo(ptr %0)
 // armv7-NEXT: call void asm sideeffect "mov
-// armv7-NEXT: [[T1:%.*]] = inttoptr i32 [[T0]] to ptr
-// armv7-NEXT: [[T2:%.*]] = call ptr @llvm.objc.retainAutoreleasedReturnValue(ptr [[T1]])
-// armv7-NEXT: [[T3:%.*]] = ptrtoint ptr [[T2]] to i32
-// armv7-NEXT: ret i32 [[T3]]
+// armv7-NEXT: [[T2:%.*]] = call ptr @llvm.objc.retainAutoreleasedReturnValue(ptr [[T0]])
+// armv7-NEXT: ret ptr [[T2]]
 
-// armv7s:    define{{( dllexport| protected)?}} swiftcc i32 @bar(i32 %0)
-// armv7s:      [[T0:%.*]] = call swiftcc i32 @foo(i32 %0)
+// armv7s:    define{{( dllexport| protected)?}} swiftcc ptr @bar(ptr %0)
+// armv7s:      [[T0:%.*]] = call swiftcc ptr @foo(ptr %0)
 // armv7s-NEXT: call void asm sideeffect "mov
-// armv7s-NEXT: [[T1:%.*]] = inttoptr i32 [[T0]] to ptr
-// armv7s-NEXT: [[T2:%.*]] = call ptr @llvm.objc.retainAutoreleasedReturnValue(ptr [[T1]])
-// armv7s-NEXT: [[T3:%.*]] = ptrtoint ptr [[T2]] to i32
-// armv7s-NEXT: ret i32 [[T3]]
+// armv7s-NEXT: [[T2:%.*]] = call ptr @llvm.objc.retainAutoreleasedReturnValue(ptr [[T0]])
+// armv7s-NEXT: ret ptr [[T2]]
 
-// armv7k:    define{{( dllexport| protected)?}} swiftcc i32 @bar(i32 %0)
-// armv7k:      [[T0:%.*]] = call swiftcc i32 @foo(i32 %0)
+// armv7k:    define{{( dllexport| protected)?}} swiftcc ptr @bar(ptr %0)
+// armv7k:      [[T0:%.*]] = call swiftcc ptr @foo(ptr %0)
 // armv7k-NEXT: call void asm sideeffect "mov
-// armv7k-NEXT: [[T1:%.*]] = inttoptr i32 [[T0]] to ptr
-// armv7k-NEXT: [[T2:%.*]] = call ptr @llvm.objc.retainAutoreleasedReturnValue(ptr [[T1]])
-// armv7k-NEXT: [[T3:%.*]] = ptrtoint ptr [[T2]] to i32
-// armv7k-NEXT: ret i32 [[T3]]
+// armv7k-NEXT: [[T2:%.*]] = call ptr @llvm.objc.retainAutoreleasedReturnValue(ptr [[T0]])
+// armv7k-NEXT: ret ptr [[T2]]
 

--- a/test/IRGen/bitcast.sil
+++ b/test/IRGen/bitcast.sil
@@ -50,16 +50,14 @@ entry(%c : $Optional<Int>):
   return %i : $Optional<Int>
 }
 
-// CHECK-i386-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @bitcast_ref(ptr %0) {{.*}} {
+// CHECK-i386-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @bitcast_ref(ptr %0) {{.*}} {
 // CHECK-i386-NEXT:  entry:
-// CHECK-i386-NEXT:    [[VALUE:%.*]] = ptrtoint ptr %0 to i32
-// CHECK-i386-NEXT:    ret i32 [[VALUE]]
+// CHECK-i386-NEXT:    ret ptr %0
 // CHECK-i386-NEXT:  }
 
-// CHECK-x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i64 @bitcast_ref(ptr %0) {{.*}} {
+// CHECK-x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @bitcast_ref(ptr %0) {{.*}} {
 // CHECK-x86_64-NEXT:  entry:
-// CHECK-x86_64-NEXT:    [[VALUE:%.*]] = ptrtoint ptr %0 to i64
-// CHECK-x86_64-NEXT:    ret i64 [[VALUE]]
+// CHECK-x86_64-NEXT:    ret ptr %0
 // CHECK-x86_64-NEXT:  }
 sil @bitcast_ref: $@convention(thin) (C) -> Optional<C> {
 entry(%c : $C):
@@ -67,14 +65,14 @@ entry(%c : $C):
   return %o : $Optional<C>
 }
 
-// CHECK-i386-LABEL:  define hidden swiftcc i32 @bitcast_ref_optional(i32 %0) {{.*}} {
+// CHECK-i386-LABEL:  define hidden swiftcc ptr @bitcast_ref_optional(ptr %0) {{.*}} {
 // CHECK-i386-NEXT: entry:
-// CHECK-i386-NEXT: ret i32 %0
+// CHECK-i386-NEXT: ret ptr %0
 // CHECK-i386-NEXT: }
 
-// CHECK-x86_64-LABEL:  define hidden swiftcc i64 @bitcast_ref_optional(i64 %0) {{.*}} {
+// CHECK-x86_64-LABEL:  define hidden swiftcc ptr @bitcast_ref_optional(ptr %0) {{.*}} {
 // CHECK-x86_64-NEXT: entry:
-// CHECK-x86_64-NEXT: ret i64 %0
+// CHECK-x86_64-NEXT: ret ptr %0
 // CHECK-x86_64-NEXT: }
 sil hidden @bitcast_ref_optional : $@convention(thin) (@owned Optional<C>) -> @owned Optional<C> {
 bb0(%0 : $Optional<C>):
@@ -124,48 +122,46 @@ bb0(%0 : $*U, %1 : $*T):
   return %r : $()
 }
 
-// CHECK-i386-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @unchecked_ref_cast_class_optional
-// CHECK-i386: ptrtoint ptr %0 to i32
-// CHECK-i386-NEXT: ret i32
+// CHECK-i386-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @unchecked_ref_cast_class_optional
+// CHECK-i386: ret ptr %0
 
-// CHECK-x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i64 @unchecked_ref_cast_class_optional
-// CHECK-x86_64: ptrtoint ptr %0 to i64
-// CHECK-x86_64-NEXT: ret i64
+// CHECK-x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @unchecked_ref_cast_class_optional
+// CHECK-x86_64: ret ptr %0
 sil @unchecked_ref_cast_class_optional : $@convention(thin) (@owned A) -> @owned Optional<AnyObject> {
 bb0(%0 : $A):
   %2 = unchecked_ref_cast %0 : $A to $Optional<AnyObject>
   return %2 : $Optional<AnyObject>
 }
 
-// CHECK-i386-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @unchecked_ref_cast_optional_optional
-// CHECK-i386: ret i32 %0
+// CHECK-i386-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @unchecked_ref_cast_optional_optional
+// CHECK-i386: ret ptr %0
 
-// CHECK-x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i64 @unchecked_ref_cast_optional_optional
-// CHECK-x86_64: ret i64 %0
+// CHECK-x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @unchecked_ref_cast_optional_optional
+// CHECK-x86_64: ret ptr %0
 sil @unchecked_ref_cast_optional_optional : $@convention(thin) (@owned Optional<A>) -> @owned Optional<AnyObject> {
 bb0(%0 : $Optional<A>):
   %2 = unchecked_ref_cast %0 : $Optional<A> to $Optional<AnyObject>
   return %2 : $Optional<AnyObject>
 }
 
-// CHECK-i386-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @unchecked_ref_cast_proto_optional
-// CHECK-i386: ptrtoint ptr %0 to i32
-// CHECK-i386-NEXT: ret i32
+// CHECK-i386-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @unchecked_ref_cast_proto_optional
+// CHECK-i386: ret ptr %0
 
-// CHECK-x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i64 @unchecked_ref_cast_proto_optional
-// CHECK-x86_64: ptrtoint ptr %0 to i64
-// CHECK-x86_64-NEXT: ret i64
+// CHECK-x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @unchecked_ref_cast_proto_optional
+// CHECK-x86_64: ret ptr %0
 sil @unchecked_ref_cast_proto_optional : $@convention(thin) (@owned CP) -> @owned Optional<AnyObject> {
 bb0(%0 : $CP):
   %2 = unchecked_ref_cast %0 : $CP to $Optional<AnyObject>
   return %2 : $Optional<AnyObject>
 }
 
-// CHECK-i386-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @unchecked_ref_cast_optionalproto_optional
-// CHECK-i386: ret i32 %0
+// CHECK-i386-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @unchecked_ref_cast_optionalproto_optional
+// CHECK-i386: [[VALUE:%.*]] = inttoptr i32 %0 to ptr
+// CHECK-i386: ret ptr [[VALUE]]
 
-// CHECK-x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i64 @unchecked_ref_cast_optionalproto_optional
-// CHECK-x86_64: ret i64 %0
+// CHECK-x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @unchecked_ref_cast_optionalproto_optional
+// CHECK-x86_64: [[VALUE:%.*]] = inttoptr i64 %0 to ptr
+// CHECK-x86_64: ret ptr [[VALUE]]
 sil @unchecked_ref_cast_optionalproto_optional : $@convention(thin) (@owned Optional<CP>) -> @owned Optional<AnyObject> {
 bb0(%0 : $Optional<CP>):
   %2 = unchecked_ref_cast %0 : $Optional<CP> to $Optional<AnyObject>

--- a/test/IRGen/casts.sil
+++ b/test/IRGen/casts.sil
@@ -133,18 +133,17 @@ entry(%0 : $A):
   return %1
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @unconditional_optional_fast_class_cast(i64 %0)
-// CHECK:         [[PTR:%.*]] = inttoptr i64 %0 to ptr
-// CHECK:         [[ISNULL:%.*]] = icmp eq ptr [[PTR]], null
-// CHECK:         [[ENN:%.*]] = call i1 @llvm.expect.i1(i1 [[ISNULL]], i1 false) 
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @unconditional_optional_fast_class_cast(ptr %0)
+// CHECK:         [[ISNULL:%.*]] = icmp eq ptr %0, null
+// CHECK:         [[ENN:%.*]] = call i1 @llvm.expect.i1(i1 [[ISNULL]], i1 false)
 // CHECK:         br i1 [[ENN]], label %[[NULLTRAPBB:[0-9]*]], label %[[CONTBB:[0-9]*]]
 // CHECK:       [[CONTBB]]:
-// CHECK:         [[ISA:%.*]] = load ptr, ptr [[PTR]]
+// CHECK:         [[ISA:%.*]] = load ptr, ptr %0
 // CHECK:         [[NE:%.*]] = icmp ne {{.*}}, [[ISA]]
-// CHECK:         [[E:%.*]] = call i1 @llvm.expect.i1(i1 [[NE]], i1 false) 
+// CHECK:         [[E:%.*]] = call i1 @llvm.expect.i1(i1 [[NE]], i1 false)
 // CHECK:         br i1 [[E]], label %[[TRAPBB:[0-9]*]], label %[[RETBB:[0-9]*]]
 // CHECK:       [[RETBB]]:
-// CHECK-NEXT:    ret ptr [[PTR]]
+// CHECK-NEXT:    ret ptr %0
 // CHECK:       [[NULLTRAPBB]]:
 // CHECK-NEXT:    call void @llvm.trap()
 // CHECK:       [[TRAPBB]]:
@@ -254,11 +253,10 @@ nay:
   unreachable
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @checked_downcast_optional({{(i32|i64)}} %0) {{.*}} {
-// CHECK:         [[T0:%.*]] = inttoptr {{(i32|i64)}} %0 to ptr
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @checked_downcast_optional(ptr %0) {{.*}} {
 // CHECK:         [[T1:%.*]] = call swiftcc %swift.metadata_response @"$s5casts1ACMa"([[INT]] 0)
 // CHECK:         [[METADATA:%.*]] = extractvalue %swift.metadata_response [[T1]], 0
-// CHECK:         [[RESULT_PTR:%.*]] = call ptr @swift_dynamicCastClass(ptr [[T0]], ptr [[METADATA]])
+// CHECK:         [[RESULT_PTR:%.*]] = call ptr @swift_dynamicCastClass(ptr %0, ptr [[METADATA]])
 // CHECK:         [[COND:%.*]] = icmp ne ptr [[RESULT_PTR]], null
 // CHECK:         br i1 [[COND]]
 sil @checked_downcast_optional : $@convention(thin) (Optional<A>) -> @owned A {
@@ -302,13 +300,12 @@ nay:
   unreachable
 }
 
-// CHECK: define {{(dllexport )?}}{{(protected )?}}swiftcc {{.*}} @checked_downcast_optional_class_to_ex([[INT]] %0)
+// CHECK: define {{(dllexport )?}}{{(protected )?}}swiftcc {{.*}} @checked_downcast_optional_class_to_ex(ptr %0)
 // CHECK: entry:
-// CHECK:   [[V1:%.*]] = inttoptr [[INT]] %0 to ptr
-// CHECK:   [[V2:%.*]] = icmp ne ptr [[V1]], null
+// CHECK:   [[V2:%.*]] = icmp ne ptr %0, null
 // CHECK:   br i1 [[V2]], label %[[LBL:.*]], label
 // CHECK:    [[LBL]]:
-// CHECK:    load ptr, ptr [[V1]]
+// CHECK:    load ptr, ptr %0
 sil @checked_downcast_optional_class_to_ex : $@convention(thin) (@guaranteed Optional<A>) -> @owned Optional<CP> {
 bb0(%0 : $Optional<A>):
   checked_cast_br Optional<A> in %0 : $Optional<A> to CP, bb1, bb2

--- a/test/IRGen/class.sil
+++ b/test/IRGen/class.sil
@@ -105,10 +105,9 @@ entry(%c : $C):
   return %c : $C
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i64 @autorelease_optional(i64 %0) {{.*}} {
-// CHECK:         %1 = inttoptr i64 %0 to ptr
-// CHECK:         call ptr @llvm.objc.autorelease(ptr %1)
-// CHECK:         ret i64 %0
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @autorelease_optional(ptr %0) {{.*}} {
+// CHECK:         call ptr @llvm.objc.autorelease(ptr %0)
+// CHECK:         ret ptr %0
 sil @autorelease_optional : $@convention(thin) (@owned C?) -> C? {
 entry(%c : $C?):
   autorelease_value %c : $C?

--- a/test/IRGen/dynamic_self_cast.swift
+++ b/test/IRGen/dynamic_self_cast.swift
@@ -42,21 +42,21 @@ public class SelfCasts {
     return s as! T
   }
 
-  // CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc {{i32|i64}} @"$s17dynamic_self_cast9SelfCastsC02toD11ConditionalyACXDSgACFZ"(ptr %0, ptr swiftself %1)
+  // CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc ptr @"$s17dynamic_self_cast9SelfCastsC02toD11ConditionalyACXDSgACFZ"(ptr %0, ptr swiftself %1)
   // CHECK: call ptr @swift_dynamicCastClass(ptr %0, ptr %1)
   // CHECK: ret
   public static func toSelfConditional(_ s: SelfCasts) -> Self? {
     return s as? Self
   }
 
-  // CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc {{i32|i64}} @"$s17dynamic_self_cast9SelfCastsC09genericToD11ConditionalyACXDSgxlFZ"(ptr noalias %0, ptr %T, ptr swiftself %1)
+  // CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc ptr @"$s17dynamic_self_cast9SelfCastsC09genericToD11ConditionalyACXDSgxlFZ"(ptr noalias %0, ptr %T, ptr swiftself %1)
   // CHECK: call zeroext i1 @swift_dynamicCast(ptr {{%.*}}, ptr {{%.*}}, ptr %T, ptr %1, {{.*}})
   // CHECK: ret
   public static func genericToSelfConditional<T>(_ s: T) -> Self? {
     return s as? Self
   }
 
-  // CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc {{i32|i64}} @"$s17dynamic_self_cast9SelfCastsC014classGenericToD11ConditionalyACXDSgxRlzClFZ"(ptr %0, ptr %T, ptr swiftself %1)
+  // CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc ptr @"$s17dynamic_self_cast9SelfCastsC014classGenericToD11ConditionalyACXDSgxRlzClFZ"(ptr %0, ptr %T, ptr swiftself %1)
   // CHECK: call ptr @swift_dynamicCastClass(ptr %0, ptr %1)
   // CHECK: ret
   public static func classGenericToSelfConditional<T : AnyObject>(_ s: T) -> Self? {
@@ -71,7 +71,7 @@ public class SelfCasts {
     return s as? T
   }
 
-  // CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc {{i32|i64}} @"$s17dynamic_self_cast9SelfCastsC016classGenericFromD11ConditionalxSgyRlzClFZ"(ptr %T, ptr swiftself %0)
+  // CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc ptr @"$s17dynamic_self_cast9SelfCastsC016classGenericFromD11ConditionalxSgyRlzClFZ"(ptr %T, ptr swiftself %0)
   // CHECK: call ptr @swift_dynamicCastUnknownClass(ptr {{%.*}}, ptr %T)
   // CHECK: ret
   public static func classGenericFromSelfConditional<T : AnyObject>() -> T? {

--- a/test/IRGen/dynamic_self_metadata.swift
+++ b/test/IRGen/dynamic_self_metadata.swift
@@ -27,17 +27,17 @@ struct G<T> : P {
 
 class C {
   class func fromMetatype() -> Self? { return nil }
-  // CHECK-LABEL: define hidden swiftcc i64 @"$s21dynamic_self_metadata1CC12fromMetatypeACXDSgyFZ"(ptr swiftself %0)
-  // CHECK: ret i64 0
+  // CHECK-LABEL: define hidden swiftcc ptr @"$s21dynamic_self_metadata1CC12fromMetatypeACXDSgyFZ"(ptr swiftself %0)
+  // CHECK: ret ptr null
 
   func fromInstance() -> Self? { return nil }
-  // CHECK-LABEL: define hidden swiftcc i64 @"$s21dynamic_self_metadata1CC12fromInstanceACXDSgyF"(ptr swiftself %0)
-  // CHECK: ret i64 0
+  // CHECK-LABEL: define hidden swiftcc ptr @"$s21dynamic_self_metadata1CC12fromInstanceACXDSgyF"(ptr swiftself %0)
+  // CHECK: ret ptr null
 
   func dynamicSelfArgument() -> Self? {
     return id(nil)
   }
-  // CHECK-LABEL: define hidden swiftcc i64 @"$s21dynamic_self_metadata1CC0A12SelfArgumentACXDSgyF"(ptr swiftself %0)
+  // CHECK-LABEL: define hidden swiftcc ptr @"$s21dynamic_self_metadata1CC0A12SelfArgumentACXDSgyF"(ptr swiftself %0)
   // CHECK: [[TYPE1:%.+]] = load {{.*}} %0
   // CHECK: [[T0:%.+]] = call swiftcc %swift.metadata_response @"$sSqMa"(i64 0, ptr [[TYPE1]])
   // CHECK: [[TYPE2:%.+]] = extractvalue %swift.metadata_response [[T0]], 0
@@ -47,7 +47,7 @@ class C {
     _ = G(t: self).f()
     return nil
   }
-  // CHECK-LABEL: define hidden swiftcc i64 @"$s21dynamic_self_metadata1CC0A18SelfConformingTypeACXDSgyF"(ptr swiftself %0)
+  // CHECK-LABEL: define hidden swiftcc ptr @"$s21dynamic_self_metadata1CC0A18SelfConformingTypeACXDSgyF"(ptr swiftself %0)
   // CHECK: [[SELF_TYPE:%.+]] = load {{.*}} %0
   // CHECK: [[METADATA_RESPONSE:%.*]] = call swiftcc %swift.metadata_response @"$s21dynamic_self_metadata1GVMa"(i64 0, ptr [[SELF_TYPE]])
   // CHECK: [[METADATA:%.*]] =  extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0

--- a/test/IRGen/dynamic_self_metadata_future.swift
+++ b/test/IRGen/dynamic_self_metadata_future.swift
@@ -28,17 +28,17 @@ struct G<T> : P {
 
 class C {
   class func fromMetatype() -> Self? { return nil }
-  // CHECK-LABEL: define hidden swiftcc i64 @"$s28dynamic_self_metadata_future1CC12fromMetatypeACXDSgyFZ"(ptr swiftself %0)
-  // CHECK: ret i64 0
+  // CHECK-LABEL: define hidden swiftcc ptr @"$s28dynamic_self_metadata_future1CC12fromMetatypeACXDSgyFZ"(ptr swiftself %0)
+  // CHECK: ret ptr null
 
   func fromInstance() -> Self? { return nil }
-  // CHECK-LABEL: define hidden swiftcc i64 @"$s28dynamic_self_metadata_future1CC12fromInstanceACXDSgyF"(ptr swiftself %0)
-  // CHECK: ret i64 0
+  // CHECK-LABEL: define hidden swiftcc ptr @"$s28dynamic_self_metadata_future1CC12fromInstanceACXDSgyF"(ptr swiftself %0)
+  // CHECK: ret ptr null
 
   func dynamicSelfArgument() -> Self? {
     return id(nil)
   }
-  // CHECK-LABEL: define hidden swiftcc i64 @"$s28dynamic_self_metadata_future1CC0A12SelfArgumentACXDSgyF"(ptr swiftself %0)
+  // CHECK-LABEL: define hidden swiftcc ptr @"$s28dynamic_self_metadata_future1CC0A12SelfArgumentACXDSgyF"(ptr swiftself %0)
   // CHECK: [[TYPE1:%.+]] = load {{.*}} %0
   // CHECK: [[T0:%.+]] = call swiftcc %swift.metadata_response @"$sSqMa"(i64 0, ptr [[TYPE1]])
   // CHECK: [[TYPE2:%.+]] = extractvalue %swift.metadata_response [[T0]], 0
@@ -48,7 +48,7 @@ class C {
     _ = G(t: self).f()
     return nil
   }
-  // CHECK-LABEL: define hidden swiftcc i64 @"$s28dynamic_self_metadata_future1CC0A18SelfConformingTypeACXDSgyF"(ptr swiftself %0)
+  // CHECK-LABEL: define hidden swiftcc ptr @"$s28dynamic_self_metadata_future1CC0A18SelfConformingTypeACXDSgyF"(ptr swiftself %0)
   // CHECK: [[SELF_TYPE:%.+]] = load {{.*}} %0
   // CHECK: call ptr @swift_getWitnessTable(
   // CHECK-SAME:   ptr  @"$s28dynamic_self_metadata_future1GVyxGAA1PAAMc"

--- a/test/IRGen/enum_32_bit.sil
+++ b/test/IRGen/enum_32_bit.sil
@@ -34,13 +34,13 @@ enum Bas {
   case Z
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @foo(i32 %0)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @foo(ptr %0)
 sil @foo : $@convention(thin) (@owned Foo) -> () {
 entry(%0 : $Foo):
   return undef : $()
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @bar(i32 %0)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @bar(ptr %0)
 sil @bar : $@convention(thin) (@owned Bar) -> () {
 entry(%0 : $Bar):
   return undef : $()

--- a/test/IRGen/newtype.swift
+++ b/test/IRGen/newtype.swift
@@ -119,13 +119,9 @@ public func anchor() -> Bool {
 
 class ObjCTest {
   // CHECK-LABEL: define internal ptr @"$s7newtype8ObjCTestC19optionalPassThroughySo14SNTErrorDomainaSgAGFTo"
-  // CHECK: [[CASTED:%.+]] = ptrtoint ptr %2 to [[INT]]
-  // CHECK: [[RESULT:%.+]] = call swiftcc [[INT]] @"$s7newtype8ObjCTestC19optionalPassThroughySo14SNTErrorDomainaSgAGF"([[INT]] [[CASTED]], ptr swiftself {{%.+}})
-  // CHECK: [[CAST_RESULT:%.+]] = inttoptr [[INT]] [[RESULT]] to ptr
-  // CHECK: [[AUTORELEASE_RESULT:%.+]] = {{(tail )?}}call ptr @llvm.objc.autoreleaseReturnValue(ptr [[CAST_RESULT]])
-  // CHECK: [[CAST_AUTORELEASE_RESULT:%.+]] = ptrtoint ptr [[AUTORELEASE_RESULT]] to [[INT]]
-  // CHECK: [[OPAQUE_RESULT:%.+]] = inttoptr [[INT]] [[CAST_AUTORELEASE_RESULT]] to ptr
-  // CHECK: ret ptr [[OPAQUE_RESULT]]
+  // CHECK: [[RESULT:%.+]] = call swiftcc ptr @"$s7newtype8ObjCTestC19optionalPassThroughySo14SNTErrorDomainaSgAGF"(ptr {{%.+}}, ptr swiftself {{%.+}})
+  // CHECK: [[AUTORELEASE_RESULT:%.+]] = {{(tail )?}}call ptr @llvm.objc.autoreleaseReturnValue(ptr [[RESULT]])
+  // CHECK: ret ptr [[AUTORELEASE_RESULT]]
   // CHECK: {{^}$}}
 
   // OPT-LABEL: define internal ptr @"$s7newtype8ObjCTestC19optionalPassThroughySo14SNTErrorDomainaSgAGFTo"

--- a/test/IRGen/objc_direct.swift
+++ b/test/IRGen/objc_direct.swift
@@ -13,9 +13,9 @@ extension Bar: BarProtocol {}
 
 let bar = Bar()
 markUsed(Bar(value: 0))
-// CHECK: call swiftcc {{i32|i64}} @"$sSo3BarC5valueABSgs5Int32V_tcfC"
+// CHECK: call swiftcc ptr @"$sSo3BarC5valueABSgs5Int32V_tcfC"
 markUsed(Bar.init(value: 0))
-// CHECK: call swiftcc {{i32|i64}} @"$sSo3BarC5valueABSgs5Int32V_tcfC"
+// CHECK: call swiftcc ptr @"$sSo3BarC5valueABSgs5Int32V_tcfC"
 
 bar.directProperty = 123
 // CHECK: call void @"\01-[Bar setDirectProperty:]"(ptr %{{[0-9]+}}, i32 {{.*}})
@@ -56,8 +56,8 @@ markUsed(Bar.directClassMethod2())
 markUsed(bar.directProtocolMethod())
 // CHECK: call {{.*}} @"\01-[Bar directProtocolMethod]"({{.*}})
 
-// CHECK: define {{.*}} swiftcc {{i32|i64}} @"$sSo3BarC5valueABSgs5Int32V_tcfC"
-// CHECK:   call swiftcc {{i32|i64}} @"$sSo3BarC5valueABSgs5Int32V_tcfcTO"
+// CHECK: define {{.*}} swiftcc ptr @"$sSo3BarC5valueABSgs5Int32V_tcfC"
+// CHECK:   call swiftcc ptr @"$sSo3BarC5valueABSgs5Int32V_tcfcTO"
 // CHECK: }
 
 // CHECK-DAG: declare i32 @"\01-[Bar directProperty]"
@@ -72,6 +72,6 @@ markUsed(bar.directProtocolMethod())
 // CHECK-DAG: declare {{.*}} @"\01+[Bar directClassMethod2]"
 // CHECK-DAG: declare {{.*}} @"\01-[Bar directProtocolMethod]"
 
-// CHECK: define {{.*}} swiftcc {{i32|i64}} @"$sSo3BarC5valueABSgs5Int32V_tcfcTO"
+// CHECK: define {{.*}} swiftcc ptr @"$sSo3BarC5valueABSgs5Int32V_tcfcTO"
 // CHECK:   call {{.*}} @"\01-[Bar initWithValue:]"
 // CHECK: }

--- a/test/IRGen/objc_implementation.swift
+++ b/test/IRGen/objc_implementation.swift
@@ -257,7 +257,7 @@ public func fn(impl: ImplClass, swiftSub: SwiftSubclass) {
 // CHECK-LABEL: define internal swifttailcc void @"$sSo9ImplClassC19objc_implementationE11asyncMethodyyYaFyyYacfU_ToTQ0_"
 
 // Make sure this function incorporates a nil check
-// CHECK: [[IS_COMPLETION_NULL:%[0-9]+]] = icmp eq i64 {{%\.reload[0-9+]}}, 0
+// CHECK: [[IS_COMPLETION_NULL:%[0-9]+]] = icmp eq ptr {{%\.reload[0-9]*}}, null
 // CHECK: br i1 [[IS_COMPLETION_NULL]], label %[[FINISH:[^,]+]], label %[[RUN_COMPLETION:[^,]+]]
 // CHECK: [[RUN_COMPLETION]]:
 

--- a/test/IRGen/optional_reference_ptr.sil
+++ b/test/IRGen/optional_reference_ptr.sil
@@ -1,0 +1,69 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s
+
+// A loadable single-level Optional of a bare retainable pointer (.none == null)
+// is lowered to `ptr` in LLVM IR, rather than a pointer-width integer.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+class C {}
+sil_vtable C {}
+
+// A single-level Optional<class> is `ptr`.
+// CHECK-LABEL: define{{.*}} swiftcc ptr @take_optional_class(ptr %0)
+sil @take_optional_class : $@convention(thin) (@guaranteed Optional<C>) -> @owned Optional<C> {
+bb0(%0 : $Optional<C>):
+  retain_value %0 : $Optional<C>
+  return %0 : $Optional<C>
+}
+
+// Optional<AnyObject> is `ptr`.
+// CHECK-LABEL: define{{.*}} swiftcc ptr @take_optional_anyobject(ptr %0)
+sil @take_optional_anyobject : $@convention(thin) (@guaranteed Optional<AnyObject>) -> @owned Optional<AnyObject> {
+bb0(%0 : $Optional<AnyObject>):
+  retain_value %0 : $Optional<AnyObject>
+  return %0 : $Optional<AnyObject>
+}
+
+// Optional<Builtin.NativeObject> is `ptr`.
+// CHECK-LABEL: define{{.*}} swiftcc ptr @take_optional_nativeobject(ptr %0)
+sil @take_optional_nativeobject : $@convention(thin) (@guaranteed Optional<Builtin.NativeObject>) -> @owned Optional<Builtin.NativeObject> {
+bb0(%0 : $Optional<Builtin.NativeObject>):
+  retain_value %0 : $Optional<Builtin.NativeObject>
+  return %0 : $Optional<Builtin.NativeObject>
+}
+
+// The empty case is exactly the null pointer.
+// CHECK-LABEL: define{{.*}} swiftcc ptr @make_none()
+// CHECK: ret ptr null
+sil @make_none : $@convention(thin) () -> @owned Optional<C> {
+bb0:
+  %0 = enum $Optional<C>, #Optional.none!enumelt
+  return %0 : $Optional<C>
+}
+
+// A switch over the optional tests the pointer directly against null.
+// CHECK-LABEL: define{{.*}} swiftcc void @switch_optional_class(ptr %0)
+// CHECK: icmp eq ptr %0, null
+sil @switch_optional_class : $@convention(thin) (@guaranteed Optional<C>) -> () {
+bb0(%0 : $Optional<C>):
+  switch_enum %0 : $Optional<C>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
+bb1(%1 : $C):
+  br bb3
+bb2:
+  br bb3
+bb3:
+  %r = tuple ()
+  return %r : $()
+}
+
+// Guard: a nested optional's outer `.none` is a *non-null* extra inhabitant, so
+// it keeps its integer representation and is unaffected by this change.
+// CHECK-LABEL: define{{.*}} swiftcc i{{[0-9]+}} @take_nested_optional(i{{[0-9]+}} %0)
+sil @take_nested_optional : $@convention(thin) (@guaranteed Optional<Optional<C>>) -> @owned Optional<Optional<C>> {
+bb0(%0 : $Optional<Optional<C>>):
+  retain_value %0 : $Optional<Optional<C>>
+  return %0 : $Optional<Optional<C>>
+}

--- a/test/IRGen/package_bypass_resilience_class.swift
+++ b/test/IRGen/package_bypass_resilience_class.swift
@@ -58,21 +58,21 @@ package class Foo {
   // CHECK-COMMON-DAG: define linkonce_odr hidden swiftcc void @"$s4Core3FooC02myB0AA3PubCSgvpACTk"
 
   // variable initialization expression of Core.Foo.myFoo
-  // CHECK-OPT-DAG: define {{(dllexport |protected )?}}swiftcc{{.*}} {{i32|i64}} @"$s4Core3FooC02myB0AA3PubCSgvpfi"() #0 {
+  // CHECK-OPT-DAG: define {{(dllexport |protected )?}}swiftcc{{.*}} ptr @"$s4Core3FooC02myB0AA3PubCSgvpfi"() #0 {
 
   // Core.Foo.myFoo.getter
-  // CHECK-RES-DAG: define hidden {{.*}}swiftcc {{i32|i64}} @"$s4Core3FooC02myB0AA3PubCSgvg"(ptr swiftself %0)
-  // CHECK-OPT-DAG: define {{(dllexport |protected )?}}swiftcc {{i32|i64}} @"$s4Core3FooC02myB0AA3PubCSgvg"(ptr swiftself %0)
+  // CHECK-RES-DAG: define hidden {{.*}}swiftcc ptr @"$s4Core3FooC02myB0AA3PubCSgvg"(ptr swiftself %0)
+  // CHECK-OPT-DAG: define {{(dllexport |protected )?}}swiftcc ptr @"$s4Core3FooC02myB0AA3PubCSgvg"(ptr swiftself %0)
 
   // merged Core.Foo.myFoo.getter
-  // CHECK-COMMON-DAG: define internal swiftcc {{i32|i64}} @"$s4Core3FooC02myB0AA3PubCSgvgTm"(ptr swiftself %0)
+  // CHECK-COMMON-DAG: define internal swiftcc ptr @"$s4Core3FooC02myB0AA3PubCSgvgTm"(ptr swiftself %0)
 
   // Core.Foo.myFoo.setter
-  // CHECK-RES-DAG: define hidden {{.*}}swiftcc void @"$s4Core3FooC02myB0AA3PubCSgvs"({{i32|i64}} %0, ptr swiftself %1) #1 {
-  // CHECK-OPT-DAG: define {{(dllexport |protected )?}}swiftcc void @"$s4Core3FooC02myB0AA3PubCSgvs"({{i32|i64}} %0, ptr swiftself %1) #1 {
+  // CHECK-RES-DAG: define hidden {{.*}}swiftcc void @"$s4Core3FooC02myB0AA3PubCSgvs"(ptr %0, ptr swiftself %1) #1 {
+  // CHECK-OPT-DAG: define {{(dllexport |protected )?}}swiftcc void @"$s4Core3FooC02myB0AA3PubCSgvs"(ptr %0, ptr swiftself %1) #1 {
 
   // merged Core.Foo.myFoo.setter
-  // CHECK-COMMON-DAG: define internal swiftcc void @"$s4Core3FooC02myB0AA3PubCSgvsTm"({{i32|i64}} %0, ptr swiftself %1)
+  // CHECK-COMMON-DAG: define internal swiftcc void @"$s4Core3FooC02myB0AA3PubCSgvsTm"(ptr %0, ptr swiftself %1)
 
   // Core.Foo.myFoo.modify
   // CHECK-RES-DAG: define hidden {{.*}}swiftcc { ptr, ptr } @"$s4Core3FooC02myB0AA3PubCSgvM"
@@ -88,10 +88,10 @@ package class Foo {
   // CHECK-COMMON-DAG: define {{(dllexport |protected )?}}swiftcc ptr @"$s4Core3FooCMu"(ptr %0, ptr %1)
 
   // dispatch thunk of Core.Foo.myFoo.getter
-  // CHECK-COMMON-DAG: define {{(dllexport |protected )?}}swiftcc {{i32|i64}} @"$s4Core3FooC02myB0AA3PubCSgvgTj"(ptr swiftself %0)
+  // CHECK-COMMON-DAG: define {{(dllexport |protected )?}}swiftcc ptr @"$s4Core3FooC02myB0AA3PubCSgvgTj"(ptr swiftself %0)
 
   // dispatch thunk of Core.Foo.myFoo.setter
-  // CHECK-COMMON-DAG: define {{(dllexport |protected )?}}swiftcc void @"$s4Core3FooC02myB0AA3PubCSgvsTj"({{i32|i64}} %0, ptr swiftself %1)
+  // CHECK-COMMON-DAG: define {{(dllexport |protected )?}}swiftcc void @"$s4Core3FooC02myB0AA3PubCSgvsTj"(ptr %0, ptr swiftself %1)
 
   // dispatch thunk of Core.Foo.myFoo.modify
   // CHECK-COMMON-DAG: define {{(dllexport |protected )?}}swiftcc { ptr, ptr } @"$s4Core3FooC02myB0AA3PubCSgvMTj"
@@ -107,9 +107,9 @@ package class Foo {
 
 final package class Bar {
   
-  // CHECK-OPT-DAG: define {{(dllexport |protected )?}}swiftcc{{.*}} {{i32|i64}} @"$s4Core3BarC02myB0AA3PubCSgvpfi"()
-  // CHECK-COMMON-DAG: define {{(dllexport |protected )?}}swiftcc {{i32|i64}} @"$s4Core3BarC02myB0AA3PubCSgvg"(ptr swiftself %0)
-  // CHECK-COMMON-DAG: define {{(dllexport |protected )?}}swiftcc void @"$s4Core3BarC02myB0AA3PubCSgvs"({{i32|i64}} %0, ptr swiftself %1)
+  // CHECK-OPT-DAG: define {{(dllexport |protected )?}}swiftcc{{.*}} ptr @"$s4Core3BarC02myB0AA3PubCSgvpfi"()
+  // CHECK-COMMON-DAG: define {{(dllexport |protected )?}}swiftcc ptr @"$s4Core3BarC02myB0AA3PubCSgvg"(ptr swiftself %0)
+  // CHECK-COMMON-DAG: define {{(dllexport |protected )?}}swiftcc void @"$s4Core3BarC02myB0AA3PubCSgvs"(ptr %0, ptr swiftself %1)
   // CHECK-COMMON-DAG: define {{(dllexport |protected )?}}swiftcc { ptr, ptr } @"$s4Core3BarC02myB0AA3PubCSgvM"
   // CHECK-COMMON-DAG: define internal swiftcc void @"$s4Core3BarC02myB0AA3PubCSgvM.resume.0"
 

--- a/test/IRGen/weak.sil
+++ b/test/IRGen/weak.sil
@@ -36,14 +36,11 @@ bb0(%0 : $*A, %1 : $Optional<C>):
   %4 = tuple ()
   return %4 : $()
 }
-// CHECK:    define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_weak_load_store(ptr dereferenceable({{.*}}) %0, i64 %1) {{.*}} {
+// CHECK:    define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_weak_load_store(ptr dereferenceable({{.*}}) %0, ptr %1) {{.*}} {
 // CHECK:      [[X:%.*]] = getelementptr inbounds{{.*}} [[A:%T4weak1AV]], ptr %0, i32 0, i32 0
 // CHECK-NEXT: [[T0:%.*]] = call ptr @swift_weakLoadStrong(ptr [[X]])
-// CHECK-NEXT: %3 = ptrtoint  ptr %2 to i64
-// CHECK-NEXT: %4 = inttoptr
-// CHECK-NEXT: call ptr @swift_weakAssign(ptr returned [[X]], ptr %4)
-// CHECK-NEXT: %6 = inttoptr i64 %3 to ptr
-// CHECK-NEXT: call void @swift_release(ptr %6)
+// CHECK-NEXT: call ptr @swift_weakAssign(ptr returned [[X]], ptr %1)
+// CHECK-NEXT: call void @swift_release(ptr [[T0]])
 // CHECK-NEXT: ret void
 
 struct B {

--- a/test/Interop/Cxx/foreign-reference/reference-counted-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/reference-counted-irgen.swift
@@ -48,20 +48,18 @@ public func getNullable(wantNullptr: Bool) -> GlobalCountNullableInit? {
     return result
 }
 
-// CHECK:      define {{.*}}swiftcc i{{.*}} @"$s4main11getNullable11wantNullptrSo011GlobalCountC4InitVSgSb_tF"(i1 %0)
+// CHECK:      define {{.*}}swiftcc ptr @"$s4main11getNullable11wantNullptrSo011GlobalCountC4InitVSgSb_tF"(i1 %0)
 // CHECK-NEXT: entry:
 // CHECK:        %1 = call ptr @{{_ZN23GlobalCountNullableInit6createEb|"\?create\@GlobalCountNullableInit\@\@SAPEAU1\@_N\@Z"}}
-// CHECK-NEXT:   %2 = ptrtoint ptr %1 to i{{.*}}
-// CHECK-NEXT:   %3 = inttoptr i{{.*}} %2 to ptr
-// CHECK-NEXT:   %4 = icmp ne ptr %3, null
-// CHECK-NEXT:   br i1 %4, label %lifetime.nonnull-value, label %lifetime.cont
+// CHECK-NEXT:   %2 = icmp ne ptr %1, null
+// CHECK-NEXT:   br i1 %2, label %lifetime.nonnull-value, label %lifetime.cont
 
 // CHECK:      lifetime.nonnull-value:
-// CHECK-NEXT:   call void @{{_Z20GCRetainNullableInitP23GlobalCountNullableInit|"\?GCRetainNullableInit\@\@YAXPEAUGlobalCountNullableInit\@\@\@Z"}}(ptr %3)
+// CHECK-NEXT:   call void @{{_Z20GCRetainNullableInitP23GlobalCountNullableInit|"\?GCRetainNullableInit\@\@YAXPEAUGlobalCountNullableInit\@\@\@Z"}}(ptr %1)
 // CHECK-NEXT:   br label %lifetime.cont
 
 // CHECK:      lifetime.cont:
-// CHECK:          ret i{{.*}} %2
+// CHECK:          ret ptr %1
 // CHECK-NEXT: }
 
 

--- a/test/embedded/dynamic-cast.swift
+++ b/test/embedded/dynamic-cast.swift
@@ -46,7 +46,7 @@ func doTryCastFromAny<T>(_ value: Any, to: T.Type) -> T? {
   value as? T
 }
 
-// IR-LABEL: define linkonce_odr hidden swiftcc {{(i32|i64)}} @"$e4main16doTryCastFromAny_2toxSgyp_xmtlFAA03SubH0C_Tt1g5"
+// IR-LABEL: define linkonce_odr hidden swiftcc ptr @"$e4main16doTryCastFromAny_2toxSgyp_xmtlFAA03SubH0C_Tt1g5"
 // IR: call zeroext i1 @swift_dynamicCast({{.*}}ptr @"$eypMf"
 
 // IR-LABEL: testAnyExistentials


### PR DESCRIPTION
rdar://144299970

A loadable `Optional<SomeClass>` (or any bare nullable reference) was lowered to `i64`, even though the empty case is just the null pointer. That only hides the pointer from LLVM and forces inttoptr/ptrtoint around every load, store, switch, and retain/release. Lower these to `ptr` with `.none` == `null`.

The gate is the existing NullableRefcounted predicate (loadable single-payload enum, one retainable-pointer payload, one empty case using extra-inhabitant #0), now factored into a helper shared by the payload schema and the copy/destroy strategy. Nested optionals (`Class??`) fall out for free.

EnumPayloadSchema gains a mode that carries explicit LLVM element types instead of a bit width, but it's used *only* for this nullable-pointer case (handing it the payload's own `ptr`); every other enum keeps the existing width-chunked integer schema. The reference-storage paths (HeapTypeInfo load/take/init/assign, strong_copy of unowned/unmanaged, and the class-existential mergeExplosion) drop their integer round-trips too. Updates the affected FileCheck tests and adds optional_reference_ptr.sil.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
