### PR TITLE
Revert "[6.4] 🌸 Differentiate explicit submodules for export_as"

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -6481,18 +6481,14 @@ class TypePrinter : public TypeVisitor<TypePrinter, void, NonRecursivePrintOptio
     return Options.CurrentModule->getVisibleClangModules(Options.InterfaceContentKind);
   }
 
-  /// If \p TyDecl belongs to an explicit submodule, return the \c ModuleDecl
-  /// for that submodule; otherwise just return the parent module.
+  /// If \p TyDecl belongs to a submodule, return the \c ModuleDecl for that
+  /// submodule; otherwise just return the parent module.
   ModuleDecl *getParentSubModuleOrModule(GenericTypeDecl *TyDecl) {
     // Only clang declarations can belong to a submodule
     if (auto clangNode = TyDecl->getClangNode()) {
       auto importer = TyDecl->getASTContext().getClangModuleLoader();
       if (auto clangMod = importer->getClangOwningModule(clangNode)) {
-        // Explicit submodules are only visible if specifically imported;
-        // everything else has the visibility of its top-level module.
-        if (clangMod->isSubModule() && clangMod->IsExplicit) {
-          return importer->getWrapperForModule(clangMod);
-        }
+        return importer->getWrapperForModule(clangMod);
       }
     }
 

--- a/test/ModuleInterface/export-as-in-swiftinterfaces-submodules.swift
+++ b/test/ModuleInterface/export-as-in-swiftinterfaces-submodules.swift
@@ -35,11 +35,6 @@ module LibraryCore {
   header "LibraryCore/LibraryCore.h"
   export *
 
-  module NonExplicitSubmodule {
-    header "LibraryCore/NonExplicitSubmodule.h"
-    export *
-  }
-
   explicit module * { export * }
 }
 
@@ -54,18 +49,12 @@ module Library {
 //--- LibraryCore/LibraryCore.h
 // This file is re-exported by Library
 #pragma once
-#include "LibraryCore/NonExplicitSubmodule.h"
 struct LibraryCoreType {};
 
 //--- LibraryCore/Submodule.h
 // This file is re-exported by Library.Submodule (which Swift does not respect)
 #pragma once
 struct LibraryCoreSubmoduleType {};
-
-//--- LibraryCore/NonExplicitSubmodule.h
-// This file is re-exported by Library
-#pragma once
-struct LibraryCoreNonExplicitSubmoduleType {};
 
 //--- LibraryCore/ReexportedSubmodule.h
 // This file is re-exported by Library
@@ -100,9 +89,6 @@ public func foo(
   // PUBLIC-SAME: c: Library::LibraryCoreReexportedSubmoduleType
   // PRIVATE-SAME: c: LibraryCore::LibraryCoreReexportedSubmoduleType
   c: LibraryCoreReexportedSubmoduleType,
-  // PUBLIC-SAME: c2: Library::LibraryCoreNonExplicitSubmoduleType
-  // PRIVATE-SAME: c2: Library::LibraryCoreNonExplicitSubmoduleType
-  c2: LibraryCoreNonExplicitSubmoduleType,
   // PUBLIC-SAME: d: Library::LibraryType
   // PRIVATE-SAME: d: Library::LibraryType
   d: LibraryType,
@@ -128,8 +114,5 @@ public func foo(
   b: LibraryCoreSubmoduleType,
   // PUBLIC-SAME: c: Library::LibraryCoreReexportedSubmoduleType
   // PRIVATE-SAME: c: LibraryCore::LibraryCoreReexportedSubmoduleType
-  c: LibraryCoreReexportedSubmoduleType,
-  // PUBLIC-SAME: c2: Library::LibraryCoreNonExplicitSubmoduleType
-  // PRIVATE-SAME: c2: LibraryCore::LibraryCoreNonExplicitSubmoduleType
-  c2: LibraryCoreNonExplicitSubmoduleType
+  c: LibraryCoreReexportedSubmoduleType
 ) {}


### PR DESCRIPTION
Reverts swiftlang/swift#90515

This change has been found to cause regressions; I'm deferring the fix out of Swift 6.4.