### PR TITLE
Add @noSanitize(<sanitizer>) function attribute

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -1066,6 +1066,13 @@ BridgedInlineAttr BridgedInlineAttr_createParsed(BridgedASTContext cContext,
                                                  swift::SourceRange range,
                                                  swift::InlineKind kind);
 
+SWIFT_NAME("BridgedNoSanitizeAttr.createParsed(_:atLoc:range:kind:)")
+BridgedNoSanitizeAttr
+BridgedNoSanitizeAttr_createParsed(BridgedASTContext cContext,
+                                   swift::SourceLoc atLoc,
+                                   swift::SourceRange range,
+                                   swift::NoSanitizeKind kind);
+
 enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedParsedLifetimeDependenceKind {
   BridgedParsedLifetimeDependenceKindDefault,
   BridgedParsedLifetimeDependenceKindBorrow,

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -118,6 +118,11 @@ enum : unsigned {
 };
 
 enum : unsigned {
+  NumNoSanitizeKindBits =
+      countBitsUsed(static_cast<unsigned>(NoSanitizeKind::Last_NoSanitizeKind))
+};
+
+enum : unsigned {
   NumEffectsKindBits =
       countBitsUsed(static_cast<unsigned>(EffectsKind::Last_EffectsKind))
 };
@@ -241,6 +246,10 @@ protected:
 
     SWIFT_INLINE_BITFIELD(InlineAttr, DeclAttribute, NumInlineKindBits,
       kind : NumInlineKindBits
+    );
+
+    SWIFT_INLINE_BITFIELD(NoSanitizeAttr, DeclAttribute, NumNoSanitizeKindBits,
+      kind : NumNoSanitizeKindBits
     );
 
     SWIFT_INLINE_BITFIELD(OptimizeAttr, DeclAttribute, NumOptimizationModeBits,
@@ -1548,6 +1557,35 @@ public:
   }
 
   bool isEquivalent(const InlineAttr *other, Decl *attachedTo) const {
+    return getKind() == other->getKind();
+  }
+};
+
+/// Represents an @_noSanitize(<kind>) attribute.
+class NoSanitizeAttr : public DeclAttribute {
+public:
+  NoSanitizeAttr(SourceLoc atLoc, SourceRange range, NoSanitizeKind kind,
+                 bool implicit = false)
+      : DeclAttribute(DeclAttrKind::NoSanitize, atLoc, range, implicit) {
+    Bits.NoSanitizeAttr.kind = unsigned(kind);
+  }
+
+  NoSanitizeAttr(NoSanitizeKind kind)
+    : NoSanitizeAttr(SourceLoc(), SourceRange(), kind) {}
+
+  NoSanitizeKind getKind() const {
+    return NoSanitizeKind(Bits.NoSanitizeAttr.kind);
+  }
+
+  static bool classof(const DeclAttribute *DA) {
+    return DA->getKind() == DeclAttrKind::NoSanitize;
+  }
+
+  NoSanitizeAttr *clone(ASTContext &ctx) const {
+    return new (ctx) NoSanitizeAttr(AtLoc, Range, getKind(), isImplicit());
+  }
+
+  bool isEquivalent(const NoSanitizeAttr *other, Decl *attachedTo) const {
     return getKind() == other->getKind();
   }
 };

--- a/include/swift/AST/AttrKind.h
+++ b/include/swift/AST/AttrKind.h
@@ -84,6 +84,14 @@ enum class ENUM_EXTENSIBILITY_ATTR(closed) InlineKind : uint8_t {
   Last_InlineKind = Always
 };
 
+/// Kinds of sanitizers that can be suppressed with @_noSanitize.
+enum class ENUM_EXTENSIBILITY_ATTR(closed) NoSanitizeKind : uint8_t {
+  Address SWIFT_NAME("address") = 0,
+  Thread SWIFT_NAME("thread") = 1,
+  MemTag SWIFT_NAME("memtag") = 2,
+  Last_NoSanitizeKind = MemTag
+};
+
 /// This enum represents the possible values of the @_effects attribute.
 /// These values are ordered from the strongest guarantee to the weakest,
 /// so please do not reorder existing values.

--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -939,11 +939,11 @@ DECL_ATTR(called, Called,
   177)
 DECL_ATTR_FEATURE_REQUIREMENT(Called, CalledAttribute)
 
