### PR TITLE
MemoryLifetimeVerifier: treat opened existentials as trivial types

### DIFF
--- a/include/swift/SIL/MemoryLocations.h
+++ b/include/swift/SIL/MemoryLocations.h
@@ -141,9 +141,11 @@ public:
 
     /// True if this location should be trated as "trivial" location.
     /// This may differ from the location's type `isTrivial` property:
-    /// Conservatively treat enums and functions as trivial (even if their types
-    /// are not trivial). Memory locations of such types can be missing destroys
-    /// in case the enum is in fact a trivial case (like `Optional.none`).
+    /// Conservatively treat enums, functions and opened existentials as trivial
+    /// (even if their types are not trivial). Memory locations of such types
+    /// can be missing destroys in case the enum is in fact a trivial case (like
+    /// `Optional.none`) or the concrete type of the opened existential is
+    /// trivial.
     bool isTrivial;
 
     /// Returns true if the location with index \p idx is this location or a

--- a/lib/SIL/Utils/MemoryLocations.cpp
+++ b/lib/SIL/Utils/MemoryLocations.cpp
@@ -510,6 +510,13 @@ bool MemoryLocations::isTrivial(SILType type, SILFunction *inFunction) {
 
 bool MemoryLocations::computeIsTrivial(SILType type, SILFunction *inFunction) {
 
+  // An opened existential can be a trivial type. In case an optimization found
+  // the concrete type of the existential, it might have removed the
+  // destroy_addr of such a location, but the type is still the opened
+  // archetype.
+  if (type.is<ExistentialArchetypeType>())
+    return true;
+
   if (inFunction->getTypeProperties(type).isInfinite()) {
     return type.isTrivial(*inFunction);
   }

--- a/test/SIL/memory_lifetime.sil
+++ b/test/SIL/memory_lifetime.sil
@@ -661,6 +661,18 @@ bb0(%0 : $*U):
   return %5 : $()
 }
 
+// An optimization may have removed the destroys of opened existentials if the
+// concrete type of the existential turned out to be trivial.
+sil [ossa] @test_missing_destroys_of_opened_existential : $@convention(thin) (@in P) -> () {
+bb0(%0 : $*P):
+  %o = open_existential_addr mutable_access %0 : $*P to $*@opened(2, P) Self
+  %s = alloc_stack $@opened(2, P) Self
+  copy_addr %o to [init] %s : $*@opened(2, P) Self
+  dealloc_stack %s : $*@opened(2, P) Self
+  %r = tuple ()
+  return %r : $()
+}
+
 sil [ossa] @test_init_two_existentials : $@convention(thin) <U: P, V: P> (@in_guaranteed U, @in_guaranteed V) -> () {
 bb0(%0 : $*U, %1 : $*V):
   %s = alloc_stack $P


### PR DESCRIPTION
If an optimization found the concrete type of an opened existential and that type is trivial, it might have removed the `destroy_addr` of such a memory location while the location still has the opened archetype type. Therefore treat opened existentials conservatively as trivial - like enums and functions.

Fixes a false MemoryLifetimeVerifier error
