### PR TITLE
[Utils] improve call coverage for classes

### DIFF
--- a/test/Interop/C/swiftify-import/counted-by-legacy.swift
+++ b/test/Interop/C/swiftify-import/counted-by-legacy.swift
@@ -346,26 +346,46 @@ module Test {
 
 //--- test.swift
 // GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -enable-experimental-feature SafeInteropWrappers -plugin-path %swift-plugin-dir -I %t -source-filename=x -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
-// GENERATED-HASH: 575ed83419e2b97be27cd4b077edb6ccbb2b892bf8e72e40c108bd581b15a6b4
+// GENERATED-HASH: e3f8601f1d670cf8b5b4d691e36ca2f93d17ca10294531e489ab8fcc51393fa7
 import Test
 
 func call_simple(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
   return unsafe simple(len, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe simple(p)
+}
+
 func call_simpleFlipped(_ p: UnsafeMutablePointer<CInt>!, _ len: CInt) {
   return unsafe simpleFlipped(p, len)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_simpleFlipped(_ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe simpleFlipped(p)
 }
 
 func call_swiftAttr(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
   return unsafe swiftAttr(len, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_swiftAttr(_ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe swiftAttr(p)
+}
+
 func call_shared(_ len: CInt, _ p1: UnsafeMutablePointer<CInt>!, _ p2: UnsafeMutablePointer<CInt>!) {
   return unsafe shared(len, p1, p2)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_shared(_ p1: UnsafeMutableBufferPointer<CInt>, _ p2: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe shared(p1, p2)
+}
+
 func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: UnsafeMutablePointer<CInt>!) {
+  return unsafe complexExpr(len, offset, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
   return unsafe complexExpr(len, offset, p)
 }
 
@@ -373,15 +393,31 @@ func call_nullUnspecified(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
   return unsafe nullUnspecified(len, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe nullUnspecified(p)
+}
+
 func call_nonnull(_ len: CInt, _ p: UnsafeMutablePointer<CInt>) {
   return unsafe nonnull(len, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe nonnull(p)
 }
 
 func call_nullable(_ len: CInt, _ p: UnsafeMutablePointer<CInt>?) {
   return unsafe nullable(len, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ p: UnsafeMutableBufferPointer<CInt>?) {
+  return unsafe nullable(p)
+}
+
 func call_returnPointer(_ len: CInt) -> UnsafeMutablePointer<CInt>! {
+  return unsafe returnPointer(len)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_returnPointer(_ len: CInt) -> UnsafeMutableBufferPointer<CInt> {
   return unsafe returnPointer(len)
 }
 
@@ -389,7 +425,15 @@ func call_offByOne(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
   return unsafe offByOne(len, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_offByOne(_ len: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe offByOne(len, p)
+}
+
 func call_offBySome(_ len: CInt, _ offset: CInt, _ p: UnsafeMutablePointer<CInt>!) {
+  return unsafe offBySome(len, offset, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_offBySome(_ len: CInt, _ offset: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
   return unsafe offBySome(len, offset, p)
 }
 
@@ -397,7 +441,15 @@ func call_scalar(_ m: CInt, _ n: CInt, _ p: UnsafeMutablePointer<CInt>!) {
   return unsafe scalar(m, n, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_scalar(_ m: CInt, _ n: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe scalar(m, n, p)
+}
+
 func call_bitwise(_ m: CInt, _ n: CInt, _ o: CInt, _ p: UnsafeMutablePointer<CInt>!) {
+  return unsafe bitwise(m, n, o, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_bitwise(_ m: CInt, _ n: CInt, _ o: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
   return unsafe bitwise(m, n, o, p)
 }
 
@@ -405,7 +457,15 @@ func call_bitshift(_ m: CInt, _ n: CInt, _ o: CInt, _ p: UnsafeMutablePointer<CI
   return unsafe bitshift(m, n, o, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_bitshift(_ m: CInt, _ n: CInt, _ o: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe bitshift(m, n, o, p)
+}
+
 func call_constInt(_ p: UnsafeMutablePointer<CInt>!) {
+  return unsafe constInt(p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_constInt(_ p: UnsafeMutableBufferPointer<CInt>) {
   return unsafe constInt(p)
 }
 
@@ -413,11 +473,23 @@ func call_constFloatCastedToInt(_ p: UnsafeMutablePointer<CInt>!) {
   return unsafe constFloatCastedToInt(p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_constFloatCastedToInt(_ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe constFloatCastedToInt(p)
+}
+
 func call_sizeofType(_ p: UnsafeMutablePointer<CInt>!) {
   return unsafe sizeofType(p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_sizeofType(_ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe sizeofType(p)
+}
+
 func call_sizeofParam(_ p: UnsafeMutablePointer<CChar>!) {
+  return unsafe sizeofParam(p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_sizeofParam(_ p: UnsafeMutableBufferPointer<CChar>) {
   return unsafe sizeofParam(p)
 }
 
@@ -441,6 +513,10 @@ func call_floatCastToInt(_ meters: CFloat, _ p: UnsafeMutablePointer<CInt>!) {
   return unsafe floatCastToInt(meters, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_floatCastToInt(_ meters: CFloat, _ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe floatCastToInt(meters, p)
+}
+
 func call_pointerCastToInt(_ square: UnsafeMutablePointer<CInt>!, _ p: UnsafeMutablePointer<CInt>!) {
   return unsafe pointerCastToInt(square, p)
 }
@@ -449,7 +525,15 @@ func call_nanAsInt(_ p: UnsafeMutablePointer<CInt>!) {
   return unsafe nanAsInt(p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nanAsInt(_ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe nanAsInt(p)
+}
+
 func call_unsignedLiteral(_ p: UnsafeMutablePointer<CInt>!) {
+  return unsafe unsignedLiteral(p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_unsignedLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
   return unsafe unsignedLiteral(p)
 }
 
@@ -457,7 +541,15 @@ func call_longLiteral(_ p: UnsafeMutablePointer<CInt>!) {
   return unsafe longLiteral(p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_longLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe longLiteral(p)
+}
+
 func call_hexLiteral(_ p: UnsafeMutablePointer<CInt>!) {
+  return unsafe hexLiteral(p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_hexLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
   return unsafe hexLiteral(p)
 }
 
@@ -465,7 +557,15 @@ func call_binaryLiteral(_ p: UnsafeMutablePointer<CInt>!) {
   return unsafe binaryLiteral(p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_binaryLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe binaryLiteral(p)
+}
+
 func call_octalLiteral(_ p: UnsafeMutablePointer<CInt>!) {
+  return unsafe octalLiteral(p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_octalLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
   return unsafe octalLiteral(p)
 }
 
@@ -473,7 +573,15 @@ func call_implicitIntCast(_ offset: CLongLong, _ len: CInt, _ p: UnsafeMutablePo
   return unsafe implicitIntCast(offset, len, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_implicitIntCast(_ offset: CLongLong, _ len: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe implicitIntCast(offset, len, p)
+}
+
 func call_castTwiceLiteral(_ p: UnsafeMutablePointer<CInt>!) {
+  return unsafe castTwiceLiteral(p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_castTwiceLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
   return unsafe castTwiceLiteral(p)
 }
 
@@ -481,122 +589,14 @@ func call_castParam(_ p: UnsafeMutablePointer<CInt>!, _ len: CShort) {
   return unsafe castParam(p, len)
 }
 
-func call_castParam2(_ p: UnsafeMutablePointer<CInt>!, _ len: CUnsignedInt) {
-  return unsafe castParam2(p, len)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_binaryLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe binaryLiteral(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_bitshift(_ m: CInt, _ n: CInt, _ o: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe bitshift(m, n, o, p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_bitwise(_ m: CInt, _ n: CInt, _ o: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe bitwise(m, n, o, p)
-}
-
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_castParam(_ p: UnsafeMutableBufferPointer<CInt>, _ len: CShort) {
   return unsafe castParam(p, len)
 }
 
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_castParam2(_ p: UnsafeMutableBufferPointer<CInt>, _ len: CUnsignedInt) {
+func call_castParam2(_ p: UnsafeMutablePointer<CInt>!, _ len: CUnsignedInt) {
   return unsafe castParam2(p, len)
 }
 
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_castTwiceLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe castTwiceLiteral(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe complexExpr(len, offset, p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_constFloatCastedToInt(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe constFloatCastedToInt(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_constInt(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe constInt(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_floatCastToInt(_ meters: CFloat, _ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe floatCastToInt(meters, p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_hexLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe hexLiteral(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_implicitIntCast(_ offset: CLongLong, _ len: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe implicitIntCast(offset, len, p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_longLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe longLiteral(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nanAsInt(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe nanAsInt(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe nonnull(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe nullUnspecified(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ p: UnsafeMutableBufferPointer<CInt>?) {
-  return unsafe nullable(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_octalLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe octalLiteral(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_offByOne(_ len: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe offByOne(len, p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_offBySome(_ len: CInt, _ offset: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe offBySome(len, offset, p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_returnPointer(_ len: CInt) -> UnsafeMutableBufferPointer<CInt> {
-  return unsafe returnPointer(len)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_scalar(_ m: CInt, _ n: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe scalar(m, n, p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_shared(_ p1: UnsafeMutableBufferPointer<CInt>, _ p2: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe shared(p1, p2)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe simple(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_simpleFlipped(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe simpleFlipped(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_sizeofParam(_ p: UnsafeMutableBufferPointer<CChar>) {
-  return unsafe sizeofParam(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_sizeofType(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe sizeofType(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_swiftAttr(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe swiftAttr(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_unsignedLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe unsignedLiteral(p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_castParam2(_ p: UnsafeMutableBufferPointer<CInt>, _ len: CUnsignedInt) {
+  return unsafe castParam2(p, len)
 }

--- a/test/Interop/C/swiftify-import/counted-by-lifetimebound-legacy.swift
+++ b/test/Interop/C/swiftify-import/counted-by-lifetimebound-legacy.swift
@@ -246,154 +246,25 @@ module Test {
 
 //--- test.swift
 // GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature Lifetimes -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers -Xcc -Wno-nullability-completeness > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
-// GENERATED-HASH: e578470f1190d56e60e74393710cb078725172a3897488e395921c158c79e5e5
+// GENERATED-HASH: 8476d10c0db1df2650fcc472ce02aac4bdc4498f8aa2b527764da0c3167d1624
 import Test
 
 func call_simple(_ len: CInt, _ len2: CInt, _ p: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
   return unsafe simple(len, len2, p)
 }
 
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ len: CInt, _ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
+  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
+  return simple(len, &p)
+}
+
 func call_shared(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
   return unsafe shared(len, p)
-}
-
-func call_complexExpr(_ len: CInt, _ offset: CInt, _ len2: CInt, _ p: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
-  return unsafe complexExpr(len, offset, len2, p)
-}
-
-func call_nullUnspecified(_ len: CInt, _ len2: CInt, _ p: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
-  return unsafe nullUnspecified(len, len2, p)
-}
-
-func call_nonnull(_ len: CInt, _ len2: CInt, _ p: UnsafeMutablePointer<CInt>) -> UnsafeMutablePointer<CInt> {
-  return unsafe nonnull(len, len2, p)
-}
-
-func call_nullable(_ len: CInt, _ len2: CInt, _ p: UnsafeMutablePointer<CInt>?) -> UnsafeMutablePointer<CInt>? {
-  return unsafe nullable(len, len2, p)
-}
-
-func call_opaque(_ len: CInt, _ len2: CInt, _ p: OpaquePointer!) -> OpaquePointer! {
-  return unsafe opaque(len, len2, p)
-}
-
-func call_noncountedLifetime(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
-  return unsafe noncountedLifetime(len, p)
-}
-
-func call_constant(_ p: UnsafeMutablePointer<CInt>?) -> UnsafeMutablePointer<CInt>? {
-  return unsafe constant(p)
-}
-
-func call_lifetimeboundEscapableReturn(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) -> EscapableStruct {
-  return unsafe lifetimeboundEscapableReturn(len, p)
-}
-
-// expected-stable-error@+2{{a function with a ~Escapable result requires '@_lifetime(...)'}}
-// expected-experimental-error@+1{{a function with a ~Escapable result requires '@_lifetime(...)'}}
-func call_lifetimeboundNonescapableReturn(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) -> NonescapableStruct {
-  return unsafe lifetimeboundNonescapableReturn(len, p)
-}
-
-func call_lifetimeboundNonescapableReturnDoubleBounds(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!, _ s: NonescapableStruct) -> NonescapableStruct {
-  return unsafe lifetimeboundNonescapableReturnDoubleBounds(len, p, s)
-}
-
-func call_oneLifetimeboundOneEscapable(_ len: CInt, _ len2: CInt, _ p: UnsafeMutablePointer<CInt>!, _ len3: CInt, _ p2: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
-  return unsafe oneLifetimeboundOneEscapable(len, len2, p, len3, p2)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
-  // expected-stable-error@+3{{missing argument for parameter #4 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
-  return complexExpr(len, offset, &p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_constant(_ p: inout MutableSpan<CInt>?) -> MutableSpan<CInt>? {
-  // expected-stable-error@+2{{cannot convert value of type 'UnsafeMutablePointer<MutableSpan<CInt>?>' (aka 'UnsafeMutablePointer<Optional<MutableSpan<Int32>>>') to expected argument type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>?' (aka 'Optional<MutableSpan<Int32>>')}}
-  return constant(&p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_lifetimeboundEscapableReturn(_ p: UnsafeMutableBufferPointer<CInt>) -> EscapableStruct {
-  // expected-stable-error@+2{{missing argument for parameter #2 in call}}
-  // expected-stable-error@+1{{cannot convert value of type 'UnsafeMutableBufferPointer<CInt>' (aka 'UnsafeMutableBufferPointer<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
-  return unsafe lifetimeboundEscapableReturn(p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_lifetimeboundNonescapableReturn(_ p: inout MutableSpan<CInt>) -> NonescapableStruct {
-  // expected-stable-error@+3{{missing argument for parameter #2 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'UnsafeMutablePointer<MutableSpan<CInt>>' (aka 'UnsafeMutablePointer<MutableSpan<Int32>>') to expected argument type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>')}}
-  // expected-stable-error@+1{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
-  return lifetimeboundNonescapableReturn(&p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p, copy s)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_lifetimeboundNonescapableReturnDoubleBounds(_ p: inout MutableSpan<CInt>, _ s: NonescapableStruct) -> NonescapableStruct {
-  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'NonescapableStruct' to expected argument type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>')}}
-  // expected-stable-error@+1{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
-  return lifetimeboundNonescapableReturnDoubleBounds(&p, s)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(borrow p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_noncountedLifetime(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) -> MutableSpan<CInt> {
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
-  return unsafe noncountedLifetime(len, p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ len: CInt, _ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
-  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
-  return nonnull(len, &p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ len: CInt, _ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
-  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
-  return nullUnspecified(len, &p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ len: CInt, _ p: inout MutableSpan<CInt>?) -> MutableSpan<CInt>? {
-  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<CInt>?' (aka 'Optional<MutableSpan<Int32>>') to expected argument type 'CInt' (aka 'Int32')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>?' (aka 'Optional<MutableSpan<Int32>>')}}
-  return nullable(len, &p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_oneLifetimeboundOneEscapable(_ len: CInt, _ p: inout MutableSpan<CInt>, _ p2: UnsafeMutableBufferPointer<CInt>) -> MutableSpan<CInt> {
-  // expected-stable-error@+4{{cannot convert value of type 'UnsafeMutableBufferPointer<CInt>' (aka 'UnsafeMutableBufferPointer<Int32>') to expected argument type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>')}}
-  // expected-stable-error@+3{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
-  // expected-stable-error@+2{{missing arguments for parameters #4, #5 in call}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
-  return unsafe oneLifetimeboundOneEscapable(len, &p, p2)
 }
 
 @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
@@ -407,12 +278,141 @@ func call_oneLifetimeboundOneEscapable(_ len: CInt, _ len2: CInt, _ p: UnsafeMut
   return shared(&p)
 }
 
+func call_complexExpr(_ len: CInt, _ offset: CInt, _ len2: CInt, _ p: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
+  return unsafe complexExpr(len, offset, len2, p)
+}
+
 @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 @_lifetime(copy p)
 @_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ len: CInt, _ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
+  // expected-stable-error@+3{{missing argument for parameter #4 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
+  return complexExpr(len, offset, &p)
+}
+
+func call_nullUnspecified(_ len: CInt, _ len2: CInt, _ p: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
+  return unsafe nullUnspecified(len, len2, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ len: CInt, _ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
   // expected-stable-error@+3{{missing argument for parameter #3 in call}}
   // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
   // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
-  return simple(len, &p)
+  return nullUnspecified(len, &p)
+}
+
+func call_nonnull(_ len: CInt, _ len2: CInt, _ p: UnsafeMutablePointer<CInt>) -> UnsafeMutablePointer<CInt> {
+  return unsafe nonnull(len, len2, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ len: CInt, _ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
+  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
+  return nonnull(len, &p)
+}
+
+func call_nullable(_ len: CInt, _ len2: CInt, _ p: UnsafeMutablePointer<CInt>?) -> UnsafeMutablePointer<CInt>? {
+  return unsafe nullable(len, len2, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ len: CInt, _ p: inout MutableSpan<CInt>?) -> MutableSpan<CInt>? {
+  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<CInt>?' (aka 'Optional<MutableSpan<Int32>>') to expected argument type 'CInt' (aka 'Int32')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>?' (aka 'Optional<MutableSpan<Int32>>')}}
+  return nullable(len, &p)
+}
+
+func call_opaque(_ len: CInt, _ len2: CInt, _ p: OpaquePointer!) -> OpaquePointer! {
+  return unsafe opaque(len, len2, p)
+}
+
+func call_noncountedLifetime(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
+  return unsafe noncountedLifetime(len, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(borrow p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_noncountedLifetime(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) -> MutableSpan<CInt> {
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
+  return unsafe noncountedLifetime(len, p)
+}
+
+func call_constant(_ p: UnsafeMutablePointer<CInt>?) -> UnsafeMutablePointer<CInt>? {
+  return unsafe constant(p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_constant(_ p: inout MutableSpan<CInt>?) -> MutableSpan<CInt>? {
+  // expected-stable-error@+2{{cannot convert value of type 'UnsafeMutablePointer<MutableSpan<CInt>?>' (aka 'UnsafeMutablePointer<Optional<MutableSpan<Int32>>>') to expected argument type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>?' (aka 'Optional<MutableSpan<Int32>>')}}
+  return constant(&p)
+}
+
+func call_lifetimeboundEscapableReturn(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) -> EscapableStruct {
+  return unsafe lifetimeboundEscapableReturn(len, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_lifetimeboundEscapableReturn(_ p: UnsafeMutableBufferPointer<CInt>) -> EscapableStruct {
+  // expected-stable-error@+2{{missing argument for parameter #2 in call}}
+  // expected-stable-error@+1{{cannot convert value of type 'UnsafeMutableBufferPointer<CInt>' (aka 'UnsafeMutableBufferPointer<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
+  return unsafe lifetimeboundEscapableReturn(p)
+}
+
+// expected-stable-error@+2{{a function with a ~Escapable result requires '@_lifetime(...)'}}
+// expected-experimental-error@+1{{a function with a ~Escapable result requires '@_lifetime(...)'}}
+func call_lifetimeboundNonescapableReturn(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) -> NonescapableStruct {
+  return unsafe lifetimeboundNonescapableReturn(len, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_lifetimeboundNonescapableReturn(_ p: inout MutableSpan<CInt>) -> NonescapableStruct {
+  // expected-stable-error@+3{{missing argument for parameter #2 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'UnsafeMutablePointer<MutableSpan<CInt>>' (aka 'UnsafeMutablePointer<MutableSpan<Int32>>') to expected argument type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>')}}
+  // expected-stable-error@+1{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
+  return lifetimeboundNonescapableReturn(&p)
+}
+
+func call_lifetimeboundNonescapableReturnDoubleBounds(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!, _ s: NonescapableStruct) -> NonescapableStruct {
+  return unsafe lifetimeboundNonescapableReturnDoubleBounds(len, p, s)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p, copy s)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_lifetimeboundNonescapableReturnDoubleBounds(_ p: inout MutableSpan<CInt>, _ s: NonescapableStruct) -> NonescapableStruct {
+  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'NonescapableStruct' to expected argument type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>')}}
+  // expected-stable-error@+1{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
+  return lifetimeboundNonescapableReturnDoubleBounds(&p, s)
+}
+
+func call_oneLifetimeboundOneEscapable(_ len: CInt, _ len2: CInt, _ p: UnsafeMutablePointer<CInt>!, _ len3: CInt, _ p2: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
+  return unsafe oneLifetimeboundOneEscapable(len, len2, p, len3, p2)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_oneLifetimeboundOneEscapable(_ len: CInt, _ p: inout MutableSpan<CInt>, _ p2: UnsafeMutableBufferPointer<CInt>) -> MutableSpan<CInt> {
+  // expected-stable-error@+4{{cannot convert value of type 'UnsafeMutableBufferPointer<CInt>' (aka 'UnsafeMutableBufferPointer<Int32>') to expected argument type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>')}}
+  // expected-stable-error@+3{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
+  // expected-stable-error@+2{{missing arguments for parameters #4, #5 in call}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
+  return unsafe oneLifetimeboundOneEscapable(len, &p, p2)
 }

--- a/test/Interop/C/swiftify-import/counted-by-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/counted-by-lifetimebound.swift
@@ -244,154 +244,25 @@ module Test {
 
 //--- test.swift
 // GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature SafeInteropWrappersNullAsEmptySpan -Xcc -Wno-nullability-completeness > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
-// GENERATED-HASH: a717bad6588597058f5a485905c9400d852f482e25d7b378fab6861cf2e92221
+// GENERATED-HASH: e82c2339c5334ba77a730cd4b5d1faf36a24849e23e0c7643d1ff3578462aff5
 import Test
 
 func call_simple(_ len: CInt, _ len2: CInt, _ p: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
   return unsafe simple(len, len2, p)
 }
 
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ len: CInt, _ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
+  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
+  return simple(len, &p)
+}
+
 func call_shared(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
   return unsafe shared(len, p)
-}
-
-func call_complexExpr(_ len: CInt, _ offset: CInt, _ len2: CInt, _ p: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
-  return unsafe complexExpr(len, offset, len2, p)
-}
-
-func call_nullUnspecified(_ len: CInt, _ len2: CInt, _ p: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
-  return unsafe nullUnspecified(len, len2, p)
-}
-
-func call_nonnull(_ len: CInt, _ len2: CInt, _ p: UnsafeMutablePointer<CInt>) -> UnsafeMutablePointer<CInt> {
-  return unsafe nonnull(len, len2, p)
-}
-
-func call_nullable(_ len: CInt, _ len2: CInt, _ p: UnsafeMutablePointer<CInt>?) -> UnsafeMutablePointer<CInt>? {
-  return unsafe nullable(len, len2, p)
-}
-
-func call_opaque(_ len: CInt, _ len2: CInt, _ p: OpaquePointer!) -> OpaquePointer! {
-  return unsafe opaque(len, len2, p)
-}
-
-func call_noncountedLifetime(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
-  return unsafe noncountedLifetime(len, p)
-}
-
-func call_constant(_ p: UnsafeMutablePointer<CInt>?) -> UnsafeMutablePointer<CInt>? {
-  return unsafe constant(p)
-}
-
-func call_lifetimeboundEscapableReturn(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) -> EscapableStruct {
-  return unsafe lifetimeboundEscapableReturn(len, p)
-}
-
-// expected-stable-error@+2{{a function with a ~Escapable result requires '@_lifetime(...)'}}
-// expected-experimental-error@+1{{a function with a ~Escapable result requires '@_lifetime(...)'}}
-func call_lifetimeboundNonescapableReturn(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) -> NonescapableStruct {
-  return unsafe lifetimeboundNonescapableReturn(len, p)
-}
-
-func call_lifetimeboundNonescapableReturnDoubleBounds(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!, _ s: NonescapableStruct) -> NonescapableStruct {
-  return unsafe lifetimeboundNonescapableReturnDoubleBounds(len, p, s)
-}
-
-func call_oneLifetimeboundOneEscapable(_ len: CInt, _ len2: CInt, _ p: UnsafeMutablePointer<CInt>!, _ len3: CInt, _ p2: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
-  return unsafe oneLifetimeboundOneEscapable(len, len2, p, len3, p2)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
-  // expected-stable-error@+3{{missing argument for parameter #4 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
-  return complexExpr(len, offset, &p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_constant(_ p: inout MutableSpan<CInt>?) -> MutableSpan<CInt> {
-  // expected-stable-error@+2{{cannot convert value of type 'UnsafeMutablePointer<MutableSpan<CInt>?>' (aka 'UnsafeMutablePointer<Optional<MutableSpan<Int32>>>') to expected argument type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
-  return constant(&p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_lifetimeboundEscapableReturn(_ p: UnsafeMutableBufferPointer<CInt>) -> EscapableStruct {
-  // expected-stable-error@+2{{missing argument for parameter #2 in call}}
-  // expected-stable-error@+1{{cannot convert value of type 'UnsafeMutableBufferPointer<CInt>' (aka 'UnsafeMutableBufferPointer<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
-  return unsafe lifetimeboundEscapableReturn(p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_lifetimeboundNonescapableReturn(_ p: inout MutableSpan<CInt>) -> NonescapableStruct {
-  // expected-stable-error@+3{{missing argument for parameter #2 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'UnsafeMutablePointer<MutableSpan<CInt>>' (aka 'UnsafeMutablePointer<MutableSpan<Int32>>') to expected argument type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>')}}
-  // expected-stable-error@+1{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
-  return lifetimeboundNonescapableReturn(&p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p, copy s)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_lifetimeboundNonescapableReturnDoubleBounds(_ p: inout MutableSpan<CInt>, _ s: NonescapableStruct) -> NonescapableStruct {
-  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'NonescapableStruct' to expected argument type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>')}}
-  // expected-stable-error@+1{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
-  return lifetimeboundNonescapableReturnDoubleBounds(&p, s)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(borrow p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_noncountedLifetime(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) -> MutableSpan<CInt> {
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
-  return unsafe noncountedLifetime(len, p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ len: CInt, _ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
-  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
-  return nonnull(len, &p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ len: CInt, _ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
-  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
-  return nullUnspecified(len, &p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ len: CInt, _ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
-  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
-  return nullable(len, &p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_oneLifetimeboundOneEscapable(_ len: CInt, _ p: inout MutableSpan<CInt>, _ p2: UnsafeMutableBufferPointer<CInt>) -> MutableSpan<CInt> {
-  // expected-stable-error@+4{{cannot convert value of type 'UnsafeMutableBufferPointer<CInt>' (aka 'UnsafeMutableBufferPointer<Int32>') to expected argument type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>')}}
-  // expected-stable-error@+3{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
-  // expected-stable-error@+2{{missing arguments for parameters #4, #5 in call}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
-  return unsafe oneLifetimeboundOneEscapable(len, &p, p2)
 }
 
 @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
@@ -405,12 +276,141 @@ func call_oneLifetimeboundOneEscapable(_ len: CInt, _ len2: CInt, _ p: UnsafeMut
   return shared(&p)
 }
 
+func call_complexExpr(_ len: CInt, _ offset: CInt, _ len2: CInt, _ p: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
+  return unsafe complexExpr(len, offset, len2, p)
+}
+
 @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 @_lifetime(copy p)
 @_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ len: CInt, _ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
+  // expected-stable-error@+3{{missing argument for parameter #4 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
+  return complexExpr(len, offset, &p)
+}
+
+func call_nullUnspecified(_ len: CInt, _ len2: CInt, _ p: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
+  return unsafe nullUnspecified(len, len2, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ len: CInt, _ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
   // expected-stable-error@+3{{missing argument for parameter #3 in call}}
   // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
   // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
-  return simple(len, &p)
+  return nullUnspecified(len, &p)
+}
+
+func call_nonnull(_ len: CInt, _ len2: CInt, _ p: UnsafeMutablePointer<CInt>) -> UnsafeMutablePointer<CInt> {
+  return unsafe nonnull(len, len2, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ len: CInt, _ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
+  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
+  return nonnull(len, &p)
+}
+
+func call_nullable(_ len: CInt, _ len2: CInt, _ p: UnsafeMutablePointer<CInt>?) -> UnsafeMutablePointer<CInt>? {
+  return unsafe nullable(len, len2, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ len: CInt, _ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
+  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
+  return nullable(len, &p)
+}
+
+func call_opaque(_ len: CInt, _ len2: CInt, _ p: OpaquePointer!) -> OpaquePointer! {
+  return unsafe opaque(len, len2, p)
+}
+
+func call_noncountedLifetime(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
+  return unsafe noncountedLifetime(len, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(borrow p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_noncountedLifetime(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) -> MutableSpan<CInt> {
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
+  return unsafe noncountedLifetime(len, p)
+}
+
+func call_constant(_ p: UnsafeMutablePointer<CInt>?) -> UnsafeMutablePointer<CInt>? {
+  return unsafe constant(p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_constant(_ p: inout MutableSpan<CInt>?) -> MutableSpan<CInt> {
+  // expected-stable-error@+2{{cannot convert value of type 'UnsafeMutablePointer<MutableSpan<CInt>?>' (aka 'UnsafeMutablePointer<Optional<MutableSpan<Int32>>>') to expected argument type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
+  return constant(&p)
+}
+
+func call_lifetimeboundEscapableReturn(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) -> EscapableStruct {
+  return unsafe lifetimeboundEscapableReturn(len, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_lifetimeboundEscapableReturn(_ p: UnsafeMutableBufferPointer<CInt>) -> EscapableStruct {
+  // expected-stable-error@+2{{missing argument for parameter #2 in call}}
+  // expected-stable-error@+1{{cannot convert value of type 'UnsafeMutableBufferPointer<CInt>' (aka 'UnsafeMutableBufferPointer<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
+  return unsafe lifetimeboundEscapableReturn(p)
+}
+
+// expected-stable-error@+2{{a function with a ~Escapable result requires '@_lifetime(...)'}}
+// expected-experimental-error@+1{{a function with a ~Escapable result requires '@_lifetime(...)'}}
+func call_lifetimeboundNonescapableReturn(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) -> NonescapableStruct {
+  return unsafe lifetimeboundNonescapableReturn(len, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_lifetimeboundNonescapableReturn(_ p: inout MutableSpan<CInt>) -> NonescapableStruct {
+  // expected-stable-error@+3{{missing argument for parameter #2 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'UnsafeMutablePointer<MutableSpan<CInt>>' (aka 'UnsafeMutablePointer<MutableSpan<Int32>>') to expected argument type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>')}}
+  // expected-stable-error@+1{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
+  return lifetimeboundNonescapableReturn(&p)
+}
+
+func call_lifetimeboundNonescapableReturnDoubleBounds(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!, _ s: NonescapableStruct) -> NonescapableStruct {
+  return unsafe lifetimeboundNonescapableReturnDoubleBounds(len, p, s)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p, copy s)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_lifetimeboundNonescapableReturnDoubleBounds(_ p: inout MutableSpan<CInt>, _ s: NonescapableStruct) -> NonescapableStruct {
+  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'NonescapableStruct' to expected argument type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>')}}
+  // expected-stable-error@+1{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
+  return lifetimeboundNonescapableReturnDoubleBounds(&p, s)
+}
+
+func call_oneLifetimeboundOneEscapable(_ len: CInt, _ len2: CInt, _ p: UnsafeMutablePointer<CInt>!, _ len3: CInt, _ p2: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
+  return unsafe oneLifetimeboundOneEscapable(len, len2, p, len3, p2)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_oneLifetimeboundOneEscapable(_ len: CInt, _ p: inout MutableSpan<CInt>, _ p2: UnsafeMutableBufferPointer<CInt>) -> MutableSpan<CInt> {
+  // expected-stable-error@+4{{cannot convert value of type 'UnsafeMutableBufferPointer<CInt>' (aka 'UnsafeMutableBufferPointer<Int32>') to expected argument type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>')}}
+  // expected-stable-error@+3{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
+  // expected-stable-error@+2{{missing arguments for parameters #4, #5 in call}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
+  return unsafe oneLifetimeboundOneEscapable(len, &p, p2)
 }

--- a/test/Interop/C/swiftify-import/counted-by-noescape-legacy.swift
+++ b/test/Interop/C/swiftify-import/counted-by-noescape-legacy.swift
@@ -368,187 +368,31 @@ module Test {
 
 //--- test.swift
 // GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature Lifetimes -Xcc -Wno-ignored-attributes -Xcc -Wno-nullability-completeness > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
-// GENERATED-HASH: 847748c9e70920d8eab1e64135c9178f418c0de85b3bedde96563a04d64417bf
+// GENERATED-HASH: af7be31152619e22cda33e9809902630827157be6fc9cd9ba1ce46afe34a5cf0
 import Test
 
 func call_simple(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
   return unsafe simple(len, p)
 }
 
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ p: inout MutableSpan<CInt>) {
+  return simple(&p)
+}
+
 func call_swiftAttr(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
   return unsafe swiftAttr(len, p)
 }
 
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_swiftAttr(_ p: inout MutableSpan<CInt>) {
+  return swiftAttr(&p)
+}
+
 func call_shared(_ len: CInt, _ p1: UnsafeMutablePointer<CInt>!, _ p2: UnsafeMutablePointer<CInt>!) {
   return unsafe shared(len, p1, p2)
-}
-
-func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: UnsafeMutablePointer<CInt>!) {
-  return unsafe complexExpr(len, offset, p)
-}
-
-func call_nullUnspecified(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
-  return unsafe nullUnspecified(len, p)
-}
-
-func call_nonnull(_ len: CInt, _ p: UnsafeMutablePointer<CInt>) {
-  return unsafe nonnull(len, p)
-}
-
-func call_nullable(_ len: CInt, _ p: UnsafeMutablePointer<CInt>?) {
-  return unsafe nullable(len, p)
-}
-
-func call_returnPointer(_ len: CInt) -> UnsafeMutablePointer<CInt>! {
-  return unsafe returnPointer(len)
-}
-
-func call_anonymous(_ len: CInt, _ _anonymous_param1: UnsafeMutablePointer<CInt>?) {
-  return unsafe anonymous(len,  _anonymous_param1)
-}
-
-func call_keyword(_ len: CInt, _ func: UnsafeMutablePointer<CInt>?, _ extension: CInt, _ init: CInt, _ open: CInt, _ var: CInt, _ is: CInt, _ as: CInt, _ in: CInt, _ guard: CInt, _ where: CInt) {
-  return unsafe keyword(len, `func`, `extension`, `init`, open, `var`, `is`, `as`, `in`, `guard`, `where`)
-}
-
-func call_pointerName(_ len: CInt, _  _pointerName_param1: UnsafeMutablePointer<CInt>?) {
-  return unsafe pointerName(len,  _pointerName_param1)
-}
-
-func call_lenName(_  _lenName_param0: CInt, _ size: CInt, _ p: UnsafeMutablePointer<CInt>?) {
-  return unsafe lenName( _lenName_param0, size, p)
-}
-
-func call_func(_ len: CInt, _  _func_param1: UnsafeMutablePointer<CInt>?) {
-  return unsafe `func`(len,  _func_param1)
-}
-
-func call_funcRenamed(len: CInt, func: UnsafeMutablePointer<CInt>?, extension: CInt, init: CInt, open: CInt, `var`: CInt, is: CInt, as: CInt, in: CInt, guard: CInt, where: CInt) -> UnsafeMutableRawPointer! {
-  return unsafe funcRenamed(len: len, func: `func`, extension: `extension`, init: `init`, open: open, var: `var`, is: `is`, as: `as`, in: `in`, guard: `guard`, where: `where`)
-}
-
-func call_funcRenamedAnon(len: CInt, func  _funcRenamedAnon_param1: UnsafeMutablePointer<CInt>?, extension  _funcRenamedAnon_param2: CInt, init  _funcRenamedAnon_param3: CInt, open  _funcRenamedAnon_param4: CInt, `var`  _funcRenamedAnon_param5: CInt, is  _funcRenamedAnon_param6: CInt, as  _funcRenamedAnon_param7: CInt, in  _funcRenamedAnon_param8: CInt, guard  _funcRenamedAnon_param9: CInt, where  _funcRenamedAnon_param10: CInt) -> UnsafeMutableRawPointer! {
-  return unsafe funcRenamedAnon(len: len, func:  _funcRenamedAnon_param1, extension:  _funcRenamedAnon_param2, init:  _funcRenamedAnon_param3, open:  _funcRenamedAnon_param4, var:  _funcRenamedAnon_param5, is:  _funcRenamedAnon_param6, as:  _funcRenamedAnon_param7, in:  _funcRenamedAnon_param8, guard:  _funcRenamedAnon_param9, where:  _funcRenamedAnon_param10)
-}
-
-func call_clash(len: CInt, func: UnsafeMutablePointer<CInt>?, clash where: CInt) {
-  return unsafe clash(len: len, func: `func`, clash: `where`)
-}
-
-func call_open(len: CInt, func: UnsafeMutablePointer<CInt>?, open where: CInt) {
-  return unsafe open(len: len, func: `func`, open: `where`)
-}
-
-func call_clash2(len: CInt, func: UnsafeMutablePointer<CInt>?, clash2  _clash2_param2: CInt) {
-  return unsafe clash2(len: len, func: `func`, clash2:  _clash2_param2)
-}
-
-func call_in(len: CInt, func: UnsafeMutablePointer<CInt>?, in  _in_param2: CInt) {
-  return unsafe `in`(len: len, func: `func`, in:  _in_param2)
-}
-
-func call_keywordType(_ len: CInt, _ p: UnsafeMutablePointer<actor?>!, _ p2: OpaquePointer) -> actor {
-  return unsafe keywordType(len, p, p2)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(_anonymous_param1: copy _anonymous_param1)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_anonymous(_ _anonymous_param1: inout MutableSpan<CInt>?) {
-  return anonymous(&_anonymous_param1)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(`func`: copy `func`)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_clash(func: inout MutableSpan<CInt>?, clash where: CInt) {
-  return clash(func: &`func`, clash: `where`)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(_clash2_param1: copy _clash2_param1)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_clash2(func _clash2_param1: inout MutableSpan<CInt>?, clash2 _clash2_param2: CInt) {
-  return clash2(func: &_clash2_param1, clash2: _clash2_param2)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: inout MutableSpan<CInt>) {
-  return complexExpr(len, offset, &p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(_func_param1: copy _func_param1)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_func(_ _func_param1: inout MutableSpan<CInt>?) {
-  return `func`(&_func_param1)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(`func`: copy `func`)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_funcRenamed(func: inout MutableSpan<CInt>?, extension: CInt, init: CInt, open: CInt, `var`: CInt, is: CInt, as: CInt, in: CInt, guard: CInt, where: CInt) -> UnsafeMutableRawPointer! {
-  return unsafe funcRenamed(func: &`func`, extension: `extension`, init: `init`, open: open, var: `var`, is: `is`, as: `as`, in: `in`, guard: `guard`, where: `where`)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(_funcRenamedAnon_param1: copy _funcRenamedAnon_param1)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_funcRenamedAnon(func _funcRenamedAnon_param1: inout MutableSpan<CInt>?, extension _funcRenamedAnon_param2: CInt, init _funcRenamedAnon_param3: CInt, open _funcRenamedAnon_param4: CInt, `var` _funcRenamedAnon_param5: CInt, is _funcRenamedAnon_param6: CInt, as _funcRenamedAnon_param7: CInt, in _funcRenamedAnon_param8: CInt, guard _funcRenamedAnon_param9: CInt, where _funcRenamedAnon_param10: CInt) -> UnsafeMutableRawPointer! {
-  return unsafe funcRenamedAnon(func: &_funcRenamedAnon_param1, extension: _funcRenamedAnon_param2, init: _funcRenamedAnon_param3, open: _funcRenamedAnon_param4, var: _funcRenamedAnon_param5, is: _funcRenamedAnon_param6, as: _funcRenamedAnon_param7, in: _funcRenamedAnon_param8, guard: _funcRenamedAnon_param9, where: _funcRenamedAnon_param10)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(_in_param1: copy _in_param1)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_in(func _in_param1: inout MutableSpan<CInt>?, in _in_param2: CInt) {
-  return `in`(func: &_in_param1, in: _in_param2)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(`func`: copy `func`)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_keyword(_ func: inout MutableSpan<CInt>?, _ extension: CInt, _ init: CInt, _ open: CInt, _ var: CInt, _ is: CInt, _ as: CInt, _ in: CInt, _ guard: CInt, _ where: CInt) {
-  return keyword(&`func`, `extension`, `init`, open, `var`, `is`, `as`, `in`, `guard`, `where`)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_keywordType(_ p: inout MutableSpan<actor?>, _ p2: OpaquePointer) -> actor {
-  return unsafe keywordType(&p, p2)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(_lenName_param2: copy _lenName_param2)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_lenName(_ _lenName_param0: CInt, _ _lenName_param1: CInt, _ _lenName_param2: inout MutableSpan<CInt>?) {
-  return lenName(_lenName_param0, _lenName_param1, &_lenName_param2)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ p: inout MutableSpan<CInt>) {
-  return nonnull(&p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ p: inout MutableSpan<CInt>) {
-  return nullUnspecified(&p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ p: inout MutableSpan<CInt>?) {
-  return nullable(&p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(`func`: copy `func`)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_open(func: inout MutableSpan<CInt>?, open where: CInt) {
-  return open(func: &`func`, open: `where`)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(_pointerName_param1: copy _pointerName_param1)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_pointerName(_ _pointerName_param1: inout MutableSpan<CInt>?) {
-  return pointerName(&_pointerName_param1)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_returnPointer(_ len: CInt) -> UnsafeMutableBufferPointer<CInt> {
-  return unsafe returnPointer(len)
 }
 
 @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
@@ -558,14 +402,170 @@ func call_keywordType(_ len: CInt, _ p: UnsafeMutablePointer<actor?>!, _ p2: Opa
   return shared(&p1, &p2)
 }
 
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ p: inout MutableSpan<CInt>) {
-  return simple(&p)
+func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: UnsafeMutablePointer<CInt>!) {
+  return unsafe complexExpr(len, offset, p)
 }
 
 @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 @_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_swiftAttr(_ p: inout MutableSpan<CInt>) {
-  return swiftAttr(&p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: inout MutableSpan<CInt>) {
+  return complexExpr(len, offset, &p)
+}
+
+func call_nullUnspecified(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
+  return unsafe nullUnspecified(len, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ p: inout MutableSpan<CInt>) {
+  return nullUnspecified(&p)
+}
+
+func call_nonnull(_ len: CInt, _ p: UnsafeMutablePointer<CInt>) {
+  return unsafe nonnull(len, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ p: inout MutableSpan<CInt>) {
+  return nonnull(&p)
+}
+
+func call_nullable(_ len: CInt, _ p: UnsafeMutablePointer<CInt>?) {
+  return unsafe nullable(len, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ p: inout MutableSpan<CInt>?) {
+  return nullable(&p)
+}
+
+func call_returnPointer(_ len: CInt) -> UnsafeMutablePointer<CInt>! {
+  return unsafe returnPointer(len)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_returnPointer(_ len: CInt) -> UnsafeMutableBufferPointer<CInt> {
+  return unsafe returnPointer(len)
+}
+
+func call_anonymous(_ len: CInt, _ _anonymous_param1: UnsafeMutablePointer<CInt>?) {
+  return unsafe anonymous(len,  _anonymous_param1)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(_anonymous_param1: copy _anonymous_param1)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_anonymous(_ _anonymous_param1: inout MutableSpan<CInt>?) {
+  return anonymous(&_anonymous_param1)
+}
+
+func call_keyword(_ len: CInt, _ func: UnsafeMutablePointer<CInt>?, _ extension: CInt, _ init: CInt, _ open: CInt, _ var: CInt, _ is: CInt, _ as: CInt, _ in: CInt, _ guard: CInt, _ where: CInt) {
+  return unsafe keyword(len, `func`, `extension`, `init`, open, `var`, `is`, `as`, `in`, `guard`, `where`)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(`func`: copy `func`)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_keyword(_ func: inout MutableSpan<CInt>?, _ extension: CInt, _ init: CInt, _ open: CInt, _ var: CInt, _ is: CInt, _ as: CInt, _ in: CInt, _ guard: CInt, _ where: CInt) {
+  return keyword(&`func`, `extension`, `init`, open, `var`, `is`, `as`, `in`, `guard`, `where`)
+}
+
+func call_pointerName(_ len: CInt, _  _pointerName_param1: UnsafeMutablePointer<CInt>?) {
+  return unsafe pointerName(len,  _pointerName_param1)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(_pointerName_param1: copy _pointerName_param1)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_pointerName(_ _pointerName_param1: inout MutableSpan<CInt>?) {
+  return pointerName(&_pointerName_param1)
+}
+
+func call_lenName(_  _lenName_param0: CInt, _ size: CInt, _ p: UnsafeMutablePointer<CInt>?) {
+  return unsafe lenName( _lenName_param0, size, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(_lenName_param2: copy _lenName_param2)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_lenName(_ _lenName_param0: CInt, _ _lenName_param1: CInt, _ _lenName_param2: inout MutableSpan<CInt>?) {
+  return lenName(_lenName_param0, _lenName_param1, &_lenName_param2)
+}
+
+func call_func(_ len: CInt, _  _func_param1: UnsafeMutablePointer<CInt>?) {
+  return unsafe `func`(len,  _func_param1)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(_func_param1: copy _func_param1)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_func(_ _func_param1: inout MutableSpan<CInt>?) {
+  return `func`(&_func_param1)
+}
+
+func call_funcRenamed(len: CInt, func: UnsafeMutablePointer<CInt>?, extension: CInt, init: CInt, open: CInt, `var`: CInt, is: CInt, as: CInt, in: CInt, guard: CInt, where: CInt) -> UnsafeMutableRawPointer! {
+  return unsafe funcRenamed(len: len, func: `func`, extension: `extension`, init: `init`, open: open, var: `var`, is: `is`, as: `as`, in: `in`, guard: `guard`, where: `where`)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(`func`: copy `func`)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_funcRenamed(func: inout MutableSpan<CInt>?, extension: CInt, init: CInt, open: CInt, `var`: CInt, is: CInt, as: CInt, in: CInt, guard: CInt, where: CInt) -> UnsafeMutableRawPointer! {
+  return unsafe funcRenamed(func: &`func`, extension: `extension`, init: `init`, open: open, var: `var`, is: `is`, as: `as`, in: `in`, guard: `guard`, where: `where`)
+}
+
+func call_funcRenamedAnon(len: CInt, func  _funcRenamedAnon_param1: UnsafeMutablePointer<CInt>?, extension  _funcRenamedAnon_param2: CInt, init  _funcRenamedAnon_param3: CInt, open  _funcRenamedAnon_param4: CInt, `var`  _funcRenamedAnon_param5: CInt, is  _funcRenamedAnon_param6: CInt, as  _funcRenamedAnon_param7: CInt, in  _funcRenamedAnon_param8: CInt, guard  _funcRenamedAnon_param9: CInt, where  _funcRenamedAnon_param10: CInt) -> UnsafeMutableRawPointer! {
+  return unsafe funcRenamedAnon(len: len, func:  _funcRenamedAnon_param1, extension:  _funcRenamedAnon_param2, init:  _funcRenamedAnon_param3, open:  _funcRenamedAnon_param4, var:  _funcRenamedAnon_param5, is:  _funcRenamedAnon_param6, as:  _funcRenamedAnon_param7, in:  _funcRenamedAnon_param8, guard:  _funcRenamedAnon_param9, where:  _funcRenamedAnon_param10)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(_funcRenamedAnon_param1: copy _funcRenamedAnon_param1)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_funcRenamedAnon(func _funcRenamedAnon_param1: inout MutableSpan<CInt>?, extension _funcRenamedAnon_param2: CInt, init _funcRenamedAnon_param3: CInt, open _funcRenamedAnon_param4: CInt, `var` _funcRenamedAnon_param5: CInt, is _funcRenamedAnon_param6: CInt, as _funcRenamedAnon_param7: CInt, in _funcRenamedAnon_param8: CInt, guard _funcRenamedAnon_param9: CInt, where _funcRenamedAnon_param10: CInt) -> UnsafeMutableRawPointer! {
+  return unsafe funcRenamedAnon(func: &_funcRenamedAnon_param1, extension: _funcRenamedAnon_param2, init: _funcRenamedAnon_param3, open: _funcRenamedAnon_param4, var: _funcRenamedAnon_param5, is: _funcRenamedAnon_param6, as: _funcRenamedAnon_param7, in: _funcRenamedAnon_param8, guard: _funcRenamedAnon_param9, where: _funcRenamedAnon_param10)
+}
+
+func call_clash(len: CInt, func: UnsafeMutablePointer<CInt>?, clash where: CInt) {
+  return unsafe clash(len: len, func: `func`, clash: `where`)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(`func`: copy `func`)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_clash(func: inout MutableSpan<CInt>?, clash where: CInt) {
+  return clash(func: &`func`, clash: `where`)
+}
+
+func call_open(len: CInt, func: UnsafeMutablePointer<CInt>?, open where: CInt) {
+  return unsafe open(len: len, func: `func`, open: `where`)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(`func`: copy `func`)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_open(func: inout MutableSpan<CInt>?, open where: CInt) {
+  return open(func: &`func`, open: `where`)
+}
+
+func call_clash2(len: CInt, func: UnsafeMutablePointer<CInt>?, clash2  _clash2_param2: CInt) {
+  return unsafe clash2(len: len, func: `func`, clash2:  _clash2_param2)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(_clash2_param1: copy _clash2_param1)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_clash2(func _clash2_param1: inout MutableSpan<CInt>?, clash2 _clash2_param2: CInt) {
+  return clash2(func: &_clash2_param1, clash2: _clash2_param2)
+}
+
+func call_in(len: CInt, func: UnsafeMutablePointer<CInt>?, in  _in_param2: CInt) {
+  return unsafe `in`(len: len, func: `func`, in:  _in_param2)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(_in_param1: copy _in_param1)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_in(func _in_param1: inout MutableSpan<CInt>?, in _in_param2: CInt) {
+  return `in`(func: &_in_param1, in: _in_param2)
+}
+
+func call_keywordType(_ len: CInt, _ p: UnsafeMutablePointer<actor?>!, _ p2: OpaquePointer) -> actor {
+  return unsafe keywordType(len, p, p2)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_keywordType(_ p: inout MutableSpan<actor?>, _ p2: OpaquePointer) -> actor {
+  return unsafe keywordType(&p, p2)
 }

--- a/test/Interop/C/swiftify-import/counted-by-noescape.swift
+++ b/test/Interop/C/swiftify-import/counted-by-noescape.swift
@@ -364,187 +364,31 @@ module Test {
 
 //--- test.swift
 // GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature Lifetimes -Xcc -Wno-ignored-attributes -Xcc -Wno-nullability-completeness > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
-// GENERATED-HASH: e996ede98d4d1961fe5a46e78c9b00418d1dc8dcc5b2d4edb8fa303f574b36df
+// GENERATED-HASH: b67c4d315ad8e3feb7a00c37b4e1b24d771668ce7f9727e0b5c9c3f0180e74ab
 import Test
 
 func call_simple(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
   return unsafe simple(len, p)
 }
 
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ p: inout MutableSpan<CInt>) {
+  return simple(&p)
+}
+
 func call_swiftAttr(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
   return unsafe swiftAttr(len, p)
 }
 
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_swiftAttr(_ p: inout MutableSpan<CInt>) {
+  return swiftAttr(&p)
+}
+
 func call_shared(_ len: CInt, _ p1: UnsafeMutablePointer<CInt>!, _ p2: UnsafeMutablePointer<CInt>!) {
   return unsafe shared(len, p1, p2)
-}
-
-func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: UnsafeMutablePointer<CInt>!) {
-  return unsafe complexExpr(len, offset, p)
-}
-
-func call_nullUnspecified(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
-  return unsafe nullUnspecified(len, p)
-}
-
-func call_nonnull(_ len: CInt, _ p: UnsafeMutablePointer<CInt>) {
-  return unsafe nonnull(len, p)
-}
-
-func call_nullable(_ len: CInt, _ p: UnsafeMutablePointer<CInt>?) {
-  return unsafe nullable(len, p)
-}
-
-func call_returnPointer(_ len: CInt) -> UnsafeMutablePointer<CInt>! {
-  return unsafe returnPointer(len)
-}
-
-func call_anonymous(_ len: CInt, _ _anonymous_param1: UnsafeMutablePointer<CInt>?) {
-  return unsafe anonymous(len,  _anonymous_param1)
-}
-
-func call_keyword(_ len: CInt, _ func: UnsafeMutablePointer<CInt>?, _ extension: CInt, _ init: CInt, _ open: CInt, _ var: CInt, _ is: CInt, _ as: CInt, _ in: CInt, _ guard: CInt, _ where: CInt) {
-  return unsafe keyword(len, `func`, `extension`, `init`, open, `var`, `is`, `as`, `in`, `guard`, `where`)
-}
-
-func call_pointerName(_ len: CInt, _  _pointerName_param1: UnsafeMutablePointer<CInt>?) {
-  return unsafe pointerName(len,  _pointerName_param1)
-}
-
-func call_lenName(_  _lenName_param0: CInt, _ size: CInt, _ p: UnsafeMutablePointer<CInt>?) {
-  return unsafe lenName( _lenName_param0, size, p)
-}
-
-func call_func(_ len: CInt, _  _func_param1: UnsafeMutablePointer<CInt>?) {
-  return unsafe `func`(len,  _func_param1)
-}
-
-func call_funcRenamed(len: CInt, func: UnsafeMutablePointer<CInt>?, extension: CInt, init: CInt, open: CInt, `var`: CInt, is: CInt, as: CInt, in: CInt, guard: CInt, where: CInt) -> UnsafeMutableRawPointer! {
-  return unsafe funcRenamed(len: len, func: `func`, extension: `extension`, init: `init`, open: open, var: `var`, is: `is`, as: `as`, in: `in`, guard: `guard`, where: `where`)
-}
-
-func call_funcRenamedAnon(len: CInt, func  _funcRenamedAnon_param1: UnsafeMutablePointer<CInt>?, extension  _funcRenamedAnon_param2: CInt, init  _funcRenamedAnon_param3: CInt, open  _funcRenamedAnon_param4: CInt, `var`  _funcRenamedAnon_param5: CInt, is  _funcRenamedAnon_param6: CInt, as  _funcRenamedAnon_param7: CInt, in  _funcRenamedAnon_param8: CInt, guard  _funcRenamedAnon_param9: CInt, where  _funcRenamedAnon_param10: CInt) -> UnsafeMutableRawPointer! {
-  return unsafe funcRenamedAnon(len: len, func:  _funcRenamedAnon_param1, extension:  _funcRenamedAnon_param2, init:  _funcRenamedAnon_param3, open:  _funcRenamedAnon_param4, var:  _funcRenamedAnon_param5, is:  _funcRenamedAnon_param6, as:  _funcRenamedAnon_param7, in:  _funcRenamedAnon_param8, guard:  _funcRenamedAnon_param9, where:  _funcRenamedAnon_param10)
-}
-
-func call_clash(len: CInt, func: UnsafeMutablePointer<CInt>?, clash where: CInt) {
-  return unsafe clash(len: len, func: `func`, clash: `where`)
-}
-
-func call_open(len: CInt, func: UnsafeMutablePointer<CInt>?, open where: CInt) {
-  return unsafe open(len: len, func: `func`, open: `where`)
-}
-
-func call_clash2(len: CInt, func: UnsafeMutablePointer<CInt>?, clash2  _clash2_param2: CInt) {
-  return unsafe clash2(len: len, func: `func`, clash2:  _clash2_param2)
-}
-
-func call_in(len: CInt, func: UnsafeMutablePointer<CInt>?, in  _in_param2: CInt) {
-  return unsafe `in`(len: len, func: `func`, in:  _in_param2)
-}
-
-func call_keywordType(_ len: CInt, _ p: UnsafeMutablePointer<actor?>!, _ p2: OpaquePointer) -> actor {
-  return unsafe keywordType(len, p, p2)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(_anonymous_param1: copy _anonymous_param1)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_anonymous(_ _anonymous_param1: inout MutableSpan<CInt>) {
-  return anonymous(&_anonymous_param1)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(`func`: copy `func`)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_clash(func: inout MutableSpan<CInt>, clash where: CInt) {
-  return clash(func: &`func`, clash: `where`)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(_clash2_param1: copy _clash2_param1)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_clash2(func _clash2_param1: inout MutableSpan<CInt>, clash2 _clash2_param2: CInt) {
-  return clash2(func: &_clash2_param1, clash2: _clash2_param2)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: inout MutableSpan<CInt>) {
-  return complexExpr(len, offset, &p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(_func_param1: copy _func_param1)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_func(_ _func_param1: inout MutableSpan<CInt>) {
-  return `func`(&_func_param1)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(`func`: copy `func`)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_funcRenamed(func: inout MutableSpan<CInt>, extension: CInt, init: CInt, open: CInt, `var`: CInt, is: CInt, as: CInt, in: CInt, guard: CInt, where: CInt) -> UnsafeMutableRawPointer! {
-  return unsafe funcRenamed(func: &`func`, extension: `extension`, init: `init`, open: open, var: `var`, is: `is`, as: `as`, in: `in`, guard: `guard`, where: `where`)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(_funcRenamedAnon_param1: copy _funcRenamedAnon_param1)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_funcRenamedAnon(func _funcRenamedAnon_param1: inout MutableSpan<CInt>, extension _funcRenamedAnon_param2: CInt, init _funcRenamedAnon_param3: CInt, open _funcRenamedAnon_param4: CInt, `var` _funcRenamedAnon_param5: CInt, is _funcRenamedAnon_param6: CInt, as _funcRenamedAnon_param7: CInt, in _funcRenamedAnon_param8: CInt, guard _funcRenamedAnon_param9: CInt, where _funcRenamedAnon_param10: CInt) -> UnsafeMutableRawPointer! {
-  return unsafe funcRenamedAnon(func: &_funcRenamedAnon_param1, extension: _funcRenamedAnon_param2, init: _funcRenamedAnon_param3, open: _funcRenamedAnon_param4, var: _funcRenamedAnon_param5, is: _funcRenamedAnon_param6, as: _funcRenamedAnon_param7, in: _funcRenamedAnon_param8, guard: _funcRenamedAnon_param9, where: _funcRenamedAnon_param10)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(_in_param1: copy _in_param1)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_in(func _in_param1: inout MutableSpan<CInt>, in _in_param2: CInt) {
-  return `in`(func: &_in_param1, in: _in_param2)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(`func`: copy `func`)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_keyword(_ func: inout MutableSpan<CInt>, _ extension: CInt, _ init: CInt, _ open: CInt, _ var: CInt, _ is: CInt, _ as: CInt, _ in: CInt, _ guard: CInt, _ where: CInt) {
-  return keyword(&`func`, `extension`, `init`, open, `var`, `is`, `as`, `in`, `guard`, `where`)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_keywordType(_ p: inout MutableSpan<actor?>, _ p2: OpaquePointer) -> actor {
-  return unsafe keywordType(&p, p2)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(_lenName_param2: copy _lenName_param2)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_lenName(_ _lenName_param0: CInt, _ _lenName_param1: CInt, _ _lenName_param2: inout MutableSpan<CInt>) {
-  return lenName(_lenName_param0, _lenName_param1, &_lenName_param2)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ p: inout MutableSpan<CInt>) {
-  return nonnull(&p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ p: inout MutableSpan<CInt>) {
-  return nullUnspecified(&p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ p: inout MutableSpan<CInt>) {
-  return nullable(&p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(`func`: copy `func`)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_open(func: inout MutableSpan<CInt>, open where: CInt) {
-  return open(func: &`func`, open: `where`)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(_pointerName_param1: copy _pointerName_param1)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_pointerName(_ _pointerName_param1: inout MutableSpan<CInt>) {
-  return pointerName(&_pointerName_param1)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_returnPointer(_ len: CInt) -> UnsafeMutableBufferPointer<CInt> {
-  return unsafe returnPointer(len)
 }
 
 @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
@@ -554,14 +398,170 @@ func call_keywordType(_ len: CInt, _ p: UnsafeMutablePointer<actor?>!, _ p2: Opa
   return shared(&p1, &p2)
 }
 
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ p: inout MutableSpan<CInt>) {
-  return simple(&p)
+func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: UnsafeMutablePointer<CInt>!) {
+  return unsafe complexExpr(len, offset, p)
 }
 
 @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 @_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_swiftAttr(_ p: inout MutableSpan<CInt>) {
-  return swiftAttr(&p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: inout MutableSpan<CInt>) {
+  return complexExpr(len, offset, &p)
+}
+
+func call_nullUnspecified(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
+  return unsafe nullUnspecified(len, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ p: inout MutableSpan<CInt>) {
+  return nullUnspecified(&p)
+}
+
+func call_nonnull(_ len: CInt, _ p: UnsafeMutablePointer<CInt>) {
+  return unsafe nonnull(len, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ p: inout MutableSpan<CInt>) {
+  return nonnull(&p)
+}
+
+func call_nullable(_ len: CInt, _ p: UnsafeMutablePointer<CInt>?) {
+  return unsafe nullable(len, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ p: inout MutableSpan<CInt>) {
+  return nullable(&p)
+}
+
+func call_returnPointer(_ len: CInt) -> UnsafeMutablePointer<CInt>! {
+  return unsafe returnPointer(len)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_returnPointer(_ len: CInt) -> UnsafeMutableBufferPointer<CInt> {
+  return unsafe returnPointer(len)
+}
+
+func call_anonymous(_ len: CInt, _ _anonymous_param1: UnsafeMutablePointer<CInt>?) {
+  return unsafe anonymous(len,  _anonymous_param1)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(_anonymous_param1: copy _anonymous_param1)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_anonymous(_ _anonymous_param1: inout MutableSpan<CInt>) {
+  return anonymous(&_anonymous_param1)
+}
+
+func call_keyword(_ len: CInt, _ func: UnsafeMutablePointer<CInt>?, _ extension: CInt, _ init: CInt, _ open: CInt, _ var: CInt, _ is: CInt, _ as: CInt, _ in: CInt, _ guard: CInt, _ where: CInt) {
+  return unsafe keyword(len, `func`, `extension`, `init`, open, `var`, `is`, `as`, `in`, `guard`, `where`)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(`func`: copy `func`)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_keyword(_ func: inout MutableSpan<CInt>, _ extension: CInt, _ init: CInt, _ open: CInt, _ var: CInt, _ is: CInt, _ as: CInt, _ in: CInt, _ guard: CInt, _ where: CInt) {
+  return keyword(&`func`, `extension`, `init`, open, `var`, `is`, `as`, `in`, `guard`, `where`)
+}
+
+func call_pointerName(_ len: CInt, _  _pointerName_param1: UnsafeMutablePointer<CInt>?) {
+  return unsafe pointerName(len,  _pointerName_param1)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(_pointerName_param1: copy _pointerName_param1)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_pointerName(_ _pointerName_param1: inout MutableSpan<CInt>) {
+  return pointerName(&_pointerName_param1)
+}
+
+func call_lenName(_  _lenName_param0: CInt, _ size: CInt, _ p: UnsafeMutablePointer<CInt>?) {
+  return unsafe lenName( _lenName_param0, size, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(_lenName_param2: copy _lenName_param2)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_lenName(_ _lenName_param0: CInt, _ _lenName_param1: CInt, _ _lenName_param2: inout MutableSpan<CInt>) {
+  return lenName(_lenName_param0, _lenName_param1, &_lenName_param2)
+}
+
+func call_func(_ len: CInt, _  _func_param1: UnsafeMutablePointer<CInt>?) {
+  return unsafe `func`(len,  _func_param1)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(_func_param1: copy _func_param1)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_func(_ _func_param1: inout MutableSpan<CInt>) {
+  return `func`(&_func_param1)
+}
+
+func call_funcRenamed(len: CInt, func: UnsafeMutablePointer<CInt>?, extension: CInt, init: CInt, open: CInt, `var`: CInt, is: CInt, as: CInt, in: CInt, guard: CInt, where: CInt) -> UnsafeMutableRawPointer! {
+  return unsafe funcRenamed(len: len, func: `func`, extension: `extension`, init: `init`, open: open, var: `var`, is: `is`, as: `as`, in: `in`, guard: `guard`, where: `where`)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(`func`: copy `func`)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_funcRenamed(func: inout MutableSpan<CInt>, extension: CInt, init: CInt, open: CInt, `var`: CInt, is: CInt, as: CInt, in: CInt, guard: CInt, where: CInt) -> UnsafeMutableRawPointer! {
+  return unsafe funcRenamed(func: &`func`, extension: `extension`, init: `init`, open: open, var: `var`, is: `is`, as: `as`, in: `in`, guard: `guard`, where: `where`)
+}
+
+func call_funcRenamedAnon(len: CInt, func  _funcRenamedAnon_param1: UnsafeMutablePointer<CInt>?, extension  _funcRenamedAnon_param2: CInt, init  _funcRenamedAnon_param3: CInt, open  _funcRenamedAnon_param4: CInt, `var`  _funcRenamedAnon_param5: CInt, is  _funcRenamedAnon_param6: CInt, as  _funcRenamedAnon_param7: CInt, in  _funcRenamedAnon_param8: CInt, guard  _funcRenamedAnon_param9: CInt, where  _funcRenamedAnon_param10: CInt) -> UnsafeMutableRawPointer! {
+  return unsafe funcRenamedAnon(len: len, func:  _funcRenamedAnon_param1, extension:  _funcRenamedAnon_param2, init:  _funcRenamedAnon_param3, open:  _funcRenamedAnon_param4, var:  _funcRenamedAnon_param5, is:  _funcRenamedAnon_param6, as:  _funcRenamedAnon_param7, in:  _funcRenamedAnon_param8, guard:  _funcRenamedAnon_param9, where:  _funcRenamedAnon_param10)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(_funcRenamedAnon_param1: copy _funcRenamedAnon_param1)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_funcRenamedAnon(func _funcRenamedAnon_param1: inout MutableSpan<CInt>, extension _funcRenamedAnon_param2: CInt, init _funcRenamedAnon_param3: CInt, open _funcRenamedAnon_param4: CInt, `var` _funcRenamedAnon_param5: CInt, is _funcRenamedAnon_param6: CInt, as _funcRenamedAnon_param7: CInt, in _funcRenamedAnon_param8: CInt, guard _funcRenamedAnon_param9: CInt, where _funcRenamedAnon_param10: CInt) -> UnsafeMutableRawPointer! {
+  return unsafe funcRenamedAnon(func: &_funcRenamedAnon_param1, extension: _funcRenamedAnon_param2, init: _funcRenamedAnon_param3, open: _funcRenamedAnon_param4, var: _funcRenamedAnon_param5, is: _funcRenamedAnon_param6, as: _funcRenamedAnon_param7, in: _funcRenamedAnon_param8, guard: _funcRenamedAnon_param9, where: _funcRenamedAnon_param10)
+}
+
+func call_clash(len: CInt, func: UnsafeMutablePointer<CInt>?, clash where: CInt) {
+  return unsafe clash(len: len, func: `func`, clash: `where`)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(`func`: copy `func`)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_clash(func: inout MutableSpan<CInt>, clash where: CInt) {
+  return clash(func: &`func`, clash: `where`)
+}
+
+func call_open(len: CInt, func: UnsafeMutablePointer<CInt>?, open where: CInt) {
+  return unsafe open(len: len, func: `func`, open: `where`)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(`func`: copy `func`)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_open(func: inout MutableSpan<CInt>, open where: CInt) {
+  return open(func: &`func`, open: `where`)
+}
+
+func call_clash2(len: CInt, func: UnsafeMutablePointer<CInt>?, clash2  _clash2_param2: CInt) {
+  return unsafe clash2(len: len, func: `func`, clash2:  _clash2_param2)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(_clash2_param1: copy _clash2_param1)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_clash2(func _clash2_param1: inout MutableSpan<CInt>, clash2 _clash2_param2: CInt) {
+  return clash2(func: &_clash2_param1, clash2: _clash2_param2)
+}
+
+func call_in(len: CInt, func: UnsafeMutablePointer<CInt>?, in  _in_param2: CInt) {
+  return unsafe `in`(len: len, func: `func`, in:  _in_param2)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(_in_param1: copy _in_param1)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_in(func _in_param1: inout MutableSpan<CInt>, in _in_param2: CInt) {
+  return `in`(func: &_in_param1, in: _in_param2)
+}
+
+func call_keywordType(_ len: CInt, _ p: UnsafeMutablePointer<actor?>!, _ p2: OpaquePointer) -> actor {
+  return unsafe keywordType(len, p, p2)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_keywordType(_ p: inout MutableSpan<actor?>, _ p2: OpaquePointer) -> actor {
+  return unsafe keywordType(&p, p2)
 }

--- a/test/Interop/C/swiftify-import/counted-by-or-null-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/counted-by-or-null-lifetimebound.swift
@@ -241,154 +241,25 @@ module Test {
 
 //--- test.swift
 // GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers -Xcc -Wno-nullability-completeness > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
-// GENERATED-HASH: e578470f1190d56e60e74393710cb078725172a3897488e395921c158c79e5e5
+// GENERATED-HASH: 8476d10c0db1df2650fcc472ce02aac4bdc4498f8aa2b527764da0c3167d1624
 import Test
 
 func call_simple(_ len: CInt, _ len2: CInt, _ p: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
   return unsafe simple(len, len2, p)
 }
 
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ len: CInt, _ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
+  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
+  return simple(len, &p)
+}
+
 func call_shared(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
   return unsafe shared(len, p)
-}
-
-func call_complexExpr(_ len: CInt, _ offset: CInt, _ len2: CInt, _ p: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
-  return unsafe complexExpr(len, offset, len2, p)
-}
-
-func call_nullUnspecified(_ len: CInt, _ len2: CInt, _ p: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
-  return unsafe nullUnspecified(len, len2, p)
-}
-
-func call_nonnull(_ len: CInt, _ len2: CInt, _ p: UnsafeMutablePointer<CInt>) -> UnsafeMutablePointer<CInt> {
-  return unsafe nonnull(len, len2, p)
-}
-
-func call_nullable(_ len: CInt, _ len2: CInt, _ p: UnsafeMutablePointer<CInt>?) -> UnsafeMutablePointer<CInt>? {
-  return unsafe nullable(len, len2, p)
-}
-
-func call_opaque(_ len: CInt, _ len2: CInt, _ p: OpaquePointer!) -> OpaquePointer! {
-  return unsafe opaque(len, len2, p)
-}
-
-func call_noncountedLifetime(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
-  return unsafe noncountedLifetime(len, p)
-}
-
-func call_constant(_ p: UnsafeMutablePointer<CInt>?) -> UnsafeMutablePointer<CInt>? {
-  return unsafe constant(p)
-}
-
-func call_lifetimeboundEscapableReturn(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) -> EscapableStruct {
-  return unsafe lifetimeboundEscapableReturn(len, p)
-}
-
-// expected-stable-error@+2{{a function with a ~Escapable result requires '@_lifetime(...)'}}
-// expected-experimental-error@+1{{a function with a ~Escapable result requires '@_lifetime(...)'}}
-func call_lifetimeboundNonescapableReturn(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) -> NonescapableStruct {
-  return unsafe lifetimeboundNonescapableReturn(len, p)
-}
-
-func call_lifetimeboundNonescapableReturnDoubleBounds(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!, _ s: NonescapableStruct) -> NonescapableStruct {
-  return unsafe lifetimeboundNonescapableReturnDoubleBounds(len, p, s)
-}
-
-func call_oneLifetimeboundOneEscapable(_ len: CInt, _ len2: CInt, _ p: UnsafeMutablePointer<CInt>!, _ len3: CInt, _ p2: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
-  return unsafe oneLifetimeboundOneEscapable(len, len2, p, len3, p2)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
-  // expected-stable-error@+3{{missing argument for parameter #4 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
-  return complexExpr(len, offset, &p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_constant(_ p: inout MutableSpan<CInt>?) -> MutableSpan<CInt>? {
-  // expected-stable-error@+2{{cannot convert value of type 'UnsafeMutablePointer<MutableSpan<CInt>?>' (aka 'UnsafeMutablePointer<Optional<MutableSpan<Int32>>>') to expected argument type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>?' (aka 'Optional<MutableSpan<Int32>>')}}
-  return constant(&p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_lifetimeboundEscapableReturn(_ p: UnsafeMutableBufferPointer<CInt>) -> EscapableStruct {
-  // expected-stable-error@+2{{missing argument for parameter #2 in call}}
-  // expected-stable-error@+1{{cannot convert value of type 'UnsafeMutableBufferPointer<CInt>' (aka 'UnsafeMutableBufferPointer<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
-  return unsafe lifetimeboundEscapableReturn(p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_lifetimeboundNonescapableReturn(_ p: inout MutableSpan<CInt>) -> NonescapableStruct {
-  // expected-stable-error@+3{{missing argument for parameter #2 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'UnsafeMutablePointer<MutableSpan<CInt>>' (aka 'UnsafeMutablePointer<MutableSpan<Int32>>') to expected argument type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>')}}
-  // expected-stable-error@+1{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
-  return lifetimeboundNonescapableReturn(&p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p, copy s)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_lifetimeboundNonescapableReturnDoubleBounds(_ p: inout MutableSpan<CInt>, _ s: NonescapableStruct) -> NonescapableStruct {
-  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'NonescapableStruct' to expected argument type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>')}}
-  // expected-stable-error@+1{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
-  return lifetimeboundNonescapableReturnDoubleBounds(&p, s)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(borrow p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_noncountedLifetime(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) -> MutableSpan<CInt> {
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
-  return unsafe noncountedLifetime(len, p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ len: CInt, _ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
-  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
-  return nonnull(len, &p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ len: CInt, _ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
-  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
-  return nullUnspecified(len, &p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ len: CInt, _ p: inout MutableSpan<CInt>?) -> MutableSpan<CInt>? {
-  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<CInt>?' (aka 'Optional<MutableSpan<Int32>>') to expected argument type 'CInt' (aka 'Int32')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>?' (aka 'Optional<MutableSpan<Int32>>')}}
-  return nullable(len, &p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_oneLifetimeboundOneEscapable(_ len: CInt, _ p: inout MutableSpan<CInt>, _ p2: UnsafeMutableBufferPointer<CInt>) -> MutableSpan<CInt> {
-  // expected-stable-error@+4{{cannot convert value of type 'UnsafeMutableBufferPointer<CInt>' (aka 'UnsafeMutableBufferPointer<Int32>') to expected argument type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>')}}
-  // expected-stable-error@+3{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
-  // expected-stable-error@+2{{missing arguments for parameters #4, #5 in call}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
-  return unsafe oneLifetimeboundOneEscapable(len, &p, p2)
 }
 
 @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
@@ -402,12 +273,141 @@ func call_oneLifetimeboundOneEscapable(_ len: CInt, _ len2: CInt, _ p: UnsafeMut
   return shared(&p)
 }
 
+func call_complexExpr(_ len: CInt, _ offset: CInt, _ len2: CInt, _ p: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
+  return unsafe complexExpr(len, offset, len2, p)
+}
+
 @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 @_lifetime(copy p)
 @_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ len: CInt, _ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
+  // expected-stable-error@+3{{missing argument for parameter #4 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
+  return complexExpr(len, offset, &p)
+}
+
+func call_nullUnspecified(_ len: CInt, _ len2: CInt, _ p: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
+  return unsafe nullUnspecified(len, len2, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ len: CInt, _ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
   // expected-stable-error@+3{{missing argument for parameter #3 in call}}
   // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
   // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
-  return simple(len, &p)
+  return nullUnspecified(len, &p)
+}
+
+func call_nonnull(_ len: CInt, _ len2: CInt, _ p: UnsafeMutablePointer<CInt>) -> UnsafeMutablePointer<CInt> {
+  return unsafe nonnull(len, len2, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ len: CInt, _ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
+  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
+  return nonnull(len, &p)
+}
+
+func call_nullable(_ len: CInt, _ len2: CInt, _ p: UnsafeMutablePointer<CInt>?) -> UnsafeMutablePointer<CInt>? {
+  return unsafe nullable(len, len2, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ len: CInt, _ p: inout MutableSpan<CInt>?) -> MutableSpan<CInt>? {
+  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<CInt>?' (aka 'Optional<MutableSpan<Int32>>') to expected argument type 'CInt' (aka 'Int32')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>?' (aka 'Optional<MutableSpan<Int32>>')}}
+  return nullable(len, &p)
+}
+
+func call_opaque(_ len: CInt, _ len2: CInt, _ p: OpaquePointer!) -> OpaquePointer! {
+  return unsafe opaque(len, len2, p)
+}
+
+func call_noncountedLifetime(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
+  return unsafe noncountedLifetime(len, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(borrow p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_noncountedLifetime(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) -> MutableSpan<CInt> {
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
+  return unsafe noncountedLifetime(len, p)
+}
+
+func call_constant(_ p: UnsafeMutablePointer<CInt>?) -> UnsafeMutablePointer<CInt>? {
+  return unsafe constant(p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_constant(_ p: inout MutableSpan<CInt>?) -> MutableSpan<CInt>? {
+  // expected-stable-error@+2{{cannot convert value of type 'UnsafeMutablePointer<MutableSpan<CInt>?>' (aka 'UnsafeMutablePointer<Optional<MutableSpan<Int32>>>') to expected argument type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>?' (aka 'Optional<MutableSpan<Int32>>')}}
+  return constant(&p)
+}
+
+func call_lifetimeboundEscapableReturn(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) -> EscapableStruct {
+  return unsafe lifetimeboundEscapableReturn(len, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_lifetimeboundEscapableReturn(_ p: UnsafeMutableBufferPointer<CInt>) -> EscapableStruct {
+  // expected-stable-error@+2{{missing argument for parameter #2 in call}}
+  // expected-stable-error@+1{{cannot convert value of type 'UnsafeMutableBufferPointer<CInt>' (aka 'UnsafeMutableBufferPointer<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
+  return unsafe lifetimeboundEscapableReturn(p)
+}
+
+// expected-stable-error@+2{{a function with a ~Escapable result requires '@_lifetime(...)'}}
+// expected-experimental-error@+1{{a function with a ~Escapable result requires '@_lifetime(...)'}}
+func call_lifetimeboundNonescapableReturn(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) -> NonescapableStruct {
+  return unsafe lifetimeboundNonescapableReturn(len, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_lifetimeboundNonescapableReturn(_ p: inout MutableSpan<CInt>) -> NonescapableStruct {
+  // expected-stable-error@+3{{missing argument for parameter #2 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'UnsafeMutablePointer<MutableSpan<CInt>>' (aka 'UnsafeMutablePointer<MutableSpan<Int32>>') to expected argument type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>')}}
+  // expected-stable-error@+1{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
+  return lifetimeboundNonescapableReturn(&p)
+}
+
+func call_lifetimeboundNonescapableReturnDoubleBounds(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!, _ s: NonescapableStruct) -> NonescapableStruct {
+  return unsafe lifetimeboundNonescapableReturnDoubleBounds(len, p, s)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p, copy s)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_lifetimeboundNonescapableReturnDoubleBounds(_ p: inout MutableSpan<CInt>, _ s: NonescapableStruct) -> NonescapableStruct {
+  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'NonescapableStruct' to expected argument type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>')}}
+  // expected-stable-error@+1{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
+  return lifetimeboundNonescapableReturnDoubleBounds(&p, s)
+}
+
+func call_oneLifetimeboundOneEscapable(_ len: CInt, _ len2: CInt, _ p: UnsafeMutablePointer<CInt>!, _ len3: CInt, _ p2: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
+  return unsafe oneLifetimeboundOneEscapable(len, len2, p, len3, p2)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_oneLifetimeboundOneEscapable(_ len: CInt, _ p: inout MutableSpan<CInt>, _ p2: UnsafeMutableBufferPointer<CInt>) -> MutableSpan<CInt> {
+  // expected-stable-error@+4{{cannot convert value of type 'UnsafeMutableBufferPointer<CInt>' (aka 'UnsafeMutableBufferPointer<Int32>') to expected argument type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>')}}
+  // expected-stable-error@+3{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
+  // expected-stable-error@+2{{missing arguments for parameters #4, #5 in call}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
+  return unsafe oneLifetimeboundOneEscapable(len, &p, p2)
 }

--- a/test/Interop/C/swiftify-import/counted-by-or-null-noescape.swift
+++ b/test/Interop/C/swiftify-import/counted-by-or-null-noescape.swift
@@ -364,187 +364,31 @@ module Test {
 
 //--- test.swift
 // GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature Lifetimes -Xcc -Wno-ignored-attributes -Xcc -Wno-nullability-completeness > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
-// GENERATED-HASH: 847748c9e70920d8eab1e64135c9178f418c0de85b3bedde96563a04d64417bf
+// GENERATED-HASH: af7be31152619e22cda33e9809902630827157be6fc9cd9ba1ce46afe34a5cf0
 import Test
 
 func call_simple(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
   return unsafe simple(len, p)
 }
 
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ p: inout MutableSpan<CInt>) {
+  return simple(&p)
+}
+
 func call_swiftAttr(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
   return unsafe swiftAttr(len, p)
 }
 
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_swiftAttr(_ p: inout MutableSpan<CInt>) {
+  return swiftAttr(&p)
+}
+
 func call_shared(_ len: CInt, _ p1: UnsafeMutablePointer<CInt>!, _ p2: UnsafeMutablePointer<CInt>!) {
   return unsafe shared(len, p1, p2)
-}
-
-func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: UnsafeMutablePointer<CInt>!) {
-  return unsafe complexExpr(len, offset, p)
-}
-
-func call_nullUnspecified(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
-  return unsafe nullUnspecified(len, p)
-}
-
-func call_nonnull(_ len: CInt, _ p: UnsafeMutablePointer<CInt>) {
-  return unsafe nonnull(len, p)
-}
-
-func call_nullable(_ len: CInt, _ p: UnsafeMutablePointer<CInt>?) {
-  return unsafe nullable(len, p)
-}
-
-func call_returnPointer(_ len: CInt) -> UnsafeMutablePointer<CInt>! {
-  return unsafe returnPointer(len)
-}
-
-func call_anonymous(_ len: CInt, _ _anonymous_param1: UnsafeMutablePointer<CInt>?) {
-  return unsafe anonymous(len,  _anonymous_param1)
-}
-
-func call_keyword(_ len: CInt, _ func: UnsafeMutablePointer<CInt>?, _ extension: CInt, _ init: CInt, _ open: CInt, _ var: CInt, _ is: CInt, _ as: CInt, _ in: CInt, _ guard: CInt, _ where: CInt) {
-  return unsafe keyword(len, `func`, `extension`, `init`, open, `var`, `is`, `as`, `in`, `guard`, `where`)
-}
-
-func call_pointerName(_ len: CInt, _  _pointerName_param1: UnsafeMutablePointer<CInt>?) {
-  return unsafe pointerName(len,  _pointerName_param1)
-}
-
-func call_lenName(_  _lenName_param0: CInt, _ size: CInt, _ p: UnsafeMutablePointer<CInt>?) {
-  return unsafe lenName( _lenName_param0, size, p)
-}
-
-func call_func(_ len: CInt, _  _func_param1: UnsafeMutablePointer<CInt>?) {
-  return unsafe `func`(len,  _func_param1)
-}
-
-func call_funcRenamed(len: CInt, func: UnsafeMutablePointer<CInt>?, extension: CInt, init: CInt, open: CInt, `var`: CInt, is: CInt, as: CInt, in: CInt, guard: CInt, where: CInt) -> UnsafeMutableRawPointer! {
-  return unsafe funcRenamed(len: len, func: `func`, extension: `extension`, init: `init`, open: open, var: `var`, is: `is`, as: `as`, in: `in`, guard: `guard`, where: `where`)
-}
-
-func call_funcRenamedAnon(len: CInt, func  _funcRenamedAnon_param1: UnsafeMutablePointer<CInt>?, extension  _funcRenamedAnon_param2: CInt, init  _funcRenamedAnon_param3: CInt, open  _funcRenamedAnon_param4: CInt, `var`  _funcRenamedAnon_param5: CInt, is  _funcRenamedAnon_param6: CInt, as  _funcRenamedAnon_param7: CInt, in  _funcRenamedAnon_param8: CInt, guard  _funcRenamedAnon_param9: CInt, where  _funcRenamedAnon_param10: CInt) -> UnsafeMutableRawPointer! {
-  return unsafe funcRenamedAnon(len: len, func:  _funcRenamedAnon_param1, extension:  _funcRenamedAnon_param2, init:  _funcRenamedAnon_param3, open:  _funcRenamedAnon_param4, var:  _funcRenamedAnon_param5, is:  _funcRenamedAnon_param6, as:  _funcRenamedAnon_param7, in:  _funcRenamedAnon_param8, guard:  _funcRenamedAnon_param9, where:  _funcRenamedAnon_param10)
-}
-
-func call_clash(len: CInt, func: UnsafeMutablePointer<CInt>?, clash where: CInt) {
-  return unsafe clash(len: len, func: `func`, clash: `where`)
-}
-
-func call_open(len: CInt, func: UnsafeMutablePointer<CInt>?, open where: CInt) {
-  return unsafe open(len: len, func: `func`, open: `where`)
-}
-
-func call_clash2(len: CInt, func: UnsafeMutablePointer<CInt>?, clash2  _clash2_param2: CInt) {
-  return unsafe clash2(len: len, func: `func`, clash2:  _clash2_param2)
-}
-
-func call_in(len: CInt, func: UnsafeMutablePointer<CInt>?, in  _in_param2: CInt) {
-  return unsafe `in`(len: len, func: `func`, in:  _in_param2)
-}
-
-func call_keywordType(_ len: CInt, _ p: UnsafeMutablePointer<actor?>!, _ p2: OpaquePointer) -> actor {
-  return unsafe keywordType(len, p, p2)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(_anonymous_param1: copy _anonymous_param1)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_anonymous(_ _anonymous_param1: inout MutableSpan<CInt>?) {
-  return anonymous(&_anonymous_param1)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(`func`: copy `func`)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_clash(func: inout MutableSpan<CInt>?, clash where: CInt) {
-  return clash(func: &`func`, clash: `where`)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(_clash2_param1: copy _clash2_param1)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_clash2(func _clash2_param1: inout MutableSpan<CInt>?, clash2 _clash2_param2: CInt) {
-  return clash2(func: &_clash2_param1, clash2: _clash2_param2)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: inout MutableSpan<CInt>) {
-  return complexExpr(len, offset, &p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(_func_param1: copy _func_param1)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_func(_ _func_param1: inout MutableSpan<CInt>?) {
-  return `func`(&_func_param1)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(`func`: copy `func`)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_funcRenamed(func: inout MutableSpan<CInt>?, extension: CInt, init: CInt, open: CInt, `var`: CInt, is: CInt, as: CInt, in: CInt, guard: CInt, where: CInt) -> UnsafeMutableRawPointer! {
-  return unsafe funcRenamed(func: &`func`, extension: `extension`, init: `init`, open: open, var: `var`, is: `is`, as: `as`, in: `in`, guard: `guard`, where: `where`)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(_funcRenamedAnon_param1: copy _funcRenamedAnon_param1)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_funcRenamedAnon(func _funcRenamedAnon_param1: inout MutableSpan<CInt>?, extension _funcRenamedAnon_param2: CInt, init _funcRenamedAnon_param3: CInt, open _funcRenamedAnon_param4: CInt, `var` _funcRenamedAnon_param5: CInt, is _funcRenamedAnon_param6: CInt, as _funcRenamedAnon_param7: CInt, in _funcRenamedAnon_param8: CInt, guard _funcRenamedAnon_param9: CInt, where _funcRenamedAnon_param10: CInt) -> UnsafeMutableRawPointer! {
-  return unsafe funcRenamedAnon(func: &_funcRenamedAnon_param1, extension: _funcRenamedAnon_param2, init: _funcRenamedAnon_param3, open: _funcRenamedAnon_param4, var: _funcRenamedAnon_param5, is: _funcRenamedAnon_param6, as: _funcRenamedAnon_param7, in: _funcRenamedAnon_param8, guard: _funcRenamedAnon_param9, where: _funcRenamedAnon_param10)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(_in_param1: copy _in_param1)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_in(func _in_param1: inout MutableSpan<CInt>?, in _in_param2: CInt) {
-  return `in`(func: &_in_param1, in: _in_param2)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(`func`: copy `func`)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_keyword(_ func: inout MutableSpan<CInt>?, _ extension: CInt, _ init: CInt, _ open: CInt, _ var: CInt, _ is: CInt, _ as: CInt, _ in: CInt, _ guard: CInt, _ where: CInt) {
-  return keyword(&`func`, `extension`, `init`, open, `var`, `is`, `as`, `in`, `guard`, `where`)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_keywordType(_ p: inout MutableSpan<actor?>, _ p2: OpaquePointer) -> actor {
-  return unsafe keywordType(&p, p2)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(_lenName_param2: copy _lenName_param2)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_lenName(_ _lenName_param0: CInt, _ _lenName_param1: CInt, _ _lenName_param2: inout MutableSpan<CInt>?) {
-  return lenName(_lenName_param0, _lenName_param1, &_lenName_param2)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ p: inout MutableSpan<CInt>) {
-  return nonnull(&p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ p: inout MutableSpan<CInt>) {
-  return nullUnspecified(&p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ p: inout MutableSpan<CInt>?) {
-  return nullable(&p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(`func`: copy `func`)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_open(func: inout MutableSpan<CInt>?, open where: CInt) {
-  return open(func: &`func`, open: `where`)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(_pointerName_param1: copy _pointerName_param1)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_pointerName(_ _pointerName_param1: inout MutableSpan<CInt>?) {
-  return pointerName(&_pointerName_param1)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_returnPointer(_ len: CInt) -> UnsafeMutableBufferPointer<CInt> {
-  return unsafe returnPointer(len)
 }
 
 @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
@@ -554,14 +398,170 @@ func call_keywordType(_ len: CInt, _ p: UnsafeMutablePointer<actor?>!, _ p2: Opa
   return shared(&p1, &p2)
 }
 
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ p: inout MutableSpan<CInt>) {
-  return simple(&p)
+func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: UnsafeMutablePointer<CInt>!) {
+  return unsafe complexExpr(len, offset, p)
 }
 
 @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 @_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_swiftAttr(_ p: inout MutableSpan<CInt>) {
-  return swiftAttr(&p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: inout MutableSpan<CInt>) {
+  return complexExpr(len, offset, &p)
+}
+
+func call_nullUnspecified(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
+  return unsafe nullUnspecified(len, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ p: inout MutableSpan<CInt>) {
+  return nullUnspecified(&p)
+}
+
+func call_nonnull(_ len: CInt, _ p: UnsafeMutablePointer<CInt>) {
+  return unsafe nonnull(len, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ p: inout MutableSpan<CInt>) {
+  return nonnull(&p)
+}
+
+func call_nullable(_ len: CInt, _ p: UnsafeMutablePointer<CInt>?) {
+  return unsafe nullable(len, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ p: inout MutableSpan<CInt>?) {
+  return nullable(&p)
+}
+
+func call_returnPointer(_ len: CInt) -> UnsafeMutablePointer<CInt>! {
+  return unsafe returnPointer(len)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_returnPointer(_ len: CInt) -> UnsafeMutableBufferPointer<CInt> {
+  return unsafe returnPointer(len)
+}
+
+func call_anonymous(_ len: CInt, _ _anonymous_param1: UnsafeMutablePointer<CInt>?) {
+  return unsafe anonymous(len,  _anonymous_param1)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(_anonymous_param1: copy _anonymous_param1)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_anonymous(_ _anonymous_param1: inout MutableSpan<CInt>?) {
+  return anonymous(&_anonymous_param1)
+}
+
+func call_keyword(_ len: CInt, _ func: UnsafeMutablePointer<CInt>?, _ extension: CInt, _ init: CInt, _ open: CInt, _ var: CInt, _ is: CInt, _ as: CInt, _ in: CInt, _ guard: CInt, _ where: CInt) {
+  return unsafe keyword(len, `func`, `extension`, `init`, open, `var`, `is`, `as`, `in`, `guard`, `where`)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(`func`: copy `func`)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_keyword(_ func: inout MutableSpan<CInt>?, _ extension: CInt, _ init: CInt, _ open: CInt, _ var: CInt, _ is: CInt, _ as: CInt, _ in: CInt, _ guard: CInt, _ where: CInt) {
+  return keyword(&`func`, `extension`, `init`, open, `var`, `is`, `as`, `in`, `guard`, `where`)
+}
+
+func call_pointerName(_ len: CInt, _  _pointerName_param1: UnsafeMutablePointer<CInt>?) {
+  return unsafe pointerName(len,  _pointerName_param1)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(_pointerName_param1: copy _pointerName_param1)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_pointerName(_ _pointerName_param1: inout MutableSpan<CInt>?) {
+  return pointerName(&_pointerName_param1)
+}
+
+func call_lenName(_  _lenName_param0: CInt, _ size: CInt, _ p: UnsafeMutablePointer<CInt>?) {
+  return unsafe lenName( _lenName_param0, size, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(_lenName_param2: copy _lenName_param2)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_lenName(_ _lenName_param0: CInt, _ _lenName_param1: CInt, _ _lenName_param2: inout MutableSpan<CInt>?) {
+  return lenName(_lenName_param0, _lenName_param1, &_lenName_param2)
+}
+
+func call_func(_ len: CInt, _  _func_param1: UnsafeMutablePointer<CInt>?) {
+  return unsafe `func`(len,  _func_param1)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(_func_param1: copy _func_param1)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_func(_ _func_param1: inout MutableSpan<CInt>?) {
+  return `func`(&_func_param1)
+}
+
+func call_funcRenamed(len: CInt, func: UnsafeMutablePointer<CInt>?, extension: CInt, init: CInt, open: CInt, `var`: CInt, is: CInt, as: CInt, in: CInt, guard: CInt, where: CInt) -> UnsafeMutableRawPointer! {
+  return unsafe funcRenamed(len: len, func: `func`, extension: `extension`, init: `init`, open: open, var: `var`, is: `is`, as: `as`, in: `in`, guard: `guard`, where: `where`)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(`func`: copy `func`)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_funcRenamed(func: inout MutableSpan<CInt>?, extension: CInt, init: CInt, open: CInt, `var`: CInt, is: CInt, as: CInt, in: CInt, guard: CInt, where: CInt) -> UnsafeMutableRawPointer! {
+  return unsafe funcRenamed(func: &`func`, extension: `extension`, init: `init`, open: open, var: `var`, is: `is`, as: `as`, in: `in`, guard: `guard`, where: `where`)
+}
+
+func call_funcRenamedAnon(len: CInt, func  _funcRenamedAnon_param1: UnsafeMutablePointer<CInt>?, extension  _funcRenamedAnon_param2: CInt, init  _funcRenamedAnon_param3: CInt, open  _funcRenamedAnon_param4: CInt, `var`  _funcRenamedAnon_param5: CInt, is  _funcRenamedAnon_param6: CInt, as  _funcRenamedAnon_param7: CInt, in  _funcRenamedAnon_param8: CInt, guard  _funcRenamedAnon_param9: CInt, where  _funcRenamedAnon_param10: CInt) -> UnsafeMutableRawPointer! {
+  return unsafe funcRenamedAnon(len: len, func:  _funcRenamedAnon_param1, extension:  _funcRenamedAnon_param2, init:  _funcRenamedAnon_param3, open:  _funcRenamedAnon_param4, var:  _funcRenamedAnon_param5, is:  _funcRenamedAnon_param6, as:  _funcRenamedAnon_param7, in:  _funcRenamedAnon_param8, guard:  _funcRenamedAnon_param9, where:  _funcRenamedAnon_param10)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(_funcRenamedAnon_param1: copy _funcRenamedAnon_param1)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_funcRenamedAnon(func _funcRenamedAnon_param1: inout MutableSpan<CInt>?, extension _funcRenamedAnon_param2: CInt, init _funcRenamedAnon_param3: CInt, open _funcRenamedAnon_param4: CInt, `var` _funcRenamedAnon_param5: CInt, is _funcRenamedAnon_param6: CInt, as _funcRenamedAnon_param7: CInt, in _funcRenamedAnon_param8: CInt, guard _funcRenamedAnon_param9: CInt, where _funcRenamedAnon_param10: CInt) -> UnsafeMutableRawPointer! {
+  return unsafe funcRenamedAnon(func: &_funcRenamedAnon_param1, extension: _funcRenamedAnon_param2, init: _funcRenamedAnon_param3, open: _funcRenamedAnon_param4, var: _funcRenamedAnon_param5, is: _funcRenamedAnon_param6, as: _funcRenamedAnon_param7, in: _funcRenamedAnon_param8, guard: _funcRenamedAnon_param9, where: _funcRenamedAnon_param10)
+}
+
+func call_clash(len: CInt, func: UnsafeMutablePointer<CInt>?, clash where: CInt) {
+  return unsafe clash(len: len, func: `func`, clash: `where`)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(`func`: copy `func`)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_clash(func: inout MutableSpan<CInt>?, clash where: CInt) {
+  return clash(func: &`func`, clash: `where`)
+}
+
+func call_open(len: CInt, func: UnsafeMutablePointer<CInt>?, open where: CInt) {
+  return unsafe open(len: len, func: `func`, open: `where`)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(`func`: copy `func`)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_open(func: inout MutableSpan<CInt>?, open where: CInt) {
+  return open(func: &`func`, open: `where`)
+}
+
+func call_clash2(len: CInt, func: UnsafeMutablePointer<CInt>?, clash2  _clash2_param2: CInt) {
+  return unsafe clash2(len: len, func: `func`, clash2:  _clash2_param2)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(_clash2_param1: copy _clash2_param1)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_clash2(func _clash2_param1: inout MutableSpan<CInt>?, clash2 _clash2_param2: CInt) {
+  return clash2(func: &_clash2_param1, clash2: _clash2_param2)
+}
+
+func call_in(len: CInt, func: UnsafeMutablePointer<CInt>?, in  _in_param2: CInt) {
+  return unsafe `in`(len: len, func: `func`, in:  _in_param2)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(_in_param1: copy _in_param1)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_in(func _in_param1: inout MutableSpan<CInt>?, in _in_param2: CInt) {
+  return `in`(func: &_in_param1, in: _in_param2)
+}
+
+func call_keywordType(_ len: CInt, _ p: UnsafeMutablePointer<actor?>!, _ p2: OpaquePointer) -> actor {
+  return unsafe keywordType(len, p, p2)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_keywordType(_ p: inout MutableSpan<actor?>, _ p2: OpaquePointer) -> actor {
+  return unsafe keywordType(&p, p2)
 }

--- a/test/Interop/C/swiftify-import/counted-by-or-null.swift
+++ b/test/Interop/C/swiftify-import/counted-by-or-null.swift
@@ -342,26 +342,46 @@ module Test {
 
 //--- test.swift
 // GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -plugin-path %swift-plugin-dir -I %t -source-filename=x -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
-// GENERATED-HASH: d2d43a5938957e3dab89c039becb367e20865af0ed9f2dd5162c48824e3b6c58
+// GENERATED-HASH: 2345b283478afbabfc9da1374ea49c8ab9ad1ad6fe1a54d54411a995aff0dc02
 import Test
 
 func call_simple(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
   return unsafe simple(len, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe simple(p)
+}
+
 func call_simpleFlipped(_ p: UnsafeMutablePointer<CInt>!, _ len: CInt) {
   return unsafe simpleFlipped(p, len)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_simpleFlipped(_ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe simpleFlipped(p)
 }
 
 func call_swiftAttr(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
   return unsafe swiftAttr(len, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_swiftAttr(_ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe swiftAttr(p)
+}
+
 func call_shared(_ len: CInt, _ p1: UnsafeMutablePointer<CInt>!, _ p2: UnsafeMutablePointer<CInt>!) {
   return unsafe shared(len, p1, p2)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_shared(_ p1: UnsafeMutableBufferPointer<CInt>, _ p2: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe shared(p1, p2)
+}
+
 func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: UnsafeMutablePointer<CInt>!) {
+  return unsafe complexExpr(len, offset, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
   return unsafe complexExpr(len, offset, p)
 }
 
@@ -369,15 +389,31 @@ func call_nullUnspecified(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
   return unsafe nullUnspecified(len, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe nullUnspecified(p)
+}
+
 func call_nonnull(_ len: CInt, _ p: UnsafeMutablePointer<CInt>) {
   return unsafe nonnull(len, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe nonnull(p)
 }
 
 func call_nullable(_ len: CInt, _ p: UnsafeMutablePointer<CInt>?) {
   return unsafe nullable(len, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ p: UnsafeMutableBufferPointer<CInt>?) {
+  return unsafe nullable(p)
+}
+
 func call_returnPointer(_ len: CInt) -> UnsafeMutablePointer<CInt>! {
+  return unsafe returnPointer(len)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_returnPointer(_ len: CInt) -> UnsafeMutableBufferPointer<CInt> {
   return unsafe returnPointer(len)
 }
 
@@ -385,7 +421,15 @@ func call_offByOne(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
   return unsafe offByOne(len, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_offByOne(_ len: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe offByOne(len, p)
+}
+
 func call_offBySome(_ len: CInt, _ offset: CInt, _ p: UnsafeMutablePointer<CInt>!) {
+  return unsafe offBySome(len, offset, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_offBySome(_ len: CInt, _ offset: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
   return unsafe offBySome(len, offset, p)
 }
 
@@ -393,7 +437,15 @@ func call_scalar(_ m: CInt, _ n: CInt, _ p: UnsafeMutablePointer<CInt>!) {
   return unsafe scalar(m, n, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_scalar(_ m: CInt, _ n: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe scalar(m, n, p)
+}
+
 func call_bitwise(_ m: CInt, _ n: CInt, _ o: CInt, _ p: UnsafeMutablePointer<CInt>!) {
+  return unsafe bitwise(m, n, o, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_bitwise(_ m: CInt, _ n: CInt, _ o: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
   return unsafe bitwise(m, n, o, p)
 }
 
@@ -401,7 +453,15 @@ func call_bitshift(_ m: CInt, _ n: CInt, _ o: CInt, _ p: UnsafeMutablePointer<CI
   return unsafe bitshift(m, n, o, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_bitshift(_ m: CInt, _ n: CInt, _ o: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe bitshift(m, n, o, p)
+}
+
 func call_constInt(_ p: UnsafeMutablePointer<CInt>!) {
+  return unsafe constInt(p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_constInt(_ p: UnsafeMutableBufferPointer<CInt>) {
   return unsafe constInt(p)
 }
 
@@ -409,11 +469,23 @@ func call_constFloatCastedToInt(_ p: UnsafeMutablePointer<CInt>!) {
   return unsafe constFloatCastedToInt(p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_constFloatCastedToInt(_ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe constFloatCastedToInt(p)
+}
+
 func call_sizeofType(_ p: UnsafeMutablePointer<CInt>!) {
   return unsafe sizeofType(p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_sizeofType(_ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe sizeofType(p)
+}
+
 func call_sizeofParam(_ p: UnsafeMutablePointer<CChar>!) {
+  return unsafe sizeofParam(p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_sizeofParam(_ p: UnsafeMutableBufferPointer<CChar>) {
   return unsafe sizeofParam(p)
 }
 
@@ -437,6 +509,10 @@ func call_floatCastToInt(_ meters: CFloat, _ p: UnsafeMutablePointer<CInt>!) {
   return unsafe floatCastToInt(meters, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_floatCastToInt(_ meters: CFloat, _ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe floatCastToInt(meters, p)
+}
+
 func call_pointerCastToInt(_ square: UnsafeMutablePointer<CInt>!, _ p: UnsafeMutablePointer<CInt>!) {
   return unsafe pointerCastToInt(square, p)
 }
@@ -445,7 +521,15 @@ func call_nanAsInt(_ p: UnsafeMutablePointer<CInt>!) {
   return unsafe nanAsInt(p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nanAsInt(_ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe nanAsInt(p)
+}
+
 func call_unsignedLiteral(_ p: UnsafeMutablePointer<CInt>!) {
+  return unsafe unsignedLiteral(p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_unsignedLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
   return unsafe unsignedLiteral(p)
 }
 
@@ -453,7 +537,15 @@ func call_longLiteral(_ p: UnsafeMutablePointer<CInt>!) {
   return unsafe longLiteral(p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_longLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe longLiteral(p)
+}
+
 func call_hexLiteral(_ p: UnsafeMutablePointer<CInt>!) {
+  return unsafe hexLiteral(p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_hexLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
   return unsafe hexLiteral(p)
 }
 
@@ -461,7 +553,15 @@ func call_binaryLiteral(_ p: UnsafeMutablePointer<CInt>!) {
   return unsafe binaryLiteral(p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_binaryLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe binaryLiteral(p)
+}
+
 func call_octalLiteral(_ p: UnsafeMutablePointer<CInt>!) {
+  return unsafe octalLiteral(p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_octalLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
   return unsafe octalLiteral(p)
 }
 
@@ -469,8 +569,16 @@ func call_mixedShared(_ len: CInt, _ p1: UnsafeMutablePointer<CInt>?, _ p2: Unsa
   return unsafe mixedShared(len, p1, p2)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_mixedShared(_ p1: UnsafeMutableBufferPointer<CInt>?, _ p2: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe mixedShared(p1, p2)
+}
+
 func call_mixedThree(_ len: CInt, _ p1: UnsafeMutablePointer<CInt>?, _ p2: UnsafeMutablePointer<CInt>!, _ p3: UnsafeMutablePointer<CInt>?) {
   return unsafe mixedThree(len, p1, p2, p3)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_mixedThree(_ p1: UnsafeMutableBufferPointer<CInt>?, _ p2: UnsafeMutableBufferPointer<CInt>, _ p3: UnsafeMutableBufferPointer<CInt>?) {
+  return unsafe mixedThree(p1, p2, p3)
 }
 
 func call_allOrNull(_ len: CInt, _ p1: UnsafeMutablePointer<CInt>?, _ p2: UnsafeMutablePointer<CInt>?) {
@@ -479,112 +587,4 @@ func call_allOrNull(_ len: CInt, _ p1: UnsafeMutablePointer<CInt>?, _ p2: Unsafe
 
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_allOrNull(_ p1: UnsafeMutableBufferPointer<CInt>?, _ p2: UnsafeMutableBufferPointer<CInt>?) {
   return unsafe allOrNull(p1, p2)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_binaryLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe binaryLiteral(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_bitshift(_ m: CInt, _ n: CInt, _ o: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe bitshift(m, n, o, p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_bitwise(_ m: CInt, _ n: CInt, _ o: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe bitwise(m, n, o, p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe complexExpr(len, offset, p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_constFloatCastedToInt(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe constFloatCastedToInt(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_constInt(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe constInt(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_floatCastToInt(_ meters: CFloat, _ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe floatCastToInt(meters, p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_hexLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe hexLiteral(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_longLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe longLiteral(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_mixedShared(_ p1: UnsafeMutableBufferPointer<CInt>?, _ p2: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe mixedShared(p1, p2)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_mixedThree(_ p1: UnsafeMutableBufferPointer<CInt>?, _ p2: UnsafeMutableBufferPointer<CInt>, _ p3: UnsafeMutableBufferPointer<CInt>?) {
-  return unsafe mixedThree(p1, p2, p3)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nanAsInt(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe nanAsInt(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe nonnull(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe nullUnspecified(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ p: UnsafeMutableBufferPointer<CInt>?) {
-  return unsafe nullable(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_octalLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe octalLiteral(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_offByOne(_ len: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe offByOne(len, p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_offBySome(_ len: CInt, _ offset: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe offBySome(len, offset, p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_returnPointer(_ len: CInt) -> UnsafeMutableBufferPointer<CInt> {
-  return unsafe returnPointer(len)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_scalar(_ m: CInt, _ n: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe scalar(m, n, p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_shared(_ p1: UnsafeMutableBufferPointer<CInt>, _ p2: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe shared(p1, p2)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe simple(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_simpleFlipped(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe simpleFlipped(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_sizeofParam(_ p: UnsafeMutableBufferPointer<CChar>) {
-  return unsafe sizeofParam(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_sizeofType(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe sizeofType(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_swiftAttr(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe swiftAttr(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_unsignedLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe unsignedLiteral(p)
 }

--- a/test/Interop/C/swiftify-import/counted-by.swift
+++ b/test/Interop/C/swiftify-import/counted-by.swift
@@ -341,26 +341,46 @@ module Test {
 
 //--- test.swift
 // GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -plugin-path %swift-plugin-dir -I %t -source-filename=x -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
-// GENERATED-HASH: d59a494a7fd5d429b92014384812f2939ec16d6e21861a19a4e84429f023ab5c
+// GENERATED-HASH: 59c09ad9c306326f1ba769c2f7d9af251c14365ff8895c191787930f55ad9991
 import Test
 
 func call_simple(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
   return unsafe simple(len, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe simple(p)
+}
+
 func call_simpleFlipped(_ p: UnsafeMutablePointer<CInt>!, _ len: CInt) {
   return unsafe simpleFlipped(p, len)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_simpleFlipped(_ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe simpleFlipped(p)
 }
 
 func call_swiftAttr(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
   return unsafe swiftAttr(len, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_swiftAttr(_ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe swiftAttr(p)
+}
+
 func call_shared(_ len: CInt, _ p1: UnsafeMutablePointer<CInt>!, _ p2: UnsafeMutablePointer<CInt>!) {
   return unsafe shared(len, p1, p2)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_shared(_ p1: UnsafeMutableBufferPointer<CInt>, _ p2: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe shared(p1, p2)
+}
+
 func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: UnsafeMutablePointer<CInt>!) {
+  return unsafe complexExpr(len, offset, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
   return unsafe complexExpr(len, offset, p)
 }
 
@@ -368,15 +388,31 @@ func call_nullUnspecified(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
   return unsafe nullUnspecified(len, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe nullUnspecified(p)
+}
+
 func call_nonnull(_ len: CInt, _ p: UnsafeMutablePointer<CInt>) {
   return unsafe nonnull(len, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe nonnull(p)
 }
 
 func call_nullable(_ len: CInt, _ p: UnsafeMutablePointer<CInt>?) {
   return unsafe nullable(len, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe nullable(p)
+}
+
 func call_returnPointer(_ len: CInt) -> UnsafeMutablePointer<CInt>! {
+  return unsafe returnPointer(len)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_returnPointer(_ len: CInt) -> UnsafeMutableBufferPointer<CInt> {
   return unsafe returnPointer(len)
 }
 
@@ -384,7 +420,15 @@ func call_offByOne(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
   return unsafe offByOne(len, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_offByOne(_ len: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe offByOne(len, p)
+}
+
 func call_offBySome(_ len: CInt, _ offset: CInt, _ p: UnsafeMutablePointer<CInt>!) {
+  return unsafe offBySome(len, offset, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_offBySome(_ len: CInt, _ offset: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
   return unsafe offBySome(len, offset, p)
 }
 
@@ -392,7 +436,15 @@ func call_scalar(_ m: CInt, _ n: CInt, _ p: UnsafeMutablePointer<CInt>!) {
   return unsafe scalar(m, n, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_scalar(_ m: CInt, _ n: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe scalar(m, n, p)
+}
+
 func call_bitwise(_ m: CInt, _ n: CInt, _ o: CInt, _ p: UnsafeMutablePointer<CInt>!) {
+  return unsafe bitwise(m, n, o, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_bitwise(_ m: CInt, _ n: CInt, _ o: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
   return unsafe bitwise(m, n, o, p)
 }
 
@@ -400,7 +452,15 @@ func call_bitshift(_ m: CInt, _ n: CInt, _ o: CInt, _ p: UnsafeMutablePointer<CI
   return unsafe bitshift(m, n, o, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_bitshift(_ m: CInt, _ n: CInt, _ o: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe bitshift(m, n, o, p)
+}
+
 func call_constInt(_ p: UnsafeMutablePointer<CInt>!) {
+  return unsafe constInt(p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_constInt(_ p: UnsafeMutableBufferPointer<CInt>) {
   return unsafe constInt(p)
 }
 
@@ -408,11 +468,23 @@ func call_constFloatCastedToInt(_ p: UnsafeMutablePointer<CInt>!) {
   return unsafe constFloatCastedToInt(p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_constFloatCastedToInt(_ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe constFloatCastedToInt(p)
+}
+
 func call_sizeofType(_ p: UnsafeMutablePointer<CInt>!) {
   return unsafe sizeofType(p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_sizeofType(_ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe sizeofType(p)
+}
+
 func call_sizeofParam(_ p: UnsafeMutablePointer<CChar>!) {
+  return unsafe sizeofParam(p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_sizeofParam(_ p: UnsafeMutableBufferPointer<CChar>) {
   return unsafe sizeofParam(p)
 }
 
@@ -436,6 +508,10 @@ func call_floatCastToInt(_ meters: CFloat, _ p: UnsafeMutablePointer<CInt>!) {
   return unsafe floatCastToInt(meters, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_floatCastToInt(_ meters: CFloat, _ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe floatCastToInt(meters, p)
+}
+
 func call_pointerCastToInt(_ square: UnsafeMutablePointer<CInt>!, _ p: UnsafeMutablePointer<CInt>!) {
   return unsafe pointerCastToInt(square, p)
 }
@@ -444,7 +520,15 @@ func call_nanAsInt(_ p: UnsafeMutablePointer<CInt>!) {
   return unsafe nanAsInt(p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nanAsInt(_ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe nanAsInt(p)
+}
+
 func call_unsignedLiteral(_ p: UnsafeMutablePointer<CInt>!) {
+  return unsafe unsignedLiteral(p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_unsignedLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
   return unsafe unsignedLiteral(p)
 }
 
@@ -452,7 +536,15 @@ func call_longLiteral(_ p: UnsafeMutablePointer<CInt>!) {
   return unsafe longLiteral(p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_longLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe longLiteral(p)
+}
+
 func call_hexLiteral(_ p: UnsafeMutablePointer<CInt>!) {
+  return unsafe hexLiteral(p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_hexLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
   return unsafe hexLiteral(p)
 }
 
@@ -460,7 +552,15 @@ func call_binaryLiteral(_ p: UnsafeMutablePointer<CInt>!) {
   return unsafe binaryLiteral(p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_binaryLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe binaryLiteral(p)
+}
+
 func call_octalLiteral(_ p: UnsafeMutablePointer<CInt>!) {
+  return unsafe octalLiteral(p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_octalLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
   return unsafe octalLiteral(p)
 }
 
@@ -468,7 +568,15 @@ func call_implicitIntCast(_ offset: CLongLong, _ len: CInt, _ p: UnsafeMutablePo
   return unsafe implicitIntCast(offset, len, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_implicitIntCast(_ offset: CLongLong, _ len: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
+  return unsafe implicitIntCast(offset, len, p)
+}
+
 func call_castTwiceLiteral(_ p: UnsafeMutablePointer<CInt>!) {
+  return unsafe castTwiceLiteral(p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_castTwiceLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
   return unsafe castTwiceLiteral(p)
 }
 
@@ -476,122 +584,14 @@ func call_castParam(_ p: UnsafeMutablePointer<CInt>!, _ len: CShort) {
   return unsafe castParam(p, len)
 }
 
-func call_castParam2(_ p: UnsafeMutablePointer<CInt>!, _ len: CUnsignedInt) {
-  return unsafe castParam2(p, len)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_binaryLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe binaryLiteral(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_bitshift(_ m: CInt, _ n: CInt, _ o: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe bitshift(m, n, o, p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_bitwise(_ m: CInt, _ n: CInt, _ o: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe bitwise(m, n, o, p)
-}
-
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_castParam(_ p: UnsafeMutableBufferPointer<CInt>, _ len: CShort) {
   return unsafe castParam(p, len)
 }
 
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_castParam2(_ p: UnsafeMutableBufferPointer<CInt>, _ len: CUnsignedInt) {
+func call_castParam2(_ p: UnsafeMutablePointer<CInt>!, _ len: CUnsignedInt) {
   return unsafe castParam2(p, len)
 }
 
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_castTwiceLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe castTwiceLiteral(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe complexExpr(len, offset, p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_constFloatCastedToInt(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe constFloatCastedToInt(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_constInt(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe constInt(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_floatCastToInt(_ meters: CFloat, _ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe floatCastToInt(meters, p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_hexLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe hexLiteral(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_implicitIntCast(_ offset: CLongLong, _ len: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe implicitIntCast(offset, len, p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_longLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe longLiteral(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nanAsInt(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe nanAsInt(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe nonnull(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe nullUnspecified(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe nullable(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_octalLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe octalLiteral(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_offByOne(_ len: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe offByOne(len, p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_offBySome(_ len: CInt, _ offset: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe offBySome(len, offset, p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_returnPointer(_ len: CInt) -> UnsafeMutableBufferPointer<CInt> {
-  return unsafe returnPointer(len)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_scalar(_ m: CInt, _ n: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe scalar(m, n, p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_shared(_ p1: UnsafeMutableBufferPointer<CInt>, _ p2: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe shared(p1, p2)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe simple(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_simpleFlipped(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe simpleFlipped(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_sizeofParam(_ p: UnsafeMutableBufferPointer<CChar>) {
-  return unsafe sizeofParam(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_sizeofType(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe sizeofType(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_swiftAttr(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe swiftAttr(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_unsignedLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
-  return unsafe unsignedLiteral(p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_castParam2(_ p: UnsafeMutableBufferPointer<CInt>, _ len: CUnsignedInt) {
+  return unsafe castParam2(p, len)
 }

--- a/test/Interop/C/swiftify-import/sized-by-legacy.swift
+++ b/test/Interop/C/swiftify-import/sized-by-legacy.swift
@@ -153,7 +153,7 @@ module Test {
 
 //--- test.swift
 // GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -enable-experimental-feature SafeInteropWrappers -plugin-path %swift-plugin-dir -I %t -source-filename=x -Xcc -Wno-nullability-completeness > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
-// GENERATED-HASH: f3a4ba5bf982f52e53454729d13d39b82e277f1a7cae401414cbf4ecf23ed0c3
+// GENERATED-HASH: 5701badde853d541916b7f9c9b7afc59f3b89e704784fd303cb1ba16b8646b2a
 import Test
 
 
@@ -162,15 +162,31 @@ func call_simple(_ len: CInt, _ p: UnsafeMutableRawPointer!) {
   return unsafe simple(len, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ p: UnsafeMutableRawBufferPointer) {
+  return unsafe simple(p)
+}
+
 func call_swiftAttr(_ len: CInt, _ p: UnsafeMutableRawPointer!) {
   return unsafe swiftAttr(len, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_swiftAttr(_ p: UnsafeMutableRawBufferPointer) {
+  return unsafe swiftAttr(p)
 }
 
 func call_shared(_ len: CInt, _ p1: UnsafeMutableRawPointer!, _ p2: UnsafeMutableRawPointer!) {
   return unsafe shared(len, p1, p2)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_shared(_ p1: UnsafeMutableRawBufferPointer, _ p2: UnsafeMutableRawBufferPointer) {
+  return unsafe shared(p1, p2)
+}
+
 func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: UnsafeMutableRawPointer!) {
+  return unsafe complexExpr(len, offset, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: UnsafeMutableRawBufferPointer) {
   return unsafe complexExpr(len, offset, p)
 }
 
@@ -178,15 +194,31 @@ func call_nullUnspecified(_ len: CInt, _ p: UnsafeMutableRawPointer!) {
   return unsafe nullUnspecified(len, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ p: UnsafeMutableRawBufferPointer) {
+  return unsafe nullUnspecified(p)
+}
+
 func call_nonnull(_ len: CInt, _ p: UnsafeMutableRawPointer) {
   return unsafe nonnull(len, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ p: UnsafeMutableRawBufferPointer) {
+  return unsafe nonnull(p)
 }
 
 func call_nullable(_ len: CInt, _ p: UnsafeMutableRawPointer?) {
   return unsafe nullable(len, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ p: UnsafeMutableRawBufferPointer?) {
+  return unsafe nullable(p)
+}
+
 func call_returnPointer(_ len: CInt) -> UnsafeMutableRawPointer! {
+  return unsafe returnPointer(len)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_returnPointer(_ len: CInt) -> UnsafeMutableRawBufferPointer {
   return unsafe returnPointer(len)
 }
 
@@ -194,15 +226,31 @@ func call_opaque(_ len: CInt, _ p: OpaquePointer!) {
   return unsafe opaque(len, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_opaque(_ p: UnsafeRawBufferPointer) {
+  return unsafe opaque(p)
+}
+
 func call_opaqueptr(_ len: CInt, _ p: OpaquePointer!) {
   return unsafe opaqueptr(len, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_opaqueptr(_ p: UnsafeRawBufferPointer) {
+  return unsafe opaqueptr(p)
 }
 
 func call_charsized(_ _charsized_param0: UnsafeMutablePointer<CChar>!, _ size: CInt) {
   return unsafe charsized( _charsized_param0, size)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_charsized(_ _charsized_param0: UnsafeMutableRawBufferPointer) {
+  return unsafe charsized(_charsized_param0)
+}
+
 func call_bytesized(_ size: CInt) -> UnsafeMutablePointer<UInt8>! {
+  return unsafe bytesized(size)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_bytesized(_ size: CInt) -> UnsafeMutableRawBufferPointer {
   return unsafe bytesized(size)
 }
 
@@ -216,52 +264,4 @@ func call_aliasedBytesized(_ p: UnsafeMutablePointer<UInt8>!, _ size: CInt) {
 
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_aliasedBytesized(_ p: UnsafeMutableRawBufferPointer) {
   return unsafe aliasedBytesized(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_bytesized(_ size: CInt) -> UnsafeMutableRawBufferPointer {
-  return unsafe bytesized(size)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_charsized(_ _charsized_param0: UnsafeMutableRawBufferPointer) {
-  return unsafe charsized(_charsized_param0)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: UnsafeMutableRawBufferPointer) {
-  return unsafe complexExpr(len, offset, p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ p: UnsafeMutableRawBufferPointer) {
-  return unsafe nonnull(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ p: UnsafeMutableRawBufferPointer) {
-  return unsafe nullUnspecified(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ p: UnsafeMutableRawBufferPointer?) {
-  return unsafe nullable(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_opaque(_ p: UnsafeRawBufferPointer) {
-  return unsafe opaque(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_opaqueptr(_ p: UnsafeRawBufferPointer) {
-  return unsafe opaqueptr(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_returnPointer(_ len: CInt) -> UnsafeMutableRawBufferPointer {
-  return unsafe returnPointer(len)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_shared(_ p1: UnsafeMutableRawBufferPointer, _ p2: UnsafeMutableRawBufferPointer) {
-  return unsafe shared(p1, p2)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ p: UnsafeMutableRawBufferPointer) {
-  return unsafe simple(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_swiftAttr(_ p: UnsafeMutableRawBufferPointer) {
-  return unsafe swiftAttr(p)
 }

--- a/test/Interop/C/swiftify-import/sized-by-lifetimebound-legacy.swift
+++ b/test/Interop/C/swiftify-import/sized-by-lifetimebound-legacy.swift
@@ -223,7 +223,7 @@ module Test {
 
 //--- test.swift
 // GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -enable-experimental-feature SafeInteropWrappers -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers -Xcc -Wno-nullability-completeness > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
-// GENERATED-HASH: 3ed369e458a494f8ed6a65c32a5a1b77f5d58e8ee26e1b29016ac8adff771740
+// GENERATED-HASH: bc828f607531ee66a74238439370c9f68f62fac068c6e4294af725c6056d2cab
 import Test
 
 
@@ -232,114 +232,17 @@ func call_simple(_ len: CInt, _ len2: CInt, _ p: UnsafeRawPointer!) -> UnsafeRaw
   return unsafe simple(len, len2, p)
 }
 
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ len: CInt, _ p: RawSpan) -> RawSpan {
+  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer?' to return type 'RawSpan'}}
+  return simple(len, p)
+}
+
 func call_shared(_ len: CInt, _ p: UnsafeRawPointer!) -> UnsafeRawPointer! {
   return unsafe shared(len, p)
-}
-
-func call_complexExpr(_ len: CInt, _ offset: CInt, _ len2: CInt, _ p: UnsafeRawPointer!) -> UnsafeRawPointer! {
-  return unsafe complexExpr(len, offset, len2, p)
-}
-
-func call_nullUnspecified(_ len: CInt, _ len2: CInt, _ p: UnsafeRawPointer!) -> UnsafeRawPointer! {
-  return unsafe nullUnspecified(len, len2, p)
-}
-
-func call_nonnull(_ len: CInt, _ len2: CInt, _ p: UnsafeRawPointer) -> UnsafeRawPointer {
-  return unsafe nonnull(len, len2, p)
-}
-
-func call_nullable(_ len: CInt, _ len2: CInt, _ p: UnsafeRawPointer?) -> UnsafeRawPointer? {
-  return unsafe nullable(len, len2, p)
-}
-
-func call_opaque(_ len: CInt, _ len2: CInt, _ p: OpaquePointer!) -> OpaquePointer! {
-  return unsafe opaque(len, len2, p)
-}
-
-func call_nonsizedLifetime(_ len: CInt, _ p: UnsafeRawPointer!) -> UnsafeRawPointer! {
-  return unsafe nonsizedLifetime(len, p)
-}
-
-func call_bytesized(_ size: CInt, _ p: UnsafePointer<UInt8>!) -> UnsafeMutablePointer<UInt8>! {
-  return unsafe bytesized(size, p)
-}
-
-func call_charsized(_ p: UnsafeMutablePointer<CChar>!, _ size: CInt) -> UnsafeMutablePointer<CChar>! {
-  return unsafe charsized(p, size)
-}
-
-func call_doublebytesized(_ p: UnsafeMutablePointer<UInt16>!, _ size: CInt) -> UnsafePointer<UInt16>! {
-  return unsafe doublebytesized(p, size)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_bytesized(_ p: RawSpan) -> MutableRawSpan {
-  // expected-stable-error@+3{{missing argument for parameter #2 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<UInt8>?' to return type 'MutableRawSpan'}}
-  return bytesized(p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_charsized(_ p: inout MutableRawSpan) -> MutableRawSpan {
-  // expected-stable-error@+2{{missing argument for parameter #2 in call}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CChar>?' (aka 'Optional<UnsafeMutablePointer<Int8>>') to return type 'MutableRawSpan'}}
-  return charsized(&p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: RawSpan) -> RawSpan {
-  // expected-stable-error@+3{{missing argument for parameter #4 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer?' to return type 'RawSpan'}}
-  return complexExpr(len, offset, p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ len: CInt, _ p: RawSpan) -> RawSpan {
-  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer' to return type 'RawSpan'}}
-  return nonnull(len, p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(borrow p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonsizedLifetime(_ len: CInt, _ p: UnsafeRawPointer!) -> RawSpan {
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer?' to return type 'RawSpan'}}
-  return unsafe nonsizedLifetime(len, p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ len: CInt, _ p: RawSpan) -> RawSpan {
-  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer?' to return type 'RawSpan'}}
-  return nullUnspecified(len, p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ len: CInt, _ p: RawSpan?) -> RawSpan? {
-  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'RawSpan?' to expected argument type 'CInt' (aka 'Int32')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer?' to return type 'RawSpan?'}}
-  return nullable(len, p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_opaque(_ len: CInt, _ p: RawSpan) -> RawSpan {
-  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'OpaquePointer?' to return type 'RawSpan'}}
-  return opaque(len, p)
 }
 
 @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
@@ -351,11 +254,108 @@ func call_doublebytesized(_ p: UnsafeMutablePointer<UInt16>!, _ size: CInt) -> U
   return shared(p)
 }
 
+func call_complexExpr(_ len: CInt, _ offset: CInt, _ len2: CInt, _ p: UnsafeRawPointer!) -> UnsafeRawPointer! {
+  return unsafe complexExpr(len, offset, len2, p)
+}
+
 @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 @_lifetime(copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ len: CInt, _ p: RawSpan) -> RawSpan {
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: RawSpan) -> RawSpan {
+  // expected-stable-error@+3{{missing argument for parameter #4 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer?' to return type 'RawSpan'}}
+  return complexExpr(len, offset, p)
+}
+
+func call_nullUnspecified(_ len: CInt, _ len2: CInt, _ p: UnsafeRawPointer!) -> UnsafeRawPointer! {
+  return unsafe nullUnspecified(len, len2, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ len: CInt, _ p: RawSpan) -> RawSpan {
   // expected-stable-error@+3{{missing argument for parameter #3 in call}}
   // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
   // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer?' to return type 'RawSpan'}}
-  return simple(len, p)
+  return nullUnspecified(len, p)
+}
+
+func call_nonnull(_ len: CInt, _ len2: CInt, _ p: UnsafeRawPointer) -> UnsafeRawPointer {
+  return unsafe nonnull(len, len2, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ len: CInt, _ p: RawSpan) -> RawSpan {
+  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer' to return type 'RawSpan'}}
+  return nonnull(len, p)
+}
+
+func call_nullable(_ len: CInt, _ len2: CInt, _ p: UnsafeRawPointer?) -> UnsafeRawPointer? {
+  return unsafe nullable(len, len2, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ len: CInt, _ p: RawSpan?) -> RawSpan? {
+  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'RawSpan?' to expected argument type 'CInt' (aka 'Int32')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer?' to return type 'RawSpan?'}}
+  return nullable(len, p)
+}
+
+func call_opaque(_ len: CInt, _ len2: CInt, _ p: OpaquePointer!) -> OpaquePointer! {
+  return unsafe opaque(len, len2, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_opaque(_ len: CInt, _ p: RawSpan) -> RawSpan {
+  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'OpaquePointer?' to return type 'RawSpan'}}
+  return opaque(len, p)
+}
+
+func call_nonsizedLifetime(_ len: CInt, _ p: UnsafeRawPointer!) -> UnsafeRawPointer! {
+  return unsafe nonsizedLifetime(len, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(borrow p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonsizedLifetime(_ len: CInt, _ p: UnsafeRawPointer!) -> RawSpan {
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer?' to return type 'RawSpan'}}
+  return unsafe nonsizedLifetime(len, p)
+}
+
+func call_bytesized(_ size: CInt, _ p: UnsafePointer<UInt8>!) -> UnsafeMutablePointer<UInt8>! {
+  return unsafe bytesized(size, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_bytesized(_ p: RawSpan) -> MutableRawSpan {
+  // expected-stable-error@+3{{missing argument for parameter #2 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<UInt8>?' to return type 'MutableRawSpan'}}
+  return bytesized(p)
+}
+
+func call_charsized(_ p: UnsafeMutablePointer<CChar>!, _ size: CInt) -> UnsafeMutablePointer<CChar>! {
+  return unsafe charsized(p, size)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_charsized(_ p: inout MutableRawSpan) -> MutableRawSpan {
+  // expected-stable-error@+2{{missing argument for parameter #2 in call}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CChar>?' (aka 'Optional<UnsafeMutablePointer<Int8>>') to return type 'MutableRawSpan'}}
+  return charsized(&p)
+}
+
+func call_doublebytesized(_ p: UnsafeMutablePointer<UInt16>!, _ size: CInt) -> UnsafePointer<UInt16>! {
+  return unsafe doublebytesized(p, size)
 }

--- a/test/Interop/C/swiftify-import/sized-by-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/sized-by-lifetimebound.swift
@@ -222,7 +222,7 @@ module Test {
 
 //--- test.swift
 // GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature SafeInteropWrappersNullAsEmptySpan -Xcc -Wno-nullability-completeness > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
-// GENERATED-HASH: 8ed2812c1671e1913d51407099db2a357e9510a43ed7fb87b804a24ba5d6a633
+// GENERATED-HASH: 7b38c4a58d03b33fb8c6c027c5705b1cb0977acf8fcbced709fd92f8d864a1a3
 import Test
 
 
@@ -231,114 +231,17 @@ func call_simple(_ len: CInt, _ len2: CInt, _ p: UnsafeRawPointer!) -> UnsafeRaw
   return unsafe simple(len, len2, p)
 }
 
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ len: CInt, _ p: RawSpan) -> RawSpan {
+  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer?' to return type 'RawSpan'}}
+  return simple(len, p)
+}
+
 func call_shared(_ len: CInt, _ p: UnsafeRawPointer!) -> UnsafeRawPointer! {
   return unsafe shared(len, p)
-}
-
-func call_complexExpr(_ len: CInt, _ offset: CInt, _ len2: CInt, _ p: UnsafeRawPointer!) -> UnsafeRawPointer! {
-  return unsafe complexExpr(len, offset, len2, p)
-}
-
-func call_nullUnspecified(_ len: CInt, _ len2: CInt, _ p: UnsafeRawPointer!) -> UnsafeRawPointer! {
-  return unsafe nullUnspecified(len, len2, p)
-}
-
-func call_nonnull(_ len: CInt, _ len2: CInt, _ p: UnsafeRawPointer) -> UnsafeRawPointer {
-  return unsafe nonnull(len, len2, p)
-}
-
-func call_nullable(_ len: CInt, _ len2: CInt, _ p: UnsafeRawPointer?) -> UnsafeRawPointer? {
-  return unsafe nullable(len, len2, p)
-}
-
-func call_opaque(_ len: CInt, _ len2: CInt, _ p: OpaquePointer!) -> OpaquePointer! {
-  return unsafe opaque(len, len2, p)
-}
-
-func call_nonsizedLifetime(_ len: CInt, _ p: UnsafeRawPointer!) -> UnsafeRawPointer! {
-  return unsafe nonsizedLifetime(len, p)
-}
-
-func call_bytesized(_ size: CInt, _ p: UnsafePointer<UInt8>!) -> UnsafeMutablePointer<UInt8>! {
-  return unsafe bytesized(size, p)
-}
-
-func call_charsized(_ p: UnsafeMutablePointer<CChar>!, _ size: CInt) -> UnsafeMutablePointer<CChar>! {
-  return unsafe charsized(p, size)
-}
-
-func call_doublebytesized(_ p: UnsafeMutablePointer<UInt16>!, _ size: CInt) -> UnsafePointer<UInt16>! {
-  return unsafe doublebytesized(p, size)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_bytesized(_ p: RawSpan) -> MutableRawSpan {
-  // expected-stable-error@+3{{missing argument for parameter #2 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<UInt8>?' to return type 'MutableRawSpan'}}
-  return bytesized(p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_charsized(_ p: inout MutableRawSpan) -> MutableRawSpan {
-  // expected-stable-error@+2{{missing argument for parameter #2 in call}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CChar>?' (aka 'Optional<UnsafeMutablePointer<Int8>>') to return type 'MutableRawSpan'}}
-  return charsized(&p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: RawSpan) -> RawSpan {
-  // expected-stable-error@+3{{missing argument for parameter #4 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer?' to return type 'RawSpan'}}
-  return complexExpr(len, offset, p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ len: CInt, _ p: RawSpan) -> RawSpan {
-  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer' to return type 'RawSpan'}}
-  return nonnull(len, p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(borrow p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonsizedLifetime(_ len: CInt, _ p: UnsafeRawPointer!) -> RawSpan {
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer?' to return type 'RawSpan'}}
-  return unsafe nonsizedLifetime(len, p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ len: CInt, _ p: RawSpan) -> RawSpan {
-  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer?' to return type 'RawSpan'}}
-  return nullUnspecified(len, p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ len: CInt, _ p: RawSpan) -> RawSpan {
-  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer?' to return type 'RawSpan'}}
-  return nullable(len, p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_opaque(_ len: CInt, _ p: RawSpan) -> RawSpan {
-  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'OpaquePointer?' to return type 'RawSpan'}}
-  return opaque(len, p)
 }
 
 @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
@@ -350,11 +253,108 @@ func call_doublebytesized(_ p: UnsafeMutablePointer<UInt16>!, _ size: CInt) -> U
   return shared(p)
 }
 
+func call_complexExpr(_ len: CInt, _ offset: CInt, _ len2: CInt, _ p: UnsafeRawPointer!) -> UnsafeRawPointer! {
+  return unsafe complexExpr(len, offset, len2, p)
+}
+
 @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 @_lifetime(copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ len: CInt, _ p: RawSpan) -> RawSpan {
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: RawSpan) -> RawSpan {
+  // expected-stable-error@+3{{missing argument for parameter #4 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer?' to return type 'RawSpan'}}
+  return complexExpr(len, offset, p)
+}
+
+func call_nullUnspecified(_ len: CInt, _ len2: CInt, _ p: UnsafeRawPointer!) -> UnsafeRawPointer! {
+  return unsafe nullUnspecified(len, len2, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ len: CInt, _ p: RawSpan) -> RawSpan {
   // expected-stable-error@+3{{missing argument for parameter #3 in call}}
   // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
   // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer?' to return type 'RawSpan'}}
-  return simple(len, p)
+  return nullUnspecified(len, p)
+}
+
+func call_nonnull(_ len: CInt, _ len2: CInt, _ p: UnsafeRawPointer) -> UnsafeRawPointer {
+  return unsafe nonnull(len, len2, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ len: CInt, _ p: RawSpan) -> RawSpan {
+  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer' to return type 'RawSpan'}}
+  return nonnull(len, p)
+}
+
+func call_nullable(_ len: CInt, _ len2: CInt, _ p: UnsafeRawPointer?) -> UnsafeRawPointer? {
+  return unsafe nullable(len, len2, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ len: CInt, _ p: RawSpan) -> RawSpan {
+  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer?' to return type 'RawSpan'}}
+  return nullable(len, p)
+}
+
+func call_opaque(_ len: CInt, _ len2: CInt, _ p: OpaquePointer!) -> OpaquePointer! {
+  return unsafe opaque(len, len2, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_opaque(_ len: CInt, _ p: RawSpan) -> RawSpan {
+  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'OpaquePointer?' to return type 'RawSpan'}}
+  return opaque(len, p)
+}
+
+func call_nonsizedLifetime(_ len: CInt, _ p: UnsafeRawPointer!) -> UnsafeRawPointer! {
+  return unsafe nonsizedLifetime(len, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(borrow p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonsizedLifetime(_ len: CInt, _ p: UnsafeRawPointer!) -> RawSpan {
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer?' to return type 'RawSpan'}}
+  return unsafe nonsizedLifetime(len, p)
+}
+
+func call_bytesized(_ size: CInt, _ p: UnsafePointer<UInt8>!) -> UnsafeMutablePointer<UInt8>! {
+  return unsafe bytesized(size, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_bytesized(_ p: RawSpan) -> MutableRawSpan {
+  // expected-stable-error@+3{{missing argument for parameter #2 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<UInt8>?' to return type 'MutableRawSpan'}}
+  return bytesized(p)
+}
+
+func call_charsized(_ p: UnsafeMutablePointer<CChar>!, _ size: CInt) -> UnsafeMutablePointer<CChar>! {
+  return unsafe charsized(p, size)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_charsized(_ p: inout MutableRawSpan) -> MutableRawSpan {
+  // expected-stable-error@+2{{missing argument for parameter #2 in call}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CChar>?' (aka 'Optional<UnsafeMutablePointer<Int8>>') to return type 'MutableRawSpan'}}
+  return charsized(&p)
+}
+
+func call_doublebytesized(_ p: UnsafeMutablePointer<UInt16>!, _ size: CInt) -> UnsafePointer<UInt16>! {
+  return unsafe doublebytesized(p, size)
 }

--- a/test/Interop/C/swiftify-import/sized-by-noescape-legacy.swift
+++ b/test/Interop/C/swiftify-import/sized-by-noescape-legacy.swift
@@ -203,7 +203,7 @@ module Test {
 
 //--- test.swift
 // GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -enable-experimental-feature SafeInteropWrappers -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature Lifetimes -Xcc -Wno-ignored-attributes -Xcc -Wno-nullability-completeness > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
-// GENERATED-HASH: 3ba35c9db4b9ff7fec5e8c6f6d49aebed3d37c8bfc91d87fa24aa09f09bcc985
+// GENERATED-HASH: a1acf7012c54d7d061449c90c3af84e202af02d69b5454d5a859464274f1dc4a
 import Test
 
 
@@ -212,31 +212,70 @@ func call_simple(_ len: CInt, _ p: UnsafeRawPointer!) {
   return unsafe simple(len, p)
 }
 
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ p: RawSpan) {
+  return simple(p)
+}
+
 func call_swiftAttr(_ len: CInt, _ p: UnsafeRawPointer!) {
   return unsafe swiftAttr(len, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_swiftAttr(_ p: RawSpan) {
+  return swiftAttr(p)
 }
 
 func call_shared(_ len: CInt, _ p1: UnsafeRawPointer!, _ p2: UnsafeRawPointer!) {
   return unsafe shared(len, p1, p2)
 }
 
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_shared(_ p1: RawSpan, _ p2: RawSpan) {
+  return shared(p1, p2)
+}
+
 func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: UnsafeRawPointer!) {
   return unsafe complexExpr(len, offset, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: RawSpan) {
+  return complexExpr(len, offset, p)
 }
 
 func call_nullUnspecified(_ len: CInt, _ p: UnsafeRawPointer!) {
   return unsafe nullUnspecified(len, p)
 }
 
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ p: RawSpan) {
+  return nullUnspecified(p)
+}
+
 func call_nonnull(_ len: CInt, _ p: UnsafeRawPointer) {
   return unsafe nonnull(len, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ p: RawSpan) {
+  return nonnull(p)
 }
 
 func call_nullable(_ len: CInt, _ p: UnsafeRawPointer?) {
   return unsafe nullable(len, p)
 }
 
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ p: RawSpan?) {
+  return nullable(p)
+}
+
 func call_returnPointer(_ len: CInt) -> UnsafeRawPointer {
+  return unsafe returnPointer(len)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_returnPointer(_ len: CInt) -> UnsafeRawBufferPointer {
   return unsafe returnPointer(len)
 }
 
@@ -244,21 +283,22 @@ func call_opaque(_ len: CInt, _ p: OpaquePointer!) {
   return unsafe opaque(len, p)
 }
 
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_opaque(_ p: RawSpan) {
+  return opaque(p)
+}
+
 func call_bytesized(_ size: CInt, _ _bytesized_param1: UnsafePointer<UInt8>!) {
   return unsafe bytesized(size,  _bytesized_param1)
-}
-
-func call_charsized(_ _charsized_param0: UnsafeMutablePointer<CChar>!, _ size: CInt) {
-  return unsafe charsized( _charsized_param0, size)
-}
-
-func call_doublebytesized(_ _doublebytesized_param0: UnsafeMutablePointer<UInt16>!, _ size: CInt) {
-  return unsafe doublebytesized( _doublebytesized_param0, size)
 }
 
 @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_bytesized(_ _bytesized_param1: RawSpan) {
   return bytesized(_bytesized_param1)
+}
+
+func call_charsized(_ _charsized_param0: UnsafeMutablePointer<CChar>!, _ size: CInt) {
+  return unsafe charsized( _charsized_param0, size)
 }
 
 @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
@@ -267,46 +307,6 @@ func call_doublebytesized(_ _doublebytesized_param0: UnsafeMutablePointer<UInt16
   return charsized(&_charsized_param0)
 }
 
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: RawSpan) {
-  return complexExpr(len, offset, p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ p: RawSpan) {
-  return nonnull(p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ p: RawSpan) {
-  return nullUnspecified(p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ p: RawSpan?) {
-  return nullable(p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_opaque(_ p: RawSpan) {
-  return opaque(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_returnPointer(_ len: CInt) -> UnsafeRawBufferPointer {
-  return unsafe returnPointer(len)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_shared(_ p1: RawSpan, _ p2: RawSpan) {
-  return shared(p1, p2)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ p: RawSpan) {
-  return simple(p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_swiftAttr(_ p: RawSpan) {
-  return swiftAttr(p)
+func call_doublebytesized(_ _doublebytesized_param0: UnsafeMutablePointer<UInt16>!, _ size: CInt) {
+  return unsafe doublebytesized( _doublebytesized_param0, size)
 }

--- a/test/Interop/C/swiftify-import/sized-by-noescape.swift
+++ b/test/Interop/C/swiftify-import/sized-by-noescape.swift
@@ -199,7 +199,7 @@ module Test {
 
 //--- test.swift
 // GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature Lifetimes -Xcc -Wno-ignored-attributes -Xcc -Wno-nullability-completeness > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
-// GENERATED-HASH: c34bcce829d0e1bd05210ae20cf42cf7d073c0bbfbc6e785111e4dc9360e6890
+// GENERATED-HASH: bde375302165d04691bbb612b91e2433944e192cba3443f545c010e74c894ab2
 import Test
 
 
@@ -208,31 +208,70 @@ func call_simple(_ len: CInt, _ p: UnsafeRawPointer!) {
   return unsafe simple(len, p)
 }
 
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ p: RawSpan) {
+  return simple(p)
+}
+
 func call_swiftAttr(_ len: CInt, _ p: UnsafeRawPointer!) {
   return unsafe swiftAttr(len, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_swiftAttr(_ p: RawSpan) {
+  return swiftAttr(p)
 }
 
 func call_shared(_ len: CInt, _ p1: UnsafeRawPointer!, _ p2: UnsafeRawPointer!) {
   return unsafe shared(len, p1, p2)
 }
 
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_shared(_ p1: RawSpan, _ p2: RawSpan) {
+  return shared(p1, p2)
+}
+
 func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: UnsafeRawPointer!) {
   return unsafe complexExpr(len, offset, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: RawSpan) {
+  return complexExpr(len, offset, p)
 }
 
 func call_nullUnspecified(_ len: CInt, _ p: UnsafeRawPointer!) {
   return unsafe nullUnspecified(len, p)
 }
 
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ p: RawSpan) {
+  return nullUnspecified(p)
+}
+
 func call_nonnull(_ len: CInt, _ p: UnsafeRawPointer) {
   return unsafe nonnull(len, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ p: RawSpan) {
+  return nonnull(p)
 }
 
 func call_nullable(_ len: CInt, _ p: UnsafeRawPointer?) {
   return unsafe nullable(len, p)
 }
 
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ p: RawSpan) {
+  return nullable(p)
+}
+
 func call_returnPointer(_ len: CInt) -> UnsafeRawPointer {
+  return unsafe returnPointer(len)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_returnPointer(_ len: CInt) -> UnsafeRawBufferPointer {
   return unsafe returnPointer(len)
 }
 
@@ -240,21 +279,22 @@ func call_opaque(_ len: CInt, _ p: OpaquePointer!) {
   return unsafe opaque(len, p)
 }
 
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_opaque(_ p: RawSpan) {
+  return opaque(p)
+}
+
 func call_bytesized(_ size: CInt, _ _bytesized_param1: UnsafePointer<UInt8>!) {
   return unsafe bytesized(size,  _bytesized_param1)
-}
-
-func call_charsized(_ _charsized_param0: UnsafeMutablePointer<CChar>!, _ size: CInt) {
-  return unsafe charsized( _charsized_param0, size)
-}
-
-func call_doublebytesized(_ _doublebytesized_param0: UnsafeMutablePointer<UInt16>!, _ size: CInt) {
-  return unsafe doublebytesized( _doublebytesized_param0, size)
 }
 
 @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_bytesized(_ _bytesized_param1: RawSpan) {
   return bytesized(_bytesized_param1)
+}
+
+func call_charsized(_ _charsized_param0: UnsafeMutablePointer<CChar>!, _ size: CInt) {
+  return unsafe charsized( _charsized_param0, size)
 }
 
 @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
@@ -263,46 +303,6 @@ func call_doublebytesized(_ _doublebytesized_param0: UnsafeMutablePointer<UInt16
   return charsized(&_charsized_param0)
 }
 
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: RawSpan) {
-  return complexExpr(len, offset, p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ p: RawSpan) {
-  return nonnull(p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ p: RawSpan) {
-  return nullUnspecified(p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ p: RawSpan) {
-  return nullable(p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_opaque(_ p: RawSpan) {
-  return opaque(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_returnPointer(_ len: CInt) -> UnsafeRawBufferPointer {
-  return unsafe returnPointer(len)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_shared(_ p1: RawSpan, _ p2: RawSpan) {
-  return shared(p1, p2)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ p: RawSpan) {
-  return simple(p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_swiftAttr(_ p: RawSpan) {
-  return swiftAttr(p)
+func call_doublebytesized(_ _doublebytesized_param0: UnsafeMutablePointer<UInt16>!, _ size: CInt) {
+  return unsafe doublebytesized( _doublebytesized_param0, size)
 }

--- a/test/Interop/C/swiftify-import/sized-by-or-null-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/sized-by-or-null-lifetimebound.swift
@@ -221,7 +221,7 @@ module Test {
 
 //--- test.swift
 // GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers -Xcc -Wno-nullability-completeness > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
-// GENERATED-HASH: 3ed369e458a494f8ed6a65c32a5a1b77f5d58e8ee26e1b29016ac8adff771740
+// GENERATED-HASH: bc828f607531ee66a74238439370c9f68f62fac068c6e4294af725c6056d2cab
 import Test
 
 
@@ -230,114 +230,17 @@ func call_simple(_ len: CInt, _ len2: CInt, _ p: UnsafeRawPointer!) -> UnsafeRaw
   return unsafe simple(len, len2, p)
 }
 
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ len: CInt, _ p: RawSpan) -> RawSpan {
+  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer?' to return type 'RawSpan'}}
+  return simple(len, p)
+}
+
 func call_shared(_ len: CInt, _ p: UnsafeRawPointer!) -> UnsafeRawPointer! {
   return unsafe shared(len, p)
-}
-
-func call_complexExpr(_ len: CInt, _ offset: CInt, _ len2: CInt, _ p: UnsafeRawPointer!) -> UnsafeRawPointer! {
-  return unsafe complexExpr(len, offset, len2, p)
-}
-
-func call_nullUnspecified(_ len: CInt, _ len2: CInt, _ p: UnsafeRawPointer!) -> UnsafeRawPointer! {
-  return unsafe nullUnspecified(len, len2, p)
-}
-
-func call_nonnull(_ len: CInt, _ len2: CInt, _ p: UnsafeRawPointer) -> UnsafeRawPointer {
-  return unsafe nonnull(len, len2, p)
-}
-
-func call_nullable(_ len: CInt, _ len2: CInt, _ p: UnsafeRawPointer?) -> UnsafeRawPointer? {
-  return unsafe nullable(len, len2, p)
-}
-
-func call_opaque(_ len: CInt, _ len2: CInt, _ p: OpaquePointer!) -> OpaquePointer! {
-  return unsafe opaque(len, len2, p)
-}
-
-func call_nonsizedLifetime(_ len: CInt, _ p: UnsafeRawPointer!) -> UnsafeRawPointer! {
-  return unsafe nonsizedLifetime(len, p)
-}
-
-func call_bytesized(_ size: CInt, _ p: UnsafePointer<UInt8>!) -> UnsafeMutablePointer<UInt8>! {
-  return unsafe bytesized(size, p)
-}
-
-func call_charsized(_ p: UnsafeMutablePointer<CChar>!, _ size: CInt) -> UnsafeMutablePointer<CChar>! {
-  return unsafe charsized(p, size)
-}
-
-func call_doublebytesized(_ p: UnsafeMutablePointer<UInt16>!, _ size: CInt) -> UnsafePointer<UInt16>! {
-  return unsafe doublebytesized(p, size)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_bytesized(_ p: RawSpan) -> MutableRawSpan {
-  // expected-stable-error@+3{{missing argument for parameter #2 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<UInt8>?' to return type 'MutableRawSpan'}}
-  return bytesized(p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_lifetime(p: copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_charsized(_ p: inout MutableRawSpan) -> MutableRawSpan {
-  // expected-stable-error@+2{{missing argument for parameter #2 in call}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CChar>?' (aka 'Optional<UnsafeMutablePointer<Int8>>') to return type 'MutableRawSpan'}}
-  return charsized(&p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: RawSpan) -> RawSpan {
-  // expected-stable-error@+3{{missing argument for parameter #4 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer?' to return type 'RawSpan'}}
-  return complexExpr(len, offset, p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ len: CInt, _ p: RawSpan) -> RawSpan {
-  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer' to return type 'RawSpan'}}
-  return nonnull(len, p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(borrow p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonsizedLifetime(_ len: CInt, _ p: UnsafeRawPointer!) -> RawSpan {
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer?' to return type 'RawSpan'}}
-  return unsafe nonsizedLifetime(len, p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ len: CInt, _ p: RawSpan) -> RawSpan {
-  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer?' to return type 'RawSpan'}}
-  return nullUnspecified(len, p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ len: CInt, _ p: RawSpan?) -> RawSpan? {
-  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'RawSpan?' to expected argument type 'CInt' (aka 'Int32')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer?' to return type 'RawSpan?'}}
-  return nullable(len, p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_opaque(_ len: CInt, _ p: RawSpan) -> RawSpan {
-  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
-  // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'OpaquePointer?' to return type 'RawSpan'}}
-  return opaque(len, p)
 }
 
 @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
@@ -349,11 +252,108 @@ func call_doublebytesized(_ p: UnsafeMutablePointer<UInt16>!, _ size: CInt) -> U
   return shared(p)
 }
 
+func call_complexExpr(_ len: CInt, _ offset: CInt, _ len2: CInt, _ p: UnsafeRawPointer!) -> UnsafeRawPointer! {
+  return unsafe complexExpr(len, offset, len2, p)
+}
+
 @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 @_lifetime(copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ len: CInt, _ p: RawSpan) -> RawSpan {
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: RawSpan) -> RawSpan {
+  // expected-stable-error@+3{{missing argument for parameter #4 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer?' to return type 'RawSpan'}}
+  return complexExpr(len, offset, p)
+}
+
+func call_nullUnspecified(_ len: CInt, _ len2: CInt, _ p: UnsafeRawPointer!) -> UnsafeRawPointer! {
+  return unsafe nullUnspecified(len, len2, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ len: CInt, _ p: RawSpan) -> RawSpan {
   // expected-stable-error@+3{{missing argument for parameter #3 in call}}
   // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
   // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer?' to return type 'RawSpan'}}
-  return simple(len, p)
+  return nullUnspecified(len, p)
+}
+
+func call_nonnull(_ len: CInt, _ len2: CInt, _ p: UnsafeRawPointer) -> UnsafeRawPointer {
+  return unsafe nonnull(len, len2, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ len: CInt, _ p: RawSpan) -> RawSpan {
+  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer' to return type 'RawSpan'}}
+  return nonnull(len, p)
+}
+
+func call_nullable(_ len: CInt, _ len2: CInt, _ p: UnsafeRawPointer?) -> UnsafeRawPointer? {
+  return unsafe nullable(len, len2, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ len: CInt, _ p: RawSpan?) -> RawSpan? {
+  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'RawSpan?' to expected argument type 'CInt' (aka 'Int32')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer?' to return type 'RawSpan?'}}
+  return nullable(len, p)
+}
+
+func call_opaque(_ len: CInt, _ len2: CInt, _ p: OpaquePointer!) -> OpaquePointer! {
+  return unsafe opaque(len, len2, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_opaque(_ len: CInt, _ p: RawSpan) -> RawSpan {
+  // expected-stable-error@+3{{missing argument for parameter #3 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'OpaquePointer?' to return type 'RawSpan'}}
+  return opaque(len, p)
+}
+
+func call_nonsizedLifetime(_ len: CInt, _ p: UnsafeRawPointer!) -> UnsafeRawPointer! {
+  return unsafe nonsizedLifetime(len, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(borrow p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonsizedLifetime(_ len: CInt, _ p: UnsafeRawPointer!) -> RawSpan {
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer?' to return type 'RawSpan'}}
+  return unsafe nonsizedLifetime(len, p)
+}
+
+func call_bytesized(_ size: CInt, _ p: UnsafePointer<UInt8>!) -> UnsafeMutablePointer<UInt8>! {
+  return unsafe bytesized(size, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_bytesized(_ p: RawSpan) -> MutableRawSpan {
+  // expected-stable-error@+3{{missing argument for parameter #2 in call}}
+  // expected-stable-error@+2{{cannot convert value of type 'RawSpan' to expected argument type 'CInt' (aka 'Int32')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<UInt8>?' to return type 'MutableRawSpan'}}
+  return bytesized(p)
+}
+
+func call_charsized(_ p: UnsafeMutablePointer<CChar>!, _ size: CInt) -> UnsafeMutablePointer<CChar>! {
+  return unsafe charsized(p, size)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_charsized(_ p: inout MutableRawSpan) -> MutableRawSpan {
+  // expected-stable-error@+2{{missing argument for parameter #2 in call}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CChar>?' (aka 'Optional<UnsafeMutablePointer<Int8>>') to return type 'MutableRawSpan'}}
+  return charsized(&p)
+}
+
+func call_doublebytesized(_ p: UnsafeMutablePointer<UInt16>!, _ size: CInt) -> UnsafePointer<UInt16>! {
+  return unsafe doublebytesized(p, size)
 }

--- a/test/Interop/C/swiftify-import/sized-by-or-null-noescape.swift
+++ b/test/Interop/C/swiftify-import/sized-by-or-null-noescape.swift
@@ -199,7 +199,7 @@ module Test {
 
 //--- test.swift
 // GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature Lifetimes -Xcc -Wno-ignored-attributes -Xcc -Wno-nullability-completeness > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
-// GENERATED-HASH: 3ba35c9db4b9ff7fec5e8c6f6d49aebed3d37c8bfc91d87fa24aa09f09bcc985
+// GENERATED-HASH: a1acf7012c54d7d061449c90c3af84e202af02d69b5454d5a859464274f1dc4a
 import Test
 
 
@@ -208,31 +208,70 @@ func call_simple(_ len: CInt, _ p: UnsafeRawPointer!) {
   return unsafe simple(len, p)
 }
 
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ p: RawSpan) {
+  return simple(p)
+}
+
 func call_swiftAttr(_ len: CInt, _ p: UnsafeRawPointer!) {
   return unsafe swiftAttr(len, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_swiftAttr(_ p: RawSpan) {
+  return swiftAttr(p)
 }
 
 func call_shared(_ len: CInt, _ p1: UnsafeRawPointer!, _ p2: UnsafeRawPointer!) {
   return unsafe shared(len, p1, p2)
 }
 
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_shared(_ p1: RawSpan, _ p2: RawSpan) {
+  return shared(p1, p2)
+}
+
 func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: UnsafeRawPointer!) {
   return unsafe complexExpr(len, offset, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: RawSpan) {
+  return complexExpr(len, offset, p)
 }
 
 func call_nullUnspecified(_ len: CInt, _ p: UnsafeRawPointer!) {
   return unsafe nullUnspecified(len, p)
 }
 
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ p: RawSpan) {
+  return nullUnspecified(p)
+}
+
 func call_nonnull(_ len: CInt, _ p: UnsafeRawPointer) {
   return unsafe nonnull(len, p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ p: RawSpan) {
+  return nonnull(p)
 }
 
 func call_nullable(_ len: CInt, _ p: UnsafeRawPointer?) {
   return unsafe nullable(len, p)
 }
 
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ p: RawSpan?) {
+  return nullable(p)
+}
+
 func call_returnPointer(_ len: CInt) -> UnsafeRawPointer {
+  return unsafe returnPointer(len)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_returnPointer(_ len: CInt) -> UnsafeRawBufferPointer {
   return unsafe returnPointer(len)
 }
 
@@ -240,21 +279,22 @@ func call_opaque(_ len: CInt, _ p: OpaquePointer!) {
   return unsafe opaque(len, p)
 }
 
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_opaque(_ p: RawSpan) {
+  return opaque(p)
+}
+
 func call_bytesized(_ size: CInt, _ _bytesized_param1: UnsafePointer<UInt8>!) {
   return unsafe bytesized(size,  _bytesized_param1)
-}
-
-func call_charsized(_ _charsized_param0: UnsafeMutablePointer<CChar>!, _ size: CInt) {
-  return unsafe charsized( _charsized_param0, size)
-}
-
-func call_doublebytesized(_ _doublebytesized_param0: UnsafeMutablePointer<UInt16>!, _ size: CInt) {
-  return unsafe doublebytesized( _doublebytesized_param0, size)
 }
 
 @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_bytesized(_ _bytesized_param1: RawSpan) {
   return bytesized(_bytesized_param1)
+}
+
+func call_charsized(_ _charsized_param0: UnsafeMutablePointer<CChar>!, _ size: CInt) {
+  return unsafe charsized( _charsized_param0, size)
 }
 
 @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
@@ -263,46 +303,6 @@ func call_doublebytesized(_ _doublebytesized_param0: UnsafeMutablePointer<UInt16
   return charsized(&_charsized_param0)
 }
 
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: RawSpan) {
-  return complexExpr(len, offset, p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ p: RawSpan) {
-  return nonnull(p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ p: RawSpan) {
-  return nullUnspecified(p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ p: RawSpan?) {
-  return nullable(p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_opaque(_ p: RawSpan) {
-  return opaque(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_returnPointer(_ len: CInt) -> UnsafeRawBufferPointer {
-  return unsafe returnPointer(len)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_shared(_ p1: RawSpan, _ p2: RawSpan) {
-  return shared(p1, p2)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ p: RawSpan) {
-  return simple(p)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_swiftAttr(_ p: RawSpan) {
-  return swiftAttr(p)
+func call_doublebytesized(_ _doublebytesized_param0: UnsafeMutablePointer<UInt16>!, _ size: CInt) {
+  return unsafe doublebytesized( _doublebytesized_param0, size)
 }

--- a/test/Interop/C/swiftify-import/sized-by-or-null.swift
+++ b/test/Interop/C/swiftify-import/sized-by-or-null.swift
@@ -149,7 +149,7 @@ module Test {
 
 //--- test.swift
 // GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -plugin-path %swift-plugin-dir -I %t -source-filename=x -Xcc -Wno-nullability-completeness > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
-// GENERATED-HASH: f3a4ba5bf982f52e53454729d13d39b82e277f1a7cae401414cbf4ecf23ed0c3
+// GENERATED-HASH: 5701badde853d541916b7f9c9b7afc59f3b89e704784fd303cb1ba16b8646b2a
 import Test
 
 
@@ -158,15 +158,31 @@ func call_simple(_ len: CInt, _ p: UnsafeMutableRawPointer!) {
   return unsafe simple(len, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ p: UnsafeMutableRawBufferPointer) {
+  return unsafe simple(p)
+}
+
 func call_swiftAttr(_ len: CInt, _ p: UnsafeMutableRawPointer!) {
   return unsafe swiftAttr(len, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_swiftAttr(_ p: UnsafeMutableRawBufferPointer) {
+  return unsafe swiftAttr(p)
 }
 
 func call_shared(_ len: CInt, _ p1: UnsafeMutableRawPointer!, _ p2: UnsafeMutableRawPointer!) {
   return unsafe shared(len, p1, p2)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_shared(_ p1: UnsafeMutableRawBufferPointer, _ p2: UnsafeMutableRawBufferPointer) {
+  return unsafe shared(p1, p2)
+}
+
 func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: UnsafeMutableRawPointer!) {
+  return unsafe complexExpr(len, offset, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: UnsafeMutableRawBufferPointer) {
   return unsafe complexExpr(len, offset, p)
 }
 
@@ -174,15 +190,31 @@ func call_nullUnspecified(_ len: CInt, _ p: UnsafeMutableRawPointer!) {
   return unsafe nullUnspecified(len, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ p: UnsafeMutableRawBufferPointer) {
+  return unsafe nullUnspecified(p)
+}
+
 func call_nonnull(_ len: CInt, _ p: UnsafeMutableRawPointer) {
   return unsafe nonnull(len, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ p: UnsafeMutableRawBufferPointer) {
+  return unsafe nonnull(p)
 }
 
 func call_nullable(_ len: CInt, _ p: UnsafeMutableRawPointer?) {
   return unsafe nullable(len, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ p: UnsafeMutableRawBufferPointer?) {
+  return unsafe nullable(p)
+}
+
 func call_returnPointer(_ len: CInt) -> UnsafeMutableRawPointer! {
+  return unsafe returnPointer(len)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_returnPointer(_ len: CInt) -> UnsafeMutableRawBufferPointer {
   return unsafe returnPointer(len)
 }
 
@@ -190,15 +222,31 @@ func call_opaque(_ len: CInt, _ p: OpaquePointer!) {
   return unsafe opaque(len, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_opaque(_ p: UnsafeRawBufferPointer) {
+  return unsafe opaque(p)
+}
+
 func call_opaqueptr(_ len: CInt, _ p: OpaquePointer!) {
   return unsafe opaqueptr(len, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_opaqueptr(_ p: UnsafeRawBufferPointer) {
+  return unsafe opaqueptr(p)
 }
 
 func call_charsized(_ _charsized_param0: UnsafeMutablePointer<CChar>!, _ size: CInt) {
   return unsafe charsized( _charsized_param0, size)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_charsized(_ _charsized_param0: UnsafeMutableRawBufferPointer) {
+  return unsafe charsized(_charsized_param0)
+}
+
 func call_bytesized(_ size: CInt) -> UnsafeMutablePointer<UInt8>! {
+  return unsafe bytesized(size)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_bytesized(_ size: CInt) -> UnsafeMutableRawBufferPointer {
   return unsafe bytesized(size)
 }
 
@@ -212,52 +260,4 @@ func call_aliasedBytesized(_ p: UnsafeMutablePointer<UInt8>!, _ size: CInt) {
 
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_aliasedBytesized(_ p: UnsafeMutableRawBufferPointer) {
   return unsafe aliasedBytesized(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_bytesized(_ size: CInt) -> UnsafeMutableRawBufferPointer {
-  return unsafe bytesized(size)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_charsized(_ _charsized_param0: UnsafeMutableRawBufferPointer) {
-  return unsafe charsized(_charsized_param0)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: UnsafeMutableRawBufferPointer) {
-  return unsafe complexExpr(len, offset, p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ p: UnsafeMutableRawBufferPointer) {
-  return unsafe nonnull(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ p: UnsafeMutableRawBufferPointer) {
-  return unsafe nullUnspecified(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ p: UnsafeMutableRawBufferPointer?) {
-  return unsafe nullable(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_opaque(_ p: UnsafeRawBufferPointer) {
-  return unsafe opaque(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_opaqueptr(_ p: UnsafeRawBufferPointer) {
-  return unsafe opaqueptr(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_returnPointer(_ len: CInt) -> UnsafeMutableRawBufferPointer {
-  return unsafe returnPointer(len)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_shared(_ p1: UnsafeMutableRawBufferPointer, _ p2: UnsafeMutableRawBufferPointer) {
-  return unsafe shared(p1, p2)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ p: UnsafeMutableRawBufferPointer) {
-  return unsafe simple(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_swiftAttr(_ p: UnsafeMutableRawBufferPointer) {
-  return unsafe swiftAttr(p)
 }

--- a/test/Interop/C/swiftify-import/sized-by.swift
+++ b/test/Interop/C/swiftify-import/sized-by.swift
@@ -168,7 +168,7 @@ module Test {
 
 //--- test.swift
 // GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -plugin-path %swift-plugin-dir -I %t -source-filename=x -Xcc -Wno-nullability-completeness > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
-// GENERATED-HASH: 4c7858f3a0bd8638c97e736244b26b6e0baaaa0a253dd5254e738ef536b873cb
+// GENERATED-HASH: 8e08b20c1fe0ad59d459839004aa632a25a1121757a363d963b133390e1584e8
 import Test
 
 
@@ -177,15 +177,31 @@ func call_simple(_ len: CInt, _ p: UnsafeMutableRawPointer!) {
   return unsafe simple(len, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ p: UnsafeMutableRawBufferPointer) {
+  return unsafe simple(p)
+}
+
 func call_swiftAttr(_ len: CInt, _ p: UnsafeMutableRawPointer!) {
   return unsafe swiftAttr(len, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_swiftAttr(_ p: UnsafeMutableRawBufferPointer) {
+  return unsafe swiftAttr(p)
 }
 
 func call_shared(_ len: CInt, _ p1: UnsafeMutableRawPointer!, _ p2: UnsafeMutableRawPointer!) {
   return unsafe shared(len, p1, p2)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_shared(_ p1: UnsafeMutableRawBufferPointer, _ p2: UnsafeMutableRawBufferPointer) {
+  return unsafe shared(p1, p2)
+}
+
 func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: UnsafeMutableRawPointer!) {
+  return unsafe complexExpr(len, offset, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: UnsafeMutableRawBufferPointer) {
   return unsafe complexExpr(len, offset, p)
 }
 
@@ -193,23 +209,47 @@ func call_nullUnspecified(_ len: CInt, _ p: UnsafeMutableRawPointer!) {
   return unsafe nullUnspecified(len, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ p: UnsafeMutableRawBufferPointer) {
+  return unsafe nullUnspecified(p)
+}
+
 func call_nonnull(_ len: CInt, _ p: UnsafeMutableRawPointer) {
   return unsafe nonnull(len, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ p: UnsafeMutableRawBufferPointer) {
+  return unsafe nonnull(p)
 }
 
 func call_nonnullTyped(_ len: CInt, _ p: UnsafeMutablePointer<CChar>) {
   return unsafe nonnullTyped(len, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnullTyped(_ p: UnsafeMutableRawBufferPointer) {
+  return unsafe nonnullTyped(p)
+}
+
 func call_nullable(_ len: CInt, _ p: UnsafeMutableRawPointer?) {
   return unsafe nullable(len, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ p: UnsafeMutableRawBufferPointer) {
+  return unsafe nullable(p)
 }
 
 func call_nullableTyped(_ len: CInt, _ p: UnsafeMutablePointer<CChar>?) {
   return unsafe nullableTyped(len, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullableTyped(_ p: UnsafeMutableRawBufferPointer) {
+  return unsafe nullableTyped(p)
+}
+
 func call_returnPointer(_ len: CInt) -> UnsafeMutableRawPointer! {
+  return unsafe returnPointer(len)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_returnPointer(_ len: CInt) -> UnsafeMutableRawBufferPointer {
   return unsafe returnPointer(len)
 }
 
@@ -217,15 +257,31 @@ func call_opaque(_ len: CInt, _ p: OpaquePointer!) {
   return unsafe opaque(len, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_opaque(_ p: UnsafeRawBufferPointer) {
+  return unsafe opaque(p)
+}
+
 func call_opaqueptr(_ len: CInt, _ p: OpaquePointer!) {
   return unsafe opaqueptr(len, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_opaqueptr(_ p: UnsafeRawBufferPointer) {
+  return unsafe opaqueptr(p)
 }
 
 func call_charsized(_ _charsized_param0: UnsafeMutablePointer<CChar>!, _ size: CInt) {
   return unsafe charsized( _charsized_param0, size)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_charsized(_ _charsized_param0: UnsafeMutableRawBufferPointer) {
+  return unsafe charsized(_charsized_param0)
+}
+
 func call_bytesized(_ size: CInt) -> UnsafeMutablePointer<UInt8>! {
+  return unsafe bytesized(size)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_bytesized(_ size: CInt) -> UnsafeMutableRawBufferPointer {
   return unsafe bytesized(size)
 }
 
@@ -239,60 +295,4 @@ func call_aliasedBytesized(_ p: UnsafeMutablePointer<UInt8>!, _ size: CInt) {
 
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_aliasedBytesized(_ p: UnsafeMutableRawBufferPointer) {
   return unsafe aliasedBytesized(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_bytesized(_ size: CInt) -> UnsafeMutableRawBufferPointer {
-  return unsafe bytesized(size)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_charsized(_ _charsized_param0: UnsafeMutableRawBufferPointer) {
-  return unsafe charsized(_charsized_param0)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: CInt, _ offset: CInt, _ p: UnsafeMutableRawBufferPointer) {
-  return unsafe complexExpr(len, offset, p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ p: UnsafeMutableRawBufferPointer) {
-  return unsafe nonnull(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnullTyped(_ p: UnsafeMutableRawBufferPointer) {
-  return unsafe nonnullTyped(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ p: UnsafeMutableRawBufferPointer) {
-  return unsafe nullUnspecified(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ p: UnsafeMutableRawBufferPointer) {
-  return unsafe nullable(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullableTyped(_ p: UnsafeMutableRawBufferPointer) {
-  return unsafe nullableTyped(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_opaque(_ p: UnsafeRawBufferPointer) {
-  return unsafe opaque(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_opaqueptr(_ p: UnsafeRawBufferPointer) {
-  return unsafe opaqueptr(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_returnPointer(_ len: CInt) -> UnsafeMutableRawBufferPointer {
-  return unsafe returnPointer(len)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_shared(_ p1: UnsafeMutableRawBufferPointer, _ p2: UnsafeMutableRawBufferPointer) {
-  return unsafe shared(p1, p2)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ p: UnsafeMutableRawBufferPointer) {
-  return unsafe simple(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_swiftAttr(_ p: UnsafeMutableRawBufferPointer) {
-  return unsafe swiftAttr(p)
 }

--- a/test/Interop/C/swiftify-import/typedef-bounds-attr.swift
+++ b/test/Interop/C/swiftify-import/typedef-bounds-attr.swift
@@ -93,7 +93,7 @@ module Test {
 
 //--- test.swift
 // GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -plugin-path %swift-plugin-dir -I %t -source-filename=x > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
-// GENERATED-HASH: 02cc53270b917da2e2b202f5f46430c1a1a4a2ba8e283f29dcc7a96f215ea7b7
+// GENERATED-HASH: 51bb8f8be8c0ca00339f66c0019a4458aeb67b12944f910c1ed8416da859b6cd
 import Test
 
 
@@ -101,24 +101,48 @@ func call_test_fooptr(_ len: CInt, _ p: OpaquePointer!) -> OpaquePointer! {
   return unsafe test_fooptr(len, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_test_fooptr(_ p: UnsafeRawBufferPointer) -> OpaquePointer! {
+  return unsafe test_fooptr(p)
+}
+
 func call_test_fooptr2(_ len: CInt, _ p: OpaquePointer!) -> OpaquePointer! {
   return unsafe test_fooptr2(len, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_test_fooptr2(_ p: UnsafeRawBufferPointer) -> UnsafeRawBufferPointer {
+  return unsafe test_fooptr2(p)
 }
 
 func call_test_fooptr3(_ len: CInt, _ p: OpaquePointer!) -> OpaquePointer! {
   return unsafe test_fooptr3(len, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_test_fooptr3(_ p: UnsafeRawBufferPointer) -> UnsafeRawBufferPointer {
+  return unsafe test_fooptr3(p)
+}
+
 func call_test_fooptr4(_ len: CInt, _ p: OpaquePointer!) -> OpaquePointer {
   return unsafe test_fooptr4(len, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_test_fooptr4(_ p: UnsafeRawBufferPointer) -> OpaquePointer {
+  return unsafe test_fooptr4(p)
 }
 
 func call_test_fooptr5(_ len: CInt, _ p: OpaquePointer!) -> OpaquePointer {
   return unsafe test_fooptr5(len, p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_test_fooptr5(_ p: UnsafeRawBufferPointer) -> OpaquePointer {
+  return unsafe test_fooptr5(p)
+}
+
 func call_test_voidptr(_ len: CInt, _ p: UnsafeMutableRawPointer!) -> UnsafeMutableRawPointer! {
   return unsafe test_voidptr(len, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_test_voidptr(_ p: UnsafeMutableRawBufferPointer) -> UnsafeMutableRawPointer! {
+  return unsafe test_voidptr(p)
 }
 
 func call_test_charptr(_ len: CInt, _ p: UnsafeMutablePointer<CChar>!) -> UnsafeMutablePointer<CChar>! {
@@ -127,28 +151,4 @@ func call_test_charptr(_ len: CInt, _ p: UnsafeMutablePointer<CChar>!) -> Unsafe
 
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_test_charptr(_ p: UnsafeMutableRawBufferPointer) -> UnsafeMutablePointer<CChar>! {
   return unsafe test_charptr(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_test_fooptr(_ p: UnsafeRawBufferPointer) -> OpaquePointer! {
-  return unsafe test_fooptr(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_test_fooptr2(_ p: UnsafeRawBufferPointer) -> UnsafeRawBufferPointer {
-  return unsafe test_fooptr2(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_test_fooptr3(_ p: UnsafeRawBufferPointer) -> UnsafeRawBufferPointer {
-  return unsafe test_fooptr3(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_test_fooptr4(_ p: UnsafeRawBufferPointer) -> OpaquePointer {
-  return unsafe test_fooptr4(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_test_fooptr5(_ p: UnsafeRawBufferPointer) -> OpaquePointer {
-  return unsafe test_fooptr5(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_test_voidptr(_ p: UnsafeMutableRawBufferPointer) -> UnsafeMutableRawPointer! {
-  return unsafe test_voidptr(p)
 }

--- a/test/Utils/swift-function-caller-generator/compile.swift
+++ b/test/Utils/swift-function-caller-generator/compile.swift
@@ -65,6 +65,15 @@ public struct Sunavailable {
   public func munavailable(x: Int) -> Int { return x }
 }
 
+public class Base {
+  public func foo() {}
+  public func bar() {}
+}
+public class Derived: Base {
+  override public func foo() {}
+  public override func bar() {}
+}
+
 //--- out.expected
 import Test
 
@@ -125,5 +134,23 @@ public extension C {
   }
   func call_clas2(x: Swift::Int) -> Swift::Int {
     return C.clas2(x: x)
+  }
+}
+
+public extension Base {
+  func call_foo() {
+    return foo()
+  }
+  func call_bar() {
+    return bar()
+  }
+}
+
+public extension Derived {
+  func call_foo_Derived() {
+    return foo()
+  }
+  func call_bar_Derived() {
+    return bar()
   }
 }

--- a/test/Utils/swift-function-caller-generator/compile.swift
+++ b/test/Utils/swift-function-caller-generator/compile.swift
@@ -107,19 +107,23 @@ public func call_qux(_ func: inout Swift::MutableSpan<Swift::CInt>) {
 
 #endif
 #endif
-  public func call_pub(_ self: S, _ x: Swift::Int) -> Swift::Int {
-  return self.pub(x)
+public extension S {
+  func call_pub(_ x: Swift::Int) -> Swift::Int {
+    return pub(x)
+  }
 }
 
-  public func call_pub(_ self: C, _ x: Swift::Int) -> Swift::Int {
-  return self.pub(x)
-}
-func call_ope(_ self: C, _ x: Swift::Int) -> Swift::Int {
-  return self.ope(x)
-}
-public func call_clas(x: Swift::Int) -> Swift::Int {
-  return C.clas(x: x)
-}
-func call_clas2(x: Swift::Int) -> Swift::Int {
-  return C.clas2(x: x)
+public extension C {
+  func call_pub(_ x: Swift::Int) -> Swift::Int {
+    return pub(x)
+  }
+  func call_ope(_ x: Swift::Int) -> Swift::Int {
+    return ope(x)
+  }
+  func call_clas(x: Swift::Int) -> Swift::Int {
+    return C.clas(x: x)
+  }
+  func call_clas2(x: Swift::Int) -> Swift::Int {
+    return C.clas2(x: x)
+  }
 }

--- a/test/Utils/swift-function-caller-generator/compile.swift
+++ b/test/Utils/swift-function-caller-generator/compile.swift
@@ -117,40 +117,40 @@ public func call_qux(_ func: inout Swift::MutableSpan<Swift::CInt>) {
 #endif
 #endif
 public extension S {
-  func call_pub(_ x: Swift::Int) -> Swift::Int {
+  func call_pub_S(_ x: Swift::Int) -> Swift::Int {
     return pub(x)
   }
 }
 
 public extension C {
-  func call_pub(_ x: Swift::Int) -> Swift::Int {
+  final func call_pub_C(_ x: Swift::Int) -> Swift::Int {
     return pub(x)
   }
-  func call_ope(_ x: Swift::Int) -> Swift::Int {
+  final func call_ope_C(_ x: Swift::Int) -> Swift::Int {
     return ope(x)
   }
-  func call_clas(x: Swift::Int) -> Swift::Int {
+  final func call_clas_C(x: Swift::Int) -> Swift::Int {
     return C.clas(x: x)
   }
-  func call_clas2(x: Swift::Int) -> Swift::Int {
+  final func call_clas2_C(x: Swift::Int) -> Swift::Int {
     return C.clas2(x: x)
   }
 }
 
 public extension Base {
-  func call_foo() {
+  final func call_foo_Base() {
     return foo()
   }
-  func call_bar() {
+  final func call_bar_Base() {
     return bar()
   }
 }
 
 public extension Derived {
-  func call_foo_Derived() {
+  final func call_foo_Derived() {
     return foo()
   }
-  func call_bar_Derived() {
+  final func call_bar_Derived() {
     return bar()
   }
 }

--- a/test/Utils/swift-function-caller-generator/inheritance-cxx.swift
+++ b/test/Utils/swift-function-caller-generator/inheritance-cxx.swift
@@ -10,7 +10,7 @@
 
 // RUN: %target-swift-ide-test -print-module -module-to-print=Test -source-filename=x -I %t -cxx-interoperability-mode=default -enable-experimental-feature ForeignReferenceTypeInheritance > %t/Test-interface.swift
 // RUN: %swift-function-caller-generator Test %t/Test-interface.swift > %t/out.swift
-// RUN: %diff %t/out.swift %t/out.expected
+// RUN: %PathSanitizingDiff --sanitize-regex '=@available\(.*, \*\)\n' %t/out.expected < %t/out.swift
 // RUN: %target-swift-frontend -typecheck %t/out.swift -I %t -cxx-interoperability-mode=default -enable-experimental-feature ForeignReferenceTypeInheritance
 
 //--- test.h
@@ -38,7 +38,6 @@ struct LeafDerived : Derived {
 import Test
 
 
-@available(macOS 13.3.0, *)
 extension Base {
   final func call_shared_Base() -> CInt {
     return shared()
@@ -51,7 +50,6 @@ extension Base {
   }
 }
 
-@available(macOS 13.3.0, *)
 extension Derived {
   final func call_shared_Derived() -> CInt {
     return shared()
@@ -73,7 +71,6 @@ extension Derived {
   }
 }
 
-@available(macOS 13.3.0, *)
 extension LeafDerived {
   final func call_shared_LeafDerived() -> CInt {
     return shared()

--- a/test/Utils/swift-function-caller-generator/inheritance-cxx.swift
+++ b/test/Utils/swift-function-caller-generator/inheritance-cxx.swift
@@ -1,0 +1,77 @@
+// Verifies that the caller generator handles C++ inheritance imported into
+// Swift: C++ base-class members exposed on a derived foreign reference type get
+// inherited-method callers, overridden members get `super` callers, and the
+// generated file actually compiles against the imported module.
+
+// REQUIRES: swift_feature_ForeignReferenceTypeInheritance
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-ide-test -print-module -module-to-print=Test -source-filename=x -I %t -cxx-interoperability-mode=default -enable-experimental-feature ForeignReferenceTypeInheritance > %t/Test-interface.swift
+// RUN: %swift-function-caller-generator Test %t/Test-interface.swift > %t/out.swift
+// RUN: %diff %t/out.swift %t/out.expected
+// RUN: %target-swift-frontend -typecheck %t/out.swift -I %t -cxx-interoperability-mode=default -enable-experimental-feature ForeignReferenceTypeInheritance
+
+//--- test.h
+#define FRT __attribute__((swift_attr("import_reference"))) \
+            __attribute__((swift_attr("retain:immortal")))  \
+            __attribute__((swift_attr("release:immortal")))
+
+struct FRT Base {
+  int baseOnly() const { return 1; }
+  virtual int shared() const { return 2; }
+  int nonVirtualShared() const { return 20; }
+};
+
+struct Derived : Base {
+  int shared() const override { return 3; }
+  int nonVirtualShared() const { return 30; }
+  int derivedOnly() const { return 4; }
+};
+
+struct LeafDerived : Derived {
+  int shared() const override { return 5; }
+};
+
+//--- out.expected
+import Test
+
+
+@available(macOS 13.3.0, *)
+extension Base {
+  final func call_shared_Base() -> CInt {
+    return shared()
+  }
+  final func call_baseOnly_Base() -> CInt {
+    return baseOnly()
+  }
+  final func call_nonVirtualShared_Base() -> CInt {
+    return nonVirtualShared()
+  }
+}
+
+@available(macOS 13.3.0, *)
+extension Derived {
+  final func call_shared_Derived() -> CInt {
+    return shared()
+  }
+  final func call_nonVirtualShared_Derived() -> CInt {
+    return nonVirtualShared()
+  }
+  final func call_derivedOnly_Derived() -> CInt {
+    return derivedOnly()
+  }
+}
+
+@available(macOS 13.3.0, *)
+extension LeafDerived {
+  final func call_shared_LeafDerived() -> CInt {
+    return shared()
+  }
+}
+//--- module.modulemap
+module Test {
+  header "test.h"
+  requires cplusplus
+}

--- a/test/Utils/swift-function-caller-generator/inheritance-cxx.swift
+++ b/test/Utils/swift-function-caller-generator/inheritance-cxx.swift
@@ -62,12 +62,30 @@ extension Derived {
   final func call_derivedOnly_Derived() -> CInt {
     return derivedOnly()
   }
+  final func call_shared_Base_super() -> CInt {
+    return super.shared()
+  }
+  final func call_baseOnly_Base_super() -> CInt {
+    return super.baseOnly()
+  }
+  final func call_nonVirtualShared_Base_super() -> CInt {
+    return super.nonVirtualShared()
+  }
 }
 
 @available(macOS 13.3.0, *)
 extension LeafDerived {
   final func call_shared_LeafDerived() -> CInt {
     return shared()
+  }
+  final func call_shared_Derived_super() -> CInt {
+    return super.shared()
+  }
+  final func call_nonVirtualShared_Derived_super() -> CInt {
+    return super.nonVirtualShared()
+  }
+  final func call_derivedOnly_Derived_super() -> CInt {
+    return super.derivedOnly()
   }
 }
 //--- module.modulemap

--- a/test/Utils/swift-function-caller-generator/inheritance.swift
+++ b/test/Utils/swift-function-caller-generator/inheritance.swift
@@ -33,43 +33,43 @@ import Test
 
 
 extension BaseClass {
-  func call_nonFinalShared(x: Int) -> Int {
+  final func call_nonFinalShared_BaseClass(x: Int) -> Int {
     return nonFinalShared(x: x)
   }
-  func call_finalBaseOnly() -> Int {
+  final func call_finalBaseOnly_BaseClass() -> Int {
     return finalBaseOnly()
   }
-  func call_baseOnly() -> Int {
+  final func call_baseOnly_BaseClass() -> Int {
     return baseOnly()
   }
 }
 
 extension DerivedClass {
-  func call_nonFinalShared_DerivedClass(x: Int) -> Int {
+  final func call_nonFinalShared_DerivedClass(x: Int) -> Int {
     return nonFinalShared(x: x)
   }
-  func call_derivedOnly() -> Int {
+  final func call_derivedOnly_DerivedClass() -> Int {
     return derivedOnly()
   }
 }
 
 extension LeafClass {
-  func call_nonFinalShared_LeafClass(x: Int) -> Int {
+  final func call_nonFinalShared_LeafClass(x: Int) -> Int {
     return nonFinalShared(x: x)
   }
 }
 
 extension BaseStruct {
-  func call_structShared() -> Int {
+  func call_structShared_BaseStruct() -> Int {
     return structShared()
   }
-  func call_structBaseOnly() -> Int {
+  func call_structBaseOnly_BaseStruct() -> Int {
     return structBaseOnly()
   }
 }
 
 extension DerivedStruct {
-  func call_structShared() -> Int {
+  func call_structShared_DerivedStruct() -> Int {
     return structShared()
   }
 }

--- a/test/Utils/swift-function-caller-generator/inheritance.swift
+++ b/test/Utils/swift-function-caller-generator/inheritance.swift
@@ -3,14 +3,6 @@
 // RUN: %swift-function-caller-generator Test %t/test.swift > %t/out.swift
 // RUN: %diff %t/out.swift %t/out.swift.expected
 
-// When a base type declares a function that a derived type does not, a caller
-// is still emitted for calling that (inherited) method on the derived type.
-// When the function is declared in both with the same signature, an additional
-// caller is emitted that invokes the base implementation via `super` from an
-// extension of the derived type. This is transitive along the inheritance
-// chain. `super` is only valid in a class, so struct types only get the
-// inherited-method callers.
-
 //--- test.swift
 class BaseClass {
   func nonFinalShared(x: Int) -> Int

--- a/test/Utils/swift-function-caller-generator/inheritance.swift
+++ b/test/Utils/swift-function-caller-generator/inheritance.swift
@@ -1,0 +1,83 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %swift-function-caller-generator Test %t/test.swift > %t/out.swift
+// RUN: %diff %t/out.swift %t/out.swift.expected
+
+// When a base type declares a function that a derived type does not, a caller
+// is still emitted for calling that (inherited) method on the derived type.
+// When the function is declared in both with the same signature, an additional
+// caller is emitted that invokes the base implementation via `super` from an
+// extension of the derived type. This is transitive along the inheritance
+// chain. `super` is only valid in a class, so struct types only get the
+// inherited-method callers.
+
+//--- test.swift
+class BaseClass {
+  func nonFinalShared(x: Int) -> Int
+  final func finalBaseOnly() -> Int
+  func baseOnly() -> Int
+}
+
+class DerivedClass : BaseClass {
+  func nonFinalShared(x: Int) -> Int
+  func derivedOnly() -> Int
+}
+
+class LeafClass : DerivedClass {
+  func nonFinalShared(x: Int) -> Int
+}
+
+struct BaseStruct {
+  func structShared() -> Int
+  func structBaseOnly() -> Int
+}
+
+struct DerivedStruct : BaseStruct {
+  func structShared() -> Int
+}
+
+//--- out.swift.expected
+import Test
+
+
+extension BaseClass {
+  func call_nonFinalShared(x: Int) -> Int {
+    return nonFinalShared(x: x)
+  }
+  func call_finalBaseOnly() -> Int {
+    return finalBaseOnly()
+  }
+  func call_baseOnly() -> Int {
+    return baseOnly()
+  }
+}
+
+extension DerivedClass {
+  func call_nonFinalShared(x: Int) -> Int {
+    return nonFinalShared(x: x)
+  }
+  func call_derivedOnly() -> Int {
+    return derivedOnly()
+  }
+}
+
+extension LeafClass {
+  func call_nonFinalShared(x: Int) -> Int {
+    return nonFinalShared(x: x)
+  }
+}
+
+extension BaseStruct {
+  func call_structShared() -> Int {
+    return structShared()
+  }
+  func call_structBaseOnly() -> Int {
+    return structBaseOnly()
+  }
+}
+
+extension DerivedStruct {
+  func call_structShared() -> Int {
+    return structShared()
+  }
+}

--- a/test/Utils/swift-function-caller-generator/inheritance.swift
+++ b/test/Utils/swift-function-caller-generator/inheritance.swift
@@ -51,11 +51,26 @@ extension DerivedClass {
   final func call_derivedOnly_DerivedClass() -> Int {
     return derivedOnly()
   }
+  final func call_nonFinalShared_BaseClass_super(x: Int) -> Int {
+    return super.nonFinalShared(x: x)
+  }
+  final func call_finalBaseOnly_BaseClass_super() -> Int {
+    return super.finalBaseOnly()
+  }
+  final func call_baseOnly_BaseClass_super() -> Int {
+    return super.baseOnly()
+  }
 }
 
 extension LeafClass {
   final func call_nonFinalShared_LeafClass(x: Int) -> Int {
     return nonFinalShared(x: x)
+  }
+  final func call_nonFinalShared_DerivedClass_super(x: Int) -> Int {
+    return super.nonFinalShared(x: x)
+  }
+  final func call_derivedOnly_DerivedClass_super() -> Int {
+    return super.derivedOnly()
   }
 }
 

--- a/test/Utils/swift-function-caller-generator/inheritance.swift
+++ b/test/Utils/swift-function-caller-generator/inheritance.swift
@@ -11,12 +11,12 @@ class BaseClass {
 }
 
 class DerivedClass : BaseClass {
-  func nonFinalShared(x: Int) -> Int
+  override func nonFinalShared(x: Int) -> Int
   func derivedOnly() -> Int
 }
 
 class LeafClass : DerivedClass {
-  func nonFinalShared(x: Int) -> Int
+  override func nonFinalShared(x: Int) -> Int
 }
 
 struct BaseStruct {
@@ -45,7 +45,7 @@ extension BaseClass {
 }
 
 extension DerivedClass {
-  func call_nonFinalShared(x: Int) -> Int {
+  func call_nonFinalShared_DerivedClass(x: Int) -> Int {
     return nonFinalShared(x: x)
   }
   func call_derivedOnly() -> Int {
@@ -54,7 +54,7 @@ extension DerivedClass {
 }
 
 extension LeafClass {
-  func call_nonFinalShared(x: Int) -> Int {
+  func call_nonFinalShared_LeafClass(x: Int) -> Int {
     return nonFinalShared(x: x)
   }
 }

--- a/test/Utils/swift-function-caller-generator/method.swift
+++ b/test/Utils/swift-function-caller-generator/method.swift
@@ -16,6 +16,12 @@ class Bar {
   class func classFunction(x: Int) -> Int
 }
 
+extension Foo {
+  func extensionMethod(x: Int) -> Int
+
+  mutating func mutatingExtensionMethod(p: UnsafeMutablePointer<Int>)
+}
+
 //--- out.swift.expected
 import Test
 
@@ -35,5 +41,14 @@ extension Foo {
 extension Bar {
   func call_classFunction(x: Int) -> Int {
     return Bar.classFunction(x: x)
+  }
+}
+
+extension Foo {
+  func call_extensionMethod(x: Int) -> Int {
+    return extensionMethod(x: x)
+  }
+  mutating func call_mutatingExtensionMethod(p: UnsafeMutablePointer<Int>) {
+    return unsafe mutatingExtensionMethod(p: p)
   }
 }

--- a/test/Utils/swift-function-caller-generator/method.swift
+++ b/test/Utils/swift-function-caller-generator/method.swift
@@ -20,16 +20,20 @@ class Bar {
 import Test
 
 
-func call_nonMutating(_ self: Foo) -> Int {
-  return self.nonMutating()
-}
-func call_mutatingMethod(_ self: inout Foo, x: Int) {
-  return self.mutatingMethod(x: x)
+extension Foo {
+  func call_nonMutating() -> Int {
+    return nonMutating()
+  }
+  mutating func call_mutatingMethod(x: Int) {
+    return mutatingMethod(x: x)
+  }
+  func call_unsafeMethod(p: UnsafeMutablePointer<Int>) {
+    return unsafe unsafeMethod(p: p)
+  }
 }
 
-func call_unsafeMethod(_ self: Foo, p: UnsafeMutablePointer<Int>) {
-  return unsafe self.unsafeMethod(p: p)
-}
-func call_classFunction(x: Int) -> Int {
-  return Bar.classFunction(x: x)
+extension Bar {
+  func call_classFunction(x: Int) -> Int {
+    return Bar.classFunction(x: x)
+  }
 }

--- a/test/Utils/swift-function-caller-generator/method.swift
+++ b/test/Utils/swift-function-caller-generator/method.swift
@@ -27,28 +27,28 @@ import Test
 
 
 extension Foo {
-  func call_nonMutating() -> Int {
+  func call_nonMutating_Foo() -> Int {
     return nonMutating()
   }
-  mutating func call_mutatingMethod(x: Int) {
+  mutating func call_mutatingMethod_Foo(x: Int) {
     return mutatingMethod(x: x)
   }
-  func call_unsafeMethod(p: UnsafeMutablePointer<Int>) {
+  func call_unsafeMethod_Foo(p: UnsafeMutablePointer<Int>) {
     return unsafe unsafeMethod(p: p)
   }
 }
 
 extension Bar {
-  func call_classFunction(x: Int) -> Int {
+  final func call_classFunction_Bar(x: Int) -> Int {
     return Bar.classFunction(x: x)
   }
 }
 
 extension Foo {
-  func call_extensionMethod(x: Int) -> Int {
+  func call_extensionMethod_Foo(x: Int) -> Int {
     return extensionMethod(x: x)
   }
-  mutating func call_mutatingExtensionMethod(p: UnsafeMutablePointer<Int>) {
+  mutating func call_mutatingExtensionMethod_Foo(p: UnsafeMutablePointer<Int>) {
     return unsafe mutatingExtensionMethod(p: p)
   }
 }

--- a/tools/swift-function-caller-generator/Sources/swift-function-caller-generator/swift-function-caller-generator.swift
+++ b/tools/swift-function-caller-generator/Sources/swift-function-caller-generator/swift-function-caller-generator.swift
@@ -35,6 +35,14 @@ import CRT
 import WinSDK
 #endif
 
+protocol Named {
+  var name: TokenSyntax { get }
+}
+extension ClassDeclSyntax: Named {
+}
+extension StructDeclSyntax: Named {
+}
+
 @main
 class SwiftMacroTestGen: SyntaxVisitor {
   static func main() {
@@ -71,41 +79,33 @@ class SwiftMacroTestGen: SyntaxVisitor {
       return .skipChildren
     }
     let surroundingType = getParentType(res)
-    let isMutating = res.modifiers.contains(where: {
-      $0.name.tokenKind == .keyword(.mutating)
-    })
-    let selfParam = surroundingType.map { type in res.isClassMethod ? type.with(\.trailingTrivia, "") : TokenSyntax("self") }
+    let selfParam = surroundingType.flatMap { type in res.isClassMethod ? type.with(\.trailingTrivia, "") : nil }
     res = createFunctionSignature(res)
     res =
       res
       .with(\.body, createBody(res, selfParam: selfParam))
       .with(\.name, "call_\(res.name.withoutBackticks)")
       .with(\.leadingTrivia, res.leadingTrivia.withoutComments)
-    if let surroundingType {
-      if !res.isClassMethod {
-        res =
-          res
-          .with(
-            \.signature.parameterClause.parameters,
-            addSelfParam(
-              res.signature.parameterClause.parameters, surroundingType, selfParam!,
-              isMutating: isMutating)
-          )
-      }
+    if surroundingType != nil {
       res =
         res
-        .with(\.leadingTrivia, "\n")
         .with(
           \.modifiers,
           res.modifiers.filter { modifier in
             switch modifier.name.tokenKind {
-            case .keyword(.mutating), .keyword(.open), .keyword(.class), .keyword(.final):
+            case .keyword(.open), .keyword(.class), .keyword(.final), .keyword(.public):
               false
             default:
               true
             }
           }
         )
+      let origIndent = node.firstToken(viewMode: .sourceAccurate)!.indentationOfLine
+      res = res
+        .with(\.leadingTrivia, "")
+        .indented(
+          by: origIndent,
+          indentFirstLine: true)
     }
     print(res)
     return .skipChildren
@@ -127,17 +127,56 @@ class SwiftMacroTestGen: SyntaxVisitor {
     return .skipChildren
   }
 
-  override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
-    if node.attributes.contains(where: { $0.isUnavailable }) {
+  class HasCallableFunction: SyntaxVisitor {
+    var hasCallableFunction = false
+    override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+      if !node.attributes.contains(where: { $0.isUnavailable }) {
+        hasCallableFunction = true
+      }
       return .skipChildren
     }
+  }
+  func shouldVisit(_ node: DeclGroupSyntax) -> Bool {
+    guard !node.attributes.contains(where: { $0.isUnavailable }) else {
+      return false
+    }
+    let walker = HasCallableFunction(viewMode: .all)
+    walker.walk(node.memberBlock)
+    return walker.hasCallableFunction
+  }
+
+  func visitPreImpl(_ node: DeclGroupSyntax & Named) -> SyntaxVisitorContinueKind {
+    guard shouldVisit(node) else {
+      return .skipChildren
+    }
+    let keyword: TokenSyntax = .keyword(
+      .extension, leadingTrivia: Trivia(), trailingTrivia: node.introducer.trailingTrivia)
+    let attributes = node.attributes.filter({ !$0.trimmed.description.starts(with: "@_") })
+    let e = ExtensionDeclSyntax(
+      leadingTrivia: .newline, attributes: attributes.with(\.leadingTrivia, Trivia()),
+      modifiers: node.modifiers.with(\.leadingTrivia, Trivia()), extensionKeyword: keyword,
+      extendedType: IdentifierTypeSyntax(name: node.name),
+      memberBlock: MemberBlockSyntax(stringLiteral: "{"))
+    print(e)
     return .visitChildren
   }
-  override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
-    if node.attributes.contains(where: { $0.isUnavailable }) {
-      return .skipChildren
+  func visitPostImpl(_ node: DeclGroupSyntax & Named) {
+    if shouldVisit(node) {
+      print("}")
     }
-    return .visitChildren
+  }
+
+  override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+    visitPreImpl(node)
+  }
+  override func visitPost(_ node: ClassDeclSyntax) {
+    visitPostImpl(node)
+  }
+  override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+    visitPreImpl(node)
+  }
+  override func visitPost(_ node: StructDeclSyntax) {
+    visitPostImpl(node)
   }
 
   func createFunctionSignature(_ f: FunctionDeclSyntax) -> FunctionDeclSyntax {

--- a/tools/swift-function-caller-generator/Sources/swift-function-caller-generator/swift-function-caller-generator.swift
+++ b/tools/swift-function-caller-generator/Sources/swift-function-caller-generator/swift-function-caller-generator.swift
@@ -37,6 +37,8 @@ import WinSDK
 
 @main
 class SwiftMacroTestGen: SyntaxVisitor {
+  var classDecls: [String: ClassDeclSyntax] = [:]
+
   static func main() {
     if CommandLine.argc < 2 {
       printError("missing module name (passed 0 arguments, expected 2)")
@@ -79,9 +81,7 @@ class SwiftMacroTestGen: SyntaxVisitor {
       .with(\.name, "call_\(res.name.withoutBackticks)")
       .with(\.leadingTrivia, res.leadingTrivia.withoutComments)
     if let surroundingType {
-      if res.modifiers.contains(where: { $0.name.tokenKind == .keyword(.override) }) {
-        res.name = "\(res.name)_\(surroundingType)"
-      }
+      res.name = "\(res.name)_\(surroundingType)"
       res =
         res
         .with(
@@ -97,11 +97,12 @@ class SwiftMacroTestGen: SyntaxVisitor {
           }
         )
       let origIndent = node.firstToken(viewMode: .sourceAccurate)!.indentationOfLine
-      res = res
-        .with(\.leadingTrivia, "")
-        .indented(
-          by: origIndent,
-          indentFirstLine: true)
+      res = res.with(\.leadingTrivia, "")
+      if classDecls.keys.contains(surroundingType.text) {
+        // filter out "final" above so that we can add it back unconditionally
+        res.modifiers.append(DeclModifierSyntax(name: .keyword(.final), trailingTrivia: .space))
+      }
+      res = res.indented(by: origIndent, indentFirstLine: true)
     }
     print(res)
     return .skipChildren
@@ -148,8 +149,10 @@ class SwiftMacroTestGen: SyntaxVisitor {
     let keyword: TokenSyntax = .keyword(
       .extension, leadingTrivia: Trivia(), trailingTrivia: node.introducer.trailingTrivia)
     let attributes = node.attributes.filter({ !$0.trimmed.description.starts(with: "@_") })
+      .with(\.leadingTrivia, Trivia())
+      .with(\.trailingTrivia, .newline)
     let e = ExtensionDeclSyntax(
-      leadingTrivia: .newline, attributes: attributes.with(\.leadingTrivia, Trivia()),
+      leadingTrivia: .newline, attributes: attributes,
       modifiers: node.modifiers.with(\.leadingTrivia, Trivia()), extensionKeyword: keyword,
       extendedType: type,
       memberBlock: MemberBlockSyntax(stringLiteral: "{"))
@@ -163,7 +166,11 @@ class SwiftMacroTestGen: SyntaxVisitor {
   }
 
   override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
-    visitPreImpl(node, type: IdentifierTypeSyntax(name: node.name))
+    let ret = visitPreImpl(node, type: IdentifierTypeSyntax(name: node.name))
+    if ret == .visitChildren {
+      classDecls[node.name.trimmed.text] = node
+    }
+    return ret
   }
   override func visitPost(_ node: ClassDeclSyntax) {
     visitPostImpl(node)

--- a/tools/swift-function-caller-generator/Sources/swift-function-caller-generator/swift-function-caller-generator.swift
+++ b/tools/swift-function-caller-generator/Sources/swift-function-caller-generator/swift-function-caller-generator.swift
@@ -70,7 +70,7 @@ class SwiftMacroTestGen: SyntaxVisitor {
     if res.attributes.contains(where: { $0.isUnavailable }) {
       return .skipChildren
     }
-    let surroundingType = getParentType(res)
+    let surroundingType = getParentType(res)?.trimmed
     let selfParam = surroundingType.flatMap { type in res.isClassMethod ? type.with(\.trailingTrivia, "") : nil }
     res = createFunctionSignature(res)
     res =
@@ -78,14 +78,18 @@ class SwiftMacroTestGen: SyntaxVisitor {
       .with(\.body, createBody(res, selfParam: selfParam))
       .with(\.name, "call_\(res.name.withoutBackticks)")
       .with(\.leadingTrivia, res.leadingTrivia.withoutComments)
-    if surroundingType != nil {
+    if let surroundingType {
+      if res.modifiers.contains(where: { $0.name.tokenKind == .keyword(.override) }) {
+        res.name = "\(res.name)_\(surroundingType)"
+      }
       res =
         res
         .with(
           \.modifiers,
           res.modifiers.filter { modifier in
             switch modifier.name.tokenKind {
-            case .keyword(.open), .keyword(.class), .keyword(.final), .keyword(.public):
+            case .keyword(.open), .keyword(.class), .keyword(.final), .keyword(.public),
+              .keyword(.override):
               false
             default:
               true

--- a/tools/swift-function-caller-generator/Sources/swift-function-caller-generator/swift-function-caller-generator.swift
+++ b/tools/swift-function-caller-generator/Sources/swift-function-caller-generator/swift-function-caller-generator.swift
@@ -35,14 +35,6 @@ import CRT
 import WinSDK
 #endif
 
-protocol Named {
-  var name: TokenSyntax { get }
-}
-extension ClassDeclSyntax: Named {
-}
-extension StructDeclSyntax: Named {
-}
-
 @main
 class SwiftMacroTestGen: SyntaxVisitor {
   static func main() {
@@ -145,7 +137,7 @@ class SwiftMacroTestGen: SyntaxVisitor {
     return walker.hasCallableFunction
   }
 
-  func visitPreImpl(_ node: DeclGroupSyntax & Named) -> SyntaxVisitorContinueKind {
+  func visitPreImpl(_ node: DeclGroupSyntax, type: TypeSyntaxProtocol) -> SyntaxVisitorContinueKind {
     guard shouldVisit(node) else {
       return .skipChildren
     }
@@ -155,27 +147,33 @@ class SwiftMacroTestGen: SyntaxVisitor {
     let e = ExtensionDeclSyntax(
       leadingTrivia: .newline, attributes: attributes.with(\.leadingTrivia, Trivia()),
       modifiers: node.modifiers.with(\.leadingTrivia, Trivia()), extensionKeyword: keyword,
-      extendedType: IdentifierTypeSyntax(name: node.name),
+      extendedType: type,
       memberBlock: MemberBlockSyntax(stringLiteral: "{"))
     print(e)
     return .visitChildren
   }
-  func visitPostImpl(_ node: DeclGroupSyntax & Named) {
+  func visitPostImpl(_ node: DeclGroupSyntax) {
     if shouldVisit(node) {
       print("}")
     }
   }
 
   override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
-    visitPreImpl(node)
+    visitPreImpl(node, type: IdentifierTypeSyntax(name: node.name))
   }
   override func visitPost(_ node: ClassDeclSyntax) {
     visitPostImpl(node)
   }
   override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
-    visitPreImpl(node)
+    visitPreImpl(node, type: IdentifierTypeSyntax(name: node.name))
   }
   override func visitPost(_ node: StructDeclSyntax) {
+    visitPostImpl(node)
+  }
+  override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
+    visitPreImpl(node, type: node.extendedType)
+  }
+  override func visitPost(_ node: ExtensionDeclSyntax) {
     visitPostImpl(node)
   }
 
@@ -329,6 +327,9 @@ func getParentType(_ node: some SyntaxProtocol) -> TokenSyntax? {
   }
   if let classType = parent.as(ClassDeclSyntax.self) {
     return classType.name
+  }
+  if let extensionType = parent.as(ExtensionDeclSyntax.self) {
+    return TokenSyntax("\(raw: extensionType.extendedType.trimmedDescription)")
   }
   return getParentType(parent)
 }

--- a/tools/swift-function-caller-generator/Sources/swift-function-caller-generator/swift-function-caller-generator.swift
+++ b/tools/swift-function-caller-generator/Sources/swift-function-caller-generator/swift-function-caller-generator.swift
@@ -38,6 +38,7 @@ import WinSDK
 @main
 class SwiftMacroTestGen: SyntaxVisitor {
   var classDecls: [String: ClassDeclSyntax] = [:]
+  var curClass: String? = nil
 
   static func main() {
     if CommandLine.argc < 2 {
@@ -73,7 +74,16 @@ class SwiftMacroTestGen: SyntaxVisitor {
       return .skipChildren
     }
     let surroundingType = getParentType(res)?.trimmed
-    let selfParam = surroundingType.flatMap { type in res.isClassMethod ? type.with(\.trailingTrivia, "") : nil }
+    let isClass = surroundingType != nil && classDecls.keys.contains(surroundingType!.text)
+    let selfParam = surroundingType.flatMap { type in
+      if res.isClassMethod {
+        return type.with(\.trailingTrivia, "")
+      }
+      if isClass, type.text != curClass {
+        return .keyword(.super)
+      }
+      return nil
+    }
     res = createFunctionSignature(res)
     res =
       res
@@ -81,7 +91,8 @@ class SwiftMacroTestGen: SyntaxVisitor {
       .with(\.name, "call_\(res.name.withoutBackticks)")
       .with(\.leadingTrivia, res.leadingTrivia.withoutComments)
     if let surroundingType {
-      res.name = "\(res.name)_\(surroundingType)"
+      let superKw = selfParam?.text == "super" ? "_super" : ""
+      res.name = "\(res.name)_\(surroundingType)\(raw: superKw)"
       res =
         res
         .with(
@@ -98,7 +109,7 @@ class SwiftMacroTestGen: SyntaxVisitor {
         )
       let origIndent = node.firstToken(viewMode: .sourceAccurate)!.indentationOfLine
       res = res.with(\.leadingTrivia, "")
-      if classDecls.keys.contains(surroundingType.text) {
+      if isClass {
         // filter out "final" above so that we can add it back unconditionally
         res.modifiers.append(DeclModifierSyntax(name: .keyword(.final), trailingTrivia: .space))
       }
@@ -169,10 +180,17 @@ class SwiftMacroTestGen: SyntaxVisitor {
     let ret = visitPreImpl(node, type: IdentifierTypeSyntax(name: node.name))
     if ret == .visitChildren {
       classDecls[node.name.trimmed.text] = node
+      curClass = node.name.trimmed.text
     }
     return ret
   }
   override func visitPost(_ node: ClassDeclSyntax) {
+    if let parentName = node.inheritanceClause?.inheritedTypes.first,
+      let parentClass = classDecls[parentName.type.trimmed.description]
+    {
+      walk(parentClass.memberBlock)
+    }
+    curClass = nil
     visitPostImpl(node)
   }
   override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {


### PR DESCRIPTION
This updates swift-function-caller-generator to call methods from extensions of the parent type rather than free functions, call methods in extensions (and not just structs and classes), and call methods in the superclass from the subclass when there's dynamic dispatch going on.

Also regenerates some test cases to make the diff smaller next time there's an actual change in those tests.