### PR TITLE
[AST][Parse] Avoid a second parse for files without `@diagnose`

### DIFF
--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -256,6 +256,10 @@ private:
   /// Stores all the \c #if source range info in this file.
   mutable IfConfigClauseRangesData IfConfigClauseRanges;
 
+  /// Set when the parser has encountered a `@daiagnose` attribute
+  /// anywhere in this file.
+  bool HasWarningControlAttr = false;
+
   friend class HasImportsMatchingFlagRequest;
 
   /// Indicates which import options have valid caches. Storage for
@@ -317,6 +321,14 @@ public:
   /// Retrieve the \c ExportedSourceFile instance produced by ASTGen, which
   /// includes the SourceFileSyntax node corresponding to this source file.
   void *getExportedSourceFile() const;
+
+  /// Whether the parser saw a `@diagnose` attr in this file.
+  ///
+  /// Used to skip generation of a SwiftWarningControl region tree
+  /// when the source file is known not to contain any such syntactic
+  /// controls at all.
+  bool hasWarningControlAttr() const { return HasWarningControlAttr; }
+  void setHasWarningControlAttr() { HasWarningControlAttr = true; }
 
   /// Defer type checking of `AFD` to the end of `Sema`
   void addDelayedFunction(AbstractFunctionDecl *AFD);

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -108,6 +108,26 @@ struct StoredDiagnosticInfo {
                              opts == DiagnosticOptions::NoUsage,
                              groupID) {}
 };
+
+/// Whether a SourceFile could carry a syntactic warning control, and needs
+/// the accurate answer from the SwiftWarningControl region tree rather than the
+/// command-line rules alone.
+static bool fileMayHaveWarningControls(const SourceFile *sf) {
+  // If the swift-syntax tree for this file already exists, consulting it costs
+  // nothing extra, so always take the accurate path.
+  if (sf->getASTContext().evaluator.hasCachedResult(
+          ExportedSourceFileRequest{sf}))
+    return true;
+
+  return sf->hasWarningControlAttr();
+}
+
+/// Whether a given SourceFile qualifies for checking for a syntactic
+/// diagnostic group control
+static bool shouldCheckSyntacticWarningControlInFile(const SourceFile *sf) {
+  return sf && sf->Kind != SourceFileKind::Interface &&
+         fileMayHaveWarningControls(sf) && sf->getExportedSourceFile();
+}
 } // end anonymous namespace
 
 // TODO: categorization
@@ -602,8 +622,10 @@ bool DiagnosticEngine::finishProcessing() {
 
 bool DiagnosticEngine::isDiagnosticGroupEnabled(SourceFile *sf, DiagGroupID groupID) const {
 #if SWIFT_BUILD_SWIFT_SYNTAX
-  if (sf && sf->Kind != SourceFileKind::Interface &&
-      sf->getExportedSourceFile()) {
+  // Consult the syntactic warning control regions only when the file
+  // is known to contain any syntactic controls, to avoid a possible
+  // unnecessary ASTGen re-parse otherwise.
+  if (shouldCheckSyntacticWarningControlInFile(sf)) {
     auto ruleRefArray = getWarningGroupBehaviorControlRefArray();
     return swift_ASTGen_isWarningGroupEnabledInFile(
         sf->getExportedSourceFile(), sf->getASTContext(),
@@ -1367,8 +1389,7 @@ DiagnosticState::determineUserControlledWarningBehavior(
     if (!sourceFiles.empty()) {
       SourceFile *SF = sourceFiles.front();
       // Don't run syntactic @diagnose controls for .swiftinterface files.
-      if (SF && SF->Kind != SourceFileKind::Interface &&
-          SF->getExportedSourceFile()) {
+      if (shouldCheckSyntacticWarningControlInFile(SF)) {
         auto ruleRefArray = getWarningGroupBehaviorControlRefArray();
         WarningGroupBehavior behavior =
             swift_ASTGen_warningGroupBehaviorAtPosition(

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3297,6 +3297,9 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
   }
 
   case DeclAttrKind::Diagnose: {
+    // Record that this file carries a syntactic warning control.
+    SF.setHasWarningControlAttr();
+
     if (!consumeIfAttributeLParen()) {
       diagnose(Loc, diag::attr_expected_lparen, AttrName,
                DeclAttribute::isDeclModifier(DK));

--- a/test/attr/diagnose_lazy_parse.swift
+++ b/test/attr/diagnose_lazy_parse.swift
@@ -1,0 +1,53 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5
+//
+// `DiagnosticEngine::isDiagnosticGroupEnabled` skips the SwiftWarningControl
+// region tree, and the corresponding SwiftParser parse, unless the parser
+// recorded a `@diagnose` in this file. Members and function bodies are parsed
+// lazily, so check that a `@diagnose` in one of those still takes effect even
+// though an earlier declaration in the file is checked first.
+
+@available(*, deprecated)
+func dep() -> Bool { return false }
+
+// Checked before anything below has been parsed, and must stay unaffected by
+// the `@diagnose` attributes that appear later in the file.
+func earlyUnaffected() -> Bool {
+  return dep() // expected-warning {{'dep()' is deprecated}}
+}
+
+// `@diagnose` on a member of a type: the member list is parsed lazily.
+struct Outer {
+  @diagnose(DeprecatedDeclaration, as: error)
+  func lateMember() -> Bool {
+    return dep() // expected-error {{'dep()' is deprecated}}
+  }
+
+  @diagnose(DeprecatedDeclaration, as: ignored)
+  func lateMemberIgnored() -> Bool {
+    return dep()
+  }
+}
+
+// `@diagnose` on a local declaration inside a function body: bodies are parsed
+// lazily.
+func host() {
+  @diagnose(DeprecatedDeclaration, as: error)
+  func lateLocal() -> Bool {
+    return dep() // expected-error {{'dep()' is deprecated}}
+  }
+  _ = lateLocal()
+}
+
+// A nested type inside a lazily parsed member list.
+enum DeepOuter {
+  struct Inner {
+    @diagnose(DeprecatedDeclaration, as: error)
+    var deep: Bool { dep() } // expected-error {{'dep()' is deprecated}}
+  }
+}
+
+// Trivia is permitted between `@` and the attribute name
+@ diagnose(DeprecatedDeclaration, as: error) // expected-warning {{extraneous whitespace between '@' and attribute name}}
+func spacedAttribute() -> Bool {
+  return dep() // expected-error {{'dep()' is deprecated}}
+}


### PR DESCRIPTION
Promoting SourceWarningControl to a default language feature made DiagnosticEngine::isDiagnosticGroupEnabled consult the SwiftWarningControl region tree unconditionally. Reaching that tree forces ExportedSourceFileRequest, which parses the file a second time with SwiftParser, and then walks every syntax node to build a region tree that is empty for any file containing no `@diagnose`.

The parser now records whether it saw a `@diagnose` attribute. When it did not, the command-line rules alone determine the answer.

A file whose swift-syntax tree already exists, from macro expansion, coverage instrumentation or ASTGen-only parsing, always takes the accurate path, because consulting the tree costs nothing extra once it has been built.

Resolves rdar://181595958