### PR TITLE
[DebugInfo] Salvage convert_function transitive users

### DIFF
--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -1829,6 +1829,7 @@ bool swift::tryEliminateOnlyOwnershipUsedForwardingInst(
   }
 
   SmallVector<Operand *, 32> worklist(getNonDebugUses(forwardingInst));
+  SmallVector<SILInstruction *, 4> forwardingUsers;
   while (!worklist.empty()) {
     auto *use = worklist.pop_back_val();
     auto *user = use->getUser();
@@ -1838,6 +1839,7 @@ bool swift::tryEliminateOnlyOwnershipUsedForwardingInst(
       continue;
 
     if (isa<CopyValueInst>(user) || isa<BeginBorrowInst>(user)) {
+      forwardingUsers.push_back(user);
       for (auto result : user->getResults())
         for (auto *resultUse : getNonDebugUses(result))
           worklist.push_back(resultUse);
@@ -1847,9 +1849,12 @@ bool swift::tryEliminateOnlyOwnershipUsedForwardingInst(
     return false;
   }
 
-  // Rewrite debug uses separately (they might need salvaging logic).
-  // Note: We know that `forwardingInst` is salvageable as this function is
-  // only called with convert_function instructions.
+  // Rewrite all debug uses separately (they might need salvaging logic).
+  // Note: We know that `forwardingInst` and its users are salvageable as this
+  // function is only called with convert_function instructions, and
+  // begin_borrow and copy_value are salvageable as well.
+  for (auto *inst : llvm::reverse(forwardingUsers))
+    salvageDebugInfo(inst);
   salvageDebugInfo(forwardingInst);
 
   // Now that we know we can perform our transform, set all uses of

--- a/test/DebugInfo/salvage_convert_function.sil
+++ b/test/DebugInfo/salvage_convert_function.sil
@@ -27,3 +27,75 @@ bb0(%0 : $@callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error an
   %r = tuple ()
   return %r : $()
 }
+
+sil @closure_body : $@convention(thin) (Int, @in_guaranteed Array<Int>) -> Int
+
+// Test that when the debug_value is on a begin_borrow of the convert_function,
+// it still gets salvaged.
+// This is reduced SIL from the standard library that was causing a crash.
+
+// CHECK-LABEL: sil [ossa] @test_salvage_convert_function_through_borrow
+// CHECK:   debug_value %{{[0-9]+}}, let, name "body", argno 1, transform {
+// CHECK:   bb0(%0 : $@noescape @callee_guaranteed (Int) -> Int):
+// CHECK:     %1 = convert_function %0 to $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>
+// CHECK:     return %1
+// CHECK:   }
+// CHECK: } // end sil function 'test_salvage_convert_function_through_borrow'
+sil [ossa] @test_salvage_convert_function_through_borrow : $@convention(thin) (@guaranteed Array<Int>, Int) -> Int {
+bb0(%0 : @guaranteed $Array<Int>, %1 : $Int):
+  %alloc = alloc_stack $Array<Int>
+  %sb = store_borrow %0 to %alloc : $*Array<Int>
+
+  %fn = function_ref @closure_body : $@convention(thin) (Int, @in_guaranteed Array<Int>) -> Int
+  %pa = partial_apply [callee_guaranteed] [on_stack] %fn(%sb) : $@convention(thin) (Int, @in_guaranteed Array<Int>) -> Int
+  %md = mark_dependence [nonescaping] %pa : $@noescape @callee_guaranteed (Int) -> Int on %sb : $*Array<Int>
+  %cf = convert_function %md : $@noescape @callee_guaranteed (Int) -> Int to $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>
+  %bb = begin_borrow %cf : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>
+
+  debug_value %bb : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>, let, name "body", argno 1, transform {
+  bb0(%d0 : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>):
+    return %d0 : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>
+  }
+
+  %r = apply %bb(%1) : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>
+  end_borrow %bb : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>
+  destroy_value %cf : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>
+  end_borrow %sb : $*Array<Int>
+  dealloc_stack %alloc : $*Array<Int>
+  return %r : $Int
+}
+
+// Test multiple levels, with both a begin_borrow and a copy_value.
+
+// CHECK-LABEL: sil [ossa] @test_salvage_convert_function_multilevel
+// CHECK:   debug_value %{{[0-9]+}}, let, name "body", argno 1, transform {
+// CHECK:   bb0(%0 : $@noescape @callee_guaranteed (Int) -> Int):
+// CHECK:     %1 = convert_function %0 to $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>
+// CHECK:     return %1
+// CHECK:   }
+// CHECK: } // end sil function 'test_salvage_convert_function_multilevel'
+sil [ossa] @test_salvage_convert_function_multilevel : $@convention(thin) (@guaranteed Array<Int>, Int) -> Int {
+bb0(%0 : @guaranteed $Array<Int>, %1 : $Int):
+  %alloc = alloc_stack $Array<Int>
+  %sb = store_borrow %0 to %alloc : $*Array<Int>
+
+  %fn = function_ref @closure_body : $@convention(thin) (Int, @in_guaranteed Array<Int>) -> Int
+  %pa = partial_apply [callee_guaranteed] [on_stack] %fn(%sb) : $@convention(thin) (Int, @in_guaranteed Array<Int>) -> Int
+  %md = mark_dependence [nonescaping] %pa : $@noescape @callee_guaranteed (Int) -> Int on %sb : $*Array<Int>
+  %cf = convert_function %md : $@noescape @callee_guaranteed (Int) -> Int to $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>
+  %bb = begin_borrow %cf : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>
+  %cp = copy_value %bb : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>
+
+  debug_value %cp : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>, let, name "body", argno 1, transform {
+  bb0(%d0 : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>):
+    return %d0 : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>
+  }
+
+  %r = apply %cp(%1) : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>
+  destroy_value %cp : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>
+  end_borrow %bb : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>
+  destroy_value %cf : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (τ_0_0) -> τ_0_1 for <Int, Int>
+  end_borrow %sb : $*Array<Int>
+  dealloc_stack %alloc : $*Array<Int>
+  return %r : $Int
+}


### PR DESCRIPTION
The debug uses of the convert_function instruction being replaced with values of a different type is a problem, as the debug value incorrectly changes type.

The salvageDebugInfo function must be called on all transitive uses, including begin_borrow and copy_value, which also need to be salvaged.

This fixes a compiler assertion for an invalid type chain.

rdar://183435195

