### PR TITLE
Sema: Downgrade errors for unavailable computed properties with initial values

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -442,6 +442,16 @@ namespace swift {
     /// until the next major language version.
     InFlightDiagnostic &warnUntilLanguageMode(LanguageMode mode);
 
+    /// Conditionally limit the diagnostic behavior to warning until the
+    /// specified language mode. If \p mode is \c std::nullopt, no limit is
+    /// imposed.
+    InFlightDiagnostic &
+    warnUntilLanguageMode(std::optional<LanguageMode> mode) {
+      if (!mode)
+        return *this;
+      return warnUntilLanguageMode(*mode);
+    }
+
     /// Limit the diagnostic behavior to warning if the context is a
     /// swiftinterface.
     ///

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2261,6 +2261,45 @@ getSemanticAvailableRangeDeclAndAttr(const Decl *decl,
   return std::nullopt;
 }
 
+// The raw values of this enum must be kept in sync with the select clause
+// in diag::availability_stored_property_no_potential and
+// diag::availability_stored_property_no_unavailable.
+enum NoAvailableAttrDiagnosticPropertyKind : unsigned {
+  StoredProperty,
+  ComputedPropertyWithInitialValue,
+};
+
+static std::optional<NoAvailableAttrDiagnosticPropertyKind>
+getPropertyKindForAvailableAttrDiagnostic(const VarDecl *VD) {
+  if (VD->hasStorageOrWrapsStorage())
+    return StoredProperty;
+
+  if (VD->hasInitialValue())
+    return ComputedPropertyWithInitialValue;
+
+  return std::nullopt;
+}
+
+/// Returns a non-null language mode if diagnostics about the availability of
+/// \p D relative to \p domain should be downgraded to a warning until that
+/// language mode.
+static std::optional<LanguageMode>
+getLanguageModeForPropertyAvailabilityErrors(const Decl *D,
+                                             AvailabilityDomain domain) {
+  auto *VD = dyn_cast<VarDecl>(D);
+  if (!VD)
+    return std::nullopt;
+
+  auto kind = getPropertyKindForAvailableAttrDiagnostic(VD);
+  if (kind != ComputedPropertyWithInitialValue)
+    return std::nullopt;
+
+  if (!domain.isPlatform() && !domain.isUniversal())
+    return std::nullopt;
+
+  return LanguageMode::future;
+}
+
 void AttributeChecker::visitAvailableAttr(AvailableAttr *parsedAttr) {
   if (Ctx.LangOpts.DisableAvailabilityChecking)
     return;
@@ -5653,13 +5692,18 @@ void AttributeChecker::checkAvailableAttrs(ArrayRef<AvailableAttr *> attrs) {
   if (!availabilityRestriction)
     return;
 
+  auto *parsedAttr = const_cast<AvailableAttr *>(
+      availabilityRestriction->getAttr().getParsedAttr());
+  auto domain = availabilityRestriction->getAttr().getDomain();
+
   // If the decl is unavailable relative to its parent and it's not a
   // declaration that is allowed to be unavailable, diagnose.
   if (availabilityRestriction->isUnavailable()) {
-    auto attr = availabilityRestriction->getAttr();
-    if (auto diag = TypeChecker::diagnosticIfDeclCannotBeUnavailable(D, attr)) {
-      diagnoseAndRemoveAttr(const_cast<AvailableAttr *>(attr.getParsedAttr()),
-                            *diag);
+    if (auto diag = TypeChecker::diagnosticIfDeclCannotBeUnavailable(
+            D, availabilityRestriction->getAttr())) {
+      diagnoseAndRemoveAttr(parsedAttr, *diag)
+          .warnUntilLanguageMode(
+              getLanguageModeForPropertyAvailabilityErrors(D, domain));
       return;
     }
   }
@@ -5667,11 +5711,11 @@ void AttributeChecker::checkAvailableAttrs(ArrayRef<AvailableAttr *> attrs) {
   // If the decl is potentially unavailable relative to its parent and it's
   // not a declaration that is allowed to be potentially unavailable, diagnose.
   if (!availabilityRestriction->isUnavailable()) {
-    auto attr = availabilityRestriction->getAttr();
     if (auto diag =
             TypeChecker::diagnosticIfDeclCannotBePotentiallyUnavailable(D))
-      diagnoseAndRemoveAttr(const_cast<AvailableAttr *>(attr.getParsedAttr()),
-                            *diag);
+      diagnoseAndRemoveAttr(parsedAttr, *diag)
+          .warnUntilLanguageMode(
+              getLanguageModeForPropertyAvailabilityErrors(D, domain));
   }
 }
 
@@ -5971,25 +6015,6 @@ Type TypeChecker::checkReferenceOwnershipAttr(VarDecl *var, Type type,
 
   // Change the type to the appropriate reference storage type.
   return ReferenceStorageType::get(type, ownershipKind, var->getASTContext());
-}
-
-// The raw values of this enum must be kept in sync with the select clause
-// in diag::availability_stored_property_no_potential and
-// diag::availability_stored_property_no_unavailable.
-enum NoAvailableAttrDiagnosticPropertyKind : unsigned {
-  StoredProperty,
-  ComputedPropertyWithInitialValue,
-};
-
-static std::optional<NoAvailableAttrDiagnosticPropertyKind>
-getPropertyKindForAvailableAttrDiagnostic(const VarDecl *VD) {
-  if (VD->hasStorageOrWrapsStorage())
-    return StoredProperty;
-
-  if (VD->hasInitialValue())
-    return ComputedPropertyWithInitialValue;
-
-  return std::nullopt;
 }
 
 std::optional<Diagnostic>

--- a/test/Availability/availability_custom_domains.swift
+++ b/test/Availability/availability_custom_domains.swift
@@ -715,3 +715,46 @@ func testSwitchExpr(e: E) -> Int { // expected-note 2 {{add '@available' attribu
     0
   }
 }
+
+struct HasPropertiesWithAvailabilityRestrictions {
+  @available(DynamicDomain) // expected-error {{stored properties cannot be marked potentially unavailable with '@available'}}
+  var potentiallyUnavailable: Int = 0
+
+  @available(DynamicDomain, unavailable) // expected-error {{stored properties cannot be marked unavailable with '@available'}}
+  var unavailable: Int = 0
+
+  @available(DynamicDomain) // OK
+  var potentiallyUnavailableComputed: Int {
+    get { 0 }
+    set { _ = newValue }
+  }
+
+  @available(DynamicDomain, unavailable) // OK
+  var unavailableComputed: Int {
+    get { 0 }
+    set { _ = newValue }
+  }
+
+  @available(DynamicDomain) // expected-error {{computed property with initial value cannot be marked potentially unavailable with '@available'}}
+  public var potentiallyUnavailableComputedWithInitialValue: Int? {
+    init { _ = newValue }
+    get { 0 }
+  }
+
+  @available(DynamicDomain, unavailable) // expected-error {{computed property with initial value cannot be marked unavailable with '@available'}}
+  public var unavailableComputedWithInitialValue: Int? {
+    init { _ = newValue }
+    get { 0 }
+  }
+
+  init() { fatalError() } // To suppress memberwise initializer
+}
+
+enum HasAssociatedValueCasesWithAvailabilityRestrictions {
+  @available(DynamicDomain) // expected-error {{enum cases with associated values cannot be marked potentially unavailable with '@available'}}
+  case potentiallyUnavailable(Int)
+
+  // FIXME: [availability] This should be rejected
+  @available(DynamicDomain, unavailable)
+  case unavailable(Int)
+}

--- a/test/Availability/availability_stored.swift
+++ b/test/Availability/availability_stored.swift
@@ -79,14 +79,14 @@ struct BadReferenceStruct1 { // expected-note 3 {{add '@available' attribute to 
     get { x }
   }
 
-  // expected-error@+1 {{computed property with initial value cannot be marked potentially unavailable with '@available'}}
+  // expected-warning@+1 {{computed property with initial value cannot be marked potentially unavailable with '@available'; this will be an error in a future Swift language mode}}
   @available(macOS 50, *)
   var computedWithInitialValue: NewStruct = .init() { // expected-error {{'NewStruct' is only available in macOS 50 or newer}}
     init { _ = newValue }
     get { x }
   }
 
-  // expected-error@+1 {{computed property with initial value cannot be marked potentially unavailable with '@available'}}
+  // expected-warning@+1 {{computed property with initial value cannot be marked potentially unavailable with '@available'; this will be an error in a future Swift language mode}}
   @available(macOS 50, *)
   var computedWithImplicitInitialValue: NewStruct? { // expected-error {{'NewStruct' is only available in macOS 50 or newer}}
     init { _ = newValue }
@@ -122,14 +122,14 @@ struct BadReferenceStruct2 {
     get { x }
   }
 
-  // expected-error@+1 {{computed property with initial value cannot be marked potentially unavailable with '@available'}}
+  // expected-warning@+1 {{computed property with initial value cannot be marked potentially unavailable with '@available'; this will be an error in a future Swift language mode}}
   @available(macOS 50, *)
   var computedWithInitialValue: NewStruct = .init() { // expected-error {{'NewStruct' is only available in macOS 50 or newer}}
     init { _ = newValue }
     get { x }
   }
 
-  // expected-error@+1 {{computed property with initial value cannot be marked potentially unavailable with '@available'}}
+  // expected-warning@+1 {{computed property with initial value cannot be marked potentially unavailable with '@available'; this will be an error in a future Swift language mode}}
   @available(macOS 50, *)
   var computedWithImplicitInitialValue: NewStruct? { // expected-error {{'NewStruct' is only available in macOS 50 or newer}}
     init { _ = newValue }
@@ -165,14 +165,14 @@ public struct PublicStruct {
     get { x }
   }
 
-  // expected-error@+1 {{computed property with initial value cannot be marked potentially unavailable with '@available'}}
+  // expected-warning@+1 {{computed property with initial value cannot be marked potentially unavailable with '@available'; this will be an error in a future Swift language mode}}
   @available(macOS 50, *)
   public var computedWithInitialValue: NewStruct = .init() { // expected-error {{'NewStruct' is only available in macOS 50 or newer}}
     init { _ = newValue }
     get { x }
   }
 
-  // expected-error@+1 {{computed property with initial value cannot be marked potentially unavailable with '@available'}}
+  // expected-warning@+1 {{computed property with initial value cannot be marked potentially unavailable with '@available'; this will be an error in a future Swift language mode}}
   @available(macOS 50, *)
   public var computedWithImplicitInitialValue: NewStruct? { // expected-error {{'NewStruct' is only available in macOS 50 or newer}}
     init { _ = newValue }

--- a/test/Availability/availability_stored_unavailable.swift
+++ b/test/Availability/availability_stored_unavailable.swift
@@ -125,14 +125,14 @@ struct BadStruct {
     get { UnavailableMacOSStruct() }
   }
 
-  // expected-error@+1 {{computed property with initial value cannot be marked unavailable with '@available'}}
+  // expected-warning@+1 {{computed property with initial value cannot be marked unavailable with '@available'; this will be an error in a future Swift language mode}}
   @available(macOS, unavailable)
   var computedUnavailableMacOSWithInitialValue: UnavailableMacOSStruct = .init() { // expected-error {{'UnavailableMacOSStruct' is unavailable in macOS}}
     init { _ = newValue }
     get { UnavailableMacOSStruct() } // expected-error {{'UnavailableMacOSStruct' is unavailable in macOS}}
   }
 
-  // expected-error@+1 {{computed property with initial value cannot be marked unavailable with '@available'}}
+  // expected-warning@+1 {{computed property with initial value cannot be marked unavailable with '@available'; this will be an error in a future Swift language mode}}
   @available(*, unavailable)
   var computedUniversallyUnavailableWithInitialValue: UniversallyUnavailableStruct = .init() { // expected-error {{'UniversallyUnavailableStruct' is unavailable}}
     init { _ = newValue }


### PR DESCRIPTION
Diagnostics banning computed properties with initial values from being marked unavailable or potentially unavailable were added recently, so stage them in as warnings to give existing code time to adapt. This is only done when the availability restriction comes from a platform or the universal domain, though; the diagnostic remains an error immediately when the restriction comes from a custom availability domain, since custom domains are new enough that there is no pre-existing source to be compatible with.

Resolves rdar://182833788.
