### PR TITLE
[Sema] Avoid invalid @objc fix-it for protocol extension witnesses

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7238,6 +7238,9 @@ WARNING(witness_non_objc_storage_optional,none,
       "optional requirement of '@objc' protocol %2",
       (bool, DeclName, Identifier))
 
+NOTE(witness_non_objc_protocol_extension,none,
+     "members of protocol extensions cannot be exposed to Objective-C", ())
+
 ERROR(nonobjc_not_allowed,none,
       "declaration is %" OBJC_ATTR_SELECT "0, and cannot be marked '@nonobjc'",
       (unsigned))

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5872,8 +5872,13 @@ void ConformanceChecker::resolveValueWitnesses() {
         // The witness must also be @objc.
         if (!witness->isObjC()) {
           bool isOptional =
-            requirement->getAttrs().hasAttribute<OptionalAttr>();
+              requirement->getAttrs().hasAttribute<OptionalAttr>();
           SourceLoc diagLoc = getLocForDiagnosingWitness(Conformance, witness);
+          // Members of protocol extensions cannot be exposed to Objective-C.
+          // Avoid suggesting an invalid @objc attribute for such witnesses.
+          bool canAddObjCAttribute =
+              !isa<ExtensionDecl>(witness->getDeclContext()) ||
+              !witness->getDeclContext()->getSelfProtocolDecl();
           if (auto witnessFunc = dyn_cast<AbstractFunctionDecl>(witness)) {
             auto diagInfo = getObjCMethodDiagInfo(witnessFunc);
             std::optional<InFlightDiagnostic> fixItDiag = C.Diags.diagnose(
@@ -5881,14 +5886,15 @@ void ConformanceChecker::resolveValueWitnesses() {
                 isOptional ? diag::witness_non_objc_optional
                            : diag::witness_non_objc,
                 diagInfo.first, diagInfo.second, Proto->getName());
-            if (diagLoc != witness->getLoc()) {
+            if (canAddObjCAttribute && diagLoc != witness->getLoc()) {
               // If the main diagnostic is emitted on the conformance, we want
               // to attach the fix-it to the note that shows where the
               // witness is defined.
               fixItDiag.emplace(
                   witness->diagnose(diag::make_decl_objc, witness));
             }
-            if (!witness->canInferObjCFromRequirement(requirement)) {
+            if (canAddObjCAttribute &&
+                !witness->canInferObjCFromRequirement(requirement)) {
               fixDeclarationObjCName(
                   fixItDiag.value(), witness,
                   witness->getObjCRuntimeName().value_or(ObjCSelector()),
@@ -5900,14 +5906,15 @@ void ConformanceChecker::resolveValueWitnesses() {
                 isOptional ? diag::witness_non_objc_storage_optional
                            : diag::witness_non_objc_storage,
                 /*isSubscript=*/false, witness->getName(), Proto->getName());
-            if (diagLoc != witness->getLoc()) {
+            if (canAddObjCAttribute && diagLoc != witness->getLoc()) {
               // If the main diagnostic is emitted on the conformance, we want
               // to attach the fix-it to the note that shows where the
               // witness is defined.
               fixItDiag.emplace(
                   witness->diagnose(diag::make_decl_objc, witness));
             }
-            if (!witness->canInferObjCFromRequirement(requirement)) {
+            if (canAddObjCAttribute &&
+                !witness->canInferObjCFromRequirement(requirement)) {
               fixDeclarationObjCName(
                   fixItDiag.value(), witness,
                   witness->getObjCRuntimeName().value_or(ObjCSelector()),
@@ -5919,15 +5926,20 @@ void ConformanceChecker::resolveValueWitnesses() {
                 isOptional ? diag::witness_non_objc_storage_optional
                            : diag::witness_non_objc_storage,
                 /*isSubscript=*/true, witness->getName(), Proto->getName());
-            if (diagLoc != witness->getLoc()) {
+            if (canAddObjCAttribute && diagLoc != witness->getLoc()) {
               // If the main diagnostic is emitted on the conformance, we want
               // to attach the fix-it to the note that shows where the
               // witness is defined.
               fixItDiag.emplace(
                   witness->diagnose(diag::make_decl_objc, witness));
             }
-            fixItDiag->fixItInsert(witness->getAttributeInsertionLoc(false),
-                                   "@objc ");
+            if (canAddObjCAttribute) {
+              fixItDiag->fixItInsert(witness->getAttributeInsertionLoc(false),
+                                     "@objc ");
+            }
+          }
+          if (!canAddObjCAttribute) {
+            witness->diagnose(diag::witness_non_objc_protocol_extension);
           }
 
           // If the requirement is optional, @nonobjc suppresses the

--- a/test/decl/ext/protocol_objc.swift
+++ b/test/decl/ext/protocol_objc.swift
@@ -22,3 +22,22 @@ func testOP1(_ oc1: OC1, ao: AnyObject) {
   // Extension of @objc protocol does not have @objc members.
   ao.extOP1a!() // expected-error{{value of type 'AnyObject' has no member 'extOP1a'; did you mean 'reqOP1a'?}}
 }
+
+// Do not offer to add @objc to a witness in a protocol extension because
+// Objective-C cannot represent members of protocol extensions.
+@objc protocol ObjCProtocolWithExtensionWitnesses {
+  func method() // expected-note {{requirement 'method()' declared here}}
+  var property: Int { get } // expected-note {{requirement 'property' declared here}}
+  subscript(index: Int) -> Int { get } // expected-note {{requirement 'subscript(_:)' declared here}}
+}
+
+extension ObjCProtocolWithExtensionWitnesses {
+  func method() {} // expected-note {{members of protocol extensions cannot be exposed to Objective-C}}
+  var property: Int { 0 } // expected-note {{members of protocol extensions cannot be exposed to Objective-C}}
+  subscript(index: Int) -> Int { index } // expected-note {{members of protocol extensions cannot be exposed to Objective-C}}
+}
+
+class UsesExtensionWitnesses: ObjCProtocolWithExtensionWitnesses {}
+// expected-error@-1 {{non-'@objc' method 'method()' does not satisfy requirement of '@objc' protocol 'ObjCProtocolWithExtensionWitnesses'}}
+// expected-error@-2 {{non-'@objc' property 'property' does not satisfy requirement of '@objc' protocol 'ObjCProtocolWithExtensionWitnesses'}}
+// expected-error@-3 {{non-'@objc' subscript does not satisfy requirement of '@objc' protocol 'ObjCProtocolWithExtensionWitnesses'}}


### PR DESCRIPTION
## Summary

- avoid offering invalid `@objc` fix-its for witnesses declared in protocol
  extensions
- emit an explanatory note for the Objective-C interoperability restriction
- avoid the current assertion in `canInferObjCFromRequirement`
- cover methods, properties, and subscripts with a regression test

Members of protocol extensions cannot be exposed to Objective-C, so adding
`@objc` cannot make these witnesses satisfy requirements of an `@objc`
protocol. The diagnostic now preserves the conformance error and requirement
location while explaining this restriction instead of suggesting an invalid
edit.

## Testing

- full Swift/LLVM build:
  `utils/build-script --skip-build-benchmarks --swift-darwin-supported-archs arm64 --release-debuginfo --swift-disable-dead-stripping -j 6`
- focused test:
  `utils/run-test --build=skip --color=false --lit ../llvm-project/llvm/utils/lit/lit.py --filter='protocol_objc' ../build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/test-macosx-arm64`
  (`1` passed, `0` failed)
- neighboring extension tests:
  `utils/run-test --build=skip --color=false --lit ../llvm-project/llvm/utils/lit/lit.py --filter='decl/ext/' ../build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/test-macosx-arm64`
  (`28` passed, `1` unsupported, `0` failed)
- all declaration tests:
  `utils/run-test --build=skip --color=false --lit ../llvm-project/llvm/utils/lit/lit.py --filter='decl/' ../build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/test-macosx-arm64`
  (`365` passed, `2` unsupported, `0` failed)
- complete Swift lit suite:
  `env PATH='/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin' utils/run-test --build=skip --color=false --lit ../llvm-project/llvm/utils/lit/lit.py ../build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/test-macosx-arm64`
  (`12,441` passed, `710` unsupported, `36` expected failures, `0` failed)
- standalone reproducer: three expected conformance errors, three requirement
  notes, three protocol-extension restriction notes, no `make_decl_objc`
  diagnostic, and no compiler crash

Fixes #49849
