### PR TITLE
[6.4] [Sema] Consolidate missing switch case notes

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7765,17 +7765,16 @@ ERROR(possibly_non_exhaustive_switch,none,
       "the compiler is unable to check that this switch is exhaustive in reasonable time",
       ())
 
-NOTE(missing_several_cases,none,
-     "add "
-     "%select{missing cases|a default clause}0", (bool))
+NOTE(missing_cases,none,
+     "add missing %select{case|cases}0: %1", (bool, StringRef))
+NOTE(missing_default_case,none,
+     "add a default clause", ())
 NOTE(missing_unknown_case,none,
      "handle unknown values using \"@unknown default\"", ())
 
 NOTE(non_exhaustive_switch_drop_unknown,none,
      "remove '@unknown' to handle remaining values", ())
 
-NOTE(missing_particular_case,none,
-     "add missing case: '%0'", (StringRef))
 WARNING(redundant_particular_case,none,
         "case is already handled by previous patterns; consider removing it",())
 WARNING(redundant_particular_literal_case,none,

--- a/include/swift/Migrator/FixitFilter.h
+++ b/include/swift/Migrator/FixitFilter.h
@@ -126,8 +126,8 @@ struct FixitFilter {
         Info.ID == diag::deprecated_any_composition.ID ||
         Info.ID == diag::deprecated_operator_body.ID ||
         Info.ID == diag::unbound_generic_parameter_explicit_fix.ID ||
-        Info.ID == diag::missing_several_cases.ID ||
-        Info.ID == diag::missing_particular_case.ID ||
+        Info.ID == diag::missing_cases.ID ||
+        Info.ID == diag::missing_default_case.ID ||
         Info.ID == diag::missing_unknown_case.ID ||
         Info.ID == diag::paren_void_probably_void.ID ||
         Info.ID == diag::make_decl_objc.ID ||

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -1200,14 +1200,14 @@ namespace {
         OS << tok::kw_default << ":\n" << placeholder << "\n";
         DE.diagnose(startLoc, mainDiagType.value())
           .limitBehaviorIf(downgrade, DiagnosticBehavior::Warning);
-        DE.diagnose(startLoc, diag::missing_several_cases, /*default*/true)
+        DE.diagnose(startLoc, diag::missing_default_case)
           .fixItInsert(insertLoc, buffer.str());
       }
         return;
       case RequiresDefault::SpaceTooLarge: {
         OS << tok::kw_default << ":\n" << "<#fatalError()#>" << "\n";
         DE.diagnose(startLoc, diag::possibly_non_exhaustive_switch);
-        DE.diagnose(startLoc, diag::missing_several_cases, /*default*/true)
+        DE.diagnose(startLoc, diag::missing_default_case)
           .fixItInsert(insertLoc, buffer.str());
       }
         return;
@@ -1292,20 +1292,47 @@ namespace {
       //     case (.some(_), .none):
       //       <#code#>
       //
-      // To also provide actionable output for command line errors, emit notes
-      // like the following:
-      //
-      // missing case '(.none, .some(_))'
-      // missing case '(.some(_), .none)'
+      // We also list the missing cases in the message, up to a given character
+      // limit to avoid being too noisy.
       SmallString<128> missingSeveralCasesFixIt;
-      int diagnosedCases = 0;
+      SmallString<85> caseList;
+
+      unsigned numCases = 0;
+      bool hasUnknownDefault = false;
+      bool listTruncated = false;
+
+      // Add the case name to the diagnostic message, truncating once it reaches
+      // the character limit. Always adds at least one case.
+      auto addCaseStr = [&](StringRef caseStr) {
+        numCases += 1;
+        if (listTruncated)
+          return;
+
+        llvm::SmallString<64> item;
+        {
+          llvm::raw_svector_ostream itemOS(item);
+          itemOS << '\'' << caseStr << '\'';
+        }
+        llvm::raw_svector_ostream caseListOS(caseList);
+        if (caseList.empty()) {
+          caseListOS << item;
+        } else if (caseList.size() + 2 + item.size() <= 80) {
+          caseListOS << ", " << item;
+        } else {
+          caseListOS << ", ...";
+          listTruncated = true;
+        }
+      };
 
       processUncoveredSpaces([&](const Space &space,
                                  bool onlyOneUncoveredSpace) {
         llvm::SmallString<64> fixItBuffer;
         llvm::raw_svector_ostream fixItOS(fixItBuffer);
         if (space.getKind() == SpaceKind::UnknownCase) {
-          fixItOS << "@unknown " << tok::kw_default << ":\n<#fatalError()#>\n";
+          hasUnknownDefault = true;
+          fixItOS << "@unknown " << tok::kw_default;
+          addCaseStr(fixItBuffer);
+          fixItOS << ":\n<#fatalError()#>\n";
           DE.diagnose(startLoc, diag::missing_unknown_case)
               .fixItInsert(insertLoc, fixItBuffer.str());
         } else {
@@ -1313,18 +1340,15 @@ namespace {
           llvm::raw_svector_ostream spaceOS(spaceBuffer);
           space.show(spaceOS);
 
+          addCaseStr(spaceBuffer);
           fixItOS << tok::kw_case << " " << spaceBuffer << ":\n"
                   << placeholder << "\n";
-          DE.diagnose(startLoc, diag::missing_particular_case,
-                      spaceBuffer.str())
-              .fixItInsert(insertLoc, fixItBuffer);
         }
-        diagnosedCases += 1;
         missingSeveralCasesFixIt += fixItBuffer;
       });
 
-      if (diagnosedCases > 1) {
-        DE.diagnose(startLoc, diag::missing_several_cases, false)
+      if ((numCases == 1 && !hasUnknownDefault) || numCases > 1) {
+        DE.diagnose(startLoc, diag::missing_cases, numCases > 1, caseList.str())
             .fixItInsert(insertLoc, missingSeveralCasesFixIt.str());
       }
     }

--- a/test/ClangImporter/availability_open_enums.swift
+++ b/test/ClangImporter/availability_open_enums.swift
@@ -8,9 +8,8 @@ import AvailabilityExtras
 
 func exhaustiveSwitch(e: NSEnumAddedCasesIn2017) {
   switch e { // expected-error{{switch must be exhaustive}}
-    // expected-note@-1{{add missing case: '.newCaseOne'}}
-    // expected-note@-2{{handle unknown values using "@unknown default"}}
-    // expected-note@-3 {{add missing cases}}
+    // expected-note@-1 {{handle unknown values using "@unknown default"}}
+    // expected-note@-2 {{add missing cases: '.newCaseOne', '@unknown default'}}
   case .existingCaseOne:
     return
   case .existingCaseTwo:

--- a/test/ClangImporter/enum-dataflow.swift
+++ b/test/ClangImporter/enum-dataflow.swift
@@ -12,9 +12,7 @@ case .original:
 }
 
 switch aliasOriginal { // expected-error {{switch must be exhaustive}}
-// expected-note@-1 {{add missing case: '.original'}}
-// expected-note@-2 {{add missing case: '.differentValue'}}
-// expected-note@-3 {{add missing cases}}
+// expected-note@-1 {{add missing cases: '.original', '.differentValue'}}
 case .bySameValue:
   break
 }

--- a/test/ClangImporter/swift2_warnings.swift
+++ b/test/ClangImporter/swift2_warnings.swift
@@ -99,9 +99,7 @@ func makeProgress<T: NSProgressReporting>(thing: T) {} // expected-error {{'NSPr
 
 func useLowercasedEnumCase(x: NSRuncingMode) {
   switch x { // expected-error {{switch must be exhaustive}}
-    // expected-note@-1 {{add missing case: '.mince'}}
-    // expected-note@-2 {{add missing case: '.quince'}}
-    // expected-note@-3 {{add missing cases}}
+    // expected-note@-1 {{add missing cases: '.mince', '.quince'}}
     case .Mince: return // expected-error {{'Mince' has been renamed to 'mince'}} {{11-16=mince}}
     case .Quince: return // expected-error {{'Quince' has been renamed to 'quince'}} {{11-17=quince}}
   }

--- a/test/Compatibility/exhaustive_switch.swift
+++ b/test/Compatibility/exhaustive_switch.swift
@@ -365,10 +365,7 @@ enum Runcible {
 
 func checkDiagnosticMinimality(x: Runcible?) {
   switch (x!, x!) { // expected-error {{switch must be exhaustive}}
-  // expected-note@-1 {{add missing case: '(.fork, _)'}}
-  // expected-note@-2 {{add missing case: '(.hat, .hat)'}}
-  // expected-note@-3 {{add missing case: '(_, .fork)'}}
-  // expected-note@-4 {{add missing cases}} {{+11:3-3=case (.fork, _):\n<#code#>\ncase (.hat, .hat):\n<#code#>\ncase (_, .fork):\n<#code#>\n}}
+  // expected-note@-1 {{add missing cases: '(.fork, _)', '(.hat, .hat)', '(_, .fork)'}} {{+8:3-3=case (.fork, _):\n<#code#>\ncase (.hat, .hat):\n<#code#>\ncase (_, .fork):\n<#code#>\n}}
   case (.spoon, .spoon):
     break
   case (.spoon, .hat):
@@ -378,11 +375,7 @@ func checkDiagnosticMinimality(x: Runcible?) {
   }
 
   switch (x!, x!) { // expected-error {{switch must be exhaustive}}
-  // expected-note@-1 {{add missing case: '(.fork, _)'}}
-  // expected-note@-2 {{add missing case: '(.hat, .spoon)'}}
-  // expected-note@-3 {{add missing case: '(.spoon, .hat)'}}
-  // expected-note@-4 {{add missing case: '(_, .fork)'}}
-  // expected-note@-5 {{add missing cases}} {{+10:3-3=case (.fork, _):\n<#code#>\ncase (.hat, .spoon):\n<#code#>\ncase (.spoon, .hat):\n<#code#>\ncase (_, .fork):\n<#code#>\n}}
+  // expected-note@-1 {{add missing cases: '(.fork, _)', '(.hat, .spoon)', '(.spoon, .hat)', '(_, .fork)'}} {{+6:3-3=case (.fork, _):\n<#code#>\ncase (.hat, .spoon):\n<#code#>\ncase (.spoon, .hat):\n<#code#>\ncase (_, .fork):\n<#code#>\n}}
   case (.spoon, .spoon):
     break
   case (.hat, .hat):
@@ -406,8 +399,7 @@ enum LargeSpaceEnum {
 
 func notQuiteBigEnough() -> Bool {
   switch (LargeSpaceEnum.case1, LargeSpaceEnum.case2) { // expected-error {{switch must be exhaustive}}
-  // expected-note@-1 110 {{add missing case:}}
-  // expected-note@-2 {{add missing cases}}
+  // expected-note@-1 {{add missing cases: '(.case10, .case0)', '(.case10, .case1)', '(.case10, .case2)', ...}}
   case (.case0, .case0): return true
   case (.case1, .case1): return true
   case (.case2, .case2): return true
@@ -445,8 +437,7 @@ enum ContainsOverlyLargeEnum {
 
 func quiteBigEnough() -> Bool {
   switch (OverlyLargeSpaceEnum.case1, OverlyLargeSpaceEnum.case2) { // expected-error {{switch must be exhaustive}}
-  // expected-note@-1 132 {{add missing case:}}
-  // expected-note@-2 {{add missing cases}}
+  // expected-note@-1 {{add missing cases: '(.case11, .case0)', '(.case11, .case1)', '(.case11, .case2)', ...}}
   case (.case0, .case0): return true
   case (.case1, .case1): return true
   case (.case2, .case2): return true
@@ -547,7 +538,7 @@ func quiteBigEnough() -> Bool {
   }
 
   // Make sure we haven't just stopped emitting diagnostics.
-  switch OverlyLargeSpaceEnum.case1 { // expected-error {{switch must be exhaustive}} expected-note 12 {{add missing case}} expected-note {{add missing cases}}
+  switch OverlyLargeSpaceEnum.case1 { // expected-error {{switch must be exhaustive}} expected-note {{add missing cases: '.case0', '.case1', '.case2', '.case3', '.case4', '.case5', '.case6', '.case7', ...}}
   }
 }
 
@@ -567,15 +558,13 @@ indirect enum MutuallyRecursive {
 
 func infinitelySized() -> Bool {
   switch (InfinitelySized.one, InfinitelySized.one) { // expected-error {{switch must be exhaustive}}
-  // expected-note@-1 8 {{add missing case:}}
-  // expected-note@-2 {{add missing cases}}
+  // expected-note@-1 {{add missing cases: '(.recur(_), _)', '(.mutualRecur(_, _), _)', '(.two, .one)', ...}}
   case (.one, .one): return true
   case (.two, .two): return true
   }
   
   switch (MutuallyRecursive.one, MutuallyRecursive.one) { // expected-error {{switch must be exhaustive}}
-  // expected-note@-1 8 {{add missing case:}}
-  // expected-note@-2 {{add missing cases}}
+  // expected-note@-1 {{add missing cases: '(.recur(_), _)', '(.mutualRecur(_, _), _)', '(.two, .one)', ...}}
   case (.one, .one): return true
   case (.two, .two): return true
   }
@@ -874,9 +863,7 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
 
   switch value { 
   // expected-warning@-1 {{switch must be exhaustive}} {{none}}
-  // expected-note@-2 {{add missing case: '.a'}} {{+5:3-3=case .a:\n<#code#>\n}} 
-  // expected-note@-3 {{add missing case: '.b'}} {{+5:3-3=case .b:\n<#code#>\n}} 
-  // expected-note@-4 {{add missing cases}} {{+5:3-3=case .a:\n<#code#>\ncase .b:\n<#code#>\n}}
+  // expected-note@-2 {{add missing cases: '.a', '.b'}} {{+3:3-3=case .a:\n<#code#>\ncase .b:\n<#code#>\n}}
   @unknown case _: break
   }
 
@@ -1033,9 +1020,7 @@ public func testNonExhaustiveWithinModule(_ value: NonExhaustive, _ payload: Non
   }
 
   switch value { // expected-warning {{switch must be exhaustive}} {{none}} 
-  // expected-note@-1 {{add missing case: '.a'}} {{+4:3-3=case .a:\n<#code#>\n}} 
-  // expected-note@-2 {{add missing case: '.b'}} {{+4:3-3=case .b:\n<#code#>\n}} 
-  // expected-note@-3 {{add missing cases}} {{+4:3-3=case .a:\n<#code#>\ncase .b:\n<#code#>\n}}
+  // expected-note@-1 {{add missing cases: '.a', '.b'}} {{+2:3-3=case .a:\n<#code#>\ncase .b:\n<#code#>\n}}
   @unknown case _: break
   }
 

--- a/test/FixCode/fixits-empty-switch-multifile.swift
+++ b/test/FixCode/fixits-empty-switch-multifile.swift
@@ -3,9 +3,6 @@
 func foo1(_ e: EMulti) {
   switch e {
 // expected-error@-1 {{switch must be exhaustive}}
-// expected-note@-2 {{add missing case: '.e1'}} {{+6:3-3=case .e1:\n<#code#>\n}}
-// expected-note@-3 {{add missing case: '.e2'}} {{+6:3-3=case .e2:\n<#code#>\n}}
-// expected-note@-4 {{add missing case: '.e3(_)'}} {{+6:3-3=case .e3(_):\n<#code#>\n}}
-// expected-note@-5 {{add missing cases}} {{+6:3-3=case .e1:\n<#code#>\ncase .e2:\n<#code#>\ncase .e3(_):\n<#code#>\n}}
+// expected-note@-2 {{add missing cases: '.e1', '.e2', '.e3(_)'}} {{+3:3-3=case .e1:\n<#code#>\ncase .e2:\n<#code#>\ncase .e3(_):\n<#code#>\n}}
   }
 }

--- a/test/FixCode/fixits-empty-switch.swift
+++ b/test/FixCode/fixits-empty-switch.swift
@@ -9,10 +9,7 @@ enum E1 {
 func foo1(_ e: E1) {
   switch e {
 //expected-error@-1 {{switch must be exhaustive}}
-//expected-note@-2 {{add missing case: '.e1'}} {{+6:3-3=case .e1:\n<#code#>\n}}
-//expected-note@-3 {{add missing case: '.e2'}} {{+6:3-3=case .e2:\n<#code#>\n}}
-//expected-note@-4 {{add missing case: '.e3'}} {{+6:3-3=case .e3:\n<#code#>\n}}
-//expected-note@-5 {{add missing cases}} {{+6:3-3=case .e1:\n<#code#>\ncase .e2:\n<#code#>\ncase .e3:\n<#code#>\n}}
+//expected-note@-2 {{add missing cases: '.e1', '.e2', '.e3'}} {{+3:3-3=case .e1:\n<#code#>\ncase .e2:\n<#code#>\ncase .e3:\n<#code#>\n}}
   }
 }
 

--- a/test/FixCode/fixits-switch-nonfrozen.swift
+++ b/test/FixCode/fixits-switch-nonfrozen.swift
@@ -9,10 +9,7 @@ enum Runcible {
 func checkDiagnosticMinimality(x: Runcible?) {
   switch (x!, x!) {
   // expected-error@-1 {{switch must be exhaustive}}
-  // expected-note@-2 {{add missing case: '(.fork, _)'}} {{+12:3-3=case (.fork, _):\n<#code#>\n}}
-  // expected-note@-3 {{add missing case: '(.hat, .hat)'}} {{+12:3-3=case (.hat, .hat):\n<#code#>\n}}
-  // expected-note@-4 {{add missing case: '(_, .fork)'}} {{+12:3-3=case (_, .fork):\n<#code#>\n}}
-  // expected-note@-5 {{add missing cases}} {{+12:3-3=case (.fork, _):\n<#code#>\ncase (.hat, .hat):\n<#code#>\ncase (_, .fork):\n<#code#>\n}}
+  // expected-note@-2 {{add missing cases: '(.fork, _)', '(.hat, .hat)', '(_, .fork)'}} {{+9:3-3=case (.fork, _):\n<#code#>\ncase (.hat, .hat):\n<#code#>\ncase (_, .fork):\n<#code#>\n}}
   case (.spoon, .spoon):
     break
   case (.spoon, .hat):
@@ -23,11 +20,7 @@ func checkDiagnosticMinimality(x: Runcible?) {
 
   switch (x!, x!) {
   // expected-error@-1 {{switch must be exhaustive}}
-  // expected-note@-2 {{add missing case: '(.fork, _)'}} {{+11:3-3=case (.fork, _):\n<#code#>\n}}
-  // expected-note@-3 {{add missing case: '(.hat, .spoon)'}} {{+11:3-3=case (.hat, .spoon):\n<#code#>\n}}
-  // expected-note@-4 {{add missing case: '(.spoon, .hat)'}} {{+11:3-3=case (.spoon, .hat):\n<#code#>\n}}
-  // expected-note@-5 {{add missing case: '(_, .fork)'}} {{+11:3-3=case (_, .fork):\n<#code#>\n}}
-  // expected-note@-6 {{add missing cases}} {{+11:3-3=case (.fork, _):\n<#code#>\ncase (.hat, .spoon):\n<#code#>\ncase (.spoon, .hat):\n<#code#>\ncase (_, .fork):\n<#code#>\n}} 
+  // expected-note@-2 {{add missing cases: '(.fork, _)', '(.hat, .spoon)', '(.spoon, .hat)', '(_, .fork)'}} {{+7:3-3=case (.fork, _):\n<#code#>\ncase (.hat, .spoon):\n<#code#>\ncase (.spoon, .hat):\n<#code#>\ncase (_, .fork):\n<#code#>\n}}
   case (.spoon, .spoon):
     break
   case (.hat, .hat):
@@ -52,8 +45,7 @@ enum LargeSpaceEnum {
 func notQuiteBigEnough() -> Bool {
   switch (LargeSpaceEnum.case1, LargeSpaceEnum.case2) {
   // expected-error@-1 {{switch must be exhaustive}}
-  // expected-note@-2 110{{add missing case}}
-  // expected-note@-3 {{add missing cases}} {{+15:3-3=case (.case10, .case0):\n<#code#>\ncase (.case10, .case1):\n<#code#>\ncase (.case10, .case2):\n<#code#>\ncase (.case10, .case3):\n<#code#>\ncase (.case10, .case4):\n<#code#>\ncase (.case10, .case5):\n<#code#>\ncase (.case10, .case6):\n<#code#>\ncase (.case10, .case7):\n<#code#>\ncase (.case10, .case8):\n<#code#>\ncase (.case10, .case9):\n<#code#>\ncase (.case9, .case0):\n<#code#>\ncase (.case9, .case1):\n<#code#>\ncase (.case9, .case2):\n<#code#>\ncase (.case9, .case3):\n<#code#>\ncase (.case9, .case4):\n<#code#>\ncase (.case9, .case5):\n<#code#>\ncase (.case9, .case6):\n<#code#>\ncase (.case9, .case7):\n<#code#>\ncase (.case9, .case8):\n<#code#>\ncase (.case9, .case10):\n<#code#>\ncase (.case8, .case0):\n<#code#>\ncase (.case8, .case1):\n<#code#>\ncase (.case8, .case2):\n<#code#>\ncase (.case8, .case3):\n<#code#>\ncase (.case8, .case4):\n<#code#>\ncase (.case8, .case5):\n<#code#>\ncase (.case8, .case6):\n<#code#>\ncase (.case8, .case7):\n<#code#>\ncase (.case8, .case9):\n<#code#>\ncase (.case8, .case10):\n<#code#>\ncase (.case7, .case0):\n<#code#>\ncase (.case7, .case1):\n<#code#>\ncase (.case7, .case2):\n<#code#>\ncase (.case7, .case3):\n<#code#>\ncase (.case7, .case4):\n<#code#>\ncase (.case7, .case5):\n<#code#>\ncase (.case7, .case6):\n<#code#>\ncase (.case7, .case8):\n<#code#>\ncase (.case7, .case9):\n<#code#>\ncase (.case7, .case10):\n<#code#>\ncase (.case6, .case0):\n<#code#>\ncase (.case6, .case1):\n<#code#>\ncase (.case6, .case2):\n<#code#>\ncase (.case6, .case3):\n<#code#>\ncase (.case6, .case4):\n<#code#>\ncase (.case6, .case5):\n<#code#>\ncase (.case6, .case7):\n<#code#>\ncase (.case6, .case8):\n<#code#>\ncase (.case6, .case9):\n<#code#>\ncase (.case6, .case10):\n<#code#>\ncase (.case5, .case0):\n<#code#>\ncase (.case5, .case1):\n<#code#>\ncase (.case5, .case2):\n<#code#>\ncase (.case5, .case3):\n<#code#>\ncase (.case5, .case4):\n<#code#>\ncase (.case5, .case6):\n<#code#>\ncase (.case5, .case7):\n<#code#>\ncase (.case5, .case8):\n<#code#>\ncase (.case5, .case9):\n<#code#>\ncase (.case5, .case10):\n<#code#>\ncase (.case4, .case0):\n<#code#>\ncase (.case4, .case1):\n<#code#>\ncase (.case4, .case2):\n<#code#>\ncase (.case4, .case3):\n<#code#>\ncase (.case4, .case5):\n<#code#>\ncase (.case4, .case6):\n<#code#>\ncase (.case4, .case7):\n<#code#>\ncase (.case4, .case8):\n<#code#>\ncase (.case4, .case9):\n<#code#>\ncase (.case4, .case10):\n<#code#>\ncase (.case3, .case0):\n<#code#>\ncase (.case3, .case1):\n<#code#>\ncase (.case3, .case2):\n<#code#>\ncase (.case3, .case4):\n<#code#>\ncase (.case3, .case5):\n<#code#>\ncase (.case3, .case6):\n<#code#>\ncase (.case3, .case7):\n<#code#>\ncase (.case3, .case8):\n<#code#>\ncase (.case3, .case9):\n<#code#>\ncase (.case3, .case10):\n<#code#>\ncase (.case2, .case0):\n<#code#>\ncase (.case2, .case1):\n<#code#>\ncase (.case2, .case3):\n<#code#>\ncase (.case2, .case4):\n<#code#>\ncase (.case2, .case5):\n<#code#>\ncase (.case2, .case6):\n<#code#>\ncase (.case2, .case7):\n<#code#>\ncase (.case2, .case8):\n<#code#>\ncase (.case2, .case9):\n<#code#>\ncase (.case2, .case10):\n<#code#>\ncase (.case1, .case0):\n<#code#>\ncase (.case1, .case2):\n<#code#>\ncase (.case1, .case3):\n<#code#>\ncase (.case1, .case4):\n<#code#>\ncase (.case1, .case5):\n<#code#>\ncase (.case1, .case6):\n<#code#>\ncase (.case1, .case7):\n<#code#>\ncase (.case1, .case8):\n<#code#>\ncase (.case1, .case9):\n<#code#>\ncase (.case1, .case10):\n<#code#>\ncase (.case0, .case1):\n<#code#>\ncase (.case0, .case2):\n<#code#>\ncase (.case0, .case3):\n<#code#>\ncase (.case0, .case4):\n<#code#>\ncase (.case0, .case5):\n<#code#>\ncase (.case0, .case6):\n<#code#>\ncase (.case0, .case7):\n<#code#>\ncase (.case0, .case8):\n<#code#>\ncase (.case0, .case9):\n<#code#>\ncase (.case0, .case10):\n<#code#>\n}} 
+  // expected-note@-2 {{add missing cases: '(.case10, .case0)', '(.case10, .case1)', '(.case10, .case2)', ...}} {{+14:3-3=case (.case10, .case0):\n<#code#>\ncase (.case10, .case1):\n<#code#>\ncase (.case10, .case2):\n<#code#>\ncase (.case10, .case3):\n<#code#>\ncase (.case10, .case4):\n<#code#>\ncase (.case10, .case5):\n<#code#>\ncase (.case10, .case6):\n<#code#>\ncase (.case10, .case7):\n<#code#>\ncase (.case10, .case8):\n<#code#>\ncase (.case10, .case9):\n<#code#>\ncase (.case9, .case0):\n<#code#>\ncase (.case9, .case1):\n<#code#>\ncase (.case9, .case2):\n<#code#>\ncase (.case9, .case3):\n<#code#>\ncase (.case9, .case4):\n<#code#>\ncase (.case9, .case5):\n<#code#>\ncase (.case9, .case6):\n<#code#>\ncase (.case9, .case7):\n<#code#>\ncase (.case9, .case8):\n<#code#>\ncase (.case9, .case10):\n<#code#>\ncase (.case8, .case0):\n<#code#>\ncase (.case8, .case1):\n<#code#>\ncase (.case8, .case2):\n<#code#>\ncase (.case8, .case3):\n<#code#>\ncase (.case8, .case4):\n<#code#>\ncase (.case8, .case5):\n<#code#>\ncase (.case8, .case6):\n<#code#>\ncase (.case8, .case7):\n<#code#>\ncase (.case8, .case9):\n<#code#>\ncase (.case8, .case10):\n<#code#>\ncase (.case7, .case0):\n<#code#>\ncase (.case7, .case1):\n<#code#>\ncase (.case7, .case2):\n<#code#>\ncase (.case7, .case3):\n<#code#>\ncase (.case7, .case4):\n<#code#>\ncase (.case7, .case5):\n<#code#>\ncase (.case7, .case6):\n<#code#>\ncase (.case7, .case8):\n<#code#>\ncase (.case7, .case9):\n<#code#>\ncase (.case7, .case10):\n<#code#>\ncase (.case6, .case0):\n<#code#>\ncase (.case6, .case1):\n<#code#>\ncase (.case6, .case2):\n<#code#>\ncase (.case6, .case3):\n<#code#>\ncase (.case6, .case4):\n<#code#>\ncase (.case6, .case5):\n<#code#>\ncase (.case6, .case7):\n<#code#>\ncase (.case6, .case8):\n<#code#>\ncase (.case6, .case9):\n<#code#>\ncase (.case6, .case10):\n<#code#>\ncase (.case5, .case0):\n<#code#>\ncase (.case5, .case1):\n<#code#>\ncase (.case5, .case2):\n<#code#>\ncase (.case5, .case3):\n<#code#>\ncase (.case5, .case4):\n<#code#>\ncase (.case5, .case6):\n<#code#>\ncase (.case5, .case7):\n<#code#>\ncase (.case5, .case8):\n<#code#>\ncase (.case5, .case9):\n<#code#>\ncase (.case5, .case10):\n<#code#>\ncase (.case4, .case0):\n<#code#>\ncase (.case4, .case1):\n<#code#>\ncase (.case4, .case2):\n<#code#>\ncase (.case4, .case3):\n<#code#>\ncase (.case4, .case5):\n<#code#>\ncase (.case4, .case6):\n<#code#>\ncase (.case4, .case7):\n<#code#>\ncase (.case4, .case8):\n<#code#>\ncase (.case4, .case9):\n<#code#>\ncase (.case4, .case10):\n<#code#>\ncase (.case3, .case0):\n<#code#>\ncase (.case3, .case1):\n<#code#>\ncase (.case3, .case2):\n<#code#>\ncase (.case3, .case4):\n<#code#>\ncase (.case3, .case5):\n<#code#>\ncase (.case3, .case6):\n<#code#>\ncase (.case3, .case7):\n<#code#>\ncase (.case3, .case8):\n<#code#>\ncase (.case3, .case9):\n<#code#>\ncase (.case3, .case10):\n<#code#>\ncase (.case2, .case0):\n<#code#>\ncase (.case2, .case1):\n<#code#>\ncase (.case2, .case3):\n<#code#>\ncase (.case2, .case4):\n<#code#>\ncase (.case2, .case5):\n<#code#>\ncase (.case2, .case6):\n<#code#>\ncase (.case2, .case7):\n<#code#>\ncase (.case2, .case8):\n<#code#>\ncase (.case2, .case9):\n<#code#>\ncase (.case2, .case10):\n<#code#>\ncase (.case1, .case0):\n<#code#>\ncase (.case1, .case2):\n<#code#>\ncase (.case1, .case3):\n<#code#>\ncase (.case1, .case4):\n<#code#>\ncase (.case1, .case5):\n<#code#>\ncase (.case1, .case6):\n<#code#>\ncase (.case1, .case7):\n<#code#>\ncase (.case1, .case8):\n<#code#>\ncase (.case1, .case9):\n<#code#>\ncase (.case1, .case10):\n<#code#>\ncase (.case0, .case1):\n<#code#>\ncase (.case0, .case2):\n<#code#>\ncase (.case0, .case3):\n<#code#>\ncase (.case0, .case4):\n<#code#>\ncase (.case0, .case5):\n<#code#>\ncase (.case0, .case6):\n<#code#>\ncase (.case0, .case7):\n<#code#>\ncase (.case0, .case8):\n<#code#>\ncase (.case0, .case9):\n<#code#>\ncase (.case0, .case10):\n<#code#>\n}}
   case (.case0, .case0): return true
   case (.case1, .case1): return true
   case (.case2, .case2): return true
@@ -92,8 +84,7 @@ enum ContainsOverlyLargeEnum {
 func quiteBigEnough() -> Bool {
   switch (OverlyLargeSpaceEnum.case1, OverlyLargeSpaceEnum.case2) {
   // expected-error@-1 {{switch must be exhaustive}}
-  // expected-note@-2 132{{add missing case}}
-  // expected-note@-3 {{add missing cases}} {{+16:3-3=case (.case11, .case0):\n<#code#>\ncase (.case11, .case1):\n<#code#>\ncase (.case11, .case2):\n<#code#>\ncase (.case11, .case3):\n<#code#>\ncase (.case11, .case4):\n<#code#>\ncase (.case11, .case5):\n<#code#>\ncase (.case11, .case6):\n<#code#>\ncase (.case11, .case7):\n<#code#>\ncase (.case11, .case8):\n<#code#>\ncase (.case11, .case9):\n<#code#>\ncase (.case11, .case10):\n<#code#>\ncase (.case10, .case0):\n<#code#>\ncase (.case10, .case1):\n<#code#>\ncase (.case10, .case2):\n<#code#>\ncase (.case10, .case3):\n<#code#>\ncase (.case10, .case4):\n<#code#>\ncase (.case10, .case5):\n<#code#>\ncase (.case10, .case6):\n<#code#>\ncase (.case10, .case7):\n<#code#>\ncase (.case10, .case8):\n<#code#>\ncase (.case10, .case9):\n<#code#>\ncase (.case10, .case11):\n<#code#>\ncase (.case9, .case0):\n<#code#>\ncase (.case9, .case1):\n<#code#>\ncase (.case9, .case2):\n<#code#>\ncase (.case9, .case3):\n<#code#>\ncase (.case9, .case4):\n<#code#>\ncase (.case9, .case5):\n<#code#>\ncase (.case9, .case6):\n<#code#>\ncase (.case9, .case7):\n<#code#>\ncase (.case9, .case8):\n<#code#>\ncase (.case9, .case10):\n<#code#>\ncase (.case9, .case11):\n<#code#>\ncase (.case8, .case0):\n<#code#>\ncase (.case8, .case1):\n<#code#>\ncase (.case8, .case2):\n<#code#>\ncase (.case8, .case3):\n<#code#>\ncase (.case8, .case4):\n<#code#>\ncase (.case8, .case5):\n<#code#>\ncase (.case8, .case6):\n<#code#>\ncase (.case8, .case7):\n<#code#>\ncase (.case8, .case9):\n<#code#>\ncase (.case8, .case10):\n<#code#>\ncase (.case8, .case11):\n<#code#>\ncase (.case7, .case0):\n<#code#>\ncase (.case7, .case1):\n<#code#>\ncase (.case7, .case2):\n<#code#>\ncase (.case7, .case3):\n<#code#>\ncase (.case7, .case4):\n<#code#>\ncase (.case7, .case5):\n<#code#>\ncase (.case7, .case6):\n<#code#>\ncase (.case7, .case8):\n<#code#>\ncase (.case7, .case9):\n<#code#>\ncase (.case7, .case10):\n<#code#>\ncase (.case7, .case11):\n<#code#>\ncase (.case6, .case0):\n<#code#>\ncase (.case6, .case1):\n<#code#>\ncase (.case6, .case2):\n<#code#>\ncase (.case6, .case3):\n<#code#>\ncase (.case6, .case4):\n<#code#>\ncase (.case6, .case5):\n<#code#>\ncase (.case6, .case7):\n<#code#>\ncase (.case6, .case8):\n<#code#>\ncase (.case6, .case9):\n<#code#>\ncase (.case6, .case10):\n<#code#>\ncase (.case6, .case11):\n<#code#>\ncase (.case5, .case0):\n<#code#>\ncase (.case5, .case1):\n<#code#>\ncase (.case5, .case2):\n<#code#>\ncase (.case5, .case3):\n<#code#>\ncase (.case5, .case4):\n<#code#>\ncase (.case5, .case6):\n<#code#>\ncase (.case5, .case7):\n<#code#>\ncase (.case5, .case8):\n<#code#>\ncase (.case5, .case9):\n<#code#>\ncase (.case5, .case10):\n<#code#>\ncase (.case5, .case11):\n<#code#>\ncase (.case4, .case0):\n<#code#>\ncase (.case4, .case1):\n<#code#>\ncase (.case4, .case2):\n<#code#>\ncase (.case4, .case3):\n<#code#>\ncase (.case4, .case5):\n<#code#>\ncase (.case4, .case6):\n<#code#>\ncase (.case4, .case7):\n<#code#>\ncase (.case4, .case8):\n<#code#>\ncase (.case4, .case9):\n<#code#>\ncase (.case4, .case10):\n<#code#>\ncase (.case4, .case11):\n<#code#>\ncase (.case3, .case0):\n<#code#>\ncase (.case3, .case1):\n<#code#>\ncase (.case3, .case2):\n<#code#>\ncase (.case3, .case4):\n<#code#>\ncase (.case3, .case5):\n<#code#>\ncase (.case3, .case6):\n<#code#>\ncase (.case3, .case7):\n<#code#>\ncase (.case3, .case8):\n<#code#>\ncase (.case3, .case9):\n<#code#>\ncase (.case3, .case10):\n<#code#>\ncase (.case3, .case11):\n<#code#>\ncase (.case2, .case0):\n<#code#>\ncase (.case2, .case1):\n<#code#>\ncase (.case2, .case3):\n<#code#>\ncase (.case2, .case4):\n<#code#>\ncase (.case2, .case5):\n<#code#>\ncase (.case2, .case6):\n<#code#>\ncase (.case2, .case7):\n<#code#>\ncase (.case2, .case8):\n<#code#>\ncase (.case2, .case9):\n<#code#>\ncase (.case2, .case10):\n<#code#>\ncase (.case2, .case11):\n<#code#>\ncase (.case1, .case0):\n<#code#>\ncase (.case1, .case2):\n<#code#>\ncase (.case1, .case3):\n<#code#>\ncase (.case1, .case4):\n<#code#>\ncase (.case1, .case5):\n<#code#>\ncase (.case1, .case6):\n<#code#>\ncase (.case1, .case7):\n<#code#>\ncase (.case1, .case8):\n<#code#>\ncase (.case1, .case9):\n<#code#>\ncase (.case1, .case10):\n<#code#>\ncase (.case1, .case11):\n<#code#>\ncase (.case0, .case1):\n<#code#>\ncase (.case0, .case2):\n<#code#>\ncase (.case0, .case3):\n<#code#>\ncase (.case0, .case4):\n<#code#>\ncase (.case0, .case5):\n<#code#>\ncase (.case0, .case6):\n<#code#>\ncase (.case0, .case7):\n<#code#>\ncase (.case0, .case8):\n<#code#>\ncase (.case0, .case9):\n<#code#>\ncase (.case0, .case10):\n<#code#>\ncase (.case0, .case11):\n<#code#>\n}}
+  // expected-note@-2 {{add missing cases: '(.case11, .case0)', '(.case11, .case1)', '(.case11, .case2)', ...}} {{+15:3-3=case (.case11, .case0):\n<#code#>\ncase (.case11, .case1):\n<#code#>\ncase (.case11, .case2):\n<#code#>\ncase (.case11, .case3):\n<#code#>\ncase (.case11, .case4):\n<#code#>\ncase (.case11, .case5):\n<#code#>\ncase (.case11, .case6):\n<#code#>\ncase (.case11, .case7):\n<#code#>\ncase (.case11, .case8):\n<#code#>\ncase (.case11, .case9):\n<#code#>\ncase (.case11, .case10):\n<#code#>\ncase (.case10, .case0):\n<#code#>\ncase (.case10, .case1):\n<#code#>\ncase (.case10, .case2):\n<#code#>\ncase (.case10, .case3):\n<#code#>\ncase (.case10, .case4):\n<#code#>\ncase (.case10, .case5):\n<#code#>\ncase (.case10, .case6):\n<#code#>\ncase (.case10, .case7):\n<#code#>\ncase (.case10, .case8):\n<#code#>\ncase (.case10, .case9):\n<#code#>\ncase (.case10, .case11):\n<#code#>\ncase (.case9, .case0):\n<#code#>\ncase (.case9, .case1):\n<#code#>\ncase (.case9, .case2):\n<#code#>\ncase (.case9, .case3):\n<#code#>\ncase (.case9, .case4):\n<#code#>\ncase (.case9, .case5):\n<#code#>\ncase (.case9, .case6):\n<#code#>\ncase (.case9, .case7):\n<#code#>\ncase (.case9, .case8):\n<#code#>\ncase (.case9, .case10):\n<#code#>\ncase (.case9, .case11):\n<#code#>\ncase (.case8, .case0):\n<#code#>\ncase (.case8, .case1):\n<#code#>\ncase (.case8, .case2):\n<#code#>\ncase (.case8, .case3):\n<#code#>\ncase (.case8, .case4):\n<#code#>\ncase (.case8, .case5):\n<#code#>\ncase (.case8, .case6):\n<#code#>\ncase (.case8, .case7):\n<#code#>\ncase (.case8, .case9):\n<#code#>\ncase (.case8, .case10):\n<#code#>\ncase (.case8, .case11):\n<#code#>\ncase (.case7, .case0):\n<#code#>\ncase (.case7, .case1):\n<#code#>\ncase (.case7, .case2):\n<#code#>\ncase (.case7, .case3):\n<#code#>\ncase (.case7, .case4):\n<#code#>\ncase (.case7, .case5):\n<#code#>\ncase (.case7, .case6):\n<#code#>\ncase (.case7, .case8):\n<#code#>\ncase (.case7, .case9):\n<#code#>\ncase (.case7, .case10):\n<#code#>\ncase (.case7, .case11):\n<#code#>\ncase (.case6, .case0):\n<#code#>\ncase (.case6, .case1):\n<#code#>\ncase (.case6, .case2):\n<#code#>\ncase (.case6, .case3):\n<#code#>\ncase (.case6, .case4):\n<#code#>\ncase (.case6, .case5):\n<#code#>\ncase (.case6, .case7):\n<#code#>\ncase (.case6, .case8):\n<#code#>\ncase (.case6, .case9):\n<#code#>\ncase (.case6, .case10):\n<#code#>\ncase (.case6, .case11):\n<#code#>\ncase (.case5, .case0):\n<#code#>\ncase (.case5, .case1):\n<#code#>\ncase (.case5, .case2):\n<#code#>\ncase (.case5, .case3):\n<#code#>\ncase (.case5, .case4):\n<#code#>\ncase (.case5, .case6):\n<#code#>\ncase (.case5, .case7):\n<#code#>\ncase (.case5, .case8):\n<#code#>\ncase (.case5, .case9):\n<#code#>\ncase (.case5, .case10):\n<#code#>\ncase (.case5, .case11):\n<#code#>\ncase (.case4, .case0):\n<#code#>\ncase (.case4, .case1):\n<#code#>\ncase (.case4, .case2):\n<#code#>\ncase (.case4, .case3):\n<#code#>\ncase (.case4, .case5):\n<#code#>\ncase (.case4, .case6):\n<#code#>\ncase (.case4, .case7):\n<#code#>\ncase (.case4, .case8):\n<#code#>\ncase (.case4, .case9):\n<#code#>\ncase (.case4, .case10):\n<#code#>\ncase (.case4, .case11):\n<#code#>\ncase (.case3, .case0):\n<#code#>\ncase (.case3, .case1):\n<#code#>\ncase (.case3, .case2):\n<#code#>\ncase (.case3, .case4):\n<#code#>\ncase (.case3, .case5):\n<#code#>\ncase (.case3, .case6):\n<#code#>\ncase (.case3, .case7):\n<#code#>\ncase (.case3, .case8):\n<#code#>\ncase (.case3, .case9):\n<#code#>\ncase (.case3, .case10):\n<#code#>\ncase (.case3, .case11):\n<#code#>\ncase (.case2, .case0):\n<#code#>\ncase (.case2, .case1):\n<#code#>\ncase (.case2, .case3):\n<#code#>\ncase (.case2, .case4):\n<#code#>\ncase (.case2, .case5):\n<#code#>\ncase (.case2, .case6):\n<#code#>\ncase (.case2, .case7):\n<#code#>\ncase (.case2, .case8):\n<#code#>\ncase (.case2, .case9):\n<#code#>\ncase (.case2, .case10):\n<#code#>\ncase (.case2, .case11):\n<#code#>\ncase (.case1, .case0):\n<#code#>\ncase (.case1, .case2):\n<#code#>\ncase (.case1, .case3):\n<#code#>\ncase (.case1, .case4):\n<#code#>\ncase (.case1, .case5):\n<#code#>\ncase (.case1, .case6):\n<#code#>\ncase (.case1, .case7):\n<#code#>\ncase (.case1, .case8):\n<#code#>\ncase (.case1, .case9):\n<#code#>\ncase (.case1, .case10):\n<#code#>\ncase (.case1, .case11):\n<#code#>\ncase (.case0, .case1):\n<#code#>\ncase (.case0, .case2):\n<#code#>\ncase (.case0, .case3):\n<#code#>\ncase (.case0, .case4):\n<#code#>\ncase (.case0, .case5):\n<#code#>\ncase (.case0, .case6):\n<#code#>\ncase (.case0, .case7):\n<#code#>\ncase (.case0, .case8):\n<#code#>\ncase (.case0, .case9):\n<#code#>\ncase (.case0, .case10):\n<#code#>\ncase (.case0, .case11):\n<#code#>\n}}
   case (.case0, .case0): return true
   case (.case1, .case1): return true
   case (.case2, .case2): return true
@@ -142,30 +133,14 @@ indirect enum MutuallyRecursive {
 func infinitelySized() -> Bool {
   switch (InfinitelySized.one, InfinitelySized.one) {
 // expected-error@-1 {{switch must be exhaustive}}
-// expected-note@-2 {{add missing case: '(.recur(_), _)'}} {{+13:3-3=case (.recur(_), _):\n<#code#>\n}}
-// expected-note@-3 {{add missing case: '(.mutualRecur(_, _), _)'}} {{+13:3-3=case (.mutualRecur(_, _), _):\n<#code#>\n}}
-// expected-note@-4 {{add missing case: '(.two, .one)'}} {{+13:3-3=case (.two, .one):\n<#code#>\n}}
-// expected-note@-5 {{add missing case: '(.recur(_), .mutualRecur(_, _))'}} {{+13:3-3=case (.recur(_), .mutualRecur(_, _)):\n<#code#>\n}}
-// expected-note@-6 {{add missing case: '(.mutualRecur(_, _), .mutualRecur(_, _))'}} {{+13:3-3=case (.mutualRecur(_, _), .mutualRecur(_, _)):\n<#code#>\n}}
-// expected-note@-7 {{add missing case: '(.one, .two)'}} {{+13:3-3=case (.one, .two):\n<#code#>\n}}
-// expected-note@-8 {{add missing case: '(_, .recur(_))'}} {{+13:3-3=case (_, .recur(_)):\n<#code#>\n}}
-// expected-note@-9 {{add missing case: '(_, .mutualRecur(_, _))'}} {{+13:3-3=case (_, .mutualRecur(_, _)):\n<#code#>\n}}
-// expected-note@-10 {{add missing cases}} {{+13:3-3=case (.recur(_), _):\n<#code#>\ncase (.mutualRecur(_, _), _):\n<#code#>\ncase (.two, .one):\n<#code#>\ncase (.recur(_), .mutualRecur(_, _)):\n<#code#>\ncase (.mutualRecur(_, _), .mutualRecur(_, _)):\n<#code#>\ncase (.one, .two):\n<#code#>\ncase (_, .recur(_)):\n<#code#>\ncase (_, .mutualRecur(_, _)):\n<#code#>\n}} 
+// expected-note@-2 {{add missing cases: '(.recur(_), _)', '(.mutualRecur(_, _), _)', '(.two, .one)', ...}} {{+5:3-3=case (.recur(_), _):\n<#code#>\ncase (.mutualRecur(_, _), _):\n<#code#>\ncase (.two, .one):\n<#code#>\ncase (.recur(_), .mutualRecur(_, _)):\n<#code#>\ncase (.mutualRecur(_, _), .mutualRecur(_, _)):\n<#code#>\ncase (.one, .two):\n<#code#>\ncase (_, .recur(_)):\n<#code#>\ncase (_, .mutualRecur(_, _)):\n<#code#>\n}}
   case (.one, .one): return true
   case (.two, .two): return true
   }
   
   switch (MutuallyRecursive.one, MutuallyRecursive.one) {
   // expected-error@-1 {{switch must be exhaustive}}
-  // expected-note@-2 {{add missing case: '(.recur(_), _)'}} {{+13:3-3=case (.recur(_), _):\n<#code#>\n}}
-  // expected-note@-3 {{add missing case: '(.mutualRecur(_, _), _)'}} {{+13:3-3=case (.mutualRecur(_, _), _):\n<#code#>\n}}
-  // expected-note@-4 {{add missing case: '(.two, .one)'}} {{+13:3-3=case (.two, .one):\n<#code#>\n}}
-  // expected-note@-5 {{add missing case: '(.recur(_), .mutualRecur(_, _))'}} {{+13:3-3=case (.recur(_), .mutualRecur(_, _)):\n<#code#>\n}}
-  // expected-note@-6 {{add missing case: '(.mutualRecur(_, _), .mutualRecur(_, _))'}} {{+13:3-3=case (.mutualRecur(_, _), .mutualRecur(_, _)):\n<#code#>\n}}
-  // expected-note@-7 {{add missing case: '(.one, .two)'}} {{+13:3-3=case (.one, .two):\n<#code#>\n}}
-  // expected-note@-8 {{add missing case: '(_, .recur(_))'}} {{+13:3-3=case (_, .recur(_)):\n<#code#>\n}}
-  // expected-note@-9 {{add missing case: '(_, .mutualRecur(_, _))'}} {{+13:3-3=case (_, .mutualRecur(_, _)):\n<#code#>\n}}
-  // expected-note@-10 {{add missing cases}} {{+13:3-3=case (.recur(_), _):\n<#code#>\ncase (.mutualRecur(_, _), _):\n<#code#>\ncase (.two, .one):\n<#code#>\ncase (.recur(_), .mutualRecur(_, _)):\n<#code#>\ncase (.mutualRecur(_, _), .mutualRecur(_, _)):\n<#code#>\ncase (.one, .two):\n<#code#>\ncase (_, .recur(_)):\n<#code#>\ncase (_, .mutualRecur(_, _)):\n<#code#>\n}} 
+  // expected-note@-2 {{add missing cases: '(.recur(_), _)', '(.mutualRecur(_, _), _)', '(.two, .one)', ...}} {{+5:3-3=case (.recur(_), _):\n<#code#>\ncase (.mutualRecur(_, _), _):\n<#code#>\ncase (.two, .one):\n<#code#>\ncase (.recur(_), .mutualRecur(_, _)):\n<#code#>\ncase (.mutualRecur(_, _), .mutualRecur(_, _)):\n<#code#>\ncase (.one, .two):\n<#code#>\ncase (_, .recur(_)):\n<#code#>\ncase (_, .mutualRecur(_, _)):\n<#code#>\n}}
   case (.one, .one): return true
   case (.two, .two): return true
   }
@@ -193,9 +168,8 @@ public enum NonExhaustivePayload {
 public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePayload, for interval: TemporalProxy, flag: Bool) {
   switch value {
   // expected-error@-1 {{switch must be exhaustive}}
-  // expected-note@-2 {{add missing case: '.b'}} {{+6:3-3=case .b:\n<#code#>\n}}
-  // expected-note@-3 {{handle unknown values using "@unknown default"}} {{+6:3-3=@unknown default:\n<#fatalError()#>\n}}
-  // expected-note@-4 {{add missing cases}} {{+6:3-3=case .b:\n<#code#>\n@unknown default:\n<#fatalError()#>\n}}
+  // expected-note@-2 {{handle unknown values using "@unknown default"}} {{+5:3-3=@unknown default:\n<#fatalError()#>\n}}
+  // expected-note@-3 {{add missing cases: '.b', '@unknown default'}} {{+5:3-3=case .b:\n<#code#>\n@unknown default:\n<#fatalError()#>\n}}
   case .a: break
   }
 
@@ -227,9 +201,7 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
 
   switch value {
   // expected-warning@-1 {{switch must be exhaustive}}
-  // expected-note@-2 {{add missing case: '.a'}} {{+5:3-3=case .a:\n<#code#>\n}}
-  // expected-note@-3 {{add missing case: '.b'}} {{+5:3-3=case .b:\n<#code#>\n}}
-  // expected-note@-4 {{add missing cases}} {{+5:3-3=case .a:\n<#code#>\ncase .b:\n<#code#>\n}}
+  // expected-note@-2 {{add missing cases: '.a', '.b'}} {{+3:3-3=case .a:\n<#code#>\ncase .b:\n<#code#>\n}}
   @unknown case _: break
   }
 
@@ -299,11 +271,7 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
 
   switch (value, interval) {
   // expected-error@-1 {{switch covers known cases, but '(NonExhaustive, TemporalProxy)' may have additional unknown values}}
-  // expected-note@-2 {{add missing case: '(_, .milliseconds(_))'}} {{+10:3-3=case (_, .milliseconds(_)):\n<#code#>\n}}
-  // expected-note@-3 {{add missing case: '(_, .microseconds(_))'}} {{+10:3-3=case (_, .microseconds(_)):\n<#code#>\n}}
-  // expected-note@-4 {{add missing case: '(_, .nanoseconds(_))'}} {{+10:3-3=case (_, .nanoseconds(_)):\n<#code#>\n}}
-  // expected-note@-5 {{add missing case: '(_, .never)'}} {{+10:3-3=case (_, .never):\n<#code#>\n}}
-  // expected-note@-6 {{add missing cases}} {{+10:3-3=case (_, .milliseconds(_)):\n<#code#>\ncase (_, .microseconds(_)):\n<#code#>\ncase (_, .nanoseconds(_)):\n<#code#>\ncase (_, .never):\n<#code#>\n}} 
+  // expected-note@-2 {{add missing cases: '(_, .milliseconds(_))', '(_, .microseconds(_))', '(_, .nanoseconds(_))', ...}} {{+6:3-3=case (_, .milliseconds(_)):\n<#code#>\ncase (_, .microseconds(_)):\n<#code#>\ncase (_, .nanoseconds(_)):\n<#code#>\ncase (_, .never):\n<#code#>\n}}
   case (_, .seconds): break
   case (.a, _): break
   case (.b, _): break
@@ -311,11 +279,7 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
 
   switch (value, interval) {
   // expected-error@-1 {{switch covers known cases, but '(NonExhaustive, TemporalProxy)' may have additional unknown values}}
-  // expected-note@-2 {{add missing case: '(_, .seconds(_))'}} {{+10:3-3=case (_, .seconds(_)):\n<#code#>\n}}
-  // expected-note@-3 {{add missing case: '(_, .milliseconds(_))'}} {{+10:3-3=case (_, .milliseconds(_)):\n<#code#>\n}}
-  // expected-note@-4 {{add missing case: '(_, .microseconds(_))'}} {{+10:3-3=case (_, .microseconds(_)):\n<#code#>\n}}
-  // expected-note@-5 {{add missing case: '(_, .nanoseconds(_))'}} {{+10:3-3=case (_, .nanoseconds(_)):\n<#code#>\n}}
-  // expected-note@-6 {{add missing cases}} {{+10:3-3=case (_, .seconds(_)):\n<#code#>\ncase (_, .milliseconds(_)):\n<#code#>\ncase (_, .microseconds(_)):\n<#code#>\ncase (_, .nanoseconds(_)):\n<#code#>\n}} 
+  // expected-note@-2 {{add missing cases: '(_, .seconds(_))', '(_, .milliseconds(_))', '(_, .microseconds(_))', ...}} {{+6:3-3=case (_, .seconds(_)):\n<#code#>\ncase (_, .milliseconds(_)):\n<#code#>\ncase (_, .microseconds(_)):\n<#code#>\ncase (_, .nanoseconds(_)):\n<#code#>\n}}
   case (_, .never): break
   case (.a, _): break
   case (.b, _): break
@@ -324,9 +288,8 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
   // Test payloaded enums.
   switch payload {
   // expected-error@-1 {{switch must be exhaustive}}
-  // expected-note@-2 {{add missing case: '.b(_)'}} {{+6:3-3=case .b(_):\n<#code#>\n}}
-  // expected-note@-3 {{handle unknown values using "@unknown default"}} {{+6:3-3=@unknown default:\n<#fatalError()#>\n}}
-  // expected-note@-4 {{add missing cases}} {{+6:3-3=case .b(_):\n<#code#>\n@unknown default:\n<#fatalError()#>\n}}
+  // expected-note@-2 {{handle unknown values using "@unknown default"}} {{+5:3-3=@unknown default:\n<#fatalError()#>\n}}
+  // expected-note@-3 {{add missing cases: '.b(_)', '@unknown default'}} {{+5:3-3=case .b(_):\n<#code#>\n@unknown default:\n<#fatalError()#>\n}}
   case .a: break
   }
 
@@ -358,9 +321,8 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
 
   switch payload {
   // expected-error@-1 {{switch must be exhaustive}}
-  // expected-note@-2 {{add missing case: '.b(true)'}} {{+7:3-3=case .b(true):\n<#code#>\n}}
-  // expected-note@-3 {{handle unknown values using "@unknown default"}} {{+7:3-3=@unknown default:\n<#fatalError()#>\n}}
-  // expected-note@-4 {{add missing cases}} {{+7:3-3=case .b(true):\n<#code#>\n@unknown default:\n<#fatalError()#>\n}}
+  // expected-note@-2 {{handle unknown values using "@unknown default"}} {{+6:3-3=@unknown default:\n<#fatalError()#>\n}}
+  // expected-note@-3 {{add missing cases: '.b(true)', '@unknown default'}} {{+6:3-3=case .b(true):\n<#code#>\n@unknown default:\n<#fatalError()#>\n}}
   case .a: break
   case .b(false): break
   }

--- a/test/FixCode/fixits-switch.swift
+++ b/test/FixCode/fixits-switch.swift
@@ -10,10 +10,7 @@ enum E1 : Int {
 func foo1(_ e : E1) -> Int {
   switch(e) {
   // expected-error@-1 {{switch must be exhaustive}}
-  // expected-note@-2 {{add missing case: '.e2'}} {{+8:3-3=case .e2:\n<#code#>\n}}
-  // expected-note@-3 {{add missing case: '.e3'}} {{+8:3-3=case .e3:\n<#code#>\n}}
-  // expected-note@-4 {{add missing case: '.e4'}} {{+8:3-3=case .e4:\n<#code#>\n}}
-  // expected-note@-5 {{add missing cases}} {{+8:3-3=case .e2:\n<#code#>\ncase .e3:\n<#code#>\ncase .e4:\n<#code#>\n}}
+  // expected-note@-2 {{add missing cases: '.e2', '.e3', '.e4'}} {{+5:3-3=case .e2:\n<#code#>\ncase .e3:\n<#code#>\ncase .e4:\n<#code#>\n}}
   case .e1:
     return 1
   }
@@ -52,15 +49,7 @@ enum E2 {
 func foo4(_ e : E2) -> Int {
   switch e {
   // expected-error@-1 {{switch must be exhaustive}}
-  // expected-note@-2 {{add missing case: '.e1(a: let a, s: let s)'}} {{+13:3-3=case .e1(a: let a, s: let s):\n<#code#>\n}}
-  // expected-note@-3 {{add missing case: '.e3(a: let a)'}} {{+13:3-3=case .e3(a: let a):\n<#code#>\n}}
-  // expected-note@-4 {{add missing case: '.e4(_)'}} {{+13:3-3=case .e4(_):\n<#code#>\n}}
-  // expected-note@-5 {{add missing case: '.e5(_, _)'}} {{+13:3-3=case .e5(_, _):\n<#code#>\n}}
-  // expected-note@-6 {{add missing case: '.e6(a: let a, _)'}} {{+13:3-3=case .e6(a: let a, _):\n<#code#>\n}}
-  // expected-note@-7 {{add missing case: '.e7'}} {{+13:3-3=case .e7:\n<#code#>\n}}
-  // expected-note@-8 {{add missing case: '.e8(a: let a, _, _)'}} {{+13:3-3=case .e8(a: let a, _, _):\n<#code#>\n}}
-  // expected-note@-9 {{add missing case: '.e9(_, _, _)'}} {{+13:3-3=case .e9(_, _, _):\n<#code#>\n}}
-  // expected-note@-10 {{add missing cases}} {{+13:3-3=case .e1(a: let a, s: let s):\n<#code#>\ncase .e3(a: let a):\n<#code#>\ncase .e4(_):\n<#code#>\ncase .e5(_, _):\n<#code#>\ncase .e6(a: let a, _):\n<#code#>\ncase .e7:\n<#code#>\ncase .e8(a: let a, _, _):\n<#code#>\ncase .e9(_, _, _):\n<#code#>\n}}
+  // expected-note@-2 {{add missing cases: '.e1(a: let a, s: let s)', '.e3(a: let a)', '.e4(_)', '.e5(_, _)', ...}} {{+5:3-3=case .e1(a: let a, s: let s):\n<#code#>\ncase .e3(a: let a):\n<#code#>\ncase .e4(_):\n<#code#>\ncase .e5(_, _):\n<#code#>\ncase .e6(a: let a, _):\n<#code#>\ncase .e7:\n<#code#>\ncase .e8(a: let a, _, _):\n<#code#>\ncase .e9(_, _, _):\n<#code#>\n}}
   case .e2:
     return 1
   }
@@ -69,11 +58,7 @@ func foo4(_ e : E2) -> Int {
 func foo5(_ e : E1) -> Int {
   switch e {
   // expected-error@-1 {{switch must be exhaustive}}
-  // expected-note@-2 {{add missing case: '.e1'}} {{+9:3-3=case .e1:\n<#code#>\n}}
-  // expected-note@-3 {{add missing case: '.e2'}} {{+9:3-3=case .e2:\n<#code#>\n}}
-  // expected-note@-4 {{add missing case: '.e3'}} {{+9:3-3=case .e3:\n<#code#>\n}}
-  // expected-note@-5 {{add missing case: '.e4'}} {{+9:3-3=case .e4:\n<#code#>\n}}
-  // expected-note@-6 {{add missing cases}} {{+9:3-3=case .e1:\n<#code#>\ncase .e2:\n<#code#>\ncase .e3:\n<#code#>\ncase .e4:\n<#code#>\n}}
+  // expected-note@-2 {{add missing cases: '.e1', '.e2', '.e3', '.e4'}} {{+5:3-3=case .e1:\n<#code#>\ncase .e2:\n<#code#>\ncase .e3:\n<#code#>\ncase .e4:\n<#code#>\n}}
   case _ where e.rawValue > 0:
     return 1
   }
@@ -82,15 +67,7 @@ func foo5(_ e : E1) -> Int {
 func foo6(_ e : E2) -> Int {
   switch e {
   // expected-error@-1 {{switch must be exhaustive}}
-  // expected-note@-2 {{add missing case: '.e2(a: let a)'}} {{+13:3-3=case .e2(a: let a):\n<#code#>\n}}
-  // expected-note@-3 {{add missing case: '.e3(a: let a)'}} {{+13:3-3=case .e3(a: let a):\n<#code#>\n}}
-  // expected-note@-4 {{add missing case: '.e4(_)'}} {{+13:3-3=case .e4(_):\n<#code#>\n}}
-  // expected-note@-5 {{add missing case: '.e5(_, _)'}} {{+13:3-3=case .e5(_, _):\n<#code#>\n}}
-  // expected-note@-6 {{add missing case: '.e6(a: let a, _)'}} {{+13:3-3=case .e6(a: let a, _):\n<#code#>\n}}
-  // expected-note@-7 {{add missing case: '.e7'}} {{+13:3-3=case .e7:\n<#code#>\n}}
-  // expected-note@-8 {{add missing case: '.e8(a: let a, _, _)'}} {{+13:3-3=case .e8(a: let a, _, _):\n<#code#>\n}}
-  // expected-note@-9 {{add missing case: '.e9(_, _, _)'}} {{+13:3-3=case .e9(_, _, _):\n<#code#>\n}}
-  // expected-note@-10 {{add missing cases}} {{+13:3-3=case .e2(a: let a):\n<#code#>\ncase .e3(a: let a):\n<#code#>\ncase .e4(_):\n<#code#>\ncase .e5(_, _):\n<#code#>\ncase .e6(a: let a, _):\n<#code#>\ncase .e7:\n<#code#>\ncase .e8(a: let a, _, _):\n<#code#>\ncase .e9(_, _, _):\n<#code#>\n}}
+  // expected-note@-2 {{add missing cases: '.e2(a: let a)', '.e3(a: let a)', '.e4(_)', '.e5(_, _)', '.e6(a: let a, _)', ...}} {{+5:3-3=case .e2(a: let a):\n<#code#>\ncase .e3(a: let a):\n<#code#>\ncase .e4(_):\n<#code#>\ncase .e5(_, _):\n<#code#>\ncase .e6(a: let a, _):\n<#code#>\ncase .e7:\n<#code#>\ncase .e8(a: let a, _, _):\n<#code#>\ncase .e9(_, _, _):\n<#code#>\n}}
   case let .e1(x, y):
     return x + y
   }
@@ -99,14 +76,7 @@ func foo6(_ e : E2) -> Int {
 func foo7(_ e : E2) -> Int {
   switch e {
   // expected-error@-1 {{switch must be exhaustive}}
-  // expected-note@-2 {{add missing case: '.e2(a: let a)'}} {{+13:3-3=case .e2(a: let a):\n<#code#>\n}}
-  // expected-note@-3 {{add missing case: '.e4(_)'}} {{+13:3-3=case .e4(_):\n<#code#>\n}}
-  // expected-note@-4 {{add missing case: '.e5(_, _)'}} {{+13:3-3=case .e5(_, _):\n<#code#>\n}}
-  // expected-note@-5 {{add missing case: '.e6(a: let a, _)'}} {{+13:3-3=case .e6(a: let a, _):\n<#code#>\n}}
-  // expected-note@-6 {{add missing case: '.e7'}} {{+13:3-3=case .e7:\n<#code#>\n}}
-  // expected-note@-7 {{add missing case: '.e8(a: let a, _, _)'}} {{+13:3-3=case .e8(a: let a, _, _):\n<#code#>\n}}
-  // expected-note@-8 {{add missing case: '.e9(_, _, _)'}} {{+13:3-3=case .e9(_, _, _):\n<#code#>\n}}
-  // expected-note@-9 {{add missing cases}} {{+13:3-3=case .e2(a: let a):\n<#code#>\ncase .e4(_):\n<#code#>\ncase .e5(_, _):\n<#code#>\ncase .e6(a: let a, _):\n<#code#>\ncase .e7:\n<#code#>\ncase .e8(a: let a, _, _):\n<#code#>\ncase .e9(_, _, _):\n<#code#>\n}}
+  // expected-note@-2 {{add missing cases: '.e2(a: let a)', '.e4(_)', '.e5(_, _)', '.e6(a: let a, _)', '.e7', ...}} {{+6:3-3=case .e2(a: let a):\n<#code#>\ncase .e4(_):\n<#code#>\ncase .e5(_, _):\n<#code#>\ncase .e6(a: let a, _):\n<#code#>\ncase .e7:\n<#code#>\ncase .e8(a: let a, _, _):\n<#code#>\ncase .e9(_, _, _):\n<#code#>\n}}
   case .e2(1): return 0
   case .e1: return 0
   case .e3: return 0

--- a/test/Parse/matching_patterns.swift
+++ b/test/Parse/matching_patterns.swift
@@ -164,9 +164,7 @@ struct ContainsEnum {
 
   func member(_ n: Possible<Int>) {
     switch n { // expected-error {{switch must be exhaustive}}
-    // expected-note@-1 {{missing case: '.Mere(_)'}}
-    // expected-note@-2 {{missing case: '.Twain(_, _)'}}
-    // expected-note@-3 {{add missing cases}}
+    // expected-note@-1 {{add missing cases: '.Mere(_)', '.Twain(_, _)'}}
     case ContainsEnum.Possible<Int>.Naught,
          ContainsEnum.Possible.Naught, // expected-warning {{case is already handled by previous patterns; consider removing it}}
          Possible<Int>.Naught, // expected-warning {{case is already handled by previous patterns; consider removing it}}
@@ -179,9 +177,7 @@ struct ContainsEnum {
 
 func nonmemberAccessesMemberType(_ n: ContainsEnum.Possible<Int>) {
   switch n { // expected-error {{switch must be exhaustive}}
-  // expected-note@-1 {{missing case: '.Mere(_)'}}
-  // expected-note@-2 {{missing case: '.Twain(_, _)'}}
-  // expected-note@-3 {{add missing cases}}
+  // expected-note@-1 {{add missing cases: '.Mere(_)', '.Twain(_, _)'}}
   case ContainsEnum.Possible<Int>.Naught,
        .Naught: // expected-warning {{case is already handled by previous patterns; consider removing it}}
     ()

--- a/test/Parse/matching_patterns_reference_bindings.swift
+++ b/test/Parse/matching_patterns_reference_bindings.swift
@@ -184,9 +184,7 @@ struct ContainsEnum {
 
   func member(_ n: Possible<Int>) {
     switch n { // expected-error {{switch must be exhaustive}}
-    // expected-note@-1 {{missing case: '.Mere(_)'}}
-    // expected-note@-2 {{missing case: '.Twain(_, _)'}}
-    // expected-note@-3 {{add missing cases}}
+    // expected-note@-1 {{add missing cases: '.Mere(_)', '.Twain(_, _)'}}
     case ContainsEnum.Possible<Int>.Naught,
          ContainsEnum.Possible.Naught, // expected-warning {{case is already handled by previous patterns; consider removing it}}
          Possible<Int>.Naught, // expected-warning {{case is already handled by previous patterns; consider removing it}}
@@ -199,9 +197,7 @@ struct ContainsEnum {
 
 func nonmemberAccessesMemberType(_ n: ContainsEnum.Possible<Int>) {
   switch n { // expected-error {{switch must be exhaustive}}
-  // expected-note@-1 {{missing case: '.Mere(_)'}}
-  // expected-note@-2 {{missing case: '.Twain(_, _)'}}
-  // expected-note@-3 {{add missing cases}}
+  // expected-note@-1 {{add missing cases: '.Mere(_)', '.Twain(_, _)'}}
   case ContainsEnum.Possible<Int>.Naught,
        .Naught: // expected-warning {{case is already handled by previous patterns; consider removing it}}
     ()

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -405,10 +405,7 @@ enum Runcible {
 
 func checkDiagnosticMinimality(x: Runcible?) {
   switch (x!, x!) { // expected-error {{switch must be exhaustive}}
-  // expected-note@-1 {{add missing case: '(.fork, _)'}}
-  // expected-note@-2 {{add missing case: '(.hat, .hat)'}}
-  // expected-note@-3 {{add missing case: '(_, .fork)'}}
-  // expected-note@-4 {{add missing cases}}
+  // expected-note@-1 {{add missing cases: '(.fork, _)', '(.hat, .hat)', '(_, .fork)'}}
   case (.spoon, .spoon):
     break
   case (.spoon, .hat):
@@ -418,11 +415,7 @@ func checkDiagnosticMinimality(x: Runcible?) {
   }
 
   switch (x!, x!) { // expected-error {{switch must be exhaustive}}
-  // expected-note@-1 {{add missing case: '(.fork, _)'}}
-  // expected-note@-2 {{add missing case: '(.hat, .spoon)'}}
-  // expected-note@-3 {{add missing case: '(.spoon, .hat)'}}
-  // expected-note@-4 {{add missing case: '(_, .fork)'}}
-  // expected-note@-5 {{add missing cases}}
+  // expected-note@-1 {{add missing cases: '(.fork, _)', '(.hat, .spoon)', '(.spoon, .hat)', '(_, .fork)'}}
   case (.spoon, .spoon):
     break
   case (.hat, .hat):
@@ -446,15 +439,13 @@ indirect enum MutuallyRecursive {
 
 func infinitelySized() -> Bool {
   switch (InfinitelySized.one, InfinitelySized.one) { // expected-error {{switch must be exhaustive}}
-  // expected-note@-1 8 {{add missing case:}}
-  // expected-note@-2 {{add missing cases}}
+  // expected-note@-1 {{add missing cases: '(.recur(_), _)', '(.mutualRecur(_, _), _)', '(.two, .one)', ...}}
   case (.one, .one): return true
   case (.two, .two): return true
   }
   
   switch (MutuallyRecursive.one, MutuallyRecursive.one) { // expected-error {{switch must be exhaustive}}
-  // expected-note@-1 8 {{add missing case:}}
-  // expected-note@-2 {{add missing cases}}
+  // expected-note@-1 {{add missing cases: '(.recur(_), _)', '(.mutualRecur(_, _), _)', '(.two, .one)', ...}}
   case (.one, .one): return true
   case (.two, .two): return true
   }
@@ -474,9 +465,7 @@ do {
 
   switch (bool1, (bool2, bool4, bool6, bool8), (bool3, bool5, bool7, bool9)) {
   // expected-error@-1 {{switch must be exhaustive}}
-  // expected-note@-2 {{add missing case: '(false, (_, false, true, _), (_, true, _, _))'}}
-  // expected-note@-3 {{add missing case: '(_, (_, true, _, _), (_, false, true, _))'}}
-  // expected-note@-4 {{add missing cases}}
+  // expected-note@-2 {{add missing cases: '(false, (_, false, true, _), (_, true, _, _))', ...}}
   case (true, (_, _, _, _), (_, true, true, _)):
     break
   case (true, (_, _, _, _), (_, _, false, _)):
@@ -816,9 +805,8 @@ public enum NonExhaustivePayload {
 public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePayload, for interval: TemporalProxy, flag: Bool) {
   switch value { 
   // expected-error@-1 {{switch must be exhaustive}} {{none}} 
-  // expected-note@-2 {{add missing case: '.b'}} {{+6:3-3=case .b:\n<#code#>\n}}
-  // expected-note@-3 {{handle unknown values using "@unknown default"}} {{+6:3-3=@unknown default:\n<#fatalError()#>\n}}
-  // expected-note@-4 {{add missing cases}} {{+6:3-3=case .b:\n<#code#>\n@unknown default:\n<#fatalError()#>\n}}
+  // expected-note@-2 {{handle unknown values using "@unknown default"}} {{+5:3-3=@unknown default:\n<#fatalError()#>\n}}
+  // expected-note@-3 {{add missing cases: '.b', '@unknown default'}} {{+5:3-3=case .b:\n<#code#>\n@unknown default:\n<#fatalError()#>\n}}
   case .a: break
   }
 
@@ -846,9 +834,7 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
 
   switch value { 
   // expected-warning@-1 {{switch must be exhaustive}} {{none}} 
-  // expected-note@-2 {{add missing case: '.a'}} {{+5:3-3=case .a:\n<#code#>\n}}
-  // expected-note@-3 {{add missing case: '.b'}} {{+5:3-3=case .b:\n<#code#>\n}}
-  // expected-note@-4 {{add missing cases}} {{+5:3-3=case .a:\n<#code#>\ncase .b:\n<#code#>\n}}
+  // expected-note@-2 {{add missing cases: '.a', '.b'}} {{+3:3-3=case .a:\n<#code#>\ncase .b:\n<#code#>\n}}
   @unknown case _: break
   }
 
@@ -916,9 +902,8 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
   // Test payloaded enums.
   switch payload { 
   // expected-error@-1 {{switch must be exhaustive}} {{none}} 
-  // expected-note@-2 {{add missing case: '.b(_)'}} {{+6:3-3=case .b(_):\n<#code#>\n}}
-  // expected-note@-3 {{handle unknown values using "@unknown default"}} {{+6:3-3=@unknown default:\n<#fatalError()#>\n}}
-  // expected-note@-4 {{add missing cases}} {{+6:3-3=case .b(_):\n<#code#>\n@unknown default:\n<#fatalError()#>\n}}
+  // expected-note@-2 {{handle unknown values using "@unknown default"}} {{+5:3-3=@unknown default:\n<#fatalError()#>\n}}
+  // expected-note@-3 {{add missing cases: '.b(_)', '@unknown default'}} {{+5:3-3=case .b(_):\n<#code#>\n@unknown default:\n<#fatalError()#>\n}}
   case .a: break
   }
 
@@ -946,9 +931,8 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
 
   switch payload { 
   // expected-error@-1 {{switch must be exhaustive}} {{none}} 
-  // expected-note@-2 {{add missing case: '.b(true)'}} {{+7:3-3=case .b(true):\n<#code#>\n}}
-  // expected-note@-3 {{handle unknown values using "@unknown default"}} {{+7:3-3=@unknown default:\n<#fatalError()#>\n}}
-  // expected-note@-4 {{add missing cases}} {{+7:3-3=case .b(true):\n<#code#>\n@unknown default:\n<#fatalError()#>\n}}
+  // expected-note@-2 {{handle unknown values using "@unknown default"}} {{+6:3-3=@unknown default:\n<#fatalError()#>\n}}
+  // expected-note@-3 {{add missing cases: '.b(true)', '@unknown default'}} {{+6:3-3=case .b(true):\n<#code#>\n@unknown default:\n<#fatalError()#>\n}}
   case .a: break
   case .b(false): break
   }
@@ -1014,9 +998,7 @@ public func testNonExhaustiveWithinModule(_ value: NonExhaustive, _ payload: Non
 
   switch value { 
   // expected-warning@-1 {{switch must be exhaustive}} {{none}} 
-  // expected-note@-2 {{add missing case: '.a'}} {{+5:3-3=case .a:\n<#code#>\n}} 
-  // expected-note@-3 {{add missing case: '.b'}} {{+5:3-3=case .b:\n<#code#>\n}}
-  // expected-note@-4 {{add missing cases}} {{+5:3-3=case .a:\n<#code#>\ncase .b:\n<#code#>\n}}
+  // expected-note@-2 {{add missing cases: '.a', '.b'}} {{+3:3-3=case .a:\n<#code#>\ncase .b:\n<#code#>\n}}
   @unknown case _: break
   }
 
@@ -1261,34 +1243,25 @@ public enum E_54081 {
   func testNotRequired(_ value: NonExhaustive, _ value2: FrozenEnum, _ value3: FrozenSameModule) {
     switch value {
       // expected-error@-1 {{switch must be exhaustive}}
-      // expected-note@-2 {{add missing case: '.a'}}
-      // expected-note@-3 {{add missing case: '.b'}}
-      // expected-note@-4 {{add missing cases}}
+      // expected-note@-2 {{add missing cases: '.a', '.b'}}
       // Do not suggest adding '@unknown default'
     }
     
     switch value2 {
       // expected-error@-1 {{switch must be exhaustive}}
-      // expected-note@-2 {{add missing case: '.a'}}
-      // expected-note@-3 {{add missing case: '.b'}}
-      // expected-note@-4 {{add missing case: '.c'}}
-      // expected-note@-5 {{add missing cases}}
+      // expected-note@-2 {{add missing cases: '.a', '.b', '.c'}}
     }
     
     switch value3 {
       // expected-error@-1 {{switch must be exhaustive}}
-      // expected-note@-2 {{add missing case: '.a'}}
-      // expected-note@-3 {{add missing case: '.b'}}
-      // expected-note@-4 {{add missing cases}}
+      // expected-note@-2 {{add missing cases: '.a', '.b'}}
     }
   }
   
   @inlinable public func testNotRequired2(_ value: FrozenSameModule) {
     switch value {
       // expected-error@-1 {{switch must be exhaustive}}
-      // expected-note@-2 {{add missing case: '.a'}}
-      // expected-note@-3 {{add missing case: '.b'}}
-      // expected-note@-4 {{add missing cases}}
+      // expected-note@-2 {{add missing cases: '.a', '.b'}}
     }
   }
   
@@ -1297,10 +1270,8 @@ public enum E_54081 {
   @inlinable public func testRequired(_ value: NonExhaustive) {
     switch value {
       // expected-error@-1 {{switch must be exhaustive}}
-      // expected-note@-2 {{add missing case: '.a'}}
-      // expected-note@-3 {{add missing case: '.b'}}
-      // expected-note@-4 {{handle unknown values using "@unknown default"}}
-      // expected-note@-5 {{add missing cases}}
+      // expected-note@-2 {{handle unknown values using "@unknown default"}}
+      // expected-note@-3 {{add missing cases: '.a', '.b', '@unknown default'}}
     }
   }
 }

--- a/test/Sema/exhaustive_switch_debugger.swift
+++ b/test/Sema/exhaustive_switch_debugger.swift
@@ -15,9 +15,8 @@ public enum NonExhaustivePayload {
 public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePayload, flag: Bool) {
   switch value { 
   // expected-error@-1 {{switch must be exhaustive}} {{none}} 
-  // expected-note@-2 {{add missing case: '.b'}} {{+6:3-3=case .b:\n<#code#>\n}}
-  // expected-note@-3 {{handle unknown values using "@unknown default"}} {{+6:3-3=@unknown default:\n<#fatalError()#>\n}}
-  // expected-note@-4 {{add missing cases}} {{+6:3-3=case .b:\n<#code#>\n@unknown default:\n<#fatalError()#>\n}}
+  // expected-note@-2 {{handle unknown values using "@unknown default"}} {{+5:3-3=@unknown default:\n<#fatalError()#>\n}}
+  // expected-note@-3 {{add missing cases: '.b', '@unknown default'}} {{+5:3-3=case .b:\n<#code#>\n@unknown default:\n<#fatalError()#>\n}}
   case .a: break
   }
 
@@ -45,9 +44,7 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
 
   switch value { 
   // expected-warning@-1 {{switch must be exhaustive}} {{none}} 
-  // expected-note@-2 {{add missing case: '.a'}} {{+5:3-3=case .a:\n<#code#>\n}}
-  // expected-note@-3 {{add missing case: '.b'}} {{+5:3-3=case .b:\n<#code#>\n}}
-  // expected-note@-4 {{add missing cases}} {{+5:3-3=case .a:\n<#code#>\ncase .b:\n<#code#>\n}}
+  // expected-note@-2 {{add missing cases: '.a', '.b'}} {{+3:3-3=case .a:\n<#code#>\ncase .b:\n<#code#>\n}}
   @unknown case _: break
   }
 
@@ -83,9 +80,8 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
   // Test payloaded enums.
   switch payload { 
   // expected-error@-1 {{switch must be exhaustive}} {{none}} 
-  // expected-note@-2 {{add missing case: '.b(_)'}} {{+6:3-3=case .b(_):\n<#code#>\n}}
-  // expected-note@-3 {{handle unknown values using "@unknown default"}} {{+6:3-3=@unknown default:\n<#fatalError()#>\n}}
-  // expected-note@-4 {{add missing cases}} {{+6:3-3=case .b(_):\n<#code#>\n@unknown default:\n<#fatalError()#>\n}}
+  // expected-note@-2 {{handle unknown values using "@unknown default"}} {{+5:3-3=@unknown default:\n<#fatalError()#>\n}}
+  // expected-note@-3 {{add missing cases: '.b(_)', '@unknown default'}} {{+5:3-3=case .b(_):\n<#code#>\n@unknown default:\n<#fatalError()#>\n}}
   case .a: break
   }
 
@@ -113,9 +109,8 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
 
   switch payload { 
   // expected-error@-1 {{switch must be exhaustive}} {{none}} 
-  // expected-note@-2 {{add missing case: '.b(true)'}} {{+7:3-3=case .b(true):\n<#code#>\n}}
-  // expected-note@-3 {{handle unknown values using "@unknown default"}} {{+7:3-3=@unknown default:\n<#fatalError()#>\n}}
-  // expected-note@-4 {{add missing cases}} {{+7:3-3=case .b(true):\n<#code#>\n@unknown default:\n<#fatalError()#>\n}}
+  // expected-note@-2 {{handle unknown values using "@unknown default"}} {{+6:3-3=@unknown default:\n<#fatalError()#>\n}}
+  // expected-note@-3 {{add missing cases: '.b(true)', '@unknown default'}} {{+6:3-3=case .b(true):\n<#code#>\n@unknown default:\n<#fatalError()#>\n}}
   case .a: break
   case .b(false): break
   }
@@ -156,9 +151,7 @@ public func testNonExhaustiveWithinModule(_ value: NonExhaustive, _ payload: Non
 
   switch value { 
   // expected-warning@-1 {{switch must be exhaustive}} {{none}} 
-  // expected-note@-2 {{add missing case: '.a'}} {{+5:3-3=case .a:\n<#code#>\n}}
-  // expected-note@-3 {{add missing case: '.b'}} {{+5:3-3=case .b:\n<#code#>\n}}
-  // expected-note@-4 {{add missing cases}} {{+5:3-3=case .a:\n<#code#>\ncase .b:\n<#code#>\n}}
+  // expected-note@-2 {{add missing cases: '.a', '.b'}} {{+3:3-3=case .a:\n<#code#>\ncase .b:\n<#code#>\n}}
   @unknown case _: break
   }
 

--- a/test/expr/unary/switch_expr.swift
+++ b/test/expr/unary/switch_expr.swift
@@ -556,9 +556,7 @@ case false:
 _ = (switch Bool.random() {
   // expected-error@-1 {{'switch' may only be used as expression in return, throw, or as the source of an assignment}}
   // expected-error@-2 {{switch must be exhaustive}}
-  // expected-note@-3 {{add missing case: 'true'}}
-  // expected-note@-4 {{add missing case: 'false'}}
-  // expected-note@-5 {{add missing cases}}
+  // expected-note@-3 {{add missing cases: 'true', 'false'}}
   #if FOO
 case true:
   0
@@ -571,9 +569,7 @@ case false:
 _ = (switch Bool.random() {
   // expected-error@-1 {{'switch' may only be used as expression in return, throw, or as the source of an assignment}}
   // expected-error@-2 {{switch must be exhaustive}}
-  // expected-note@-3 {{add missing case: 'true'}}
-  // expected-note@-4 {{add missing case: 'false'}}
-  // expected-note@-5 {{add missing cases}}
+  // expected-note@-3 {{add missing cases: 'true', 'false'}}
   #if FOO
 case true:
   0

--- a/test/stmt/nonexhaustive_switch_stmt_editor.swift
+++ b/test/stmt/nonexhaustive_switch_stmt_editor.swift
@@ -9,9 +9,8 @@ public enum NonExhaustive {
 @inlinable
 public func testNonExhaustive(_ value: NonExhaustive) {
   switch value { // expected-error {{switch must be exhaustive}}
-  // expected-note@-1 {{add missing case: '.b'}}
-  // expected-note@-2 {{handle unknown values using "@unknown default"}}
-  // expected-note@-3 {{add missing cases}}
+  // expected-note@-1 {{handle unknown values using "@unknown default"}}
+  // expected-note@-2 {{add missing cases: '.b', '@unknown default'}}
   case .a: break
   }
 
@@ -24,10 +23,8 @@ public func testNonExhaustive(_ value: NonExhaustive) {
 
   switch value {
   // expected-error@-1 {{switch must be exhaustive}}
-  // expected-note@-2 {{add missing case: '.a'}} {{+6:3-3=case .a:\n<#code#>\n}}
-  // expected-note@-3 {{add missing case: '.b'}} {{+6:3-3=case .b:\n<#code#>\n}}
-  // expected-note@-4 {{handle unknown values using "@unknown default"}} {{+6:3-3=@unknown default:\n<#fatalError()#>\n}}
-  // expected-note@-5 {{add missing cases}} {{+6:3-3=case .a:\n<#code#>\ncase .b:\n<#code#>\n@unknown default:\n<#fatalError()#>\n}}
+  // expected-note@-2 {{handle unknown values using "@unknown default"}} {{+4:3-3=@unknown default:\n<#fatalError()#>\n}}
+  // expected-note@-3 {{add missing cases: '.a', '.b', '@unknown default'}} {{+4:3-3=case .a:\n<#code#>\ncase .b:\n<#code#>\n@unknown default:\n<#fatalError()#>\n}}
   }
 
   switch value {

--- a/test/stmt/rdar40400251.swift
+++ b/test/stmt/rdar40400251.swift
@@ -29,9 +29,7 @@ func foo(_ e: E2) {
 func bar(_ e: E2) {
   switch e {
     // expected-error@-1 {{switch must be exhaustive}}
-    // expected-note@-2 {{add missing case: '.bar(_)'}}
-    // expected-note@-3 {{add missing case: '.baz'}}
-    // expected-note@-4 {{add missing cases}}
+    // expected-note@-2 {{add missing cases: '.bar(_)', '.baz'}}
 
     case .foo((_, _, _)): break
   }

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -498,9 +498,7 @@ func r25178926(_ a : Type) {
   }
 
   switch a { // expected-error {{switch must be exhaustive}}
-  // expected-note@-1 {{missing case: '.Foo'}}
-  // expected-note@-2 {{missing case: '.Bar'}}
-  // expected-note@-3 {{add missing cases}}
+  // expected-note@-1 {{add missing cases: '.Foo', '.Bar'}}
   case .Foo where 1 != 100, .Bar where 1 != 100:
     break
   }

--- a/test/stmt/switch_stmt1.swift
+++ b/test/stmt/switch_stmt1.swift
@@ -7,8 +7,6 @@ enum E {
 
 func foo1(e : E, i : Int) {
   switch e {} // expected-error{{switch must be exhaustive}}
-  // expected-note@-1 {{add missing cases}}{{13-13=case .e1:\n<#code#>\ncase .e2:\n<#code#>\n}}
-  // expected-note@-2 {{missing case: '.e1'}}
-  // expected-note@-3 {{missing case: '.e2'}}
+  // expected-note@-1 {{add missing cases: '.e1', '.e2'}}{{13-13=case .e1:\n<#code#>\ncase .e2:\n<#code#>\n}}
   switch i {} // expected-error{{'switch' statement body must have at least one 'case' or 'default' block; add a default case}}{{13-13=default:\n<#code#>\n}}
 }

--- a/test/stmt/switch_stmt2.swift
+++ b/test/stmt/switch_stmt2.swift
@@ -98,17 +98,13 @@ func testSwitchEnumBoolTuple(_ b1: Bool, b2: Bool, xi: Int) -> Int {
   }
 
   switch Cond { // expected-error{{switch must be exhaustive}}
-  // expected-note@-1 {{add missing case: '(false, _)'}}
-  // expected-note@-2 {{add missing case: '(_, false)'}}
-  // expected-note@-3 {{add missing cases}}
+  // expected-note@-1 {{add missing cases: '(false, _)', '(_, false)'}}
   case (true, true):
     x += 1
   }
 
   switch Cond { // expected-error{{switch must be exhaustive}}
-  // expected-note@-1 {{add missing case: '(true, _)'}}
-  // expected-note@-2 {{add missing case: '(_, false)'}}
-  // expected-note@-3 {{add missing cases}}
+  // expected-note@-1 {{add missing cases: '(true, _)', '(_, false)'}}
   case (false, true):
     x += 1
   }


### PR DESCRIPTION
*6.4 cherry-pick of #90966*

- Explanation: Consolidates the separate notes for each missing case in the "switch must be exhaustive" diagnostic into a single note that lists the cases up to a given limit. This makes the diagnostic less noisy, especially for large enums
- Scope: Affects diagnostic logic for non-exhaustive switches
- Issue: rdar://143342616
- Risk: Low, only affects invalid code, and only changes how this particular diagnostic is presented to the user
- Testing: Added tests to test suite
- Reviewer: Pavel Yaskevich