### PR TITLE
Add a SIL diagnostic for condfail messages that are not literals

### DIFF
--- a/include/swift/AST/DiagnosticGroups.def
+++ b/include/swift/AST/DiagnosticGroups.def
@@ -77,6 +77,7 @@ GROUP(OptionObsoletedByModuleSelectors,none,"option-obsoleted-by-module-selector
 GROUP(ModuleNotTestable,none,"module-not-testable")
 GROUP(ModuleSelfImport,none,"module-self-import")
 GROUP(ModuleVersionMissing,none,"module-version-missing")
+GROUP(MissingRuntimeFailureMessage,DefaultIgnoreWarnings,"")
 GROUP(MultipleInheritance,none,"multiple-inheritance")
 GROUP(MutableGlobalVariable,none,"mutable-global-variable")
 GROUP(NominalTypes,none,"nominal-types")

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -809,6 +809,13 @@ WARNING(oslog_call_in_unreachable_code, none, "os log call will never be "
 ERROR(global_string_pointer_on_non_constant, none, "globalStringTablePointer "
       "builtin must be used only on string literals", ())
 
+GROUPED_WARNING(runtime_failure_message_not_literal,
+        MissingRuntimeFailureMessage, none,
+        "runtime failure message is not a string literal; the failure will be "
+        "reported as '%0'", (StringRef))
+NOTE(runtime_failure_message_produced_here, none, "message is produced here",
+     ())
+
 ERROR(polymorphic_builtin_passed_non_trivial_non_builtin_type, none, "Argument "
       "of type %0 can not be passed as an argument to a Polymorphic "
       "builtin. Polymorphic builtins can only be passed arguments that are "

--- a/lib/SILOptimizer/Mandatory/IRGenPrepare.cpp
+++ b/lib/SILOptimizer/Mandatory/IRGenPrepare.cpp
@@ -22,6 +22,8 @@
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "sil-cleanup"
+#include "swift/AST/DiagnosticEngine.h"
+#include "swift/AST/DiagnosticsSIL.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILInstruction.h"
@@ -32,6 +34,10 @@
 #include "swift/Strings.h"
 
 using namespace swift;
+
+/// The message a `cond_fail` gets when the `Builtin.condfail_message` it came
+/// from had no statically known message.
+static const StringRef DefaultCondFailMessage = "unknown program error";
 
 // Print the message string of encountered `cond_fail` instructions the first
 // time the message string is encountered.
@@ -44,6 +50,38 @@ static llvm::cl::opt<bool> IncludeCondFailMessagesFunction(
                  "the current SIL function name"));
 
 static llvm::DenseSet<StringRef> CondFailMessages;
+
+/// Warn that the message of \p condFailInst is about to be replaced by
+/// `DefaultCondFailMessage`, and point at the value that stands in for the
+/// message the programmer wrote.
+static void diagnoseMissingMessage(SILFunction &fn, BuiltinInst *condFailInst) {
+  SILValue message = condFailInst->getOperand(1);
+
+  // If the message did resolve to a literal, ConstantFolding or SILCombine
+  // would have folded this builtin into a cond_fail carrying it. Nothing is
+  // lost, so there is nothing to diagnose.
+  if (auto *sli = dyn_cast<StringLiteralInst>(message))
+    if (sli->getEncoding() == StringLiteralInst::Encoding::UTF8)
+      return;
+
+  ASTContext &ctx = fn.getModule().getASTContext();
+  SourceLoc failureLoc = condFailInst->getLoc().getSourceLoc();
+
+  // Compiler-generated code has no location to point at. Only diagnose
+  // actionable warnings.
+  if (failureLoc.isInvalid())
+    return;
+
+  ctx.Diags.diagnose(failureLoc, diag::runtime_failure_message_not_literal,
+                     DefaultCondFailMessage);
+
+  // Point at the source location of the message.
+  if (auto *def = message->getDefiningInstruction()) {
+    SourceLoc defLoc = def->getLoc().getSourceLoc();
+    if (defLoc.isValid() && defLoc != failureLoc)
+      ctx.Diags.diagnose(defLoc, diag::runtime_failure_message_produced_here);
+  }
+}
 
 static bool cleanFunction(SILFunction &fn) {
   bool madeChange = false;
@@ -87,9 +125,10 @@ static bool cleanFunction(SILFunction &fn) {
 
       switch (bi->getBuiltinInfo().ID) {
         case BuiltinValueKind::CondFailMessage: {
+          diagnoseMissingMessage(fn, bi);
           SILBuilderWithScope Builder(bi);
           Builder.createCondFail(bi->getLoc(), bi->getOperand(0),
-            "unknown program error");
+            DefaultCondFailMessage);
           LLVM_FALLTHROUGH;
         }
         case BuiltinValueKind::PoundAssert:

--- a/stdlib/public/core/Assert.swift
+++ b/stdlib/public/core/Assert.swift
@@ -136,8 +136,7 @@ public func precondition(
     }
   } else if _isReleaseAssertConfiguration() {
     let error = !condition()
-    Builtin.condfail_message(error._value,
-      StaticString("precondition failure").unsafeRawPointer)
+    Builtin.condfail_message(error._value, message().unsafeRawPointer)
   }
 }
 #endif
@@ -253,8 +252,7 @@ public func preconditionFailure(
     _assertionFailure(kind: .fatal(), message(), file: file, line: line,
       flags: _fatalErrorFlags())
   } else if _isReleaseAssertConfiguration() {
-    Builtin.condfail_message(true._value,
-      StaticString("precondition failure").unsafeRawPointer)
+    Builtin.condfail_message(true._value, message().unsafeRawPointer)
   }
   _conditionallyUnreachable()
 }
@@ -301,8 +299,7 @@ public func fatalError(
     _assertionFailure(kind: .fatal(), message(), file: file, line: line,
       flags: _fatalErrorFlags())
   } else {
-    Builtin.condfail_message(true._value,
-      StaticString("fatal error").unsafeRawPointer)
+    Builtin.condfail_message(true._value, message().unsafeRawPointer)
     Builtin.unreachable()
   }
 }

