### PR TITLE
Implement Aliased*Span and Aliased*Ref

### DIFF
--- a/Runtimes/Core/Core/CMakeLists.txt
+++ b/Runtimes/Core/Core/CMakeLists.txt
@@ -25,6 +25,8 @@ gyb_expand(Tuple.swift.gyb Tuple.swift
 # crashes if they are.
 add_library(swiftCore
   Algorithm.swift
+  AliasedMutableRef.swift
+  AliasedRef.swift
   ArrayBody.swift
   ArrayBuffer.swift
   ArrayBufferProtocol.swift
@@ -172,6 +174,10 @@ add_library(swiftCore
   Span/Span.swift
   Span/RawSpan.swift
   Span/MutableSpan.swift
+  Span/AliasedMutableRawSpan.swift
+  Span/AliasedMutableSpan.swift
+  Span/AliasedRawSpan.swift
+  Span/AliasedSpan.swift
   Span/MutableRawSpan.swift
   Span/OutputSpan.swift
   Span/OutputRawSpan.swift

--- a/stdlib/public/core/AliasedMutableRef.swift
+++ b/stdlib/public/core/AliasedMutableRef.swift
@@ -1,0 +1,166 @@
+//===--- AliasedMutableRef.swift ------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A safe mutable reference allowing reads and writes of a single value that
+/// may be aliased.
+///
+/// `AliasedMutableRef` is to `MutableRef` what `AliasedMutableSpan` is to
+/// `MutableSpan`. It provides lifetime safety for a mutable reference to a
+/// single value, but does not depend on the Law of Exclusivity, so the
+/// referenced value may be read or written through some other reference while
+/// this one is alive.
+///
+/// Because it already accounts for the presence of aliases,
+/// `AliasedMutableRef` is `Copyable`, and its setter is non-mutating: storing
+/// a value changes the referenced memory, not the reference. Reads and writes
+/// copy the value, so `Value` must be `Copyable`.
+@frozen
+@safe
+@available(SwiftStdlib 6.5, *)
+public struct AliasedMutableRef<Value>: Copyable, ~Escapable, BitwiseCopyable {
+  @usableFromInline
+  internal let _pointer: UnsafeMutablePointer<Value>
+
+  /// Initializes an instance of `AliasedMutableRef` referring to the given
+  /// mutable value.
+  ///
+  /// Unlike `MutableRef`, creating an `AliasedMutableRef` does not establish
+  /// exclusive access to the referenced value: other references to the same
+  /// storage may read and write it while this reference is alive.
+  @available(SwiftStdlib 6.5, *)
+  @export(implementation)
+  @_lifetime(&value)
+  @_transparent
+  public init(_ value: inout Value) {
+    let ref = unsafe AliasedMutableRef(
+      _unchecked: UnsafeMutablePointer(Builtin.unprotectedAddressOf(&value))
+    )
+    self = unsafe _overrideLifetime(ref, mutating: &value)
+  }
+
+  /// Unsafely initializes an instance of `AliasedMutableRef` using the given
+  /// 'unsafeAddress' as the mutable reference, based on the mutating lifetime
+  /// of the given 'owner' argument.
+  ///
+  /// - Parameter pointer: The address to use to mutably reference an instance
+  ///                      of type `Value`.
+  /// - Parameter owner: The owning instance that this `AliasedMutableRef`
+  ///                    instance's lifetime is based on.
+  @available(SwiftStdlib 6.5, *)
+  @unsafe
+  @export(implementation)
+  @_lifetime(&owner)
+  @_transparent
+  public init<Owner: ~Copyable & ~Escapable>(
+    unsafeAddress pointer: UnsafeMutablePointer<Value>,
+    mutating owner: inout Owner
+  ) {
+    let ref = unsafe AliasedMutableRef(_unchecked: pointer)
+    self = unsafe _overrideLifetime(ref, mutating: &owner)
+  }
+
+  @unsafe
+  @export(implementation)
+  @inline(__always)
+  @_lifetime(borrow pointer)
+  internal init(_unchecked pointer: UnsafeMutablePointer<Value>) {
+    unsafe _pointer = pointer
+  }
+}
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableRef: @unchecked Sendable
+where Value: Sendable & FullyInhabited {}
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableRef {
+  /// The referenced value.
+  ///
+  /// Unlike `MutableRef.value`, this property copies the value into and out
+  /// of the referenced storage rather than providing direct access to it. The
+  /// copy ensures that the accessed value remains valid even if another
+  /// reference to the same storage replaces it concurrently.
+  ///
+  /// The setter is non-mutating because storing a value does not change the
+  /// reference itself, only the contents of the storage it references.
+  @available(SwiftStdlib 6.5, *)
+  @export(implementation)
+  @_transparent
+  public var value: Value {
+    get {
+      unsafe _pointer.pointee
+    }
+    nonmutating set {
+      unsafe _pointer.pointee = newValue
+    }
+  }
+}
+
+// MARK: - conversions
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableRef {
+  /// An aliased reference to the same value as this mutable reference.
+  ///
+  /// Retrieving a non-mutating aliased ref from an aliased mutable ref is a
+  /// safe operation, because both already assume that the underlying storage
+  /// may be aliased.
+  @available(SwiftStdlib 6.5, *)
+  @export(implementation)
+  @_transparent
+  public var aliased: AliasedRef<Value> {
+    @_lifetime(copy self)
+    get {
+      let result = unsafe AliasedRef(_unchecked: UnsafePointer(_pointer))
+      return unsafe _overrideLifetime(result, copying: self)
+    }
+  }
+
+  /// A mutable reference to the same value as this aliased mutable
+  /// reference.
+  ///
+  /// Retrieving a `MutableRef` from an `AliasedMutableRef` is an unsafe
+  /// operation, because one must ensure that the underlying storage is not
+  /// accessed at all (read or write) through any other reference while the
+  /// mutable ref is in use.
+  @unsafe
+  @available(SwiftStdlib 6.5, *)
+  @export(implementation)
+  @_transparent
+  public var mutableRef: MutableRef<Value> {
+    @_lifetime(copy self)
+    get {
+      var copyOfSelf = self
+      let result = unsafe MutableRef(
+        unsafeAddress: _pointer, mutating: &copyOfSelf
+      )
+      return unsafe _overrideLifetime(result, copying: self)
+    }
+  }
+}
+
+@available(SwiftStdlib 6.5, *)
+extension MutableRef {
+  /// Retrieve an aliased mutable ref from this mutable ref.
+  ///
+  /// This operation consumes the `MutableRef`, which ensures that the
+  /// original reference (which assumes exclusivity) cannot be used while the
+  /// returned `AliasedMutableRef`, or any copy of it, is still in use.
+  @available(SwiftStdlib 6.5, *)
+  @export(implementation)
+  @_lifetime(copy self)
+  @_transparent
+  public consuming func asAliased() -> AliasedMutableRef<Value> {
+    let result = unsafe AliasedMutableRef(_unchecked: pointer)
+    return unsafe _overrideLifetime(result, copying: self)
+  }
+}

--- a/stdlib/public/core/AliasedRef.swift
+++ b/stdlib/public/core/AliasedRef.swift
@@ -1,0 +1,145 @@
+//===--- AliasedRef.swift -------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A safe reference allowing reads of a single value that may be aliased.
+///
+/// `AliasedRef` is to `Ref` what `AliasedSpan` is to `Span`: it provides
+/// lifetime safety for a reference to a single value, but does not depend on
+/// the Law of Exclusivity, so the referenced value may be modified through
+/// some other reference while this one is alive.
+///
+/// Unlike `Ref`, whose representation is opaque, an `AliasedRef` always stores
+/// a pointer to the referenced value. Reading the value produces a copy, so
+/// `Value` must be `Copyable`.
+@frozen
+@safe
+@available(SwiftStdlib 6.5, *)
+public struct AliasedRef<Value>: Copyable, ~Escapable, BitwiseCopyable {
+  @usableFromInline
+  internal let _pointer: UnsafePointer<Value>
+
+  /// Initializes an instance of `AliasedRef` referring to the given borrowed
+  /// value.
+  ///
+  /// Unlike `Ref`, creating an `AliasedRef` does not establish that the
+  /// referenced value will not change: other references to the same storage
+  /// may write to it while this reference is alive.
+  @available(SwiftStdlib 6.5, *)
+  @export(implementation)
+  @_lifetime(borrow value)
+  @_transparent
+  public init(_ value: borrowing @_addressable Value) {
+    let ref = unsafe AliasedRef(
+      _unchecked: UnsafePointer(Builtin.unprotectedAddressOfBorrow(value))
+    )
+    self = unsafe _overrideLifetime(ref, borrowing: value)
+  }
+
+  /// Unsafely initializes an instance of `AliasedRef` using the given
+  /// 'unsafeAddress' as the reference, based on the borrowed lifetime of the
+  /// given 'owner' argument.
+  ///
+  /// - Parameter pointer: The address to use to reference an instance of
+  ///                      type `Value`.
+  /// - Parameter owner: The owning instance that this `AliasedRef` instance's
+  ///                    lifetime is based on.
+  @available(SwiftStdlib 6.5, *)
+  @unsafe
+  @export(implementation)
+  @_lifetime(borrow owner)
+  @_transparent
+  public init<Owner: ~Copyable & ~Escapable>(
+    unsafeAddress pointer: UnsafePointer<Value>,
+    borrowing owner: borrowing Owner
+  ) {
+    let ref = unsafe AliasedRef(_unchecked: pointer)
+    self = unsafe _overrideLifetime(ref, borrowing: owner)
+  }
+
+  @unsafe
+  @export(implementation)
+  @inline(__always)
+  @_lifetime(borrow pointer)
+  internal init(_unchecked pointer: UnsafePointer<Value>) {
+    unsafe _pointer = pointer
+  }
+}
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedRef: @unchecked Sendable
+where Value: Sendable & FullyInhabited {}
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedRef {
+  /// A copy of the referenced value.
+  ///
+  /// Unlike `Ref.value`, this property copies the value out of the referenced
+  /// storage rather than borrowing it in place. The copy ensures that the
+  /// returned value remains valid even if another reference to the same
+  /// storage replaces it while the result of this access is still in use.
+  @available(SwiftStdlib 6.5, *)
+  @export(implementation)
+  @_transparent
+  public var value: Value {
+    get {
+      unsafe _pointer.pointee
+    }
+  }
+}
+
+// MARK: - conversions to and from `Ref`
+
+@available(SwiftStdlib 6.5, *)
+extension Ref {
+  /// An aliased reference to a temporary copy of the referenced value.
+  ///
+  /// `Ref` does not necessarily store a pointer to its referent, whereas
+  /// `AliasedRef` does. This accessor therefore copies the value into
+  /// temporary storage and yields an `AliasedRef` referring to that copy,
+  /// which remains valid for the duration of the access.
+  //
+  // FIXME: Spelled `_read` rather than `yielding borrow` because the
+  // CoroutineAccessors experimental feature is not enabled for the standard
+  // library. The two are the same accessor; switch the spelling once the
+  // feature is on.
+  @available(SwiftStdlib 6.5, *)
+  @export(implementation)
+  public var aliased: AliasedRef<Value> {
+    @_lifetime(borrow self)
+    _read {
+      let copy = self.value
+      yield unsafe AliasedRef(
+        _unchecked: UnsafePointer(Builtin.addressOfBorrow(copy))
+      )
+    }
+  }
+}
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedRef {
+  /// A reference to the same value as this aliased reference.
+  ///
+  /// Retrieving a `Ref` from an `AliasedRef` is an unsafe operation, because
+  /// one must ensure that the underlying storage is not modified by any code
+  /// while the ref (or any copy derived from it) is in use.
+  @unsafe
+  @available(SwiftStdlib 6.5, *)
+  @export(implementation)
+  @_transparent
+  public var ref: Ref<Value> {
+    @_lifetime(copy self)
+    get {
+      let result = unsafe Ref(unsafeAddress: _pointer, borrowing: self)
+      return unsafe _overrideLifetime(result, copying: self)
+    }
+  }
+}

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -30,6 +30,8 @@ split_embedded_sources(
   ### -- PLEASE KEEP THIS LIST IN ALPHABETICAL ORDER ###
   EMBEDDED ASCII.swift
   EMBEDDED Algorithm.swift
+  EMBEDDED AliasedMutableRef.swift
+  EMBEDDED AliasedRef.swift
   EMBEDDED AnyHashable.swift
   EMBEDDED Array.swift
   EMBEDDED ArrayBody.swift
@@ -183,6 +185,10 @@ split_embedded_sources(
   EMBEDDED SliceBuffer.swift
   EMBEDDED SmallString.swift
   EMBEDDED Sort.swift
+  EMBEDDED Span/AliasedMutableRawSpan.swift
+  EMBEDDED Span/AliasedMutableSpan.swift
+  EMBEDDED Span/AliasedRawSpan.swift
+  EMBEDDED Span/AliasedSpan.swift
   EMBEDDED Span/MutableRawSpan.swift
   EMBEDDED Span/MutableSpan.swift
   EMBEDDED Span/OutputRawSpan.swift

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -205,6 +205,10 @@
     "UnsafeRawBufferPointer.swift"
   ],
   "Span": [
+    "AliasedMutableRawSpan.swift",
+    "AliasedMutableSpan.swift",
+    "AliasedRawSpan.swift",
+    "AliasedSpan.swift",
     "MutableRawSpan.swift",
     "MutableSpan.swift",
     "OutputRawSpan.swift",
@@ -284,6 +288,8 @@
     "Exclusivity.swift",
     "Ref.swift",
     "MutableRef.swift",
+    "AliasedRef.swift",
+    "AliasedMutableRef.swift",
     "UniqueBox.swift"
   ],
   "Result": [

--- a/stdlib/public/core/Span/AliasedMutableRawSpan.swift
+++ b/stdlib/public/core/Span/AliasedMutableRawSpan.swift
@@ -1,0 +1,1010 @@
+//===--- AliasedMutableRawSpan.swift --------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// `AliasedMutableRawSpan` represents a contiguous region of memory which
+/// contains initialized bytes that can be both read and written, and which may
+/// be aliased by other references to the same memory.
+///
+/// `AliasedMutableRawSpan` is to `MutableRawSpan` what `AliasedMutableSpan` is
+/// to `MutableSpan`. Because it already accounts for the presence of aliases,
+/// it is `Copyable`, and its mutating operations are non-mutating on `self`:
+/// storing bytes changes the referenced memory, not the span.
+@frozen
+@safe
+@available(SwiftStdlib 6.5, *)
+public struct AliasedMutableRawSpan: ~Escapable, Copyable, BitwiseCopyable {
+
+  @usableFromInline
+  internal let _pointer: UnsafeMutableRawPointer?
+
+  @usableFromInline
+  internal let _count: Int
+
+  @unsafe
+  @export(implementation)
+  @inline(__always)
+  internal func _start() -> UnsafeMutableRawPointer {
+    unsafe _pointer._unsafelyUnwrappedUnchecked
+  }
+
+  /// Create an empty span.
+  @export(implementation)
+  @inline(__always)
+  @_lifetime(immortal)
+  public init() {
+    unsafe _pointer = nil
+    _count = 0
+  }
+
+  @unsafe
+  @export(implementation)
+  @inline(__always)
+  @_lifetime(borrow pointer)
+  internal init(
+    _unchecked pointer: UnsafeMutableRawPointer?,
+    byteCount: Int
+  ) {
+    unsafe _pointer = pointer
+    _count = byteCount
+  }
+}
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableRawSpan: @unchecked Sendable {}
+
+// MARK: - unsafe construction
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableRawSpan {
+
+  /// Unsafely create an `AliasedMutableRawSpan` over initialized memory.
+  ///
+  /// The memory in `bytes` must remain valid and initialized throughout the
+  /// lifetime of the newly-created span. Unlike `MutableRawSpan`, the memory
+  /// is *not* required to be exclusively accessed.
+  ///
+  /// - Parameters:
+  ///   - bytes: an `UnsafeMutableRawBufferPointer` to initialized memory.
+  @unsafe
+  @export(implementation)
+  @_lifetime(borrow bytes)
+  public init(_unsafeBytes bytes: UnsafeMutableRawBufferPointer) {
+    let (baseAddress, count) = (bytes.baseAddress, bytes.count)
+    let span = unsafe AliasedMutableRawSpan(
+      _unchecked: baseAddress, byteCount: count
+    )
+    self = unsafe _overrideLifetime(span, borrowing: bytes)
+  }
+
+  /// Unsafely create an `AliasedMutableRawSpan` over initialized memory.
+  ///
+  /// - Parameters:
+  ///   - bytes: a `Slice<UnsafeMutableRawBufferPointer>` to initialized
+  ///     memory.
+  @unsafe
+  @export(implementation)
+  @_lifetime(borrow bytes)
+  public init(
+    _unsafeBytes bytes: borrowing Slice<UnsafeMutableRawBufferPointer>
+  ) {
+    let rebased = unsafe UnsafeMutableRawBufferPointer(rebasing: bytes)
+    let span = unsafe AliasedMutableRawSpan(_unsafeBytes: rebased)
+    self = unsafe _overrideLifetime(span, borrowing: bytes)
+  }
+
+  /// Unsafely create an `AliasedMutableRawSpan` over initialized memory.
+  ///
+  /// - Parameters:
+  ///   - pointer: a pointer to the first initialized byte.
+  ///   - byteCount: the number of initialized bytes in the span.
+  @unsafe
+  @export(implementation)
+  @_lifetime(borrow pointer)
+  public init(_unsafeStart pointer: UnsafeMutableRawPointer, byteCount: Int) {
+    _precondition(byteCount >= 0, "Count must not be negative")
+    unsafe self.init(_unchecked: pointer, byteCount: byteCount)
+  }
+
+  /// Unsafely create an `AliasedMutableRawSpan` over initialized memory.
+  ///
+  /// - Parameters:
+  ///   - elements: an `UnsafeMutableBufferPointer<Element>` to initialized
+  ///     memory.
+  @unsafe
+  @export(implementation)
+  @_lifetime(borrow elements)
+  public init<Element: BitwiseCopyable>(
+    _unsafeElements elements: UnsafeMutableBufferPointer<Element>
+  ) {
+    let bytes = UnsafeMutableRawBufferPointer(elements)
+    let span = unsafe AliasedMutableRawSpan(_unsafeBytes: bytes)
+    self = unsafe _overrideLifetime(span, borrowing: elements)
+  }
+
+  /// Unsafely create an `AliasedMutableRawSpan` over initialized memory.
+  ///
+  /// - Parameters:
+  ///   - elements: a `Slice<UnsafeMutableBufferPointer<Element>>` to
+  ///     initialized memory.
+  @unsafe
+  @export(implementation)
+  @_lifetime(borrow elements)
+  public init<Element: BitwiseCopyable>(
+    _unsafeElements elements:
+      borrowing Slice<UnsafeMutableBufferPointer<Element>>
+  ) {
+    let rebased = unsafe UnsafeMutableBufferPointer(rebasing: elements)
+    let span = unsafe AliasedMutableRawSpan(_unsafeElements: rebased)
+    self = unsafe _overrideLifetime(span, borrowing: elements)
+  }
+}
+
+// MARK: - conversion from typed aliased spans
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableRawSpan {
+
+  /// Unsafely convert a typed aliased mutable span to a raw aliased mutable
+  /// span.
+  ///
+  /// This is unsafe because `Element` may contain padding bytes, which are
+  /// not necessarily initialized, and because writing arbitrary bytes may
+  /// produce an invalid instance of `Element`.
+  ///
+  /// - Parameters:
+  ///   - elements: An existing `AliasedMutableSpan<Element>`, from which this
+  ///     span will inherit its lifetime.
+  @unsafe
+  @export(implementation)
+  @_lifetime(copy elements)
+  public init<Element>(unsafeElements elements: AliasedMutableSpan<Element>) {
+    let (start, count) = unsafe (elements._pointer, elements._count)
+    let span = unsafe AliasedMutableRawSpan(
+      _unchecked: start,
+      byteCount: (count == 1) ? MemoryLayout<Element>.size
+                 : (count &* MemoryLayout<Element>.stride)
+    )
+    self = unsafe _overrideLifetime(span, copying: elements)
+  }
+
+  /// Convert a typed aliased mutable span to a raw aliased mutable span.
+  ///
+  /// - Parameters:
+  ///   - elements: An existing `AliasedMutableSpan<Element>`, from which this
+  ///     span will inherit its lifetime.
+  @export(implementation)
+  @_lifetime(copy elements)
+  public init<Element: ConvertibleFromBytes & ConvertibleToBytes>(
+    elements: AliasedMutableSpan<Element>
+  ) {
+    self = unsafe Self.init(unsafeElements: elements)
+  }
+}
+
+// MARK: - basic properties
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableRawSpan {
+
+  /// The number of bytes in the span.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_semantics("fixed_storage.get_count")
+  public var byteCount: Int { _assumeNonNegative(_count) }
+
+  /// A Boolean value indicating whether the span is empty.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_transparent
+  public var isEmpty: Bool { byteCount == 0 }
+
+  /// The valid byte offsets for accessing this span, in ascending order.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  public var byteOffsets: Range<Int> {
+    unsafe Range(_uncheckedBounds: (0, byteCount))
+  }
+}
+
+// MARK: - byte access
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableRawSpan {
+  // SILOptimizer looks for fixed_storage.check_index semantics
+  // for bounds checking optimizations.
+  @_semantics("fixed_storage.check_index")
+  @export(implementation) @inline(__always)
+  internal func _checkIndex(_ position: Int) {
+    _precondition(byteOffsets.contains(position), "Index out of bounds")
+  }
+
+  /// Accesses the byte at the specified offset in the span.
+  ///
+  /// The setter is non-mutating because storing a byte does not change the
+  /// span itself, only the contents of the memory it references.
+  ///
+  /// - Parameter byteOffset: The offset of the byte to access. `byteOffset`
+  ///     must be greater than or equal to zero, and less than `byteCount`.
+  @export(implementation) @inline(__always)
+  public subscript(_ byteOffset: Int) -> UInt8 {
+    get {
+      _checkIndex(byteOffset)
+      return unsafe self[unchecked: byteOffset]
+    }
+    nonmutating set {
+      _checkIndex(byteOffset)
+      unsafe self[unchecked: byteOffset] = newValue
+    }
+  }
+
+  /// Accesses the byte at the specified offset in the span.
+  ///
+  /// This subscript does not validate `byteOffset`. Using this subscript
+  /// with an invalid `byteOffset` results in undefined behaviour.
+  ///
+  /// - Parameter byteOffset: The offset of the byte to access. `byteOffset`
+  ///     must be greater than or equal to zero, and less than `byteCount`.
+  @export(implementation) @inline(__always)
+  @unsafe
+  public subscript(unchecked byteOffset: Int) -> UInt8 {
+    get {
+      unsafe unsafeLoad(fromUncheckedByteOffset: byteOffset, as: UInt8.self)
+    }
+    nonmutating set {
+      unsafe storeBytes(
+        of: newValue, toUncheckedByteOffset: byteOffset, as: UInt8.self
+      )
+    }
+  }
+}
+
+// MARK: - UnsafeRawBufferPointer access hatch
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableRawSpan {
+
+  /// Calls the given closure with a pointer to the underlying bytes of
+  /// the viewed contiguous storage.
+  ///
+  /// The buffer pointer passed as an argument to `body` is valid only
+  /// during the execution of `withUnsafeBytes(_:)`.
+  /// Do not store or return the pointer for later use.
+  ///
+  /// - Note: Because the storage may be aliased, its contents may change
+  ///   while `body` is executing.
+  ///
+  /// - Parameter body: A closure with an `UnsafeRawBufferPointer`
+  ///   parameter that points to the viewed contiguous storage.
+  /// - Returns: The return value of the `body` closure parameter.
+  @export(implementation)
+  @_transparent
+  @safe
+  public func withUnsafeBytes<E: Error, Result: ~Copyable>(
+    _ body: (_ buffer: UnsafeRawBufferPointer) throws(E) -> Result
+  ) throws(E) -> Result {
+    try unsafe body(.init(start: _pointer, count: _count))
+  }
+
+  /// Calls the given closure with a mutable pointer to the underlying bytes
+  /// of the viewed contiguous storage.
+  ///
+  /// The buffer pointer passed as an argument to `body` is valid only
+  /// during the execution of `withUnsafeMutableBytes(_:)`.
+  /// Do not store or return the pointer for later use.
+  ///
+  /// - Note: Because the storage may be aliased, its contents may change
+  ///   while `body` is executing.
+  ///
+  /// - Parameter body: A closure with an `UnsafeMutableRawBufferPointer`
+  ///   parameter that points to the viewed contiguous storage.
+  /// - Returns: The return value of the `body` closure parameter.
+  @export(implementation)
+  @_transparent
+  @safe
+  public func withUnsafeMutableBytes<E: Error, Result: ~Copyable>(
+    _ body: (UnsafeMutableRawBufferPointer) throws(E) -> Result
+  ) throws(E) -> Result {
+    try unsafe body(.init(start: _pointer, count: _count))
+  }
+}
+
+// MARK: - load
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableRawSpan {
+
+  /// Returns a new instance of the given type, constructed from the raw
+  /// memory at the specified offset.
+  ///
+  /// This is an unsafe operation. Failure to meet the preconditions of
+  /// alignment and layout compatibility may produce an invalid value of `T`.
+  ///
+  /// - Parameters:
+  ///   - offset: The offset from the beginning of this span, in bytes.
+  ///     `offset` must be nonnegative. The default is zero.
+  ///   - type: The type of the instance to create.
+  /// - Returns: A new instance of type `T`, read from the raw bytes at
+  ///     `offset`.
+  @unsafe
+  @export(implementation)
+  public func unsafeLoad<T>(
+    fromByteOffset offset: Int = 0, as type: T.Type
+  ) -> T {
+    _precondition(
+      UInt(bitPattern: offset) <= UInt(bitPattern: _count) &&
+      MemoryLayout<T>.size <= (_count &- offset),
+      "Byte offset range out of bounds"
+    )
+    return unsafe unsafeLoad(fromUncheckedByteOffset: offset, as: T.self)
+  }
+
+  /// Returns a new instance of the given type, constructed from the raw
+  /// memory at the specified offset.
+  ///
+  /// This is an unsafe operation. This function does not validate the bounds
+  /// of the memory access.
+  ///
+  /// - Parameters:
+  ///   - offset: The offset from the beginning of this span, in bytes.
+  ///     `offset` must be nonnegative.
+  ///   - type: The type of the instance to create.
+  /// - Returns: A new instance of type `T`, read from the raw bytes at
+  ///     `offset`.
+  @unsafe
+  @export(implementation)
+  public func unsafeLoad<T>(
+    fromUncheckedByteOffset offset: Int, as type: T.Type
+  ) -> T {
+    unsafe _start().load(fromByteOffset: offset, as: T.self)
+  }
+
+  /// Returns a new instance of the given type, constructed from the raw
+  /// memory at the specified offset.
+  ///
+  /// This is an unsafe operation. Failure to meet the precondition of layout
+  /// compatibility may produce an invalid value of `T`.
+  ///
+  /// - Parameters:
+  ///   - offset: The offset from the beginning of this span, in bytes.
+  ///     `offset` must be nonnegative. The default is zero.
+  ///   - type: The type of the instance to create.
+  /// - Returns: A new instance of type `T`, read from the raw bytes at
+  ///     `offset`.
+  @unsafe
+  @export(implementation)
+  public func unsafeLoadUnaligned<T: BitwiseCopyable>(
+    fromByteOffset offset: Int = 0, as type: T.Type
+  ) -> T {
+    _precondition(
+      UInt(bitPattern: offset) <= UInt(bitPattern: _count) &&
+      MemoryLayout<T>.size <= (_count &- offset),
+      "Byte offset range out of bounds"
+    )
+    return unsafe unsafeLoadUnaligned(
+      fromUncheckedByteOffset: offset, as: T.self
+    )
+  }
+
+  /// Returns a new instance of the given type, constructed from the raw
+  /// memory at the specified offset.
+  ///
+  /// This is an unsafe operation. This function does not validate the bounds
+  /// of the memory access.
+  ///
+  /// - Parameters:
+  ///   - offset: The offset from the beginning of this span, in bytes.
+  ///     `offset` must be nonnegative.
+  ///   - type: The type of the instance to create.
+  /// - Returns: A new instance of type `T`, read from the raw bytes at
+  ///     `offset`.
+  @unsafe
+  @export(implementation)
+  public func unsafeLoadUnaligned<T: BitwiseCopyable>(
+    fromUncheckedByteOffset offset: Int, as type: T.Type
+  ) -> T {
+    unsafe _start().loadUnaligned(fromByteOffset: offset, as: T.self)
+  }
+
+  /// Returns a value constructed from the raw memory at the specified offset.
+  ///
+  /// The range of bytes required to construct a value of type `T` starting at
+  /// `offset` must be completely within the span.
+  /// `offset` is not required to be aligned for `T`.
+  ///
+  /// - Parameters:
+  ///   - offset: The offset from the beginning of this span, in bytes.
+  ///     `offset` must be nonnegative.
+  ///   - type: The type of the instance to create.
+  /// - Returns: A new value of type `T`, read from `offset`.
+  @export(implementation)
+  public func load<T: ConvertibleFromBytes>(
+    fromByteOffset offset: Int,
+    as type: T.Type
+  ) -> T {
+    unsafe unsafeLoadUnaligned(fromByteOffset: offset, as: T.self)
+  }
+
+  /// Returns a value constructed from the raw memory at the specified offset.
+  ///
+  /// - Parameters:
+  ///   - offset: The offset from the beginning of this span, in bytes.
+  ///     `offset` must be nonnegative.
+  ///   - type: The type of the instance to create.
+  ///   - byteOrder: The order in which the bytes will be decoded.
+  /// - Returns: A new value of type `T`, read from `offset`.
+  @export(implementation)
+  public func load<T: ConvertibleFromBytes & FixedWidthInteger>(
+    fromByteOffset offset: Int,
+    as type: T.Type,
+    _ byteOrder: ByteOrder
+  ) -> T {
+    let rawValue = load(fromByteOffset: offset, as: T.self)
+    return switch byteOrder {
+    case .bigEndian: rawValue.bigEndian
+    case .littleEndian: rawValue.littleEndian
+    }
+  }
+}
+
+// MARK: - store
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableRawSpan {
+
+  /// Stores the given value's bytes into the span's raw memory at the
+  /// specified byte offset.
+  ///
+  /// - Parameters:
+  ///   - value: The value to store as raw bytes.
+  ///   - offset: The offset from the start of the span, in bytes.
+  ///     `offset` must be nonnegative. The default is zero.
+  ///   - type: The type of `value`.
+  @unsafe
+  @export(implementation)
+  public func storeBytes<T: BitwiseCopyable>(
+    of value: T, toByteOffset offset: Int = 0, as type: T.Type
+  ) {
+    unsafe _storeBytes(of: value, toByteOffset: offset, as: T.self)
+  }
+
+  @unsafe
+  @export(implementation) @_transparent
+  internal func _storeBytes<T: BitwiseCopyable>(
+    of value: T, toByteOffset offset: Int, as type: T.Type
+  ) {
+    _precondition(
+      UInt(bitPattern: offset) <= UInt(bitPattern: _count) &&
+      MemoryLayout<T>.size <= (_count &- offset),
+      "Byte offset range out of bounds"
+    )
+    unsafe storeBytes(of: value, toUncheckedByteOffset: offset, as: T.self)
+  }
+
+  /// Stores the given value's bytes into the span's raw memory at the
+  /// specified byte offset.
+  ///
+  /// This function does not validate `offset`; this is an unsafe operation.
+  ///
+  /// - Parameters:
+  ///   - value: The value to store as raw bytes.
+  ///   - offset: The offset from the start of the span, in bytes.
+  ///     `offset` must be nonnegative.
+  ///   - type: The type of `value`.
+  @unsafe
+  @export(implementation)
+  public func storeBytes<T: BitwiseCopyable>(
+    of value: T, toUncheckedByteOffset offset: Int, as type: T.Type
+  ) {
+    unsafe _start().storeBytes(of: value, toByteOffset: offset, as: T.self)
+  }
+
+  /// Stores the given value's bytes to the specified offset into
+  /// the span's memory.
+  ///
+  /// The range of bytes required to store a value of type `T` starting at
+  /// byte offset `offset` must be completely within the span.
+  ///
+  /// - Parameters:
+  ///   - value: The value to store as raw bytes.
+  ///   - offset: The offset in bytes into the span's memory at which to begin
+  ///       writing the bytes from the value.
+  ///   - type: The type of the instance to store.
+  @export(implementation)
+  public func storeBytes<T: ConvertibleToBytes & BitwiseCopyable>(
+    of value: T, toByteOffset offset: Int, as type: T.Type
+  ) {
+    unsafe _storeBytes(of: value, toByteOffset: offset, as: T.self)
+  }
+
+  /// Stores the given value's bytes to the specified offset into
+  /// the span's memory.
+  ///
+  /// - Parameters:
+  ///   - value: The value to store as raw bytes.
+  ///   - offset: The offset in bytes into the span's memory at which to begin
+  ///       writing the bytes from the value.
+  ///   - type: The type of the instance to store.
+  ///   - byteOrder: The order in which the bytes will be encoded to the span.
+  @export(implementation)
+  public func storeBytes<
+    T: ConvertibleToBytes & BitwiseCopyable & FixedWidthInteger
+  >(
+    of value: T,
+    toByteOffset offset: Int,
+    as type: T.Type,
+    _ byteOrder: ByteOrder
+  ) {
+    switch byteOrder {
+    case .bigEndian:
+      storeBytes(of: value.bigEndian, toByteOffset: offset, as: T.self)
+    case .littleEndian:
+      storeBytes(of: value.littleEndian, toByteOffset: offset, as: T.self)
+    }
+  }
+
+  /// Stores the given value's bytes repeatedly into this span's memory.
+  ///
+  /// There must be at least `count * MemoryLayout<T>.stride` bytes
+  /// available in the span.
+  ///
+  /// - Parameters:
+  ///   - repeatedValue: The value to store as raw bytes.
+  ///   - count: The number of copies of `repeatedValue` to store
+  ///      into this span.
+  ///   - type: The type of the instance to store repeatedly.
+  @unsafe
+  @export(implementation)
+  public func storeBytes<T: BitwiseCopyable>(
+    repeating repeatedValue: T, count: Int, as type: T.Type
+  ) {
+    unsafe _storeBytes(repeating: repeatedValue, count: count, as: T.self)
+  }
+
+  @unsafe
+  @export(implementation) @_transparent
+  internal func _storeBytes<T: BitwiseCopyable>(
+    repeating repeatedValue: T, count: Int, as type: T.Type
+  ) {
+    _precondition(
+      count &* MemoryLayout<T>.stride <= _count,
+      "Span cannot contain every element"
+    )
+    unsafe _start().withMemoryRebound(to: T.self, capacity: count) {
+      unsafe $0.update(repeating: repeatedValue, count: count)
+    }
+  }
+
+  /// Stores the given value's bytes repeatedly into this span's memory.
+  ///
+  /// There must be at least `count * MemoryLayout<T>.stride` bytes
+  /// available in the span.
+  ///
+  /// - Parameters:
+  ///   - repeatedValue: The value to store as raw bytes.
+  ///   - count: The number of copies of `repeatedValue` to store
+  ///      into this span.
+  ///   - type: The type of the instance to store repeatedly.
+  @export(implementation)
+  public func storeBytes<T: ConvertibleToBytes & BitwiseCopyable>(
+    repeating repeatedValue: T, count: Int, as type: T.Type
+  ) {
+    unsafe _storeBytes(repeating: repeatedValue, count: count, as: T.self)
+  }
+
+  /// Stores the given value's bytes repeatedly into this span's memory.
+  ///
+  /// - Parameters:
+  ///   - repeatedValue: The value to store as raw bytes.
+  ///   - count: The number of copies of `repeatedValue` to store
+  ///      into this span.
+  ///   - type: The type of the instance to store repeatedly.
+  ///   - byteOrder: The order in which the bytes will be encoded to the span.
+  @export(implementation)
+  public func storeBytes<
+    T: ConvertibleToBytes & BitwiseCopyable & FixedWidthInteger
+  >(
+    repeating repeatedValue: T,
+    count: Int,
+    as type: T.Type,
+    _ byteOrder: ByteOrder
+  ) {
+    let value = switch byteOrder {
+    case .bigEndian: repeatedValue.bigEndian
+    case .littleEndian: repeatedValue.littleEndian
+    }
+    storeBytes(repeating: value, count: count, as: T.self)
+  }
+}
+
+// MARK: - sub-spans
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableRawSpan {
+
+  /// Constructs a new span over the bytes within the supplied range of
+  /// positions within this span.
+  ///
+  /// The returned span's first byte is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this span.
+  ///
+  /// - Returns: An `AliasedMutableRawSpan` over the bytes within `bounds`.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(_ bounds: Range<Int>) -> Self {
+    _precondition(
+      UInt(bitPattern: bounds.lowerBound) <= UInt(bitPattern: _count) &&
+      UInt(bitPattern: bounds.upperBound) <= UInt(bitPattern: _count),
+      "Byte offset range out of bounds"
+    )
+    return unsafe extracting(unchecked: bounds)
+  }
+
+  /// Constructs a new span over the bytes within the supplied range of
+  /// positions within this span.
+  ///
+  /// This function does not validate `bounds`; this is an unsafe operation.
+  ///
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this span.
+  ///
+  /// - Returns: An `AliasedMutableRawSpan` over the bytes within `bounds`.
+  ///
+  /// - Complexity: O(1)
+  @unsafe
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(unchecked bounds: Range<Int>) -> Self {
+    let newStart = unsafe _pointer?.advanced(by: bounds.lowerBound)
+    let newSpan = unsafe Self(_unchecked: newStart, byteCount: bounds.count)
+    return unsafe _overrideLifetime(newSpan, copying: self)
+  }
+
+  /// Constructs a new span over the bytes within the supplied range of
+  /// positions within this span.
+  ///
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this span.
+  ///
+  /// - Returns: An `AliasedMutableRawSpan` over the bytes within `bounds`.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(_ bounds: some RangeExpression<Int>) -> Self {
+    extracting(bounds.relative(to: byteOffsets))
+  }
+
+  /// Constructs a new span over the bytes within the supplied range of
+  /// positions within this span.
+  ///
+  /// This function does not validate `bounds`; this is an unsafe operation.
+  ///
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this span.
+  ///
+  /// - Returns: An `AliasedMutableRawSpan` over the bytes within `bounds`.
+  ///
+  /// - Complexity: O(1)
+  @unsafe
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(unchecked bounds: ClosedRange<Int>) -> Self {
+    let range = unsafe Range(
+      _uncheckedBounds: (bounds.lowerBound, bounds.upperBound + 1)
+    )
+    return unsafe extracting(unchecked: range)
+  }
+
+  /// Constructs a new span over all the bytes of this span.
+  ///
+  /// - Returns: An `AliasedMutableRawSpan` over all the bytes of this span.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(_: UnboundedRange) -> Self {
+    self
+  }
+}
+
+// MARK: - prefixes and suffixes
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableRawSpan {
+
+  /// Returns a span containing the initial bytes of this span,
+  /// up to the specified maximum length.
+  ///
+  /// - Parameter maxLength: The maximum number of bytes to return.
+  ///   `maxLength` must be greater than or equal to zero.
+  /// - Returns: A span with at most `maxLength` bytes.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(first maxLength: Int) -> Self {
+    _precondition(maxLength >= 0, "Can't have a prefix of negative length")
+    let newCount = min(maxLength, byteCount)
+    let newSpan = unsafe Self(_unchecked: _pointer, byteCount: newCount)
+    return unsafe _overrideLifetime(newSpan, copying: self)
+  }
+
+  /// Returns a span over all but the given number of trailing bytes.
+  ///
+  /// - Parameter k: The number of bytes to drop off the end of
+  ///   the span. `k` must be greater than or equal to zero.
+  /// - Returns: A span leaving off the specified number of bytes at the end.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(droppingLast k: Int) -> Self {
+    _precondition(k >= 0, "Can't drop a negative number of bytes")
+    let droppedCount = min(k, byteCount)
+    let newSpan = unsafe Self(
+      _unchecked: _pointer, byteCount: byteCount &- droppedCount
+    )
+    return unsafe _overrideLifetime(newSpan, copying: self)
+  }
+
+  /// Returns a span containing the trailing bytes of the span,
+  /// up to the given maximum length.
+  ///
+  /// - Parameter maxLength: The maximum number of bytes to return.
+  ///   `maxLength` must be greater than or equal to zero.
+  /// - Returns: A span with at most `maxLength` bytes.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(last maxLength: Int) -> Self {
+    _precondition(maxLength >= 0, "Can't have a suffix of negative length")
+    let newCount = min(maxLength, byteCount)
+    let newStart = unsafe _pointer?.advanced(by: byteCount &- newCount)
+    let newSpan = unsafe Self(_unchecked: newStart, byteCount: newCount)
+    return unsafe _overrideLifetime(newSpan, copying: self)
+  }
+
+  /// Returns a span over all but the given number of initial bytes.
+  ///
+  /// - Parameter k: The number of bytes to drop from the beginning of
+  ///   the span. `k` must be greater than or equal to zero.
+  /// - Returns: A span starting after the specified number of bytes.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(droppingFirst k: Int) -> Self {
+    _precondition(k >= 0, "Can't drop a negative number of bytes")
+    let droppedCount = min(k, byteCount)
+    let newStart = unsafe _pointer?.advanced(by: droppedCount)
+    let newCount = byteCount &- droppedCount
+    let newSpan = unsafe Self(_unchecked: newStart, byteCount: newCount)
+    return unsafe _overrideLifetime(newSpan, copying: self)
+  }
+}
+
+// MARK: - identity
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableRawSpan {
+
+  /// Returns a Boolean value indicating whether two instances refer to the
+  /// same memory region.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  public func isIdentical(to other: Self) -> Bool {
+    unsafe (self._pointer == other._pointer) && (self._count == other._count)
+  }
+
+  /// Returns a Boolean value indicating whether two instances refer to the
+  /// same memory region.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  public func isTriviallyIdentical(to other: Self) -> Bool {
+    unsafe (self._pointer == other._pointer) && (self._count == other._count)
+  }
+
+  /// Returns the byte offsets within this span where the memory represented
+  /// by `other` is located, or `nil` if `other` is not located within this
+  /// span.
+  @export(implementation)
+  public func byteOffsets(of other: borrowing Self) -> Range<Int>? {
+    bytes.byteOffsets(of: other.bytes)
+  }
+}
+
+// MARK: - usage hints
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableRawSpan {
+
+  @export(implementation)
+  @available(*, unavailable, renamed: "extracting(_:)")
+  public subscript(bounds: Range<Int>) -> Self {
+    Builtin.unreachable()
+  }
+
+  @export(implementation)
+  @available(*, unavailable, renamed: "extracting(_:)")
+  public subscript(bounds: some RangeExpression<Int>) -> Self {
+    Builtin.unreachable()
+  }
+
+  @export(implementation)
+  @available(*, unavailable, renamed: "extracting(_:)")
+  public subscript(bounds: UnboundedRange) -> Self {
+    Builtin.unreachable()
+  }
+
+  @export(implementation)
+  @available(*, unavailable, renamed: "extracting(first:)")
+  public func prefix(_ maxLength: Int) -> Self {
+    Builtin.unreachable()
+  }
+
+  @export(implementation)
+  @available(*, unavailable, renamed: "extracting(last:)")
+  public func suffix(_ maxLength: Int) -> Self {
+    Builtin.unreachable()
+  }
+
+  @export(implementation)
+  @available(*, unavailable, renamed: "extracting(droppingFirst:)")
+  public func dropFirst(_ k: Int = 1) -> Self {
+    Builtin.unreachable()
+  }
+
+  @export(implementation)
+  @available(*, unavailable, renamed: "extracting(droppingLast:)")
+  public func dropLast(_ k: Int = 1) -> Self {
+    Builtin.unreachable()
+  }
+}
+
+// MARK: - description
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableRawSpan {
+  @export(implementation)
+  public var _description: String {
+    let addr = unsafe String(
+      UInt(bitPattern: _pointer), radix: 16, uppercase: false
+    )
+    return "(0x\(addr), \(_count))"
+  }
+}
+
+// MARK: - Iterable
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableRawSpan: Iterable {
+  @available(SwiftStdlib 6.5, *)
+  public typealias Failure = Never
+
+  @export(implementation)
+  public var underestimatedCount: Int {
+    self.byteCount
+  }
+
+  @available(SwiftStdlib 6.5, *)
+  @export(implementation)
+  @_lifetime(borrow self)
+  public func makeBorrowingIterator() -> AliasedSpan<UInt8>.BorrowingIterator {
+    .init(AliasedSpan(viewing: self.bytes))
+  }
+}
+
+// MARK: - conversions
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableRawSpan {
+
+  /// An aliased raw span referencing the same bytes as this mutable span.
+  ///
+  /// Retrieving a non-mutating aliased raw span from an aliased mutable raw
+  /// span is a safe operation, because both already assume that the
+  /// underlying storage may be aliased.
+  @export(implementation)
+  @_transparent
+  public var bytes: AliasedRawSpan {
+    @_lifetime(copy self)
+    get {
+      let result = unsafe AliasedRawSpan(
+        _unchecked: UnsafeRawPointer(_pointer), byteCount: _count
+      )
+      return unsafe _overrideLifetime(result, copying: self)
+    }
+  }
+
+  /// A mutable raw span referencing the same bytes as this aliased mutable
+  /// raw span.
+  ///
+  /// Retrieving a `MutableRawSpan` from an `AliasedMutableRawSpan` is an
+  /// unsafe operation, because one must ensure that the underlying storage is
+  /// not accessed at all (read or write) through any other reference while
+  /// the mutable raw span is in use.
+  @unsafe
+  @export(implementation)
+  @_transparent
+  public var mutableRawSpan: MutableRawSpan {
+    @_lifetime(copy self)
+    get {
+      let result = unsafe MutableRawSpan(
+        _unchecked: _pointer, byteCount: _count
+      )
+      return unsafe _overrideLifetime(result, copying: self)
+    }
+  }
+}
+
+@available(SwiftStdlib 6.5, *)
+extension MutableRawSpan {
+
+  /// Retrieve an aliased mutable raw span from this mutable raw span.
+  ///
+  /// This operation consumes the `MutableRawSpan`, which ensures that the
+  /// original span (which assumes exclusivity) cannot be used while the
+  /// returned `AliasedMutableRawSpan`, or any copy of it, is still in use.
+  @export(implementation)
+  @_lifetime(copy self)
+  @_transparent
+  public consuming func asAliased() -> AliasedMutableRawSpan {
+    let result = unsafe AliasedMutableRawSpan(
+      _unchecked: _pointer, byteCount: _count
+    )
+    return unsafe _overrideLifetime(result, copying: self)
+  }
+}
+
+// MARK: - typed views
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableRawSpan {
+
+  /// Unsafely view the bytes of this span as instances of `T`.
+  @unsafe
+  @export(implementation)
+  @_lifetime(copy self)
+  public func _unsafeView<T: BitwiseCopyable>(
+    as type: T.Type
+  ) -> AliasedSpan<T> {
+    let bytes = unsafe UnsafeRawBufferPointer(start: _pointer, count: _count)
+    let span = unsafe AliasedSpan<T>(_unsafeBytes: bytes)
+    return unsafe _overrideLifetime(span, copying: self)
+  }
+
+  /// Unsafely view the bytes of this span as mutable instances of `T`.
+  @unsafe
+  @export(implementation)
+  @_lifetime(copy self)
+  public func _unsafeMutableView<T: BitwiseCopyable>(
+    as type: T.Type
+  ) -> AliasedMutableSpan<T> {
+    let bytes = unsafe UnsafeMutableRawBufferPointer(
+      start: _pointer, count: _count
+    )
+    let span = unsafe AliasedMutableSpan<T>(_unsafeBytes: bytes)
+    return unsafe _overrideLifetime(span, copying: self)
+  }
+}

