### PR TITLE
[Synchronization] Use umin/umax for unsigned Atomic.min/max

### DIFF
--- a/test/stdlib/Synchronization/Atomics/Basics/Tests.gyb-template
+++ b/test/stdlib/Synchronization/Atomics/Basics/Tests.gyb-template
@@ -356,6 +356,33 @@ suite.test("Atomic${label} ${name} ${order}") {
 
 %     end
 %   end
+
+// Min/max must use Value's own comparison (SE-0410). Operands that cross the
+// sign bit make signed vs unsigned atomicrmw disagree, so exercise that here.
+%   for (name, _, _, _) in integerOperations:
+%     if name == "Min" or name == "Max":
+%       for (order, _, _, _, _) in updateOrderings:
+suite.test("Atomic${label} ${name} signBit ${order}") {
+%         if type.startswith("UInt"):
+  let high: ${type} = .max
+  let low: ${type} = 1
+%         else:
+  let high: ${type} = -1
+  let low: ${type} = 1
+%         end
+  let expected: ${type} = Swift.${lowerFirst(name)}(high, low)
+
+  let v = Atomic<${type}>(high)
+  let r = v.${lowerFirst(name)}(low, ordering: .${order})
+  expectEqual(r.oldValue, high)
+  expectEqual(r.newValue, expected)
+  expectEqual(v.load(ordering: .relaxed), expected)
+  expectEqual(r.newValue, v.load(ordering: .relaxed))
+}
+
+%       end
+%     end
+%   end
 % end
 } // if #available(SwiftStdlib 6.0, *)
 % end

--- a/utils/SwiftAtomics.py
+++ b/utils/SwiftAtomics.py
@@ -123,9 +123,12 @@ def llvmToCaseName(ordering):
 
 
 def atomicOperationName(intType, operation):
-    if operation == "Min":
+    # Call sites pass the lowercase LLVM builtin name ("min"/"max"), not the
+    # capitalized Swift operation name ("Min"/"Max"). Unsigned integer types
+    # must use umin/umax so Atomic.min/max match Swift.min/max (SE-0410).
+    if operation == "min":
         return "umin" if intType.startswith("U") else "min"
-    if operation == "Max":
+    if operation == "max":
         return "umax" if intType.startswith("U") else "max"
     return operation
 


### PR DESCRIPTION
## Summary

`Atomic.min` / `Atomic.max` on unsigned integer types were lowering to signed `atomicrmw min` / `max` instead of `umin` / `umax`. That made the value stored in the atomic disagree with both SE-0410 (`a = Swift.min(a, b)` / `Swift.max`) and the `newValue` half of the returned tuple, which is computed with unsigned-correct `Swift.min` / `Swift.max`.

Root cause: `atomicOperationName` in `utils/SwiftAtomics.py` compared against `"Min"` / `"Max"`, but `AtomicIntegers.swift.gyb` passes the lowercase LLVM builtin names `"min"` / `"max"`, so the unsigned branches were unreachable.

## Changes

- Match `"min"` / `"max"` in `atomicOperationName` so unsigned types emit `umin` / `umax`.
- Add a `signBit` regression test covering operands that cross the sign bit (where signed and unsigned comparison diverge).

Fixes #91176

## Test plan

- [ ] `utils/gyb.py` expand of `AtomicIntegers.swift.gyb` shows `atomicrmw_umin_*` / `umax_*` for `UInt*` and `min_*` / `max_*` for `Int*`
- [ ] Run Synchronization atomics basics tests, e.g. `AtomicUInt32.swift.gyb` / `AtomicInt32.swift.gyb` (and ideally the other integer widths)
- [ ] Confirm the issue repro no longer diverges:

```swift
import Synchronization
let a = Atomic<UInt32>(.max)
let r = a.max(1, ordering: .relaxed)
assert(r.newValue == a.load(ordering: .relaxed))
```