### PR TITLE
AST: Synthesize @available attributes for declarations in availability scopes

### DIFF
--- a/include/swift/AST/AvailabilityContext.h
+++ b/include/swift/AST/AvailabilityContext.h
@@ -160,6 +160,14 @@ public:
   /// Returns true if `other` is as available or is more available.
   bool isContainedIn(const AvailabilityContext other) const;
 
+  /// Creates implicit `@available` attributes describing the availability
+  /// restrictions that this context imposes relative to \p other and appends
+  /// them to \p attrs. Restrictions that cannot be expressed as attributes are
+  /// omitted.
+  void createImplicitAvailableAttrs(
+      const AvailabilityContext &other, ASTContext &ctx,
+      llvm::SmallVectorImpl<AvailableAttr *> &attrs) const;
+
   friend bool operator==(const AvailabilityContext &lhs,
                          const AvailabilityContext &rhs) {
     return lhs.storage == rhs.storage;

--- a/include/swift/AST/AvailabilityScope.h
+++ b/include/swift/AST/AvailabilityScope.h
@@ -209,7 +209,8 @@ private:
 
   AvailabilityScope *findMostRefinedSubContextImpl(
       SourceLoc Loc, ASTContext &Ctx,
-      llvm::SmallVectorImpl<AvailabilityScope *> *ScopeStack);
+      llvm::SmallVectorImpl<AvailabilityScope *> *ScopeStack,
+      ASTNode stopAtASTNode);
 
   AvailabilityScope(ASTContext &Ctx, IntroNode Node, AvailabilityScope *Parent,
                     SourceRange SrcRange, const AvailabilityContext Info);
@@ -296,6 +297,14 @@ public:
   /// Returns the reason this scope was introduced.
   Reason getReason() const;
 
+  /// Returns the AST node that introduced this scope, or a null `ASTNode` if
+  /// the node cannot be represented as one.
+  ASTNode getASTNode() const;
+
+  /// Returns true if this scope was introduced by a statement, as opposed to a
+  /// declaration or the root of a source file.
+  bool isIntroducedByStmt() const;
+
   /// Returns the AST node that introduced this availability scope. Note that
   /// this node may be different than the refined range. For example, an
   /// availability scope covering an IfStmt Then branch will have the
@@ -340,8 +349,13 @@ public:
   void addChild(AvailabilityScope *Child, ASTContext &Ctx);
 
   /// Returns the innermost AvailabilityScope descendant of this scope
-  /// for the given source location.
-  AvailabilityScope *findMostRefinedSubContext(SourceLoc Loc, ASTContext &Ctx);
+  /// for the given source location. If \p stopAtASTNode is non-null, scopes
+  /// that were introduced by that node are not descended into (or expanded), so
+  /// the result describes the availability of the position \p stopAtASTNode
+  /// appears in rather than the availability that it introduces.
+  AvailabilityScope *
+  findMostRefinedSubContext(SourceLoc Loc, ASTContext &Ctx,
+                            ASTNode stopAtASTNode = ASTNode());
 
   /// Like `findMostRefinedSubContext()`, but also populates \p ScopeStack with
   /// the chain of scopes that contain \p Loc, ordered outermost first and