--- a/stdlib/public/core/Span/AliasedMutableSpan.swift
+++ b/stdlib/public/core/Span/AliasedMutableSpan.swift
@@ -1,0 +1,904 @@
+//===--- AliasedMutableSpan.swift -----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// `AliasedMutableSpan<Element>` represents a contiguous region of memory
+/// which contains initialized instances of `Element` and which can be both
+/// read and written, and which may be aliased by other references to the same
+/// memory.
+///
+/// `AliasedMutableSpan` is the mutable counterpart of `AliasedSpan`, in the
+/// same way that `MutableSpan` is the mutable counterpart of `Span`. It
+/// differs from `MutableSpan` in two important ways:
+///
+/// * It is `Copyable`. `MutableSpan` is noncopyable specifically to prevent
+///   the creation of aliases to its storage; since `AliasedMutableSpan`
+///   already accounts for aliases, there is no reason to prevent copies.
+///   Consequently, the operations that are `mutating` or `consuming` on
+///   `MutableSpan` are non-mutating here.
+/// * Element accesses use `get` and `nonmutating set` accessors rather than
+///   `borrow` and `mutate` accessors, so `Element` must be `Copyable`.
+///
+/// Use `AliasedMutableSpan` only when aliasing genuinely cannot be ruled out,
+/// such as for shared memory or memory that is also reachable from C or C++
+/// code. Prefer `MutableSpan` everywhere else.
+@frozen
+@safe
+@available(SwiftStdlib 6.5, *)
+public struct AliasedMutableSpan<Element>
+: ~Escapable, Copyable, BitwiseCopyable {
+
+  @usableFromInline
+  internal let _pointer: UnsafeMutableRawPointer?
+
+  @usableFromInline
+  internal let _count: Int
+
+  @unsafe
+  @export(implementation)
+  @_transparent
+  internal func _start() -> UnsafeMutableRawPointer {
+    unsafe _pointer._unsafelyUnwrappedUnchecked
+  }
+
+  /// Create an empty span.
+  @export(implementation)
+  @inline(__always)
+  @_lifetime(immortal)
+  public init() {
+    unsafe _pointer = nil
+    _count = 0
+  }
+
+  @unsafe
+  @export(implementation)
+  @inline(__always)
+  @_lifetime(borrow start)
+  @_disfavoredOverload
+  internal init(
+    _unchecked start: UnsafeMutableRawPointer?,
+    count: Int
+  ) {
+    unsafe _pointer = start
+    _count = count
+  }
+
+  @unsafe
+  @export(implementation)
+  @_transparent
+  @_lifetime(borrow start)
+  internal init(
+    _unchecked start: UnsafeMutablePointer<Element>,
+    count: Int
+  ) {
+    unsafe _pointer = UnsafeMutableRawPointer(start)
+    _count = count
+  }
+}
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableSpan: @unchecked Sendable
+where Element: Sendable & FullyInhabited {}
+
+// MARK: - unsafe construction
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableSpan {
+
+  /// Unsafely create an `AliasedMutableSpan` over initialized memory.
+  ///
+  /// The memory in `buffer` must remain valid and initialized throughout the
+  /// lifetime of the newly-created span. Unlike `MutableSpan`, the memory is
+  /// *not* required to be exclusively accessed: other references may read and
+  /// write it. Failure to maintain this invariant results in undefined
+  /// behaviour.
+  ///
+  /// - Parameters:
+  ///   - buffer: an `UnsafeMutableBufferPointer` to initialized elements.
+  @unsafe
+  @export(implementation)
+  @_lifetime(borrow buffer)
+  public init(_unsafeElements buffer: UnsafeMutableBufferPointer<Element>) {
+    _precondition(
+      buffer._isWellAligned(),
+      "baseAddress must be properly aligned to access Element"
+    )
+    let span = unsafe AliasedMutableSpan(
+      _unchecked: UnsafeMutableRawPointer(buffer.baseAddress),
+      count: buffer.count
+    )
+    self = unsafe _overrideLifetime(span, borrowing: buffer)
+  }
+
+  /// Unsafely create an `AliasedMutableSpan` over initialized memory.
+  ///
+  /// The region of memory representing `count` instances starting at `start`
+  /// must remain valid and initialized throughout the lifetime of the
+  /// newly-created span.
+  ///
+  /// - Parameters:
+  ///   - start: a pointer to the first initialized element.
+  ///   - count: the number of initialized elements in the span.
+  @unsafe
+  @export(implementation)
+  @_transparent
+  @_lifetime(borrow start)
+  public init(
+    _unsafeStart start: UnsafeMutablePointer<Element>,
+    count: Int
+  ) {
+    _precondition(count >= 0, "Count must not be negative")
+    let buffer = unsafe UnsafeMutableBufferPointer(start: start, count: count)
+    let span = unsafe AliasedMutableSpan(_unsafeElements: buffer)
+    self = unsafe _overrideLifetime(span, borrowing: start)
+  }
+
+  /// Unsafely create an `AliasedMutableSpan` over initialized memory.
+  ///
+  /// - Parameters:
+  ///   - elements: an `UnsafeMutableBufferPointer` slice of initialized
+  ///     elements.
+  @unsafe
+  @export(implementation)
+  @_lifetime(borrow elements)
+  public init(
+    _unsafeElements elements:
+      borrowing Slice<UnsafeMutableBufferPointer<Element>>
+  ) {
+    let rebased = unsafe UnsafeMutableBufferPointer(rebasing: elements)
+    let span = unsafe AliasedMutableSpan(_unsafeElements: rebased)
+    self = unsafe _overrideLifetime(span, borrowing: elements)
+  }
+}
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableSpan where Element: BitwiseCopyable {
+
+  /// Unsafely create an `AliasedMutableSpan` over initialized memory.
+  ///
+  /// `buffer` must be correctly aligned for accessing an element of type
+  /// `Element`, and must contain a number of bytes that is an exact multiple
+  /// of `Element`'s stride.
+  ///
+  /// - Parameters:
+  ///   - buffer: a buffer of initialized elements.
+  @unsafe
+  @export(implementation)
+  @_lifetime(borrow buffer)
+  public init(_unsafeBytes buffer: UnsafeMutableRawBufferPointer) {
+    _precondition(
+      ((Int(bitPattern: buffer.baseAddress) &
+        (MemoryLayout<Element>.alignment &- 1)) == 0),
+      "baseAddress must be properly aligned to access Element"
+    )
+    let (byteCount, stride) = (buffer.count, MemoryLayout<Element>.stride)
+    let (count, remainder) = byteCount.quotientAndRemainder(dividingBy: stride)
+    _precondition(
+      remainder == 0, "Span must contain a whole number of elements"
+    )
+    let span = unsafe AliasedMutableSpan(
+      _unchecked: buffer.baseAddress, count: count
+    )
+    self = unsafe _overrideLifetime(span, borrowing: buffer)
+  }
+
+  /// Unsafely create an `AliasedMutableSpan` over initialized memory.
+  ///
+  /// `pointer` must be correctly aligned for accessing an element of type
+  /// `Element`, and `byteCount` must be an exact multiple of `Element`'s
+  /// stride.
+  ///
+  /// - Parameters:
+  ///   - pointer: a pointer to the first initialized element.
+  ///   - byteCount: the number of bytes in the span.
+  @unsafe
+  @export(implementation)
+  @_lifetime(borrow pointer)
+  public init(_unsafeStart pointer: UnsafeMutableRawPointer, byteCount: Int) {
+    _precondition(byteCount >= 0, "Count must not be negative")
+    let bytes = unsafe UnsafeMutableRawBufferPointer(
+      start: pointer, count: byteCount
+    )
+    let span = unsafe AliasedMutableSpan(_unsafeBytes: bytes)
+    self = unsafe _overrideLifetime(span, borrowing: pointer)
+  }
+
+  /// Unsafely create an `AliasedMutableSpan` over initialized memory.
+  ///
+  /// - Parameters:
+  ///   - buffer: a buffer of initialized elements.
+  @unsafe
+  @export(implementation)
+  @_lifetime(borrow buffer)
+  public init(_unsafeBytes buffer: borrowing Slice<UnsafeMutableRawBufferPointer>) {
+    let bytes = unsafe UnsafeMutableRawBufferPointer(rebasing: buffer)
+    let span = unsafe AliasedMutableSpan(_unsafeBytes: bytes)
+    self = unsafe _overrideLifetime(span, borrowing: buffer)
+  }
+}
+
+// MARK: - conversion from raw spans
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableSpan
+where Element: ConvertibleFromBytes & ConvertibleToBytes {
+
+  /// View untyped memory as a typed mutable span.
+  ///
+  /// The `byteCount` of `mutableBytes` must be a multiple of `Element`'s
+  /// stride, and the starting address of `mutableBytes` must be well-aligned
+  /// for the type of `Element`. If either of these requirements is not met,
+  /// this initializer will trap at runtime.
+  ///
+  /// - Parameter mutableBytes: A raw span to reinterpret as typed elements.
+  @export(implementation)
+  @_lifetime(copy mutableBytes)
+  public init(mutableBytes: AliasedMutableRawSpan) {
+    _precondition(
+      unsafe ((Int(bitPattern: mutableBytes._pointer) &
+        (MemoryLayout<Element>.alignment &- 1)) == 0),
+      "baseAddress must be properly aligned to access Element"
+    )
+    let byteCount = mutableBytes.byteCount
+    let stride = MemoryLayout<Element>.stride
+    let (count, remainder) = byteCount.quotientAndRemainder(dividingBy: stride)
+    _precondition(
+      remainder == 0, "Span must contain a whole number of elements"
+    )
+    self = unsafe _overrideLifetime(
+      AliasedMutableSpan(_unchecked: mutableBytes._pointer, count: count),
+      copying: mutableBytes
+    )
+  }
+}
+
+// MARK: - basic properties
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableSpan {
+
+  /// The number of elements in the span.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_semantics("fixed_storage.get_count")
+  public var count: Int { _assumeNonNegative(_count) }
+
+  /// A Boolean value indicating whether the span is empty.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_transparent
+  public var isEmpty: Bool { _count == 0 }
+
+  /// The type that represents an index in an `AliasedMutableSpan`.
+  public typealias Index = Int
+
+  /// The range of valid indices for subscripting the span.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  public var indices: Range<Index> {
+    unsafe Range(_uncheckedBounds: (0, count))
+  }
+}
+
+// MARK: - element access
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableSpan {
+  // SILOptimizer looks for fixed_storage.check_index semantics for bounds
+  // check optimizations.
+  @_semantics("fixed_storage.check_index")
+  @inline(__always)
+  @export(implementation)
+  internal func _checkIndex(_ position: Index) {
+    _precondition(indices.contains(position), "Index out of bounds")
+  }
+
+  /// Accesses a copy of the element at the specified index in the span.
+  ///
+  /// Unlike `MutableSpan`, this subscript copies the element into and out of
+  /// the underlying storage rather than providing direct access to it. The
+  /// copy ensures that the accessed value remains valid even if another
+  /// reference to the same storage replaces the element concurrently.
+  ///
+  /// The setter is non-mutating because storing an element does not change
+  /// the span itself, only the contents of the storage it references.
+  ///
+  /// - Parameter position: The offset of the element to access. `position`
+  ///     must be greater or equal to zero, and less than `count`.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  public subscript(_ position: Index) -> Element {
+    @_transparent
+    get {
+      _checkIndex(position)
+      return unsafe self[unchecked: position]
+    }
+    @_transparent
+    nonmutating set {
+      _checkIndex(position)
+      unsafe self[unchecked: position] = newValue
+    }
+  }
+
+  /// Accesses a copy of the element at the specified index in the span.
+  ///
+  /// This subscript does not validate `position`; this is an unsafe
+  /// operation.
+  ///
+  /// - Parameter position: The offset of the element to access. `position`
+  ///     must be greater or equal to zero, and less than `count`.
+  ///
+  /// - Complexity: O(1)
+  @unsafe
+  @export(implementation)
+  public subscript(unchecked position: Index) -> Element {
+    get {
+      unsafe UnsafePointer<Element>(
+        _unsafeAddressOfElement(unchecked: position)
+      ).pointee
+    }
+    nonmutating set {
+      let address = unsafe _unsafeAddressOfElement(unchecked: position)
+      unsafe UnsafeMutablePointer<Element>(address).pointee = newValue
+    }
+  }
+
+  @unsafe
+  @export(implementation)
+  @_transparent
+  internal func _unsafeAddressOfElement(
+    unchecked position: Index
+  ) -> Builtin.RawPointer {
+#if $BuiltinGepProjection
+    unsafe Builtin.gepProjection_Word(
+      _start()._rawValue, position._builtinWordValue, Element.self
+    )
+#else
+    let elementOffset = position &* MemoryLayout<Element>.stride
+    return unsafe _start().advanced(by: elementOffset)._rawValue
+#endif
+  }
+}
+
+// MARK: - bulk update functions
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableSpan {
+
+  /// Exchange the elements at the two given indices.
+  ///
+  /// - Parameter i: A valid index into this span.
+  /// - Parameter j: A valid index into this span.
+  @export(implementation)
+  public func swapAt(_ i: Index, _ j: Index) {
+    _checkIndex(i)
+    _checkIndex(j)
+    unsafe swapAt(unchecked: i, unchecked: j)
+  }
+
+  /// Exchange the elements at the two given indices.
+  ///
+  /// This function does not validate `i` or `j`; this is an unsafe operation.
+  ///
+  /// - Parameter i: A valid index into this span.
+  /// - Parameter j: A valid index into this span.
+  @unsafe
+  @export(implementation)
+  public func swapAt(unchecked i: Index, unchecked j: Index) {
+    let temporary = unsafe self[unchecked: i]
+    unsafe self[unchecked: i] = self[unchecked: j]
+    unsafe self[unchecked: j] = temporary
+  }
+
+  /// Update every element of this span to the given value.
+  ///
+  /// - Parameter repeatedValue: The value to set for every element.
+  @export(implementation)
+  public func update(repeating repeatedValue: consuming Element) {
+    guard !isEmpty else { return }
+    unsafe _start().withMemoryRebound(to: Element.self, capacity: count) {
+      unsafe $0.update(repeating: repeatedValue, count: count)
+    }
+  }
+}
+
+// MARK: - UnsafeBufferPointer access hatch
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableSpan {
+
+  /// Call a closure with a pointer to the viewed contiguous storage.
+  ///
+  /// The buffer pointer passed as an argument to `body` is valid only
+  /// during the execution of `withUnsafeBufferPointer(_:)`.
+  /// Do not store or return the pointer for later use.
+  ///
+  /// - Note: Because the storage may be aliased, its contents may change
+  ///   while `body` is executing.
+  ///
+  /// - Parameter body: A closure with an `UnsafeBufferPointer` parameter
+  ///   that points to the viewed contiguous storage.
+  /// - Returns: The return value of the `body` closure parameter.
+  @export(implementation)
+  @_transparent
+  @safe
+  public func withUnsafeBufferPointer<E: Error, Result: ~Copyable>(
+    _ body: (_ buffer: UnsafeBufferPointer<Element>) throws(E) -> Result
+  ) throws(E) -> Result {
+    let bytes = unsafe UnsafeRawBufferPointer(
+      start: _pointer, count: _count &* MemoryLayout<Element>.stride
+    )
+    return try unsafe bytes.withMemoryRebound(to: Element.self) {
+      buffer throws(E) -> Result in
+      try unsafe body(buffer)
+    }
+  }
+
+  /// Call a closure with a pointer to the viewed mutable contiguous storage.
+  ///
+  /// The buffer pointer passed as an argument to `body` is valid only
+  /// during the execution of `withUnsafeMutableBufferPointer(_:)`.
+  /// Do not store or return the pointer for later use.
+  ///
+  /// - Note: Because the storage may be aliased, its contents may change
+  ///   while `body` is executing.
+  ///
+  /// - Parameter body: A closure with an `UnsafeMutableBufferPointer`
+  ///   parameter that points to the viewed contiguous storage.
+  /// - Returns: The return value of the `body` closure parameter.
+  @export(implementation)
+  @_transparent
+  @safe
+  public func withUnsafeMutableBufferPointer<E: Error, Result: ~Copyable>(
+    _ body: (UnsafeMutableBufferPointer<Element>) throws(E) -> Result
+  ) throws(E) -> Result {
+    let bytes = unsafe UnsafeMutableRawBufferPointer(
+      start: _pointer, count: _count &* MemoryLayout<Element>.stride
+    )
+    return try unsafe bytes.withMemoryRebound(to: Element.self) {
+      buffer throws(E) -> Result in
+      try unsafe body(buffer)
+    }
+  }
+}
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableSpan where Element: BitwiseCopyable {
+
+  /// Calls the given closure with a pointer to the underlying bytes of
+  /// the viewed contiguous storage.
+  ///
+  /// - Parameter body: A closure with an `UnsafeRawBufferPointer`
+  ///   parameter that points to the viewed contiguous storage.
+  /// - Returns: The return value of the `body` closure parameter.
+  @export(implementation)
+  @_transparent
+  @safe
+  public func withUnsafeBytes<E: Error, Result: ~Copyable>(
+    _ body: (_ buffer: UnsafeRawBufferPointer) throws(E) -> Result
+  ) throws(E) -> Result {
+    let bytes = unsafe UnsafeRawBufferPointer(
+      start: _pointer, count: _count &* MemoryLayout<Element>.stride
+    )
+    return try unsafe body(bytes)
+  }
+
+  /// Calls the given closure with a mutable pointer to the underlying bytes
+  /// of the viewed contiguous storage.
+  ///
+  /// - Parameter body: A closure with an `UnsafeMutableRawBufferPointer`
+  ///   parameter that points to the viewed contiguous storage.
+  /// - Returns: The return value of the `body` closure parameter.
+  @export(implementation)
+  @_transparent
+  @safe
+  public func withUnsafeMutableBytes<E: Error, Result: ~Copyable>(
+    _ body: (_ buffer: UnsafeMutableRawBufferPointer) throws(E) -> Result
+  ) throws(E) -> Result {
+    let bytes = unsafe UnsafeMutableRawBufferPointer(
+      start: _pointer, count: _count &* MemoryLayout<Element>.stride
+    )
+    return try unsafe body(bytes)
+  }
+}
+
+// MARK: - sub-spans
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableSpan {
+
+  /// Constructs a new span over the items within the supplied range of
+  /// indices within this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter bounds: A valid range of indices. Every index in
+  ///     this range must be within the bounds of this span.
+  ///
+  /// - Returns: An `AliasedMutableSpan` over the items within `bounds`.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(_ bounds: Range<Index>) -> Self {
+    _precondition(
+      UInt(bitPattern: bounds.lowerBound) <= UInt(bitPattern: _count) &&
+      UInt(bitPattern: bounds.upperBound) <= UInt(bitPattern: _count),
+      "Index range out of bounds"
+    )
+    return unsafe extracting(unchecked: bounds)
+  }
+
+  /// Constructs a new span over the items within the supplied range of
+  /// indices within this span.
+  ///
+  /// This function does not validate `bounds`; this is an unsafe operation.
+  ///
+  /// - Parameter bounds: A valid range of indices. Every index in
+  ///     this range must be within the bounds of this span.
+  ///
+  /// - Returns: An `AliasedMutableSpan` over the items within `bounds`.
+  ///
+  /// - Complexity: O(1)
+  @unsafe
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(unchecked bounds: Range<Index>) -> Self {
+    let delta = bounds.lowerBound &* MemoryLayout<Element>.stride
+    let newStart = unsafe _pointer?.advanced(by: delta)
+    let newSpan = unsafe Self(_unchecked: newStart, count: bounds.count)
+    return unsafe _overrideLifetime(newSpan, copying: self)
+  }
+
+  /// Constructs a new span over the items within the supplied range of
+  /// indices within this span.
+  ///
+  /// - Parameter bounds: A valid range of indices. Every index in
+  ///     this range must be within the bounds of this span.
+  ///
+  /// - Returns: An `AliasedMutableSpan` over the items within `bounds`.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(_ bounds: some RangeExpression<Index>) -> Self {
+    extracting(bounds.relative(to: indices))
+  }
+
+  /// Constructs a new span over the items within the supplied range of
+  /// indices within this span.
+  ///
+  /// This function does not validate `bounds`; this is an unsafe operation.
+  ///
+  /// - Parameter bounds: A valid range of indices. Every index in
+  ///     this range must be within the bounds of this span.
+  ///
+  /// - Returns: An `AliasedMutableSpan` over the items within `bounds`.
+  ///
+  /// - Complexity: O(1)
+  @unsafe
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(unchecked bounds: ClosedRange<Index>) -> Self {
+    let range = unsafe Range(
+      _uncheckedBounds: (bounds.lowerBound, bounds.upperBound + 1)
+    )
+    return unsafe extracting(unchecked: range)
+  }
+
+  /// Constructs a new span over all the items of this span.
+  ///
+  /// - Returns: An `AliasedMutableSpan` over all the items of this span.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(_: UnboundedRange) -> Self {
+    self
+  }
+}
+
+// MARK: - prefixes and suffixes
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableSpan {
+
+  /// Returns a span containing the initial elements of this span,
+  /// up to the specified maximum length.
+  ///
+  /// - Parameter maxLength: The maximum number of elements to return.
+  ///   `maxLength` must be greater than or equal to zero.
+  /// - Returns: A span with at most `maxLength` elements.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(first maxLength: Int) -> Self {
+    _precondition(maxLength >= 0, "Can't have a prefix of negative length")
+    let newCount = min(maxLength, count)
+    let newSpan = unsafe Self(_unchecked: _pointer, count: newCount)
+    return unsafe _overrideLifetime(newSpan, copying: self)
+  }
+
+  /// Returns a span over all but the given number of trailing elements.
+  ///
+  /// - Parameter k: The number of elements to drop off the end of
+  ///   the span. `k` must be greater than or equal to zero.
+  /// - Returns: A span leaving off the specified number of elements at the
+  ///   end.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(droppingLast k: Int) -> Self {
+    _precondition(k >= 0, "Can't drop a negative number of elements")
+    let droppedCount = min(k, count)
+    let newSpan = unsafe Self(
+      _unchecked: _pointer, count: count &- droppedCount
+    )
+    return unsafe _overrideLifetime(newSpan, copying: self)
+  }
+
+  /// Returns a span containing the trailing elements of the span,
+  /// up to the given maximum length.
+  ///
+  /// - Parameter maxLength: The maximum number of elements to return.
+  ///   `maxLength` must be greater than or equal to zero.
+  /// - Returns: A span with at most `maxLength` elements.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(last maxLength: Int) -> Self {
+    _precondition(maxLength >= 0, "Can't have a suffix of negative length")
+    let newCount = min(maxLength, count)
+    let offset = (count &- newCount) &* MemoryLayout<Element>.stride
+    let newStart = unsafe _pointer?.advanced(by: offset)
+    let newSpan = unsafe Self(_unchecked: newStart, count: newCount)
+    return unsafe _overrideLifetime(newSpan, copying: self)
+  }
+
+  /// Returns a span over all but the given number of initial elements.
+  ///
+  /// - Parameter k: The number of elements to drop from the beginning of
+  ///   the span. `k` must be greater than or equal to zero.
+  /// - Returns: A span starting after the specified number of elements.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(droppingFirst k: Int) -> Self {
+    _precondition(k >= 0, "Can't drop a negative number of elements")
+    let droppedCount = min(k, count)
+    let offset = droppedCount &* MemoryLayout<Element>.stride
+    let newStart = unsafe _pointer?.advanced(by: offset)
+    let newCount = count &- droppedCount
+    let newSpan = unsafe Self(_unchecked: newStart, count: newCount)
+    return unsafe _overrideLifetime(newSpan, copying: self)
+  }
+}
+
+// MARK: - identity
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableSpan {
+
+  /// Returns a Boolean value indicating whether two instances refer to the
+  /// same memory region.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  public func isIdentical(to other: Self) -> Bool {
+    unsafe (self._pointer == other._pointer) && (self._count == other._count)
+  }
+
+  /// Returns a Boolean value indicating whether two instances refer to the
+  /// same memory region.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  public func isTriviallyIdentical(to other: Self) -> Bool {
+    unsafe (self._pointer == other._pointer) && (self._count == other._count)
+  }
+
+  /// Returns the indices within this span where the memory represented
+  /// by `other` is located, or `nil` if `other` is not located within this
+  /// span.
+  @export(implementation)
+  public func indices(of other: borrowing Self) -> Range<Index>? {
+    aliased.indices(of: other.aliased)
+  }
+}
+
+// MARK: - usage hints
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableSpan {
+
+  @export(implementation)
+  @available(*, unavailable, renamed: "extracting(_:)")
+  public subscript(bounds: Range<Index>) -> Self {
+    Builtin.unreachable()
+  }
+
+  @export(implementation)
+  @available(*, unavailable, renamed: "extracting(_:)")
+  public subscript(bounds: some RangeExpression<Index>) -> Self {
+    Builtin.unreachable()
+  }
+
+  @export(implementation)
+  @available(*, unavailable, renamed: "extracting(_:)")
+  public subscript(bounds: UnboundedRange) -> Self {
+    Builtin.unreachable()
+  }
+
+  @export(implementation)
+  @available(*, unavailable, renamed: "extracting(first:)")
+  public func prefix(_ maxLength: Int) -> Self {
+    Builtin.unreachable()
+  }
+
+  @export(implementation)
+  @available(*, unavailable, renamed: "extracting(last:)")
+  public func suffix(_ maxLength: Int) -> Self {
+    Builtin.unreachable()
+  }
+
+  @export(implementation)
+  @available(*, unavailable, renamed: "extracting(droppingFirst:)")
+  public func dropFirst(_ k: Int = 1) -> Self {
+    Builtin.unreachable()
+  }
+
+  @export(implementation)
+  @available(*, unavailable, renamed: "extracting(droppingLast:)")
+  public func dropLast(_ k: Int = 1) -> Self {
+    Builtin.unreachable()
+  }
+}
+
+// MARK: - description
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableSpan {
+  @export(implementation)
+  public var _description: String {
+    let addr = unsafe String(
+      UInt(bitPattern: _pointer), radix: 16, uppercase: false
+    )
+    return "(0x\(addr), \(_count))"
+  }
+}
+
+// MARK: - Iterable
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableSpan: Iterable {
+  @available(SwiftStdlib 6.5, *)
+  public typealias Failure = Never
+
+  @export(implementation)
+  public var underestimatedCount: Int {
+    self.count
+  }
+
+  @available(SwiftStdlib 6.5, *)
+  @export(implementation)
+  @_lifetime(borrow self)
+  public func makeBorrowingIterator() -> AliasedSpan<Element>.BorrowingIterator {
+    .init(self.aliased)
+  }
+}
+
+// MARK: - conversions
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableSpan {
+
+  /// An aliased span referencing the same storage as this mutable span.
+  ///
+  /// Retrieving a non-mutating aliased span from an aliased mutable span is a
+  /// safe operation, because both already assume that the underlying storage
+  /// may be aliased.
+  @export(implementation)
+  @_transparent
+  public var aliased: AliasedSpan<Element> {
+    @_lifetime(copy self)
+    get {
+      let result = unsafe AliasedSpan<Element>(
+        _unchecked: UnsafeRawPointer(_pointer), count: _count
+      )
+      return unsafe _overrideLifetime(result, copying: self)
+    }
+  }
+
+  /// A mutable span referencing the same storage as this aliased mutable
+  /// span.
+  ///
+  /// Retrieving a `MutableSpan` from an `AliasedMutableSpan` is an unsafe
+  /// operation, because one must ensure that the underlying storage is not
+  /// accessed at all (read or write) through any other reference while the
+  /// mutable span is in use.
+  @unsafe
+  @export(implementation)
+  @_transparent
+  public var mutableSpan: MutableSpan<Element> {
+    @_lifetime(copy self)
+    get {
+      let result = unsafe MutableSpan<Element>(
+        _unchecked: _pointer, count: _count
+      )
+      return unsafe _overrideLifetime(result, copying: self)
+    }
+  }
+}
+
+@available(SwiftStdlib 6.5, *)
+extension MutableSpan {
+
+  /// Retrieve an aliased mutable span from this mutable span.
+  ///
+  /// This operation consumes the `MutableSpan`, which ensures that the
+  /// original span (which assumes exclusivity) cannot be used while the
+  /// returned `AliasedMutableSpan`, or any copy of it, is still in use.
+  @export(implementation)
+  @_lifetime(copy self)
+  @_transparent
+  public consuming func asAliased() -> AliasedMutableSpan<Element> {
+    let result = unsafe AliasedMutableSpan<Element>(
+      _unchecked: _pointer, count: _count
+    )
+    return unsafe _overrideLifetime(result, copying: self)
+  }
+}
+
+// MARK: - bytes
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableSpan where Element: ConvertibleToBytes {
+
+  /// A raw span over the memory represented by this span.
+  ///
+  /// - Returns: An `AliasedRawSpan` over the memory represented by this span.
+  @export(implementation)
+  @_transparent
+  public var bytes: AliasedRawSpan {
+    @_lifetime(copy self)
+    get {
+      AliasedRawSpan(elements: self.aliased)
+    }
+  }
+}
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedMutableSpan
+where Element: ConvertibleToBytes & ConvertibleFromBytes {
+
+  /// A mutable raw span over the memory represented by this span.
+  ///
+  /// - Returns: An `AliasedMutableRawSpan` over the memory represented by
+  ///   this span.
+  @export(implementation)
+  @_transparent
+  public var mutableBytes: AliasedMutableRawSpan {
+    @_lifetime(copy self)
+    get {
+      AliasedMutableRawSpan(elements: self)
+    }
+  }
+}

