### PR TITLE
SIL: Remove DebugValueInst::hasAddrVal (NFC)

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -5861,19 +5861,6 @@ public:
       *getTrailingObjects<const SILDebugScope *>() = NewDS;
   }
 
-  /// Whether the SSA value associated with the current debug_value
-  /// instruction has an address type.
-  bool hasAddrVal() const {
-    return getOperand()->getType().isAddress();
-  }
-
-  /// An utility to check if \p I is DebugValueInst and
-  /// whether it's associated with address type SSA value.
-  static DebugValueInst *hasAddrVal(SILInstruction *I) {
-    auto *DVI = dyn_cast_or_null<DebugValueInst>(I);
-    return DVI && DVI->hasAddrVal()? DVI : nullptr;
-  }
-
   /// Whether this debug value has a DIExpr with a deref.
   /// For address-only types with a debug reconstruction block, the deref
   /// applies after the BB's result. Otherwise, this is incompatible with

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -4777,7 +4777,7 @@ protected:
     // Rewriting them would also break nullary debug reconstruction blocks.
     if (isa<SILUndef>(dbg->getOperand()))
       return;
-    if (!dbg->hasAddrVal() &&
+    if (!dbg->getOperand()->getType().isAddress() &&
         (assignment.isPotentiallyCArray(dbg->getOperand()->getType()) ||
          overlapsWithOnStackDebugLoc(dbg->getOperand()))) {
       assignment.markForDeletion(dbg);

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -2405,9 +2405,7 @@ swift::getSingleInitAllocStackUse(AllocStackInst *asi,
         destroyingUses->push_back(use);
       continue;
     case SILInstructionKind::DebugValueInst:
-      if (cast<DebugValueInst>(user)->hasAddrVal())
-        continue;
-      break;
+      continue;
     case SILInstructionKind::DeallocStackInst:
     case SILInstructionKind::LoadBorrowInst:
       continue;

--- a/lib/SIL/Utils/MemoryLocations.cpp
+++ b/lib/SIL/Utils/MemoryLocations.cpp
@@ -341,9 +341,7 @@ bool MemoryLocations::analyzeLocationUsesRecursively(SILValue V, unsigned locIdx
         break;
       }
       case SILInstructionKind::DebugValueInst:
-        if (cast<DebugValueInst>(user)->hasAddrVal())
-          break;
-        return false;
+        break;
       case SILInstructionKind::ApplyInst: {
         auto *apply = cast<ApplyInst>(user);
         if (apply->hasAddressResult()) {

--- a/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
+++ b/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
@@ -786,13 +786,6 @@ void MemoryLifetimeVerifier::checkBlock(SILBasicBlock *block, Bits &bits) {
         requireBitsSet(bits, I.getOperand(0), &I);
         break;
       case SILInstructionKind::DebugValueInst:
-        // We don't want to check `debug_value` instructions that
-        // are used to mark variable declarations (e.g. its SSA value is
-        // an alloc_stack), which don't have any `op_deref` in its
-        // di-expression, because that memory doesn't need to be initialized
-        // when `debug_value` is referencing it.
-        if (!DebugValueInst::hasAddrVal(&I))
-          requireBitsSet(bits, I.getOperand(0), &I);
         break;
       case SILInstructionKind::UncheckedTakeEnumDataAddrInst: {
         auto enumInst = cast<UncheckedTakeEnumDataAddrInst>(&I);

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -880,12 +880,7 @@ struct ImmutableAddressUseVerifier {
       case SILInstructionKind::IgnoredUseInst:
         break;
       case SILInstructionKind::DebugValueInst:
-        if (cast<DebugValueInst>(inst)->hasAddrVal())
-          break;
-        else {
-          llvm::errs() << "Unhandled, unexpected instruction: " << *inst;
-          llvm_unreachable("invoking standard assertion failure");
-        }
+        break;
       case SILInstructionKind::AddressToPointerInst:
         // We assume that the user is attempting to do something unsafe since we
         // are converting to a raw pointer. So just ignore this use.

--- a/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
@@ -131,9 +131,7 @@ void AccessSummaryAnalysis::processArgument(FunctionInfo *info,
                           operand, order);
       break;
     case SILInstructionKind::DebugValueInst:
-      if (DebugValueInst::hasAddrVal(user))
-        break;
-      LLVM_FALLTHROUGH;
+      break;
     default:
       // FIXME: These likely represent scenarios in which we're not generating
       // begin access markers. Ignore these for now. But we really should

--- a/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
+++ b/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
@@ -586,22 +586,21 @@ SILValue ClosureCloner::getProjectBoxMappedVal(SILValue operandValue) {
 /// if its operand is the promoted address argument then lower it to
 /// another debug_value, otherwise it is handled normally.
 void ClosureCloner::visitDebugValueInst(DebugValueInst *inst) {
-  if (inst->hasAddrVal())
-    if (SILValue value = getProjectBoxMappedVal(inst->getOperand())) {
-      getBuilder().setCurrentDebugScope(getOpScope(inst->getDebugScope()));
-      auto varInfo = *inst->getVarInfo();
-      if (varInfo.Scope)
-        varInfo.Scope = getOpScope(inst->getDebugScope());
-      // The operand is promoted from a project_box (address), to an object
-      // type: strip the leading op_deref.
-      ASSERT(!inst->getDebugReconstructionBlock() &&
-             "Unexpected debug reconstruction block in Diagnostic Pass");
-      ASSERT(varInfo.DIExpr.startsWithDeref() &&
-             "Address value debug_value must start with op_deref");
-      varInfo.DIExpr.eraseElement(varInfo.DIExpr.element_begin());
-      getBuilder().createDebugValue(inst->getLoc(), value, varInfo);
-      return;
-    }
+  if (SILValue value = getProjectBoxMappedVal(inst->getOperand())) {
+    getBuilder().setCurrentDebugScope(getOpScope(inst->getDebugScope()));
+    auto varInfo = *inst->getVarInfo();
+    if (varInfo.Scope)
+      varInfo.Scope = getOpScope(inst->getDebugScope());
+    // The operand is promoted from a project_box (address), to an object
+    // type: strip the leading op_deref.
+    ASSERT(!inst->getDebugReconstructionBlock() &&
+           "Unexpected debug reconstruction block in Diagnostic Pass");
+    ASSERT(varInfo.DIExpr.startsWithDeref() &&
+           "Address value debug_value must start with op_deref");
+    varInfo.DIExpr.eraseElement(varInfo.DIExpr.element_begin());
+    getBuilder().createDebugValue(inst->getLoc(), value, varInfo);
+    return;
+  }
   SILCloner<ClosureCloner>::visitDebugValueInst(inst);
 }
 
@@ -898,7 +897,7 @@ getPartialApplyArgMutationsAndEscapes(PartialApplyInst *pai,
       return false;
     }
 
-    if (DebugValueInst::hasAddrVal(addrUser) ||
+    if (isa<DebugValueInst>(addrUser) ||
         isa<MarkFunctionEscapeInst>(addrUser) || isa<EndAccessInst>(addrUser)) {
       return false;
     }

--- a/lib/SILOptimizer/Transforms/StringOptimization.cpp
+++ b/lib/SILOptimizer/Transforms/StringOptimization.cpp
@@ -449,9 +449,7 @@ isStringStoreToIdentifyableObject(SILInstruction *inst) {
       case SILInstructionKind::LoadBorrowInst:
         break;
       case SILInstructionKind::DebugValueInst:
-        if (DebugValueInst::hasAddrVal(user))
-          break;
-        LLVM_FALLTHROUGH;
+        break;
       default:
         if (!mayWriteToIdentifyableObject(user)) {
           // We don't handle user. It is some instruction which may write to

--- a/lib/SILOptimizer/Utils/ConstExpr.cpp
+++ b/lib/SILOptimizer/Utils/ConstExpr.cpp
@@ -1363,7 +1363,7 @@ ConstExprFunctionState::initializeAddressFromSingleWriter(SILValue addr) {
     // Ignore markers, loads, and other things that aren't stores to this stack
     // value.
     if (isa<LoadInst>(user) || isa<DeallocStackInst>(user) ||
-        isa<DestroyAddrInst>(user) || DebugValueInst::hasAddrVal(user))
+        isa<DestroyAddrInst>(user) || isa<DebugValueInst>(user))
       continue;
 
     // TODO: Allow BeginAccess/EndAccess users.

--- a/lib/SILOptimizer/Utils/Existential.cpp
+++ b/lib/SILOptimizer/Utils/Existential.cpp
@@ -89,7 +89,7 @@ static SILInstruction *getStackInitInst(SILValue allocStackAddr,
     // Ignore instructions which don't write to the stack location.
     // Also ignore ASIUser (only kicks in if ASIUser is the original apply).
     if (isa<DeallocStackInst>(User) ||
-        DebugValueInst::hasAddrVal(User) ||
+        isa<DebugValueInst>(User) ||
         isa<DestroyAddrInst>(User) || isa<WitnessMethodInst>(User) ||
         isa<DeinitExistentialAddrInst>(User) ||
         OpenExistentialAddrInst::isRead(User) || User == ASIUser) {

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -433,10 +433,6 @@ getConcreteValueOfExistentialBoxAddr(SILValue addr, SILInstruction *ignoreUser) 
     case SILInstructionKind::LoadInst:
       break;
     case SILInstructionKind::DebugValueInst:
-      if (!DebugValueInst::hasAddrVal(stackUser)) {
-        if (stackUser != ignoreUser)
-          return SILValue();
-      }
       break;
     case SILInstructionKind::StoreInst: {
       auto *store = cast<StoreInst>(stackUser);


### PR DESCRIPTION
The `DebugValueInst::hasAddrVal ` function is what remains of the distinction between debug_value and debug_value_addr, but it is unnecessary.

What this function did is check if the operand is an address type, but this function was only called in contexts where the operand was known to be an address type.