### PR TITLE
[DiagVerify] support multiple expansions sharing a location

### DIFF
--- a/include/swift/Frontend/DiagnosticVerifier.h
+++ b/include/swift/Frontend/DiagnosticVerifier.h
@@ -25,6 +25,7 @@
 #include "llvm/Support/SourceMgr.h"
 #include "swift/AST/DiagnosticConsumer.h"
 #include "swift/Basic/LLVM.h"
+#include <optional>
 
 namespace {
 struct ExpectedDiagnosticInfo;
@@ -213,7 +214,72 @@ private:
   std::string renderFixits(ArrayRef<CapturedFixItInfo> ActualFixIts,
                            unsigned BufferID, unsigned DiagnosticLineNo) const;
 
-  llvm::DenseMap<SourceLoc, unsigned> Expansions;
+  public:
+  /// Tracks the set of macro-expansion buffers produced at a single source
+  /// location. A location can drive several sibling expansions (e.g. multiple
+  /// peer macros on one declaration); their buffers are ordered by the source
+  /// location of the attached-macro attribute that produced each, so that each
+  /// expansion has a stable "expansion index" matching source order. The
+  /// verifier numbers 'expected-expansion' directives at a location in source
+  /// order and matches directive #k to expansion index #k.
+  class ExpansionContext {
+    /// Each produced sibling expansion as (sortKey, bufferID), kept sorted so
+    /// the expansion index matches the source order of the macros that produced
+    /// the siblings. sortKey is the source-location pointer of the generating
+    /// attached-macro attribute; SourceManager orders locations by pointer (see
+    /// isBeforeInBuffer), so an earlier attribute sorts first. Ties (e.g. no
+    /// attribute) fall back to buffer-ID order.
+    SmallVector<std::pair<uintptr_t, unsigned>, 2> buffers;
+    /// Number of directives already routed to a buffer during verification.
+    size_t verifiedCount = 0;
+    /// Number of directives already routed to a buffer during parsing.
+    size_t parsedCount = 0;
+
+  public:
+    ExpansionContext() = default;
+
+    void addBuffer(unsigned ID, uintptr_t sortKey) {
+      assert(verifiedCount == 0 && parsedCount == 0 &&
+             "added buffer after routing began");
+      for (const auto &Buffer : buffers)
+        if (Buffer.second == ID)
+          return;
+      buffers.emplace_back(sortKey, ID);
+      llvm::sort(buffers);
+    }
+
+    size_t expansionIndex(unsigned ID) const {
+      for (size_t I = 0, E = buffers.size(); I != E; ++I)
+        if (buffers[I].second == ID)
+          return I;
+      llvm_unreachable("buffer not in expansion context");
+    }
+
+    // The buffer for the next 'expected-expansion' directive at this location
+    // during verification, in source order. Returns std::nullopt once every
+    // produced expansion has been claimed, so surplus directives are reported
+    // as "expected expansion not produced" rather than running off the end of
+    // the buffer list.
+    std::optional<unsigned> nextBuffer() {
+      if (verifiedCount >= buffers.size())
+        return std::nullopt;
+      return buffers[verifiedCount++].second;
+    }
+
+    // The buffer for the next 'expected-expansion' directive at this location
+    // during parsing, in source order. Because directives are numbered in the
+    // same order the verifier assigns expansion indices, this binds each
+    // block's '#name@N' markers to the specific sibling expansion that block
+    // targets. Returns std::nullopt when the directive has no corresponding
+    // produced expansion (the "not produced" case is diagnosed separately).
+    std::optional<unsigned> nextParseBuffer() {
+      if (parsedCount >= buffers.size())
+        return std::nullopt;
+      return buffers[parsedCount++].second;
+    }
+  };
+  private:
+  llvm::DenseMap<SourceLoc, ExpansionContext> Expansions;
 
   struct MarkerLocation {
     unsigned BufferID;
@@ -241,9 +307,10 @@ private:
   /// Handle location marker definitions found inside an expected-expansion
   /// block whose interior text is \p BlockText. A plain "// #name" is banned;
   /// an expansion-relative "// #name@N" is bound to line N of the expansion
-  /// buffer \p ExpansionBufferID (0 if the expansion was not produced).
-  void processExpansionMarkerDefinitions(StringRef BlockText,
-                                         unsigned ExpansionBufferID);
+  /// buffer \p ExpansionBufferID.
+  void
+  processExpansionMarkerDefinitions(StringRef BlockText,
+                                    std::optional<unsigned> ExpansionBufferID);
 
   /// Resolve '@#marker' references in \p Diags (and their children) whose
   /// resolution was deferred because the marker is a '// #name@N' whose

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Frontend/DiagnosticVerifier.h"
+#include "swift/AST/Attr.h"
 #include "swift/AST/DiagnosticConsumer.h"
 #include "swift/AST/DiagnosticsFrontend.h"
 #include "swift/Basic/Assertions.h"
@@ -23,10 +24,12 @@
 #include "swift/Parse/Lexer.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/Twine.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/ScopedPrinter.h"
 #include "llvm/Support/raw_ostream.h"
 #include <optional>
 
@@ -575,8 +578,10 @@ void DiagnosticVerifier::printDiagnostic(const llvm::SMDiagnostic &Diag) const {
     SourceLoc ParentLoc = GSI->originalSourceRange.getStart();
     if (ParentLoc.isInvalid())
       return;
+    const ExpansionContext &ctx = Expansions.find(ParentLoc)->getSecond();
+    auto idx = llvm::to_string(ctx.expansionIndex(BufferID));
     printDiagnostic(SM.GetMessage(ParentLoc, llvm::SourceMgr::DK_Note,
-                                  "in expansion from here", {}, {}));
+                                  "in expansion " + idx + " from here", {}, {}));
   }
 }
 
