### PR TITLE
[Utils] add minimize-verify-tests tool

### DIFF
--- a/test/Utils/minimize-verify-tests/child-notes.swift
+++ b/test/Utils/minimize-verify-tests/child-notes.swift
@@ -1,0 +1,138 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// --- child-notes-merge: Children with relative offsets merge -------------
+// RUN: %minimize-verify-tests %t/child-notes-merge.swift
+// RUN: %diff %t/child-notes-merge.swift %t/child-notes-merge.swift.expected
+
+// --- child-notes-differ: Different child note text stays separate --------
+// RUN: %minimize-verify-tests %t/child-notes-differ.swift
+// RUN: %diff %t/child-notes-differ.swift %t/child-notes-differ.swift.expected
+
+// --- child-notes-mixed: One diag has children, the other does not --------
+// RUN: %minimize-verify-tests %t/child-notes-mixed.swift
+// RUN: %diff %t/child-notes-mixed.swift %t/child-notes-mixed.swift.expected
+
+// --- child-notes-no-children-merge: Same message, no children, merges ---
+// RUN: %minimize-verify-tests %t/child-notes-no-children-merge.swift
+// RUN: %diff %t/child-notes-no-children-merge.swift %t/child-notes-no-children-merge.swift.expected
+
+// --- child-notes-multiline: Multi-line children blocks merge ------------
+// RUN: %minimize-verify-tests %t/child-notes-multiline.swift
+// RUN: %diff %t/child-notes-multiline.swift %t/child-notes-multiline.swift.expected
+
+// --- child-notes-in-expansion: Children on diags inside expansions -------
+// RUN: %minimize-verify-tests %t/child-notes-in-expansion.swift
+// RUN: %diff %t/child-notes-in-expansion.swift %t/child-notes-in-expansion.swift.expected
+
+//--- child-notes-merge.swift
+// RUN: true -verify -verify-child-notes -verify-additional-prefix a-
+// RUN: true -verify -verify-child-notes -verify-additional-prefix b-
+
+struct S {}
+struct S {}
+// expected-a-error @-1 {{invalid redeclaration of 'S'}} {{children: expected-note@-2 {{'S' previously declared here}} }}
+// expected-b-error @-2 {{invalid redeclaration of 'S'}} {{children: expected-note@-3 {{'S' previously declared here}} }}
+//--- child-notes-merge.swift.expected
+// RUN: true -verify -verify-child-notes -verify-additional-prefix a-
+// RUN: true -verify -verify-child-notes -verify-additional-prefix b-
+
+struct S {}
+struct S {}
+// expected-error @-1 {{invalid redeclaration of 'S'}} {{children: expected-note@-2 {{'S' previously declared here}} }}
+//--- child-notes-differ.swift
+// RUN: true -verify -verify-child-notes -verify-additional-prefix a-
+// RUN: true -verify -verify-child-notes -verify-additional-prefix b-
+
+struct T {}
+struct T {}
+// expected-a-error @-1 {{invalid redeclaration of 'T'}} {{children: expected-note@-2 {{'T' previously declared here}} }}
+// expected-b-error @-2 {{invalid redeclaration of 'T'}} {{children: expected-note@-3 {{other note}} }}
+//--- child-notes-differ.swift.expected
+// RUN: true -verify -verify-child-notes -verify-additional-prefix a-
+// RUN: true -verify -verify-child-notes -verify-additional-prefix b-
+
+struct T {}
+struct T {}
+// expected-a-error @-1 {{invalid redeclaration of 'T'}} {{children: expected-note@-2 {{'T' previously declared here}} }}
+// expected-b-error @-2 {{invalid redeclaration of 'T'}} {{children: expected-note@-3 {{other note}} }}
+//--- child-notes-mixed.swift
+// RUN: true -verify -verify-child-notes -verify-additional-prefix a-
+// RUN: true -verify -verify-child-notes -verify-additional-prefix b-
+
+struct U {}
+struct U {}
+// expected-a-error @-1 {{invalid redeclaration of 'U'}} {{children: expected-note@-2 {{'U' previously declared here}} }}
+// expected-b-error @-2 {{invalid redeclaration of 'U'}}
+//--- child-notes-mixed.swift.expected
+// RUN: true -verify -verify-child-notes -verify-additional-prefix a-
+// RUN: true -verify -verify-child-notes -verify-additional-prefix b-
+
+struct U {}
+struct U {}
+// expected-a-error @-1 {{invalid redeclaration of 'U'}} {{children: expected-note@-2 {{'U' previously declared here}} }}
+// expected-b-error @-2 {{invalid redeclaration of 'U'}}
+//--- child-notes-no-children-merge.swift
+// RUN: true -verify -verify-child-notes -verify-additional-prefix a-
+// RUN: true -verify -verify-child-notes -verify-additional-prefix b-
+
+func foo(_ x: Int) {}
+foo("hello") // expected-a-error {{cannot convert value of type 'String' to expected argument type 'Int'}}
+// expected-b-error @-1 {{cannot convert value of type 'String' to expected argument type 'Int'}}
+//--- child-notes-no-children-merge.swift.expected
+// RUN: true -verify -verify-child-notes -verify-additional-prefix a-
+// RUN: true -verify -verify-child-notes -verify-additional-prefix b-
+
+func foo(_ x: Int) {}
+foo("hello") // expected-error {{cannot convert value of type 'String' to expected argument type 'Int'}}
+//--- child-notes-multiline.swift
+// RUN: true -verify -verify-child-notes -verify-additional-prefix a-
+// RUN: true -verify -verify-child-notes -verify-additional-prefix b-
+
+struct V {}
+struct V {}
+// expected-a-error @-1 {{invalid redeclaration of 'V'}} {{children:
+//   expected-note@-3 {{'V' previously declared here}}
+// }}
+// expected-b-error @-4 {{invalid redeclaration of 'V'}} {{children:
+//   expected-note@-6 {{'V' previously declared here}}
+// }}
+//--- child-notes-multiline.swift.expected
+// RUN: true -verify -verify-child-notes -verify-additional-prefix a-
+// RUN: true -verify -verify-child-notes -verify-additional-prefix b-
+
+struct V {}
+struct V {}
+// expected-error @-1 {{invalid redeclaration of 'V'}} {{children:
+//   expected-note@-3 {{'V' previously declared here}}
+// }}
+//--- child-notes-in-expansion.swift
+// RUN: true -verify -verify-child-notes -verify-additional-prefix a-
+// RUN: true -verify -verify-child-notes -verify-additional-prefix b-
+
+@freestanding(expression)
+macro myMacro() = #externalMacro(module: "M", type: "T")
+let x = #myMacro
+// expected-a-expansion@-1:9{{
+//   expected-a-error@1 {{redecl}} {{children: expected-note@2 {{prev}} }}
+//   expected-a-error@3 {{other}} {{children: expected-note@4 {{different a}} }}
+//   expected-a-warning@2 {{unused}}
+// }}
+// expected-b-expansion@-6:9{{
+//   expected-b-error@1 {{redecl}} {{children: expected-note@2 {{prev}} }}
+//   expected-b-error@3 {{other}} {{children: expected-note@4 {{different b}} }}
+//   expected-b-warning@2 {{unused}}
+// }}
+//--- child-notes-in-expansion.swift.expected
+// RUN: true -verify -verify-child-notes -verify-additional-prefix a-
+// RUN: true -verify -verify-child-notes -verify-additional-prefix b-
+
+@freestanding(expression)
+macro myMacro() = #externalMacro(module: "M", type: "T")
+let x = #myMacro
+// expected-expansion@-1:9{{
+//   expected-error@1 {{redecl}} {{children: expected-note@2 {{prev}} }}
+//   expected-warning@2 {{unused}}
+//   expected-a-error@3 {{other}} {{children: expected-note@4 {{different a}} }}
+//   expected-b-error@3 {{other}} {{children: expected-note@4 {{different b}} }}
+// }}

