### PR TITLE
[test] Cxx/foreign-reference/array-of-classes: set -target to %target-swift-5.8-abi-triple (#90179)

### DIFF
--- a/test/Interop/Cxx/foreign-reference/array-of-classes.swift
+++ b/test/Interop/Cxx/foreign-reference/array-of-classes.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
-// RUN: %swiftc_driver -O -I %t/Inputs  %t/test.swift -cxx-interoperability-mode=default -I %swift_src_root/lib/ClangImporter/SwiftBridging -o %t/a.out
+// RUN: %swiftc_driver -target %target-swift-5.8-abi-triple -O -I %t/Inputs %t/test.swift -cxx-interoperability-mode=default -I %swift_src_root/lib/ClangImporter/SwiftBridging -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 


### PR DESCRIPTION
Line 3 used %swiftc_driver, which doesn't inject -target like %target-build-swift does, so the test binary was built for the build host's arch. When cross- compiling, shipping it to the target fails with "Bad CPU type in executable". Add -target %target-swift-5.8-abi-triple to pin the build to the variant.

The test's `RefType` is annotated `@available(macOS 13.3.0, *)`. Using %target-swift-5.8-abi-triple satisfies the availability constraint.

(cherry picked from commit 468a69c1241f889291de9b471e51dc596670c9df)