### PR TITLE
[test] Disable validation-test/stdlib/Dictionary.swift

### DIFF
--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -6,6 +6,7 @@
 //
 // RUN: %target-codesign %t/Dictionary && %line-directive %t/main.swift -- %target-run %t/Dictionary
 // REQUIRES: executable_test
+// REQUIRES: rdar183479588
 
 import StdlibUnittest
 import StdlibCollectionUnittest


### PR DESCRIPTION
Multiple `BridgedToObjC.*` cases fail their leak checks under a Debug-built libswiftCore against MacOSX27.0.sdk on macOS 26+. Disabling validation-test/stdlib/Dictionary.swift until a fix can be found.