### PR TITLE
[synthesize-interface] Always show @unsafe, never @safe

### DIFF
--- a/lib/DriverTool/swift_synthesize_interface_main.cpp
+++ b/lib/DriverTool/swift_synthesize_interface_main.cpp
@@ -399,13 +399,7 @@ int swift_synthesize_interface_main(ArrayRef<const char *> Args,
       printOpts.PrintAccess = true;
   }
 
-  // Under strict memory safety, print @unsafe even though the attribute is
-  // normally implicit and hidden.
-  if (Invocation.getLangOptions().hasFeature(Feature::StrictMemorySafety,
-                                             /*allowMigration=*/true)) {
-    printOpts.AlwaysIncludeAttrList.push_back(DeclAttrKind::Unsafe);
-    printOpts.AlwaysIncludeAttrList.push_back(DeclAttrKind::Safe);
-  }
+  printOpts.AlwaysIncludeAttrList.push_back(DeclAttrKind::Unsafe);
 
   swift::OptionSet<swift::ide::ModuleTraversal> traversalOpts = std::nullopt;
   if (ParsedArgs.hasArg(OPT_include_submodules)) {

--- a/test/SynthesizeInterfaceTool/strict-memory-safety.swift
+++ b/test/SynthesizeInterfaceTool/strict-memory-safety.swift
@@ -1,13 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-/// By default, the `@unsafe` attribute that ClangImporter attaches is implicit
-/// and hidden, so it is not printed.
-// RUN: %target-swift-synthesize-interface -module-name CxxUnions -I %t/Inputs -cxx-interoperability-mode=default | %FileCheck %s --implicit-check-not=@unsafe
-
-/// With -strict-memory-safety, unsafe declarations (e.g. C++ union field
-/// accessors) are marked `@unsafe`.
-// RUN: %target-swift-synthesize-interface -module-name CxxUnions -I %t/Inputs -cxx-interoperability-mode=default -strict-memory-safety | %FileCheck %s --check-prefix=UNSAFE
+// RUN: %target-swift-synthesize-interface -module-name CxxUnions -I %t/Inputs -cxx-interoperability-mode=default | %FileCheck %s
 
 //--- Inputs/module.modulemap
 module CxxUnions {
@@ -24,9 +18,5 @@ union Value {
 };
 
 // CHECK: public struct Value {
-// CHECK:     public var number: CInt
-// CHECK:     public var decimal: CFloat
-
-// UNSAFE: public struct Value {
-// UNSAFE:     @unsafe public var number: CInt
-// UNSAFE:     @unsafe public var decimal: CFloat
+// CHECK:     @unsafe public var number: CInt
+// CHECK:     @unsafe public var decimal: CFloat


### PR DESCRIPTION
@unsafe is part of the shape of the interface a client interacts with, so print it unconditionally instead of only under -strict-memory-safety.

@safe is intentionally not shown: it communicates nothing to clients (it just asserts that unsafe state is encapsulated) and can be assumed by default.

rdar://182315398