### PR TITLE
[Debug Info] Bump the default ELF DWARF version to 5 

### DIFF
--- a/lib/Driver/ToolChains.h
+++ b/lib/Driver/ToolChains.h
@@ -148,6 +148,11 @@ protected:
   InvocationInfo constructInvocation(const AutolinkExtractJobAction &job,
                                      const JobContext &context) const override;
 
+  void addCommonFrontendArgs(
+      const OutputInfo &OI, const CommandOutput &output,
+      const llvm::opt::ArgList &inputArgs,
+      llvm::opt::ArgStringList &arguments) const override;
+
   /// If provided, and if the user has not already explicitly specified a
   /// linker to use via the "-fuse-ld=" option, this linker will be passed to
   /// the compiler invocation via "-fuse-ld=". Return an empty string to not

--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -42,6 +42,32 @@ using namespace swift::driver;
 using namespace llvm::opt;
 using namespace swift::driver::toolchains;
 
+static unsigned getDefaultDWARFVersionForUnixTriple(const llvm::Triple &triple) {
+  // Match Clang: DWARF v5 is the default everywhere except Android, which
+  // stays on v4 for compatibility with the NDK's bundled debugging tools.
+  if (triple.isAndroid())
+    return 4;
+  return 5;
+}
+
+void toolchains::GenericUnix::addCommonFrontendArgs(
+    const OutputInfo &OI, const CommandOutput &output,
+    const llvm::opt::ArgList &inputArgs,
+    llvm::opt::ArgStringList &arguments) const {
+  ToolChain::addCommonFrontendArgs(OI, output, inputArgs, arguments);
+
+  std::string dwarfVersion;
+  {
+    llvm::raw_string_ostream os(dwarfVersion);
+    os << "-dwarf-version=";
+    if (OI.DWARFVersion)
+      os << std::to_string(*OI.DWARFVersion);
+    else
+      os << getDefaultDWARFVersionForUnixTriple(getTriple());
+  }
+  arguments.push_back(inputArgs.MakeArgString(dwarfVersion));
+}
+
 std::string
 toolchains::GenericUnix::sanitizerRuntimeLibName(StringRef Sanitizer,
                                                  bool shared) const {

--- a/stdlib/public/RuntimeModule/Dwarf.swift
+++ b/stdlib/public/RuntimeModule/Dwarf.swift
@@ -298,6 +298,9 @@ private enum DwarfError: Error {
   case missingStrOffsetsBase
   case missingLocListsBase
   case unspecifiedAddressSize
+  case badRangeListEntry(Dwarf_Byte)
+  case missingRngListsSection
+  case missingRngListsBase
 }
 
 // .. Dwarf utilities for ImageSource ..........................................
@@ -534,6 +537,7 @@ class DwarfReader<S: DwarfSource & AnyObject> {
   var lineStrSection: ImageSource?
   var strOffsetsSection: ImageSource?
   var rangesSection: ImageSource?
+  var rngListsSection: ImageSource?
   var shouldSwap: Bool
 
   typealias DwarfAbbrev = UInt64
@@ -553,6 +557,7 @@ class DwarfReader<S: DwarfSource & AnyObject> {
     var addrBase: UInt64?
     var strOffsetsBase: UInt64?
     var loclistsBase: UInt64?
+    var rnglistsBase: UInt64?
 
     var abbrevs: [DwarfAbbrev: AbbrevInfo]
 
@@ -595,6 +600,7 @@ class DwarfReader<S: DwarfSource & AnyObject> {
     lineStrSection = source.getDwarfSection(.debugLineStr)
     strOffsetsSection = source.getDwarfSection(.debugStrOffsets)
     rangesSection = source.getDwarfSection(.debugRanges)
+    rngListsSection = source.getDwarfSection(.debugRngLists)
 
     self.source = source
     self.shouldSwap = shouldSwap
@@ -766,6 +772,10 @@ class DwarfReader<S: DwarfSource & AnyObject> {
       if let value = firstPass[.DW_AT_loclists_base],
          case let .sectionOffset(offset) = value {
         unit.loclistsBase = offset
+      }
+      if let value = firstPass[.DW_AT_rnglists_base],
+         case let .sectionOffset(offset) = value {
+        unit.rnglistsBase = offset
       }
       if let value = firstPass[.DW_AT_stmt_list],
          case let .sectionOffset(offset) = value {
@@ -1515,6 +1525,189 @@ class DwarfReader<S: DwarfSource & AnyObject> {
     return attributes
   }
 
+  private func readAddress(
+    at cursor: inout ImageSourceCursor,
+    addressSize: Int
+  ) throws -> Address {
+    switch addressSize {
+      case 4:
+        return Address(maybeSwap(try cursor.read(as: UInt32.self)))
+      case 8:
+        return maybeSwap(try cursor.read(as: UInt64.self))
+      default:
+        throw DwarfError.badAddressSize(addressSize)
+    }
+  }
+
+  private func fetchIndexedAddress(
+    _ index: UInt64,
+    unit: Unit
+  ) throws -> Address {
+    guard let addrSection = addrSection else {
+      throw DwarfError.missingAddrSection
+    }
+    guard let addrBase = unit.addrBase else {
+      throw DwarfError.missingAddrBase
+    }
+
+    switch unit.addressSize {
+      case 4:
+        return Address(maybeSwap(
+          try addrSection.fetch(from: index * 4 + addrBase, as: UInt32.self)))
+      case 8:
+        return maybeSwap(
+          try addrSection.fetch(from: index * 8 + addrBase, as: UInt64.self))
+      default:
+        throw DwarfError.badAddressSize(unit.addressSize)
+    }
+  }
+
+  /// Call `fn` with the (lowPC, highPC) of every range described by a
+  /// `DW_AT_ranges` value, resolving `.debug_rnglists` (DWARF 5+) or
+  /// `.debug_ranges` (DWARF ≤4) as appropriate for `unit`.
+  private func forEachRange(
+    of rangeVal: DwarfValue,
+    unit: Unit,
+    _ fn: (Address, Address) -> ()
+  ) throws {
+    if unit.version >= 5 {
+      guard let rngListsSection = rngListsSection else {
+        throw DwarfError.missingRngListsSection
+      }
+
+      let offset: Address
+      switch rangeVal {
+        case let .sectionOffset(off):
+          offset = off
+        case let .rangeList(index):
+          guard let rnglistsBase = unit.rnglistsBase else {
+            throw DwarfError.missingRngListsBase
+          }
+
+          let entryAddr: Address
+          let rawOffset: UInt64
+          if unit.isDwarf64 {
+            entryAddr = rnglistsBase + index * 8
+            rawOffset = maybeSwap(
+              try rngListsSection.fetch(from: entryAddr, as: UInt64.self))
+          } else {
+            entryAddr = rnglistsBase + index * 4
+            rawOffset = UInt64(maybeSwap(
+              try rngListsSection.fetch(from: entryAddr, as: UInt32.self)))
+          }
+
+          // Entries in the offsets table are relative to the base itself.
+          offset = rnglistsBase + rawOffset
+        default:
+          return
+      }
+
+      var cursor = ImageSourceCursor(source: rngListsSection, offset: offset)
+      var base: Address? = unit.lowPC
+
+      entries: while true {
+        let rawKind = try cursor.read(as: Dwarf_Byte.self)
+        guard let kind = Dwarf_RLE_Entry(rawValue: rawKind) else {
+          throw DwarfError.badRangeListEntry(rawKind)
+        }
+
+        switch kind {
+          case .DW_RLE_end_of_list:
+            break entries
+
+          case .DW_RLE_base_addressx:
+            let ndx = try cursor.readULEB128()
+            base = try fetchIndexedAddress(ndx, unit: unit)
+
+          case .DW_RLE_base_address:
+            base = try readAddress(at: &cursor, addressSize: unit.addressSize)
+
+          case .DW_RLE_startx_endx:
+            let startNdx = try cursor.readULEB128()
+            let endNdx = try cursor.readULEB128()
+            let start = try fetchIndexedAddress(startNdx, unit: unit)
+            let end = try fetchIndexedAddress(endNdx, unit: unit)
+            fn(start, end)
+
+          case .DW_RLE_startx_length:
+            let startNdx = try cursor.readULEB128()
+            let length = try cursor.readULEB128()
+            let start = try fetchIndexedAddress(startNdx, unit: unit)
+            fn(start, start + length)
+
+          case .DW_RLE_offset_pair:
+            let off0 = try cursor.readULEB128()
+            let off1 = try cursor.readULEB128()
+            let theBase = base ?? 0
+            fn(theBase + off0, theBase + off1)
+
+          case .DW_RLE_start_end:
+            let start = try readAddress(at: &cursor, addressSize: unit.addressSize)
+            let end = try readAddress(at: &cursor, addressSize: unit.addressSize)
+            fn(start, end)
+
+          case .DW_RLE_start_length:
+            let start = try readAddress(at: &cursor, addressSize: unit.addressSize)
+            let length = try cursor.readULEB128()
+            fn(start, start + length)
+
+          default:
+            throw DwarfError.badRangeListEntry(rawKind)
+        }
+      }
+    } else {
+      guard let rangesSection = rangesSection else {
+        return
+      }
+
+      let offset: UInt64
+      switch rangeVal {
+        case let .sectionOffset(off):
+          offset = off
+        case let .unsignedInt32(off):
+          offset = UInt64(off)
+        case let .unsignedInt64(off):
+          offset = off
+        default:
+          return
+      }
+
+      var rangeCursor = ImageSourceCursor(source: rangesSection,
+                                          offset: offset)
+      var rangeBase: Address = unit.lowPC ?? 0
+
+      while true {
+        let beginning: Address
+        let ending: Address
+
+        switch unit.addressSize {
+          case 4:
+            beginning = UInt64(maybeSwap(try rangeCursor.read(as: UInt32.self)))
+            ending = UInt64(maybeSwap(try rangeCursor.read(as: UInt32.self)))
+            if beginning == 0xffffffff {
+              rangeBase = ending
+              continue
+            }
+          case 8:
+            beginning = maybeSwap(try rangeCursor.read(as: UInt64.self))
+            ending = maybeSwap(try rangeCursor.read(as: UInt64.self))
+            if beginning == 0xffffffffffffffff {
+              rangeBase = ending
+              continue
+            }
+          default:
+            throw DwarfError.badAddressSize(unit.addressSize)
+        }
+
+        if beginning == 0 && ending == 0 {
+          break
+        }
+
+        fn(beginning + rangeBase, ending + rangeBase)
+      }
+    }
+  }
+
   struct CallSiteInfo {
     var depth: Int
     var rawName: String?
@@ -1634,49 +1827,14 @@ class DwarfReader<S: DwarfSource & AnyObject> {
            filename: filename,
            line: Int(callLine),
            column: Int(callColumn)))
-    } else if let rangeVal = attributes[.DW_AT_ranges],
-              let rangesSection = rangesSection,
-              case let .sectionOffset(offset) = rangeVal,
-              unit.version < 5 {
-      // We don't support .debug_rnglists at present (which is what we'd
-      // have if unit.version is 5 or higher).
-      var rangeCursor = ImageSourceCursor(source: rangesSection,
-                                          offset: offset)
-      var rangeBase: Address = unit.lowPC ?? 0
-
-      while true {
-        let beginning: Address
-        let ending: Address
-
-        switch unit.addressSize {
-          case 4:
-            beginning = UInt64(maybeSwap(try rangeCursor.read(as: UInt32.self)))
-            ending = UInt64(maybeSwap(try rangeCursor.read(as: UInt32.self)))
-            if beginning == 0xffffffff {
-              rangeBase = ending
-              continue
-            }
-          case 8:
-            beginning = maybeSwap(try rangeCursor.read(as: UInt64.self))
-            ending = maybeSwap(try rangeCursor.read(as: UInt64.self))
-            if beginning == 0xffffffffffffffff {
-              rangeBase = ending
-              continue
-            }
-          default:
-            throw DwarfError.badAddressSize(unit.addressSize)
-        }
-
-        if beginning == 0 && ending == 0 {
-          break
-        }
-
+    } else if let rangeVal = attributes[.DW_AT_ranges] {
+      try forEachRange(of: rangeVal, unit: unit) { lowPC, highPC in
         fn(CallSiteInfo(
              depth: depth,
              rawName: rawName,
              name: name,
-             lowPC: beginning + rangeBase,
-             highPC: ending + rangeBase,
+             lowPC: lowPC,
+             highPC: highPC,
              filename: filename,
              line: Int(callLine),
              column: Int(callColumn)))
@@ -1759,6 +1917,15 @@ class DwarfReader<S: DwarfSource & AnyObject> {
            name: name,
            lowPC: lowPC,
            highPC: highPC))
+    } else if let rangeVal = attributes[.DW_AT_ranges] {
+      try forEachRange(of: rangeVal, unit: unit) { lowPC, highPC in
+        fn(FunctionInfo(
+             depth: depth,
+             rawName: rawName,
+             name: name,
+             lowPC: lowPC,
+             highPC: highPC))
+      }
     }
   }
 
@@ -2229,6 +2396,9 @@ public func testDwarfReaderFor(path: String) -> Bool {
     print("Units:")
     print(reader.units)
 
+    print("Functions:")
+    print(reader.functions)
+
     print("Call Sites:")
     print(reader.inlineCallSites)
     return true
@@ -2252,6 +2422,9 @@ public func testDwarfReaderFor(path: String) -> Bool {
         print("  <unnamed>")
       }
     }
+
+    print("Functions:")
+    print(reader.functions)
 
     print("Call Sites:")
     print(reader.inlineCallSites)

--- a/test/Backtracing/DwarfReader.swift
+++ b/test/Backtracing/DwarfReader.swift
@@ -29,6 +29,7 @@ struct DwarfReader {
 
     // CHECK: {{.*}}/Inlining is a {{32|64}}-bit ELF image
     // CHECK: Units:
+    // CHECK: Functions:
     // CHECK: Call Sites:
 
     if !testDwarfReaderFor(path: CommandLine.arguments[1]) {

--- a/test/Backtracing/DwarfReaderRngLists.swift
+++ b/test/Backtracing/DwarfReaderRngLists.swift
@@ -1,0 +1,77 @@
+// RUN: %empty-directory(%t)
+// RUN: %yaml2obj %S/Inputs/DwarfRngLists.yaml -o %t/rnglists.o
+// RUN: %target-build-swift %s -parse-as-library -g -o %t/DwarfReaderRngLists
+// RUN: %target-run %t/DwarfReaderRngLists %t/rnglists.o | %FileCheck %s
+
+// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: backtracing
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// Regression test for DwarfReader's DWARF v5 .debug_rnglists support
+// (DW_FORM_rnglistx / DW_AT_ranges). Inputs/DwarfRngLists.yaml is a
+// hand-crafted object exercising every DW_RLE_* range list encoding,
+// including discontiguous ranges on both a DW_TAG_subprogram and several
+// DW_TAG_inlined_subroutine DIEs.
+
+@_spi(DwarfTest) import Runtime
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(SwiftWASILibc)
+import SwiftWASILibc
+#elseif canImport(ucrt)
+import ucrt
+#elseif canImport(SwiftGlibc)
+import SwiftGlibc
+#endif
+
+@main
+struct DwarfReaderRngLists {
+  static func main() {
+    if CommandLine.argc != 2 {
+      print("usage: DwarfReaderRngLists <path-to-binary>")
+      return
+    }
+
+    // CHECK: is a 64-bit ELF image
+    // CHECK: Units:
+
+    // rangelist 0 (DW_RLE_base_address + two DW_RLE_offset_pair), attached
+    // directly to the enclosing DW_TAG_subprogram's DW_AT_ranges.
+    // CHECK: Functions:
+    // CHECK: lowPC: 4112, highPC: 4128
+    // CHECK-SAME: lowPC: 4144, highPC: 4160
+
+    // CHECK: Call Sites:
+
+    // rangelist 3 (DW_RLE_startx_length, .debug_addr[0] = 0x2000)
+    // CHECK: lowPC: 8192, highPC: 8200
+    // CHECK-SAME: line: 30
+
+    // rangelist 1 (DW_RLE_base_addressx + two discontiguous
+    // DW_RLE_offset_pair -- the original bug scenario)
+    // CHECK-SAME: lowPC: 8196, highPC: 8200
+    // CHECK-SAME: line: 10
+    // CHECK-SAME: lowPC: 8208, highPC: 8216
+    // CHECK-SAME: line: 10
+
+    // rangelist 2 (DW_RLE_startx_endx, .debug_addr[1..2])
+    // CHECK-SAME: lowPC: 12288, highPC: 12304
+    // CHECK-SAME: line: 20
+
+    // rangelist 4 (DW_RLE_base_address + DW_RLE_offset_pair)
+    // CHECK-SAME: lowPC: 36865, highPC: 36866
+    // CHECK-SAME: line: 40
+
+    // rangelist 5 (DW_RLE_start_end + discontiguous DW_RLE_start_length)
+    // CHECK-SAME: lowPC: 40960, highPC: 40976
+    // CHECK-SAME: line: 50
+    // CHECK-SAME: lowPC: 45056, highPC: 45072
+    // CHECK-SAME: line: 50
+
+    if !testDwarfReaderFor(path: CommandLine.arguments[1]) {
+      exit(1)
+    }
+  }
+}

--- a/test/Backtracing/Inputs/DwarfRngLists.yaml
+++ b/test/Backtracing/Inputs/DwarfRngLists.yaml
@@ -1,0 +1,176 @@
+## A hand-crafted ELF object holding a single DWARF v5 compile unit that
+## exercises every DW_RLE_* range list encoding in .debug_rnglists, via
+## DW_FORM_rnglistx. This is what a real DWARF 5 compiler emits for
+## discontiguous PC ranges (e.g. an inlined subroutine split across two
+## blocks by the optimizer) -- see DwarfReaderRngLists.swift.
+##
+## Layout:
+##   DIE @ 0x1d: DW_TAG_subprogram, linkage_name "callee"
+##               (the abstract-origin target for every inlined_subroutine
+##               DIE below)
+##   DIE @ 0x25: DW_TAG_subprogram, DW_AT_ranges -> rangelist 0
+##               (no low_pc/high_pc: exercises buildFunctionInfo's
+##               DW_AT_ranges fallback)
+##     DIE: DW_TAG_inlined_subroutine, call_line 10, ranges -> rangelist 1
+##          (DW_RLE_base_addressx + two DW_RLE_offset_pair: discontiguous,
+##          indexed base address -- the original bug scenario)
+##     DIE: DW_TAG_inlined_subroutine, call_line 20, ranges -> rangelist 2
+##          (DW_RLE_startx_endx)
+##     DIE: DW_TAG_inlined_subroutine, call_line 30, ranges -> rangelist 3
+##          (DW_RLE_startx_length)
+##     DIE: DW_TAG_inlined_subroutine, call_line 40, ranges -> rangelist 4
+##          (DW_RLE_base_address + DW_RLE_offset_pair)
+##     DIE: DW_TAG_inlined_subroutine, call_line 50, ranges -> rangelist 5
+##          (DW_RLE_start_end + DW_RLE_start_length: discontiguous)
+##
+## Expected resolved ranges (verified against this exact file with
+## llvm-dwarfdump and a standalone DwarfReader probe):
+##   rangelist 0: [0x1010, 0x1020) [0x1030, 0x1040)
+##   rangelist 1: [0x2004, 0x2008) [0x2010, 0x2018)   (.debug_addr[0] = 0x2000)
+##   rangelist 2: [0x3000, 0x3010)                    (.debug_addr[1..2])
+##   rangelist 3: [0x2000, 0x2008)                    (.debug_addr[0] = 0x2000)
+##   rangelist 4: [0x9001, 0x9002)
+##   rangelist 5: [0xa000, 0xa010) [0xb000, 0xb010)
+
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_EXEC
+  Machine: EM_X86_64
+DWARF:
+  debug_abbrev:
+    - Table:
+        - Code:     0x01
+          Tag:      DW_TAG_compile_unit
+          Children: DW_CHILDREN_yes
+          Attributes:
+            - Attribute: DW_AT_low_pc
+              Form:      DW_FORM_addr
+            - Attribute: DW_AT_addr_base
+              Form:      DW_FORM_sec_offset
+            - Attribute: DW_AT_rnglists_base
+              Form:      DW_FORM_sec_offset
+        - Code:     0x02
+          Tag:      DW_TAG_subprogram
+          Children: DW_CHILDREN_no
+          Attributes:
+            - Attribute: DW_AT_linkage_name
+              Form:      DW_FORM_string
+        - Code:     0x03
+          Tag:      DW_TAG_subprogram
+          Children: DW_CHILDREN_yes
+          Attributes:
+            - Attribute: DW_AT_ranges
+              Form:      DW_FORM_rnglistx
+        - Code:     0x04
+          Tag:      DW_TAG_inlined_subroutine
+          Children: DW_CHILDREN_no
+          Attributes:
+            - Attribute: DW_AT_abstract_origin
+              Form:      DW_FORM_ref4
+            - Attribute: DW_AT_ranges
+              Form:      DW_FORM_rnglistx
+            - Attribute: DW_AT_call_file
+              Form:      DW_FORM_data1
+            - Attribute: DW_AT_call_line
+              Form:      DW_FORM_data1
+            - Attribute: DW_AT_call_column
+              Form:      DW_FORM_data1
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      AddrSize: 8
+      Entries:
+        - AbbrCode: 0x01
+          Values:
+            - Value: 0x0000          # DW_AT_low_pc
+            - Value: 0x08            # DW_AT_addr_base
+            - Value: 0x0c            # DW_AT_rnglists_base
+        - AbbrCode: 0x02
+          Values:
+            - CStr: "callee"          # DW_AT_linkage_name
+        - AbbrCode: 0x03
+          Values:
+            - Value: 0x00            # DW_AT_ranges (rangelist 0)
+        - AbbrCode: 0x04
+          Values:
+            - Value: 0x1d            # DW_AT_abstract_origin -> "callee" DIE
+            - Value: 0x01            # DW_AT_ranges (rangelist 1)
+            - Value: 0x01            # DW_AT_call_file
+            - Value: 0x0A            # DW_AT_call_line = 10
+            - Value: 0x01            # DW_AT_call_column
+        - AbbrCode: 0x04
+          Values:
+            - Value: 0x1d
+            - Value: 0x02            # rangelist 2
+            - Value: 0x01
+            - Value: 0x14            # 20
+            - Value: 0x01
+        - AbbrCode: 0x04
+          Values:
+            - Value: 0x1d
+            - Value: 0x03            # rangelist 3
+            - Value: 0x01
+            - Value: 0x1E            # 30
+            - Value: 0x01
+        - AbbrCode: 0x04
+          Values:
+            - Value: 0x1d
+            - Value: 0x04            # rangelist 4
+            - Value: 0x01
+            - Value: 0x28            # 40
+            - Value: 0x01
+        - AbbrCode: 0x04
+          Values:
+            - Value: 0x1d
+            - Value: 0x05            # rangelist 5
+            - Value: 0x01
+            - Value: 0x32            # 50
+            - Value: 0x01
+        - AbbrCode: 0x00              # end of subprogram's children
+        - AbbrCode: 0x00              # end of compile unit's children
+  debug_addr:
+    - Version: 5
+      Entries:
+        - Address: 0x2000
+        - Address: 0x3000
+        - Address: 0x3010
+  debug_rnglists:
+    - Lists:
+        - Entries:                    # rangelist 0
+            - Operator: DW_RLE_base_address
+              Values:   [ 0x1000 ]
+            - Operator: DW_RLE_offset_pair
+              Values:   [ 0x10, 0x20 ]
+            - Operator: DW_RLE_offset_pair
+              Values:   [ 0x30, 0x40 ]
+            - Operator: DW_RLE_end_of_list
+        - Entries:                    # rangelist 1
+            - Operator: DW_RLE_base_addressx
+              Values:   [ 0x00 ]
+            - Operator: DW_RLE_offset_pair
+              Values:   [ 0x04, 0x08 ]
+            - Operator: DW_RLE_offset_pair
+              Values:   [ 0x10, 0x18 ]
+            - Operator: DW_RLE_end_of_list
+        - Entries:                    # rangelist 2
+            - Operator: DW_RLE_startx_endx
+              Values:   [ 0x01, 0x02 ]
+            - Operator: DW_RLE_end_of_list
+        - Entries:                    # rangelist 3
+            - Operator: DW_RLE_startx_length
+              Values:   [ 0x00, 0x08 ]
+            - Operator: DW_RLE_end_of_list
+        - Entries:                    # rangelist 4
+            - Operator: DW_RLE_base_address
+              Values:   [ 0x9000 ]
+            - Operator: DW_RLE_offset_pair
+              Values:   [ 0x01, 0x02 ]
+            - Operator: DW_RLE_end_of_list
+        - Entries:                    # rangelist 5
+            - Operator: DW_RLE_start_end
+              Values:   [ 0xA000, 0xA010 ]
+            - Operator: DW_RLE_start_length
+              Values:   [ 0xB000, 0x10 ]
+            - Operator: DW_RLE_end_of_list

--- a/test/Driver/options.swift
+++ b/test/Driver/options.swift
@@ -147,6 +147,19 @@
 // RUN: %swift_driver -### -g -target arm64_32-apple-watchos11 %s 2>&1 | %FileCheck -check-prefix DWARF_VERSION_5 %s
 // RUN: %swiftc_driver -### -g -target arm64_32-apple-watchos11 %s 2>&1 | %FileCheck -check-prefix DWARF_VERSION_5 %s
 
+// All ELF targets default to DWARF 5, except Android.
+// which stays on DWARF 4 for compatibility with the NDK's debugging tools.
+// RUN: %swift_driver -### -g -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck -check-prefix DWARF_VERSION_5 %s
+// RUN: %swiftc_driver -### -g -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck -check-prefix DWARF_VERSION_5 %s
+// RUN: %swift_driver -### -g -target aarch64-unknown-linux-android %s 2>&1 | %FileCheck -check-prefix DWARF_VERSION_4 %s
+// RUN: %swiftc_driver -### -g -target aarch64-unknown-linux-android %s 2>&1 | %FileCheck -check-prefix DWARF_VERSION_4 %s
+// RUN: %swift_driver -### -g -target x86_64-unknown-freebsd %s 2>&1 | %FileCheck -check-prefix DWARF_VERSION_5 %s
+// RUN: %swiftc_driver -### -g -target x86_64-unknown-freebsd %s 2>&1 | %FileCheck -check-prefix DWARF_VERSION_5 %s
+// RUN: %swift_driver -### -g -target x86_64-unknown-openbsd %s 2>&1 | %FileCheck -check-prefix DWARF_VERSION_5 %s
+// RUN: %swiftc_driver -### -g -target x86_64-unknown-openbsd %s 2>&1 | %FileCheck -check-prefix DWARF_VERSION_5 %s
+// RUN: %swift_driver -### -g -dwarf-version=3 -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck -check-prefix DWARF_VERSION_3 %s
+// RUN: %swiftc_driver -### -g -dwarf-version=3 -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck -check-prefix DWARF_VERSION_3 %s
+
 // RUN: not %swift_driver -gline-tables-only -debug-info-format=codeview %s 2>&1 | %FileCheck -check-prefix BAD_DEBUG_LEVEL_ERROR %s
 // RUN: not %swift_driver -gdwarf-types -debug-info-format=codeview %s 2>&1 | %FileCheck -check-prefix BAD_DEBUG_LEVEL_ERROR %s
 // RUN: not %swiftc_driver -gline-tables-only -debug-info-format=codeview %s 2>&1 | %FileCheck -check-prefix BAD_DEBUG_LEVEL_ERROR %s


### PR DESCRIPTION
Except on Android, which according to a comment in the Clang driver is stuck on DWARF 4.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
