### PR TITLE
[cxx-interop] Sanitize Swift names that are not valid C++ identifiers

### DIFF
--- a/docs/CppInteroperability/UserGuide-CallingSwiftFromC++.md
+++ b/docs/CppInteroperability/UserGuide-CallingSwiftFromC++.md
@@ -66,6 +66,49 @@ int main() {
 }
 ```
 
+## Name Translation
+
+Most Swift declarations keep their name when they are exposed to C++. There are
+two exceptions:
+
+- A Swift name that is a C++ keyword, like `register`, gets an underscore
+  suffix: `register_`.
+- A Swift name that is not a valid C++ identifier is sanitized. This applies to
+  [raw identifiers](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0451-escaped-identifiers.md)
+  like `` `hello world` `` as well as names with non-ASCII characters. Every
+  character that is not valid in a C++ identifier is replaced with its Unicode
+  scalar value, spelled like a C++ universal-character-name: `_uXXXX` (exactly
+  four uppercase hexadecimal digits) for scalars up to U+FFFF, or `_UXXXXXXXX`
+  (exactly eight uppercase hexadecimal digits) for larger scalars. A name that
+  starts with a digit is preceded by an underscore.
+
+For example, the following Swift declarations:
+
+```swift
+public func `hello world`() { ... }
+
+public enum Direction {
+  case `1`
+  case `2`
+  case über
+}
+```
+
+are exposed to C++ as:
+
+```c++
+void hello_u0020world();
+
+class Direction {
+  // enum class cases { _1, _2, _u00FCber };
+  ...
+};
+```
+
+Swift operator functions whose spelling is also a valid C++ operator, like
+`==`, are exposed as that C++ operator. Operator functions that have no C++
+equivalent, like `~=` or custom operators, are not exposed to C++.
+
 ## Calling Swift Functions
 
 Swift functions that are callable from C++ are available in their corresponding module namespace. Their return and parameter types are transcribed to C++ primitive types and class types that represents the underlying Swift return and parameter types.

--- a/docs/CppInteroperability/UserGuide-CallingSwiftFromC++.md
+++ b/docs/CppInteroperability/UserGuide-CallingSwiftFromC++.md
@@ -97,6 +97,7 @@ public enum Direction {
 are exposed to C++ as:
 
 ```c++
