### PR TITLE
SILGen: route to TrivialOpaqueValueTypeLowering for trivial address-o…

### DIFF
--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2313,6 +2313,111 @@ namespace {
     }
   };
 
+  class TrivialOpaqueValueTypeLowering : public LoadableTypeLowering {
+  public:
+    TrivialOpaqueValueTypeLowering(SILType type, SILTypeProperties properties,
+                                   TypeExpansionContext forExpansion)
+        : LoadableTypeLowering(type, properties, IsNotReferenceCounted,
+                               forExpansion) {
+      assert(properties.isTrivial());
+      assert(properties.isAddressOnly());
+    }
+
+    SILValue emitLoadOfCopy(SILBuilder &B, SILLocation loc, SILValue addr,
+                            IsTake_t isTake) const override {
+      return emitLoad(B, loc, addr, LoadOwnershipQualifier::Trivial);
+    }
+
+    void emitStoreOfCopy(SILBuilder &B, SILLocation loc, SILValue value,
+                         SILValue addr,
+                         IsInitialization_t isInit) const override {
+      emitStore(B, loc, value, addr, StoreOwnershipQualifier::Trivial);
+    }
+
+    void emitStore(SILBuilder &B, SILLocation loc, SILValue value,
+                   SILValue addr, StoreOwnershipQualifier qual) const override {
+      if (B.getFunction().hasOwnership()) {
+        B.createStore(loc, value, addr, StoreOwnershipQualifier::Trivial);
+        return;
+      }
+      B.createStore(loc, value, addr, StoreOwnershipQualifier::Unqualified);
+    }
+
+    SILValue emitLoad(SILBuilder &B, SILLocation loc, SILValue addr,
+                      LoadOwnershipQualifier qual) const override {
+      if (B.getFunction().hasOwnership())
+        return B.createLoad(loc, addr, LoadOwnershipQualifier::Trivial);
+      return B.createLoad(loc, addr, LoadOwnershipQualifier::Unqualified);
+    }
+
+    void emitLoweredStore(SILBuilder &B, SILLocation loc, SILValue value,
+                          SILValue addr, StoreOwnershipQualifier qual,
+                          Lowering::TypeLowering::TypeExpansionKind
+                              expansionKind) const override {
+      if (B.getFunction().hasOwnership()) {
+        B.createStore(loc, value, addr, StoreOwnershipQualifier::Trivial);
+        return;
+      }
+      B.createStore(loc, value, addr, StoreOwnershipQualifier::Unqualified);
+    }
+
+    SILValue emitLoweredLoad(SILBuilder &B, SILLocation loc, SILValue addr,
+                             LoadOwnershipQualifier qual,
+                             TypeExpansionKind) const override {
+      if (B.getFunction().hasOwnership())
+        return B.createLoad(loc, addr, LoadOwnershipQualifier::Trivial);
+      return B.createLoad(loc, addr, LoadOwnershipQualifier::Unqualified);
+    }
+
+    void emitDestroyAddress(SILBuilder &B, SILLocation loc,
+                            SILValue addr) const override {
+      // Trivial
+    }
+
+    void
+    emitLoweredDestroyValue(SILBuilder &B, SILLocation loc, SILValue value,
+                            TypeExpansionKind loweringStyle) const override {
+      // Trivial
+    }
+
+    SILValue emitLoweredCopyValue(SILBuilder &B, SILLocation loc,
+                                  SILValue value,
+                                  TypeExpansionKind style) const override {
+      // Trivial
+      return value;
+    }
+
+    SILValue emitCopyValue(SILBuilder &B, SILLocation loc,
+                           SILValue value) const override {
+      // Trivial
+      return value;
+    }
+
+    void emitCopyInto(SILBuilder &B, SILLocation loc, SILValue src,
+                      SILValue dest, IsTake_t isTake,
+                      IsInitialization_t isInit) const override {
+      if (B.getFunction().hasLoweredAddresses()) {
+        B.createCopyAddr(loc, src, dest, isTake, isInit);
+      } else {
+        SILValue value = emitLoad(B, loc, src, LoadOwnershipQualifier::Trivial);
+        emitStore(B, loc, value, dest, StoreOwnershipQualifier::Trivial);
+      }
+    }
+
+    void emitDestroyValue(SILBuilder &B, SILLocation loc,
+                          SILValue value) const override {
+      if (B.getFunction().hasOwnership() &&
+          B.getModule().getStage() == SILStage::Raw && value->isFromVarDecl()) {
+        // Do not use destroy_value for trivial values. The lifetime introducer
+        // may be implicitly copied and used outside of its original scope,
+        // which violates the invariants of destroy_value.
+        B.createExtendLifetime(loc, value);
+        return;
+      }
+      // Trivial
+    }
+  };
+
   /// Build the appropriate TypeLowering subclass for the given type,
   /// which is assumed to already have been lowered.
   class LowerType
