### PR TITLE
[Sema] Add a Fix-It to remove a redundant conformance

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1989,7 +1989,10 @@ SourceLoc InheritedTypes::getColonLoc() const {
     precedingTok = typeDecl->getNameLoc();
   } else {
     auto *ext = cast<const ExtensionDecl *>(Decl);
-    precedingTok = ext->getSourceRange().End;
+    auto *extendedTypeRepr = ext->getExtendedTypeRepr();
+    if (!extendedTypeRepr)
+      return SourceLoc();
+    precedingTok = extendedTypeRepr->getEndLoc();
   }
 
   auto &ctx = getASTContext();

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -6862,6 +6862,49 @@ static bool isImpliedByConformancePredatingConcurrency(
   return isImpliedByConformancePredatingConcurrency(implied);
 }
 
+/// Find the source range to remove the inheritance clause entry of \p idc
+/// that declared a redundant conformance to \p proto at \p loc, for use in
+/// a Fix-It.
+///
+/// Returns an invalid range when the redundant conformance cannot be removed
+/// by deleting an inheritance clause entry: it was not written directly in
+/// this declaration's inheritance clause, or the entry that declared it
+/// states more than just this conformance (e.g. a protocol composition or a
+/// typealias referring to one).
+static SourceRange getRedundantConformanceRemovalRange(IterableDeclContext *idc,
+                                                       ProtocolDecl *proto,
+                                                       SourceLoc loc) {
+  if (loc.isInvalid())
+    return SourceRange();
+
+  llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *> decl;
+  if (auto *ext = dyn_cast<ExtensionDecl>(idc->getDecl()))
+    decl = ext;
+  else
+    decl = cast<NominalTypeDecl>(idc->getDecl());
+
+  auto inheritedTypes = InheritedTypes(decl);
+  for (auto i : inheritedTypes.getIndices()) {
+    auto *typeRepr = inheritedTypes.getTypeRepr(i);
+    if (!typeRepr || typeRepr->getLoc() != loc)
+      continue;
+
+    // Only offer to remove the entry when it declares nothing besides the
+    // redundant conformance itself.
+    SmallVector<InheritedNominalEntry, 2> entries;
+    InvertibleProtocolSet inverses;
+    bool anyObject = false;
+    getDirectlyInheritedNominalTypeDecls(decl, i, entries, inverses, anyObject);
+    if (anyObject || !inverses.empty() || entries.size() != 1 ||
+        entries.front().Item != proto || entries.front().isSuppressed)
+      return SourceRange();
+
+    return inheritedTypes.getRemovalRange(i);
+  }
+
+  return SourceRange();
+}
+
 void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
   auto *const dc = idc->getAsGenericContext();
   auto *sf = dc->getParentSourceFile();
@@ -7088,6 +7131,15 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
                                   currentSig.getCanonicalSignature() !=
                                       existingSig.getCanonicalSignature();
 
+    // If the redundant conformance was explicitly written in this
+    // declaration's inheritance clause, offer to remove it. The range is
+    // invalid when no removal Fix-It applies, in which case attaching it
+    // below is a no-op.
+    SourceRange removalRange;
+    if (diag.Kind == ConformanceEntryKind::Explicit)
+      removalRange =
+          getRedundantConformanceRemovalRange(idc, diag.Protocol, diag.Loc);
+
     // If we've redundantly stated a conformance for which the original
     // conformance came from the module of the type or the module of the
     // protocol, just warn; we'll pick up the original conformance.
@@ -7140,16 +7192,22 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
         Context.Diags.diagnose(diag.Loc, diag::redundant_conformance,
                                nominal->getDeclaredInterfaceType(),
                                diag.Protocol->getName())
-          .limitBehavior(DiagnosticBehavior::Warning);
+          .limitBehavior(DiagnosticBehavior::Warning)
+          .fixItRemoveChars(removalRange.Start, removalRange.End);
       } else {
         auto diagID = differentlyConditional
                           ? diag::redundant_conformance_adhoc_conditional
                           : diag::redundant_conformance_adhoc;
-        Context.Diags.diagnose(diag.Loc, diagID, dc->getDeclaredInterfaceType(),
-                               diag.Protocol->getName(),
-                               existingModule->getName() ==
-                                   extendedNominal->getParentModule()->getName(),
-                               existingModule->getName());
+        auto inFlight = Context.Diags.diagnose(
+            diag.Loc, diagID, dc->getDeclaredInterfaceType(),
+            diag.Protocol->getName(),
+            existingModule->getName() ==
+                extendedNominal->getParentModule()->getName(),
+            existingModule->getName());
+        // Don't suggest removing a conditional conformance; the user needs
+        // to decide which of the two conformances to keep.
+        if (!differentlyConditional)
+          inFlight.fixItRemoveChars(removalRange.Start, removalRange.End);
       }
 
       // Complain about any declarations in this extension whose names match
