### PR TITLE
Sema: classify COM interface references

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4471,22 +4471,26 @@ private:
   Kind DeclKind;
   StringRef ID;
   std::optional<COMThreadingModel> ThreadingModel;
+  ProtocolDecl *RootInterface;
   ArrayRef<ProtocolDecl *> Interfaces;
+  ArrayRef<ProtocolDecl *> Slots;
 
   COMDeclInfo(Kind kind, StringRef id, std::optional<COMThreadingModel> model,
-              ArrayRef<ProtocolDecl *> interfaces)
-      : DeclKind(kind), ID(id), ThreadingModel(model), Interfaces(interfaces) {}
+              ProtocolDecl *root, ArrayRef<ProtocolDecl *> interfaces,
+              ArrayRef<ProtocolDecl *> slots)
+      : DeclKind(kind), ID(id), ThreadingModel(model), RootInterface(root),
+        Interfaces(interfaces), Slots(slots) {}
 
 public:
   static COMDeclInfo forInterface(StringRef iid) {
-    return {Kind::Interface, iid, std::nullopt, {}};
+    return {Kind::Interface, iid, std::nullopt, nullptr, {}, {}};
   }
 
   static COMDeclInfo
-  forImplementation(StringRef clsid,
-                    std::optional<COMThreadingModel> threadingModel,
-                    ArrayRef<ProtocolDecl *> interfaces) {
-    return {Kind::Implementation, clsid, threadingModel, interfaces};
+  forImplementation(StringRef clsid, std::optional<COMThreadingModel> model,
+                    ProtocolDecl *root, ArrayRef<ProtocolDecl *> interfaces,
+                    ArrayRef<ProtocolDecl *> slots) {
+    return {Kind::Implementation, clsid, model, root, interfaces, slots};
   }
 
   Kind getKind() const { return DeclKind; }
@@ -4515,10 +4519,28 @@ public:
     return ThreadingModel;
   }
 
