### PR TITLE
[SE-0537] Implement inference rules and lift limitations on @section for functions

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -1347,10 +1347,11 @@ BridgedReferenceOwnershipAttr BridgedReferenceOwnershipAttr_createParsed(
     BridgedASTContext cContext, swift::SourceLoc atLoc,
     swift::SourceRange range, BridgedReferenceOwnership cKind);
 
-SWIFT_NAME("BridgedSectionAttr.createParsed(_:atLoc:range:name:)")
+SWIFT_NAME("BridgedSectionAttr.createParsed(_:atLoc:range:isDefault:name:)")
 BridgedSectionAttr BridgedSectionAttr_createParsed(BridgedASTContext cContext,
                                                    swift::SourceLoc atLoc,
                                                    swift::SourceRange range,
+                                                   bool isDefault,
                                                    BridgedStringRef cName);
 
 SWIFT_NAME("BridgedSemanticsAttr.createParsed(_:atLoc:range:value:)")

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -735,15 +735,18 @@ public:
 /// Defines the @section attribute.
 class SectionAttr : public DeclAttribute {
 public:
-  SectionAttr(StringRef Name, SourceLoc AtLoc, SourceRange Range, bool Implicit)
+  SectionAttr(std::optional<StringRef> Name, SourceLoc AtLoc, SourceRange Range,
+              bool Implicit)
       : DeclAttribute(DeclAttrKind::Section, AtLoc, Range, Implicit),
         Name(Name) {}
 
-  SectionAttr(StringRef Name, bool Implicit)
+  SectionAttr(std::optional<StringRef> Name, bool Implicit)
     : SectionAttr(Name, SourceLoc(), SourceRange(), Implicit) {}
 
-  /// The section name.
-  const StringRef Name;
+  /// The section name, or std::nullopt if this represents @section(default).
+  const std::optional<StringRef> Name;
+
+  bool isDefault() const { return !Name.has_value(); }
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::Section;

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1151,6 +1151,14 @@ public:
   CodeGenerationModel
   getEffectiveCodeGenerationModel() const;
 
+  /// Determine the section into which this declaration should be placed,
+  /// based on an explicit `@section` attribute or the inference rules for
+  /// `@section`.
+  ///
+  /// \returns the name of the section, or \c std::nullopt if this declaration
+  /// belongs in the platform-appropriate default section.
+  std::optional<StringRef> getSection() const;
+
   using AuxiliaryDeclCallback = llvm::function_ref<void(Decl *)>;
 
   /// Iterate over the auxiliary declarations for this declaration,

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -4187,6 +4187,13 @@ public:
     this->actorIsolation = actorIsolation;
   }
 
+  /// Determine the section into which this closure should be placed, based on
+  /// an explicit `@section` attribute or the inference rules for `@section`.
+  ///
+  /// \returns the name of the section, or \c std::nullopt if this closure
+  /// belongs in the platform-appropriate default section.
+  std::optional<StringRef> getSection() const;
+
   static bool classof(const Expr *E) {
     return E->getKind() >= ExprKind::First_AbstractClosureExpr &&
            E->getKind() <= ExprKind::Last_AbstractClosureExpr;
@@ -6781,8 +6788,16 @@ void simple_display(llvm::raw_ostream &out, const ClosureExpr *CE);
 void simple_display(llvm::raw_ostream &out, const DefaultArgumentExpr *expr);
 void simple_display(llvm::raw_ostream &out, const Expr *expr);
 
+/// Disambiguate between the \c Expr and \c DeclContext overloads, both of
+/// which \c AbstractClosureExpr inherits.
+void simple_display(llvm::raw_ostream &out, const AbstractClosureExpr *CE);
+
 SourceLoc extractNearestSourceLoc(const ClosureExpr *expr);
 SourceLoc extractNearestSourceLoc(const Expr *expr);
+
+/// Disambiguate between the \c Expr and \c DeclContext overloads, both of
+/// which \c AbstractClosureExpr inherits.
+SourceLoc extractNearestSourceLoc(const AbstractClosureExpr *expr);
 
 } // end namespace swift
 

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -5343,6 +5343,33 @@ public:
   void cacheResult(DeclAttributes) const;
 };
 
