### PR TITLE
[cxx-interop] Fix `counted-by-method.swift`

### DIFF
--- a/test/Interop/Cxx/swiftify-import/counted-by-method.swift
+++ b/test/Interop/Cxx/swiftify-import/counted-by-method.swift
@@ -442,20 +442,14 @@ func call_refSubBasic(_ self: InheritRef, _ p: UnsafePointer<CInt>!, _ len: CInt
 }
 
 func call_refNoescape(_ self: InheritRef, _ p: Span<CInt>) {
-  // expected-error@+2{{missing argument for parameter #2 in call}}
-  // expected-error@+1{{cannot convert value of type 'Span<CInt>' (aka 'Span<Int32>') to expected argument type 'UnsafePointer<CInt>' (aka 'UnsafePointer<Int32>')}}
   return self.refNoescape(p)
 }
 
 func call_refBasic(_ self: InheritRef, _ p: UnsafeBufferPointer<CInt>) -> CInt {
-  // expected-error@+2{{missing argument for parameter #2 in call}}
-  // expected-error@+1{{cannot convert value of type 'UnsafeBufferPointer<CInt>' (aka 'UnsafeBufferPointer<Int32>') to expected argument type 'UnsafePointer<CInt>' (aka 'UnsafePointer<Int32>')}}
   return unsafe self.refBasic(p)
 }
 
 func call_refNonconstSelf(_ self: InheritRef, _ p: UnsafeBufferPointer<CInt>) {
-  // expected-error@+2{{missing argument for parameter #2 in call}}
-  // expected-error@+1{{cannot convert value of type 'UnsafeBufferPointer<CInt>' (aka 'UnsafeBufferPointer<Int32>') to expected argument type 'UnsafePointer<CInt>' (aka 'UnsafePointer<Int32>')}}
   return unsafe self.refNonconstSelf(p)
 }
 
@@ -495,8 +489,6 @@ func call_refPrivateSubBasic(_ self: InheritRefPrivate, _ p: UnsafePointer<CInt>
 }
 
 func call_refNoescape(_ self: InheritRefPrivate, _ p: Span<CInt>) {
-  // expected-error@+2{{missing argument for parameter #2 in call}}
-  // expected-error@+1{{cannot convert value of type 'Span<CInt>' (aka 'Span<Int32>') to expected argument type 'UnsafePointer<CInt>' (aka 'UnsafePointer<Int32>')}}
   return self.refNoescape(p)
 }
 
@@ -505,13 +497,9 @@ func call_refNoescape(_ self: InheritRefPrivate, _ p: Span<CInt>) {
 }
 
 func call_refBasic(_ self: InheritRefPrivate, _ p: UnsafeBufferPointer<CInt>) -> CInt {
-  // expected-error@+2{{missing argument for parameter #2 in call}}
-  // expected-error@+1{{cannot convert value of type 'UnsafeBufferPointer<CInt>' (aka 'UnsafeBufferPointer<Int32>') to expected argument type 'UnsafePointer<CInt>' (aka 'UnsafePointer<Int32>')}}
   return unsafe self.refBasic(p)
 }
 
 func call_refNonconstSelf(_ self: InheritRefPrivate, _ p: UnsafeBufferPointer<CInt>) {
-  // expected-error@+2{{missing argument for parameter #2 in call}}
-  // expected-error@+1{{cannot convert value of type 'UnsafeBufferPointer<CInt>' (aka 'UnsafeBufferPointer<Int32>') to expected argument type 'UnsafePointer<CInt>' (aka 'UnsafePointer<Int32>')}}
   return unsafe self.refNonconstSelf(p)
 }


### PR DESCRIPTION
This test is failing in CI because of a mid-flight collision between two previous commits.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
