### PR TITLE
OpaqueValues: more typed throws fixes

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -6559,6 +6559,12 @@ SILValue SILGenFunction::emitApplyWithRethrow(SILLocation loc, SILValue fn,
     // can end up here. Since the callee cannot actually throw, emit
     // an unreachable in the error branch.
     ASSERT(silFnType->getErrorResult().getInterfaceType()->isNever());
+    // If direct, the block still needs to have a dummy Never error arg.
+    if (!fnConv.hasIndirectSILErrorResults()) {
+      errorBB->createPhiArgument(
+          fnConv.getSILErrorType(getTypeExpansionContext()),
+          OwnershipKind::Owned);
+    }
     B.emitBlock(errorBB);
     B.createUnreachable(loc);
   } else {

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -502,7 +502,7 @@ ManagedValue SILGenBuilder::createUncheckedEnumDataAddrForTake(
 ManagedValue
 SILGenBuilder::createLoadIfLoadable(SILLocation loc, ManagedValue addr) {
   assert(addr.getType().isAddress());
-  if (!addr.getType().isLoadable(SGF.F))
+  if (!addr.getType().isLoadableOrOpaque(SGF.F))
     return addr;
   return createLoadWithSameOwnership(loc, addr);
 }

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1209,7 +1209,7 @@ SILGenFunction::ForceTryEmission::ForceTryEmission(SILGenFunction &SGF,
 
   SILValue indirectError;
   auto &errorTL = SGF.getTypeLowering(loc->getThrownError());
-  if (!errorTL.isAddressOnly()) {
+  if (!errorTL.isAddress()) {
     (void) catchBB->createPhiArgument(errorTL.getLoweredType(),
                                       OwnershipKind::Owned);
   } else {
@@ -1265,8 +1265,8 @@ void SILGenFunction::ForceTryEmission::finish() {
               return error.getType().getObjectType().getASTType();
             }, LookUpConformanceInModule());
 
-        // Generic errors are passed indirectly.
-        if (!error.getType().isAddress()) {
+        // If lowering addresses, the error must be passed indirectly.
+        if (SGF.silConv.useLoweredAddresses() && !error.getType().isAddress()) {
           auto *tmp = SGF.B.createAllocStack(
               Loc, error.getType().getObjectType(), std::nullopt);
           error.forwardInto(SGF, Loc, tmp);

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -1361,9 +1361,9 @@ void StmtEmitter::visitDoCatchStmt(DoCatchStmt *S) {
   auto &exnTL = SGF.getTypeLowering(formalExnType);
 
   SILValue exnArg;
-
-  // FIXME: opaque values
-  if (exnTL.isAddressOnly()) {
+  bool errorIsIndirect = exnTL.isAddress();
+  
+  if (errorIsIndirect) {
     exnArg = SGF.B.createAllocStack(
         S, exnTL.getLoweredType());
     SGF.enterDeallocStackCleanup(exnArg);
@@ -1373,8 +1373,7 @@ void StmtEmitter::visitDoCatchStmt(DoCatchStmt *S) {
   JumpDest throwDest = createThrowDest(S->getBody(),
                                        ThrownErrorInfo(exnArg));
 
-  // FIXME: opaque values
-  if (!exnTL.isAddressOnly()) {
+  if (!errorIsIndirect) {
     exnArg = throwDest.getBlock()->createPhiArgument(
         exnTL.getLoweredType(), OwnershipKind::Owned);
   }

--- a/lib/SILGen/SILGenTopLevel.cpp
+++ b/lib/SILGen/SILGenTopLevel.cpp
@@ -259,9 +259,9 @@ void SILGenFunction::emitCallToMain(FuncDecl *mainFunc) {
   }
 
   // Form a call to the main function.
-  CanSILFunctionType mainFnType = mainFunction->getConventions().funcTy;
+  auto mainFnConv = mainFunction->getConventions();
   ASTContext &ctx = getASTContext();
-  if (mainFnType->hasErrorResult()) {
+  if (mainFnConv.funcTy->hasErrorResult()) {
     auto *successBlock = createBasicBlock();
     B.setInsertionPoint(successBlock);
     successBlock->createPhiArgument(SGM.Types.getEmptyTupleType(),
@@ -270,8 +270,7 @@ void SILGenFunction::emitCallToMain(FuncDecl *mainFunc) {
         B.createIntegerLiteral(loc, builtinInt32Type, 0);
     B.createBranch(loc, exitBlock, {zeroReturnValue});
 
-    SILResultInfo errorResult = mainFnType->getErrorResult();
-    SILType errorType = errorResult.getSILStorageInterfaceType();
+    SILType errorType = mainFnConv.getSILErrorType(getTypeExpansionContext());
 
     auto *failureBlock = createBasicBlock();
     B.setInsertionPoint(failureBlock);
@@ -301,8 +300,6 @@ void SILGenFunction::emitCallToMain(FuncDecl *mainFunc) {
     } else {
       // Call the _errorInMainTyped entrypoint, which handles
       // arbitrary error types.
-      SILValue tmpBuffer;
-
       FuncDecl *entrypoint = ctx.getErrorInMainTyped();
       auto genericSig = entrypoint->getGenericSignature();
       SubstitutionMap subMap = SubstitutionMap::get(
@@ -310,14 +307,13 @@ void SILGenFunction::emitCallToMain(FuncDecl *mainFunc) {
             return errorType.getASTType();
           }, LookUpConformanceInModule());
 
-      // Generic errors are passed indirectly.
-      if (!error->getType().isAddress()) {
+      // The intrinsic receives the error through a generic parameter, which is
+      // indirect if we've lowered addresses, so allocate if needed.
+      if (!error->getType().isAddress() && silConv.useLoweredAddresses()) {
         auto *tmp = B.createAllocStack(loc, error->getType().getObjectType(),
                                        std::nullopt);
-        emitSemanticStore(
-            loc, error, tmp,
-            getTypeLowering(tmp->getType()), IsInitialization);
-        tmpBuffer = tmp;
+        emitSemanticStore(loc, error, tmp,
+                          getTypeLowering(tmp->getType()), IsInitialization);
         error = tmp;
       }
 

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -850,7 +850,8 @@ void OpaqueValueVisitor::checkForIndirectApply(ApplySite applySite) {
   }
 
   if (applySite.getSubstCalleeType()->hasIndirectFormalResults() ||
-      applySite.getSubstCalleeType()->hasIndirectFormalYields()) {
+      applySite.getSubstCalleeType()->hasIndirectFormalYields() ||
+      applySite.getSubstCalleeType()->hasIndirectErrorResult()) {
     pass.indirectApplies.insert(applySite);
   }
 }
@@ -3311,8 +3312,12 @@ void ReturnRewriter::rewriteThrow(ThrowInst *throwInst) {
   auto idx = pass.loweredFnConv.getArgumentIndexOfIndirectErrorResult();
   SILArgument *errorResultAddr = pass.function->getArgument(idx.value());
 
-  auto throwBuilder = pass.getBuilder(beforeStorageDeallocs(throwInst));
-  rewriteElement(throwInst->getOperand(), errorResultAddr, throwBuilder);
+  // Copy the error into the indirect error result argument.
+  auto elementBuilder = pass.getBuilder(beforeStorageDeallocs(throwInst));
+  rewriteElement(throwInst->getOperand(), errorResultAddr, elementBuilder);
+
+  // A throw_addr replaces the direct throw.
+  auto throwBuilder = pass.getBuilder(throwInst->getIterator());
   throwBuilder.createThrowAddr(throwInst->getLoc());
   pass.deleter.forceDelete(throwInst);
 }

--- a/test/SILGen/attr_main_typed_throws.swift
+++ b/test/SILGen/attr_main_typed_throws.swift
@@ -1,5 +1,5 @@
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -Xllvm -sil-print-types -parse-as-library %s
+// RUN: %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -Xllvm -sil-print-types -parse-as-library %s
+// RUN: %target-swift-emit-sil -sil-verify-all -enable-sil-opaque-values -parse-as-library %s -o /dev/null
 
 // RUN: %target-swift-emit-silgen -Xllvm -sil-print-types -parse-as-library %s | %FileCheck %s
 

--- a/test/SILGen/if_expr.swift
+++ b/test/SILGen/if_expr.swift
@@ -1,5 +1,5 @@
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -Xllvm -sil-print-types -enable-experimental-feature ThenStatements %s
+// RUN: %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -Xllvm -sil-print-types -enable-experimental-feature ThenStatements %s
+// RUN: %target-swift-emit-sil -sil-verify-all -enable-sil-opaque-values -enable-experimental-feature ThenStatements %s -o /dev/null
 
 // RUN: %target-swift-emit-silgen -Xllvm -sil-print-types -enable-experimental-feature ThenStatements %s | %FileCheck %s
 // RUN: %target-swift-emit-ir -enable-experimental-feature ThenStatements %s

--- a/test/SILGen/issue-77295.swift
+++ b/test/SILGen/issue-77295.swift
@@ -1,5 +1,5 @@
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -verify %s
+// RUN: %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -verify %s
+// RUN: %target-swift-emit-sil -sil-verify-all -enable-sil-opaque-values -verify %s -o /dev/null
 
 // RUN: %target-swift-emit-silgen %s -verify
 

--- a/test/SILGen/switch_expr.swift
+++ b/test/SILGen/switch_expr.swift
@@ -1,5 +1,5 @@
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -Xllvm -sil-print-types -enable-experimental-feature ThenStatements %s
+// RUN: %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -Xllvm -sil-print-types -enable-experimental-feature ThenStatements %s
+// RUN: %target-swift-emit-sil -sil-verify-all -enable-sil-opaque-values -enable-experimental-feature ThenStatements %s -o /dev/null
 
 // RUN: %target-swift-emit-silgen -Xllvm -sil-print-types -enable-experimental-feature ThenStatements %s | %FileCheck %s
 // RUN: %target-swift-emit-ir -enable-experimental-feature ThenStatements %s

--- a/test/SILGen/switch_expr_address_only_tuple_return_value_context.swift
+++ b/test/SILGen/switch_expr_address_only_tuple_return_value_context.swift
@@ -1,5 +1,5 @@
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -verify %s
+// RUN: %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -verify %s
+// RUN: %target-swift-emit-sil -sil-verify-all -enable-sil-opaque-values -verify %s -o /dev/null
 
 // RUN: %target-swift-emit-silgen -verify %s
 

--- a/test/SILGen/typed_throws.swift
+++ b/test/SILGen/typed_throws.swift
@@ -1,8 +1,5 @@
 // RUN: %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values %s
-// AddressLowering cannot yet lower a typed-throws @error_indirect result under
-// opaque values, so -emit-sil crashes even though the SILGen output above is
-// valid. FIXME: drop `not --crash` once AddressLowering handles it.
-// RUN: not --crash %target-swift-emit-sil -sil-verify-all -enable-sil-opaque-values %s -o /dev/null
+// RUN: %target-swift-emit-sil -sil-verify-all -enable-sil-opaque-values %s -o /dev/null
 
 // RUN: %target-swift-emit-silgen -Xllvm -sil-print-types %s | %FileCheck %s --enable-var-scope
 // RUN: %target-swift-emit-sil -sil-verify-all %s

--- a/test/SILGen/typed_throws.swift
+++ b/test/SILGen/typed_throws.swift
@@ -1,5 +1,8 @@
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values %s
+// RUN: %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values %s
+// AddressLowering cannot yet lower a typed-throws @error_indirect result under
+// opaque values, so -emit-sil crashes even though the SILGen output above is
+// valid. FIXME: drop `not --crash` once AddressLowering handles it.
+// RUN: not --crash %target-swift-emit-sil -sil-verify-all -enable-sil-opaque-values %s -o /dev/null
 
 // RUN: %target-swift-emit-silgen -Xllvm -sil-print-types %s | %FileCheck %s --enable-var-scope
 // RUN: %target-swift-emit-sil -sil-verify-all %s

--- a/test/SILGen/typed_throws_destination_conversion_83826.swift
+++ b/test/SILGen/typed_throws_destination_conversion_83826.swift
@@ -1,5 +1,5 @@
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -module-name main %s
+// RUN: %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -module-name main %s
+// RUN: %target-swift-emit-sil -sil-verify-all -enable-sil-opaque-values -module-name main %s -o /dev/null
 
 // RUN: %target-swift-emit-silgen -module-name main %s | %FileCheck %s
 

--- a/test/SILGen/typed_throws_generic.swift
+++ b/test/SILGen/typed_throws_generic.swift
@@ -1,8 +1,5 @@
 // RUN: %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -swift-version 5 -Xllvm -sil-print-types %s -enable-experimental-feature FullTypedThrows
-// AddressLowering cannot yet lower a typed-throws @error_indirect result under
-// opaque values, so -emit-sil crashes even though the SILGen output above is
-// valid. FIXME: drop `not --crash` once AddressLowering handles it.
-// RUN: not --crash %target-swift-emit-sil -sil-verify-all -enable-sil-opaque-values -swift-version 5 %s -enable-experimental-feature FullTypedThrows -o /dev/null
+// RUN: %target-swift-emit-sil -sil-verify-all -enable-sil-opaque-values -swift-version 5 %s -enable-experimental-feature FullTypedThrows -o /dev/null
 
 // RUN: %target-swift-emit-silgen -swift-version 5 -Xllvm -sil-print-types %s -enable-experimental-feature FullTypedThrows | %FileCheck %s
 

--- a/test/SILGen/typed_throws_generic.swift
+++ b/test/SILGen/typed_throws_generic.swift
@@ -1,5 +1,8 @@
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -swift-version 5 -Xllvm -sil-print-types %s -enable-experimental-feature FullTypedThrows
+// RUN: %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -swift-version 5 -Xllvm -sil-print-types %s -enable-experimental-feature FullTypedThrows
+// AddressLowering cannot yet lower a typed-throws @error_indirect result under
+// opaque values, so -emit-sil crashes even though the SILGen output above is
+// valid. FIXME: drop `not --crash` once AddressLowering handles it.
+// RUN: not --crash %target-swift-emit-sil -sil-verify-all -enable-sil-opaque-values -swift-version 5 %s -enable-experimental-feature FullTypedThrows -o /dev/null
 
 // RUN: %target-swift-emit-silgen -swift-version 5 -Xllvm -sil-print-types %s -enable-experimental-feature FullTypedThrows | %FileCheck %s
 

--- a/test/SILGen/typed_throws_thunk.swift
+++ b/test/SILGen/typed_throws_thunk.swift
@@ -1,5 +1,5 @@
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values %s
+// RUN: %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values %s
+// RUN: %target-swift-emit-sil -sil-verify-all -enable-sil-opaque-values %s -o /dev/null
 
 // RUN: %target-swift-emit-silgen %s | %FileCheck %s
 


### PR DESCRIPTION
This also fixes a number of execution tests under opaque values:

```
Unexpectedly Passed Tests (15):
  Swift(macosx-arm64) :: Concurrency/Runtime/RuntimeDemangle.swift
  Swift(macosx-arm64) :: Concurrency/Runtime/async_sequence.swift
  Swift(macosx-arm64) :: Concurrency/Runtime/must_not_hop_withContinuation.swift
  Swift(macosx-arm64) :: Concurrency/Runtime/nonisolated_nonsending_hop_to_executor_throws.swift
  Swift(macosx-arm64) :: Distributed/Runtime/distributed_actor_localSystem_distributedProtocol.swift
  Swift(macosx-arm64) :: Interop/Cxx/stdlib/use-std-map.swift
  Swift(macosx-arm64) :: Interpreter/async_typed_throws_default_impl.swift
  Swift(macosx-arm64) :: Interpreter/issue88993.swift
  Swift(macosx-arm64) :: Interpreter/typed_throws_destination_conversion_83826.swift
  Swift(macosx-arm64) :: stdlib/StringCreate.swift
  Swift(macosx-arm64) :: stdlib/StringDeconstruction.swift
  Swift(macosx-arm64) :: stdlib/TemporaryAllocation.swift
  Swift(macosx-arm64) :: stdlib/UTF8SpanIteratorTests.swift
  Swift(macosx-arm64) :: stdlib/UTF8SpanQueriesComparisons.swift
  Swift(macosx-arm64) :: stdlib/subString.swift
```