### PR TITLE
[cxx-interop] Emit metadata scaffolding for `CChar32`, `Float16`, `Int128`, `UInt128`

### DIFF
--- a/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
+++ b/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
@@ -23,6 +23,7 @@
 #include "clang/Basic/AddressSpaces.h"
 #include "clang/Basic/TargetInfo.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
 
 using namespace swift;
 
@@ -153,7 +154,7 @@ static void printTypeMetadataResponseType(SwiftToClangInteropContext &ctx,
 void printPrimitiveGenericTypeTraits(raw_ostream &os, ASTContext &astContext,
                                      PrimitiveTypeMapping &typeMapping,
                                      bool isCForwardDefinition) {
-  Type supportedPrimitiveTypes[] = {
+  SmallVector<Type, 16> supportedPrimitiveTypes = {
       astContext.getBoolType(),
 
       // Primitive integer, C integer and Int/UInt mappings.
@@ -168,10 +169,7 @@ void printPrimitiveGenericTypeTraits(raw_ostream &os, ASTContext &astContext,
       // Pointer types.
       // FIXME: support raw pointers?
       astContext.getOpaquePointerType(),
-
-      astContext.getIntType(), astContext.getUIntType()};
-
-  auto primTypesArray = llvm::ArrayRef(supportedPrimitiveTypes);
+  };
 
   // Ensure that `long` and `unsigned long` are treated as valid
   // generic Swift types (`Int` and `UInt`) on platforms
@@ -183,8 +181,32 @@ void printPrimitiveGenericTypeTraits(raw_ostream &os, ASTContext &astContext,
       clangTI.getPtrDiffType(clang::LangAS::Default) == clang::TransferrableTargetInfo::SignedLong;
   bool isInt64Long =
       clangTI.getInt64Type() == clang::TransferrableTargetInfo::SignedLong;
-  if (!(isSwiftIntLong && !isInt64Long))
-    primTypesArray = primTypesArray.drop_back(2);
+  if (isSwiftIntLong && !isInt64Long) {
+    supportedPrimitiveTypes.push_back(astContext.getIntType());
+    supportedPrimitiveTypes.push_back(astContext.getUIntType());
+  }
+
+  // The following Swift types bridge to C++ types that aren't available on
+  // every target. Only emit trait specializations for them when the target
+  // supports the underlying C++ type, so that the generated header remains
+  // compilable everywhere while still supporting these types where possible.
+  auto stdlibModule = astContext.getStdlibModule();
+
+  if (Type unicodeScalar =
+          astContext.getNamedSwiftType(stdlibModule, "CChar32"))
+    supportedPrimitiveTypes.push_back(unicodeScalar);
+
+  if (clangTI.hasInt128Type()) {
+    if (Type int128Ty = astContext.getInt128Type())
+      supportedPrimitiveTypes.push_back(int128Ty);
+    if (Type uint128Ty = astContext.getUInt128Type())
+      supportedPrimitiveTypes.push_back(uint128Ty);
+  }
+
+  if (clangTI.hasFloat16Type()) {
+    if (Type float16 = astContext.getNamedSwiftType(stdlibModule, "Float16"))
+      supportedPrimitiveTypes.push_back(float16);
+  }
 
   // We do not have metadata for primitive types in Embedded Swift.
   // As a result, the following features are not supported with primitive types in this mode:
@@ -194,7 +216,7 @@ void printPrimitiveGenericTypeTraits(raw_ostream &os, ASTContext &astContext,
   // - Metadata source parameter
   bool embedded = astContext.LangOpts.hasFeature(Feature::Embedded);
 
-  for (Type type : primTypesArray) {
+  for (Type type : supportedPrimitiveTypes) {
     auto typeInfo = *typeMapping.getKnownCxxTypeInfo(
         type->getNominalOrBoundGenericNominal());
 

--- a/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx-darwin64bit.swift
+++ b/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx-darwin64bit.swift
@@ -35,6 +35,14 @@
 // CHECK-NEXT: SWIFT_IMPORT_STDLIB_SYMBOL extern size_t $sSiN;
 // CHECK-NEXT: // type metadata address for UInt.
 // CHECK-NEXT: SWIFT_IMPORT_STDLIB_SYMBOL extern size_t $sSuN;
+// CHECK-NEXT: // type metadata address for CChar32.
+// CHECK-NEXT: SWIFT_IMPORT_STDLIB_SYMBOL extern size_t $ss7UnicodeO6ScalarVN;
+// CHECK-NEXT: // type metadata address for Int128.
+// CHECK-NEXT: SWIFT_IMPORT_STDLIB_SYMBOL extern size_t $ss6Int128VN;
+// CHECK-NEXT: // type metadata address for UInt128.
+// CHECK-NEXT: SWIFT_IMPORT_STDLIB_SYMBOL extern size_t $ss7UInt128VN;
+// CHECK-NEXT: // type metadata address for Float16.
+// CHECK-NEXT: SWIFT_IMPORT_STDLIB_SYMBOL extern size_t $ss7Float16VN;
 // CHECK-EMPTY:
 // CHECK-NEXT: #ifdef __cplusplus
 // CHECK-NEXT: }
@@ -66,6 +74,46 @@
 // CHECK-NEXT: struct TypeMetadataTrait<swift::UInt> {
 // CHECK-NEXT:   static SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
 // CHECK-NEXT:     return &_impl::$sSuN;
+// CHECK-NEXT:   }
+// CHECK-NEXT: };
+// CHECK-EMPTY:
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const constexpr bool isUsableInGenericContext<char32_t> = true;
+// CHECK-EMPTY:
+// CHECK-NEXT: template<>
+// CHECK-NEXT: struct TypeMetadataTrait<char32_t> {
+// CHECK-NEXT:   static SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:     return &_impl::$ss7UnicodeO6ScalarVN;
+// CHECK-NEXT:   }
+// CHECK-NEXT: };
+// CHECK-EMPTY:
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const constexpr bool isUsableInGenericContext<__int128> = true;
+// CHECK-EMPTY:
+// CHECK-NEXT: template<>
+// CHECK-NEXT: struct TypeMetadataTrait<__int128> {
+// CHECK-NEXT:   static SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:     return &_impl::$ss6Int128VN;
+// CHECK-NEXT:   }
+// CHECK-NEXT: };
+// CHECK-EMPTY:
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const constexpr bool isUsableInGenericContext<unsigned __int128> = true;
+// CHECK-EMPTY:
+// CHECK-NEXT: template<>
+// CHECK-NEXT: struct TypeMetadataTrait<unsigned __int128> {
+// CHECK-NEXT:   static SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:     return &_impl::$ss7UInt128VN;
+// CHECK-NEXT:   }
+// CHECK-NEXT: };
+// CHECK-EMPTY:
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const constexpr bool isUsableInGenericContext<_Float16> = true;
+// CHECK-EMPTY:
+// CHECK-NEXT: template<>
+// CHECK-NEXT: struct TypeMetadataTrait<_Float16> {
+// CHECK-NEXT:   static SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:     return &_impl::$ss7Float16VN;
 // CHECK-NEXT:   }
 // CHECK-NEXT: };
 // CHECK-EMPTY:

--- a/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx.swift
@@ -223,6 +223,17 @@
 // CHECK-NEXT:   }
 // CHECK-NEXT: };
 // CHECK-EMPTY:
+
+// Target-conditional swift::Int/swift::UInt blocks may appear here.
+
+// CHECK:      inline const constexpr bool isUsableInGenericContext<char32_t> = true;
+// CHECK-EMPTY:
+// CHECK-NEXT: template<>
+// CHECK-NEXT: struct TypeMetadataTrait<char32_t> {
+// CHECK-NEXT:   static SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:     return &_impl::$ss7UnicodeO6ScalarVN;
+// CHECK-NEXT:   }
+// CHECK-NEXT: };
 // CHECK: #pragma clang diagnostic pop
 // CHECK-EMPTY:
 // CHECK-NEXT: } // namespace swift

--- a/test/Interop/SwiftToCxx/stdlib/swift-array-optional-of-primitives-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/swift-array-optional-of-primitives-in-cxx.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name UsePrimitives -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/uses.h
+// RUN: %FileCheck %s < %t/uses.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/uses.h -Wno-reserved-identifier -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
+
+// REQUIRES: PTRSIZE=64
+
+public struct UsesUnicodeScalar {
+    public var scalars: [Unicode.Scalar]
+    public var maybeScalar: Unicode.Scalar?
+}
+
+// The trait specializations must be emitted so that the swift::Array /
+// swift::Optional instantiations below satisfy their internal static_assert.
+
+// CHECK: inline const constexpr bool isUsableInGenericContext<char32_t> = true;
+
+// CHECK: swift::Array<char32_t> getScalars() const
+// CHECK: swift::Optional<char32_t> getMaybeScalar() const


### PR DESCRIPTION
The generated reverse interop C++ header contains metadata accessors for certain primitive Swift types that have an equivalent primitive C++ type. Those accessors were already emitted for `(U)Int*` types, `Float`, `Double`, etc.

This adds metadata accessors for more such types.

Fixes an issue where the generated C++ header that refers to these types would trigger a `static_assert`.

rdar://183028476

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