--- a/test/Utils/minimize-verify-tests/lit.local.cfg
+++ b/test/Utils/minimize-verify-tests/lit.local.cfg
@@ -1,0 +1,4 @@
+import sys
+
+if sys.version_info < (3, 9):
+    config.unsupported = True

--- a/test/Utils/minimize-verify-tests/minimize-verify-tests.swift
+++ b/test/Utils/minimize-verify-tests/minimize-verify-tests.swift
@@ -1,0 +1,195 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// --- basic-merge: Two prefixes merge to default expected-error -----------
+// RUN: %minimize-verify-tests %t/basic-merge.swift
+// RUN: %diff %t/basic-merge.swift %t/basic-merge.swift.expected
+
+// --- no-merge-subset: No single prefix covers the subset ----------------
+// RUN: %minimize-verify-tests %t/no-merge-subset.swift
+// RUN: %diff %t/no-merge-subset.swift %t/no-merge-subset.swift.expected
+
+// --- merge-to-additional-prefix: Merge to a shared non-default prefix ---
+// RUN: %minimize-verify-tests %t/merge-to-additional-prefix.swift
+// RUN: %diff %t/merge-to-additional-prefix.swift %t/merge-to-additional-prefix.swift.expected
+
+// --- multiple-groups: One group mergeable, another not ------------------
+// RUN: %minimize-verify-tests %t/multiple-groups.swift
+// RUN: %diff %t/multiple-groups.swift %t/multiple-groups.swift.expected
+
+// --- already-minimal: Nothing to change ---------------------------------
+// RUN: %minimize-verify-tests %t/already-minimal.swift
+// RUN: %diff %t/already-minimal.swift %t/already-minimal.swift.expected
+
+// --- separate-lines: Offset auto-adjusts after line removal -------------
+// RUN: %minimize-verify-tests %t/separate-lines.swift
+// RUN: %diff %t/separate-lines.swift %t/separate-lines.swift.expected
+
+// --- inline-diag: Inline directive preferred over @-N one ---------------
+// RUN: %minimize-verify-tests %t/inline-diag.swift
+// RUN: %diff %t/inline-diag.swift %t/inline-diag.swift.expected
+
+// --- run-line-continuation: Backslash-continued RUN lines ---------------
+// RUN: %minimize-verify-tests %t/run-line-continuation.swift
+// RUN: %diff %t/run-line-continuation.swift %t/run-line-continuation.swift.expected
+
+//--- basic-merge.swift
+// RUN: true -verify -verify-additional-prefix swift5-
+// RUN: true -verify -verify-additional-prefix swift6-
+
+func basic_merge() {
+  let x = 1
+  // expected-swift5-error @-1 {{cannot find 'x' in scope}}
+  // expected-swift6-error @-2 {{cannot find 'x' in scope}}
+}
+//--- basic-merge.swift.expected
+// RUN: true -verify -verify-additional-prefix swift5-
+// RUN: true -verify -verify-additional-prefix swift6-
+
+func basic_merge() {
+  let x = 1
+  // expected-error @-1 {{cannot find 'x' in scope}}
+}
+//--- no-merge-subset.swift
+// RUN: true -verify -verify-additional-prefix a-
+// RUN: true -verify -verify-additional-prefix b-
+// RUN: true -verify -verify-additional-prefix c-
+
+func no_merge_subset() {
+  let x = 1
+  // expected-a-error @-1 {{cannot find 'x' in scope}}
+  // expected-b-error @-2 {{cannot find 'x' in scope}}
+}
+//--- no-merge-subset.swift.expected
+// RUN: true -verify -verify-additional-prefix a-
+// RUN: true -verify -verify-additional-prefix b-
+// RUN: true -verify -verify-additional-prefix c-
+
+func no_merge_subset() {
+  let x = 1
+  // expected-a-error @-1 {{cannot find 'x' in scope}}
+  // expected-b-error @-2 {{cannot find 'x' in scope}}
+}
+//--- merge-to-additional-prefix.swift
+// RUN: true -verify -verify-additional-prefix a-
+// RUN: true -verify -verify-additional-prefix b- -verify-additional-prefix shared-
+// RUN: true -verify -verify-additional-prefix c- -verify-additional-prefix shared-
+
+func merge_to_additional_prefix() {
+  let x = 1
+  // expected-b-error @-1 {{cannot find 'x' in scope}}
+  // expected-c-error @-2 {{cannot find 'x' in scope}}
+}
+//--- merge-to-additional-prefix.swift.expected
+// RUN: true -verify -verify-additional-prefix a-
+// RUN: true -verify -verify-additional-prefix b- -verify-additional-prefix shared-
+// RUN: true -verify -verify-additional-prefix c- -verify-additional-prefix shared-
+
+func merge_to_additional_prefix() {
+  let x = 1
+  // expected-shared-error @-1 {{cannot find 'x' in scope}}
+}
+//--- multiple-groups.swift
+// RUN: true -verify -verify-additional-prefix a-
+// RUN: true -verify -verify-additional-prefix b-
+// RUN: true -verify -verify-additional-prefix c-
+
+func first() {
+  let x = 1
+  // expected-a-error @-1 {{first error}}
+  // expected-b-error @-2 {{first error}}
+  // expected-c-error @-3 {{first error}}
+}
+
+func second() {
+  let y = 2
+  // expected-a-warning @-1 {{second warning}}
+  // expected-b-warning @-2 {{second warning}}
+}
+//--- multiple-groups.swift.expected
+// RUN: true -verify -verify-additional-prefix a-
+// RUN: true -verify -verify-additional-prefix b-
+// RUN: true -verify -verify-additional-prefix c-
+
+func first() {
+  let x = 1
+  // expected-error @-1 {{first error}}
+}
+
+func second() {
+  let y = 2
+  // expected-a-warning @-1 {{second warning}}
+  // expected-b-warning @-2 {{second warning}}
+}
+//--- already-minimal.swift
+// RUN: true -verify -verify-additional-prefix swift5-
+// RUN: true -verify -verify-additional-prefix swift6-
+
+func already_minimal() {
+  let x = 1 // expected-error {{already minimal}}
+}
+//--- already-minimal.swift.expected
+// RUN: true -verify -verify-additional-prefix swift5-
+// RUN: true -verify -verify-additional-prefix swift6-
+
+func already_minimal() {
+  let x = 1 // expected-error {{already minimal}}
+}
+//--- separate-lines.swift
+// RUN: true -verify -verify-additional-prefix swift5-
+// RUN: true -verify -verify-additional-prefix swift6-
+
+func separate_lines() {
+  let x = 1
+  let y = 2
+  // expected-swift5-error @-2 {{error on x}}
+  // expected-swift6-error @-3 {{error on x}}
+  // expected-swift5-warning @-3 {{warning on y}}
+  // expected-swift6-warning @-4 {{warning on y}}
+}
+//--- separate-lines.swift.expected
+// RUN: true -verify -verify-additional-prefix swift5-
+// RUN: true -verify -verify-additional-prefix swift6-
+
+func separate_lines() {
+  let x = 1
+  let y = 2
+  // expected-error @-2 {{error on x}}
+  // expected-warning @-2 {{warning on y}}
+}
+//--- inline-diag.swift
+// RUN: true -verify -verify-additional-prefix swift5-
+// RUN: true -verify -verify-additional-prefix swift6-
+
+func inline_diag() {
+  let x = 1 // expected-swift5-error {{inline error}}
+  // expected-swift6-error @-1 {{inline error}}
+}
+//--- inline-diag.swift.expected
+// RUN: true -verify -verify-additional-prefix swift5-
+// RUN: true -verify -verify-additional-prefix swift6-
+
+func inline_diag() {
+  let x = 1 // expected-error {{inline error}}
+}
+//--- run-line-continuation.swift
+// RUN: true -verify \
+// RUN:   -verify-additional-prefix swift5-
+// RUN: true -verify \
+// RUN:   -verify-additional-prefix swift6-
+
+func run_line_continuation() {
+  let x = 1
+  // expected-swift5-error @-1 {{error msg}}
+  // expected-swift6-error @-2 {{error msg}}
+}
+//--- run-line-continuation.swift.expected
+// RUN: true -verify \
+// RUN:   -verify-additional-prefix swift5-
+// RUN: true -verify \
+// RUN:   -verify-additional-prefix swift6-
+
+func run_line_continuation() {
+  let x = 1
+  // expected-error @-1 {{error msg}}
+}

