### PR TITLE
[6.4] IRGen: don't pass a metadata pack pointer to swift_checkMetadataState…

### DIFF
--- a/lib/IRGen/GenPack.cpp
+++ b/lib/IRGen/GenPack.cpp
@@ -767,8 +767,15 @@ llvm::Value *irgen::emitTypeMetadataPackElementRef(
     DynamicMetadataRequest request,
     llvm::SmallVectorImpl<llvm::Value *> &wtables) {
   // If the packs have already been materialized, just gep into them.
+  //
+  // Request the pack at Abstract state: a metadata pack pointer is not a scalar
+  // Metadata* and must never be passed to swift_checkMetadataState (which is
+  // what forwarding a higher request would emit via the local-type-data cache).
+  // We only need the pack pointer to index into; the extracted element's state
+  // is checked by the caller.
   auto materializedMetadataPack =
-      tryGetLocalPackTypeMetadata(IGF, packType, request);
+      tryGetLocalPackTypeMetadata(IGF, packType,
+                                  DynamicMetadataRequest(MetadataState::Abstract));
   llvm::SmallVector<llvm::Value *> materializedWtablePacks;
   for (auto conformance : conformances) {
     auto *wtablePack = tryGetLocalPackTypeData(

--- a/test/Interpreter/Inputs/vanishing_tuple_boxes.swift
+++ b/test/Interpreter/Inputs/vanishing_tuple_boxes.swift
@@ -1,0 +1,8 @@
+// Compiled with library evolution, so its layout is opaque to clients. A
+// client that stores a `Box<T>` must instantiate the box's metadata at
+// runtime, which forces the enclosing type's metadata completion function to
+// bind its metadata pack before the tuple field is laid out.
+public struct Box<Value> {
+  public var value: Value
+  public init(_ value: Value) { self.value = value }
+}

--- a/test/Interpreter/variadic_generic_vanishing_tuple_resilient_field.swift
+++ b/test/Interpreter/variadic_generic_vanishing_tuple_resilient_field.swift
@@ -1,0 +1,37 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(vanishing_tuple_boxes)) -enable-library-evolution %S/Inputs/vanishing_tuple_boxes.swift -emit-module -emit-module-path %t/vanishing_tuple_boxes.swiftmodule -module-name vanishing_tuple_boxes
+// RUN: %target-codesign %t/%target-library-name(vanishing_tuple_boxes)
+// RUN: %target-build-swift -target %target-swift-5.9-abi-triple %s -lvanishing_tuple_boxes -I %t -L %t -o %t/main %target-rpath(%t)
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main %t/%target-library-name(vanishing_tuple_boxes) | %FileCheck %s
+
+// REQUIRES: executable_test
+
+// Instantiating metadata for a variadic-generic struct that has a resilient
+// stored property laid out *before* a tuple built from the pack used to crash:
+// the resilient field's metadata accessor binds the metadata pack into the
+// completion function's local cache at Abstract state, and the subsequent
+// vanishing-tuple element lookup then passed the metadata *pack pointer* to
+// swift_checkMetadataState as if it were a scalar Metadata*, corrupting the
+// element pointer and crashing.
+
+import vanishing_tuple_boxes
+
+struct Repeater<each Input> {
+  // Field 0: a resilient generic type parameterized by the nested Storage,
+  // laid out before the pack tuple field. Storing it forces a runtime metadata
+  // instantiation that binds the metadata pack.
+  private var __storage: Box<Storage> = Box(Storage())
+  private var input: (repeat each Input)
+  init(_ input: repeat each Input) { self.input = (repeat each input) }
+}
+
+// The nested type captures the pack, so its accessor is what seeds the pack in
+// the completion function's local type-data cache.
+extension Repeater { final class Storage {} }
+
+print("before")
+// CHECK: before
+_ = Repeater(1)
+print("after")
+// CHECK: after


### PR DESCRIPTION
 - **Explanation**:
    IRGen's `emitTypeMetadataPackElementRef` had a fast path that, when a metadata
    pack was already materialized in the local-type-data cache, forwarded the
    caller's (state-raising) `DynamicMetadataRequest` to the pack lookup. A metadata
    pack pointer is not a scalar `Metadata*` (it's an array of `Metadata*` with an
    on-heap tag in the LSB), so raising its state caused the cache to emit
    `swift_checkMetadataState` on the pack pointer as if it were a metadata record.
    The runtime dereferenced garbage, corrupting the extracted element pointer and
    crashing type-metadata instantiation. This surfaces for a variadic-generic
    struct with a resilient stored property laid out before a tuple built from the
    pack: the resilient field's metadata accessor binds the pack into the completion
    function's cache at `Abstract` state, and the subsequent vanishing-tuple element
    lookup then state-raises that cached pack. The fix fetches the materialized pack
    at `Abstract` state — we only need the pointer to index into, and the extracted
    element's state is still checked by the caller.

  - **Scope**:
    Narrow. Affects only the already-materialized fast path of
    `emitTypeMetadataPackElementRef` in variadic-generics metadata codegen. The
    fallback paths that apply the request to the element metadata are unchanged, and
    both callers of the function were verified safe. Fixes a runtime crash on
    well-formed code; no ABI or runtime changes.

  - **Issues**:
    rdar://183073688

  - **Original PRs**:
     https://github.com/swiftlang/swift/pull/91115

  - **Risk**:
    Low. Single-line codegen change confined to the pack-element materialized fast
    path; the previously-emitted `swift_checkMetadataState` on the pack pointer was
    always illegal, so removing it only drops a bogus (crashing) call. Element-level
    state checking is preserved. No runtime/ABI/stdlib changes.

  - **Testing**:
    Added an execution regression test
    (`test/Interpreter/variadic_generic_vanishing_tuple_resilient_field.swift` +
    input) that crashes without the fix (asserts build: `Assertion failed:
    (isTypeMetadata())` in Metadata.h; release: SIGSEGV) and passes with it. Verified
    a clean before/after on identical source: the illegal
    `swift_checkMetadataState(pack)` is gone from the emitted IR while the legitimate
    element check remains. Ran `test/IRGen` + `test/Interpreter` filtered to
    `pack|variadic|tuple` (47/47 pass, including the new test) with no regressions.

  - **Reviewers**: @hjyamauchi 