### PR TITLE
[Sema] Diagnose invalid key path dynamic member lookup

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2910,6 +2910,11 @@ bool ContextualFailure::diagnoseAsError() {
     }
   }
 
+  case ConstraintLocator::KeyPathDynamicMember: {
+    diagnostic = diag::expr_keypath_value_covert_to_contextual_type;
+    break;
+  }
+
   default:
     return false;
   }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7232,7 +7232,18 @@ bool ConstraintSystem::repairFailures(
   case ConstraintLocator::KeyPathDynamicMember: {
     if (lhs->isPlaceholder() || rhs->isPlaceholder())
       return true;
-    break;
+    if (lhs->isTypeVariableOrMember())
+      break;
+    // If the subscript's value type is not fully resolved, hold its parameters
+    // so the failure surfaces as an inference error rather than a redundant one.
+    if (rhs->hasTypeVariable()) {
+      recordAnyTypeVarAsPotentialHole(rhs);
+      return true;
+    }
+    // Nothing else repairs a mismatch here, so record one to allow diagnosis.
+    conversionsOrFixes.push_back(ContextualMismatch::create(
+        *this, lhs, rhs, getConstraintLocator(locator)));
+    return true;
   }
 
   default:

--- a/test/Constraints/keypath_dynamic_member_lookup_errors.swift
+++ b/test/Constraints/keypath_dynamic_member_lookup_errors.swift
@@ -25,9 +25,7 @@ struct Test<U: P> {
   }
 }
 
-// https://github.com/swiftlang/swift/issues/90751 - a member whose type does
-// not satisfy the subscript's key path value type should be diagnosed rather
-// than crashing with "failed to produce diagnostic".
+// https://github.com/swiftlang/swift/issues/90751
 struct Column<Value> {}
 
 struct Columns {

--- a/test/Constraints/keypath_dynamic_member_lookup_errors.swift
+++ b/test/Constraints/keypath_dynamic_member_lookup_errors.swift
@@ -24,3 +24,45 @@ struct Test<U: P> {
     // expected-note@-2 {{'subscript(dynamicMember:)' declared in 'ObservedObject<U>' uses 'ReferenceWritableKeyPath' which only supports classes}}
   }
 }
+
+// https://github.com/swiftlang/swift/issues/90751 - a member whose type does
+// not satisfy the subscript's key path value type should be diagnosed rather
+// than crashing with "failed to produce diagnostic".
+struct Column<Value> {}
+
+struct Columns {
+  var rowid: Int { 0 }
+  let age = Column<Int>()
+}
+
+@dynamicMemberLookup
+struct Path<Value> {
+  subscript<Member>(dynamicMember keyPath: KeyPath<Columns, Column<Member>>) -> Path<Member> {
+    // expected-note@-1 {{in call to 'subscript(dynamicMember:)'}}
+    Path<Member>()
+  }
+}
+
+func testMemberValueMismatch(p: Path<String>) {
+  _ = p.rowid
+  // expected-error@-1 {{generic parameter 'Member' could not be inferred}}
+  _ = p.age // Ok
+}
+
+func extract<Member>(_ path: KeyPath<Path<String>, Path<Member>>) {}
+// expected-note@-1 {{in call to function 'extract'}}
+
+func testKeyPathValueMismatch() {
+  extract(\.rowid)
+  // expected-error@-1 {{generic parameter 'Member' could not be inferred}}
+}
+
+@dynamicMemberLookup
+struct ConcretePath {
+  subscript(dynamicMember keyPath: KeyPath<Columns, Column<Int>>) -> Bool { true }
+}
+
+func testConcreteValueMismatch(p: ConcretePath) {
+  _ = p.rowid
+  // expected-error@-1 {{key path value type 'Int' cannot be converted to contextual type 'Column<Int>'}}
+}


### PR DESCRIPTION
When the key path's `Value` type does not satisfy the subscript, no diagnostic is produced. Record mismatch or surface inference failure.

Resolves https://github.com/swiftlang/swift/issues/90733.