+  ProtocolDecl *getRootInterface() const {
+    assert(isImplementation());
+    return RootInterface;
+  }
+
   /// The COM interfaces to which this implementation conforms.
   ArrayRef<ProtocolDecl *> getInterfaces() const {
     assert(isImplementation());
     return Interfaces;
+  }
+
+  /// The elements defining the maximal set for the implementation's COM
+  /// refinement order.
+  ///
+  /// The compiler-managed \c ISwiftObject interface is first. It is followed by
+  /// the maximal user interface from each independent refinement chain; their
+  /// ABI-base closures cover every supported interface. Subclasses preserve
+  /// inherited positions, replacing an entry only when they add a more-derived
+  /// interface in the same chain.
+  ArrayRef<ProtocolDecl *> getInterfaceSlots() const {
+    assert(isImplementation());
+    return Slots;
   }
 };
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2259,6 +2259,37 @@ ERROR(com_interface_refinement_requires_identity, none,
 ERROR(com_interface_repeated_iid, none,
       "COM interface %0 and inherited interface %1 use the same interface "
       "identifier '%2'", (DeclName, DeclName, StringRef))
+ERROR(com_cominterface_existential, none,
+      "'any COMInterface' is invalid because 'COMInterface' does not identify a COM interface",
+      ())
+ERROR(com_existential_multiple_interfaces, none,
+      "COM existential cannot contain interfaces %0 and %1 because neither refines the other",
+      (DeclName, DeclName))
+ERROR(com_existential_non_marker_protocol, none,
+      "COM existential containing interface %0 cannot also contain non-marker protocol %1",
+      (DeclName, DeclName))
+ERROR(com_existential_anyobject, none,
+      "COM existential containing interface %0 cannot also contain 'AnyObject'",
+      (DeclName))
+ERROR(com_existential_superclass, none,
+      "COM existential containing interface %0 cannot also contain class constraint %1",
+      (DeclName, Type))
+ERROR(com_conformance_requires_class, none,
+      "non-class type %0 cannot conform to COM interface %1", (Type, Type))
+ERROR(com_conformance_must_be_in_type_module, none,
+      "conformance of %0 to COM interface %1 must be declared in the same module as %0",
+      (Type, Type))
+ERROR(com_conditional_conformance, none,
+      "conditional conformance of %0 to COM interface %1 is not supported",
+      (Type, Type))
+ERROR(com_actor_implementation, none,
+      "actor %0 cannot provide a COM implementation", (DeclName))
+ERROR(com_non_native_implementation, none,
+      "class %0 cannot provide a COM implementation because it does not use the native Swift object model",
+      (DeclName))
+ERROR(com_generic_activatable_implementation, none,
+      "generic class %0 cannot declare a COM implementation identifier",
+      (DeclName))
 
 ERROR(metatype_extension_com_only, none,
       "protocol metatype extensions are reserved for COM interop", ())

--- a/include/swift/AST/ExistentialLayout.h
+++ b/include/swift/AST/ExistentialLayout.h
@@ -30,6 +30,23 @@ namespace swift {
   class ProtocolType;
   class ProtocolCompositionType;
 
+struct COMExistentialInterfaceResolution {
+  ProtocolDecl *interface = nullptr;
+
+  /// The first interface incomparable with \c interface in canonical order.
+  ///
+  /// Two interfaces are incomparable when neither refines the other and
+  /// therefore require distinct physical interface pointers.
+  ProtocolDecl *firstIncomparableInterface = nullptr;
+
+  /// The first non-marker Swift protocol, retained for diagnostics.
+  ProtocolDecl *firstNonMarkerProtocol = nullptr;
+
+  /// Whether the composition contains the compiler-managed \c COMInterface
+  /// protocol itself.
+  bool containsCOMInterfaceProtocol = false;
+};
+
 struct ExistentialLayout {
   enum Kind { Class, Error, Opaque };
 
@@ -105,6 +122,13 @@ struct ExistentialLayout {
   /// Does this existential consist of an Error protocol only with no other
   /// constraints?
   bool isErrorExistential() const;
+
+  /// Resolve the most-dervied COM interface and any protocols that prevent this
+  /// existential layout from representing a single COM interface.
+  COMExistentialInterfaceResolution resolveCOMInterface() const;
+
+  /// Retrieve the single COM interface represented by a valid layout.
+  ProtocolDecl *getCOMInterface() const;
 
   ArrayRef<ProtocolDecl*> getProtocols() const & {
     return protocols;

--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -160,6 +160,7 @@ CXX_PROTOCOL(UnsafeCxxMutableContiguousIterator)
 // COM Protocols
 COM_PROTOCOL(IUnknown)
 COM_PROTOCOL(ISwiftObject)
+COM_PROTOCOL(COMInterface)
 
 PROTOCOL(AsyncSequence)
 PROTOCOL(AsyncIteratorProtocol)

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3070,11 +3070,12 @@ public:
   bool isCached() const { return true; }
 };
 
-/// Synthesizes the \c static \c var \c CLSID member on a \c @com class.  The
-/// GUID is read from the class's own \c COMAttr.
-class SynthesizeCOMImplementationIDRequest
-    : public SimpleRequest<SynthesizeCOMImplementationIDRequest,
-                           VarDecl *(ClassDecl *),
+/// Synthesizes the Microsoft COM model's \c static \c var \c CLSID member on a
+/// \c @com class. The GUID is read from the class's own \c COMAttr. Rootless
+/// models retian the implementation identity without introducing this
+/// Microsoft-specific API.
+class SynthesizeCOMCLSIDRequest
+    : public SimpleRequest<SynthesizeCOMCLSIDRequest, VarDecl *(ClassDecl *),
                            RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -460,7 +460,7 @@ SWIFT_REQUEST(TypeChecker, SynthesizeDefaultInitRequest,
               ConstructorDecl *(NominalTypeDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, SynthesizeCOMInterfaceIDRequest,
               VarDecl *(ProtocolDecl *), Cached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, SynthesizeCOMImplementationIDRequest,
+SWIFT_REQUEST(TypeChecker, SynthesizeCOMCLSIDRequest,
               VarDecl *(ClassDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, TypeCheckPrimaryFileRequest,
               bool(SouceFile *), SeparatelyCached, NoLocationInfo)

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -339,7 +339,7 @@ namespace swift {
     /// may override it. `ISwiftObject` is compiler-managed under every model.
     enum class COMInteropModel {
       Microsoft,      ///< Microsoft COM: `IUnknown` root.
-      CoreFoundation, ///< CoreFoundation CFPlugIn: `IUnknown` root.
+      CoreFoundation, ///< CoreFoundation CFPlugIn: no protocol root.
     };
     std::optional<COMInteropModel> COMModel = std::nullopt;
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1576,6 +1576,7 @@ ProtocolDecl *ASTContext::getProtocol(KnownProtocolKind kind) const {
     break;
   case KnownProtocolKind::IUnknown:
   case KnownProtocolKind::ISwiftObject:
+  case KnownProtocolKind::COMInterface:
     M = getLoadedModule(Id_COM);
     if (!M)
       M = MainModule;

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2254,8 +2254,7 @@ static void populateMembersForLazyName(DeclName name, NominalTypeDecl *decl,
     } else if (auto *CD = dyn_cast<ClassDecl>(decl)) {
       if (name.isSimpleName(ctx.Id_CLSID) &&
           CD->isCOMImplementation() && CD->isInSwiftSourceFile()) {
-        evaluateOrDefault(ctx.evaluator,
-                          SynthesizeCOMImplementationIDRequest{CD}, nullptr);
+        evaluateOrDefault(ctx.evaluator, SynthesizeCOMCLSIDRequest{CD}, nullptr);
       }
     }
   }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -426,6 +426,54 @@ bool ExistentialLayout::requiresClass() const {
   return false;
 }
 
+COMExistentialInterfaceResolution
+ExistentialLayout::resolveCOMInterface() const {
+  COMExistentialInterfaceResolution resolution;
+
+  for (ProtocolDecl *protocol : getProtocols()) {
+    if (protocol->isSpecificProtocol(KnownProtocolKind::COMInterface)) {
+      resolution.containsCOMInterfaceProtocol = true;
+      continue;
+    }
+
+    if (!protocol->isCOMInterface()) {
+      if (!protocol->isMarkerProtocol())
+        if (!resolution.firstNonMarkerProtocol)
+          resolution.firstNonMarkerProtocol = protocol;
+      continue;
+    }
+
+    auto *hierarchy = protocol->getCOMInterfaceHierarchy();
+    if (!hierarchy || hierarchy->isInvalid())
+      continue;
+
+    if (!resolution.interface) {
+      resolution.interface = protocol;
+      continue;
+    }
+
+    if (resolution.interface->inheritsFrom(protocol)) {
+      resolution.interface = protocol;
+      continue;
+    }
+
+    if (!resolution.firstIncomparableInterface)
+      resolution.firstIncomparableInterface = protocol;
+  }
+
+  return resolution;
+}
+
+ProtocolDecl *ExistentialLayout::getCOMInterface() const {
+  COMExistentialInterfaceResolution result = resolveCOMInterface();
+  if (hasExplicitAnyObject || explicitSuperclass ||
+      result.containsCOMInterfaceProtocol ||
+      result.firstIncomparableInterface ||
+      result.firstNonMarkerProtocol)
+    return nullptr;
+  return result.interface;
+}
+
 Type ExistentialLayout::getExplicitSuperclassOrProtocolSuperclass() const {
   if (explicitSuperclass)
     return explicitSuperclass;

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -7701,6 +7701,7 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
   case KnownProtocolKind::ConvertibleFromBytes:
   case KnownProtocolKind::IUnknown:
   case KnownProtocolKind::ISwiftObject:
+  case KnownProtocolKind::COMInterface:
     return SpecialProtocol::None;
   }
 

--- a/lib/Sema/TypeCheckCOM.cpp
+++ b/lib/Sema/TypeCheckCOM.cpp
@@ -548,8 +548,8 @@ VarDecl *SynthesizeCOMInterfaceIDRequest::evaluate(Evaluator &evaluator,
   return ::com::synthesizeIIDProperty(PD, ASTContext, info->getInterfaceID());
 }
 
-VarDecl *SynthesizeCOMImplementationIDRequest::evaluate(Evaluator &evaluator,
-                                                        ClassDecl *CD) const {
+VarDecl *SynthesizeCOMCLSIDRequest::evaluate(Evaluator &evaluator,
+                                             ClassDecl *CD) const {
   auto &ASTContext = CD->getASTContext();
   auto *info = CD->getCOMDeclInfo();
   if (!info)

--- a/lib/Sema/TypeCheckCOM.cpp
+++ b/lib/Sema/TypeCheckCOM.cpp
@@ -50,8 +50,9 @@ getRootProtocol(std::optional<LangOptions::COMInteropModel> model) {
 
   switch (*model) {
   case LangOptions::COMInteropModel::Microsoft:
-  case LangOptions::COMInteropModel::CoreFoundation:
     return KnownProtocolKind::IUnknown;
+  case LangOptions::COMInteropModel::CoreFoundation:
+    return std::nullopt;
   }
   llvm_unreachable("unhandled COMInteropModel");
 }
@@ -551,6 +552,13 @@ VarDecl *SynthesizeCOMInterfaceIDRequest::evaluate(Evaluator &evaluator,
 VarDecl *SynthesizeCOMCLSIDRequest::evaluate(Evaluator &evaluator,
                                              ClassDecl *CD) const {
   auto &ASTContext = CD->getASTContext();
+
+  // CLSID is the Microsoft model's spelling and activation surface. Other
+  // models may consume the implementation UUID through their own policy, but
+  // must not acquire a synthetic Microsoft-named member.
+  if (ASTContext.LangOpts.COMModel != LangOptions::COMInteropModel::Microsoft)
+    return nullptr;
+
   auto *info = CD->getCOMDeclInfo();
   if (!info)
     return nullptr;

--- a/lib/Sema/TypeCheckCOM.cpp
+++ b/lib/Sema/TypeCheckCOM.cpp
@@ -336,15 +336,66 @@ COMDeclInfoRequest::evaluate(Evaluator &evaluator,
 
     return ctx.AllocateObjectCopy(COMDeclInfo::forInterface(attr->IID));
   } else if (auto *CD = dyn_cast<ClassDecl>(nominal)) {
+    ProtocolDecl *root = nullptr;
+    if (auto interface = ::com::getRootProtocol(ctx.LangOpts.COMModel))
+      root = ctx.getProtocol(*interface);
+
     SmallVector<ProtocolDecl *, 2> interfaces;
     for (auto *proto : CD->getAllProtocols(/*sorted=*/true)) {
-      if (proto->isCOMInterface())
+      if (proto->isCOMInterface() && proto != root &&
+          !proto->isSpecificProtocol(KnownProtocolKind::ISwiftObject))
         interfaces.push_back(proto);
     }
 
+    const COMDeclInfo *superInfo = nullptr;
+    if (auto *superclass = CD->getSuperclassDecl()) {
+      auto *info = superclass->getCOMDeclInfo();
+      if (info && info->isImplementation())
+        superInfo = info;
+    }
+
     auto *attr = ::com::getAttribute(CD);
-    if (!attr && interfaces.empty())
+    if (!attr && interfaces.empty() && !superInfo)
       return nullptr;
+
+    SmallVector<ProtocolDecl *, 2> antichain;
+    if (superInfo) {
+      llvm::append_range(antichain, superInfo->getInterfaceSlots());
+    } else {
+      // Keep the compiler-managed Swift identity interface at the stable
+      // position closest to the Swift heap-object address point.
+      ProtocolDecl *ISO = ctx.getProtocol(KnownProtocolKind::ISwiftObject);
+      ASSERT(ISO);
+      antichain.push_back(ISO);
+    }
+
+    // Preserve every superclass interface position. A more-derived interface
+    // in an existing refinement chain replaces that position; a new
+    // independent chain is appended. This keeps an interface value formed from
+    // a statically typed superclass reference valid for every subclass
+    // instance.
+    for (ProtocolDecl *interface : interfaces) {
+      if (llvm::any_of(interfaces, [&](const ProtocolDecl *PD) {
+                        return PD != interface && PD->inheritsFrom(interface);
+                       }))
+          continue;
+
+      bool inserted = false;
+      for (auto &PD : drop_begin(antichain)) {
+        if (interface == PD || PD->inheritsFrom(interface)) {
+          inserted = true;
+          break;
+        }
+        if (interface->inheritsFrom(PD)) {
+          PD = interface;
+          inserted = true;
+          break;
+        }
+      }
+
+      if (!inserted)
+        antichain.push_back(interface);
+    }
 
     StringRef implementationID;
     std::optional<COMThreadingModel> threadingModel;
@@ -355,7 +406,8 @@ COMDeclInfoRequest::evaluate(Evaluator &evaluator,
     }
 
     return ctx.AllocateObjectCopy(COMDeclInfo::forImplementation(
-        implementationID, threadingModel, ctx.AllocateCopy(interfaces)));
+        implementationID, threadingModel, root, ctx.AllocateCopy(interfaces),
+        ctx.AllocateCopy(antichain)));
   }
 
   return nullptr;
@@ -383,6 +435,7 @@ COMInterfaceHierarchyRequest::evaluate(Evaluator &evaluator,
                              /*isSuppressed=*/false);
     }
   } else {
+    // Class constraints do not participate in the COM interface hierarchy.
     bool ignoredAnyObject = false;
     InvertibleProtocolSet inverses;
     inherited = getDirectlyInheritedNominalTypeDecls(protocol, inverses,
@@ -483,13 +536,65 @@ COMInterfaceHierarchyRequest::evaluate(Evaluator &evaluator,
       COMInterfaceHierarchy(C.AllocateCopy(markers), C.AllocateCopy(chain)));
 }
 
+void com::validateImplementation(ClassDecl *CD) {
+  auto *info = CD->getCOMDeclInfo();
+  if (!info)
+    return;
+
+  if (CD->isActor())
+    CD->diagnose(diag::com_actor_implementation, CD->getName());
+
+  if (CD->getObjectModel() != ReferenceCounting::Native)
+    CD->diagnose(diag::com_non_native_implementation, CD->getName());
+
+  if (CD->isGenericContext() && info->getImplementationID())
+    CD->diagnose(diag::com_generic_activatable_implementation, CD->getName());
+}
+
+void com::validateConformance(ProtocolConformance *conformance) {
+  auto *normal = dyn_cast<NormalProtocolConformance>(conformance);
+  if (!normal ||
+      normal->getSourceKind() != ConformanceEntryKind::Explicit)
+    return;
+
+  auto *protocol = normal->getProtocol();
+  if (!protocol->isCOMInterface())
+    return;
+
+  Type type = normal->getType();
+  auto *nominal = type->getAnyNominal();
+  auto *CD = dyn_cast_or_null<ClassDecl>(nominal);
+  auto &context = normal->getDeclContext()->getASTContext();
+  if (!CD) {
+    context.Diags.diagnose(normal->getLoc(),
+                           diag::com_conformance_requires_class, type,
+                           protocol->getDeclaredInterfaceType());
+    return;
+  }
+
+  auto *typeModule = CD->getParentModule();
+  auto *conformanceModule = normal->getDeclContext()->getParentModule();
+  if (!typeModule->isSameModuleLookingThroughOverlays(conformanceModule)) {
+    context.Diags.diagnose(normal->getLoc(),
+                           diag::com_conformance_must_be_in_type_module, type,
+                           protocol->getDeclaredInterfaceType());
+  }
+
+  if (!normal->getConditionalRequirements().empty()) {
+    context.Diags.diagnose(normal->getLoc(),
+                           diag::com_conditional_conformance, type,
+                           protocol->getDeclaredInterfaceType());
+  }
+}
+
 ProtocolConformance *
 com::deriveImplicitConformance(NominalTypeDecl *NTD, KnownProtocolKind KP) {
   const auto *CD = dyn_cast<ClassDecl>(NTD);
   if (CD == nullptr)
     return nullptr;
 
-  if (!::com::getAttribute(CD))
+  auto *info = CD->getCOMDeclInfo();
+  if (!info || !info->isImplementation())
     return nullptr;
 
   ASTContext &context = NTD->getASTContext();

--- a/lib/Sema/TypeCheckCOM.h
+++ b/lib/Sema/TypeCheckCOM.h
@@ -16,6 +16,7 @@
 #include <cstdint>
 
 namespace swift {
+class ClassDecl;
 class NominalTypeDecl;
 class ProtocolConformance;
 enum class KnownProtocolKind : uint8_t;
@@ -25,6 +26,12 @@ namespace com {
 /// is valid to do so.
 ProtocolConformance *
 deriveImplicitConformance(NominalTypeDecl *NTD, KnownProtocolKind KP);
+
+/// Diagnose declaration-level restrictions on a native COM implementation.
+void validateImplementation(ClassDecl *CD);
+
+/// Diagnose restrictions on an explicitly declared COM conformance.
+void validateConformance(ProtocolConformance *conformance);
 }
 } // end namespace swift
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2967,10 +2967,13 @@ static ArrayRef<Decl *> evaluateMembersRequest(
     (void)nominal->getDistributedActorSystemProperty();
   }
 
-  // Synthesize the COM identity members -- a @com class's CLSID, a @com
-  // protocol's IID -- so they are always present in getAllMembers/getABIMembers
-  // for vtable emission, code completion, and ABI, not only when name lookup
-  // forces them.  For imported types the request finds the deserialized member.
+  // Synthesize the COM identity members:
+  //  - a @com protocol's IID
+  //  - under Microsoft's model, a @com class's CLSID
+  //
+  // so they are always present in getAllMembers/getABIMembers for vtable
+  // emission, code completion, and ABI, not only when name lookup forces them.
+  // For imported types the request finds the deserialized member.
   if (ctx.LangOpts.EnableCOMInterop) {
     if (auto *PD = dyn_cast_or_null<ProtocolDecl>(nominal)) {
       if (PD->isCOMInterface())

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2978,8 +2978,8 @@ static ArrayRef<Decl *> evaluateMembersRequest(
                                 SynthesizeCOMInterfaceIDRequest{PD}, nullptr);
     } else if (auto *CD = dyn_cast_or_null<ClassDecl>(nominal)) {
       if (CD->isCOMImplementation())
-        (void)evaluateOrDefault(ctx.evaluator,
-                                SynthesizeCOMImplementationIDRequest{CD}, nullptr);
+        (void)evaluateOrDefault(ctx.evaluator, SynthesizeCOMCLSIDRequest{CD},
+                                nullptr);
     }
   }
 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -21,6 +21,7 @@
 #include "MiscDiagnostics.h"
 #include "TypeCheckAccess.h"
 #include "TypeCheckAvailability.h"
+#include "TypeCheckCOM.h"
 #include "TypeCheckConcurrency.h"
 #include "TypeCheckDecl.h"
 #include "TypeCheckEmbedded.h"
@@ -3583,6 +3584,8 @@ public:
     }
 
     checkInheritanceClause(CD);
+    if (Ctx.LangOpts.EnableCOMInterop)
+      com::validateImplementation(CD);
     diagnoseMissingExplicitSendable(CD);
 
     checkAccessControl(CD);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -22,6 +22,7 @@
 #include "TypeCheckAccess.h"
 #include "TypeCheckAvailability.h"
 #include "TypeCheckBitwise.h"
+#include "TypeCheckCOM.h"
 #include "TypeCheckConcurrency.h"
 #include "TypeCheckDistributed.h"
 #include "TypeCheckEffects.h"
@@ -6889,6 +6890,9 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
   bool hasDeprecatedUnsafeSendable = false;
   bool sendableConformancePreconcurrency = false;
   for (auto conformance : conformances) {
+    if (Context.LangOpts.EnableCOMInterop)
+      com::validateConformance(conformance);
+
     // Check and record normal conformances.
     if (auto normal = dyn_cast<NormalProtocolConformance>(conformance)) {
       groupChecker.addConformance(normal);

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -727,6 +727,8 @@ private:
                                    TypeResolutionOptions options);
   NeverNullType resolveTupleType(TupleTypeRepr *repr,
                                  TypeResolutionOptions options);
+  NeverNullType validateCOMExistential(Type constraintType, TypeRepr *repr,
+                                       TypeResolutionOptions options);
   NeverNullType resolveCompositionType(CompositionTypeRepr *repr,
                                        TypeResolutionOptions options);
   NeverNullType resolveExistentialType(ExistentialTypeRepr *repr,
@@ -5623,6 +5625,9 @@ TypeResolver::resolveDeclRefTypeRepr(DeclRefTypeRepr *repr,
 
   if (result->isConstraintType() &&
       options.isConstraintImplicitExistential()) {
+    result = validateCOMExistential(result, repr, options);
+    if (result->hasError())
+      return result;
     return ExistentialType::get(result);
   }
 
@@ -6555,6 +6560,53 @@ NeverNullType TypeResolver::resolveTupleType(TupleTypeRepr *repr,
 }
 
 NeverNullType
+TypeResolver::validateCOMExistential(Type constraintType, TypeRepr *repr,
+                                     TypeResolutionOptions options) {
+  auto &ctx = getASTContext();
+  if (!ctx.LangOpts.EnableCOMInterop ||
+      options.contains(TypeResolutionFlags::SilenceDiagnostics))
+    return constraintType;
+
+  if (auto existential = constraintType->getAs<ExistentialType>())
+    constraintType = existential->getConstraintType();
+  if (!constraintType->isConstraintType())
+    return constraintType;
+
+  auto layout = constraintType->getExistentialLayout();
+  auto resolution = layout.resolveCOMInterface();
+  if (resolution.containsCOMInterfaceProtocol) {
+    diagnose(repr->getLoc(), diag::com_cominterface_existential);
+    repr->setInvalid();
+    return ErrorType::get(ctx);
+  }
+
+  auto *interface = resolution.interface;
+  if (!interface)
+    return constraintType;
+
+  if (resolution.firstIncomparableInterface) {
+    diagnose(repr->getLoc(), diag::com_existential_multiple_interfaces,
+             interface->getName(),
+             resolution.firstIncomparableInterface->getName());
+  } else if (resolution.firstNonMarkerProtocol) {
+    diagnose(repr->getLoc(), diag::com_existential_non_marker_protocol,
+             interface->getName(),
+             resolution.firstNonMarkerProtocol->getName());
+  } else if (layout.hasExplicitAnyObject) {
+    diagnose(repr->getLoc(), diag::com_existential_anyobject,
+             interface->getName());
+  } else if (layout.explicitSuperclass) {
+    diagnose(repr->getLoc(), diag::com_existential_superclass,
+             interface->getName(), layout.explicitSuperclass);
+  } else {
+    return constraintType;
+  }
+
+  repr->setInvalid();
+  return ErrorType::get(ctx);
+}
+
+NeverNullType
 TypeResolver::resolveCompositionType(CompositionTypeRepr *repr,
                                      TypeResolutionOptions options) {
 
@@ -6693,6 +6745,9 @@ TypeResolver::resolveCompositionType(CompositionTypeRepr *repr,
   }
 
   if (options.isConstraintImplicitExistential()) {
+    composition = validateCOMExistential(composition, repr, options);
+    if (composition->hasError())
+      return composition;
     return ExistentialType::get(composition);
   }
 
@@ -6712,6 +6767,9 @@ TypeResolver::resolveExistentialType(ExistentialTypeRepr *repr,
     return ErrorType::get(getASTContext());
 
   if (constraintType->isConstraintType()) {
+    constraintType = validateCOMExistential(constraintType, repr, options);
+    if (constraintType->hasError())
+      return constraintType;
     return ExistentialType::get(constraintType);
   }
 

--- a/test/Inputs/COM.swift
+++ b/test/Inputs/COM.swift
@@ -1,3 +1,4 @@
+
 public struct GUID {
   public var data1: UInt32
   public var data2: UInt16
@@ -20,4 +21,11 @@ public typealias CLSID = GUID
 public protocol IUnknown: AnyObject { }
 
 @com(interface: "8e369447-5188-5ada-b9ec-8fcb732d226b")
-public protocol ISwiftObject: AnyObject { }
+public protocol ISwiftObject {
+  var object: UnsafeMutableRawPointer { get }
+  var metadata: UnsafeRawPointer { get }
+}
+
+public protocol COMInterface {
+  var IID: IID { get }
+}

--- a/test/Interpreter/com_identity.swift
+++ b/test/Interpreter/com_identity.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/%target-library-name(COM)) -emit-module-path %t/COM.swiftmodule -module-name COM -Xfrontend -enable-experimental-com-interop %S/../Inputs/COM.swift
-// RUN: %target-build-swift-dylib(%t/%target-library-name(Widget)) -emit-module-path %t/Widget.swiftmodule -module-name Widget -Xfrontend -enable-experimental-com-interop -I %t -L %t -lCOM %target-rpath(%t) %S/Inputs/com_widget.swift
-// RUN: %target-build-swift %s -o %t/a.out -module-name main -Xfrontend -enable-experimental-com-interop -I %t -L %t -lCOM -lWidget %target-rpath(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(COM)) -emit-module-path %t/COM.swiftmodule -module-name COM -Xfrontend -enable-experimental-com-interop -Xfrontend -com-interop-model=microsoft %S/../Inputs/COM.swift
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Widget)) -emit-module-path %t/Widget.swiftmodule -module-name Widget -Xfrontend -enable-experimental-com-interop -Xfrontend -com-interop-model=microsoft -I %t -L %t -lCOM %target-rpath(%t) %S/Inputs/com_widget.swift
+// RUN: %target-build-swift %s -o %t/a.out -module-name main -Xfrontend -enable-experimental-com-interop -Xfrontend -com-interop-model=microsoft -I %t -L %t -lCOM -lWidget %target-rpath(%t)
 // RUN: %target-codesign %t/a.out %t/%target-library-name(COM) %t/%target-library-name(Widget)
 // RUN: %target-run %t/a.out %t/%target-library-name(COM) %t/%target-library-name(Widget) | %FileCheck %s
 // REQUIRES: executable_test

--- a/test/Sema/COM-GUID-cross-module.swift
+++ b/test/Sema/COM-GUID-cross-module.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module-path %t/COM.swiftmodule -module-name COM -enable-experimental-com-interop %S/../Inputs/COM.swift
+// RUN: %target-swift-frontend -emit-module-path %t/COM.swiftmodule -module-name COM -enable-experimental-com-interop -com-interop-model=microsoft %S/../Inputs/COM.swift
 
 // Build module A (importing COM) which defines the `@com` interface IWidget:
-// RUN: %target-swift-frontend -emit-module-path %t/A.swiftmodule -module-name A -enable-experimental-com-interop -I %t %S/Inputs/com_iwidget_moduleA.swift
+// RUN: %target-swift-frontend -emit-module-path %t/A.swiftmodule -module-name A -enable-experimental-com-interop -com-interop-model=microsoft -I %t %S/Inputs/com_iwidget_moduleA.swift
 
 // Client: import A and use `IWidget.IID`, proving the IID is re-derived in the
 // importer from the deserialized `@com` attribute.

--- a/test/Sema/COM-GUID-synthesis.swift
+++ b/test/Sema/COM-GUID-synthesis.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module-path %t/COM.swiftmodule -module-name COM -enable-experimental-com-interop %S/../Inputs/COM.swift
-// RUN: %target-typecheck-verify-swift -enable-experimental-com-interop -I %t
+// RUN: %target-swift-frontend -emit-module-path %t/COM.swiftmodule -module-name COM -enable-experimental-com-interop -com-interop-model=microsoft %S/../Inputs/COM.swift
+// RUN: %target-typecheck-verify-swift -enable-experimental-com-interop -com-interop-model=microsoft -I %t
 
 import COM
 

--- a/test/Sema/COM-ISwiftObject.swift
+++ b/test/Sema/COM-ISwiftObject.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module-path %t/COM.swiftmodule -module-name COM -enable-experimental-com-interop %S/../Inputs/COM.swift
-// RUN: %target-typecheck-verify-swift -enable-experimental-com-interop -I %t
+// RUN: %target-swift-frontend -emit-module-path %t/COM.swiftmodule -module-name COM -enable-experimental-com-interop -com-interop-model=microsoft %S/../Inputs/COM.swift
+// RUN: %target-typecheck-verify-swift -enable-experimental-com-interop -com-interop-model=microsoft -I %t
 
 import COM
 

--- a/test/Sema/COM-ISwiftObject.swift
+++ b/test/Sema/COM-ISwiftObject.swift
@@ -7,14 +7,18 @@ import COM
 // expected-note@+1 {{'@com' automatically provides 'ISwiftObject' conformance}}
 @com
 class CClass1: ISwiftObject {
+  var object: UnsafeMutableRawPointer { fatalError() }
+  var metadata: UnsafeRawPointer { fatalError() }
 }
-// expected-error@-2 {{'ISwiftObject' conformance is compiler-managed and cannot be declared explicitly}}
+// expected-error@-4 {{'ISwiftObject' conformance is compiler-managed and cannot be declared explicitly}}
 
 // expected-note@+1 {{'@com' automatically provides 'ISwiftObject' conformance}}
 @com(implementation: "00000000-0000-0000-0000-000000000000")
 class CClass2: ISwiftObject {
+  var object: UnsafeMutableRawPointer { fatalError() }
+  var metadata: UnsafeRawPointer { fatalError() }
 }
-// expected-error@-2 {{'ISwiftObject' conformance is compiler-managed and cannot be declared explicitly}}
+// expected-error@-4 {{'ISwiftObject' conformance is compiler-managed and cannot be declared explicitly}}
 
 @com
 class CClass3 {
@@ -25,4 +29,6 @@ class CClass4: IUnknown {
 }
 
 class CClass5: ISwiftObject {
+  var object: UnsafeMutableRawPointer { fatalError() }
+  var metadata: UnsafeRawPointer { fatalError() }
 }

--- a/test/Sema/COM-import-required.swift
+++ b/test/Sema/COM-import-required.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module-path %t/COM.swiftmodule -module-name COM -enable-experimental-com-interop %S/../Inputs/COM.swift
-// RUN: %target-swift-frontend -typecheck -verify -enable-experimental-com-interop -disable-implicit-com-module-import -I %t -primary-file %s %S/Inputs/com_importer.swift
+// RUN: %target-swift-frontend -emit-module-path %t/COM.swiftmodule -module-name COM -enable-experimental-com-interop -com-interop-model=microsoft %S/../Inputs/COM.swift
+// RUN: %target-swift-frontend -typecheck -verify -enable-experimental-com-interop -com-interop-model=microsoft -disable-implicit-com-module-import -I %t -primary-file %s %S/Inputs/com_importer.swift
 
 // `@com` ID synthesis references the COM module's `CLSID`/`IID` types, so it
 // must require that COM is imported by *this* file -- not merely loaded because

--- a/test/Sema/COMSynthesis.swift
+++ b/test/Sema/COMSynthesis.swift
@@ -18,8 +18,12 @@ class CClass1 {
 func com<COMType: IUnknown>(_ interface: COMType) {
 }
 
+func swift<COMType: ISwiftObject>(_ interface: COMType) {
+}
+
 func implicit(_ object: CClass1) {
   com(object)
+  swift(object)
 }
 
 @com

--- a/test/Sema/COMSynthesis.swift
+++ b/test/Sema/COMSynthesis.swift
@@ -1,10 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module-path %t/COM.swiftmodule -module-name COM -enable-experimental-com-interop %S/../Inputs/COM.swift
 // RUN: %target-typecheck-verify-swift -enable-experimental-com-interop -com-interop-model=microsoft -I %t
-// RUN: %target-typecheck-verify-swift -enable-experimental-com-interop -com-interop-model=corefoundation -I %t
 
-// Both interop models root at `IUnknown`, so the synthesized root conformance
-// is the same under either; run both to pin that portability.
+// Microsoft's COM supplies `IUnknown` as an implicit identity root.
 
 import COM
 

--- a/test/Sema/Inputs/com_foreign_class.swift
+++ b/test/Sema/Inputs/com_foreign_class.swift
@@ -1,0 +1,3 @@
+public class Foreign {
+  public init() {}
+}

--- a/test/Sema/com-corefoundation-model.swift
+++ b/test/Sema/com-corefoundation-model.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module-path %t/COM.swiftmodule -module-name COM -enable-experimental-com-interop -com-interop-model=corefoundation %S/../Inputs/COM.swift
+// RUN: %target-typecheck-verify-swift -enable-experimental-com-interop -com-interop-model=corefoundation -I %t
+
+import COM
+
+@com(interface: "10000000-0000-0000-0000-000000000001")
+protocol IRootless {}
+
+@com(implementation: "20000000-0000-0000-0000-000000000001")
+final class Implementation: IRootless {}
+
+let _: IID = IRootless.IID
+let _ = Implementation.CLSID
+// expected-error@-1 {{type 'Implementation' has no member 'CLSID'}}
+
+func requiresSwiftIdentity<T: ISwiftObject>(_: T) {}
+// expected-note@+1 {{where 'T' = 'Implementation'}}
+func requiresMicrosoftRoot<T: IUnknown>(_: T) {}
+
+func check(_ value: Implementation) {
+  requiresSwiftIdentity(value)
+  requiresMicrosoftRoot(value)
+  // expected-error@-1 {{global function 'requiresMicrosoftRoot' requires that 'Implementation' conform to 'IUnknown'}}
+}

--- a/test/Sema/com-existentials.swift
+++ b/test/Sema/com-existentials.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module-path %t/COM.swiftmodule -module-name COM -enable-experimental-com-interop %S/../Inputs/COM.swift
+// RUN: %target-typecheck-verify-swift -enable-experimental-com-interop -I %t
+
+import COM
+
+@_marker
+protocol LocalMarker {}
+
+protocol SwiftProtocol {
+  func requirement()
+}
+
+class NativeBase {}
+
+@com(interface: "10000000-0000-0000-0000-000000000001")
+protocol IBase {}
+
+@com(interface: "10000000-0000-0000-0000-000000000002")
+protocol IDerived: IBase {}
+
+@com(interface: "20000000-0000-0000-0000-000000000001")
+protocol IIndependent {}
+
+func acceptInterface(_: any IDerived) {}
+func acceptMarked(_: any IDerived & Sendable & LocalMarker) {}
+func acceptRefinementChain(_: any IDerived & IBase) {}
+
+// A generic environment can carry independent COM conformances separately.
+func acceptGeneric<T: IDerived & IIndependent>(_: T) {}
+
+func rejectIndependent(_: any IDerived & IIndependent) {}
+// expected-error@-1 {{COM existential cannot contain interfaces 'IDerived' and 'IIndependent' because neither refines the other}}
+
+func rejectSwiftProtocol(_: any IDerived & SwiftProtocol) {}
+// expected-error@-1 {{COM existential containing interface 'IDerived' cannot also contain non-marker protocol 'SwiftProtocol'}}
+
+func rejectAnyObject(_: any IDerived & AnyObject) {}
+// expected-error@-1 {{COM existential containing interface 'IDerived' cannot also contain 'AnyObject'}}
+
+func rejectSuperclass(_: any NativeBase & IDerived) {}
+// expected-error@-1 {{COM existential containing interface 'IDerived' cannot also contain class constraint 'NativeBase'}}
+
+func rejectCOMInterface(_: any COMInterface) {}
+// expected-error@-1 {{'any COMInterface' is invalid because 'COMInterface' does not identify a COM interface}}

--- a/test/Sema/com-implementation-cross-module.swift
+++ b/test/Sema/com-implementation-cross-module.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module-path %t/COM.swiftmodule -module-name COM -enable-experimental-com-interop %S/../Inputs/COM.swift
+// RUN: %target-swift-frontend -emit-module-path %t/ForeignClass.swiftmodule -module-name ForeignClass %S/Inputs/com_foreign_class.swift
+// RUN: %target-typecheck-verify-swift -enable-experimental-com-interop -I %t
+
+import COM
+import ForeignClass
+
+@com(interface: "10000000-0000-0000-0000-000000000001")
+protocol ILocal {}
+
+extension Foreign: ILocal {}
+// expected-error@-1 {{conformance of 'Foreign' to COM interface 'ILocal' must be declared in the same module as 'Foreign'}}

--- a/test/Sema/com-implementation-objc.swift
+++ b/test/Sema/com-implementation-objc.swift
@@ -1,0 +1,26 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -emit-module-path %t/COM.swiftmodule -module-name COM -enable-experimental-com-interop %S/../Inputs/COM.swift
+// RUN: %target-swift-frontend -typecheck -verify %t/main.swift -enable-experimental-com-interop -I %t
+
+// REQUIRES: objc_interop
+
+//--- module.modulemap
+module ObjCRoot {
+  header "ObjCRoot.h"
+}
+
+//--- ObjCRoot.h
+__attribute__((__objc_root_class__))
+@interface ObjCRoot
+@end
+
+//--- main.swift
+import COM
+import ObjCRoot
+
+@com(interface: "10000000-0000-0000-0000-000000000001")
+protocol IInterface {}
+
+class ObjCImplementation: ObjCRoot, IInterface {}
+// expected-error@-1 {{class 'ObjCImplementation' cannot provide a COM implementation because it does not use the native Swift object model}}

--- a/test/Sema/com-implementations.swift
+++ b/test/Sema/com-implementations.swift
@@ -1,0 +1,49 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module-path %t/COM.swiftmodule -module-name COM -enable-experimental-com-interop -com-interop-model=microsoft %S/../Inputs/COM.swift
+// RUN: %target-typecheck-verify-swift -enable-experimental-com-interop -com-interop-model=microsoft -I %t
+
+import COM
+
+@com(interface: "10000000-0000-0000-0000-000000000001")
+protocol IBase {}
+
+@com(interface: "10000000-0000-0000-0000-000000000002")
+protocol IDerived: IBase {}
+
+@com(interface: "20000000-0000-0000-0000-000000000001")
+protocol IIndependent {}
+
+struct ValueImplementation: IDerived {}
+// expected-error@-1 {{non-class type 'ValueImplementation' cannot conform to COM interface 'IDerived'}}
+
+enum EnumImplementation: IIndependent {}
+// expected-error@-1 {{non-class type 'EnumImplementation' cannot conform to COM interface 'IIndependent'}}
+
+// expected-error@+1 {{actor 'ActorImplementation' cannot provide a COM implementation}}
+actor ActorImplementation: IDerived {}
+
+// Multiple independent interfaces on one implementation are valid.
+class MultipleImplementation: IDerived, IIndependent {}
+
+func requiresCompilerManagedInterfaces<
+    T: IUnknown & ISwiftObject>(_ value: T) {}
+
+func inferredCompilerManagedInterfaces(
+    _ value: MultipleImplementation) {
+  requiresCompilerManagedInterfaces(value)
+}
+
+// A generic implementation is valid when it has no activation identity.
+class GenericImplementation<T>: IDerived {}
+
+@com
+class ExplicitGenericImplementation<T>: IDerived {}
+
+@com(implementation: "30000000-0000-0000-0000-000000000001")
+class ActivatableGenericImplementation<T>: IDerived {}
+// expected-error@-1 {{generic class 'ActivatableGenericImplementation' cannot declare a COM implementation identifier}}
+
+class ConditionalImplementation<T> {}
+
+extension ConditionalImplementation: IIndependent where T: Equatable {}
+// expected-error@-1 {{conditional conformance of 'ConditionalImplementation<T>' to COM interface 'IIndependent' is not supported}}


### PR DESCRIPTION
A COM existential carries the identity of one selected interface rather than an arbitrary Swift protocol composition. Teach existential layout to resolve that interface once and diagnose compositions that cannot have a single COM pointer, while leaving generic constraints free to require independent interfaces.

Make the COM class-only invariant a conformance rule instead of relying on AnyObject inheritance. Reject actors, foreign object models, retroactive and conditional conformances, and activation identities on generic implementations.

Record the maximal implemented interfaces in COMDeclInfo so IRGen can build one vtable and query-map entry per independent refinement branch. Add the compiler-managed COMInterface protocol to the permanent test module.