### PR TITLE
[DebugInfo] Salvage begin_borrow

### DIFF
--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -1914,6 +1914,14 @@ static void salvageNullaryInst(SingleValueInstruction *inst) {
 static void salvageUnaryInst(SingleValueInstruction *SVI) {
   assert(SVI->getNumOperands() == 1 &&
          "salvageUnaryInst expects a single operand");
+  // Having an opened existential type salvaged into the debug reconstruction
+  // block is a problem: when the instruction defining the archetype is
+  // removed, it would leave an undef with a dangling opened existential type,
+  // which would trip the SIL verifier.
+  // There should be no debug use if the operand is null, but bail early.
+  if (!SVI->getOperand(0) || SVI->getOperand(0)->getType().hasOpenedExistential()) {
+    return;
+  }
   SmallVector<Operand *> debugUses(getDebugUses(SVI));
   for (Operand *U : debugUses) {
     auto *DbgInst = cast<DebugValueInst>(U->getUser());
@@ -2340,7 +2348,8 @@ void swift::salvageDebugInfo(SILInstruction *I) {
   if (isa<IndexAddrInst>(I) || isa<IndexRawPointerInst>(I))
     salvageBinaryInst(cast<SingleValueInstruction>(I));
 
-  if (isa<CopyValueInst>(I) || isa<MoveValueInst>(I))
+  if (isa<CopyValueInst>(I) || isa<MoveValueInst>(I) ||
+      isa<BeginBorrowInst>(I))
     salvageIdentityInst(cast<SingleValueInstruction>(I));
 
   if (auto *builtin = dyn_cast<BuiltinInst>(I)) {

--- a/test/DebugInfo/salvage_dce.sil
+++ b/test/DebugInfo/salvage_dce.sil
@@ -12,6 +12,7 @@ struct TwoFields {
   @_hasStorage var y: Int64 { get set }
 }
 
+class Klass {}
 
 // CHECK-LABEL: sil @test_dce_struct_extract
 // CHECK: bb0(%0 : $TwoFields):
@@ -70,4 +71,26 @@ bb0(%0 : $TwoFields):
   debug_value %2 : $Builtin.Int64, let, name "field"
   %3 = integer_literal $Builtin.Int64, 42
   return %3 : $Builtin.Int64
+}
+
+// A begin_borrow instruction can only get salvaged through DCE.
+// When the borrow only has debug uses, repoint it to the root, as they are
+// equivalent.
+// This pattern where a borrow has a debug use after the end_borrow is common
+// due to salvaging. This is valid as long as it is before the destroy of the
+// root (see the kill-invalid-debug-values pass).
+
+// CHECK-LABEL: sil [ossa] @test_dce_borrow
+// CHECK: bb0(%0 : @owned $Klass):
+// CHECK:   debug_value %0, let, name "borrowed"
+// CHECK-NOT: transform
+// CHECK:   destroy_value %0
+sil [ossa] @test_dce_borrow : $@convention(thin) (@owned Klass) -> Builtin.Int64 {
+bb0(%0 : @owned $Klass):
+  %1 = begin_borrow %0 : $Klass
+  end_borrow %1 : $Klass
+  debug_value %1 : $Klass, let, name "borrowed"
+  destroy_value %0 : $Klass
+  %5 = integer_literal $Builtin.Int64, 42
+  return %5 : $Builtin.Int64
 }

--- a/test/SILOptimizer/dead_alloc.swift
+++ b/test/SILOptimizer/dead_alloc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -O -emit-sil -parse-as-library -sil-verify-all %s | %FileCheck %s
+// RUN: %target-swift-frontend -O -emit-sil -parse-as-library -sil-verify-all -Xllvm -sil-print-transform-blocks=false %s | %FileCheck %s
 
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 
@@ -51,7 +51,6 @@ public func deadClassInstance() {
 
 // CHECK-LABEL: sil @$s10dead_alloc0A13ManagedBufferyyF :
 // CHECK:       bb0:
-// CHECK-NEXT:    debug_value
 // CHECK-NEXT:    debug_value
 // CHECK-NEXT:    tuple
 // CHECK-NEXT:    return

--- a/test/SILOptimizer/devirt_inherited_conformance.swift
+++ b/test/SILOptimizer/devirt_inherited_conformance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -O %s -emit-sil | %FileCheck %s
+// RUN: %target-swift-frontend -O %s -emit-sil -Xllvm -sil-print-transform-blocks=false | %FileCheck %s
 
 // Make sure that we can dig all the way through the class hierarchy and
 // protocol conformances.
@@ -165,8 +165,8 @@ public func compareComparable<T:Comparable>(_ x: T, _ y:T) -> Bool {
 // CHECK: bb0
 // CHECK-NEXT: debug_value undef : $D, let, name "x", argno 1
 // CHECK-NEXT: debug_value undef : $D, let, name "y", argno 2
-// CHECK-NEXT: debug_value undef : $C, let, name "lhs", argno 1
-// CHECK-NEXT: debug_value undef : $C, let, name "rhs", argno 2
+// CHECK-NEXT: debug_value undef : {{.*}}, let, name "lhs", argno 1
+// CHECK-NEXT: debug_value undef : {{.*}}, let, name "rhs", argno 2
 // CHECK-NEXT: integer_literal $Builtin.Int1, -1
 // CHECK-NEXT: struct $Bool
 // CHECK: return
@@ -182,8 +182,8 @@ public func testCompareEquals() -> Bool {
 // CHECK: bb0
 // CHECK-NEXT: debug_value undef : $D, let, name "x", argno 1
 // CHECK-NEXT: debug_value undef : $D, let, name "y", argno 2
-// CHECK-NEXT: debug_value undef : $C, let, name "lhs", argno 1
-// CHECK-NEXT: debug_value undef : $C, let, name "rhs", argno 2
+// CHECK-NEXT: debug_value undef : {{.*}}, let, name "lhs", argno 1
+// CHECK-NEXT: debug_value undef : {{.*}}, let, name "rhs", argno 2
 // CHECK-NEXT: integer_literal $Builtin.Int1, -1
 // CHECK-NEXT: struct $Bool
 // CHECK: return
@@ -196,11 +196,11 @@ public func testCompareMinMinMin() -> Bool {
 // CHECK: bb0
 // CHECK-NEXT: debug_value undef : $D, let, name "x", argno 1
 // CHECK-NEXT: debug_value undef : $D, let, name "y", argno 2
-// CHECK-NEXT: debug_value undef : $C, let, name "c1", argno 1
-// CHECK-NEXT: debug_value undef : $C, let, name "c2", argno 2
-// CHECK-NEXT: debug_value undef : $C, let, name "self", argno 3
-// CHECK-NEXT: debug_value undef : $C, let, name "lhs", argno 1
-// CHECK-NEXT: debug_value undef : $C, let, name "rhs", argno 2
+// CHECK-NEXT: debug_value undef : {{.*}}, let, name "c1", argno 1
+// CHECK-NEXT: debug_value undef : {{.*}}, let, name "c2", argno 2
+// CHECK-NEXT: debug_value undef : {{.*}}, let, name "self", argno 3
+// CHECK-NEXT: debug_value undef : {{.*}}, let, name "lhs", argno 1
+// CHECK-NEXT: debug_value undef : {{.*}}, let, name "rhs", argno 2
 // CHECK-NEXT: integer_literal $Builtin.Int1, -1
 // CHECK-NEXT: struct $Bool
 // CHECK: return
@@ -217,9 +217,9 @@ public func BooCall<T:Simple>(_ x:T, _ y:T) -> Bool {
 // CHECK: bb0
 // CHECK-NEXT: debug_value undef : $D, let, name "x", argno 1
 // CHECK-NEXT: debug_value undef : $D, let, name "y", argno 2
-// CHECK-NEXT: debug_value undef : $C, let, name "c1", argno 1
-// CHECK-NEXT: debug_value undef : $C, let, name "c2", argno 2
-// CHECK-NEXT: debug_value undef : $C, let, name "self", argno 3
+// CHECK-NEXT: debug_value undef : {{.*}}, let, name "c1", argno 1
+// CHECK-NEXT: debug_value undef : {{.*}}, let, name "c2", argno 2
+// CHECK-NEXT: debug_value undef : {{.*}}, let, name "self", argno 3
 // CHECK-NEXT: integer_literal $Builtin.Int1, 0
 // CHECK-NEXT: struct $Bool
 // CHECK: return

--- a/test/SILOptimizer/simplify_struct.sil
+++ b/test/SILOptimizer/simplify_struct.sil
@@ -14,10 +14,11 @@ struct Outer {
 
 // CHECK-LABEL: sil [ossa] @simple_delay_struct :
 // CHECK:       bb0
+// CHECK-NEXT:    debug_value %0, var, name "y", type $S, expr op_fragment:#S.a
+// CHECK-NEXT:    debug_value %1, var, name "y", type $S, expr op_fragment:#S.b
 // CHECK-NEXT:    debug_value %0, var, name "x", type $S, expr op_fragment:#S.a
 // CHECK-NEXT:    debug_value %1, var, name "x", type $S, expr op_fragment:#S.b
 // CHECK-NEXT:    [[B:%.*]] = begin_borrow %0
-// TODO: begin_borrow should get salvaged too.
 // CHECK-NEXT:    fix_lifetime [[B]]
 // CHECK-NEXT:    fix_lifetime %1
 // CHECK-NEXT:    end_borrow [[B]]


### PR DESCRIPTION

Now that DCE calls salvageDebugInfo, begin_borrow accounted for 5% of missing salvages.

This also uncovered a problem when opened existentials were salvaged, as DCE would set the operand to an undef of a removed archetype, so those are no longer supported.

Increases DWARF variables with location by 0.35% in the stdlib.