--- a/test/SILOptimizer/warn_missing_runtime_failure_message.swift
+++ b/test/SILOptimizer/warn_missing_runtime_failure_message.swift
@@ -1,0 +1,40 @@
+// RUN: %target-swift-frontend -emit-ir -O -enable-builtin-module -disable-access-control -Wwarning MissingRuntimeFailureMessage -verify %s -o /dev/null
+// The group is off by default, so nothing is reported without -Wwarning.
+// RUN: %target-swift-frontend -emit-ir -O -enable-builtin-module -disable-access-control %s -o /dev/null 2>&1 | %FileCheck --allow-empty --check-prefix SILENT %s
+// SILENT-NOT: warning
+
+// A `Builtin.condfail_message` whose message operand cannot be resolved to a
+// string literal loses that message: IRGenPrepare replaces it with the generic
+// "unknown program error". Check that we warn about it, at the location of the
+// failure rather than somewhere inside the standard library.
+
+import Builtin
+import Swift
+
+// A literal message survives into the cond_fail, so there is nothing to warn
+// about here.
+public func literalMessage(_ cond: Builtin.Int1) {
+  Builtin.condfail_message(cond, StaticString("literal message").unsafeRawPointer)
+}
+
+// An empty literal is still a literal.
+public func emptyLiteralMessage(_ cond: Builtin.Int1) {
+  Builtin.condfail_message(cond, StaticString("").unsafeRawPointer)
+}
+
+public func opaqueMessage(_ cond: Builtin.Int1, _ message: Builtin.RawPointer) {
+  Builtin.condfail_message(cond, message) // expected-warning {{runtime failure message is not a string literal; the failure will be reported as 'unknown program error'}}
+}
+
+let global: StaticString = "from a global"
+
+public func messageFromGlobal(_ cond: Builtin.Int1) {
+  Builtin.condfail_message(cond, global.unsafeRawPointer) // expected-warning {{runtime failure message is not a string literal; the failure will be reported as 'unknown program error'}} expected-note {{message is produced here}}
+}
+
+// Both branches are literals, but the value reaching the builtin is a block
+// argument, so no literal is available to fold.
+public func messageFromBranch(_ cond: Builtin.Int1, _ which: Bool) {
+  let message: StaticString = which ? "one" : "other"
+  Builtin.condfail_message(cond, message.unsafeRawPointer) // expected-warning {{runtime failure message is not a string literal; the failure will be reported as 'unknown program error'}} expected-note {{message is produced here}}
+}

