### PR TITLE
[Embedded] Change _swift_reportError to return and trap in the stdlib 

### DIFF
--- a/stdlib/public/EmbeddedPlatform/EmbeddedPlatformPOSIX.swift
+++ b/stdlib/public/EmbeddedPlatform/EmbeddedPlatformPOSIX.swift
@@ -144,12 +144,11 @@ public func _swift_reportError(
   _ message: UnsafePointer<UInt8>?,
   _ messageCount: Int,
   _ flags: UInt64
-) -> Never {
+) {
   unsafe _reportError(
     prefix: _reportErrorPrefix(flags),
     fileName: nil, fileNameCount: 0, line: 0,
     message: message, messageCount: messageCount)
-  Builtin.int_trap()
 }
 
 @export(interface)
@@ -161,12 +160,11 @@ public func _swift_reportErrorAt(
   _ fileNameCount: Int,
   _ line: Int,
   _ flags: UInt64
-) -> Never {
+) {
   unsafe _reportError(
     prefix: _reportErrorPrefix(flags),
     fileName: fileName, fileNameCount: fileNameCount, line: line,
     message: message, messageCount: messageCount)
-  Builtin.int_trap()
 }
 
 #if SWIFT_STDLIB_HAS_MALLOC_TYPE

--- a/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
+++ b/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
@@ -363,7 +363,11 @@ __swift_size_t _swift_writeToStandardOutput(
     __swift_size_t count);
 
 /**
- * Reports a fatal error and terminates the program.
+ * Reports a fatal error before the program is terminated.
+ *
+ * A platform may implement this as an empty function. After returning from this
+ * function the standard library terminates the program using a unique trap
+ * whose debug info also carries the stop reason and source location.
  *
  * - Parameters:
  *   - message: The UTF-8 code points that make up the failure message. It is
@@ -376,10 +380,14 @@ void _swift_reportError(
     const unsigned char * EMBEDDED_SWIFT_NULLABLE EMBEDDED_SWIFT_COUNTED_BY(messageCount) message,
     __swift_size_t messageCount,
     __swift_options_t flags
-) EMBEDDED_SWIFT_NORETURN;
+);
 
 /**
- * Reports a fatal error at a given file/line and terminates the program.
+ * Reports a fatal error at a given file/line.
+ *
+ * A platform may implement this as an empty function. After returning from
+ * this function the standard library terminates the program using a unique trap
+ * whose debug info also carries the stop reason and source location.
  *
  * - Parameters:
  *   - message: The UTF-8 code points that make up the failure message. It is
@@ -399,7 +407,7 @@ void _swift_reportErrorAt(
     __swift_size_t fileNameCount,
     __swift_size_t line,
     __swift_options_t flags
-) EMBEDDED_SWIFT_NORETURN;
+);
 
 /**
  * Generates random bytes into the given buffer.

--- a/stdlib/public/core/AssertCommon.swift
+++ b/stdlib/public/core/AssertCommon.swift
@@ -152,9 +152,10 @@ internal func _assertionFailure(
     _embeddedReportFatalErrorInFile(prefix: prefix, message: message,
       file: file, line: line)
   }
-#endif
-  Builtin.condfail_message(false._value, message.unsafeRawPointer)
-  Builtin.int_trap()
+#endif  
+  Builtin.condfail_message(true._value, message.unsafeRawPointer)
+  // condfail doesn't return Never, hence the unreachable.
+  Builtin.unreachable()
 }
 
 /// Error-kind-based variant of the above, emitted into clients (rather than
@@ -178,8 +179,9 @@ internal func _assertionFailure(
     _embeddedReportFatalErrorInFile(kind: kind, message: message,
       file: file, line: line)
   }
-  Builtin.condfail_message(false._value, message.unsafeRawPointer)
-  Builtin.int_trap()
+  Builtin.condfail_message(true._value, message.unsafeRawPointer)
+  // condfail doesn't return Never, hence the unreachable.
+  Builtin.unreachable()
 #endif
 }
 
@@ -322,8 +324,8 @@ internal func _assertionFailure(
     _embeddedReportFatalError(prefix: prefix, message: message)
   }
 
-  Builtin.condfail_message(false._value, message.unsafeRawPointer)
-  Builtin.int_trap()
+  Builtin.condfail_message(true._value, message.unsafeRawPointer)
+  Builtin.unreachable()
 }
 
 /// Error-kind-based variant of the above, emitted into clients via
@@ -338,8 +340,8 @@ internal func _assertionFailure(
     _embeddedReportFatalError(kind: kind, message: message)
   }
 
-  Builtin.condfail_message(false._value, message.unsafeRawPointer)
-  Builtin.int_trap()
+  Builtin.condfail_message(true._value, message.unsafeRawPointer)
+  Builtin.unreachable()
 }
 #endif
 

--- a/test/SILOptimizer/irgen_prepare_condfail_message.sil
+++ b/test/SILOptimizer/irgen_prepare_condfail_message.sil
@@ -1,0 +1,24 @@
+// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -irgen-prepare | %FileCheck %s
+
+// IRGenPrepare lowers `Builtin.condfail_message` into a
+// `cond_fail`. If the parameter isn't a StringLiteral at this point
+// it ghets replaces by a generic error message.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+// A message that is only known at runtime.
+//
+// CHECK-LABEL: sil @opaque_message :
+// CHECK-NOT:     builtin "condfail_message"
+// CHECK:         cond_fail %0 : $Builtin.Int1, "unknown program error"
+// CHECK-NOT:     builtin "condfail_message"
+// CHECK:       } // end sil function 'opaque_message'
+sil @opaque_message : $@convention(thin) (Builtin.Int1, Builtin.RawPointer) -> () {
+bb0(%0 : $Builtin.Int1, %1 : $Builtin.RawPointer):
+  %2 = builtin "condfail_message"(%0 : $Builtin.Int1, %1 : $Builtin.RawPointer) : $()
+  %3 = tuple ()
+  return %3 : $()
+}

--- a/test/embedded/traps-preserve-message-asserts.swift
+++ b/test/embedded/traps-preserve-message-asserts.swift
@@ -1,0 +1,59 @@
+// With assertions enabled the standard library reports a failure through the
+// platform's error reporting hook, which is allowed to return, and then traps.
+// The message is a literal by the time it reaches the trap, so it is recorded in
+// the debug info under the trap as well as printed at runtime. `assert` and
+// `assertionFailure` only exist in this configuration.
+
+// RUN: %target-swift-frontend -emit-sil -O     -assert-config Debug -enable-experimental-feature Embedded -wmo -module-name main %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -Osize -assert-config Debug -enable-experimental-feature Embedded -wmo -module-name main %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -g -O   -assert-config Debug -enable-experimental-feature Embedded -wmo -module-name main %s | %FileCheck --check-prefix CHECK-IR %s
+
+// REQUIRES: optimized_stdlib
+// REQUIRES: swift_feature_Embedded
+
+// Each function is checked for both halves of the failure: the report, which
+// prints the message, and the trap that terminates once it returns.
+
+// CHECK-LABEL: sil @$e4main9viaAssertyySiF
+// CHECK: function_ref @{{.*}}_embeddedReportFatalErrorInFile
+// CHECK: cond_fail {{%.*}}, "assert message"
+public func viaAssert(_ x: Int) {
+  assert(x >= 0, "assert message")
+}
+
+// CHECK-LABEL: sil @$e4main19viaAssertionFailureyySiF
+// CHECK: function_ref @{{.*}}_embeddedReportFatalErrorInFile
+// CHECK: cond_fail {{%.*}}, "assertionFailure message"
+public func viaAssertionFailure(_ x: Int) {
+  if x < -1 { assertionFailure("assertionFailure message") }
+}
+
+// CHECK-LABEL: sil @$e4main15viaPreconditionyySiF
+// CHECK: function_ref @{{.*}}_embeddedReportFatalErrorInFile
+// CHECK: cond_fail {{%.*}}, "precondition message"
+public func viaPrecondition(_ x: Int) {
+  precondition(x > 100, "precondition message")
+}
+
+// CHECK-LABEL: sil @$e4main22viaPreconditionFailureyySiF
+// CHECK: function_ref @{{.*}}_embeddedReportFatalErrorInFile
+// CHECK: cond_fail {{%.*}}, "preconditionFailure message"
+public func viaPreconditionFailure(_ x: Int) {
+  if x < -7 { preconditionFailure("preconditionFailure message") }
+}
+
+// CHECK-LABEL: sil @$e4main13viaFatalErroryySiF
+// CHECK: function_ref @{{.*}}_embeddedReportFatalErrorInFile
+// CHECK: cond_fail {{%.*}}, "fatalError message"
+public func viaFatalError(_ x: Int) {
+  if x < -13 { fatalError("fatalError message") }
+}
+
+// These messages are unique to this file, so their presence is enough. The
+// sibling release-mode test checks that each subprogram belongs to the trap of
+// the function it came from.
+// CHECK-IR-DAG: !DISubprogram(name: "Swift runtime failure: assert message"
+// CHECK-IR-DAG: !DISubprogram(name: "Swift runtime failure: assertionFailure message"
+// CHECK-IR-DAG: !DISubprogram(name: "Swift runtime failure: precondition message"
+// CHECK-IR-DAG: !DISubprogram(name: "Swift runtime failure: preconditionFailure message"
+// CHECK-IR-DAG: !DISubprogram(name: "Swift runtime failure: fatalError message"

--- a/test/embedded/traps-unique.swift
+++ b/test/embedded/traps-unique.swift
@@ -13,18 +13,17 @@ public func foobar(i: Int) {
 
 // CHECK: define {{.*}}@"$e4main6foobar1iySi_tF"{{.*}} {
 // CHECK: entry:
-// CHECK:   switch i64 %0, label %3 [
-// CHECK:     i64 1, label %1
-// CHECK:     i64 2, label %2
+// CHECK:   switch i64 %0, label %{{[0-9]+}} [
+// CHECK:     i64 1, label %[[ONE:[0-9]+]]
+// CHECK:     i64 2, label %[[TWO:[0-9]+]]
 // CHECK:   ]
-// CHECK: 1:
+// CHECK:   ret void
+// CHECK: [[ONE]]:
 // CHECK:   tail call void @llvm.trap() [[NOMERGE:#[0-9]+]]
 // CHECK:   unreachable
-// CHECK: 2:
+// CHECK: [[TWO]]:
 // CHECK:   tail call void @llvm.trap() [[NOMERGE]]
 // CHECK:   unreachable
-// CHECK: 3:
-// CHECK:   ret void
 // CHECK: }
 // CHECK: attributes [[NOMERGE]] = {{{.*}}nomerge{{.*}}}
 


### PR DESCRIPTION
This unifies the behavior of assertions, preconditions, and fatal errors by
creating a unique trap with the failure reason in the debug info, so LLDB can
display the appropriate stop reason as long as the assertion text is a static
string after inlining.

It also clarifies to platform implementers that the canonical way to get at stop
reason and location is the debug info, and the _swift_reportError() is an
optional way to process the failure at runtime.

Assisted-by: claude

Depends on https://github.com/swiftlang/swift/pull/91140