### PR TITLE
[Literal Expressions][Parser] Route type-shaped generic arguments as types

### DIFF
--- a/include/swift/AST/ASTWalker.h
+++ b/include/swift/AST/ASTWalker.h
@@ -610,6 +610,15 @@ public:
     return false;
   }
 
+  /// Whether the walker should walk into the expression of a
+  /// \c GenericArgumentExprTypeRepr.
+  virtual bool shouldWalkIntoGenericArgumentExprTypeRepr() const {
+    // That expression is type-checked separately by
+    // `resolveGenericArgumentExprTypeRepr`, so it is hidden by default. Opt in
+    // to reach the TypeReprs the parser built inside it.
+    return false;
+  }
+
   virtual bool shouldWalkIntoForEachDesugaredStmt() { return true; }
 
   /// This method configures how the walker should walk the initializers of

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -178,7 +178,8 @@ public:
   ///
   /// \returns true if the predicate returns true for the given type or any of
   /// its children.
-  bool findIf(llvm::function_ref<bool(TypeRepr *)> pred);
+  bool findIf(llvm::function_ref<bool(TypeRepr *)> pred,
+              bool walkIntoGenericArgumentExprs = false);
 
   /// Check recursively whether this type repr or any of its descendants are
   /// opaque return type reprs.

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1755,6 +1755,12 @@ public:
   bool canParseGenericArguments();
   bool canParseGenericValueLiteral();
 
