### PR TITLE
`@objc @implementation` cleanup

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1746,27 +1746,6 @@ void AttributeChecker::visitNonObjCAttr(NonObjCAttr *attr) {
   }
 }
 
-static bool hasObjCImplementationFeature(Decl *D, ObjCImplementationAttr *attr,
-                                         Feature requiredFeature) {
-  auto &ctx = D->getASTContext();
-
-  if (ctx.LangOpts.hasFeature(requiredFeature))
-    return true;
-
-  // Allow the use of @_objcImplementation *without* Feature::ObjCImplementation
-  // as long as you're using the early adopter syntax. (Avoids breaking existing
-  // adopters.)
-  if (requiredFeature == Feature::ObjCImplementation && attr->isEarlyAdopter())
-    return true;
-
-  // Either you're using Feature::ObjCImplementation without the early adopter
-  // syntax, or you're using Feature::CImplementation. Either way, no go.
-  ctx.Diags.diagnose(attr->getLocation(), diag::requires_experimental_feature,
-                     attr->getAttrName(), attr->isDeclModifier(),
-                     requiredFeature.getName());
-  return false;
-}
-
 static SourceRange getArgListRange(ASTContext &Ctx, DeclAttribute *attr) {
   // attr->getRange() covers the attr name and argument list; adjust it to
   // exclude the first token.
@@ -1805,9 +1784,6 @@ visitObjCImplementationAttr(ObjCImplementationAttr *attr) {
   }
 
   if (auto ED = dyn_cast<ExtensionDecl>(D)) {
-    if (!hasObjCImplementationFeature(D, attr, Feature::ObjCImplementation))
-      return;
-
     auto objcLangAttr = dyn_cast<ObjCAttr>(langAttr);
     assert(objcLangAttr && "extension with @_cdecl or another lang attr???");
 

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -4206,11 +4206,6 @@ public:
           || getAttr()->hasInvalidImplicitLangAttrs())
       return;
 
-    // Only encourage adoption if the corresponding language feature is enabled.
-    if (isa<ExtensionDecl>(decl) &&
-        !decl->getASTContext().LangOpts.hasFeature(Feature::ObjCImplementation))
-      return;
-
     auto diag = diagnose(getAttr()->getLocation(),
                          diag::objc_implementation_early_spelling_deprecated);
     diag.fixItReplace(getAttr()->getRangeWithAt(), "@implementation");

--- a/test/decl/ext/objc_implementation.swift
+++ b/test/decl/ext/objc_implementation.swift
@@ -1,6 +1,5 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -import-objc-header %S/Inputs/objc_implementation.h -enable-experimental-feature ObjCImplementation -target %target-stable-abi-triple -Xcc -Wno-nullability-completeness
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -import-objc-header %S/Inputs/objc_implementation.h -target %target-stable-abi-triple -Xcc -Wno-nullability-completeness
 // REQUIRES: objc_interop
-// REQUIRES: swift_feature_ObjCImplementation
 
 protocol EmptySwiftProto {}
 

--- a/test/decl/ext/objc_implementation_async_availability.swift
+++ b/test/decl/ext/objc_implementation_async_availability.swift
@@ -1,6 +1,5 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -import-objc-header %S/Inputs/objc_implementation_async_availability.h -enable-experimental-feature ObjCImplementation -target %target-stable-abi-triple -Xcc -Wno-nullability-completeness
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -import-objc-header %S/Inputs/objc_implementation_async_availability.h -target %target-stable-abi-triple -Xcc -Wno-nullability-completeness
 // REQUIRES: objc_interop
-// REQUIRES: swift_feature_ObjCImplementation
 
 // An imported Objective-C completion-handler method that carries an
 // availability attribute must still expose its async alternative. Otherwise an

--- a/test/decl/ext/objc_implementation_deployment_target.swift
+++ b/test/decl/ext/objc_implementation_deployment_target.swift
@@ -1,8 +1,7 @@
 // Hardcode x86_64 macOS because Apple Silicon was born ABI-stable
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -import-objc-header %S/Inputs/objc_implementation.h -target x86_64-apple-macosx10.14.3 -enable-experimental-feature ObjCImplementation
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -import-objc-header %S/Inputs/objc_implementation.h -target x86_64-apple-macosx10.14.3
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx
-// REQUIRES: swift_feature_ObjCImplementation
 // REQUIRES: SWIFT_STDLIB_ARCH=x86_64
 
 @objc @implementation extension ObjCImplSubclass {

--- a/test/decl/ext/objc_implementation_direct_to_storage.swift
+++ b/test/decl/ext/objc_implementation_direct_to_storage.swift
@@ -1,6 +1,5 @@
-// RUN: %target-typecheck-verify-swift -Xcc -fmodule-map-file=%S/Inputs/objc_implementation_private.modulemap -enable-experimental-feature ObjCImplementation -target %target-stable-abi-triple
+// RUN: %target-typecheck-verify-swift -Xcc -fmodule-map-file=%S/Inputs/objc_implementation_private.modulemap -target %target-stable-abi-triple
 // REQUIRES: objc_interop
-// REQUIRES: swift_feature_ObjCImplementation
 // REQUIRES: OS=macosx
 
 import objc_implementation_internal

--- a/test/decl/ext/objc_implementation_early_adopter.swift
+++ b/test/decl/ext/objc_implementation_early_adopter.swift
@@ -1,6 +1,5 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -import-objc-header %S/Inputs/objc_implementation.h -enable-experimental-feature ObjCImplementation -target %target-stable-abi-triple
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -import-objc-header %S/Inputs/objc_implementation.h -target %target-stable-abi-triple
 // REQUIRES: objc_interop
-// REQUIRES: swift_feature_ObjCImplementation
 
 protocol EmptySwiftProto {}
 

--- a/test/decl/ext/objc_implementation_features.swift
+++ b/test/decl/ext/objc_implementation_features.swift
@@ -1,15 +1,16 @@
 // REQUIRES: objc_interop
 
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -typecheck %s -import-objc-header %S/Inputs/objc_implementation.h >%t.txt 2>&1
-// RUN: %FileCheck %s --input-file %t.txt
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -typecheck -verify -verify-ignore-unrelated %s -import-objc-header %S/Inputs/objc_implementation.h -Xcc -Wno-nullability-completeness
 
-// CHECK-DAG: objc_implementation_features.swift:[[@LINE+1]]:{{[0-9]+}}: warning: '@_objcImplementation' is deprecated; use '@implementation' instead
 @_objcImplementation(EmptyCategory) extension ObjCClass {}
+// expected-warning@-1 {{'@_objcImplementation' is deprecated; use '@implementation' instead}}
 
-// CHECK-DAG: objc_implementation_features.swift:[[@LINE+2]]:{{[0-9]+}}: warning: extension for main class interface does not provide all required implementations; this will become an error after adopting '@implementation'
-// CHECK-NOT: objc_implementation_features.swift:[[@LINE+1]]:{{[0-9]+}}: warning: '@_objcImplementation' is deprecated; use '@implementation' instead
 @_objcImplementation extension ObjCSubclass {}
+// expected-warning@-1 {{extension for main class interface does not provide all required implementations; this will become an error after adopting '@implementation'}}
+// expected-note@-2 {{missing instance method 'subclassMethod(fromHeader1:)'}}
+// expected-note@-3 {{add stub for missing '@implementation' requirement}}
 
-// CHECK-DAG: objc_implementation_features.swift:[[@LINE+2]]:{{[0-9]+}}: error: extension for main class interface does not provide all required implementations{{$}}
-// CHECK-NOT: objc_implementation_features.swift:[[@LINE+1]]:{{[0-9]+}}: error: 'implementation' attribute is only valid when experimental feature ObjCImplementation is enabled
 @objc @implementation extension ObjCBasicInitClass {}
+// expected-error@-1 {{extension for main class interface does not provide all required implementations}}
+// expected-note@-2 {{missing initializer 'init()'}}
+// expected-note@-3 {{add stub for missing '@implementation' requirement}}

--- a/test/decl/ext/objc_implementation_inherited_init.swift
+++ b/test/decl/ext/objc_implementation_inherited_init.swift
@@ -1,6 +1,5 @@
-// RUN: %target-swift-frontend -emit-silgen -verify -import-objc-header %S/Inputs/objc_implementation_inherited_init.h -enable-experimental-feature ObjCImplementation -target %target-stable-abi-triple -Xcc -Wno-nullability-completeness %s
+// RUN: %target-swift-frontend -emit-silgen -verify -import-objc-header %S/Inputs/objc_implementation_inherited_init.h -target %target-stable-abi-triple -Xcc -Wno-nullability-completeness %s
 // REQUIRES: objc_interop
-// REQUIRES: swift_feature_ObjCImplementation
 
 // Declaring a designated initializer suppresses inheritance of NSObject's
 // 'init()', which the compiler turns into a trapping stub. Objective-C callers


### PR DESCRIPTION
The `ObjCImplementation` feature shipped a couple of years ago so it isn't necessary to enable it in tests or check whether it is enabled in the compiler anymore.