### PR TITLE
Sema: Avoid checking effects in skipped local function bodies

### DIFF
--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -5031,6 +5031,9 @@ void TypeChecker::checkFunctionEffects(AbstractFunctionDecl *fn) {
   PrettyStackTraceDecl debugStack("checking effects handling for", fn);
 #endif
 
+  if (fn->isBodySkipped())
+    return;
+
   auto context = Context::forFunction(fn);
   auto &ctx = fn->getASTContext();
   CheckEffectsCoverage checker(ctx, context);

--- a/test/SILGen/skip_local_function_bodies.swift
+++ b/test/SILGen/skip_local_function_bodies.swift
@@ -1,6 +1,8 @@
 // RUN: %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values %s
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -experimental-skip-non-inlinable-function-bodies-without-types %s -emit-module-path %t/skip_local_function_bodies.swiftmodule
+// RUN: %target-swift-frontend -emit-module -verify %s -emit-module-path /dev/null
+// RUN: %target-swift-frontend -emit-module -verify -experimental-skip-non-inlinable-function-bodies-without-types %s -emit-module-path /dev/null
+// RUN: %target-swift-frontend -emit-module -verify -experimental-skip-non-inlinable-function-bodies %s -emit-module-path /dev/null
+// RUN: %target-swift-frontend -emit-module -verify -experimental-skip-all-function-bodies %s -emit-module-path /dev/null
 
 public protocol P {
     init()
@@ -11,7 +13,32 @@ extension P {
         typealias T = Self
 
         func g(_ x: T) {}
-	g(self)
+        g(self)
     }
 }
 
+func throwsError() throws -> Int { 0 }
+
+extension P {
+    public func h() {
+        typealias T = Self
+
+        func g(_ x: T) {
+            do {
+                _ = try throwsError()
+            } catch {
+            }
+        }
+        g(self)
+    }
+}
+
+let globalWithLocalFunc: Void = {
+    func g() {
+        do {
+            _ = try throwsError()
+        } catch {
+        }
+    }
+    g()
+}()


### PR DESCRIPTION
Make sure `TypeChecker::checkFunctionEffects()` returns early when it is given a skipped function to prevent spurious diagnostics.

The `LocalFunctionEffectsChecker` AST walker invokes the effects checker on all local function bodies, regardless of whether those functions are skipped. Without the early return, this was causing spurious diagnostics since the effects checker expects a type checked AST as input.

Resolves rdar://183430912 and https://github.com/swiftlang/swift/issues/91025.