+  /// Assuming the parser is positioned at the opening '(' of a generic argument
+  /// that would otherwise be parsed as a value expression, check if the
+  /// parenthesized group contains an opaque 'some' type that requires it to be
+  /// parsed as a type instead.
+  bool parenGenericArgumentContainsTypeOnlySyntax();
+
   bool canParseTypedPattern();
 
   /// Returns true if a qualified declaration name base type can be parsed.

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -2448,8 +2448,17 @@ bool Traversal::visitLifetimeDependentTypeRepr(LifetimeDependentTypeRepr *T) {
 
 bool Traversal::visitGenericArgumentExprTypeRepr(
     GenericArgumentExprTypeRepr *T) {
-  return false; // Don't walk the inner expression; it will be type-checked
-                // independently by `resolveGenericArgumentExprTypeRepr`
+  if (!Walker.shouldWalkIntoGenericArgumentExprTypeRepr())
+    return false; // Don't walk the inner expression; it will be type-checked
+                  // independently by `resolveGenericArgumentExprTypeRepr`
+
+  auto *argExpr = T->getArgExpr();
+  if (!argExpr)
+    argExpr = T->getOriginalArgExpr();
+  if (!argExpr)
+    return false;
+
+  return doIt(argExpr) == nullptr;
 }
 
 Expr *Expr::walk(ASTWalker &walker) {

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -3961,6 +3961,12 @@ CollectedOpaqueReprs swift::collectOpaqueTypeReprs(TypeRepr *r, ASTContext &ctx,
       return MacroWalking::ArgumentsAndExpansion;
     }
 
+    /// An opaque type can sit inside a generic argument that was parsed as a
+    /// value expression, such as 'G<(Int, some P)>'.
+    bool shouldWalkIntoGenericArgumentExprTypeRepr() const override {
+      return true;
+    }
+
     PreWalkAction walkToTypeReprPre(TypeRepr *repr) override {
 
       // Don't allow variadic opaque parameter or return types.

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -77,17 +77,25 @@ SourceRange TypeRepr::getSourceRange() const {
   llvm_unreachable("unknown kind!");
 }
 
-bool TypeRepr::findIf(llvm::function_ref<bool(TypeRepr *)> pred) {
+bool TypeRepr::findIf(llvm::function_ref<bool(TypeRepr *)> pred,
+                      bool walkIntoGenericArgumentExprs) {
   struct Walker : ASTWalker {
     llvm::function_ref<bool(TypeRepr *)> Pred;
+    bool WalkIntoGenericArgumentExprs;
     bool FoundIt;
 
-    explicit Walker(llvm::function_ref<bool(TypeRepr *)> pred)
-        : Pred(pred), FoundIt(false) {}
+    explicit Walker(llvm::function_ref<bool(TypeRepr *)> pred,
+                    bool walkIntoGenericArgumentExprs)
+        : Pred(pred), WalkIntoGenericArgumentExprs(walkIntoGenericArgumentExprs),
+          FoundIt(false) {}
 
     /// Walk everything in a macro
     MacroWalking getMacroWalkingBehavior() const override {
       return MacroWalking::ArgumentsAndExpansion;
+    }
+
+    bool shouldWalkIntoGenericArgumentExprTypeRepr() const override {
+      return WalkIntoGenericArgumentExprs;
     }
 
     PreWalkAction walkToTypeReprPre(TypeRepr *ty) override {
@@ -99,7 +107,7 @@ bool TypeRepr::findIf(llvm::function_ref<bool(TypeRepr *)> pred) {
     }
   };
 
-  Walker walker(pred);
+  Walker walker(pred, walkIntoGenericArgumentExprs);
   walk(walker);
   return walker.FoundIt;
 }
@@ -108,7 +116,8 @@ bool TypeRepr::findIf(llvm::function_ref<bool(TypeRepr *)> pred) {
 // `RecursiveProperties` to track this instead of computing it.
 bool TypeRepr::hasOpaque() {
   return isa<NamedOpaqueReturnTypeRepr>(this) ||
-    findIf([](TypeRepr *ty) { return isa<OpaqueReturnTypeRepr>(ty); });
+    findIf([](TypeRepr *ty) { return isa<OpaqueReturnTypeRepr>(ty); },
+           /*walkIntoGenericArgumentExprs=*/true);
 }
 
 bool TypeRepr::isParenType() const {

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -514,6 +514,19 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
     return makeParserResult(typeExpr);
   }
 
+  // 'some' followed by another identifier is an opaque type.
+  if (Tok.isContextualKeyword("some") &&
+      (peekToken().is(tok::identifier) ||
+       peekToken().isContextualPunctuator("~")) &&
+      !peekToken().isAtStartOfLine()) {
+    ParserResult<TypeRepr> ty = parseType();
+    if (ty.isNull())
+      return nullptr;
+
+    auto *typeExpr = new (Context) TypeExpr(ty.get());
+    return makeParserResult(typeExpr);
+  }
+
   // 'repeat' as an expression prefix is a pack expansion expression.
   if (Tok.is(tok::kw_repeat)) {
     SourceLoc repeatLoc = consumeToken();

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -1621,6 +1621,13 @@ ParserResult<TypeRepr> Parser::parseTypeOrValue(Diag<> MessageID,
       shouldParseValueExpr = true;
   }
 
+  // A parenthesized expression that contains type-only syntax such as an opaque
+  // 'some' type must be parsed as a type, not a value expression: opaque types
+  // have to appear as TypeReprs in the enclosing declaration.
+  if (shouldParseValueExpr && Tok.is(tok::l_paren) &&
+      parenGenericArgumentContainsTypeOnlySyntax())
+    shouldParseValueExpr = false;
+
   if (shouldParseValueExpr) {
     // Ensure that constituent references get parsed as declaration references,
     // not type references.
@@ -1633,9 +1640,29 @@ ParserResult<TypeRepr> Parser::parseTypeOrValue(Diag<> MessageID,
     }
     return makeParserResult(
         new (Context) GenericArgumentExprTypeRepr(expr.get(), &Context));
-  } else {
-    return parseType(MessageID, reason);
   }
+  return parseType(MessageID, reason);
+}
+
+bool Parser::parenGenericArgumentContainsTypeOnlySyntax() {
+  assert(Tok.is(tok::l_paren) && "not at a parenthesized generic argument");
+  BacktrackingScope backtrack(*this);
+  unsigned depth = 0;
+  do {
+    // An opaque 'some' type can only appear as a type, never as part of a
+    // value expression.
+    if (Tok.isContextualKeyword("some")) {
+      BacktrackingScope probe(*this);
+      if (canParseType())
+        return true;
+    }
+    if (Tok.isAny(tok::l_paren, tok::l_square, tok::l_brace))
+      ++depth;
+    else if (Tok.isAny(tok::r_paren, tok::r_square, tok::r_brace))
+      --depth;
+    consumeToken();
+  } while (depth > 0 && Tok.isNot(tok::eof));
+  return false;
 }
 
 bool Parser::canParseGenericValueLiteral() {

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -1622,8 +1622,9 @@ ParserResult<TypeRepr> Parser::parseTypeOrValue(Diag<> MessageID,
   }
 
   // A parenthesized expression that contains type-only syntax such as an opaque
-  // 'some' type must be parsed as a type, not a value expression: opaque types
-  // have to appear as TypeReprs in the enclosing declaration.
+  // 'some' type, or a top-level comma (making it a tuple type), must be parsed
+  // as a type, not a value expression: such types have to appear as TypeReprs
+  // in the enclosing declaration, and a tuple is never a generic value argument.
   if (shouldParseValueExpr && Tok.is(tok::l_paren) &&
       parenGenericArgumentContainsTypeOnlySyntax())
     shouldParseValueExpr = false;
@@ -1656,6 +1657,10 @@ bool Parser::parenGenericArgumentContainsTypeOnlySyntax() {
       if (canParseType())
         return true;
     }
+    // A top-level comma makes this a tuple type; tuples are never valid generic
+    // value arguments, so parse it as a type.
+    if (depth == 1 && Tok.is(tok::comma))
+      return true;
     if (Tok.isAny(tok::l_paren, tok::l_square, tok::l_brace))
       ++depth;
     else if (Tok.isAny(tok::r_paren, tok::r_square, tok::r_brace))

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -1733,10 +1733,22 @@ bool Parser::canParseGenericArguments() {
   }
 
   do {
+    // With LiteralExpressions enabled, a generic argument may be a
+    // parenthesized value expression such as '(1 + 2)'. Treat a parenthesized
+    // group as a value expression only when it is immediately followed by ','
+    // or '>'; otherwise parse it as a type so that parenthesized and function
+    // types like '(Int, Int) -> Bool' are still recognized.
+    bool parsedValueExpr = false;
     if (Context.LangOpts.hasFeature(Feature::LiteralExpressions) &&
-        Tok.is(tok::l_paren))
+        Tok.is(tok::l_paren)) {
+      CancellableBacktrackingScope backtrack(*this);
       skipSingle();
-    else if (!canParseType())
+      if (Tok.is(tok::comma) || startsWithGreater(Tok)) {
+        backtrack.cancelBacktrack();
+        parsedValueExpr = true;
+      }
+    }
+    if (!parsedValueExpr && !canParseType())
       return false;
 
     // Parse the comma, if the list continues.

--- a/test/LiteralExpressions/GenericArgumentOpaqueTypes.swift
+++ b/test/LiteralExpressions/GenericArgumentOpaqueTypes.swift
@@ -1,0 +1,40 @@
+// REQUIRES: swift_feature_LiteralExpressions
+
+// Opaque types inside a parenthesized generic argument.
+//
+// FIXME: SwiftParser has no 'some' rule in expression position, so it parses
+// these as tuple expressions and round-trip verification fails with
+// "unexpected code 'P' in tuple". Drop the flag once SwiftParser matches.
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature LiteralExpressions -disable-experimental-parser-round-trip
+
+protocol P {}
+struct S: P {}
+struct G<T> {}
+
+// An opaque type has to reach the enclosing declaration as a TypeRepr, because
+// OpaqueResultTypeRequest collects it by walking that declaration's TypeRepr
+// tree. The parser builds a TypeExpr for 'some P' even on the expression path,
+// and the collector walks into the generic argument expression to find it.
+
+var opaqueAlone: G<(some P)> { G<S>() }
+var opaqueInTuple: G<(Int, some P)> { G<(Int, S)>() }
+var opaqueInNestedTuple: G<((Int, some P))> { G<(Int, S)>() }
+
+func opaqueInParameter(_ x: G<(some P)>) {}
+func opaqueInResult() -> G<(Int, some P)> { G<(Int, S)>() }
+
+// The opaque type is a real opaque parameter, so conflicting underlying types
+// are still diagnosed.
+var conflictingUnderlyingTypes: G<(some P)> {
+  // expected-error@-1 {{function declares an opaque return type 'some P', but the return statements in its body do not have matching underlying types}}
+  if Bool.random() {
+    return G<S>() // expected-note {{return statement has underlying type 'S'}}
+  }
+  return G<S2>() // expected-note {{return statement has underlying type 'S2'}}
+}
+struct S2: P {}
+
+// Ordinals stay correct when an opaque type on the expression path sits
+// alongside one on the type path.
+func twoOpaqueTypes() -> (G<(some P)>, some P) { (G<S>(), S()) }
+func opaqueParameterAndArgument(_ x: some P, _ y: G<(some P)>) {}

--- a/test/LiteralExpressions/GenericArgumentTypeParsing.swift
+++ b/test/LiteralExpressions/GenericArgumentTypeParsing.swift
@@ -1,0 +1,42 @@
+// REQUIRES: swift_feature_LiteralExpressions
+
+// Parenthesized generic arguments that must resolve as types, not as generic
+// value expressions.
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature LiteralExpressions
+
+struct G<T> {}
+struct Pair<T, U> {}
+
+// =============================================================================
+// Function types
+//
+// The parentheses open a function type, not a value expression, so the '->'
+// must be consumed before the generic argument list's closing '>'.
+// =============================================================================
+
+func functionTypeInSignature(_ x: G<(Int, Int) -> Bool>) -> G<(Int) -> Void> {
+  return G<(Int) -> Void>()
+}
+
+func functionTypeInExpression() {
+  _ = G<(Int, Int) -> Bool>()
+  _ = G<(Int, Int) -> Bool>.self
+  _ = G<((Int) -> Int) -> Bool>()
+  _ = G<(Int, Int) throws -> Bool>()
+}
+
+let functionTypeAlongsideValue: Pair<(Int, Int) -> Bool, (2 + 3)>? = nil
+// expected-error@-1 {{cannot use value type '5' for generic argument 'U'}}
+
+// =============================================================================
+// Value expressions still take the expression path
+// =============================================================================
+
+let sum: InlineArray<(2 + 3), Int> = [1, 2, 3, 4, 5]
+let sugar: [(3 * 2) of Int] = [1, 2, 3, 4, 5, 6]
+let valueAlongsideFunctionType: InlineArray<(2 + 3), (Int, Int) -> Bool>? = nil
+
+// A tuple of values is not a generic value argument.
+let tupleOfValues: InlineArray<(1, 2), Int> = [1]
+// expected-error@-1 {{cannot convert value of type '(Int, Int)' to raw type 'Int'}}
+// expected-error@-2 {{generic value must be an integer literal expression}}

--- a/test/LiteralExpressions/GenericArgumentTypeParsing.swift
+++ b/test/LiteralExpressions/GenericArgumentTypeParsing.swift
@@ -1,0 +1,82 @@
+// REQUIRES: swift_feature_LiteralExpressions
+
+// Parenthesized generic arguments that must be parsed as types, not as
+// generic value expressions.
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature LiteralExpressions -disable-experimental-parser-round-trip
+
+protocol P {}
+struct S: P {}
+struct G<T> {}
+struct Pair<T, U> {}
+protocol Container<Element> { associatedtype Element }
+struct Box<E>: Container { typealias Element = E }
+
+// =============================================================================
+// Function types
+//
+// The parentheses open a function type, not a value expression, so the '->'
+// must be consumed before the generic argument list's closing '>'.
+// =============================================================================
+
+func functionTypeInSignature(_ x: G<(Int, Int) -> Bool>) -> G<(Int) -> Void> {
+  return G<(Int) -> Void>()
+}
+
+func functionTypeInExpression() {
+  _ = G<(Int, Int) -> Bool>()
+  _ = G<(Int, Int) -> Bool>.self
+  _ = G<((Int) -> Int) -> Bool>()
+  _ = G<(Int, Int) throws -> Bool>()
+}
+
+let functionTypeAlongsideValue: Pair<(Int, Int) -> Bool, (2 + 3)>? = nil
+// expected-error@-1 {{cannot use value type '5' for generic argument 'U'}}
+
+// =============================================================================
+// Opaque 'some' types
+//
+// An opaque type must reach the enclosing declaration as a TypeRepr, because
+// OpaqueResultTypeRequest collects it by walking the declaration's TypeRepr
+// tree. Parsing the group as an expression hides it and resolution fails with
+// "'some' types are only permitted in properties, subscripts, and functions".
+// =============================================================================
+
+var opaqueAlone: G<(some P)> { G<S>() }
+var opaqueInTuple: G<(Int, some P)> { G<(Int, S)>() }
+var opaqueInNestedTuple: G<((Int, some P))> { G<(Int, S)>() }
+
+func opaqueInParameter(_ x: G<(some P)>) {}
+func opaqueInResult() -> G<(Int, some P)> { G<(Int, S)>() }
+
+// 'any' and protocol compositions recover from the expression path, but check
+// that they keep working here.
+var existentialInTuple: G<(Int, any P)>? { nil }
+
+// =============================================================================
+// Tuple types
+//
+// A top-level comma makes the group a tuple type. It is never a generic value
+// argument, so routing it to the expression parser produced a spurious
+// 'circular reference' when the tuple mentioned Self or an associated type.
+// =============================================================================
+
+let tupleArgument: G<(Int, String)> = G<(Int, String)>()
+let parenthesizedArgument: G<(Int)> = G<Int>()
+
+protocol SelfReferencingTuple {
+  associatedtype A
+  associatedtype B: Container<(A, Self)>
+}
+
+struct ConformsToSelfReferencingTuple: SelfReferencingTuple {
+  typealias A = Int
+  typealias B = Box<(Int, ConformsToSelfReferencingTuple)>
+}
+
+// =============================================================================
+// Value expressions still take the expression path
+// =============================================================================
+
+let sum: InlineArray<(2 + 3), Int> = [1, 2, 3, 4, 5]
+let sugar: [(3 * 2) of Int] = [1, 2, 3, 4, 5, 6]
+let valueAlongsideFunctionType: InlineArray<(2 + 3), (Int, Int) -> Bool>? = nil


### PR DESCRIPTION
- **Fix generic-argument recognition of function types**
`canParseGenericArguments` unconditionally skipped a parenthesized group at the start of a generic argument, so a function type like `(Int, Int) -> Bool` left its `->` dangling and the argument list's closing `>` was never matched. With `LiteralExpressions` enabled this rejects valid code such as  `Foo<(Int, Int) -> Bool>`. Treat the parentheses as a value expression only when immediately followed by `,` or `>`; otherwise, parse a type, matching the disambiguation already used in `parseTypeOrValue`.

- **Find opaque types in generic arguments**
With `LiteralExpressions` enabled, `G<(Int, some P)>` puts the opaque type inside a `GenericArgumentExprTypeRepr`. The expression parser had no `some` rule, so it resolved `some` as a declaration reference and reported "cannot find `some` in scope". Parse it as a type instead, matching the `any`, `@`,`inout`, and `nonisolated` rules that already delegate to parseType.
The implicit `OpaqueTypeDecl` is also collected by walking the enclosing declaration's `TypeRepr` tree, and that walk stops at a `GenericArgumentExprTypeRepr`. Add an ASTWalker opt-in for walking into the argument expression, and use it from `collectOpaqueTypeReprs` and `TypeRepr::hasOpaque`. The walk stays off by-default because the argument expression is type-checked separately and must not reach the constraint-system walkers.