### PR TITLE
[CS] NFC: Remove dead `ResultBuilderBodyResult` locator element

### DIFF
--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -299,9 +299,6 @@ public:
   /// Determine whether this locator points to the `try?` expression.
   bool isForOptionalTry() const;
 
-  /// Determine whether this locator is for a result builder body result type.
-  bool isForResultBuilderBodyResult() const;
-
   /// Determine whether this locator is for a macro expansion.
   bool isForMacroExpansion() const;
 

--- a/include/swift/Sema/ConstraintLocatorPathElts.def
+++ b/include/swift/Sema/ConstraintLocatorPathElts.def
@@ -87,9 +87,6 @@ SIMPLE_LOCATOR_PATH_ELT(FunctionArgument)
 /// The result type of a function.
 SIMPLE_LOCATOR_PATH_ELT(FunctionResult)
 
-/// The result type of a result builder body.
-SIMPLE_LOCATOR_PATH_ELT(ResultBuilderBodyResult)
-
 /// A generic argument.
 /// FIXME: Add support for named generic arguments?
 CUSTOM_LOCATOR_PATH_ELT(GenericArgument)

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -304,13 +304,6 @@ ValueDecl *RequirementFailure::getDeclRef() const {
     return opaqueLocator->getDecl();
   }
 
-  // If the locator is for a result builder body result type, the requirement
-  // came from the function's return type.
-  if (getLocator()->isForResultBuilderBodyResult()) {
-    auto *func = getAsDecl<FuncDecl>(getAnchor());
-    return getAffectedDeclFromType(func->getResultInterfaceType());
-  }
-
   if (isFromContextualType()) {
     auto anchor = getRawAnchor();
     auto contextualPurpose = getContextualTypePurpose(anchor);
@@ -1023,10 +1016,6 @@ bool GenericArgumentsMismatchFailure::diagnoseAsError() {
       diagnostic = getDiagnosticFor(purpose);
       break;
     }
-
-    case ConstraintLocator::ResultBuilderBodyResult:
-      diagnostic = diag::cannot_convert_result_builder_result_to_return_type;
-      break;
 
     case ConstraintLocator::AutoclosureResult:
     case ConstraintLocator::ApplyArgToParam:
@@ -2884,11 +2873,6 @@ bool ContextualFailure::diagnoseAsError() {
     }
 
     return true;
-  }
-
-  case ConstraintLocator::ResultBuilderBodyResult: {
-    diagnostic = *getDiagnosticFor(CTP_Initialization, toType);
-    break;
   }
 
   case ConstraintLocator::OptionalInjection: {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7136,17 +7136,6 @@ bool ConstraintSystem::repairFailures(
     return true;
   }
 
-  case ConstraintLocator::ResultBuilderBodyResult: {
-    // If result type of the body couldn't be determined
-    // there is going to be other fix available to diagnose
-    // the underlying issue.
-    if (lhs->isPlaceholder())
-      return true;
-
-    conversionsOrFixes.push_back(ContextualMismatch::create(
-        *this, lhs, rhs, getConstraintLocator(locator)));
-    break;
-  }
   case ConstraintLocator::GlobalActorType: {
     // Drop global actor element as it servers only to indentify the global
     // actor matching.

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -49,7 +49,6 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
   case ConstraintLocator::ClosureBody:
   case ConstraintLocator::ConstructorMember:
   case ConstraintLocator::ConstructorMemberType:
-  case ConstraintLocator::ResultBuilderBodyResult:
   case ConstraintLocator::InstanceType:
   case ConstraintLocator::AutoclosureResult:
   case ConstraintLocator::OptionalInjection:
@@ -217,10 +216,6 @@ void LocatorPathElt::dump(raw_ostream &out) const {
 
   case ConstraintLocator::FunctionResult:
     out << "function result";
-    break;
-
-  case ConstraintLocator::ResultBuilderBodyResult:
-    out << "result builder body result";
     break;
 
   case ConstraintLocator::SequenceElementType:
@@ -681,10 +676,6 @@ bool ConstraintLocator::isForCoercion() const {
 
 bool ConstraintLocator::isForOptionalTry() const {
   return directlyAt<OptionalTryExpr>();
-}
-
-bool ConstraintLocator::isForResultBuilderBodyResult() const {
-  return isFirstElement<LocatorPathElt::ResultBuilderBodyResult>();
 }
 
 bool ConstraintLocator::isForMacroExpansion() const {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3784,11 +3784,6 @@ void constraints::simplifyLocator(ASTNode &anchor,
       break;
     }
 
-    case ConstraintLocator::ResultBuilderBodyResult: {
-      path = path.slice(1);
-      break;
-    }
-
     case ConstraintLocator::UnresolvedMemberChainResult: {
       auto *resultExpr = castToExpr<UnresolvedMemberChainResultExpr>(anchor);
       anchor = resultExpr->getSubExpr();


### PR DESCRIPTION
Seems like this has been dead since the result builder rework.