### PR TITLE
[test] Disable ConstraintSystem-repairFailures-731b5f.swift

### DIFF
--- a/validation-test/IDE/crashers/ConstraintSystem-repairFailures-731b5f.swift
+++ b/validation-test/IDE/crashers/ConstraintSystem-repairFailures-731b5f.swift
@@ -1,6 +1,7 @@
 // {"kind":"complete","original":"fc5babc7","signature":"swift::constraints::ConstraintSystem::repairFailures(swift::Type, swift::Type, swift::constraints::ConstraintKind, swift::optionset::OptionSet<swift::constraints::ConstraintSystem::TypeMatchFlags, unsigned int>, llvm::SmallVectorImpl<swift::constraints::RestrictionOrFix>&, swift::constraints::ConstraintLocatorBuilder)","signatureAssert":"Assertion failed: (!hasCallerSideDefaultExpr()), function getTypeOfDefaultExpr","signatureNext":"ConstraintSystem::matchTypes"}
 // RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 // REQUIRES: OS=macosx
+// REQUIRES: rdar183383395
 import Foundation
 NSError(
   (""


### PR DESCRIPTION
The recorded crasher no longer reproduces against the Xcode 27 / MacOSX27.0.sdk Foundation NSError.init overloads. Disabling the test until it can be converted to a SDK-independent test.