### PR TITLE
[DebugInfo] Anchor the special stdlib builtin types in DWARF

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1747,7 +1747,8 @@ private:
   llvm::DIType *createPointerSizedStruct(
       llvm::DIScope *Scope, StringRef Name, llvm::DIType *PointeeTy,
       llvm::DIFile *File, unsigned Line, llvm::DINode::DIFlags Flags,
-      StringRef MangledName, llvm::DIType *SpecificationOf = nullptr) {
+      StringRef MangledName, llvm::DIType *SpecificationOf = nullptr,
+      uint32_t NumExtraInhabitants = 0) {
     unsigned PtrSize =
         CI.getTargetInfo().getPointerWidth(clang::LangAS::Default);
     auto PtrTy = DBuilder.createPointerType(PointeeTy, PtrSize, 0);
@@ -1756,14 +1757,14 @@ private:
     return DBuilder.createStructType(
         Scope, Name, File, Line, PtrSize, 0, Flags,
         /* DerivedFrom */ nullptr, DBuilder.getOrCreateArray(Elements),
-        llvm::dwarf::DW_LANG_Swift, nullptr, MangledName, SpecificationOf);
+        llvm::dwarf::DW_LANG_Swift, nullptr, MangledName, SpecificationOf,
+        NumExtraInhabitants);
   }
 
-  llvm::DIType *
-  createDoublePointerSizedStruct(llvm::DIScope *Scope, StringRef Name,
-                                 llvm::DIType *PointeeTy, llvm::DIFile *File,
-                                 unsigned Line, llvm::DINode::DIFlags Flags,
-                                 StringRef MangledName) {
+  llvm::DIType *createDoublePointerSizedStruct(
+      llvm::DIScope *Scope, StringRef Name, llvm::DIType *PointeeTy,
+      llvm::DIFile *File, unsigned Line, llvm::DINode::DIFlags Flags,
+      StringRef MangledName, uint32_t NumExtraInhabitants = 0) {
     unsigned PtrSize = CI.getTargetInfo().getPointerWidth(clang::LangAS::Default);
     llvm::Metadata *Elements[] = {
         DBuilder.createMemberType(
@@ -1775,7 +1776,8 @@ private:
     return DBuilder.createStructType(
         Scope, Name, File, Line, 2 * PtrSize, 0, Flags,
         /* DerivedFrom */ nullptr, DBuilder.getOrCreateArray(Elements),
-        llvm::dwarf::DW_LANG_Swift, nullptr, MangledName);
+        llvm::dwarf::DW_LANG_Swift, nullptr, MangledName,
+        /*Specification=*/nullptr, NumExtraInhabitants);
   }
 
   llvm::DIType *createFixedValueBufferStruct(llvm::DIType *PointeeTy) {
@@ -1810,7 +1812,8 @@ private:
   llvm::DIType *createFunctionPointer(DebugTypeInfo DbgTy, llvm::DIScope *Scope,
                                       unsigned SizeInBits, unsigned AlignInBits,
                                       llvm::DINode::DIFlags Flags,
-                                      StringRef MangledName) {
+                                      StringRef MangledName,
+                                      uint32_t NumExtraInhabitants) {
     auto FwdDecl = createTemporaryReplaceableForwardDecl(
         DbgTy.getType(), Scope, MainFile, 0, SizeInBits, AlignInBits, Flags,
         MangledName, MangledName);
@@ -1838,15 +1841,18 @@ private:
       if (SizeInBits == 2 * CI.getTargetInfo().getPointerWidth(clang::LangAS::Default))
         // This is a FunctionPairTy: { i8*, %swift.refcounted* }.
         DITy = createDoublePointerSizedStruct(Scope, MangledName, FnTy,
-                                              MainFile, 0, Flags, MangledName);
+                                              MainFile, 0, Flags, MangledName,
+                                              NumExtraInhabitants);
       else
         // This is a generic function as noted above.
         DITy = createOpaqueStruct(Scope, MangledName, MainFile, 0, SizeInBits,
-                                  AlignInBits, Flags, MangledName);
+                                  AlignInBits, Flags, MangledName, {}, nullptr,
+                                  nullptr, NumExtraInhabitants);
     } else {
       assert(SizeInBits == CI.getTargetInfo().getPointerWidth(clang::LangAS::Default));
-      DITy = createPointerSizedStruct(Scope, MangledName, FnTy, MainFile, 0,
-                                      Flags, MangledName);
+      DITy = createPointerSizedStruct(
+          Scope, MangledName, FnTy, MainFile, 0, Flags, MangledName,
+          /*SpecificationOf=*/nullptr, NumExtraInhabitants);
     }
     return DBuilder.replaceTemporary(std::move(FwdDecl), DITy);
   }
