### PR TITLE
Sema: validate COM interface inheritance hierarchy

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4413,6 +4413,49 @@ enum KeyPathTypeKind : unsigned char {
   KPTK_ReferenceWritableKeyPath
 };
 
+/// The validated inheritance hierarchy of a COM interface.
+///
+/// COM interface inheritance contributes at most one ABI-bearing base chain.
+/// Marker protocols can refine the interface without contributing to that
+/// chain.
+class COMInterfaceHierarchy {
+  ArrayRef<ProtocolDecl *> MarkerProtocols;
+  ArrayRef<ProtocolDecl *> ABIChain;
+
+  COMInterfaceHierarchy() = default;
+
+public:
+  COMInterfaceHierarchy(ArrayRef<ProtocolDecl *> markers,
+                        ArrayRef<ProtocolDecl *> chain)
+      : MarkerProtocols(markers), ABIChain(chain) {
+    assert(!chain.empty());
+  }
+
+  static COMInterfaceHierarchy invalid() { return {}; }
+
+  bool isInvalid() const { return ABIChain.empty(); }
+
+  /// The most-derived directly inherited COM interface, or null for a root
+  /// interface.
+  ProtocolDecl *getABIBase() const {
+    assert(!isInvalid());
+    return ABIChain.size() > 1 ? ABIChain[ABIChain.size() - 2] : nullptr;
+  }
+
+  /// Marker protocols inherited by this interface or its COM ABI bases.
+  ArrayRef<ProtocolDecl *> getMarkerProtocols() const {
+    assert(!isInvalid());
+    return MarkerProtocols;
+  }
+
+  /// The COM ABI inheritance chain in base-most-to-derived order, including
+  /// this interface as its final element.
+  ArrayRef<ProtocolDecl *> getABIChain() const {
+    assert(!isInvalid());
+    return ABIChain;
+  }
+};
+
 /// The COM role and associated declaration information for a nominal type.
 ///
 /// A protocol can declare an interface, while a class can provide an
@@ -5815,6 +5858,13 @@ public:
   bool isCOMInterface() const {
     return getCOMDeclInfo() != nullptr;
   }
+
+  /// Retrieve this COM interface's validated inheritance hierarchy.
+  ///
+  /// Returns null for a protocol that does not declare a COM interface. An
+  /// invalid COM interface has a non-null hierarchy whose \c isInvalid() is
+  /// true.
+  const COMInterfaceHierarchy *getCOMInterfaceHierarchy() const;
 
   /// Retrieve the ClassDecl for the superclass of this protocol, or null if there
   /// is no superclass.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2244,6 +2244,21 @@ ERROR(attr_com_missing_module, none,
       "'COM' module not imported, required for '@com'", ())
 ERROR(com_module_missing_type, none,
       "type '%0' not found in the 'COM' module", (StringRef))
+ERROR(com_interface_inherits_non_marker, none,
+      "COM interface %0 cannot inherit non-COM, non-marker protocol %1",
+      (DeclName, DeclName))
+ERROR(com_interface_inherits_non_protocol, none,
+      "COM interface %0 cannot inherit non-protocol type %1",
+      (DeclName, Type))
+ERROR(com_interface_multiple_abi_bases, none,
+      "COM interface %0 cannot inherit unrelated COM interfaces %1 and %2",
+      (DeclName, DeclName, DeclName))
+ERROR(com_interface_refinement_requires_identity, none,
+      "protocol %0 refines COM interface %1 and must declare its own "
+      "'@com(interface:)' identity", (DeclName, DeclName))
+ERROR(com_interface_repeated_iid, none,
+      "COM interface %0 and inherited interface %1 use the same interface "
+      "identifier '%2'", (DeclName, DeclName, StringRef))
 
 ERROR(metatype_extension_com_only, none,
       "protocol metatype extensions are reserved for COM interop", ())

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -53,6 +53,7 @@ class BreakStmt;
 class ContextualPattern;
 class ContinueStmt;
 class COMDeclInfo;
+class COMInterfaceHierarchy;
 class DefaultArgumentExpr;
 class DefaultArgumentType;
 class DoCatchStmt;
@@ -1272,6 +1273,26 @@ private:
 
   const COMDeclInfo *evaluate(Evaluator &evaluator,
                               NominalTypeDecl *nominal) const;
