### PR TITLE
MemoryLifetimeVerifier: fix a false alarm for nested untracked struct fields

### DIFF
--- a/include/swift/SIL/MemoryLocations.h
+++ b/include/swift/SIL/MemoryLocations.h
@@ -228,6 +228,16 @@ public:
   /// Returns the root location of \p index.
   const Location *getRootLocation(unsigned index) const;
 
+  /// Returns true if the location with a given \p index has any tracked
+  /// sub-locations.
+  bool hasSubLocations(unsigned index) const {
+    const Location &loc = locations[index];
+    // Either the location has sub-locations in addition to its "self" bit, or
+    // it's completely covered by its sub-locations, in which case the "self"
+    // bit is not set.
+    return loc.subLocations.count() > 1 || !loc.subLocations.test(index);
+  }
+
   /// Registers an address projection instruction for a location.
   void registerProjection(SILValue projection, unsigned locIdx) {
     addr2LocIdx[projection] = locIdx;

--- a/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
+++ b/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
@@ -298,11 +298,18 @@ void MemoryLifetimeVerifier::requireBitsSetForArgument(const Bits &bits, Operand
        errorLocIdx = missingBits.find_next(errorLocIdx)) {
     auto *errorLoc = locations.getLocation(errorLocIdx);
 
-    // We only have a valid address if this is not the "self" bit which represents
-    // unknown sub-fields.
+    // We only have a valid address if this is not the "self" bit of a
+    // partially covered location. In that case the "self" bit represents the
+    // untracked fields, but the representative value is the address of the
+    // whole location - which is too imprecise to check if the callee reads
+    // from the untracked fields.
     SILValue addr;
-    if (errorLocIdx != locIdx || !errorLoc->selfBitRepresentsUnknownSubFields())
+    if (!errorLoc->selfBitRepresentsUnknownSubFields() ||
+        // If the location has no sub-locations at all, its "self" bit represents
+        // the whole location and the representative value is its exact address.
+        !locations.hasSubLocations(errorLocIdx)) {
       addr = errorLoc->representativeValue;
+    }
 
     if (applyMayRead(argOp, addr)) {
       reportError("argument memory is not initialized, but should be",

--- a/test/SIL/memory_lifetime.sil
+++ b/test/SIL/memory_lifetime.sil
@@ -39,6 +39,10 @@ struct IntPair {
   var b: Int
 }
 
+struct NestedIntPair {
+  var p: IntPair
+}
+
 struct MyError : Error {
   var x: AnyObject
 }
@@ -923,6 +927,39 @@ bb0(%0 : $Int):
   dealloc_stack %1
   %7 = tuple ()
   return %7
+}
+
+sil [ossa] @read_p_a : $@convention(thin) (@inout NestedIntPair) -> () {
+[%0: read s0.s0.v**]
+}
+
+// The uninitialized `p.b` is not tracked as a location, but represented by the
+// "self" bit of the `p` sub-location.
+sil [ossa] @callee_reads_unknown_nested_subfield : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %1 = alloc_stack $NestedIntPair
+  %2 = struct_element_addr %1, #NestedIntPair.p
+  %3 = struct_element_addr %2, #IntPair.a
+  store %0 to [trivial] %3
+  %5 = function_ref @read_p_a : $@convention(thin) (@inout NestedIntPair) -> ()
+  %6 = apply %5(%1) : $@convention(thin) (@inout NestedIntPair) -> ()
+  dealloc_stack %1
+  %8 = tuple ()
+  return %8
+}
+
+sil [ossa] @callee_reads_known_nested_subfield : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %1 = alloc_stack $NestedIntPair
+  %2 = struct_element_addr %1, #NestedIntPair.p
+  %3 = struct_element_addr %2, #IntPair.a
+  %4 = struct_element_addr %2, #IntPair.b
+  store %0 to [trivial] %3
+  %6 = function_ref @read_p_a : $@convention(thin) (@inout NestedIntPair) -> ()
+  %7 = apply %6(%1) : $@convention(thin) (@inout NestedIntPair) -> ()
+  dealloc_stack %1
+  %9 = tuple ()
+  return %9
 }
 
 sil @dont_read_from_inout : $@convention(thin) (@inout Bool) -> ()

--- a/test/SIL/memory_lifetime_failures.sil
+++ b/test/SIL/memory_lifetime_failures.sil
@@ -28,6 +28,11 @@ struct Mixed {
   var i: Int
 }
 
+struct IntPair {
+  var a: Int
+  var b: Int
+}
+
 enum E {
   case a(T)
   case b(T)
@@ -976,3 +981,19 @@ bb0(%0 : $*GenWrapper<T>):
   return %4
 }
 
+sil [ossa] @read_int_pair_a : $@convention(thin) (@inout IntPair) -> () {
+[%0: read s0.v**]
+}
+
+// CHECK: SIL memory lifetime failure in @callee_reads_completely_uninitialized: argument memory is not initialized, but should be
+// CHECK: memory location:   %0 = alloc_stack $IntPair
+// CHECK: at instruction:   %2 = apply %1(%0) : $@convention(thin) (@inout IntPair) -> ()
+sil [ossa] @callee_reads_completely_uninitialized : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $IntPair
+  %1 = function_ref @read_int_pair_a : $@convention(thin) (@inout IntPair) -> ()
+  %2 = apply %1(%0) : $@convention(thin) (@inout IntPair) -> ()
+  dealloc_stack %0
+  %4 = tuple ()
+  return %4
+}


### PR DESCRIPTION
If a struct field is not referenced in a function, it's represented by the "self" bit of its parent location. In that case the location's representative value is the address of the whole parent field, which is too imprecise to check whether a callee reads from the untracked field.

The existing workaround only handled the case where the parent is the argument location itself. Generalize it to sub-locations, but keep checking locations without any sub-locations, where the representative value is exact.

This bug was uncovered by https://github.com/swiftlang/swift/pull/91097
