### PR TITLE
Sema: -enable-crash-on-valid-salvage => -enable-diagnose-valid-salvage

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -1043,9 +1043,13 @@ namespace swift {
     /// debugging
     unsigned ShuffleDisjunctionChoicesSeed = 0;
 
-    /// If true, we will crash if the constraint solver found a valid solution
-    /// in diagnostic mode.
-    bool CrashOnValidSalvage = false;
+    /// If true, we will emit a fallback diagnostic if the constraint solver
+    /// finds a valid solution in diagnostic mode.
+    bool DiagnoseValidSalvage = false;
+
+    /// If true, trigger an assertion failure whenever we emit the fallback
+    /// diagnostic.
+    bool CrashFailDiagnostic = false;
 
     /// Triggers llvm fatal error if the typechecker tries to typecheck a decl
     /// or an identifier reference with any of the provided prefix names. This

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -471,11 +471,17 @@ def solver_shuffle_disjunctions_EQ : Joined<["-"], "solver-shuffle-disjunctions=
 def solver_shuffle_choices_EQ : Joined<["-"], "solver-shuffle-choices=">,
   HelpText<"Random seed for shuffling disjunction choices. For debugging solver performance">;
 
-def solver_enable_crash_on_valid_salvage : Flag<["-"], "solver-enable-crash-on-valid-salvage">,
+def solver_enable_diagnose_valid_salvage : Flag<["-"], "solver-enable-diagnose-valid-salvage">,
   HelpText<"Reject valid solutions in diagnostic mode">;
 
-def solver_disable_crash_on_valid_salvage : Flag<["-"], "solver-disable-crash-on-valid-salvage">,
+def solver_disable_diagnose_valid_salvage : Flag<["-"], "solver-disable-diagnose-valid-salvage">,
   HelpText<"Accept valid solutions in diagnostic mode">;
+
+def solver_enable_crash_fail_diagnostic : Flag<["-"], "solver-enable-crash-fail-diagnostic">,
+  HelpText<"Trigger assertion failure on 'failed to produce diagnostic for expression'">;
+
+def solver_disable_crash_fail_diagnostic : Flag<["-"], "solver-disable-crash-fail-diagnostic">,
+  HelpText<"Do not trigger assertion failure on 'failed to produce diagnostic for expression'">;
 
 def solver_enable_transitive_conformance : Flag<["-"], "solver-enable-transitive-conformance">,
   HelpText<"Enable transitive conformance constraint optimization">;

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4086,6 +4086,9 @@ public:
     return ResolvedOverloads;
   }
 
+  /// Emit a fallback diagnostic.
+  void produceFallbackDiagnostic(SourceLoc loc) const;
+
   /// If we aren't certain that we've emitted a diagnostic, emit a fallback
   /// diagnostic.
   void maybeProduceFallbackDiagnostic(SourceLoc loc) const;

--- a/include/swift/Sema/Solution.h
+++ b/include/swift/Sema/Solution.h
@@ -380,6 +380,10 @@ public:
   /// Retrieve the constraint system that this solution solves.
   ConstraintSystem &getConstraintSystem() const { return *constraintSystem; }
 
+  /// Whether this looks like a valid solution, without any fixes or holes.
+  /// Such solutions must not be produced from salvage() mode.
+  bool isValidSolution() const;
+
   DeclContext *getDC() const;
 
   /// The set of type bindings.

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2145,10 +2145,15 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
   if (Args.getLastArg(OPT_solver_disable_splitter))
     Opts.SolverDisableSplitter = true;
 