@@ -349,7 +363,8 @@ public:
   /// enclosing scopes of the result.
   AvailabilityScope *findMostRefinedSubContext(
       SourceLoc Loc, ASTContext &Ctx,
-      llvm::SmallVectorImpl<AvailabilityScope *> &ScopeStack);
+      llvm::SmallVectorImpl<AvailabilityScope *> &ScopeStack,
+      ASTNode stopAtASTNode = ASTNode());
 
   bool getNeedsExpansion() const { return LazyInfo.needsExpansion; }
 

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -4458,6 +4458,26 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Synthesizes the implicit `@available` attributes that are implied by the
+/// availability scopes that contain a declaration in a local context, attaching
+/// them to the declaration as a side effect.
+class SynthesizeLocalAvailableAttrsRequest
+    : public SimpleRequest<SynthesizeLocalAvailableAttrsRequest,
+                           evaluator::SideEffect(Decl *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  evaluator::SideEffect evaluate(Evaluator &evaluator, Decl *decl) const;
+
+public:
+  bool isCached() const { return true; }
+  static bool appliesTo(const Decl *decl);
+};
+
 class ClosureEffectsRequest
     : public SimpleRequest<ClosureEffectsRequest,
                            FunctionType::ExtInfo(ClosureExpr *),

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -510,6 +510,9 @@ SWIFT_REQUEST(TypeChecker, RenamedDeclRequest,
 SWIFT_REQUEST(TypeChecker, DeclRuntimeAvailabilityRequest,
               DeclRuntimeAvailability(const Decl *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, SynthesizeLocalAvailableAttrsRequest,
+              evaluator::SideEffect(Decl *),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ClosureEffectsRequest,
               FunctionType::ExtInfo(ClosureExpr *),
               Cached, NoLocationInfo)

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -20,12 +20,13 @@
 #include "swift/AST/AvailabilityDomain.h"
 #include "swift/AST/AvailabilityInference.h"
 #include "swift/AST/AvailabilityRange.h"
+#include "swift/AST/AvailabilityScope.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DeclExportabilityVisitor.h"
-// FIXME: [availability] Remove this when possible
-#include "swift/AST/DiagnosticsParse.h"
 #include "swift/AST/DiagnosticsSema.h"
+#include "swift/AST/Module.h"
 #include "swift/AST/PlatformKindUtils.h"
+#include "swift/AST/SourceFile.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/TypeWalker.h"
 #include "swift/AST/Types.h"
@@ -288,6 +289,95 @@ bool Decl::isAvailableAsSPI() const {
   return false;
 }
 
+bool SynthesizeLocalAvailableAttrsRequest::appliesTo(const Decl *decl) {
+  // Only a declaration in a local context can be covered by an availability
+  // scope that isn't already accounted for by the availability of a parent
+  // declaration.
+  if (!decl->getDeclContext()->isLocalContext())
+    return false;
+
+  // The storage for a local variable is emitted as part of its enclosing
+  // function, and a use of the variable that precedes its declaration is
+  // rejected, so every reference to it is already inside the region that the
+  // attributes would describe.
+  if (isa<AbstractStorageDecl>(decl) || isa<PatternBindingDecl>(decl))
+    return false;
+
+  // The accessors for local variables, on the other hand, need implicit
+  // availability to control whether they get emitted as independent functions
+  // by SILGen.
+  if (isa<AccessorDecl>(decl))
+    return true;
+
+  // Implicit declarations should generally be synthesized with appropriate
+  // availability.
+  return !decl->isImplicit();
+}
+
+evaluator::SideEffect
+SynthesizeLocalAvailableAttrsRequest::evaluate(Evaluator &evaluator,
+                                               Decl *decl) const {
+  DEBUG_ASSERT(appliesTo(decl));
+
+  auto loc = decl->getSourceRangeIncludingAttrs().Start;
+  if (loc.isInvalid())
+    return {};
+
+  auto &ctx = decl->getASTContext();
+  auto *sf = decl->getDeclContext()
+                 ->getParentModule()
+                 ->getSourceFileContainingLocation(loc);
+  if (!sf)
+    return {};
+
+  auto *rootScope = AvailabilityScope::getOrBuildForSourceFile(*sf);
+  if (!rootScope)
+    return {};
+
+  // Find the scope that describes the availability of the position that the
+  // declaration appears in. Scopes introduced by the declaration itself are
+  // excluded since the restrictions they describe are the ones that are already
+  // written on the declaration.
+  ASTNode stopAtNode =
+      const_cast<Decl *>(decl->getConcreteSyntaxDeclForAttributes());
+  llvm::SmallVector<AvailabilityScope *, 8> scopeStack;
+  auto *scope =
+      rootScope->findMostRefinedSubContext(loc, ctx, scopeStack, stopAtNode);
+  if (!scope)
+    return {};
+
+  // Find the innermost enclosing scope that a declaration introduced. The
+  // restrictions that it and the scopes above it describe are already inherited
+  // from that declaration.
+  AvailabilityScope *declScope = scopeStack.front();
+  for (auto [parent, candidate] :
+       llvm::zip_first(llvm::drop_begin(llvm::reverse(scopeStack)),
+                       llvm::reverse(scopeStack))) {
+    // A scope that does not refine the availability of its parent, like the
+    // placeholder that lazy expansion leaves behind for a declaration, does not
+    // describe a restriction of its own.
+    if (candidate->getAvailabilityContext() == parent->getAvailabilityContext())
+      continue;
+
+    if (!candidate->isIntroducedByStmt()) {
+      declScope = candidate;
+      break;
+    }
+  }
+
+  if (declScope == scope)
+    return {};
+
+  llvm::SmallVector<AvailableAttr *, 4> attrs;
+  scope->getAvailabilityContext().createImplicitAvailableAttrs(
+      declScope->getAvailabilityContext(), ctx, attrs);
+
+  for (auto *attr : attrs)
+    decl->getAttrs().add(attr);
+
+  return {};
+}
+
 SemanticAvailableAttributes
 Decl::getSemanticAvailableAttrs(bool includeInactive) const {
   // A decl in an @abi gets its availability from the decl it's attached to.
@@ -297,6 +387,14 @@ Decl::getSemanticAvailableAttrs(bool includeInactive) const {
 
   // Apply file defaults for availability attributes.
   const_cast<Decl *>(this)->applyFileDefaults();
+
+  // Synthesize the attributes that are implied by the availability scopes
+  // containing a declaration in a local context.
+  if (SynthesizeLocalAvailableAttrsRequest::appliesTo(this)) {
+    evaluateOrDefault(
+        getASTContext().evaluator,
+        SynthesizeLocalAvailableAttrsRequest{const_cast<Decl *>(this)}, {});
+  }
 
   // We assume all requests that add attributes as a side effect have been made.
   // Requesting ExpandMemberAttributeMacros or similar would be a cycle though,

--- a/lib/AST/AvailabilityContext.cpp
+++ b/lib/AST/AvailabilityContext.cpp
@@ -432,6 +432,73 @@ bool AvailabilityContext::isContainedIn(const AvailabilityContext other) const {
   return true;
 }
 
+/// Returns an implicit `@available` attribute that describes the restriction
+/// that \p domainInfo represents, or `nullptr` if the restriction cannot be
+/// expressed as an attribute.
+static AvailableAttr *
+createImplicitAvailableAttr(AvailabilityContext::DomainInfo domainInfo,
+                            ASTContext &ctx) {
+  auto domain = domainInfo.getDomain();
+  auto kind = AvailableAttr::Kind::Default;
+  llvm::VersionTuple introduced;
+
+  if (domainInfo.isUnavailable()) {
+    // FIXME: [availability] Disambiguate effective vs explicit unavailability.
+    // Regions that are @available(..., unavailable) need to be modeled
+    // separately from regions that are "known unreachable" in order to
+    // determine whether it is appropriate to add @available(..., unavailable)
+    // for a versioned domain.
+    if (domain.isVersioned())
+      return nullptr;
+
+    kind = AvailableAttr::Kind::Unavailable;
+  } else if (domain.isVersioned()) {
+    introduced = domainInfo.getRange().getRawMinimumVersion();
+  }
+
+  return new (ctx) AvailableAttr(
+      SourceLoc(), SourceRange(), domain, SourceLoc(), kind, /*Message=*/"",
+      /*Rename=*/"", introduced, /*IntroducedRange=*/SourceRange(),
+      /*Deprecated=*/{}, /*DeprecatedRange=*/SourceRange(),
+      /*Obsoleted=*/{}, /*ObsoletedRange=*/SourceRange(),
+      /*Implicit=*/true, /*IsSPI=*/false);
+}
+
+void AvailabilityContext::createImplicitAvailableAttrs(
+    const AvailabilityContext &other, ASTContext &ctx,
+    llvm::SmallVectorImpl<AvailableAttr *> &attrs) const {
+  auto platform = targetPlatform(ctx.LangOpts);
+  if (platform != PlatformKind::none) {
+    // Only describe the platform range if it is strictly narrower than the
+    // range that is already implied by `other`.
+    if (other.storage->platformRange.isSupersetOf(storage->platformRange)) {
+      if (auto *attr = createImplicitAvailableAttr(
+              DomainInfo(AvailabilityDomain::forPlatform(platform),
+                         storage->platformRange),
+              ctx))
+        attrs.push_back(attr);
+    }
+  }
+
+  for (auto domainInfo : storage->getDomainInfos()) {
+    auto domain = domainInfo.getDomain();
+    auto constrained = other;
+    // FIXME: [availability] This is inefficient.
+    if (domainInfo.isUnavailable()) {
+      constrained.constrainWithUnavailableDomain(domain, ctx);
+    } else {
+      constrained.constrainWithAvailabilityRange(domainInfo.getRange(), domain,
+                                                 ctx);
+    }
+
+    if (constrained == other)
+      continue;
+
+    if (auto *attr = createImplicitAvailableAttr(domainInfo, ctx))
+      attrs.push_back(attr);
+  }
+}
+
 std::optional<AvailabilityRestriction>
 AvailabilityContext::restrictionForDecl(const Decl *decl,
                                         AvailabilityRestrictionFlags flags) {

--- a/lib/AST/AvailabilityScope.cpp
+++ b/lib/AST/AvailabilityScope.cpp
@@ -271,10 +271,19 @@ void AvailabilityScope::addChild(AvailabilityScope *Child, ASTContext &Ctx) {
 
 AvailabilityScope *AvailabilityScope::findMostRefinedSubContextImpl(
     SourceLoc Loc, ASTContext &Ctx,
-    llvm::SmallVectorImpl<AvailabilityScope *> *ScopeStack) {
+    llvm::SmallVectorImpl<AvailabilityScope *> *ScopeStack,
+    ASTNode stopAtASTNode) {
   DEBUG_ASSERT(Loc.isValid());
 
   if (SrcRange.isValid() && !Ctx.SourceMgr.containsTokenLoc(SrcRange, Loc))
+    return nullptr;
+
+  // If this scope was introduced by the node that the caller is asking about,
+  // treat it as not containing the location. The caller wants the availability
+  // of the position that the node appears in, and expanding this scope may
+  // require querying the availability that the node introduces, which may be
+  // what triggered this lookup in the first place.
+  if (stopAtASTNode && getASTNode() == stopAtASTNode)
     return nullptr;
 
   (void)evaluateOrDefault(Ctx.evaluator,
@@ -295,8 +304,8 @@ AvailabilityScope *AvailabilityScope::findMostRefinedSubContextImpl(
   // Check whether the matching child or any of its descendants contain
   // the given location.
   if (iter != Children.end()) {
-    if (auto found =
-            (*iter)->findMostRefinedSubContextImpl(Loc, Ctx, ScopeStack))
+    if (auto found = (*iter)->findMostRefinedSubContextImpl(
+            Loc, Ctx, ScopeStack, stopAtASTNode))
       return found;
   }
 
@@ -306,14 +315,17 @@ AvailabilityScope *AvailabilityScope::findMostRefinedSubContextImpl(
 }
 
 AvailabilityScope *
-AvailabilityScope::findMostRefinedSubContext(SourceLoc Loc, ASTContext &Ctx) {
-  return findMostRefinedSubContextImpl(Loc, Ctx, /*ScopeStack=*/nullptr);
+AvailabilityScope::findMostRefinedSubContext(SourceLoc Loc, ASTContext &Ctx,
+                                             ASTNode stopAtASTNode) {
+  return findMostRefinedSubContextImpl(Loc, Ctx, /*ScopeStack=*/nullptr,
+                                       stopAtASTNode);
 }
 
 AvailabilityScope *AvailabilityScope::findMostRefinedSubContext(
     SourceLoc Loc, ASTContext &Ctx,
-    llvm::SmallVectorImpl<AvailabilityScope *> &ScopeStack) {
-  return findMostRefinedSubContextImpl(Loc, Ctx, &ScopeStack);
+    llvm::SmallVectorImpl<AvailabilityScope *> &ScopeStack,
+    ASTNode stopAtASTNode) {
+  return findMostRefinedSubContextImpl(Loc, Ctx, &ScopeStack, stopAtASTNode);
 }
 
 void AvailabilityScope::dump(SourceManager &SrcMgr) const {
@@ -323,6 +335,61 @@ void AvailabilityScope::dump(SourceManager &SrcMgr) const {
 void AvailabilityScope::dump(raw_ostream &OS, SourceManager &SrcMgr) const {
   print(OS, SrcMgr, 0);
   OS << '\n';
+}
+
+ASTNode AvailabilityScope::getASTNode() const {
+  switch (getReason()) {
+  case Reason::Root:
+    // A source file cannot be represented as an `ASTNode`.
+    return ASTNode();
+
+  case Reason::Decl:
+  case Reason::DeclImplicit:
+    return Node.getAsDecl();
+
+  case Reason::IfStmtThenBranch:
+  case Reason::IfStmtElseBranch:
+    return static_cast<Stmt *>(Node.getAsIfStmt());
+
+  case Reason::ConditionFollowingAvailabilityQuery:
+    return ASTNode();
+
+  case Reason::GuardStmtFallthrough:
+  case Reason::GuardStmtElseBranch:
+    return static_cast<Stmt *>(Node.getAsGuardStmt());
+
+  case Reason::WhileStmtBody:
+    return static_cast<Stmt *>(Node.getAsWhileStmt());
+
+  case Reason::SwitchStmt:
+    return static_cast<Stmt *>(Node.getAsSwitchStmt());
+
+  case Reason::SwitchStmtCaseBody:
+    return static_cast<Stmt *>(Node.getAsCaseStmt());
+  }
+
+  llvm_unreachable("Unhandled Reason in switch.");
+}
+
+bool AvailabilityScope::isIntroducedByStmt() const {
+  switch (getReason()) {
+  case Reason::Root:
+  case Reason::Decl:
+  case Reason::DeclImplicit:
+    return false;
+
+  case Reason::IfStmtThenBranch:
+  case Reason::IfStmtElseBranch:
+  case Reason::ConditionFollowingAvailabilityQuery:
+  case Reason::GuardStmtFallthrough:
+  case Reason::GuardStmtElseBranch:
+  case Reason::WhileStmtBody:
+  case Reason::SwitchStmt:
+  case Reason::SwitchStmtCaseBody:
+    return true;
+  }
+
+  llvm_unreachable("Unhandled Reason in switch.");
 }
 
 SourceLoc AvailabilityScope::getIntroductionLoc() const {

--- a/lib/AST/AvailabilityScopeBuilder.cpp
+++ b/lib/AST/AvailabilityScopeBuilder.cpp
@@ -331,6 +331,14 @@ private:
     if (isa<ExtensionDecl>(decl))
       return true;
 
+    // Declarations in local contexts may have availability attributes that are
+    // synthesized from the availability scopes that contain them (see
+    // SynthesizeLocalAvailableAttrsRequest). Expanding lazily ensures that
+    // building out the scopes for the enclosing function body does not query
+    // the availability of these declarations, which would be circular.
+    if (SynthesizeLocalAvailableAttrsRequest::appliesTo(decl))
+      return true;
+
     return false;
   }
 

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -335,7 +335,8 @@ void StmtEmitter::visitBraceStmt(BraceStmt *S) {
         // Other decls define entities that may be used by the program, such as
         // local function declarations. So handle them here, before checking for
         // reachability, and then continue looping.
-        SGF.visit(D);
+        if (!SGF.SGM.shouldSkipDecl(D))
+          SGF.visit(D);
         continue;
       }
     }

--- a/test/Availability/availability_custom_domains.swift
+++ b/test/Availability/availability_custom_domains.swift
@@ -285,6 +285,62 @@ func testUniversallyUnavailable() {
   if #unavailable(EnabledDomain) {} // FIXME: [availability] Diagnose?
 }
 
+func testLocalDeclsWithExplicitAvailability() {
+  // expected-note@-1 {{add '@available' attribute to enclosing global function}}
+  if #available(EnabledDomain) {
+    @available(DynamicDomain)
+    func restrictedInAnotherDomain() {
+      availableInEnabledDomain()
+      availableInDynamicDomain()
+    }
+
+    restrictedInAnotherDomain() // expected-error {{'restrictedInAnotherDomain()' is only available in DynamicDomain}}
+    // expected-note@-1 {{add 'if #available' version check}}
+
+    if #available(DynamicDomain) {
+      restrictedInAnotherDomain()
+    }
+
+    @available(EnabledDomain)
+    func redundantlyRestricted() {
+      availableInEnabledDomain()
+    }
+    redundantlyRestricted()
+
+    @available(EnabledDomain, unavailable)
+    func localUnavailableInEnabledDomain() { }
+    // expected-note@-1 2 {{'localUnavailableInEnabledDomain()' has been explicitly marked unavailable here}}
+    localUnavailableInEnabledDomain() // expected-error {{'localUnavailableInEnabledDomain()' is unavailable}}
+
+    if #unavailable(EnabledDomain) {
+      // FIXME: [availability] Should not be diagnosed
+      localUnavailableInEnabledDomain() // expected-error {{'localUnavailableInEnabledDomain()' is unavailable}}
+    }
+  }
+}
+
+func testLocalDeclsAfterGuard() { // expected-note 3 {{add '@available' attribute to enclosing global function}}
+  useAfterGuard() // expected-error {{'useAfterGuard()' is only available in EnabledDomain}}
+  // expected-note@-1 {{add 'if #available' version check}}
+  useAfterGuardInDynamicDomain() // expected-error {{'useAfterGuardInDynamicDomain()' is only available in EnabledDomain}}
+  // expected-note@-1 {{add 'if #available' version check}}
+
+  guard #available(EnabledDomain) else { return }
+
+  func useAfterGuard() {
+    availableInEnabledDomain()
+  }
+  useAfterGuard()
+
+  @available(DynamicDomain)
+  func useAfterGuardInDynamicDomain() {
+    availableInDynamicDomain()
+  }
+  useAfterGuardInDynamicDomain() // expected-error {{'useAfterGuardInDynamicDomain()' is only available in DynamicDomain}}
+  // expected-note@-1 {{add 'if #available' version check}}
+}
+
+
 @available(EnabledDomain)
 struct EnabledDomainAvailable {
   @available(DynamicDomain)

--- a/test/Availability/availability_scopes_custom_domains.swift
+++ b/test/Availability/availability_scopes_custom_domains.swift
@@ -24,3 +24,50 @@ func availableInAB() { }
 // CHECK: {{^}}  (decl version={{.*}} decl=deprecatedInA()
 @available(A, deprecated)
 func deprecatedInA() { }
+
+// CHECK: {{^}}  (condition_following_availability version={{.*}} available=A
+// CHECK-NEXT: {{^}}  (if_then version={{.*}} available=A
+// CHECK-NEXT: {{^}}    (decl_implicit version={{.*}} available=A decl=unannotatedFuncInIfThen()
+// CHECK-NEXT: {{^}}      (decl version={{.*}} available=A decl=unannotatedFuncInIfThen()
+// CHECK-NEXT: {{^}}    (decl_implicit version={{.*}} available=A decl=availableInBFuncInIfThen()
+// CHECK-NEXT: {{^}}      (decl version={{.*}} available=A,B decl=availableInBFuncInIfThen()
+// CHECK-NEXT: {{^}}    (decl_implicit version={{.*}} available=A decl=availableInAFuncInIfThen()
+// CHECK-NEXT: {{^}}      (decl version={{.*}} available=A decl=availableInAFuncInIfThen()
+// CHECK-NEXT: {{^}}    (decl_implicit version={{.*}} available=A decl=unavailableInAFuncInIfThen()
+// CHECK-NEXT: {{^}}      (decl version={{.*}} unavailable=A decl=unavailableInAFuncInIfThen()
+// CHECK-NEXT: {{^}}    (decl_implicit version={{.*}} available=A decl=AvailableInBStructInIfThen
+// CHECK-NEXT: {{^}}      (decl version={{.*}} available=A,B decl=AvailableInBStructInIfThen
+// CHECK-NEXT: {{^}}        (decl version={{.*}} available=B unavailable=A decl=unavailableInAMethod()
+// CHECK-NEXT: {{^}}  (condition_following_availability version={{.*}} available=A
+// CHECK-NEXT: {{^}}  (guard_else version={{.*}} unavailable=A
+// CHECK-NEXT: {{^}}  (guard_fallthrough version={{.*}} available=A
+// CHECK-NEXT: {{^}}    (decl_implicit version={{.*}} available=A decl=funcInGuardFallthrough()
+// CHECK-NEXT: {{^}}      (decl version={{.*}} available=A,B decl=funcInGuardFallthrough()
+
+func localDeclsInAvailabilityScopes() {
+  if #available(A) {
+    func unannotatedFuncInIfThen() { }
+
+    @available(B)
+    func availableInBFuncInIfThen() { }
+
+    @available(A)
+    func availableInAFuncInIfThen() { }
+
+    @available(A, unavailable)
+    func unavailableInAFuncInIfThen() { }
+
+    @available(B)
+    struct AvailableInBStructInIfThen {
+      func method() { }
+
+      @available(A, unavailable)
+      func unavailableInAMethod() { }
+    }
+  }
+
+  guard #available(A) else { return }
+
+  @available(B)
+  func funcInGuardFallthrough() { }
+}

--- a/test/Availability/availability_scopes_macos.swift
+++ b/test/Availability/availability_scopes_macos.swift
@@ -7,9 +7,11 @@
 
 // CHECK-NEXT: {{^}}  (decl version=51 decl=SomeClass
 // CHECK-NEXT: {{^}}    (decl version=52 decl=someMethod()
-// CHECK-NEXT: {{^}}      (decl version=53 decl=someInnerFunc()
-// CHECK-NEXT: {{^}}      (decl version=53 decl=InnerClass
-// CHECK-NEXT: {{^}}        (decl version=54 decl=innerClassMethod
+// CHECK-NEXT: {{^}}      (decl_implicit version=52 decl=someInnerFunc()
+// CHECK-NEXT: {{^}}        (decl version=53 decl=someInnerFunc()
+// CHECK-NEXT: {{^}}      (decl_implicit version=52 decl=InnerClass
+// CHECK-NEXT: {{^}}        (decl version=53 decl=InnerClass
+// CHECK-NEXT: {{^}}          (decl version=54 decl=innerClassMethod
 // CHECK-NEXT: {{^}}    (decl_implicit version=51 decl=someStaticProperty
 // CHECK-NEXT: {{^}}      (decl version=52 decl=someStaticProperty
 // CHECK-NEXT: {{^}}    (decl_implicit version=51 decl=someStaticPropertyInferredType
@@ -89,12 +91,15 @@ extension SomeClass {
 // CHECK-NEXT: {{^}}      (condition_following_availability version=54
 // CHECK-NEXT: {{^}}      (if_then version=54
 // CHECK-NEXT: {{^}}        (condition_following_availability version=55
-// CHECK-NEXT: {{^}}        (decl version=55 decl=funcInGuardElse()
+// CHECK-NEXT: {{^}}        (decl_implicit version=54 decl=funcInGuardElse()
+// CHECK-NEXT: {{^}}          (decl version=55 decl=funcInGuardElse()
 // CHECK-NEXT: {{^}}        (guard_fallthrough version=55
 // CHECK-NEXT: {{^}}          (condition_following_availability version=56
 // CHECK-NEXT: {{^}}          (guard_fallthrough version=56
-// CHECK-NEXT: {{^}}      (decl version=57 decl=funcInInnerIfElse()
-// CHECK-NEXT: {{^}}    (decl version=53 decl=funcInOuterIfElse()
+// CHECK-NEXT: {{^}}      (decl_implicit version=53 decl=funcInInnerIfElse()
+// CHECK-NEXT: {{^}}        (decl version=57 decl=funcInInnerIfElse()
+// CHECK-NEXT: {{^}}    (decl_implicit version=51 decl=funcInOuterIfElse()
+// CHECK-NEXT: {{^}}      (decl version=53 decl=funcInOuterIfElse()
 @available(OSX 51, *)
 func functionWithStmtCondition() {
   if #available(OSX 52, *),
@@ -148,7 +153,8 @@ func functionWithUnnecessaryStmtCondition() {
 
 // CHECK-NEXT: {{^}}  (decl version=51 decl=functionWithUnnecessaryStmtConditionsHavingElseBranch
 // CHECK-NEXT: {{^}}    (if_else version=none
-// CHECK-NEXT: {{^}}      (decl version=none decl=funcInInnerIfElse()
+// CHECK-NEXT: {{^}}      (decl_implicit version=none decl=funcInInnerIfElse()
+// CHECK-NEXT: {{^}}        (decl version=none decl=funcInInnerIfElse()
 // CHECK-NEXT: {{^}}    (if_else version=none
 // CHECK-NEXT: {{^}}    (guard_else version=none
 // CHECK-NEXT: {{^}}    (guard_else version=none
@@ -202,7 +208,8 @@ func functionWithUnnecessaryStmtConditionsHavingElseBranch(p: Int?) {
 // CHECK-NEXT: {{^}}  (decl version=51 decl=functionWithWhile()
 // CHECK-NEXT: {{^}}    (condition_following_availability version=52
 // CHECK-NEXT: {{^}}    (while_body version=52
-// CHECK-NEXT: {{^}}      (decl version=54 decl=funcInWhileBody()
+// CHECK-NEXT: {{^}}      (decl_implicit version=52 decl=funcInWhileBody()
+// CHECK-NEXT: {{^}}        (decl version=54 decl=funcInWhileBody()
 @available(OSX 51, *)
 func functionWithWhile() {
   while #available(OSX 52, *),
@@ -260,12 +267,15 @@ extension SomeClass {
 // CHECK-NEXT: {{^}}          (condition_following_availability version=54 unavailable=macOS
 // CHECK-NEXT: {{^}}          (if_then version=54 unavailable=macOS
 // CHECK-NEXT: {{^}}            (condition_following_availability version=55 unavailable=macOS
-// CHECK-NEXT: {{^}}            (decl version=54 unavailable=macOS decl=funcInGuardElse()
+// CHECK-NEXT: {{^}}            (decl_implicit version=54 unavailable=macOS decl=funcInGuardElse()
+// CHECK-NEXT: {{^}}              (decl version=54 unavailable=macOS decl=funcInGuardElse()
 // CHECK-NEXT: {{^}}            (guard_fallthrough version=55 unavailable=macOS
 // CHECK-NEXT: {{^}}              (condition_following_availability version=56 unavailable=macOS
 // CHECK-NEXT: {{^}}              (guard_fallthrough version=56 unavailable=macOS
-// CHECK-NEXT: {{^}}          (decl version=53 unavailable=macOS decl=funcInInnerIfElse()
-// CHECK-NEXT: {{^}}        (decl version=50 unavailable=macOS decl=funcInOuterIfElse()
+// CHECK-NEXT: {{^}}          (decl_implicit version=53 unavailable=macOS decl=funcInInnerIfElse()
+// CHECK-NEXT: {{^}}            (decl version=53 unavailable=macOS decl=funcInInnerIfElse()
+// CHECK-NEXT: {{^}}        (decl_implicit version=50 unavailable=macOS decl=funcInOuterIfElse()
+// CHECK-NEXT: {{^}}          (decl version=50 unavailable=macOS decl=funcInOuterIfElse()
 @available(OSX, unavailable)
 extension SomeClass {
   @available(OSX 51, *)
@@ -351,7 +361,8 @@ enum SomeEnum {
 // CHECK-NEXT: {{^}}      (switch_case_body version=52
 // CHECK-NEXT: {{^}}        (condition_following_availability version=53
 // CHECK-NEXT: {{^}}        (if_then version=53
-// CHECK-NEXT: {{^}}          (decl version=54 decl=funcInIfThen()
+// CHECK-NEXT: {{^}}          (decl_implicit version=53 decl=funcInIfThen()
+// CHECK-NEXT: {{^}}            (decl version=54 decl=funcInIfThen()
 // CHECK-NEXT: {{^}}      (switch_case_body version=53
 // CHECK-NEXT: {{^}}      (switch_case_body version=53
 // CHECK-NEXT: {{^}}      (switch_case_body version=51 unavailable=macOS
@@ -511,6 +522,54 @@ func deprecatedOnMacOS() {
 
 @available(iOS, introduced: 53)
 func availableOniOS() { }
+
+// CHECK-NEXT: {{^}}  (decl version=51 decl=localDeclsInAvailabilityScopes()
+// CHECK-NEXT: {{^}}    (condition_following_availability version=52
+// CHECK-NEXT: {{^}}    (if_then version=52
+// CHECK-NEXT: {{^}}      (decl_implicit version=52 decl=unannotatedFuncInIfThen()
+// CHECK-NEXT: {{^}}        (decl version=52 decl=unannotatedFuncInIfThen()
+// CHECK-NEXT: {{^}}      (decl_implicit version=52 decl=lessAvailableFuncInIfThen()
+// CHECK-NEXT: {{^}}        (decl version=53 decl=lessAvailableFuncInIfThen()
+// CHECK-NEXT: {{^}}      (decl_implicit version=52 decl=moreAvailableFuncInIfThen()
+// CHECK-NEXT: {{^}}        (decl version=52 decl=moreAvailableFuncInIfThen()
+// CHECK-NEXT: {{^}}      (decl_implicit version=52 decl=unavailableFuncInIfThen()
+// CHECK-NEXT: {{^}}        (decl version=52 unavailable=macOS decl=unavailableFuncInIfThen()
+// CHECK-NEXT: {{^}}      (decl_implicit version=52 decl=LessAvailableStructInIfThen
+// CHECK-NEXT: {{^}}        (decl version=53 decl=LessAvailableStructInIfThen
+// CHECK-NEXT: {{^}}          (decl version=54 decl=lessAvailableMethod()
+// CHECK-NEXT: {{^}}    (condition_following_availability version=52
+// CHECK-NEXT: {{^}}    (guard_fallthrough version=52
+// CHECK-NEXT: {{^}}      (decl_implicit version=52 decl=funcInGuardFallthrough()
+// CHECK-NEXT: {{^}}        (decl version=53 decl=funcInGuardFallthrough()
+
+@available(OSX 51, *)
+func localDeclsInAvailabilityScopes() {
+  if #available(OSX 52, *) {
+    func unannotatedFuncInIfThen() { }
+
+    @available(OSX 53, *)
+    func lessAvailableFuncInIfThen() { }
+
+    @available(OSX 51, *)
+    func moreAvailableFuncInIfThen() { }
+
+    @available(OSX, unavailable)
+    func unavailableFuncInIfThen() { }
+
+    @available(OSX 53, *)
+    struct LessAvailableStructInIfThen {
+      func method() { }
+
+      @available(OSX 54, *)
+      func lessAvailableMethod() { }
+    }
+  }
+
+  guard #available(OSX 52, *) else { return }
+
+  @available(OSX 53, *)
+  func funcInGuardFallthrough() { }
+}
 
 // CHECK-NEXT: {{^}}  (decl version=51 decl=FinalDecl
 

--- a/test/Availability/availability_versions.swift
+++ b/test/Availability/availability_versions.swift
@@ -1493,6 +1493,76 @@ func twoGuardsInSameBlock(_ p: Int) {
         // expected-note@-1 {{add 'if #available' version check}}
 }
 
+func localDeclInGuardFallthrough() {
+        // expected-note@-1 3{{add '@available' attribute to enclosing global function}}
+  // The fallthrough of a guard extends to the end of the enclosing brace, so
+  // this local function is visible above the guard even though its body runs at
+  // macOS 51.
+  localFuncInFallthrough() // expected-error {{'localFuncInFallthrough()' is only available in macOS 51 or newer}}
+        // expected-note@-1 {{add 'if #available' version check}}
+
+  _ = LocalStructInFallthrough() // expected-error {{'LocalStructInFallthrough' is only available in macOS 51 or newer}}
+        // expected-note@-1 {{add 'if #available' version check}}
+
+  if #available(OSX 51, *) {
+    localFuncInFallthrough()
+    _ = LocalStructInFallthrough()
+  }
+
+  lessRestrictedAfterGuard() // expected-error {{'lessRestrictedAfterGuard()' is only available in macOS 51 or newer}}
+        // expected-note@-1 {{add 'if #available' version check}}
+
+  guard #available(OSX 51, *) else { return }
+
+  func localFuncInFallthrough() {
+    _ = globalFuncAvailableOn51()
+  }
+
+  struct LocalStructInFallthrough {
+    func m() { _ = globalFuncAvailableOn51() }
+  }
+
+  localFuncInFallthrough()
+  _ = LocalStructInFallthrough()
+
+  @available(OSX 50, *)
+  func lessRestrictedAfterGuard() { _ = globalFuncAvailableOn51() }
+  lessRestrictedAfterGuard()
+}
+
+func localDeclsWithExplicitAvailability() {
+        // expected-note@-1 {{add '@available' attribute to enclosing global function}}
+  if #available(OSX 51, *) {
+    @available(OSX 52, *)
+    func moreRestricted() { _ = globalFuncAvailableOn52() }
+
+    moreRestricted() // expected-error {{'moreRestricted()' is only available in macOS 52 or newer}}
+        // expected-note@-1 {{add 'if #available' version check}}
+
+    if #available(OSX 52, *) {
+      moreRestricted()
+    }
+
+    @available(OSX 50, *)
+    func lessRestricted() { _ = globalFuncAvailableOn51() }
+    lessRestricted()
+
+    @available(OSX, unavailable)
+    func unavailableOnMacOS() { }
+        // expected-note@-1 {{'unavailableOnMacOS()' has been explicitly marked unavailable here}}
+    unavailableOnMacOS() // expected-error {{'unavailableOnMacOS()' is unavailable in macOS}}
+
+    @available(*, unavailable)
+    func neverAvailable() { }
+        // expected-note@-1 {{'neverAvailable()' has been explicitly marked unavailable here}}
+    neverAvailable() // expected-error {{'neverAvailable()' is unavailable}}
+
+    @available(OSX, deprecated: 51)
+    func deprecatedOnMacOS() { }
+    deprecatedOnMacOS() // expected-warning {{'deprecatedOnMacOS()' was deprecated in macOS 51}}
+  }
+}
+
 // Refining while loops
 
 while globalFuncAvailableOn51() > 10 { } // expected-error {{'globalFuncAvailableOn51()' is only available in macOS 51 or newer}}

--- a/test/IRGen/availability_custom_domains.swift
+++ b/test/IRGen/availability_custom_domains.swift
@@ -3,14 +3,14 @@
 // RUN:   -define-enabled-availability-domain EnabledDomain \
 // RUN:   -define-always-enabled-availability-domain AlwaysEnabledDomain \
 // RUN:   -define-disabled-availability-domain DisabledDomain \
-// RUN:   -Onone | %FileCheck %s --check-prefixes=CHECK
+// RUN:   -Onone | %FileCheck %s
 
 // RUN: %target-swift-emit-irgen -module-name Test %s -verify \
 // RUN:   -enable-experimental-feature CustomAvailability \
 // RUN:   -define-enabled-availability-domain EnabledDomain \
 // RUN:   -define-always-enabled-availability-domain AlwaysEnabledDomain \
 // RUN:   -define-disabled-availability-domain DisabledDomain \
-// RUN:   -O | %FileCheck %s --check-prefixes=CHECK
+// RUN:   -O | %FileCheck %s
 
 // REQUIRES: swift_feature_CustomAvailability
 
@@ -85,3 +85,156 @@ public func ifUnavailableDisabledDomain() {
     never()
   }
 }
+
+// CHECK-LABEL: define {{.*}}swiftcc void @"$s4Test28whileAvailableDisabledDomainyyF"()
+// CHECK-NOT: call swiftcc void @never()
+public func whileAvailableDisabledDomain() {
+  while #available(DisabledDomain) {
+    never()
+  }
+}
+
+// CHECK-LABEL: define {{.*}}swiftcc void @"$s4Test29whileUnavailableEnabledDomainyyF"()
+// CHECK-NOT: call swiftcc void @never()
+public func whileUnavailableEnabledDomain() {
+  while #unavailable(EnabledDomain) {
+    never()
+  }
+}
+
+// CHECK-LABEL: define {{.*}}swiftcc void @"$s4Test27guardAvailableEnabledDomainyyF"()
+// CHECK: call swiftcc void @always()
+// CHECK-NOT: call swiftcc void @never()
+public func guardAvailableEnabledDomain() {
+  guard #available(EnabledDomain) else {
+    never()
+    return
+  }
+  always()
+}
+
+// CHECK-LABEL: define {{.*}}swiftcc void @"$s4Test28guardAvailableDisabledDomainyyF"()
+// CHECK-NOT: call swiftcc void @never()
+// CHECK: call swiftcc void @always()
+public func guardAvailableDisabledDomain() {
+  guard #available(DisabledDomain) else {
+    always()
+    return
+  }
+  never()
+}
+
+// CHECK-LABEL: define {{.*}}swiftcc void @"$s4Test29guardUnavailableEnabledDomainyyF"()
+// CHECK-NOT: call swiftcc void @never()
+// CHECK: call swiftcc void @always()
+public func guardUnavailableEnabledDomain() {
+  guard #unavailable(EnabledDomain) else {
+    always()
+    return
+  }
+  never()
+}
+
+// CHECK-LABEL: define {{.*}}swiftcc void @"$s4Test40testIfAvailableDisabledDomainNestedDeclsyyF"()
+// CHECK-NOT: call swiftcc void @never()
+public func testIfAvailableDisabledDomainNestedDecls() {
+  if #available(DisabledDomain) {
+    func nestedFunc() { never()}
+    let nestedClosure = { never() }
+    struct NestedStruct {
+      func m() { never() }
+    }
+    nestedFunc()
+    nestedClosure()
+    NestedStruct().m()
+  }
+}
+
+// CHECK-NOT: define internal swiftcc void @"$s4Test40testIfAvailableDisabledDomainNestedDeclsyyF10nestedFuncL_yyF"
+// CHECK-NOT: define internal swiftcc void @"$s4Test40testIfAvailableDisabledDomainNestedDeclsyyFyycfU_"
+
+// CHECK-LABEL: define {{.*}}swiftcc void @"$s4Test43testIfAvailableEnabledDomainElseNestedDeclsyyF"()
+// CHECK-NOT: call swiftcc void @never()
+public func testIfAvailableEnabledDomainElseNestedDecls() {
+  if #available(EnabledDomain) {
+  } else {
+    func nestedFunc() { never()}
+    let nestedClosure = { never() }
+    struct NestedStruct {
+      func m() { never() }
+    }
+    nestedFunc()
+    nestedClosure()
+    NestedStruct().m()
+  }
+}
+
+// CHECK-NOT: define internal swiftcc void @"$s4Test43testIfAvailableEnabledDomainElseNestedDeclsyyF10nestedFuncL_yyF"
+// CHECK-NOT: define internal swiftcc void @"$s4Test43testIfAvailableEnabledDomainElseNestedDeclsyyFyycfU_"
+
+// CHECK-LABEL: define {{.*}}swiftcc void @"$s4Test43testWhileAvailableDisabledDomainNestedDeclsyyF"()
+// CHECK-NOT: call swiftcc void @never()
+public func testWhileAvailableDisabledDomainNestedDecls() {
+  while #available(DisabledDomain) {
+    func nestedFunc() { never() }
+    let nestedClosure = { never() }
+    struct NestedStruct {
+      func m() { never() }
+    }
+    nestedFunc()
+    nestedClosure()
+    NestedStruct().m()
+  }
+}
+
+// CHECK-NOT: define internal swiftcc void @"$s4Test43testWhileAvailableDisabledDomainNestedDeclsyyF10nestedFuncL_yyF"
+// CHECK-NOT: define internal swiftcc void @"$s4Test43testWhileAvailableDisabledDomainNestedDeclsyyFyycfU_"
+
+// CHECK-LABEL: define {{.*}}swiftcc void @"$s4Test46testIfAvailableDisabledDomainLocalVarAccessorsyyF"()
+// CHECK-NOT: call swiftcc void @never()
+// CHECK-NOT: $s4Test46testIfAvailableDisabledDomainLocalVarAccessorsyyF{{[0-9]}}
+public func testIfAvailableDisabledDomainLocalVarAccessors() {
+  if #available(DisabledDomain) {
+    var computed: Int { never(); return 0 }
+    var observed: Int = 0 { didSet { never() } }
+    var explicitAccessors: Int {
+      get { never(); return 0 }
+      set { if newValue == 0 { never() } }
+    }
+    observed = computed
+    explicitAccessors = observed
+    _ = explicitAccessors
+  }
+}
+
+// CHECK-LABEL: define {{.*}}swiftcc void @"$s4Test43testGuardAvailableDisabledDomainNestedDeclsyyF"()
+// CHECK-NOT: call swiftcc void @never()
+// CHECK: ret void
+public func testGuardAvailableDisabledDomainNestedDecls() {
+  guard #available(DisabledDomain) else { return }
+  func nestedFunc() { never() }
+  let nestedClosure = { never() }
+  struct NestedStruct {
+    func m() { never() }
+  }
+  nestedFunc()
+  nestedClosure()
+  NestedStruct().m()
+}
+
+// CHECK-NOT: define internal swiftcc void @"$s4Test43testGuardAvailableDisabledDomainNestedDeclsyyFyycfU_"
+// CHECK-NOT: define internal swiftcc void @"$s4Test43testGuardAvailableDisabledDomainNestedDeclsyyF10nestedFuncL_yyF"
+
+// CHECK-NOT: define internal swiftcc void @"$s4Test40testIfAvailableDisabledDomainNestedDeclsyyF0G6StructL_V1myyF"
+// CHECK-NOT: define internal swiftcc void @"$s4Test43testIfAvailableEnabledDomainElseNestedDeclsyyF0H6StructL_V1myyF"
+// CHECK-NOT: define internal swiftcc void @"$s4Test43testWhileAvailableDisabledDomainNestedDeclsyyF0G6StructL_V1myyF"
+// CHECK-NOT: define internal swiftcc void @"$s4Test43testGuardAvailableDisabledDomainNestedDeclsyyF0G6StructL_V1myyF"
+
+// CHECK-NOT: @"$s4Test40testIfAvailableDisabledDomainNestedDeclsyyF0G6StructL_VMa"
+// CHECK-NOT: @"$s4Test43testIfAvailableEnabledDomainElseNestedDeclsyyF0H6StructL_VMa"
+// CHECK-NOT: @"$s4Test43testWhileAvailableDisabledDomainNestedDeclsyyF0G6StructL_VMa"
+// CHECK-NOT: @"$s4Test43testGuardAvailableDisabledDomainNestedDeclsyyF0G6StructL_VMa"
+// CHECK-NOT: @"$s4Test40testIfAvailableDisabledDomainNestedDeclsyyF0G6StructL_VMn"
+// CHECK-NOT: @"$s4Test43testIfAvailableEnabledDomainElseNestedDeclsyyF0H6StructL_VMn"
+// CHECK-NOT: @"$s4Test43testWhileAvailableDisabledDomainNestedDeclsyyF0G6StructL_VMn"
+// CHECK-NOT: @"$s4Test43testGuardAvailableDisabledDomainNestedDeclsyyF0G6StructL_VMn"

--- a/test/SILGen/availability_query_custom_domains.swift
+++ b/test/SILGen/availability_query_custom_domains.swift
@@ -186,3 +186,477 @@ public func testIfUnavailableDynamicDomain() {
   }
 }
 // CHECK: end sil function '$s4Test30testIfUnavailableDynamicDomainyyF'
+
+// CHECK-LABEL: sil{{.*}}testIfAvailableEnabledDomainAlways{{[a-zA-Z0-9]*}}yyF : $@convention(thin) () -> ()
+public func testIfAvailableEnabledDomainAlwaysEnabledDomain() {
+  // CHECK: bb0:
+  // CHECK:   [[PRED0:%.*]] = integer_literal $Builtin.Int1, -1
+  // CHECK:   cond_br [[PRED0]]
+
+  // CHECK:   [[PRED1:%.*]] = integer_literal $Builtin.Int1, -1
+  // CHECK:   cond_br [[PRED1]]
+
+  // CHECK:   function_ref @$s4Test24availableInEnabledDomainyyF
+  if #available(EnabledDomain), #available(AlwaysEnabledDomain) {
+    availableInEnabledDomain()
+  } else {
+  }
+}
+// CHECK: end sil function '{{.*}}testIfAvailableEnabledDomainAlways{{[a-zA-Z0-9]*}}yyF'
+
+// CHECK-LABEL: sil{{.*}}testIfAvailableEnabledDomainDisabled{{[a-zA-Z0-9]*}}yyF : $@convention(thin) () -> ()
+public func testIfAvailableEnabledDomainDisabledDomain() {
+  // CHECK: bb0:
+  // CHECK:   [[PRED0:%.*]] = integer_literal $Builtin.Int1, -1
+  // CHECK:   cond_br [[PRED0]], [[TRUE_BB0:bb[0-9]+]], [[FALSE_BB0:bb[0-9]+]]
+
+  // CHECK: [[TRUE_BB0]]:
+  // CHECK:   [[PRED1:%.*]] = integer_literal $Builtin.Int1, 0
+  // CHECK:   cond_br [[PRED1]], [[TRUE_BB1:bb[0-9]+]], [[FALSE_BB1:bb[0-9]+]]
+
+  // CHECK: [[TRUE_BB1]]:
+  // CHECK:   function_ref @$s4Test25availableInDisabledDomainyyF
+  // CHECK:   br [[CONT_BB:bb[0-9]+]]
+
+  // CHECK: [[FALSE_BB1]]:
+  // CHECK-NEXT:   br [[ELSE_BB:bb[0-9]+]]
+
+  // CHECK: [[FALSE_BB0]]:
+  // CHECK-NEXT:   br [[ELSE_BB]]
+
+  // CHECK: [[ELSE_BB]]:
+  // CHECK:   function_ref @$s4Test30availableInAlwaysEnabledDomainyyF
+  // CHECK:   br [[CONT_BB]]
+  if #available(EnabledDomain), #available(DisabledDomain) {
+    availableInDisabledDomain()
+  } else {
+    availableInAlwaysEnabledDomain()
+  }
+}
+// CHECK: end sil function '{{.*}}testIfAvailableEnabledDomainDisabled{{[a-zA-Z0-9]*}}yyF'
+
+// CHECK-LABEL: sil{{.*}}testIfAvailableEnabledDomainDynamic{{[a-zA-Z0-9]*}}yyF : $@convention(thin) () -> ()
+public func testIfAvailableEnabledDomainDynamicDomain() {
+  // FIXME: [availability] Call dynamic domain predicate function
+  // CHECK: bb0:
+  // CHECK:   [[PRED0:%.*]] = integer_literal $Builtin.Int1, -1
+  // CHECK:   cond_br [[PRED0]], [[TRUE_BB0:bb[0-9]+]], [[FALSE_BB0:bb[0-9]+]]
+
+  // CHECK: [[TRUE_BB0]]:
+  // CHECK:   [[PRED1:%.*]] = integer_literal $Builtin.Int1, -1
+  // CHECK:   cond_br [[PRED1]], [[TRUE_BB1:bb[0-9]+]], [[FALSE_BB1:bb[0-9]+]]
+
+  // CHECK: [[TRUE_BB1]]:
+  // CHECK:   function_ref @$s4Test24availableInDynamicDomainyyF
+  // CHECK:   br [[CONT_BB:bb[0-9]+]]
+
+  // CHECK: [[FALSE_BB1]]:
+  // CHECK-NEXT:   br [[ELSE_BB:bb[0-9]+]]
+
+  // CHECK: [[FALSE_BB0]]:
+  // CHECK-NEXT:   br [[ELSE_BB]]
+
+  // CHECK: [[ELSE_BB]]:
+  // CHECK:   function_ref @$s4Test30availableInAlwaysEnabledDomainyyF
+  // CHECK:   br [[CONT_BB]]
+  if #available(EnabledDomain), #available(DynamicDomain) {
+    availableInDynamicDomain()
+  } else {
+    availableInAlwaysEnabledDomain()
+  }
+}
+// CHECK: end sil function '{{.*}}testIfAvailableEnabledDomainDynamic{{[a-zA-Z0-9]*}}yyF'
+
+// CHECK-LABEL: sil{{.*}}$s4Test31testGuardAvailableEnabledDomainyyF : $@convention(thin) () -> ()
+public func testGuardAvailableEnabledDomain() {
+  // CHECK: bb0:
+  // CHECK:   [[PRED:%.*]] = integer_literal $Builtin.Int1, -1
+  // CHECK:   cond_br [[PRED]], [[TRUE_BB:bb[0-9]+]], [[FALSE_BB:bb[0-9]+]]
+
+  // CHECK: [[TRUE_BB]]:
+  // CHECK:   function_ref @$s4Test24availableInEnabledDomainyyF
+
+  // CHECK: [[FALSE_BB]]:
+  // CHECK:   function_ref @$s4Test26unavailableInEnabledDomainyyF
+  guard #available(EnabledDomain) else {
+    unavailableInEnabledDomain()
+    return
+  }
+  availableInEnabledDomain()
+}
+// CHECK: end sil function '$s4Test31testGuardAvailableEnabledDomainyyF'
+
+// CHECK-LABEL: sil{{.*}}$s4Test33testGuardUnavailableEnabledDomainyyF : $@convention(thin) () -> ()
+public func testGuardUnavailableEnabledDomain() {
+  // CHECK: bb0:
+  // CHECK:   [[PRED:%.*]] = integer_literal $Builtin.Int1, 0
+  // CHECK:   cond_br [[PRED]], [[TRUE_BB:bb[0-9]+]], [[FALSE_BB:bb[0-9]+]]
+
+  // CHECK: [[TRUE_BB]]:
+  // CHECK:   function_ref @$s4Test26unavailableInEnabledDomainyyF
+
+  // CHECK: [[FALSE_BB]]:
+  // CHECK:   function_ref @$s4Test24availableInEnabledDomainyyF
+  guard #unavailable(EnabledDomain) else {
+    availableInEnabledDomain()
+    return
+  }
+  unavailableInEnabledDomain()
+}
+// CHECK: end sil function '$s4Test33testGuardUnavailableEnabledDomainyyF'
+
+// CHECK-LABEL: sil{{.*}}$s4Test32testGuardAvailableDisabledDomainyyF : $@convention(thin) () -> ()
+public func testGuardAvailableDisabledDomain() {
+  // CHECK: bb0:
+  // CHECK:   [[PRED:%.*]] = integer_literal $Builtin.Int1, 0
+  // CHECK:   cond_br [[PRED]], [[TRUE_BB:bb[0-9]+]], [[FALSE_BB:bb[0-9]+]]
+
+  // CHECK: [[TRUE_BB]]:
+  // CHECK:   function_ref @$s4Test25availableInDisabledDomainyyF
+
+  // CHECK: [[FALSE_BB]]:
+  // CHECK:   function_ref @$s4Test27unavailableInDisabledDomainyyF
+  guard #available(DisabledDomain) else {
+    unavailableInDisabledDomain()
+    return
+  }
+  availableInDisabledDomain()
+}
+// CHECK: end sil function '$s4Test32testGuardAvailableDisabledDomainyyF'
+
+// CHECK-LABEL: sil{{.*}}$s4Test34testGuardUnavailableDisabledDomainyyF : $@convention(thin) () -> ()
+public func testGuardUnavailableDisabledDomain() {
+  // CHECK: bb0:
+  // CHECK:   [[PRED:%.*]] = integer_literal $Builtin.Int1, -1
+  // CHECK:   cond_br [[PRED]], [[TRUE_BB:bb[0-9]+]], [[FALSE_BB:bb[0-9]+]]
+
+  // CHECK: [[TRUE_BB]]:
+  // CHECK:   function_ref @$s4Test27unavailableInDisabledDomainyyF
+
+  // CHECK: [[FALSE_BB]]:
+  // CHECK:   function_ref @$s4Test25availableInDisabledDomainyyF
+  guard #unavailable(DisabledDomain) else {
+    availableInDisabledDomain()
+    return
+  }
+  unavailableInDisabledDomain()
+}
+// CHECK: end sil function '$s4Test34testGuardUnavailableDisabledDomainyyF'
+
+// CHECK-LABEL: sil{{.*}}$s4Test31testGuardAvailableDynamicDomainyyF : $@convention(thin) () -> ()
+public func testGuardAvailableDynamicDomain() {
+  // FIXME: [availability] Call dynamic domain predicate function
+  // CHECK: bb0:
+  // CHECK:   [[PRED:%.*]] = integer_literal $Builtin.Int1, -1
+  // CHECK:   cond_br [[PRED]], [[TRUE_BB:bb[0-9]+]], [[FALSE_BB:bb[0-9]+]]
+
+  // CHECK: [[TRUE_BB]]:
+  // CHECK:   function_ref @$s4Test24availableInDynamicDomainyyF
+
+  // CHECK: [[FALSE_BB]]:
+  // CHECK:   function_ref @$s4Test26unavailableInDynamicDomainyyF
+  guard #available(DynamicDomain) else {
+    unavailableInDynamicDomain()
+    return
+  }
+  availableInDynamicDomain()
+}
+// CHECK: end sil function '$s4Test31testGuardAvailableDynamicDomainyyF'
+
+// CHECK-LABEL: sil{{.*}}testGuardAvailableEnabledDomainDisabled{{[a-zA-Z0-9]*}}yyF : $@convention(thin) () -> ()
+public func testGuardAvailableEnabledDomainDisabledDomain() {
+  // CHECK: bb0:
+  // CHECK:   [[PRED0:%.*]] = integer_literal $Builtin.Int1, -1
+  // CHECK:   cond_br [[PRED0]], [[TRUE_BB0:bb[0-9]+]], [[FALSE_BB0:bb[0-9]+]]
+
+  // CHECK: [[TRUE_BB0]]:
+  // CHECK:   [[PRED1:%.*]] = integer_literal $Builtin.Int1, 0
+  // CHECK:   cond_br [[PRED1]], [[TRUE_BB1:bb[0-9]+]], [[FALSE_BB1:bb[0-9]+]]
+
+  // CHECK: [[TRUE_BB1]]:
+  // CHECK:   function_ref @$s4Test25availableInDisabledDomainyyF
+  // CHECK:   br [[CONT_BB:bb[0-9]+]]
+
+  // CHECK: [[FALSE_BB1]]:
+  // CHECK-NEXT:   br [[ELSE_BB:bb[0-9]+]]
+
+  // CHECK: [[FALSE_BB0]]:
+  // CHECK-NEXT:   br [[ELSE_BB]]
+
+  // CHECK: [[ELSE_BB]]:
+  // CHECK:   function_ref @$s4Test30availableInAlwaysEnabledDomainyyF
+  // CHECK:   br [[CONT_BB]]
+  guard #available(EnabledDomain), #available(DisabledDomain) else {
+    availableInAlwaysEnabledDomain()
+    return
+  }
+  availableInDisabledDomain()
+}
+// CHECK: end sil function '{{.*}}testGuardAvailableEnabledDomainDisabled{{[a-zA-Z0-9]*}}yyF'
+
+// CHECK-LABEL: sil{{.*}}$s4Test31testWhileAvailableEnabledDomainyyF : $@convention(thin) () -> ()
+public func testWhileAvailableEnabledDomain() {
+  // CHECK: bb0:
+  // CHECK:   br [[LOOP_BB:bb[0-9]+]]
+
+  // CHECK: [[LOOP_BB]]:
+  // CHECK:   [[PRED:%.*]] = integer_literal $Builtin.Int1, -1
+  // CHECK:   cond_br [[PRED]], [[BODY_BB:bb[0-9]+]], [[EXIT_BB:bb[0-9]+]]
+
+  // CHECK: [[BODY_BB]]:
+  // CHECK:   function_ref @$s4Test24availableInEnabledDomainyyF
+  // CHECK:   br [[LOOP_BB]]
+
+  // CHECK: [[EXIT_BB]]:
+  // CHECK-NEXT:   tuple
+  // CHECK-NEXT:   return
+  while #available(EnabledDomain) {
+    availableInEnabledDomain()
+  }
+}
+// CHECK: end sil function '$s4Test31testWhileAvailableEnabledDomainyyF'
+
+// CHECK-LABEL: sil{{.*}}$s4Test33testWhileUnavailableEnabledDomainyyF : $@convention(thin) () -> ()
+public func testWhileUnavailableEnabledDomain() {
+  // CHECK: bb0:
+  // CHECK:   br [[LOOP_BB:bb[0-9]+]]
+
+  // CHECK: [[LOOP_BB]]:
+  // CHECK:   [[PRED:%.*]] = integer_literal $Builtin.Int1, 0
+  // CHECK:   cond_br [[PRED]], [[BODY_BB:bb[0-9]+]], [[EXIT_BB:bb[0-9]+]]
+
+  // CHECK: [[BODY_BB]]:
+  // CHECK:   function_ref @$s4Test26unavailableInEnabledDomainyyF
+  // CHECK:   br [[LOOP_BB]]
+
+  // CHECK: [[EXIT_BB]]:
+  // CHECK-NEXT:   tuple
+  // CHECK-NEXT:   return
+  while #unavailable(EnabledDomain) {
+    unavailableInEnabledDomain()
+  }
+}
+// CHECK: end sil function '$s4Test33testWhileUnavailableEnabledDomainyyF'
+
+// CHECK-LABEL: sil{{.*}}$s4Test32testWhileAvailableDisabledDomainyyF : $@convention(thin) () -> ()
+public func testWhileAvailableDisabledDomain() {
+  // CHECK: bb0:
+  // CHECK:   br [[LOOP_BB:bb[0-9]+]]
+
+  // CHECK: [[LOOP_BB]]:
+  // CHECK:   [[PRED:%.*]] = integer_literal $Builtin.Int1, 0
+  // CHECK:   cond_br [[PRED]], [[BODY_BB:bb[0-9]+]], [[EXIT_BB:bb[0-9]+]]
+
+  // CHECK: [[BODY_BB]]:
+  // CHECK:   function_ref @$s4Test25availableInDisabledDomainyyF
+  // CHECK:   br [[LOOP_BB]]
+
+  // CHECK: [[EXIT_BB]]:
+  // CHECK-NEXT:   tuple
+  // CHECK-NEXT:   return
+  while #available(DisabledDomain) {
+    availableInDisabledDomain()
+  }
+}
+// CHECK: end sil function '$s4Test32testWhileAvailableDisabledDomainyyF'
+
+// CHECK-LABEL: sil{{.*}}$s4Test31testWhileAvailableDynamicDomainyyF : $@convention(thin) () -> ()
+public func testWhileAvailableDynamicDomain() {
+  // FIXME: [availability] Call dynamic domain predicate function
+  // CHECK: bb0:
+  // CHECK:   br [[LOOP_BB:bb[0-9]+]]
+
+  // CHECK: [[LOOP_BB]]:
+  // CHECK:   [[PRED:%.*]] = integer_literal $Builtin.Int1, -1
+  // CHECK:   cond_br [[PRED]], [[BODY_BB:bb[0-9]+]], [[EXIT_BB:bb[0-9]+]]
+
+  // CHECK: [[BODY_BB]]:
+  // CHECK:   function_ref @$s4Test24availableInDynamicDomainyyF
+  // CHECK:   br [[LOOP_BB]]
+
+  // CHECK: [[EXIT_BB]]:
+  // CHECK-NEXT:   tuple
+  // CHECK-NEXT:   return
+  while #available(DynamicDomain) {
+    availableInDynamicDomain()
+  }
+}
+// CHECK: end sil function '$s4Test31testWhileAvailableDynamicDomainyyF'
+
+// CHECK-LABEL: sil{{.*}}$s4Test40testIfAvailableDisabledDomainNestedDeclsyyF : $@convention(thin) () -> ()
+public func testIfAvailableDisabledDomainNestedDecls() {
+  // CHECK: bb0:
+  // CHECK:   [[PRED:%.*]] = integer_literal $Builtin.Int1, 0
+  // CHECK:   cond_br [[PRED]], [[TRUE_BB:bb[0-9]+]], [[FALSE_BB:bb[0-9]+]]
+
+  // CHECK: [[TRUE_BB]]:
+  // CHECK:   function_ref @$s4Test40testIfAvailableDisabledDomainNestedDeclsyyFyycfU_
+  // CHECK:   function_ref @$s4Test40testIfAvailableDisabledDomainNestedDeclsyyF10nestedFuncL_yyF
+  // CHECK:   function_ref @$s4Test40testIfAvailableDisabledDomainNestedDeclsyyF0G6StructL_V1myyF
+  // CHECK:   br [[CONT_BB:bb[0-9]+]]
+
+  // CHECK: [[FALSE_BB]]:
+  // CHECK-NEXT:   br [[CONT_BB]]
+  if #available(DisabledDomain) {
+    func nestedFunc() { }
+    let nestedClosure = { }
+    struct NestedStruct {
+      func m() { }
+    }
+    nestedFunc()
+    nestedClosure()
+    NestedStruct().m()
+  }
+}
+// CHECK: end sil function '$s4Test40testIfAvailableDisabledDomainNestedDeclsyyF'
+
+// The closure is emitted (but will be removed by mandatory optimization).
+// CHECK: closure #1 in testIfAvailableDisabledDomainNestedDecls()
+// CHECK-LABEL: sil private{{.*}}$s4Test40testIfAvailableDisabledDomainNestedDeclsyyFyycfU_ : $@convention(thin) () -> () {
+
+// The nested function and the nested struct's members are emitted as
+// declarations only; a trailing '{' would indicate that a body was emitted.
+// CHECK-LABEL: sil{{.*}}$s4Test40testIfAvailableDisabledDomainNestedDeclsyyF10nestedFuncL_yyF : $@convention(thin) () -> (){{$}}
+// CHECK-LABEL: sil{{.*}}$s4Test40testIfAvailableDisabledDomainNestedDeclsyyF0G6StructL_VADycfC : $@convention(method) (@thin NestedStruct.Type) -> NestedStruct{{$}}
+// CHECK-LABEL: sil{{.*}}$s4Test40testIfAvailableDisabledDomainNestedDeclsyyF0G6StructL_V1myyF : $@convention(method) (NestedStruct) -> (){{$}}
+
+// CHECK-LABEL: sil{{.*}}$s4Test43testIfAvailableEnabledDomainElseNestedDeclsyyF : $@convention(thin) () -> ()
+public func testIfAvailableEnabledDomainElseNestedDecls() {
+  // CHECK: bb0:
+  // CHECK:   [[PRED:%.*]] = integer_literal $Builtin.Int1, -1
+  // CHECK:   cond_br [[PRED]], [[TRUE_BB:bb[0-9]+]], [[FALSE_BB:bb[0-9]+]]
+
+  // CHECK: [[TRUE_BB]]:
+  // CHECK-NEXT:   br [[CONT_BB:bb[0-9]+]]
+
+  // CHECK: [[FALSE_BB]]:
+  // CHECK:   function_ref @$s4Test43testIfAvailableEnabledDomainElseNestedDeclsyyFyycfU_
+  // CHECK:   function_ref @$s4Test43testIfAvailableEnabledDomainElseNestedDeclsyyF10nestedFuncL_yyF
+  // CHECK:   function_ref @$s4Test43testIfAvailableEnabledDomainElseNestedDeclsyyF0H6StructL_V1myyF
+  // CHECK:   br [[CONT_BB]]
+  if #available(EnabledDomain) {
+  } else {
+    func nestedFunc() { }
+    let nestedClosure = { }
+    struct NestedStruct {
+      func m() { }
+    }
+    nestedFunc()
+    nestedClosure()
+    NestedStruct().m()
+  }
+}
+// CHECK: end sil function '$s4Test43testIfAvailableEnabledDomainElseNestedDeclsyyF'
+
+// The closure is emitted (but will be removed by mandatory optimization).
+// CHECK: closure #1 in testIfAvailableEnabledDomainElseNestedDecls()
+// CHECK-LABEL: sil private{{.*}}$s4Test43testIfAvailableEnabledDomainElseNestedDeclsyyFyycfU_ : $@convention(thin) () -> () {
+
+// CHECK-LABEL: sil{{.*}}$s4Test43testIfAvailableEnabledDomainElseNestedDeclsyyF10nestedFuncL_yyF : $@convention(thin) () -> (){{$}}
+// CHECK-LABEL: sil{{.*}}$s4Test43testIfAvailableEnabledDomainElseNestedDeclsyyF0H6StructL_VADycfC : $@convention(method) (@thin NestedStruct.Type) -> NestedStruct{{$}}
+// CHECK-LABEL: sil{{.*}}$s4Test43testIfAvailableEnabledDomainElseNestedDeclsyyF0H6StructL_V1myyF : $@convention(method) (NestedStruct) -> (){{$}}
+
+// CHECK-LABEL: sil{{.*}}$s4Test43testGuardAvailableDisabledDomainNestedDeclsyyF : $@convention(thin) () -> ()
+public func testGuardAvailableDisabledDomainNestedDecls() {
+  // CHECK: bb0:
+  // CHECK:   [[PRED:%.*]] = integer_literal $Builtin.Int1, 0
+  // CHECK:   cond_br [[PRED]], [[TRUE_BB:bb[0-9]+]], [[FALSE_BB:bb[0-9]+]]
+
+  // CHECK: [[TRUE_BB]]:
+  // CHECK:   function_ref @$s4Test43testGuardAvailableDisabledDomainNestedDeclsyyFyycfU_
+  // CHECK:   function_ref @$s4Test43testGuardAvailableDisabledDomainNestedDeclsyyF10nestedFuncL_yyF
+  // CHECK:   function_ref @$s4Test43testGuardAvailableDisabledDomainNestedDeclsyyF0G6StructL_V1myyF
+  // CHECK:   br [[CONT_BB:bb[0-9]+]]
+
+  // CHECK: [[FALSE_BB]]:
+  // CHECK-NEXT:   br [[CONT_BB]]
+  guard #available(DisabledDomain) else { return }
+  func nestedFunc() { }
+  let nestedClosure = { }
+  struct NestedStruct {
+    func m() { }
+  }
+  nestedFunc()
+  nestedClosure()
+  NestedStruct().m()
+}
+// CHECK: end sil function '$s4Test43testGuardAvailableDisabledDomainNestedDeclsyyF'
+
+// The closure is emitted (but will be removed by mandatory optimization).
+// CHECK: closure #1 in testGuardAvailableDisabledDomainNestedDecls()
+// CHECK-LABEL: sil private{{.*}}$s4Test43testGuardAvailableDisabledDomainNestedDeclsyyFyycfU_ : $@convention(thin) () -> () {
+
+// CHECK-LABEL: sil{{.*}}$s4Test43testGuardAvailableDisabledDomainNestedDeclsyyF10nestedFuncL_yyF : $@convention(thin) () -> (){{$}}
+// CHECK-LABEL: sil{{.*}}$s4Test43testGuardAvailableDisabledDomainNestedDeclsyyF0G6StructL_VADycfC : $@convention(method) (@thin NestedStruct.Type) -> NestedStruct{{$}}
+// CHECK-LABEL: sil{{.*}}$s4Test43testGuardAvailableDisabledDomainNestedDeclsyyF0G6StructL_V1myyF : $@convention(method) (NestedStruct) -> (){{$}}
+
+// CHECK-LABEL: sil{{.*}}$s4Test42testGuardAvailableEnabledDomainNestedDeclsyyF : $@convention(thin) () -> ()
+public func testGuardAvailableEnabledDomainNestedDecls() {
+  // CHECK: bb0:
+  // CHECK:   [[PRED:%.*]] = integer_literal $Builtin.Int1, -1
+  // CHECK:   cond_br [[PRED]], [[TRUE_BB:bb[0-9]+]], [[FALSE_BB:bb[0-9]+]]
+
+  // CHECK: [[TRUE_BB]]:
+  // CHECK:   function_ref @$s4Test24availableInEnabledDomainyyF
+
+  // CHECK: [[FALSE_BB]]:
+  // CHECK:   function_ref @$s4Test42testGuardAvailableEnabledDomainNestedDeclsyyFyycfU_
+  // CHECK:   function_ref @$s4Test42testGuardAvailableEnabledDomainNestedDeclsyyF10nestedFuncL_yyF
+  // CHECK:   function_ref @$s4Test42testGuardAvailableEnabledDomainNestedDeclsyyF0G6StructL_V1myyF
+  guard #available(EnabledDomain) else {
+    func nestedFunc() { }
+    let nestedClosure = { }
+    struct NestedStruct {
+      func m() { }
+    }
+    nestedFunc()
+    nestedClosure()
+    NestedStruct().m()
+    return
+  }
+  availableInEnabledDomain()
+}
+// CHECK: end sil function '$s4Test42testGuardAvailableEnabledDomainNestedDeclsyyF'
+
+// The closure is emitted (but will be removed by mandatory optimization).
+// CHECK: closure #1 in testGuardAvailableEnabledDomainNestedDecls()
+// CHECK-LABEL: sil private{{.*}}$s4Test42testGuardAvailableEnabledDomainNestedDeclsyyFyycfU_ : $@convention(thin) () -> () {
+
+// CHECK-LABEL: sil{{.*}}$s4Test42testGuardAvailableEnabledDomainNestedDeclsyyF10nestedFuncL_yyF : $@convention(thin) () -> (){{$}}
+// CHECK-LABEL: sil{{.*}}$s4Test42testGuardAvailableEnabledDomainNestedDeclsyyF0G6StructL_VADycfC : $@convention(method) (@thin NestedStruct.Type) -> NestedStruct{{$}}
+// CHECK-LABEL: sil{{.*}}$s4Test42testGuardAvailableEnabledDomainNestedDeclsyyF0G6StructL_V1myyF : $@convention(method) (NestedStruct) -> (){{$}}
+
+// CHECK-LABEL: sil{{.*}}$s4Test43testWhileAvailableDisabledDomainNestedDeclsyyF : $@convention(thin) () -> ()
+public func testWhileAvailableDisabledDomainNestedDecls() {
+  // CHECK: bb0:
+  // CHECK:   br [[LOOP_BB:bb[0-9]+]]
+
+  // CHECK: [[LOOP_BB]]:
+  // CHECK:   [[PRED:%.*]] = integer_literal $Builtin.Int1, 0
+  // CHECK:   cond_br [[PRED]], [[BODY_BB:bb[0-9]+]], [[EXIT_BB:bb[0-9]+]]
+
+  // CHECK: [[BODY_BB]]:
+  // CHECK:   function_ref @$s4Test43testWhileAvailableDisabledDomainNestedDeclsyyFyycfU_
+  // CHECK:   function_ref @$s4Test43testWhileAvailableDisabledDomainNestedDeclsyyF10nestedFuncL_yyF
+  // CHECK:   function_ref @$s4Test43testWhileAvailableDisabledDomainNestedDeclsyyF0G6StructL_V1myyF
+  // CHECK:   br [[LOOP_BB]]
+  while #available(DisabledDomain) {
+    func nestedFunc() { }
+    let nestedClosure = { }
+    struct NestedStruct {
+      func m() { }
+    }
+    nestedFunc()
+    nestedClosure()
+    NestedStruct().m()
+  }
+}
+// CHECK: end sil function '$s4Test43testWhileAvailableDisabledDomainNestedDeclsyyF'
+
+// The closure is emitted (but will be removed by mandatory optimization).
+// CHECK: closure #1 in testWhileAvailableDisabledDomainNestedDecls()
+// CHECK-LABEL: sil private{{.*}}$s4Test43testWhileAvailableDisabledDomainNestedDeclsyyFyycfU_ : $@convention(thin) () -> () {
+
+// CHECK-LABEL: sil{{.*}}$s4Test43testWhileAvailableDisabledDomainNestedDeclsyyF10nestedFuncL_yyF : $@convention(thin) () -> (){{$}}
+// CHECK-LABEL: sil{{.*}}$s4Test43testWhileAvailableDisabledDomainNestedDeclsyyF0G6StructL_VADycfC : $@convention(method) (@thin NestedStruct.Type) -> NestedStruct{{$}}
+// CHECK-LABEL: sil{{.*}}$s4Test43testWhileAvailableDisabledDomainNestedDeclsyyF0G6StructL_V1myyF : $@convention(method) (NestedStruct) -> (){{$}}

