### PR TITLE
SIL: Multi-operand debug_value infrastructure (NFC)

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
@@ -338,12 +338,13 @@ struct AliasAnalysis {
       return defaultEffects(of: endBorrow, on: memLoc)
 
     case let debugValue as DebugValueInst:
-      let v = debugValue.operand.value
-      if v.type.isAddress, !(v is Undef), memLoc.mayAlias(with: v, self) {
-        return .init(read: true)
-      } else {
-        return .noEffects
+      for operand in debugValue.operands {
+        let v = operand.value
+        if v.type.isAddress, !(v is Undef), memLoc.mayAlias(with: v, self) {
+          return .init(read: true)
+        }
       }
+      return .noEffects
 
     case let destroy as DestroyValueInst:
       if destroy.destroyedValue.type.isNoEscapeFunction {

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AllocBoxToStack.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AllocBoxToStack.swift
@@ -254,11 +254,11 @@ private struct FunctionSpecializations {
       case let debugValue as DebugValueInst:
         if debugValue.debugReconstructionBlock != nil {
           // A box cannot be salvaged.
-          debugValue.killOperand()
+          debugValue.killOperand(index: use.index)
         } else {
           // A bare debug_value on an alloc_box describes the box content: repoint it to the alloc_stack with a deref.
-          debugValue.operand.set(to: stack, context)
-          debugValue.prependDeref()
+          use.set(to: stack, context)
+          debugValue.prependDeref(index: use.index)
         }
       case let apply as ApplySite:
         specialize(apply: apply, context)

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/KillInvalidDebugValues.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/KillInvalidDebugValues.swift
@@ -34,29 +34,33 @@ let killInvalidDebugValuesPass = FunctionPass(name: "kill-invalid-debug-values")
   // Collect debug_values grouped by root, so ranges are only computed once.
   var rootWorklist = ValueWorklist(context)
   defer { rootWorklist.deinitialize() }
-  var debugValuesForRoot: [ObjectIdentifier: [DebugValueInst]] = [:]
+  var debugOperandsForRoot: [ObjectIdentifier: [Operand]] = [:]
 
   for block in function.blocks {
     for inst in block.instructions {
-      guard let dbg = inst as? DebugValueInst,
-            let root = findOwnershipRoot(of: dbg.operand.value) else {
+      guard let dbg = inst as? DebugValueInst else {
         continue
       }
-      rootWorklist.pushIfNotVisited(root)
-      debugValuesForRoot[ObjectIdentifier(root), default: []].append(dbg)
+      for operand in dbg.operands {
+        guard let root = findOwnershipRoot(of: operand.value) else {
+          continue
+        }
+        rootWorklist.pushIfNotVisited(root)
+        debugOperandsForRoot[ObjectIdentifier(root), default: []].append(operand)
+      }
     }
   }
 
   while let root = rootWorklist.pop() {
-    let debugValues = debugValuesForRoot[ObjectIdentifier(root)]!
+    let debugOperands = debugOperandsForRoot[ObjectIdentifier(root)]!
     guard context.continueWithNextSubpassRun(forValue: root) else {
       return
     }
-    killInvalidDebugValues(debugValues, root: root, context)
+    killInvalidDebugOperands(debugOperands, root: root, context)
   }
 }
 
-private func killInvalidDebugValues(_ debugValues: [DebugValueInst], root: Value,
+private func killInvalidDebugOperands(_ debugOperands: [Operand], root: Value,
                                     _ context: FunctionPassContext) {
   // Build a range from the root to where the content is actually destroyed.
   // Forwarding consumers (struct, tuple, etc.) don't free the content, so having debug values on
@@ -87,9 +91,10 @@ private func killInvalidDebugValues(_ debugValues: [DebugValueInst], root: Value
     }
   }
 
-  for dbg in debugValues {
+  for operand in debugOperands {
+    let dbg = operand.instruction as! DebugValueInst
     if !range.contains(dbg) {
-      dbg.killOperand()
+      dbg.killOperand(index: operand.index)
     }
   }
 }

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/TempLValueElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/TempLValueElimination.swift
@@ -257,7 +257,7 @@ private func combineWithDestroy(copy: CopyAddrInst, _ context: FunctionPassConte
       // Don't let debug info think that the value is still valid after the `copy [take]`.
       context.erase(instructions: debugInsts)
       return
-    case let debugInst as DebugValueInst where debugInst.operand.value == copy.source:
+    case let debugInst as DebugValueInst where debugInst.operands.contains(where: { $0.value == copy.source }):
       debugInsts.append(debugInst)
     default:
       if inst.mayReadOrWriteMemory {

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/TempRValueElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/TempRValueElimination.swift
@@ -109,7 +109,7 @@ private func tryEliminate(copy: CopyLikeInstruction, keepDebugInfo: Bool, _ cont
     return
   }
 
-  liverange.moveDebugValuesIntoLiverange(debugUsers: allocStackUses.debugUsers, after: copy.loadingInstruction)
+  liverange.moveDebugValuesIntoLiverange(debugUses: allocStackUses.debugUses, after: copy.loadingInstruction)
   liverange.extendAccessScopes()
 
   if !copy.isTakeOfSource {
@@ -189,12 +189,12 @@ private extension AllocStackInst {
 /// Collects all uses of the `alloc_stack`.
 private struct UseCollector : AddressDefUseWalker {
   private(set) var users: Stack<Instruction>
-  private(set) var debugUsers: Stack<DebugValueInst>
+  private(set) var debugUses: Stack<Operand>
   private let copy: CopyLikeInstruction
 
   init(copy: CopyLikeInstruction, _ context: FunctionPassContext) {
     self.users = Stack(context)
-    self.debugUsers = Stack(context)
+    self.debugUses = Stack(context)
     self.copy = copy
   }
 
@@ -289,8 +289,8 @@ private struct UseCollector : AddressDefUseWalker {
       users.append(address.instruction)
       return .continueWalk
 
-    case let debugValue as DebugValueInst:
-      debugUsers.append(debugValue)
+    case is DebugValueInst:
+      debugUses.append(address)
       return .continueWalk
 
     case is DeallocStackInst:
@@ -317,7 +317,7 @@ private struct UseCollector : AddressDefUseWalker {
 
   mutating func deinitialize() {
     users.deinitialize()
-    debugUsers.deinitialize()
+    debugUses.deinitialize()
   }
 }
 
@@ -429,15 +429,17 @@ private struct Liverange {
   }
 
   /// Move `debug_value` instructions, which are located _before_ the copy instruction, after the copy instruction.
-  func moveDebugValuesIntoLiverange(debugUsers: Stack<DebugValueInst>, after copy: Instruction) {
-    for debugValue in debugUsers where !liverange.hasBeenPushed(debugValue) {
-      if debugValue.operand.value is AllocStackInst {
-        debugValue.move(before: copy.next!, context)
+  func moveDebugValuesIntoLiverange(debugUses: Stack<Operand>, after copy: Instruction) {
+    for operand in debugUses where !liverange.hasBeenPushed(operand.instruction) {
+      if operand.value is AllocStackInst {
+        operand.instruction.move(before: copy.next!, context)
       } else {
         // If the operand of the `debugValue` is a projection, the projection can be located after the `copy`.
         // Therefore we cannot move the `debugValue` immediately after the `copy`.
         // It's not ideal to delete the `debugValue`, however this is a very rare case.
-        context.erase(instruction: debugValue)
+        context.erase(instruction: operand.instruction)
+        // TODO: This should be the following:
+        // (operand.instruction as! DebugValueInst).killOperand(index: operand.index)
       }
     }
   }

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyAllocStack.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyAllocStack.swift
@@ -81,10 +81,10 @@ private extension AllocStackInst {
         uteda.replace(with: newAlloc, context)
       case let dv as DebugValueInst:
         if let caseIndex {
-          dv.salvageEnumPayload(caseIndex: caseIndex, enumType: oldAllocType.objectType, context)
+          dv.salvageEnumPayload(index: use.index, caseIndex: caseIndex, enumType: oldAllocType.objectType, context)
         } else {
           // Kill the operand, and fix the type to be the enum type rather than the payload type.
-          dv.killOperand(withType: oldAllocType)
+          dv.killOperand(index: use.index, withType: oldAllocType)
         }
       case is DestroyAddrInst, is DeallocStackInst, is StoreInst:
         break
@@ -558,19 +558,19 @@ private struct EnumCaseUseBlocks : AddressDefUseWalker {
 private extension DebugValueInst {
   /// Salvages debug info when an enum `alloc_stack` is replaced with a payload
   /// `alloc_stack`.
-  func salvageEnumPayload(caseIndex: Int, enumType: Type, _ context: SimplifyContext) {
-    let operandType = self.operand.value.type
+  func salvageEnumPayload(index: Int, caseIndex: Int, enumType: Type, _ context: SimplifyContext) {
+    let operandType = self.operands[index].value.type
 
     // Address-only types can't be represented in DWARF expressions.
     guard operandType.objectType.isLoadable(in: self.parentFunction),
           enumType.isLoadable(in: self.parentFunction) else {
       // Kill the operand, and fix the type to be the enum type rather than the payload type.
-      self.killOperand(withType: enumType)
+      self.killOperand(index: index, withType: enumType)
       return
     }
 
     // Strip deref: removes the enum load it becomes an object type.
-    self.stripDeref()
+    self.stripDeref(index: index)
 
     let debugBB = self.getOrCreateDebugReconstructionBlock()
     guard debugBB.arguments.count > 0 else {

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyStoreBorrow.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyStoreBorrow.swift
@@ -44,8 +44,8 @@ extension StoreBorrowInst : Simplifiable, SILCombineSimplifiable {
     //   %2 = store_borrow %1
     //   debug_value %1
     // ``
-    for debugValue in uses.users(ofType: DebugValueInst.self) {
-      debugValue.operand.set(to: destination, context)
+    for use in uses where use.instruction is DebugValueInst {
+      use.set(to: destination, context)
     }
 
     context.erase(instructionIncludingAllUsers: self)

--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/DiagnoseUnknownConstValues.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/DiagnoseUnknownConstValues.swift
@@ -73,7 +73,7 @@ private func verifyLocal(debugValueInst: DebugValueInst,
     return
   }
   
-  if !constExprState.isConstantValue(debugValueInst.operand.value) {
+  if debugValueInst.operands.contains(where: { !constExprState.isConstantValue($0.value) }) {
     context.diagnosticEngine.diagnose(.require_const_initializer_for_const,
                                       at: debugValueInst.location)
   }

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -704,7 +704,7 @@ public protocol DebugVariableInstruction : VarDeclInstruction {
 @_semantics("fast_cast")
 public protocol MetaInstruction: Instruction {}
 
-final public class DebugValueInst : Instruction, UnaryInstruction, DebugVariableInstruction, MetaInstruction {
+final public class DebugValueInst : Instruction, DebugVariableInstruction, MetaInstruction {
   public var varDecl: VarDecl? {
     bridged.DebugValue_getDecl().getAs(VarDecl.self)
   }
@@ -721,10 +721,10 @@ final public class DebugValueInst : Instruction, UnaryInstruction, DebugVariable
     bridged.DebugValue_getOrCreateDebugReconstructionBlock().block
   }
 
-  public func stripDeref() { bridged.DebugValue_stripDeref() }
-  public func prependDeref() { bridged.DebugValue_prependDeref() }
-  public func killOperand(withType type: Type? = nil) {
-    bridged.DebugValue_killOperand(type?.bridged ?? BridgedType())
+  public func stripDeref(index: Int) { bridged.DebugValue_stripDeref(index) }
+  public func prependDeref(index: Int) { bridged.DebugValue_prependDeref(index) }
+  public func killOperand(index: Int, withType type: Type? = nil) {
+    bridged.DebugValue_killOperand(index, type?.bridged ?? BridgedType())
   }
 }
 

--- a/include/swift/SIL/DebugUtils.h
+++ b/include/swift/SIL/DebugUtils.h
@@ -68,13 +68,13 @@ inline void deleteAllDebugUses(SILInstruction *inst) {
 /// but replaces its operand with undef and strips non-fragment DIExpr parts.
 /// Use this when salvage has NOT already created a replacement debug_value.
 inline void killAllDebugUses(SILValue value) {
-  SmallVector<DebugValueInst *, 4> debugUsers;
+  SmallVector<Operand *, 4> debugUses;
   for (auto *use : value->getUses()) {
-    if (auto *dvi = dyn_cast<DebugValueInst>(use->getUser()))
-      debugUsers.push_back(dvi);
+    if (isa<DebugValueInst>(use->getUser()))
+      debugUses.push_back(use);
   }
-  for (auto *dvi : debugUsers)
-    dvi->killOperand();
+  for (auto *use : debugUses)
+    cast<DebugValueInst>(use->getUser())->killOperand(use->getOperandNumber());
 }
 
 /// Drops all of the debug uses of any result of \p inst.

--- a/include/swift/SIL/DebugUtils.h
+++ b/include/swift/SIL/DebugUtils.h
@@ -528,7 +528,7 @@ struct DebugVarCarryingInst : VarDeclCarryingInst {
     case Kind::Invalid:
       llvm_unreachable("Invalid?!");
     case Kind::DebugValue:
-      return cast<DebugValueInst>(**this)->getOperand();
+      return cast<DebugValueInst>(**this)->getSingleOperand();
     case Kind::AllocStack:
       return cast<AllocStackInst>(**this);
     case Kind::AllocBox:

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -1022,9 +1022,9 @@ struct BridgedInstruction {
   DebugValue_getDebugReconstructionBlock() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedBasicBlock
   DebugValue_getOrCreateDebugReconstructionBlock() const;
-  BRIDGED_INLINE void DebugValue_stripDeref() const;
-  BRIDGED_INLINE void DebugValue_prependDeref() const;
-  BRIDGED_INLINE void DebugValue_killOperand(BridgedType operandType) const;
+  BRIDGED_INLINE void DebugValue_stripDeref(SwiftInt operandIdx) const;
+  BRIDGED_INLINE void DebugValue_prependDeref(SwiftInt operandIdx) const;
+  BRIDGED_INLINE void DebugValue_killOperand(SwiftInt operandIdx, BridgedType operandType) const;
 
   BRIDGED_INLINE bool AllocStack_hasVarInfo() const;
   BRIDGED_INLINE BridgedSILDebugVariable AllocStack_getVarInfo() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -2109,7 +2109,7 @@ void BridgedInstruction::DebugValue_prependDeref() const {
   getAs<swift::DebugValueInst>()->prependDeref();
 }
 void BridgedInstruction::DebugValue_killOperand(BridgedType operandType) const {
-  getAs<swift::DebugValueInst>()->killOperand(operandType.unbridged());
+  getAs<swift::DebugValueInst>()->killOperand(0, operandType.unbridged());
 }
 
 bool BridgedInstruction::AllocStack_hasVarInfo() const {

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -2102,14 +2102,14 @@ BridgedBasicBlock BridgedInstruction::DebugValue_getOrCreateDebugReconstructionB
   return {getAs<swift::DebugValueInst>()->getOrCreateDebugReconstructionBlock()};
 }
 
-void BridgedInstruction::DebugValue_stripDeref() const {
-  getAs<swift::DebugValueInst>()->stripDeref();
+void BridgedInstruction::DebugValue_stripDeref(SwiftInt operandIdx) const {
+  getAs<swift::DebugValueInst>()->stripDeref(operandIdx);
 }
-void BridgedInstruction::DebugValue_prependDeref() const {
-  getAs<swift::DebugValueInst>()->prependDeref();
+void BridgedInstruction::DebugValue_prependDeref(SwiftInt operandIdx) const {
+  getAs<swift::DebugValueInst>()->prependDeref(operandIdx);
 }
-void BridgedInstruction::DebugValue_killOperand(BridgedType operandType) const {
-  getAs<swift::DebugValueInst>()->killOperand(0, operandType.unbridged());
+void BridgedInstruction::DebugValue_killOperand(SwiftInt operandIdx, BridgedType operandType) const {
+  getAs<swift::DebugValueInst>()->killOperand(operandIdx, operandType.unbridged());
 }
 
 bool BridgedInstruction::AllocStack_hasVarInfo() const {

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1095,6 +1095,10 @@ public:
       SILLocation Loc, SILValue src, SILDebugVariable Var,
       UsesMoveableValueDebugInfo_t wasMoved = DoesNotUseMoveableValueDebugInfo,
       bool trace = false, bool overrideLoc = true);
+  DebugValueInst *createDebugValue(
+      SILLocation Loc, ArrayRef<SILValue> operands, SILDebugVariable Var,
+      UsesMoveableValueDebugInfo_t wasMoved = DoesNotUseMoveableValueDebugInfo,
+      bool trace = false, bool overrideLoc = true);
 
   DebugStepInst *createDebugStep(SILLocation Loc) {
     return insert(new (getModule()) DebugStepInst(getSILDebugLocation(Loc)));

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1817,8 +1817,14 @@ SILCloner<ImplClass>::visitDebugValueInst(DebugValueInst *Inst) {
   std::optional<SILDebugVariable> VarInfo = Inst->getVarInfo();
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   remapDebugVariable(VarInfo);
+
+  // Remap all operands.
+  SmallVector<SILValue, 4> remappedOperands;
+  for (auto &op : Inst->getAllOperands())
+    remappedOperands.push_back(getOpValue(op.get()));
+
   auto *NewInst = getBuilder().createDebugValue(
-      Inst->getLoc(), getOpValue(Inst->getOperand()), *VarInfo,
+      Inst->getLoc(), remappedOperands, *VarInfo,
       Inst->usesMoveableValueDebugInfo(), Inst->hasTrace());
 
   // Clone the debug-only reconstruction block if present.

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -5735,12 +5735,11 @@ public:
 /// Define the start or update to a symbolic variable value (for loadable
 /// types).
 class DebugValueInst final
-    : public UnaryInstructionBase<SILInstructionKind::DebugValueInst,
-                                  NonValueInstruction>,
-      private SILDebugVariableSupplement,
-      private llvm::TrailingObjects<DebugValueInst, SILType, SILLocation,
-                                    const SILDebugScope *, SILDIExprElement,
-                                    char> {
+    : public InstructionBaseWithTrailingOperands<
+          SILInstructionKind::DebugValueInst, DebugValueInst,
+          NonValueInstruction, SILType, SILLocation, const SILDebugScope *,
+          SILDIExprElement, char>,
+      private SILDebugVariableSupplement {
   friend TrailingObjects;
   friend SILBuilder;
 
@@ -5750,7 +5749,7 @@ class DebugValueInst final
   /// Optional debug basic block holding reconstruction instructions.
   SILBasicBlock *ReconstructionBlock = nullptr;
 
-  DebugValueInst(SILDebugLocation DebugLoc, SILValue Operand,
+  DebugValueInst(SILDebugLocation DebugLoc, SILValue Operand, SILModule &M,
                  SILDebugVariable Var,
                  UsesMoveableValueDebugInfo_t operandWasMoved, bool trace,
                  bool prependDeref);
@@ -5759,11 +5758,18 @@ class DebugValueInst final
                                 UsesMoveableValueDebugInfo_t operandWasMoved,
                                 bool trace);
 
+  using InstructionBaseWithTrailingOperands::numTrailingObjects;
   SIL_DEBUG_VAR_SUPPLEMENT_TRAILING_OBJS_IMPL()
 
-  size_t numTrailingObjects(OverloadToken<char>) const { return 1; }
-
 public:
+  // FIXME: These following 2 functions are temporary, while debug_value
+  // transitions to being a multi-operand instruction.
+  SILValue getOperand() const { return getAllOperands()[0].get(); }
+  void setOperand(SILValue V) { getAllOperands()[0].set(V); }
+
+  ArrayRef<Operand> getTypeDependentOperands() const { return {}; }
+  MutableArrayRef<Operand> getTypeDependentOperands() { return {}; }
+
   /// Sets a bool that states this debug_value is supposed to use the
   void setUsesMoveableValueDebugInfo() {
     sharedUInt8().DebugValueInst.usesMoveableValueDebugInfo =

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -5894,7 +5894,7 @@ public:
   /// an address type (when moved to the stack, for example).
   /// If a reconstruction block exists, a load is added at the beginning.
   /// Otherwise, it will be prepended to the DIExpr.
-  void prependDeref(unsigned operandIdx = 0);
+  void prependDeref(unsigned operandIdx);
 
   /// Removes a deref operator to this debug_value in place.
   /// This must be called when the operand is changed from an address type to
@@ -5903,7 +5903,7 @@ public:
   /// If a reconstruction block exists, a load is removed at the beginning. If
   /// there is no load at the beginning, the operand is killed, marking the
   /// variable as optimized away.
-  void stripDeref(unsigned operandIdx = 0);
+  void stripDeref(unsigned operandIdx);
 
   /// Validates the type chain of the DIExpr.
   /// Starting from VarType, narrows through fragments (outermost first)
@@ -5947,7 +5947,7 @@ public:
   /// reconstruction block.
   /// If \p varType is specified, the undef will use that type (in the
   /// appropriate address/object form) instead of the current operand's type.
-  void killOperand(unsigned operandIdx = 0, SILType operandType = SILType());
+  void killOperand(unsigned operandIdx, SILType operandType = SILType());
 
   bool hasTrace() const { return sharedUInt8().DebugValueInst.trace; }
 

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -5749,12 +5749,13 @@ class DebugValueInst final
   /// Optional debug basic block holding reconstruction instructions.
   SILBasicBlock *ReconstructionBlock = nullptr;
 
-  DebugValueInst(SILDebugLocation DebugLoc, SILValue Operand, SILModule &M,
-                 SILDebugVariable Var,
+  DebugValueInst(SILDebugLocation DebugLoc, ArrayRef<SILValue> Operands,
+                 SILModule &M, SILDebugVariable Var,
                  UsesMoveableValueDebugInfo_t operandWasMoved, bool trace,
                  bool prependDeref);
-  static DebugValueInst *create(SILDebugLocation DebugLoc, SILValue Operand,
-                                SILModule &M, SILDebugVariable Var,
+  static DebugValueInst *create(SILDebugLocation DebugLoc,
+                                ArrayRef<SILValue> Operands, SILModule &M,
+                                SILDebugVariable Var,
                                 UsesMoveableValueDebugInfo_t operandWasMoved,
                                 bool trace);
 

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -5767,6 +5767,14 @@ public:
   SILValue getOperand() const { return getAllOperands()[0].get(); }
   void setOperand(SILValue V) { getAllOperands()[0].set(V); }
 
+  /// Returns the single operand, asserting that there is exactly one.
+  /// Should only be used in contexts where it is known that there is no
+  /// debug reconstruction block.
+  SILValue getSingleOperand() const {
+    ASSERT(getAllOperands().size() == 1);
+    return getAllOperands()[0].get();
+  }
+
   ArrayRef<Operand> getTypeDependentOperands() const { return {}; }
   MutableArrayRef<Operand> getTypeDependentOperands() { return {}; }
 
@@ -5886,7 +5894,7 @@ public:
   /// an address type (when moved to the stack, for example).
   /// If a reconstruction block exists, a load is added at the beginning.
   /// Otherwise, it will be prepended to the DIExpr.
-  void prependDeref();
+  void prependDeref(unsigned operandIdx = 0);
 
   /// Removes a deref operator to this debug_value in place.
   /// This must be called when the operand is changed from an address type to
@@ -5895,7 +5903,7 @@ public:
   /// If a reconstruction block exists, a load is removed at the beginning. If
   /// there is no load at the beginning, the operand is killed, marking the
   /// variable as optimized away.
-  void stripDeref();
+  void stripDeref(unsigned operandIdx = 0);
 
   /// Validates the type chain of the DIExpr.
   /// Starting from VarType, narrows through fragments (outermost first)
@@ -5939,7 +5947,7 @@ public:
   /// reconstruction block.
   /// If \p varType is specified, the undef will use that type (in the
   /// appropriate address/object form) instead of the current operand's type.
-  void killOperand(SILType operandType = SILType());
+  void killOperand(unsigned operandIdx = 0, SILType operandType = SILType());
 
   bool hasTrace() const { return sharedUInt8().DebugValueInst.trace; }
 

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -29,6 +29,7 @@
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/Support/Compiler.h"
+#include "llvm/Support/TrailingObjects.h"
 #include "llvm/Support/raw_ostream.h"
 #include <optional>
 
@@ -39,6 +40,7 @@ class PostOrderFunctionInfo;
 class ReversePostOrderInfo;
 class Operand;
 class SILInstruction;
+class SILModule;
 class SILArgument;
 class SILLocation;
 class DeadEndBlocks;

--- a/include/swift/SILOptimizer/Utils/OSSACanonicalizeOwned.h
+++ b/include/swift/SILOptimizer/Utils/OSSACanonicalizeOwned.h
@@ -275,10 +275,10 @@ private:
   /// pruned liveness does not consider destroy_values.
   llvm::SmallSetVector<SILBasicBlock *, 8> consumingBlocks;
 
-  /// Record all interesting debug_value instructions here rather then treating
+  /// Record all interesting debug_value operands here rather then treating
   /// them like a normal use. An interesting debug_value is one that may lie
   /// outside the pruned liveness at the time it is discovered.
-  llvm::SmallPtrSet<DebugValueInst *, 8> debugValues;
+  llvm::SmallPtrSet<Operand *, 8> debugUses;
 
   struct Def {
     enum Kind {
@@ -364,7 +364,7 @@ public:
 
   void initializeLiveness(SILValue def,
                           ArrayRef<SILInstruction *> lexicalLifetimeEnds) {
-    assert(consumingBlocks.empty() && debugValues.empty());
+    assert(consumingBlocks.empty() && debugUses.empty());
     clear();
 
     currentDef = def;
@@ -383,7 +383,7 @@ public:
     accessBlocks = nullptr;
 
     consumingBlocks.clear();
-    debugValues.clear();
+    debugUses.clear();
     discoveredBlocks.clear();
     consumes.clear();
     destroys.clear();
@@ -493,7 +493,7 @@ private:
     return module.getASTContext().SILOpts.supportsLexicalLifetimes(module);
   }
 
-  void recordDebugValue(DebugValueInst *dvi) { debugValues.insert(dvi); }
+  void recordDebugUse(Operand *use) { debugUses.insert(use); }
 
   void recordConsumingUse(Operand *use) { recordConsumingUser(use->getUser()); }
   /// Record that the value is consumed at `user`.

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -624,9 +624,9 @@ struct StructLoweringState {
   SmallVector<MakeBorrowInst *, 16> makeBorrowInstsToMod;
   // All dereference_borrow instrs that should be converted to dereference_addr_borrow
   SmallVector<DereferenceBorrowInst *, 16> dereferenceBorrowInstsToMod;
-  // All debug instructions.
+  // All debug uses.
   // to be modified *only if* the operands are used in "real" instructions
-  SmallVector<DebugValueInst *, 16> debugInstsToMod;
+  SmallVector<Operand *, 16> debugUsesToMod;
 
   StructLoweringState(SILFunction *F, irgen::IRGenModule &Mod,
                       LargeSILTypeMapper &Mapper)
@@ -1024,7 +1024,7 @@ void LargeValueVisitor::visitDebugValueInst(DebugValueInst *instr) {
   for (Operand &operand : instr->getAllOperands()) {
     if (std::find(pass.largeLoadableArgs.begin(), pass.largeLoadableArgs.end(),
                   operand.get()) != pass.largeLoadableArgs.end()) {
-      pass.debugInstsToMod.push_back(instr);
+      pass.debugUsesToMod.push_back(&operand);
     }
   }
 }
@@ -1267,8 +1267,7 @@ void LoadableStorageAllocation::replaceLoadWithCopyAddr(
       break;
     }
     case SILInstructionKind::DebugValueInst: {
-      auto *insToInsert = cast<DebugValueInst>(userIns);
-      pass.debugInstsToMod.push_back(insToInsert);
+      pass.debugUsesToMod.push_back(user);
       break;
     }
     case SILInstructionKind::DestroyValueInst: {
@@ -1430,8 +1429,7 @@ void LoadableStorageAllocation::replaceLoadWithCopyAddrForModifiable(
       break;
     }
     case SILInstructionKind::DebugValueInst: {
-      auto *insToInsert = cast<DebugValueInst>(userIns);
-      pass.debugInstsToMod.push_back(insToInsert);
+      pass.debugUsesToMod.push_back(use);
       usesToMod.push_back(use);
       break;
     }
@@ -1900,8 +1898,8 @@ static void rewriteUsesOfScalar(StructLoweringState &pass, SILValue address,
       storeUser->eraseFromParent();
     } else if (auto *dbgInst = dyn_cast<DebugValueInst>(user)) {
       // Update the debug_value to point to the variable in the alloca.
-      dbgInst->setOperand(address);
-      dbgInst->prependDeref();
+      scalarUse->set(address);
+      dbgInst->prependDeref(scalarUse->getOperandNumber());
     }
   }
 }
@@ -2409,22 +2407,19 @@ static void rewriteFunction(StructLoweringState &pass,
     instr->getParent()->erase(instr);
   }
 
-  for (DebugValueInst *instr : pass.debugInstsToMod) {
-    assert(instr->getAllOperands().size() == 1 &&
-           "Debug instructions have one operand");
-    for (Operand &operand : instr->getAllOperands()) {
-      auto currOperand = operand.get();
-      if (pass.argsToLoadedValueMap.find(currOperand) !=
-          pass.argsToLoadedValueMap.end()) {
-        SILValue newOperand = pass.argsToLoadedValueMap[currOperand];
-        assert(newOperand != currOperand &&
-               "Did not allocate storage and convert operand");
-        operand.set(newOperand);
-      } else {
-        assert(currOperand->getType().isAddress() &&
-               "Expected an address type");
-        instr->prependDeref();
-      }
+  for (Operand *operand : pass.debugUsesToMod) {
+    auto *instr = cast<DebugValueInst>(operand->getUser());
+    auto currOperand = operand->get();
+    if (pass.argsToLoadedValueMap.find(currOperand) !=
+        pass.argsToLoadedValueMap.end()) {
+      SILValue newOperand = pass.argsToLoadedValueMap[currOperand];
+      assert(newOperand != currOperand &&
+             "Did not allocate storage and convert operand");
+      operand->set(newOperand);
+    } else {
+      assert(currOperand->getType().isAddress() &&
+             "Expected an address type");
+      instr->prependDeref(operand->getOperandNumber());
     }
   }
 
@@ -4772,20 +4767,29 @@ protected:
   }
 
   void visitDebugValueInst(DebugValueInst *dbg) {
-    // Undef debug values have a special meaning. Don't allocate stack space
-    // for those.
-    // Rewriting them would also break nullary debug reconstruction blocks.
-    if (isa<SILUndef>(dbg->getOperand()))
-      return;
-    if (!dbg->getOperand()->getType().isAddress() &&
-        (assignment.isPotentiallyCArray(dbg->getOperand()->getType()) ||
-         overlapsWithOnStackDebugLoc(dbg->getOperand()))) {
-      assignment.markForDeletion(dbg);
-      return;
+    for (auto &operand : dbg->getAllOperands()) {
+      SILValue operandVal = operand.get();
+      // The same conditions as in `AddressAssignment::assign` need to be
+      // done for each operand: rewrite all operands that need rewriting.
+      if (!operandVal->getType().isObject())
+        continue;
+      if (!assignment.isLargeLoadableType(operandVal->getType()))
+        continue;
+      // Undef debug values have a special meaning. Don't allocate stack space
+      // for those.
+      // Rewriting them would also break nullary debug reconstruction blocks.
+      if (isa<SILUndef>(operandVal))
+        continue;
+      if (!operandVal->getType().isAddress() &&
+          (assignment.isPotentiallyCArray(operandVal->getType()) ||
+           overlapsWithOnStackDebugLoc(operandVal))) {
+        assignment.markForDeletion(dbg);
+        return;
+      }
+      SILValue addr = assignment.getAddressForValue(operandVal);
+      operand.set(addr);
+      dbg->prependDeref(operand.getOperandNumber());
     }
-    SILValue addr = assignment.getAddressForValue(dbg->getOperand());
-    dbg->setOperand(addr);
-    dbg->prependDeref();
   }
 
   void visitRetainValueInst(RetainValueInst *r) {

--- a/lib/SIL/IR/SILBuilder.cpp
+++ b/lib/SIL/IR/SILBuilder.cpp
@@ -642,6 +642,15 @@ DebugValueInst *SILBuilder::createDebugValue(SILLocation Loc, SILValue src,
                                              SILDebugVariable Var,
                                              UsesMoveableValueDebugInfo_t moved,
                                              bool trace, bool overrideLoc) {
+  return createDebugValue(Loc, ArrayRef<SILValue> { src }, Var, moved, trace,
+                          overrideLoc);
+}
+
+DebugValueInst *SILBuilder::createDebugValue(SILLocation Loc,
+                                             ArrayRef<SILValue> operands,
+                                             SILDebugVariable Var,
+                                             UsesMoveableValueDebugInfo_t moved,
+                                             bool trace, bool overrideLoc) {
   if (shouldDropVariable(Var, Loc))
     return nullptr;
 
@@ -656,7 +665,7 @@ DebugValueInst *SILBuilder::createDebugValue(SILLocation Loc, SILValue src,
     DebugLoc = getSILDebugLocation(Loc, true);
   }
 
-  return insert(DebugValueInst::create(DebugLoc, src, getModule(),
+  return insert(DebugValueInst::create(DebugLoc, operands, getModule(),
                                        *substituteAnonymousArgs(Name, Var, Loc),
                                        moved, trace));
 }

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -436,11 +436,11 @@ SILType AllocBoxInst::getAddressType() const {
 }
 
 DebugValueInst::DebugValueInst(
-    SILDebugLocation DebugLoc, SILValue Operand, SILModule &M,
+    SILDebugLocation DebugLoc, ArrayRef<SILValue> Operands, SILModule &M,
     SILDebugVariable Var,
     UsesMoveableValueDebugInfo_t usesMoveableValueDebugInfo, bool trace,
     bool prependDeref)
-    : InstructionBaseWithTrailingOperands({Operand}, DebugLoc),
+    : InstructionBaseWithTrailingOperands(Operands, DebugLoc),
       SILDebugVariableSupplement(Var.DIExpr.getNumElements(),
                                  Var.Type.has_value(), Var.Loc.has_value(),
                                  Var.Scope),
@@ -448,7 +448,10 @@ DebugValueInst::DebugValueInst(
               getTrailingObjects<SILLocation>(),
               getTrailingObjects<const SILDebugScope *>(),
               getTrailingObjects<SILDIExprElement>()) {
-  if (usesMoveableValueDebugInfo || Operand->getType().isMoveOnly())
+  if (usesMoveableValueDebugInfo ||
+      llvm::any_of(Operands, [](SILValue op) {
+        return op->getType().isMoveOnly();
+      }))
     setUsesMoveableValueDebugInfo();
   setTrace(trace);
   if (prependDeref)
@@ -456,8 +459,8 @@ DebugValueInst::DebugValueInst(
 }
 
 DebugValueInst *DebugValueInst::create(SILDebugLocation DebugLoc,
-                                       SILValue Operand, SILModule &M,
-                                       SILDebugVariable Var,
+                                       ArrayRef<SILValue> Operands,
+                                       SILModule &M, SILDebugVariable Var,
                                        UsesMoveableValueDebugInfo_t wasMoved,
                                        bool trace) {
   // Don't store the same information twice.
@@ -465,7 +468,8 @@ DebugValueInst *DebugValueInst::create(SILDebugLocation DebugLoc,
     Var.Loc = {};
   if (Var.Scope == DebugLoc.getScope())
     Var.Scope = nullptr;
-  if (Var.Type == Operand->getType().getObjectType() &&
+  if (Operands.size() == 1 &&
+      Var.Type == Operands[0]->getType().getObjectType() &&
       !Var.DIExpr.getFragmentPart())
     Var.Type = {};
   // Use the prependDeref bit rather than storing it in the DIExpr.
@@ -473,9 +477,9 @@ DebugValueInst *DebugValueInst::create(SILDebugLocation DebugLoc,
   if (prependDeref) {
     Var.DIExpr.eraseElement(Var.DIExpr.element_begin());
   }
-  void *buf = allocateDebugVarCarryingInst<DebugValueInst>(M, Var, {Operand});
+  void *buf = allocateDebugVarCarryingInst<DebugValueInst>(M, Var, Operands);
   return ::new (buf)
-    DebugValueInst(DebugLoc, Operand, M, Var, wasMoved, trace, prependDeref);
+    DebugValueInst(DebugLoc, Operands, M, Var, wasMoved, trace, prependDeref);
 }
 
 void DebugValueInst::prependDeref(unsigned operandIdx) {

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -478,22 +478,24 @@ DebugValueInst *DebugValueInst::create(SILDebugLocation DebugLoc,
     DebugValueInst(DebugLoc, Operand, M, Var, wasMoved, trace, prependDeref);
 }
 
-void DebugValueInst::prependDeref() {
+void DebugValueInst::prependDeref(unsigned operandIdx) {
+  SILValue operand = getAllOperands()[operandIdx].get();
   if (!ReconstructionBlock) {
     ASSERT(!hasDeref() && "Debug value cannot have two derefs!");
     sharedUInt8().DebugValueInst.prependDeref = true;
     return;
   }
+
   // If we have an undef, the reconstruction block shouldn't have an argument.
   // Nothing to do.
-  if (isa<SILUndef>(getOperand()))
+  if (isa<SILUndef>(operand))
     return;
 
   // If the type is address-only (not loadable or opaque), we cannot insert
   // a load into the reconstruction block. Kill the operand instead.
-  SILArgument *oldArg = ReconstructionBlock->getArgument(0);
+  SILArgument *oldArg = ReconstructionBlock->getArgument(operandIdx);
   if (!oldArg->getType().isLoadableOrOpaque(*getFunction()))
-    return killOperand();
+    return killOperand(operandIdx);
 
   // If we have a reconstruction block, add a load at the beginning.
   SILBuilder builder(ReconstructionBlock->begin());
@@ -503,7 +505,7 @@ void DebugValueInst::prependDeref() {
                                       LoadOwnershipQualifier::Unqualified);
   oldArg->replaceAllUsesWith(load);
   SILArgument *newArg =
-      ReconstructionBlock->replacePhiArgument(0, addrType, OwnershipKind::None);
+      ReconstructionBlock->replacePhiArgument(operandIdx, addrType, OwnershipKind::None);
   load->setOperand(newArg);
 }
 
@@ -520,11 +522,12 @@ void DebugValueInst::convertDerefToLoad() {
   sharedUInt8().DebugValueInst.prependDeref = false;
 }
 
-void DebugValueInst::stripDeref() {
+void DebugValueInst::stripDeref(unsigned operandIdx) {
+  SILValue operand = getAllOperands()[operandIdx].get();
   // If we have an undef, nothing to do.
-  if (isa<SILUndef>(getOperand()))
+  if (isa<SILUndef>(operand))
     return;
-  ASSERT(getOperand()->getType().isLoadableOrOpaque(*getFunction()) &&
+  ASSERT(operand->getType().isLoadableOrOpaque(*getFunction()) &&
          "cannot strip deref for address-only types");
   if (!ReconstructionBlock) {
     ASSERT(hasDeref() && "Cannot strip deref without one!");
@@ -534,7 +537,7 @@ void DebugValueInst::stripDeref() {
 
   // Replace all uses of the operand with undef.
   // Load users are salvaged to use the direct value.
-  SILArgument *oldArg = ReconstructionBlock->getArgument(0);
+  SILArgument *oldArg = ReconstructionBlock->getArgument(operandIdx);
   SILType objType = oldArg->getType().getObjectType();
   SILValue undefAddr = SILUndef::get(oldArg);
   SmallVector<LoadInst *, 16> loads;
@@ -550,11 +553,11 @@ void DebugValueInst::stripDeref() {
 
   // If there are no loads, this operand is no longer used. Kill it.
   if (loads.empty())
-    return killOperand();
+    return killOperand(operandIdx);
 
   // Otherwise, replace the arguments and all uses
   SILArgument *newArg =
-      ReconstructionBlock->replacePhiArgument(0, objType, OwnershipKind::None);
+      ReconstructionBlock->replacePhiArgument(operandIdx, objType, OwnershipKind::None);
 
   for (LoadInst *load : loads) {
     load->replaceAllUsesWith(newArg);
@@ -570,7 +573,7 @@ SILBasicBlock *DebugValueInst::getOrCreateDebugReconstructionBlock() {
   auto *block = getFunction()->createEmptyDebugReconstructionBlock();
   SILBuilder builder(block);
 
-  SILValue operand = getOperand();
+  SILValue operand = getSingleOperand();
   bool addressOnly = !operand->getType().isLoadableOrOpaque(*getFunction());
   SILValue retVal;
   if (isa<SILUndef>(operand)) {
@@ -611,19 +614,21 @@ void DebugValueInst::cloneReconstructionBlockFrom(DebugValueInst *src) {
     .cloneDebugReconstructionBlockContent(srcBB, newBB);
 }
 
-void DebugValueInst::killOperand(SILType operandType) {
-  if (isa<SILUndef>(getOperand())) {
+void DebugValueInst::killOperand(unsigned operandIdx, SILType operandType) {
+  Operand &operandRef = getAllOperands()[operandIdx];
+  SILValue operand = operandRef.get();
+  if (isa<SILUndef>(operand)) {
     // Already undef: no operand to kill.
     return;
   }
 
-  SILType origType = operandType ? operandType : getOperand()->getType();
+  SILType origType = operandType ? operandType : operand->getType();
 
   // Non-undef debug_values on alloc_box are allowed and fixed by IRGen to
   // refer to the project_box. Undef debug_values, however, should always
   // have the type of the variable.
   if (!operandType)
-    if (auto *abi = dyn_cast<AllocBoxInst>(getOperand()))
+    if (auto *abi = dyn_cast<AllocBoxInst>(operand))
       origType = abi->getAddressType().getObjectType();
 
   bool addressOnly = !origType.isLoadableOrOpaque(*getFunction());
@@ -633,7 +638,7 @@ void DebugValueInst::killOperand(SILType operandType) {
   SILValue undef =
       SILUndef::get(getFunction(), addressOnly ? origType.getAddressType()
                                                : origType.getObjectType());
-  setOperand(undef);
+  operandRef.set(undef);
 
   // Strip prependDeref (unless address-only).
   // The stored DIExpr only contains fragments, which we want to keep.
@@ -643,10 +648,14 @@ void DebugValueInst::killOperand(SILType operandType) {
   // Rather than completely removing the debug reconstruction block, remove its
   // argument, as a part of the variable might be constant and recoverable.
   if (auto bb = getDebugReconstructionBlock()) {
-    ASSERT(bb->getNumArguments() == 1);
-    auto argument = bb->getArgument(0);
+    ASSERT(operandIdx < bb->getNumArguments());
+    ASSERT(bb->getNumArguments() == 1 && "Multi operand support not ready");
+    auto argument = bb->getArgument(operandIdx);
     argument->replaceAllUsesWithUndef();
-    bb->eraseArgument(0);
+    // FIXME: For correct multi operand support, the operand must also be
+    // removed from the debug_value instruction's operand list, or the
+    // indices will not match.
+    bb->eraseArgument(operandIdx);
   }
 }
 
@@ -656,11 +665,15 @@ SILType DebugValueInst::getVarType() const {
   if (auto *debugBB = getDebugReconstructionBlock())
     return cast<ReturnInst>(debugBB->getTerminator())
         ->getOperand()->getType().getObjectType();
-  return getOperand()->getType().getObjectType();
+  return getSingleOperand()->getType().getObjectType();
 }
 
 bool DebugValueInst::isExprTypeValid() const {
   auto varInfo = getCompleteVarInfo();
+
+  // TODO: Multiple operands are not yet supported.
+  if (getAllOperands().size() != 1)
+    return false;
 
   // Ignore trace debug values.
   if (hasTrace())
@@ -670,11 +683,12 @@ bool DebugValueInst::isExprTypeValid() const {
   if (!F)
     return false;
 
-  SILType valueType = getOperand()->getType();
+  SILValue operand = getSingleOperand();
+  SILType valueType = operand->getType();
 
   // Special case: a DebugValueInst with an alloc_box operand is equivalent to
   // the alloc_box.
-  if (auto *box = dyn_cast<AllocBoxInst>(getOperand()))
+  if (auto *box = dyn_cast<AllocBoxInst>(operand))
     if (varInfo.DIExpr.elements().empty() &&
         getDebugReconstructionBlock() == nullptr &&
         varInfo.Type == box->getAddressType().getObjectType())

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -436,9 +436,11 @@ SILType AllocBoxInst::getAddressType() const {
 }
 
 DebugValueInst::DebugValueInst(
-    SILDebugLocation DebugLoc, SILValue Operand, SILDebugVariable Var,
-    UsesMoveableValueDebugInfo_t usesMoveableValueDebugInfo, bool trace, bool prependDeref)
-    : UnaryInstructionBase(DebugLoc, Operand),
+    SILDebugLocation DebugLoc, SILValue Operand, SILModule &M,
+    SILDebugVariable Var,
+    UsesMoveableValueDebugInfo_t usesMoveableValueDebugInfo, bool trace,
+    bool prependDeref)
+    : InstructionBaseWithTrailingOperands({Operand}, DebugLoc),
       SILDebugVariableSupplement(Var.DIExpr.getNumElements(),
                                  Var.Type.has_value(), Var.Loc.has_value(),
                                  Var.Scope),
@@ -471,9 +473,9 @@ DebugValueInst *DebugValueInst::create(SILDebugLocation DebugLoc,
   if (prependDeref) {
     Var.DIExpr.eraseElement(Var.DIExpr.element_begin());
   }
-  void *buf = allocateDebugVarCarryingInst<DebugValueInst>(M, Var);
+  void *buf = allocateDebugVarCarryingInst<DebugValueInst>(M, Var, {Operand});
   return ::new (buf)
-    DebugValueInst(DebugLoc, Operand, Var, wasMoved, trace, prependDeref);
+    DebugValueInst(DebugLoc, Operand, M, Var, wasMoved, trace, prependDeref);
 }
 
 void DebugValueInst::prependDeref() {

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -452,7 +452,7 @@ DebugValueInst::DebugValueInst(
     setUsesMoveableValueDebugInfo();
   setTrace(trace);
   if (prependDeref)
-    this->prependDeref();
+    this->prependDeref(0);
 }
 
 DebugValueInst *DebugValueInst::create(SILDebugLocation DebugLoc,

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -3742,10 +3742,10 @@ protected:
   }
 
   void visitDebugValueInst(DebugValueInst *debugInst) {
-    SILValue srcVal = debugInst->getOperand();
+    SILValue srcVal = use->get();
     SILValue srcAddr = pass.valueStorageMap.getStorage(srcVal).storageAddress;
-    debugInst->setOperand(srcAddr);
-    debugInst->prependDeref();
+    use->set(srcAddr);
+    debugInst->prependDeref(use->getOperandNumber());
   }
 
   void visitDeinitExistentialValueInst(

--- a/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
+++ b/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
@@ -586,7 +586,7 @@ SILValue ClosureCloner::getProjectBoxMappedVal(SILValue operandValue) {
 /// if its operand is the promoted address argument then lower it to
 /// another debug_value, otherwise it is handled normally.
 void ClosureCloner::visitDebugValueInst(DebugValueInst *inst) {
-  if (SILValue value = getProjectBoxMappedVal(inst->getOperand())) {
+  if (SILValue value = getProjectBoxMappedVal(inst->getSingleOperand())) {
     getBuilder().setCurrentDebugScope(getOpScope(inst->getDebugScope()));
     auto varInfo = *inst->getVarInfo();
     if (varInfo.Scope)

--- a/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableAddressesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableAddressesChecker.cpp
@@ -1005,7 +1005,7 @@ public:
     // Do not clone if our inst argument is one of our cloned arguments. In such
     // a case, we are going to handle the debug_value when we visit a post
     // dominating consuming reinit.
-    if (oldArgSet.count(inst->getOperand())) {
+    if (oldArgSet.count(inst->getSingleOperand())) {
       LLVM_DEBUG(llvm::dbgs()
                  << "    Visiting debug value that is in the old arg set!\n");
       return;

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -2380,7 +2380,7 @@ bool GatherUsesVisitor::visitUse(Operand *op) {
     // immutable, so it is fine if we see debug_values or other uses that aren't
     // directly related to the current marked use; they will have to behave
     // compatibly anyway.
-    if (di->getOperand() == getRootAddress()) {
+    if (di->getSingleOperand() == getRootAddress()) {
       useState.debugValue = di;
     }
     return true;

--- a/lib/SILOptimizer/Transforms/SILSROA.cpp
+++ b/lib/SILOptimizer/Transforms/SILSROA.cpp
@@ -316,7 +316,7 @@ void SROAMemoryUseAnalyzer::chopUpAlloca(std::vector<AllocStackInst *> &Worklist
     // variable from the different allocations, but a debug_value can only have
     // one operand.
     if (DVI->getDebugReconstructionBlock()) {
-      DVI->killOperand();
+      DVI->killOperand(Operand->getOperandNumber());
       continue;
     }
     for (size_t i : indices(NewAllocations)) {

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -1962,7 +1962,7 @@ static void salvageBinaryInst(SingleValueInstruction *SVI) {
 
     if (!lhsNullary && !rhsNullary) {
       // Debug values cannot currently have multiple operands.
-      DbgInst->killOperand();
+      DbgInst->killOperand(U->getOperandNumber());
       continue;
     }
 
@@ -1983,7 +1983,7 @@ static void salvageBinaryInst(SingleValueInstruction *SVI) {
       // Both nullary, no operand remains.
       cloned->setOperand(0, clonedLhs);
       cloned->setOperand(1, clonedRhs);
-      DbgInst->killOperand();
+      DbgInst->killOperand(U->getOperandNumber());
     } else if (rhsNullary) {
       auto *newArg =
           debugBB->replacePhiArgument(0, lhs->getType(), OwnershipKind::None);
@@ -2103,7 +2103,7 @@ static void transferStoreDebugValue(DebugVarCarryingInst DefiningInst,
   if (auto *srcDVI = dyn_cast<DebugValueInst>(*DefiningInst))
     newDVI->cloneReconstructionBlockFrom(srcDVI);
 
-  newDVI->stripDeref();
+  newDVI->stripDeref(0);
 }
 
 void swift::salvageStoreDebugInfo(SILInstruction *SI,
@@ -2384,8 +2384,8 @@ void swift::salvageLoadDebugInfo(LoadOperation load) {
     // The debug_value must be "hoisted" to the load to ensure that the
     // address is still valid.
     debugInst->moveBefore(load.getLoadInst());
-    debugInst->setOperand(load.getOperand());
-    debugInst->prependDeref();
+    debugUse->set(load.getOperand());
+    debugInst->prependDeref(debugUse->getOperandNumber());
   }
 }
 

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -1897,11 +1897,11 @@ static void salvageNullaryInst(SingleValueInstruction *inst) {
   SmallVector<Operand *> debugUses(getDebugUses(inst));
   for (Operand *U : debugUses) {
     auto *DbgInst = cast<DebugValueInst>(U->getUser());
+    unsigned opIdx = U->getOperandNumber();
     SILBasicBlock *debugBB = DbgInst->getOrCreateDebugReconstructionBlock();
     SILValue cloned = inst->clone(&*debugBB->begin());
-    debugBB->getArgument(0)->replaceAllUsesWith(cloned);
-    debugBB->eraseArgument(0);
-    DbgInst->setOperand(SILUndef::get(DbgInst->getOperand()));
+    debugBB->getArgument(opIdx)->replaceAllUsesWith(cloned);
+    DbgInst->killOperand(opIdx);
   }
 }
 
@@ -1921,9 +1921,10 @@ static void salvageUnaryInst(SingleValueInstruction *SVI) {
   SmallVector<Operand *> debugUses(getDebugUses(SVI));
   for (Operand *U : debugUses) {
     auto *DbgInst = cast<DebugValueInst>(U->getUser());
+    unsigned opIdx = U->getOperandNumber();
     SILBasicBlock *debugBB =
         DbgInst->getOrCreateDebugReconstructionBlock();
-    SILArgument *oldArg = debugBB->getArgument(0);
+    SILArgument *oldArg = debugBB->getArgument(opIdx);
 
     // Clone the instruction into the debug BB. TrivialCloner keeps
     // original operands, which we fix up below.
@@ -1934,9 +1935,9 @@ static void salvageUnaryInst(SingleValueInstruction *SVI) {
     // Replace the block arg type with the input operand type.
     SILValue operand = SVI->getOperand(0);
     auto *newArg =
-        debugBB->replacePhiArgument(0, operand->getType(), OwnershipKind::None);
+        debugBB->replacePhiArgument(opIdx, operand->getType(), OwnershipKind::None);
     cloned->setOperand(0, newArg);
-    DbgInst->setOperand(operand);
+    U->set(operand);
   }
 }
 
@@ -1959,15 +1960,16 @@ static void salvageBinaryInst(SingleValueInstruction *SVI) {
   SmallVector<Operand *> debugUses(getDebugUses(SVI));
   for (Operand *U : debugUses) {
     auto *DbgInst = cast<DebugValueInst>(U->getUser());
+    unsigned opIdx = U->getOperandNumber();
 
     if (!lhsNullary && !rhsNullary) {
       // Debug values cannot currently have multiple operands.
-      DbgInst->killOperand(U->getOperandNumber());
+      DbgInst->killOperand(opIdx);
       continue;
     }
 
     SILBasicBlock *debugBB = DbgInst->getOrCreateDebugReconstructionBlock();
-    SILArgument *oldArg = debugBB->getArgument(0);
+    SILArgument *oldArg = debugBB->getArgument(opIdx);
 
     auto *cloned = cast<SingleValueInstruction>(SVI->clone(&*debugBB->begin()));
     oldArg->replaceAllUsesWith(cloned);
@@ -1983,19 +1985,19 @@ static void salvageBinaryInst(SingleValueInstruction *SVI) {
       // Both nullary, no operand remains.
       cloned->setOperand(0, clonedLhs);
       cloned->setOperand(1, clonedRhs);
-      DbgInst->killOperand(U->getOperandNumber());
+      DbgInst->killOperand(opIdx);
     } else if (rhsNullary) {
       auto *newArg =
-          debugBB->replacePhiArgument(0, lhs->getType(), OwnershipKind::None);
+          debugBB->replacePhiArgument(opIdx, lhs->getType(), OwnershipKind::None);
       cloned->setOperand(0, newArg);
       cloned->setOperand(1, clonedRhs);
-      DbgInst->setOperand(lhs);
+      U->set(lhs);
     } else {
       auto *newArg =
-          debugBB->replacePhiArgument(0, rhs->getType(), OwnershipKind::None);
+          debugBB->replacePhiArgument(opIdx, rhs->getType(), OwnershipKind::None);
       cloned->setOperand(0, clonedLhs);
       cloned->setOperand(1, newArg);
-      DbgInst->setOperand(rhs);
+      U->set(rhs);
     }
   }
 }
@@ -2040,8 +2042,7 @@ static void salvageIdentityInst(SingleValueInstruction *SVI) {
          "salvageIdentityInst expects an operand");
   SmallVector<Operand *> debugUses(getDebugUses(SVI));
   for (Operand *U : debugUses) {
-    auto *DbgInst = cast<DebugValueInst>(U->getUser());
-    DbgInst->setOperand(SVI->getOperand(0));
+    U->set(SVI->getOperand(0));
   }
 }
 
@@ -2059,9 +2060,10 @@ static void salvageDestructureInst(SILInstruction *I) {
     SmallVector<Operand *> debugUses(getDebugUses(result));
     for (Operand *U : debugUses) {
       auto *DbgInst = cast<DebugValueInst>(U->getUser());
+      unsigned opIdx = U->getOperandNumber();
       SILBasicBlock *debugBB =
           DbgInst->getOrCreateDebugReconstructionBlock();
-      SILArgument *oldArg = debugBB->getArgument(0);
+      SILArgument *oldArg = debugBB->getArgument(opIdx);
 
       // Create the equivalent extract instruction in the debug BB.
       SILBuilder builder(&*debugBB->begin());
@@ -2079,9 +2081,9 @@ static void salvageDestructureInst(SILInstruction *I) {
 
       // Replace the block arg type with the struct/tuple operand type.
       auto *newArg = debugBB->replacePhiArgument(
-          0, structOrTupleOperand->getType(), OwnershipKind::None);
+          opIdx, structOrTupleOperand->getType(), OwnershipKind::None);
       extractInst->setOperand(0, newArg);
-      DbgInst->setOperand(structOrTupleOperand);
+      U->set(structOrTupleOperand);
     }
   }
 }
@@ -2218,6 +2220,7 @@ void swift::salvageDebugInfo(SILInstruction *I) {
       SmallVector<Operand *> debugUses(getDebugUses(STVal));
       for (Operand *U : debugUses) {
         auto *DbgInst = cast<DebugValueInst>(U->getUser());
+        unsigned opIdx = U->getOperandNumber();
         auto VarInfo = DbgInst->getCompleteVarInfo();
         if (SILBasicBlock *debugBB = DbgInst->getDebugReconstructionBlock()) {
           // Cannot combine debug reconstruction blocks and fragments.
@@ -2225,7 +2228,7 @@ void swift::salvageDebugInfo(SILInstruction *I) {
           // single operand, only salvage one field (the first one).
           SILValue fieldVal = STI->getOperand(0);
           SILType structTy = STVal->getType();
-          SILArgument *oldArg = debugBB->getArgument(0);
+          SILArgument *oldArg = debugBB->getArgument(opIdx);
 
           // Create an all-undef struct instruction.
           SILBuilder builder(debugBB->begin());
@@ -2238,9 +2241,9 @@ void swift::salvageDebugInfo(SILInstruction *I) {
 
           // Replace the block arg and wire the operand.
           auto *newArg = debugBB->replacePhiArgument(
-            0, fieldVal->getType(), OwnershipKind::None);
+            opIdx, fieldVal->getType(), OwnershipKind::None);
           newStructInst->setOperand(0, newArg);
-          DbgInst->setOperand(fieldVal);
+          U->set(fieldVal);
         } else {
           // Fragments are the only way to use multiple operands to reconstruct
           // a variable, as debug values can only have a single operand.
@@ -2271,13 +2274,14 @@ void swift::salvageDebugInfo(SILInstruction *I) {
       SmallVector<Operand *> debugUses(getDebugUses(TTVal));
       for (Operand *U : debugUses) {
         auto *DbgInst = cast<DebugValueInst>(U->getUser());
+        unsigned opIdx = U->getOperandNumber();
         auto VarInfo = DbgInst->getCompleteVarInfo();
         if (SILBasicBlock *debugBB = DbgInst->getDebugReconstructionBlock()) {
           // Cannot combine debug reconstruction blocks and fragments.
           // Only salvage one element (the first one).
           SILValue eltVal = TTI->getOperand(0);
           SILType tupleTy = TTVal->getType();
-          SILArgument *oldArg = debugBB->getArgument(0);
+          SILArgument *oldArg = debugBB->getArgument(opIdx);
 
           // Create an all-undef tuple instruction.
           SILBuilder builder(debugBB->begin());
@@ -2290,10 +2294,9 @@ void swift::salvageDebugInfo(SILInstruction *I) {
 
           // Replace the block arg and wire the operand.
           auto *newArg = debugBB->replacePhiArgument(
-            0, eltVal->getType(), OwnershipKind::None);
+            opIdx, eltVal->getType(), OwnershipKind::None);
           tupleInst->setOperand(0, newArg);
-          // Update the debug_value operand.
-          DbgInst->setOperand(eltVal);
+          U->set(eltVal);
         } else {
           TupleType *TT = TTI->getTupleType();
           for (auto i : indices(TT->getElements())) {

--- a/lib/SILOptimizer/Utils/OSSACanonicalizeOwned.cpp
+++ b/lib/SILOptimizer/Utils/OSSACanonicalizeOwned.cpp
@@ -188,7 +188,7 @@ bool OSSACanonicalizeOwned::computeCanonicalLiveness() {
           // interesting.
           if (liveness->getBlockLiveness(dvi->getParent()) !=
               PrunedLiveBlocks::LiveOut) {
-            recordDebugValue(dvi);
+            recordDebugUse(use);
           }
           continue;
         }
@@ -1366,12 +1366,13 @@ void OSSACanonicalizeOwned::rewriteCopies(
     for (auto *destroy : newDestroys) {
       liveness->updateForUse(destroy, /*lifetimeEnding=*/true);
     }
-    for (auto *dvi : debugValues) {
+    for (auto *use : debugUses) {
+      auto *dvi = cast<DebugValueInst>(use->getUser());
       if (liveness->isWithinBoundary(dvi)) {
         continue;
       }
       LLVM_DEBUG(llvm::dbgs() << "  Killing debug_value: " << *dvi);
-      dvi->killOperand();
+      dvi->killOperand(use->getOperandNumber());
     }
   }
 


### PR DESCRIPTION
Each commit gradually transitions all code paths using debug_value instructions to support multiple operands.
This PR should be NFC. Only the internal compiler storage for debug_values is changing, it is still impossible to create multi-operands debug_values.

It does not update everything:
- The verifier still asserts only one operand exists per debug_value
- SIL serialization is untouched
- SIL printer/parser still expect one operand
- Debug reconstruction block salvaging and IRGen have not been updated

However:
- Debug values can store multiple operands
- Most passes are updated to iterate over operands or refer to the debug use (operand) rather than the debug user (instruction)