### PR TITLE
[DebugInfo] Anchor typealiases referenced by generic arguments 

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -161,6 +161,7 @@ class IRGenDebugInfoImpl : public IRGenDebugInfo {
   llvm::StringMap<llvm::TrackingMDNodeRef> DIFileCache;
   llvm::StringMap<llvm::TrackingMDNodeRef> RuntimeErrorFnCache;
   llvm::StringSet<> OriginallyDefinedInTypes;
+  llvm::StringSet<> AnchoredTypeAliases;
   TrackingDIRefMap DIRefMap;
   TrackingDIRefMap InnerTypeCache;
   TrackingDIRefMap ExistentialTypeAliasMap;
@@ -1215,16 +1216,18 @@ private:
                 memberTy,
                 IGM.getTypeInfoForUnlowered(
                     IGM.getSILTypes().getAbstractionPattern(VD), memberTy),
-                IGM))
+                IGM)) {
           MemberTypes.emplace_back(VD->getName().str(),
                                    getByteSize() *
                                        DbgTy->getAlignment().getValue(),
                                    getOrCreateType(*DbgTy));
-        else
+          anchorTypeAliasesIn(memberTy);
+        } else {
           // Without complete type info we can only create a forward decl.
           return DBuilder.createForwardDecl(
               llvm::dwarf::DW_TAG_structure_type, MangledName, Scope, File, Line,
               llvm::dwarf::DW_LANG_Swift, SizeInBits, 0);
+        }
       }
     }
 
@@ -1278,6 +1281,7 @@ private:
         MemberTypes.emplace_back(VD->getName().str(),
                                  getByteSize() * DbgTy.getAlignment().getValue(),
                                  getOrCreateType(DbgTy));
+        anchorTypeAliasesIn(memberTy);
       }
     }
 
@@ -1530,6 +1534,7 @@ private:
                                  getByteSize() *
                                      ElemDbgTy->getAlignment().getValue(),
                                  TrackingDIType(PayloadDITy));
+        anchorTypeAliasesIn(PayloadTy);
       } else {
         // A variant with no payload.
         MemberTypes.emplace_back(ElemDecl->getBaseIdentifier().str(), 0,
@@ -1591,6 +1596,7 @@ private:
                                  getByteSize() *
                                      ElemDbgTy->getAlignment().getValue(),
                                  TrackingDIType(PayloadDITy));
+        anchorTypeAliasesIn(PayloadTy);
       } else {
         // A variant with no payload.
         MemberTypes.emplace_back(ElemDecl->getBaseIdentifier().str(), 0,
@@ -2651,6 +2657,31 @@ private:
 #define MAP_BUILTIN_TYPE(CLANG, SWIFT) anchorAlias(#SWIFT);
 #include "swift/ClangImporter/BuiltinMappedTypes.def"
 #undef MAP_BUILTIN_TYPE
+  }
+
+  /// Forward-declared composite types may still refer refer to a type alias by
+  /// name in their mangled name. We need to make sure they are emitted in
+  /// DWARF.
+  void anchorTypeAliasesIn(Type Ty) {
+    if (!Ty || Opts.DebugInfoLevel < IRGenDebugInfoLevel::ASTTypes)
+      return;
+    Ty.findIf([&](Type T) -> bool {
+      auto *Alias = llvm::dyn_cast<TypeAliasType>(T.getPointer());
+      if (!Alias)
+        return false;
+      DebugTypeInfo AliasDbgTy = DebugTypeInfo::getForwardDecl(Alias);
+      // Dedup by the alias's mangled name.
+      auto Mangled = getMangledName(AliasDbgTy);
+      if (Mangled.Sugared.empty() ||
+          !AnchoredTypeAliases.insert(Mangled.Sugared).second)
+        return false;
+      if (llvm::DIType *TypeDef = getOrCreateType(AliasDbgTy)) {
+        DBuilder.retainType(TypeDef);
+        // Keep dsymutil from stripping the typedef as unused.
+        DBuilder.createImportedDeclaration(TheCU, TypeDef, MainFile, 0);
+      }
+      return false;
+    });
   }
 
   /// A TypeWalker that finds if a given type's mangling is affected by an

--- a/test/DebugInfo/embedded-typealias-anchor.swift
+++ b/test/DebugInfo/embedded-typealias-anchor.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend %s -target %target-cpu-apple-macos14 -emit-ir -g -enable-experimental-feature Embedded -wmo -disable-availability-checking -o - | %FileCheck %s
+
+// REQUIRES: OS=macosx
+// REQUIRES: embedded_stdlib
+// REQUIRES: swift_feature_Embedded
+
+// A type alias (Handler) that only ever appears as a generic argument of a
+// stored property's type (handler: Handler?). The enclosing bound-generic type
+// is emitted by mangled name only, without recursing into its generic
+// arguments, so the alias must still be anchored with its own DW_TAG_typedef.
+
+// CHECK-DAG: ![[TYPEDEF:[0-9]+]] = !DIDerivedType(tag: DW_TAG_typedef, name: "{{.*}}7StorageC7Handlera{{.*}}", scope: {{.*}}baseType: ![[CLOSURE:[0-9]+]]
+// CHECK-DAG: ![[CLOSURE]] = !DICompositeType(tag: DW_TAG_structure_type, name: "$eyxYbcD",{{.*}}identifier: "$eyxYbcD")
+
+final class Storage<Element> {
+  typealias Handler = @Sendable (Element) -> Void
+  var handler: Handler? = nil
+}
+
+let g: Storage<Int>? = nil


### PR DESCRIPTION
Make sure typealiases are anchored in debug info even when they appear as a generic argument of a forward declaration.

rdar://178774840

Assisted-by: claude

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
