### PR TITLE
Add sanitizer ignorelists from clang driver to ModuleDependencyScanner

### DIFF
--- a/include/swift/DependencyScan/ModuleDependencyScanner.h
+++ b/include/swift/DependencyScan/ModuleDependencyScanner.h
@@ -242,7 +242,8 @@ class SwiftDependencyTracker {
 public:
   SwiftDependencyTracker(std::shared_ptr<llvm::cas::ObjectStore> CAS,
                          llvm::PrefixMapper *Mapper,
-                         const CompilerInvocation &CI);
+                         const CompilerInvocation &CI,
+                         ArrayRef<std::string> ClangBlocklists = {});
   
   void startTracking(bool includeCommonDeps = true);
 
@@ -294,7 +295,7 @@ public:
     if (!CAS)
       return std::nullopt;
 
-    return SwiftDependencyTracker(CAS, PrefixMapper.get(), CI);
+    return SwiftDependencyTracker(CAS, PrefixMapper.get(), CI, ClangBlocklists);
   }
 
   /// PrefixMapper for scanner.
@@ -473,6 +474,11 @@ private:
   /// File prefix mapper.
   std::unique_ptr<llvm::PrefixMapper> PrefixMapper;
   std::unique_ptr<llvm::PrefixMapper> ReversePrefixMapping;
+  /// Paths of files referenced by the Clang cc1 command line that the driver
+  /// implicitly injected (e.g. `-fsanitize-ignorelist=...` added when a
+  /// sanitizer is enabled). These must be part of the CAS input tree for a
+  /// cached `-compile-module-from-interface` job to open them at replay time.
+  std::vector<std::string> ClangBlocklists;
   /// CAS file system for loading file content.
   llvm::IntrusiveRefCntPtr<llvm::cas::CASBackedFileSystem> CacheFS;
   /// Protect worker access.

--- a/include/swift/DependencyScan/ModuleDependencyScanner.h
+++ b/include/swift/DependencyScan/ModuleDependencyScanner.h
@@ -243,7 +243,7 @@ public:
   SwiftDependencyTracker(std::shared_ptr<llvm::cas::ObjectStore> CAS,
                          llvm::PrefixMapper *Mapper,
                          const CompilerInvocation &CI,
-                         ArrayRef<std::string> ClangBlocklists = {});
+                         ArrayRef<std::string> ExtraFiles = {});
   
   void startTracking(bool includeCommonDeps = true);
 

--- a/include/swift/DependencyScan/ModuleDependencyScanner.h
+++ b/include/swift/DependencyScan/ModuleDependencyScanner.h
@@ -291,12 +291,7 @@ public:
 
   /// CAS Dependency Tracker.
   std::optional<SwiftDependencyTracker>