-DECL_ATTR(_noSanitize, NoSanitize,
+DECL_ATTR(noSanitize, NoSanitize,
   OnAbstractFunction | OnSubscript,
-  UserInaccessible | AllowMultipleAttributes | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove | ForbiddenInABIAttr,
+  AllowMultipleAttributes | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove | ForbiddenInABIAttr,
   178)
-
+DECL_ATTR_FEATURE_REQUIREMENT(NoSanitize, NoSanitize)
 LAST_DECL_ATTR(NoSanitize)
 
 #undef DECL_ATTR_ALIAS

--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -939,7 +939,12 @@ DECL_ATTR(called, Called,
   177)
 DECL_ATTR_FEATURE_REQUIREMENT(Called, CalledAttribute)
 
-LAST_DECL_ATTR(Called)
+DECL_ATTR(_noSanitize, NoSanitize,
+  OnAbstractFunction | OnSubscript,
+  UserInaccessible | AllowMultipleAttributes | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove | ForbiddenInABIAttr,
+  178)
+
+LAST_DECL_ATTR(NoSanitize)
 
 #undef DECL_ATTR_ALIAS
 #undef CONTEXTUAL_DECL_ATTR_ALIAS

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -632,6 +632,11 @@ EXPERIMENTAL_FEATURE(Reparenting, true)
 /// Allows a `get` returning a noncopyable type have owned semantics in opaque interfaces.
 EXPERIMENTAL_FEATURE(UnderscoreOwned, true)
 
+/// Allows `@noSanitize(<kind>)` on functions to suppress LLVM sanitize_*
+/// function attributes on the emitted function (mirrors Clang's
+/// __attribute__((no_sanitize("<kind>")))).
+EXPERIMENTAL_FEATURE(NoSanitize, true)
+
 /// Allow access to the Iterable protocols/types outside the stdlib.
 LANGUAGE_FEATURE(BorrowingSequence, 516, "Iterable protocol")
 

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -352,6 +352,10 @@ private:
 
   PerformanceConstraints perfConstraints = PerformanceConstraints::None;
 
+  /// Bitmask of sanitizers suppressed for this function by @_noSanitize.
+  /// Bit positions match NoSanitizeKind (0=Address, 1=Thread, 2=MemTag).
+  uint8_t noSanitizeMask = 0;
+
   /// The undefs of each type in the function.
   llvm::SmallMapVector<SILType, SILUndef *, 1> undefValues;
 
@@ -1140,6 +1144,12 @@ public:
   void setPerfConstraints(PerformanceConstraints perfConstr) {
     perfConstraints = perfConstr;
   }
+
+  /// Bitmask of sanitizers suppressed via @_noSanitize on this function's
+  /// decl. Bit positions match NoSanitizeKind (0=Address, 1=Thread, 2=MemTag).
+  uint8_t getNoSanitizeMask() const { return noSanitizeMask; }
+
+  void setNoSanitizeMask(uint8_t mask) { noSanitizeMask = mask; }
 
   // see `IsPerformanceConstraint`
   bool isPerformanceConstraint() const { return IsPerformanceConstraint; }

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -604,6 +604,17 @@ static StringRef getDumpString(InlineKind kind) {
   }
   llvm_unreachable("unhandled InlineKind");
 }
