### PR TITLE
[Macros] Fix peer macro expansions that contain other macros.

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -305,6 +305,39 @@ bool BridgedASTContext_testCanImport(BridgedASTContext cContext,
 SWIFT_NAME("getter:BridgedASTContext.staticBuildConfigurationPtr(self:)")
 void * _Nonnull BridgedASTContext_staticBuildConfiguration(BridgedASTContext cContext);
 
+/// Describes the declaration that lexically encloses a macro expansion buffer.
+///
+/// The syntax tree of a macro expansion buffer is rooted at the buffer itself,
+/// so walking up its parent nodes never reaches the code the macro was
+/// expanded within. This describes where to resume that walk.
+struct BridgedMacroExpansionEnclosingDecl {
+  /// The `ExportedSourceFile` for the buffer containing the enclosing
+  /// declaration, or null if there is no enclosing declaration, i.e. the
+  /// expansion is at file scope.
+  void *_Nullable exportedSourceFile;
+
+  /// The start location of the enclosing declaration, within
+  /// \c exportedSourceFile.
+  swift::SourceLoc location;
+};
+
+/// Given a source location within a macro expansion buffer, find the
+/// declaration that lexically encloses that buffer.
+///
+/// The enclosing declaration is the innermost declaration context the buffer
+/// logically resides in, which accounts for how each macro role splices its
+/// expansion into the enclosing code. For example, a peer macro's expansion is
+/// a sibling of the declaration the macro is attached to, so the enclosing
+/// declaration is that declaration's context rather than the declaration
+/// itself.
+///
+/// Returns a result with a null \c exportedSourceFile if \p location is not
+/// within a macro expansion buffer, or if the buffer resides at file scope.
+SWIFT_NAME("BridgedASTContext.macroExpansionEnclosingDecl(self:at:)")
+BridgedMacroExpansionEnclosingDecl
+BridgedASTContext_macroExpansionEnclosingDecl(BridgedASTContext cContext,
+                                              swift::SourceLoc location);
+
 //===----------------------------------------------------------------------===//
 // MARK: AST nodes
 //===----------------------------------------------------------------------===//

--- a/lib/AST/Bridging/ASTContextBridging.cpp
+++ b/lib/AST/Bridging/ASTContextBridging.cpp
@@ -15,6 +15,8 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTContextGlobalCache.h"
 #include "swift/AST/AvailabilitySpec.h"
+#include "swift/AST/Module.h"
+#include "swift/AST/SourceFile.h"
 #include "swift/Bridging/BasicSwift.h"
 
 using namespace swift;
@@ -143,4 +145,50 @@ void *BridgedASTContext_staticBuildConfiguration(BridgedASTContext cContext) {
   }
 
   return staticBuildConfiguration;
+}
+
+BridgedMacroExpansionEnclosingDecl
+BridgedASTContext_macroExpansionEnclosingDecl(BridgedASTContext cContext,
+                                              SourceLoc location) {
+  BridgedMacroExpansionEnclosingDecl none{nullptr, SourceLoc()};
+
+  if (location.isInvalid())
+    return none;
+
+  ASTContext &ctx = cContext.unbridged();
+  SourceManager &sourceMgr = ctx.SourceMgr;
+
+  auto bufferID = sourceMgr.findBufferContainingLoc(location);
+  auto *generatedInfo = sourceMgr.getGeneratedSourceInfo(bufferID);
+  if (!generatedInfo)
+    return none;
+
+  // The declaration context recorded for the buffer is where the expansion
+  // logically resides, which already accounts for the macro role, e.g. peer
+  // macro expansions are recorded against the context of the declaration the
+  // macro is attached to rather than that declaration.
+  auto *dc = generatedInfo->declContext;
+  if (!dc || dc->isModuleScopeContext())
+    return none;
+
+  auto *decl = dc->getAsDecl();
+  if (!decl)
+    decl = dc->getInnermostDeclarationDeclContext();
+  if (!decl)
+    return none;
+
+  auto declLoc = decl->getStartLoc();
+  if (declLoc.isInvalid())
+    return none;
+
+  auto *sourceFile =
+      decl->getModuleContext()->getSourceFileContainingLocation(declLoc);
+  if (!sourceFile)
+    return none;
+
+  auto *exportedSourceFile = sourceFile->getExportedSourceFile();
+  if (!exportedSourceFile)
+    return none;
+
+  return {exportedSourceFile, declLoc};
 }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -13197,6 +13197,20 @@ void MissingDecl::forEachMacroExpandedDecl(MacroExpandedDeclCallback callback) {
     return;
   auto *module = getModuleContext();
 
+  // Once we've found a declaration produced by this macro reference, any
+  // macros attached to *that* declaration can introduce further declarations
+  // that are visible in the same scope. Recursively visit them; there is no
+  // need to filter by macro reference at this point, because everything we
+  // find is nested within an expansion we've already matched.
+  std::function<void(Decl *)> visitNested = [&](Decl *decl) {
+    decl->visitAuxiliaryDecls([&](Decl *nestedDecl) {
+      if (auto *vd = dyn_cast<ValueDecl>(nestedDecl))
+        callback(vd);
+
+      visitNested(nestedDecl);
+    });
+  };
+
   baseDecl->visitAuxiliaryDecls([&](Decl *auxiliaryDecl) {
     SourceFile *sf = auxiliaryDecl->getLoc()
         ? module->getSourceFileContainingLocation(auxiliaryDecl->getLoc())
@@ -13217,6 +13231,11 @@ void MissingDecl::forEachMacroExpandedDecl(MacroExpandedDeclCallback callback) {
     }
     if (auto *vd = dyn_cast<ValueDecl>(auxiliaryDecl))
       callback(vd);
+
+    // Macros attached to the expanded declaration can introduce declarations
+    // of their own, which are equally visible at the point where this macro
+    // was expanded. Visit them, too.
+    visitNested(auxiliaryDecl);
   });
 }
 

