### PR TITLE
Parse: expose COM models to conditional compilation

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -343,6 +343,15 @@ namespace swift {
     };
     std::optional<COMInteropModel> COMModel = std::nullopt;
 
+    /// Return the compiler-owned conditional-compilation identifier for the
+    /// selected COM interop model, or an empty string when COM interop is
+    /// disabled.
+    StringRef getCOMInteropModelConditionalCompilationFlag() const;
+
+    /// Whether \p Name is reserved for a COM interop model's
+    /// conditional-compilation identifier.
+    static bool isCOMInteropModelConditionalCompilationFlag(StringRef Name);
+
     /// Enable C++ interop code generation and build configuration
     /// options. Disabled by default because there is no way to control the
     /// language mode of clang on a per-header or even per-module basis. Also

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -33,6 +33,23 @@
 
 using namespace swift;
 
+StringRef LangOptions::getCOMInteropModelConditionalCompilationFlag() const {
+  if (!EnableCOMInterop || !COMModel)
+    return {};
+
+  switch (*COMModel) {
+  case COMInteropModel::Microsoft:
+    return "$_MicrosoftCOM";
+  case COMInteropModel::CoreFoundation:
+    return "$_CoreFoundationCOM";
+  }
+  llvm_unreachable("unhandled COM interop model");
+}
+
+bool LangOptions::isCOMInteropModelConditionalCompilationFlag(StringRef Name) {
+  return Name == "$_MicrosoftCOM" || Name == "$_CoreFoundationCOM";
+}
+
 LangOptions::LangOptions() {
   // Add all promoted language features
 #define LANGUAGE_FEATURE(FeatureName, SENumber, Description)                   \

--- a/lib/Basic/LangOptionsBridging.cpp
+++ b/lib/Basic/LangOptionsBridging.cpp
@@ -175,6 +175,15 @@ void BridgedLangOptions_enumerateBuildConfigurationEntries(
     callback(cLangOpts, callbackContext, BCKFeature, StringRef(#FeatureName));
 #include "swift/Basic/Features.def"
 
+  // Compiler-owned COM model conditions use the same `$Name` source syntax as
+  // language features, but are derived exclusively from COMModel rather than
+  // Features.def or an independently-enableable feature flag.
+  if (auto condition = langOpts.getCOMInteropModelConditionalCompilationFlag();
+      !condition.empty()) {
+    assert(condition.starts_with("$"));
+    callback(cLangOpts, callbackContext, BCKFeature, condition.drop_front());
+  }
+
   // Enumerate attributes that are available.
 #define DECL_ATTR(SPELLING, CLASS, REQUIREMENTS, BEHAVIORS, CODE)              \
   if ((BEHAVIORS) == 0) \

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1681,13 +1681,18 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
         " " + printFormalCxxInteropVersion(Opts);
 
   Opts.UseStaticStandardLibrary = Args.hasArg(OPT_use_static_resource_dir);
-  Opts.EnableCOMInterop = Args.hasArg(OPT_enable_com_interop);
+  // Preserve COM interop inherited by a textual-interface sub-invocation.
+  // This mirrors C++ interop above: parsing the interface's own flags may
+  // enable or refine the inherited model, but must not turn it back off.
+  Opts.EnableCOMInterop |= Args.hasArg(OPT_enable_com_interop);
   // A COM interop model is in effect exactly when interop is enabled: default
   // it from the target, then honor an explicit override.
   if (Opts.EnableCOMInterop) {
-    Opts.COMModel = Target.isOSDarwin()
-                        ? LangOptions::COMInteropModel::CoreFoundation
-                        : LangOptions::COMInteropModel::Microsoft;
+    if (!Opts.COMModel)
+      Opts.COMModel = Target.isOSDarwin()
+                          ? LangOptions::COMInteropModel::CoreFoundation
+                          : LangOptions::COMInteropModel::Microsoft;
+
     if (const Arg *A = Args.getLastArg(OPT_com_interop_model)) {
       std::optional<LangOptions::COMInteropModel> model =
           llvm::StringSwitch<decltype(model)>(A->getValue())

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -2046,6 +2046,29 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
     GenericArgs.push_back("Embedded");
   }
 
+  // Inherit COM interop and its selected model. Textual interfaces can use
+  // compiler-owned COM model conditions, so both the in-process invocation and
+  // its reproducible build arguments must agree with the importing context.
+  genericSubInvocation.getLangOptions().EnableCOMInterop =
+      langOpts.EnableCOMInterop;
+  genericSubInvocation.getLangOptions().COMModel = langOpts.COMModel;
+  if (langOpts.EnableCOMInterop) {
+    assert(langOpts.COMModel && "enabled COM interop requires a model");
+    GenericArgs.push_back("-enable-experimental-com-interop");
+
+    StringRef modelName;
+    switch (*langOpts.COMModel) {
+    case LangOptions::COMInteropModel::Microsoft:
+      modelName = "microsoft";
+      break;
+    case LangOptions::COMInteropModel::CoreFoundation:
+      modelName = "corefoundation";
+      break;
+    }
+    GenericArgs.push_back(
+        ArgSaver.save((Twine("-com-interop-model=") + modelName).str()));
+  }
+
   if (langOpts.DebuggerSupport) {
     if (clangImporterOpts.DirectClangCC1ModuleBuild) {
       subClangImporterOpts.ExtraArgs.push_back("-dwarf-ext-refs");
@@ -2852,6 +2875,20 @@ std::unique_ptr<ExplicitCASModuleLoader> ExplicitCASModuleLoader::create(
 }
 
 namespace swift::SwiftInterfaceModuleOutputPathResolution {
+static unsigned getCOMInteropCacheState(const LangOptions &langOpts) {
+  if (!langOpts.EnableCOMInterop)
+    return 0;
+
+  assert(langOpts.COMModel && "enabled COM interop requires a model");
+  switch (*langOpts.COMModel) {
+  case LangOptions::COMInteropModel::Microsoft:
+    return 1;
+  case LangOptions::COMInteropModel::CoreFoundation:
+    return 2;
+  }
+  llvm_unreachable("unhandled COM interop model");
+}
+
 /// Construct a key for the .swiftmodule being generated. There is a
 /// balance to be struck here between things that go in the cache key and
 /// things that go in the "up to date" check of the cache entry. We want to
@@ -2930,8 +2967,11 @@ static std::string getContextHash(const CompilerInvocation &CI,
       unsigned(CI.getLangOptions().EnableCXXInterop),
 
       // Is Embedded Swift enabled?
-      unsigned(CI.getLangOptions().hasFeature(Feature::Embedded))
-  );
+      unsigned(CI.getLangOptions().hasFeature(Feature::Embedded)),
+
+      // COM model conditions can select different declarations from the same
+      // textual interface.
+      getCOMInteropCacheState(CI.getLangOptions()));
 
   return llvm::toString(llvm::APInt(64, H), 36, /*Signed=*/false);
 }

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -573,6 +573,10 @@ public:
     if (Name.empty())
       return false;
 
+    if (LangOptions::isCOMInteropModelConditionalCompilationFlag(Name))
+      return Name ==
+             Ctx.LangOpts.getCOMInteropModelConditionalCompilationFlag();
+
     if (Name.starts_with("$") && Ctx.LangOpts.hasFeature(Name.drop_front()))
       return true;
 

--- a/test/Misc/verify-swift-feature-testing.test-sh
+++ b/test/Misc/verify-swift-feature-testing.test-sh
@@ -17,6 +17,8 @@ EXCEPTIONAL_FILES = [
     # Tests for UnknownFeature not existing
     pathlib.Path("test/Frontend/features/upcoming_feature.swift"),
     pathlib.Path("test/Frontend/features/strict_features.swift"),
+    # Tests that a compiler-owned COM condition is not a language feature
+    pathlib.Path("test/Parse/ConditionalCompilation/com_interop_model.swift"),
     # Tests for ModuleInterfaceExportAs being ignored
     pathlib.Path("test/ModuleInterface/swift-export-as.swift"),
     # Uses the pseudo-feature AvailabilityMacro=

--- a/test/ModuleInterface/ModuleCache/com-interop-caching.swift
+++ b/test/ModuleInterface/ModuleCache/com-interop-caching.swift
@@ -1,0 +1,77 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %empty-directory(%t/ModuleCache)
+
+// Disabled COM interop builds one cache entry and then reuses it.
+// RUN: %target-swift-frontend -parse-stdlib -typecheck \
+// RUN:   %t/RebuildDisabled.swift -I %t -module-cache-path %t/ModuleCache \
+// RUN:   -Rmodule-interface-rebuild -verify
+// RUN: %target-swift-frontend -parse-stdlib -typecheck \
+// RUN:   %t/UseDisabled.swift -I %t -module-cache-path %t/ModuleCache \
+// RUN:   -Rmodule-interface-rebuild -verify
+// RUN: %find_files %t/ModuleCache 'Lib-*.swiftmodule' \
+// RUN:   | %llvm_obj_root/bin/count 1
+
+// The Microsoft model gets a distinct cache entry and then reuses it.
+// RUN: %target-swift-frontend -parse-stdlib -typecheck \
+// RUN:   %t/RebuildMicrosoft.swift -I %t -module-cache-path %t/ModuleCache \
+// RUN:   -Rmodule-interface-rebuild -verify \
+// RUN:   -enable-experimental-com-interop -com-interop-model=microsoft \
+// RUN:   -disable-implicit-com-module-import
+// RUN: %target-swift-frontend -parse-stdlib -typecheck \
+// RUN:   %t/UseMicrosoft.swift -I %t -module-cache-path %t/ModuleCache \
+// RUN:   -Rmodule-interface-rebuild -verify \
+// RUN:   -enable-experimental-com-interop -com-interop-model=microsoft \
+// RUN:   -disable-implicit-com-module-import
+// RUN: %find_files %t/ModuleCache 'Lib-*.swiftmodule' \
+// RUN:   | %llvm_obj_root/bin/count 2
+
+// The CoreFoundation model gets a third cache entry and then reuses it.
+// RUN: %target-swift-frontend -parse-stdlib -typecheck \
+// RUN:   %t/RebuildCoreFoundation.swift -I %t \
+// RUN:   -module-cache-path %t/ModuleCache -Rmodule-interface-rebuild -verify \
+// RUN:   -enable-experimental-com-interop -com-interop-model=corefoundation \
+// RUN:   -disable-implicit-com-module-import
+// RUN: %target-swift-frontend -parse-stdlib -typecheck \
+// RUN:   %t/UseCoreFoundation.swift -I %t \
+// RUN:   -module-cache-path %t/ModuleCache -Rmodule-interface-rebuild -verify \
+// RUN:   -enable-experimental-com-interop -com-interop-model=corefoundation \
+// RUN:   -disable-implicit-com-module-import
+// RUN: %find_files %t/ModuleCache 'Lib-*.swiftmodule' \
+// RUN:   | %llvm_obj_root/bin/count 3
+
+//--- Lib.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -parse-stdlib -module-name Lib
+
+#if $_MicrosoftCOM
+public enum Microsoft {}
+#elseif $_CoreFoundationCOM
+public enum CoreFoundation {}
+#else
+public enum Disabled {}
+#endif
+
+//--- RebuildDisabled.swift
+import Lib // expected-remark {{rebuilding module 'Lib' from interface}}
+func use(_: Disabled.Type) {}
+
+//--- UseDisabled.swift
+import Lib
+func use(_: Disabled.Type) {}
+
+//--- RebuildMicrosoft.swift
+import Lib // expected-remark {{rebuilding module 'Lib' from interface}}
+func use(_: Microsoft.Type) {}
+
+//--- UseMicrosoft.swift
+import Lib
+func use(_: Microsoft.Type) {}
+
+//--- RebuildCoreFoundation.swift
+import Lib // expected-remark {{rebuilding module 'Lib' from interface}}
+func use(_: CoreFoundation.Type) {}
+
+//--- UseCoreFoundation.swift
+import Lib
+func use(_: CoreFoundation.Type) {}

--- a/test/ModuleInterface/com-interop-options.swift
+++ b/test/ModuleInterface/com-interop-options.swift
@@ -1,0 +1,37 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -parse-stdlib -swift-version 5 \
+// RUN:   -enable-library-evolution \
+// RUN:   -enable-experimental-com-interop -com-interop-model=microsoft \
+// RUN:   -disable-implicit-com-module-import -module-name MicrosoftCOMOptions \
+// RUN:   -emit-module -o /dev/null \
+// RUN:   -emit-module-interface-path %t/MicrosoftCOMOptions.swiftinterface %s
+// RUN: %FileCheck %s --check-prefix=MICROSOFT \
+// RUN:   < %t/MicrosoftCOMOptions.swiftinterface
+// RUN: %target-swift-frontend -compile-module-from-interface \
+// RUN:   -o %t/MicrosoftCOMOptions.swiftmodule \
+// RUN:   %t/MicrosoftCOMOptions.swiftinterface
+
+// RUN: %target-swift-frontend -parse-stdlib -swift-version 5 \
+// RUN:   -enable-library-evolution \
+// RUN:   -enable-experimental-com-interop -com-interop-model=corefoundation \
+// RUN:   -disable-implicit-com-module-import \
+// RUN:   -module-name CoreFoundationCOMOptions \
+// RUN:   -emit-module -o /dev/null \
+// RUN:   -emit-module-interface-path \
+// RUN:   %t/CoreFoundationCOMOptions.swiftinterface %s
+// RUN: %FileCheck %s --check-prefix=COREFOUNDATION \
+// RUN:   < %t/CoreFoundationCOMOptions.swiftinterface
+// RUN: %target-swift-frontend -compile-module-from-interface \
+// RUN:   -o %t/CoreFoundationCOMOptions.swiftmodule \
+// RUN:   %t/CoreFoundationCOMOptions.swiftinterface
+
+// MICROSOFT: swift-module-flags:
+// MICROSOFT-SAME: -enable-experimental-com-interop
+// MICROSOFT-SAME: -com-interop-model=microsoft
+
+// COREFOUNDATION: swift-module-flags:
+// COREFOUNDATION-SAME: -enable-experimental-com-interop
+// COREFOUNDATION-SAME: -com-interop-model=corefoundation
+
+public func value() {}

--- a/test/Parse/ConditionalCompilation/com_interop_model.swift
+++ b/test/Parse/ConditionalCompilation/com_interop_model.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swift-frontend -typecheck %s -enable-experimental-com-interop -com-interop-model=microsoft -D EXPECT_MICROSOFT
+// RUN: %target-swift-frontend -typecheck %s -enable-experimental-com-interop -com-interop-model=corefoundation -D EXPECT_COREFOUNDATION
+// RUN: %target-swift-frontend -typecheck %s -D EXPECT_DISABLED
+// RUN: %target-swift-frontend -typecheck %s -D EXPECT_DISABLED -D '$_MicrosoftCOM'
+// RUN: %target-swift-frontend -typecheck %s -D EXPECT_DISABLED -enable-experimental-feature _MicrosoftCOM
+
+#if EXPECT_MICROSOFT
+  #if !$_MicrosoftCOM
+    #error("$_MicrosoftCOM should be enabled for the Microsoft COM model")
+  #endif
+  #if $_CoreFoundationCOM
+    #error("$_CoreFoundationCOM should be disabled for the Microsoft COM model")
+  #endif
+#elseif EXPECT_COREFOUNDATION
+  #if $_MicrosoftCOM
+    #error("$_MicrosoftCOM should be disabled for the CoreFoundation COM model")
+  #endif
+  #if !$_CoreFoundationCOM
+    #error("$_CoreFoundationCOM should be enabled for the CoreFoundation COM model")
+  #endif
+#elseif EXPECT_DISABLED
+  #if $_MicrosoftCOM
+    #error("$_MicrosoftCOM should be disabled when COM interop is disabled")
+  #endif
+  #if $_CoreFoundationCOM
+    #error("$_CoreFoundationCOM should be disabled when COM interop is disabled")
+  #endif
+#else
+  #error("test configuration missing")
+#endif

--- a/test/Parse/ConditionalCompilation/com_interop_model_astgen.swift
+++ b/test/Parse/ConditionalCompilation/com_interop_model_astgen.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swift-frontend -typecheck %s -enable-experimental-feature ParserASTGen -enable-experimental-com-interop -com-interop-model=microsoft -D EXPECT_MICROSOFT
+// RUN: %target-swift-frontend -typecheck %s -enable-experimental-feature ParserASTGen -enable-experimental-com-interop -com-interop-model=corefoundation -D EXPECT_COREFOUNDATION
+// RUN: %target-swift-frontend -typecheck %s -enable-experimental-feature ParserASTGen -D EXPECT_DISABLED
+
+// REQUIRES: swift_feature_ParserASTGen
+
+#if EXPECT_MICROSOFT
+  #if !$_MicrosoftCOM
+    #error("$_MicrosoftCOM should be enabled for the Microsoft COM model")
+  #endif
+  #if $_CoreFoundationCOM
+    #error("$_CoreFoundationCOM should be disabled for the Microsoft COM model")
+  #endif
+#elseif EXPECT_COREFOUNDATION
+  #if $_MicrosoftCOM
+    #error("$_MicrosoftCOM should be disabled for the CoreFoundation COM model")
+  #endif
+  #if !$_CoreFoundationCOM
+    #error("$_CoreFoundationCOM should be enabled for the CoreFoundation COM model")
+  #endif
+#elseif EXPECT_DISABLED
+  #if $_MicrosoftCOM
+    #error("$_MicrosoftCOM should be disabled when COM interop is disabled")
+  #endif
+  #if $_CoreFoundationCOM
+    #error("$_CoreFoundationCOM should be disabled when COM interop is disabled")
+  #endif
+#else
+  #error("test configuration missing")
+#endif


### PR DESCRIPTION
Expose the active COM interop model through compiler-owned `$_MicrosoftCOM` and `$_CoreFoundationCOM` conditions. Derive the condition from the selected model so it cannot be enabled independently through `-D` or `-enable-experimental-feature`.

Make the condition available to both parsers so the COM supplemental module can select model-specific API while preserving a common source surface.