--- a/stdlib/public/core/Span/AliasedRawSpan.swift
+++ b/stdlib/public/core/Span/AliasedRawSpan.swift
@@ -1,0 +1,815 @@
+//===--- AliasedRawSpan.swift ---------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// `AliasedRawSpan` represents a contiguous region of memory which contains
+/// initialized bytes, and which may be aliased by other references to the same
+/// memory.
+///
+/// `AliasedRawSpan` is to `RawSpan` what `AliasedSpan` is to `Span`: it
+/// provides the same lifetime and bounds safety, but does not depend on the
+/// Law of Exclusivity, so the bytes it references may be modified through some
+/// other reference while this span is alive.
+@frozen
+@safe
+@available(SwiftStdlib 6.5, *)
+public struct AliasedRawSpan: ~Escapable, Copyable, BitwiseCopyable {
+
+  /// The starting address of this `AliasedRawSpan`.
+  @usableFromInline
+  internal let _pointer: UnsafeRawPointer?
+
+  @unsafe
+  @export(implementation)
+  @inline(__always)
+  internal func _start() -> UnsafeRawPointer {
+    unsafe _pointer._unsafelyUnwrappedUnchecked
+  }
+
+  /// The number of bytes in this `AliasedRawSpan`.
+  @usableFromInline
+  internal let _count: Int
+
+  /// Create an empty span.
+  @export(implementation)
+  @inline(__always)
+  @_lifetime(immortal)
+  public init() {
+    unsafe _pointer = nil
+    _count = 0
+  }
+
+  @unsafe
+  @export(implementation)
+  @inline(__always)
+  @_lifetime(borrow pointer)
+  internal init(
+    _unchecked pointer: UnsafeRawPointer?,
+    byteCount: Int
+  ) {
+    unsafe _pointer = pointer
+    _count = byteCount
+  }
+}
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedRawSpan: @unchecked Sendable {}
+
+// MARK: - unsafe construction
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedRawSpan {
+
+  /// Unsafely create an `AliasedRawSpan` over initialized memory.
+  ///
+  /// The memory in `buffer` must remain valid and initialized throughout the
+  /// lifetime of the newly-created span. Unlike `RawSpan`, the memory is
+  /// *not* required to be immutable.
+  ///
+  /// - Parameters:
+  ///   - buffer: an `UnsafeRawBufferPointer` to initialized memory.
+  @unsafe
+  @export(implementation)
+  @_lifetime(borrow buffer)
+  public init(_unsafeBytes buffer: UnsafeRawBufferPointer) {
+    let baseAddress = buffer.baseAddress
+    let span = unsafe AliasedRawSpan(
+      _unchecked: baseAddress, byteCount: buffer.count
+    )
+    self = unsafe _overrideLifetime(span, borrowing: buffer)
+  }
+
+  /// Unsafely create an `AliasedRawSpan` over initialized memory.
+  ///
+  /// - Parameters:
+  ///   - buffer: a `Slice<UnsafeRawBufferPointer>` to initialized memory.
+  @unsafe
+  @export(implementation)
+  @_lifetime(borrow buffer)
+  public init(_unsafeBytes buffer: borrowing Slice<UnsafeRawBufferPointer>) {
+    let rebased = unsafe UnsafeRawBufferPointer(rebasing: buffer)
+    let span = unsafe AliasedRawSpan(_unsafeBytes: rebased)
+    self = unsafe _overrideLifetime(span, borrowing: buffer)
+  }
+
+  /// Unsafely create an `AliasedRawSpan` over initialized memory.
+  ///
+  /// - Parameters:
+  ///   - buffer: an `UnsafeMutableRawBufferPointer` to initialized memory.
+  @unsafe
+  @export(implementation)
+  @_lifetime(borrow buffer)
+  public init(_unsafeBytes buffer: UnsafeMutableRawBufferPointer) {
+    let span = unsafe AliasedRawSpan(
+      _unsafeBytes: UnsafeRawBufferPointer(buffer)
+    )
+    self = unsafe _overrideLifetime(span, borrowing: buffer)
+  }
+
+  /// Unsafely create an `AliasedRawSpan` over initialized memory.
+  ///
+  /// - Parameters:
+  ///   - buffer: a `Slice<UnsafeMutableRawBufferPointer>` to initialized
+  ///     memory.
+  @unsafe
+  @export(implementation)
+  @_lifetime(borrow buffer)
+  public init(
+    _unsafeBytes buffer: borrowing Slice<UnsafeMutableRawBufferPointer>
+  ) {
+    let rebased = UnsafeRawBufferPointer(
+      unsafe UnsafeMutableRawBufferPointer(rebasing: buffer)
+    )
+    let span = unsafe AliasedRawSpan(_unsafeBytes: rebased)
+    self = unsafe _overrideLifetime(span, borrowing: buffer)
+  }
+
+  /// Unsafely create an `AliasedRawSpan` over initialized memory.
+  ///
+  /// - Parameters:
+  ///   - pointer: a pointer to the first initialized byte.
+  ///   - byteCount: the number of initialized bytes in the span.
+  @unsafe
+  @export(implementation)
+  @_lifetime(borrow pointer)
+  public init(_unsafeStart pointer: UnsafeRawPointer, byteCount: Int) {
+    _precondition(byteCount >= 0, "Count must not be negative")
+    unsafe self.init(_unchecked: pointer, byteCount: byteCount)
+  }
+
+  /// Unsafely create an `AliasedRawSpan` over initialized memory.
+  ///
+  /// - Parameters:
+  ///   - buffer: an `UnsafeBufferPointer<T>` to initialized memory.
+  @unsafe
+  @export(implementation)
+  @_lifetime(borrow buffer)
+  public init<T: BitwiseCopyable>(_unsafeElements buffer: UnsafeBufferPointer<T>) {
+    let span = unsafe AliasedRawSpan(
+      _unsafeBytes: UnsafeRawBufferPointer(buffer)
+    )
+    self = unsafe _overrideLifetime(span, borrowing: buffer)
+  }
+
+  /// Unsafely create an `AliasedRawSpan` over initialized memory.
+  ///
+  /// - Parameters:
+  ///   - buffer: an `UnsafeMutableBufferPointer<T>` to initialized memory.
+  @unsafe
+  @export(implementation)
+  @_lifetime(borrow buffer)
+  public init<T: BitwiseCopyable>(
+    _unsafeElements buffer: UnsafeMutableBufferPointer<T>
+  ) {
+    let span = unsafe AliasedRawSpan(
+      _unsafeBytes: UnsafeRawBufferPointer(buffer)
+    )
+    self = unsafe _overrideLifetime(span, borrowing: buffer)
+  }
+
+  /// Unsafely create an `AliasedRawSpan` over initialized memory.
+  ///
+  /// - Parameters:
+  ///   - pointer: a pointer to the first initialized element.
+  ///   - count: the number of initialized elements in the span.
+  @unsafe
+  @export(implementation)
+  @_lifetime(borrow pointer)
+  public init<T: BitwiseCopyable>(
+    _unsafeStart pointer: UnsafePointer<T>,
+    count: Int
+  ) {
+    _precondition(count >= 0, "Count must not be negative")
+    unsafe self.init(
+      _unchecked: pointer, byteCount: count &* MemoryLayout<T>.stride
+    )
+  }
+}
+
+// MARK: - conversion from typed aliased spans
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedRawSpan {
+
+  /// Unsafely view a typed aliased span as a raw aliased span.
+  ///
+  /// This is unsafe because `Element` may contain padding bytes, which are
+  /// not necessarily initialized.
+  ///
+  /// - Parameters:
+  ///   - span: An existing `AliasedSpan<Element>`, from which this span will
+  ///     inherit its lifetime.
+  @unsafe
+  @export(implementation)
+  @_lifetime(copy span)
+  public init<Element>(unsafeElements span: AliasedSpan<Element>) {
+    let rawSpan = unsafe AliasedRawSpan(
+      _unchecked: unsafe span._pointer,
+      byteCount: span.count == 1 ? MemoryLayout<Element>.size
+                 : span.count &* MemoryLayout<Element>.stride
+    )
+    self = unsafe _overrideLifetime(rawSpan, copying: span)
+  }
+
+  /// View a typed aliased span as a raw aliased span.
+  ///
+  /// - Parameters:
+  ///   - span: An existing `AliasedSpan<Element>`, from which this span will
+  ///     inherit its lifetime.
+  @export(implementation)
+  @_lifetime(copy span)
+  public init<Element: ConvertibleToBytes>(elements span: AliasedSpan<Element>) {
+    unsafe self = Self.init(unsafeElements: span)
+  }
+}
+
+// MARK: - basic properties
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedRawSpan {
+
+  /// The number of bytes in the span.
+  ///
+  /// To check whether the span is empty, use its `isEmpty` property
+  /// instead of comparing `byteCount` to zero.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_semantics("fixed_storage.get_count")
+  public var byteCount: Int { _assumeNonNegative(_count) }
+
+  /// A Boolean value indicating whether the span is empty.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_transparent
+  public var isEmpty: Bool { byteCount == 0 }
+
+  /// The byte offsets that are valid for subscripting the span, in ascending
+  /// order.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  public var byteOffsets: Range<Int> {
+    unsafe Range(_uncheckedBounds: (0, byteCount))
+  }
+}
+
+// MARK: - byte access
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedRawSpan {
+  // SILOptimizer looks for fixed_storage.check_index semantics
+  // for bounds checking optimizations.
+  @_semantics("fixed_storage.check_index")
+  @export(implementation) @inline(__always)
+  internal func _checkIndex(_ position: Int) {
+    _precondition(byteOffsets.contains(position), "Index out of bounds")
+  }
+
+  /// Accesses the byte at the specified offset in the span.
+  ///
+  /// - Parameter byteOffset: The offset of the byte to access. `byteOffset`
+  ///     must be greater than or equal to zero, and less than `byteCount`.
+  @export(implementation) @inline(__always)
+  public subscript(_ byteOffset: Int) -> UInt8 {
+    _checkIndex(byteOffset)
+    return unsafe self[unchecked: byteOffset]
+  }
+
+  /// Accesses the byte at the specified offset in the span.
+  ///
+  /// This subscript does not validate `byteOffset`. Using this subscript
+  /// with an invalid `byteOffset` results in undefined behaviour.
+  ///
+  /// - Parameter byteOffset: The offset of the byte to access. `byteOffset`
+  ///     must be greater than or equal to zero, and less than `byteCount`.
+  @export(implementation) @inline(__always)
+  @unsafe
+  public subscript(unchecked byteOffset: Int) -> UInt8 {
+    unsafe unsafeLoad(fromUncheckedByteOffset: byteOffset, as: UInt8.self)
+  }
+}
+
+// MARK: - sub-spans
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedRawSpan {
+
+  /// Constructs a new span over the bytes within the supplied range of
+  /// positions within this span.
+  ///
+  /// The returned span's first byte is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this span.
+  ///
+  /// - Returns: An `AliasedRawSpan` over the bytes within `bounds`.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(_ bounds: Range<Int>) -> Self {
+    _precondition(
+      UInt(bitPattern: bounds.lowerBound) <= UInt(bitPattern: _count) &&
+      UInt(bitPattern: bounds.upperBound) <= UInt(bitPattern: _count),
+      "Byte offset range out of bounds"
+    )
+    return unsafe extracting(unchecked: bounds)
+  }
+
+  /// Constructs a new span over the bytes within the supplied range of
+  /// positions within this span.
+  ///
+  /// This function does not validate `bounds`; this is an unsafe operation.
+  ///
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this span.
+  ///
+  /// - Returns: An `AliasedRawSpan` over the bytes within `bounds`.
+  ///
+  /// - Complexity: O(1)
+  @unsafe
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(unchecked bounds: Range<Int>) -> Self {
+    let newStart = unsafe _pointer?.advanced(by: bounds.lowerBound)
+    let newSpan = unsafe Self(_unchecked: newStart, byteCount: bounds.count)
+    return unsafe _overrideLifetime(newSpan, copying: self)
+  }
+
+  /// Constructs a new span over the bytes within the supplied range of
+  /// positions within this span.
+  ///
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this span.
+  ///
+  /// - Returns: An `AliasedRawSpan` over the bytes within `bounds`.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(_ bounds: some RangeExpression<Int>) -> Self {
+    extracting(bounds.relative(to: byteOffsets))
+  }
+
+  /// Constructs a new span over the bytes within the supplied range of
+  /// positions within this span.
+  ///
+  /// This function does not validate `bounds`; this is an unsafe operation.
+  ///
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this span.
+  ///
+  /// - Returns: An `AliasedRawSpan` over the bytes within `bounds`.
+  ///
+  /// - Complexity: O(1)
+  @unsafe
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(unchecked bounds: ClosedRange<Int>) -> Self {
+    let range = unsafe Range(
+      _uncheckedBounds: (bounds.lowerBound, bounds.upperBound + 1)
+    )
+    return unsafe extracting(unchecked: range)
+  }
+
+  /// Constructs a new span over all the bytes of this span.
+  ///
+  /// - Returns: An `AliasedRawSpan` over all the bytes of this span.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(_: UnboundedRange) -> Self {
+    self
+  }
+}
+
+// MARK: - prefixes and suffixes
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedRawSpan {
+
+  /// Returns a span containing the initial bytes of this span,
+  /// up to the specified maximum length.
+  ///
+  /// - Parameter maxLength: The maximum number of bytes to return.
+  ///   `maxLength` must be greater than or equal to zero.
+  /// - Returns: A span with at most `maxLength` bytes.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(first maxLength: Int) -> Self {
+    _precondition(maxLength >= 0, "Can't have a prefix of negative length")
+    let newCount = min(maxLength, byteCount)
+    let newSpan = unsafe Self(_unchecked: _pointer, byteCount: newCount)
+    return unsafe _overrideLifetime(newSpan, copying: self)
+  }
+
+  /// Returns a span over all but the given number of trailing bytes.
+  ///
+  /// - Parameter k: The number of bytes to drop off the end of
+  ///   the span. `k` must be greater than or equal to zero.
+  /// - Returns: A span leaving off the specified number of bytes at the end.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(droppingLast k: Int) -> Self {
+    _precondition(k >= 0, "Can't drop a negative number of bytes")
+    let droppedCount = min(k, byteCount)
+    let newSpan = unsafe Self(
+      _unchecked: _pointer, byteCount: byteCount &- droppedCount
+    )
+    return unsafe _overrideLifetime(newSpan, copying: self)
+  }
+
+  /// Returns a span containing the trailing bytes of the span,
+  /// up to the given maximum length.
+  ///
+  /// - Parameter maxLength: The maximum number of bytes to return.
+  ///   `maxLength` must be greater than or equal to zero.
+  /// - Returns: A span with at most `maxLength` bytes.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(last maxLength: Int) -> Self {
+    _precondition(maxLength >= 0, "Can't have a suffix of negative length")
+    let newCount = min(maxLength, byteCount)
+    let newStart = unsafe _pointer?.advanced(by: byteCount &- newCount)
+    let newSpan = unsafe Self(_unchecked: newStart, byteCount: newCount)
+    return unsafe _overrideLifetime(newSpan, copying: self)
+  }
+
+  /// Returns a span over all but the given number of initial bytes.
+  ///
+  /// - Parameter k: The number of bytes to drop from the beginning of
+  ///   the span. `k` must be greater than or equal to zero.
+  /// - Returns: A span starting after the specified number of bytes.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(droppingFirst k: Int) -> Self {
+    _precondition(k >= 0, "Can't drop a negative number of bytes")
+    let droppedCount = min(k, byteCount)
+    let newStart = unsafe _pointer?.advanced(by: droppedCount)
+    let newCount = byteCount &- droppedCount
+    let newSpan = unsafe Self(_unchecked: newStart, byteCount: newCount)
+    return unsafe _overrideLifetime(newSpan, copying: self)
+  }
+}
+
+// MARK: - UnsafeRawBufferPointer access hatch
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedRawSpan {
+
+  /// Calls the given closure with a pointer to the underlying bytes of
+  /// the viewed contiguous storage.
+  ///
+  /// The buffer pointer passed as an argument to `body` is valid only
+  /// during the execution of `withUnsafeBytes(_:)`.
+  /// Do not store or return the pointer for later use.
+  ///
+  /// - Note: Because the storage may be aliased, its contents may change
+  ///   while `body` is executing.
+  ///
+  /// - Parameter body: A closure with an `UnsafeRawBufferPointer`
+  ///   parameter that points to the viewed contiguous storage.
+  /// - Returns: The return value of the `body` closure parameter.
+  @export(implementation)
+  @_transparent
+  @safe
+  public func withUnsafeBytes<E: Error, Result: ~Copyable>(
+    _ body: (_ buffer: UnsafeRawBufferPointer) throws(E) -> Result
+  ) throws(E) -> Result {
+    try unsafe body(.init(start: _pointer, count: byteCount))
+  }
+}
+
+// MARK: - load
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedRawSpan {
+
+  /// Returns a new instance of the given type, constructed from the raw
+  /// memory at the specified offset.
+  ///
+  /// The memory at this pointer plus `offset` must be properly aligned for
+  /// accessing `T` and initialized to `T` or another type that is layout
+  /// compatible with `T`.
+  ///
+  /// This is an unsafe operation. Failure to meet the preconditions
+  /// above may produce an invalid value of `T`.
+  ///
+  /// - Parameters:
+  ///   - offset: The offset from the beginning of this span, in bytes.
+  ///     `offset` must be nonnegative. The default is zero.
+  ///   - type: The type of the instance to create.
+  /// - Returns: A new instance of type `T`, read from the raw bytes at
+  ///     `offset`.
+  @unsafe
+  @export(implementation)
+  public func unsafeLoad<T>(
+    fromByteOffset offset: Int = 0, as type: T.Type
+  ) -> T {
+    _precondition(
+      UInt(bitPattern: offset) <= UInt(bitPattern: _count) &&
+      MemoryLayout<T>.size <= (_count &- offset),
+      "Byte offset range out of bounds"
+    )
+    return unsafe unsafeLoad(fromUncheckedByteOffset: offset, as: T.self)
+  }
+
+  /// Returns a new instance of the given type, constructed from the raw
+  /// memory at the specified offset.
+  ///
+  /// This is an unsafe operation. This function does not validate the bounds
+  /// of the memory access.
+  ///
+  /// - Parameters:
+  ///   - offset: The offset from the beginning of this span, in bytes.
+  ///     `offset` must be nonnegative.
+  ///   - type: The type of the instance to create.
+  /// - Returns: A new instance of type `T`, read from the raw bytes at
+  ///     `offset`.
+  @unsafe
+  @export(implementation)
+  public func unsafeLoad<T>(
+    fromUncheckedByteOffset offset: Int, as type: T.Type
+  ) -> T {
+    unsafe _start().load(fromByteOffset: offset, as: T.self)
+  }
+
+  /// Returns a new instance of the given type, constructed from the raw
+  /// memory at the specified offset.
+  ///
+  /// This is an unsafe operation. Failure to meet the preconditions
+  /// above may produce an invalid value of `T`.
+  ///
+  /// - Parameters:
+  ///   - offset: The offset from the beginning of this span, in bytes.
+  ///     `offset` must be nonnegative. The default is zero.
+  ///   - type: The type of the instance to create.
+  /// - Returns: A new instance of type `T`, read from the raw bytes at
+  ///     `offset`.
+  @unsafe
+  @export(implementation)
+  public func unsafeLoadUnaligned<T: BitwiseCopyable>(
+    fromByteOffset offset: Int = 0, as type: T.Type
+  ) -> T {
+    _precondition(
+      UInt(bitPattern: offset) <= UInt(bitPattern: _count) &&
+      MemoryLayout<T>.size <= (_count &- offset),
+      "Byte offset range out of bounds"
+    )
+    return unsafe unsafeLoadUnaligned(
+      fromUncheckedByteOffset: offset, as: T.self
+    )
+  }
+
+  /// Returns a new instance of the given type, constructed from the raw
+  /// memory at the specified offset.
+  ///
+  /// This is an unsafe operation. This function does not validate the bounds
+  /// of the memory access.
+  ///
+  /// - Parameters:
+  ///   - offset: The offset from the beginning of this span, in bytes.
+  ///     `offset` must be nonnegative.
+  ///   - type: The type of the instance to create.
+  /// - Returns: A new instance of type `T`, read from the raw bytes at
+  ///     `offset`.
+  @unsafe
+  @export(implementation)
+  public func unsafeLoadUnaligned<T: BitwiseCopyable>(
+    fromUncheckedByteOffset offset: Int, as type: T.Type
+  ) -> T {
+    unsafe _start().loadUnaligned(fromByteOffset: offset, as: T.self)
+  }
+
+  /// Returns a value constructed from the raw memory at the specified offset.
+  ///
+  /// The range of bytes required to construct a value of type `T` starting at
+  /// `offset` must be completely within the span.
+  /// `offset` is not required to be aligned for `T`.
+  ///
+  /// - Parameters:
+  ///   - offset: The offset from the beginning of this span, in bytes.
+  ///     `offset` must be nonnegative.
+  ///   - type: The type of the instance to create.
+  /// - Returns: A new value of type `T`, read from `offset`.
+  @export(implementation)
+  public func load<T: ConvertibleFromBytes>(
+    fromByteOffset offset: Int,
+    as type: T.Type
+  ) -> T {
+    unsafe unsafeLoadUnaligned(fromByteOffset: offset, as: T.self)
+  }
+
+  /// Returns a value constructed from the raw memory at the specified offset.
+  ///
+  /// The range of bytes required to construct a value of type `T` starting at
+  /// `offset` must be completely within the span.
+  /// `offset` is not required to be aligned for `T`.
+  ///
+  /// - Parameters:
+  ///   - offset: The offset from the beginning of this span, in bytes.
+  ///     `offset` must be nonnegative.
+  ///   - type: The type of the instance to create.
+  ///   - byteOrder: The order in which the bytes will be decoded.
+  /// - Returns: A new value of type `T`, read from `offset`.
+  @export(implementation)
+  public func load<T: ConvertibleFromBytes & FixedWidthInteger>(
+    fromByteOffset offset: Int,
+    as type: T.Type,
+    _ byteOrder: ByteOrder
+  ) -> T {
+    let rawValue = load(fromByteOffset: offset, as: T.self)
+    return switch byteOrder {
+    case .bigEndian: rawValue.bigEndian
+    case .littleEndian: rawValue.littleEndian
+    }
+  }
+}
+
+// MARK: - identity
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedRawSpan {
+
+  /// Returns a Boolean value indicating whether two instances refer to the
+  /// same memory region.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  public func isIdentical(to other: Self) -> Bool {
+    unsafe (self._pointer == other._pointer) && (self._count == other._count)
+  }
+
+  /// Returns a Boolean value indicating whether two instances refer to the
+  /// same memory region.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  public func isTriviallyIdentical(to other: Self) -> Bool {
+    unsafe (self._pointer == other._pointer) && (self._count == other._count)
+  }
+
+  /// Returns the byte offsets within this span where the memory represented
+  /// by `other` is located, or `nil` if `other` is not located within this
+  /// span.
+  ///
+  /// - Parameters:
+  ///   - other: a span that may be a subrange of `self`
+  /// - Returns: A range of byte offsets within `self`, or `nil`.
+  @export(implementation)
+  public func byteOffsets(of other: borrowing Self) -> Range<Int>? {
+    if other._count > _count { return nil }
+    guard let spanStart = unsafe other._pointer, _count > 0 else {
+      return unsafe _pointer == other._pointer ? 0..<0 : nil
+    }
+    let start = unsafe _start()
+    let spanEnd = unsafe spanStart + other._count
+    if unsafe spanStart < start || (start + _count) < spanEnd { return nil }
+    let lower = unsafe start.distance(to: spanStart)
+    return unsafe Range(_uncheckedBounds: (lower, lower &+ other._count))
+  }
+}
+
+// MARK: - usage hints
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedRawSpan {
+
+  @export(implementation)
+  @available(*, unavailable, renamed: "extracting(_:)")
+  public subscript(bounds: Range<Int>) -> Self {
+    Builtin.unreachable()
+  }
+
+  @export(implementation)
+  @available(*, unavailable, renamed: "extracting(_:)")
+  public subscript(bounds: some RangeExpression<Int>) -> Self {
+    Builtin.unreachable()
+  }
+
+  @export(implementation)
+  @available(*, unavailable, renamed: "extracting(_:)")
+  public subscript(bounds: UnboundedRange) -> Self {
+    Builtin.unreachable()
+  }
+
+  @export(implementation)
+  @available(*, unavailable, renamed: "extracting(first:)")
+  public func prefix(_ maxLength: Int) -> Self {
+    Builtin.unreachable()
+  }
+
+  @export(implementation)
+  @available(*, unavailable, renamed: "extracting(last:)")
+  public func suffix(_ maxLength: Int) -> Self {
+    Builtin.unreachable()
+  }
+
+  @export(implementation)
+  @available(*, unavailable, renamed: "extracting(droppingFirst:)")
+  public func dropFirst(_ k: Int = 1) -> Self {
+    Builtin.unreachable()
+  }
+
+  @export(implementation)
+  @available(*, unavailable, renamed: "extracting(droppingLast:)")
+  public func dropLast(_ k: Int = 1) -> Self {
+    Builtin.unreachable()
+  }
+}
+
+// MARK: - description
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedRawSpan {
+  @export(implementation)
+  public var _description: String {
+    let addr = unsafe String(
+      UInt(bitPattern: _pointer), radix: 16, uppercase: false
+    )
+    return "(0x\(addr), \(_count))"
+  }
+}
+
+// MARK: - Iterable
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedRawSpan: Iterable {
+  @available(SwiftStdlib 6.5, *)
+  public typealias Failure = Never
+
+  @export(implementation)
+  public var underestimatedCount: Int {
+    self.byteCount
+  }
+
+  @available(SwiftStdlib 6.5, *)
+  @export(implementation)
+  @_lifetime(borrow self)
+  public func makeBorrowingIterator() -> AliasedSpan<UInt8>.BorrowingIterator {
+    .init(AliasedSpan(viewing: self))
+  }
+}
+
+// MARK: - conversions to and from `RawSpan`
+
+@available(SwiftStdlib 6.5, *)
+extension RawSpan {
+
+  /// An aliased raw span referencing the same bytes as this raw span.
+  ///
+  /// This conversion is always safe: `AliasedRawSpan` makes strictly fewer
+  /// assumptions about the storage than `RawSpan` does.
+  @export(implementation)
+  @_transparent
+  public var aliased: AliasedRawSpan {
+    @_lifetime(copy self)
+    get {
+      let result = unsafe AliasedRawSpan(
+        _unchecked: _pointer, byteCount: _count
+      )
+      return unsafe _overrideLifetime(result, copying: self)
+    }
+  }
+}
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedRawSpan {
+
+  /// A raw span referencing the same bytes as this aliased raw span.
+  ///
+  /// Retrieving a `RawSpan` from an `AliasedRawSpan` is an unsafe operation,
+  /// because one must ensure that the underlying storage is not modified by
+  /// any code while the span (or any copy derived from it) is in use.
+  @unsafe
+  @export(implementation)
+  @_transparent
+  public var rawSpan: RawSpan {
+    @_lifetime(copy self)
+    get {
+      let result = unsafe RawSpan(_unchecked: _pointer, byteCount: _count)
+      return unsafe _overrideLifetime(result, copying: self)
+    }
+  }
+}