@@ -799,9 +804,36 @@ void DiagnosticVerifier::parseNestedExpectedDiagInfoBlock(
     unsigned &PrevExpectedContinuationLine,
     std::vector<ExpectedDiagnosticInfo> &NestedDiagsOut, size_t &End,
     bool InExpansion) {
+  // Find the '}}' that closes this block by balancing brace pairs. Callers
+  // enter this function already inside one block. Normalize by skipping a
+  // leading '{{' if present and starting at depth 1, then scanning for the '}}'
+  // that returns to depth 0.
+  size_t BlockClose = StringRef::npos;
+  {
+    size_t Depth = 1;
+    for (size_t P = MatchStartIn.starts_with("{{") ? 2 : 0,
+                E = MatchStartIn.size();
+         P + 1 < E;) {
+      if (MatchStartIn[P] == '{' && MatchStartIn[P + 1] == '{') {
+        ++Depth;
+        P += 2;
+      } else if (MatchStartIn[P] == '}' && MatchStartIn[P + 1] == '}') {
+        if (--Depth == 0) {
+          BlockClose = P;
+          break;
+        }
+        P += 2;
+      } else {
+        ++P;
+      }
+    }
+  }
+
   size_t NestedMatch = MatchStartIn.find("expected-");
-  if (NestedMatch == StringRef::npos) {
-    End = MatchStartIn.find("}}");
+  // A block with no nested 'expected-' directive before its own closing '}}'.
+  if (NestedMatch == StringRef::npos ||
+      (BlockClose != StringRef::npos && NestedMatch > BlockClose)) {
+    End = BlockClose;
     return;
   }
   // Scan the memory buffer looking for expected-note/warning/error.
@@ -1059,8 +1091,15 @@ unsigned DiagnosticVerifier::parseExpectedDiagInfo(
 
     SourceLoc ExpansionLoc =
         SM.getLocForLineCol(BufferID, Expected.LineNo, *Expected.ColumnNo);
-    // The buffer this expansion expands to, if it was produced (0 otherwise).
-    unsigned ExpansionBufferID = Expansions.lookup(ExpansionLoc);
+    // Bind this block's '#name@N' markers to the specific sibling expansion
+    // this directive targets. Directives at a shared location are parsed in
+    // source order, which is the same order the verifier numbers expansion
+    // indices, so nextParseBuffer() hands back the matching buffer (0 if this
+    // directive has no corresponding produced expansion).
+    auto ExpansionIt = Expansions.find(ExpansionLoc);
+    std::optional<unsigned> ExpansionBufferID = std::nullopt;
+    if (ExpansionIt != Expansions.end())
+      ExpansionBufferID = ExpansionIt->second.nextParseBuffer();
     processExpansionMarkerDefinitions(MatchStart.slice(2, End),
                                       ExpansionBufferID);
   } else {
@@ -1301,12 +1340,19 @@ void DiagnosticVerifier::verifyDiagnostics(
     // Check to see if we had this expected diagnostic.
     if (expected.Classification == DiagnosticKindExpansion) {
       SourceLoc Loc = SM.getLocForLineCol(BufferID, expected.LineNo, *expected.ColumnNo);
-      if (Expansions.count(Loc) == 0) {
+      auto It = Expansions.find(Loc);
+      // nextBuffer() yields std::nullopt both when no expansion was produced
+      // at this location and when every produced expansion has already been
+      // claimed by an earlier directive (i.e. there are more directives than
+      // sibling expansions). Either way this directive has nothing to bind to.
+      std::optional<unsigned> ExpansionBufferID;
+      if (It != Expansions.end())
+        ExpansionBufferID = It->second.nextBuffer();
+      if (!ExpansionBufferID) {
         addError(expected.ExpectedStart, "expected expansion not produced");
         continue;
       }
-      unsigned ExpansionBufferID = Expansions[Loc];
-      verifyDiagnostics(expected.NestedDiags, ExpansionBufferID,
+      verifyDiagnostics(expected.NestedDiags, *ExpansionBufferID,
                         /*ParentDiagnostic=*/std::nullopt);
       if (expected.NestedDiags.empty())
         ExpectedDiagnostics.erase(ExpectedDiagnostics.begin()+i);
@@ -1771,7 +1817,7 @@ void DiagnosticVerifier::scanForMarkers(unsigned BufferID) {
 
 /// Handle location marker definitions found inside an expected-expansion block.
 void DiagnosticVerifier::processExpansionMarkerDefinitions(
-    StringRef BlockText, unsigned ExpansionBufferID) {
+    StringRef BlockText, std::optional<unsigned> ExpansionBufferID) {
   forEachMarkerDefinition(
       BlockText, [&](const char *HashLoc, StringRef MarkerName,
                      std::optional<unsigned> ExpansionLine) {
@@ -1797,7 +1843,7 @@ void DiagnosticVerifier::processExpansionMarkerDefinitions(
         if (!ExpansionBufferID)
           return;
 
-        if (SM.getLocForLineCol(ExpansionBufferID, *ExpansionLine, 1)
+        if (SM.getLocForLineCol(*ExpansionBufferID, *ExpansionLine, 1)
                 .isInvalid()) {
           addError(HashLoc, "line " + Twine(*ExpansionLine) +
                                 " does not exist in the expansion buffer");
@@ -1811,7 +1857,7 @@ void DiagnosticVerifier::processExpansionMarkerDefinitions(
         // than clobbering it.
         MarkerLocation &MarkerLoc = LocationMarkers[MarkerName];
         if (MarkerLoc.BufferID == 0)
-          MarkerLoc = {ExpansionBufferID, *ExpansionLine};
+          MarkerLoc = {*ExpansionBufferID, *ExpansionLine};
       });
 }
 
@@ -2074,7 +2120,7 @@ void DiagnosticVerifier::printRemainingDiagnostics() const {
 }
 
 static void
-processExpansions(SourceManager &SM, llvm::DenseMap<SourceLoc, unsigned> &Expansions,
+processExpansions(SourceManager &SM, llvm::DenseMap<SourceLoc, DiagnosticVerifier::ExpansionContext> &Expansions,
                   std::vector<CapturedDiagnosticInfo> &CapturedDiagnostics) {
   for (auto &diag : CapturedDiagnostics) {
     if (!diag.SourceBufferID.has_value())
@@ -2086,13 +2132,16 @@ processExpansions(SourceManager &SM, llvm::DenseMap<SourceLoc, unsigned> &Expans
     SourceLoc ExpansionStart = GSI->originalSourceRange.getStart();
     if (ExpansionStart.isInvalid())
       continue;
-    if (Expansions.count(ExpansionStart)) {
-      ASSERT(Expansions[ExpansionStart] == diag.SourceBufferID.value() &&
-             "diagnostics in multiple expansions for the same decl not "
-             "supported by -verify");
-      continue;
-    }
-    Expansions.insert(std::make_pair(ExpansionStart, diag.SourceBufferID.value()));
+    // Order sibling expansions by the source location of the attached-macro
+    // attribute that produced each, so the first attribute in source order
+    // becomes expansion index 0 (matching the order 'expected-expansion'
+    // directives are written). Buffers with no attribute fall back to
+    // buffer-ID order via a zero key.
+    uintptr_t SortKey = 0;
+    if (GSI->attachedMacroCustomAttr)
+      SortKey = reinterpret_cast<uintptr_t>(
+          GSI->attachedMacroCustomAttr->getLocation().getPointer());
+    Expansions[ExpansionStart].addBuffer(diag.SourceBufferID.value(), SortKey);
   }
 }
 

--- a/test/Frontend/DiagnosticVerifier/clang-attribute.swift
+++ b/test/Frontend/DiagnosticVerifier/clang-attribute.swift
@@ -22,41 +22,41 @@ module TestClang {
 }
 
 // CHECK: @__swiftmacro_So3foo15_SwiftifyImportfMp_.swift:1:1: error: unexpected remark produced: macro content: |/// This is an auto-generated wrapper for safer interop|
-// CHECK: TEST_H:1:25: note: in expansion from here
+// CHECK: TEST_H:1:25: note: in expansion 0 from here
 // CHECK: TEST_H:1:25: note: file 'TEST_H' is not parsed for 'expected' statements. Use '-verify-additional-file TEST_H' to enable, or '-verify-ignore-unrelated' to ignore diagnostics in this file
 // CHECK: <empty-filename>:1:1: error: unexpected note produced: in expansion of macro '_SwiftifyImport' on global function 'foo' here
 //  // CHECK-NEXT: @_SwiftifyImport(.countedBy(pointer: .param(2), count: "len"))
-// CHECK: TEST_H:1:6: note: in expansion from here
+// CHECK: TEST_H:1:6: note: in expansion 0 from here
 // CHECK: TEST_H:1:6: note: file 'TEST_H' is not parsed for 'expected' statements. Use '-verify-additional-file TEST_H' to enable, or '-verify-ignore-unrelated' to ignore diagnostics in this file 
 
 // CHECK: @__swiftmacro_So3foo15_SwiftifyImportfMp_.swift:2:1: error: unexpected remark produced: macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func foo(_ p: UnsafeMutableBufferPointer<CInt>) {|
-// CHECK: TEST_H:1:25: note: in expansion from here
+// CHECK: TEST_H:1:25: note: in expansion 0 from here
 // CHECK: TEST_H:1:25: note: file 'TEST_H' is not parsed for 'expected' statements. Use '-verify-additional-file TEST_H' to enable, or '-verify-ignore-unrelated' to ignore diagnostics in this file
 // CHECK: <empty-filename>:1:1: error: unexpected note produced: in expansion of macro '_SwiftifyImport' on global function 'foo' here
   // CHECK-NEXT: @_SwiftifyImport(.countedBy(pointer: .param(2), count: "len"))
-// CHECK: TEST_H:1:6: note: in expansion from here
+// CHECK: TEST_H:1:6: note: in expansion 0 from here
 // CHECK: TEST_H:1:6: note: file 'TEST_H' is not parsed for 'expected' statements. Use '-verify-additional-file TEST_H' to enable, or '-verify-ignore-unrelated' to ignore diagnostics in this file 
 
 // CHECK: @__swiftmacro_So3foo15_SwiftifyImportfMp_.swift:3:1: error: unexpected remark produced: macro content: |    let len = CInt(exactly: p.count)!|
-// CHECK: TEST_H:1:25: note: in expansion from here
+// CHECK: TEST_H:1:25: note: in expansion 0 from here
 // CHECK: TEST_H:1:25: note: file 'TEST_H' is not parsed for 'expected' statements. Use '-verify-additional-file TEST_H' to enable, or '-verify-ignore-unrelated' to ignore diagnostics in this file
 // CHECK: <empty-filename>:1:1: error: unexpected note produced: in expansion of macro '_SwiftifyImport' on global function 'foo' here
   // CHECK-NEXT: @_SwiftifyImport(.countedBy(pointer: .param(2), count: "len"))
-// CHECK: TEST_H:1:6: note: in expansion from here
+// CHECK: TEST_H:1:6: note: in expansion 0 from here
 // CHECK: TEST_H:1:6: note: file 'TEST_H' is not parsed for 'expected' statements. Use '-verify-additional-file TEST_H' to enable, or '-verify-ignore-unrelated' to ignore diagnostics in this file 
 
 // CHECK: @__swiftmacro_So3foo15_SwiftifyImportfMp_.swift:4:1: error: unexpected remark produced: macro content: |    return unsafe foo(len, p.baseAddress)|
-// CHECK: TEST_H:1:25: note: in expansion from here
+// CHECK: TEST_H:1:25: note: in expansion 0 from here
 // CHECK: TEST_H:1:25: note: file 'TEST_H' is not parsed for 'expected' statements. Use '-verify-additional-file TEST_H' to enable, or '-verify-ignore-unrelated' to ignore diagnostics in this file
 // CHECK: <empty-filename>:1:1: error: unexpected note produced: in expansion of macro '_SwiftifyImport' on global function 'foo' here
   // CHECK-NEXT: @_SwiftifyImport(.countedBy(pointer: .param(2), count: "len"))
-// CHECK: TEST_H:1:6: note: in expansion from here
+// CHECK: TEST_H:1:6: note: in expansion 0 from here
 // CHECK: TEST_H:1:6: note: file 'TEST_H' is not parsed for 'expected' statements. Use '-verify-additional-file TEST_H' to enable, or '-verify-ignore-unrelated' to ignore diagnostics in this file 
 
 // CHECK: @__swiftmacro_So3foo15_SwiftifyImportfMp_.swift:5:1: error: unexpected remark produced: macro content: |}|
-// CHECK: TEST_H:1:25: note: in expansion from here
+// CHECK: TEST_H:1:25: note: in expansion 0 from here
 // CHECK: TEST_H:1:25: note: file 'TEST_H' is not parsed for 'expected' statements. Use '-verify-additional-file TEST_H' to enable, or '-verify-ignore-unrelated' to ignore diagnostics in this file
 // CHECK: <empty-filename>:1:1: error: unexpected note produced: in expansion of macro '_SwiftifyImport' on global function 'foo' here
   // CHECK-NEXT: @_SwiftifyImport(.countedBy(pointer: .param(2), count: "len"))
-// CHECK: TEST_H:1:6: note: in expansion from here
+// CHECK: TEST_H:1:6: note: in expansion 0 from here
 // CHECK: TEST_H:1:6: note: file 'TEST_H' is not parsed for 'expected' statements. Use '-verify-additional-file TEST_H' to enable, or '-verify-ignore-unrelated' to ignore diagnostics in this file 

--- a/test/Frontend/DiagnosticVerifier/expansion-remarks.swift
+++ b/test/Frontend/DiagnosticVerifier/expansion-remarks.swift
@@ -18,6 +18,16 @@
 // RUN: %target-swift-frontend-verify -swift-version 5 -verify-ignore-macro-note -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/ignore-macro-note.swift -verify-child-notes
 // RUN: not %target-swift-frontend-verify -swift-version 5 -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/ignore-macro-note.swift 2>&1 | %FileCheck --check-prefix=DISABLED %t/ignore-macro-note.swift
 
+// Multiple expansions attached at the same source location (several peer macros
+// on one declaration). Each produces a distinct sibling expansion buffer, and
+// expansion directives are matched to them by position.
+// RUN: %target-swift-frontend-verify -swift-version 5 -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/multi-both.swift
+// RUN: not %target-swift-frontend-verify -swift-version 5 -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/multi-misrouting.swift 2>&1 | %FileCheck --check-prefix=CHECK-MISROUTE %t/multi-misrouting.swift
+// RUN: %target-swift-frontend-verify -swift-version 5 -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/multi-markers-outside.swift
+// RUN: %target-swift-frontend-verify -swift-version 5 -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/multi-marker-sibling.swift
+// RUN: not %target-swift-frontend-verify -swift-version 5 -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/multi-more-directives.swift 2>&1 | %FileCheck --check-prefix=CHECK-MOREDIRS %t/multi-more-directives.swift
+// RUN: not %target-swift-frontend-verify -swift-version 5 -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/multi-more-expansions.swift 2>&1 | %FileCheck --check-prefix=CHECK-MOREEXP %t/multi-more-expansions.swift
+
 //--- main.swift
 @attached(peer, names: overloaded)
 macro unstringifyPeer(_ s: String) =
@@ -161,3 +171,189 @@ func foo() {}
 // expected-expansion@-1:14{{
 //   expected-warning@2{{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}}
 // }}
+
+//--- multi-both.swift
+// Two peer macros attached to the same declaration expand at the same source
+// location (column 14 of 'func baz() {}'), producing two sibling expansion
+// buffers. The verifier gives each a positional "expansion index" following the
+// source order of the macro attributes, and routes the expansion directives to
+// those indices in the order the directives appear in the source. Here each
+// sibling produces its own distinct diagnostic: the first directive matches
+// expansion 0 (from unstringifyPeer) and the second matches expansion 1 (from
+// unstringifyPeer2). This covers a diagnostic present in expansion 0, one
+// present in expansion 1, and thus both expansions carrying a diagnostic.
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+@attached(peer, names: overloaded)
+macro unstringifyPeer2(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+// expected-note@+1{{in expansion of macro 'unstringifyPeer' on global function 'baz()' here}}
+@unstringifyPeer("func baz(_ x: Int) {\nlet a = x\n}")
+// expected-note@+1{{in expansion of macro 'unstringifyPeer2' on global function 'baz()' here}}
+@unstringifyPeer2("func baz(_ y: String) {\nlet b = y\n}")
+// expected-expansion@+6:14{{
+//   expected-warning@2{{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}}
+// }}
+// expected-expansion@+3:14{{
+//   expected-warning@2{{initialization of immutable value 'b' was never used; consider replacing with assignment to '_' or removing it}}
+// }}
+func baz() {}
+
+//--- multi-misrouting.swift
+// The same two-expansion setup as multi-both.swift, but the two directives are
+// swapped: the first directive (expansion 0) expects the diagnostic that only
+// occurs in expansion 1, and vice versa..
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+@attached(peer, names: overloaded)
+macro unstringifyPeer2(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+// expected-note@+1{{in expansion of macro 'unstringifyPeer' on global function 'baz()' here}}
+@unstringifyPeer("func baz(_ x: Int) {\nlet a = x\n}")
+// expected-note@+1{{in expansion of macro 'unstringifyPeer2' on global function 'baz()' here}}
+@unstringifyPeer2("func baz(_ y: String) {\nlet b = y\n}")
+// The nested diagnostics are matched against the wrong sibling buffers.
+// CHECK-MISROUTE: :[[@LINE+2]]:6: error: expected warning not produced
+// expected-expansion@+13:14{{
+//   expected-warning@2{{initialization of immutable value 'b' was never used; consider replacing with assignment to '_' or removing it}}
+// }}
+// CHECK-MISROUTE: :[[@LINE+2]]:6: error: expected warning not produced
+// expected-expansion@+9:14{{
+//   expected-warning@2{{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}}
+// }}
+// The real diagnostics are then reported as unexpected against the sibling that
+// actually produced them.
+// CHECK-MISROUTE: :2:9: error: unexpected warning produced: initialization of immutable value 'b'
+// CHECK-MISROUTE: :[[@LINE+3]]:14: note: in expansion 1 from here
+// CHECK-MISROUTE: :2:9: error: unexpected warning produced: initialization of immutable value 'a'
+// CHECK-MISROUTE: :[[@LINE+1]]:14: note: in expansion 0 from here
+func baz() {}
+
+//--- multi-markers-outside.swift
+// A '#name@N' location marker defined inside a sibling expansion binds to line
+// N of that expansion's buffer, not merely the first sibling. Here a
+// marker is defined in each of the two expansions and referenced by directives
+// outside the expansion blocks; each must resolve into its own buffer.
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+@attached(peer, names: overloaded)
+macro unstringifyPeer2(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+// expected-note@+1{{in expansion of macro 'unstringifyPeer' on global function 'baz()' here}}
+@unstringifyPeer("func baz(_ x: Int) {\nlet a = x\n}")
+// expected-note@+1{{in expansion of macro 'unstringifyPeer2' on global function 'baz()' here}}
+@unstringifyPeer2("func baz(_ y: String) {\nlet b = y\n}")
+// expected-expansion@+6:14{{
+//   #aMarker@2
+// }}
+// expected-expansion@+3:14{{
+//   #bMarker@2
+// }}
+func baz() {}
+// expected-warning@#aMarker{{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}}
+// expected-warning@#bMarker{{initialization of immutable value 'b' was never used; consider replacing with assignment to '_' or removing it}}
+
+//--- multi-marker-sibling.swift
+// A '#name@N' marker defined inside one sibling expansion (expansion 1) is
+// referenced by a directive that lives inside the other sibling's block
+// (expansion 0). The reference must resolve to the defining expansion's buffer,
+// exercising cross-sibling marker routing rather than binding to the block the
+// reference textually sits in.
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+@attached(peer, names: overloaded)
+macro unstringifyPeer2(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+// expected-note@+1{{in expansion of macro 'unstringifyPeer' on global function 'baz()' here}}
+@unstringifyPeer("func baz(_ x: Int) {\nlet a = x\n}")
+// expected-note@+1{{in expansion of macro 'unstringifyPeer2' on global function 'baz()' here}}
+@unstringifyPeer2("func baz(_ y: String) {\nlet b = y\n}")
+// The '@#bMarker' reference below sits in expansion 0's block but resolves to
+// expansion 1's buffer, where '#bMarker' is defined.
+// expected-expansion@+7:14{{
+//   expected-warning@2{{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}}
+//   expected-warning@#bMarker{{initialization of immutable value 'b' was never used; consider replacing with assignment to '_' or removing it}}
+// }}
+// expected-expansion@+3:14{{
+//   #bMarker@2
+// }}
+func baz() {}
+
+//--- multi-more-directives.swift
+// More expansion directives than expansions actually produced. The
+// surplus directive has no sibling to bind to and is reported as "expected
+// expansion not produced". 'baz' exercises a surplus directive that
+// carries nested expectations; 'qux' exercises an empty surplus directive.
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+// expected-note@+1{{in expansion of macro 'unstringifyPeer' on global function 'baz()' here}}
+@unstringifyPeer("func baz(_ x: Int) {\nlet a = x\n}")
+// expected-expansion@+9:14{{
+//   expected-warning@2{{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}}
+// }}
+// The surplus directive, and its nested expectation, have no expansion to bind.
+// CHECK-MOREDIRS: :[[@LINE+2]]:4: error: expected expansion not produced
+// CHECK-MOREDIRS: :[[@LINE+2]]:6: error: expected warning not produced
+// expected-expansion@+3:14{{
+//   expected-warning@2{{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}}
+// }}
+func baz() {}
+
+// expected-note@+1{{in expansion of macro 'unstringifyPeer' on global function 'qux()' here}}
+@unstringifyPeer("func qux(_ x: Int) {\nlet a = x\n}")
+// expected-expansion@+6:14{{
+//   expected-warning@2{{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}}
+// }}
+// CHECK-MOREDIRS: :[[@LINE+1]]:4: error: expected expansion not produced
+// expected-expansion@+2:14{{
+// }}
+func qux() {}
+
+//--- multi-more-expansions.swift
+// Fewer expansion directives than expansions actually produced. The
+// single directive claims expansion 0; the remaining sibling's diagnostics are
+// left over and reported as unexpected, tagged with the index of the expansion
+// they came from. 'baz' uses a directive with nested expectations; 'qux' uses
+// an empty directive, so both siblings' diagnostics are left unclaimed.
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+@attached(peer, names: overloaded)
+macro unstringifyPeer2(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+// expected-note@+1{{in expansion of macro 'unstringifyPeer' on global function 'baz()' here}}
+@unstringifyPeer("func baz(_ x: Int) {\nlet a = x\n}")
+// expected-note@+1{{in expansion of macro 'unstringifyPeer2' on global function 'baz()' here}}
+@unstringifyPeer2("func baz(_ y: String) {\nlet b = y\n}")
+// The lone directive claims expansion 0 ('a'); expansion 1 ('b') is unclaimed.
+// CHECK-MOREEXP: :2:9: error: unexpected warning produced: initialization of immutable value 'b'
+// CHECK-MOREEXP: :[[@LINE+4]]:14: note: in expansion 1 from here
+// expected-expansion@+3:14{{
+//   expected-warning@2{{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}}
+// }}
+func baz() {}
+
+// expected-note@+1{{in expansion of macro 'unstringifyPeer' on global function 'qux()' here}}
+@unstringifyPeer("func qux(_ x: Int) {\nlet a = x\n}")
+// expected-note@+1{{in expansion of macro 'unstringifyPeer2' on global function 'qux()' here}}
+@unstringifyPeer2("func qux(_ y: String) {\nlet b = y\n}")
+// The empty directive claims expansion 0 but expects nothing, so both siblings'
+// diagnostics are unclaimed.
+// CHECK-MOREEXP: :2:9: error: unexpected warning produced: initialization of immutable value 'b'
+// CHECK-MOREEXP: :[[@LINE+5]]:14: note: in expansion 1 from here
+// CHECK-MOREEXP: :2:9: error: unexpected warning produced: initialization of immutable value 'a'
+// CHECK-MOREEXP: :[[@LINE+3]]:14: note: in expansion 0 from here
+// expected-expansion@+2:14{{
+// }}
+func qux() {}

--- a/test/Utils/update-verify-tests/expansion.swift
+++ b/test/Utils/update-verify-tests/expansion.swift
@@ -39,6 +39,49 @@
 // RUN: %target-swift-frontend-verify -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/nested.swift
 // RUN: %diff %t/nested.swift %t/nested.swift.expected
 
+// RUN: not %target-swift-frontend-verify -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/multiple-at-same-location.swift 2>%t/output.txt
+// RUN: %update-verify-tests < %t/output.txt
+// RUN: %target-swift-frontend-verify -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/multiple-at-same-location.swift
+// RUN: %diff %t/multiple-at-same-location.swift %t/multiple-at-same-location.swift.expected
+
+// Sibling expansions where each expansion emits several diagnostics: every
+// diagnostic must route into the matching sibling and accumulate there.
+// RUN: not %target-swift-frontend-verify -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/sibling-multiple-diags.swift 2>%t/output.txt
+// RUN: %update-verify-tests < %t/output.txt
+// RUN: %target-swift-frontend-verify -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/sibling-multiple-diags.swift
+// RUN: %diff %t/sibling-multiple-diags.swift %t/sibling-multiple-diags.swift.expected
+
+// Sibling expansions with pre-existing (empty) directives already present: the
+// diagnostics must be routed into the existing directives by index rather than
+// synthesizing new ones.
+// RUN: not %target-swift-frontend-verify -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/sibling-existing.swift 2>%t/output.txt
+// RUN: %update-verify-tests < %t/output.txt
+// RUN: %target-swift-frontend-verify -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/sibling-existing.swift
+// RUN: %diff %t/sibling-existing.swift %t/sibling-existing.swift.expected
+
+// Three sibling expansions at one location, to check index routing scales past
+// two.
+// RUN: not %target-swift-frontend-verify -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/sibling-three.swift 2>%t/output.txt
+// RUN: %update-verify-tests < %t/output.txt
+// RUN: %target-swift-frontend-verify -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/sibling-three.swift
+// RUN: %diff %t/sibling-three.swift %t/sibling-three.swift.expected
+
+// One sibling directive already exists (index 0); the other sibling must be
+// synthesized (index 1) and laid out after the existing one so source order
+// matches expansion-index order.
+// RUN: not %target-swift-frontend-verify -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/sibling-partial.swift 2>%t/output.txt
+// RUN: %update-verify-tests < %t/output.txt
+// RUN: %target-swift-frontend-verify -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/sibling-partial.swift
+// RUN: %diff %t/sibling-partial.swift %t/sibling-partial.swift.expected
+
+// Stale sibling directives whose target declaration was deleted, so their
+// offsets dangle past the end of the file: they must be dropped rather than
+// crashing on the out-of-range target.
+// RUN: not %target-swift-frontend-verify -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/sibling-gone.swift 2>%t/output.txt
+// RUN: %update-verify-tests < %t/output.txt
+// RUN: %target-swift-frontend-verify -load-plugin-library %t/%target-library-name(UnstringifyMacroDefinition) -typecheck %t/sibling-gone.swift
+// RUN: %diff %t/sibling-gone.swift %t/sibling-gone.swift.expected
+
 // RUN: not %target-swift-frontend-verify -I %t -plugin-path %swift-plugin-dir -typecheck %t/unparsed.swift 2>%t/output.txt -Rmacro-expansions
 // RUN: not %update-verify-tests < %t/output.txt | %FileCheck --check-prefix CHECK-UNPARSED %s
 
@@ -311,6 +354,337 @@ func bar(_ y: Int) {
 //   expected-error@10{{argument passed to call that takes no arguments}}
 // }}
 func bar() {}
+
+//--- multiple-at-same-location.swift
+// Two peer macros attached to the same declaration expand at the same source
+// location, so their diagnostics share one expansion source location but land
+// in distinct expansion buffers. The verifier reports each nested diagnostic
+// with the index of the expansion it came from ("in expansion N from here"),
+// and update-verify-tests must route each into the matching sibling
+// expansion directive rather than merging them or swapping them.
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+@attached(peer, names: overloaded)
+macro unstringifyPeer2(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+@unstringifyPeer("""
+func baz(_ x: Int) {
+    let a = x
+}
+""")
+@unstringifyPeer2("""
+func baz(_ y: String) {
+    let b = y
+}
+""")
+func baz() {}
+
+//--- multiple-at-same-location.swift.expected
+// Two peer macros attached to the same declaration expand at the same source
+// location, so their diagnostics share one expansion source location but land
+// in distinct expansion buffers. The verifier reports each nested diagnostic
+// with the index of the expansion it came from ("in expansion N from here"),
+// and update-verify-tests must route each into the matching sibling
+// expansion directive rather than merging them or swapping them.
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+@attached(peer, names: overloaded)
+macro unstringifyPeer2(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+// expected-note@+1{{in expansion of macro 'unstringifyPeer' on global function 'baz()' here}}
+@unstringifyPeer("""
+func baz(_ x: Int) {
+    let a = x
+}
+""")
+// expected-note@+1{{in expansion of macro 'unstringifyPeer2' on global function 'baz()' here}}
+@unstringifyPeer2("""
+func baz(_ y: String) {
+    let b = y
+}
+""")
+// expected-expansion@+6:14{{
+//   expected-warning@2{{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}}
+// }}
+// expected-expansion@+3:14{{
+//   expected-warning@2{{initialization of immutable value 'b' was never used; consider replacing with assignment to '_' or removing it}}
+// }}
+func baz() {}
+
+//--- sibling-multiple-diags.swift
+// Each of the two sibling expansions emits multiple diagnostics; every one must
+// be routed into its own sibling directive and accumulate there.
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+@attached(peer, names: overloaded)
+macro unstringifyPeer2(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+@unstringifyPeer("""
+func baz(_ x: Int) {
+    let a = x
+    let b = x
+}
+""")
+@unstringifyPeer2("""
+func baz(_ y: String) {
+    let c = y
+    let d = y
+}
+""")
+func baz() {}
+
+//--- sibling-multiple-diags.swift.expected
+// Each of the two sibling expansions emits multiple diagnostics; every one must
+// be routed into its own sibling directive and accumulate there.
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+@attached(peer, names: overloaded)
+macro unstringifyPeer2(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+// expected-note@+1 2{{in expansion of macro 'unstringifyPeer' on global function 'baz()' here}}
+@unstringifyPeer("""
+func baz(_ x: Int) {
+    let a = x
+    let b = x
+}
+""")
+// expected-note@+1 2{{in expansion of macro 'unstringifyPeer2' on global function 'baz()' here}}
+@unstringifyPeer2("""
+func baz(_ y: String) {
+    let c = y
+    let d = y
+}
+""")
+// expected-expansion@+8:14{{
+//   expected-warning@2{{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}}
+//   expected-warning@3{{initialization of immutable value 'b' was never used; consider replacing with assignment to '_' or removing it}}
+// }}
+// expected-expansion@+4:14{{
+//   expected-warning@2{{initialization of immutable value 'c' was never used; consider replacing with assignment to '_' or removing it}}
+//   expected-warning@3{{initialization of immutable value 'd' was never used; consider replacing with assignment to '_' or removing it}}
+// }}
+func baz() {}
+
+//--- sibling-existing.swift
+// The sibling expansion directives already exist but are empty; their
+// diagnostics must be routed into the existing directives by index instead of
+// synthesizing new ones.
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+@attached(peer, names: overloaded)
+macro unstringifyPeer2(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+// expected-note@+1{{in expansion of macro 'unstringifyPeer' on global function 'baz()' here}}
+@unstringifyPeer("""
+func baz(_ x: Int) {
+    let a = x
+}
+""")
+// expected-note@+1{{in expansion of macro 'unstringifyPeer2' on global function 'baz()' here}}
+@unstringifyPeer2("""
+func baz(_ y: String) {
+    let b = y
+}
+""")
+// expected-expansion@+4:14{{
+// }}
+// expected-expansion@+2:14{{
+// }}
+func baz() {}
+
+//--- sibling-existing.swift.expected
+// The sibling expansion directives already exist but are empty; their
+// diagnostics must be routed into the existing directives by index instead of
+// synthesizing new ones.
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+@attached(peer, names: overloaded)
+macro unstringifyPeer2(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+// expected-note@+1{{in expansion of macro 'unstringifyPeer' on global function 'baz()' here}}
+@unstringifyPeer("""
+func baz(_ x: Int) {
+    let a = x
+}
+""")
+// expected-note@+1{{in expansion of macro 'unstringifyPeer2' on global function 'baz()' here}}
+@unstringifyPeer2("""
+func baz(_ y: String) {
+    let b = y
+}
+""")
+// expected-expansion@+6:14{{
+//   expected-warning@2{{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}}
+// }}
+// expected-expansion@+3:14{{
+//   expected-warning@2{{initialization of immutable value 'b' was never used; consider replacing with assignment to '_' or removing it}}
+// }}
+func baz() {}
+
+//--- sibling-three.swift
+// Three sibling expansions at one location, to check that index routing scales
+// past two.
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+@attached(peer, names: overloaded)
+macro unstringifyPeer2(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+@attached(peer, names: overloaded)
+macro unstringifyPeer3(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+@unstringifyPeer("""
+func baz(_ x: Int) {
+    let a = x
+}
+""")
+@unstringifyPeer2("""
+func baz(_ y: String) {
+    let b = y
+}
+""")
+@unstringifyPeer3("""
+func baz(_ z: Double) {
+    let c = z
+}
+""")
+func baz() {}
+
+//--- sibling-three.swift.expected
+// Three sibling expansions at one location, to check that index routing scales
+// past two.
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+@attached(peer, names: overloaded)
+macro unstringifyPeer2(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+@attached(peer, names: overloaded)
+macro unstringifyPeer3(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+// expected-note@+1{{in expansion of macro 'unstringifyPeer' on global function 'baz()' here}}
+@unstringifyPeer("""
+func baz(_ x: Int) {
+    let a = x
+}
+""")
+// expected-note@+1{{in expansion of macro 'unstringifyPeer2' on global function 'baz()' here}}
+@unstringifyPeer2("""
+func baz(_ y: String) {
+    let b = y
+}
+""")
+// expected-note@+1{{in expansion of macro 'unstringifyPeer3' on global function 'baz()' here}}
+@unstringifyPeer3("""
+func baz(_ z: Double) {
+    let c = z
+}
+""")
+// expected-expansion@+9:14{{
+//   expected-warning@2{{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}}
+// }}
+// expected-expansion@+6:14{{
+//   expected-warning@2{{initialization of immutable value 'b' was never used; consider replacing with assignment to '_' or removing it}}
+// }}
+// expected-expansion@+3:14{{
+//   expected-warning@2{{initialization of immutable value 'c' was never used; consider replacing with assignment to '_' or removing it}}
+// }}
+func baz() {}
+
+//--- sibling-partial.swift
+// One sibling expansion directive (index 0) is already present and correct; the
+// other sibling's diagnostic is unexpected and must be added as a new directive
+// placed after the existing one, not ahead of it.
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+@attached(peer, names: overloaded)
+macro unstringifyPeer2(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+// expected-note@+1{{in expansion of macro 'unstringifyPeer' on global function 'baz()' here}}
+@unstringifyPeer("""
+func baz(_ x: Int) {
+    let a = x
+}
+""")
+// expected-note@+1{{in expansion of macro 'unstringifyPeer2' on global function 'baz()' here}}
+@unstringifyPeer2("""
+func baz(_ y: String) {
+    let b = y
+}
+""")
+// expected-expansion@+3:14{{
+//   expected-warning@2{{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}}
+// }}
+func baz() {}
+
+//--- sibling-partial.swift.expected
+// One sibling expansion directive (index 0) is already present and correct; the
+// other sibling's diagnostic is unexpected and must be added as a new directive
+// placed after the existing one, not ahead of it.
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+@attached(peer, names: overloaded)
+macro unstringifyPeer2(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+// expected-note@+1{{in expansion of macro 'unstringifyPeer' on global function 'baz()' here}}
+@unstringifyPeer("""
+func baz(_ x: Int) {
+    let a = x
+}
+""")
+// expected-note@+1{{in expansion of macro 'unstringifyPeer2' on global function 'baz()' here}}
+@unstringifyPeer2("""
+func baz(_ y: String) {
+    let b = y
+}
+""")
+// expected-expansion@+6:14{{
+//   expected-warning@2{{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}}
+// }}
+// expected-expansion@+3:14{{
+//   expected-warning@2{{initialization of immutable value 'b' was never used; consider replacing with assignment to '_' or removing it}}
+// }}
+func baz() {}
+
+//--- sibling-gone.swift
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+// The declaration these sibling directives targeted was deleted, so their
+// '@+N' offsets now dangle past the end of the file.
+// expected-expansion@+4:14{{
+//   expected-warning@2{{initialization of immutable value 'b' was never used; consider replacing with assignment to '_' or removing it}}
+// }}
+// expected-expansion@+2:14{{
+//   expected-warning@2{{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}}
+// }}
+
+//--- sibling-gone.swift.expected
+@attached(peer, names: overloaded)
+macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "UnstringifyMacroDefinition", type: "UnstringifyPeerMacro")
+
+// The declaration these sibling directives targeted was deleted, so their
+// '@+N' offsets now dangle past the end of the file.
 
 //--- unparsed.h
 // CHECK-UNPARSED: no files updated: found diagnostics in unparsed files TMP_DIR{{/|\\}}unparsed.h

--- a/utils/update_verify_tests/core.py
+++ b/utils/update_verify_tests/core.py
@@ -635,6 +635,7 @@ def add_diag(
     orig_lines,
     prefix,
     nested_context,
+    insert_after=None,
 ):
     if nested_context:
         prev_line = None
@@ -650,7 +651,19 @@ def add_diag(
         line_n = orig_line_n_to_new_line_n(orig_target_line_n, orig_lines)
         target = lines[line_n - 1]
 
-        prev_line, total_offset, new_line_n = infer_line_context(target, line_n)
+        if insert_after is not None:
+            # Place the new directive immediately after `insert_after` rather
+            # than stacking it above the other diagnostics targeting this line.
+            # Used for a synthesized sibling expansion, which has a higher
+            # expansion index than every pre-existing sibling and so must be
+            # laid out below them for source order to match index order.
+            prev_line = insert_after
+            new_line_n = insert_after.line_n + 1
+            total_offset = target.line_n - new_line_n
+        else:
+            prev_line, total_offset, new_line_n = infer_line_context(
+                target, line_n
+            )
     indent = get_indent(prev_line.content)
     new_line = Line(indent + "{{DIAG}}\n", new_line_n)
     add_line(new_line, lines)
@@ -1159,16 +1172,74 @@ def update_lines(
                 diag.had_absolute_line_in_source
             )
 
-    diag_errors.sort(reverse=True, key=lambda diag_error: diag_error.line)
+    # Process bottom-to-top so inserting directives above a target line does
+    # not shift the not-yet-processed targets below it. Within a single line,
+    # break ties by expansion index (also descending): sibling expansions that
+    # need to be synthesized are each inserted just above the shared target, so
+    # the last one processed ends up highest. Feeding them highest-index-first
+    # therefore lays them out in ascending index order, matching the order the
+    # verifier assigns expansion indices to `expected-expansion` directives.
+    def _sort_key(diag_error):
+        index = getattr(diag_error, "expansion_index", None)
+        return (diag_error.line, index if index is not None else -1)
+
+    diag_errors.sort(reverse=True, key=_sort_key)
+
+    # Snapshot the sibling expected-expansion directives already present at
+    # each expansion target line, in source order, before synthesizing any new
+    # ones. The verifier's expansion index is positional in this order, so
+    # capturing it up front keeps index->directive routing stable even as we
+    # add missing siblings during this pass. `synthesized_expansions` records
+    # siblings we create here, keyed by (target line, index), so a later nested
+    # diag for a different index at the same location reuses or extends the set
+    # instead of mis-filing into an existing sibling.
+    preexisting_expansions = {}
+    synthesized_expansions = {}
+    for diag_error in diag_errors:
+        if (
+            isinstance(diag_error, NestedDiag)
+            and diag_error.expansion_index is not None
+            and diag_error.line not in preexisting_expansions
+        ):
+            preexisting_expansions[diag_error.line] = find_other_targeting(
+                lines, orig_lines, bool(nested_context), diag_error, prefix
+            )
+
     for diag_error in diag_errors:
         if not isinstance(diag_error, ExtraDiag) and not isinstance(
             diag_error, NestedDiag
         ):
             continue
-        other_diags = find_other_targeting(
-            lines, orig_lines, bool(nested_context), diag_error, prefix
+        expansion_index = getattr(diag_error, "expansion_index", None)
+        is_indexed_expansion = (
+            isinstance(diag_error, NestedDiag) and expansion_index is not None
         )
-        diag = other_diags[0] if other_diags else None
+        sibling_anchor = None
+        if is_indexed_expansion and expansion_index is not None:
+            # Route the nested diag to the specific sibling expansion the
+            # verifier reported by its expansion index. Indices below the count
+            # of pre-existing siblings map positionally onto them; higher
+            # indices belong to siblings we synthesize during this pass.
+            preexisting = preexisting_expansions.get(diag_error.line, [])
+            if expansion_index < len(preexisting):
+                diag = preexisting[expansion_index]
+            else:
+                diag = synthesized_expansions.get(
+                    (diag_error.line, expansion_index)
+                )
+                # A synthesized sibling has a higher index than every
+                # pre-existing sibling, so it must be laid out after them for
+                # source order to match expansion-index order. Anchor it below
+                # the last pre-existing sibling instead of stacking it above.
+                # Siblings are processed highest-index-first, so anchoring each
+                # to the same line still lays them out in ascending order.
+                if preexisting:
+                    sibling_anchor = preexisting[-1].line
+        else:
+            other_diags = find_other_targeting(
+                lines, orig_lines, bool(nested_context), diag_error, prefix
+            )
+            diag = other_diags[0] if other_diags else None
         if diag:
             diag.increment_count()
         else:
@@ -1181,7 +1252,12 @@ def update_lines(
                 orig_lines,
                 diag_error.prefix,
                 nested_context,
+                insert_after=sibling_anchor,
             )
+            if is_indexed_expansion:
+                synthesized_expansions[
+                    (diag_error.line, expansion_index)
+                ] = diag
         if isinstance(diag_error, NestedDiag):
             if not diag.closer:
                 whitespace = (
@@ -1429,7 +1505,14 @@ def update_test_file(filename, diag_errors, prefix, updated_test_files):
             if expansion_context:
                 diag.parent = expansion_context[-1]
             else:
-                diag.set_target(lines[diag.absolute_target() - 1])
+                target_idx = diag.absolute_target() - 1
+                if 0 <= target_idx < len(lines):
+                    diag.set_target(lines[target_idx])
+                # Otherwise the directive points outside the file (e.g. the code
+                # it targeted was deleted, leaving the offset dangling past the
+                # end). Leave it targetless: the verifier reports its expansion
+                # as "not produced", so it is dropped as a dead directive rather
+                # than crashing here on an out-of-range line index.
             if diag.category == "expansion":
                 expansion_context.append(diag)
             elif diag.category == "closing":
@@ -1530,12 +1613,18 @@ diag_error_re4 = re.compile(
 
 """
 ex:
-test.swift:12:14: note: in expansion from here
+test.swift:12:14: note: in expansion 0 from here
 func foo() {}
              ^
+
+The trailing integer is the index of the expansion among all expansions that
+share this source location, in the order their `expected-expansion` directives
+appear in the source (see DiagnosticVerifier's ExpansionContext). It routes a
+nested diagnostic to the correct sibling expansion when several expansions are
+attached at the same location (e.g. multiple peer macros on one declaration).
 """
 diag_expansion_note_re = re.compile(
-    r"(\S+):(\d+):(\d+): note: in expansion from here"
+    r"(\S+):(\d+):(\d+): note: in expansion (\d+) from here"
 )
 
 """
@@ -1739,13 +1828,14 @@ class StripChildrenBlock:
 
 
 class NestedDiag:
-    def __init__(self, file, line, col, nested):
+    def __init__(self, file, line, col, nested, expansion_index):
         self.file = file
         self.line = line
         self.col = col
         self.category = "expansion"
         self.content = None
         self.nested = nested
+        self.expansion_index = expansion_index
         self.prefix = ""
 
     def __str__(self):
@@ -1999,7 +2089,13 @@ def check_expectations(tool_output, prefix):
                 nested_note_lines = tool_output[i : i + 3]
                 dprint(f"nested note lines: {nested_note_lines}")
                 curr = [
-                    NestedDiag(m.group(1), int(m.group(2)), int(m.group(3)), e)
+                    NestedDiag(
+                        m.group(1),
+                        int(m.group(2)),
+                        int(m.group(3)),
+                        e,
+                        int(m.group(4)),
+                    )
                     for e in curr
                 ]
                 i += len(nested_note_lines)


### PR DESCRIPTION
Previously DiagnosticVerifier would assert that two expansions with checked diagnostics didn't share a location, because there was no support for keeping track of what should belong to each buffer. This change tracks both the directives and the macros in source order, so that the buffers are paired up in a stable and predictable fashion across runs. Also adds support for this to update-verify-tests, since the messages emitted from DiagnosticVerifier are changed to include an index of the expansion for that particular location.

This is motivated by test cases exercising safe wrappers in C++, since C++ interop ends up cloning functions into derived classes, resulting in multiple safe wrappers for the same underlying clang decl. 