### PR TITLE
[cxx-interop] Disable protected special member test again

### DIFF
--- a/test/Interop/Cxx/class/inheritance/protected-special-member-executable.swift
+++ b/test/Interop/Cxx/class/inheritance/protected-special-member-executable.swift
@@ -2,10 +2,10 @@
 //
 // REQUIRES: executable_test
 //
+// REQUIRES: rdar168302720
 // Fails on Windows：  https://github.com/swiftlang/swift/issues/67288
 // Fails on non-macOS: https://github.com/swiftlang/swift/issues/86426
-// See also rdar://168302720
-// REQUIRES: OS=macosx
+// Apparently, also fails on some macOS CI bots. 
 
 import StdlibUnittest
 import ProtectedSpecialMember


### PR DESCRIPTION
This partially reverts #91123. Interestingly, while this test passes locally, it crashes on some of the CI builders. I updated the comments to reflect this.

rdar://183794484