--- a/stdlib/public/core/Span/AliasedSpan.swift
+++ b/stdlib/public/core/Span/AliasedSpan.swift
@@ -1,0 +1,936 @@
+//===--- AliasedSpan.swift ------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// `AliasedSpan<Element>` represents a contiguous region of memory which
+/// contains initialized instances of `Element`, and which may be aliased
+/// by other references to the same memory.
+///
+/// Like `Span`, an `AliasedSpan` instance is a non-owning, non-escaping view
+/// into memory. When an `AliasedSpan` is created, it inherits the lifetime of
+/// the container owning the contiguous memory, ensuring temporal safety and
+/// avoiding use-after-free errors. Operations on `AliasedSpan` are
+/// bounds-checked, ensuring spatial safety and avoiding buffer overflow errors.
+///
+/// Unlike `Span`, an `AliasedSpan` does not rely on the Law of Exclusivity:
+/// the memory it references may be modified through some other reference
+/// while this span is alive. To remain memory-safe in the presence of such
+/// aliases, every read produces an independent copy of the element rather
+/// than a borrow of the storage. That has two consequences:
+///
+/// * `Element` must be `Copyable`, and
+/// * accesses are more expensive than the corresponding accesses on `Span`.
+///
+/// Use `AliasedSpan` only when aliasing genuinely cannot be ruled out, such
+/// as for shared memory or memory that is also reachable from C or C++ code.
+/// Prefer `Span` everywhere else.
+@frozen
+@safe
+@available(SwiftStdlib 6.5, *)
+public struct AliasedSpan<Element>: ~Escapable, Copyable, BitwiseCopyable {
+
+  /// The starting address of this `AliasedSpan`.
+  ///
+  /// If `_count` is zero, `_pointer` may point to valid memory or it may be
+  /// `nil`, but no accesses may be performed through it. Otherwise, `_pointer`
+  /// must point to initialized memory containing `_count` instances of
+  /// `Element`, which must remain valid and initialized for the lifetime of
+  /// this `AliasedSpan`. Unlike `Span`, the memory *may* be mutated during
+  /// that lifetime.
+  @usableFromInline
+  internal let _pointer: UnsafeRawPointer?
+
+  @unsafe
+  @export(implementation)
+  @inline(__always)
+  internal func _start() -> UnsafeRawPointer {
+    unsafe _pointer._unsafelyUnwrappedUnchecked
+  }
+
+  /// The number of elements in this `AliasedSpan`.
+  @usableFromInline
+  internal let _count: Int
+
+  /// Create an empty span.
+  @export(implementation)
+  @inline(__always)
+  @_lifetime(immortal)
+  public init() {
+    unsafe _pointer = nil
+    _count = 0
+  }
+
+  @unsafe
+  @export(implementation)
+  @inline(__always)
+  @_lifetime(borrow pointer)
+  @_disfavoredOverload
+  internal init(
+    _unchecked pointer: UnsafeRawPointer?,
+    count: Int
+  ) {
+    unsafe _pointer = pointer
+    _count = count
+  }
+
+  @unsafe
+  @export(implementation)
+  @_transparent
+  @_lifetime(borrow pointer)
+  internal init(
+    _unchecked pointer: UnsafePointer<Element>,
+    count: Int
+  ) {
+    unsafe _pointer = UnsafeRawPointer(pointer)
+    _count = count
+  }
+}
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedSpan: @unchecked Sendable
+where Element: Sendable & FullyInhabited {}
+
+// MARK: - unsafe construction
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedSpan {
+
+  /// Unsafely create an `AliasedSpan` over initialized memory.
+  ///
+  /// The memory in `buffer` must remain valid and initialized throughout the
+  /// lifetime of the newly-created `AliasedSpan`. Unlike `Span`, the memory
+  /// is *not* required to be immutable: other references may modify it.
+  /// Failure to maintain this invariant results in undefined behaviour.
+  ///
+  /// - Parameters:
+  ///   - buffer: an `UnsafeBufferPointer` to initialized elements.
+  @unsafe
+  @export(implementation)
+  @_lifetime(borrow buffer)
+  public init(_unsafeElements buffer: UnsafeBufferPointer<Element>) {
+    _precondition(
+      buffer._isWellAligned(),
+      "baseAddress must be properly aligned to access Element"
+    )
+    let span = unsafe AliasedSpan(
+      _unchecked: UnsafeRawPointer(buffer.baseAddress), count: buffer.count
+    )
+    // As a trivial value, 'baseAddress' does not formally depend on the
+    // lifetime of 'buffer'. Make the dependence explicit.
+    self = unsafe _overrideLifetime(span, borrowing: buffer)
+  }
+
+  /// Unsafely create an `AliasedSpan` over initialized memory.
+  ///
+  /// The memory in `buffer` must remain valid and initialized throughout the
+  /// lifetime of the newly-created `AliasedSpan`.
+  /// Failure to maintain this invariant results in undefined behaviour.
+  ///
+  /// - Parameters:
+  ///   - buffer: an `UnsafeMutableBufferPointer` to initialized elements.
+  @unsafe
+  @export(implementation)
+  @_lifetime(borrow buffer)
+  public init(_unsafeElements buffer: UnsafeMutableBufferPointer<Element>) {
+    let span = unsafe AliasedSpan(
+      _unsafeElements: UnsafeBufferPointer(buffer)
+    )
+    self = unsafe _overrideLifetime(span, borrowing: buffer)
+  }
+
+  /// Unsafely create an `AliasedSpan` over initialized memory.
+  ///
+  /// The region of memory representing `count` instances starting at `pointer`
+  /// must remain valid and initialized throughout the lifetime of the
+  /// newly-created `AliasedSpan`.
+  /// Failure to maintain this invariant results in undefined behaviour.
+  ///
+  /// - Parameters:
+  ///   - pointer: a pointer to the first initialized element.
+  ///   - count: the number of initialized elements in the span.
+  @unsafe
+  @export(implementation)
+  @_lifetime(borrow pointer)
+  public init(_unsafeStart pointer: UnsafePointer<Element>, count: Int) {
+    _precondition(count >= 0, "Count must not be negative")
+    let buffer = unsafe UnsafeBufferPointer(start: pointer, count: count)
+    let span = unsafe AliasedSpan(_unsafeElements: buffer)
+    self = unsafe _overrideLifetime(span, borrowing: pointer)
+  }
+
+  /// Unsafely create an `AliasedSpan` over initialized memory.
+  ///
+  /// The memory in `buffer` must remain valid and initialized throughout the
+  /// lifetime of the newly-created `AliasedSpan`.
+  ///
+  /// - Parameters:
+  ///   - buffer: an `UnsafeBufferPointer` to initialized elements.
+  @unsafe
+  @export(implementation)
+  @_lifetime(borrow buffer)
+  public init(
+    _unsafeElements buffer: borrowing Slice<UnsafeBufferPointer<Element>>
+  ) {
+    let rebased = unsafe UnsafeBufferPointer(rebasing: buffer)
+    let span = unsafe AliasedSpan(_unsafeElements: rebased)
+    self = unsafe _overrideLifetime(span, borrowing: buffer)
+  }
+
+  /// Unsafely create an `AliasedSpan` over initialized memory.
+  ///
+  /// The memory in `buffer` must remain valid and initialized throughout the
+  /// lifetime of the newly-created `AliasedSpan`.
+  ///
+  /// - Parameters:
+  ///   - buffer: an `UnsafeMutableBufferPointer` to initialized elements.
+  @unsafe
+  @export(implementation)
+  @_lifetime(borrow buffer)
+  public init(
+    _unsafeElements buffer: borrowing Slice<UnsafeMutableBufferPointer<Element>>
+  ) {
+    let rebased = unsafe UnsafeBufferPointer(rebasing: buffer)
+    let span = unsafe AliasedSpan(_unsafeElements: rebased)
+    self = unsafe _overrideLifetime(span, borrowing: buffer)
+  }
+}
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedSpan where Element: BitwiseCopyable {
+
+  /// Unsafely create an `AliasedSpan` over initialized memory.
+  ///
+  /// `buffer` must be correctly aligned for accessing an element of type
+  /// `Element`, and must contain a number of bytes that is an exact multiple
+  /// of `Element`'s stride.
+  ///
+  /// - Parameters:
+  ///   - buffer: a buffer of initialized elements.
+  @unsafe
+  @export(implementation)
+  @_lifetime(borrow buffer)
+  public init(_unsafeBytes buffer: UnsafeRawBufferPointer) {
+    let baseAddress = buffer.baseAddress
+    _precondition(
+      ((Int(bitPattern: baseAddress) &
+        (MemoryLayout<Element>.alignment &- 1)) == 0),
+      "baseAddress must be properly aligned to access Element"
+    )
+    let (byteCount, stride) = (buffer.count, MemoryLayout<Element>.stride)
+    let (count, remainder) = byteCount.quotientAndRemainder(dividingBy: stride)
+    _precondition(
+      remainder == 0, "Span must contain a whole number of elements"
+    )
+    let span = unsafe AliasedSpan(_unchecked: baseAddress, count: count)
+    self = unsafe _overrideLifetime(span, borrowing: buffer)
+  }
+
+  /// Unsafely create an `AliasedSpan` over initialized memory.
+  ///
+  /// - Parameters:
+  ///   - buffer: a buffer of initialized elements.
+  @unsafe
+  @export(implementation)
+  @_lifetime(borrow buffer)
+  public init(_unsafeBytes buffer: UnsafeMutableRawBufferPointer) {
+    let span = unsafe AliasedSpan(
+      _unsafeBytes: UnsafeRawBufferPointer(buffer)
+    )
+    self = unsafe _overrideLifetime(span, borrowing: buffer)
+  }
+
+  /// Unsafely create an `AliasedSpan` over initialized memory.
+  ///
+  /// `pointer` must be correctly aligned for accessing an element of type
+  /// `Element`, and `byteCount` must be an exact multiple of `Element`'s
+  /// stride.
+  ///
+  /// - Parameters:
+  ///   - pointer: a pointer to the first initialized element.
+  ///   - byteCount: the number of bytes in the span.
+  @unsafe
+  @export(implementation)
+  @_lifetime(borrow pointer)
+  public init(_unsafeStart pointer: UnsafeRawPointer, byteCount: Int) {
+    _precondition(byteCount >= 0, "Count must not be negative")
+    let buffer = unsafe UnsafeRawBufferPointer(
+      start: pointer, count: byteCount
+    )
+    let span = unsafe AliasedSpan(_unsafeBytes: buffer)
+    self = unsafe _overrideLifetime(span, borrowing: pointer)
+  }
+}
+
+// MARK: - conversion from raw spans
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedSpan where Element: ConvertibleFromBytes {
+
+  /// View initialized raw memory as a typed span.
+  ///
+  /// The `byteCount` of `bytes` must be a multiple of `Element`'s stride,
+  /// and the starting address of `bytes` must be well-aligned for the type
+  /// of `Element`. If either of these requirements is not met, this
+  /// initializer will trap at runtime.
+  ///
+  /// - Parameters:
+  ///   - bytes: An existing `AliasedRawSpan`, which will define both this
+  ///            span's lifetime and the memory it represents.
+  @export(implementation)
+  @_lifetime(copy bytes)
+  public init(viewing bytes: AliasedRawSpan) {
+    let buffer = unsafe UnsafeRawBufferPointer(
+      start: bytes._pointer, count: bytes.byteCount
+    )
+    let span = unsafe AliasedSpan(_unsafeBytes: buffer)
+    self = unsafe _overrideLifetime(span, copying: bytes)
+  }
+}
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedSpan where Element == UInt8 {
+
+  /// View initialized raw memory as a span of bytes.
+  ///
+  /// - Parameters:
+  ///   - bytes: An existing `AliasedRawSpan`, which will define both this
+  ///            span's lifetime and the memory it represents.
+  @export(implementation)
+  @_lifetime(copy bytes)
+  public init(viewing bytes: AliasedRawSpan) {
+    let span = unsafe Self(_unchecked: bytes._pointer, count: bytes._count)
+    self = unsafe _overrideLifetime(span, copying: bytes)
+  }
+}
+
+// MARK: - basic properties
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedSpan {
+
+  /// The number of elements in the span.
+  ///
+  /// To check whether the span is empty, use its `isEmpty` property
+  /// instead of comparing `count` to zero.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_semantics("fixed_storage.get_count")
+  public var count: Int { _assumeNonNegative(_count) }
+
+  /// A Boolean value indicating whether the span is empty.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_transparent
+  public var isEmpty: Bool { _count == 0 }
+
+  /// The representation for an index in `AliasedSpan`.
+  public typealias Index = Int
+
+  /// The indices that are valid for subscripting the span, in ascending
+  /// order.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  public var indices: Range<Index> {
+    unsafe Range(_uncheckedBounds: (0, count))
+  }
+}
+
+// MARK: - element access
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedSpan {
+  // SILOptimizer looks for fixed_storage.check_index semantics for bounds
+  // check optimizations.
+  @_semantics("fixed_storage.check_index")
+  @inline(__always)
+  @export(implementation)
+  internal func _checkIndex(_ position: Index) {
+    _precondition(indices.contains(position), "Index out of bounds")
+  }
+
+  /// Accesses a copy of the element at the specified index in the span.
+  ///
+  /// Unlike `Span`, this subscript copies the element out of the underlying
+  /// storage. The copy ensures that the returned value remains valid even if
+  /// another reference to the same storage replaces the element while the
+  /// result of this access is still in use.
+  ///
+  /// - Parameter position: The offset of the element to access. `position`
+  ///     must be greater or equal to zero, and less than `count`.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  public subscript(_ position: Index) -> Element {
+    @_transparent
+    get {
+      _checkIndex(position)
+      return unsafe self[unchecked: position]
+    }
+  }
+
+  /// Accesses a copy of the element at the specified index in the span.
+  ///
+  /// This subscript does not validate `position`. Using this subscript
+  /// with an invalid `position` results in undefined behaviour.
+  ///
+  /// - Parameter position: The offset of the element to access. `position`
+  ///     must be greater or equal to zero, and less than `count`.
+  ///
+  /// - Complexity: O(1)
+  @unsafe
+  @export(implementation)
+  public subscript(unchecked position: Index) -> Element {
+    get {
+      unsafe UnsafePointer<Element>(
+        _unsafeAddressOfElement(unchecked: position)
+      ).pointee
+    }
+  }
+
+  @unsafe
+  @export(implementation)
+  @_transparent
+  internal func _unsafeAddressOfElement(
+    unchecked position: Index
+  ) -> Builtin.RawPointer {
+#if $BuiltinGepProjection
+    unsafe Builtin.gepProjection_Word(
+      _start()._rawValue, position._builtinWordValue, Element.self
+    )
+#else
+    let elementOffset = position &* MemoryLayout<Element>.stride
+    return unsafe _start().advanced(by: elementOffset)._rawValue
+#endif
+  }
+}
+
+// MARK: - bytes
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedSpan where Element: ConvertibleToBytes {
+
+  /// A raw span over the memory represented by this span.
+  ///
+  /// - Returns: An `AliasedRawSpan` over the memory represented by this span.
+  @export(implementation)
+  @_transparent
+  public var bytes: AliasedRawSpan {
+    @_lifetime(copy self)
+    get {
+      AliasedRawSpan(elements: self)
+    }
+  }
+}
+
+// MARK: - sub-spans
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedSpan {
+
+  /// Constructs a new span over the items within the supplied range of
+  /// indices within this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter bounds: A valid range of indices. Every index in
+  ///     this range must be within the bounds of this span.
+  ///
+  /// - Returns: An `AliasedSpan` over the items within `bounds`.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(_ bounds: Range<Index>) -> Self {
+    _precondition(
+      UInt(bitPattern: bounds.lowerBound) <= UInt(bitPattern: _count) &&
+      UInt(bitPattern: bounds.upperBound) <= UInt(bitPattern: _count),
+      "Index range out of bounds"
+    )
+    return unsafe extracting(unchecked: bounds)
+  }
+
+  /// Constructs a new span over the items within the supplied range of
+  /// indices within this span.
+  ///
+  /// This function does not validate `bounds`; this is an unsafe operation.
+  ///
+  /// - Parameter bounds: A valid range of indices. Every index in
+  ///     this range must be within the bounds of this span.
+  ///
+  /// - Returns: An `AliasedSpan` over the items within `bounds`.
+  ///
+  /// - Complexity: O(1)
+  @unsafe
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(unchecked bounds: Range<Index>) -> Self {
+    let delta = bounds.lowerBound &* MemoryLayout<Element>.stride
+    let newStart = unsafe _pointer?.advanced(by: delta)
+    let newSpan = unsafe Self(_unchecked: newStart, count: bounds.count)
+    return unsafe _overrideLifetime(newSpan, copying: self)
+  }
+
+  /// Constructs a new span over the items within the supplied range of
+  /// indices within this span.
+  ///
+  /// - Parameter bounds: A valid range of indices. Every index in
+  ///     this range must be within the bounds of this span.
+  ///
+  /// - Returns: An `AliasedSpan` over the items within `bounds`.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(_ bounds: some RangeExpression<Index>) -> Self {
+    extracting(bounds.relative(to: indices))
+  }
+
+  /// Constructs a new span over the items within the supplied range of
+  /// indices within this span.
+  ///
+  /// This function does not validate `bounds`; this is an unsafe operation.
+  ///
+  /// - Parameter bounds: A valid range of indices. Every index in
+  ///     this range must be within the bounds of this span.
+  ///
+  /// - Returns: An `AliasedSpan` over the items within `bounds`.
+  ///
+  /// - Complexity: O(1)
+  @unsafe
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(unchecked bounds: ClosedRange<Index>) -> Self {
+    let range = unsafe Range(
+      _uncheckedBounds: (bounds.lowerBound, bounds.upperBound + 1)
+    )
+    return unsafe extracting(unchecked: range)
+  }
+
+  /// Constructs a new span over all the items of this span.
+  ///
+  /// - Returns: An `AliasedSpan` over all the items of this span.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(_: UnboundedRange) -> Self {
+    self
+  }
+}
+
+// MARK: - prefixes and suffixes
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedSpan {
+
+  /// Returns a span containing the initial elements of this span,
+  /// up to the specified maximum length.
+  ///
+  /// If the maximum length exceeds the length of this span,
+  /// the result contains all the elements.
+  ///
+  /// - Parameter maxLength: The maximum number of elements to return.
+  ///   `maxLength` must be greater than or equal to zero.
+  /// - Returns: A span with at most `maxLength` elements.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(first maxLength: Int) -> Self {
+    _precondition(maxLength >= 0, "Can't have a prefix of negative length")
+    let newCount = min(maxLength, count)
+    let newSpan = unsafe Self(_unchecked: _pointer, count: newCount)
+    return unsafe _overrideLifetime(newSpan, copying: self)
+  }
+
+  /// Returns a span over all but the given number of trailing elements.
+  ///
+  /// If the number of elements to drop exceeds the number of elements in
+  /// the span, the result is an empty span.
+  ///
+  /// - Parameter k: The number of elements to drop off the end of
+  ///   the span. `k` must be greater than or equal to zero.
+  /// - Returns: A span leaving off the specified number of elements at the
+  ///   end.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(droppingLast k: Int) -> Self {
+    _precondition(k >= 0, "Can't drop a negative number of elements")
+    let droppedCount = min(k, count)
+    let newSpan = unsafe Self(
+      _unchecked: _pointer, count: count &- droppedCount
+    )
+    return unsafe _overrideLifetime(newSpan, copying: self)
+  }
+
+  /// Returns a span containing the trailing elements of the span,
+  /// up to the given maximum length.
+  ///
+  /// If the maximum length exceeds the length of this span,
+  /// the result contains all the elements.
+  ///
+  /// - Parameter maxLength: The maximum number of elements to return.
+  ///   `maxLength` must be greater than or equal to zero.
+  /// - Returns: A span with at most `maxLength` elements.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(last maxLength: Int) -> Self {
+    _precondition(maxLength >= 0, "Can't have a suffix of negative length")
+    let newCount = min(maxLength, count)
+    let offset = (count &- newCount) &* MemoryLayout<Element>.stride
+    let newStart = unsafe _pointer?.advanced(by: offset)
+    let newSpan = unsafe Self(_unchecked: newStart, count: newCount)
+    return unsafe _overrideLifetime(newSpan, copying: self)
+  }
+
+  /// Returns a span over all but the given number of initial elements.
+  ///
+  /// If the number of elements to drop exceeds the number of elements in
+  /// the span, the result is an empty span.
+  ///
+  /// - Parameter k: The number of elements to drop from the beginning of
+  ///   the span. `k` must be greater than or equal to zero.
+  /// - Returns: A span starting after the specified number of elements.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  @_lifetime(copy self)
+  public func extracting(droppingFirst k: Int) -> Self {
+    _precondition(k >= 0, "Can't drop a negative number of elements")
+    let droppedCount = min(k, count)
+    let offset = droppedCount &* MemoryLayout<Element>.stride
+    let newStart = unsafe _pointer?.advanced(by: offset)
+    let newCount = count &- droppedCount
+    let newSpan = unsafe Self(_unchecked: newStart, count: newCount)
+    return unsafe _overrideLifetime(newSpan, copying: self)
+  }
+}
+
+// MARK: - UnsafeBufferPointer access hatch
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedSpan {
+
+  /// Calls a closure with a pointer to the viewed contiguous storage.
+  ///
+  /// The buffer pointer passed as an argument to `body` is valid only
+  /// during the execution of `withUnsafeBufferPointer(_:)`.
+  /// Do not store or return the pointer for later use.
+  ///
+  /// - Note: Because the storage may be aliased, its contents may change
+  ///   while `body` is executing. Values read through `buffer` must be
+  ///   copied before they are used across any operation that could write
+  ///   through another alias.
+  ///
+  /// - Parameter body: A closure with an `UnsafeBufferPointer` parameter
+  ///   that points to the viewed contiguous storage.
+  /// - Returns: The return value of the `body` closure parameter.
+  @export(implementation)
+  @_transparent
+  @safe
+  public func withUnsafeBufferPointer<E: Error, Result: ~Copyable>(
+    _ body: (_ buffer: UnsafeBufferPointer<Element>) throws(E) -> Result
+  ) throws(E) -> Result {
+    let bytes = unsafe UnsafeRawBufferPointer(
+      start: _pointer, count: _count &* MemoryLayout<Element>.stride
+    )
+    return try unsafe bytes.withMemoryRebound(to: Element.self) {
+      buffer throws(E) -> Result in
+      try unsafe body(buffer)
+    }
+  }
+}
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedSpan where Element: BitwiseCopyable {
+
+  /// Calls the given closure with a pointer to the underlying bytes of
+  /// the viewed contiguous storage.
+  ///
+  /// The buffer pointer passed as an argument to `body` is valid only
+  /// during the execution of `withUnsafeBytes(_:)`.
+  /// Do not store or return the pointer for later use.
+  ///
+  /// - Note: Because the storage may be aliased, its contents may change
+  ///   while `body` is executing.
+  ///
+  /// - Parameter body: A closure with an `UnsafeRawBufferPointer`
+  ///   parameter that points to the viewed contiguous storage.
+  /// - Returns: The return value of the `body` closure parameter.
+  @export(implementation)
+  @_transparent
+  @safe
+  public func withUnsafeBytes<E: Error, Result: ~Copyable>(
+    _ body: (_ buffer: UnsafeRawBufferPointer) throws(E) -> Result
+  ) throws(E) -> Result {
+    let bytes = unsafe UnsafeRawBufferPointer(
+      start: _pointer, count: _count &* MemoryLayout<Element>.stride
+    )
+    return try unsafe body(bytes)
+  }
+}
+
+// MARK: - identity
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedSpan {
+
+  /// Returns a Boolean value indicating whether two instances refer to the
+  /// same memory region.
+  ///
+  /// - Parameter other: A span to compare with this one.
+  /// - Returns: Whether `self` and `other` reference the same region
+  ///     in memory.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  public func isIdentical(to other: Self) -> Bool {
+    unsafe (self._pointer == other._pointer) && (self._count == other._count)
+  }
+
+  /// Returns a Boolean value indicating whether two instances refer to the
+  /// same memory region.
+  ///
+  /// - Parameter other: A span to compare with this one.
+  /// - Returns: Whether `self` and `other` reference the same region
+  ///     in memory.
+  ///
+  /// - Complexity: O(1)
+  @export(implementation)
+  public func isTriviallyIdentical(to other: Self) -> Bool {
+    unsafe (self._pointer == other._pointer) && (self._count == other._count)
+  }
+
+  /// Returns the indices within this span where the memory represented
+  /// by `other` is located, or `nil` if `other` is not located within this
+  /// span.
+  ///
+  /// - Parameters:
+  ///   - other: a span that may be a subrange of `self`
+  /// - Returns: A range of indices within `self`, or `nil`.
+  @export(implementation)
+  public func indices(of other: borrowing Self) -> Range<Index>? {
+    if other._count > _count { return nil }
+    guard let spanStart = unsafe other._pointer, _count > 0 else {
+      return unsafe _pointer == other._pointer ? 0..<0 : nil
+    }
+    let start = unsafe _start()
+    let stride = MemoryLayout<Element>.stride
+    let spanEnd = unsafe spanStart + stride &* other._count
+    if unsafe spanStart < start || spanEnd > (start + stride &* _count) {
+      return nil
+    }
+    let byteOffset = unsafe start.distance(to: spanStart)
+    let (lower, r) = byteOffset.quotientAndRemainder(dividingBy: stride)
+    guard r == 0 else { return nil }
+    return unsafe Range(_uncheckedBounds: (lower, lower &+ other._count))
+  }
+}
+
+// MARK: - usage hints
+//
+// `AliasedSpan` is not a `Collection`. We add the following unavailable
+// members to redirect users who reach for the `Collection` slicing API
+// towards the corresponding `extracting(...)` function.
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedSpan {
+
+  @export(implementation)
+  @available(*, unavailable, renamed: "extracting(_:)")
+  public subscript(bounds: Range<Index>) -> Self {
+    Builtin.unreachable()
+  }
+
+  @export(implementation)
+  @available(*, unavailable, renamed: "extracting(_:)")
+  public subscript(bounds: some RangeExpression<Index>) -> Self {
+    Builtin.unreachable()
+  }
+
+  @export(implementation)
+  @available(*, unavailable, renamed: "extracting(_:)")
+  public subscript(bounds: UnboundedRange) -> Self {
+    Builtin.unreachable()
+  }
+
+  @export(implementation)
+  @available(*, unavailable, renamed: "extracting(first:)")
+  public func prefix(_ maxLength: Int) -> Self {
+    Builtin.unreachable()
+  }
+
+  @export(implementation)
+  @available(*, unavailable, renamed: "extracting(last:)")
+  public func suffix(_ maxLength: Int) -> Self {
+    Builtin.unreachable()
+  }
+
+  @export(implementation)
+  @available(*, unavailable, renamed: "extracting(droppingFirst:)")
+  public func dropFirst(_ k: Int = 1) -> Self {
+    Builtin.unreachable()
+  }
+
+  @export(implementation)
+  @available(*, unavailable, renamed: "extracting(droppingLast:)")
+  public func dropLast(_ k: Int = 1) -> Self {
+    Builtin.unreachable()
+  }
+}
+
+// MARK: - description
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedSpan {
+  @export(implementation)
+  public var _description: String {
+    let addr = unsafe String(
+      UInt(bitPattern: _pointer), radix: 16, uppercase: false
+    )
+    return "(0x\(addr), \(_count))"
+  }
+}
+
+// MARK: - Iterable
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedSpan {
+
+  /// An iterator over the elements of an `AliasedSpan`.
+  ///
+  /// Because the underlying storage may be modified through another alias
+  /// while iteration is in progress, this iterator cannot vend a `Span`
+  /// directly over that storage. Instead it copies elements into storage it
+  /// owns and vends a `Span` over the copies, in the same manner as the
+  /// borrowing iterator of an arbitrary `Sequence`.
+  @frozen
+  @available(SwiftStdlib 6.5, *)
+  public struct BorrowingIterator
+  : BorrowingIteratorProtocol, ~Copyable, ~Escapable {
+    @usableFromInline
+    internal let _span: AliasedSpan<Element>
+
+    @usableFromInline
+    internal var _position: Int
+
+    /// Storage for the element that the most recent call to `nextSpan`
+    /// vended a span over.
+    @usableFromInline
+    internal var _buffered: Element?
+
+    @available(SwiftStdlib 6.5, *)
+    public typealias Failure = Never
+
+    @available(SwiftStdlib 6.5, *)
+    @_lifetime(copy elements)
+    @inlinable
+    public init(_ elements: AliasedSpan<Element>) {
+      _span = elements
+      _position = 0
+      _buffered = nil
+    }
+
+    @available(SwiftStdlib 6.5, *)
+    @export(implementation)
+    @_lifetime(&self)
+    @_lifetime(self: copy self)
+    public mutating func nextSpan(maxCount: Int) -> Span<Element> {
+      _precondition(maxCount >= 0, "Can't have a prefix of negative length")
+      guard maxCount > 0, _position < _span.count else {
+        _buffered = nil
+        return Span()
+      }
+      _buffered = unsafe _span[unchecked: _position]
+      _position &+= 1
+      return _buffered._span()
+    }
+
+    @available(SwiftStdlib 6.5, *)
+    @export(implementation)
+    @_lifetime(self: copy self)
+    public mutating func skip(by maxOffset: Int) -> Int {
+      _precondition(maxOffset >= 0, "Can't skip by a negative offset")
+      let c = Swift.min(maxOffset, _span.count &- _position)
+      _position &+= c
+      return c
+    }
+  }
+}
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedSpan: Iterable {
+  @available(SwiftStdlib 6.5, *)
+  public typealias Failure = Never
+
+  @export(implementation)
+  public var underestimatedCount: Int {
+    self.count
+  }
+
+  @available(SwiftStdlib 6.5, *)
+  @export(implementation)
+  @_lifetime(borrow self)
+  public func makeBorrowingIterator() -> BorrowingIterator {
+    .init(self)
+  }
+}
+
+// MARK: - conversions to and from `Span`
+
+@available(SwiftStdlib 6.5, *)
+extension Span {
+
+  /// An aliased span referencing the same storage as this span.
+  ///
+  /// This conversion is always safe: `AliasedSpan` makes strictly fewer
+  /// assumptions about the storage than `Span` does.
+  @export(implementation)
+  @_transparent
+  public var aliased: AliasedSpan<Element> {
+    @_lifetime(copy self)
+    get {
+      let result = unsafe AliasedSpan<Element>(
+        _unchecked: _pointer, count: _count
+      )
+      return unsafe _overrideLifetime(result, copying: self)
+    }
+  }
+}
+
+@available(SwiftStdlib 6.5, *)
+extension AliasedSpan {
+
+  /// A span referencing the same storage as this aliased span.
+  ///
+  /// Retrieving a `Span` from an `AliasedSpan` is an unsafe operation,
+  /// because one must ensure that the underlying storage is not modified by
+  /// any code while the span (or any copy derived from it) is in use.
+  @unsafe
+  @export(implementation)
+  @_transparent
+  public var span: Span<Element> {
+    @_lifetime(copy self)
+    get {
+      let result = unsafe Span<Element>(_unchecked: _pointer, count: _count)
+      return unsafe _overrideLifetime(result, copying: self)
+    }
+  }
+}

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1349,3 +1349,58 @@ Added: _$sSs9UTF16ViewV13_copyContents12initializings16IndexingIteratorVyABG_Sit
 // Changing the ABI of _SwiftCreateBridgedString
 Removed: _$ss35_SwiftCreateBridgedString_DoNotCall5bytes6length8encodings9UnmanagedVyyXlGSPys5UInt8VG_Sis6UInt32VtF
 Added: _$ss35_SwiftCreateBridgedString_DoNotCall5bytes6length8encodings9UnmanagedVyyXlGSgSPys5UInt8VG_Sis6UInt32VtF
