### PR TITLE
[IRGen] Defer WME for escaping private conformances

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2757,7 +2757,16 @@ static void addWTableTypeMetadata(IRGenModule &IGM,
   auto linkage = stripExternalFromLinkage(wt->getLinkage());
   switch (linkage) {
   case SILLinkage::Private:
-    vis = VCallVisibility::VCallVisibilityTranslationUnit;
+    // A private conformance can escape its defining module as an existential.
+    // If the protocol is defined in another module, the dispatch thunks that
+    // make witness method uses visible to VFE are not in this translation
+    // unit. Only assume they are in the linkage unit when the user explicitly
+    // allows link-time internalization.
+    if (conf->getProtocol()->getModuleContext() == IGM.getSwiftModule()) {
+      vis = VCallVisibility::VCallVisibilityTranslationUnit;
+    } else if (IGM.getOptions().InternalizeAtLink) {
+      vis = VCallVisibility::VCallVisibilityLinkageUnit;
+    }
     break;
   case SILLinkage::Hidden:
   case SILLinkage::Shared:

--- a/test/IRGen/witness-method-elimination-ir-thunks.swift
+++ b/test/IRGen/witness-method-elimination-ir-thunks.swift
@@ -4,12 +4,35 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -Xfrontend -enable-llvm-wme -parse-as-library %s -DLIBRARY -module-name Library -emit-module -o %t/Library.swiftmodule
 // RUN: %target-build-swift -Xfrontend -enable-llvm-wme -parse-as-library %s -DCLIENT -module-name Main -I%t -emit-ir -o - | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -enable-llvm-wme -parse-as-library %s -DIMPLEMENTATION -module-name Implementation -I%t -O -emit-ir -o - | %FileCheck %s --check-prefixes=PRIVATE-CONFORMANCE,PUBLIC-VISIBILITY
+// RUN: %target-build-swift -Xfrontend -enable-llvm-wme -Xfrontend -internalize-at-link -parse-as-library %s -DIMPLEMENTATION -module-name Implementation -I%t -O -emit-ir -o - | %FileCheck %s --check-prefixes=PRIVATE-CONFORMANCE,LINKAGE-VISIBILITY
 
 #if LIBRARY
 
 public protocol MyLibraryProtocol {
   func library_req()
 }
+
+#endif
+
+#if IMPLEMENTATION
+
+import Library
+
+private struct PrivateConformer: MyLibraryProtocol {
+  func library_req() {}
+}
+
+public func makePrivateConformer() -> any MyLibraryProtocol {
+  PrivateConformer()
+}
+
+// A private conformance can escape its module as an existential. The protocol
+// dispatch thunk lives in Library, so pre-link VFE in Implementation cannot
+// see the call and must preserve the witness until link time.
+// PRIVATE-CONFORMANCE: = internal constant [2 x ptr] [ptr {{.*}}, ptr @"{{.*}}PrivateConformer{{.*}}library_reqyyFTW"], {{.*}}!vcall_visibility ![[VIS:[0-9]+]]
+// PUBLIC-VISIBILITY: ![[VIS]] = !{i64 0,
+// LINKAGE-VISIBILITY: ![[VIS]] = !{i64 1,
 
 #endif
 


### PR DESCRIPTION
## Summary

- Use public VFE visibility for a private conformance whose protocol is defined in another Swift module.
- Narrow that visibility to the linkage unit when `-internalize-at-link` explicitly seals the client graph.
- Preserve translation-unit visibility for private conformances whose protocol and dispatch thunks are in the same module.
- Extend the cross-module WME IR test with a private conformer that escapes through a public existential factory.

## Problem

A private concrete type and conformance can escape its defining module as a public protocol existential:

```swift
// ProtocolAPI
public protocol SettingsService {
  func value() -> Int
}

// Implementation
private struct SettingsServiceImpl: SettingsService {
  func value() -> Int { 42 }
}

public func makeSettingsService() -> any SettingsService {
  SettingsServiceImpl()
}
```

With `-enable-llvm-wme` and optimization enabled, IRGen currently gives the private witness table translation-unit `vcall_visibility`. LLVM pre-link GlobalDCE therefore assumes every call is visible in the implementation module. The checked-load dispatch thunk is actually emitted in `ProtocolAPI`, so the implementation module contains no matching use. GlobalDCE replaces the still-live witness entry with null before LTO sees the complete linkage unit.

The client then loads and calls that null witness entry.

## Fix

When a private conformance's protocol comes from another module, use public visibility by default. This prevents both pre-link and final-link VFE from assuming that dispatch thunks in another dynamic image are visible.

If `-internalize-at-link` explicitly promises that all clients are in the final link unit, use linkage-unit visibility instead. This prevents destructive pre-link VFE and lets link-time GlobalDCE make the decision after the protocol module and its dispatch thunks are visible.

Private conformances to protocols defined in the same module retain translation-unit visibility.

This builds on the WME mechanism introduced in [#39287](https://github.com/swiftlang/swift/pull/39287).

## Validation

Using Apple Swift 6.3.2 and a three-module ThinLTO reduction:

- current WME/VFE emits `[descriptor, null, null]` in the implementation bitcode and the executable exits with signal 11 / status 139;
- disabling frontend VFE preserves the witness entries and the identical executable prints `42`;
- the existing cross-module dispatch-thunk FileCheck assertions still pass;
- the added regression fails against the current compiler and checks both expected post-fix IR contracts: public visibility normally and linkage-unit visibility under `-internalize-at-link`.

The added regression needs to be exercised by upstream Swift CI on a rebuilt compiler.