--- a/lib/ASTGen/Sources/MacroEvaluation/Macros.swift
+++ b/lib/ASTGen/Sources/MacroEvaluation/Macros.swift
@@ -517,7 +517,12 @@ func expandFreestandingMacroImpl(
         in: sourceFilePtr,
         pluginProtocolVersion: pluginProtocolVersion
       )!,
-      lexicalContext: pluginLexicalContext(of: expansionSyntax, pluginProtocolVersion: pluginProtocolVersion),
+      lexicalContext: pluginLexicalContext(
+        of: expansionSyntax,
+        in: sourceFilePtr,
+        cContext: cContext,
+        pluginProtocolVersion: pluginProtocolVersion
+      ),
       staticBuildConfiguration: try cContext.staticBuildConfiguration.asJSON
     )
     let result = try macro.plugin.sendMessageAndWait(message)
@@ -639,16 +644,56 @@ func expandAttachedMacro(
 
 /// Produce the full lexical context of the given node to pass along to
 /// macro expansion.
-private func lexicalContext(of node: some SyntaxProtocol) -> [Syntax] {
-  // FIXME: Should we query the source manager to get the macro expansion
-  // information?
-  node.allMacroLexicalContexts()
+///
+/// A syntax tree only spans a single source buffer, so walking up from a node
+/// inside a macro expansion buffer stops at that buffer's root and never
+/// reaches the code the macro was expanded within. Whenever the walk runs out
+/// of buffer, ask the compiler for the declaration that lexically encloses
+/// the buffer and resume the walk there, which stitches the context back
+/// together across any number of nested expansions.
+private func lexicalContext(
+  of node: some SyntaxProtocol,
+  in sourceFilePtr: UnsafePointer<ExportedSourceFile>?,
+  cContext: BridgedASTContext
+) -> [Syntax] {
+  var currentSourceFile = sourceFilePtr
+
+  return node.allMacroLexicalContexts { _ in
+    // Any location within the buffer identifies it to the compiler. Use the
+    // start of the buffer rather than a position from the syntax tree, which
+    // may be detached and therefore not correspond to this buffer at all.
+    guard let sourceFile = currentSourceFile,
+      let bufferStart = sourceFile.pointee.buffer.baseAddress
+    else {
+      return nil
+    }
+
+    let enclosing = cContext.macroExpansionEnclosingDecl(at: SourceLoc(raw: bufferStart))
+    guard let enclosingSourceFile = enclosing.exportedSourceFile else {
+      return nil
+    }
+
+    currentSourceFile = UnsafePointer(enclosingSourceFile.assumingMemoryBound(to: ExportedSourceFile.self))
+
+    // Resume from the enclosing declaration itself, so that it is counted as
+    // part of the lexical context along with everything that encloses it.
+    return findSyntaxNodeInSourceFile(
+      sourceFilePtr: enclosingSourceFile,
+      sourceLocationPtr: enclosing.location.getRaw()?.assumingMemoryBound(to: UInt8.self),
+      where: { $0.isProtocol((any DeclSyntaxProtocol).self) }
+    )
+  }
 }
 
 /// Produce the full lexical context of the given node to pass along to
 /// macro expansion.
-private func pluginLexicalContext(of node: some SyntaxProtocol, pluginProtocolVersion: Int) -> [PluginMessage.Syntax] {
-  lexicalContext(of: node).compactMap {
+private func pluginLexicalContext(
+  of node: some SyntaxProtocol,
+  in sourceFilePtr: UnsafePointer<ExportedSourceFile>?,
+  cContext: BridgedASTContext,
+  pluginProtocolVersion: Int
+) -> [PluginMessage.Syntax] {
+  lexicalContext(of: node, in: sourceFilePtr, cContext: cContext).compactMap {
     .init(syntax: $0, pluginProtocolVersion: pluginProtocolVersion)
   }
 }
@@ -746,6 +791,8 @@ func expandAttachedMacroImpl(
       conformanceListSyntax: conformanceListSyntax,
       lexicalContext: pluginLexicalContext(
         of: declarationNode,
+        in: declarationSourceFilePtr,
+        cContext: cContext,
         pluginProtocolVersion: pluginProtocolVersion
       ),
       staticBuildConfiguration: try cContext.staticBuildConfiguration.asJSON

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -2262,13 +2262,19 @@ void SILGenModule::emitSourceFile(SourceFile *sf) {
     emitEntryPoint(sf);
   }
 
-  for (auto *D : sf->getTopLevelDecls()) {
-    // Emit auxiliary decls.
+  // Emit a declaration along with its auxiliary decls. Auxiliary decls can
+  // themselves have auxiliary decls, e.g. when a macro expands to a
+  // declaration that has another macro attached to it, so this recurses.
+  std::function<void(Decl *)> emitDecl = [&](Decl *D) {
     D->visitAuxiliaryDecls([&](Decl *auxiliaryDecl) {
-      visit(auxiliaryDecl);
+      emitDecl(auxiliaryDecl);
     });
 
     visit(D);
+  };
+
+  for (auto *D : sf->getTopLevelDecls()) {
+    emitDecl(D);
   }
 
   // Visit extensions recorded in the synthesized file separately. The code

--- a/lib/SILGen/SILGenTopLevel.cpp
+++ b/lib/SILGen/SILGenTopLevel.cpp
@@ -392,9 +392,17 @@ SILGenTopLevel::SILGenTopLevel(SILGenFunction &SGF) : SGF(SGF) {}
 
 void SILGenTopLevel::visitSourceFile(SourceFile *SF) {
 
-  for (auto *D : SF->getTopLevelDecls()) {
-    D->visitAuxiliaryDecls([&](Decl *AuxiliaryDecl) { visit(AuxiliaryDecl); });
+  // Auxiliary decls can themselves have auxiliary decls, e.g. when a macro
+  // expands to a declaration that has another macro attached to it, so this
+  // recurses.
+  std::function<void(Decl *)> visitDecl = [&](Decl *D) {
+    D->visitAuxiliaryDecls(
+        [&](Decl *AuxiliaryDecl) { visitDecl(AuxiliaryDecl); });
     visit(D);
+  };
+
+  for (auto *D : SF->getTopLevelDecls()) {
+    visitDecl(D);
   }
 
   if (auto *SynthesizedFile = SF->getSynthesizedFile()) {

--- a/test/Macros/macro_expand_nested_lexical_context.swift
+++ b/test/Macros/macro_expand_nested_lexical_context.swift
@@ -1,0 +1,162 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: split-file --leading-lines %s %t
+
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -parse-as-library -module-name=MacroDefinition %t/MacroDefinition.swift -g -no-toolchain-stdlib-rpath
+
+// RUN: %target-swift-frontend -swift-version 5 -typecheck -verify -load-plugin-library %t/%target-library-name(MacroDefinition) %t/macro_expand_nested_lexical_context.swift -disable-availability-checking
+
+// RUN: %target-swift-frontend -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) %t/macro_expand_nested_lexical_context.swift -disable-availability-checking -dump-macro-expansions > %t/expansions-dump.txt 2>&1
+// RUN: %FileCheck %s < %t/expansions-dump.txt
+
+//--- MacroDefinition.swift
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// Peer macro that reports the lexical context it was expanded in, so that
+/// the test can check the context macros observe.
+public struct ReportLexicalContextMacro: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    let description = context.lexicalContext.map { "\($0.kind)" }.joined(separator: ",")
+    let name = context.makeUniqueName("lexicalContext")
+    return [
+      """
+      var \(name): String { "lexicalContext(\(raw: description))" }
+      """
+    ]
+  }
+}
+
+/// Peer macro that introduces a declaration annotated with
+/// `@ReportLexicalContext`.
+public struct NestReportInPeerMacro: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return [
+      """
+      @ReportLexicalContext
+      func \(context.makeUniqueName("nested"))() {}
+      """
+    ]
+  }
+}
+
+/// Peer macro that introduces a declaration annotated with `@NestReportInPeer`,
+/// so that the reporting macro ends up two expansions deep.
+public struct NestReportInPeerTwiceMacro: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return [
+      """
+      @NestReportInPeer
+      func \(context.makeUniqueName("nestedTwice"))() {}
+      """
+    ]
+  }
+}
+
+/// Member macro that introduces a member annotated with
+/// `@ReportLexicalContext`.
+public struct NestReportInMemberMacro: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return [
+      """
+      @ReportLexicalContext
+      func \(context.makeUniqueName("nestedMember"))() {}
+      """
+    ]
+  }
+}
+
+/// Freestanding declaration macro that introduces a declaration annotated with
+/// `@ReportLexicalContext`.
+public struct NestReportInFreestandingMacro: DeclarationMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return [
+      """
+      @ReportLexicalContext
+      func \(context.makeUniqueName("nestedFreestanding"))() {}
+      """
+    ]
+  }
+}
+
+//--- macro_expand_nested_lexical_context.swift
+
+@attached(peer)
+macro ReportLexicalContext() = #externalMacro(module: "MacroDefinition", type: "ReportLexicalContextMacro")
+
+@attached(peer)
+macro NestReportInPeer() = #externalMacro(module: "MacroDefinition", type: "NestReportInPeerMacro")
+
+@attached(peer)
+macro NestReportInPeerTwice() = #externalMacro(module: "MacroDefinition", type: "NestReportInPeerTwiceMacro")
+
+@attached(member)
+macro NestReportInMember() = #externalMacro(module: "MacroDefinition", type: "NestReportInMemberMacro")
+
+@freestanding(declaration)
+macro nestReportInFreestanding() = #externalMacro(module: "MacroDefinition", type: "NestReportInFreestandingMacro")
+
+// A macro expanded inside another macro's expansion must observe the same
+// lexical context it would have observed had it been written in the original
+// source, rather than an empty context. The syntax tree of an expansion buffer
+// stops at the buffer, so this requires stitching the context back together
+// across buffers.
+
+struct S {
+  // Written directly, as a baseline.
+  @ReportLexicalContext
+  func direct() {}
+
+  // Reached through a peer macro's expansion.
+  @NestReportInPeer
+  func viaPeer() {}
+
+  // Reached through two levels of peer macro expansion.
+  @NestReportInPeerTwice
+  func viaPeerTwice() {}
+
+  // Reached through a freestanding macro's expansion.
+  #nestReportInFreestanding
+}
+
+// Reached through a member macro's expansion.
+@NestReportInMember
+struct T {}
+
+// Every one of the above sits inside a struct, so all of them must report the
+// struct as their lexical context.
+// CHECK-COUNT-5: lexicalContext(structDecl)
+// CHECK-NOT: lexicalContext(structDecl)
+
+// At file scope there is no enclosing declaration, so the context is empty
+// whether or not the macro is nested.
+@ReportLexicalContext
+func topLevelDirect() {}
+
+@NestReportInPeer
+func topLevelViaPeer() {}
+
+// CHECK-COUNT-2: lexicalContext()
+// CHECK-NOT: lexicalContext()

