### PR TITLE
utils: Add `/source-charset:utf-8` to MSVC flags

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1833,7 +1833,7 @@ $Compilers = @{
     C = @{
       Executable        = "cl.exe"
       DriverStyle       = [DriverStyle]::CL
-      Flags             = @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:inline", "/Zc:preprocessor")
+      Flags             = @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/utf-8", "/Zc:inline", "/Zc:preprocessor")
       DebugFlags        = { param([string] $Format)
         @()
       }
@@ -1842,7 +1842,7 @@ $Compilers = @{
     CXX = @{
       Executable        = "cl.exe"
       DriverStyle       = [DriverStyle]::CL
-      Flags             = @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:inline", "/Zc:preprocessor", "/Zc:__cplusplus")
+      Flags             = @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/utf-8", "/Zc:inline", "/Zc:preprocessor", "/Zc:__cplusplus")
       DebugFlags        = { param([string] $Format)
         @()
       }

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1833,7 +1833,7 @@ $Compilers = @{
     C = @{
       Executable        = "cl.exe"
       DriverStyle       = [DriverStyle]::CL
-      Flags             = @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/utf-8", "/Zc:inline", "/Zc:preprocessor")
+      Flags             = @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/source-charset:utf-8", "/Zc:inline", "/Zc:preprocessor")
       DebugFlags        = { param([string] $Format)
         @()
       }
@@ -1842,7 +1842,7 @@ $Compilers = @{
     CXX = @{
       Executable        = "cl.exe"
       DriverStyle       = [DriverStyle]::CL
-      Flags             = @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/utf-8", "/Zc:inline", "/Zc:preprocessor", "/Zc:__cplusplus")
+      Flags             = @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/source-charset:utf-8", "/Zc:inline", "/Zc:preprocessor", "/Zc:__cplusplus")
       DebugFlags        = { param([string] $Format)
         @()
       }


### PR DESCRIPTION
This is necessary with recent versions of MSVC because cl.exe fails to parse `swift/include/swift/AST/LocalizationLangauges.def`, which contains Unicode characters. The MSVC documentation states that, absent a BOM, the compiler defaults to the current user code page, unless a code page is specified by using `/source-charset:utf-8`. [1]

[1] https://learn.microsoft.com/en-us/cpp/build/reference/utf-8-set-source-and-executable-character-sets-to-utf-8