+
+// struct AliasedSpan
+Added: _$ss11AliasedSpanVMa
+Added: _$ss11AliasedSpanVMn
+Added: _$ss11AliasedSpanV6_countSivg
+Added: _$ss11AliasedSpanV8_pointerSVSgvg
+Added: _$ss11AliasedSpanVyxGs8IterablesMc
+
+// struct AliasedSpan.BorrowingIterator
+Added: _$ss11AliasedSpanV17BorrowingIteratorVMa
+Added: _$ss11AliasedSpanV17BorrowingIteratorVMn
+Added: _$ss11AliasedSpanV17BorrowingIteratorV5_spanAByxGvg
+Added: _$ss11AliasedSpanV17BorrowingIteratorV9_bufferedxSgvM
+Added: _$ss11AliasedSpanV17BorrowingIteratorV9_bufferedxSgvg
+Added: _$ss11AliasedSpanV17BorrowingIteratorV9_bufferedxSgvs
+Added: _$ss11AliasedSpanV17BorrowingIteratorV9_positionSivM
+Added: _$ss11AliasedSpanV17BorrowingIteratorV9_positionSivg
+Added: _$ss11AliasedSpanV17BorrowingIteratorV9_positionSivs
+Added: _$ss11AliasedSpanV17BorrowingIteratorVyADyx_GAByxGcfC
+Added: _$ss11AliasedSpanV17BorrowingIteratorVyx_Gs0cD8ProtocolsMc
+
+// struct AliasedMutableSpan
+Added: _$ss18AliasedMutableSpanVMa
+Added: _$ss18AliasedMutableSpanVMn
+Added: _$ss18AliasedMutableSpanV6_countSivg
+Added: _$ss18AliasedMutableSpanV8_pointerSvSgvg
+Added: _$ss18AliasedMutableSpanVyxGs8IterablesMc
+
+// struct AliasedRawSpan
+Added: _$ss14AliasedRawSpanVMa
+Added: _$ss14AliasedRawSpanVMn
+Added: _$ss14AliasedRawSpanVN
+Added: _$ss14AliasedRawSpanV6_countSivg
+Added: _$ss14AliasedRawSpanV8_pointerSVSgvg
+Added: _$ss14AliasedRawSpanVs8IterablesMc
+Added: _$ss14AliasedRawSpanVs8IterablesWP
+
+// struct AliasedMutableRawSpan
+Added: _$ss21AliasedMutableRawSpanVMa
+Added: _$ss21AliasedMutableRawSpanVMn
+Added: _$ss21AliasedMutableRawSpanVN
+Added: _$ss21AliasedMutableRawSpanV6_countSivg
+Added: _$ss21AliasedMutableRawSpanV8_pointerSvSgvg
+Added: _$ss21AliasedMutableRawSpanVs8IterablesMc
+Added: _$ss21AliasedMutableRawSpanVs8IterablesWP
+
+// struct AliasedRef
+Added: _$ss10AliasedRefVMa
+Added: _$ss10AliasedRefVMn
+Added: _$ss10AliasedRefV8_pointerSPyxGvg
+
+// struct AliasedMutableRef
+Added: _$ss17AliasedMutableRefVMa
+Added: _$ss17AliasedMutableRefVMn
+Added: _$ss17AliasedMutableRefV8_pointerSpyxGvg

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -1344,3 +1344,59 @@ Added: _$sSs9UTF16ViewV13_copyContents12initializings16IndexingIteratorVyABG_Sit
 // Changing the ABI of _SwiftCreateBridgedString
 Removed: _$ss35_SwiftCreateBridgedString_DoNotCall5bytes6length8encodings9UnmanagedVyyXlGSPys5UInt8VG_Sis6UInt32VtF
 Added: _$ss35_SwiftCreateBridgedString_DoNotCall5bytes6length8encodings9UnmanagedVyyXlGSgSPys5UInt8VG_Sis6UInt32VtF
