### PR TITLE
🍒[6.4.x] ASTDemangler: reconstruct constrained existential compositions faithfully

### DIFF
--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -913,10 +913,33 @@ Type ASTBuilder::createExistentialMetatypeType(
                                       getMetatypeRepresentation(*repr));
 }
 
+/// Collect the inherited protocols not already present in memberProtocols into
+/// recoverableProtocols, in source order.
+static void collectRecoverableProtocols(
+    ProtocolDecl *proto,
+    const llvm::SmallDenseSet<ProtocolDecl *, 2> &memberProtocols,
+    llvm::SmallSetVector<ProtocolDecl *, 4> &recoverableProtocols,
+    llvm::SmallDenseSet<ProtocolDecl *, 4> &visitedInheritedProtocols) {
+  // Visiting inherited protocols depth-first preserves source order, where
+  // LIFO order in ProtocolDecl::walkInheritedProtocols() would cause them
+  // to be reconstructed in the wrong order.
+  for (auto *inheritedProto : proto->getInheritedProtocols()) {
+    if (!visitedInheritedProtocols.insert(inheritedProto).second)
+      continue;
+
+    if (!memberProtocols.contains(inheritedProto))
+      recoverableProtocols.insert(inheritedProto);
+
+    collectRecoverableProtocols(inheritedProto, memberProtocols,
+                                recoverableProtocols,
+                                visitedInheritedProtocols);
+  }
+}
+
 Type ASTBuilder::createConstrainedExistentialType(
     Type base, ArrayRef<BuiltRequirement> constraints,
     ArrayRef<BuiltInverseRequirement> inverseRequirements) {
-  llvm::SmallDenseMap<AssociatedTypeDecl *, Type> primaryAssociatedTypes;
+  llvm::SmallMapVector<AssociatedTypeDecl *, Type, 2> primaryAssociatedTypes;
   llvm::SmallDenseSet<AssociatedTypeDecl *> claimed;
 
   for (const auto &req : constraints) {
@@ -945,35 +968,100 @@ Type ASTBuilder::createConstrainedExistentialType(
     return Type();
   }
 
-  auto maybeFormParameterizedProtocolType = [&](ProtocolType *protoTy) -> Type {
-    auto *proto = protoTy->getDecl();
-
-    llvm::SmallVector<Type, 4> args;
-    for (auto *assocTy : proto->getPrimaryAssociatedTypes()) {
-      auto found = primaryAssociatedTypes.find(assocTy);
-      if (found != primaryAssociatedTypes.end()) {
-        args.push_back(found->second);
-        claimed.insert(found->first);
-        continue;
-      }
+  auto getPrimaryAssociatedTypeConstraint =
+      [&](AssociatedTypeDecl *assocTy,
+          bool allowAnchoredMatch)
+          -> std::optional<std::pair<Type, AssociatedTypeDecl *>> {
+    if (auto found = primaryAssociatedTypes.find(assocTy);
+        found != primaryAssociatedTypes.end()) {
+      return std::pair<Type, AssociatedTypeDecl *>(found->second, found->first);
     }
 
-    // We may not have any arguments because the constrained existential is a
-    // plain protocol with an inverse requirement.
-    if (args.empty())
+    if (!allowAnchoredMatch)
+      return std::nullopt;
+
+    auto *assocTyAnchor = assocTy->getAssociatedTypeAnchor();
+    for (const auto &entry : primaryAssociatedTypes) {
+      if (entry.first->getAssociatedTypeAnchor() == assocTyAnchor)
+        return std::pair<Type, AssociatedTypeDecl *>(entry.second, entry.first);
+    }
+
+    return std::nullopt;
+  };
+
+  struct ParameterizedProtocolTypeMatch {
+    Type type;
+    SmallVector<AssociatedTypeDecl *, 4> matchedAssocTypes;
+  };
+
+  auto maybeGetParameterizedProtocolTypeMatch =
+      [&](ProtocolType *protoTy, bool allowAnchoredMatch)
+          -> std::optional<ParameterizedProtocolTypeMatch> {
+    auto *proto = protoTy->getDecl();
+    auto primaryAssocTypes = proto->getPrimaryAssociatedTypes();
+
+    if (primaryAssocTypes.empty())
+      return std::nullopt;
+
+    llvm::SmallVector<Type, 4> args;
+    SmallVector<AssociatedTypeDecl *, 4> matchedAssocTypes;
+    for (auto *assocTy : primaryAssocTypes) {
+      auto found =
+          getPrimaryAssociatedTypeConstraint(assocTy, allowAnchoredMatch);
+      if (!found)
+        return std::nullopt;
+
+      args.push_back(found->first);
+      matchedAssocTypes.push_back(found->second);
+    }
+
+    ParameterizedProtocolTypeMatch match{
+        ParameterizedProtocolType::get(Ctx, protoTy, args), {}};
+    match.matchedAssocTypes.append(matchedAssocTypes.begin(),
+                                   matchedAssocTypes.end());
+    return match;
+  };
+
+  auto maybeFormParameterizedProtocolType =
+      [&](ProtocolType *protoTy, bool allowAnchoredMatch) -> Type {
+    auto match =
+        maybeGetParameterizedProtocolTypeMatch(protoTy, allowAnchoredMatch);
+    if (!match)
       return protoTy;
 
-    return ParameterizedProtocolType::get(Ctx, protoTy, args);
+    for (auto *assocTy : match->matchedAssocTypes)
+      claimed.insert(assocTy);
+
+    return match->type;
   };
 
   SmallVector<Type, 2> members;
+  llvm::SmallDenseSet<ProtocolDecl *, 2> memberProtocols;
   bool hasExplicitAnyObject = false;
   InvertibleProtocolSet inverses;
+
+  auto extractProtocolDecl = [](Type member) -> ProtocolDecl * {
+    if (auto *protoTy = member->getAs<ProtocolType>())
+      return protoTy->getDecl();
+
+    if (auto *paramProtoTy = member->getAs<ParameterizedProtocolType>())
+      return paramProtoTy->getProtocol();
+
+    return nullptr;
+  };
+
+  auto addMember = [&](Type member) {
+    members.push_back(member);
+
+    if (auto *proto = extractProtocolDecl(member))
+      memberProtocols.insert(proto);
+  };
 
   // We're given either a single protocol type, or a composition of protocol
   // types. Transform each protocol type to add arguments, if necessary.
   if (auto protoTy = base->getAs<ProtocolType>()) {
-    members.push_back(maybeFormParameterizedProtocolType(protoTy));
+    addMember(
+        maybeFormParameterizedProtocolType(protoTy, /*allowAnchoredMatch=*/false));
   } else {
     auto compositionTy = base->castTo<ProtocolCompositionType>();
     hasExplicitAnyObject = compositionTy->hasExplicitAnyObject();
@@ -981,12 +1069,97 @@ Type ASTBuilder::createConstrainedExistentialType(
 
     for (auto member : compositionTy->getMembers()) {
       if (auto *protoTy = member->getAs<ProtocolType>()) {
-        members.push_back(maybeFormParameterizedProtocolType(protoTy));
+        addMember(maybeFormParameterizedProtocolType(
+            protoTy, /*allowAnchoredMatch=*/false));
         continue;
       }
       ASSERT(member->getClassOrBoundGenericClass());
-      members.push_back(member);
+      addMember(member);
     }
+  }
+
+  // The mangled base type may canonicalize away an inherited protocol while the
+  // requirement list still constrains one of its primary associated types. In
+  // that case, reintroduce the inherited protocol member so we can faithfully
+  // reconstruct the original constrained existential shape.
+  llvm::SmallDenseSet<ProtocolDecl *, 2> protocolsToAdd;
+
+  // For each protocol, cache the anchors of its primary associated types so
+  // membership can be tested without rescanning the protocol on every
+  // candidate/constraint pair below.
+  llvm::DenseMap<ProtocolDecl *, llvm::SmallDenseSet<AssociatedTypeDecl *, 4>>
+      primaryAnchorSets;
+
+  auto protocolCanClaimAssociatedType =
+      [&](ProtocolDecl *proto, AssociatedTypeDecl *assocTy) {
+    auto [entry, inserted] = primaryAnchorSets.try_emplace(proto);
+    if (inserted) {
+      for (auto *primaryAssocTy : proto->getPrimaryAssociatedTypes())
+        entry->second.insert(primaryAssocTy->getAssociatedTypeAnchor());
+    }
+    return entry->second.count(assocTy->getAssociatedTypeAnchor()) != 0;
+  };
+
+  auto matchClaimsNewAssociatedType =
+      [&](const ParameterizedProtocolTypeMatch &match) {
+        return llvm::any_of(match.matchedAssocTypes,
+                            [&](AssociatedTypeDecl *assocTy) {
+                              return !claimed.contains(assocTy);
+                            });
+      };
+
+  llvm::SmallSetVector<ProtocolDecl *, 4> recoverableProtocolsInSourceOrder;
+  for (auto member : members) {
+    auto *memberProto = extractProtocolDecl(member);
+    if (!memberProto)
+      continue;
+
+    llvm::SmallDenseSet<ProtocolDecl *, 4> visitedInheritedProtocols;
+    collectRecoverableProtocols(memberProto, memberProtocols,
+                                recoverableProtocolsInSourceOrder,
+                                visitedInheritedProtocols);
+  }
+
+  for (const auto &entry : primaryAssociatedTypes) {
+    auto *assocTy = entry.first;
+    if (claimed.contains(assocTy))
+      continue;
+
+    SmallVector<ProtocolDecl *, 2> viableCandidateProtocols;
+    for (auto *candidateProto : recoverableProtocolsInSourceOrder) {
+      if (!protocolCanClaimAssociatedType(candidateProto, assocTy))
+        continue;
+
+      auto *candidateProtoTy =
+          candidateProto->getDeclaredInterfaceType()->castTo<ProtocolType>();
+      auto candidateMatch = maybeGetParameterizedProtocolTypeMatch(
+          candidateProtoTy, /*allowAnchoredMatch=*/true);
+      if (!candidateMatch || !matchClaimsNewAssociatedType(*candidateMatch))
+        continue;
+
+      viableCandidateProtocols.push_back(candidateProto);
+    }
+
+    // Keep only the most-derived candidates. canonicalizeProtocols also sorts,
+    // but order doesn't matter here: protocolsToAdd is a membership set and the
+    // members are emitted in source order below.
+    ProtocolType::canonicalizeProtocols(viableCandidateProtocols);
+    for (auto *candidateProto : viableCandidateProtocols)
+      protocolsToAdd.insert(candidateProto);
+  }
+
+  for (auto *proto : recoverableProtocolsInSourceOrder) {
+    if (!protocolsToAdd.count(proto))
+      continue;
+
+    auto claimedSize = claimed.size();
+    auto *protoTy = proto->getDeclaredInterfaceType()->castTo<ProtocolType>();
+    auto member =
+        maybeFormParameterizedProtocolType(protoTy, /*allowAnchoredMatch=*/true);
+    if (claimed.size() == claimedSize)
+      continue;
+
+    addMember(member);
   }
 
   // Make sure that all arguments were actually used.

--- a/test/TypeDecoder/constrained_existentials.swift
+++ b/test/TypeDecoder/constrained_existentials.swift
@@ -57,3 +57,154 @@ do {
 //   blackHole_noncopyable(consume e0)
 //   blackHole_noncopyable(consume e1)
 }
+
+// Constrained existential compositions where an inherited protocol is listed
+// explicitly alongside a constraint on one of its primary associated types.
+// The mangled base type canonicalizes away the redundant inherited member,
+// but the same-type constraint on its primary associated type survives in
+// the requirement list, so reconstruction must recover the inherited member
+// to claim it. (https://github.com/swiftlang/swift/issues/87358)
+//
+// The mangled names below are compiler-generated via...
+//
+//   swiftc -emit-ir -g -module-name constrained_existentials \
+//     -Xfrontend -disable-availability-checking \
+//     test/TypeDecoder/constrained_existentials.swift
+
+protocol Base<T> {
+  associatedtype T
+}
+
+protocol Derived: Base {}
+
+struct SDerived<T>: Derived {}
+
+do {
+  let e0: any Derived & Base<Int> = SDerived<Int>()
+  let e1: any (Derived & Base<Int>).Type = SDerived<Int>.self
+  let e2: (any Derived & Base<Int>).Type = (any Derived & Base<Int>).self
+
+  blackHole(e0, e1, e2)
+}
+
+// DEMANGLE: _$s24constrained_existentials7Derived_pSi1TAA4BasePRts_XPD
+// DEMANGLE: _$s24constrained_existentials7Derived_pSi1TAA4BasePRts_XPXmTD
+// DEMANGLE: _$s24constrained_existentials7Derived_pSi1TAA4BasePRts_XPXMtD
+
+// CHECK: any Derived & Base<Int>
+// CHECK: @thick any (Derived & Base<Int>).Type
+// CHECK: @thin (any Derived & Base<Int>).Type
+
+// Same shape, but the inherited base being recovered is one of two siblings
+// that both refine a common ancestor with two primary associated types; only
+// one sibling's associated type is actually constrained.
+protocol BaseProtocolUT {
+  associatedtype U
+  associatedtype T
+}
+
+protocol ProtocolGenericU<U>: BaseProtocolUT {}
+protocol ProtocolGenericT<T>: BaseProtocolUT {}
+protocol FullProtocol<U, T>: ProtocolGenericU, ProtocolGenericT {}
+
+struct SFull<U, T>: FullProtocol {}
+
+do {
+  let e0: any FullProtocol & ProtocolGenericU<Int> = SFull<Int, String>()
+  let e1: any (FullProtocol & ProtocolGenericU<Int>).Type = SFull<Int, String>.self
+  let e2: (any FullProtocol & ProtocolGenericU<Int>).Type =
+    (any FullProtocol & ProtocolGenericU<Int>).self
+
+  blackHole(e0, e1, e2)
+}
+
+// DEMANGLE: _$s24constrained_existentials12FullProtocol_pSi1UAA04BaseD2UTPRts_XPD
+// DEMANGLE: _$s24constrained_existentials12FullProtocol_pSi1UAA04BaseD2UTPRts_XPXmTD
+// DEMANGLE: _$s24constrained_existentials12FullProtocol_pSi1UAA04BaseD2UTPRts_XPXMtD
+
+// CHECK: any FullProtocol & ProtocolGenericU<Int>
+// CHECK: @thick any (FullProtocol & ProtocolGenericU<Int>).Type
+// CHECK: @thin (any FullProtocol & ProtocolGenericU<Int>).Type
+
+do {
+  let e0: any FullProtocol & ProtocolGenericT<String> = SFull<Int, String>()
+  let e1: any (FullProtocol & ProtocolGenericT<String>).Type = SFull<Int, String>.self
+  let e2: (any FullProtocol & ProtocolGenericT<String>).Type =
+    (any FullProtocol & ProtocolGenericT<String>).self
+
+  blackHole(e0, e1, e2)
+}
+
+// DEMANGLE: _$s24constrained_existentials12FullProtocol_pSS1TAA04BaseD2UTPRts_XPD
+// DEMANGLE: _$s24constrained_existentials12FullProtocol_pSS1TAA04BaseD2UTPRts_XPXmTD
+// DEMANGLE: _$s24constrained_existentials12FullProtocol_pSS1TAA04BaseD2UTPRts_XPXMtD
+
+// CHECK: any FullProtocol & ProtocolGenericT<String>
+// CHECK: @thick any (FullProtocol & ProtocolGenericT<String>).Type
+// CHECK: @thin (any FullProtocol & ProtocolGenericT<String>).Type
+
+// Multiple inherited protocols get canonicalized away at once; reconstruction
+// must recover all of them and re-add them in their original source order.
+protocol HopBase {
+  associatedtype Parent
+  associatedtype Successor
+  associatedtype Destination
+}
+
+protocol HopGenericParent<Parent>: HopBase {}
+protocol HopGenericSuccessor<Successor>: HopBase {}
+protocol HopGenericDestination<Destination>: HopBase {}
+protocol Hop<Parent, Successor>:
+  HopGenericParent, HopGenericSuccessor, HopGenericDestination {}
+
+struct SHop<Parent, Successor, Destination>: Hop {}
+
+do {
+  let e0: any Hop & HopGenericSuccessor<Int> & HopGenericDestination<String> =
+    SHop<Bool, Int, String>()
+  let e1: any (Hop & HopGenericSuccessor<Int> & HopGenericDestination<String>).Type =
+    SHop<Bool, Int, String>.self
+  let e2: (any Hop & HopGenericSuccessor<Int> & HopGenericDestination<String>).Type =
+    (any Hop & HopGenericSuccessor<Int> & HopGenericDestination<String>).self
+
+  blackHole(e0, e1, e2)
+}
+
+// DEMANGLE: _$s24constrained_existentials3Hop_pSS11DestinationAA0C4BasePRts_Si9SuccessorAERtsXPD
+// DEMANGLE: _$s24constrained_existentials3Hop_pSS11DestinationAA0C4BasePRts_Si9SuccessorAERtsXPXmTD
+// DEMANGLE: _$s24constrained_existentials3Hop_pSS11DestinationAA0C4BasePRts_Si9SuccessorAERtsXPXMtD
+
+// CHECK: any Hop & HopGenericSuccessor<Int> & HopGenericDestination<String>
+// CHECK: @thick any (Hop & HopGenericSuccessor<Int> & HopGenericDestination<String>).Type
+// CHECK: @thin (any Hop & HopGenericSuccessor<Int> & HopGenericDestination<String>).Type
+
+// The most-specific recoverable inherited protocol ("Full") needs both Root
+// and Value to parameterize, but only Root is actually constrained here, so
+// reconstruction must fall back to the less-specific "GenericRoot" instead.
+protocol TwoFieldBase {
+  associatedtype Root
+  associatedtype Value
+}
+
+protocol GenericRoot<Root>: TwoFieldBase {}
+protocol GenericValue<Value>: TwoFieldBase {}
+protocol Full<Root, Value>: GenericRoot, GenericValue {}
+protocol Writable<Root, Value>: Full {}
+
+struct SWritable<Root, Value>: Writable {}
+
+do {
+  let e0: any Writable & GenericRoot<Int> = SWritable<Int, String>()
+  let e1: any (Writable & GenericRoot<Int>).Type = SWritable<Int, String>.self
+  let e2: (any Writable & GenericRoot<Int>).Type = (any Writable & GenericRoot<Int>).self
+
+  blackHole(e0, e1, e2)
+}
+
+// DEMANGLE: _$s24constrained_existentials8Writable_pSi4RootAA12TwoFieldBasePRts_XPD
+// DEMANGLE: _$s24constrained_existentials8Writable_pSi4RootAA12TwoFieldBasePRts_XPXmTD
+// DEMANGLE: _$s24constrained_existentials8Writable_pSi4RootAA12TwoFieldBasePRts_XPXMtD
+
+// CHECK: any Writable & GenericRoot<Int>
+// CHECK: @thick any (Writable & GenericRoot<Int>).Type
+// CHECK: @thin (any Writable & GenericRoot<Int>).Type


### PR DESCRIPTION
- **Explanation**:
Fixes an assertion failure in `ASTDemangler::createConstrainedExistentialType()` when reconstructing constrained existential compositions where the mangled base canonicalized away an inherited protocol (e.g. `any Derived & Base<T>` with `Derived: Base`).

- **Scope**:
One function in `lib/AST/ASTDemangler.cpp`, plus a regression test. Only affects constrained existentials whose requirements are left unclaimed — no ABI, mangling, or semantic changes, and no codegen involvement.

- **Issues**:
https://github.com/swiftlang/swift/issues/87358

- **Original PRs**:
https://github.com/swiftlang/swift/pull/87949

- **Risk**:
Low. A path that previously asserted now reconstructs correctly; nothing that already worked changes. Worst case is a member ordering difference in reconstructed debug info, not miscompilation.

- **Testing**:
New `test/TypeDecoder/constrained_existentials.swift` cases assert the exact reconstructed types. I also cherrypicked this change onto a recent 6.4.x snapshot tag, built a variant of the 6.4.x-snapshot-2026-07-20 toolchain, and used that variant to verify the issue was resolved and didn't introduce additional issues in our suite of internal swift projects.

- **Reviewers**:
@slavapestov