### PR TITLE
[NFC] Refactor withWitnessableMetadataCollector to delete dead parameter

### DIFF
--- a/lib/IRGen/Outlining.cpp
+++ b/lib/IRGen/Outlining.cpp
@@ -295,7 +295,7 @@ irgen::getTypeAndGenericSignatureForManglingOutlineFunction(SILType type) {
 }
 
 bool TypeInfo::withWitnessableMetadataCollector(
-    IRGenFunction &IGF, SILType T, LayoutIsNeeded_t mayNeedLayout,
+    IRGenFunction &IGF, SILType T,
     DeinitIsNeeded_t needsDeinit,
     llvm::function_ref<void(OutliningMetadataCollector &)> invocation) const {
   bool needsCollector = false;
@@ -330,7 +330,7 @@ void TypeInfo::callOutlinedCopy(IRGenFunction &IGF, Address dest, Address src,
                                 SILType T, IsInitialization_t isInit,
                                 IsTake_t isTake) const {
   if (withWitnessableMetadataCollector(
-          IGF, T, LayoutIsNeeded, DeinitIsNotNeeded, [&](auto collector) {
+          IGF, T, DeinitIsNotNeeded, [&](auto collector) {
             collector.emitCallToOutlinedCopy(dest, src, T, *this, isInit,
                                              isTake);
           })) {
@@ -553,7 +553,7 @@ void TypeInfo::callOutlinedDestroy(IRGenFunction &IGF,
     return;
 
   if (withWitnessableMetadataCollector(
-          IGF, T, LayoutIsNeeded, DeinitIsNeeded, [&](auto collector) {
+          IGF, T, DeinitIsNeeded, [&](auto collector) {
             collector.emitCallToOutlinedDestroy(addr, T, *this);
           })) {
     return;

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -617,7 +617,7 @@ public:
   /// Returns whether there was an appropriate emitter (and whether \p
   /// invocation was called).
   bool withWitnessableMetadataCollector(
-      IRGenFunction &IGF, SILType T, LayoutIsNeeded_t needsLayout,
+      IRGenFunction &IGF, SILType T,
       DeinitIsNeeded_t needsDeinit,
       llvm::function_ref<void(OutliningMetadataCollector &)> invocation) const;
 


### PR DESCRIPTION
Since https://github.com/swiftlang/swift/commit/765d23bbbc53acaad06966b7a6f12be9ad43b317, the mayNeedLayout parameter in this method is unused. If a given SILType requires metadata to be collected seems to be sufficiently determined within the body of the method, and need not be specified by callers.

