### PR TITLE
utils: introduce sxs-audit

### DIFF
--- a/utils/sxs-audit/Invoke-SwiftToolchainSxSAudit.ps1
+++ b/utils/sxs-audit/Invoke-SwiftToolchainSxSAudit.ps1
@@ -1,0 +1,120 @@
+# Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+param
+(
+  [Parameter(Mandatory = $true)]
+  [string] $ToolchainRoot,
+
+  [string] $RuntimeRoot,
+
+  [string] $InstallerRoot,
+
+  [string] $Swift = 'swift'
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (!$InstallerRoot) {
+  $repository = Join-Path $PSScriptRoot '..\..\..'
+  $InstallerRoot = Join-Path $repository 'swift-installer-scripts\platforms\Windows'
+}
+
+if (!$RuntimeRoot) {
+  $version = (Split-Path $ToolchainRoot -Leaf) -split '\+', 2
+  $installation = Split-Path (Split-Path $ToolchainRoot -Parent) -Parent
+  $RuntimeRoot = Join-Path $installation "Runtimes\$($version[0])\usr\bin"
+}
+
+$ScanRoot = Join-Path $ToolchainRoot 'usr\bin'
+$WiXNamespace = 'http://wixtoolset.org/schemas/v4/wxs'
+$ToolPackages = @('bld', 'cli', 'dbg', 'ide')
+$Disabled = '<\?if\s+True\s*==\s*False\s*\?>.*?<\?endif\s*\?>'
+$PE = '\.(exe|dll)$'
+$Assembly = '^\$\(ToolchainRoot\)[\\/]usr[\\/]bin[\\/]([^\\/]+)[\\/]([^\\/]+\.dll)$'
+
+function Read-WiX([string] $Path) {
+  $text = Get-Content -Raw -Encoding UTF8 $Path
+  $options = [Text.RegularExpressions.RegexOptions]::IgnoreCase -bor [Text.RegularExpressions.RegexOptions]::Singleline
+  $text = [Text.RegularExpressions.Regex]::Replace($text, $Disabled, '', $options)
+  $document = [Xml.XmlDocument]::new()
+  $document.LoadXml($text)
+  return ,$document
+}
+
+function New-NamespaceManager([Xml.XmlDocument] $Document) {
+  $manager = [Xml.XmlNamespaceManager]::new($Document.NameTable)
+  $manager.AddNamespace('wix', $WiXNamespace)
+  return ,$manager
+}
+
+$arguments = @()
+foreach ($package in $ToolPackages) {
+  $path = Join-Path $InstallerRoot "$package\$package.wxi"
+  $document = Read-WiX $path
+  $namespaces = New-NamespaceManager $document
+  $files = $document.SelectNodes('/wix:Include/wix:Package//wix:File[@Source]', $namespaces)
+  foreach ($file in $files) {
+    $node = $file
+    $directory = $null
+    while ($null -ne $node) {
+      if ($node.NodeType -eq [Xml.XmlNodeType]::Element -and $node.HasAttribute('Directory')) {
+        $directory = $node.GetAttribute('Directory')
+        break
+      }
+      $node = $node.ParentNode
+    }
+    if ($directory -ne 'toolchain_$(VariantName)_usr_bin') {
+      continue
+    }
+
+    $name = $file.GetAttribute('Name')
+    if (!$name) {
+      $name = [IO.Path]::GetFileName($file.GetAttribute('Source'))
+    }
+    if ($name -notmatch $PE) {
+      continue
+    }
+    if (!(Test-Path (Join-Path $ScanRoot $name) -PathType Leaf)) {
+      continue
+    }
+    $arguments += '--file', "$package=$name"
+  }
+}
+
+$groups = @{}
+$path = Join-Path $InstallerRoot 'prt\prt.wxi'
+$document = Read-WiX $path
+$namespaces = New-NamespaceManager $document
+foreach ($group in $document.SelectNodes('/wix:Include/wix:Package//wix:ComponentGroup', $namespaces)) {
+  $assemblies = @()
+  foreach ($file in $group.SelectNodes('.//wix:File[@Source]', $namespaces)) {
+    $match = [Text.RegularExpressions.Regex]::Match($file.GetAttribute('Source'), $Assembly, [Text.RegularExpressions.RegexOptions]::IgnoreCase)
+    if (!$match.Success) { continue }
+    $name = [IO.Path]::GetFileNameWithoutExtension($match.Groups[2].Value)
+    if ($name -ieq $match.Groups[1].Value) {
+      $assemblies += $match.Groups[1].Value
+    }
+  }
+  $groups[$group.GetAttribute('Id')] = $assemblies
+}
+
+foreach ($package in $ToolPackages) {
+  $identifier = "SxSSwiftRuntime$($package.ToUpperInvariant())"
+  $feature = $document.SelectSingleNode("/wix:Include/wix:Package//wix:Feature[@Id='$identifier']", $namespaces)
+  if ($null -eq $feature) {
+    throw "PRT feature not found: $identifier"
+  }
+
+  $arguments += '--feature', "$package=$identifier"
+  foreach ($reference in $feature.SelectNodes('./wix:ComponentGroupRef', $namespaces)) {
+    $group = $reference.GetAttribute('Id')
+    foreach ($assembly in $groups[$group]) {
+      $arguments += '--authored', "$package=$assembly"
+    }
+  }
+}
+
+$command = @('run', '--package-path', $PSScriptRoot, 'sxs-audit', '--root', $ScanRoot, '--runtime-root', $RuntimeRoot) + $arguments
+& $Swift @command
+exit $LASTEXITCODE

--- a/utils/sxs-audit/Package.resolved
+++ b/utils/sxs-audit/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "47997272de3a2c5a08c430208393ce337f0849125af2fe0224cbd5a130d2c988",
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/utils/sxs-audit/Package.swift
+++ b/utils/sxs-audit/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 6.4
+
+internal import PackageDescription
+
+let package =
+    Package(name: "sxs-audit",
+            products: [
+              .executable(name: "sxs-audit",
+                          targets: ["SxSAudit"]),
+            ],
+            dependencies: [
+              .package(url: "https://github.com/apple/swift-argument-parser",
+                       from: "1.8.2"),
+            ],
+            targets: [
+              .executableTarget(name: "SxSAudit",
+                                dependencies: [
+                                  .product(name: "ArgumentParser",
+                                           package: "swift-argument-parser"),
+                                ],
+                                linkerSettings: [
+                                  .linkedLibrary("Dbghelp",
+                                                 .when(platforms: [.windows])),
+                                ]),
+              .testTarget(name: "SxSAuditTests",
+                          dependencies: ["SxSAudit"]),
+            ])

--- a/utils/sxs-audit/README.md
+++ b/utils/sxs-audit/README.md
@@ -1,0 +1,92 @@
+# SxS Audit
+
+`sxs-audit` computes the private runtime closure required by groups of Windows
+PE files. It can also compare those requirements with authored runtime
+features.
+
+The scan root contains package-provided EXEs and DLLs. Private assemblies use
+the Windows SxS layout `<root>\<assembly>\<assembly>.dll`. The runtime root is a
+complete flat directory of candidate runtime DLLs from which the package
+closures are trimmed.
+
+The executable is Windows-only. It uses:
+
+- `FoundationEssentials.URL`, `FileManager`, and mapped `Data` for files;
+- `WinSDK` and DbgHelp to inspect PE images in-place;
+- `swift-argument-parser` for the command-line interface;
+- the Swift standard library for dependency closure and report emission.
+
+## Run
+
+The analyzer groups PE files by an arbitrary package name:
+
+- `--root` is the directory containing the EXEs and DLLs to inspect.
+- `--runtime-root` is a flat directory containing every DLL that may be
+  selected for the private runtime.
+- `--file PACKAGE=FILE` assigns an EXE or DLL from the scan root to `PACKAGE`.
+  Repeat it for every file provided by that package. The analyzer combines
+  their dependencies into one runtime closure.
+
+For example, the following invocation calculates separate closures for a
+compiler package and a debugger package. `compiler.exe` and
+`CompilerSupport.dll` both contribute to the `compiler` closure.
+
+```powershell
+swift run `
+  --package-path C:\path\to\sxs-audit `
+  sxs-audit `
+  --root C:\path\to\image\bin `
+  --runtime-root C:\path\to\runtime\bin `
+  --file compiler=compiler.exe `
+  --file compiler=CompilerSupport.dll `
+  --file debugger=debugger.exe
+```
+
+`compiler` and `debugger` are user-defined package names. The file names
+identify direct children of the scan root. Both roots are required; the
+analyzer makes no assumptions about a toolchain or its installation layout.
+
+To audit installer authoring, `--feature PACKAGE=FEATURE` associates a package
+with the name of its runtime feature. Each `--authored PACKAGE=ASSEMBLY` then
+declares an assembly already present in that feature:
+
+```powershell
+  --feature compiler=CompilerRuntime `
+  --authored compiler=Core `
+  --authored compiler=Dispatch
+```
+
+Assembly values are DLL names without the `.dll` extension. If no
+`--feature` or `--authored` options are supplied, the analyzer only reports the
+required closures.
+
+Use `--exclude-runtime-dll NAME` to add an exact DLL name or a trailing-`*`
+prefix pattern to the default VC runtime and non-shipping test-runtime
+exclusions.
+
+## Swift installer adapter
+
+`Invoke-SwiftToolchainSxSAudit.ps1` extracts package provisions and PRT feature
+memberships from the Swift installer authoring:
+
+```powershell
+C:\path\to\swift\utils\sxs-audit\Invoke-SwiftToolchainSxSAudit.ps1 `
+  -ToolchainRoot $toolchain
+```
+
+By default, the script finds `swift-installer-scripts` beside the Swift
+repository and derives the matching flat runtime from the installed toolchain.
+Use `-InstallerRoot` or `-RuntimeRoot` to override either location, or `-Swift`
+to select a different `swift` executable.
+
+Configure `SDKROOT` for that Swift installation. Its flat runtime directory
+must also be on `PATH` so SwiftPM can run temporary manifest executables.
+
+## Output
+
+The report is CSV with the columns `record`, `package`, `subject`, `category`,
+and `value`. File records describe direct runtime roots and their transitive
+closures. Package records compare required and authored assemblies. Diagnostic
+records identify missing provisions, missing authored features, incomplete flat
+runtimes, unowned runtime-dependent files, and unused runtime assemblies. An
+empty category produces no rows.

--- a/utils/sxs-audit/Sources/SxSAudit/DependencyPlan.swift
+++ b/utils/sxs-audit/Sources/SxSAudit/DependencyPlan.swift
@@ -1,0 +1,253 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+internal import struct FoundationEssentials.URL
+
+internal struct FilePlan {
+  internal let file: String
+  internal let package: String
+  internal let roots: Array<String>
+  internal let closure: Array<String>
+}
+
+internal struct PackagePlan {
+  internal let package: String
+  internal let feature: String?
+  internal let required: Array<String>
+  internal let authored: Array<String>?
+  internal let missing: Array<String>
+  internal let extra: Array<String>
+}
+
+internal struct Plan {
+  internal let files: Array<FilePlan>
+  internal let packages: Array<PackagePlan>
+  internal let missing: Array<String>
+  internal let absent: Array<String>
+  internal let incomplete: Array<String>
+  internal let unmapped: Array<String>
+  internal let unused: Array<String>
+}
+
+private let kExcludedDLLs: InlineArray<_, String> = [
+  "concrt140",
+  "msvcp140*",
+  "testing",
+  "_testing_foundation",
+  "_testing_winsdk",
+  "_testinginterop",
+  "vccorlib140",
+  "vcruntime140*",
+  "xctest",
+]
+
+extension Span where Element == String {
+  internal borrowing func excludes(_ value: String) -> Bool {
+    let value = value.lowercased()
+    for pattern in self {
+      let pattern = pattern.lowercased()
+      let matches = if pattern.hasSuffix("*") {
+        value.hasPrefix(pattern.dropLast())
+      } else {
+        value == pattern
+      }
+      if matches { return true }
+    }
+    return false
+  }
+}
+
+extension Sequence where Element == String {
+  internal func sorted() -> Array<String> {
+    sorted { $0.lowercased() < $1.lowercased() }
+  }
+}
+
+private func mapping(_ paths: Array<URL>) throws(AnalyzerError)
+    -> Dictionary<String, URL> {
+  var result = Dictionary<String, URL>()
+  for path in paths {
+    let key = path.lastPathComponent.lowercased()
+    if let previous = result[key] {
+      throw AnalyzerError("case-insensitive filename collision: " +
+                          "\(previous) and \(path)")
+    }
+    result[key] = path
+  }
+  return result
+}
+
+extension ImportReader {
+  internal mutating func imports(of path: URL,
+                                 names: Dictionary<String, String>) throws
+      -> Set<String> {
+    var result = Set<String>()
+    for imported in try imports(of: path) {
+      let file = URL(fileURLWithPath: imported)
+      let name = file.stem.lowercased()
+      if let canonical = names[name] {
+        result.insert(canonical)
+      }
+    }
+    return result
+  }
+
+  internal mutating func roots(of path: URL, files: Dictionary<String, URL>,
+                               names: Dictionary<String, String>) throws
+      -> Set<String> {
+    var roots = Set<String>()
+    var visited = Set<URL>()
+    var queue = [path]
+    var cursor = 0
+    while cursor < queue.count {
+      let current = queue[cursor]
+      cursor += 1
+      guard visited.insert(current).inserted else { continue }
+
+      for imported in try imports(of: current) {
+        let file = URL(fileURLWithPath: imported)
+        if let canonical = names[file.stem.lowercased()] {
+          roots.insert(canonical)
+        } else if let local = files[file.lastPathComponent.lowercased()] {
+          queue.append(local)
+        }
+      }
+    }
+    return roots
+  }
+}
+
+private func assemblies(in root: URL) throws(AnalyzerError) -> Array<URL> {
+  try root.children().compactMap { directory in
+    guard directory.directory else { return nil }
+    let assembly = directory
+      .appendingPathComponent(directory.lastPathComponent)
+      .appendingPathExtension("dll")
+    return assembly.file ? assembly : nil
+  }
+}
+
+private func closure(of roots: Set<String>,
+                     graph: Dictionary<String, Set<String>>) -> Set<String> {
+  var result = Set<String>()
+  var queue = Array(roots)
+  var cursor = 0
+  while cursor < queue.count {
+    let current = queue[cursor]
+    cursor += 1
+    guard result.insert(current).inserted else { continue }
+    queue.append(contentsOf: graph[current] ?? [])
+  }
+  return result
+}
+
+internal func plan(root: URL, runtime: URL, packages: Array<PackageInput>,
+                   exclusions: Array<String>) throws
+    -> Plan {
+  var provisions = Dictionary<String, String>()
+  for package in packages {
+    for (folded, install) in package.files {
+      if let previous = provisions[folded],
+          previous != package.name {
+        throw AnalyzerError("\(install) is referenced by both " +
+                            "\(previous) and \(package.name)")
+      }
+      provisions[folded] = package.name
+    }
+  }
+
+  let runtimes = try runtime.children(withExtension: "dll")
+    .filter {
+      !kExcludedDLLs.span.excludes($0.stem) &&
+        !exclusions.span.excludes($0.stem)
+    }
+  guard !runtimes.isEmpty else {
+    throw AnalyzerError("no runtime DLLs found in \(runtime.path)")
+  }
+
+  var files = try mapping(runtimes)
+  var incomplete = Set<String>()
+  for path in try assemblies(in: root)
+      where !kExcludedDLLs.span.excludes(path.stem) &&
+        !exclusions.span.excludes(path.stem) {
+    let key = path.lastPathComponent.lowercased()
+    if files[key] == nil {
+      files[key] = path
+      incomplete.insert(path.stem)
+    }
+  }
+  let names = Dictionary(uniqueKeysWithValues: files.map { key, path in
+    (String(key.dropLast(4)), path.stem)
+  })
+  let installed = try mapping(root.children(withExtension: "exe") +
+                              root.children(withExtension: "dll"))
+  var reader = ImportReader()
+
+  var graph = Dictionary<String, Set<String>>()
+  for path in files.values {
+    graph[path.stem] = try reader.imports(of: path, names: names)
+  }
+
+  var plans = Array<FilePlan>()
+  var missing = Array<String>()
+  var needs = Dictionary<String, Set<String>>()
+  for (folded, package) in provisions.sorted(by: { $0.key < $1.key }) {
+    guard let path = installed[folded] else {
+      missing.append(folded)
+      continue
+    }
+    let roots = try reader.roots(of: path, files: installed, names: names)
+    let closure = closure(of: roots, graph: graph)
+    needs[package, default: []].formUnion(closure)
+    plans.append(FilePlan(file: path.lastPathComponent, package: package,
+                          roots: roots.sorted(), closure: closure.sorted()))
+  }
+
+  var unmapped = Array<String>()
+  for (folded, path) in installed.sorted(by: { $0.key < $1.key })
+      where provisions[folded] == nil {
+    let roots = try reader.roots(of: path, files: installed, names: names)
+    if !roots.isEmpty { unmapped.append(path.lastPathComponent) }
+  }
+
+  var features = Array<PackagePlan>()
+  let auditing = packages.contains { $0.authored != nil }
+  var absent = Array<String>()
+  var used = Set<String>()
+  for package in packages {
+    let required = needs[package.name] ?? []
+    let authored = package.authored
+    if auditing, package.feature == nil {
+      absent.append(package.name)
+    }
+    used.formUnion(required)
+    features.append(PackagePlan(package: package.name, feature: package.feature,
+                                required: required.sorted(),
+                                authored: authored.map { $0.sorted() },
+                                missing: authored.map {
+                                  required.subtracting($0).sorted()
+                                } ?? [],
+                                extra: authored.map {
+                                  $0.subtracting(required).sorted()
+                                } ?? []))
+  }
+
+  let order = Dictionary(uniqueKeysWithValues: packages.enumerated().map {
+    ($0.element.name, $0.offset)
+  })
+  plans.sort {
+    let lhs = order[$0.package] ?? Int.max
+    let rhs = order[$1.package] ?? Int.max
+    return if lhs == rhs {
+      $0.file.lowercased() < $1.file.lowercased()
+    } else {
+      lhs < rhs
+    }
+  }
+
+  return Plan(files: plans, packages: features, missing: missing.sorted(),
+              absent: absent.sorted(),
+              incomplete: incomplete.sorted(),
+              unmapped: unmapped.sorted(),
+              unused: Set(names.values).subtracting(used).sorted())
+}

--- a/utils/sxs-audit/Sources/SxSAudit/Diagnostics.swift
+++ b/utils/sxs-audit/Sources/SxSAudit/Diagnostics.swift
@@ -1,0 +1,10 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+internal struct AnalyzerError: Error, CustomStringConvertible {
+  internal let description: String
+
+  internal init(_ description: String) {
+    self.description = description
+  }
+}

--- a/utils/sxs-audit/Sources/SxSAudit/FileSystem.swift
+++ b/utils/sxs-audit/Sources/SxSAudit/FileSystem.swift
@@ -1,0 +1,50 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+internal import class FoundationEssentials.FileManager
+internal import struct FoundationEssentials.Data
+internal import struct FoundationEssentials.URL
+
+extension URL {
+  internal var stem: String {
+    deletingPathExtension().lastPathComponent
+  }
+
+  internal var directory: Bool {
+    var directory = false
+    return FileManager.default.fileExists(atPath: path,
+                                          isDirectory: &directory) &&
+      directory
+  }
+
+  internal var file: Bool {
+    var directory = false
+    return FileManager.default.fileExists(atPath: path,
+                                          isDirectory: &directory) &&
+      !directory
+  }
+
+  internal func children() throws(AnalyzerError) -> Array<URL> {
+    let names: Array<String>
+    do {
+      names = try FileManager.default.contentsOfDirectory(atPath: path)
+    } catch {
+      throw AnalyzerError("unable to enumerate \(path): \(error)")
+    }
+    return names.map { appendingPathComponent($0) }
+  }
+
+  internal func children(withExtension extension: String)
+      throws(AnalyzerError) -> Array<URL> {
+    try children()
+      .filter { $0.pathExtension.lowercased() == `extension`.lowercased() }
+  }
+}
+
+internal func contents(_ url: URL) throws(AnalyzerError) -> Data {
+  do {
+    return try Data(contentsOf: url, options: .mappedIfSafe)
+  } catch {
+    throw AnalyzerError("unable to read \(url.path): \(error)")
+  }
+}

--- a/utils/sxs-audit/Sources/SxSAudit/Inputs.swift
+++ b/utils/sxs-audit/Sources/SxSAudit/Inputs.swift
@@ -1,0 +1,26 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+internal import struct FoundationEssentials.URL
+
+internal struct Inputs {
+  internal let root: URL
+  internal let runtime: URL
+  internal let exclusions: Array<String>
+}
+
+internal func inputs(root: String, runtime: String, exclusions: Array<String>)
+    throws(AnalyzerError) -> Inputs {
+  let root = URL(fileURLWithPath: root)
+  guard root.directory else {
+    throw AnalyzerError("scan root not found: \(root.path)")
+  }
+  let runtime = URL(fileURLWithPath: runtime)
+  guard runtime.directory else {
+    throw AnalyzerError("runtime root not found: \(runtime.path)")
+  }
+  return Inputs(root: root, runtime: runtime,
+                exclusions: exclusions.map {
+                  URL(fileURLWithPath: $0).stem
+                })
+}

--- a/utils/sxs-audit/Sources/SxSAudit/PEImports.swift
+++ b/utils/sxs-audit/Sources/SxSAudit/PEImports.swift
@@ -1,0 +1,111 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+internal import struct FoundationEssentials.URL
+private import WinSDK
+
+private func offset(of pointer: UnsafeRawPointer,
+                    relativeTo base: UnsafeRawPointer,
+                    in image: borrowing RawSpan,
+                    count: Int) -> Int? {
+  let start = UInt(bitPattern: base)
+  let address = UInt(bitPattern: pointer)
+  guard address >= start, count >= 0 else { return nil }
+  let distance = address - start
+  guard distance <= UInt(image.byteCount) else { return nil }
+  let offset = Int(distance)
+  guard count <= image.byteCount - offset else {
+    return nil
+  }
+  return offset
+}
+
+private func load<T>(_ type: T.Type, from bytes: borrowing RawSpan,
+                     at offset: Int) -> T {
+  bytes.withUnsafeBytes {
+    $0.loadUnaligned(fromByteOffset: offset, as: type)
+  }
+}
+
+internal struct ImportReader {
+  private var cache = Dictionary<URL, Set<String>>()
+
+  internal mutating func imports(of path: URL) throws -> Set<String> {
+    if let cached = cache[path] { return cached }
+
+    let data = try contents(path)
+    let bytes = data.span
+    let image = bytes.bytes
+    let names = try image.withUnsafeBytes { buffer in
+      guard let address = buffer.baseAddress else {
+        throw AnalyzerError("empty PE image: \(path.path)")
+      }
+      let base = UnsafeMutableRawPointer(mutating: address)
+      guard let headers = ImageNtHeader(base) else {
+        throw AnalyzerError("invalid PE image: \(path.path)")
+      }
+
+      var names = Set<String>()
+      try read(in: image, base: base, headers: headers,
+               directory: IMAGE_DIRECTORY_ENTRY_IMPORT,
+               name: \IMAGE_IMPORT_DESCRIPTOR.Name, into: &names)
+      try read(in: image, base: base, headers: headers,
+               directory: IMAGE_DIRECTORY_ENTRY_DELAY_IMPORT,
+               name: \IMAGE_DELAYLOAD_DESCRIPTOR.DllNameRVA, into: &names)
+      return names
+    }
+    cache[path] = names
+    return names
+  }
+
+  private func read<Descriptor>(in image: borrowing RawSpan,
+                                base: UnsafeMutableRawPointer,
+                                headers: PIMAGE_NT_HEADERS64,
+                                directory: USHORT,
+                                name: KeyPath<Descriptor, UInt32>,
+                                into names: inout Set<String>)
+      throws(AnalyzerError) {
+    var length = ULONG(0)
+    var found: PIMAGE_SECTION_HEADER?
+    guard let data = ImageDirectoryEntryToDataEx(base, BOOLEAN(0), directory,
+                                                 &length, &found) else {
+      return
+    }
+
+    let stride = MemoryLayout<Descriptor>.stride
+    guard stride != 0,
+        let directoryOffset = offset(of: data, relativeTo: base, in: image,
+                                     count: Int(length)) else {
+      throw AnalyzerError("invalid PE import directory")
+    }
+
+    let count = Int(length) / stride
+    let descriptors = image.extracting(directoryOffset ..<
+                                       directoryOffset + Int(length))
+    var section: PIMAGE_SECTION_HEADER?
+    for index in 0 ..< count {
+      let entry = load(Descriptor.self, from: descriptors, at: index * stride)
+      let rva = entry[keyPath: name]
+      if rva == 0 { break }
+      guard let address = ImageRvaToVa(headers, base, rva, &section),
+          let nameOffset = offset(of: address, relativeTo: base, in: image,
+                                  count: 1) else {
+        throw AnalyzerError("invalid PE import name RVA")
+      }
+
+      let bytes = image.extracting(nameOffset ..< image.byteCount)
+      var length = 0
+      for byte in bytes {
+        if byte == 0 { break }
+        length += 1
+      }
+      guard length < bytes.byteCount else {
+        throw AnalyzerError("unterminated PE import name")
+      }
+      let name = bytes.extracting(0 ..< length).withUnsafeBytes {
+        String(decoding: $0, as: UTF8.self)
+      }
+      names.insert(name)
+    }
+  }
+}

--- a/utils/sxs-audit/Sources/SxSAudit/PackageMappings.swift
+++ b/utils/sxs-audit/Sources/SxSAudit/PackageMappings.swift
@@ -1,0 +1,75 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+internal struct PackageInput {
+  internal let name: String
+  internal let files: Dictionary<String, String>
+  internal let feature: String?
+  internal let authored: Set<String>?
+}
+
+private func mapping(_ value: String, option: String) throws(AnalyzerError)
+    -> (String, String) {
+  let mapping = value
+  guard let separator = value.firstIndex(of: "=") else {
+    throw AnalyzerError("\(option) requires PACKAGE=VALUE: \(value)")
+  }
+  let package = String(value[..<separator]).lowercased()
+  let value = String(value[value.index(after: separator)...])
+  guard !package.isEmpty, !value.isEmpty else {
+    throw AnalyzerError("\(option) requires PACKAGE=VALUE: \(mapping)")
+  }
+  return (package, value)
+}
+
+internal func packages(files: Array<String>, features: Array<String>,
+                       authored: Array<String>) throws(AnalyzerError)
+    -> Array<PackageInput> {
+  var order = Array<String>()
+  var provisions = Dictionary<String, Dictionary<String, String>>()
+  for value in files {
+    let (package, file) = try mapping(value, option: "--file")
+    if provisions[package] == nil {
+      order.append(package)
+    }
+    provisions[package, default: Dictionary<String, String>()][
+      file.lowercased()
+    ] = file
+  }
+  guard !order.isEmpty else {
+    throw AnalyzerError("at least one --file PACKAGE=FILE is required")
+  }
+
+  var names = Dictionary<String, String>()
+  for value in features {
+    let (package, feature) = try mapping(value, option: "--feature")
+    guard provisions[package] != nil else {
+      throw AnalyzerError("--feature references unknown package: \(package)")
+    }
+    if let previous = names[package], previous != feature {
+      throw AnalyzerError("\(package) references both \(previous) and " +
+                          "\(feature)")
+    }
+    names[package] = feature
+  }
+
+  var assemblies = Dictionary<String, Set<String>>()
+  for value in authored {
+    let (package, assembly) = try mapping(value, option: "--authored")
+    guard provisions[package] != nil else {
+      throw AnalyzerError("--authored references unknown package: \(package)")
+    }
+    guard names[package] != nil else {
+      throw AnalyzerError("--authored requires --feature for \(package)")
+    }
+    assemblies[package, default: []].insert(assembly)
+  }
+
+  return order.map { package in
+    PackageInput(name: package,
+                 files: provisions[package] ?? Dictionary<String, String>(),
+                 feature: names[package],
+                 authored: names[package] == nil ? nil :
+                   assemblies[package] ?? [])
+  }
+}

--- a/utils/sxs-audit/Sources/SxSAudit/Report.swift
+++ b/utils/sxs-audit/Sources/SxSAudit/Report.swift
@@ -1,0 +1,73 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+private func field(_ value: String) -> String {
+  guard value.contains(where: {
+    $0 == "," || $0 == "\"" || $0 == "\r" || $0 == "\n"
+  }) else {
+    return value
+  }
+
+  var escaped = "\""
+  for character in value {
+    if character == "\"" { escaped.append("\"") }
+    escaped.append(character)
+  }
+  escaped.append("\"")
+  return escaped
+}
+
+private func row(_ record: String, _ package: String, _ subject: String,
+                 _ category: String,
+                 _ value: String) -> String {
+  "\(field(record)),\(field(package)),\(field(subject))," +
+    "\(field(category)),\(field(value))"
+}
+
+private func append(_ lines: inout Array<String>, record: String,
+                    package: String = "",
+                    subject: String = "",
+                    category: String,
+                    values: Array<String>) {
+  for value in values {
+    lines.append(row(record, package, subject, category, value))
+  }
+}
+
+internal func report(_ plan: Plan) -> String {
+  var lines = ["record,package,subject,category,value"]
+  for file in plan.files {
+    append(&lines, record: "file", package: file.package, subject: file.file,
+           category: "runtime-root", values: file.roots)
+    append(&lines, record: "file", package: file.package, subject: file.file,
+           category: "runtime-closure", values: file.closure)
+  }
+
+  for package in plan.packages {
+    let subject = package.feature ?? ""
+    append(&lines, record: "package", package: package.package,
+           subject: subject, category: "required", values: package.required)
+    if let authored = package.authored {
+      append(&lines, record: "package", package: package.package,
+             subject: subject, category: "authored", values: authored)
+      append(&lines, record: "package", package: package.package,
+             subject: subject, category: "missing", values: package.missing)
+      append(&lines, record: "package", package: package.package,
+             subject: subject, category: "extra", values: package.extra)
+    }
+  }
+
+  append(&lines, record: "diagnostic",
+         category: "missing-referenced-package-files", values: plan.missing)
+  append(&lines, record: "diagnostic",
+         category: "missing-authored-features", values: plan.absent)
+  append(&lines, record: "diagnostic",
+         category: "missing-flat-runtime-assemblies",
+         values: plan.incomplete)
+  append(&lines, record: "diagnostic",
+         category: "unmapped-runtime-dependent-files",
+         values: plan.unmapped)
+  append(&lines, record: "diagnostic",
+         category: "unused-runtime-assemblies", values: plan.unused)
+  return lines.joined(separator: "\r\n") + "\r\n"
+}

--- a/utils/sxs-audit/Sources/SxSAudit/WinSDK+Overlay.swift
+++ b/utils/sxs-audit/Sources/SxSAudit/WinSDK+Overlay.swift
@@ -1,0 +1,14 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+internal import WinSDK
+
+@_transparent
+internal var IMAGE_DIRECTORY_ENTRY_IMPORT: USHORT {
+  USHORT(WinSDK.IMAGE_DIRECTORY_ENTRY_IMPORT)
+}
+
+@_transparent
+internal var IMAGE_DIRECTORY_ENTRY_DELAY_IMPORT: USHORT {
+  USHORT(WinSDK.IMAGE_DIRECTORY_ENTRY_DELAY_IMPORT)
+}

--- a/utils/sxs-audit/Sources/SxSAudit/main.swift
+++ b/utils/sxs-audit/Sources/SxSAudit/main.swift
@@ -1,0 +1,49 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+internal import ArgumentParser
+
+@main
+internal struct SxSAudit: ParsableCommand {
+  internal static var configuration: CommandConfiguration {
+    CommandConfiguration(commandName: "sxs-audit",
+                         abstract: "Audit the private runtime closure " +
+                           "required by Windows PE packages.")
+  }
+
+  @Option(help: ArgumentHelp("Directory containing the PE files and private " +
+                             "assembly directories."))
+  internal var root: String
+
+  @Option(name: .customLong("runtime-root"),
+          help: "Directory containing the complete flat private runtime.")
+  internal var runtime: String
+
+  @Option(name: .customLong("exclude-runtime-dll"), parsing: .singleValue,
+          help: ArgumentHelp("Add a DLL name or trailing-* prefix to the " +
+                             "default exclusions."))
+  internal var exclusions = Array<String>()
+
+  @Option(name: .customLong("file"), parsing: .singleValue,
+          help: "Assign a provided PE file with PACKAGE=FILE.")
+  internal var files = Array<String>()
+
+  @Option(name: .customLong("feature"), parsing: .singleValue,
+          help: "Assign an authored runtime feature with PACKAGE=FEATURE.")
+  internal var features = Array<String>()
+
+  @Option(name: .customLong("authored"), parsing: .singleValue,
+          help: "Add an authored runtime member with PACKAGE=ASSEMBLY.")
+  internal var authored = Array<String>()
+
+  internal mutating func run() throws {
+    let inputs = try inputs(root: root, runtime: runtime,
+                            exclusions: exclusions)
+    let packages = try packages(files: files, features: features,
+                                authored: authored)
+    let result = try plan(root: inputs.root, runtime: inputs.runtime,
+                          packages: packages,
+                          exclusions: inputs.exclusions)
+    print(report(result), terminator: "")
+  }
+}

--- a/utils/sxs-audit/Tests/SxSAuditTests/PackageMappingsTests.swift
+++ b/utils/sxs-audit/Tests/SxSAuditTests/PackageMappingsTests.swift
@@ -1,0 +1,48 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+private import Testing
+@testable private import SxSAudit
+
+@Test
+internal func packageMappings() throws {
+  let inputs = try packages(files: [
+                              "build=compiler.exe", "build=Support.dll",
+                              "package=package.exe",
+                            ],
+                            features: [
+                              "build=BuildRuntime", "package=PackageRuntime",
+                            ],
+                            authored: [
+                              "build=Core", "package=Networking",
+                            ])
+
+  #expect(inputs.count == 2)
+  #expect(inputs[0].name == "build")
+  #expect(inputs[0].files["compiler.exe"] == "compiler.exe")
+  #expect(inputs[0].files["support.dll"] == "Support.dll")
+  #expect(inputs[0].feature == "BuildRuntime")
+  #expect(inputs[0].authored == ["Core"])
+  #expect(inputs[1].name == "package")
+  #expect(inputs[1].feature == "PackageRuntime")
+  #expect(inputs[1].authored == ["Networking"])
+}
+
+@Test
+internal func planningMappings() throws {
+  let inputs = try packages(files: ["build=compiler.exe"], features: [],
+                            authored: [])
+
+  #expect(inputs[0].feature == nil)
+  #expect(inputs[0].authored == nil)
+}
+
+@Test
+internal func emptyFeature() throws {
+  let inputs = try packages(files: ["build=compiler.exe"],
+                            features: ["build=BuildRuntime"],
+                            authored: [])
+
+  #expect(inputs[0].feature == "BuildRuntime")
+  #expect(inputs[0].authored?.isEmpty == true)
+}

--- a/utils/sxs-audit/Tests/SxSAuditTests/ReportTests.swift
+++ b/utils/sxs-audit/Tests/SxSAuditTests/ReportTests.swift
@@ -1,0 +1,40 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+private import Testing
+@testable private import SxSAudit
+
+@Test
+internal func emission() {
+  let plan = Plan(files: [
+                    FilePlan(file: "package,model.dll", package: "package",
+                             roots: ["Core"],
+                             closure: ["Core"]),
+                  ],
+                  packages: [
+                    PackagePlan(package: "package",
+                                feature: "PackageRuntime",
+                                required: ["Core"], authored: ["Core"],
+                                missing: [],
+                                extra: []),
+                  ],
+                  missing: ["missing.exe"],
+                  absent: ["ide"],
+                  incomplete: ["Networking"],
+                  unmapped: [],
+                  unused: ["Unused\"Runtime"])
+
+  let output = report(plan)
+  #expect(output == """
+    record,package,subject,category,value\r
+    file,package,"package,model.dll",runtime-root,Core\r
+    file,package,"package,model.dll",runtime-closure,Core\r
+    package,package,PackageRuntime,required,Core\r
+    package,package,PackageRuntime,authored,Core\r
+    diagnostic,,,missing-referenced-package-files,missing.exe\r
+    diagnostic,,,missing-authored-features,ide\r
+    diagnostic,,,missing-flat-runtime-assemblies,Networking\r
+    diagnostic,,,unused-runtime-assemblies,"Unused""Runtime"\r
+
+    """)
+}


### PR DESCRIPTION
This tool (authored as Swift Package) allows for programatic analysis of the toolchain to ensure that we are able to identify the transitive closure of the runtime required for the runtime distribution for the toolchain. It is intended as a toolchain developer aid and not to be shipped.