### PR TITLE
Fix mangling of nested objc protocol for older targets

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2904,6 +2904,12 @@ void ASTMangler::appendProtocolName(const ProtocolDecl *protocol,
     return;
   }
 
+  // As we're mangling a plain (non-symbolic) name for this protocol,
+  // the enclosing context mangled below must not use a symbolic
+  // reference either so that it will be resolvable at
+  // runtime. Temporarily disable symbolic references.
+  llvm::SaveAndRestore<bool> X(AllowSymbolicReferences, false);
+
   BaseEntitySignature base(protocol);
   appendContextOf(protocol, base);
   auto *clangDecl = protocol->getClangDecl();

--- a/test/Interpreter/objc_protocol_symbolic_reference_nested.swift
+++ b/test/Interpreter/objc_protocol_symbolic_reference_nested.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -target %target-cpu-apple-macosx14 %s -module-name main -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import Foundation
+
+struct S<T> {}
+
+struct Outer {
+  @objc protocol InnerP {}
+}
+
+let t = S<Outer.InnerP>.self
+print(t, ObjectIdentifier(t))
+
+// CHECK: S<InnerP> ObjectIdentifier(0x


### PR DESCRIPTION
Bug: when ASTMangler::appendProtocolName detects cases where objc protocol symbolic references aren't allowed for older targets that predate objc protocol symbolic references, it fails to disallow a symbolic reference for the enclosing context (the appendContextOf call) - producing a combination of an symbolic reference for the context and the old name mangling for the protocol, which isn't resolvable at run time and causes a crash.

Fix: temporarily disable symbolic referencing around the appendContextOf call to be consistently symbolic reference free in that code path.

rdar://166247488
