### PR TITLE
[cxx-interop] Remove some redundant test requirements

### DIFF
--- a/test/Interop/Cxx/class/inheritance/protected-special-member-executable.swift
+++ b/test/Interop/Cxx/class/inheritance/protected-special-member-executable.swift
@@ -2,9 +2,10 @@
 //
 // REQUIRES: executable_test
 //
-// REQUIRES: rdar168302720
 // Fails on Windows：  https://github.com/swiftlang/swift/issues/67288
 // Fails on non-macOS: https://github.com/swiftlang/swift/issues/86426
+// See also rdar://168302720
+// REQUIRES: OS=macosx
 
 import StdlibUnittest
 import ProtectedSpecialMember

--- a/test/Interop/Cxx/objc-correctness/posix.swift
+++ b/test/Interop/Cxx/objc-correctness/posix.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=swift-5.9 %s
-// REQUIRES: objc_interop
 
 import MockPOSIX
 


### PR DESCRIPTION
There is one that should not require the ObjC runtime and one that should pass on macOS but was blanket disabled.
