### PR TITLE
[rbi] Rewind partition history across CFG joins to explain sent-value isolation

### DIFF
--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -1097,6 +1097,17 @@ public:
   /// \returns true if there is more history that can be popped.
   bool popHistory(SmallVectorImpl<IsolationHistory> &foundJoinedHistories);
 
+  /// Pop one history node (a single node; multiple nodes can make up one
+  /// PartitionOp worth of history). Undoes the popped node's effect on the
+  /// partition. Callers that want to inspect the popped node should read
+  /// \c getIsolationHistory().getHead() *before* calling.
+  ///
+  /// Same sending-state precondition as \c popHistory.
+  ///
+  /// \returns false when the popped node is a SequenceBoundary or the history
+  /// is empty; true otherwise.
+  bool popHistoryOnce(SmallVectorImpl<IsolationHistory> &foundJoinHistoryNodes);
+
   /// Returns true if this value has any isolation history stored.
   bool hasHistory() const { return bool(history.getHead()); }
 
@@ -1223,12 +1234,6 @@ public:
   Region merge(Element fst, Element snd, bool updateHistory = true);
 
 private:
-  /// Pop one history node. Multiple history nodes can make up one PartitionOp
-  /// worth of history, so this is called by popHistory.
-  ///
-  /// Returns true if we succesfully popped a single history node.
-  bool popHistoryOnce(SmallVectorImpl<IsolationHistory> &foundJoinHistoryNodes);
-
   /// A canonical region is defined to have its region number as equal to the
   /// minimum element number of all of its assigned element numbers. This
   /// routine goes through the element -> region map and transforms the
@@ -1360,17 +1365,15 @@ public:
     Element sentElement;
     SILDynamicMergedIsolationInfo isolationRegionInfo;
 
-    /// The isolation history of the partition at the point the send was
-    /// detected. Used to emit notes explaining why a disconnected element ended
-    /// up in an isolated region.
-    IsolationHistory isolationHistory;
+    /// The partition at the point where the error was emitted. Used for
+    /// isolation history rewinding.
+    Partition partition;
 
     SentNeverSendableError(const PartitionOp &op, Element sentElement,
                            SILDynamicMergedIsolationInfo isolationRegionInfo,
-                           IsolationHistory isolationHistory)
+                           const Partition &p)
         : op(&op), sentElement(sentElement),
-          isolationRegionInfo(isolationRegionInfo),
-          isolationHistory(isolationHistory) {}
+          isolationRegionInfo(isolationRegionInfo), partition(p) {}
 
     SentNeverSendableError(SentNeverSendableError &&other) = default;
     SentNeverSendableError &operator=(SentNeverSendableError &&other) = default;
@@ -2571,8 +2574,8 @@ private:
     }
 
     // Ok, we actually need to emit a call to the callback.
-    return handleError(SentNeverSendableError(
-        op, elt, dynamicMergedIsolationInfo, p.getIsolationHistory()));
+    return handleError(
+        SentNeverSendableError(op, elt, dynamicMergedIsolationInfo, p));
   }
 };
 

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -1083,34 +1083,22 @@ public:
     return p;
   }
 
-  /// Rewind one PartitionOp worth of history from the partition.
+  /// Pop and undo one history node from this partition, returning the node that
+  /// was popped (its effect on the partition has already been reversed), or
+  /// null when the history is empty. Multiple nodes can make up one PartitionOp
+  /// worth of history; a caller rewinds by calling this in a loop and
+  /// inspecting each returned node (e.g. its kind, flow value, or — for a
+  /// CFGHistoryJoin — its predecessor block).
   ///
-  /// If we rewind through a CFG join, the predecessor block whose exit
-  /// partition was joined in is appended to \p foundJoinedBlocks. A consumer
-  /// that wants to keep rewinding across the join should recover that block's
-  /// exit partition (from RegionAnalysis) and rewind it in turn.
+  /// A popped CFGHistoryJoin appends its predecessor block to
+  /// \p foundJoinedBlocks; the joined branch itself is recovered from that
+  /// block's exit partition.
   ///
-  /// NOTE: This can only be used if one has cleared the sent state using
-  /// Partition::clearSendingOperandState or constructed a new Partiton using
-  /// Partition::removingSendingOperandState(). This is because history
-  /// rewinding doesn't use send information so just to be careful around
-  /// potential invariants being broken, we just require the elimination of the
-  /// send information.
-  ///
-  /// \returns true if there is more history that can be popped.
-  bool popHistory(SmallVectorImpl<SILBasicBlock *> &foundJoinedBlocks);
-
-  /// Pop one history node (a single node; multiple nodes can make up one
-  /// PartitionOp worth of history). Undoes the popped node's effect on the
-  /// partition. Callers that want to inspect the popped node should read
-  /// \c getIsolationHistory().getHead() *before* calling.
-  ///
-  /// Same sending-state precondition as \c popHistory. A popped CFG join
-  /// appends its predecessor block to \p foundJoinedBlocks.
-  ///
-  /// \returns false when the popped node is a SequenceBoundary or the history
-  /// is empty; true otherwise.
-  bool popHistoryOnce(SmallVectorImpl<SILBasicBlock *> &foundJoinedBlocks);
+  /// This can only be used if one is not tracking sending-operand state (see
+  /// \c clearSendingOperandState / \c removingSendingOperandState) — history
+  /// rewinding does not use send information.
+  const IsolationHistoryNode *
+  popHistoryOnce(SmallVectorImpl<SILBasicBlock *> &foundJoinedBlocks);
 
   /// Returns true if this value has any isolation history stored.
   bool hasHistory() const { return bool(history.getHead()); }

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -335,13 +335,9 @@ public:
   void pushAssignElementRegions(Element elementToMergeInto,
                                 Element elementToMerge);
 
-  /// Push that \p other should be merged into this region.
-  void pushCFGHistoryJoin(Node *otherNode);
-
-  /// Push the top node of \p history as a CFG history join.
-  void pushCFGHistoryJoin(IsolationHistory history) {
-    return pushCFGHistoryJoin(history.getHead());
-  }
+  /// Push a CFG history join recording that \p predBlock's exit partition was
+  /// merged into this history at a control-flow merge point.
+  void pushCFGHistoryJoin(SILBasicBlock *predBlock);
 
   Node *pop();
   void print(ASTContext &ctx, llvm::raw_ostream &os) const;
@@ -395,10 +391,14 @@ private:
 
   /// Contains:
   ///
-  /// 1. Node * if we have a CFGHistoryJoin.
+  /// 1. A SILBasicBlock * if we have a CFGHistoryJoin — the predecessor block
+  ///    whose exit partition was joined in. The joined branch's history head is
+  ///    not stored; it is recovered on demand as the head of that block's exit
+  ///    partition (from RegionAnalysis), which also gives the full partition to
+  ///    keep rewinding across the join.
   /// 2. A SILLocation if we have a SequenceBoundary.
   /// 3. An element otherwise.
-  std::variant<Element, Node *, SILLocation> data;
+  std::variant<Element, SILBasicBlock *, SILLocation> data;
 
   /// Number of additional element arguments stored in the tail allocated array.
   unsigned numAdditionalElements;
@@ -447,8 +447,8 @@ private:
                             &getAdditionalElementArgs().data()[1]);
   }
 
-  Node(Kind kind, Node *parent, Node *node)
-      : kind(kind), next(parent), data(node), numAdditionalElements(0) {}
+  Node(Kind kind, Node *parent, SILBasicBlock *block)
+      : kind(kind), next(parent), data(block), numAdditionalElements(0) {}
 
 public:
   Kind getKind() const { return kind; }
@@ -462,10 +462,13 @@ public:
     return std::get<Element>(data);
   }
 
