### PR TITLE
Test: establish current OpaqueValues XFAILs

### DIFF
--- a/test/ASTGen/exprs.swift
+++ b/test/ASTGen/exprs.swift
@@ -17,6 +17,7 @@
 
 // rdar://116686158
 // UNSUPPORTED: asan
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 // NB: Ridiculous formatting to test that we do not include leading trivia in locations.
 

--- a/test/AutoDiff/validation-test/address_only_tangentvector.swift
+++ b/test/AutoDiff/validation-test/address_only_tangentvector.swift
@@ -1,5 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 // Would fail due to unavailability of swift_autoDiffCreateLinearMapContext.
 

--- a/test/AutoDiff/validation-test/inout_parameters.swift
+++ b/test/AutoDiff/validation-test/inout_parameters.swift
@@ -1,5 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 // Would fail due to unavailability of swift_autoDiffCreateLinearMapContext.
 

--- a/test/AutoDiff/validation-test/issue-58353.swift
+++ b/test/AutoDiff/validation-test/issue-58353.swift
@@ -1,5 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 // https://github.com/apple/swift/issues/58353
 

--- a/test/AutoDiff/validation-test/property_wrappers.swift
+++ b/test/AutoDiff/validation-test/property_wrappers.swift
@@ -2,6 +2,7 @@
 // TODO(TF-1254): Support and test forward-mode differentiation.
 // TODO(TF-1254): %target-run-simple-swift(-Xfrontend -enable-experimental-forward-mode-differentiation)
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 import DifferentiationUnittest

--- a/test/AutoDiff/validation-test/reabstraction.swift
+++ b/test/AutoDiff/validation-test/reabstraction.swift
@@ -1,5 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import _Differentiation
 import StdlibUnittest

--- a/test/Backtracing/CrashNoDebug.test
+++ b/test/Backtracing/CrashNoDebug.test
@@ -16,6 +16,7 @@
 // REQUIRES: executable_test
 // REQUIRES: backtracing
 // REQUIRES: OS=macosx || OS=linux-gnu
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 
 // NODEBUG: *** Program crashed: {{(Bad pointer dereference|Access violation)}} at 0x{{0*}}4 ***

--- a/test/Backtracing/CrashOpt.test
+++ b/test/Backtracing/CrashOpt.test
@@ -11,6 +11,7 @@
 // REQUIRES: executable_test
 // REQUIRES: backtracing
 // REQUIRES: OS=macosx || OS=linux-gnu
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 
 // CHECK: *** Program crashed: {{(Bad // OPTIMIZED: *** Program crashed: {{(Bad pointer dereference|Access violation)}} at 0x{{0+}}4 ***

--- a/test/Casting/ParameterizedExistentials.swift
+++ b/test/Casting/ParameterizedExistentials.swift
@@ -30,6 +30,7 @@
 // not available in on-device runtimes, or in the back-deployment runtime.
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import Swift
 

--- a/test/ClangImporter/enum-closed-raw-value.swift
+++ b/test/ClangImporter/enum-closed-raw-value.swift
@@ -2,6 +2,7 @@
 // RUN: %target-run-simple-swift(-cxx-interoperability-mode=default -import-objc-header %S/Inputs/enum-closed-raw-value.h)
 
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 

--- a/test/ClangImporter/enum-error-execute.swift
+++ b/test/ClangImporter/enum-error-execute.swift
@@ -6,6 +6,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import Foundation
 

--- a/test/Concurrency/Runtime/RuntimeDemangle.swift
+++ b/test/Concurrency/Runtime/RuntimeDemangle.swift
@@ -8,6 +8,7 @@
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: runtime_module
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import Swift
 import Runtime

