### PR TITLE
[SILCloner] Use TypeSubstCloner directly for debug reconstruction blocks

### DIFF
--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -540,8 +540,12 @@ protected:
     asImpl().visit(BB->getTerminator());
   }
 
-  /// Clone a debug-only reconstruction block.
-  void cloneDebugBasicBlock(SILBasicBlock *SrcBB, SILBasicBlock *NewBB);
+  /// Clone a debug reconstruction block. By default, this uses a
+  /// DebugBasicBlockCloner.
+  void cloneDebugReconstructionBlock(SILBasicBlock *SrcBB, SILBasicBlock *NewBB);
+
+  /// Clone a debug reconstruction block using this cloner's visit methods.
+  void cloneDebugReconstructionBlockContent(SILBasicBlock *SrcBB, SILBasicBlock *NewBB);
 
   // CFG cloning requires cloneFunction() or cloneReachableBlocks().
   void visitSILBasicBlock(SILFunction *F) = delete;
@@ -701,8 +705,6 @@ protected:
 private:
   /// MARK: SILCloner implementation details hidden from CRTP extensions.
 
-  friend class DebugBasicBlockCloner;
-
   void clonePhiArgs(SILBasicBlock *oldBB);
 
   void visitBlocksDepthFirst(SILBasicBlock *StartBB);
@@ -712,25 +714,18 @@ private:
   void commonFixUp(SILFunction *F);
 };
 
-/// A minimal cloner for debug-only reconstruction blocks.
-/// Uses the base SILCloner machinery (ValueMap, BBMap, clonePhiArgs).
+/// A minimal cloner for debug reconstruction blocks.
 class DebugBasicBlockCloner : public SILCloner<DebugBasicBlockCloner> {
-  friend class SILCloner<DebugBasicBlockCloner>;
   friend class SILInstructionVisitor<DebugBasicBlockCloner>;
 public:
+  using SILCloner::cloneDebugReconstructionBlockContent;
+
   explicit DebugBasicBlockCloner(SILFunction &F)
       : SILCloner<DebugBasicBlockCloner>(F) {}
   DebugBasicBlockCloner(SILFunction &F,
                         const SubstitutionMapWithLocalArchetypes &Subs)
       : SILCloner<DebugBasicBlockCloner>(F) {
     Functor = Subs;
-  }
-  void clone(SILBasicBlock *SrcBB, SILBasicBlock *NewBB) {
-    Builder.setInsertionPoint(NewBB);
-    BBMap[SrcBB] = NewBB;
-    clonePhiArgs(SrcBB);
-    visitInstructionsInBlock(SrcBB);
-    visit(SrcBB->getTerminator());
   }
 };
 
@@ -1002,12 +997,22 @@ void SILCloner<ImplClass>::clonePhiArgs(SILBasicBlock *oldBB) {
 }
 
 template <typename ImplClass>
