### PR TITLE
SILGen: pass key-path intrinsic base directly under opaque values

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -4617,10 +4617,13 @@ LValue SILGenLValue::visitKeyPathApplicationExpr(KeyPathApplicationExpr *e,
                     ? SGFAccessKind::BorrowedAddressRead
                     : SGFAccessKind::ReadWrite);
   } else {
+    // Under opaque values, the object form is chosen because the
+    // intrinsic's base parameter is non-indirect.
     // For all the other kinds, we want the emit the base as an address
     // r-value; we don't support key paths for storage with mutating read
     // operations.
-    subAccess = SGFAccessKind::BorrowedAddressRead;
+    subAccess = SGF.F.hasLoweredAddresses() ? SGFAccessKind::BorrowedAddressRead
+                                            : SGFAccessKind::BorrowedObjectRead;
   }
 
   // For now, just ignore any options we were given.

--- a/test/SILGen/keypath_application.swift
+++ b/test/SILGen/keypath_application.swift
@@ -1,5 +1,4 @@
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values %s
+// RUN: %target-swift-emit-sil -sil-verify-all -o /dev/null -enable-sil-opaque-values %s
 
 
 // RUN: %target-swift-emit-silgen -Xllvm -sil-print-types %s | %FileCheck %s
@@ -199,7 +198,7 @@ extension Int {
 func writebackNesting(x: inout Int,
                       y: WritableKeyPath<Int, Int>,
                       z: WritableKeyPath<Int, Int>,
-                      w: Int) -> Int {
+                      w: Int) {
   // -- get 'b'
   // CHECK: function_ref @$sSi19keypath_applicationE1bSivg
   // -- apply keypath y


### PR DESCRIPTION
`visitKeyPathApplicationExpr` always emitted the base of a read access as `BorrowedAddressRead`. That forces `LogicalPathComponent::projectForRead` to materialize a formal-access temporary, so the base reached `swift_getAtKeyPath` as an address.

Under `-enable-sil-opaque-values` the intrinsic's `@in_guaranteed` base is not indirect: `isIndirectSILParam` defers to
`isTypeIndirectForIndirectParamConvention`, which is false when `loweredAddresses` is. The apply therefore wants `$T`, and SILGen handed it `$*T`, tripping "TYPE MISMATCH IN ARGUMENT 0 OF APPLY" in `emitRawApply`.

Request `BorrowedObjectRead` instead when the function is not using lowered addresses, which routes `projectForRead` to its non-materializing path.

Reproducer:
```
// repro.swift

class A {}
class B {}

func reabstracted(writable: inout () -> (),
                  wkp: WritableKeyPath<() -> (), (A) -> B>){
  _ = writable[keyPath: wkp]
}
```

command: `swift-frontend -emit-silgen-ossa -o /dev/null -enable-sil-opaque-values repro.swift`

Resolves rdar://180980977.