### PR TITLE
Swiftify irgen crash 6.4

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -2292,7 +2292,8 @@ IRGenModule *IRGenerator::getGenModule(SourceFile *SF) {
    // to a function imported from clang module, so it doesn't have a mapping
    // in GenModule. The contents are @_alwaysEmitIntoClient, so for all intents
    // and purposes they belong to the primary module.
-   ASSERT(SF->getParentModule()->findUnderlyingClangModule());
+   const ModuleDecl *M = SF->getParentModule();
+   ASSERT(M->findUnderlyingClangModule() || M->isClangHeaderImportModule());
    return getPrimaryIGM();
  }
 

--- a/test/Interop/C/swiftify-import/bridging-header-multiple-outputs.swift
+++ b/test/Interop/C/swiftify-import/bridging-header-multiple-outputs.swift
@@ -1,0 +1,36 @@
+// Regression test: this used to trigger a compiler crash in IRGenerator::getGenModule
+// since the SourceFile for the _SwiftifyImport macro expansion had no corresponding
+// IRGenModule. This would only trigger with multiple outputs and multiple threads
+// since there's only a single IRGenModule to return otherwise.
+// This is the bridging header, non-embedded, counterpart of
+// test/embedded/safe-interop-multiple-outputs.swift, which covers the same crash
+// when the annotated function is imported as a clang module instead.
+
+// The bridging header case is still broken: the macro expansion buffer's parent
+// module is the main module rather than a clang module, so the fallback in
+// IRGenerator::getGenModule asserts instead of returning the primary IGM.
+// XFAIL: *
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -c -plugin-path %swift-plugin-dir \
+// RUN:   -import-bridging-header %t/bridging.h \
+// RUN:   -parse-as-library -num-threads 2 \
+// RUN:   %t/A.swift %t/B.swift \
+// RUN:   -o %t/A.swift.o -o %t/B.swift.o
+
+//--- bridging.h
+#pragma once
+
+#define __counted_by(x) __attribute__((__counted_by__(x)))
+
+void foo(const int *__counted_by(len) p, int len);
+
+//--- A.swift
+public func bar(_ s: UnsafeBufferPointer<CInt>) {
+    foo(s)
+}
+
+//--- B.swift
+public struct Baz {}

--- a/test/Interop/C/swiftify-import/bridging-header-multiple-outputs.swift
+++ b/test/Interop/C/swiftify-import/bridging-header-multiple-outputs.swift
@@ -6,11 +6,6 @@
 // test/embedded/safe-interop-multiple-outputs.swift, which covers the same crash
 // when the annotated function is imported as a clang module instead.
 
-// The bridging header case is still broken: the macro expansion buffer's parent
-// module is the main module rather than a clang module, so the fallback in
-// IRGenerator::getGenModule asserts instead of returning the primary IGM.
-// XFAIL: *
-
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 


### PR DESCRIPTION
- **Explanation**:
This relaxes an ASSERT (active in release builds) from requiring that a module is imported from a clang module, to additionally allowing the bridging header module. This ASSERT is only reached when safe interop wrappers are used.
- **Scope**:
This prevents a compiler crash, otherwise no change.
- **Issues**:
https://github.com/swiftlang/swift/issues/90987
rdar://183277122
- **Original PRs**:
https://github.com/swiftlang/swift/pull/91015
- **Risk**:
Low: only affects cases that currently crash
- **Testing**:
Regression test using reproducer from bug report
- **Reviewers**:
@Xazax-hun 