### PR TITLE
[Driver] Fix dependency scanning option diagnostics

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -283,10 +283,6 @@ static void validateDependencyScanningArgs(DiagnosticEngine &diags,
     diags.diagnose(SourceLoc(), diag::error_requirement_not_met,
                    "-import-prescan", "-scan-dependencies");
   }
-  if (Prescan && !ScanDependencies) {
-    diags.diagnose(SourceLoc(), diag::error_requirement_not_met,
-                   "-import-prescan", "-scan-dependencies");
-  }
   if (SerializeCache && !ScanDependencies) {
     diags.diagnose(SourceLoc(), diag::error_requirement_not_met,
                    "-serialize-dependency-scan-cache", "-scan-dependencies");
@@ -302,7 +298,7 @@ static void validateDependencyScanningArgs(DiagnosticEngine &diags,
   }
   if (ReuseCache && !CacheSerializationPath) {
     diags.diagnose(SourceLoc(), diag::error_requirement_not_met,
-                   "-serialize-dependency-scan-cache",
+                   "-load-dependency-scan-cache",
                    "-dependency-scan-cache-path");
   }
   if (ValidatePriorCache && !ReuseCache) {

--- a/test/Driver/dependency-scanning-options.swift
+++ b/test/Driver/dependency-scanning-options.swift
@@ -1,0 +1,10 @@
+// REQUIRES: legacy_swift_driver
+
+// RUN: not %swiftc_driver -import-prescan %s 2>&1 | %FileCheck %s --check-prefix=IMPORT-PRESCAN
+// RUN: not %swiftc_driver -scan-dependencies -load-dependency-scan-cache %s 2>&1 \
+// RUN:   | %FileCheck %s --check-prefix=LOAD-CACHE
+
+// IMPORT-PRESCAN: error: '-import-prescan' requires '-scan-dependencies'
+// IMPORT-PRESCAN-NOT: error: '-import-prescan' requires '-scan-dependencies'
+
+// LOAD-CACHE: error: '-load-dependency-scan-cache' requires '-dependency-scan-cache-path'


### PR DESCRIPTION
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->


The legacy driver validates `-import-prescan` twice when `-scan-dependencies` is absent, causing it to emit the same requirement diagnostic twice. It also names `-serialize-dependency-scan-cache` in the missing cache-path diagnostic for `-load-dependency-scan-cache`.

Remove the duplicate validation and correct the option named in the cache reuse diagnostic. Add focused legacy-driver coverage that verifies the prescan diagnostic is emitted once and that the cache-path diagnostic references the load option.