### PR TITLE
[Concurrency] Fix async stream onTermination handler stack exhaustion

### DIFF
--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -122,7 +122,9 @@ public struct AsyncStream<Element> {
       /// The stream finished as a result of cancellation.
       case cancelled
     }
-    
+
+    internal typealias Storage = _AsyncStreamStorage<Element, Never, Termination>
+
     /// A type that indicates the result of yielding a value to a client, by
     /// way of the continuation.
     ///
@@ -181,7 +183,7 @@ public struct AsyncStream<Element> {
       case bufferingNewest(Int)
     }
 
-    let storage: _AsyncStreamStorage<Element, Never>
+    let storage: Storage
 
     /// Resume the task awaiting the next iteration point by having it return
     /// normally from its suspension point with a given element.
@@ -229,20 +231,20 @@ public struct AsyncStream<Element> {
     /// ``withTaskCancellationHandler(operation:onCancel:)``.
     public var onTermination: (@Sendable (Termination) -> Void)? {
       get {
-        return adaptToStreamTerminationHandler(storage.getOnTermination())
+        return unbox(storage.getOnTermination())
       }
       nonmutating set {
-        storage.setOnTermination(adaptToStorageTerminationHandler(newValue))
+        storage.setOnTermination(box(newValue))
       }
     }
   }
 
   final class _Context {
-    let storage: _AsyncStreamStorage<Element, Never>?
+    let storage: Continuation.Storage?
     let produce: () async -> Element?
 
     init(
-      storage: _AsyncStreamStorage<Element, Never>? = nil,
+      storage: Continuation.Storage? = nil,
       produce: @escaping () async -> Element?
     ) {
       self.storage = storage
@@ -304,7 +306,7 @@ public struct AsyncStream<Element> {
     bufferingPolicy limit: Continuation.BufferingPolicy = .unbounded,
     _ build: (Continuation) -> Void
   ) {
-    let storage: _AsyncStreamStorage<Element, Never> = .init(
+    let storage: Continuation.Storage = .init(
       bufferingPolicy: limit.asStorageBufferingPolicy()
     )
     context = _Context(storage: storage, produce: storage.next)

--- a/stdlib/public/Concurrency/AsyncStreamBuffer.swift
+++ b/stdlib/public/Concurrency/AsyncStreamBuffer.swift
@@ -120,7 +120,9 @@ fileprivate struct Disconnected<Value: ~Copyable>: ~Copyable, @unchecked Sendabl
 /// Once the stream has reached its terminal state, all subsequent consumers will **immediately return nil**,
 /// and any **new values are rejected**.
 @safe
-internal final class _AsyncStreamStorage<Element, Failure: Error>: @unchecked Sendable {
+internal final class _AsyncStreamStorage<
+  Element, Failure: Error, PublicTermination
+>: @unchecked Sendable {
   struct Continuation {
     enum BufferingPolicy {
       case unbounded
@@ -150,7 +152,7 @@ internal final class _AsyncStreamStorage<Element, Failure: Error>: @unchecked Se
     typealias Buffer = _Deque<Element>
     typealias Consumer = UnsafeContinuation<Result<Element?, Failure>, Never> // TODO: Switch to ~Copyable Continuation
     typealias Consumers = _Deque<Consumer> // TODO: Switch to UniqueDeque
-    typealias TerminationHandler = @Sendable (Continuation.Termination) -> Void
+    typealias TerminationHandler = _AsyncStreamTerminationHandlerBox<Element, Failure, PublicTermination>
 
     @unsafe
     enum State: ~Copyable {
@@ -264,6 +266,33 @@ internal final class _AsyncStreamStorage<Element, Failure: Error>: @unchecked Se
   }
 }
 
+/// Holds the termination handler an adopter installed through the public
+/// `Continuation.onTermination` setter.
+@safe
+internal final class _AsyncStreamTerminationHandlerBox<
+  Element, Failure: Error, TerminationType
+>: Sendable {
+  typealias StorageTermination =
+    _AsyncStreamStorage<Element, Failure, TerminationType>.Continuation.Termination
+
+  let handler: @Sendable (TerminationType) -> Void
+  private let invokeHandler: @Sendable (StorageTermination) -> Void
+
+  /// `map` translates the storage's `Termination` and is installed once, when
+  /// the box is created, so no wrapper is ever appended to `handler` itself
+  init(
+    handler: @escaping @Sendable (TerminationType) -> Void,
+    map: @escaping @Sendable (StorageTermination) -> TerminationType
+  ) {
+    self.handler = handler
+    self.invokeHandler = { termination in handler(map(termination)) }
+  }
+
+  func invoke(_ termination: StorageTermination) {
+    self.invokeHandler(termination)
+  }
+}
+
 extension _AsyncStreamStorage.StateMachine {
   enum BufferingNewestDecision {
     case append
@@ -297,24 +326,35 @@ extension _AsyncStreamStorage.StateMachine {
     }
   }
 
-  mutating func setOnTermination(_ newValue: TerminationHandler?) {
+  /// Set a termination handler.
+  ///
+  /// - Returns: the previous handler, if there was one.
+  mutating func setOnTermination(_ newValue: TerminationHandler?) -> TerminationHandler? {
+    var previous: TerminationHandler? = nil
+
     switch unsafe consume self.state { // TODO: Set a TerminationHandler only in certain states
     case .idle(var idle):
+      previous = idle.terminationHandler
       idle.terminationHandler = newValue
       unsafe self = .init(state: .idle(idle))
 
     case .waiting(var waiting):
+      previous = unsafe waiting.terminationHandler
       unsafe waiting.terminationHandler = newValue
       unsafe self = .init(state: .waiting(waiting))
 
     case .draining(var draining):
+      previous = draining.terminationHandler
       draining.terminationHandler = newValue
       unsafe self = .init(state: .draining(draining))
 
     case .terminated(var terminated):
+      previous = terminated.terminationHandler
       terminated.terminationHandler = newValue
       unsafe self = .init(state: .terminated(terminated))
     }
+
+    return previous
   }
 
   mutating func yield(_ value: consuming sending Element) -> YieldAction {
@@ -535,9 +575,13 @@ extension _AsyncStreamStorage {
   }
 
   func setOnTermination(_ newValue: StateMachine.TerminationHandler?) {
-    withLock { state in
-      state.setOnTermination(newValue)
+    // The handler we're replacing must be released after the lock is
+    // dropped: an adopter may have composed a chain of handlers, and releasing
+    // that chain can run arbitrary `deinit` code
+    let previous = withLock { state in
+      return state.setOnTermination(newValue)
     }
+    withExtendedLifetime(previous) {}
   }
 
   func yield(_ value: consuming sending Element) -> Continuation.YieldResult {
@@ -600,7 +644,7 @@ extension _AsyncStreamStorage {
 
     switch unsafe consume action {
     case .callAndResume(var callAndResume):
-      unsafe callAndResume.terminationHandler?(terminationReason)
+      unsafe callAndResume.terminationHandler?.invoke(terminationReason)
 
       if let failure = unsafe callAndResume.failure {
         let consumer = unsafe callAndResume.consumers.removeFirst()
@@ -612,7 +656,7 @@ extension _AsyncStreamStorage {
       }
 
     case .call(let terminationHandler):
-      terminationHandler?(terminationReason)
+      terminationHandler?.invoke(terminationReason)
 
     case .none:
       return

--- a/stdlib/public/Concurrency/AsyncStreamShims.swift
+++ b/stdlib/public/Concurrency/AsyncStreamShims.swift
@@ -20,7 +20,7 @@ import Swift
 
 extension AsyncStream.Continuation.BufferingPolicy {
   func asStorageBufferingPolicy()
-  -> _AsyncStreamStorage<Element, Never>.Continuation.BufferingPolicy {
+  -> AsyncStream<Element>.Continuation.Storage.Continuation.BufferingPolicy {
     switch self {
     case .unbounded:
       return .unbounded
@@ -33,18 +33,6 @@ extension AsyncStream.Continuation.BufferingPolicy {
 }
 
 // Termination
-
-extension AsyncStream.Continuation.Termination {
-  func asStorageTermination()
-  -> _AsyncStreamStorage<Element, Never>.Continuation.Termination {
-    switch self {
-    case .finished:
-      return .finished(nil)
-    case .cancelled:
-      return .cancelled
-    }
-  }
-}
 
 extension _AsyncStreamStorage.Continuation.Termination {
   func asStreamTermination()
@@ -61,34 +49,19 @@ extension _AsyncStreamStorage.Continuation.Termination {
 // TerminationHandler
 
 extension AsyncStream.Continuation {
-  internal typealias StorageTerminationHandler =
-  @Sendable (_AsyncStreamStorage<Element, Never>.Continuation.Termination) -> Void
+  internal typealias TerminationHandlerBox =
+    _AsyncStreamTerminationHandlerBox<Element, Never, Termination>
 
-  internal typealias StreamTerminationHandler =
-  @Sendable (Termination) -> Void
+  func box(_ onTermination: (@Sendable (Termination) -> Void)?) -> TerminationHandlerBox? {
+    guard let onTermination else { return nil }
 
-  func adaptToStreamTerminationHandler(
-    _ onTermination: StorageTerminationHandler?
-  ) -> StreamTerminationHandler? {
-    guard
-      let onTermination
-    else { return nil }
-
-    return { @Sendable termination in
-      onTermination(termination.asStorageTermination())
+    return TerminationHandlerBox(handler: onTermination) { termination in
+      termination.asStreamTermination()
     }
   }
 
-  func adaptToStorageTerminationHandler(
-    _ onTermination: StreamTerminationHandler?
-  ) -> StorageTerminationHandler? {
-    guard
-      let onTermination
-    else { return nil }
-
-    return { @Sendable termination in
-      onTermination(termination.asStreamTermination())
-    }
+  func unbox(_ box: TerminationHandlerBox?) -> (@Sendable (Termination) -> Void)? {
+    return box?.handler
   }
 }
 
@@ -114,7 +87,7 @@ extension _AsyncStreamStorage.Continuation.YieldResult {
 
 extension AsyncThrowingStream.Continuation.BufferingPolicy {
   func asStorageBufferingPolicy()
-  -> _AsyncStreamStorage<Element, Failure>.Continuation.BufferingPolicy {
+  -> AsyncThrowingStream<Element, Failure>.Continuation.Storage.Continuation.BufferingPolicy {
     switch self {
     case .unbounded:
       return .unbounded
@@ -127,18 +100,6 @@ extension AsyncThrowingStream.Continuation.BufferingPolicy {
 }
 
 // Termination
-
-extension AsyncThrowingStream.Continuation.Termination {
-  func asStorageTermination()
-  -> _AsyncStreamStorage<Element, Failure>.Continuation.Termination {
-    switch self {
-    case .finished:
-      return .finished(nil)
-    case .cancelled:
-      return .cancelled
-    }
-  }
-}
 
 extension _AsyncStreamStorage.Continuation.Termination {
   func asStreamTermination()
@@ -155,34 +116,19 @@ extension _AsyncStreamStorage.Continuation.Termination {
 // TerminationHandler
 
 extension AsyncThrowingStream.Continuation {
-  internal typealias StorageTerminationHandler =
-  @Sendable (_AsyncStreamStorage<Element, Failure>.Continuation.Termination) -> Void
+  internal typealias TerminationHandlerBox =
+    _AsyncStreamTerminationHandlerBox<Element, Failure, Termination>
 
-  internal typealias StreamTerminationHandler =
-  @Sendable (Termination) -> Void
+  func box(_ onTermination: (@Sendable (Termination) -> Void)?) -> TerminationHandlerBox? {
+    guard let onTermination else { return nil }
 
-  func adaptToStreamTerminationHandler(
-    _ onTermination: StorageTerminationHandler?
-  ) -> StreamTerminationHandler? {
-    guard
-      let onTermination
-    else { return nil }
-
-    return { @Sendable termination in
-      onTermination(termination.asStorageTermination())
+    return TerminationHandlerBox(handler: onTermination) { termination in
+      termination.asStreamTermination()
     }
   }
 
-  func adaptToStorageTerminationHandler(
-    _ onTermination: StreamTerminationHandler?
-  ) -> StorageTerminationHandler? {
-    guard
-      let onTermination
-    else { return nil }
-
-    return { @Sendable termination in
-      onTermination(termination.asStreamTermination())
-    }
+  func unbox(_ box: TerminationHandlerBox?) -> (@Sendable (Termination) -> Void)? {
+    return box?.handler
   }
 }
 

--- a/stdlib/public/Concurrency/AsyncThrowingStream.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingStream.swift
@@ -145,7 +145,9 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
       /// The stream finished as a result of cancellation.
       case cancelled
     }
-    
+
+    internal typealias Storage = _AsyncStreamStorage<Element, Failure, Termination>
+
     /// A type that indicates the result of yielding a value to a client, by
     /// way of the continuation.
     ///
@@ -205,7 +207,7 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
       case bufferingNewest(Int)
     }
 
-    let storage: _AsyncStreamStorage<Element, Failure>
+    let storage: Storage
 
     /// Resume the task awaiting the next iteration point by having it return
     /// normally from its suspension point with a given element.
@@ -255,20 +257,20 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
     /// ``withTaskCancellationHandler(operation:onCancel:)``.
     public var onTermination: (@Sendable (Termination) -> Void)? {
       get {
-        return adaptToStreamTerminationHandler(storage.getOnTermination())
+        return unbox(storage.getOnTermination())
       }
       nonmutating set {
-        storage.setOnTermination(adaptToStorageTerminationHandler(newValue))
+        storage.setOnTermination(box(newValue))
       }
     }
   }
 
   final class _Context {
-    let storage: _AsyncStreamStorage<Element, Failure>?
+    let storage: Continuation.Storage?
     let produce: () async throws(Failure) -> Element?
 
     init(
-      storage: _AsyncStreamStorage<Element, Failure>? = nil,
+      storage: Continuation.Storage? = nil,
       produce: @escaping () async throws(Failure) -> Element?
     ) {
       self.storage = storage
@@ -341,7 +343,7 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
     bufferingPolicy limit: Continuation.BufferingPolicy = .unbounded,
     _ build: (Continuation) -> Void
   ) where Failure == Error {
-    let storage: _AsyncStreamStorage<Element, Failure> = .init(
+    let storage: Continuation.Storage = .init(
       bufferingPolicy: limit.asStorageBufferingPolicy()
     )
     context = _Context(storage: storage, produce: storage.next)

--- a/test/Concurrency/Runtime/async_stream_termination_handler_stack.swift
+++ b/test/Concurrency/Runtime/async_stream_termination_handler_stack.swift
@@ -1,0 +1,142 @@
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library)
+
+// REQUIRES: concurrency
+// REQUIRES: executable_test
+// REQUIRES: concurrency_runtime
+
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: freestanding
+// XFAIL: OS=emscripten
+
+// Reading `Continuation.onTermination` and writing it back
+// must not accumulate closure wrappers. Doing so may create a long chain
+// of closures which would be destroyed linearily upon destruction,
+// and a too long chain may exhaust the stack.
+//
+// This is a specific regression test for this situation.
+// See: https://github.com/swiftlang/swift/pull/91086 / rdar://183369172
+//
+// This test uses a small probe in the closure, to see if we're accumulating
+// increasingly more closures or not by accident. This would have shown increasing
+// "stack usage" in a closure wrapping impl that would be prone to these issues.
+
+import _Concurrency
+import Synchronization
+import StdlibUnittest
+
+// Releasing the chain must not deepen as round trips accumulate. A regressed
+// implementation grows this by roughly 1730 bytes per round trip, so even a
+// handful of extra round trips clears this comfortably
+let growthToleranceBytes = 4 * 1024
+
+struct ProbeState {
+  var releaseAddress: UInt = 0
+  var releaseCount: Int = 0
+}
+
+let probeState = Mutex(ProbeState())
+
+@inline(never)
+func stackAddress() -> UInt {
+  var local: Int = 0 // sneaky trick to get stack address we're at
+  return withUnsafeMutablePointer(to: &local) { UInt(bitPattern: $0) }
+}
+
+// Owned only by the `onTermination` closure, so `deinit` runs at the deepest
+// point of the recursive release of the handler chain
+final class StackProbe {
+  deinit {
+    let address = stackAddress()
+    probeState.withLock { state in
+      state.releaseCount += 1
+      state.releaseAddress = address
+    }
+  }
+}
+
+func resetProbe() {
+  probeState.withLock { state in
+    state = ProbeState()
+  }
+}
+
+// The returned closure is the sole owner of the probe. Callers must assign it
+// straight into `onTermination` without binding it to a local, otherwise the
+// enclosing frame keeps the probe alive past the teardown being measured.
+@inline(never)
+func makeProbeHandler<Termination>(
+  _: Termination.Type = Termination.self
+) -> @Sendable (Termination) -> Void {
+  return { [probe = StackProbe()] _ in
+    withExtendedLifetime(probe) {}
+  }
+}
+
+func stackDelta(from reference: UInt, to measured: UInt) -> Int {
+  guard measured != 0 else { return -1 }
+  return Int(reference > measured ? reference - measured : measured - reference)
+}
+
+// This is synchronous, so `finish()` releases the handler chain on the same
+// thread that took the reference address and the two are comparable
+@inline(never)
+func releaseCost(roundTrips: Int) -> Int {
+  let reference = stackAddress()
+  resetProbe()
+  do {
+    let (stream, continuation) = AsyncStream<Int>.makeStream()
+    continuation.onTermination = makeProbeHandler()
+    for _ in 0..<roundTrips {
+      continuation.onTermination = continuation.onTermination
+    }
+    continuation.finish()
+    withExtendedLifetime(stream) {}
+  }
+  return stackDelta(from: reference, to: probeState.withLock { $0.releaseAddress })
+}
+
+@inline(never)
+func releaseCostThrowing(roundTrips: Int) -> Int {
+  let reference = stackAddress()
+  resetProbe()
+  do {
+    let (stream, continuation) = AsyncThrowingStream<Int, Error>.makeStream()
+    continuation.onTermination = makeProbeHandler()
+    for _ in 0..<roundTrips {
+      continuation.onTermination = continuation.onTermination
+    }
+    continuation.finish()
+    withExtendedLifetime(stream) {}
+  }
+  return stackDelta(from: reference, to: probeState.withLock { $0.releaseAddress })
+}
+
+@MainActor var tests = TestSuite("AsyncStreamTerminationHandlerStack")
+
+@main struct Main {
+  static func main() async {
+    tests.test("AsyncStream onTermination round trip does not grow the handler chain") {
+      let one = releaseCost(roundTrips: 1)
+      let many = releaseCost(roundTrips: 8)
+      print("release: \(one) bytes at 1 round trip, \(many) bytes at 8")
+
+      expectEqual(1, probeState.withLock { $0.releaseCount })
+      expectGE(one, 0)
+      expectGE(many, 0)
+      expectLT(many - one, growthToleranceBytes)
+    }
+
+    tests.test("AsyncThrowingStream onTermination round trip does not grow the handler chain") {
+      let one = releaseCostThrowing(roundTrips: 1)
+      let many = releaseCostThrowing(roundTrips: 8)
+      print("release: \(one) bytes at 1 round trip, \(many) bytes at 8")
+
+      expectEqual(1, probeState.withLock { $0.releaseCount })
+      expectGE(one, 0)
+      expectGE(many, 0)
+      expectLT(many - one, growthToleranceBytes)
+    }
+
+    await runAllTestsAsync()
+  }
+}


### PR DESCRIPTION
By doing the closure "adapter" each time, the previous approach would cause a long chain of closures with the adapters; this would then be released in a long chain of objects, potentially exhausting the stack.

This revised approach uses a box and only adapts the termination once.

Resolves rdar://183369172 so we won't have to revert the impl yet again (https://github.com/swiftlang/swift/pull/91086)