+
+//
+// struct AliasedSpan
+Added: _$ss11AliasedSpanVMa
+Added: _$ss11AliasedSpanVMn
+Added: _$ss11AliasedSpanV6_countSivg
+Added: _$ss11AliasedSpanV8_pointerSVSgvg
+Added: _$ss11AliasedSpanVyxGs8IterablesMc
+
+// struct AliasedSpan.BorrowingIterator
+Added: _$ss11AliasedSpanV17BorrowingIteratorVMa
+Added: _$ss11AliasedSpanV17BorrowingIteratorVMn
+Added: _$ss11AliasedSpanV17BorrowingIteratorV5_spanAByxGvg
+Added: _$ss11AliasedSpanV17BorrowingIteratorV9_bufferedxSgvM
+Added: _$ss11AliasedSpanV17BorrowingIteratorV9_bufferedxSgvg
+Added: _$ss11AliasedSpanV17BorrowingIteratorV9_bufferedxSgvs
+Added: _$ss11AliasedSpanV17BorrowingIteratorV9_positionSivM
+Added: _$ss11AliasedSpanV17BorrowingIteratorV9_positionSivg
+Added: _$ss11AliasedSpanV17BorrowingIteratorV9_positionSivs
+Added: _$ss11AliasedSpanV17BorrowingIteratorVyADyx_GAByxGcfC
+Added: _$ss11AliasedSpanV17BorrowingIteratorVyx_Gs0cD8ProtocolsMc
+
+// struct AliasedMutableSpan
+Added: _$ss18AliasedMutableSpanVMa
+Added: _$ss18AliasedMutableSpanVMn
+Added: _$ss18AliasedMutableSpanV6_countSivg
+Added: _$ss18AliasedMutableSpanV8_pointerSvSgvg
+Added: _$ss18AliasedMutableSpanVyxGs8IterablesMc
+
+// struct AliasedRawSpan
+Added: _$ss14AliasedRawSpanVMa
+Added: _$ss14AliasedRawSpanVMn
+Added: _$ss14AliasedRawSpanVN
+Added: _$ss14AliasedRawSpanV6_countSivg
+Added: _$ss14AliasedRawSpanV8_pointerSVSgvg
+Added: _$ss14AliasedRawSpanVs8IterablesMc
+Added: _$ss14AliasedRawSpanVs8IterablesWP
+
+// struct AliasedMutableRawSpan
+Added: _$ss21AliasedMutableRawSpanVMa
+Added: _$ss21AliasedMutableRawSpanVMn
+Added: _$ss21AliasedMutableRawSpanVN
+Added: _$ss21AliasedMutableRawSpanV6_countSivg
+Added: _$ss21AliasedMutableRawSpanV8_pointerSvSgvg
+Added: _$ss21AliasedMutableRawSpanVs8IterablesMc
+Added: _$ss21AliasedMutableRawSpanVs8IterablesWP
+
+// struct AliasedRef
+Added: _$ss10AliasedRefVMa
+Added: _$ss10AliasedRefVMn
+Added: _$ss10AliasedRefV8_pointerSPyxGvg
+
+// struct AliasedMutableRef
+Added: _$ss17AliasedMutableRefVMa
+Added: _$ss17AliasedMutableRefVMn
+Added: _$ss17AliasedMutableRefV8_pointerSpyxGvg

