### PR TITLE
[cxx-interop] Mark value types with pure virtual methods as unavailable

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2916,6 +2916,14 @@ namespace {
 
       if (cxxRecordDecl) {
         if (auto structResult = dyn_cast<StructDecl>(result)) {
+          // If this class is abstract, any of its methods might use a pure
+          // virtual method.
+          if (cxxRecordDecl->isAbstract()) {
+            Impl.markUnavailable(
+                result,
+                "abstract C++ classes cannot be used as values in Swift");
+          }
+
           // Address-only type is a type that can't be passed in registers.
           // Address-only types are typically non-trivial, however some
           // non-trivial types can be loadable as well (although such types

--- a/test/Interop/Cxx/class/inheritance/Inputs/abstract-class-value-type.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/abstract-class-value-type.h
@@ -1,0 +1,25 @@
+class AbstractBase {
+public:
+  AbstractBase(int x) : _x(x) {}
+  virtual ~AbstractBase() {}
+
+  int getValue() const { return _x; }
+  int callsPureVirtual() const { return pureVirtual(); }
+
+  virtual int pureVirtual() const = 0;
+
+private:
+  int _x;
+};
+
+class ConcreteDerived : public AbstractBase {
+public:
+  ConcreteDerived() : AbstractBase(42) {}
+  int pureVirtual() const override { return 123; }
+  ~ConcreteDerived() {}
+};
+
+class StillAbstractDerived : public AbstractBase {
+public:
+  StillAbstractDerived() : AbstractBase(0) {}
+};

--- a/test/Interop/Cxx/class/inheritance/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/inheritance/Inputs/module.modulemap
@@ -59,3 +59,8 @@ module InheritedStringField {
   header "inherited-string-field.h"
   requires cplusplus
 }
+
+module AbstractClassValueType {
+  header "abstract-class-value-type.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/class/inheritance/abstract-class-value-type-typechecker.swift
+++ b/test/Interop/Cxx/class/inheritance/abstract-class-value-type-typechecker.swift
@@ -1,0 +1,14 @@
+// RUN: %target-typecheck-verify-swift -suppress-notes -I %S/Inputs -cxx-interoperability-mode=default
+
+import AbstractClassValueType
+
+func takesAbstractByValue(_ x: AbstractBase) {} // expected-error {{'AbstractBase' is unavailable: abstract C++ classes cannot be used as values in Swift}}
+func returnsAbstract() -> AbstractBase {} // expected-error {{'AbstractBase' is unavailable: abstract C++ classes cannot be used as values in Swift}}
+
+_ = AbstractBase.self // expected-error {{'AbstractBase' is unavailable: abstract C++ classes cannot be used as values in Swift}}
+
+func takesStillAbstract(_ x: StillAbstractDerived) {} // expected-error {{'StillAbstractDerived' is unavailable: abstract C++ classes cannot be used as values in Swift}}
+
+let a = ConcreteDerived()
+let b = a
+_ = b.getValue()

--- a/test/Interop/Cxx/class/inheritance/virtual-methods-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/virtual-methods-module-interface.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-ide-test -print-module -cxx-interoperability-mode=default -print-implicit-attrs -module-to-print=VirtualMethods -I %S/Inputs -source-filename=x | %FileCheck %s
 
-// CHECK: struct Base {
+// CHECK:      @available(*, unavailable, message: "abstract C++ classes cannot be used as values in Swift")
+// CHECK-NEXT: struct Base {
 // CHECK-NEXT:   @available(*, unavailable, message: "constructors of abstract C++ classes are unavailable in Swift")
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   @available(*, unavailable, message: "virtual function is not available in Swift because it is pure")
@@ -18,7 +19,8 @@
 // CHECK-NEXT:  @_addressableSelf mutating func foo()
 // CHECK-NEXT: }
 
-// CHECK:       struct Base2 {
+// CHECK:      @available(*, unavailable, message: "abstract C++ classes cannot be used as values in Swift")
+// CHECK-NEXT: struct Base2 {
 // CHECK-NEXT:    @available(*, unavailable, message: "constructors of abstract C++ classes are unavailable in Swift")
 // CHECK-NEXT:    init()
 // CHECK-NEXT:    @available(*, unavailable, message: "virtual function is not available in Swift because it is pure")
@@ -71,7 +73,8 @@
 // CHECK-NEXT:    @_addressableSelf func swiftName() -> CInt
 // CHECK-NEXT:  }
 //
-// CHECK:       struct PureVirtualRenamedBase {
+// CHECK:      @available(*, unavailable, message: "abstract C++ classes cannot be used as values in Swift")
+// CHECK-NEXT: struct PureVirtualRenamedBase {
 // CHECK-NEXT:    @available(*, unavailable, message: "constructors of abstract C++ classes are unavailable in Swift")
 // CHECK-NEXT:    init()
 // CHECK-NEXT:    @available(*, unavailable, message: "virtual function is not available in Swift because it is pure")

--- a/test/Interop/Cxx/class/inheritance/virtual-methods-typechecker.swift
+++ b/test/Interop/Cxx/class/inheritance/virtual-methods-typechecker.swift
@@ -3,9 +3,11 @@
 import VirtualMethods
 
 let _ = Base() // expected-error {{'init()' is unavailable: constructors of abstract C++ classes are unavailable in Swift}}
+// expected-error@-1 {{'Base' is unavailable: abstract C++ classes cannot be used as values in Swift}}
 let _ = DerivedInt()
 
 let _ = Base2() // expected-error {{'init()' is unavailable: constructors of abstract C++ classes are unavailable in Swift}}
+// expected-error@-1 {{'Base2' is unavailable: abstract C++ classes cannot be used as values in Swift}}
 
 let _ = Derived2()
 let _ = Derived3()
@@ -22,11 +24,11 @@ let vro = VirtualRenamedOverridden()
 let _ = vro.cxxName() // expected-error {{has no member 'cxxName'}}
 let _ = vro.swiftName()
 
-func check(pvrb: PureVirtualRenamedBase) {
+func check(pvrb: PureVirtualRenamedBase) { // expected-error {{'PureVirtualRenamedBase' is unavailable: abstract C++ classes cannot be used as values in Swift}}
   let _ = pvrb.cxxName() // expected-error {{has no member 'cxxName'}}
   let _ = pvrb.swiftName() // expected-error {{virtual function is not available in Swift because it is pure}}
 }
-func check(pvri: PureVirtualRenamedInherited) {
+func check(pvri: PureVirtualRenamedInherited) { // expected-error {{'PureVirtualRenamedInherited' is unavailable: abstract C++ classes cannot be used as values in Swift}}
   let _ = pvri.cxxName() // expected-error {{has no member 'cxxName'}}
   let _ = pvri.swiftName() // expected-error {{virtual function is not available in Swift because it is pure}}
 }


### PR DESCRIPTION
Swift already marks pure virtual methods of C++ value type as unavailable, since their implementations will not be available.

However, that restriction is not strong enough, since a non-virtual method of a value type might call a virtual method in its implementation. In practice, this caused runtime crashes.

This marks abstract value types as unavailable in Swift. FRTs with pure virtual methods continue to be available in Swift (although their constructors are still unavailable).

rdar://183465360

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
