### PR TITLE
Support Hashable generic requirements and Dictionary in C++ interop

### DIFF
--- a/docs/CppInteroperability/CppInteroperabilityStatus.md
+++ b/docs/CppInteroperability/CppInteroperabilityStatus.md
@@ -238,3 +238,4 @@ This status table describes which of the following Swift standard library APIs h
 | `String`     | Can be used as a type in C++. APIs in extensions are not exposed to C++. Conversion between `std.string` is not yet supported   |
 | `Array<T>`   | Can be used as a type in C++. Ranged for loops are supported. Limited set of APIs in some extensions are exposed to C++. |
 | `Optional<T>`   | Can be used as a type in C++. Can be constructed. `get` extracts the optional value and it's also implicitly castable to `bool`.  |
+| `Dictionary<K, V>`   | Can be used as a type in C++ outside Embedded Swift. Can be constructed. Key lookup via `operator []` returns an `Optional`, mutation via `updateValueForKey` / `removeValueForKey`. Iteration over keys/values is not yet supported. |

--- a/docs/CppInteroperability/CppInteroperabilityStatus.md
+++ b/docs/CppInteroperability/CppInteroperabilityStatus.md
@@ -205,11 +205,29 @@ Swift functions can be called from C++, with some restrictions. See this table f
 
 | **Swift Language Feature**   | **Implemented Experimental Support For Using It In C++** |
 |------------------------------|----------------------------------------------------------|
-| Generic functions            | Partially, only without generic constraints              |
-| Generic methods              | Partially, only without generic constraints              |
-| Generic `struct` types       | Partially, only without generic constraints and less than 4 generic parameters             |
-| Generic `enum` types         | Partially, only without generic constraints and less than 4 generic parameters |
+| Generic functions            | Partially; direct `Hashable` requirements on generic parameters are supported outside Embedded Swift |
+| Generic methods              | Partially; direct `Hashable` requirements on generic parameters are supported outside Embedded Swift |
+| Generic `struct` types       | Partially; direct `Hashable` requirements are supported outside Embedded Swift, with at most three combined type metadata and conformance arguments |
+| Generic `enum` types         | Partially; direct `Hashable` requirements are supported outside Embedded Swift, with at most three combined type metadata and conformance arguments |
 | Generic `class` types        | No |
+
+Generated C++ templates cannot statically enforce Swift protocol conformances.
+When a generated API has a `Hashable` requirement, the conformance is looked up
+from the Swift type metadata at runtime. Using the API with a type that does not
+have a loaded Swift `Hashable` conformance terminates the process with a fatal
+error. When the runtime and concurrency runtime can enforce an isolated
+conformance, the generated binding checks that execution is on the
+conformance's global-actor executor before passing its witness table to the
+generic API. Configurations that cannot perform this check—including older
+Apple back-deployment runtimes and runtimes without the concurrency hook—retain
+the legacy lookup behavior and cannot reject off-actor use. Runtime-discovered
+conformances must be present in a loaded image at lookup time. If a conformance
+is defined only in an otherwise-unreferenced member of a static archive, the
+linker must be instructed to load that member.
+Runtime witness-table lookup is limited to direct `Hashable` requirements; this
+does not expose arbitrary Swift protocols.
+This support does not make protocol existential or opaque result types such as
+`any Hashable` or `some Hashable` representable in C++.
 
 ### Swift standard library
 

--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticsSema.h"
+#include "swift/AST/KnownProtocols.h"
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/ParameterList.h"
@@ -323,6 +324,12 @@ swift::cxx_translation::getDeclRepresentation(
   if (isa<MacroDecl>(VD))
     return {Unsupported, UnrepresentableMacro};
   GenericSignature genericSignature;
+  // A declaration can be contextually generic without declaring generic
+  // parameters of its own. Validate the full signature so inherited
+  // requirements and requirements on subscripts cannot bypass the C++
+  // representability checks below.
+  if (auto *genericContext = VD->getAsGenericContext())
+    genericSignature = genericContext->getGenericSignature();
   // Don't expose decls with definitions that are emitted into the client.
   if (VD->isAlwaysEmittedIntoClient())
     return {Unsupported, UnrepresentableRequiresClientEmission};
@@ -333,8 +340,6 @@ swift::cxx_translation::getDeclRepresentation(
         !AFD->getASTContext().LangOpts.hasFeature(
             Feature::GenerateBindingsForThrowingFunctionsInCXX))
       return {Unsupported, UnrepresentableThrows};
-    if (AFD->hasGenericParamList())
-      genericSignature = AFD->getGenericSignature();
   }
   if (const auto *typeDecl = dyn_cast<NominalTypeDecl>(VD)) {
     if (isa<ProtocolDecl>(typeDecl)) {
@@ -349,11 +354,8 @@ swift::cxx_translation::getDeclRepresentation(
       return {Unsupported, UnrepresentableMoveOnly};
     if (isa<ClassDecl>(VD) && VD->isObjC())
       return {Unsupported, UnrepresentableObjC};
-    if (typeDecl->hasGenericParamList()) {
-      if (isa<ClassDecl>(VD))
-        return {Unsupported, UnrepresentableGeneric};
-      genericSignature = typeDecl->getGenericSignature();
-    }
+    if (isa<ClassDecl>(VD) && genericSignature)
+      return {Unsupported, UnrepresentableGeneric};
     if (!isa<ClassDecl>(typeDecl) && isZeroSized && (*isZeroSized)(typeDecl))
       return {Unsupported, UnrepresentableZeroSizedValueType};
   }
@@ -392,7 +394,8 @@ swift::cxx_translation::getDeclRepresentation(
     }
   }
 
-  // Generic requirements are not yet supported in C++.
+  // Reject generic requirements that the generated C++ binding cannot
+  // instantiate.
   if (!isExposableToCxx(genericSignature)) {
     return {Unsupported, UnrepresentableGenericRequirements};
   }
@@ -446,8 +449,22 @@ bool swift::cxx_translation::isExposableToCxx(GenericSignature genericSig) {
         return false;
 
       auto proto = req.getProtocolDecl();
-      if (!proto->isMarkerProtocol() && !proto->hasClangNode())
-        return false;
+      if (proto->isMarkerProtocol() || proto->hasClangNode())
+        continue;
+
+      // Conformance requirements to a small set of known standard library
+      // protocols are representable: the generated C++ code instantiates
+      // the required witness table via the Swift runtime. This is what
+      // allows e.g. `Dictionary<Key: Hashable, Value>` to be exposed.
+      // Restrict this to requirements directly on a generic parameter, as
+      // the generated code cannot obtain type metadata for a dependent
+      // member type. Embedded Swift has no runtime conformance lookup.
+      if (proto->isSpecificProtocol(KnownProtocolKind::Hashable) &&
+          req.getFirstType()->is<GenericTypeParamType>() &&
+          !proto->getASTContext().LangOpts.hasFeature(Feature::Embedded))
+        continue;
+
+      return false;
     }
   }
 

--- a/lib/PrintAsClang/ClangSyntaxPrinter.cpp
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.cpp
@@ -21,6 +21,7 @@
 #include "swift/AST/Type.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/IRGen/Linking.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclTemplate.h"
