### PR TITLE
[Sema] Remove `DiagnosticTransaction` from `CallerSideDefaultArgExprRequest`

### DIFF
--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -759,36 +759,10 @@ Expr *CallerSideDefaultArgExprRequest::evaluate(
   auto *initExpr = synthesizeCallerSideDefault(param, defaultExpr, dc);
   assert(dc && "Expected a DeclContext before type-checking caller-side arg");
 
-  auto &ctx = param->getASTContext();
-  DiagnosticTransaction transaction(ctx.Diags);
   if (!TypeChecker::typeCheckParameterDefault(initExpr, dc, paramTy,
                                               param->isAutoClosure(),
                                               /*atCallerSide=*/true)) {
-    auto isSimpleLiteral = [&]() -> bool {
-      switch (param->getDefaultArgumentKind()) {
-#define MAGIC_IDENTIFIER(NAME, STRING) \
-      case DefaultArgumentKind::NAME: return true;
-#include "swift/AST/MagicIdentifierKinds.def"
-      case DefaultArgumentKind::NilLiteral:
-      case DefaultArgumentKind::EmptyArray:
-      case DefaultArgumentKind::EmptyDictionary:
-        return true;
-      default:
-        return false;
-      }
-    };
-    if (param->hasDefaultExpr() && isSimpleLiteral()) {
-      // HACK: If we were unable to type-check the default argument in context,
-      // then retry by type-checking it within the parameter decl, which should
-      // also fail. This will present the user with a better error message and
-      // allow us to avoid diagnosing on each call site.
-      // Note we can't do this for expression macros since name lookup may
-      // differ at the call side vs the declaration. We can however do it for
-      // simple literals.
-      transaction.abort();
-      (void)param->getTypeCheckedDefaultExpr();
-      ASSERT(ctx.Diags.hadAnyError());
-    }
+    auto &ctx = param->getASTContext();
     return new (ctx) ErrorExpr(initExpr->getSourceRange(), paramTy);
   }
   if (param->getDefaultArgumentKind() == DefaultArgumentKind::ExpressionMacro) {

--- a/test/Constraints/type_inference_from_default_exprs.swift
+++ b/test/Constraints/type_inference_from_default_exprs.swift
@@ -179,8 +179,8 @@ func test_magic_defaults() {
   func with_magic(_: Int = #function) {} // expected-error {{default argument value of type 'String' cannot be converted to type 'Int'}}
   func generic_with_magic<T>(_: T = #line) -> T {} // expected-error {{default argument value of type 'Int' cannot be converted to type 'T'}}
 
-  let _ = with_magic()
-  let _: String = generic_with_magic()
+  let _ = with_magic() // expected-error {{default argument value of type 'String' cannot be converted to type 'Int'}}
+  let _: String = generic_with_magic() // expected-error {{default argument value of type 'Int' cannot be converted to type 'String'}}
 }
 
 // https://github.com/apple/swift/issues/58330

--- a/test/Sema/property_wrapper_parameter.swift
+++ b/test/Sema/property_wrapper_parameter.swift
@@ -248,3 +248,8 @@ struct Widget {
 func buildWidget(_ w: ProjectionWrapper<Int>) -> Widget {
   Widget($w: w)
 }
+
+// FIXME: This should work, currently we don't consider property wrappers
+// when matching default arguments with parameters.
+func testCallerSideDefault(@Wrapper x: Int? = nil) {}
+testCallerSideDefault() // expected-error {{nil default argument value cannot be converted to type 'Wrapper<Int?>'}}

--- a/test/decl/func/default-values.swift
+++ b/test/decl/func/default-values.swift
@@ -179,10 +179,10 @@ let fooThing6 = Foo(a: 0, d: 1, e: 2, h: nil) // expected-error {{missing argume
   do {
   func f(x: Int) {}
   func f(line: String = #line) {} // expected-error {{default argument value of type 'Int' cannot be converted to type 'String'}}
-  f()
+  f() // expected-error {{default argument value of type 'Int' cannot be converted to type 'String'}}
 
   class C { init(line: String = #line) {} } // expected-error {{default argument value of type 'Int' cannot be converted to type 'String'}}
-  let _ = C()
+  let _ = C() // expected-error {{default argument value of type 'Int' cannot be converted to type 'String'}}
 }
 
 // https://github.com/apple/swift/issues/54034
@@ -191,6 +191,7 @@ let fooThing6 = Foo(a: 0, d: 1, e: 2, h: nil) // expected-error {{missing argume
 // expected-error@+1 {{default argument value of type 'String' cannot be converted to type 'T'}}
 func badGenericMagicLiteral<T : ExpressibleByIntegerLiteral>(_ x: T = #function) -> T { x }
 let _: Int = badGenericMagicLiteral()
+// expected-error@-1 {{default argument value of type 'String' cannot be converted to type 'Int'}}
 
 func genericMagicLiteral<T : ExpressibleByIntegerLiteral>(_ x: T = #line) -> T { x } // expected-note {{where 'T' = 'String'}}
 let _: Int = genericMagicLiteral()

--- a/test/multifile/default-arguments/one-module/invalid-magic-literals.swift
+++ b/test/multifile/default-arguments/one-module/invalid-magic-literals.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -emit-sil -verify -module-name main -primary-file %s %S/Inputs/invalid-magic-literals-other.swift
 
 func bar() {
-  badMagicLiteral()
-  let _: Int = badGenericMagicLiteral()
+  badMagicLiteral() // expected-error {{default argument value of type 'Int' cannot be converted to type 'String'}}
+  let _: Int = badGenericMagicLiteral() // expected-error {{default argument value of type 'String' cannot be converted to type 'Int'}}
 }

--- a/validation-test/compiler_crashers/CallerSideDefaultArgExprRequest-evaluate-372b93.swift
+++ b/validation-test/compiler_crashers/CallerSideDefaultArgExprRequest-evaluate-372b93.swift
@@ -1,0 +1,11 @@
+// {"kind":"typecheck","signature":"swift::CallerSideDefaultArgExprRequest::evaluate(swift::Evaluator&, swift::DefaultArgumentExpr*) const","signatureAssert":"Assertion failed: (ctx.Diags.hadAnyError()), function evaluate","signatureNext":"CallerSideDefaultArgExprRequest::OutputType"}
+// RUN: not --crash %target-swift-frontend -typecheck %s
+@propertyWrapper
+struct a {
+  var wrappedValue: Int?
+  var projectedValue: a {
+  }
+  init(projectedValue: a)
+}
+func b(@a c: Int? = nil)
+b()

--- a/validation-test/compiler_crashers/ExtraneousPropertyWrapperUnwrapFailure-diagnoseAsError-8d34bb.swift
+++ b/validation-test/compiler_crashers/ExtraneousPropertyWrapperUnwrapFailure-diagnoseAsError-8d34bb.swift
@@ -1,0 +1,8 @@
+// {"kind":"typecheck","signature":"swift::constraints::ExtraneousPropertyWrapperUnwrapFailure::diagnoseAsError()","signatureAssert":"Assertion failed: (isa<To>(Val) && \"cast<Ty>() argument of incompatible type!\"), function cast","signatureNext":"UsePropertyWrapper::diagnose"}
+// RUN: not --crash %target-swift-frontend -typecheck %s
+@propertyWrapper struct a {
+  wrappedValue: Int?
+  var projectedValue
+}
+func b(@a  Int?)
+b

--- a/validation-test/compiler_crashers/SILType-hasAbstractionDifference-917b35.swift
+++ b/validation-test/compiler_crashers/SILType-hasAbstractionDifference-917b35.swift
@@ -1,0 +1,13 @@
+// {"kind":"emit-silgen","signature":"swift::SILType::hasAbstractionDifference(swift::SILFunctionTypeRepresentation, swift::SILType)","signatureNext":"ScalarResultPlan::finish"}
+// RUN: not --crash %target-swift-frontend -emit-silgen %s
+@propertyWrapper
+struct a {
+  var wrappedValue: Int
+  var projectedValue: Self {
+  }
+  init(projectedValue: Self) {
+  }
+}
+func b(@a c: Int = 0) {
+  b()
+}

--- a/validation-test/compiler_crashers_fixed/CallerSideDefaultArgExprRequest-evaluate-372b93.swift
+++ b/validation-test/compiler_crashers_fixed/CallerSideDefaultArgExprRequest-evaluate-372b93.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"swift::CallerSideDefaultArgExprRequest::evaluate(swift::Evaluator&, swift::DefaultArgumentExpr*) const","signatureAssert":"Assertion failed: (ctx.Diags.hadAnyError()), function evaluate","signatureNext":"CallerSideDefaultArgExprRequest::OutputType"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 @propertyWrapper
 struct a {
   var wrappedValue: Int?


### PR DESCRIPTION
2019 me had good intentions with this, but it's a fundamentally unsound hack and isn't worth the tradeoff. Let's just remove it.

rdar://141047299