### PR TITLE
[Concurrency] Allow `nonisolated(unsafe)` on wrapped property to be d…

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6420,6 +6420,32 @@ computeDefaultInferredActorIsolation(ValueDecl *value) {
     return {{ActorIsolation::forNonisolatedNonsending(), {}}, nullptr, {}};
   }
 
+  // Lets use `nonisolated(unsafe)` and @preconcurrency from the wrapped
+  // property as a default isolation for its backing storage property.
+  // These attributes are intended for the storage and helpful
+  // when property wrapper initializer references something that would
+  // otherwise cause concurrency warnings or errors and since it's a
+  // default it doesn't clash with other inference rules associated with
+  // property wrappers.
+  if (auto *var = dyn_cast<VarDecl>(value)) {
+    if (auto *originalVar = var->getOriginalWrappedProperty(
+            PropertyWrapperSynthesizedPropertyKind::Backing)) {
+      if (auto *nonisolated =
+              originalVar->getAttrs().getAttribute<NonisolatedAttr>()) {
+        if (nonisolated->isUnsafe()) {
+          auto isolation =
+              ActorIsolation::forNonisolated(/*unsafe=*/true)
+                  .withPreconcurrency(originalVar->getAttrs()
+                                          .hasAttribute<PreconcurrencyAttr>());
+          return {{isolation, IsolationSource(originalVar,
+                                              IsolationSource::Kind::Explicit)},
+                  nullptr,
+                  {}};
+        }
+      }
+    }
+  }
+
   // We did not find anything special, return unspecified.
   return {{ActorIsolation::forUnspecified(), {}}, nullptr, {}};
 }

--- a/test/Concurrency/nonisolated_unsafe_and_property_wrappers.swift
+++ b/test/Concurrency/nonisolated_unsafe_and_property_wrappers.swift
@@ -1,0 +1,26 @@
+// RUN: %target-typecheck-verify-swift -language-mode 6 -target %target-swift-5.1-abi-triple
+
+// REQUIRES: concurrency
+
+class Storage {
+  var data: [String: Bool] = [:]
+}
+
+@propertyWrapper
+struct StorageBacked {
+  let key: String
+  let storage: Storage
+  let defaultValue: Bool
+
+  var wrappedValue: Bool {
+    get { storage.data[key] ?? defaultValue }
+    set { }
+  }
+}
+
+nonisolated(unsafe) private let storage = Storage()
+
+enum Test {
+  @StorageBacked(key: "flag", storage: storage, defaultValue: false)
+  nonisolated(unsafe) static var flag: Bool // Ok
+}


### PR DESCRIPTION
…efault isolation of backing storage

Lets use `nonisolated(unsafe)` and @preconcurrency from the wrapped property as a default isolation for its backing storage property. These attributes are intended for the storage and helpful when property wrapper initializer references something that would otherwise cause concurrency warnings or errors and since it's a default it doesn't clash with other inference rules associated with property wrappers.

Resolves: rdar://179894304

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
