### PR TITLE
[stdlib] Use MutableSpan in Sequence.reversed()

### DIFF
--- a/benchmark/single-source/ReversedCollections.swift
+++ b/benchmark/single-source/ReversedCollections.swift
@@ -19,7 +19,13 @@ public let benchmarks = [
   BenchmarkInfo(name: "ReversedBidirectional", runFunction: run_ReversedBidirectional, tags: [.validation, .api, .cpubench]),
   BenchmarkInfo(name: "ReversedDictionary2", runFunction: run_ReversedDictionary, tags: [.validation, .api, .Dictionary],
       setUpFunction: { blackHole(dictionaryInput) },
-      tearDownFunction: { dictionaryInput = nil })
+      tearDownFunction: { dictionaryInput = nil }),
+  BenchmarkInfo(name: "ReversedSequenceToArray", runFunction: run_ReversedSequenceToArray, tags: [.validation, .api, .Array],
+      setUpFunction: { blackHole(sequenceInput) },
+      tearDownFunction: { sequenceInput = nil }),
+  BenchmarkInfo(name: "ReversedShortSequenceToArray", runFunction: run_ReversedShortSequenceToArray, tags: [.validation, .api, .Array],
+      setUpFunction: { blackHole(shortSequenceInput) },
+      tearDownFunction: { shortSequenceInput = nil })
 ]
 
 // These benchmarks compare the performance of iteration through several
@@ -73,5 +79,44 @@ public func run_ReversedDictionary(_ n: Int) {
       blackHole(key)
       blackHole(value)
     }
+  }
+}
+
+// These benchmarks measure building the reversed `Array` of a sequence that is
+// not a `BidirectionalCollection`, which is what dispatches to
+// `Sequence.reversed() -> [Element]`.
+
+struct OnePassSequence: Sequence {
+  var elements: [Int]
+
+  func makeIterator() -> Array<Int>.Iterator {
+    return elements.makeIterator()
+  }
+}
+
+let sequenceLength = 10_000
+
+var sequenceInput: OnePassSequence! = OnePassSequence(
+  elements: Array(0..<sequenceLength))
+
+var shortSequenceInput: OnePassSequence! = OnePassSequence(elements: [0])
+
+@inline(never)
+public func run_ReversedSequenceToArray(_ n: Int) {
+  let sequence = sequenceInput!
+
+  for _ in 1...n {
+    blackHole(sequence.reversed())
+  }
+}
+
+// A single element sequence has nothing to reverse, so this only measures the
+// fixed overhead of the algorithm.
+@inline(never)
+public func run_ReversedShortSequenceToArray(_ n: Int) {
+  let sequence = shortSequenceInput!
+
+  for _ in 1...n*1_000 {
+    blackHole(sequence.reversed())
   }
 }