--- a/test/Utils/minimize-verify-tests/minimize-verify-tests.swift
+++ b/test/Utils/minimize-verify-tests/minimize-verify-tests.swift
@@ -37,6 +37,10 @@
 // RUN: %minimize-verify-tests %t/expansion.swift
 // RUN: %diff %t/expansion.swift %t/expansion.swift.expected
 
+// --- expansion-already-shared: Non-prefixed expansion block still has its contents merged
+// RUN: %minimize-verify-tests %t/expansion-already-shared.swift
+// RUN: %diff %t/expansion-already-shared.swift %t/expansion-already-shared.swift.expected
+
 //--- basic-merge.swift
 // RUN: true -verify -verify-additional-prefix swift5-
 // RUN: true -verify -verify-additional-prefix swift6-
@@ -225,3 +229,29 @@ let x = #myMacro
 //   expected-a-warning@2 {{a-only warning}}
 // }}
 // expected-error @-4 {{some error}}
+//--- expansion-already-shared.swift
+// RUN: true -verify -verify-additional-prefix a-
+// RUN: true -verify -verify-additional-prefix b-
+
+@freestanding(expression)
+macro myMacro() = #externalMacro(module: "M", type: "T")
+let x = #myMacro
+// expected-expansion@-1:9{{
+//   expected-a-warning@1 {{shared warning}}
+//   expected-a-warning@2 {{a-only warning}}
+//   expected-b-warning@1 {{shared warning}}
+// }}
+// expected-a-error @-6 {{some error}}
+// expected-b-error @-7 {{some error}}
+//--- expansion-already-shared.swift.expected
+// RUN: true -verify -verify-additional-prefix a-
+// RUN: true -verify -verify-additional-prefix b-
+
+@freestanding(expression)
+macro myMacro() = #externalMacro(module: "M", type: "T")
+let x = #myMacro
+// expected-expansion@-1:9{{
+//   expected-warning@1 {{shared warning}}
+//   expected-a-warning@2 {{a-only warning}}
+// }}
+// expected-error @-5 {{some error}}

--- a/test/Utils/minimize-verify-tests/minimize-verify-tests.swift
+++ b/test/Utils/minimize-verify-tests/minimize-verify-tests.swift
@@ -33,6 +33,10 @@
 // RUN: %minimize-verify-tests %t/run-line-continuation.swift
 // RUN: %diff %t/run-line-continuation.swift %t/run-line-continuation.swift.expected
 
+// --- expansion: Prefixed expansion blocks merge -------------------------
+// RUN: %minimize-verify-tests %t/expansion.swift
+// RUN: %diff %t/expansion.swift %t/expansion.swift.expected
+
 //--- basic-merge.swift
 // RUN: true -verify -verify-additional-prefix swift5-
 // RUN: true -verify -verify-additional-prefix swift6-
