### PR TITLE
[cxx-interop] Import functions with inferred lifetimes as unsafe

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4606,11 +4606,14 @@ namespace {
                 CxxEscapability::Unknown) == CxxEscapability::NonEscapable)
           lifetimeDependencies.push_back(immortalLifetime);
       }
-      bool resultIsNonEscapable =
-          isNonEscapableAnnotatedType(retType.getTypePtr());
+      clang::QualType resultTypeForEscapability = retType;
       if (auto *ctordecl = dyn_cast<clang::CXXConstructorDecl>(decl))
-        resultIsNonEscapable = isNonEscapableAnnotatedType(
-            ctordecl->getParent()->getTypeForDecl());
+        resultTypeForEscapability =
+            Impl.getClangASTContext().getRecordType(ctordecl->getParent());
+      bool resultIsNonEscapable =
+          isNonEscapableAnnotatedType(resultTypeForEscapability.getTypePtr());
+      bool resultDependenceIsAnnotated =
+          getLifetimeDependenceFor(lifetimeDependencies, returnIdx).has_value();
 
       if (!lifetimeDependencies.empty()) {
         Impl.SwiftContext.evaluator.cacheOutput(
@@ -4630,7 +4633,17 @@ namespace {
             decl->getLocation());
       }
 
-      if (hasSkippedLifetimeAnnotation) {
+      // A ~Escapable result with no dependency spelled in C++ still gets one
+      // synthesized by Swift's implicit inference. Import it as @unsafe unless
+      // it has a hand-written '@lifetime(...)' or an explicit 'safe' as an
+      // author's audit.
+      bool resultDependenceIsInferred =
+          !resultDependenceIsAnnotated &&
+          !isEscapable(resultTypeForEscapability) &&
+          !result->getAttrs().hasAttribute<LifetimeAttr>() &&
+          !hasSwiftAttribute(decl, {"safe"});
+
+      if (hasSkippedLifetimeAnnotation || resultDependenceIsInferred) {
         result->addAttribute(new (ASTContext) UnsafeAttr(/*implicit=*/true));
       } else {
         for (auto [idx, param] : llvm::enumerate(decl->parameters())) {

--- a/test/Interop/Cxx/class/safe-interop-mode.swift
+++ b/test/Interop/Cxx/class/safe-interop-mode.swift
@@ -1,7 +1,7 @@
 
 // RUN: rm -rf %t
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -typecheck -verify -Xcc -iapinotes-modules -Xcc %swift_src_root/stdlib/public/Cxx/std -Xcc -std=c++20 -I %t/Inputs  %t/test.swift -strict-memory-safety -enable-experimental-feature LifetimeDependence -cxx-interoperability-mode=default -diagnostic-style llvm -plugin-path %swift-plugin-dir 2>&1
+// RUN: %target-swift-frontend -typecheck -verify -Xcc -iapinotes-modules -Xcc %swift_src_root/stdlib/public/Cxx/std -Xcc -std=c++20 -I %t/Inputs  %t/test.swift -strict-memory-safety -enable-experimental-feature LifetimeDependence -cxx-interoperability-mode=default -diagnostic-style llvm -plugin-path %swift-plugin-dir -verify-additional-file %t/Inputs/nonescapable.h 2>&1
 
 // REQUIRES: objc_interop
 // REQUIRES: swift_feature_LifetimeDependence
@@ -63,6 +63,37 @@ using UnsafeTuple = std::tuple<int, int*, int>;
 View safeFunc(View v1 [[clang::noescape]], View v2 [[clang::lifetimebound]]);
 // Second non-escapable type is not annotated in any way.
 void unsafeFunc(View v1 [[clang::noescape]], View v2);
+
+// expected-warning@+1{{the returned type 'View' is annotated as non-escapable; its lifetime dependencies must be annotated}}
+View returnsViewNoAnnotation(const Owner &o);
+
+struct InferredNonEscapable {
+  View v;
+};
+InferredNonEscapable returnsInferredNonEscapable(const Owner &o);
+
+struct HasUnannotatedViewGetter {
+  // expected-warning@+2{{the returned type 'View' is annotated as non-escapable; its lifetime dependencies must be annotated}}
+  // expected-error@+1{{cannot infer lifetime dependence on a method because 'self' is BitwiseCopyable, specify '@_lifetime(borrow self)'}}
+  View getView() const;
+};
+
+// expected-warning@+2{{the returned type 'void' is annotated as non-escapable; its lifetime dependencies must be annotated}}
+struct SWIFT_NONESCAPABLE ViewWithUnannotatedCtor {
+    ViewWithUnannotatedCtor(const Owner &o);
+private:
+    const int *member;
+};
+
+View returnsViewLifetimebound(const Owner &o [[clang::lifetimebound]]);
+
+__attribute__((swift_attr("@lifetime(borrow o)")))
+// expected-warning@+1{{the returned type 'View' is annotated as non-escapable; its lifetime dependencies must be annotated}}
+View returnsViewHandWrittenLifetime(const Owner &o);
+
+__attribute__((swift_attr("safe")))
+// expected-warning@+1{{the returned type 'View' is annotated as non-escapable; its lifetime dependencies must be annotated}}
+View returnsViewAuditedSafe(const Owner &o);
 
 class SharedObject {
 public:
@@ -210,6 +241,27 @@ func useSafeLifetimeAnnotated(v: View) {
 func useUnsafeLifetimeAnnotated(v: View) {
     // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
     unsafeFunc(v, v) // expected-note{{reference to unsafe global function 'unsafeFunc'}}
+}
+
+func useInferredLifetimeDependency(o: Owner, g: HasUnannotatedViewGetter) {
+    // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+    let _ = returnsViewNoAnnotation(o) // expected-note{{reference to unsafe global function 'returnsViewNoAnnotation'}}
+    // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+    let _ = returnsInferredNonEscapable(o) // expected-note{{reference to unsafe global function 'returnsInferredNonEscapable'}}
+    // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+    let _ = g.getView() // expected-note{{reference to unsafe instance method 'getView()'}}
+    // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+    let _ = ViewWithUnannotatedCtor(o) // expected-note{{reference to unsafe initializer 'init(_:)'}}
+}
+
+func useDefaultConstructedView() {
+    let _ = View()
+}
+
+func useAnnotatedLifetimeDependency(o: Owner) {
+    let _ = returnsViewLifetimebound(o)
+    let _ = returnsViewHandWrittenLifetime(o)
+    let _ = returnsViewAuditedSafe(o)
 }
 
 @available(SwiftStdlib 5.8, *)


### PR DESCRIPTION
Functions returning ~Escapable types need lifetime annotations. When those were not specified in C++, Swift helpfully inferred them. Unfortunately, those lifetimes are not guaranteed to be correct since the body of the function was never checked by the Swift compiler (as it is implemented in C++). This PR makes sure that we consider functions with inferred lifetimes as unsafe.

rdar://183168058

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
