### PR TITLE
[cxx-interop] Fix incorrect safety analysis results in some cases

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5769,7 +5769,7 @@ ClangTypeEscapability::evaluate(Evaluator &evaluator,
       auto conditionalParams = getConditionalEscapableAttrParams(recordDecl);
 
       if (!STLParams.empty() || !conditionalParams.empty()) {
-        hasUnknown &= checkConditionalParams<CxxEscapability>(
+        hasUnknown |= checkConditionalParams<CxxEscapability>(
             recordDecl, desc.impl, STLParams, conditionalParams,
             maybePushToStack);
         continue;
@@ -8660,7 +8660,7 @@ CxxValueSemantics::evaluate(Evaluator &evaluator,
       if (!STLParams.empty() || !conditionalParams.empty()) {
         if (isa<clang::ClassTemplateSpecializationDecl>(recordDecl) &&
             importerImpl) {
-          hasUnknown &= checkConditionalParams<CxxValueSemanticsKind>(
+          hasUnknown |= checkConditionalParams<CxxValueSemanticsKind>(
               recordDecl, importerImpl, STLParams, conditionalParams,
               maybePushToStack);
         }

--- a/test/Interop/Cxx/class/safe-interop-mode.swift
+++ b/test/Interop/Cxx/class/safe-interop-mode.swift
@@ -18,6 +18,7 @@ module Test {
 #include <span>
 #include <vector>
 #include <tuple>
+#include <memory>
 
 struct SWIFT_NONESCAPABLE View {
     __attribute__((swift_attr("@lifetime(immortal)")))
@@ -46,6 +47,24 @@ struct SafeEscapableAggregate {
 struct UnknownEscapabilityAggregate {
     SafeEscapableAggregate agg;
     Unannotated unann;
+};
+
+template <typename T> struct SWIFT_ESCAPABLE_IF(T) EscapableIfT { T t; };
+using SafeEscapableIf = EscapableIfT<int>;
+
+struct ConditionalMemberBeforePointer {
+    SafeEscapableIf cond;
+    int *pointer;
+};
+
+struct ConditionalMemberAfterPointer {
+    int *pointer;
+    SafeEscapableIf cond;
+};
+
+struct SharedPtrBeforePointer {
+    std::shared_ptr<int> shared;
+    int *pointer;
 };
 
 struct MyContainer {
@@ -184,6 +203,25 @@ func useUnsafeParam2(x: UnsafeReference) {
 func useUnsafeParam3(x: UnknownEscapabilityAggregate) {
   // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
   _ = x // expected-note{{reference to parameter 'x' involves unsafe type}}
+}
+
+func useConditionalMemberBeforePointer(x: ConditionalMemberBeforePointer) {
+  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  _ = x // expected-note{{reference to parameter 'x' involves unsafe type}}
+}
+
+func useConditionalMemberAfterPointer(x: ConditionalMemberAfterPointer) {
+  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  _ = x // expected-note{{reference to parameter 'x' involves unsafe type}}
+}
+
+func useSharedPtrBeforePointer(x: SharedPtrBeforePointer) {
+  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  _ = x // expected-note{{reference to parameter 'x' involves unsafe type}}
+}
+
+func useSafeEscapableIf(x: SafeEscapableIf) {
+  _ = x
 }
 
 func useSafeParams(x: Owner, y: View, z: SafeEscapableAggregate, c: MyContainer) {


### PR DESCRIPTION
Due to a typo, sometimes the result of applying injected conditional escapability annotations reset the escapability analysis resulting in inadvertently considering an unsafe type as safe. The same typo was there in the value semantics analysis but I was not able to trigger a test case that actually surfaces that problem but wanted to make the fix defensively.

rdar://183683395

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