--- a/test/Macros/macro_expand_nested_unique_names.swift
+++ b/test/Macros/macro_expand_nested_unique_names.swift
@@ -1,0 +1,136 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: split-file --leading-lines %s %t
+
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -parse-as-library -module-name=MacroDefinition %t/MacroDefinition.swift -g -no-toolchain-stdlib-rpath
+
+// RUN: %target-swift-frontend -swift-version 5 -typecheck -verify -load-plugin-library %t/%target-library-name(MacroDefinition) %t/macro_expand_nested_unique_names.swift -disable-availability-checking
+
+// RUN: %target-swift-frontend -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) %t/macro_expand_nested_unique_names.swift -disable-availability-checking -dump-macro-expansions > %t/expansions-dump.txt 2>&1
+// RUN: %FileCheck %s < %t/expansions-dump.txt
+
+// Declarations introduced by a macro nested inside another macro's expansion
+// must also be emitted, not just type-checked.
+// RUN: %target-swift-emit-silgen -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library %t/macro_expand_nested_unique_names.swift -disable-availability-checking | %FileCheck %s -check-prefix=CHECK-SIL
+
+//--- MacroDefinition.swift
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// Peer macro that introduces a declaration which is itself annotated with
+/// the "inner" macro below.
+public struct NestedMacroOuterMacro: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    guard let funcDecl = declaration.as(FunctionDeclSyntax.self) else {
+      return []
+    }
+
+    let name = context.makeUniqueName(funcDecl.name.text)
+    return [
+      """
+      @NestedMacroInner
+      func \(name)() {}
+      """
+    ]
+  }
+}
+
+/// Peer macro that introduces two declarations with unique names, where one
+/// refers to the other.
+public struct NestedMacroInnerMacro: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    let storageName = context.makeUniqueName("storage")
+    let accessorName = context.makeUniqueName("accessor")
+    return [
+      """
+      var \(storageName): Int { 42 }
+      """,
+      """
+      func \(accessorName)() -> Int { return \(storageName) }
+      """,
+    ]
+  }
+}
+
+//--- macro_expand_nested_unique_names.swift
+
+@attached(peer)
+macro NestedMacroOuter() = #externalMacro(module: "MacroDefinition", type: "NestedMacroOuterMacro")
+
+@attached(peer)
+macro NestedMacroInner() = #externalMacro(module: "MacroDefinition", type: "NestedMacroInnerMacro")
+
+// A macro used directly, as a baseline: the unique names it introduces must
+// resolve against each other.
+@NestedMacroInner
+func directlyAnnotated() {}
+
+// CHECK-LABEL: @__swiftmacro_32macro_expand_nested_unique_names17directlyAnnotated16NestedMacroInnerfMp_.swift
+// CHECK: var [[DIRECT_STORAGE:\$s32macro_expand_nested_unique_names17directlyAnnotated16NestedMacroInnerfMp_7storagefMu_]]: Int
+// CHECK: func $s32macro_expand_nested_unique_names17directlyAnnotated16NestedMacroInnerfMp_8accessorfMu_() -> Int {
+// CHECK:   return [[DIRECT_STORAGE]]
+
+// The same inner macro, but reached through the expansion of another macro.
+// The unique names it introduces must still resolve against each other, even
+// though the declaration they are attached to lives in a macro expansion
+// buffer rather than in the original source file.
+@NestedMacroOuter
+func topLevelOuter() {}
+
+// CHECK-LABEL: @__swiftmacro_32macro_expand_nested_unique_names13topLevelOuter011NestedMacroH0fMp_.swift
+// CHECK: @NestedMacroInner
+// CHECK: func $s32macro_expand_nested_unique_names13topLevelOuter011NestedMacroH0fMp_13topLevelOuterfMu_()
+
+// CHECK-LABEL: @__swiftmacro_32macro_expand_nested_unique_names010$s32macro_{{.*}}0jK5InnerfMp_.swift
+// CHECK: var [[TOP_STORAGE:\$s32macro_expand_nested_unique_names010\$s32macro_.*7storagefMu_]]: Int
+// CHECK: func $s32macro_expand_nested_unique_names010$s32macro_{{.*}}8accessorfMu_() -> Int {
+// CHECK:   return [[TOP_STORAGE]]
+
+// The same thing in a type context, which uses a different name lookup path.
+struct S {
+  @NestedMacroInner
+  func directlyAnnotated() {}
+
+  @NestedMacroOuter
+  func nestedOuter() {}
+}
+
+// CHECK-LABEL: @__swiftmacro_32macro_expand_nested_unique_names1SV17directlyAnnotated16NestedMacroInnerfMp_.swift
+// CHECK: var [[MEMBER_DIRECT_STORAGE:\$s32macro_expand_nested_unique_names1SV17directlyAnnotated16NestedMacroInnerfMp_7storagefMu_]]: Int
+// CHECK: func $s32macro_expand_nested_unique_names1SV17directlyAnnotated16NestedMacroInnerfMp_8accessorfMu_() -> Int {
+// CHECK:   return [[MEMBER_DIRECT_STORAGE]]
+
+// CHECK-LABEL: @__swiftmacro_32macro_expand_nested_unique_names1SV0C5Outer011NestedMacroF0fMp_.swift
+// CHECK: @NestedMacroInner
+// CHECK: func $s32macro_expand_nested_unique_names1SV0C5Outer011NestedMacroF0fMp_11nestedOuterfMu_()
+
+// CHECK-LABEL: @__swiftmacro_32macro_expand_nested_unique_names1SV010$s32macro_{{.*}}0kL5InnerfMp_.swift
+// CHECK: var [[MEMBER_STORAGE:\$s32macro_expand_nested_unique_names1SV010\$s32macro_.*7storagefMu_]]: Int
+// CHECK: func $s32macro_expand_nested_unique_names1SV010$s32macro_{{.*}}8accessorfMu_() -> Int {
+// CHECK:   return [[MEMBER_STORAGE]]
+
+// The peers of the directly-annotated function, as a baseline.
+// CHECK-SIL-DAG: sil hidden [ossa] @$s32macro_expand_nested_unique_names{{.*}}17directlyAnnotated16NestedMacroInnerfMp_7storagefMu_Sivg
+// CHECK-SIL-DAG: sil hidden [ossa] @$s32macro_expand_nested_unique_names{{.*}}17directlyAnnotated16NestedMacroInnerfMp_8accessorfMu_SiyF
+
+// The function introduced by the outer macro...
+// CHECK-SIL-DAG: sil hidden [ossa] @$s32macro_expand_nested_unique_names{{.*}}13topLevelOuter011NestedMacroH0fMp_13topH9OuterfMu_yyF
+
+// ...and the peers introduced by the inner macro attached to it.
+// CHECK-SIL-DAG: sil hidden [ossa] @$s32macro_expand_nested_unique_names{{.*}}13topLevelOuter{{.*}}Inner{{.*}}7storagefU1_Sivg
+// CHECK-SIL-DAG: sil hidden [ossa] @$s32macro_expand_nested_unique_names{{.*}}13topLevelOuter{{.*}}Inner{{.*}}8accessorfU1_SiyF
+
+// The same, in a type context.
+// CHECK-SIL-DAG: sil hidden [ossa] @$s32macro_expand_nested_unique_names1SV{{.*}}0C5Outer011NestedMacroF0fMp_11C9OuterfMu_yyF
+// CHECK-SIL-DAG: sil hidden [ossa] @$s32macro_expand_nested_unique_names1SV{{.*}}Outer{{.*}}Inner{{.*}}7storagefU1_Sivg
+// CHECK-SIL-DAG: sil hidden [ossa] @$s32macro_expand_nested_unique_names1SV{{.*}}Outer{{.*}}Inner{{.*}}8accessorfU1_SiyF

