### PR TITLE
[SILOptimizer] LICM: don't speculatively hoist loads from weakly-imported globals

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
@@ -1198,6 +1198,15 @@ private extension ScopedInstruction {
     case is BeginApplyInst:
       return true // Has already been checked with other full applies.
     case let loadBorrowInst as LoadBorrowInst:
+      // Hoisting a scoped instruction is speculative: `hoistWithSinkScopedInstructions` also hoists
+      // instructions from blocks which do not dominate the loop exits, i.e. which are only
+      // conditionally executed. The address of a weakly-imported global is null if the symbol is
+      // unavailable at runtime. Therefore a load from it - which is guarded by an `#available`
+      // check in the source - must not be executed speculatively.
+      // See https://github.com/swiftlang/swift/issues/90916
+      if loadBorrowInst.loadsFromWeaklyImportedGlobal {
+        return false
+      }
       return !analyzedInstructions.sideEffectsMayWrite(to: loadBorrowInst.address, outsideOf: scope, context)
 
     case let beginAccess as BeginAccessInst:
@@ -1218,6 +1227,22 @@ private extension ScopedInstruction {
     default:
       return false
     }
+  }
+}
+
+private extension LoadBorrowInst {
+  /// True if this load's address is rooted in a weakly-imported global variable.
+  ///
+  /// Such an address is null at runtime if the weakly-linked symbol is unavailable
+  /// (e.g. an availability-gated global constant, running on an OS version older than
+  /// the constant's introduction). A load from it traps and therefore must not be
+  /// executed speculatively - it is only safe where the programmer put it: behind
+  /// the `#available` check.
+  var loadsFromWeaklyImportedGlobal: Bool {
+    if case .global(let global) = address.accessBase {
+      return global.isWeaklyImported
+    }
+    return false
   }
 }
 

--- a/SwiftCompilerSources/Sources/SIL/GlobalVariable.swift
+++ b/SwiftCompilerSources/Sources/SIL/GlobalVariable.swift
@@ -49,6 +49,15 @@ final public class GlobalVariable : CustomStringConvertible, HasShortDescription
   /// For example, `public_external` linkage.
   public var isDefinedExternally: Bool { linkage.isExternal }
 
