### PR TITLE
[Concurrency] Fix use-after-free of function string in CheckedContinuation's deinit.

### DIFF
--- a/stdlib/public/Concurrency/CheckedContinuation.swift
+++ b/stdlib/public/Concurrency/CheckedContinuation.swift
@@ -74,7 +74,6 @@ internal final class CheckedContinuationCanary: @unchecked Sendable {
   }
 
   deinit {
-    unsafe _functionPtr.deinitialize(count: 1)
     // Log if the continuation was never consumed before the instance was
     // destructed.
     if unsafe _continuationPtr.pointee != nil {
@@ -84,6 +83,7 @@ internal final class CheckedContinuationCanary: @unchecked Sendable {
       fatalError("SWIFT TASK CONTINUATION MISUSE")
       #endif
     }
+    unsafe _functionPtr.deinitialize(count: 1)
   }
 }
 

--- a/test/Concurrency/Runtime/checked_continuation_leak_diagnostic.swift
+++ b/test/Concurrency/Runtime/checked_continuation_leak_diagnostic.swift
@@ -1,0 +1,38 @@
+// RUN: %target-run-simple-swift( -O -target %target-swift-5.1-abi-triple -parse-as-library) 2>&1 | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+// UNSUPPORTED: back_deployment_runtime
+
+// Ensure that the CheckedContinuation's function string isn't destroyed before
+// the diagnostic is printed.
+
+import _Concurrency
+
+@inline(never)
+func heapAllocatedName() -> String {
+  // Long enough to require heap storage. The random component ensures that it
+  // can't be a static string.
+  return "0123456789abcdef\(Int.random(in: 0...1))"
+}
+
+@main struct Main {
+  static func main() async {
+    for _ in 0..<50 {
+      await withUnsafeContinuation { (uc: UnsafeContinuation<Void, Never>) in
+        do {
+          let checked = unsafe CheckedContinuation(continuation: uc,
+                                                  function: heapAllocatedName())
+          _ = checked
+        }
+        unsafe uc.resume()
+      }
+    }
+
+    print("done")
+  }
+}
+
+// CHECK-COUNT-50: SWIFT TASK CONTINUATION MISUSE: 0123456789abcdef{{0|1}} leaked its continuation
+// CHECK: done


### PR DESCRIPTION
Deinitialize the string after printing the diagnostic rather than before.

Assisted-by: Claude

rdar://183451602