### PR TITLE
[Utils] update-verify-tests: support several expected-* directives per line

### DIFF
--- a/test/Utils/update-verify-tests/multiple-diags-one-line-prefix.swift
+++ b/test/Utils/update-verify-tests/multiple-diags-one-line-prefix.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: not %target-swift-frontend-verify -verify-additional-prefix check- -typecheck %t/test.swift 2>&1 | %update-verify-tests --prefix check-
+// RUN: %target-swift-frontend-verify -verify-additional-prefix check- -typecheck %t/test.swift
+// RUN: %diff %t/test.swift %t/test.swift.expected
+
+//--- test.swift
+func mixedPrefixesOnOneLine() {
+  // Two directives share one comment, with different prefixes. The prefixed
+  // one is stale; picking the right directive to rewrite has to survive the
+  // prefix filtering.
+  a = 2; b = 2 // expected-check-error {{stale}} expected-error {{cannot find 'b' in scope}}
+}
+//--- test.swift.expected
+func mixedPrefixesOnOneLine() {
+  // Two directives share one comment, with different prefixes. The prefixed
+  // one is stale; picking the right directive to rewrite has to survive the
+  // prefix filtering.
+  a = 2; b = 2 // expected-check-error {{cannot find 'a' in scope}} expected-error {{cannot find 'b' in scope}}
+}

--- a/test/Utils/update-verify-tests/multiple-diags-one-line.swift
+++ b/test/Utils/update-verify-tests/multiple-diags-one-line.swift
@@ -1,0 +1,109 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: not %target-swift-frontend-verify -typecheck %t/test.swift 2>&1 | %update-verify-tests
+// RUN: %target-swift-frontend-verify -typecheck %t/test.swift
+// RUN: %diff %t/test.swift %t/test.swift.expected
+
+//--- test.swift
+func wrongMessageInMiddle() {
+  // Three directives share one comment; only the middle message is stale.
+  // The reported column is what tells the directives apart, so only that one
+  // is rewritten and its siblings are left byte-for-byte alone.
+  a = 2; b = 2; c = 2 // expected-error {{cannot find 'a' in scope}} expected-error {{stale message}} expected-error {{cannot find 'c' in scope}}
+}
+
+func separateComments() {
+  // Each directive opens its own comment. The parser must find both, rather
+  // than bailing out on the second '//'.
+  d = 2; e = 2 // expected-error {{cannot find 'd' in scope}} // expected-error {{stale message}}
+}
+
+func everyDirectiveWrong() {
+  // Both messages are stale, so the verifier reports two errors against this
+  // one line. Each directive must absorb one of them; attributing both to the
+  // same directive would take its count negative. The messages land swapped
+  // because that is the pairing the verifier itself reports.
+  f = 2; g = 2 // expected-error {{stale one}} expected-error {{stale two}}
+}
+
+func staleDirectiveFirst() {
+  // The stale directive owns the '//' of the comment. Removing it must hand
+  // the '//' to the surviving directive, which is written without one.
+  h = 2 // expected-error {{never produced}} expected-error {{cannot find 'h' in scope}}
+}
+
+func everyDirectiveStale() {
+  // Nothing is emitted on this line, so the whole comment goes away.
+  let _ = 0 // expected-error {{never produced}} expected-error {{also never produced}}
+}
+
+func countOnMultiDirectiveLine() {
+  // A count expectation next to a sibling directive: the two 'i' errors are
+  // matched by the count, and only the stale sibling is rewritten.
+  i = 2; i = 3; j = 2 // expected-error 2{{cannot find 'i' in scope}} expected-error {{stale message}}
+}
+
+func fixitOnMultiDirectiveLine() {
+  // The fix-it mismatch is reported inside the first directive's fix-it run,
+  // so the corrected fix-it must land on that directive and not on its
+  // sibling.
+  let k = 2; let l = 3 // expected-warning {{initialization of immutable value 'k' was never used}} {{1-2=wrong}} expected-warning {{initialization of immutable value 'l' was never used}}
+}
+
+func alreadyCorrect() {
+  // Nothing to update here: a multi-directive line that already matches must
+  // round-trip with its unusual whitespace intact.
+  m = 2; n = 2 //  expected-error{{cannot find 'm' in scope}}     expected-error {{cannot find 'n' in scope}}
+}
+//--- test.swift.expected
+func wrongMessageInMiddle() {
+  // Three directives share one comment; only the middle message is stale.
+  // The reported column is what tells the directives apart, so only that one
+  // is rewritten and its siblings are left byte-for-byte alone.
+  a = 2; b = 2; c = 2 // expected-error {{cannot find 'a' in scope}} expected-error {{cannot find 'b' in scope}} expected-error {{cannot find 'c' in scope}}
+}
+
+func separateComments() {
+  // Each directive opens its own comment. The parser must find both, rather
+  // than bailing out on the second '//'.
+  d = 2; e = 2 // expected-error {{cannot find 'd' in scope}} // expected-error {{cannot find 'e' in scope}}
+}
+
+func everyDirectiveWrong() {
+  // Both messages are stale, so the verifier reports two errors against this
+  // one line. Each directive must absorb one of them; attributing both to the
+  // same directive would take its count negative. The messages land swapped
+  // because that is the pairing the verifier itself reports.
+  f = 2; g = 2 // expected-error {{cannot find 'g' in scope}} expected-error {{cannot find 'f' in scope}}
+}
+
+func staleDirectiveFirst() {
+  // The stale directive owns the '//' of the comment. Removing it must hand
+  // the '//' to the surviving directive, which is written without one.
+  h = 2 // expected-error {{cannot find 'h' in scope}}
+}
+
+func everyDirectiveStale() {
+  // Nothing is emitted on this line, so the whole comment goes away.
+  let _ = 0
+}
+
+func countOnMultiDirectiveLine() {
+  // A count expectation next to a sibling directive: the two 'i' errors are
+  // matched by the count, and only the stale sibling is rewritten.
+  i = 2; i = 3; j = 2 // expected-error 2{{cannot find 'i' in scope}} expected-error {{cannot find 'j' in scope}}
+}
+
+func fixitOnMultiDirectiveLine() {
+  // The fix-it mismatch is reported inside the first directive's fix-it run,
+  // so the corrected fix-it must land on that directive and not on its
+  // sibling.
+  let k = 2; let l = 3 // expected-warning {{initialization of immutable value 'k' was never used}} {{3-8=_}} expected-warning {{initialization of immutable value 'l' was never used}}
+}
+
+func alreadyCorrect() {
+  // Nothing to update here: a multi-directive line that already matches must
+  // round-trip with its unusual whitespace intact.
+  m = 2; n = 2 //  expected-error{{cannot find 'm' in scope}}     expected-error {{cannot find 'n' in scope}}
+}

