### PR TITLE
AST: classify COM declarations

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4413,6 +4413,72 @@ enum KeyPathTypeKind : unsigned char {
   KPTK_ReferenceWritableKeyPath
 };
 
+/// The COM role and associated declaration information for a nominal type.
+///
+/// A protocol can declare an interface, while a class can provide an
+/// implementation. Other nominal declarations have no COM declaration info.
+class COMDeclInfo {
+public:
+  enum class Kind : uint8_t {
+    Interface,
+    Implementation,
+  };
+
+private:
+  Kind DeclKind;
+  StringRef ID;
+  std::optional<COMThreadingModel> ThreadingModel;
+  ArrayRef<ProtocolDecl *> Interfaces;
+
+  COMDeclInfo(Kind kind, StringRef id, std::optional<COMThreadingModel> model,
+              ArrayRef<ProtocolDecl *> interfaces)
+      : DeclKind(kind), ID(id), ThreadingModel(model), Interfaces(interfaces) {}
+
+public:
+  static COMDeclInfo forInterface(StringRef iid) {
+    return {Kind::Interface, iid, std::nullopt, {}};
+  }
+
+  static COMDeclInfo
+  forImplementation(StringRef clsid,
+                    std::optional<COMThreadingModel> threadingModel,
+                    ArrayRef<ProtocolDecl *> interfaces) {
+    return {Kind::Implementation, clsid, threadingModel, interfaces};
+  }
+
+  Kind getKind() const { return DeclKind; }
+  bool isInterface() const { return DeclKind == Kind::Interface; }
+  bool isImplementation() const {
+    return DeclKind == Kind::Implementation;
+  }
+
+  StringRef getInterfaceID() const {
+    assert(isInterface());
+    return ID;
+  }
+
+  std::optional<StringRef> getImplementationID() const {
+    assert(isImplementation());
+    if (ID.empty())
+      return std::nullopt;
+    return ID;
+  }
+
+  /// The effective threading model for an \c \@com implementation
+  /// declaration. This is absent when the implementation is classified solely
+  /// from its COM interface conformances.
+  std::optional<COMThreadingModel> getThreadingModel() const {
+    assert(isImplementation());
+    return ThreadingModel;
+  }
+
+  /// The COM interfaces to which this implementation conforms.
+  ArrayRef<ProtocolDecl *> getInterfaces() const {
+    assert(isImplementation());
+    return Interfaces;
+  }
+};
+
 /// NominalTypeDecl - a declaration of a nominal type, like a struct.
 class NominalTypeDecl : public GenericTypeDecl, public IterableDeclContext {
   SourceRange Braces;
@@ -4684,6 +4750,10 @@ public:
   ///
   /// \param sorted Whether to sort the protocols in canonical order.
   SmallVector<ProtocolDecl *, 2> getAllProtocols(bool sorted = false) const;
+
+  /// Retrieve this nominal declaration's COM role and associated information,
+  /// or \c nullptr when it is not a COM interface or implementation.
+  const COMDeclInfo *getCOMDeclInfo() const;
 
   /// Retrieve all of the protocol conformances for this nominal type.
   SmallVector<ProtocolConformance *, 2> getAllConformances(
@@ -5428,13 +5498,13 @@ public:
   /// allocation, etc.), the Swift model, or has no reference counting at all.
   ReferenceCounting getObjectModel() const;
 
-  /// Whether this class participates in the COM object model, i.e. it conforms
-  /// to a COM interface (a protocol marked \c \@com).
+  /// Whether this class provides a COM implementation.
   ///
-  /// Keying on the \c \@com marker rather than a shared root such as
-  /// \c IUnknown covers rootless COM frameworks such as IOKit; keying on
-  /// conformance rather than the class's own attribute covers subclasses.
-  bool isCOMObject() const;
+  /// This includes both explicitly \c \@com classes and classes that conform to
+  /// a COM interface.
+  bool isCOMImplementation() const {
+    return getCOMDeclInfo() != nullptr;
+  }
 
   LayoutConstraintKind getLayoutConstraintKind() const {
     if (getObjectModel() == ReferenceCounting::ObjC)
@@ -5740,6 +5810,11 @@ public:
 
   /// Determine whether this protocol has a superclass.
   bool hasSuperclass() const { return (bool)getSuperclassDecl(); }
+
+  /// Whether this protocol declares a COM interface.
+  bool isCOMInterface() const {
+    return getCOMDeclInfo() != nullptr;
+  }
 
   /// Retrieve the ClassDecl for the superclass of this protocol, or null if there
   /// is no superclass.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -52,6 +52,7 @@ class AvailabilityScope;
 class BreakStmt;
 class ContextualPattern;
 class ContinueStmt;
+class COMDeclInfo;
 class DefaultArgumentExpr;
 class DefaultArgumentType;
 class DoCatchStmt;
@@ -1257,11 +1258,11 @@ public:
   bool isCached() const { return true; }
 };
 
-/// Determine whether a class participates in the COM object model, i.e. it
-/// conforms to a protocol marked \c \@com.
-class IsCOMObjectRequest :
-    public SimpleRequest<IsCOMObjectRequest,
-                         bool(ClassDecl *),
+/// Retrieve the COM role and associated declaration information for a nominal
+/// type, or \c nullptr when it is not a COM interface or implementation.
+class COMDeclInfoRequest :
+    public SimpleRequest<COMDeclInfoRequest,
+                         const COMDeclInfo *(NominalTypeDecl *),
                          RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -1269,7 +1270,8 @@ public:
 private:
   friend SimpleRequest;
 
-  bool evaluate(Evaluator &evaluator, ClassDecl *classDecl) const;
+  const COMDeclInfo *evaluate(Evaluator &evaluator,
+                              NominalTypeDecl *nominal) const;
 
 public:
   // Caching

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -113,7 +113,8 @@ SWIFT_REQUEST(TypeChecker, ResultBuilderTypeRequest, Type(ValueDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsActorRequest, bool(NominalTypeDecl *),
               Cached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, IsCOMObjectRequest, bool(ClassDecl *),
+SWIFT_REQUEST(TypeChecker, COMDeclInfoRequest,
+              const COMDeclInfo *(NominalTypeDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsDefaultActorRequest,
               bool(ClassDecl *, ModuleDecl *, ResilienceExpansion),

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7430,15 +7430,15 @@ ReferenceCounting ClassDecl::getObjectModel() const {
   return ReferenceCounting::Native;
 }
 
-bool ClassDecl::isCOMObject() const {
+const COMDeclInfo *NominalTypeDecl::getCOMDeclInfo() const {
   // COM is only in play when the experimental interop is enabled; keep the
   // common case free and never touch the evaluator cache for it.
   if (!getASTContext().LangOpts.EnableCOMInterop)
-    return false;
+    return nullptr;
 
-  auto *mutableThis = const_cast<ClassDecl *>(this);
+  auto *mutableThis = const_cast<NominalTypeDecl *>(this);
   return evaluateOrDefault(getASTContext().evaluator,
-                           IsCOMObjectRequest{mutableThis}, false);
+                           COMDeclInfoRequest{mutableThis}, nullptr);
 }
 
 EnumCaseDecl *EnumCaseDecl::create(SourceLoc CaseLoc,

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2247,13 +2247,13 @@ static void populateMembersForLazyName(DeclName name, NominalTypeDecl *decl,
   if (ctx.LangOpts.EnableCOMInterop) {
     if (auto *PD = dyn_cast<ProtocolDecl>(decl)) {
       if (name.isSimpleName(ctx.Id_IID) &&
-          PD->getAttrs().hasAttribute<COMAttr>() && PD->isInSwiftSourceFile()) {
+          PD->isCOMInterface() && PD->isInSwiftSourceFile()) {
         evaluateOrDefault(ctx.evaluator, SynthesizeCOMInterfaceIDRequest{PD},
                           nullptr);
       }
     } else if (auto *CD = dyn_cast<ClassDecl>(decl)) {
       if (name.isSimpleName(ctx.Id_CLSID) &&
-          CD->getAttrs().hasAttribute<COMAttr>() && CD->isInSwiftSourceFile()) {
+          CD->isCOMImplementation() && CD->isInSwiftSourceFile()) {
         evaluateOrDefault(ctx.evaluator,
                           SynthesizeCOMImplementationIDRequest{CD}, nullptr);
       }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2495,7 +2495,7 @@ void AttributeChecker::visitCOMAttr(COMAttr *attr) {
       return;
     }
 
-    if (attr->CLSID && !attr->CLSID->empty()) {
+    if (attr->CLSID) {
       diagnose(attr->getLocation(), diag::attr_com_protocol_unexpected_arg, "CLSID");
       attr->setInvalid();
       return;

--- a/lib/Sema/TypeCheckCOM.cpp
+++ b/lib/Sema/TypeCheckCOM.cpp
@@ -257,17 +257,65 @@ VarDecl *lookupCOMImplementationID(ClassDecl *CD) {
   return nullptr;
 }
 
+const COMAttr *getAttribute(const ClassDecl *CD) {
+  auto *attr = CD->getAttrs().getAttribute<COMAttr>();
+  if (!attr)
+    return nullptr;
+
+  ASSERT(attr->IID.empty());
+  ASSERT(!attr->CLSID || !attr->CLSID->empty());
+  return attr;
+}
+
+const COMAttr *getAttribute(const ProtocolDecl *PD) {
+  auto *attr = PD->getAttrs().getAttribute<COMAttr>();
+  if (!attr)
+    return nullptr;
+
+  ASSERT(!attr->IID.empty());
+  ASSERT(!attr->CLSID);
+  return attr;
+}
+
 }
 }
 
 namespace swift {
-bool IsCOMObjectRequest::evaluate(Evaluator &evaluator, ClassDecl *CD) const {
-  // A class participates in the COM object model when it conforms to a COM
-  // interface, a protocol marked @com.
-  for (auto *proto : CD->getAllProtocols())
-    if (proto->getAttrs().hasAttribute<COMAttr>())
-      return true;
-  return false;
+const COMDeclInfo *
+COMDeclInfoRequest::evaluate(Evaluator &evaluator,
+                             NominalTypeDecl *nominal) const {
+  auto &ctx = nominal->getASTContext();
+
+  if (auto *PD = dyn_cast<ProtocolDecl>(nominal)) {
+    auto *attr = ::com::getAttribute(PD);
+    if (!attr)
+      return nullptr;
+
+    return ctx.AllocateObjectCopy(COMDeclInfo::forInterface(attr->IID));
+  } else if (auto *CD = dyn_cast<ClassDecl>(nominal)) {
+    SmallVector<ProtocolDecl *, 2> interfaces;
+    for (auto *proto : CD->getAllProtocols(/*sorted=*/true)) {
+      if (proto->isCOMInterface())
+        interfaces.push_back(proto);
+    }
+
+    auto *attr = ::com::getAttribute(CD);
+    if (!attr && interfaces.empty())
+      return nullptr;
+
+    StringRef implementationID;
+    std::optional<COMThreadingModel> threadingModel;
+    if (attr) {
+      if (attr->CLSID)
+        implementationID = *attr->CLSID;
+      threadingModel = attr->getThreadingModel();
+    }
+
+    return ctx.AllocateObjectCopy(COMDeclInfo::forImplementation(
+        implementationID, threadingModel, ctx.AllocateCopy(interfaces)));
+  }
+
+  return nullptr;
 }
 
 ProtocolConformance *
@@ -276,7 +324,7 @@ com::deriveImplicitConformance(NominalTypeDecl *NTD, KnownProtocolKind KP) {
   if (CD == nullptr)
     return nullptr;
 
-  if (!CD->getAttrs().hasAttribute<COMAttr>())
+  if (!::com::getAttribute(CD))
     return nullptr;
 
   ASTContext &context = NTD->getASTContext();
@@ -324,10 +372,8 @@ com::deriveImplicitConformance(NominalTypeDecl *NTD, KnownProtocolKind KP) {
 VarDecl *SynthesizeCOMInterfaceIDRequest::evaluate(Evaluator &evaluator,
                                                    ProtocolDecl *PD) const {
   auto &ASTContext = PD->getASTContext();
-  if (!ASTContext.LangOpts.EnableCOMInterop)
-    return nullptr;
-  auto *attr = PD->getAttrs().getAttribute<COMAttr>();
-  if (!attr || attr->isInvalid() || attr->IID.empty())
+  auto *info = PD->getCOMDeclInfo();
+  if (!info)
     return nullptr;
   // Only synthesize for a protocol defined in a source file of the module being
   // compiled.  A deserialized module or swiftinterface already carries the
@@ -335,21 +381,22 @@ VarDecl *SynthesizeCOMInterfaceIDRequest::evaluate(Evaluator &evaluator,
   // would duplicate it, or fabricate a member absent from an older interface.
   if (!PD->isInSwiftSourceFile())
     return ::com::lookupCOMInterfaceID(PD);
-  return ::com::synthesizeIIDProperty(PD, ASTContext, attr->IID);
+  return ::com::synthesizeIIDProperty(PD, ASTContext, info->getInterfaceID());
 }
 
 VarDecl *SynthesizeCOMImplementationIDRequest::evaluate(Evaluator &evaluator,
                                                         ClassDecl *CD) const {
   auto &ASTContext = CD->getASTContext();
-  if (!ASTContext.LangOpts.EnableCOMInterop)
+  auto *info = CD->getCOMDeclInfo();
+  if (!info)
     return nullptr;
-  auto *attr = CD->getAttrs().getAttribute<COMAttr>();
-  if (!attr || attr->isInvalid() || !attr->CLSID || attr->CLSID->empty())
+  auto implementationID = info->getImplementationID();
+  if (!implementationID)
     return nullptr;
   // Synthesize only for a source-file class; recover the imported member by
   // name lookup (see SynthesizeCOMInterfaceIDRequest).
   if (!CD->isInSwiftSourceFile())
     return ::com::lookupCOMImplementationID(CD);
-  return ::com::synthesizeCLSIDProperty(CD, ASTContext, *attr->CLSID);
+  return ::com::synthesizeCLSIDProperty(CD, ASTContext, *implementationID);
 }
 }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2941,11 +2941,11 @@ static ArrayRef<Decl *> evaluateMembersRequest(
   // forces them.  For imported types the request finds the deserialized member.
   if (ctx.LangOpts.EnableCOMInterop) {
     if (auto *PD = dyn_cast_or_null<ProtocolDecl>(nominal)) {
-      if (PD->getAttrs().hasAttribute<COMAttr>())
+      if (PD->isCOMInterface())
         (void)evaluateOrDefault(ctx.evaluator,
                                 SynthesizeCOMInterfaceIDRequest{PD}, nullptr);
     } else if (auto *CD = dyn_cast_or_null<ClassDecl>(nominal)) {
-      if (CD->getAttrs().hasAttribute<COMAttr>())
+      if (CD->isCOMImplementation())
         (void)evaluateOrDefault(ctx.evaluator,
                                 SynthesizeCOMImplementationIDRequest{CD}, nullptr);
     }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2231,14 +2231,11 @@ static void dumpGenericSignature(ASTContext &ctx, GenericContext *GC) {
 
 namespace {
 
-/// A metatype extension is a COM construct when it extends a COM interface
-/// — a protocol marked @com. The @com marker, not derivation from IUnknown,
-/// is the key: COM-model frameworks like IOKit use QI/AddRef/Release without
-/// deriving from a shared IUnknown, so keying on the marker (which the Clang
-/// importer can also apply to imported interfaces) is what makes this correct.
+/// A metatype extension is a COM construct when it extends a declaration
+/// canonically classified as a COM interface.
 static bool isCOMMetatypeExtension(const ExtensionDecl *ED) {
   auto *proto = dyn_cast_or_null<ProtocolDecl>(ED->getExtendedNominal());
-  return proto && proto->getAttrs().hasAttribute<COMAttr>();
+  return proto && proto->isCOMInterface();
 }
 
 class DeclChecker : public DeclVisitor<DeclChecker> {

--- a/test/Sema/COM-GUID-cross-module.swift
+++ b/test/Sema/COM-GUID-cross-module.swift
@@ -12,3 +12,4 @@ import COM
 import A
 
 let _: GUID = IWidget.IID   // re-derived in the importer from the deserialized @com attribute
+let _: GUID = Widget.CLSID

--- a/test/Sema/COM-GUID-synthesis.swift
+++ b/test/Sema/COM-GUID-synthesis.swift
@@ -34,6 +34,7 @@ let _ = BareWidget.CLSID // expected-error {{type 'BareWidget' has no member 'CL
 
 class ConcreteWidget: IWidget { }
 let _ = ConcreteWidget.IID // expected-error {{type 'ConcreteWidget' has no member 'IID'}}
+let _ = ConcreteWidget.CLSID // expected-error {{type 'ConcreteWidget' has no member 'CLSID'}}
 
 // --- Well-known protocols from the COM module
 

--- a/test/Sema/COMAttr.swift
+++ b/test/Sema/COMAttr.swift
@@ -61,6 +61,16 @@ protocol IInterface6: IUnknown { }
 protocol IInterface7: IUnknown { }
 // expected-error@-2 {{'@com' on a protocol requires 'interface:' argument}}
 
+@com(interface: "00000000-0000-0000-0000-000000000008",
+     implementation: "00000000-0000-0000-0000-000000000009")
+protocol IInterface8: IUnknown { }
+// expected-error@-3 {{'@com' on a protocol must only have 'interface:'; 'CLSID' is not allowed}}
+
+@com(interface: "00000000-0000-0000-0000-000000000010",
+     implementation: "")
+protocol IInterface9: IUnknown { }
+// expected-error@-3 {{'@com' on a protocol must only have 'interface:'; 'CLSID' is not allowed}}
+
 @com(interface: "00000000-0000-0000-0000-000000000000")
 class CClass10 { }
 // expected-error@-2 {{'@com' on a class must not have 'interface:'; use 'implementation:' instead}}
@@ -72,3 +82,12 @@ class CClass11 { }
 @com(implementation: "")
 class CClass12 { }
 // expected-error@-2 {{'' is not a valid GUID}}
+
+// Declaration classification admits only a valid @com(interface:) protocol.
+// In particular, the presence of a malformed attribute must not unlock the
+// otherwise-reserved protocol metatype extension feature.
+extension IInterface1.Protocol {}
+extension IInterface4.Protocol {}
+// expected-error@-1 {{protocol metatype extensions are reserved for COM interop}}
+extension IInterface8.Protocol {}
+// expected-error@-1 {{protocol metatype extensions are reserved for COM interop}}

--- a/test/Sema/Inputs/com_iwidget_moduleA.swift
+++ b/test/Sema/Inputs/com_iwidget_moduleA.swift
@@ -2,3 +2,6 @@ import COM
 
 @com(interface: "10000000-0000-0000-0000-000000000001")
 public protocol IWidget: IUnknown { }
+
+@com(implementation: "20000000-0000-0000-0000-000000000002")
+public class Widget: IWidget { }

--- a/test/Sema/metatype-extension-cross-module.swift
+++ b/test/Sema/metatype-extension-cross-module.swift
@@ -15,3 +15,11 @@ let _: String = IWidget.describe()
 
 // The synthesized IID is still reachable too.
 let _: GUID = IWidget.IID
+
+// Declaration classification is reconstructed from the deserialized @com
+// attribute, so a client can also extend the imported interface metatype.
+extension IWidget.Protocol {
+  var clientTag: Int { 8 }
+}
+
+let _: Int = IWidget.clientTag


### PR DESCRIPTION
COM interfaces and their class implementations are two roles in the same object model, but the compiler previously rediscovered them through separate attribute and conformance checks. That split could make IID and implementation metadata disagree with the predicates used by semantic analysis and IRGen.

Add a cached COMDeclInfoRequest over NominalTypeDecl with interface and implementation results. The interface view carries its validated IID; the implementation view carries activation metadata and the canonically ordered COM interface conformances. Keep isCOMInterface and isCOMImplementation as typed convenience predicates over the shared result.

Use the declaration info for identity synthesis, metatype extensions, implementation discovery, and lazy member population. Cover malformed declarations, conformance-only implementations, and deserialized interface and implementation metadata.