### PR TITLE
[Parse] Suggest '.' when consecutive identifiers look like member access

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1091,6 +1091,8 @@ ERROR(statement_begins_with_closure,none,
       "top-level statement cannot begin with a closure expression", ())
 ERROR(statement_same_line_without_semi,none,
       "consecutive statements on a line must be separated by ';'", ())
+NOTE(did_you_mean_member_access,none,
+     "did you forget to write '.'?", ())
 ERROR(statement_same_line_without_newline,none,
       "consecutive statements on a line must be separated by a newline", ())
 ERROR(invalid_label_on_stmt,none,

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -362,6 +362,30 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
       diagnose(EndOfPreviousLoc, diag::statement_same_line_without_semi)
         .fixItInsert(EndOfPreviousLoc, ";");
       // FIXME: Add semicolon to the AST?
+
+      // If the previous item was an expression and the next token looks like a
+      // member name, also suggest inserting '.' (SR-8507 / #51027).
+      auto previousWasExpr = [&]() -> bool {
+        if (Entries.empty())
+          return false;
+        ASTNode Prev = Entries.back();
+        if (Prev.is<Expr *>())
+          return true;
+        if (auto *D = Prev.dyn_cast<Decl *>()) {
+          if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D)) {
+            if (auto *Body = TLCD->getBody()) {
+              auto Elts = Body->getElements();
+              return !Elts.empty() && Elts.back().is<Expr *>();
+            }
+          }
+        }
+        return false;
+      };
+      if (previousWasExpr() && Tok.is(tok::identifier) &&
+          !isStartOfStmt(/*preferExpr*/ true) && !isStartOfSwiftDecl()) {
+        diagnose(EndOfPreviousLoc, diag::did_you_mean_member_access)
+            .fixItInsert(EndOfPreviousLoc, ".");
+      }
     }
 
     ParserPosition BeginParserPosition;

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -1117,6 +1117,12 @@ Parser::parseListItem(ParserStatus &Status, tok RightK, SourceLoc LeftLoc,
 
   diagnose(Tok, diag::expected_separator, ",")
       .fixItInsertAfter(PreviousLoc, ",");
+  // If the next token looks like a member name, also suggest '.' (SR-8507).
+  if (Tok.is(tok::identifier) && !isStartOfStmt(/*preferExpr*/ true) &&
+      !isStartOfSwiftDecl()) {
+    diagnose(PreviousLoc, diag::did_you_mean_member_access)
+        .fixItInsertAfter(PreviousLoc, ".");
+  }
   Status.setIsParseError();
   return ParseListItemResult::Continue;
 }

--- a/test/Parse/consecutive_statements.swift
+++ b/test/Parse/consecutive_statements.swift
@@ -70,3 +70,20 @@ enum Color {
 // At the top level
 var i, j : Int i = j j = i // expected-error{{consecutive statements}} {{15-15=;}} expected-error{{consecutive statements}} {{21-21=;}}
 
+// SR-8507 / #51027: missing '.' between an expression and an identifier should
+// also suggest inserting '.' (in addition to ';').
+struct MissingDotFoo {
+  var bar = 0
+}
+func testMissingDotMemberAccess() {
+  let foo = MissingDotFoo()
+  let _ = 1 + foo bar // expected-error{{consecutive statements}} {{19-19=;}} expected-note{{did you forget to write '.'?}} {{19-19=.}}
+  // expected-error@-1{{binary operator '+'}}
+  // expected-error@-2{{cannot find 'bar' in scope}}
+  foo bar = 1 // expected-error{{consecutive statements}} {{6-6=;}} expected-note{{did you forget to write '.'?}} {{6-6=.}}
+  // expected-warning@-1{{expression of type 'MissingDotFoo' is unused}}
+  // expected-error@-2{{cannot find 'bar' in scope}}
+  print(foo bar) // expected-error{{expected ',' separator}} {{13-13=,}} expected-note{{did you forget to write '.'?}} {{13-13=.}}
+  // expected-error@-1{{cannot find 'bar' in scope}}
+}
+


### PR DESCRIPTION
## Summary

When code like `foo bar` is written (missing `.` for member access), the parser diagnoses consecutive statements / a missing list separator and only offers a `;` or `,` fix-it. That misleads toward the wrong recovery.

Also emit a note with a `.` fix-it when the previous brace item was an expression and the next token is an identifier (and not the start of a statement/declaration). The same heuristic applies in comma-separated lists (e.g. `print(foo bar)`).

Fixes #51027

## Changes

- New note `did_you_mean_member_access` ("did you forget to write '.'?")
- `parseBraceItems`: offer `.` note when previous item was an expression
- `parseListItem`: offer `.` note alongside the expected `,` separator
- Tests in `test/Parse/consecutive_statements.swift`

## Test plan

- [ ] `test/Parse/consecutive_statements.swift`
- [ ] Confirm existing consecutive-statement cases that are true consecutive statements still only get the `;` fix-it (e.g. `i = j j = i`, `let r : Int i = j`)