### PR TITLE
[Embedded PAL] Split the recursive mutex entrypoints out from the non-recursive ones

### DIFF
--- a/include/swift/Threading/Impl/ThreadEmbeddedImpl.h
+++ b/include/swift/Threading/Impl/ThreadEmbeddedImpl.h
@@ -94,7 +94,9 @@ inline void mutex_unsafe_unlock(mutex_handle &handle) {
   _swift_mutex_unlock(&handle);
 }
 
-using recursive_mutex_handle = mutex_handle;
+struct recursive_mutex_handle {
+  uintptr_t storage[EMBEDDED_SWIFT_MUTEX_RECURSIVE_NUM_WORDS] = {};
+};
 
 inline void recursive_mutex_init(recursive_mutex_handle &handle,
                                  bool checked = false) {

--- a/include/swift/Threading/Impl/ThreadEmbeddedImpl.h
+++ b/include/swift/Threading/Impl/ThreadEmbeddedImpl.h
@@ -98,22 +98,20 @@ using recursive_mutex_handle = mutex_handle;
 
 inline void recursive_mutex_init(recursive_mutex_handle &handle,
                                  bool checked = false) {
-  _swift_mutex_init(&handle,
-                    static_cast<swift_mutex_flags_t>(
-                        SWIFT_MUTEX_RECURSIVE |
-                        (checked ? SWIFT_MUTEX_CHECKED : SWIFT_MUTEX_NONE)));
+  _swift_mutexRecursive_init(
+      &handle, checked ? SWIFT_MUTEX_CHECKED : SWIFT_MUTEX_NONE);
 }
 
 inline void recursive_mutex_destroy(recursive_mutex_handle &handle) {
-  _swift_mutex_destroy(&handle);
+  _swift_mutexRecursive_destroy(&handle);
 }
 
 inline void recursive_mutex_lock(recursive_mutex_handle &handle) {
-  _swift_mutex_lock(&handle);
+  _swift_mutexRecursive_lock(&handle);
 }
 
 inline void recursive_mutex_unlock(recursive_mutex_handle &handle) {
-  _swift_mutex_unlock(&handle);
+  _swift_mutexRecursive_unlock(&handle);
 }
 
 inline void once_impl(once_t &predicate, void (*fn)(void *), void *ctx) {

--- a/stdlib/public/EmbeddedPlatform/EmbeddedPlatformMultiThreadedDarwin.c
+++ b/stdlib/public/EmbeddedPlatform/EmbeddedPlatformMultiThreadedDarwin.c
@@ -12,14 +12,14 @@
  *
  * A Darwin-only implementation of the Embedded Swift platform mutex hooks:
  *
- *   - The common non-recursive case (with or without the CHECKED flag) uses
- *     `os_unfair_lock` (see <os/lock.h>), stored fully inline in the
- *     caller-owned mutex storage.
+ *   - The non-recursive `_swift_mutex_*` family (with or without the CHECKED
+ *     flag) uses `os_unfair_lock` (see <os/lock.h>), stored fully inline in
+ *     the caller-owned mutex storage.
  *
- *   - The RECURSIVE case uses a heap-allocated `pthread_mutex_t` initialized
- *     with `PTHREAD_MUTEX_RECURSIVE`, since `os_unfair_lock` has no reentrant
- *     mode and building one on top of it would duplicate what pthreads
- *     already provides.
+ *   - The `_swift_mutexRecursive_*` family uses a `pthread_mutex_t`
+ *     initialized with `PTHREAD_MUTEX_RECURSIVE`, since `os_unfair_lock` has
+ *     no reentrant mode and building one on top of it would duplicate what
+ *     pthreads already provides.
  *
  *===----------------------------------------------------------------------===*/
 
@@ -39,16 +39,11 @@
 
 extern int pthread_key_init_np(int, void (*)(void *));
 
-// Storage layout that we impose on the caller-owned mutex buffer. `flags` is
-// used as the discriminator between the two backends: if it has
-// `SWIFT_MUTEX_RECURSIVE` set, `u.heap` is a heap-allocated
-// `pthread_mutex_t`; otherwise `u.unfair` is an inline `os_unfair_lock`.
+// Storage layout for the non-recursive `_swift_mutex_*` family, backed by an
+// inline `os_unfair_lock`.
 typedef struct {
   uint32_t flags;
-  union {
-    os_unfair_lock unfair;
-    pthread_mutex_t *heap;
-  } u;
+  os_unfair_lock unfair;
 } swift_darwin_mutex_t;
 
 _Static_assert(sizeof(swift_darwin_mutex_t) <= EMBEDDED_SWIFT_MUTEX_NUM_WORDS * sizeof(void *),
@@ -57,6 +52,16 @@ _Static_assert(sizeof(swift_darwin_mutex_t) <= EMBEDDED_SWIFT_MUTEX_NUM_WORDS * 
                "pointer-sized words)");
 _Static_assert(_Alignof(swift_darwin_mutex_t) <= _Alignof(void *),
                "swift_darwin_mutex_t requires stronger alignment than the "
+               "Embedded Swift Platform mutex storage provides");
+
+// The `_swift_mutexRecursive_*` family is backed directly by a
+// `pthread_mutex_t`, constructed in place in the caller-owned storage.
+_Static_assert(sizeof(pthread_mutex_t) <= EMBEDDED_SWIFT_MUTEX_NUM_WORDS * sizeof(void *),
+               "pthread_mutex_t does not fit in the Embedded Swift Platform "
+               "mutex storage (EMBEDDED_SWIFT_MUTEX_NUM_WORDS pointer-sized "
+               "words)");
+_Static_assert(_Alignof(pthread_mutex_t) <= _Alignof(void *),
+               "pthread_mutex_t requires stronger alignment than the "
                "Embedded Swift Platform mutex storage provides");
 
 static void trap_if(int failed) {
@@ -77,65 +82,51 @@ static pthread_key_t swift_embedded_platform_tls_key(swift_tls_key_t key) {
 void _swift_mutex_init(void *mutex, swift_mutex_flags_t flags) {
   swift_darwin_mutex_t *m = (swift_darwin_mutex_t *)mutex;
   m->flags = (uint32_t)flags;
-
-  if (flags & SWIFT_MUTEX_RECURSIVE) {
-    pthread_mutex_t *heap = (pthread_mutex_t *)_swift_allocate(
-        _Alignof(pthread_mutex_t), sizeof(pthread_mutex_t), SWIFT_ALLOC_NONE);
-    trap_if(heap == NULL);
-
-    pthread_mutexattr_t attr;
-    trap_if(pthread_mutexattr_init(&attr) != 0);
-    trap_if(pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE) != 0);
-    trap_if(pthread_mutex_init(heap, &attr) != 0);
-    (void)pthread_mutexattr_destroy(&attr);
-
-    m->u.heap = heap;
-    return;
-  }
-
-  m->u.unfair = (os_unfair_lock)OS_UNFAIR_LOCK_INIT;
+  m->unfair = (os_unfair_lock)OS_UNFAIR_LOCK_INIT;
 }
 
 void _swift_mutex_destroy(void *mutex) {
-  swift_darwin_mutex_t *m = (swift_darwin_mutex_t *)mutex;
-  if (m->flags & SWIFT_MUTEX_RECURSIVE) {
-    trap_if(pthread_mutex_destroy(m->u.heap) != 0);
-    _swift_deallocate(m->u.heap, _Alignof(pthread_mutex_t),
-                      sizeof(pthread_mutex_t), SWIFT_DEALLOC_NONE);
-    m->u.heap = NULL;
-  }
-  // Non-recursive: `os_unfair_lock` has no destroy step.
+  // `os_unfair_lock` has no destroy step.
 }
 
 void _swift_mutex_lock(void *mutex) {
   swift_darwin_mutex_t *m = (swift_darwin_mutex_t *)mutex;
-  if (m->flags & SWIFT_MUTEX_RECURSIVE) {
-    trap_if(pthread_mutex_lock(m->u.heap) != 0);
-    return;
-  }
-  os_unfair_lock_lock(&m->u.unfair);
+  os_unfair_lock_lock(&m->unfair);
 }
 
 void _swift_mutex_unlock(void *mutex) {
   swift_darwin_mutex_t *m = (swift_darwin_mutex_t *)mutex;
-  if (m->flags & SWIFT_MUTEX_RECURSIVE) {
-    trap_if(pthread_mutex_unlock(m->u.heap) != 0);
-    return;
-  }
   if (m->flags & SWIFT_MUTEX_CHECKED) {
     // Aborts if the current thread does not own the lock, or the lock is
     // not held at all.
-    os_unfair_lock_assert_owner(&m->u.unfair);
+    os_unfair_lock_assert_owner(&m->unfair);
   }
-  os_unfair_lock_unlock(&m->u.unfair);
+  os_unfair_lock_unlock(&m->unfair);
 }
 
 __swift_ptrdiff_t _swift_mutex_tryLock(void *mutex) {
   swift_darwin_mutex_t *m = (swift_darwin_mutex_t *)mutex;
-  if (m->flags & SWIFT_MUTEX_RECURSIVE) {
-    return pthread_mutex_trylock(m->u.heap) == 0 ? 1 : 0;
-  }
-  return os_unfair_lock_trylock(&m->u.unfair) ? 1 : 0;
+  return os_unfair_lock_trylock(&m->unfair) ? 1 : 0;
+}
+
+void _swift_mutexRecursive_init(void *mutex, swift_mutex_flags_t flags) {
+  pthread_mutexattr_t attr;
+  trap_if(pthread_mutexattr_init(&attr) != 0);
+  trap_if(pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE) != 0);
+  trap_if(pthread_mutex_init((pthread_mutex_t *)mutex, &attr) != 0);
+  (void)pthread_mutexattr_destroy(&attr);
+}
+
+void _swift_mutexRecursive_destroy(void *mutex) {
+  trap_if(pthread_mutex_destroy((pthread_mutex_t *)mutex) != 0);
+}
+
+void _swift_mutexRecursive_lock(void *mutex) {
+  trap_if(pthread_mutex_lock((pthread_mutex_t *)mutex) != 0);
+}
+
+void _swift_mutexRecursive_unlock(void *mutex) {
+  trap_if(pthread_mutex_unlock((pthread_mutex_t *)mutex) != 0);
 }
 
 void _swift_tls_init(swift_tls_key_t key, __swift_tls_dtor_t destructor) {

--- a/stdlib/public/EmbeddedPlatform/EmbeddedPlatformMultiThreadedDarwin.c
+++ b/stdlib/public/EmbeddedPlatform/EmbeddedPlatformMultiThreadedDarwin.c
@@ -56,13 +56,14 @@ _Static_assert(_Alignof(swift_darwin_mutex_t) <= _Alignof(void *),
 
 // The `_swift_mutexRecursive_*` family is backed directly by a
 // `pthread_mutex_t`, constructed in place in the caller-owned storage.
-_Static_assert(sizeof(pthread_mutex_t) <= EMBEDDED_SWIFT_MUTEX_NUM_WORDS * sizeof(void *),
+_Static_assert(sizeof(pthread_mutex_t) <= EMBEDDED_SWIFT_MUTEX_RECURSIVE_NUM_WORDS * sizeof(void *),
                "pthread_mutex_t does not fit in the Embedded Swift Platform "
-               "mutex storage (EMBEDDED_SWIFT_MUTEX_NUM_WORDS pointer-sized "
+               "recursive mutex storage "
+               "(EMBEDDED_SWIFT_MUTEX_RECURSIVE_NUM_WORDS pointer-sized "
                "words)");
 _Static_assert(_Alignof(pthread_mutex_t) <= _Alignof(void *),
                "pthread_mutex_t requires stronger alignment than the "
-               "Embedded Swift Platform mutex storage provides");
+               "Embedded Swift Platform recursive mutex storage provides");
 
 static void trap_if(int failed) {
   if (failed) {

--- a/stdlib/public/EmbeddedPlatform/EmbeddedPlatformMultiThreadedPOSIX.c
+++ b/stdlib/public/EmbeddedPlatform/EmbeddedPlatformMultiThreadedPOSIX.c
@@ -38,6 +38,12 @@ _Static_assert(sizeof(pthread_mutex_t) <= EMBEDDED_SWIFT_MUTEX_NUM_WORDS * sizeo
 _Static_assert(_Alignof(pthread_mutex_t) <= _Alignof(void *),
                "pthread_mutex_t requires stronger alignment than the Embedded "
                "Swift Platform mutex storage provides");
+_Static_assert(sizeof(pthread_mutex_t) <= EMBEDDED_SWIFT_MUTEX_RECURSIVE_NUM_WORDS * sizeof(void *),
+               "pthread_mutex_t does not fit in the Embedded Swift Platform "
+               "recursive mutex storage (8 pointer-sized words)");
+_Static_assert(_Alignof(pthread_mutex_t) <= _Alignof(void *),
+               "pthread_mutex_t requires stronger alignment than the Embedded "
+               "Swift Platform recursive mutex storage provides");
 #endif
 
 static void trap_if(int failed) {

--- a/stdlib/public/EmbeddedPlatform/EmbeddedPlatformMultiThreadedPOSIX.c
+++ b/stdlib/public/EmbeddedPlatform/EmbeddedPlatformMultiThreadedPOSIX.c
@@ -79,25 +79,16 @@ swift_embedded_platform_tls_init_if_needed(swift_tls_key_t key,
 }
 
 void _swift_mutex_init(void *mutex, swift_mutex_flags_t flags) {
-  int type;
-  if (flags & SWIFT_MUTEX_RECURSIVE) {
-    type = PTHREAD_MUTEX_RECURSIVE;
-  } else if (flags & SWIFT_MUTEX_CHECKED) {
-    type = PTHREAD_MUTEX_ERRORCHECK;
-  } else {
-    type = PTHREAD_MUTEX_NORMAL;
-  }
-
-  if (type == PTHREAD_MUTEX_NORMAL) {
-    trap_if(pthread_mutex_init((pthread_mutex_t *)mutex, NULL) != 0);
+  if (flags & SWIFT_MUTEX_CHECKED) {
+    pthread_mutexattr_t attr;
+    trap_if(pthread_mutexattr_init(&attr) != 0);
+    trap_if(pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK) != 0);
+    trap_if(pthread_mutex_init((pthread_mutex_t *)mutex, &attr) != 0);
+    (void)pthread_mutexattr_destroy(&attr);
     return;
   }
 
-  pthread_mutexattr_t attr;
-  trap_if(pthread_mutexattr_init(&attr) != 0);
-  trap_if(pthread_mutexattr_settype(&attr, type) != 0);
-  trap_if(pthread_mutex_init((pthread_mutex_t *)mutex, &attr) != 0);
-  (void)pthread_mutexattr_destroy(&attr);
+  trap_if(pthread_mutex_init((pthread_mutex_t *)mutex, NULL) != 0);
 }
 
 void _swift_mutex_destroy(void *mutex) {
@@ -114,6 +105,26 @@ void _swift_mutex_unlock(void *mutex) {
 
 __swift_ptrdiff_t _swift_mutex_tryLock(void *mutex) {
   return pthread_mutex_trylock((pthread_mutex_t *)mutex) == 0 ? 1 : 0;
+}
+
+void _swift_mutexRecursive_init(void *mutex, swift_mutex_flags_t flags) {
+  pthread_mutexattr_t attr;
+  trap_if(pthread_mutexattr_init(&attr) != 0);
+  trap_if(pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE) != 0);
+  trap_if(pthread_mutex_init((pthread_mutex_t *)mutex, &attr) != 0);
+  (void)pthread_mutexattr_destroy(&attr);
+}
+
+void _swift_mutexRecursive_destroy(void *mutex) {
+  trap_if(pthread_mutex_destroy((pthread_mutex_t *)mutex) != 0);
+}
+
+void _swift_mutexRecursive_lock(void *mutex) {
+  trap_if(pthread_mutex_lock((pthread_mutex_t *)mutex) != 0);
+}
+
+void _swift_mutexRecursive_unlock(void *mutex) {
+  trap_if(pthread_mutex_unlock((pthread_mutex_t *)mutex) != 0);
 }
 
 void _swift_tls_init(swift_tls_key_t key, __swift_tls_dtor_t destructor) {

--- a/stdlib/public/EmbeddedPlatform/EmbeddedPlatformSingleThreaded.swift
+++ b/stdlib/public/EmbeddedPlatform/EmbeddedPlatformSingleThreaded.swift
@@ -12,7 +12,6 @@
 
 fileprivate struct SingleThreadedMutex {
   var checked: Bool
-  var recursive: Bool
   var lockCount: UInt
 }
 
@@ -24,7 +23,6 @@ public func _swift_mutex_init(
   let storage = mutex.assumingMemoryBound(to: SingleThreadedMutex.self)
   storage.pointee = SingleThreadedMutex(
     checked: flags.contains(.checked),
-    recursive: flags.contains(.recursive),
     lockCount: 0)
 }
 
@@ -35,17 +33,14 @@ public func _swift_mutex_destroy(_ mutex: UnsafeMutableRawPointer) {
     fatalError("destroying a locked mutex")
   }
 
-  storage.pointee = SingleThreadedMutex(
-    checked: false,
-    recursive: false,
-    lockCount: 0)
+  storage.pointee = SingleThreadedMutex(checked: false, lockCount: 0)
 }
 
 @implementation @c
 public func _swift_mutex_lock(_ mutex: UnsafeMutableRawPointer) {
   let storage = mutex.assumingMemoryBound(to: SingleThreadedMutex.self)
   if storage.pointee.checked {
-    if storage.pointee.lockCount != 0 && !storage.pointee.recursive {
+    if storage.pointee.lockCount != 0 {
       fatalError("locking an already locked mutex")
     }
     storage.pointee.lockCount += 1
@@ -67,12 +62,57 @@ public func _swift_mutex_unlock(_ mutex: UnsafeMutableRawPointer) {
 public func _swift_mutex_tryLock(_ mutex: UnsafeMutableRawPointer) -> Int {
   let storage = mutex.assumingMemoryBound(to: SingleThreadedMutex.self)
   if storage.pointee.checked {
-    if storage.pointee.lockCount != 0 && !storage.pointee.recursive {
+    if storage.pointee.lockCount != 0 {
       return 0
     }
     storage.pointee.lockCount += 1
   }
   return 1
+}
+
+fileprivate struct SingleThreadedRecursiveMutex {
+  var checked: Bool
+  var lockCount: UInt
+}
+
+@implementation @c
+public func _swift_mutexRecursive_init(
+  _ mutex: UnsafeMutableRawPointer,
+  _ flags: SwiftMutexFlags
+) {
+  let storage = mutex.assumingMemoryBound(to: SingleThreadedRecursiveMutex.self)
+  storage.pointee = SingleThreadedRecursiveMutex(
+    checked: flags.contains(.checked),
+    lockCount: 0)
+}
+
+@implementation @c
+public func _swift_mutexRecursive_destroy(_ mutex: UnsafeMutableRawPointer) {
+  let storage = mutex.assumingMemoryBound(to: SingleThreadedRecursiveMutex.self)
+  if storage.pointee.checked && storage.pointee.lockCount != 0 {
+    fatalError("destroying a locked mutex")
+  }
+
+  storage.pointee = SingleThreadedRecursiveMutex(checked: false, lockCount: 0)
+}
+
+@implementation @c
+public func _swift_mutexRecursive_lock(_ mutex: UnsafeMutableRawPointer) {
+  let storage = mutex.assumingMemoryBound(to: SingleThreadedRecursiveMutex.self)
+  if storage.pointee.checked {
+    storage.pointee.lockCount += 1
+  }
+}
+
+@implementation @c
+public func _swift_mutexRecursive_unlock(_ mutex: UnsafeMutableRawPointer) {
+  let storage = mutex.assumingMemoryBound(to: SingleThreadedRecursiveMutex.self)
+  if storage.pointee.checked {
+    if storage.pointee.lockCount == 0 {
+      fatalError("unlocking an unlocked mutex")
+    }
+    storage.pointee.lockCount -= 1
+  }
 }
 
 fileprivate struct SingleThreadedTLS {

--- a/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
+++ b/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
@@ -230,12 +230,7 @@ typedef enum EMBEDDED_SWIFT_OPTION_SET: __swift_options_t {
   /**
    * Diagnose mutex misuse when the platform can do so cheaply.
    */
-  SWIFT_MUTEX_CHECKED EMBEDDED_SWIFT_NAME(checked) = 0x01,
-
-  /**
-   * Allow the same execution context to acquire the mutex recursively.
-   */
-  SWIFT_MUTEX_RECURSIVE EMBEDDED_SWIFT_NAME(recursive) = 0x02
+  SWIFT_MUTEX_CHECKED EMBEDDED_SWIFT_NAME(checked) = 0x01
 } swift_mutex_flags_t EMBEDDED_SWIFT_NAME(SwiftMutexFlags);
 
 /**
@@ -509,6 +504,51 @@ void _swift_mutex_unlock(void * EMBEDDED_SWIFT_NONNULL mutex);
  * - Returns: Nonzero if the mutex was acquired, or zero if it was not acquired.
  */
 __swift_ptrdiff_t _swift_mutex_tryLock(void * EMBEDDED_SWIFT_NONNULL mutex);
+
+/**
+ * Initializes a recursive mutex, i.e., one that can be acquired more than
+ * once by the same execution context without deadlocking.
+ *
+ * - Parameters:
+ *   - mutex: Opaque caller-owned mutex storage initialized by this function
+ *     and later passed to the other `_swift_mutexRecursive_*` functions. The
+ *     contents are private to the platform implementation. The storage is at
+ *     least EMBEDDED_SWIFT_MUTEX_NUM_WORDS pointer-sized words and has
+ *     pointer alignment.
+ *   - flags: Flags controlling mutex behavior.
+ *
+ * This function is required when using Synchronization.Mutex with a
+ * recursive locking policy.
+ */
+void _swift_mutexRecursive_init(void * EMBEDDED_SWIFT_NONNULL mutex,
+                                swift_mutex_flags_t flags);
+
+/**
+ * Destroys a recursive mutex initialized by `_swift_mutexRecursive_init`.
+ *
+ * - Parameters:
+ *   - mutex: The mutex to destroy. Must not be locked.
+ */
+void _swift_mutexRecursive_destroy(void * EMBEDDED_SWIFT_NONNULL mutex);
+
+/**
+ * Acquires a recursive mutex, blocking or spinning until ownership is
+ * obtained. If the current execution context already holds the mutex, this
+ * increments its recursion count instead of deadlocking.
+ *
+ * - Parameters:
+ *   - mutex: The mutex to acquire.
+ */
+void _swift_mutexRecursive_lock(void * EMBEDDED_SWIFT_NONNULL mutex);
+
+/**
+ * Releases one level of recursive ownership of a mutex held by the current
+ * execution context.
+ *
+ * - Parameters:
+ *   - mutex: The mutex to release.
+ */
+void _swift_mutexRecursive_unlock(void * EMBEDDED_SWIFT_NONNULL mutex);
 
 /**
  * Initializes a reserved TLS key. `key` is one of the numeric reserved keys

--- a/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
+++ b/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
@@ -135,8 +135,9 @@ extern "C" {
 #endif
 
 /**
- * The number of pointer-size words that will be used to store a Mutex (as
- * provided by the Synchronization library).
+ * The number of pointer-size words that will be used to store a non-recursive
+ * Mutex (as provided by the Synchronization library), i.e., one backed by the
+ * `_swift_mutex_*` functions.
  *
  * This needs to be large enough to accommodate any implementation of Mutex that
  * can be implemented for that given platform (e.g., via the `_swift_mutex_*`
@@ -151,6 +152,26 @@ extern "C" {
 #define EMBEDDED_SWIFT_MUTEX_NUM_WORDS (__swift_ptrdiff_t)12
 #else
 #define EMBEDDED_SWIFT_MUTEX_NUM_WORDS (__swift_ptrdiff_t)8
+#endif
+#endif
+
+/**
+ * The number of pointer-size words that will be used to store a recursive
+ * Mutex, i.e., one backed by the `_swift_mutexRecursive_*` functions.
+ *
+ * This is tracked separately from EMBEDDED_SWIFT_MUTEX_NUM_WORDS because a
+ * platform's recursive mutex implementation need not have the same size as
+ * its non-recursive one. It can be defined externally (via `-D` on the
+ * command line for Clang, `-Xcc -D` for Swift) to a different value, but that
+ * value must be consistent throughout the build to prevent ABI mismatches.
+ */
+#ifndef EMBEDDED_SWIFT_MUTEX_RECURSIVE_NUM_WORDS
+#if defined(__APPLE__) && __SIZEOF_POINTER__ == 4
+// On 32-bit Apple targets (e.g., watchOS armv7k / arm64_32) `pthread_mutex_t`
+// is 40 bytes, which doesn't fit in 8 four-byte words.
+#define EMBEDDED_SWIFT_MUTEX_RECURSIVE_NUM_WORDS (__swift_ptrdiff_t)12
+#else
+#define EMBEDDED_SWIFT_MUTEX_RECURSIVE_NUM_WORDS (__swift_ptrdiff_t)8
 #endif
 #endif
 
@@ -513,8 +534,8 @@ __swift_ptrdiff_t _swift_mutex_tryLock(void * EMBEDDED_SWIFT_NONNULL mutex);
  *   - mutex: Opaque caller-owned mutex storage initialized by this function
  *     and later passed to the other `_swift_mutexRecursive_*` functions. The
  *     contents are private to the platform implementation. The storage is at
- *     least EMBEDDED_SWIFT_MUTEX_NUM_WORDS pointer-sized words and has
- *     pointer alignment.
+ *     least EMBEDDED_SWIFT_MUTEX_RECURSIVE_NUM_WORDS pointer-sized words and
+ *     has pointer alignment.
  *   - flags: Flags controlling mutex behavior.
  *
  * This function is required when using Synchronization.Mutex with a

--- a/test/embedded/embedded-platform-single-threaded-mutex.swift
+++ b/test/embedded/embedded-platform-single-threaded-mutex.swift
@@ -36,6 +36,18 @@ func _swift_mutex_unlock(_: UnsafeMutableRawPointer)
 @_extern(c, "_swift_mutex_tryLock")
 func _swift_mutex_tryLock(_: UnsafeMutableRawPointer) -> Int
 
+@_extern(c, "_swift_mutexRecursive_init")
+func _swift_mutexRecursive_init(_: UnsafeMutableRawPointer, _: CUnsignedLongLong)
+
+@_extern(c, "_swift_mutexRecursive_destroy")
+func _swift_mutexRecursive_destroy(_: UnsafeMutableRawPointer)
+
+@_extern(c, "_swift_mutexRecursive_lock")
+func _swift_mutexRecursive_lock(_: UnsafeMutableRawPointer)
+
+@_extern(c, "_swift_mutexRecursive_unlock")
+func _swift_mutexRecursive_unlock(_: UnsafeMutableRawPointer)
+
 func check(_ condition: Bool) {
   if !condition {
     fatalError("unexpected single-threaded mutex behavior")
@@ -50,7 +62,6 @@ func withMutexStorage(_ body: (UnsafeMutableRawPointer) -> Void) {
 }
 
 let checked: CUnsignedLongLong = 0x01
-let recursive: CUnsignedLongLong = 0x02
 
 @main
 struct Main {
@@ -101,14 +112,12 @@ struct Main {
     }
 
     withMutexStorage { mutex in
-      _swift_mutex_init(mutex, checked | recursive)
-      _swift_mutex_lock(mutex)
-      _swift_mutex_lock(mutex)
-      check(_swift_mutex_tryLock(mutex) != 0)
-      _swift_mutex_unlock(mutex)
-      _swift_mutex_unlock(mutex)
-      _swift_mutex_unlock(mutex)
-      _swift_mutex_destroy(mutex)
+      _swift_mutexRecursive_init(mutex, checked)
+      _swift_mutexRecursive_lock(mutex)
+      _swift_mutexRecursive_lock(mutex)
+      _swift_mutexRecursive_unlock(mutex)
+      _swift_mutexRecursive_unlock(mutex)
+      _swift_mutexRecursive_destroy(mutex)
     }
 #endif
   }


### PR DESCRIPTION
The Darwin multi-threaded platform implementation showed how these two
types can be very different. There, it's an os_unfair_lock for
non-recursive, and a pthreads lock for the recursive version, and we
had an extra memory allocation + indirection for the latter case.

It's also possible that a platform might only have the non-recursive
version, which is suitable for Synchronization.Mutex but not
sufficient for the concurrency runtime.