-void SILCloner<ImplClass>::cloneDebugBasicBlock(SILBasicBlock *SrcBB,
+void SILCloner<ImplClass>::cloneDebugReconstructionBlock(SILBasicBlock *SrcBB,
                                                 SILBasicBlock *NewBB) {
   // By default, this uses its own cloner, as the debug basic block should
-  // be left untouched by transformations.
+  // be left untouched by most transformations.
   DebugBasicBlockCloner cloner(*NewBB->getParent(), Functor);
-  cloner.clone(SrcBB, NewBB);
+  cloner.cloneDebugReconstructionBlockContent(SrcBB, NewBB);
+}
+
+template <typename ImplClass>
+void SILCloner<ImplClass>::cloneDebugReconstructionBlockContent(SILBasicBlock *SrcBB,
+                                                        SILBasicBlock *NewBB) {
+  SavedInsertionPointRAII savedIP(getBuilder(), NewBB);
+  BBMap[SrcBB] = NewBB;
+  clonePhiArgs(SrcBB);
+  asImpl().visitInstructionsInBlock(SrcBB);
+  asImpl().visit(SrcBB->getTerminator());
 }
 
 // This private helper visits BBs in depth-first preorder (only processing
@@ -1820,7 +1825,7 @@ SILCloner<ImplClass>::visitDebugValueInst(DebugValueInst *Inst) {
     SILBasicBlock *NewDebugBB =
         NewInst->getFunction()->createEmptyDebugReconstructionBlock();
     NewInst->setDebugReconstructionBlock(NewDebugBB);
-    asImpl().cloneDebugBasicBlock(SrcDebugBB, NewDebugBB);
+    asImpl().cloneDebugReconstructionBlock(SrcDebugBB, NewDebugBB);
     
     // Type substitutions may map an address-only (generic) type to something
     // else, in which case, the op_deref must be converted to a load.

--- a/include/swift/SIL/TypeSubstCloner.h
+++ b/include/swift/SIL/TypeSubstCloner.h
@@ -184,6 +184,12 @@ protected:
     return Sty;
   }
 
+  /// This cloner's visit methods are needed to clone debug reconstruction
+  /// block content, for its folding of upcast.
+  void cloneDebugReconstructionBlock(SILBasicBlock *SrcBB, SILBasicBlock *NewBB) {
+    this->cloneDebugReconstructionBlockContent(SrcBB, NewBB);
+  }
+
   void visitApplyInst(ApplyInst *Inst) {
     ApplySiteCloningHelper Helper(ApplySite(Inst), *this);
     ApplyInst *N =

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -605,7 +605,8 @@ void DebugValueInst::cloneReconstructionBlockFrom(DebugValueInst *src) {
     return;
   auto *newBB = getFunction()->createEmptyDebugReconstructionBlock();
   setDebugReconstructionBlock(newBB);
-  DebugBasicBlockCloner(*getFunction()).clone(srcBB, newBB);
+  DebugBasicBlockCloner(*getFunction())
+    .cloneDebugReconstructionBlockContent(srcBB, newBB);
 }
 
 void DebugValueInst::killOperand(SILType operandType) {

--- a/test/DebugInfo/generic_specializer_fold_identity_upcast.sil
+++ b/test/DebugInfo/generic_specializer_fold_identity_upcast.sil
@@ -1,0 +1,39 @@
+// RUN: %target-sil-opt %s -generic-specializer -enable-sil-verify-all | %FileCheck %s
+
+// Test that specializing a generic function folds away identity upcasts in
+// debug reconstruction blocks.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+class Animal {}
+
+
+// Specialization with T=Animal. The upcast from Animal to Animal must be folded away.
+
+// CHECK-LABEL: sil shared @$s19generic_with_upcast4main6AnimalC_Tg5
+// CHECK:         debug_value %0, let, name "self", argno 1, transform {
+// CHECK:         bb0(%0 : $Animal):
+// CHECK-NEXT:      return %0
+// CHECK-NEXT:    }
+// CHECK-LABEL: } // end sil function '$s19generic_with_upcast4main6AnimalC_Tg5'
+
+sil @generic_with_upcast : $@convention(thin) <T where T : Animal> (@guaranteed T) -> Builtin.Int64 {
+bb0(%0 : $T):
+  debug_value %0 : $T, let, name "self", argno 1, transform {
+  bb0(%0 : $T):
+    %1 = upcast %0 : $T to $Animal
+    return %1 : $Animal
+  }
+  %lit = integer_literal $Builtin.Int64, 10
+  return %lit : $Builtin.Int64
+}
+
+sil @caller : $@convention(thin) (@guaranteed Animal) -> Builtin.Int64 {
+bb0(%0 : $Animal):
+  %fn = function_ref @generic_with_upcast : $@convention(thin) <T where T : Animal> (@guaranteed T) -> Builtin.Int64
+  %result = apply %fn<Animal>(%0) : $@convention(thin) <T where T : Animal> (@guaranteed T) -> Builtin.Int64
+  return %result : $Builtin.Int64
+}


### PR DESCRIPTION
If a debug reconstruction block contains an upcast, due to a salvage of that instruction, and the function gets specialized with the same type, it would create an invalid upcast from a type to itself.

TypeSubstCloner already handles this outside of debug reconstruction blocks, so just use itself to clone debug reconstruction blocks too.

This blocks the salvage of begin_borrow: #90918 