-  createSwiftDependencyTracker(const CompilerInvocation &CI) {
-    if (!CAS)
-      return std::nullopt;
-
-    return SwiftDependencyTracker(CAS, PrefixMapper.get(), CI, ClangBlocklists);
-  }
+  createSwiftDependencyTracker(const CompilerInvocation &CI);
 
   /// PrefixMapper for scanner.
   bool hasPathMapping() const {
@@ -474,11 +469,6 @@ private:
   /// File prefix mapper.
   std::unique_ptr<llvm::PrefixMapper> PrefixMapper;
   std::unique_ptr<llvm::PrefixMapper> ReversePrefixMapping;
-  /// Paths of files referenced by the Clang cc1 command line that the driver
-  /// implicitly injected (e.g. `-fsanitize-ignorelist=...` added when a
-  /// sanitizer is enabled). These must be part of the CAS input tree for a
-  /// cached `-compile-module-from-interface` job to open them at replay time.
-  std::vector<std::string> ClangBlocklists;
   /// CAS file system for loading file content.
   llvm::IntrusiveRefCntPtr<llvm::cas::CASBackedFileSystem> CacheFS;
   /// Protect worker access.

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -457,7 +457,7 @@ ModuleDependencyScanner::getModuleImportIdentifier(StringRef moduleName) {
 
 SwiftDependencyTracker::SwiftDependencyTracker(
     std::shared_ptr<llvm::cas::ObjectStore> CAS, llvm::PrefixMapper *Mapper,
-    const CompilerInvocation &CI, ArrayRef<std::string> ClangBlocklists)
+    const CompilerInvocation &CI, ArrayRef<std::string> ExtraFiles)
     : CAS(CAS), Mapper(Mapper) {
   auto &SearchPathOpts = CI.getSearchPathOptions();
 
@@ -495,9 +495,10 @@ SwiftDependencyTracker::SwiftDependencyTracker(
   for (auto &File: CI.getFrontendOptions().BlocklistConfigFilePaths)
     addCommonFile(File);
 
-  // Add files referenced by the Clang cc1 command line that will be needed at
-  // replay time (e.g. sanitizer ignorelists auto-injected by the Clang driver).
-  for (auto &File : ClangBlocklists)
+  // Add extra files that are needed at replay time but are not otherwise
+  // named in the Swift invocation (e.g. sanitizer ignorelists auto-injected
+  // by the Clang driver).
+  for (auto &File : ExtraFiles)
     addCommonFile(File);
 
   // Add access notes.

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -23,6 +23,7 @@
 #include "swift/Basic/PrettyStackTrace.h"
 #include "swift/Basic/Statistic.h"
 #include "swift/ClangImporter/ClangImporter.h"
+#include "clang/Frontend/CompilerInstance.h"
 #include "swift/DependencyScan/ModuleDependencyScanner.h"
 #include "swift/Frontend/ModuleInterfaceLoader.h"
 #include "swift/Serialization/ScanningLoaders.h"
@@ -628,21 +629,6 @@ ModuleDependencyScanner::ModuleDependencyScanner(
     CacheFS = cast<llvm::cas::CASBackedFileSystem>(
         llvm::cas::createCASProvidingFileSystem(
             CAS, ScanASTContext.SourceMgr.getFileSystem()));
-
-  // Collect paths referenced by cc1 args that the Clang driver implicitly
-  // injects (e.g. sanitizer ignorelists for `-fsanitize=...`). These are not
-  // named anywhere in the Swift invocation but must still land in the CAS
-  // input tree for cached `-compile-module-from-interface` replay.
-  if (CAS && ScanASTContext.ClangImporterOpts.ClangImporterDirectCC1Scan) {
-    auto *clangImporter =
-        static_cast<ClangImporter *>(ScanASTContext.getClangModuleLoader());
-    for (const auto &Arg : clangImporter->getSwiftExplicitModuleDirectCC1Args()) {
-      StringRef Path = Arg;
-      if (Path.consume_front("-fsanitize-ignorelist=") ||
-          Path.consume_front("-fsanitize-system-ignorelist="))
-        ClangBlocklists.push_back(Path.str());
-    }
-  }
 
   // TODO: Make num threads configurable
   for (size_t i = 0; i < NumThreads; ++i)
@@ -2172,6 +2158,21 @@ std::string ModuleDependencyScanner::remapPath(StringRef Path) const {
   if (!PrefixMapper)
     return Path.str();
   return PrefixMapper->mapToString(Path);
+}
+
+std::optional<SwiftDependencyTracker>
+ModuleDependencyScanner::createSwiftDependencyTracker(
+    const CompilerInvocation &CI) {
+  if (!CAS)
+    return std::nullopt;
+
+  // Files referenced by cc1 args that the Clang driver implicitly injects
+  // (e.g. sanitizer ignorelists for `-fsanitize=...`) live on the parsed
+  // Clang invocation and must be added to the CAS input tree.
+  const auto &clangLangOpts =
+      ScanASTContext.getClangModuleLoader()->getClangInstance().getLangOpts();
+  return SwiftDependencyTracker(CAS, PrefixMapper.get(), CI,
+                                clangLangOpts.NoSanitizeFiles);
 }
 
 LibraryLevel swift::libraryLevelFromPath(StringRef modulePath,

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -456,7 +456,7 @@ ModuleDependencyScanner::getModuleImportIdentifier(StringRef moduleName) {
 
 SwiftDependencyTracker::SwiftDependencyTracker(
     std::shared_ptr<llvm::cas::ObjectStore> CAS, llvm::PrefixMapper *Mapper,
-    const CompilerInvocation &CI)
+    const CompilerInvocation &CI, ArrayRef<std::string> ClangBlocklists)
     : CAS(CAS), Mapper(Mapper) {
   auto &SearchPathOpts = CI.getSearchPathOptions();
 
@@ -492,6 +492,11 @@ SwiftDependencyTracker::SwiftDependencyTracker(
 
   // Add blocklist file.
   for (auto &File: CI.getFrontendOptions().BlocklistConfigFilePaths)
+    addCommonFile(File);
+
+  // Add files referenced by the Clang cc1 command line that will be needed at
+  // replay time (e.g. sanitizer ignorelists auto-injected by the Clang driver).
+  for (auto &File : ClangBlocklists)
     addCommonFile(File);
 
   // Add access notes.
@@ -623,6 +628,21 @@ ModuleDependencyScanner::ModuleDependencyScanner(
     CacheFS = cast<llvm::cas::CASBackedFileSystem>(
         llvm::cas::createCASProvidingFileSystem(
             CAS, ScanASTContext.SourceMgr.getFileSystem()));
+
+  // Collect paths referenced by cc1 args that the Clang driver implicitly
+  // injects (e.g. sanitizer ignorelists for `-fsanitize=...`). These are not
+  // named anywhere in the Swift invocation but must still land in the CAS
+  // input tree for cached `-compile-module-from-interface` replay.
+  if (CAS && ScanASTContext.ClangImporterOpts.ClangImporterDirectCC1Scan) {
+    auto *clangImporter =
+        static_cast<ClangImporter *>(ScanASTContext.getClangModuleLoader());
+    for (const auto &Arg : clangImporter->getSwiftExplicitModuleDirectCC1Args()) {
+      StringRef Path = Arg;
+      if (Path.consume_front("-fsanitize-ignorelist=") ||
+          Path.consume_front("-fsanitize-system-ignorelist="))
+        ClangBlocklists.push_back(Path.str());
+    }
+  }
 
   // TODO: Make num threads configurable
   for (size_t i = 0; i < NumThreads; ++i)

--- a/test/CAS/sanitize-ignorelist.swift
+++ b/test/CAS/sanitize-ignorelist.swift
@@ -1,0 +1,31 @@
+// Verify that the sanitizer ignorelist file that the Clang driver auto-injects
+// for `-sanitize=address` is included in the CAS input tree for a cached
+// `-compile-module-from-interface` job. Without this, replaying the cached
+// compile fails to open the ignorelist file.
+
+// REQUIRES: OS=macosx
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   -sanitize=address \
+// RUN:   -I %t/include \
+// RUN:   %t/main.swift -o %t/deps.json -cache-compile-job -cas-path %t/cas
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json A > %t/A.cmd
+// RUN: %FileCheck %s -check-prefix CMD -input-file=%t/A.cmd
+// CMD: -fsanitize-ignorelist={{.*}}asan_ignorelist.txt
+
+// RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json A casFSRootID > %t/A.casid
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-include-tree-list @%t/A.casid | %FileCheck %s --check-prefix=A-FS
+// A-FS: asan_ignorelist.txt
+
+//--- main.swift
+import A
+
+//--- include/A.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name A -O -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -user-module-version 1.0
+public func a() { }


### PR DESCRIPTION
Clang's dependency on the sanitizer ignorelists is not currently captured by the module dependency scanner. This causes issues when CAS is enabled, as these files will be missing from the virtual CAS filesystem.

Assisted-by: Claude

rdar://175696080