### PR TITLE
[TypeChecker] Implement consuming capture inference for `@called(once)` closures

### DIFF
--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1626,6 +1626,10 @@ static ValueDecl *getCalledValue(Expr *E, bool skipFunctionConversions) {
   }
 
   Expr *E2 = E->getValueProvidingExpr();
+
+  if (auto *L = dyn_cast<LoadExpr>(E2))
+    E2 = L->getSubExpr()->getValueProvidingExpr();
+
   if (E != E2)
     return getCalledValue(E2, skipFunctionConversions);
 

--- a/lib/SIL/Verifier/SILOwnershipVerifier.cpp
+++ b/lib/SIL/Verifier/SILOwnershipVerifier.cpp
@@ -563,6 +563,25 @@ bool SILValueOwnershipChecker::checkDeadEnds(
   return allWithinBoundary;
 }
 
+/// Returns true if \p f's entire body has been reduced to a single
+/// `unreachable` instruction, e.g. by DiagnosticDeadFunctionElimination
+/// stubbing out a dead function. Such a stub can never execute, so missing
+/// lifetime ending uses for its `@owned` parameters can't leak anything.
+static bool isStubbedDeadFunctionBody(const SILFunction *F) {
+  if (!F->hasSemanticsAttr(semantics::DELETE_IF_UNUSED))
+    return false;
+
+  if (std::next(F->begin()) != F->end())
+    return false;
+
+  auto &BB = *F->begin();
+  if (BB.empty())
+    return false;
+
+  return &BB.front() == BB.getTerminator() &&
+         isa<UnreachableInst>(BB.getTerminator());
+}
+
 bool SILValueOwnershipChecker::checkFunctionArgWithoutLifetimeEndingUses(
     SILFunctionArgument *arg, ArrayRef<Operand *> regularUses,
     ArrayRef<Operand *> extendLifetimeUses) {
@@ -574,6 +593,13 @@ bool SILValueOwnershipChecker::checkFunctionArgWithoutLifetimeEndingUses(
   case OwnershipKind::None:
     return true;
   case OwnershipKind::Owned:
+    // `@called(once)` closures, in contrast to regular closures, can have
+    // `@owned` parameters. DiagnosticDeadFunctionElimination pass replaces
+    // whole body with an `unreachable` instruction which needs to be handled
+    // specifically here because it removes lifetime ending uses for such
+    // parameters.
+    if (isStubbedDeadFunctionBody(arg->getFunction()))
+      return true;
     break;
   }
 

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -20,17 +20,20 @@
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/Decl.h"
-#include "swift/AST/Initializer.h"
+#include "swift/AST/Expr.h"
 #include "swift/AST/ForeignErrorConvention.h"
 #include "swift/AST/GenericSignature.h"
+#include "swift/AST/Initializer.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/TypeWalker.h"
+#include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/Defer.h"
 #include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/Support/Casting.h"
 using namespace swift;
 
 namespace {
@@ -57,6 +60,9 @@ class FindCapturedVars : public ASTWalker {
   /// The captured types.
   SmallVector<CapturedType, 4> CapturedTypes;
   llvm::SmallDenseMap<CanType, unsigned, 4> CapturedTypeEntryNumber;
+
+  /// The values that have consuming uses in the closure.
+  llvm::SmallPtrSet<ValueDecl *, 1> ConsumedValues;
 
   SourceLoc GenericParamCaptureLoc;
   SourceLoc DynamicSelfCaptureLoc;
@@ -407,20 +413,14 @@ public:
                                       : AccessKind::Read,
               CurDC->getParentModule(), CurDC->getResilienceExpansion()))
         Flags |= CapturedValue::IsDirect;
-
-      // `@called(once)` captures can be moved into `@called(once)` closures
-      // because the closure itself cannot be called more than once.
-      if (CalledOnce) {
-        if (auto fnType = var->getInterfaceType()->getAs<AnyFunctionType>()) {
-          if (fnType->isCalledOnce())
-            Flags |= CapturedValue::IsConsumed;
-        }
-      }
     }
 
     // If the closure is noescape, then we can capture the decl as noescape.
     if (NoEscape)
       Flags |= CapturedValue::IsNoEscape;
+
+    if (CalledOnce && ConsumedValues.count(D))
+      Flags |= CapturedValue::IsConsumed;
 
     addCapture(CapturedValue(D, Flags, DRE->getStartLoc()));
 
@@ -507,6 +507,18 @@ public:
     // the local type itself.
     if (isa<NominalTypeDecl>(D))
       return Action::SkipNode();
+
+    if (CalledOnce) {
+      if (auto *PBD = dyn_cast<PatternBindingDecl>(D)) {
+        auto *var = PBD->getSingleVar();
+        if (var && var->hasStorage()) {
+          if (auto *init = var->getParentExecutableInitializer()) {
+            if (auto *V = getReferencedNonCopyableValue(init))
+              recordConsumingUse(V);
+          }
+        }
+      }
+    }
 
     return Action::Continue();
   }
@@ -665,10 +677,112 @@ public:
     return true;
   }
 