-  Node *getFirstArgAsNode() const {
+  /// The predecessor block whose exit partition this CFGHistoryJoin merged in.
+  /// The joined branch's history is recovered as that block's exit-partition
+  /// isolation history (see \c data).
+  SILBasicBlock *getFirstArgAsBlock() const {
     assert(kind == CFGHistoryJoin);
-    assert(std::holds_alternative<Node *>(data));
-    return std::get<Node *>(data);
+    assert(std::holds_alternative<SILBasicBlock *>(data));
+    return std::get<SILBasicBlock *>(data);
   }
 
   ArrayRef<Element> getAdditionalElementArgs() const {
@@ -477,12 +480,12 @@ public:
     return getKind() == SequenceBoundary;
   }
 
-  /// If this node is a history sequence join, return its node. Otherwise,
-  /// return nullptr.
-  Node *getHistorySequenceJoin() const {
+  /// If this node is a CFG history join, return the predecessor block whose
+  /// exit partition it merged in. Otherwise, return nullptr.
+  SILBasicBlock *getHistorySequenceJoin() const {
     if (kind != CFGHistoryJoin)
       return nullptr;
-    return getFirstArgAsNode();
+    return getFirstArgAsBlock();
   }
 
   std::optional<SILLocation> getHistoryBoundaryLoc() const {
@@ -1082,10 +1085,10 @@ public:
 
   /// Rewind one PartitionOp worth of history from the partition.
   ///
-  /// If we rewind through a join, the joined isolation history before merging
-  /// is inserted into \p foundJoinedHistories which should be processed
-  /// afterwards if the current linear history does not find what one is looking
-  /// for.
+  /// If we rewind through a CFG join, the predecessor block whose exit
+  /// partition was joined in is appended to \p foundJoinedBlocks. A consumer
+  /// that wants to keep rewinding across the join should recover that block's
+  /// exit partition (from RegionAnalysis) and rewind it in turn.
   ///
   /// NOTE: This can only be used if one has cleared the sent state using
   /// Partition::clearSendingOperandState or constructed a new Partiton using
@@ -1095,18 +1098,19 @@ public:
   /// send information.
   ///
   /// \returns true if there is more history that can be popped.
-  bool popHistory(SmallVectorImpl<IsolationHistory> &foundJoinedHistories);
+  bool popHistory(SmallVectorImpl<SILBasicBlock *> &foundJoinedBlocks);
 
   /// Pop one history node (a single node; multiple nodes can make up one
   /// PartitionOp worth of history). Undoes the popped node's effect on the
   /// partition. Callers that want to inspect the popped node should read
   /// \c getIsolationHistory().getHead() *before* calling.
   ///
-  /// Same sending-state precondition as \c popHistory.
+  /// Same sending-state precondition as \c popHistory. A popped CFG join
+  /// appends its predecessor block to \p foundJoinedBlocks.
   ///
   /// \returns false when the popped node is a SequenceBoundary or the history
   /// is empty; true otherwise.
-  bool popHistoryOnce(SmallVectorImpl<IsolationHistory> &foundJoinHistoryNodes);
+  bool popHistoryOnce(SmallVectorImpl<SILBasicBlock *> &foundJoinedBlocks);
 
   /// Returns true if this value has any isolation history stored.
   bool hasHistory() const { return bool(history.getHead()); }
@@ -1137,8 +1141,13 @@ public:
   /// NOTE: snd is passed in as mutable since we may canonicalize snd. We will
   /// not perform any further mutations to snd.
   ///
+  /// \p sndBlock is the predecessor block \p snd is the exit partition of, if
+  /// known; it is recorded on the CFG history join so the join can later be
+  /// rewound by recovering \p sndBlock's exit partition.
+  ///
   /// Runs in quadratic time.
-  static Partition join(const Partition &fst, Partition &snd);
+  static Partition join(const Partition &fst, Partition &snd,
+                        SILBasicBlock *sndBlock = nullptr);
 
   void dump_labels() const LLVM_ATTRIBUTE_USED {
     llvm::dbgs() << "Partition";
@@ -1269,10 +1278,10 @@ private:
     history.pushRemoveElementFromRegion(elementFromOldRegion, elementToRemove);
   }
 
-  /// Push that \p other should be merged into this region.
-  void pushCFGHistoryJoin(IsolationHistory otherHistory) {
-    if (auto *head = otherHistory.head)
-      history.pushCFGHistoryJoin(head);
+  /// Record that \p predBlock's exit partition was merged into this partition's
+  /// history at a control-flow merge point.
+  void pushCFGHistoryJoin(SILBasicBlock *predBlock) {
+    history.pushCFGHistoryJoin(predBlock);
   }
 
   /// \see IsolationHistory::pushMergeElementRegions.
@@ -2190,7 +2199,6 @@ public:
         handleError(UnknownCodePatternError(op));
       }
       assert(state.isolationInfo && "Cannot have unknown");
-      state.isolationHistory.pushCFGHistoryJoin(p.getIsolationHistory());
       auto *ptrSet = ptrSetFactory.get(op.getSourceOp());
       p.markSent(op.getOpArg1(), ptrSet);
       return;

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -4861,8 +4861,8 @@ void RegionAnalysisFunctionInfo::runDataflow() {
         REGIONBASEDISOLATION_LOG(
             llvm::dbgs() << "    Pred. bb" << predBlock->getDebugID() << ": ";
             predState.exitPartition.print(llvm::dbgs()));
-        newEntryPartition =
-            Partition::join(newEntryPartition, predState.exitPartition);
+        newEntryPartition = Partition::join(newEntryPartition,
+                                            predState.exitPartition, predBlock);
       }
 
       // Update the entry partition. We need to still try to

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -874,54 +874,75 @@ bool IsolationHistoryNoteEmitter::processFrame(Frame frame) {
   // explored every predecessor it would be pinned to the first boundary of
   // whichever branch we happen to walk first — e.g. the 'else' arm of a
   // diamond, which never touched the isolated value. So while such a merge is
-  // pending, prefer the predecessor(s) where a tracked element is actually
-  // isolated at the block exit — the branch that holds the user-written merge —
-  // and prune the rest. Only when no predecessor has the chain isolated do we
-  // fall back to exploring them all.
+  // pending, find the branch responsible for the isolation and prune the rest.
+  //
+  // The signal is a *discriminating* element: one that is isolated at some
+  // predecessor's exit but merely disconnected at another's. Its isolation was
+  // introduced on the branch(es) where it is isolated, so the predecessors
+  // where it is disconnected did not cause it and are pruned. (Elements that
+  // are isolated everywhere, or absent, or disconnected everywhere — e.g.
+  // block- local temporaries — do not distinguish the branches and are
+  // ignored.)
   struct PredExit {
     SILBasicBlock *block;
     Partition exit;
-    bool chainIsolated;
   };
   SmallVector<PredExit, 4> preds;
-  bool anyIsolated = false;
   for (SILBasicBlock *predBlock : joinedBlocks) {
     if (!visitedBlocks.insert(predBlock).second)
       continue;
     auto predBlockState = inputFunctionInfo->getBlockState(predBlock);
     if (!predBlockState)
       continue;
-    Partition exit =
-        predBlockState.get()->getExitPartition().removingSendingOperandState();
+    preds.push_back({predBlock, predBlockState.get()
+                                    ->getExitPartition()
+                                    .removingSendingOperandState()});
+  }
 
-    bool chainIsolated = false;
-    if (state.pendingTargetMerge) {
-      for (Element e : state.tracked) {
-        if (!exit.isTrackingElement(e))
+  SmallVector<bool, 4> resets(preds.size(), false);
+  if (state.pendingTargetMerge) {
+    for (Element e : state.tracked) {
+      // Classify e at each predecessor exit: isolated, or present-but-
+      // disconnected. (Absent predecessors are left out — they say nothing.)
+      SmallVector<bool, 4> isolatedInPred(preds.size(), false);
+      SmallVector<bool, 4> disconnectedInPred(preds.size(), false);
+      bool anyIsolated = false;
+      for (unsigned i = 0, n = preds.size(); i != n; ++i) {
+        if (!preds[i].exit.isTrackingElement(e))
           continue;
-        Region region = exit.getRegion(e);
-        for (auto pair : exit.range()) {
+        bool isolatedHere = false;
+        Region region = preds[i].exit.getRegion(e);
+        for (auto pair : preds[i].exit.range()) {
           if (pair.second != region)
             continue;
           auto info = inputValueMap.getIsolationRegion(pair.first);
           if (info && !info.isDisconnected()) {
-            chainIsolated = true;
+            isolatedHere = true;
             break;
           }
         }
-        if (chainIsolated)
-          break;
+        isolatedInPred[i] = isolatedHere;
+        disconnectedInPred[i] = !isolatedHere;
+        anyIsolated |= isolatedHere;
       }
-    }
 
-    anyIsolated |= chainIsolated;
-    preds.push_back({predBlock, std::move(exit), chainIsolated});
+      // e discriminates only if it is isolated somewhere; then the branches
+      // where it is disconnected are the ones that reset it.
+      if (anyIsolated)
+        for (unsigned i = 0, n = preds.size(); i != n; ++i)
+          if (disconnectedInPred[i])
+            resets[i] = true;
+    }
   }
 
-  for (auto &pred : preds) {
-    if (state.pendingTargetMerge && anyIsolated && !pred.chainIsolated)
+  bool anyResponsible = false;
+  for (bool reset : resets)
+    anyResponsible |= !reset;
+
+  for (unsigned i = 0, n = preds.size(); i != n; ++i) {
+    if (state.pendingTargetMerge && anyResponsible && resets[i])
       continue;
-    worklist.push_back(Frame{std::move(pred.exit), state});
+    worklist.push_back(Frame{std::move(preds[i].exit), state});
   }
   return false;
 }

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -867,48 +867,61 @@ bool IsolationHistoryNoteEmitter::processFrame(Frame frame) {
   }
 
   // The chain continues into the predecessor blocks joined at this frame.
-  // Schedule each, inheriting the walk state as of here.
   //
   // A pendingTargetMerge still set here has no location: it came from a region
   // unification the dataflow join introduced, not a user-written merge (which
   // would have been followed by its SequenceBoundary in this same frame). If we
-  // carried it into every predecessor it would be pinned to the first boundary
-  // of whichever branch we explore first — e.g. the 'else' arm of a diamond,
-  // which never touched the isolated value. Route it only to the predecessor
-  // that actually made the chain isolated (a tracked element shares an isolated
-  // region at that block's exit); the user-written merge there re-anchors it.
+  // explored every predecessor it would be pinned to the first boundary of
+  // whichever branch we happen to walk first — e.g. the 'else' arm of a
+  // diamond, which never touched the isolated value. So while such a merge is
+  // pending, prefer the predecessor(s) where a tracked element is actually
+  // isolated at the block exit — the branch that holds the user-written merge —
+  // and prune the rest. Only when no predecessor has the chain isolated do we
+  // fall back to exploring them all.
+  struct PredExit {
+    SILBasicBlock *block;
+    Partition exit;
+    bool chainIsolated;
+  };
+  SmallVector<PredExit, 4> preds;
+  bool anyIsolated = false;
   for (SILBasicBlock *predBlock : joinedBlocks) {
     if (!visitedBlocks.insert(predBlock).second)
       continue;
     auto predBlockState = inputFunctionInfo->getBlockState(predBlock);
     if (!predBlockState)
       continue;
-    Partition predExit =
+    Partition exit =
         predBlockState.get()->getExitPartition().removingSendingOperandState();
 
-    WalkState childState = state;
-    if (childState.pendingTargetMerge) {
-      bool chainIsolatedInPred = false;
+    bool chainIsolated = false;
+    if (state.pendingTargetMerge) {
       for (Element e : state.tracked) {
-        if (!predExit.isTrackingElement(e))
+        if (!exit.isTrackingElement(e))
           continue;
-        Region region = predExit.getRegion(e);
-        for (auto pair : predExit.range()) {
+        Region region = exit.getRegion(e);
+        for (auto pair : exit.range()) {
           if (pair.second != region)
             continue;
           auto info = inputValueMap.getIsolationRegion(pair.first);
           if (info && !info.isDisconnected()) {
-            chainIsolatedInPred = true;
+            chainIsolated = true;
             break;
           }
         }
-        if (chainIsolatedInPred)
+        if (chainIsolated)
           break;
       }
-      childState.pendingTargetMerge = chainIsolatedInPred;
     }
 
-    worklist.push_back(Frame{std::move(predExit), std::move(childState)});
+    anyIsolated |= chainIsolated;
+    preds.push_back({predBlock, std::move(exit), chainIsolated});
+  }
+
+  for (auto &pred : preds) {
+    if (state.pendingTargetMerge && anyIsolated && !pred.chainIsolated)
+      continue;
+    worklist.push_back(Frame{std::move(pred.exit), state});
   }
   return false;
 }

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -752,9 +752,10 @@ void IsolationHistoryNoteEmitter::collectIsolationHistoryNotes() {
         break;
 
       case Node::CFGHistoryJoin:
-        // Save the joined branch for later and continue on the parent path.
-        if (auto *joinedNode = node->getFirstArgAsNode())
-          worklist.push_back(joinedNode);
+        // The joined branch now lives in a predecessor block's exit partition
+        // (node->getFirstArgAsBlock()) rather than an inline history node.
+        // Recovering and walking it is deferred; for now we do not follow
+        // joins.
         break;
 
       case Node::AddNewRegionForElement:

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -868,15 +868,47 @@ bool IsolationHistoryNoteEmitter::processFrame(Frame frame) {
 
   // The chain continues into the predecessor blocks joined at this frame.
   // Schedule each, inheriting the walk state as of here.
+  //
+  // A pendingTargetMerge still set here has no location: it came from a region
+  // unification the dataflow join introduced, not a user-written merge (which
+  // would have been followed by its SequenceBoundary in this same frame). If we
+  // carried it into every predecessor it would be pinned to the first boundary
+  // of whichever branch we explore first — e.g. the 'else' arm of a diamond,
+  // which never touched the isolated value. Route it only to the predecessor
+  // that actually made the chain isolated (a tracked element shares an isolated
+  // region at that block's exit); the user-written merge there re-anchors it.
   for (SILBasicBlock *predBlock : joinedBlocks) {
     if (!visitedBlocks.insert(predBlock).second)
       continue;
-    auto predState = inputFunctionInfo->getBlockState(predBlock);
-    if (!predState)
+    auto predBlockState = inputFunctionInfo->getBlockState(predBlock);
+    if (!predBlockState)
       continue;
-    worklist.push_back(Frame{
-        predState.get()->getExitPartition().removingSendingOperandState(),
-        state});
+    Partition predExit =
+        predBlockState.get()->getExitPartition().removingSendingOperandState();
+
+    WalkState childState = state;
+    if (childState.pendingTargetMerge) {
+      bool chainIsolatedInPred = false;
+      for (Element e : state.tracked) {
+        if (!predExit.isTrackingElement(e))
+          continue;
+        Region region = predExit.getRegion(e);
+        for (auto pair : predExit.range()) {
+          if (pair.second != region)
+            continue;
+          auto info = inputValueMap.getIsolationRegion(pair.first);
+          if (info && !info.isDisconnected()) {
+            chainIsolatedInPred = true;
+            break;
+          }
+        }
+        if (chainIsolatedInPred)
+          break;
+      }
+      childState.pendingTargetMerge = chainIsolatedInPred;
+    }
+
+    worklist.push_back(Frame{std::move(predExit), std::move(childState)});
   }
   return false;
 }

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -481,10 +481,11 @@ class IsolationHistoryNoteEmitter {
 public:
   /// Single-use entry point. Constructs an internal emitter from the inputs
   /// and emits any isolation-history notes that apply.
-  static void emit(SILFunction *fn, RegionAnalysisValueMap &valueMap,
-                   Element sentElement, Partition &&partition,
+  static void emit(SILFunction *fn, RegionAnalysisFunctionInfo *functionInfo,
+                   RegionAnalysisValueMap &valueMap, Element sentElement,
+                   Partition &&partition,
                    SILDynamicMergedIsolationInfo regionInfo) {
-    IsolationHistoryNoteEmitter emitter(fn, valueMap, sentElement,
+    IsolationHistoryNoteEmitter emitter(fn, functionInfo, valueMap, sentElement,
                                         std::move(partition), regionInfo);
     emitter.emitHelper();
   }
@@ -512,6 +513,10 @@ private:
   /// The region analysis value map; used to look up element isolation state
   /// and to recover representative SILValues for name inference.
   RegionAnalysisValueMap &inputValueMap;
+
+  /// The region analysis for this function; used to recover a predecessor
+  /// block's exit partition when following a CFG history join.
+  RegionAnalysisFunctionInfo *inputFunctionInfo;
 
   /// The element whose path into the isolated region we are explaining.
   Element inputSentElement;
@@ -542,11 +547,14 @@ private:
   /// \c collectIsolationHistoryNotes.
   Identifier isolatedName;
 
-  IsolationHistoryNoteEmitter(SILFunction *fn, RegionAnalysisValueMap &valueMap,
+  IsolationHistoryNoteEmitter(SILFunction *fn,
+                              RegionAnalysisFunctionInfo *functionInfo,
+                              RegionAnalysisValueMap &valueMap,
                               Element sentElement, Partition &&partition,
                               SILDynamicMergedIsolationInfo regionInfo)
-      : inputFn(fn), inputValueMap(valueMap), inputSentElement(sentElement),
-        inputPartition(std::move(partition)), inputRegionInfo(regionInfo) {}
+      : inputFn(fn), inputValueMap(valueMap), inputFunctionInfo(functionInfo),
+        inputSentElement(sentElement), inputPartition(std::move(partition)),
+        inputRegionInfo(regionInfo) {}
 
   void emitHelper() {
     if (!shouldEmit())
@@ -593,6 +601,7 @@ private:
   }
 
   void collectIsolationHistoryNotes();
+  void collectIsolationHistoryNotesFromPartition(Partition &p);  
 
   /// Returns true when isolation-history emission is on for this function and
   /// the sent element is "disconnected" (i.e., it became isolated by being
@@ -637,14 +646,15 @@ private:
 
 } // namespace
 
-/// Walk the isolation history DAG looking for the merge that brought
-/// \c inputSentElement's region into the isolated region. We follow the chain
-/// of merges transitively: starting with a tracking set containing only
-/// \c inputSentElement, each time we see a MergeElementRegions involving any
-/// tracked element, we examine the other elements involved. If any of them is
-/// itself isolated (per \c inputValueMap), that merge is the answer. Otherwise
-/// the others are also disconnected values that became isolated transitively,
-/// so we add them to the tracking set and keep walking.
+/// Find the merge that brought \c inputSentElement's region into the isolated
+/// region by *rewinding* the send-time partition one history node at a time
+/// (\c Partition::popHistoryOnce), undoing each node's effect as we go.
+/// Starting with a tracking set containing only \c inputSentElement, each
+/// MergeElementRegions we rewind past that involves a tracked element is
+/// examined: if any other element in it is itself isolated (per
+/// \c inputValueMap) that merge is the answer; otherwise the others are
+/// disconnected values that became isolated transitively, so we track them and
+/// keep rewinding.
 ///
 /// On exit, populates the output members:
 ///   - \c originatingLoc: source location of the originating merge, or empty
@@ -655,6 +665,10 @@ private:
 ///   - \c isolatedName: the user-visible name of the isolated source, if one
 ///     could be recovered.
 ///
+/// Names come from the element's equivalence-class representative
+/// (\c maybeGetRepresentative). Using the more specific value stamped on the
+/// merge node is a planned refinement.
+///
 /// If the chain has no intermediate disconnected steps — i.e.,
 /// \c inputSentElement is merged directly with an already-isolated element —
 /// \c originatingLoc is left empty. In that case the user is conceptually
@@ -662,78 +676,103 @@ private:
 /// task-isolated), so a "value was merged … here" note pointing at the same
 /// call site adds no information.
 ///
-/// CFGHistoryJoin nodes introduce branches in the DAG. We push the joined
-/// branch onto a worklist and continue along the parent path; if neither path
-/// finds an answer \c originatingLoc remains empty.
+/// When rewinding reaches a CFGHistoryJoin the chain may continue in a
+/// predecessor block, whose history lives in that block's exit partition. We
+/// push a new frame for each such predecessor carrying the walk state as of the
+/// join, and explore frames depth-first so a dead-end predecessor path simply
+/// backtracks to the next frame.
 void IsolationHistoryNoteEmitter::collectIsolationHistoryNotes() {
   using Node = IsolationHistory::Node;
 
+  // A partition to rewind plus the walk state carried into it. Rewinding cannot
+  // cross a CFG join within a single partition (the joined branch lives in a
+  // predecessor block's exit partition), so at a join we spawn a frame per
+  // predecessor that inherits the state as of the join.
+  struct Frame {
+    Partition partition;
+    llvm::SmallSet<Element, 8> tracked;
+    bool pendingTargetMerge;
+    bool intermediateSeen;
+    Element isolatedElement;
+    bool isolatedFound;
+  };
+
+  // popHistoryOnce requires that we not be tracking sending-operand state, so
+  // clear it on the send-time partition before seeding.
+  Frame seed{inputPartition.removingSendingOperandState(),
+             {},
+             /*pendingTargetMerge=*/false,
+             /*intermediateSeen=*/false,
+             /*isolatedElement=*/inputSentElement,
+             /*isolatedFound=*/false};
+  seed.tracked.insert(inputSentElement);
+
+  SmallVector<Frame, 8> worklist;
+  worklist.push_back(std::move(seed));
+
+  // Blocks whose exit partition we have already scheduled, so a CFG cycle does
+  // not make us rewind the same block forever.
+  llvm::SmallPtrSet<SILBasicBlock *, 8> visitedBlocks;
+
+  // The winning frame's naming state, captured when we record originatingLoc.
   llvm::SmallSet<Element, 8> tracked;
-  tracked.insert(inputSentElement);
-
-  // Work list of nodes to try if the current path finds nothing. Each entry
-  // is the head of an alternative path to explore.
-  SmallVector<const Node *, 4> worklist;
-  worklist.push_back(inputPartition.getIsolationHistory().getHead());
-
-  // Set to true when the most recently seen MergeElementRegions involved an
-  // already-tracked element being merged with something that is itself
-  // isolated. The next SequenceBoundary we encounter holds the source location
-  // for that merge.
-  bool pendingTargetMerge = false;
-
-  // True once we've followed at least one chain link through a disconnected
-  // intermediate. If we find the target merge before this is true the chain
-  // is trivial and we suppress the originating note.
-  bool intermediateSeen = false;
-
-  // The first isolated element we encounter. Used to attribute a name to the
-  // originating note ("y is connected to x …").
   Element isolatedElement = inputSentElement;
   bool isolatedFound = false;
 
   while (!worklist.empty() && !originatingLoc) {
-    const auto *node = worklist.pop_back_val();
+    Frame frame = std::move(worklist.back());
+    worklist.pop_back();
 
-    for (; node; node = node->getNext()) {
+    bool pendingTargetMerge = frame.pendingTargetMerge;
+    bool intermediateSeen = frame.intermediateSeen;
+    Element frameIsolatedElement = frame.isolatedElement;
+    bool frameIsolatedFound = frame.isolatedFound;
+
+    // Predecessor blocks reached at CFG joins while rewinding this frame.
+    SmallVector<SILBasicBlock *, 4> joinedBlocks;
+
+    // True once we rewind past the SequenceBoundary of the merge that reached
+    // the isolated source — the chain has ended (whether or not we emit).
+    bool foundChainEnd = false;
+
+    while (const Node *node = frame.partition.popHistoryOnce(joinedBlocks)) {
       switch (node->getKind()) {
       case Node::MergeElementRegions: {
         Element rep = node->getFirstArgAsElement();
         ArrayRef<Element> others = node->getAdditionalElementArgs();
 
-        // Is any tracked element involved in this merge?
-        bool repIsTracked = tracked.count(rep);
-        bool anyOtherTracked =
-            llvm::any_of(others, [&](Element e) { return tracked.count(e); });
-        if (!repIsTracked && !anyOtherTracked)
+        // Is any element in this merge already tracked?
+        bool anyTracked = frame.tracked.count(rep);
+        for (Element e : others)
+          anyTracked |= bool(frame.tracked.count(e));
+        if (!anyTracked)
           break;
 
-        // Helper: classify a non-tracked element as either the merge target
-        // (isolated) or another disconnected sibling to track. If the element
-        // has no value-map entry (which can legitimately happen when an
-        // element was tracked transiently in history but no longer in the
-        // map), ignore it.
-        auto consider = [&](Element e) {
-          if (tracked.count(e))
-            return;
+        // Classify every not-yet-tracked element in the merge. An isolated
+        // element is the merge target that ends the chain; a disconnected one
+        // is another intermediate we keep following. Elements with no value-map
+        // entry (tracked transiently in history but no longer in the map) are
+        // ignored.
+        SmallVector<Element, 8> involved;
+        involved.push_back(rep);
+        involved.append(others.begin(), others.end());
+        for (Element e : involved) {
+          if (frame.tracked.count(e))
+            continue;
           auto info = inputValueMap.getIsolationRegion(e);
           if (!info)
-            return;
+            continue;
           if (!info.isDisconnected()) {
             pendingTargetMerge = true;
-            if (!isolatedFound) {
-              isolatedFound = true;
-              isolatedElement = e;
+            if (!frameIsolatedFound) {
+              frameIsolatedFound = true;
+              frameIsolatedElement = e;
             }
-          } else {
-            tracked.insert(e);
-            intermediateSeen = true;
+            continue;
           }
-        };
-
-        consider(rep);
-        for (Element e : others)
-          consider(e);
+          frame.tracked.insert(e);
+          intermediateSeen = true;
+        }
         break;
       }
 
@@ -742,9 +781,8 @@ void IsolationHistoryNoteEmitter::collectIsolationHistoryNotes() {
           if (auto loc = node->getHistoryBoundaryLoc()) {
             if (intermediateSeen)
               originatingLoc = loc;
-            // Either way (suppressed or not), we've found the chain end.
-            worklist.clear();
-            node = nullptr;
+            // Either way (emitted or suppressed) we've found the chain end.
+            foundChainEnd = true;
             break;
           }
         }
@@ -752,20 +790,43 @@ void IsolationHistoryNoteEmitter::collectIsolationHistoryNotes() {
         break;
 
       case Node::CFGHistoryJoin:
-        // The joined branch now lives in a predecessor block's exit partition
-        // (node->getFirstArgAsBlock()) rather than an inline history node.
-        // Recovering and walking it is deferred; for now we do not follow
-        // joins.
-        break;
-
       case Node::AddNewRegionForElement:
       case Node::RemoveLastElementFromRegion:
       case Node::RemoveElementFromRegion:
         break;
       }
 
-      if (!node)
+      if (foundChainEnd)
         break;
+    }
+
+    // Finding the chain end ends the whole search — a trivial chain suppresses
+    // the note, a real one has already set originatingLoc.
+    if (foundChainEnd) {
+      if (originatingLoc) {
+        tracked = std::move(frame.tracked);
+        isolatedElement = frameIsolatedElement;
+        isolatedFound = frameIsolatedFound;
+      }
+      break;
+    }
+
+    // The chain continues into the predecessor blocks joined at this frame.
+    // Schedule each, inheriting the walk state as of here.
+    for (SILBasicBlock *predBlock : joinedBlocks) {
+      if (!visitedBlocks.insert(predBlock).second)
+        continue;
+      auto predState = inputFunctionInfo->getBlockState(predBlock);
+      if (!predState)
+        continue;
+      Frame next{
+          predState.get()->getExitPartition().removingSendingOperandState(),
+          frame.tracked,
+          pendingTargetMerge,
+          intermediateSeen,
+          frameIsolatedElement,
+          frameIsolatedFound};
+      worklist.push_back(std::move(next));
     }
   }
 
@@ -774,49 +835,44 @@ void IsolationHistoryNoteEmitter::collectIsolationHistoryNotes() {
 
   // Build the named-step list. For each tracked element other than the sent
   // element, infer a user name + the source location of its declaration.
-  // Sort by source location so chainSteps[0] is closest to the send (newest)
-  // and chainSteps.back() is closest to the isolated source (oldest).
   llvm::SmallDenseSet<const void *, 4> seenLocs;
-
-  auto inferStepFor = [&](Element elt) -> std::optional<ChainStep> {
-    SILValue rep = inputValueMap.maybeGetRepresentative(elt);
-    if (!rep)
-      return {};
-    auto namePair = VariableNameInferrer::inferNameAndFirstPathComponent(rep);
-    if (!namePair)
-      return {};
-    if (!namePair->second.isValid())
-      return {};
-    // VariableNameInferrer falls back to the literal identifier "unknown" when
-    // it can't recover a name. That's never useful in a diagnostic; treat it
-    // as no-name.
-    if (namePair->first.str() == "unknown")
-      return {};
-    return ChainStep{namePair->second, namePair->first, elt};
-  };
 
   // Look up the isolated source's user-visible name, if any. We do this first
   // so we can skip chain steps whose name coincides with it (those are aliases
   // of the isolated source rather than independent links in the chain).
+  //
+  // VariableNameInferrer falls back to the literal identifier "unknown" when it
+  // can't recover a name; that is never useful in a diagnostic, so treat it as
+  // no-name.
   if (isolatedFound) {
-    if (auto step = inferStepFor(isolatedElement))
-      isolatedName = step->name;
+    if (SILValue rep = inputValueMap.maybeGetRepresentative(isolatedElement)) {
+      auto namePair = VariableNameInferrer::inferNameAndFirstPathComponent(rep);
+      if (namePair && namePair->second.isValid() &&
+          namePair->first.str() != "unknown")
+        isolatedName = namePair->first;
+    }
   }
 
   for (Element elt : tracked) {
     if (elt == inputSentElement)
       continue;
-    auto step = inferStepFor(elt);
-    if (!step)
+    SILValue rep = inputValueMap.maybeGetRepresentative(elt);
+    if (!rep)
       continue;
-    // Skip elements whose inferred name matches the isolated source — these
-    // are aliases produced by copies along the chain that the name inferrer
+    auto namePair = VariableNameInferrer::inferNameAndFirstPathComponent(rep);
+    if (!namePair || !namePair->second.isValid() ||
+        namePair->first.str() == "unknown")
+      continue;
+    Identifier name = namePair->first;
+    SourceLoc declLoc = namePair->second;
+    // Skip elements whose inferred name matches the isolated source — these are
+    // aliases produced by copies along the chain that the name inferrer
     // collapses back to the original.
-    if (!isolatedName.empty() && step->name == isolatedName)
+    if (!isolatedName.empty() && name == isolatedName)
       continue;
-    if (!seenLocs.insert(step->declLoc.getOpaquePointerValue()).second)
+    if (!seenLocs.insert(declLoc.getOpaquePointerValue()).second)
       continue;
-    chainSteps.push_back(*step);
+    chainSteps.push_back(ChainStep{declLoc, name, elt});
   }
 
   // Sort newest-first (highest source position first) so that chainSteps[0]
@@ -2635,6 +2691,10 @@ class SentNeverSendableDiagnosticEmitter {
   /// The partition at the point of the error.
   Partition partition;
 
+  /// The region analysis for this function; forwarded to the isolation-history
+  /// note emitter so it can recover predecessor exit partitions across joins.
+  RegionAnalysisFunctionInfo *info;
+
   using SentNeverSendableError = PartitionOpError::SentNeverSendableError;
 
 public:
@@ -2644,7 +2704,8 @@ public:
         diagnosticEmitter(error.op->getSourceOp(),
                           valueMap.getRepresentative(error.sentElement),
                           error.isolationRegionInfo),
-        sentElement(error.sentElement), partition(std::move(error.partition)) {}
+        sentElement(error.sentElement), partition(std::move(error.partition)),
+        info(info) {}
 
   /// Gathers diagnostics. Returns false if we emitted a "I don't understand
   /// error". If we emit such an error, we should bail without emitting any
@@ -2686,8 +2747,9 @@ private:
 
 void SentNeverSendableDiagnosticEmitter::emitIsolationHistoryNoteIfNeeded() {
   IsolationHistoryNoteEmitter::emit(
-      diagnosticEmitter.getOperand()->getFunction(), valueMap, sentElement,
-      std::move(partition), diagnosticEmitter.getIsolationRegionInfo());
+      diagnosticEmitter.getOperand()->getFunction(), info, valueMap,
+      sentElement, std::move(partition),
+      diagnosticEmitter.getIsolationRegionInfo());
 }
 
 bool SentNeverSendableDiagnosticEmitter::initForSendingPartialApply(

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -547,6 +547,37 @@ private:
   /// \c collectIsolationHistoryNotes.
   Identifier isolatedName;
 
+  /// A saved (partition, walk-state) snapshot on the DFS worklist. When a merge
+  /// chain crosses a CFG join the joined branch lives in a predecessor block's
+  /// exit partition, so we push a frame per predecessor carrying the walk state
+  /// as of the join and explore them depth-first, backtracking on dead ends.
+  struct Frame {
+    Partition partition;
+    llvm::SmallSet<Element, 8> tracked;
+    bool pendingTargetMerge;
+    bool intermediateSeen;
+    Element isolatedElement;
+    bool isolatedFound;
+  };
+
+  /// Current walk state, restored from the frame being processed by
+  /// \c processFrame. \c tracked is the set of elements known to be in the sent
+  /// element's chain; the flags and \c isolatedElement describe progress toward
+  /// the isolated source. \c pendingTargetMerge is set when the most recently
+  /// rewound merge reached the isolated source — the next SequenceBoundary
+  /// holds its location. \c intermediateSeen gates suppressing a trivial chain.
+  /// On success these hold the winning frame's state, which names the chain.
+  llvm::SmallSet<Element, 8> tracked;
+  bool pendingTargetMerge = false;
+  bool intermediateSeen = false;
+  Element isolatedElement = Element(0);
+  bool isolatedFound = false;
+
+  /// DFS worklist of frames still to explore, and the set of predecessor blocks
+  /// already scheduled so a CFG cycle cannot rewind the same block forever.
+  SmallVector<Frame, 8> worklist;
+  llvm::SmallPtrSet<SILBasicBlock *, 8> visitedBlocks;
+
   IsolationHistoryNoteEmitter(SILFunction *fn,
                               RegionAnalysisFunctionInfo *functionInfo,
                               RegionAnalysisValueMap &valueMap,
@@ -601,7 +632,13 @@ private:
   }
 
   void collectIsolationHistoryNotes();
-  void collectIsolationHistoryNotesFromPartition(Partition &p);  
+
+  /// Rewind one frame's partition, updating the walk-state members in place.
+  /// Returns true if the chain end was reached — \c originatingLoc is set for a
+  /// real chain and left empty for a suppressed trivial one. Otherwise
+  /// schedules a frame per joined predecessor block onto \c worklist and
+  /// returns false.
+  bool processFrame(Frame frame);
 
   /// Returns true when isolation-history emission is on for this function and
   /// the sent element is "disconnected" (i.e., it became isolated by being
@@ -682,152 +719,23 @@ private:
 /// join, and explore frames depth-first so a dead-end predecessor path simply
 /// backtracks to the next frame.
 void IsolationHistoryNoteEmitter::collectIsolationHistoryNotes() {
-  using Node = IsolationHistory::Node;
+  // Seed the walk state: only the sent element is tracked. popHistoryOnce
+  // requires that we not be tracking sending-operand state, so clear it on the
+  // send-time partition before seeding the first frame with it.
+  tracked.insert(inputSentElement);
+  isolatedElement = inputSentElement;
+  worklist.push_back(Frame{inputPartition.removingSendingOperandState(), tracked,
+                           pendingTargetMerge, intermediateSeen, isolatedElement,
+                           isolatedFound});
 
-  // A partition to rewind plus the walk state carried into it. Rewinding cannot
-  // cross a CFG join within a single partition (the joined branch lives in a
-  // predecessor block's exit partition), so at a join we spawn a frame per
-  // predecessor that inherits the state as of the join.
-  struct Frame {
-    Partition partition;
-    llvm::SmallSet<Element, 8> tracked;
-    bool pendingTargetMerge;
-    bool intermediateSeen;
-    Element isolatedElement;
-    bool isolatedFound;
-  };
-
-  // popHistoryOnce requires that we not be tracking sending-operand state, so
-  // clear it on the send-time partition before seeding.
-  Frame seed{inputPartition.removingSendingOperandState(),
-             {},
-             /*pendingTargetMerge=*/false,
-             /*intermediateSeen=*/false,
-             /*isolatedElement=*/inputSentElement,
-             /*isolatedFound=*/false};
-  seed.tracked.insert(inputSentElement);
-
-  SmallVector<Frame, 8> worklist;
-  worklist.push_back(std::move(seed));
-
-  // Blocks whose exit partition we have already scheduled, so a CFG cycle does
-  // not make us rewind the same block forever.
-  llvm::SmallPtrSet<SILBasicBlock *, 8> visitedBlocks;
-
-  // The winning frame's naming state, captured when we record originatingLoc.
-  llvm::SmallSet<Element, 8> tracked;
-  Element isolatedElement = inputSentElement;
-  bool isolatedFound = false;
-
+  // Explore frames depth-first. processFrame rewinds one frame, updating the
+  // walk-state members, and either records originatingLoc (done) or schedules a
+  // frame per joined predecessor block.
   while (!worklist.empty() && !originatingLoc) {
     Frame frame = std::move(worklist.back());
     worklist.pop_back();
-
-    bool pendingTargetMerge = frame.pendingTargetMerge;
-    bool intermediateSeen = frame.intermediateSeen;
-    Element frameIsolatedElement = frame.isolatedElement;
-    bool frameIsolatedFound = frame.isolatedFound;
-
-    // Predecessor blocks reached at CFG joins while rewinding this frame.
-    SmallVector<SILBasicBlock *, 4> joinedBlocks;
-
-    // True once we rewind past the SequenceBoundary of the merge that reached
-    // the isolated source — the chain has ended (whether or not we emit).
-    bool foundChainEnd = false;
-
-    while (const Node *node = frame.partition.popHistoryOnce(joinedBlocks)) {
-      switch (node->getKind()) {
-      case Node::MergeElementRegions: {
-        Element rep = node->getFirstArgAsElement();
-        ArrayRef<Element> others = node->getAdditionalElementArgs();
-
-        // Is any element in this merge already tracked?
-        bool anyTracked = frame.tracked.count(rep);
-        for (Element e : others)
-          anyTracked |= bool(frame.tracked.count(e));
-        if (!anyTracked)
-          break;
-
-        // Classify every not-yet-tracked element in the merge. An isolated
-        // element is the merge target that ends the chain; a disconnected one
-        // is another intermediate we keep following. Elements with no value-map
-        // entry (tracked transiently in history but no longer in the map) are
-        // ignored.
-        SmallVector<Element, 8> involved;
-        involved.push_back(rep);
-        involved.append(others.begin(), others.end());
-        for (Element e : involved) {
-          if (frame.tracked.count(e))
-            continue;
-          auto info = inputValueMap.getIsolationRegion(e);
-          if (!info)
-            continue;
-          if (!info.isDisconnected()) {
-            pendingTargetMerge = true;
-            if (!frameIsolatedFound) {
-              frameIsolatedFound = true;
-              frameIsolatedElement = e;
-            }
-            continue;
-          }
-          frame.tracked.insert(e);
-          intermediateSeen = true;
-        }
-        break;
-      }
-
-      case Node::SequenceBoundary:
-        if (pendingTargetMerge) {
-          if (auto loc = node->getHistoryBoundaryLoc()) {
-            if (intermediateSeen)
-              originatingLoc = loc;
-            // Either way (emitted or suppressed) we've found the chain end.
-            foundChainEnd = true;
-            break;
-          }
-        }
-        pendingTargetMerge = false;
-        break;
-
-      case Node::CFGHistoryJoin:
-      case Node::AddNewRegionForElement:
-      case Node::RemoveLastElementFromRegion:
-      case Node::RemoveElementFromRegion:
-        break;
-      }
-
-      if (foundChainEnd)
-        break;
-    }
-
-    // Finding the chain end ends the whole search — a trivial chain suppresses
-    // the note, a real one has already set originatingLoc.
-    if (foundChainEnd) {
-      if (originatingLoc) {
-        tracked = std::move(frame.tracked);
-        isolatedElement = frameIsolatedElement;
-        isolatedFound = frameIsolatedFound;
-      }
+    if (processFrame(std::move(frame)))
       break;
-    }
-
-    // The chain continues into the predecessor blocks joined at this frame.
-    // Schedule each, inheriting the walk state as of here.
-    for (SILBasicBlock *predBlock : joinedBlocks) {
-      if (!visitedBlocks.insert(predBlock).second)
-        continue;
-      auto predState = inputFunctionInfo->getBlockState(predBlock);
-      if (!predState)
-        continue;
-      Frame next{
-          predState.get()->getExitPartition().removingSendingOperandState(),
-          frame.tracked,
-          pendingTargetMerge,
-          intermediateSeen,
-          frameIsolatedElement,
-          frameIsolatedFound};
-      worklist.push_back(std::move(next));
-    }
   }
 
   if (!originatingLoc)
@@ -882,6 +790,98 @@ void IsolationHistoryNoteEmitter::collectIsolationHistoryNotes() {
     return rhs.declLoc.getOpaquePointerValue() <
            lhs.declLoc.getOpaquePointerValue();
   });
+}
+
+bool IsolationHistoryNoteEmitter::processFrame(Frame frame) {
+  using Node = IsolationHistory::Node;
+
+  // Restore the walk state captured when this frame was scheduled.
+  Partition partition = std::move(frame.partition);
+  tracked = std::move(frame.tracked);
+  pendingTargetMerge = frame.pendingTargetMerge;
+  intermediateSeen = frame.intermediateSeen;
+  isolatedElement = frame.isolatedElement;
+  isolatedFound = frame.isolatedFound;
+
+  // Predecessor blocks reached at CFG joins while rewinding this frame.
+  SmallVector<SILBasicBlock *, 4> joinedBlocks;
+
+  while (const Node *node = partition.popHistoryOnce(joinedBlocks)) {
+    switch (node->getKind()) {
+    case Node::MergeElementRegions: {
+      Element rep = node->getFirstArgAsElement();
+      ArrayRef<Element> others = node->getAdditionalElementArgs();
+
+      // Is any element in this merge already tracked?
+      bool anyTracked = tracked.count(rep);
+      for (Element e : others)
+        anyTracked |= bool(tracked.count(e));
+      if (!anyTracked)
+        break;
+
+      // Classify every not-yet-tracked element in the merge. An isolated
+      // element is the merge target that ends the chain; a disconnected one is
+      // another intermediate we keep following. Elements with no value-map
+      // entry (tracked transiently in history but no longer in the map) are
+      // ignored.
+      SmallVector<Element, 8> involved;
+      involved.push_back(rep);
+      involved.append(others.begin(), others.end());
+      for (Element e : involved) {
+        if (tracked.count(e))
+          continue;
+        auto info = inputValueMap.getIsolationRegion(e);
+        if (!info)
+          continue;
+        if (!info.isDisconnected()) {
+          pendingTargetMerge = true;
+          if (!isolatedFound) {
+            isolatedFound = true;
+            isolatedElement = e;
+          }
+          continue;
+        }
+        tracked.insert(e);
+        intermediateSeen = true;
+      }
+      break;
+    }
+
+    case Node::SequenceBoundary:
+      if (pendingTargetMerge) {
+        if (auto loc = node->getHistoryBoundaryLoc()) {
+          if (intermediateSeen)
+            originatingLoc = loc;
+          // Either way (emitted or suppressed) we've found the chain end; the
+          // walk-state members now hold the winning frame's naming state.
+          return true;
+        }
+      }
+      pendingTargetMerge = false;
+      break;
+
+    case Node::CFGHistoryJoin:
+    case Node::AddNewRegionForElement:
+    case Node::RemoveLastElementFromRegion:
+    case Node::RemoveElementFromRegion:
+      break;
+    }
+  }
+
+  // The chain continues into the predecessor blocks joined at this frame.
+  // Schedule each, inheriting the walk state as of here.
+  for (SILBasicBlock *predBlock : joinedBlocks) {
+    if (!visitedBlocks.insert(predBlock).second)
+      continue;
+    auto predState = inputFunctionInfo->getBlockState(predBlock);
+    if (!predState)
+      continue;
+    worklist.push_back(
+        Frame{predState.get()->getExitPartition().removingSendingOperandState(),
+              tracked, pendingTargetMerge, intermediateSeen, isolatedElement,
+              isolatedFound});
+  }
+  return false;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -482,10 +482,10 @@ public:
   /// Single-use entry point. Constructs an internal emitter from the inputs
   /// and emits any isolation-history notes that apply.
   static void emit(SILFunction *fn, RegionAnalysisValueMap &valueMap,
-                   Element sentElement, IsolationHistory isolationHistory,
+                   Element sentElement, Partition &&partition,
                    SILDynamicMergedIsolationInfo regionInfo) {
     IsolationHistoryNoteEmitter emitter(fn, valueMap, sentElement,
-                                        isolationHistory, regionInfo);
+                                        std::move(partition), regionInfo);
     emitter.emitHelper();
   }
 
@@ -516,8 +516,8 @@ private:
   /// The element whose path into the isolated region we are explaining.
   Element inputSentElement;
 
-  /// The isolation history DAG to walk.
-  IsolationHistory inputIsolationHistory;
+  /// The input partition to use for our emission.
+  Partition inputPartition;
 
   /// Merged isolation info for the receiving region. Supplies the
   /// task-isolated flag and the descriptive-kind string used in the
@@ -543,11 +543,10 @@ private:
   Identifier isolatedName;
 
   IsolationHistoryNoteEmitter(SILFunction *fn, RegionAnalysisValueMap &valueMap,
-                              Element sentElement,
-                              IsolationHistory isolationHistory,
+                              Element sentElement, Partition &&partition,
                               SILDynamicMergedIsolationInfo regionInfo)
       : inputFn(fn), inputValueMap(valueMap), inputSentElement(sentElement),
-        inputIsolationHistory(isolationHistory), inputRegionInfo(regionInfo) {}
+        inputPartition(std::move(partition)), inputRegionInfo(regionInfo) {}
 
   void emitHelper() {
     if (!shouldEmit())
@@ -675,7 +674,7 @@ void IsolationHistoryNoteEmitter::collectIsolationHistoryNotes() {
   // Work list of nodes to try if the current path finds nothing. Each entry
   // is the head of an alternative path to explore.
   SmallVector<const Node *, 4> worklist;
-  worklist.push_back(inputIsolationHistory.getHead());
+  worklist.push_back(inputPartition.getIsolationHistory().getHead());
 
   // Set to true when the most recently seen MergeElementRegions involved an
   // already-tracked element being merged with something that is itself
@@ -2632,20 +2631,19 @@ class SentNeverSendableDiagnosticEmitter {
   /// region).
   Element sentElement;
 
-  /// The isolation history of the partition at the point of the error.
-  IsolationHistory isolationHistory;
+  /// The partition at the point of the error.
+  Partition partition;
 
   using SentNeverSendableError = PartitionOpError::SentNeverSendableError;
 
 public:
   SentNeverSendableDiagnosticEmitter(RegionAnalysisFunctionInfo *info,
-                                     SentNeverSendableError error)
+                                     SentNeverSendableError &&error)
       : valueMap(info->getValueMap()),
         diagnosticEmitter(error.op->getSourceOp(),
                           valueMap.getRepresentative(error.sentElement),
                           error.isolationRegionInfo),
-        sentElement(error.sentElement),
-        isolationHistory(error.isolationHistory) {}
+        sentElement(error.sentElement), partition(std::move(error.partition)) {}
 
   /// Gathers diagnostics. Returns false if we emitted a "I don't understand
   /// error". If we emit such an error, we should bail without emitting any
@@ -2688,7 +2686,7 @@ private:
 void SentNeverSendableDiagnosticEmitter::emitIsolationHistoryNoteIfNeeded() {
   IsolationHistoryNoteEmitter::emit(
       diagnosticEmitter.getOperand()->getFunction(), valueMap, sentElement,
-      isolationHistory, diagnosticEmitter.getIsolationRegionInfo());
+      std::move(partition), diagnosticEmitter.getIsolationRegionInfo());
 }
 
 bool SentNeverSendableDiagnosticEmitter::initForSendingPartialApply(
@@ -3098,7 +3096,7 @@ public:
   class LastValueEnum;
 
   InOutSendingReturnedDiagnosticEmitter(RegionAnalysisFunctionInfo *raFuncInfo,
-                                        Error error)
+                                        Error &&error)
       : raFuncInfo(raFuncInfo),
         functionExitingInst(cast<TermInst>(error.op->getSourceInst())),
         inoutSendingParam(raFuncInfo->getValueMap().getRepresentative(
@@ -3745,7 +3743,7 @@ private:
 
 public:
   InOutSendingNotDisconnectedAtExitDiagnosticEmitter(
-      RegionAnalysisFunctionInfo *info, Error error)
+      RegionAnalysisFunctionInfo *info, Error &&error)
       : functionExitingInst(cast<TermInst>(error.op->getSourceInst())),
         inoutSendingParam(
             info->getValueMap().getRepresentative(error.inoutSendingElement)),
@@ -3886,7 +3884,7 @@ private:
 
 public:
   AssignNeverSendableIntoSendingResultDiagnosticEmitter(
-      RegionAnalysisFunctionInfo *info, Error error)
+      RegionAnalysisFunctionInfo *info, Error &&error)
       : srcOperand(error.op->getSourceOp()), outSendingResult(error.destValue),
         neverSentValue(error.srcValue),
         isolatedValueIsolationRegionInfo(error.srcIsolationRegionInfo) {}
@@ -4456,7 +4454,7 @@ private:
 
 public:
   UnknownCodePatternDiagnosticEmitter(RegionAnalysisFunctionInfo *info,
-                                      Error error)
+                                      Error &&error)
       : inst(error.op->getSourceInst()) {}
 
   void emit() {
@@ -4491,7 +4489,7 @@ struct IncompatibleRegionMergeDiagnosticEmitter {
   RegionMergeReason reason;
 
   IncompatibleRegionMergeDiagnosticEmitter(RegionAnalysisFunctionInfo *info,
-                                           Error error)
+                                           Error &&error)
       : valueMap(info->getValueMap()), op(error.op->getSourceOp()),
         srcRegionValueElt(error.srcRegionElt),
         srcIsolationInfo(error.srcIsolationRegionInfo),

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -547,31 +547,33 @@ private:
   /// \c collectIsolationHistoryNotes.
   Identifier isolatedName;
 
+  /// The mutable state of the chain walk. \c tracked is the set of elements
+  /// known to be in the sent element's chain; the flags and \c isolatedElement
+  /// describe progress toward the isolated source. \c pendingTargetMerge is set
+  /// when the most recently rewound merge reached the isolated source — the
+  /// next SequenceBoundary holds its location. \c intermediateSeen gates
+  /// suppressing a trivial chain.
+  struct WalkState {
+    llvm::SmallSet<Element, 8> tracked;
+    bool pendingTargetMerge = false;
+    bool intermediateSeen = false;
+    Element isolatedElement = Element(0);
+    bool isolatedFound = false;
+  };
+
   /// A saved (partition, walk-state) snapshot on the DFS worklist. When a merge
   /// chain crosses a CFG join the joined branch lives in a predecessor block's
   /// exit partition, so we push a frame per predecessor carrying the walk state
   /// as of the join and explore them depth-first, backtracking on dead ends.
   struct Frame {
     Partition partition;
-    llvm::SmallSet<Element, 8> tracked;
-    bool pendingTargetMerge;
-    bool intermediateSeen;
-    Element isolatedElement;
-    bool isolatedFound;
+    WalkState state;
   };
 
-  /// Current walk state, restored from the frame being processed by
-  /// \c processFrame. \c tracked is the set of elements known to be in the sent
-  /// element's chain; the flags and \c isolatedElement describe progress toward
-  /// the isolated source. \c pendingTargetMerge is set when the most recently
-  /// rewound merge reached the isolated source — the next SequenceBoundary
-  /// holds its location. \c intermediateSeen gates suppressing a trivial chain.
-  /// On success these hold the winning frame's state, which names the chain.
-  llvm::SmallSet<Element, 8> tracked;
-  bool pendingTargetMerge = false;
-  bool intermediateSeen = false;
-  Element isolatedElement = Element(0);
-  bool isolatedFound = false;
+  /// The current walk state. \c processFrame restores this from the frame it is
+  /// given; on success it holds the winning frame's state, which names the
+  /// chain.
+  WalkState state;
 
   /// DFS worklist of frames still to explore, and the set of predecessor blocks
   /// already scheduled so a CFG cycle cannot rewind the same block forever.
@@ -722,11 +724,10 @@ void IsolationHistoryNoteEmitter::collectIsolationHistoryNotes() {
   // Seed the walk state: only the sent element is tracked. popHistoryOnce
   // requires that we not be tracking sending-operand state, so clear it on the
   // send-time partition before seeding the first frame with it.
-  tracked.insert(inputSentElement);
-  isolatedElement = inputSentElement;
-  worklist.push_back(Frame{inputPartition.removingSendingOperandState(), tracked,
-                           pendingTargetMerge, intermediateSeen, isolatedElement,
-                           isolatedFound});
+  state.tracked.insert(inputSentElement);
+  state.isolatedElement = inputSentElement;
+  worklist.push_back(
+      Frame{inputPartition.removingSendingOperandState(), state});
 
   // Explore frames depth-first. processFrame rewinds one frame, updating the
   // walk-state members, and either records originatingLoc (done) or schedules a
@@ -752,8 +753,9 @@ void IsolationHistoryNoteEmitter::collectIsolationHistoryNotes() {
   // VariableNameInferrer falls back to the literal identifier "unknown" when it
   // can't recover a name; that is never useful in a diagnostic, so treat it as
   // no-name.
-  if (isolatedFound) {
-    if (SILValue rep = inputValueMap.maybeGetRepresentative(isolatedElement)) {
+  if (state.isolatedFound) {
+    if (SILValue rep =
+            inputValueMap.maybeGetRepresentative(state.isolatedElement)) {
       auto namePair = VariableNameInferrer::inferNameAndFirstPathComponent(rep);
       if (namePair && namePair->second.isValid() &&
           namePair->first.str() != "unknown")
@@ -761,7 +763,7 @@ void IsolationHistoryNoteEmitter::collectIsolationHistoryNotes() {
     }
   }
 
-  for (Element elt : tracked) {
+  for (Element elt : state.tracked) {
     if (elt == inputSentElement)
       continue;
     SILValue rep = inputValueMap.maybeGetRepresentative(elt);
@@ -797,11 +799,7 @@ bool IsolationHistoryNoteEmitter::processFrame(Frame frame) {
 
   // Restore the walk state captured when this frame was scheduled.
   Partition partition = std::move(frame.partition);
-  tracked = std::move(frame.tracked);
-  pendingTargetMerge = frame.pendingTargetMerge;
-  intermediateSeen = frame.intermediateSeen;
-  isolatedElement = frame.isolatedElement;
-  isolatedFound = frame.isolatedFound;
+  state = std::move(frame.state);
 
   // Predecessor blocks reached at CFG joins while rewinding this frame.
   SmallVector<SILBasicBlock *, 4> joinedBlocks;
@@ -813,9 +811,9 @@ bool IsolationHistoryNoteEmitter::processFrame(Frame frame) {
       ArrayRef<Element> others = node->getAdditionalElementArgs();
 
       // Is any element in this merge already tracked?
-      bool anyTracked = tracked.count(rep);
+      bool anyTracked = state.tracked.count(rep);
       for (Element e : others)
-        anyTracked |= bool(tracked.count(e));
+        anyTracked |= bool(state.tracked.count(e));
       if (!anyTracked)
         break;
 
@@ -828,36 +826,36 @@ bool IsolationHistoryNoteEmitter::processFrame(Frame frame) {
       involved.push_back(rep);
       involved.append(others.begin(), others.end());
       for (Element e : involved) {
-        if (tracked.count(e))
+        if (state.tracked.count(e))
           continue;
         auto info = inputValueMap.getIsolationRegion(e);
         if (!info)
           continue;
         if (!info.isDisconnected()) {
-          pendingTargetMerge = true;
-          if (!isolatedFound) {
-            isolatedFound = true;
-            isolatedElement = e;
+          state.pendingTargetMerge = true;
+          if (!state.isolatedFound) {
+            state.isolatedFound = true;
+            state.isolatedElement = e;
           }
           continue;
         }
-        tracked.insert(e);
-        intermediateSeen = true;
+        state.tracked.insert(e);
+        state.intermediateSeen = true;
       }
       break;
     }
 
     case Node::SequenceBoundary:
-      if (pendingTargetMerge) {
+      if (state.pendingTargetMerge) {
         if (auto loc = node->getHistoryBoundaryLoc()) {
-          if (intermediateSeen)
+          if (state.intermediateSeen)
             originatingLoc = loc;
           // Either way (emitted or suppressed) we've found the chain end; the
-          // walk-state members now hold the winning frame's naming state.
+          // walk state now holds the winning frame's naming state.
           return true;
         }
       }
-      pendingTargetMerge = false;
+      state.pendingTargetMerge = false;
       break;
 
     case Node::CFGHistoryJoin:
@@ -876,10 +874,9 @@ bool IsolationHistoryNoteEmitter::processFrame(Frame frame) {
     auto predState = inputFunctionInfo->getBlockState(predBlock);
     if (!predState)
       continue;
-    worklist.push_back(
-        Frame{predState.get()->getExitPartition().removingSendingOperandState(),
-              tracked, pendingTargetMerge, intermediateSeen, isolatedElement,
-              isolatedFound});
+    worklist.push_back(Frame{
+        predState.get()->getExitPartition().removingSendingOperandState(),
+        state});
   }
   return false;
 }

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -605,29 +605,6 @@ Partition Partition::join(const Partition &fst, Partition &mutableSnd,
   return result;
 }
 
-bool Partition::popHistory(
-    SmallVectorImpl<SILBasicBlock *> &foundJoinedBlocks) {
-  // We only allow for history rewinding if we are not tracking any
-  // sending operands. This is because the history rewinding does not
-  // care about sending. One can either construct a new Partition from
-  // the current Partition using Partition::removeSendingOperandSet or clear
-  // the sending information using Partition::clearSendingOperandState().
-  assert(regionToSendingOpMap.empty() &&
-         "Can only rewind history if not tracking any sending operands");
-
-  if (!history.getHead())
-    return false;
-
-  // Just put in a continue here to ensure that clang-format doesn't do weird
-  // things with the semicolon.
-  while (popHistoryOnce(foundJoinedBlocks))
-    continue;
-
-  // Return if our history head is non-null so our user knows if there are more
-  // things to pop.
-  return history.getHead();
-}
-
 void Partition::print(llvm::raw_ostream &os,
                       std::function<bool(llvm::raw_ostream &, Region)>
                           printRegionIsolation) const {
@@ -927,18 +904,18 @@ void Partition::horizontalUpdate(
   }
 }
 
-bool Partition::popHistoryOnce(
-    SmallVectorImpl<SILBasicBlock *> &foundJoinedBlocks) {
+const IsolationHistory::Node *
+Partition::popHistoryOnce(SmallVectorImpl<SILBasicBlock *> &foundJoinedBlocks) {
   const auto *head = history.pop();
   if (!head)
-    return false;
+    return nullptr;
 
   // When popping, we /always/ want to canonicalize.
   canonicalize();
 
   switch (head->getKind()) {
   case IsolationHistory::Node::SequenceBoundary:
-    return false;
+    break;
 
   case IsolationHistory::Node::AddNewRegionForElement: {
     // We added an element to its own region... so we should remove it and it
@@ -953,13 +930,13 @@ bool Partition::popHistoryOnce(
                            return pair.second == oldRegion;
                          }) &&
            "Should have been last element?!");
-    return true;
+    break;
   }
   case IsolationHistory::Node::RemoveLastElementFromRegion:
     // We removed an element from a region and it was the last element. Just
     // add new.
     trackNewElement(head->getFirstArgAsElement(), false /*update history*/);
-    return true;
+    break;
   case IsolationHistory::Node::RemoveElementFromRegion:
     // We removed an element from a specific region. So, we need to add it
     // back. pushRemoveElementFromRegion stores the surviving sibling at
@@ -968,7 +945,7 @@ bool Partition::popHistoryOnce(
     assignElement(head->getFirstArgAsElement(),
                   head->getAdditionalElementArgs()[0],
                   false /*update history*/);
-    return true;
+    break;
 
   case IsolationHistory::Node::MergeElementRegions: {
     // We merged two regions together. We need to remove all elements from the
@@ -988,7 +965,7 @@ bool Partition::popHistoryOnce(
       merge(e, elementsToExtract[0], false /*update history*/);
     }
 
-    return true;
+    break;
   }
   case IsolationHistory::Node::CFGHistoryJoin:
     // When we have a CFG history join, we cannot simply pop: the joined branch
@@ -996,8 +973,10 @@ bool Partition::popHistoryOnce(
     // history. Signal the predecessor block to the caller so it can recover
     // that exit partition and keep rewinding.
     foundJoinedBlocks.push_back(head->getFirstArgAsBlock());
-    return true;
+    break;
   }
+
+  return head;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -483,7 +483,8 @@ void Partition::assignElement(Element oldElt, Element newElt,
   canonical = false;
 }
 
-Partition Partition::join(const Partition &fst, Partition &mutableSnd) {
+Partition Partition::join(const Partition &fst, Partition &mutableSnd,
+                          SILBasicBlock *sndBlock) {
   ++NumPartitionJoin;
   // READ THIS! Remember, we cannot touch mutableSnd after this point. We just
   // use it to canonicalize to avoid having to copy snd. After this point,
@@ -496,9 +497,10 @@ Partition Partition::join(const Partition &fst, Partition &mutableSnd) {
   Partition result = fst;
   result.canonicalize();
 
-  // Push a history join so when processing, we know the next element to
-  // process.
-  result.pushCFGHistoryJoin(snd.history);
+  // Push a history join recording the predecessor block whose exit partition
+  // (snd) we are merging in, so the join can later be rewound by recovering
+  // that block's exit partition.
+  result.pushCFGHistoryJoin(sndBlock);
 
   // For each (sndEltNumber, sndRegionNumber) in snd_reduced...
   for (auto pair : snd.elementToRegionMap) {
@@ -604,7 +606,7 @@ Partition Partition::join(const Partition &fst, Partition &mutableSnd) {
 }
 
 bool Partition::popHistory(
-    SmallVectorImpl<IsolationHistory> &foundJoinedHistories) {
+    SmallVectorImpl<SILBasicBlock *> &foundJoinedBlocks) {
   // We only allow for history rewinding if we are not tracking any
   // sending operands. This is because the history rewinding does not
   // care about sending. One can either construct a new Partition from
@@ -618,7 +620,7 @@ bool Partition::popHistory(
 
   // Just put in a continue here to ensure that clang-format doesn't do weird
   // things with the semicolon.
-  while (popHistoryOnce(foundJoinedHistories))
+  while (popHistoryOnce(foundJoinedBlocks))
     continue;
 
   // Return if our history head is non-null so our user knows if there are more
@@ -926,7 +928,7 @@ void Partition::horizontalUpdate(
 }
 
 bool Partition::popHistoryOnce(
-    SmallVectorImpl<IsolationHistory> &foundJoinedHistoryNodes) {
+    SmallVectorImpl<SILBasicBlock *> &foundJoinedBlocks) {
   const auto *head = history.pop();
   if (!head)
     return false;
@@ -989,12 +991,11 @@ bool Partition::popHistoryOnce(
     return true;
   }
   case IsolationHistory::Node::CFGHistoryJoin:
-    // When we have a CFG History Merge, we cannot simply pop. Instead, we need
-    // to signal to the user that they need to visit each history node in turn
-    // by returning it in the out parameter.
-    auto newHistory = IsolationHistory(history.factory);
-    newHistory.head = head->getFirstArgAsNode();
-    foundJoinedHistoryNodes.push_back(newHistory);
+    // When we have a CFG history join, we cannot simply pop: the joined branch
+    // lives in a predecessor block's exit partition, not in this linear
+    // history. Signal the predecessor block to the caller so it can recover
+    // that exit partition and keep rewinding.
+    foundJoinedBlocks.push_back(head->getFirstArgAsBlock());
     return true;
   }
 }
@@ -1050,24 +1051,18 @@ void IsolationHistory::pushMergeElementRegions(Element elementInNewRegion,
                         elementInOldRegion, eltsToMerge);
 }
 
-// Push that \p other should be merged into this region.
-void IsolationHistory::pushCFGHistoryJoin(Node *otherNode) {
-  // If otherNode is nullptr or represents our same history, do not merge.
-  if (!otherNode || otherNode == head)
+// Record that \p predBlock's exit partition was merged into this history at a
+// control-flow merge point. The joined history is not copied in; it is
+// recovered on demand as predBlock's exit-partition isolation history.
+void IsolationHistory::pushCFGHistoryJoin(SILBasicBlock *predBlock) {
+  // Without a predecessor block there is nothing to recover the joined history
+  // from later, so there is nothing to record.
+  if (!predBlock)
     return;
 
-  // If we do not have any history, just take on the history of otherNode. We
-  // are going to merge our contents.
-  if (!head) {
-    head = otherNode;
-    return;
-  }
-
-  // Otherwise, create a node that joins our true head and other node as a side
-  // path we can follow.
   unsigned size = Node::totalSizeToAlloc<Element>(0);
   void *mem = factory->allocator.Allocate(size, alignof(Node));
-  head = new (mem) Node(Node(Node::CFGHistoryJoin, head, otherNode));
+  head = new (mem) Node(Node::CFGHistoryJoin, head, predBlock);
 }
 
 IsolationHistory::Node *IsolationHistory::pop() {
@@ -1125,10 +1120,15 @@ void IsolationHistory::Node::print(ASTContext &ctx, llvm::raw_ostream &os,
        << prefix << "Element To Merge: " << getAdditionalElementArgs()[0]
        << '\n';
     break;
-  case CFGHistoryJoin:
-    os << "CFGHistoryJoin\n"
-       << prefix << "Other Node: " << getFirstArgAsNode() << '\n';
+  case CFGHistoryJoin: {
+    auto *predBlock = getFirstArgAsBlock();
+    os << "CFGHistoryJoin\n" << prefix << "Pred Block: ";
+    if (predBlock)
+      os << "bb" << predBlock->getDebugID() << '\n';
+    else
+      os << "<none>\n";
     break;
+  }
   case SequenceBoundary:
     os << "SequenceBoundary\n" << prefix << "Value: ";
     getHistoryBoundaryLoc()->print(os);

--- a/test/Concurrency/transfernonsendable_isolationhistory.sil
+++ b/test/Concurrency/transfernonsendable_isolationhistory.sil
@@ -235,14 +235,14 @@ bb0(%x : @guaranteed $NonSendableKlass, %cond : $Builtin.Int1):
 
   %mk = function_ref @makeFresh : $@convention(thin) () -> @owned NonSendableKlass
   %r0 = apply %mk() : $@convention(thin) () -> @owned NonSendableKlass
-  %y = move_value [lexical] [var_decl] %r0 : $NonSendableKlass // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+  %y = move_value [lexical] [var_decl] %r0 : $NonSendableKlass
   debug_value %y : $NonSendableKlass, let, name "y"
   cond_br %cond, bb_merge, bb_no_merge
 
 bb_merge:
   %yb = begin_borrow %y : $NonSendableKlass
   %f2 = function_ref @mergeTwo : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> @owned NonSendableKlass
-  %rm = apply %f2(%x, %yb) : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> @owned NonSendableKlass
+  %rm = apply %f2(%x, %yb) : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> @owned NonSendableKlass // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
   end_borrow %yb : $NonSendableKlass
   destroy_value %rm : $NonSendableKlass
   br bb_join

--- a/test/Concurrency/transfernonsendable_isolationhistory.swift
+++ b/test/Concurrency/transfernonsendable_isolationhistory.swift
@@ -287,9 +287,9 @@ func diamond_let_both_isolated(_ x: NS, _ flag: Bool) async {
 ////////////////////////////////////////////////////////////////////////////////
 
 func loop_assign(_ x: NS, _ count: Int) async {
-  var y = NS() // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+  var y = NS()
   for _ in 0..<count {
-    y = x
+    y = x // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
   }
   await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
   // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
@@ -425,13 +425,15 @@ func unknown_legit_name(_ x: NS) async {
 ////////////////////////////////////////////////////////////////////////////////
 
 func loop_with_inner_diamond(_ x: NS, _ count: Int, _ flag: Bool) async {
-  // expected-note@+1{{'y' is connected to 'x' which is accessible to code in the current isolation context}}
   var y = NS()
   for _ in 0..<count {
     if flag {
       y = x
     } else {
-      y = NS()
+      // FIXME: The chain note is anchored on this 'else' reassignment rather
+      // than the 'y = x' merge above — the rewind's first-explored predecessor
+      // at the diamond join is this branch. The note text is still correct.
+      y = NS() // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
     }
   }
   await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}

--- a/test/Concurrency/transfernonsendable_isolationhistory.swift
+++ b/test/Concurrency/transfernonsendable_isolationhistory.swift
@@ -1079,3 +1079,47 @@ func break_in_loop_chain(_ x: NS, _ n: Int) async {
   }
   await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// KNOWN-BAD DIAGNOSTICS (characterization). These pin current behavior where the
+// chain walker loses information: an internal/runtime name leaks into the chain,
+// a projection collapses to its base, the note names something other than the
+// value actually sent, or we fall back to a nameless generic note. They should
+// be *fixed* later; each FIXME says what the note ought to say.
+////////////////////////////////////////////////////////////////////////////////
+
+// FIXME: The sent value is 'box.ns', but the chain note names the container
+// 'box'. It should say 'box.ns' (or at least agree with the sending note).
+func send_projection_of_isolated(_ x: NS) async {
+  var box = Box1(NS())
+  box.ns = x // expected-note {{'box' is connected to 'x' which is accessible to code in the current isolation context}}
+  await transferToMain(box.ns) // expected-warning {{sending 'box.ns' risks causing data races}} expected-note {{sending 'box.ns' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+// FIXME: The write is 'box.b.b.ns = x', but the note collapses the whole access
+// path to the base 'box'. It loses which field flowed the isolated value in.
+func deep_projection_store(_ x: NS) async {
+  var box = Box3(Box2(Box1(NS())))
+  box.b.b.ns = x // expected-note {{'box' is connected to 'x' which is accessible to code in the current isolation context}}
+  await transferToMain(box) // expected-warning {{sending 'box' risks causing data races}} expected-note {{sending 'box' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+// FIXME: 'y' is a copy of the actor's stored property, yet we emit only the
+// nameless generic "value was merged … here" note. It should name the chain,
+// e.g. "'y' is connected to 'slot'".
+actor SlotActor {
+  var slot = NS()
+  func probe() async {
+    let y = slot // expected-note {{value was merged into 'self'-isolated code region here}}
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}} expected-note {{sending 'self'-isolated 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
+  }
+}
+
+// FIXME: The array-literal lowering leaks the compiler-internal
+// '_allocateUninitializedArray' as a chain step. An internal runtime name
+// should never appear in a user-facing note.
+func array_append_leak(_ x: NS) async {
+  var arr = [NS()] // expected-note {{'_allocateUninitializedArray' is connected to 'arr'}}
+  arr.append(x) // expected-note {{'arr' is connected to 'x' which is accessible to code in the current isolation context}}
+  await transferToMain(arr) // expected-warning {{sending 'arr' risks causing data races}} expected-note {{sending 'arr' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}

--- a/test/Concurrency/transfernonsendable_isolationhistory.swift
+++ b/test/Concurrency/transfernonsendable_isolationhistory.swift
@@ -428,14 +428,9 @@ func loop_with_inner_diamond(_ x: NS, _ count: Int, _ flag: Bool) async {
   var y = NS()
   for _ in 0..<count {
     if flag {
-      y = x
+      y = x // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
     } else {
-      // FIXME: The chain note is anchored on this 'else' reassignment rather
-      // than the 'y = x' merge above. The join-merge routing that anchors the
-      // acyclic diamonds correctly cannot disambiguate here: the loop fixpoint
-      // leaves y isolated at *both* branch exits, so both predecessors look
-      // equally responsible. The note text is still correct.
-      y = NS() // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+      y = NS()
     }
   }
   await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}

--- a/test/Concurrency/transfernonsendable_isolationhistory.swift
+++ b/test/Concurrency/transfernonsendable_isolationhistory.swift
@@ -966,7 +966,8 @@ func switch_one_isolated(_ x: NS, _ n: Int) async {
   default:
     break
   }
-  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
+// expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
 
 func switch_two_isolated(_ x: NS, _ n: Int) async {
@@ -979,7 +980,8 @@ func switch_two_isolated(_ x: NS, _ n: Int) async {
   default:
     y = NS()
   }
-  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
+// expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
 
 func nested_diamond(_ x: NS, _ a: Bool, _ b: Bool) async {
@@ -993,12 +995,14 @@ func nested_diamond(_ x: NS, _ a: Bool, _ b: Bool) async {
   } else {
     y = NS()
   }
-  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
+// expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
 
 func ternary_chain(_ x: NS, _ flag: Bool) async {
   let y = flag ? x : NS() // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
-  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
+// expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
 
 func while_loop_chain(_ x: NS, _ flag: Bool) async {
@@ -1010,7 +1014,8 @@ func while_loop_chain(_ x: NS, _ flag: Bool) async {
     }
     i += 1
   }
-  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
+// expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
 
 func repeat_while_chain(_ x: NS, _ flag: Bool) async {
@@ -1022,7 +1027,8 @@ func repeat_while_chain(_ x: NS, _ flag: Bool) async {
     }
     i += 1
   } while i < 10
-  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
+// expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
 
 func nested_loop_chain(_ x: NS, _ n: Int) async {
@@ -1032,7 +1038,8 @@ func nested_loop_chain(_ x: NS, _ n: Int) async {
       y = x // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
     }
   }
-  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
+// expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
 
 // Two distinct isolated sources, both branches isolate y. Neither branch resets
@@ -1045,7 +1052,8 @@ func two_isolated_sources(_ a: NS, _ b: NS, _ flag: Bool) async {
   } else {
     y = b // expected-note {{'y' is connected to 'a' which is accessible to code in the current isolation context}}
   }
-  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
+// expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
 
 func sequential_diamonds(_ x: NS, _ f1: Bool, _ f2: Bool) async {
@@ -1058,17 +1066,20 @@ func sequential_diamonds(_ x: NS, _ f1: Bool, _ f2: Bool) async {
   if f2 {
     _ = y
   }
-  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
+// expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
 
 func do_catch_chain(_ x: NS) async throws {
   var y = NS()
   do {
-    y = try makeOrThrow(x) // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}} expected-note {{'makeOrThrow' is connected to 'y'}}
+    y = try makeOrThrow(x) // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+// expected-note @-1 {{'makeOrThrow' is connected to 'y'}}
   } catch {
     y = NS()
   }
-  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
+  // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
 
 func break_in_loop_chain(_ x: NS, _ n: Int) async {
@@ -1077,7 +1088,8 @@ func break_in_loop_chain(_ x: NS, _ n: Int) async {
     y = x // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
     break
   }
-  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
+  // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1093,7 +1105,8 @@ func break_in_loop_chain(_ x: NS, _ n: Int) async {
 func send_projection_of_isolated(_ x: NS) async {
   var box = Box1(NS())
   box.ns = x // expected-note {{'box' is connected to 'x' which is accessible to code in the current isolation context}}
-  await transferToMain(box.ns) // expected-warning {{sending 'box.ns' risks causing data races}} expected-note {{sending 'box.ns' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+  await transferToMain(box.ns) // expected-warning {{sending 'box.ns' risks causing data races}}
+// expected-note @-1 {{sending 'box.ns' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
 
 // FIXME: The write is 'box.b.b.ns = x', but the note collapses the whole access
@@ -1101,7 +1114,8 @@ func send_projection_of_isolated(_ x: NS) async {
 func deep_projection_store(_ x: NS) async {
   var box = Box3(Box2(Box1(NS())))
   box.b.b.ns = x // expected-note {{'box' is connected to 'x' which is accessible to code in the current isolation context}}
-  await transferToMain(box) // expected-warning {{sending 'box' risks causing data races}} expected-note {{sending 'box' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+  await transferToMain(box) // expected-warning {{sending 'box' risks causing data races}}
+// expected-note @-1 {{sending 'box' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
 
 // FIXME: 'y' is a copy of the actor's stored property, yet we emit only the
@@ -1111,7 +1125,8 @@ actor SlotActor {
   var slot = NS()
   func probe() async {
     let y = slot // expected-note {{value was merged into 'self'-isolated code region here}}
-    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}} expected-note {{sending 'self'-isolated 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
+// expected-note @-1 {{sending 'self'-isolated 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
   }
 }
 
@@ -1121,5 +1136,6 @@ actor SlotActor {
 func array_append_leak(_ x: NS) async {
   var arr = [NS()] // expected-note {{'_allocateUninitializedArray' is connected to 'arr'}}
   arr.append(x) // expected-note {{'arr' is connected to 'x' which is accessible to code in the current isolation context}}
-  await transferToMain(arr) // expected-warning {{sending 'arr' risks causing data races}} expected-note {{sending 'arr' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+  await transferToMain(arr) // expected-warning {{sending 'arr' risks causing data races}}
+  // expected-note @-1 {{sending 'arr' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }

--- a/test/Concurrency/transfernonsendable_isolationhistory.swift
+++ b/test/Concurrency/transfernonsendable_isolationhistory.swift
@@ -179,9 +179,9 @@ func var_reassign_chain(_ x: NS, _ flag: Bool) async {
 ////////////////////////////////////////////////////////////////////////////////
 
 func diamond_then_branch_only(_ x: NS, _ flag: Bool) async {
-  var y = NS() // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+  var y = NS()
   if flag {
-    y = x
+    y = x // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
   } else {
     // No merge here — y stays disconnected along this path.
   }
@@ -233,9 +233,9 @@ func diamond_mixed_then_isolated(_ x: NS, _ flag: Bool) async {
 func diamond_mixed_else_isolated(_ x: NS, _ flag: Bool) async {
   var y = NS()
   if flag {
-    y = x
+    y = x // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
   } else {
-    y = NS() // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+    y = NS()
   }
   await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
   // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
@@ -251,9 +251,9 @@ func diamond_mixed_else_isolated(_ x: NS, _ flag: Bool) async {
 func diamond_let_then_isolated(_ x: NS, _ flag: Bool) async {
   let y: NS
   if flag {
-    y = x
+    y = x // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
   } else {
-    y = NS() // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+    y = NS()
   }
   await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
   // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
@@ -431,8 +431,10 @@ func loop_with_inner_diamond(_ x: NS, _ count: Int, _ flag: Bool) async {
       y = x
     } else {
       // FIXME: The chain note is anchored on this 'else' reassignment rather
-      // than the 'y = x' merge above — the rewind's first-explored predecessor
-      // at the diamond join is this branch. The note text is still correct.
+      // than the 'y = x' merge above. The join-merge routing that anchors the
+      // acyclic diamonds correctly cannot disambiguate here: the loop fixpoint
+      // leaves y isolated at *both* branch exits, so both predecessors look
+      // equally responsible. The note text is still correct.
       y = NS() // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
     }
   }

--- a/test/Concurrency/transfernonsendable_isolationhistory.swift
+++ b/test/Concurrency/transfernonsendable_isolationhistory.swift
@@ -950,3 +950,132 @@ func per_arg_loc_coroutine(_ x: NS) async {
   await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
   // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// Additional control-flow coverage: switches, nested/ternary diamonds, while/
+// repeat/nested loops, guard, do/catch, break, and multiple isolated sources.
+////////////////////////////////////////////////////////////////////////////////
+
+func switch_one_isolated(_ x: NS, _ n: Int) async {
+  var y = NS()
+  switch n {
+  case 0:
+    y = x // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+  case 1:
+    y = NS()
+  default:
+    break
+  }
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func switch_two_isolated(_ x: NS, _ n: Int) async {
+  var y = NS()
+  switch n {
+  case 0:
+    y = x
+  case 1:
+    y = x // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+  default:
+    y = NS()
+  }
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func nested_diamond(_ x: NS, _ a: Bool, _ b: Bool) async {
+  var y = NS()
+  if a {
+    if b {
+      y = x // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+    } else {
+      y = NS()
+    }
+  } else {
+    y = NS()
+  }
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func ternary_chain(_ x: NS, _ flag: Bool) async {
+  let y = flag ? x : NS() // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func while_loop_chain(_ x: NS, _ flag: Bool) async {
+  var y = NS()
+  var i = 0
+  while i < 10 {
+    if flag {
+      y = x // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+    }
+    i += 1
+  }
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func repeat_while_chain(_ x: NS, _ flag: Bool) async {
+  var y = NS()
+  var i = 0
+  repeat {
+    if flag {
+      y = x // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+    }
+    i += 1
+  } while i < 10
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func nested_loop_chain(_ x: NS, _ n: Int) async {
+  var y = NS()
+  for _ in 0..<n {
+    for _ in 0..<n {
+      y = x // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+    }
+  }
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+// Two distinct isolated sources, both branches isolate y. Neither branch resets
+// the isolation, so the discriminating-element rule cannot prefer one; the walk
+// falls back to first-explored (names 'a', anchored on the else arm).
+func two_isolated_sources(_ a: NS, _ b: NS, _ flag: Bool) async {
+  var y = NS()
+  if flag {
+    y = a
+  } else {
+    y = b // expected-note {{'y' is connected to 'a' which is accessible to code in the current isolation context}}
+  }
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func sequential_diamonds(_ x: NS, _ f1: Bool, _ f2: Bool) async {
+  var y = NS()
+  if f1 {
+    y = x // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+  } else {
+    y = NS()
+  }
+  if f2 {
+    _ = y
+  }
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func do_catch_chain(_ x: NS) async throws {
+  var y = NS()
+  do {
+    y = try makeOrThrow(x) // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}} expected-note {{'makeOrThrow' is connected to 'y'}}
+  } catch {
+    y = NS()
+  }
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func break_in_loop_chain(_ x: NS, _ n: Int) async {
+  var y = NS()
+  for _ in 0..<n {
+    y = x // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+    break
+  }
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}

--- a/unittests/SILOptimizer/IsolationHistory.cpp
+++ b/unittests/SILOptimizer/IsolationHistory.cpp
@@ -153,88 +153,6 @@ TEST(IsolationHistory, PushMergeElementRegionsPrimitive) {
   EXPECT_EQ(args[1], Element(5));
 }
 
-// CFGHistoryJoin is suppressed when joining the same head — pushCFGHistoryJoin
-// early-returns rather than recording a self-edge that would pollute the
-// walker's worklist.
-TEST(IsolationHistory, CFGHistoryJoinSelfSuppressed) {
-  llvm::BumpPtrAllocator allocator;
-  IsolationHistory::Factory historyFactory(allocator);
-
-  IsolationHistory history = historyFactory.get();
-  history.pushHistorySequenceBoundary(SILLocation::invalid());
-  auto *headBefore = history.getHead();
-
-  // Joining ourselves at our current head should be a no-op.
-  history.pushCFGHistoryJoin(headBefore);
-
-  EXPECT_EQ(history.getHead(), headBefore);
-}
-
-// pushCFGHistoryJoin(nullptr) is the other early-return path. The walker
-// occasionally hands us a null head when the predecessor never recorded
-// anything — must not allocate or rewrite head.
-TEST(IsolationHistory, CFGHistoryJoinNullSuppressed) {
-  llvm::BumpPtrAllocator allocator;
-  IsolationHistory::Factory historyFactory(allocator);
-
-  IsolationHistory history = historyFactory.get();
-  history.pushHistorySequenceBoundary(SILLocation::invalid());
-  auto *headBefore = history.getHead();
-
-  history.pushCFGHistoryJoin(static_cast<IsolationHistory::Node *>(nullptr));
-
-  EXPECT_EQ(history.getHead(), headBefore);
-}
-
-// pushCFGHistoryJoin from an empty-headed history adopts otherNode directly
-// rather than synthesizing a CFGHistoryJoin wrapper. This is the
-// "predecessor's history wins" shortcut that drives
-// TestHistory_JoiningEmptyAndNotEmpty's historySize == 2 expectation.
-TEST(IsolationHistory, CFGHistoryJoinFromEmptyAdoptsOther) {
-  llvm::BumpPtrAllocator allocator;
-  IsolationHistory::Factory historyFactory(allocator);
-
-  // Build a non-empty otherNode chain.
-  IsolationHistory other = historyFactory.get();
-  other.pushHistorySequenceBoundary(SILLocation::invalid());
-  other.pushNewElementRegion(Element(3));
-  auto *otherHead = other.getHead();
-
-  IsolationHistory empty = historyFactory.get();
-  EXPECT_EQ(empty.getHead(), nullptr);
-
-  empty.pushCFGHistoryJoin(otherHead);
-
-  EXPECT_EQ(empty.getHead(), otherHead)
-      << "Empty history should adopt otherNode rather than wrap it.";
-}
-
-// When both histories are non-empty and have distinct heads, pushCFGHistoryJoin
-// allocates a fresh CFGHistoryJoin node whose firstArgAsNode is otherNode and
-// whose parent is the previous head. This is the only path that records a
-// genuine CFG merge for the SendNonSendable walker to recurse into.
-TEST(IsolationHistory, CFGHistoryJoinDistinctNonEmptyCreatesNode) {
-  llvm::BumpPtrAllocator allocator;
-  IsolationHistory::Factory historyFactory(allocator);
-
-  IsolationHistory other = historyFactory.get();
-  other.pushHistorySequenceBoundary(SILLocation::invalid());
-  auto *otherHead = other.getHead();
-
-  IsolationHistory main = historyFactory.get();
-  main.pushHistorySequenceBoundary(SILLocation::invalid());
-  auto *mainHeadBefore = main.getHead();
-
-  main.pushCFGHistoryJoin(otherHead);
-
-  auto *newHead = main.getHead();
-  ASSERT_NE(newHead, nullptr);
-  EXPECT_NE(newHead, mainHeadBefore);
-  EXPECT_EQ(newHead->getKind(), IsolationHistory::Node::CFGHistoryJoin);
-  EXPECT_EQ(newHead->getFirstArgAsNode(), otherHead);
-  EXPECT_EQ(newHead->getNext(), mainHeadBefore);
-}
-
 //===----------------------------------------------------------------------===//
 //                       MARK: Higher Level Operations
 //===----------------------------------------------------------------------===//
@@ -342,7 +260,7 @@ TEST(IsolationHistory, SingleRegionRoundTrip) {
 
   // Drain history. popHistory returns true while there's more to pop;
   // joins is unused since singleRegion never records a CFGHistoryJoin.
-  llvm::SmallVector<IsolationHistory, 4> joins;
+  llvm::SmallVector<SILBasicBlock *, 4> joins;
   while (p.popHistory(joins))
     continue;
 
@@ -516,7 +434,7 @@ TEST(IsolationHistory, SeparateRegionsRoundTrip) {
   auto p = makePartitionWithSeparateRegions(
       loc, {Element(0), Element(1), Element(2)}, historyFactory.get());
 
-  llvm::SmallVector<IsolationHistory, 4> joins;
+  llvm::SmallVector<SILBasicBlock *, 4> joins;
   while (p.popHistory(joins))
     continue;
 
@@ -586,7 +504,7 @@ TEST(IsolationHistory, JoinSecondBranchPushPopAsymmetry) {
 
   // Drain the joined partition's history. After full unwind, no element
   // should be tracked — both fst and snd's contributions should reverse.
-  llvm::SmallVector<IsolationHistory, 4> joins;
+  llvm::SmallVector<SILBasicBlock *, 4> joins;
   while (joined.popHistory(joins))
     continue;
 
@@ -609,7 +527,7 @@ TEST(IsolationHistory, CreateVariable) {
   llvm::BumpPtrAllocator allocator;
   Partition::SendingOperandSetFactory factory(allocator);
   IsolationHistory::Factory historyFactory(allocator);
-  SmallVector<IsolationHistory, 8> joinedHistories;
+  SmallVector<SILBasicBlock *, 8> joinedHistories;
   SendingOperandToStateMap transferringOpToStateMap(historyFactory);
 
   // First make sure that we do this correctly with an assign fresh.
@@ -638,7 +556,7 @@ TEST(IsolationHistory, AssignRegion) {
   Partition::SendingOperandSetFactory factory(allocator);
   IsolationHistory::Factory historyFactory(allocator);
   SendingOperandToStateMap transferringOpToStateMap(historyFactory);
-  SmallVector<IsolationHistory, 8> joinedHistories;
+  SmallVector<SILBasicBlock *, 8> joinedHistories;
 
   // First make sure that we do this correctly with an assign fresh.
   Partition p(historyFactory.get());
@@ -678,7 +596,7 @@ TEST(IsolationHistory, BuildNewRegionRepIsMerge) {
   Partition::SendingOperandSetFactory factory(allocator);
   IsolationHistory::Factory historyFactory(allocator);
   SendingOperandToStateMap transferringOpToStateMap(historyFactory);
-  SmallVector<IsolationHistory, 8> joinedHistories;
+  SmallVector<SILBasicBlock *, 8> joinedHistories;
 
   Partition p(historyFactory.get());
   {
@@ -726,7 +644,7 @@ TEST(IsolationHistory, ReturnFalseWhenNoneLeft) {
   llvm::BumpPtrAllocator allocator;
   Partition::SendingOperandSetFactory factory(allocator);
   IsolationHistory::Factory historyFactory(allocator);
-  SmallVector<IsolationHistory, 8> joinedHistories;
+  SmallVector<SILBasicBlock *, 8> joinedHistories;
   SendingOperandToStateMap transferringOpToStateMap(historyFactory);
 
   Partition p(historyFactory.get());
@@ -752,7 +670,7 @@ TEST(IsolationHistory, JoiningTwoEmpty) {
   llvm::BumpPtrAllocator allocator;
   Partition::SendingOperandSetFactory factory(allocator);
   IsolationHistory::Factory historyFactory(allocator);
-  SmallVector<IsolationHistory, 8> joinedHistories;
+  SmallVector<SILBasicBlock *, 8> joinedHistories;
 
   Partition p1(historyFactory.get());
   Partition p2(historyFactory.get());
@@ -768,7 +686,7 @@ TEST(IsolationHistory, JoiningNotEmptyAndEmpty) {
   llvm::BumpPtrAllocator allocator;
   Partition::SendingOperandSetFactory factory(allocator);
   IsolationHistory::Factory historyFactory(allocator);
-  SmallVector<IsolationHistory, 8> joinedHistories;
+  SmallVector<SILBasicBlock *, 8> joinedHistories;
   SendingOperandToStateMap transferringOpToStateMap(historyFactory);
 
   Partition p1(historyFactory.get());
@@ -795,7 +713,7 @@ TEST(IsolationHistory, JoiningEmptyAndNotEmpty) {
   Partition::SendingOperandSetFactory factory(allocator);
   IsolationHistory::Factory historyFactory(allocator);
   SendingOperandToStateMap transferringOpToStateMap(historyFactory);
-  SmallVector<IsolationHistory, 8> joinedHistories;
+  SmallVector<SILBasicBlock *, 8> joinedHistories;
 
   Partition p1(historyFactory.get());
   Partition p2(historyFactory.get());
@@ -828,7 +746,7 @@ TEST(IsolationHistory, AssignDirectMovesElementRoundTrip) {
   Partition::SendingOperandSetFactory factory(allocator);
   IsolationHistory::Factory historyFactory(allocator);
   SendingOperandToStateMap opToStateMap(historyFactory);
-  SmallVector<IsolationHistory, 8> joins;
+  SmallVector<SILBasicBlock *, 8> joins;
 
   // Set up two separate regions: {0, 1} and {2}. Element 1 lives in 0's
   // region.

--- a/unittests/SILOptimizer/IsolationHistory.cpp
+++ b/unittests/SILOptimizer/IsolationHistory.cpp
@@ -93,6 +93,18 @@ bool everyMergeHasAncestorBoundary(IsolationHistory history) {
   return true;
 }
 
+/// Pop one PartitionOp worth of history (nodes up to and including the next
+/// SequenceBoundary), undoing each. Returns true if more history remains.
+/// Mirrors the drain the removed Partition::popHistory used to provide, built
+/// on the node-returning popHistoryOnce.
+bool popOnePartitionOp(Partition &p, SmallVectorImpl<SILBasicBlock *> &blocks) {
+  while (auto *node = p.popHistoryOnce(blocks)) {
+    if (node->getKind() == IsolationHistory::Node::SequenceBoundary)
+      break;
+  }
+  return p.hasHistory();
+}
+
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -261,7 +273,7 @@ TEST(IsolationHistory, SingleRegionRoundTrip) {
   // Drain history. popHistory returns true while there's more to pop;
   // joins is unused since singleRegion never records a CFGHistoryJoin.
   llvm::SmallVector<SILBasicBlock *, 4> joins;
-  while (p.popHistory(joins))
+  while (popOnePartitionOp(p, joins))
     continue;
 
   EXPECT_FALSE(p.hasHistory());
@@ -435,7 +447,7 @@ TEST(IsolationHistory, SeparateRegionsRoundTrip) {
       loc, {Element(0), Element(1), Element(2)}, historyFactory.get());
 
   llvm::SmallVector<SILBasicBlock *, 4> joins;
-  while (p.popHistory(joins))
+  while (popOnePartitionOp(p, joins))
     continue;
 
   EXPECT_FALSE(p.hasHistory());
@@ -505,7 +517,7 @@ TEST(IsolationHistory, JoinSecondBranchPushPopAsymmetry) {
   // Drain the joined partition's history. After full unwind, no element
   // should be tracked — both fst and snd's contributions should reverse.
   llvm::SmallVector<SILBasicBlock *, 4> joins;
-  while (joined.popHistory(joins))
+  while (popOnePartitionOp(joined, joins))
     continue;
 
   EXPECT_FALSE(joined.isTrackingElement(Element(1)))
@@ -545,7 +557,7 @@ TEST(IsolationHistory, CreateVariable) {
     eval.apply({PartitionOp::AssignFresh(Element(2))});
   }
 
-  p.popHistory(joinedHistories);
+  popOnePartitionOp(p, joinedHistories);
 
   EXPECT_TRUE(Partition::equals(p, pSnapshot));
   EXPECT_TRUE(joinedHistories.empty());
@@ -580,12 +592,12 @@ TEST(IsolationHistory, AssignRegion) {
     eval.apply({PartitionOp::AssignDirect(Element(0), Element(2))});
   }
 
-  p.popHistory(joinedHistories);
+  popOnePartitionOp(p, joinedHistories);
 
   EXPECT_TRUE(Partition::equals(p, pSnapshot2));
   EXPECT_TRUE(joinedHistories.empty());
 
-  p.popHistory(joinedHistories);
+  popOnePartitionOp(p, joinedHistories);
 
   EXPECT_TRUE(Partition::equals(p, pSnapshot));
   EXPECT_TRUE(joinedHistories.empty());
@@ -628,13 +640,13 @@ TEST(IsolationHistory, BuildNewRegionRepIsMerge) {
   EXPECT_TRUE(Partition::equals(p, pSnapshot2));
 
   // We pop but nothing changes since we did not need to change anything.
-  p.popHistory(joinedHistories);
+  popOnePartitionOp(p, joinedHistories);
 
   EXPECT_TRUE(Partition::equals(p, pSnapshot2));
   EXPECT_TRUE(joinedHistories.empty());
 
   // We pop a last time to return to our original value.
-  p.popHistory(joinedHistories);
+  popOnePartitionOp(p, joinedHistories);
 
   EXPECT_TRUE(Partition::equals(p, pSnapshot));
   EXPECT_TRUE(joinedHistories.empty());
@@ -649,7 +661,7 @@ TEST(IsolationHistory, ReturnFalseWhenNoneLeft) {
 
   Partition p(historyFactory.get());
 
-  EXPECT_FALSE(p.popHistory(joinedHistories));
+  EXPECT_FALSE(popOnePartitionOp(p, joinedHistories));
   EXPECT_TRUE(joinedHistories.empty());
 
   {
@@ -658,10 +670,10 @@ TEST(IsolationHistory, ReturnFalseWhenNoneLeft) {
                 PartitionOp::AssignFresh(Element(3))});
   }
 
-  EXPECT_TRUE(p.popHistory(joinedHistories));
+  EXPECT_TRUE(popOnePartitionOp(p, joinedHistories));
   EXPECT_TRUE(joinedHistories.empty());
 
-  EXPECT_FALSE(p.popHistory(joinedHistories));
+  EXPECT_FALSE(popOnePartitionOp(p, joinedHistories));
   EXPECT_TRUE(joinedHistories.empty());
 }
 
@@ -779,7 +791,7 @@ TEST(IsolationHistory, AssignDirectMovesElementRoundTrip) {
   EXPECT_EQ(after.getRegion(1), after.getRegion(2));
   EXPECT_NE(after.getRegion(1), after.getRegion(0));
 
-  p.popHistory(joins);
+  popOnePartitionOp(p, joins);
   EXPECT_TRUE(joins.empty());
   EXPECT_TRUE(Partition::equals(p, snapshot))
       << "AssignDirect that moved an element across regions did not "


### PR DESCRIPTION
                                                                                                                            
  Reworks the isolation-history chain-note emitter (behind -sil-region-isolation-emit-isolation-history) so it explains
  how a disconnected value became part of an isolated region by rewinding the send-time partition rather than statically
  walking the history DAG. This fixes a class of diagnostic-location bugs — most importantly, the chain note now anchors  
  on the user-written merge that actually connects the value to the isolated source, instead of a variable's declaration
  or the wrong branch of a diamond.                                                                                       
                                                                                                                          
  The feature is off by default; only output under the flag changes. 