--- a/utils/update-verify-tests.py
+++ b/utils/update-verify-tests.py
@@ -14,7 +14,6 @@ from update_verify_tests.core import check_expectations
   - multiple prefixes on the same line (-verify-additional-prefix my-prefix -verify-additional-prefix my-other-prefix)
   - multiple prefixes on separate RUN lines (RUN: -verify-additional-prefix my-prefix\nRUN: -verify-additional-prefix my-other-prefix)
   - regexes matchers
-  - multiple checks targeting the same line are supported, but a line may only contain one check
   - if multiple checks targeting the same line are failing the script is not guaranteed to produce a minimal diff
   - columns
   - doc files

--- a/utils/update_verify_tests/core.py
+++ b/utils/update_verify_tests/core.py
@@ -47,18 +47,62 @@ def parse_error_category(s, prefix):
 class Line:
     def __init__(self, content, line_n):
         self.content = content
-        self.diag = None
+        # Every `expected-*` directive on this line, in source order. A line
+        # may carry several: the verifier scans the buffer for `expected-`,
+        # so `// expected-error{{a}} expected-note{{b}}` is two directives
+        # sharing one comment, and `// expected-error{{a}} //
+        # expected-note{{b}}` is two directives each with their own. `content`
+        # holds one `{{DIAG}}` placeholder per entry.
+        self.diags = []
         self.line_n = line_n
         self.targeting_diags = []
+
+    @property
+    def diag(self):
+        """The line's first directive, or None. Most of the pipeline deals with
+        one directive per line; multi-directive lines are handled explicitly by
+        iterating `diags`."""
+        return self.diags[0] if self.diags else None
+
+    @diag.setter
+    def diag(self, value):
+        self.diags = [value] if value is not None else []
 
     def update_line_n(self, n):
         self.line_n = n
 
     def render(self):
-        if not self.diag:
+        if not self.diags:
             return self.content
-        assert "{{DIAG}}" in self.content
-        res = self.content.replace("{{DIAG}}", self.diag.render())
+        parts = self.content.split("{{DIAG}}")
+        assert len(parts) == len(self.diags) + 1
+        res = parts[0]
+        # The `//` of a comment belongs to the first directive in it; the
+        # ones packed after it render bare. If that first directive is being
+        # removed, its `//` must be handed to whichever directive in the
+        # comment survives, otherwise the survivor would render as code.
+        pending_slash = None
+        for diag, tail in zip(self.diags, parts[1:]):
+            rendered = diag.render()
+            owns_slashes = getattr(diag, "has_slashes", True)
+            if rendered:
+                if not owns_slashes and pending_slash is not None:
+                    # The survivor renders its own leading whitespace, so only
+                    # borrow the removed directive's when it has none.
+                    own_ws = (
+                        getattr(diag, "whitespace_strings", None)
+                        or DEFAULT_WHITESPACE
+                    ).slash
+                    borrowed = "" if own_ws else pending_slash
+                    rendered = "//" + borrowed + rendered
+                pending_slash = None
+            elif owns_slashes:
+                ws = (
+                    getattr(diag, "whitespace_strings", None)
+                    or DEFAULT_WHITESPACE
+                )
+                pending_slash = ws.slash
+            res += rendered + tail
         if not res.strip():
             return ""
         return res.rstrip() + "\n"
@@ -85,6 +129,8 @@ class Diag:
         had_none_fixit_marker=False,
         preserved_markers=None,
         had_absolute_line_in_source=False,
+        has_slashes=True,
+        source_span=None,
     ):
         self.prefix = prefix
         self.diag_content = diag_content
@@ -137,10 +183,24 @@ class Diag:
         self.children_closer = None
         self.is_child_note = False
         self.child_of = None