--- a/test/attr/attr_availability_osx.swift
+++ b/test/attr/attr_availability_osx.swift
@@ -84,7 +84,7 @@ doSomethingDeprecatedOniOS() // okay
 struct TestStruct {} // expected-note 2 {{enclosing scope requires availability of macOS 10.10 or newer}}
 
 @available(macOS 10.10, *)
-extension TestStruct { // expected-note {{enclosing scope requires availability of macOS 10.10 or newer}}
+extension TestStruct { // expected-note 2 {{enclosing scope requires availability of macOS 10.10 or newer}}
   @available(swift 400)
   func doTheThing() {} // expected-note {{'doTheThing()' was introduced in Swift 400}}
 
@@ -99,6 +99,14 @@ extension TestStruct { // expected-note {{enclosing scope requires availability 
   @available(macOS 10.12, *)
   @available(swift 1)
   func doFourthThing() {}
+
+  func doLocalThing() {
+    @available(macOS 10.9, *) // expected-warning {{local function cannot be more available than enclosing scope}}
+    func moreAvailableFunction() { }
+
+    @available(macOS 10.12, *)
+    func lessAvailableFunction() { }
+  }
 
   @available(*, deprecated)
   func doDeprecatedThing() {}


### PR DESCRIPTION
A declaration nested in a region of a function body that has its own availability scope, like the branch of an `if #available` or the fallthrough of a `guard #available`, was not itself constrained by the availability that the region establishes. SILGen therefore emitted a separate SIL function for the declaration's body even when the region could never execute:

    func f() {
      if #available(DisabledDomain) {
        func g() { availableInDisabledDomain() }
        g()
      }
    }

Mandatory dead code elimination removes the branch containing the call to `g()` because the query has a constant result. However, at -Onone the SIL functions associated with local declarations like `g()` are preserved even if they are not referenced in case the user wants to invoke them in the debugger. As a result, the body of `g()` survived to IRGen and caused a failure to link since emitting SIL for `availableInDisabledDomain()` is skipped due to its availability.

To solve this, the compiler now synthesizes implicit `@available` attributes for declarations in local contexts, giving these declarations the same availability as the scopes that contain them. This ensures that they will be skipped during SILGen if they are unreachable at runtime, even at -Onone.

The synthesized attributes also close a soundness hole. The fallthrough of a `guard` extends to the end of the enclosing brace, so a declaration there is visible to the statements above the guard:

    func f() {
      g()
      guard #available(macOS 99, *) else { return }
      func g() { somethingOnlyAvailableInMacOS99() }
    }

The call to `g()` used to be accepted, which meant that code requiring macOS 99 could run on older systems. It is now diagnosed as a use of a declaration that is only available in macOS 99 or newer.

To keep the synthesis from being circular, availability scopes for declarations in local contexts are now expanded lazily, so building out the scopes for a function body no longer queries the availability of the declarations inside it, and the scope lookup that the request performs stops at the scopes introduced by the declaration being asked about.

Resolves rdar://180338823.