### PR TITLE
Test: run OpaqueValues execution tests in CI

### DIFF
--- a/test/AutoDiff/validation-test/class_differentiation.swift
+++ b/test/AutoDiff/validation-test/class_differentiation.swift
@@ -2,6 +2,7 @@
 // NOTE: Verify whether forward-mode differentiation crashes. It currently does.
 // RUN: not --crash %target-swift-frontend -enable-experimental-forward-mode-differentiation -emit-sil %s
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 import DifferentiationUnittest

--- a/test/AutoDiff/validation-test/default_derivatives.swift
+++ b/test/AutoDiff/validation-test/default_derivatives.swift
@@ -1,5 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 import DifferentiationUnittest

--- a/test/AutoDiff/validation-test/derivative_registration.swift
+++ b/test/AutoDiff/validation-test/derivative_registration.swift
@@ -1,5 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 import DifferentiationUnittest

--- a/test/AutoDiff/validation-test/forward_mode_simple.swift
+++ b/test/AutoDiff/validation-test/forward_mode_simple.swift
@@ -1,5 +1,6 @@
 // RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-forward-mode-differentiation)
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 import DifferentiationUnittest

--- a/test/Concurrency/Runtime/RuntimeDemangle.swift
+++ b/test/Concurrency/Runtime/RuntimeDemangle.swift
@@ -8,7 +8,6 @@
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: runtime_module
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import Swift
 import Runtime

--- a/test/Concurrency/Runtime/async_sequence.swift
+++ b/test/Concurrency/Runtime/async_sequence.swift
@@ -6,7 +6,6 @@
 // REQUIRES: concurrency
 
 // REQUIRES: concurrency_runtime
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 

--- a/test/Concurrency/Runtime/must_not_hop_withContinuation.swift
+++ b/test/Concurrency/Runtime/must_not_hop_withContinuation.swift
@@ -8,7 +8,6 @@
 // UNSUPPORTED: freestanding
 // REQUIRES: libdispatch
 // REQUIRES: synchronization
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import Synchronization
 

--- a/test/Concurrency/Runtime/nonisolated_nonsending_hop_to_executor_throws.swift
+++ b/test/Concurrency/Runtime/nonisolated_nonsending_hop_to_executor_throws.swift
@@ -7,7 +7,6 @@
 // REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 // UNSUPPORTED: freestanding
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 // Regression tests for: https://github.com/swiftlang/swift/issues/88259
 //

--- a/test/Distributed/Runtime/distributed_actor_localSystem_distributedProtocol.swift
+++ b/test/Distributed/Runtime/distributed_actor_localSystem_distributedProtocol.swift
@@ -18,7 +18,6 @@
 
 // rdar://90373022
 // UNSUPPORTED: OS=watchos
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import Distributed
 

--- a/test/Interop/Cxx/stdlib/use-std-map.swift
+++ b/test/Interop/Cxx/stdlib/use-std-map.swift
@@ -16,7 +16,6 @@
 // Undefined hidden symbol to C++ voidify in libcxx
 // rdar://121551667
 // XFAIL: OS=freebsd
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 #if !BRIDGING_HEADER

--- a/test/Interpreter/async_typed_throws_default_impl.swift
+++ b/test/Interpreter/async_typed_throws_default_impl.swift
@@ -2,7 +2,6 @@
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: concurrency_runtime
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 struct Failure: Error, Equatable { var value = 1 }
 

--- a/test/Interpreter/issue88993.swift
+++ b/test/Interpreter/issue88993.swift
@@ -8,7 +8,6 @@
 // REQUIRES: executable_test
 
 // UNSUPPORTED: back_deployment_runtime
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 // https://github.com/swiftlang/swift/issues/88993
 

--- a/test/Interpreter/typed_throws_destination_conversion_83826.swift
+++ b/test/Interpreter/typed_throws_destination_conversion_83826.swift
@@ -1,6 +1,5 @@
 // RUN: %target-run-simple-swift | %FileCheck %s
 // REQUIRES: executable_test
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 // https://github.com/swiftlang/swift/issues/83826
 //

--- a/test/stdlib/StringCreate.swift
+++ b/test/stdlib/StringCreate.swift
@@ -3,7 +3,6 @@
 
 // rdar://91405760
 // UNSUPPORTED: use_os_stdlib, back_deployment_runtime
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 defer { runAllTests() }

--- a/test/stdlib/StringDeconstruction.swift
+++ b/test/stdlib/StringDeconstruction.swift
@@ -1,7 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // UNSUPPORTED: freestanding
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 defer { runAllTests() }

--- a/test/stdlib/TemporaryAllocation.swift
+++ b/test/stdlib/TemporaryAllocation.swift
@@ -1,6 +1,5 @@
 // RUN: %target-run-simple-swift(-strict-memory-safety)
 // REQUIRES: executable_test
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 import SwiftShims

--- a/test/stdlib/UTF8SpanIteratorTests.swift
+++ b/test/stdlib/UTF8SpanIteratorTests.swift
@@ -1,7 +1,6 @@
 // RUN: %target-run-stdlib-swift(-enable-experimental-feature LifetimeDependence) %S/Inputs/
 // REQUIRES: swift_feature_LifetimeDependence
 // REQUIRES: executable_test
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import Swift
 import StdlibUnittest

--- a/test/stdlib/UTF8SpanQueriesComparisons.swift
+++ b/test/stdlib/UTF8SpanQueriesComparisons.swift
@@ -1,7 +1,6 @@
 // RUN: %target-run-stdlib-swift %S/Inputs/
 
 // REQUIRES: executable_test
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import Swift
 import StdlibUnittest

