### PR TITLE
[Diagnostics] Drop language-mode wrapper text when upgraded to error

### DIFF
--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -1592,9 +1592,39 @@ DiagnosticEngine::diagnosticInfoForDiagnostic(const Diagnostic &diagnostic,
 
   auto formatString =
       getFormatStringForDiagnostic(diagnostic, includeDiagnosticName);
+  DiagID emitID = diagnostic.getID();
+  ArrayRef<DiagnosticArgument> formatArgs = diagnostic.getArgs();
 
-  return DiagnosticInfo(diagnostic.getID(), loc, toDiagnosticKind(behavior),
-                        formatString, diagnostic.getArgs(), CategoryName,
+  // If a language-mode downgrade wrapped this diagnostic and it was later
+  // upgraded back to an error (e.g. -warnings-as-errors), drop the
+  // "; this will be an error in…" wrapper text. Claiming a future error when
+  // it is already an error is incorrect (#90933).
+  if ((behavior == DiagnosticBehavior::Error ||
+       behavior == DiagnosticBehavior::Fatal) &&
+      (diagnostic.is(diag::error_in_a_future_swift_lang_mode) ||
+       diagnostic.is(diag::error_in_swift_lang_mode))) {
+    if (auto wrapped = diagnostic.getWrappedDiagnostic()) {
+      emitID = (*wrapped)->ID;
+      formatString = (*wrapped)->FormatString;
+      formatArgs = (*wrapped)->FormatArgs;
+      if (includeDiagnosticName &&
+          printDiagnosticNamesMode == PrintDiagnosticNamesMode::Identifier) {
+        const int additionalCharsLength = 3; // ' ', '[', ']'
+        auto name = diagnosticIDStringFor(emitID);
+        std::string messageWithName;
+        messageWithName.reserve(formatString.size() + name.size() +
+                                additionalCharsLength);
+        messageWithName += formatString;
+        messageWithName += " [";
+        messageWithName += name;
+        messageWithName += "]";
+        formatString = DiagnosticStringsSaver.save(messageWithName);
+      }
+    }
+  }
+
+  return DiagnosticInfo(emitID, loc, toDiagnosticKind(behavior),
+                        formatString, formatArgs, CategoryName,
                         getDefaultDiagnosticLoc(),
                         /*child note info*/ {}, diagnostic.getRanges(), fixIts,
                         diagnostic.isChildNote());

--- a/test/diagnostics/warnings_as_errors_language_mode_downgrade.swift
+++ b/test/diagnostics/warnings_as_errors_language_mode_downgrade.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -typecheck %s 2>&1 | %FileCheck %s --check-prefix=NOWAE
+// RUN: %target-swift-frontend -typecheck -warnings-as-errors %s 2>&1 | %FileCheck %s --check-prefix=WAE
+// REQUIRES: concurrency
+
+// https://github.com/swiftlang/swift/issues/90933
+// Language-mode downgrade wrappers must not claim a "future" error when the
+// diagnostic is upgraded to an error (e.g. via -warnings-as-errors).
+
+typealias F = () -> ()
+
+func foo(_ f: @escaping @Sendable F) {}
+
+// NOWAE: warning: attribute '@Sendable' cannot be applied to a type alias; this will be an error in a future Swift language mode
+// WAE: error: attribute '@Sendable' cannot be applied to a type alias
+// WAE-NOT: this will be an error


### PR DESCRIPTION
## Summary

`limitBehaviorUntilLanguageMode` wraps diagnostics with `; this will be an error in a future Swift language mode` when downgrading to a warning. `-warnings-as-errors` can later upgrade that warning back to an error, leaving wrapper text that claims a *future* error which is already an error.

When emitting a wrapped language-mode downgrade whose final behavior is Error/Fatal, emit the original diagnostic text instead.

Fixes #90933

## Test plan

- [ ] `test/diagnostics/warnings_as_errors_language_mode_downgrade.swift`
- [ ] Confirm warning path still includes the future-error suffix without `-warnings-as-errors`