### PR TITLE
[Embedded] Enable serialized debug info for the embedded standard library

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/InitializeStaticGlobals.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/InitializeStaticGlobals.swift
@@ -471,7 +471,7 @@ private struct InitValueBuilder: AddressDefUseWalker {
         return .abortWalk
       }
 
-    case is LoadInst, is DeallocStackInst:
+    case is LoadInst, is DeallocStackInst, is DebugValueInst:
       return .continueWalk
     case let bi as BuiltinInst:
       switch bi.id {

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ObjectOutliner.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ObjectOutliner.swift
@@ -326,6 +326,14 @@ private func isValidUseOfObject(_ use: Operand) -> Bool {
     }
     return true
 
+  case let store as StoreInst:
+    // Tolerate a redundant store of the (not yet fully initialized) object into
+    // the global variable this function is initializing.
+    return use == store.sourceOperand &&
+           (store.destination as? GlobalAddrInst).map {
+             $0.global.isLet && $0.parentFunction.initializedGlobal == $0.global
+           } ?? false
+
   case is StructElementAddrInst,
        is AddressToPointerInst,
        is StructInst,

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ObjectOutliner.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ObjectOutliner.swift
@@ -102,7 +102,7 @@ private func optimizeObjectAllocation(allocRef: AllocRefInstBase, _ context: Fun
     return nil
   }
 
-  guard let (storesToClassFields, storesToTailElements) = getInitialization(of: allocRef,
+  guard let (storesToClassFields, storesToTailElements, redundantStores) = getInitialization(of: allocRef,
                                                                             ignore: endOfInitInst,
                                                                             context) else
   {
@@ -120,6 +120,10 @@ private func optimizeObjectAllocation(allocRef: AllocRefInstBase, _ context: Fun
   constructObject(of: allocRef, inInitializerOf: outlinedGlobal, storesToClassFields, storesToTailElements, context)
   context.erase(instructions: storesToClassFields)
   context.erase(instructions: storesToTailElements)
+  // These stores are dead: they are always superseded by a later store of the fully
+  // initialized object (see `isValidUseOfObject`). Remove them so that later passes,
+  // like InitializeStaticGlobals, don't see two stores into the same global.
+  context.erase(instructions: redundantStores)
 
   return replace(object: allocRef, with: outlinedGlobal, context)
 }
@@ -160,7 +164,7 @@ private func findEndOfInitialization(of object: Value, canStoreToGlobal: Bool) -
 
 private func getInitialization(of allocRef: AllocRefInstBase, ignore ignoreInst: Instruction,
                                _ context: FunctionPassContext)
-  -> (storesToClassFields: [StoreInst], storesToTailElements: [StoreInst])?
+  -> (storesToClassFields: [StoreInst], storesToTailElements: [StoreInst], redundantStores: [StoreInst])?
 {
   guard let numTailElements = allocRef.numTailElements else {
     return nil
@@ -176,8 +180,9 @@ private func getInitialization(of allocRef: AllocRefInstBase, ignore ignoreInst:
   //   store %1 to %4
   let tailCount = numTailElements != 0 ? numTailElements * allocRef.numStoresPerTailElement : 0
   var tailStores = Array<StoreInst?>(repeating: nil, count: tailCount)
+  var redundantStores = [StoreInst]()
 
-  if !findInitStores(of: allocRef, &fieldStores, &tailStores, ignore: ignoreInst, context) {
+  if !findInitStores(of: allocRef, &fieldStores, &tailStores, ignore: ignoreInst, &redundantStores, context) {
     return nil
   }
 
@@ -185,13 +190,14 @@ private func getInitialization(of allocRef: AllocRefInstBase, ignore ignoreInst:
   if fieldStores.contains(nil) || tailStores.contains(nil) {
     return nil
   }
-  return (fieldStores.map { $0! }, tailStores.map { $0! })
+  return (fieldStores.map { $0! }, tailStores.map { $0! }, redundantStores)
 }
 
 private func findInitStores(of object: Value,
                             _ fieldStores: inout [StoreInst?],
                             _ tailStores: inout [StoreInst?],
                             ignore ignoreInst: Instruction,
+                            _ redundantStores: inout [StoreInst],
                             _ context: FunctionPassContext) -> Bool
 {
   for use in object.uses {
@@ -202,22 +208,22 @@ private func findInitStores(of object: Value,
          is MoveValueInst,
          is EndInitLetRefInst,
          is BeginBorrowInst:
-      if !findInitStores(of: user as! SingleValueInstruction, &fieldStores, &tailStores, ignore: ignoreInst, context) {
+      if !findInitStores(of: user as! SingleValueInstruction, &fieldStores, &tailStores, ignore: ignoreInst, &redundantStores, context) {
         return false
       }
     case let rea as RefElementAddrInst:
-      if !findStores(inUsesOf: rea, index: rea.fieldIndex, stores: &fieldStores, context) {
+      if !findStores(inUsesOf: rea, index: rea.fieldIndex, stores: &fieldStores, &redundantStores, context) {
         return false
       }
     case let rta as RefTailAddrInst:
-      if !findStores(toTailAddress: rta, tailElementIndex: 0, stores: &tailStores, context) {
+      if !findStores(toTailAddress: rta, tailElementIndex: 0, stores: &tailStores, &redundantStores, context) {
         return false
       }
     case ignoreInst,
          is EndBorrowInst:
       break
     default:
-      if !isValidUseOfObject(use) {
+      if !isValidUseOfObject(use, &redundantStores) {
         return false
       }
     }
@@ -226,6 +232,7 @@ private func findInitStores(of object: Value,
 }
 
 private func findStores(toTailAddress tailAddr: Value, tailElementIndex: Int, stores: inout [StoreInst?],
+                        _ redundantStores: inout [StoreInst],
                         _ context: FunctionPassContext) -> Bool {
   for use in tailAddr.uses {
     switch use.instruction {
@@ -235,26 +242,26 @@ private func findStores(toTailAddress tailAddr: Value, tailElementIndex: Int, st
       {
         return false
       }
-      if !findStores(toTailAddress: indexAddr, tailElementIndex: tailElementIndex + tailIdx, stores: &stores, context) {
+      if !findStores(toTailAddress: indexAddr, tailElementIndex: tailElementIndex + tailIdx, stores: &stores, &redundantStores, context) {
         return false
       }
     case let tea as TupleElementAddrInst:
       // The tail elements are tuples. There is a separate store for each tuple element.
       let numTupleElements = tea.tuple.type.tupleElements.count
       let tupleIdx = tea.fieldIndex
-      if !findStores(inUsesOf: tea, index: tailElementIndex * numTupleElements + tupleIdx, stores: &stores, context) {
+      if !findStores(inUsesOf: tea, index: tailElementIndex * numTupleElements + tupleIdx, stores: &stores, &redundantStores, context) {
         return false
       }
     case let atp as AddressToPointerInst:
-      if !findStores(toTailAddress: atp, tailElementIndex: tailElementIndex, stores: &stores, context) {
+      if !findStores(toTailAddress: atp, tailElementIndex: tailElementIndex, stores: &stores, &redundantStores, context) {
         return false
       }
     case let mdi as MarkDependenceInst:
-      if !findStores(toTailAddress: mdi, tailElementIndex: tailElementIndex, stores: &stores, context) {
+      if !findStores(toTailAddress: mdi, tailElementIndex: tailElementIndex, stores: &stores, &redundantStores, context) {
         return false
       }
     case let pta as PointerToAddressInst:
-      if !findStores(toTailAddress: pta, tailElementIndex: tailElementIndex, stores: &stores, context) {
+      if !findStores(toTailAddress: pta, tailElementIndex: tailElementIndex, stores: &stores, &redundantStores, context) {
         return false
       }
     case let store as StoreInst:
@@ -267,7 +274,7 @@ private func findStores(toTailAddress tailAddr: Value, tailElementIndex: Int, st
         return false
       }
     default:
-      if !isValidUseOfObject(use) {
+      if !isValidUseOfObject(use, &redundantStores) {
         return false
       }
     }
@@ -276,6 +283,7 @@ private func findStores(toTailAddress tailAddr: Value, tailElementIndex: Int, st
 }
 
 private func findStores(inUsesOf address: Value, index: Int, stores: inout [StoreInst?],
+                        _ redundantStores: inout [StoreInst],
                         _ context: FunctionPassContext) -> Bool
 {
   for use in address.uses {
@@ -283,7 +291,7 @@ private func findStores(inUsesOf address: Value, index: Int, stores: inout [Stor
       if !handleStore(store, index: index, stores: &stores, context) {
         return false
       }
-    } else if !isValidUseOfObject(use) {
+    } else if !isValidUseOfObject(use, &redundantStores) {
       return false
     }
   }
@@ -302,7 +310,7 @@ private func handleStore(_ store: StoreInst, index: Int, stores: inout [StoreIns
   return false
 }
 
-private func isValidUseOfObject(_ use: Operand) -> Bool {
+private func isValidUseOfObject(_ use: Operand, _ redundantStores: inout [StoreInst]) -> Bool {
   let inst = use.instruction
   switch inst {
   case is DebugValueInst,
@@ -320,7 +328,7 @@ private func isValidUseOfObject(_ use: Operand) -> Bool {
       return true;
     }
     for mdiUse in mdi.uses {
-      if !isValidUseOfObject(mdiUse) {
+      if !isValidUseOfObject(mdiUse, &redundantStores) {
         return false
       }
     }
@@ -328,11 +336,17 @@ private func isValidUseOfObject(_ use: Operand) -> Bool {
 
   case let store as StoreInst:
     // Tolerate a redundant store of the (not yet fully initialized) object into
-    // the global variable this function is initializing.
-    return use == store.sourceOperand &&
-           (store.destination as? GlobalAddrInst).map {
-             $0.global.isLet && $0.parentFunction.initializedGlobal == $0.global
-           } ?? false
+    // the global variable this function is initializing. The store is dead (it's
+    // always superseded by a later store of the fully initialized object), so
+    // remember it to be erased once outlining is committed to.
+    guard use == store.sourceOperand,
+          let ga = store.destination as? GlobalAddrInst,
+          ga.global.isLet, ga.parentFunction.initializedGlobal == ga.global
+    else {
+      return false
+    }
+    redundantStores.append(store)
+    return true
 
   case is StructElementAddrInst,
        is AddressToPointerInst,
@@ -347,7 +361,7 @@ private func isValidUseOfObject(_ use: Operand) -> Bool {
        is RefTailAddrInst,
        is RefElementAddrInst:
     for instUse in (inst as! SingleValueInstruction).uses {
-      if !isValidUseOfObject(instUse) {
+      if !isValidUseOfObject(instUse, &redundantStores) {
         return false
       }
     }

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -2019,7 +2019,7 @@ public:
                       ValueOwnershipKind forwardingOwnershipKind) {
     return insert(new (getModule()) StructExtractInst(
         getSILDebugLocation(Loc), Operand, Field, ResultTy,
-        Operand->getOwnershipKind()));
+        forwardingOwnershipKind));
   }
 
   StructElementAddrInst *createStructElementAddr(SILLocation Loc,

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -298,9 +298,7 @@ SerializationOptions CompilerInvocation::computeSerializationOptions(
   // This is important to get diagnostics for errors which are located in imported modules.
   // Such errors can sometimes only be detected when building the client module, because
   // the error can be in a generic function which is specialized in the client module.
-  if (serializationOpts.EmbeddedSwiftModule &&
-      // Except for the stdlib core. We don't want to get error locations inside stdlib internals.
-      !getParseStdlib()) {
+  if (serializationOpts.EmbeddedSwiftModule) {
     serializationOpts.SerializeDebugInfoSIL = true;
   }
 

--- a/lib/SILOptimizer/UtilityPasses/Link.cpp
+++ b/lib/SILOptimizer/UtilityPasses/Link.cpp
@@ -170,8 +170,12 @@ linkEmbeddedRuntimeFunctionByName(#NAME, EFFECT, StringRef(#CC) == "C_CC");    \
                                       bool byAsmName) {
     SILModule &M = *getModule();
 
-    // Bail if function is already loaded.
-    if (auto *Fn = M.lookUpFunction(name, byAsmName)) return Fn;
+    // Bail if function is already loaded, unless it's a zombie. Zombies
+    // will need to be re-loaded.
+    if (auto *Fn = M.lookUpFunction(name, byAsmName)) {
+      if (!Fn->isZombie())
+        return Fn;
+    }
 
     SILFunction *Fn =
         M.getSILLoader()->lookupSILFunction(name, Linkage,byAsmName);

--- a/test/DebugInfo/salvage_nested_struct_extract_unreachable.sil
+++ b/test/DebugInfo/salvage_nested_struct_extract_unreachable.sil
@@ -1,0 +1,53 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -diagnose-unreachable -sil-print-debuginfo | %FileCheck %s
+
+// Regression test for a crash when DiagnoseUnreachable deletes a chain of two
+// ownership-forwarding struct_extract instructions together, where the outer
+// struct_extract has a debug_value use that must be salvaged. Salvaging
+// clones the outer struct_extract, which needs the forwarding ownership kind
+// of the inner struct_extract; if that ownership kind is recomputed live from
+// the inner extract's operand (rather than using the ownership kind that was
+// passed in when cloning), it can observe the inner extract's operand after
+// it has already been unlinked by the same deletion, causing a crash.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+class Klass {}
+
+struct Inner {
+  @_hasStorage var k: Klass { get set }
+}
+
+struct Wrapper {
+  @_hasStorage var inner: Inner { get set }
+}
+
+sil_scope 1 { loc "test.swift":1:1 parent @test_nested_struct_extract_salvage : $@convention(thin) (@guaranteed Wrapper) -> () }
+
+// The struct_extract chain and its debug_value are unreachable and get
+// deleted entirely along with bb2; the important thing is that this compiles
+// without crashing (see comment above).
+// CHECK-LABEL: sil [ossa] @test_nested_struct_extract_salvage
+// CHECK:       bb0({{%[0-9]+}} : @guaranteed $Wrapper):
+// CHECK-NEXT:    br bb1
+// CHECK:       bb1:
+// CHECK-NEXT:    tuple ()
+// CHECK-NEXT:    return
+// CHECK-LABEL: } // end sil function 'test_nested_struct_extract_salvage'
+sil [ossa] @test_nested_struct_extract_salvage : $@convention(thin) (@guaranteed Wrapper) -> () {
+bb0(%0 : @guaranteed $Wrapper):
+  %cond = integer_literal $Builtin.Int1, 1
+  cond_br %cond, bb1, bb2
+
+bb1:
+  %t = tuple ()
+  return %t : $()
+
+bb2:
+  %1 = struct_extract %0 : $Wrapper, #Wrapper.inner
+  %2 = struct_extract %1 : $Inner, #Inner.k
+  debug_value %2 : $Klass, let, name "k", loc "test.swift":1:1, scope 1
+  unreachable
+}

--- a/test/embedded/no-allocations.swift
+++ b/test/embedded/no-allocations.swift
@@ -1,10 +1,19 @@
 // RUN: %target-swift-emit-ir %s -wmo
 // RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded -wmo
-// RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded -no-allocations -wmo -verify -verify-ignore-unknown
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: echo "// expected-error@'%swift_src_root/stdlib/public/core/ArrayShared.swift':48{{cannot use allocating type '_ContiguousArrayStorage<Int>' in -no-allocations mode}}" >> %t/main.swift
+// RUN: echo "// expected-error@'%swift_src_root/stdlib/public/core/SwiftNativeNSArray.swift':501{{cannot use allocating type '__SwiftNativeNSArrayWithContiguousStorage' in -no-allocations mode}}" >> %t/main.swift
+// RUN: echo "// expected-error@'%swift_src_root/stdlib/public/core/ContiguousArrayBuffer.swift':361{{cannot use allocating type '_ContiguousArrayStorage<Int>' in -no-allocations mode}}" >> %t/main.swift
+// RUN: echo "// expected-error@'%swift_src_root/stdlib/public/core/UnsafePointer.swift':831{{cannot use allocating operation in -no-allocations mode}}" >> %t/main.swift
+// RUN: %target-swift-emit-ir %t/main.swift -enable-experimental-feature Embedded -no-allocations -wmo -verify -verify-ignore-unknown
 
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx || OS=linux-gnu || OS=wasip1
 // REQUIRES: swift_feature_Embedded
+
+//--- main.swift
 
 public class X {} // expected-error {{cannot use allocating type 'X' in -no-allocations mode}}
 public func use_a_class() -> X {
@@ -13,10 +22,10 @@ public func use_a_class() -> X {
 }
 
 public func use_an_array() -> Int {
-	let a = [1, 2, 3] // expected-error {{cannot use allocating type '_ContiguousArrayStorage<Int>' in -no-allocations mode}}
+	let a = [1, 2, 3] // expected-note {{generic specialization called here}}
 	return a.count
 }
 
 public func use_unsafepointer_allocate() -> UnsafeMutablePointer<UInt8> {
-	return UnsafeMutablePointer<UInt8>.allocate(capacity: 10) // expected-error {{cannot use allocating operation in -no-allocations mode}}
+	return UnsafeMutablePointer<UInt8>.allocate(capacity: 10) // expected-note {{generic specialization called here}}
 }

--- a/test/embedded/no-allocations.swift
+++ b/test/embedded/no-allocations.swift
@@ -10,7 +10,7 @@
 // RUN: %target-swift-emit-ir %t/main.swift -enable-experimental-feature Embedded -no-allocations -wmo -verify -verify-ignore-unknown
 
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu || OS=wasip1
+// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 //--- main.swift

--- a/test/embedded/runtime-function-not-zombie.swift
+++ b/test/embedded/runtime-function-not-zombie.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-emit-ir %s -module-name main -enable-experimental-feature Embedded -wmo -parse-as-library | %FileCheck %s
+
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu || OS=wasip1
+// REQUIRES: swift_feature_Embedded
+
+// swift_retain must be emitted with a body, not just declared.
+// CHECK: define {{.*}}@swift_retain(
+// CHECK-NOT: {{^}}declare {{.*}}@swift_retain(
+
+public class C {
+  var x: Int = 0
+}
+
+public func make() -> C { return C() }


### PR DESCRIPTION
Improve source-location information for code inlined from the standard
library by serializing debug information for SIL. This required one
fix in the handling of the Swift runtime functions defined in the
embedded runtime, because we they were getting treated as zombies and
then wouldn't be deserialized, even when the definitions were pulled
in later.

Fixes rdar://178239424.