### PR TITLE
Support -clang-target with symbolgraph extract

### DIFF
--- a/lib/DriverTool/swift_symbolgraph_extract_main.cpp
+++ b/lib/DriverTool/swift_symbolgraph_extract_main.cpp
@@ -113,6 +113,13 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args,
   Invocation.setSDKPath(SDK);
 
   Invocation.setTargetTriple(Target);
+  if (auto *A = ParsedArgs.getLastArg(OPT_clang_target)) {
+    Invocation.getLangOptions().ClangTarget = llvm::Triple(A->getValue());
+  }
+  if (auto *A = ParsedArgs.getLastArg(OPT_clang_target_variant)) {
+    Invocation.getLangOptions().ClangTargetVariant =
+        llvm::Triple(A->getValue());
+  }
 
   for (const auto *A : ParsedArgs.filtered(OPT_Xcc)) {
     Invocation.getClangImporterOptions().ExtraArgs.push_back(A->getValue());

--- a/test/SymbolGraph/ClangImporter/ClangTarget.swift
+++ b/test/SymbolGraph/ClangImporter/ClangTarget.swift
@@ -1,0 +1,20 @@
+// REQUIRES: OS=macosx
+
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/Output)
+
+// Build the explicit Clang modules for a different target than the Swift
+// invocation. The extractor must use -clang-target to load these PCMs.
+// RUN: %target-swift-emit-pcm -target %target-cpu-apple-macosx12.0 -module-name ClangTarget \
+// RUN:   %S/Inputs/ClangTarget/module.modulemap -o %t/ClangTarget.pcm -Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules
+// RUN: %target-swift-emit-pcm -target %target-cpu-apple-macosx12.0 -module-name SwiftShims \
+// RUN:   %swift-lib-dir/swift/shims/module.modulemap -o %t/SwiftShims.pcm -Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules
+// RUN: %target-swift-symbolgraph-extract -sdk %sdk -target %target-cpu-apple-macosx11.0 -clang-target %target-cpu-apple-macosx12.0 \
+// RUN:   -module-name ClangTarget -I %S/Inputs/ClangTarget \
+// RUN:   -Xcc -fmodule-file=ClangTarget=%t/ClangTarget.pcm -Xcc -fmodule-map-file=%S/Inputs/ClangTarget/module.modulemap \
+// RUN:   -Xcc -fmodule-file=SwiftShims=%t/SwiftShims.pcm -Xcc -fmodule-map-file=%swift-lib-dir/swift/shims/module.modulemap \
+// RUN:   -Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules -Xcc -fno-implicit-module-maps -Xcc -fno-implicit-modules \
+// RUN:   -pretty-print -output-dir %t/Output
+// RUN: %FileCheck %s --input-file %t/Output/ClangTarget.symbols.json
+
+// CHECK: "title": "ClangTargetValue"

--- a/test/SymbolGraph/ClangImporter/Inputs/ClangTarget/ClangTarget.h
+++ b/test/SymbolGraph/ClangImporter/Inputs/ClangTarget/ClangTarget.h
@@ -1,0 +1,3 @@
+typedef struct ClangTargetValue {
+  int value;
+} ClangTargetValue;

--- a/test/SymbolGraph/ClangImporter/Inputs/ClangTarget/module.modulemap
+++ b/test/SymbolGraph/ClangImporter/Inputs/ClangTarget/module.modulemap
@@ -1,0 +1,3 @@
+module ClangTarget {
+  header "ClangTarget.h"
+}


### PR DESCRIPTION
If you're trying to share explicit module pcms between
swift-symbolgraph-extract invocations and normal compile invocations,
this tool must support -clang-target to be able to load them
