### PR TITLE
OperandOwnership: AddTaskLocalValue and TaskLocalValuePush under OV

### DIFF
--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -1062,6 +1062,32 @@ OperandOwnershipBuiltinClassifier::visitCreateAsyncTask(BuiltinInst *bi,
   return OperandOwnership::InstantaneousUse;
 }
 
+// Both AddTaskLocalValue and TaskLocalValuePush have the same signature:
+// operand 0 is the key (Builtin.RawPointer), always trivial; operand 1 is
+// the generic value that is consumed.
+static OperandOwnership visitTaskLocalValueOperand(const Operand &op,
+                                                   BuiltinInst *bi) {
+  if (&op == &bi->getOperandRef(0))
+    return OperandOwnership::TrivialUse;
+
+  assert(&op == &bi->getOperandRef(1));
+  if (op.get()->getType().isAddress())
+    return OperandOwnership::TrivialUse;
+  return OperandOwnership::DestroyingConsume;
+}
+
+OperandOwnership
+OperandOwnershipBuiltinClassifier::visitAddTaskLocalValue(BuiltinInst *bi,
+                                                          StringRef attr) {
+  return visitTaskLocalValueOperand(op, bi);
+}
+
+OperandOwnership
+OperandOwnershipBuiltinClassifier::visitTaskLocalValuePush(BuiltinInst *bi,
+                                                           StringRef attr) {
+  return visitTaskLocalValueOperand(op, bi);
+}
+
 OperandOwnership OperandOwnershipBuiltinClassifier::
 visitResumeNonThrowingContinuationReturning(BuiltinInst *bi, StringRef attr) {
   // The value operand is consumed.
@@ -1123,13 +1149,8 @@ BUILTIN_OPERAND_OWNERSHIP(TrivialUse, TaskRemoveCancellationHandler)
 BUILTIN_OPERAND_OWNERSHIP(BitwiseEscape, TaskAddPriorityEscalationHandler)
 // Trivial use since our operand is just an UnsafeRawPointer.
 BUILTIN_OPERAND_OWNERSHIP(TrivialUse, TaskRemovePriorityEscalationHandler)
-// This is a trivial use since our first operand is a Builtin.RawPointer and our
-// second is an address to our generic Value.
-BUILTIN_OPERAND_OWNERSHIP(TrivialUse, TaskLocalValuePush)
-BUILTIN_OPERAND_OWNERSHIP(TrivialUse, AddTaskLocalValue)
 // Trivial use of the token result of AddTaskLocalValue.
 BUILTIN_OPERAND_OWNERSHIP(TrivialUse, RemoveTaskLocalValue)
-
 BUILTIN_OPERAND_OWNERSHIP(TrivialUse, TaskCancellationShieldPush)
 BUILTIN_OPERAND_OWNERSHIP(TrivialUse, TaskCancellationShieldPop)
 

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -1040,6 +1040,33 @@ OperandOwnershipBuiltinClassifier::visitCreateAsyncTask(BuiltinInst *bi,
   return OperandOwnership::InstantaneousUse;
 }
 
+// Both AddTaskLocalValue and TaskLocalValuePush have the same signature:
+// operand 0 is the key (Builtin.RawPointer), always trivial; operand 1 is
+// the generic Value, which SILGen emits as an address normally but as an
+// owned object under opaque values, so its ownership must vary accordingly.
+static OperandOwnership visitTaskLocalValueOperand(const Operand &op,
+                                                   BuiltinInst *bi) {
+  if (&op == &bi->getOperandRef(0))
+    return OperandOwnership::TrivialUse;
+
+  assert(&op == &bi->getOperandRef(1));
+  if (op.get()->getType().isAddress())
+    return OperandOwnership::TrivialUse;
+  return OperandOwnership::DestroyingConsume;
+}
+
+OperandOwnership
+OperandOwnershipBuiltinClassifier::visitAddTaskLocalValue(BuiltinInst *bi,
+                                                          StringRef attr) {
+  return visitTaskLocalValueOperand(op, bi);
+}
+
+OperandOwnership
+OperandOwnershipBuiltinClassifier::visitTaskLocalValuePush(BuiltinInst *bi,
+                                                           StringRef attr) {
+  return visitTaskLocalValueOperand(op, bi);
+}
+
 OperandOwnership OperandOwnershipBuiltinClassifier::
 visitResumeNonThrowingContinuationReturning(BuiltinInst *bi, StringRef attr) {
   // The value operand is consumed.
@@ -1099,13 +1126,8 @@ BUILTIN_OPERAND_OWNERSHIP(TrivialUse, TaskRemoveCancellationHandler)
 BUILTIN_OPERAND_OWNERSHIP(BitwiseEscape, TaskAddPriorityEscalationHandler)
 // Trivial use since our operand is just an UnsafeRawPointer.
 BUILTIN_OPERAND_OWNERSHIP(TrivialUse, TaskRemovePriorityEscalationHandler)
-// This is a trivial use since our first operand is a Builtin.RawPointer and our
-// second is an address to our generic Value.
-BUILTIN_OPERAND_OWNERSHIP(TrivialUse, TaskLocalValuePush)
-BUILTIN_OPERAND_OWNERSHIP(TrivialUse, AddTaskLocalValue)
 // Trivial use of the token result of AddTaskLocalValue.
 BUILTIN_OPERAND_OWNERSHIP(TrivialUse, RemoveTaskLocalValue)
-
 BUILTIN_OPERAND_OWNERSHIP(TrivialUse, TaskCancellationShieldPush)
 BUILTIN_OPERAND_OWNERSHIP(TrivialUse, TaskCancellationShieldPop)
 

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -3927,7 +3927,11 @@ protected:
         builder.emitLoadBorrowOperation(uncheckedCastInst->getLoc(), destAddr);
     uncheckedCastInst->replaceAllUsesWith(load);
     pass.deleter.forceDelete(uncheckedCastInst);
-    emitEndBorrows(load, pass);
+    // emitLoadBorrowOperation only produces a real borrow (needing an
+    // end_borrow) for non-trivial types; for trivial types it emits a plain
+    // load [trivial], which has no borrow scope to end.
+    if (!load->getType().isTrivial(*pass.function))
+      emitEndBorrows(load, pass);
   }
 
   void
@@ -3936,6 +3940,11 @@ protected:
   }
 
   void visitUncheckedValueCastInst(UncheckedValueCastInst *uncheckedCastInst) {
+    rewriteOpaqueUncheckedCastUse(uncheckedCastInst);
+  }
+
+  void visitUncheckedTrivialBitCastInst(
+      UncheckedTrivialBitCastInst *uncheckedCastInst) {
     rewriteOpaqueUncheckedCastUse(uncheckedCastInst);
   }
 

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -3638,7 +3638,10 @@ protected:
   void visitBuiltinInst(BuiltinInst *bi) {
     switch (bi->getBuiltinKind().value_or(BuiltinValueKind::None)) {
     case BuiltinValueKind::ResumeNonThrowingContinuationReturning:
-    case BuiltinValueKind::ResumeThrowingContinuationReturning: {
+    case BuiltinValueKind::ResumeThrowingContinuationReturning:
+    case BuiltinValueKind::AddTaskLocalValue:
+    case BuiltinValueKind::TaskLocalValuePush:
+    case BuiltinValueKind::GetEnumTag: {
       SILValue opAddr = addrMat.materializeAddress(use->get());
       bi->setOperand(use->getOperandNumber(), opAddr);
       break;

--- a/test/SILGen/builtins.swift
+++ b/test/SILGen/builtins.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -Xllvm -sil-print-types  -enable-builtin-module %s -disable-access-control -disable-objc-attr-requires-foundation-module -enable-objc-interop
+// RUN: %target-swift-emit-sil -sil-verify-all -o /dev/null -enable-sil-opaque-values -Xllvm -sil-print-types  -enable-builtin-module %s -disable-access-control -disable-objc-attr-requires-foundation-module -enable-objc-interop
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-emit-silgen -Xllvm -sil-print-types  -enable-builtin-module %s -disable-access-control -disable-objc-attr-requires-foundation-module -enable-objc-interop -o %t/builtins.silgen

--- a/test/SILGen/builtins.swift
+++ b/test/SILGen/builtins.swift
@@ -1,5 +1,4 @@
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -Xllvm -sil-print-types  -enable-builtin-module %s -disable-access-control -disable-objc-attr-requires-foundation-module -enable-objc-interop
+// RUN: %target-swift-emit-silgen-ossa -o /dev/null -enable-sil-opaque-values -Xllvm -sil-print-types  -enable-builtin-module %s -disable-access-control -disable-objc-attr-requires-foundation-module -enable-objc-interop
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-emit-silgen -Xllvm -sil-print-types  -enable-builtin-module %s -disable-access-control -disable-objc-attr-requires-foundation-module -enable-objc-interop -o %t/builtins.silgen


### PR DESCRIPTION
Both builtins have the same signature:
operand 0 is the key (Builtin.RawPointer), always trivial; operand 1 is the generic Value, which SILGen emits as an address normally but as an owned object under opaque values, so its ownership must vary accordingly.

Resolves rdar://183732629.
