### PR TITLE
[6.4 test only] Embedded concurrency requires release stdlib

### DIFF
--- a/test/embedded/availability-macos.swift
+++ b/test/embedded/availability-macos.swift
@@ -9,6 +9,7 @@
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: OS=macosx
 // REQUIRES: concurrency
+// REQUIRES: optimized_stdlib
 
 import _Concurrency
 


### PR DESCRIPTION
- **Explanation**: Require the release standard library for some Embedded Swift concurrency tests.
- **Scope**: Test-only.
- **Issues**: rdar://181873608
- **Original PRs**: https://github.com/swiftlang/swift/pull/89024
- **Risk**: Very low.
- **Testing**: CI
