### PR TITLE
[cxx-interop] Honor `swift_attr` on virtual methods of FRTs

### DIFF
--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -2318,6 +2318,8 @@ clang::CXXMethodDecl *SwiftDeclSynthesizer::synthesizeCXXForwardingMethod(
   }
   if (auto swiftNameAttr = method->getAttr<clang::SwiftNameAttr>())
     newMethod->addAttr(swiftNameAttr->clone(clangCtx));
+  for (auto swiftAttr : method->specific_attrs<clang::SwiftAttrAttr>())
+    newMethod->addAttr(swiftAttr->clone(clangCtx));
 
   llvm::SmallVector<clang::ParmVarDecl *, 4> params;
   for (auto *param : method->parameters()) {

--- a/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
+++ b/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
@@ -139,3 +139,8 @@ module FrtSequence {
   header "frt-sequence.h"
   requires cplusplus
 }
+
+module VirtualMethodAttrs {
+  header "virtual-methods-attrs.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/foreign-reference/Inputs/virtual-methods-attrs.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/virtual-methods-attrs.h
@@ -1,0 +1,9 @@
+#include "swift/bridging"
+
+class SWIFT_UNSAFE_REFERENCE MyUnsafeReferenceType {
+public:
+  virtual void virtualSafeMethod() SWIFT_SAFE {}
+  virtual void virtualUnsafeMethod() {}
+  void nonvirtualSafeMethod() SWIFT_SAFE {}
+  virtual ~MyUnsafeReferenceType() = default;
+};

--- a/test/Interop/Cxx/foreign-reference/virtual-methods-attrs-typechecker.swift
+++ b/test/Interop/Cxx/foreign-reference/virtual-methods-attrs-typechecker.swift
@@ -1,0 +1,14 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs %s -strict-memory-safety -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1
+
+import VirtualMethodAttrs
+
+@available(SwiftStdlib 5.8, *)
+func useVirtualMethods(_ x: MyUnsafeReferenceType) {
+    x.virtualSafeMethod()
+
+    x.nonvirtualSafeMethod()
+
+    x.virtualUnsafeMethod() // expected-warning {{expression uses unsafe constructs but is not marked with 'unsafe'}}
+    // expected-note@-1 {{reference to parameter 'x' involves unsafe type 'MyUnsafeReferenceType'}}
+    // expected-note@-2 {{argument 'self' in call to instance method 'virtualUnsafeMethod' has unsafe type 'MyUnsafeReferenceType'}}
+}


### PR DESCRIPTION
Swift creates synthetic accessor methods for C++ virtual methods of foreign reference types.

This makes sure the `swift_attr` attributes that are applied to the original C++ method are cloned onto the synthesized accessor.

rdar://183234362

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
