### PR TITLE
[cxx-interop] Import lifetimebound functions returning Escapable as unsafe

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4470,6 +4470,9 @@ namespace {
       auto retType = decl->getReturnType();
       auto warnForEscapableReturnType = [&] {
         if (isEscapableAnnotatedType(retType.getTypePtr())) {
+          // Swift drops lifetime dependencies on Escapable targets, so this
+          // annotation is not enforced. Import the API as @unsafe.
+          hasSkippedLifetimeAnnotation = true;
           Impl.addImportDiagnostic(
               decl,
               Diagnostic(diag::return_escapable_with_lifetimebound,

--- a/test/Interop/Cxx/class/safe-interop-mode.swift
+++ b/test/Interop/Cxx/class/safe-interop-mode.swift
@@ -87,6 +87,11 @@ private:
 
 View returnsViewLifetimebound(const Owner &o [[clang::lifetimebound]]);
 
+// A lifetime dependency whose target is Escapable is dropped, so the annotation
+// is not enforced: import the function as unsafe.
+// expected-warning@+1{{the returned type 'Owner' is annotated as escapable; it cannot have lifetime dependencies}}
+Owner returnsOwnerLifetimebound(const View &v [[clang::lifetimebound]]);
+
 __attribute__((swift_attr("@lifetime(borrow o)")))
 // expected-warning@+1{{the returned type 'View' is annotated as non-escapable; its lifetime dependencies must be annotated}}
 View returnsViewHandWrittenLifetime(const Owner &o);
@@ -262,6 +267,11 @@ func useAnnotatedLifetimeDependency(o: Owner) {
     let _ = returnsViewLifetimebound(o)
     let _ = returnsViewHandWrittenLifetime(o)
     let _ = returnsViewAuditedSafe(o)
+}
+
+func useEscapableLifetimeDependency(v: View) {
+    // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+    let _ = returnsOwnerLifetimebound(v) // expected-note{{reference to unsafe global function 'returnsOwnerLifetimebound'}}
 }
 
 @available(SwiftStdlib 5.8, *)


### PR DESCRIPTION
A C++ function that annotates a parameter `[[clang::lifetimebound]]` and returns a `SWIFT_ESCAPABLE` type already produced an import-time warning, but it was still imported as a safe API. Swift drops lifetime dependencies whose target is `Escapable`, so the annotation was not enforced anywhere. This treats the dropped annotation like the other lifetime annotations we cannot faithfully represent and imports the function as `@unsafe`.

rdar://183165440