### PR TITLE
SILOptimizer: Run YieldOnceCheck on yield-once-2 coroutines

### DIFF
--- a/lib/SILOptimizer/Mandatory/YieldOnceCheck.cpp
+++ b/lib/SILOptimizer/Mandatory/YieldOnceCheck.cpp
@@ -11,7 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 // This pass statically verifies that yield-once coroutines, such as the
-// generalized accessors `read` and `modify`, yield exactly once in every
+// generalized accessors `_read` and `_modify` and the coroutine accessors
+// `yielding borrow` and `yielding mutate`, yield exactly once in every
 // invocation, and diagnoses any violation of this property. This pass uses a
 // linear-time, data-flow analysis to check that every path in the control-flow
 // graph of the coroutine has a yield instruction before a return instruction.
@@ -524,9 +525,14 @@ class YieldOnceCheck : public SILFunctionTransform {
   void run() override {
     auto *fun = getFunction();
 
-    if (fun->getLoweredFunctionType()->getCoroutineKind() !=
-        SILCoroutineKind::YieldOnce)
+    switch (fun->getLoweredFunctionType()->getCoroutineKind()) {
+    case SILCoroutineKind::YieldOnce:
+    case SILCoroutineKind::YieldOnce2:
+      break;
+    case SILCoroutineKind::None:
+    case SILCoroutineKind::YieldMany:
       return;
+    }
 
     diagnoseYieldOnceUsage(*fun);
   }

--- a/test/SILOptimizer/coroutine_accessors_yield_once.swift
+++ b/test/SILOptimizer/coroutine_accessors_yield_once.swift
@@ -1,0 +1,113 @@
+// RUN: %target-swift-frontend -sil-verify-all -emit-sil -primary-file %s -o /dev/null -verify \
+// RUN:     -enable-experimental-feature CoroutineAccessors
+
+// REQUIRES: swift_feature_CoroutineAccessors
+
+// Tests for yield-once diagnostics emitted for the `yielding borrow` and
+// `yielding mutate` coroutine accessors, which are yield-once-2 coroutines.
+
+struct TestNoYield {
+  var stored: Int
+
+  var computed: Int {
+    yielding borrow {
+    } // expected-error {{accessor must yield before returning}}
+
+    yielding mutate {
+    } // expected-error {{accessor must yield before returning}}
+  }
+}
+
+extension Never {
+  var computed: Never? {
+    yielding borrow {
+      Optional<Never>.none
+    } // expected-error {{accessor must yield before returning}}
+  }
+}
+
+struct TestReturnPathWithoutYield {
+  var stored: Int
+  var flag: Bool
+
+  var computed: Int {
+    mutating yielding borrow {
+      if flag {   // expected-note {{missing yield when the condition is false}}
+        yield stored
+      }
+      flag = true
+    } // expected-error {{accessor must yield on all paths before returning}}
+
+    yielding mutate {
+      if flag {   // expected-note {{missing yield when the condition is false}}
+        yield &stored
+      }
+    } // expected-error {{accessor must yield on all paths before returning}}
+  }
+}
+
+struct TestMultipleYields {
+  var stored: Int
+
+  var computed: Int {
+    yielding borrow {
+      yield stored  // expected-note {{previous yield was here}}
+      yield stored  // expected-error {{accessor must not yield more than once}}
+    }
+
+    yielding mutate {
+      yield &stored // expected-note {{previous yield was here}}
+      yield &stored // expected-error {{accessor must not yield more than once}}
+    }
+  }
+}
+
+struct TestYieldInLoop {
+  var stored: Int
+
+  var computed: Int {
+    yielding borrow {
+      for _ in 0 ..< 10 {
+        yield stored  // expected-note {{previous yield was here}}
+                      // expected-error@-1 {{accessor must not yield more than once}}
+      }
+    }
+  }
+}
+
+struct TestYieldInOptionalBinding<T> {
+  var storedOpt: T?
+
+  var computed: T {
+    yielding borrow {
+      if let stored = storedOpt {
+        yield stored
+      }                   // expected-note {{missing yield in the nil case}}
+    } // expected-error {{accessor must yield on all paths before returning}}
+  }
+}
+
+struct TestValidYields {
+  var stored: Int
+  var flag: Bool
+
+  var computed: Int {
+    yielding borrow {
+      yield stored
+    }
+
+    yielding mutate {
+      yield &stored
+    }
+  }
+
+  var branching: Int {
+    mutating yielding borrow {
+      if flag {
+        yield stored
+      } else {
+        yield 0
+      }
+    }
+  }
+}


### PR DESCRIPTION
The pass that diagnoses missing, duplicate, and conditional yields only ran on functions with a coroutine kind of YieldOnce, which was the only yield-once kind when the pass was written. The `yielding borrow` and `yielding mutate` accessors lower to YieldOnce2, so their bodies were never checked. A missing yield in one of these accessors made it all the way to IRGen and was caught by the LLVM coro verifier instead, which reported "Broken function" as a fatal error with no source location, giving the developer nothing to go on.

Check YieldOnce2 as well, and use a covered switch so that a new coroutine kind can't silently bypass the pass again.

Resolves rdar://182853089.
