### PR TITLE
[6.4] SILOptimizer: complete lifetimes in FunctionSignatureOpts for no-return thunks

### DIFF
--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
@@ -42,7 +42,9 @@
 #include "swift/SILOptimizer/Analysis/RCIdentityAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/CFGOptUtils.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
+#include "swift/SILOptimizer/Utils/OwnershipOptUtils.h"
 #include "swift/SILOptimizer/Utils/SILInliner.h"
 #include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
 #include "swift/SILOptimizer/Utils/SpecializationMangler.h"
@@ -914,6 +916,15 @@ public:
     assert(F->isThunk() && "Old function should have been turned into a thunk");
 
     invalidateAnalysis(SILAnalysis::InvalidationKind::FunctionBody);
+
+    // The thunk body was built from scratch after transferring the original
+    // blocks to the specialized function. If the thunk is no-return, it was
+    // terminated with an `unreachable`, which may require completing
+    // lifetimes and breaking infinite loops before the pass finishes.
+    if (F->needBreakInfiniteLoops())
+      breakInfiniteLoops(getPassManager(), F);
+    if (F->needCompleteLifetimes())
+      completeAllLifetimes(getPassManager(), F);
 
     // Make sure the PM knows about this function. This will also help us
     // with self-recursion.

--- a/test/SILOptimizer/issue-90720.swift
+++ b/test/SILOptimizer/issue-90720.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -O -sil-verify-all -emit-sil %s -o /dev/null
+
+// Regression test for https://github.com/swiftlang/swift/issues/90720
+//
+// When FunctionSignatureOpts specializes a no-return function (here: the
+// implicit closure for the unapplied reference to `crash`), the rewritten
+// thunk is terminated with an `unreachable`, which cuts off lifetimes and
+// requires them to be completed before the pass finishes. This used to hit
+// the "didn't complete lifetimes" assertion in the pass manager.
+
+struct Hooks {
+    static var handler: (() -> Never)?
+    static func crash() -> Never { fatalError() }
+    static func reset() { handler = crash }
+}


### PR DESCRIPTION
- **Explanation**: Without this fix, the compiler crashes at `-O` when the user stores a reference to a `Never`-returning static method in a variable of function type from another static method of the same type - for example, a `fatalError()`-based error handler assigned to a static var. The fix calls `breakInfiniteLoops` and `completeAllLifetimes` in `FunctionSignatureOpts::run()` after the pass rewrites such a function into a no-return thunk, mirroring the handling already present in `GenericSpecializer` and `ExistentialTransform`.
- **Scope**: The change only affects the code path where `FunctionSignatureOpts` creates a no-return thunk - i.e., when it specializes a `Never`-returning function. It cannot affect any other compilation since the added code is guarded by `needBreakInfiniteLoops()` / `needCompleteLifetimes()` checks. It cannot break existing code.
- **Issues**: https://github.com/swiftlang/swift/issues/90720, rdar://182396772
- **Original PRs**: https://github.com/swiftlang/swift/pull/90996
- **Risk**: Very low. The added code is a few lines that only execute when the compiler would otherwise crash with an assertion failure. The pattern is identical to what `GenericSpecializer` and `ExistentialTransform` already do. This is a regression from Swift 6.2.4 that affects Xcode 27 betas .
- **Testing**: Regression test added (`test/SILOptimizer/issue-90720.swift`). Full SILOptimizer lit suite passes with no regressions. The originally affected library ([MobiusCore](https://github.com/spotify/Mobius.swift)) compiles at `-O` with `-sil-verify-all` using the fixed compiler.
- **Reviewers**: @eeckstein
