### PR TITLE
Float parsing: don't read past end of provided buffer

### DIFF
--- a/stdlib/public/core/FloatingPointFromString.swift
+++ b/stdlib/public/core/FloatingPointFromString.swift
@@ -882,23 +882,25 @@ fileprivate func fastParse64(
   if t < 10 {
     leadingDigits = UInt64(t)
     i &+= 1
-    if i >= input.count {
-      // Exactly one non-zero digit
+    while i < input.count {
+        let t = unsafe input[unchecked: i] &- 0x30
+        if t > 9 {
+            break
+        }
+        leadingDigits &*= 10
+        leadingDigits &+= UInt64(t)
+        i &+= 1
+    }
+    nonZeroDigitCount = i - firstNonZeroDigitOffset
+    if i >= input.count && nonZeroDigitCount < 19 {
+      // Pure integer
       return .decimal(digits: leadingDigits,
                       base10Exponent: 0,
                       unparsedDigitCount: 0,
                       firstUnparsedDigitOffset: UInt16(i),
-                      leadingDigitCount: 1,
+                      leadingDigitCount: UInt8(truncatingIfNeeded:nonZeroDigitCount),
                       sign: sign)
     }
-    t = unsafe input[unchecked: i] &- 0x30
-    while t < 10 && i < input.count {
-      leadingDigits &*= 10
-      leadingDigits &+= UInt64(t)
-      i &+= 1
-      t = unsafe input[unchecked: i] &- 0x30
-    }
-    nonZeroDigitCount = i - firstNonZeroDigitOffset
   }
 
   var unparsedDigitCount = 0
@@ -934,13 +936,15 @@ fileprivate func fastParse64(
       // https://lemire.me/blog/2018/09/30/quickly-identifying-a-sequence-of-digits-in-a-string-of-characters/
       // and
       // https://lemire.me/blog/2022/01/21/swar-explained-parsing-eight-digits/
-      var t = unsafe input[unchecked: i] &- 0x30
-      while t < 10 && i < input.count {
+      repeat {
+        let t = unsafe input[unchecked: i] &- 0x30
+        if t > 9 {
+          break
+        }
         leadingDigits &*= 10
         leadingDigits &+= UInt64(t)
         i &+= 1
-        t = unsafe input[unchecked: i] &- 0x30
-      }
+      } while i < input.count
     }
     nonZeroDigitCount &+= i &- firstSignificantDigitAfterDecimalPointOffset
     base10Exponent &-= Int32(truncatingIfNeeded: i &- firstDigitAfterDecimalPointOffset)
@@ -975,12 +979,14 @@ fileprivate func fastParse64(
     // For speed, we let the exponent overflow here.
     var explicitExponent = Int32(0)
     let firstExponentDigitOffset = i
-    var byte = unsafe input[unchecked: i]
-    while i < input.count && byte >= 0x30 && byte <= 0x39 {
+    while i < input.count {
+      let t = unsafe input[unchecked: i] - 0x30
+      if t > 9 {
+        break
+      }
       explicitExponent &*= 10
-      explicitExponent &+= Int32(byte) &- 0x30
+      explicitExponent &+= Int32(t)
       i &+= 1
-      byte = unsafe input[unchecked: i]
     }
     // Did we scan more than 8 digits in the exponent?
     if i &- firstExponentDigitOffset > 8 {

--- a/test/stdlib/ParseFloat64.swift
+++ b/test/stdlib/ParseFloat64.swift
@@ -364,6 +364,33 @@ tests.test("Substring - long") {
   expectEqual(parsed!.bitPattern, (2.0).bitPattern)
 }
 
+tests.test("Integers") {
+  expectParse("1", 1.0);
+  expectParse("12", 12.0);
+  expectParse("123", 123.0);
+  expectParse("1234", 1234.0);
+  expectParse("12345", 12345.0);
+  expectParse("123456", 123456.0);
+  expectParse("1234567", 1234567.0);
+  expectParse("12345678", 12345678.0);
+  expectParse("123456789", 123456789.0);
+  expectParse("1234567890", 1234567890.0);
+  expectParse("12345678901", 12345678901.0);
+  expectParse("123456789012", 123456789012.0);
+  expectParse("1234567890123", 1234567890123.0);
+  expectParse("12345678901234", 12345678901234.0);
+  expectParse("123456789012345", 123456789012345.0);
+  expectParse("1234567890123456", 1234567890123456.0);
+  expectParse("12345678901234567", 12345678901234567.0);
+  expectParse("123456789012345678", 123456789012345678.0);
+  expectParse("1234567890123456789", 1234567890123456789.0);
+  expectParse("12345678901234567890", 12345678901234567890.0);
+  expectParse("123456789012345678901", 123456789012345678901.0);
+  expectParse("1234567890123456789012", 1234567890123456789012.0);
+  expectParse("12345678901234567890123", 12345678901234567890123.0);
+  expectParse("123456789012345678901234", 123456789012345678901234.0);
+}
+
 /*
  // These need Foundation to run, so can't run on Linux?
 tests.test("Bridged - short") {


### PR DESCRIPTION
The floating-point parsing code read the next character before checking whether it was within the bounds of the buffer.  These were not caught by runtime checks because this code uses `unchecked:` subscripts extensively for performance.

This PR restructures a few loops to always check bounds before reading the next character.

This bug is a _latent_ safety problem, but has no impact today:

* It does not affect correctness:  The character was read before bounds checks, but the value was only used after the bounds check passed.

* It is not a real safety problem:  we only ever parse from a String and String always allocates at least one byte beyond what's required for the text.  But we're considering parsing directly from buffers in memory and that may not always be true.

Testing:
* I added a pure-integer test (sequences of digits with no decimal point or exponent phrase)
* I locally removed all of the `unchecked:` subscripts and re-ran the full test suite to try to verify there were no other beyond-bounds accesses