### PR TITLE
[Sema] Emit protocol stubs for inherited rename near-misses

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4581,6 +4581,22 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
     const auto &best = matches[bestIdx];
     auto witness = best.Witness;
 
+    // A renamed near-miss inherited from another type (e.g. an NSObject
+    // member nearly matching an ObjC protocol requirement) is not an
+    // actionable rename for the adopter. Treat it as missing so we still
+    // emit a requirement stub alongside the rename diagnostic (SR-11420).
+    if (best.Kind == MatchKind::RenamedMatch &&
+        !witnessHasImplementsAttrForRequiredName(best.Witness, requirement)) {
+      auto *conformingNominal = Conformance->getType()->getAnyNominal();
+      auto *witnessNominal =
+          best.Witness->getDeclContext()->getSelfNominalTypeDecl();
+      if (witnessNominal != conformingNominal) {
+        getASTContext().addDelayedMissingWitness(Conformance,
+                                                 {requirement, matches});
+        return ResolveWitnessResult::Missing;
+      }
+    }
+
     // If the name didn't actually line up, complain.
     if (ignoringNames &&
         requirement->getName() != best.Witness->getName() &&

--- a/test/decl/protocol/conforms/fixit_stub_rename.swift
+++ b/test/decl/protocol/conforms/fixit_stub_rename.swift
@@ -1,0 +1,23 @@
+// RUN: %target-typecheck-verify-swift
+
+// SR-11420 / #53821: when a requirement nearly matches an *inherited* member
+// (rename near-miss), still emit a stub for that requirement so the "add stubs"
+// fix-it covers every missing requirement.
+
+protocol RenamedStubProto {
+  func foo(x: Int)
+  // expected-note@-1 {{protocol requires function 'foo(x:)' with type '(Int) -> ()'}}
+  // expected-note@-2 {{requirement 'foo(x:)' declared here}}
+  func bar()
+  // expected-note@-1 {{protocol requires function 'bar()' with type '() -> ()'}}
+}
+
+class RenamedStubBase {
+  func foo(y: Int) {}
+  // expected-note@-1 {{rename to 'foo(x:)' to satisfy this requirement}}
+}
+
+class RenamedStubDerived: RenamedStubBase, RenamedStubProto {
+  // expected-error@-1 {{type 'RenamedStubDerived' does not conform to protocol 'RenamedStubProto'}}
+  // expected-note@-2 {{add stubs for conformance}} {{67-67=\n    func foo(x: Int) {\n        <#code#>\n    \}\n\n    func bar() {\n        <#code#>\n    \}\n}}
+}


### PR DESCRIPTION
## Summary

`MatchKind::RenamedMatch` is viable, so `resolveWitnessViaLookup` treated an inherited near-miss (for example an `NSObject` member that nearly matches an ObjC protocol requirement) as a successful witness. That requirement never entered `MissingWitnesses`, so the "add stubs for conformance" fix-it omitted it even though renaming a declaration the adopter does not control is not actionable.

When the best match is a rename on a **different** nominal type than the conforming type, record the requirement as missing so stubs are still emitted (rename notes from `diagnoseMatch` are preserved). Same-type renames (e.g. `name_mismatch.swift`) are unchanged.

Fixes #53821

## Changes

- `ConformanceChecker::resolveWitnessViaLookup`: inherited `RenamedMatch` → delayed missing witness
- New test `test/decl/protocol/conforms/fixit_stub_rename.swift`

## Test plan

- [ ] `test/decl/protocol/conforms/fixit_stub_rename.swift`
- [ ] `test/decl/protocol/req/name_mismatch.swift` (same-type rename behavior must stay as-is)
- [ ] `test/decl/protocol/conforms/fixit_stub*.swift`