### PR TITLE
[6.4] Embedded: Skip the key path non-public property check in SILVerifier

### DIFF
--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -507,7 +507,8 @@ void verifyKeyPathComponent(SILModule &M,
   switch (auto kind = component.getKind()) {
   case KeyPathPatternComponent::Kind::StoredProperty: {
     auto property = component.getStoredPropertyDecl();
-    if (expansion == ResilienceExpansion::Minimal) {
+    if (expansion == ResilienceExpansion::Minimal &&
+        !M.getASTContext().LangOpts.hasFeature(Feature::Embedded)) {
       require(property->getEffectiveAccess() >= AccessLevel::Package,
               "Key path in serialized function cannot reference non-public "
               "property");

--- a/test/embedded/keypath-internal-property-multi-module.swift
+++ b/test/embedded/keypath-internal-property-multi-module.swift
@@ -1,0 +1,39 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -enable-experimental-feature EmbeddedKeyPaths -O -c -parse-as-library %t/MyModule.swift -o %t/MyModule.o -emit-module -emit-module-path %t/MyModule.swiftmodule
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -enable-experimental-feature EmbeddedKeyPaths -O -c -I%t -parse-as-library %t/Main.swift -o %t/Main.o
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/Main.o %t/MyModule.o -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_EmbeddedKeyPaths
+
+//--- MyModule.swift
+
+struct Match {
+  let route: Int
+}
+
+public struct Tree<T> {
+  public init() {}
+
+  public func resolve() -> Int {
+    let matches = [Match(route: 5), Match(route: 37)]
+    let routes = matches.map(\.route)
+    return routes[0] + routes[1]
+  }
+}
+
+//--- Main.swift
+
+import MyModule
+
+@main
+struct Main {
+  static func main() {
+    // CHECK: 42
+    print(Tree<Int>().resolve())
+  }
+}


### PR DESCRIPTION
Cherry-pick of #91059, merged to `main` as 767cc3a939aaaf3206ed52bd19047a05abdb4957

**Explanation**: Referencing an internal stored property from a key path in a generic function crashed the SIL verifier when another module deserialized that function. Added `test/embedded/keypath-internal-property-multi-module.swift` to cover this missing case.
**Scope**: Limited to key paths use in Embedded Swift
**Risk**: Low due to very limited scope.
**Testing**: Added a regression lit test.
**Issue**: https://github.com/swiftlang/swift/issues/91057
**Reviewed by**: @DougGregor