+/// Determine the section into which the given declaration or closure should be
+/// placed, based on an explicit `@section` attribute or the inference rules
+/// for `@section`.
+///
+/// Produces the name of the section, or `std::nullopt` if the entity belongs in
+/// the platform-appropriate default section.
+class SectionForDeclRequest
+    : public SimpleRequest<SectionForDeclRequest,
+                           std::optional<StringRef>(
+                               llvm::PointerUnion<const Decl *,
+                                                  const AbstractClosureExpr *>),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  std::optional<StringRef>
+  evaluate(Evaluator &evaluator,
+           llvm::PointerUnion<const Decl *, const AbstractClosureExpr *>
+               declOrClosure) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 class UniqueUnderlyingTypeSubstitutionsRequest
     : public SimpleRequest<UniqueUnderlyingTypeSubstitutionsRequest,
                            std::optional<SubstitutionMap>(

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -613,6 +613,11 @@ SWIFT_REQUEST(TypeChecker, IsCCompatibleDeclRequest,
 SWIFT_REQUEST(TypeChecker, SemanticDeclAttrsRequest,
               DeclAttributes(const Decl *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, SectionForDeclRequest,
+              std::optional<StringRef>(
+                  llvm::PointerUnion<const Decl *,
+                                     const AbstractClosureExpr *>),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, UniqueUnderlyingTypeSubstitutionsRequest,
               std::optional<SubstitutionMap>(const Decl *),
               SeparatelyCached, NoLocationInfo)

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -5579,7 +5579,10 @@ public:
   }
   void visitSectionAttr(SectionAttr *Attr, Label label) {
     printCommon(Attr, "section_attr", label);
-    printFieldQuoted(Attr->Name, Label::always("name"));
+    if (auto sectionName = Attr->Name)
+      printFieldQuoted(*sectionName, Label::always("name"));
+    else
+      printFlag("default");
     printFoot();
   }
   void visitSemanticsAttr(SemanticsAttr *Attr, Label label) {

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1357,11 +1357,16 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     break;
   }
 
-  case DeclAttrKind::Section:
+  case DeclAttrKind::Section: {
     Printer.printAttrName("@section");
-    Printer << "(\"" << cast<SectionAttr>(this)->Name << "\")";
+    auto sectionAttr = cast<SectionAttr>(this);
+    if (sectionAttr->isDefault())
+      Printer << "(default)";
+    else
+      Printer << "(\"" << *sectionAttr->Name << "\")";
     break;
-      
+  }
+
   case DeclAttrKind::Diagnose: {
     auto diagnoseAttr = cast<DiagnoseAttr>(this);
     Printer.printAttrName("@diagnose(");

--- a/lib/AST/Bridging/DeclAttributeBridging.cpp
+++ b/lib/AST/Bridging/DeclAttributeBridging.cpp
@@ -738,9 +738,12 @@ BridgedReferenceOwnershipAttr_createParsed(BridgedASTContext cContext,
 BridgedSectionAttr BridgedSectionAttr_createParsed(BridgedASTContext cContext,
                                                    SourceLoc atLoc,
                                                    SourceRange range,
+                                                   bool isDefault,
                                                    BridgedStringRef cName) {
-  return new (cContext.unbridged()) SectionAttr(cName.unbridged(), atLoc, range,
-                                                /*Implicit=*/false);
+  return new (cContext.unbridged()) SectionAttr(
+      isDefault ? std::nullopt
+                : std::optional<StringRef>(cName.unbridged()),
+      atLoc, range, /*Implicit=*/false);
 }
 
 BridgedSemanticsAttr

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2488,6 +2488,11 @@ Decl::getEffectiveCodeGenerationModel() const {
   return getModuleContext()->codeGenerationModel();
 }
 
+std::optional<StringRef> Decl::getSection() const {
+  return evaluateOrDefault(getASTContext().evaluator,
+                           SectionForDeclRequest{this}, std::nullopt);
+}
+
 PatternBindingDecl::PatternBindingDecl(SourceLoc StaticLoc,
                                        StaticSpellingKind StaticSpelling,
                                        SourceLoc VarLoc,

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2128,6 +2128,11 @@ bool AbstractClosureExpr::hasSingleExpressionBody() const {
   return true;
 }
 
+std::optional<StringRef> AbstractClosureExpr::getSection() const {
+  return evaluateOrDefault(getASTContext().evaluator,
+                           SectionForDeclRequest{this}, std::nullopt);
+}
+
 Expr *AbstractClosureExpr::getSingleExpressionBody() const {
   if (auto closure = dyn_cast<ClosureExpr>(this))
     return closure->getSingleExpressionBody();
@@ -2991,11 +2996,25 @@ void swift::simple_display(llvm::raw_ostream &out,
   out << "expression";
 }
 
+void swift::simple_display(llvm::raw_ostream &out,
+                           const AbstractClosureExpr *CE) {
+  if (!CE) {
+    out << "(null)";
+    return;
+  }
+
+  out << "closure";
+}
+
 SourceLoc swift::extractNearestSourceLoc(const ClosureExpr *expr) {
   return expr->getLoc();
 }
 
 SourceLoc swift::extractNearestSourceLoc(const Expr *expr) {
+  return expr->getLoc();
+}
+
+SourceLoc swift::extractNearestSourceLoc(const AbstractClosureExpr *expr) {
   return expr->getLoc();
 }
 

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -2663,6 +2663,137 @@ void SemanticDeclAttrsRequest::cacheResult(DeclAttributes attrs) const {
 }
 
 //----------------------------------------------------------------------------//
+// SectionForDeclRequest computation.
+//----------------------------------------------------------------------------//
+
+/// The set of accessors that provide read-only access to storage. A synthesized
+/// accessor in this set infers its section from an accessor in this set that
+/// was written explicitly.
+static const AccessorKind ReadAccessorKinds[] = {
+  AccessorKind::Get,
+  AccessorKind::DistributedGet,
+  AccessorKind::Read,
+  AccessorKind::YieldingBorrow,
+  AccessorKind::Borrow,
+  AccessorKind::Address
+};
+
+/// The set of accessors that provide write or read-write access to storage. A
+/// synthesized accessor in this set infers its section from an accessor in this
+/// set that was written explicitly.
+static const AccessorKind WriteAccessorKinds[] = {
+  AccessorKind::Set,
+  AccessorKind::Modify,
+  AccessorKind::YieldingMutate,
+  AccessorKind::Mutate,
+  AccessorKind::MutableAddress,
+  AccessorKind::Init,
+  AccessorKind::WillSet,
+  AccessorKind::DidSet
+};
+
+/// Find the explicitly-written accessor from which the given synthesized
+/// accessor infers its section, or nullptr if there is none.
+///
+/// An accessor that provides read-only access infers from an explicitly-written
+/// accessor that provides read-only access, and an accessor that writes infers
+/// from an explicitly-written accessor that writes.
+static AccessorDecl *
+findAccessorForSectionInference(const AccessorDecl *accessor) {
+  auto isKindIn = [&](ArrayRef<AccessorKind> kinds) {
+    return llvm::is_contained(kinds, accessor->getAccessorKind());
+  };
+
+  ArrayRef<AccessorKind> kinds;
+  if (isKindIn(WriteAccessorKinds))
+    kinds = WriteAccessorKinds;
+  else if (isKindIn(ReadAccessorKinds))
+    kinds = ReadAccessorKinds;
+  else
+    return nullptr;
+
+  auto storage = accessor->getStorage();
+  for (auto kind : kinds) {
+    auto parsed = storage->getParsedAccessor(kind);
+    if (parsed && parsed->getAttrs().hasAttribute<SectionAttr>())
+      return parsed;
+  }
+
+  return nullptr;
+}
+
+/// Infer the section for an entity based on the function or closure that
+/// encloses it, if there is one.
+static std::optional<StringRef>
+inferSectionFromEnclosingContext(const DeclContext *dc) {
+  while (dc) {
+    // A function or closure provides its own section for inference.
+    if (auto afd = dyn_cast<AbstractFunctionDecl>(dc))
+      return afd->getSection();
+    if (auto ace = dyn_cast<AbstractClosureExpr>(dc))
+      return ace->getSection();
+
+    // Look through an initializer context to the entity it initializes. This
+    // matters for the default argument of a function: the code of the default
+    // argument generator is emitted with the section of the function, so a
+    // closure written in that default argument belongs there too.
+    //
+    // For the initializer of a variable, this walks to the type or file that
+    // contains the variable, where the search then terminates: a section is
+    // never inferred from a variable to code, nor into a type.
+    if (isa<Initializer>(dc)) {
+      dc = dc->getParent();
+      continue;
+    }
+
+    break;
+  }
+
+  return std::nullopt;
+}
+
+std::optional<StringRef> SectionForDeclRequest::evaluate(
+    Evaluator &evaluator,
+    llvm::PointerUnion<const Decl *, const AbstractClosureExpr *>
+        declOrClosure) const {
+  if (auto closure = declOrClosure.dyn_cast<const AbstractClosureExpr *>()) {
+    // An explicit '@section' on the closure wins.
+    if (auto explicitClosure = dyn_cast<ClosureExpr>(closure)) {
+      if (auto attr = explicitClosure->getAttrs().getAttribute<SectionAttr>())
+        return attr->Name;
+    }
+
+    // Otherwise, infer from the enclosing function or closure.
+    return inferSectionFromEnclosingContext(closure->getParent());
+  }
+
+  auto decl = cast<const Decl *>(declOrClosure);
+
+  // An explicit '@section' wins. Note that '@section(default)' has no name,
+  // which suppresses any inference that would otherwise occur.
+  if (auto attr = decl->getAttrs().getAttribute<SectionAttr>())
+    return attr->Name;
+
+  // A synthesized accessor infers its section from an accessor that was written
+  // explicitly. Note that this includes '@section(default)', which suppresses
+  // the inference below.
+  if (auto accessor = dyn_cast<AccessorDecl>(decl)) {
+    if (accessor->isImplicit()) {
+      if (auto source = findAccessorForSectionInference(accessor))
+        return source->getSection();
+    }
+  }
+
+  // A local function (or the accessor of a local variable) infers its section
+  // from the function or closure that encloses it. Nothing else infers a
+  // section, because code and data tend to go in different sections.
+  if (isa<AbstractFunctionDecl>(decl))
+    return inferSectionFromEnclosingContext(decl->getDeclContext());
+
+  return std::nullopt;
+}
+
+//----------------------------------------------------------------------------//
 // UniqueUnderlyingTypeSubstitutionsRequest computation.
 //----------------------------------------------------------------------------//
 

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -1122,20 +1122,35 @@ extension ASTGenVisitor {
   /// E.g.
   ///   ```
   ///   @section("__TEXT,__mysection")
+  ///   @section(default)
   ///   ```
   func generateSectionAttr(attribute node: AttributeSyntax) -> BridgedSectionAttr? {
-    return self.generateWithLabeledExprListArguments(attribute: node) { args in
-      guard let name = self.generateConsumingSimpleStringLiteralAttrOption(args: &args) else {
+    guard let arg = node.arguments?.as(SectionAttributeArgumentSyntax.self) else {
+      self.diagnose(.expectedArgumentsInAttribute(node))
+      return nil
+    }
+
+    let isDefault: Bool
+    let name: BridgedStringRef
+    switch arg.section {
+    case .defaultKeyword:
+      isDefault = true
+      name = ""
+    case .expression(let expr):
+      guard let sectionName = self.generateStringLiteralTextIfNotInterpolated(expr: expr) else {
         return nil
       }
-
-      return .createParsed(
-        self.ctx,
-        atLoc: self.generateSourceLoc(node.atSign),
-        range: self.generateAttrSourceRange(node),
-        name: name
-      )
+      isDefault = false
+      name = sectionName
     }
+
+    return .createParsed(
+      self.ctx,
+      atLoc: self.generateSourceLoc(node.atSign),
+      range: self.generateAttrSourceRange(node),
+      isDefault: isDefault,
+      name: name
+    )
   }
 
   /// E.g.:
@@ -2494,14 +2509,15 @@ extension ASTGenVisitor {
   func generateStringLiteralTextIfNotInterpolated(expr node: some ExprSyntaxProtocol) -> BridgedStringRef? {
     if let segments = node.as(SimpleStringLiteralExprSyntax.self)?.segments {
       return extractRawText(segments).bridged
-    } else if let segments = node.as(StringLiteralExprSyntax.self)?.segments,
-      segments.allSatisfy({ $0.is(StringSegmentSyntax.self) })
-    {
+    } else if let segments = node.as(StringLiteralExprSyntax.self)?.segments {
+      guard segments.allSatisfy({ $0.is(StringSegmentSyntax.self) }) else {
+        self.diagnose(.forbiddenInterpolatedStringArgument(node))
+        return nil
+      }
       return extractRawText(segments).bridged
     }
-    // TODO: Diagnose.
-    fatalError("expected string literal without interpolation")
-    // return nil
+    self.diagnose(.expectedStringLiteralArgument(node))
+    return nil
   }
 
   /// Convenient method for processing an attribute with `LabeledExprListSyntax`.

--- a/lib/ASTGen/Sources/ASTGen/Diagnostics.swift
+++ b/lib/ASTGen/Sources/ASTGen/Diagnostics.swift
@@ -171,6 +171,20 @@ extension ASTGenDiagnostic {
       message: "unexpected arguments in '\(attribute.attributeName.trimmedDescription)' attribute"
     )
   }
+
+  static func expectedStringLiteralArgument(_ node: some SyntaxProtocol) -> Self {
+    Self(
+      node: node,
+      message: "expected string literal"
+    )
+  }
+
+  static func forbiddenInterpolatedStringArgument(_ node: some SyntaxProtocol) -> Self {
+    Self(
+      node: node,
+      message: "argument cannot be an interpolated string literal"
+    )
+  }
 }
 
 extension ASTGenDiagnostic {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3263,20 +3263,25 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
       return makeParserSuccess();
     }
 
-    if (Tok.isNot(tok::string_literal)) {
+    std::optional<StringRef> Name;
+    if (consumeIf(tok::kw_default)) {
+      // Leave the name empty to signal '@section(default)'.
+      AttrRange = SourceRange(Loc, Tok.getRange().getStart());
+    } else if (Tok.isNot(tok::string_literal)) {
       diagnose(Loc, diag::attr_expected_string_literal, AttrName);
       return makeParserSuccess();
+    } else {
+      // Parse the name as a string literal.
+      Name = getStringLiteralIfNotInterpolated(
+          Loc, ("'" + AttrName + "'").str());
+
+      consumeToken(tok::string_literal);
+
+      if (Name.has_value())
+        AttrRange = SourceRange(Loc, Tok.getRange().getStart());
+      else
+        DiscardAttribute = true;
     }
-
-    auto Name = getStringLiteralIfNotInterpolated(
-        Loc, ("'" + AttrName + "'").str());
-
-    consumeToken(tok::string_literal);
-
-    if (Name.has_value())
-      AttrRange = SourceRange(Loc, Tok.getRange().getStart());
-    else
-      DiscardAttribute = true;
 
     if (!consumeIf(tok::r_paren)) {
       diagnose(Loc, diag::attr_expected_rparen, AttrName,
@@ -3290,7 +3295,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     }
 
     if (!DiscardAttribute)
-      Attributes.add(new (Context) SectionAttr(Name.value(), AtLoc,
+      Attributes.add(new (Context) SectionAttr(Name, AtLoc,
                                                AttrRange, /*Implicit=*/false));
 
     break;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3289,11 +3289,8 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
       return makeParserSuccess();
     }
 
-    // @section in a local scope is not allowed.
-    if (CurDeclContext->isLocalContext()) {
-      diagnose(Loc, diag::attr_name_only_at_non_local_scope, AttrName);
-    }
-
+    // @section in a local scope is only allowed on functions and closures,
+    // which is checked in Sema.
     if (!DiscardAttribute)
       Attributes.add(new (Context) SectionAttr(Name, AtLoc,
                                                AttrRange, /*Implicit=*/false));

--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -254,9 +254,8 @@ void SILFunctionBuilder::addFunctionAttributes(
 
   // Add section for anything that was originally a function.
   if (isa<AbstractFunctionDecl>(decl)) {
-    if (auto *SA = Attrs.getAttribute<SectionAttr>())
-      if (auto sectionName = SA->Name)
-        F->setSection(*sectionName);
+    if (auto sectionName = decl->getSection())
+      F->setSection(*sectionName);
   }
 
   // Only emit replacements for the objc entry point of objc methods.
@@ -443,6 +442,11 @@ SILFunction *SILFunctionBuilder::getOrCreateFunction(
     addFunctionAttributes(F, decl->getAttrs(), mod, getOrCreateDeclaration,
                           constant);
   } else if (auto *ce = constant.getAbstractClosureExpr()) {
+    // Add the section for the closure, which can be specified explicitly or
+    // inferred from the enclosing function or closure.
+    if (auto sectionName = ce->getSection())
+      F->setSection(*sectionName);
+
     if (mod.getOptions().EnableGlobalAssemblyVision) {
       F->addSemanticsAttr(semantics::FORCE_EMIT_OPT_REMARK_PREFIX);
     } else {

--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -255,7 +255,8 @@ void SILFunctionBuilder::addFunctionAttributes(
   // Add section for anything that was originally a function.
   if (isa<AbstractFunctionDecl>(decl)) {
     if (auto *SA = Attrs.getAttribute<SectionAttr>())
-      F->setSection(SA->Name);
+      if (auto sectionName = SA->Name)
+        F->setSection(*sectionName);
   }
 
   // Only emit replacements for the objc entry point of objc methods.

--- a/lib/SILGen/SILGenGlobalVariable.cpp
+++ b/lib/SILGen/SILGenGlobalVariable.cpp
@@ -78,7 +78,8 @@ SILGlobalVariable *SILGenModule::getSILGlobalVariable(VarDecl *gDecl,
   silGlobal->setDeclaration(!forDef);
 
   if (auto sectionAttr = gDecl->getAttrs().getAttribute<SectionAttr>())
-    silGlobal->setSection(sectionAttr->Name);
+    if (auto sectionName = sectionAttr->Name)
+      silGlobal->setSection(*sectionName);
 
   if (cExternAttr) {
     silGlobal->setAsmName(cExternAttr->getCName(gDecl));

--- a/lib/SILGen/SILGenGlobalVariable.cpp
+++ b/lib/SILGen/SILGenGlobalVariable.cpp
@@ -77,9 +77,8 @@ SILGlobalVariable *SILGenModule::getSILGlobalVariable(VarDecl *gDecl,
       M, silLinkage, IsNotSerialized, mangledName, silTy, std::nullopt, gDecl);
   silGlobal->setDeclaration(!forDef);
 
-  if (auto sectionAttr = gDecl->getAttrs().getAttribute<SectionAttr>())
-    if (auto sectionName = sectionAttr->Name)
-      silGlobal->setSection(*sectionName);
+  if (auto sectionName = gDecl->getSection())
+    silGlobal->setSection(*sectionName);
 
   if (cExternAttr) {
     silGlobal->setAsmName(cExternAttr->getCName(gDecl));

--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
@@ -607,6 +607,10 @@ void FunctionSignatureTransform::createFunctionSignatureOptimizedFunction() {
       NewF->addSemanticsAttr(Attr);
   }
 
+  // The optimized function, which takes over the body of the original
+  // function, goes into the same section as the original function.
+  NewF->setSection(F->section());
+
   // Do the last bit of work to the newly created optimized function.
   DeadArgumentFinalizeOptimizedFunction();
   ArgumentExplosionFinalizeOptimizedFunction();

--- a/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
+++ b/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
@@ -476,6 +476,8 @@ ClosureCloner::initCloned(SILOptFunctionBuilder &functionBuilder,
       orig->getEffectsKind(), orig, orig->getDebugScope());
   for (auto &attr : orig->getSemanticsAttrs())
     fn->addSemanticsAttr(attr);
+  // The cloned closure goes into the same section as the original closure.
+  fn->setSection(orig->section());
   return fn;
 }
 

--- a/lib/SILOptimizer/Utils/GenericCloner.cpp
+++ b/lib/SILOptimizer/Utils/GenericCloner.cpp
@@ -87,6 +87,9 @@ SILFunction *GenericCloner::createDeclaration(
   if (!Orig->hasOwnership()) {
     NewF->setOwnershipEliminated();
   }
+  // A specialization of a function goes into the same section as the original
+  // function.
+  NewF->setSection(Orig->section());
   NewF->copyEffects(Orig);
   return NewF;
 }

--- a/lib/SILOptimizer/Utils/OptimizerBridging.cpp
+++ b/lib/SILOptimizer/Utils/OptimizerBridging.cpp
@@ -479,6 +479,10 @@ createSpecializedFunctionDeclaration(BridgedStringRef specializedName,
   for (auto &Attr : original->getSemanticsAttrs())
     specializedApplySiteCallee->addSemanticsAttr(Attr);
 
+  // A specialization of a function goes into the same section as the original
+  // function.
+  specializedApplySiteCallee->setSection(original->section());
+
   return {specializedApplySiteCallee};
 }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2768,7 +2768,7 @@ void AttributeChecker::visitUsedAttr(UsedAttr *attr) {
 
 void AttributeChecker::visitSectionAttr(SectionAttr *attr) {
   // The name must not be empty.
-  if (attr->Name.empty())
+  if (attr->Name && attr->Name->empty())
     diagnose(attr->getLocation(), diag::section_empty_name);
 
   if (D->getDeclContext()->isLocalContext())

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2771,21 +2771,24 @@ void AttributeChecker::visitSectionAttr(SectionAttr *attr) {
   if (attr->Name && attr->Name->empty())
     diagnose(attr->getLocation(), diag::section_empty_name);
 
-  if (D->getDeclContext()->isLocalContext())
-    return; // already diagnosed
+  // All of the remaining restrictions apply only to variables. Functions can
+  // have a '@section' anywhere, because all functions go into a text section.
+  auto *VarD = dyn_cast<VarDecl>(D);
+  if (!VarD)
+    return;
 
-  if (D->getDeclContext()->isGenericContext() &&
-      !D->getDeclContext()
-           ->getGenericSignatureOfContext()
-           ->areAllParamsConcrete())
+  if (D->getDeclContext()->isLocalContext()) {
+    diagnose(attr->getLocation(), diag::attr_only_at_non_local_scope, attr);
+  } else if (D->getDeclContext()->isGenericContext() &&
+             !D->getDeclContext()
+                  ->getGenericSignatureOfContext()
+                  ->areAllParamsConcrete()) {
     diagnose(attr->getLocation(), diag::attr_only_at_non_generic_scope, attr);
-  else if (auto *VarD = dyn_cast<VarDecl>(D)) {
-    if (!VarD->isStatic() && !D->getDeclContext()->isModuleScopeContext()) {
-      diagnose(attr->getLocation(), diag::attr_only_on_static_properties, attr);
-    } else if (!VarD->hasStorageOrWrapsStorage()) {
-      diagnose(attr->getLocation(), diag::attr_not_on_computed_properties,
-               attr);
-    }
+  } else if (!VarD->isStatic() &&
+             !D->getDeclContext()->isModuleScopeContext()) {
+    diagnose(attr->getLocation(), diag::attr_only_on_static_properties, attr);
+  } else if (!VarD->hasStorageOrWrapsStorage()) {
+    diagnose(attr->getLocation(), diag::attr_not_on_computed_properties, attr);
   }
 }
 
@@ -3438,6 +3441,13 @@ SynthesizeMainFunctionRequest::evaluate(Evaluator &evaluator,
   // It's never useful to provide a dynamic replacement of this function--it is
   // just a pass-through to MainType.main.
   func->setIsDynamic(false);
+
+  // The entry points the compiler emits for the '@main' type go into the same
+  // section as the 'main' function they call.
+  if (auto *sectionAttr =
+          mainFunction->getAttrs().getAttribute<SectionAttr>()) {
+    func->getAttrs().add(sectionAttr->clone(context));
+  }
 
   auto *params = context.Allocate<MainTypeAttrParams>();
   params->mainFunction = mainFunction;
@@ -9143,6 +9153,12 @@ public:
 
   void visitSendableAttr(SendableAttr *attr) {
     // Nothing else to check.
+  }
+
+  void visitSectionAttr(SectionAttr *attr) {
+    // The name must not be empty.
+    if (attr->Name && attr->Name->empty())
+      ctx.Diags.diagnose(attr->getLocation(), diag::section_empty_name);
   }
 
   void checkExecutionBehaviorAttribute(DeclAttribute *attr) {

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2536,39 +2536,6 @@ synthesizeAccessorBody(AbstractFunctionDecl *fn, void *) {
   llvm_unreachable("bad synthesized function kind");
 }
 
-/// If the accessor is one of the given kinds, and there is a @section on a
-/// parsed accessor of one of the given kinds, transfer it to the accessor.
-///
-/// Returns true if anything was transferred.
-static bool tryTransferAccessorSection(
-    AccessorDecl *accessor, ArrayRef<AccessorKind> kinds) {
-  // Is our accessor one of the expected kinds?
-  if (std::find(kinds.begin(), kinds.end(), accessor->getAccessorKind()) ==
-        kinds.end())
-    return false;
-
-  // If the accessor has a @section attribute already, we're done.
-  if (accessor->getAttrs().hasAttribute<SectionAttr>())
-    return true;
-
-  // Look for a parsed accessor from which we can pull the section name.
-  auto storage = accessor->getStorage();
-  for (auto kind : kinds) {
-    auto parsed = storage->getParsedAccessor(kind);
-    if (!parsed)
-      continue;
-
-    if (auto section = parsed->getAttrs().getAttribute<SectionAttr>()) {
-      // Clone the attribute.
-      ASTContext &ctx = storage->getASTContext();
-      accessor->getAttrs().add(section->clone(ctx));
-      return true;
-    }
-  }
-
-  return false;
-}
-
 static void finishImplicitAccessor(AccessorDecl *accessor,
                                    ASTContext &ctx) {
   accessor->setImplicit();
@@ -2578,28 +2545,6 @@ static void finishImplicitAccessor(AccessorDecl *accessor,
 
   if (accessor->doesAccessorHaveBody())
     accessor->setBodySynthesizer(&synthesizeAccessorBody);
-
-  // Look for a @section attribute to transfer.
-  AccessorKind readAccessors[] = {
-    AccessorKind::Get,
-    AccessorKind::DistributedGet,
-    AccessorKind::Read,
-    AccessorKind::YieldingBorrow,
-    AccessorKind::Borrow,
-    AccessorKind::Address
-  };
-  AccessorKind writeAccessors[] = {
-    AccessorKind::Set,
-    AccessorKind::Modify,
-    AccessorKind::YieldingMutate,
-    AccessorKind::Mutate,
-    AccessorKind::MutableAddress,
-    AccessorKind::Init,
-    AccessorKind::WillSet,
-    AccessorKind::DidSet
-  };
-  if (!tryTransferAccessorSection(accessor, writeAccessors))
-    tryTransferAccessorSection(accessor, readAccessors);
 }
 
 static AccessorDecl *createGetterPrototype(AbstractStorageDecl *storage,

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -6736,9 +6736,12 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
 
       case decls_block::Section_DECL_ATTR: {
         bool isImplicit;
+        bool isDefault;
         serialization::decls_block::SectionDeclAttrLayout::readRecord(
-            scratch, isImplicit);
-        Attr = new (ctx) SectionAttr(blobData, isImplicit);
+            scratch, isImplicit, isDefault);
+        Attr = new (ctx) SectionAttr(
+            isDefault ? std::nullopt : std::optional<StringRef>(blobData),
+            isImplicit);
         break;
       }
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 1014; // @called(once) attribute support
+const uint16_t SWIFTMODULE_VERSION_MINOR = 1015; // @section(default)
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -2323,6 +2323,7 @@ namespace decls_block {
   using SectionDeclAttrLayout = BCRecordLayout<
     Section_DECL_ATTR,
     BCFixed<1>, // implicit flag
+    BCFixed<1>, // default flag
     BCBlob      // _section
   >;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3582,9 +3582,10 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
     case DeclAttrKind::Section: {
       auto *theAttr = cast<SectionAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[SectionDeclAttrLayout::Code];
-      SectionDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
-                                           theAttr->isImplicit(),
-                                           theAttr->Name);
+      bool isDefault = theAttr->isDefault();
+      SectionDeclAttrLayout::emitRecord(
+          S.Out, S.ScratchRecord, abbrCode, theAttr->isImplicit(), isDefault,
+          isDefault ? StringRef() : *theAttr->Name);
       return;
     }
 

--- a/test/ASTGen/attrs.swift
+++ b/test/ASTGen/attrs.swift
@@ -137,6 +137,11 @@ class ExclusivityAttrClass {
 struct SectionStruct {
 	@section("__TEXT,__mysection") @used func foo() {}
 	@section(default) @used func bar() {}
+
+	func withClosures(_ body: () -> Void) {
+		withClosures { @section("__TEXT,__mysection") in }
+		withClosures { @section(default) in }
+	}
 }
 
 protocol ImplementsProto {

--- a/test/ASTGen/attrs.swift
+++ b/test/ASTGen/attrs.swift
@@ -136,6 +136,7 @@ class ExclusivityAttrClass {
 
 struct SectionStruct {
 	@section("__TEXT,__mysection") @used func foo() {}
+	@section(default) @used func bar() {}
 }
 
 protocol ImplementsProto {

--- a/test/IRGen/section.swift
+++ b/test/IRGen/section.swift
@@ -42,6 +42,13 @@ func defaultSection() { }
 @section(default)
 var gDefault: Int = 7
 
+// A variable with '@section' may have property observers, which can have their
+// own '@section'.
+@section("__DATA,__mysection")
+var gObserved: Int = 9 {
+  @section("__TEXT,__mysection") didSet { }
+}
+
 // SIL: @section("__DATA,__mysection") @_hasStorage @_hasInitialValue var g0: Int { get set }
 // SIL: @section("__DATA,__mysection") @_hasStorage @_hasInitialValue var g1: (Int, Int) { get set }
 // SIL: @section("__DATA,__mysection") @_hasStorage @_hasInitialValue var g2: Bool { get set }
@@ -96,6 +103,11 @@ var gDefault: Int = 7
 // SIL: sil hidden [used] [section "__TEXT,__mysection"] @$s7section7MyClassCfD : $@convention(method)
 // SIL: sil hidden @$s7section6testityypypnF : $@convention(thin) (@in Any) -> @out Any {
 // SIL: sil hidden @$s7section14defaultSectionyyF : $@convention(thin) () -> () {
+
+// The 'didSet' has its own section, which is used for the synthesized 'set'.
+// SIL: sil private [section "__TEXT,__mysection"] @$s7section9gObservedSivW
+// SIL: sil hidden @$s7section9gObservedSivg
+// SIL: sil hidden [section "__TEXT,__mysection"] @$s7section9gObservedSivs
 
 // IR:  @"$s7section2g0Sivp" = hidden global %TSi <{ {{(i64|i32)}} 1 }>, section "__DATA,__mysection"
 // IR:  @"$s7section2g1Si_Sitvp" = hidden global <{ %TSi, %TSi }> <{ %TSi <{ {{(i64|i32)}} 42 }>, %TSi <{ {{(i64|i32)}} 43 }> }>, section "__DATA,__mysection"

--- a/test/IRGen/section.swift
+++ b/test/IRGen/section.swift
@@ -36,6 +36,12 @@ class MyClass {
 var functionptr = testit
 func testit(_ e: consuming Any) -> Any { e }
 
+@section(default)
+func defaultSection() { }
+
+@section(default)
+var gDefault: Int = 7
+
 // SIL: @section("__DATA,__mysection") @_hasStorage @_hasInitialValue var g0: Int { get set }
 // SIL: @section("__DATA,__mysection") @_hasStorage @_hasInitialValue var g1: (Int, Int) { get set }
 // SIL: @section("__DATA,__mysection") @_hasStorage @_hasInitialValue var g2: Bool { get set }
@@ -55,6 +61,12 @@ func testit(_ e: consuming Any) -> Any { e }
 // SIL:    @section("__TEXT,__mysection") get
 // SIL:    @section("__TEXT,__mymutsection") set
 // SIL:  }
+// SIL: @section(default) func defaultSection()
+// SIL: @section(default) @_hasStorage @_hasInitialValue var gDefault: Int { get set }
+
+// '@section(default)' places the declaration in the default section, so no
+// section is recorded in SIL.
+// SIL: sil_global hidden @$s7section8gDefaultSivp : $Int = {
 
 // SIL: sil private [global_init_once_fn] @$s7section2g0_WZ : $@convention(c)
 // SIL: sil hidden [global_init] @$s7section2g0Sivau : $@convention(thin)
@@ -83,6 +95,7 @@ func testit(_ e: consuming Any) -> Any { e }
 // SIL: sil hidden [used] [section "__TEXT,__mysection"] @$s7section7MyClassCfd : $@convention(method)
 // SIL: sil hidden [used] [section "__TEXT,__mysection"] @$s7section7MyClassCfD : $@convention(method)
 // SIL: sil hidden @$s7section6testityypypnF : $@convention(thin) (@in Any) -> @out Any {
+// SIL: sil hidden @$s7section14defaultSectionyyF : $@convention(thin) () -> () {
 
 // IR:  @"$s7section2g0Sivp" = hidden global %TSi <{ {{(i64|i32)}} 1 }>, section "__DATA,__mysection"
 // IR:  @"$s7section2g1Si_Sitvp" = hidden global <{ %TSi, %TSi }> <{ %TSi <{ {{(i64|i32)}} 42 }>, %TSi <{ {{(i64|i32)}} 43 }> }>, section "__DATA,__mysection"
@@ -91,6 +104,8 @@ func testit(_ e: consuming Any) -> Any { e }
 // IR:  @"$s7section2g4SpySiGSgvp" = hidden global {{i64|i32}} 0, section "__DATA,__mysection"
 // IR:  @"$s7section2g5SpySiGSgvp" = hidden global {{i64|i32}} 1111638594, section "__DATA,__mysection"
 // IR:  @"$s7section8MyStructV7static0SivpZ" = hidden global %TSi <{ {{(i64|i32)}} 1 }>, section "__DATA,__mysection"
+// IR:  @"$s7section8gDefaultSivp" = hidden global %TSi <{ {{(i64|i32)}} 7 }>, align {{[0-9]+$}}
 // IR:  define {{.*}}@"$s7section3fooyyF"(){{.*}} section "__TEXT,__mysection"
 // IR:  define {{.*}}@"$s7section8MyStructV3fooyyF"() #0 section "__TEXT,__mysection"
 // IR:  define {{.*}}@"$s7section8MyStructV12initialValueACSi_tcfC"({{.*}}) #0 section "__TEXT,__mysection"
+// IR:  define {{.*}}@"$s7section14defaultSectionyyF"() #{{[0-9]+}} {{[{]$}}

--- a/test/IRGen/section_async.swift
+++ b/test/IRGen/section_async.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -emit-ir -parse-as-library %s | %FileCheck %s
+
+// REQUIRES: concurrency
+
+// Each of the partial functions that the implementation produces for an 'async'
+// function respects the '@section' attribute.
+
+@inline(never)
+func other(_ x: Int) async -> Int { x + 1 }
+
+@section("__TEXT,boot")
+public func bootAsync() async -> Int {
+  let first = await other(1)
+  return await other(first)
+}
+
+// CHECK: define{{.*}} @"$s13section_async9bootAsyncSiyYaF"({{.*}}section "__TEXT,boot"
+// CHECK: define{{.*}} @"$s13section_async9bootAsyncSiyYaFTQ0_"({{.*}}section "__TEXT,boot"
+// CHECK: define{{.*}} @"$s13section_async9bootAsyncSiyYaFTQ1_"({{.*}}section "__TEXT,boot"

--- a/test/IRGen/section_errors.swift
+++ b/test/IRGen/section_errors.swift
@@ -17,7 +17,7 @@ struct MyStruct2 {
 struct MyStruct3<T> {
   static var member1: Int = 1 // expected-error {{static stored properties not supported in generic types}}
 
-  @section("__TEXT,__mysection") func foo() {} // expected-error {{attribute @section cannot be used in a generic context}}
+  @section("__TEXT,__mysection") func foo() {} // ok, functions can go in a section anywhere
 }
 
 struct MyStruct4<T> {
@@ -27,7 +27,7 @@ struct MyStruct4<T> {
     @section("__TEXT,__mysection") static var member3: Int = 1 // expected-error {{static stored properties not supported in generic types}}
     // expected-error@-1 {{attribute @section cannot be used in a generic context}}
 
-    @section("__TEXT,__mysection") func foo() {} // expected-error {{attribute @section cannot be used in a generic context}}
+    @section("__TEXT,__mysection") func foo() {} // ok
   }
 }
 
@@ -43,14 +43,25 @@ struct SomeStruct {}
 
 @section("") var g1: Int = 1 // expected-error {{'@section' section name cannot be empty}}
 
+@section("") func emptySection() {} // expected-error {{'@section' section name cannot be empty}}
+
+func emptySectionInClosure() {
+  _ = { @section("") in } // expected-error {{'@section' section name cannot be empty}}
+}
+
 func function() {
-  @section("__TEXT,__mysection") var l0: Int = 1 // expected-error {{attribute 'section' can only be used in a non-local scope}}
+  @section("__TEXT,__mysection") var l0: Int = 1 // expected-error {{attribute @section can only be used in a non-local scope}}
   l0 += 1
   _ = l0
 
   @used var l1: Int = 1 // expected-error {{attribute @used can only be used in a non-local scope}}
   l1 += 1
   _ = l1
+
+  @section("__TEXT,__mysection") func l2() {} // ok, functions can have a section in a local scope
+  l2()
+
+  _ = { @section("__TEXT,__mysection") in } // ok, closures can have a section
 }
 
 func function_with_type() {

--- a/test/IRGen/section_functions.swift
+++ b/test/IRGen/section_functions.swift
@@ -1,0 +1,184 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-sil -parse-as-library | %FileCheck %s --check-prefix=SIL
+// RUN: %target-swift-frontend -primary-file %s -emit-sil -O -parse-as-library | %FileCheck %s --check-prefix=SIL-OPT
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -parse-as-library | %FileCheck %s --check-prefix=IR
+
+func registerCallback(_ body: () -> Void) {}
+
+// Functions in a generic context can have a '@section', because all functions
+// go into a text section.
+@section("__TEXT,boot")
+func genericBoot<T>(_ value: T) -> T { value }
+
+struct Generic<T> {
+  @section("__TEXT,boot")
+  func member() {}
+}
+
+// A specialization of a generic function goes into the same section as the
+// generic function it was specialized from.
+public func callGenericBoot() -> Int {
+  genericBoot(42)
+}
+
+// '@section' is inferred for local functions and closures within a function
+// that has a '@section'.
+@section("__TEXT,boot")
+func firmwareBootEntrypoint() {
+  func helper() {}
+  helper()
+
+  registerCallback {
+    // Inference applies to nested closures, too.
+    registerCallback {}
+  }
+
+  // '@section(default)' suppresses the inference.
+  @section(default)
+  func notBoot() {}
+  notBoot()
+
+  registerCallback { @section(default) in }
+
+  // An explicit '@section' overrides the inference.
+  @section("__TEXT,boot2")
+  func elsewhere() {}
+  elsewhere()
+
+  registerCallback { @section("__TEXT,boot2") in }
+}
+
+// Local types (and their members) do not infer a '@section'.
+@section("__TEXT,boot")
+func withLocalType() {
+  struct Local {
+    func member() {}
+
+    var property: Int { 0 }
+  }
+
+  Local().member()
+  _ = Local().property
+
+  // The accessors of a local variable are code within the enclosing function,
+  // so they do infer the section.
+  var localProperty: Int { 17 }
+  _ = localProperty
+}
+
+// There is no inference from a variable to its accessors.
+@section("__DATA,boot")
+var storedVariable: Int = 0
+
+// Nor from a variable to a closure in its initializer.
+var initializedVariable: Int = registerCallbackReturningInt { 0 }
+
+func registerCallbackReturningInt(_ body: () -> Int) -> Int { body() }
+
+// The code of a default argument generator is emitted with the section of the
+// function it belongs to, so a closure in a default argument belongs there too.
+@section("__TEXT,boot")
+func withDefaultArgument(callback: () -> Int = { 0 }) {}
+
+// A synthesized accessor that provides read-only access infers its section from
+// an explicitly-written accessor that provides read-only access, and likewise
+// for the accessors that write.
+struct AccessorInference {
+  var viaCoroutines: Int {
+    @section("__TEXT,boot") _read { yield 0 }
+    @section("__TEXT,boot2") _modify { var x = 0; yield &x }
+  }
+
+  var viaGetSet: Int {
+    @section("__TEXT,boot") get { 0 }
+    @section("__TEXT,boot2") set {}
+  }
+
+  // '@section(default)' on the explicitly-written accessor suppresses the
+  // inference for the synthesized accessors of the same flavor.
+  var suppressed: Int {
+    @section("__TEXT,boot") get { 0 }
+    @section(default) set {}
+  }
+
+  // The property observers can carry a '@section', which is then used for the
+  // 'set' that the implementation synthesizes.
+  var observedDidSet: Int = 0 {
+    @section("__TEXT,boot") didSet {}
+  }
+
+  var observedWillSet: Int = 0 {
+    @section("__TEXT,boot2") willSet {}
+  }
+}
+
+// The section applies to initializers and deinitializers as well.
+class BootConfig {
+  @section("__TEXT,boot") init() {}
+  @section("__TEXT,boot") deinit {}
+}
+
+// SIL: sil hidden [section "__TEXT,boot"] @$s17section_functions11genericBootyxxlF
+// SIL: sil hidden [section "__TEXT,boot"] @$s17section_functions7GenericV6memberyyF
+
+// SIL: sil hidden [section "__TEXT,boot"] @$s17section_functions22firmwareBootEntrypointyyF
+// SIL: sil private [section "__TEXT,boot"] @$s17section_functions22firmwareBootEntrypointyyF6helperL_yyF
+// SIL: sil private [section "__TEXT,boot"] @$s17section_functions22firmwareBootEntrypointyyFyyXEfU_
+// SIL: sil private [section "__TEXT,boot"] @$s17section_functions22firmwareBootEntrypointyyFyyXEfU_yyXEfU_
+// SIL: sil private @$s17section_functions22firmwareBootEntrypointyyF03notD0L_yyF
+// SIL: sil private @$s17section_functions22firmwareBootEntrypointyyFyyXEfU0_
+// SIL: sil private [section "__TEXT,boot2"] @$s17section_functions22firmwareBootEntrypointyyF9elsewhereL_yyF
+// SIL: sil private [section "__TEXT,boot2"] @$s17section_functions22firmwareBootEntrypointyyFyyXEfU1_
+
+// SIL: sil hidden [section "__TEXT,boot"] @$s17section_functions13withLocalTypeyyF
+// SIL: sil private @$s17section_functions13withLocalTypeyyF0D0L_V6memberyyF
+// SIL: sil private @$s17section_functions13withLocalTypeyyF0D0L_V8propertySivg
+// SIL: sil private [section "__TEXT,boot"] @$s17section_functions13withLocalTypeyyF13localPropertyL_Sivg
+
+// SIL: sil hidden [global_init] @$s17section_functions14storedVariableSivau
+// SIL: sil private @$s17section_functions19initializedVariableSivpfiSiyXEfU_
+
+// Both the default argument generator and the closure written inside it.
+// SIL: sil hidden [section "__TEXT,boot"] @$s17section_functions19withDefaultArgument8callbackySiyXE_tFfA_
+// SIL: sil private [section "__TEXT,boot"] @$s17section_functions19withDefaultArgument8callbackySiyXE_tFfA_SiycfU_
+
+// The synthesized 'get' comes from '_read', the synthesized 'set' from
+// '_modify'.
+// SIL: sil hidden [section "__TEXT,boot"] @$s17section_functions17AccessorInferenceV13viaCoroutinesSivr
+// SIL: sil hidden [section "__TEXT,boot2"] @$s17section_functions17AccessorInferenceV13viaCoroutinesSivM
+// SIL: sil hidden [transparent] [section "__TEXT,boot"] @$s17section_functions17AccessorInferenceV13viaCoroutinesSivg
+// SIL: sil hidden [transparent] [section "__TEXT,boot2"] @$s17section_functions17AccessorInferenceV13viaCoroutinesSivs
+
+// The synthesized '_modify' comes from 'set'.
+// SIL: sil hidden [section "__TEXT,boot"] @$s17section_functions17AccessorInferenceV9viaGetSetSivg
+// SIL: sil hidden [section "__TEXT,boot2"] @$s17section_functions17AccessorInferenceV9viaGetSetSivs
+// SIL: sil hidden [transparent] [section "__TEXT,boot2"] @$s17section_functions17AccessorInferenceV9viaGetSetSivM
+
+// SIL: sil hidden [section "__TEXT,boot"] @$s17section_functions17AccessorInferenceV10suppressedSivg
+// SIL: sil hidden @$s17section_functions17AccessorInferenceV10suppressedSivs
+// SIL: sil hidden [transparent] @$s17section_functions17AccessorInferenceV10suppressedSivM
+
+// The synthesized 'set' and '_modify' come from 'didSet'.
+// SIL: sil private [section "__TEXT,boot"] @$s17section_functions17AccessorInferenceV14observedDidSetSivW
+// SIL: sil hidden @$s17section_functions17AccessorInferenceV14observedDidSetSivg
+// SIL: sil hidden [section "__TEXT,boot"] @$s17section_functions17AccessorInferenceV14observedDidSetSivs
+// SIL: sil hidden [section "__TEXT,boot"] @$s17section_functions17AccessorInferenceV14observedDidSetSivM
+
+// The synthesized 'set' and '_modify' come from 'willSet'.
+// SIL: sil private [section "__TEXT,boot2"] @$s17section_functions17AccessorInferenceV15observedWillSetSivw
+// SIL: sil hidden [transparent] @$s17section_functions17AccessorInferenceV15observedWillSetSivg
+// SIL: sil hidden [section "__TEXT,boot2"] @$s17section_functions17AccessorInferenceV15observedWillSetSivs
+// SIL: sil hidden [transparent] [section "__TEXT,boot2"] @$s17section_functions17AccessorInferenceV15observedWillSetSivM
+
+// SIL: sil hidden [exact_self_class] [section "__TEXT,boot"] @$s17section_functions10BootConfigCACycfC
+// SIL: sil hidden [section "__TEXT,boot"] @$s17section_functions10BootConfigCACycfc
+// SIL: sil hidden [section "__TEXT,boot"] @$s17section_functions10BootConfigCfd
+// SIL: sil hidden [section "__TEXT,boot"] @$s17section_functions10BootConfigCfD
+
+// The specialization of 'genericBoot' lands in the same section.
+// SIL-OPT: sil shared [section "__TEXT,boot"] @$s17section_functions11genericBootyxxlFSi_Tg5
+
+// IR: define {{.*}}@"$s17section_functions11genericBootyxxlF"({{.*}}section "__TEXT,boot"
+// IR: define {{.*}}@"$s17section_functions7GenericV6memberyyF"({{.*}}section "__TEXT,boot"
+// IR: define {{.*}}@"$s17section_functions22firmwareBootEntrypointyyF"({{.*}}section "__TEXT,boot"
+// IR: define {{.*}}@"$s17section_functions22firmwareBootEntrypointyyF6helperL_yyF"({{.*}}section "__TEXT,boot"
+// IR: define {{.*}}@"$s17section_functions22firmwareBootEntrypointyyFyyXEfU_"({{.*}}section "__TEXT,boot"

--- a/test/IRGen/section_main.swift
+++ b/test/IRGen/section_main.swift
@@ -5,6 +5,9 @@
 
 // The '@section' on the 'main' function of a '@main' type also applies to the
 // entry points that the compiler synthesizes for it.
+//
+// The C entry point is named 'main', except on WebAssembly, whose C ABI calls
+// it '__main_argc_argv'.
 
 #if ASYNC
 @main
@@ -16,7 +19,7 @@ struct Boot {
 // ASYNC: sil hidden [section "__TEXT,boot"] @$s12section_main4BootV0B0yyYaFZ
 // ASYNC: sil hidden [section "__TEXT,boot"] @$s12section_main4BootV5$mainyyYaFZ
 // ASYNC: sil private [section "__TEXT,boot"] @async_Main
-// ASYNC: sil [section "__TEXT,boot"] @main
+// ASYNC: sil [section "__TEXT,boot"] @{{main|__main_argc_argv}}
 #else
 @main
 struct Boot {
@@ -26,5 +29,5 @@ struct Boot {
 
 // SYNC: sil hidden [section "__TEXT,boot"] @$s12section_main4BootV0B0yyFZ
 // SYNC: sil hidden [section "__TEXT,boot"] @$s12section_main4BootV5$mainyyFZ
-// SYNC: sil [section "__TEXT,boot"] @main
+// SYNC: sil [section "__TEXT,boot"] @{{main|__main_argc_argv}}
 #endif

--- a/test/IRGen/section_main.swift
+++ b/test/IRGen/section_main.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swift-frontend -emit-sil -parse-as-library %s | %FileCheck %s --check-prefix=SYNC
+// RUN: %target-swift-frontend -emit-sil -parse-as-library -DASYNC %s | %FileCheck %s --check-prefix=ASYNC
+
+// REQUIRES: concurrency
+
+// The '@section' on the 'main' function of a '@main' type also applies to the
+// entry points that the compiler synthesizes for it.
+
+#if ASYNC
+@main
+struct Boot {
+  @section("__TEXT,boot")
+  static func main() async {}
+}
+
+// ASYNC: sil hidden [section "__TEXT,boot"] @$s12section_main4BootV0B0yyYaFZ
+// ASYNC: sil hidden [section "__TEXT,boot"] @$s12section_main4BootV5$mainyyYaFZ
+// ASYNC: sil private [section "__TEXT,boot"] @async_Main
+// ASYNC: sil [section "__TEXT,boot"] @main
+#else
+@main
+struct Boot {
+  @section("__TEXT,boot")
+  static func main() {}
+}
+
+// SYNC: sil hidden [section "__TEXT,boot"] @$s12section_main4BootV0B0yyFZ
+// SYNC: sil hidden [section "__TEXT,boot"] @$s12section_main4BootV5$mainyyFZ
+// SYNC: sil [section "__TEXT,boot"] @main
+#endif

--- a/test/SILOptimizer/section_derived_functions.swift
+++ b/test/SILOptimizer/section_derived_functions.swift
@@ -1,0 +1,52 @@
+// RUN: %target-swift-frontend -emit-sil -O -parse-as-library %s | %FileCheck %s
+
+// The functions that the optimizer derives from a function with a '@section'
+// go into the same section.
+
+public final class Box {
+  var x = 0
+}
+
+@inline(never)
+@section("__TEXT,boot")
+func deadArgument(_ b: Box, _ unused: Box) -> Int { b.x }
+
+@inline(never)
+@section("__TEXT,boot")
+func takesClosure(_ fn: () -> Int) -> Int { fn() + fn() }
+
+@inline(never)
+@section("__TEXT,boot")
+func promotesCapture(_ b: Box) -> Int {
+  var x = 1
+  @inline(never)
+  func inner() -> Int { x + b.x }
+  x = 2
+  return inner()
+}
+
+@inline(never)
+@section("__TEXT,boot")
+func generic<T: BinaryInteger>(_ value: T) -> T { value + 1 }
+
+public func driver(_ b: Box) -> Int {
+  var total = deadArgument(b, b)
+  total += takesClosure { b.x }
+  total += promotesCapture(b)
+  total += generic(b.x)
+  return total
+}
+
+// The generic specialization.
+// CHECK-DAG: sil {{.*}}[section "__TEXT,boot"] @$s25section_derived_functions7genericyxxSzRzlFSi_Tg5
+
+// The function-signature-optimized function that takes over the body of
+// 'deadArgument', as well as the thunk that is left behind.
+// CHECK-DAG: sil {{.*}}[signature_optimized_thunk] {{.*}}[section "__TEXT,boot"] @$s25section_derived_functions12deadArgumentySiAA3BoxC_ADtF
+// CHECK-DAG: sil {{.*}}[section "__TEXT,boot"] @$s25section_derived_functions12deadArgumentySiAA3BoxC_ADtFTf4nd_n
+
+// The closure-specialized version of 'takesClosure'.
+// CHECK-DAG: sil {{.*}}[section "__TEXT,boot"] @$s25section_derived_functions12takesClosureyS2iyXEF{{.*}}Tf1c_n
+
+// The capture-promoted version of 'inner'.
+// CHECK-DAG: sil {{.*}}[section "__TEXT,boot"] @$s25section_derived_functions15promotesCaptureySiAA3BoxCF5innerL_SiyFTf0sn_n

--- a/test/Serialization/attr-section.swift
+++ b/test/Serialization/attr-section.swift
@@ -1,11 +1,33 @@
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -parse-as-library -emit-module-path %t/a.swiftmodule -module-name a %s
+// RUN: %target-swift-frontend -parse-as-library -emit-module-path %t/a.swiftmodule -module-name a -emit-module-interface-path %t/a.swiftinterface -enable-library-evolution -swift-version 5 %s
 // RUN: %llvm-bcanalyzer -dump %t/a.swiftmodule | %FileCheck --check-prefix BC-CHECK --implicit-check-not UnknownCode %s
 // RUN: %target-swift-ide-test -print-module -module-to-print a -source-filename x -I %t | %FileCheck --check-prefix MODULE-CHECK %s
+// RUN: %FileCheck --check-prefix INTERFACE-CHECK %s < %t/a.swiftinterface
 
 // BC-CHECK: <Section_DECL_ATTR
 
 // MODULE-CHECK: @section("SOME_SECT") let Constant: Int
 @section("SOME_SECT")
-let Constant = 321
+public let Constant = 321
+
+// MODULE-CHECK: @section(default) func defaultSection()
+@section(default)
+public func defaultSection() {}
+
+// MODULE-CHECK: @section("SOME_TEXT_SECT") func function()
+@section("SOME_TEXT_SECT")
+public func function() {}
+
+public struct HasAccessors {
+  public var value: Int {
+    @section("SOME_TEXT_SECT") get { 0 }
+    @section("SOME_MUT_SECT") set {}
+  }
+}
+
+// The '@section' on each explicitly-written accessor round-trips; the sections
+// of the synthesized accessors are re-inferred from these.
+// INTERFACE-CHECK: public var value: Swift::Int {
+// INTERFACE-CHECK-NEXT: @section("SOME_TEXT_SECT") get
+// INTERFACE-CHECK-NEXT: @section("SOME_MUT_SECT") set


### PR DESCRIPTION
Implement https://github.com/section for functions as spelled out in the proposal, which includes:

* Inference rules for https://github.com/section on local functions/closures, including `@section(default)` to stop inference
* Support for https://github.com/section on closures
* Propagation of https://github.com/section to async funclets, generic specializations, etc.
* Lifting restrictions on https://github.com/section for generic functions (not variables)

Tracked by rdar://178898017.