### PR TITLE
[Windows] Fix CI undefined variable

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3350,6 +3350,7 @@ function Test-Compilers([Hashtable] $Platform, [string] $Variant, [switch] $Test
     $TestingDefines["SWIFT_BUILD_LIBEXEC"] = "YES"
     # Keep %host-build-swift on the same platform SDK that Stage2 uses.
     $TestingDefines["SWIFT_HOST_SDKROOT"] = $SwiftSDK
+    $Targets = @()
     if ($TestLLVM) { $Targets += @("check-llvm") }
     if ($TestClang) { $Targets += @("check-clang") }
     if ($TestLLD) { $Targets += @("check-lld") }


### PR DESCRIPTION
When only testing `check-lldb` or `check-lldb-swift`, the `$Target` variable is not written to before it's readen. This causes an error:
```
Error: The variable '$Targets' cannot be retrieved because it has not been set.
```