### PR TITLE
LoopInvariantCodeMotion: don't move scoped instructions out of the loop speculatively

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/DominatorTree.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/DominatorTree.swift
@@ -68,6 +68,27 @@ extension BasicBlock {
   }
 }
 
+extension Instruction {
+  /// Returns true if `otherInst` is in the same block and is dominated by this instruction or
+  /// the parent block of the instruction dominates parent block of `otherInst`.
+  func dominates(_ otherInst: Instruction, _ domTree: DominatorTree) -> Bool {
+    if parentBlock == otherInst.parentBlock {
+      return dominatesInBlock(otherInst)
+    } else {
+      return parentBlock.dominates(otherInst.parentBlock, domTree)
+    }
+  }
+
+  /// Like `Instruction.dominates`, but also returns false if `otherInst` == `self`.
+  func strictlyDominates(_ otherInst: Instruction, _ domTree: DominatorTree) -> Bool {
+    if parentBlock == otherInst.parentBlock {
+      return strictlyDominatesInBlock(otherInst)
+    } else {
+      return parentBlock.dominates(otherInst.parentBlock, domTree)
+    }
+  }
+}
+
 //===--------------------------------------------------------------------===//
 //                              Tests
 //===--------------------------------------------------------------------===//
@@ -88,4 +109,20 @@ let domtreeTest = FunctionTest("domtree") {
   })
 
   print("order: \(order.map { $0.index })")
+}
+
+let dominanceTest = FunctionTest("dominance") {
+  function, arguments, context in
+
+  let domtree = context.dominatorTree
+
+  let literals = Array(function.instructions.compactMap { $0 as? IntegerLiteralInst })
+
+  for first in literals {
+    for second in literals {
+      let dominates = first.dominates(second, domtree)
+      let strictly = first.strictlyDominates(second, domtree)
+      print("(\(first.value!), \(second.value!)): dominates: \(dominates), strictly: \(strictly)")
+    }
+  }
 }