+static StringRef getDumpString(NoSanitizeKind kind) {
+  switch (kind) {
+  case NoSanitizeKind::Address:
+    return "address";
+  case NoSanitizeKind::Thread:
+    return "thread";
+  case NoSanitizeKind::MemTag:
+    return "memtag";
+  }
+  llvm_unreachable("unhandled NoSanitizeKind");
+}
 static StringRef getDumpString(ExportKind kind) {
   switch (kind) {
   case ExportKind::Interface:
@@ -5382,6 +5393,11 @@ public:
   }
   void visitInlineAttr(InlineAttr *Attr, Label label) {
     printCommon(Attr, "inline_attr", label);
+    printField(Attr->getKind(), Label::always("kind"));
+    printFoot();
+  }
+  void visitNoSanitizeAttr(NoSanitizeAttr *Attr, Label label) {
+    printCommon(Attr, "no_sanitize_attr", label);
     printField(Attr->getKind(), Label::always("kind"));
     printFoot();
   }

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -2009,11 +2009,11 @@ StringRef DeclAttribute::getAttrName() const {
   case DeclAttrKind::NoSanitize: {
     switch (cast<NoSanitizeAttr>(this)->getKind()) {
     case NoSanitizeKind::Address:
-      return "_noSanitize(address)";
+      return "noSanitize(address)";
     case NoSanitizeKind::Thread:
-      return "_noSanitize(thread)";
+      return "noSanitize(thread)";
     case NoSanitizeKind::MemTag:
-      return "_noSanitize(memtag)";
+      return "noSanitize(memtag)";
     }
     llvm_unreachable("Invalid no-sanitize kind");
   }

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1158,6 +1158,7 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
 #define SIMPLE_DECL_ATTR(X, CLASS, ...) case DeclAttrKind::CLASS:
 #include "swift/AST/DeclAttr.def"
   case DeclAttrKind::Inline:
+  case DeclAttrKind::NoSanitize:
   case DeclAttrKind::AccessControl:
   case DeclAttrKind::ReferenceOwnership:
   case DeclAttrKind::Effects:
@@ -2004,6 +2005,17 @@ StringRef DeclAttribute::getAttrName() const {
       return "inline(always)";
     }
     llvm_unreachable("Invalid inline kind");
+  }
+  case DeclAttrKind::NoSanitize: {
+    switch (cast<NoSanitizeAttr>(this)->getKind()) {
+    case NoSanitizeKind::Address:
+      return "_noSanitize(address)";
+    case NoSanitizeKind::Thread:
+      return "_noSanitize(thread)";
+    case NoSanitizeKind::MemTag:
+      return "_noSanitize(memtag)";
+    }
+    llvm_unreachable("Invalid no-sanitize kind");
   }
   case DeclAttrKind::NonSendable: {
     switch (cast<NonSendableAttr>(this)->Specificity) {

--- a/lib/AST/Bridging/DeclAttributeBridging.cpp
+++ b/lib/AST/Bridging/DeclAttributeBridging.cpp
@@ -404,6 +404,14 @@ BridgedInlineAttr BridgedInlineAttr_createParsed(BridgedASTContext cContext,
   return new (cContext.unbridged()) InlineAttr(atLoc, range, kind);
 }
 
+BridgedNoSanitizeAttr
+BridgedNoSanitizeAttr_createParsed(BridgedASTContext cContext,
+                                   SourceLoc atLoc,
+                                   SourceRange range,
+                                   swift::NoSanitizeKind kind) {
+  return new (cContext.unbridged()) NoSanitizeAttr(atLoc, range, kind);
+}
+
 static swift::ParsedLifetimeDependenceKind
 unbridged(BridgedParsedLifetimeDependenceKind kind) {
   switch (kind) {

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -565,6 +565,10 @@ static bool usesFeatureNonexhaustiveAttribute(Decl *decl) {
   return decl->getAttrs().hasAttribute<NonexhaustiveAttr>();
 }
 
+static bool usesFeatureNoSanitize(Decl *decl) {
+  return decl->getAttrs().hasAttribute<NoSanitizeAttr>();
+}
+
 static bool usesFeatureAlwaysInheritActorContext(Decl *decl) {
   auto *VD = dyn_cast<ValueDecl>(decl);
   if (!VD)

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -162,6 +162,8 @@ extension ASTGenVisitor {
         return handle(self.generateImplementsAttr(attribute: node)?.asDeclAttribute)
       case .Inline:
         return handle(self.generateInlineAttr(attribute: node)?.asDeclAttribute)
+      case .NoSanitize:
+        return handle(self.generateNoSanitizeAttr(attribute: node)?.asDeclAttribute)
       case .Lifetime:
         return handle(self.generateLifetimeAttr(attribute: node)?.asDeclAttribute)
       case .MacroRole:
@@ -1209,6 +1211,35 @@ extension ASTGenVisitor {
         case "never": return .never
         case "__always": return .alwaysUnderscored
         case "always": return .always
+        default: return nil
+        }
+      }
+    )
+    guard let kind else {
+      return nil
+    }
+    return .createParsed(
+      self.ctx,
+      atLoc: self.generateSourceLoc(node.atSign),
+      range: self.generateAttrSourceRange(node),
+      kind: kind
+    )
+  }
+
+  /// E.g.:
+  ///   ```
+  ///   @_noSanitize(address)
+  ///   @_noSanitize(thread)
+  ///   @_noSanitize(memtag)
+  ///   ```
+  func generateNoSanitizeAttr(attribute node: AttributeSyntax) -> BridgedNoSanitizeAttr? {
+    let kind: swift.NoSanitizeKind? = self.generateSingleAttrOption(
+      attribute: node,
+      {
+        switch $0.rawText {
+        case "address": return .address
+        case "thread": return .thread
+        case "memtag": return .memtag
         default: return nil
         }
       }

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1953,14 +1953,26 @@ IRGenSILFunction::IRGenSILFunction(IRGenModule &IGM, SILFunction *f,
                     f->getOptimizationMode(), f->getDebugScope(),
                     f->getLocation()),
       CurSILFn(f) {
-  // Apply sanitizer attributes to the function.
-  // TODO: Check if the function is supposed to be excluded from ASan either by
-  // being in the external file or via annotations.
-  if (IGM.IRGen.Opts.Sanitizers & SanitizerKind::Address)
+  // Apply sanitizer attributes to the function. Kinds listed in one or more
+  // @_noSanitize(<kind>) attributes on the function's decl are suppressed,
+  // mirroring Clang's __attribute__((no_sanitize("<kind>"))).
+  bool noAsan = false, noTsan = false, noMemTag = false;
+  if (f->hasLocation()) {
+    if (auto *D = f->getLocation().getAsASTNode<Decl>()) {
+      for (auto *attr : D->getAttrs().getAttributes<NoSanitizeAttr>()) {
+        switch (attr->getKind()) {
+        case NoSanitizeKind::Address: noAsan = true; break;
+        case NoSanitizeKind::Thread:  noTsan = true; break;
+        case NoSanitizeKind::MemTag:  noMemTag = true; break;
+        }
+      }
+    }
+  }
+  if ((IGM.IRGen.Opts.Sanitizers & SanitizerKind::Address) && !noAsan)
     CurFn->addFnAttr(llvm::Attribute::SanitizeAddress);
-  if (IGM.IRGen.Opts.Sanitizers & SanitizerKind::MemTagStack)
+  if ((IGM.IRGen.Opts.Sanitizers & SanitizerKind::MemTagStack) && !noMemTag)
     CurFn->addFnAttr(llvm::Attribute::SanitizeMemTag);
-  if (IGM.IRGen.Opts.Sanitizers & SanitizerKind::Thread) {
+  if ((IGM.IRGen.Opts.Sanitizers & SanitizerKind::Thread) && !noTsan) {
     auto declContext = f->getDeclContext();
     if (isa_and_nonnull<DestructorDecl>(declContext)) {
       // Do not report races in deinit and anything called from it

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2879,6 +2879,22 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     break;
   }
 
+  case DeclAttrKind::NoSanitize: {
+    auto kind = parseSingleAttrOption<NoSanitizeKind>(
+        *this, Loc, AttrRange, AttrName, DK, {
+          { Context.getIdentifier("address"), NoSanitizeKind::Address },
+          { Context.getIdentifier("thread"),  NoSanitizeKind::Thread },
+          { Context.getIdentifier("memtag"),  NoSanitizeKind::MemTag },
+        });
+    if (!kind)
+      return makeParserSuccess();
+
+    if (!DiscardAttribute)
+      Attributes.add(new (Context) NoSanitizeAttr(AtLoc, AttrRange, *kind));
+
+    break;
+  }
+
   case DeclAttrKind::Optimize: {
     auto optMode = parseSingleAttrOption<OptimizationMode>(
         *this, Loc, AttrRange, AttrName, DK, {

--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -220,6 +220,12 @@ void SILFunctionBuilder::addFunctionAttributes(
     F->setPerfConstraints(PerformanceConstraints::ManualOwnership);
   }
 
+  uint8_t noSanitizeMask = 0;
+  for (auto *attr : Attrs.getAttributes<NoSanitizeAttr>())
+    noSanitizeMask |= 1u << unsigned(attr->getKind());
+  if (noSanitizeMask)
+    F->setNoSanitizeMask(noSanitizeMask);
+
   if (Attrs.hasAttribute<LexicalLifetimesAttr>()) {
     F->setForceEnableLexicalLifetimes(DoForceEnableLexicalLifetimes);
   }

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -3906,6 +3906,14 @@ void SILFunction::print(SILPrintContext &PrintCtx) const {
     case PerformanceConstraints::ManualOwnership: OS << "[manual_ownership] "; break;
   }
 
+  uint8_t noSan = getNoSanitizeMask();
+  if (noSan & (1u << unsigned(NoSanitizeKind::Address)))
+    OS << "[no_sanitize_address] ";
+  if (noSan & (1u << unsigned(NoSanitizeKind::Thread)))
+    OS << "[no_sanitize_thread] ";
+  if (noSan & (1u << unsigned(NoSanitizeKind::MemTag)))
+    OS << "[no_sanitize_memtag] ";
+
   if (isPerformanceConstraint())
     OS << "[perf_constraint] ";
 

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -694,7 +694,7 @@ static bool parseDeclSILOptional(
     SILFunction **usedAdHocRequirementWitness, Identifier *objCReplacementFor,
     SILFunction::Purpose *specialPurpose, Inline_t *inlineStrategy,
     OptimizationMode *optimizationMode, PerformanceConstraints *perfConstraints,
-    bool *isPerformanceConstraint, bool *markedAsUsed, StringRef *asmName,
+    bool *isPerformanceConstraint, uint8_t *noSanitizeMask, bool *markedAsUsed, StringRef *asmName,
     StringRef *section,
     bool *isLet, bool *isWeakImported,
     std::optional<CodeGenerationModel> *codeGenerationModel,
@@ -814,6 +814,12 @@ static bool parseDeclSILOptional(
       *perfConstraints = PerformanceConstraints::NoObjCBridging;
     else if (perfConstraints && SP.P.Tok.getText() == "manual_ownership")
       *perfConstraints = PerformanceConstraints::ManualOwnership;
+    else if (noSanitizeMask && SP.P.Tok.getText() == "no_sanitize_address")
+      *noSanitizeMask |= 1u << unsigned(NoSanitizeKind::Address);
+    else if (noSanitizeMask && SP.P.Tok.getText() == "no_sanitize_thread")
+      *noSanitizeMask |= 1u << unsigned(NoSanitizeKind::Thread);
+    else if (noSanitizeMask && SP.P.Tok.getText() == "no_sanitize_memtag")
+      *noSanitizeMask |= 1u << unsigned(NoSanitizeKind::MemTag);
     else if (isPerformanceConstraint && SP.P.Tok.getText() == "perf_constraint")
       *isPerformanceConstraint = true;
     else if (markedAsUsed && SP.P.Tok.getText() == "used")
@@ -7618,6 +7624,7 @@ bool SILParserState::parseDeclSIL(Parser &P) {
   OptimizationMode optimizationMode = OptimizationMode::NotSet;
   PerformanceConstraints perfConstr = PerformanceConstraints::None;
   bool isPerformanceConstraint = false;
+  uint8_t noSanitizeMask = 0;
   bool markedAsUsed = false;
   StringRef asmName;
   StringRef section;
@@ -7638,7 +7645,7 @@ bool SILParserState::parseDeclSIL(Parser &P) {
           &isExactSelfClass, &DynamicallyReplacedFunction,
           &AdHocWitnessFunction, &objCReplacementFor, &specialPurpose,
           &inlineStrategy, &optimizationMode, &perfConstr,
-          &isPerformanceConstraint, &markedAsUsed, &asmName, &section, nullptr,
+          &isPerformanceConstraint, &noSanitizeMask, &markedAsUsed, &asmName, &section, nullptr,
           &isWeakImported, &codeGenerationModel, &needStackProtection, nullptr,
           &availability, &isWithoutActuallyEscapingThunk, &Semantics,
           &SpecAttrs, &ClangDecl, &MRK, &actorIsolation, FunctionState, M) ||
@@ -7696,6 +7703,7 @@ bool SILParserState::parseDeclSIL(Parser &P) {
     FunctionState.F->setOptimizationMode(optimizationMode);
     FunctionState.F->setPerfConstraints(perfConstr);
     FunctionState.F->setIsPerformanceConstraint(isPerformanceConstraint);
+    FunctionState.F->setNoSanitizeMask(noSanitizeMask);
     FunctionState.F->setEffectsKind(MRK);
     FunctionState.F->setMarkedAsUsed(markedAsUsed);
     FunctionState.F->setAsmName(asmName);
@@ -7905,7 +7913,7 @@ bool SILParserState::parseSILGlobal(Parser &P) {
           nullptr, &isSerialized, nullptr, nullptr, nullptr, nullptr, nullptr,
           nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
           nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-          &isMarkedAsUsed, &asmName, &section, &isLet, nullptr,
+          nullptr, &isMarkedAsUsed, &asmName, &section, &isLet, nullptr,
           &codeGenerationModel, nullptr, nullptr, nullptr, nullptr, nullptr,
           nullptr, nullptr, nullptr, nullptr, State, M) ||
       P.parseToken(tok::at_sign, diag::expected_sil_value_name) ||
@@ -7967,7 +7975,7 @@ bool SILParserState::parseSILProperty(Parser &P) {
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-                           nullptr, SP, M))
+                           nullptr, nullptr, SP, M))
     return true;
 
   ValueDecl *VD;
@@ -8059,7 +8067,7 @@ bool SILParserState::parseSILVTable(Parser &P) {
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-                           nullptr, VTableState, M))
+                           nullptr, nullptr, VTableState, M))
     return true;
 
   ClassDecl *theClass = nullptr;
@@ -8205,7 +8213,7 @@ bool SILParserState::parseSILMoveOnlyDeinit(Parser &parser) {
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-                           nullptr, moveOnlyDeinitTableState, M))
+                           nullptr, nullptr, moveOnlyDeinitTableState, M))
     return true;
 
   // Parse the class name.
@@ -8728,7 +8736,7 @@ bool SILParserState::parseSILWitnessTable(Parser &P) {
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-                           nullptr, nullptr, nullptr, nullptr, nullptr,
+                           nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            &isSpecialized, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, WitnessState, M))
     return true;

--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -15,8 +15,11 @@
 #include "swift/SILOptimizer/Analysis/IsSelfRecursiveAnalysis.h"
 #include "swift/SILOptimizer/Utils/PerformanceInlinerUtils.h"
 #include "swift/AST/Module.h"
+#include "swift/AST/SILOptions.h"
 #include "swift/AST/SubstitutionMap.h"
+#include "swift/AST/AttrKind.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/Sanitizers.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
 #include "llvm/Support/CommandLine.h"
 
@@ -807,6 +810,25 @@ SILFunction *swift::getEligibleFunction(FullApplySite AI,
   // Explicitly disabled inlining or optimization.
   if (Callee->getInlineStrategy() == NoInline) {
     return nullptr;
+  }
+
+  // Refuse to inline across @_noSanitize boundaries when a sanitizer active in
+  // this build would apply differently on either side. IRGen sets the LLVM
+  // sanitize_* function attributes per SILFunction; inlining the callee into
+  // the caller would silently re-instrument (or de-instrument) the callee's
+  // body, defeating the attribute.
+  if (uint8_t diff = Callee->getNoSanitizeMask() ^
+                     AI.getFunction()->getNoSanitizeMask()) {
+    const auto &enabled = Callee->getModule().getOptions().Sanitizers;
+    uint8_t enabledMask = 0;
+    if (enabled.contains(SanitizerKind::Address))
+      enabledMask |= 1u << unsigned(NoSanitizeKind::Address);
+    if (enabled.contains(SanitizerKind::Thread))
+      enabledMask |= 1u << unsigned(NoSanitizeKind::Thread);
+    if (enabled.contains(SanitizerKind::MemTagStack))
+      enabledMask |= 1u << unsigned(NoSanitizeKind::MemTag);
+    if (diff & enabledMask)
+      return nullptr;
   }
 
   if (!SILInlineNeverFuns.empty() &&

--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -812,13 +812,13 @@ SILFunction *swift::getEligibleFunction(FullApplySite AI,
     return nullptr;
   }
 
-  // Refuse to inline across @_noSanitize boundaries when a sanitizer active in
-  // this build would apply differently on either side. IRGen sets the LLVM
-  // sanitize_* function attributes per SILFunction; inlining the callee into
-  // the caller would silently re-instrument (or de-instrument) the callee's
-  // body, defeating the attribute.
-  if (uint8_t diff = Callee->getNoSanitizeMask() ^
-                     AI.getFunction()->getNoSanitizeMask()) {
+  // Refuse to inline a @noSanitize callee into a caller that doesn't opt out
+  // of the same sanitizer: IRGen would otherwise re-instrument the callee's
+  // body inside the caller's LLVM function, defeating the attribute. The
+  // reverse direction (a regular callee into a @noSanitize caller) is fine —
+  // the callee never asked to keep sanitizer instrumentation.
+  if (uint8_t calleeOnly = Callee->getNoSanitizeMask() &
+                           ~AI.getFunction()->getNoSanitizeMask()) {
     const auto &enabled = Callee->getModule().getOptions().Sanitizers;
     uint8_t enabledMask = 0;
     if (enabled.contains(SanitizerKind::Address))
@@ -827,7 +827,7 @@ SILFunction *swift::getEligibleFunction(FullApplySite AI,
       enabledMask |= 1u << unsigned(NoSanitizeKind::Thread);
     if (enabled.contains(SanitizerKind::MemTagStack))
       enabledMask |= 1u << unsigned(NoSanitizeKind::MemTag);
-    if (diff & enabledMask)
+    if (calleeOnly & enabledMask)
       return nullptr;
   }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -201,6 +201,7 @@ public:
   IGNORED_ATTR(Semantics)
   IGNORED_ATTR(NoLocks)
   IGNORED_ATTR(NoAllocation)
+  IGNORED_ATTR(NoSanitize)
   IGNORED_ATTR(NoRuntime)
   IGNORED_ATTR(NoExistentials)
   IGNORED_ATTR(NoManualOwnership)

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1632,6 +1632,7 @@ namespace  {
     UNINTERESTING_ATTR(NoLocks)
     UNINTERESTING_ATTR(NoAllocation)
     UNINTERESTING_ATTR(NoRuntime)
+    UNINTERESTING_ATTR(NoSanitize)
     UNINTERESTING_ATTR(NoExistentials)
     UNINTERESTING_ATTR(NoManualOwnership)
     UNINTERESTING_ATTR(NoObjCBridging)

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -6182,6 +6182,14 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
         break;
       }
 
+      case decls_block::NoSanitize_DECL_ATTR: {
+        unsigned kind;
+        serialization::decls_block::NoSanitizeDeclAttrLayout::readRecord(
+            scratch, kind);
+        Attr = new (ctx) NoSanitizeAttr((NoSanitizeKind)kind);
+        break;
+      }
+
       case decls_block::Export_DECL_ATTR: {
         unsigned kind;
         serialization::decls_block::ExportDeclAttrLayout::readRecord(

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -2480,6 +2480,11 @@ namespace decls_block {
     BCFixed<2>  // inline value
   >;
 
+  using NoSanitizeDeclAttrLayout = BCRecordLayout<
+    NoSanitize_DECL_ATTR,
+    BCFixed<2>  // no-sanitize kind
+  >;
+
   using ExportDeclAttrLayout = BCRecordLayout<
     Export_DECL_ATTR,
     BCFixed<1>  // export kind value

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3197,6 +3197,14 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
+    case DeclAttrKind::NoSanitize: {
+      auto *theAttr = cast<NoSanitizeAttr>(DA);
+      auto abbrCode = S.DeclTypeAbbrCodes[NoSanitizeDeclAttrLayout::Code];
+      NoSanitizeDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
+                                           (unsigned)theAttr->getKind());
+      return;
+    }
+
     case DeclAttrKind::Export: {
       auto *theAttr = cast<ExportAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[ExportDeclAttrLayout::Code];

--- a/test/IRGen/no-sanitize-address-attribute.swift
+++ b/test/IRGen/no-sanitize-address-attribute.swift
@@ -1,0 +1,22 @@
+// REQUIRES: asan_runtime
+// Verify @_noSanitize(address) suppresses the LLVM sanitize_address
+// function attribute (mirrors Clang's __attribute__((no_sanitize("address")))).
+
+// RUN: %target-swift-frontend -emit-ir -sanitize=address %s | %FileCheck %s
+
+// CHECK: define {{.*}}@"$s4main8withAsanSiyF"() [[ASAN:#[0-9]+]]
+public func withAsan() -> Int { 0 }
+
+// CHECK: define {{.*}}@"$s4main6noAsanSiyF"() [[NO_ASAN:#[0-9]+]]
+@_noSanitize(address)
+public func noAsan() -> Int { 1 }
+
+// A @_noSanitize(thread) on an ASan build must NOT suppress ASan.
+// CHECK: define {{.*}}@"$s4main7noTsan1SiyF"() [[ASAN]]
+@_noSanitize(thread)
+public func noTsan1() -> Int { 2 }
+
+// CHECK: attributes [[ASAN]] = { sanitize_address
+// The @_noSanitize(address) function has no enum attributes and so its
+// attribute set opens with a string attribute like "frame-pointer".
+// CHECK: attributes [[NO_ASAN]] = { "

--- a/test/IRGen/no-sanitize-address-attribute.swift
+++ b/test/IRGen/no-sanitize-address-attribute.swift
@@ -1,22 +1,24 @@
 // REQUIRES: asan_runtime
-// Verify @_noSanitize(address) suppresses the LLVM sanitize_address
+// REQUIRES: swift_feature_NoSanitize
+// Verify @noSanitize(address) suppresses the LLVM sanitize_address
 // function attribute (mirrors Clang's __attribute__((no_sanitize("address")))).
 
-// RUN: %target-swift-frontend -emit-ir -sanitize=address %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -sanitize=address \
+// RUN:   -enable-experimental-feature NoSanitize %s | %FileCheck %s
 
 // CHECK: define {{.*}}@"$s4main8withAsanSiyF"() [[ASAN:#[0-9]+]]
 public func withAsan() -> Int { 0 }
 
 // CHECK: define {{.*}}@"$s4main6noAsanSiyF"() [[NO_ASAN:#[0-9]+]]
-@_noSanitize(address)
+@noSanitize(address)
 public func noAsan() -> Int { 1 }
 
-// A @_noSanitize(thread) on an ASan build must NOT suppress ASan.
+// A @noSanitize(thread) on an ASan build must NOT suppress ASan.
 // CHECK: define {{.*}}@"$s4main7noTsan1SiyF"() [[ASAN]]
-@_noSanitize(thread)
+@noSanitize(thread)
 public func noTsan1() -> Int { 2 }
 
 // CHECK: attributes [[ASAN]] = { sanitize_address
-// The @_noSanitize(address) function has no enum attributes and so its
+// The @noSanitize(address) function has no enum attributes and so its
 // attribute set opens with a string attribute like "frame-pointer".
 // CHECK: attributes [[NO_ASAN]] = { "

--- a/test/IRGen/no-sanitize-thread-attribute.swift
+++ b/test/IRGen/no-sanitize-thread-attribute.swift
@@ -1,20 +1,22 @@
 // REQUIRES: tsan_runtime
 // REQUIRES: PTRSIZE=64
-// Verify @_noSanitize(thread) suppresses the LLVM sanitize_thread
+// REQUIRES: swift_feature_NoSanitize
+// Verify @noSanitize(thread) suppresses the LLVM sanitize_thread
 // function attribute.
 
-// RUN: %target-swift-frontend -emit-ir -sanitize=thread %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -sanitize=thread \
+// RUN:   -enable-experimental-feature NoSanitize %s | %FileCheck %s
 
 // CHECK: define {{.*}}@"$s4main8withTsanSiyF"() [[TSAN:#[0-9]+]]
 public func withTsan() -> Int { 0 }
 
 // CHECK: define {{.*}}@"$s4main6noTsanSiyF"() [[NO_TSAN:#[0-9]+]]
-@_noSanitize(thread)
+@noSanitize(thread)
 public func noTsan() -> Int { 1 }
 
-// A @_noSanitize(address) on a TSan build must NOT suppress TSan.
+// A @noSanitize(address) on a TSan build must NOT suppress TSan.
 // CHECK: define {{.*}}@"$s4main8noAsan1_SiyF"() [[TSAN]]
-@_noSanitize(address)
+@noSanitize(address)
 public func noAsan1_() -> Int { 2 }
 
 // CHECK: attributes [[TSAN]] = { sanitize_thread

--- a/test/IRGen/no-sanitize-thread-attribute.swift
+++ b/test/IRGen/no-sanitize-thread-attribute.swift
@@ -1,0 +1,21 @@
+// REQUIRES: tsan_runtime
+// REQUIRES: PTRSIZE=64
+// Verify @_noSanitize(thread) suppresses the LLVM sanitize_thread
+// function attribute.
+
+// RUN: %target-swift-frontend -emit-ir -sanitize=thread %s | %FileCheck %s
+
+// CHECK: define {{.*}}@"$s4main8withTsanSiyF"() [[TSAN:#[0-9]+]]
+public func withTsan() -> Int { 0 }
+
+// CHECK: define {{.*}}@"$s4main6noTsanSiyF"() [[NO_TSAN:#[0-9]+]]
+@_noSanitize(thread)
+public func noTsan() -> Int { 1 }
+
+// A @_noSanitize(address) on a TSan build must NOT suppress TSan.
+// CHECK: define {{.*}}@"$s4main8noAsan1_SiyF"() [[TSAN]]
+@_noSanitize(address)
+public func noAsan1_() -> Int { 2 }
+
+// CHECK: attributes [[TSAN]] = { sanitize_thread
+// CHECK: attributes [[NO_TSAN]] = { "

--- a/test/SILGen/no_sanitize_attribute.swift
+++ b/test/SILGen/no_sanitize_attribute.swift
@@ -1,0 +1,29 @@
+// Verify @_noSanitize(<kind>) parses on functions and is preserved through
+// SILGen (printed on the AST decl above the SIL function body).
+
+// RUN: %target-swift-emit-silgen -parse-as-library %s | %FileCheck %s
+
+// CHECK-DAG: @_noSanitize(address){{.*}}func noAsan
+@_noSanitize(address)
+public func noAsan() -> Int { 0 }
+
+// CHECK-DAG: @_noSanitize(thread){{.*}}func noTsan
+@_noSanitize(thread)
+public func noTsan() -> Int { 1 }
+
+// CHECK-DAG: @_noSanitize(memtag){{.*}}func noMemTag
+@_noSanitize(memtag)
+public func noMemTag() -> Int { 3 }
+
+// Stacking multiple @_noSanitize attributes on one function is allowed.
+// CHECK-DAG: @_noSanitize(address){{.*}}@_noSanitize(thread){{.*}}func stacked
+@_noSanitize(address)
+@_noSanitize(thread)
+public func stacked() -> Int { 4 }
+
+// Also allowed on subscripts.
+public struct S {
+  // CHECK-DAG: @_noSanitize(address){{.*}}subscript
+  @_noSanitize(address)
+  public subscript(i: Int) -> Int { i }
+}

--- a/test/SILGen/no_sanitize_attribute.swift
+++ b/test/SILGen/no_sanitize_attribute.swift
@@ -1,29 +1,32 @@
-// Verify @_noSanitize(<kind>) parses on functions and is preserved through
+// Verify @noSanitize(<kind>) parses on functions and is preserved through
 // SILGen (printed on the AST decl above the SIL function body).
 
-// RUN: %target-swift-emit-silgen -parse-as-library %s | %FileCheck %s
+// REQUIRES: swift_feature_NoSanitize
 
-// CHECK-DAG: @_noSanitize(address){{.*}}func noAsan
-@_noSanitize(address)
+// RUN: %target-swift-emit-silgen -parse-as-library \
+// RUN:   -enable-experimental-feature NoSanitize %s | %FileCheck %s
+
+// CHECK-DAG: @noSanitize(address){{.*}}func noAsan
+@noSanitize(address)
 public func noAsan() -> Int { 0 }
 
-// CHECK-DAG: @_noSanitize(thread){{.*}}func noTsan
-@_noSanitize(thread)
+// CHECK-DAG: @noSanitize(thread){{.*}}func noTsan
+@noSanitize(thread)
 public func noTsan() -> Int { 1 }
 
-// CHECK-DAG: @_noSanitize(memtag){{.*}}func noMemTag
-@_noSanitize(memtag)
+// CHECK-DAG: @noSanitize(memtag){{.*}}func noMemTag
+@noSanitize(memtag)
 public func noMemTag() -> Int { 3 }
 
-// Stacking multiple @_noSanitize attributes on one function is allowed.
-// CHECK-DAG: @_noSanitize(address){{.*}}@_noSanitize(thread){{.*}}func stacked
-@_noSanitize(address)
-@_noSanitize(thread)
+// Stacking multiple @noSanitize attributes on one function is allowed.
+// CHECK-DAG: @noSanitize(address){{.*}}@noSanitize(thread){{.*}}func stacked
+@noSanitize(address)
+@noSanitize(thread)
 public func stacked() -> Int { 4 }
 
 // Also allowed on subscripts.
 public struct S {
-  // CHECK-DAG: @_noSanitize(address){{.*}}subscript
-  @_noSanitize(address)
+  // CHECK-DAG: @noSanitize(address){{.*}}subscript
+  @noSanitize(address)
   public subscript(i: Int) -> Int { i }
 }

--- a/test/SILOptimizer/no_sanitize_inline_barrier.swift
+++ b/test/SILOptimizer/no_sanitize_inline_barrier.swift
@@ -1,22 +1,25 @@
 // Verify that the SIL performance inliner refuses to inline a
-// @_noSanitize(<kind>) callee into a caller with a different mask when the
+// @noSanitize(<kind>) callee into a caller without the same bit when the
 // corresponding sanitizer is enabled — inlining would otherwise cause the
-// callee's body to be (de)instrumented at IRGen time, defeating the attribute.
+// callee's body to be re-instrumented at IRGen time, defeating the attribute.
 
 // REQUIRES: asan_runtime
 // REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_NoSanitize
 
 // Baseline: without a sanitizer, the mismatch is inert; the callee is inlined
 // (verified indirectly by absence of a direct call in the caller's IR).
-// RUN: %target-swift-frontend -O -emit-sil -parse-as-library %s \
+// RUN: %target-swift-frontend -O -emit-sil -parse-as-library \
+// RUN:   -enable-experimental-feature NoSanitize %s \
 // RUN:   | %FileCheck %s --check-prefix=NOSAN
 
 // With ASan enabled, the mismatch blocks inlining, so the caller keeps the
 // direct call.
 // RUN: %target-swift-frontend -O -sanitize=address -emit-sil \
-// RUN:   -parse-as-library %s | %FileCheck %s --check-prefix=WITHSAN
+// RUN:   -enable-experimental-feature NoSanitize -parse-as-library %s \
+// RUN:   | %FileCheck %s --check-prefix=WITHSAN
 
-@_noSanitize(address)
+@noSanitize(address)
 public func skippedCallee(_ x: Int) -> Int {
   return x &+ 1
 }
@@ -32,4 +35,19 @@ public func skippedCallee(_ x: Int) -> Int {
 // WITHSAN: function_ref {{.*}}skippedCallee
 public func caller() -> Int {
   return skippedCallee(41)
+}
+
+// The reverse direction is fine: a regular callee has no sanitizer contract to
+// lose, so it can be inlined into a @noSanitize caller even with ASan on.
+public func plainCallee(_ x: Int) -> Int {
+  return x &+ 2
+}
+
+// NOSAN-LABEL: sil {{.*}} @$s26no_sanitize_inline_barrier0A9SanCallerSiyF
+// NOSAN-NOT: plainCallee
+// WITHSAN-LABEL: sil {{.*}} @$s26no_sanitize_inline_barrier0A9SanCallerSiyF
+// WITHSAN-NOT: plainCallee
+@noSanitize(address)
+public func noSanCaller() -> Int {
+  return plainCallee(41)
 }

--- a/test/SILOptimizer/no_sanitize_inline_barrier.swift
+++ b/test/SILOptimizer/no_sanitize_inline_barrier.swift
@@ -1,0 +1,35 @@
+// Verify that the SIL performance inliner refuses to inline a
+// @_noSanitize(<kind>) callee into a caller with a different mask when the
+// corresponding sanitizer is enabled — inlining would otherwise cause the
+// callee's body to be (de)instrumented at IRGen time, defeating the attribute.
+
+// REQUIRES: asan_runtime
+// REQUIRES: swift_in_compiler
+
+// Baseline: without a sanitizer, the mismatch is inert; the callee is inlined
+// (verified indirectly by absence of a direct call in the caller's IR).
+// RUN: %target-swift-frontend -O -emit-sil -parse-as-library %s \
+// RUN:   | %FileCheck %s --check-prefix=NOSAN
+
+// With ASan enabled, the mismatch blocks inlining, so the caller keeps the
+// direct call.
+// RUN: %target-swift-frontend -O -sanitize=address -emit-sil \
+// RUN:   -parse-as-library %s | %FileCheck %s --check-prefix=WITHSAN
+
+@_noSanitize(address)
+public func skippedCallee(_ x: Int) -> Int {
+  return x &+ 1
+}
+
+// Without a sanitizer, the callee is fully inlined and no function_ref remains
+// pointing at it.
+// NOSAN-LABEL: sil {{.*}}@$s26no_sanitize_inline_barrier6callerSiyF
+// NOSAN-NOT: skippedCallee
+
+// With ASan enabled, the mismatched no-sanitize mask blocks inlining, so the
+// caller retains the call.
+// WITHSAN-LABEL: sil {{.*}}@$s26no_sanitize_inline_barrier6callerSiyF
+// WITHSAN: function_ref {{.*}}skippedCallee
+public func caller() -> Int {
+  return skippedCallee(41)
+}


### PR DESCRIPTION
This adds an analog to clang's `__attribute__((no_sanitize("<sanitizer>"))`. The implementation is closely modelled after the swift `@inline` attribute.

I think the plumbing is pretty straightforward -- the one interesting bit is the SIL inliner now looks at the attribute to prevent a unsanitized function from being inlined into a sanitized function.

Assisted-by: Claude

rdar://33394397