### PR TITLE
[demangler] Recognize async_Main{async_suffix} as mangled names

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -13,12 +13,21 @@ Mangling
   mangled-name ::= '_T0' global // Swift 4.0
   mangled-name ::= '$S' global  // Swift 4.2
   mangled-name ::= '$e' global  // Embedded Swift (unstable)
+  mangled-name ::= async-main-entry-point
 
 All Swift-mangled names begin with a common prefix. Since Swift 4.0, the
 compiler has used variations of the mangling described in this document, though
 pre-stable versions may not exactly conform to this description. By using
 distinct prefixes, tools can attempt to accommodate bugs and version variations
 in pre-stable versions of Swift.
+
+The one exception is the async entry point that runs a program's top-level
+code, which carries no prefix at all::
+
+  async-main-entry-point ::= 'async_Main'
+
+It is still a Swift async function, so its funclets take the usual mangled
+suffixes (``async_MainTY1_``, ``async_MainTQ0_``, ``async_MainTu``, ...).
 
 The basic mangling scheme is a list of 'operators' where the operators are
 structured in a post-fix order. For example the mangling may start with an

--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -406,6 +406,14 @@ inline bool isMangledName(llvm::StringRef mangledName) {
   return getManglingPrefixLength(mangledName) != 0;
 }
 
+/// Returns true if \p mangledName names ASYNC_MAIN_ENTRY_POINT_NAME or one of
+/// its async funclets. Not covered by isMangledName(), which requires a prefix.
+bool isAsyncMainEntryPointSymbol(llvm::StringRef mangledName);
+
+/// Returns the length of the ASYNC_MAIN_ENTRY_POINT_NAME at the start of
+/// \p mangledName, including any Mach-O underscore, or 0 if there is none.
+int getAsyncMainEntryPointNameLength(llvm::StringRef mangledName);
+
 /// Returns true if the mangledName starts with the swift mangling prefix.
 ///
 /// This includes the old (<= swift 3.x) mangling prefix "_T".

--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -390,6 +390,14 @@ inline bool isMangledName(llvm::StringRef mangledName) {
   return getManglingPrefixLength(mangledName) != 0;
 }
 
+/// Returns true if \p mangledName names ASYNC_MAIN_ENTRY_POINT_NAME or one of
+/// its async funclets. Not covered by isMangledName(), which requires a prefix.
+bool isAsyncMainEntryPointSymbol(llvm::StringRef mangledName);
+
+/// Returns the length of the ASYNC_MAIN_ENTRY_POINT_NAME at the start of
+/// \p mangledName, including any Mach-O underscore, or 0 if there is none.
+int getAsyncMainEntryPointNameLength(llvm::StringRef mangledName);
+
 /// Returns true if the mangledName starts with the swift mangling prefix.
 ///
 /// This includes the old (<= swift 3.x) mangling prefix "_T".

--- a/include/swift/Demangling/DemangleNodes.def
+++ b/include/swift/Demangling/DemangleNodes.def
@@ -427,6 +427,7 @@ NODE(ConstValue)
 // Added in Swift 6.TBD
 CONTEXT_NODE(BorrowAccessor)
 CONTEXT_NODE(MutateAccessor)
+NODE(AsyncMainEntryPoint)
 NODE(CalledOnceFunctionType)
 
 #undef CONTEXT_NODE

--- a/include/swift/Demangling/ManglingMacros.h
+++ b/include/swift/Demangling/ManglingMacros.h
@@ -94,5 +94,11 @@ _Pragma("clang diagnostic pop")
 #define OBJC_PARTIAL_APPLY_THUNK_SYM \
           MANGLE_SYM(OBJC_PARTIAL_APPLY_THUNK_MANGLING)
 
+/// The async entry point running a program's top-level code. It is the one
+/// Swift function with no mangling, yet its async funclets are still named by
+/// appending the usual mangled suffixes to it (e.g. "async_MainTY1_"), so the
+/// demangler accepts it wherever a mangled name is expected.
+#define ASYNC_MAIN_ENTRY_POINT_NAME "async_Main"
+
 #endif // SWIFT_DEMANGLING_MANGLING_MACROS_H
 

