### PR TITLE
[Embedded] Add aarch64-unknown-uefi as an embedded target

### DIFF
--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -105,6 +105,7 @@ static const SupportedConditionalValue SupportedConditionalCompilationOSs[] = {
   "Haiku",
   "WASI",
   "Emscripten",
+  "UEFI",
   "none",
 };
 
@@ -603,6 +604,9 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
     break;
   case llvm::Triple::Emscripten:
     addPlatformConditionValue(PlatformConditionKind::OS, "Emscripten");
+    break;
+  case llvm::Triple::UEFI:
+    addPlatformConditionValue(PlatformConditionKind::OS, "UEFI");
     break;
   case llvm::Triple::UnknownOS:
     if (Target.getOSName() == "none") {

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -301,6 +301,9 @@ StringRef swift::getPlatformNameForTriple(const llvm::Triple &triple) {
   case llvm::Triple::UnknownOS:
     return "none";
   case llvm::Triple::UEFI:
+    // UEFI is a freestanding, non-Darwin target with no platform SDK, so it
+    // uses the same resource layout as other bare-metal ("none") targets.
+    return "none";
   case llvm::Triple::LiteOS:
   case llvm::Triple::Managarm:
     llvm_unreachable("unsupported OS");

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -457,6 +457,7 @@ Driver::buildToolChain(const llvm::opt::InputArgList &ArgList) {
   case llvm::Triple::WASIp2:
   case llvm::Triple::WASIp3:
     return std::make_unique<toolchains::WebAssembly>(*this, target);
+  case llvm::Triple::UEFI:
   case llvm::Triple::UnknownOS:
     return std::make_unique<toolchains::GenericUnix>(*this, target);
   default:

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -276,6 +276,8 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING)
     if("AArch64" IN_LIST LLVM_TARGETS_TO_BUILD)
       list(APPEND EMBEDDED_STDLIB_TARGET_TRIPLES
         "aarch64  aarch64-none-none-elf     aarch64-none-none-elf"
+        # UEFI firmware target (COFF/PE object format).
+        "aarch64  aarch64-unknown-uefi      aarch64-unknown-uefi"
       )
     endif()
     if("RISCV" IN_LIST LLVM_TARGETS_TO_BUILD)


### PR DESCRIPTION
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
### Description

Adds `aarch64-unknown-uefi` as a supported Embedded Swift target, so Swift can
produce PE/COFF `.efi` binaries for AArch64 UEFI firmware — the AArch64
counterpart to the existing `x86_64-unknown-uefi` support.

- Recognize `UEFI` as a supported OS for `#if os(UEFI)` conditional compilation
  and set the corresponding platform condition (`LangOptions`).
- Map the UEFI triple to the freestanding platform name (`Platform.cpp`).
- Build the cross-compiled Embedded standard library for `aarch64-unknown-uefi`.

With the matching LLVM/clang changes, `swiftc -target aarch64-unknown-uefi
-enable-experimental-feature Embedded` builds the embedded stdlib and emits valid
`coff-arm64` objects that link (via `lld-link -subsystem:efi_application`) into
bootable EFI applications.

### Dependency

Requires the AArch64 UEFI target support in the LLVM project (clang
`UEFIAArch64TargetInfo` + backend COFF/CFI handling). Until that lands in the
llvm-project this repo builds against, the embedded-stdlib build for this triple
(and therefore CI) will not succeed.

- Upstream: https://github.com/llvm/llvm-project/pull/213275
- Downstream cherry-pick https://github.com/swiftlang/llvm-project/pull/13596
- https://github.com/swiftlang/swift-driver/pull/2164

### Testing

Built locally against a patched toolchain: the embedded stdlib builds for the
triple (Swift.swiftmodule identical in size to `aarch64-none-none-elf`), and a
sample `@_cdecl("efi_main")` compiles to a COFF object with a correct frame
record. Lit/regression tests to follow.