### PR TITLE
[SILGen] Fix async witness thunk emission when isolation comes from a…

### DIFF
--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -7623,32 +7623,42 @@ void SILGenFunction::emitProtocolWitness(
   if (enterIsolation) {
     // If we are supposed to enter the actor, do so now by hopping to the
     // actor.
-    std::optional<ManagedValue> actorSelf;
+    std::optional<ManagedValue> actor;
 
-    // For an instance actor, get the actor 'self'.
-    if (*enterIsolation == ActorIsolation::ActorInstance) {
-      assert(enterIsolation->isActorInstanceForSelfParameter() && "Not self?");
-      auto actorSelfVal = origParams.back();
+    // If the requirement is isolated to an actor instance it could be either
+    // `self` or an `isolated` parameter.
+    if (enterIsolation->isActorInstanceIsolated()) {
+      ManagedValue actorParamVal;
+      if (enterIsolation->isActorInstanceForSelfParameter()) {
+        // Get the actor 'self'.
+        actorParamVal = origParams.back();
+      } else {
+        // Or `isolated` parameter.
+        unsigned formalIndex = enterIsolation->getActorInstanceParameterIndex();
+        actorParamVal =
+            origParams[reqtOrigTy.getLoweredParamIndex(formalIndex)];
+      }
 
-      if (actorSelfVal.getType().isAddress()) {
-        auto &actorSelfTL = getTypeLowering(actorSelfVal.getType());
-        if (!actorSelfTL.isAddressOnly()) {
-          actorSelfVal = emitManagedLoad(
-              *this, loc, actorSelfVal, actorSelfTL);
+      // Load the actor instance if necessary.
+      if (actorParamVal.getType().isAddress()) {
+        auto &actorInstanceTL = getTypeLowering(actorParamVal.getType());
+        if (!actorInstanceTL.isAddressOnly()) {
+          actorParamVal =
+              emitManagedLoad(*this, loc, actorParamVal, actorInstanceTL);
         }
       }
 
-      actorSelf = actorSelfVal;
+      actor = actorParamVal;
     }
 
     if (!F.isAsync()) {
       assert(isPreconcurrency);
 
       if (getASTContext().LangOpts.isDynamicActorIsolationCheckingEnabled()) {
-        emitPreconditionCheckExpectedExecutor(loc, *enterIsolation, actorSelf);
+        emitPreconditionCheckExpectedExecutor(loc, *enterIsolation, actor);
       }
     } else {
-      emitHopToTargetActor(loc, enterIsolation, actorSelf);
+      emitHopToTargetActor(loc, enterIsolation, actor);
     }
   }
 

--- a/test/Concurrency/sync_parameter_isolated_witness_of_async_requirement.swift
+++ b/test/Concurrency/sync_parameter_isolated_witness_of_async_requirement.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-emit-silgen %s -verify | %FileCheck %s
+
+// REQUIRES: concurrency
+
+protocol P {
+  func test(isolation: isolated (any Actor)?) async
+}
+
+struct S: P {
+  func test(isolation: isolated (any Actor)?) {
+  }
+}
+
+// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s52sync_parameter_isolated_witness_of_async_requirement1SVAA1PA2aDP4test9isolationyScA_pSgYi_tYaFTW : $@convention(witness_method: P) @async (@sil_isolated @guaranteed Optional<any Actor>, @in_guaranteed S) -> () {
+// CHECK: bb0([[ISOLATION:%.*]] : @guaranteed $Optional<any Actor>, [[SELF:%.*]] : $*S):
+// CHECK:  hop_to_executor [[ISOLATION]]
+// CHECK:  [[WITNESS:%.*]] = function_ref @$s52sync_parameter_isolated_witness_of_async_requirement1SV4test9isolationyScA_pSgYi_tF : $@convention(method) (@sil_isolated @guaranteed Optional<any Actor>, S) -> ()
+// CHECK:  apply [[WITNESS]]([[ISOLATION]], {{.*}}) : $@convention(method) (@sil_isolated @guaranteed Optional<any Actor>, S) -> ()
+// CHECK: } // end sil function '$s52sync_parameter_isolated_witness_of_async_requirement1SVAA1PA2aDP4test9isolationyScA_pSgYi_tYaFTW'


### PR DESCRIPTION
… parameter

If a requirement is isolated to an actor instance it could mean either "self" or `isolated` parameter, the thunk emission only handled the former.

Resolves: rdar://171869494

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