+        # False for a directive packed onto a comment opened by an earlier
+        # directive on the same line (`// expected-error{{a}}
+        # expected-note{{b}}`): it renders without a leading `//`.
+        self.has_slashes = has_slashes
+        # 1-based, inclusive column range this directive occupies in its source
+        # line, fix-it run included. A verifier error always points somewhere
+        # inside this range, which is what tells sibling directives on one line
+        # apart. None for synthesized directives (they own their whole line).
+        self.source_span = source_span
 
     def decrement_count(self):
+        if self.count <= 0:
+            raise KnownException(
+                f"more diagnostics reported against "
+                f"'expected-{self.category}{{{{{self.diag_content}}}}}' than it "
+                f"expects. Aborting to avoid corrupting the test."
+            )
         self.count -= 1
-        assert self.count >= 0
 
     def increment_count(self):
         assert self.count >= 0
@@ -271,8 +331,9 @@ class Diag:
         ws_count = ws.count
         if count_s and not ws_count and self.original_count_str is None:
             ws_count = " "
+        slashes_s = "//" if self.has_slashes else ""
         base_s = (
-            f"//{ws.slash}expected-{self.prefix}{self.category}{re_s}"
+            f"{slashes_s}{ws.slash}expected-{self.prefix}{self.category}{re_s}"
             f"{ws.at}{line_location_s}{col_s}{ws_count}{count_s}{ws.braces}"
         )
         if self.category == "expansion":
