### PR TITLE
[ASTDumper] Close type_attributed, type_error, and using_decl nodes

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2231,6 +2231,7 @@ namespace {
           UD->getSpecifiedAttributes(),
           [&](auto *attr, Label label) { printRec(attr, Ctx, DC, label); },
           Label::optional("specified_attrs"));
+      printFoot();
     }
 
     void visitExtensionDecl(ExtensionDecl *ED, Label label) {
@@ -4748,6 +4749,7 @@ public:
     printCommon("type_error", label);
     if (auto *originalExpr = T->getOriginalExpr())
       printRec(originalExpr, Label::optional("original_expr"));
+    printFoot();
   }
 
   void visitAttributedTypeRepr(AttributedTypeRepr *T, Label label) {
@@ -4755,6 +4757,7 @@ public:
     printFieldQuotedRaw([&](raw_ostream &OS) { T->printAttrs(OS); },
                         Label::always("attrs"));
     printRec(T->getTypeRepr(), Label::optional("type_repr"));
+    printFoot();
   }
 
   void visitDeclRefTypeRepr(DeclRefTypeRepr *T, Label label) {

--- a/test/Frontend/dump-parse-attributed-type.swift
+++ b/test/Frontend/dump-parse-attributed-type.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend -dump-parse %s | %FileCheck %s
+
+// https://github.com/swiftlang/swift/issues/91094
+// The S-expression dumper used to drop the closing parenthesis of
+// `type_attributed` nodes (`visitAttributedTypeRepr` never called
+// `printFoot()`), so any dump containing an attributed type was
+// unbalanced and consumers that match parentheses silently reparented
+// every node printed after it. `type_error` and `using_decl` had the
+// same omission.
+
+let f: (@escaping (Int) -> Void) -> Void = { _ in }
+
+// CHECK: (pattern_named "f"
+// CHECK: (type_function
+// CHECK-NEXT: (type_tuple
+// CHECK-NEXT: (type_attributed attrs="@escaping "
+// CHECK-NEXT: (type_function
+// CHECK-NEXT: (type_tuple
+// CHECK-NEXT: (type_unqualified_ident id="Int" unbound))
+// The attributed node must close here: its own paren, after the inner
+// function type's — four closes returns to the parameter tuple's level.
+// CHECK-NEXT: (type_unqualified_ident id="Void" unbound)))){{$}}
+// CHECK-NEXT: (type_unqualified_ident id="Void" unbound))


### PR DESCRIPTION
`visitAttributedTypeRepr`, `visitErrorTypeRepr`, and `visitUsingDecl` printed their node head and children but never called `printFoot()`, so every attributed type reaching a dump cost the S-expression output one closing parenthesis (and the JSON output one unterminated object). Every node printed after the unclosed one is structurally reparented for any consumer that matches parentheses, and `(source_file` never closes.

Reproduction:

```swift
var f: (@escaping (Int) -> Void) -> Void = { _ in }
```

```
$ swiftc -dump-parse repro.swift | tr -cd '(' | wc -c
24
$ swiftc -dump-parse repro.swift | tr -cd ')' | wc -c
23
```

`(type_attributed attrs="@escaping "` opens and never closes; all sibling visitors end with `printFoot()`.

This PR adds the missing `printFoot()` calls to the three visitors and a lit test anchoring the closing parentheses of the attributed type. With the fix, the reproduction above emits 24/24 parentheses.

Verified locally (macOS arm64, release build): the new `test/Frontend/dump-parse-attributed-type.swift` passes, as do `Frontend/dump-parse.swift`, `Frontend/dump-parse-skip-function-body.swift`, `Frontend/dump-parse-syntactically-valid.swift`, `Frontend/ast-dump.swift`, `Frontend/ast-dump-json.swift`, and `AutoDiff/Parse/differentiable_func_type.swift` (existing `FileCheck` patterns match by substring, so the added parenthesis does not disturb them).

Resolves #91094.