--- a/stdlib/public/core/SequenceAlgorithms.swift
+++ b/stdlib/public/core/SequenceAlgorithms.swift
@@ -754,6 +754,31 @@ extension Sequence {
     // FIXME(performance): optimize to 1 pass?  But Array(self) can be
     // optimized to a memcpy() sometimes.  Those cases are usually collections,
     // though.
+    //
+    // Swapping through a `MutableSpan` makes the buffer uniquely referenced and
+    // mutable once instead of once per swap. `ContiguousArray` is used instead
+    // of `Array` because its `mutableSpan` is back deployed, which keeps the
+    // availability check below at the oldest ABI stable runtime rather than at
+    // the runtime that introduced `Span`, and because it has no bridged
+    // representation to check for. Rewrapping the result as an `Array` is O(1).
+    //
+    // The version list below is SwiftCompatibilitySpan 5.0, spelled out because
+    // availability macros cannot be used in an '@inlinable' function.
+    if #available(
+      macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visionOS 1.0, *
+    ) {
+      var result = ContiguousArray(self)
+      let count = result.count
+      // Forming the span has a constant cost that is pure overhead when there
+      // is nothing to swap.
+      if count > 1 {
+        var span = result.mutableSpan
+        for i in 0..<count/2 {
+          unsafe span.swapAt(unchecked: i, unchecked: count - ((i + 1) as Int))
+        }
+      }
+      return Array(result)
+    }
     var result = Array(self)
     let count = result.count
     for i in 0..<count/2 {


### PR DESCRIPTION
Resolves #91145.

`Sequence.reversed()` builds an `Array` and then reverses it in place with `Array.swapAt(_:_:)`. Every one of those swaps re-checks that the buffer is uniquely referenced and mutable, and bounds-checks both indices. Reversing through a `MutableSpan` pays for that once.

### Taking the span from a `ContiguousArray`

`Array.mutableSpan` is `@available(SwiftStdlib 6.2, *)`, so using it here would put a version check for the runtime that introduced `Span` in the middle of an `@inlinable` function that everybody's deployment target is below today. `ContiguousArray.mutableSpan` is `@available(SwiftCompatibilitySpan 5.0, *)` and back deployed, so the check lands on the oldest ABI stable runtime instead: it folds away at compile time for any client whose deployment target is macOS 10.14.4 / iOS 12.2 or newer, and everyone else keeps exactly today's code. `ContiguousArray` also has no bridged representation to test for, and rewrapping the result as an `Array` is O(1) — both go through the same `_copyToContiguousArray()` customization point, so the copy out of the sequence is unchanged. This follows @David_Smith's suggestion in the pitch thread.

The version list is spelled out rather than written as `SwiftCompatibilitySpan 5.0` because availability macros cannot be used in an `@inlinable` function.

### Not forming the span when there is nothing to swap

Forming the span makes the buffer uniquely referenced and mutable, which is a fixed cost. For counts 0 and 1 there is nothing to swap, so paying it is a pure regression — and a large one, because it also blocks the optimizer from eliminating the allocation entirely. The `count > 1` guard is what keeps this change from being a regression for short sequences; the `unguarded` column below is the same patch without it.

### Numbers

Measured on M-series macOS 26.3, `-O`, against a stdlib built from this branch. The harness A/Bs the real `reversed()` against a local copy of the previous implementation in one process, interleaving the two round by round so drift cannot be mistaken for a difference, and keeps the best time each achieved. `Array` is `let x: [T] = array.reversed()`; `Sequence` is a wrapper that is not a `BidirectionalCollection`, which is the shape that actually dispatches here.

`Element == Int`:

| count | input | before | after | | unguarded | |
|---:|---|---:|---:|---:|---:|---:|
| 0 | Array | 12.0 ns | 8.4 ns | 0.70x | 15.5 ns | 1.30x |
| 0 | Sequence | 11.1 ns | 10.7 ns | 0.97x | 16.4 ns | 1.48x |
| 1 | Array | 12.2 ns | 8.9 ns | 0.73x | 43.0 ns | 3.53x |
| 1 | Sequence | 40.8 ns | 40.7 ns | 1.00x | 41.1 ns | 1.01x |
| 2 | Array | 50.0 ns | 43.2 ns | 0.86x | 43.0 ns | 0.86x |
| 2 | Sequence | 42.9 ns | 40.8 ns | 0.95x | 41.1 ns | 0.96x |
| 16 | Array | 67.8 ns | 44.9 ns | 0.66x | 44.6 ns | 0.66x |
| 16 | Sequence | 181.8 ns | 159.0 ns | 0.87x | 160.7 ns | 0.88x |
| 64 | Array | 130.0 ns | 55.6 ns | 0.43x | 53.8 ns | 0.41x |
| 256 | Array | 372.4 ns | 89.5 ns | 0.24x | 88.6 ns | 0.24x |
| 256 | Sequence | 786.1 ns | 502.2 ns | 0.64x | 495.0 ns | 0.63x |
| 1000 | Array | 1336.6 ns | 236.0 ns | 0.18x | 235.4 ns | 0.18x |
| 10000 | Array | 14274.5 ns | 3442.2 ns | 0.24x | 3166.0 ns | 0.22x |
| 10000 | Sequence | 20420.1 ns | 9652.5 ns | 0.47x | 9704.0 ns | 0.48x |
| 100000 | Array | 133408.8 ns | 26434.9 ns | 0.20x | 26213.1 ns | 0.20x |
| 100000 | Sequence | 199137.8 ns | 90882.1 ns | 0.46x | 89922.7 ns | 0.45x |

`Element == String`, to check that a non-POD element type behaves the same:

| count | input | before | after | | unguarded | |
|---:|---|---:|---:|---:|---:|---:|
| 0 | Array | 11.8 ns | 8.2 ns | 0.69x | 15.0 ns | 1.27x |
| 1 | Array | 13.8 ns | 9.4 ns | 0.68x | 54.0 ns | 3.92x |
| 2 | Sequence | 83.6 ns | 79.4 ns | 0.95x | 77.9 ns | 0.93x |
| 16 | Array | 144.4 ns | 96.8 ns | 0.67x | 96.5 ns | 0.67x |
| 256 | Sequence | 1659.6 ns | 1056.9 ns | 0.64x | 1064.0 ns | 0.64x |
| 10000 | Array | 53107.5 ns | 30399.3 ns | 0.57x | 30712.3 ns | 0.58x |
| 10000 | Sequence | 53759.9 ns | 31335.2 ns | 0.58x | 31283.7 ns | 0.58x |

No size regresses, the win reaches ~2x for a real sequence and ~5x when the copy is a memcpy, and the short-input cases that the issue asked about come out at parity or slightly ahead.

### Benchmarks

There was no benchmark covering this overload — the existing `Reversed*` benchmarks measure iterating an already reversed collection — so this adds two, over a sequence that is not a `BidirectionalCollection`:

- `ReversedSequenceToArray`, 10,000 elements, the case the change is for.
- `ReversedShortSequenceToArray`, a single element, which measures only the fixed overhead of the algorithm.

### One thing worth a reviewer's opinion

The swap uses `swapAt(unchecked:unchecked:)`, as the issue proposed, which is why the `unsafe` marker is there. The bounds-checked `swapAt(_:_:)` measures 5–10% slower on this loop and would keep the function free of `unsafe`. Happy to switch if that trade is preferred.