@@ -193,3 +197,31 @@ func run_line_continuation() {
   let x = 1
   // expected-error @-1 {{error msg}}
 }
+//--- expansion.swift
+// RUN: true -verify -verify-additional-prefix a-
+// RUN: true -verify -verify-additional-prefix b-
+
+@freestanding(expression)
+macro myMacro() = #externalMacro(module: "M", type: "T")
+let x = #myMacro
+// expected-a-expansion@-1:9{{
+//   expected-a-warning@1 {{shared warning}}
+//   expected-a-warning@2 {{a-only warning}}
+// }}
+// expected-b-expansion@-5:9{{
+//   expected-b-warning@1 {{shared warning}}
+// }}
+// expected-a-error @-7 {{some error}}
+// expected-b-error @-8 {{some error}}
+//--- expansion.swift.expected
+// RUN: true -verify -verify-additional-prefix a-
+// RUN: true -verify -verify-additional-prefix b-
+
+@freestanding(expression)
+macro myMacro() = #externalMacro(module: "M", type: "T")
+let x = #myMacro
+// expected-expansion@-1:9{{
+//   expected-warning@1 {{shared warning}}
+//   expected-a-warning@2 {{a-only warning}}
+// }}
+// expected-error @-4 {{some error}}

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -860,6 +860,9 @@ config.substitutions.append( ('%update-verify-tests', '%s %s' % (config.python, 
 config.update_pathsanitizing_diff_tests = make_path(config.swift_utils, "update-pathsanitizing-diff-tests.py")
 config.substitutions.append( ('%update-pathsanitizing-diff-tests', '%s %s' % (config.python, config.update_pathsanitizing_diff_tests)) )
 
+config.minimize_verify_tests = make_path(config.swift_utils, "minimize-verify-tests.py")
+config.substitutions.append( ('%minimize-verify-tests', '%s %s' % (config.python, config.minimize_verify_tests)) )
+
 config.update_generated_tests = make_path(config.swift_utils, "update-generated-tests.py")
 config.lit_pythonpath = os.path.dirname(os.path.dirname(lit.__file__))
 config.substitutions.append(

--- a/utils/minimize-verify-tests.py
+++ b/utils/minimize-verify-tests.py
@@ -8,9 +8,9 @@ from update_verify_tests.core import minimize_verify_test
 
  For each RUN line the script determines which verify prefixes are active
  (the default empty prefix plus any `-verify-additional-prefix` values).
- It then finds overlapping expected-* directives — those that point to the
+ It then finds overlapping expected-* directives - those that point to the
  same source location, have the same category, content, count, and fix-its
- but differ in prefix — and merges them when a single prefix exists that is
+ but differ in prefix - and merges them when a single prefix exists that is
  active in exactly the union of RUN lines covered by the overlapping set.
 
 Example usage:
@@ -20,9 +20,7 @@ Example usage:
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "file", nargs="+", help="Test file(s) to minimize"
-    )
+    parser.add_argument("file", nargs="+", help="Test file(s) to minimize")
     args = parser.parse_args()
     for f in args.file:
         err = minimize_verify_test(f)

--- a/utils/minimize-verify-tests.py
+++ b/utils/minimize-verify-tests.py
@@ -1,0 +1,35 @@
+import sys
+import argparse
+from update_verify_tests.core import minimize_verify_test
+
+"""
+ Minimize an already-passing -verify test case by merging redundant
+ prefixed expected-* directives.
+
+ For each RUN line the script determines which verify prefixes are active
+ (the default empty prefix plus any `-verify-additional-prefix` values).
+ It then finds overlapping expected-* directives — those that point to the
+ same source location, have the same category, content, count, and fix-its
+ but differ in prefix — and merges them when a single prefix exists that is
+ active in exactly the union of RUN lines covered by the overlapping set.
+
+Example usage:
+  python3 minimize-verify-tests.py test.swift
+"""
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "file", nargs="+", help="Test file(s) to minimize"
+    )
+    args = parser.parse_args()
+    for f in args.file:
+        err = minimize_verify_test(f)
+        if err:
+            print(err, file=sys.stderr)
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/update_verify_tests/core.py
+++ b/utils/update_verify_tests/core.py
@@ -2243,10 +2243,63 @@ def _collect_verify_prefixes(raw_lines):
     return run_prefixes, prefix_to_runs
 
 
+def _trailing_content(diag):
+    """Return the portion of the line content after the ``{{DIAG}}``
+    placeholder.  This captures ``{{children:...}}`` blocks and any other
+    trailing text that is semantically part of the directive."""
+    marker = "{{DIAG}}"
+    idx = diag.line.content.find(marker)
+    if idx < 0:
+        return ""
+    return diag.line.content[idx + len(marker):]
+
+
+# Matches `@-N` or `@+N` that follow an `expected-*` directive prefix
+# inside a ``{{children:...}}`` block.
+_children_ref_re = re.compile(
+    r"(expected-[a-zA-Z0-9-]*(?:note|warning|error|remark)(?:-re)?\s*)@([+-])(\d+)"
+)
+
+
+def _normalized_trailing(diag):
+    """Like ``_trailing_content`` but with relative ``@-N`` / ``@+N``
+    references inside ``{{children:...}}`` blocks resolved to absolute
+    line numbers.  This allows two directives on different lines to be
+    recognised as overlapping when their children blocks reference the
+    same target lines."""
+    trailing = _trailing_content(diag)
+    line_n = diag.line.line_n
+
+    def _resolve(m):
+        prefix = m.group(1)
+        sign = m.group(2)
+        offset = int(m.group(3))
+        abs_n = line_n + (-offset if sign == "-" else offset)
+        return f"{prefix}@={abs_n}"
+
+    return _children_ref_re.sub(_resolve, trailing)
+
+
 def _overlap_key(diag):
     """Return a hashable key that groups directives which could potentially
     be merged: same target line, same category, same content, same count,
-    same regex flag, and same fix-it annotations."""
+    same regex flag, same fix-it annotations, and same trailing content
+    (which includes ``{{children:...}}`` blocks with offsets normalised
+    to absolute line numbers).
+
+    For multi-line ``{{children:`` blocks the continuation lines have been
+    folded into ``nested_lines``; those are included as a content
+    fingerprint so that blocks with different child notes stay separate."""
+    nested_key = ()
+    if diag.nested_lines:
+        parts = []
+        for nl in diag.nested_lines:
+            nd = nl.diag
+            if nd:
+                parts.append((nd.absolute_target(), nd.category,
+                              nd.diag_content, nd.count, nd.is_re,
+                              nd.fixits_raw_str))
+        nested_key = tuple(parts)
     return (
         diag.absolute_target(),
         diag.category,
@@ -2254,6 +2307,8 @@ def _overlap_key(diag):
         diag.count,
         diag.is_re,
         diag.fixits_raw_str,
+        _normalized_trailing(diag),
+        nested_key,
     )
 
 
@@ -2299,6 +2354,7 @@ def _nested_diag_key(nd):
         nd.count,
         nd.is_re,
         nd.fixits_raw_str,
+        _trailing_content(nd),
     )
 
 
@@ -2382,6 +2438,33 @@ def _merge_expansion_groups(expansion_diags, prefix_to_runs,
     return changed
 
 
+def _has_multiline_children_open(diag):
+    """Return True if *diag*'s line opens a multi-line ``{{children:``
+    block (the block continues on subsequent lines rather than closing
+    on the same line)."""
+    trailing = _trailing_content(diag)
+    # Look for {{children: that is NOT closed by }} on the same line.
+    idx = trailing.find("{{children:")
+    if idx < 0:
+        return False
+    after = trailing[idx:]
+    # Count braces: the block is multi-line if we never see the matching }}.
+    depth = 0
+    i = 0
+    while i < len(after):
+        if after[i:i+2] == "{{":
+            depth += 1
+            i += 2
+        elif after[i:i+2] == "}}":
+            depth -= 1
+            if depth == 0:
+                return False  # closed on the same line
+            i += 2
+        else:
+            i += 1
+    return True  # never closed — multi-line
+
+
 def minimize_verify_test(filename):
     """Read *filename*, merge redundant prefixed expected-* directives where
     a single prefix can replace a set of overlapping ones, and write the
@@ -2404,28 +2487,50 @@ def minimize_verify_test(filename):
     orig_lines = list(lines)
 
     # Parse every expected-* directive (all prefixes).
+    # Both expansion_context (for expected-expansion blocks) and
+    # children_context (for multi-line {{children: blocks) track nesting
+    # so that continuation lines get a parent reference and are later
+    # folded out of the main line list.
     expansion_context = []
+    children_context = []
     for line in lines:
         diag = parse_diag(line, filename, "", all_prefixes=True)
         if diag:
             line.diag = diag
+            # Pick the innermost active context.
+            parent_ctx = (children_context or expansion_context)
             if isinstance(diag, ExpansionDiagClose):
-                if expansion_context:
+                if children_context:
+                    diag.parent = children_context[-1]
+                    children_context.pop()
+                elif expansion_context:
                     diag.parent = expansion_context[-1]
                     expansion_context.pop()
             elif diag.category == "expansion":
-                if expansion_context:
-                    diag.parent = expansion_context[-1]
+                if parent_ctx:
+                    diag.parent = parent_ctx[-1]
                 else:
                     diag.set_target(lines[diag.absolute_target() - 1])
                 expansion_context.append(diag)
             else:
-                if expansion_context:
-                    diag.parent = expansion_context[-1]
+                if parent_ctx:
+                    diag.parent = parent_ctx[-1]
+                    # Notes inside multi-line {{children: blocks still
+                    # need their target resolved before folding, so that
+                    # absolute_target() works after line renumbering.
+                    if children_context:
+                        diag.set_target(
+                            lines[diag.absolute_target() - 1])
                 else:
                     diag.set_target(lines[diag.absolute_target() - 1])
+                # Check if this diag opens a multi-line children block.
+                if (not parent_ctx
+                        and not isinstance(diag, ExpansionDiagClose)
+                        and _has_multiline_children_open(diag)):
+                    children_context.append(diag)
 
-    # Fold expansion blocks so nested lines live inside the parent diag.
+    # Fold expansion blocks *and* multi-line children blocks so nested
+    # lines live inside the parent diag.
     fold_expansions(lines)
 
     # Separate expansion and regular diags.
@@ -2470,7 +2575,22 @@ def minimize_verify_test(filename):
         changed = True
 
     if changed:
+        # Re-insert nested lines for both expansion blocks and multi-line
+        # children blocks.
         expand_expansions(lines)
+        # Also expand children-block nested lines on non-expansion diags.
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            if (line.diag
+                    and not isinstance(line.diag, ExpansionDiagClose)
+                    and line.diag.category != "expansion"
+                    and line.diag.nested_lines):
+                for j, nested in enumerate(
+                        line.diag.nested_lines + [line.diag.closer]):
+                    nested.line_n = line.line_n + j + 1
+                    add_line(nested, lines)
+            i += 1
         with open(filename, "w") as f:
             for line in lines:
                 f.write(line.render())

--- a/utils/update_verify_tests/core.py
+++ b/utils/update_verify_tests/core.py
@@ -2272,6 +2272,116 @@ def _pick_keeper(diags):
     return min(diags, key=sort_key)
 
 
+def _find_merge_prefix(prefixes, prefix_to_runs, runs_to_prefixes):
+    """Given a list of prefixes, compute their combined RUN-line coverage
+    and return a single prefix that covers exactly that set, or ``None``
+    if no such prefix exists.  Prefers the default (empty) prefix."""
+    coverage = set()
+    for p in prefixes:
+        rset = prefix_to_runs.get(p)
+        if rset is None:
+            return None
+        coverage |= rset
+    candidates = runs_to_prefixes.get(frozenset(coverage))
+    if not candidates:
+        return None
+    if "" in candidates:
+        return ""
+    return min(candidates, key=lambda p: (len(p), p))
+
+
+def _nested_diag_key(nd):
+    """Overlap key for a directive nested inside an expansion block."""
+    return (
+        nd.absolute_target(),
+        nd.category,
+        nd.diag_content,
+        nd.count,
+        nd.is_re,
+        nd.fixits_raw_str,
+    )
+
+
+def _merge_expansion_groups(expansion_diags, prefix_to_runs,
+                            runs_to_prefixes, lines):
+    """Merge expansion blocks that target the same source location.
+
+    Two expansion blocks at the same ``(absolute_target, column)`` are
+    combined into one whose prefix covers the union of runs.  Their
+    nested directives are individually merged where an appropriate prefix
+    exists; non-overlapping nested directives are kept with their original
+    prefix.
+    """
+    # Group by (absolute_target, col).
+    groups = {}
+    for d in expansion_diags:
+        key = (d.absolute_target(), d.col())
+        groups.setdefault(key, []).append(d)
+
+    changed = False
+    for key, exp_list in groups.items():
+        if len(exp_list) < 2:
+            continue
+
+        # Find a prefix for the merged expansion block.
+        exp_prefix = _find_merge_prefix(
+            [d.prefix for d in exp_list], prefix_to_runs, runs_to_prefixes)
+        if exp_prefix is None:
+            continue
+
+        keeper = _pick_keeper(exp_list)
+
+        # Collect all nested lines from every block in the group.
+        all_nested = []
+        for d in exp_list:
+            all_nested.extend(d.nested_lines)
+
+        # Group nested diags by overlap key within the expansion.
+        nested_groups = {}
+        for nl in all_nested:
+            if not nl.diag:
+                continue
+            nk = _nested_diag_key(nl.diag)
+            nested_groups.setdefault(nk, []).append(nl)
+
+        # Merge overlapping nested diags where possible.
+        merged_nested = []
+        for nk, nl_list in nested_groups.items():
+            if len(nl_list) > 1:
+                np = _find_merge_prefix(
+                    [nl.diag.prefix for nl in nl_list],
+                    prefix_to_runs, runs_to_prefixes)
+                if np is not None:
+                    nl_list[0].diag.prefix = np
+                    merged_nested.append(nl_list[0])
+                    continue
+            # Single diag or unmergeable — keep all.
+            merged_nested.extend(nl_list)
+
+        # Sort by target line within expansion, then by category for
+        # stability.
+        merged_nested.sort(
+            key=lambda nl: (nl.diag.absolute_target() if nl.diag else 0,
+                            nl.diag.category if nl.diag else ""))
+
+        # Install merged content into the keeper.
+        keeper.prefix = exp_prefix
+        keeper.nested_lines = merged_nested
+        for i, nl in enumerate(keeper.nested_lines):
+            nl.line_n = i + 1
+
+        # Remove the other expansion blocks from `lines`.
+        for d in exp_list:
+            if d is keeper:
+                continue
+            if d.target is not None:
+                d.unset_target()
+            remove_line(d.line, lines)
+        changed = True
+
+    return changed
+
+
 def minimize_verify_test(filename):
     """Read *filename*, merge redundant prefixed expected-* directives where
     a single prefix can replace a set of overlapping ones, and write the
@@ -2295,7 +2405,6 @@ def minimize_verify_test(filename):
 
     # Parse every expected-* directive (all prefixes).
     expansion_context = []
-    all_diags = []
     for line in lines:
         diag = parse_diag(line, filename, "", all_prefixes=True)
         if diag:
@@ -2315,53 +2424,40 @@ def minimize_verify_test(filename):
                     diag.parent = expansion_context[-1]
                 else:
                     diag.set_target(lines[diag.absolute_target() - 1])
-                all_diags.append(diag)
 
-    # Group by overlap key.
+    # Fold expansion blocks so nested lines live inside the parent diag.
+    fold_expansions(lines)
+
+    # Separate expansion and regular diags.
+    expansion_diags = []
+    regular_diags = []
+    for line in lines:
+        if line.diag and not isinstance(line.diag, ExpansionDiagClose):
+            if line.diag.category == "expansion":
+                expansion_diags.append(line.diag)
+            else:
+                regular_diags.append(line.diag)
+
+    changed = False
+
+    # --- Pass 1: merge expansion blocks at the same location. ---
+    changed |= _merge_expansion_groups(
+        expansion_diags, prefix_to_runs, runs_to_prefixes, lines)
+
+    # --- Pass 2: merge regular (non-expansion) diags. ---
     groups = {}
-    for diag in all_diags:
+    for diag in regular_diags:
         key = _overlap_key(diag)
         groups.setdefault(key, []).append(diag)
 
-    changed = False
-    # Process each group that has more than one directive.
     for key, diag_list in groups.items():
         if len(diag_list) < 2:
             continue
 
-        # All prefixes in the group must be known to the RUN-line map.
-        # Directives whose prefix is not mentioned in any RUN line cannot
-        # be reasoned about; skip the group.
-        coverage = set()
-        skip = False
-        for d in diag_list:
-            rset = prefix_to_runs.get(d.prefix)
-            if rset is None:
-                skip = True
-                break
-            coverage |= rset
-        if skip:
+        merge_prefix = _find_merge_prefix(
+            [d.prefix for d in diag_list], prefix_to_runs, runs_to_prefixes)
+        if merge_prefix is None:
             continue
-        coverage = frozenset(coverage)
-
-        # Is there a prefix that covers exactly this set of runs?
-        candidates = runs_to_prefixes.get(coverage)
-        if not candidates:
-            continue
-
-        # Prefer the default prefix when possible; otherwise pick the
-        # shortest candidate (arbitrary but stable).
-        if "" in candidates:
-            merge_prefix = ""
-        else:
-            merge_prefix = min(candidates, key=lambda p: (len(p), p))
-
-        # If one of the diags already uses the merge prefix, we'd end up
-        # keeping it and removing the others.  Make sure we don't create a
-        # duplicate by checking whether there's already a surviving diag
-        # with the merge prefix at this location outside this group.
-        # (In a well-formed passing test this shouldn't happen, but be
-        # safe.)
 
         keeper = _pick_keeper(diag_list)
         keeper.prefix = merge_prefix
@@ -2374,6 +2470,7 @@ def minimize_verify_test(filename):
         changed = True
 
     if changed:
+        expand_expansions(lines)
         with open(filename, "w") as f:
             for line in lines:
                 f.write(line.render())

--- a/utils/update_verify_tests/core.py
+++ b/utils/update_verify_tests/core.py
@@ -2358,6 +2358,57 @@ def _nested_diag_key(nd):
     )
 
 
+def _merge_nested_diags(keeper, exp_list, prefix_to_runs, runs_to_prefixes):
+    """Merge the directives nested inside the expansion blocks in
+    *exp_list*, installing the result as *keeper*'s nested lines.
+
+    Directives from every block in the group are pooled, so one that
+    appears in several blocks collapses into a single directive whose
+    prefix covers all of their runs.  Directives that appear only once, or
+    whose prefixes have no single replacement, are kept as they are.
+
+    Returns True if any directives were actually merged.
+    """
+    all_nested = []
+    for d in exp_list:
+        all_nested.extend(d.nested_lines)
+
+    # Group nested diags by overlap key within the expansion.
+    nested_groups = {}
+    for nl in all_nested:
+        nested_groups.setdefault(_nested_diag_key(nl.diag), []).append(nl)
+
+    merged = False
+    merged_nested = []
+    for nl_list in nested_groups.values():
+        if len(nl_list) > 1:
+            np = _find_merge_prefix(
+                [nl.diag.prefix for nl in nl_list],
+                prefix_to_runs, runs_to_prefixes)
+            if np is not None:
+                nl_list[0].diag.prefix = np
+                merged_nested.append(nl_list[0])
+                merged = True
+                continue
+        # Single diag or unmergeable — keep all.
+        merged_nested.extend(nl_list)
+
+    if not merged and len(exp_list) == 1:
+        # Nothing changed, so leave the block's nested lines alone rather
+        # than reordering them gratuitously.
+        return False
+
+    # Sort by target line within expansion, then by category for
+    # stability.
+    merged_nested.sort(
+        key=lambda nl: (nl.diag.absolute_target(), nl.diag.category))
+
+    keeper.nested_lines = merged_nested
+    for i, nl in enumerate(keeper.nested_lines):
+        nl.line_n = i + 1
+    return merged
+
+
 def _merge_expansion_groups(expansion_diags, prefix_to_runs,
                             runs_to_prefixes, lines):
     """Merge expansion blocks that target the same source location.
@@ -2367,6 +2418,10 @@ def _merge_expansion_groups(expansion_diags, prefix_to_runs,
     nested directives are individually merged where an appropriate prefix
     exists; non-overlapping nested directives are kept with their original
     prefix.
+
+    Blocks that stay separate — because a location has only one block, or
+    because the group's prefixes have no single replacement — still get
+    their own contents minimized.
     """
     # Group by (absolute_target, col).
     groups = {}
@@ -2375,56 +2430,27 @@ def _merge_expansion_groups(expansion_diags, prefix_to_runs,
         groups.setdefault(key, []).append(d)
 
     changed = False
-    for key, exp_list in groups.items():
-        if len(exp_list) < 2:
-            continue
-
+    for exp_list in groups.values():
         # Find a prefix for the merged expansion block.
-        exp_prefix = _find_merge_prefix(
-            [d.prefix for d in exp_list], prefix_to_runs, runs_to_prefixes)
+        exp_prefix = None
+        if len(exp_list) > 1:
+            exp_prefix = _find_merge_prefix(
+                [d.prefix for d in exp_list], prefix_to_runs,
+                runs_to_prefixes)
+
         if exp_prefix is None:
+            # The blocks stay separate, so pooling their contents would
+            # move directives from one block into another.  Minimize each
+            # block's own contents instead.
+            for d in exp_list:
+                changed |= _merge_nested_diags(
+                    d, [d], prefix_to_runs, runs_to_prefixes)
             continue
 
         keeper = _pick_keeper(exp_list)
-
-        # Collect all nested lines from every block in the group.
-        all_nested = []
-        for d in exp_list:
-            all_nested.extend(d.nested_lines)
-
-        # Group nested diags by overlap key within the expansion.
-        nested_groups = {}
-        for nl in all_nested:
-            if not nl.diag:
-                continue
-            nk = _nested_diag_key(nl.diag)
-            nested_groups.setdefault(nk, []).append(nl)
-
-        # Merge overlapping nested diags where possible.
-        merged_nested = []
-        for nk, nl_list in nested_groups.items():
-            if len(nl_list) > 1:
-                np = _find_merge_prefix(
-                    [nl.diag.prefix for nl in nl_list],
-                    prefix_to_runs, runs_to_prefixes)
-                if np is not None:
-                    nl_list[0].diag.prefix = np
-                    merged_nested.append(nl_list[0])
-                    continue
-            # Single diag or unmergeable — keep all.
-            merged_nested.extend(nl_list)
-
-        # Sort by target line within expansion, then by category for
-        # stability.
-        merged_nested.sort(
-            key=lambda nl: (nl.diag.absolute_target() if nl.diag else 0,
-                            nl.diag.category if nl.diag else ""))
-
-        # Install merged content into the keeper.
+        _merge_nested_diags(keeper, exp_list, prefix_to_runs,
+                            runs_to_prefixes)
         keeper.prefix = exp_prefix
-        keeper.nested_lines = merged_nested
-        for i, nl in enumerate(keeper.nested_lines):
-            nl.line_n = i + 1
 
         # Remove the other expansion blocks from `lines`.
         for d in exp_list:

--- a/utils/update_verify_tests/core.py
+++ b/utils/update_verify_tests/core.py
@@ -2167,3 +2167,214 @@ def check_expectations(tool_output, prefix):
         return update_test_files(top_level, prefix, unparsed_files)
     else:
         return ("no mismatching diagnostics found", None)
+
+
+# ---------------------------------------------------------------------------
+# minimize-verify-tests: merge redundant prefixed expected-* directives
+# ---------------------------------------------------------------------------
+
+# Regex to extract `-verify-additional-prefix <prefix>` from a RUN command.
+_additional_prefix_re = re.compile(r"-verify-additional-prefix\s+(\S+)")
+
+# Detects that a RUN command involves the diagnostic verifier.  Matches
+# `-verify` as a standalone flag (not part of `-verify-additional-prefix`,
+# `-verify-ignore-unrelated`, etc.) or known lit substitutions that imply it.
+_verify_flag_re = re.compile(
+    r"(?:-verify(?![-\w])|%-*target-typecheck-verify-swift\b|"
+    r"%-*target-swift-frontend-verify\b)"
+)
+
+
+def _parse_run_lines(raw_lines):
+    """Return a list of full RUN-line command strings with continuations
+    joined.  Each entry is a single logical RUN command."""
+    runs = []
+    current = None
+    for raw in raw_lines:
+        text = raw.rstrip("\n")
+        m = re.match(r"^\s*//\s*RUN:\s*(.*)", text)
+        if m:
+            part = m.group(1)
+            if current is not None:
+                current += " " + part
+            else:
+                current = part
+            if current.endswith("\\"):
+                current = current[:-1]
+            else:
+                runs.append(current)
+                current = None
+        else:
+            if current is not None:
+                runs.append(current)
+                current = None
+    if current is not None:
+        runs.append(current)
+    return runs
+
+
+def _collect_verify_prefixes(raw_lines):
+    """Parse every verify-RUN line and return two structures:
+
+    * ``run_prefixes``: a list of ``frozenset`` where each element is the
+      set of active prefixes for that verify-RUN line (always includes the
+      default ``""``).
+    * ``prefix_to_runs``: a dict mapping each prefix to the
+      ``frozenset`` of verify-RUN indices where it is active.
+
+    Non-verify RUN lines are silently skipped.
+    """
+    commands = _parse_run_lines(raw_lines)
+    run_prefixes = []
+    for cmd in commands:
+        if not _verify_flag_re.search(cmd):
+            continue
+        prefixes = {""}
+        for m in _additional_prefix_re.finditer(cmd):
+            prefixes.add(m.group(1))
+        run_prefixes.append(frozenset(prefixes))
+
+    prefix_to_runs = {}
+    for run_idx, pset in enumerate(run_prefixes):
+        for p in pset:
+            prefix_to_runs.setdefault(p, set()).add(run_idx)
+    # Freeze the sets so they are hashable / easily comparable.
+    prefix_to_runs = {p: frozenset(s) for p, s in prefix_to_runs.items()}
+    return run_prefixes, prefix_to_runs
+
+
+def _overlap_key(diag):
+    """Return a hashable key that groups directives which could potentially
+    be merged: same target line, same category, same content, same count,
+    same regex flag, and same fix-it annotations."""
+    return (
+        diag.absolute_target(),
+        diag.category,
+        diag.diag_content,
+        diag.count,
+        diag.is_re,
+        diag.fixits_raw_str,
+    )
+
+
+def _pick_keeper(diags):
+    """From a list of mergeable ``Diag`` objects choose the one to keep.
+
+    Preference order:
+    1. On the same line as the target (relative offset 0) — avoids ``@+N``.
+    2. Closest to the target (smallest absolute relative offset).
+    3. Earliest in the file (smallest ``line.line_n``).
+    """
+    def sort_key(d):
+        rel = abs(d.relative_target())
+        return (rel != 0, rel, d.line.line_n)
+
+    return min(diags, key=sort_key)
+
+
+def minimize_verify_test(filename):
+    """Read *filename*, merge redundant prefixed expected-* directives where
+    a single prefix can replace a set of overlapping ones, and write the
+    result back.  Returns an error string on failure, or ``None`` on
+    success."""
+    with open(filename, "r") as f:
+        raw_lines = f.readlines()
+
+    run_prefixes, prefix_to_runs = _collect_verify_prefixes(raw_lines)
+    if not run_prefixes:
+        return None  # no verify-RUN lines — nothing to do
+
+    # Build the inverse mapping: frozenset-of-runs → list of prefixes that
+    # cover exactly that set.
+    runs_to_prefixes = {}
+    for pfx, rset in prefix_to_runs.items():
+        runs_to_prefixes.setdefault(rset, []).append(pfx)
+
+    lines = [Line(line, i + 1) for i, line in enumerate(raw_lines + [""])]
+    orig_lines = list(lines)
+
+    # Parse every expected-* directive (all prefixes).
+    expansion_context = []
+    all_diags = []
+    for line in lines:
+        diag = parse_diag(line, filename, "", all_prefixes=True)
+        if diag:
+            line.diag = diag
+            if isinstance(diag, ExpansionDiagClose):
+                if expansion_context:
+                    diag.parent = expansion_context[-1]
+                    expansion_context.pop()
+            elif diag.category == "expansion":
+                if expansion_context:
+                    diag.parent = expansion_context[-1]
+                else:
+                    diag.set_target(lines[diag.absolute_target() - 1])
+                expansion_context.append(diag)
+            else:
+                if expansion_context:
+                    diag.parent = expansion_context[-1]
+                else:
+                    diag.set_target(lines[diag.absolute_target() - 1])
+                all_diags.append(diag)
+
+    # Group by overlap key.
+    groups = {}
+    for diag in all_diags:
+        key = _overlap_key(diag)
+        groups.setdefault(key, []).append(diag)
+
+    changed = False
+    # Process each group that has more than one directive.
+    for key, diag_list in groups.items():
+        if len(diag_list) < 2:
+            continue
+
+        # All prefixes in the group must be known to the RUN-line map.
+        # Directives whose prefix is not mentioned in any RUN line cannot
+        # be reasoned about; skip the group.
+        coverage = set()
+        skip = False
+        for d in diag_list:
+            rset = prefix_to_runs.get(d.prefix)
+            if rset is None:
+                skip = True
+                break
+            coverage |= rset
+        if skip:
+            continue
+        coverage = frozenset(coverage)
+
+        # Is there a prefix that covers exactly this set of runs?
+        candidates = runs_to_prefixes.get(coverage)
+        if not candidates:
+            continue
+
+        # Prefer the default prefix when possible; otherwise pick the
+        # shortest candidate (arbitrary but stable).
+        if "" in candidates:
+            merge_prefix = ""
+        else:
+            merge_prefix = min(candidates, key=lambda p: (len(p), p))
+
+        # If one of the diags already uses the merge prefix, we'd end up
+        # keeping it and removing the others.  Make sure we don't create a
+        # duplicate by checking whether there's already a surviving diag
+        # with the merge prefix at this location outside this group.
+        # (In a well-formed passing test this shouldn't happen, but be
+        # safe.)
+
+        keeper = _pick_keeper(diag_list)
+        keeper.prefix = merge_prefix
+        for d in diag_list:
+            if d is keeper:
+                continue
+            if d.target is not None:
+                d.unset_target()
+            remove_line(d.line, lines)
+        changed = True
+
+    if changed:
+        with open(filename, "w") as f:
+            for line in lines:
+                f.write(line.render())
+    return None


### PR DESCRIPTION
Add a new entry point minimize_verify_test() to utils/update_verify_tests/core.py
that takes an already-passing -verify test file and merges overlapping
expected-* directives. For each RUN line it collects the active verify
prefixes (default + -verify-additional-prefix values), then finds
directives that point to the same location with the same category,
content, count, and fix-its but differ in prefix. When a single prefix
exists that is active in exactly the union of RUN lines covered by the
overlapping set, the directives are merged into one using that prefix.

This tool is not (yet?) included as part of the update-verify-tests lit plugin and
has to be run as a standalone tool.