### PR TITLE
ModuleInterface: Don't reserve conditional conformances to invertible protocols

### DIFF
--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -486,6 +486,15 @@ class InheritedProtocolCollector {
 
       ExistentialLayout layout = inheritedTy->getExistentialLayout();
       for (ProtocolDecl *protoDecl : layout.getProtocols()) {
+        // Do not record conformances to invertible protocols, as their
+        // conformances are always re-inferred using the interface itself.
+        // Note that the existential layout of an inherited type synthesizes
+        // entries for every invertible protocol that the type does not
+        // suppress, so these are usually not conformances that the extension
+        // actually declares.
+        if (protoDecl->getInvertibleProtocolKind())
+          continue;
+
         auto protoTy = protoDecl->getDeclaredInterfaceType()->castTo<ProtocolType>();
         if (!isPublicOrUsableFromInline(protoTy))
           continue;
@@ -747,35 +756,20 @@ public:
       return false;
     assert(nominal->isGenericContext());
 
-    auto emitExtension =
-        [&](ArrayRef<const ProtocolType *> conformanceProtos) {
-      if (!printOptions.printPublicInterface())
-        out << "@_spi(" << DummyProtocolName << ")\n";
-      out << "@available(*, unavailable)\nextension ";
-      nominal->getDeclaredType().print(out, printOptions);
-      out << " : ";
-      llvm::interleave(
-          conformanceProtos,
-          [&out, &printOptions](const ProtocolType *protoTy) {
-            protoTy->print(out, printOptions);
-          },
-          [&out] { out << ", "; });
-      out << " where "
-          << nominal->getGenericSignature().getGenericParams()[0]->getName()
-          << " : " << DummyProtocolName << " {}\n";
-    };
-
-    // We have to print conformances for invertible protocols in separate
-    // extensions, so do those first and save the rest for one extension.
-    SmallVector<const ProtocolType *, 8> regulars;
-    for (auto *proto : ConditionalConformanceProtocols) {
-      if (proto->getDecl()->getInvertibleProtocolKind()) {
-        emitExtension(proto);
-        continue;
-      }
-      regulars.push_back(proto);
-    }
-    emitExtension(regulars);
+    if (!printOptions.printPublicInterface())
+      out << "@_spi(" << DummyProtocolName << ")\n";
+    out << "@available(*, unavailable)\nextension ";
+    nominal->getDeclaredType().print(out, printOptions);
+    out << " : ";
+    llvm::interleave(
+        ConditionalConformanceProtocols,
+        [&out, &printOptions](const ProtocolType *protoTy) {
+          protoTy->print(out, printOptions);
+        },
+        [&out] { out << ", "; });
+    out << " where "
+        << nominal->getGenericSignature().getGenericParams()[0]->getName()
+        << " : " << DummyProtocolName << " {}\n";
     return true;
   }
 

--- a/test/ModuleInterface/Inputs/NoncopyableGenerics_Misc.swift
+++ b/test/ModuleInterface/Inputs/NoncopyableGenerics_Misc.swift
@@ -151,3 +151,12 @@ public enum Moptional<Wrapped: ~Copyable & ~Escapable>: ~Copyable, ~Escapable {
 }
 extension Moptional: Copyable where Wrapped: Copyable, Wrapped: ~Escapable {}
 extension Moptional: Escapable where Wrapped: Escapable, Wrapped: ~Copyable {}
+
+public struct GenericNCContainer<Element: ~Copyable>: ~Copyable { }
+
+// rdar://183466980
+struct InternalElement: ~Copyable {}
+extension GenericNCContainer: Publik where Element == InternalElement {}
+
+extension GenericNCContainer: P where Element == Int {}
+

--- a/test/ModuleInterface/noncopyable_generics.swift
+++ b/test/ModuleInterface/noncopyable_generics.swift
@@ -155,10 +155,21 @@ import NoncopyableGenerics_Misc
 // CHECK-MISC: extension {{.*}}::Moptional : Swift::Copyable where Wrapped : Swift::Copyable, Wrapped : ~Escapable {
 // CHECK-MISC: extension {{.*}}::Moptional : Swift::Escapable where Wrapped : Swift::Escapable, Wrapped : ~Copyable {
 
+// CHECK-MISC: public struct GenericNCContainer<Element> : ~Swift::Copyable where Element : ~Copyable {
+// CHECK-MISC-NEXT: }
+
 // CHECK-MISC-NOT:  ~
 
 // NOTE: below are extensions emitted at the end of NoncopyableGenerics_Misc::swift
 // CHECK-MISC: extension {{.*}}::VeryNested : {{.*}}::Publik {}
+
+// CHECK-MISC:      @available(*, unavailable)
+// CHECK-MISC-NEXT: extension {{.*}}::GenericNCContainer : {{.*}}::Publik where Element : _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}
+
+// CHECK-MISC-NOT: extension {{.*}}::GenericNCContainer
+
+// CHECK-MISC:      @usableFromInline
+// CHECK-MISC-NEXT: internal protocol _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}
 
 import Swiftskell
 

--- a/test/ModuleInterface/nonescapable_types.swift
+++ b/test/ModuleInterface/nonescapable_types.swift
@@ -54,3 +54,18 @@ public func derive<T : ~Escapable>(_ y: Y<T>) -> Y<T> {
 public func derive<T : ~Escapable>(_ x: X<T>) -> X<T> {
   x
 }
+
+public protocol PublicP: ~Escapable { }
+extension X: PublicP where T == InternalStruct { }
+
+// CHECK:      @available(*, unavailable)
+// CHECK-NEXT: extension Test::X : Test::PublicP where T : _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}
+
+struct InternalStruct: ~Escapable { }
+protocol InternalP: ~Escapable { }
+
+// CHECK-NOT: extension Test::X
+extension X: InternalP where T == InternalStruct { }
+
+// CHECK:      @usableFromInline
+// CHECK-NEXT: internal protocol _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}

--- a/validation-test/ParseableInterface/rdar128577611.swift
+++ b/validation-test/ParseableInterface/rdar128577611.swift
@@ -6,11 +6,11 @@
 struct InternalStruct {}
 extension [Int: InternalStruct]: Sendable {}
 
-// CHECK: @available(*, unavailable)
-// CHECK-NEXT: extension Swift::Dictionary : Swift::Copyable where Key : _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}
-
-// CHECK: @available(*, unavailable)
-// CHECK-NEXT: extension Swift::Dictionary : Swift::Escapable where Key : _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}
+// CHECK-NOT: extension Swift::Dictionary : Swift::Copyable
+// CHECK-NOT: extension Swift::Dictionary : Swift::Escapable
 
 // CHECK: @available(*, unavailable)
 // CHECK-NEXT: extension Swift::Dictionary : Swift::Sendable where Key : _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}
+
+// CHECK:      @usableFromInline
+// CHECK-NEXT: internal protocol _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}


### PR DESCRIPTION
When an extension adds a conditional conformance that can't be printed in the interface, we reserve it with a dummy extension constrained by `_ConstraintThatIsNotPartOfTheAPIOfThisLibrary` so that no other module can declare a conflicting conformance. The set of protocols to reserve was collected from the existential layout of each inherited type, but that layout synthesizes entries for every invertible protocol the type doesn't suppress. An extension like

    extension X: InternalP where T == Int {}

would therefore also reserve a conformance to Escapable, which the extension never declared. Reserving an invertible protocol produces an interface that can't be read back, since a conditional conformance to a suppressible protocol is not allowed to depend on an arbitrary requirement. Conformances to invertible protocols are always re-inferred from the interface anyway, so skip them when collecting, as we already do when printing synthesized extensions.

Dropping the invertible protocols also means the extension emitted for the remaining ones can no longer be empty, so the logic that split them into separate extensions is no longer needed. That split was the source of a second bug: with nothing left to print, it emitted `extension X : where ...` with no protocol at all.

Resolves rdar://183466980.
