### PR TITLE
[AST] Don't crash in hasTestableOrPrivateImport when imports are unresolved

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2937,6 +2937,12 @@ void SourceFile::forEachImportOfModule(
 bool SourceFile::hasTestableOrPrivateImport(
     AccessLevel accessLevel, const swift::ValueDecl *ofDecl,
     SourceFile::ImportQueryKind queryKind) const {
+  // Parse-only actions (e.g. -dump-parse) never resolve imports, so Imports
+  // stays unset. Treat that as "no special import" rather than crashing when
+  // access checking runs while dumping a recovered AST (#91100).
+  if (!Imports)
+    return false;
+
   auto *module = ofDecl->getModuleContext();
   switch (accessLevel) {
   case AccessLevel::Internal:

--- a/validation-test/compiler_crashers_fixed/issue-91100.swift
+++ b/validation-test/compiler_crashers_fixed/issue-91100.swift
@@ -1,0 +1,5 @@
+// RUN: not %target-swift-frontend %s -dump-parse
+// https://github.com/swiftlang/swift/issues/91100
+protocol P {
+actor A: P {
+    init() {


### PR DESCRIPTION
## Summary

`-dump-parse` never resolves imports, so `SourceFile::Imports` stays `nullopt`. Dumping a recovered actor nested in an unclosed protocol can still evaluate `InitKindRequest` → superclass / unqualified lookup → access checking, which dereferenced `*Imports` and segfaulted.

Guard like `getImportedModules`: if imports have not been set, return `false`.

Fixes #91100

## Changes

- `SourceFile::hasTestableOrPrivateImport`: early return when `!Imports`
- Crasher test `validation-test/compiler_crashers_fixed/issue-91100.swift`

## Test plan

- [ ] `validation-test/compiler_crashers_fixed/issue-91100.swift`
- [ ] Manual: `swift-frontend -dump-parse` on the issue repro no longer SIGSEGVs