+  void recordConsumingUse(ValueDecl *V) {
+    ASSERT(V);
+    ConsumedValues.insert(V);
+  }
+
+  ValueDecl *getReferencedNonCopyableValue(Expr *E) {
+    if (!E)
+      return nullptr;
+
+    E = E->getSemanticsProvidingExpr();
+    if (auto *L = dyn_cast<LoadExpr>(E))
+      return getReferencedNonCopyableValue(L->getSubExpr());
+
+    auto *DRE = dyn_cast<DeclRefExpr>(E);
+    if (!DRE)
+      return nullptr;
+
+    auto ref = DRE->getDeclRef();
+    if (!ref)
+      return nullptr;
+
+    auto type = ref.getDecl()->getInterfaceType();
+    if (ref.isSpecialized())
+      type = type.subst(ref.getSubstitutions());
+
+    return type->isNoncopyable() ? ref.getDecl() : nullptr;
+  }
+
+  /// Check whether the given expression represents a consuming use of some
+  /// non-Copyable value and record the value as "consumed" by the closure.
+  ///
+  /// Consuming uses of non-Copyable values include - use of `consume` operator,
+  /// appearing on right-hand side of an assignment, passing it to `consuming`
+  /// parameter, calling a `consuming` method. For more details see SE-0390.
+  void recordConsumedValues(Expr *E) {
+    // `consume x`
+    if (auto *consume = dyn_cast<ConsumeExpr>(E)) {
+      if (auto *V = getReferencedNonCopyableValue(consume->getSubExpr()))
+        recordConsumingUse(V);
+    }
+
+    // assignments - `... = x`
+    if (auto *assignment = dyn_cast<AssignExpr>(E)) {
+      if (auto *V = getReferencedNonCopyableValue(assignment->getSrc()))
+        recordConsumingUse(V);
+    }
+
+    // consuming get/set
+    if (auto *memberRef = dyn_cast<MemberRefExpr>(E)) {
+      auto member = memberRef->getMember();
+      auto *property = dyn_cast<VarDecl>(member.getDecl());
+      if (property && !property->hasStorage()) {
+        auto *assignment = dyn_cast_or_null<AssignExpr>(Parent.getAsExpr());
+        auto accessorKind = assignment && assignment->getDest() == memberRef
+                                ? AccessorKind::Set
+                                : AccessorKind::Get;
+
+        auto *accessor = property->getAccessor(accessorKind);
+        if (accessor->getAttrs().hasAttribute<ConsumingAttr>()) {
+          if (auto *base = getReferencedNonCopyableValue(memberRef->getBase()))
+            recordConsumingUse(base);
+        }
+      }
+    }
+
+    // - calling `@called(once)` value
+    // - passing a value to a `consuming` parameter
+    // - calling a `consuming` method ("self" is consumed).
+    if (auto *callSite = dyn_cast<ApplyExpr>(E)) {
+      auto fnTy = callSite->getFn()->getType()->castTo<FunctionType>();
+
+      bool isInitializer = false;
+      if (auto *callee =
+              callSite->getCalledValue(/*skipFunctionConversions=*/true)) {
+        // Calling a `@called(once)` value is a consuming operation.
+        if (fnTy->isCalledOnce())
+          recordConsumingUse(callee);
+
+        isInitializer = isa<ConstructorDecl>(callee);
+      }
+
+      auto *arguments = callSite->getArgs();
+      for (unsigned i : indices(fnTy->getParams())) {
+        const auto &param = fnTy->getParams()[i];
+
+        // Parameter either has to be explicitly `consuming` or,
+        // if this is a call to initializer - not explicitly `borrowing`.
+        if (!(param.isOwned() ||
+              (isInitializer &&
+               param.getParameterFlags().getOwnershipSpecifier() !=
+                   ParamSpecifier::Borrowing)))
+          continue;
+
+        if (auto *V = getReferencedNonCopyableValue(arguments->getExpr(i)))
+          recordConsumingUse(V);
+      }
+    }
+  }
+
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     if (usesTypeMetadataOfFormalType(E)) {
       checkType(E->getType(), E->getLoc());
     }
+
+    if (CalledOnce)
+      recordConsumedValues(E);
 
     // Some kinds of expression don't really evaluate their subexpression,
     // so we don't need to traverse.
@@ -776,6 +890,15 @@ public:
           assert(VisitingForEachEnv.count(env) == 0);
           VisitingForEachEnv.insert(env);
         }
+      }
+    }
+
+    // `return` of a non-Copyable value is a consuming use.
+    if (CalledOnce && isa<ReturnStmt>(S)) {
+      auto *returnStmt = cast<ReturnStmt>(S);
+      if (returnStmt->hasResult()) {
+        if (auto *V = getReferencedNonCopyableValue(returnStmt->getResult()))
+          recordConsumingUse(V);
       }
     }
 