@@ -1895,13 +1901,14 @@ private:
                unsigned Line, unsigned SizeInBits, unsigned AlignInBits,
                llvm::DINode::DIFlags Flags, StringRef MangledName,
                llvm::DINodeArray Elements, llvm::DINodeArray BoundParams,
-               llvm::DIType *SpecificationOf, llvm::DINodeArray Annotations) {
+               llvm::DIType *SpecificationOf, llvm::DINodeArray Annotations,
+               uint32_t NumExtraInhabitants = 0) {
 
     auto StructType = DBuilder.createStructType(
         Scope, Name, File, Line, SizeInBits, AlignInBits, Flags,
         /* DerivedFrom */ nullptr, Elements, llvm::dwarf::DW_LANG_Swift,
-        nullptr, MangledName, SpecificationOf,
-        /*NumExtraInhabitants=*/0, Annotations);
+        nullptr, MangledName, SpecificationOf, NumExtraInhabitants,
+        Annotations);
 
     if (BoundParams)
       DBuilder.replaceArrays(StructType, nullptr, BoundParams);
@@ -1914,10 +1921,11 @@ private:
                      llvm::DINode::DIFlags Flags, StringRef MangledName,
                      llvm::DINodeArray BoundParams = {},
                      llvm::DIType *SpecificationOf = nullptr,
-                     llvm::DINodeArray Annotations = nullptr) {
+                     llvm::DINodeArray Annotations = nullptr,
+                     uint32_t NumExtraInhabitants = 0) {
     return createStruct(Scope, Name, File, Line, SizeInBits, AlignInBits, Flags,
                         MangledName, {}, BoundParams, SpecificationOf,
-                        Annotations);
+                        Annotations, NumExtraInhabitants);
   }
 
   bool shouldCacheDIType(llvm::DIType *DITy, DebugTypeInfo &DbgTy) {
@@ -2366,10 +2374,10 @@ private:
       auto L = getFileAndLocation(DbgTy.getDecl());
       unsigned FwdDeclLine = 0;
 
-      return DBuilder.createStructType(Scope, MangledName, L.File, FwdDeclLine,
-                                       SizeInBits, AlignInBits, Flags, nullptr,
-                                       nullptr, llvm::dwarf::DW_LANG_Swift,
-                                       nullptr, MangledName);
+      return DBuilder.createStructType(
+          Scope, MangledName, L.File, FwdDeclLine, SizeInBits, AlignInBits,
+          Flags, nullptr, nullptr, llvm::dwarf::DW_LANG_Swift, nullptr,
+          MangledName, /*Specification=*/nullptr, NumExtraInhabitants);
     }
 
     case TypeKind::SILFunction:
@@ -2377,10 +2385,11 @@ private:
     case TypeKind::GenericFunction: {
       if (Opts.DebugInfoLevel > IRGenDebugInfoLevel::ASTTypes)
         return createFunctionPointer(DbgTy, Scope, SizeInBits, AlignInBits,
-                                     Flags, MangledName);
+                                     Flags, MangledName, NumExtraInhabitants);
       else
         return createOpaqueStruct(Scope, MangledName, MainFile, 0, SizeInBits,
-                                  AlignInBits, Flags, MangledName);
+                                  AlignInBits, Flags, MangledName, {}, nullptr,
+                                  nullptr, NumExtraInhabitants);
     }
 
     case TypeKind::Enum: {
@@ -2507,12 +2516,16 @@ private:
           nullptr, llvm::dwarf::DW_LANG_Swift, nullptr, MangledName);
     }
 
+    // A special stdlib builtin type, which the debugger looks up by mangled
+    // name, so it must not be renamed to "<unknown>" below.
+    case TypeKind::BuiltinUnsafeValueBuffer:
+      break;
+
     // The following types exist primarily for internal use by the type
     // checker.
     case TypeKind::Error:
     case TypeKind::SILBlockStorage:
     case TypeKind::SILToken:
-    case TypeKind::BuiltinUnsafeValueBuffer:
     case TypeKind::BuiltinDefaultActorStorage:
     case TypeKind::BuiltinNonDefaultDistributedActorStorage:
     case TypeKind::SILMoveOnlyWrapped:
