### PR TITLE
[stdlib] Export ActiveTask symbol

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -100,6 +100,24 @@ static bool shouldYieldThread() {
 /******************************* TASK TRACKING ******************************/
 /*****************************************************************************/
 
+/// The currently executing task. If this has thread-local storage (Windows,
+/// Linux) or is a plain global (embedded), give it a stable name and protected
+/// visibility, enabling debuggers to locate the symbol by name and ensuring it
+/// survives stripping the symbol table.
+/// Bump _concurrency_current_task_storage_kind in Debug.h if this changes.
+#ifdef SWIFT_THREAD_LOCAL
+extern "C" {
+// (windows) dllexport is not allowed on thread-local variables.
+#if defined(__ELF__)
+SWIFT_ATTRIBUTE_FOR_EXPORTS
+#endif
+#else
+namespace {
+#endif
+SWIFT_THREAD_LOCAL_TYPE(TLSPointer<AsyncTask>, tls_key::concurrency_task)
+_swift_concurrency_currentTask;
+}
+
 namespace {
 
 /// A class which encapsulates the information we track about
@@ -191,23 +209,15 @@ public:
 };
 
 class ActiveTask {
-  /// A thread-local variable pointing to the active tracking
-  /// information about the current thread, if any.
-  static SWIFT_THREAD_LOCAL_TYPE(TLSPointer<AsyncTask>,
-                                 tls_key::concurrency_task) Value;
-
 public:
-  static void set(AsyncTask *task) { Value.set(task); }
-  static AsyncTask *get() { return Value.get(); }
+  static void set(AsyncTask *task) { _swift_concurrency_currentTask.set(task); }
+  static AsyncTask *get() { return _swift_concurrency_currentTask.get(); }
   static AsyncTask *swap(AsyncTask *newTask) {
-    return Value.swap(newTask);
+    return _swift_concurrency_currentTask.swap(newTask);
   }
 };
 
 /// Define the thread-locals.
-SWIFT_THREAD_LOCAL_TYPE(TLSPointer<AsyncTask>, tls_key::concurrency_task)
-ActiveTask::Value;
-
 SWIFT_THREAD_LOCAL_TYPE(TLSPointer<ExecutorTrackingInfo>,
                         tls_key::concurrency_executor_tracking_info)
 ExecutorTrackingInfo::ActiveInfoInThread;

--- a/stdlib/public/Concurrency/Debug.h
+++ b/stdlib/public/Concurrency/Debug.h
@@ -70,13 +70,14 @@ bool _swift_concurrency_debug_supportsPriorityEscalation;
 /// new value; bump _swift_concurrency_debug_internal_layout_version when
 /// adding one.
 enum class _concurrency_current_task_storage_kind : uint8_t {
-  /// The task pointer lives in TLS at offset 0 of the runtime's internal
-  /// current-task variable, which the debugger locates via debug info.
+  /// The task pointer lives in TLS at offset 0 of the runtime's exported
+  /// current-task variable, `_swift_concurrency_currentTask`.
   cxx_thread_local = 1,
 
-  /// The task pointer lives at offset 0 of the runtime's internal current-task
-  /// variable (no TLS resolution). Used by single-threaded /
-  /// SWIFT_THREADING_NONE builds where `SWIFT_THREAD_LOCAL` expands to nothing.
+  /// The task pointer lives at offset 0 of the runtime's current-task variable,
+  /// `_swift_concurrency_currentTask` (no TLS resolution). Used by
+  /// single-threaded / SWIFT_THREADING_NONE builds where `SWIFT_THREAD_LOCAL`
+  /// expands to nothing.
   global = 2,
 
   /// Pthread thread-specific data with a *reserved* (compile-time constant)


### PR DESCRIPTION
The debugger needs to access this variable when the concurrency library
is compiled with ThreadLocalStorage enabled (Linux, Windows). Mangled
names on anonymous namespaces are not reliable, and a file-scope local
would not survive stripping the concurrency library of symbols (.symtab
does not survive, whereas .dynsym does). In those platforms, this
patch gives it protected visibility and a stable name.

A consequence is that the variable is renamed _and_ moved outside the
helper class on all platforms, since `extern C` and class statics are
not compatible. This mostly cosmetic, with a very minor effect on
encapsulation.

On Windows, thread local + SWIFT_ATTRIBUTE_FOR_EXPORTS (dllexport) is
not a valid combination. So we only give it a stable name, but this
should suffice on that platform.