--- a/lib/Demangling/Context.cpp
+++ b/lib/Demangling/Context.cpp
@@ -40,7 +40,7 @@ void Context::clear() {
 
 NodePointer Context::demangleSymbolAsNode(llvm::StringRef MangledName) {
 #if SWIFT_SUPPORT_OLD_MANGLING
-  if (isMangledName(MangledName)) {
+  if (isMangledName(MangledName) || isAsyncMainEntryPointSymbol(MangledName)) {
     return D->demangleSymbol(MangledName);
   }
   return demangleOldSymbolAsNode(MangledName, *D);

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -199,8 +199,26 @@ int swift::Demangle::getManglingPrefixLength(llvm::StringRef mangledName) {
   return 0;
 }
 
+bool swift::Demangle::isAsyncMainEntryPointSymbol(llvm::StringRef mangledName) {
+  return getAsyncMainEntryPointNameLength(mangledName) != 0;
+}
+
+int swift::Demangle::getAsyncMainEntryPointNameLength(
+    llvm::StringRef mangledName) {
+  llvm::StringRef name = ASYNC_MAIN_ENTRY_POINT_NAME;
+  if (mangledName.starts_with(name))
+    return name.size();
+  // Mach-O prefixes symbols with an underscore, just like for "_$s" names.
+  if (mangledName.consume_front("_") && mangledName.starts_with(name))
+    return name.size() + 1;
+  return 0;
+}
+
 bool swift::Demangle::isSwiftSymbol(llvm::StringRef mangledName) {
   if (isOldFunctionTypeMangling(mangledName))
+    return true;
+
+  if (isAsyncMainEntryPointSymbol(mangledName))
     return true;
 
   return getManglingPrefixLength(mangledName) != 0;
@@ -804,14 +822,21 @@ NodePointer Demangler::demangleSymbol(StringRef MangledName,
 #endif
 
   unsigned PrefixLength = getManglingPrefixLength(MangledName);
-  if (PrefixLength == 0)
-    return nullptr;
+  if (PrefixLength == 0) {
+    // Stand a node in for the unmangled base name so the mangled funclet
+    // suffixes that follow it can be parsed.
+    int NameLength = getAsyncMainEntryPointNameLength(MangledName);
+    if (NameLength == 0)
+      return nullptr;
+    Pos += NameLength;
+    pushNode(createNode(Node::Kind::AsyncMainEntryPoint));
+  } else {
+    if (MangledName.starts_with(MANGLING_PREFIX_EMBEDDED_STR))
+      Flavor = ManglingFlavor::Embedded;
 
-  if (MangledName.starts_with(MANGLING_PREFIX_EMBEDDED_STR))
-    Flavor = ManglingFlavor::Embedded;
-
-  IsOldFunctionTypeMangling = isOldFunctionTypeMangling(MangledName);
-  Pos += PrefixLength;
+    IsOldFunctionTypeMangling = isOldFunctionTypeMangling(MangledName);
+    Pos += PrefixLength;
+  }
 
   // If any other prefixes are accepted, please update Mangler::verify.
 

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -199,8 +199,26 @@ int swift::Demangle::getManglingPrefixLength(llvm::StringRef mangledName) {
   return 0;
 }
 
+bool swift::Demangle::isAsyncMainEntryPointSymbol(llvm::StringRef mangledName) {
+  return getAsyncMainEntryPointNameLength(mangledName) != 0;
+}
+
+int swift::Demangle::getAsyncMainEntryPointNameLength(
+    llvm::StringRef mangledName) {
+  llvm::StringRef name = ASYNC_MAIN_ENTRY_POINT_NAME;
+  if (mangledName.starts_with(name))
+    return name.size();
+  // Mach-O prefixes symbols with an underscore, just like for "_$s" names.
+  if (mangledName.consume_front("_") && mangledName.starts_with(name))
+    return name.size() + 1;
+  return 0;
+}
+
 bool swift::Demangle::isSwiftSymbol(llvm::StringRef mangledName) {
   if (isOldFunctionTypeMangling(mangledName))
+    return true;
+
+  if (isAsyncMainEntryPointSymbol(mangledName))
     return true;
 
   return getManglingPrefixLength(mangledName) != 0;
@@ -774,14 +792,21 @@ NodePointer Demangler::demangleSymbol(StringRef MangledName,
 #endif
 
   unsigned PrefixLength = getManglingPrefixLength(MangledName);
-  if (PrefixLength == 0)
-    return nullptr;
+  if (PrefixLength == 0) {
+    // Stand a node in for the unmangled base name so the mangled funclet
+    // suffixes that follow it can be parsed.
+    int NameLength = getAsyncMainEntryPointNameLength(MangledName);
+    if (NameLength == 0)
+      return nullptr;
+    Pos += NameLength;
+    pushNode(createNode(Node::Kind::AsyncMainEntryPoint));
+  } else {
+    if (MangledName.starts_with(MANGLING_PREFIX_EMBEDDED_STR))
+      Flavor = ManglingFlavor::Embedded;
 
-  if (MangledName.starts_with(MANGLING_PREFIX_EMBEDDED_STR))
-    Flavor = ManglingFlavor::Embedded;
-
-  IsOldFunctionTypeMangling = isOldFunctionTypeMangling(MangledName);
-  Pos += PrefixLength;
+    IsOldFunctionTypeMangling = isOldFunctionTypeMangling(MangledName);
+    Pos += PrefixLength;
+  }
 
   // If any other prefixes are accepted, please update Mangler::verify.
 

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -313,6 +313,7 @@ bool NodePrinter::isSimpleType(NodePointer Node) {
   case Node::Kind::AssociatedTypeDescriptor:
   case Node::Kind::AssociatedTypeMetadataAccessor:
   case Node::Kind::AssociatedTypeWitnessTableAccessor:
+  case Node::Kind::AsyncMainEntryPoint:
   case Node::Kind::AsyncRemoved:
   case Node::Kind::AutoClosureType:
   case Node::Kind::BaseConformanceDescriptor:
@@ -3460,6 +3461,9 @@ NodePointer NodePrinter::print(NodePointer Node, unsigned depth,
     return nullptr;
   case Node::Kind::AsyncFunctionPointer:
     Printer << "async function pointer to ";
+    return nullptr;
+  case Node::Kind::AsyncMainEntryPoint:
+    Printer << "async main entry point";
     return nullptr;
   case Node::Kind::AsyncAwaitResumePartialFunction:
     if (Options.ShowAsyncResumePartial) {

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -796,6 +796,9 @@ ManglingError
 Remangler::mangleAsyncSuspendResumePartialFunction(Node *node, unsigned depth) {
   return MANGLING_ERROR(ManglingError::UnsupportedNodeKind, node);
 }
+ManglingError Remangler::mangleAsyncMainEntryPoint(Node *node, unsigned depth) {
+  return MANGLING_ERROR(ManglingError::UnsupportedNodeKind, node);
+}
 
 ManglingError Remangler::mangleDirectness(Node *node, unsigned depth) {
   switch (node->getIndex()) {

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -1834,6 +1834,21 @@ ManglingError Remangler::mangleGetter(Node *node, unsigned depth) {
 }
 
 ManglingError Remangler::mangleGlobal(Node *node, unsigned depth) {
+  // An unmangled base name must not pick up a mangling prefix.
+  bool isAsyncMainEntryPoint = false;
+  for (Node *Child : *node)
+    isAsyncMainEntryPoint |=
+        Child->getKind() == Node::Kind::AsyncMainEntryPoint;
+
+  if (isAsyncMainEntryPoint) {
+    Buffer << ASYNC_MAIN_ENTRY_POINT_NAME;
+    for (Node *Child : *node) {
+      if (Child->getKind() != Node::Kind::AsyncMainEntryPoint)
+        RETURN_IF_ERROR(mangle(Child, depth + 1));
+    }
+    return ManglingError::Success;
+  }
+
   switch (Flavor) {
   case ManglingFlavor::Default:
     Buffer << MANGLING_PREFIX_STR;
@@ -2736,6 +2751,11 @@ ManglingError
 Remangler::mangleAsyncSuspendResumePartialFunction(Node *node, unsigned depth) {
   Buffer << "TY";
   return mangleChildNode(node, 0, depth + 1);
+}
+
+ManglingError Remangler::mangleAsyncMainEntryPoint(Node *node, unsigned depth) {
+  Buffer << ASYNC_MAIN_ENTRY_POINT_NAME;
+  return ManglingError::Success;
 }
 
 ManglingError Remangler::manglePostfixOperator(Node *node, unsigned depth) {

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -22,6 +22,7 @@
 #include "swift/Basic/CodeGenerationModel.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/ClangImporter/ClangModule.h"
+#include "swift/Demangling/ManglingMacros.h"
 #include "swift/SIL/SILLinkage.h"
 #include "swift/SIL/SILLocation.h"
 #include "swift/SILOptimizer/Utils/SpecializationMangler.h"
@@ -1550,7 +1551,7 @@ std::string SILDeclRef::mangle(ManglingKind MKind) const {
                                                       SKind);
 
   case SILDeclRef::Kind::AsyncEntryPoint: {
-    return "async_Main";
+    return ASYNC_MAIN_ENTRY_POINT_NAME;
   }
   case SILDeclRef::Kind::EntryPoint: {
     return getASTContext().getEntryPointFunctionName();

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -22,6 +22,7 @@
 #include "swift/Basic/CodeGenerationModel.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/ClangImporter/ClangModule.h"
+#include "swift/Demangling/ManglingMacros.h"
 #include "swift/SIL/SILLinkage.h"
 #include "swift/SIL/SILLocation.h"
 #include "swift/SILOptimizer/Utils/SpecializationMangler.h"
@@ -1564,7 +1565,7 @@ std::string SILDeclRef::mangle(ManglingKind MKind) const {
                                                       SKind);
 
   case SILDeclRef::Kind::AsyncEntryPoint: {
-    return "async_Main";
+    return ASYNC_MAIN_ENTRY_POINT_NAME;
   }
   case SILDeclRef::Kind::EntryPoint: {
     return getASTContext().getEntryPointFunctionName();

--- a/test/Concurrency/async_main.swift
+++ b/test/Concurrency/async_main.swift
@@ -63,7 +63,7 @@ func asyncFunc() async {
 // main
 // CHECK-SIL-LABEL: sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 
-// CHECK-SIL:       // function_ref async_Main
+// CHECK-SIL:       // function_ref async main entry point
 // CHECK-SIL-NEXT:  [[ASYNC_MAIN_FN:%.*]] = function_ref @async_Main : $@convention(thin) @async () -> ()
 // CHECK-SIL-NEXT:  [[T0:%.*]] = integer_literal $Builtin.Int64, 2048
 // CHECK-SIL-NEXT:  [[FLAGS:%.*]] = struct $Int ([[T0]] : $Builtin.Int64)

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -522,3 +522,8 @@ $sIeg_BAIegHgIL_TR ---> {T:} reabstraction thunk helper from @escaping @callee_g
 $sSiBW ---> Builtin.Borrow<Swift.Int>
 $sBAIeNghHgIL_BAytIeNghHgILr_TR ---> {T:} reabstraction thunk helper from @escaping @caller_isolated @callee_guaranteed @Sendable @async (@guaranteed Builtin.ImplicitActor) -> () to @escaping @caller_isolated @callee_guaranteed @Sendable @async (@guaranteed Builtin.ImplicitActor) -> (@out ())
 $s4main12testCallOnceyyyyXOnF ---> main.testCallOnce(__owned @called(once) () -> ()) -> ()
+async_Main ---> async main entry point
+async_MainTY1_ ---> (2) suspend resume partial function for async main entry point
+async_MainTQ0_ ---> (1) await resume partial function for async main entry point
+async_MainTu ---> async function pointer to async main entry point
+_async_MainTY1_ ---> (2) suspend resume partial function for async main entry point

--- a/tools/swift-demangle/swift-demangle.cpp
+++ b/tools/swift-demangle/swift-demangle.cpp
@@ -299,11 +299,23 @@ static bool findMaybeMangled(llvm::StringRef input, llvm::StringRef &match) {
   } state = Start;
   const char *matchStart = nullptr;
 
-  // Find _T, $S, $s, _$S, _$s, @__swiftmacro_ followed by a valid mangled string
+  // Find _T, $S, $s, _$S, _$s, @__swiftmacro_ followed by a valid mangled
+  // string, or ASYNC_MAIN_ENTRY_POINT_NAME.
   while (ptr < end) {
     switch (state) {
     case Start:
       while (ptr < end) {
+        // No prefix to look for here: match the whole name plus any suffix.
+        if (int nameLen = swift::Demangle::getAsyncMainEntryPointNameLength(
+                llvm::StringRef(ptr, end - ptr))) {
+          matchStart = ptr;
+          ptr += nameLen;
+          while (ptr < end && isValidInMangling(*ptr))
+            ++ptr;
+          match = llvm::StringRef(matchStart, ptr - matchStart);
+          return true;
+        }
+
         char ch = *ptr++;
 
         if (ch == '_') {


### PR DESCRIPTION
Unwinders (as well as most functionality inside LLDB) rely on the demangler to recognize async functions. The fact that async_Main cannot be demangled results in many confusing bugs for users of the debugger.

This patch adds a special case inside the demangler for the async main funclets.

rdar://149105066