### PR TITLE
Surface an error when a AccessorFunctionReference is encountered in t…

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -160,6 +160,13 @@ struct RemoteExistential {
       IsBridgedError(IsBridgedError) {}
 };
 
+enum class DemangleFailureReason {
+  None,
+  /// The mangled name contained an accessor-function symbolic reference,
+  /// e.g., a noncopyable stored property built for a pre-macOS 27 runtime.
+  AccessorFunctionReference,
+};
+
 /// A generic reader of metadata.
 ///
 /// BuilderType must implement a particular interface which is currently
@@ -448,7 +455,10 @@ public:
   Demangle::NodePointer demangle(RemoteRef<char> mangledName,
                                  MangledNameKind kind,
                                  Demangler &dem,
-                                 bool useOpaqueTypeSymbolicReferences = false) {
+                                 bool useOpaqueTypeSymbolicReferences = false,
+                                 DemangleFailureReason *failureReason = nullptr) {
+    if (failureReason)
+      *failureReason = DemangleFailureReason::None;
     // Symbolic reference resolver for the demangle operation below.
     auto symbolicReferenceResolver = [&](SymbolicReferenceKind kind,
                                          Directness directness,
@@ -496,6 +506,8 @@ public:
       case Demangle::SymbolicReferenceKind::AccessorFunctionReference: {
         // The symbolic reference points at a resolver function, but we can't
         // execute code in the target process to resolve it from here.
+        if (failureReason)
+          *failureReason = DemangleFailureReason::AccessorFunctionReference;
         return nullptr;
       }
       case Demangle::SymbolicReferenceKind::UniqueExtendedExistentialTypeShape: {

--- a/include/swift/RemoteInspection/TypeRefBuilder.h
+++ b/include/swift/RemoteInspection/TypeRefBuilder.h
@@ -1602,6 +1602,10 @@ private:
   RefDemangler TypeRefDemangler;
   UnderlyingTypeReader OpaqueUnderlyingTypeReader;
 
+  /// Reason the most recent TypeRefDemangler run produced a null node.
+  remote::DemangleFailureReason LastTypeRefDemangleFailure =
+      remote::DemangleFailureReason::None;
+
   // Opaque fields captured from the MetadataReader's MemoryReader
   ByteReader OpaqueByteReader;
   StringReader OpaqueStringReader;
@@ -1623,7 +1627,8 @@ public:
                                          bool useOpaqueTypeSymbolicReferences)
                              -> Demangle::Node * {
           return reader.demangle(string, remote::MangledNameKind::Type, Dem,
-                                 useOpaqueTypeSymbolicReferences);
+                                 useOpaqueTypeSymbolicReferences,
+                                 &LastTypeRefDemangleFailure);
         }),
         OpaqueUnderlyingTypeReader(
             [&reader](remote::RemoteAddress descriptorAddr,
@@ -1705,6 +1710,12 @@ public:
   Demangle::Node *demangleTypeRef(RemoteRef<char> string,
                                   bool useOpaqueTypeSymbolicReferences = true) {
     return TypeRefDemangler(string, useOpaqueTypeSymbolicReferences);
+  }
+
+  /// Reason the most recent demangleTypeRef() produced a null node (or None).
+  /// Valid only immediately after that call.
+  remote::DemangleFailureReason getLastDemangleFailure() const {
+    return LastTypeRefDemangleFailure;
   }
 
   TypeConverter &getTypeConverter() { return TC; }

--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -2879,7 +2879,11 @@ const RecordTypeInfo *TypeConverter::getClassInstanceTypeInfo(
     std::vector<FieldTypeInfo> Fields;
     if (!getBuilder().getFieldTypeRefs(TR, *FD.get(), ExternalTypeInfo,
                                        Fields)) {
-      setError("cannot get fields", TR);
+      if (getBuilder().getLastDemangleFailure() ==
+          remote::DemangleFailureReason::AccessorFunctionReference)
+        setError("cannot get fields: accessor function symbolic reference", TR);
+      else
+        setError("cannot get fields", TR);
       return nullptr;
     }
 


### PR DESCRIPTION
…he demangler

Currently manglings using these are not supported by remote mirrors. To help diagnosing why types with these fail in LLDB we need to surface the error through the API.

rdar://183059406

Assisted-by: claude

See also https://github.com/swiftlang/llvm-project/pull/13490
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
