### PR TITLE
[6.4.x][android] Switch compiling Swift source in stdlib and the test suite to target triples with the API level specified (#90650)

### DIFF
--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -385,6 +385,7 @@ macro(configure_sdk_unix name architectures)
     if("${prefix}" STREQUAL "ANDROID")
       swift_android_sysroot(android_sysroot)
       set(SWIFT_SDK_ANDROID_ARCH_${arch}_PATH "${android_sysroot}")
+      set(SWIFT_SDK_ANDROID_TEST_DEPLOYMENT_VERSION "${SWIFT_ANDROID_API_LEVEL}")
 
       if("${arch}" STREQUAL "armv7")
         set(SWIFT_SDK_ANDROID_ARCH_${arch}_NDK_TRIPLE "arm-linux-androideabi")

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -2581,11 +2581,6 @@ function(add_swift_target_library name)
         list(APPEND swiftlib_link_flags_all "-Wl,-z,max-page-size=16384")
       endif()
 
-      # This is a Android-specific hack till we transition the stdlib fully to versioned triples.
-      if(sdk STREQUAL "ANDROID" AND name STREQUAL "swiftSwiftReflectionTest")
-        list(APPEND swiftlib_swift_compile_flags_all "-target" "${SWIFT_SDK_ANDROID_ARCH_${arch}_TRIPLE}${SWIFT_ANDROID_API_LEVEL}")
-      endif()
-
       if (SWIFTLIB_BACK_DEPLOYMENT_LIBRARY)
         set(back_deployment_library_option BACK_DEPLOYMENT_LIBRARY ${SWIFTLIB_BACK_DEPLOYMENT_LIBRARY})
       else()

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -271,6 +271,11 @@ function(_add_target_variant_swift_compile_flags
     if(target_variant)
       list(APPEND result "-target-variant" "${target_variant}")
     endif()
+  elseif("${sdk}" STREQUAL "ANDROID")
+    get_target_triple(target target_variant "${sdk}" "${arch}"
+    DEPLOYMENT_VERSION "${SWIFT_ANDROID_API_LEVEL}")
+
+    list(APPEND result "-target" "${target}")
   else()
     list(APPEND result
         "-target" "${SWIFT_SDK_${sdk}_ARCH_${arch}_TRIPLE}")

--- a/test/IRGen/availability_android.swift
+++ b/test/IRGen/availability_android.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -target %target-triple24 -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK-24
-// RUN: %target-swift-frontend -target %target-triple28 -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK-28
+// RUN: %target-swift-frontend -target %target-arch-unknown-linux-android24 -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK-24
+// RUN: %target-swift-frontend -target %target-arch-unknown-linux-android28 -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK-28
 
 // CHECK-24-LABEL: define{{.*}}$s20availability_android0A5CheckyyF
 // CHECK-24: call swiftcc i1 @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"(
@@ -7,7 +7,7 @@
 // CHECK-28-LABEL: define{{.*}}$s20availability_android0A5CheckyyF
 // CHECK-28-NOT: call swiftcc i1 @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"(
 
-// REQUIRES: OS=linux-android
+// REQUIRES: OS=linux-android, OS=linux-androideabi
 
 public func availabilityCheck() {
   if #available(Android 28, *) {

--- a/test/IRGen/noncopyable_field_descriptors.swift
+++ b/test/IRGen/noncopyable_field_descriptors.swift
@@ -17,10 +17,8 @@
 // RUN: %swift-frontend -emit-ir -o - %s -module-name test \
 // RUN:   -parse-as-library \
 // RUN:   -enable-library-evolution \
-// RUN:   -target %target-future-triple \
+// RUN:   -target %target-swift-6.4-abi-triple \
 // RUN:   > %t/test_safe_runtime.irgen
-
-// FIXME: this should be `-target %target-swift-6.4-abi-triple` once the platform versions are known.
 
 // RUN: %FileCheck --check-prefix=NEW %s < %t/test_new.irgen
 // RUN: %FileCheck --check-prefix=OLD %s < %t/test_old.irgen

--- a/test/Interop/Cxx/class/invalid-members/stdlib-containers-of-incomplete.swift
+++ b/test/Interop/Cxx/class/invalid-members/stdlib-containers-of-incomplete.swift
@@ -30,9 +30,6 @@
 //
 // REQUIRES: swift_feature_ImportCxxMembersLazily
 
-// Requires specifying the Android API when compiling
-// XFAIL: OS=linux-android, OS=linux-androideabi
-
 //--- Inputs/module.modulemap
 module StdContain {
   header "std-contain-incomplete.h"

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
@@ -21,6 +21,9 @@
 // RUN: %target-interop-build-clangxx -fsyntax-only -x c++-header %t/full-cxx-swift-cxx-bridging.h -std=gnu++17 -c -fmodules -fcxx-modules -I %t 
 // FIXME: test c++20 (rdar://117419434)
 
+// Failing for Android since NDK 29, android/ndk#2242
+// UNSUPPORTED: OS=linux-android, OS=linux-androideabi
+
 //--- header.h
 
 struct Trivial {

--- a/test/Reflection/noncopyable_field_typeref.swift
+++ b/test/Reflection/noncopyable_field_typeref.swift
@@ -10,6 +10,7 @@
 // UNSUPPORTED: CPU=arm64e
 // UNSUPPORTED: OS=linux-android
 // UNSUPPORTED: CPU=armv7k && OS=watchos
+// XFAIL: OS=linux-android, OS=linux-androideabi
 
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -target %module-target-future %s -parse-as-library -emit-module -emit-library -module-name NoncopyableFields -o %t/%target-library-name(NoncopyableFields)

--- a/test/Reflection/noncopyable_field_typeref.swift
+++ b/test/Reflection/noncopyable_field_typeref.swift
@@ -10,13 +10,10 @@
 // UNSUPPORTED: CPU=arm64e
 // UNSUPPORTED: OS=linux-android
 // UNSUPPORTED: CPU=armv7k && OS=watchos
-// XFAIL: OS=linux-android, OS=linux-androideabi
 
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -target %module-target-future %s -parse-as-library -emit-module -emit-library -module-name NoncopyableFields -o %t/%target-library-name(NoncopyableFields)
+// RUN: %target-build-swift -target %target-swift-6.4-abi-triple %s -parse-as-library -emit-module -emit-library -module-name NoncopyableFields -o %t/%target-library-name(NoncopyableFields)
 // RUN: %target-swift-reflection-dump %t/%target-library-name(NoncopyableFields) | %FileCheck %s
-
-// FIXME: this should be `-target %target-swift-6.4-abi-triple` once the platform versions are known.
 
 struct NC: ~Copyable {}
 

--- a/test/Reflection/typeref_decoding_packs.swift
+++ b/test/Reflection/typeref_decoding_packs.swift
@@ -19,7 +19,7 @@
 // RUN: %target-swift-reflection-dump %t/TypesToReflect | %FileCheck %s
 
 // Fails only with Android NDK 28 because of an lld issue
-// XFAIL: OS=linux-android
+// UNSUPPORTED: OS=linux-android
 
 // CHECK: FIELDS:
 // CHECK: =======

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -13,7 +13,7 @@
 // UNSUPPORTED: CPU=arm64e
 
 // This started failing for Android with #89305, disable until NDK 30 is used.
-// XFAIL: OS=linux-android && CPU=aarch64
+// UNSUPPORTED: OS=linux-android && CPU=aarch64
 
 // RUN: %target-build-swift -target %target-swift-5.2-abi-triple -Xfrontend -disable-availability-checking %S/Inputs/TypeLowering.swift -parse-as-library -emit-module -emit-library %no-fixup-chains -module-name TypeLowering -o %t/%target-library-name(TypesToReflect)
 // RUN: %target-build-swift -target %target-swift-5.2-abi-triple -Xfrontend -disable-availability-checking %S/Inputs/TypeLowering.swift %S/Inputs/main.swift -emit-module -emit-executable %no-fixup-chains -module-name TypeLowering -o %t/TypesToReflect

--- a/test/Reflection/typeref_lowering_packs.swift
+++ b/test/Reflection/typeref_lowering_packs.swift
@@ -17,7 +17,7 @@
 // REQUIRES: PTRSIZE=64
 
 // Fails only with Android NDK 28 because of an lld issue
-// XFAIL: OS=linux-android
+// UNSUPPORTED: OS=linux-android
 
 12TypeLowering6SimpleV
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2043,8 +2043,7 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
     config.target_build_swift = ' '.join([
         config.swiftc,
         '-target', config.variant_triple,
-        '-sdk', config.variant_sdk, '-Xclang-linker',
-        '--target={}{}'.format(config.variant_triple, config.android_api_level),
+        '-sdk', config.variant_sdk,
         '-tools-directory', tools_directory,
         config.resource_dir_opt, mcp_opt, config.swift_test_options,
         config.swift_driver_test_options, swift_execution_tests_extra_flags])
@@ -2097,8 +2096,7 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
         config.swiftc,
         '-target', config.variant_triple,
         '-toolchain-stdlib-rpath',
-        '-sdk', config.variant_sdk, '-Xclang-linker',
-        '--target={}{}'.format(config.variant_triple, config.android_api_level),
+        '-sdk', config.variant_sdk,
         '-tools-directory', tools_directory,
         config.resource_dir_opt, mcp_opt,
         config.swift_driver_test_options])


### PR DESCRIPTION
- **Explanation**: Following on the new Runtimes/ CMake config, which has been used to build the Android stdlib with versioned target triples on Windows since last year, this switches the stdlib/ CMake config used on linux/Mac to do the same with its Swift source, as already done with the stdlib C/C++ source and to link against the Android libc with the API level given. Switch the compiler validation suite to using these versioned target triples also, and disable four tests for NDK 30.

- **Scope**: Only affects Android stdlib cross-compilation and the compiler tests

- **Issues**: #85522

- **Original PRs**: #90650, #90999, #91130

- **Risk**: Low, everything works in trunk

- **Testing**: Passed all trunk CI, plus needed for the upcoming Android LTS NDK 30, which requires versioned target triples

- **Reviewers**: @edymtt @etcwilde