--- a/test/embedded/traps-preserve-message.swift
+++ b/test/embedded/traps-preserve-message.swift
@@ -1,0 +1,64 @@
+// The Embedded `StaticString` overloads of `fatalError`, `precondition`, and
+// `preconditionFailure` pass the caller's message to
+// `Builtin.condfail_message`, so a literal message reaches the `cond_fail` and,
+// from there, the name of the trap's artificial subprogram in the debug
+// info. In release configurations that is the only place the message survives.
+
+// RUN: %target-swift-frontend -emit-sil -O     -enable-experimental-feature Embedded -wmo -module-name main %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -Osize -enable-experimental-feature Embedded -wmo -module-name main %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -g -O   -enable-experimental-feature Embedded -wmo -module-name main %s | %FileCheck --check-prefix CHECK-IR %s
+
+// REQUIRES: optimized_stdlib
+// REQUIRES: swift_feature_Embedded
+
+// Each function traps on a different condition to avoid function merging.
+
+// CHECK-LABEL: sil @$e4main12fatalMessageyySiF
+// CHECK: cond_fail {{%.*}}, "fatalError message"
+// CHECK-IR-LABEL: define {{.*}}@"$e4main12fatalMessageyySiF"
+// CHECK-IR: call void @llvm.trap(){{.*}}!dbg ![[FATAL_LOC:[0-9]+]]
+public func fatalMessage(_ x: Int) {
+  if x < 0 { fatalError("fatalError message") }  // LINE 21
+}
+
+// CHECK-LABEL: sil @$e4main19preconditionMessageyySiF
+// CHECK: cond_fail {{%.*}}, "precondition message"
+// CHECK-IR-LABEL: define {{.*}}@"$e4main19preconditionMessageyySiF"
+// CHECK-IR: call void @llvm.trap(){{.*}}!dbg ![[PRECONDITION_LOC:[0-9]+]]
+public func preconditionMessage(_ x: Int) {
+  precondition(x > 100, "precondition message")  // LINE 29
+}
+
+// CHECK-LABEL: sil @$e4main26preconditionFailureMessageyySiF
+// CHECK: cond_fail {{%.*}}, "preconditionFailure message"
+// CHECK-IR-LABEL: define {{.*}}@"$e4main26preconditionFailureMessageyySiF"
+// CHECK-IR: call void @llvm.trap(){{.*}}!dbg ![[PRECONDITION_FAILURE_LOC:[0-9]+]]
+public func preconditionFailureMessage(_ x: Int) {
+  if x < -7 { preconditionFailure("preconditionFailure message") }  // LINE 37
+}
+
+// Messages that aren't literals are replaced with a generic error message.
+
+// CHECK-LABEL: sil @$e4main15fallbackMessageyySi_s12StaticStringVtF
+// CHECK: builtin "condfail_message"
+// CHECK-IR-LABEL: define {{.*}}@"$e4main15fallbackMessageyySi_s12StaticStringVtF"
+// CHECK-IR: call void @llvm.trap(){{.*}}!dbg ![[FALLBACK_LOC:[0-9]+]]
+public func fallbackMessage(_ x: Int, _ message: StaticString) {
+  if x < -13 { fatalError(message) }  // LINE 47
+}
+
+// CHECK-IR-DAG: ![[FATAL_LOC]] = !DILocation(line: 0, scope: ![[FATAL:[0-9]+]], inlinedAt: ![[FATAL_CALL:[0-9]+]])
+// CHECK-IR-DAG: ![[FATAL]] = distinct !DISubprogram(name: "Swift runtime failure: fatalError message"
+// CHECK-IR-DAG: ![[FATAL_CALL]] = !DILocation(line: 21, column: {{[0-9]+}},
+
+// CHECK-IR-DAG: ![[PRECONDITION_LOC]] = !DILocation(line: 0, scope: ![[PRECONDITION:[0-9]+]], inlinedAt: ![[PRECONDITION_CALL:[0-9]+]])
+// CHECK-IR-DAG: ![[PRECONDITION]] = distinct !DISubprogram(name: "Swift runtime failure: precondition message"
+// CHECK-IR-DAG: ![[PRECONDITION_CALL]] = !DILocation(line: 29, column: {{[0-9]+}},
+
+// CHECK-IR-DAG: ![[PRECONDITION_FAILURE_LOC]] = !DILocation(line: 0, scope: ![[PRECONDITION_FAILURE:[0-9]+]], inlinedAt: ![[PRECONDITION_FAILURE_CALL:[0-9]+]])
+// CHECK-IR-DAG: ![[PRECONDITION_FAILURE]] = distinct !DISubprogram(name: "Swift runtime failure: preconditionFailure message"
+// CHECK-IR-DAG: ![[PRECONDITION_FAILURE_CALL]] = !DILocation(line: 37, column: {{[0-9]+}},
+
+// CHECK-IR-DAG: ![[FALLBACK_LOC]] = !DILocation(line: 0, scope: ![[FALLBACK:[0-9]+]], inlinedAt: ![[FALLBACK_CALL:[0-9]+]])
+// CHECK-IR-DAG: ![[FALLBACK]] = distinct !DISubprogram(name: "Swift runtime failure: unknown program error"
+// CHECK-IR-DAG: ![[FALLBACK_CALL]] = !DILocation(line: 47, column: {{[0-9]+}},


### PR DESCRIPTION
Now that the embedded Swift stdlib passes user strings through to
Builtin.condfail() it is useful to have a mechanism that alerts users when the
message isn't resolvable to a static string literal after optimizations.

Depends on https://github.com/swiftlang/swift/pull/91140