### PR TITLE
[rbi] Make Partition's read-only queries const

### DIFF
--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -1046,21 +1046,24 @@ public:
   /// Assigns \p oldElt to the region associated with \p newElt.
   void assignElement(Element oldElt, Element newElt, bool updateHistory = true);
 
-  bool areElementsInSameRegion(Element firstElt, Element secondElt) {
+  bool areElementsInSameRegion(Element firstElt, Element secondElt) const {
     canonicalize();
     return elementToRegionMap.at(firstElt) == elementToRegionMap.at(secondElt);
   }
 
-  Region getRegion(Element elt) {
+  Region getRegion(Element elt) const {
     canonicalize();
     return elementToRegionMap.at(elt);
   }
 
   using iterator = std::map<Element, Region>::iterator;
+  using const_iterator = std::map<Element, Region>::const_iterator;
 
 private:
   iterator begin() { return elementToRegionMap.begin(); }
   iterator end() { return elementToRegionMap.end(); }
+  const_iterator begin() const { return elementToRegionMap.begin(); }
+  const_iterator end() const { return elementToRegionMap.end(); }
 
 public:
   /// Return an iterator over the element/range in this partition. Will
@@ -1070,7 +1073,7 @@ public:
   /// NOTE: To work with iterators without canonicalizing, please use begin/end
   /// directly. This should only be done internally to the Partition
   /// implementation. We never want to expose
-  llvm::iterator_range<iterator> range() {
+  llvm::iterator_range<const_iterator> range() const {
     canonicalize();
     return {begin(), end()};
   }
@@ -1173,8 +1176,11 @@ public:
   }
 
 private:
+  /// The non-const body behind \c canonicalize.
+  void canonicalizeImpl();
+
   /// Return region if we have it. Will canonicalize the partition b
-  std::optional<Region> maybeGetRegion(Element elt) {
+  std::optional<Region> maybeGetRegion(Element elt) const {
     canonicalize();
     auto iter = elementToRegionMap.find(elt);
     if (iter == elementToRegionMap.end())
@@ -1237,7 +1243,13 @@ private:
   /// partition state to restore this property.
   ///
   /// This runs in linear time.
-  void canonicalize();
+  ///
+  /// Const because canonicalization only relabels regions: it never changes
+  /// which elements share a region, so it does not change what this partition
+  /// means. Being callable on a const partition lets a read-only query run
+  /// against a partition the caller does not own, instead of copying it first
+  /// just to be allowed to ask.
+  void canonicalize() const;
 
   /// Walk the elementToRegionMap updating all elements in the region of \p
   /// targetElement will be changed to now point at \p newRegion.

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -1009,7 +1009,7 @@ public:
   /// then comparing for exact equality.
   ///
   /// Runs in linear time.
-  static bool equals(Partition &fst, Partition &snd) {
+  static bool equals(const Partition &fst, const Partition &snd) {
     fst.canonicalize();
     snd.canonicalize();
 

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -608,19 +608,13 @@ Partition Partition::join(const Partition &fst, Partition &mutableSnd,
 void Partition::print(llvm::raw_ostream &os,
                       std::function<bool(llvm::raw_ostream &, Region)>
                           printRegionIsolation) const {
-  // If we are asked to printRegionIsolation, we need to canonicalize before we
-  // can get the correct regions. So, check if we are canonicalized. If we are
-  // not then we can continue printing below. Otherwise, we copy ourselves,
-  // canonicalize the copy, and then print that. We do this since the whole
-  // point of printing this type of information is to help us understand how the
-  // program flowed normally and if we canonicalize this partition to print, we
-  // would change the compiler state.
-  if (printRegionIsolation && !canonical) {
-    auto other = *this;
-    other.canonicalize();
-    other.print(os, printRegionIsolation);
-    return;
-  }
+  // Group by region, so the region numbers have to be the canonical ones or the
+  // grouping is against labels that happen to be stale. Canonicalizing is safe
+  // from a const printer: it relabels regions without changing which elements
+  // share one, so it does not change what this partition means.
+  //
+  // Use dump_labels() to see the labels as they stand instead.
+  canonicalize();
 
   SmallFrozenMultiMap<Region, Element, 8> multimap;
 
@@ -657,6 +651,9 @@ void Partition::print(llvm::raw_ostream &os,
 }
 
 void Partition::printVerbose(llvm::raw_ostream &os) const {
+  // Canonical region numbers, for the same reason as print.
+  canonicalize();
+
   SmallFrozenMultiMap<Region, Element, 8> multimap;
 
   for (auto [eltNo, regionNo] : elementToRegionMap)

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -823,7 +823,14 @@ Region Partition::merge(Element fst, Element snd, bool updateHistory) {
   return result;
 }
 
-void Partition::canonicalize() {
+void Partition::canonicalize() const {
+  // Canonicalization is a lazy normalization of the region labels, so running it
+  // from a const query does not change what the partition means. See the
+  // declaration.
+  const_cast<Partition *>(this)->canonicalizeImpl();
+}
+
+void Partition::canonicalizeImpl() {
   if (canonical)
     return;
   canonical = true;


### PR DESCRIPTION
`Partition` canonicalizes lazily. Canonicalization relabels regions so that each
region's number is the smallest element in it. It never changes which elements
share a region, so it does not change what a partition means.

Because `canonicalize()` was non-const, every query that needs it was non-const
too: `getRegion`, `areElementsInSameRegion`, `range`, and through
`maybeGetRegion` also `isSent` and `getSentOperandSet`. So a caller holding a
`const Partition` could not ask which region an element is in. It had to copy the
whole partition first — including `elementToRegionMap`, which is a `std::map`, so
one node per tracked element — just to be allowed to ask a question that reads
nothing but that map.

This PR makes the lazy normalization const and cleans up the two places that were
working around it not being const. No functional change.

This is part of a set of commits before I land isolation history.