-  Opts.CrashOnValidSalvage =
-      Args.hasFlag(OPT_solver_enable_crash_on_valid_salvage,
-                   OPT_solver_disable_crash_on_valid_salvage,
-                   Opts.CrashOnValidSalvage);
+  Opts.DiagnoseValidSalvage =
+      Args.hasFlag(OPT_solver_enable_diagnose_valid_salvage,
+                   OPT_solver_disable_diagnose_valid_salvage,
+                   Opts.DiagnoseValidSalvage);
+
+  Opts.CrashFailDiagnostic =
+      Args.hasFlag(OPT_solver_enable_crash_fail_diagnostic,
+                   OPT_solver_disable_crash_fail_diagnostic,
+                   Opts.CrashFailDiagnostic);
 
   Opts.SolverEnableTransitiveConformance =
       Args.hasFlag(OPT_solver_enable_transitive_conformance,

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2044,6 +2044,13 @@ OverloadChoice::getIUOReferenceKind(ConstraintSystem &cs,
   return IUOReferenceKind::ReturnValue;
 }
 
+bool Solution::isValidSolution() const {
+  return (Fixes.empty() &&
+          FixedScore.Data[SK_Unavailable] == 0 &&
+          FixedScore.Data[SK_Hole] == 0 &&
+          FixedScore.Data[SK_Fix] == 0);
+}
+
 SolutionResult ConstraintSystem::salvage() {
   if (isDebugMode()) {
     llvm::errs() << "---Attempting to salvage and emit diagnostics---\n";
@@ -2085,19 +2092,12 @@ SolutionResult ConstraintSystem::salvage() {
         viable[0] = std::move(viable[*best]);
       viable.erase(viable.begin() + 1, viable.end());
 
-      if (getASTContext().TypeCheckerOpts.CrashOnValidSalvage) {
-        auto &solution = viable[0];
-        if (solution.Fixes.empty() &&
-            diagnosticTransaction == nullptr &&
-            !getASTContext().LangOpts.DisableAvailabilityChecking &&
-            solution.getFixedScore().Data[SK_Unavailable] == 0 &&
-            solution.getFixedScore().Data[SK_Hole] == 0 &&
-            solution.getFixedScore().Data[SK_Fix] == 0) {
-          ABORT([&](auto &out) {
-            out << "Found valid solution in salvage()\n\n";
-            solution.dump(out, 0);
-          });
-        }
+      // We should not have found a valid solution in salvage().
+      if (getASTContext().TypeCheckerOpts.DiagnoseValidSalvage &&
+          diagnosticTransaction == nullptr &&
+          !getASTContext().LangOpts.DisableAvailabilityChecking &&
+          viable[0].isValidSolution()) {
+        return SolutionResult::forUndiagnosedError();
       }
 
       return SolutionResult::forSolved(std::move(viable[0]));
@@ -4765,7 +4765,7 @@ void ConstraintSystem::diagnoseFailureFor(SyntacticElementTarget target) {
   // If constraint system is in invalid state always produce
   // a fallback diagnostic that asks to file a bug.
   if (inInvalidState()) {
-    DE.diagnose(target.getLoc(), diag::failed_to_produce_diagnostic);
+    produceFallbackDiagnostic(target.getLoc());
     return;
   }
 
@@ -4804,9 +4804,7 @@ void ConstraintSystem::diagnoseFailureFor(SyntacticElementTarget target) {
   }
 
   // Emit a poor fallback message.
-  auto diag = DE.diagnose(target.getLoc(), diag::failed_to_produce_diagnostic);
-  if (auto *expr = target.getAsExpr())
-    diag.highlight(expr->getSourceRange());
+  produceFallbackDiagnostic(target.getLoc());
 }
 
 bool ConstraintSystem::isDeclUnavailable(const Decl *D,
@@ -4841,6 +4839,15 @@ bool ConstraintSystem::isConformanceUnavailable(ProtocolConformanceRef conforman
   return isDeclUnavailable(ext, locator);
 }
 
+void ConstraintSystem::produceFallbackDiagnostic(SourceLoc loc) const {
+  auto &ctx = getASTContext();
+  if (ctx.TypeCheckerOpts.CrashFailDiagnostic) {
+    ABORT("Failed to produce a diagnostic, and "
+          "-solver-enable-crash-fail-diagnostic was enabled");
+  }
+  ctx.Diags.diagnose(loc, diag::failed_to_produce_diagnostic);
+}
+
 /// If we aren't certain that we've emitted a diagnostic, emit a fallback
 /// diagnostic.
 void ConstraintSystem::maybeProduceFallbackDiagnostic(SourceLoc loc) const {
@@ -4855,7 +4862,7 @@ void ConstraintSystem::maybeProduceFallbackDiagnostic(SourceLoc loc) const {
       (diagnosticTransaction && diagnosticTransaction->hasErrors()))
     return;
 
-  ctx.Diags.diagnose(loc, diag::failed_to_produce_diagnostic);
+  produceFallbackDiagnostic(loc);
 }
 
 SourceLoc constraints::getLoc(ASTNode anchor) {

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -696,7 +696,7 @@ function(_compile_swift_files
   #
   # We're not ready to enable this flag uconditionally yet, but turn it on for the
   # standard library.
-  list(APPEND swift_flags "-Xfrontend" "-solver-enable-crash-on-valid-salvage")
+  list(APPEND swift_flags "-Xfrontend" "-solver-enable-diagnose-valid-salvage")
 
   list(APPEND swift_flags ${SWIFT_STDLIB_EXTRA_SWIFT_COMPILE_FLAGS})
 

--- a/test/Constraints/binding_order.swift
+++ b/test/Constraints/binding_order.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated
-// RUN: not --crash %target-typecheck-verify-swift -verify-ignore-unrelated -DSALVAGE
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -solver-enable-diagnose-valid-salvage -verify-additional-prefix salvage-
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -solver-disable-diagnose-valid-salvage
 
 // The next two sets of examples cause difficulties because our
 // subtype lattice is not actually a lattice; existentials fail
@@ -108,9 +108,8 @@ do {
     let _: [any Command] = [a, b].flatMap { [$0] }
     // expected-error@-1 {{cannot convert value of type '[Super]' to closure result type '(any Command)?'}}
 
-    #if SALVAGE
     let _: [any Command] = [[a], [b]].flatMap { $0 }
-    #endif
+    // expected-salvage-error@-1 {{failed to produce diagnostic for expression; please submit a bug report}}
   }
 }
 

--- a/test/Constraints/rdar44816848.swift
+++ b/test/Constraints/rdar44816848.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -solver-disable-crash-on-valid-salvage
-// RUN: not --crash %target-swift-frontend -solver-enable-crash-on-valid-salvage -typecheck %s
+// RUN: %target-typecheck-verify-swift -solver-disable-diagnose-valid-salvage
+// RUN: %target-typecheck-verify-swift -solver-enable-diagnose-valid-salvage -verify-additional-prefix salvage-
 
 class A {}
 class B: A {}
@@ -12,6 +12,8 @@ struct S {
 func bar(_ s: S, _ forced_s: S!) {
   s.foo(types: [A.self, B.self]) // ok
   s.foo(types: [B.self, A.self]) // ok
+  // expected-salvage-error@-1 {{failed to produce diagnostic for expression; please submit a bug report}}
   forced_s.foo(types: [A.self, B.self]) // ok
   forced_s.foo(types: [B.self, A.self]) // ok
+  // expected-salvage-error@-1 {{failed to produce diagnostic for expression; please submit a bug report}}
 }

--- a/test/Constraints/salvage_fixed.swift
+++ b/test/Constraints/salvage_fixed.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-enable-crash-on-valid-salvage
+// RUN: %target-typecheck-verify-swift -solver-enable-diagnose-valid-salvage
 
 /// This file collects some random test cases where we used to find
 /// a valid solution in salvage().

--- a/test/Constraints/transitive_literal_inference.swift
+++ b/test/Constraints/transitive_literal_inference.swift
@@ -1,6 +1,5 @@
-// RUN: %target-typecheck-verify-swift -DSALVAGE -solver-disable-crash-on-valid-salvage
-// RUN: not --crash %target-typecheck-verify-swift -DSALVAGE -solver-enable-crash-on-valid-salvage
-// RUN: %target-typecheck-verify-swift -solver-enable-crash-on-valid-salvage
+// RUN: %target-typecheck-verify-swift -solver-disable-diagnose-valid-salvage
+// RUN: %target-typecheck-verify-swift -solver-enable-diagnose-valid-salvage -verify-additional-prefix salvage-
 
 // All of the below should of course type check successfully.
 // FIXME: Once everything below is passing, we can gyb it.

--- a/test/DebugInfo/locatable_type.swift
+++ b/test/DebugInfo/locatable_type.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %S/Inputs/result_builder.swift -emit-module -emit-module-path %t/result_builder.swiftmodule
-// RUN: %target-swift-frontend -emit-ir %s -I %t -g -O -solver-disable-crash-on-valid-salvage
-// RUN: not --crash %target-swift-frontend -emit-ir %s -I %t -g -O -solver-enable-crash-on-valid-salvage
+// RUN: %target-swift-frontend -emit-ir %s -I %t -g -O -solver-disable-diagnose-valid-salvage
+// RUN: not %target-swift-frontend -typecheck %s -I %t -g -O -solver-enable-diagnose-valid-salvage
 
 // FIXME: Devise a test case that does not involve -O.
 

--- a/test/SILOptimizer/pack_specialization.swift
+++ b/test/SILOptimizer/pack_specialization.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend %s -emit-ir -O -solver-disable-crash-on-valid-salvage | %FileCheck %s
-// RUN: not --crash %target-swift-frontend %s -emit-ir -O -solver-enable-crash-on-valid-salvage
+// RUN: %target-swift-frontend %s -emit-ir -O -solver-disable-diagnose-valid-salvage | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -solver-enable-diagnose-valid-salvage
 
 
 // When no witness methods are called on pack elements, all pack code can be fully eliminated.
@@ -31,7 +31,9 @@ func addTogether<each A: Numeric>(xs: repeat each A) -> (repeat each A) {
 }
 
 public func addTogetherCaller() -> Int32 {
+  // This is only diagnosed when we RUN with -solver-enable-diagnose-valid-salvage.
   return addTogether(xs: 1)
+  // expected-error@-1 {{failed to produce diagnostic for expression; please submit a bug report}}
 }
 
 // Dependent/member types (e.g. each T.IntegerLiteralType) must also resolve to

--- a/test/SILOptimizer/simplify_open_existential_ref.sil
+++ b/test/SILOptimizer/simplify_open_existential_ref.sil
@@ -23,8 +23,8 @@ sil @use_generic_obj_guaranteed : $@convention(thin) <T> (@guaranteed T) -> ()
 sil [ossa] @fold_owned_direct_cast : $@convention(thin) (@owned Klass) -> @owned Builtin.NativeObject {
 bb0(%0 : @owned $Klass):
   %1 = init_existential_ref %0 : $Klass : $Klass, $AnyObject
-  %2 = open_existential_ref %1 : $AnyObject to $@opened("11111111-1111-1111-1111-111111111111", AnyObject) Self
-  %3 = unchecked_ref_cast %2 : $@opened("11111111-1111-1111-1111-111111111111", AnyObject) Self to $Builtin.NativeObject
+  %2 = open_existential_ref %1 : $AnyObject to $@opened(1, AnyObject) Self
+  %3 = unchecked_ref_cast %2 : $@opened(1, AnyObject) Self to $Builtin.NativeObject
   return %3 : $Builtin.NativeObject
 }
 
@@ -45,13 +45,13 @@ bb0(%0 : @owned $Klass):
 sil [ossa] @fold_owned_borrow_scope_and_direct_cast : $@convention(thin) (@owned Klass) -> @owned Builtin.NativeObject {
 bb0(%0 : @owned $Klass):
   %1 = init_existential_ref %0 : $Klass : $Klass, $AnyObject
-  %2 = open_existential_ref %1 : $AnyObject to $@opened("22222222-2222-2222-2222-222222222222", AnyObject) Self
-  %3 = begin_borrow %2 : $@opened("22222222-2222-2222-2222-222222222222", AnyObject) Self
-  %4 = unchecked_ref_cast %3 : $@opened("22222222-2222-2222-2222-222222222222", AnyObject) Self to $Klass
+  %2 = open_existential_ref %1 : $AnyObject to $@opened(2, AnyObject) Self
+  %3 = begin_borrow %2 : $@opened(2, AnyObject) Self
+  %4 = unchecked_ref_cast %3 : $@opened(2, AnyObject) Self to $Klass
   %5 = function_ref @takeKlass : $@convention(thin) (@guaranteed Klass) -> ()
   %6 = apply %5(%4) : $@convention(thin) (@guaranteed Klass) -> ()
-  end_borrow %3 : $@opened("22222222-2222-2222-2222-222222222222", AnyObject) Self
-  %7 = unchecked_ref_cast %2 : $@opened("22222222-2222-2222-2222-222222222222", AnyObject) Self to $Builtin.NativeObject
+  end_borrow %3 : $@opened(2, AnyObject) Self
+  %7 = unchecked_ref_cast %2 : $@opened(2, AnyObject) Self to $Builtin.NativeObject
   return %7 : $Builtin.NativeObject
 }
 
@@ -78,23 +78,23 @@ bb0(%0 : @owned $Klass):
 sil [ossa] @fold_owned_multiblock_borrow_scope : $@convention(thin) (@owned Klass) -> @owned Builtin.NativeObject {
 bb0(%0 : @owned $Klass):
   %1 = init_existential_ref %0 : $Klass : $Klass, $AnyObject
-  %2 = open_existential_ref %1 : $AnyObject to $@opened("33333333-3333-3333-3333-333333333333", AnyObject) Self
-  %3 = begin_borrow %2 : $@opened("33333333-3333-3333-3333-333333333333", AnyObject) Self
+  %2 = open_existential_ref %1 : $AnyObject to $@opened(3, AnyObject) Self
+  %3 = begin_borrow %2 : $@opened(3, AnyObject) Self
   cond_br undef, bb1, bb2
 
 bb1:
-  %4 = unchecked_ref_cast %3 : $@opened("33333333-3333-3333-3333-333333333333", AnyObject) Self to $Klass
+  %4 = unchecked_ref_cast %3 : $@opened(3, AnyObject) Self to $Klass
   %5 = function_ref @takeKlass : $@convention(thin) (@guaranteed Klass) -> ()
   %6 = apply %5(%4) : $@convention(thin) (@guaranteed Klass) -> ()
-  end_borrow %3 : $@opened("33333333-3333-3333-3333-333333333333", AnyObject) Self
+  end_borrow %3 : $@opened(3, AnyObject) Self
   br bb3
 
 bb2:
-  end_borrow %3 : $@opened("33333333-3333-3333-3333-333333333333", AnyObject) Self
+  end_borrow %3 : $@opened(3, AnyObject) Self
   br bb3
 
 bb3:
-  %7 = unchecked_ref_cast %2 : $@opened("33333333-3333-3333-3333-333333333333", AnyObject) Self to $Builtin.NativeObject
+  %7 = unchecked_ref_cast %2 : $@opened(3, AnyObject) Self to $Builtin.NativeObject
   return %7 : $Builtin.NativeObject
 }
 
@@ -116,16 +116,16 @@ bb3:
 sil [ossa] @fold_guaranteed_existential_partial : $@convention(thin) (@guaranteed Klass) -> () {
 bb0(%0 : @guaranteed $Klass):
   %1 = init_existential_ref %0 : $Klass : $Klass, $AnyObject
-  %2 = open_existential_ref %1 : $AnyObject to $@opened("44444444-4444-4444-4444-444444444444", AnyObject) Self
-  %3 = unchecked_ref_cast %2 : $@opened("44444444-4444-4444-4444-444444444444", AnyObject) Self to $Klass
+  %2 = open_existential_ref %1 : $AnyObject to $@opened(4, AnyObject) Self
+  %3 = unchecked_ref_cast %2 : $@opened(4, AnyObject) Self to $Klass
   %4 = function_ref @takeKlass : $@convention(thin) (@guaranteed Klass) -> ()
   %5 = apply %4(%3) : $@convention(thin) (@guaranteed Klass) -> ()
-  %6 = begin_borrow %2 : $@opened("44444444-4444-4444-4444-444444444444", AnyObject) Self
-  %7 = unchecked_ref_cast %6 : $@opened("44444444-4444-4444-4444-444444444444", AnyObject) Self to $Klass
+  %6 = begin_borrow %2 : $@opened(4, AnyObject) Self
+  %7 = unchecked_ref_cast %6 : $@opened(4, AnyObject) Self to $Klass
   %8 = apply %4(%7) : $@convention(thin) (@guaranteed Klass) -> ()
-  end_borrow %6 : $@opened("44444444-4444-4444-4444-444444444444", AnyObject) Self
+  end_borrow %6 : $@opened(4, AnyObject) Self
   %9 = function_ref @use_generic_obj_guaranteed : $@convention(thin) <T> (@guaranteed T) -> ()
-  apply %9<@opened("44444444-4444-4444-4444-444444444444", AnyObject) Self>(%2) : $@convention(thin) <T> (@guaranteed T) -> ()
+  apply %9<@opened(4, AnyObject) Self>(%2) : $@convention(thin) <T> (@guaranteed T) -> ()
   %r = tuple ()
   return %r : $()
 }
@@ -145,10 +145,10 @@ bb0(%0 : @guaranteed $Klass):
 sil [ossa] @fold_guaranteed_ignoring_type_dependent_operand : $@convention(thin) (@guaranteed Klass) -> () {
 bb0(%0 : @guaranteed $Klass):
   %1 = init_existential_ref %0 : $Klass : $Klass, $AnyObject
-  %2 = open_existential_ref %1 : $AnyObject to $@opened("55555555-5555-5555-5555-555555555555", AnyObject) Self
-  %3 = metatype $@thick (@opened("55555555-5555-5555-5555-555555555555", AnyObject) Self).Type
+  %2 = open_existential_ref %1 : $AnyObject to $@opened(5, AnyObject) Self
+  %3 = metatype $@thick (@opened(5, AnyObject) Self).Type
   fix_lifetime %3
-  %4 = unchecked_ref_cast %2 : $@opened("55555555-5555-5555-5555-555555555555", AnyObject) Self to $Klass
+  %4 = unchecked_ref_cast %2 : $@opened(5, AnyObject) Self to $Klass
   %5 = function_ref @takeKlass : $@convention(thin) (@guaranteed Klass) -> ()
   %6 = apply %5(%4) : $@convention(thin) (@guaranteed Klass) -> ()
   %r = tuple ()
@@ -171,10 +171,10 @@ bb0(%0 : @guaranteed $Klass):
 sil [ossa] @fold_guaranteed_ignoring_type_dependent_cast_operand : $@convention(thin) (@guaranteed Klass, @guaranteed Klass) -> () {
 bb0(%0 : @guaranteed $Klass, %1 : @guaranteed $Klass):
   %2 = init_existential_ref %0 : $Klass : $Klass, $AnyObject
-  %3 = open_existential_ref %2 : $AnyObject to $@opened("BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB", AnyObject) Self
-  %4 = unchecked_ref_cast %1 : $Klass to $@opened("BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB", AnyObject) Self
+  %3 = open_existential_ref %2 : $AnyObject to $@opened(6, AnyObject) Self
+  %4 = unchecked_ref_cast %1 : $Klass to $@opened(6, AnyObject) Self
   fix_lifetime %4
-  %5 = unchecked_ref_cast %3 : $@opened("BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB", AnyObject) Self to $Klass
+  %5 = unchecked_ref_cast %3 : $@opened(6, AnyObject) Self to $Klass
   %6 = function_ref @takeKlass : $@convention(thin) (@guaranteed Klass) -> ()
   %7 = apply %6(%5) : $@convention(thin) (@guaranteed Klass) -> ()
   %r = tuple ()
@@ -193,8 +193,8 @@ bb0(%0 : @guaranteed $Klass, %1 : @guaranteed $Klass):
 sil @fold_non_ossa : $@convention(thin) (@owned Klass) -> @owned Builtin.NativeObject {
 bb0(%0 : $Klass):
   %1 = init_existential_ref %0 : $Klass : $Klass, $AnyObject
-  %2 = open_existential_ref %1 : $AnyObject to $@opened("66666666-6666-6666-6666-666666666666", AnyObject) Self
-  %3 = unchecked_ref_cast %2 : $@opened("66666666-6666-6666-6666-666666666666", AnyObject) Self to $Builtin.NativeObject
+  %2 = open_existential_ref %1 : $AnyObject to $@opened(7, AnyObject) Self
+  %3 = unchecked_ref_cast %2 : $@opened(7, AnyObject) Self to $Builtin.NativeObject
   return %3 : $Builtin.NativeObject
 }
 
@@ -208,10 +208,10 @@ bb0(%0 : $Klass):
 sil [ossa] @dont_fold_owned_apply_use : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
   %1 = init_existential_ref %0 : $Klass : $Klass, $AnyObject
-  %2 = open_existential_ref %1 : $AnyObject to $@opened("77777777-7777-7777-7777-777777777777", AnyObject) Self
+  %2 = open_existential_ref %1 : $AnyObject to $@opened(8, AnyObject) Self
   %f = function_ref @use_generic_obj_guaranteed : $@convention(thin) <T> (@guaranteed T) -> ()
-  apply %f<@opened("77777777-7777-7777-7777-777777777777", AnyObject) Self>(%2) : $@convention(thin) <T> (@guaranteed T) -> ()
-  destroy_value %2 : $@opened("77777777-7777-7777-7777-777777777777", AnyObject) Self
+  apply %f<@opened(8, AnyObject) Self>(%2) : $@convention(thin) <T> (@guaranteed T) -> ()
+  destroy_value %2 : $@opened(8, AnyObject) Self
   %x = tuple ()
   return %x : $()
 }
@@ -227,12 +227,12 @@ bb0(%0 : @owned $Klass):
 sil [ossa] @dont_fold_owned_noncast_use_in_borrow_scope : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
   %1 = init_existential_ref %0 : $Klass : $Klass, $AnyObject
-  %2 = open_existential_ref %1 : $AnyObject to $@opened("88888888-8888-8888-8888-888888888888", AnyObject) Self
-  %3 = begin_borrow %2 : $@opened("88888888-8888-8888-8888-888888888888", AnyObject) Self
+  %2 = open_existential_ref %1 : $AnyObject to $@opened(9, AnyObject) Self
+  %3 = begin_borrow %2 : $@opened(9, AnyObject) Self
   %f = function_ref @use_generic_obj_guaranteed : $@convention(thin) <T> (@guaranteed T) -> ()
-  apply %f<@opened("88888888-8888-8888-8888-888888888888", AnyObject) Self>(%3) : $@convention(thin) <T> (@guaranteed T) -> ()
-  end_borrow %3 : $@opened("88888888-8888-8888-8888-888888888888", AnyObject) Self
-  destroy_value %2 : $@opened("88888888-8888-8888-8888-888888888888", AnyObject) Self
+  apply %f<@opened(9, AnyObject) Self>(%3) : $@convention(thin) <T> (@guaranteed T) -> ()
+  end_borrow %3 : $@opened(9, AnyObject) Self
+  destroy_value %2 : $@opened(9, AnyObject) Self
   %x = tuple ()
   return %x : $()
 }
@@ -254,8 +254,8 @@ bb0(%0 : @owned $Klass):
   %1 = init_existential_ref %0 : $Klass : $Klass, $AnyObject
   %f = function_ref @use_generic_obj_guaranteed : $@convention(thin) <T> (@guaranteed T) -> ()
   apply %f<AnyObject>(%1) : $@convention(thin) <T> (@guaranteed T) -> ()
-  %2 = open_existential_ref %1 : $AnyObject to $@opened("99999999-9999-9999-9999-999999999999", AnyObject) Self
-  %3 = unchecked_ref_cast %2 : $@opened("99999999-9999-9999-9999-999999999999", AnyObject) Self to $Builtin.NativeObject
+  %2 = open_existential_ref %1 : $AnyObject to $@opened(10, AnyObject) Self
+  %3 = unchecked_ref_cast %2 : $@opened(10, AnyObject) Self to $Builtin.NativeObject
   return %3 : $Builtin.NativeObject
 }
 
@@ -266,8 +266,8 @@ bb0(%0 : @owned $Klass):
 // CHECK-LABEL: } // end sil function 'dont_fold_non_init_existential_source'
 sil [ossa] @dont_fold_non_init_existential_source : $@convention(thin) (@guaranteed AnyObject) -> () {
 bb0(%0 : @guaranteed $AnyObject):
-  %1 = open_existential_ref %0 : $AnyObject to $@opened("AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA", AnyObject) Self
-  %2 = unchecked_ref_cast %1 : $@opened("AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA", AnyObject) Self to $Klass
+  %1 = open_existential_ref %0 : $AnyObject to $@opened(11, AnyObject) Self
+  %2 = unchecked_ref_cast %1 : $@opened(11, AnyObject) Self to $Klass
   %3 = function_ref @takeKlass : $@convention(thin) (@guaranteed Klass) -> ()
   %4 = apply %3(%2) : $@convention(thin) (@guaranteed Klass) -> ()
   %r = tuple ()

--- a/test/Serialization/transitive_conformances_and_cgfloat_double.swift
+++ b/test/Serialization/transitive_conformances_and_cgfloat_double.swift
@@ -1,4 +1,8 @@
-// RUN: %target-swift-frontend -emit-module %s -o %t -solver-enable-crash-on-valid-salvage -solver-disable-transitive-conformance
+// RUN: %target-swift-frontend -emit-module %s -o %t -solver-disable-transitive-conformance
+// RUN: %target-typecheck-verify-swift -solver-enable-transitive-conformance
+
+// FIXME: Removing -solver-enable-transitive-conformance and the associated
+// optimization will fix the salvage issue.
 
 // REQUIRES: objc_interop
 
@@ -21,7 +25,7 @@ struct Proxy: P {
 }
 
 struct Test {
-  @Builder var proxy: some P {
+  @Builder var proxy: some P {  // expected-error {{failed to produce diagnostic for expression; please submit a bug report}}
     Proxy { point in
       if let point {
         let _: SIMD2<Double>? = SIMD2(point, point)

--- a/test/expr/cast/cf.swift
+++ b/test/expr/cast/cf.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -verify -solver-disable-crash-on-valid-salvage
-// RUN: not --crash %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -solver-enable-crash-on-valid-salvage
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -verify -solver-disable-diagnose-valid-salvage -verify-additional-prefix nosalvage-
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -verify -solver-enable-diagnose-valid-salvage -verify-additional-prefix salvage-
 
 // REQUIRES: objc_interop
 
@@ -124,11 +124,12 @@ func testCastWithImplicitErasure() {
         key1: flag,
         key2: info.id,
         key3: info.options ?? Null()
-        // expected-warning@-1 {{expression implicitly coerced from 'Any?' to 'Any'}}
-        // expected-note@-2 {{provide a default value to avoid this warning}}
-        // expected-note@-3 {{force-unwrap the value to avoid this warning}}
-        // expected-note@-4 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}
+        // expected-nosalvage-warning@-1 {{expression implicitly coerced from 'Any?' to 'Any'}}
+        // expected-nosalvage-note@-2 {{provide a default value to avoid this warning}}
+        // expected-nosalvage-note@-3 {{force-unwrap the value to avoid this warning}}
+        // expected-nosalvage-note@-4 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}
       ] as CFDictionary
+      // expected-salvage-error@-1 {{failed to produce diagnostic for expression; please submit a bug report}}
     }
   }
 }

--- a/test/expr/leading_dot/salvage_leading_dot.swift
+++ b/test/expr/leading_dot/salvage_leading_dot.swift
@@ -1,5 +1,8 @@
-// RUN: %target-typecheck-verify-swift -solver-disable-crash-on-valid-salvage
-// RUN: not --crash %target-swift-frontend -typecheck %s -solver-enable-crash-on-valid-salvage
+// RUN: %target-typecheck-verify-swift -solver-disable-diagnose-valid-salvage
+// RUN: %target-typecheck-verify-swift -solver-enable-diagnose-valid-salvage -verify-additional-prefix salvage-
+// RUN: not --crash %target-swift-frontend -typecheck %s -solver-enable-crash-fail-diagnostic
+
+// Once this bug is fixed, please add a new test to exercise -solver-enable-crash-fail-diagnostic.
 
 struct S {
   static func foo(_ s: S?) -> S? {s}
@@ -8,5 +11,6 @@ struct S {
 
 public func test() {
   let _: S? = .foo(S())
+  // expected-salvage-error@-1 {{failed to produce diagnostic for expression; please submit a bug report}}
 }
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2380,8 +2380,8 @@ config.substitutions.append(('%api-digester', config.swift_api_digester))
 config.substitutions.append(('%cache-tool', config.swift_cache_tool))
 
 # Enable typo-correction for testing purposes.
-config.target_swift_frontend += " -typo-correction-limit 10 -solver-enable-crash-on-valid-salvage "
-subst_target_swift_frontend_mock_sdk += " -typo-correction-limit 10 -solver-enable-crash-on-valid-salvage "
+config.target_swift_frontend += " -typo-correction-limit 10 -solver-enable-diagnose-valid-salvage "
+subst_target_swift_frontend_mock_sdk += " -typo-correction-limit 10 -solver-enable-diagnose-valid-salvage "
 
 config.substitutions.append(('%module-target-triple',
                              target_specific_module_triple))

--- a/validation-test/Sema/SwiftUI/leading_dot_delay.swift
+++ b/validation-test/Sema/SwiftUI/leading_dot_delay.swift
@@ -1,5 +1,5 @@
-// RUN: not --crash %target-typecheck-verify-swift -target %target-cpu-apple-macosx11 -swift-version 5 -solver-enable-crash-on-valid-salvage
-// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx13 -swift-version 5 -solver-enable-crash-on-valid-salvage
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx11 -swift-version 5 -solver-enable-diagnose-valid-salvage -verify-additional-prefix salvage-
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx13 -swift-version 5 -solver-enable-diagnose-valid-salvage -verify-additional-prefix nosalvage-
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx
 
@@ -17,7 +17,7 @@ struct FolderView: View {
   let folderList: [Folder]
   var currentFolder: String
 
-  var body: some View {
+  var body: some View {  // expected-salvage-error {{failed to produce diagnostic for expression; please submit a bug report}}
     ForEach(folderList) { folder in
       Text(folder.name).foregroundStyle(
         folder.id == currentFolder ? .blue : .secondary)
@@ -33,7 +33,9 @@ struct MyButtonStyle: PrimitiveButtonStyle {
     Button(action: configuration.trigger) {
       configuration.label.foregroundStyle(isEnabled ? .white : .secondary)
     }
-    .background {
+    .background {  // expected-salvage-error {{type '() -> Color' cannot conform to 'View'}}
+      // expected-salvage-note@-1 {{only concrete types such as structs, enums and classes can conform to protocols}}
+      // expected-salvage-note@-2 {{required by instance method 'background(_:alignment:)' where 'Background' = '() -> Color'}}
       return Color.clear
     }
   }
@@ -49,11 +51,11 @@ struct Hay {}
 
 func emptyPlaceholder(_ text: Text, _ flag: Bool, _ color: Color,
                       _ barn: Barn<(hay: Hay, horses: [Horse])>) -> some View {
-  return AnyView(
+  return AnyView( // expected-salvage-error {{failed to produce diagnostic for expression; please submit a bug report}}
     VStack() {
       text.foregroundStyle(flag ? .secondary : color)
 
-      if case let .animal((hay, _)) = barn {  // expected-warning {{immutable value 'hay' was never used; consider replacing with '_' or removing it}}
+      if case let .animal((hay, _)) = barn {  // expected-nosalvage-warning {{immutable value 'hay' was never used; consider replacing with '_' or removing it}}
         EmptyView()
       } else {
         EmptyView()

--- a/validation-test/Sema/implicit_cgfloat_double_conversion_correctness.swift
+++ b/validation-test/Sema/implicit_cgfloat_double_conversion_correctness.swift
@@ -1,10 +1,10 @@
-// RUN: %target-typecheck-verify-swift -solver-enable-crash-on-valid-salvage
-// RUN: %target-typecheck-verify-swift -DSALVAGE -solver-disable-crash-on-valid-salvage
-// RUN: not --crash %target-typecheck-verify-swift -DSALVAGE -solver-enable-crash-on-valid-salvage
+// RUN: %target-typecheck-verify-swift -solver-enable-diagnose-valid-salvage -verify-additional-prefix salvage-
+// RUN: %target-typecheck-verify-swift -solver-disable-diagnose-valid-salvage
 
 // REQUIRES: objc_interop
 
-// Note this cannot use a fake Foundation because it lacks required operator overloads
+// Note this cannot use the mock SDK Foundation because it lacks required
+// operator overloads
 
 import Foundation
 import CoreGraphics
@@ -128,21 +128,13 @@ func testLeadingDotAmbiguity() {
 
   func test1(z: Double) {
     f1(max(.x, z), max(.y, z))  // expected-error {{type 'Double' has no member 'y'}}
-#if SALVAGE
-    f2(max(.x, z), max(.y, z))
-#endif
+    f2(max(.x, z), max(.y, z))  // expected-salvage-error {{failed to produce diagnostic for expression; please submit a bug report}}
     f3(max(.x, z), max(.y, z))  // expected-error {{type 'Double' has no member 'y'}}
-#if SALVAGE
-    f4(max(.x, z), max(.y, z))
-#endif
+    f4(max(.x, z), max(.y, z))  // expected-salvage-error {{failed to produce diagnostic for expression; please submit a bug report}}
     f5(max(.x, z), max(.y, z))  // expected-error {{type 'Double' has no member 'y'}}
-#if SALVAGE
-    f6(max(.x, z), max(.y, z))
-#endif
+    f6(max(.x, z), max(.y, z))  // expected-salvage-error {{failed to produce diagnostic for expression; please submit a bug report}}
     f7(max(.x, z), max(.y, z))  // expected-error {{type 'Double' has no member 'y'}}
-#if SALVAGE
-    f8(max(.x, z), max(.y, z))
-#endif
+    f8(max(.x, z), max(.y, z))  // expected-salvage-error {{failed to produce diagnostic for expression; please submit a bug report}}
     f9(max(.x, z), max(.y, z))  // expected-error {{type 'Double' has no member 'y'}}
     f10(max(.x, z), max(.y, z))  // expected-error {{type 'Double' has no member 'y'}}
     f11(max(.x, z), max(.y, z))  // expected-error {{type 'Double' has no member 'y'}}
@@ -156,10 +148,8 @@ func testLeadingDotAmbiguity() {
   func test2(z: Double) {
     f1(max(.y, z), max(.x, z))  // expected-error {{type 'Double' has no member 'y'}}
     f2(max(.y, z), max(.x, z))  // expected-error {{type 'Double' has no member 'y'}}
-#if SALVAGE
-    f3(max(.y, z), max(.x, z))
-    f4(max(.y, z), max(.x, z))
-#endif
+    f3(max(.y, z), max(.x, z))  // expected-salvage-error {{failed to produce diagnostic for expression; please submit a bug report}}
+    f4(max(.y, z), max(.x, z))  // expected-salvage-error {{failed to produce diagnostic for expression; please submit a bug report}}
     f5(max(.y, z), max(.x, z))  // expected-error {{type 'Double' has no member 'y'}}
     f6(max(.y, z), max(.x, z))  // expected-error {{type 'Double' has no member 'y'}}
     f7(max(.y, z), max(.x, z))  // expected-error {{type 'Double' has no member 'y'}}
@@ -170,9 +160,7 @@ func testLeadingDotAmbiguity() {
     f12(max(.y, z), max(.x, z))  // expected-error {{type 'Double' has no member 'y'}}
     f13(max(.y, z), max(.x, z))  // expected-error {{type 'Double' has no member 'y'}}
     f14(max(.y, z), max(.x, z))  // expected-error {{type 'Double' has no member 'y'}}
-#if SALVAGE
-    f15(max(.y, z), max(.x, z))
-    f16(max(.y, z), max(.x, z))
-#endif
+    f15(max(.y, z), max(.x, z))  // expected-salvage-error {{failed to produce diagnostic for expression; please submit a bug report}}
+    f16(max(.y, z), max(.x, z))  // expected-salvage-error {{failed to produce diagnostic for expression; please submit a bug report}}
   }
 }

--- a/validation-test/compiler_crashers_fixed/ConstraintSystem-getType-03ecc7.swift
+++ b/validation-test/compiler_crashers_fixed/ConstraintSystem-getType-03ecc7.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"fae2ea2c","signature":"swift::constraints::ConstraintSystem::getType(swift::ASTNode) const","signatureAssert":"Assertion failed: (found != NodeTypes.end() && \"Expected type to have been set!\"), function getType","signatureNext":"SyntacticElementSolutionApplication::visitReturnStmt"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 protocol a
   struct b
     var c: some a = {

--- a/validation-test/compiler_crashers_fixed/ConstraintSystem-getType-2222f8.swift
+++ b/validation-test/compiler_crashers_fixed/ConstraintSystem-getType-2222f8.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"eeb55458","signature":"swift::constraints::ConstraintSystem::getType(swift::ASTNode) const","signatureAssert":"Assertion failed: (found != NodeTypes.end() && \"Expected type to have been set!\"), function getType","signatureNext":"Solution::getResolvedType"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 // REQUIRES: OS=macosx
 import Foundation
 class a {

--- a/validation-test/compiler_crashers_fixed/ExprRewriter-coerceToType-0d561b.swift
+++ b/validation-test/compiler_crashers_fixed/ExprRewriter-coerceToType-0d561b.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"35c38675","signature":"(anonymous namespace)::ExprRewriter::coerceToType(swift::Expr*, swift::Type, swift::constraints::ConstraintLocatorBuilder)","signatureNext":"ExprWalker::rewriteTarget"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 @resultBuilder enum a<b {
   static  buildBlock(b ) -> [[b]]
 }

--- a/validation-test/compiler_crashers_fixed/ExprRewriter-coerceToType-1643de.swift
+++ b/validation-test/compiler_crashers_fixed/ExprRewriter-coerceToType-1643de.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"be86e682","signature":"(anonymous namespace)::ExprRewriter::coerceToType(swift::Expr*, swift::Type, swift::constraints::ConstraintLocatorBuilder)::$_3::operator()(swift::Type, swift::Type) const","signatureAssert":"Assertion failed: (restriction == ConversionRestrictionKind::DeepEquality), function operator()","signatureNext":"ExprRewriter::coerceCallArguments"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 protocol a {
   associatedtype b
   var c: b {

--- a/validation-test/compiler_crashers_fixed/ExprRewriter-coerceToType-394fca.swift
+++ b/validation-test/compiler_crashers_fixed/ExprRewriter-coerceToType-394fca.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"0251a12c","signature":"(anonymous namespace)::ExprRewriter::coerceToType(swift::Expr*, swift::Type, swift::constraints::ConstraintLocatorBuilder)","signatureNext":"ExprRewriter::coerceCallArguments"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 protocol a {
   associatedtype b
 }

--- a/validation-test/compiler_crashers_fixed/ExprRewriter-coerceToType-fd043a.swift
+++ b/validation-test/compiler_crashers_fixed/ExprRewriter-coerceToType-fd043a.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"456e5f49","signature":"(anonymous namespace)::ExprRewriter::coerceToType(swift::Expr*, swift::Type, swift::constraints::ConstraintLocatorBuilder)","signatureNext":"ExprRewriter::visitUnresolvedMemberChainResultExpr"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 protocol a {
   associatedtype b
 }

--- a/validation-test/compiler_crashers_fixed/ExprRewriter-visitDeclRefExpr-1e0608.swift
+++ b/validation-test/compiler_crashers_fixed/ExprRewriter-visitDeclRefExpr-1e0608.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"(anonymous namespace)::ExprRewriter::visitDeclRefExpr(swift::DeclRefExpr*)","signatureNext":"ExprWalker::walkToExprPost"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 {
   for b  0..<0 {
     let a = Array(0..<b)

--- a/validation-test/compiler_crashers_fixed/ExprWalker-rewriteTarget-b05b4c.swift
+++ b/validation-test/compiler_crashers_fixed/ExprWalker-rewriteTarget-b05b4c.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"cc97dd1d","signature":"(anonymous namespace)::ExprWalker::rewriteTarget(swift::constraints::SyntacticElementTarget)","signatureNext":"SyntacticElementSolutionApplication::apply"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 // REQUIRES: OS=macosx
 import Foundation
 let a = DispatchQueue(

--- a/validation-test/compiler_crashers_fixed/Traversal-doIt-5d8931.swift
+++ b/validation-test/compiler_crashers_fixed/Traversal-doIt-5d8931.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"3316325f","signature":"(anonymous namespace)::Traversal::doIt(swift::Expr*)","signatureNext":"Expr::walk"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 func a(b: [UInt8], c: () -> Int) {
   let d = c()
   e

--- a/validation-test/compiler_crashers_fixed/VarDeclUsageChecker-walkToExprPre-80cf80.swift
+++ b/validation-test/compiler_crashers_fixed/VarDeclUsageChecker-walkToExprPre-80cf80.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"eed30a35","signature":"(anonymous namespace)::VarDeclUsageChecker::walkToExprPre(swift::Expr*)","signatureAssert":"Assertion failed: (AllExprsSeen.insert(E).second && \"duplicate traversal\"), function walkToExprPre","signatureNext":"Traversal::doIt"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 // REQUIRES: OS=macosx
 import Foundation
 DispatchQueue.global(qos: .userInitiated).async {


### PR DESCRIPTION
A crash log here doesn't really give any useful information because the stack trace of the call into the expression type checker doesn't really determine the outcome. To understand why the solver found a valid solution in salvage, you really need to look at -debug-constraints output anyway.

So it's better to just emit a fallback diagnostic instead. This cleans up some tests as well, since we can flag the exact expression that ends up in this code path instead of just expecting a crash.

Note that this flag is already enabled for the standard library and validation tests, and I'd like to enable it by default soon once we fix some more bugs.