### PR TITLE
[ObjC interop] Diagnose unsupported accessors

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7211,6 +7211,9 @@ ERROR(borrowed_on_objc_protocol_requirement,none,
       "%kindonly0 cannot be '@_borrowed' if it is an '@objc' protocol "
       "requirement",
       (const AbstractStorageDecl *))
+ERROR(objc_borrowing_accessor,none,
+      "'borrow' and 'yielding borrow' accessors are not supported in "
+      "Objective-C", ())
 ERROR(borrowed_with_effect,none,
       "%kindonly0 cannot be '@_borrowed' if it is 'async' or 'throws'",
       (const AccessorDecl *))

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -1162,6 +1162,36 @@ bool swift::isRepresentableInLanguage(
   return true;
 }
 
+/// Check whether the given declaration lacks an Objective-C-representable
+/// accessor -- Objective-C reaches storage through a getter, and a setter when
+/// it is mutable, so storage read through a 'borrow'/'yielding borrow' accessor
+/// (which has no getter) or written only through a 'mutate' accessor (which has
+/// no setter) has no Objective-C entry point and is not representable.
+/// ('_read'/'_modify' and 'yielding mutate' synthesize an ordinary
+/// getter/setter, and '@_borrowed' keeps its explicit getter, so those remain
+/// representable.)  Note: a missing getter always comes from a 'borrow'/
+/// 'yielding borrow' accessor (the only no-setter case, 'mutate', requires a
+/// 'borrow'), so the diagnostic names those; revisit its wording if another
+/// non-representable accessor is ever added.
+static bool
+checkObjCWithNoRepresentableAccessor(const AbstractStorageDecl *storage,
+                                     ObjCReason Reason) {
+  bool hasGetter = storage->requiresOpaqueGetter() ||
+                   storage->getParsedAccessor(AccessorKind::Get);
+  bool hasSetterIfNeeded = !storage->supportsMutation() ||
+                           storage->requiresOpaqueSetter() ||
+                           storage->getParsedAccessor(AccessorKind::Set);
+  if (hasGetter && hasSetterIfNeeded)
+    return false;
+
+  auto behavior = behaviorLimitForObjCReason(Reason, storage->getASTContext());
+  softenIfAccessNote(storage, Reason.getAttr(),
+                     storage->diagnose(diag::objc_borrowing_accessor)
+                         .limitBehavior(behavior));
+  Reason.describe(storage);
+  return true;
+}
+
 bool swift::isRepresentableInObjC(const VarDecl *VD, ObjCReason Reason) {
   // If you change this function, you must add or modify a test in PrintAsClang.
   
@@ -1205,6 +1235,9 @@ bool swift::isRepresentableInObjC(const VarDecl *VD, ObjCReason Reason) {
     Reason.describe(VD);
     return false;
   }
+
+  if (checkObjCWithNoRepresentableAccessor(VD, Reason))
+    return false;
 
   if (!Result) {
     SourceRange TypeRange = VD->getTypeSourceRangeForDiagnostics();
@@ -1251,6 +1284,9 @@ bool swift::isRepresentableInObjC(const SubscriptDecl *SD, ObjCReason Reason) {
     Reason.describe(SD);
     return false;
   }
+
+  if (checkObjCWithNoRepresentableAccessor(SD, Reason))
+    return false;
 
   // ObjC doesn't support class subscripts.
   if (!SD->isInstanceMember()) {

--- a/test/attr/attr_objc_noncanonical_accessors.swift
+++ b/test/attr/attr_objc_noncanonical_accessors.swift
@@ -1,0 +1,69 @@
+// RUN: %target-typecheck-verify-swift \
+// RUN:     -enable-experimental-feature CoroutineAccessors \
+// RUN:     -enable-experimental-feature BorrowAndMutateAccessors
+
+// REQUIRES: objc_interop
+// REQUIRES: swift_feature_CoroutineAccessors
+// REQUIRES: swift_feature_BorrowAndMutateAccessors
+
+import Foundation
+
+// Objective-C reaches storage through a getter, and a setter when it is
+// mutable.  An accessor that is not a getter/setter -- a 'borrow'/'yielding
+// borrow' read, or a 'mutate' write -- has no Objective-C entry point, and
+// storage read/written only through one has no getter/setter to expose, so it
+// is not representable in Objective-C.  ('_read'/'_modify' and 'yielding mutate'
+// synthesize an ordinary getter/setter, and '@_borrowed' keeps its explicit
+// getter, so those remain representable.)
+
+@objc protocol P {
+  var yieldingBorrow: Int { yielding borrow } // expected-error {{'borrow' and 'yielding borrow' accessors are not supported in Objective-C}}
+  // expected-note@-1 {{inferring '@objc' because the declaration is a member of an '@objc' protocol}}
+
+  var borrowed: Int { borrow } // expected-error {{'borrow' and 'yielding borrow' accessors are not supported in Objective-C}}
+  // expected-note@-1 {{inferring '@objc' because the declaration is a member of an '@objc' protocol}}
+
+  var yieldingBorrowSet: Int { yielding borrow set } // expected-error {{'borrow' and 'yielding borrow' accessors are not supported in Objective-C}}
+  // expected-note@-1 {{inferring '@objc' because the declaration is a member of an '@objc' protocol}}
+
+  subscript(i: Int) -> Int { yielding borrow set } // expected-error {{'borrow' and 'yielding borrow' accessors are not supported in Objective-C}}
+  // expected-note@-1 {{inferring '@objc' because the declaration is a member of an '@objc' protocol}}
+
+  // Ordinary requirements remain representable.
+  var plain: Int { get set }
+  subscript(s: String) -> Int { get }
+}
+
+@objc class C: NSObject {
+  var _storage = 0
+
+  @objc var yieldingBorrow: Int { yielding borrow { yield 0 } } // expected-error {{'borrow' and 'yielding borrow' accessors are not supported in Objective-C}}
+
+  @objc var borrowed: Int { borrow { return _storage } } // expected-error {{'borrow' and 'yielding borrow' accessors are not supported in Objective-C}}
+
+  @objc var borrowMutate: Int { borrow { return _storage } mutate { return &_storage } } // expected-error {{'borrow' and 'yielding borrow' accessors are not supported in Objective-C}}
+
+  @objc subscript(i: Int) -> Int { yielding borrow { yield 0 } } // expected-error {{'borrow' and 'yielding borrow' accessors are not supported in Objective-C}}
+
+  // A 'yielding mutate' write synthesizes a setter, so with a getter present
+  // this is representable.
+  @objc var mutable: Int { get { 0 } yielding mutate { yield &_storage } }
+
+  // '@_borrowed' keeps an explicit getter for Objective-C and only changes the
+  // Swift-side opaque accessor, so it remains allowed.
+  @objc @_borrowed var borrowedAttr: Int { get { 0 } }
+
+  // Ordinary '@objc' members are unaffected.
+  @objc var plain: Int { get { 0 } }
+  @objc var stored: Int = 0
+}
+
+// Not exposed to Objective-C: these accessors are fine.
+protocol Q {
+  var value: Int { yielding borrow }
+  subscript(i: Int) -> Int { borrow }
+}
+
+class D {
+  var value: Int { yielding borrow { yield 0 } }
+}


### PR DESCRIPTION
We previously failed to issue a diagnostic when a property relied on accessor types that could not be represented in Objective-C.  This resulted in a broken property: The property would be advertised in the generated header file, but no ObjC-callable selector was emitted.  Any attempt to use the exposed property from ObjC would deterministically crash.

This now diagnoses any such problem by checking whether an ObjC-compatible getter is either provided or synthesized.

The new logic here does check _setter_ availability and triggers the same diagnostic message on a failure, but our interacting accessor compatibility requirements make it impossible to encounter such a failure.  For that reason, the actual message doesn't bother to mention setter incompatibility as a possibility.  This may need to be altered if new ObjC-incompatible mutating accessors are ever added.