### PR TITLE
LoopInvariantCodeMotion: don't hoist and sink `store [assign]`

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
@@ -227,13 +227,8 @@ private func collectMovableInstructions(
         loadInstCounter += 1
       case is UncheckedOwnershipConversionInst:
         break // TODO: Add support
-      case let storeInst as StoreInst:
-        switch storeInst.storeOwnership {
-        case .assign:
-          continue  // TODO: Add support
-        case .unqualified, .trivial, .initialize:
-          break
-        }
+      case is StoreInst:
+        break // Stores are moved out of the loop in `hoistAndSinkLoadsAndStores`
       case let condFailInst as CondFailInst:
         // We can (and must) hoist cond_fail instructions if the operand is
         // invariant. We must hoist them so that we preserve memory safety. A
@@ -322,7 +317,10 @@ private extension AnalyzedInstructions {
       switch sideEffect {
       case let storeInst as StoreInst:
         if storeInst.storesTo(accessPath) {
-          return false
+          // TODO: Add support for `store [assign]`. Moving such a store out of the loop
+          //       requires to insert a `destroy_value` for the overwritten value at the
+          //       original store location.
+          return storeInst.storeOwnership == .assign
         }
       case let loadInst as LoadInst:
         if loadInst.loadsFrom(accessPath) {

--- a/test/SILOptimizer/licm.sil
+++ b/test/SILOptimizer/licm.sil
@@ -1977,6 +1977,36 @@ bb3:
   return %r : $()
 }
 
+// Hoisting `store [assign]` is currently not supported, because it would require to
+// insert a `destroy_value` for the overwritten value at the original store location.
+// CHECK-LABEL: sil [ossa] @dont_hoist_store_assign :
+// CHECK-NOT:     load [take]
+// CHECK:       bb2:
+// CHECK:         store %{{[0-9]+}} to [assign] %2
+// CHECK:       bb3:
+// CHECK-LABEL: } // end sil function 'dont_hoist_store_assign'
+sil [ossa] @dont_hoist_store_assign : $@convention(thin) (@guaranteed String) -> () {
+bb0(%0 : @guaranteed $String):
+  %1 = alloc_box ${ var String }
+  %2 = project_box %1, 0
+  %3 = copy_value %0
+  store %3 to [init] %2
+  br bb1
+
+bb1:
+  cond_br undef, bb2, bb3
+
+bb2:
+  %6 = copy_value %0
+  store %6 to [assign] %2
+  br bb1
+
+bb3:
+  destroy_value %1
+  %r = tuple()
+  return %r : $()
+}
+
 // CHECK-LABEL: sil [ossa] @store_and_load_borrow :
 // CHECK:       bb1({{.*}}):
 // CHECK:         store %1 to [trivial]


### PR DESCRIPTION
This was accidentally enabled by 4114b28139d, which moved the collection of `loadsAndStores` from `collectMovableInstructions` (where stores with an `assign` ownership were filtered out) to the new `collectSpeculativelyMovableInstructions`, which doesn't filter at all.

`hoistAndSinkLoadAndStore` doesn't support `store [assign]`: it erases the store without destroying the overwritten value, which leaks the value coming from the SSAUpdater's phi argument Reject such access paths in `isOnlyLoadedAndStored` again and remove the now dead ownership check in `collectMovableInstructions`.

Fixes an ownership verifier error
rdar://183953843
