### PR TITLE
vim: enhance opaque, existential types and touch up concurrency

### DIFF
--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -98,6 +98,7 @@ syn keyword swiftScope
 
 syn keyword swiftFuncAttribute skipwhite skipempty nextgroup=swiftFuncDefinition
       \ borrowing
+      \ consuming
       \ mutating
 syn keyword swiftFuncDefinition skipwhite skipempty nextgroup=swiftTypeName,swiftOperator
       \ func

--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -44,6 +44,12 @@ syn keyword swiftCoreTypes
       \ Any
       \ AnyObject
 
+syn keyword swiftExistentialType contained skipwhite skipempty nextgroup=swiftType
+      \ any
+
+syn keyword swiftOpaqueType contained skipwhite skipempty nextgroup=swiftType
+      \ some
+
 syn keyword swiftImport skipwhite skipempty nextgroup=swiftImportModule
       \ import
 
@@ -69,7 +75,9 @@ syn keyword swiftDefinitionModifier
       \ throws
       \ weak
 
-syn keyword swiftInOutKeyword skipwhite skipempty nextgroup=swiftTypeName
+syn keyword swiftTypeSpecifier contained skipwhite skipempty nextgroup=swiftTypeSpecifier,swiftExistentialType,swiftOpaqueType,swiftTypeName
+      \ borrowing
+      \ consuming
       \ inout
 
 syn keyword swiftIdentifierKeyword
@@ -145,27 +153,27 @@ syn match swiftImplicitVarName
 syn match swiftType contained skipwhite skipempty nextgroup=swiftTypeParameters
       \ /\<[A-Za-z_][A-Za-z_0-9\.]*\>[!?]\?/
 " [Type:Type] (dictionary) or [Type] (array)
-syn region swiftType contained contains=swiftTypePair,swiftType
+syn region swiftType contained contains=swiftTypePair,swiftType,swiftOpaqueType,swiftExistentialType
       \ matchgroup=Delimiter start=/\[/ end=/\]/
 syn match swiftTypePair contained skipwhite skipempty nextgroup=swiftTypeParameters,swiftTypeDeclaration
       \ /\<[A-Za-z_][A-Za-z_0-9\.]*\>[!?]\?/
 " (Type[, Type]) (tuple)
 " FIXME: we should be able to use skip="," and drop swiftParamDelim
-syn region swiftType contained contains=swiftType,swiftParamDelim
+syn region swiftType contained contains=swiftType,swiftParamDelim,swiftTypeSpecifier,swiftExistentialType,swiftOpaqueType
       \ matchgroup=Delimiter start="[^@]\?(" end=")" matchgroup=NONE skip=","
 syn match swiftParamDelim contained
       \ /,/
 " <Generic Clause> (generics)
-syn region swiftTypeParameters contained contains=swiftVarName,swiftConstraint
+syn region swiftTypeParameters contained contains=swiftVarName,swiftConstraint,swiftOpaqueType,swiftExistentialType
       \ matchgroup=Delimiter start="<" end=">" matchgroup=NONE skip=","
 syn keyword swiftConstraint contained
       \ where
 
-syn match swiftTypeAliasValue skipwhite skipempty nextgroup=swiftType
+syn match swiftTypeAliasValue skipwhite skipempty nextgroup=swiftExistentialType,swiftType
       \ /=/
-syn match swiftTypeDeclaration skipwhite skipempty nextgroup=swiftType,swiftInOutKeyword
+syn match swiftTypeDeclaration skipwhite skipempty nextgroup=swiftTypeSpecifier,swiftExistentialType,swiftOpaqueType,swiftOpaqueType,swiftType
       \ /:/
-syn match swiftTypeDeclaration skipwhite skipempty nextgroup=swiftType
+syn match swiftTypeDeclaration skipwhite skipempty nextgroup=swiftExistentialType,swiftOpaqueType,swiftType
       \ /->/
 
 syn match swiftKeyword
@@ -224,9 +232,9 @@ syn match swiftAttribute
 
 syn keyword swiftTodo MARK TODO FIXME contained
 
-syn match swiftCastOp skipwhite skipempty nextgroup=swiftType,swiftCoreTypes
+syn match swiftCastOp skipwhite skipempty nextgroup=swiftExistentialType,swiftType,swiftCoreTypes
       \ "\<is\>"
-syn match swiftCastOp skipwhite skipempty nextgroup=swiftType,swiftCoreTypes
+syn match swiftCastOp skipwhite skipempty nextgroup=swiftExistentialType,swiftType,swiftCoreTypes
       \ "\<as\>[!?]\?"
 
 syn match swiftNilOps
@@ -250,7 +258,7 @@ hi def link swiftTypeName Function
 hi def link swiftConstraint Special
 hi def link swiftFuncDefinition Define
 hi def link swiftDefinitionModifier Operator
-hi def link swiftInOutKeyword Define
+hi def link swiftExistentialType Type
 hi def link swiftFuncAttribute Statement
 hi def link swiftFuncKeyword Function
 hi def link swiftFuncKeywordGeneral Function
@@ -262,6 +270,7 @@ hi def link swiftIdentifierKeyword Identifier
 hi def link swiftTypeAliasValue Delimiter
 hi def link swiftTypeDeclaration Delimiter
 hi def link swiftTypeParameters Delimiter
