### PR TITLE
[Swiftify][IRGen] relax unconditional assert and clean up bridging module checks

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -644,7 +644,7 @@ public:
       SmallVectorImpl<ModuleDecl *> &overlays);
 
   /// Returns true if this module is the Clang header import module.
-  bool isClangHeaderImportModule() const;
+  bool isClangBridgingHeaderImportModule() const;
 
   /// Convenience accessor for clients that know what kind of file they're
   /// dealing with.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -960,7 +960,7 @@ static ModuleDecl *getModuleContextForNameLookupForCxxDecl(const Decl *decl) {
 
   // We only need to look for the real parent module when the existing parent
   // is the imported header module.
-  if (!parentModule->isClangHeaderImportModule()) {
+  if (!parentModule->isClangBridgingHeaderImportModule()) {
     if (isClonedMember)
       return parentModule;
     return nullptr;

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -3001,7 +3001,7 @@ RestrictedImportKind SourceFile::getRestrictedImportKind(const ModuleDecl *modul
 
   // Workaround for the cases where the bridging header isn't properly
   // imported implicitly.
-  if (module->getName().str() == CLANG_HEADER_MODULE_NAME)
+  if (module->isClangBridgingHeaderImportModule())
     return RestrictedImportKind::None;
 
   // Look at the imports of this source file.

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2628,7 +2628,7 @@ Identifier ModuleDecl::getNameForModuleSelector() {
   return this->getName();
 }
 
-bool ModuleDecl::isClangHeaderImportModule() const {
+bool ModuleDecl::isClangBridgingHeaderImportModule() const {
   auto importer = getASTContext().getClangModuleLoader();
   if (!importer)
     return false;
@@ -3083,7 +3083,7 @@ SourceFile::getImportAccessLevel(const ModuleDecl *targetModule) const {
   if ((!restrictiveImport.has_value() ||
        restrictiveImport->accessLevel < AccessLevel::Public) &&
       !(restrictiveImport &&
-        restrictiveImport->module.importedModule->isClangHeaderImportModule()) &&
+        restrictiveImport->module.importedModule->isClangBridgingHeaderImportModule()) &&
       imports.isImportedBy(targetModule, getParentModule()))
     return std::nullopt;
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2405,15 +2405,15 @@ shouldDiagnoseConflict(NominalTypeDecl *ty, AbstractFunctionDecl *newDecl,
   auto newDeclModuleName = newDecl->getModuleContext()->getName();
   auto newDeclPrivateModuleName = newDecl->getASTContext().getIdentifier(
                      (llvm::Twine(newDeclModuleName.str()) + "_Private").str());
-  auto bridgingHeaderModuleName = newDecl->getASTContext().getIdentifier(
-                                                     CLANG_HEADER_MODULE_NAME);
   if (llvm::all_of(vec, [&](AbstractFunctionDecl *oldDecl) {
     if (!oldDecl->hasClangNode())
       return false;
-    auto oldDeclModuleName = oldDecl->getModuleContext()->getName();
+    auto oldDeclModule = oldDecl->getModuleContext();
+    if (oldDeclModule->isClangBridgingHeaderImportModule())
+      return true;
+    auto oldDeclModuleName = oldDeclModule->getName();
     return oldDeclModuleName == newDeclModuleName
-               || oldDeclModuleName == newDeclPrivateModuleName
-               || oldDeclModuleName == bridgingHeaderModuleName;
+               || oldDeclModuleName == newDeclPrivateModuleName;
   }))
     return false;
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3400,7 +3400,7 @@ static bool isDeclaredInModule(const ClangModuleUnit *ModuleFilter,
                                const Decl *VD) {
   // Sometimes imported decls get put into the clang header module. If we
   // found one of these decls, don't filter it out.
-  if (VD->getModuleContext()->getName().str() == CLANG_HEADER_MODULE_NAME) {
+  if (VD->getModuleContext()->isClangBridgingHeaderImportModule()) {
     return true;
   }
   // Because the ClangModuleUnit saved as a decl context will be saved as the top-level module, but

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -634,7 +634,7 @@ static size_t getNumParams(const clang::FunctionDecl* D) {
 }
 
 static bool shouldSkipModule(ModuleDecl *M) {
-  if (M->getName().str() == CLANG_HEADER_MODULE_NAME) {
+  if (M->isClangBridgingHeaderImportModule()) {
     DLOG("is from bridging header (or C++ namespace)\n");
     return false;
   }
@@ -675,7 +675,7 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
   }
 
   const clang::Module *OwningModule = getOwningModule(ClangDecl);
-  bool IsInBridgingHeader = MappedDecl->getModuleContext()->getName().str() == CLANG_HEADER_MODULE_NAME;
+  bool IsInBridgingHeader = MappedDecl->getModuleContext()->isClangBridgingHeaderImportModule();
   ASSERT(OwningModule || IsInBridgingHeader);
   ForwardDeclaredConcreteTypeVisitor CheckForwardDecls(OwningModule);
 

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -248,7 +248,7 @@ static void printImports(raw_ostream &out,
   for (auto import : allImports) {
     auto importedModule = import.importedModule;
     if (importedModule->isOnoneSupportModule() ||
-        importedModule->isClangHeaderImportModule()) {
+        importedModule->isClangBridgingHeaderImportModule()) {
       continue;
     }
 

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -2353,7 +2353,8 @@ IRGenModule *IRGenerator::getGenModule(SourceFile *SF) {
    // to a function imported from clang module, so it doesn't have a mapping
    // in GenModule. The contents are @_alwaysEmitIntoClient, so for all intents
    // and purposes they belong to the primary module.
-   ASSERT(SF->getParentModule()->findUnderlyingClangModule());
+   const ModuleDecl *M = SF->getParentModule();
+   ASSERT(M->findUnderlyingClangModule() || M->isClangHeaderImportModule());
    return getPrimaryIGM();
  }
 

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -2354,7 +2354,7 @@ IRGenModule *IRGenerator::getGenModule(SourceFile *SF) {
    // in GenModule. The contents are @_alwaysEmitIntoClient, so for all intents
    // and purposes they belong to the primary module.
    const ModuleDecl *M = SF->getParentModule();
-   ASSERT(M->findUnderlyingClangModule() || M->isClangHeaderImportModule());
+   ASSERT(M->findUnderlyingClangModule() || M->isClangBridgingHeaderImportModule());
    return getPrimaryIGM();
  }
 

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -476,7 +476,7 @@ public:
 
     if (outputLangMode == OutputLanguageMode::Cxx) {
       // Do not expose compiler private '_ObjC' module.
-      if (otherModule->getName().str() == CLANG_HEADER_MODULE_NAME)
+      if (otherModule->isClangBridgingHeaderImportModule())
         return true;
       // Add C++ module imports in C++ mode explicitly, to ensure that their
       // import is always emitted in the header.

--- a/lib/PrintAsClang/PrintAsClang.cpp
+++ b/lib/PrintAsClang/PrintAsClang.cpp
@@ -432,7 +432,7 @@ writeImports(raw_ostream &out, llvm::SmallPtrSetImpl<ImportModuleTy> &imports,
     if (bridgingHeader.empty())
       return import != &M && import->getName() == M.getName();
 
-    return import->isClangHeaderImportModule();
+    return import->isClangBridgingHeaderImportModule();
   };
 
   clang::FileSystemOptions fileSystemOptions;

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -161,7 +161,7 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
                            problematicImport->accessLevel,
                            problematicImport->module.importedModule,
                            problematicImport->module.importedModule
-                             ->isClangHeaderImportModule());
+                             ->isClangBridgingHeaderImportModule());
   }
 
   return (downgradeToWarning == DowngradeToWarning::No);
@@ -247,7 +247,7 @@ static bool diagnoseTypeAliasDeclRefExportability(SourceLoc loc,
                        limitImport->accessLevel,
                        limitImport->module.importedModule,
                        limitImport->module.importedModule
-                         ->isClangHeaderImportModule());
+                         ->isClangBridgingHeaderImportModule());
   }
 
   return true;
@@ -454,7 +454,7 @@ static bool diagnoseValueDeclRefExportability(SourceLoc loc, const ValueDecl *D,
                        import->accessLevel,
                        import->module.importedModule,
                        import->module.importedModule
-                         ->isClangHeaderImportModule());
+                         ->isClangBridgingHeaderImportModule());
   }
 
   return true;
@@ -546,7 +546,7 @@ TypeChecker::diagnoseConformanceExportability(SourceLoc loc,
                        limitImport->accessLevel,
                        limitImport->module.importedModule,
                        limitImport->module.importedModule
-                         ->isClangHeaderImportModule());
+                         ->isClangBridgingHeaderImportModule());
   }
 
   return true;

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -462,14 +462,14 @@ static void noteLimitingImport(const Decl *userDecl, ASTContext &ctx,
                          limitImport->accessLevel,
                          limitImport->module.importedModule,
                          limitImport->module.importedModule
-                           ->isClangHeaderImportModule());
+                           ->isClangBridgingHeaderImportModule());
 
     if (limitImport->importLoc.isValid())
       ctx.Diags.diagnose(limitImport->importLoc, diag::decl_import_via_here,
                          complainDecl, limitImport->accessLevel,
                          limitImport->module.importedModule,
                          limitImport->module.importedModule
-                           ->isClangHeaderImportModule());
+                           ->isClangBridgingHeaderImportModule());
   } else if (limitImport->importLoc.isValid()) {
     ctx.Diags.diagnose(limitImport->importLoc, diag::module_imported_here,
                        limitImport->module.importedModule,
@@ -2192,7 +2192,7 @@ swift::getDisallowedOriginKind(const Decl *decl,
   auto importSource = decl->getImportAccessFrom(where.getDeclContext());
   if (importSource.has_value() &&
       importSource->accessLevel < AccessLevel::Public) {
-    return importSource->module.importedModule->isClangHeaderImportModule()
+    return importSource->module.importedModule->isClangBridgingHeaderImportModule()
       ? DisallowedOriginKind::InternalBridgingHeaderImport
       : DisallowedOriginKind::NonPublicImport;
   }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1845,7 +1845,7 @@ static void diagnoseRetroactiveConformances(
   ModuleDecl *extTypeModule = extendedNominalDecl->getParentModule();
 
   // If the type comes from the __ObjC clang header module, don't warn.
-  if (extTypeModule->getName().is(CLANG_HEADER_MODULE_NAME))
+  if (extTypeModule->isClangBridgingHeaderImportModule())
     return;
 
   // At this point, we know we're extending a type declared outside this module.

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1093,7 +1093,7 @@ createMacroSourceFile(std::unique_ptr<llvm::MemoryBuffer> buffer,
     ModuleDecl *originModule = nullptr;
     // FIXME: remove this workaround once namespace contents are imported into
     // their corresponding modules
-    if (macroSourceFile->getParentModule()->isClangHeaderImportModule())
+    if (macroSourceFile->getParentModule()->isClangBridgingHeaderImportModule())
       originModule = cast<Decl *>(target)->getModuleContextForNameLookup();
     performImportResolutionForClangMacroBuffer(*macroSourceFile, originModule);
   }

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -1018,7 +1018,7 @@ bool swift::shouldDiagnoseMissingImportForMember(const ValueDecl *decl,
     // to the Clang header import module which should always be implicitly
     // visible. However, that module is not implicitly imported in source files
     // so we need to special case it here and avoid diagnosing.
-    if (definingModule->isClangHeaderImportModule())
+    if (definingModule->isClangBridgingHeaderImportModule())
       return false;
   }
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2494,10 +2494,10 @@ ModuleFile::resolveCrossReference(ModuleID MID, uint32_t pathLen) {
     if (getContext().LangOpts.EnableWorkaroundBrokenModules &&
         errorKind == ModularizationError::Kind::DeclMoved &&
         (baseModule->findUnderlyingClangModule() ||
-         baseModule->isClangHeaderImportModule()) &&
+         baseModule->isClangBridgingHeaderImportModule()) &&
         foundIn->findUnderlyingClangModule() &&
         !values.empty()) {
-      if (baseModule->isClangHeaderImportModule()) {
+      if (baseModule->isClangBridgingHeaderImportModule()) {
         // C++ namespaces are placed in the '__ObjC' header import module
         // but are found in their actual Clang module during deserialization.
         // This is expected, so recover silently.

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -763,7 +763,7 @@ IdentifierID Serializer::addContainingModuleRef(const DeclContext *DC,
     return CURRENT_MODULE_ID;
   if (M == this->M->getASTContext().TheBuiltinModule)
     return BUILTIN_MODULE_ID;
-  if (M->isClangHeaderImportModule())
+  if (M->isClangBridgingHeaderImportModule())
     return OBJC_HEADER_MODULE_ID;
 
   // Reject references to hidden dependencies.

--- a/test/Interop/C/swiftify-import/bridging-header-multiple-outputs.swift
+++ b/test/Interop/C/swiftify-import/bridging-header-multiple-outputs.swift
@@ -1,0 +1,36 @@
+// Regression test: this used to trigger a compiler crash in IRGenerator::getGenModule
+// since the SourceFile for the _SwiftifyImport macro expansion had no corresponding
+// IRGenModule. This would only trigger with multiple outputs and multiple threads
+// since there's only a single IRGenModule to return otherwise.
+// This is the bridging header, non-embedded, counterpart of
+// test/embedded/safe-interop-multiple-outputs.swift, which covers the same crash
+// when the annotated function is imported as a clang module instead.
+
+// The bridging header case is still broken: the macro expansion buffer's parent
+// module is the main module rather than a clang module, so the fallback in
+// IRGenerator::getGenModule asserts instead of returning the primary IGM.
+// XFAIL: *
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -c -plugin-path %swift-plugin-dir \
+// RUN:   -import-bridging-header %t/bridging.h \
+// RUN:   -parse-as-library -num-threads 2 \
+// RUN:   %t/A.swift %t/B.swift \
+// RUN:   -o %t/A.swift.o -o %t/B.swift.o
+
+//--- bridging.h
+#pragma once
+
+#define __counted_by(x) __attribute__((__counted_by__(x)))
+
+void foo(const int *__counted_by(len) p, int len);
+
+//--- A.swift
+public func bar(_ s: UnsafeBufferPointer<CInt>) {
+    foo(s)
+}
+
+//--- B.swift
+public struct Baz {}

--- a/test/Interop/C/swiftify-import/bridging-header-multiple-outputs.swift
+++ b/test/Interop/C/swiftify-import/bridging-header-multiple-outputs.swift
@@ -6,11 +6,6 @@
 // test/embedded/safe-interop-multiple-outputs.swift, which covers the same crash
 // when the annotated function is imported as a clang module instead.
 
-// The bridging header case is still broken: the macro expansion buffer's parent
-// module is the main module rather than a clang module, so the fallback in
-// IRGenerator::getGenModule asserts instead of returning the primary IGM.
-// XFAIL: *
-
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -1056,7 +1056,7 @@ static void collectModuleDependencies(ModuleDecl *TopMod,
     if (Mod->isSystemModule())
       continue;
     // FIXME: Setup dependencies on the included headers.
-    if (Mod->isClangHeaderImportModule())
+    if (Mod->isClangBridgingHeaderImportModule())
       continue;
     bool NewVisit = Visited.insert(Mod).second;
     if (!NewVisit)


### PR DESCRIPTION
This relaxes the assertion that a module have a corresponding clang
module: it could also be the `__ObjC` module for the bridging header.

Resolves https://github.com/swiftlang/swift/issues/90987

rdar://183277122

Also renames isClangHeaderImportModule to isClangBridgingHeaderImportModule, and replaces a bunch of existing module string name comparisons with it.