### PR TITLE
[cxx-interop] Update availability guard on CxxIterable

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3869,7 +3869,11 @@ void swift::printWithCompatibilityFeatureChecks(ASTPrinter &printer,
   // these Swift stdlib protocols even though they don't exist in the SDK's
   // stdlib. To handle this, we guard them behind a Swift version.
   if (isCxxIterableOrBorrowingIterator(decl)) {
-    printer << "#if canImport(Swift, _version: 6.4.0.30)\n";
+    // Iterable exists on 6.4.0.30+ and 6.5.0.7+,
+    // but it is absent in [6.5, 6.5.0.7).
+    printer << "#if canImport(Swift, _version: 6.5.0.7) || "
+                  "(canImport(Swift, _version: 6.4.0.30) && "
+                  "!canImport(Swift, _version: 6.5))\n";
     printBody();
     printer.printNewline();
     printer << "#endif";


### PR DESCRIPTION
The renaming of `BorrowingSequence` to `Iterable` landed in `6.4.0.30` and the Swift version check in the Cxx overlay was updated accordingly (https://github.com/swiftlang/swift/pull/90660).

However, this renaming was only included from the version `6.5.0.7` of Swift 6.5. Therefore, we need to update the Swift version used on the guard again.

rdar://183156274

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
