### PR TITLE
[test] Fix xrsimulator lit failures via mock SDK VersionMap (#90672)

### DIFF
--- a/test/IDE/print_clang_header_i386.swift
+++ b/test/IDE/print_clang_header_i386.swift
@@ -5,5 +5,5 @@
 // RUN: echo '#include "header-to-print.h"' > %t.i386.m
 // RUN: %empty-directory(%t)
 // RUN: %build-clang-importer-objc-overlays
-// RUN: %target-swift-ide-test -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -I %t --cc-args -arch i386 -isysroot %clang-importer-sdk-path -fsyntax-only %t.i386.m -I %S/Inputs/print_clang_header > %t.i386.txt
+// RUN: %target-swift-ide-test -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -I %t --cc-args -target %target-triple -arch i386 -isysroot %clang-importer-sdk-path -fsyntax-only %t.i386.m -I %S/Inputs/print_clang_header > %t.i386.txt
 // RUN: diff -u %S/Inputs/print_clang_header/header-to-print.h.printed.txt %t.i386.txt

--- a/test/Inputs/clang-importer-sdk/SDKSettings.json
+++ b/test/Inputs/clang-importer-sdk/SDKSettings.json
@@ -1,0 +1,67 @@
+{
+  "CanonicalName": "xros1.0",
+  "Version": "1.0",
+  "IsBaseSDK": "YES",
+  "DisplayName": "Mock SDK",
+  "MinimalDisplayName": "Mock",
+  "SupportedTargets": {
+    "macosx": {
+      "Archs": ["arm64", "arm64e", "x86_64"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "macosx", "LLVMTargetTripleEnvironment": "",
+      "MinimumDeploymentTarget": "10.9", "MaximumDeploymentTarget": "26.0.99",
+      "DefaultDeploymentTarget": "26.0", "RecommendedDeploymentTarget": "26.0"
+    },
+    "iphoneos": {
+      "Archs": ["arm64", "arm64e"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "ios", "LLVMTargetTripleEnvironment": "",
+      "MinimumDeploymentTarget": "9.0", "MaximumDeploymentTarget": "26.0.99",
+      "DefaultDeploymentTarget": "26.0", "RecommendedDeploymentTarget": "26.0"
+    },
+    "iphonesimulator": {
+      "Archs": ["arm64", "x86_64"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "ios", "LLVMTargetTripleEnvironment": "simulator",
+      "MinimumDeploymentTarget": "9.0", "MaximumDeploymentTarget": "26.0.99",
+      "DefaultDeploymentTarget": "26.0", "RecommendedDeploymentTarget": "26.0"
+    },
+    "appletvos": {
+      "Archs": ["arm64"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "tvos", "LLVMTargetTripleEnvironment": "",
+      "MinimumDeploymentTarget": "9.0", "MaximumDeploymentTarget": "26.0.99",
+      "DefaultDeploymentTarget": "26.0", "RecommendedDeploymentTarget": "26.0"
+    },
+    "appletvsimulator": {
+      "Archs": ["arm64", "x86_64"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "tvos", "LLVMTargetTripleEnvironment": "simulator",
+      "MinimumDeploymentTarget": "9.0", "MaximumDeploymentTarget": "26.0.99",
+      "DefaultDeploymentTarget": "26.0", "RecommendedDeploymentTarget": "26.0"
+    },
+    "watchos": {
+      "Archs": ["arm64_32", "arm64"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "watchos", "LLVMTargetTripleEnvironment": "",
+      "MinimumDeploymentTarget": "2.0", "MaximumDeploymentTarget": "26.0.99",
+      "DefaultDeploymentTarget": "26.0", "RecommendedDeploymentTarget": "26.0"
+    },
+    "watchsimulator": {
+      "Archs": ["arm64", "x86_64"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "watchos", "LLVMTargetTripleEnvironment": "simulator",
+      "MinimumDeploymentTarget": "2.0", "MaximumDeploymentTarget": "26.0.99",
+      "DefaultDeploymentTarget": "26.0", "RecommendedDeploymentTarget": "26.0"
+    },
+    "xros": {
+      "Archs": ["arm64", "arm64e", "x86_64"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "xros", "LLVMTargetTripleEnvironment": "",
+      "MinimumDeploymentTarget": "1.0", "MaximumDeploymentTarget": "26.0.99",
+      "DefaultDeploymentTarget": "1.0", "RecommendedDeploymentTarget": "1.0"
+    },
+    "xrsimulator": {
+      "Archs": ["arm64", "x86_64"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "xros", "LLVMTargetTripleEnvironment": "simulator",
+      "MinimumDeploymentTarget": "1.0", "MaximumDeploymentTarget": "26.0.99",
+      "DefaultDeploymentTarget": "1.0", "RecommendedDeploymentTarget": "1.0"
+    },
+    "driverkit": {
+      "Archs": ["arm64", "arm64e", "x86_64"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "driverkit", "LLVMTargetTripleEnvironment": "",
+      "MinimumDeploymentTarget": "19.0", "MaximumDeploymentTarget": "26.0.99",
+      "DefaultDeploymentTarget": "26.0", "RecommendedDeploymentTarget": "26.0"
+    }
+  },
+  "VersionMap": {
+    "visionOS_iOS": {"1.0": "17.1", "1.1": "17.4", "1.2": "17.5", "2.0": "18.0", "2.1": "18.1", "2.2": "18.2", "2.3": "18.3", "2.4": "18.4", "2.5": "18.5", "2.6": "18.6", "26.0": "26.0"},
+    "iOS_visionOS": {"17.1": "1.0", "17.4": "1.1", "17.5": "1.2", "18.0": "2.0", "18.1": "2.1", "18.2": "2.2", "18.3": "2.3", "18.4": "2.4", "18.5": "2.5", "18.6": "2.6", "26.0": "26.0"},
+    "xrOS_iOS": {"1.0": "17.1", "1.1": "17.4", "1.2": "17.5", "2.0": "18.0", "2.1": "18.1", "2.2": "18.2", "2.3": "18.3", "2.4": "18.4", "2.5": "18.5", "2.6": "18.6", "26.0": "26.0"},
+    "iOS_xrOS": {"17.1": "1.0", "17.4": "1.1", "17.5": "1.2", "18.0": "2.0", "18.1": "2.1", "18.2": "2.2", "18.3": "2.3", "18.4": "2.4", "18.5": "2.5", "18.6": "2.6", "26.0": "26.0"}
+  },
+  "DefaultDeploymentTarget": "26.0",
+  "MaximumDeploymentTarget": "26.0.99"
+}


### PR DESCRIPTION
A few xrsimulator tests currently fail to infer the correct visionOS version and falsely see SwiftStdlib 5.x symbols as unavailable.

This PR fixes those tests by:
- Adding `SDKSettings.json` to the shared `test/Inputs/clang-importer-sdk` to provide a correct version map
- Pinning the CC target triple in `IDE/print_clang_header_i386.swift` as a result of the first change. Once the mock SDK carries an `SDKSettings.json`, clang's Darwin driver derives the target from the SDK as `i386-apple-<CanonicalName>`, which is not a valid target with a working Swift stdlib. Pinning `%target-triple` preserves the historical behavior.

(cherry picked from commit e3f3a9335a70d1f9f7604299db511712777326d4)