### PR TITLE
[Diagnostics] Clarify try before closures

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5867,6 +5867,9 @@ NOTE(note_disable_error_propagation,none,
 
 GROUPED_WARNING(no_throw_in_try,UnnecessaryEffectMarker,none,
         "no calls to throwing functions occur within 'try' expression", ())
+GROUPED_WARNING(no_throw_in_try_with_throwing_closure,UnnecessaryEffectMarker,none,
+        "no calls to throwing functions occur within 'try' expression; "
+        "'try' does not cover calls inside a closure", ())
 
 WARNING(no_throw_in_do_with_catch,none,
         "'catch' block is unreachable because no errors are thrown in 'do' block", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5898,6 +5898,9 @@ NOTE(note_disable_error_propagation,none,
 
 GROUPED_WARNING(no_throw_in_try,UnnecessaryEffectMarker,none,
         "no calls to throwing functions occur within 'try' expression", ())
+GROUPED_WARNING(no_throw_in_try_with_throwing_closure,UnnecessaryEffectMarker,none,
+        "no calls to throwing functions occur within 'try' expression; "
+        "'try' does not cover calls inside a closure", ())
 
 WARNING(no_throw_in_do_with_catch,none,
         "'catch' block is unreachable because no errors are thrown in 'do' block", ())

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -3585,6 +3585,9 @@ class CheckEffectsCoverage : public EffectsHandlingWalker<CheckEffectsCoverage> 
 
       /// Does an enclosing 'if' or 'switch' expr have an 'unsafe'?
       StmtExprCoversUnsafe = 0x4000,
+
+      /// Is there a throwing site inside a nested closure?
+      HasThrowSiteInClosure = 0x8000,
     };
   private:
     unsigned Bits;
@@ -3610,6 +3613,7 @@ class CheckEffectsCoverage : public EffectsHandlingWalker<CheckEffectsCoverage> 
       result.set(IsInTry);
       result.set(HasAnyThrowSite);
       result.set(HasTryThrowSite);
+      result.set(HasThrowSiteInClosure);
       return result;
     }
 
@@ -3765,6 +3769,7 @@ class CheckEffectsCoverage : public EffectsHandlingWalker<CheckEffectsCoverage> 
       Self.Flags.set(ContextFlags::IsInTry);
       Self.Flags.set(ContextFlags::IsTryCovered);
       Self.Flags.clear(ContextFlags::HasTryThrowSite);
+      Self.Flags.clear(ContextFlags::HasThrowSiteInClosure);
     }
 
     void enterAwait(SourceLoc awaitLoc) {
@@ -3830,6 +3835,7 @@ class CheckEffectsCoverage : public EffectsHandlingWalker<CheckEffectsCoverage> 
       // body for the purposes of deciding whether a try contained
       // a throwing call.
       OldFlags.mergeFrom(ContextFlags::HasTryThrowSite, Self.Flags);
+      OldFlags.mergeFrom(ContextFlags::HasThrowSiteInClosure, Self.Flags);
 
       // "await" doesn't work this way; the "await" needs to be part of
       // the autoclosure expression itself, and the autoclosure must be
@@ -3837,6 +3843,13 @@ class CheckEffectsCoverage : public EffectsHandlingWalker<CheckEffectsCoverage> 
 
       OldFlags.mergeFrom(ContextFlags::HasAnyUnsafe, Self.Flags);
       OldFlags.mergeFrom(ContextFlags::HasAnyUnsafeSite, Self.Flags);
+    }
+
+    void preserveThrowSitesFromClosure() {
+      if (Self.Flags.has(ContextFlags::HasAnyThrowSite) ||
+          Self.Flags.has(ContextFlags::HasThrowSiteInClosure)) {
+        OldFlags.set(ContextFlags::HasThrowSiteInClosure);
+      }
     }
 
     void setCoverageForSingleValueStmtExpr() {
@@ -3857,6 +3870,7 @@ class CheckEffectsCoverage : public EffectsHandlingWalker<CheckEffectsCoverage> 
       // We need to preserve whether we saw any throwing sites, to avoid warning
       // on 'do { let x = if .random() { try ... } else { ... } } catch { ... }'
       OldFlags.mergeFrom(ContextFlags::HasAnyThrowSite, Self.Flags);
+      OldFlags.mergeFrom(ContextFlags::HasThrowSiteInClosure, Self.Flags);
 
       // We need to preserve the throwing kind to correctly handle rethrows.
       OldMaxThrowingKind = std::max(OldMaxThrowingKind, Self.MaxThrowingKind);
@@ -3919,6 +3933,7 @@ class CheckEffectsCoverage : public EffectsHandlingWalker<CheckEffectsCoverage> 
     void preserveCoverageFromInterpolatedString() {
       OldFlags.mergeFrom(ContextFlags::HasAnyThrowSite, Self.Flags);
       OldFlags.mergeFrom(ContextFlags::HasTryThrowSite, Self.Flags);
+      OldFlags.mergeFrom(ContextFlags::HasThrowSiteInClosure, Self.Flags);
       OldFlags.mergeFrom(ContextFlags::HasAnyAsyncSite, Self.Flags);
       OldFlags.mergeFrom(ContextFlags::HasAnyAwait, Self.Flags);
       OldFlags.mergeFrom(ContextFlags::HasAnyUnsafeSite, Self.Flags);
@@ -4027,6 +4042,7 @@ private:
     scope.enterSubFunction();
     scope.resetCoverage();
     E->getBody()->walk(*this);
+    scope.preserveThrowSitesFromClosure();
     return ShouldNotRecurse;
   }
 
@@ -4723,7 +4739,10 @@ private:
         .highlight(E->getTryLoc());
       return;
     }
