### PR TITLE
[Sema] Diagnose missing typealias imports under MemberImportVisibility

### DIFF
--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -26,6 +26,8 @@
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/TypeDeclFinder.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/Feature.h"
+#include "llvm/ADT/SmallString.h"
 
 using namespace swift;
 
@@ -201,9 +203,13 @@ static bool diagnoseTypeAliasDeclRefExportability(SourceLoc loc,
   // As an exception, if the import of the module that defines the desugared
   // decl is just missing (as opposed to imported explicitly with reduced
   // visibility) then we should only diagnose if we're building a resilient
-  // module.
+  // module — unless MemberImportVisibility is enabled. That feature makes
+  // import visibility part of the language model, and member-import
+  // diagnostics do not cover top-level typealias desugaring (#91096).
   if (originKind == DisallowedOriginKind::MissingImport &&
-      !exportingModule->isResilient())
+      !exportingModule->isResilient() &&
+      !ctx.LangOpts.hasFeature(Feature::MemberImportVisibility,
+                               /*allowMigration=*/true))
     return false;
 
   auto definingModule = D->getModuleContext();
@@ -235,6 +241,21 @@ static bool diagnoseTypeAliasDeclRefExportability(SourceLoc loc,
       originKind == DisallowedOriginKind::MissingImport &&
       !ctx.isLanguageModeAtLeast(LanguageMode::v6))
     addMissingImport(loc, D, where);