--- a/test/SIL/called_once_consuming_captures.swift
+++ b/test/SIL/called_once_consuming_captures.swift
@@ -1,0 +1,214 @@
+// RUN: %target-swift-frontend %s \
+// RUN: -emit-sil \
+// RUN: -enable-experimental-feature CalledAttribute \
+// RUN: -verify
+
+// REQUIRES: swift_feature_CalledAttribute
+
+struct Resource: ~Copyable {
+  init() {}
+  consuming func use() {}
+  borrowing func peek() {}
+}
+
+struct Box: ~Copyable {
+  private var _r: Resource
+  init(_ r: consuming Resource) { _r = r }
+
+  var r: Resource {
+    consuming get { _r }
+  }
+}
+
+struct Slot: ~Copyable {
+  private var _r: Resource = Resource()
+  
+  var r: Resource {
+    get { fatalError() }
+    consuming set { _r = newValue }
+  }
+}
+
+// `consume` operator.
+func testExplicitConsumeOfCapturedStruct(r: consuming Resource) {
+  let g = { @called(once) in
+    let taken = consume r
+    taken.use()
+  }
+  g()
+}
+
+// Source of an assignment.
+func testAssignmentConsumesCapturedStruct(r: consuming Resource) {
+  let g = { @called(once) in
+    var local = Resource()
+    local = r
+    local.use()
+  }
+  g()
+}
+
+// Passing to a `consuming` parameter of a plain function.
+func testConsumingParamCallConsumesCapture(r: consuming Resource) {
+  func consumeResource(_: consuming Resource) {}
+
+  let g = { @called(once) in
+    consumeResource(r)
+  }
+  g()
+}
+
+// Passing to an initializer's implicitly-`consuming` parameter.
+func testConsumingInitParamConsumesCapture(r: consuming Resource) {
+  struct Wrapper: ~Copyable {
+    let r: Resource // memberwise initializer parameter is implicitly consuming
+  }
+
+  class ConsumingWrapper {
+    init(_: consuming Resource) {}
+  }
+  
+  let g = { @called(once) in
+    let w = Wrapper(r: r)
+    _ = w
+  }
+  g()
+
+  let localResource = Resource()
+  let h = { @called(once) in
+    let w = ConsumingWrapper(localResource)
+    _ = w
+  }
+  h()
+}
+
+// Calling a `consuming` method (`self` is consumed).
+func testConsumingMethodCallConsumesCapture(r: consuming Resource) {
+  let g = { @called(once) in
+    r.use()
+  }
+  g()
+}
+
+// Intiailization consumes the value
+func testLocalBindingConsumesCapture(r: consuming Resource) {
+  let g = { @called(once) in
+    let taken = r
+    taken.use()
+  }
+  g()
+}
+
+func tesReassignmentOfProperties(r1: consuming Resource, r2: consuming Resource) {
+  struct S: ~Copyable {
+    var prop = Resource()
+  }
+
+  class C {
+    var prop = Resource()
+  }
+
+  var s = S()
+  let c = C()
+  
+  let g = { @called(once) in
+    s.prop = r1
+  }
+  g()
+
+  let h = { @called(once) in
+    c.prop = r2
+  }
+  h()
+
+  // Make sure that the same value cannot be consumed twice by different closures
+  
+  let r3 = Resource() // expected-error {{'r3' consumed more than once}}
+  let _ = { @called(once) in // expected-note {{consumed here}}
+    s.prop = r3 
+  }
+
+  let _ = { @called(once) in // expected-note {{consumed again here}}
+    c.prop = r3
+  }
+}
+
+// Capture aliasing.
+func testCaptureListConsumesCapture(r: consuming Resource) {
+  let g = { @called(once) [taken = r] in
+    taken.use()
+  }
+  g()
+}
+
+// `return` is a consuming use.
+func testReturnConsumesCapture(r: consuming Resource) -> Resource {
+  let g: @called(once) () -> Resource = { @called(once) in
+    return r
+  }
+  return g()
+}
+
+func testBorrowingCallDoesNotConsumeCapture(r: consuming Resource) {
+  func borrowResource(_: borrowing Resource) {}
+
+  let g = { @called(once) in
+    r.peek() // borrowing use
+    borrowResource(r)
+    r.use() // consume
+  }
+  g()
+}
+
+func testDoubleConsumeOfCapturedValue(r: consuming Resource) { // expected-error 2 {{'r' consumed more than once}}
+  let g = { @called(once) in
+    r.use() // expected-note 2 {{consumed here}}
+    r.use() // expected-note 2 {{consumed again here}}
+  }
+  g()
+}
+
+func testRegularClosureCannotConsumeCapturedStruct(r: consuming Resource) { // expected-error {{missing reinitialization of closure capture 'r' after consume}}
+  let g = { // not @called(once)
+    r.use() // expected-note {{consumed here}}
+  }
+  g()
+}
+
+func testNestedClosurePropagatesConsumedCapture(r: consuming Resource) {
+  let inner = { @called(once) in r.use() }
+  let outer = { @called(once) in inner() }
+  outer()
+}
+
+func testCaptureNotConsumedWhenOnlyBorrowedAcrossNesting(r: consuming Resource) {
+  let inner = { @called(once) in r.peek() }
+  let outer = { @called(once) in inner() }
+  outer()
+  r.use() // expected-error {{noncopyable 'r' cannot be consumed when captured by an escaping closure or borrowed by a non-Escapable type}}
+}
+
+func testConsumingCalledOnceNestedInRegularClosure(r: consuming Resource) { // expected-error {{reinitialization of closure capture 'r' after consume}}
+  let f = {
+    let g = { @called(once) in // expected-note {{consumed here}}
+      r.use()
+    }
+    g()
+  }
+  f()
+}
+
+func testConsumingGetterConsumesCapture(_ box: consuming Box) {
+  let g = { @called(once) in
+    let v = box.r
+    _ = v
+  }
+  g()
+}
+
+func testConsumingSetterConsumesCapture(_ slot: consuming Slot, _ r: consuming Resource) {
+  let g = { @called(once) in
+    slot.r = r
+  }
+  g()
+}

