### PR TITLE
[cxx-interop] Fix various lifetimes related crashes

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -8651,6 +8651,20 @@ public:
   /// Whether the function is a non-static method.
   bool isInstanceMethod() const { return hasImplicitSelfDecl() && !isStatic(); }
 
+  /// Whether 'self' occupies an index in this function's lifetime dependence
+  /// index space, which consists of the parameters, optionally followed by
+  /// 'self', followed by the result.
+  ///
+  /// An imported C++ constructor's implicit metatype 'self' is dropped when
+  /// lowering to SIL (see TypeConverter::getLoweredFormalTypes()), so, unlike
+  /// the 'self' of an importer-synthesized value constructor, it does not
+  /// occupy an index.
+  bool hasSelfInLifetimeDependenceIndices() const;
+
+  /// The index representing this function's result in its lifetime dependence
+  /// index space. See hasSelfInLifetimeDependenceIndices().
+  unsigned getLifetimeDependenceResultIndex() const;
+
   /// Retrieve the declaration that this method overrides, if any.
   AbstractFunctionDecl *getOverriddenDecl() const {
     return cast_or_null<AbstractFunctionDecl>(ValueDecl::getOverriddenDecl());

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8913,6 +8913,9 @@ ERROR(lifetime_dependence_cannot_infer_kind, none,
 ERROR(lifetime_dependence_cannot_infer_scope_ownership, none,
       "cannot borrow the lifetime of '%0', which has consuming ownership on %1",
       (StringRef, StringRef))
+ERROR(lifetime_dependence_cannot_infer_scope_foreign_by_value, none,
+      "cannot borrow the lifetime of '%0', which is passed by value on %1",
+      (StringRef, StringRef))
 NOTE(lifetime_dependence_cannot_infer_inout_suggest, none,
      "use '@_lifetime(%0: copy %0) to forward the inout dependency",
      (StringRef))

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -80,6 +80,7 @@
 #include "clang/Basic/Module.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/AST/Attr.h"
+#include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclObjC.h"
 
 #include <algorithm>
@@ -11240,6 +11241,16 @@ ParamDecl *AbstractFunctionDecl::getImplicitSelfDecl(bool createIfNeeded) {
     (*selfDecl)->setAddressable(true);
   }
   return *selfDecl;
+}
+
+bool AbstractFunctionDecl::hasSelfInLifetimeDependenceIndices() const {
+  return isInstanceMethod() &&
+         !isa_and_nonnull<clang::CXXConstructorDecl>(getClangDecl());
+}
+
+unsigned AbstractFunctionDecl::getLifetimeDependenceResultIndex() const {
+  return getParameters()->size() +
+         (hasSelfInLifetimeDependenceIndices() ? 1 : 0);
 }
 
 void AbstractFunctionDecl::setParameters(ParameterList *BodyParams) {

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -19,7 +19,6 @@
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/Module.h"
-#include "swift/AST/PackConformance.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SourceFile.h"
@@ -29,6 +28,7 @@
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/Range.h"
 #include "swift/Basic/SourceManager.h"
+#include "clang/AST/Decl.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/MapVector.h"
 
@@ -478,12 +478,6 @@ class LifetimeDependenceChecker {
   bool performedDiagnostics = false;
 
 public:
-  static unsigned getResultIndex(AbstractFunctionDecl *afd) {
-    return afd->isInstanceMethod()
-               ? (unsigned)(afd->getParameters()->size() + 1)
-               : (unsigned)afd->getParameters()->size();
-  }
-
   static unsigned getResultIndex(EnumElementDecl *eed) {
     auto *paramList = eed->getParameterList();
     return paramList ? (unsigned)(paramList->size() + 1) : 1;
@@ -507,7 +501,7 @@ public:
   }
 
   static std::optional<ParamInfo> getSelfParamInfo(AbstractFunctionDecl *afd) {
-    if (!afd->isInstanceMethod())
+    if (!afd->hasSelfInLifetimeDependenceIndices())
       return std::nullopt;
     auto *selfDecl = afd->getImplicitSelfDecl();
     if (!selfDecl)
@@ -601,7 +595,7 @@ public:
         escapableDecl(ctx.getProtocol(
             swift::getKnownProtocolKind(InvertibleProtocolKind::Escapable))),
         genericEnv(afd->getGenericEnvironment()),
-        resultIndex(getResultIndex(afd)),
+        resultIndex(afd->getLifetimeDependenceResultIndex()),
         resultTy(afd->mapTypeIntoEnvironment(getResultOrYieldInterface(afd))),
         returnLoc(getReturnLoc(afd)),
         implicitSelfParamInfo(getSelfParamInfo(afd)),
@@ -861,10 +855,12 @@ protected:
         return qualifier;
       }
     }
+    if (isInit) {
+      // An imported C++ constructor has no 'self' in the lifetime dependence
+      // index space, so this cannot rely on 'implicitSelfParamInfo'.
+      return "an initializer";
+    }
     if (implicitSelfParamInfo.has_value()) {
-      if (isInit) {
-        return "an initializer";
-      }
       if (implicitSelfParamInfo->param.isInOut()) {
         return "a mutating method";
       }
@@ -1849,6 +1845,39 @@ protected:
       return;
     }
     auto kind = LifetimeDependenceKind::Scope;
+    // A foreign function's parameter conventions are fixed by its C
+    // declaration. Imported C records are addressable-for-dependencies (see
+    // TypeConverter::getTypeProperties()), so a scoped dependency on one is
+    // lowered as an address dependency -- but a record that the callee receives
+    // as its own copy has no borrowable storage in the caller to form one on.
+    // Do not infer a dependency that cannot be lowered; an explicit annotation
+    // is required instead.
+    //
+    // A record passed by pointer or lvalue reference does have borrowable
+    // storage, so those keep their inferred dependency.
+    if (auto *clangFn =
+            dyn_cast_or_null<clang::FunctionDecl>(afd->getClangDecl())) {
+      // 'self' is not part of the Clang parameter list, and inference only
+      // reaches this point for a single Swift parameter.
+      if (clangFn->getNumParams() == 1) {
+        auto clangParamTy = clangFn->getParamDecl(0)->getType();
+        // An rvalue reference is imported as 'consuming', which likewise leaves
+        // nothing to borrow.
+        if (auto *rvalueRef = clangParamTy->getAs<clang::RValueReferenceType>())
+          clangParamTy = rvalueRef->getPointeeType();
+        if (clangParamTy->isRecordType()) {
+          // C++ allows unnamed parameters. Inference only reaches this point
+          // for a function with a single parameter, so name it positionally.
+          StringRef paramName =
+              paramInfo.name().empty() ? "parameter #1" : paramInfo.name();
+          diagnose(
+              returnLoc,
+              diag::lifetime_dependence_cannot_infer_scope_foreign_by_value,
+              paramName, diagnosticQualifier());
+          return;
+        }
+      }
+    }
     if (!isCompatibleWithOwnership(kind, paramInfo)) {
       diagnose(returnLoc,
                diag::lifetime_dependence_cannot_infer_scope_ownership,

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2201,13 +2201,9 @@ namespace {
     // `fd`. This also prevents the implicit single-parameter
     // lifetime-dependence inference from running for it.
     void cacheImmortalLifetime(AbstractFunctionDecl *fd) {
-      unsigned resultIndex = fd->getParameters()->size();
-      if (fd->isInstanceMethod()) {
-        ++resultIndex;
-      }
       SmallVector<LifetimeDependenceInfo, 1> lifetimeDependencies;
       LifetimeDependenceInfo immortalLifetime(
-          nullptr, nullptr, resultIndex,
+          nullptr, nullptr, fd->getLifetimeDependenceResultIndex(),
           LifetimeFlags().withImmortalSpecifier().withAnnotated());
       lifetimeDependencies.push_back(immortalLifetime);
       Impl.SwiftContext.evaluator.cacheOutput(
@@ -4442,10 +4438,7 @@ namespace {
         return false;
       };
 
-      auto swiftParams = result->getParameters();
-      bool hasSelf =
-          result->isInstanceMethod() && !isa<ConstructorDecl>(result);
-      auto returnIdx = swiftParams->size() + hasSelf;
+      auto returnIdx = result->getLifetimeDependenceResultIndex();
 
       if (inferSelfDependence(decl, result, returnIdx))
         return;
@@ -4626,10 +4619,13 @@ namespace {
         // synthesize a scoped dependency that would be invalid.
         cacheImmortalLifetime(result);
       } else if (resultIsNonEscapable) {
+        auto policy = Impl.getClangASTContext().getPrintingPolicy();
+        policy.SuppressTagKeyword = true;
         Impl.addImportDiagnostic(
             decl,
             Diagnostic(diag::return_nonescapable_without_lifetimebound,
-                       Impl.SwiftContext.AllocateCopy(retType.getAsString())),
+                       Impl.SwiftContext.AllocateCopy(
+                           resultTypeForEscapability.getAsString(policy))),
             decl->getLocation());
       }
 

--- a/test/Interop/Cxx/class/nonescapable-errors.swift
+++ b/test/Interop/Cxx/class/nonescapable-errors.swift
@@ -5,6 +5,7 @@
 // RUN:   -I %t%{fs-sep}Inputs \
 // RUN:   -cxx-interoperability-mode=default \
 // RUN:   -verify-ignore-unrelated \
+// RUN:   -Xcc -Wno-nullability-completeness \
 // RUN:   -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}nonescapable.h \
 // RUN:   -verify-additional-prefix LIFETIMES- \
 // RUN:   -enable-experimental-feature LifetimeDependence
@@ -13,6 +14,7 @@
 // RUN:   -I %t%{fs-sep}Inputs \
 // RUN:   -cxx-interoperability-mode=default \
 // RUN:   -verify-ignore-unrelated \
+// RUN:   -Xcc -Wno-nullability-completeness \
 // RUN:   -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}nonescapable.h \
 // RUN:   -verify-additional-prefix NO-LIFETIMES-
 
@@ -40,6 +42,13 @@ private:
 struct SWIFT_ESCAPABLE Owner {
     int data;
 };
+
+class SharedFRT {
+public:
+    int data;
+} SWIFT_SHARED_REFERENCE(retainSharedFRT, releaseSharedFRT);
+inline void retainSharedFRT(SharedFRT *) {}
+inline void releaseSharedFRT(SharedFRT *) {}
 
 template<typename T>
 struct SWIFT_ESCAPABLE TemplatedOwner {
@@ -74,6 +83,36 @@ TemplatedFloatOwner f4(int* x [[clang::lifetimebound]]) {
 View g(int* x) {
     return View(x);
 }
+
+// expected-warning@+2 {{the returned type 'View' is annotated as non-escapable; its lifetime dependencies must be annotated}}
+// expected-LIFETIMES-error@+1 {{cannot borrow the lifetime of 'o', which is passed by value on a function}}
+View gByValue(Owner o);
+// expected-NO-LIFETIMES-error@-1 {{a function cannot return a ~Escapable result}}
+
+// expected-warning@+2 {{the returned type 'View' is annotated as non-escapable; its lifetime dependencies must be annotated}}
+// expected-LIFETIMES-error@+1 {{cannot borrow the lifetime of 'o', which is passed by value on a function}}
+View gByRvalueRef(Owner &&o);
+// expected-NO-LIFETIMES-error@-1 {{a function cannot return a ~Escapable result}}
+
+// expected-warning@+2 {{the returned type 'View' is annotated as non-escapable; its lifetime dependencies must be annotated}}
+// expected-LIFETIMES-error@+1 {{cannot borrow the lifetime of 'parameter #1', which is passed by value on a function}}
+View gByValueUnnamed(Owner);
+// expected-NO-LIFETIMES-error@-1 {{a function cannot return a ~Escapable result}}
+
+// expected-warning@+2 {{the returned type 'View' is annotated as non-escapable; its lifetime dependencies must be annotated}}
+// expected-NO-LIFETIMES-error@+1 {{a function cannot return a ~Escapable result}}
+View gByPointer(Owner *o);
+
+// expected-warning@+2 {{the returned type 'View' is annotated as non-escapable; its lifetime dependencies must be annotated}}
+// expected-NO-LIFETIMES-error@+1 {{a function cannot return a ~Escapable result}}
+View gByFRTPointer(SharedFRT *_Nonnull p);
+
+struct SWIFT_NONESCAPABLE ViewByValueCtor {
+    // expected-warning@+2 {{the returned type 'ViewByValueCtor' is annotated as non-escapable; its lifetime dependencies must be annotated}}
+    // expected-LIFETIMES-error@+1 {{cannot borrow the lifetime of 'o', which is passed by value on an initializer}}
+    ViewByValueCtor(Owner o);
+    // expected-NO-LIFETIMES-error@-1 {{an initializer cannot return a ~Escapable result}}
+};
 
 template<typename F, typename S>
 struct SWIFT_ESCAPABLE_IF(F, S) MyPair {
@@ -354,6 +393,19 @@ public func noAnnotations() -> View {
     l1()
     l2()
     return View()
+}
+
+public func diagnoseByValue(_ o: Owner) {
+    gByValue(o)
+    gByRvalueRef(consuming: Owner(data: 0))
+    gByValueUnnamed(o)
+    _ = ViewByValueCtor(o)
+}
+
+@available(SwiftStdlib 5.8, *)
+public func doNotDiagnoseIndirectlyPassedRecords(_ o: UnsafeMutablePointer<Owner>, _ p: SharedFRT) {
+    gByPointer(o)
+    gByFRTPointer(p)
 }
 
 public func diagnoseInvalidSwiftAttributes() {

--- a/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
+++ b/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
@@ -2,7 +2,7 @@
 // RUN: split-file %s %t
 // RUN: %target-swift-frontend  -I %t/Inputs -emit-sil %t/test.swift -enable-experimental-feature LifetimeDependence -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s
 // RUN: %target-swift-frontend  -I %t/Inputs -emit-sil %t/test.swift -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s
-// RUN: %target-swift-frontend  -I %t/Inputs -emit-sil -verify %t/escaping_scopes.swift -enable-experimental-feature Lifetimes -cxx-interoperability-mode=default -diagnostic-style llvm
+// RUN: %target-swift-frontend  -I %t%{fs-sep}Inputs -emit-sil -verify %t%{fs-sep}escaping_scopes.swift -enable-experimental-feature Lifetimes -cxx-interoperability-mode=default -diagnostic-style llvm -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}nonescapable.h
 
 // REQUIRES: swift_feature_LifetimeDependence
 // REQUIRES: swift_feature_Lifetimes
@@ -127,6 +127,22 @@ CaptureView getCaptureView(const Owner& owner [[clang::lifetimebound]]) {
 }
 
 struct SWIFT_NONESCAPABLE AggregateView {
+    const int *member;
+};
+
+struct SWIFT_NONESCAPABLE ViewFromValue {
+    ViewFromValue(Owner o [[clang::lifetimebound]]);
+    const int *member;
+};
+
+struct SWIFT_NONESCAPABLE ViewFromFactory {
+    static ViewFromFactory make(Owner o [[clang::lifetimebound]]) SWIFT_NAME(init(_:));
+    const int *member;
+};
+
+// expected-warning@+2 {{the returned type 'ViewNoAnnotation' is annotated as non-escapable; its lifetime dependencies must be annotated}}
+struct SWIFT_NONESCAPABLE ViewNoAnnotation {
+    ViewNoAnnotation(const Owner &o);
     const int *member;
 };
 
@@ -303,6 +319,8 @@ View fromRvalueRefNonTrivialValue(NonTrivialByValue &&o [[clang::lifetimebound]]
 // CHECK: sil {{.*}}[clang CaptureView.captureView] {{.*}} : $@convention(cxx_method) (View, @lifetime(copy 0) @inout CaptureView) -> ()
 // CHECK: sil {{.*}}[clang CaptureView.handOut] {{.*}} : $@convention(cxx_method) (@lifetime(copy 1) @inout View, @in_guaranteed CaptureView) -> ()
 // CHECK: sil {{.*}}[clang NS.getView] {{.*}} : $@convention(c) (@in_guaranteed Owner) -> @lifetime(borrow address 0) @owned View
+// CHECK: sil {{.*}}[clang ViewFromValue.init] {{.*}} : $@convention(c) (Owner) -> @lifetime(immortal) @out ViewFromValue
+// CHECK: sil {{.*}}[clang ViewFromFactory.init] {{.*}} : $@convention(c) (Owner) -> @lifetime(immortal) @owned ViewFromFactory
 // CHECK: sil {{.*}}[clang moveOnlyId] {{.*}} : $@convention(c) (@in_guaranteed MoveOnly) -> @lifetime(borrow {{.*}}0) @out MoveOnly
 // CHECK: sil {{.*}}[clang makeAnonUnionNonEscapable] {{.*}} : $@convention(c) (@in_guaranteed Owner) -> @lifetime(borrow address 0) @owned HasAnonUnion<NonEscapable>
 // CHECK: sil {{.*}}[clang makeAnonStructNonEscapable] {{.*}} : $@convention(c) (@in_guaranteed Owner) -> @lifetime(borrow address 0) @owned HasAnonStruct<NonEscapable>
@@ -344,6 +362,11 @@ public func test() {
 
 public func test2(_ x: AggregateView) {
     let _ = AggregateView(member: x.member)
+}
+
+public func test3(_ o: Owner) {
+    let _ = unsafe ViewFromValue(o)
+    let _ = unsafe ViewFromFactory(o)
 }
 
 func canImportMoveOnlyNonEscapable(_ x: borrowing MoveOnly) {
@@ -396,6 +419,16 @@ func viaMethod() -> View {
 @_lifetime(immortal)
 func viaFreeFunc() -> View {
   return getView(globalOwner)
+  // expected-error @-1 {{lifetime-dependent value escapes its scope}}
+  // expected-note @-2 {{it depends on this scoped access to variable 'globalOwner'}}
+  // expected-note @-3 {{this use causes the lifetime-dependent value to escape}}
+}
+
+// An unannotated constructor's dependency is inferred, and it is a real borrow
+// of the parameter rather than an immortal lifetime.
+@_lifetime(immortal)
+func viaUnannotatedCtor() -> ViewNoAnnotation {
+  return ViewNoAnnotation(globalOwner)
   // expected-error @-1 {{lifetime-dependent value escapes its scope}}
   // expected-note @-2 {{it depends on this scoped access to variable 'globalOwner'}}
   // expected-note @-3 {{this use causes the lifetime-dependent value to escape}}

--- a/test/Interop/Cxx/class/safe-interop-mode.swift
+++ b/test/Interop/Cxx/class/safe-interop-mode.swift
@@ -78,7 +78,7 @@ struct HasUnannotatedViewGetter {
   View getView() const;
 };
 
-// expected-warning@+2{{the returned type 'void' is annotated as non-escapable; its lifetime dependencies must be annotated}}
+// expected-warning@+2{{the returned type 'ViewWithUnannotatedCtor' is annotated as non-escapable; its lifetime dependencies must be annotated}}
 struct SWIFT_NONESCAPABLE ViewWithUnannotatedCtor {
     ViewWithUnannotatedCtor(const Owner &o);
 private:


### PR DESCRIPTION
Sometimes Swift's inference tried to infer a lifetime dependency for a foreign function where the dependency can never be lowered to valid SIL (the object was passed by value, so no borrowed storage exists). The other crash is an indexing mismatch between AST and lowered SIL for C++ constructors. There were found while working on some unrelated problems.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
