### PR TITLE
LoopUnroll: create borrowed_from instructions for new guaranteed phis

### DIFF
--- a/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
@@ -556,6 +556,7 @@ class LoopUnrolling : public SILFunctionTransform {
       Changed |= tryToUnrollLoop(Loop, SRA, deb);
 
     if (Changed) {
+      updateAllGuaranteedPhis(PM, Fun);
       invalidateAnalysis(SILAnalysis::InvalidationKind::FunctionBody);
       removeUnreachableBlocks(*Fun);
       if (Fun->needBreakInfiniteLoops())

--- a/test/SILOptimizer/loop_unroll_ossa.sil
+++ b/test/SILOptimizer/loop_unroll_ossa.sil
@@ -733,6 +733,45 @@ bb3:
   return %tup : $()
 }
 
+// A borrow which is live-out of the loop needs a reborrow phi in the exit
+// block. The pass must create the corresponding borrowed_from instruction.
+// CHECK-LABEL: sil [ossa] @unroll_with_guaranteed_phi :
+// CHECK:       bb{{[0-9]+}}([[OWNED:%.*]] : @owned $Klass, [[REBORROW:%.*]] : @reborrow $Klass):
+// CHECK-NEXT:    borrowed [[REBORROW]] from ([[OWNED]])
+// CHECK-LABEL: } // end sil function 'unroll_with_guaranteed_phi'
+sil [ossa] @unroll_with_guaranteed_phi : $@convention(thin) (@guaranteed Array<Klass>) -> () {
+bb0(%0 : @guaranteed $Array<Klass>):
+  %1 = integer_literal $Builtin.Int1, -1
+  %2 = struct $Bool (%1 : $Builtin.Int1)
+  %3 = integer_literal $Builtin.Int64, 0
+  %4 = integer_literal $Builtin.Int64, 2
+  %5 = integer_literal $Builtin.Int64, 1
+  %6 = function_ref @getElement : $@convention(method) (Int64, Bool, _DependenceToken, @guaranteed Array<Klass>) -> @owned Klass
+  %7 = struct $_DependenceToken ()
+  br bb1(%3 : $Builtin.Int64)
+
+bb1(%9 : $Builtin.Int64):
+  %10 = struct $Int64 (%9 : $Builtin.Int64)
+  %11 = apply %6(%10, %2, %7, %0) : $@convention(method) (Int64, Bool, _DependenceToken, @guaranteed Array<Klass>) -> @owned Klass
+  // The borrow is live out of the loop: it is ended in the exit block bb3.
+  %12 = begin_borrow %11 : $Klass
+  %13 = builtin "sadd_with_overflow_Int64"(%9 : $Builtin.Int64, %5 : $Builtin.Int64, %1 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %14 = tuple_extract %13 : $(Builtin.Int64, Builtin.Int1), 0
+  %15 = builtin "cmp_eq_Int64"(%14 : $Builtin.Int64, %4 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %15, bb3, bb2
+
+bb2:
+  end_borrow %12 : $Klass
+  destroy_value %11 : $Klass
+  br bb1(%14 : $Builtin.Int64)
+
+bb3:
+  end_borrow %12 : $Klass
+  destroy_value %11 : $Klass
+  %tup = tuple ()
+  return %tup : $()
+}
+
 // Ensure we don't trigger presence of address phis verification
 sil [ossa] @unroll_with_addr_proj1 : $@convention(thin) (@in_guaranteed WrapperStruct) -> () {
 bb0(%0 : $*WrapperStruct):


### PR DESCRIPTION
A borrow which is live-out of the loop results in a reborrow phi in the loop exit block after unrolling. Call updateAllGuaranteedPhis to create the corresponding `borrowed_from` instruction, which otherwise triggers an ownership verification error.

rdar://184013690