+
+public:
+  // Caching
+  bool isCached() const { return true; }
+};
+
+/// Retrieve the validated inheritance hierarchy for a COM interface, or null
+/// when the protocol does not declare a COM interface.
+class COMInterfaceHierarchyRequest
+    : public SimpleRequest<COMInterfaceHierarchyRequest,
+                           const COMInterfaceHierarchy *(ProtocolDecl *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  const COMInterfaceHierarchy *evaluate(Evaluator &evaluator,
+                                        ProtocolDecl *protocol) const;
 
 public:
   // Caching

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -116,6 +116,9 @@ SWIFT_REQUEST(TypeChecker, IsActorRequest, bool(NominalTypeDecl *),
 SWIFT_REQUEST(TypeChecker, COMDeclInfoRequest,
               const COMDeclInfo *(NominalTypeDecl *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, COMInterfaceHierarchyRequest,
+              const COMInterfaceHierarchy *(ProtocolDecl *), Cached,
+              NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsDefaultActorRequest,
               bool(ClassDecl *, ModuleDecl *, ResilienceExpansion),
               Cached, NoLocationInfo)

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7441,6 +7441,17 @@ const COMDeclInfo *NominalTypeDecl::getCOMDeclInfo() const {
                            COMDeclInfoRequest{mutableThis}, nullptr);
 }
 
+const COMInterfaceHierarchy *ProtocolDecl::getCOMInterfaceHierarchy() const {
+  // Preserve the non-COM fast path and, in particular, do not make early COM
+  // identity lookup resolve protocol inheritance.
+  if (!isCOMInterface())
+    return nullptr;
+
+  auto *mutableThis = const_cast<ProtocolDecl *>(this);
+  return evaluateOrDefault(getASTContext().evaluator,
+                           COMInterfaceHierarchyRequest{mutableThis}, nullptr);
+}
+
 EnumCaseDecl *EnumCaseDecl::create(SourceLoc CaseLoc,
                                    ArrayRef<EnumElementDecl *> Elements,
                                    DeclContext *DC) {

--- a/lib/Sema/TypeCheckCOM.cpp
+++ b/lib/Sema/TypeCheckCOM.cpp
@@ -21,6 +21,7 @@
 #include "swift/AST/ImportCache.h"
 #include "swift/AST/KnownProtocols.h"
 #include "swift/AST/Module.h"
+#include "swift/AST/NameLookup.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/Pattern.h"
 #include "swift/AST/ProtocolConformance.h"
@@ -277,6 +278,47 @@ const COMAttr *getAttribute(const ProtocolDecl *PD) {
   return attr;
 }
 
+/// Select the unique most-derived interface among a set of comparable COM
+/// bases. Unrelated bases cannot share one interface pointer and are invalid.
+std::optional<ProtocolDecl *>
+resolveABIBase(ProtocolDecl *protocol,
+               ArrayRef<std::pair<ProtocolDecl *, SourceLoc>> bases) {
+  ASSERT(!bases.empty());
+  ProtocolDecl *selection = nullptr;
+  bool invalid = false;
+  ASTContext &C = protocol->getASTContext();
+
+  for (auto [base, loc] : bases) {
+    auto *hierarchy = base->getCOMInterfaceHierarchy();
+    if (!hierarchy || hierarchy->isInvalid()) {
+      invalid = true;
+    } else if (!selection || base->inheritsFrom(selection)) {
+      selection = base;
+    } else if (selection != base && !selection->inheritsFrom(base)) {
+      C.Diags.diagnose(loc, diag::com_interface_multiple_abi_bases,
+                       protocol->getName(), selection->getName(),
+                       base->getName());
+      invalid = true;
+    }
+  }
+
+  if (invalid)
+    return std::nullopt;
+  ASSERT(selection);
+  return selection;
+}
+
+ProtocolDecl *findInterface(ArrayRef<ProtocolDecl *> chain,
+                            StringRef iid) {
+  for (auto *interface : chain) {
+    auto *info = interface->getCOMDeclInfo();
+    ASSERT(info && info->isInterface());
+    if (iid.equals_insensitive(info->getInterfaceID()))
+      return interface;
+  }
+  return nullptr;
+}
+
 }
 }
 
@@ -316,6 +358,128 @@ COMDeclInfoRequest::evaluate(Evaluator &evaluator,
   }
 
   return nullptr;
+}
+
+const COMInterfaceHierarchy *
+COMInterfaceHierarchyRequest::evaluate(Evaluator &evaluator,
+                                       ProtocolDecl *protocol) const {
+  auto &C = protocol->getASTContext();
+  auto *info = protocol->getCOMDeclInfo();
+
+  // Ordinary circular-inheritance checking owns the diagnostic. Do not start
+  // a recursive COM hierarchy walk in that case.
+  if (protocol->hasCircularInheritedProtocols()) {
+    if (!info)
+      return nullptr;
+    return C.AllocateObjectCopy(COMInterfaceHierarchy::invalid());
+  }
+
+  SmallVector<InheritedNominalEntry, 4> inherited;
+  if (protocol->wasDeserialized()) {
+    for (auto *base : protocol->getInheritedProtocols()) {
+      inherited.emplace_back(base, SourceLoc(), /*inheritedTypeRepr=*/nullptr,
+                             ConformanceAttributes(),
+                             /*isSuppressed=*/false);
+    }
+  } else {
+    bool ignoredAnyObject = false;
+    InvertibleProtocolSet inverses;
+    inherited = getDirectlyInheritedNominalTypeDecls(protocol, inverses,
+                                                      ignoredAnyObject);
+  }
+
+  // A protocol that refines a COM interface must itself introduce a COM
+  // identity. A malformed @com attribute already has its own diagnostic, so
+  // do not obscure it with this follow-on error.
+  if (!info) {
+    if (protocol->getAttrs().hasAttribute<COMAttr>(
+            /*AllowInvalid=*/true))
+      return nullptr;
+
+    for (const auto &entry : inherited) {
+      auto *PD = dyn_cast<ProtocolDecl>(entry.Item);
+      if (PD && PD->isCOMInterface()) {
+        C.Diags.diagnose(entry.Loc,
+                         diag::com_interface_refinement_requires_identity,
+                         protocol->getName(), PD->getName());
+        break;
+      }
+    }
+
+    return nullptr;
+  }
+
+  bool invalid = false;
+
+  SmallVector<ProtocolDecl *, 4> markers;
+  auto record = [&](ProtocolDecl *marker) {
+    if (!llvm::is_contained(markers, marker))
+      markers.push_back(marker);
+  };
+
+  SmallVector<std::pair<ProtocolDecl *, SourceLoc>, 2> bases;
+
+  for (const auto &entry : inherited) {
+    auto *PD = dyn_cast<ProtocolDecl>(entry.Item);
+    if (!PD) {
+      C.Diags.diagnose(entry.Loc, diag::com_interface_inherits_non_protocol,
+                       protocol->getName(),
+                       entry.Item->getDeclaredInterfaceType());
+      invalid = true;
+    } else if (PD->isCOMInterface()) {
+      bases.emplace_back(PD, entry.Loc);
+    } else if (PD->isMarkerProtocol()) {
+      record(PD);
+      for (auto *marker : PD->getAllInheritedProtocols()) {
+        if (marker->isMarkerProtocol())
+          record(marker);
+      }
+    } else {
+      C.Diags.diagnose(entry.Loc, diag::com_interface_inherits_non_marker,
+                       protocol->getName(), PD->getName());
+      invalid = true;
+    }
+  }
+
+  ProtocolDecl *base = nullptr;
+  if (!bases.empty()) {
+    if (const auto resolved = ::com::resolveABIBase(protocol, bases))
+      base = *resolved;
+    else
+      invalid = true;
+  }
+
+  if (invalid)
+    return C.AllocateObjectCopy(COMInterfaceHierarchy::invalid());
+
+  SmallVector<ProtocolDecl *, 4> chain;
+  // A root interface has no COM base; its ABI chain starts with the current
+  // interface when it is appended below.
+  if (base) {
+    auto *hierarchy = base->getCOMInterfaceHierarchy();
+    ASSERT(hierarchy && !hierarchy->isInvalid());
+    for (auto *marker : hierarchy->getMarkerProtocols())
+      record(marker);
+    llvm::append_range(chain, hierarchy->getABIChain());
+  }
+  llvm::sort(markers, [](ProtocolDecl *lhs, ProtocolDecl *rhs) {
+    return TypeDecl::compare(lhs, rhs) < 0;
+  });
+
+  // An IID denotes one logical interface in an ABI chain. Reusing it for a
+  // derived declaration would make QueryInterface unable to distinguish the
+  // two layouts.
+  if (auto *interface = ::com::findInterface(chain, info->getInterfaceID())) {
+    auto *attr = protocol->getAttrs().getAttribute<COMAttr>();
+    SourceLoc loc = attr ? attr->getLocation() : protocol->getLoc();
+    C.Diags.diagnose(loc, diag::com_interface_repeated_iid, protocol->getName(),
+                     interface->getName(), info->getInterfaceID());
+    return C.AllocateObjectCopy(COMInterfaceHierarchy::invalid());
+  }
+
+  chain.push_back(protocol);
+  return C.AllocateObjectCopy(
+      COMInterfaceHierarchy(C.AllocateCopy(markers), C.AllocateCopy(chain)));
 }
 
 ProtocolConformance *

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3609,6 +3609,13 @@ public:
 
     checkInheritanceClause(PD);
 
