### PR TITLE
[IRGen] Use the concrete payload type for additional enum cases

### DIFF
--- a/lib/IRGen/EnumPayload.cpp
+++ b/lib/IRGen/EnumPayload.cpp
@@ -633,6 +633,13 @@ EnumPayload::emitGatherSpareBits(IRGenFunction &IGF,
     if (DL.isBigEndian()) {
       offset = bitWidth - usedBits - numBitsInPart;
     }
+    // emitGatherBits operates on integers, so cast a pointer-typed payload
+    // element (the `.none == null` optional-reference representation) to an
+    // integer of the same width first.
+    if (!isa<llvm::IntegerType>(v->getType())) {
+      auto *intTy = llvm::IntegerType::get(C, size);
+      v = IGF.Builder.CreateBitOrPointerCast(v, intTy);
+    }
     // Get the spare bits from this part.
     auto bits = irgen::emitGatherBits(IGF, spareBitsPart,
                                       v, offset, resultBitWidth);

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -1978,22 +1978,73 @@ namespace {
                .getFixedExtraInhabitantCount(IGM) > 0;
     }
 
+    /// Whether a loadable single-payload enum can carry its payload directly as
+    /// a pointer, lowering the whole enum to `ptr` in LLVM IR.
+    ///
+    /// This holds when the payload occupies exactly one scalar pointer that
+    /// holds a managed reference -- either a bare retainable pointer, or
+    /// another enum that is itself already lowered this way (e.g. a nested
+    /// optional) -- and the payload has at least as many extra inhabitants as
+    /// the enum has no-payload cases. In that case every empty case is encoded
+    /// as one of the payload's low, invalid-pointer extra inhabitants and the
+    /// enum needs no separate tag storage, so it has the payload's
+    /// single-pointer layout. Only genuine (valid) pointer values are ever
+    /// loaded or dereferenced, so carrying the empty cases' sentinel bit
+    /// patterns in a `ptr` is safe.
+    ///
+    /// This is a strict superset of `isNullableRefcountedPayload`, which is the
+    /// special case of a single `.none == null` empty case (and additionally
+    /// permits the NullableRefcounted copy/destroy shortcut). The broader set
+    /// here -- multiple empty cases and arbitrarily nested optionals -- still
+    /// lowers to `ptr` but relies on the normal tag-checking copy/destroy.
+    static bool canRepresentPayloadAsPointer(IRGenModule &IGM,
+                                             const TypeInfo &payloadTI,
+                                             TypeInfoKind tik,
+                                             unsigned numNoPayloadCases) {
+      if (tik < TypeInfoKind::Loadable)
+        return false;
+      auto *fixedTI = dyn_cast<FixedTypeInfo>(&payloadTI);
+      if (!fixedTI)
+        return false;
+      // Every no-payload case must fit in one of the payload's extra
+      // inhabitants, so the enum keeps the payload's single-pointer layout with
+      // no separate tag storage.
+      if (fixedTI->getFixedExtraInhabitantCount(IGM) < numNoPayloadCases)
+        return false;
+      // The payload must occupy exactly one scalar pointer.
+      ExplosionSchema schema;
+      payloadTI.getSchema(schema);
+      if (schema.size() != 1 || !schema.begin()->isScalar() ||
+          !schema.begin()->getScalarType()->isPointerTy())
+        return false;
+      // ...and hold a managed reference. A single retainable pointer qualifies
+      // directly; a nested optional qualifies because it is itself already
+      // lowered to `ptr` and is non-trivial. Excluding trivially-destroyable
+      // pointers (metatypes, unsafe pointers, ...) keeps unrelated types on
+      // their existing integer representation.
+      return payloadTI.isSingleRetainablePointer(ResilienceExpansion::Maximal,
+                                                 nullptr) ||
+             !payloadTI.isTriviallyDestroyable(ResilienceExpansion::Maximal);
+    }
+
     static EnumPayloadSchema
     getPreferredPayloadSchema(IRGenModule &IGM, Element payloadElement,
                               TypeInfoKind tik, unsigned numNoPayloadCases) {
       // TODO: If the payload type info provides a preferred explosion schema,
       // use it. For now, just use a generic word-chunked schema.
       if (auto fixedTI = dyn_cast<FixedTypeInfo>(payloadElement.ti)) {
-        // When the empty case is exactly the zero pointer, represent the
-        // payload as its own pointer type so the enum lowers to `ptr` in LLVM
-        // IR with `.none == null`, rather than an opaque integer word.
-        if (isNullableRefcountedPayload(IGM, *fixedTI, tik, numNoPayloadCases,
-                                        /*refcounting=*/nullptr)) {
+        // When the payload is a single pointer and all empty cases fit in its
+        // extra inhabitants, represent the payload as its own pointer type so
+        // the enum lowers to `ptr` in LLVM IR (with the empty cases occupying
+        // low invalid-pointer values), rather than an opaque integer word.
+        if (canRepresentPayloadAsPointer(IGM, *fixedTI, tik,
+                                         numNoPayloadCases)) {
           ExplosionSchema payloadSchema;
           fixedTI->getSchema(payloadSchema);
-          assert(payloadSchema.size() == 1 && payloadSchema.begin()->isScalar()
-                 && payloadSchema.begin()->getScalarType()->isPointerTy()
-                 && "single retainable pointer should be one scalar pointer");
+          assert(payloadSchema.size() == 1 &&
+                 payloadSchema.begin()->isScalar() &&
+                 payloadSchema.begin()->getScalarType()->isPointerTy() &&
+                 "pointer-representable payload should be one scalar pointer");
           return EnumPayloadSchema::withExplicitTypes(
               payloadSchema.begin()->getScalarType());
         }

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -1978,53 +1978,111 @@ namespace {
                .getFixedExtraInhabitantCount(IGM) > 0;
     }
 
-    /// Whether a loadable single-payload enum can carry its payload directly as
-    /// a pointer, lowering the whole enum to `ptr` in LLVM IR.
+    /// Whether a loadable single-payload enum can carry its payload with some
+    /// of its words typed as pointers (`ptr`) rather than as opaque integer
+    /// words. On success `types` receives the payload's element types.
     ///
-    /// This holds when the payload occupies exactly one scalar pointer that
-    /// holds a managed reference -- either a bare retainable pointer, or
-    /// another enum that is itself already lowered this way (e.g. a nested
-    /// optional) -- and the payload has at least as many extra inhabitants as
-    /// the enum has no-payload cases. In that case every empty case is encoded
-    /// as one of the payload's low, invalid-pointer extra inhabitants and the
-    /// enum needs no separate tag storage, so it has the payload's
-    /// single-pointer layout. Only genuine (valid) pointer values are ever
-    /// loaded or dereferenced, so carrying the empty cases' sentinel bit
-    /// patterns in a `ptr` is safe.
+    /// This holds when the payload holds a managed reference and stores the
+    /// enum's tag in that reference's extra inhabitants:
+    ///   * the payload has at least as many extra inhabitants as the enum has
+    ///     no-payload cases, so every empty case is one of the payload's low,
+    ///     invalid-pointer extra inhabitants and no separate tag storage is
+    ///     needed (the enum keeps the payload's own layout); and
+    ///   * the payload is non-trivial, i.e. it contains a managed reference
+    ///     (whose extra inhabitants the tag rides in) -- this also keeps
+    ///     unrelated pointer-shaped-but-trivial types (metatypes, unsafe
+    ///     pointers, ...) on their existing integer representation.
+    /// Only genuine (valid) pointer values are ever loaded or dereferenced, so
+    /// carrying the empty cases' sentinel bit patterns in a `ptr` is safe.
+    ///
+    /// The payload is chunked into pointer-sized words exactly as the generic
+    /// integer schema would (so the element offsets, sizes, and the overall
+    /// layout are unchanged), but every word that holds a single pointer is
+    /// typed `ptr` instead of an integer. Because a pointer is pointer-aligned
+    /// and pointer-sized it always fills one whole word, so any padding around
+    /// it stays inside the neighbouring integer words -- this handles payloads
+    /// whose reference is not word-adjacent (e.g. `{ Int32, Class }`) without
+    /// having to model inter-field padding.
+    ///
+    /// The pointers are located by walking the payload's loadable explosion
+    /// schema and reconstructing each element's offset by natural alignment.
+    /// (The in-memory storage type can't be used: a `.none == null` optional is
+    /// lowered to `ptr` in its explosion but keeps an opaque `[N x i8]` storage
+    /// type, so a nested optional's pointer would be missed.) A final check
+    /// that the reconstruction reproduces the payload's real size guards
+    /// against any layout whose fields are not naturally aligned.
     ///
     /// This is a strict superset of `isNullableRefcountedPayload`, which is the
-    /// special case of a single `.none == null` empty case (and additionally
-    /// permits the NullableRefcounted copy/destroy shortcut). The broader set
-    /// here -- multiple empty cases and arbitrarily nested optionals -- still
-    /// lowers to `ptr` but relies on the normal tag-checking copy/destroy.
-    static bool canRepresentPayloadAsPointer(IRGenModule &IGM,
-                                             const TypeInfo &payloadTI,
-                                             TypeInfoKind tik,
-                                             unsigned numNoPayloadCases) {
+    /// special case of a single `.none == null` empty case over a single bare
+    /// retainable pointer (and additionally permits the NullableRefcounted
+    /// copy/destroy shortcut). The broader set here -- multiple empty cases,
+    /// nested optionals, and multi-word payloads such as a class-bound
+    /// existential -- relies on the normal tag-checking copy/destroy.
+    static bool
+    tryGetConcretePayloadTypes(IRGenModule &IGM, const TypeInfo &payloadTI,
+                               TypeInfoKind tik, unsigned numNoPayloadCases,
+                               SmallVectorImpl<llvm::Type *> &types) {
       if (tik < TypeInfoKind::Loadable)
         return false;
       auto *fixedTI = dyn_cast<FixedTypeInfo>(&payloadTI);
       if (!fixedTI)
         return false;
-      // Every no-payload case must fit in one of the payload's extra
-      // inhabitants, so the enum keeps the payload's single-pointer layout with
-      // no separate tag storage.
+      // The tag must fit in the payload's extra inhabitants, so the enum adds
+      // no separate tag storage and keeps the payload's own layout.
       if (fixedTI->getFixedExtraInhabitantCount(IGM) < numNoPayloadCases)
         return false;
-      // The payload must occupy exactly one scalar pointer.
+      // The payload must hold a managed reference (whose extra inhabitants the
+      // tag rides in). Excluding trivially-destroyable payloads keeps unrelated
+      // pointer-shaped types (metatypes, unsafe pointers, ...) on their integer
+      // representation.
+      if (payloadTI.isTriviallyDestroyable(ResilienceExpansion::Maximal))
+        return false;
+
+      auto &DL = IGM.DataLayout;
+      uint64_t ptrBytes = IGM.getPointerSize().getValue();
+      unsigned ptrBits = IGM.getPointerSize().getValueInBits();
+      uint64_t payloadBytes = fixedTI->getFixedSize().getValue();
+      uint64_t numWords = payloadBytes / ptrBytes;
+
       ExplosionSchema schema;
       payloadTI.getSchema(schema);
-      if (schema.size() != 1 || !schema.begin()->isScalar() ||
-          !schema.begin()->getScalarType()->isPointerTy())
+
+      // Walk the explosion, reconstructing each element's offset by natural
+      // alignment, and build the word-chunked schema directly: each pointer
+      // emits its own `ptr` word, and the whole words before it are filled with
+      // integers.
+      uint64_t offset = 0;   // running byte offset in the payload
+      uint64_t nextWord = 0; // number of whole words already appended
+      bool hasPointer = false;
+      for (auto &elt : schema) {
+        if (!elt.isScalar())
+          return false;
+        auto *ty = elt.getScalarType();
+        offset = llvm::alignTo(offset, DL.getABITypeAlign(ty).value());
+        if (ty->isPointerTy()) {
+          uint64_t word = offset / ptrBytes; // pointer-aligned, fills one word
+          for (; nextWord < word; ++nextWord)
+            types.push_back(IGM.SizeTy);
+          types.push_back(IGM.PtrTy);
+          ++nextWord;
+          hasPointer = true;
+        }
+        offset += DL.getTypeAllocSize(ty);
+      }
+
+      // Bail unless the naturally-aligned reconstruction reproduces the
+      // payload's real size and actually found a pointer.
+      if (offset != payloadBytes || !hasPointer) {
+        types.clear();
         return false;
-      // ...and hold a managed reference. A single retainable pointer qualifies
-      // directly; a nested optional qualifies because it is itself already
-      // lowered to `ptr` and is non-trivial. Excluding trivially-destroyable
-      // pointers (metatypes, unsafe pointers, ...) keeps unrelated types on
-      // their existing integer representation.
-      return payloadTI.isSingleRetainablePointer(ResilienceExpansion::Maximal,
-                                                 nullptr) ||
-             !payloadTI.isTriviallyDestroyable(ResilienceExpansion::Maximal);
+      }
+
+      // Fill the trailing whole words and the sub-word tail with integers.
+      for (; nextWord < numWords; ++nextWord)
+        types.push_back(IGM.SizeTy);
+      if (unsigned tailBits = (payloadBytes * 8) % ptrBits)
+        types.push_back(llvm::IntegerType::get(IGM.getLLVMContext(), tailBits));
+      return true;
     }
 
     static EnumPayloadSchema
@@ -2033,21 +2091,15 @@ namespace {
       // TODO: If the payload type info provides a preferred explosion schema,
       // use it. For now, just use a generic word-chunked schema.
       if (auto fixedTI = dyn_cast<FixedTypeInfo>(payloadElement.ti)) {
-        // When the payload is a single pointer and all empty cases fit in its
-        // extra inhabitants, represent the payload as its own pointer type so
-        // the enum lowers to `ptr` in LLVM IR (with the empty cases occupying
-        // low invalid-pointer values), rather than an opaque integer word.
-        if (canRepresentPayloadAsPointer(IGM, *fixedTI, tik,
-                                         numNoPayloadCases)) {
-          ExplosionSchema payloadSchema;
-          fixedTI->getSchema(payloadSchema);
-          assert(payloadSchema.size() == 1 &&
-                 payloadSchema.begin()->isScalar() &&
-                 payloadSchema.begin()->getScalarType()->isPointerTy() &&
-                 "pointer-representable payload should be one scalar pointer");
-          return EnumPayloadSchema::withExplicitTypes(
-              payloadSchema.begin()->getScalarType());
-        }
+        // When the payload holds a managed reference and stores the enum's tag
+        // in that reference's extra inhabitants, represent the payload with its
+        // concrete element types so pointers lower to `ptr` in LLVM IR (with
+        // the empty cases occupying low invalid-pointer values), rather than
+        // opaque integer words.
+        SmallVector<llvm::Type *, 2> concreteTypes;
+        if (tryGetConcretePayloadTypes(IGM, *fixedTI, tik, numNoPayloadCases,
+                                       concreteTypes))
+          return EnumPayloadSchema::withExplicitTypes(concreteTypes);
         return EnumPayloadSchema(fixedTI->getFixedSize().getValueInBits());
       }
       return EnumPayloadSchema();

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -1115,33 +1115,20 @@ class ClassExistentialTypeInfo final
 
   /// Given an explosion with multiple pointer elements in them, pack them
   /// into an enum payload explosion.
-  /// FIXME: Assumes the explosion is broken into word-sized integer chunks.
-  /// Should use EnumPayload.
   void mergeExplosion(Explosion &In, Explosion &Out, IRGenFunction &IGF)
   const {
-    // We always have at least one entry.
-    auto *part = In.claimNext();
-
-    // With no stored protocols the optional class existential is a single
-    // retainable pointer, so its `.none == null` optional is lowered to `ptr`;
-    // keep the reference word as a pointer. With witness tables the optional
-    // uses the word-chunked integer payload representation.
-    if (getNumStoredProtocols() == 0) {
-      Out.add(part);
-      return;
-    }
-
-    Out.add(IGF.Builder.CreatePtrToInt(part, IGF.IGM.IntPtrTy));
-
-    for (unsigned i = 0; i != getNumStoredProtocols(); ++i) {
-      part = In.claimNext();
-      Out.add(IGF.Builder.CreatePtrToInt(part, IGF.IGM.IntPtrTy));
-    }
+    // A loadable optional class existential is lowered with its concrete
+    // pointer element types (the reference word and each witness table are
+    // `ptr`), just like the non-optional existential. Forward the words into
+    // the enum payload explosion unchanged, rather than round-tripping them
+    // through pointer-width integers.
+    Out.add(In.claimNext());
+    for (unsigned i = 0; i != getNumStoredProtocols(); ++i)
+      Out.add(In.claimNext());
   }
 
-  // Given an exploded enum payload consisting of consecutive word-sized
-  // chunks, cast them to their underlying component types.
-  // FIXME: Assumes the payload is word-chunked. Should use
+  // Given an exploded enum payload consisting of consecutive pointer-typed
+  // words, cast them to their underlying component types.
   void decomposeExplosion(Explosion &InE, Explosion &OutE,
                           IRGenFunction &IGF) const {
     // The first entry is always the weak*.

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -6325,11 +6325,22 @@ void IRGenSILFunction::visitCopyBlockInst(CopyBlockInst *i) {
 void IRGenSILFunction::visitImplicitActorToOpaqueIsolationCastInst(
     ImplicitActorToOpaqueIsolationCastInst *i) {
   auto lowered = getLoweredExplosion(i->getOperand());
+  // Reinterpret the implicit-actor words as the opaque isolation value,
+  // clearing the tag bits on the actor word. Match the result type's schema
+  // element types (the `(any Actor)?` enum now carries its words as `ptr`).
+  auto &resultTI = cast<LoadableTypeInfo>(getTypeInfo(i->getType()));
+  ExplosionSchema schema;
+  resultTI.getSchema(schema);
+  assert(schema.size() == 2 && schema.begin()[0].isScalar() &&
+         schema.begin()[1].isScalar() &&
+         "opaque isolation should be two scalars");
+  auto *word1 = lowered.claimNext();
+  auto *word2 = clearImplicitIsolatedActorBits(*this, lowered.claimNext());
   Explosion result;
-  result.add(Builder.CreateBitOrPointerCast(lowered.claimNext(), IGM.IntPtrTy));
-  result.add(Builder.CreateBitOrPointerCast(
-      clearImplicitIsolatedActorBits(*this, lowered.claimNext()),
-      IGM.IntPtrTy));
+  result.add(
+      Builder.CreateBitOrPointerCast(word1, schema.begin()[0].getScalarType()));
+  result.add(
+      Builder.CreateBitOrPointerCast(word2, schema.begin()[1].getScalarType()));
   setLoweredExplosion(i, result);
 }
 
@@ -6355,6 +6366,37 @@ static const ReferenceTypeInfo &getReferentTypeInfo(IRGenFunction &IGF,
   if (auto ty = type->getOptionalObjectType())
     type = ty->getCanonicalType();
   return cast<ReferenceTypeInfo>(IGF.getTypeInfoForLowered(type));
+}
+
+/// Reinterpret a reference-storage explosion as its loaded referent. The two
+/// share their bit patterns word-for-word, but the referent's lowering may use
+/// different element types (e.g. an optional reference whose enum now carries
+/// its pointers as `ptr` rather than integer words). Cast each word to the
+/// referent's schema type; if the shapes don't line up, forward unchanged.
+static Explosion coerceReferenceStorageResult(IRGenSILFunction &IGF,
+                                              SILType resultTy,
+                                              Explosion &storage) {
+  auto &resultTI = cast<LoadableTypeInfo>(IGF.getTypeInfo(resultTy));
+  ExplosionSchema schema;
+  resultTI.getSchema(schema);
+
+  auto values = storage.claimAll();
+  Explosion result;
+  if (values.size() != schema.size()) {
+    // Shapes differ; forward the words unchanged.
+    for (auto *value : values)
+      result.add(value);
+    return result;
+  }
+
+  unsigned idx = 0;
+  for (auto &elt : schema) {
+    llvm::Value *value = values[idx++];
+    if (elt.isScalar() && value->getType() != elt.getScalarType())
+      value = IGF.Builder.CreateBitOrPointerCast(value, elt.getScalarType());
+    result.add(value);
+  }
+  return result;
 }
 
 void IRGenSILFunction::visitStrongCopyWeakValueInst(
@@ -6487,28 +6529,18 @@ IRGenSILFunction::visitDereferenceBorrowAddrInst(DereferenceBorrowAddrInst *i) {
       swift::StrongCopy##Name##ValueInst *i) {                                 \
     Explosion in = getLoweredExplosion(i->getOperand());                       \
     auto silTy = i->getOperand()->getType();                                   \
-    auto ty = cast<Name##StorageType>(silTy.getASTType());                     \
-    auto isOptional = bool(ty.getReferentType()->getOptionalObjectType());     \
     auto &ti = getReferentTypeInfo(*this, silTy);                              \
     ti.strongRetain##Name(*this, in, irgen::Atomicity::Atomic);                \
     /* Semantically we are just passing through the input parameter but as a   \
      */                                                                        \
-    /* strong reference... at LLVM IR level these type differences don't */    \
-    /* matter. A loadable optional reference that lowers to a nullable */      \
-    /* pointer already matches the referent, so it can be forwarded as-is. */  \
-    /* An optional with a multi-word payload (e.g. a class existential with */ \
-    /* witness tables) still uses the word-chunked integer enum payload, so */ \
-    /* convert the pointer words back to integers to match it. */              \
+    /* strong reference... at LLVM IR level the reference-storage explosion */ \
+    /* and the loaded referent share their bit patterns but may use */         \
+    /* different element types (e.g. the referent's enum now carries its */    \
+    /* pointers as `ptr`). Coerce each word to the referent's schema type. */  \
     Explosion output = getLoweredExplosion(i->getOperand());                   \
-    if (isOptional && !ti.isSingleRetainablePointer(                           \
-                          ResilienceExpansion::Maximal, nullptr)) {            \
-      auto values = output.claimAll();                                         \
-      output.reset();                                                          \
-      for (auto value : values) {                                              \
-        output.add(Builder.CreatePtrToInt(value, IGM.IntPtrTy));               \
-      }                                                                        \
-    }                                                                          \
-    setLoweredExplosion(i, output);                                            \
+    Explosion coerced =                                                        \
+        coerceReferenceStorageResult(*this, i->getType(), output);             \
+    setLoweredExplosion(i, coerced);                                           \
   }
 #define SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, name, ...) \
   NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, name, "...") \
@@ -6518,30 +6550,20 @@ IRGenSILFunction::visitDereferenceBorrowAddrInst(DereferenceBorrowAddrInst *i) {
       swift::StrongCopy##Name##ValueInst *i) {                                 \
     Explosion in = getLoweredExplosion(i->getOperand());                       \
     auto silTy = i->getOperand()->getType();                                   \
-    auto ty = cast<Name##StorageType>(silTy.getASTType());                     \
-    auto isOptional = bool(ty.getReferentType()->getOptionalObjectType());     \
     auto &ti = getReferentTypeInfo(*this, silTy);                              \
     /* Since we are unchecked, we just use strong retain here. We do not       \
      * perform any checks */                                                   \
     ti.strongRetain(*this, in, irgen::Atomicity::Atomic);                      \
     /* Semantically we are just passing through the input parameter but as a   \
      */                                                                        \
-    /* strong reference... at LLVM IR level these type differences don't */    \
-    /* matter. A loadable optional reference that lowers to a nullable */      \
-    /* pointer already matches the referent, so it can be forwarded as-is. */  \
-    /* An optional with a multi-word payload (e.g. a class existential with */ \
-    /* witness tables) still uses the word-chunked integer enum payload, so */ \
-    /* convert the pointer words back to integers to match it. */              \
+    /* strong reference... at LLVM IR level the reference-storage explosion */ \
+    /* and the loaded referent share their bit patterns but may use */         \
+    /* different element types (e.g. the referent's enum now carries its */    \
+    /* pointers as `ptr`). Coerce each word to the referent's schema type. */  \
     Explosion output = getLoweredExplosion(i->getOperand());                   \
-    if (isOptional && !ti.isSingleRetainablePointer(                           \
-                          ResilienceExpansion::Maximal, nullptr)) {            \
-      auto values = output.claimAll();                                         \
-      output.reset();                                                          \
-      for (auto value : values) {                                              \
-        output.add(Builder.CreatePtrToInt(value, IGM.IntPtrTy));               \
-      }                                                                        \
-    }                                                                          \
-    setLoweredExplosion(i, output);                                            \
+    Explosion coerced =                                                        \
+        coerceReferenceStorageResult(*this, i->getType(), output);             \
+    setLoweredExplosion(i, coerced);                                           \
   }
 #include "swift/AST/ReferenceStorage.def"
 #undef COMMON_CHECKED_REF_STORAGE

--- a/test/Concurrency/isolation_macro_ir.swift
+++ b/test/Concurrency/isolation_macro_ir.swift
@@ -24,11 +24,13 @@ func implicitParam(_ x: (any Actor)? = #isolation) {
 //
 // TBI: define swifttailcc void @"$s18isolation_macro_ir46nonisolatedNonsendingUsePoundIsolationDirectlyyyYaF"(ptr swiftasync %0, i64 %1, i64 [[SECOND_WORD:%.*]])
 // TBI: [[MASKED_SECOND_WORD:%.*]] = and i64 [[SECOND_WORD]], -3458764513820540929
-// TBI: call swiftcc void @"$s18isolation_macro_ir8useActor3isoyScA_pSg_tF"(i64 %1, i64 [[MASKED_SECOND_WORD]])
+// TBI: [[SECOND_PTR:%.*]] = inttoptr i64 [[MASKED_SECOND_WORD]] to ptr
+// TBI: call swiftcc void @"$s18isolation_macro_ir8useActor3isoyScA_pSg_tF"(ptr {{.*}}, ptr [[SECOND_PTR]])
 
 // NO-TBI: define swifttailcc void @"$s18isolation_macro_ir46nonisolatedNonsendingUsePoundIsolationDirectlyyyYaF"(ptr swiftasync %0, i64 [[FIRST_WORD:%.*]], i64 [[SECOND_WORD:%.*]])
 // NO-TBI: [[MASKED_SECOND_WORD:%.*]] = and i64 [[SECOND_WORD]], -4
-// NO-TBI: call swiftcc void @"$s18isolation_macro_ir8useActor3isoyScA_pSg_tF"(i64 [[FIRST_WORD]], i64 [[MASKED_SECOND_WORD]])
+// NO-TBI: [[SECOND_PTR:%.*]] = inttoptr i64 [[MASKED_SECOND_WORD]] to ptr
+// NO-TBI: call swiftcc void @"$s18isolation_macro_ir8useActor3isoyScA_pSg_tF"(ptr {{.*}}, ptr [[SECOND_PTR]])
 
 public nonisolated(nonsending) func nonisolatedNonsendingUsePoundIsolationDirectly() async {
   let iso = #isolation
@@ -39,11 +41,13 @@ public nonisolated(nonsending) func nonisolatedNonsendingUsePoundIsolationDirect
 //
 // TBI: define swifttailcc void @"$s18isolation_macro_ir45nonisolatedNonsendingPoundIsolationDefaultArgyyYaF"(ptr swiftasync {{%.*}}, i64 {{%.*}}, i64 [[WORD_2:%.*]])
 // TBI: [[MASKED_WORD_2:%.*]] = and i64 [[WORD_2]], -3458764513820540929
-// TBI: call swiftcc void @"$s18isolation_macro_ir13implicitParamyyScA_pSgF"(i64 {{%.*}}, i64 [[MASKED_WORD_2]])
+// TBI: [[WORD_2_PTR:%.*]] = inttoptr i64 [[MASKED_WORD_2]] to ptr
+// TBI: call swiftcc void @"$s18isolation_macro_ir13implicitParamyyScA_pSgF"(ptr {{.*}}, ptr [[WORD_2_PTR]])
 
 // NO-TBI: define swifttailcc void @"$s18isolation_macro_ir45nonisolatedNonsendingPoundIsolationDefaultArgyyYaF"(ptr swiftasync %0, i64 [[WORD_1:%.*]], i64 [[WORD_2:%.*]])
 // NO-TBI: [[MASKED_WORD_2:%.*]] = and i64 [[WORD_2]], -4
-// NO-TBI: call swiftcc void @"$s18isolation_macro_ir13implicitParamyyScA_pSgF"(i64 {{%.*}}, i64 [[MASKED_WORD_2]])
+// NO-TBI: [[WORD_2_PTR:%.*]] = inttoptr i64 [[MASKED_WORD_2]] to ptr
+// NO-TBI: call swiftcc void @"$s18isolation_macro_ir13implicitParamyyScA_pSgF"(ptr {{.*}}, ptr [[WORD_2_PTR]])
 public nonisolated(nonsending) func nonisolatedNonsendingPoundIsolationDefaultArg() async {
   implicitParam()
 }

--- a/test/Distributed/distributed_actor_accessor_thunks_64bit.swift
+++ b/test/Distributed/distributed_actor_accessor_thunks_64bit.swift
@@ -302,10 +302,10 @@ public distributed actor MyOtherActor {
 // CHECK: [[ARG_2_SIZE:%.*]] = and i64 {{.*}}, -16
 // CHECK-NEXT: [[ARG_2_BUF:%.*]] = call swiftcc ptr @swift_task_alloc(i64 [[ARG_2_SIZE]])
 
-// CHECK: [[NATIVE_OPT_VAL_0_PTR:%.*]] = getelementptr inbounds{{.*}} { i64, i64 }, ptr [[ARG_2_BUF]], i32 0, i32 0
+// CHECK: [[NATIVE_OPT_VAL_0_PTR:%.*]] = getelementptr inbounds{{.*}} { i64, ptr }, ptr [[ARG_2_BUF]], i32 0, i32 0
 // CHECK-NEXT: [[NATIVE_OPT_VAL_0:%.*]] = load i64, ptr [[NATIVE_OPT_VAL_0_PTR]]
-// CHECK-NEXT: [[NATIVE_OPT_VAL_1_PTR:%.*]] = getelementptr inbounds{{.*}} { i64, i64 }, ptr [[ARG_2_BUF]], i32 0, i32 1
-// CHECK-NEXT: [[NATIVE_OPT_VAL_1:%.*]] = load i64, ptr [[NATIVE_OPT_VAL_1_PTR]]
+// CHECK-NEXT: [[NATIVE_OPT_VAL_1_PTR:%.*]] = getelementptr inbounds{{.*}} { i64, ptr }, ptr [[ARG_2_BUF]], i32 0, i32 1
+// CHECK-NEXT: [[NATIVE_OPT_VAL_1:%.*]] = load ptr, ptr [[NATIVE_OPT_VAL_1_PTR]]
 
 /// -> LargeStruct (passed indirectly)
 
@@ -315,7 +315,7 @@ public distributed actor MyOtherActor {
 
 /// Now let's make sure that distributed thunk call uses the arguments correctly
 
-// CHECK: [[THUNK_RESULT:%.*]] = call { ptr, ptr } (i32, ptr, ptr, ...) @llvm.coro.suspend.async.sl_p0p0s({{.*}}, ptr [[RESULT_BUFF]], ptr {{.*}}, {{.*}} [[NATIVE_ARR_VAL]], ptr [[NATIVE_OBJ_VAL]], i64 [[NATIVE_OPT_VAL_0]], i64 [[NATIVE_OPT_VAL_1]], ptr [[ARG_3_BUF]], ptr {{.*}})
+// CHECK: [[THUNK_RESULT:%.*]] = call { ptr, ptr } (i32, ptr, ptr, ...) @llvm.coro.suspend.async.sl_p0p0s({{.*}}, ptr [[RESULT_BUFF]], ptr {{.*}}, {{.*}} [[NATIVE_ARR_VAL]], ptr [[NATIVE_OBJ_VAL]], i64 [[NATIVE_OPT_VAL_0]], ptr [[NATIVE_OPT_VAL_1]], ptr [[ARG_3_BUF]], ptr {{.*}})
 
 /// RESULT is returned indirectly so there is nothing to pass to `end`
 

--- a/test/IRGen/big_types_corner_cases.sil
+++ b/test/IRGen/big_types_corner_cases.sil
@@ -138,9 +138,9 @@ bb0(%funcpointer : $@callee_owned () -> @owned @callee_owned (@owned Builtin.Int
   return %ret : $()
 }
 
-// CHECK-LABEL: define swiftcc { i64, i64 } @ret_pointer_to_mod()
+// CHECK-LABEL: define swiftcc { ptr, ptr } @ret_pointer_to_mod()
 // CHECK-NEXT: entry
-// CHECK-NEXT: ret { i64, i64 } zeroinitializer
+// CHECK-NEXT: ret { ptr, ptr } zeroinitializer
 sil @ret_pointer_to_mod : $@convention(thin) () -> @owned Optional<@callee_owned () -> @owned Optional<BigStruct>> {
 bb0:
   %0 = enum $Optional<@callee_owned () -> @owned Optional<BigStruct>>, #Optional.none!enumelt // user: %1

--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -307,13 +307,13 @@ public extension QueryHandler {
         return body(query)
     }
 
-// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, i64 } @"$s22big_types_corner_cases12QueryHandlerPAAE13forceHandle_35query8ReturnedQyd___SbAA9BigStructVcSgtqd___tAA0E0Rd__lF"(ptr noalias %0, ptr noalias %1, ptr{{.*}}, ptr{{.*}}, ptr {{.*}}.QueryHandler, ptr {{.*}}.Query, ptr noalias swiftself %2)
-// CHECK-64: {{.*}} = call swiftcc { i64, i64 } {{.*}}(ptr noalias {{.*}}, ptr noalias {{.*}}, ptr swiftself {{.*}})
-// CHECK-64: ret { i64, i64 }
+// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @"$s22big_types_corner_cases12QueryHandlerPAAE13forceHandle_35query8ReturnedQyd___SbAA9BigStructVcSgtqd___tAA0E0Rd__lF"(ptr noalias %0, ptr noalias %1, ptr{{.*}}, ptr{{.*}}, ptr {{.*}}.QueryHandler, ptr {{.*}}.Query, ptr noalias swiftself %2)
+// CHECK-64: {{.*}} = call swiftcc { ptr, ptr } {{.*}}(ptr noalias {{.*}}, ptr noalias {{.*}}, ptr swiftself {{.*}})
+// CHECK-64: ret { ptr, ptr }
 
-// CHECK-32-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i32, i32 } @"$s22big_types_corner_cases12QueryHandlerPAAE13forceHandle_35query8ReturnedQyd___SbAA9BigStructVcSgtqd___tAA0E0Rd__lF"(ptr noalias %0, ptr noalias %1, ptr{{.*}}, ptr{{.*}}, ptr {{.*}}.QueryHandler, ptr {{.*}}.Query, ptr noalias swiftself %2)
-// CHECK-32: {{.*}} = call swiftcc { i32, i32 } {{.*}}(ptr noalias {{.*}}, ptr noalias {{.*}}, ptr swiftself {{.*}})
-// CHECK-32: ret { i32, i32 }
+// CHECK-32-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @"$s22big_types_corner_cases12QueryHandlerPAAE13forceHandle_35query8ReturnedQyd___SbAA9BigStructVcSgtqd___tAA0E0Rd__lF"(ptr noalias %0, ptr noalias %1, ptr{{.*}}, ptr{{.*}}, ptr {{.*}}.QueryHandler, ptr {{.*}}.Query, ptr noalias swiftself %2)
+// CHECK-32: {{.*}} = call swiftcc { ptr, ptr } {{.*}}(ptr noalias {{.*}}, ptr noalias {{.*}}, ptr swiftself {{.*}})
+// CHECK-32: ret { ptr, ptr }
     func forceHandle_3<Q: Query>(query: Q) -> (Q.Returned, Filter?) {
         guard let body = handle_3 as? (Q) -> (Q.Returned, Filter?) else {
             fatalError("handler \(self) is expected to handle query \(query)")
@@ -321,13 +321,13 @@ public extension QueryHandler {
         return body(query)
     }
 
-// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, i64 } @"$s22big_types_corner_cases12QueryHandlerPAAE13forceHandle_45query8ReturnedQyd___SbAA9BigStructVcSgtqd___tKAA0E0Rd__lF"(ptr noalias %0, ptr noalias %1, ptr{{.*}}, ptr{{.*}}, ptr {{.*}}.QueryHandler, ptr {{.*}}.Query, ptr noalias swiftself %2, ptr noalias swifterror captures(none) dereferenceable({{.*}}) %3)
-// CHECK-64: {{.*}} = call swiftcc { i64, i64 } {{.*}}(ptr noalias {{.*}}, ptr noalias {{.*}}, ptr swiftself {{.*}}, ptr noalias swifterror captures(none) {{.*}})
-// CHECK-64: ret { i64, i64 }
+// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @"$s22big_types_corner_cases12QueryHandlerPAAE13forceHandle_45query8ReturnedQyd___SbAA9BigStructVcSgtqd___tKAA0E0Rd__lF"(ptr noalias %0, ptr noalias %1, ptr{{.*}}, ptr{{.*}}, ptr {{.*}}.QueryHandler, ptr {{.*}}.Query, ptr noalias swiftself %2, ptr noalias swifterror captures(none) dereferenceable({{.*}}) %3)
+// CHECK-64: {{.*}} = call swiftcc { ptr, ptr } {{.*}}(ptr noalias {{.*}}, ptr noalias {{.*}}, ptr swiftself {{.*}}, ptr noalias swifterror captures(none) {{.*}})
+// CHECK-64: ret { ptr, ptr }
 
-// CHECK-32-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i32, i32 } @"$s22big_types_corner_cases12QueryHandlerPAAE13forceHandle_45query8ReturnedQyd___SbAA9BigStructVcSgtqd___tKAA0E0Rd__lF"(ptr noalias %0, ptr noalias %1, ptr{{.*}}, ptr{{.*}}, ptr {{.*}}.QueryHandler, ptr {{.*}}.Query, ptr noalias swiftself %2, ptr noalias swifterror captures(none) dereferenceable({{.*}}) %3)
-// CHECK-32: {{.*}} = call swiftcc { i32, i32 } {{.*}}(ptr noalias {{.*}}, ptr noalias {{.*}}, ptr swiftself {{.*}}, ptr noalias{{.*}} captures(none) {{.*}})
-// CHECK-32: ret { i32, i32 }
+// CHECK-32-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @"$s22big_types_corner_cases12QueryHandlerPAAE13forceHandle_45query8ReturnedQyd___SbAA9BigStructVcSgtqd___tKAA0E0Rd__lF"(ptr noalias %0, ptr noalias %1, ptr{{.*}}, ptr{{.*}}, ptr {{.*}}.QueryHandler, ptr {{.*}}.Query, ptr noalias swiftself %2, ptr noalias swifterror captures(none) dereferenceable({{.*}}) %3)
+// CHECK-32: {{.*}} = call swiftcc { ptr, ptr } {{.*}}(ptr noalias {{.*}}, ptr noalias {{.*}}, ptr swiftself {{.*}}, ptr noalias{{.*}} captures(none) {{.*}})
+// CHECK-32: ret { ptr, ptr }
     func forceHandle_4<Q: Query>(query: Q) throws -> (Q.Returned, Filter?) {
         guard let body = handle_4 as? (Q) throws -> (Q.Returned, Filter?) else {
             fatalError("handler \(self) is expected to handle query \(query)")

--- a/test/IRGen/bitcast.sil
+++ b/test/IRGen/bitcast.sil
@@ -156,12 +156,10 @@ bb0(%0 : $CP):
 }
 
 // CHECK-i386-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @unchecked_ref_cast_optionalproto_optional
-// CHECK-i386: [[VALUE:%.*]] = inttoptr i32 %0 to ptr
-// CHECK-i386: ret ptr [[VALUE]]
+// CHECK-i386: ret ptr %0
 
 // CHECK-x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @unchecked_ref_cast_optionalproto_optional
-// CHECK-x86_64: [[VALUE:%.*]] = inttoptr i64 %0 to ptr
-// CHECK-x86_64: ret ptr [[VALUE]]
+// CHECK-x86_64: ret ptr %0
 sil @unchecked_ref_cast_optionalproto_optional : $@convention(thin) (@owned Optional<CP>) -> @owned Optional<AnyObject> {
 bb0(%0 : $Optional<CP>):
   %2 = unchecked_ref_cast %0 : $Optional<CP> to $Optional<AnyObject>

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -1119,9 +1119,10 @@ enum SinglePayloadClass {
   case w
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_class_switch(i64 %0) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_class_switch(ptr %0) {{.*}} {
 // CHECK-64: entry:
-// CHECK-64:   switch i64 %0, label %[[DFLT:[0-9]+]] [
+// CHECK-64:   [[TAG:%.*]] = ptrtoint ptr %0 to i64
+// CHECK-64:   switch i64 [[TAG]], label %[[DFLT:[0-9]+]] [
 // CHECK-64:     i64 0, label {{%.*}}
 // CHECK-objc-64-simulator-false:   i64 2, label {{%.*}}
 // CHECK-objc-64-simulator-false:   i64 4, label {{%.*}}
@@ -1131,7 +1132,7 @@ enum SinglePayloadClass {
 // CHECK-native-64: i64 2, label {{%.*}}
 // CHECK-64:   ]
 // CHECK-64: [[DFLT]]:
-// CHECK-64:   inttoptr [[WORD]] %0 to ptr
+// CHECK-64:   phi ptr [ %0,
 
 // CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_class_switch(i32 %0) {{.*}} {
 // CHECK-32: entry:
@@ -1167,8 +1168,9 @@ enum SinglePayloadClassProtocol {
   case y, z, w
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_class_protocol_switch(i64 %0, i64 %1) {{.*}} {
-// CHECK-64:   switch i64 %0, label {{%.*}} [
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_class_protocol_switch(ptr %0, ptr %1) {{.*}} {
+// CHECK-64:   [[TAG:%.*]] = ptrtoint ptr %0 to i64
+// CHECK-64:   switch i64 [[TAG]], label {{%.*}} [
 // CHECK-64:     i64 0, label {{%.*}}
 // CHECK-objc-64-simulator-false:     i64 2, label {{%.*}}
 // CHECK-objc-64-simulator-false:     i64 4, label {{%.*}}
@@ -1178,9 +1180,11 @@ enum SinglePayloadClassProtocol {
 // CHECK-native-64:   i64 2, label {{%.*}}
 // CHECK-64:   ]
 
-// CHECK-objc-64:     inttoptr i64 %0 to ptr
-// CHECK-native-64:   inttoptr i64 %0 to ptr
-// CHECK-64:   inttoptr i64 %1 to ptr
+// CHECK-objc-64:     ptrtoint ptr %0 to i64
+// CHECK-native-64:   ptrtoint ptr %0 to i64
+// CHECK-64:   inttoptr i64 {{%.*}} to ptr
+// CHECK-64:   [[P1:%.*]] = ptrtoint ptr %1 to i64
+// CHECK-64:   inttoptr i64 [[P1]] to ptr
 
 // CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_class_protocol_switch(i32 %0, i32 %1) {{.*}} {
 // CHECK-32:   switch i32 %0, label {{%.*}} [
@@ -2407,10 +2411,10 @@ entry(%0 : $DynamicSingleton<NoPayloads>):
 
 // Check that payloads get properly masked in nested single-payload enums.
 // rdar://problem/18841262
-// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i1 @optional_optional_class_protocol(i64 %0, i64 %1)
-// CHECK-objc-64-simulator-false:       icmp eq i64 %0, 2
-// CHECK-objc-64-simulator-true:       icmp eq i64 %0, 1
-// CHECK-native-64:     icmp eq i64 %0, 1
+// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i1 @optional_optional_class_protocol(ptr %0, ptr %1)
+// CHECK-objc-64-simulator-false:       icmp eq ptr %0, inttoptr (i64 2 to ptr)
+// CHECK-objc-64-simulator-true:       icmp eq ptr %0, inttoptr (i64 1 to ptr)
+// CHECK-native-64:     icmp eq ptr %0, inttoptr (i64 1 to ptr)
 // CHECK-32-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i1 @optional_optional_class_protocol(i32 %0, i32 %1)
 // CHECK-32:         icmp eq i32 %0, 1
 enum Optionable<T> {
@@ -2431,8 +2435,8 @@ struct ContainsUnownedObjC {
   unowned let x: C
 }
 // CHECK-LABEL: define {{.*}} @optional_unowned() {{.*}} {
-// CHECK-objc:     ret { [[WORD]], [[WORD]], i8 } { [[WORD]] 0, [[WORD]] 0, i8 1 }
-// CHECK-native:   ret { [[WORD]], [[WORD]] } { [[WORD]] 0, [[WORD]] 1 }
+// CHECK-objc:     ret { ptr, [[WORD]], i8 } { ptr null, [[WORD]] 0, i8 1 }
+// CHECK-native:   ret { ptr, ptr } { ptr null, ptr inttoptr (i64 1 to ptr) }
 sil @optional_unowned : $@convention(thin) () -> (Optionable<ContainsUnowned>, Optionable<Optionable<ContainsUnowned>>) {
 entry:
   %a = enum $Optionable<ContainsUnowned>, #Optionable.none!enumelt
@@ -2441,8 +2445,8 @@ entry:
   return %t : $(Optionable<ContainsUnowned>, Optionable<Optionable<ContainsUnowned>>)
 }
 // CHECK-LABEL: define {{.*}} @optional_unowned_objc() {{.*}} {
-// CHECK-objc:     ret { [[WORD]], [[WORD]], i8 } { [[WORD]] 0, [[WORD]] 0, i8 1 }
-// CHECK-native:   ret { [[WORD]], [[WORD]] } { [[WORD]] 0, [[WORD]] 1 }
+// CHECK-objc:     ret { ptr, [[WORD]], i8 } { ptr null, [[WORD]] 0, i8 1 }
+// CHECK-native:   ret { ptr, ptr } { ptr null, ptr inttoptr (i64 1 to ptr) }
 sil @optional_unowned_objc : $@convention(thin) () -> (Optionable<ContainsUnownedObjC>, Optionable<Optionable<ContainsUnownedObjC>>) {
 entry:
   %a = enum $Optionable<ContainsUnownedObjC>, #Optionable.none!enumelt

--- a/test/IRGen/enum_function.sil
+++ b/test/IRGen/enum_function.sil
@@ -12,18 +12,19 @@ bb0:
   return %0 : $()
 }
 
-// CHECK-64:  define hidden swiftcc void @test1([[WORD:i64]] %0, [[WORD]] %1)
-// CHECK-32:  define hidden swiftcc void @test1([[WORD:i32]] %0, [[WORD]] %1)
+// CHECK-64:  define hidden swiftcc void @test1(ptr %0, ptr %1)
+// CHECK-32:  define hidden swiftcc void @test1(ptr %0, ptr %1)
 sil hidden @test1 : $@convention(thin) (@owned Optional<() -> ()>) -> () {
 bb0(%0 : $Optional<() -> ()>):
   // CHECK: call void @"$sIey_SgWOy"
   retain_value %0 : $Optional<() -> ()>
 
-  // CHECK: icmp eq i64 %0, 0
+  // CHECK: icmp eq ptr %0, null
   switch_enum %0 : $Optional<() -> ()>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
 
-  // CHECK: [[FNPTR:%.*]] = inttoptr [[WORD]] %0 to ptr
-  // CHECK: [[CTX:%.*]] = inttoptr [[WORD]] %1 to ptr
+  // CHECK-64: [[FNPTR:%.*]] = inttoptr [[WORD:i64]] {{%.*}} to ptr
+  // CHECK-32: [[FNPTR:%.*]] = inttoptr [[WORD:i32]] {{%.*}} to ptr
+  // CHECK: [[CTX:%.*]] = inttoptr [[WORD]] {{%.*}} to ptr
   // CHECK: br label
   // CHECK: [[FNPTR2:%.*]] = phi ptr [ [[FNPTR]], {{%.*}} ]
   // CHECK: [[CTX2:%.*]] = phi ptr [ [[CTX]], {{%.*}} ]

--- a/test/IRGen/enum_future.sil
+++ b/test/IRGen/enum_future.sil
@@ -1123,9 +1123,10 @@ enum SinglePayloadClass {
   case w
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_class_switch(i64 %0) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_class_switch(ptr %0) {{.*}} {
 // CHECK-64: entry:
-// CHECK-64:   switch i64 %0, label %[[DFLT:[0-9]+]] [
+// CHECK-64:   [[ADDR:%.*]] = ptrtoint ptr %0 to i64
+// CHECK-64:   switch i64 [[ADDR]], label %[[DFLT:[0-9]+]] [
 // CHECK-64:     i64 0, label {{%.*}}
 // CHECK-objc-64-simulator-false:   i64 2, label {{%.*}}
 // CHECK-objc-64-simulator-false:   i64 4, label {{%.*}}
@@ -1135,17 +1136,18 @@ enum SinglePayloadClass {
 // CHECK-native-64: i64 2, label {{%.*}}
 // CHECK-64:   ]
 // CHECK-64: [[DFLT]]:
-// CHECK-64:   inttoptr [[WORD]] %0 to ptr
+// CHECK-64:   phi ptr [ %0,
 
-// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_class_switch(i32 %0) {{.*}} {
+// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_class_switch(ptr %0) {{.*}} {
 // CHECK-32: entry:
-// CHECK-32:   switch i32 %0, label %[[DFLT:[0-9]+]] [
+// CHECK-32:   [[ADDR:%.*]] = ptrtoint ptr %0 to i32
+// CHECK-32:   switch i32 [[ADDR]], label %[[DFLT:[0-9]+]] [
 // CHECK-32:     i32 0, label {{%.*}}
 // CHECK-32:     i32 1, label {{%.*}}
 // CHECK-32:     i32 2, label {{%.*}}
 // CHECK-32:   ]
 // CHECK-32: [[DFLT]]:
-// CHECK-32:   inttoptr [[WORD]] %0 to ptr
+// CHECK-32:   phi ptr [ %0,
 
 sil @single_payload_class_switch : $(SinglePayloadClass) -> () {
 entry(%c : $SinglePayloadClass):
@@ -1171,8 +1173,9 @@ enum SinglePayloadClassProtocol {
   case y, z, w
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_class_protocol_switch(i64 %0, i64 %1) {{.*}} {
-// CHECK-64:   switch i64 %0, label {{%.*}} [
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_class_protocol_switch(ptr %0, ptr %1) {{.*}} {
+// CHECK-64:   [[ADDR:%.*]] = ptrtoint ptr %0 to i64
+// CHECK-64:   switch i64 [[ADDR]], label {{%.*}} [
 // CHECK-64:     i64 0, label {{%.*}}
 // CHECK-objc-64-simulator-false:     i64 2, label {{%.*}}
 // CHECK-objc-64-simulator-false:     i64 4, label {{%.*}}
@@ -1182,20 +1185,27 @@ enum SinglePayloadClassProtocol {
 // CHECK-native-64:   i64 2, label {{%.*}}
 // CHECK-64:   ]
 
-// CHECK-objc-64:     inttoptr i64 %0 to ptr
-// CHECK-native-64:   inttoptr i64 %0 to ptr
-// CHECK-64:   inttoptr i64 %1 to ptr
+// CHECK-objc-64:     [[P0:%.*]] = ptrtoint ptr %0 to i64
+// CHECK-objc-64:     inttoptr i64 [[P0]] to ptr
+// CHECK-native-64:   [[P0:%.*]] = ptrtoint ptr %0 to i64
+// CHECK-native-64:   inttoptr i64 [[P0]] to ptr
+// CHECK-64:   [[P1:%.*]] = ptrtoint ptr %1 to i64
+// CHECK-64:   inttoptr i64 [[P1]] to ptr
 
-// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_class_protocol_switch(i32 %0, i32 %1) {{.*}} {
-// CHECK-32:   switch i32 %0, label {{%.*}} [
+// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_class_protocol_switch(ptr %0, ptr %1) {{.*}} {
+// CHECK-32:   [[ADDR:%.*]] = ptrtoint ptr %0 to i32
+// CHECK-32:   switch i32 [[ADDR]], label {{%.*}} [
 // CHECK-32:     i32 0, label {{%.*}}
 // CHECK-32:     i32 1, label {{%.*}}
 // CHECK-32:     i32 2, label {{%.*}}
 // CHECK-32:   ]
 
-// CHECK-objc-32:     inttoptr i32 %0 to ptr
-// CHECK-native-32:   inttoptr i32 %0 to ptr
-// CHECK-32:   inttoptr i32 %1 to ptr
+// CHECK-objc-32:     [[P0:%.*]] = ptrtoint ptr %0 to i32
+// CHECK-objc-32:     inttoptr i32 [[P0]] to ptr
+// CHECK-native-32:   [[P0:%.*]] = ptrtoint ptr %0 to i32
+// CHECK-native-32:   inttoptr i32 [[P0]] to ptr
+// CHECK-32:   [[P1:%.*]] = ptrtoint ptr %1 to i32
+// CHECK-32:   inttoptr i32 [[P1]] to ptr
 
 sil @single_payload_class_protocol_switch : $(SinglePayloadClassProtocol) -> () {
 entry(%c : $SinglePayloadClassProtocol):
@@ -2411,12 +2421,12 @@ entry(%0 : $DynamicSingleton<NoPayloads>):
 
 // Check that payloads get properly masked in nested single-payload enums.
 // rdar://problem/18841262
-// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i1 @optional_optional_class_protocol(i64 %0, i64 %1)
-// CHECK-objc-64-simulator-false:       icmp eq i64 %0, 2
-// CHECK-objc-64-simulator-true:       icmp eq i64 %0, 1
-// CHECK-native-64:     icmp eq i64 %0, 1
-// CHECK-32-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i1 @optional_optional_class_protocol(i32 %0, i32 %1)
-// CHECK-32:         icmp eq i32 %0, 1
+// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i1 @optional_optional_class_protocol(ptr %0, ptr %1)
+// CHECK-objc-64-simulator-false:       icmp eq ptr %0, inttoptr (i64 2 to ptr)
+// CHECK-objc-64-simulator-true:       icmp eq ptr %0, inttoptr (i64 1 to ptr)
+// CHECK-native-64:     icmp eq ptr %0, inttoptr (i64 1 to ptr)
+// CHECK-32-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i1 @optional_optional_class_protocol(ptr %0, ptr %1)
+// CHECK-32:         icmp eq ptr %0, inttoptr (i32 1 to ptr)
 enum Optionable<T> {
   case some(T), none
 }
@@ -2435,8 +2445,8 @@ struct ContainsUnownedObjC {
   unowned let x: C
 }
 // CHECK-LABEL: define {{.*}} @optional_unowned() {{.*}} {
-// CHECK-objc:     ret { [[WORD]], [[WORD]], i8 } { [[WORD]] 0, [[WORD]] 0, i8 1 }
-// CHECK-native:   ret { [[WORD]], [[WORD]] } { [[WORD]] 0, [[WORD]] 1 }
+// CHECK-objc:     ret { ptr, [[WORD]], i8 } { ptr null, [[WORD]] 0, i8 1 }
+// CHECK-native:   ret { ptr, ptr } { ptr null, ptr inttoptr (i64 1 to ptr) }
 sil @optional_unowned : $@convention(thin) () -> (Optionable<ContainsUnowned>, Optionable<Optionable<ContainsUnowned>>) {
 entry:
   %a = enum $Optionable<ContainsUnowned>, #Optionable.none!enumelt
@@ -2445,8 +2455,8 @@ entry:
   return %t : $(Optionable<ContainsUnowned>, Optionable<Optionable<ContainsUnowned>>)
 }
 // CHECK-LABEL: define {{.*}} @optional_unowned_objc() {{.*}} {
-// CHECK-objc:     ret { [[WORD]], [[WORD]], i8 } { [[WORD]] 0, [[WORD]] 0, i8 1 }
-// CHECK-native:   ret { [[WORD]], [[WORD]] } { [[WORD]] 0, [[WORD]] 1 }
+// CHECK-objc:     ret { ptr, [[WORD]], i8 } { ptr null, [[WORD]] 0, i8 1 }
+// CHECK-native:   ret { ptr, ptr } { ptr null, ptr inttoptr (i64 1 to ptr) }
 sil @optional_unowned_objc : $@convention(thin) () -> (Optionable<ContainsUnownedObjC>, Optionable<Optionable<ContainsUnownedObjC>>) {
 entry:
   %a = enum $Optionable<ContainsUnownedObjC>, #Optionable.none!enumelt

--- a/test/IRGen/enum_objc.sil
+++ b/test/IRGen/enum_objc.sil
@@ -29,8 +29,8 @@ enum SinglePayloadObjCProtocol {
   case y, z, w
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_class_protocol_switch(i64 %0, i64 %1) {{.*}} {
-// CHECK-64:   switch i64 %0, label {{%.*}} [
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_class_protocol_switch(ptr %0, ptr %1) {{.*}} {
+// CHECK-64:   switch i64 {{%.*}}, label {{%.*}} [
 // CHECK-64:     i64 0, label {{%.*}}
 // CHECK-64-simulator-false:     i64 2, label {{%.*}}
 // CHECK-64-simulator-false:     i64 4, label {{%.*}}
@@ -38,18 +38,18 @@ enum SinglePayloadObjCProtocol {
 // CHECK-64-simulator-true:     i64 2, label {{%.*}}
 // CHECK-64:   ]
 
-// CHECK-64:     inttoptr i64 %0 to ptr
-// CHECK-64:   inttoptr i64 %1 to ptr
+// CHECK-64:     inttoptr i64 {{%.*}} to ptr
+// CHECK-64:   inttoptr i64 {{%.*}} to ptr
 
-// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_class_protocol_switch(i32 %0, i32 %1) {{.*}} {
-// CHECK-32:   switch i32 %0, label {{%.*}} [
+// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_class_protocol_switch(ptr %0, ptr %1) {{.*}} {
+// CHECK-32:   switch i32 {{%.*}}, label {{%.*}} [
 // CHECK-32:     i32 0, label {{%.*}}
 // CHECK-32:     i32 1, label {{%.*}}
 // CHECK-32:     i32 2, label {{%.*}}
 // CHECK-32:   ]
 
-// CHECK-32:     inttoptr i32 %0 to ptr
-// CHECK-32:   inttoptr i32 %1 to ptr
+// CHECK-32:     inttoptr i32 {{%.*}} to ptr
+// CHECK-32:   inttoptr i32 {{%.*}} to ptr
 
 sil @single_payload_class_protocol_switch : $(SinglePayloadClassProtocol) -> () {
 entry(%c : $SinglePayloadClassProtocol):
@@ -68,23 +68,23 @@ end:
   return undef : $()
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_objc_protocol_switch(i64 %0) {{.*}} {
-// CHECK-64:   switch i64 %0, label {{%.*}}
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_objc_protocol_switch(ptr %0) {{.*}} {
+// CHECK-64:   switch i64 {{%.*}}, label {{%.*}}
 // CHECK-64:     i64 0, label {{%.*}}
 // CHECK-64-simulator-false:     i64 2, label {{%.*}}
 // CHECK-64-simulator-false:     i64 4, label {{%.*}}
 // CHECK-64-simulator-true:     i64 1, label {{%.*}}
 // CHECK-64-simulator-true:     i64 2, label {{%.*}}
 // CHECK-64:   ]
-// CHECK-64:     inttoptr i64 %0 to ptr
+// CHECK-64:     phi ptr [ %0
 
-// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_objc_protocol_switch(i32 %0) {{.*}} {
-// CHECK-32:   switch i32 %0, label {{%.*}}
+// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_objc_protocol_switch(ptr %0) {{.*}} {
+// CHECK-32:   switch i32 {{%.*}}, label {{%.*}}
 // CHECK-32:     i32 0, label {{%.*}}
 // CHECK-32:     i32 1, label {{%.*}}
 // CHECK-32:     i32 2, label {{%.*}}
 // CHECK-32:   ]
-// CHECK-32:     inttoptr i32 %0 to ptr
+// CHECK-32:     phi ptr [ %0
 
 sil @single_payload_objc_protocol_switch : $(SinglePayloadObjCProtocol) -> () {
 entry(%c : $SinglePayloadObjCProtocol):

--- a/test/IRGen/enum_reference_concrete_repr.sil
+++ b/test/IRGen/enum_reference_concrete_repr.sil
@@ -1,0 +1,82 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s
+
+// REQUIRES: CPU=x86_64 || CPU=arm64
+
+// A loadable single-payload enum whose payload holds a managed reference and
+// stores its tag in that reference's extra inhabitants keeps the payload's
+// concrete element types, so pointers lower to `ptr` (rather than opaque
+// integer words). This covers multi-word payloads: class-bound existentials,
+// aggregates mixing a reference with other fields, and their optionals.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+class C {}
+sil_vtable C {}
+
+protocol P : class { func noop() }
+
+struct Pair { var a: C; var b: Int }
+
+struct PaddedRef { var x: Int32; var ref: C }
+
+// A class-bound existential (with a witness table) is a two-pointer value; its
+// optional carries both words as `ptr`.
+// CHECK-LABEL: define{{.*}} swiftcc { ptr, ptr } @take_optional_existential(ptr %0, ptr %1)
+sil @take_optional_existential : $@convention(thin) (@guaranteed Optional<P>) -> @owned Optional<P> {
+bb0(%0 : $Optional<P>):
+  retain_value %0 : $Optional<P>
+  return %0 : $Optional<P>
+}
+
+// A struct mixing a reference and an integer: the reference word is `ptr`, the
+// integer word keeps its concrete type.
+// CHECK-LABEL: define{{.*}} swiftcc { ptr, i64 } @take_optional_pair(ptr %0, i64 %1)
+sil @take_optional_pair : $@convention(thin) (@guaranteed Optional<Pair>) -> @owned Optional<Pair> {
+bb0(%0 : $Optional<Pair>):
+  retain_value %0 : $Optional<Pair>
+  return %0 : $Optional<Pair>
+}
+
+// A padded payload: a leading `Int32` pushes the reference to the second word,
+// leaving 4 bytes of padding. The reference word is still `ptr`; the padding
+// stays inside the leading integer word.
+// CHECK-LABEL: define{{.*}} swiftcc { i64, ptr } @take_optional_padded(i64 %0, ptr %1)
+sil @take_optional_padded : $@convention(thin) (@guaranteed Optional<PaddedRef>) -> @owned Optional<PaddedRef> {
+bb0(%0 : $Optional<PaddedRef>):
+  retain_value %0 : $Optional<PaddedRef>
+  return %0 : $Optional<PaddedRef>
+}
+
+// A custom single-payload enum over a two-pointer existential, with extra empty
+// cases, still uses the concrete two-pointer layout.
+enum ExistentialOrTags {
+  case value(P)
+  case a
+  case b
+}
+
+// CHECK-LABEL: define{{.*}} swiftcc { ptr, ptr } @take_existential_or_tags(ptr %0, ptr %1)
+sil @take_existential_or_tags : $@convention(thin) (@guaranteed ExistentialOrTags) -> @owned ExistentialOrTags {
+bb0(%0 : $ExistentialOrTags):
+  retain_value %0 : $ExistentialOrTags
+  return %0 : $ExistentialOrTags
+}
+
+// Switching over the existential optional tests the reference word directly
+// (against null) without round-tripping through an integer.
+// CHECK-LABEL: define{{.*}} swiftcc void @switch_optional_existential(ptr %0, ptr %1)
+// CHECK: icmp eq ptr %0, null
+sil @switch_optional_existential : $@convention(thin) (@guaranteed Optional<P>) -> () {
+bb0(%0 : $Optional<P>):
+  switch_enum %0 : $Optional<P>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
+bb1(%1 : $P):
+  br bb3
+bb2:
+  br bb3
+bb3:
+  %r = tuple ()
+  return %r : $()
+}

--- a/test/IRGen/enum_value_semantics.sil
+++ b/test/IRGen/enum_value_semantics.sil
@@ -182,7 +182,7 @@ bb0(%0 : $SinglePayloadNontrivial):
   return %v : $()
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_nontrivial_copy_destroy(i64 %0)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_nontrivial_copy_destroy(ptr %0)
 // CHECK:      call void @"$s20enum_value_semantics23SinglePayloadNontrivialOWOy"
 // CHECK-NEXT: call swiftcc void @single_payload_nontrivial_user
 // CHECK-NEXT: call void @"$s20enum_value_semantics23SinglePayloadNontrivialOWOe"
@@ -262,8 +262,9 @@ bb0(%0 : $SinglePayloadNontrivial):
 
 // -- SinglePayloadNontrivial destroyBuffer
 // CHECK: define internal void @"$s20enum_value_semantics23SinglePayloadNontrivialOwxx"(ptr noalias [[OBJ:%.*]], ptr %SinglePayloadNontrivial) {{.*}} {
-// CHECK: [[PAYLOAD:%.*]] = load i64, ptr [[OBJ]], align 8
-// CHECK-NEXT: switch i64 %0, label %[[RELEASE_PAYLOAD:[0-9]+]] [
+// CHECK: [[PAYLOAD:%.*]] = load ptr, ptr [[OBJ]], align 8
+// CHECK-NEXT: [[PAYLOAD_INT:%.*]] = ptrtoint ptr [[PAYLOAD]] to i64
+// CHECK-NEXT: switch i64 [[PAYLOAD_INT]], label %[[RELEASE_PAYLOAD:[0-9]+]] [
 // CHECK:        i64 0, label %[[DONE:[0-9]+]]
 // CHECK-native:      i64 1, label %[[DONE]]
 // CHECK-native:      i64 2, label %[[DONE]]

--- a/test/IRGen/enum_value_semantics_future.sil
+++ b/test/IRGen/enum_value_semantics_future.sil
@@ -191,7 +191,7 @@ bb0(%0 : $SinglePayloadNontrivial):
   return %v : $()
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_nontrivial_copy_destroy(i64 %0)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_nontrivial_copy_destroy(ptr %0)
 // CHECK:      call void @"$s27enum_value_semantics_future23SinglePayloadNontrivialOWOy"
 // CHECK-NEXT: call swiftcc void @single_payload_nontrivial_user
 // CHECK-NEXT: call void @"$s27enum_value_semantics_future23SinglePayloadNontrivialOWOe"
@@ -267,7 +267,8 @@ bb0(%0 : $SinglePayloadNontrivial):
 
 // -- SinglePayloadNontrivial destroyBuffer
 // CHECK: define internal void @"$s27enum_value_semantics_future23SinglePayloadNontrivialOwxx"(ptr noalias [[OBJ:%.*]], ptr %SinglePayloadNontrivial) {{.*}} {
-// CHECK: [[PAYLOAD:%.*]] = load i64, ptr [[OBJ]], align 8
+// CHECK: [[PAYLOAD:%.*]] = load ptr, ptr [[OBJ]], align 8
+// CHECK-NEXT: [[PAYLOAD_INT:%.*]] = ptrtoint ptr [[PAYLOAD]] to i64
 // CHECK-NEXT: switch i64 {{.*}}, label %[[RELEASE_PAYLOAD:[0-9]+]] [
 // CHECK:        i64 0, label %[[DONE:[0-9]+]]
 // CHECK-native:      i64 1, label %[[DONE]]

--- a/test/IRGen/enum_value_semantics_special_cases.sil
+++ b/test/IRGen/enum_value_semantics_special_cases.sil
@@ -95,18 +95,19 @@ enum MultipleEmptyRefcounted {
 
 // CHECK-LABEL: define internal void @"$s34enum_value_semantics_special_cases23MultipleEmptyRefcountedOwxx"(ptr noalias %object, ptr %MultipleEmptyRefcounted) {{.*}} {
 // CHECK: entry:
-// CHECK:   %0 = load i64, ptr %object, align 8
-// CHECK:   switch i64 %0, label %1 [
-// CHECK:     i64 0, label %2
-// CHECK-native:   i64 1, label %2
-// CHECK-objc-simulator-false:     i64 2, label %2
-// CHECK-objc-simulator-true:     i64 1, label %2
+// CHECK:   %0 = load ptr, ptr %object, align 8
+// CHECK:   %1 = ptrtoint ptr %0 to i64
+// CHECK:   switch i64 %1, label %2 [
+// CHECK:     i64 0, label %3
+// CHECK-native:   i64 1, label %3
+// CHECK-objc-simulator-false:     i64 2, label %3
+// CHECK-objc-simulator-true:     i64 1, label %3
 // CHECK:   ]
-// CHECK: 1:                                      ; preds = %entry
+// CHECK: 2:                                      ; preds = %entry
 // CHECK:   %toDestroy = load ptr, ptr %object, align 8
 // CHECK:   call void @swift_release(ptr %toDestroy)
-// CHECK:   br label %2
-// CHECK: 2:                                      ; preds = %1, %entry, %entry
+// CHECK:   br label %3
+// CHECK: 3:                                      ; preds = %2, %entry, %entry
 // CHECK:   ret void
 // CHECK: }
 

--- a/test/IRGen/existentials.sil
+++ b/test/IRGen/existentials.sil
@@ -47,26 +47,22 @@ entry(%s : $CP):
   return %z : $CP
 }
 
-// CHECK-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @class_existential_weak(ptr noalias sret({{.*}}) %0, i64 %1, i64 %2)
+// CHECK-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @class_existential_weak(ptr noalias sret({{.*}}) %0, ptr %1, ptr %2)
 sil @class_existential_weak : $@convention(thin) (@owned CP?) -> @out @sil_weak CP? {
 entry(%w : $*@sil_weak CP?, %a : $CP?):
   // CHECK: [[V:%.*]] = alloca { %swift.weak, ptr }
   %v = alloc_stack $@sil_weak CP?
 
-  // CHECK: [[SRC_REF:%.*]] = inttoptr {{.*}} ptr
-  // CHECK: [[SRC_WITNESS:%.*]] = inttoptr {{.*}} ptr
   // CHECK: [[DEST_WITNESS_ADDR:%.*]] = getelementptr inbounds{{.*}} { %swift.weak, ptr }, ptr %0, i32 0, i32 1
-  // CHECK: store ptr [[SRC_WITNESS]], ptr [[DEST_WITNESS_ADDR]]
+  // CHECK: store ptr %2, ptr [[DEST_WITNESS_ADDR]]
   // CHECK: [[DEST_REF_ADDR:%.*]] = getelementptr inbounds{{.*}} { %swift.weak, ptr }, ptr %0, i32 0, i32 0
-  // CHECK: call ptr @swift_weakInit(ptr returned [[DEST_REF_ADDR]], ptr [[SRC_REF]])
+  // CHECK: call ptr @swift_weakInit(ptr returned [[DEST_REF_ADDR]], ptr %1)
   store_weak %a to [init] %w : $*@sil_weak CP?
 
-  // CHECK: [[SRC_REF:%.*]] = inttoptr {{.*}} ptr
-  // CHECK: [[SRC_WITNESS:%.*]] = inttoptr {{.*}} ptr
   // CHECK: [[DEST_WITNESS_ADDR:%.*]] = getelementptr inbounds{{.*}} { %swift.weak, ptr }, ptr %0, i32 0, i32 1
-  // CHECK: store ptr [[SRC_WITNESS]], ptr [[DEST_WITNESS_ADDR]]
+  // CHECK: store ptr %2, ptr [[DEST_WITNESS_ADDR]]
   // CHECK: [[DEST_REF_ADDR:%.*]] = getelementptr inbounds{{.*}} { %swift.weak, ptr }, ptr %0, i32 0, i32 0
-  // CHECK: call ptr @swift_weakAssign(ptr returned [[DEST_REF_ADDR]], ptr [[SRC_REF]])
+  // CHECK: call ptr @swift_weakAssign(ptr returned [[DEST_REF_ADDR]], ptr %1)
   store_weak %a to                  %w : $*@sil_weak CP?
 
   // CHECK: [[SRC_REF_ADDR:%.*]] = getelementptr inbounds{{.*}} { %swift.weak, ptr }, ptr %0, i32 0, i32 0

--- a/test/IRGen/existentials_objc.sil
+++ b/test/IRGen/existentials_objc.sil
@@ -97,22 +97,18 @@ entry(%s : $CP):
   return %z : $CP
 }
 
-// CHECK-DAG: define{{( protected)?}} swiftcc void @class_existential_weak(ptr noalias sret({{.*}}) %0, i64 %1, i64 %2)
+// CHECK-DAG: define{{( protected)?}} swiftcc void @class_existential_weak(ptr noalias sret({{.*}}) %0, ptr [[SRC_REF:%.*]], ptr [[SRC_WITNESS:%.*]])
 sil @class_existential_weak : $@convention(thin) (@owned CP?) -> @out @sil_weak CP? {
 entry(%w : $*@sil_weak CP?, %a : $CP?):
   // CHECK: [[V:%.*]] = alloca { %swift.weak, ptr }
   %v = alloc_stack $@sil_weak CP?
 
-  // CHECK: [[SRC_REF:%.*]] = inttoptr {{.*}} ptr
-  // CHECK: [[SRC_WITNESS:%.*]] = inttoptr {{.*}} ptr
   // CHECK: [[DEST_WITNESS_ADDR:%.*]] = getelementptr inbounds{{.*}} { %swift.weak, ptr }, ptr %0, i32 0, i32 1
   // CHECK: store ptr [[SRC_WITNESS]], ptr [[DEST_WITNESS_ADDR]]
   // CHECK: [[DEST_REF_ADDR:%.*]] = getelementptr inbounds{{.*}} { %swift.weak, ptr }, ptr %0, i32 0, i32 0
   // CHECK: call ptr @swift_unknownObjectWeakInit(ptr returned [[DEST_REF_ADDR]], ptr [[SRC_REF]])
   store_weak %a to [init] %w : $*@sil_weak CP?
 
-  // CHECK: [[SRC_REF:%.*]] = inttoptr {{.*}} ptr
-  // CHECK: [[SRC_WITNESS:%.*]] = inttoptr {{.*}} ptr
   // CHECK: [[DEST_WITNESS_ADDR:%.*]] = getelementptr inbounds{{.*}} { %swift.weak, ptr }, ptr %0, i32 0, i32 1
   // CHECK: store ptr [[SRC_WITNESS]], ptr [[DEST_WITNESS_ADDR]]
   // CHECK: [[DEST_REF_ADDR:%.*]] = getelementptr inbounds{{.*}} { %swift.weak, ptr }, ptr %0, i32 0, i32 0

--- a/test/IRGen/fixlifetime.sil
+++ b/test/IRGen/fixlifetime.sil
@@ -8,7 +8,7 @@
 // unnecessary.
 // ONONE-NOT: @__swift_fixLifetime
 
-// CHECK-objc-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test(ptr %0, ptr %1, ptr %2, ptr %3, ptr %4, ptr noalias captures(none) dereferenceable({{.*}}) %5, {{(i64|i32)}} %6, {{(i64|i32)}} %7) {{.*}} {
+// CHECK-objc-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test(ptr %0, ptr %1, ptr %2, ptr %3, ptr %4, ptr noalias captures(none) dereferenceable({{.*}}) %5, ptr %6, ptr %7) {{.*}} {
 // CHECK-objc: entry:
 // CHECK-objc:  call void @__swift_fixLifetime(ptr
 // CHECK-objc:  call void @__swift_fixLifetime(ptr
@@ -16,11 +16,12 @@
 // CHECK-objc:  call void @__swift_fixLifetime(ptr
 // CHECK-objc:  call void @__swift_fixLifetime(ptr
 // CHECK-objc:  call void @__swift_fixLifetime(ptr
-// CHECK-objc:  [[TEMP:%.*]] = inttoptr {{(i64|i32)}} %6 to ptr
+// CHECK-objc:  [[INT:%.*]] = ptrtoint ptr %6 to {{(i64|i32)}}
+// CHECK-objc:  [[TEMP:%.*]] = inttoptr {{(i64|i32)}} [[INT]] to ptr
 // CHECK-objc:  call void @__swift_fixLifetime(ptr [[TEMP]])
 // CHECK-objc:  call void @__swift_fixLifetime(ptr
 
-// CHECK-native-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test(ptr %0, ptr %1, ptr %2, ptr %3, ptr %4, ptr noalias captures(none) dereferenceable({{.*}}) %5, {{(i64|i32)}} %6, {{(i64|i32)}} %7) {{.*}} {
+// CHECK-native-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test(ptr %0, ptr %1, ptr %2, ptr %3, ptr %4, ptr noalias captures(none) dereferenceable({{.*}}) %5, ptr %6, ptr %7) {{.*}} {
 // CHECK-native: entry:
 // CHECK-native:  call void @__swift_fixLifetime(ptr
 // CHECK-native:  call void @__swift_fixLifetime(ptr

--- a/test/IRGen/implicitactor_to_opaqueisolation_cast.sil
+++ b/test/IRGen/implicitactor_to_opaqueisolation_cast.sil
@@ -10,18 +10,22 @@ import _Concurrency
 // REQUIRES: SWIFT_STDLIB_ARCH=arm64
 // REQUIRES: OS=macosx
 
-// TAGGED_POINTER: define swiftcc { i64, i64 } @test_cast_implicitactor_to_opaqueisolation(i64 [[WORD1:%.*]], i64 [[WORD2:%.*]])
+// TAGGED_POINTER: define swiftcc { ptr, ptr } @test_cast_implicitactor_to_opaqueisolation(i64 [[WORD1:%.*]], i64 [[WORD2:%.*]])
 // TAGGED_POINTER: [[MASKED_WORD:%.*]] = and i64 [[WORD2]], -4
-// TAGGED_POINTER: [[TUP1:%.*]] = insertvalue { i64, i64 } undef, i64 [[WORD1]], 0
-// TAGGED_POINTER: [[TUP2:%.*]] = insertvalue { i64, i64 } [[TUP1]], i64 [[MASKED_WORD]], 1
-// TAGGED_POINTER: ret { i64, i64 } [[TUP2]]
+// TAGGED_POINTER: [[PTR1:%.*]] = inttoptr i64 [[WORD1]] to ptr
+// TAGGED_POINTER: [[PTR2:%.*]] = inttoptr i64 [[MASKED_WORD]] to ptr
+// TAGGED_POINTER: [[TUP1:%.*]] = insertvalue { ptr, ptr } undef, ptr [[PTR1]], 0
+// TAGGED_POINTER: [[TUP2:%.*]] = insertvalue { ptr, ptr } [[TUP1]], ptr [[PTR2]], 1
+// TAGGED_POINTER: ret { ptr, ptr } [[TUP2]]
 // TAGGED_POINTER-NEXT: }
 
-// TBI: define swiftcc { i64, i64 } @test_cast_implicitactor_to_opaqueisolation(i64 [[WORD1:%.*]], i64 [[WORD2:%.*]])
-// TBI: [[MASKED_WORD:%.*]] = and i64 [[WORD2]], -3458764513820540929 
-// TBI: [[TUP1:%.*]] = insertvalue { i64, i64 } undef, i64 [[WORD1]], 0
-// TBI: [[TUP2:%.*]] = insertvalue { i64, i64 } [[TUP1]], i64 [[MASKED_WORD]], 1
-// TBI: ret { i64, i64 } [[TUP2]]
+// TBI: define swiftcc { ptr, ptr } @test_cast_implicitactor_to_opaqueisolation(i64 [[WORD1:%.*]], i64 [[WORD2:%.*]])
+// TBI: [[MASKED_WORD:%.*]] = and i64 [[WORD2]], -3458764513820540929
+// TBI: [[PTR1:%.*]] = inttoptr i64 [[WORD1]] to ptr
+// TBI: [[PTR2:%.*]] = inttoptr i64 [[MASKED_WORD]] to ptr
+// TBI: [[TUP1:%.*]] = insertvalue { ptr, ptr } undef, ptr [[PTR1]], 0
+// TBI: [[TUP2:%.*]] = insertvalue { ptr, ptr } [[TUP1]], ptr [[PTR2]], 1
+// TBI: ret { ptr, ptr } [[TUP2]]
 // TBI-NEXT: }
 sil @test_cast_implicitactor_to_opaqueisolation : $@convention(thin) (@guaranteed Builtin.ImplicitActor) -> @owned Optional<any Actor> {
 bb0(%0 : $Builtin.ImplicitActor):

--- a/test/IRGen/isolated_any.sil
+++ b/test/IRGen/isolated_any.sil
@@ -16,7 +16,7 @@ entry(%actor: $Optional<any Actor>, %int: $Int):
   return %closure : $@callee_guaranteed @isolated(any) () -> ()
 }
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @form_closure
-// CHECK: ([[INT]] %0, [[INT]] %1, [[INT]] %2, ptr %T)
+// CHECK: (ptr %0, ptr %1, [[INT]] %2, ptr %T)
 //   ptr: heap metadata
 //   ptr: heap refcount
 //   ptr: isolation ref
@@ -26,10 +26,10 @@ entry(%actor: $Optional<any Actor>, %int: $Int):
 // CHECK-64: [[BOX:%.*]] = call noalias ptr @swift_allocObject(ptr {{.*}}, [[INT]] 48, [[INT]] 7)
 // CHECK-32: [[BOX:%.*]] = call noalias ptr @swift_allocObject(ptr {{.*}}, [[INT]] 24, [[INT]] 3)
 // CHECK-NEXT: [[ISO_ADDR:%.*]] = getelementptr inbounds{{.*}} <{ %swift.refcounted, %TScA_pSg, [{{4|8}} x i8], %TSi }>, ptr [[BOX]], i32 0, i32 1
-// CHECK-NEXT: [[ISO_REF_ADDR:%.*]] = getelementptr inbounds{{.*}} { [[INT]], [[INT]] }, ptr [[ISO_ADDR]], i32 0, i32 0
-// CHECK-NEXT: store [[INT]] %0, ptr [[ISO_REF_ADDR]], align
-// CHECK-NEXT: [[ISO_WT_ADDR:%.*]] = getelementptr inbounds{{.*}} { [[INT]], [[INT]] }, ptr [[ISO_ADDR]], i32 0, i32 1
-// CHECK-NEXT: store [[INT]] %1, ptr [[ISO_WT_ADDR]], align
+// CHECK-NEXT: [[ISO_REF_ADDR:%.*]] = getelementptr inbounds{{.*}} { ptr, ptr }, ptr [[ISO_ADDR]], i32 0, i32 0
+// CHECK-NEXT: store ptr %0, ptr [[ISO_REF_ADDR]], align
+// CHECK-NEXT: [[ISO_WT_ADDR:%.*]] = getelementptr inbounds{{.*}} { ptr, ptr }, ptr [[ISO_ADDR]], i32 0, i32 1
+// CHECK-NEXT: store ptr %1, ptr [[ISO_WT_ADDR]], align
 // CHECK-NEXT: [[T_ADDR:%.*]] = getelementptr inbounds{{.*}} <{ %swift.refcounted, %TScA_pSg, [{{4|8}} x i8], %TSi }>, ptr [[BOX]], i32 0, i32 2
 // CHECK-NEXT: store ptr %T, ptr [[T_ADDR]], align
 // CHECK:      [[RESULT:%.*]] = insertvalue { ptr, ptr } { ptr @"$s7closureTA{{(\.ptrauth.*)?}}", ptr undef }, ptr [[BOX]], 1
@@ -40,14 +40,14 @@ entry(%fn : $@callee_guaranteed @isolated(any) () -> ()):
   %actor = function_extract_isolation %fn : $@callee_guaranteed @isolated(any) () -> ()
   return %actor : $Optional<any Actor>
 }
-// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, i64 } @extract_closure_isolation
-// CHECK-32-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i32, i32 } @extract_closure_isolation
+// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @extract_closure_isolation
+// CHECK-32-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @extract_closure_isolation
 // CHECK-64:   [[ISO_ADDR:%.*]] = getelementptr inbounds i8, ptr %1, i32 16
 // CHECK-32:   [[ISO_ADDR:%.*]] = getelementptr inbounds i8, ptr %1, i32 8
-// CHECK-NEXT: [[ISO_REF_ADDR:%.*]] = getelementptr inbounds{{.*}} { [[INT]], [[INT]] }, ptr [[ISO_ADDR]], i32 0, i32 0
-// CHECK-NEXT: [[ISO_REF:%.*]] = load [[INT]], ptr [[ISO_REF_ADDR]], align
-// CHECK-NEXT: [[ISO_WT_ADDR:%.*]] = getelementptr inbounds{{.*}} { [[INT]], [[INT]] }, ptr [[ISO_ADDR]], i32 0, i32 1
-// CHECK-NEXT: [[ISO_WT:%.*]] = load [[INT]], ptr [[ISO_WT_ADDR]], align
-// CHECK-NEXT: [[T0:%.*]] = insertvalue { [[INT]], [[INT]] } undef, [[INT]] [[ISO_REF]], 0
-// CHECK-NEXT: [[T1:%.*]] = insertvalue { [[INT]], [[INT]] } [[T0]], [[INT]] [[ISO_WT]], 1
-// CHECK-NEXT: ret { [[INT]], [[INT]] } [[T1]]
+// CHECK-NEXT: [[ISO_REF_ADDR:%.*]] = getelementptr inbounds{{.*}} { ptr, ptr }, ptr [[ISO_ADDR]], i32 0, i32 0
+// CHECK-NEXT: [[ISO_REF:%.*]] = load ptr, ptr [[ISO_REF_ADDR]], align
+// CHECK-NEXT: [[ISO_WT_ADDR:%.*]] = getelementptr inbounds{{.*}} { ptr, ptr }, ptr [[ISO_ADDR]], i32 0, i32 1
+// CHECK-NEXT: [[ISO_WT:%.*]] = load ptr, ptr [[ISO_WT_ADDR]], align
+// CHECK-NEXT: [[T0:%.*]] = insertvalue { ptr, ptr } undef, ptr [[ISO_REF]], 0
+// CHECK-NEXT: [[T1:%.*]] = insertvalue { ptr, ptr } [[T0]], ptr [[ISO_WT]], 1
+// CHECK-NEXT: ret { ptr, ptr } [[T1]]

--- a/test/IRGen/optional_reference_ptr.sil
+++ b/test/IRGen/optional_reference_ptr.sil
@@ -118,9 +118,10 @@ bb0(%0 : $ManyEmpty):
   return %0 : $ManyEmpty
 }
 
-// The second no-payload case is extra inhabitant #1 (pointer value 1).
+// The second no-payload case is a distinct low, non-null extra inhabitant of
+// the pointer (the exact value is platform-dependent).
 // CHECK-LABEL: define{{.*}} swiftcc ptr @make_many_empty_b()
-// CHECK: ret ptr inttoptr (i{{[0-9]+}} 1 to ptr)
+// CHECK: ret ptr inttoptr (i{{[0-9]+}} {{[0-9]+}} to ptr)
 sil @make_many_empty_b : $@convention(thin) () -> @owned ManyEmpty {
 bb0:
   %0 = enum $ManyEmpty, #ManyEmpty.b!enumelt

--- a/test/IRGen/optional_reference_ptr.sil
+++ b/test/IRGen/optional_reference_ptr.sil
@@ -1,7 +1,11 @@
 // RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s
 
-// A loadable single-level Optional of a bare retainable pointer (.none == null)
-// is lowered to `ptr` in LLVM IR, rather than a pointer-width integer.
+// A loadable single-payload enum whose payload is a single retainable pointer
+// (a bare class/AnyObject/NativeObject, or a nested optional already lowered
+// this way) is lowered to `ptr` in LLVM IR, rather than a pointer-width
+// integer. This holds for arbitrarily nested optionals and for custom enums
+// with more than one no-payload case, as long as every empty case fits in one
+// of the payload's low, invalid-pointer extra inhabitants.
 
 sil_stage canonical
 
@@ -59,11 +63,81 @@ bb3:
   return %r : $()
 }
 
-// Guard: a nested optional's outer `.none` is a *non-null* extra inhabitant, so
-// it keeps its integer representation and is unaffected by this change.
-// CHECK-LABEL: define{{.*}} swiftcc i{{[0-9]+}} @take_nested_optional(i{{[0-9]+}} %0)
+// A nested optional is also a single pointer: the outer `.none` occupies a
+// non-null low extra inhabitant of the payload, and `.some(.none)` is null.
+// Only valid pointers are ever dereferenced, so the sentinels ride along in a
+// `ptr`.
+// CHECK-LABEL: define{{.*}} swiftcc ptr @take_nested_optional(ptr %0)
 sil @take_nested_optional : $@convention(thin) (@guaranteed Optional<Optional<C>>) -> @owned Optional<Optional<C>> {
 bb0(%0 : $Optional<Optional<C>>):
   retain_value %0 : $Optional<Optional<C>>
   return %0 : $Optional<Optional<C>>
+}
+
+// A triply-nested optional stays a single pointer too.
+// CHECK-LABEL: define{{.*}} swiftcc ptr @take_triple_nested_optional(ptr %0)
+sil @take_triple_nested_optional : $@convention(thin) (@guaranteed Optional<Optional<Optional<C>>>) -> @owned Optional<Optional<Optional<C>>> {
+bb0(%0 : $Optional<Optional<Optional<C>>>):
+  retain_value %0 : $Optional<Optional<Optional<C>>>
+  return %0 : $Optional<Optional<Optional<C>>>
+}
+
+// `.some(.none)` of a nested optional is the null pointer.
+// CHECK-LABEL: define{{.*}} swiftcc ptr @make_some_none()
+// CHECK: ret ptr null
+sil @make_some_none : $@convention(thin) () -> @owned Optional<Optional<C>> {
+bb0:
+  %0 = enum $Optional<C>, #Optional.none!enumelt
+  %1 = enum $Optional<Optional<C>>, #Optional.some!enumelt, %0 : $Optional<C>
+  return %1 : $Optional<Optional<C>>
+}
+
+// The outer `.none` of a nested optional is a non-null low extra inhabitant.
+// CHECK-LABEL: define{{.*}} swiftcc ptr @make_outer_none()
+// CHECK: ret ptr inttoptr
+sil @make_outer_none : $@convention(thin) () -> @owned Optional<Optional<C>> {
+bb0:
+  %0 = enum $Optional<Optional<C>>, #Optional.none!enumelt
+  return %0 : $Optional<Optional<C>>
+}
+
+// A custom single-payload enum whose payload is a single retainable pointer
+// lowers to `ptr` even with several no-payload cases: each empty case takes a
+// distinct low extra inhabitant of the pointer.
+enum ManyEmpty {
+  case value(C)
+  case a
+  case b
+  case c
+}
+
+// CHECK-LABEL: define{{.*}} swiftcc ptr @take_many_empty(ptr %0)
+sil @take_many_empty : $@convention(thin) (@guaranteed ManyEmpty) -> @owned ManyEmpty {
+bb0(%0 : $ManyEmpty):
+  retain_value %0 : $ManyEmpty
+  return %0 : $ManyEmpty
+}
+
+// The second no-payload case is extra inhabitant #1 (pointer value 1).
+// CHECK-LABEL: define{{.*}} swiftcc ptr @make_many_empty_b()
+// CHECK: ret ptr inttoptr (i{{[0-9]+}} 1 to ptr)
+sil @make_many_empty_b : $@convention(thin) () -> @owned ManyEmpty {
+bb0:
+  %0 = enum $ManyEmpty, #ManyEmpty.b!enumelt
+  return %0 : $ManyEmpty
+}
+
+// A custom single-payload enum whose payload is itself a `ptr`-lowered optional
+// is a single pointer too.
+enum OptPayload {
+  case value(Optional<C>)
+  case p
+  case q
+}
+
+// CHECK-LABEL: define{{.*}} swiftcc ptr @take_opt_payload(ptr %0)
+sil @take_opt_payload : $@convention(thin) (@guaranteed OptPayload) -> @owned OptPayload {
+bb0(%0 : $OptPayload):
+  retain_value %0 : $OptPayload
+  return %0 : $OptPayload
 }

--- a/test/IRGen/outlined_copy_addr.swift
+++ b/test/IRGen/outlined_copy_addr.swift
@@ -36,7 +36,7 @@ struct OtherInternal<T> {
 struct MyPrivate<T: P> {
   var otherHelper: OtherInternal<T>? = nil
 
-  // CHECK-LABEL: define hidden swiftcc {{i32|i64}} @"$s11outcopyaddr9MyPrivateVyACyxGxcfC"(ptr noalias %0, ptr %T, ptr %T.P) {{.*}} {
+  // CHECK-LABEL: define hidden swiftcc ptr @"$s11outcopyaddr9MyPrivateVyACyxGxcfC"(ptr noalias %0, ptr %T, ptr %T.P) {{.*}} {
   // CHECK: call ptr @"$s11outcopyaddr9MyPrivateVyxGAA1PRzlWOh"(ptr {{%.*}})
   // CHECK: ret
   init(_: T) { }

--- a/test/IRGen/weak.sil
+++ b/test/IRGen/weak.sil
@@ -56,18 +56,16 @@ bb0(%0 : $*B, %1 : $Optional<P>):
   %4 = tuple ()
   return %4 : $()
 }
-// CHECK:    define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_weak_load_store_proto(ptr dereferenceable({{.*}}) %0, i64 %1, i64 %2)
+// CHECK:    define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_weak_load_store_proto(ptr dereferenceable({{.*}}) %0, ptr %1, ptr %2)
 // CHECK:      [[X:%.*]] = getelementptr inbounds{{.*}} [[B:%T4weak1BV]], ptr %0, i32 0, i32 0
 // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds{{.*}} { [[WEAK:%swift.weak]], ptr }, ptr [[X]], i32 0, i32 0
 // CHECK-NEXT: [[T1:%.*]] = call ptr @swift_unknownObjectWeakLoadStrong(ptr [[T0]])
 // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds{{.*}} { [[WEAK]], ptr }, ptr [[X]], i32 0, i32 1
 // CHECK-NEXT: [[W:%.*]] = load ptr, ptr [[T0]], align 8
-// CHECK: [[TMPOBJ:%.*]] = inttoptr {{.*}} to ptr
-// CHECK: [[TMPTAB:%.*]] = inttoptr {{.*}} to ptr
 // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds{{.*}} { [[WEAK]], ptr }, ptr [[X]], i32 0, i32 1
-// CHECK-NEXT: store ptr [[TMPTAB]], ptr [[T0]], align 8
+// CHECK-NEXT: store ptr %2, ptr [[T0]], align 8
 // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds{{.*}} { [[WEAK]], ptr }, ptr [[X]], i32 0, i32 0
-// CHECK-NEXT: call ptr @swift_unknownObjectWeakAssign(ptr returned [[T0]], ptr [[TMPOBJ]])
+// CHECK-NEXT: call ptr @swift_unknownObjectWeakAssign(ptr returned [[T0]], ptr %1)
 // CHECK: call void @swift_unknownObjectRelease
 
 sil @test_weak_alloc_stack : $@convention(thin) (Optional<P>) -> () {
@@ -79,14 +77,12 @@ bb0(%0 : $Optional<P>):
   %4 = tuple ()
   return %4 : $()
 }
-// CHECK:    define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_weak_alloc_stack(i64 %0, i64 %1)
+// CHECK:    define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_weak_alloc_stack(ptr %0, ptr %1)
 // CHECK:      [[X:%.*]] = alloca { [[WEAK]], ptr }, align 8
-// CHECK: [[TMPOBJ:%.*]] = inttoptr {{.*}} to ptr
-// CHECK: [[TMPTAB:%.*]] = inttoptr {{.*}} to ptr
 // CHECK: [[T0:%.*]] = getelementptr inbounds{{.*}} { [[WEAK]], ptr }, ptr [[X]], i32 0, i32 1
-// CHECK-NEXT: store ptr [[TMPTAB:%.*]], ptr [[T0]], align 8
+// CHECK-NEXT: store ptr %1, ptr [[T0]], align 8
 // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds{{.*}} { [[WEAK]], ptr }, ptr [[X]], i32 0, i32 0
-// CHECK-NEXT: call ptr @swift_unknownObjectWeakInit(ptr returned [[T0]], ptr [[TMPOBJ:%.*]])
+// CHECK-NEXT: call ptr @swift_unknownObjectWeakInit(ptr returned [[T0]], ptr %0)
 // CHECK-NEXT: call ptr @"$s4weak1P_pSgXwWOh"(ptr [[X]])
 // CHECK-NEXT: llvm.lifetime.end
 // CHECK-NEXT: ret void

--- a/test/IRGen/weak_class_protocol.sil
+++ b/test/IRGen/weak_class_protocol.sil
@@ -6,16 +6,13 @@ import Swift
 
 protocol Foo: class { }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @store_weak(ptr noalias sret({{.*}}) %0, i64 %1, i64 %2) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @store_weak(ptr noalias sret({{.*}}) %0, ptr %1, ptr %2) {{.*}} {
 // CHECK:       entry:
-// CHECK-objc:    [[INSTANCE:%.*]] = inttoptr i64 %1 to ptr
-// CHECK-native:  [[INSTANCE:%.*]] = inttoptr i64 %1 to ptr
-// CHECK:         [[WTABLE:%.*]] = inttoptr i64 %2 to ptr
 // CHECK:         [[WTABLE_SLOT:%.*]] = getelementptr inbounds{{.*}} { %swift.weak, ptr }, ptr %0, i32 0, i32 1
-// CHECK:         store ptr [[WTABLE]], ptr [[WTABLE_SLOT]], align 8
+// CHECK:         store ptr %2, ptr [[WTABLE_SLOT]], align 8
 // CHECK:         [[INSTANCE_SLOT:%.*]] = getelementptr inbounds{{.*}} { %swift.weak, ptr }, ptr %0, i32 0, i32 0
-// CHECK-objc:    call ptr @swift_unknownObjectWeakAssign(ptr returned [[INSTANCE_SLOT]], ptr [[INSTANCE]]) {{#[0-9]+}}
-// CHECK-native:  call ptr @swift_weakAssign(ptr returned [[INSTANCE_SLOT]], ptr [[INSTANCE]]) {{#[0-9]+}}
+// CHECK-objc:    call ptr @swift_unknownObjectWeakAssign(ptr returned [[INSTANCE_SLOT]], ptr %1) {{#[0-9]+}}
+// CHECK-native:  call ptr @swift_weakAssign(ptr returned [[INSTANCE_SLOT]], ptr %1) {{#[0-9]+}}
 // CHECK:         ret void
 // CHECK:       }
 sil @store_weak : $@convention(thin) (@owned Foo?) -> @out @sil_weak Foo? {

--- a/test/Interpreter/enum_reference_concrete_repr.swift
+++ b/test/Interpreter/enum_reference_concrete_repr.swift
@@ -1,0 +1,102 @@
+// RUN: %target-run-simple-swift(-Onone) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O) | %FileCheck %s
+// REQUIRES: executable_test
+
+// Runtime coverage for the concrete-typed representation of single-payload
+// enums whose payload holds a managed reference in a multi-word value: a
+// class-bound existential optional, a struct mixing a reference and an integer,
+// and a custom enum over an existential with extra empty cases. Construction,
+// switching, and retain/release must all stay correct even though the enum now
+// carries its pointer words as `ptr`.
+
+protocol P: AnyObject {
+  var n: Int { get }
+}
+
+final class Box: P {
+  let n: Int
+  init(_ n: Int) { self.n = n }
+  deinit { print("deinit \(n)") }
+}
+
+// A class-bound existential optional: `(any P)?` is two pointers.
+func describe(_ v: (any P)?) -> String {
+  switch v {
+  case .some(let p): return "some(\(p.n))"
+  case .none: return "none"
+  }
+}
+
+func testExistentialOptional() {
+  print("== testExistentialOptional ==")  // CHECK: == testExistentialOptional ==
+  do {
+    let v: (any P)? = Box(1)
+    print(describe(v))                     // CHECK-NEXT: some(1)
+    print(describe(nil))                   // CHECK-NEXT: none
+    let copy = v                           // retain through both words
+    print(describe(copy))                  // CHECK-NEXT: some(1)
+  }                                        // CHECK-NEXT: deinit 1
+}
+testExistentialOptional()
+
+// A struct mixing a reference and an integer, wrapped in an optional.
+struct Pair { var a: Box; var b: Int }
+
+func testPairOptional() {
+  print("== testPairOptional ==")          // CHECK: == testPairOptional ==
+  do {
+    let p: Pair? = Pair(a: Box(2), b: 42)
+    switch p {
+    case .some(let x): print("some(\(x.a.n), \(x.b))")  // CHECK-NEXT: some(2, 42)
+    case .none: print("none")
+    }
+    print(p == nil ? "nil" : "nonnil")      // CHECK-NEXT: nonnil
+  }                                         // CHECK-NEXT: deinit 2
+}
+testPairOptional()
+
+// A padded payload: the leading Int32 pushes the reference into the second
+// word, so the reference word is `ptr` while the padding stays in the leading
+// integer word.
+struct PaddedRef { var x: Int32; var ref: Box }
+
+func testPaddedOptional() {
+  print("== testPaddedOptional ==")          // CHECK: == testPaddedOptional ==
+  do {
+    let p: PaddedRef? = PaddedRef(x: 7, ref: Box(5))
+    switch p {
+    case .some(let v): print("some(\(v.x), \(v.ref.n))")  // CHECK-NEXT: some(7, 5)
+    case .none: print("none")
+    }
+    print(p == nil ? "nil" : "nonnil")        // CHECK-NEXT: nonnil
+  }                                           // CHECK-NEXT: deinit 5
+}
+testPaddedOptional()
+
+// A custom single-payload enum over an existential with extra empty cases.
+enum ExistentialOrTags {
+  case value(any P)
+  case a
+  case b
+}
+
+func describe(_ e: ExistentialOrTags) -> String {
+  switch e {
+  case .value(let p): return "value(\(p.n))"
+  case .a: return "a"
+  case .b: return "b"
+  }
+}
+
+func testExistentialOrTags() {
+  print("== testExistentialOrTags ==")     // CHECK: == testExistentialOrTags ==
+  print(describe(.a))                       // CHECK-NEXT: a
+  print(describe(.b))                       // CHECK-NEXT: b
+  do {
+    let e: ExistentialOrTags = .value(Box(3))
+    print(describe(e))                      // CHECK-NEXT: value(3)
+  }                                         // CHECK-NEXT: deinit 3
+}
+testExistentialOrTags()
+
+print("== done ==")                         // CHECK: == done ==

--- a/test/Interpreter/optional_reference_ptr.swift
+++ b/test/Interpreter/optional_reference_ptr.swift
@@ -1,0 +1,107 @@
+// RUN: %target-run-simple-swift(-Onone) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O) | %FileCheck %s
+// REQUIRES: executable_test
+
+// Runtime coverage for the `ptr`-lowered single-payload enum representation:
+// nested optionals of a class reference, and custom single-payload enums with
+// several no-payload cases. These carry the empty cases in the payload
+// pointer's low, invalid-pointer extra inhabitants; only genuine pointers are
+// ever dereferenced, so construction, switching, and retain/release must all
+// stay correct.
+
+final class Box {
+  let n: Int
+  init(_ n: Int) { self.n = n }
+  deinit { print("deinit \(n)") }
+}
+
+// A custom single-payload enum with a single retainable-pointer payload and
+// more than one no-payload case.
+enum Many {
+  case value(Box)
+  case a
+  case b
+  case c
+}
+
+func describe(_ e: Many) -> String {
+  switch e {
+  case .value(let b): return "value(\(b.n))"
+  case .a: return "a"
+  case .b: return "b"
+  case .c: return "c"
+  }
+}
+
+func testMany() {
+  print("== testMany ==")           // CHECK: == testMany ==
+  do {
+    let e: Many = .value(Box(1))
+    print(describe(e))              // CHECK-NEXT: value(1)
+    print(describe(.a))             // CHECK-NEXT: a
+    print(describe(.b))             // CHECK-NEXT: b
+    print(describe(.c))             // CHECK-NEXT: c
+    let copy = e                    // retain the payload
+    print(describe(copy))           // CHECK-NEXT: value(1)
+  }                                 // CHECK-NEXT: deinit 1
+}
+testMany()
+
+// Nested optionals of a class reference.
+func d2(_ v: Box??) -> String {
+  switch v {
+  case .some(.some(let b)): return "some(some(\(b.n)))"
+  case .some(.none): return "some(none)"
+  case .none: return "none"
+  }
+}
+
+func testNested() {
+  print("== testNested ==")         // CHECK: == testNested ==
+  do {
+    let x: Box?? = Box(2)
+    print(d2(x))                    // CHECK-NEXT: some(some(2))
+    print(d2(.some(.none)))         // CHECK-NEXT: some(none)
+    print(d2(.none))                // CHECK-NEXT: none
+    let copy = x                    // retain through two optional layers
+    print(d2(copy))                 // CHECK-NEXT: some(some(2))
+  }                                 // CHECK-NEXT: deinit 2
+
+  do {
+    let y: Box??? = Box(3)
+    if case .some(.some(.some(let b))) = y {
+      print("sss(\(b.n))")          // CHECK-NEXT: sss(3)
+    }
+  }                                 // CHECK-NEXT: deinit 3
+}
+testNested()
+
+// A custom single-payload enum whose payload is itself a `ptr`-lowered optional.
+enum OptPayload {
+  case value(Box?)
+  case p
+  case q
+}
+
+func d3(_ f: OptPayload) -> String {
+  switch f {
+  case .value(.some(let b)): return "value(some(\(b.n)))"
+  case .value(.none): return "value(none)"
+  case .p: return "p"
+  case .q: return "q"
+  }
+}
+
+func testOptPayload() {
+  print("== testOptPayload ==")     // CHECK: == testOptPayload ==
+  print(d3(.value(nil)))            // CHECK-NEXT: value(none)
+  print(d3(.p))                     // CHECK-NEXT: p
+  print(d3(.q))                     // CHECK-NEXT: q
+  do {
+    let f: OptPayload = .value(Box(4))
+    print(d3(f))                    // CHECK-NEXT: value(some(4))
+  }                                 // CHECK-NEXT: deinit 4
+}
+testOptPayload()
+
+print("== done ==")                 // CHECK: == done ==

--- a/test/ModuleInterface/enums-layout.swift
+++ b/test/ModuleInterface/enums-layout.swift
@@ -61,7 +61,7 @@ func testFutureproofIndirectEnum() -> FutureproofIndirectEnum {
 func testFrozenIndirectEnum() -> FrozenIndirectEnum {
   // Whether this is "1" or "2" depends on whether the reserved ObjC tagged
   // pointer bit is the top or bottom bit on this platform.
-  // CHECK: ret i{{32|64}} {{1|2}}
+  // CHECK: ret ptr inttoptr (i{{32|64}} {{1|2}} to ptr)
   return .c
 }
 
@@ -79,6 +79,6 @@ func testFutureproofIndirectCaseEnum() -> FutureproofIndirectCaseEnum {
 func testFrozenIndirectCaseEnum() -> FrozenIndirectCaseEnum {
   // Whether this is "1" or "2" depends on whether the reserved ObjC tagged
   // pointer bit is the top or bottom bit on this platform.
-  // CHECK: ret i{{32|64}} {{1|2}}
+  // CHECK: ret ptr inttoptr (i{{32|64}} {{1|2}} to ptr)
   return .c
 }

--- a/test/embedded/unowned-task-executor.swift
+++ b/test/embedded/unowned-task-executor.swift
@@ -15,14 +15,12 @@ public var e: (any TaskExecutor)? = nil
 // CHECK-LABEL: define {{.*}}@"$e4test6testits19UnownedTaskExecutorVyF"()
 // CHECK: [[EXISTENTIAL_ADDR:%.*]] = call {{.*}}"$e4test1eSch_pSgvau"
 // CHECK: [[INSTANCE_ADDR:%.*]] = getelementptr {{.*}}[[EXISTENTIAL_ADDR]]{{, i[0-9]+ 0, i[0-9]+ 0}}
-// CHECK: [[INSTANCE:%.*]] = load {{.*}}ptr [[INSTANCE_ADDR]]
+// CHECK: [[INSTANCE:%.*]] = load ptr, ptr [[INSTANCE_ADDR]]
 // CHECK: [[CONFORMANCE_ADDR:%.*]] = getelementptr {{.*}}[[EXISTENTIAL_ADDR]]{{, i[0-9]+ 0, i[0-9]+ 1}}
-// CHECK: [[CONFORMANCE:%.*]] = load {{.*}}ptr [[CONFORMANCE_ADDR]]
-// CHECK: {{^[0-9a-z]+:}}
-// CHECK: [[INSTANCE_PTR:%.*]] = inttoptr {{i[0-9]+}} [[INSTANCE]]
-// CHECK: [[CONFORMANCE_PTR:%.*]] = inttoptr {{i[0-9]+}} [[CONFORMANCE]]
-// CHECK: [[INSTANCE_PHI:%.*]] = phi ptr [ [[INSTANCE_PTR]]
-// CHECK: [[CONFORMANCE_PHI:%.*]] = phi ptr [ [[CONFORMANCE_PTR]]
+// CHECK: [[CONFORMANCE:%.*]] = load ptr, ptr [[CONFORMANCE_ADDR]]
+// CHECK: icmp eq ptr [[INSTANCE]], null
+// CHECK: [[INSTANCE_PHI:%.*]] = phi ptr
+// CHECK: [[CONFORMANCE_PHI:%.*]] = phi ptr
 // CHECK: [[INSTANCE_ISA:%.*]] = load ptr, ptr [[INSTANCE_PHI]]
 // CHECK: call {{.*}}@"$es19UnownedTaskExecutorVyABxhcSchRzlufC"(ptr [[INSTANCE_PHI]], ptr [[INSTANCE_ISA]], ptr [[CONFORMANCE_PHI]])
 // CHECK-LABEL: {{^}}}


### PR DESCRIPTION
rdar://183333056
rdar://183333300

  Extend the .none == null pointer lowering to more reference enums

  Builds on the existing .none == null optimization, which only lowered a loadable single-payload enum to ptr when the payload was a single bare retainable pointer with exactly one empty case.

  1. Nested optionals and multi-empty-case enums (rdar://183333056)
  Lower to ptr any loadable single-payload enum whose payload is a single pointer holding a managed reference, as long as the empty cases fit in the payload's extra inhabitants. This covers arbitrarily nested
  optionals (Class??, Class???) and custom enums with several empty cases — the empty cases just occupy low, invalid-pointer values, which are never dereferenced.

  2. Multi-word payloads (rdar://183333300)
  Extend it to payloads that store their tag in a reference's extra inhabitants but span more than one word. The payload is chunked into pointer-sized words as before, but every word that holds a single pointer is
  typed ptr instead of an opaque integer (padding stays in the neighbouring integer words). So a class-bound existential optional lowers to {ptr, ptr}, Optional<{Class, Int}> to {ptr, i64}, Optional<{Int32, Class}>
  to {i64, ptr}, etc., instead of hiding every reference behind an integer.

  This removes the integer round-trips these representations used to need: ClassExistentialTypeInfo::mergeExplosion no longer ptrtoints the existential words, strong_copy_{unowned,unmanaged}_value coerces
  reference-storage words to the referent's schema types, and implicitactor_to_opaqueisolation_cast builds the (any Actor)? result with its schema types. Updates the affected FileCheck tests and adds
  enum_reference_concrete_repr.{sil,swift} plus interpreter coverage.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
