### PR TITLE
AST: add `ClassDecl::isCOMObject`

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5428,6 +5428,14 @@ public:
   /// allocation, etc.), the Swift model, or has no reference counting at all.
   ReferenceCounting getObjectModel() const;
 
+  /// Whether this class participates in the COM object model, i.e. it conforms
+  /// to a COM interface (a protocol marked \c \@com).
+  ///
+  /// Keying on the \c \@com marker rather than a shared root such as
+  /// \c IUnknown covers rootless COM frameworks such as IOKit; keying on
+  /// conformance rather than the class's own attribute covers subclasses.
+  bool isCOMObject() const;
+
   LayoutConstraintKind getLayoutConstraintKind() const {
     if (getObjectModel() == ReferenceCounting::ObjC)
       return LayoutConstraintKind::Class;

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1257,6 +1257,25 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Determine whether a class participates in the COM object model, i.e. it
+/// conforms to a protocol marked \c \@com.
+class IsCOMObjectRequest :
+    public SimpleRequest<IsCOMObjectRequest,
+                         bool(ClassDecl *),
+                         RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  bool evaluate(Evaluator &evaluator, ClassDecl *classDecl) const;
+
+public:
+  // Caching
+  bool isCached() const { return true; }
+};
+
 /// Determine whether the given class is a default actor.
 class IsDefaultActorRequest :
     public SimpleRequest<IsDefaultActorRequest,

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -113,6 +113,8 @@ SWIFT_REQUEST(TypeChecker, ResultBuilderTypeRequest, Type(ValueDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsActorRequest, bool(NominalTypeDecl *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, IsCOMObjectRequest, bool(ClassDecl *),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsDefaultActorRequest,
               bool(ClassDecl *, ModuleDecl *, ResilienceExpansion),
               Cached, NoLocationInfo)

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7428,6 +7428,17 @@ ReferenceCounting ClassDecl::getObjectModel() const {
   return ReferenceCounting::Native;
 }
 
+bool ClassDecl::isCOMObject() const {
+  // COM is only in play when the experimental interop is enabled; keep the
+  // common case free and never touch the evaluator cache for it.
+  if (!getASTContext().LangOpts.EnableCOMInterop)
+    return false;
+
+  auto *mutableThis = const_cast<ClassDecl *>(this);
+  return evaluateOrDefault(getASTContext().evaluator,
+                           IsCOMObjectRequest{mutableThis}, false);
+}
+
 EnumCaseDecl *EnumCaseDecl::create(SourceLoc CaseLoc,
                                    ArrayRef<EnumElementDecl *> Elements,
                                    DeclContext *DC) {

--- a/lib/Sema/TypeCheckCOM.cpp
+++ b/lib/Sema/TypeCheckCOM.cpp
@@ -261,6 +261,15 @@ VarDecl *lookupCOMImplementationID(ClassDecl *CD) {
 }
 
 namespace swift {
+bool IsCOMObjectRequest::evaluate(Evaluator &evaluator, ClassDecl *CD) const {
+  // A class participates in the COM object model when it conforms to a COM
+  // interface, a protocol marked @com.
+  for (auto *proto : CD->getAllProtocols())
+    if (proto->getAttrs().hasAttribute<COMAttr>())
+      return true;
+  return false;
+}
+
 ProtocolConformance *
 com::deriveImplicitConformance(NominalTypeDecl *NTD, KnownProtocolKind KP) {
   const auto *CD = dyn_cast<ClassDecl>(NTD);


### PR DESCRIPTION
Recognize a class as participating in the COM object model when it conforms to a `@com`-marked protocol. Keying on the `@com` marker rather than derivation from a root such as `IUnknown` also covers COM-model frameworks like IOKit, whose interfaces share no root and would be marked `@com` by the Clang importer. Keying on conformance rather than the class's own attribute covers subclasses of COM classes. The predicate is inert and gated on `-enable-experimental-com-interop`; the COM object-model layout builds on it.