### PR TITLE
CMake: Add missing dependency on SwiftAtomics.py

### DIFF
--- a/Runtimes/Supplemental/Synchronization/CMakeLists.txt
+++ b/Runtimes/Supplemental/Synchronization/CMakeLists.txt
@@ -111,8 +111,14 @@ add_link_options($<$<PLATFORM_ID:Windows>:LINKER:/WX>)
 # Ensure all symbols are fully resolved on Linux
 add_link_options($<$<PLATFORM_ID:Android,Linux>:LINKER:-z,defs>)
 
-gyb_expand(Atomics/AtomicIntegers.swift.gyb Atomics/AtomicIntegers.swift)
-gyb_expand(Atomics/AtomicStorage.swift.gyb Atomics/AtomicStorage.swift)
+gyb_expand(Atomics/AtomicIntegers.swift.gyb
+  Atomics/AtomicIntegers.swift
+  DEPENDS "${SwiftSynchronization_SWIFTC_SOURCE_DIR}/utils/SwiftAtomics.py"
+)
+gyb_expand(Atomics/AtomicStorage.swift.gyb
+  Atomics/AtomicStorage.swift
+  DEPENDS "${SwiftSynchronization_SWIFTC_SOURCE_DIR}/utils/SwiftAtomics.py"
+)
 
 add_library(swiftSynchronization
   Atomics/Atomic.swift

--- a/cmake/modules/SwiftHandleGybSources.cmake
+++ b/cmake/modules/SwiftHandleGybSources.cmake
@@ -120,6 +120,7 @@ function(handle_gyb_sources dependency_out_var_name sources_var_name)
   set(gyb_extra_sources
       "${SWIFT_SOURCE_DIR}/utils/GYBUnicodeDataUtils.py"
       "${SWIFT_SOURCE_DIR}/utils/SwiftIntTypes.py"
+      "${SWIFT_SOURCE_DIR}/utils/SwiftAtomics.py"
       "${SWIFT_SOURCE_DIR}/utils/SwiftFloatingPointTypes.py"
       "${SWIFT_SOURCE_DIR}/utils/UnicodeData/GraphemeBreakProperty.txt"
       "${SWIFT_SOURCE_DIR}/utils/UnicodeData/GraphemeBreakTest.txt"


### PR DESCRIPTION
The Atomics gyb files depend on `utils/SwiftAtomics.py`. Adding the dependency edge to rebuild those files when `utils/SwiftAtomics.py` is modified.