--- a/test/Macros/macro_expand_recursive_peer.swift
+++ b/test/Macros/macro_expand_recursive_peer.swift
@@ -1,0 +1,55 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: split-file --leading-lines %s %t
+
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -parse-as-library -module-name=MacroDefinition %t/MacroDefinition.swift -g -no-toolchain-stdlib-rpath
+
+// RUN: not %target-swift-frontend -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) %t/macro_expand_recursive_peer.swift -disable-availability-checking 2>&1 | %FileCheck %s
+
+//--- MacroDefinition.swift
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// Peer macro that expands to a declaration annotated with itself, to check
+/// that recursive expansion is diagnosed rather than expanded forever.
+public struct RecursivePeerMacro: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return [
+      """
+      @RecursivePeer
+      func \(context.makeUniqueName("again"))() {}
+      """
+    ]
+  }
+}
+
+//--- macro_expand_recursive_peer.swift
+
+// A peer macro that expands to a declaration annotated with itself must be
+// diagnosed rather than expanded forever. Name lookup walks into declarations
+// introduced by macros nested inside other macro expansions, so it can reach
+// the recursive expansion; the check that stops it lives in macro expansion
+// itself.
+
+@attached(peer)
+macro RecursivePeer() = #externalMacro(module: "MacroDefinition", type: "RecursivePeerMacro")
+
+// At file scope.
+@RecursivePeer
+func topLevelRecursive() {}
+
+// In a type context, which uses a different name lookup path.
+struct S {
+  @RecursivePeer
+  func inTypeRecursive() {}
+}
+
+// CHECK-DAG: error: recursive expansion of macro 'RecursivePeer()'
+// CHECK-DAG: in expansion of macro 'RecursivePeer' on global function 'topLevelRecursive()' here
+// CHECK-DAG: in expansion of macro 'RecursivePeer' on instance method 'inTypeRecursive()' here