--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/LoopTree.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/LoopTree.swift
@@ -110,20 +110,6 @@ struct Loop {
   func contains(block: BasicBlock) -> Bool {
     return bridged.contains(block.bridged)
   }
-  
-  func splitCriticalExitingAndBackEdges(_ context: FunctionPassContext) {
-    for exitingOrLatchBlock in exitingAndLatchBlocks {
-      for (index, succesor) in exitingOrLatchBlock.successors.enumerated() where !contains(block: succesor) {
-        splitCriticalEdge(
-          from: exitingOrLatchBlock.terminator.parentBlock,
-          toEdgeIndex: index,
-          dominatorTree: context.dominatorTree,
-          loopTree: context.loopTree,
-          context
-        )
-      }
-    }
-  }
 }
 
 struct TopLevelLoopArray: BridgedRandomAccessCollection {

--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/LoopTree.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/LoopTree.swift
@@ -80,8 +80,8 @@ struct Loop {
     return loopBlock.successors.contains { !contains(block: $0) }
   }
   
-  func getBlocksThatDominateAllExitingAndLatchBlocks(_ context: FunctionPassContext) -> [BasicBlock] {
-    var result: [BasicBlock] = []
+  func getBlocksThatDominateAllExitingAndLatchBlocks(_ context: FunctionPassContext) -> BasicBlockSet {
+    var result = BasicBlockSet(context)
     var cachedExitingAndLatchBlocks = Stack<BasicBlock>(context)
     var workList = BasicBlockWorklist(context)
     defer {
@@ -99,8 +99,8 @@ struct Loop {
         continue
       }
       
-      result.append(block)
-      
+      result.insert(block)
+
       workList.pushIfNotVisited(contentsOf: context.dominatorTree.getChildren(of: block))
     }
     

--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/PostDominatorTree.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/PostDominatorTree.swift
@@ -26,3 +26,44 @@ extension BasicBlock {
     postDominates(other, pdomTree) && self != other
   }
 }
+
+extension Instruction {
+  /// Returns true if `otherInst` is in the same block and is post-dominated by this instruction or
+  /// the parent block of the instruction post-dominates parent block of `otherInst`.
+  func postDominates(_ otherInst: Instruction, _ postDomTree: PostDominatorTree) -> Bool {
+    if parentBlock == otherInst.parentBlock {
+      return otherInst.dominatesInBlock(self)
+    } else {
+      return parentBlock.postDominates(otherInst.parentBlock, postDomTree)
+    }
+  }
+
+  /// Like `Instruction.postDominates`, but also returns false if `otherInst` == `self`.
+  func strictlyPostDominates(_ otherInst: Instruction, _ postDomTree: PostDominatorTree) -> Bool {
+    if parentBlock == otherInst.parentBlock {
+      return otherInst.strictlyDominatesInBlock(self)
+    } else {
+      return parentBlock.postDominates(otherInst.parentBlock, postDomTree)
+    }
+  }
+}
+
+//===--------------------------------------------------------------------===//
+//                              Tests
+//===--------------------------------------------------------------------===//
+
+let postDominanceTest = FunctionTest("post_dominance") {
+  function, arguments, context in
+
+  let domtree = context.postDominatorTree
+
+  let literals = Array(function.instructions.compactMap { $0 as? IntegerLiteralInst })
+
+  for first in literals {
+    for second in literals {
+      let dominates = first.postDominates(second, domtree)
+      let strictly = first.strictlyPostDominates(second, domtree)
+      print("(\(first.value!), \(second.value!)): dominates: \(dominates), strictly: \(strictly)")
+    }
+  }
+}

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
@@ -84,38 +84,37 @@ private struct AnalyzedInstructions {
   /// * an apply to the addressor of the global
   /// * a builtin "once" of the global initializer
   var globalInitCalls: Stack<Instruction>
-  var readOnlyApplies: Stack<FullApplySite>
   var loads: Stack<LoadInst>
   var stores: Stack<StoreInst>
   var scopedInsts: Stack<UnaryInstruction>
-  var fullApplies: Stack<FullApplySite>
-  
+
+  // loop blocks that dominate all exiting and latch blocks
+  var dominatingBlocks: BasicBlockSet
+
   /// `true` if the loop has instructions which (may) read from memory, which are not in `Loads` and not in `sideEffects`.
   var hasOtherMemReadingInsts = false
   
   /// `true` if one of the side effects might release.
-  lazy var sideEffectsMayRelease = loopSideEffects.contains(where: { $0.mayRelease })
-  
-  init (_ context: FunctionPassContext) {
+  var sideEffectsMayRelease: Bool { loopSideEffects.contains(where: { $0.mayRelease }) }
+
+  init (in loop: Loop, _ context: FunctionPassContext) {
     self.loopSideEffects = StackWithCount<Instruction>(context)
     self.blockSideEffectBottomMarker = loopSideEffects.top
     
     self.globalInitCalls = Stack<Instruction>(context)
-    self.readOnlyApplies = Stack<FullApplySite>(context)
     self.loads = Stack<LoadInst>(context)
     self.stores = Stack<StoreInst>(context)
     self.scopedInsts = Stack<UnaryInstruction>(context)
-    self.fullApplies = Stack<FullApplySite>(context)
+    self.dominatingBlocks = loop.getBlocksThatDominateAllExitingAndLatchBlocks(context)
   }
   
   mutating func deinitialize() {
-    readOnlyApplies.deinitialize()
     globalInitCalls.deinitialize()
     loopSideEffects.deinitialize()
     loads.deinitialize()
     stores.deinitialize()
     scopedInsts.deinitialize()
-    fullApplies.deinitialize()
+    dominatingBlocks.deinitialize()
   }
   
   /// Mark the start of currently processed block side effects.
@@ -130,27 +129,27 @@ private struct AnalyzedInstructions {
 /// This may split some loads into smaller loads.
 private func analyzeLoopAndSplitLoads(loop: Loop, _ context: FunctionPassContext) -> MovableInstructions {
   var movableInstructions = MovableInstructions()
-  var analyzedInstructions = AnalyzedInstructions(context)
+  var analyzedInstructions = AnalyzedInstructions(in: loop, context)
   defer { analyzedInstructions.deinitialize() }
 
-  analyzeInstructions(in: loop, &analyzedInstructions, &movableInstructions, context)
+  analyzeInstructions(in: loop, &analyzedInstructions, context)
 
   collectHoistableGlobalInitCalls(in: loop, analyzedInstructions, &movableInstructions, context)
 
   collectProjectableAccessPathsAndSplitLoads(in: loop, &analyzedInstructions, &movableInstructions, context)
-  
-  collectMovableInstructions(in: loop, &analyzedInstructions, &movableInstructions, context)
+
+  collectSpeculativelyMovableInstructions(in: loop,  &movableInstructions)
+
+  collectMovableInstructions(in: loop, analyzedInstructions, &movableInstructions, context)
     
   return movableInstructions
 }
 
 /// Analyze instructions inside the `loop`. Compute side effects and populate `analyzedInstructions`.
 ///
-/// - note: Ideally, `movableInstructions` should be fully computed in `collectMovableInstructions`.
 private func analyzeInstructions(
   in loop: Loop,
   _ analyzedInstructions: inout AnalyzedInstructions,
-  _ movableInstructions: inout MovableInstructions,
   _ context: FunctionPassContext
 ) {
   for bb in loop.loopBlocks {
@@ -159,64 +158,43 @@ private func analyzeInstructions(
     for inst in bb.instructions {
       switch inst {
       case is FixLifetimeInst:
-        break // We can ignore the side effects of FixLifetimes
+        continue // We can ignore the side effects of FixLifetimes
       case let loadInst as LoadInst:
         analyzedInstructions.loads.append(loadInst)
-      case let uncheckedOwnershipConversionInst as UncheckedOwnershipConversionInst:
-        analyzedInstructions.analyzeSideEffects(ofInst: uncheckedOwnershipConversionInst)
+        continue // Don't set `hasOtherMemReadingInsts` in `analyzeSideEffects`
       case let storeInst as StoreInst:
         analyzedInstructions.stores.append(storeInst)
-        analyzedInstructions.analyzeSideEffects(ofInst: storeInst)
       case let beginAccessInst as BeginAccessInst:
         analyzedInstructions.scopedInsts.append(beginAccessInst)
-        analyzedInstructions.analyzeSideEffects(ofInst: beginAccessInst)
-      case let beginBorrowInst as BeginBorrowInstruction:
-        analyzedInstructions.analyzeSideEffects(ofInst: beginBorrowInst)
-      case let refElementAddrInst as RefElementAddrInst:
-        movableInstructions.speculativelyHoistable.append(refElementAddrInst)
-      case let condFailInst as CondFailInst:
-        analyzedInstructions.analyzeSideEffects(ofInst: condFailInst)
       case let fullApply as FullApplySite:
-        if fullApply.isSafeReadOnlyApply(context.calleeAnalysis) {
-          analyzedInstructions.readOnlyApplies.append(fullApply)
-        } else if let callee = fullApply.referencedFunction,
-                  callee.isGlobalInitFunction, // Calls to global inits are different because we don't care about side effects which are "after" the call in the loop.
-                  !fullApply.globalInitMayConflictWith(
-                    blockSideEffectSegment: analyzedInstructions.sideEffectsOfCurrentBlock,
-                    context.aliasAnalysis
-                  ) {
-          // Check against side-effects within the same block.
-          // Side-effects in other blocks are checked later (after we
-          // scanned all blocks of the loop) in `collectHoistableGlobalInitCalls`.
+        if let callee = fullApply.referencedFunction,
+           callee.isGlobalInitFunction,
+           // Calls to global inits are different because we don't care about side effects which are "after"
+           // the call in the loop.
+           // Check against side-effects within the same block. Side-effects in other blocks are checked
+           // later (after we scanned all blocks of the loop) in `collectHoistableGlobalInitCalls`.
+           !fullApply.globalInitMayConflictWith(
+              blockSideEffectSegment: analyzedInstructions.sideEffectsOfCurrentBlock,
+              context.aliasAnalysis)
+        {
           analyzedInstructions.globalInitCalls.append(fullApply)
         }
-        
-        analyzedInstructions.fullApplies.append(fullApply)
-        
-        // Check for array semantics and side effects - same as default
-        fallthrough
-      default:
-        switch inst {
-        case let builtinInst as BuiltinInst:
-          switch builtinInst.id {
-          case .Once, .OnceWithContext:
-            if !builtinInst.globalInitMayConflictWith(
-              blockSideEffectSegment: analyzedInstructions.sideEffectsOfCurrentBlock,
-              context.aliasAnalysis
-            ) {
-              analyzedInstructions.globalInitCalls.append(builtinInst)
-            }
-          default: break
+      case let builtinInst as BuiltinInst:
+        switch builtinInst.id {
+        case .Once, .OnceWithContext:
+          if !builtinInst.globalInitMayConflictWith(
+            blockSideEffectSegment: analyzedInstructions.sideEffectsOfCurrentBlock,
+            context.aliasAnalysis
+          ) {
+            analyzedInstructions.globalInitCalls.append(builtinInst)
           }
-        default: break
+        default:
+          break
         }
-        
-        analyzedInstructions.analyzeSideEffects(ofInst: inst)
-        
-        if inst.canBeHoisted(outOf: loop, context) {
-          movableInstructions.hoistUp.append(inst)
-        }
+      default:
+        break
       }
+      analyzedInstructions.analyzeSideEffects(ofInst: inst)
     }
   }
 }
@@ -234,11 +212,12 @@ private func collectHoistableGlobalInitCalls(
     // The effects in the same block have already been checked before
     // adding this global init call to `analyzedInstructions.globalInitCalls` in `analyzeInstructions`.
     if globalInitCall.parentBlock.postDominates(loop.preheader!, context.postDominatorTree),
+       analyzedInstructions.dominatingBlocks.contains(globalInitCall.parentBlock),
        !globalInitCall.globalInitMayConflictWith(
          loopSideEffects: analyzedInstructions.loopSideEffects,
          context.aliasAnalysis,
-         context.postDominatorTree
-       ) {
+         context.postDominatorTree)
+    {
       movableInstructions.hoistUp.append(globalInitCall)
     }
   }
@@ -276,16 +255,38 @@ private func collectProjectableAccessPathsAndSplitLoads(
   }
 }
 
-/// Computes movable instructions using computed analyzed instructions.
+/// Collect movable instructions, even if they are not executed in every loop iteration.
+private func collectSpeculativelyMovableInstructions(in loop: Loop, _ movableInstructions: inout MovableInstructions) {
+  for bb in loop.loopBlocks {
+    for inst in bb.instructions {
+      switch inst {
+      case is LoadInst, is StoreInst:
+        movableInstructions.loadsAndStores.append(inst)
+      case let refElementAddrInst as RefElementAddrInst:
+        movableInstructions.speculativelyHoistable.append(refElementAddrInst)
+      default:
+        break
+      }
+    }
+  }
+}
+
+/// Collect movable instructions. Only includes instructions which are executed in every loop iteration.
 private func collectMovableInstructions(
   in loop: Loop,
-  _ analyzedInstructions: inout AnalyzedInstructions,
+  _ analyzedInstructions: AnalyzedInstructions,
   _ movableInstructions: inout MovableInstructions,
   _ context: FunctionPassContext
 ) {
   var loadInstCounter = 0
   var readOnlyApplyCounter = 0
+  lazy var sideEffectsMayRelease = analyzedInstructions.sideEffectsMayRelease
   for bb in loop.loopBlocks {
+    // Skip blocks which are not executed in every loop iteration
+    guard analyzedInstructions.dominatingBlocks.contains(bb) else {
+      continue
+    }
+
     for inst in bb.instructions {
       switch inst {
       case let fixLifetimeInst as FixLifetimeInst:
@@ -293,8 +294,8 @@ private func collectMovableInstructions(
           continue
         }
         
-        if !analyzedInstructions.sideEffectsMayRelease ||
-            !analyzedInstructions.sideEffectsMayWrite(to: fixLifetimeInst.operand.value, context.aliasAnalysis)
+        if !sideEffectsMayRelease ||
+           !analyzedInstructions.sideEffectsMayWrite(to: fixLifetimeInst.operand.value, context.aliasAnalysis)
         {
           movableInstructions.sinkDown.append(fixLifetimeInst)
         }
@@ -313,8 +314,6 @@ private func collectMovableInstructions(
         }
         
         loadInstCounter += 1
-        
-        movableInstructions.loadsAndStores.append(loadInst)
       case is UncheckedOwnershipConversionInst:
         break // TODO: Add support
       case let storeInst as StoreInst:
@@ -324,7 +323,6 @@ private func collectMovableInstructions(
         case .unqualified, .trivial, .initialize:
           break
         }
-        movableInstructions.loadsAndStores.append(storeInst)
       case let condFailInst as CondFailInst:
         // We can (and must) hoist cond_fail instructions if the operand is
         // invariant. We must hoist them so that we preserve memory safety. A
@@ -340,27 +338,21 @@ private func collectMovableInstructions(
           movableInstructions.scopedInsts.append(beginBorrowInst)
         }
       case let fullApplySite as FullApplySite:
-        guard analyzedInstructions.readOnlyApplies.contains(where: { $0 == fullApplySite }) else {
-          break
-        }
-        
         // Avoid quadratic complexity in corner cases. Usually, this limit will not be exceeded.
         if readOnlyApplyCounter * analyzedInstructions.loopSideEffects.count < 8000,
-           fullApplySite.isSafeReadOnlyApply(
-             for: analyzedInstructions.loopSideEffects,
-             context.aliasAnalysis,
-             context.calleeAnalysis
-           ) {
+           fullApplySite.isSafeReadOnlyApply(for: analyzedInstructions.loopSideEffects, in: loop, context)
+        {
           if let beginApplyInst = fullApplySite as? BeginApplyInst {
             movableInstructions.scopedInsts.append(beginApplyInst)
           } else {
             movableInstructions.hoistUp.append(fullApplySite)
           }
-          
           readOnlyApplyCounter += 1
         }
       default:
-        break
+        if inst.canBeHoisted(outOf: loop, context) {
+          movableInstructions.hoistUp.append(inst)
+        }
       }
     }
   }
@@ -651,13 +643,10 @@ private extension MovableInstructions {
   /// Only hoists instructions in blocks that dominate all exit and latch blocks.
   /// It doesn't hoist instructions speculatively.
   mutating func hoistInstructions(outOf loop: Loop, _ context: FunctionPassContext) -> Bool {
-    let dominatingBlocks = loop.getBlocksThatDominateAllExitingAndLatchBlocks(context)
     var changed = false
 
-    for bb in dominatingBlocks {
-      for inst in bb.instructions where hoistUp.contains(inst) {
-        changed = inst.hoist(outOf: loop, context) || changed
-      }
+    for hoistableInst in hoistUp {
+      changed = hoistableInst.hoist(outOf: loop, context) || changed
     }
 
     return changed
@@ -665,10 +654,9 @@ private extension MovableInstructions {
 
   /// Sink instructions.
   mutating func sinkInstructions(outOf loop: Loop, _ context: FunctionPassContext) -> Bool {
-    let dominatingBlocks = loop.getBlocksThatDominateAllExitingAndLatchBlocks(context)
     var changed = false
 
-    for inst in sinkDown where dominatingBlocks.contains(inst.parentBlock) {
+    for inst in sinkDown {
       changed = inst.sink(outOf: loop, context) || changed
     }
 
@@ -932,17 +920,6 @@ private extension Instruction {
     switch self {
     case is TermInst, is Allocation, is Deallocation:
       return false
-    case is ApplyInst:
-      switch arraySemanticsCallKind {
-      case .getCount, .getCapacity:
-        if canHoistArraySemanticsCall(to: loop.preheader!.terminator, context) {
-          return true
-        }
-      case .arrayPropsIsNativeTypeChecked:
-        return false
-      default:
-        break
-      }
     default:
       break
     }
@@ -1098,29 +1075,31 @@ private extension LoadInst {
 }
 
 private extension FullApplySite {
-  /// Returns `true` if this apply inst could be safely hoisted.
-  func isSafeReadOnlyApply(_ calleeAnalysis: CalleeAnalysis) -> Bool {
-    guard functionConvention.resultsWithError.allSatisfy({ $0.convention == .unowned }) else {
-      return false
-    }
-
-    if let callee = referencedFunction,
-       callee.hasSemanticsAttribute("array.props.isNativeTypeChecked") {
-      return false
-    }
-
-    return !calleeAnalysis.getSideEffects(ofApply: self).memory.write
-  }
-  
   /// Returns `true` if the `sideEffects` contain any memory writes which
   /// may alias with any memory which is read by this `ApplyInst`.
   /// - Note: This function should only be called on a read-only apply!
   func isSafeReadOnlyApply(
     for sideEffects: StackWithCount<Instruction>,
-    _ aliasAnalysis: AliasAnalysis,
-    _ calleeAnalysis: CalleeAnalysis
+    in loop: Loop,
+    _ context: FunctionPassContext
   ) -> Bool {
-    if calleeAnalysis.getSideEffects(ofApply: self).memory == .noEffects {
+    switch arraySemanticsCallKind {
+    case .getCount, .getCapacity:
+      if canHoistArraySemanticsCall(to: loop.preheader!.terminator, context) {
+        return true
+      }
+    default:
+      break
+    }
+    guard functionConvention.resultsWithError.allSatisfy({ $0.convention == .unowned }) else {
+      return false
+    }
+    if let callee = referencedFunction,
+       callee.hasSemanticsAttribute("array.props.isNativeTypeChecked")
+    {
+      return false
+    }
+    if context.calleeAnalysis.getSideEffects(ofApply: self).memory == .noEffects {
       return true
     }
 
@@ -1129,16 +1108,16 @@ private extension FullApplySite {
       switch sideEffect {
       case let storeInst as StoreInst:
         if storeInst.storeOwnership == .assign ||
-           mayRead(fromAddress: storeInst.destination, aliasAnalysis) {
+           mayRead(fromAddress: storeInst.destination, context.aliasAnalysis) {
           return false
         }
       case let copyAddrInst as CopyAddrInst:
         if !copyAddrInst.isInitializationOfDestination ||
-           mayRead(fromAddress: copyAddrInst.destination, aliasAnalysis) {
+           mayRead(fromAddress: copyAddrInst.destination, context.aliasAnalysis) {
           return false
         }
       case let fullApplySite as FullApplySite:
-        if calleeAnalysis.getSideEffects(ofApply: fullApplySite).memory.write {
+        if context.calleeAnalysis.getSideEffects(ofApply: fullApplySite).memory.write {
           return false
         }
       case is CondFailInst, is StrongRetainInst, is UnmanagedRetainValueInst,

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
@@ -60,7 +60,6 @@ private struct MovableInstructions {
   var speculativelyHoistable: [Instruction] = []
   var loadsAndStores: [Instruction] = []
   var hoistUp: [Instruction] = []
-  var sinkDown: [Instruction] = []
   var scopedInsts: [ScopedInstruction] = []
 }
 
@@ -94,9 +93,6 @@ private struct AnalyzedInstructions {
   /// `true` if the loop has instructions which (may) read from memory, which are not in `Loads` and not in `sideEffects`.
   var hasOtherMemReadingInsts = false
   
-  /// `true` if one of the side effects might release.
-  var sideEffectsMayRelease: Bool { loopSideEffects.contains(where: { $0.mayRelease }) }
-
   init (in loop: Loop, _ context: FunctionPassContext) {
     self.loopSideEffects = StackWithCount<Instruction>(context)
     self.blockSideEffectBottomMarker = loopSideEffects.top
@@ -280,7 +276,6 @@ private func collectMovableInstructions(
 ) {
   var loadInstCounter = 0
   var readOnlyApplyCounter = 0
-  lazy var sideEffectsMayRelease = analyzedInstructions.sideEffectsMayRelease
   for bb in loop.loopBlocks {
     // Skip blocks which are not executed in every loop iteration
     guard analyzedInstructions.dominatingBlocks.contains(bb) else {
@@ -289,16 +284,6 @@ private func collectMovableInstructions(
 
     for inst in bb.instructions {
       switch inst {
-      case let fixLifetimeInst as FixLifetimeInst:
-        guard fixLifetimeInst.parentBlock.dominates(loop.preheader!, context.dominatorTree) else {
-          continue
-        }
-        
-        if !sideEffectsMayRelease ||
-           !analyzedInstructions.sideEffectsMayWrite(to: fixLifetimeInst.operand.value, context.aliasAnalysis)
-        {
-          movableInstructions.sinkDown.append(fixLifetimeInst)
-        }
       case let loadInst as LoadInst:
         // Avoid quadratic complexity in corner cases. Usually, this limit will not be exceeded.
         if loadInstCounter * analyzedInstructions.loopSideEffects.count < 8000,
@@ -375,7 +360,6 @@ private func optimizeLoop(
   changed = movableInstructions.speculativelyHoistInstructions(outOf: loop, context)  || changed
   changed = movableInstructions.hoistAndSinkLoadsAndStores(outOf: loop, context)      || changed
   changed = movableInstructions.hoistInstructions(outOf: loop, context)               || changed
-  changed = movableInstructions.sinkInstructions(outOf: loop, context)                || changed
   changed = movableInstructions.hoistWithSinkScopedInstructions(outOf: loop, context) || changed
 
   return changed
@@ -647,17 +631,6 @@ private extension MovableInstructions {
 
     for hoistableInst in hoistUp {
       changed = hoistableInst.hoist(outOf: loop, context) || changed
-    }
-
-    return changed
-  }
-
-  /// Sink instructions.
-  mutating func sinkInstructions(outOf loop: Loop, _ context: FunctionPassContext) -> Bool {
-    var changed = false
-
-    for inst in sinkDown {
-      changed = inst.sink(outOf: loop, context) || changed
     }
 
     return changed

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
@@ -129,9 +129,6 @@ private struct AnalyzedInstructions {
 ///
 /// This may split some loads into smaller loads.
 private func analyzeLoopAndSplitLoads(loop: Loop, _ context: FunctionPassContext) -> MovableInstructions {
-  // TODO: Remove once uses lowered OSSA.
-  loop.splitCriticalExitingAndBackEdges(context)
-
   var movableInstructions = MovableInstructions()
   var analyzedInstructions = AnalyzedInstructions(context)
   defer { analyzedInstructions.deinitialize() }

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
@@ -67,22 +67,6 @@ private struct MovableInstructions {
 private struct AnalyzedInstructions {
   /// Side effects of the loop.
   var loopSideEffects: StackWithCount<Instruction>
-  
-  private var blockSideEffectBottomMarker: StackWithCount<Instruction>.Marker
-  
-  /// Side effects of the currently analyzed block.
-  var sideEffectsOfCurrentBlock: StackWithCount<Instruction>.Segment {
-    return StackWithCount<Instruction>.Segment(
-      in: loopSideEffects,
-      low: blockSideEffectBottomMarker,
-      high: loopSideEffects.top
-    )
-  }
-  
-  /// Contains either:
-  /// * an apply to the addressor of the global
-  /// * a builtin "once" of the global initializer
-  var globalInitCalls: Stack<Instruction>
   var loads: Stack<LoadInst>
   var stores: Stack<StoreInst>
   var scopedInsts: Stack<UnaryInstruction>
@@ -95,9 +79,6 @@ private struct AnalyzedInstructions {
   
   init (in loop: Loop, _ context: FunctionPassContext) {
     self.loopSideEffects = StackWithCount<Instruction>(context)
-    self.blockSideEffectBottomMarker = loopSideEffects.top
-    
-    self.globalInitCalls = Stack<Instruction>(context)
     self.loads = Stack<LoadInst>(context)
     self.stores = Stack<StoreInst>(context)
     self.scopedInsts = Stack<UnaryInstruction>(context)
@@ -105,17 +86,11 @@ private struct AnalyzedInstructions {
   }
   
   mutating func deinitialize() {
-    globalInitCalls.deinitialize()
     loopSideEffects.deinitialize()
     loads.deinitialize()
     stores.deinitialize()
     scopedInsts.deinitialize()
     dominatingBlocks.deinitialize()
-  }
-  
-  /// Mark the start of currently processed block side effects.
-  mutating func markBeginOfBlock() {
-    blockSideEffectBottomMarker = loopSideEffects.top
   }
 }
 
@@ -129,8 +104,6 @@ private func analyzeLoopAndSplitLoads(loop: Loop, _ context: FunctionPassContext
   defer { analyzedInstructions.deinitialize() }
 
   analyzeInstructions(in: loop, &analyzedInstructions, context)
-
-  collectHoistableGlobalInitCalls(in: loop, analyzedInstructions, &movableInstructions, context)
 
   collectProjectableAccessPathsAndSplitLoads(in: loop, &analyzedInstructions, &movableInstructions, context)
 
@@ -149,72 +122,25 @@ private func analyzeInstructions(
   _ context: FunctionPassContext
 ) {
   for bb in loop.loopBlocks {
-    analyzedInstructions.markBeginOfBlock()
-    
     for inst in bb.instructions {
       switch inst {
       case is FixLifetimeInst:
         continue // We can ignore the side effects of FixLifetimes
       case let loadInst as LoadInst:
         analyzedInstructions.loads.append(loadInst)
-        continue // Don't set `hasOtherMemReadingInsts` in `analyzeSideEffects`
+        continue // Don't set `hasOtherMemReadingInsts`
       case let storeInst as StoreInst:
         analyzedInstructions.stores.append(storeInst)
       case let beginAccessInst as BeginAccessInst:
         analyzedInstructions.scopedInsts.append(beginAccessInst)
-      case let fullApply as FullApplySite:
-        if let callee = fullApply.referencedFunction,
-           callee.isGlobalInitFunction,
-           // Calls to global inits are different because we don't care about side effects which are "after"
-           // the call in the loop.
-           // Check against side-effects within the same block. Side-effects in other blocks are checked
-           // later (after we scanned all blocks of the loop) in `collectHoistableGlobalInitCalls`.
-           !fullApply.globalInitMayConflictWith(
-              blockSideEffectSegment: analyzedInstructions.sideEffectsOfCurrentBlock,
-              context.aliasAnalysis)
-        {
-          analyzedInstructions.globalInitCalls.append(fullApply)
-        }
-      case let builtinInst as BuiltinInst:
-        switch builtinInst.id {
-        case .Once, .OnceWithContext:
-          if !builtinInst.globalInitMayConflictWith(
-            blockSideEffectSegment: analyzedInstructions.sideEffectsOfCurrentBlock,
-            context.aliasAnalysis
-          ) {
-            analyzedInstructions.globalInitCalls.append(builtinInst)
-          }
-        default:
-          break
-        }
       default:
         break
       }
-      analyzedInstructions.analyzeSideEffects(ofInst: inst)
-    }
-  }
-}
-
-/// Process collected global init calls. Moves them to `hoistUp` if they don't conflict with any side effects.
-private func collectHoistableGlobalInitCalls(
-  in loop: Loop,
-  _ analyzedInstructions: AnalyzedInstructions,
-  _ movableInstructions: inout MovableInstructions,
-  _ context: FunctionPassContext
-) {
-  for globalInitCall in analyzedInstructions.globalInitCalls {
-    // Check against side effects which are "before" (i.e. post-dominated by) the global initializer call.
-    //
-    // The effects in the same block have already been checked before
-    // adding this global init call to `analyzedInstructions.globalInitCalls` in `analyzeInstructions`.
-    if globalInitCall.parentBlock.postDominates(loop.preheader!, context.postDominatorTree),
-       analyzedInstructions.dominatingBlocks.contains(globalInitCall.parentBlock),
-       !globalInitCall.globalInitMayConflictWith(
-         loopSideEffects: analyzedInstructions.loopSideEffects,
-         context.aliasAnalysis,
-         context.postDominatorTree)
-    {
-      movableInstructions.hoistUp.append(globalInitCall)
+      if inst.mayHaveSideEffects {
+        analyzedInstructions.loopSideEffects.append(inst)
+      } else if inst.mayReadFromMemory {
+        analyzedInstructions.hasOtherMemReadingInsts = true
+      }
     }
   }
 }
@@ -333,6 +259,14 @@ private func collectMovableInstructions(
             movableInstructions.hoistUp.append(fullApplySite)
           }
           readOnlyApplyCounter += 1
+        } else if let callee = fullApplySite.referencedFunction,
+                  callee.isGlobalInitFunction,
+                  !fullApplySite.globalInitMayConflictWith(analyzedInstructions.loopSideEffects, context) {
+          movableInstructions.hoistUp.append(fullApplySite)
+        }
+      case let builtin as BuiltinInst where builtin.id == .Once || builtin.id == .OnceWithContext:
+        if !builtin.globalInitMayConflictWith(analyzedInstructions.loopSideEffects, context) {
+          movableInstructions.hoistUp.append(builtin)
         }
       default:
         if inst.canBeHoisted(outOf: loop, context) {
@@ -374,15 +308,6 @@ extension BasicBlock {
 }
 
 private extension AnalyzedInstructions {
-  /// Adds side effects of `inst` to the analyzed instructions.
-  mutating func analyzeSideEffects(ofInst inst: Instruction) {
-    if inst.mayHaveSideEffects {
-      loopSideEffects.append(inst)
-    } else if inst.mayReadFromMemory {
-      hasOtherMemReadingInsts = true
-    }
-  }
-  
   /// Returns true if all instructions in `sideEffects` which may alias with
   /// this path are either loads or stores from this path.
   ///
@@ -981,37 +906,20 @@ private extension Instruction {
     }
   }
   
-  /// Returns `true` if any of the instructions in `sideEffects` cannot be
-  /// reordered with a call to this global initializer (which is in the same basic
-  /// block).
-  func globalInitMayConflictWith(
-    blockSideEffectSegment: StackWithCount<Instruction>.Segment,
-    _ aliasAnalysis: AliasAnalysis
-  ) -> Bool {
-    return blockSideEffectSegment
-      .contains { sideEffect in
-        globalInitMayConflictWith(
-          sideEffect: sideEffect,
-          aliasAnalysis
-        )
-      }
-  }
-
   /// Returns `true` if any of the instructions in `loopSideEffects` which are
   /// post-dominated by a call to this global initializer cannot be reordered with
   /// the call.
   func globalInitMayConflictWith(
-    loopSideEffects: StackWithCount<Instruction>,
-    _ aliasAnalysis: AliasAnalysis,
-    _ postDomTree: PostDominatorTree
+    _ loopSideEffects: StackWithCount<Instruction>,
+    _ context: FunctionPassContext
   ) -> Bool {
+    let aliasAnalysis = context.aliasAnalysis
+    let postDominatorTree = context.postDominatorTree
     return loopSideEffects
       .contains { sideEffect in
         // Only check instructions in blocks which are "before" (i.e. post-dominated
         // by) the block which contains the init-call.
-        // Instructions which are before the call in the same block have already
-        // been checked.
-        parentBlock.strictlyPostDominates(sideEffect.parentBlock, postDomTree) &&
+        self.strictlyPostDominates(sideEffect, postDominatorTree) &&
         globalInitMayConflictWith(sideEffect: sideEffect, aliasAnalysis)
       }
   }

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
@@ -368,14 +368,7 @@ private func optimizeLoop(
 extension BasicBlock {
   func containsStoresTo(accessPath: AccessPath) -> Bool {
     return instructions.contains { inst in
-      return inst.operands.contains { operand in
-        if let storeInst = operand.instruction as? StoreInst,
-           storeInst.destination.accessPath == accessPath {
-          return true
-        } else {
-          return false
-        }
-      }
+      (inst as? StoreInst)?.destination.accessPath == accessPath
     }
   }
 }
@@ -400,7 +393,7 @@ private extension AnalyzedInstructions {
     storeAddr: Value,
     _ aliasAnalysis: AliasAnalysis
   ) -> Bool {
-    if (loopSideEffects.contains { sideEffect in
+    if loopSideEffects.contains(where: { sideEffect in
       switch sideEffect {
       case let storeInst as StoreInst:
         if storeInst.storesTo(accessPath) {
@@ -412,20 +405,20 @@ private extension AnalyzedInstructions {
         }
       default: break
       }
-      
+
       // Pass the original address value until we can fix alias analysis.
       return sideEffect.mayReadOrWrite(address: storeAddr, aliasAnalysis)
     }) {
       return false
     }
-        
-    if (loads.contains { loadInst in
+
+    if loads.contains(where: { loadInst in
       loadInst.mayRead(fromAddress: storeAddr, aliasAnalysis) && !loadInst.overlaps(accessPath: accessPath)
     }) {
       return false
     }
-          
-    if (stores.contains { storeInst in
+
+    if stores.contains(where: { storeInst in
       storeInst.mayWrite(toAddress: storeAddr, aliasAnalysis) && !storeInst.storesTo(accessPath)
     }) {
       return false
@@ -502,7 +495,7 @@ private extension AnalyzedInstructions {
       }
       
       if exitingBlocksSet.contains(block),
-         block.successors.filter({ $0.terminator is UnreachableInst }).count != block.successors.count {
+         !block.successors.allSatisfy({ $0.terminator is UnreachableInst }) {
         return false
       }
       
@@ -729,7 +722,9 @@ private extension MovableInstructions {
       }
     }
 
-    let phiOwnership: Ownership = firstStore.parentFunction.hasOwnership ? (firstStore.source.type.isTrivial(in: firstStore.parentFunction) ? .none : .owned) : .none
+    let function = firstStore.parentFunction
+    let phiOwnership: Ownership =
+      function.hasOwnership && !firstStore.source.type.isTrivial(in: function) ? .owned : .none
 
     var ssaUpdater = SSAUpdater(
       type: firstStore.destination.type.objectType,
@@ -765,7 +760,14 @@ private extension MovableInstructions {
       return false
     }
 
-    let ownership: LoadInst.LoadOwnership = firstStore.parentFunction.hasOwnership ? (initialAddr.type.isTrivial(in: firstStore.parentFunction) ? .trivial : .take) : .unqualified
+    let ownership: LoadInst.LoadOwnership
+    if !function.hasOwnership {
+      ownership = .unqualified
+    } else if initialAddr.type.isTrivial(in: function) {
+      ownership = .trivial
+    } else {
+      ownership = .take
+    }
 
     let initialLoad = builder.createLoad(fromAddress: initialAddr, ownership: ownership)
     ssaUpdater.addAvailableValue(initialLoad, in: loop.preheader!)

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -594,22 +594,6 @@ extension Instruction {
     }
   }
 
-  /// Returns true if `otherInst` is in the same block and is strictly dominated by this instruction or
-  /// the parent block of the instruction dominates parent block of `otherInst`.
-  func dominates(
-    _ otherInst: Instruction,
-    _ domTree: DominatorTree
-  ) -> Bool {
-    if parentBlock == otherInst.parentBlock {
-      return dominatesInBlock(otherInst)
-    } else {
-      return parentBlock.dominates(
-        otherInst.parentBlock,
-        domTree
-      )
-    }
-  }
-
   /// If this instruction uses a (single) existential archetype, i.e. it has a type-dependent operand,
   /// returns the concrete type if it is known.
   var concreteTypeOfDependentExistentialArchetype: CanonicalType? {

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/Test.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/Test.swift
@@ -56,6 +56,8 @@ public func registerOptimizerTests() {
     argumentConventionsTest,
     breakInfiniteLoopsTest,
     domtreeTest,
+    dominanceTest,
+    postDominanceTest,
     extendBorrowScopeTest,
     getAutoDiffSpecializationInfoTest,
     interiorLivenessTest,

--- a/test/SILOptimizer/domtree_unit.sil
+++ b/test/SILOptimizer/domtree_unit.sil
@@ -2,6 +2,8 @@
 
 sil_stage canonical
 
+import Builtin
+
 // CHECK-LABEL: begin running test 1 of 1 on simple_order: domtree with: @block[0]
 // CHECK:       order: [0, 6, 2, 4, 5, 1, 3]
 // CHECK:       end running test 1 of 1 on simple_order: domtree with: @block[0]
@@ -55,6 +57,63 @@ bb2:
 bb3:
   br bb4
 bb4:
+  return undef : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 2 on dominance: dominance
+// CHECK:         (1, 1): dominates: true, strictly: false
+// CHECK:         (1, 2): dominates: true, strictly: true
+// CHECK:         (1, 3): dominates: true, strictly: true
+// CHECK:         (1, 4): dominates: true, strictly: true
+// CHECK:         (2, 1): dominates: false, strictly: false
+// CHECK:         (2, 2): dominates: true, strictly: false
+// CHECK:         (2, 3): dominates: true, strictly: true
+// CHECK:         (2, 4): dominates: false, strictly: false
+// CHECK:         (3, 1): dominates: false, strictly: false
+// CHECK:         (3, 2): dominates: false, strictly: false
+// CHECK:         (3, 3): dominates: true, strictly: false
+// CHECK:         (3, 4): dominates: false, strictly: false
+// CHECK:         (4, 1): dominates: false, strictly: false
+// CHECK:         (4, 2): dominates: false, strictly: false
+// CHECK:         (4, 3): dominates: false, strictly: false
+// CHECK:         (4, 4): dominates: true, strictly: false
+// CHECK:       end running test 1 of 2 on dominance: dominance
+//
+// CHECK-LABEL: begin running test 2 of 2 on dominance: post_dominance
+// CHECK:         (1, 1): dominates: true, strictly: false
+// CHECK:         (1, 2): dominates: false, strictly: false
+// CHECK:         (1, 3): dominates: false, strictly: false
+// CHECK:         (1, 4): dominates: false, strictly: false
+// CHECK:         (2, 1): dominates: false, strictly: false
+// CHECK:         (2, 2): dominates: true, strictly: false
+// CHECK:         (2, 3): dominates: false, strictly: false
+// CHECK:         (2, 4): dominates: false, strictly: false
+// CHECK:         (3, 1): dominates: false, strictly: false
+// CHECK:         (3, 2): dominates: true, strictly: true
+// CHECK:         (3, 3): dominates: true, strictly: false
+// CHECK:         (3, 4): dominates: false, strictly: false
+// CHECK:         (4, 1): dominates: true, strictly: true
+// CHECK:         (4, 2): dominates: true, strictly: true
+// CHECK:         (4, 3): dominates: true, strictly: true
+// CHECK:         (4, 4): dominates: true, strictly: false
+// CHECK:       end running test 2 of 2 on dominance: post_dominance
+sil [ossa] @dominance : $@convention(thin) () -> () {
+bb0:
+  specify_test "dominance"
+  specify_test "post_dominance"
+  %1 =  integer_literal $Builtin.Int32, 1
+  cond_br undef, bb1, bb2
+
+bb1:
+  %2 =  integer_literal $Builtin.Int32, 2
+  %3 =  integer_literal $Builtin.Int32, 3
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  %4 =  integer_literal $Builtin.Int32, 4
   return undef : $()
 }
 

--- a/test/SILOptimizer/licm.sil
+++ b/test/SILOptimizer/licm.sil
@@ -41,6 +41,8 @@ struct Pair  {
 // globalArray
 sil_global @globalArray : $Storage
 
+sil_global public_external [let] @gg : $AnyObject
+
 // CHECK-LABEL: @memset
 
 // CHECK: bb0
@@ -1158,8 +1160,6 @@ struct State {
 // CHECK:     [[PRELOADADR:%.*]] = tuple_element_addr %{{.*}} : $*(Int64, Int64, Int64), 1
 // CHECK:     [[PRELOAD:%.*]] = load [[PRELOADADR]] : $*Int64
 // ...Split element 0
-// CHECK:     [[ELT0:%.*]] = load [[HOISTADR]] : $*Int64
-// CHECK:     [[HOISTVAL:%.*]] = struct_extract [[ELT0]] : $Int64, #Int64._value
 // CHECK:     [[HOISTADR2:%.*]] = tuple_element_addr %{{.*}} : $*(Int64, Int64, Int64), 0
 // CHECK:     [[ELT0B:%.*]] = load [[HOISTADR2]] : $*Int64
 // ...Split element 2
@@ -1168,6 +1168,8 @@ struct State {
 // ...Split State.singlevalue
 // CHECK:     [[SINGLEADR:%.*]] = struct_element_addr %{{.*}} : $*State, #State.singleValue
 // CHECK:     [[SINGLEVAL:%.*]] = load [[SINGLEADR]] : $*Int64
+// CHECK:     [[ELT0:%.*]] = load [[HOISTADR]] : $*Int64
+// CHECK:     [[HOISTVAL:%.*]] = struct_extract [[ELT0]] : $Int64, #Int64._value
 // ...Hoisted element 0
 // CHECK:     br bb1([[PRELOAD]] : $Int64)
 // ...Loop
@@ -1432,9 +1434,9 @@ bb3:
 // CHECK: bb0(%0 : $Int64, %1 : $Int64, %2 : $Builtin.RawPointer):
 // CHECK: [[ELT_1:%.*]] = tuple_element_addr %3 : $*(Int64, (Int64, Int64)), 1
 // CHECK: [[V1:%.*]] = load %4 : $*(Int64, Int64)
+// CHECK: [[ELT_0:%.*]] = tuple_element_addr %3 : $*(Int64, (Int64, Int64)), 0
 // CHECK: [[ARG0:%.*]] = tuple (%0 : $Int64, %0 : $Int64)
 // CHECK: [[ARG1:%.*]] = tuple (%1 : $Int64, %1 : $Int64)
-// CHECK: [[ELT_0:%.*]] = tuple_element_addr %3 : $*(Int64, (Int64, Int64)), 0
 // CHECK: [[ARG0_0:%.*]] = tuple_extract [[ARG0]] : $(Int64, Int64), 0
 // CHECK:   br bb1([[V1]] : $(Int64, Int64))
 // CHECK: bb1([[PHI:%.*]] : $(Int64, Int64)):
@@ -2456,3 +2458,34 @@ bb3:
   return %r : $()
 }
 
+// CHECK-LABEL: sil [ossa] @dont_speculatively_hoist_load_borrow :
+// CHECK:       bb2:
+// CHECK-NEXT:    load_borrow
+// CHECK-LABEL: } // end sil function 'dont_speculatively_hoist_load_borrow'
+sil [ossa] @dont_speculatively_hoist_load_borrow : $@convention(thin) () -> () {
+bb0:
+  %0 = global_addr @gg : $*AnyObject
+  br bb1
+
+bb1:
+  cond_br undef, bb2, bb3
+
+bb2:
+  %3 = load_borrow %0
+  fix_lifetime %3
+  end_borrow %3
+  br bb4
+
+bb3:
+  br bb4
+
+bb4:
+  cond_br undef, bb5, bb6
+
+bb5:
+  br bb1
+
+bb6:
+  %r = tuple ()
+  return %r 
+}


### PR DESCRIPTION
We have a check for this for non-scoped instructions but were missing it for scoped instructions, e.g. `load_borrow`.
In worst case this bug could lead to a miscompile, e.g. if the `load_borrow` is loading from a weak global inside an availability-checked if-branch.

This PR also includes some refactoring to make the code simpler.

https://github.com/swiftlang/swift/issues/90916
rdar://183032640