+/// Swift name: '`hello world`()'
 void hello_u0020world();
 
 class Direction {
@@ -104,6 +105,9 @@ class Direction {
   ...
 };
 ```
+
+A C++ declaration whose name was sanitized carries a doc comment that states
+the original Swift name.
 
 Swift operator functions whose spelling is also a valid C++ operator, like
 `==`, are exposed as that C++ operator. Operator functions that have no C++

--- a/include/swift/AST/SwiftNameTranslation.h
+++ b/include/swift/AST/SwiftNameTranslation.h
@@ -66,6 +66,23 @@ namespace cxx_translation {
 
 using objc_translation::CustomNamesOnly_t;
 
+/// Returns true if the given name is a valid identifier in C++. Only ASCII
+/// identifiers are considered valid, with an exception for '$', which is
+/// accepted as an extension by the major C++ compilers.
+bool isValidCxxIdentifier(StringRef name);
+
+/// Returns a copy of the given Swift name that is a valid C++ identifier.
+///
+/// Swift raw identifiers can contain characters that are not valid in a C++
+/// identifier, such as whitespace, punctuation, and non-ASCII characters.
+/// Each such character is replaced with an encoding of its Unicode scalar
+/// value spelled like a C++ universal-character-name: `_uXXXX` (exactly four
+/// uppercase hexadecimal digits) for scalars up to U+FFFF, and `_UXXXXXXXX`
+/// (exactly eight uppercase hexadecimal digits) for larger scalars. A name
+/// that starts with an ASCII digit is prefixed with an underscore, e.g. a
+/// Swift enum case named `1` is exposed to C++ as `_1`.
+std::string sanitizeNameForCxx(StringRef name);
+
 StringRef
 getNameForCxx(const ValueDecl *VD,
               CustomNamesOnly_t customNamesOnly = objc_translation::Normal);

--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -234,10 +234,11 @@ std::string swift::cxx_translation::sanitizeNameForCxx(StringRef name) {
 /// Returns the given Swift name, sanitized if needed to form a valid C++
 /// identifier. The result is interned in the ASTContext to remain valid past
 /// the lifetime of the sanitized string.
-static StringRef getSanitizedNameForCxx(ASTContext &ctx, StringRef name) {
-  if (name.empty() || swift::cxx_translation::isValidCxxIdentifier(name))
-    return name;
-  return ctx.getIdentifier(swift::cxx_translation::sanitizeNameForCxx(name))
+static StringRef getSanitizedNameForCxx(ASTContext &ctx, Identifier name) {
+  if (name.empty() || swift::cxx_translation::isValidCxxIdentifier(name.str()))
+    return name.str();
+  return ctx
+      .getIdentifier(swift::cxx_translation::sanitizeNameForCxx(name.str()))
       .str();
 }
 
@@ -305,11 +306,11 @@ swift::cxx_translation::getNameForCxx(const ValueDecl *VD,
         os << char(std::toupper(paramNameStr[0]));
         os << paramNameStr.drop_front(1);
       }
-      return getSanitizedNameForCxx(ctx, ctx.getIdentifier(os.str()).str());
+      return getSanitizedNameForCxx(ctx, ctx.getIdentifier(os.str()));
     }
   }
 
-  return getSanitizedNameForCxx(ctx, VD->getBaseIdentifier().str());
+  return getSanitizedNameForCxx(ctx, VD->getBaseIdentifier());
 }
 
 namespace {

--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -29,9 +29,13 @@
 #include "swift/Basic/StringExtras.h"
 
 #include "clang/AST/DeclObjC.h"
+#include "clang/Basic/CharInfo.h"
 #include "clang/Basic/Module.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallString.h"
+#include "llvm/Support/ConvertUTF.h"
+#include "llvm/Support/Format.h"
+#include "llvm/Support/raw_ostream.h"
 #include <optional>
 
 using namespace swift;
@@ -185,6 +189,58 @@ isVisibleToObjC(const ValueDecl *VD, AccessLevel minRequiredAccess,
   return false;
 }
 
+bool swift::cxx_translation::isValidCxxIdentifier(StringRef name) {
+  // Permit '$', which is accepted as an extension by the major C++ compilers.
+  // It occurs in the names of property wrapper projected values.
+  return clang::isValidAsciiIdentifier(name, /*AllowDollar=*/true);
+}
+
+std::string swift::cxx_translation::sanitizeNameForCxx(StringRef name) {
+  std::string result;
+  llvm::raw_string_ostream os(result);
+  const llvm::UTF8 *next = reinterpret_cast<const llvm::UTF8 *>(name.begin());
+  const llvm::UTF8 *end = reinterpret_cast<const llvm::UTF8 *>(name.end());
+  while (next < end) {
+    llvm::UTF32 scalar;
+    if (llvm::convertUTF8Sequence(&next, end, &scalar,
+                                  llvm::strictConversion) !=
+        llvm::conversionOK) {
+      // Swift identifiers are always valid UTF-8, but treat each byte of an
+      // invalid sequence as an unknown character just in case.
+      scalar = *next++;
+    }
+    if (clang::isASCII(scalar) &&
+        clang::isAsciiIdentifierContinue(static_cast<unsigned char>(scalar),
+                                         /*AllowDollar=*/true)) {
+      // A digit is a valid identifier character, but not at the start of the
+      // name. Precede a leading digit with an underscore.
+      if (result.empty() && clang::isDigit(static_cast<unsigned char>(scalar)))
+        os << '_';
+      os << static_cast<char>(scalar);
+      continue;
+    }
+    // Replace a character that is not valid in a C++ identifier with its
+    // Unicode scalar value, spelled like a C++ universal-character-name. The
+    // number of hexadecimal digits is fixed so that the encoding cannot
+    // collide with a subsequent character that happens to be a hex digit.
+    if (scalar <= 0xFFFF)
+      os << "_u" << llvm::format_hex_no_prefix(scalar, 4, /*Upper=*/true);
+    else
+      os << "_U" << llvm::format_hex_no_prefix(scalar, 8, /*Upper=*/true);
+  }
+  return result;
+}
+
+/// Returns the given Swift name, sanitized if needed to form a valid C++
+/// identifier. The result is interned in the ASTContext to remain valid past
+/// the lifetime of the sanitized string.
+static StringRef getSanitizedNameForCxx(ASTContext &ctx, StringRef name) {
+  if (name.empty() || swift::cxx_translation::isValidCxxIdentifier(name))
+    return name;
+  return ctx.getIdentifier(swift::cxx_translation::sanitizeNameForCxx(name))
+      .str();
+}
+
 StringRef
 swift::cxx_translation::getNameForCxx(const ValueDecl *VD,
                                       CustomNamesOnly_t customNamesOnly) {
@@ -249,12 +305,11 @@ swift::cxx_translation::getNameForCxx(const ValueDecl *VD,
         os << char(std::toupper(paramNameStr[0]));
         os << paramNameStr.drop_front(1);
       }
-      auto r = ctx.getIdentifier(os.str());
-      return r.str();
+      return getSanitizedNameForCxx(ctx, ctx.getIdentifier(os.str()).str());
     }
   }
 
-  return VD->getBaseIdentifier().str();
+  return getSanitizedNameForCxx(ctx, VD->getBaseIdentifier().str());
 }
 
 namespace {

--- a/lib/PrintAsClang/ClangSyntaxPrinter.cpp
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.cpp
@@ -70,6 +70,21 @@ void ClangSyntaxPrinter::printBaseName(const ValueDecl *decl) const {
   printIdentifier(cxx_translation::getNameForCxx(decl));
 }
 
+void ClangSyntaxPrinter::printSwiftNameCommentIfNeeded(const ValueDecl *decl,
+                                                       StringRef indent) const {
+  // An operator either keeps its C++ spelling or is not exposed at all.
+  if (decl->isOperator())
+    return;
+  auto baseName = decl->getName().getBaseName();
+  if (baseName.isSpecial() || baseName.getIdentifier().empty() ||
+      cxx_translation::isValidCxxIdentifier(baseName.getIdentifier().str()))
+    return;
+  os << indent << "/// Swift name: '";
+  decl->getName().print(os, /*skipEmptyArgumentNames=*/false,
+                        /*escapeIfNeeded=*/true);
+  os << "'\n";
+}
+
 void ClangSyntaxPrinter::printModuleNameCPrefix(const ModuleDecl &mod) {
   os << cxx_translation::sanitizeNameForCxx(mod.getName().str()) << '_';
 }

--- a/lib/PrintAsClang/ClangSyntaxPrinter.cpp
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.cpp
@@ -71,7 +71,7 @@ void ClangSyntaxPrinter::printBaseName(const ValueDecl *decl) const {
 }
 
 void ClangSyntaxPrinter::printModuleNameCPrefix(const ModuleDecl &mod) {
-  os << mod.getName().str() << '_';
+  os << cxx_translation::sanitizeNameForCxx(mod.getName().str()) << '_';
 }
 
 void ClangSyntaxPrinter::printModuleNamespaceQualifiersIfNeeded(

--- a/lib/PrintAsClang/ClangSyntaxPrinter.cpp
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.cpp
@@ -72,7 +72,8 @@ void ClangSyntaxPrinter::printBaseName(const ValueDecl *decl) const {
 
 void ClangSyntaxPrinter::printSwiftNameCommentIfNeeded(const ValueDecl *decl,
                                                        StringRef indent) const {
-  // An operator either keeps its C++ spelling or is not exposed at all.
+  // An operator either keeps its Swift spelling, when that is also a valid
+  // C++ operator, or is not exposed at all.
   if (decl->isOperator())
     return;
   auto baseName = decl->getName().getBaseName();

--- a/lib/PrintAsClang/ClangSyntaxPrinter.cpp
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.cpp
@@ -66,7 +66,9 @@ void ClangSyntaxPrinter::printIdentifier(StringRef name) const {
 }
 
 void ClangSyntaxPrinter::printBaseName(const ValueDecl *decl) const {
-  assert(decl->getName().isSimpleName());
+  // An enum element can have a compound name when it has a payload, but it is
+  // still exposed to C++ under its base name.
+  assert(decl->getName().isSimpleName() || isa<EnumElementDecl>(decl));
   printIdentifier(cxx_translation::getNameForCxx(decl));
 }
 

--- a/lib/PrintAsClang/ClangSyntaxPrinter.h
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.h
@@ -59,6 +59,12 @@ public:
   /// Print the base name of the given declaration.
   void printBaseName(const ValueDecl *decl) const;
 
+  /// If the name of the given declaration had to be sanitized because it is
+  /// not a valid C++ identifier, print a doc comment that states the
+  /// original Swift name, e.g. `/// Swift name: '🚀speed()'`.
+  void printSwiftNameCommentIfNeeded(const ValueDecl *decl,
+                                     StringRef indent = "") const;
+
   /// Print the C-style prefix for the given module name, that's used for
   /// C type names inside the module.
   void printModuleNameCPrefix(const ModuleDecl &mod);

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -871,7 +871,10 @@ private:
           llvm::interleave(
               elementTagMapping, os,
               [&](const auto &pair) {
-                os << "\n    ";
+                os << "\n";
+                syntaxPrinter.printSwiftNameCommentIfNeeded(pair.first,
+                                                            /*indent=*/"    ");
+                os << "    ";
                 syntaxPrinter.printIdentifier(
                     cxx_translation::getNameForCxx(pair.first));
                 syntaxPrinter.printSymbolUSRAttribute(pair.first);
@@ -1243,6 +1246,13 @@ private:
       owningPrinter.prologueOS << cFuncPrologueOS.str();
 
       printDocumentationComment(AFD);
+      // For an accessor, the name exposed to C++ is derived from the name of
+      // the storage it accesses.
+      const ValueDecl *namedDecl = AFD;
+      if (const auto *accessor = dyn_cast<AccessorDecl>(AFD))
+        namedDecl = accessor->getStorage();
+      ClangSyntaxPrinter(AFD->getASTContext(), os)
+          .printSwiftNameCommentIfNeeded(namedDecl, /*indent=*/"  ");
       DeclAndTypeClangFunctionPrinter declPrinter(
           os, owningPrinter.prologueOS, owningPrinter.typeMapping,
           owningPrinter.interopContext, owningPrinter);
@@ -1751,6 +1761,8 @@ private:
       FuncDecl *FD, const FunctionSwiftABIInformation &funcABI) {
     assert(outputLang == OutputLanguageMode::Cxx);
     printDocumentationComment(FD);
+    ClangSyntaxPrinter(FD->getASTContext(), os)
+        .printSwiftNameCommentIfNeeded(FD);
 
     std::optional<ForeignAsyncConvention> asyncConvention =
         FD->getForeignAsyncConvention();

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -576,7 +576,8 @@ private:
 
       std::string declName, defName, name;
       llvm::raw_string_ostream declOS(declName), defOS(defName), nameOS(name);
-      ClangSyntaxPrinter(elementDecl->getASTContext(), nameOS).printIdentifier(elementDecl->getNameStr());
+      ClangSyntaxPrinter(elementDecl->getASTContext(), nameOS)
+          .printIdentifier(cxx_translation::getNameForCxx(elementDecl));
       name[0] = std::toupper(name[0]);
 
       clangFuncPrinter.printCustomCxxFunction(
@@ -871,7 +872,8 @@ private:
               elementTagMapping, os,
               [&](const auto &pair) {
                 os << "\n    ";
-                syntaxPrinter.printIdentifier(pair.first->getNameStr());
+                syntaxPrinter.printIdentifier(
+                    cxx_translation::getNameForCxx(pair.first));
                 syntaxPrinter.printSymbolUSRAttribute(pair.first);
               },
               ",");
@@ -887,10 +889,11 @@ private:
           os << "#pragma clang diagnostic ignored \"-Wc++17-extensions\"  "
              << "// allow use of inline static data member\n";
           for (const auto &pair : elementTagMapping) {
+            auto caseName = cxx_translation::getNameForCxx(pair.first);
             // Printing struct
-            printStruct(pair.first->getNameStr(), pair.first, pair.second);
+            printStruct(caseName, pair.first, pair.second);
             // Printing `is` function
-            printIsFunction(pair.first->getNameStr(), ED);
+            printIsFunction(caseName, ED);
             if (pair.first->hasAssociatedValues()) {
               // Printing `get` function
               printGetFunction(pair.first);
@@ -922,7 +925,8 @@ private:
                  << cxx_synthesis::getCxxImplNamespaceName();
               os << "::" << pair.second.globalVariableName
                  << ") return cases::";
-              syntaxPrinter.printIdentifier(pair.first->getNameStr());
+              syntaxPrinter.printIdentifier(
+                  cxx_translation::getNameForCxx(pair.first));
               os << ";\n";
             }
             os << "    return cases::" << resilientUnknownDefaultCaseName
@@ -931,7 +935,8 @@ private:
             os << "    switch (_getEnumTag()) {\n";
             for (const auto &pair : elementTagMapping) {
               os << "      case " << pair.second.tag << ": return cases::";
-              syntaxPrinter.printIdentifier(pair.first->getNameStr());
+              syntaxPrinter.printIdentifier(
+                  cxx_translation::getNameForCxx(pair.first));
               os << ";\n";
             }
             // TODO: change to Swift's fatalError when it's available in C++
@@ -1511,8 +1516,10 @@ private:
         Type objTy;
         std::tie(objTy, kind) =
             getObjectTypeAndOptionality(param, param->getInterfaceType());
-        StringRef paramName =
-            param->getName().empty() ? "" : param->getName().str();
+        std::string paramName =
+            param->getName().empty()
+                ? ""
+                : cxx_translation::sanitizeNameForCxx(param->getName().str());
         print(objTy, kind, paramName, IsFunctionParam);
         ++index;
       });
@@ -2003,6 +2010,15 @@ private:
     if (outputLang == OutputLanguageMode::Cxx) {
       if (FD->getDeclContext()->isTypeContext())
         return printAbstractFunctionAsMethod(FD, FD->isStatic());
+
+      // A Swift operator function whose spelling is not a valid C++ operator
+      // has no name in C++; skip it instead of emitting a nameless function.
+      if (FD->isOperator() && cxx_translation::getNameForCxx(FD).empty()) {
+        owningPrinter.getCxxDeclEmissionScope()
+            .additionalUnrepresentableDeclarations.insert(
+                {FD, "the operator can not be represented as a C++ operator"});
+        return;
+      }
 
       // Emit the underlying C signature that matches the Swift ABI
       // in the generated C++ implementation prologue for the module.

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -577,7 +577,7 @@ private:
       std::string declName, defName, name;
       llvm::raw_string_ostream declOS(declName), defOS(defName), nameOS(name);
       ClangSyntaxPrinter(elementDecl->getASTContext(), nameOS)
-          .printIdentifier(cxx_translation::getNameForCxx(elementDecl));
+          .printBaseName(elementDecl);
       name[0] = std::toupper(name[0]);
 
       clangFuncPrinter.printCustomCxxFunction(
@@ -875,8 +875,7 @@ private:
                 syntaxPrinter.printSwiftNameCommentIfNeeded(pair.first,
                                                             /*indent=*/"    ");
                 os << "    ";
-                syntaxPrinter.printIdentifier(
-                    cxx_translation::getNameForCxx(pair.first));
+                syntaxPrinter.printBaseName(pair.first);
                 syntaxPrinter.printSymbolUSRAttribute(pair.first);
               },
               ",");
@@ -928,8 +927,7 @@ private:
                  << cxx_synthesis::getCxxImplNamespaceName();
               os << "::" << pair.second.globalVariableName
                  << ") return cases::";
-              syntaxPrinter.printIdentifier(
-                  cxx_translation::getNameForCxx(pair.first));
+              syntaxPrinter.printBaseName(pair.first);
               os << ";\n";
             }
             os << "    return cases::" << resilientUnknownDefaultCaseName
@@ -938,8 +936,7 @@ private:
             os << "    switch (_getEnumTag()) {\n";
             for (const auto &pair : elementTagMapping) {
               os << "      case " << pair.second.tag << ": return cases::";
-              syntaxPrinter.printIdentifier(
-                  cxx_translation::getNameForCxx(pair.first));
+              syntaxPrinter.printBaseName(pair.first);
               os << ";\n";
             }
             // TODO: change to Swift's fatalError when it's available in C++

--- a/lib/PrintAsClang/PrintAsClang.cpp
+++ b/lib/PrintAsClang/PrintAsClang.cpp
@@ -21,6 +21,7 @@
 #include "swift/AST/DiagnosticsFrontend.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/PrettyStackTrace.h"
+#include "swift/AST/SwiftNameTranslation.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/Version.h"
 #include "swift/ClangImporter/ClangImporter.h"
@@ -655,7 +656,8 @@ static void writeEpilogue(raw_ostream &os) {
 }
 
 static std::string computeMacroGuard(const ModuleDecl *M) {
-  return (llvm::Twine(M->getNameStr().upper()) + "_SWIFT_H").str();
+  std::string moduleName = cxx_translation::sanitizeNameForCxx(M->getNameStr());
+  return (llvm::Twine(llvm::StringRef(moduleName).upper()) + "_SWIFT_H").str();
 }
 
 bool swift::printAsClangHeader(raw_ostream &os, ModuleDecl *M,

--- a/lib/PrintAsClang/PrintClangClassType.cpp
+++ b/lib/PrintAsClang/PrintClangClassType.cpp
@@ -61,6 +61,8 @@ void ClangClassTypePrinter::printClassTypeDecl(
       baseClassQualifiedName = "swift::_impl::RefCountedClass";
     }
 
+    ClangSyntaxPrinter(typeDecl->getASTContext(), os)
+        .printSwiftNameCommentIfNeeded(typeDecl);
     os << "class";
     declAndTypePrinter.printAvailability(os, typeDecl);
     ClangSyntaxPrinter(typeDecl->getASTContext(), os).printSymbolUSRAttribute(typeDecl);

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -834,7 +834,7 @@ static void renameCxxParameterIfNeeded(const AbstractFunctionDecl *FD,
   // Rename a parameter in an enum method that shadows an existing case name,
   // to avoid a -Wshadow warning in Clang.
   for (const auto *Case : enumDecl->getAllElements()) {
-    if (Case->getNameStr() == paramName) {
+    if (cxx_translation::getNameForCxx(Case) == paramName) {
       paramName = (llvm::Twine(paramName) + "_").str();
       return;
     }
@@ -870,7 +870,8 @@ ClangRepresentation DeclAndTypeClangFunctionPrinter::printFunctionSignature(
     //        colliding functions.
     for (const auto *enumElement : enumDecl->getAllElements()) {
       auto elementName = enumElement->getName();
-      if (!elementName.isSpecial() && elementName.getBaseIdentifier().is(name))
+      if (!elementName.isSpecial() &&
+          cxx_translation::getNameForCxx(enumElement) == name)
         return ClangRepresentation::unsupported;
     }
   }
@@ -1013,7 +1014,9 @@ ClangRepresentation DeclAndTypeClangFunctionPrinter::printFunctionSignature(
     };
     auto printParamName = [&](const ParamDecl &param) {
       std::string paramName =
-          param.getName().empty() ? "" : param.getName().str().str();
+          param.getName().empty()
+              ? ""
+              : cxx_translation::sanitizeNameForCxx(param.getName().str());
       if (param.isSelfParameter())
         paramName = "_self";
       if (!paramName.empty()) {
@@ -1128,7 +1131,9 @@ ClangRepresentation DeclAndTypeClangFunctionPrinter::printFunctionSignature(
               DeclAndTypePrinter::getObjectTypeAndOptionality(
                   param, param->getInterfaceType());
           std::string paramName =
-              param->getName().empty() ? "" : param->getName().str().str();
+              param->getName().empty()
+                  ? ""
+                  : cxx_translation::sanitizeNameForCxx(param->getName().str());
           renameCxxParameterIfNeeded(FD, paramName);
           // Always emit a named parameter for the C++ inline thunk to ensure it
           // can be referenced in the body.
@@ -1397,9 +1402,10 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
         paramOS << "_";
       paramOS << paramIndex;
     } else {
-      StringRef nameStr = param.getName().str();
+      std::string nameStr =
+          cxx_translation::sanitizeNameForCxx(param.getName().str());
       if (isConsumed)
-        paramName += nameStr.str();
+        paramName += nameStr;
       else
         paramName = nameStr;
       renameCxxParameterIfNeeded(FD, paramName);

--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -284,6 +284,7 @@ void ClangValueTypePrinter::printValueTypeDecl(
     };
 
     // Print out the C++ class itself.
+    ClangSyntaxPrinter(Context, os).printSwiftNameCommentIfNeeded(typeDecl);
     printGenericSignature(os);
     os << "class";
     declAndTypePrinter.printAvailability(os, typeDecl);

--- a/test/Interop/SwiftToCxx/raw-identifiers/raw-identifiers-execution.cpp
+++ b/test/Interop/SwiftToCxx/raw-identifiers/raw-identifiers-execution.cpp
@@ -1,0 +1,65 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %S/raw-identifiers-in-cxx.swift -module-name RawIdentifiers -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/raw.h
+
+// RUN: %target-interop-build-clangxx -c %s -I %t -o %t/raw-identifiers-execution.o
+// RUN: %target-interop-build-swift %S/raw-identifiers-in-cxx.swift -o %t/raw-identifiers-execution -Xlinker %t/raw-identifiers-execution.o -module-name RawIdentifiers -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+
+// RUN: %target-codesign %t/raw-identifiers-execution
+// RUN: %target-run %t/raw-identifiers-execution
+
+// REQUIRES: executable_test
+
+#include <cassert>
+#include "raw.h"
+
+using namespace RawIdentifiers;
+
+int switchTest(const Enum_u0020Name &e) {
+  switch (e) {
+  case Enum_u0020Name::default_:
+    assert(e.isDefault_());
+    return 0;
+  case Enum_u0020Name::_1:
+    assert(e.is_1());
+    return 1;
+  case Enum_u0020Name::_2:
+    assert(e.is_2());
+    assert(e.get_2() == 24);
+    return 2;
+  case Enum_u0020Name::hello_u0020world:
+    assert(e.isHello_u0020world());
+    return 3;
+  }
+}
+
+int main() {
+  assert(hello_u0020world() == 42);
+  assert(_u00FCber(41) == 42);
+  assert(_U0001F680speed() == 100);
+
+  auto s = Struct_u0020Name::init(21);
+  assert(s.getProp_u0020name() == 21);
+  assert(s.method_u0020name() == 42);
+  s.setProp_u0020name(50);
+  assert(s.getProp_u0020name() == 50);
+  assert(s.method_u0020name() == 100);
+
+  {
+    auto e = Enum_u0020Name::default_();
+    assert(switchTest(e) == 0);
+  }
+  {
+    auto e = Enum_u0020Name::_1();
+    assert(switchTest(e) == 1);
+  }
+  {
+    auto e = Enum_u0020Name::_2(24);
+    assert(switchTest(e) == 2);
+  }
+  {
+    auto e = Enum_u0020Name::hello_u0020world();
+    assert(switchTest(e) == 3);
+  }
+  return 0;
+}

--- a/test/Interop/SwiftToCxx/raw-identifiers/raw-identifiers-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/raw-identifiers/raw-identifiers-in-cxx.swift
@@ -8,7 +8,8 @@
 // exposed to C++: every character that is not valid in a C++ identifier is
 // replaced with its Unicode scalar value, spelled like a C++
 // universal-character-name (`_uXXXX` or `_UXXXXXXXX`), and a leading digit is
-// preceded by an underscore.
+// preceded by an underscore. A declaration with a sanitized name gets a doc
+// comment that states its original Swift name.
 
 // CHECK: namespace RawIdentifiers SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("RawIdentifiers") {
 
@@ -18,34 +19,33 @@ public enum `Enum Name` {
   case `2`(CInt)
   case `hello world`
 }
-
-// CHECK: class SWIFT_SYMBOL({{.*}}) Enum_u0020Name final {
+// CHECK: /// Swift name: '`Enum Name`'
+// CHECK-NEXT: class SWIFT_SYMBOL({{.*}}) Enum_u0020Name final {
 // CHECK: enum class cases {
+// CHECK-NEXT: /// Swift name: '`2`(_:)'
 // CHECK-NEXT: _2 SWIFT_SYMBOL({{.*}}),
 // CHECK-NEXT: default_ SWIFT_SYMBOL({{.*}}),
+// CHECK-NEXT: /// Swift name: '`1`'
 // CHECK-NEXT: _1 SWIFT_SYMBOL({{.*}}),
+// CHECK-NEXT: /// Swift name: '`hello world`'
 // CHECK-NEXT: hello_u0020world SWIFT_SYMBOL({{.*}})
 // CHECK-NEXT: };
-
 // CHECK: inline const static struct _impl__2 {  // impl struct for case _2
 // CHECK: constexpr operator cases() const {
 // CHECK-NEXT: return cases::_2;
 // CHECK: } _2 SWIFT_SYMBOL({{.*}});
 // CHECK: bool is_2() const;
 // CHECK: int get_2() const;
-
 // CHECK: inline const static struct _impl_default {  // impl struct for case default
 // CHECK: constexpr operator cases() const {
 // CHECK-NEXT: return cases::default_;
 // CHECK: } default_ SWIFT_SYMBOL({{.*}});
 // CHECK: bool isDefault_() const;
-
 // CHECK: inline const static struct _impl__1 {  // impl struct for case _1
 // CHECK: constexpr operator cases() const {
 // CHECK-NEXT: return cases::_1;
 // CHECK: } _1 SWIFT_SYMBOL({{.*}});
 // CHECK: bool is_1() const;
-
 // CHECK: inline const static struct _impl_hello_u0020world {  // impl struct for case hello_u0020world
 // CHECK: constexpr operator cases() const {
 // CHECK-NEXT: return cases::hello_u0020world;
@@ -63,29 +63,32 @@ public struct `Struct Name` {
     return `prop name` * 2
   }
 }
-
-// CHECK: class SWIFT_SYMBOL({{.*}}) Struct_u0020Name final {
-// CHECK: SWIFT_INLINE_THUNK int getProp_u0020name() const
-// CHECK: SWIFT_INLINE_THUNK void setProp_u0020name(int
-// CHECK: SWIFT_INLINE_THUNK int method_u0020name() const
+// CHECK: /// Swift name: '`Struct Name`'
+// CHECK-NEXT: class SWIFT_SYMBOL({{.*}}) Struct_u0020Name final {
+// CHECK: /// Swift name: '`prop name`'
+// CHECK-NEXT: SWIFT_INLINE_THUNK int getProp_u0020name() const
+// CHECK: /// Swift name: '`prop name`'
+// CHECK-NEXT: SWIFT_INLINE_THUNK void setProp_u0020name(int
+// CHECK: /// Swift name: '`method name`()'
+// CHECK-NEXT: SWIFT_INLINE_THUNK int method_u0020name() const
 
 public func `hello world`() -> CInt {
   return 42
 }
-
-// CHECK-DAG: SWIFT_INLINE_THUNK int hello_u0020world() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
+// CHECK: /// Swift name: '`hello world`()'
+// CHECK-NEXT: SWIFT_INLINE_THUNK int hello_u0020world() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 
 public func über(_ `param name`: CInt) -> CInt {
   return `param name` + 1
 }
-
-// CHECK-DAG: SWIFT_INLINE_THUNK int _u00FCber(int param_u0020name) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
+// CHECK: /// Swift name: 'über(_:)'
+// CHECK-NEXT: SWIFT_INLINE_THUNK int _u00FCber(int param_u0020name) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 
 public func 🚀speed() -> CInt {
   return 100
 }
-
-// CHECK-DAG: SWIFT_INLINE_THUNK int _U0001F680speed() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
+// CHECK: /// Swift name: '🚀speed()'
+// CHECK-NEXT: SWIFT_INLINE_THUNK int _U0001F680speed() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 
 // A Swift operator function whose spelling is not a valid C++ operator is not
 // exposed, instead of emitting a nameless C++ function that would not compile.
@@ -93,5 +96,4 @@ infix operator +++
 public func +++ (a: CInt, b: CInt) -> CInt {
   return a + b
 }
-
 // CHECK: // Unavailable in C++: Swift operator function '+++(_:_:)'. the operator can not be represented as a C++ operator.

--- a/test/Interop/SwiftToCxx/raw-identifiers/raw-identifiers-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/raw-identifiers/raw-identifiers-in-cxx.swift
@@ -1,0 +1,97 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name RawIdentifiers -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/raw.h
+// RUN: %FileCheck %s < %t/raw.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/raw.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
+
+// Swift names that are not valid C++ identifiers are sanitized when they are
+// exposed to C++: every character that is not valid in a C++ identifier is
+// replaced with its Unicode scalar value, spelled like a C++
+// universal-character-name (`_uXXXX` or `_UXXXXXXXX`), and a leading digit is
+// preceded by an underscore.
+
+// CHECK: namespace RawIdentifiers SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("RawIdentifiers") {
+
+public enum `Enum Name` {
+  case `default`
+  case `1`
+  case `2`(CInt)
+  case `hello world`
+}
+
+// CHECK: class SWIFT_SYMBOL({{.*}}) Enum_u0020Name final {
+// CHECK: enum class cases {
+// CHECK-NEXT: _2 SWIFT_SYMBOL({{.*}}),
+// CHECK-NEXT: default_ SWIFT_SYMBOL({{.*}}),
+// CHECK-NEXT: _1 SWIFT_SYMBOL({{.*}}),
+// CHECK-NEXT: hello_u0020world SWIFT_SYMBOL({{.*}})
+// CHECK-NEXT: };
+
+// CHECK: inline const static struct _impl__2 {  // impl struct for case _2
+// CHECK: constexpr operator cases() const {
+// CHECK-NEXT: return cases::_2;
+// CHECK: } _2 SWIFT_SYMBOL({{.*}});
+// CHECK: bool is_2() const;
+// CHECK: int get_2() const;
+
+// CHECK: inline const static struct _impl_default {  // impl struct for case default
+// CHECK: constexpr operator cases() const {
+// CHECK-NEXT: return cases::default_;
+// CHECK: } default_ SWIFT_SYMBOL({{.*}});
+// CHECK: bool isDefault_() const;
+
+// CHECK: inline const static struct _impl__1 {  // impl struct for case _1
+// CHECK: constexpr operator cases() const {
+// CHECK-NEXT: return cases::_1;
+// CHECK: } _1 SWIFT_SYMBOL({{.*}});
+// CHECK: bool is_1() const;
+
+// CHECK: inline const static struct _impl_hello_u0020world {  // impl struct for case hello_u0020world
+// CHECK: constexpr operator cases() const {
+// CHECK-NEXT: return cases::hello_u0020world;
+// CHECK: } hello_u0020world SWIFT_SYMBOL({{.*}});
+// CHECK: bool isHello_u0020world() const;
+
+public struct `Struct Name` {
+  public var `prop name`: CInt
+
+  public init(_ x: CInt) {
+    self.`prop name` = x
+  }
+
+  public func `method name`() -> CInt {
+    return `prop name` * 2
+  }
+}
+
+// CHECK: class SWIFT_SYMBOL({{.*}}) Struct_u0020Name final {
+// CHECK: SWIFT_INLINE_THUNK int getProp_u0020name() const
+// CHECK: SWIFT_INLINE_THUNK void setProp_u0020name(int
+// CHECK: SWIFT_INLINE_THUNK int method_u0020name() const
+
+public func `hello world`() -> CInt {
+  return 42
+}
+
+// CHECK-DAG: SWIFT_INLINE_THUNK int hello_u0020world() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
+
+public func über(_ `param name`: CInt) -> CInt {
+  return `param name` + 1
+}
+
+// CHECK-DAG: SWIFT_INLINE_THUNK int _u00FCber(int param_u0020name) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
+
+public func 🚀speed() -> CInt {
+  return 100
+}
+
+// CHECK-DAG: SWIFT_INLINE_THUNK int _U0001F680speed() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
+
+// A Swift operator function whose spelling is not a valid C++ operator is not
+// exposed, instead of emitting a nameless C++ function that would not compile.
+infix operator +++
+public func +++ (a: CInt, b: CInt) -> CInt {
+  return a + b
+}
+
+// CHECK: // Unavailable in C++: Swift operator function '+++(_:_:)'. the operator can not be represented as a C++ operator.

--- a/unittests/AST/CMakeLists.txt
+++ b/unittests/AST/CMakeLists.txt
@@ -11,6 +11,7 @@ add_swift_unittest(SwiftASTTests
   DiagnosticFormattingTests.cpp
   DiagnosticInfoTests.cpp
   SourceLocTests.cpp
+  SwiftNameTranslationTests.cpp
   TestContext.cpp
   TypeMatchTests.cpp
   VersionRangeTests.cpp

--- a/unittests/AST/SwiftNameTranslationTests.cpp
+++ b/unittests/AST/SwiftNameTranslationTests.cpp
@@ -1,0 +1,64 @@
+//===--- SwiftNameTranslationTests.cpp ------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/SwiftNameTranslation.h"
+#include "gtest/gtest.h"
+
+using namespace swift;
+
+TEST(SwiftNameTranslation, IsValidCxxIdentifier) {
+  EXPECT_TRUE(cxx_translation::isValidCxxIdentifier("x"));
+  EXPECT_TRUE(cxx_translation::isValidCxxIdentifier("_x"));
+  EXPECT_TRUE(cxx_translation::isValidCxxIdentifier("x1"));
+  EXPECT_TRUE(cxx_translation::isValidCxxIdentifier("helloWorld"));
+  // '$' is accepted as an extension by the major C++ compilers.
+  EXPECT_TRUE(cxx_translation::isValidCxxIdentifier("$x"));
+
+  EXPECT_FALSE(cxx_translation::isValidCxxIdentifier(""));
+  EXPECT_FALSE(cxx_translation::isValidCxxIdentifier("1"));
+  EXPECT_FALSE(cxx_translation::isValidCxxIdentifier("1x"));
+  EXPECT_FALSE(cxx_translation::isValidCxxIdentifier("hello world"));
+  EXPECT_FALSE(cxx_translation::isValidCxxIdentifier("~"));
+  EXPECT_FALSE(cxx_translation::isValidCxxIdentifier("Ü"));
+}
+
+TEST(SwiftNameTranslation, SanitizeNameForCxx) {
+  // Valid identifiers are unchanged.
+  EXPECT_EQ(cxx_translation::sanitizeNameForCxx("helloWorld"), "helloWorld");
+  EXPECT_EQ(cxx_translation::sanitizeNameForCxx("_1"), "_1");
+  EXPECT_EQ(cxx_translation::sanitizeNameForCxx("$x"), "$x");
+
+  // A leading digit is preceded by an underscore.
+  EXPECT_EQ(cxx_translation::sanitizeNameForCxx("1"), "_1");
+  EXPECT_EQ(cxx_translation::sanitizeNameForCxx("2nd"), "_2nd");
+
+  // Characters that are not valid in a C++ identifier are replaced with
+  // their Unicode scalar values.
+  EXPECT_EQ(cxx_translation::sanitizeNameForCxx("hello world"),
+            "hello_u0020world");
+  EXPECT_EQ(cxx_translation::sanitizeNameForCxx("~"), "_u007E");
+  EXPECT_EQ(cxx_translation::sanitizeNameForCxx("+ - *"),
+            "_u002B_u0020_u002D_u0020_u002A");
+
+  // Non-ASCII characters are replaced with their Unicode scalar values, which
+  // are always four hexadecimal digits for scalars in the basic multilingual
+  // plane and eight hexadecimal digits for larger scalars.
+  EXPECT_EQ(cxx_translation::sanitizeNameForCxx("Ü"), "_u00DC");
+  EXPECT_EQ(cxx_translation::sanitizeNameForCxx("über"), "_u00FCber");
+  EXPECT_EQ(cxx_translation::sanitizeNameForCxx("日本語"),
+            "_u65E5_u672C_u8A9E");
+  EXPECT_EQ(cxx_translation::sanitizeNameForCxx("🚀speed"),
+            "_U0001F680speed");
+
+  // A digit after a replaced character is not a leading digit.
+  EXPECT_EQ(cxx_translation::sanitizeNameForCxx(" 1"), "_u00201");
+}


### PR DESCRIPTION
Swift raw identifiers (SE-0451) like `` `hello world` `` or `` `1` ``, and names
with non-ASCII characters like `Ü` or `🚀speed`, were printed verbatim into the
generated C++ interop header, producing C++ that does not compile:

```c++
SWIFT_INLINE_THUNK int hello world() noexcept { ... }
enum class cases { default_, 1, 2, hello world };
```

This change sanitizes every Swift name that is not a valid C++ identifier when
it is exposed to C++:

- Each character that is not valid in a C++ identifier is replaced with its
  Unicode scalar value, spelled like a C++ universal-character-name: `_uXXXX`
  (exactly four uppercase hex digits) for scalars up to U+FFFF, `_UXXXXXXXX`
  (exactly eight) for larger scalars. `` `hello world` `` → `hello_u0020world`,
  `Ü` → `_u00DC`, `🚀speed` → `_U0001F680speed`. The fixed digit count keeps
  the encoding unambiguous when the next character is itself a hex digit.
- A name starting with a digit is prefixed with an underscore: `` case `1` ``
  → `_1`.
- C++ keywords keep the existing underscore-suffix treatment
  (`default` → `default_`), and `$` remains allowed (property wrapper
  projected values; accepted by the major C++ compilers).

The sanitization is applied in `getNameForCxx` and in the printer paths that
bypass it: enum case names (the `cases` enum, `_impl_<case>` structs, and the
derived `is<Case>`/`get<Case>` accessors), C++ parameter names in inline thunk
signatures and bodies, `@_cdecl` C declaration parameter names, and the module
name used for the C type-name prefix and the header macro guard.

Additionally, a Swift operator function whose spelling is not a valid C++
operator (e.g. a custom `+++`) used to be emitted as a *nameless* C++
function, because `getNameForCxx` returns an empty string for it. Such
operators are now skipped and reported with an "Unavailable in C++" stub
comment.

Tests: new lit test FileChecks the sanitized names and compiles the header at
C++14/17/20; a new execution test calls the sanitized APIs (functions, struct
accessors, enum cases with payload) from C++; unit tests cover the encoder.
The name-translation rules are documented in
`docs/CppInteroperability/UserGuide-CallingSwiftFromC++.md`.