### PR TITLE
[Distributed] Prevent remote refs from ever passing assert isolation

### DIFF
--- a/stdlib/public/Distributed/DistributedAssertions.swift
+++ b/stdlib/public/Distributed/DistributedAssertions.swift
@@ -51,6 +51,10 @@ extension DistributedActor {
       return
     }
 
+    precondition(__isLocalActor(self),
+        "Incorrect actor executor assumption; Cannot be isolated to remote distributed actor reference of type '\(self)'. \(message())",
+        file: file, line: line)
+
     let unownedExecutor = unsafe self.unownedExecutor
     let expectationCheck = unsafe _taskIsCurrentExecutor(unownedExecutor._executor)
 
@@ -96,6 +100,13 @@ extension DistributedActor {
       file: StaticString = #fileID, line: UInt = #line
   ) {
     guard _isDebugAssertConfiguration() else {
+      return
+    }
+
+    guard __isLocalActor(self) else {
+      assertionFailure(
+          "Incorrect actor executor assumption; Cannot be isolated to remote distributed actor reference of type '\(self)'. \(message())",
+          file: file, line: line)
       return
     }
 

--- a/stdlib/public/Distributed/DistributedDefaultExecutor.swift
+++ b/stdlib/public/Distributed/DistributedDefaultExecutor.swift
@@ -37,6 +37,12 @@ internal final class DistributedRemoteActorReferenceExecutor: SerialExecutor {
   }
   #endif // !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
 
+  /// A remote distributed actor reference is never isolated to any context,
+  /// since the actual actor instance lives in another process
+  public func checkIsolated() {
+    fatalError("Incorrect actor executor assumption; Cannot be isolated to a remote distributed actor reference!")
+  }
+
   public func asUnownedSerialExecutor() -> UnownedSerialExecutor {
     unsafe UnownedSerialExecutor(ordinary: self)
   }

--- a/test/Distributed/Runtime/distributed_actor_executor_asserts.swift
+++ b/test/Distributed/Runtime/distributed_actor_executor_asserts.swift
@@ -89,6 +89,44 @@ actor EnqueueTest {
         let wrongUse = EnqueueTest(unownedExecutor: normalRemoteWorker.unownedExecutor)
         await wrongUse.test()
       }
+
+      // A remote actor reference must never be considered isolated, even if
+      // the actor uses a shared executor, e.g. the MainActor
+      do {
+        let mainLocalWorker = MainWorker(actorSystem: system)
+        precondition(__isLocalActor(mainLocalWorker), "must be local")
+
+        let mainRemoteWorker = try! MainWorker.resolve(id: mainLocalWorker.id, using: system)
+        precondition(__isRemoteActor(mainRemoteWorker), "must be remote")
+
+        tests.test("preconditionIsolated: remote reference using MainActor's executor, called from MainActor") {
+          expectCrashLater(withMessage: "Cannot be isolated to remote distributed actor reference")
+          await MainActor.run {
+            mainRemoteWorker.preconditionIsolated()
+          }
+        }
+
+        tests.test("assertIsolated: remote reference using MainActor's executor, called from MainActor") {
+          if _isDebugAssertConfiguration() {
+            expectCrashLater(withMessage: "Cannot be isolated to remote distributed actor reference")
+          }
+          await MainActor.run {
+            mainRemoteWorker.assertIsolated()
+          }
+        }
+
+        tests.test("preconditionIsolated: remote reference with default executor") {
+          expectCrashLater(withMessage: "Cannot be isolated to remote distributed actor reference")
+          normalRemoteWorker.preconditionIsolated()
+        }
+
+        tests.test("preconditionIsolated: local reference using MainActor's executor, called from MainActor") {
+          await MainActor.run {
+            mainLocalWorker.preconditionIsolated()
+            mainLocalWorker.assertIsolated()
+          }
+        }
+      }
     }
 
     await runAllTestsAsync()

--- a/test/abi/macOS/arm64/distributed.swift
+++ b/test/abi/macOS/arm64/distributed.swift
@@ -110,3 +110,6 @@ Added: _$s11Distributed26_distributedStubFatalError8functions5NeverOSS_tF
 Added: _$s11Distributed0A5ActorPAAE9whenLocalyqd__Sgqd__xYiYaYbqd_0_YKXEYaqd_0_YKs8SendableRd__s5ErrorRd_0_r0_lF
 // async function pointer to (extension in Distributed):Distributed.DistributedActor.whenLocal<A, B where A1: Swift.Sendable, B1: Swift.Error>(@Sendable (isolated A) async throws(B1) -> A1) async throws(B1) -> A1?
 Added: _$s11Distributed0A5ActorPAAE9whenLocalyqd__Sgqd__xYiYaYbqd_0_YKXEYaqd_0_YKs8SendableRd__s5ErrorRd_0_r0_lFTu
+
+// Distributed.DistributedRemoteActorReferenceExecutor.checkIsolated() -> ()
+Added: _$s11Distributed0A28RemoteActorReferenceExecutorC13checkIsolatedyyF

--- a/test/abi/macOS/x86_64/distributed.swift
+++ b/test/abi/macOS/x86_64/distributed.swift
@@ -110,3 +110,6 @@ Added: _$s11Distributed26_distributedStubFatalError8functions5NeverOSS_tF
 Added: _$s11Distributed0A5ActorPAAE9whenLocalyqd__Sgqd__xYiYaYbqd_0_YKXEYaqd_0_YKs8SendableRd__s5ErrorRd_0_r0_lF
 // async function pointer to (extension in Distributed):Distributed.DistributedActor.whenLocal<A, B where A1: Swift.Sendable, B1: Swift.Error>(@Sendable (isolated A) async throws(B1) -> A1) async throws(B1) -> A1?
 Added: _$s11Distributed0A5ActorPAAE9whenLocalyqd__Sgqd__xYiYaYbqd_0_YKXEYaqd_0_YKs8SendableRd__s5ErrorRd_0_r0_lFTu
+
+// Distributed.DistributedRemoteActorReferenceExecutor.checkIsolated() -> ()
+Added: _$s11Distributed0A28RemoteActorReferenceExecutorC13checkIsolatedyyF


### PR DESCRIPTION
A remote reference can never be used for isolation; it literarily "does not exist" in this process and is only a remote proxy.

If we used some shared executor, we should wrongly asume the same executor means that it is isolated; but that's not the case, since a remote ref is always a proxy and cannot be used for isolation, even if in a local instance of such type would be using the same executor.

resolves rdar://182990720