+    // Validate COM inheritance only after ordinary inherited types have been
+    // resolved. Keep this out of the early declaration-classification query
+    // used by name lookup and identity synthesis.
+    if (Ctx.LangOpts.EnableCOMInterop && !PD->hasCircularInheritedProtocols())
+      (void)evaluateOrDefault(Ctx.evaluator, COMInterfaceHierarchyRequest{PD},
+                              nullptr);
+
     // Explicitly compute the requirement signature to detect errors.
     // Do this before visiting members, to avoid a request cycle if
     // a member references another declaration whose generic signature

--- a/test/Inputs/COM.swift
+++ b/test/Inputs/COM.swift
@@ -20,4 +20,4 @@ public typealias CLSID = GUID
 public protocol IUnknown: AnyObject { }
 
 @com(interface: "8e369447-5188-5ada-b9ec-8fcb732d226b")
-public protocol ISwiftObject: IUnknown { }
+public protocol ISwiftObject: AnyObject { }

--- a/test/Sema/COM-interface-hierarchy-cross-module.swift
+++ b/test/Sema/COM-interface-hierarchy-cross-module.swift
@@ -1,0 +1,50 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -emit-module-path %t/COM.swiftmodule -module-name COM -enable-experimental-com-interop %S/../Inputs/COM.swift
+// RUN: %target-swift-frontend -emit-module-path %t/BinaryBase.swiftmodule -module-name BinaryBase -enable-experimental-com-interop -I %t %t/BinaryBase.swift
+// RUN: %target-swift-frontend -typecheck -module-name BinaryClient -enable-experimental-com-interop -I %t %t/BinaryClient.swift
+// RUN: %target-swift-frontend -compile-module-from-interface %t/Base.swiftinterface -o %t/Base.swiftmodule -enable-experimental-com-interop -I %t
+// RUN: %target-swift-frontend -compile-module-from-interface %t/Derived.swiftinterface -o %t/Derived.swiftmodule -enable-experimental-com-interop -I %t
+// RUN: %target-swift-frontend -typecheck -enable-experimental-com-interop -I %t %t/Client.swift
+
+//--- BinaryBase.swift
+import COM
+
+@com(interface: "31000000-0000-0000-0000-000000000001")
+public protocol IBinaryBase {}
+
+@com(interface: "31000000-0000-0000-0000-000000000002")
+public protocol IBinaryMiddle: IBinaryBase {}
+
+//--- BinaryClient.swift
+import COM
+import BinaryBase
+
+@com(interface: "31000000-0000-0000-0000-000000000003")
+protocol IBinaryLeaf: IBinaryMiddle, IBinaryBase {}
+
+//--- Base.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name Base -language-mode 5 -enable-library-evolution -enable-experimental-com-interop
+import COM
+
+@com(interface: "30000000-0000-0000-0000-000000000001")
+public protocol IBase {}
+
+@com(interface: "30000000-0000-0000-0000-000000000002")
+public protocol IMiddle: IBase {}
+
+//--- Derived.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name Derived -language-mode 5 -enable-library-evolution -enable-experimental-com-interop
+import COM
+import Base
+
+@com(interface: "30000000-0000-0000-0000-000000000003")
+public protocol ILeaf: IMiddle, IBase, Sendable {}
+
+//--- Client.swift
+import COM
+import Derived
+
+func use(_ value: any ILeaf) {}

