### PR TITLE
[AST] Detect that `@called(once)` capture is consumed by `@called(once)` closure during capture inference

### DIFF
--- a/include/swift/AST/CaptureInfo.h
+++ b/include/swift/AST/CaptureInfo.h
@@ -54,16 +54,17 @@ class Type;
 class CapturedValue {
   friend class Lowering::TypeConverter;
 
-public:
-  using Storage =
-      llvm::PointerIntPair<llvm::PointerUnion<ValueDecl *, Expr *>, 2,
-                           unsigned>;
-
 private:
-  Storage Value;
+  llvm::PointerUnion<ValueDecl *, Expr *> Value;
+  // This is really unfortunate but we cannot use PointerIntPair here
+  // since flags need 3 bits and only two are available because union
+  // needs an extra bit for its discriminator.
+  unsigned Flags;
   SourceLoc Loc;
 
-  explicit CapturedValue(Storage V, SourceLoc Loc) : Value(V), Loc(Loc) {}
+  explicit CapturedValue(llvm::PointerUnion<ValueDecl *, Expr *> V,
+                         unsigned Flags, SourceLoc Loc)
+      : Value(V), Flags(Flags), Loc(Loc) {}
 
 public:
   friend struct llvm::DenseMapInfo<CapturedValue>;
@@ -76,11 +77,17 @@ public:
     /// IsNoEscape is set when a vardecl is captured by a noescape closure, and
     /// thus has its lifetime guaranteed.  It can be closed over by a fixed
     /// address if it has storage.
-    IsNoEscape = 1 << 1
+    IsNoEscape = 1 << 1,
+
+    /// IsConsumed is set when a VarDecl is consumed by the closure. One example
+    /// of this would be an explicit capture like `_ = { [v] in ... }` since
+    /// explicit captures are emitted as fresh variables and initialized with an
+    /// owned r-value.
+    IsConsumed = 1 << 2,
   };
 
   CapturedValue(ValueDecl *Val, unsigned Flags, SourceLoc Loc)
-      : Value(Val, Flags), Loc(Loc) {}
+      : Value(Val), Flags(Flags), Loc(Loc) {}
 
   CapturedValue(Expr *Val, unsigned Flags);
 
@@ -89,14 +96,13 @@ public:
     return CapturedValue((ValueDecl *)nullptr, 0, SourceLoc());
   }
 
-  bool isDirect() const { return Value.getInt() & IsDirect; }
-  bool isNoEscape() const { return Value.getInt() & IsNoEscape; }
+  bool isDirect() const { return Flags & IsDirect; }
+  bool isNoEscape() const { return Flags & IsNoEscape; }
+  bool isConsumed() const { return Flags & IsConsumed; }
 
-  bool isDynamicSelfMetadata() const { return !Value.getPointer(); }
+  bool isDynamicSelfMetadata() const { return !Value; }
 
-  bool isExpr() const {
-    return Value.getPointer().dyn_cast<Expr *>();
-  }
+  bool isExpr() const { return Value.dyn_cast<Expr *>(); }
 
   bool isPackElement() const;
   bool isOpaqueValue() const;
@@ -108,16 +114,12 @@ public:
   bool isLocalCapture() const;
 
   CapturedValue mergeFlags(unsigned flags) const {
-    return CapturedValue(Storage(Value.getPointer(), getFlags() & flags), Loc);
+    return CapturedValue(Value, getFlags() & flags, Loc);
   }
 
-  ValueDecl *getDecl() const {
-    return Value.getPointer().dyn_cast<ValueDecl *>();
-  }
+  ValueDecl *getDecl() const { return Value.dyn_cast<ValueDecl *>(); }
 
-  Expr *getExpr() const {
-    return Value.getPointer().dyn_cast<Expr *>();
-  }
+  Expr *getExpr() const { return Value.dyn_cast<Expr *>(); }
 
   OpaqueValueExpr *getOpaqueValue() const;
 
@@ -127,7 +129,7 @@ public:
 
   SourceLoc getLoc() const { return Loc; }
 
-  unsigned getFlags() const { return Value.getInt(); }
+  unsigned getFlags() const { return Flags; }
 };
 
 /// Describes a type that has been captured by a closure or local function.

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -4156,6 +4156,9 @@ public:
   /// Whether this closure is Sendable.
   bool isSendable() const;
 
