### PR TITLE
[cxx-interop] Export some Swift lifetimes as C++ lifetime annotations

### DIFF
--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -23,6 +23,7 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/GenericParamList.h"
+#include "swift/AST/LifetimeDependence.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/SwiftNameTranslation.h"
@@ -248,11 +249,26 @@ public:
       os << " SWIFT_NOESCAPE";
   }
 
-  void printInoutTypeModifier(bool cannotEscape = false) {
-    os << (languageMode == swift::OutputLanguageMode::Cxx ? " &"
-                                                          : " * _Nonnull");
+  /// Print the '&' of a parameter that is passed as a C++ reference, i.e. one
+  /// for which the callee sees the caller's object rather than a copy of it.
+  void printReferenceTypeModifier(bool cannotEscape) {
+    os << '&';
+    printedParamAsReference = true;
     printNoEscapeAttrIfNeeded(cannotEscape);
   }
+
+  void printInoutTypeModifier(bool cannotEscape = false) {
+    if (languageMode == swift::OutputLanguageMode::Cxx) {
+      os << " ";
+      printReferenceTypeModifier(cannotEscape);
+      return;
+    }
+    os << " * _Nonnull";
+    printNoEscapeAttrIfNeeded(cannotEscape);
+  }
+
+  /// Whether the type just printed for a parameter is a C++ reference.
+  bool didPrintParamAsReference() const { return printedParamAsReference; }
 
   bool printIfKnownSimpleType(const TypeDecl *typeDecl,
                               std::optional<OptionalTypeKind> optionalKind,
@@ -273,8 +289,7 @@ public:
     });
     if (!paramInfo.isInOutParam && shouldPrintOptional &&
         typeUseKind == FunctionSignatureTypeUse::ParamType) {
-      os << '&';
-      printNoEscapeAttrIfNeeded(paramInfo.cannotEscape);
+      printReferenceTypeModifier(paramInfo.cannotEscape);
     }
     if (paramInfo.isInOutParam)
       printInoutTypeModifier(paramInfo.cannotEscape);
@@ -400,8 +415,7 @@ public:
           .printPrimaryCxxTypeName(cd, moduleContext);
     });
     if (typeUseKind == FunctionSignatureTypeUse::ParamType) {
-      os << "&";
-      printNoEscapeAttrIfNeeded(paramInfo.cannotEscape);
+      printReferenceTypeModifier(paramInfo.cannotEscape);
     }
     return ClangRepresentation::representable;
   }
@@ -462,8 +476,7 @@ public:
         os << "const ";
       printOptional(optionalKind, [&]() { handler.printTypeName(decl->getASTContext(), os); });
       if (typeUseKind == FunctionSignatureTypeUse::ParamType) {
-        os << '&';
-        printNoEscapeAttrIfNeeded(paramInfo.cannotEscape);
+        printReferenceTypeModifier(paramInfo.cannotEscape);
       }
       return ClangRepresentation::representable;
     }
@@ -477,8 +490,7 @@ public:
         ClangSyntaxPrinter(decl->getASTContext(), os).printPrimaryCxxTypeName(decl, moduleContext);
         result = visitGenericArgs(genericArgs);
       });
-      os << '&';
-      printNoEscapeAttrIfNeeded(paramInfo.cannotEscape);
+      printReferenceTypeModifier(paramInfo.cannotEscape);
       return result;
     }
 
@@ -582,8 +594,7 @@ public:
     });
     // Pass a reference to the template type.
     if (isParam) {
-      os << '&';
-      printNoEscapeAttrIfNeeded(paramInfo.cannotEscape);
+      printReferenceTypeModifier(paramInfo.cannotEscape);
     }
     return ClangRepresentation::representable;
   }
@@ -619,6 +630,7 @@ private:
   const ModuleDecl *moduleContext;
   DeclAndTypePrinter &declPrinter;
   FunctionSignatureTypeUse typeUseKind;
