### PR TITLE
[utils] Propagate swift-api-dump failures

### DIFF
--- a/test/ClangImporter/swift-api-dump.swift
+++ b/test/ClangImporter/swift-api-dump.swift
@@ -1,0 +1,4 @@
+// RUN: %empty-directory(%t)
+// RUN: not %{python} %utils/swift-api-dump.py -s macosx -m ThisModuleDoesNotExist -i %swift-ide-test_plain -o %t -j 1 -q
+
+// REQUIRES: OS=macosx

--- a/utils/swift-api-dump.py
+++ b/utils/swift-api-dump.py
@@ -124,7 +124,7 @@ def create_parser():
 
 def output_command_result_to_file(command_args, filename):
     with open(filename, 'w') as output_file:
-        subprocess.call(command_args, stdout=output_file)
+        subprocess.check_call(command_args, stdout=output_file)
 
 
 def run_command(args):


### PR DESCRIPTION
## Summary

`swift-api-dump.py` ignored nonzero `swift-ide-test` exit statuses while writing module dumps, which could leave a zero-byte dump and still exit successfully. Propagate the failed command through the worker pool instead.

## Testing

- Python syntax check for `utils/swift-api-dump.py`.
- End-to-end failing-command reproduction: the script now exits 1 instead of 0.
- Added a macOS lit regression test using an unavailable module.
