### PR TITLE
test: Skip attr_dynamic_member_lookup_default_args.swift in back deployment configs

### DIFF
--- a/test/attr/attr_dynamic_member_lookup_default_args.swift
+++ b/test/attr/attr_dynamic_member_lookup_default_args.swift
@@ -1,5 +1,7 @@
-// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking)
+// RUN: %target-run-simple-swift(-target %target-swift-6.2-abi-triple)
 // REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
 // XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Adjust a test from https://github.com/swiftlang/swift/pull/88480 so that it doesn't run on bot configs that don't support it.

Also, use a real deployment target instead of `-disable-availability-checking`.

Resolves rdar://181742095.