@@ -305,6 +366,17 @@ class ExpansionDiagClose:
 
 expected_diag_re = re.compile(
     r"//(\s*)expected-([a-zA-Z0-9-]*)(note|warning|error|remark)(-re)?(\s*?)(@[+-]?\d+|@(?=:))?(:\d+)?(\s*)(\d+)?(\s*)\{\{(.*?)\}\}"
+)
+# Same as `expected_diag_re` minus the `//`, for a directive packed onto a
+# comment an earlier directive on the same line already opened. Only ever
+# matched anchored directly after that directive, never searched for: the
+# verifier finds directives by scanning for `expected-` anywhere in the buffer,
+# but matching a bare `expected-` at an arbitrary position would also hit
+# ordinary code and string literals. Group layout is identical so both regexes
+# share the group-extraction code, with group 1 holding the whitespace before
+# `expected-` instead of the whitespace after `//`.
+continuation_diag_re = re.compile(
+    r"(\s*)expected-([a-zA-Z0-9-]*)(note|warning|error|remark)(-re)?(\s*?)(@[+-]?\d+|@(?=:))?(:\d+)?(\s*)(\d+)?(\s*)\{\{(.*?)\}\}"
 )
 expected_expansion_diag_re = re.compile(
     r"//(\s*)expected-([a-zA-Z0-9-]*)(expansion)(-re)?(\s*?)(@[+-]?\d+|@(?=:))(:\d+)(\s*)(\d+)?(\s*)\{\{(.*?)"
@@ -454,109 +526,202 @@ def split_fixit_markers(s):
     return results
 
 
-def parse_diag(line, filename, prefix, all_prefixes=False):
+def _consumed_end(s, m):
+    """End offset in *s* of the directive *m* matched, fix-it run included."""
+    if m.re is expected_expansion_diag_re:
+        return m.end()
+    fixits_raw_str, _, _ = consume_trailing_fixits(s[m.end() :])
+    return m.end() + len(fixits_raw_str)
+
+
+def _find_diag_matches(s):
+    """Every `expected-*` directive match on the line, in source order.
+
+    The first directive of a comment carries the `//`; any further directives
+    packed onto that same comment are matched as continuations, anchored right
+    after the previous directive's message (and fix-it run) so a bare
+    `expected-` elsewhere on the line is never mistaken for a directive.
+    """
+    matches = []
+    pos = 0
+    while True:
+        m = expected_diag_re.search(s, pos)
+        if not m:
+            return matches
+        matches.append(m)
+        pos = _consumed_end(s, m)
+        while c := continuation_diag_re.match(s, pos):
+            matches.append(c)
+            pos = _consumed_end(s, c)
+
+
+def parse_diags(line, filename, prefix, all_prefixes=False):
+    """Parse every directive on *line*, replacing each with a `{{DIAG}}`
+    placeholder in `line.content`, and return them in source order. Directives
+    whose prefix doesn't match are left in the content verbatim."""
     s = line.content
-    matches = list(expected_diag_re.finditer(s))
-    matched_re = expected_diag_re
+    matches = _find_diag_matches(s)
     if not matches:
         matches = list(expected_expansion_diag_re.finditer(s))
-        matched_re = expected_expansion_diag_re
+        if len(matches) > 1:
+            raise KnownException(
+                f"multiple expansions on line {filename}:{line.line_n}. Aborting due to missing implementation."
+            )
     if not matches:
         ms = expected_expansion_close_re.findall(s)
         if not ms:
-            return None
+            return []
         if len(ms) > 1:
             raise KnownException(
                 f"multiple closed scopes on line {filename}:{line.line_n}. Aborting due to missing implementation."
             )
         line.content = expected_expansion_close_re.sub("{{DIAG}}", s)
-        return ExpansionDiagClose(ms[0], line)
-    if len(matches) > 1:
-        raise KnownException(
-            f"multiple diags on line {filename}:{line.line_n}. Aborting due to missing implementation."
-        )
-    m = matches[0]
-    [
-        ws_slash,
-        check_prefix,
-        category_s,
-        re_s,
-        ws_at,
-        target_line_s,
-        target_col_s,
-        ws_count,
-        count_s,
-        ws_braces,
-        diag_s,
-    ] = m.groups()
-    if check_prefix != prefix and check_prefix != "" and not all_prefixes:
-        return None
-    if not target_line_s or target_line_s == "@":
-        target_line_n = 0
-        is_absolute = False
-    elif target_line_s.startswith("@+"):
-        target_line_n = int(target_line_s[2:])
-        is_absolute = False
-    elif target_line_s.startswith("@-"):
-        target_line_n = int(target_line_s[1:])
-        is_absolute = False
-    else:
-        target_line_n = int(target_line_s[1:])
-        is_absolute = True
-    col = int(target_col_s[1:]) if target_col_s else None
-    count = int(count_s) if count_s else 1
-    if matched_re is expected_diag_re:
-        fixits_raw_str, has_none_marker, preserved_markers = (
-            consume_trailing_fixits(s[m.end() :])
-        )
-        # Detect whether any source-side fix-it marker carries an absolute
-        # `<line>:<col>` position; if so, future updates preserve absolute
-        # form, otherwise actual fix-its are rewritten as relative offsets.
-        had_absolute_line = False
-        for marker in split_fixit_markers(fixits_raw_str):
-            fm = fixit_marker_re.match(marker)
-            if not fm:
-                continue
-            content = fm.group("content")
-            if (
-                content == "none"
-                or content.startswith("documentation-file=")
-                or content.startswith("group-name=")
-            ):
-                continue
-            if _fixit_content_has_absolute_line(content):
-                had_absolute_line = True
-                break
-    else:
-        fixits_raw_str, has_none_marker, preserved_markers = "", False, []
-        had_absolute_line = False
-    line.content = (
-        s[: m.start()] + "{{DIAG}}" + s[m.end() + len(fixits_raw_str) :]
-    )
+        return [ExpansionDiagClose(ms[0], line)]
 
-    unescaped_diag_s = decode(
-        encode(diag_s, "utf-8", "backslashreplace"), "unicode-escape"
-    )
-    return Diag(
-        check_prefix,
-        unescaped_diag_s,
-        category_s,
-        target_line_n,
-        is_absolute,
-        col,
-        count,
-        line,
-        bool(re_s),
-        Whitespace(slash=ws_slash, at=ws_at, count=ws_count, braces=ws_braces),
-        True,
-        [],
-        diag_content_raw=diag_s,
-        original_count_str=count_s if count_s else None,
-        fixits_raw_str=fixits_raw_str,
-        had_none_fixit_marker=has_none_marker,
-        preserved_markers=preserved_markers,
-        had_absolute_line_in_source=had_absolute_line,
-    )
+    diags = []
+    new_content = ""
+    last_end = 0
+    for m in matches:
+        [
+            ws_slash,
+            check_prefix,
+            category_s,
+            re_s,
+            ws_at,
+            target_line_s,
+            target_col_s,
+            ws_count,
+            count_s,
+            ws_braces,
+            diag_s,
+        ] = m.groups()
+        if check_prefix != prefix and check_prefix != "" and not all_prefixes:
+            # Leave it in the content verbatim, as if it weren't a directive.
+            continue
+        if not target_line_s or target_line_s == "@":
+            target_line_n = 0
+            is_absolute = False
+        elif target_line_s.startswith("@+"):
+            target_line_n = int(target_line_s[2:])
+            is_absolute = False
+        elif target_line_s.startswith("@-"):
+            target_line_n = int(target_line_s[1:])
+            is_absolute = False
+        else:
+            target_line_n = int(target_line_s[1:])
+            is_absolute = True
+        col = int(target_col_s[1:]) if target_col_s else None
+        count = int(count_s) if count_s else 1
+        consumed_end = _consumed_end(s, m)
+        if m.re is not expected_expansion_diag_re:
+            fixits_raw_str, has_none_marker, preserved_markers = (
+                consume_trailing_fixits(s[m.end() :])
+            )
+            # Detect whether any source-side fix-it marker carries an absolute
+            # `<line>:<col>` position; if so, future updates preserve absolute
+            # form, otherwise actual fix-its are rewritten as relative offsets.
+            had_absolute_line = False
+            for marker in split_fixit_markers(fixits_raw_str):
+                fm = fixit_marker_re.match(marker)
+                if not fm:
+                    continue
+                content = fm.group("content")
+                if (
+                    content == "none"
+                    or content.startswith("documentation-file=")
+                    or content.startswith("group-name=")
+                ):
+                    continue
+                if _fixit_content_has_absolute_line(content):
+                    had_absolute_line = True
+                    break
+        else:
+            fixits_raw_str, has_none_marker, preserved_markers = "", False, []
+            had_absolute_line = False
+
+        new_content += s[last_end : m.start()] + "{{DIAG}}"
+        last_end = consumed_end
+
+        unescaped_diag_s = decode(
+            encode(diag_s, "utf-8", "backslashreplace"), "unicode-escape"
+        )
+        diags.append(
+            Diag(
+                check_prefix,
+                unescaped_diag_s,
+                category_s,
+                target_line_n,
+                is_absolute,
+                col,
+                count,
+                line,
+                bool(re_s),
+                Whitespace(
+                    slash=ws_slash, at=ws_at, count=ws_count, braces=ws_braces
+                ),
+                True,
+                [],
+                diag_content_raw=diag_s,
+                original_count_str=count_s if count_s else None,
+                fixits_raw_str=fixits_raw_str,
+                had_none_fixit_marker=has_none_marker,
+                preserved_markers=preserved_markers,
+                had_absolute_line_in_source=had_absolute_line,
+                has_slashes=m.re is not continuation_diag_re,
+                source_span=(m.start() + 1, consumed_end),
+            )
+        )
+    new_content += s[last_end:]
+    line.content = new_content
+    return diags
+
+
+def parse_diag(line, filename, prefix, all_prefixes=False, col=None):
+    """The single directive on *line*, or None. When the line carries several
+    and *col* is given, the one the column points into is returned."""
+    diags = parse_diags(line, filename, prefix, all_prefixes)
+    if not diags:
+        return None
+    if col is not None:
+        for diag in diags:
+            span = getattr(diag, "source_span", None)
+            if span and span[0] <= col <= span[1]:
+                return diag
+    return diags[0]
+
+
+def find_diag_on_line(line, col, category=None, content=None):
+    """Pick the directive on *line* that a verifier error at column *col*
+    refers to. Every error the verifier reports against a directive points
+    inside it, so the column is what tells sibling directives on one line
+    apart. Falls back to a content/category match, and then to the last
+    directive starting at or before the column, for the error kinds whose
+    location sits just outside the directive (e.g. a `{{children:` marker)."""
+    if not line.diags:
+        return None
+    if col:
+        for diag in line.diags:
+            span = getattr(diag, "source_span", None)
+            if span and span[0] <= col <= span[1]:
+                return diag
+    if content is not None:
+        for diag in line.diags:
+            if (
+                getattr(diag, "diag_content", None) == content
+                and diag.category == category
+                and getattr(diag, "count", 0) > 0
+            ):
+                return diag
+    if col:
+        before = [
+            diag
+            for diag in line.diags
+            if getattr(diag, "source_span", None)
+            and diag.source_span[0] <= col
+        ]
+        if before:
+            return before[-1]
+    return line.diags[0]
 
 
 def add_line(new_line, lines):
@@ -894,103 +1059,103 @@ def remove_dead_diags(lines, prefix):
         if line not in lines:
             # Already removed by an earlier take(); skip.
             continue
-        if not line.diag:
+        if not line.diags:
             continue
-        if getattr(line.diag, "children", None) or (
-            getattr(line.diag, "children_closer", None) is not None
-        ):
-            _collapse_dead_children(line.diag, prefix)
-        if line.diag.category == "expansion":
-            if not line.diag.prefix or line.diag.prefix == prefix:
-                # Whether the verifier already reported this expansion as
-                # missing (parent count was decremented to 0 in update_lines).
-                was_reported_missing = line.diag.count == 0
-                remove_dead_diags(line.diag.nested_lines, prefix)
-                if (
-                    was_reported_missing
-                    and _split_dead_expansion_for_foreign_prefixes(
-                        line, lines, prefix
-                    )
-                ):
-                    # The dead expansion has been replaced with one new
-                    # expansion directive per foreign prefix. Drop the original
-                    # so the cleanup at the bottom of the loop removes it.
-                    line.diag.nested_lines = []
-                    line.diag.closer = None
-                    line.diag.count = 0
-                elif line.diag.nested_lines:
-                    line.diag.count = 1
-                else:
-                    line.diag.count = 0
-        if line.diag.count != 0:
-            continue
-        # Try absorbing a same-category sibling first so the dead diag's
-        # formatting (whitespace, original_count_str) survives a content
-        # rewrite. Nested expansion diags have no target, so skip.
-        #
-        # Expansion directives never absorb a sibling. take() transfers a
-        # diagnostic's *message* state, but an expansion directive carries no
-        # message: what identifies it is its anchor column, and what it renders
-        # is its nested_lines plus its closer, none of which take() moves. So
-        # absorbing a live sibling expansion would keep this directive's stale
-        # column while dropping the sibling's nested diagnostics along with its
-        # line, leaving an empty `expected-expansion` anchored at the wrong
-        # column. That is worse than simply deleting the dead directive and
-        # letting the live sibling render itself, and it does not converge:
-        # re-running on the mangled output reproduces the same shape forever.
-        took = False
-        if (
-            line.diag.target is not None
-            and line.diag.category != "expansion"
-            and not getattr(line.diag, "is_child_note", False)
-        ):
-            for other_diag in line.diag.target.targeting_diags:
-                if (
-                    other_diag.is_from_source_file
-                    or other_diag.count == 0
-                    or other_diag.category != line.diag.category
-                    or getattr(other_diag, "is_child_note", False)
-                ):
-                    continue
-                if other_diag.is_re or line.diag.is_re:
-                    continue
-                assert line.diag.is_from_source_file
-                line.diag.take(other_diag)
-                remove_line(other_diag.line, lines)
-                took = True
+        # A line can carry several directives; each is retired on its own, and
+        # the line itself only goes away once nothing is left to render on it.
+        for diag in list(line.diags):
+            if line not in lines:
                 break
-        if took:
-            continue
-        # Even if take() didn't merge (e.g. because the synthesized sibling
-        # has a different category, as in the wrong-category-with-fix-it
-        # case), transfer the dead diag's fix-it state to a live sibling on
-        # the same target. The fix-it was reported by the verifier against
-        # this source location, so it logically belongs to whichever diag
-        # ends up rendering at this location.
-        if (
-            line.diag.actual_fixits is not None
-            and line.diag.target is not None
-        ):
-            for other_diag in line.diag.target.targeting_diags:
-                if (
-                    other_diag is line.diag
-                    or other_diag.is_from_source_file
-                    or other_diag.count == 0
-                    or other_diag.actual_fixits is not None
-                    or getattr(other_diag, "is_child_note", False)
-                ):
-                    continue
-                other_diag.actual_fixits = line.diag.actual_fixits
-                other_diag.had_none_fixit_marker = (
-                    line.diag.had_none_fixit_marker
-                )
-                other_diag.preserved_markers = line.diag.preserved_markers
-                other_diag.had_absolute_line_in_source = (
-                    line.diag.had_absolute_line_in_source
-                )
-                break
-        if line.render() == "":
+            _retire_diag_if_dead(diag, line, lines, prefix)
+        if line in lines and line.render() == "":
             remove_line(line, lines)
+
+
+def _retire_diag_if_dead(diag, line, lines, prefix):
+    if getattr(diag, "children", None) or (
+        getattr(diag, "children_closer", None) is not None
+    ):
+        _collapse_dead_children(diag, prefix)
+    if diag.category == "expansion":
+        if not diag.prefix or diag.prefix == prefix:
+            # Whether the verifier already reported this expansion as
+            # missing (parent count was decremented to 0 in update_lines).
+            was_reported_missing = diag.count == 0
+            remove_dead_diags(diag.nested_lines, prefix)
+            if (
+                was_reported_missing
+                and _split_dead_expansion_for_foreign_prefixes(
+                    line, lines, prefix
+                )
+            ):
+                # The dead expansion has been replaced with one new
+                # expansion directive per foreign prefix. Drop the original
+                # so the cleanup in remove_dead_diags removes it.
+                diag.nested_lines = []
+                diag.closer = None
+                diag.count = 0
+            elif diag.nested_lines:
+                diag.count = 1
+            else:
+                diag.count = 0
+    if diag.count != 0:
+        return
+    # Try absorbing a same-category sibling first so the dead diag's
+    # formatting (whitespace, original_count_str) survives a content
+    # rewrite. Nested expansion diags have no target, so skip.
+    #
+    # Expansion directives never absorb a sibling. take() transfers a
+    # diagnostic's *message* state, but an expansion directive carries no
+    # message: what identifies it is its anchor column, and what it renders
+    # is its nested_lines plus its closer, none of which take() moves. So
+    # absorbing a live sibling expansion would keep this directive's stale
+    # column while dropping the sibling's nested diagnostics along with its
+    # line, leaving an empty `expected-expansion` anchored at the wrong
+    # column. That is worse than simply deleting the dead directive and
+    # letting the live sibling render itself, and it does not converge:
+    # re-running on the mangled output reproduces the same shape forever.
+    if (
+        diag.target is not None
+        and diag.category != "expansion"
+        and not getattr(diag, "is_child_note", False)
+    ):
+        for other_diag in diag.target.targeting_diags:
+            if (
+                other_diag.is_from_source_file
+                or other_diag.count == 0
+                or other_diag.category != diag.category
+                or getattr(other_diag, "is_child_note", False)
+            ):
+                continue
+            if other_diag.is_re or diag.is_re:
+                continue
+            assert diag.is_from_source_file
+            diag.take(other_diag)
+            remove_line(other_diag.line, lines)
+            return
+    # Even if take() didn't merge (e.g. because the synthesized sibling
+    # has a different category, as in the wrong-category-with-fix-it
+    # case), transfer the dead diag's fix-it state to a live sibling on
+    # the same target. The fix-it was reported by the verifier against
+    # this source location, so it logically belongs to whichever diag
+    # ends up rendering at this location.
+    if diag.actual_fixits is not None and diag.target is not None:
+        for other_diag in diag.target.targeting_diags:
+            if (
+                other_diag is diag
+                or other_diag.is_from_source_file
+                or other_diag.count == 0
+                or other_diag.actual_fixits is not None
+                or getattr(other_diag, "is_child_note", False)
+            ):
+                continue
+            other_diag.actual_fixits = diag.actual_fixits
+            other_diag.had_none_fixit_marker = diag.had_none_fixit_marker
+            other_diag.preserved_markers = diag.preserved_markers
+            other_diag.had_absolute_line_in_source = (
+                diag.had_absolute_line_in_source
+            )
+            break
 
 
 def fold_expansions(lines):
@@ -1026,8 +1191,8 @@ def _child_parent_of(line):
     block, or None. Set for both parsed child-note lines (via the note diag's
     `child_of`) and for literal lines inside the block (via `_children_literal`,
     e.g. `@#marker` child notes we don't parse structurally)."""
-    if line.diag is not None:
-        parent = getattr(line.diag, "child_of", None)
+    for diag in line.diags:
+        parent = getattr(diag, "child_of", None)
         if parent is not None:
             return parent
     return getattr(line, "_children_literal", None)
@@ -1058,13 +1223,16 @@ def expand_children(lines):
     i = 0
     while i < len(lines):
         line = lines[i]
-        d = line.diag
-        if d is None or not getattr(d, "children", None):
+        block = []
+        for d in line.diags:
+            if not getattr(d, "children", None):
+                continue
+            block.extend(d.children)
+            if d.children_closer is not None:
+                block.append(d.children_closer)
+        if not block:
             i += 1
             continue
-        block = list(d.children)
-        if d.children_closer is not None:
-            block.append(d.children_closer)
         for j, nested in enumerate(block):
             nested.line_n = line.line_n + j + 1
             add_line(nested, lines)
@@ -1087,11 +1255,12 @@ def error_refers_to_diag(diag_error, diag, target_line_n):
 def find_other_targeting(lines, orig_lines, is_nested, diag_error, prefix):
     if is_nested:
         other_diags = [
-            line.diag
+            diag
             for line in lines
-            if line.diag
-            and (not line.diag.prefix or line.diag.prefix == prefix)
-            and error_refers_to_diag(diag_error, line.diag, diag_error.line)
+            for diag in line.diags
+            if isinstance(diag, Diag)
+            and (not diag.prefix or diag.prefix == prefix)
+            and error_refers_to_diag(diag_error, diag, diag_error.line)
         ]
     else:
         target = orig_lines[diag_error.line - 1]
@@ -1152,16 +1321,20 @@ def update_lines(
             continue
         line_n = diag_error.line
         line = orig_lines[line_n - 1]
-        assert line.diag or nested_context
-        if not line.diag or diag_error.content != line.diag.diag_content:
+        assert line.diags or nested_context
+        # The line may hold several directives; the reported column says which.
+        diag = find_diag_on_line(
+            line, diag_error.col, diag_error.category, diag_error.content
+        )
+        if diag is None or diag_error.content != diag.diag_content:
             raise KnownException(
-                f"{filename}:{line_n} - found diag {line.diag.diag_content} but expected {diag_error.content}"
+                f"{filename}:{line_n} - found diag {diag.diag_content if diag else None} but expected {diag_error.content}"
             )
-        if diag_error.category != line.diag.category:
+        if diag_error.category != diag.category:
             raise KnownException(
-                f"{filename}:{line_n} - found {line.diag.category} diag but expected {diag_error.category}"
+                f"{filename}:{line_n} - found {diag.category} diag but expected {diag_error.category}"
             )
-        line.diag.decrement_count()
+        diag.decrement_count()
 
     # Group FixitErrors by their target diag. When count > 1 and the verifier
     # produces distinct actual fix-it sets per occurrence (e.g.
@@ -1175,11 +1348,12 @@ def update_lines(
             continue
         line_n = diag_error.line
         line = orig_lines[line_n - 1]
-        if not line.diag:
+        diag = find_diag_on_line(line, diag_error.col)
+        if diag is None:
             raise KnownException(
                 f"{filename}:{line_n} - fix-it mismatch reported, but no expected-* directive parsed on that line"
             )
-        bucket = fixit_errors_by_diag.setdefault(id(line.diag), (line.diag, []))
+        bucket = fixit_errors_by_diag.setdefault(id(diag), (diag, []))
         bucket[1].append(diag_error.actual_fixits)
 
     for diag, actuals_list in fixit_errors_by_diag.values():
@@ -1418,7 +1592,7 @@ def update_lines(
                 f"{diag_error.file}:{diag_error.line} for unexpected child note"
             )
         parent_line = orig_lines[diag_error.line - 1]
-        parent_diag = parent_line.diag
+        parent_diag = find_diag_on_line(parent_line, diag_error.col)
         if parent_diag is None or parent_diag.category in (
             "closing",
             "expansion",
@@ -1511,7 +1685,9 @@ def update_lines(
             continue
         if not (1 <= diag_error.line <= len(orig_lines)):
             continue
-        parent_diag = orig_lines[diag_error.line - 1].diag
+        parent_diag = find_diag_on_line(
+            orig_lines[diag_error.line - 1], diag_error.col
+        )
         if parent_diag is None or parent_diag.category in (
             "closing",
             "expansion",
@@ -1549,19 +1725,21 @@ def update_test_file(filename, diag_errors, prefix, updated_test_files):
     unmatched_closers = []
     for line in lines:
         dprint(f"parsing line {line.render()}")
-        diag = parse_diag(line, filename, prefix, all_prefixes=True)
+        diags = parse_diags(line, filename, prefix, all_prefixes=True)
+        diag = diags[0] if diags else None
         if children_context is not None:
             # Inside a `{{children:...}}` block: route the closer and the
             # child-note (or literal) lines to the owning parent rather than
             # treating them as top-level diags/expansions.
             if diag and diag.category == "closing":
-                line.diag = diag
+                line.diags = diags
                 diag.child_of = children_context
                 children_context = None
             elif diag:
-                line.diag = diag
-                diag.is_child_note = True
-                diag.child_of = children_context
+                line.diags = diags
+                for d in diags:
+                    d.is_child_note = True
+                    d.child_of = children_context
             elif line.content.lstrip().startswith("}}"):
                 # A `}}`-first line that didn't parse as a `// }}` closer
                 # (e.g. a C-comment `}}*/` block terminator): treat it as a
@@ -1587,22 +1765,29 @@ def update_test_file(filename, diag_errors, prefix, updated_test_files):
             continue
         if diag:
             dprint(f"  parsed diag {diag.render()}")
-            line.diag = diag
-            if expansion_context:
-                diag.parent = expansion_context[-1]
-            else:
-                target_idx = diag.absolute_target() - 1
-                if 0 <= target_idx < len(lines):
-                    diag.set_target(lines[target_idx])
-                # Otherwise the directive points outside the file (e.g. the code
-                # it targeted was deleted, leaving the offset dangling past the
-                # end). Leave it targetless: the verifier reports its expansion
-                # as "not produced", so it is dropped as a dead directive rather
-                # than crashing here on an out-of-range line index.
-            if diag.category == "expansion":
-                expansion_context.append(diag)
+            line.diags = diags
+            for d in diags:
+                if expansion_context:
+                    d.parent = expansion_context[-1]
+                else:
+                    target_idx = d.absolute_target() - 1
+                    if 0 <= target_idx < len(lines):
+                        d.set_target(lines[target_idx])
+                    # Otherwise the directive points outside the file (e.g. the
+                    # code it targeted was deleted, leaving the offset dangling
+                    # past the end). Leave it targetless: the verifier reports
+                    # its expansion as "not produced", so it is dropped as a
+                    # dead directive rather than crashing here on an
+                    # out-of-range line index.
+            last = diags[-1]
+            if last.category == "expansion":
+                expansion_context.append(last)
+            elif last.category == "closing":
+                expansion_context.pop()
             elif _opens_children_block(line.content):
-                children_context = diag
+                # The opener is glued to the end of the line, so the block
+                # belongs to the last directive on it.
+                children_context = last
         else:
             dprint(f"  no diag")
 
@@ -1996,7 +2181,10 @@ def check_expectations(tool_output, prefix):
                 extra_lines = tool_output[i + 1 : i + 3]
                 dprint(f"extra lines: {extra_lines}")
                 diag = parse_diag(
-                    Line(extra_lines[0], int(m.group(2))), m.group(1), prefix
+                    Line(extra_lines[0], int(m.group(2))),
+                    m.group(1),
+                    prefix,
+                    col=int(m.group(3)),
                 )
                 curr.append(
                     NotFoundDiag(
@@ -2099,7 +2287,10 @@ def check_expectations(tool_output, prefix):
                 extra_lines = tool_output[i + 1 : i + 4]
                 dprint(f"extra lines: {extra_lines}")
                 diag = parse_diag(
-                    Line(extra_lines[0], int(m.group(2))), m.group(1), prefix
+                    Line(extra_lines[0], int(m.group(2))),
+                    m.group(1),
+                    prefix,
+                    col=int(m.group(3)),
                 )
                 curr.append(
                     NotFoundDiag(
@@ -2126,7 +2317,10 @@ def check_expectations(tool_output, prefix):
                 extra_lines = tool_output[i + 1 : i + 4]
                 dprint(f"extra lines: {extra_lines}")
                 diag = parse_diag(
-                    Line(extra_lines[0], int(m.group(2))), m.group(1), prefix
+                    Line(extra_lines[0], int(m.group(2))),
+                    m.group(1),
+                    prefix,
+                    col=int(m.group(3)),
                 )
                 assert diag.category == m.group(4)
                 assert extra_lines[2].strip() == m.group(5)


### PR DESCRIPTION
The diagnostic verifier locates directives by scanning the buffer for `expected-`, so one line can carry several of them: either sharing a single comment (`// expected-error{{a}} expected-note{{b}}`) or each opening its own (`// expected-error{{a}} // expected-note{{b}}`). update-verify-tests assumed one directive per line and mishandled both forms. The second form bailed out with "multiple diags on line"; the first parsed only the leading directive, since the regex requires a `//`, and then attributed every error reported on that line to it. That either drove its count below zero (an AssertionError traceback out of decrement_count) or silently rewrote the wrong directive, leaving the stale one in place.

A Line now holds a list of directives with one `{{DIAG}}` placeholder each, and directives packed onto an already-open comment are matched by a continuation regex anchored right after the preceding directive, so a bare `expected-` in code or a string literal is never mistaken for one. Those carry no `//` of their own, so render hands the comment's `//` to the surviving directive when the one that owned it is removed. Each directive also records the column range it occupies, fix-it run included: every error the verifier reports against a directive points inside that range, which is what tells siblings on one line apart when routing not-produced errors, fix-it mismatches and child notes. Dead directives are now retired individually, and a line is dropped only once nothing renders on it.

decrement_count raises KnownException instead of asserting, so any future mis-attribution surfaces as a readable lit message rather than a traceback.