--- a/test/stdlib/Span/AliasedSpanTests.swift
+++ b/test/stdlib/Span/AliasedSpanTests.swift
@@ -1,0 +1,392 @@
+//===--- AliasedSpanTests.swift -------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %target-run-stdlib-swift
+
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+var suite = TestSuite("AliasedSpan Tests")
+defer { runAllTests() }
+
+suite.test("Initialize with ordinary element")
+.require(.stdlib_6_5).code {
+  guard #available(SwiftStdlib 6.5, *) else { return }
+
+  let capacity = 4
+  let a = Array(0..<capacity)
+  a.withUnsafeBufferPointer {
+    let span = unsafe AliasedSpan(_unsafeElements: $0)
+    expectEqual(span.count, capacity)
+    expectFalse(span.isEmpty)
+    for i in span.indices {
+      expectEqual(span[i], i)
+    }
+  }
+}
+
+suite.test("isEmpty")
+.require(.stdlib_6_5).code {
+  guard #available(SwiftStdlib 6.5, *) else { return }
+
+  expectTrue(AliasedSpan<Int>().isEmpty)
+  expectEqual(AliasedSpan<Int>().count, 0)
+}
+
+suite.test("extracting sub-spans")
+.require(.stdlib_6_5).code {
+  guard #available(SwiftStdlib 6.5, *) else { return }
+
+  let capacity = 8
+  let a = Array(0..<capacity)
+  a.withUnsafeBufferPointer {
+    let span = unsafe AliasedSpan(_unsafeElements: $0)
+
+    let prefix = span.extracting(first: 3)
+    expectEqual(prefix.count, 3)
+    expectEqual(prefix[0], 0)
+    expectEqual(prefix[2], 2)
+
+    let suffix = span.extracting(last: 3)
+    expectEqual(suffix.count, 3)
+    expectEqual(suffix[0], 5)
+
+    let middle = span.extracting(2..<5)
+    expectEqual(middle.count, 3)
+    expectEqual(middle[0], 2)
+
+    expectEqual(span.extracting(droppingFirst: 2).count, 6)
+    expectEqual(span.extracting(droppingLast: 2).count, 6)
+    expectEqual(span.extracting(...).count, capacity)
+    expectEqual(span.extracting(3...).count, 5)
+
+    expectEqual(span.indices(of: middle), 2..<5)
+    expectTrue(span.extracting(...).isIdentical(to: span))
+  }
+}
+
+suite.test("Span <-> AliasedSpan round trip")
+.require(.stdlib_6_5).code {
+  guard #available(SwiftStdlib 6.5, *) else { return }
+
+  let a = [1, 2, 3, 4, 5]
+  a.withUnsafeBufferPointer {
+    let span = unsafe Span(_unsafeElements: $0)
+    let aliased = span.aliased
+    expectEqual(aliased.count, span.count)
+    expectEqual(aliased[2], 3)
+
+    let backAgain = unsafe aliased.span
+    expectEqual(backAgain.count, span.count)
+    expectTrue(backAgain.isIdentical(to: span))
+  }
+}
+
+suite.test("AliasedSpan iteration")
+.require(.stdlib_6_5).code {
+  guard #available(SwiftStdlib 6.5, *) else { return }
+
+  let a = [10, 20, 30, 40]
+  a.withUnsafeBufferPointer {
+    let span = unsafe AliasedSpan(_unsafeElements: $0)
+    expectEqual(span.underestimatedCount, 4)
+
+    var seen: [Int] = []
+    var iterator = span.makeBorrowingIterator()
+    while true {
+      let chunk = iterator.nextSpan()
+      if chunk.isEmpty { break }
+      for i in chunk.indices { seen.append(chunk[i]) }
+    }
+    expectEqual(seen, a)
+  }
+}
+
+suite.test("AliasedSpan iterator skip")
+.require(.stdlib_6_5).code {
+  guard #available(SwiftStdlib 6.5, *) else { return }
+
+  let a = [10, 20, 30, 40]
+  a.withUnsafeBufferPointer {
+    let span = unsafe AliasedSpan(_unsafeElements: $0)
+    var iterator = span.makeBorrowingIterator()
+    expectEqual(iterator.skip(by: 2), 2)
+    do {
+      let chunk = iterator.nextSpan()
+      expectEqual(chunk.count, 1)
+      expectEqual(chunk[0], 30)
+    }
+    expectEqual(iterator.skip(by: 10), 1)
+    expectTrue(iterator.nextSpan().isEmpty)
+  }
+}
+
+suite.test("AliasedMutableSpan element mutation")
+.require(.stdlib_6_5).code {
+  guard #available(SwiftStdlib 6.5, *) else { return }
+
+  var a = [1, 2, 3, 4]
+  a.withUnsafeMutableBufferPointer {
+    let span = unsafe AliasedMutableSpan(_unsafeElements: $0)
+    expectEqual(span.count, 4)
+
+    // The setter is non-mutating: it works on a `let` binding.
+    span[0] = 100
+    span[3] = 400
+    expectEqual(span[0], 100)
+    expectEqual(span[3], 400)
+
+    span.swapAt(0, 3)
+    expectEqual(span[0], 400)
+    expectEqual(span[3], 100)
+  }
+  expectEqual(a, [400, 2, 3, 100])
+}
+
+suite.test("AliasedMutableSpan update(repeating:)")
+.require(.stdlib_6_5).code {
+  guard #available(SwiftStdlib 6.5, *) else { return }
+
+  var a = [1, 2, 3, 4]
+  a.withUnsafeMutableBufferPointer {
+    let span = unsafe AliasedMutableSpan(_unsafeElements: $0)
+    span.update(repeating: 7)
+  }
+  expectEqual(a, [7, 7, 7, 7])
+}
+
+suite.test("AliasedMutableSpan is copyable")
+.require(.stdlib_6_5).code {
+  guard #available(SwiftStdlib 6.5, *) else { return }
+
+  var a = [1, 2, 3, 4]
+  a.withUnsafeMutableBufferPointer {
+    let span = unsafe AliasedMutableSpan(_unsafeElements: $0)
+    // Two aliases of the same storage, both usable.
+    let copy = span
+    span[0] = 10
+    expectEqual(copy[0], 10)
+    copy[1] = 20
+    expectEqual(span[1], 20)
+    expectTrue(span.isIdentical(to: copy))
+  }
+  expectEqual(a, [10, 20, 3, 4])
+}
+
+suite.test("MutableSpan.asAliased()")
+.require(.stdlib_6_5).code {
+  guard #available(SwiftStdlib 6.5, *) else { return }
+
+  var a = [1, 2, 3, 4]
+  a.withUnsafeMutableBufferPointer {
+    let mutable = unsafe MutableSpan(_unsafeElements: $0)
+    let aliased = mutable.asAliased()
+    aliased[2] = 30
+    expectEqual(aliased.aliased[2], 30)
+  }
+  expectEqual(a, [1, 2, 30, 4])
+}
+
+suite.test("AliasedRawSpan basics")
+.require(.stdlib_6_5).code {
+  guard #available(SwiftStdlib 6.5, *) else { return }
+
+  let a: [UInt32] = [0x0000_0001, 0x0000_0002]
+  a.withUnsafeBufferPointer {
+    let span = unsafe AliasedRawSpan(_unsafeElements: $0)
+    expectEqual(span.byteCount, 8)
+    expectFalse(span.isEmpty)
+    expectEqual(span.byteOffsets, 0..<8)
+
+    expectEqual(span.load(fromByteOffset: 0, as: UInt32.self), 1)
+    expectEqual(span.load(fromByteOffset: 4, as: UInt32.self), 2)
+
+    let tail = span.extracting(droppingFirst: 4)
+    expectEqual(tail.byteCount, 4)
+    expectEqual(span.byteOffsets(of: tail), 4..<8)
+  }
+}
+
+suite.test("AliasedMutableRawSpan store and load")
+.require(.stdlib_6_5).code {
+  guard #available(SwiftStdlib 6.5, *) else { return }
+
+  var a: [UInt32] = [0, 0, 0, 0]
+  a.withUnsafeMutableBufferPointer {
+    let span = unsafe AliasedMutableRawSpan(_unsafeElements: $0)
+    expectEqual(span.byteCount, 16)
+
+    // Non-mutating stores on a `let` binding.
+    span.storeBytes(of: UInt32(0xDEAD), toByteOffset: 0, as: UInt32.self)
+    span.storeBytes(of: UInt32(0xBEEF), toByteOffset: 4, as: UInt32.self)
+    expectEqual(span.load(fromByteOffset: 0, as: UInt32.self), 0xDEAD)
+    expectEqual(span.load(fromByteOffset: 4, as: UInt32.self), 0xBEEF)
+
+    span[8] = 0xFF
+    expectEqual(span[8], 0xFF)
+  }
+  expectEqual(a[0], 0xDEAD)
+  expectEqual(a[1], 0xBEEF)
+}
+
+suite.test("AliasedMutableRawSpan byte order")
+.require(.stdlib_6_5).code {
+  guard #available(SwiftStdlib 6.5, *) else { return }
+
+  var a: [UInt8] = Array(repeating: 0, count: 4)
+  a.withUnsafeMutableBufferPointer {
+    let span = unsafe AliasedMutableRawSpan(_unsafeElements: $0)
+    span.storeBytes(
+      of: UInt32(0x0102_0304), toByteOffset: 0, as: UInt32.self, .bigEndian
+    )
+    expectEqual(
+      span.load(fromByteOffset: 0, as: UInt32.self, .bigEndian), 0x0102_0304
+    )
+  }
+  expectEqual(a, [0x01, 0x02, 0x03, 0x04])
+}
+
+suite.test("Raw span conversions")
+.require(.stdlib_6_5).code {
+  guard #available(SwiftStdlib 6.5, *) else { return }
+
+  var a: [UInt32] = [1, 2, 3, 4]
+  a.withUnsafeMutableBufferPointer {
+    let raw = unsafe RawSpan(_unsafeElements: $0)
+    let aliasedRaw = raw.aliased
+    expectEqual(aliasedRaw.byteCount, raw.byteCount)
+    expectTrue(unsafe aliasedRaw.rawSpan.isIdentical(to: raw))
+
+    let mutableRaw = unsafe MutableRawSpan(_unsafeElements: $0)
+    let aliasedMutableRaw = mutableRaw.asAliased()
+    expectEqual(aliasedMutableRaw.byteCount, 16)
+    expectEqual(aliasedMutableRaw.bytes.byteCount, 16)
+  }
+}
+
+suite.test("Typed <-> raw aliased spans")
+.require(.stdlib_6_5).code {
+  guard #available(SwiftStdlib 6.5, *) else { return }
+
+  var a: [UInt32] = [1, 2, 3, 4]
+  a.withUnsafeMutableBufferPointer {
+    let span = unsafe AliasedMutableSpan(_unsafeElements: $0)
+    let bytes = span.mutableBytes
+    expectEqual(bytes.byteCount, 16)
+
+    let typed = AliasedMutableSpan<UInt32>(mutableBytes: bytes)
+    expectEqual(typed.count, 4)
+    typed[1] = 20
+  }
+  expectEqual(a, [1, 20, 3, 4])
+}
+
+suite.test("AliasedSpan(viewing:) an AliasedRawSpan")
+.require(.stdlib_6_5).code {
+  guard #available(SwiftStdlib 6.5, *) else { return }
+
+  let a: [UInt32] = [1, 2, 3, 4]
+  a.withUnsafeBufferPointer {
+    let raw = unsafe AliasedRawSpan(_unsafeElements: $0)
+    let typed = AliasedSpan<UInt32>(viewing: raw)
+    expectEqual(typed.count, 4)
+    expectEqual(typed[3], 4)
+
+    let asBytes = typed.bytes
+    expectEqual(asBytes.byteCount, 16)
+  }
+}
+
+suite.test("withUnsafeBufferPointer access hatches")
+.require(.stdlib_6_5).code {
+  guard #available(SwiftStdlib 6.5, *) else { return }
+
+  var a = [1, 2, 3, 4]
+  a.withUnsafeMutableBufferPointer {
+    let span = unsafe AliasedMutableSpan(_unsafeElements: $0)
+    let sum = span.withUnsafeBufferPointer { buffer in
+      unsafe buffer.reduce(0, +)
+    }
+    expectEqual(sum, 10)
+
+    span.withUnsafeMutableBufferPointer { buffer in
+      for i in buffer.indices { unsafe buffer[i] *= 2 }
+    }
+  }
+  expectEqual(a, [2, 4, 6, 8])
+}
+
+suite.test("AliasedRef basics")
+.require(.stdlib_6_5).code {
+  guard #available(SwiftStdlib 6.5, *) else { return }
+
+  let x = 42
+  let ref = AliasedRef(x)
+  expectEqual(ref.value, 42)
+}
+
+suite.test("AliasedMutableRef basics")
+.require(.stdlib_6_5).code {
+  guard #available(SwiftStdlib 6.5, *) else { return }
+
+  var x = 42
+  do {
+    let ref = AliasedMutableRef(&x)
+    expectEqual(ref.value, 42)
+    // The setter is non-mutating.
+    ref.value = 100
+    expectEqual(ref.value, 100)
+
+    // `AliasedMutableRef` is copyable: two aliases of the same storage.
+    let copy = ref
+    copy.value = 200
+    expectEqual(ref.value, 200)
+    expectEqual(ref.aliased.value, 200)
+  }
+  expectEqual(x, 200)
+}
+
+suite.test("MutableRef.asAliased()")
+.require(.stdlib_6_5).code {
+  guard #available(SwiftStdlib 6.5, *) else { return }
+
+  var x = 1
+  do {
+    let mutableRef = MutableRef(&x)
+    let aliased = mutableRef.asAliased()
+    aliased.value = 7
+    expectEqual(aliased.value, 7)
+  }
+  expectEqual(x, 7)
+}
+
+suite.test("Ref.aliased")
+.require(.stdlib_6_5).code {
+  guard #available(SwiftStdlib 6.5, *) else { return }
+
+  let x = 314
+  let ref = Ref(x)
+  expectEqual(ref.aliased.value, 314)
+}
+
+suite.test("Bounds checking traps")
+.require(.stdlib_6_5).code {
+  guard #available(SwiftStdlib 6.5, *) else { return }
+
+  let a = [1, 2, 3]
+  a.withUnsafeBufferPointer {
+    let span = unsafe AliasedSpan(_unsafeElements: $0)
+    expectCrashLater()
+    _ = span[3]
+  }
+}


### PR DESCRIPTION
These are more-or-less straightforward implementations based on the non-aliased versions of these types, accounting for the (somewhat subtle) API differences outlined in the proposal.

The Iterable implementation uses a single-element buffer, but it might be more efficient to use a multi-element buffer. This decision will become ABI, so we should think about it.
