### PR TITLE
IRGen: Adjust to "Reapply [ConstantInt] Disable implicit truncation in ConstantInt::get() (#171456)"

### DIFF
--- a/lib/IRGen/ExtraInhabitants.cpp
+++ b/lib/IRGen/ExtraInhabitants.cpp
@@ -106,7 +106,7 @@ llvm::Value *PointerInfo::getExtraInhabitantIndex(IRGenFunction &IGF,
                                                   Address src) const {
   llvm::BasicBlock *contBB = IGF.createBasicBlock("is-valid-pointer");
   SmallVector<std::pair<llvm::BasicBlock*, llvm::Value*>, 3> phiValues;
-  auto invalidIndex = llvm::ConstantInt::getSigned(IGF.IGM.Int32Ty, -1);
+  auto invalidIndex = llvm::ConstantInt::getAllOnesValue(IGF.IGM.Int32Ty);
 
   src = IGF.Builder.CreateElementBitCast(src, IGF.IGM.SizeTy);
 

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -5239,9 +5239,9 @@ void irgen::emitYieldOnce2CoroutineEntry(IRGenFunction &IGF,
   auto *typeID = IGF.getMallocTypeId();
   emitRetconCoroutineEntry(
       IGF, fnType, buffer, llvm::Intrinsic::coro_id_retcon_once_dynamic,
-      Size(-1) /*dynamic-to-IRGen size*/, IGF.IGM.getCoroStaticFrameAlignment(),
-      {cfp, allocator}, allocFn, deallocFn,
-      {allocFrameFn, deallocFrameFn, typeID});
+      Size(uint32_t(-1)) /*dynamic-to-IRGen size*/,
+      IGF.IGM.getCoroStaticFrameAlignment(), {cfp, allocator}, allocFn,
+      deallocFn, {allocFrameFn, deallocFrameFn, typeID});
 }
 void irgen::emitYieldOnce2CoroutineEntry(
     IRGenFunction &IGF, LinkEntity coroFunction, CanSILFunctionType fnType,

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -799,7 +799,7 @@ namespace {
     const override {
       if (!getSingleton()) {
         // Any empty value is a valid value.
-        return llvm::ConstantInt::getSigned(IGF.IGM.Int32Ty, -1);
+        return llvm::ConstantInt::getAllOnesValue(IGM.Int32Ty);
       }
 
       return getFixedSingleton()->getExtraInhabitantIndex(IGF,
@@ -1275,8 +1275,8 @@ namespace {
       auto valid
         = IGF.Builder.CreateICmpSLT(val,
                                     llvm::ConstantInt::get(IGF.IGM.Int32Ty, 0));
-      val = IGF.Builder.CreateSelect(valid,
-                        llvm::ConstantInt::getSigned(IGF.IGM.Int32Ty, -1), val);
+      val = IGF.Builder.CreateSelect(
+          valid, llvm::ConstantInt::getAllOnesValue(IGM.Int32Ty), val);
 
       return val;
     }
@@ -3649,9 +3649,8 @@ namespace {
          llvm::ConstantInt::get(IGM.Int32Ty, ElementsWithNoPayload.size()));
       auto valid = IGF.Builder.CreateICmpSLT(index,
                                    llvm::ConstantInt::get(IGM.Int32Ty, 0));
-      index = IGF.Builder.CreateSelect(valid,
-                              llvm::ConstantInt::getSigned(IGM.Int32Ty, -1),
-                              index);
+      index = IGF.Builder.CreateSelect(
+          valid, llvm::ConstantInt::getAllOnesValue(IGM.Int32Ty), index);
       return index;
     }
 

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -935,8 +935,16 @@ namespace {
     /// Map the given element to the appropriate value in the
     /// discriminator type.
     llvm::ConstantInt *getDiscriminatorIdxConst(EnumElementDecl *target) const {
-      int64_t index = getDiscriminatorIndex(target);
-      return llvm::ConstantInt::get(getDiscriminatorType(), index);
+      auto index = getDiscriminatorIndex(target);
+      auto *intType = getDiscriminatorType();
+
+      // Construct an all-ones value for a null index.
+      if (!index) {
+        return cast<llvm::ConstantInt>(
+            llvm::ConstantInt::getAllOnesValue(intType));
+      }
+
+      return llvm::ConstantInt::get(intType, index.value());
     }
     
 
@@ -1205,9 +1213,10 @@ namespace {
 
 
     // TODO: Support this function also for other enum implementation strategies.
-    int64_t getDiscriminatorIndex(EnumElementDecl *elt) const override {
+    std::optional<uint64_t>
+    getDiscriminatorIndex(EnumElementDecl *elt) const override {
       // The elements are assigned discriminators in declaration order.
-      return getTagIndex(elt);
+      return uint64_t(getTagIndex(elt));
     }
 
     // TODO: Support this function also for other enum implementation strategies.
@@ -1313,13 +1322,14 @@ namespace {
     : public NoPayloadEnumImplStrategyBase
   {
   protected:
-    int64_t getDiscriminatorIndex(EnumElementDecl *target) const override {
+    std::optional<uint64_t>
+    getDiscriminatorIndex(EnumElementDecl *target) const override {
       // The elements are assigned discriminators ABI-compatible with their
-      // raw values from C. An invalid raw value is assigned the error index -1.
+      // raw values from C. If the raw value is invalid, return nil.
       auto intExpr =
           dyn_cast_or_null<IntegerLiteralExpr>(target->getRawValueExpr());
       if (!intExpr) {
-        return -1;
+        return std::nullopt;
       }
       auto intType = getDiscriminatorType();
 

--- a/lib/IRGen/GenEnum.h
+++ b/lib/IRGen/GenEnum.h
@@ -15,6 +15,7 @@
 
 #include "TypeInfo.h"
 #include "LoadableTypeInfo.h"
+#include <optional>
 
 namespace llvm {
   class BasicBlock;
@@ -239,9 +240,11 @@ public:
 
   /// Map the given element to the appropriate index in the
   /// discriminator type.
-  /// Returns -1 if this is not supported by the enum implementation.
-  virtual int64_t getDiscriminatorIndex(EnumElementDecl *target) const {
-    return -1;
+  /// `std::nullopt` signals an invalid index or that this is not supported by
+  /// the enum implementation.
+  virtual std::optional<uint64_t>
+  getDiscriminatorIndex(EnumElementDecl *target) const {
+    return std::nullopt;
   }
 
   /// Emit field names for enum reflection.

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -852,8 +852,8 @@ llvm::Value *IRGenFunction::getReferenceStorageExtraInhabitantIndex(Address src,
   llvm::Value *ptr = Builder.CreateLoad(src);
   llvm::Value *isNull = Builder.CreateIsNull(ptr);
   llvm::Value *result =
-    Builder.CreateSelect(isNull, Builder.getInt32(0),
-                         llvm::ConstantInt::getSigned(IGM.Int32Ty, -1));
+      Builder.CreateSelect(isNull, Builder.getInt32(0),
+                           llvm::ConstantInt::getAllOnesValue(IGM.Int32Ty));
   return result;
 }
 

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -1786,7 +1786,7 @@ llvm::Constant *IRGenModule::emitStaticKeyPathInstance(KeyPathInst *KPI) {
   if (!swiftImmortalRefCount) {
     // = HeapObject.immortalRefCount | HeapObject.doNotFreeBit
     // (all-ones on both 32-bit and 64-bit).
-    swiftImmortalRefCount = llvm::ConstantInt::get(IntPtrTy, -1);
+    swiftImmortalRefCount = llvm::ConstantInt::getAllOnesValue(IntPtrTy);
   }
 
   auto *ObjectHeaderTy = RefCountedStructTy;

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -2872,8 +2872,7 @@ namespace {
               if (isUnavailability) {
                 // Invert the result of "at least" check by xor'ing resulting
                 // boolean with `-1`.
-                success =
-                    IGF.Builder.CreateXor(success, IGF.Builder.getIntN(1, -1));
+                success = IGF.Builder.CreateXor(success, IGF.Builder.getTrue());
               }
 
               auto nextCondOrRet = queryIndex == queries.size() - 1

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -744,13 +744,14 @@ llvm::Value *irgen::getFixedTypeEnumTagSinglePayload(
     result0 = getExtraInhabitantIndex(enumAddr);
     noExtraTagBitsBB = Builder.GetInsertBlock();
   } else {
-    result0 = llvm::ConstantInt::getSigned(IGM.Int32Ty, -1);
+    result0 = llvm::ConstantInt::getAllOnesValue(IGM.Int32Ty);
   }
   Builder.CreateBr(resultBB);
 
   Builder.emitBlock(singleCaseEnumBB);
   // Otherwise, we have a valid payload.
-  auto *result2 = llvm::ConstantInt::getSigned(IGM.Int32Ty, -1);
+
+  auto *result2 = llvm::ConstantInt::getAllOnesValue(IGM.Int32Ty);
   Builder.CreateBr(resultBB);
 
   Builder.emitBlock(resultBB);
@@ -759,7 +760,7 @@ llvm::Value *irgen::getFixedTypeEnumTagSinglePayload(
   result->addIncoming(result1, extraTagBitsBB);
   result->addIncoming(result2, singleCaseEnumBB);
 
-  return Builder.CreateAdd(result, llvm::ConstantInt::get(IGM.Int32Ty, 1));
+  return Builder.CreateAdd(result, Builder.getInt32(1));
 }
 
 void FixedTypeInfo::storeEnumTagSinglePayload(IRGenFunction &IGF,

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -5271,8 +5271,8 @@ mapTriviallyToInt(IRGenSILFunction &IGF, const EnumImplStrategy &EIS, SelectEnum
   for (unsigned i = 0, e = inst->getNumCases(); i < e; ++i) {
     auto casePair = inst->getCase(i);
 
-    int64_t index = EIS.getDiscriminatorIndex(casePair.first);
-    if (index < 0)
+    auto index = EIS.getDiscriminatorIndex(casePair.first);
+    if (!index)
       return nullptr;
     
     auto *intLit = dyn_cast<IntegerLiteralInst>(casePair.second);
@@ -5280,7 +5280,7 @@ mapTriviallyToInt(IRGenSILFunction &IGF, const EnumImplStrategy &EIS, SelectEnum
       return nullptr;
     
     APInt caseValue = intLit->getValue();
-    APInt offset = caseValue - index;
+    APInt offset = caseValue - index.value();
     if (offsetValid) {
       if (offset != commonOffset)
         return nullptr;


### PR DESCRIPTION
Follow-up to https://github.com/swiftlang/swift/pull/90857. The buffer size here can be all-ones (uint64_t)—not something that fits in 32 bits. Unclear if this was behaving as expected. For now, explicitly allow truncation under a FIXME to unblock rebranch.

FYI: This was found while running LLDB tests: `lang/swift/yielding_accessors/TestSwiftYieldingAccessors.py`.