### PR TITLE
[Sema] Assign discriminators to custom attribute closures

### DIFF
--- a/include/swift/AST/Initializer.h
+++ b/include/swift/AST/Initializer.h
@@ -21,12 +21,14 @@
 #define SWIFT_INITIALIZER_H
 
 #include "swift/AST/DeclContext.h"
+#include "swift/Basic/Assertions.h"
 
 namespace llvm {
 class raw_ostream;
 }
 
 namespace swift {
+class CustomAttr;
 class ParamDecl;
 class PatternBindingDecl;
 
@@ -192,6 +194,15 @@ public:
 /// An expression within a custom attribute. The parent context is the
 /// context in which the attributed declaration occurs.
 class CustomAttributeInitializer : public Initializer {
+  CustomAttr *Attribute = nullptr;
+
+  friend class CustomAttr;
+  void setAttribute(CustomAttr *attribute) {
+    ASSERT(attribute);
+    ASSERT(!Attribute && "Cannot change the attribute after the fact");
+    Attribute = attribute;
+  }
+
 public:
   explicit CustomAttributeInitializer(DeclContext *parent)
       : Initializer(InitializerKind::CustomAttribute, parent) {}
@@ -202,6 +213,11 @@ public:
 
   void setEnclosingInitializer(Initializer *newParent) {
     setParent(newParent);
+  }
+
+  CustomAttr *getAttribute() const {
+    ASSERT(Attribute && "Initializer is not attached to an attribute");
+    return Attribute;
   }
 
   static bool classof(const DeclContext *DC) {

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -22,6 +22,7 @@
 #include "swift/AST/Expr.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/IndexSubset.h"
+#include "swift/AST/Initializer.h"
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/NameLookupRequests.h"
@@ -3314,6 +3315,8 @@ CustomAttr::CustomAttr(SourceLoc atLoc, SourceRange range, TypeExpr *type,
     : DeclAttribute(DeclAttrKind::Custom, atLoc, range, implicit),
       typeExpr(type), argList(argList), owner(owner), initContext(initContext) {
   assert(type);
+  if (initContext)
+    initContext->setAttribute(this);
   isArgUnsafeBit = false;
 }
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -423,6 +423,7 @@ unsigned LocalDiscriminatorsRequest::evaluate(
   }
 
   ASTNode node;
+  ArgumentList *args = nullptr;
   ParameterList *params = nullptr;
   ParamDecl *selfParam = nullptr;
   if (auto func = dyn_cast<AbstractFunctionDecl>(dc)) {
@@ -473,12 +474,17 @@ unsigned LocalDiscriminatorsRequest::evaluate(
       node = initInfo.getInitFromProjectedValue();
       break;
     }
+  } else if (auto customAttrInit = dyn_cast<CustomAttributeInitializer>(dc)) {
+    args = customAttrInit->getAttribute()->getArgs();
+    // Custom attribute initializer contexts are omitted when mangling, so
+    // number their closures in the enclosing context.
+    dc = customAttrInit->getParent();
   } else {
     params = getParameterList(dc);
   }
 
   auto startDiscriminator = ctx.getNextDiscriminator(dc);
-  if (!node && !params && !selfParam)
+  if (!node && !args && !params && !selfParam)
     return startDiscriminator;
 
   SetLocalDiscriminators visitor(startDiscriminator);
@@ -496,6 +502,9 @@ unsigned LocalDiscriminatorsRequest::evaluate(
 
   if (node)
     node.walk(visitor);
+
+  if (args)
+    args->walk(visitor);
 
   unsigned nextDiscriminator = visitor.maxAssignedDiscriminator();
   ctx.setMaxAssignedDiscriminator(dc, nextDiscriminator);

--- a/test/Index/index_macro_attribute_closure.swift
+++ b/test/Index/index_macro_attribute_closure.swift
@@ -1,0 +1,39 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: split-file --leading-lines %s %t
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %t/MacroDefinition.swift -g -no-toolchain-stdlib-rpath
+// RUN: %target-swift-ide-test -print-indexed-symbols -include-locals -source-filename %t/Test.swift -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library | %FileCheck %s
+
+//--- MacroDefinition.swift
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public struct EmptyPeerMacro: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return []
+  }
+}
+
+//--- Test.swift
+@attached(peer)
+macro test(_ first: (Int) -> Int?, _ second: (Int) -> Int?) =
+  #externalMacro(module: "MacroDefinition", type: "EmptyPeerMacro")
+
+// Matching parameter names within and across custom attributes should have
+// distinct USRs.
+@test({ value in nil }, { value in nil })
+func first() {}
+
+// CHECK: [[@LINE-3]]:9 | param(local)/Swift | value | s:14swift_ide_testSiSgSiXEfU_5valueL_Sivp | Def | rel: 0
+// CHECK: [[@LINE-4]]:27 | param(local)/Swift | value | s:14swift_ide_testSiSgSiXEfU0_5valueL_Sivp | Def | rel: 0
+
+@test({ value in nil }, { value in nil })
+func second() {}
+
+// CHECK: [[@LINE-3]]:9 | param(local)/Swift | value | s:14swift_ide_testSiSgSiXEfU1_5valueL_Sivp | Def | rel: 0
+// CHECK: [[@LINE-4]]:27 | param(local)/Swift | value | s:14swift_ide_testSiSgSiXEfU2_5valueL_Sivp | Def | rel: 0


### PR DESCRIPTION
Custom attribute initializer contexts are left out from mangling, but `LocalDiscriminatorsRequest` did not walk their argument lists. As a result, explicit closure parameters in custom attributes could reach USR generation without an assigned discriminator and numbering within each initializer context would also make for duplicate USRs across attributes.

This PR retains the owning `CustomAttr` on its initializer context, then walks its complete argument list while getting closure discriminators from the enclosing context. The regression covers same named closure parameters both within one custom attribute and across two custom attributes to verify that all four receive distinct USRs.

Resolves #90922
rdar://183058471
