### PR TITLE
IRGen: don't pass a metadata pack pointer to swift_checkMetadataState…

### DIFF
--- a/lib/IRGen/GenPack.cpp
+++ b/lib/IRGen/GenPack.cpp
@@ -767,8 +767,15 @@ llvm::Value *irgen::emitTypeMetadataPackElementRef(
     DynamicMetadataRequest request,
     llvm::SmallVectorImpl<llvm::Value *> &wtables) {
   // If the packs have already been materialized, just gep into them.
+  //
+  // Request the pack at Abstract state: a metadata pack pointer is not a scalar
+  // Metadata* and must never be passed to swift_checkMetadataState (which is
+  // what forwarding a higher request would emit via the local-type-data cache).
+  // We only need the pack pointer to index into; the extracted element's state
+  // is checked by the caller.
   auto materializedMetadataPack =
-      tryGetLocalPackTypeMetadata(IGF, packType, request);
+      tryGetLocalPackTypeMetadata(IGF, packType,
+                                  DynamicMetadataRequest(MetadataState::Abstract));
   llvm::SmallVector<llvm::Value *> materializedWtablePacks;
   for (auto conformance : conformances) {
     auto *wtablePack = tryGetLocalPackTypeData(

--- a/test/Interpreter/Inputs/vanishing_tuple_boxes.swift
+++ b/test/Interpreter/Inputs/vanishing_tuple_boxes.swift
@@ -1,0 +1,8 @@
+// Compiled with library evolution, so its layout is opaque to clients. A
+// client that stores a `Box<T>` must instantiate the box's metadata at
+// runtime, which forces the enclosing type's metadata completion function to
+// bind its metadata pack before the tuple field is laid out.
+public struct Box<Value> {
+  public var value: Value
+  public init(_ value: Value) { self.value = value }
+}

--- a/test/Interpreter/variadic_generic_vanishing_tuple_resilient_field.swift
+++ b/test/Interpreter/variadic_generic_vanishing_tuple_resilient_field.swift
@@ -1,0 +1,44 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(vanishing_tuple_boxes)) -enable-library-evolution %S/Inputs/vanishing_tuple_boxes.swift -emit-module -emit-module-path %t/vanishing_tuple_boxes.swiftmodule -module-name vanishing_tuple_boxes
+// RUN: %target-codesign %t/%target-library-name(vanishing_tuple_boxes)
+// RUN: %target-build-swift -target %target-swift-5.9-abi-triple %s -lvanishing_tuple_boxes -I %t -L %t -o %t/main %target-rpath(%t)
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main %t/%target-library-name(vanishing_tuple_boxes) | %FileCheck %s
+
+// REQUIRES: executable_test
+
+// Storing a pack-expansion tuple property hits an unrelated pre-existing SILGen
+// assertion under SIL opaque values (TupleInitialization::copyOrInitValueInto);
+// the metadata-completion bug this test guards is in IRGen and is exercised by
+// every other configuration.
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
+
+
+// Instantiating metadata for a variadic-generic struct that has a resilient
+// stored property laid out *before* a tuple built from the pack used to crash:
+// the resilient field's metadata accessor binds the metadata pack into the
+// completion function's local cache at Abstract state, and the subsequent
+// vanishing-tuple element lookup then passed the metadata *pack pointer* to
+// swift_checkMetadataState as if it were a scalar Metadata*, corrupting the
+// element pointer and crashing.
+
+import vanishing_tuple_boxes
+
+struct Repeater<each Input> {
+  // Field 0: a resilient generic type parameterized by the nested Storage,
+  // laid out before the pack tuple field. Storing it forces a runtime metadata
+  // instantiation that binds the metadata pack.
+  private var __storage: Box<Storage> = Box(Storage())
+  private var input: (repeat each Input)
+  init(_ input: repeat each Input) { self.input = (repeat each input) }
+}
+
+// The nested type captures the pack, so its accessor is what seeds the pack in
+// the completion function's local type-data cache.
+extension Repeater { final class Storage {} }
+
+print("before")
+// CHECK: before
+_ = Repeater(1)
+print("after")
+// CHECK: after


### PR DESCRIPTION
… when extracting a vanishing-tuple element

emitTypeMetadataPackElementRef's materialized-pack fast path forwarded the caller's (state-raising) request to the local-type-data cache lookup for the metadata pack. A metadata pack pointer is not a scalar Metadata* (it is an array of Metadata* with an on-heap tag in the LSB), so raising its state made the cache emit swift_checkMetadataState(pack) as if it were a metadata record. The runtime then dereferenced garbage and the extracted element pointer was corrupted, crashing metadata instantiation.

This reproduces for a variadic-generic struct with a resilient stored property laid out before a tuple built from the pack: the resilient field's metadata accessor binds the metadata pack into the completion function's local cache at Abstract state, and the subsequent vanishing-tuple element lookup then state-raises that cached pack.

Fetch the materialized pack at Abstract state instead: we only need the pack pointer to index into, and the extracted element's state is still checked by the caller. The fallback paths that apply the request to the element metadata are unchanged. Runtime is unaffected.

rdar://183073688

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
