### PR TITLE
[cxx-interop] Fix incorrect addToAggLowering implementation for imported C++ records with super classes

### DIFF
--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -448,12 +448,6 @@ namespace {
 
     void addToAggLowering(IRGenModule &IGM, SwiftAggLowering &lowering,
                           Size offset) const override {
-      if (auto cxxRecordDecl = dyn_cast<clang::CXXRecordDecl>(ClangDecl)) {
-        for (auto base : getBasesAndOffsets(cxxRecordDecl)) {
-          lowering.addTypedData(base.decl, base.offset.asCharUnits());
-        }
-      }
-
       lowering.addTypedData(ClangDecl, offset.asCharUnits());
     }
 

--- a/test/Interop/Cxx/class/inheritance/aggregate-lowering-irgen.swift
+++ b/test/Interop/Cxx/class/inheritance/aggregate-lowering-irgen.swift
@@ -1,0 +1,26 @@
+// RUN: %target-swift-emit-irgen -I %S/Inputs -cxx-interoperability-mode=default %s | %FileCheck %s
+// REQUIRES: PTRSIZE=64
+
+// This test is meant to demonstrate how we once added imported C++ record with a class hierarchy incorrectly to aggregate lowerings
+// and assert we don't make this mistake again.
+
+import Fields
+
+struct WrapperWithDerivedClangRecord {
+  var leading: Double
+  var value: DerivedFromOneField
+}
+
+// Previously, we would add storage that defines the layout of base classes (OneField in this case) twice,
+// first at the wrong offset. This first erroneous adding of the base class storage for the value field
+// would be added "on top of" the storage for the leading field, leading to an opaque lowering for the leading
+// parts of the SwiftAggLowering. That lead the following suboptimal signature:
+
+// define hidden swiftcc void @"$s4main36consumeWrapperWithDerivedClangRecordyyAA0cdefG0VF"(i64 %0, i32 %1)
+
+func consumeWrapperWithDerivedClangRecord(
+  _ value: WrapperWithDerivedClangRecord
+) {}
+
+// Base-class fields must be placed relative to the containing aggregate.
+// CHECK: define hidden swiftcc void @"$s4main36consumeWrapperWithDerivedClangRecordyyAA0cdefG0VF"(double %0, i32 %1)


### PR DESCRIPTION


In https://github.com/swiftlang/swift/pull/39349/changes/bb00e8dcfedf50014a521292296843c3cc64ad72, we add basic support for importing C++ base classes. I believe the logic added to LoadableClangRecord::addToAggLowering is incorrect here, for the following reasons:

1.) The existing call to addTypedData already handles this:

```
lowering.addTypedData(ClangDecl, offset.asCharUnits());
```

https://github.com/swiftlang/llvm-project/blob/next/clang/lib/CodeGen/SwiftCallingConv.cpp#L150-L155

```
//   - non-virtual bases
    for (auto &baseSpecifier : cxxRecord->bases()) {
      if (baseSpecifier.isVirtual()) continue;

      auto baseRecord = baseSpecifier.getType()->getAsCXXRecordDecl();
      addTypedData(baseRecord, begin + layout.getBaseClassOffset(baseRecord));
    }
```

This is also alluded to in review comments on the original PR: https://github.com/swiftlang/swift/pull/39349#discussion_r717186388

2.) We add the base class storage to the aggregate at the wrong offset.

In the current implementation, when we call:

```
lowering.addTypedData(base.decl, base.offset.asCharUnits());
```
it should instead be:

```
lowering.addTypedData(base.decl, offset + base.offset.asCharUnits());
```

`addToAggLowering` is used to add the value the TypeInfo describes to some existing aggregate lowering. We need to add the storage at the offset it resides in that enclosing aggregate lowering, not just the offset within the C++ record we are currently adding.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
