### PR TITLE
[CMake] Handle stdlib-less builds

### DIFF
--- a/stdlib/public/Cxx/CMakeLists.txt
+++ b/stdlib/public/Cxx/CMakeLists.txt
@@ -52,7 +52,9 @@ add_swift_target_library(swiftCxx STATIC NO_LINK_NAME IS_STDLIB IS_SWIFT_ONLY
     INSTALL_BINARY_SWIFTMODULE NON_DARWIN_ONLY
     INSTALL_WITH_SHARED)
 
-if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
+# stdlib-less builds skip the upper CMakeLists.txt, so the `embedded-libraries`
+# target never gets defined.
+if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND TARGET embedded-libraries)
   add_custom_target(embedded-cxx)
   add_dependencies(embedded-libraries embedded-cxx)
 

--- a/stdlib/public/Cxx/cxxshim/CMakeLists.txt
+++ b/stdlib/public/Cxx/cxxshim/CMakeLists.txt
@@ -87,7 +87,9 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
                              DESTINATION "lib/swift/embedded"
                              COMPONENT compiler)
 
-  add_dependencies(embedded-libraries cxxshim-embedded)
+  if(TARGET embedded-libraries)
+    add_dependencies(embedded-libraries cxxshim-embedded)
+  endif()
 endif()
 
 add_custom_target(libcxxshim_modulemap DEPENDS ${libcxxshim_modulemap_target_list})


### PR DESCRIPTION
stdlib-less builds still build the Cxx overlay libraries. However, they don't build the embedded libraries at all, so the embedded-libraries target is missing. We don't need the embedded Cxx libraries here, so check for the target's presence.

Fixes rdar://183369153.
