### PR TITLE
[cxx-interop] Make SIMD types work again in reverse interop

### DIFF
--- a/lib/PrintAsClang/PrimitiveTypeMapping.cpp
+++ b/lib/PrintAsClang/PrimitiveTypeMapping.cpp
@@ -15,6 +15,7 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/Module.h"
+#include "swift/AST/NameLookup.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include <optional>
@@ -31,15 +32,26 @@ static TypeDecl *findTypeInModuleByName(ASTContext &ctx, Identifier moduleName,
   // Find all of the declarations with this name in the Swift module.
   SmallVector<ValueDecl *, 1> results;
   module->lookupValue(typeName, NLKind::UnqualifiedLookup, results);
+  if (results.empty()) {
+    // A type that the module only re-exports is not found above, because
+    // lookupValue does not follow re-exports. This is how the Clang types of
+    // the module that a Swift overlay shadows are named, e.g. 'simd_float3'
+    // from the 'simd' module.
+    module->lookupQualified(module, DeclNameRef(typeName), SourceLoc(),
+                            NLOptions(NLFlags::QualifiedDefault) |
+                                NLFlags::OnlyTypes,
+                            results);
+  }
   assert(results.size() <= 1 &&
          "Expected at most one match for a primitive type");
-  for (auto result : results) {
-    if (auto nominal = dyn_cast<NominalTypeDecl>(result))
-      return nominal;
+  if (results.size() != 1)
+    return nullptr;
 
-    if (auto typealias = dyn_cast<TypeAliasDecl>(result))
-      return typealias;
-  }
+  if (auto nominal = dyn_cast<NominalTypeDecl>(results[0]))
+    return nominal;
+
+  if (auto typealias = dyn_cast<TypeAliasDecl>(results[0]))
+    return typealias;
 
   return nullptr;
 }

--- a/test/Interop/SwiftToCxx/stdlib/swift-simd-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/stdlib/swift-simd-in-cxx-execution.cpp
@@ -9,7 +9,8 @@
 // RUN: %target-run %t/swift-simd-execution | %FileCheck %s
 
 // REQUIRES: executable_test
-// REQUIRES: rdar157848231
+// The 'simd' module ships with the Apple SDKs.
+// REQUIRES: sdk_min_version_26
 
 #include "simd.h"
 #include <assert.h>

--- a/test/Interop/SwiftToCxx/stdlib/swift-simd-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/swift-simd-in-cxx.swift
@@ -6,7 +6,7 @@
 // RUN: %target-interop-build-clangxx -std=gnu++20 -fobjc-arc -c -x objective-c++-header %t/UseSIMD.h -o %t/o.o
 
 // REQUIRES: objc_interop
-// REQUIRES: rdar157848231
+// REQUIRES: sdk_min_version_26
 
 import simd
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1431,6 +1431,24 @@ if run_vendor == 'apple':
     config.available_features.add('objc_interop')
     run_objc_interop = "objc"
 
+    # Expose the version of the SDK being tested against, so that a test that
+    # depends on the contents of a recent SDK can gate on it with e.g.
+    # 'REQUIRES: sdk_min_version_27'. Apple SDKs share a version number, so one
+    # feature covers macOS, iOS, tvOS, watchOS and visionOS.
+    if config.variant_sdk:
+        try:
+            sdk_version = darwin_get_sdk_version(config.variant_sdk)[1]
+            if isinstance(sdk_version, bytes):
+                sdk_version = sdk_version.decode('utf-8')
+            sdk_major_version = int(sdk_version.split('.')[0])
+        except Exception:
+            lit_config.note('Could not determine the version of the SDK at ' +
+                            config.variant_sdk)
+        else:
+            lit_config.note('SDK version: %s' % sdk_version)
+            for version in range(10, sdk_major_version + 1):
+                config.available_features.add('sdk_min_version_%d' % version)
+
     # The "freestanding" tests will link against the static libswiftCore.a and
     # cannot use any of Obj-C / Dispatch / Foundation.
     if "-freestanding" in config.variant_suffix:


### PR DESCRIPTION
These tests got disabled due to too old SDKs on some of the CI machines. Unfortunately, these tests no longer worked even on new SDKs due to some code changes, specifically looking up the exact declaration instead of just names for built-in types. The code to find the declarations is doing un-qualified lookup that did not follow reexports and the SIMD declarations were reexported in a Swift overlay. This patch makes us fall back to qualified lookup that follows reexports if the unqualified lookup fails and reenables the tests.

rdar://182808194

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
