### PR TITLE
[benchmark] Add String.insert(contentsOf:at:) benchmarks

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -198,6 +198,7 @@ set(SWIFT_BENCH_MODULES
     single-source/StringDistance
     single-source/StringEdits
     single-source/StringEnum
+    single-source/StringInsert
     single-source/StringInterpolation
     single-source/StringMatch
     single-source/StringRemoveDupes

--- a/benchmark/single-source/StringInsert.swift
+++ b/benchmark/single-source/StringInsert.swift
@@ -1,0 +1,121 @@
+//===--- StringInsert.swift -----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import TestsUtils
+
+// Benchmarks for `String.insert(contentsOf:at:)`, the RangeReplaceableCollection
+// insertion that takes an arbitrary Collection of Characters. Every payload
+// below inserts the same three characters, so the numbers only differ in the
+// type of the collection being inserted from.
+//
+// String, Substring and Array<Character> have `@_specialize` attributes on
+// `insert(contentsOf:at:)`; Repeated<Character> does not, so it covers the
+// unspecialized generic path. That path is more than an order of magnitude
+// slower, so the Repeated<Character> benchmarks perform fewer insertions per
+// iteration to keep every benchmark inside the runtime window that
+// `Benchmark_Driver check` expects. Divide by `specialized`/`unspecialized`
+// before comparing numbers across payload types.
+//
+// The single-`Character` overload is covered by InsertCharacter.swift.
+
+let tags: [BenchmarkCategory] = [.validation, .api, .String, .cpubench]
+
+public let benchmarks = [
+  BenchmarkInfo(
+    name: "String.insertContentsOf.String.Small",
+    runFunction: { insert($0, smallString, with: stringPayload, count: specialized) },
+    tags: tags,
+    setUpFunction: buildWorkload
+  ),
+  BenchmarkInfo(
+    name: "String.insertContentsOf.String",
+    runFunction: { insert($0, largeString, with: stringPayload, count: specialized) },
+    tags: tags,
+    setUpFunction: buildWorkload
+  ),
+  BenchmarkInfo(
+    name: "String.insertContentsOf.Substring.Small",
+    runFunction: { insert($0, smallString, with: substringPayload, count: specialized) },
+    tags: tags,
+    setUpFunction: buildWorkload
+  ),
+  BenchmarkInfo(
+    name: "String.insertContentsOf.Substring",
+    runFunction: { insert($0, largeString, with: substringPayload, count: specialized) },
+    tags: tags,
+    setUpFunction: buildWorkload
+  ),
+  BenchmarkInfo(
+    name: "String.insertContentsOf.ArrChar.Small",
+    runFunction: { insert($0, smallString, with: arrayPayload, count: specialized) },
+    tags: tags,
+    setUpFunction: buildWorkload
+  ),
+  BenchmarkInfo(
+    name: "String.insertContentsOf.ArrChar",
+    runFunction: { insert($0, largeString, with: arrayPayload, count: specialized) },
+    tags: tags,
+    setUpFunction: buildWorkload
+  ),
+  BenchmarkInfo(
+    name: "String.insertContentsOf.RepChar.Small",
+    runFunction: { insert($0, smallString, with: repeatedPayload, count: unspecialized) },
+    tags: tags,
+    setUpFunction: buildWorkload
+  ),
+  BenchmarkInfo(
+    name: "String.insertContentsOf.RepChar",
+    runFunction: { insert($0, largeString, with: repeatedPayload, count: unspecialized) },
+    tags: tags,
+    setUpFunction: buildWorkload
+  ),
+]
+
+// Insertions performed per iteration of `n`, picked so that every benchmark
+// lands well inside the 20–1000 μs window checked by `Benchmark_Driver check`.
+let specialized = 3000
+let unspecialized = 900
+
+let smallString = "coffee"
+let largeString = "coffee\u{301}coffeecoffeecoffeecoffee"
+
+let stringPayload = "ttt"
+let substringPayload = "ttt"[...]
+let arrayPayload = Array<Character>(["t", "t", "t"])
+let repeatedPayload = repeatElement(Character("t"), count: 3)
+
+// Force the lazy initialization of the workloads out of the measured region.
+func buildWorkload() {
+  blackHole(smallString)
+  blackHole(largeString)
+  blackHole(stringPayload)
+  blackHole(substringPayload)
+  blackHole(arrayPayload)
+  blackHole(repeatedPayload)
+}
+
+// Insert at the start index, so the existing contents have to be shifted out of
+// the way. Each iteration starts from a fresh copy: repeatedly inserting into
+// the same string would make it grow without bound, turning the workload
+// super-linear in `n` and pushing the small-string cases out of small form
+// after the first few insertions. The copy costs the same for every payload
+// type, so the comparison between them still holds.
+@inline(never)
+private func insert<C: Collection>(
+  _ n: Int, _ string: String, with newElements: C, count: Int
+) where C.Element == Character {
+  for _ in 0 ..< count * n {
+    var copy = getString(string)
+    copy.insert(contentsOf: newElements, at: copy.startIndex)
+    blackHole(copy)
+  }
+}

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -203,6 +203,7 @@ import StringComparison
 import StringDistance
 import StringEdits
 import StringEnum
+import StringInsert
 import StringInterpolation
 import StringMatch
 import StringRemoveDupes
@@ -417,6 +418,7 @@ register(StringComparison.benchmarks)
 register(StringDistance.benchmarks)
 register(StringEdits.benchmarks)
 register(StringEnum.benchmarks)
+register(StringInsert.benchmarks)
 register(StringInterpolation.benchmarks)
 register(StringMatch.benchmarks)
 register(StringRemoveDupes.benchmarks)


### PR DESCRIPTION
Fills one of the gaps listed in #51411: `insert<C: Collection>(_: C)` with arguments of type `String`, `Substring`, `Array<Character>` and `Repeated<Character>`. The single-`Character` overload is already covered by `InsertCharacter.swift`, and `replaceSubrange<C>` by `StringReplaceSubrange.swift` (#25310), which this benchmark is modelled after.

### What is measured

Eight benchmarks: four payload types × two receivers (a small-form `"coffee"` and a larger non-ASCII `"coffee\u{301}coffee…"`). All four payloads insert the same three characters, so the numbers differ only in the type of the collection being inserted from.

Insertion happens at `startIndex`, so the existing contents have to be shifted out of the way. Each iteration starts from a fresh copy — repeatedly inserting into the same string would make it grow without bound, turning the workload super-linear in `n` and pushing the small-string cases out of small form after the first few insertions. The copy costs the same for every payload type, so the comparison between them still holds.

`String.insert(contentsOf:at:)` carries `@_specialize` attributes for `String`, `Substring` and `Array<Character>`, but not for arbitrary collections, so `Repeated<Character>` exercises the unspecialized generic path. It turns out to be an order of magnitude slower, which is why those two benchmarks perform 900 insertions per iteration where the others perform 3000 — with a single shared count, one end or the other of the suite ends up outside the runtime window that `Benchmark_Driver check` expects.

### Results

`Benchmark_O`, 30 samples, Apple silicon, arm64-apple-macosx13.0. The last column normalizes for the differing insertion counts:

| Benchmark | MIN | MEDIAN | ns per insertion |
|---|---|---|---|
| `String.insertContentsOf.String.Small` | 110.5 µs | 172.2 µs | 36.8 |
| `String.insertContentsOf.Substring.Small` | 134.0 µs | 154.4 µs | 44.7 |
| `String.insertContentsOf.ArrChar.Small` | 134.6 µs | 165.7 µs | 44.9 |
| `String.insertContentsOf.String` | 194.8 µs | 213.0 µs | 64.9 |
| `String.insertContentsOf.ArrChar` | 230.2 µs | 259.0 µs | 76.7 |
| `String.insertContentsOf.Substring` | 237.2 µs | 261.3 µs | 79.1 |
| `String.insertContentsOf.RepChar.Small` | 588.7 µs | 703.3 µs | 654.1 |
| `String.insertContentsOf.RepChar` | 596.9 µs | 682.2 µs | 663.3 |

Every benchmark sits inside the 20–1000 µs window; names are at most 39 characters and match the naming convention regex. `Benchmark_Driver check` is clean on repeated runs — it does intermittently report a ~6% setup overhead, but on a different benchmark each time and not at all on most runs, which is the `2 × (i1 − i2)` estimate picking up ordinary run-to-run jitter rather than real setup work; the workloads themselves are initialized in `setUpFunction`.