+  /// Whether this closure could be called at most once.
+  bool isCalledOnce() const;
+
   /// Whether this closure consists of a single expression.
   bool hasSingleExpressionBody() const;
 

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -790,8 +790,7 @@ public:
 
   /// Return the CaptureKind to use when capturing a decl.
   CaptureKind getDeclCaptureKind(CapturedValue capture,
-                                 TypeExpansionContext expansion,
-                                 const FunctionTypeInfo *closureInfo);
+                                 TypeExpansionContext expansion);
 
   /// Return a most-general-possible abstraction pattern.
   AbstractionPattern getMostGeneralAbstraction() {

--- a/lib/AST/CaptureInfo.cpp
+++ b/lib/AST/CaptureInfo.cpp
@@ -21,7 +21,7 @@
 using namespace swift;
 
 CapturedValue::CapturedValue(Expr *Val, unsigned Flags)
-    : Value(Val, Flags), Loc(SourceLoc()) {
+    : Value(Val), Flags(Flags), Loc(SourceLoc()) {
   assert(isa<OpaqueValueExpr>(Val) || isa<PackElementExpr>(Val));
 }
 
@@ -210,6 +210,6 @@ void CaptureInfo::print(raw_ostream &OS) const {
 //===----------------------------------------------------------------------===//
 
 bool CapturedValue::isLocalCapture() const {
-  auto *decl = Value.getPointer().dyn_cast<ValueDecl *>();
+  auto *decl = Value.dyn_cast<ValueDecl *>();
   return decl && decl->isLocalCapture();
 }

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2073,52 +2073,38 @@ std::optional<Type> AbstractClosureExpr::getEffectiveThrownType() const {
   return std::nullopt;
 }
 
-bool AbstractClosureExpr::isBodyThrowing() const {
-  if (!getType() || getType()->hasError()) {
+static FunctionType::ExtInfo
+getOrComputeExtInfo(const AbstractClosureExpr *closure) {
+  auto closureType = closure->getType();
+  if (!closureType || closureType->hasError()) {
     // Scan the closure body to infer effects.
-    if (auto closure = dyn_cast<ClosureExpr>(this)) {
+    if (auto explicitClosure = dyn_cast<ClosureExpr>(closure)) {
       return evaluateOrDefault(
-          getASTContext().evaluator,
-          ClosureEffectsRequest{const_cast<ClosureExpr *>(closure)},
-          FunctionType::ExtInfo()).isThrowing();
+          closure->getASTContext().evaluator,
+          ClosureEffectsRequest{const_cast<ClosureExpr *>(explicitClosure)},
+          FunctionType::ExtInfo());
     }
 
-    return false;
+    return {};
   }
-  
-  return getType()->castTo<FunctionType>()->getExtInfo().isThrowing();
+
+  return closureType->castTo<FunctionType>()->getExtInfo();
+}
+
+bool AbstractClosureExpr::isBodyThrowing() const {
+  return getOrComputeExtInfo(this).isThrowing();
 }
 
 bool AbstractClosureExpr::isSendable() const {
-  if (!getType() || getType()->hasError()) {
-    // Scan the closure body to infer effects.
-    if (auto closure = dyn_cast<ClosureExpr>(this)) {
-      return evaluateOrDefault(
-          getASTContext().evaluator,
-          ClosureEffectsRequest{const_cast<ClosureExpr *>(closure)},
-          FunctionType::ExtInfo()).isSendable();
-    }
-
-    return false;
-  }
-
-  return getType()->castTo<FunctionType>()->getExtInfo().isSendable();
+  return getOrComputeExtInfo(this).isSendable();
 }
 
 bool AbstractClosureExpr::isBodyAsync() const {
-  if (!getType() || getType()->hasError()) {
-    // Scan the closure body to infer effects.
-    if (auto closure = dyn_cast<ClosureExpr>(this)) {
-      return evaluateOrDefault(
-          getASTContext().evaluator,
-          ClosureEffectsRequest{const_cast<ClosureExpr *>(closure)},
-          FunctionType::ExtInfo()).isAsync();
-    }
+  return getOrComputeExtInfo(this).isAsync();
+}
 
-    return false;
-  }
-
-  return getType()->castTo<FunctionType>()->getExtInfo().isAsync();
+bool AbstractClosureExpr::isCalledOnce() const {
+  return getOrComputeExtInfo(this).isCalledOnce();
 }
 
 bool AbstractClosureExpr::hasSingleExpressionBody() const {

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2528,7 +2528,7 @@ lowerCaptureContextParameters(TypeConverter &TC, SILDeclRef function,
         TC.getTypeLowering(AbstractionPattern(genericSig, interfaceType),
                            interfaceType, expansion);
     auto loweredTy = loweredTL.getLoweredType();
-    switch (TC.getDeclCaptureKind(capture, expansion, closureInfo)) {
+    switch (TC.getDeclCaptureKind(capture, expansion)) {
     case CaptureKind::Constant: {
       // Constants are captured by value.
       ParameterConvention convention;

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -133,6 +133,9 @@ TypeConverter::getDeclCaptureKind(CapturedValue capture,
     return CaptureKind::Immutable;
   }
 
+  if (capture.isConsumed())
+    return CaptureKind::Consuming;
+
   auto decl = capture.getDecl();
   auto *var = cast<VarDecl>(decl);
   assert(var->hasStorage() &&
@@ -146,17 +149,6 @@ TypeConverter::getDeclCaptureKind(CapturedValue capture,
   bool isInOutCapture = false;
   if (auto *param = dyn_cast<ParamDecl>(var))
     isInOutCapture = param->isInOut();
-
-  if (!isInOutCapture && !capture.isNoEscape()) {
-    // @called(once) capture of a @called(once) closure is supposed to
-    // be consumed by the closure because it's guaranteed to be called
-    // at most once.
-    if (auto *fnTy = contextTy->getAs<AnyFunctionType>()) {
-      if (fnTy->isCalledOnce() && closureInfo &&
-          closureInfo->ExpectedLoweredType->isCalledOnce())
-        return CaptureKind::Consuming;
-    }
-  }
 
   // If this is a noncopyable 'let' constant that is not a shared paramdecl or
   // used by a noescape capture, then we know it is boxed and want to pass it in

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -118,8 +118,7 @@ static bool hasSingletonMetatype(CanType instanceType) {
 
 CaptureKind
 TypeConverter::getDeclCaptureKind(CapturedValue capture,
-                                  TypeExpansionContext expansion,
-                                  const FunctionTypeInfo *closureInfo) {
+                                  TypeExpansionContext expansion) {
   if (auto *expr = capture.getPackElement()) {
     auto contextTy = expr->getType();
     auto props = getTypeProperties(
@@ -145,10 +144,6 @@ TypeConverter::getDeclCaptureKind(CapturedValue capture,
   auto props = getTypeProperties(
       contextTy, TypeExpansionContext::noOpaqueTypeArchetypesSubstitution(
                           expansion.getResilienceExpansion()));
-
-  bool isInOutCapture = false;
-  if (auto *param = dyn_cast<ParamDecl>(var))
-    isInOutCapture = param->isInOut();
 
   // If this is a noncopyable 'let' constant that is not a shared paramdecl or
   // used by a noescape capture, then we know it is boxed and want to pass it in

--- a/lib/SILGen/SILGenConcurrency.cpp
+++ b/lib/SILGen/SILGenConcurrency.cpp
@@ -639,9 +639,9 @@ static ManagedValue emitLoadOfCaptureIsolation(SILGenFunction &SGF,
     if (capturedVar != isolatedCapture) continue;
 
     // Captured actor references should always be captured as constants.
-    assert(TC.getDeclCaptureKind(
-               capture, TC.getCaptureTypeExpansionContext(constant),
-               TC.getClosureTypeInfo(constant)) == CaptureKind::Constant);
+    assert(TC.getDeclCaptureKind(capture,
+                                 TC.getCaptureTypeExpansionContext(constant)) ==
+           CaptureKind::Constant);
 
     auto value = captureArgs[i].copy(SGF, loc);
     return SGF.emitActorInstanceIsolation(loc, value, isolatedVarType);

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -670,8 +670,7 @@ void SILGenFunction::emitCaptures(SILLocation loc,
       Diags.diagnose(capture.getLoc(), diag::value_captured_here);
 
       // Emit an 'undef' of the correct type.
-      auto captureKind = SGM.Types.getDeclCaptureKind(
-          capture, expansion, SGM.Types.getClosureTypeInfo(closure));
+      auto captureKind = SGM.Types.getDeclCaptureKind(capture, expansion);
       switch (captureKind) {
       case CaptureKind::Constant:
       case CaptureKind::Consuming:
@@ -785,8 +784,7 @@ void SILGenFunction::emitCaptures(SILLocation loc,
     auto &Entry = found->second;
     auto val = Entry.value;
 
-    switch (SGM.Types.getDeclCaptureKind(
-        capture, expansion, SGM.Types.getClosureTypeInfo(closure))) {
+    switch (SGM.Types.getDeclCaptureKind(capture, expansion)) {
     case CaptureKind::Constant: {
       assert(!isPack);
 

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1221,7 +1221,6 @@ static void emitCaptureArguments(SILGenFunction &SGF,
                                  GenericSignature origGenericSig,
                                  CapturedValue capture,
                                  uint16_t ArgNo) {
-  auto closureInfo = SGF.TypeContext ? &*SGF.TypeContext : nullptr;
   if (auto *expr = capture.getPackElement()) {
     SILLocation Loc(expr);
     Loc.markAsPrologue();
@@ -1235,8 +1234,7 @@ static void emitCaptureArguments(SILGenFunction &SGF,
     SILValue arg;
 
     auto expansion = SGF.getTypeExpansionContext();
-    auto captureKind =
-        SGF.SGM.Types.getDeclCaptureKind(capture, expansion, closureInfo);
+    auto captureKind = SGF.SGM.Types.getDeclCaptureKind(capture, expansion);
     switch (captureKind) {
     case CaptureKind::Constant:
     case CaptureKind::StorageAddress:
@@ -1321,8 +1319,7 @@ static void emitCaptureArguments(SILGenFunction &SGF,
   SILFunctionArgument *box = nullptr;
 
   auto expansion = SGF.getTypeExpansionContext();
-  auto captureKind =
-      SGF.SGM.Types.getDeclCaptureKind(capture, expansion, closureInfo);
+  auto captureKind = SGF.SGM.Types.getDeclCaptureKind(capture, expansion);
   SILAccessEnforcement enforcement;
   switch (captureKind) {
   case CaptureKind::Constant: {

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -64,18 +64,16 @@ class FindCapturedVars : public ASTWalker {
   OpaqueValueExpr *OpaqueValue = nullptr;
   SourceLoc CaptureLoc;
   DeclContext *CurDC;
-  bool NoEscape, ObjC;
+  bool NoEscape, ObjC, CalledOnce;
   bool HasGenericParamCaptures;
   bool HasUsesOfCurrentIsolation = false;
 
 public:
-  FindCapturedVars(SourceLoc CaptureLoc,
-                   DeclContext *CurDC,
-                   bool NoEscape,
-                   bool ObjC,
-                   bool IsGenericFunction)
+  FindCapturedVars(SourceLoc CaptureLoc, DeclContext *CurDC, bool NoEscape,
+                   bool ObjC, bool IsGenericFunction, bool IsCalledOnce)
       : Context(CurDC->getASTContext()), CaptureLoc(CaptureLoc), CurDC(CurDC),
-        NoEscape(NoEscape), ObjC(ObjC), HasGenericParamCaptures(IsGenericFunction) {}
+        NoEscape(NoEscape), ObjC(ObjC), CalledOnce(IsCalledOnce),
+        HasGenericParamCaptures(IsGenericFunction) {}
 
   CaptureInfo getCaptureInfo() const {
     DynamicSelfType *dynamicSelfToRecord = nullptr;
@@ -249,6 +247,9 @@ public:
       // then the result is escaping.
       auto existing = Captures[entryNumber-1];
       unsigned flags = existing.getFlags() & capture.getFlags();
+      // One consuming use makes the capture consuming.
+      if (existing.isConsumed() || capture.isConsumed())
+        flags |= CapturedValue::IsConsumed;
       capture = CapturedValue(VD, flags, existing.getLoc());
       Captures[entryNumber-1] = capture;
     }
@@ -406,6 +407,15 @@ public:
                                       : AccessKind::Read,
               CurDC->getParentModule(), CurDC->getResilienceExpansion()))
         Flags |= CapturedValue::IsDirect;
+
+      // `@called(once)` captures can be moved into `@called(once)` closures
+      // because the closure itself cannot be called more than once.
+      if (CalledOnce) {
+        if (auto fnType = var->getInterfaceType()->getAs<AnyFunctionType>()) {
+          if (fnType->isCalledOnce())
+            Flags |= CapturedValue::IsConsumed;
+        }
+      }
     }
 
     // If the closure is noescape, then we can capture the decl as noescape.
@@ -453,6 +463,10 @@ public:
       // escaping, even if they are coming from an inner noescape closure.
       if (!NoEscape)
         Flags &= ~CapturedValue::IsNoEscape;
+
+      // Regular closures cannot consume their captures.
+      if (!CalledOnce)
+        Flags &= ~CapturedValue::IsConsumed;
 
       addCapture(capture.mergeFlags(Flags));
     }
@@ -823,9 +837,11 @@ CaptureInfo CaptureInfoRequest::evaluate(Evaluator &evaluator,
   if (type->is<ErrorType>())
     return CaptureInfo::empty();
 
-  bool isNoEscape = type->castTo<AnyFunctionType>()->isNoEscape();
-  FindCapturedVars finder(AFD->getLoc(), AFD, isNoEscape,
-                          AFD->isObjC(), AFD->hasGenericParamList());
+  auto fnType = type->castTo<AnyFunctionType>();
+  bool isNoEscape = fnType->isNoEscape();
+  bool isCalledOnce = fnType->isCalledOnce();
+  FindCapturedVars finder(AFD->getLoc(), AFD, isNoEscape, AFD->isObjC(),
+                          AFD->hasGenericParamList(), isCalledOnce);
 
   if (auto *body = AFD->getTypecheckedBody())
     body->walk(finder);
@@ -888,9 +904,11 @@ void TypeChecker::computeCaptures(AbstractClosureExpr *ACE) {
     return;
   }
 
-  bool isNoEscape = type->castTo<FunctionType>()->isNoEscape();
+  auto fnType = type->castTo<FunctionType>();
+  bool isNoEscape = fnType->isNoEscape();
+  bool isCalledOnce = fnType->isCalledOnce();
   FindCapturedVars finder(ACE->getLoc(), ACE, isNoEscape,
-                          /*isObjC=*/false, /*isGeneric=*/false);
+                          /*isObjC=*/false, /*isGeneric=*/false, isCalledOnce);
   body->walk(finder);
 
   finder.checkType(type, ACE->getLoc());
@@ -910,11 +928,15 @@ CaptureInfo ParamCaptureInfoRequest::evaluate(Evaluator &evaluator,
   // A generic function always captures outer generic parameters.
   bool isGeneric = DC->isInnermostContextGeneric();
 
-  FindCapturedVars finder(E->getLoc(),
-                          DC,
+  bool isCalledOnce = false;
+  if (auto *closure = dyn_cast<AbstractClosureExpr>(E)) {
+    isCalledOnce = closure->isCalledOnce();
+  }
+
+  FindCapturedVars finder(E->getLoc(), DC,
                           /*isNoEscape=*/false,
                           /*isObjC=*/false,
-                          /*IsGeneric*/isGeneric);
+                          /*IsGeneric*/ isGeneric, isCalledOnce);
   E->walk(finder);
 
   if (!DC->getParent()->isLocalContext() &&
@@ -942,7 +964,8 @@ CaptureInfo PatternBindingCaptureInfoRequest::evaluate(Evaluator &evaluator,
   FindCapturedVars finder(init->getLoc(), DC,
                           /*NoEscape=*/false,
                           /*ObjC=*/false,
-                          /*IsGenericFunction*/ false);
+                          /*IsGenericFunction*/ false,
+                          /*IsCalledOnce=*/false);
   init->walk(finder);
 
   auto &ctx = DC->getASTContext();


### PR DESCRIPTION
Introduce a new `CapturedValue` flag - `IsConsumed` that is used to indicate whether the capture
is going to be consumed by the closure. This flag currently only applies to captures of `@called(once)`
values by `@called(once)` closures but the idea is to use extend that to other non-Copyable values
that have consuming uses in `@called(once)` closures.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
