### PR TITLE
[Test] Fix test/IRGen/objc_super.swift

### DIFF
--- a/test/IRGen/objc_super.swift
+++ b/test/IRGen/objc_super.swift
@@ -4,6 +4,7 @@
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 
 import gizmo
 

--- a/test/IRGen/objc_super.swift
+++ b/test/IRGen/objc_super.swift
@@ -4,7 +4,6 @@
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop
-// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 
 import gizmo
 
@@ -94,7 +93,7 @@ class GenericRuncer<T> : Gizmo {
 // Use a constant indirect field access instead of a non-constant direct
 // access because the layout dependents on the alignment of y.
 
-// CHECK: define hidden swiftcc i64 @"$s10objc_super13GenericRuncerC1xSo5GizmoCSgvg"(ptr swiftself %0)
+// CHECK: define hidden swiftcc ptr @"$s10objc_super13GenericRuncerC1xSo5GizmoCSgvg"(ptr swiftself %0)
 // CHECK:    inttoptr
 // CHECK:   [[ISA:%.*]] = load i64, ptr %0
 // CHECK:   [[ISAMASK:%.*]] = load i64, ptr @swift_isaMask
@@ -103,10 +102,9 @@ class GenericRuncer<T> : Gizmo {
 // CHECK:   [[OFFSETADDR:%.*]] = getelementptr inbounds i64, ptr [[TY]], i64 11
 // CHECK:   [[FIELDOFFSET:%.*]] = load i64, ptr [[OFFSETADDR]]
 // CHECK:   [[FIELDADDR:%.*]] = getelementptr inbounds i8, ptr %0, i64 [[FIELDOFFSET]]
-// CHECK:   [[OPTIONAL:%.*]] = load i64, ptr [[FIELDADDR]]
-// CHECK:   [[OBJ:%.*]] = inttoptr i64 [[OPTIONAL]] to ptr
+// CHECK:   [[OBJ:%.*]] = load ptr, ptr [[FIELDADDR]]
 // CHECK:   call ptr @llvm.objc.retain(ptr [[OBJ]])
-// CHECK:   ret i64 [[OPTIONAL]]
+// CHECK:   ret ptr [[OBJ]]
 
   // CHECK: define hidden swiftcc void @"$s10objc_super13GenericRuncerC5runceyyFZ"(ptr swiftself %0) {{.*}} {
   override class func runce() {


### PR DESCRIPTION
This test only runs in no assert builds and had to adjusted after changes to make optional references be represented as ptr in IR

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
