### PR TITLE
[update-checkout] Allow repos to be worktrees

### DIFF
--- a/utils/update_checkout/tests/test_update_worktree.py
+++ b/utils/update_checkout/tests/test_update_worktree.py
@@ -69,6 +69,20 @@ class WorktreeTestCase(scheme_mock.SchemeMockTestCase):
             ]
         )
 
+    def test_clone_skips_worktree_repositories(self):
+        self.call(
+            [
+                self.update_checkout_path,
+                "--config",
+                self.config_path,
+                "--source-root",
+                self.worktree_path,
+                "--scheme",
+                "main",
+                "--clone",
+            ]
+        )
+
     def setUp(self):
         super(WorktreeTestCase, self).setUp()
         self.worktree_path = os.path.join(self.workspace, WORKTREE_NAME)

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -873,7 +873,7 @@ def obtain_all_additional_swift_sources(
                         break
 
         else:
-            repo_exists = repo_path.joinpath(".git").is_dir()
+            repo_exists = repo_path.joinpath(".git").exists()
 
         if repo_exists:
             skipped_repositories.append(


### PR DESCRIPTION
Previously if you use a worktree for a repo that is pulled by update
checkout you would see:

```
[oss-swift-rel] 'git clone --recursive https://github.com/swiftlang/llvm-project.git llvm-project' returned (128) with the following fatal: destination path 'llvm-project' already exists and is not an empty directory.
```

Since in the worktree case `.git` is a file that points back to the
primary repo:

```
% cat llvm-project/.git
gitdir: /home/ksmiley/dev/apple/oss-swift/llvm-project/.git/worktrees/llvm-project
```
