### PR TITLE
[cxx-interop] Emit noescape attributes in the reverse interop header

### DIFF
--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -213,11 +213,20 @@ private:
   const clang::TagDecl *typeDecl;
 };
 
+/// Describes how a parameter should be printed: whether it is `inout`, and
+/// whether the reference/pointer printed for it can be marked SWIFT_NOESCAPE
+/// (i.e. it is a value-type parameter whose reference cannot escape the
+/// callee).
+struct ParamTypeInfo {
+  bool isInOutParam = false;
+  bool cannotEscape = false;
+};
+
 // Prints types in the C function signature that corresponds to the
 // native Swift function/method.
 class CFunctionSignatureTypePrinter
     : public TypeVisitor<CFunctionSignatureTypePrinter, ClangRepresentation,
-                         std::optional<OptionalTypeKind>, bool>,
+                         std::optional<OptionalTypeKind>, ParamTypeInfo>,
       private ClangSyntaxPrinter {
 public:
   CFunctionSignatureTypePrinter(
@@ -234,20 +243,26 @@ public:
         moduleContext(moduleContext), declPrinter(declPrinter),
         typeUseKind(typeUseKind) {}
 
-  void printInoutTypeModifier() {
+  void printNoEscapeAttrIfNeeded(bool cannotEscape) {
+    if (cannotEscape)
+      os << " SWIFT_NOESCAPE";
+  }
+
+  void printInoutTypeModifier(bool cannotEscape = false) {
     os << (languageMode == swift::OutputLanguageMode::Cxx ? " &"
                                                           : " * _Nonnull");
+    printNoEscapeAttrIfNeeded(cannotEscape);
   }
 
   bool printIfKnownSimpleType(const TypeDecl *typeDecl,
                               std::optional<OptionalTypeKind> optionalKind,
-                              bool isInOutParam) {
+                              ParamTypeInfo paramInfo) {
     auto knownTypeInfo = getKnownTypeInfo(typeDecl, typeMapping, languageMode);
     if (!knownTypeInfo)
       return false;
     bool shouldPrintOptional = optionalKind && *optionalKind != OTK_None &&
                                !knownTypeInfo->canBeNullable;
-    if (!isInOutParam && shouldPrintOptional &&
+    if (!paramInfo.isInOutParam && shouldPrintOptional &&
         typeUseKind == FunctionSignatureTypeUse::ParamType)
       os << "const ";
     printOptional(shouldPrintOptional ? optionalKind : std::nullopt, [&]() {
@@ -256,11 +271,13 @@ public:
         printNullability(optionalKind);
       }
     });
-    if (!isInOutParam && shouldPrintOptional &&
-        typeUseKind == FunctionSignatureTypeUse::ParamType)
+    if (!paramInfo.isInOutParam && shouldPrintOptional &&
+        typeUseKind == FunctionSignatureTypeUse::ParamType) {
       os << '&';
-    if (isInOutParam)
-      printInoutTypeModifier();
+      printNoEscapeAttrIfNeeded(paramInfo.cannotEscape);
+    }
+    if (paramInfo.isInOutParam)
+      printInoutTypeModifier(paramInfo.cannotEscape);
     return true;
   }
 
@@ -276,7 +293,7 @@ public:
 
   ClangRepresentation visitType(TypeBase *Ty,
                                 std::optional<OptionalTypeKind> optionalKind,
-                                bool isInOutParam) {
+                                ParamTypeInfo paramInfo) {
     assert(Ty->getDesugaredType() == Ty && "unhandled sugared type");
     os << "/* ";
     Ty->print(os);
@@ -287,7 +304,7 @@ public:
   ClangRepresentation
   visitExistentialType(ExistentialType *ty,
                        std::optional<OptionalTypeKind> optionalKind,
-                       bool isInOutParam) {
+                       ParamTypeInfo paramInfo) {
     bool hasSwiftSuperClass = false;
     if (auto superClass = ty->getExistentialLayout()
           .getExplicitSuperclassOrProtocolSuperclass()) {
@@ -296,19 +313,19 @@ public:
     }
     if (ty->isObjCExistentialType() && !hasSwiftSuperClass) {
       declPrinter.withOutputStream(os).print(ty, optionalKind);
-      if (isInOutParam) {
+      if (paramInfo.isInOutParam) {
         os << " __strong";
-        printInoutTypeModifier();
+        printInoutTypeModifier(paramInfo.cannotEscape);
       }
       return ClangRepresentation::objcxxonly;
     }
 
-    return visitPart(ty->getConstraintType(), optionalKind, isInOutParam);
+    return visit(ty->getConstraintType(), optionalKind, paramInfo);
   }
 
   ClangRepresentation
   visitTupleType(TupleType *TT, std::optional<OptionalTypeKind> optionalKind,
-                 bool isInOutParam) {
+                 ParamTypeInfo paramInfo) {
     if (TT->getNumElements() > 0)
       // FIXME: Handle non-void type.
       return ClangRepresentation::unsupported;
@@ -322,25 +339,24 @@ public:
   ClangRepresentation
   visitTypeAliasType(TypeAliasType *aliasTy,
                      std::optional<OptionalTypeKind> optionalKind,
-                     bool isInOutParam) {
+                     ParamTypeInfo paramInfo) {
     const TypeAliasDecl *alias = aliasTy->getDecl();
-    if (printIfKnownSimpleType(alias, optionalKind, isInOutParam))
+    if (printIfKnownSimpleType(alias, optionalKind, paramInfo))
       return ClangRepresentation::representable;
 
-    return visitSugarType(aliasTy, optionalKind, isInOutParam);
+    return visitSugarType(aliasTy, optionalKind, paramInfo);
   }
 
   ClangRepresentation
   visitSugarType(SugarType *sugarTy,
                  std::optional<OptionalTypeKind> optionalKind,
-                 bool isInOutParam) {
-    return visitPart(sugarTy->getSinglyDesugaredType(), optionalKind,
-                     isInOutParam);
+                 ParamTypeInfo paramInfo) {
+    return visit(sugarTy->getSinglyDesugaredType(), optionalKind, paramInfo);
   }
 
   ClangRepresentation
   visitClassType(ClassType *CT, std::optional<OptionalTypeKind> optionalKind,
-                 bool isInOutParam) {
+                 ParamTypeInfo paramInfo) {
     auto *cd = CT->getDecl();
     if (cd->hasClangNode()) {
       const auto *clangDecl = cd->getClangDecl();
@@ -357,10 +373,10 @@ public:
       os << (alreadyPointer ? " " : " *")
          << (!optionalKind || *optionalKind == OTK_None ? "_Nonnull"
                                                         : "_Nullable");
-      if (isInOutParam) {
+      if (paramInfo.isInOutParam) {
         if (isa<clang::ObjCContainerDecl>(cd->getClangDecl()))
           os << " __strong";
-        printInoutTypeModifier();
+        printInoutTypeModifier(paramInfo.cannotEscape);
       }
       // FIXME: Mark that this is only ObjC representable.
       return ClangRepresentation::representable;
@@ -370,33 +386,38 @@ public:
       os << "void * "
          << (!optionalKind || *optionalKind == OTK_None ? "_Nonnull"
                                                         : "_Nullable");
-      if (isInOutParam)
+      if (paramInfo.isInOutParam) {
         os << " * _Nonnull";
+        printNoEscapeAttrIfNeeded(paramInfo.cannotEscape);
+      }
       return ClangRepresentation::representable;
     }
-    if (typeUseKind == FunctionSignatureTypeUse::ParamType && !isInOutParam)
+    if (typeUseKind == FunctionSignatureTypeUse::ParamType &&
+        !paramInfo.isInOutParam)
       os << "const ";
     printOptional(optionalKind, [&]() {
       ClangSyntaxPrinter(CT->getASTContext(), os)
           .printPrimaryCxxTypeName(cd, moduleContext);
     });
-    if (typeUseKind == FunctionSignatureTypeUse::ParamType)
+    if (typeUseKind == FunctionSignatureTypeUse::ParamType) {
       os << "&";
+      printNoEscapeAttrIfNeeded(paramInfo.cannotEscape);
+    }
     return ClangRepresentation::representable;
   }
 
   ClangRepresentation
   visitEnumType(EnumType *ET, std::optional<OptionalTypeKind> optionalKind,
-                bool isInOutParam) {
+                ParamTypeInfo paramInfo) {
     return visitValueType(ET, ET->getNominalOrBoundGenericNominal(),
-                          optionalKind, isInOutParam);
+                          optionalKind, paramInfo);
   }
 
   ClangRepresentation
   visitStructType(StructType *ST, std::optional<OptionalTypeKind> optionalKind,
-                  bool isInOutParam) {
+                  ParamTypeInfo paramInfo) {
     return visitValueType(ST, ST->getNominalOrBoundGenericNominal(),
-                          optionalKind, isInOutParam);
+                          optionalKind, paramInfo);
   }
 
   ClangRepresentation visitGenericArgs(ArrayRef<Type> genericArgs) {
@@ -409,9 +430,8 @@ public:
     llvm::SaveAndRestore<decltype(modifiersDelegate)> modReset(
         modifiersDelegate, emptyModifiersDelegate);
     ClangRepresentation result = ClangRepresentation::representable;
-    llvm::interleaveComma(genericArgs, os, [&](Type t) {
-      result.merge(visitPart(t, std::nullopt, false));
-    });
+    llvm::interleaveComma(
+        genericArgs, os, [&](Type t) { result.merge(visit(t, std::nullopt)); });
     os << '>';
     return result;
   }
@@ -419,11 +439,11 @@ public:
   ClangRepresentation
   visitValueType(TypeBase *type, const NominalTypeDecl *decl,
                  std::optional<OptionalTypeKind> optionalKind,
-                 bool isInOutParam, ArrayRef<Type> genericArgs = {}) {
+                 ParamTypeInfo paramInfo, ArrayRef<Type> genericArgs = {}) {
     assert(isa<StructDecl>(decl) || isa<EnumDecl>(decl));
 
     // Handle known type names.
-    if (printIfKnownSimpleType(decl, optionalKind, isInOutParam))
+    if (printIfKnownSimpleType(decl, optionalKind, paramInfo))
       return ClangRepresentation::representable;
     if (!declPrinter.shouldInclude(decl))
       return ClangRepresentation::unsupported; // FIXME: propagate why it's not
@@ -438,16 +458,18 @@ public:
       if (!handler.isRepresentable())
         return ClangRepresentation::unsupported;
       if (typeUseKind == FunctionSignatureTypeUse::ParamType &&
-          !isInOutParam)
+          !paramInfo.isInOutParam)
         os << "const ";
       printOptional(optionalKind, [&]() { handler.printTypeName(decl->getASTContext(), os); });
-      if (typeUseKind == FunctionSignatureTypeUse::ParamType)
+      if (typeUseKind == FunctionSignatureTypeUse::ParamType) {
         os << '&';
+        printNoEscapeAttrIfNeeded(paramInfo.cannotEscape);
+      }
       return ClangRepresentation::representable;
     }
 
     if (typeUseKind == FunctionSignatureTypeUse::ParamType) {
-      if (!isInOutParam) {
+      if (!paramInfo.isInOutParam) {
         os << "const ";
       }
       ClangRepresentation result = ClangRepresentation::representable;
@@ -456,6 +478,7 @@ public:
         result = visitGenericArgs(genericArgs);
       });
       os << '&';
+      printNoEscapeAttrIfNeeded(paramInfo.cannotEscape);
       return result;
     }
 
@@ -477,7 +500,7 @@ public:
   std::optional<ClangRepresentation>
   printIfKnownGenericStruct(const BoundGenericStructType *BGT,
                             std::optional<OptionalTypeKind> optionalKind,
-                            bool isInOutParam) {
+                            ParamTypeInfo paramInfo) {
     auto bgsTy = Type(const_cast<BoundGenericStructType *>(BGT));
     bool isConst;
     if (bgsTy->isUnsafePointer())
@@ -502,7 +525,7 @@ public:
       if (isKnownCType(arg, typeMapping, BGT->getASTContext()) ==
           KnownTypeKind::Unknown)
         return ClangRepresentation(ClangRepresentation::unsupported);
-      auto partRepr = visitPart(arg, OTK_None, /*isInOutParam=*/false);
+      auto partRepr = visit(arg, OTK_None);
       if (partRepr.isUnsupported())
         return partRepr;
     }
@@ -510,40 +533,39 @@ public:
       os << " const";
     os << " *";
     printNullability(optionalKind);
-    if (isInOutParam)
-      printInoutTypeModifier();
+    if (paramInfo.isInOutParam)
+      printInoutTypeModifier(paramInfo.cannotEscape);
     return ClangRepresentation(ClangRepresentation::representable);
   }
 
   ClangRepresentation
   visitBoundGenericStructType(BoundGenericStructType *BGT,
                               std::optional<OptionalTypeKind> optionalKind,
-                              bool isInOutParam) {
-    if (auto result =
-            printIfKnownGenericStruct(BGT, optionalKind, isInOutParam))
+                              ParamTypeInfo paramInfo) {
+    if (auto result = printIfKnownGenericStruct(BGT, optionalKind, paramInfo))
       return *result;
-    return visitValueType(BGT, BGT->getDecl(), optionalKind, isInOutParam,
+    return visitValueType(BGT, BGT->getDecl(), optionalKind, paramInfo,
                           BGT->getGenericArgs());
   }
 
   ClangRepresentation
   visitBoundGenericEnumType(BoundGenericEnumType *BGT,
                             std::optional<OptionalTypeKind> optionalKind,
-                            bool isInOutParam) {
+                            ParamTypeInfo paramInfo) {
     if (optionalKind == OTK_None) {
       if (auto objTy = BGT->getOptionalObjectType())
-        return visitPart(objTy, OTK_Optional, isInOutParam);
+        return visit(objTy, OTK_Optional, paramInfo);
     }
-    return visitValueType(BGT, BGT->getDecl(), optionalKind, isInOutParam,
+    return visitValueType(BGT, BGT->getDecl(), optionalKind, paramInfo,
                           BGT->getGenericArgs());
   }
 
   ClangRepresentation
   visitGenericTypeParamType(GenericTypeParamType *genericTpt,
                             std::optional<OptionalTypeKind> optionalKind,
-                            bool isInOutParam) {
+                            ParamTypeInfo paramInfo) {
     bool isParam = typeUseKind == FunctionSignatureTypeUse::ParamType;
-    if (isParam && !isInOutParam)
+    if (isParam && !paramInfo.isInOutParam)
       os << "const ";
 
     if (languageMode != OutputLanguageMode::Cxx) {
@@ -559,31 +581,33 @@ public:
       ClangSyntaxPrinter(genericTpt->getASTContext(), os).printGenericTypeParamTypeName(genericTpt);
     });
     // Pass a reference to the template type.
-    if (isParam)
+    if (isParam) {
       os << '&';
+      printNoEscapeAttrIfNeeded(paramInfo.cannotEscape);
+    }
     return ClangRepresentation::representable;
   }
 
   ClangRepresentation
   visitDynamicSelfType(DynamicSelfType *ds,
                        std::optional<OptionalTypeKind> optionalKind,
-                       bool isInOutParam) {
-    return visitPart(ds->getSelfType(), optionalKind, isInOutParam);
+                       ParamTypeInfo paramInfo) {
+    return visit(ds->getSelfType(), optionalKind, paramInfo);
   }
 
   ClangRepresentation
   visitMetatypeType(MetatypeType *mt,
                     std::optional<OptionalTypeKind> optionalKind,
-                    bool isInOutParam) {
+                    ParamTypeInfo paramInfo) {
     if (typeUseKind == FunctionSignatureTypeUse::TypeReference)
-      return visitPart(mt->getInstanceType(), optionalKind, isInOutParam);
+      return visit(mt->getInstanceType(), optionalKind, paramInfo);
     return ClangRepresentation::unsupported;
   }
 
-  ClangRepresentation visitPart(Type Ty,
-                                std::optional<OptionalTypeKind> optionalKind,
-                                bool isInOutParam) {
-    return TypeVisitor::visit(Ty, optionalKind, isInOutParam);
+  ClangRepresentation visit(Type Ty,
+                            std::optional<OptionalTypeKind> optionalKind,
+                            ParamTypeInfo paramInfo = {}) {
+    return TypeVisitor::visit(Ty, optionalKind, paramInfo);
   }
 
 private:
@@ -597,6 +621,26 @@ private:
   FunctionSignatureTypeUse typeUseKind;
 };
 
+/// Returns true if a reference/pointer printed for a parameter of the given
+/// object type cannot escape the callee, so it can be marked SWIFT_NOESCAPE.
+static bool paramTypeCannotEscape(Type objectType) {
+  objectType = objectType->lookThroughAllOptionalTypes();
+  // Generic parameters / archetypes could be instantiated with a class, and
+  // existentials could hold one, so treat them conservatively as escapable.
+  if (objectType->isTypeParameter() || objectType->is<ArchetypeType>() ||
+      objectType->isExistentialType())
+    return false;
+  // A class (reference-semantics) parameter can be retained and stored by the
+  // callee regardless of its ownership, so its pointer may escape.
+  return !objectType->isAnyClassReferenceType();
+}
+
+/// Computes how \p param should be printed: whether it is `inout`, and whether
+/// the reference/pointer printed for it can be marked SWIFT_NOESCAPE.
+static ParamTypeInfo getParamTypeInfo(const ParamDecl &param) {
+  return {param.isInOut(), paramTypeCannotEscape(param.getInterfaceType())};
+}
+
 } // end namespace
 
 ClangRepresentation
@@ -608,7 +652,7 @@ DeclAndTypeClangFunctionPrinter::printClangFunctionReturnType(
       CFunctionSignatureTypePrinterModifierDelegate(), moduleContext,
       declPrinter, FunctionSignatureTypeUse::ReturnType);
   // Param for indirect return cannot be marked as inout
-  return typePrinter.visit(ty, optKind, /*isInOutParam=*/false);
+  return typePrinter.visit(ty, optKind);
 }
 
 static void addABIRecordToTypeEncoding(llvm::raw_ostream &typeEncodingOS,
@@ -837,15 +881,14 @@ ClangRepresentation DeclAndTypeClangFunctionPrinter::printFunctionSignature(
   // FIXME: Might need a PrintMultiPartType here.
   auto print =
       [&, this](Type ty, std::optional<OptionalTypeKind> optionalKind,
-                StringRef name, bool isInOutParam,
+                StringRef name, ParamTypeInfo paramInfo = {},
                 CFunctionSignatureTypePrinterModifierDelegate delegate = {})
       -> ClangRepresentation {
-    // FIXME: add support for noescape and PrintMultiPartType,
-    // see DeclAndTypePrinter::print.
+    // FIXME: add support for PrintMultiPartType, see DeclAndTypePrinter::print.
     CFunctionSignatureTypePrinter typePrinter(
         functionSignatureOS, cPrologueOS, typeMapping, outputLang,
         interopContext, delegate, emittedModule, declPrinter);
-    auto result = typePrinter.visit(ty, optionalKind, isInOutParam);
+    auto result = typePrinter.visit(ty, optionalKind, paramInfo);
 
     if (!name.empty()) {
       functionSignatureOS << ' ';
@@ -880,8 +923,7 @@ ClangRepresentation DeclAndTypeClangFunctionPrinter::printFunctionSignature(
           llvm::nulls(), llvm::nulls(), typeMapping, OutputLanguageMode::Cxx,
           interopContext, CFunctionSignatureTypePrinterModifierDelegate(),
           emittedModule, declPrinter, FunctionSignatureTypeUse::ReturnType);
-      if (resultingRepresentation
-              .merge(typePrinter.visit(objTy, optKind, /*isInOutParam=*/false))
+      if (resultingRepresentation.merge(typePrinter.visit(objTy, optKind))
               .isUnsupported())
         return resultingRepresentation;
     }
@@ -957,8 +999,8 @@ ClangRepresentation DeclAndTypeClangFunctionPrinter::printFunctionSignature(
           interopContext, CFunctionSignatureTypePrinterModifierDelegate(),
           emittedModule, declPrinter, FunctionSignatureTypeUse::ParamType);
       if (resultingRepresentation
-              .merge(typePrinter.visit(objTy, optKind,
-                                       /*isInOutParam=*/param->isInOut()))
+              .merge(
+                  typePrinter.visit(objTy, optKind, getParamTypeInfo(*param)))
               .isUnsupported())
         return resultingRepresentation;
     }
@@ -989,7 +1031,7 @@ ClangRepresentation DeclAndTypeClangFunctionPrinter::printFunctionSignature(
           functionSignatureOS, cPrologueOS, typeMapping, outputLang,
           interopContext, CFunctionSignatureTypePrinterModifierDelegate(),
           emittedModule, declPrinter);
-      auto s = typePrinter.visit(ty, optionalKind, param.isInOut());
+      auto s = typePrinter.visit(ty, optionalKind, getParamTypeInfo(param));
       resultingRepresentation.merge(s);
     };
     signature.visitParameterList(
@@ -1096,7 +1138,7 @@ ClangRepresentation DeclAndTypeClangFunctionPrinter::printFunctionSignature(
             os << "_" << paramIndex;
           }
           resultingRepresentation.merge(
-              print(objTy, argKind, paramName, param->isInOut()));
+              print(objTy, argKind, paramName, getParamTypeInfo(*param)));
           ++paramIndex;
         });
     if (resultingRepresentation.isUnsupported()) {
@@ -1131,7 +1173,7 @@ void DeclAndTypeClangFunctionPrinter::printTypeImplTypeSpecifier(
       os, cPrologueOS, typeMapping, OutputLanguageMode::Cxx, interopContext,
       delegate, moduleContext, declPrinter,
       FunctionSignatureTypeUse::TypeReference);
-  auto result = typePrinter.visit(type, std::nullopt, /*isInOut=*/false);
+  auto result = typePrinter.visit(type, std::nullopt);
   assert(!result.isUnsupported());
 }
 
@@ -1382,8 +1424,7 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
         typeOS, cPrologueOS, typeMapping, OutputLanguageMode::Cxx,
         interopContext, CFunctionSignatureTypePrinterModifierDelegate(),
         moduleContext, declPrinter, FunctionSignatureTypeUse::TypeReference);
