### PR TITLE
[test] sort_integers.swift: fix vacuous sortedness check

### DIFF
--- a/test/stdlib/sort_integers.swift
+++ b/test/stdlib/sort_integers.swift
@@ -75,7 +75,7 @@ let sort_verifier: ([Int]) -> Void = {
     }
 }
 
-//CHECK-NOT: Error!
+//CHECK-NOT: Error
 permute(2, sort_verifier)
 permute(6, sort_verifier)
 permute(7, sort_verifier)
@@ -111,7 +111,7 @@ let partition_verifier: ([Int]) -> Void = {
 permute(2, partition_verifier)
 permute(6, partition_verifier)
 permute(7, partition_verifier)
-//CHECK-NOT: Error!
+//CHECK-NOT: Error
 //CHECK: Test2 - Done
 print("Test2 - Done")
 
@@ -119,7 +119,7 @@ print("Test2 - Done")
 randomize(70, sort_verifier)
 randomize(700, sort_verifier)
 randomize(1900, sort_verifier)
-//CHECK-NOT: Error!
+//CHECK-NOT: Error
 //CHECK: Test3 - Done
 print("Test3 - Done")
 

--- a/test/stdlib/sort_integers.swift
+++ b/test/stdlib/sort_integers.swift
@@ -69,7 +69,7 @@ let sort_verifier: ([Int]) -> Void = {
     var y = $0.sorted()
     for i in 0..<y.count - 1 {
     if (y[i] > y[i+1]) {
-        print("Error: \(y)")
+        print("Error! \(y)")
         return
       }
     }


### PR DESCRIPTION
Resolves https://github.com/swiftlang/swift/issues/91077.

`sort_verifier` in `test/stdlib/sort_integers.swift` reports a failure by
printing `Error: <array>`, but the `CHECK-NOT` directives guarding it look for
the literal `Error!`. FileCheck matches literal substrings, so `Error: [1, 0]`
does not match `Error!` and the test exits 0 even when the verifier has detected
an unsorted result. `partition_verifier`, twenty lines below in the same file,
prints exactly `Error!` and is matched correctly — the two verifiers disagree on
the sentinel, and only one of them matches its directive.

To be clear about impact: `sorted()` is correct and is well covered elsewhere.
This is a test-infrastructure defect — the file has not been able to fail for the
reason it exists for.

## The two commits

**1. Align the message with the directive** (`Error: ` → `Error! `). One
character; keeps the offending array in the diagnostic and makes the file
internally consistent with `partition_verifier`.

**2. Widen the three directives** (`CHECK-NOT: Error!` → `CHECK-NOT: Error`).
This removes the coupling that caused the bug rather than just repairing its
effect. `85533dd7d` reworded `Error!` to `Error: \(y)` specifically so a failure
would show the offending array — an improvement in isolation, with nothing to
signal that the message text was load-bearing. The widened directive means the
next such reword cannot silently make the test vacuous again.

Safe because the expected output contains no other occurrence of `Error`: the
only three sites are the failure paths in the two verifiers.

**Either commit restores the check on its own** — I measured this, see the table
below. They are kept separate so the second can be dropped if you'd rather not
loosen the match. If only one is wanted I'd suggest the second, since the
brittleness is what produced an 11-year outage.

## Scope

Two of the three `CHECK-NOT` groups were affected, both guarding `sort_verifier`:
line 78 (`permute(2/6/7)`, Test1) and line 122 (`randomize(70/700/1900)`, Test3).
Line 114 guards `partition_verifier` (Test2) and was already correct; it is
widened for consistency only.

## Verification

Beyond the FileCheck-layer reproduction in the issue, I ran an end-to-end
mutation test: replace `$0.sorted()` with a sort that returns its input
unchanged, leaving the rest of the file identical, compile, and pipe real stdout
through FileCheck.

| file state | mutant (broken sort) | clean run (real `sorted()`) |
|---|---|---|
| as it ships today | **passes** — 5,762 `Error: …` lines emitted, none matched | passes |
| commit 1 only | fails at line 78 | passes |
| commit 2 only | fails at line 78 | passes |
| both commits | fails at line 78 | passes, all three `- Done` markers present |

The failure diagnostic under the patch:

```
sort_integers.swift:78:14: error: CHECK-NOT: excluded string found in input
//CHECK-NOT: Error
             ^
<stdin>:7:1: note: found here
Error! [1, 0]
^~~~~~
```

Checked with FileCheck 22.1.8 against `04015859907`.

## Not addressed here

`sort_verifier` checks only that the result is ordered, not that it is a
permutation of the input, so a `sorted()` that duplicated elements would still
pass. That is a separate widening and is deliberately left out of this change.