+hi def link swiftTypeSpecifier Define
 hi def link swiftBoolean Boolean
 hi def link swiftString String
 hi def link swiftInterpolation Special
@@ -272,6 +281,7 @@ hi def link swiftHex Number
 hi def link swiftOct Number
 hi def link swiftBin Number
 hi def link swiftOperator Function
+hi def link swiftOpaqueType Type
 hi def link swiftChar Character
 hi def link swiftLabel Operator
 hi def link swiftPreproc PreCondit

--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -79,6 +79,10 @@ syn keyword swiftTypeSpecifier contained skipwhite skipempty nextgroup=swiftType
       \ borrowing
       \ consuming
       \ inout
+      \ isolated
+
+syn keyword swiftConcurrencySpecifier contained skipwhite skipempty nextgroup=swiftTypeSpecifier,swiftOpaqueType,swiftExistentialType,swiftType
+      \ sending
 
 syn keyword swiftIdentifierKeyword
       \ Self
@@ -160,7 +164,7 @@ syn match swiftTypePair contained skipwhite skipempty nextgroup=swiftTypeParamet
       \ /\<[A-Za-z_][A-Za-z_0-9\.]*\>[!?]\?/
 " (Type[, Type]) (tuple)
 " FIXME: we should be able to use skip="," and drop swiftParamDelim
-syn region swiftType contained contains=swiftType,swiftParamDelim,swiftTypeSpecifier,swiftExistentialType,swiftOpaqueType
+syn region swiftType contained contains=swiftType,swiftParamDelim,swiftTypeSpecifier,swiftConcurrencySpecifier,swiftExistentialType,swiftOpaqueType
       \ matchgroup=Delimiter start="[^@]\?(" end=")" matchgroup=NONE skip=","
 syn match swiftParamDelim contained
       \ /,/
@@ -172,9 +176,9 @@ syn keyword swiftConstraint contained
 
 syn match swiftTypeAliasValue skipwhite skipempty nextgroup=swiftExistentialType,swiftType
       \ /=/
-syn match swiftTypeDeclaration skipwhite skipempty nextgroup=swiftTypeSpecifier,swiftExistentialType,swiftOpaqueType,swiftOpaqueType,swiftType
+syn match swiftTypeDeclaration skipwhite skipempty nextgroup=swiftConcurrencySpecifier,swiftTypeSpecifier,swiftExistentialType,swiftOpaqueType,swiftOpaqueType,swiftType
       \ /:/
-syn match swiftTypeDeclaration skipwhite skipempty nextgroup=swiftExistentialType,swiftOpaqueType,swiftType
+syn match swiftTypeDeclaration skipwhite skipempty nextgroup=swiftConcurrencySpecifier,swiftExistentialType,swiftOpaqueType,swiftType
       \ /->/
 
 syn match swiftKeyword
@@ -272,6 +276,7 @@ hi def link swiftTypeAliasValue Delimiter
 hi def link swiftTypeDeclaration Delimiter
 hi def link swiftTypeParameters Delimiter
 hi def link swiftTypeSpecifier Define
+hi def link swiftConcurrencySpecifier Define
 hi def link swiftBoolean Boolean
 hi def link swiftString String
 hi def link swiftInterpolation Special


### PR DESCRIPTION
This pull request enhances Swift syntax highlighting in the `swift.vim` Vim syntax file by adding support for new Swift type specifiers, concurrency specifiers, and better handling of existential and opaque types. It also updates highlighting groups to reflect these additions.

**Syntax support improvements:**

* Added new syntax groups for Swift existential (`any`) and opaque (`some`) types, ensuring these keywords are correctly parsed and highlighted as types. [[1]](diffhunk://#diff-00d745ba43737aa26576b1f8e67b3370a8717074454d27158c36ddcfa20a0e09R47-R52) [[2]](diffhunk://#diff-00d745ba43737aa26576b1f8e67b3370a8717074454d27158c36ddcfa20a0e09L148-R181)
* Introduced new syntax groups for Swift type specifiers (`borrowing`, `consuming`, `inout`, `isolated`) and concurrency specifiers (`sending`), and updated parsing rules to recognize them in type declarations. [[1]](diffhunk://#diff-00d745ba43737aa26576b1f8e67b3370a8717074454d27158c36ddcfa20a0e09L72-R85) [[2]](diffhunk://#diff-00d745ba43737aa26576b1f8e67b3370a8717074454d27158c36ddcfa20a0e09L148-R181)

**Highlighting updates:**

* Updated highlighting groups to link the new syntax groups (`swiftExistentialType`, `swiftOpaqueType`, `swiftTypeSpecifier`, `swiftConcurrencySpecifier`) to appropriate highlight styles, improving visual clarity for these Swift features. [[1]](diffhunk://#diff-00d745ba43737aa26576b1f8e67b3370a8717074454d27158c36ddcfa20a0e09L253-R266) [[2]](diffhunk://#diff-00d745ba43737aa26576b1f8e67b3370a8717074454d27158c36ddcfa20a0e09R278-R279) [[3]](diffhunk://#diff-00d745ba43737aa26576b1f8e67b3370a8717074454d27158c36ddcfa20a0e09R290)

**Parsing improvements:**

* Enhanced parsing logic for type regions, type parameters, and type alias values to include the new existential and opaque type groups, ensuring nested and complex type expressions are correctly handled.
* Updated cast operator parsing to recognize existential types in `is` and `as` expressions.