-    auto result = typePrinter.visit(param.getInterfaceType(), OTK_None,
-                                    /*isInOutParam=*/false);
+    auto result = typePrinter.visit(param.getInterfaceType(), OTK_None);
     assert(!result.isUnsupported());
     typeOS.flush();
 
@@ -1448,8 +1489,7 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
               interopContext, CFunctionSignatureTypePrinterModifierDelegate(),
               moduleContext, declPrinter,
               FunctionSignatureTypeUse::TypeReference);
-          auto result = typePrinter.visit(param.getInterfaceType(), OTK_None,
-                                          /*isInOutParam=*/false);
+          auto result = typePrinter.visit(param.getInterfaceType(), OTK_None);
           assert(!result.isUnsupported());
           os << ">::getTypeMetadata()";
           return;
@@ -1507,8 +1547,7 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
               interopContext, delegate, moduleContext, declPrinter,
               FunctionSignatureTypeUse::TypeReference);
           auto result =
-              typePrinter.visit(metadataSrcParam.getType(), std::nullopt,
-                                /*isInOut=*/false);
+              typePrinter.visit(metadataSrcParam.getType(), std::nullopt);
           assert(!result.isUnsupported());
           os << ">::getTypeMetadata()";
         },
@@ -1863,8 +1902,7 @@ void DeclAndTypeClangFunctionPrinter::printCustomCxxFunction(
         emittedModule, declPrinter,
         NeedsReturnTypes ? FunctionSignatureTypeUse::ReturnType
                          : FunctionSignatureTypeUse::ParamType);
-    auto support =
-        typePrinter.visit(objectType, optKind, /* isInOutParam */ false);
+    auto support = typePrinter.visit(objectType, optKind);
     (void)support;
     assert(!support.isUnsupported());
     types.insert({type, typeOS.str()});
@@ -1875,7 +1913,7 @@ void DeclAndTypeClangFunctionPrinter::printCustomCxxFunction(
         typeRefOS, cPrologueOS, typeMapping, OutputLanguageMode::Cxx,
         interopContext, CFunctionSignatureTypePrinterModifierDelegate(),
         emittedModule, declPrinter, FunctionSignatureTypeUse::TypeReference);
-    typeRefPrinter.visit(objectType, optKind, /* isInOutParam */ false);
+    typeRefPrinter.visit(objectType, optKind);
     typeRefs.insert({type, typeRefOS.str()});
   }
 
@@ -1915,8 +1953,7 @@ ClangRepresentation DeclAndTypeClangFunctionPrinter::getTypeRepresentation(
       llvm::nulls(), llvm::nulls(), typeMapping, OutputLanguageMode::Cxx,
       interopContext, delegate, emittedModule, declPrinter,
       FunctionSignatureTypeUse::TypeReference);
-  auto result = typePrinter.visit(ty, OptionalTypeKind::OTK_None,
-                                  /*isInOutParam=*/false);
+  auto result = typePrinter.visit(ty, OptionalTypeKind::OTK_None);
   declPrinter.typeRepresentations[ty] = result;
   return result;
 }
@@ -1928,7 +1965,7 @@ void DeclAndTypeClangFunctionPrinter::printTypeName(
       os, cPrologueOS, typeMapping, OutputLanguageMode::Cxx, interopContext,
       delegate, moduleContext, declPrinter,
       FunctionSignatureTypeUse::TypeReference);