@@ -7184,8 +7242,13 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
       auto diagID = differentlyConditional
                         ? diag::redundant_conformance_conditional
                         : diag::redundant_conformance;
-      Context.Diags.diagnose(diag.Loc, diagID, dc->getDeclaredInterfaceType(),
-                             diag.Protocol->getName());
+      auto inFlight = Context.Diags.diagnose(
+          diag.Loc, diagID, dc->getDeclaredInterfaceType(),
+          diag.Protocol->getName());
+      // Don't suggest removing a conditional conformance; the user needs to
+      // decide which of the two conformances to keep.
+      if (!differentlyConditional)
+        inFlight.fixItRemoveChars(removalRange.Start, removalRange.End);
     }
 
     // Special case: explain that 'RawRepresentable' conformance

--- a/test/decl/protocol/conforms/redundant_conformance.swift
+++ b/test/decl/protocol/conforms/redundant_conformance.swift
@@ -8,7 +8,7 @@ import redundant_conformance_A
 import redundant_conformance_B
 
 extension ConformsToP
-  : P1 { // expected-warning{{conformance of 'ConformsToP' to protocol 'P1' was already stated in the type's module 'redundant_conformance_A'}}
+  : P1 { // expected-warning{{conformance of 'ConformsToP' to protocol 'P1' was already stated in the type's module 'redundant_conformance_A'}} {{10:22-11:7=}}
   typealias A = Double // expected-note{{type alias 'A' will not be used to satisfy the conformance to 'P1'}}
 
   func f() -> Double { return 0.0 } // expected-note{{instance method 'f()' will not be used to satisfy the conformance to 'P1'}}
@@ -16,10 +16,10 @@ extension ConformsToP
 }
 
 extension ConformsToP
-  : P2 { // expected-warning{{conformance of 'ConformsToP' to protocol 'P2' was already stated in the protocol's module 'redundant_conformance_B'}}
+  : P2 { // expected-warning{{conformance of 'ConformsToP' to protocol 'P2' was already stated in the protocol's module 'redundant_conformance_B'}} {{18:22-19:7=}}
 }
 
-extension OtherConformsToP : P1 { // expected-error{{redundant conformance of 'OtherConformsToP' to protocol 'P1'}}
+extension OtherConformsToP : P1 { // expected-error{{redundant conformance of 'OtherConformsToP' to protocol 'P1'}} {{27-32=}}
   func f() -> Int { return 0 }
 }
 
@@ -44,7 +44,7 @@ extension GenericConformsToP: P2 where T: P1 {
 }
 
 extension OtherGenericConformsToP: P1 where T: P1 {
-// expected-error@-1{{conflicting conformance of 'OtherGenericConformsToP<T>' to protocol 'P1'; there cannot be more than one conformance, even with different conditional bounds}}
+// expected-error@-1{{conflicting conformance of 'OtherGenericConformsToP<T>' to protocol 'P1'; there cannot be more than one conformance, even with different conditional bounds}} {{none}}
     typealias A = Double
     func f() -> Double { return 0.0 }
 }
@@ -61,7 +61,7 @@ extension GenericConditionalConformsToP: P2 {
 }
 
 extension OtherGenericConditionalConformsToP: P1 {
-// expected-error@-1{{conflicting conformance of 'OtherGenericConditionalConformsToP<T>' to protocol 'P1'; there cannot be more than one conformance, even with different conditional bounds}}
+// expected-error@-1{{conflicting conformance of 'OtherGenericConditionalConformsToP<T>' to protocol 'P1'; there cannot be more than one conformance, even with different conditional bounds}} {{none}}
     typealias A = Double
     func f() -> Double { return 0.0 }
 }
@@ -91,5 +91,5 @@ class SomeMockClass: Class3.ProviderThree { // okay
 class ImplicitCopyable {}
 
 class InheritImplicitCopyable: ImplicitCopyable, Copyable {}
-// expected-warning@-1 {{redundant conformance of 'InheritImplicitCopyable' to protocol 'Copyable'}}
+// expected-warning@-1 {{redundant conformance of 'InheritImplicitCopyable' to protocol 'Copyable'}} {{48-58=}}
 // expected-note@-2 {{'InheritImplicitCopyable' inherits conformance to protocol 'Copyable' from superclass here}}

--- a/test/decl/protocol/conforms/redundant_conformance_fixit.swift
+++ b/test/decl/protocol/conforms/redundant_conformance_fixit.swift
@@ -1,0 +1,52 @@
+// RUN: %target-typecheck-verify-swift
+
+// https://github.com/swiftlang/swift/issues/47634
+// The redundant conformance diagnostic should offer to remove the redundant
+// conformance from the inheritance clause.
+
+protocol P1 {}
+protocol P2 {}
+
+// Remove the whole inheritance clause when the redundant conformance is its
+// only entry.
+struct S1: P1 {} // expected-note {{'S1' declares conformance to protocol 'P1' here}}
+extension S1: P1 {} // expected-error {{redundant conformance of 'S1' to protocol 'P1'}} {{13-17=}}
+
+// Remove through the start of the next entry when the redundant conformance
+// comes first.
+struct S2: P1 {} // expected-note {{'S2' declares conformance to protocol 'P1' here}}
+extension S2: P1, P2 {} // expected-error {{redundant conformance of 'S2' to protocol 'P1'}} {{15-19=}}
+
+// Remove from the end of the previous entry when the redundant conformance
+// comes last.
+struct S3: P1 {} // expected-note {{'S3' declares conformance to protocol 'P1' here}}
+extension S3: P2, P1 {} // expected-error {{redundant conformance of 'S3' to protocol 'P1'}} {{17-21=}}
+
+// The conformance on the type declaration itself wins even when the
+// extension comes first in the file; the extension gets the Fix-It.
+extension S4: P1 {}
+// expected-error@-1 {{redundant conformance of 'S4' to protocol 'P1'}} {{13-17=}}
+struct S4: P1 {} // expected-note {{'S4' declares conformance to protocol 'P1' here}}
+
+// The Fix-It also applies to the type declaration's own inheritance clause,
+// and entries surrounding the removed one are kept intact.
+class Base2: P1 {}
+class Sub2: Base2, P1 {}
+// expected-error@-1 {{redundant conformance of 'Sub2' to protocol 'P1'}} {{18-22=}}
+// expected-note@-2 {{'Sub2' inherits conformance to protocol 'P1' from superclass here}}
+
+// No Fix-It when the conformance was written as part of a protocol
+// composition; the other members of the composition must stay.
+struct S5: P1 {} // expected-note {{'S5' declares conformance to protocol 'P1' here}}
+extension S5: P1 & P2 {} // expected-error {{redundant conformance of 'S5' to protocol 'P1'}} {{none}}
+
+// No Fix-It when the conformance came from a typealias that also states
+// other conformances.
+typealias BothP1AndP2 = P1 & P2
+struct S6: P1 {} // expected-note {{'S6' declares conformance to protocol 'P1' here}}
+extension S6: BothP1AndP2 {} // expected-error {{redundant conformance of 'S6' to protocol 'P1'}} {{none}}
+
+// A typealias naming just the redundant protocol can be removed.
+typealias JustP1 = P1
+struct S7: P1 {} // expected-note {{'S7' declares conformance to protocol 'P1' here}}
+extension S7: JustP1 {} // expected-error {{redundant conformance of 'S7' to protocol 'P1'}} {{13-21=}}


### PR DESCRIPTION
Fixes #47634 (SR-5058)

The redundant conformance diagnostic points at the redundant protocol entry, but doesn't offer to remove it:

```swift
protocol Foo {}
struct Bar {}

extension Bar: Foo {}
extension Bar: Foo {} // error: redundant conformance of 'Bar' to protocol 'Foo'
```

Attach a Fix-It that deletes the inheritance clause entry (via `InheritedTypes::getRemovalRange`, which accounts for commas and the colon) when the conformance was explicitly written and the entry declares nothing besides that conformance. Entries that mention anything else — protocol compositions (`P & Q`) or typealiases referring to them — are left alone, since their other members must stay. The conditional variants of the diagnostic keep offering no Fix-It: there the user has to decide which of the two conformances to keep, matching the `duplicate_inheritance` precedent. The Fix-It also applies to the cross-module `was already stated in ...` warnings.

Testing:
- New `test/decl/protocol/conforms/redundant_conformance_fixit.swift` covering removal at each clause position, on the type declaration itself, and the no-Fix-It cases (compositions, typealiases to compositions, conditional conformances)
- Updated `test/decl/protocol/conforms/redundant_conformance.swift` with Fix-It expectations
- Ran `llvm-lit` over `test/decl/protocol/conforms` plus every other test that mentions these diagnostics (54 tests) — all pass

While wiring this up, `InheritedTypes::getColonLoc()` turned out to have a latent bug: for extensions it derived the location from `ext->getSourceRange().End` — the end of the whole extension, past the closing brace — which produced an inverted removal range. The single-entry removal path was previously unreachable for extensions, so nothing hit it before. It now uses the end location of the extended type repr.
