### PR TITLE
[Sema] Avoid tautological property-wrapper diagnostic without init(wrappedValue:)

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -4096,8 +4096,26 @@ bool ExtraneousPropertyWrapperUnwrapFailure::diagnoseAsError() {
     return true;
   }
 
+  // When init(wrappedValue:) is missing, CSGen records UsePropertyWrapper with
+  // (argType, wrapperType). If the argument is already the wrapper type, that
+  // produces the tautological "Wrapper → Wrapper, use wrapper instead"
+  // message (#90985). Diagnose as a conversion to the wrapped value type
+  // instead, matching the diagnostic when init(wrappedValue:) exists.
+  auto fromType = getFromType();
+  auto toType = getToType();
+  if (fromType->isEqual(toType)) {
+    if (auto *param = dyn_cast<ParamDecl>(getProperty())) {
+      if (auto wrappedValueType =
+              computeWrappedValueType(param, toType)) {
+        emitDiagnostic(diag::cannot_convert_argument_value, fromType,
+                       wrappedValueType);
+        return true;
+      }
+    }
+  }
+
   emitDiagnostic(diag::incorrect_property_wrapper_reference, getPropertyName(),
-                 getFromType(), getToType(), false)
+                 fromType, toType, false)
       .fixItInsert(getLoc(), newPrefix);
   return true;
 }

--- a/test/Sema/property_wrapper_parameter.swift
+++ b/test/Sema/property_wrapper_parameter.swift
@@ -253,3 +253,19 @@ func buildWidget(_ w: ProjectionWrapper<Int>) -> Widget {
 // when matching default arguments with parameters.
 func testCallerSideDefault(@Wrapper x: Int? = nil) {}
 testCallerSideDefault() // expected-error {{nil default argument value cannot be converted to type 'Wrapper<Int?>'}}
+
+// https://github.com/swiftlang/swift/issues/90985
+// Without init(wrappedValue:), passing the wrapper type itself must not
+// diagnose a tautological "Wrapper → Wrapper, use wrapper instead".
+@propertyWrapper
+struct ProjectedOnlyWrapper {
+  var wrappedValue: Int
+  var projectedValue: Self { self }
+  init(projectedValue: Self) { self.wrappedValue = projectedValue.wrappedValue }
+}
+
+func takesProjectedOnly(@ProjectedOnlyWrapper _ x: Int) {}
+func passProjectedOnlyWrapper(_ x: ProjectedOnlyWrapper) {
+  takesProjectedOnly(x)
+  // expected-error@-1 {{cannot convert value of type 'ProjectedOnlyWrapper' to expected argument type 'Int'}}
+}


### PR DESCRIPTION
## Summary

When an external property-wrapper parameter lacks `init(wrappedValue:)`, CSGen records `UsePropertyWrapper` with `(argType, wrapperType)`. Passing a value that is already the wrapper type then diagnoses as converting `Wrapper` to `Wrapper`, "use wrapper instead".

If the from/to types are equal, diagnose a normal conversion to the wrapped value type instead — matching the message when `init(wrappedValue:)` is present.

Fixes #90985

## Test plan

- [ ] `test/Sema/property_wrapper_parameter.swift` (new ProjectedOnlyWrapper case)
- [ ] `validation-test/Sema/type_checker_crashers_fixed/issue-65500.swift` (still Bool → Wrapper, use wrapper)