### PR TITLE
[Sema] Suggest removing calls from #selector

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -756,6 +756,8 @@ ERROR(expr_selector_module_missing,none,
 ERROR(expr_selector_no_declaration,none,
       "argument of '#selector' does not refer to an '@objc' method, property, "
       "or initializer", ())
+NOTE(expr_selector_remove_call,none,
+     "remove the parentheses to reference the method", ())
 ERROR(expr_selector_not_method,none,
       "argument of '#selector' cannot refer to %select{local|global}0 "
       "function %1", (bool, const ValueDecl *))

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4987,6 +4987,13 @@ namespace {
       if (!foundDecl) {
         de.diagnose(E->getLoc(), diag::expr_selector_no_declaration)
             .highlight(subExpr->getSourceRange());
+        if (auto *call = dyn_cast<CallExpr>(subExpr)) {
+          auto *args = call->getArgs();
+          if (args->empty()) {
+            de.diagnose(args->getLParenLoc(), diag::expr_selector_remove_call)
+                .fixItRemove(args->getSourceRange());
+          }
+        }
         return E;
       }
 

--- a/test/expr/primary/selector/selector.swift
+++ b/test/expr/primary/selector/selector.swift
@@ -25,6 +25,7 @@ class C1 {
     let testUnqualifiedSelector = 1
     _ = #selector(testUnqualifiedSelector(_:b:))
     _ = testUnqualifiedSelector // suppress unused warning
+    _ = #selector(getC1()) // expected-error{{argument of '#selector' does not refer to an '@objc' method, property, or initializer}} expected-note{{remove the parentheses to reference the method}}{{24-26=}}
   }
 
   @objc func testParam(_ testParam: A) { // expected-note{{'testParam' declared here}}


### PR DESCRIPTION
A declaration reference expression in a `#selector` should not include an argument list. Diagnose the call and offer a fix-it that removes the arguments while preserving the referenced declaration.

Resolves https://github.com/swiftlang/swift/issues/48543.

Testing:

- Combined Swift frontend build
- `utils/run-test --build-dir <build> test/decl/attr/selector.swift`