+
+  // Offer a source-level import fix-it for a missing module (#91096).
+  if (originKind == DisallowedOriginKind::MissingImport) {
+    if (auto *SF = DC->getParentSourceFile()) {
+      SourceLoc bestLoc = ctx.Diags.getBestAddImportFixItLoc(SF);
+      if (bestLoc.isValid()) {
+        llvm::SmallString<64> importText;
+        importText += "import ";
+        importText += definingModule->getName().str();
+        importText += "\n";
+        ctx.Diags.diagnose(bestLoc, diag::candidate_add_import, definingModule)
+            .fixItInsert(bestLoc, importText);
+      }
+    }
+  }
 
   // If limited by an import, note which one.
   if (originKind == DisallowedOriginKind::NonPublicImport) {

--- a/test/Sema/missing-import-typealias-member-import-visibility.swift
+++ b/test/Sema/missing-import-typealias-member-import-visibility.swift
@@ -1,0 +1,28 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module -o %t/Original.swiftmodule %t/Original.swift
+// RUN: %target-swift-frontend -emit-module -I %t -o %t/Aliases.swiftmodule %t/Aliases.swift
+
+// Without library evolution, MemberImportVisibility still diagnoses a public
+// use of a typealias whose underlying type comes from a missing import.
+// https://github.com/swiftlang/swift/issues/91096
+// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unrelated %t/Client.swift -I %t -enable-upcoming-feature MemberImportVisibility
+
+// REQUIRES: swift_feature_MemberImportVisibility
+
+//--- Original.swift
+public struct DataLike {
+  public init() {}
+}
+
+//--- Aliases.swift
+import Original
+public typealias MyData = DataLike
+
+//--- Client.swift
+import Aliases
+
+// expected-warning@+2 {{'MyData' aliases 'Original.DataLike' and cannot be used here because 'Original' was not imported by this file; this is an error in the Swift 6 language mode}}
+// expected-note@+1 {{add import of module 'Original'}} {{1-1=import Original\n}}
+public func foo(x: MyData) {}

--- a/test/Sema/missing-import-typealias-swift6.swift
+++ b/test/Sema/missing-import-typealias-swift6.swift
@@ -28,6 +28,7 @@ public typealias ClazzAlias = Clazz
 
 public import Aliases
 
-// expected-error@+1 {{'ClazzAlias' aliases 'Original.Clazz' and cannot be used in a public or '@usableFromInline' conformance because 'Original' was not imported by this file}}
+// expected-error@+2 {{'ClazzAlias' aliases 'Original.Clazz' and cannot be used in a public or '@usableFromInline' conformance because 'Original' was not imported by this file}}
+// expected-note@+1 {{add import of module 'Original'}}
 public class InheritsFromClazzAlias: ClazzAlias {}
 

--- a/test/Sema/missing-import-typealias.swift
+++ b/test/Sema/missing-import-typealias.swift
@@ -79,29 +79,34 @@ import Aliases
 
 // CHECK-NON-RESILIENT-NOT: was not imported by this file
 
-// expected-warning@+2 {{'ClazzAlias' aliases 'Original.Clazz' and cannot be used in a public or '@usableFromInline' conformance because 'Original' was not imported by this file; this is an error in the Swift 6 language mode}}
-// expected-note@+1 {{The missing import of module 'Original' will be added implicitly}}
+// expected-warning@+3 {{'ClazzAlias' aliases 'Original.Clazz' and cannot be used in a public or '@usableFromInline' conformance because 'Original' was not imported by this file; this is an error in the Swift 6 language mode}}
+// expected-note@+2 {{The missing import of module 'Original' will be added implicitly}}
+// expected-note@+1 {{add import of module 'Original'}} {{1-1=import Original\n}}
 public class InheritsFromClazzAlias: ClazzAlias {}
 
 @inlinable public func inlinableFunc() {
-  // expected-warning@+2 {{'StructAlias' aliases 'Original.Struct' and cannot be used in an '@inlinable' function because 'Original' was not imported by this file; this is an error in the Swift 6 language mode}}
-  // expected-note@+1 {{The missing import of module 'Original' will be added implicitly}}
+  // expected-warning@+3 {{'StructAlias' aliases 'Original.Struct' and cannot be used in an '@inlinable' function because 'Original' was not imported by this file; this is an error in the Swift 6 language mode}}
+  // expected-note@+2 {{The missing import of module 'Original' will be added implicitly}}
+  // expected-note@+1 {{add import of module 'Original'}}
   _ = StructAlias.self
 }
 
-// expected-warning@+2 {{'ProtoAlias' aliases 'Original.Proto' and cannot be used here because 'Original' was not imported by this file; this is an error in the Swift 6 language mode}}
-// expected-note@+1 {{The missing import of module 'Original' will be added implicitly}}
+// expected-warning@+3 {{'ProtoAlias' aliases 'Original.Proto' and cannot be used here because 'Original' was not imported by this file; this is an error in the Swift 6 language mode}}
+// expected-note@+2 {{The missing import of module 'Original' will be added implicitly}}
+// expected-note@+1 {{add import of module 'Original'}}
 public func takesGeneric<T: ProtoAlias>(_ t: T) {}
 
 public struct HasMembers {
-  // expected-warning@+3 {{cannot use property 'wrappedValue' here; 'Original' was not imported by this file}}
-  // expected-warning@+2 {{'WrapperAlias' aliases 'Original.Wrapper' and cannot be used as property wrapper here because 'Original' was not imported by this file; this is an error in the Swift 6 language mode}}
- // expected-note@+1 {{The missing import of module 'Original' will be added implicitly}}
+  // expected-warning@+4 {{cannot use property 'wrappedValue' here; 'Original' was not imported by this file}}
+  // expected-warning@+3 {{'WrapperAlias' aliases 'Original.Wrapper' and cannot be used as property wrapper here because 'Original' was not imported by this file; this is an error in the Swift 6 language mode}}
+  // expected-note@+2 {{The missing import of module 'Original' will be added implicitly}}
+  // expected-note@+1 {{add import of module 'Original'}}
   @WrapperAlias public var wrapped: Int
 }
 
-// expected-warning@+2 {{'StructAlias' aliases 'Original.Struct' and cannot be used in an extension with public or '@usableFromInline' members because 'Original' was not imported by this file; this is an error in the Swift 6 language mode}}
-// expected-note@+1 {{The missing import of module 'Original' will be added implicitly}}
+// expected-warning@+3 {{'StructAlias' aliases 'Original.Struct' and cannot be used in an extension with public or '@usableFromInline' members because 'Original' was not imported by this file; this is an error in the Swift 6 language mode}}
+// expected-note@+2 {{The missing import of module 'Original' will be added implicitly}}
+// expected-note@+1 {{add import of module 'Original'}}
 extension StructAlias {
   public func someFunc() {}
 }


### PR DESCRIPTION
## Summary

Exportability checking for typealias desugaring skipped `MissingImport` diagnostics in non-resilient modules, so a public use of `typealias MyData = Foundation.Data` without importing Foundation only failed under `-enable-library-evolution`. With `MemberImportVisibility`, import visibility is part of the language model, and member-import diagnostics do not cover this top-level alias case.

Also emit a `candidate_add_import` fix-it so the remediation (`import Foundation`) is obvious. Non-resilient builds without MemberImportVisibility keep the existing skip (no superfluous swiftinterface concern).

Fixes #91096

## Test plan

- [ ] `test/Sema/missing-import-typealias.swift` (import fix-it notes)
- [ ] `test/Sema/missing-import-typealias-swift6.swift`
- [ ] `test/Sema/missing-import-typealias-member-import-visibility.swift` (MIV without library evolution)
- [ ] Confirm CHECK-NON-RESILIENT still silent without MIV / evolution