### PR TITLE
wasm: Emit custom sections for `@section(".custom_section.*")` globals

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -1362,5 +1362,11 @@ ERROR(invalid_multiple_return_borrow_accessor, none,
 ERROR(unsupported_borrow_abstraction, none,
       "cannot witness borrow requirement for result type %0",
       (Type))
+
+// WebAssembly custom sections
+ERROR(wasm_custom_section_not_addressable, none,
+      "cannot reference %0 placed in a WebAssembly custom section; a custom "
+      "section has no address at runtime and cannot be read or written",
+      (const ValueDecl *))
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/SIL/SILGlobalVariable.h
+++ b/include/swift/SIL/SILGlobalVariable.h
@@ -182,6 +182,17 @@ public:
   StringRef section() const { return Section; }
   void setSection(StringRef value) { Section = value; }
 
+  /// The @section name prefix that, on WebAssembly, requests emission into a
+  /// custom section rather than an ordinary data segment.
+  static StringRef getWasmCustomSectionPrefix() { return ".custom_section."; }
+
+  /// Whether \p section (a @section name) requests a WebAssembly custom section,
+  /// i.e. it has the `.custom_section.` prefix. Combine with a Wasm-target check
+  /// at the use site (see \c isWasmCustomSection).
+  static bool isWasmCustomSectionName(StringRef section) {
+    return section.starts_with(getWasmCustomSectionPrefix());
+  }
+
   void setDeclaration(bool isD) { IsDeclaration = isD; }
 
   /// True if this is a definition of the variable.

--- a/lib/IRGen/GenConstant.cpp
+++ b/lib/IRGen/GenConstant.cpp
@@ -514,3 +514,27 @@ void ConstantAggregateBuilderBase::addUniqueHash(StringRef data) {
   auto truncHash = llvm::ArrayRef(rawHash).slice(0, NumBytes_UniqueHash);
   add(llvm::ConstantDataArray::get(IGM().getLLVMContext(), truncHash));
 }
+
+bool irgen::tryFlattenConstantBytes(IRGenModule &IGM, llvm::Constant *C,
+                                    llvm::SmallVectorImpl<char> &bytes) {
+  const llvm::DataLayout &DL = IGM.DataLayout;
+  uint64_t size = DL.getTypeAllocSize(C->getType());
+  bytes.reserve(bytes.size() + size);
+  for (uint64_t offset = 0; offset < size; ++offset) {
+    llvm::Constant *byte = llvm::ConstantFoldLoadFromConst(
+        C, IGM.Int8Ty, llvm::APInt(64, offset), DL);
+    if (!byte)
+      return false;
+    if (auto *intByte = dyn_cast<llvm::ConstantInt>(byte)) {
+      bytes.push_back(static_cast<char>(intByte->getZExtValue()));
+    } else if (isa<llvm::UndefValue>(byte)) {
+      // Padding (or otherwise-poison) bytes: emit as zero for determinism.
+      bytes.push_back(0);
+    } else {
+      // A byte we can't resolve to a concrete value, e.g. one that overlaps a
+      // relocatable pointer. Custom sections can't carry relocations.
+      return false;
+    }
+  }
+  return true;
+}

--- a/lib/IRGen/GenConstant.h
+++ b/lib/IRGen/GenConstant.h
@@ -42,6 +42,15 @@ Explosion emitConstantValue(IRGenModule &IGM, SILValue value,
 /// containing constant values.
 llvm::Constant *emitConstantObject(IRGenModule &IGM, ObjectInst *OI,
                                    StructLayout *ClassLayout);
+
+/// Flatten a constant into its in-memory byte representation, appending the
+/// bytes to \p bytes. Reuses LLVM's own layout logic (endianness, padding,
+/// element stride) by reading each byte back out of \p C. Padding bytes are
+/// emitted as zero. Returns false if any byte cannot be determined statically
+/// (e.g. the constant contains a relocatable pointer), in which case \p bytes
+/// is left in an unspecified state.
+bool tryFlattenConstantBytes(IRGenModule &IGM, llvm::Constant *C,
+                             llvm::SmallVectorImpl<char> &bytes);
 }
 }
 

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2744,6 +2744,53 @@ void IRGenModule::emitGlobalDecl(Decl *D) {
   llvm_unreachable("bad decl kind!");
 }
 
