### PR TITLE
utils: Use DebugFormat in Build-SPMProject

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2548,7 +2548,7 @@ function Build-SPMProject {
       "-c", $Configuration
     )
     if ($DebugInfo) {
-      if ($Platform.OS -eq [OS]::Windows) {
+      if ($Platform.DebugFormat -eq "codeview") {
         $Arguments += @("-debug-info-format", "codeview")
       } else {
         $Arguments += @("-debug-info-format", "dwarf")

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2548,11 +2548,7 @@ function Build-SPMProject {
       "-c", $Configuration
     )
     if ($DebugInfo) {
-      if ($Platform.DebugFormat -eq "codeview") {
-        $Arguments += @("-debug-info-format", "codeview")
-      } else {
-        $Arguments += @("-debug-info-format", "dwarf")
-      }
+      $Arguments += @("-debug-info-format", $Platform.DebugFormat)
     } else {
       $Arguments += @("-debug-info-format", "none")
     }


### PR DESCRIPTION
It is cleaner to use `$Platform.DebugFormat` as the source of truth for the debug arguments to use for SPM.

Follow-up from #90940.