### PR TITLE
[android][test] Fully disable C++ bridging test that fails with the planned LTS NDK 30 beta 2 CI

### DIFF
--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
@@ -21,6 +21,9 @@
 // RUN: %target-interop-build-clangxx -fsyntax-only -x c++-header %t/full-cxx-swift-cxx-bridging.h -std=gnu++17 -c -fmodules -fcxx-modules -I %t 
 // FIXME: test c++20 (rdar://117419434)
 
+// Failing for Android since NDK 29, android/ndk#2242
+// UNSUPPORTED: OS=linux-android, OS=linux-androideabi
+
 //--- header.h
 
 struct Trivial {


### PR DESCRIPTION
NDK 30 CI are planned in swiftlang/swift-docker#580, while swiftlang/swift-docker#579 shows the need for this temporary change while we figure out the modularity issue upstream.