### PR TITLE
Introduce SerializableHiddenTypeInfoRepresentation for ClangLoadableRecordTypeInfo type hierarchy

### DIFF
--- a/include/swift/AST/SerializableHiddenTypeInfoRepresentation.h
+++ b/include/swift/AST/SerializableHiddenTypeInfoRepresentation.h
@@ -79,6 +79,9 @@ public:
   uint32_t explosionSize = 0;
 };
 
+class SerializableLoadableStructTypeInfoRepresentation
+    : public SerializableLoadableRecordTypeInfoRepresentation {};
+
 } // namespace swift
 
 #endif // SWIFT_AST_SERIALIZABLEHIDDENTYPEINFOREPRESENTATION_H

--- a/include/swift/AST/SerializableHiddenTypeInfoRepresentation.h
+++ b/include/swift/AST/SerializableHiddenTypeInfoRepresentation.h
@@ -62,6 +62,9 @@ public:
   irgen::SpareBitVector spareBits;
 };
 
+class SerializableLoadableTypeInfoRepresentation
+    : public SerializableFixedTypeInfoRepresentation {};
+
 } // namespace swift
 
 #endif // SWIFT_AST_SERIALIZABLEHIDDENTYPEINFOREPRESENTATION_H

--- a/include/swift/AST/SerializableHiddenTypeInfoRepresentation.h
+++ b/include/swift/AST/SerializableHiddenTypeInfoRepresentation.h
@@ -1,0 +1,60 @@
+//===--- SerializableHiddenTypeInfoRepresentation.h ------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines serializable representations of IRGen TypeInfo objects
+// used to describe hidden types.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_SERIALIZABLEHIDDENTYPEINFOREPRESENTATION_H
+#define SWIFT_AST_SERIALIZABLEHIDDENTYPEINFOREPRESENTATION_H
+
+#include "swift/AST/TypeInfoStorage.h"
+#include "llvm/IR/Type.h"
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace swift {
+
+// This is used to provide a serializable representation of
+// the llvm::Type used to represent type layout in TypeInfo objects.
+// In producing this structure from an llvm::Type, we also transform
+// any llvm::StructTypes in identified form into literal form. The identity
+// of a member field type is not important for hidden types, only the layout.
+struct SerializableLLVMTypeRepresentation {
+  explicit SerializableLLVMTypeRepresentation(llvm::Type::TypeID kind)
+      : kind(kind) {}
+
+  llvm::Type::TypeID kind;
+
+  // llvm::Type objects form a graph. Each node has a type, and some have children
+  // and additional attributes. Payload is a re-useable field to represent such attributes.
+  // For example, integers have a bit width attribute, arrays and vectors have a size attribute.
+  uint64_t payload = 0;
+  // Packged is used to describe if a struct is packed or not.
+  bool packed = false;
+  std::vector<std::unique_ptr<SerializableLLVMTypeRepresentation>>
+      children;
+};
+
+class SerializableHiddenTypeInfoRepresentation {
+public:
+  std::unique_ptr<SerializableLLVMTypeRepresentation> storageType;
+  irgen::TypeInfoBitfields bits = {0};
+
+  virtual ~SerializableHiddenTypeInfoRepresentation() = default;
+};
+
+} // namespace swift
+
+#endif // SWIFT_AST_SERIALIZABLEHIDDENTYPEINFOREPRESENTATION_H

--- a/include/swift/AST/SerializableHiddenTypeInfoRepresentation.h
+++ b/include/swift/AST/SerializableHiddenTypeInfoRepresentation.h
@@ -55,6 +55,13 @@ public:
   virtual ~SerializableHiddenTypeInfoRepresentation() = default;
 };
 
+class SerializableFixedTypeInfoRepresentation
+    : public SerializableHiddenTypeInfoRepresentation {
+public:
+  uint32_t size = 0;
+  irgen::SpareBitVector spareBits;
+};
+
 } // namespace swift
 
 #endif // SWIFT_AST_SERIALIZABLEHIDDENTYPEINFOREPRESENTATION_H

--- a/include/swift/AST/SerializableHiddenTypeInfoRepresentation.h
+++ b/include/swift/AST/SerializableHiddenTypeInfoRepresentation.h
@@ -65,6 +65,20 @@ public:
 class SerializableLoadableTypeInfoRepresentation
     : public SerializableFixedTypeInfoRepresentation {};
 
+struct SerializableRecordFieldRepresentation {
+  std::unique_ptr<SerializableHiddenTypeInfoRepresentation> typeInfo;
+  irgen::ElementLayoutStorage layout;
+  irgen::RecordFieldStorage storage;
+};
+
+class SerializableLoadableRecordTypeInfoRepresentation
+    : public SerializableLoadableTypeInfoRepresentation {
+public:
+  std::vector<SerializableRecordFieldRepresentation> fields;
+  bool fieldsAreABIAccessible = false;
+  uint32_t explosionSize = 0;
+};
+
 } // namespace swift
 
 #endif // SWIFT_AST_SERIALIZABLEHIDDENTYPEINFOREPRESENTATION_H

--- a/include/swift/AST/SerializableHiddenTypeInfoRepresentation.h
+++ b/include/swift/AST/SerializableHiddenTypeInfoRepresentation.h
@@ -82,6 +82,19 @@ public:
 class SerializableLoadableStructTypeInfoRepresentation
     : public SerializableLoadableRecordTypeInfoRepresentation {};
 
+struct SerializableAggLoweringInputRepresentation {
+  uint64_t begin = 0;
+  uint64_t end = 0;
+  std::unique_ptr<SerializableLLVMTypeRepresentation> type;
+};
+
+class SerializableLoadableClangRecordTypeInfoRepresentation final
+    : public SerializableLoadableStructTypeInfoRepresentation {
+public:
+  bool hasReferenceField = false;
+  std::vector<SerializableAggLoweringInputRepresentation> aggLoweringInputs;
+};
+
 } // namespace swift
 
 #endif // SWIFT_AST_SERIALIZABLEHIDDENTYPEINFOREPRESENTATION_H

--- a/include/swift/AST/TypeInfoStorage.h
+++ b/include/swift/AST/TypeInfoStorage.h
@@ -1,0 +1,102 @@
+//===--- TypeInfoStorage.h - TypeInfo storage definitions -------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_TYPEINFOSTORAGE_H
+#define SWIFT_AST_TYPEINFOSTORAGE_H
+
+#include "swift/Basic/InlineBitfield.h"
+#include <cstdint>
+
+namespace swift {
+namespace irgen {
+
+class FixedTypeInfo;
+class TypeInfo;
+
+enum class SpecialTypeInfoKind : uint8_t {
+  Unimplemented,
+
+  None,
+
+  /// Everything after this is statically fixed-size.
+  Fixed,
+  Weak,
+
+  /// Everything after this is loadable.
+  Loadable,
+  Reference,
+
+  Last_Kind = Reference
+};
+enum : unsigned {
+  NumSpecialTypeInfoKindBits =
+      countBitsUsed(static_cast<unsigned>(SpecialTypeInfoKind::Last_Kind))
+};
+
+// clang-format off
+union TypeInfoBitfields {
+  uint64_t OpaqueBits;
+
+  SWIFT_INLINE_BITFIELD_BASE(TypeInfo,
+                           bitmax(NumSpecialTypeInfoKindBits,8)+6+1+1+1+1+3+1+1,
+    /// The kind of supplemental API this type has, if any.
+    Kind : bitmax(NumSpecialTypeInfoKindBits,8),
+
+    /// The storage alignment of this type in log2 bytes.
+    AlignmentShift : 6,
+
+    /// Whether this type is known to be trivially destructible.
+    TriviallyDestroyable : 1,
+    
+    /// Whether this type is known to be bitwise-takable.
+    BitwiseTakable : 1,
+
+    /// Whether this type is known to be bitwise-borrowable.
+    BitwiseBorrowable : 1,
+
+    /// Whether this type is known to be copyable.
+    Copyable : 1,
+
+    /// An arbitrary discriminator for the subclass.  This is useful for e.g.
+    /// distinguishing between different TypeInfos that all implement the same
+    /// kind of type.
+    /// FIXME -- Create TypeInfoNodes.def and get rid of this field.
+    SubclassKind : 3,
+
+    /// Whether this type can be assumed to have a fixed size from all
+    /// resilience domains.
+    AlwaysFixedSize : 1,
+
+    /// Whether this type is ABI-accessible from this SILModule.
+    ABIAccessible : 1
+  );
+
+  /// FixedTypeInfo will use the remaining bits for the size.
+  ///
+  /// NOTE: Until one can define statically sized inline arrays in the
+  /// language, defining an extremely large object is quite impractical.
+  /// For now: "4 GiB should be more than good enough."
+  SWIFT_INLINE_BITFIELD_FULL(FixedTypeInfo, TypeInfo, 32,
+    : NumPadBits,
+
+    /// The storage size of this type in bytes.  This may be zero even
+    /// for well-formed and complete types, such as a trivial enum or
+    /// tuple.
+    Size : 32
+  );
+};
+// clang-format on
+
+} // namespace irgen
+} // namespace swift
+
+#endif // SWIFT_AST_TYPEINFOSTORAGE_H

