### PR TITLE
[cxx-interop] Fix emitted constructor of `swift::Optional` enum payloads

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -495,6 +495,24 @@ private:
     return false;
   }
 
+  /// Whether instances of this type can be copied with memcpy.
+  bool isTriviallyCopyable(const NominalTypeDecl *objectTypeDecl,
+                           OptionalTypeKind optKind) {
+    if (!objectTypeDecl)
+      return false;
+    auto knownCxxTypeInfo =
+        owningPrinter.typeMapping.getKnownCxxTypeInfo(objectTypeDecl);
+    // An optional payload bridges to a Swift `Optional` wrapper, unless the
+    // wrapped type maps to a nullable C++ type (e.g. a pointer), in which case
+    // the optionality is folded into that trivial representation.
+    bool resultIsSwiftOptional =
+        optKind != OTK_None &&
+        !(knownCxxTypeInfo && knownCxxTypeInfo->canBeNullable);
+    if (resultIsSwiftOptional)
+      return false;
+    return knownCxxTypeInfo || isClangPOD(objectTypeDecl);
+  }
+
   void visitEnumDeclCxx(EnumDecl *ED) {
     assert(owningPrinter.outputLang == OutputLanguageMode::Cxx);
 
@@ -607,10 +625,7 @@ private:
             auto objectTypeDecl = objectType->getNominalOrBoundGenericNominal();
             assert(objectTypeDecl != nullptr || paramType->isOptional());
 
-            if (objectTypeDecl &&
-                (owningPrinter.typeMapping.getKnownCxxTypeInfo(
-                     objectTypeDecl) ||
-                 isClangPOD(objectTypeDecl))) {
+            if (isTriviallyCopyable(objectTypeDecl, optKind)) {
               outOfLineOS << "    " << types[paramType] << " result;\n";
               outOfLineOS << "    "
                              "memcpy(&result, payloadFromDestruction, "
@@ -776,10 +791,7 @@ private:
                       objectType->getNominalOrBoundGenericNominal();
                   assert(objectTypeDecl != nullptr || paramType->isOptional());
 
-                  if (objectTypeDecl &&
-                      (owningPrinter.typeMapping.getKnownCxxTypeInfo(
-                           objectTypeDecl) ||
-                       isClangPOD(objectTypeDecl))) {
+                  if (isTriviallyCopyable(objectTypeDecl, optKind)) {
                     outOfLineOS
                         << "    memcpy(result._getOpaquePointer(), &val, "
                            "sizeof(val));\n";

--- a/test/Interop/SwiftToCxx/enums/enum-optional-payload-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/enum-optional-payload-in-cxx.swift
@@ -1,0 +1,42 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name Enums -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/enums.h
+// RUN: %FileCheck %s < %t/enums.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/enums.h -Wno-unused-private-field -Wno-unused-function -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
+
+// REQUIRES: PTRSIZE=64
+
+public enum MatchResult {
+    case none
+    case scalar(Unicode.Scalar?)
+    case value(Int32?)
+    case rawptr(UnsafeRawPointer?)
+}
+
+// An optional value-type payload is returned via returnNewValue, not by
+// default-constructing swift::Optional<...>.
+
+// CHECK:      SWIFT_INLINE_THUNK swift::Optional<char32_t> MatchResult::getScalar() const {
+// CHECK:        return swift::_impl::implClassFor<swift::Optional<char32_t>>::type::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:     swift::_impl::implClassFor<swift::Optional<char32_t>>::type::initializeWithTake(result, payloadFromDestruction);
+// CHECK-NEXT:   });
+
+// CHECK:      SWIFT_INLINE_THUNK MatchResult MatchResult::_impl_value::operator()(const swift::Optional<int32_t>& val) const {
+// CHECK:        swift::_impl::implClassFor<swift::Optional<int32_t>>::type::initializeWithTake(result._getOpaquePointer(), swift::_impl::implClassFor<swift::Optional<int32_t>>::type::getOpaquePointer(*valCopy));
+
+// CHECK:      SWIFT_INLINE_THUNK swift::Optional<int32_t> MatchResult::getValue() const {
+// CHECK:        return swift::_impl::implClassFor<swift::Optional<int32_t>>::type::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:     swift::_impl::implClassFor<swift::Optional<int32_t>>::type::initializeWithTake(result, payloadFromDestruction);
+// CHECK-NEXT:   });
+
+// An optional pointer payload bridges to a nullable C++ pointer, which is a
+// trivial value, so both the case constructor and the getter keep the memcpy
+// path.
+
+// CHECK:      SWIFT_INLINE_THUNK MatchResult MatchResult::_impl_rawptr::operator()(void const * _Nullable val) const {
+// CHECK:        memcpy(result._getOpaquePointer(), &val, sizeof(val));
+
+// CHECK:      SWIFT_INLINE_THUNK void const * _Nullable MatchResult::getRawptr() const {
+// CHECK:        void const * _Nullable result;
+// CHECK-NEXT:   memcpy(&result, payloadFromDestruction, sizeof(result));
+// CHECK-NEXT:   return result;


### PR DESCRIPTION
For Swift enums with associated values, the generated reverse interop header contains getters that return the associated values. When the associated value is an `Optional` of a trivial type, the `Optional` needs to be constructed as a Swift enum, not as a trivial value.

Instead of using `memcpy`, let's invoke the constructor of `Optional`.

rdar://183131768