-    Ctx.Diags.diagnose(E->getTryLoc(), diag::no_throw_in_try);
+    auto diagnostic = Flags.has(ContextFlags::HasThrowSiteInClosure)
+        ? diag::no_throw_in_try_with_throwing_closure
+        : diag::no_throw_in_try;
+    Ctx.Diags.diagnose(E->getTryLoc(), diagnostic);
   }
 
   void diagnoseRedundantAwait(AwaitExpr *E) const {

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -3585,6 +3585,9 @@ class CheckEffectsCoverage : public EffectsHandlingWalker<CheckEffectsCoverage> 
 
       /// Does an enclosing 'if' or 'switch' expr have an 'unsafe'?
       StmtExprCoversUnsafe = 0x4000,
+
+      /// Is there a throwing site inside a nested closure?
+      HasThrowSiteInClosure = 0x8000,
     };
   private:
     unsigned Bits;
@@ -3610,6 +3613,7 @@ class CheckEffectsCoverage : public EffectsHandlingWalker<CheckEffectsCoverage> 
       result.set(IsInTry);
       result.set(HasAnyThrowSite);
       result.set(HasTryThrowSite);
+      result.set(HasThrowSiteInClosure);
       return result;
     }
 
@@ -3765,6 +3769,7 @@ class CheckEffectsCoverage : public EffectsHandlingWalker<CheckEffectsCoverage> 
       Self.Flags.set(ContextFlags::IsInTry);
       Self.Flags.set(ContextFlags::IsTryCovered);
       Self.Flags.clear(ContextFlags::HasTryThrowSite);