--- a/test/SourceKit/Macros/expansion_decl_cursor_info.swift
+++ b/test/SourceKit/Macros/expansion_decl_cursor_info.swift
@@ -34,12 +34,19 @@ macro AddFuncPeer(x: Int) = #externalMacro(module: "MacroDefinition", type: "Add
 @freestanding(declaration, names: named(foo))
 macro AddFunc(x: Int) = #externalMacro(module: "MacroDefinition", type: "AddFuncMacro")
 
+// Note that the peer macro is deliberately not attached to the freestanding
+// macro expansion below. Attributes written on a macro expansion declaration
+// are inherited by the declarations it expands to, so attaching the peer macro
+// to it would expand the peer macro a second time, against the expanded
+// 'foo(_: String)', and the two expansions would both declare 'foo(_: Int)'.
 @AddFuncPeer(x: 0)
+func other() {}
+
 #AddFunc(x: 0)
 
 foo(0)
 // RUN: %sourcekitd-test -req=cursor %t/main.swift -pos=%(line-1):1 -- %t/main.swift -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser | %FileCheck --check-prefix PEER %s
-// PEER: source.lang.swift.ref.function.free ([[@LINE-5]]:1-[[@LINE-5]]:19)
+// PEER: source.lang.swift.ref.function.free ([[@LINE-7]]:1-[[@LINE-7]]:19)
 
 foo("")
 // RUN: %sourcekitd-test -req=cursor %t/main.swift -pos=%(line-1):1 -- %t/main.swift -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser | %FileCheck --check-prefix FREESTANDING %s


### PR DESCRIPTION
A macro attached to a declaration produced by another macro was mishandled in three places:

* Name lookup never walked into nested expansions, so unique names introduced by the inner macro couldn't resolve against each other. Fixed by updating `MissingDecl::forEachMacroExpandedDecl` to recurse into auxiliary declarations which might have their own auxiliary declarations.

* Likewise, SILGen only visited auxiliary declarations one level deep; it now recurses as well.

* The lexical context passed to a macro stopped at the root of its expansion buffer, so if the inner macro was inside a type context, it wouldn't be able to see any of that context. For example,

  ```swift struct S { @MyTest func f() {} } ```

  if `@MyTest` expands to include `@Test` (à la Swift Testing), the expansion of `@Test` couldn't see that it was inside the type `S`.

  This is now fixed; inner expansions now ask for the declaration enclosing the expansion buffer and continue the walk.