-  typePrinter.visit(ty, std::nullopt, /*isInOut=*/false);
+  typePrinter.visit(ty, std::nullopt);
 }
 
 void DeclAndTypeClangFunctionPrinter::printCxxReturnsRetainedAttribute(

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
@@ -311,17 +311,17 @@ public struct Strct {
 // CHECK-NEXT:   _impl::$s8UseCxxTy20takeImmortalTemplateyySo2nsO0028ImmortalTemplateCInt_jBAGgnbVF(x);
 // CHECK-NEXT: }
 
-// CHECK: SWIFT_INLINE_THUNK void takeNonTrivial2(const ns::NonTrivialTemplate<ns::TrivialinNS>& x) noexcept SWIFT_SYMBOL({{.*}}) {
+// CHECK: SWIFT_INLINE_THUNK void takeNonTrivial2(const ns::NonTrivialTemplate<ns::TrivialinNS>& SWIFT_NOESCAPE x) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT:   _impl::$s8UseCxxTy15takeNonTrivial2yySo2nsO0042NonTrivialTemplatensTrivialinNS_HlGFlenawcVF(swift::_impl::getOpaquePointer(x));
 // CHECK-NEXT: }
 
-// CHECK: SWIFT_INLINE_THUNK void takeSimpleScopedEnum(const SimpleScopedEnum& x) noexcept SWIFT_SYMBOL({{.*}}) {
+// CHECK: SWIFT_INLINE_THUNK void takeSimpleScopedEnum(const SimpleScopedEnum& SWIFT_NOESCAPE x) noexcept SWIFT_SYMBOL({{.*}}) {
 
-// CHECK: SWIFT_INLINE_THUNK void takeTrivial(const Trivial& x) noexcept SWIFT_SYMBOL({{.*}}) {
+// CHECK: SWIFT_INLINE_THUNK void takeTrivial(const Trivial& SWIFT_NOESCAPE x) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT:   _impl::$s8UseCxxTy11takeTrivialyySo0E0VF(UseCxxTy::_impl::swift_interop_passDirect_UseCxxTy_uint32_t_0_4(reinterpret_cast<const char *>(swift::_impl::getOpaquePointer(x))));
 // CHECK-NEXT: }
 
-// CHECK: SWIFT_INLINE_THUNK void takeTrivialInout(Trivial& x) noexcept SWIFT_SYMBOL({{.*}}) {
+// CHECK: SWIFT_INLINE_THUNK void takeTrivialInout(Trivial& SWIFT_NOESCAPE x) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT:   _impl::$s8UseCxxTy16takeTrivialInoutyySo0E0VzF(swift::_impl::getOpaquePointer(x));
 // CHECK-NEXT: }
 

--- a/test/Interop/CxxToSwiftToCxx/bridge-noncopyable-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/bridge-noncopyable-cxx-struct-back-to-cxx.swift
@@ -43,10 +43,10 @@ public func returnNonCopyable() -> NonCopyable { return NonCopyable() }
 // CHECK: SWIFT_INLINE_THUNK NonCopyableNonTrivial returnNonCopyableNonTrivial() noexcept {{.*}}{
 public func returnNonCopyableNonTrivial() -> NonCopyableNonTrivial { return NonCopyableNonTrivial() }
 
-// CHECK: SWIFT_INLINE_THUNK void takeNonCopyable(const NonCopyable& x) noexcept {{.*}}{
+// CHECK: SWIFT_INLINE_THUNK void takeNonCopyable(const NonCopyable& SWIFT_NOESCAPE x) noexcept {{.*}}{
 public func takeNonCopyable(_ x: borrowing NonCopyable) {}
 
-// CHECK: SWIFT_INLINE_THUNK void takeNonCopyableNonTrivial(const NonCopyableNonTrivial& x) noexcept {{.*}}{
+// CHECK: SWIFT_INLINE_THUNK void takeNonCopyableNonTrivial(const NonCopyableNonTrivial& SWIFT_NOESCAPE x) noexcept {{.*}}{
 public func takeNonCopyableNonTrivial(_ x: borrowing NonCopyableNonTrivial) {}
 
 // Not yet supported.

--- a/test/Interop/CxxToSwiftToCxx/simd-bridge-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/simd-bridge-cxx-struct-back-to-cxx.swift
@@ -44,7 +44,7 @@ public func passStruct(_ x : Struct) {
 
 // CHECK: class SWIFT_SYMBOL("s:8UseCxxTy6StructV") Struct final {
 
-// CHECK: SWIFT_INLINE_THUNK void passStruct(const Struct& x) noexcept SWIFT_SYMBOL("s:8UseCxxTy10passStructyyAA0E0VF") {
+// CHECK: SWIFT_INLINE_THUNK void passStruct(const Struct& SWIFT_NOESCAPE x) noexcept SWIFT_SYMBOL("s:8UseCxxTy10passStructyyAA0E0VF") {
 // CHECK-NEXT:   UseCxxTy::_impl::$s8UseCxxTy10passStructyyAA0E0VF(UseCxxTy::_impl::swift_interop_passDirect_UseCxxTy_swift_float4_0_16_swift_float4_16_32_swift_float4_32_48_swift_float4_48_64(UseCxxTy::_impl::_impl_Struct::getOpaquePointer(x)));
 // CHECK-NEXT:}
 

--- a/test/Interop/CxxToSwiftToObjC/bridge-cxx-types-to-objc.swift
+++ b/test/Interop/CxxToSwiftToObjC/bridge-cxx-types-to-objc.swift
@@ -7,4 +7,4 @@ import CxxModule
 
 public func bar(x: Foo, y: UnsafeMutablePointer<UnsafeMutableRawPointer?>) {}
 
-// CHECK: void bar(const Foo& x, void * _Nullable * _Nonnull y) noexcept
+// CHECK: void bar(const Foo& SWIFT_NOESCAPE x, void * _Nullable * _Nonnull y) noexcept

--- a/test/Interop/SwiftToCxx/cross-module-refs/imported-enum-refs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/cross-module-refs/imported-enum-refs-in-cxx.swift
@@ -21,11 +21,11 @@ public func inoutLargeEnum(_ s: inout LargeEnum) {
     return s = LargeEnum.B
 }
 
-// CHECK: SWIFT_INLINE_THUNK void inoutLargeEnum(Enums::LargeEnum& s) noexcept SWIFT_SYMBOL("s:9UsesEnums14inoutLargeEnumyy0B00dE0OzF") {
+// CHECK: SWIFT_INLINE_THUNK void inoutLargeEnum(Enums::LargeEnum& SWIFT_NOESCAPE s) noexcept SWIFT_SYMBOL("s:9UsesEnums14inoutLargeEnumyy0B00dE0OzF") {
 // CHECK-NEXT: _impl::$s9UsesEnums14inoutLargeEnumyy0B00dE0OzF(Enums::_impl::_impl_LargeEnum::getOpaquePointer(s));
 // CHECK-NEXT: }
 
-// CHECK: SWIFT_INLINE_THUNK Enums::LargeEnum UsesEnumsLargeEnum::passThroughStructSeveralI64(const Enums::LargeEnum& y) const {
+// CHECK: SWIFT_INLINE_THUNK Enums::LargeEnum UsesEnumsLargeEnum::passThroughStructSeveralI64(const Enums::LargeEnum& SWIFT_NOESCAPE y) const {
 // CHECK-NEXT: return Enums::_impl::_impl_LargeEnum::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:   _impl::$s9UsesEnums0aB9LargeEnumV27passThroughStructSeveralI64y0B00cD0OAGF(result, Enums::_impl::_impl_LargeEnum::getOpaquePointer(y), _getOpaquePointer());
 // CHECK-NEXT: });

--- a/test/Interop/SwiftToCxx/cross-module-refs/imported-struct-refs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/cross-module-refs/imported-struct-refs-in-cxx.swift
@@ -21,7 +21,7 @@ public struct UsesStructsStruct {
     public let x: StructSeveralI64
 }
 
-// CHECK:      SWIFT_INLINE_THUNK Structs::StructSeveralI64 passThroughStructSeveralI64(const Structs::StructSeveralI64& y) const SWIFT_SYMBOL("s:11UsesStructs0aB6StructV011passThroughC10SeveralI64y0B00cfG0VAGF");
+// CHECK:      SWIFT_INLINE_THUNK Structs::StructSeveralI64 passThroughStructSeveralI64(const Structs::StructSeveralI64& SWIFT_NOESCAPE y) const SWIFT_SYMBOL("s:11UsesStructs0aB6StructV011passThroughC10SeveralI64y0B00cfG0VAGF");
 // CHECK-NEXT: SWIFT_INLINE_THUNK Structs::StructSeveralI64 getX() const SWIFT_SYMBOL("s:11UsesStructs0aB6StructV1x0B00C10SeveralI64Vvp");
 
 
@@ -37,24 +37,24 @@ public func passThroughStructSmallDirect(_ x: SmallStructDirectPassing) -> Small
     return x
 }
 
-// CHECK:      SWIFT_INLINE_THUNK void inoutStructSeveralI64(Structs::StructSeveralI64& s) noexcept SWIFT_SYMBOL("s:11UsesStructs21inoutStructSeveralI64yy0B00deF0VzF") {
+// CHECK:      SWIFT_INLINE_THUNK void inoutStructSeveralI64(Structs::StructSeveralI64& SWIFT_NOESCAPE s) noexcept SWIFT_SYMBOL("s:11UsesStructs21inoutStructSeveralI64yy0B00deF0VzF") {
 // CHECK-NEXT:   _impl::$s11UsesStructs21inoutStructSeveralI64yy0B00deF0VzF(Structs::_impl::_impl_StructSeveralI64::getOpaquePointer(s));
 // CHECK-NEXT: }
 
 
-// CHECK:      SWIFT_INLINE_THUNK Structs::StructSeveralI64 passThroughStructSeveralI64(const Structs::StructSeveralI64& x) noexcept SWIFT_SYMBOL("s:11UsesStructs27passThroughStructSeveralI64y0B00efG0VAEF") SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      SWIFT_INLINE_THUNK Structs::StructSeveralI64 passThroughStructSeveralI64(const Structs::StructSeveralI64& SWIFT_NOESCAPE x) noexcept SWIFT_SYMBOL("s:11UsesStructs27passThroughStructSeveralI64y0B00efG0VAEF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return Structs::_impl::_impl_StructSeveralI64::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:    _impl::$s11UsesStructs27passThroughStructSeveralI64y0B00efG0VAEF(result, Structs::_impl::_impl_StructSeveralI64::getOpaquePointer(x));
 // CHECK-NEXT:  });
 // CHECK-NEXT: }
 
-// CHECK:      SWIFT_INLINE_THUNK Structs::SmallStructDirectPassing passThroughStructSmallDirect(const Structs::SmallStructDirectPassing& x) noexcept SWIFT_SYMBOL("s:11UsesStructs28passThroughStructSmallDirecty0B00feG7PassingVAEF") SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      SWIFT_INLINE_THUNK Structs::SmallStructDirectPassing passThroughStructSmallDirect(const Structs::SmallStructDirectPassing& SWIFT_NOESCAPE x) noexcept SWIFT_SYMBOL("s:11UsesStructs28passThroughStructSmallDirecty0B00feG7PassingVAEF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return Structs::_impl::_impl_SmallStructDirectPassing::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:    UsesStructs::_impl::swift_interop_returnDirect_UsesStructs_uint32_t_0_4(result, UsesStructs::_impl::$s11UsesStructs28passThroughStructSmallDirecty0B00feG7PassingVAEF(UsesStructs::_impl::swift_interop_passDirect_UsesStructs_uint32_t_0_4(Structs::_impl::_impl_SmallStructDirectPassing::getOpaquePointer(x))));
 // CHECK-NEXT:  });
 // CHECK-NEXT: }
 
-// CHECK: SWIFT_INLINE_THUNK Structs::StructSeveralI64 UsesStructsStruct::passThroughStructSeveralI64(const Structs::StructSeveralI64& y) const {
+// CHECK: SWIFT_INLINE_THUNK Structs::StructSeveralI64 UsesStructsStruct::passThroughStructSeveralI64(const Structs::StructSeveralI64& SWIFT_NOESCAPE y) const {
 // CHECK-NEXT: return Structs::_impl::_impl_StructSeveralI64::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:   UsesStructs::_impl::$s11UsesStructs0aB6StructV011passThroughC10SeveralI64y0B00cfG0VAGF(result, Structs::_impl::_impl_StructSeveralI64::getOpaquePointer(y), _getOpaquePointer());
 // CHECK-NEXT: });

--- a/test/Interop/SwiftToCxx/enums/large-enums-pass-return-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/large-enums-pass-return-in-cxx.swift
@@ -44,7 +44,7 @@ public func inoutLarge(_ en: inout Large, _ x: Int) {
 // CHECK: SWIFT_EXTERN void $s5Enums10printLargeyyAA0C0OF(const void * _Nonnull en) SWIFT_NOEXCEPT SWIFT_CALL; // printLarge(_:)
 // CHECK: class SWIFT_SYMBOL("s:5Enums5LargeO") Large final {
 
-// CHECK:      SWIFT_INLINE_THUNK void inoutLarge(Large& en, swift::Int x) noexcept SWIFT_SYMBOL("s:5Enums10inoutLargeyyAA0C0Oz_SitF") {
+// CHECK:      SWIFT_INLINE_THUNK void inoutLarge(Large& SWIFT_NOESCAPE en, swift::Int x) noexcept SWIFT_SYMBOL("s:5Enums10inoutLargeyyAA0C0Oz_SitF") {
 // CHECK-NEXT:   Enums::_impl::$s5Enums10inoutLargeyyAA0C0Oz_SitF(Enums::_impl::_impl_Large::getOpaquePointer(en), x);
 // CHECK-NEXT: }
 
@@ -54,12 +54,12 @@ public func inoutLarge(_ en: inout Large, _ x: Int) {
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
-// CHECK:      SWIFT_INLINE_THUNK Large passThroughLarge(const Large& en) noexcept SWIFT_SYMBOL("s:5Enums16passThroughLargeyAA0D0OADF") SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      SWIFT_INLINE_THUNK Large passThroughLarge(const Large& SWIFT_NOESCAPE en) noexcept SWIFT_SYMBOL("s:5Enums16passThroughLargeyAA0D0OADF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return Enums::_impl::_impl_Large::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:     Enums::_impl::$s5Enums16passThroughLargeyAA0D0OADF(result, Enums::_impl::_impl_Large::getOpaquePointer(en));
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
-// CHECK:      SWIFT_INLINE_THUNK void printLarge(const Large& en) noexcept SWIFT_SYMBOL("s:5Enums10printLargeyyAA0C0OF") {
+// CHECK:      SWIFT_INLINE_THUNK void printLarge(const Large& SWIFT_NOESCAPE en) noexcept SWIFT_SYMBOL("s:5Enums10printLargeyyAA0C0OF") {
 // CHECK-NEXT:   Enums::_impl::$s5Enums10printLargeyyAA0C0OF(Enums::_impl::_impl_Large::getOpaquePointer(en));
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/enums/small-enums-pass-return-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/small-enums-pass-return-in-cxx.swift
@@ -108,11 +108,11 @@ public func inoutSmall(_ en: inout Small, _ x: Int) {
 // CHECK: class SWIFT_SYMBOL("s:5Enums5SmallO") Small final {
 // CHECK: class SWIFT_SYMBOL("s:5Enums4TinyO") Tiny final {
 
-// CHECK:      SWIFT_INLINE_THUNK void inoutSmall(Small& en, swift::Int x) noexcept SWIFT_SYMBOL("s:5Enums10inoutSmallyyAA0C0Oz_SitF") {
+// CHECK:      SWIFT_INLINE_THUNK void inoutSmall(Small& SWIFT_NOESCAPE en, swift::Int x) noexcept SWIFT_SYMBOL("s:5Enums10inoutSmallyyAA0C0Oz_SitF") {
 // CHECK-NEXT:  Enums::_impl::$s5Enums10inoutSmallyyAA0C0Oz_SitF(Enums::_impl::_impl_Small::getOpaquePointer(en), x);
 // CHECK-NEXT: }
 
-// CHECK:      SWIFT_INLINE_THUNK void inoutTiny(Tiny& en, swift::Int x) noexcept SWIFT_SYMBOL("s:5Enums9inoutTinyyyAA0C0Oz_SitF") {
+// CHECK:      SWIFT_INLINE_THUNK void inoutTiny(Tiny& SWIFT_NOESCAPE en, swift::Int x) noexcept SWIFT_SYMBOL("s:5Enums9inoutTinyyyAA0C0Oz_SitF") {
 // CHECK-NEXT:   Enums::_impl::$s5Enums9inoutTinyyyAA0C0Oz_SitF(Enums::_impl::_impl_Tiny::getOpaquePointer(en), x);
 // CHECK-NEXT: }
 
@@ -128,22 +128,22 @@ public func inoutSmall(_ en: inout Small, _ x: Int) {
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
-// CHECK:      SWIFT_INLINE_THUNK Small passThroughSmall(const Small& en) noexcept SWIFT_SYMBOL("s:5Enums16passThroughSmallyAA0D0OADF") SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      SWIFT_INLINE_THUNK Small passThroughSmall(const Small& SWIFT_NOESCAPE en) noexcept SWIFT_SYMBOL("s:5Enums16passThroughSmallyAA0D0OADF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return Enums::_impl::_impl_Small::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:     Enums::_impl::swift_interop_returnDirect_Enums_[[Small]](result, Enums::_impl::$s5Enums16passThroughSmallyAA0D0OADF(Enums::_impl::swift_interop_passDirect_Enums_[[Small]](Enums::_impl::_impl_Small::getOpaquePointer(en))));
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
-// CHECK:      SWIFT_INLINE_THUNK Tiny passThroughTiny(const Tiny& en) noexcept SWIFT_SYMBOL("s:5Enums15passThroughTinyyAA0D0OADF") SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      SWIFT_INLINE_THUNK Tiny passThroughTiny(const Tiny& SWIFT_NOESCAPE en) noexcept SWIFT_SYMBOL("s:5Enums15passThroughTinyyAA0D0OADF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return Enums::_impl::_impl_Tiny::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:     Enums::_impl::swift_interop_returnDirect_Enums_uint8_t_0_1(result, Enums::_impl::$s5Enums15passThroughTinyyAA0D0OADF(Enums::_impl::swift_interop_passDirect_Enums_uint8_t_0_1(Enums::_impl::_impl_Tiny::getOpaquePointer(en))));
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
-// CHECK:      SWIFT_INLINE_THUNK void printSmall(const Small& en) noexcept SWIFT_SYMBOL("s:5Enums10printSmallyyAA0C0OF") {
+// CHECK:      SWIFT_INLINE_THUNK void printSmall(const Small& SWIFT_NOESCAPE en) noexcept SWIFT_SYMBOL("s:5Enums10printSmallyyAA0C0OF") {
 // CHECK-NEXT:   Enums::_impl::$s5Enums10printSmallyyAA0C0OF(Enums::_impl::swift_interop_passDirect_Enums_[[Small]](Enums::_impl::_impl_Small::getOpaquePointer(en)));
 // CHECK-NEXT: }
 
-// CHECK:      SWIFT_INLINE_THUNK void printTiny(const Tiny& en) noexcept SWIFT_SYMBOL("s:5Enums9printTinyyyAA0C0OF") {
+// CHECK:      SWIFT_INLINE_THUNK void printTiny(const Tiny& SWIFT_NOESCAPE en) noexcept SWIFT_SYMBOL("s:5Enums9printTinyyyAA0C0OF") {
 // CHECK-NEXT:   Enums::_impl::$s5Enums9printTinyyyAA0C0OF(Enums::_impl::swift_interop_passDirect_Enums_uint8_t_0_1(Enums::_impl::_impl_Tiny::getOpaquePointer(en)));
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/functions/swift-operators.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-operators.swift
@@ -46,7 +46,7 @@ public func -(lhs: IntBox, rhs: IntBox) -> CInt {
   return lhs.x - rhs.x
 }
 
-// CHECK: SWIFT_INLINE_THUNK int operator-(const IntBox& lhs, const IntBox& rhs) noexcept SWIFT_SYMBOL("s:9Operators1soiys5Int32VAA6IntBoxV_AFtF") SWIFT_WARN_UNUSED_RESULT {
+// CHECK: SWIFT_INLINE_THUNK int operator-(const IntBox& SWIFT_NOESCAPE lhs, const IntBox& SWIFT_NOESCAPE rhs) noexcept SWIFT_SYMBOL("s:9Operators1soiys5Int32VAA6IntBoxV_AFtF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return Operators::_impl::$s9Operators1soiys5Int32VAA6IntBoxV_AFtF(Operators::_impl::swift_interop_passDirect_Operators_uint32_t_0_4(Operators::_impl::_impl_IntBox::getOpaquePointer(lhs)), Operators::_impl::swift_interop_passDirect_Operators_uint32_t_0_4(Operators::_impl::_impl_IntBox::getOpaquePointer(rhs)));
 // CHECK-NEXT: }
 
@@ -54,7 +54,7 @@ public func ==(lhs: IntBox, rhs: IntBox) -> Bool {
   return lhs.x == rhs.x
 }
 
-// CHECK: SWIFT_INLINE_THUNK bool operator==(const IntBox& lhs, const IntBox& rhs) noexcept SWIFT_SYMBOL("s:9Operators2eeoiySbAA6IntBoxV_ADtF") SWIFT_WARN_UNUSED_RESULT {
+// CHECK: SWIFT_INLINE_THUNK bool operator==(const IntBox& SWIFT_NOESCAPE lhs, const IntBox& SWIFT_NOESCAPE rhs) noexcept SWIFT_SYMBOL("s:9Operators2eeoiySbAA6IntBoxV_ADtF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return Operators::_impl::$s9Operators2eeoiySbAA6IntBoxV_ADtF(Operators::_impl::swift_interop_passDirect_Operators_uint32_t_0_4(Operators::_impl::_impl_IntBox::getOpaquePointer(lhs)), Operators::_impl::swift_interop_passDirect_Operators_uint32_t_0_4(Operators::_impl::_impl_IntBox::getOpaquePointer(rhs)));
 // CHECK-NEXT: }
 

--- a/test/Interop/SwiftToCxx/functions/swift-primitive-inout-functions-cxx-bridging.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-primitive-inout-functions-cxx-bridging.swift
@@ -4,29 +4,29 @@
 
 // RUN: %check-interop-cxx-header-in-clang(%t/functions.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
-// CHECK: SWIFT_EXTERN void $s9Functions8inOutIntyySizF(ptrdiff_t * _Nonnull x) SWIFT_NOEXCEPT SWIFT_CALL; // inOutInt(_:)
-// CHECK: SWIFT_EXTERN void $s9Functions11inOutTwoIntyySiz_SiztF(ptrdiff_t * _Nonnull x, ptrdiff_t * _Nonnull y) SWIFT_NOEXCEPT SWIFT_CALL; // inOutTwoInt(_:_:)
-// CHECK: SWIFT_EXTERN void $s9Functions13inOutTwoParamyySbz_SdztF(bool * _Nonnull x, double * _Nonnull y) SWIFT_NOEXCEPT SWIFT_CALL; // inOutTwoParam(_:_:)
-// CHECK: SWIFT_EXTERN void $s9Functions24inoutTypeWithNullabilityyySVzF(void const * _Nonnull * _Nonnull x) SWIFT_NOEXCEPT SWIFT_CALL; // inoutTypeWithNullability(_:)
-// CHECK: SWIFT_EXTERN void $s9Functions25inoutUnsafeGenericPointeryySPys5Int32VGzF(int32_t const * _Nonnull * _Nonnull x) SWIFT_NOEXCEPT SWIFT_CALL; // inoutUnsafeGenericPointer(_:)
+// CHECK: SWIFT_EXTERN void $s9Functions8inOutIntyySizF(ptrdiff_t * _Nonnull SWIFT_NOESCAPE x) SWIFT_NOEXCEPT SWIFT_CALL; // inOutInt(_:)
+// CHECK: SWIFT_EXTERN void $s9Functions11inOutTwoIntyySiz_SiztF(ptrdiff_t * _Nonnull SWIFT_NOESCAPE x, ptrdiff_t * _Nonnull SWIFT_NOESCAPE y) SWIFT_NOEXCEPT SWIFT_CALL; // inOutTwoInt(_:_:)
+// CHECK: SWIFT_EXTERN void $s9Functions13inOutTwoParamyySbz_SdztF(bool * _Nonnull SWIFT_NOESCAPE x, double * _Nonnull SWIFT_NOESCAPE y) SWIFT_NOEXCEPT SWIFT_CALL; // inOutTwoParam(_:_:)
+// CHECK: SWIFT_EXTERN void $s9Functions24inoutTypeWithNullabilityyySVzF(void const * _Nonnull * _Nonnull SWIFT_NOESCAPE x) SWIFT_NOEXCEPT SWIFT_CALL; // inoutTypeWithNullability(_:)
+// CHECK: SWIFT_EXTERN void $s9Functions25inoutUnsafeGenericPointeryySPys5Int32VGzF(int32_t const * _Nonnull * _Nonnull SWIFT_NOESCAPE x) SWIFT_NOEXCEPT SWIFT_CALL; // inoutUnsafeGenericPointer(_:)
 
-// CHECK:      SWIFT_INLINE_THUNK void inOutInt(swift::Int & x) noexcept SWIFT_SYMBOL({{.*}}) {
+// CHECK:      SWIFT_INLINE_THUNK void inOutInt(swift::Int & SWIFT_NOESCAPE x) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT:   _impl::$s9Functions8inOutIntyySizF(&x);
 // CHECK-NEXT: }
 
-// CHECK:      SWIFT_INLINE_THUNK void inOutTwoInt(swift::Int & x, swift::Int & y) noexcept SWIFT_SYMBOL({{.*}}) {
+// CHECK:      SWIFT_INLINE_THUNK void inOutTwoInt(swift::Int & SWIFT_NOESCAPE x, swift::Int & SWIFT_NOESCAPE y) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT:   _impl::$s9Functions11inOutTwoIntyySiz_SiztF(&x, &y);
 // CHECK-NEXT: }
 
-// CHECK:      SWIFT_INLINE_THUNK void inOutTwoParam(bool & x, double & y) noexcept SWIFT_SYMBOL({{.*}}) {
+// CHECK:      SWIFT_INLINE_THUNK void inOutTwoParam(bool & SWIFT_NOESCAPE x, double & SWIFT_NOESCAPE y) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT:   _impl::$s9Functions13inOutTwoParamyySbz_SdztF(&x, &y);
 // CHECK-NEXT: }
 
-// CHECK:      SWIFT_INLINE_THUNK void inoutTypeWithNullability(void const * _Nonnull & x) noexcept SWIFT_SYMBOL({{.*}}) {
+// CHECK:      SWIFT_INLINE_THUNK void inoutTypeWithNullability(void const * _Nonnull & SWIFT_NOESCAPE x) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT:   _impl::$s9Functions24inoutTypeWithNullabilityyySVzF(&x);
 // CHECK-NEXT: }
 
-// CHECK:      SWIFT_INLINE_THUNK void inoutUnsafeGenericPointer(int32_t const * _Nonnull & x) noexcept SWIFT_SYMBOL({{.*}}) {
+// CHECK:      SWIFT_INLINE_THUNK void inoutUnsafeGenericPointer(int32_t const * _Nonnull & SWIFT_NOESCAPE x) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT:   _impl::$s9Functions25inoutUnsafeGenericPointeryySPys5Int32VGzF(&x);
 // CHECK-NEXT: }
 

--- a/test/Interop/SwiftToCxx/generics/generic-enum-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-enum-in-cxx.swift
@@ -176,7 +176,7 @@ public func inoutConcreteOpt(_ x: inout GenericOpt<UInt16>) {
 // CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getComputedProp() const SWIFT_SYMBOL("s:8Generics10GenericOptO12computedPropSivp");
 
 
-// CHECK: SWIFT_INLINE_THUNK void inoutConcreteOpt(GenericOpt<uint16_t>& x) noexcept SWIFT_SYMBOL("s:8Generics16inoutConcreteOptyyAA07GenericD0Oys6UInt16VGzF") {
+// CHECK: SWIFT_INLINE_THUNK void inoutConcreteOpt(GenericOpt<uint16_t>& SWIFT_NOESCAPE x) noexcept SWIFT_SYMBOL("s:8Generics16inoutConcreteOptyyAA07GenericD0Oys6UInt16VGzF") {
 // CHECK-NEXT:   Generics::_impl::$s8Generics16inoutConcreteOptyyAA07GenericD0Oys6UInt16VGzF(Generics::_impl::_impl_GenericOpt<uint16_t>::getOpaquePointer(x));
 // CHECK-NEXT: }
 
@@ -185,7 +185,7 @@ public func inoutConcreteOpt(_ x: inout GenericOpt<UInt16>) {
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: SWIFT_INLINE_THUNK void inoutGenericOpt(GenericOpt<T_0_0>& x, const T_0_0& y) noexcept SWIFT_SYMBOL("s:8Generics15inoutGenericOptyyAA0cD0OyxGz_xtlF") {
+// CHECK-NEXT: SWIFT_INLINE_THUNK void inoutGenericOpt(GenericOpt<T_0_0>& SWIFT_NOESCAPE x, const T_0_0& y) noexcept SWIFT_SYMBOL("s:8Generics15inoutGenericOptyyAA0cD0OyxGz_xtlF") {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: #endif
@@ -214,7 +214,7 @@ public func inoutConcreteOpt(_ x: inout GenericOpt<UInt16>) {
 // CHECK-NEXT: }
 
 
-// CHECK: SWIFT_INLINE_THUNK void takeConcreteOpt(const GenericOpt<uint16_t>& x) noexcept SWIFT_SYMBOL("s:8Generics15takeConcreteOptyyAA07GenericD0Oys6UInt16VGF") {
+// CHECK: SWIFT_INLINE_THUNK void takeConcreteOpt(const GenericOpt<uint16_t>& SWIFT_NOESCAPE x) noexcept SWIFT_SYMBOL("s:8Generics15takeConcreteOptyyAA07GenericD0Oys6UInt16VGF") {
 // CHECK-NEXT:   Generics::_impl::$s8Generics15takeConcreteOptyyAA07GenericD0Oys6UInt16VGF(Generics::_impl::swift_interop_passDirect_Generics_uint32_t_0_4(Generics::_impl::_impl_GenericOpt<uint16_t>::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
@@ -223,7 +223,7 @@ public func inoutConcreteOpt(_ x: inout GenericOpt<UInt16>) {
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: SWIFT_INLINE_THUNK void takeGenericOpt(const GenericOpt<T_0_0>& x) noexcept SWIFT_SYMBOL("s:8Generics14takeGenericOptyyAA0cD0OyxGlF") {
+// CHECK-NEXT: SWIFT_INLINE_THUNK void takeGenericOpt(const GenericOpt<T_0_0>& SWIFT_NOESCAPE x) noexcept SWIFT_SYMBOL("s:8Generics14takeGenericOptyyAA0cD0OyxGlF") {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: #endif

--- a/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
@@ -301,7 +301,7 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: #pragma clang diagnostic pop
 // CHECK-NEXT: } // namespace swift
 
-// CHECK: SWIFT_INLINE_THUNK void inoutConcretePair(uint16_t x, GenericPair<uint16_t, uint16_t>& y) noexcept SWIFT_SYMBOL("s:8Generics17inoutConcretePairyys6UInt16V_AA07GenericD0VyA2DGztF") {
+// CHECK: SWIFT_INLINE_THUNK void inoutConcretePair(uint16_t x, GenericPair<uint16_t, uint16_t>& SWIFT_NOESCAPE y) noexcept SWIFT_SYMBOL("s:8Generics17inoutConcretePairyys6UInt16V_AA07GenericD0VyA2DGztF") {
 // CHECK-NEXT:   Generics::_impl::$s8Generics17inoutConcretePairyys6UInt16V_AA07GenericD0VyA2DGztF(x, Generics::_impl::_impl_GenericPair<uint16_t, uint16_t>::getOpaquePointer(y));
 // CHECK-NEXT: }
 
@@ -309,7 +309,7 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: SWIFT_INLINE_THUNK void inoutGenericPair(GenericPair<T_0_0, T_0_1>& x, const T_0_0& y) noexcept SWIFT_SYMBOL("s:8Generics16inoutGenericPairyyAA0cD0Vyxq_Gz_xtr0_lF") {
+// CHECK-NEXT: SWIFT_INLINE_THUNK void inoutGenericPair(GenericPair<T_0_0, T_0_1>& SWIFT_NOESCAPE x, const T_0_0& y) noexcept SWIFT_SYMBOL("s:8Generics16inoutGenericPairyyAA0cD0Vyxq_Gz_xtr0_lF") {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");
@@ -331,7 +331,7 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
-// CHECK: SWIFT_INLINE_THUNK GenericPair<uint16_t, uint16_t> passThroughConcretePair(const GenericPair<uint16_t, uint16_t>& x, uint16_t y) noexcept SWIFT_SYMBOL("s:8Generics23passThroughConcretePair_1yAA07GenericE0Vys6UInt16VAGGAH_AGtF") SWIFT_WARN_UNUSED_RESULT {
+// CHECK: SWIFT_INLINE_THUNK GenericPair<uint16_t, uint16_t> passThroughConcretePair(const GenericPair<uint16_t, uint16_t>& SWIFT_NOESCAPE x, uint16_t y) noexcept SWIFT_SYMBOL("s:8Generics23passThroughConcretePair_1yAA07GenericE0Vys6UInt16VAGGAH_AGtF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return Generics::_impl::_impl_GenericPair<uint16_t, uint16_t>::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:     Generics::_impl::swift_interop_returnDirect_Generics_uint32_t_0_4(result, Generics::_impl::$s8Generics23passThroughConcretePair_1yAA07GenericE0Vys6UInt16VAGGAH_AGtF(Generics::_impl::swift_interop_passDirect_Generics_uint32_t_0_4(Generics::_impl::_impl_GenericPair<uint16_t, uint16_t>::getOpaquePointer(x)), y));
 // CHECK-NEXT:   });
@@ -341,7 +341,7 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: SWIFT_INLINE_THUNK GenericPair<T_0_0, T_0_1> passThroughGenericPair(const GenericPair<T_0_0, T_0_1>& x, const T_0_1& y) noexcept SWIFT_SYMBOL("s:8Generics22passThroughGenericPairyAA0dE0Vyxq_GAE_q_tr0_lF") SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT: SWIFT_INLINE_THUNK GenericPair<T_0_0, T_0_1> passThroughGenericPair(const GenericPair<T_0_0, T_0_1>& SWIFT_NOESCAPE x, const T_0_1& y) noexcept SWIFT_SYMBOL("s:8Generics22passThroughGenericPairyAA0dE0Vyxq_GAE_q_tr0_lF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");
@@ -351,7 +351,7 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
-// CHECK: SWIFT_INLINE_THUNK void takeConcretePair(const GenericPair<uint16_t, uint16_t>& x) noexcept SWIFT_SYMBOL("s:8Generics16takeConcretePairyyAA07GenericD0Vys6UInt16VAFGF") {
+// CHECK: SWIFT_INLINE_THUNK void takeConcretePair(const GenericPair<uint16_t, uint16_t>& SWIFT_NOESCAPE x) noexcept SWIFT_SYMBOL("s:8Generics16takeConcretePairyyAA07GenericD0Vys6UInt16VAFGF") {
 // CHECK-NEXT:   _impl::$s8Generics16takeConcretePairyyAA07GenericD0Vys6UInt16VAFGF(Generics::_impl::swift_interop_passDirect_Generics_uint32_t_0_4(Generics::_impl::_impl_GenericPair<uint16_t, uint16_t>::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
@@ -359,7 +359,7 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: SWIFT_INLINE_THUNK void takeGenericPair(const GenericPair<T_0_0, T_0_1>& x) noexcept SWIFT_SYMBOL("s:8Generics15takeGenericPairyyAA0cD0Vyxq_Gr0_lF") {
+// CHECK-NEXT: SWIFT_INLINE_THUNK void takeGenericPair(const GenericPair<T_0_0, T_0_1>& SWIFT_NOESCAPE x) noexcept SWIFT_SYMBOL("s:8Generics15takeGenericPairyyAA0cD0Vyxq_Gr0_lF") {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");
@@ -442,7 +442,7 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: SWIFT_INLINE_THUNK void GenericPair<T_0_0, T_0_1>::mutatingMethod(const GenericPair<T_0_1, T_0_0>& other) {
+// CHECK-NEXT: SWIFT_INLINE_THUNK void GenericPair<T_0_0, T_0_1>::mutatingMethod(const GenericPair<T_0_1, T_0_0>& SWIFT_NOESCAPE other) {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");

--- a/test/Interop/SwiftToCxx/generics/generic-struct-known-layout-direct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-known-layout-direct-in-cxx.swift
@@ -97,12 +97,12 @@
 // CHECK-NEXT: #pragma clang diagnostic pop
 // CHECK-NEXT: }
 
-// CHECK: SWIFT_INLINE_THUNK void inoutConcretePair(uint16_t x, GenericPair<uint16_t, uint16_t>& y) noexcept SWIFT_SYMBOL("s:8Generics17inoutConcretePairyys6UInt16V_AA07GenericD0VyA2DGztF") {
+// CHECK: SWIFT_INLINE_THUNK void inoutConcretePair(uint16_t x, GenericPair<uint16_t, uint16_t>& SWIFT_NOESCAPE y) noexcept SWIFT_SYMBOL("s:8Generics17inoutConcretePairyys6UInt16V_AA07GenericD0VyA2DGztF") {
 // CHECK-NEXT: Generics::_impl::$s8Generics17inoutConcretePairyys6UInt16V_AA07GenericD0VyA2DGztF(x, Generics::_impl::_impl_GenericPair<uint16_t, uint16_t>::getOpaquePointer(y));
 // CHECK-NEXT: }
 
 
-// CHECK: SWIFT_INLINE_THUNK void inoutGenericPair(GenericPair<T_0_0, T_0_1>& x, const T_0_0& y) noexcept SWIFT_SYMBOL("s:8Generics16inoutGenericPairyyAA0cD0Vyxq_Gz_xtr0_lF") {
+// CHECK: SWIFT_INLINE_THUNK void inoutGenericPair(GenericPair<T_0_0, T_0_1>& SWIFT_NOESCAPE x, const T_0_0& y) noexcept SWIFT_SYMBOL("s:8Generics16inoutGenericPairyyAA0cD0Vyxq_Gz_xtr0_lF") {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");
@@ -122,11 +122,11 @@
 // CHECK-NEXT:  return Generics::_impl::_impl_GenericPair<T_0_0, T_0_1>::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:    _impl::swift_interop_returnDirect_Generics_[[PTRPTRENC]](result, Generics::_impl::$s8Generics15makeGenericPairyAA0cD0Vyxq_Gx_q_tr0_lF(swift::_impl::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata()));
 
-// CHECK: SWIFT_INLINE_THUNK GenericPair<uint16_t, uint16_t> passThroughConcretePair(const GenericPair<uint16_t, uint16_t>& x, uint16_t y) noexcept SWIFT_SYMBOL("s:8Generics23passThroughConcretePair_1yAA07GenericE0Vys6UInt16VAGGAH_AGtF") SWIFT_WARN_UNUSED_RESULT {
+// CHECK: SWIFT_INLINE_THUNK GenericPair<uint16_t, uint16_t> passThroughConcretePair(const GenericPair<uint16_t, uint16_t>& SWIFT_NOESCAPE x, uint16_t y) noexcept SWIFT_SYMBOL("s:8Generics23passThroughConcretePair_1yAA07GenericE0Vys6UInt16VAGGAH_AGtF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return Generics::_impl::_impl_GenericPair<uint16_t, uint16_t>::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:    Generics::_impl::swift_interop_returnDirect_Generics_[[PTRPTRENC]](result, Generics::_impl::$s8Generics23passThroughConcretePair_1yAA07GenericE0Vys6UInt16VAGGAH_AGtF(Generics::_impl::swift_interop_passDirect_Generics_[[PTRPTRENC]](Generics::_impl::_impl_GenericPair<uint16_t, uint16_t>::getOpaquePointer(x)), y));
 
-// CHECK: SWIFT_INLINE_THUNK GenericPair<T_0_0, T_0_1> passThroughGenericPair(const GenericPair<T_0_0, T_0_1>& x, const T_0_1& y) noexcept SWIFT_SYMBOL("s:8Generics22passThroughGenericPairyAA0dE0Vyxq_GAE_q_tr0_lF") SWIFT_WARN_UNUSED_RESULT {
+// CHECK: SWIFT_INLINE_THUNK GenericPair<T_0_0, T_0_1> passThroughGenericPair(const GenericPair<T_0_0, T_0_1>& SWIFT_NOESCAPE x, const T_0_1& y) noexcept SWIFT_SYMBOL("s:8Generics22passThroughGenericPairyAA0dE0Vyxq_GAE_q_tr0_lF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");
@@ -134,11 +134,11 @@
 // CHECK-NEXT:  return Generics::_impl::_impl_GenericPair<T_0_0, T_0_1>::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:    Generics::_impl::swift_interop_returnDirect_Generics_[[PTRPTRENC]](result, Generics::_impl::$s8Generics22passThroughGenericPairyAA0dE0Vyxq_GAE_q_tr0_lF(Generics::_impl::swift_interop_passDirect_Generics_[[PTRPTRENC]](Generics::_impl::_impl_GenericPair<T_0_0, T_0_1>::getOpaquePointer(x)), swift::_impl::getOpaquePointer(y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata()));
 
-// CHECK: SWIFT_INLINE_THUNK void takeConcretePair(const GenericPair<uint16_t, uint16_t>& x) noexcept SWIFT_SYMBOL("s:8Generics16takeConcretePairyyAA07GenericD0Vys6UInt16VAFGF") {
+// CHECK: SWIFT_INLINE_THUNK void takeConcretePair(const GenericPair<uint16_t, uint16_t>& SWIFT_NOESCAPE x) noexcept SWIFT_SYMBOL("s:8Generics16takeConcretePairyyAA07GenericD0Vys6UInt16VAFGF") {
 // CHECK-NEXT: _impl::$s8Generics16takeConcretePairyyAA07GenericD0Vys6UInt16VAFGF(Generics::_impl::swift_interop_passDirect_Generics_[[PTRPTRENC]](Generics::_impl::_impl_GenericPair<uint16_t, uint16_t>::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
-// CHECK:  SWIFT_INLINE_THUNK void takeGenericPair(const GenericPair<T_0_0, T_0_1>& x) noexcept SWIFT_SYMBOL("s:8Generics15takeGenericPairyyAA0cD0Vyxq_Gr0_lF") {
+// CHECK:  SWIFT_INLINE_THUNK void takeGenericPair(const GenericPair<T_0_0, T_0_1>& SWIFT_NOESCAPE x) noexcept SWIFT_SYMBOL("s:8Generics15takeGenericPairyyAA0cD0Vyxq_Gr0_lF") {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");

--- a/test/Interop/SwiftToCxx/initializers/init-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/initializers/init-in-cxx.swift
@@ -71,7 +71,7 @@ public struct LargeStruct {
 // CHECK: class SWIFT_SYMBOL("s:4Init11LargeStructV") LargeStruct final {
 // CHECK:       SWIFT_INLINE_THUNK swift::Int getX6() const SWIFT_SYMBOL("s:4Init11LargeStructV2x6Sivp");
 // CHECK-NEXT:  static SWIFT_INLINE_THUNK LargeStruct init() SWIFT_SYMBOL("s:4Init11LargeStructVACycfc");
-// CHECK-NEXT:  static SWIFT_INLINE_THUNK LargeStruct init(swift::Int x, const FirstSmallStruct& y) SWIFT_SYMBOL("s:4Init11LargeStructV1x1yACSi_AA010FirstSmallC0Vtcfc");
+// CHECK-NEXT: static SWIFT_INLINE_THUNK LargeStruct init(swift::Int x, const FirstSmallStruct& SWIFT_NOESCAPE y) SWIFT_SYMBOL("s:4Init11LargeStructV1x1yACSi_AA010FirstSmallC0Vtcfc");
 // CHECK-NEXT: private:
 
 private class RefCountedClass {
@@ -151,7 +151,7 @@ public struct WrapOverloadedInits {
 // CHECK: DerivedClassTwo DerivedClassTwo::init(swift::Int x, swift::Int y) {
 // CHECK-NEXT: return _impl::_impl_DerivedClassTwo::makeRetained(Init::_impl::$s4Init15DerivedClassTwoCyACSi_SitcfC(x, y, swift::TypeMetadataTrait<DerivedClassTwo>::getTypeMetadata()));
 
-// CHECK: FinalClass FinalClass::init(const FirstSmallStruct& prop) {
+// CHECK: FinalClass FinalClass::init(const FirstSmallStruct& SWIFT_NOESCAPE prop) {
 // CHECK-NEXT: return _impl::_impl_FinalClass::makeRetained(Init::_impl::$s4Init10FinalClassCyAcA16FirstSmallStructVcfC(Init::_impl::swift_interop_passDirect_Init_uint32_t_0_4(Init::_impl::_impl_FirstSmallStruct::getOpaquePointer(prop)), swift::TypeMetadataTrait<FinalClass>::getTypeMetadata()));
 
 
@@ -174,7 +174,7 @@ public struct WrapOverloadedInits {
 // CHECK-NEXT:   _impl::$s4Init11LargeStructVACycfC(result);
 // CHECK-NEXT: });
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct LargeStruct::init(swift::Int x, const FirstSmallStruct& y) {
+// CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct LargeStruct::init(swift::Int x, const FirstSmallStruct& SWIFT_NOESCAPE y) {
 // CHECK-NEXT: return Init::_impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:   _impl::$s4Init11LargeStructV1x1yACSi_AA010FirstSmallC0VtcfC(result, x, Init::_impl::swift_interop_passDirect_Init_uint32_t_0_4(Init::_impl::_impl_FirstSmallStruct::getOpaquePointer(y)));
 // CHECK-NEXT: });

--- a/test/Interop/SwiftToCxx/methods/method-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/methods/method-in-cxx.swift
@@ -110,7 +110,7 @@ public final class PassStructInClassMethod {
 // CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct doubled() const SWIFT_SYMBOL("s:7Methods11LargeStructV7doubledACyF");
 // CHECK-NEXT: SWIFT_INLINE_THUNK void dump() const SWIFT_SYMBOL("s:7Methods11LargeStructV4dumpyyF");
 // CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct scaled(swift::Int x, swift::Int y) const SWIFT_SYMBOL("s:7Methods11LargeStructV6scaledyACSi_SitF");
-// CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct added(const LargeStruct& x) const SWIFT_SYMBOL("s:7Methods11LargeStructV5addedyA2CF");
+// CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct added(const LargeStruct& SWIFT_NOESCAPE x) const SWIFT_SYMBOL("s:7Methods11LargeStructV5addedyA2CF");
 // CHECK-NEXT: static SWIFT_INLINE_THUNK void staticMethod() SWIFT_SYMBOL("s:7Methods11LargeStructV12staticMethodyyFZ");
 // CHECK-NEXT: private
 
@@ -193,7 +193,7 @@ public func createPassStructInClassMethod() -> PassStructInClassMethod {
 // CHECK-NEXT:   _impl::$s7Methods11LargeStructV6scaledyACSi_SitF(result, x, y, _getOpaquePointer());
 // CHECK-NEXT: });
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct LargeStruct::added(const LargeStruct& x) const {
+// CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct LargeStruct::added(const LargeStruct& SWIFT_NOESCAPE x) const {
 // CHECK-NEXT: return Methods::_impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:   _impl::$s7Methods11LargeStructV5addedyA2CF(result, Methods::_impl::_impl_LargeStruct::getOpaquePointer(x), _getOpaquePointer());
 // CHECK-NEXT: });
@@ -207,6 +207,6 @@ public func createPassStructInClassMethod() -> PassStructInClassMethod {
 // CHECK-NEXT:   _impl::$s7Methods23PassStructInClassMethodC03retC0yAA05LargeC0VSiF(result, x, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT: });
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK void PassStructInClassMethod::updateStruct(swift::Int x, const LargeStruct& y) {
+// CHECK-NEXT: SWIFT_INLINE_THUNK void PassStructInClassMethod::updateStruct(swift::Int x, const LargeStruct& SWIFT_NOESCAPE y) {
 // CHECK-NEXT: _impl::$s7Methods23PassStructInClassMethodC06updateC0yySi_AA05LargeC0VtF(x, Methods::_impl::_impl_LargeStruct::getOpaquePointer(y), ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/ownership/consuming-parameter-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/ownership/consuming-parameter-in-cxx.swift
@@ -109,7 +109,7 @@ public struct TheGenericContainerInitNonTriv {
 // CHECK-NEXT: _impl::$s4Init6AKlassC9takeKlassyyF(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(consumedParamCopy_this));
 // CHECK-NEXT: }
 
-// CHECK: SWIFT_INLINE_THUNK InitFromEnumNonTrivial InitFromEnumNonTrivial::init(const EnumNonTrivial& x) {
+// CHECK: SWIFT_INLINE_THUNK InitFromEnumNonTrivial InitFromEnumNonTrivial::init(const EnumNonTrivial& SWIFT_NOESCAPE x) {
 // CHECK-NEXT: alignas(alignof(EnumNonTrivial)) char copyBuffer_consumedParamCopy_x[sizeof(EnumNonTrivial)];
 // CHECK-NEXT: auto &consumedParamCopy_x = *(new(copyBuffer_consumedParamCopy_x) EnumNonTrivial(x));
 // CHECK-NEXT: ConsumedValueStorageDestroyer<EnumNonTrivial> storageGuard_consumedParamCopy_x(consumedParamCopy_x);
@@ -123,17 +123,17 @@ public struct TheGenericContainerInitNonTriv {
 // CHECK-NEXT: returnNewValue
 // CHECK-NEXT: swift::_impl::_impl_RefCountedClass::getOpaquePointer(consumedParamCopy_x)
 
-// CHECK: SWIFT_INLINE_THUNK InitFromLargeStructNonTrivial InitFromLargeStructNonTrivial::init(const LargeStructNonTrivial& x) {
+// CHECK: SWIFT_INLINE_THUNK InitFromLargeStructNonTrivial InitFromLargeStructNonTrivial::init(const LargeStructNonTrivial& SWIFT_NOESCAPE x) {
 // CHECK-NEXT: alignas(alignof(LargeStructNonTrivial)) char copyBuffer_consumedParamCopy_x[sizeof(LargeStructNonTrivial)];
 // CHECK-NEXT: auto &consumedParamCopy_x = *(new(copyBuffer_consumedParamCopy_x) LargeStructNonTrivial(x));
 // CHECK-NEXT: swift::_impl::ConsumedValueStorageDestroyer<LargeStructNonTrivial> storageGuard_consumedParamCopy_x(consumedParamCopy_x);
 
-// CHECK:  SWIFT_INLINE_THUNK InitFromSmall InitFromSmall::init(const SmallStructNonTrivial& x) {
+// CHECK:  SWIFT_INLINE_THUNK InitFromSmall InitFromSmall::init(const SmallStructNonTrivial& SWIFT_NOESCAPE x) {
 // CHECK-NEXT: alignas(alignof(SmallStructNonTrivial)) char copyBuffer_consumedParamCopy_x[sizeof(SmallStructNonTrivial)];
 // CHECK-NEXT: auto &consumedParamCopy_x = *(new(copyBuffer_consumedParamCopy_x) SmallStructNonTrivial(x));
 // CHECK-NEXT: swift::_impl::ConsumedValueStorageDestroyer<SmallStructNonTrivial> storageGuard_consumedParamCopy_x(consumedParamCopy_x);
 
-// CHECK: SWIFT_INLINE_THUNK void InitFromSmall::takeSmallLarge(const SmallStructNonTrivial& _1, const LargeStructNonTrivial& _2) const {
+// CHECK: SWIFT_INLINE_THUNK void InitFromSmall::takeSmallLarge(const SmallStructNonTrivial& SWIFT_NOESCAPE _1, const LargeStructNonTrivial& SWIFT_NOESCAPE _2) const {
 // CHECK-NEXT: alignas(alignof(SmallStructNonTrivial)) char copyBuffer_consumedParamCopy_1[sizeof(SmallStructNonTrivial)];
 // CHECK-NEXT: auto &consumedParamCopy_1 = *(new(copyBuffer_consumedParamCopy_1) SmallStructNonTrivial(_1));
 // CHECK-NEXT: swift::_impl::ConsumedValueStorageDestroyer<SmallStructNonTrivial> storageGuard_consumedParamCopy_1(consumedParamCopy_1);
@@ -169,10 +169,10 @@ public struct TheGenericContainerInitNonTriv {
 // CHECK-NEXT: _impl::$s4Init19TheGenericContainerV04takecD0yyF(swift::TypeMetadataTrait<TheGenericContainer<T_0_0>>::getTypeMetadata(), Init::_impl::_impl_TheGenericContainer<T_0_0>::getOpaquePointer(consumedParamCopy_this));
 // CHECK-NEXT: }
 
-// CHECK: SWIFT_INLINE_THUNK TheGenericContainerInitNonTriv TheGenericContainerInitNonTriv::init(const TheGenericContainer<AKlass>& x) {
+// CHECK: SWIFT_INLINE_THUNK TheGenericContainerInitNonTriv TheGenericContainerInitNonTriv::init(const TheGenericContainer<AKlass>& SWIFT_NOESCAPE x) {
 // CHECK-NEXT: alignas(alignof(TheGenericContainer<AKlass>)) char copyBuffer_consumedParamCopy_x[sizeof(TheGenericContainer<AKlass>)];
 // CHECK-NEXT: auto &consumedParamCopy_x = *(new(copyBuffer_consumedParamCopy_x) TheGenericContainer<AKlass>(x));
 // CHECK-NEXT: swift::_impl::ConsumedValueStorageDestroyer<TheGenericContainer<AKlass>> storageGuard_consumedParamCopy_x(consumedParamCopy_x);
 
-// CHECK: SWIFT_INLINE_THUNK TheGenericContainerInitTriv TheGenericContainerInitTriv::init(const TheGenericContainer<swift::Int>& x) {
+// CHECK: SWIFT_INLINE_THUNK TheGenericContainerInitTriv TheGenericContainerInitTriv::init(const TheGenericContainer<swift::Int>& SWIFT_NOESCAPE x) {
 // CHECK-NON_EVO-NEXT: return

--- a/test/Interop/SwiftToCxx/ownership/noescape-parameter-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/ownership/noescape-parameter-in-cxx.swift
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name NoEsc -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/noesc.h
+// RUN: %FileCheck %s < %t/noesc.h
+// RUN: %check-interop-cxx-header-in-clang(%t/noesc.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
+
+public struct ValueType { public var x: Int64 = 0 }
+public final class RefType { public init() {} }
+
+public func takeBorrowedValue(_ x: borrowing ValueType) {}
+public func takeDefaultValue(_ x: ValueType) {}
+public func takeInoutValue(_ x: inout ValueType) {}
+public func takeConsumingValue(_ x: consuming ValueType) {}
+
+public func takeBorrowedRef(_ x: borrowing RefType) {}
+public func takeInoutRef(_ x: inout RefType) {}
+
+public func takeInt(_ x: Int) {}
+public func takeInoutInt(_ x: inout Int) {}
+
+public func takeGeneric<T>(_ x: T) {}
+
+// CHECK: SWIFT_EXTERN void $s5NoEsc12takeInoutIntyySizF(ptrdiff_t * _Nonnull SWIFT_NOESCAPE x) SWIFT_NOEXCEPT SWIFT_CALL; // takeInoutInt(_:)
+
+// CHECK: SWIFT_INLINE_THUNK void takeBorrowedRef(const RefType& x) noexcept SWIFT_SYMBOL({{.*}}) {
+// CHECK: SWIFT_INLINE_THUNK void takeBorrowedValue(const ValueType& SWIFT_NOESCAPE x) noexcept SWIFT_SYMBOL({{.*}}) {
+// CHECK: SWIFT_INLINE_THUNK void takeConsumingValue(const ValueType& SWIFT_NOESCAPE x) noexcept SWIFT_SYMBOL({{.*}}) {
+// CHECK: SWIFT_INLINE_THUNK void takeDefaultValue(const ValueType& SWIFT_NOESCAPE x) noexcept SWIFT_SYMBOL({{.*}}) {
+// CHECK: SWIFT_INLINE_THUNK void takeGeneric(const T_0_0& x) noexcept SWIFT_SYMBOL({{.*}}) {
+// CHECK: SWIFT_INLINE_THUNK void takeInoutInt(swift::Int & SWIFT_NOESCAPE x) noexcept SWIFT_SYMBOL({{.*}}) {
+// CHECK: SWIFT_INLINE_THUNK void takeInoutRef(RefType& x) noexcept SWIFT_SYMBOL({{.*}}) {
+// CHECK: SWIFT_INLINE_THUNK void takeInoutValue(ValueType& SWIFT_NOESCAPE x) noexcept SWIFT_SYMBOL({{.*}}) {
+// CHECK: SWIFT_INLINE_THUNK void takeInt(swift::Int x) noexcept SWIFT_SYMBOL({{.*}}) {

--- a/test/Interop/SwiftToCxx/properties/setter-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/properties/setter-in-cxx.swift
@@ -58,9 +58,9 @@ public struct LargeStructWithProps {
 // CHECK:      class SWIFT_SYMBOL({{.*}}) LargeStructWithProps final {
 // CHECK-NEXT: public:
 // CHECK:      SWIFT_INLINE_THUNK LargeStruct getStoredLargeStruct() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK void setStoredLargeStruct(const LargeStruct& value) SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK void setStoredLargeStruct(const LargeStruct& SWIFT_NOESCAPE value) SWIFT_SYMBOL({{.*}});
 // CHECK-NEXT: SWIFT_INLINE_THUNK FirstSmallStruct getStoredSmallStruct() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK void setStoredSmallStruct(const FirstSmallStruct& value) SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK void setStoredSmallStruct(const FirstSmallStruct& SWIFT_NOESCAPE value) SWIFT_SYMBOL({{.*}});
 
 public final class PropertiesInClass {
     public var storedInt: Int32
@@ -118,7 +118,7 @@ public struct SmallStructWithProps {
 // CHECK-NEXT:    SWIFT_INLINE_THUNK swift::Int getComputedInt() const SWIFT_SYMBOL({{.*}});
 // CHECK-NEXT:    SWIFT_INLINE_THUNK void setComputedInt(swift::Int newValue) SWIFT_SYMBOL({{.*}});
 // CHECK-NEXT:    SWIFT_INLINE_THUNK LargeStructWithProps getLargeStructWithProps() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT:    SWIFT_INLINE_THUNK void setLargeStructWithProps(const LargeStructWithProps& newValue) SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:    SWIFT_INLINE_THUNK void setLargeStructWithProps(const LargeStructWithProps& SWIFT_NOESCAPE newValue) SWIFT_SYMBOL({{.*}});
 // CHECK-NEXT: private:
 
 public func createSmallStructWithProps() -> SmallStructWithProps {
@@ -155,7 +155,7 @@ public func createFirstSmallStruct(_ x: UInt32) -> FirstSmallStruct {
 // CHECK-NEXT:     _impl::$s10Properties20LargeStructWithPropsV06storedbC0AA0bC0Vvg(result, _getOpaquePointer());
 // CHECK-NEXT:   });
 // CHECK-NEXT:   }
-// CHECK-NEXT:   SWIFT_INLINE_THUNK void LargeStructWithProps::setStoredLargeStruct(const LargeStruct& value) {
+// CHECK-NEXT:   SWIFT_INLINE_THUNK void LargeStructWithProps::setStoredLargeStruct(const LargeStruct& SWIFT_NOESCAPE value) {
 // CHECK-NEXT:   _impl::$s10Properties20LargeStructWithPropsV06storedbC0AA0bC0Vvs(Properties::_impl::_impl_LargeStruct::getOpaquePointer(value), _getOpaquePointer());
 // CHECK-NEXT:   }
 // CHECK-NEXT:   SWIFT_INLINE_THUNK FirstSmallStruct LargeStructWithProps::getStoredSmallStruct() const {
@@ -163,7 +163,7 @@ public func createFirstSmallStruct(_ x: UInt32) -> FirstSmallStruct {
 // CHECK-NEXT:     _impl::swift_interop_returnDirect_Properties_uint32_t_0_4(result, Properties::_impl::$s10Properties20LargeStructWithPropsV011storedSmallC0AA05FirstgC0Vvg(_getOpaquePointer()));
 // CHECK-NEXT:   });
 // CHECK-NEXT:   }
-// CHECK-NEXT:   SWIFT_INLINE_THUNK void LargeStructWithProps::setStoredSmallStruct(const FirstSmallStruct& value) {
+// CHECK-NEXT:   SWIFT_INLINE_THUNK void LargeStructWithProps::setStoredSmallStruct(const FirstSmallStruct& SWIFT_NOESCAPE value) {
 // CHECK-NEXT:   _impl::$s10Properties20LargeStructWithPropsV011storedSmallC0AA05FirstgC0Vvs(Properties::_impl::swift_interop_passDirect_Properties_uint32_t_0_4(Properties::_impl::_impl_FirstSmallStruct::getOpaquePointer(value)), _getOpaquePointer());
 // CHECK-NEXT:   }
 
@@ -197,6 +197,6 @@ public func createFirstSmallStruct(_ x: UInt32) -> FirstSmallStruct {
 // CHECK-NEXT:    _impl::$s10Properties20SmallStructWithPropsV05largecdE0AA05LargecdE0Vvg(result, Properties::_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer()));
 // CHECK-NEXT:  });
 // CHECK-NEXT:  }
-// CHECK-NEXT:  SWIFT_INLINE_THUNK void SmallStructWithProps::setLargeStructWithProps(const LargeStructWithProps& newValue) {
+// CHECK-NEXT:  SWIFT_INLINE_THUNK void SmallStructWithProps::setLargeStructWithProps(const LargeStructWithProps& SWIFT_NOESCAPE newValue) {
 // CHECK-NEXT:  _impl::$s10Properties20SmallStructWithPropsV05largecdE0AA05LargecdE0Vvs(Properties::_impl::_impl_LargeStructWithProps::getOpaquePointer(newValue), _getOpaquePointer());
 // CHECK-NEXT:  }

--- a/test/Interop/SwiftToCxx/stdlib/optional/optional-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/optional/optional-in-cxx.swift
@@ -79,7 +79,7 @@ public func resetOpt<T>(_ val: inout Optional<T>) {
 // CHECK-NEXT: }
 
 
-// CHECK: SWIFT_INLINE_THUNK void takeCIntOpt(const swift::Optional<int>& val) noexcept SWIFT_SYMBOL("s:11UseOptional11takeCIntOptyys5Int32VSgF") {
+// CHECK: SWIFT_INLINE_THUNK void takeCIntOpt(const swift::Optional<int>& SWIFT_NOESCAPE val) noexcept SWIFT_SYMBOL("s:11UseOptional11takeCIntOptyys5Int32VSgF") {
 // CHECK-NEXT:  UseOptional::_impl::$s11UseOptional11takeCIntOptyys5Int32VSgF(UseOptional::_impl::swift_interop_passDirect_UseOptional_[[CINTENC]](swift::_impl::_impl_Optional<int>::getOpaquePointer(val)));
 // CHECK-NEXT: }
 
@@ -89,6 +89,6 @@ public func resetOpt<T>(_ val: inout Optional<T>) {
 // CHECK-NEXT: }
 
 
-// CHECK: SWIFT_INLINE_THUNK void takeSmallStructOpt(const swift::Optional<SmallStruct>& val) noexcept SWIFT_SYMBOL("s:11UseOptional18takeSmallStructOptyyAA0dE0VSgF") {
+// CHECK: SWIFT_INLINE_THUNK void takeSmallStructOpt(const swift::Optional<SmallStruct>& SWIFT_NOESCAPE val) noexcept SWIFT_SYMBOL("s:11UseOptional18takeSmallStructOptyyAA0dE0VSgF") {
 // CHECK-NEXT:  UseOptional::_impl::$s11UseOptional18takeSmallStructOptyyAA0dE0VSgF(UseOptional::_impl::swift_interop_passDirect_UseOptional_uint32_t_0_4(swift::_impl::_impl_Optional<SmallStruct>::getOpaquePointer(val)));
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
@@ -85,9 +85,9 @@
 // CHECK-NEXT:  SWIFT_INLINE_THUNK String &operator =(const String &other) noexcept {
 // CHECK:  }
 // CHECK-NEXT:  static SWIFT_INLINE_THUNK String init() SWIFT_SYMBOL({{.*}});
-// CHECK:  SWIFT_INLINE_THUNK void append(const String& other)
+// CHECK:  SWIFT_INLINE_THUNK void append(const String& SWIFT_NOESCAPE other)
 // CHECK:  SWIFT_INLINE_THUNK __StringNested::UTF8View getUtf8() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT:  SWIFT_INLINE_THUNK void setUtf8(const __StringNested::UTF8View& newValue) SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:  SWIFT_INLINE_THUNK void setUtf8(const __StringNested::UTF8View& SWIFT_NOESCAPE newValue) SWIFT_SYMBOL({{.*}});
 // CHECK:  SWIFT_INLINE_THUNK operator NSString * _Nonnull () const noexcept {
 // CHECK-NEXT:    return (__bridge_transfer NSString *)(_impl::$sSS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF(_impl::swift_interop_passDirect_Swift_String(_getOpaquePointer())));
 // CHECK-NEXT:   }
@@ -122,12 +122,12 @@
 // CHECK: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK __StringNested::Index getStartIndex() const SWIFT_SYMBOL({{.*}});
 // CHECK-NEXT:   SWIFT_INLINE_THUNK __StringNested::Index getEndIndex() const SWIFT_SYMBOL({{.*}});
-// CHECK:   SWIFT_INLINE_THUNK swift::Optional<__StringNested::Index> indexOffsetByLimitedBy(const __StringNested::Index& i, swift::Int n, const __StringNested::Index& limit) const SWIFT_SYMBOL({{.*}});
-// CHECK:   SWIFT_INLINE_THUNK swift::Int distanceFromTo(const __StringNested::Index& i, const __StringNested::Index& j) const SWIFT_SYMBOL({{.*}});
-// CHECK: SWIFT_INLINE_THUNK uint8_t operator [](const __StringNested::Index& i) const SWIFT_SYMBOL({{.*}});
+// CHECK:   SWIFT_INLINE_THUNK swift::Optional<__StringNested::Index> indexOffsetByLimitedBy(const __StringNested::Index& SWIFT_NOESCAPE i, swift::Int n, const __StringNested::Index& SWIFT_NOESCAPE limit) const SWIFT_SYMBOL({{.*}});
+// CHECK:   SWIFT_INLINE_THUNK swift::Int distanceFromTo(const __StringNested::Index& SWIFT_NOESCAPE i, const __StringNested::Index& SWIFT_NOESCAPE j) const SWIFT_SYMBOL({{.*}});
+// CHECK: SWIFT_INLINE_THUNK uint8_t operator [](const __StringNested::Index& SWIFT_NOESCAPE i) const SWIFT_SYMBOL({{.*}});
 // CHECK:   SWIFT_INLINE_THUNK String getDescription() const SWIFT_SYMBOL({{.*}});
 // CHECK:   SWIFT_INLINE_THUNK swift::Int getCount() const SWIFT_SYMBOL({{.*}});
-// CHECK:   SWIFT_INLINE_THUNK bool isTriviallyIdenticalTo(const __StringNested::UTF8View& other) const SWIFT_SYMBOL({{.*}}){{.*}};
+// CHECK:   SWIFT_INLINE_THUNK bool isTriviallyIdenticalTo(const __StringNested::UTF8View& SWIFT_NOESCAPE other) const SWIFT_SYMBOL({{.*}}){{.*}};
 // CHECK-NEXT: private:
 
 // CHECK: class AnyKeyPath { } SWIFT_UNAVAILABLE_MSG("class 'AnyKeyPath' is not yet exposed to C++");

--- a/test/Interop/SwiftToCxx/structs/large-structs-pass-return-indirect-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/large-structs-pass-return-indirect-in-cxx.swift
@@ -31,19 +31,19 @@ public func inoutStructSeveralI64(_ s: inout StructSeveralI64) {
     s.x5 = -5
 }
 
-// CHECK:      SWIFT_INLINE_THUNK void inoutStructSeveralI64(StructSeveralI64& s) noexcept SWIFT_SYMBOL("s:7Structs21inoutStructSeveralI64yyAA0cdE0VzF") {
+// CHECK:      SWIFT_INLINE_THUNK void inoutStructSeveralI64(StructSeveralI64& SWIFT_NOESCAPE s) noexcept SWIFT_SYMBOL("s:7Structs21inoutStructSeveralI64yyAA0cdE0VzF") {
 // CHECK-NEXT:   Structs::_impl::$s7Structs21inoutStructSeveralI64yyAA0cdE0VzF(Structs::_impl::_impl_StructSeveralI64::getOpaquePointer(s));
 // CHECK-NEXT: }
 
 
-// CHECK: SWIFT_INLINE_THUNK StructSeveralI64 passThroughStructSeveralI64(int64_t i, const StructSeveralI64& x, float j) noexcept SWIFT_SYMBOL("s:7Structs27passThroughStructSeveralI641i_1jAA0deF0Vs5Int64V_AFSftF") SWIFT_WARN_UNUSED_RESULT {
+// CHECK: SWIFT_INLINE_THUNK StructSeveralI64 passThroughStructSeveralI64(int64_t i, const StructSeveralI64& SWIFT_NOESCAPE x, float j) noexcept SWIFT_SYMBOL("s:7Structs27passThroughStructSeveralI641i_1jAA0deF0Vs5Int64V_AFSftF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return Structs::_impl::_impl_StructSeveralI64::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:    Structs::_impl::$s7Structs27passThroughStructSeveralI641i_1jAA0deF0Vs5Int64V_AFSftF(result, i, Structs::_impl::_impl_StructSeveralI64::getOpaquePointer(x), j);
 // CHECK-NEXT:  });
 // CHECK-NEXT: }
 
 
-// CHECK: SWIFT_INLINE_THUNK void printStructSeveralI64(const StructSeveralI64& x) noexcept SWIFT_SYMBOL("s:7Structs21printStructSeveralI64yyAA0cdE0VF") {
+// CHECK: SWIFT_INLINE_THUNK void printStructSeveralI64(const StructSeveralI64& SWIFT_NOESCAPE x) noexcept SWIFT_SYMBOL("s:7Structs21printStructSeveralI64yyAA0cdE0VF") {
 // CHECK-NEXT:  Structs::_impl::$s7Structs21printStructSeveralI64yyAA0cdE0VF(Structs::_impl::_impl_StructSeveralI64::getOpaquePointer(x));
 // CHECK-NEXT: }
 

--- a/test/Interop/SwiftToCxx/structs/resilient-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/resilient-struct-in-cxx.swift
@@ -232,11 +232,11 @@ public func mutateSmall(_ x: inout FirstSmallStruct) {
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
-// CHECK:      SWIFT_INLINE_THUNK void mutateSmall(FirstSmallStruct& x) noexcept SWIFT_SYMBOL({{.*}}) {
+// CHECK:      SWIFT_INLINE_THUNK void mutateSmall(FirstSmallStruct& SWIFT_NOESCAPE x) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT:   Structs::_impl::$s7Structs11mutateSmallyyAA05FirstC6StructVzF(Structs::_impl::_impl_FirstSmallStruct::getOpaquePointer(x));
 // CHECK-NEXT: }
 
-// CHECK:      SWIFT_INLINE_THUNK void printSmallAndLarge(const FirstSmallStruct& x, const LargeStruct& y) noexcept SWIFT_SYMBOL({{.*}}) {
+// CHECK:      SWIFT_INLINE_THUNK void printSmallAndLarge(const FirstSmallStruct& SWIFT_NOESCAPE x, const LargeStruct& SWIFT_NOESCAPE y) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT:   Structs::_impl::$s7Structs18printSmallAndLargeyyAA05FirstC6StructV_AA0eG0VtF(Structs::_impl::_impl_FirstSmallStruct::getOpaquePointer(x), Structs::_impl::_impl_LargeStruct::getOpaquePointer(y));
 // CHECK-NEXT: }
 

--- a/test/Interop/SwiftToCxx/structs/small-structs-pass-return-direct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/small-structs-pass-return-direct-in-cxx.swift
@@ -120,61 +120,61 @@ public func inoutStructDoubleAndFloat(_ s: inout StructDoubleAndFloat) {
     s.y /= 10
 }
 
-// CHECK: SWIFT_INLINE_THUNK double getStructDoubleAndFloat_x(const StructDoubleAndFloat& x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
+// CHECK: SWIFT_INLINE_THUNK double getStructDoubleAndFloat_x(const StructDoubleAndFloat& SWIFT_NOESCAPE x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return Structs::_impl::$s7Structs25getStructDoubleAndFloat_xySdAA0cdeF0VF(Structs::_impl::swift_interop_passDirect_Structs_double_0_8_float_8_12(Structs::_impl::_impl_StructDoubleAndFloat::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 
-// CHECK: SWIFT_INLINE_THUNK float getStructDoubleAndFloat_y(const StructDoubleAndFloat& x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
+// CHECK: SWIFT_INLINE_THUNK float getStructDoubleAndFloat_y(const StructDoubleAndFloat& SWIFT_NOESCAPE x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return Structs::_impl::$s7Structs25getStructDoubleAndFloat_yySfAA0cdeF0VF(Structs::_impl::swift_interop_passDirect_Structs_double_0_8_float_8_12(Structs::_impl::_impl_StructDoubleAndFloat::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 
-// CHECK: SWIFT_INLINE_THUNK uint8_t getStructU16AndPointer_x(const StructU16AndPointer& x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
+// CHECK: SWIFT_INLINE_THUNK uint8_t getStructU16AndPointer_x(const StructU16AndPointer& SWIFT_NOESCAPE x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return Structs::_impl::$s7Structs24getStructU16AndPointer_xys5UInt8VAA0cdeF0VF(Structs::_impl::swift_interop_passDirect_Structs_[[StructU16AndPointer:[0-9a-z_]+]](Structs::_impl::_impl_StructU16AndPointer::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 
-// CHECK: SWIFT_INLINE_THUNK void * _Nonnull getStructU16AndPointer_y(const StructU16AndPointer& x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
+// CHECK: SWIFT_INLINE_THUNK void * _Nonnull getStructU16AndPointer_y(const StructU16AndPointer& SWIFT_NOESCAPE x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return Structs::_impl::$s7Structs24getStructU16AndPointer_yySvAA0cdeF0VF(Structs::_impl::swift_interop_passDirect_Structs_[[StructU16AndPointer]](Structs::_impl::_impl_StructU16AndPointer::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 
-// CHECK:      SWIFT_INLINE_THUNK void inoutStructDoubleAndFloat(StructDoubleAndFloat& s) noexcept SWIFT_SYMBOL({{.*}}) {
+// CHECK:      SWIFT_INLINE_THUNK void inoutStructDoubleAndFloat(StructDoubleAndFloat& SWIFT_NOESCAPE s) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT:   Structs::_impl::$s7Structs25inoutStructDoubleAndFloatyyAA0cdeF0VzF(Structs::_impl::_impl_StructDoubleAndFloat::getOpaquePointer(s));
 // CHECK-NEXT: }
 
 
-// CHECK:      SWIFT_INLINE_THUNK void inoutStructOneI16AndOneStruct(StructOneI16AndOneStruct& s, const StructTwoI32& s2) noexcept SWIFT_SYMBOL({{.*}}) {
+// CHECK:      SWIFT_INLINE_THUNK void inoutStructOneI16AndOneStruct(StructOneI16AndOneStruct& SWIFT_NOESCAPE s, const StructTwoI32& SWIFT_NOESCAPE s2) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT:   Structs::_impl::$s7Structs020inoutStructOneI16AnddC0yyAA0cdefdC0Vz_AA0C6TwoI32VtF(Structs::_impl::_impl_StructOneI16AndOneStruct::getOpaquePointer(s), Structs::_impl::swift_interop_passDirect_Structs_[[StructTwoI32]](Structs::_impl::_impl_StructTwoI32::getOpaquePointer(s2)));
 // CHECK-NEXT: }
 
 
-// CHECK: SWIFT_INLINE_THUNK StructOneI64 passThroughStructOneI64(const StructOneI64& x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
+// CHECK: SWIFT_INLINE_THUNK StructOneI64 passThroughStructOneI64(const StructOneI64& SWIFT_NOESCAPE x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return Structs::_impl::_impl_StructOneI64::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:    Structs::_impl::swift_interop_returnDirect_Structs_uint64_t_0_8(result, Structs::_impl::$s7Structs23passThroughStructOneI64yAA0deF0VADF(Structs::_impl::swift_interop_passDirect_Structs_uint64_t_0_8(Structs::_impl::_impl_StructOneI64::getOpaquePointer(x))));
 // CHECK-NEXT:  });
 // CHECK-NEXT: }
 
 
-// CHECK: SWIFT_INLINE_THUNK StructTwoI32 passThroughStructTwoI32(int32_t i, const StructTwoI32& x, int32_t j) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
+// CHECK: SWIFT_INLINE_THUNK StructTwoI32 passThroughStructTwoI32(int32_t i, const StructTwoI32& SWIFT_NOESCAPE x, int32_t j) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return Structs::_impl::_impl_StructTwoI32::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:    Structs::_impl::swift_interop_returnDirect_Structs_[[StructTwoI32]](result, Structs::_impl::$s7Structs23passThroughStructTwoI32yAA0deF0Vs5Int32V_AdFtF(i, Structs::_impl::swift_interop_passDirect_Structs_[[StructTwoI32]](Structs::_impl::_impl_StructTwoI32::getOpaquePointer(x)), j));
 // CHECK-NEXT:  });
 // CHECK-NEXT: }
 
 
-// CHECK: SWIFT_INLINE_THUNK void printStructOneI64(const StructOneI64& x) noexcept SWIFT_SYMBOL({{.*}}) {
+// CHECK: SWIFT_INLINE_THUNK void printStructOneI64(const StructOneI64& SWIFT_NOESCAPE x) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT:   Structs::_impl::$s7Structs17printStructOneI64yyAA0cdE0VF(Structs::_impl::swift_interop_passDirect_Structs_uint64_t_0_8(Structs::_impl::_impl_StructOneI64::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 
-// CHECK: SWIFT_INLINE_THUNK void printStructStructTwoI32_and_OneI16AndOneStruct(const StructTwoI32& y, const StructOneI16AndOneStruct& x) noexcept SWIFT_SYMBOL({{.*}}) {
+// CHECK: SWIFT_INLINE_THUNK void printStructStructTwoI32_and_OneI16AndOneStruct(const StructTwoI32& SWIFT_NOESCAPE y, const StructOneI16AndOneStruct& SWIFT_NOESCAPE x) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT:  Structs::_impl::$s7Structs011printStructc20TwoI32_and_OneI16AndgC0yyAA0cdE0V_AA0cghigC0VtF(Structs::_impl::swift_interop_passDirect_Structs_[[StructTwoI32]](Structs::_impl::_impl_StructTwoI32::getOpaquePointer(y)), Structs::_impl::swift_interop_passDirect_Structs_[[StructOneI16AndOneStruct:[0-9a-z_]+]](Structs::_impl::_impl_StructOneI16AndOneStruct::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 
-// CHECK: SWIFT_INLINE_THUNK void printStructTwoI32(const StructTwoI32& x) noexcept SWIFT_SYMBOL({{.*}}) {
+// CHECK: SWIFT_INLINE_THUNK void printStructTwoI32(const StructTwoI32& SWIFT_NOESCAPE x) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT:  Structs::_impl::$s7Structs17printStructTwoI32yyAA0cdE0VF(Structs::_impl::swift_interop_passDirect_Structs_[[StructTwoI32]](Structs::_impl::_impl_StructTwoI32::getOpaquePointer(x)));
 // CHECK-NEXT: }
 


### PR DESCRIPTION
In some scenarios, Swift is guaranteed to not escape the reference or pointer that was passed to it. This PR makes sure the header communicates this information to the C++ compiler. This can help both optimization and lifetime analysis.

rdar://182942386