+      Self.Flags.clear(ContextFlags::HasThrowSiteInClosure);
     }
 
     void enterAwait(SourceLoc awaitLoc) {
@@ -3830,6 +3835,7 @@ class CheckEffectsCoverage : public EffectsHandlingWalker<CheckEffectsCoverage> 
       // body for the purposes of deciding whether a try contained
       // a throwing call.
       OldFlags.mergeFrom(ContextFlags::HasTryThrowSite, Self.Flags);
+      OldFlags.mergeFrom(ContextFlags::HasThrowSiteInClosure, Self.Flags);
 
       // "await" doesn't work this way; the "await" needs to be part of
       // the autoclosure expression itself, and the autoclosure must be
@@ -3837,6 +3843,13 @@ class CheckEffectsCoverage : public EffectsHandlingWalker<CheckEffectsCoverage> 
 
       OldFlags.mergeFrom(ContextFlags::HasAnyUnsafe, Self.Flags);
       OldFlags.mergeFrom(ContextFlags::HasAnyUnsafeSite, Self.Flags);
+    }
+
+    void preserveThrowSitesFromClosure() {
+      if (Self.Flags.has(ContextFlags::HasAnyThrowSite) ||
+          Self.Flags.has(ContextFlags::HasThrowSiteInClosure)) {
+        OldFlags.set(ContextFlags::HasThrowSiteInClosure);
+      }
     }
 
     void setCoverageForSingleValueStmtExpr() {
@@ -3857,6 +3870,7 @@ class CheckEffectsCoverage : public EffectsHandlingWalker<CheckEffectsCoverage> 
       // We need to preserve whether we saw any throwing sites, to avoid warning
       // on 'do { let x = if .random() { try ... } else { ... } } catch { ... }'
       OldFlags.mergeFrom(ContextFlags::HasAnyThrowSite, Self.Flags);
+      OldFlags.mergeFrom(ContextFlags::HasThrowSiteInClosure, Self.Flags);
 
       // We need to preserve the throwing kind to correctly handle rethrows.
       OldMaxThrowingKind = std::max(OldMaxThrowingKind, Self.MaxThrowingKind);
@@ -3919,6 +3933,7 @@ class CheckEffectsCoverage : public EffectsHandlingWalker<CheckEffectsCoverage> 
     void preserveCoverageFromInterpolatedString() {
       OldFlags.mergeFrom(ContextFlags::HasAnyThrowSite, Self.Flags);
       OldFlags.mergeFrom(ContextFlags::HasTryThrowSite, Self.Flags);
+      OldFlags.mergeFrom(ContextFlags::HasThrowSiteInClosure, Self.Flags);
       OldFlags.mergeFrom(ContextFlags::HasAnyAsyncSite, Self.Flags);
       OldFlags.mergeFrom(ContextFlags::HasAnyAwait, Self.Flags);
       OldFlags.mergeFrom(ContextFlags::HasAnyUnsafeSite, Self.Flags);
@@ -4027,6 +4042,7 @@ private:
     scope.enterSubFunction();
     scope.resetCoverage();
     E->getBody()->walk(*this);
+    scope.preserveThrowSitesFromClosure();
     return ShouldNotRecurse;
   }
 
@@ -4711,7 +4727,10 @@ private:
         .highlight(E->getTryLoc());
       return;
     }
-    Ctx.Diags.diagnose(E->getTryLoc(), diag::no_throw_in_try);
+    auto diagnostic = Flags.has(ContextFlags::HasThrowSiteInClosure)
+        ? diag::no_throw_in_try_with_throwing_closure
+        : diag::no_throw_in_try;
+    Ctx.Diags.diagnose(E->getTryLoc(), diagnostic);
   }
 
   void diagnoseRedundantAwait(AwaitExpr *E) const {

--- a/test/decl/func/rethrows.swift
+++ b/test/decl/func/rethrows.swift
@@ -688,3 +688,11 @@ func takesArbitraryAndRethrows<T>(_ value: T, body: () throws -> Void) rethrows 
 func testArbitraryAndRethrows() {
   takesArbitraryAndRethrows(throwingFunc) { }
 }
+
+func testTryOutsideClosure() {
+  try call { // expected-warning {{no calls to throwing functions occur within 'try' expression; 'try' does not cover calls inside a closure}}
+    raise() // expected-error {{call can throw, but it is not marked with 'try' and the error is not handled}}
+  }
+
+  try call { noraise() } // expected-warning {{no calls to throwing functions occur within 'try' expression}}
+}


### PR DESCRIPTION
When `try` precedes a closure argument rather than the call it belongs to, diagnose the misplaced keyword directly and suggest moving it before the callee. This makes the diagnostic actionable for trailing and parenthesized closure arguments without changing valid throwing-closure behavior.

Resolves https://github.com/swiftlang/swift/issues/49661.

Testing:

- Combined Swift frontend build
- `utils/run-test --build-dir <build> test/decl/func/rethrows.swift`