### PR TITLE
[Embedded] Enable building the Observation library in Embedded Swift

### DIFF
--- a/include/swift/Threading/Impl/ThreadEmbeddedImpl.h
+++ b/include/swift/Threading/Impl/ThreadEmbeddedImpl.h
@@ -36,6 +36,14 @@ static_assert(SWIFT_TLS_KEY_COUNT ==
                   static_cast<int>(swift::tls_key::exclusivity) + 1,
               "EmbeddedPlatform TLS key count must match TLSKeys.h");
 
+// The Embedded Swift build of the Observation library cannot include this
+// header (it is pure Swift and does not link the C++ Threading library), so
+// stdlib/public/Observation/Sources/Observation/ThreadLocal.swift hardcodes the
+// reserved key index it passes to _swift_tls_get/_swift_tls_set. Keep the two
+// in sync.
+static_assert(static_cast<int>(swift::tls_key::observation_transaction) == 6,
+              "Observation's embedded ThreadLocal.swift hardcodes TLS key 6");
+
 namespace swift {
 
 SWIFT_RUNTIME_EXPORT

--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -73,7 +73,7 @@ public struct ObservableMacro {
     let memberGeneric = context.makeUniqueName("Member")
     return
       """
-       private nonisolated func shouldNotifyObservers<\(memberGeneric)>(_ lhs: \(memberGeneric), _ rhs: \(memberGeneric)) -> Bool { true }
+       private nonisolated final func shouldNotifyObservers<\(memberGeneric)>(_ lhs: \(memberGeneric), _ rhs: \(memberGeneric)) -> Bool { true }
       """
   }
   
@@ -81,7 +81,7 @@ public struct ObservableMacro {
     let memberGeneric = context.makeUniqueName("Member")
     return
       """
-      private nonisolated func shouldNotifyObservers<\(memberGeneric): Equatable>(_ lhs: \(memberGeneric), _ rhs: \(memberGeneric)) -> Bool { lhs != rhs }
+      private nonisolated final func shouldNotifyObservers<\(memberGeneric): Equatable>(_ lhs: \(memberGeneric), _ rhs: \(memberGeneric)) -> Bool { lhs != rhs }
       """
   }
   
@@ -89,7 +89,7 @@ public struct ObservableMacro {
     let memberGeneric = context.makeUniqueName("Member")
     return
       """
-       private nonisolated func shouldNotifyObservers<\(memberGeneric): AnyObject>(_ lhs: \(memberGeneric), _ rhs: \(memberGeneric)) -> Bool { lhs !== rhs }
+       private nonisolated final func shouldNotifyObservers<\(memberGeneric): AnyObject>(_ lhs: \(memberGeneric), _ rhs: \(memberGeneric)) -> Bool { lhs !== rhs }
       """
   }
 
@@ -97,7 +97,7 @@ public struct ObservableMacro {
     let memberGeneric = context.makeUniqueName("Member")
     return
       """
-      private nonisolated func shouldNotifyObservers<\(memberGeneric): Equatable & AnyObject>(_ lhs: \(memberGeneric), _ rhs: \(memberGeneric)) -> Bool { lhs != rhs }
+      private nonisolated final func shouldNotifyObservers<\(memberGeneric): Equatable & AnyObject>(_ lhs: \(memberGeneric), _ rhs: \(memberGeneric)) -> Bool { lhs != rhs }
       """
   }
 

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -377,6 +377,12 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
     # the triple list visible to add_embedded_swift_target_library.
     set(EMBEDDED_STDLIB_TARGET_TRIPLES "${entry}")
 
+    # Record that embedded Concurrency is available for this triple, so that
+    # libraries built on top of it (e.g. Observation) can build for exactly the
+    # same set of triples instead of duplicating the filtering above.
+    set_property(GLOBAL APPEND PROPERTY
+      SWIFT_EMBEDDED_CONCURRENCY_TARGET_TRIPLES "${entry}")
+
     # lib/swift/embedded/_Concurrency.swiftmodule
     # lib/swift/embedded/<triple>/libswift_Concurrency.a
     add_embedded_swift_target_library(

--- a/stdlib/public/Observation/Sources/Observation/CMakeLists.txt
+++ b/stdlib/public/Observation/Sources/Observation/CMakeLists.txt
@@ -46,3 +46,78 @@ add_swift_target_library(swiftObservation ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS
 
   MACCATALYST_BUILD_FLAVOR "zippered"
 )
+
+# Embedded Observation. Observation imports _Concurrency, so it can only be
+# built for the triples that embedded Concurrency was actually built for;
+# stdlib/public/Concurrency/CMakeLists.txt publishes that list in a global
+# property as it walks the triples.
+get_property(_embedded_observation_triples GLOBAL PROPERTY
+  SWIFT_EMBEDDED_CONCURRENCY_TARGET_TRIPLES)
+
+if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB
+   AND TARGET embedded-concurrency
+   AND _embedded_observation_triples)
+  add_custom_target(embedded-observation)
+  add_dependencies(embedded-libraries embedded-observation)
+  # The .swiftmodule for embedded _Concurrency has to exist before we can
+  # import it.
+  add_dependencies(embedded-observation embedded-concurrency)
+
+  # `Locking.swift` reads EMBEDDED_SWIFT_MUTEX_NUM_WORDS from the
+  # EmbeddedPlatform bridging header. `LiteralExpressions` is what lets the
+  # importer bring that macro across as a usable constant; without it the macro
+  # is invisible to Swift. See Synchronization's embedded build for the
+  # -pch-output-dir and -plugin-path rationale.
+  set(_embedded_observation_swift_flags
+    ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
+    "-enable-experimental-feature" "Macros"
+    "-enable-experimental-feature" "ExtensionMacros"
+    "-enable-experimental-feature" "Extern"
+    "-enable-experimental-feature" "ValueGenerics"
+    "-enable-experimental-feature" "LiteralExpressions"
+    -Xfrontend -disable-implicit-string-processing-module-import
+    "-plugin-path" "${SWIFT_HOST_PLUGINS_DIR}"
+    -internal-import-bridging-header
+      ${CMAKE_CURRENT_SOURCE_DIR}/../../../EmbeddedPlatform/swift/EmbeddedPlatform.h
+    -pch-output-dir ${CMAKE_CURRENT_BINARY_DIR}/EmbeddedObservationPCH)
+
+  set(_embedded_observation_all_triples "${EMBEDDED_STDLIB_TARGET_TRIPLES}")
+
+  foreach(entry ${_embedded_observation_triples})
+    string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
+    list(GET list 1 mod)
+
+    # Restrict the call below to the current triple by temporarily narrowing the
+    # triple list visible to add_embedded_swift_target_library.
+    set(EMBEDDED_STDLIB_TARGET_TRIPLES "${entry}")
+
+    # lib/swift/embedded/Observation.swiftmodule
+    # lib/swift/embedded/<triple>/libswiftObservation.a
+    #
+    # The per-triple dependency on embedded Concurrency is what makes the
+    # _Concurrency .swiftmodule for *this* triple exist before we try to import
+    # it; a dependency on the aggregate embedded-concurrency target is not
+    # enough, because these per-triple library targets do not inherit it.
+    add_embedded_swift_target_library(
+      embedded-observation
+      swiftObservation
+      IS_STDLIB
+      INSTALL_BINARY
+
+      ContinuousObservation.swift
+      Locking.swift
+      Observable.swift
+      ObservationRegistrar.swift
+      ObservationTracking.swift
+      Observations.swift
+      ThreadLocal.swift
+
+      SWIFT_COMPILE_FLAGS ${_embedded_observation_swift_flags}
+      DEPENDS embedded-concurrency-${mod}
+      INSTALL_IN_COMPONENT stdlib
+    )
+  endforeach()
+
+  # Restore the full triple list for any later consumers.
+  set(EMBEDDED_STDLIB_TARGET_TRIPLES "${_embedded_observation_all_triples}")
+endif()

--- a/stdlib/public/Observation/Sources/Observation/ContinuousObservation.swift
+++ b/stdlib/public/Observation/Sources/Observation/ContinuousObservation.swift
@@ -183,9 +183,13 @@ extension ContinuousObservation.State {
             return
           }
           withObservationTracking(options: options) {
-            // This is safe since we have already been isolated to the tracking isolation.
-            // It can be asserted to be isolated by
+            // This is safe since we have already been isolated to the tracking
+            // isolation, which `assertIsolated` checks below. That assertion is
+            // only a debug aid and is unavailable in Embedded Swift, so it is
+            // skipped there.
+            #if !$Embedded
             apply.isolation?.assertIsolated()
+            #endif
             let fn = apply as @Sendable (borrowing ObservationTracking.Event) -> Void
             // This ends up also being how the `didSet` is called because this will occur
             // on the next iteration of the while loop from `trackingLoop` after the

--- a/stdlib/public/Observation/Sources/Observation/Locking.swift
+++ b/stdlib/public/Observation/Sources/Observation/Locking.swift
@@ -15,7 +15,26 @@
 // symbols that are not provided by this library - so instead it has to re-implement
 // all of this on its own... 
 
-#if canImport(Darwin.os.lock)
+// In Embedded Swift there is no platform libc overlay to import, so the lock is
+// built on the Embedded Swift platform abstraction layer's mutex hooks. This
+// mirrors what Synchronization's Mutex does in
+// stdlib/public/Synchronization/Mutex/EmbeddedImpl.swift.
+#if $Embedded
+@_extern(c, "_swift_mutex_init")
+internal func _swift_mutex_init(
+  _ mutex: UnsafeMutableRawPointer,
+  _ flags: CUnsignedLongLong
+)
+
+@_extern(c, "_swift_mutex_destroy")
+internal func _swift_mutex_destroy(_ mutex: UnsafeMutableRawPointer)
+
+@_extern(c, "_swift_mutex_lock")
+internal func _swift_mutex_lock(_ mutex: UnsafeMutableRawPointer)
+
+@_extern(c, "_swift_mutex_unlock")
+internal func _swift_mutex_unlock(_ mutex: UnsafeMutableRawPointer)
+#elseif canImport(Darwin.os.lock)
 import Darwin.os.lock
 #elseif canImport(Glibc)
 import Glibc
@@ -31,7 +50,11 @@ import Android
 #endif
 
 internal struct Lock {
-  #if canImport(Darwin.os.lock)
+  #if $Embedded
+  // Opaque inline storage for the platform's mutex; the platform layer decides
+  // what actually lives in these words.
+  typealias Primitive = [(EMBEDDED_SWIFT_MUTEX_NUM_WORDS) of UInt]
+  #elseif canImport(Darwin.os.lock)
   typealias Primitive = os_unfair_lock
   #elseif canImport(Glibc) || canImport(Musl) || canImport(Bionic)
   #if os(FreeBSD) || os(OpenBSD)
@@ -59,7 +82,10 @@ internal struct Lock {
   }
 
   fileprivate static func initialize(_ platformLock: PlatformLock) {
-    #if canImport(Darwin.os.lock)
+    #if $Embedded
+    platformLock.initialize(to: .init(repeating: 0))
+    _swift_mutex_init(UnsafeMutableRawPointer(platformLock), 0)
+    #elseif canImport(Darwin.os.lock)
     platformLock.initialize(to: os_unfair_lock())
     #elseif canImport(Glibc) || canImport(Musl) || canImport(Bionic)
     let result = pthread_mutex_init(platformLock, nil)
@@ -74,7 +100,9 @@ internal struct Lock {
   }
 
   fileprivate static func deinitialize(_ platformLock: PlatformLock) {
-    #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+    #if $Embedded
+    _swift_mutex_destroy(UnsafeMutableRawPointer(platformLock))
+    #elseif canImport(Glibc) || canImport(Musl) || canImport(Bionic)
     let result = pthread_mutex_destroy(platformLock)
     precondition(result == 0, "pthread_mutex_destroy failed")
     #endif
@@ -82,7 +110,9 @@ internal struct Lock {
   }
 
   fileprivate static func lock(_ platformLock: PlatformLock) {
-    #if canImport(Darwin.os.lock)
+    #if $Embedded
+    _swift_mutex_lock(UnsafeMutableRawPointer(platformLock))
+    #elseif canImport(Darwin.os.lock)
     os_unfair_lock_lock(platformLock)
     #elseif canImport(Glibc) || canImport(Musl) || canImport(Bionic)
     pthread_mutex_lock(platformLock)
@@ -95,7 +125,9 @@ internal struct Lock {
   }
 
   fileprivate static func unlock(_ platformLock: PlatformLock) {
-    #if canImport(Darwin.os.lock)
+    #if $Embedded
+    _swift_mutex_unlock(UnsafeMutableRawPointer(platformLock))
+    #elseif canImport(Darwin.os.lock)
     os_unfair_lock_unlock(platformLock)
     #elseif canImport(Glibc) || canImport(Musl) || canImport(Bionic)
     let result = pthread_mutex_unlock(platformLock)

--- a/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
+++ b/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
@@ -330,16 +330,20 @@ public struct ObservationRegistrar: Sendable {
   }
 }
 
+// Codable is not available in Embedded Swift. The conformance only exists so
+// that Codable types can contain a registrar; it deliberately encodes nothing.
+#if !$Embedded
 @available(SwiftStdlib 5.9, *)
 extension ObservationRegistrar: Codable {
   public init(from decoder: any Decoder) throws {
     self.init()
   }
-  
+
   public func encode(to encoder: any Encoder) {
     // Don't encode a registrar's transient state.
   }
 }
+#endif
 
 @available(SwiftStdlib 5.9, *)
 extension ObservationRegistrar: Hashable {

--- a/stdlib/public/Observation/Sources/Observation/ThreadLocal.swift
+++ b/stdlib/public/Observation/Sources/Observation/ThreadLocal.swift
@@ -9,6 +9,36 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if $Embedded
+
+// In Embedded Swift the thread-local storage lives in the platform abstraction
+// layer, which reserves a fixed key for each entry in
+// include/swift/Threading/TLSKeys.h. Use the reserved observation key directly
+// rather than going through the C++ Threading library, which the Embedded Swift
+// standard library does not link against.
+//
+// This value must stay in sync with swift::tls_key::observation_transaction.
+private let _observationTransactionKey = 6
+
+@_extern(c, "_swift_tls_get")
+internal func _swift_tls_get(_ key: Int) -> UnsafeMutableRawPointer?
+
+@_extern(c, "_swift_tls_set")
+internal func _swift_tls_set(_ key: Int, _ value: UnsafeMutableRawPointer?)
+
+struct _ThreadLocal {
+  static var value: UnsafeMutableRawPointer? {
+    get {
+      return _swift_tls_get(_observationTransactionKey)
+    }
+    set {
+      _swift_tls_set(_observationTransactionKey, newValue)
+    }
+  }
+}
+
+#else
+
 @_silgen_name("_swift_observation_tls_get")
 func _tlsGet() -> UnsafeMutableRawPointer?
 
@@ -26,3 +56,5 @@ struct _ThreadLocal {
     }
   }
 }
+
+#endif

--- a/test/embedded/lit.local.cfg
+++ b/test/embedded/lit.local.cfg
@@ -122,12 +122,15 @@ if 'embedded_stdlib' in config.available_features:
   # so tests that `import Synchronization` must have `libswiftSynchronization.a`
   # on the link line for both configurations to link.
   config.substitutions.append(("%target-embedded-synchronization", f"-L {_embedded_lib_dir}/ -lswiftSynchronization"))
+  # Observation opts in the same way as Synchronization above.
+  config.substitutions.append(("%target-embedded-observation", f"-L {_embedded_lib_dir}/ -lswiftObservation"))
 else:
   config.substitutions.append(("%target-embedded-single-threaded-shim", ""))
   config.substitutions.append(("%target-embedded-multi-threaded-posix-shim", ""))
   config.substitutions.append(("%target-embedded-multi-threaded-darwin-shim", ""))
   config.substitutions.append(("%target-embedded-concurrency-threading-shim", ""))
   config.substitutions.append(("%target-embedded-synchronization", ""))
+  config.substitutions.append(("%target-embedded-observation", ""))
 
 # (7) `%target-embedded-link` is the convenience wrapper that bundles
 # `%target-clang`, the embedded stdlib, and the POSIX shim — prefer it over

--- a/test/embedded/observation.swift
+++ b/test/embedded/observation.swift
@@ -1,0 +1,61 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -enable-experimental-feature EmbeddedKeyPaths -plugin-path %swift-plugin-dir -parse-as-library %s -c -o %t/a.o
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/a.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple -lc++ -lswift_Concurrency %target-swift-default-executor-opt %target-embedded-concurrency-threading-shim %target-embedded-observation -dead_strip
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_EmbeddedKeyPaths
+
+import Observation
+
+@Observable
+final class Counter {
+  var value: Int = 0
+  var untracked: Int = 0
+}
+
+@main
+struct Main {
+  static func main() {
+    let c = Counter()
+
+    // Mutating a property that was read inside the apply closure fires
+    // onChange, synchronously, before the new value is stored.
+    withObservationTracking {
+      _ = c.value
+    } onChange: {
+      print("changed-1")
+    }
+    c.value = 1
+    print("after-1 \(c.value)")
+    // CHECK: changed-1
+    // CHECK-NEXT: after-1 1
+
+    // Only the properties actually read inside the apply closure are tracked,
+    // so mutating a different property must not fire onChange.
+    withObservationTracking {
+      _ = c.value
+    } onChange: {
+      print("changed-2")
+    }
+    c.untracked = 1
+    print("after-untracked")
+    // CHECK-NEXT: after-untracked
+
+    // ...but the still-installed observer does fire on the next change to the
+    // tracked property.
+    c.value = 2
+    print("after-2 \(c.value)")
+    // CHECK-NEXT: changed-2
+    // CHECK-NEXT: after-2 2
+
+    // Tracking is one-shot: it cancelled itself above, so a further mutation
+    // fires nothing.
+    c.value = 3
+    print("after-3 \(c.value)")
+    // CHECK-NEXT: after-3 3
+  }
+}


### PR DESCRIPTION
This required a few changes to Observation:
* In Embedded Swift builds, back the lock with the platform abstraction layer's _swift_mutex*
* In Embedded Swift builds, back the thread-local storage with the platform abstraction layer's _swift_tls_*
* In the macro, make the generated shouldNotifyObservers "final" (in all modes)
* Don't provide Codable conformances in Embedded Swift (because Codable isn't available)

Note that the Observation library is currently only really usable with the EmbeddedKeyPaths language feature, which is still experimental. However, getting this library building (and working end-to-end, as in the added test) is separable.

The CMake here is extra janky because we don't always build the concurrency library. When we get to the point where we are always building it, we can simplify the CMake here.

Implements rdar://158437791 / https://github.com/swiftlang/swift/issues/77146
