### PR TITLE
[ClangImporter] pass valid source loc when emitting modularization error

### DIFF
--- a/lib/ClangImporter/ClangSynthesizedDecls.h
+++ b/lib/ClangImporter/ClangSynthesizedDecls.h
@@ -34,8 +34,9 @@ inline clang::DeclRefExpr *
 createClangDeclRefExpr(clang::ASTContext &ctx, clang::ValueDecl *decl,
                        clang::QualType type,
                        clang::ExprValueKind vk = clang::VK_PRValue) {
-  return new (ctx) clang::DeclRefExpr(ctx, decl, false, type, vk,
-                                      clang::SourceLocation());
+  decl->setIsUsed();
+  return new (ctx)
+      clang::DeclRefExpr(ctx, decl, false, type, vk, decl->getLocation());
 }
 
 inline clang::ReturnStmt *createClangReturnStmt(clang::ASTContext &ctx,

--- a/test/Interop/Cxx/foreign-reference/virtual-method-hidden-param-type.swift
+++ b/test/Interop/Cxx/foreign-reference/virtual-method-hidden-param-type.swift
@@ -2,8 +2,10 @@
 // RUN: split-file %s %t
 
 // Module forgets to re-export the module defining the parameter type.
-// RUN: not --crash %target-swift-frontend -typecheck -I %t%{fs-sep}Inputs -I %t%{fs-sep}FailingInputs \
-// RUN:   -cxx-interoperability-mode=default -verify -verify-additional-prefix modularization-failure- %t/test.swift
+// RUN: %target-swift-frontend -typecheck -I %t%{fs-sep}Inputs -I %t%{fs-sep}FailingInputs \
+// RUN:   -cxx-interoperability-mode=default -verify -verify-additional-prefix modularization-failure- \
+// RUN:   -verify-additional-file %t%{fs-sep}FailingInputs%{fs-sep}test.h \
+// RUN:   -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}foo.h %t/test.swift
 
 // Same header contents, same Swift contents - only module re-export differs.
 // RUN: cp %t/FailingInputs/test.h %t/PassingInputs/test.h
@@ -11,15 +13,12 @@
 // RUN: %target-swift-frontend -typecheck -I %t%{fs-sep}Inputs -I %t%{fs-sep}PassingInputs \
 // RUN:   -cxx-interoperability-mode=default %t/test.swift -verify
 
-// When importing the incorrectly modularized header ClangImporter crashes when
-// trying to create a thunk:
-// Assertion failed: ((M->isGlobalModule() || Loc.isValid()) &&
-// "setVisible expects a valid import location"), function setVisible
-//
-// The assertion only fires when the method is virtual (no thunk is synthesized
-// otherwise), when the enclosing type is a foreign reference type (value types
-// need no thunk either), and when the method has a body in the header (a call
-// to a declaration does not need the parameter type to be complete).
+// Importing a virtual method of a foreign reference type synthesizes a C++
+// thunk that calls the method, and building that call requires the parameter
+// type to be complete. When the header is incorrectly modularized the
+// definition of the parameter type is not reachable from the client, which is
+// diagnosed as a modularization failure. This exercises a path that used to
+// crash when emitting the error.
 
 //--- Inputs/module.modulemap
 module Foo {
@@ -28,6 +27,7 @@ module Foo {
 }
 
 //--- Inputs/foo.h
+// expected-modularization-failure-note@+1{{definition here is not reachable}}
 struct Foo { };
 
 //--- FailingInputs/module.modulemap
@@ -49,6 +49,7 @@ struct __attribute__((swift_attr("import_reference")))
 __attribute__((swift_attr("retain:immortal")))
 __attribute__((swift_attr("release:immortal"))) Base {
   // This function decl needs to be a definition to reproduce.
+  // expected-modularization-failure-error@+1{{definition of 'Foo' must be imported from module 'Foo' before it is required}}
   virtual void takeFoo(Foo values) {}
 };
 

--- a/test/Interop/Cxx/foreign-reference/virtual-method-hidden-param-type.swift
+++ b/test/Interop/Cxx/foreign-reference/virtual-method-hidden-param-type.swift
@@ -1,0 +1,61 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// Module forgets to re-export the module defining the parameter type.
+// RUN: not --crash %target-swift-frontend -typecheck -I %t%{fs-sep}Inputs -I %t%{fs-sep}FailingInputs \
+// RUN:   -cxx-interoperability-mode=default -verify -verify-additional-prefix modularization-failure- %t/test.swift
+
+// Same header contents, same Swift contents - only module re-export differs.
+// RUN: cp %t/FailingInputs/test.h %t/PassingInputs/test.h
+
+// RUN: %target-swift-frontend -typecheck -I %t%{fs-sep}Inputs -I %t%{fs-sep}PassingInputs \
+// RUN:   -cxx-interoperability-mode=default %t/test.swift -verify
+
+// When importing the incorrectly modularized header ClangImporter crashes when
+// trying to create a thunk:
+// Assertion failed: ((M->isGlobalModule() || Loc.isValid()) &&
+// "setVisible expects a valid import location"), function setVisible
+//
+// The assertion only fires when the method is virtual (no thunk is synthesized
+// otherwise), when the enclosing type is a foreign reference type (value types
+// need no thunk either), and when the method has a body in the header (a call
+// to a declaration does not need the parameter type to be complete).
+
+//--- Inputs/module.modulemap
+module Foo {
+  header "foo.h"
+  requires cplusplus
+}
+
+//--- Inputs/foo.h
+struct Foo { };
+
+//--- FailingInputs/module.modulemap
+module Test {
+  header "test.h"
+  requires cplusplus
+}
+//--- PassingInputs/module.modulemap
+module Test {
+  header "test.h"
+  requires cplusplus
+  export Foo
+}
+
+//--- FailingInputs/test.h
+#include "foo.h"
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:immortal")))
+__attribute__((swift_attr("release:immortal"))) Base {
+  // This function decl needs to be a definition to reproduce.
+  virtual void takeFoo(Foo values) {}
+};
+
+//--- test.swift
+import Test
+
+@available(SwiftStdlib 5.8, *)
+func test(_ base: Base) {
+  _ = base.takeFoo
+}

--- a/test/Interop/Cxx/foreign-reference/virtual-method-hidden-param-type.swift
+++ b/test/Interop/Cxx/foreign-reference/virtual-method-hidden-param-type.swift
@@ -11,7 +11,7 @@
 // RUN: cp %t/FailingInputs/test.h %t/PassingInputs/test.h
 
 // RUN: %target-swift-frontend -typecheck -I %t%{fs-sep}Inputs -I %t%{fs-sep}PassingInputs \
-// RUN:   -cxx-interoperability-mode=default %t/test.swift -verify
+// RUN:   -cxx-interoperability-mode=default %t%{fs-sep}test.swift -verify
 
 // Importing a virtual method of a foreign reference type synthesizes a C++
 // thunk that calls the method, and building that call requires the parameter

--- a/test/Interop/Cxx/foreign-reference/virtual-method-hidden-param-type.swift
+++ b/test/Interop/Cxx/foreign-reference/virtual-method-hidden-param-type.swift
@@ -3,7 +3,8 @@
 
 // Module forgets to re-export the module defining the parameter type.
 // RUN: %target-swift-frontend -typecheck -I %t%{fs-sep}Inputs -I %t%{fs-sep}FailingInputs \
-// RUN:   -cxx-interoperability-mode=default -verify -verify-additional-prefix modularization-failure- \
+// RUN:   -cxx-interoperability-mode=default -disable-objc-interop \
+// RUN:   -verify -verify-additional-prefix modularization-failure- \
 // RUN:   -verify-additional-file %t%{fs-sep}FailingInputs%{fs-sep}test.h \
 // RUN:   -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}foo.h %t/test.swift
 
@@ -11,7 +12,7 @@
 // RUN: cp %t/FailingInputs/test.h %t/PassingInputs/test.h
 
 // RUN: %target-swift-frontend -typecheck -I %t%{fs-sep}Inputs -I %t%{fs-sep}PassingInputs \
-// RUN:   -cxx-interoperability-mode=default %t%{fs-sep}test.swift -verify
+// RUN:   -cxx-interoperability-mode=default -disable-objc-interop %t%{fs-sep}test.swift -verify
 
 // Importing a virtual method of a foreign reference type synthesizes a C++
 // thunk that calls the method, and building that call requires the parameter
@@ -49,7 +50,7 @@ struct __attribute__((swift_attr("import_reference")))
 __attribute__((swift_attr("retain:immortal")))
 __attribute__((swift_attr("release:immortal"))) Base {
   // This function decl needs to be a definition to reproduce.
-  // expected-modularization-failure-error@+1{{definition of 'Foo' must be imported from module 'Foo' before it is required}}
+  // expected-modularization-failure-error@+1{{missing '#include "foo.h"'; 'Foo' must be defined before it is used}}
   virtual void takeFoo(Foo values) {}
 };
 


### PR DESCRIPTION
When creating a clang::DeclRef to a decl in a context where that decl is
unavailable, clang automatically emits a modularization error
diagnostic. When emitting a thunk for a virtual function this would
crash, because we were not passing a valid source location. After
passing a valid source location we'd get a crash in clang's codegen
because EmitDeclRefLValue would no longer skip its check that the decl
was marked used, so this also marks the decl as used.

rdar://183784754