### PR TITLE
SimplifyPointerToAddress: correctly handle `load_borrow`

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyPointerToAddress.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyPointerToAddress.swift
@@ -211,8 +211,12 @@ private extension PointerToAddressInst {
     case .unlimitedLifetime:
       return false
     case .limitedLifetime:
-      var addressUses = AddressUses(of: self, context)
+      var addressUses = AddressUses(context)
       defer { addressUses.deinitialize() }
+      if addressUses.walkDownUses(ofAddress: self, path: UnusedWalkingPath()) == .abortWalk {
+        // We cannot reason about all uses (e.g. a reborrowed `load_borrow`), so bail conservatively.
+        return true
+      }
       return addressUses.hasUsesOutside(of: lifetimeFrontier, beginInstruction: baseAddress)
     }
   }
@@ -259,9 +263,8 @@ private extension AccessBase {
 private struct AddressUses : AddressDefUseWalker {
   var users: InstructionWorklist
 
-  init(of address: Value, _ context: SimplifyContext) {
+  init(_ context: SimplifyContext) {
     users = InstructionWorklist(context)
-    _ = walkDownUses(ofAddress: address, path: UnusedWalkingPath())
   }
 
   mutating func deinitialize() {
@@ -274,6 +277,22 @@ private struct AddressUses : AddressDefUseWalker {
       return walkDownUses(ofAddress: ia, path: path)
     }
     users.pushIfNotVisited(address.instruction)
+
+    if let loadBorrow = address.instruction as? LoadBorrowInst {
+      // A `load_borrow` opens a borrow scope which borrows the memory of the address. If the address
+      // is an interior pointer into a borrowed object, that scope must be nested within the object's
+      // borrow scope. The scope can extend beyond the `load_borrow` itself, so its scope-ending
+      // `end_borrow`s are the relevant latest uses of the interior pointer and must be checked against
+      // the object's lifetime.
+      for endOperand in loadBorrow.scopeEndingOperands {
+        // A `load_borrow` can be reborrowed, in which case its scope is ended by a `br` instead of an
+        // `end_borrow`. We cannot track the reborrowed value's uses here, so bail conservatively.
+        guard let endBorrow = endOperand.instruction as? EndBorrowInst else {
+          return .abortWalk
+        }
+        users.pushIfNotVisited(endBorrow)
+      }
+    }
     return .continueWalk
   }
 

--- a/test/SILOptimizer/simplify_pointer_to_address.sil
+++ b/test/SILOptimizer/simplify_pointer_to_address.sil
@@ -9,6 +9,10 @@ import SwiftShims
 
 class C {}
 
+class D {
+  @_hasStorage var x: Int { get set }
+}
+
 // CHECK-LABEL: sil @remove_conversion :
 // CHECK-NOT:     address_to_pointer
 // CHECK-NOT:     pointer_to_address
@@ -114,6 +118,78 @@ bb0(%0 : @guaranteed $C):
   %6 = load [trivial] %5 : $*Int
   end_borrow %1 : $C
   return %6 : $Int
+}
+
+// The loaded value %5 opens a borrow scope whose use (%6) and end_borrow extend past the
+// outer end_borrow. Removing the address_to_pointer/pointer_to_address pair would turn %4
+// into a real interior pointer, making %5 outlive its object's borrow -> invalid OSSA.
+// Must NOT be folded.
+// CHECK-LABEL: sil [ossa] @borrow_load_borrow_escape :
+// CHECK:         address_to_pointer
+// CHECK:         pointer_to_address
+// CHECK:       } // end sil function 'borrow_load_borrow_escape'
+sil [ossa] @borrow_load_borrow_escape : $@convention(thin) (@guaranteed C) -> Int {
+bb0(%0 : @guaranteed $C):
+  %1 = begin_borrow %0 : $C
+  %2 = ref_tail_addr %1 : $C, $D
+  %3 = address_to_pointer %2 : $*D to $Builtin.RawPointer
+  %4 = pointer_to_address %3 : $Builtin.RawPointer to [strict] $*D
+  %5 = load_borrow %4 : $*D
+  end_borrow %1 : $C
+  %6 = ref_element_addr %5 : $D, #D.x
+  %7 = begin_access [read] [dynamic] %6 : $*Int
+  %8 = load [trivial] %7 : $*Int
+  end_access %7 : $*Int
+  end_borrow %5 : $D
+  return %8 : $Int
+}
+
+// Here the load_borrow's scope ends before the outer end_borrow, so the pair is safe to
+// remove.
+// CHECK-LABEL: sil [ossa] @borrow_load_borrow_no_escape :
+// CHECK-NOT:     address_to_pointer
+// CHECK-NOT:     pointer_to_address
+// CHECK:       } // end sil function 'borrow_load_borrow_no_escape'
+sil [ossa] @borrow_load_borrow_no_escape : $@convention(thin) (@guaranteed C) -> Int {
+bb0(%0 : @guaranteed $C):
+  %1 = begin_borrow %0 : $C
+  %2 = ref_tail_addr %1 : $C, $D
+  %3 = address_to_pointer %2 : $*D to $Builtin.RawPointer
+  %4 = pointer_to_address %3 : $Builtin.RawPointer to [strict] $*D
+  %5 = load_borrow %4 : $*D
+  %6 = ref_element_addr %5 : $D, #D.x
+  %7 = begin_access [read] [dynamic] %6 : $*Int
+  %8 = load [trivial] %7 : $*Int
+  end_access %7 : $*Int
+  end_borrow %5 : $D
+  end_borrow %1 : $C
+  return %8 : $Int
+}
+
+// A reborrowed load_borrow: its scope is ended by a `br`, not an `end_borrow`. We cannot track
+// the reborrowed value's uses, so we bail conservatively and do not fold.
+// CHECK-LABEL: sil [ossa] @borrow_load_borrow_reborrow :
+// CHECK:         address_to_pointer
+// CHECK:         pointer_to_address
+// CHECK:       } // end sil function 'borrow_load_borrow_reborrow'
+sil [ossa] @borrow_load_borrow_reborrow : $@convention(thin) (@guaranteed C) -> Int {
+bb0(%0 : @guaranteed $C):
+  %1 = begin_borrow %0 : $C
+  %2 = ref_tail_addr %1 : $C, $D
+  %3 = address_to_pointer %2 : $*D to $Builtin.RawPointer
+  %4 = pointer_to_address %3 : $Builtin.RawPointer to [strict] $*D
+  %5 = load_borrow %4 : $*D
+  br bb1(%5 : $D)
+
+bb1(%6 : @guaranteed $D):
+  %7 = borrowed %6 : $D from ()
+  end_borrow %1 : $C
+  %8 = ref_element_addr %7 : $D, #D.x
+  %9 = begin_access [read] [dynamic] %8 : $*Int
+  %10 = load [trivial] %9 : $*Int
+  end_access %9 : $*Int
+  end_borrow %7 : $D
+  return %10 : $Int
 }
 
 // CHECK-LABEL: sil [ossa] @stack_escape :


### PR DESCRIPTION
When folding an address_to_pointer/pointer_to_address pair, a `load_borrow` of the resulting interior pointer opens a borrow scope whose `end_borrow`s can outlive the object's borrow scope. Account for those scope-ending uses in the lifetime check.

Fixes an ownership verification error
rdar://182126561
