### PR TITLE
[cxx-interop] Add a concept of a direct view

### DIFF
--- a/lib/ClangImporter/ClangAnalysis.cpp
+++ b/lib/ClangImporter/ClangAnalysis.cpp
@@ -9,6 +9,7 @@
 #include "clang/AST/RecordLayout.h"
 #include "clang/AST/Type.h"
 #include "clang/Basic/Specifiers.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 
@@ -24,6 +25,120 @@ bool importer::hasImportAsOpaquePointerAttr(const clang::RecordDecl *decl) {
              return swiftAttr->getAttribute() == "import_opaque_pointer";
            return false;
          });
+}
+
+//===----------------------------------------------------------------------===//
+// Direct view analysis
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+/// Whether \p type is "self-contained" for the purpose of direct-view
+/// inference: it is escapable (SWIFT_ESCAPABLE), a foreign reference type
+/// (SWIFT_SHARED_REFERENCE / SWIFT_IMMORTAL_REFERENCE), or a record explicitly
+/// annotated SWIFT_SELF_CONTAINED (import_owned). A record explicitly marked
+/// unsafe is never self-contained, which also excludes
+/// SWIFT_UNSAFE_REFERENCE.
+bool isSelfContainedForDirectView(const clang::Type *type, Evaluator &eval) {
+  type = type->getUnqualifiedDesugaredType();
+
+  // A function (pointer) refers to code, and a pointer to member is an offset
+  // rather than an address, so neither can dangle.
+  if (type->isFunctionPointerType() || type->isFunctionType() ||
+      type->isMemberPointerType())
+    return true;
+
+  if (const auto *recordType = type->getAs<clang::RecordType>()) {
+    auto *definition = recordType->getDecl()->getDefinition();
+    if (!definition)
+      return false;
+    // An explicitly unsafe type is never self-contained, so its unsafety is
+    // not silently dropped by an enclosing view.
+    if (importer::hasSwiftAttribute(definition, {"unsafe"}))
+      return false;
+    // Reference types are managed by Swift, so a pointer to one does not
+    // introduce a lifetime dependency. Use the request rather than a raw
+    // attribute lookup, so that reference-ness inherited from a base class is
+    // taken into account.
+    if (evaluateOrDefault(eval, ForeignReferenceTypeInfoRequest({definition}),
+                          ForeignReferenceTypeInfo())
+            .isReference())
+      return true;
+    if (importer::hasOwnedValueAttr(definition))
+      return true;
+  }
+
+  return evaluateOrDefault(eval, ClangTypeEscapability({type, nullptr}),
+                           CxxEscapability::Unknown) ==
+         CxxEscapability::Escapable;
+}
+
+bool isDirectViewTypeImpl(const clang::Type *type, Evaluator &eval,
+                          llvm::SmallDenseSet<const clang::Decl *, 4> &seen) {
+  type = type->getUnqualifiedDesugaredType();
+
+  // (A) A pointer or reference is a direct view if its pointee is
+  // self-contained. Block and ObjC-object pointers are not "pointers into a
+  // buffer of self-contained objects", so they are deliberately not matched
+  // here.
+  if (type->isPointerType() || type->isReferenceType()) {
+    clang::QualType pointee = type->getPointeeType();
+    // We do not know what is stored at the pointed-to memory, so a `void *`
+    // cannot be a pointer into a buffer of self-contained objects.
+    if (pointee->isFunctionType() || pointee->isVoidType())
+      return false;
+    return isSelfContainedForDirectView(pointee.getTypePtr(), eval);
+  }
+
+  // (B) A record is a direct view if every field and base is either
+  // self-contained or itself a direct view. A record with no indirection at
+  // all is treated as having a single level of indirection, so that a
+  // non-escapable marker type (`struct SWIFT_NONESCAPABLE Token { long id; };`)
+  // stays a direct view: it holds no pointer, so nothing in it can dangle.
+  if (const auto *recordType = type->getAs<clang::RecordType>()) {
+    auto *recordDecl = recordType->getDecl()->getDefinition();
+    if (!recordDecl)
+      return false;
+    if (importer::hasSwiftAttribute(recordDecl, {"unsafe"}))
+      return false;
+    if (!seen.insert(recordDecl).second)
+      return true;
+
+    auto isSelfContainedOrDirectView = [&](clang::QualType t) {
+      const clang::Type *ty = t.getTypePtr();
+      return isSelfContainedForDirectView(ty, eval) ||
+             isDirectViewTypeImpl(ty, eval, seen);
+    };
+
+    if (const auto *cxxRecordDecl =
+            dyn_cast<clang::CXXRecordDecl>(recordDecl)) {
+      for (auto base : cxxRecordDecl->bases())
+        if (!isSelfContainedOrDirectView(base.getType()))
+          return false;
+    }
+    for (auto *field : recordDecl->fields())
+      if (!isSelfContainedOrDirectView(field->getType()))
+        return false;
+    return true;
+  }
+
+  // (C) Anything else is not itself a direct view.
+  return false;
+}
+
+} // end anonymous namespace
+
+bool importer::isDirectViewType(const clang::Type *type, Evaluator &eval) {
+  llvm::SmallDenseSet<const clang::Decl *, 4> seen;
+  return isDirectViewTypeImpl(type, eval, seen);
+}
+
+bool importer::isDirectViewType(const clang::Decl *decl, ASTContext &swiftCtx) {
+  if (const auto *typeDecl = dyn_cast<clang::TypeDecl>(decl)) {
+    clang::QualType type = typeDecl->getASTContext().getTypeDeclType(typeDecl);
+    return isDirectViewType(type.getTypePtr(), swiftCtx.evaluator);
+  }
+  return false;
 }
 
 namespace {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -9095,12 +9095,24 @@ ExplicitSafety ClangDeclExplicitSafety::evaluate(
       continue;
     }
 
-    // Escapability annotations imply that the declaration is safe
-    if (evaluateOrDefault(
-            evaluator,
-            ClangTypeEscapability({recordDecl->getTypeForDecl(), nullptr}),
-            CxxEscapability::Unknown) != CxxEscapability::Unknown)
+    // Escapability tells us how to treat this record's safety.
+    switch (evaluateOrDefault(
+        evaluator,
+        ClangTypeEscapability({recordDecl->getTypeForDecl(), nullptr}),
+        CxxEscapability::Unknown)) {
+    case CxxEscapability::Escapable:
+      // A self-contained (escapable) type is safe.
       continue;
+    case CxxEscapability::NonEscapable:
+      // A non-escapable "view" is safe only if it is a *direct* view. Views
+      // with more complex lifetime dependencies are imported as unsafe.
+      if (importer::isDirectViewType(recordDecl->getTypeForDecl(), evaluator))
+        continue;
+      return ExplicitSafety::Unsafe;
+    case CxxEscapability::Unknown:
+      // Fall through to the field/base and template-argument checks below.
+      break;
+    }
 
     // A template class is unsafe if any of its type arguments are unsafe.
     // Note that this does not rely on the record being defined.

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -2292,6 +2292,20 @@ getCxxValueSemanticsKind(const clang::Type *type,
 
 bool isViewType(const clang::CXXRecordDecl *decl);
 
+/// Determine whether \p type is a "direct view": a pointer or reference to a
+/// self-contained pointee, or a record (including a class template
+/// specialization) in which every field and base is either self-contained or
+/// itself a direct view. Here "self-contained" means escapable
+/// (SWIFT_ESCAPABLE), a foreign reference type, or a type annotated
+/// SWIFT_SELF_CONTAINED (import_owned); a type explicitly marked unsafe is
+/// never self-contained. Incomplete/forward-declared types, `void` pointees,
+/// and function pointees are never direct views.
+///
+/// This is meant to be called on types that are imported as views, i.e. types
+/// that are non-escapable.
+bool isDirectViewType(const clang::Type *type, Evaluator &eval);
+bool isDirectViewType(const clang::Decl *decl, ASTContext &swiftCtx);
+
 inline const clang::Type *desugarIfElaborated(const clang::Type *type) {
   if (auto elaborated = dyn_cast<clang::ElaboratedType>(type))
     return elaborated->desugar().getTypePtr();

--- a/unittests/ClangImporter/CMakeLists.txt
+++ b/unittests/ClangImporter/CMakeLists.txt
@@ -3,6 +3,8 @@ configure_file(${SWIFT_SOURCE_DIR}/stdlib/public/Cxx/libstdcxx/libstdcxx.modulem
 
 add_swift_unittest(SwiftClangImporterTests
   ClangImporterTests.cpp
+  CxxInteropTestHarness.cpp
+  CxxDirectViewTests.cpp
 )
 
 target_link_libraries(SwiftClangImporterTests
@@ -11,4 +13,10 @@ target_link_libraries(SwiftClangImporterTests
     swiftSema
     swiftParse
     swiftAST
+    swiftSIL
+    swiftSerialization
 )
+
+target_compile_definitions(SwiftClangImporterTests PRIVATE
+  SWIFTLIB_DIR=\"${SWIFTLIB_DIR}\")
+

--- a/unittests/ClangImporter/CxxDirectViewTests.cpp
+++ b/unittests/ClangImporter/CxxDirectViewTests.cpp
@@ -1,0 +1,281 @@
+//===--- CxxDirectViewTests.cpp -------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Unit tests for the "direct view" classifier (importer::isDirectViewType) and
+// the corresponding safety of imported non-escapable C++ types.
+//
+//===----------------------------------------------------------------------===//
+
+#include "CxxInteropTestHarness.h"
+#include "../../lib/ClangImporter/ImporterImpl.h"
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/Decl.h"
+#include "clang/AST/DeclBase.h"
+#include "gtest/gtest.h"
+
+using namespace swift;
+using namespace swift::unittest;
+
+namespace {
+
+/// Import \p cxxSource and return whether the C++ type named \p name is a
+/// direct view (runs `importer::isDirectViewType` on the clang decl).
+bool isDirectView(StringRef cxxSource, StringRef name) {
+  bool result = false;
+  import(cxxSource).checkCppDecl(name,
+                                 [&](const clang::Decl *d, ASTContext &ctx) {
+                                   result = importer::isDirectViewType(d, ctx);
+                                 });
+  return result;
+}
+
+/// Import \p cxxSource and return the explicit safety of the imported Swift
+/// decl named \p name.
+ExplicitSafety importedSafety(StringRef cxxSource, StringRef name) {
+  ExplicitSafety result = ExplicitSafety::Unspecified;
+  import(cxxSource).checkDecl(name, [&](ValueDecl *d) {
+    result = d->getExplicitSafety();
+  });
+  return result;
+}
+
+} // end anonymous namespace
+
+//===----------------------------------------------------------------------===//
+// isDirectViewType classifier
+//===----------------------------------------------------------------------===//
+
+TEST(CxxDirectView, PointerToSelfContainedIsDirectView) {
+  EXPECT_TRUE(isDirectView("struct S { int *p; };", "S"));
+}
+
+TEST(CxxDirectView, StringRefLikeStructIsDirectView) {
+  EXPECT_TRUE(
+      isDirectView("struct StringRef { char *p; unsigned long n; };", "StringRef"));
+}
+
+TEST(CxxDirectView, MultipleDirectViewMembersIsDirectView) {
+  EXPECT_TRUE(
+      isDirectView("struct StringView { const char *begin, *end; };", "StringView"));
+}
+
+TEST(CxxDirectView, DoublePointerIsNotDirectView) {
+  EXPECT_FALSE(isDirectView("struct S { int **pp; };", "S"));
+}
+
+TEST(CxxDirectView, StructStoringPointerToViewIsNotDirectView) {
+  EXPECT_FALSE(isDirectView("struct StringRef { char *p; unsigned long n; };\n"
+                            "struct Holder { StringRef *ref; };",
+                            "Holder"));
+}
+
+TEST(CxxDirectView, SpanOfSelfContainedIsDirectView) {
+  EXPECT_TRUE(isDirectView(
+      "template <class X> struct Span { X *data; unsigned long n; };\n"
+      "template struct Span<int>;\n"
+      "typedef Span<int> SpanInt;",
+      "SpanInt"));
+}
+
+TEST(CxxDirectView, SpanOfViewIsNotDirectView) {
+  EXPECT_FALSE(isDirectView(
+      "struct View { int *p; };\n"
+      "template <class X> struct Span { X *data; unsigned long n; };\n"
+      "template struct Span<View>;\n"
+      "typedef Span<View> SpanView;",
+      "SpanView"));
+}
+
+TEST(CxxDirectView, PointerToSelfContainedRecordIsDirectView) {
+  EXPECT_TRUE(isDirectView(
+      "struct " SWIFT_TEST_SELF_CONTAINED " Owned { char *storage; };\n"
+      "struct View { Owned *owned; };",
+      "View"));
+}
+
+TEST(CxxDirectView, NestedDirectViewStructByValueIsDirectView) {
+  EXPECT_TRUE(isDirectView("struct StringRef { char *p; unsigned long n; };\n"
+                           "struct Nested { StringRef sv; };",
+                           "Nested"));
+}
+
+TEST(CxxDirectView, VoidPointerIsNotDirectView) {
+  EXPECT_FALSE(isDirectView("struct S { void *p; };", "S"));
+}
+
+TEST(CxxDirectView, PointerToForeignReferenceTypeIsDirectView) {
+  EXPECT_TRUE(isDirectView("struct " SWIFT_TEST_IMPORT_REFERENCE
+                           " Obj { int x; };\n"
+                           "struct View { Obj *o; };",
+                           "View"));
+}
+
+TEST(CxxDirectView, SafeAnnotatedPointeeBehavesLikeUnannotated) {
+  EXPECT_EQ(isDirectView("struct " SWIFT_TEST_SAFE " T { int h; };\n"
+                         "struct View { T *p; };",
+                         "View"),
+            isDirectView("struct T { int h; };\n"
+                         "struct View { T *p; };",
+                         "View"));
+  EXPECT_EQ(isDirectView("struct " SWIFT_TEST_SAFE " T { void *h; };\n"
+                         "struct View { T *p; };",
+                         "View"),
+            isDirectView("struct T { void *h; };\n"
+                         "struct View { T *p; };",
+                         "View"));
+}
+
+TEST(CxxDirectView, PointerToInheritedForeignReferenceTypeIsDirectView) {
+  EXPECT_TRUE(isDirectView("struct " SWIFT_TEST_IMPORT_REFERENCE
+                           " Base { int x; };\n"
+                           "struct Derived : Base {};\n"
+                           "struct View { Derived *o; };",
+                           "View"));
+}
+
+TEST(CxxDirectView, PointerToUnsafeReferenceTypeIsNotDirectView) {
+  // SWIFT_UNSAFE_REFERENCE is a reference type that is also explicitly marked
+  // unsafe; the unsafety must not be dropped.
+  EXPECT_FALSE(isDirectView("struct " SWIFT_TEST_IMPORT_REFERENCE
+                            " " SWIFT_TEST_UNSAFE " Obj { int x; };\n"
+                            "struct View { Obj *o; };",
+                            "View"));
+}
+
+TEST(CxxDirectView, PointerToEscapableUnsafeTypeIsNotDirectView) {
+  // An escapable type that is explicitly marked unsafe must not be treated as
+  // a safe pointee.
+  EXPECT_FALSE(isDirectView("struct " SWIFT_TEST_ESCAPABLE " " SWIFT_TEST_UNSAFE
+                            " EscUnsafe { int x; };\n"
+                            "struct View { EscUnsafe *p; };",
+                            "View"));
+}
+
+TEST(CxxDirectView, DirectViewBaseIsDirectView) {
+  EXPECT_TRUE(isDirectView("struct Base { int *p; };\n"
+                           "struct Derived : Base {};",
+                           "Derived"));
+}
+
+TEST(CxxDirectView, NonDirectViewBaseIsNotDirectView) {
+  EXPECT_FALSE(isDirectView("struct Base { int **pp; };\n"
+                            "struct Derived : Base {};",
+                            "Derived"));
+}
+
+TEST(CxxDirectView, SharedByValueSubobjectIsDirectView) {
+  // Both fields have the same record type, exercising the visited-set
+  // de-duplication in the classifier.
+  EXPECT_TRUE(isDirectView("struct Leaf { int *p; };\n"
+                           "struct S { Leaf a; Leaf b; };",
+                           "S"));
+}
+
+TEST(CxxDirectView, ReferenceToSelfContainedIsDirectView) {
+  EXPECT_TRUE(isDirectView("struct S { int &r; };", "S"));
+}
+
+TEST(CxxDirectView, FunctionPointerFieldIsDirectView) {
+  EXPECT_TRUE(isDirectView("struct S { void (*fn)(); };", "S"));
+  EXPECT_TRUE(isDirectView("struct S { void (*fn)(); const int *ctx; };", "S"));
+}
+
+TEST(CxxDirectView, MemberPointerFieldIsDirectView) {
+  EXPECT_TRUE(isDirectView("struct Host { int m; };\n"
+                           "struct S { int Host::*mp; const int *ctx; };",
+                           "S"));
+  EXPECT_TRUE(isDirectView("struct Host { void f(); };\n"
+                           "struct S { void (Host::*mf)(); const int *ctx; };",
+                           "S"));
+}
+
+TEST(CxxDirectView, SelfReferentialStructIsNotDirectView) {
+  // `Node *` points to a non-self-contained type (Node has pointer members), so
+  // it is not a direct view.
+  EXPECT_FALSE(isDirectView("struct Node { Node *next; };", "Node"));
+}
+
+TEST(CxxDirectView, IncompleteTypeIsNotDirectView) {
+  // `Incomplete` is only forward-declared, so we cannot enumerate its fields
+  // and must conservatively treat a pointer to it as not a direct view.
+  EXPECT_FALSE(isDirectView("struct Incomplete;\n"
+                            "struct S { Incomplete *p; };",
+                            "S"));
+}
+
+// An optional-like wrapper stores its payload in an anonymous union. The
+// structural field walk sees through the union's fields, so no special case is
+// needed: such a wrapper is a direct view exactly when its payload is a view
+// with a single level of indirection.
+#define OPTIONAL_LIKE                                                          \
+  "template <class T> struct optional {\n"                                     \
+  "  union { char none; T value; };\n"                                         \
+  "  bool engaged;\n"                                                          \
+  "  optional() : none(0), engaged(false) {}\n"                                \
+  "  ~optional() {}\n"                                                         \
+  "};\n"
+
+TEST(CxxDirectView, OptionalOfDirectViewIsDirectView) {
+  EXPECT_TRUE(isDirectView(OPTIONAL_LIKE "struct View { int *p; };\n"
+                                         "template struct optional<View>;\n"
+                                         "typedef optional<View> OptView;",
+                           "OptView"));
+}
+
+TEST(CxxDirectView, OptionalOfNonDirectViewIsNotDirectView) {
+  EXPECT_FALSE(isDirectView(OPTIONAL_LIKE
+                            "struct Indirect { int **pp; };\n"
+                            "template struct optional<Indirect>;\n"
+                            "typedef optional<Indirect> OptIndirect;",
+                            "OptIndirect"));
+}
+
+//===----------------------------------------------------------------------===//
+// Imported safety of non-escapable types
+//===----------------------------------------------------------------------===//
+
+TEST(CxxDirectView, DirectViewImportedAsSafe) {
+  EXPECT_EQ(importedSafety(
+                "struct " SWIFT_TEST_NONESCAPABLE " View { const int *p; };",
+                "View"),
+            ExplicitSafety::Safe);
+}
+
+TEST(CxxDirectView, NonDirectViewImportedAsUnsafe) {
+  EXPECT_EQ(importedSafety("struct " SWIFT_TEST_NONESCAPABLE " V { int *p; };\n"
+                           "struct " SWIFT_TEST_NONESCAPABLE " VV { V **pp; };",
+                           "VV"),
+            ExplicitSafety::Unsafe);
+}
+
+TEST(CxxDirectView, NonDirectViewFieldMakesEnclosingViewUnsafe) {
+  // Exercises the classifier recursing into a by-value non-escapable field: the
+  // inner view is not a direct view (double pointer), so the outer view is
+  // unsafe too.
+  EXPECT_EQ(importedSafety(
+                "struct V { int *p; };\n"
+                "struct " SWIFT_TEST_NONESCAPABLE " Inner { V **pp; };\n"
+                "struct " SWIFT_TEST_NONESCAPABLE " Outer { Inner i; };",
+                "Outer"),
+            ExplicitSafety::Unsafe);
+}
+
+TEST(CxxDirectView, ExplicitlyUnsafeSubobjectMakesViewUnsafe) {
+  // `Owned` is self-contained (import_owned) but explicitly marked unsafe, so a
+  // view containing it must not be silently imported as safe.
+  EXPECT_EQ(importedSafety(
+                "struct " SWIFT_TEST_SELF_CONTAINED " " SWIFT_TEST_UNSAFE
+                " Owned { char *p; };\n"
+                "struct " SWIFT_TEST_NONESCAPABLE " V { Owned o; };",
+                "V"),
+            ExplicitSafety::Unsafe);
+}

--- a/unittests/ClangImporter/CxxInteropTestHarness.cpp
+++ b/unittests/ClangImporter/CxxInteropTestHarness.cpp
@@ -1,0 +1,210 @@
+//===--- CxxInteropTestHarness.cpp ------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "CxxInteropTestHarness.h"
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/Decl.h"
+#include "swift/AST/DiagnosticConsumer.h"
+#include "swift/AST/DiagnosticEngine.h"
+#include "swift/AST/Module.h"
+#include "swift/AST/NameLookup.h"
+#include "swift/AST/SILOptions.h"
+#include "swift/AST/SearchPathOptions.h"
+#include "swift/Basic/CASOptions.h"
+#include "swift/Basic/LLVMInitialize.h"
+#include "swift/Basic/LangOptions.h"
+#include "swift/Basic/Platform.h"
+#include "swift/Basic/SourceManager.h"
+#include "swift/ClangImporter/ClangImporter.h"
+#include "swift/Serialization/SerializationOptions.h"
+#include "swift/Serialization/SerializedModuleLoader.h"
+#include "swift/Subsystems.h"
+#include "swift/SymbolGraphGen/SymbolGraphOptions.h"
+#include "clang/AST/DeclBase.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/VirtualFileSystem.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/TargetParser/Host.h"
+#include "gtest/gtest.h"
+
+using namespace swift;
+using namespace swift::unittest;
+
+namespace {
+
+/// Absolute path of the in-memory C++ header the tests import as a bridging
+/// header. It only ever exists in the in-memory overlay VFS.
+///
+/// The path must be absolute in the host's native path style: on Windows a
+/// POSIX-style "/cxx-interop-test/..." path is not absolute (it has no drive
+/// letter), so it would not match the lookups the importer performs and the
+/// header would appear not to exist. Deriving it from the current directory
+/// keeps it absolute everywhere without hardcoding a drive letter. Nothing is
+/// written to disk; the in-memory overlay shadows this location.
+static std::string getTestHeaderPath() {
+  SmallString<128> path;
+  if (llvm::sys::fs::current_path(path))
+    path = "/";
+  llvm::sys::path::append(path, "cxx-interop-test", "TestModule.h");
+  return std::string(path);
+}
+
+/// Prints error diagnostics to stderr so import failures are visible in test
+/// output.
+class StderrDiagnosticConsumer : public DiagnosticConsumer {
+public:
+  void handleDiagnostic(SourceManager &SM,
+                        const DiagnosticInfo &Info) override {
+    if (Info.Kind != DiagnosticKind::Error)
+      return;
+    llvm::errs() << "[diag] ";
+    DiagnosticEngine::formatDiagnosticText(llvm::errs(), Info.FormatString,
+                                           Info.FormatArgs);
+    llvm::errs() << "\n";
+  }
+};
+
+} // end anonymous namespace
+
+namespace swift::unittest {
+
+/// Owns an ASTContext + ClangImporter that have imported a snippet of C++
+/// source as a bridging header. The source lives entirely in an in-memory
+/// overlay filesystem (no temp files); the Swift standard library is loaded so
+/// that importing pointer-bearing C++ types succeeds.
+class CxxInteropModule {
+  // Declared before `diags` so it outlives the DiagnosticEngine that refers to
+  // it (members are destroyed in reverse declaration order).
+  StderrDiagnosticConsumer diagConsumer;
+
+  LangOptions langOpts;
+  TypeCheckerOptions typecheckOpts;
+  SILOptions silOpts;
+  SearchPathOptions searchPathOpts;
+  ClangImporterOptions clangImporterOpts;
+  symbolgraphgen::SymbolGraphOptions symbolGraphOpts;
+  CASOptions casOpts;
+  SerializationOptions serializationOpts;
+  SourceManager sourceMgr;
+  DiagnosticEngine diags;
+
+  std::unique_ptr<ASTContext> context;
+  ClangImporter *importer = nullptr;
+  ModuleDecl *module = nullptr;
+
+public:
+  explicit CxxInteropModule(StringRef cxxSource) : diags(sourceMgr) {
+    INITIALIZE_LLVM();
+
+    // Put the C++ source in an in-memory overlay over the real filesystem, so
+    // the header is never written to disk while the real stdlib remains
+    // reachable. The ClangImporter reads through SourceManager's filesystem.
+    std::string headerPath = getTestHeaderPath();
+    auto inMemoryFS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
+    inMemoryFS->addFile(headerPath, /*ModificationTime=*/0,
+                        llvm::MemoryBuffer::getMemBufferCopy(cxxSource,
+                                                             headerPath));
+    auto overlayFS = llvm::makeIntrusiveRefCnt<llvm::vfs::OverlayFileSystem>(
+        llvm::vfs::getRealFileSystem());
+    overlayFS->pushOverlay(inMemoryFS);
+    sourceMgr.setFileSystem(overlayFS);
+
+    langOpts.Target = llvm::Triple(llvm::sys::getDefaultTargetTriple());
+    langOpts.EnableCXXInterop = true;
+    diags.addConsumer(diagConsumer);
+
+    // Point at the just-built Swift standard library.
+    SmallString<128> libDir(SWIFTLIB_DIR);
+    llvm::sys::path::append(libDir, getPlatformNameForTriple(langOpts.Target));
+    searchPathOpts.RuntimeResourcePath = SWIFTLIB_DIR;
+    searchPathOpts.RuntimeLibraryPaths.push_back(std::string(libDir.str()));
+    searchPathOpts.setRuntimeLibraryImportPaths({std::string(libDir.str())});
+
+    context.reset(ASTContext::get(langOpts, typecheckOpts, silOpts,
+                                  searchPathOpts, clangImporterOpts,
+                                  symbolGraphOpts, casOpts, serializationOpts,
+                                  sourceMgr, diags));
+
+    registerParseRequestFunctions(context->evaluator);
+    registerTypeCheckerRequestFunctions(context->evaluator);
+    registerClangImporterRequestFunctions(context->evaluator);
+
+    context->addModuleLoader(ImplicitSerializedModuleLoader::create(*context));
+    auto importerOwner = ClangImporter::create(*context);
+    importer = importerOwner.get();
+    context->addModuleLoader(std::move(importerOwner), /*isClang=*/true);
+
+    context->getStdlibModule(/*loadIfAbsent=*/true);
+
+    // Import the C++ source as a bridging header. This parses the header
+    // directly (no module cache / .pcm written to disk) and exposes its decls
+    // through the imported-header module.
+    auto *mainModule = ModuleDecl::createEmpty(
+        context->getIdentifier("CxxInteropTestMain"), *context);
+    bool failed = importer->importBridgingHeader(headerPath, mainModule);
+    EXPECT_FALSE(failed) << "failed to import C++ bridging header";
+    if (!failed)
+      module = importer->getImportedHeaderModule();
+  }
+
+  CxxInteropModule(const CxxInteropModule &) = delete;
+  CxxInteropModule &operator=(const CxxInteropModule &) = delete;
+
+  ASTContext &getASTContext() { return *context; }
+
+  /// Look up the imported Swift decl named \p name.
+  ValueDecl *lookupSwiftDecl(StringRef name) {
+    if (!module)
+      return nullptr;
+    SmallVector<ValueDecl *, 4> results;
+    module->lookupValue(context->getIdentifier(name),
+                        NLKind::UnqualifiedLookup, results);
+    if (results.size() != 1)
+      return nullptr;
+    return results.front();
+  }
+};
+
+CxxInteropChecker::CxxInteropChecker(StringRef cxxSource)
+    : impl(std::make_shared<CxxInteropModule>(cxxSource)) {}
+
+void CxxInteropChecker::checkDecl(
+    StringRef name, llvm::function_ref<void(ValueDecl *)> check) {
+  ValueDecl *decl = impl->lookupSwiftDecl(name);
+  EXPECT_TRUE(decl) << "could not find imported Swift decl '" << name.str()
+                    << "'";
+  if (decl)
+    check(decl);
+}
+
+void CxxInteropChecker::checkCppDecl(
+    StringRef name,
+    llvm::function_ref<void(const clang::Decl *, ASTContext &)> check) {
+  ValueDecl *decl = impl->lookupSwiftDecl(name);
+  EXPECT_TRUE(decl) << "could not find imported Swift decl '" << name.str()
+                    << "'";
+  if (!decl)
+    return;
+  const clang::Decl *clangDecl = decl->getClangDecl();
+  EXPECT_TRUE(clangDecl) << "imported decl '" << name.str()
+                         << "' has no backing clang decl";
+  if (clangDecl)
+    check(clangDecl, impl->getASTContext());
+}
+
+CxxInteropChecker import(StringRef cxxSource) {
+  return CxxInteropChecker(cxxSource);
+}
+
+} // end namespace swift::unittest

--- a/unittests/ClangImporter/CxxInteropTestHarness.h
+++ b/unittests/ClangImporter/CxxInteropTestHarness.h
@@ -1,0 +1,85 @@
+//===--- CxxInteropTestHarness.h --------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// A lightweight in-process harness for C++ interop unit tests. It imports a
+// snippet of C++ source (as an in-memory bridging header) and lets a callback
+// inspect either the imported Swift Decl or the underlying clang::Decl:
+//
+//   import("struct S { int a; };")
+//       .checkDecl("S", [](ValueDecl *d) { ... });
+//
+//   import("struct S { int a; };")
+//       .checkCppDecl("S", [](const clang::Decl *d, ASTContext &ctx) { ... });
+//
+// The Swift standard library is loaded so importing pointer-bearing C++ types
+// succeeds. Reuse this harness from any unittests/ClangImporter test.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_UNITTESTS_CLANGIMPORTER_CXXINTEROPTESTHARNESS_H
+#define SWIFT_UNITTESTS_CLANGIMPORTER_CXXINTEROPTESTHARNESS_H
+
+#include "llvm/ADT/STLFunctionalExtras.h"
+#include "llvm/ADT/StringRef.h"
+#include <memory>
+
+namespace clang {
+class Decl;
+} // end namespace clang
+
+namespace swift {
+
+class ASTContext;
+class ValueDecl;
+
+namespace unittest {
+
+class CxxInteropModule;
+
+/// Handle over an imported C++ test module.
+class CxxInteropChecker {
+  std::shared_ptr<CxxInteropModule> impl;
+
+public:
+  explicit CxxInteropChecker(llvm::StringRef cxxSource);
+
+  /// Look up the imported Swift decl named \p name and invoke \p check on it.
+  void checkDecl(llvm::StringRef name,
+                 llvm::function_ref<void(ValueDecl *)> check);
+
+  /// Look up the imported Swift decl named \p name, then invoke \p check on the
+  /// underlying clang::Decl (with the importing ASTContext, for running
+  /// importer queries). Going through the Swift import ensures the decl (and
+  /// any referenced template specialization) is fully instantiated.
+  void checkCppDecl(
+      llvm::StringRef name,
+      llvm::function_ref<void(const clang::Decl *, ASTContext &)> check);
+};
+
+/// Import a snippet of C++ source into a synthetic module.
+CxxInteropChecker import(llvm::StringRef cxxSource);
+
+} // end namespace unittest
+} // end namespace swift
+
+// Attribute spellings for forcing escapability/ownership in C++ test inputs.
+// Use with string concatenation, e.g.:
+//   import("struct " SWIFT_TEST_NONESCAPABLE " V { int *p; };")
+#define SWIFT_TEST_NONESCAPABLE R"(__attribute__((swift_attr("~Escapable"))))"
+#define SWIFT_TEST_ESCAPABLE R"(__attribute__((swift_attr("Escapable"))))"
+#define SWIFT_TEST_SELF_CONTAINED R"(__attribute__((swift_attr("import_owned"))))"
+#define SWIFT_TEST_UNSAFE R"(__attribute__((swift_attr("unsafe"))))"
+#define SWIFT_TEST_SAFE R"(__attribute__((swift_attr("safe"))))"
+#define SWIFT_TEST_IMPORT_REFERENCE                                            \
+  R"(__attribute__((swift_attr("import_reference"), swift_attr("retain:immortal"), swift_attr("release:immortal"))))"
+
+#endif // SWIFT_UNITTESTS_CLANGIMPORTER_CXXINTEROPTESTHARNESS_H


### PR DESCRIPTION
Currently, every non-escapable type is considered safe. We do not have rich enough annotations to describe the lifetime contracts of arbitrary types like that. This PR reduces the set of types imported as @safe to direct views that have at most one level of indirection.

It also adds a new way to test the interop feature without any file IO, which results in very fast unit tests. Moreover, we can test some properties that are hard to express in regular LIT tests and we can write more concise tests without boilerplate.

rdar://179534681