+/// The @section name prefix that, on WebAssembly, requests emission into a
+/// Wasm custom section instead of an ordinary data segment. This mirrors the
+/// convention understood by LLVM's Wasm assembly parser and object writer.
+static const StringRef WasmCustomSectionPrefix = ".custom_section.";
+
+/// Whether \p section is an @section name that requests a WebAssembly custom
+/// section (i.e. the target is Wasm and the name has the `.custom_section.`
+/// prefix). Such sections are emitted via `wasm.custom_sections` module
+/// metadata rather than as an ordinary section on a global.
+static bool isWasmCustomSectionName(IRGenModule &IGM, StringRef section) {
+  return IGM.Triple.isWasm() && section.starts_with(WasmCustomSectionPrefix);
+}
+
+bool IRGenModule::tryEmitWasmCustomSection(SILGlobalVariable *var) {
+  // A `.custom_section.`-prefixed @section name on WebAssembly is emitted as a
+  // Wasm custom section holding the global's constant bytes. This is metadata,
+  // not an addressable global, so no `llvm::GlobalVariable` is created for it.
+  if (!var->isDefinition() || var->isInitializedObject() ||
+      !isWasmCustomSectionName(*this, var->section()))
+    return false;
+
+  auto *initInst = dyn_cast_or_null<SingleValueInstruction>(
+      var->getStaticInitializerValue());
+  if (!initInst)
+    return false;
+
+  Explosion initExp = emitConstantValue(*this, initInst);
+  llvm::Constant *initVal = getConstantValue(std::move(initExp),
+                                             /*paddingBytes=*/0);
+  llvm::SmallVector<char, 64> bytes;
+  if (!tryFlattenConstantBytes(*this, initVal, bytes))
+    // The initializer isn't a plain byte blob (e.g. it embeds a relocatable
+    // pointer, which a Wasm custom section cannot represent). Fall back to
+    // emitting it as an ordinary global.
+    return false;
+
+  StringRef name = var->section().drop_front(WasmCustomSectionPrefix.size());
+  auto &ctx = getLLVMContext();
+  llvm::Metadata *entry[] = {
+      llvm::MDString::get(ctx, name),
+      llvm::MDString::get(ctx, StringRef(bytes.data(), bytes.size())),
+  };
+  Module.getOrInsertNamedMetadata("wasm.custom_sections")
+      ->addOperand(llvm::MDNode::get(ctx, entry));
+  return true;
+}
+
 Address IRGenModule::getAddrOfSILGlobalVariable(SILGlobalVariable *var,
                                                 const TypeInfo &ti,
                                                 ForDefinition_t forDefinition) {

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2744,25 +2744,13 @@ void IRGenModule::emitGlobalDecl(Decl *D) {
   llvm_unreachable("bad decl kind!");
 }
 
-/// The @section name prefix that, on WebAssembly, requests emission into a
-/// Wasm custom section instead of an ordinary data segment. This mirrors the
-/// convention understood by LLVM's Wasm assembly parser and object writer.
-static const StringRef WasmCustomSectionPrefix = ".custom_section.";
-
-/// Whether \p section is an @section name that requests a WebAssembly custom
-/// section (i.e. the target is Wasm and the name has the `.custom_section.`
-/// prefix). Such sections are emitted via `wasm.custom_sections` module
-/// metadata rather than as an ordinary section on a global.
-static bool isWasmCustomSectionName(IRGenModule &IGM, StringRef section) {
-  return IGM.Triple.isWasm() && section.starts_with(WasmCustomSectionPrefix);
-}
-
 bool IRGenModule::tryEmitWasmCustomSection(SILGlobalVariable *var) {
   // A `.custom_section.`-prefixed @section name on WebAssembly is emitted as a
   // Wasm custom section holding the global's constant bytes. This is metadata,
   // not an addressable global, so no `llvm::GlobalVariable` is created for it.
   if (!var->isDefinition() || var->isInitializedObject() ||
-      !isWasmCustomSectionName(*this, var->section()))
+      !Triple.isWasm() ||
+      !SILGlobalVariable::isWasmCustomSectionName(var->section()))
     return false;
 
   auto *initInst = dyn_cast_or_null<SingleValueInstruction>(
@@ -2780,7 +2768,8 @@ bool IRGenModule::tryEmitWasmCustomSection(SILGlobalVariable *var) {
     // emitting it as an ordinary global.
     return false;
 
-  StringRef name = var->section().drop_front(WasmCustomSectionPrefix.size());
+  StringRef name = var->section().drop_front(
+      SILGlobalVariable::getWasmCustomSectionPrefix().size());
   auto &ctx = getLLVMContext();
   llvm::Metadata *entry[] = {
       llvm::MDString::get(ctx, name),

--- a/lib/IRGen/GenInit.cpp
+++ b/lib/IRGen/GenInit.cpp
@@ -54,6 +54,11 @@ void IRGenModule::emitSILGlobalVariable(SILGlobalVariable *var) {
     return;
   }
 
+  // A WebAssembly `@section(".custom_section.*")` global becomes a Wasm custom
+  // section (metadata only), with no addressable global variable.
+  if (tryEmitWasmCustomSection(var))
+    return;
+
   /// Create the global variable.
   getAddrOfSILGlobalVariable(var, ti,
                      var->isDefinition() ? ForDefinition : NotForDefinition);

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1725,6 +1725,12 @@ public:
   void maybeEmitOpaqueTypeDecl(OpaqueTypeDecl *D);
 
   void emitSILGlobalVariable(SILGlobalVariable *gv);
+
+  /// If \p var is a WebAssembly `@section(".custom_section.*")` global, emit its
+  /// constant bytes into a Wasm custom section via `wasm.custom_sections` module
+  /// metadata (no `llvm::GlobalVariable` is created) and return true. Otherwise
+  /// return false, leaving the global to be emitted normally.
+  bool tryEmitWasmCustomSection(SILGlobalVariable *var);
   void emitCoverageMaps(ArrayRef<const SILCoverageMap *> Mappings);
   void emitSILFunction(SILFunction *f);
   void emitSILWitnessTable(SILWitnessTable *wt);

--- a/lib/SILGen/SILGenGlobalVariable.cpp
+++ b/lib/SILGen/SILGenGlobalVariable.cpp
@@ -15,6 +15,7 @@
 #include "ManagedValue.h"
 #include "Scope.h"
 #include "swift/AST/ASTMangler.h"
+#include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/GenericSignature.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/SIL/FormalLinkage.h"
@@ -91,6 +92,13 @@ ManagedValue
 SILGenFunction::emitGlobalVariableRef(SILLocation loc, VarDecl *var,
                                       std::optional<ActorIsolation> actorIso) {
   assert(!VarLocs.count(var));
+
+  // A WebAssembly `.custom_section.` global is emitted as a custom section
+  // (metadata) with no runtime address, so it cannot be read or written.
+  if (auto *sectionAttr = var->getAttrs().getAttribute<SectionAttr>())
+    if (SGM.M.getASTContext().LangOpts.Target.isWasm() &&
+        SILGlobalVariable::isWasmCustomSectionName(sectionAttr->Name))
+      SGM.diagnose(loc, diag::wasm_custom_section_not_addressable, var);
   if (var->isLazilyInitializedGlobal()) {
     // Call the global accessor to get the variable's address.
     SILFunction *accessorFn = SGM.getFunction(
@@ -200,7 +208,17 @@ struct GenGlobalAccessors : public PatternVisitor<GenGlobalAccessors>
 
   // When we see a variable binding, emit its global accessor.
   void visitNamedPattern(NamedPattern *P) {
-    SGM.emitGlobalAccessor(P->getDecl(), OnceToken, OnceFunc);
+    auto *var = P->getDecl();
+    // On WebAssembly, a `.custom_section.`-prefixed @section global is emitted
+    // as a custom section (metadata) with no runtime address, so it has no
+    // addressable storage to accessor into. Emitting a global accessor would
+    // reference a global that is never defined and fail to link; any attempt to
+    // read or write the global is instead diagnosed at the use site.
+    if (auto *sectionAttr = var->getAttrs().getAttribute<SectionAttr>())
+      if (SGM.M.getASTContext().LangOpts.Target.isWasm() &&
+          SILGlobalVariable::isWasmCustomSectionName(sectionAttr->Name))
+        return;
+    SGM.emitGlobalAccessor(var, OnceToken, OnceFunc);
   }
 
 #define INVALID_PATTERN(Id, Parent) \

--- a/test/IRGen/section_wasm_custom_section.sil
+++ b/test/IRGen/section_wasm_custom_section.sil
@@ -1,0 +1,44 @@
+// RUN: %swift_frontend_plain -parse-stdlib -target wasm32-unknown-wasi -module-name main -emit-ir %s -o - | %FileCheck %s
+
+// REQUIRES: CODEGENERATOR=WebAssembly
+
+// On WebAssembly, a `.custom_section.`-prefixed @section name is emitted as a
+// real Wasm custom section via `wasm.custom_sections` module metadata (with the
+// prefix stripped and the constant's bytes as contents). Because a custom
+// section is metadata rather than an addressable global, no LLVM global variable
+// is emitted for it. A plain section name is unchanged (an ordinary data segment).
+
+sil_stage canonical
+
+import Builtin
+
+struct T {
+  @_hasStorage var a: Builtin.Int32 { get set }
+}
+
+// A `.custom_section.`-prefixed global does not emit an addressable global at all;
+// its bytes only appear in the `wasm.custom_sections` metadata below.
+// CHECK-NOT: @g0 =
+// CHECK-NOT: @g1 =
+sil_global hidden [used] [section ".custom_section.mysection"] @g0 : $T = {
+  %0 = integer_literal $Builtin.Int32, 42
+  %initval = struct $T (%0 : $Builtin.Int32)
+}
+
+sil_global hidden [used] [section ".custom_section.other"] @g1 : $T = {
+  %0 = integer_literal $Builtin.Int32, 1
+  %initval = struct $T (%0 : $Builtin.Int32)
+}
+
+// A plain (non-prefixed) @section name is still lowered to an ordinary data segment.
+// CHECK: @g2 = hidden global %T4main1TV <{ i32 7 }>, section "regular_data"
+sil_global hidden [used] [section "regular_data"] @g2 : $T = {
+  %0 = integer_literal $Builtin.Int32, 7
+  %initval = struct $T (%0 : $Builtin.Int32)
+}
+
+// The custom section bytes are carried as metadata: name (prefix stripped) plus
+// the constant's little-endian bytes (42 = 0x2a = '*', and 1).
+// CHECK: !wasm.custom_sections = !{![[M:[0-9]+]], ![[O:[0-9]+]]}
+// CHECK-DAG: ![[M]] = !{!"mysection", !"*\00\00\00"}
+// CHECK-DAG: ![[O]] = !{!"other", !"\01\00\00\00"}

--- a/test/IRGen/section_wasm_custom_section_e2e.swift
+++ b/test/IRGen/section_wasm_custom_section_e2e.swift
@@ -1,0 +1,19 @@
+// End-to-end check that a `.custom_section.`-prefixed @section constant survives
+// the whole pipeline from Swift source (AST) through IRGen and the linker as a
+// real Wasm custom section, and that no addressable global is emitted for it
+// (which would otherwise fail to link, since a custom section has no address).
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature CompileTimeValuesPreview -c -o %t/main.o
+// RUN: wasm-ld --no-entry --allow-undefined %t/main.o -o %t/main.wasm
+// RUN: obj2yaml %t/main.wasm | %FileCheck %s
+
+// REQUIRES: CPU=wasm32
+// REQUIRES: swift_feature_CompileTimeValuesPreview
+
+@section(".custom_section.swift_metadata")
+let metadata: InlineArray<4, UInt8> = [0xDE, 0xAD, 0xBE, 0xEF]
+
+// CHECK:      - Type:    CUSTOM
+// CHECK:        Name:    swift_metadata
+// CHECK:        Payload: DEADBEEF


### PR DESCRIPTION
For WebAssembly, lower a global whose `@section` name starts with `.custom_section.` as a real Wasm custom section instead of a data segment.

Its bytes are placed in the `wasm.custom_sections` named LLVM module metadata, which the WebAssembly `AsmPrinter` lowers into a custom section [1]. A custom section is metadata rather than an addressable global, so no `llvm::GlobalVariable` is emitted for it.

Any other `@section` name keeps its existing behavior: a data segment on Wasm, or the verbatim name on other object formats. Non-Wasm targets are unaffected.

[1]: https://github.com/swiftlang/llvm-project/blob/6f2057ffeafd4c6232d0cb7c034b77b21e133ad3/llvm/lib/Target/WebAssembly/WebAssemblyAsmPrinter.cpp#L423

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
