### PR TITLE
[cxx-interop] [NFC] Refactor C++ safety analysis

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -362,7 +362,7 @@ public:
   bool SkipUnderscoredSystemProtocols = false;
 
   /// Whether to skip unsafe C++ class methods that were renamed
-  /// (e.g. __fooUnsafe). See IsSafeUseOfCxxDecl.
+  /// (e.g. __fooUnsafe).
   bool SkipUnsafeCXXMethods = false;
 
   /// Whether to skip extensions that don't add protocols or no members.

--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -496,47 +496,6 @@ private:
   ValueDecl *evaluate(Evaluator &evaluator, CxxRecordSemanticsDescriptor) const;
 };
 
-struct SafeUseOfCxxDeclDescriptor final {
-  const clang::Decl *decl;
-  ASTContext& ctx;
-
-  SafeUseOfCxxDeclDescriptor(const clang::Decl *decl, ASTContext &ctx)
-      : decl(decl), ctx(ctx) {}
-
-  friend llvm::hash_code hash_value(const SafeUseOfCxxDeclDescriptor &desc) {
-    return llvm::hash_combine(desc.decl);
-  }
-
-  friend bool operator==(const SafeUseOfCxxDeclDescriptor &lhs,
-                         const SafeUseOfCxxDeclDescriptor &rhs) {
-    return lhs.decl == rhs.decl;
-  }
-
-  friend bool operator!=(const SafeUseOfCxxDeclDescriptor &lhs,
-                         const SafeUseOfCxxDeclDescriptor &rhs) {
-    return !(lhs == rhs);
-  }
-};
-
-void simple_display(llvm::raw_ostream &out, SafeUseOfCxxDeclDescriptor desc);
-SourceLoc extractNearestSourceLoc(SafeUseOfCxxDeclDescriptor desc);
-
-class IsSafeUseOfCxxDecl
-    : public SimpleRequest<IsSafeUseOfCxxDecl, bool(SafeUseOfCxxDeclDescriptor),
-                           RequestFlags::Uncached> {
-public:
-  using SimpleRequest::SimpleRequest;
-
-  // Source location
-  SourceLoc getNearestLoc() const { return SourceLoc(); };
-
-private:
-  friend SimpleRequest;
-
-  // Evaluation.
-  bool evaluate(Evaluator &evaluator, SafeUseOfCxxDeclDescriptor desc) const;
-};
-
 enum class CustomRefCountingOperationKind { retain, release };
 
 struct CustomRefCountingOperationDescriptor final {

--- a/include/swift/ClangImporter/ClangImporterTypeIDZone.def
+++ b/include/swift/ClangImporter/ClangImporterTypeIDZone.def
@@ -36,9 +36,6 @@ SWIFT_REQUEST(ClangImporter, CxxRecordSemantics,
 SWIFT_REQUEST(ClangImporter, CxxRecordAsSwiftType,
               ValueDecl *(CxxRecordSemanticsDescriptor), Cached,
               NoLocationInfo)
-SWIFT_REQUEST(ClangImporter, IsSafeUseOfCxxDecl,
-              bool(SafeUseOfCxxRecordDescriptor), Cached,
-              NoLocationInfo)
 SWIFT_REQUEST(ClangImporter, CustomRefCountingOperation,
               CustomRefCountingOperationResult(CustomRefCountingOperationDescriptor), Cached,
               NoLocationInfo)

--- a/lib/ClangImporter/ClangAnalysis.cpp
+++ b/lib/ClangImporter/ClangAnalysis.cpp
@@ -1,9 +1,11 @@
+#include "ClangDerivedConformances.h"
 #include "ImporterImpl.h"
 #include "swift/AST/DiagnosticsClangImporter.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Defer.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/ClangImporter/ClangImporterRequests.h"
+#include "clang/AST/Attr.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclObjC.h"
 #include "clang/AST/RecordLayout.h"
@@ -469,4 +471,161 @@ swift::importer::getOwnershipOfReturnedFRT(const clang::NamedDecl *decl) {
   }
 
   return std::nullopt;
+}
+
+//===----------------------------------------------------------------------===//
+// Unsafe projection ("__fooUnsafe") analysis
+//===----------------------------------------------------------------------===//
+
+/// Is \a type a pointer or reference to a foreign reference type?
+static bool clangTypeIsForeignReference(const clang::QualType type,
+                                        ASTContext &ctx) {
+  if (!type->isPointerOrReferenceType())
+    return false;
+  auto *pointee = type->getPointeeType().getCanonicalType()->getAsRecordDecl();
+  if (!pointee)
+    return false;
+  auto info = evaluateOrDefault(ctx.evaluator,
+                                ForeignReferenceTypeInfoRequest({pointee}), {});
+  return info.isReference();
+}
+
+static bool hasCustomCopyOrMoveConstructor(const clang::CXXRecordDecl *decl) {
+  return decl->hasUserDeclaredCopyConstructor() ||
+         decl->hasUserDeclaredMoveConstructor();
+}
+
+bool importer::isSwiftClassType(const clang::CXXRecordDecl *decl) {
+  // Swift type must be annotated with external_source_symbol attribute.
+  auto essAttr = decl->getAttr<clang::ExternalSourceSymbolAttr>();
+  if (!essAttr || essAttr->getLanguage() != "Swift" ||
+      essAttr->getDefinedIn().empty() || essAttr->getUSR().empty())
+    return false;
+
+  // Ensure that the baseclass is swift::RefCountedClass.
+  auto baseDecl = decl->getDefinition();
+  if (!baseDecl)
+    return false;
+  do {
+    if (baseDecl->getNumBases() != 1)
+      return false;
+    auto baseClassSpecifier = *baseDecl->bases_begin();
+    auto Ty = baseClassSpecifier.getType();
+    auto nextBaseDecl = Ty->getAsCXXRecordDecl();
+    if (!nextBaseDecl)
+      return false;
+    baseDecl = nextBaseDecl->getDefinition();
+    if (!baseDecl)
+      return false;
+  } while (baseDecl->getName() != "RefCountedClass");
+
+  return true;
+}
+
+static bool anySubobjectsSelfContained(const clang::CXXRecordDecl *decl) {
+  // std::pair and std::tuple might have copy and move constructors, or base
+  // classes with copy and move constructors, but they are not self-contained
+  // types, e.g. `std::pair<UnsafeType, T>`.
+  if (decl->isInStdNamespace() &&
+      (decl->getName() == "pair" || decl->getName() == "tuple"))
+    return false;
+
+  if (!decl->getDefinition())
+    return false;
+
+  if (hasCustomCopyOrMoveConstructor(decl) || importer::hasOwnedValueAttr(decl))
+    return true;
+
+  auto checkType = [](clang::QualType t) {
+    if (auto recordType = dyn_cast<clang::RecordType>(t.getCanonicalType())) {
+      if (auto cxxRecord =
+              dyn_cast<clang::CXXRecordDecl>(recordType->getDecl())) {
+        return anySubobjectsSelfContained(cxxRecord);
+      }
+    }
+
+    return false;
+  };
+
+  for (auto field : decl->fields()) {
+    if (checkType(field->getType()))
+      return true;
+  }
+
+  for (auto base : decl->bases()) {
+    if (checkType(base.getType()))
+      return true;
+  }
+
+  return false;
+}
+
+bool importer::shouldRenameCXXMethodAsUnsafe(const clang::CXXMethodDecl *method,
+                                             ASTContext &ctx) {
+  // The user explicitly explicitly acknowledged this method's unsafety
+  // and asked us to import it as is anyway. No renaming needed.
+  if (hasUnsafeAPIAttr(method))
+    return false;
+
+  // If it's a static method, it cannot project anything. It's fine.
+  if (method->isOverloadedOperator() || method->isStatic() ||
+      isa<clang::CXXConstructorDecl>(method))
+    return false;
+
+  // begin and end methods likely return an iterator, so they're unsafe.
+  // This is required so that automatic the conformance to RAC works properly.
+  if (method->getNameAsString() == "begin" ||
+      method->getNameAsString() == "end")
+    return true;
+
+  if (clangTypeIsForeignReference(method->getReturnType(), ctx))
+    return false;
+
+  auto parentQualType =
+      method->getParent()->getTypeForDecl()->getCanonicalTypeUnqualified();
+
+  bool parentIsSelfContained =
+      !clangTypeIsForeignReference(parentQualType, ctx) &&
+      anySubobjectsSelfContained(method->getParent());
+
+  // If it returns a pointer or reference from an owned parent, that's a
+  // projection (unsafe).
+  if (method->getReturnType()->isPointerType() ||
+      method->getReturnType()->isReferenceType())
+    return parentIsSelfContained;
+
+  // Check if it's one of the known unsafe methods we currently
+  // mark as safe by default.
+  if (isUnsafeStdMethod(method))
+    return true;
+
+  // Try to figure out the semantics of the return type. If it's a
+  // pointer/iterator, it's unsafe.
+  if (auto returnType = dyn_cast<clang::RecordType>(
+          method->getReturnType().getCanonicalType())) {
+    if (auto cxxRecordReturnType =
+            dyn_cast<clang::CXXRecordDecl>(returnType->getDecl())) {
+      if (isSwiftClassType(cxxRecordReturnType))
+        return false;
+
+      if (hasIteratorAPIAttr(cxxRecordReturnType) ||
+          hasIteratorCategory(cxxRecordReturnType))
+        return true;
+
+      // Mark this as safe to help our diganostics down the road.
+      if (!cxxRecordReturnType->getDefinition()) {
+        return false;
+      }
+
+      // A projection of a view type (such as a string_view) from a self
+      // contained parent is a proejction (unsafe).
+      if (!anySubobjectsSelfContained(cxxRecordReturnType) &&
+          isViewType(cxxRecordReturnType)) {
+        return parentIsSelfContained;
+      }
+    }
+  }
+
+  // Otherwise, it's safe.
+  return false;
 }

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8789,77 +8789,73 @@ static bool anySubobjectsSelfContained(const clang::CXXRecordDecl *decl) {
   return false;
 }
 
-bool IsSafeUseOfCxxDecl::evaluate(Evaluator &evaluator,
-                                  SafeUseOfCxxDeclDescriptor desc) const {
-  const clang::Decl *decl = desc.decl;
+bool importer::shouldRenameCXXMethodAsUnsafe(const clang::CXXMethodDecl *method,
+                                             ASTContext &ctx) {
+  // The user explicitly asked us to import this method.
+  if (hasUnsafeAPIAttr(method))
+    return false;
 
-  if (auto method = dyn_cast<clang::CXXMethodDecl>(decl)) {
-    // The user explicitly asked us to import this method.
-    if (hasUnsafeAPIAttr(method))
-      return true;
+  // If it's a static method, it cannot project anything. It's fine.
+  if (method->isOverloadedOperator() || method->isStatic() ||
+      isa<clang::CXXConstructorDecl>(method))
+    return false;
 
-    // If it's a static method, it cannot project anything. It's fine.
-    if (method->isOverloadedOperator() || method->isStatic() ||
-        isa<clang::CXXConstructorDecl>(decl))
-      return true;
+  // begin and end methods likely return an iterator, so they're unsafe.
+  // This is required so that automatic the conformance to RAC works properly.
+  if (method->getNameAsString() == "begin" ||
+      method->getNameAsString() == "end")
+    return true;
 
-    // begin and end methods likely return an iterator, so they're unsafe.
-    // This is required so that automatic the conformance to RAC works properly.
-    if (method->getNameAsString() == "begin" ||
-        method->getNameAsString() == "end")
-      return false;
+  if (clangTypeIsForeignReference(method->getReturnType(), ctx))
+    return false;
 
-    if (clangTypeIsForeignReference(method->getReturnType(), desc.ctx))
-      return true;
+  auto parentQualType =
+      method->getParent()->getTypeForDecl()->getCanonicalTypeUnqualified();
 
-    auto parentQualType = method
-      ->getParent()->getTypeForDecl()->getCanonicalTypeUnqualified();
+  bool parentIsSelfContained =
+      !clangTypeIsForeignReference(parentQualType, ctx) &&
+      anySubobjectsSelfContained(method->getParent());
 
-    bool parentIsSelfContained =
-        !clangTypeIsForeignReference(parentQualType, desc.ctx) &&
-        anySubobjectsSelfContained(method->getParent());
+  // If it returns a pointer or reference from an owned parent, that's a
+  // projection (unsafe).
+  if (method->getReturnType()->isPointerType() ||
+      method->getReturnType()->isReferenceType())
+    return parentIsSelfContained;
 
-    // If it returns a pointer or reference from an owned parent, that's a
-    // projection (unsafe).
-    if (method->getReturnType()->isPointerType() ||
-        method->getReturnType()->isReferenceType())
-      return !parentIsSelfContained;
+  // Check if it's one of the known unsafe methods we currently
+  // mark as safe by default.
+  if (isUnsafeStdMethod(method))
+    return true;
 
-    // Check if it's one of the known unsafe methods we currently
-    // mark as safe by default.
-    if (isUnsafeStdMethod(method))
-      return false;
+  // Try to figure out the semantics of the return type. If it's a
+  // pointer/iterator, it's unsafe.
+  if (auto returnType = dyn_cast<clang::RecordType>(
+          method->getReturnType().getCanonicalType())) {
+    if (auto cxxRecordReturnType =
+            dyn_cast<clang::CXXRecordDecl>(returnType->getDecl())) {
+      if (isSwiftClassType(cxxRecordReturnType))
+        return false;
 
-    // Try to figure out the semantics of the return type. If it's a
-    // pointer/iterator, it's unsafe.
-    if (auto returnType = dyn_cast<clang::RecordType>(
-            method->getReturnType().getCanonicalType())) {
-      if (auto cxxRecordReturnType =
-              dyn_cast<clang::CXXRecordDecl>(returnType->getDecl())) {
-        if (isSwiftClassType(cxxRecordReturnType))
-          return true;
+      if (hasIteratorAPIAttr(cxxRecordReturnType) ||
+          hasIteratorCategory(cxxRecordReturnType))
+        return true;
 
-        if (hasIteratorAPIAttr(cxxRecordReturnType) ||
-            hasIteratorCategory(cxxRecordReturnType))
-          return false;
+      // Mark this as safe to help our diganostics down the road.
+      if (!cxxRecordReturnType->getDefinition()) {
+        return false;
+      }
 
-        // Mark this as safe to help our diganostics down the road.
-        if (!cxxRecordReturnType->getDefinition()) {
-          return true;
-        }
-
-        // A projection of a view type (such as a string_view) from a self
-        // contained parent is a proejction (unsafe).
-        if (!anySubobjectsSelfContained(cxxRecordReturnType) &&
-            isViewType(cxxRecordReturnType)) {
-          return !parentIsSelfContained;
-        }
+      // A projection of a view type (such as a string_view) from a self
+      // contained parent is a proejction (unsafe).
+      if (!anySubobjectsSelfContained(cxxRecordReturnType) &&
+          isViewType(cxxRecordReturnType)) {
+        return parentIsSelfContained;
       }
     }
   }
 
   // Otherwise, it's safe.
-  return true;
+  return false;
 }
 
 void swift::simple_display(llvm::raw_ostream &out,
@@ -8869,20 +8865,6 @@ void swift::simple_display(llvm::raw_ostream &out,
 }
 
 SourceLoc swift::extractNearestSourceLoc(CxxRecordSemanticsDescriptor desc) {
-  return SourceLoc();
-}
-
-void swift::simple_display(llvm::raw_ostream &out,
-                           SafeUseOfCxxDeclDescriptor desc) {
-  out << "Checking if '";
-  if (auto namedDecl = dyn_cast<clang::NamedDecl>(desc.decl))
-    out << namedDecl->getNameAsString();
-  else
-    out << "<invalid decl>";
-  out << "' is safe to use in context.\n";
-}
-
-SourceLoc swift::extractNearestSourceLoc(SafeUseOfCxxDeclDescriptor desc) {
   return SourceLoc();
 }
 
@@ -9029,7 +9011,6 @@ CustomRefCountingOperationResult CustomRefCountingOperation::evaluate(
 ExplicitSafety ClangDeclExplicitSafety::evaluate(
     Evaluator &evaluator, ClangDeclExplicitSafetyDescriptor desc) const {
   // FIXME: Also similar to hasPointerInSubobjects
-  // FIXME: should probably also subsume IsSafeUseOfCxxDecl
 
   if (desc.isClass)
     // Safety for class types is handled a bit differently than other types.

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8333,19 +8333,6 @@ importer::getValueDeclsForName(NominalTypeDecl *decl, StringRef name) {
   return TinyPtrVector<ValueDecl *>(ArrayRef(results));
 }
 
-/// Is this a pointer or a reference to a foreign reference type.
-static bool clangTypeIsForeignReference(const clang::QualType type,
-                                        ASTContext &ctx) {
-  if (!type->isPointerOrReferenceType())
-    return false;
-  auto *pointee = type->getPointeeType().getCanonicalType()->getAsRecordDecl();
-  if (!pointee)
-    return false;
-  auto info = evaluateOrDefault(ctx.evaluator,
-                                ForeignReferenceTypeInfoRequest({pointee}), {});
-  return info.isReference();
-}
-
 bool importer::hasSwiftAttribute(const clang::Decl *decl,
                                  ArrayRef<StringRef> attrs) {
   if (decl->hasAttrs() && llvm::any_of(decl->getAttrs(), [&](auto *A) {
@@ -8501,11 +8488,6 @@ static bool hasDestroyTypeOperations(const clang::CXXRecordDecl *decl,
   return false;
 }
 
-static bool hasCustomCopyOrMoveConstructor(const clang::CXXRecordDecl *decl) {
-  return decl->hasUserDeclaredCopyConstructor() ||
-         decl->hasUserDeclaredMoveConstructor();
-}
-
 static bool
 hasConstructorWithUnsupportedDefaultArgs(const clang::CXXRecordDecl *decl) {
   return llvm::any_of(decl->ctors(), [](clang::CXXConstructorDecl *ctor) {
@@ -8513,33 +8495,6 @@ hasConstructorWithUnsupportedDefaultArgs(const clang::CXXRecordDecl *decl) {
            // FIXME: Support default arguments (https://github.com/swiftlang/swift/issues/86260)
            ctor->getNumParams() != 1;
   });
-}
-
-static bool isSwiftClassType(const clang::CXXRecordDecl *decl) {
-  // Swift type must be annotated with external_source_symbol attribute.
-  auto essAttr = decl->getAttr<clang::ExternalSourceSymbolAttr>();
-  if (!essAttr || essAttr->getLanguage() != "Swift" ||
-      essAttr->getDefinedIn().empty() || essAttr->getUSR().empty())
-    return false;
-
-  // Ensure that the baseclass is swift::RefCountedClass.
-  auto baseDecl = decl->getDefinition();
-  if (!baseDecl)
-    return false;
-  do {
-    if (baseDecl->getNumBases() != 1)
-      return false;
-    auto baseClassSpecifier = *baseDecl->bases_begin();
-    auto Ty = baseClassSpecifier.getType();
-    auto nextBaseDecl = Ty->getAsCXXRecordDecl();
-    if (!nextBaseDecl)
-      return false;
-    baseDecl = nextBaseDecl->getDefinition();
-    if (!baseDecl)
-      return false;
-  } while (baseDecl->getName() != "RefCountedClass");
-
-  return true;
 }
 
 CxxRecordSemanticsKind
@@ -8749,113 +8704,6 @@ void swift::simple_display(llvm::raw_ostream &out,
 
 SourceLoc swift::extractNearestSourceLoc(CxxValueSemanticsDescriptor) {
   return SourceLoc();
-}
-
-static bool anySubobjectsSelfContained(const clang::CXXRecordDecl *decl) {
-  // std::pair and std::tuple might have copy and move constructors, or base
-  // classes with copy and move constructors, but they are not self-contained
-  // types, e.g. `std::pair<UnsafeType, T>`.
-  if (decl->isInStdNamespace() &&
-      (decl->getName() == "pair" || decl->getName() == "tuple"))
-    return false;
-
-  if (!decl->getDefinition())
-    return false;
-
-  if (hasCustomCopyOrMoveConstructor(decl) || hasOwnedValueAttr(decl))
-    return true;
-
-  auto checkType = [](clang::QualType t) {
-    if (auto recordType = dyn_cast<clang::RecordType>(t.getCanonicalType())) {
-      if (auto cxxRecord =
-              dyn_cast<clang::CXXRecordDecl>(recordType->getDecl())) {
-        return anySubobjectsSelfContained(cxxRecord);
-      }
-    }
-
-    return false;
-  };
-
-  for (auto field : decl->fields()) {
-    if (checkType(field->getType()))
-      return true;
-  }
-
-  for (auto base : decl->bases()) {
-    if (checkType(base.getType()))
-      return true;
-  }
-
-  return false;
-}
-
-bool importer::shouldRenameCXXMethodAsUnsafe(const clang::CXXMethodDecl *method,
-                                             ASTContext &ctx) {
-  // The user explicitly asked us to import this method.
-  if (hasUnsafeAPIAttr(method))
-    return false;
-
-  // If it's a static method, it cannot project anything. It's fine.
-  if (method->isOverloadedOperator() || method->isStatic() ||
-      isa<clang::CXXConstructorDecl>(method))
-    return false;
-
-  // begin and end methods likely return an iterator, so they're unsafe.
-  // This is required so that automatic the conformance to RAC works properly.
-  if (method->getNameAsString() == "begin" ||
-      method->getNameAsString() == "end")
-    return true;
-
-  if (clangTypeIsForeignReference(method->getReturnType(), ctx))
-    return false;
-
-  auto parentQualType =
-      method->getParent()->getTypeForDecl()->getCanonicalTypeUnqualified();
-
-  bool parentIsSelfContained =
-      !clangTypeIsForeignReference(parentQualType, ctx) &&
-      anySubobjectsSelfContained(method->getParent());
-
-  // If it returns a pointer or reference from an owned parent, that's a
-  // projection (unsafe).
-  if (method->getReturnType()->isPointerType() ||
-      method->getReturnType()->isReferenceType())
-    return parentIsSelfContained;
-
-  // Check if it's one of the known unsafe methods we currently
-  // mark as safe by default.
-  if (isUnsafeStdMethod(method))
-    return true;
-
-  // Try to figure out the semantics of the return type. If it's a
-  // pointer/iterator, it's unsafe.
-  if (auto returnType = dyn_cast<clang::RecordType>(
-          method->getReturnType().getCanonicalType())) {
-    if (auto cxxRecordReturnType =
-            dyn_cast<clang::CXXRecordDecl>(returnType->getDecl())) {
-      if (isSwiftClassType(cxxRecordReturnType))
-        return false;
-
-      if (hasIteratorAPIAttr(cxxRecordReturnType) ||
-          hasIteratorCategory(cxxRecordReturnType))
-        return true;
-
-      // Mark this as safe to help our diganostics down the road.
-      if (!cxxRecordReturnType->getDefinition()) {
-        return false;
-      }
-
-      // A projection of a view type (such as a string_view) from a self
-      // contained parent is a proejction (unsafe).
-      if (!anySubobjectsSelfContained(cxxRecordReturnType) &&
-          isViewType(cxxRecordReturnType)) {
-        return parentIsSelfContained;
-      }
-    }
-  }
-
-  // Otherwise, it's safe.
-  return false;
 }
 
 void swift::simple_display(llvm::raw_ostream &out,

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4726,9 +4726,7 @@ namespace {
       auto importedName = Impl.importFullName(clangDecl, Impl.CurrentVersion);
       if (!importedName || importedName.hasCustomName())
         return;
-      if (evaluateOrDefault(Impl.SwiftContext.evaluator,
-                            IsSafeUseOfCxxDecl({clangDecl, Impl.SwiftContext}),
-                            {}))
+      if (!shouldRenameCXXMethodAsUnsafe(clangDecl, Impl.SwiftContext))
         return;
 
       DeclName currentName = swiftDecl->getName();
@@ -9480,10 +9478,11 @@ ClangImporter::Implementation::importSwiftAttrAttributes(Decl *MappedDecl) {
       importNontrivialAttribute(MappedDecl, swiftAttr->getAttribute());
     }
 
-    bool importUnsafeHeuristic =
-        isa<clang::CXXMethodDecl>(ClangDecl) &&
-        !evaluateOrDefault(SwiftContext.evaluator,
-                           IsSafeUseOfCxxDecl({ClangDecl, SwiftContext}), {});
+    bool importUnsafeHeuristic = false;
+    if (const auto *CXXMethod = dyn_cast<clang::CXXMethodDecl>(ClangDecl);
+        CXXMethod && shouldRenameCXXMethodAsUnsafe(CXXMethod, SwiftContext))
+      importUnsafeHeuristic = true;
+
     if (seenUnsafe || importUnsafeHeuristic) {
       auto attr = new (SwiftContext) UnsafeAttr(/*implicit=*/!seenUnsafe);
       MappedDecl->addAttribute(attr);

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -2306,6 +2306,13 @@ bool isViewType(const clang::CXXRecordDecl *decl);
 bool isDirectViewType(const clang::Type *type, Evaluator &eval);
 bool isDirectViewType(const clang::Decl *decl, ASTContext &swiftCtx);
 
+/// Whether the C++ method \p method can be safely used in Swift, i.e. it is not
+/// a projection that could yield a dangling pointer/reference/iterator. Methods
+/// that are not safe are imported under a \c __<name>Unsafe name and/or marked
+/// \c @unsafe. See also PrintOptions::SkipUnsafeCXXMethods.
+bool shouldRenameCXXMethodAsUnsafe(const clang::CXXMethodDecl *method,
+                                   ASTContext &ctx);
+
 inline const clang::Type *desugarIfElaborated(const clang::Type *type) {
   if (auto elaborated = dyn_cast<clang::ElaboratedType>(type))
     return elaborated->desugar().getTypePtr();

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -2306,6 +2306,11 @@ bool isViewType(const clang::CXXRecordDecl *decl);
 bool isDirectViewType(const clang::Type *type, Evaluator &eval);
 bool isDirectViewType(const clang::Decl *decl, ASTContext &swiftCtx);
 
+/// Whether \p decl is a C++ record that is really a Swift class type exposed
+/// back to C++ (annotated with a Swift \c external_source_symbol attribute and
+/// derived from \c swift::RefCountedClass).
+bool isSwiftClassType(const clang::CXXRecordDecl *decl);
+
 /// Whether the C++ method \p method can be safely used in Swift, i.e. it is not
 /// a projection that could yield a dangling pointer/reference/iterator. Methods
 /// that are not safe are imported under a \c __<name>Unsafe name and/or marked


### PR DESCRIPTION
The C++ safety analysis is written as a request buried in ClangImporter.cpp. It does not need to be cached now since it's only called during imports, which are themselves already cached.

Move it to ClangAnalysis.cpp and rewrite it as a function call.