--- a/test/Sema/COM-interface-hierarchy.swift
+++ b/test/Sema/COM-interface-hierarchy.swift
@@ -1,0 +1,62 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module-path %t/COM.swiftmodule -module-name COM -enable-experimental-com-interop %S/../Inputs/COM.swift
+// RUN: %target-swift-frontend -emit-ir -o /dev/null -verify -enable-experimental-com-interop -I %t %s
+
+import COM
+
+@_marker
+protocol BaseMarker {}
+
+@_marker
+protocol LocalMarker: BaseMarker {}
+
+protocol SwiftProtocol {
+  func requirement()
+}
+
+@com(interface: "A0000000-0000-0000-0000-000000000001")
+protocol IBase {}
+
+@com(interface: "10000000-0000-0000-0000-000000000002")
+protocol IMiddle: IBase {}
+
+// Comparable COM bases form one ABI chain. Marker refinements do not
+// contribute an ABI base.
+@com(interface: "10000000-0000-0000-0000-000000000003")
+protocol ILeaf: IMiddle, IBase, Sendable, LocalMarker {}
+
+@com(interface: "10000000-0000-0000-0000-000000000004")
+protocol IReverseLeaf: IBase, IMiddle {}
+
+// AnyObject continues to carry the class-bound invariant until COM-reference
+// existentials and conformance checking enforce it directly.
+@com(interface: "20000000-0000-0000-0000-000000000001")
+protocol IClassBound: AnyObject {}
+
+@com(interface: "20000000-0000-0000-0000-000000000002")
+protocol ISwiftRefinement: SwiftProtocol {}
+// expected-error@-1 {{COM interface 'ISwiftRefinement' cannot inherit non-COM, non-marker protocol 'SwiftProtocol'}}
+
+class NativeBase {}
+
+@com(interface: "20000000-0000-0000-0000-000000000005")
+protocol INativeBase: NativeBase {}
+// expected-error@-1 {{COM interface 'INativeBase' cannot inherit non-protocol type 'NativeBase'}}
+
+@com(interface: "20000000-0000-0000-0000-000000000003")
+protocol IIndependent {}
+
+@com(interface: "20000000-0000-0000-0000-000000000004")
+protocol IMultipleBases: IBase, IIndependent {}
+// expected-error@-1 {{COM interface 'IMultipleBases' cannot inherit unrelated COM interfaces 'IBase' and 'IIndependent'}}
+
+protocol MissingIdentity: IBase {}
+// expected-error@-1 {{protocol 'MissingIdentity' refines COM interface 'IBase' and must declare its own '@com(interface:)' identity}}
+
+@com(interface: "A0000000-0000-0000-0000-000000000001")
+protocol IRepeatedIID: IBase {}
+// expected-error@-2 {{COM interface 'IRepeatedIID' and inherited interface 'IBase' use the same interface identifier 'A0000000-0000-0000-0000-000000000001'}}
+
+@com(interface: "a0000000-0000-0000-0000-000000000001")
+protocol IRepeatedIIDCaseInsensitive: IBase {}
+// expected-error@-2 {{COM interface 'IRepeatedIIDCaseInsensitive' and inherited interface 'IBase' use the same interface identifier 'a0000000-0000-0000-0000-000000000001'}}

