### PR TITLE
[stdlib] Fix Atomic.min/max using signed comparison on unsigned types

### DIFF
--- a/test/stdlib/Synchronization/Atomics/Basics/Tests.gyb-template
+++ b/test/stdlib/Synchronization/Atomics/Basics/Tests.gyb-template
@@ -352,6 +352,23 @@ suite.test("Atomic${label} ${name} ${order}") {
   expectEqual(val2.oldValue, result1)
   expectEqual(val2.newValue, result2)
   expectEqual(v.load(ordering: .relaxed), result2)
+
+  // The operands above stay in a narrow low range, where wrapping never occurs
+  // and signed and unsigned comparison agree. Repeat at the bounds of the type.
+  // https://github.com/swiftlang/swift/issues/91176
+  for extreme in [${type}.min, ${type}.max] {
+%       if name == "Min" or name == "Max":
+    let expected: ${type} = Swift.${lowerFirst(name)}(extreme, 1)
+%       else:
+    let expected: ${type} = extreme ${operator} 1
+%       end
+    let w = Atomic<${type}>(extreme)
+
+    let val3 = w.${lowerFirst(name)}(1, ordering: .${order})
+    expectEqual(val3.oldValue, extreme)
+    expectEqual(val3.newValue, expected)
+    expectEqual(w.load(ordering: .relaxed), expected)
+  }
 }
 
 %     end

--- a/utils/SwiftAtomics.py
+++ b/utils/SwiftAtomics.py
@@ -122,10 +122,14 @@ def llvmToCaseName(ordering):
         return "sequentiallyConsistent"
 
 
+# Note: 'operation' is the LLVM name from the second column of
+# integerOperations, so the comparisons below must be against the lowercase
+# spelling. Comparing against the capitalized Swift name silently selects the
+# signed builtin for unsigned types.
 def atomicOperationName(intType, operation):
-    if operation == "Min":
+    if operation == "min":
         return "umin" if intType.startswith("U") else "min"
-    if operation == "Max":
+    if operation == "max":
         return "umax" if intType.startswith("U") else "max"
     return operation
 


### PR DESCRIPTION
`Atomic<T>.min(_:ordering:)` and `.max(_:ordering:)` lowered to the signed `atomicrmw min` / `atomicrmw max` for every integer type, including unsigned ones, while the `newValue` half of the returned tuple was computed with `Swift.min` / `Swift.max` and was unsigned-correct. The two halves of the same tuple therefore disagreed once a value crossed the sign bit, and the value left in memory was not the one reported. SE-0410 specifies these operations as `a = Swift.min(a, b)`, so the stored result was wrong rather than merely surprising.

`atomicOperationName` in `utils/SwiftAtomics.py` selected the builtin by comparing against the capitalized Swift names `"Min"` / `"Max"`, but the three call sites in `AtomicIntegers.swift.gyb` pass `builtinName`, the lowercase LLVM name from the same table. The comparison never matched, so the `umin` / `umax` branches were unreachable. This has been the case since the module was introduced in f7471620849.

Comparing against the lowercase spelling fixes it without touching the call sites. Passing `name` at the call sites instead would make the other five operations generate `Builtin.atomicrmw_WrappingAdd_...` and friends, which `lib/AST/Builtins.cpp` rejects. No compiler work is needed: Sema already accepts the `umin` / `umax` sub-operations, and IRGen already maps them onto `AtomicRMWInst::UMin` / `UMax`.

Regenerating `AtomicIntegers.swift` before and after the change produces a diff of exactly 140 lines: 70 `min` / `max` builtin references on unsigned types replaced by their `umin` / `umax` counterparts, and nothing else.

On the test side, the integer operation tests did cover every type and ordering, but only with the operands `3`, `8` and `12`. In that range wrapping never occurs and signed and unsigned comparison agree, so neither this bug nor an overflow bug in the wrapping operations could show. Every operation is now also exercised at the bounds of its type. Against an unfixed toolchain that fails for all five unsigned widths (10 assertions each, `Min` and `Max` across 5 orderings), while every signed type and every other operation still passes.

Resolves https://github.com/swiftlang/swift/issues/91176