### PR TITLE
Fix SILGen crash for _Nonnull completion-handler params in objc thunks

### DIFF
--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -2073,19 +2073,28 @@ void SILGenFunction::emitNativeToForeignThunk(SILDeclRef thunk) {
           }
           
           // For non-error arguments, pass a placeholder.
-          // If the argument type is non-trivial, it must be Optional, and
-          // we pass nil.
+          // If the argument type is non-trivial and Optional, pass nil.
+          // A non-trivial, non-Optional parameter must be _Nonnull as
+          // ClangImporter only imports a non-trivial
+          // completion-handler parameter bare when the header
+          // indicates nonnull. Synthesize and pass nil.
           auto param = completionTy->getParameters()[i];
           auto paramTy = param.getSILStorageInterfaceType();
           if (paramTy.isTrivial(F)) {
             // If it's trivial, pass a zero value of whatever the type is.
             auto zero = B.createZeroInitValue(loc, paramTy);
             completionHandlerArgs.push_back(zero);
-          } else {
-            // If it's not trivial, it must be a nullable class type. Pass
-            // nil.
+          } else if (paramTy.getOptionalObjectType()) {
+            // If it's Optional, pass nil.
             auto none = B.createOptionalNone(loc, paramTy);
             completionHandlerArgs.push_back(none);
+          } else {
+            // Non-trivial, non-optional (_Nonnull): synthesize nil via
+            // Optional<T>.none, bitcast to the bare type.
+            auto optionalTy = paramTy.wrapInOptionalType();
+            auto none = B.createOptionalNone(loc, optionalTy);
+            auto nil = B.createUncheckedBitwiseCast(loc, none, paramTy);
+            completionHandlerArgs.push_back(nil);
           }
         }
         // Pass the bridged error on to the completion handler.

--- a/test/SILGen/objc_async_nonnull_completion_handler_arg.swift
+++ b/test/SILGen/objc_async_nonnull_completion_handler_arg.swift
@@ -1,0 +1,36 @@
+// RUN: %empty-directory(%t/src)
+// RUN: split-file %s %t/src
+
+// RUN: %target-swift-frontend -emit-silgen-ossa %t/src/main.swift -import-objc-header %t/src/Test.h -target %target-swift-5.1-abi-triple -module-name main -I %t/src | %FileCheck %t/src/main.swift
+
+// REQUIRES: concurrency
+// REQUIRES: objc_interop
+
+// rdar://181185273
+
+//--- Test.h
+
+#import <Foundation/Foundation.h>
+
+typedef void (^MockRegistrationCallback)(NSDictionary<NSString *, NSString *> * _Nonnull cachedEvents, NSError *error);
+
+@protocol MockSubscriptionProviding <NSObject>
+- (void)registerWithCompletion:(MockRegistrationCallback)completion;
+@end
+
+//--- main.swift
+
+import Foundation
+
+final class Repro: NSObject, MockSubscriptionProviding {
+  func register() async throws -> [String : String] {
+    [:]
+  }
+}
+
+// CHECK-LABEL: sil shared [thunk] [ossa] @{{.*}}8registerSDyS2SGyYaKFyyYacfU_To
+// CHECK: bb{{[0-9]+}}({{%.*}} : @guaranteed $@convention(block) @Sendable (NSDictionary, Optional<NSError>) -> ()):
+// CHECK: [[NSERROR:%.*]] = enum $Optional<NSError>, #Optional.some!enumelt, {{%.*}}
+// CHECK: [[NONE:%.*]] = enum $Optional<NSDictionary>, #Optional.none!enumelt
+// CHECK: [[NIL:%.*]] = unchecked_bitwise_cast [[NONE]] to $NSDictionary
+// CHECK: apply {{%.*}}([[NIL]], [[NSERROR]]) : $@convention(block) @Sendable (NSDictionary, Optional<NSError>) -> ()


### PR DESCRIPTION
The compiler crashes (or fails in the SIL verification) when compiling a class that satisfies an @objc protocol's completion-handler-based method via a Swift async throws implementation, if the completion handler's non-error parameter is _Nonnull.
    
In SILGenFunction::emitNativeToForeignThunk, the synthetic @objc thunk built for the async implementation needs a placeholder value for each non-error completion-handler parameter on the error path. The old code assumed every non-trivial parameter was Optional and always passed nil. That doesn't just work for _Nonnull parameters, which ClangImporter imports bare rather than wrapped in Optional, producing invalid SIL (an EnumInst on a non-enum type). Fix this by synthesizing a nil for the _Nonnull case: build Optional<T>.none in the wrapped optional type and reinterpret it as the bare type. This relies on the ABI guarantee that Optional<T>.none for a single-pointer reference type is represented as a null pointer via the type's extra inhabitants, so IRGen gets a well-defined null. This also matches real-world Objective-C behavior, where hand-written implementations routinely pass nil for a _Nonnull completion-handler result on the error path despite the annotation.
    
rdar://181185273