### PR TITLE
[ClangImporter] dedup imported availability

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -612,6 +612,19 @@ static ImportedType rectifySubscriptTypes(Type getterType, bool getterIsIUO,
   return {OptionalType::get(setterType), true};
 }
 
+/// Returns the `@available` attribute on \p decl whose resolved domain is the
+/// platform \p platform, or null. Semantic availability is not resolved yet
+/// during import, so this matches on the parsed attribute's domain.
+static AvailableAttr *findAvailableAttrForPlatform(Decl *decl,
+                                                   PlatformKind platform) {
+  for (auto *attr : decl->getAttrs().getAttributes<AvailableAttr>()) {
+    auto domain = attr->getDomainOrIdentifier().getAsDomain();
+    if (domain && domain->isPlatform() && domain->getPlatformKind() == platform)
+      return attr;
+  }
+  return nullptr;
+}
+
 /// Add an AvailableAttr to the declaration for the given
 /// version range.
 static void applyAvailableAttribute(Decl *decl, AvailabilityRange &info,
@@ -9885,6 +9898,25 @@ void ClangImporter::Implementation::importAttributes(
       StringRef swiftReplacement = "";
       if (!replacement.empty())
         swiftReplacement = getSwiftNameFromClangName(replacement);
+
+      // If an earlier phase already introduced this platform (e.g. the
+      // synthesized Swift-runtime availability for foreign reference types),
+      // fold its introduction version into this attribute and drop it, rather
+      // than leaving two @available attributes for the same platform (which
+      // can render as an invalid short-form @available).
+      if (auto *prevAttr =
+              findAvailableAttrForPlatform(MappedDecl, *platformK)) {
+        if (auto prevIntroduced = prevAttr->getRawIntroduced()) {
+          // Only fold the introduction version into an attribute that actually
+          // introduces availability. For an unavailable attribute an
+          // introduction version would be meaningless (the platform is
+          // unavailable regardless), so just drop the earlier attribute.
+          if (AttrKind == AvailableAttr::Kind::Default &&
+              (introduced.empty() || *prevIntroduced > introduced))
+            introduced = *prevIntroduced;
+          MappedDecl->getAttrs().removeAttribute(prevAttr);
+        }
+      }
 
       auto AvAttr = new (C) AvailableAttr(
           SourceLoc(), SourceRange(),

--- a/test/ClangImporter/implicit_availability.h
+++ b/test/ClangImporter/implicit_availability.h
@@ -1,0 +1,224 @@
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+// RUN: %target-swift-ide-test -print-module -module-to-print=__ObjC -import-objc-header %s -source-filename=x -target %target-cpu-apple-macosx13.0 -Xcc -Werror -Xcc -Wavailability | %FileCheck %s
+
+// Check how the printed interface renders availability that comes from three
+// different sources in the same Clang module:
+//   1. An explicit Clang `availability` attribute.
+//   2. The implicit Swift 5.8 runtime availability synthesized for foreign
+//      reference types (and how it combines with an explicit attribute).
+//   3. Availability of a protocol requirement mirrored into an adopting class.
+// The deployment target is pinned below 13.3 so the implicit foreign-reference
+// availability is actually emitted.
+
+#define REF \
+    __attribute__((swift_attr("import_reference"))) \
+    __attribute__((swift_attr("retain:immortal")))  \
+    __attribute__((swift_attr("release:immortal")))
+#define AVAIL(...) __attribute__((availability(__VA_ARGS__)))
+
+AVAIL(macos, introduced=15.0)
+@interface ExplicitlyAvailable
+- (void)doThing;
+@end
+// An explicit availability attribute is imported directly.
+// CHECK:      @available(macOS 15.0, *)
+// CHECK-NEXT: class ExplicitlyAvailable {
+// CHECK-NEXT:   class func doThing()
+// CHECK-NEXT:   func doThing()
+// CHECK-NEXT: }
+
+AVAIL(macos, introduced=14.0, deprecated=15.0)
+@interface ExplicitlyAvailableDe
+- (void)doThing;
+@end
+// CHECK-NEXT: @available(macOS, introduced: 14.0, deprecated: 15.0)
+// CHECK-NEXT: class ExplicitlyAvailableDe {
+// CHECK-NEXT:   class func doThing()
+// CHECK-NEXT:   func doThing()
+// CHECK-NEXT: }
+
+AVAIL(macos, introduced=14.0)
+AVAIL(macos, deprecated=15.0)
+@interface ExplicitlyAvailableDepSeparate
+- (void)doThing;
+@end
+// CHECK-NEXT: @available(macOS 14.0, *)
+// CHECK-NEXT: @available(macOS, deprecated: 15.0)
+// CHECK-NEXT: class ExplicitlyAvailableDepSeparate {
+// CHECK-NEXT:   class func doThing()
+// CHECK-NEXT:   func doThing()
+// CHECK-NEXT: }
+
+AVAIL(macos, introduced=14.0)
+AVAIL(anyAppleOS, introduced=26.0, deprecated=26.2)
+@interface ExplicitlyAvailableDepSeparateAny
+- (void)doThing;
+@end
+// CHECK-NEXT: @available(macOS 14.0, *)
+// CHECK-NEXT: class ExplicitlyAvailableDepSeparateAny {
+// CHECK-NEXT:   class func doThing()
+// CHECK-NEXT:   func doThing()
+// CHECK-NEXT: }
+
+struct REF RefType {};
+// A foreign reference type gets the implicit Swift 5.8 runtime availability.
+// CHECK-NEXT: @available(macOS 13.3.0, *)
+// CHECK-NEXT: class RefType {
+// CHECK-NEXT: }
+
+struct REF AVAIL(macos, introduced=26.0) LateRefType {};
+// FIXME: this is invalid syntax in Swift
+// CHECK-NEXT: @available(macOS 13.3.0, macOS 26.0, *)
+// CHECK-NEXT: class LateRefType {
+// CHECK-NEXT: }
+
+struct REF AVAIL(macos, deprecated=15.0, message="gone") DeprecatedRef {};
+// CHECK-NEXT: @available(macOS 13.3.0, *)
+// CHECK-NEXT: @available(macOS, deprecated: 15.0, message: "gone")
+// CHECK-NEXT: class DeprecatedRef {
+// CHECK-NEXT: }
+
+struct REF AVAIL(macos, unavailable, message="nope") UnavailableRef {};
+// CHECK-NEXT: @available(macOS 13.3.0, *)
+// CHECK-NEXT: @available(macOS, unavailable, message: "nope")
+// CHECK-NEXT: class UnavailableRef {
+// CHECK-NEXT: }
+
+struct REF AVAIL(macos, introduced=14.0, deprecated=15.0) LateIntroDepRef {};
+// CHECK-NEXT: @available(macOS 13.3.0, *)
+// CHECK-NEXT: @available(macOS, introduced: 14.0, deprecated: 15.0)
+// CHECK-NEXT: class LateIntroDepRef {
+// CHECK-NEXT: }
+
+struct REF AVAIL(macos, introduced=12.0, deprecated=15.0) EarlyIntroLateDepRef {};
+// CHECK-NEXT: @available(macOS 13.3.0, *)
+// CHECK-NEXT: @available(macOS, introduced: 12.0, deprecated: 15.0)
+// CHECK-NEXT: class EarlyIntroLateDepRef {
+// CHECK-NEXT: }
+
+struct REF AVAIL(macos, introduced=12.0, deprecated=13.0) EarlyIntroEarlyDepRef {};
+// CHECK-NEXT: @available(macOS 13.3.0, *)
+// CHECK-NEXT: @available(macOS, introduced: 12.0, deprecated: 13.0)
+// CHECK-NEXT: class EarlyIntroEarlyDepRef {
+// CHECK-NEXT: }
+
+struct REF AVAIL(macos, introduced=12.0) AVAIL(macos, deprecated=13.0) EarlyIntroEarlyDepRefSeparate {};
+// FIXME: this is invalid syntax in Swift
+// CHECK-NEXT: @available(macOS 13.3.0, macOS 12.0, *)
+// CHECK-NEXT: @available(macOS, deprecated: 13.0)
+// CHECK-NEXT: class EarlyIntroEarlyDepRefSeparate {
+// CHECK-NEXT: }
+
+struct REF AVAIL(macos, deprecated=13.0) DepOnlyEarly {};
+// FIXME: this is invalid syntax in Swift
+// CHECK-NEXT: @available(macOS 13.3.0, *)
+// CHECK-NEXT: @available(macOS, deprecated: 13.0)
+// CHECK-NEXT: class DepOnlyEarly {
+// CHECK-NEXT: }
+
+struct REF AVAIL(macos, deprecated=14.0) DepOnlyLate {};
+// FIXME: this is invalid syntax in Swift
+// CHECK-NEXT: @available(macOS 13.3.0, *)
+// CHECK-NEXT: @available(macOS, deprecated: 14.0)
+// CHECK-NEXT: class DepOnlyLate {
+// CHECK-NEXT: }
+
+AVAIL(macos, introduced=14.0)
+@protocol AvailProto
+- (void)fromAvailableProtocol;
+- (void)fromAvailableProtocolExplicit AVAIL(macos, introduced=15.0);
+- (void)fromAvailableProtocolExplicitAny AVAIL(anyAppleOS, introduced=26.0);
+- (void)fromAvailableProtocolExplicitLow AVAIL(macos, introduced=13.0);
+@end
+// CHECK-NEXT: @available(macOS 14.0, *)
+// CHECK-NEXT: protocol AvailProto {
+// CHECK-NEXT:   func fromAvailableProtocol()
+// CHECK-NEXT:   @available(macOS 15.0, *)
+// CHECK-NEXT:   func fromAvailableProtocolExplicit()
+// CHECK-NEXT:   @available(anyAppleOS 26.0, *)
+// CHECK-NEXT:   func fromAvailableProtocolExplicitAny()
+// CHECK-NEXT:   @available(macOS 13.0, *)
+// CHECK-NEXT:   func fromAvailableProtocolExplicitLow()
+// CHECK-NEXT: }
+
+@interface Adopter <AvailProto>
+@end
+// CHECK-NEXT: class Adopter : AvailProto {
+// Explicit is protocol availability is propagated to the
+// copy mirrored into an adopting class.
+// CHECK-NEXT:   @available(macOS 14.0, *)
+// CHECK-NEXT:   func fromAvailableProtocol()
+// CHECK-NEXT:   @available(macOS 14.0, *)
+// CHECK-NEXT:   class func fromAvailableProtocol()
+// Subsumed availability is NOT copied.
+// CHECK-NEXT:   @available(macOS 15.0, *)
+// CHECK-NEXT:   func fromAvailableProtocolExplicit()
+// CHECK-NEXT:   @available(macOS 15.0, *)
+// CHECK-NEXT:   class func fromAvailableProtocolExplicit()
+// CHECK-NEXT:   @available(anyAppleOS 26.0, *)
+// CHECK-NEXT:   func fromAvailableProtocolExplicitAny()
+// CHECK-NEXT:   @available(anyAppleOS 26.0, *)
+// CHECK-NEXT:   class func fromAvailableProtocolExplicitAny()
+// CHECK-NEXT:   @available(macOS 13.0, *)
+// CHECK-NEXT:   func fromAvailableProtocolExplicitLow()
+// CHECK-NEXT:   @available(macOS 13.0, *)
+// CHECK-NEXT:   class func fromAvailableProtocolExplicitLow()
+// CHECK-NEXT: }
+
+AVAIL(anyAppleOS, introduced=26.0)
+@protocol AvailProtoAny
+- (void)fromAvailableProtocol;
+- (void)fromAvailableProtocolExplicit AVAIL(macos, introduced=27.0);
+- (void)fromAvailableProtocolExplicitAny AVAIL(anyAppleOS, introduced=27.0);
+- (void)fromAvailableProtocolExplicitLow AVAIL(macos, introduced=13.0);
+- (void)fromAvailableProtocolExplicitIos AVAIL(ios, introduced=27.0);
+- (void)fromAvailableProtocolExplicitIosLow AVAIL(ios, introduced=15.0);
+@end
+// Also works for anyAppleOS.
+// CHECK-NEXT: @available(anyAppleOS 26.0, *)
+// CHECK-NEXT: protocol AvailProtoAny {
+// CHECK-NEXT:   func fromAvailableProtocol()
+// CHECK-NEXT:   @available(macOS 27.0, *)
+// CHECK-NEXT:   func fromAvailableProtocolExplicit()
+// CHECK-NEXT:   @available(anyAppleOS 27.0, *)
+// CHECK-NEXT:   func fromAvailableProtocolExplicitAny()
+// FIXME? Earlier availability than the surrounding context would be an error
+// in Swift, but clang allows it.
+// CHECK-NEXT:   @available(macOS 13.0, *)
+// CHECK-NEXT:   func fromAvailableProtocolExplicitLow()
+// Another OSs availability is ignored
+// CHECK-NEXT:   func fromAvailableProtocolExplicitIos()
+// CHECK-NEXT:   func fromAvailableProtocolExplicitIosLow()
+// CHECK-NEXT: }
+
+@interface AdopterAny <AvailProtoAny>
+@end
+// CHECK-NEXT: class AdopterAny : AvailProtoAny {
+// CHECK-NEXT:   @available(macOS 26.0, *)
+// CHECK-NEXT:   func fromAvailableProtocol()
+// CHECK-NEXT:   @available(macOS 26.0, *)
+// CHECK-NEXT:   class func fromAvailableProtocol()
+// CHECK-NEXT:   @available(macOS 27.0, *)
+// CHECK-NEXT:   func fromAvailableProtocolExplicit()
+// CHECK-NEXT:   @available(macOS 27.0, *)
+// CHECK-NEXT:   class func fromAvailableProtocolExplicit()
+// CHECK-NEXT:   @available(anyAppleOS 27.0, *)
+// CHECK-NEXT:   func fromAvailableProtocolExplicitAny()
+// CHECK-NEXT:   @available(anyAppleOS 27.0, *)
+// CHECK-NEXT:   class func fromAvailableProtocolExplicitAny()
+// CHECK-NEXT:   @available(macOS 13.0, *)
+// CHECK-NEXT:   func fromAvailableProtocolExplicitLow()
+// CHECK-NEXT:   @available(macOS 13.0, *)
+// CHECK-NEXT:   class func fromAvailableProtocolExplicitLow()
+// Functions with explicit annotations for another OS still inherit from protocol
+// CHECK-NEXT:   @available(macOS 26.0, *)
+// CHECK-NEXT:   func fromAvailableProtocolExplicitIos()
+// CHECK-NEXT:   @available(macOS 26.0, *)
+// CHECK-NEXT:   class func fromAvailableProtocolExplicitIos()
+// CHECK-NEXT:   @available(macOS 26.0, *)
+// CHECK-NEXT:   func fromAvailableProtocolExplicitIosLow()
+// CHECK-NEXT:   @available(macOS 26.0, *)
+// CHECK-NEXT:   class func fromAvailableProtocolExplicitIosLow()
+// CHECK-NEXT: }

--- a/test/ClangImporter/implicit_availability.h
+++ b/test/ClangImporter/implicit_availability.h
@@ -44,8 +44,7 @@ AVAIL(macos, deprecated=15.0)
 @interface ExplicitlyAvailableDepSeparate
 - (void)doThing;
 @end
-// CHECK-NEXT: @available(macOS 14.0, *)
-// CHECK-NEXT: @available(macOS, deprecated: 15.0)
+// CHECK-NEXT: @available(macOS, introduced: 14.0, deprecated: 15.0)
 // CHECK-NEXT: class ExplicitlyAvailableDepSeparate {
 // CHECK-NEXT:   class func doThing()
 // CHECK-NEXT:   func doThing()
@@ -69,59 +68,49 @@ struct REF RefType {};
 // CHECK-NEXT: }
 
 struct REF AVAIL(macos, introduced=26.0) LateRefType {};
-// FIXME: this is invalid syntax in Swift
-// CHECK-NEXT: @available(macOS 13.3.0, macOS 26.0, *)
+// A foreign reference type with an explicit (later) availability merges
+// the implicit runtime availability and the explicit one.
+// CHECK-NEXT: @available(macOS 26.0, *)
 // CHECK-NEXT: class LateRefType {
 // CHECK-NEXT: }
 
 struct REF AVAIL(macos, deprecated=15.0, message="gone") DeprecatedRef {};
-// CHECK-NEXT: @available(macOS 13.3.0, *)
-// CHECK-NEXT: @available(macOS, deprecated: 15.0, message: "gone")
+// CHECK-NEXT: @available(macOS, introduced: 13.3.0, deprecated: 15.0, message: "gone")
 // CHECK-NEXT: class DeprecatedRef {
 // CHECK-NEXT: }
 
 struct REF AVAIL(macos, unavailable, message="nope") UnavailableRef {};
-// CHECK-NEXT: @available(macOS 13.3.0, *)
 // CHECK-NEXT: @available(macOS, unavailable, message: "nope")
 // CHECK-NEXT: class UnavailableRef {
 // CHECK-NEXT: }
 
 struct REF AVAIL(macos, introduced=14.0, deprecated=15.0) LateIntroDepRef {};
-// CHECK-NEXT: @available(macOS 13.3.0, *)
 // CHECK-NEXT: @available(macOS, introduced: 14.0, deprecated: 15.0)
 // CHECK-NEXT: class LateIntroDepRef {
 // CHECK-NEXT: }
 
 struct REF AVAIL(macos, introduced=12.0, deprecated=15.0) EarlyIntroLateDepRef {};
-// CHECK-NEXT: @available(macOS 13.3.0, *)
-// CHECK-NEXT: @available(macOS, introduced: 12.0, deprecated: 15.0)
+// CHECK-NEXT: @available(macOS, introduced: 13.3.0, deprecated: 15.0)
 // CHECK-NEXT: class EarlyIntroLateDepRef {
 // CHECK-NEXT: }
 
 struct REF AVAIL(macos, introduced=12.0, deprecated=13.0) EarlyIntroEarlyDepRef {};
-// CHECK-NEXT: @available(macOS 13.3.0, *)
-// CHECK-NEXT: @available(macOS, introduced: 12.0, deprecated: 13.0)
+// CHECK-NEXT: @available(macOS, introduced: 13.3.0, deprecated: 13.0)
 // CHECK-NEXT: class EarlyIntroEarlyDepRef {
 // CHECK-NEXT: }
 
 struct REF AVAIL(macos, introduced=12.0) AVAIL(macos, deprecated=13.0) EarlyIntroEarlyDepRefSeparate {};
-// FIXME: this is invalid syntax in Swift
-// CHECK-NEXT: @available(macOS 13.3.0, macOS 12.0, *)
-// CHECK-NEXT: @available(macOS, deprecated: 13.0)
+// CHECK-NEXT: @available(macOS, introduced: 13.3.0, deprecated: 13.0)
 // CHECK-NEXT: class EarlyIntroEarlyDepRefSeparate {
 // CHECK-NEXT: }
 
 struct REF AVAIL(macos, deprecated=13.0) DepOnlyEarly {};
-// FIXME: this is invalid syntax in Swift
-// CHECK-NEXT: @available(macOS 13.3.0, *)
-// CHECK-NEXT: @available(macOS, deprecated: 13.0)
+// CHECK-NEXT: @available(macOS, introduced: 13.3.0, deprecated: 13.0)
 // CHECK-NEXT: class DepOnlyEarly {
 // CHECK-NEXT: }
 
 struct REF AVAIL(macos, deprecated=14.0) DepOnlyLate {};
-// FIXME: this is invalid syntax in Swift
-// CHECK-NEXT: @available(macOS 13.3.0, *)
-// CHECK-NEXT: @available(macOS, deprecated: 14.0)
+// CHECK-NEXT: @available(macOS, introduced: 13.3.0, deprecated: 14.0)
 // CHECK-NEXT: class DepOnlyLate {
 // CHECK-NEXT: }
 

--- a/test/ClangImporter/lit.local.cfg
+++ b/test/ClangImporter/lit.local.cfg
@@ -1,0 +1,3 @@
+# Allow header files with RUN lines (e.g. bridging headers exercised directly)
+# to be treated as tests in this directory.
+config.suffixes.add('.h')

--- a/test/IDE/print_bridging_header.swift
+++ b/test/IDE/print_bridging_header.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-ide-test -print-module -module-to-print=__ObjC -source-filename x -import-objc-header %t/bridge.h > %t/bridge.swiftinterface
+// RUN: %diff %t/bridge.swiftinterface %t/bridge.swiftinterface.expected
+
+// -print-module recognizes the special __ObjC module name and maps it to the
+// bridging header passed via -import-objc-header, printing that header's
+// interface.
+
+//--- bridge.h
+void foo(int x);
+//--- bridge.swiftinterface.expected
+func foo(_ x: CInt)

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -35,6 +35,7 @@
 #include "swift/Basic/PathRemapper.h"
 #include "swift/Config.h"
 #include "swift/Demangling/Demangle.h"
+#include "swift/Strings.h"
 #include "swift/Driver/FrontendUtil.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
@@ -3311,6 +3312,28 @@ static int doPrintModules(const CompilerInvocation &InitInvok,
   for (StringRef ModuleToPrint : ModulesToPrint) {
     if (ModuleToPrint.empty()) {
       ExitCode = 1;
+      continue;
+    }
+
+    // The declarations imported from a bridging header live in the special
+    // __ObjC module, which cannot be resolved by name. Recognize that name and
+    // map it to the bridging header passed via -import-objc-header.
+    if (ModuleToPrint == CLANG_HEADER_MODULE_NAME) {
+      auto &FEOpts = Invocation.getFrontendOptions();
+      if (FEOpts.ImplicitObjCHeaderPath.empty()) {
+        llvm::errs() << "error: module '" << ModuleToPrint
+                     << "' requires a bridging header passed with "
+                        "-import-objc-header\n";
+        ExitCode = 1;
+        continue;
+      }
+      auto *Importer =
+          static_cast<ClangImporter *>(Context.getClangModuleLoader());
+      Importer->importBridgingHeader(FEOpts.ImplicitObjCHeaderPath,
+                                     CI.getMainModule(), /*diagLoc=*/{},
+                                     /*trackParsedSymbols=*/true);
+      printHeaderInterface(FEOpts.ImplicitObjCHeaderPath, Context, *Printer,
+                           Options);
       continue;
     }
 


### PR DESCRIPTION
When multiple sources of availability attributes interact in
ClangImporter, we can end up with an AST containing attributes that are
(sometimes partially) subsumed by other attributes. This checks existing
availability attributes and merges attributes when they target the same
platform. Thus we avoid printing an interface that would be invalid to
write in Swift.

Also adds support to swift-ide-test for printing the interface of a bridging header
using `-module-to-print=__ObjC`, to allow for simple interface testing without
needing to write a module map.