### PR TITLE
[Embedded concurrency] Don't enable vouchers for embedded concurrency

### DIFF
--- a/include/swift/Runtime/VoucherShims.h
+++ b/include/swift/Runtime/VoucherShims.h
@@ -22,7 +22,7 @@
 // swift-corelibs-libdispatch has os/voucher_private.h but it doesn't work for
 // us yet, so only look for it on Apple platforms.  We also don't need vouchers
 // in the single threaded concurrency runtime.
-#if __APPLE__ && !SWIFT_THREADING_NONE && __has_include(<os/voucher_private.h>)
+#if __APPLE__ && !SWIFT_THREADING_NONE && !SWIFT_THREADING_EMBEDDED && __has_include(<os/voucher_private.h>)
 #define SWIFT_HAS_VOUCHER_HEADER 1
 #include <os/voucher_private.h>
 #endif
@@ -34,7 +34,7 @@
 #define SWIFT_DEAD_VOUCHER ((voucher_t)-1)
 
 // The OS has voucher support if it has the header or if it has ObjC interop.
-#if (SWIFT_HAS_VOUCHER_HEADER || SWIFT_OBJC_INTEROP) && !SWIFT_THREADING_NONE
+#if (SWIFT_HAS_VOUCHER_HEADER || SWIFT_OBJC_INTEROP) && !SWIFT_THREADING_NONE && !SWIFT_THREADING_EMBEDDED
 #define SWIFT_HAS_VOUCHERS 1
 #endif
 


### PR DESCRIPTION
The switch to the "embedded" threading model accidentally enabled vouchers for the embedded concurrency library on Apple platforms. This would create an additional platform dependency that we do not want. Extend the #if checks that excluded SWIFT_THREADING_NONE already to account for "embedded".

Fixes rdar://183833808.