+  bool printedParamAsReference = false;
 };
 
 /// Returns true if a reference/pointer printed for a parameter of the given
@@ -841,6 +853,21 @@ static void renameCxxParameterIfNeeded(const AbstractFunctionDecl *FD,
   }
 }
 
+/// The lifetime dependency of `FD`'s result, if it has one.
+///
+/// The sources of that dependency are the arguments whose lifetime the returned
+/// value is tied to; they are indexed by the function's parameter indices, with
+/// 'self' following the last parameter.
+static std::optional<LifetimeDependenceInfo>
+getResultLifetimeDependence(const AbstractFunctionDecl *FD) {
+  auto dependencies = FD->getLifetimeDependencies();
+  if (!dependencies)
+    return std::nullopt;
+  unsigned resultIndex =
+      FD->getParameters()->size() + (FD->isInstanceMethod() ? 1 : 0);
+  return getLifetimeDependenceFor(*dependencies, resultIndex);
+}
+
 ClangRepresentation DeclAndTypeClangFunctionPrinter::printFunctionSignature(
     const AbstractFunctionDecl *FD, const LoweredFunctionSignature &signature,
     StringRef name, Type resultTy, FunctionSignatureKind kind,
@@ -882,13 +909,15 @@ ClangRepresentation DeclAndTypeClangFunctionPrinter::printFunctionSignature(
   auto print =
       [&, this](Type ty, std::optional<OptionalTypeKind> optionalKind,
                 StringRef name, ParamTypeInfo paramInfo = {},
-                CFunctionSignatureTypePrinterModifierDelegate delegate = {})
-      -> ClangRepresentation {
+                CFunctionSignatureTypePrinterModifierDelegate delegate = {},
+                bool *printedAsReference = nullptr) -> ClangRepresentation {
     // FIXME: add support for PrintMultiPartType, see DeclAndTypePrinter::print.
     CFunctionSignatureTypePrinter typePrinter(
         functionSignatureOS, cPrologueOS, typeMapping, outputLang,
         interopContext, delegate, emittedModule, declPrinter);
     auto result = typePrinter.visit(ty, optionalKind, paramInfo);
+    if (printedAsReference)
+      *printedAsReference = typePrinter.didPrintParamAsReference();
 
     if (!name.empty()) {
       functionSignatureOS << ' ';
@@ -1115,6 +1144,25 @@ ClangRepresentation DeclAndTypeClangFunctionPrinter::printFunctionSignature(
 
   // Print out the C++ parameter types.
   auto params = FD->getParameters();
+  // Mark the arguments that the result's lifetime depends on, so that Clang's
+  // lifetime analyses can check the calls to this thunk.
+  auto resultLifetimeDependence = getResultLifetimeDependence(FD);
+  auto isLifetimeSource = [&](unsigned index, bool isPassedByReference) {
+    if (!resultLifetimeDependence)
+      return false;
+    // A scoped dependency borrows the argument's storage, which is what
+    // 'lifetimebound' means, but only if the callee sees the caller's object.
+    if (resultLifetimeDependence->checkScope(index))
+      return isPassedByReference;
+    // An inherited dependency ties the result to the lifetime the argument
+    // itself depends on, rather than to the argument's storage. That is what
+    // 'lifetimebound' means for an argument passed by value; for one passed by
+    // reference there is no way to spell it, so leave the parameter
+    // unannotated.
+    if (resultLifetimeDependence->checkInherit(index))
+      return !isPassedByReference;
+    return false;
+  };
   if (params->size()) {
     if (HasParams)
       functionSignatureOS << ", ";
@@ -1137,8 +1185,12 @@ ClangRepresentation DeclAndTypeClangFunctionPrinter::printFunctionSignature(
             llvm::raw_string_ostream os(paramName);
             os << "_" << paramIndex;
           }
-          resultingRepresentation.merge(
-              print(objTy, argKind, paramName, getParamTypeInfo(*param)));
+          bool printedAsReference = false;
+          resultingRepresentation.merge(print(objTy, argKind, paramName,
+                                              getParamTypeInfo(*param), {},
+                                              &printedAsReference));
+          if (isLifetimeSource(paramIndex - 1, printedAsReference))
+            functionSignatureOS << " SWIFT_LIFETIMEBOUND";
           ++paramIndex;
         });
     if (resultingRepresentation.isUnsupported()) {
@@ -1150,6 +1202,12 @@ ClangRepresentation DeclAndTypeClangFunctionPrinter::printFunctionSignature(
     functionSignatureOS << " const";
   if (modifiers.isNoexcept)
     functionSignatureOS << " noexcept";
+  // 'self' is the implicit object parameter of a member thunk, which always
+  // refers to the caller's object, so its annotation goes after the parameter
+  // list.
+  if (FD->isInstanceMethod() &&
+      isLifetimeSource(params->size(), /*isPassedByReference=*/true))
+    functionSignatureOS << " SWIFT_SELF_LIFETIMEBOUND";
   if (modifiers.hasSymbolUSR)
     ClangSyntaxPrinter(FD->getASTContext(), functionSignatureOS)
         .printSymbolUSRAttribute(

--- a/lib/PrintAsClang/_SwiftCxxInteroperability.h
+++ b/lib/PrintAsClang/_SwiftCxxInteroperability.h
@@ -86,6 +86,26 @@
 #define SWIFT_PRIVATE_ATTR
 #endif
 
+/// The `SWIFT_LIFETIMEBOUND` macro is applied to a parameter of an inline thunk
+/// whose lifetime the thunk's return value depends on, so that Clang's lifetime
+/// analyses can diagnose calls that let the return value outlive the argument.
+///
+/// `SWIFT_SELF_LIFETIMEBOUND` is the equivalent for the implicit object
+/// parameter of a member thunk. Clang rejects the GNU spelling of the attribute
+/// in that position, so it is only available in language modes that support the
+/// `[[...]]` spelling.
+#if defined(__cplusplus) && __cplusplus >= 201103L &&                          \
+    __has_cpp_attribute(clang::lifetimebound)
+#define SWIFT_LIFETIMEBOUND [[clang::lifetimebound]]
+#define SWIFT_SELF_LIFETIMEBOUND [[clang::lifetimebound]]
+#elif __has_attribute(lifetimebound)
+#define SWIFT_LIFETIMEBOUND __attribute__((lifetimebound))
+#define SWIFT_SELF_LIFETIMEBOUND
+#else
+#define SWIFT_LIFETIMEBOUND
+#define SWIFT_SELF_LIFETIMEBOUND
+#endif
+
 namespace swift SWIFT_PRIVATE_ATTR {
 namespace _impl {
 

--- a/test/Interop/SwiftToCxx/functions/lifetime-dependence-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/functions/lifetime-dependence-in-cxx.swift
@@ -1,0 +1,79 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name Lifetimes -enable-experimental-feature Lifetimes -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/lifetimes.h
+// RUN: %FileCheck %s < %t/lifetimes.h
+// RUN: %check-interop-cxx-header-in-clang(%t/lifetimes.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
+
+// REQUIRES: swift_feature_Lifetimes
+
+public struct Owner {
+    public var data: Int64 = 0
+    public init() {}
+}
+
+public struct View: ~Escapable {
+    var p: UnsafePointer<Int64>
+    @_lifetime(borrow o)
+    init(_ o: borrowing Owner, _ p: UnsafePointer<Int64>) { self.p = p }
+    @_lifetime(copy other)
+    init(_ other: borrowing View) { self.p = other.p }
+}
+
+@_lifetime(borrow o)
+public func borrowDefaultParam(_ o: Owner) -> View { View(o, o.address) }
+
+@_lifetime(borrow o)
+public func borrowBorrowingParam(_ o: borrowing Owner) -> View { View(o, o.address) }
+
+@_lifetime(&o)
+public func borrowInoutParam(_ o: inout Owner) -> View { View(o, o.address) }
+
+// A copy dependency ties the result to the lifetime the argument depends on,
+// not to the argument's storage; the argument is passed as a reference in C++,
+// so the dependency cannot be expressed with 'lifetimebound'.
+@_lifetime(copy v)
+public func copyDefaultParam(_ v: View) -> View { View(v) }
+
+@_lifetime(copy v)
+public func copyBorrowingParam(_ v: borrowing View) -> View { View(v) }
+
+@_lifetime(&v)
+public func borrowInoutViewParam(_ v: inout View) -> View { View(v) }
+
+@_lifetime(borrow o)
+public func borrowSecondParam(_ ignored: Int64, _ o: Owner) -> View { View(o, o.address) }
+
+extension Owner {
+    var address: UnsafePointer<Int64> {
+        withUnsafePointer(to: self) {
+            UnsafeRawPointer($0).assumingMemoryBound(to: Int64.self)
+        }
+    }
+
+    @_lifetime(borrow self)
+    public func borrowSelf() -> View { View(self, address) }
+
+    @_lifetime(&self)
+    public mutating func borrowSelfMutating() -> View { View(self, address) }
+
+    public var viewProperty: View {
+        @_lifetime(borrow self)
+        get { View(self, address) }
+    }
+}
+
+// CHECK: SWIFT_INLINE_THUNK View borrowSelf() const SWIFT_SELF_LIFETIMEBOUND SWIFT_SYMBOL({{.*}});
+// CHECK: SWIFT_INLINE_THUNK View borrowSelfMutating() SWIFT_SELF_LIFETIMEBOUND SWIFT_SYMBOL({{.*}});
+// CHECK: SWIFT_INLINE_THUNK View getViewProperty() const SWIFT_SELF_LIFETIMEBOUND SWIFT_SYMBOL({{.*}});
+
+// CHECK: SWIFT_INLINE_THUNK View borrowBorrowingParam(const Owner& SWIFT_NOESCAPE o SWIFT_LIFETIMEBOUND) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
+// CHECK: SWIFT_INLINE_THUNK View borrowDefaultParam(const Owner& SWIFT_NOESCAPE o SWIFT_LIFETIMEBOUND) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
+// CHECK: SWIFT_INLINE_THUNK View borrowInoutParam(Owner& SWIFT_NOESCAPE o SWIFT_LIFETIMEBOUND) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
+// CHECK: SWIFT_INLINE_THUNK View borrowInoutViewParam(View& SWIFT_NOESCAPE v SWIFT_LIFETIMEBOUND) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
+// CHECK: SWIFT_INLINE_THUNK View borrowSecondParam(int64_t ignored, const Owner& SWIFT_NOESCAPE o SWIFT_LIFETIMEBOUND) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
+// CHECK: SWIFT_INLINE_THUNK View copyBorrowingParam(const View& SWIFT_NOESCAPE v) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
+// CHECK: SWIFT_INLINE_THUNK View copyDefaultParam(const View& SWIFT_NOESCAPE v) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
+
+// The attribute is repeated on the out-of-line definitions of the members.
+// CHECK: SWIFT_INLINE_THUNK View Owner::borrowSelf() const SWIFT_SELF_LIFETIMEBOUND {
+// CHECK: SWIFT_INLINE_THUNK View Owner::borrowSelfMutating() SWIFT_SELF_LIFETIMEBOUND {
+// CHECK: SWIFT_INLINE_THUNK View Owner::getViewProperty() const SWIFT_SELF_LIFETIMEBOUND {


### PR DESCRIPTION
When a Swift lifetime can be modeled as a C++ [[clang::lifetimebound]] annotation, emit a MACRO that expands to said annotation after the parameter.

rdar://182944907