--- a/test/stdlib/subString.swift
+++ b/test/stdlib/subString.swift
@@ -1,7 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // UNSUPPORTED: freestanding
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 

--- a/test/swift_test.py
+++ b/test/swift_test.py
@@ -69,6 +69,8 @@ class SwiftTest(lit.formats.ShTest, object):
             # Some of these tests are notoriously slow.
             and not ("Interop" in test.path_in_suite and "Cxx" in test.path_in_suite)
             and not ("swift-dev-utils.test" in test.path_in_suite)
+            # TODO: remove once the number of XFAILs under opaque values is close to zero.
+            and not ("swift_test_mode_optimize_none_with_opaque_values" in test.config.available_features)
         ):
             test.allowed_retries = 5
 

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -647,6 +647,10 @@ install-swift-testing-macros
 # We need to build the unittest extras so we can test
 build-swift-stdlib-unittest-extra
 
+# Run the execution tests compiled with -enable-sil-opaque-values
+# to provide coverage while opaque values is being brought up.
+test-optimize-none-with-opaque-values
+
 # Make sure our stdlib is RA.
 swift-stdlib-build-type=RelWithDebInfo
 swift-stdlib-enable-assertions=true
@@ -1820,6 +1824,10 @@ release
 assertions
 
 build-swift-stdlib-unittest-extra
+
+# Run the execution tests compiled with -enable-sil-opaque-values
+# to provide coverage while opaque values is being brought up.
+test-optimize-none-with-opaque-values
 
 libcxx
 

--- a/utils/swift_build_support/swift_build_support/host_specific_configuration.py
+++ b/utils/swift_build_support/swift_build_support/host_specific_configuration.py
@@ -215,8 +215,14 @@ class HostSpecificConfiguration(object):
                     self.swift_test_run_targets.append(
                         "check-swift{}-optimize_none_with_implicit_dynamic-{}"
                         .format(subset_suffix, name))
+                # TODO: restricted to the major platforms during opaque values
+                # bring-up; widen as coverage stabilizes.
                 if args.test_optimize_none_with_opaque_values and \
-                        not test_host_only:
+                        not test_host_only and \
+                        deployment_platform in [
+                            StdlibDeploymentTarget.OSX,
+                            StdlibDeploymentTarget.Linux,
+                            StdlibDeploymentTarget.Windows]:
                     self.swift_test_run_targets.append(
                         "check-swift{}-optimize_none_with_opaque_values-{}"
                         .format(subset_suffix, name))

--- a/validation-test/stdlib/Array.swift.gyb
+++ b/validation-test/stdlib/Array.swift.gyb
@@ -1,7 +1,6 @@
 // RUN: %enable-cow-checking %target-run-simple-swiftgyb
 // REQUIRES: executable_test
 // REQUIRES: reflection
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 import StdlibCollectionUnittest

--- a/validation-test/stdlib/ContiguousArray.swift.gyb
+++ b/validation-test/stdlib/ContiguousArray.swift.gyb
@@ -1,7 +1,6 @@
 // RUN: %target-run-simple-swiftgyb
 // REQUIRES: executable_test
 // REQUIRES: reflection
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 import StdlibCollectionUnittest

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -6,7 +6,6 @@
 //
 // RUN: %target-codesign %t/Dictionary && %line-directive %t/main.swift -- %target-run %t/Dictionary
 // REQUIRES: executable_test
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 import StdlibCollectionUnittest

--- a/validation-test/stdlib/ErrorHandling.swift
+++ b/validation-test/stdlib/ErrorHandling.swift
@@ -1,6 +1,5 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 //
 // Tests for error handling in standard library APIs.

--- a/validation-test/stdlib/HashedCollectionFilter.swift
+++ b/validation-test/stdlib/HashedCollectionFilter.swift
@@ -1,6 +1,5 @@
 // RUN: %target-run-stdlib-swift
 // REQUIRES: executable_test
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 

--- a/validation-test/stdlib/SequenceType.swift.gyb
+++ b/validation-test/stdlib/SequenceType.swift.gyb
@@ -3,7 +3,6 @@
 // REQUIRES: executable_test
 // rdar://125917150
 // UNSUPPORTED: freestanding
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 % import os.path
 % import gyb
 

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -6,7 +6,6 @@
 //
 // RUN: %target-codesign %t/Set && %line-directive %t/main.swift -- %target-run %t/Set
 // REQUIRES: executable_test
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 import StdlibCollectionUnittest

--- a/validation-test/stdlib/SetOperations.swift.gyb
+++ b/validation-test/stdlib/SetOperations.swift.gyb
@@ -3,7 +3,6 @@
 // RUN: %line-directive %t/SetOperations.swift -- %target-build-swift %t/SetOperations.swift -o %t/SetOperations -Xfrontend -disable-access-control -swift-version 5
 // RUN: %target-codesign %t/SetOperations && %line-directive %t/SetOperations.swift -- %target-run %t/SetOperations
 // REQUIRES: executable_test
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 import StdlibCollectionUnittest

--- a/validation-test/stdlib/UnicodeWordRecognizer.swift
+++ b/validation-test/stdlib/UnicodeWordRecognizer.swift
@@ -4,7 +4,6 @@
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 // REQUIRES: optimized_stdlib
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 // Validate that the various forms of word breaking all lead to consistent
 // results by exhaustively enumerating all possible state machine inputs up to


### PR DESCRIPTION
This PR changes build presets so that CI testing runs `check-swift-optimize_none_with_opaque_values` in smoke and full macOS test configurations. 

This is a follow-up to https://github.com/swiftlang/swift/pull/90953

Related discussion: https://forums.swift.org/t/progress-on-opaque-sil-values/88589