--- a/test/Sema/COMAttr.swift
+++ b/test/Sema/COMAttr.swift
@@ -5,7 +5,7 @@
 @com(interface: "00000000-0000-0000-0000-000000000000")
 protocol IInterface1: IUnknown { }
 
-@com(interface: "00000000-0000-0000-0000-000000000000")
+@com(interface: "00000000-0000-0000-0000-000000000002")
 protocol IInterface2: IInterface1 { }
 
 @com(interface: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")

--- a/test/Serialization/COM.swift
+++ b/test/Serialization/COM.swift
@@ -18,4 +18,3 @@ public class CClass2 { }
 @com
 public class CClass3 { }
 // CHECK-DAG: <COM_DECL_ATTR abbrevid=292 op0=0 op1=0 op2=2/> blob data = ''
-


### PR DESCRIPTION
A COM interface value carries one interface pointer, so its inheritance must reduce to a single ABI-bearing chain. Comparable COM bases may be repeated and marker protocols may refine the interface, but unrelated COM bases would require multiple pointers. An ordinary Swift protocol would add requirements without introducing a corresponding COM interface identity.

Add a cached COMInterfaceHierarchyRequest which selects the unique most-derived ABI base and records the complete base-to-derived chain along with its inherited marker protocols. Evaluate it after ordinary inheritance checking so declaration classification and identity synthesis remain shallow and circular inheritance keeps its existing diagnostic path.

Require every protocol refining a COM interface to declare its own interface identity, and reject non-protocol bases, non-marker Swift protocols, unrelated COM bases, and reuse of an inherited IID. Cover source declarations and hierarchies reconstructed across binary modules and textual interfaces.