@@ -2387,6 +2492,10 @@ namespace {
       // derived per query by TypeLowering::getLoweredType(bool) from the
       // caller's lowered-addresses state, rather than baked in here.
       auto silType = SILType::getPrimitiveObjectType(type);
+      if (properties.isTrivial()) {
+        return new (TC)
+            TrivialOpaqueValueTypeLowering(silType, properties, Expansion);
+      }
       return new (TC) OpaqueValueTypeLowering(silType, properties, Expansion);
     }
     

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -4068,7 +4068,8 @@ void UseRewriter::visitStoreInst(StoreInst *storeInst) {
   if (qualifier == StoreOwnershipQualifier::Init)
     isInit = IsInitialization;
   else {
-    assert(qualifier == StoreOwnershipQualifier::Assign);
+    assert(qualifier == StoreOwnershipQualifier::Assign ||
+           qualifier == StoreOwnershipQualifier::Trivial);
     isInit = IsNotInitialization;
   }
   rewriteStore(storeInst->getSrc(), storeInst->getDest(), isInit);
@@ -4485,7 +4486,9 @@ protected:
     if (loadInst->getOwnershipQualifier() == LoadOwnershipQualifier::Take)
       isTake = IsTake;
     else {
-      assert(loadInst->getOwnershipQualifier() == LoadOwnershipQualifier::Copy);
+      assert(
+          loadInst->getOwnershipQualifier() == LoadOwnershipQualifier::Copy ||
+          loadInst->getOwnershipQualifier() == LoadOwnershipQualifier::Trivial);
       isTake = IsNotTake;
     }
     // Dummy loads are already mapped to their storage address.

--- a/test/Interpreter/borrow_layout.swift
+++ b/test/Interpreter/borrow_layout.swift
@@ -40,6 +40,48 @@
 // RUN:   %s
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out 2>&1 | %FileCheck %s
+//
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking \
+// RUN:   -Xfrontend -enable-sil-opaque-values \
+// RUN:   -enable-experimental-feature BuiltinModule \
+// RUN:   -enable-experimental-feature Lifetimes \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend LoanPointer \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend OptionalLoanPointer \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend Optional2LoanPointer \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend LoanNPEnum \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend OptionalLoanNPEnum \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend Optional2LoanNPEnum \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend LoanAFD \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend OptionalLoanAFD \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend Optional2LoanAFD \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend LoanNBB \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend OptionalLoanNBB \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend Optional2LoanNBB \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend LoanNotQuiteBig \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend OptionalLoanNotQuiteBig \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend Optional2LoanNotQuiteBig \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend LoanAlmostBig \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend OptionalLoanAlmostBig \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend Optional2LoanAlmostBig \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend LoanBig \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend OptionalLoanBig \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend Optional2LoanBig \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend LoanGrainy \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend OptionalLoanGrainy \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend Optional2LoanGrainy \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend LoanArray1 \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend OptionalLoanArray1 \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend Optional2LoanArray1 \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend LoanArray3 \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend OptionalLoanArray3 \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend Optional2LoanArray3 \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend LoanString \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend OptionalLoanString \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend Optional2LoanString \
+// RUN:   -o %t/a-opaque-values.out \
+// RUN:   %s
+// RUN: %target-codesign %t/a-opaque-values.out
+// RUN: %target-run %t/a-opaque-values.out 2>&1 | %FileCheck %s
 
 // Type layout verifier is only compiled into the runtime in asserts builds.
 // REQUIRES: swift_stdlib_asserts
@@ -50,7 +92,6 @@
 //
 // REQUIRES: swift_feature_Lifetimes
 // REQUIRES: swift_feature_BuiltinModule
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 // CHECK-NOT: Type verification
 

--- a/test/Interpreter/element_archetype_captures.swift
+++ b/test/Interpreter/element_archetype_captures.swift
@@ -1,7 +1,7 @@
 // RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift(-Xfrontend -enable-sil-opaque-values)
 
 // REQUIRES: executable_test
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 func callee<X: P1, T: P2, U: P3, V: P4>(x: X, t: T, u: U, v: V)
     -> (any P1, any P2, any P3, any P4) {

--- a/test/Interpreter/variadic_generic_captures.swift
+++ b/test/Interpreter/variadic_generic_captures.swift
@@ -1,8 +1,8 @@
 // RUN: %target-run-simple-swift(-Xfrontend -disable-concrete-type-metadata-mangled-name-accessors)
 // RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift(-Xfrontend -enable-sil-opaque-values)
 
 // REQUIRES: executable_test
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 

--- a/test/Interpreter/variadic_generic_func_types.swift
+++ b/test/Interpreter/variadic_generic_func_types.swift
@@ -1,7 +1,7 @@
 // RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift(-Xfrontend -enable-sil-opaque-values)
 
 // REQUIRES: executable_test
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 

--- a/test/Interpreter/variadic_generic_opaque_type.swift
+++ b/test/Interpreter/variadic_generic_opaque_type.swift
@@ -7,12 +7,16 @@
 // RUN: %target-codesign %t/main.out
 //
 // RUN: %target-run %t/main.out %t/%target-library-name(variadic_generic_opaque_type_other)
+//
+// RUN: %target-build-swift %s -Xfrontend -enable-sil-opaque-values -I %t -o %t/main-opaque-values.out -L %t %target-rpath(%t) -lvariadic_generic_opaque_type_other
+// RUN: %target-codesign %t/main-opaque-values.out
+//
+// RUN: %target-run %t/main-opaque-values.out %t/%target-library-name(variadic_generic_opaque_type_other)
 
 // REQUIRES: executable_test
 
 // This test needs a Swift 5.9 runtime or newer.
 // UNSUPPORTED: back_deployment_runtime
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import variadic_generic_opaque_type_other
 import StdlibUnittest

--- a/test/SILGen/builtin_borrow.swift
+++ b/test/SILGen/builtin_borrow.swift
@@ -1,7 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -module-name ResilientTypes -emit-module-path %t/ResilientTypes.swiftmodule -enable-library-evolution %S/Inputs/builtin_borrow_ResilientTypes.swift
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -module-name main -enable-experimental-feature BuiltinModule -enable-experimental-feature AddressableTypes -enable-experimental-feature Lifetimes -enable-experimental-feature RawLayout -I %t %s
+// RUN: %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -module-name main -enable-experimental-feature BuiltinModule -enable-experimental-feature AddressableTypes -enable-experimental-feature Lifetimes -enable-experimental-feature RawLayout -I %t %s
 
 // RUN: %target-swift-emit-silgen -module-name main -enable-experimental-feature BuiltinModule -enable-experimental-feature AddressableTypes -enable-experimental-feature Lifetimes -enable-experimental-feature RawLayout -I %t %s | %FileCheck %s
 // RUN: %target-swift-emit-sil -module-name main -enable-experimental-feature BuiltinModule -enable-experimental-feature AddressableTypes -enable-experimental-feature Lifetimes -enable-experimental-feature RawLayout -I %t %s | %FileCheck --check-prefix=CHECK-POST-CLEANUP %s

--- a/test/SILGen/builtin_vector.swift
+++ b/test/SILGen/builtin_vector.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-emit-silgen -Xllvm -sil-print-types -disable-experimental-parser-round-trip -disable-availability-checking -enable-experimental-feature BuiltinModule %s | %FileCheck %s
 
+// RUN: %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -Xllvm -sil-print-types -disable-experimental-parser-round-trip -disable-availability-checking -enable-experimental-feature BuiltinModule %s
 // REQUIRES: swift_feature_BuiltinModule
 
 import Builtin


### PR DESCRIPTION
Under -enable-sil-opaque-values, type lowering crashes (assertion !properties.isTrivial()) while lowering a type that is trivial yet address-only. This happens for Builtin.Borrow<T> when the referent's layout is abstracted/resilient (ie: builtin_borrow, builtin_borrowat_unimplemented), and for a struct wrapping Builtin.FixedArray<N, Int> with a generic (dependent) count N (ie: builtin_vector).

Example reproducer 1:
```
// repro.swift
import Builtin
import ResilientTypes

func resilient(_: Builtin.Borrow<Resilient>) {} // address
```

Example reproducer 2:
```
// repro.swift
import Builtin

struct MyVector<let N: Int, T: ~Copyable>: ~Copyable {
    var storage: Builtin.FixedArray<N, T>
}
extension MyVector: Copyable where T: Copyable {}

func trivial_dep<let N: Int>(a: MyVector<N, Int>)
    -> (MyVector<N, Int>, MyVector<N, Int>)
{
    return (a, a)
}
```

command:
`swift-frontend -emit-sil -sil-verify-all -enable-sil-opaque-values -module-name main -enable-experimental-feature BuiltinModule [for borrow tests: -enable-experimental-feature AddressableTypes -enable-experimental-feature Lifetimes] repro.swift`

Resolves rdar://180980115.