### PR TITLE
[CS] Do not require AnyObject for foreign reference class constraints

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -16528,7 +16528,9 @@ void ConstraintSystem::addConstraint(Requirement req,
       }
     }
 
-    conformsToAnyObject = true;
+    // Native classes conform to AnyObject, but foreign reference types do not,
+    // so only imply the AnyObject requirement when the bound isn't an FRT.
+    conformsToAnyObject = !req.getSecondType()->isForeignReferenceType();
     kind = ConstraintKind::Subtype;
     break;
   }

--- a/test/Interop/Cxx/foreign-reference/Inputs/inherited-generic-argument.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/inherited-generic-argument.h
@@ -1,0 +1,24 @@
+#define IMMORTAL_FRT                                                           \
+  __attribute__((swift_attr("import_reference")))                              \
+  __attribute__((swift_attr("retain:immortal")))                              \
+  __attribute__((swift_attr("release:immortal")))
+
+struct IMMORTAL_FRT BaseObj {
+  virtual int tag() const { return 0; }
+};
+
+struct DerivedObj1 : BaseObj {
+  int tag() const override { return 1; }
+  static DerivedObj1 &make() {
+    static DerivedObj1 instance;
+    return instance;
+  }
+};
+
+struct DerivedObj2 : BaseObj {
+  int tag() const override { return 2; }
+  static DerivedObj2 &make() {
+    static DerivedObj2 instance;
+    return instance;
+  }
+};

--- a/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
+++ b/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
@@ -144,3 +144,8 @@ module VirtualMethodAttrs {
   header "virtual-methods-attrs.h"
   requires cplusplus
 }
+
+module InheritedGenericArgument {
+  header "inherited-generic-argument.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/foreign-reference/inherited-generic-argument-executable.swift
+++ b/test/Interop/Cxx/foreign-reference/inherited-generic-argument-executable.swift
@@ -1,0 +1,20 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ForeignReferenceTypeInheritance -Xfrontend -disable-availability-checking)
+
+// Miscompiles due to unrelated SIL type lowering issue
+// UNSUPPORTED: OS=linux-gnu
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_ForeignReferenceTypeInheritance
+
+import InheritedGenericArgument
+import StdlibUnittest
+
+var Tests = TestSuite("InheritedGenericArgument")
+
+func classify<T: BaseObj>(_ obj: T) -> CInt { obj.tag() }
+
+Tests.test("base-constrained generic with derived FRT argument") {
+  expectEqual(1, classify(DerivedObj1.make()))
+  expectEqual(2, classify(DerivedObj2.make()))
+}
+
+runAllTests()

--- a/test/Interop/Cxx/foreign-reference/inherited-generic-argument-executable.swift
+++ b/test/Interop/Cxx/foreign-reference/inherited-generic-argument-executable.swift
@@ -1,0 +1,18 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ForeignReferenceTypeInheritance -Xfrontend -disable-availability-checking)
+
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_ForeignReferenceTypeInheritance
+
+import InheritedGenericArgument
+import StdlibUnittest
+
+var Tests = TestSuite("InheritedGenericArgument")
+
+func classify<T: BaseObj>(_ obj: T) -> CInt { obj.tag() }
+
+Tests.test("base-constrained generic with derived FRT argument") {
+  expectEqual(1, classify(DerivedObj1.make()))
+  expectEqual(2, classify(DerivedObj2.make()))
+}
+
+runAllTests()

--- a/test/Interop/Cxx/foreign-reference/inherited-generic-argument-executable.swift
+++ b/test/Interop/Cxx/foreign-reference/inherited-generic-argument-executable.swift
@@ -1,9 +1,8 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ForeignReferenceTypeInheritance -Xfrontend -disable-availability-checking)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -Xfrontend -disable-availability-checking)
 
 // Miscompiles due to unrelated SIL type lowering issue
 // UNSUPPORTED: OS=linux-gnu
 // REQUIRES: executable_test
-// REQUIRES: swift_feature_ForeignReferenceTypeInheritance
 
 import InheritedGenericArgument
 import StdlibUnittest

--- a/test/Interop/Cxx/foreign-reference/inherited-generic-argument-executable.swift
+++ b/test/Interop/Cxx/foreign-reference/inherited-generic-argument-executable.swift
@@ -1,7 +1,6 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ForeignReferenceTypeInheritance -Xfrontend -disable-availability-checking)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -Xfrontend -disable-availability-checking)
 
 // REQUIRES: executable_test
-// REQUIRES: swift_feature_ForeignReferenceTypeInheritance
 
 import InheritedGenericArgument
 import StdlibUnittest

--- a/test/Interop/Cxx/foreign-reference/inherited-generic-argument-typechecker.swift
+++ b/test/Interop/Cxx/foreign-reference/inherited-generic-argument-typechecker.swift
@@ -1,0 +1,15 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ForeignReferenceTypeInheritance -disable-availability-checking
+
+// REQUIRES: swift_feature_ForeignReferenceTypeInheritance
+
+// Native classes conform to AnyObject, but foreign reference types do not, so a
+// base-constrained generic called with a derived FRT must not be ambiguous.
+
+import InheritedGenericArgument
+
+func add<T: BaseObj>(_ obj: T) {}
+
+func test() {
+  add(DerivedObj1.make())
+  add(DerivedObj2.make())
+}

--- a/test/Interop/Cxx/foreign-reference/inherited-generic-argument-typechecker.swift
+++ b/test/Interop/Cxx/foreign-reference/inherited-generic-argument-typechecker.swift
@@ -1,6 +1,4 @@
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ForeignReferenceTypeInheritance -disable-availability-checking
-
-// REQUIRES: swift_feature_ForeignReferenceTypeInheritance
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default -disable-availability-checking
 
 // Native classes conform to AnyObject, but foreign reference types do not, so a
 // base-constrained generic called with a derived FRT must not be ambiguous.


### PR DESCRIPTION
Lowering a superclass generic requirement (`T: Base`) also implied
`T: AnyObject`. Foreign reference types are imported as classes that do
not conform to AnyObject, so the requirement was unsatisfiable.

The first patch in this patch set skips the implied AnyObject requirement
when the superclass bound is an FRT.

Without it, the solver recovers with a fix, leaving `T = Derived` and
`T = Base` equally viable and spuriously diagnosing "conflicting
arguments to generic parameter".

rdar://183954952