### PR TITLE
[Sema] Suggest a case correction for misspelled module names in imports

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -869,6 +869,8 @@ ERROR(sema_no_import,Fatal,
       "no such module '%0'", (StringRef))
 NOTE(did_you_mean_cxxstdlib,none,
       "did you mean 'CxxStdlib'?'", ())
+NOTE(sema_no_import_case_mismatch,none,
+     "did you mean %0?", (Identifier))
 ERROR(sema_no_import_target,Fatal,
       "could not find module '%0' for target '%1'; "
       "found: %2, at: %3", (StringRef, StringRef, StringRef, StringRef))

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -529,6 +529,24 @@ ImportPath::Module getRealModulePath(ImportPath::Builder &builder, ImportPath::M
   return builder.get().getModulePath(false);
 }
 
+/// Returns the name of a visible top-level module that differs from \p name
+/// only in capitalization, if there is exactly one such module.
+static Identifier findModuleNameDifferingOnlyInCase(ASTContext &ctx,
+                                                    Identifier name) {
+  SmallVector<Identifier, 16> visibleNames;
+  ctx.getVisibleTopLevelModuleNames(visibleNames);
+
+  Identifier result;
+  for (Identifier candidate : visibleNames) {
+    if (candidate == name || !candidate.str().equals_insensitive(name.str()))
+      continue;
+    if (!result.empty())
+      return Identifier();
+    result = candidate;
+  }
+  return result;
+}
+
 static void diagnoseNoSuchModule(ModuleDecl *importingModule,
                                  SourceLoc importLoc,
                                  ImportPath::Module modulePath,
@@ -555,6 +573,19 @@ static void diagnoseNoSuchModule(ModuleDecl *importingModule,
     if (realFront != sourceFront)
       ctx.Diags.diagnose(importLoc, diag::sema_module_aliased, sourceFront,
                          realFront);
+
+    // Suggest a module that differs from the written name only in
+    // capitalization. Skip this when the import was rewritten by
+    // -module-alias, since the fix-it would edit the aliased spelling.
+    const SourceLoc frontLoc = modulePath.front().Loc;
+    if (realFront == sourceFront && frontLoc.isValid()) {
+      Identifier corrected =
+          findModuleNameDifferingOnlyInCase(ctx, modulePath.front().Item);
+      if (!corrected.empty())
+        ctx.Diags
+            .diagnose(frontLoc, diag::sema_no_import_case_mismatch, corrected)
+            .fixItReplace(frontLoc, corrected.str());
+    }
   }
 
   if (ctx.SearchPathOpts.getSDKPath().empty() &&

--- a/test/ImportResolution/import-case-mismatch.swift
+++ b/test/ImportResolution/import-case-mismatch.swift
@@ -1,0 +1,33 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// These errors are fatal, so test each one separately. Clang modules are used
+// because their name lookup is case-sensitive on all platforms, unlike
+// serialized Swift modules on case-insensitive filesystems.
+
+// RUN: %target-swift-frontend -typecheck -verify -I %t/include %t/wrong-case.swift
+// RUN: %target-swift-frontend -typecheck -verify -I %t/include %t/wrong-case-submodule.swift
+// RUN: %target-swift-frontend -typecheck -verify -I %t/include %t/unrelated-name.swift
+// RUN: %target-swift-frontend -typecheck -verify -I %t/include -I %t/ambiguous %t/ambiguous-case.swift
+
+//--- include/module.modulemap
+module Cheese { }
+
+//--- wrong-case.swift
+import cheese // expected-error{{no such module 'cheese'}}
+              // expected-note@-1{{did you mean 'Cheese'?}}{{8-14=Cheese}} {{none}}
+
+//--- wrong-case-submodule.swift
+import CHEESE.Curds // expected-error{{no such module 'CHEESE.Curds'}}
+                    // expected-note@-1{{did you mean 'Cheese'?}}{{8-14=Cheese}} {{none}}
+
+//--- unrelated-name.swift
+import Gorgonzola // expected-error{{no such module 'Gorgonzola'}}
+
+//--- ambiguous/module.modulemap
+module Fondue { }
+module FONDUE { }
+
+//--- ambiguous-case.swift
+// No suggestion when several modules match the written name case-insensitively.
+import fondue // expected-error{{no such module 'fondue'}}


### PR DESCRIPTION
When an `import` fails because no module with the written name exists, we now check whether exactly one visible top-level module differs from the written name only in capitalization, and if so attach a note with a fix-it.

Before:

```
imp.swift:1:8: error: no such module 'foundation'
1 | import foundation
  |        `- error: no such module 'foundation'
```

After:

```
imp.swift:1:8: error: no such module 'foundation'
1 | import foundation
  |        |- error: no such module 'foundation'
  |        `- note: did you mean 'Foundation'?
```

Notes on the implementation:

* The lookup uses `ASTContext::getVisibleTopLevelModuleNames()`, so it covers serialized Swift modules, Clang modules, and SDK frameworks uniformly, and only runs on the error path.
* No suggestion is made when several visible modules match the written name case-insensitively, or when the name was rewritten by `-module-alias` (the fix-it would edit the aliased spelling written in source).
* The lit test uses Clang modules because their name lookup is case-sensitive on all platforms; serialized Swift modules on case-insensitive filesystems fail earlier with `serialization::Status::NameMismatch` ("cannot load module 'X' as 'x'"), the path that #18308 previously attempted to improve.

Resolves #46842 (SR-4259).
