### PR TITLE
Fix a few CI tests on Android

### DIFF
--- a/test/SILGen/builtin_borrowat_unimplemented.swift
+++ b/test/SILGen/builtin_borrowat_unimplemented.swift
@@ -1,5 +1,4 @@
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -enable-experimental-feature BuiltinModule -enable-experimental-feature AddressableTypes -enable-experimental-feature Lifetimes -verify %s
+// FIXME: crashes under opaque values (unexpectedly doesn't produce the INTERNAL ERROR)
 
 // RUN: %target-swift-emit-silgen \
 // RUN: -enable-experimental-feature BuiltinModule \

--- a/test/SILGen/variadic-generic-closures.swift
+++ b/test/SILGen/variadic-generic-closures.swift
@@ -1,5 +1,4 @@
 // FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -target %target-swift-5.9-abi-triple %s
 
 // RUN: %target-swift-emit-silgen -target %target-swift-5.9-abi-triple %s | %FileCheck %s
 


### PR DESCRIPTION
Did not expect some opaque values tests to be passing on `android-aarch64`