@@ -336,11 +337,9 @@ void ClangSyntaxPrinter::printValueWitnessTableAccessSequenceFromTypeMetadata(
 void ClangSyntaxPrinter::printCTypeMetadataTypeFunction(
     const TypeDecl *typeDecl, StringRef typeMetadataFuncName,
     llvm::ArrayRef<GenericRequirement> genericRequirements) {
-  // FIXME: Support generic requirements > 3.
-  if (!genericRequirements.empty())
-    os << "static_assert(" << genericRequirements.size()
-       << " <= " << NumDirectGenericTypeMetadataAccessFunctionArgs
-       << ", \"unsupported generic requirement list for metadata func\");\n";
+  assert(genericRequirements.size() <=
+             NumDirectGenericTypeMetadataAccessFunctionArgs &&
+         "generic metadata accessor requires an indirect argument buffer");
   os << "// Type metadata accessor for " << typeDecl->getNameStr() << "\n";
   os << "SWIFT_EXTERN ";
   printSwiftImplQualifier();
@@ -411,10 +410,25 @@ void ClangSyntaxPrinter::printGenericSignatureParams(
 
 void ClangSyntaxPrinter::printGenericRequirementInstantiantion(
     const GenericRequirement &requirement) {
-  assert(requirement.isAnyMetadata() &&
-         "protocol requirements not supported yet!");
+  assert((requirement.isAnyMetadata() || requirement.isAnyWitnessTable()) &&
+         "unsupported generic requirement");
   auto *gtpt = requirement.getTypeParameter()->getAs<GenericTypeParamType>();
   assert(gtpt && "unexpected generic param type");
+  if (requirement.isAnyWitnessTable()) {
+    // Instantiate the witness table for the required protocol conformance
+    // via the Swift runtime.
+    auto *proto = requirement.getProtocol();
+    std::string protocolDescriptorName =
+        irgen::LinkEntity::forProtocolDescriptor(proto).mangleAsString(
+            proto->getASTContext());
+    printSwiftImplQualifier();
+    os << "getConformanceWitnessTable<";
+    printGenericTypeParamTypeName(gtpt);
+    os << ", &";
+    printSwiftImplQualifier();
+    os << protocolDescriptorName << ">()";
+    return;
+  }
   os << "swift::TypeMetadataTrait<";
   printGenericTypeParamTypeName(gtpt);
   os << ">::getTypeMetadata()";

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -3046,6 +3046,8 @@ static bool hasExposeAttr(const ValueDecl *VD) {
       return true;
     if (VD == VD->getASTContext().getArrayDecl())
       return true;
+    if (VD == VD->getASTContext().getDictionaryDecl())
+      return true;
     if (VD == VD->getASTContext().getOptionalDecl())
       return true;
     if (isStringNestedType(VD, "UTF8View") || isStringNestedType(VD, "Index"))

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -3056,6 +3056,8 @@ static bool hasExposeAttr(const ValueDecl *VD) {
       return true;
     if (VD == VD->getASTContext().getArrayDecl())
       return true;
+    if (VD == VD->getASTContext().getDictionaryDecl())
+      return true;
     if (VD == VD->getASTContext().getOptionalDecl())
       return true;
     if (isStringNestedType(VD, "UTF8View") || isStringNestedType(VD, "Index"))

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -19,6 +19,7 @@
 #include "PrintClangValueType.h"
 #include "SwiftToClangInteropContext.h"
 
+#include "swift/ABI/MetadataValues.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/ASTVisitor.h"
@@ -54,6 +55,8 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/raw_ostream.h"
+#include <algorithm>
+#include <utility>
 
 using namespace swift;
 using namespace swift::objc_translation;
@@ -122,6 +125,32 @@ struct CxxEmissionScopeRAII {
   }
   ~CxxEmissionScopeRAII() { printer.setCxxDeclEmissionScope(prevScope); }
 };
+
+static StringRef getCxxOverloadName(const ValueDecl *valueDecl) {
+  if (isa<SubscriptDecl>(valueDecl))
+    return "operator []";
+  return cxx_translation::getNameForCxx(valueDecl);
+}
+
+static bool isCxxOverloadCandidate(const ValueDecl *valueDecl) {
+  return isa<SubscriptDecl>(valueDecl) ||
+         (isa<AbstractFunctionDecl>(valueDecl) &&
+          !isa<AccessorDecl>(valueDecl));
+}
+
+/// Returns the number of Swift generic requirements used to prioritize
+/// declarations within a C++ overload set. This only determines visitation
+/// order; final signature collisions are detected after ABI validation.
+static unsigned
+getGenericRequirementCountForCxxOverload(const ValueDecl *valueDecl) {
+  auto *genericContext = valueDecl->getAsGenericContext();
+  if (!genericContext)
+    return 0;
+  auto genericSignature = genericContext->getGenericSignature();
+  if (!genericSignature)
+    return 0;
+  return genericSignature.getRequirements().size();
+}
 
 class DeclAndTypePrinter::Implementation
     : private DeclVisitor<DeclAndTypePrinter::Implementation>,
@@ -250,12 +279,42 @@ private:
     os << ";\n";
   }
 
+  /// Returns the C++ parameter type strings for a function as they would
+  /// appear in the C++ inline thunk signature.
+  llvm::SmallVector<std::string, 4>
+  getCxxParamTypes(const AbstractFunctionDecl *funcDecl) const {
+    llvm::SmallVector<std::string, 4> result;
+    auto *params = funcDecl->getParameters();
+    if (!params)
+      return result;
+    auto *emittedModule = funcDecl->getModuleContext();
+    for (auto *param : *params) {
+      auto type = param->getInterfaceType();
+      // In C++ different integer types have different bitwidths. To
+      // avoid producing redefinition errors, we are conservative with
+      // these types and consider all integral types the same.
+      if (type->isStdlibInteger()) {
+        result.push_back("int");
+      } else {
+        std::string typeStr;
+        llvm::raw_string_ostream typeOS(typeStr);
+        owningPrinter.printTypeName(typeOS, type, emittedModule);
+        result.push_back(typeStr);
+      }
+    }
+    return result;
+  }
+
   /// Prints the members of a class, extension, or protocol.
   template <bool AllowDelayed = false, typename R>
   void printMembers(R &&members) {
+    SmallVector<const Decl *, 32> orderedMembers;
+    for (const Decl *member : members)
+      orderedMembers.push_back(member);
+
     // Using statements for nested types.
     if (outputLang == OutputLanguageMode::Cxx) {
-      for (const Decl *member : members) {
+      for (const Decl *member : orderedMembers) {
         if (member->getModuleContext()->isStdlibModule())
           break;
         auto VD = dyn_cast<ValueDecl>(member);
@@ -264,9 +323,10 @@ private:
         if (const auto *TD = dyn_cast<NominalTypeDecl>(member))
           printUsingForNestedType(TD, TD->getModuleContext());
       }
+      owningPrinter.orderCxxOverloadsForEmission(orderedMembers);
     }
     bool protocolMembersOptional = false;
-    for (const Decl *member : members) {
+    for (const Decl *member : orderedMembers) {
       auto VD = dyn_cast<ValueDecl>(member);
       if (!VD || !shouldInclude(VD) || isa<TypeDecl>(VD))
         continue;
@@ -421,6 +481,27 @@ private:
     os << "@end\n";
   }
 
+  /// Returns true if the members of the given extension should be included
+  /// in the C++ class that represents the extended nominal type.
+  bool shouldIncludeExtensionMembersInCxx(const ExtensionDecl *ext) {
+    return cxx_translation::isExposableToCxx(ext->getGenericSignature());
+  }
+
+  SmallVector<const Decl *, 32>
+  getCxxValueTypeMembers(const NominalTypeDecl *nominal) {
+    SmallVector<const Decl *, 32> members;
+    for (const auto *member : nominal->getAllMembers())
+      members.push_back(member);
+    for (const auto *ext :
+         owningPrinter.interopContext.getExtensionsForNominalType(nominal)) {
+      if (!shouldIncludeExtensionMembersInCxx(ext))
+        continue;
+      for (const auto *member : ext->getAllMembers())
+        members.push_back(member);
+    }
+    return members;
+  }
+
   void visitStructDecl(StructDecl *SD) {
     if (outputLang != OutputLanguageMode::Cxx)
       return;
@@ -431,14 +512,8 @@ private:
         SD, /*bodyPrinter=*/
         [&]() {
           CxxEmissionScopeRAII cxxScopeRAII(owningPrinter);
-          printMembers(SD->getAllMembers());
-          for (const auto *ed :
-               owningPrinter.interopContext.getExtensionsForNominalType(SD)) {
-            if (!cxx_translation::isExposableToCxx(ed->getGenericSignature()))
-              continue;
-
-            printMembers(ed->getAllMembers());
-          }
+          auto members = getCxxValueTypeMembers(SD);
+          printMembers(members);
         },
         owningPrinter);
     recordEmittedDeclInCurrentCxxLexicalScope(SD);
@@ -940,15 +1015,8 @@ private:
           os << "\n";
 
           CxxEmissionScopeRAII cxxScopeRAII(owningPrinter);
-          printMembers(ED->getAllMembers());
-
-          for (const auto *ext :
-               owningPrinter.interopContext.getExtensionsForNominalType(ED)) {
-            if (!cxx_translation::isExposableToCxx(ext->getGenericSignature()))
-              continue;
-
-            printMembers(ext->getAllMembers());
-          }
+          auto members = getCxxValueTypeMembers(ED);
+          printMembers(members);
         },
         owningPrinter);
     recordEmittedDeclInCurrentCxxLexicalScope(ED);
@@ -1112,32 +1180,6 @@ private:
            sel.getSelectorPieces().front().str() == "init";
   }
 
-  /// Returns the C++ parameter type strings for a function as they would
-  /// appear in the C++ inline thunk signature.
-  llvm::SmallVector<std::string, 4>
-  getCxxParamTypes(const AbstractFunctionDecl *funcDecl) const {
-    llvm::SmallVector<std::string, 4> result;
-    auto *params = funcDecl->getParameters();
-    if (!params)
-      return result;
-    auto *emittedModule = funcDecl->getModuleContext();
-    for (auto *param : *params) {
-      auto type = param->getInterfaceType();
-      // In C++ different integer types have different bitwidths. To
-      // avoid producing redefinition errors, we are conservative with
-      // these types and consider all integral types the same.
-      if (type->isStdlibInteger()) {
-        result.push_back("int");
-      } else {
-        std::string typeStr;
-        llvm::raw_string_ostream typeOS(typeStr);
-        owningPrinter.printTypeName(typeOS, type, emittedModule);
-        result.push_back(typeStr);
-      }
-    }
-    return result;
-  }
-
   /// Returns true if the given function overload is safe to emit in the current
   /// C++ lexical scope. If \p cxxNameOverride is non-empty, it is used as the
   /// C++ function name instead of the default name derived from the
@@ -1214,19 +1256,18 @@ private:
       // Check for naming conflicts between accessors and explicit methods
       // using the unified emittedFunctionOverloads map.
       if (auto *accessor = dyn_cast<AccessorDecl>(AFD)) {
-        // Subscript accessors emit as operator[] and cannot conflict with
-        // named methods, so skip the overload check for them.
-        if (!SD) {
-          std::string remappedName = remapPropertyName(accessor, resultTy);
-          if (!canPrintOverloadOfFunction(AFD, remappedName)) {
+        std::string remappedName =
+            SD ? "operator []" : remapPropertyName(accessor, resultTy);
+        if (!canPrintOverloadOfFunction(AFD, remappedName)) {
+          if (!SD) {
             auto comment = ("  // skip emitting accessor method for \'" +
                             accessor->getStorage()->getBaseIdentifier().str() +
                             "\'. \'" + remappedName + "\' already declared.\n")
                                .str();
             os << comment;
             owningPrinter.outOfLineDefinitionsOS << comment;
-            return;
           }
+          return;
         }
       } else {
         if (!canPrintOverloadOfFunction(AFD))
@@ -3135,6 +3176,20 @@ static bool isEnumExposableToCxx(const ValueDecl *VD,
   return true;
 }
 
+static bool hasSupportedGenericMetadataAccessor(const ValueDecl *VD,
+                                                DeclAndTypePrinter &printer) {
+  auto *nominal = dyn_cast<NominalTypeDecl>(VD);
+  if (!nominal)
+    return true;
+
+  auto requirements =
+      printer.getInteropContext()
+          .getIrABIDetails()
+          .getTypeMetadataAccessFunctionGenericRequirementParameters(
+              const_cast<NominalTypeDecl *>(nominal));
+  return requirements.size() <= NumDirectGenericTypeMetadataAccessFunctionArgs;
+}
+
 bool DeclAndTypePrinter::shouldInclude(const ValueDecl *VD) {
   if (VD->isInvalid())
     return false;
@@ -3154,6 +3209,8 @@ bool DeclAndTypePrinter::shouldInclude(const ValueDecl *VD) {
     if (!cxx_translation::isExposableToCxx(
             VD,
             [this](const NominalTypeDecl *decl) { return isZeroSized(decl); }))
+      return false;
+    if (!hasSupportedGenericMetadataAccessor(VD, *this))
       return false;
     if (!isEnumExposableToCxx(VD, *this))
       return false;
@@ -3231,6 +3288,47 @@ void DeclAndTypePrinter::printTypeName(raw_ostream &os, Type ty,
 
 void DeclAndTypePrinter::printAvailability(raw_ostream &os, const Decl *D) {
   getImpl().printAvailability(os, D);
+}
+
+/// Swift generic requirements are erased from C++ function signatures. Within
+/// each C++ overload set, visit declarations with fewer requirements first so
+/// an unconstrained thunk claims a colliding signature when possible.
+///
+/// Do not predict signature collisions here: computing final C++ parameter
+/// spellings can emit supporting stubs, and detailed ABI representability is
+/// established later. The existing overload tracker remains authoritative
+/// after those checks. Reordering all same-named candidates, rather than
+/// preselecting one, also lets a later candidate claim the signature if the
+/// preferred declaration proves unprintable.
+void DeclAndTypePrinter::orderCxxOverloadsForEmission(
+    MutableArrayRef<const Decl *> declarations) {
+  struct OverloadGroup {
+    SmallVector<size_t, 2> positions;
+    SmallVector<const Decl *, 2> declarations;
+  };
+
+  llvm::StringMap<OverloadGroup> groupsByName;
+  for (size_t index = 0; index < declarations.size(); ++index) {
+    auto *valueDecl = dyn_cast<ValueDecl>(declarations[index]);
+    if (!valueDecl || !isCxxOverloadCandidate(valueDecl) ||
+        !shouldInclude(valueDecl))
+      continue;
+
+    auto &group = groupsByName[getCxxOverloadName(valueDecl)];
+    group.positions.push_back(index);
+    group.declarations.push_back(declarations[index]);
+  }
+
+  for (auto &nameAndGroup : groupsByName) {
+    auto &group = nameAndGroup.second;
+    llvm::stable_sort(group.declarations, [](const Decl *lhs, const Decl *rhs) {
+      return getGenericRequirementCountForCxxOverload(cast<ValueDecl>(lhs)) <
+             getGenericRequirementCountForCxxOverload(cast<ValueDecl>(rhs));
+    });
+    for (auto [position, declaration] :
+         llvm::zip_equal(group.positions, group.declarations))
+      declarations[position] = declaration;
+  }
 }
 
 void DeclAndTypePrinter::printAdHocCategory(

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -19,6 +19,7 @@
 #include "PrintClangValueType.h"
 #include "SwiftToClangInteropContext.h"
 
+#include "swift/ABI/MetadataValues.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/ASTVisitor.h"
@@ -54,6 +55,8 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/raw_ostream.h"
+#include <algorithm>
+#include <utility>
 
 using namespace swift;
 using namespace swift::objc_translation;
@@ -122,6 +125,32 @@ struct CxxEmissionScopeRAII {
   }
   ~CxxEmissionScopeRAII() { printer.setCxxDeclEmissionScope(prevScope); }
 };
+
+static StringRef getCxxOverloadName(const ValueDecl *valueDecl) {
+  if (isa<SubscriptDecl>(valueDecl))
+    return "operator []";
+  return cxx_translation::getNameForCxx(valueDecl);
+}
+
+static bool isCxxOverloadCandidate(const ValueDecl *valueDecl) {
+  return isa<SubscriptDecl>(valueDecl) ||
+         (isa<AbstractFunctionDecl>(valueDecl) &&
+          !isa<AccessorDecl>(valueDecl));
+}
+
+/// Returns the number of Swift generic requirements used to prioritize
+/// declarations within a C++ overload set. This only determines visitation
+/// order; final signature collisions are detected after ABI validation.
+static unsigned
+getGenericRequirementCountForCxxOverload(const ValueDecl *valueDecl) {
+  auto *genericContext = valueDecl->getAsGenericContext();
+  if (!genericContext)
+    return 0;
+  auto genericSignature = genericContext->getGenericSignature();
+  if (!genericSignature)
+    return 0;
+  return genericSignature.getRequirements().size();
+}
 
 class DeclAndTypePrinter::Implementation
     : private DeclVisitor<DeclAndTypePrinter::Implementation>,
@@ -252,12 +281,42 @@ private:
     os << ";\n";
   }
 
+  /// Returns the C++ parameter type strings for a function as they would
+  /// appear in the C++ inline thunk signature.
+  llvm::SmallVector<std::string, 4>
+  getCxxParamTypes(const AbstractFunctionDecl *funcDecl) const {
+    llvm::SmallVector<std::string, 4> result;
+    auto *params = funcDecl->getParameters();
+    if (!params)
+      return result;
+    auto *emittedModule = funcDecl->getModuleContext();
+    for (auto *param : *params) {
+      auto type = param->getInterfaceType();
+      // In C++ different integer types have different bitwidths. To
+      // avoid producing redefinition errors, we are conservative with
+      // these types and consider all integral types the same.
+      if (type->isStdlibInteger()) {
+        result.push_back("int");
+      } else {
+        std::string typeStr;
+        llvm::raw_string_ostream typeOS(typeStr);
+        owningPrinter.printTypeName(typeOS, type, emittedModule);
+        result.push_back(typeStr);
+      }
+    }
+    return result;
+  }
+
   /// Prints the members of a class, extension, or protocol.
   template <bool AllowDelayed = false, typename R>
   void printMembers(R &&members) {
+    SmallVector<const Decl *, 32> orderedMembers;
+    for (const Decl *member : members)
+      orderedMembers.push_back(member);
+
     // Using statements for nested types.
     if (outputLang == OutputLanguageMode::Cxx) {
-      for (const Decl *member : members) {
+      for (const Decl *member : orderedMembers) {
         if (member->getModuleContext()->isStdlibModule())
           break;
         auto VD = dyn_cast<ValueDecl>(member);
@@ -266,9 +325,10 @@ private:
         if (const auto *TD = dyn_cast<NominalTypeDecl>(member))
           printUsingForNestedType(TD, TD->getModuleContext());
       }
+      owningPrinter.orderCxxOverloadsForEmission(orderedMembers);
     }
     bool protocolMembersOptional = false;
-    for (const Decl *member : members) {
+    for (const Decl *member : orderedMembers) {
       auto VD = dyn_cast<ValueDecl>(member);
       if (!VD || !shouldInclude(VD) || isa<TypeDecl>(VD))
         continue;
@@ -423,6 +483,27 @@ private:
     os << "@end\n";
   }
 
+  /// Returns true if the members of the given extension should be included
+  /// in the C++ class that represents the extended nominal type.
+  bool shouldIncludeExtensionMembersInCxx(const ExtensionDecl *ext) {
+    return cxx_translation::isExposableToCxx(ext->getGenericSignature());
+  }
+
+  SmallVector<const Decl *, 32>
+  getCxxValueTypeMembers(const NominalTypeDecl *nominal) {
+    SmallVector<const Decl *, 32> members;
+    for (const auto *member : nominal->getAllMembers())
+      members.push_back(member);
+    for (const auto *ext :
+         owningPrinter.interopContext.getExtensionsForNominalType(nominal)) {
+      if (!shouldIncludeExtensionMembersInCxx(ext))
+        continue;
+      for (const auto *member : ext->getAllMembers())
+        members.push_back(member);
+    }
+    return members;
+  }
+
   void visitStructDecl(StructDecl *SD) {
     if (outputLang != OutputLanguageMode::Cxx)
       return;
@@ -433,14 +514,8 @@ private:
         SD, /*bodyPrinter=*/
         [&]() {
           CxxEmissionScopeRAII cxxScopeRAII(owningPrinter);
-          printMembers(SD->getAllMembers());
-          for (const auto *ed :
-               owningPrinter.interopContext.getExtensionsForNominalType(SD)) {
-            if (!cxx_translation::isExposableToCxx(ed->getGenericSignature()))
-              continue;
-
-            printMembers(ed->getAllMembers());
-          }
+          auto members = getCxxValueTypeMembers(SD);
+          printMembers(members);
         },
         owningPrinter);
     recordEmittedDeclInCurrentCxxLexicalScope(SD);
@@ -930,15 +1005,8 @@ private:
           os << "\n";
 
           CxxEmissionScopeRAII cxxScopeRAII(owningPrinter);
-          printMembers(ED->getAllMembers());
-
-          for (const auto *ext :
-               owningPrinter.interopContext.getExtensionsForNominalType(ED)) {
-            if (!cxx_translation::isExposableToCxx(ext->getGenericSignature()))
-              continue;
-
-            printMembers(ext->getAllMembers());
-          }
+          auto members = getCxxValueTypeMembers(ED);
+          printMembers(members);
         },
         owningPrinter);
     recordEmittedDeclInCurrentCxxLexicalScope(ED);
@@ -1102,32 +1170,6 @@ private:
            sel.getSelectorPieces().front().str() == "init";
   }
 
-  /// Returns the C++ parameter type strings for a function as they would
-  /// appear in the C++ inline thunk signature.
-  llvm::SmallVector<std::string, 4>
-  getCxxParamTypes(const AbstractFunctionDecl *funcDecl) const {
-    llvm::SmallVector<std::string, 4> result;
-    auto *params = funcDecl->getParameters();
-    if (!params)
-      return result;
-    auto *emittedModule = funcDecl->getModuleContext();
-    for (auto *param : *params) {
-      auto type = param->getInterfaceType();
-      // In C++ different integer types have different bitwidths. To
-      // avoid producing redefinition errors, we are conservative with
-      // these types and consider all integral types the same.
-      if (type->isStdlibInteger()) {
-        result.push_back("int");
-      } else {
-        std::string typeStr;
-        llvm::raw_string_ostream typeOS(typeStr);
-        owningPrinter.printTypeName(typeOS, type, emittedModule);
-        result.push_back(typeStr);
-      }
-    }
-    return result;
-  }
-
   /// Returns true if the given function overload is safe to emit in the current
   /// C++ lexical scope. If \p cxxNameOverride is non-empty, it is used as the
   /// C++ function name instead of the default name derived from the
@@ -1204,19 +1246,18 @@ private:
       // Check for naming conflicts between accessors and explicit methods
       // using the unified emittedFunctionOverloads map.
       if (auto *accessor = dyn_cast<AccessorDecl>(AFD)) {
-        // Subscript accessors emit as operator[] and cannot conflict with
-        // named methods, so skip the overload check for them.
-        if (!SD) {
-          std::string remappedName = remapPropertyName(accessor, resultTy);
-          if (!canPrintOverloadOfFunction(AFD, remappedName)) {
+        std::string remappedName =
+            SD ? "operator []" : remapPropertyName(accessor, resultTy);
+        if (!canPrintOverloadOfFunction(AFD, remappedName)) {
+          if (!SD) {
             auto comment = ("  // skip emitting accessor method for \'" +
                             accessor->getStorage()->getBaseIdentifier().str() +
                             "\'. \'" + remappedName + "\' already declared.\n")
                                .str();
             os << comment;
             owningPrinter.outOfLineDefinitionsOS << comment;
-            return;
           }
+          return;
         }
       } else {
         if (!canPrintOverloadOfFunction(AFD))
@@ -3125,6 +3166,20 @@ static bool isEnumExposableToCxx(const ValueDecl *VD,
   return true;
 }
 
+static bool hasSupportedGenericMetadataAccessor(const ValueDecl *VD,
+                                                DeclAndTypePrinter &printer) {
+  auto *nominal = dyn_cast<NominalTypeDecl>(VD);
+  if (!nominal)
+    return true;
+
+  auto requirements =
+      printer.getInteropContext()
+          .getIrABIDetails()
+          .getTypeMetadataAccessFunctionGenericRequirementParameters(
+              const_cast<NominalTypeDecl *>(nominal));
+  return requirements.size() <= NumDirectGenericTypeMetadataAccessFunctionArgs;
+}
+
 bool DeclAndTypePrinter::shouldInclude(const ValueDecl *VD) {
   if (VD->isInvalid())
     return false;
@@ -3144,6 +3199,8 @@ bool DeclAndTypePrinter::shouldInclude(const ValueDecl *VD) {
     if (!cxx_translation::isExposableToCxx(
             VD,
             [this](const NominalTypeDecl *decl) { return isZeroSized(decl); }))
+      return false;
+    if (!hasSupportedGenericMetadataAccessor(VD, *this))
       return false;
     if (!isEnumExposableToCxx(VD, *this))
       return false;
@@ -3221,6 +3278,47 @@ void DeclAndTypePrinter::printTypeName(raw_ostream &os, Type ty,
 
 void DeclAndTypePrinter::printAvailability(raw_ostream &os, const Decl *D) {
   getImpl().printAvailability(os, D);
+}
+
+/// Swift generic requirements are erased from C++ function signatures. Within
+/// each C++ overload set, visit declarations with fewer requirements first so
+/// an unconstrained thunk claims a colliding signature when possible.
+///
+/// Do not predict signature collisions here: computing final C++ parameter
+/// spellings can emit supporting stubs, and detailed ABI representability is
+/// established later. The existing overload tracker remains authoritative
+/// after those checks. Reordering all same-named candidates, rather than
+/// preselecting one, also lets a later candidate claim the signature if the
+/// preferred declaration proves unprintable.
+void DeclAndTypePrinter::orderCxxOverloadsForEmission(
+    MutableArrayRef<const Decl *> declarations) {
+  struct OverloadGroup {
+    SmallVector<size_t, 2> positions;
+    SmallVector<const Decl *, 2> declarations;
+  };
+
+  llvm::StringMap<OverloadGroup> groupsByName;
+  for (size_t index = 0; index < declarations.size(); ++index) {
+    auto *valueDecl = dyn_cast<ValueDecl>(declarations[index]);
+    if (!valueDecl || !isCxxOverloadCandidate(valueDecl) ||
+        !shouldInclude(valueDecl))
+      continue;
+
+    auto &group = groupsByName[getCxxOverloadName(valueDecl)];
+    group.positions.push_back(index);
+    group.declarations.push_back(declarations[index]);
+  }
+
+  for (auto &nameAndGroup : groupsByName) {
+    auto &group = nameAndGroup.second;
+    llvm::stable_sort(group.declarations, [](const Decl *lhs, const Decl *rhs) {
+      return getGenericRequirementCountForCxxOverload(cast<ValueDecl>(lhs)) <
+             getGenericRequirementCountForCxxOverload(cast<ValueDecl>(rhs));
+    });
+    for (auto [position, declaration] :
+         llvm::zip_equal(group.positions, group.declarations))
+      declarations[position] = declaration;
+  }
 }
 
 void DeclAndTypePrinter::printAdHocCategory(

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -133,6 +133,11 @@ static StringRef getCxxOverloadName(const ValueDecl *valueDecl) {
 }
 
 static bool isCxxOverloadCandidate(const ValueDecl *valueDecl) {
+  // Destructors are emitted as the C++ destructor of the type they belong to,
+  // so they never participate in an overload set. They are also named by a
+  // special base name that has no C++ spelling.
+  if (isa<DestructorDecl>(valueDecl))
+    return false;
   return isa<SubscriptDecl>(valueDecl) ||
          (isa<AbstractFunctionDecl>(valueDecl) &&
           !isa<AccessorDecl>(valueDecl));

--- a/lib/PrintAsClang/DeclAndTypePrinter.h
+++ b/lib/PrintAsClang/DeclAndTypePrinter.h
@@ -22,6 +22,7 @@
 // for OptionalTypeKind
 #include "swift/AST/TypeRepr.h"
 #include "swift/ClangImporter/ClangImporter.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/StringSet.h"
 
@@ -148,6 +149,11 @@ public:
   void printTypeName(raw_ostream &os, Type ty, const ModuleDecl *moduleContext);
 
   void printAvailability(raw_ostream &os, const Decl *D);
+
+  /// Orders potential C++ overload collisions so declarations with fewer
+  /// generic requirements are attempted first. Final collision detection still
+  /// happens after ABI validation while printing.
+  void orderCxxOverloadsForEmission(MutableArrayRef<const Decl *> declarations);
 
   /// Is \p ED empty of members and protocol conformances to include?
   bool isEmptyExtensionDecl(const ExtensionDecl *ED);

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -43,6 +43,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/Support/raw_ostream.h"
+#include <algorithm>
 #include <utility>
 
 using namespace swift;
@@ -1014,6 +1015,12 @@ public:
     declsToWrite.assign(decls.begin(), decls.end());
 
     if (outputLangMode == OutputLanguageMode::Cxx) {
+      // `declsToWrite` is a stack, so temporarily put it in emission order
+      // while arranging potential overload collisions.
+      std::reverse(declsToWrite.begin(), declsToWrite.end());
+      printer.orderCxxOverloadsForEmission(declsToWrite);
+      std::reverse(declsToWrite.begin(), declsToWrite.end());
+
       for (const Decl *D : declsToWrite) {
         if (auto *ED = dyn_cast<ExtensionDecl>(D)) {
           const auto *type = ED->getExtendedNominal();

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -42,6 +42,7 @@
 
 #include "llvm/ADT/SetVector.h"
 #include "llvm/Support/raw_ostream.h"
+#include <algorithm>
 #include <utility>
 
 using namespace swift;
@@ -1018,6 +1019,12 @@ public:
     declsToWrite.assign(decls.begin(), decls.end());
 
     if (outputLangMode == OutputLanguageMode::Cxx) {
+      // `declsToWrite` is a stack, so temporarily put it in emission order
+      // while arranging potential overload collisions.
+      std::reverse(declsToWrite.begin(), declsToWrite.end());
+      printer.orderCxxOverloadsForEmission(declsToWrite);
+      std::reverse(declsToWrite.begin(), declsToWrite.end());
+
       for (const Decl *D : declsToWrite) {
         if (auto *ED = dyn_cast<ExtensionDecl>(D)) {
           const auto *type = ED->getExtendedNominal();

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -1073,12 +1073,10 @@ ClangRepresentation DeclAndTypeClangFunctionPrinter::printFunctionSignature(
                 &genericRequirementParam) {
           emitNewParam();
           functionSignatureOS << "void * _Nonnull ";
-          auto reqt = genericRequirementParam.getRequirement();
-          if (reqt.isAnyWitnessTable())
-            ClangSyntaxPrinter(FD->getASTContext(), functionSignatureOS)
-                .printBaseName(reqt.getProtocol());
-          else
-            assert(reqt.isAnyMetadata());
+          assert(
+              (genericRequirementParam.getRequirement().isAnyMetadata() ||
+               genericRequirementParam.getRequirement().isAnyWitnessTable()) &&
+              "unsupported generic requirement");
         },
         [&](const LoweredFunctionSignature::MetadataSourceParameter
                 &metadataSrcParam) {
@@ -1551,13 +1549,10 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
                 &genericRequirementParam) {
           emitNewParam();
           auto genericRequirement = genericRequirementParam.getRequirement();
-          // FIXME: Add protocol requirement support.
-          assert(genericRequirement.isAnyMetadata());
           if (auto *gtpt = genericRequirement.getTypeParameter()
                                ->getAs<GenericTypeParamType>()) {
-            os << "swift::TypeMetadataTrait<";
-            ClangSyntaxPrinter(gtpt->getASTContext(), os).printGenericTypeParamTypeName(gtpt);
-            os << ">::getTypeMetadata()";
+            ClangSyntaxPrinter(gtpt->getASTContext(), os)
+                .printGenericRequirementInstantiantion(genericRequirement);
             return;
           }
           os << "ERROR";

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -1079,12 +1079,10 @@ ClangRepresentation DeclAndTypeClangFunctionPrinter::printFunctionSignature(
                 &genericRequirementParam) {
           emitNewParam();
           functionSignatureOS << "void * _Nonnull ";
-          auto reqt = genericRequirementParam.getRequirement();
-          if (reqt.isAnyWitnessTable())
-            ClangSyntaxPrinter(FD->getASTContext(), functionSignatureOS)
-                .printBaseName(reqt.getProtocol());
-          else
-            assert(reqt.isAnyMetadata());
+          assert(
+              (genericRequirementParam.getRequirement().isAnyMetadata() ||
+               genericRequirementParam.getRequirement().isAnyWitnessTable()) &&
+              "unsupported generic requirement");
         },
         [&](const LoweredFunctionSignature::MetadataSourceParameter
                 &metadataSrcParam) {
@@ -1526,13 +1524,10 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
                 &genericRequirementParam) {
           emitNewParam();
           auto genericRequirement = genericRequirementParam.getRequirement();
-          // FIXME: Add protocol requirement support.
-          assert(genericRequirement.isAnyMetadata());
           if (auto *gtpt = genericRequirement.getTypeParameter()
                                ->getAs<GenericTypeParamType>()) {
-            os << "swift::TypeMetadataTrait<";
-            ClangSyntaxPrinter(gtpt->getASTContext(), os).printGenericTypeParamTypeName(gtpt);
-            os << ">::getTypeMetadata()";
+            ClangSyntaxPrinter(gtpt->getASTContext(), os)
+                .printGenericRequirementInstantiantion(genericRequirement);
             return;
           }
           os << "ERROR";

--- a/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
+++ b/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
@@ -15,7 +15,9 @@
 #include "PrimitiveTypeMapping.h"
 #include "SwiftToClangInteropContext.h"
 #include "swift/ABI/MetadataValues.h"
+#include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/KnownProtocols.h"
 #include "swift/AST/Type.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/IRGen/IRABIDetailsProvider.h"
@@ -250,6 +252,29 @@ void printPrimitiveGenericTypeTraits(raw_ostream &os, ASTContext &astContext,
   }
 }
 
+/// Prints the extern declarations for the protocol descriptors of the known
+/// standard library protocols that can occur in exposed generic requirements
+/// (see `swift::cxx_translation::isExposableToCxx`). The generated code uses
+/// them to instantiate protocol conformance witness tables via the Swift
+/// runtime.
+static void printKnownProtocolDescriptorDecls(raw_ostream &os,
+                                              ASTContext &astContext) {
+  // We do not have protocol conformance metadata in Embedded Swift.
+  if (astContext.LangOpts.hasFeature(Feature::Embedded))
+    return;
+
+  const KnownProtocolKind supportedProtocols[] = {KnownProtocolKind::Hashable};
+  for (auto kind : supportedProtocols) {
+    auto *proto = astContext.getProtocol(kind);
+    if (!proto)
+      continue;
+    auto entity = irgen::LinkEntity::forProtocolDescriptor(proto);
+    os << "// protocol descriptor for " << proto->getNameStr() << ".\n";
+    os << "SWIFT_IMPORT_STDLIB_SYMBOL extern size_t "
+       << entity.mangleAsString(astContext) << ";\n";
+  }
+}
+
 void swift::printSwiftToClangCoreScaffold(SwiftToClangInteropContext &ctx,
                                           ASTContext &astContext,
                                           PrimitiveTypeMapping &typeMapping,
@@ -267,6 +292,8 @@ void swift::printSwiftToClangCoreScaffold(SwiftToClangInteropContext &ctx,
                 os << "\n";
                 printPrimitiveGenericTypeTraits(os, astContext, typeMapping,
                                                 /*isCForwardDefinition=*/true);
+                os << "\n";
+                printKnownProtocolDescriptorDecls(os, astContext);
               });
               os << "\n";
             });

--- a/lib/PrintAsClang/_SwiftCxxInteroperability.h
+++ b/lib/PrintAsClang/_SwiftCxxInteroperability.h
@@ -27,6 +27,14 @@
 #if !defined(SWIFT_CALL)
 # define SWIFT_CALL __attribute__((swiftcall))
 #endif
+#if !defined(SWIFT_IMPORT_STDLIB_SYMBOL)
+#if defined(_WIN32)
+#define SWIFT_IMPORT_STDLIB_SYMBOL __declspec(dllimport)
+#else
+#define SWIFT_IMPORT_STDLIB_SYMBOL
+#endif
+#define SWIFT_CXX_INTEROP_UNDEFINE_IMPORT_STDLIB_SYMBOL
+#endif
 
 #if __has_attribute(transparent_stepping)
 #define SWIFT_INLINE_THUNK_ATTRIBUTES                                          \
@@ -113,6 +121,34 @@ extern "C" void *_Nonnull swift_retain(void *_Nonnull) noexcept;
 
 extern "C" void swift_release(void *_Nonnull) noexcept;
 
+extern "C" const void *_Nullable swift_conformsToProtocol(
+    const void *_Nonnull type, const void *_Nonnull protocol) noexcept;
+
+#if defined(__APPLE__) && __has_attribute(weak_import)
+extern "C" SWIFT_IMPORT_STDLIB_SYMBOL size_t
+    swift_ConformanceExecutionContextSize __attribute__((weak_import));
+
+extern "C" const void *_Nullable swift_conformsToProtocolWithExecutionContext(
+    const void *_Nonnull type, const void *_Nonnull protocol,
+    void *_Nonnull context) noexcept __attribute__((weak_import));
+
+extern "C" bool
+swift_isInConformanceExecutionContext(const void *_Nonnull type,
+                                      const void *_Nonnull context) noexcept
+    __attribute__((weak_import));
+#else
+extern "C" SWIFT_IMPORT_STDLIB_SYMBOL size_t
+    swift_ConformanceExecutionContextSize;
+
+extern "C" const void *_Nullable swift_conformsToProtocolWithExecutionContext(
+    const void *_Nonnull type, const void *_Nonnull protocol,
+    void *_Nonnull context) noexcept;
+
+extern "C" bool
+swift_isInConformanceExecutionContext(const void *_Nonnull type,
+                                      const void *_Nonnull context) noexcept;
+#endif
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wreserved-identifier"
 
@@ -162,6 +198,89 @@ SWIFT_INLINE_THUNK void opaqueFree(void *_Nonnull p) noexcept {
   free(p);
 #endif
 #endif
+}
+
+SWIFT_INLINE_PRIVATE_HELPER bool
+hasConformanceExecutionContextRuntimeSupport() noexcept {
+#if defined(__APPLE__) && __has_attribute(weak_import)
+  return &swift_ConformanceExecutionContextSize != nullptr &&
+         swift_conformsToProtocolWithExecutionContext != nullptr &&
+         swift_isInConformanceExecutionContext != nullptr;
+#else
+  return true;
+#endif
+}
+
+template <size_t MessageSize>
+[[noreturn]] SWIFT_INLINE_PRIVATE_HELPER void
+fatalConformanceLookup(const char (&message)[MessageSize]) noexcept {
+  _swift_stdlib_reportFatalError("Fatal error", 11, message,
+                                 static_cast<int>(MessageSize - 1),
+                                 /*flags=*/0);
+  abort();
+}
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Walloca"
+
+SWIFT_INLINE_PRIVATE_HELPER const void
+    *_Nullable lookupConformanceWithExecutionContext(
+        void *_Nonnull typeMetadata,
+        const void *_Nonnull protocolDescriptor) noexcept {
+  // The runtime publishes the size of this opaque context dynamically. Keep
+  // its storage in this frame because the lookup and validation APIs both
+  // access it.
+  size_t contextSize = swift_ConformanceExecutionContextSize;
+  auto *context =
+      static_cast<unsigned char *_Nonnull>(__builtin_alloca(contextSize));
+  for (size_t index = 0; index < contextSize; ++index)
+    context[index] = 0;
+
+  const void *_Nonnull signedProtocolDescriptor = protocolDescriptor;
+#ifdef __arm64e__
+  signedProtocolDescriptor = ptrauth_sign_unauthenticated(
+      const_cast<void *>(protocolDescriptor),
+      ptrauth_key_process_dependent_data,
+      ptrauth_string_discriminator("ProtocolDescriptor"));
+#endif
+
+  const void *_Nullable witnessTable =
+      swift_conformsToProtocolWithExecutionContext(
+          typeMetadata, signedProtocolDescriptor, context);
+  if (witnessTable &&
+      !swift_isInConformanceExecutionContext(typeMetadata, context)) {
+    fatalConformanceLookup(
+        "Swift protocol conformance is unavailable in the current "
+        "execution context\n");
+  }
+  return witnessTable;
+}
+
+#pragma clang diagnostic pop
+
+/// Returns the witness table for the conformance of the Swift type identified
+/// by the given type metadata to the Swift protocol identified by the given
+/// protocol descriptor. Aborts if the conformance is unavailable or, when
+/// supported by the linked runtime, cannot be used in the current execution
+/// context.
+SWIFT_INLINE_PRIVATE_HELPER void *_Nonnull loadConformanceWitnessTable(
+    void *_Nonnull typeMetadata,
+    const void *_Nonnull protocolDescriptor) noexcept {
+  const void *_Nullable witnessTable;
+  if (hasConformanceExecutionContextRuntimeSupport()) {
+    witnessTable =
+        lookupConformanceWithExecutionContext(typeMetadata, protocolDescriptor);
+  } else {
+    // Older Apple runtimes do not expose conformance execution contexts.
+    // Preserve their dynamic-cast behavior for back deployment.
+    witnessTable = swift_conformsToProtocol(typeMetadata, protocolDescriptor);
+  }
+
+  if (!witnessTable)
+    fatalConformanceLookup(
+        "Swift protocol conformance required by generic requirements is "
+        "unavailable\n");
+  return const_cast<void *>(witnessTable);
 }
 
 /// Base class for a container for an opaque Swift value, like resilient struct.
@@ -298,6 +417,18 @@ template <class T> static inline const constexpr bool isOpaqueLayout = false;
 template <class T>
 static inline const constexpr bool isSwiftBridgedCxxRecord = false;
 
+/// Returns the witness table for the conformance of the Swift type `T` to the
+/// Swift protocol identified by the given protocol descriptor.
+///
+/// The Swift runtime caches conformance lookup results. The execution context
+/// is checked on every use because an isolated conformance may only be used
+/// while running on its global actor.
+template <class T, size_t *_Nonnull ProtocolDescriptor>
+SWIFT_INLINE_PRIVATE_HELPER void *_Nonnull getConformanceWitnessTable() {
+  return loadConformanceWitnessTable(TypeMetadataTrait<T>::getTypeMetadata(),
+                                     ProtocolDescriptor);
+}
+
 /// Returns the opaque pointer to the given value.
 template <class T>
 SWIFT_INLINE_THUNK const void *_Nonnull getOpaquePointer(const T &value) {
@@ -334,6 +465,12 @@ private:
 #pragma clang diagnostic pop
 
 } // namespace swift SWIFT_PRIVATE_ATTR
+
+#if defined(SWIFT_CXX_INTEROP_UNDEFINE_IMPORT_STDLIB_SYMBOL)
+#undef SWIFT_CXX_INTEROP_UNDEFINE_IMPORT_STDLIB_SYMBOL
+#undef SWIFT_IMPORT_STDLIB_SYMBOL
+#endif
+
 #endif
 
 #endif // SWIFT_CXX_INTEROPERABILITY_H

--- a/lib/PrintAsClang/_SwiftCxxInteroperability.h
+++ b/lib/PrintAsClang/_SwiftCxxInteroperability.h
@@ -27,6 +27,14 @@
 #if !defined(SWIFT_CALL)
 # define SWIFT_CALL __attribute__((swiftcall))
 #endif
+#if !defined(SWIFT_IMPORT_STDLIB_SYMBOL)
+#if defined(_WIN32)
+#define SWIFT_IMPORT_STDLIB_SYMBOL __declspec(dllimport)
+#else
+#define SWIFT_IMPORT_STDLIB_SYMBOL
+#endif
+#define SWIFT_CXX_INTEROP_UNDEFINE_IMPORT_STDLIB_SYMBOL
+#endif
 
 #if __has_attribute(transparent_stepping)
 #define SWIFT_INLINE_THUNK_ATTRIBUTES                                          \
@@ -93,6 +101,34 @@ extern "C" void *_Nonnull swift_retain(void *_Nonnull) noexcept;
 
 extern "C" void swift_release(void *_Nonnull) noexcept;
 
+extern "C" const void *_Nullable swift_conformsToProtocol(
+    const void *_Nonnull type, const void *_Nonnull protocol) noexcept;
+
+#if defined(__APPLE__) && __has_attribute(weak_import)
+extern "C" SWIFT_IMPORT_STDLIB_SYMBOL size_t
+    swift_ConformanceExecutionContextSize __attribute__((weak_import));
+
+extern "C" const void *_Nullable swift_conformsToProtocolWithExecutionContext(
+    const void *_Nonnull type, const void *_Nonnull protocol,
+    void *_Nonnull context) noexcept __attribute__((weak_import));
+
+extern "C" bool
+swift_isInConformanceExecutionContext(const void *_Nonnull type,
+                                      const void *_Nonnull context) noexcept
+    __attribute__((weak_import));
+#else
+extern "C" SWIFT_IMPORT_STDLIB_SYMBOL size_t
+    swift_ConformanceExecutionContextSize;
+
+extern "C" const void *_Nullable swift_conformsToProtocolWithExecutionContext(
+    const void *_Nonnull type, const void *_Nonnull protocol,
+    void *_Nonnull context) noexcept;
+
+extern "C" bool
+swift_isInConformanceExecutionContext(const void *_Nonnull type,
+                                      const void *_Nonnull context) noexcept;
+#endif
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wreserved-identifier"
 
@@ -142,6 +178,89 @@ SWIFT_INLINE_THUNK void opaqueFree(void *_Nonnull p) noexcept {
   free(p);
 #endif
 #endif
+}
+
+SWIFT_INLINE_PRIVATE_HELPER bool
+hasConformanceExecutionContextRuntimeSupport() noexcept {
+#if defined(__APPLE__) && __has_attribute(weak_import)
+  return &swift_ConformanceExecutionContextSize != nullptr &&
+         swift_conformsToProtocolWithExecutionContext != nullptr &&
+         swift_isInConformanceExecutionContext != nullptr;
+#else
+  return true;
+#endif
+}
+
+template <size_t MessageSize>
+[[noreturn]] SWIFT_INLINE_PRIVATE_HELPER void
+fatalConformanceLookup(const char (&message)[MessageSize]) noexcept {
+  _swift_stdlib_reportFatalError("Fatal error", 11, message,
+                                 static_cast<int>(MessageSize - 1),
+                                 /*flags=*/0);
+  abort();
+}
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Walloca"
+
+SWIFT_INLINE_PRIVATE_HELPER const void
+    *_Nullable lookupConformanceWithExecutionContext(
+        void *_Nonnull typeMetadata,
+        const void *_Nonnull protocolDescriptor) noexcept {
+  // The runtime publishes the size of this opaque context dynamically. Keep
+  // its storage in this frame because the lookup and validation APIs both
+  // access it.
+  size_t contextSize = swift_ConformanceExecutionContextSize;
+  auto *context =
+      static_cast<unsigned char *_Nonnull>(__builtin_alloca(contextSize));
+  for (size_t index = 0; index < contextSize; ++index)
+    context[index] = 0;
+
+  const void *_Nonnull signedProtocolDescriptor = protocolDescriptor;
+#ifdef __arm64e__
+  signedProtocolDescriptor = ptrauth_sign_unauthenticated(
+      const_cast<void *>(protocolDescriptor),
+      ptrauth_key_process_dependent_data,
+      ptrauth_string_discriminator("ProtocolDescriptor"));
+#endif
+
+  const void *_Nullable witnessTable =
+      swift_conformsToProtocolWithExecutionContext(
+          typeMetadata, signedProtocolDescriptor, context);
+  if (witnessTable &&
+      !swift_isInConformanceExecutionContext(typeMetadata, context)) {
+    fatalConformanceLookup(
+        "Swift protocol conformance is unavailable in the current "
+        "execution context\n");
+  }
+  return witnessTable;
+}
+
+#pragma clang diagnostic pop
+
+/// Returns the witness table for the conformance of the Swift type identified
+/// by the given type metadata to the Swift protocol identified by the given
+/// protocol descriptor. Aborts if the conformance is unavailable or, when
+/// supported by the linked runtime, cannot be used in the current execution
+/// context.
+SWIFT_INLINE_PRIVATE_HELPER void *_Nonnull loadConformanceWitnessTable(
+    void *_Nonnull typeMetadata,
+    const void *_Nonnull protocolDescriptor) noexcept {
+  const void *_Nullable witnessTable;
+  if (hasConformanceExecutionContextRuntimeSupport()) {
+    witnessTable =
+        lookupConformanceWithExecutionContext(typeMetadata, protocolDescriptor);
+  } else {
+    // Older Apple runtimes do not expose conformance execution contexts.
+    // Preserve their dynamic-cast behavior for back deployment.
+    witnessTable = swift_conformsToProtocol(typeMetadata, protocolDescriptor);
+  }
+
+  if (!witnessTable)
+    fatalConformanceLookup(
+        "Swift protocol conformance required by generic requirements is "
+        "unavailable\n");
+  return const_cast<void *>(witnessTable);
 }
 
 /// Base class for a container for an opaque Swift value, like resilient struct.
@@ -278,6 +397,18 @@ template <class T> static inline const constexpr bool isOpaqueLayout = false;
 template <class T>
 static inline const constexpr bool isSwiftBridgedCxxRecord = false;
 
+/// Returns the witness table for the conformance of the Swift type `T` to the
+/// Swift protocol identified by the given protocol descriptor.
+///
+/// The Swift runtime caches conformance lookup results. The execution context
+/// is checked on every use because an isolated conformance may only be used
+/// while running on its global actor.
+template <class T, size_t *_Nonnull ProtocolDescriptor>
+SWIFT_INLINE_PRIVATE_HELPER void *_Nonnull getConformanceWitnessTable() {
+  return loadConformanceWitnessTable(TypeMetadataTrait<T>::getTypeMetadata(),
+                                     ProtocolDescriptor);
+}
+
 /// Returns the opaque pointer to the given value.
 template <class T>
 SWIFT_INLINE_THUNK const void *_Nonnull getOpaquePointer(const T &value) {
@@ -314,6 +445,12 @@ private:
 #pragma clang diagnostic pop
 
 } // namespace swift SWIFT_PRIVATE_ATTR
+
+#if defined(SWIFT_CXX_INTEROP_UNDEFINE_IMPORT_STDLIB_SYMBOL)
+#undef SWIFT_CXX_INTEROP_UNDEFINE_IMPORT_STDLIB_SYMBOL
+#undef SWIFT_IMPORT_STDLIB_SYMBOL
+#endif
+
 #endif
 
 #endif // SWIFT_CXX_INTEROPERABILITY_H

--- a/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx-darwin64bit.swift
+++ b/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx-darwin64bit.swift
@@ -44,6 +44,9 @@
 // CHECK-NEXT: // type metadata address for Float16.
 // CHECK-NEXT: SWIFT_IMPORT_STDLIB_SYMBOL extern size_t $ss7Float16VN;
 // CHECK-EMPTY:
+// CHECK-NEXT: // protocol descriptor for Hashable.
+// CHECK-NEXT: SWIFT_IMPORT_STDLIB_SYMBOL extern size_t $sSHMp;
+// CHECK-EMPTY:
 // CHECK-NEXT: #ifdef __cplusplus
 // CHECK-NEXT: }
 // CHECK-NEXT: #endif

--- a/test/Interop/SwiftToCxx/enums/enum-element-method-name-clash.swift
+++ b/test/Interop/SwiftToCxx/enums/enum-element-method-name-clash.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -module-name Enums -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/enums.h
 // RUN: %FileCheck %s < %t/enums.h
+// RUN: %check-interop-cxx-header-in-clang(%t/enums.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 public enum Foo: Hashable, Sendable {
     case bar(Parameters)
@@ -33,4 +34,5 @@ extension Foo {
 // CHECK-NEXT:  }
 // CHECK-EMPTY:
 // Before the fix, we had the static method's thunk here.
-// CHECK-NEXT:    swift::Int getHashValue() const
+// CHECK-NOT:     Foo bar(swift::Int version)
+// CHECK:         swift::Int getHashValue() const

--- a/test/Interop/SwiftToCxx/generics/generic-function-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-function-in-cxx.swift
@@ -38,6 +38,23 @@ public func genericRet<T>(_ x: T) -> T {
 public func genericRequirementProtocol<T: Hashable>(_ x: T) {
 }
 
+public func genericRequirementTwoHashableParameters<T: Hashable, U: Hashable>(
+    _ x: T, _ y: U
+) {
+}
+
+public func genericOverloadUnconstrainedFirst<T>(_ x: T) {
+}
+
+public func genericOverloadUnconstrainedFirst<T: Hashable>(_ x: T) {
+}
+
+public func genericOverloadConstrainedFirst<T: Hashable>(_ x: T) {
+}
+
+public func genericOverloadConstrainedFirst<T>(_ x: T) {
+}
+
 public func genericRequirementClass<T>(_ x: T) where T: TestClass {
 }
 
@@ -91,6 +108,10 @@ public struct TestSmallStruct {
             x1 -= 1
         }
     }
+
+    public func genericMethodHashable<T: Hashable>(_ x: T) -> Bool {
+        return x == x
+    }
 }
 
 public func createTestSmallStruct(_ x: UInt32) -> TestSmallStruct {
@@ -99,14 +120,24 @@ public func createTestSmallStruct(_ x: UInt32) -> TestSmallStruct {
 
 // CHECK: SWIFT_EXTERN void $s9Functions15TestSmallStructV24genericMethodPassThroughyxxlF(SWIFT_INDIRECT_RESULT void * _Nonnull, const void * _Nonnull x, struct swift_interop_passStub_Functions_uint32_t_0_4 _self, void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // genericMethodPassThrough(_:)
 // CHECK-NEXT: SWIFT_EXTERN void $s9Functions15TestSmallStructV20genericMethodMutTakeyyxlF(const void * _Nonnull x, void * _Nonnull , SWIFT_CONTEXT void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // genericMethodMutTake(_:)
+// CHECK-NEXT: SWIFT_EXTERN bool {{.*}}genericMethodHashable{{.*}}; // genericMethodHashable(_:)
+
+// CHECK: SWIFT_EXTERN void $s9Functions31genericOverloadConstrainedFirstyyxlF(
+// CHECK-NEXT: SWIFT_EXTERN void $s9Functions33genericOverloadUnconstrainedFirstyyxlF(
 
 // CHECK: SWIFT_EXTERN void $s9Functions20genericPrintFunctionyyxlF(const void * _Nonnull x, void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // genericPrintFunction(_:)
 // CHECK-NEXT: SWIFT_EXTERN void $s9Functions32genericPrintFunctionMultiGenericyySi_xxSiq_tr0_lF(ptrdiff_t x, const void * _Nonnull t1, const void * _Nonnull t1p, ptrdiff_t y, const void * _Nonnull t2, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // genericPrintFunctionMultiGeneric(_:_:_:_:_:)
 // CHECK-NEXT: SWIFT_EXTERN void $s9Functions26genericPrintFunctionTwoArgyyx_SitlF(const void * _Nonnull x, ptrdiff_t y, void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // genericPrintFunctionTwoArg(_:_:)
+// A 'Hashable' generic requirement is passed as a protocol witness table, after the type metadata.
+// CHECK-NEXT: SWIFT_EXTERN void $s9Functions26genericRequirementProtocolyyxSHRzlF(const void * _Nonnull x, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // genericRequirementProtocol(_:)
+// Generic requirement parameters are unnamed because multiple generic
+// parameters can each require the same protocol.
+// CHECK-NEXT: SWIFT_EXTERN void {{.*}}genericRequirementTwoHashableParameters{{.*}}(const void * _Nonnull x, const void * _Nonnull y, void * _Nonnull , void * _Nonnull , void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // genericRequirementTwoHashableParameters(_:_:)
 // CHECK-NEXT: SWIFT_EXTERN void $s9Functions10genericRetyxxlF(SWIFT_INDIRECT_RESULT void * _Nonnull, const void * _Nonnull x, void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // genericRet(_:)
 // CHECK-NEXT: SWIFT_EXTERN void $s9Functions11genericSwapyyxz_xztlF(void * _Nonnull x, void * _Nonnull y, void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // genericSwap(_:_:)
 
-// CHECK-NOT: genericRequirement
+// Superclass generic requirements are still not representable in C++.
+// CHECK-NOT: genericRequirementClass
 
 // Skip templates in impl classes.
 // CHECK: _impl_TestSmallStruct
@@ -120,8 +151,15 @@ public func createTestSmallStruct(_ x: UInt32) -> TestSmallStruct {
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: #endif
 // CHECK-NEXT: SWIFT_INLINE_THUNK void genericMethodMutTake(const T_0_0& x) SWIFT_SYMBOL("s:9Functions15TestSmallStructV20genericMethodMutTakeyyxlF");
+// CHECK: SWIFT_INLINE_THUNK bool genericMethodHashable
 // CHECK:      template<class T>
 // CHECK-NEXT: returnNewValue
+
+// Swift generic requirements are erased from C++ function signatures. When a
+// constrained and unconstrained overload collide, keep the unconstrained one
+// in either source order so calls with non-Hashable types remain valid.
+// CHECK: SWIFT_INLINE_THUNK void genericOverloadConstrainedFirst(const T_0_0& x) noexcept SWIFT_SYMBOL("s:9Functions31genericOverloadConstrainedFirstyyxlF")
+// CHECK: SWIFT_INLINE_THUNK void genericOverloadUnconstrainedFirst(const T_0_0& x) noexcept SWIFT_SYMBOL("s:9Functions33genericOverloadUnconstrainedFirstyyxlF")
 
 // CHECK:      template<class T_0_0>
 // CHECK-NEXT: #ifdef __cpp_concepts
@@ -158,6 +196,22 @@ public func createTestSmallStruct(_ x: UInt32) -> TestSmallStruct {
 // CHECK-NEXT: #endif
 // CHECK-NEXT:   _impl::$s9Functions26genericPrintFunctionTwoArgyyx_SitlF(swift::_impl::getOpaquePointer(x), y, swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
 // CHECK-NEXT: }
+
+// The witness table for a 'Hashable' requirement is instantiated at runtime.
+// CHECK:      template<class T_0_0>
+// CHECK-NEXT: #ifdef __cpp_concepts
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
+// CHECK-NEXT: #endif
+// CHECK-NEXT: SWIFT_INLINE_THUNK void genericRequirementProtocol(const T_0_0& x) noexcept SWIFT_SYMBOL("s:9Functions26genericRequirementProtocolyyxSHRzlF") {
+// CHECK-NEXT: #ifndef __cpp_concepts
+// CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
+// CHECK-NEXT: #endif
+// CHECK-NEXT:   _impl::$s9Functions26genericRequirementProtocolyyxSHRzlF(swift::_impl::getOpaquePointer(x), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::_impl::getConformanceWitnessTable<T_0_0, &swift::_impl::$sSHMp>());
+// CHECK-NEXT: }
+
+// CHECK:      SWIFT_INLINE_THUNK void genericRequirementTwoHashableParameters
+// CHECK:      getConformanceWitnessTable<T_0_0, &swift::_impl::$sSHMp>()
+// CHECK-SAME: getConformanceWitnessTable<T_0_1, &swift::_impl::$sSHMp>()
 
 // CHECK:      template<class T_0_0>
 // CHECK-NEXT: #ifdef __cpp_concepts
@@ -245,3 +299,12 @@ public func createTestSmallStruct(_ x: UInt32) -> TestSmallStruct {
 // CHECK-NEXT: #endif
 // CHECK-NEXT:   _impl::$s9Functions15TestSmallStructV20genericMethodMutTakeyyxlF(swift::_impl::getOpaquePointer(x), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), _getOpaquePointer());
 // CHECK-NEXT:   }
+
+// CHECK:      SWIFT_INLINE_THUNK bool TestSmallStruct::genericMethodHashable
+// CHECK:      getConformanceWitnessTable<T_0_0, &swift::_impl::$sSHMp>()
+
+// A constrained and an unconstrained generic overload have the same C++
+// parameter types. Verify that one overload is omitted regardless of source
+// order instead of emitting an invalid duplicate C++ declaration.
+// CHECK: // Unavailable in C++: Swift global function 'genericOverloadConstrainedFirst(_:)'. An overload with the same C++ parameter types already exists.
+// CHECK: // Unavailable in C++: Swift global function 'genericOverloadUnconstrainedFirst(_:)'. An overload with the same C++ parameter types already exists.

--- a/test/Interop/SwiftToCxx/generics/generic-hashable-isolated-conformance-execution.cpp
+++ b/test/Interop/SwiftToCxx/generics/generic-hashable-isolated-conformance-execution.cpp
@@ -1,0 +1,46 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend %t/generics.swift -module-name Generics -cxx-interoperability-mode=default -typecheck -verify -emit-clang-header-path %t/generics.h
+// RUN: %target-interop-build-clangxx -fno-exceptions -std=gnu++20 -c %t/isolated-hashable-execution.cpp -I %t -o %t/isolated-hashable-execution.o
+// RUN: %target-build-swift %t/generics.swift -o %t/isolated-hashable-execution -Xlinker %t/isolated-hashable-execution.o -module-name Generics -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+// RUN: %target-codesign %t/isolated-hashable-execution
+// RUN: not --crash %target-run %t/isolated-hashable-execution 2>&1 | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deploy_concurrency
+// UNSUPPORTED: back_deployment_runtime
+
+//--- generics.swift
+@globalActor
+private actor TestActor {
+    static let shared = TestActor()
+}
+
+@_expose(Cxx)
+public struct IsolatedHashable: @TestActor Hashable {
+    public let value: Int
+
+    public init(_ value: Int) {
+        self.value = value
+    }
+}
+
+@_expose(Cxx)
+public func genericAreEqual<T: Hashable>(_ a: T, _ b: T) -> Bool {
+    return a == b
+}
+
+//--- isolated-hashable-execution.cpp
+#include "generics.h"
+
+int main() {
+  auto value = Generics::IsolatedHashable::init(7);
+  (void)Generics::genericAreEqual(value, value);
+  return 0;
+}
+
+// CHECK: Fatal error: Swift protocol conformance is unavailable in the current execution context

--- a/test/Interop/SwiftToCxx/generics/generic-hashable-ptrauth.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-hashable-ptrauth.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend %t/input.swift -module-name Input -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/input.h
+// RUN: %target-interop-build-clangxx -std=gnu++20 -target arm64e-apple-macosx13.0 -O1 -S -emit-llvm %t/test.cpp -I %t -o - | %FileCheck %s
+
+// REQUIRES: OS=macosx
+
+// The conformance execution-context API requires a process-dependent signed
+// protocol descriptor on arm64e. Lock in both the key and the runtime's
+// ProtocolDescriptor string discriminator.
+// CHECK-LABEL: define{{.*}} ptr @lookupConformance(
+// CHECK: call i64 @llvm.ptrauth.sign(i64 {{.*}}, i32 3, i64 59657)
+
+//--- input.swift
+public func acceptHashable<Value: Hashable>(_ value: Value) {}
+
+//--- test.cpp
+#include "input.h"
+
+extern "C" void *lookupConformance(void *typeMetadata) {
+  return swift::_impl::loadConformanceWitnessTable(
+      typeMetadata, &swift::_impl::$sSHMp);
+}

--- a/test/Interop/SwiftToCxx/generics/generic-hashable-requirement-boundaries.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-hashable-requirement-boundaries.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name Boundaries -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/boundaries.h
+// RUN: %FileCheck %s < %t/boundaries.h
+// RUN: %check-interop-cxx-header-in-clang(%t/boundaries.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
+
+public func requiresComparable<Value: Comparable>(_ value: Value) {}
+
+public func acceptsAnyHashable(_ value: any Hashable) {}
+
+public func returnsAnyHashable() -> any Hashable {
+    return 0
+}
+
+public func returnsSomeHashable() -> some Hashable {
+    return 0
+}
+
+// Only direct Hashable requirements are supported. This does not expose other
+// protocols, protocol existential values, or opaque result types to C++.
+// CHECK: // Unavailable in C++: Swift global function 'acceptsAnyHashable
+// CHECK: // Unavailable in C++: Swift global function 'requiresComparable
+// CHECK: // Unavailable in C++: Swift global function 'returnsAnyHashable
+// CHECK: // Unavailable in C++: Swift global function 'returnsSomeHashable

--- a/test/Interop/SwiftToCxx/generics/generic-hashable-requirement-embedded.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-hashable-requirement-embedded.swift
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -target %target-cpu-apple-macos15.0 -module-name EmbeddedGenerics -enable-experimental-feature Embedded -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/embedded-generics.h
+// RUN: %FileCheck %s --implicit-check-not='protocol descriptor for Hashable' --implicit-check-not='getConformanceWitnessTable<' < %t/embedded-generics.h
+// RUN: %check-interop-cxx-header-in-clang(%t/embedded-generics.h -target %target-cpu-apple-macos15.0 -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
+
+// REQUIRES: OS=macosx
+// REQUIRES: embedded_stdlib
+// REQUIRES: swift_feature_Embedded
+
+public func requiresHashable<Value: Hashable>(_ value: Value) {}
+
+public struct HashableBox<Value: Hashable> {
+    public let value: Value
+
+    public init(_ value: Value) {
+        self.value = value
+    }
+}
+
+// Runtime protocol-conformance lookup is not available in Embedded Swift.
+// CHECK: class HashableBox { } SWIFT_UNAVAILABLE_MSG(
+// CHECK: // Unavailable in C++: Swift global function 'requiresHashable

--- a/test/Interop/SwiftToCxx/generics/generic-hashable-requirement-execution.cpp
+++ b/test/Interop/SwiftToCxx/generics/generic-hashable-requirement-execution.cpp
@@ -1,0 +1,305 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend %t/generics.swift -module-name Generics -cxx-interoperability-mode=default -typecheck -verify -emit-clang-header-path %t/generics.h
+
+// RUN: %target-interop-build-clangxx -fno-exceptions -std=gnu++20 -c %t/generic-hashable-execution.cpp -I %t -o %t/swift-generics-execution.o
+// RUN: %target-build-swift %t/generics.swift -o %t/swift-generics-execution -Xlinker %t/swift-generics-execution.o -module-name Generics -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+// RUN: %target-codesign %t/swift-generics-execution
+// RUN: %target-run %t/swift-generics-execution | %FileCheck %s
+
+// RUN: %target-interop-build-clangxx -fno-exceptions -std=gnu++20 -c %t/non-hashable-execution.cpp -I %t -o %t/non-hashable-execution.o
+// RUN: %target-build-swift %t/generics.swift -o %t/non-hashable-execution -Xlinker %t/non-hashable-execution.o -module-name Generics -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+// RUN: %target-codesign %t/non-hashable-execution
+// RUN: not --crash %target-run %t/non-hashable-execution 2>&1 | %FileCheck %s --check-prefix=NON-HASHABLE
+
+// REQUIRES: executable_test
+
+//--- generics.swift
+@_expose(Cxx)
+public func genericAreEqual<T: Hashable>(_ a: T, _ b: T) -> Bool {
+    return a == b
+}
+
+@_expose(Cxx)
+public func printIsEqual<T: Hashable>(_ a: T, _ b: T) {
+    print(a == b ? "EQUAL" : "NOT EQUAL")
+}
+
+@_expose(Cxx)
+public func genericBothAreEqual<A: Hashable, B: Hashable>(
+    _ a1: A, _ a2: A, _ b1: B, _ b2: B
+) -> Bool {
+    return a1 == a2 && b1 == b2
+}
+
+@_expose(Cxx)
+public struct ConditionallyHashable<Value> {
+    public let value: Value
+
+    public init(_ value: Value) {
+        self.value = value
+    }
+}
+
+extension ConditionallyHashable: Equatable where Value: Equatable {}
+extension ConditionallyHashable: Hashable where Value: Hashable {}
+
+@_expose(Cxx)
+public struct ConditionalExtensionHost<Value> {
+    public let value: Value
+
+    public init(_ value: Value) {
+        self.value = value
+    }
+}
+
+extension ConditionalExtensionHost where Value: Hashable {
+    public func isSelfEqual() -> Bool {
+        return value == value
+    }
+}
+
+@_expose(Cxx)
+public struct NonHashable {
+    public let value: Int
+
+    public init(_ value: Int) {
+        self.value = value
+    }
+}
+
+@_expose(Cxx)
+public struct HashableMethodHost {
+    private var marker: Int
+
+    public init() {
+        marker = 0
+    }
+
+    public func areEqual<Value: Hashable>(_ lhs: Value, _ rhs: Value) -> Bool {
+        return lhs == rhs
+    }
+
+    public func overloadUnconstrainedFirst<Value>(_ value: Value) -> Int {
+        return 1
+    }
+
+    public func overloadUnconstrainedFirst<Value: Hashable>(
+        _ value: Value
+    ) -> Int {
+        return 2
+    }
+
+    public func overloadConstrainedFirst<Value: Hashable>(
+        _ value: Value
+    ) -> Int {
+        return 2
+    }
+
+    public func overloadsWithDifferentSignatures<Value: Hashable>(
+        _ value: Value
+    ) -> Int {
+        return 2
+    }
+
+    public func overloadsWithDifferentSignatures<Value>(
+        _ value: Value, marker: Int
+    ) -> Int {
+        return 1
+    }
+
+    public func markerOverloadConstrainedFirst<Value: Sendable>(
+        _ value: Value
+    ) -> Int {
+        return 2
+    }
+
+    public func markerOverloadConstrainedFirst<Value>(_ value: Value) -> Int {
+        return 1
+    }
+}
+
+extension HashableMethodHost {
+    public func overloadConstrainedFirst<Value>(_ value: Value) -> Int {
+        return 1
+    }
+}
+
+@_expose(Cxx)
+public struct UnconstrainedSubscriptFirst {
+    private var marker: Int
+
+    public init() {
+        marker = 0
+    }
+
+    public subscript<Value>(_ value: Value) -> Int {
+        return 1
+    }
+
+    public subscript<Value: Hashable>(hashable value: Value) -> Int {
+        return 2
+    }
+}
+
+@_expose(Cxx)
+public struct ConstrainedSubscriptFirst {
+    private var marker: Int
+
+    public init() {
+        marker = 0
+    }
+
+    public subscript<Value: Hashable>(_ value: Value) -> Int {
+        return 2
+    }
+
+    public subscript<Value>(unconstrained value: Value) -> Int {
+        return 1
+    }
+}
+
+@_expose(Cxx)
+public struct KeyedContainer<Key: Hashable> {
+    var storage: Set<Key>
+
+    public init() {
+        storage = []
+    }
+
+    public mutating func insert(_ key: Key) {
+        storage.insert(key)
+    }
+
+    public func contains(_ key: Key) -> Bool {
+        return storage.contains(key)
+    }
+
+    public var count: Int {
+        return storage.count
+    }
+}
+
+@_expose(Cxx)
+public enum HashableChoice<Value: Hashable> {
+    case value(Value)
+    case empty
+
+    public func contains(_ candidate: Value) -> Bool {
+        switch self {
+        case .value(let value):
+            return value == candidate
+        case .empty:
+            return false
+        }
+    }
+}
+
+//--- generic-hashable-execution.cpp
+#include <cassert>
+#include "generics.h"
+
+int main() {
+  {
+    // A generic function with a Hashable requirement.
+    assert(Generics::genericAreEqual(1, 1));
+    assert(!Generics::genericAreEqual(1, 2));
+    assert(Generics::genericAreEqual(swift::String("abc"), swift::String("abc")));
+    assert(Generics::genericBothAreEqual(
+        1, 1, swift::String("abc"), swift::String("abc")));
+    Generics::printIsEqual(-11, -11);
+    Generics::printIsEqual(4.0, 2.0);
+  }
+// CHECK: EQUAL
+// CHECK-NEXT: NOT EQUAL
+  {
+    // Resolve a conditional conformance declared by the Swift producer module.
+    auto lhs = Generics::ConditionallyHashable<int>::init(7);
+    auto rhs = Generics::ConditionallyHashable<int>::init(7);
+    assert(Generics::genericAreEqual(lhs, rhs));
+  }
+  {
+    // A conditional extension can add a supported Hashable requirement to an
+    // otherwise-unconstrained generic type.
+    auto host = Generics::ConditionalExtensionHost<int>::init(7);
+    assert(host.isSelfEqual());
+  }
+  {
+    // A generic method with a Hashable requirement.
+    auto host = Generics::HashableMethodHost::init();
+    assert(host.areEqual(17, 17));
+    assert(!host.areEqual(swift::String("left"), swift::String("right")));
+    auto nonHashable = Generics::NonHashable::init(3);
+    // Generic requirements are not part of the C++ signature. The
+    // unconstrained overload must win in either source order, including when
+    // it is declared in an extension.
+    assert(host.overloadUnconstrainedFirst(nonHashable) == 1);
+    assert(host.overloadConstrainedFirst(nonHashable) == 1);
+    assert(host.overloadUnconstrainedFirst(3) == 1);
+    assert(host.overloadConstrainedFirst(3) == 1);
+
+    // Ordering a same-named overload set must not discard declarations whose
+    // final C++ parameter lists do not collide.
+    assert(host.overloadsWithDifferentSignatures(3) == 2);
+    assert(host.overloadsWithDifferentSignatures(nonHashable, 0) == 1);
+
+    // Marker-protocol requirements are also erased from the C++ signature,
+    // even though they do not require a runtime witness lookup.
+    assert(host.markerOverloadConstrainedFirst(3) == 1);
+  }
+  {
+    // Subscript labels and generic requirements are not part of the C++
+    // operator[] signature. The unconstrained overload must win in either
+    // source order.
+    auto value = Generics::NonHashable::init(3);
+    auto unconstrainedFirst = Generics::UnconstrainedSubscriptFirst::init();
+    auto constrainedFirst = Generics::ConstrainedSubscriptFirst::init();
+    assert(unconstrainedFirst[value] == 1);
+    assert(constrainedFirst[value] == 1);
+  }
+  {
+    // A generic type with a Hashable requirement.
+    auto container = Generics::KeyedContainer<int>::init();
+    assert(container.getCount() == 0);
+    container.insert(42);
+    container.insert(42);
+    container.insert(7);
+    assert(container.getCount() == 2);
+    assert(container.contains(42));
+    assert(container.contains(7));
+    assert(!container.contains(9));
+
+    // Copy and destroy the value.
+    auto copy = container;
+    copy.insert(1);
+    assert(copy.getCount() == 3);
+    assert(container.getCount() == 2);
+  }
+  {
+    auto container = Generics::KeyedContainer<swift::String>::init();
+    container.insert("hello");
+    assert(container.contains("hello"));
+    assert(!container.contains("world"));
+  }
+  {
+    // A generic enum with a Hashable requirement.
+    auto choice = Generics::HashableChoice<int>::value(23);
+    assert(choice.contains(23));
+    assert(!choice.contains(42));
+    auto empty = Generics::HashableChoice<int>::empty();
+    assert(!empty.contains(23));
+  }
+  return 0;
+}
+
+//--- non-hashable-execution.cpp
+#include "generics.h"
+
+int main() {
+  auto value = Generics::NonHashable::init(7);
+  (void)Generics::genericAreEqual(value, value);
+  return 0;
+}
+
+// NON-HASHABLE: Fatal error: Swift protocol conformance required by generic requirements is unavailable

--- a/test/Interop/SwiftToCxx/generics/generic-requirement-extensions-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-requirement-extensions-in-cxx.swift
@@ -1,0 +1,116 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name Generics -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/generics.h
+// RUN: %FileCheck %s --implicit-check-not=onlyWhenUIsComparable --implicit-check-not=FourArgumentInner --implicit-check-not=requiresComparable --implicit-check-not='protocol descriptor for Comparable' < %t/generics.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/generics.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
+
+public struct Box<T: Hashable, U> {
+    var t: T
+    var u: U
+
+    public init(t: T, u: U) {
+        self.t = t
+        self.u = u
+    }
+
+    public func alwaysAvailable() -> Int { return 1 }
+}
+
+// A supported requirement added by a conditional extension is checked by the
+// same runtime witness lookup as a requirement declared directly on a member.
+extension Box where U: Hashable {
+    public func onlyWhenUIsHashable() -> Int { return 2 }
+}
+
+// Unsupported requirements still make the extension's members unavailable.
+extension Box where U: Comparable {
+    public func onlyWhenUIsComparable() -> Int { return 4 }
+}
+
+// An extension whose requirements are already implied by the type's own
+// generic signature is exposed as usual.
+extension Box where T: Hashable {
+    public func implicitlySatisfiedRequirement() -> Int { return 3 }
+}
+
+// The generated C++ binding implements the direct form of a generic type
+// metadata accessor, which accepts at most three arguments. Larger accessors
+// use an indirect argument buffer that the binding does not implement yet.
+// Witness tables count toward the direct limit, so this type cannot be
+// represented: its accessor would need metadata for A, B, and C, plus the
+// A: Hashable witness table.
+public struct TooManyGenericRequirements<A: Hashable, B, C> {
+    var a: A
+    var b: B
+    var c: C
+}
+
+// A nested nominal can inherit generic requirements from its context without
+// having a generic parameter list of its own. Count those inherited metadata
+// accessor arguments too.
+public struct ContextuallyGenericOuter<A, B, C> {
+    var a: A
+    var b: B
+    var c: C
+
+    public init(a: A, b: B, c: C) {
+        self.a = a
+        self.b = b
+        self.c = c
+    }
+
+    public struct FourArgumentInner where A: Hashable {
+        var a: A
+        var b: B
+        var c: C
+
+        public init(a: A, b: B, c: C) {
+            self.a = a
+            self.b = b
+            self.c = c
+        }
+    }
+}
+
+// A member can add a requirement to a parameter from its enclosing type
+// without having a generic parameter list of its own. Such contextually
+// generic declarations must still go through requirement validation.
+public struct ContextuallyConstrainedMembers<Value> {
+    private var value: Value
+
+    public init(_ value: Value) {
+        self.value = value
+    }
+
+    public func requiresHashable() where Value: Hashable {}
+    public func requiresComparable() where Value: Comparable {}
+}
+
+// Subscripts are generic contexts in their own right rather than abstract
+// function declarations. Their requirements must pass through the same
+// validation before their accessor thunks are printed.
+public struct ConstrainedSubscripts {
+    private var marker: Int
+
+    public init() {
+        marker = 0
+    }
+
+    public subscript<Value: Hashable>(_ value: Value) -> Int {
+        return 1
+    }
+
+    public subscript<Value: Comparable>(comparable value: Value) -> Int {
+        return 2
+    }
+}
+
+// CHECK-LABEL: class SWIFT_SYMBOL("s:8Generics3BoxV") Box final {
+// CHECK-DAG: alwaysAvailable()
+// CHECK-DAG: implicitlySatisfiedRequirement()
+// CHECK-DAG: onlyWhenUIsHashable()
+// CHECK-LABEL: class SWIFT_SYMBOL("s:8Generics21ConstrainedSubscriptsV") ConstrainedSubscripts final {
+// CHECK: operator [](
+// CHECK-LABEL: class SWIFT_SYMBOL("s:8Generics30ContextuallyConstrainedMembersV") ContextuallyConstrainedMembers final {
+// CHECK: requiresHashable()
+// CHECK-LABEL: class TooManyGenericRequirements { } SWIFT_UNAVAILABLE_MSG(

--- a/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
@@ -220,7 +220,6 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: #endif
 // CHECK-NEXT: class _impl_GenericPair;
 // CHECK-EMPTY:
-// CHECK-NEXT: static_assert(2 <= 3, "unsupported generic requirement list for metadata func");
 // CHECK-NEXT: // Type metadata accessor for GenericPair
 // CHECK-NEXT: SWIFT_EXTERN swift::_impl::MetadataResponseTy $s8Generics11GenericPairVMa(swift::_impl::MetadataRequestTy, void * _Nonnull, void * _Nonnull) SWIFT_NOEXCEPT SWIFT_CALL;
 

--- a/test/Interop/SwiftToCxx/stdlib/dictionary/dictionary-execution-cxx17.cpp
+++ b/test/Interop/SwiftToCxx/stdlib/dictionary/dictionary-execution-cxx17.cpp
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %S/dictionary-execution.cpp %t
+
+// RUN: %target-swift-frontend %t/use-dictionary.swift -module-name UseDictionary -cxx-interoperability-mode=default -typecheck -verify -emit-clang-header-path %t/UseDictionary.h
+
+// RUN: %target-interop-build-clangxx -fno-exceptions -std=gnu++17 -c %t/dictionary-execution.cpp -I %t -o %t/swift-stdlib-execution.o
+// RUN: %target-build-swift %t/use-dictionary.swift -o %t/swift-stdlib-execution -Xlinker %t/swift-stdlib-execution.o -module-name UseDictionary -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+// RUN: %target-codesign %t/swift-stdlib-execution
+// RUN: %target-run %t/swift-stdlib-execution | %FileCheck %S/dictionary-execution.cpp
+
+// REQUIRES: executable_test

--- a/test/Interop/SwiftToCxx/stdlib/dictionary/dictionary-execution.cpp
+++ b/test/Interop/SwiftToCxx/stdlib/dictionary/dictionary-execution.cpp
@@ -1,0 +1,127 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend %t/use-dictionary.swift -module-name UseDictionary -cxx-interoperability-mode=default -typecheck -verify -emit-clang-header-path %t/UseDictionary.h
+
+// RUN: %target-interop-build-clangxx -fno-exceptions -std=gnu++20 -c %t/dictionary-execution.cpp -I %t -o %t/swift-stdlib-execution.o
+// RUN: %target-build-swift %t/use-dictionary.swift -o %t/swift-stdlib-execution -Xlinker %t/swift-stdlib-execution.o -module-name UseDictionary -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+// RUN: %target-codesign %t/swift-stdlib-execution
+// RUN: %target-run %t/swift-stdlib-execution | %FileCheck %s
+
+// REQUIRES: executable_test
+
+//--- use-dictionary.swift
+@_expose(Cxx)
+public func createDictionary(_ key: CInt, _ value: CInt) -> [CInt: CInt] {
+    return [key: value]
+}
+
+@_expose(Cxx)
+public func passthroughDictionary(_ dict: [CInt: CInt]) -> Dictionary<CInt, CInt> {
+    return dict
+}
+
+@_expose(Cxx)
+public struct CustomKey: Hashable {
+    public let rawValue: CInt
+
+    public init(_ rawValue: CInt) {
+        self.rawValue = rawValue
+    }
+}
+
+@_expose(Cxx)
+public func printDictionary(_ dict: Dictionary<CInt, CInt>) {
+    var res = ""
+    for key in dict.keys.sorted() {
+        res += "\(key)=\(dict[key]!);"
+    }
+    print(res)
+}
+
+public func printStringDictionary(_ dict: [String: String]) {
+    for key in dict.keys.sorted() {
+        print("GOT '\(key)' -> '\(dict[key]!)'")
+    }
+    print("DONE PRINTING.")
+}
+
+//--- dictionary-execution.cpp
+#include <cassert>
+#include "UseDictionary.h"
+
+int main() {
+  using namespace swift;
+  {
+    // Read a Swift-created dictionary from C++.
+    auto dict = UseDictionary::createDictionary(11, 42);
+    assert(dict.getCount() == 1);
+    assert(!dict.isEmpty());
+    auto value = dict[11];
+    assert(value);
+    assert(value.get() == 42);
+    auto missing = dict[7];
+    assert(!missing);
+    UseDictionary::printDictionary(UseDictionary::passthroughDictionary(dict));
+  }
+// CHECK: 11=42;
+  {
+    // Create and mutate a dictionary in C++, read it from Swift.
+    auto dict = Dictionary<int, int>::init();
+    assert(dict.getCount() == 0);
+    assert(dict.isEmpty());
+    auto old = dict.updateValueForKey(100, 1);
+    assert(!old);
+    old = dict.updateValueForKey(200, 1);
+    assert(old);
+    assert(old.get() == 100);
+    dict.updateValueForKey(300, 3);
+    assert(dict.getCount() == 2);
+    UseDictionary::printDictionary(dict);
+// CHECK-NEXT: 1=200;3=300;
+    auto removed = dict.removeValueForKey(3);
+    assert(removed);
+    assert(removed.get() == 300);
+    assert(dict.getCount() == 1);
+    auto notRemoved = dict.removeValueForKey(99);
+    assert(!notRemoved);
+    UseDictionary::printDictionary(dict);
+// CHECK-NEXT: 1=200;
+  }
+  {
+    // Pass a dictionary value around by copy.
+    auto dict = Dictionary<int, int>::init();
+    dict.updateValueForKey(-1, 5);
+    auto copy = dict;
+    copy.updateValueForKey(-2, 6);
+    assert(dict.getCount() == 1);
+    assert(copy.getCount() == 2);
+    assert(copy[5].get() == -1);
+    assert(copy[6].get() == -2);
+    UseDictionary::printDictionary(UseDictionary::passthroughDictionary(copy));
+  }
+// CHECK-NEXT: 5=-1;6=-2;
+  {
+    // Use Swift String keys and values from C++.
+    auto dict = Dictionary<swift::String, swift::String>::init();
+    dict.updateValueForKey("world", "hello");
+    dict.updateValueForKey("swift", "hola");
+    auto value = dict["hello"];
+    assert(value);
+    UseDictionary::printStringDictionary(dict);
+  }
+// CHECK-NEXT: GOT 'hello' -> 'world'
+// CHECK-NEXT: GOT 'hola' -> 'swift'
+// CHECK-NEXT: DONE PRINTING.
+  {
+    // The key need not have a C++ std::hash specialization. Dictionary uses
+    // the Swift Hashable conformance associated with the key's type metadata.
+    auto key = UseDictionary::CustomKey::init(8);
+    auto dict = Dictionary<UseDictionary::CustomKey, int>::init();
+    dict.updateValueForKey(99, key);
+    auto value = dict[key];
+    assert(value);
+    assert(value.get() == 99);
+  }
+  return 0;
+}

--- a/test/Interop/SwiftToCxx/stdlib/dictionary/dictionary-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/dictionary/dictionary-in-cxx.swift
@@ -1,0 +1,41 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name UseDict -cxx-interoperability-mode=default -typecheck -verify -emit-clang-header-path %t/UseDict.h
+// RUN: %FileCheck %s < %t/UseDict.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/UseDict.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
+
+@_expose(Cxx)
+public func makeDict(_ key: String, _ value: Int) -> [String: Int] {
+    return [key: value]
+}
+
+@_expose(Cxx)
+public func takeDict(_ dict: [String: Int]) -> Int {
+    return dict.count
+}
+
+@_expose(Cxx)
+public func makeOptionalDict() -> [Int: Int]? {
+    return nil
+}
+
+@_expose(Cxx)
+public func makeDictOfArrays() -> [Int: [Int]] {
+    return [1: [2, 3]]
+}
+
+// The Dictionary class template is emitted into the generated standard-library
+// bindings.
+// CHECK: template<class T_0_0, class T_0_1>
+// CHECK-NEXT: #ifdef __cpp_concepts
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
+// CHECK-NEXT: #endif // __cpp_concepts
+// CHECK-NEXT: class SWIFT_SYMBOL("s:SD") Dictionary;
+
+// CHECK: class SWIFT_SYMBOL("s:SD") Dictionary final {
+
+// The thunks for the exposed functions use swift::Dictionary.
+// CHECK: swift::Dictionary<swift::String, swift::Int> makeDict(const swift::String& key, swift::Int value)
+// CHECK: swift::Dictionary<swift::Int, swift::Array<swift::Int>> makeDictOfArrays()
+// CHECK: swift::Optional<swift::Dictionary<swift::Int, swift::Int>> makeOptionalDict()
+// CHECK: swift::Int takeDict(const swift::Dictionary<swift::String, swift::Int>& dict)

--- a/test/Interop/SwiftToCxx/stdlib/dictionary/dictionary-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/dictionary/dictionary-in-cxx.swift
@@ -1,0 +1,41 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name UseDict -cxx-interoperability-mode=default -typecheck -verify -emit-clang-header-path %t/UseDict.h
+// RUN: %FileCheck %s < %t/UseDict.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/UseDict.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
+
+@_expose(Cxx)
+public func makeDict(_ key: String, _ value: Int) -> [String: Int] {
+    return [key: value]
+}
+
+@_expose(Cxx)
+public func takeDict(_ dict: [String: Int]) -> Int {
+    return dict.count
+}
+
+@_expose(Cxx)
+public func makeOptionalDict() -> [Int: Int]? {
+    return nil
+}
+
+@_expose(Cxx)
+public func makeDictOfArrays() -> [Int: [Int]] {
+    return [1: [2, 3]]
+}
+
+// The Dictionary class template is emitted into the generated standard-library
+// bindings.
+// CHECK: template<class T_0_0, class T_0_1>
+// CHECK-NEXT: #ifdef __cpp_concepts
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
+// CHECK-NEXT: #endif // __cpp_concepts
+// CHECK-NEXT: class SWIFT_SYMBOL("s:SD") Dictionary;
+
+// CHECK: class SWIFT_SYMBOL("s:SD") Dictionary final {
+
+// The thunks for the exposed functions use swift::Dictionary.
+// CHECK: swift::Dictionary<swift::String, swift::Int> makeDict(const swift::String& SWIFT_NOESCAPE key, swift::Int value)
+// CHECK: swift::Dictionary<swift::Int, swift::Array<swift::Int>> makeDictOfArrays()
+// CHECK: swift::Optional<swift::Dictionary<swift::Int, swift::Int>> makeOptionalDict()
+// CHECK: swift::Int takeDict(const swift::Dictionary<swift::String, swift::Int>& SWIFT_NOESCAPE dict)

--- a/test/Interop/SwiftToCxx/stdlib/dictionary/dictionary-memory-execution.cpp
+++ b/test/Interop/SwiftToCxx/stdlib/dictionary/dictionary-memory-execution.cpp
@@ -1,0 +1,82 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend %t/use-dictionary.swift -module-name UseDictionary -cxx-interoperability-mode=default -typecheck -verify -emit-clang-header-path %t/UseDictionary.h
+
+// RUN: %target-interop-build-clangxx -fno-exceptions -std=gnu++20 -c %t/dictionary-memory-execution.cpp -I %t -o %t/swift-stdlib-execution.o
+// RUN: %target-build-swift %t/use-dictionary.swift -o %t/swift-stdlib-execution -Xlinker %t/swift-stdlib-execution.o -module-name UseDictionary -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+// RUN: %target-codesign %t/swift-stdlib-execution
+// RUN: %target-run %t/swift-stdlib-execution | %FileCheck %s
+
+// REQUIRES: executable_test
+
+//--- use-dictionary.swift
+public final class Tracked {
+    public let id: Int
+    public init(id: Int) {
+        self.id = id
+        Counter.live += 1
+    }
+    deinit { Counter.live -= 1 }
+}
+
+public enum Counter {
+    public static var live = 0
+}
+
+@_expose(Cxx)
+public func makeTracked(_ id: Int) -> Tracked {
+    return Tracked(id: id)
+}
+
+@_expose(Cxx)
+public func liveCount() -> Int {
+    return Counter.live
+}
+
+@_expose(Cxx)
+public func printLiveCount() {
+    print("live=\(Counter.live)")
+}
+
+//--- dictionary-memory-execution.cpp
+#include <cassert>
+#include "UseDictionary.h"
+
+// Verifies that the value witness table operations used by the generated
+// swift::Dictionary bindings (which pass a 'Key: Hashable' witness table to
+// the type metadata accessor) manage the lifetime of the values correctly.
+int main() {
+  using namespace swift;
+  {
+    auto dict = Dictionary<int, UseDictionary::Tracked>::init();
+    dict.updateValueForKey(UseDictionary::makeTracked(1), 10);
+    dict.updateValueForKey(UseDictionary::makeTracked(2), 20);
+    assert(UseDictionary::liveCount() == 2);
+    UseDictionary::printLiveCount();
+// CHECK: live=2
+    {
+      // Copying the dictionary creates or destroys no Tracked instances.
+      auto copy = dict;
+      assert(UseDictionary::liveCount() == 2);
+      copy.updateValueForKey(UseDictionary::makeTracked(3), 30);
+      assert(UseDictionary::liveCount() == 3);
+      UseDictionary::printLiveCount();
+// CHECK-NEXT: live=3
+    }
+    // Destroying the copy destroys its newly inserted instance while the
+    // instances shared with the original dictionary remain alive.
+    assert(UseDictionary::liveCount() == 2);
+    UseDictionary::printLiveCount();
+// CHECK-NEXT: live=2
+    auto removed = dict.removeValueForKey(10);
+    assert(removed);
+    // The removed value is still owned by the returned optional.
+    assert(UseDictionary::liveCount() == 2);
+  }
+  // Destroying the dictionary and the optional releases everything.
+  UseDictionary::printLiveCount();
+// CHECK-NEXT: live=0
+  assert(UseDictionary::liveCount() == 0);
+  return 0;
+}


### PR DESCRIPTION

## Summary

- Support direct Swift `Hashable` requirements when exporting generic functions, methods, value types, subscripts, and conditional extensions to C++.
- Expose `swift::Dictionary<Key, Value>` using that support.
- Prefer unconstrained overloads when Swift-only generic requirements erase to the same C++ signature.

## Design

Generated C++ templates obtain the Swift `Hashable` witness table from type metadata at runtime and pass it through the existing generic ABI. This uses existing runtime entry points, including `swift_conformsToProtocol`; it does not add a new Swift runtime symbol or ABI surface.

This is deliberately narrower than general protocol interoperability:

- only direct `Hashable` requirements on generic parameters are supported;
- `any Hashable`, `some Hashable`, dependent-member requirements, arbitrary protocols, and generic classes remain unavailable;
- `std::hash` is not used because it cannot provide a Swift protocol witness table;
- invalid C++ instantiations terminate at runtime when no loaded Swift conformance exists;
- metadata accessors requiring more than three direct metadata/witness arguments remain unavailable;
- Embedded Swift is excluded because it has no runtime conformance lookup.

The lookup uses conformance execution contexts where supported, so isolated conformances are only used on their global-actor executor. Older Apple runtimes and runtimes without the concurrency hook retain legacy lookup behavior. Static archives must arrange for otherwise-unreferenced conformance objects to be loaded.

## Testing

- Generated-header checks under C++14, C++17, and C++20 with `-Weverything -Werror`.
- Runtime coverage for valid and invalid `Hashable` instantiations, conditional conformances/extensions, overloads, subscripts, generic structs/enums, and isolated conformances.
- arm64e IR coverage for the protocol-descriptor pointer-authentication key and discriminator.
- `Dictionary` coverage under C++17/C++20 for construction, lookup, mutation, custom Swift keys without `std::hash`, copying, and value lifetime/destruction.
- Complete local `Interop/SwiftToCxx` coverage accounted for 167 passing tests and 9 configuration-based unsupported tests. The minimal build's SIMD test was run separately while ignoring its expected missing `_StringProcessing` remark.
- Final changed-test run after splitting commits: 13 passed and 1 Embedded-only test was unsupported by the local configuration.

Resolves https://github.com/swiftlang/swift/issues/86172

Resolves https://github.com/swiftlang/swift/issues/76134
