### PR TITLE
[RemoteInspection] Let EnumTypeInfoBuilder calculate alignment if not known

### DIFF
--- a/include/swift/RemoteInspection/DescriptorFinder.h
+++ b/include/swift/RemoteInspection/DescriptorFinder.h
@@ -53,6 +53,8 @@ struct BuiltinTypeDescriptorBase {
         Borrowability(Borrowability),
         AddressableForDependencies(AFD) {}
 
+  bool hasKnownAlignment() const { return Alignment != 0; }
+
   virtual ~BuiltinTypeDescriptorBase(){};
 
   virtual llvm::StringRef getMangledTypeName() = 0;

--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -2365,7 +2365,10 @@ public:
     //  * Has at least two cases with non-zero payload size
     //  * Has a descriptor stored as BuiltinTypeInfo
     Size = FixedDescriptor->Size;
-    Alignment = FixedDescriptor->Alignment;
+    // If the descriptor doesn't know its alignment, let EnumTypeInfoBuilder
+    // calculate it.
+    if (FixedDescriptor->hasKnownAlignment())
+      Alignment = FixedDescriptor->Alignment;
     NumExtraInhabitants = FixedDescriptor->NumExtraInhabitants;
     Borrowability = FixedDescriptor->Borrowability;
     // Builtin descriptors don't record addressable-for-dependencies, but we


### PR DESCRIPTION
When encoding descriptors in DWARF, the compiler only emits the alignment if it's not standard.

EnumTypeInfoBuilder already knows how to calculate the alignment of an enum, so in that case, don't overwrite it if the descriptor does not know what it is.
