### PR TITLE
[stdlib] Check if a collection is empty before emptying

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1395,8 +1395,9 @@ extension Array: RangeReplaceableCollection {
   public mutating func removeAll(keepingCapacity keepCapacity: Bool = false) {
     if !keepCapacity {
       _buffer = _Buffer()
-    }
-    else if _buffer.isMutableAndUniquelyReferenced() {
+    } else if self.isEmpty {
+      return
+    } else if _buffer.isMutableAndUniquelyReferenced() {
       self.replaceSubrange(indices, with: EmptyCollection())
     }
     else {

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -1080,8 +1080,9 @@ extension ArraySlice: RangeReplaceableCollection {
   public mutating func removeAll(keepingCapacity keepCapacity: Bool = false) {
     if !keepCapacity {
       _buffer = _Buffer()
-    }
-    else if _buffer.isMutableAndUniquelyReferenced() {
+    } else if isEmpty {
+      return
+    } else if _buffer.isMutableAndUniquelyReferenced() {
       self.replaceSubrange(indices, with: EmptyCollection())
     }
     else {

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -989,8 +989,9 @@ extension ContiguousArray: RangeReplaceableCollection {
   public mutating func removeAll(keepingCapacity keepCapacity: Bool = false) {
     if !keepCapacity {
       _buffer = _Buffer()
-    }
-    else if _buffer.isMutableAndUniquelyReferenced() {
+    } else if isEmpty {
+      return
+    } else if _buffer.isMutableAndUniquelyReferenced() {
       self.replaceSubrange(indices, with: EmptyCollection())
     }
     else {

--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -639,8 +639,9 @@ extension RangeReplaceableCollection {
   public mutating func removeAll(keepingCapacity keepCapacity: Bool = false) {
     if !keepCapacity {
       self = Self()
-    }
-    else {
+    } else if isEmpty {
+      return
+    } else {
       replaceSubrange(startIndex..<endIndex, with: EmptyCollection())
     }
   }

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift
@@ -304,6 +304,7 @@ extension String: RangeReplaceableCollection {
       self = ""
       return
     }
+    if isEmpty { return }
     _guts.clear()
   }
 }


### PR DESCRIPTION
This change adds an early exit for the `removeAll(keepingCapacity:)` method for RangeReplaceableCollection and its conforming types if the collection is already empty and `keepingCapacity` is true. If `keepingCapacity` is false, the method already exits early by reassigning to an empty `Self()` (or a shared empty singleton).

In _StringProcessing, this check has a significant measurable impact, at least for arrays, likely due to the uniqueness check.

This early exit does lead to a slight behavior difference, where a shared empty array will no longer have a unique address after calling `removeAll`, unlike the existing behavior, which leads to a uniquely held array whenever `keepingCapacity` is `true`. This behavior is not documented, unlike with the `reserveCapacity` method.