@@ -2606,11 +2619,36 @@ private:
   void createSpecialStlibBuiltinTypes() {
     if (Opts.DebugInfoLevel <= IRGenDebugInfoLevel::ASTTypes)
       return;
-    for (auto BuiltinType: IGM.getOrCreateSpecialStlibBuiltinTypes()) {
+    for (auto BuiltinType : IGM.getOrCreateSpecialStlibBuiltinTypes()) {
       auto DbgTy = DebugTypeInfo::getFromTypeInfo(
           BuiltinType, IGM.getTypeInfoForUnlowered(BuiltinType), IGM);
-      DBuilder.retainType(getOrCreateType(DbgTy));
+      anchorType(getOrCreateType(DbgTy));
+
+      // The reflection metadata emits AnyObject as the old
+      // Builtin.UnknownObject for ABI compatibility (see
+      // FixedTypeMetadataBuilder::layout()), so emit a second DIE under that
+      // name.
+      if (!BuiltinType->isAnyObject())
+        continue;
+      if (auto CompletedDbgTy = completeType(DbgTy)) {
+        StringRef Prefix = IGM.Context.LangOpts.hasFeature(Feature::Embedded)
+                               ? MANGLING_PREFIX_EMBEDDED_STR
+                               : MANGLING_PREFIX_STR;
+        anchorType(DBuilder.createBasicType(
+            BumpAllocatedString((Twine(Prefix) + "BOD").str()),
+            CompletedDbgTy->getSizeInBits(), /*Encoding=*/0,
+            llvm::DINode::FlagZero,
+            CompletedDbgTy->getNumExtraInhabitants().value_or(0)));
+      }
     }
+  }
+
+  /// Retain \p DITy, and keep dsymutil from stripping it as unused.
+  void anchorType(llvm::DIType *DITy) {
+    if (!DITy)
+      return;
+    DBuilder.retainType(DITy);
+    DBuilder.createImportedDeclaration(TheCU, DITy, MainFile, 0);
   }
 
   /// Anchor DW_TAG_typedef DIEs for the stdlib C-interop typealiases (CChar,
@@ -2649,10 +2687,7 @@ private:
                                          /*genericArgs=*/{}, Underlying);
       auto AliasDbgTy = DebugTypeInfo::getFromTypeInfo(
           AliasTy, IGM.getTypeInfoForUnlowered(AliasTy), IGM);
-      llvm::DIType *TypeDef = getOrCreateType(AliasDbgTy);
-      DBuilder.retainType(TypeDef);
-      // This is needed to prevent dsymutil from considering the type unused.
-      DBuilder.createImportedDeclaration(TheCU, TypeDef, MainFile, 0);
+      anchorType(getOrCreateType(AliasDbgTy));
     };
 #define MAP_BUILTIN_TYPE(CLANG, SWIFT) anchorAlias(#SWIFT);
 #include "swift/ClangImporter/BuiltinMappedTypes.def"

--- a/test/DebugInfo/special-stdlib-builtin-types-dsym.swift
+++ b/test/DebugInfo/special-stdlib-builtin-types-dsym.swift
@@ -1,0 +1,42 @@
+/*
+REQUIRES: OS_FAMILY=darwin
+
+Verify the DIEs for the special stdlib builtin types survive dsymutil's DWARF
+linker. Nothing in the program refers to these types, so
+DIBuilder::retainType() alone does not keep them: the
+DW_TAG_imported_declaration anchor emitted alongside each one is what stops the
+DWARFLinker from pruning it. special-stdlib-builtin-types.swift covers the
+emission itself, on IR, and so runs everywhere; this test covers survival.
+
+RUN: %empty-directory(%t)
+RUN: %target-swift-frontend -c -g -gdwarf-types -o %t/main.o %s
+RUN: %target-build-swift -g -o %t/a.out %t/main.o
+RUN: %dsymutil %t/a.out -o %t/a.out.dSYM
+RUN: %llvm-dwarfdump --debug-info %t/a.out.dSYM | %FileCheck %s
+
+Builtin.UnknownObject ("BO") and Builtin.UnsafeValueBuffer ("BB") are the two a
+debugger could not find at all before: the first had no DIE, and the second was
+named "<unknown>".
+
+CHECK-DAG: DW_AT_name ("$sBOD")
+CHECK-DAG: DW_AT_name ("$sBBD")
+
+CHECK-DAG: DW_AT_name ("$sBoD")
+CHECK-DAG: DW_AT_name ("$sBbD")
+CHECK-DAG: DW_AT_name ("$sBpD")
+CHECK-DAG: DW_AT_name ("$syyXfD")
+CHECK-DAG: DW_AT_name ("$sypXpD")
+
+The extra inhabitant counts have to survive too, not just the names -- they are
+what the descriptor is for.
+
+CHECK-DAG: DW_AT_LLVM_num_extra_inhabitants
+
+Spot-check that the anchors themselves are in the linked output.
+
+CHECK-DAG: DW_AT_import ({{0x[0-9a-f]+}} "$sBOD")
+CHECK-DAG: DW_AT_import ({{0x[0-9a-f]+}} "$sBBD")
+*/
+
+func use<T>(_ t: T) {}
+use(42)