--- a/include/swift/AST/TypeInfoStorage.h
+++ b/include/swift/AST/TypeInfoStorage.h
@@ -27,6 +27,65 @@ class TypeInfo;
 /// store vectors of spare bits.
 using SpareBitVector = ClusteredBitVector;
 
+enum class ElementLayoutKind {
+  /// The element is known to require no storage in the aggregate.
+  /// Its offset in the aggregate is always statically zero.
+  Empty,
+
+  /// The element is known to require no storage in the aggregate.
+  /// But it has an offset in the aggregate. This is to support getting the
+  /// offset of tail allocated storage using MemoryLayout<>.offset(of:).
+  EmptyTailAllocatedCType,
+
+  /// The element can be positioned at a fixed offset within the
+  /// aggregate.
+  Fixed,
+
+  /// The element cannot be positioned at a fixed offset within the
+  /// aggregate.
+  NonFixed,
+
+  /// The element is an object lacking a fixed size but located at
+  /// offset zero.  This is necessary because LLVM forbids even a
+  /// 'gep 0' on an unsized type.
+  InitialNonFixedSize
+
+  // IncompleteKind comes here
+};
+
+struct ElementLayoutStorage {
+  /// The offset in bytes from the start of the struct.
+  unsigned ByteOffset;
+
+  /// The offset in bytes from the start of the struct, except EmptyFields are
+  /// placed at the current byte offset instead of 0. For the purpose of the
+  /// final layout empty fields are placed at offset 0, that however creates a
+  /// whole slew of special cases to deal with. Instead of dealing with these
+  /// special cases during layout, we pretend that empty fields are placed
+  /// just like any other field at the current offset.
+  unsigned ByteOffsetForLayout;
+
+  /// The index of this element, either in the LLVM struct (if fixed)
+  /// or in the non-fixed elements array (if non-fixed).
+  unsigned Index : 28;
+
+  /// Whether this element is known to be trivially destructible in the local
+  /// resilience domain.
+  unsigned IsTriviallyDestroyable : 1;
+
+  /// The kind of layout performed for this element.
+  unsigned TheKind : 3;
+
+  ElementLayoutStorage()
+      : TheKind(unsigned(ElementLayoutKind::InitialNonFixedSize) + 1) {}
+};
+
+struct RecordFieldStorage {
+  /// The range of explosion indexes for this element.
+  unsigned Begin;
+  unsigned End;
+};
+
 enum class SpecialTypeInfoKind : uint8_t {
   Unimplemented,
 

--- a/include/swift/AST/TypeInfoStorage.h
+++ b/include/swift/AST/TypeInfoStorage.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_AST_TYPEINFOSTORAGE_H
 #define SWIFT_AST_TYPEINFOSTORAGE_H
 
+#include "swift/Basic/ClusteredBitVector.h"
 #include "swift/Basic/InlineBitfield.h"
 #include <cstdint>
 
@@ -21,6 +22,10 @@ namespace irgen {
 
 class FixedTypeInfo;
 class TypeInfo;
+
+/// In IRGen, we use Swift's ClusteredBitVector data structure to
+/// store vectors of spare bits.
+using SpareBitVector = ClusteredBitVector;
 
 enum class SpecialTypeInfoKind : uint8_t {
   Unimplemented,

--- a/lib/IRGen/FixedTypeInfo.h
+++ b/lib/IRGen/FixedTypeInfo.h
@@ -44,6 +44,7 @@ protected:
                 const SerializableFixedTypeInfoRepresentation &representation);
 
   void populateSerializableHiddenTypeInfoRepresentation(
+      IRGenModule &IGM,
       SerializableFixedTypeInfoRepresentation &representation) const;
 
   FixedTypeInfo(llvm::Type *type, Size size,
@@ -84,7 +85,7 @@ public:
   static bool isFixed() { return true; }
 
   std::unique_ptr<SerializableHiddenTypeInfoRepresentation>
-  createSerializableHiddenTypeInfoRepresentation() const override;
+  createSerializableHiddenTypeInfoRepresentation(IRGenModule &IGM) const override;
 
   /// Whether this type is known to be empty.
   bool isKnownEmpty(ResilienceExpansion expansion) const {

--- a/lib/IRGen/FixedTypeInfo.h
+++ b/lib/IRGen/FixedTypeInfo.h
@@ -40,6 +40,12 @@ private:
   SpareBitVector SpareBits;
   
 protected:
+  FixedTypeInfo(IRGenModule &IGM,
+                const SerializableFixedTypeInfoRepresentation &representation);
+
+  void populateSerializableHiddenTypeInfoRepresentation(
+      SerializableFixedTypeInfoRepresentation &representation) const;
+
   FixedTypeInfo(llvm::Type *type, Size size,
                 const SpareBitVector &spareBits,
                 Alignment align, IsTriviallyDestroyable_t pod,
@@ -76,6 +82,9 @@ protected:
 public:
   // This is useful for metaprogramming.
   static bool isFixed() { return true; }
+
+  std::unique_ptr<SerializableHiddenTypeInfoRepresentation>
+  createSerializableHiddenTypeInfoRepresentation() const override;
 
   /// Whether this type is known to be empty.
   bool isKnownEmpty(ResilienceExpansion expansion) const {

--- a/lib/IRGen/GenRecord.h
+++ b/lib/IRGen/GenRecord.h
@@ -27,6 +27,7 @@
 #include "LoadableTypeInfo.h"
 #include "Outlining.h"
 #include "TypeInfo.h"
+#include "swift/AST/SerializableHiddenTypeInfoRepresentation.h"
 #include "StructLayout.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/TrailingObjects.h"
@@ -40,12 +41,9 @@ template <class, class, class> class RecordTypeBuilder;
 /// A field of a record type.
 template <class FieldImpl> class RecordField {
   ElementLayout Layout;
+  RecordFieldStorage Storage;
 
   template <class, class, class> friend class RecordTypeBuilder;
-
-  /// Begin/End - the range of explosion indexes for this element
-  unsigned Begin;
-  unsigned End;
 
 protected:
   explicit RecordField(const TypeInfo &elementTI)
@@ -53,7 +51,7 @@ protected:
 
   explicit RecordField(const ElementLayout &layout,
                        unsigned begin, unsigned end)
-    : Layout(layout), Begin(begin), End(end) {}
+    : Layout(layout), Storage{begin, end} {}
 
   const FieldImpl *asImpl() const {
     return static_cast<const FieldImpl*>(this);
@@ -94,6 +92,10 @@ public:
     return Layout.getByteOffset();
   }
 
+  Size getByteOffsetDuringLayout() const {
+    return Layout.getByteOffsetDuringLayout();
+  }
+
   unsigned getStructIndex() const { return Layout.getStructIndex(); }
 
   unsigned getNonFixedElementIndex() const {
@@ -101,7 +103,11 @@ public:
   }
 
   std::pair<unsigned, unsigned> getProjectionRange() const {
-    return {Begin, End};
+    return {Storage.Begin, Storage.End};
+  }
+
+  const ElementLayoutStorage &getLayoutStorage() const {
+    return Layout.getStorage();
   }
 };
 
@@ -129,6 +135,25 @@ private:
 
 protected:
   const Impl &asImpl() const { return *static_cast<const Impl*>(this); }
+
+  void populateSerializableRecordTypeInfoRepresentation(
+      SerializableLoadableRecordTypeInfoRepresentation &representation) const {
+    Base::populateSerializableHiddenTypeInfoRepresentation(representation);
+    representation.fieldsAreABIAccessible = areFieldsABIAccessible();
+    representation.fields.clear();
+    representation.fields.reserve(NumFields);
+
+    for (const auto &field : getFields()) {
+      SerializableRecordFieldRepresentation fieldRepresentation;
+      fieldRepresentation.typeInfo =
+          field.getTypeInfo().createSerializableHiddenTypeInfoRepresentation();
+      fieldRepresentation.layout = field.getLayoutStorage();
+      auto projectionRange = field.getProjectionRange();
+      fieldRepresentation.storage.Begin = projectionRange.first;
+      fieldRepresentation.storage.End = projectionRange.second;
+      representation.fields.push_back(std::move(fieldRepresentation));
+    }
+  }
 
   template <class... As> 
   RecordTypeInfoImpl(ArrayRef<FieldImpl> fields,
@@ -780,12 +805,37 @@ class RecordTypeInfo<Impl, Base, FieldImpl,
 protected:
   using super::asImpl;
 
+  // We intentionally construct RecordTypeInfo and derived TypeInfo classes
+  // from both a serialized representation, and a separately provided set of
+  // field information. Clients may have more or less information about dependent
+  // field types and constructor their representation. If the native AST based definition
+  // of a type is available, they are free to use that instead of the serialized hidden
+  // representation.
+  RecordTypeInfo(
+      ArrayRef<FieldImpl> fields, IRGenModule &IGM,
+      const SerializableLoadableRecordTypeInfoRepresentation &representation)
+      : super(fields,
+              representation.fieldsAreABIAccessible
+                  ? FieldsAreABIAccessible
+                  : FieldsAreNotABIAccessible,
+              IGM, representation),
+        ExplosionSize(representation.explosionSize) {
+    assert(representation.fields.size() == fields.size());
+    assert(ExplosionSize == representation.explosionSize && "truncation");
+  }
+
   template <class... As> 
   RecordTypeInfo(ArrayRef<FieldImpl> fields,
                  unsigned explosionSize,
                  As &&...args)
     : super(fields, std::forward<As>(args)...),
       ExplosionSize(explosionSize) {}
+
+  void populateSerializableHiddenTypeInfoRepresentation(
+      SerializableLoadableRecordTypeInfoRepresentation &representation) const {
+    super::populateSerializableRecordTypeInfoRepresentation(representation);
+    representation.explosionSize = ExplosionSize;
+  }
 
 private:
   template <void (LoadableTypeInfo::*Op)(IRGenFunction &IGF,
@@ -847,6 +897,14 @@ private:
 
 public:
   using super::getFields;
+
+  std::unique_ptr<SerializableHiddenTypeInfoRepresentation>
+  createSerializableHiddenTypeInfoRepresentation() const override {
+    auto representation =
+        std::make_unique<SerializableLoadableRecordTypeInfoRepresentation>();
+    populateSerializableHiddenTypeInfoRepresentation(*representation);
+    return representation;
+  }
 
   void loadAsCopy(IRGenFunction &IGF, Address addr,
                   Explosion &out) const override {
@@ -970,14 +1028,14 @@ public:
       }
 
       auto &fieldInfo = fields.back();
-      fieldInfo.Begin = explosionSize;
+      fieldInfo.Storage.Begin = explosionSize;
       bool overflow = false;
       explosionSize = llvm::SaturatingAdd(explosionSize, loadableFieldTI->getExplosionSize(), &overflow);
       if (overflow) {
         IGM.Context.Diags.diagnose(SourceLoc(), diag::explosion_size_oveflow);
       }
 
-      fieldInfo.End = explosionSize;
+      fieldInfo.Storage.End = explosionSize;
     }
 
     // Perform layout and fill in the fields.

--- a/lib/IRGen/GenRecord.h
+++ b/lib/IRGen/GenRecord.h
@@ -137,16 +137,18 @@ protected:
   const Impl &asImpl() const { return *static_cast<const Impl*>(this); }
 
   void populateSerializableRecordTypeInfoRepresentation(
+      IRGenModule &IGM, 
       SerializableLoadableRecordTypeInfoRepresentation &representation) const {
-    Base::populateSerializableHiddenTypeInfoRepresentation(representation);
+    Base::populateSerializableHiddenTypeInfoRepresentation(IGM, representation);
     representation.fieldsAreABIAccessible = areFieldsABIAccessible();
     representation.fields.clear();
     representation.fields.reserve(NumFields);
 
     for (const auto &field : getFields()) {
       SerializableRecordFieldRepresentation fieldRepresentation;
-      fieldRepresentation.typeInfo =
-          field.getTypeInfo().createSerializableHiddenTypeInfoRepresentation();
+      fieldRepresentation.typeInfo = field.getTypeInfo()
+                                         .createSerializableHiddenTypeInfoRepresentation(
+                                             IGM);
       fieldRepresentation.layout = field.getLayoutStorage();
       auto projectionRange = field.getProjectionRange();
       fieldRepresentation.storage.Begin = projectionRange.first;
@@ -832,8 +834,10 @@ protected:
       ExplosionSize(explosionSize) {}
 
   void populateSerializableHiddenTypeInfoRepresentation(
+      IRGenModule &IGM,
       SerializableLoadableRecordTypeInfoRepresentation &representation) const {
-    super::populateSerializableRecordTypeInfoRepresentation(representation);
+    super::populateSerializableRecordTypeInfoRepresentation(IGM,
+                                                             representation);
     representation.explosionSize = ExplosionSize;
   }
 
@@ -899,10 +903,10 @@ public:
   using super::getFields;
 
   std::unique_ptr<SerializableHiddenTypeInfoRepresentation>
-  createSerializableHiddenTypeInfoRepresentation() const override {
+  createSerializableHiddenTypeInfoRepresentation(IRGenModule &IGM) const override {
     auto representation =
         std::make_unique<SerializableLoadableRecordTypeInfoRepresentation>();
-    populateSerializableHiddenTypeInfoRepresentation(*representation);
+    populateSerializableHiddenTypeInfoRepresentation(IGM, *representation);
     return representation;
   }
 

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -540,12 +540,7 @@ namespace {
     void addToAggLowering(IRGenModule &, SwiftAggLowering &lowering,
                           Size offset) const override {
       for (const auto &input : AggLoweringInputs) {
-        auto begin = offset.asCharUnits() + input.Begin;
-        auto end = offset.asCharUnits() + input.End;
-        if (input.Type)
-          lowering.addTypedData(input.Type, begin, end);
-        else
-          lowering.addOpaqueData(begin, end);
+        lowering.addDecomposedData(input, offset.asCharUnits());
       }
     }
 

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -158,11 +158,29 @@ namespace {
       super::setSubclassKind((unsigned) kind);
     }
 
+    StructTypeInfoBase(
+        StructTypeInfoKind kind, ArrayRef<FieldInfoType> fields,
+        IRGenModule &IGM,
+        const SerializableLoadableStructTypeInfoRepresentation &representation)
+        : super(fields, IGM, representation) {
+      super::setSubclassKind((unsigned) kind);
+    }
+
+    void populateSerializableHiddenTypeInfoRepresentation(
+        SerializableLoadableStructTypeInfoRepresentation &representation) const {
+      super::populateSerializableHiddenTypeInfoRepresentation(representation);
+    }
+
     using super::asImpl;
+    using super::assertNotDeserialized;
 
   public:
 
     const FieldInfoType &getFieldInfo(VarDecl *field) const {
+      // TypeInfo derived from a hidden representation does not support
+      // AST based operations.
+      assertNotDeserialized("StructTypeInfoBase::getFieldInfo");
+
       // FIXME: cache the physical field index in the VarDecl.
       for (auto &fieldInfo : asImpl().getFields()) {
         if (fieldInfo.Field == field)
@@ -191,6 +209,8 @@ namespace {
     /// single field.
     Address projectFieldAddress(IRGenFunction &IGF, Address addr, SILType T,
                                 const FieldInfoType &field) const {
+      // We can't access field.Field with deserialized TypeInfo.
+      assertNotDeserialized("StructTypeInfoBase::projectFieldAddress");
       return asImpl().projectFieldAddress(IGF, addr, T, field.Field);
     }
 
@@ -298,6 +318,9 @@ namespace {
 
     void destroy(IRGenFunction &IGF, Address address, SILType T,
                  bool isOutlined) const override {
+      // The code below checks the AST to call a deinit method
+      // which we don't support from hidden representations yet
+      assertNotDeserialized("StructTypeInfoBase::destroy");
 
       // If the struct has a deinit declared, then call it to destroy the
       // value.
@@ -347,6 +370,8 @@ namespace {
             }
           };
 
+          // We can't access field.Field without AST backed TypeInfo
+          assertNotDeserialized("StructTypeInfoBase::verify");
           FindOffsetOfFieldOffsetVector scanner(IGF.IGM, field.Field);
           scanner.layout();
 

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -167,8 +167,10 @@ namespace {
     }
 
     void populateSerializableHiddenTypeInfoRepresentation(
+        IRGenModule &IGM,
         SerializableLoadableStructTypeInfoRepresentation &representation) const {
-      super::populateSerializableHiddenTypeInfoRepresentation(representation);
+      super::populateSerializableHiddenTypeInfoRepresentation(IGM,
+                                                               representation);
     }
 
     using super::asImpl;
@@ -412,11 +414,46 @@ namespace {
   class LoadableClangRecordTypeInfo final
       : public StructTypeInfoBase<LoadableClangRecordTypeInfo, LoadableTypeInfo,
                                   ClangFieldInfo> {
-    const clang::RecordDecl *ClangDecl;
     bool HasReferenceField;
+    std::vector<SwiftAggLowering::StorageEntry> AggLoweringInputs;
+
+    static std::vector<SwiftAggLowering::StorageEntry>
+    computeAggLoweringInputs(IRGenModule &IGM,
+                             const clang::RecordDecl *clangDecl) {
+      assert(clangDecl && "decomposing Clang TypeInfo without a Clang decl");
+      std::vector<SwiftAggLowering::StorageEntry> inputs;
+      SwiftAggLowering decomposer(IGM.getClangCGM());
+      auto appendInput = [&](const SwiftAggLowering::StorageEntry &entry) {
+        inputs.push_back(entry);
+      };
+
+      decomposer.decomposeTypedData(clangDecl, clang::CharUnits::Zero(),
+                                    appendInput);
+      return inputs;
+    }
+
+    void populateSerializableHiddenTypeInfoRepresentation(
+        IRGenModule &IGM,
+        SerializableLoadableClangRecordTypeInfoRepresentation
+            &representation) const {
+      StructTypeInfoBase::populateSerializableHiddenTypeInfoRepresentation(
+          IGM, representation);
+      representation.hasReferenceField = HasReferenceField;
+
+      representation.aggLoweringInputs.clear();
+      for (const auto &entry : AggLoweringInputs) {
+        SerializableAggLoweringInputRepresentation input;
+        input.begin = entry.Begin.getQuantity();
+        input.end = entry.End.getQuantity();
+        if (entry.Type)
+          input.type = serializeLLVMType(entry.Type);
+        representation.aggLoweringInputs.push_back(std::move(input));
+      }
+    }
 
   public:
     LoadableClangRecordTypeInfo(ArrayRef<ClangFieldInfo> fields,
+                                IRGenModule &IGM,
                                 unsigned explosionSize, llvm::Type *storageType,
                                 Size size, SpareBitVector &&spareBits,
                                 Alignment align,
@@ -429,7 +466,36 @@ namespace {
                              storageType, size, std::move(spareBits), align,
                              isTriviallyDestroyable, isCopyable, IsFixedSize,
                              IsABIAccessible),
-          ClangDecl(clangDecl), HasReferenceField(hasReferenceField) {}
+          HasReferenceField(hasReferenceField),
+          AggLoweringInputs(computeAggLoweringInputs(IGM, clangDecl)) {}
+
+    LoadableClangRecordTypeInfo(
+        ArrayRef<ClangFieldInfo> fields, IRGenModule &IGM,
+        const SerializableLoadableClangRecordTypeInfoRepresentation
+            &representation)
+        : StructTypeInfoBase(
+              StructTypeInfoKind::LoadableClangRecordTypeInfo, fields, IGM,
+              static_cast<const SerializableLoadableStructTypeInfoRepresentation
+                              &>(representation)),
+          HasReferenceField(representation.hasReferenceField) {
+      AggLoweringInputs.reserve(representation.aggLoweringInputs.size());
+      for (const auto &input : representation.aggLoweringInputs) {
+        AggLoweringInputs.push_back({
+            clang::CharUnits::fromQuantity(input.begin),
+            clang::CharUnits::fromQuantity(input.end),
+            input.type ? deserializeLLVMType(IGM, input.type) : nullptr,
+        });
+      }
+    }
+
+    std::unique_ptr<SerializableHiddenTypeInfoRepresentation>
+    createSerializableHiddenTypeInfoRepresentation(
+        IRGenModule &IGM) const override {
+      auto representation = std::make_unique<
+          SerializableLoadableClangRecordTypeInfoRepresentation>();
+      populateSerializableHiddenTypeInfoRepresentation(IGM, *representation);
+      return representation;
+    }
 
     TypeLayoutEntry
     *buildTypeLayoutEntry(IRGenModule &IGM,
@@ -471,9 +537,16 @@ namespace {
       LoadableClangRecordTypeInfo::initialize(IGF, params, addr, isOutlined);
     }
 
-    void addToAggLowering(IRGenModule &IGM, SwiftAggLowering &lowering,
+    void addToAggLowering(IRGenModule &, SwiftAggLowering &lowering,
                           Size offset) const override {
-      lowering.addTypedData(ClangDecl, offset.asCharUnits());
+      for (const auto &input : AggLoweringInputs) {
+        auto begin = offset.asCharUnits() + input.Begin;
+        auto end = offset.asCharUnits() + input.End;
+        if (input.Type)
+          lowering.addTypedData(input.Type, begin, end);
+        else
+          lowering.addOpaqueData(begin, end);
+      }
     }
 
     std::nullopt_t getNonFixedOffsets(IRGenFunction &IGF) const {
@@ -1463,7 +1536,7 @@ public:
           ClangDecl);
     }
     return LoadableClangRecordTypeInfo::create(
-        FieldInfos, NextExplosionIndex, llvmType, TotalStride,
+        FieldInfos, IGM, NextExplosionIndex, llvmType, TotalStride,
         std::move(SpareBits), TotalAlignment,
         (SwiftDecl &&
          (SwiftDecl->hasValueTypeDestructor() || hasReferenceField))

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -18,22 +18,24 @@
 #include "swift/AST/CanTypeVisitor.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/GenericEnvironment.h"
-#include "swift/AST/LazyResolver.h"
 #include "swift/AST/IRGenOptions.h"
+#include "swift/AST/LazyResolver.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/SearchPathOptions.h"
+#include "swift/AST/SerializableHiddenTypeInfoRepresentation.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/Platform.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/IRGen/Linking.h"
 #include "swift/SIL/SILModule.h"
-#include "llvm/IR/DerivedTypes.h"
+#include "clang/CodeGen/SwiftCallingConv.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallString.h"
+#include "llvm/IR/DerivedTypes.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/Path.h"
-#include "clang/CodeGen/SwiftCallingConv.h"
 
 #include "BitPatternBuilder.h"
 #include "CallEmission.h"
@@ -62,6 +64,144 @@
 
 using namespace swift;
 using namespace irgen;
+
+using SerializableLLVMType = SerializableLLVMTypeRepresentation;
+
+static std::unique_ptr<SerializableLLVMType> serializeLLVMTypeImpl(
+    llvm::Type *type, llvm::SmallPtrSetImpl<llvm::Type *> &activeTypes) {
+  auto create = [](llvm::Type::TypeID kind, uint64_t payload = 0) {
+    auto result = std::make_unique<SerializableLLVMType>(kind);
+    result->payload = payload;
+    return result;
+  };
+
+  switch (type->getTypeID()) {
+  case llvm::Type::HalfTyID:
+  case llvm::Type::BFloatTyID:
+  case llvm::Type::FloatTyID:
+  case llvm::Type::DoubleTyID:
+  case llvm::Type::X86_FP80TyID:
+  case llvm::Type::FP128TyID:
+  case llvm::Type::PPC_FP128TyID:
+    return create(type->getTypeID());
+  case llvm::Type::IntegerTyID:
+    return create(type->getTypeID(),
+                  cast<llvm::IntegerType>(type)->getBitWidth());
+  case llvm::Type::PointerTyID:
+    return create(type->getTypeID(),
+                  cast<llvm::PointerType>(type)->getAddressSpace());
+  case llvm::Type::ArrayTyID: {
+    auto *arrayType = cast<llvm::ArrayType>(type);
+    auto result = create(type->getTypeID(), arrayType->getNumElements());
+    result->children.push_back(serializeLLVMTypeImpl(
+        arrayType->getElementType(), activeTypes));
+    return result;
+  }
+  case llvm::Type::FixedVectorTyID: {
+    auto *vectorType = cast<llvm::FixedVectorType>(type);
+    auto result = create(type->getTypeID(), vectorType->getNumElements());
+    result->children.push_back(serializeLLVMTypeImpl(
+        vectorType->getElementType(), activeTypes));
+    return result;
+  }
+  case llvm::Type::StructTyID: {
+    auto *structType = cast<llvm::StructType>(type);
+    if (structType->isOpaque())
+      llvm::report_fatal_error("cannot serialize an opaque LLVM storage type");
+    if (!activeTypes.insert(type).second)
+      llvm::report_fatal_error("cannot serialize a cyclic LLVM storage type");
+
+    auto result = create(type->getTypeID());
+    result->packed = structType->isPacked();
+    result->children.reserve(structType->getNumElements());
+    for (auto *elementType : structType->elements())
+      result->children.push_back(
+          serializeLLVMTypeImpl(elementType, activeTypes));
+
+    activeTypes.erase(type);
+    return result;
+  }
+  case llvm::Type::VoidTyID:
+  case llvm::Type::LabelTyID:
+  case llvm::Type::MetadataTyID:
+  case llvm::Type::X86_AMXTyID:
+  case llvm::Type::TokenTyID:
+  case llvm::Type::FunctionTyID:
+  case llvm::Type::ScalableVectorTyID:
+  case llvm::Type::TypedPointerTyID:
+  case llvm::Type::TargetExtTyID:
+    llvm::report_fatal_error("unsupported LLVM storage type");
+  }
+
+  llvm_unreachable("unhandled LLVM storage type");
+}
+
+std::unique_ptr<SerializableLLVMType>
+swift::irgen::serializeLLVMType(llvm::Type *type) {
+  llvm::SmallPtrSet<llvm::Type *, 4> activeTypes;
+  return serializeLLVMTypeImpl(type, activeTypes);
+}
+
+static llvm::Type *
+deserializeLLVMTypeImpl(llvm::LLVMContext &ctx,
+                        const SerializableLLVMType &representation) {
+  switch (representation.kind) {
+  case llvm::Type::HalfTyID:
+    return llvm::Type::getHalfTy(ctx);
+  case llvm::Type::BFloatTyID:
+    return llvm::Type::getBFloatTy(ctx);
+  case llvm::Type::FloatTyID:
+    return llvm::Type::getFloatTy(ctx);
+  case llvm::Type::DoubleTyID:
+    return llvm::Type::getDoubleTy(ctx);
+  case llvm::Type::X86_FP80TyID:
+    return llvm::Type::getX86_FP80Ty(ctx);
+  case llvm::Type::FP128TyID:
+    return llvm::Type::getFP128Ty(ctx);
+  case llvm::Type::PPC_FP128TyID:
+    return llvm::Type::getPPC_FP128Ty(ctx);
+  case llvm::Type::IntegerTyID:
+    return llvm::IntegerType::get(ctx, representation.payload);
+  case llvm::Type::PointerTyID:
+    return llvm::PointerType::get(ctx, representation.payload);
+  case llvm::Type::ArrayTyID:
+    assert(representation.children.size() == 1);
+    return llvm::ArrayType::get(
+        deserializeLLVMTypeImpl(ctx, *representation.children.front()),
+        representation.payload);
+  case llvm::Type::FixedVectorTyID:
+    assert(representation.children.size() == 1);
+    return llvm::FixedVectorType::get(
+        deserializeLLVMTypeImpl(ctx, *representation.children.front()),
+        representation.payload);
+  case llvm::Type::StructTyID: {
+    llvm::SmallVector<llvm::Type *, 8> elementTypes;
+    for (auto &element : representation.children)
+      elementTypes.push_back(deserializeLLVMTypeImpl(ctx, *element));
+    return llvm::StructType::get(ctx, elementTypes, representation.packed);
+  }
+  case llvm::Type::VoidTyID:
+  case llvm::Type::LabelTyID:
+  case llvm::Type::MetadataTyID:
+  case llvm::Type::X86_AMXTyID:
+  case llvm::Type::TokenTyID:
+  case llvm::Type::FunctionTyID:
+  case llvm::Type::ScalableVectorTyID:
+  case llvm::Type::TypedPointerTyID:
+  case llvm::Type::TargetExtTyID:
+    llvm::report_fatal_error("unsupported serialized LLVM storage type");
+  }
+
+  llvm_unreachable("unhandled serialized LLVM storage type");
+}
+
+llvm::Type *swift::irgen::deserializeLLVMType(
+    IRGenModule &IGM,
+    const std::unique_ptr<SerializableLLVMType> &representation) {
+  if (!representation)
+    llvm::report_fatal_error("serialized TypeInfo has no LLVM storage type");
+  return deserializeLLVMTypeImpl(IGM.getLLVMContext(), *representation);
+}
 
 Alignment IRGenModule::getCappedAlignment(Alignment align) {
   return std::min(align, Alignment(MaximumAlignment));
@@ -115,6 +255,28 @@ TypeInfo::~TypeInfo() {
     delete nativeReturnSchema;
   if (nativeParameterSchema)
     delete nativeParameterSchema;
+}
+
+TypeInfo::TypeInfo(
+    IRGenModule &IGM,
+    const SerializableHiddenTypeInfoRepresentation &representation)
+    : CreatedFromSerializableHiddenTypeInfoRepresentation(true),
+      StorageType(deserializeLLVMType(IGM, representation.storageType)) {
+  Bits = representation.bits;
+}
+
+std::unique_ptr<SerializableHiddenTypeInfoRepresentation>
+TypeInfo::createSerializableHiddenTypeInfoRepresentation() const {
+  auto representation =
+      std::make_unique<SerializableHiddenTypeInfoRepresentation>();
+  populateSerializableHiddenTypeInfoRepresentation(*representation);
+  return representation;
+}
+
+void TypeInfo::populateSerializableHiddenTypeInfoRepresentation(
+    SerializableHiddenTypeInfoRepresentation &representation) const {
+  representation.storageType = serializeLLVMType(getStorageType());
+  representation.bits = Bits;
 }
 
 Address TypeInfo::getAddressForPointer(llvm::Value *ptr) const {

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -279,6 +279,32 @@ void TypeInfo::populateSerializableHiddenTypeInfoRepresentation(
   representation.bits = Bits;
 }
 
+FixedTypeInfo::FixedTypeInfo(
+    IRGenModule &IGM,
+    const SerializableFixedTypeInfoRepresentation &representation)
+    : TypeInfo(IGM, representation),
+      SpareBits(representation.spareBits) {
+  setSpecialTypeInfoKind(SpecialTypeInfoKind::Fixed);
+  assert(SpareBits.size() == representation.size * uint32_t(8));
+  Bits.FixedTypeInfo.Size = representation.size;
+  assert(Bits.FixedTypeInfo.Size == representation.size && "truncation");
+}
+
+void FixedTypeInfo::populateSerializableHiddenTypeInfoRepresentation(
+    SerializableFixedTypeInfoRepresentation &representation) const {
+  TypeInfo::populateSerializableHiddenTypeInfoRepresentation(representation);
+  representation.size = getFixedSize().getValue();
+  representation.spareBits = getSpareBits();
+}
+
+std::unique_ptr<SerializableHiddenTypeInfoRepresentation>
+FixedTypeInfo::createSerializableHiddenTypeInfoRepresentation() const {
+  auto representation =
+      std::make_unique<SerializableFixedTypeInfoRepresentation>();
+  populateSerializableHiddenTypeInfoRepresentation(*representation);
+  return representation;
+}
+
 Address TypeInfo::getAddressForPointer(llvm::Value *ptr) const {
   return Address(ptr, getStorageType(), getBestKnownAlignment());
 }

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -265,6 +265,13 @@ TypeInfo::TypeInfo(
   Bits = representation.bits;
 }
 
+void TypeInfo::assertNotDeserialized(const char *operation) const {
+  if (CreatedFromSerializableHiddenTypeInfoRepresentation)
+    llvm::report_fatal_error(
+        llvm::Twine(operation) +
+        " requires AST information unavailable to a reconstructed TypeInfo");
+}
+
 std::unique_ptr<SerializableHiddenTypeInfoRepresentation>
 TypeInfo::createSerializableHiddenTypeInfoRepresentation() const {
   auto representation =

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -305,6 +305,33 @@ FixedTypeInfo::createSerializableHiddenTypeInfoRepresentation() const {
   return representation;
 }
 
+LoadableTypeInfo::LoadableTypeInfo(
+    IRGenModule &IGM,
+    const SerializableLoadableTypeInfoRepresentation &representation)
+    : FixedTypeInfo(IGM, representation) {
+  setSpecialTypeInfoKind(SpecialTypeInfoKind::Loadable);
+  // All currently implemented LoadableTypeInfo are bitwise loadable and takable,
+  // so assert we haven't introduced a method to create one which is not
+  // via deserialization.
+  assert(isBitwiseTakable(ResilienceExpansion::Maximal));
+  assert(isBitwiseBorrowable(ResilienceExpansion::Maximal));
+  assert(isLoadable());
+}
+
+void LoadableTypeInfo::populateSerializableHiddenTypeInfoRepresentation(
+    SerializableLoadableTypeInfoRepresentation &representation) const {
+  FixedTypeInfo::populateSerializableHiddenTypeInfoRepresentation(
+      representation);
+}
+
+std::unique_ptr<SerializableHiddenTypeInfoRepresentation>
+LoadableTypeInfo::createSerializableHiddenTypeInfoRepresentation() const {
+  auto representation =
+      std::make_unique<SerializableLoadableTypeInfoRepresentation>();
+  populateSerializableHiddenTypeInfoRepresentation(*representation);
+  return representation;
+}
+
 Address TypeInfo::getAddressForPointer(llvm::Value *ptr) const {
   return Address(ptr, getStorageType(), getBestKnownAlignment());
 }

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -273,14 +273,16 @@ void TypeInfo::assertNotDeserialized(const char *operation) const {
 }
 
 std::unique_ptr<SerializableHiddenTypeInfoRepresentation>
-TypeInfo::createSerializableHiddenTypeInfoRepresentation() const {
+TypeInfo::createSerializableHiddenTypeInfoRepresentation(
+    IRGenModule &IGM) const {
   auto representation =
       std::make_unique<SerializableHiddenTypeInfoRepresentation>();
-  populateSerializableHiddenTypeInfoRepresentation(*representation);
+  populateSerializableHiddenTypeInfoRepresentation(IGM, *representation);
   return representation;
 }
 
 void TypeInfo::populateSerializableHiddenTypeInfoRepresentation(
+    IRGenModule &IGM,
     SerializableHiddenTypeInfoRepresentation &representation) const {
   representation.storageType = serializeLLVMType(getStorageType());
   representation.bits = Bits;
@@ -298,17 +300,20 @@ FixedTypeInfo::FixedTypeInfo(
 }
 
 void FixedTypeInfo::populateSerializableHiddenTypeInfoRepresentation(
+    IRGenModule &IGM,
     SerializableFixedTypeInfoRepresentation &representation) const {
-  TypeInfo::populateSerializableHiddenTypeInfoRepresentation(representation);
+  TypeInfo::populateSerializableHiddenTypeInfoRepresentation(IGM,
+                                                              representation);
   representation.size = getFixedSize().getValue();
   representation.spareBits = getSpareBits();
 }
 
 std::unique_ptr<SerializableHiddenTypeInfoRepresentation>
-FixedTypeInfo::createSerializableHiddenTypeInfoRepresentation() const {
+FixedTypeInfo::createSerializableHiddenTypeInfoRepresentation(
+    IRGenModule &IGM) const {
   auto representation =
       std::make_unique<SerializableFixedTypeInfoRepresentation>();
-  populateSerializableHiddenTypeInfoRepresentation(*representation);
+  populateSerializableHiddenTypeInfoRepresentation(IGM, *representation);
   return representation;
 }
 
@@ -326,16 +331,18 @@ LoadableTypeInfo::LoadableTypeInfo(
 }
 
 void LoadableTypeInfo::populateSerializableHiddenTypeInfoRepresentation(
+    IRGenModule &IGM,
     SerializableLoadableTypeInfoRepresentation &representation) const {
   FixedTypeInfo::populateSerializableHiddenTypeInfoRepresentation(
-      representation);
+      IGM, representation);
 }
 
 std::unique_ptr<SerializableHiddenTypeInfoRepresentation>
-LoadableTypeInfo::createSerializableHiddenTypeInfoRepresentation() const {
+LoadableTypeInfo::createSerializableHiddenTypeInfoRepresentation(
+    IRGenModule &IGM) const {
   auto representation =
       std::make_unique<SerializableLoadableTypeInfoRepresentation>();
-  populateSerializableHiddenTypeInfoRepresentation(*representation);
+  populateSerializableHiddenTypeInfoRepresentation(IGM, *representation);
   return representation;
 }
 

--- a/lib/IRGen/IRGen.h
+++ b/lib/IRGen/IRGen.h
@@ -22,6 +22,7 @@
 #include "clang/AST/CharUnits.h"
 #include "clang/CodeGen/ConstantInitFuture.h"
 #include "swift/AST/ResilienceExpansion.h"
+#include "swift/AST/TypeInfoStorage.h"
 #include "swift/SIL/AbstractionPattern.h"
 #include <cassert>
 
@@ -31,7 +32,6 @@ namespace llvm {
 
 namespace swift {
   class CanType;
-  class ClusteredBitVector;
   enum ForDefinition_t : bool;
 
 namespace irgen {
@@ -39,10 +39,6 @@ namespace irgen {
   class ConstantInitBuilder;
   using clang::CodeGen::ConstantInitFuture;
   class IRGenFunction;
-
-/// In IRGen, we use Swift's ClusteredBitVector data structure to
-/// store vectors of spare bits.
-using SpareBitVector = ClusteredBitVector;
 
 enum class StackProtectorMode : bool { NoStackProtector, StackProtector };
 

--- a/lib/IRGen/LoadableTypeInfo.h
+++ b/lib/IRGen/LoadableTypeInfo.h
@@ -56,6 +56,13 @@ public:
 /// memory.
 class LoadableTypeInfo : public FixedTypeInfo {
 protected:
+  LoadableTypeInfo(
+      IRGenModule &IGM,
+      const SerializableLoadableTypeInfoRepresentation &representation);
+
+  void populateSerializableHiddenTypeInfoRepresentation(
+      SerializableLoadableTypeInfoRepresentation &representation) const;
+
   LoadableTypeInfo(llvm::Type *type, Size size,
                    const SpareBitVector &spareBits,
                    Alignment align,
@@ -91,7 +98,10 @@ protected:
 public:
   // This is useful for metaprogramming.
   static bool isLoadable() { return true; }
-  
+
+  std::unique_ptr<SerializableHiddenTypeInfoRepresentation>
+  createSerializableHiddenTypeInfoRepresentation() const override;
+
   /// Return the number of elements in an explosion of this type.
   virtual unsigned getExplosionSize() const = 0;
 

--- a/lib/IRGen/LoadableTypeInfo.h
+++ b/lib/IRGen/LoadableTypeInfo.h
@@ -61,6 +61,7 @@ protected:
       const SerializableLoadableTypeInfoRepresentation &representation);
 
   void populateSerializableHiddenTypeInfoRepresentation(
+      IRGenModule &IGM,
       SerializableLoadableTypeInfoRepresentation &representation) const;
 
   LoadableTypeInfo(llvm::Type *type, Size size,
@@ -100,7 +101,7 @@ public:
   static bool isLoadable() { return true; }
 
   std::unique_ptr<SerializableHiddenTypeInfoRepresentation>
-  createSerializableHiddenTypeInfoRepresentation() const override;
+  createSerializableHiddenTypeInfoRepresentation(IRGenModule &IGM) const override;
 
   /// Return the number of elements in an explosion of this type.
   virtual unsigned getExplosionSize() const = 0;

--- a/lib/IRGen/StructLayout.h
+++ b/lib/IRGen/StructLayout.h
@@ -79,31 +79,7 @@ public:
 /// of aggregate structure.
 class ElementLayout {
 public:
-  enum class Kind {
-    /// The element is known to require no storage in the aggregate.
-    /// Its offset in the aggregate is always statically zero.
-    Empty,
-
-    /// The element is known to require no storage in the aggregate.
-    /// But it has an offset in the aggregate. This is to support getting the
-    /// offset of tail allocated storage using MemoryLayout<>.offset(of:).
-    EmptyTailAllocatedCType,
-
-    /// The element can be positioned at a fixed offset within the
-    /// aggregate.
-    Fixed,
-
-    /// The element cannot be positioned at a fixed offset within the
-    /// aggregate.
-    NonFixed,
-
-    /// The element is an object lacking a fixed size but located at
-    /// offset zero.  This is necessary because LLVM forbids even a
-    /// 'gep 0' on an unsized type.
-    InitialNonFixedSize
-
-    // IncompleteKind comes here
-  };
+  using Kind = ElementLayoutKind;
 
 private:
   enum : unsigned { IncompleteKind  = unsigned(Kind::InitialNonFixedSize) + 1 };
@@ -111,33 +87,13 @@ private:
   /// The swift type information for this element's layout.
   const TypeInfo *Type;
 
-  /// The offset in bytes from the start of the struct.
-  unsigned ByteOffset;
-
-  /// The offset in bytes from the start of the struct, except EmptyFields are
-  /// placed at the current byte offset instead of 0. For the purpose of the
-  /// final layout empty fields are placed at offset 0, that however creates a
-  /// whole slew of special cases to deal with. Instead of dealing with these
-  /// special cases during layout, we pretend that empty fields are placed
-  /// just like any other field at the current offset.
-  unsigned ByteOffsetForLayout;
-
-  /// The index of this element, either in the LLVM struct (if fixed)
-  /// or in the non-fixed elements array (if non-fixed).
-  unsigned Index : 28;
-
-  /// Whether this element is known to be trivially destructible in the local
-  /// resilience domain.
-  unsigned IsTriviallyDestroyable : 1;
-
-  /// The kind of layout performed for this element.
-  unsigned TheKind : 3;
+  ElementLayoutStorage Storage;
 
   explicit ElementLayout(const TypeInfo &type)
-    : Type(&type), TheKind(IncompleteKind) {}
+    : Type(&type) {}
 
   bool isCompleted() const {
-    return (TheKind != IncompleteKind);
+    return (Storage.TheKind != IncompleteKind);
   }
 
 public:
@@ -147,45 +103,41 @@ public:
 
   void completeFrom(const ElementLayout &other) {
     assert(!isCompleted());
-    TheKind = other.TheKind;
-    IsTriviallyDestroyable = other.IsTriviallyDestroyable;
-    ByteOffset = other.ByteOffset;
-    ByteOffsetForLayout = other.ByteOffsetForLayout;
-    Index = other.Index;
+    Storage = other.Storage;
   }
 
   void completeEmpty(IsTriviallyDestroyable_t isTriviallyDestroyable, Size byteOffset) {
-    TheKind = unsigned(Kind::Empty);
-    IsTriviallyDestroyable = unsigned(isTriviallyDestroyable);
-    ByteOffset = 0;
-    ByteOffsetForLayout = byteOffset.getValue();
-    Index = 0; // make a complete write of the bitfield
+    Storage.TheKind = unsigned(Kind::Empty);
+    Storage.IsTriviallyDestroyable = unsigned(isTriviallyDestroyable);
+    Storage.ByteOffset = 0;
+    Storage.ByteOffsetForLayout = byteOffset.getValue();
+    Storage.Index = 0; // make a complete write of the bitfield
   }
 
   void completeInitialNonFixedSize(IsTriviallyDestroyable_t isTriviallyDestroyable) {
-    TheKind = unsigned(Kind::InitialNonFixedSize);
-    IsTriviallyDestroyable = unsigned(isTriviallyDestroyable);
-    ByteOffset = 0;
-    ByteOffsetForLayout = ByteOffset;
-    Index = 0; // make a complete write of the bitfield
+    Storage.TheKind = unsigned(Kind::InitialNonFixedSize);
+    Storage.IsTriviallyDestroyable = unsigned(isTriviallyDestroyable);
+    Storage.ByteOffset = 0;
+    Storage.ByteOffsetForLayout = Storage.ByteOffset;
+    Storage.Index = 0; // make a complete write of the bitfield
   }
 
   void completeFixed(IsTriviallyDestroyable_t isTriviallyDestroyable, Size byteOffset, unsigned structIndex) {
-    TheKind = unsigned(Kind::Fixed);
-    IsTriviallyDestroyable = unsigned(isTriviallyDestroyable);
-    ByteOffset = byteOffset.getValue();
-    ByteOffsetForLayout = ByteOffset;
-    Index = structIndex;
+    Storage.TheKind = unsigned(Kind::Fixed);
+    Storage.IsTriviallyDestroyable = unsigned(isTriviallyDestroyable);
+    Storage.ByteOffset = byteOffset.getValue();
+    Storage.ByteOffsetForLayout = Storage.ByteOffset;
+    Storage.Index = structIndex;
 
     assert(getByteOffset() == byteOffset);
   }
 
   void completeEmptyTailAllocatedCType(IsTriviallyDestroyable_t isTriviallyDestroyable, Size byteOffset) {
-    TheKind = unsigned(Kind::EmptyTailAllocatedCType);
-    IsTriviallyDestroyable = unsigned(isTriviallyDestroyable);
-    ByteOffset = byteOffset.getValue();
-    ByteOffsetForLayout = ByteOffset;
-    Index = 0;
+    Storage.TheKind = unsigned(Kind::EmptyTailAllocatedCType);
+    Storage.IsTriviallyDestroyable = unsigned(isTriviallyDestroyable);
+    Storage.ByteOffset = byteOffset.getValue();
+    Storage.ByteOffsetForLayout = Storage.ByteOffset;
+    Storage.Index = 0;
 
     assert(getByteOffset() == byteOffset);
   }
@@ -194,16 +146,21 @@ public:
   ///
   /// \param nonFixedElementIndex - the index into the elements array
   void completeNonFixed(IsTriviallyDestroyable_t isTriviallyDestroyable, unsigned nonFixedElementIndex) {
-    TheKind = unsigned(Kind::NonFixed);
-    IsTriviallyDestroyable = unsigned(isTriviallyDestroyable);
-    Index = nonFixedElementIndex;
+    Storage.TheKind = unsigned(Kind::NonFixed);
+    Storage.IsTriviallyDestroyable = unsigned(isTriviallyDestroyable);
+    Storage.Index = nonFixedElementIndex;
   }
 
   const TypeInfo &getType() const { return *Type; }
 
+  const ElementLayoutStorage &getStorage() const {
+    assert(isCompleted());
+    return Storage;
+  }
+
   Kind getKind() const {
     assert(isCompleted());
-    return Kind(TheKind);
+    return Kind(Storage.TheKind);
   }
 
   /// Is this element known to be empty?
@@ -215,7 +172,7 @@ public:
   /// Is this element known to be POD?
   IsTriviallyDestroyable_t isTriviallyDestroyable() const {
     assert(isCompleted());
-    return IsTriviallyDestroyable_t(IsTriviallyDestroyable);
+    return IsTriviallyDestroyable_t(Storage.IsTriviallyDestroyable);
   }
 
   /// Can we access this element at a static offset?
@@ -238,7 +195,7 @@ public:
   /// Given that this element has a fixed offset, return that offset in bytes.
   Size getByteOffset() const {
     assert(isCompleted() && hasByteOffset());
-    return Size(ByteOffset);
+    return Size(Storage.ByteOffset);
   }
 
   /// The offset in bytes from the start of the struct, except EmptyFields are
@@ -249,21 +206,21 @@ public:
   /// just like any other field at the current offset.
   Size getByteOffsetDuringLayout() const {
     assert(isCompleted() && hasByteOffset());
-    return Size(ByteOffsetForLayout);
+    return Size(Storage.ByteOffsetForLayout);
   }
 
   /// Given that this element has a fixed offset, return the index in
   /// the LLVM struct.
   unsigned getStructIndex() const {
     assert(isCompleted() && getKind() == Kind::Fixed);
-    return Index;
+    return Storage.Index;
   }
 
   /// Given that this element does not have a fixed offset, return its
   /// index in the nonfixed-elements array.
   unsigned getNonFixedElementIndex() const {
     assert(isCompleted() && getKind() == Kind::NonFixed);
-    return Index;
+    return Storage.Index;
   }
 
   Address project(IRGenFunction &IGF, Address addr,

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -124,6 +124,8 @@ protected:
 
   bool CreatedFromSerializableHiddenTypeInfoRepresentation;
 
+  void assertNotDeserialized(const char *operation) const;
+
   /// Change the minimum alignment of a stored value of this type.
   void setStorageAlignment(Alignment alignment) {
     auto Prev = Bits.TypeInfo.AlignmentShift;

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -28,8 +28,10 @@
 #include "IRGen.h"
 #include "Outlining.h"
 #include "swift/AST/ReferenceCounting.h"
+#include "swift/AST/TypeInfoStorage.h"
 #include "swift/SIL/SILInstruction.h"
 #include "llvm/ADT/MapVector.h"
+#include <memory>
 
 namespace llvm {
   class Constant;
@@ -40,6 +42,8 @@ namespace llvm {
 namespace swift {
   enum IsInitialization_t : bool;
   enum IsTake_t : bool;
+  struct SerializableLLVMTypeRepresentation;
+  class SerializableHiddenTypeInfoRepresentation;
   class SILType;
 
 namespace irgen {
@@ -58,6 +62,12 @@ namespace irgen {
   class RValueSchema;
   class TypeLayoutEntry;
 
+std::unique_ptr<SerializableLLVMTypeRepresentation>
+serializeLLVMType(llvm::Type *type);
+llvm::Type *deserializeLLVMType(
+    IRGenModule &IGM,
+    const std::unique_ptr<SerializableLLVMTypeRepresentation> &representation);
+
 /// Ways in which an object can fit into a fixed-size buffer.
 enum class FixedPacking {
   /// It fits at offset zero.
@@ -70,24 +80,6 @@ enum class FixedPacking {
   Dynamic
 };
 
-enum class SpecialTypeInfoKind : uint8_t {
-  Unimplemented,
-
-  None,
-
-  /// Everything after this is statically fixed-size.
-  Fixed,
-  Weak,
-
-  /// Everything after this is loadable.
-  Loadable,
-  Reference,
-
-  Last_Kind = Reference
-};
-enum : unsigned { NumSpecialTypeInfoKindBits =
-  countBitsUsed(static_cast<unsigned>(SpecialTypeInfoKind::Last_Kind)) };
-
 /// Information about the IR representation and generation of the
 /// given type.
 class TypeInfo {
@@ -97,68 +89,16 @@ class TypeInfo {
   friend class TypeConverter;
 
 protected:
-  // clang-format off
-  union {
-    uint64_t OpaqueBits;
-
-    SWIFT_INLINE_BITFIELD_BASE(TypeInfo,
-                             bitmax(NumSpecialTypeInfoKindBits,8)+6+1+1+1+1+3+1+1,
-      /// The kind of supplemental API this type has, if any.
-      Kind : bitmax(NumSpecialTypeInfoKindBits,8),
-
-      /// The storage alignment of this type in log2 bytes.
-      AlignmentShift : 6,
-
-      /// Whether this type is known to be trivially destructible.
-      TriviallyDestroyable : 1,
-      
-      /// Whether this type is known to be bitwise-takable.
-      BitwiseTakable : 1,
-
-      /// Whether this type is known to be bitwise-borrowable.
-      BitwiseBorrowable : 1,
-
-      /// Whether this type is known to be copyable.
-      Copyable : 1,
-
-      /// An arbitrary discriminator for the subclass.  This is useful for e.g.
-      /// distinguishing between different TypeInfos that all implement the same
-      /// kind of type.
-      /// FIXME -- Create TypeInfoNodes.def and get rid of this field.
-      SubclassKind : 3,
-
-      /// Whether this type can be assumed to have a fixed size from all
-      /// resilience domains.
-      AlwaysFixedSize : 1,
-
-      /// Whether this type is ABI-accessible from this SILModule.
-      ABIAccessible : 1
-    );
-
-    /// FixedTypeInfo will use the remaining bits for the size.
-    ///
-    /// NOTE: Until one can define statically sized inline arrays in the
-    /// language, defining an extremely large object is quite impractical.
-    /// For now: "4 GiB should be more than good enough."
-    SWIFT_INLINE_BITFIELD_FULL(FixedTypeInfo, TypeInfo, 32,
-      : NumPadBits,
-
-      /// The storage size of this type in bytes.  This may be zero even
-      /// for well-formed and complete types, such as a trivial enum or
-      /// tuple.
-      Size : 32
-    );
-  } Bits;
-  // clang-format on
+  TypeInfoBitfields Bits;
 
   enum { InvalidSubclassKind = 0x7 };
 
   TypeInfo(llvm::Type *Type, Alignment A, IsTriviallyDestroyable_t pod,
-           IsBitwiseTakable_t bitwiseTakable,
-           IsCopyable_t copyable,
-           IsFixedSize_t alwaysFixedSize,
-           IsABIAccessible_t abiAccessible,
-           SpecialTypeInfoKind stik) : StorageType(Type) {
+           IsBitwiseTakable_t bitwiseTakable, IsCopyable_t copyable,
+           IsFixedSize_t alwaysFixedSize, IsABIAccessible_t abiAccessible,
+           SpecialTypeInfoKind stik)
+      : CreatedFromSerializableHiddenTypeInfoRepresentation(false),
+        StorageType(Type) {
     assert(stik >= SpecialTypeInfoKind::Fixed || !alwaysFixedSize);
     Bits.OpaqueBits = 0;
     Bits.TypeInfo.Kind = unsigned(stik);
@@ -173,6 +113,14 @@ protected:
     Bits.TypeInfo.ABIAccessible = abiAccessible;
   }
 
+  TypeInfo(IRGenModule &IGM,
+           const SerializableHiddenTypeInfoRepresentation &representation);
+
+  void populateSerializableHiddenTypeInfoRepresentation(
+      SerializableHiddenTypeInfoRepresentation &representation) const;
+
+  bool CreatedFromSerializableHiddenTypeInfoRepresentation;
+
   /// Change the minimum alignment of a stored value of this type.
   void setStorageAlignment(Alignment alignment) {
     auto Prev = Bits.TypeInfo.AlignmentShift;
@@ -180,6 +128,10 @@ protected:
     assert(Next >= Prev && "Alignment can only increase");
     (void)Prev;
     Bits.TypeInfo.AlignmentShift = Next;
+  }
+
+  void setSpecialTypeInfoKind(SpecialTypeInfoKind kind) {
+    Bits.TypeInfo.Kind = unsigned(kind);
   }
 
   void setSubclassKind(unsigned kind) {
@@ -200,6 +152,9 @@ private:
 
 public:
   virtual ~TypeInfo();
+
+  virtual std::unique_ptr<SerializableHiddenTypeInfoRepresentation>
+  createSerializableHiddenTypeInfoRepresentation() const;
 
   /// Unsafely cast this to the given subtype.
   template <class T> const T &as() const {

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -45,6 +45,7 @@ namespace swift {
   struct SerializableLLVMTypeRepresentation;
   class SerializableFixedTypeInfoRepresentation;
   class SerializableHiddenTypeInfoRepresentation;
+  class SerializableLoadableTypeInfoRepresentation;
   class SILType;
 
 namespace irgen {

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -45,6 +45,7 @@ namespace swift {
   struct SerializableLLVMTypeRepresentation;
   class SerializableFixedTypeInfoRepresentation;
   class SerializableHiddenTypeInfoRepresentation;
+  class SerializableLoadableRecordTypeInfoRepresentation;
   class SerializableLoadableTypeInfoRepresentation;
   class SILType;
 

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -43,6 +43,7 @@ namespace swift {
   enum IsInitialization_t : bool;
   enum IsTake_t : bool;
   struct SerializableLLVMTypeRepresentation;
+  class SerializableFixedTypeInfoRepresentation;
   class SerializableHiddenTypeInfoRepresentation;
   class SILType;
 

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -120,6 +120,7 @@ protected:
            const SerializableHiddenTypeInfoRepresentation &representation);
 
   void populateSerializableHiddenTypeInfoRepresentation(
+      IRGenModule &IGM,
       SerializableHiddenTypeInfoRepresentation &representation) const;
 
   bool CreatedFromSerializableHiddenTypeInfoRepresentation;
@@ -159,7 +160,7 @@ public:
   virtual ~TypeInfo();
 
   virtual std::unique_ptr<SerializableHiddenTypeInfoRepresentation>
-  createSerializableHiddenTypeInfoRepresentation() const;
+  createSerializableHiddenTypeInfoRepresentation(IRGenModule &IGM) const;
 
   /// Unsafely cast this to the given subtype.
   template <class T> const T &as() const {


### PR DESCRIPTION
TypeInfo objects largely govern LLVM IR generation of operations manipulating types in Swift (ex. copy this type, destroy this type). The whole idea behind hidden types is to serialize the minimal amount of information about a type such that a client without the AST based definition of the type, can still generate correct and efficient IR manipulating the type. This means producing correct and compatible TypeInfo for the type from its hidden representations.

What is a correct and efficient TypeInfo representation is not very easily defined, and it often depends on correspondence with TypeInfo derived from the visible type. For example, if TypeInfo derived from the visible type passes the type in registers, so should TypeInfo derived from the hidden type.

Until now, efforts have been made to produce analogous "Hidden" versions of TypeInfo from the hidden representation, not re-use the same class. So for example, the hidden representation of a Swift struct might produce a HiddenLoadableStructTypeInfo object, where the visible representation might just produce a LoadableStructTypeInfo object.

This approach has been error prone, and I expect it to be difficult to maintain in the future. When deciding what information is necessary in a hidden representation, you must manually audit the visible representation and convince yourself that your hidden TypeInfo is compatible. If such issues are introduced, it can be easy to introduce miss-compiles. For example, in a previous attempt to represent ClangLoadableRecordTypeInfo, I failed to correctly encode extra inhabitant information, a bug which would subtly cause enums containing hidden  ClangLoadableRecordTypeInfo object to differ in layout from those generated from the visible AST.

In this PR we change our approach. We re-use the existing TypeInfo objects, and we add state to them that encodes if they were created from a hidden representation or not. This allows us to assert against operations which are not supported on hidden types (ie. field access operations), and co-locate the hidden and visible implementations of the same operation. For example, the copy of a hidden C++ type may go through a witness call, while the visible may not, but the two implementations are defined in the same method and so can be more easily compared for compatibility.

Lastly, we introduce a hierarchy of types that represent TypeInfo objects in a more serializable format. It is desirable to have as abstract a serializable representation for hidden types (after all they are supposed to be an implementation detail). However, it has become clear that attempting to introduce too abstract a representation, often leads to correctness bugs. So instead we faithfully serialize information very close to the state actually stored in TypeInfo object (ex: just store the layout instead of trying to re-derive it from some abstract layout), and assert against usages of information we don't faithfully encode (ie. AST nodes).