### PR TITLE
[stdlib] Back out recent Musl changes for output/input streams

### DIFF
--- a/stdlib/public/Platform/Musl.swift.gyb
+++ b/stdlib/public/Platform/Musl.swift.gyb
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 @_exported import SwiftMusl // Clang module
-import SwiftOverlayShims
 
 public let MAP_FAILED: UnsafeMutableRawPointer! = UnsafeMutableRawPointer(bitPattern: -1)
 
@@ -70,17 +69,3 @@ public let ${prefix}_TRUE_MIN = ${type}.leastNonzeroMagnitude
 #endif
 % end
 %end
-
-// `struct _IO_FILE` is only forward-declared in Musl's <stdio.h>, but Swift
-// still imports pointers to it as `UnsafeMutablePointer<FILE>`, and every
-// stdio function in the same overlay (fputs, setvbuf, etc.) is imported
-// with that signature.
-nonisolated(unsafe) public var stdin: UnsafeMutablePointer<FILE>! {
-  _swift_stdlib_stdin().assumingMemoryBound(to: FILE.self)
-}
-nonisolated(unsafe) public var stdout: UnsafeMutablePointer<FILE>! {
-  _swift_stdlib_stdout().assumingMemoryBound(to: FILE.self)
-}
-nonisolated(unsafe) public var stderr: UnsafeMutablePointer<FILE>! {
-  _swift_stdlib_stderr().assumingMemoryBound(to: FILE.self)
-}


### PR DESCRIPTION
Recent pulls #89891 and #90679 tried to improve the async typing for Musl but broke the static linux SDK CI, so temporarily reverting.