### PR TITLE
[6.4] Remove Copyable requirement from OutputSpan's Iterable conformance

### DIFF
--- a/stdlib/public/core/Span/OutputSpan.swift
+++ b/stdlib/public/core/Span/OutputSpan.swift
@@ -579,7 +579,7 @@ extension OutputSpan where Element: Copyable {
 
 #if !SPAN_COMPATIBILITY_STUB
 @available(SwiftStdlib 6.4, *)
-extension OutputSpan: Iterable {
+extension OutputSpan: Iterable where Element: ~Copyable {
   @available(SwiftStdlib 6.4, *)
   public typealias Failure = Never
 

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1197,7 +1197,7 @@ Added: _$s7Failures8IterablePTl
 Added: _$sSTss8IterableRzrlE19underestimatedCountSivpMV
 Added: _$sSTss8IterableRzrlE21makeBorrowingIterators0cD7AdapterVy0D0STQzGyF
 Added: _$sSlss8IterableRzrlE19underestimatedCountSivpMV
-Added: _$ss10OutputSpanVyxGs8IterablesMc
+Added: _$ss10OutputSpanVyxGs8IterablesRi_zrlMc
 Added: _$ss11InlineArrayVyxq_Gs8IterablesRi__rlMc
 Added: _$ss11InlineArrayVsRi__rlE19underestimatedCountSivpMV
 Added: _$ss11MutableSpanVyxGs8IterablesRi_zrlMc

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -1192,7 +1192,7 @@ Added: _$s7Failures8IterablePTl
 Added: _$sSTss8IterableRzrlE19underestimatedCountSivpMV
 Added: _$sSTss8IterableRzrlE21makeBorrowingIterators0cD7AdapterVy0D0STQzGyF
 Added: _$sSlss8IterableRzrlE19underestimatedCountSivpMV
-Added: _$ss10OutputSpanVyxGs8IterablesMc
+Added: _$ss10OutputSpanVyxGs8IterablesRi_zrlMc
 Added: _$ss11InlineArrayVyxq_Gs8IterablesRi__rlMc
 Added: _$ss11InlineArrayVsRi__rlE19underestimatedCountSivpMV
 Added: _$ss11MutableSpanVyxGs8IterablesRi_zrlMc

--- a/test/stdlib/BorrowingSequence.swift
+++ b/test/stdlib/BorrowingSequence.swift
@@ -505,6 +505,32 @@ suite.test("UniqueArray/noncopyable-elementsEqual")
   expectTrue(b.elementsEqual(b))
 }
 
+// MARK: - Conformance checks
+
+@available(SwiftStdlib 6.4, *)
+func takesIterable<I: Iterable<T, F> & ~Copyable & ~Escapable, T: ~Copyable, F>(_ iterable: borrowing I) {}
+
+@available(SwiftStdlib 6.4, *)
+func testConformances() {
+  // Compile-only checks
+  
+  func copyableInlineArray(_ x: borrowing UniqueArray<Int>) { takesIterable(x) }
+  func copyableUniqueArray(_ x: InlineArray<1, Int>) { takesIterable(x) }
+  func copyableSpan(_ x: Span<Int>) { takesIterable(x) }
+  func copyableMutableSpan(_ x: borrowing MutableSpan<Int>) { takesIterable(x) }
+  func copyableOutputSpan(_ x: borrowing OutputSpan<Int>) { takesIterable(x) }
+
+  func noncopyableInlineArray(_ x: borrowing UniqueArray<NoncopyableInt>) { takesIterable(x) }
+  func noncopyableUniqueArray(_ x: borrowing InlineArray<1, NoncopyableInt>) { takesIterable(x) }
+  func noncopyableSpan(_ x: borrowing Span<NoncopyableInt>) { takesIterable(x) }
+  func noncopyableMutableSpan(_ x: borrowing MutableSpan<NoncopyableInt>) { takesIterable(x) }
+  func noncopyableOutputSpan(_ x: borrowing OutputSpan<NoncopyableInt>) { takesIterable(x) }
+  
+  func rawSpan(_ x: RawSpan) { takesIterable(x) }
+  func mutableRawSpan(_ x: borrowing MutableRawSpan) { takesIterable(x) }
+  func outputRawSpan(_ x: borrowing OutputRawSpan) { takesIterable(x) }
+}
+
 // MARK: - Throwing Iterable tests
 
 #if false // error: lifetime-dependent value escapes its scope


### PR DESCRIPTION
- **Explanation**: Corrects the omitted `~Copyable` constraint that implicitly requires `Copyable` elements for the `OutputSpan: Iterable` conformance.
- **Scope**: This corrects the conformance of `OutputSpan`, which hasn't been part of a Swift release yet.
- **Issues**: rdar://183153655
- **Original PRs**: #90969
- **Risk**: Low. The conformance was only recently added. Any risk comes from running binaries compiled since the conformance was added on a new standard library.
- **Testing**: Unit test added to check this (and other) conformances.
- **Reviewers**: @stephentyrone 