--- a/test/Concurrency/Runtime/async_parameter_pack.swift
+++ b/test/Concurrency/Runtime/async_parameter_pack.swift
@@ -4,6 +4,7 @@
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // UNSUPPORTED: back_deployment_runtime || use_os_stdlib
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 protocol P {
   associatedtype A

--- a/test/Concurrency/Runtime/async_sequence.swift
+++ b/test/Concurrency/Runtime/async_sequence.swift
@@ -6,6 +6,7 @@
 // REQUIRES: concurrency
 
 // REQUIRES: concurrency_runtime
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 

--- a/test/Concurrency/Runtime/async_taskgroup_discarding_neverConsumingTasks.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_discarding_neverConsumingTasks.swift
@@ -10,6 +10,7 @@
 
 // FIXME: enable discarding taskgroup on windows; rdar://104762037
 // UNSUPPORTED: OS=windows-msvc
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 actor Waiter {
   let until: Int

--- a/test/Concurrency/Runtime/cancellation_handler_only_once.swift
+++ b/test/Concurrency/Runtime/cancellation_handler_only_once.swift
@@ -8,6 +8,7 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 // UNSUPPORTED: freestanding
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import Synchronization
 

--- a/test/Concurrency/Runtime/isolated_conformance.swift
+++ b/test/Concurrency/Runtime/isolated_conformance.swift
@@ -6,6 +6,7 @@
 // REQUIRES: concurrency
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 @_spi(ExperimentalCustomExecutors) import _Concurrency
 

--- a/test/Concurrency/Runtime/must_not_hop_withContinuation.swift
+++ b/test/Concurrency/Runtime/must_not_hop_withContinuation.swift
@@ -8,6 +8,7 @@
 // UNSUPPORTED: freestanding
 // REQUIRES: libdispatch
 // REQUIRES: synchronization
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import Synchronization
 

--- a/test/Concurrency/Runtime/nonisolated_nonsending_hop_to_executor_throws.swift
+++ b/test/Concurrency/Runtime/nonisolated_nonsending_hop_to_executor_throws.swift
@@ -7,6 +7,7 @@
 // REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 // UNSUPPORTED: freestanding
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 // Regression tests for: https://github.com/swiftlang/swift/issues/88259
 //

--- a/test/Constraints/result_builder_ast_transform.swift
+++ b/test/Constraints/result_builder_ast_transform.swift
@@ -4,6 +4,7 @@
 // RUN: %target-run %t/main | %FileCheck %s
 
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 @propertyWrapper
 struct Wrapper<Value> {

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_through_generic.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_through_generic.swift
@@ -14,6 +14,7 @@
 
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
 // UNSUPPORTED: OS=windows-msvc
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import Distributed
 import FakeDistributedActorSystems

--- a/test/Distributed/Runtime/distributed_actor_localSystem_distributedProtocol.swift
+++ b/test/Distributed/Runtime/distributed_actor_localSystem_distributedProtocol.swift
@@ -18,6 +18,7 @@
 
 // rdar://90373022
 // UNSUPPORTED: OS=watchos
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import Distributed
 

--- a/test/Generics/inverse_assoc_types_sequence.swift
+++ b/test/Generics/inverse_assoc_types_sequence.swift
@@ -9,6 +9,7 @@
 // REQUIRES: swift_feature_Lifetimes
 
 // UNSUPPORTED: back_deployment_runtime || use_os_stdlib
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 /// MARK: IterProto
 public protocol IterProto<Element>: ~Copyable {

--- a/test/IRGen/run_variadic_generics.sil
+++ b/test/IRGen/run_variadic_generics.sil
@@ -8,6 +8,7 @@
 // RUN: %target-run %t/main %t/%target-library-name(PrintShims) | %FileCheck %s
 
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import Builtin
 import Swift

--- a/test/Interop/C/swiftify-import/runtime-legacy.swift
+++ b/test/Interop/C/swiftify-import/runtime-legacy.swift
@@ -12,6 +12,7 @@
 //
 // REQUIRES: executable_test
 // UNSUPPORTED: back_deployment_runtime || use_os_stdlib
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 //--- Inputs/module.modulemap
 module Test {

--- a/test/Interop/C/swiftify-import/runtime.swift
+++ b/test/Interop/C/swiftify-import/runtime.swift
@@ -7,6 +7,7 @@
 //
 // REQUIRES: executable_test
 // UNSUPPORTED: back_deployment_runtime || use_os_stdlib
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 //--- Inputs/module.modulemap
 module Test {

--- a/test/Interop/Cxx/class/access/non-public-nested-enum-executable.swift
+++ b/test/Interop/Cxx/class/access/non-public-nested-enum-executable.swift
@@ -5,6 +5,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_ImportNonPublicCxxMembers
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 //--- Inputs/module.modulemap
 module CxxModule {

--- a/test/Interop/Cxx/class/method/methods.swift
+++ b/test/Interop/Cxx/class/method/methods.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 import Methods

--- a/test/Interop/Cxx/class/safe-use-of-returned-reference-with-borrowing.swift
+++ b/test/Interop/Cxx/class/safe-use-of-returned-reference-with-borrowing.swift
@@ -5,6 +5,7 @@
 // RUN: %target-swift-frontend -DBORROW_PASS_TO_VALUE_PARAM -emit-ir -o /dev/null -I %t/Inputs %t/test.swift -enable-experimental-cxx-interop -verify
 
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 //--- Inputs/module.modulemap
 module CxxTest {

--- a/test/Interop/Cxx/foreign-reference/refcounted-smartpointer-fields.swift
+++ b/test/Interop/Cxx/foreign-reference/refcounted-smartpointer-fields.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift(-I %swift_src_root/lib/ClangImporter/SwiftBridging -I %S/Inputs -cxx-interoperability-mode=default -Xfrontend -disable-availability-checking -Onone) | %FileCheck %s
 
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import RefCountedSmartPtrs
 

--- a/test/Interop/Cxx/foreign-reference/refcounted-smartpointers.swift
+++ b/test/Interop/Cxx/foreign-reference/refcounted-smartpointers.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -Xfrontend -disable-availability-checking -Onone) | %FileCheck %s
 
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import RefCountedSmartPtrs
 

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -3,6 +3,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++23 -D CPP23)
 //
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import MemberInline
 import StdlibUnittest

--- a/test/Interop/Cxx/reference/reference.swift
+++ b/test/Interop/Cxx/reference/reference.swift
@@ -5,6 +5,7 @@
 // RUN: %target-run %t/reference
 //
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import Reference
 import StdlibUnittest

--- a/test/Interop/Cxx/reference/rvalue-reference.swift
+++ b/test/Interop/Cxx/reference/rvalue-reference.swift
@@ -2,6 +2,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -O) | %FileCheck -check-prefix=CHECK-DASH-O %s
 //
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import SpecialMembers
 

--- a/test/Interop/Cxx/stdlib/avoid-redundant-copies.swift
+++ b/test/Interop/Cxx/stdlib/avoid-redundant-copies.swift
@@ -4,6 +4,7 @@
 
 // https://github.com/apple/swift/issues/70226
 // UNSUPPORTED: OS=windows-msvc
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 import StdUniquePtr

--- a/test/Interop/Cxx/stdlib/overlay/custom-borrowing-sequence.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-borrowing-sequence.swift
@@ -5,6 +5,7 @@
 // std::contiguous_iterator_tag from C++20.
 // UNSUPPORTED: LinuxDistribution=ubuntu-20.04
 // UNSUPPORTED: LinuxDistribution=amzn-2
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 import CustomIterable

--- a/test/Interop/Cxx/stdlib/overlay/custom-collection.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-collection.swift
@@ -3,6 +3,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
 //
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 import CustomSequence

--- a/test/Interop/Cxx/stdlib/print-stdlib-types.swift
+++ b/test/Interop/Cxx/stdlib/print-stdlib-types.swift
@@ -2,6 +2,7 @@
 
 // REQUIRES: executable_test
 // XFAIL: OS=windows-msvc
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 // FIXME: We can't import std::unique_ptr or std::shared_ptr properly on Windows (https://github.com/apple/swift/issues/70226)
 
 import StdStringAndVector

--- a/test/Interop/Cxx/stdlib/use-std-any.swift
+++ b/test/Interop/Cxx/stdlib/use-std-any.swift
@@ -7,6 +7,7 @@
 // In Microsoft STL, all overloads of std::any_cast return a dependent templated
 // type, which Swift isn't able to instantiate. 
 // UNSUPPORTED: OS=windows-msvc
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 import StdAny

--- a/test/Interop/Cxx/stdlib/use-std-list-generic.swift
+++ b/test/Interop/Cxx/stdlib/use-std-list-generic.swift
@@ -2,6 +2,7 @@
 // Test iterating through a list using the borrowing iterators (currently behind a feature flag).
 
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 import StdList

--- a/test/Interop/Cxx/stdlib/use-std-list.swift
+++ b/test/Interop/Cxx/stdlib/use-std-list.swift
@@ -2,6 +2,7 @@
 // Test iterating through a list using the borrowing iterators (currently behind a feature flag).
 
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 import StdList

--- a/test/Interop/Cxx/stdlib/use-std-map.swift
+++ b/test/Interop/Cxx/stdlib/use-std-map.swift
@@ -16,6 +16,7 @@
 // Undefined hidden symbol to C++ voidify in libcxx
 // rdar://121551667
 // XFAIL: OS=freebsd
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 #if !BRIDGING_HEADER

--- a/test/Interop/Cxx/stdlib/use-std-span.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span.swift
@@ -4,6 +4,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: std_span
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 import StdSpan

--- a/test/Interop/Cxx/stdlib/use-std-string-with-opts.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string-with-opts.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++20 -O)
 //
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 // Tests optimizations related to CxxStdlib.
 

--- a/test/Interop/Cxx/stdlib/use-std-unique-ptr.swift
+++ b/test/Interop/Cxx/stdlib/use-std-unique-ptr.swift
@@ -9,6 +9,7 @@
 
 // https://github.com/apple/swift/issues/70226
 // UNSUPPORTED: OS=windows-msvc
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 import StdUniquePtr

--- a/test/Interop/Cxx/stdlib/use-std-vector-borrowing-iterators.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector-borrowing-iterators.swift
@@ -14,6 +14,7 @@
 // REQUIRES: OS=macosx || OS=windows-msvc
 
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 #if !BRIDGING_HEADER

--- a/test/Interop/Cxx/stdlib/use-std-vector.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector.swift
@@ -13,6 +13,7 @@
 // %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=gnu++20)
 //
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 #if !BRIDGING_HEADER

--- a/test/Interop/Cxx/templates/member-templates.swift
+++ b/test/Interop/Cxx/templates/member-templates.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import MemberTemplates
 import StdlibUnittest

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx-execution.cpp
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx-execution.cpp
@@ -16,6 +16,7 @@
 // REQUIRES: swift_feature_Lifetimes
 // REQUIRES: swift_feature_Reparenting
 // REQUIRES: swift_feature_AddressableParameters
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 //--- header.h
 

--- a/test/Interop/CxxToSwiftToCxx/span/span-execution.cpp
+++ b/test/Interop/CxxToSwiftToCxx/span/span-execution.cpp
@@ -11,6 +11,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: std_span
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 //--- header.h
 #include <cstdint>

--- a/test/Interop/SwiftToCxx/structs/nested-structs-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/structs/nested-structs-in-cxx-execution.cpp
@@ -10,6 +10,7 @@
 // RUN: %target-run %t/swift-structs-execution
 
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 #include "structs.h"
 

--- a/test/Interpreter/FunctionConversion.swift
+++ b/test/Interpreter/FunctionConversion.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 //
 
 import StdlibUnittest

--- a/test/Interpreter/SDK/objc_dynamic_lookup.swift
+++ b/test/Interpreter/SDK/objc_dynamic_lookup.swift
@@ -2,6 +2,7 @@
 // REQUIRES: executable_test
 
 // REQUIRES: objc_interop
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import Foundation
 

--- a/test/Interpreter/async_typed_throws_default_impl.swift
+++ b/test/Interpreter/async_typed_throws_default_impl.swift
@@ -2,6 +2,7 @@
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: concurrency_runtime
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 struct Failure: Error, Equatable { var value = 1 }
 

--- a/test/Interpreter/borrow_layout.swift
+++ b/test/Interpreter/borrow_layout.swift
@@ -50,6 +50,7 @@
 //
 // REQUIRES: swift_feature_Lifetimes
 // REQUIRES: swift_feature_BuiltinModule
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 // CHECK-NOT: Type verification
 

--- a/test/Interpreter/borrowing_switch_resilient_enum.swift
+++ b/test/Interpreter/borrowing_switch_resilient_enum.swift
@@ -8,6 +8,7 @@
 // RUN: %target-run %t/main %t/%target-library-name(EnumLib)
 
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import EnumLib
 

--- a/test/Interpreter/element_archetype_captures.swift
+++ b/test/Interpreter/element_archetype_captures.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 func callee<X: P1, T: P2, U: P3, V: P4>(x: X, t: T, u: U, v: V)
     -> (any P1, any P2, any P3, any P4) {

--- a/test/Interpreter/enforce_exclusive_access.swift
+++ b/test/Interpreter/enforce_exclusive_access.swift
@@ -7,6 +7,7 @@
 // REQUIRES: thread_safe_runtime
 
 // UNSUPPORTED: use_os_stdlib
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 // Tests for traps at run time when enforcing exclusive access.
 

--- a/test/Interpreter/enum-nonexhaustivity.swift
+++ b/test/Interpreter/enum-nonexhaustivity.swift
@@ -9,6 +9,7 @@
 // RUN: %target-codesign %t/main3
 // RUN: %target-run %t/main3
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 

--- a/test/Interpreter/foreach_borrowing.swift
+++ b/test/Interpreter/foreach_borrowing.swift
@@ -12,6 +12,7 @@
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 struct NoncopyableInt: ~Copyable {
   var value: Int

--- a/test/Interpreter/foreach_borrowing_typed_throws.swift
+++ b/test/Interpreter/foreach_borrowing_typed_throws.swift
@@ -6,6 +6,7 @@
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 enum IterationError: Error, CustomStringConvertible {
   case reachedLimit(Int)

--- a/test/Interpreter/function_metatypes.swift
+++ b/test/Interpreter/function_metatypes.swift
@@ -1,5 +1,6 @@
 // RUN: %target-run-simple-swift | %FileCheck %s
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 protocol ProtocolHasInOut {
   associatedtype Input

--- a/test/Interpreter/import_parameter_pack_library.swift
+++ b/test/Interpreter/import_parameter_pack_library.swift
@@ -12,6 +12,7 @@
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import variadic_generic_library
 import StdlibUnittest

--- a/test/Interpreter/init_accessors.swift
+++ b/test/Interpreter/init_accessors.swift
@@ -2,6 +2,7 @@
 // RUN: %target-run-simple-swift(-O) | %FileCheck %s
 
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 struct TestInit {
   var x: Int

--- a/test/Interpreter/inlinable_init_accessors.swift
+++ b/test/Interpreter/inlinable_init_accessors.swift
@@ -22,6 +22,7 @@
 // REQUIRES: executable_test
 
 // UNSUPPORTED: remote_run || device_run
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 //--- Library.swift
 @frozen

--- a/test/Interpreter/inline_array_enum_tags.swift
+++ b/test/Interpreter/inline_array_enum_tags.swift
@@ -4,6 +4,7 @@
 // REQUIRES: executable_test
 
 // UNSUPPORTED: back_deployment_runtime || use_os_stdlib
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 struct Foo {
     let x: UInt64

--- a/test/Interpreter/issue-78598.swift
+++ b/test/Interpreter/issue-78598.swift
@@ -6,6 +6,7 @@
 
 // This test needs a Swift 5.9 runtime or newer.
 // UNSUPPORTED: back_deployment_runtime
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 var counter = 0
 

--- a/test/Interpreter/issue88993.swift
+++ b/test/Interpreter/issue88993.swift
@@ -8,6 +8,7 @@
 // REQUIRES: executable_test
 
 // UNSUPPORTED: back_deployment_runtime
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 // https://github.com/swiftlang/swift/issues/88993
 

--- a/test/Interpreter/layout_reabstraction.swift
+++ b/test/Interpreter/layout_reabstraction.swift
@@ -1,5 +1,6 @@
 // RUN: %target-run-simple-swift | %FileCheck %s
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 struct S {}
 struct Q {}

--- a/test/Interpreter/moveonly_deinit_autoclosure.swift
+++ b/test/Interpreter/moveonly_deinit_autoclosure.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 internal func _myPrecondition(
   _ body: @autoclosure () -> Bool

--- a/test/Interpreter/moveonly_generics.swift
+++ b/test/Interpreter/moveonly_generics.swift
@@ -6,6 +6,7 @@
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 // Needed due to limitations of autoclosures and noncopyable types.
 func eagerAssert(_ b: Bool, _ line: Int = #line) {

--- a/test/Interpreter/moveonly_linkedlist_2_simple.swift
+++ b/test/Interpreter/moveonly_linkedlist_2_simple.swift
@@ -8,6 +8,7 @@
 // RUN: %target-run-simple-swift(-O -parse-as-library -enable-builtin-module -Xfrontend -sil-verify-all) | %FileCheck %s
 
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 // CHECK-IR-NOT: @"$sBpWV"
 

--- a/test/Interpreter/moveonly_swiftskell.swift
+++ b/test/Interpreter/moveonly_swiftskell.swift
@@ -29,6 +29,7 @@
 
 // And on older OS (rdar://132936383)
 // UNSUPPORTED: use_os_stdlib
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import Swiftskell
 

--- a/test/Interpreter/named_opaque_result_types.swift
+++ b/test/Interpreter/named_opaque_result_types.swift
@@ -4,6 +4,7 @@
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
 dynamic func lazyMapCollection<C: Collection, T>(_ collection: C, body: @escaping (C.Element) -> T)

--- a/test/Interpreter/pack_iteration.swift
+++ b/test/Interpreter/pack_iteration.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 

--- a/test/Interpreter/polymorphic_builtins.swift
+++ b/test/Interpreter/polymorphic_builtins.swift
@@ -26,6 +26,7 @@
 // RUN: %target-run %t/a.out %t/%target-library-name(mysimd)
 
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import Builtin
 import StdlibUnittest

--- a/test/Interpreter/raw_layout.swift
+++ b/test/Interpreter/raw_layout.swift
@@ -5,6 +5,7 @@
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import Builtin
 import Synchronization

--- a/test/Interpreter/rdar80847020.swift
+++ b/test/Interpreter/rdar80847020.swift
@@ -10,6 +10,7 @@
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 func run(_ s: Clazz) async throws {
     let res: (String, String) = try await s.doSomethingMultiResultFlaggy()

--- a/test/Interpreter/synthesized_extension_conformances.swift
+++ b/test/Interpreter/synthesized_extension_conformances.swift
@@ -5,6 +5,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import Foundation
 

--- a/test/Interpreter/typed_throws_abi.swift
+++ b/test/Interpreter/typed_throws_abi.swift
@@ -6,6 +6,7 @@
 
 // REQUIRES: executable_test
 // UNSUPPORTED: back_deployment_runtime
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import TypedThrowsABI
 

--- a/test/Interpreter/typed_throws_destination_conversion_83826.swift
+++ b/test/Interpreter/typed_throws_destination_conversion_83826.swift
@@ -1,5 +1,6 @@
 // RUN: %target-run-simple-swift | %FileCheck %s
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 // https://github.com/swiftlang/swift/issues/83826
 //

--- a/test/Interpreter/variadic_generic_captures.swift
+++ b/test/Interpreter/variadic_generic_captures.swift
@@ -2,6 +2,7 @@
 // RUN: %target-run-simple-swift
 
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 

--- a/test/Interpreter/variadic_generic_conformances.swift
+++ b/test/Interpreter/variadic_generic_conformances.swift
@@ -4,6 +4,7 @@
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 

--- a/test/Interpreter/variadic_generic_func_types.swift
+++ b/test/Interpreter/variadic_generic_func_types.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 

--- a/test/Interpreter/variadic_generic_opaque_type.swift
+++ b/test/Interpreter/variadic_generic_opaque_type.swift
@@ -12,6 +12,7 @@
 
 // This test needs a Swift 5.9 runtime or newer.
 // UNSUPPORTED: back_deployment_runtime
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import variadic_generic_opaque_type_other
 import StdlibUnittest

--- a/test/Interpreter/variadic_generic_tuples.swift
+++ b/test/Interpreter/variadic_generic_tuples.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 

--- a/test/Interpreter/variadic_generic_types.swift
+++ b/test/Interpreter/variadic_generic_types.swift
@@ -5,6 +5,7 @@
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 

--- a/test/Macros/init_accessor.swift
+++ b/test/Macros/init_accessor.swift
@@ -6,6 +6,7 @@
 // RUN: %target-run %t/main
 
 // REQUIRES: swift_swift_parser, executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 @attached(peer, names: named(_value), named(_$value))
 macro Wrapped() = #externalMacro(module: "MacroDefinition",

--- a/test/Parse/type_parameter_packs_executable.swift
+++ b/test/Parse/type_parameter_packs_executable.swift
@@ -1,4 +1,5 @@
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 // RUN: %target-run-simple-swift
 
 import StdlibUnittest

--- a/test/SIL/borrow_accessor_e2e.swift
+++ b/test/SIL/borrow_accessor_e2e.swift
@@ -4,6 +4,7 @@
 // RUN: %target-run %t/a.out
 
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 public struct Container<Element: ~Copyable >: ~Copyable {
   var _storage: UnsafeMutableBufferPointer<Element>

--- a/test/SILOptimizer/inline_array_loop_mutation.swift
+++ b/test/SILOptimizer/inline_array_loop_mutation.swift
@@ -4,6 +4,7 @@
 // REQUIRES: executable_test
 
 // UNSUPPORTED: back_deployment_runtime || use_os_stdlib
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 // Regression test for a miscompile where TBAA failed to recurse into
 // `Builtin.FixedArray`'s element type, allowing LICM to hoist a load out

--- a/test/SILOptimizer/isolated_conformances.swift
+++ b/test/SILOptimizer/isolated_conformances.swift
@@ -12,6 +12,7 @@
 
 // UNSUPPORTED: back_deployment_runtime
 // UNSUPPORTED: back_deploy_concurrency
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 protocol P {
   func f() -> Int

--- a/test/SILOptimizer/static_inline_arrays.swift
+++ b/test/SILOptimizer/static_inline_arrays.swift
@@ -9,6 +9,7 @@
 // REQUIRES: executable_test,optimized_stdlib
 // REQUIRES: OS=macosx || OS=linux-gnu || OS=windows-msvc
 // UNSUPPORTED: back_deployment_runtime
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 extension InlineArray: Collection {
   var asArray: Array<Element> { map { $0 } }

--- a/test/SILOptimizer/templvalueopt_and_exclusivity.swift
+++ b/test/SILOptimizer/templvalueopt_and_exclusivity.swift
@@ -8,6 +8,7 @@
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 
 // Check that TempLValueElimination does not cause an exclusivity violation at runtime.

--- a/test/Sanitizers/tsan/objc_async.swift
+++ b/test/Sanitizers/tsan/objc_async.swift
@@ -11,6 +11,7 @@
 
 // rdar://76038845
 // UNSUPPORTED: use_os_stdlib
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 @main struct Main {
   static func main() async {

--- a/test/attr/attr_dynamic_member_lookup_default_args.swift
+++ b/test/attr/attr_dynamic_member_lookup_default_args.swift
@@ -1,5 +1,6 @@
 // RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking)
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 //===----------------------------------------------------------------------===//
 // Magic Literals

--- a/test/embedded/arrays-enums.swift
+++ b/test/embedded/arrays-enums.swift
@@ -3,6 +3,7 @@
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 enum Node {
   indirect case inner(Node, Node)

--- a/test/embedded/class-func.swift
+++ b/test/embedded/class-func.swift
@@ -3,6 +3,7 @@
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 @main
 struct Main {

--- a/test/embedded/classes-arrays.swift
+++ b/test/embedded/classes-arrays.swift
@@ -4,6 +4,7 @@
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 class MyClass {
   init() { print("MyClass.init") }

--- a/test/embedded/collection-difference.swift
+++ b/test/embedded/collection-difference.swift
@@ -4,6 +4,7 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx || OS=wasip1
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 @main
 struct Main {

--- a/test/embedded/deserialize-vtables.swift
+++ b/test/embedded/deserialize-vtables.swift
@@ -6,6 +6,7 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_feature_Extern
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 @main
 struct Main {

--- a/test/embedded/dict-init.swift
+++ b/test/embedded/dict-init.swift
@@ -3,6 +3,7 @@
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx || OS=wasip1
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 public func foo() {
     let d = Dictionary<Int, StaticString>.init(uniqueKeysWithValues: [(10, "hello"), (20, "world")])

--- a/test/embedded/dictionary-runtime.swift
+++ b/test/embedded/dictionary-runtime.swift
@@ -6,6 +6,7 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx || OS=wasip1
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 var dict1: [Int: Int] = [1:10]
 var dict2: [Int: Int] = [1:20]

--- a/test/embedded/dynamic-cast.swift
+++ b/test/embedded/dynamic-cast.swift
@@ -5,6 +5,7 @@
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 protocol P { }
 protocol CP: AnyObject { }

--- a/test/embedded/existential-class-bound1.swift
+++ b/test/embedded/existential-class-bound1.swift
@@ -5,6 +5,7 @@
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 protocol ClassBound: AnyObject {
     func foo()

--- a/test/embedded/existential-class-bound2.swift
+++ b/test/embedded/existential-class-bound2.swift
@@ -3,6 +3,7 @@
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 protocol ClassBound: AnyObject {
     func foo()

--- a/test/embedded/existential-class-bound3.swift
+++ b/test/embedded/existential-class-bound3.swift
@@ -3,6 +3,7 @@
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 protocol ClassBound: AnyObject {
     func foo()

--- a/test/embedded/existential-class-bound4.swift
+++ b/test/embedded/existential-class-bound4.swift
@@ -4,6 +4,7 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx || OS=linux-gnu || OS=wasip1
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 public protocol Base: AnyObject {
     func foo()

--- a/test/embedded/existential-default-method.swift
+++ b/test/embedded/existential-default-method.swift
@@ -5,6 +5,7 @@
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 // Simple case
 

--- a/test/embedded/existential.swift
+++ b/test/embedded/existential.swift
@@ -8,6 +8,7 @@
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 class CP {
 }

--- a/test/embedded/existential_foreign.swift
+++ b/test/embedded/existential_foreign.swift
@@ -4,6 +4,7 @@
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 protocol P {
   func printme()

--- a/test/embedded/general-existentials1.swift
+++ b/test/embedded/general-existentials1.swift
@@ -5,6 +5,7 @@
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 protocol P {
     func foo()

--- a/test/embedded/generic-classes2.swift
+++ b/test/embedded/generic-classes2.swift
@@ -4,6 +4,7 @@
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 class B<T> {
 }

--- a/test/embedded/generic-specialization.swift
+++ b/test/embedded/generic-specialization.swift
@@ -3,6 +3,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 func f<V>(_ a: [V]) -> [String] {
     return a.indices.map { String($0 /* as Int*/) }  // adding `as Int` makes it compile

--- a/test/embedded/keypaths-exec.swift
+++ b/test/embedded/keypaths-exec.swift
@@ -6,6 +6,7 @@
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_feature_EmbeddedKeyPaths
 // REQUIRES: swift_feature_KeyPathWithMethodMembers
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 // -----------------------------------------------------------------------------
 // Generic wrappers

--- a/test/embedded/keypaths-static.swift
+++ b/test/embedded/keypaths-static.swift
@@ -18,6 +18,7 @@
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_feature_EmbeddedKeyPaths
 // REQUIRES: swift_feature_KeyPathWithMethodMembers
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 public struct S {
   var a: Int32

--- a/test/embedded/keypaths2.swift
+++ b/test/embedded/keypaths2.swift
@@ -4,6 +4,7 @@
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 @dynamicMemberLookup
 public struct Box<T>: ~Copyable {

--- a/test/embedded/keypaths3.swift
+++ b/test/embedded/keypaths3.swift
@@ -4,6 +4,7 @@
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 @dynamicMemberLookup
 public struct Box<T>: ~Copyable {

--- a/test/embedded/lazy-collections.swift
+++ b/test/embedded/lazy-collections.swift
@@ -3,6 +3,7 @@
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 @main
 struct Main {

--- a/test/embedded/managed-buffer2.swift
+++ b/test/embedded/managed-buffer2.swift
@@ -6,6 +6,7 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx || OS=linux-gnu || OS=wasip1
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 struct CountAndCapacity {
   var count: Int

--- a/test/embedded/optionset.swift
+++ b/test/embedded/optionset.swift
@@ -4,6 +4,7 @@
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 struct ShippingOptions: OptionSet {
   let rawValue: Int

--- a/test/embedded/runtime-release.swift
+++ b/test/embedded/runtime-release.swift
@@ -5,6 +5,7 @@
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 @main
 struct Main {

--- a/test/embedded/runtime.swift
+++ b/test/embedded/runtime.swift
@@ -6,6 +6,7 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_feature_Extern
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 @_extern(c, "putchar")
 @discardableResult

--- a/test/embedded/sensitive.swift
+++ b/test/embedded/sensitive.swift
@@ -7,6 +7,7 @@
 // REQUIRES: OS=macosx || OS=linux-gnu || OS=wasip1
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_feature_Sensitive
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 var checkBuffer: UnsafeBufferPointer<UInt32>?
 

--- a/test/embedded/set-runtime.swift
+++ b/test/embedded/set-runtime.swift
@@ -6,6 +6,7 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx || OS=wasip1
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 @main
 struct Main {

--- a/test/embedded/specialize-attrs2.swift
+++ b/test/embedded/specialize-attrs2.swift
@@ -6,6 +6,7 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx || OS=wasip1
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 @main
 struct Main {

--- a/test/embedded/static-string-interpolation.swift
+++ b/test/embedded/static-string-interpolation.swift
@@ -3,6 +3,7 @@
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 public struct MyInterpolation : StringInterpolationProtocol {
     public typealias StringLiteralType = StaticString

--- a/test/embedded/stdlib-parsing.swift
+++ b/test/embedded/stdlib-parsing.swift
@@ -4,6 +4,7 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx || OS=linux-gnu || OS=wasip1
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 @main
 struct Main {

--- a/test/embedded/stdlib-strings-append.swift
+++ b/test/embedded/stdlib-strings-append.swift
@@ -4,6 +4,7 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx || OS=linux-gnu || OS=wasip1
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 @main
 struct Main {

--- a/test/embedded/stdlib-strings-datatables.swift
+++ b/test/embedded/stdlib-strings-datatables.swift
@@ -5,6 +5,7 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx || OS=wasip1
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 public func test1() {
   let string = "string"

--- a/test/embedded/stdlib-strings-interpolation2.swift
+++ b/test/embedded/stdlib-strings-interpolation2.swift
@@ -4,6 +4,7 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx || OS=linux-gnu || OS=wasip1
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 struct Event {
   var id: String

--- a/test/embedded/stdlib-strings-lossless-convertible.swift
+++ b/test/embedded/stdlib-strings-lossless-convertible.swift
@@ -4,6 +4,7 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx || OS=linux-gnu || OS=wasip1
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 func f<T: LosslessStringConvertible>(t: inout T?, s: String) {
   t = .init(s)

--- a/test/embedded/stdlib-strings-unicode.swift
+++ b/test/embedded/stdlib-strings-unicode.swift
@@ -5,6 +5,7 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx || OS=wasip1
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 @main
 struct Main {

--- a/test/embedded/string-switch.swift
+++ b/test/embedded/string-switch.swift
@@ -4,6 +4,7 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx || OS=wasip1
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 enum MyEnum: String {
     case foo

--- a/test/embedded/synchronization.swift
+++ b/test/embedded/synchronization.swift
@@ -5,6 +5,7 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: synchronization
 // REQUIRES: swift_feature_Embedded
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import Synchronization
 

--- a/test/embedded/volatile-exec.swift
+++ b/test/embedded/volatile-exec.swift
@@ -5,6 +5,7 @@
 // REQUIRES: volatile
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_feature_Extern
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import _Volatile
 

--- a/test/stdlib/BorrowingSequence.swift
+++ b/test/stdlib/BorrowingSequence.swift
@@ -15,6 +15,7 @@
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_SuppressedAssociatedTypesWithDefaults
 // REQUIRES: swift_feature_Lifetimes
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 

--- a/test/stdlib/BridgeIdAsAny.swift.gyb
+++ b/test/stdlib/BridgeIdAsAny.swift.gyb
@@ -7,6 +7,7 @@
 // REQUIRES: executable_test
 //
 // REQUIRES: objc_interop
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 import Foundation

--- a/test/stdlib/BridgedArrayNonContiguous.swift
+++ b/test/stdlib/BridgedArrayNonContiguous.swift
@@ -14,6 +14,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 

--- a/test/stdlib/InlineArray.swift
+++ b/test/stdlib/InlineArray.swift
@@ -17,6 +17,7 @@
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_ValueGenerics
 // UNSUPPORTED: use_os_stdlib
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 // END.
 //
 //===----------------------------------------------------------------------===//

--- a/test/stdlib/MirrorWithPacks.swift
+++ b/test/stdlib/MirrorWithPacks.swift
@@ -20,6 +20,7 @@
 
 // rdar://96439408
 // UNSUPPORTED: use_os_stdlib
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 

--- a/test/stdlib/NoncopyableComparable.swift
+++ b/test/stdlib/NoncopyableComparable.swift
@@ -14,6 +14,7 @@
 // RUN: %target-run-simple-swift(-target %target-swift-5.8-abi-triple -enable-experimental-feature Lifetimes)
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_Lifetimes
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 

--- a/test/stdlib/NoncopyableEquatable.swift
+++ b/test/stdlib/NoncopyableEquatable.swift
@@ -14,6 +14,7 @@
 // RUN: %target-run-simple-swift(-target %target-swift-5.8-abi-triple -enable-experimental-feature Lifetimes)
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_Lifetimes
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 

--- a/test/stdlib/NoncopyableHashable.swift
+++ b/test/stdlib/NoncopyableHashable.swift
@@ -14,6 +14,7 @@
 // RUN: %target-run-simple-swift(-target %target-swift-5.8-abi-triple -enable-experimental-feature Lifetimes)
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_Lifetimes
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 

--- a/test/stdlib/Noncopyables/RefMutableRef.swift
+++ b/test/stdlib/Noncopyables/RefMutableRef.swift
@@ -4,6 +4,7 @@
 // REQUIRES: executable_test
 // REQUIRES: synchronization
 // REQUIRES: swift_feature_Lifetimes
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import Builtin
 import Synchronization

--- a/test/stdlib/Noncopyables/UniqueBox.swift
+++ b/test/stdlib/Noncopyables/UniqueBox.swift
@@ -2,6 +2,7 @@
 // RUN: %target-run-simple-swift
 
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 

--- a/test/stdlib/OSLogExecutionTest.swift
+++ b/test/stdlib/OSLogExecutionTest.swift
@@ -12,6 +12,7 @@
 // REQUIRES: VENDOR=apple
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 // Run-time tests for testing the correctness of the optimizations that optimize the
 // construction of the format string and the byte buffer from a string interpolation.

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -10,6 +10,7 @@
 // REQUIRES: objc_interop
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 import Observation

--- a/test/stdlib/Observation/ObservableDidSetWillSet.swift
+++ b/test/stdlib/Observation/ObservableDidSetWillSet.swift
@@ -7,6 +7,7 @@
 // REQUIRES: objc_interop
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import Observation
 

--- a/test/stdlib/Optional.swift
+++ b/test/stdlib/Optional.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: reflection
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 import Swift

--- a/test/stdlib/Runtime.swift.gyb
+++ b/test/stdlib/Runtime.swift.gyb
@@ -7,6 +7,7 @@
 // REQUIRES: executable_test
 // REQUIRES: reflection
 // REQUIRES: swift_feature_Extern
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import Swift
 import StdlibUnittest

--- a/test/stdlib/Span/ArraySpanProperties.swift
+++ b/test/stdlib/Span/ArraySpanProperties.swift
@@ -13,6 +13,7 @@
 // RUN: %target-run-stdlib-swift
 
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 

--- a/test/stdlib/Span/BridgedStringUTF8ViewSpanTests.swift
+++ b/test/stdlib/Span/BridgedStringUTF8ViewSpanTests.swift
@@ -14,6 +14,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 

--- a/test/stdlib/Span/InlineSpanProperties.swift
+++ b/test/stdlib/Span/InlineSpanProperties.swift
@@ -16,6 +16,7 @@
 // REQUIRES: swift_feature_AddressableTypes
 // REQUIRES: swift_feature_LifetimeDependence
 // REQUIRES: swift_feature_ValueGenerics
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 

--- a/test/stdlib/Span/MutableSpanTests.swift
+++ b/test/stdlib/Span/MutableSpanTests.swift
@@ -13,6 +13,7 @@
 // RUN: %target-run-stdlib-swift
 
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 

--- a/test/stdlib/Span/OutputRawSpanTests.swift
+++ b/test/stdlib/Span/OutputRawSpanTests.swift
@@ -14,6 +14,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_Lifetimes
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 

--- a/test/stdlib/Span/OutputSpanTests.swift
+++ b/test/stdlib/Span/OutputSpanTests.swift
@@ -13,6 +13,7 @@
 // RUN: %target-run-stdlib-swift
 
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 

--- a/test/stdlib/Span/SpanTests.swift
+++ b/test/stdlib/Span/SpanTests.swift
@@ -13,6 +13,7 @@
 // RUN: %target-run-stdlib-swift
 
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 

--- a/test/stdlib/StringCreate.swift
+++ b/test/stdlib/StringCreate.swift
@@ -3,6 +3,7 @@
 
 // rdar://91405760
 // UNSUPPORTED: use_os_stdlib, back_deployment_runtime
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 defer { runAllTests() }

--- a/test/stdlib/StringDeconstruction.swift
+++ b/test/stdlib/StringDeconstruction.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // UNSUPPORTED: freestanding
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 defer { runAllTests() }

--- a/test/stdlib/TemporaryAllocation.swift
+++ b/test/stdlib/TemporaryAllocation.swift
@@ -1,5 +1,6 @@
 // RUN: %target-run-simple-swift(-strict-memory-safety)
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 import SwiftShims

--- a/test/stdlib/UTF8SpanIteratorTests.swift
+++ b/test/stdlib/UTF8SpanIteratorTests.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-stdlib-swift(-enable-experimental-feature LifetimeDependence) %S/Inputs/
 // REQUIRES: swift_feature_LifetimeDependence
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import Swift
 import StdlibUnittest

--- a/test/stdlib/UTF8SpanQueriesComparisons.swift
+++ b/test/stdlib/UTF8SpanQueriesComparisons.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-stdlib-swift %S/Inputs/
 
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import Swift
 import StdlibUnittest

--- a/test/stdlib/subString.swift
+++ b/test/stdlib/subString.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // UNSUPPORTED: freestanding
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 

--- a/validation-test/Evolution/test_protocol_add_reparented_seq.swift
+++ b/validation-test/Evolution/test_protocol_add_reparented_seq.swift
@@ -7,6 +7,7 @@
 // REQUIRES: swift_feature_SuppressedAssociatedTypesWithDefaults
 // REQUIRES: swift_feature_Lifetimes
 // REQUIRES: swift_feature_LifetimeDependence
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 import protocol_add_reparented_seq

--- a/validation-test/IRGen/pack_stack_metadata_alloc_loop.sil
+++ b/validation-test/IRGen/pack_stack_metadata_alloc_loop.sil
@@ -3,6 +3,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: CPU=arm64
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 // Allocate metadata packs on the stack in a loop.  If these packs weren't
 // deallocated, the stack would be exhausted.

--- a/validation-test/Reflection/reflect_variadic_generic.swift
+++ b/validation-test/Reflection/reflect_variadic_generic.swift
@@ -8,6 +8,7 @@
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: asan
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import SwiftReflectionTest
 

--- a/validation-test/SILGen/rdar85526916.swift
+++ b/validation-test/SILGen/rdar85526916.swift
@@ -9,6 +9,7 @@
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 func run(on object: PFXObject) async throws {
   // CHECK: howdy

--- a/validation-test/compiler_crashers_fixed/rdar80704382.swift
+++ b/validation-test/compiler_crashers_fixed/rdar80704382.swift
@@ -10,6 +10,7 @@
 // rdar://82123254
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 func run() async throws {
   // CHECK: item_id

--- a/validation-test/compiler_crashers_fixed/rdar80704984.swift
+++ b/validation-test/compiler_crashers_fixed/rdar80704984.swift
@@ -10,6 +10,7 @@
 // rdar://82123254
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 func run1(on object: PFXObject) async throws {
   do {

--- a/validation-test/compiler_crashers_fixed/rdar80704984_2.swift
+++ b/validation-test/compiler_crashers_fixed/rdar80704984_2.swift
@@ -10,6 +10,7 @@
 // rdar://82123254
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 func run1(on object: PFXObject) async throws {
   do {

--- a/validation-test/compiler_crashers_fixed/rdar80704984_3.swift
+++ b/validation-test/compiler_crashers_fixed/rdar80704984_3.swift
@@ -10,6 +10,7 @@
 // rdar://82123254
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 func run1(on object: PFXObject) async throws {
   do {

--- a/validation-test/compiler_crashers_fixed/rdar81590807.swift
+++ b/validation-test/compiler_crashers_fixed/rdar81590807.swift
@@ -16,6 +16,7 @@
 // rdar://82123254
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 func run(on object: PFXObject) async throws {
   // CHECK: passSync

--- a/validation-test/compiler_crashers_fixed/rdar81590807_2.swift
+++ b/validation-test/compiler_crashers_fixed/rdar81590807_2.swift
@@ -10,6 +10,7 @@
 // rdar://82123254
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 func run(on object: PFXObject) async throws {
   // CHECK: syncSuccess

--- a/validation-test/compiler_crashers_fixed/rdar81617749.swift
+++ b/validation-test/compiler_crashers_fixed/rdar81617749.swift
@@ -10,6 +10,7 @@
 // rdar://82123254
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 func run(on object: PFXObject) async throws {
   // CHECK: performSingleFlaggy1

--- a/validation-test/stdlib/Array.swift.gyb
+++ b/validation-test/stdlib/Array.swift.gyb
@@ -1,6 +1,7 @@
 // RUN: %enable-cow-checking %target-run-simple-swiftgyb
 // REQUIRES: executable_test
 // REQUIRES: reflection
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 import StdlibCollectionUnittest

--- a/validation-test/stdlib/ContiguousArray.swift.gyb
+++ b/validation-test/stdlib/ContiguousArray.swift.gyb
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swiftgyb
 // REQUIRES: executable_test
 // REQUIRES: reflection
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 import StdlibCollectionUnittest

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -6,6 +6,7 @@
 //
 // RUN: %target-codesign %t/Dictionary && %line-directive %t/main.swift -- %target-run %t/Dictionary
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 import StdlibCollectionUnittest

--- a/validation-test/stdlib/ErrorHandling.swift
+++ b/validation-test/stdlib/ErrorHandling.swift
@@ -1,5 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 //
 // Tests for error handling in standard library APIs.

--- a/validation-test/stdlib/HashedCollectionFilter.swift
+++ b/validation-test/stdlib/HashedCollectionFilter.swift
@@ -1,5 +1,6 @@
 // RUN: %target-run-stdlib-swift
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 

--- a/validation-test/stdlib/Prototypes/PersistentVector.swift.gyb
+++ b/validation-test/stdlib/Prototypes/PersistentVector.swift.gyb
@@ -5,6 +5,7 @@
 // RUN: %line-directive %t/PersistentVector.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 // REQUIRES: reflection
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 /*
 

--- a/validation-test/stdlib/SequenceType.swift.gyb
+++ b/validation-test/stdlib/SequenceType.swift.gyb
@@ -3,6 +3,7 @@
 // REQUIRES: executable_test
 // rdar://125917150
 // UNSUPPORTED: freestanding
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 % import os.path
 % import gyb
 

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -6,6 +6,7 @@
 //
 // RUN: %target-codesign %t/Set && %line-directive %t/main.swift -- %target-run %t/Set
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 import StdlibCollectionUnittest

--- a/validation-test/stdlib/SetOperations.swift.gyb
+++ b/validation-test/stdlib/SetOperations.swift.gyb
@@ -3,6 +3,7 @@
 // RUN: %line-directive %t/SetOperations.swift -- %target-build-swift %t/SetOperations.swift -o %t/SetOperations -Xfrontend -disable-access-control -swift-version 5
 // RUN: %target-codesign %t/SetOperations && %line-directive %t/SetOperations.swift -- %target-run %t/SetOperations
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 import StdlibCollectionUnittest

--- a/validation-test/stdlib/UnicodeWordRecognizer.swift
+++ b/validation-test/stdlib/UnicodeWordRecognizer.swift
@@ -4,6 +4,7 @@
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 // REQUIRES: optimized_stdlib
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 // Validate that the various forms of word breaking all lead to consistent
 // results by exhaustively enumerating all possible state machine inputs up to


### PR DESCRIPTION
This PR stages in what is effectively our TODO list of execution tests that are broken under `-enable-sil-opaque-values` to help track their eventual fix. It serves as a guard for regressing compiler support for opaque values. For now, CI doesn't run opaque values testing by default. You can run the build target `check-swift-optimize_none_with_opaque_values` to check for regressions locally. I'm using that today to track if I've introduced regressions while working on opaque values.

Eventually this build target will be required to pass in CI so that feature support doesn't regress. So, please do not add any more XFAIL's of this kind! If you break something under this configuration, you please fix it before merging your PR.

