### PR TITLE
[SILGEN] fix  of an address-only lvalue under opaque values

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -7459,7 +7459,7 @@ RValue RValueEmitter::visitCopyExpr(CopyExpr *E, SGFContext C) {
         SGF.emitLValue(li->getSubExpr(), SGFAccessKind::BorrowedAddressRead);
     auto address = SGF.emitAddressOfLValue(subExpr, std::move(lv));
 
-    if (subType.isLoadable(SGF.F)) {
+    if (subType.isLoadableOrOpaque(SGF.F)) {
       // Trivial types don't undergo any lifetime analysis, so simply load
       // the value.
       if (subType.isTrivial(SGF.F)

--- a/test/SILGen/copy_expr.swift
+++ b/test/SILGen/copy_expr.swift
@@ -1,5 +1,4 @@
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -enable-experimental-feature NoImplicitCopy %s
+// RUN: %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -enable-experimental-feature NoImplicitCopy %s
 
 // RUN: %target-swift-emit-silgen -enable-experimental-feature NoImplicitCopy %s | %FileCheck %s
 


### PR DESCRIPTION
`RValueEmitter::visitCopyExpr`'s LoadExpr path chose between a loaded `explicit_copy_value` and an `explicit_copy_addr` into a temporary based on `isLoadable`. Under `-enable-sil-opaque-values` an address-only type is still represented as an object, so address-only operands took the address path and produced a `$*T` argument for a `$T` parameter, tripping the "TYPE MISMATCH IN ARGUMENT" assertion in `emitRawApply`.

Reproducer:
```
// repro.swift
final class Klass {
  var k: Klass? = nil
}

protocol P {
  static var value: Self { get }

  consuming func consumeFunc()
}

func testCallMethodOnAddressOnlyVarCopy<T : P>(_ t: T.Type) {
  var x = T.value
  (copy x).consumeFunc()
}
```
Command: `swift-frontend -emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -enable-experimental-feature NoImplicitCopy repro.swift`

Resolves rdar://180980693.