### PR TITLE
[CS] Fix missing null check in `MissingConformanceFailure`

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -683,7 +683,9 @@ bool MissingConformanceFailure::diagnoseAsError() {
   }
 
   if (isExpr<KeyPathExpr>(anchor)) {
-    if (auto *P = dyn_cast<ProtocolDecl>(protocolType->getAnyNominal())) {
+    // Note that we may not have a nominal here for a layout constraint.
+    auto *NTD = protocolType->getAnyNominal();
+    if (auto *P = dyn_cast_or_null<ProtocolDecl>(NTD)) {
       if (P->isSpecificProtocol(KnownProtocolKind::Copyable)) {
         emitDiagnostic(diag::expr_keypath_noncopyable_type, nonConformingType);
         return true;

--- a/validation-test/compiler_crashers_fixed/MissingConformanceFailure-diagnoseAsError-d16789.swift
+++ b/validation-test/compiler_crashers_fixed/MissingConformanceFailure-diagnoseAsError-d16789.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"swift::constraints::MissingConformanceFailure::diagnoseAsError()","signatureAssert":"Assertion failed: (detail::isPresent(Val) && \"dyn_cast on a non-existent value\"), function dyn_cast","signatureNext":"MissingConformance::diagnose"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 struct a: Identifiable {
 }
 \a.id

--- a/validation-test/compiler_crashers_fixed/MissingConformanceFailure-diagnoseAsError-ff5d77.swift
+++ b/validation-test/compiler_crashers_fixed/MissingConformanceFailure-diagnoseAsError-ff5d77.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"abf6d355","signature":"swift::constraints::MissingConformanceFailure::diagnoseAsError()","signatureAssert":"Assertion failed: (detail::isPresent(Val) && \"dyn_cast on a non-existent value\"), function dyn_cast","signatureNext":"MissingConformance::diagnose"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 struct a<b: AnyObject> {
 }
 \a<a>.c


### PR DESCRIPTION
For a layout constraint the RHS type may not have a nominal

rdar://183408250