### PR TITLE
Sema: Diagnose useless availability queries in MiscDiagnostics

### DIFF
--- a/include/swift/AST/AvailabilityScope.h
+++ b/include/swift/AST/AvailabilityScope.h
@@ -207,6 +207,10 @@ private:
 
   void verify(const AvailabilityScope *parent, ASTContext &ctx) const;
 
+  AvailabilityScope *findMostRefinedSubContextImpl(
+      SourceLoc Loc, ASTContext &Ctx,
+      llvm::SmallVectorImpl<AvailabilityScope *> *ScopeStack);
+
   AvailabilityScope(ASTContext &Ctx, IntroNode Node, AvailabilityScope *Parent,
                     SourceRange SrcRange, const AvailabilityContext Info);
 
@@ -338,6 +342,14 @@ public:
   /// Returns the innermost AvailabilityScope descendant of this scope
   /// for the given source location.
   AvailabilityScope *findMostRefinedSubContext(SourceLoc Loc, ASTContext &Ctx);
+
+  /// Like `findMostRefinedSubContext()`, but also populates \p ScopeStack with
+  /// the chain of scopes that contain \p Loc, ordered outermost first and
+  /// ending with the returned scope. This allows callers to inspect the
+  /// enclosing scopes of the result.
+  AvailabilityScope *findMostRefinedSubContext(
+      SourceLoc Loc, ASTContext &Ctx,
+      llvm::SmallVectorImpl<AvailabilityScope *> &ScopeStack);
 
   bool getNeedsExpansion() const { return LazyInfo.needsExpansion; }
 

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -36,6 +36,7 @@ namespace swift {
 class AnyPattern;
 class ASTContext;
 class ASTWalker;
+class AvailabilityScope;
 class AvailabilitySpec;
 class Decl;
 class DeclContext;
@@ -516,6 +517,10 @@ class alignas(8) PoundAvailableInfo final :
   /// The type-checked availability query information.
   std::optional<const AvailabilityQuery> Query;
 
+  /// The availability scope that the query introduces for the code that it
+  /// guards, or `nullptr` if it does not refine availability.
+  AvailabilityScope *IntroducedScope = nullptr;
+
   struct {
     unsigned isInvalid : 1;
 
@@ -567,6 +572,18 @@ public:
   }
   void setAvailabilityQuery(const AvailabilityQuery &query) {
     Query.emplace(query);
+  }
+
+  /// Returns the availability scope that this query introduces for the code
+  /// that it guards. Returns `nullptr` if the query does not refine
+  /// availability, which is the case when the availability that it checks for is
+  /// already guaranteed at the position that the query appears in, and for
+  /// statements that haven't been type-checked.
+  AvailabilityScope *getIntroducedAvailabilityScope() const {
+    return IntroducedScope;
+  }
+  void setIntroducedAvailabilityScope(AvailabilityScope *scope) {
+    IntroducedScope = scope;
   }
 
   bool isUnavailability() const { return Flags.isUnavailability; }

--- a/lib/AST/AvailabilityScope.cpp
+++ b/lib/AST/AvailabilityScope.cpp
@@ -269,8 +269,9 @@ void AvailabilityScope::addChild(AvailabilityScope *Child, ASTContext &Ctx) {
   Children.insert(iter, Child);
 }
 
-AvailabilityScope *
-AvailabilityScope::findMostRefinedSubContext(SourceLoc Loc, ASTContext &Ctx) {
+AvailabilityScope *AvailabilityScope::findMostRefinedSubContextImpl(
+    SourceLoc Loc, ASTContext &Ctx,
+    llvm::SmallVectorImpl<AvailabilityScope *> *ScopeStack) {
   DEBUG_ASSERT(Loc.isValid());
 
   if (SrcRange.isValid() && !Ctx.SourceMgr.containsTokenLoc(SrcRange, Loc))
@@ -279,6 +280,9 @@ AvailabilityScope::findMostRefinedSubContext(SourceLoc Loc, ASTContext &Ctx) {
   (void)evaluateOrDefault(Ctx.evaluator,
                           ExpandChildAvailabilityScopesRequest{this}, {});
   DEBUG_ASSERT(!getNeedsExpansion());
+
+  if (ScopeStack)
+    ScopeStack->push_back(this);
 
   // Do a binary search to find the first child with a source range that
   // ends after the given location.
@@ -291,13 +295,25 @@ AvailabilityScope::findMostRefinedSubContext(SourceLoc Loc, ASTContext &Ctx) {
   // Check whether the matching child or any of its descendants contain
   // the given location.
   if (iter != Children.end()) {
-    if (auto found = (*iter)->findMostRefinedSubContext(Loc, Ctx))
+    if (auto found =
+            (*iter)->findMostRefinedSubContextImpl(Loc, Ctx, ScopeStack))
       return found;
   }
 
   // The location is in this context's range but not in any child's, so this
   // context must be the innermost context.
   return this;
+}
+
+AvailabilityScope *
+AvailabilityScope::findMostRefinedSubContext(SourceLoc Loc, ASTContext &Ctx) {
+  return findMostRefinedSubContextImpl(Loc, Ctx, /*ScopeStack=*/nullptr);
+}
+
+AvailabilityScope *AvailabilityScope::findMostRefinedSubContext(
+    SourceLoc Loc, ASTContext &Ctx,
+    llvm::SmallVectorImpl<AvailabilityScope *> &ScopeStack) {
+  return findMostRefinedSubContextImpl(Loc, Ctx, &ScopeStack);
 }
 
 void AvailabilityScope::dump(SourceManager &SrcMgr) const {

--- a/lib/AST/AvailabilityScopeBuilder.cpp
+++ b/lib/AST/AvailabilityScopeBuilder.cpp
@@ -1216,44 +1216,10 @@ private:
         newContext.constrainWithAvailabilityRange(*trueRange, domain, Context);
 
       // Check whether the new context refines availability. If it doesn't, the
-      // query is useless and should potentially be diagnosed.
-      if (currentContext.isContainedIn(newContext)) {
-        // If the explicitly-specified (via #availability) version range for the
-        // current scope is completely contained in the range for the spec, then
-        // a version query can never be false, so the spec is useless.
-        // If so, report this.
-        auto explicitRange =
-            currentScope->getExplicitAvailabilityRange(domain, Context);
-        if (explicitRange && trueRange &&
-            explicitRange->isContainedIn(*trueRange)) {
-          // Platform unavailability queries never refine availability so don't
-          // diangose them.
-          if (isUnavailability.value())
-            continue;
-
-          // Skip diagnosing useless availability in fragile functions with
-          // opaque result types since removing an availability check could
-          // change the ABI of the function and result in a miscompilation.
-          auto *dc = getCurrentDeclContext();
-          if (dc->getResilienceExpansion() == ResilienceExpansion::Minimal) {
-            if (auto decl = dc->getInnermostDeclarationDeclContext()) {
-              if (auto afd = dyn_cast<AbstractFunctionDecl>(decl)) {
-                if (afd->getOpaqueResultTypeDecl())
-                  continue;
-              }
-            }
-          }
-
-          DiagnosticEngine &diags = Context.Diags;
-          diags.diagnose(query->getLoc(),
-                         diag::availability_query_useless_enclosing_scope,
-                         domain.getNameForAttributePrinting());
-          diags.diagnose(currentScope->getIntroductionLoc(),
-                         diag::availability_query_useless_enclosing_scope_here);
-        }
-
+      // query is useless. Diagnosing that is the responsibility of
+      // diagnoseAvailabilityCondition() in MiscDiagnostics.
+      if (currentContext.isContainedIn(newContext))
         continue;
-      }
 
       // If the #available() is not useless then there is a potential false
       // flow and we need to potentially expand the range covered by the false
@@ -1264,6 +1230,7 @@ private:
       auto *scope = AvailabilityScope::createForConditionFollowingQuery(
           Context, query, lastElement, getCurrentDeclContext(), currentScope,
           newContext);
+      query->setIntroducedAvailabilityScope(scope);
 
       pushContext(scope, ParentTy());
       ++nestedCount;

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -23,6 +23,7 @@
 #include "swift/AST/ASTBridging.h"
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/ASTWalker.h"
+#include "swift/AST/AvailabilityScope.h"
 #include "swift/AST/AvailabilitySpec.h"
 #include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/ConformanceLookup.h"
@@ -5369,6 +5370,113 @@ checkImplicitPromotionsInCondition(const StmtConditionElement &cond,
   }
 }
 
+/// Returns true if a useless availability query should be diagnosed in the given
+/// source file.
+static bool shouldDiagnoseUselessAvailabilityConditions(const SourceFile &sf) {
+  switch (sf.Kind) {
+  case SourceFileKind::MacroExpansion:
+  case SourceFileKind::SyntheticMacro:
+  case SourceFileKind::Interface:
+  case SourceFileKind::DefaultArgument:
+  case SourceFileKind::SIL:
+    return false;
+  case SourceFileKind::Library:
+  case SourceFileKind::Main:
+    return true;
+  }
+
+  llvm_unreachable("bad SourceFileKind");
+}
+
+/// Diagnoses an availability query that can never be false because an enclosing
+/// scope already guarantees the availability that it checks for.
+static void diagnoseUselessAvailabilityCondition(PoundAvailableInfo *info,
+                                                 DeclContext *DC) {
+  auto loc = info->getStartLoc();
+  auto *sf = DC->getParentModule()->getSourceFileContainingLocation(loc);
+  if (!sf)
+    return;
+
+  if (!shouldDiagnoseUselessAvailabilityConditions(*sf))
+    return;
+
+  // Unavailability queries never refine availability, so they are never
+  // diagnosed as useless.
+  if (info->isUnavailability())
+    return;
+
+  // Removing an availability check from a fragile function with an opaque
+  // result type could change the function's ABI and result in a miscompilation,
+  // so don't suggest it.
+  if (DC->getResilienceExpansion() == ResilienceExpansion::Minimal) {
+    if (auto *decl = DC->getInnermostDeclarationDeclContext()) {
+      if (auto *afd = dyn_cast<AbstractFunctionDecl>(decl)) {
+        if (afd->getOpaqueResultTypeDecl())
+          return;
+      }
+    }
+  }
+
+  auto query = info->getAvailabilityQuery();
+  if (!query)
+    return;
+
+  if (info->getIntroducedAvailabilityScope())
+    return;
+
+  auto &ctx = DC->getASTContext();
+
+  // Only the spec that the query resolved to is relevant; the others apply
+  // when compiling for other targets. A query that resolved to a wildcard is
+  // never diagnosed for the same reason: the specs that were written may be
+  // useful for another target.
+  auto semanticSpecs = info->getSemanticAvailabilitySpecs(DC);
+  auto foundSpec =
+      llvm::find_if(semanticSpecs, [query](SemanticAvailabilitySpec spec) {
+        if (spec.isWildcard())
+          return false;
+        return spec.getDomain() == query->getDomain();
+      });
+
+  if (foundSpec == semanticSpecs.end())
+    return;
+
+  SemanticAvailabilitySpec spec = *foundSpec;
+  auto domain = spec.getDomain();
+  auto specRange = domain.isVersioned() ? AvailabilityRange(spec.getVersion())
+                                        : AvailabilityRange::alwaysAvailable();
+
+  // Find the innermost enclosing scope that specifies an availability range
+  // for the domain in source so that it can be pointed at in a note. Scopes
+  // that don't specify one are skipped; a query nested in the body of a switch
+  // case, for example, is contained by the placeholder scope for the switch.
+  auto *rootScope = AvailabilityScope::getOrBuildForSourceFile(*sf);
+  if (!rootScope)
+    return;
+
+  llvm::SmallVector<AvailabilityScope *, 8> scopeStack;
+  rootScope->findMostRefinedSubContext(loc, ctx, scopeStack);
+
+  for (auto scope : llvm::reverse(scopeStack)) {
+    auto explicitRange = scope->getExplicitAvailabilityRange(domain, ctx);
+    if (!explicitRange)
+      continue;
+
+    // Only diagnose if the range that was written in source is what makes the
+    // query always true. The query may instead be useless because of the
+    // deployment target, in which case there is nothing to point at.
+    if (explicitRange->isContainedIn(specRange)) {
+      ctx.Diags.diagnose(info->getLoc(),
+                         diag::availability_query_useless_enclosing_scope,
+                         domain.getNameForAttributePrinting());
+      ctx.Diags.diagnose(scope->getIntroductionLoc(),
+                         diag::availability_query_useless_enclosing_scope_here);
+    }
+
+    break;
+  }
+}
+
 /// Diagnoses a `if #available(...)` condition. Returns true if a diagnostic
 /// was emitted.
 static bool diagnoseAvailabilityCondition(PoundAvailableInfo *info,
@@ -5484,6 +5592,8 @@ static bool diagnoseAvailabilityCondition(PoundAvailableInfo *info,
       }
     }
   }
+
+  diagnoseUselessAvailabilityCondition(info, DC);
 
   return false;
 }

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -847,14 +847,39 @@ static bool fixAvailabilityByNarrowingNearbyVersionCheck(
   if (!Domain.isPlatform())
     return false;
 
+  // Find the innermost enclosing scope that specifies an availability range for
+  // the domain in source. Scopes that don't specify one (such as the
+  // placeholder scopes of declarations in local contexts) are skipped.
+  auto loc = ReferenceRange.Start;
+  if (loc.isInvalid())
+    return false;
+
+  auto *sf =
+      ReferenceDC->getParentModule()->getSourceFileContainingLocation(loc);
+  if (!sf)
+    return false;
+
+  auto *rootScope = AvailabilityScope::getOrBuildForSourceFile(*sf);
+  if (!rootScope)
+    return false;
+
+  llvm::SmallVector<AvailabilityScope *, 8> scopeStack;
+  if (!rootScope->findMostRefinedSubContext(loc, Context, scopeStack))
+    return false;
+
   const AvailabilityScope *scope = nullptr;
-  (void)AvailabilityContext::forLocation(ReferenceRange.Start, ReferenceDC,
-                                         &scope);
+  std::optional<AvailabilityRange> ExplicitAvailability;
+  for (auto candidate : llvm::reverse(scopeStack)) {
+    if (auto range = candidate->getExplicitAvailabilityRange(Domain, Context)) {
+      ExplicitAvailability.emplace(*range);
+      scope = candidate;
+      break;
+    }
+  }
+
   if (!scope)
     return false;
 
-  auto ExplicitAvailability =
-      scope->getExplicitAvailabilityRange(Domain, Context);
   if (ExplicitAvailability && !RequiredAvailability.isAlwaysAvailable() &&
       scope->getReason() != AvailabilityScope::Reason::Root &&
       RequiredAvailability.isContainedIn(*ExplicitAvailability)) {

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -222,6 +222,7 @@ public struct Job: Sendable, ~Copyable {
     self.context = job.context
   }
 
+  @diagnose(UselessAvailabilityCheck, as: ignored)
   public var priority: JobPriority {
     let raw: UInt8
     if #available(StdlibDeploymentTarget 6.3, *) {
@@ -296,6 +297,7 @@ public struct ExecutorJob: Sendable, ~Copyable {
     self.context = job.context
   }
 
+  @diagnose(UselessAvailabilityCheck, as: ignored)
   internal(set) public var priority: JobPriority {
     get {
       let raw: UInt8

--- a/stdlib/public/Concurrency/TaskSleepDuration.swift
+++ b/stdlib/public/Concurrency/TaskSleepDuration.swift
@@ -77,6 +77,7 @@ fileprivate func durationComponents<C: Clock>(for duration: C.Duration, clock: C
 @_unavailableInEmbedded
 extension Task where Success == Never, Failure == Never {
   @available(StdlibDeploymentTarget 5.7, *)
+  @diagnose(UselessAvailabilityCheck, as: ignored)
   internal static func _sleep<C: Clock>(
     until instant: C.Instant,
     tolerance: C.Duration?,

--- a/test/Availability/availability_unnecessary.swift
+++ b/test/Availability/availability_unnecessary.swift
@@ -13,7 +13,7 @@ enum MacOSVersions {
 }
 
 @available(macOS 11, *)
-func annotatedFunc( // expected-note 3 {{enclosing scope here}}
+func annotatedFunc( // expected-note 5 {{enclosing scope here}}
   _ e: MacOSVersions,
 ) {
   if #available(macOS 10, *) { } // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}} {{group-name=UselessAvailabilityCheck}}
@@ -31,9 +31,9 @@ func annotatedFunc( // expected-note 3 {{enclosing scope here}}
 
   switch e {
   case .macOS_10:
-    if #available(macOS 10, *) { _ = 1 } // FIXME: [availability] Should be diagnosed
+    if #available(macOS 10, *) { _ = 1 } // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
   case .macOS_11:
-    if #available(macOS 11, *) { _ = 1 } // FIXME: [availability] Should be diagnosed
+    if #available(macOS 11, *) { _ = 1 } // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
   case .macOS_12:
     if #available(macOS 12, *) { _ = 1 }
   case .macOS_13:

--- a/test/Availability/availability_versions.swift
+++ b/test/Availability/availability_versions.swift
@@ -1674,6 +1674,26 @@ func testForFixitWithNestedMemberRefExpr() {
       
 }
 
+@available(OSX 51.1, *)
+func globalFuncAvailableOn51_1() -> Int { return 9 }
+
+func testForFixitNarrowingNearbyVersionCheck(_ i: Int) {
+  if #available(OSX 51, *) {
+    _ = globalFuncAvailableOn51_1()
+        // expected-error@-1 {{'globalFuncAvailableOn51_1()' is only available in macOS 51.1 or newer}} {{-1:21-23=51.1}}
+  }
+
+  if #available(OSX 51, *) {
+    switch i {
+    case 0:
+      _ = globalFuncAvailableOn51_1()
+          // expected-error@-1 {{'globalFuncAvailableOn51_1()' is only available in macOS 51.1 or newer}} {{-3:21-23=51.1}}
+    default:
+      break
+    }
+  }
+}
+
 // Protocol Conformances
 
 protocol ProtocolWithRequirementMentioningPotentiallyUnavailable {


### PR DESCRIPTION
The warning for an `#available` query that can never be false because an enclosing scope already guarantees the availability being checked was emitted by `AvailabilityScopeBuilder` as a side effect of building the scope for a statement condition. Diagnosing from the builder meant the check could only consult the scopes that happened to be on top of the builder's context stack (which may be truncated when expanding a lazy scope), so a query nested inside a scope that doesn't specify an availability range of its own was never diagnosed. Switch case bodies are one example:

    @available(macOS 11, *)
    func annotatedFunc(_ e: MacOSVersions) {
      switch e {
      case .macOS_10:
        if #available(macOS 10, *) { } // wasn't diagnosed
      }
    }

Move the diagnostic to `diagnoseAvailabilityCondition()` in MiscDiagnostics, where the rest of the diagnostics for availability conditions already live. To find the nearest scope with explicit availability that makes the check redundant, add an overload of `findMostRefinedSubContext()` that records the chain of scopes containing a location so that it can be searched outward.

`fixAvailabilityByNarrowingNearbyVersionCheck()` searches outward the same way now, so the fix-it that narrows a nearby version check is offered in more places as well. Add tests for it, including one where the reference is in the body of a switch case and the `if #available` to narrow can only be found by searching past the placeholder scope for the switch.