### PR TITLE
[AST] Allow fallback closure discriminator in macro argument

### DIFF
--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -23,6 +23,7 @@
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/Decl.h" // FIXME: Bad dependency
 #include "swift/AST/ExistentialLayout.h"
+#include "swift/AST/NameLookup.h"
 #include "swift/AST/MacroDiscriminatorContext.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/Stmt.h"
@@ -1982,15 +1983,15 @@ unsigned AbstractClosureExpr::getDiscriminator() const {
 
   // If we don't have a discriminator, and either
   //   1. We have ill-formed code and we're able to assign a discriminator, or
-  //   2. We are in a macro expansion buffer
+  //   2. We are in a macro expansion buffer or argument
   //   3. We are within top-level code where there's nothing to anchor to
   //
   // then assign the next discriminator now.
   if (getRawDiscriminator() == InvalidDiscriminator &&
-      (ctx.Diags.hadAnyError() ||
-       getParentSourceFile()->getFulfilledMacroRole() != std::nullopt ||
+      (useFallbackDiscriminator || ctx.Diags.hadAnyError() ||
        getParent()->isModuleScopeContext() ||
-       useFallbackDiscriminator)) {
+       getParentSourceFile()->getFulfilledMacroRole() != std::nullopt ||
+       namelookup::isInMacroArgument(getParentSourceFile(), getLoc()))) {
     auto discriminator = ctx.getNextDiscriminator(getParent());
     ctx.setMaxAssignedDiscriminator(getParent(), discriminator + 1);
     const_cast<AbstractClosureExpr *>(this)->

--- a/test/SourceKit/Refactoring/issue-90922.swift
+++ b/test/SourceKit/Refactoring/issue-90922.swift
@@ -1,0 +1,33 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file --leading-lines %s %t
+
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %t/plugin.swift -g -no-toolchain-stdlib-rpath
+
+// RUN: %target-swift-frontend -dump-ast %t/main.swift -load-plugin-library %t/%target-library-name(MacroDefinition) -o /dev/null
+
+// REQUIRES: swift_swift_parser
+
+// https://github.com/swiftlang/swift/issues/90922
+
+//--- plugin.swift
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public struct EmptyMacro: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    []
+  }
+}
+
+//--- main.swift
+@attached(peer)
+macro M(_ fn: (Int) -> Void) = #externalMacro(module: "MacroDefinition", type: "EmptyMacro")
+
+// RUN: %sourcekitd-test -req=find-local-rename-ranges -pos=%(line+2):6 %t/main.swift -- %t/main.swift -load-plugin-library %t/%target-library-name(MacroDefinition) | %FileCheck %s
+@M({ _ in })
+func foo() {}
+// CHECK: [[@LINE-1]]:6-[[@LINE-1]]:9 source.refactoring.range.kind.basename


### PR DESCRIPTION
Macro arguments are never emitted so we can use fallback discriminators for them in asserts builds. For non-asserts builds we always use a fallback discriminator anyway.

rdar://183058471
Resolves #90922