### PR TITLE
[SourceKit] Fix macro inlay hint crash

### DIFF
--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1593,8 +1593,18 @@ public:
   
   bool shouldSkip(Decl *D) {
     if (!Walker.shouldWalkMacroArgumentsAndExpansion().second &&
-        Walker.isDeclInMacroExpansion(D) && !Walker.Parent.isNull())
-      return true;
+        !Walker.Parent.isNull()) {
+      if (Walker.isDeclInMacroExpansion(D))
+        return true;
+
+      // Legacy traversal presents accessors as peers of their storage.
+      // Preserve the storage's macro expansion boundary when deciding whether
+      // to walk them.
+      if (Walker.shouldWalkAccessorsTheOldWay())
+        if (auto *accessor = dyn_cast<AccessorDecl>(D))
+          if (Walker.isDeclInMacroExpansion(accessor->getStorage()))
+            return true;
+    }
 
     if (auto *VD = dyn_cast<VarDecl>(D)) {
       // VarDecls are walked via their NamedPattern, ignore them if we encounter

--- a/test/SourceKit/VariableType/macro_expansion.swift
+++ b/test/SourceKit/VariableType/macro_expansion.swift
@@ -1,0 +1,47 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroPlugin) -module-name=MacroPlugin %t/MacroPlugin.swift -g -no-toolchain-stdlib-rpath
+// RUN: %sourcekitd-test -req=collect-var-type %t/test.swift -- -swift-version 5 -load-plugin-library %t/%target-library-name(MacroPlugin) -module-name MacroUser %t/test.swift | %FileCheck %s
+
+// CHECK: (12:9, 12:14): Int (explicit type: 0)
+
+//--- MacroPlugin.swift
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct EmitClosureArrayMacro: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    [
+      """
+      static var generated: [Int] {
+        [accept { value in value }]
+      }
+      """
+    ]
+  }
+}
+
+//--- test.swift
+func accept(_ transform: (Int) -> Int) -> Int {
+  transform(0)
+}
+
+@attached(member, names: named(generated))
+macro EmitClosureArray() =
+  #externalMacro(module: "MacroPlugin", type: "EmitClosureArrayMacro")
+
+@EmitClosureArray
+struct Demo {
+  func triggerInlayHints() {
+    let local = 0
+    print(local)
+  }
+}


### PR DESCRIPTION
When SourceKit collects variable types for inlay hints, AST traversal can encounter declarations synthesized in a macro expansion buffer. Converting those locations relative to the primary source buffer triggers an assertion in `SourceManager::getLocOffsetInBuffer`.

For me this manifested itself as the VSCode extension's LSP continually crashing when navigating a file that exhibits this bug, making features dependent on it unusable for a large portion of files that I work with.

This PR fixes that by ignoring variable declarations outside the requested buffer, matching existing SourceKit handling for source annotations.

Resolves https://github.com/swiftlang/swift/issues/90976