--- a/test/DebugInfo/special-stdlib-builtin-types.swift
+++ b/test/DebugInfo/special-stdlib-builtin-types.swift
@@ -1,0 +1,54 @@
+/*
+Verify the debug info for the special stdlib builtin types
+(IRGenModule::getOrCreateSpecialStlibBuiltinTypes()) carries everything a
+debugger needs to build a builtin type descriptor out of DWARF: a mangled name
+to find it by, a size, and an extra inhabitant count. A debugger has to do this
+when there is no reflection metadata to read, which is always the case in
+embedded Swift.
+
+RUN: %target-swift-frontend -emit-ir -g -gdwarf-types %s -o - | %FileCheck %s
+RUN: %target-swift-frontend -emit-ir -g               %s -o - | %FileCheck %s --check-prefix=ASTTYPES
+
+The counts and sizes are target dependent (they follow LeastValidPointerValue,
+which differs between Darwin and everything else, and between embedded and
+non-embedded), so only their presence is checked here. Builtin.RawPointer is
+the exception: it is nullable and null is its only extra inhabitant, so its
+count is 1 everywhere.
+
+CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "$sBoD",{{.*}} num_extra_inhabitants: {{[0-9]+}},
+CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "$sBbD",{{.*}} num_extra_inhabitants: {{[0-9]+}},
+CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "$sBpD",{{.*}} num_extra_inhabitants: 1,
+
+A thin function type and an existential metatype are emitted as structs rather
+than base types, so the count has to be attached to the struct.
+
+CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "$syyXfD",{{.*}} num_extra_inhabitants: {{[0-9]+}},
+CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "$sypXpD",{{.*}} num_extra_inhabitants: {{[0-9]+}},
+
+Builtin.UnsafeValueBuffer has no dedicated case in createType() and must not
+fall into the unhandled-type bucket, which would rename it "<unknown>".
+
+CHECK-DAG: ![[BB:[0-9]+]] = !DIBasicType(name: "$sBBD", size: {{[0-9]+}})
+
+AnyObject is not a builtin, but the reflection metadata emits it as the old
+Builtin.UnknownObject for ABI compatibility, so a debugger asks for "BO".
+
+CHECK-DAG: ![[BO:[0-9]+]] = !DIBasicType(name: "$sBOD", size: {{[0-9]+}}, num_extra_inhabitants: {{[0-9]+}})
+
+Each one is anchored with a DW_TAG_imported_declaration; retaining the type is
+not enough to survive dsymutil, since nothing in the program refers to these
+types. (special-stdlib-builtin-types-dsym.swift verifies they survive.)
+
+CHECK-DAG: !DIImportedEntity(tag: DW_TAG_imported_declaration, scope: !{{[0-9]+}}, entity: ![[BB]],
+CHECK-DAG: !DIImportedEntity(tag: DW_TAG_imported_declaration, scope: !{{[0-9]+}}, entity: ![[BO]],
+
+None of this is emitted below the DwarfTypes level, where there is no type
+lowering information to describe anyway.
+
+ASTTYPES-NOT: name: "$sBOD"
+ASTTYPES-NOT: name: "$sBBD"
+ASTTYPES-NOT: name: "$syyXfD"
+*/
+
+func use<T>(_ t: T) {}
+use(42)


### PR DESCRIPTION
RemoteInspection expects to find certain special stlib lib build types. For embedded swift lldb feeds DWARF into RemoteInspection to build type information. We've encoded these special types in DWARF, but they could be stripped by dsymutil since they had no uses. Anchor them so they're not stripped.

Assisted-by: claude

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