+  /// True, if the global variable is weakly imported, i.e. it may not be available at
+  /// runtime because it was introduced in an OS version which is newer than the
+  /// deployment target.
+  ///
+  /// The address of a weakly-imported global is null if the symbol is unavailable at
+  /// runtime. Therefore the global must only be accessed behind a matching `#available`
+  /// check and such an access must not be executed speculatively.
+  public var isWeaklyImported: Bool { bridged.isWeaklyImported() }
+
   public var staticInitializerInstructions: InstructionList? {
     if let firstStaticInitInst = bridged.getFirstStaticInitInst().instruction {
       return InstructionList(first: firstStaticInitInst)

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -675,6 +675,7 @@ struct BridgedGlobalVar {
   BRIDGED_INLINE BridgedLinkage getLinkage() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE swift::SourceLoc getSourceLocation() const;
   BRIDGED_INLINE bool isPossiblyUsedExternally() const;
+  BRIDGED_INLINE bool isWeaklyImported() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE OptionalBridgedInstruction getFirstStaticInitInst() const;
   bool canBeInitializedStatically() const;
   bool mustBeInitializedStatically() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -1108,6 +1108,13 @@ bool BridgedGlobalVar::isPossiblyUsedExternally() const {
   return getGlobal()->isPossiblyUsedExternally();
 }
 
+bool BridgedGlobalVar::isWeaklyImported() const {
+  swift::SILGlobalVariable *global = getGlobal();
+  if (swift::VarDecl *decl = global->getDecl())
+    return decl->isWeakImported(global->getModule().getSwiftModule());
+  return false;
+}
+
 OptionalBridgedInstruction BridgedGlobalVar::getFirstStaticInitInst() const {
   if (getGlobal()->begin() == getGlobal()->end()) {
     return {nullptr};

--- a/test/SILOptimizer/licm_weakly_imported_global.swift
+++ b/test/SILOptimizer/licm_weakly_imported_global.swift
@@ -1,0 +1,63 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -O -emit-sil -I %t/GatedGlobals %t/main.swift | %FileCheck %s
+
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+// LICM must not speculatively hoist loads from weakly-imported globals out of
+// #available-guarded blocks: the address of a weakly-imported global is null at
+// runtime if the symbol is unavailable (its availability lies in the future
+// relative to the deployment target), so the hoisted load would dereference
+// null and crash - even though the source only reads the global behind a
+// matching `#available` check, which the compiler itself requires.
+//
+// This happened in practice with AVFoundation's availability-gated constants,
+// e.g. `AVCaptureDeviceTypeMicrophone` (iOS 17+): comparing against it inside
+// a loop behind `#available(iOS 17.0, *)` crashed with EXC_BAD_ACCESS at 0x0
+// on iOS 16 in -O builds, because the load of the constant was hoisted into
+// the loop preheader.
+// See https://github.com/swiftlang/swift/issues/90916
+
+//--- GatedGlobals/module.modulemap
+module GatedGlobals {
+  header "gated.h"
+  export *
+}
+
+//--- GatedGlobals/gated.h
+#import <Foundation/Foundation.h>
+extern NSString * const gatedName __attribute__((availability(macos,introduced=99)));
+extern NSString * const ungatedName;
+
+//--- main.swift
+import GatedGlobals
+
+// The load of `gatedName` must stay behind the availability check and must not
+// be moved into the loop preheader. The load of `ungatedName` (strongly linked)
+// may still be hoisted.
+
+// CHECK-LABEL: sil {{.*}}@${{.*}}countGatedMatches
+// CHECK: [[GATED:%[0-9]+]] = global_addr @gatedName
+// CHECK-NOT: load [[GATED]]
+// CHECK: apply {{.*}}isOSVersionAtLeast
+// CHECK-NOT: load [[GATED]]
+// CHECK: cond_br
+// CHECK: load [[GATED]]
+// CHECK: } // end sil function '${{.*}}countGatedMatches
+@inline(never)
+public func countGatedMatches(_ names: [String]) -> Int {
+  var count = 0
+  for name in names {
+    if #available(macOS 99, *) {
+      if name == gatedName {
+        count += 1
+      }
+    } else {
+      if name == ungatedName {
+        count += 1
+      }
+    }
+  }
+  return count
+}


### PR DESCRIPTION
Resolves #90916.

## The bug

The address of a weakly-imported global is null at runtime if the symbol is unavailable on the deployed OS version. This applies in particular to availability-gated clang global constants, e.g. AVFoundation's `AVCaptureDeviceTypeMicrophone` (iOS 17+) when the deployment target is below iOS 17. The compiler itself enforces that such globals are only accessed behind a matching `#available` check.

However, LICM hoists `load_borrow` instructions via the scoped-instructions path (`hoistWithSinkScopedInstructions`), which - unlike `hoistInstructions` - also hoists from blocks that do not dominate the loop exits, i.e. speculatively. This moves the load of a weakly-imported global out of its `#available`-guarded block into the loop preheader. On an OS version where the symbol is unavailable, the hoisted load dereferences the null address: a deterministic `EXC_BAD_ACCESS at 0x0`, in `-O` builds only, even though the source program never executes the access on that OS.

This shipped as a real-world crash: react-native-vision-camera comparing `deviceType == .microphone` behind `#available(iOS 17.0, *)` inside its input-classification loop crashed 100% reproducibly on iOS 16 devices on the first session reconfigure. Full analysis, minimal repro, disassembly/IRGen/SIL evidence, and an on-device A/B/C verification (`-O` crashes; `-Onone` and `-O -Xllvm -sil-disable-pass=loop-invariant-code-motion` survive; physical iPhone 8, iOS 16.7.16) are in #90916.

## The fix

`canScopedInstructionBeHoisted` now refuses to hoist a `load_borrow` whose address is rooted in a weakly-imported global (`AccessBase.global` whose `GlobalVariable` is weakly imported).

To make that query available, `Decl::isWeakImported` is exposed through SILBridging as `GlobalVariable.isWeaklyImported` - the same predicate IRGen uses when it decides to emit a weak reference - so other passes that speculate loads can adopt the same check.

The other LICM hoisting paths appear safe as-is: plain `LoadInst` hoisting goes through `hoistInstructions`, which only processes blocks that dominate all exiting and latch blocks (trap-equivalent), and the access-path projection machinery is gated on `storesCommonlyDominateExits`.

## Test

`test/SILOptimizer/licm_weakly_imported_global.swift` mirrors the field crash: a clang module exporting an availability-gated `NSString * const` next to an ungated one, compared inside a loop behind `#available`. It asserts the gated global's load stays behind the availability check while the ungated global is unaffected.

The test shape was validated against a current release compiler (Apple Swift 6.3.3): at `-O` it hoists both loads into the loop preheader (the gated load is the miscompile; the exact SIL is quoted in #90916), so the test fails without this change. I could not run the full test suite locally, so please let CI validate.