--- a/test/SILGen/called_once_consuming_captures.swift
+++ b/test/SILGen/called_once_consuming_captures.swift
@@ -1,0 +1,310 @@
+// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types -enable-experimental-feature CalledAttribute %s | %FileCheck %s
+
+// REQUIRES: swift_feature_CalledAttribute
+
+struct Resource: ~Copyable {
+  init() {}
+  consuming func use() {}
+  borrowing func peek() {}
+}
+
+struct Box: ~Copyable {
+  private var _r: Resource
+  init(_ r: consuming Resource) { _r = r }
+
+  var r: Resource {
+    consuming get { _r }
+  }
+
+  var borrowedR: Resource {
+    get { fatalError() }
+  }
+}
+
+struct Slot: ~Copyable {
+  private var _r: Resource = Resource()
+  
+  var r: Resource {
+    get { fatalError() }
+    consuming set { _r = newValue }
+  }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s30called_once_consuming_captures35testExplicitConsumeOfCapturedStructyyAA8ResourceVnF : $@convention(thin) (@owned Resource) -> () {
+// CHECK: bb0([[R:%.*]] : @owned $Resource):
+// CHECK:  [[R_PROJ:%.*]] = project_box {{.*}} : ${ var Resource }, 0
+// CHECK:  [[R_TAKE_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[R_PROJ]] : $*Resource
+// CHECK:  [[R_VALUE:%.*]] = load [take] [[R_TAKE_ADDR]] : $*Resource
+// CHECK:  partial_apply {{.*}}([[R_VALUE]]) : $@convention(thin) (@owned Resource) -> ()
+// CHECK: } // end sil function '$s30called_once_consuming_captures35testExplicitConsumeOfCapturedStructyyAA8ResourceVnF'
+func testExplicitConsumeOfCapturedStruct(_ r: consuming Resource) {
+  let g = { @called(once) in
+    let taken = consume r
+    taken.use()
+  }
+  g()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s30called_once_consuming_captures36testAssignmentConsumesCapturedStructyyAA8ResourceVnF : $@convention(thin) (@owned Resource) -> () {
+// CHECK: bb0([[R:%.*]] : @owned $Resource):
+// CHECK:  [[R_PROJ:%.*]] = project_box {{.*}} : ${ var Resource }, 0
+// CHECK:  [[R_TAKE_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[R_PROJ]] : $*Resource
+// CHECK:  [[R_VALUE:%.*]] = load [take] [[R_TAKE_ADDR]] : $*Resource
+// CHECK:  partial_apply {{.*}}([[R_VALUE]]) : $@convention(thin) (@owned Resource) -> ()
+// CHECK: } // end sil function '$s30called_once_consuming_captures36testAssignmentConsumesCapturedStructyyAA8ResourceVnF'
+func testAssignmentConsumesCapturedStruct(_ r: consuming Resource) {
+  let g = { @called(once) in
+    var local = Resource()
+    local = r
+    local.use()
+  }
+  g()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s30called_once_consuming_captures37testConsumingParamCallConsumesCaptureyyAA8ResourceVnF : $@convention(thin) (@owned Resource) -> () {
+// CHECK: bb0([[R:%.*]] : @owned $Resource):
+// CHECK:  [[R_PROJ:%.*]] = project_box {{.*}} : ${ var Resource }, 0
+// CHECK:  [[R_TAKE_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[R_PROJ]] : $*Resource
+// CHECK:  [[R_VALUE:%.*]] = load [take] [[R_TAKE_ADDR]] : $*Resource
+// CHECK:  partial_apply {{.*}}([[R_VALUE]]) : $@convention(thin) (@owned Resource) -> ()
+// CHECK: } // end sil function '$s30called_once_consuming_captures37testConsumingParamCallConsumesCaptureyyAA8ResourceVnF'
+func testConsumingParamCallConsumesCapture(_ r: consuming Resource) {
+  func consumeResource(_ r: consuming Resource) {}
+
+  let g = { @called(once) in
+    consumeResource(r)
+  }
+  g()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s30called_once_consuming_captures37testConsumingInitParamConsumesCaptureyyAA8ResourceVnF : $@convention(thin) (@owned Resource) -> () {
+// CHECK: bb0([[R:%.*]] : @owned $Resource):
+// CHECK:  [[R_PROJ:%.*]] = project_box {{.*}} : ${ var Resource }, 0
+// CHECK:  [[R_TAKE_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[R_PROJ]] : $*Resource
+// CHECK:  [[R_VALUE:%.*]] = load [take] [[R_TAKE_ADDR]] : $*Resource
+// CHECK:  partial_apply {{.*}}([[R_VALUE]]) : $@convention(thin) (@owned Resource) -> ()
+// CHECK: } // end sil function '$s30called_once_consuming_captures37testConsumingInitParamConsumesCaptureyyAA8ResourceVnF'
+func testConsumingInitParamConsumesCapture(_ r: consuming Resource) {
+  struct Wrapper: ~Copyable {
+    let r: Resource
+  }
+
+  let g = { @called(once) in
+    _ = Wrapper(r: r)
+  }
+  g()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s30called_once_consuming_captures38testConsumingMethodCallConsumesCaptureyyAA8ResourceVnF : $@convention(thin) (@owned Resource) -> () {
+// CHECK: bb0([[R:%.*]] : @owned $Resource):
+// CHECK:  [[R_PROJ:%.*]] = project_box {{.*}} : ${ var Resource }, 0
+// CHECK:  [[R_TAKE_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[R_PROJ]] : $*Resource
+// CHECK:  [[R_VALUE:%.*]] = load [take] [[R_TAKE_ADDR]] : $*Resource
+// CHECK:  partial_apply {{.*}}([[R_VALUE]]) : $@convention(thin) (@owned Resource) -> ()
+// CHECK: } // end sil function '$s30called_once_consuming_captures38testConsumingMethodCallConsumesCaptureyyAA8ResourceVnF'
+
+// CHECK-LABEL: sil private [ossa] @$s30called_once_consuming_captures38testConsumingMethodCallConsumesCaptureyyAA8ResourceVnFyyXOfU_ : $@convention(thin) (@owned Resource) -> () {
+// CHECK: bb0([[R_CAPTURE:%.*]] : @closureCapture @owned $Resource):
+// CHECK:  [[R_STACK:%.*]] = alloc_stack $Resource, var, name "r"
+// CHECK:  [[R_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[R_STACK]] : $*Resource
+// CHECK:  store [[R_CAPTURE]] to [init] [[R_ADDR]] : $*Resource
+// CHECK:  [[R_ADDR_2:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[R_ADDR]] : $*Resource
+// CHECK:  [[R_DEINIT_ACCESS:%.*]] = begin_access [deinit] [unknown] [[R_ADDR_2]] : $*Resource
+// CHECK:  [[R_TAKEN:%.*]] = load [take] [[R_DEINIT_ACCESS]] : $*Resource
+// CHECK:  [[USE_REF:%.*]] = function_ref @$s30called_once_consuming_captures8ResourceV3useyyF
+// CHECK:  apply [[USE_REF]]([[R_TAKEN]]) : $@convention(method) (@owned Resource) -> ()
+// CHECK: } // end sil function '$s30called_once_consuming_captures38testConsumingMethodCallConsumesCaptureyyAA8ResourceVnFyyXOfU_'
+func testConsumingMethodCallConsumesCapture(_ r: consuming Resource) {
+  let g = { @called(once) in
+    r.use()
+  }
+  g()
+}
+
+// A plain local `let taken = r` binding of a captured value is a consuming
+// use, just like an explicit `consume`.
+// CHECK-LABEL: sil hidden [ossa] @$s30called_once_consuming_captures31testLocalBindingConsumesCaptureyyAA8ResourceVnF : $@convention(thin) (@owned Resource) -> () {
+// CHECK: bb0([[R:%.*]] : @owned $Resource):
+// CHECK:  [[R_PROJ:%.*]] = project_box {{.*}} : ${ var Resource }, 0
+// CHECK:  [[R_TAKE_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[R_PROJ]] : $*Resource
+// CHECK:  [[R_VALUE:%.*]] = load [take] [[R_TAKE_ADDR]] : $*Resource
+// CHECK:  partial_apply {{.*}}([[R_VALUE]]) : $@convention(thin) (@owned Resource) -> ()
+// CHECK: } // end sil function '$s30called_once_consuming_captures31testLocalBindingConsumesCaptureyyAA8ResourceVnF'
+func testLocalBindingConsumesCapture(_ r: consuming Resource) {
+  let g = { @called(once) in
+    let taken = r
+    taken.use()
+  }
+  g()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s30called_once_consuming_captures36testBorrowingUsesDoNotConsumeCaptureyyAA8ResourceVF : $@convention(thin) (@guaranteed Resource) -> () {
+// CHECK: bb0([[R:%.*]] : @guaranteed $Resource):
+// CHECK:  [[R_COPY:%.*]] = copy_value [[R]] : $Resource
+// CHECK:  [[R_ADDR:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[R_COPY]] : $Resource
+// CHECK:  [[R_ARG_COPY:%.*]] = copy_value [[R_ADDR]] : $Resource
+// CHECK:  partial_apply {{.*}}([[R_ARG_COPY]]) : $@convention(thin) (@guaranteed Resource) -> ()
+// CHECK: } // end sil function '$s30called_once_consuming_captures36testBorrowingUsesDoNotConsumeCaptureyyAA8ResourceVF'
+func testBorrowingUsesDoNotConsumeCapture(_ r: borrowing Resource) {
+  func borrowResource(_ r: borrowing Resource) {}
+
+  let g = { @called(once) in
+    r.peek()
+    borrowResource(r)
+  }
+  g()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s30called_once_consuming_captures38testMixedConsumingAndBorrowingCapturesyyAA8ResourceVn_ADtF : $@convention(thin) (@owned Resource, @guaranteed Resource) -> () {
+// CHECK: bb0([[CONSUMED:%.*]] : @owned $Resource, [[BORROWED:%.*]] : @guaranteed $Resource)
+// CHECK:  [[CONSUMED_PROJ:%.*]] = project_box {{.*}} : ${ var Resource }, 0
+// CHECK:  [[BORROWED_COPY:%.*]] = copy_value [[BORROWED]] : $Resource
+// CHECK:  [[BORROWED_ADDR:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[BORROWED_COPY]] : $Resource
+// CHECK:  [[BORROWED_ARG_COPY:%.*]] = copy_value [[BORROWED_ADDR]] : $Resource
+// CHECK:  [[CONSUMED_TAKE_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[CONSUMED_PROJ]] : $*Resource
+// CHECK:  [[CONSUMED_VALUE:%.*]] = load [take] [[CONSUMED_TAKE_ADDR]] : $*Resource
+// CHECK:  partial_apply {{.*}}([[BORROWED_ARG_COPY]], [[CONSUMED_VALUE]]) : $@convention(thin) (@guaranteed Resource, @owned Resource) -> ()
+// CHECK: } // end sil function '$s30called_once_consuming_captures38testMixedConsumingAndBorrowingCapturesyyAA8ResourceVn_ADtF'
+
+// CHECK-LABEL: sil private [ossa] @$s30called_once_consuming_captures38testMixedConsumingAndBorrowingCapturesyyAA8ResourceVn_ADtFyyXOfU_ : $@convention(thin) (@guaranteed Resource, @owned Resource) -> () {
+// CHECK: bb0([[BORROWED_CAPTURE:%.*]] : @closureCapture @guaranteed $Resource, [[CONSUMED_CAPTURE:%.*]] : @closureCapture @owned $Resource):
+func testMixedConsumingAndBorrowingCaptures(_ consumed: consuming Resource, _ borrowed: borrowing Resource) {
+  let g = { @called(once) in
+    borrowed.peek()
+    consumed.use()
+  }
+  g()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s30called_once_consuming_captures27tesReassignmentOfProperties2r12r2yAA8ResourceVn_AFntF : $@convention(thin) (@owned Resource, @owned Resource) -> () {
+// CHECK: bb0([[R1:%.*]] : @owned $Resource, [[R2:%.*]] : @owned $Resource):
+// CHECK:  [[R1_PROJ:%.*]] = project_box {{.*}} : ${ var Resource }, 0
+// CHECK:  [[R2_PROJ:%.*]] = project_box {{.*}} : ${ var Resource }, 0
+// CHECK:  [[CLOSURE_G:%.*]] = function_ref @$s30called_once_consuming_captures27tesReassignmentOfProperties2r12r2yAA8ResourceVn_AFntFyyXOfU_
+// CHECK:  [[R1_TAKE_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[R1_PROJ]] : $*Resource
+// CHECK:  [[R1_VALUE:%.*]] = load [take] [[R1_TAKE_ADDR]] : $*Resource
+// CHECK:  partial_apply [[CLOSURE_G]]({{.*}}, [[R1_VALUE]]) : $@convention(thin) (@guaranteed { var S }, @owned Resource) -> ()
+// CHECK:  [[CLOSURE_H:%.*]] = function_ref @$s30called_once_consuming_captures27tesReassignmentOfProperties2r12r2yAA8ResourceVn_AFntFyyXOfU0_
+// CHECK:  [[R2_TAKE_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[R2_PROJ]] : $*Resource
+// CHECK:  [[R2_VALUE:%.*]] = load [take] [[R2_TAKE_ADDR]] : $*Resource
+// CHECK:  partial_apply [[CLOSURE_H]]({{.*}}, [[R2_VALUE]]) : $@convention(thin) (@guaranteed C, @owned Resource) -> ()
+// CHECK: } // end sil function '$s30called_once_consuming_captures27tesReassignmentOfProperties2r12r2yAA8ResourceVn_AFntF'
+
+// CHECK-LABEL: sil private [ossa] @$s30called_once_consuming_captures27tesReassignmentOfProperties2r12r2yAA8ResourceVn_AFntFyyXOfU_ : $@convention(thin) (@guaranteed { var S }, @owned Resource) -> () {
+// CHECK: bb0([[S_CAPTURE:%.*]] : @closureCapture @guaranteed ${ var S }, [[R1_CAPTURE:%.*]] : @closureCapture @owned $Resource):
+// CHECK:  [[S_PROJ:%.*]] = project_box [[S_CAPTURE]] : ${ var S }, 0
+// CHECK:  [[R1_STACK:%.*]] = alloc_stack $Resource, var, name "r1"
+// CHECK:  [[R1_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[R1_STACK]] : $*Resource
+// CHECK:  store [[R1_CAPTURE]] to [init] [[R1_ADDR]] : $*Resource
+// CHECK:  [[R1_ADDR_2:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[R1_ADDR]] : $*Resource
+// CHECK:  [[R1_READ_ACCESS:%.*]] = begin_access [read] [unknown] [[R1_ADDR_2]] : $*Resource
+// CHECK:  [[R1_FAKE_COPY:%.*]] = load [copy] [[R1_READ_ACCESS]] : $*Resource
+// CHECK:  end_access [[R1_READ_ACCESS]] : $*Resource
+// CHECK:  [[S_ACCESS:%.*]] = begin_access [modify] [unknown] [[S_PROJ]] : $*S
+// CHECK:  [[S_WRITE_ADDR:%.*]] = mark_unresolved_non_copyable_value [assignable_but_not_consumable] [[S_ACCESS]] : $*S
+// CHECK:  [[PROP_ADDR:%.*]] = struct_element_addr [[S_WRITE_ADDR]] : $*S, #{{.*}}S.prop
+// CHECK:  assign [[R1_FAKE_COPY]] to [[PROP_ADDR]] : $*Resource
+// CHECK:  end_access [[S_ACCESS]] : $*S
+// CHECK: } // end sil function '$s30called_once_consuming_captures27tesReassignmentOfProperties2r12r2yAA8ResourceVn_AFntFyyXOfU_'
+
+// CHECK-LABEL: sil private [ossa] @$s30called_once_consuming_captures27tesReassignmentOfProperties2r12r2yAA8ResourceVn_AFntFyyXOfU0_ : $@convention(thin) (@guaranteed C, @owned Resource) -> () {
+// CHECK: bb0([[C_CAPTURE:%.*]] : @closureCapture @guaranteed $C, [[R2_CAPTURE:%.*]] : @closureCapture @owned $Resource):
+// CHECK:  [[R2_STACK:%.*]] = alloc_stack $Resource, var, name "r2"
+// CHECK:  [[R2_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[R2_STACK]] : $*Resource
+// CHECK:  store [[R2_CAPTURE]] to [init] [[R2_ADDR]] : $*Resource
+// CHECK:  [[R2_ADDR_2:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[R2_ADDR]] : $*Resource
+// CHECK:  [[R2_READ_ACCESS:%.*]] = begin_access [read] [unknown] [[R2_ADDR_2]] : $*Resource
+// CHECK:  [[R2_FAKE_COPY:%.*]] = load [copy] [[R2_READ_ACCESS]] : $*Resource
+// CHECK:  end_access [[R2_READ_ACCESS]] : $*Resource
+// CHECK:  [[SETTER:%.*]] = class_method [[C_CAPTURE]] : $C, #{{.*}}C.prop!setter
+// CHECK:  apply [[SETTER]]([[R2_FAKE_COPY]], [[C_CAPTURE]]) : $@convention(method) (@owned Resource, @guaranteed C) -> ()
+// CHECK: } // end sil function '$s30called_once_consuming_captures27tesReassignmentOfProperties2r12r2yAA8ResourceVn_AFntFyyXOfU0_'
+func tesReassignmentOfProperties(r1: consuming Resource, r2: consuming Resource) {
+  struct S: ~Copyable {
+    var prop = Resource()
+  }
+
+  class C {
+    var prop = Resource()
+  }
+
+  var s = S()
+  let c = C()
+
+  let g = { @called(once) in
+    s.prop = r1
+  }
+  g()
+
+  let h = { @called(once) in
+    c.prop = r2
+  }
+  h()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s30called_once_consuming_captures34testConsumingGetterConsumesCaptureyyAA3BoxVnF : $@convention(thin) (@owned Box) -> () {
+// CHECK: bb0([[BOX:%.*]] : @owned $Box):
+// CHECK:  [[BOX_PROJ:%.*]] = project_box {{.*}} : ${ var Box }, 0
+// CHECK:  [[BOX_TAKE_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[BOX_PROJ]] : $*Box
+// CHECK:  [[BOX_VALUE:%.*]] = load [take] [[BOX_TAKE_ADDR]] : $*Box
+// CHECK:  partial_apply {{.*}}([[BOX_VALUE]]) : $@convention(thin) (@owned Box) -> ()
+// CHECK: } // end sil function '$s30called_once_consuming_captures34testConsumingGetterConsumesCaptureyyAA3BoxVnF'
+
+// CHECK-LABEL: sil private [ossa] @$s30called_once_consuming_captures34testConsumingGetterConsumesCaptureyyAA3BoxVnFyyXOfU_ : $@convention(thin) (@owned Box) -> () {
+// CHECK: bb0([[BOX_CAPTURE:%.*]] : @closureCapture @owned $Box):
+// CHECK:  [[BOX_STACK:%.*]] = alloc_stack $Box, var, name "box"
+// CHECK:  [[BOX_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[BOX_STACK]] : $*Box
+// CHECK:  store [[BOX_CAPTURE]] to [init] [[BOX_ADDR]] : $*Box
+// CHECK:  [[BOX_ADDR_2:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[BOX_ADDR]] : $*Box
+// CHECK:  [[BOX_READ_ACCESS:%.*]] = begin_access [read] [unknown] [[BOX_ADDR_2]] : $*Box
+// CHECK:  [[BOX_BORROW:%.*]] = load_borrow [unchecked] [[BOX_READ_ACCESS]] : $*Box
+// CHECK:  [[BOX_COPY:%.*]] = copy_value [[BOX_BORROW]] : $Box
+// CHECK:  [[GETTER:%.*]] = function_ref @$s30called_once_consuming_captures3BoxV1rAA8ResourceVvg : $@convention(method) (@owned Box) -> @owned Resource
+// CHECK:  [[R_VALUE:%.*]] = apply [[GETTER]]([[BOX_COPY]]) : $@convention(method) (@owned Box) -> @owned Resource
+// CHECK:  end_borrow [[BOX_BORROW]] : $Box
+// CHECK:  end_access [[BOX_READ_ACCESS]] : $*Box
+// CHECK: } // end sil function '$s30called_once_consuming_captures34testConsumingGetterConsumesCaptureyyAA3BoxVnFyyXOfU_'
+func testConsumingGetterConsumesCapture(_ box: consuming Box) {
+  let g = { @called(once) in
+    let v = box.r
+    _ = v
+  }
+  g()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s30called_once_consuming_captures34testConsumingSetterConsumesCaptureyyAA4SlotVn_AA8ResourceVntF : $@convention(thin) (@owned Slot, @owned Resource) -> () {
+// CHECK: bb0([[SLOT:%.*]] : @owned $Slot, [[R:%.*]] : @owned $Resource):
+// CHECK:  [[SLOT_PROJ:%.*]] = project_box {{.*}} : ${ var Slot }, 0
+// CHECK:  [[R_PROJ:%.*]] = project_box {{.*}} : ${ var Resource }, 0
+// CHECK:  [[SLOT_TAKE_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[SLOT_PROJ]] : $*Slot
+// CHECK:  [[SLOT_VALUE:%.*]] = load [take] [[SLOT_TAKE_ADDR]] : $*Slot
+// CHECK:  [[R_TAKE_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[R_PROJ]] : $*Resource
+// CHECK:  [[R_VALUE:%.*]] = load [take] [[R_TAKE_ADDR]] : $*Resource
+// CHECK:  partial_apply {{.*}}([[SLOT_VALUE]], [[R_VALUE]]) : $@convention(thin) (@owned Slot, @owned Resource) -> ()
+// CHECK: } // end sil function '$s30called_once_consuming_captures34testConsumingSetterConsumesCaptureyyAA4SlotVn_AA8ResourceVntF'
+
+// CHECK-LABEL: sil private [ossa] @$s30called_once_consuming_captures34testConsumingSetterConsumesCaptureyyAA4SlotVn_AA8ResourceVntFyyXOfU_ : $@convention(thin) (@owned Slot, @owned Resource) -> () {
+// CHECK: bb0([[SLOT_CAPTURE:%.*]] : @closureCapture @owned $Slot, [[R_CAPTURE:%.*]] : @closureCapture @owned $Resource):
+// CHECK:  [[SLOT_STACK:%.*]] = alloc_stack $Slot, var, name "slot"
+// CHECK:  [[SLOT_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[SLOT_STACK]] : $*Slot
+// CHECK:  store [[SLOT_CAPTURE]] to [init] [[SLOT_ADDR]] : $*Slot
+// CHECK:  [[SLOT_ADDR_2:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[SLOT_ADDR]] : $*Slot
+// CHECK:  [[R_STACK:%.*]] = alloc_stack $Resource, var, name "r"
+// CHECK:  [[R_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[R_STACK]] : $*Resource
+// CHECK:  store [[R_CAPTURE]] to [init] [[R_ADDR]] : $*Resource
+// CHECK:  [[R_ADDR_2:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[R_ADDR]] : $*Resource
+// CHECK:  [[R_READ_ACCESS:%.*]] = begin_access [read] [unknown] [[R_ADDR_2]] : $*Resource
+// CHECK:  [[R_FAKE_COPY:%.*]] = load [copy] [[R_READ_ACCESS]] : $*Resource
+// CHECK:  end_access [[R_READ_ACCESS]] : $*Resource
+// CHECK:  [[SLOT_READ_ACCESS:%.*]] = begin_access [read] [unknown] [[SLOT_ADDR_2]] : $*Slot
+// CHECK:  [[SLOT_BORROW:%.*]] = load_borrow [unchecked] [[SLOT_READ_ACCESS]] : $*Slot
+// CHECK:  [[SLOT_COPY:%.*]] = copy_value [[SLOT_BORROW]] : $Slot
+// CHECK:  [[SETTER:%.*]] = function_ref @$s30called_once_consuming_captures4SlotV1rAA8ResourceVvs : $@convention(method) (@owned Resource, @owned Slot) -> ()
+// CHECK:  apply [[SETTER]]([[R_FAKE_COPY]], [[SLOT_COPY]]) : $@convention(method) (@owned Resource, @owned Slot) -> ()
+// CHECK: } // end sil function '$s30called_once_consuming_captures34testConsumingSetterConsumesCaptureyyAA4SlotVn_AA8ResourceVntFyyXOfU_'
+func testConsumingSetterConsumesCapture(_ slot: consuming Slot, _ r: consuming Resource) {
+  let g = { @called(once) in
+    slot.r = r
+  }
+  g()
+}


### PR DESCRIPTION
Because `@called(once)` closures can only be called at most once
it makes it possible to safely capture non-Copyable values that
perform a consuming operation in the body, that doesn't run into
re-initialization issues like regular closures that could be
called multiple times.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
