### PR TITLE
Use withContiguousStorageIfAvailable in Sequence.elementsEqual

### DIFF
--- a/stdlib/public/core/SequenceAlgorithms.swift
+++ b/stdlib/public/core/SequenceAlgorithms.swift
@@ -291,6 +291,36 @@ extension Sequence where Element: Equatable {
 //===----------------------------------------------------------------------===//
 
 extension Sequence {
+  
+  @inlinable
+  func elementsEqualSelfNonContiguous<OtherSequence: Sequence>(
+    _ other: OtherSequence,
+    by areEquivalent: (Element, OtherSequence.Element) throws -> Bool
+  ) rethrows -> Bool {
+    let contigResult = try other.withContiguousStorageIfAvailable { buffer in
+      return try unsafe buffer.elementsEqual(
+        self,
+        by: { try areEquivalent($1, $0) }
+      )
+    }
+    if let contigResult {
+      return contigResult
+    }
+    var iter1 = self.makeIterator()
+    var iter2 = other.makeIterator()
+    while true {
+      switch (iter1.next(), iter2.next()) {
+      case let (e1?, e2?):
+        if try !areEquivalent(e1, e2) {
+          return false
+        }
+      case (_?, nil), (nil, _?): return false
+      case (nil, nil):           return true
+      }
+    }
+    fatalError()
+  }
+  
   /// Returns a Boolean value indicating whether this sequence and another
   /// sequence contain equivalent elements in the same order, using the given
   /// predicate as the equivalence test.
@@ -320,19 +350,11 @@ extension Sequence {
     _ other: OtherSequence,
     by areEquivalent: (Element, OtherSequence.Element) throws -> Bool
   ) rethrows -> Bool {
-    var iter1 = self.makeIterator()
-    var iter2 = other.makeIterator()
-    while true {
-      switch (iter1.next(), iter2.next()) {
-      case let (e1?, e2?):
-        if try !areEquivalent(e1, e2) {
-          return false
-        }
-      case (_?, nil), (nil, _?): return false
-      case (nil, nil):           return true
-      }
+    let contigResult = try withContiguousStorageIfAvailable { buffer in
+      return try unsafe buffer.elementsEqual(other, by: areEquivalent)
     }
-    fatalError()
+    if let contigResult { return contigResult }
+    return try elementsEqualSelfNonContiguous(other, by: areEquivalent)
   }
 }
 

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -1709,6 +1709,48 @@ where Element: ~Copyable {
 }
 
 extension Unsafe${Mutable}BufferPointer: ConvertibleToBytes {}
+
+extension Unsafe${Mutable}BufferPointer {
+
+  @inlinable
+  func elementsEqualOtherNonContiguous<OtherSequence: Sequence>(
+    _ other: OtherSequence,
+    by areEquivalent: (Element, OtherSequence.Element) throws -> Bool
+  ) rethrows -> Bool {
+    var iter1 = unsafe self.makeIterator()
+    var iter2 = other.makeIterator()
+    while true {
+      switch (unsafe iter1.next(), iter2.next()) {
+      case let (e1?, e2?):
+        if try !areEquivalent(e1, e2) {
+          return false
+        }
+      case (_?, nil), (nil, _?): return false
+      case (nil, nil):           return true
+      }
+    }
+    fatalError()
+  }
+
+  @inlinable
+  func elementsEqual<OtherSequence: Sequence>(
+    _ other: OtherSequence,
+    by areEquivalent: (Element, OtherSequence.Element) throws -> Bool
+  ) rethrows -> Bool {
+    let contigResult = try other.withContiguousStorageIfAvailable { buffer in
+      guard count == buffer.count else { return false }
+      var i = 0
+      while i < count {
+        guard unsafe try areEquivalent(self[i], buffer[i]) else { return false }
+        i &+= 1
+      }
+      return true
+    }
+    if let contigResult { return contigResult }
+    return try unsafe elementsEqualOtherNonContiguous(other, by: areEquivalent)
+  }
+}
+
 %end
 
 // ${'Local Variables'}:


### PR DESCRIPTION
Locally measured at ~2x faster for UnsafeBufferPointer<UInt8>, ~4x faster for Array<UInt8>, and O(n) -> O(1) when the left and right side have different counts.