### PR TITLE
[SILOptimizer] Diagnose missing nil in failable initializer returns

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -267,6 +267,9 @@ ERROR(self_inside_catch_superselfinit,none,
 ERROR(return_from_init_without_initing_stored_properties,none,
       "return from initializer without initializing all"
       " stored properties", ())
+ERROR(return_from_failable_init_without_nil,none,
+      "return from failable initializer before initializing all stored "
+      "properties; did you mean to return 'nil'?", ())
 
 ERROR(explicit_store_of_compilerinitialized,none,
       "illegal assignment to '@_compilerInitialized' storage", ())

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -540,6 +540,9 @@ namespace {
     void diagnoseRefElementAddr(RefElementAddrInst *REI);
     bool diagnoseMethodCall(const DIMemoryUse &Use,
                             bool SuperInitDone);
+    std::optional<SILLocation>
+    getUninitializedExplicitReturnLocation(const DIMemoryUse &Use);
+    bool diagnoseMissingNilInFailableInitializer(const DIMemoryUse &Use);
     void diagnoseBadExplicitStore(SILInstruction *Inst);
     
     bool isBlockIsReachableFromEntry(const SILBasicBlock *BB);
@@ -2321,6 +2324,64 @@ bool LifetimeChecker::diagnoseReturnWithoutInitializingStoredProperties(
   return true;
 }
 
+std::optional<SILLocation>
+LifetimeChecker::getUninitializedExplicitReturnLocation(
+    const DIMemoryUse &Use) {
+  auto *block = Use.Inst->getParent();
+  auto isUninitializedExplicitReturn = [&](SILInstruction *inst) {
+    return inst->getLoc().is<ReturnLocation>() &&
+           getAnyUninitializedMemberAtInst(inst, Use.FirstElement,
+                                           Use.NumElements) != -1;
+  };
+
+  if (isUninitializedExplicitReturn(block->getTerminator()))
+    return block->getTerminator()->getLoc();
+
+  for (auto *predecessor : block->getPredecessorBlocks()) {
+    auto *terminator = predecessor->getTerminator();
+    if (isUninitializedExplicitReturn(terminator))
+      return terminator->getLoc();
+  }
+
+  return std::nullopt;
+}
+
+bool LifetimeChecker::diagnoseMissingNilInFailableInitializer(
+    const DIMemoryUse &Use) {
+  // SIL functions parsed from a .sil file and top-level code have no decl
+  // context, so this has to be checked before asking for the decl.
+  auto *DC = F.getDeclContext();
+  if (!DC)
+    return false;
+
+  auto *ctor = dyn_cast_or_null<ConstructorDecl>(DC->getAsDecl());
+  if (!ctor || !ctor->isFailable())
+    return false;
+
+  // Only diagnose when the failure is reached through an explicit return that
+  // leaves stored properties uninitialized. Any other use before initialization
+  // keeps its own, more precise diagnostic.
+  auto returnLoc = getUninitializedExplicitReturnLocation(Use);
+  if (!returnLoc)
+    return false;
+
+  if (!shouldEmitError(Use.Inst))
+    return false;
+
+  // The diagnostic has to be flushed before the notes are emitted: notes are
+  // held back while another diagnostic is in flight, and they refer to storage
+  // that does not outlive noteUninitializedMembers().
+  {
+    auto diag = diagnose(Module, *returnLoc,
+                         diag::return_from_failable_init_without_nil);
+    if (auto *returnStmt = returnLoc->getAsASTNode<ReturnStmt>())
+      diag.fixItInsertAfter(returnStmt->getEndLoc(), " nil");
+  }
+
+  noteUninitializedMembers(Use);
+  return true;
+}
+
 /// Check and diagnose various failures when a load use is not fully
 /// initialized.
 ///
@@ -2342,6 +2403,9 @@ void LifetimeChecker::handleLoadUseFailure(const DIMemoryUse &Use,
     emitSelfConsumedDiagnostic(Inst);
     return;
   }
+
+  if (diagnoseMissingNilInFailableInitializer(Use))
+    return;
   
   // If this is a load with a single user that is a return (and optionally a
   // retain_value for non-trivial structs/enums), then this is a return in the

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -1163,7 +1163,7 @@ struct S1_44078 {
   init?(x: Int, y: Int) {
     self.a = x
     if y == 42 {
-      return // expected-error {{return from initializer without initializing all stored properties}}
+      return // expected-error {{return from failable initializer before initializing all stored properties; did you mean to return 'nil'?}} {{13-13= nil}}
     }
     // many lines later
     self.b = y
@@ -1176,7 +1176,7 @@ struct S2_44078 {
   
   init?(x: Int, y: Int) {
     self.a = x
-    return // expected-error {{return from initializer without initializing all stored properties}}
+    return // expected-error {{return from failable initializer before initializing all stored properties; did you mean to return 'nil'?}} {{11-11= nil}}
   }
 }
 

--- a/test/SILOptimizer/definite_init_failable_initializers_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_failable_initializers_diagnostics.swift
@@ -20,6 +20,39 @@ struct A {
   } // expected-error {{return from initializer without initializing all stored properties}}
 }
 
+class MissingNilInFailableInitializer {
+  let value: Int  // expected-note {{'self.value' not initialized}}
+
+  init?(value: Int?) {
+    guard let value = value else {
+      return // expected-error {{return from failable initializer before initializing all stored properties; did you mean to return 'nil'?}} {{13-13= nil}}
+    }
+    self.value = value
+  }
+}
+
+class ValidReturnFromFailableInitializer {
+  let value: Int
+
+  init?(value: Int) {
+    self.value = value
+    return // no-error
+  }
+}
+
+// A use before initialization keeps its own diagnostic, even when the failable
+// initializer contains a bare return elsewhere.
+class UseBeforeInitInFailableInitializer {
+  let value: Int
+
+  init?(fail: Bool) {
+    guard !fail else { return nil }
+    print(value) // expected-error {{constant 'self.value' used before being initialized}}
+    self.value = 0
+    return // no-error
+  }
+}
+
 // Delegating, failable initializers that doesn't initialize along all paths must produce correct diagnostics.
 extension Int {
   init?(i: Int) {


### PR DESCRIPTION
A plain `return` is permitted in a failable initializer after all stored properties have been initialized. However, when it occurs on a path that returns before initialization is complete, definite initialization currently emits an unhelpful diagnostic at the end of the initializer.

This detects an explicit bare `return` after definite initialization has established that the return path is invalid, diagnoses it at the return statement, and offers a fix-it to insert `nil`. A plain `return` after full initialization remains valid.

The return is identified from SIL: the terminator of the block containing the failing use, or of one of its predecessors, has to carry an explicit `ReturnLocation` and still leave stored properties uninitialized. An implicit return at the closing brace keeps its existing diagnostic, and a use before initialization that is not reached through such a return keeps its own, more precise message.

This also changes the diagnostic for two existing cases in `test/SILOptimizer/definite_init_diagnostics.swift`, `S1_44078` and `S2_44078`. Both are explicit returns without `nil` in a failable struct initializer, which is exactly the case this issue is about, so their expectations are updated to the new message and fix-it.

Adds a regression test for the diagnostic, a positive case for the valid return, and a case where a use before initialization coexists with a legal bare return.

Resolves https://github.com/swiftlang/swift/issues/54860.
