### PR TITLE
ClangImporter: Adjust to "[Modules] Handle decl attributes on deserialization the same as during parsing. (#208348)"

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1710,7 +1710,7 @@ std::unique_ptr<ClangImporter> ClangImporter::create(
                                                 /*SkipFunctionBodies=*/false));
 
   clangPP.EnterMainSourceFile();
-  importer->Impl.Parser->Initialize();
+  importer->Impl.Parser->ConsumeToken();
 
   importer->Impl.nameImporter.reset(new NameImporter(
       importer->Impl.SwiftContext, importer->Impl.platformAvailability,


### PR DESCRIPTION
See https://github.com/swiftlang/llvm-project/pull/13601.