### PR TITLE
[SILOptimizer] Complete lifetimes in FunctionSignatureOpts for no-return thunks

### DIFF
--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
@@ -42,7 +42,9 @@
 #include "swift/SILOptimizer/Analysis/RCIdentityAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/CFGOptUtils.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
+#include "swift/SILOptimizer/Utils/OwnershipOptUtils.h"
 #include "swift/SILOptimizer/Utils/SILInliner.h"
 #include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
 #include "swift/SILOptimizer/Utils/SpecializationMangler.h"
@@ -914,6 +916,15 @@ public:
     assert(F->isThunk() && "Old function should have been turned into a thunk");
 
     invalidateAnalysis(SILAnalysis::InvalidationKind::FunctionBody);
+
+    // The thunk body was built from scratch after transferring the original
+    // blocks to the specialized function. If the thunk is no-return, it was
+    // terminated with an `unreachable`, which may require completing
+    // lifetimes and breaking infinite loops before the pass finishes.
+    if (F->needBreakInfiniteLoops())
+      breakInfiniteLoops(getPassManager(), F);
+    if (F->needCompleteLifetimes())
+      completeAllLifetimes(getPassManager(), F);
 
     // Make sure the PM knows about this function. This will also help us
     // with self-recursion.

--- a/test/SILOptimizer/issue-90720.swift
+++ b/test/SILOptimizer/issue-90720.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -O -sil-verify-all -emit-sil %s -o /dev/null
+
+// Regression test for https://github.com/swiftlang/swift/issues/90720
+//
+// When FunctionSignatureOpts specializes a no-return function (here: the
+// implicit closure for the unapplied reference to `crash`), the rewritten
+// thunk is terminated with an `unreachable`, which cuts off lifetimes and
+// requires them to be completed before the pass finishes. This used to hit
+// the "didn't complete lifetimes" assertion in the pass manager.
+
+struct Hooks {
+    static var handler: (() -> Never)?
+    static func crash() -> Never { fatalError() }
+    static func reset() { handler = crash }
+}


### PR DESCRIPTION
### What changed
- Adds a call to `breakInfiniteLoops` and `completeAllLifetimes` in `FunctionSignatureOpts::run()` after the pass rewrites a function into a thunk, mirroring the handling already present in `GenericSpecializer` and `ExistentialTransform`. 
- Adds a regression test (`test/SILOptimizer/issue-90720.swift`).

### Why
- When `FunctionSignatureOpts` rewrites a function into a thunk that calls the specialized version, and the callee is no-return, the thunk is terminated with `unreachable`. In OSSA, creating an `unreachable` sets `NeedCompleteLifetimes`, and erasing the original blocks sets `NeedBreakInfiniteLoops` but the pass never addressed either flag before finishing, so the pass manager hit the "didn't complete lifetimes" assertion in `SwiftPassInvocation::finishedFunctionPassRun()`.
- This crashes any `-O` compilation where `DeadArgSignatureOpt` processes an unapplied reference to a `Never`-returning static method stored from another static method of the same type.
- Resolves https://github.com/swiftlang/swift/issues/90720