### PR TITLE
[Embedded] Move the Concurrency clocks into the platform abstraction layer

### DIFF
--- a/stdlib/public/Concurrency/Clock.cpp
+++ b/stdlib/public/Concurrency/Clock.cpp
@@ -13,6 +13,16 @@
 #include "swift/Runtime/Concurrency.h"
 #include "swift/Runtime/Once.h"
 
+#include "Error.h"
+
+#if SWIFT_USE_EMBEDDED_SWIFT_PLATFORM
+
+// Under the Embedded Swift platform abstraction layer the clocks come from
+// the platform, so the runtime keeps no direct dependency on a libc clock.
+#include "swift/EmbeddedPlatform.h"
+
+#else
+
 #include <errno.h>
 #include <time.h>
 #if defined(_WIN32)
@@ -32,17 +42,60 @@
 #endif
 #endif // __has_include(<chrono>)
 
-#include "Error.h"
-
 #ifndef NSEC_PER_SEC
 #define NSEC_PER_SEC 1000000000ull
 #endif
 
+#endif // SWIFT_USE_EMBEDDED_SWIFT_PLATFORM
+
 using namespace swift;
 
-// The individual clocks, implemented on top of the platform's native clock
-// facilities. The runtime entry points below are thin wrappers that forward
-// to these.
+// The individual clocks. The runtime entry points below are thin wrappers
+// that forward to these.
+
+#if SWIFT_USE_EMBEDDED_SWIFT_PLATFORM
+
+// The platform reports time as int64_t while the entry points hand out
+// long long. Those are the same width everywhere Swift runs, but not
+// necessarily the same type, so convert through a temporary.
+
+static void getContinuousTime(long long *seconds, long long *nanoseconds) {
+  __swift_int64_t s;
+  __swift_int64_t ns;
+  _swift_clockContinuous_getTime(&s, &ns);
+  *seconds = s;
+  *nanoseconds = ns;
+}
+
+static void getContinuousResolution(long long *seconds, long long *nanoseconds) {
+  __swift_int64_t s;
+  __swift_int64_t ns;
+  _swift_clockContinuous_getResolution(&s, &ns);
+  *seconds = s;
+  *nanoseconds = ns;
+}
+
+static void getSuspendingTime(long long *seconds, long long *nanoseconds) {
+  __swift_int64_t s;
+  __swift_int64_t ns;
+  _swift_clockSuspending_getTime(&s, &ns);
+  *seconds = s;
+  *nanoseconds = ns;
+}
+
+static void getSuspendingResolution(long long *seconds, long long *nanoseconds) {
+  __swift_int64_t s;
+  __swift_int64_t ns;
+  _swift_clockSuspending_getResolution(&s, &ns);
+  *seconds = s;
+  *nanoseconds = ns;
+}
+
+static void sleepFor(long long seconds, long long nanoseconds) {
+  _swift_clock_sleep(seconds, nanoseconds);
+}
+
+#else
 
 static void getContinuousTime(long long *seconds, long long *nanoseconds) {
   struct timespec continuous;
@@ -234,6 +287,8 @@ static void sleepFor(long long seconds, long long nanoseconds) {
 #endif
 }
 
+#endif // SWIFT_USE_EMBEDDED_SWIFT_PLATFORM
+
 SWIFT_EXPORT_FROM(swift_Concurrency)
 SWIFT_CC(swift)
 void swift_get_time(
@@ -246,7 +301,13 @@ void swift_get_time(
     case swift_clock_id_suspending:
       return getSuspendingTime(seconds, nanoseconds);
     case swift_clock_id_wall:
+#if SWIFT_USE_EMBEDDED_SWIFT_PLATFORM
+      // Embedded Swift has no producer for this clock ID.
+      // Treat it like any other invalid clock ID.
+      break;
+#else
       return getWallTime(seconds, nanoseconds);
+#endif
   }
   swift_Concurrency_fatalError(0, "Fatal error: invalid clock ID %d\n",
                                clock_id);
@@ -264,7 +325,13 @@ void swift_get_clock_res(
     case swift_clock_id_suspending:
       return getSuspendingResolution(seconds, nanoseconds);
     case swift_clock_id_wall:
+#if SWIFT_USE_EMBEDDED_SWIFT_PLATFORM
+      // Embedded Swift has no producer for this clock ID.
+      // Treat it like any other invalid clock ID.
+      break;
+#else
       return getWallResolution(seconds, nanoseconds);
+#endif
   }
   swift_Concurrency_fatalError(0, "Fatal error: invalid clock ID %d\n",
                                clock_id);

--- a/stdlib/public/Concurrency/Clock.cpp
+++ b/stdlib/public/Concurrency/Clock.cpp
@@ -13,6 +13,8 @@
 #include "swift/Runtime/Concurrency.h"
 #include "swift/Runtime/Once.h"
 
+#include "Error.h"
+
 #include <errno.h>
 #include <time.h>
 #if defined(_WIN32)
@@ -32,13 +34,26 @@
 #endif
 #endif // __has_include(<chrono>)
 
-#include "Error.h"
-
 #ifndef NSEC_PER_SEC
 #define NSEC_PER_SEC 1000000000ull
 #endif
 
 using namespace swift;
+
+// The platform clock services. The runtime entry points below forward to
+// these functions; the default implementations at the end of this file wrap
+// the platform's native clock facilities.
+typedef swift_clock_id swift_clock_id_t;
+
+extern "C" void _swift_clock_getTime(swift_clock_id_t clock_id,
+                                     long long *seconds,
+                                     long long *nanoseconds);
+
+extern "C" void _swift_clock_getResolution(swift_clock_id_t clock_id,
+                                           long long *seconds,
+                                           long long *nanoseconds);
+
+extern "C" void _swift_clock_sleep(long long seconds, long long nanoseconds);
 
 SWIFT_EXPORT_FROM(swift_Concurrency)
 SWIFT_CC(swift)
@@ -46,6 +61,34 @@ void swift_get_time(
   long long *seconds,
   long long *nanoseconds,
   swift_clock_id clock_id) {
+  _swift_clock_getTime(static_cast<swift_clock_id_t>(clock_id),
+                       seconds, nanoseconds);
+}
+
+SWIFT_EXPORT_FROM(swift_Concurrency)
+SWIFT_CC(swift)
+void swift_get_clock_res(
+  long long *seconds,
+  long long *nanoseconds,
+  swift_clock_id clock_id) {
+  _swift_clock_getResolution(static_cast<swift_clock_id_t>(clock_id),
+                             seconds, nanoseconds);
+}
+
+SWIFT_EXPORT_FROM(swift_Concurrency)
+SWIFT_CC(swift)
+void swift_sleep(
+  long long seconds,
+  long long nanoseconds) {
+  _swift_clock_sleep(seconds, nanoseconds);
+}
+
+// Default implementations of the platform clock services on top of the
+// platform's native clock facilities.
+
+extern "C" void _swift_clock_getTime(swift_clock_id_t clock_id,
+                                     long long *seconds,
+                                     long long *nanoseconds) {
   switch (clock_id) {
     case swift_clock_id_continuous: {
       struct timespec continuous;
@@ -143,13 +186,10 @@ void swift_get_time(
                                clock_id);
 }
 
-SWIFT_EXPORT_FROM(swift_Concurrency)
-SWIFT_CC(swift)
-void swift_get_clock_res(
-  long long *seconds,
-  long long *nanoseconds,
-  swift_clock_id clock_id) {
-switch (clock_id) {
+extern "C" void _swift_clock_getResolution(swift_clock_id_t clock_id,
+                                           long long *seconds,
+                                           long long *nanoseconds) {
+  switch (clock_id) {
     case swift_clock_id_continuous: {
       struct timespec continuous;
 #if defined(__linux__)
@@ -217,11 +257,7 @@ switch (clock_id) {
                                clock_id);
 }
 
-SWIFT_EXPORT_FROM(swift_Concurrency)
-SWIFT_CC(swift)
-void swift_sleep(
-  long long seconds,
-  long long nanoseconds) {
+extern "C" void _swift_clock_sleep(long long seconds, long long nanoseconds) {
 #if defined(_WIN32)
   ULONGLONG now;
   (void)QueryInterruptTimePrecise(&now);

--- a/stdlib/public/Concurrency/Clock.cpp
+++ b/stdlib/public/Concurrency/Clock.cpp
@@ -15,6 +15,27 @@
 
 #include "Error.h"
 
+#if SWIFT_CONCURRENCY_EMBEDDED && SWIFT_USE_EMBEDDED_SWIFT_PLATFORM
+
+// When the Embedded Swift platform abstraction layer is in use, the clock
+// services declared in swift/EmbeddedPlatform.h are provided by the platform
+// at link time and the default implementations at the end of this file are
+// not compiled. This keeps the embedded runtime free of any direct libc
+// clock dependency.
+#include "swift/EmbeddedPlatform.h"
+
+static_assert(SWIFT_CLOCK_CONTINUOUS ==
+                  static_cast<int>(swift::swift_clock_id_continuous),
+              "platform clock IDs must match the runtime clock IDs");
+static_assert(SWIFT_CLOCK_SUSPENDING ==
+                  static_cast<int>(swift::swift_clock_id_suspending),
+              "platform clock IDs must match the runtime clock IDs");
+static_assert(SWIFT_CLOCK_WALL ==
+                  static_cast<int>(swift::swift_clock_id_wall),
+              "platform clock IDs must match the runtime clock IDs");
+
+#else
+
 #include <errno.h>
 #include <time.h>
 #if defined(_WIN32)
@@ -38,11 +59,16 @@
 #define NSEC_PER_SEC 1000000000ull
 #endif
 
+#endif // SWIFT_CONCURRENCY_EMBEDDED && SWIFT_USE_EMBEDDED_SWIFT_PLATFORM
+
 using namespace swift;
 
+#if !(SWIFT_CONCURRENCY_EMBEDDED && SWIFT_USE_EMBEDDED_SWIFT_PLATFORM)
 // The platform clock services. The runtime entry points below forward to
 // these functions; the default implementations at the end of this file wrap
-// the platform's native clock facilities.
+// the platform's native clock facilities. When the embedded platform
+// abstraction layer is in use, they are declared in swift/EmbeddedPlatform.h
+// and provided by the platform instead.
 typedef swift_clock_id swift_clock_id_t;
 
 extern "C" void _swift_clock_getTime(swift_clock_id_t clock_id,
@@ -54,6 +80,7 @@ extern "C" void _swift_clock_getResolution(swift_clock_id_t clock_id,
                                            long long *nanoseconds);
 
 extern "C" void _swift_clock_sleep(long long seconds, long long nanoseconds);
+#endif // !(SWIFT_CONCURRENCY_EMBEDDED && SWIFT_USE_EMBEDDED_SWIFT_PLATFORM)
 
 SWIFT_EXPORT_FROM(swift_Concurrency)
 SWIFT_CC(swift)
@@ -61,6 +88,15 @@ void swift_get_time(
   long long *seconds,
   long long *nanoseconds,
   swift_clock_id clock_id) {
+#if SWIFT_CONCURRENCY_EMBEDDED && SWIFT_USE_EMBEDDED_SWIFT_PLATFORM
+  // The platform implementation is only required to handle the declared
+  // clock IDs; validate before crossing the platform boundary.
+  if (clock_id != swift_clock_id_continuous &&
+      clock_id != swift_clock_id_suspending &&
+      clock_id != swift_clock_id_wall)
+    swift_Concurrency_fatalError(0, "Fatal error: invalid clock ID %d\n",
+                                 clock_id);
+#endif
   _swift_clock_getTime(static_cast<swift_clock_id_t>(clock_id),
                        seconds, nanoseconds);
 }
@@ -71,6 +107,15 @@ void swift_get_clock_res(
   long long *seconds,
   long long *nanoseconds,
   swift_clock_id clock_id) {
+#if SWIFT_CONCURRENCY_EMBEDDED && SWIFT_USE_EMBEDDED_SWIFT_PLATFORM
+  // The platform implementation is only required to handle the declared
+  // clock IDs; validate before crossing the platform boundary.
+  if (clock_id != swift_clock_id_continuous &&
+      clock_id != swift_clock_id_suspending &&
+      clock_id != swift_clock_id_wall)
+    swift_Concurrency_fatalError(0, "Fatal error: invalid clock ID %d\n",
+                                 clock_id);
+#endif
   _swift_clock_getResolution(static_cast<swift_clock_id_t>(clock_id),
                              seconds, nanoseconds);
 }
@@ -82,6 +127,8 @@ void swift_sleep(
   long long nanoseconds) {
   _swift_clock_sleep(seconds, nanoseconds);
 }
+
+#if !(SWIFT_CONCURRENCY_EMBEDDED && SWIFT_USE_EMBEDDED_SWIFT_PLATFORM)
 
 // Default implementations of the platform clock services on top of the
 // platform's native clock facilities.
@@ -292,3 +339,5 @@ extern "C" void _swift_clock_sleep(long long seconds, long long nanoseconds) {
   #error Missing platform sleep definition
 #endif
 }
+
+#endif // !(SWIFT_CONCURRENCY_EMBEDDED && SWIFT_USE_EMBEDDED_SWIFT_PLATFORM)

--- a/stdlib/public/Concurrency/Clock.cpp
+++ b/stdlib/public/Concurrency/Clock.cpp
@@ -40,188 +40,165 @@
 
 using namespace swift;
 
-SWIFT_EXPORT_FROM(swift_Concurrency)
-SWIFT_CC(swift)
-void swift_get_time(
-  long long *seconds,
-  long long *nanoseconds,
-  swift_clock_id clock_id) {
-  switch (clock_id) {
-    case swift_clock_id_continuous: {
-      struct timespec continuous;
-#if defined(__linux__)
-      clock_gettime(CLOCK_BOOTTIME, &continuous);
-#elif defined(__APPLE__)
-      clock_gettime(CLOCK_MONOTONIC_RAW, &continuous);
-#elif (defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__wasi__) || defined(__EMSCRIPTEN__))
-      clock_gettime(CLOCK_MONOTONIC, &continuous);
-#elif defined(_WIN32)
-      // This needs to match what swift-corelibs-libdispatch does
+// The individual clocks, implemented on top of the platform's native clock
+// facilities. The runtime entry points below are thin wrappers that forward
+// to these.
 
-      // QueryInterruptTimePrecise() outputs a value measured in 100ns
-      // units. We must divide the output by 10,000,000 to get a value in
-      // seconds and multiply the remainder by 100 to get nanoseconds.
-      ULONGLONG interruptTime;
-      (void)QueryInterruptTimePrecise(&interruptTime);
-      continuous.tv_sec = interruptTime / 10'000'000;
-      continuous.tv_nsec = (interruptTime % 10'000'000) * 100;
+static void getContinuousTime(long long *seconds, long long *nanoseconds) {
+  struct timespec continuous;
+#if defined(__linux__)
+  clock_gettime(CLOCK_BOOTTIME, &continuous);
+#elif defined(__APPLE__)
+  clock_gettime(CLOCK_MONOTONIC_RAW, &continuous);
+#elif (defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__wasi__) || defined(__EMSCRIPTEN__))
+  clock_gettime(CLOCK_MONOTONIC, &continuous);
+#elif defined(_WIN32)
+  // This needs to match what swift-corelibs-libdispatch does
+
+  // QueryInterruptTimePrecise() outputs a value measured in 100ns
+  // units. We must divide the output by 10,000,000 to get a value in
+  // seconds and multiply the remainder by 100 to get nanoseconds.
+  ULONGLONG interruptTime;
+  (void)QueryInterruptTimePrecise(&interruptTime);
+  continuous.tv_sec = interruptTime / 10'000'000;
+  continuous.tv_nsec = (interruptTime % 10'000'000) * 100;
 #elif WE_HAVE_STD_CHRONO
-      auto now = std::chrono::steady_clock::now();
-      auto epoch = std::chrono::steady_clock::min();
-      auto timeSinceEpoch = now - epoch;
-      auto sec = std::chrono::duration_cast<std::chrono::seconds>(timeSinceEpoch);
-      auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(timeSinceEpoch - sec);
-      continuous.tv_sec = sec;
-      continuous.tv_nsec = ns;
+  auto now = std::chrono::steady_clock::now();
+  auto epoch = std::chrono::steady_clock::min();
+  auto timeSinceEpoch = now - epoch;
+  auto sec = std::chrono::duration_cast<std::chrono::seconds>(timeSinceEpoch);
+  auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(timeSinceEpoch - sec);
+  continuous.tv_sec = sec;
+  continuous.tv_nsec = ns;
 #else
 #error Missing platform continuous time definition
 #endif
-      *seconds = continuous.tv_sec;
-      *nanoseconds = continuous.tv_nsec;
-      return;
-    }
-    case swift_clock_id_suspending: {
-      struct timespec suspending;
-#if defined(__linux__)
-      clock_gettime(CLOCK_MONOTONIC, &suspending);
-#elif defined(__APPLE__)
-      clock_gettime(CLOCK_UPTIME_RAW, &suspending);
-#elif defined(__wasi__) || defined(__EMSCRIPTEN__)
-      clock_gettime(CLOCK_MONOTONIC, &suspending);
-#elif (defined(__OpenBSD__) || defined(__FreeBSD__))
-      clock_gettime(CLOCK_UPTIME, &suspending);
-#elif defined(_WIN32)
-      // This needs to match what swift-corelibs-libdispatch does
+  *seconds = continuous.tv_sec;
+  *nanoseconds = continuous.tv_nsec;
+}
 
-      // QueryUnbiasedInterruptTimePrecise() outputs a value measured in 100ns
-      // units. We must divide the output by 10,000,000 to get a value in
-      // seconds and multiply the remainder by 100 to get nanoseconds.
-      ULONGLONG unbiasedTime;
-      (void)QueryUnbiasedInterruptTimePrecise(&unbiasedTime);
-      suspending.tv_sec = unbiasedTime / 10'000'000;
-      suspending.tv_nsec = (unbiasedTime % 10'000'000) * 100;
+static void getContinuousResolution(long long *seconds, long long *nanoseconds) {
+  struct timespec continuous;
+#if defined(__linux__)
+  clock_getres(CLOCK_BOOTTIME, &continuous);
+#elif defined(__APPLE__)
+  clock_getres(CLOCK_MONOTONIC_RAW, &continuous);
+#elif (defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__wasi__) || defined(__EMSCRIPTEN__))
+  clock_getres(CLOCK_MONOTONIC, &continuous);
+#elif defined(_WIN32)
+  continuous.tv_sec = 0;
+  continuous.tv_nsec = 100;
 #elif WE_HAVE_STD_CHRONO
-      auto now = std::chrono::steady_clock::now();
-      auto epoch = std::chrono::steady_clock::min();
-      auto timeSinceEpoch = now - epoch;
-      auto sec = std::chrono::duration_cast<std::chrono::seconds>(timeSinceEpoch);
-      auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(timeSinceEpoch - sec);
-      suspending.tv_sec = sec;
-      suspending.tv_nsec = ns;
+  auto num = std::chrono::steady_clock::period::num;
+  auto den = std::chrono::steady_clock::period::den;
+  continuous.tv_sec = num / den;
+  continuous.tv_nsec = (num * 1000000000ll) % den;
+#else
+#error Missing platform continuous time definition
+#endif
+  *seconds = continuous.tv_sec;
+  *nanoseconds = continuous.tv_nsec;
+}
+
+static void getSuspendingTime(long long *seconds, long long *nanoseconds) {
+  struct timespec suspending;
+#if defined(__linux__)
+  clock_gettime(CLOCK_MONOTONIC, &suspending);
+#elif defined(__APPLE__)
+  clock_gettime(CLOCK_UPTIME_RAW, &suspending);
+#elif defined(__wasi__) || defined(__EMSCRIPTEN__)
+  clock_gettime(CLOCK_MONOTONIC, &suspending);
+#elif (defined(__OpenBSD__) || defined(__FreeBSD__))
+  clock_gettime(CLOCK_UPTIME, &suspending);
+#elif defined(_WIN32)
+  // This needs to match what swift-corelibs-libdispatch does
+
+  // QueryUnbiasedInterruptTimePrecise() outputs a value measured in 100ns
+  // units. We must divide the output by 10,000,000 to get a value in
+  // seconds and multiply the remainder by 100 to get nanoseconds.
+  ULONGLONG unbiasedTime;
+  (void)QueryUnbiasedInterruptTimePrecise(&unbiasedTime);
+  suspending.tv_sec = unbiasedTime / 10'000'000;
+  suspending.tv_nsec = (unbiasedTime % 10'000'000) * 100;
+#elif WE_HAVE_STD_CHRONO
+  auto now = std::chrono::steady_clock::now();
+  auto epoch = std::chrono::steady_clock::min();
+  auto timeSinceEpoch = now - epoch;
+  auto sec = std::chrono::duration_cast<std::chrono::seconds>(timeSinceEpoch);
+  auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(timeSinceEpoch - sec);
+  suspending.tv_sec = sec;
+  suspending.tv_nsec = ns;
 #else
 #error Missing platform suspending time definition
 #endif
-      *seconds = suspending.tv_sec;
-      *nanoseconds = suspending.tv_nsec;
-      return;
-    case swift_clock_id_wall:
-      struct timespec wall;
+  *seconds = suspending.tv_sec;
+  *nanoseconds = suspending.tv_nsec;
+}
+
+static void getSuspendingResolution(long long *seconds, long long *nanoseconds) {
+  struct timespec suspending;
+#if defined(__linux__)
+  clock_getres(CLOCK_MONOTONIC_RAW, &suspending);
+#elif defined(__APPLE__)
+  clock_getres(CLOCK_UPTIME_RAW, &suspending);
+#elif defined(__wasi__) || defined(__EMSCRIPTEN__)
+  clock_getres(CLOCK_MONOTONIC, &suspending);
+#elif (defined(__OpenBSD__) || defined(__FreeBSD__))
+  clock_getres(CLOCK_UPTIME, &suspending);
+#elif defined(_WIN32)
+  suspending.tv_sec = 0;
+  suspending.tv_nsec = 100;
+#elif WE_HAVE_STD_CHRONO
+  auto num = std::chrono::steady_clock::period::num;
+  auto den = std::chrono::steady_clock::period::den;
+  suspending.tv_sec = num / den;
+  suspending.tv_nsec = (num * 1'000'000'000ll) % den;
+#else
+#error Missing platform suspending time definition
+#endif
+  *seconds = suspending.tv_sec;
+  *nanoseconds = suspending.tv_nsec;
+}
+
+static void getWallTime(long long *seconds, long long *nanoseconds) {
+  struct timespec wall;
 #if defined(__linux__) || defined(__APPLE__) || defined(__wasi__) || defined(__EMSCRIPTEN__) || defined(__OpenBSD__) || defined(__FreeBSD__)
-      clock_gettime(CLOCK_REALTIME, &wall);
+  clock_gettime(CLOCK_REALTIME, &wall);
 #elif defined(_WIN32)
-      // This needs to match what swift-corelibs-libdispatch does
+  // This needs to match what swift-corelibs-libdispatch does
 
-      static const uint64_t kNTToUNIXBiasAdjustment = 11644473600 * NSEC_PER_SEC;
-      // FILETIME is 100-nanosecond intervals since January 1, 1601 (UTC).
-      FILETIME ft;
-      ULARGE_INTEGER li;
-      GetSystemTimePreciseAsFileTime(&ft);
-      li.LowPart = ft.dwLowDateTime;
-      li.HighPart = ft.dwHighDateTime;
-      ULONGLONG ns = li.QuadPart * 100ull - kNTToUNIXBiasAdjustment;
-      wall.tv_sec = ns / 1000000000ull;
-      wall.tv_nsec = ns % 1000000000ull;
+  static const uint64_t kNTToUNIXBiasAdjustment = 11644473600 * NSEC_PER_SEC;
+  // FILETIME is 100-nanosecond intervals since January 1, 1601 (UTC).
+  FILETIME ft;
+  ULARGE_INTEGER li;
+  GetSystemTimePreciseAsFileTime(&ft);
+  li.LowPart = ft.dwLowDateTime;
+  li.HighPart = ft.dwHighDateTime;
+  ULONGLONG ns = li.QuadPart * 100ull - kNTToUNIXBiasAdjustment;
+  wall.tv_sec = ns / 1000000000ull;
+  wall.tv_nsec = ns % 1000000000ull;
 #else
 #error Missing platform wall time definition
 #endif
-      *seconds = wall.tv_sec;
-      *nanoseconds = wall.tv_nsec;
-      return;
-    }
-  }
-  swift_Concurrency_fatalError(0, "Fatal error: invalid clock ID %d\n",
-                               clock_id);
+  *seconds = wall.tv_sec;
+  *nanoseconds = wall.tv_nsec;
 }
 
-SWIFT_EXPORT_FROM(swift_Concurrency)
-SWIFT_CC(swift)
-void swift_get_clock_res(
-  long long *seconds,
-  long long *nanoseconds,
-  swift_clock_id clock_id) {
-switch (clock_id) {
-    case swift_clock_id_continuous: {
-      struct timespec continuous;
-#if defined(__linux__)
-      clock_getres(CLOCK_BOOTTIME, &continuous);
-#elif defined(__APPLE__)
-      clock_getres(CLOCK_MONOTONIC_RAW, &continuous);
-#elif (defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__wasi__) || defined(__EMSCRIPTEN__))
-      clock_getres(CLOCK_MONOTONIC, &continuous);
-#elif defined(_WIN32)
-      continuous.tv_sec = 0;
-      continuous.tv_nsec = 100;
-#elif WE_HAVE_STD_CHRONO
-      auto num = std::chrono::steady_clock::period::num;
-      auto den = std::chrono::steady_clock::period::den;
-      continuous.tv_sec = num / den;
-      continuous.tv_nsec = (num * 1000000000ll) % den;
-#else
-#error Missing platform continuous time definition
-#endif
-      *seconds = continuous.tv_sec;
-      *nanoseconds = continuous.tv_nsec;
-      return;
-    }
-    case swift_clock_id_suspending: {
-      struct timespec suspending;
-#if defined(__linux__)
-      clock_getres(CLOCK_MONOTONIC_RAW, &suspending);
-#elif defined(__APPLE__)
-      clock_getres(CLOCK_UPTIME_RAW, &suspending);
-#elif defined(__wasi__) || defined(__EMSCRIPTEN__)
-      clock_getres(CLOCK_MONOTONIC, &suspending);
-#elif (defined(__OpenBSD__) || defined(__FreeBSD__))
-      clock_getres(CLOCK_UPTIME, &suspending);
-#elif defined(_WIN32)
-      suspending.tv_sec = 0;
-      suspending.tv_nsec = 100;
-#elif WE_HAVE_STD_CHRONO
-      auto num = std::chrono::steady_clock::period::num;
-      auto den = std::chrono::steady_clock::period::den;
-      suspending.tv_sec = num / den;
-      suspending.tv_nsec = (num * 1'000'000'000ll) % den;
-#else
-#error Missing platform suspending time definition
-#endif
-      *seconds = suspending.tv_sec;
-      *nanoseconds = suspending.tv_nsec;
-      return;
-    }
-    case swift_clock_id_wall: {
-      struct timespec wall;
+static void getWallResolution(long long *seconds, long long *nanoseconds) {
+  struct timespec wall;
 #if defined(__linux__) || defined(__APPLE__) || defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__wasi__) || defined(__EMSCRIPTEN__)
-      clock_getres(CLOCK_REALTIME, &wall);
+  clock_getres(CLOCK_REALTIME, &wall);
 #elif defined(_WIN32)
-      wall.tv_sec = 0;
-      wall.tv_nsec = 100;
+  wall.tv_sec = 0;
+  wall.tv_nsec = 100;
 #else
 #error Missing platform wall time definition
 #endif
-      *seconds = wall.tv_sec;
-      *nanoseconds = wall.tv_nsec;
-      return;
-    }
-  }
-  swift_Concurrency_fatalError(0, "Fatal error: invalid clock ID %d\n",
-                               clock_id);
+  *seconds = wall.tv_sec;
+  *nanoseconds = wall.tv_nsec;
 }
 
-SWIFT_EXPORT_FROM(swift_Concurrency)
-SWIFT_CC(swift)
-void swift_sleep(
-  long long seconds,
-  long long nanoseconds) {
+static void sleepFor(long long seconds, long long nanoseconds) {
 #if defined(_WIN32)
   ULONGLONG now;
   (void)QueryInterruptTimePrecise(&now);
@@ -255,4 +232,48 @@ void swift_sleep(
 #else
   #error Missing platform sleep definition
 #endif
+}
+
+SWIFT_EXPORT_FROM(swift_Concurrency)
+SWIFT_CC(swift)
+void swift_get_time(
+  long long *seconds,
+  long long *nanoseconds,
+  swift_clock_id clock_id) {
+  switch (clock_id) {
+    case swift_clock_id_continuous:
+      return getContinuousTime(seconds, nanoseconds);
+    case swift_clock_id_suspending:
+      return getSuspendingTime(seconds, nanoseconds);
+    case swift_clock_id_wall:
+      return getWallTime(seconds, nanoseconds);
+  }
+  swift_Concurrency_fatalError(0, "Fatal error: invalid clock ID %d\n",
+                               clock_id);
+}
+
+SWIFT_EXPORT_FROM(swift_Concurrency)
+SWIFT_CC(swift)
+void swift_get_clock_res(
+  long long *seconds,
+  long long *nanoseconds,
+  swift_clock_id clock_id) {
+  switch (clock_id) {
+    case swift_clock_id_continuous:
+      return getContinuousResolution(seconds, nanoseconds);
+    case swift_clock_id_suspending:
+      return getSuspendingResolution(seconds, nanoseconds);
+    case swift_clock_id_wall:
+      return getWallResolution(seconds, nanoseconds);
+  }
+  swift_Concurrency_fatalError(0, "Fatal error: invalid clock ID %d\n",
+                               clock_id);
+}
+
+SWIFT_EXPORT_FROM(swift_Concurrency)
+SWIFT_CC(swift)
+void swift_sleep(
+  long long seconds,
+  long long nanoseconds) {
+  sleepFor(seconds, nanoseconds);
 }

--- a/stdlib/public/Concurrency/Clock.swift
+++ b/stdlib/public/Concurrency/Clock.swift
@@ -41,7 +41,48 @@ public protocol Clock<Duration>: Sendable {
 #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
   func sleep(until deadline: Instant, tolerance: Instant.Duration?) async throws
 #endif
+
+#if $Embedded
+  /// Decompose a deadline for the global executor fallback in `Task._sleep`.
+  ///
+  /// The fallback needs the deadline as a runtime clock ID plus seconds and
+  /// nanoseconds. Outside Embedded Swift it recovers that by dynamic casting
+  /// the clock to `ContinuousClock` or `SuspendingClock`; those casts are
+  /// outside the Embedded Swift language subset, so each clock supplies its
+  /// own decomposition instead and generic specialization turns this into a
+  /// direct call.
+  ///
+  /// A clock with no runtime timebase returns nil, which preserves the
+  /// "unknown clock in fallback path" behavior of the non-embedded fallback.
+  ///
+  /// The clock ID is an `Int32` rather than the runtime's `_ClockID` because
+  /// this is a requirement of a public protocol and `_ClockID` is internal.
+  func _timestampComponents(for instant: Instant)
+    -> (clockID: Int32, seconds: Int64, nanoseconds: Int64)?
+
+  /// Decompose a tolerance for the global executor fallback in `Task._sleep`,
+  /// as with `_timestampComponents(for:)`.
+  func _durationComponents(for duration: Instant.Duration)
+    -> (seconds: Int64, nanoseconds: Int64)?
+#endif
 }
+
+#if $Embedded
+@available(StdlibDeploymentTarget 5.7, *)
+extension Clock {
+  @available(StdlibDeploymentTarget 5.7, *)
+  public func _timestampComponents(for instant: Instant)
+    -> (clockID: Int32, seconds: Int64, nanoseconds: Int64)? {
+    nil
+  }
+
+  @available(StdlibDeploymentTarget 5.7, *)
+  public func _durationComponents(for duration: Instant.Duration)
+    -> (seconds: Int64, nanoseconds: Int64)? {
+    nil
+  }
+}
+#endif
 
 @available(StdlibDeploymentTarget 5.7, *)
 extension Clock {

--- a/stdlib/public/Concurrency/ContinuousClock.swift
+++ b/stdlib/public/Concurrency/ContinuousClock.swift
@@ -21,7 +21,6 @@ import Swift
 ///
 /// This clock is suitable for high resolution measurements of execution.
 @available(StdlibDeploymentTarget 5.7, *)
-@_unavailableInEmbedded
 public struct ContinuousClock: Sendable {
   /// A continuous point in time used for `ContinuousClock`.
   public struct Instant: Sendable {
@@ -57,7 +56,6 @@ extension Duration {
 }
 
 @available(StdlibDeploymentTarget 5.7, *)
-@_unavailableInEmbedded
 extension Clock where Self == ContinuousClock {
   /// A clock that measures time that always increments but does not stop
   /// incrementing while the system is asleep.
@@ -69,7 +67,6 @@ extension Clock where Self == ContinuousClock {
 }
 
 @available(StdlibDeploymentTarget 5.7, *)
-@_unavailableInEmbedded
 extension ContinuousClock: Clock {
   /// The current continuous instant.
   public var now: ContinuousClock.Instant {
@@ -134,7 +131,6 @@ extension ContinuousClock: Clock {
 }
 
 @available(StdlibDeploymentTarget 5.7, *)
-@_unavailableInEmbedded
 extension ContinuousClock {
   @available(SwiftStdlib 5.7, *)
   @export(implementation)
@@ -144,7 +140,6 @@ extension ContinuousClock {
 }
 
 @available(SwiftStdlib 5.7, *)
-@_unavailableInEmbedded
 extension ContinuousClock.Instant: InstantProtocol {
   public static var now: ContinuousClock.Instant { ContinuousClock.now }
 

--- a/stdlib/public/Concurrency/SuspendingClock.swift
+++ b/stdlib/public/Concurrency/SuspendingClock.swift
@@ -21,7 +21,6 @@ import Swift
 ///
 /// This clock is suitable for high resolution measurements of execution.
 @available(StdlibDeploymentTarget 5.7, *)
-@_unavailableInEmbedded
 public struct SuspendingClock: Sendable {
   public struct Instant: Sendable {
     internal var _value: Swift.Duration
@@ -41,7 +40,6 @@ extension SuspendingClock.Instant: Codable {
 #endif
 
 @available(StdlibDeploymentTarget 5.7, *)
-@_unavailableInEmbedded
 extension Clock where Self == SuspendingClock {
   /// A clock that measures time that always increments but stops incrementing
   /// while the system is asleep.
@@ -53,7 +51,6 @@ extension Clock where Self == SuspendingClock {
 }
 
 @available(StdlibDeploymentTarget 5.7, *)
-@_unavailableInEmbedded
 extension SuspendingClock: Clock {
   /// The current instant accounting for machine suspension.
   @available(StdlibDeploymentTarget 5.7, *)
@@ -122,7 +119,6 @@ extension SuspendingClock: Clock {
 }
 
 @available(StdlibDeploymentTarget 5.7, *)
-@_unavailableInEmbedded
 extension SuspendingClock {
   @available(SwiftStdlib 5.7, *)
   @export(implementation)
@@ -132,7 +128,6 @@ extension SuspendingClock {
 }
 
 @available(SwiftStdlib 5.7, *)
-@_unavailableInEmbedded
 extension SuspendingClock.Instant: InstantProtocol {
   public static var now: SuspendingClock.Instant { SuspendingClock().now }
 

--- a/stdlib/public/Concurrency/TaskSleep.swift
+++ b/stdlib/public/Concurrency/TaskSleep.swift
@@ -14,7 +14,6 @@ import Swift
 
 #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
 @available(SwiftStdlib 5.1, *)
-@_unavailableInEmbedded
 extension Task where Success == Never, Failure == Never {
   @available(*, deprecated, renamed: "Task.sleep(nanoseconds:)")
   /// Suspends the current task for at least the given duration

--- a/stdlib/public/Concurrency/TaskSleepDuration.swift
+++ b/stdlib/public/Concurrency/TaskSleepDuration.swift
@@ -13,7 +13,6 @@
 import Swift
 
 #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
-@_unavailableInEmbedded
 extension ContinuousClock {
   func timestamp(for instant: Instant)
     -> (clockID: _ClockID, seconds: Int64, nanoseconds: Int64)
@@ -31,7 +30,6 @@ extension ContinuousClock {
   }
 }
 
-@_unavailableInEmbedded
 extension SuspendingClock {
   func timestamp(for instant: Instant)
     -> (clockID: _ClockID, seconds: Int64, nanoseconds: Int64)
@@ -49,9 +47,53 @@ extension SuspendingClock {
   }
 }
 
+#if $Embedded
+// The witnesses for the Clock requirements that stand in for the dynamic
+// casts below. Full specialization turns each of these into a direct call.
+@available(StdlibDeploymentTarget 5.7, *)
+extension ContinuousClock {
+  @available(StdlibDeploymentTarget 5.7, *)
+  public func _timestampComponents(for instant: Instant)
+    -> (clockID: Int32, seconds: Int64, nanoseconds: Int64)? {
+    let stamp = timestamp(for: instant)
+    return (clockID: stamp.clockID.rawValue, seconds: stamp.seconds,
+            nanoseconds: stamp.nanoseconds)
+  }
+
+  @available(StdlibDeploymentTarget 5.7, *)
+  public func _durationComponents(for duration: Instant.Duration)
+    -> (seconds: Int64, nanoseconds: Int64)? {
+    durationComponents(for: duration)
+  }
+}
+
+@available(StdlibDeploymentTarget 5.7, *)
+extension SuspendingClock {
+  @available(StdlibDeploymentTarget 5.7, *)
+  public func _timestampComponents(for instant: Instant)
+    -> (clockID: Int32, seconds: Int64, nanoseconds: Int64)? {
+    let stamp = timestamp(for: instant)
+    return (clockID: stamp.clockID.rawValue, seconds: stamp.seconds,
+            nanoseconds: stamp.nanoseconds)
+  }
+
+  @available(StdlibDeploymentTarget 5.7, *)
+  public func _durationComponents(for duration: Instant.Duration)
+    -> (seconds: Int64, nanoseconds: Int64)? {
+    durationComponents(for: duration)
+  }
+}
+#endif
+
 fileprivate func timestamp<C: Clock>(for instant: C.Instant, clock: C)
   -> (clockID: _ClockID, seconds: Int64, nanoseconds: Int64) {
-  #if !$Embedded
+  #if $Embedded
+  if let components = clock._timestampComponents(for: instant),
+     let clockID = _ClockID(rawValue: components.clockID) {
+    return (clockID: clockID, seconds: components.seconds,
+            nanoseconds: components.nanoseconds)
+  }
+  #else
   if let continuousClock = clock as? ContinuousClock {
     return continuousClock.timestamp(for: instant as! ContinuousClock.Instant)
   } else if let suspendingClock = clock as? SuspendingClock {
@@ -63,7 +105,11 @@ fileprivate func timestamp<C: Clock>(for instant: C.Instant, clock: C)
 
 fileprivate func durationComponents<C: Clock>(for duration: C.Duration, clock: C)
   -> (seconds: Int64, nanoseconds: Int64) {
-  #if !$Embedded
+  #if $Embedded
+  if let components = clock._durationComponents(for: duration) {
+    return components
+  }
+  #else
   if let continuousClock = clock as? ContinuousClock {
     return continuousClock.durationComponents(for: duration as! ContinuousClock.Duration)
   } else if let suspendingClock = clock as? SuspendingClock {
@@ -74,7 +120,6 @@ fileprivate func durationComponents<C: Clock>(for duration: C.Duration, clock: C
 }
 
 @available(StdlibDeploymentTarget 5.7, *)
-@_unavailableInEmbedded
 extension Task where Success == Never, Failure == Never {
   @available(StdlibDeploymentTarget 5.7, *)
   @diagnose(UselessAvailabilityCheck, as: ignored)
@@ -207,7 +252,6 @@ extension Task where Success == Never, Failure == Never {
     }
   }
 
-  #if !$Embedded
   /// Suspends the current task until the given deadline within a tolerance.
   ///
   /// If the task is canceled before the time ends, this function throws
@@ -244,7 +288,6 @@ extension Task where Success == Never, Failure == Never {
   ) async throws {
     try await clock.sleep(for: duration, tolerance: tolerance)
   }
-  #endif
 }
 #else
 @available(SwiftStdlib 5.7, *)

--- a/stdlib/public/EmbeddedPlatform/CMakeLists.txt
+++ b/stdlib/public/EmbeddedPlatform/CMakeLists.txt
@@ -26,6 +26,8 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   add_dependencies(embedded-libraries embedded-multi-threaded-posix-shim)
   add_custom_target(embedded-multi-threaded-darwin-shim)
   add_dependencies(embedded-libraries embedded-multi-threaded-darwin-shim)
+  add_custom_target(embedded-clock-posix-shim)
+  add_dependencies(embedded-libraries embedded-clock-posix-shim)
 
   # The bridging header annotates its C declarations with Clang bounds-safety
   # attributes (EMBEDDED_SWIFT_COUNTED_BY / EMBEDDED_SWIFT_SIZED_BY, i.e.
@@ -127,4 +129,31 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       INSTALL_IN_COMPONENT stdlib
     )
   endif()
+
+  # The POSIX clock shim implements the platform clock hooks with
+  # `clock_gettime`/`clock_getres`/`nanosleep`.
+  #
+  # It cannot live in `swiftEmbeddedPlatformPOSIX`: that library is written in
+  # Swift against `@_extern(c)` declarations, so it needs no headers and is
+  # built for bare-metal triples too, whereas the clocks need `struct timespec`
+  # and `clockid_t` from `<time.h>`. Their layouts are not portably expressible
+  # from Swift either -- on wasm32 `tv_sec` is 64-bit while `tv_nsec` is 32-bit
+  # and padded -- so this is C, and like the pthread shim above it shares that
+  # shim's skip list: bare-metal targets provide their own clock hooks.
+  add_embedded_swift_target_library(
+    embedded-clock-posix-shim
+    swiftEmbeddedPlatformClockPOSIX
+    PARTIAL_SOURCES_INTENDED
+    INSTALL_BINARY
+    NON_EMPTY_OBJECT_FILE
+
+    EmbeddedPlatformClockPOSIX.c
+
+    C_COMPILE_FLAGS -nostdinc++ -I${CMAKE_CURRENT_SOURCE_DIR}/swift
+    SKIP_MOD_REGEX "-windows-msvc$"
+    SKIP_ARCH_REGEX "avr"
+    SKIP_TRIPLE_REGEX ${_mt_posix_skip_triple}
+    ARCHITECTURE_KEY mod
+    INSTALL_IN_COMPONENT stdlib
+  )
 endif()

--- a/stdlib/public/EmbeddedPlatform/CMakeLists.txt
+++ b/stdlib/public/EmbeddedPlatform/CMakeLists.txt
@@ -26,6 +26,8 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   add_dependencies(embedded-libraries embedded-multi-threaded-posix-shim)
   add_custom_target(embedded-multi-threaded-darwin-shim)
   add_dependencies(embedded-libraries embedded-multi-threaded-darwin-shim)
+  add_custom_target(embedded-clock-posix-shim)
+  add_dependencies(embedded-libraries embedded-clock-posix-shim)
 
   # The bridging header annotates its C declarations with Clang bounds-safety
   # attributes (EMBEDDED_SWIFT_COUNTED_BY / EMBEDDED_SWIFT_SIZED_BY, i.e.
@@ -127,4 +129,25 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       INSTALL_IN_COMPONENT stdlib
     )
   endif()
+
+  # The POSIX clock shim implements the platform clock hooks with
+  # `clock_gettime`/`clock_getres`/`nanosleep`. Like the pthread shim above,
+  # it only makes sense on hosted POSIX-ish targets, so it shares the same
+  # skip list: bare-metal targets provide their own clock hooks.
+  add_embedded_swift_target_library(
+    embedded-clock-posix-shim
+    swiftEmbeddedPlatformClockPOSIX
+    PARTIAL_SOURCES_INTENDED
+    INSTALL_BINARY
+    NON_EMPTY_OBJECT_FILE
+
+    EmbeddedPlatformClockPOSIX.c
+
+    C_COMPILE_FLAGS -nostdinc++ -I${CMAKE_CURRENT_SOURCE_DIR}/swift
+    SKIP_MOD_REGEX "-windows-msvc$"
+    SKIP_ARCH_REGEX "avr"
+    SKIP_TRIPLE_REGEX ${_mt_posix_skip_triple}
+    ARCHITECTURE_KEY mod
+    INSTALL_IN_COMPONENT stdlib
+  )
 endif()

--- a/stdlib/public/EmbeddedPlatform/EmbeddedPlatformClockPOSIX.c
+++ b/stdlib/public/EmbeddedPlatform/EmbeddedPlatformClockPOSIX.c
@@ -1,0 +1,94 @@
+/*===------ EmbeddedPlatformClockPOSIX.c -------------------------*- C -*-===*
+ *
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2026 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+ *
+ *===----------------------------------------------------------------------===*
+ *
+ * An implementation of the Embedded Swift platform clock hooks on top of the
+ * POSIX clock facilities.
+ *
+ * The mapping from the Swift clocks to the native clocks matches the default
+ * implementations in stdlib/public/Concurrency/Clock.cpp, so that enabling the
+ * platform abstraction layer does not change the observable clock behavior on
+ * these targets.
+ *
+ *===----------------------------------------------------------------------===*/
+
+#include "swift/EmbeddedPlatform.h"
+
+#include <errno.h>
+#include <time.h>
+
+#if defined(__APPLE__)
+#define SWIFT_CONTINUOUS_CLOCK CLOCK_MONOTONIC_RAW
+#define SWIFT_SUSPENDING_CLOCK CLOCK_UPTIME_RAW
+#define SWIFT_SUSPENDING_RESOLUTION_CLOCK CLOCK_UPTIME_RAW
+#elif defined(__linux__)
+#define SWIFT_CONTINUOUS_CLOCK CLOCK_BOOTTIME
+#define SWIFT_SUSPENDING_CLOCK CLOCK_MONOTONIC
+/* Clock.cpp asks CLOCK_MONOTONIC_RAW for the suspending clock's resolution
+ * even though it reads the time from CLOCK_MONOTONIC. Reproduce that here
+ * rather than quietly change what minimumResolution reports on Linux. */
+#define SWIFT_SUSPENDING_RESOLUTION_CLOCK CLOCK_MONOTONIC_RAW
+#elif defined(__FreeBSD__) || defined(__OpenBSD__)
+#define SWIFT_CONTINUOUS_CLOCK CLOCK_MONOTONIC
+#define SWIFT_SUSPENDING_CLOCK CLOCK_UPTIME
+#define SWIFT_SUSPENDING_RESOLUTION_CLOCK CLOCK_UPTIME
+#else
+#define SWIFT_CONTINUOUS_CLOCK CLOCK_MONOTONIC
+#define SWIFT_SUSPENDING_CLOCK CLOCK_MONOTONIC
+#define SWIFT_SUSPENDING_RESOLUTION_CLOCK CLOCK_MONOTONIC
+#endif
+
+static void swift_platform_getTime(clockid_t clock,
+                                   __swift_int64_t *seconds,
+                                   __swift_int64_t *nanoseconds) {
+  struct timespec ts;
+  clock_gettime(clock, &ts);
+  *seconds = ts.tv_sec;
+  *nanoseconds = ts.tv_nsec;
+}
+
+static void swift_platform_getResolution(clockid_t clock,
+                                         __swift_int64_t *seconds,
+                                         __swift_int64_t *nanoseconds) {
+  struct timespec ts;
+  clock_getres(clock, &ts);
+  *seconds = ts.tv_sec;
+  *nanoseconds = ts.tv_nsec;
+}
+
+void _swift_clockContinuous_getTime(__swift_int64_t *seconds,
+                                    __swift_int64_t *nanoseconds) {
+  swift_platform_getTime(SWIFT_CONTINUOUS_CLOCK, seconds, nanoseconds);
+}
+
+void _swift_clockContinuous_getResolution(__swift_int64_t *seconds,
+                                          __swift_int64_t *nanoseconds) {
+  swift_platform_getResolution(SWIFT_CONTINUOUS_CLOCK, seconds, nanoseconds);
+}
+
+void _swift_clockSuspending_getTime(__swift_int64_t *seconds,
+                                    __swift_int64_t *nanoseconds) {
+  swift_platform_getTime(SWIFT_SUSPENDING_CLOCK, seconds, nanoseconds);
+}
+
+void _swift_clockSuspending_getResolution(__swift_int64_t *seconds,
+                                          __swift_int64_t *nanoseconds) {
+  swift_platform_getResolution(SWIFT_SUSPENDING_RESOLUTION_CLOCK,
+                               seconds, nanoseconds);
+}
+
+void _swift_clock_sleep(__swift_int64_t seconds, __swift_int64_t nanoseconds) {
+  struct timespec ts;
+  ts.tv_sec = (time_t)seconds;
+  ts.tv_nsec = (long)nanoseconds;
+  while (nanosleep(&ts, &ts) == -1 && errno == EINTR) {
+  }
+}

--- a/stdlib/public/EmbeddedPlatform/EmbeddedPlatformClockPOSIX.c
+++ b/stdlib/public/EmbeddedPlatform/EmbeddedPlatformClockPOSIX.c
@@ -1,0 +1,88 @@
+/*===------ EmbeddedPlatformClockPOSIX.c -------------------------*- C -*-===*
+ *
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2026 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+ *
+ *===----------------------------------------------------------------------===*
+ *
+ * An implementation of the Embedded Swift platform clock hooks on top of the
+ * POSIX clock facilities. The mapping from Swift clocks to native clocks
+ * matches the default implementations in stdlib/public/Concurrency/Clock.cpp
+ * so that enabling the platform abstraction layer does not change the
+ * observable clock behavior on these targets.
+ *
+ *===----------------------------------------------------------------------===*/
+
+#include "swift/EmbeddedPlatform.h"
+
+#include <errno.h>
+#include <time.h>
+
+static clockid_t swift_embedded_platform_time_clock(
+    swift_clock_id_t clock_id) {
+  switch (clock_id) {
+  case SWIFT_CLOCK_CONTINUOUS:
+#if defined(__APPLE__)
+    return CLOCK_MONOTONIC_RAW;
+#elif defined(__linux__)
+    return CLOCK_BOOTTIME;
+#else
+    return CLOCK_MONOTONIC;
+#endif
+  case SWIFT_CLOCK_SUSPENDING:
+#if defined(__APPLE__)
+    return CLOCK_UPTIME_RAW;
+#elif defined(__FreeBSD__) || defined(__OpenBSD__)
+    return CLOCK_UPTIME;
+#else
+    return CLOCK_MONOTONIC;
+#endif
+  case SWIFT_CLOCK_WALL:
+    return CLOCK_REALTIME;
+  }
+  /* Unreachable: the runtime only passes the declared clock IDs. */
+  return CLOCK_REALTIME;
+}
+
+/* The resolution mapping matches the clock_getres calls in Clock.cpp, which
+ * on Linux query CLOCK_MONOTONIC_RAW for the suspending clock even though
+ * the corresponding clock_gettime uses CLOCK_MONOTONIC. */
+static clockid_t swift_embedded_platform_resolution_clock(
+    swift_clock_id_t clock_id) {
+#if defined(__linux__)
+  if (clock_id == SWIFT_CLOCK_SUSPENDING)
+    return CLOCK_MONOTONIC_RAW;
+#endif
+  return swift_embedded_platform_time_clock(clock_id);
+}
+
+void _swift_clock_getTime(swift_clock_id_t clock_id,
+                          long long *seconds,
+                          long long *nanoseconds) {
+  struct timespec ts;
+  clock_gettime(swift_embedded_platform_time_clock(clock_id), &ts);
+  *seconds = ts.tv_sec;
+  *nanoseconds = ts.tv_nsec;
+}
+
+void _swift_clock_getResolution(swift_clock_id_t clock_id,
+                                long long *seconds,
+                                long long *nanoseconds) {
+  struct timespec ts;
+  clock_getres(swift_embedded_platform_resolution_clock(clock_id), &ts);
+  *seconds = ts.tv_sec;
+  *nanoseconds = ts.tv_nsec;
+}
+
+void _swift_clock_sleep(long long seconds, long long nanoseconds) {
+  struct timespec ts;
+  ts.tv_sec = (time_t)seconds;
+  ts.tv_nsec = (long)nanoseconds;
+  while (nanosleep(&ts, &ts) == -1 && errno == EINTR) {
+  }
+}

--- a/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
+++ b/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
@@ -36,6 +36,16 @@ typedef ptrdiff_t __swift_ptrdiff_t;
 #endif
 
 /**
+ * A signed 64-bit integer, the same type as `int64_t`.
+ */
+#if defined(__INT64_TYPE__)
+typedef __INT64_TYPE__ __swift_int64_t;
+#else
+#include <stdint.h>
+typedef int64_t __swift_int64_t;
+#endif
+
+/**
  * 64-bit type identifier information that is used for typed allocation and
  * deallocation.
  */
@@ -128,7 +138,7 @@ typedef void (*__swift_tls_dtor_t)(void * EMBEDDED_SWIFT_NULLABLE);
  * entrypoints might be optional, where the entrypoint is needed only when
  * certain Swift functionality is used.
  */
-#define EMBEDDED_SWIFT_PLATFORM_VERSION_MINOR 1
+#define EMBEDDED_SWIFT_PLATFORM_VERSION_MINOR 2
 
 #if defined(__cplusplus)
 extern "C" {
@@ -591,6 +601,132 @@ __swift_ptrdiff_t _swift_thread_isMain(void);
  * function.
  */
 void _swift_exit(int code);
+
+/*
+ * The runtime's clock entry points reference the five clock functions below
+ * in three groups: reading the time of either clock references both
+ * *_getTime functions, reading either clock's resolution references both
+ * *_getResolution functions, and the default cooperative global executor's
+ * wait loop references _swift_clock_sleep. A referenced function must
+ * resolve at link time even if it is never called. With function-level dead
+ * stripping, only the groups whose entry points survive the link are
+ * referenced; without it, linking the runtime references all five.
+ * Providing all five is therefore always safe: one that a platform cannot
+ * usefully implement can be a trap, or an alias of another clock, as
+ * described on each function.
+ */
+
+/**
+ * Reads the current time of the continuous clock.
+ *
+ * - Parameters:
+ *   - seconds: On return, the whole seconds of the current time.
+ *   - nanoseconds: On return, the remaining nanoseconds of the current time,
+ *     in the range [0, 999999999].
+ *
+ * The continuous clock increments monotonically and keeps incrementing while
+ * the system is asleep, matching the Swift `ContinuousClock`. Its time is
+ * measured from an arbitrary fixed point in the past, such as system boot,
+ * so only differences between two readings are meaningful.
+ *
+ * This function is called whenever the program reads the continuous clock's
+ * time: through `ContinuousClock.now`, through the `swift_time_now` C
+ * interface that executor implementations use, or through the default
+ * cooperative global executor when it re-reads a deadline expressed on this
+ * clock. A platform with no continuous time source can implement it as a
+ * trap, or use the same time source as the suspending clock.
+ *
+ * This function can be implemented as a call to `clock_gettime` with
+ * `CLOCK_BOOTTIME` on Linux, or `CLOCK_MONOTONIC_RAW` on Darwin.
+ */
+void _swift_clockContinuous_getTime(
+    __swift_int64_t * EMBEDDED_SWIFT_NONNULL EMBEDDED_SWIFT_SINGLE seconds,
+    __swift_int64_t * EMBEDDED_SWIFT_NONNULL EMBEDDED_SWIFT_SINGLE nanoseconds);
+
+/**
+ * Reports the resolution of the continuous clock.
+ *
+ * - Parameters:
+ *   - seconds: On return, the whole seconds of the clock's resolution.
+ *   - nanoseconds: On return, the remaining nanoseconds of the clock's
+ *     resolution, in the range [0, 999999999].
+ *
+ * This is the value reported by `ContinuousClock.minimumResolution`, and by
+ * the `swift_time_getResolution` C interface that executor implementations
+ * can use.
+ *
+ * This function can be implemented as a call to `clock_getres`.
+ */
+void _swift_clockContinuous_getResolution(
+    __swift_int64_t * EMBEDDED_SWIFT_NONNULL EMBEDDED_SWIFT_SINGLE seconds,
+    __swift_int64_t * EMBEDDED_SWIFT_NONNULL EMBEDDED_SWIFT_SINGLE nanoseconds);
+
+/**
+ * Reads the current time of the suspending clock.
+ *
+ * - Parameters:
+ *   - seconds: On return, the whole seconds of the current time.
+ *   - nanoseconds: On return, the remaining nanoseconds of the current time,
+ *     in the range [0, 999999999].
+ *
+ * The suspending clock increments monotonically but stops incrementing while
+ * the system is asleep, matching the Swift `SuspendingClock`. Its time is
+ * measured from an arbitrary fixed point in the past, such as system boot,
+ * so only differences between two readings are meaningful.
+ *
+ * A platform that never suspends, or that cannot tell how long it was
+ * suspended for, may use the same time source as the continuous clock.
+ *
+ * This function is called whenever the program reads the suspending clock's
+ * time, through `SuspendingClock.now` or the `swift_time_now` C interface.
+ * The default cooperative global executor also runs its timer queue on this
+ * clock, so under that executor every `Task.sleep` reads it, whichever
+ * clock the sleep is expressed in.
+ *
+ * This function can be implemented as a call to `clock_gettime` with
+ * `CLOCK_MONOTONIC` on Linux, or `CLOCK_UPTIME_RAW` on Darwin.
+ */
+void _swift_clockSuspending_getTime(
+    __swift_int64_t * EMBEDDED_SWIFT_NONNULL EMBEDDED_SWIFT_SINGLE seconds,
+    __swift_int64_t * EMBEDDED_SWIFT_NONNULL EMBEDDED_SWIFT_SINGLE nanoseconds);
+
+/**
+ * Reports the resolution of the suspending clock.
+ *
+ * - Parameters:
+ *   - seconds: On return, the whole seconds of the clock's resolution.
+ *   - nanoseconds: On return, the remaining nanoseconds of the clock's
+ *     resolution, in the range [0, 999999999].
+ *
+ * This is the value reported by `SuspendingClock.minimumResolution`, and by
+ * the `swift_time_getResolution` C interface that executor implementations
+ * can use.
+ *
+ * This function can be implemented as a call to `clock_getres`.
+ */
+void _swift_clockSuspending_getResolution(
+    __swift_int64_t * EMBEDDED_SWIFT_NONNULL EMBEDDED_SWIFT_SINGLE seconds,
+    __swift_int64_t * EMBEDDED_SWIFT_NONNULL EMBEDDED_SWIFT_SINGLE nanoseconds);
+
+/**
+ * Blocks the calling execution context for at least the given relative
+ * duration.
+ *
+ * - Parameters:
+ *   - seconds: The whole seconds of the duration.
+ *   - nanoseconds: The remaining nanoseconds of the duration, in the range
+ *     [0, 999999999].
+ *
+ * Only the default cooperative global executor calls this function; it uses
+ * it to wait until the next delayed job becomes ready to run. A platform that
+ * installs a custom global executor that schedules delayed jobs by other
+ * means, such as a hardware timer, may implement this function as a no-op or
+ * a trap.
+ *
+ * This function can be implemented as a call to `nanosleep`, retrying when
+ * the sleep is interrupted by a signal.
+ */
+void _swift_clock_sleep(__swift_int64_t seconds, __swift_int64_t nanoseconds);
 
 #if defined(__cplusplus)
 }

--- a/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
+++ b/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
@@ -128,7 +128,7 @@ typedef void (*__swift_tls_dtor_t)(void * EMBEDDED_SWIFT_NULLABLE);
  * entrypoints might be optional, where the entrypoint is needed only when
  * certain Swift functionality is used.
  */
-#define EMBEDDED_SWIFT_PLATFORM_VERSION_MINOR 1
+#define EMBEDDED_SWIFT_PLATFORM_VERSION_MINOR 2
 
 #if defined(__cplusplus)
 extern "C" {
@@ -253,6 +253,34 @@ typedef enum EMBEDDED_SWIFT_OPTION_SET: __swift_options_t {
    */
   SWIFT_MUTEX_CHECKED EMBEDDED_SWIFT_NAME(checked) = 0x01
 } swift_mutex_flags_t EMBEDDED_SWIFT_NAME(SwiftMutexFlags);
+
+/**
+ * Identifies one of the clocks used by the Swift time APIs.
+ *
+ * The values match the runtime's `swift_clock_id`.
+ */
+typedef enum EMBEDDED_SWIFT_ENUM: int {
+  /**
+   * A clock that increments monotonically and keeps incrementing while the
+   * system is asleep, like the Swift `ContinuousClock`.
+   */
+  SWIFT_CLOCK_CONTINUOUS EMBEDDED_SWIFT_NAME(continuous) = 1,
+
+  /**
+   * A clock that increments monotonically but stops incrementing while the
+   * system is asleep, like the Swift `SuspendingClock`.
+   *
+   * A platform that cannot distinguish the two behaviors may use the same
+   * time source for the continuous and suspending clocks.
+   */
+  SWIFT_CLOCK_SUSPENDING EMBEDDED_SWIFT_NAME(suspending) = 2,
+
+  /**
+   * A clock that measures wall-clock time since the UNIX epoch
+   * (January 1, 1970).
+   */
+  SWIFT_CLOCK_WALL EMBEDDED_SWIFT_NAME(wall) = 3,
+} swift_clock_id_t EMBEDDED_SWIFT_NAME(SwiftClockID);
 
 /**
  * Allocates memory and returns the resulting pointer.
@@ -619,6 +647,74 @@ __swift_ptrdiff_t _swift_thread_isMain(void);
  * function.
  */
 void _swift_exit(int code);
+
+/**
+ * Reads the current time of one of the Swift clocks.
+ *
+ * - Parameters:
+ *   - clock_id: The clock to read.
+ *   - seconds: On return, the whole seconds of the current time.
+ *   - nanoseconds: On return, the remaining nanoseconds of the current time.
+ *     The value should be in the range [0, 999999999].
+ *
+ * The time reported by the continuous and suspending clocks is measured from
+ * an arbitrary fixed point in the past, such as system boot. The wall clock
+ * reports time since the UNIX epoch (January 1, 1970).
+ *
+ * The runtime only calls this function with one of the declared
+ * `swift_clock_id_t` values.
+ *
+ * This function is required when using the Swift clock APIs, such as
+ * `ContinuousClock`, or any functionality built on top of them, such as
+ * `Task.sleep`.
+ *
+ * This function can be implemented as a call to `clock_gettime`.
+ */
+void _swift_clock_getTime(swift_clock_id_t clock_id,
+    long long * EMBEDDED_SWIFT_NONNULL EMBEDDED_SWIFT_SINGLE seconds,
+    long long * EMBEDDED_SWIFT_NONNULL EMBEDDED_SWIFT_SINGLE nanoseconds);
+
+/**
+ * Reports the resolution of one of the Swift clocks.
+ *
+ * - Parameters:
+ *   - clock_id: The clock whose resolution is being requested.
+ *   - seconds: On return, the whole seconds of the clock's resolution.
+ *   - nanoseconds: On return, the remaining nanoseconds of the clock's
+ *     resolution. The value should be in the range [0, 999999999].
+ *
+ * The runtime only calls this function with one of the declared
+ * `swift_clock_id_t` values.
+ *
+ * This function is required when using the Swift clock APIs; the
+ * `minimumResolution` properties of the clocks report the value returned
+ * here.
+ *
+ * This function can be implemented as a call to `clock_getres`.
+ */
+void _swift_clock_getResolution(swift_clock_id_t clock_id,
+    long long * EMBEDDED_SWIFT_NONNULL EMBEDDED_SWIFT_SINGLE seconds,
+    long long * EMBEDDED_SWIFT_NONNULL EMBEDDED_SWIFT_SINGLE nanoseconds);
+
+/**
+ * Blocks the calling execution context for at least the given relative
+ * duration.
+ *
+ * - Parameters:
+ *   - seconds: The whole seconds of the duration.
+ *   - nanoseconds: The remaining nanoseconds of the duration.
+ *
+ * Only the default cooperative global executor calls this function; it uses
+ * it to wait until the next delayed job becomes ready to run. The function
+ * must be linkable whenever the Concurrency clock entry points are in use,
+ * but a platform that installs a custom global executor that schedules
+ * delayed jobs by other means (e.g., a hardware timer) may implement it as
+ * a no-op or a trap.
+ *
+ * This function can be implemented as a call to `nanosleep`, retrying when
+ * the sleep is interrupted by a signal.
+ */
+void _swift_clock_sleep(long long seconds, long long nanoseconds);
 
 #if defined(__cplusplus)
 }

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -1151,7 +1151,7 @@ public func swift_getPlatformLayerVersion(
   _ minor: UnsafeMutablePointer<Int>
 ) {
   unsafe major.pointee = 1 // EMBEDDED_SWIFT_PLATFORM_VERSION_MAJOR
-  unsafe minor.pointee = 1 // EMBEDDED_SWIFT_PLATFORM_VERSION_MINOR
+  unsafe minor.pointee = 2 // EMBEDDED_SWIFT_PLATFORM_VERSION_MINOR
 }
 #endif
 

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -1135,7 +1135,7 @@ public func swift_getPlatformLayerVersion(
   _ minor: UnsafeMutablePointer<Int>
 ) {
   unsafe major.pointee = 1 // EMBEDDED_SWIFT_PLATFORM_VERSION_MAJOR
-  unsafe minor.pointee = 1 // EMBEDDED_SWIFT_PLATFORM_VERSION_MINOR
+  unsafe minor.pointee = 2 // EMBEDDED_SWIFT_PLATFORM_VERSION_MINOR
 }
 #endif
 

--- a/test/embedded/concurrency-clock-pal.swift
+++ b/test/embedded/concurrency-clock-pal.swift
@@ -1,0 +1,243 @@
+// The Swift clock APIs on top of the Embedded Swift platform abstraction
+// layer: ContinuousClock, SuspendingClock and Task.sleep, down to the clock
+// hooks in swift/EmbeddedPlatform.h.
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// (1) With a fake platform clock, the Swift clock APIs must report exactly
+// the values the platform hooks return. Each clock's hooks answer with
+// distinct values, so what the APIs print identifies which hook produced it.
+// fake-clock.c defines every hook, so the clock shim archive that
+// %target-embedded-link bundles is never drawn on.
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %t/values.swift -c -o %t/values.o
+// RUN: %target-embedded-link %target-clang-resource-dir-opt -I %swift_obj_root/include -x c %t/fake-clock.c -x none %t/values.o -o %t/values.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple -lc++ -lswift_Concurrency %target-swift-default-executor-opt %target-embedded-concurrency-threading-shim -dead_strip
+// RUN: %target-run %t/values.out | %FileCheck %t/values.swift
+
+// (2) With the bundled POSIX clock shim, the same APIs link without a
+// user-provided clock, report advancing time, and actually sleep.
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %t/sleep.swift -c -o %t/sleep.o
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/sleep.o -o %t/sleep.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple -lc++ -lswift_Concurrency %target-swift-default-executor-opt %target-embedded-concurrency-threading-shim -dead_strip
+// RUN: %target-run %t/sleep.out | %FileCheck %t/sleep.swift
+
+// (3) Only the default cooperative global executor calls the sleep hook. A
+// program with a custom global executor schedules delayed jobs itself, so
+// Task.sleep still works with a clock whose sleep hook traps. The link line
+// spells out %target-embedded-link's archives instead of using the wrapper
+// so that the bundled clock shim stays out — trap-clock.c must be the only
+// clock provider for the trapping sleep hook to prove anything — and the
+// default executor is replaced by the custom one.
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %t/executor.swift -c -o %t/executor.o
+// RUN: %target-clang -x c -std=c11 -I %swift_obj_root/include -c %S/Inputs/executor.c -o %t/custom-executor.o
+// RUN: %target-clang %target-clang-resource-dir-opt -I %swift_obj_root/include -x c %t/trap-clock.c -x none %t/executor.o %t/custom-executor.o -o %t/executor.out %swift_obj_root/lib/swift/embedded/%module-target-triple/libswiftCore.a %swift_obj_root/lib/swift/embedded/%module-target-triple/libswiftEmbeddedPlatformPOSIX.a %swift_obj_root/lib/swift/embedded/%module-target-triple/libswift_Concurrency.a %target-embedded-concurrency-threading-shim -dead_strip
+// RUN: %target-run %t/executor.out | %FileCheck %t/executor.swift
+
+// REQUIRES: swift_embedded_platform
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx
+// REQUIRES: swift_feature_Embedded
+
+//--- values.swift
+
+import _Concurrency
+
+// A Duration as whole seconds plus nanoseconds, which is how the platform
+// hooks report time.
+func report(_ label: String, _ duration: Duration) {
+  let (seconds, attoseconds) = duration.components
+  print("\(label): \(seconds) \(attoseconds / 1_000_000_000)")
+}
+
+@main
+struct Main {
+  static func main() {
+    let continuous = ContinuousClock()
+    let suspending = SuspendingClock()
+
+    // `systemEpoch` is the clock's zero instant, so the duration from it to
+    // `now` is exactly what the platform hook returned.
+    report("continuous now", continuous.systemEpoch.duration(to: continuous.now))
+    // CHECK: continuous now: 11 22
+    report("continuous resolution", continuous.minimumResolution)
+    // CHECK-NEXT: continuous resolution: 0 33
+
+    // Distinct values, so this also shows the continuous and suspending
+    // entry points reach their own hooks and not each other's.
+    report("suspending now", suspending.systemEpoch.duration(to: suspending.now))
+    // CHECK-NEXT: suspending now: 44 55
+    report("suspending resolution", suspending.minimumResolution)
+    // CHECK-NEXT: suspending resolution: 0 66
+
+    // Instant arithmetic and `measure` are plain Swift on top of `now`.
+    let start = continuous.now
+    report("advanced", start.duration(to: start.advanced(by: .seconds(5))))
+    // CHECK-NEXT: advanced: 5 0
+
+    // The fake clock never moves, so a measured interval is zero.
+    report("measured", continuous.measure { })
+    // CHECK-NEXT: measured: 0 0
+
+    print("done")
+    // CHECK-NEXT: done
+  }
+}
+
+//--- sleep.swift
+
+import _Concurrency
+
+func elapsedMilliseconds(_ duration: Duration) -> Int64 {
+  let (seconds, attoseconds) = duration.components
+  return seconds * 1000 + attoseconds / 1_000_000_000_000_000
+}
+
+func check(_ label: String, _ elapsed: Duration, atLeast milliseconds: Int64) {
+  print(elapsedMilliseconds(elapsed) >= milliseconds
+        ? "\(label): ok" : "\(label): too short")
+}
+
+@main
+struct Main {
+  static func main() async {
+    let continuous = ContinuousClock()
+
+    let first = continuous.now
+    let second = continuous.now
+    print(first <= second ? "advancing" : "not advancing")
+    // CHECK: advancing
+
+    var start = continuous.now
+    try! await Task.sleep(for: .milliseconds(50))
+    check("Task.sleep(for:)", start.duration(to: continuous.now), atLeast: 50)
+    // CHECK-NEXT: Task.sleep(for:): ok
+
+    start = continuous.now
+    try! await Task.sleep(until: start.advanced(by: .milliseconds(50)))
+    check("Task.sleep(until:)", start.duration(to: continuous.now), atLeast: 50)
+    // CHECK-NEXT: Task.sleep(until:): ok
+
+    start = continuous.now
+    try! await Task.sleep(nanoseconds: 50_000_000)
+    check("Task.sleep(nanoseconds:)", start.duration(to: continuous.now),
+          atLeast: 50)
+    // CHECK-NEXT: Task.sleep(nanoseconds:): ok
+
+    // The same, driven by the suspending clock rather than the continuous one.
+    let suspending = SuspendingClock()
+    let suspendingStart = suspending.now
+    try! await suspending.sleep(
+      until: suspendingStart.advanced(by: .milliseconds(50)))
+    check("SuspendingClock.sleep(until:)",
+          suspendingStart.duration(to: suspending.now), atLeast: 50)
+    // CHECK-NEXT: SuspendingClock.sleep(until:): ok
+
+    print("done")
+    // CHECK-NEXT: done
+  }
+}
+
+//--- executor.swift
+
+import _Concurrency
+
+@main
+struct Main {
+  static func main() async {
+    // The custom executor schedules the delayed job off its own timer, so
+    // this completes without the runtime ever calling the sleep hook.
+    try! await Task.sleep(for: .milliseconds(10))
+    print("slept")
+    // CHECK: slept
+
+    let task = Task { 42 }
+    print(await task.value == 42 ? "ran" : "did not run")
+    // CHECK: ran
+
+    print("done")
+    // CHECK: done
+  }
+}
+
+//--- fake-clock.c
+
+/* A fake platform clock. Each hook reports a fixed, distinct value, so the
+   Swift clock APIs can be checked against exact numbers. */
+
+#include <swift/EmbeddedPlatform.h>
+
+void _swift_clockContinuous_getTime(__swift_int64_t *seconds,
+                                    __swift_int64_t *nanoseconds) {
+  *seconds = 11;
+  *nanoseconds = 22;
+}
+
+void _swift_clockContinuous_getResolution(__swift_int64_t *seconds,
+                                          __swift_int64_t *nanoseconds) {
+  *seconds = 0;
+  *nanoseconds = 33;
+}
+
+void _swift_clockSuspending_getTime(__swift_int64_t *seconds,
+                                    __swift_int64_t *nanoseconds) {
+  *seconds = 44;
+  *nanoseconds = 55;
+}
+
+void _swift_clockSuspending_getResolution(__swift_int64_t *seconds,
+                                          __swift_int64_t *nanoseconds) {
+  *seconds = 0;
+  *nanoseconds = 66;
+}
+
+void _swift_clock_sleep(__swift_int64_t seconds, __swift_int64_t nanoseconds) {
+  (void)seconds;
+  (void)nanoseconds;
+}
+
+//--- trap-clock.c
+
+/* A minimal clock provider for a program with a custom global executor. The
+   executor drives its timer queue from swift_time_now, so the time hooks must
+   answer; the sleep hook is only ever called by the default cooperative
+   global executor, so it traps. */
+
+#include <swift/EmbeddedPlatform.h>
+
+#include <time.h>
+
+static void getTime(clockid_t clock, __swift_int64_t *seconds,
+                    __swift_int64_t *nanoseconds) {
+  struct timespec ts;
+  clock_gettime(clock, &ts);
+  *seconds = ts.tv_sec;
+  *nanoseconds = ts.tv_nsec;
+}
+
+void _swift_clockContinuous_getTime(__swift_int64_t *seconds,
+                                    __swift_int64_t *nanoseconds) {
+  getTime(CLOCK_MONOTONIC_RAW, seconds, nanoseconds);
+}
+
+void _swift_clockContinuous_getResolution(__swift_int64_t *seconds,
+                                          __swift_int64_t *nanoseconds) {
+  *seconds = 0;
+  *nanoseconds = 1;
+}
+
+void _swift_clockSuspending_getTime(__swift_int64_t *seconds,
+                                    __swift_int64_t *nanoseconds) {
+  getTime(CLOCK_UPTIME_RAW, seconds, nanoseconds);
+}
+
+void _swift_clockSuspending_getResolution(__swift_int64_t *seconds,
+                                          __swift_int64_t *nanoseconds) {
+  *seconds = 0;
+  *nanoseconds = 1;
+}
+
+void _swift_clock_sleep(__swift_int64_t seconds, __swift_int64_t nanoseconds) {
+  (void)seconds;
+  (void)nanoseconds;
+  __builtin_trap();
+}

--- a/test/embedded/concurrency-clock-pal.swift
+++ b/test/embedded/concurrency-clock-pal.swift
@@ -1,0 +1,174 @@
+// Verify that the Concurrency runtime routes clock queries through the
+// Embedded Swift platform abstraction layer clock hooks.
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %t/main.swift -c -o %t/main.o
+
+// (1) With a fake platform clock, the runtime must report exactly the values
+// the platform hooks return, passing each clock ID and the sleep duration
+// through unchanged. The fake provider is an explicit object on the link
+// line, so it takes precedence over the bundled clock shim archive.
+// RUN: %target-embedded-link %target-clang-resource-dir-opt -x c %t/fake-clock.c -x none %t/main.o -o %t/fake.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple -lc++ -lswift_Concurrency %target-embedded-concurrency-threading-shim -dead_strip
+// RUN: %target-run %t/fake.out | %FileCheck %t/main.swift --check-prefixes=CHECK,FAKE
+
+// (2) With the bundled POSIX clock shim, the same program links without a
+// user-provided clock and reports monotonically advancing time.
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/main.o -o %t/real.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple -lc++ -lswift_Concurrency %target-embedded-concurrency-threading-shim -dead_strip
+// RUN: %target-run %t/real.out | %FileCheck %t/main.swift --check-prefix=CHECK
+
+// (3) A program with a custom global executor does not need the bundled
+// POSIX shim or a working sleep: this executor consults swift_time_now to
+// drive its timer queue, so the provider must answer getTime, but only the
+// default cooperative global executor calls swift_sleep, so the sleep hook
+// may trap as long as it is linkable. The link line deliberately spells out
+// the archives instead of using %target-embedded-link so that the bundled
+// clock shim is not linked; trap-clock.c stands in for a platform's own
+// clock hooks.
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %t/noclock.swift -c -o %t/noclock.o
+// RUN: %target-clang -x c -std=c11 -I %swift_obj_root/include -c %S/Inputs/executor.c -o %t/executor.o
+// RUN: %target-clang %target-clang-resource-dir-opt -x c %t/trap-clock.c -x none %t/noclock.o %t/executor.o -o %t/noclock.out %swift_obj_root/lib/swift/embedded/%module-target-triple/libswiftCore.a %swift_obj_root/lib/swift/embedded/%module-target-triple/libswiftEmbeddedPlatformPOSIX.a %swift_obj_root/lib/swift/embedded/%module-target-triple/libswift_Concurrency.a %target-embedded-concurrency-threading-shim -dead_strip
+// RUN: %target-run %t/noclock.out | %FileCheck %t/noclock.swift --check-prefix=NOCLOCK
+
+// REQUIRES: swift_embedded_platform
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx
+// REQUIRES: swift_feature_Embedded
+
+//--- main.swift
+
+@_silgen_name("swift_get_time")
+func swift_get_time(
+  _ seconds: UnsafeMutablePointer<Int64>,
+  _ nanoseconds: UnsafeMutablePointer<Int64>,
+  _ clock_id: CInt)
+
+@_silgen_name("swift_get_clock_res")
+func swift_get_clock_res(
+  _ seconds: UnsafeMutablePointer<Int64>,
+  _ nanoseconds: UnsafeMutablePointer<Int64>,
+  _ clock_id: CInt)
+
+@_silgen_name("swift_sleep")
+func swift_sleep(_ seconds: Int64, _ nanoseconds: Int64)
+
+func getTime(_ clockID: CInt) -> (Int64, Int64) {
+  var s: Int64 = 0
+  var ns: Int64 = 0
+  swift_get_time(&s, &ns, clockID)
+  return (s, ns)
+}
+
+@main
+struct Main {
+  static func main() {
+    print("begin")
+    // CHECK: begin
+
+    // The fake clock reports the clock ID as the seconds value and a call
+    // counter as the nanoseconds value, so these lines verify that each
+    // clock ID reaches the platform hook unchanged.
+    let (c1s, c1n) = getTime(1) // continuous
+    let (c2s, c2n) = getTime(1)
+    print("t1: \(Int(c1s)) \(Int(c1n))")
+    print("t2: \(Int(c2s)) \(Int(c2n))")
+    // FAKE: t1: 1 1
+    // FAKE: t2: 1 2
+
+    let monotonic = c2s > c1s || (c2s == c1s && c2n >= c1n)
+    print("monotonic: \(monotonic ? "yes" : "no")")
+    // CHECK: monotonic: yes
+
+    let (ss, sn) = getTime(2) // suspending
+    print("suspending: \(Int(ss)) \(Int(sn))")
+    // FAKE: suspending: 2 3
+
+    let (ws, wn) = getTime(3) // wall
+    print("wall: \(Int(ws)) \(Int(wn))")
+    // FAKE: wall: 3 4
+
+    var rs: Int64 = -1
+    var rns: Int64 = -1
+    swift_get_clock_res(&rs, &rns, 1)
+    print("res: \(Int(rs)) \(Int(rns))")
+    // FAKE: res: 0 1
+
+    // The fake sleep prints its arguments; the bundled shim sleeps 5ms.
+    swift_sleep(0, 5_000_000)
+    // FAKE: sleep: 0 5000000
+
+    print("end")
+    // CHECK: end
+  }
+}
+
+//--- noclock.swift
+
+import _Concurrency
+
+@main
+struct Main {
+  static func main() async {
+    print("begin")
+    // NOCLOCK: begin
+    let t = Task { 42 }
+    let v = await t.value
+    print(v == 42 ? "ok" : "bad")
+    // NOCLOCK: ok
+    print("end")
+    // NOCLOCK: end
+  }
+}
+
+//--- fake-clock.c
+
+#include <stdio.h>
+
+static long long ticks = 0;
+
+void _swift_clock_getTime(int clock_id, long long *seconds,
+                          long long *nanoseconds) {
+  ticks += 1;
+  *seconds = clock_id;
+  *nanoseconds = ticks;
+}
+
+void _swift_clock_getResolution(int clock_id, long long *seconds,
+                                long long *nanoseconds) {
+  *seconds = 0;
+  *nanoseconds = clock_id;
+}
+
+void _swift_clock_sleep(long long seconds, long long nanoseconds) {
+  printf("sleep: %lld %lld\n", seconds, nanoseconds);
+}
+
+//--- trap-clock.c
+
+/* A minimal clock provider for a program with a custom global executor. The
+   executor uses swift_time_now, so getTime must answer; swift_sleep is only
+   called by the default cooperative global executor, so the sleep hook may
+   trap. */
+
+static long long ticks = 0;
+
+void _swift_clock_getTime(int clock_id, long long *seconds,
+                          long long *nanoseconds) {
+  (void)clock_id;
+  *seconds = 0;
+  *nanoseconds = ++ticks;
+}
+
+void _swift_clock_getResolution(int clock_id, long long *seconds,
+                                long long *nanoseconds) {
+  (void)clock_id;
+  *seconds = 0;
+  *nanoseconds = 0;
+}
+
+void _swift_clock_sleep(long long seconds, long long nanoseconds) {
+  (void)seconds;
+  (void)nanoseconds;
+  __builtin_trap();
+}

--- a/test/embedded/lit.local.cfg
+++ b/test/embedded/lit.local.cfg
@@ -90,9 +90,21 @@ else:
 # `-L` ordering would otherwise pick the host `libswiftCore.dylib`.
 _embedded_lib_dir = (
   f"{config.swift_obj_root}/lib/swift/embedded/{target_specific_module_triple}")
+# The POSIX clock shim exists only where it is built: the platform
+# abstraction layer must be enabled, and bare-metal triples skip it (the
+# same skip list as the pthread shim).
+_clock_shim_available = (
+  'swift_embedded_platform' in config.available_features and
+  not config.available_features.intersection({'OS=none-eabi', 'OS=none-elf'}))
 _posix_shim_parts = [f"{_embedded_lib_dir}/libswiftCore.a"]
 if 'swift_embedded_platform' in config.available_features:
   _posix_shim_parts.append(f"{_embedded_lib_dir}/libswiftEmbeddedPlatformPOSIX.a")
+# Under the abstraction layer the clock entry points read platform hooks,
+# and the default cooperative global executor keeps the time and sleep hooks
+# referenced in any async program, so the clock shim is bundled alongside
+# the allocator shim.
+if _clock_shim_available:
+  _posix_shim_parts.append(f"{_embedded_lib_dir}/libswiftEmbeddedPlatformClockPOSIX.a")
 config.substitutions.append(("%target-embedded-posix-shim",
                              " ".join(_posix_shim_parts)))
 
@@ -133,7 +145,7 @@ else:
   config.substitutions.append(("%target-embedded-observation", ""))
 
 # (7) `%target-embedded-link` is the convenience wrapper that bundles
-# `%target-clang`, the embedded stdlib, and the POSIX shim — prefer it over
+# `%target-clang`, the embedded stdlib, and the POSIX shims — prefer it over
 # spelling those out by hand. The lower-level substitutions remain available
 # for tests that need finer control over the link line.
 # Emscripten uses its own `%target-embedded-link` set above via `emcc`.
@@ -145,4 +157,6 @@ if 'OS=emscripten' not in config.available_features:
       f"-L {_embedded_lib_dir}/ -lswiftCore")
   if 'swift_embedded_platform' in config.available_features:
     _embedded_link_parts.append("-lswiftEmbeddedPlatformPOSIX")
+  if _clock_shim_available:
+    _embedded_link_parts.append("-lswiftEmbeddedPlatformClockPOSIX")
   config.substitutions.append(("%target-embedded-link", " ".join(_embedded_link_parts)))

--- a/test/embedded/lit.local.cfg
+++ b/test/embedded/lit.local.cfg
@@ -91,8 +91,15 @@ else:
 _embedded_lib_dir = (
   f"{config.swift_obj_root}/lib/swift/embedded/{target_specific_module_triple}")
 _posix_shim_parts = [f"{_embedded_lib_dir}/libswiftCore.a"]
+# The POSIX clock shim provides the platform clock hooks that the Concurrency
+# runtime forwards to under the platform abstraction layer. It only exists for
+# hosted POSIX-ish triples (bare-metal targets provide their own clock hooks),
+# so include it only where it was built.
+_clock_shim_archive = f"{_embedded_lib_dir}/libswiftEmbeddedPlatformClockPOSIX.a"
 if 'swift_embedded_platform' in config.available_features:
   _posix_shim_parts.append(f"{_embedded_lib_dir}/libswiftEmbeddedPlatformPOSIX.a")
+  if os.path.exists(_clock_shim_archive):
+    _posix_shim_parts.append(_clock_shim_archive)
 config.substitutions.append(("%target-embedded-posix-shim",
                              " ".join(_posix_shim_parts)))
 
@@ -142,4 +149,6 @@ if 'OS=emscripten' not in config.available_features:
       f"-L {_embedded_lib_dir}/ -lswiftCore")
   if 'swift_embedded_platform' in config.available_features:
     _embedded_link_parts.append("-lswiftEmbeddedPlatformPOSIX")
+    if os.path.exists(_clock_shim_archive):
+      _embedded_link_parts.append("-lswiftEmbeddedPlatformClockPOSIX")
   config.substitutions.append(("%target-embedded-link", " ".join(_embedded_link_parts)))


### PR DESCRIPTION
### Motivation

#90965 made the Concurrency runtime buildable freestanding, and #91047 connected it to the Embedded Swift platform abstraction layer for threading. As @DougGregor noted in https://github.com/swiftlang/swift/pull/91047#issuecomment-5140201033, clocks are still handled ad hoc: `Clock.cpp` unconditionally includes `<time.h>`/`<errno.h>` and hardcodes per-OS clock mappings, so embedded targets without a POSIX-ish libc cannot use the clock entry points at all.

This PR moves the clocks behind the platform abstraction layer, following the existing `_swift_mutex_*` and `_swift_thread_*` hook families.

### Design

Three hooks are added to `swift/EmbeddedPlatform.h` (platform layer version 1.1 -> 1.2, an additive minor-version update):

```c
void _swift_clock_getTime(swift_clock_id_t clock_id,
                          long long *seconds, long long *nanoseconds);
void _swift_clock_getResolution(swift_clock_id_t clock_id,
                                long long *seconds, long long *nanoseconds);
void _swift_clock_sleep(long long seconds, long long nanoseconds);
```

- `swift_clock_id_t` is declared in the platform header (which cannot include Concurrency headers); `static_assert`s in `Clock.cpp` pin its values to the runtime's `swift_clock_id`.
- The entry points (`swift_get_time`, `swift_get_clock_res`, `swift_sleep`) always call these hooks. Like `_swift_exit` in `ExecutorBridge.cpp`, `Clock.cpp` provides the existing per-OS implementations as defaults for non-PAL builds, preserving existing behavior.
- Under the abstraction layer, the entry points validate the clock ID before crossing the platform boundary, so a platform implementation only has to handle the declared IDs. The platform provider remains the only place that maps a Swift clock ID to a native clock.
- `_swift_clock_sleep` is only called by the default cooperative global executor; a platform that installs a custom global executor may implement it as a no-op or a trap, but it must be linkable whenever the clock entry points are in use.

### Bundled POSIX shim

Like the pthread shim, hosted POSIX-ish triples get a bundled provider, `libswiftEmbeddedPlatformClockPOSIX.a`, which reproduces the `Clock.cpp` mappings exactly — including the Linux asymmetry where the suspending clock's `clock_getres` queries `CLOCK_MONOTONIC_RAW` while `clock_gettime` uses `CLOCK_MONOTONIC` — so enabling the abstraction layer does not change observable clock behavior on these targets. Bare-metal and Windows triples skip the shim; their platform integrations must provide the hooks. `test/embedded/lit.local.cfg` folds the shim into the standard embedded link lines when the archive is available.

### Testing

The new `test/embedded/concurrency-clock-pal.swift` verifies, on a stdlib built with the abstraction layer:

- with a fake platform clock, the runtime reports exactly the values the hooks return, passing each clock ID and the sleep duration through unchanged;
- with the bundled shim, the same program links without a user-provided clock and reports monotonically advancing time;
- a program with a custom global executor runs with a minimal user-provided clock in place of the bundled shim, where the sleep hook is a trap — verifying that only the default cooperative global executor calls `swift_sleep`.

CC @DougGregor 