### PR TITLE
🍒[6.4] Backdeployment: fix withUnsafeCurrentTask

### DIFF
--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -751,25 +751,21 @@ public func withUnsafeCurrentTask<T>(body: (UnsafeCurrentTask?) throws -> T) ret
 ///
 /// - Returns: The return value, if any, of the `body` closure.
 @available(SwiftStdlib 6.0, *)
-// Note: Could not be always-emit-into client since the UnsafeCurrentTask initializer was not usableFromInline
-// in 6.0, so we can't make this symbol more available than the availability of UnsafeCurrentTask.init.
+@export(implementation)
 @abi(
-  // abi only necessary to avoid redeclaration clash with previous declaration (__abi_withUnsafeCurrentTask)
-  nonisolated(nonsending) func withUnsafeCurrentTaskNonsending<T>(
+  nonisolated(nonsending) func withUnsafeCurrentTaskNonsendingExportedImpl<T>(
     body: nonisolated(nonsending) (UnsafeCurrentTask?) async throws -> T
   ) async rethrows -> T
 )
 public nonisolated(nonsending) func withUnsafeCurrentTask<T>(
   body: nonisolated(nonsending) (UnsafeCurrentTask?) async throws -> T
 ) async rethrows -> T {
-  guard let _task = _getCurrentAsyncTask() else {
-    return try await body(nil)
-  }
-
-  // FIXME: This will be unnecessary once we avoid the release of the task builtin
-  Builtin.retain(_task)
-
-  return try unsafe await body(UnsafeCurrentTask(_task))
+  // This is a backdeployment workaround!
+  // We cannot use the UnsafeCurrentTask initializer since it can't be used from a backdeployed function.
+  // We can get the UnsafeCurrentTask using the withUnsafeCurrentTask and escape the reference.
+  // This is safe, because we know this is the _current task_ so it must be alive still anyway.
+  let task: UnsafeCurrentTask? = unsafe withUnsafeCurrentTask { unsafe $0 }
+  return try unsafe await body(task)
 }
 
 // Old version for ABI compatibility
@@ -780,6 +776,19 @@ public nonisolated(nonsending) func withUnsafeCurrentTask<T>(
 )
 internal func __abi_withUnsafeCurrentTask<T>(
   body: (UnsafeCurrentTask?) async throws -> T
+) async rethrows -> T {
+  unsafe try await withUnsafeCurrentTask(body: body)
+}
+
+// Old version for ABI compatibility
+@available(SwiftStdlib 6.4, *)
+@abi(
+  nonisolated(nonsending) func withUnsafeCurrentTaskNonsending<T>(
+    body: nonisolated(nonsending) (UnsafeCurrentTask?) async throws -> T
+  ) async rethrows -> T
+)
+public nonisolated(nonsending) func __abi_withUnsafeCurrentTaskNonsending<T>(
+  body: nonisolated(nonsending) (UnsafeCurrentTask?) async throws -> T
 ) async rethrows -> T {
   unsafe try await withUnsafeCurrentTask(body: body)
 }

--- a/test/Concurrency/Backdeploy/withFuncs_nonsending.swift
+++ b/test/Concurrency/Backdeploy/withFuncs_nonsending.swift
@@ -1,0 +1,108 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %s -target %target-cpu-apple-macosx27.0 -module-name main -emit-ir -o %t/new.ir
+// RUN: %FileCheck %s --check-prefix=NEW < %t/new.ir
+// RUN: %FileCheck %s --check-prefix=NEW-NO-EXTERNAL-REF < %t/new.ir
+
+// RUN: %target-swift-frontend %s -target %target-cpu-apple-macosx15.0 -module-name main -emit-ir -o %t/backdeploy.ir
+// RUN: %FileCheck %s --check-prefix=BACKDEPLOY < %t/backdeploy.ir
+// RUN: %FileCheck %s --check-prefix=BACKDEPLOY-NO-EXTERNAL-REF < %t/backdeploy.ir
+
+// REQUIRES: OS=macosx
+// REQUIRES: concurrency
+
+// Make sure that when we introduce `nonsending` overloads of with... functions,
+// we don't accidentally break break backdeployment.
+//
+// Getting this wrong would manifest in runtime crashes and missing symbold when
+// running in a backdeployment scenario, so it's worth having this test to verify.
+
+enum TL { static let value = TaskLocal<Int>(wrappedValue: 0) }
+
+@available(macOS 15.0, *)
+func testWithUnsafeCurrentTask() async {
+  await withUnsafeCurrentTask { _ in
+    try? await Task.sleep(nanoseconds: 1)
+  }
+}
+
+@available(macOS 15.0, *)
+func testTaskLocalWithValue() async {
+  await TL.value.withValue(1) {
+    try? await Task.sleep(nanoseconds: 1)
+  }
+}
+
+@available(macOS 15.0, *)
+func testWithCheckedContinuation() async {
+  _ = await withCheckedContinuation { (c: CheckedContinuation<Int, Never>) in
+    c.resume(returning: 1)
+  }
+}
+
+@available(macOS 15.0, *)
+func testWithCheckedThrowingContinuation() async throws {
+  _ = try await withCheckedThrowingContinuation { (c: CheckedContinuation<Int, Error>) in
+    c.resume(returning: 1)
+  }
+}
+
+@available(macOS 15.0, *)
+func testWithUnsafeContinuation() async {
+  _ = await withUnsafeContinuation { (c: UnsafeContinuation<Int, Never>) in
+    c.resume(returning: 1)
+  }
+}
+
+@available(macOS 15.0, *)
+func testWithUnsafeThrowingContinuation() async throws {
+  _ = try await withUnsafeThrowingContinuation { (c: UnsafeContinuation<Int, Error>) in
+    c.resume(returning: 1)
+  }
+}
+
+@available(macOS 15.0, *)
+func testWithTaskCancellationHandler() async {
+  await withTaskCancellationHandler {
+    try? await Task.sleep(nanoseconds: 1)
+  } onCancel: { }
+}
+
+@available(macOS 15.0, *)
+func testTaskGroupWaitForAll() async {
+  await withTaskGroup(of: Int.self) { group in
+    group.addTask { 1 }
+    await group.waitForAll()
+  }
+}
+
+@available(macOS 15.0, *)
+func testThrowingTaskGroupWaitForAll() async throws {
+  try await withThrowingTaskGroup(of: Int.self) { group in
+    group.addTask { 1 }
+    try await group.waitForAll()
+  }
+}
+
+@available(macOS 15.0, *)
+func testThrowingTaskGroupNextResult() async throws {
+  try await withThrowingTaskGroup(of: Int.self) { group in
+    group.addTask { 1 }
+    _ = await group.nextResult()
+  }
+}
+
+@available(macOS 15.0, *)
+func testClockMeasure() async {
+  _ = await ContinuousClock().measure {
+    try? await Task.sleep(nanoseconds: 1)
+  }
+}
+
+// In backdeployment, nothing may reference a symbol that only exists in a newer concurrency runtime.
+//
+// BACKDEPLOY-NO-EXTERNAL-REF-NOT: declare {{.*}}Nonsending
+// NEW-NO-EXTERNAL-REF-NOT: declare {{.*}}Nonsending
+
+// BACKDEPLOY: define linkonce_odr hidden swifttailcc void @"$ss43withUnsafeCurrentTaskNonsendingExportedImpl4bodyxxSctSgYaKYCXE_tYaKlF"
+// NEW: define linkonce_odr hidden swifttailcc void @"$ss43withUnsafeCurrentTaskNonsendingExportedImpl4bodyxxSctSgYaKYCXE_tYaKlF"


### PR DESCRIPTION
**Explanation**: 

Introducing nonsending to withUnsafeCurrentTask specifically, broke its use in backdeployment, as it followed a slightly different pattern than other code where we did this (due to limitations of APIs it touched internally).

We slightly messed up in https://github.com/swiftlang/swift/pull/89343 while adding nonisolated nonsending overload there.

We sadly cannot make this func just usable from inline or always emit into client as we'd do normally because funcs it needs are not usable from inline... Instead, we have to backdeploy this func and use a small trick in the func body to get the unsafe current task. This should be correct even in backdeployment.

**Scope**: 
Uses of withUnsafeCurrentTask in backdeployment situations were broken by this change in 6.4 so we should fix it to not break existing users.

**Risk**: 
- Low, this is a safe pattern, just needed extra attention due to limitations of some APIs that we could not touch from inlinable code.


**Testing**: 
- CI testing, added specific tests to trigger the backdeployment issue described in https://github.com/swiftlang/swift/issues/90946
- 

**Original PR**:
- https://github.com/swiftlang/swift/pull/91051

**Reviewed by**:
- @xedin 
- @tshortli 

**Issues**: 
- resolves rdar://183132497
- resolves https://github.com/swiftlang/swift/issues/90946


