### PR TITLE
Make _FoundationInternationalizationData a Swift library

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -4114,7 +4114,7 @@ function Get-SelectedSDKBuilds() {
 # search path. CMake consumers receive a -vfsoverlay from the target's PUBLIC
 # interface; SDK consumers do not and therefore need the physical headers.
 function Repair-SDKHeaders([string] $SDKRoot) {
-  foreach ($Module in ("Block", "dispatch", "os", "_foundation_unicode", "_FoundationCShims", "_FoundationInternationalizationData")) {
+  foreach ($Module in ("Block", "dispatch", "os", "_foundation_unicode", "_FoundationCShims")) {
     foreach ($ResourceType in ("swift", "swift_static")) {
       $ModuleDirectory = "$SDKRoot\usr\lib\$ResourceType\$Module"
       if (Test-Path $ModuleDirectory) {


### PR DESCRIPTION
Updates `build.ps1` to stop copying _FoundationInternationalizationData into /usr/include now that it is a Swift module rather than a set of C headers