### PR TITLE
utils: Disable CMP0215

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2107,8 +2107,6 @@ function Build-CMakeProject {
     Add-KeyValueIfNew $Defines CMAKE_POLICY_DEFAULT_CMP0181 NEW
     # Enable CMP0214: Honor CMAKE_EXE_LINKER_FLAGS for Swift executable targets.
     Add-KeyValueIfNew $Defines CMAKE_POLICY_DEFAULT_CMP0214 NEW
-    # Enable CMP0215: Ninja generators emit Swift modules separately from compilation.
-    Add-KeyValueIfNew $Defines CMAKE_POLICY_DEFAULT_CMP0215 NEW
 
     Add-KeyValueIfNew $Defines CMAKE_BUILD_TYPE Release
 


### PR DESCRIPTION
CMP0215 resulted in a 1 hour regression in the toolchain build. It seems to cause Swift modules to be built twice. This disables CMP0215 until the root cause is understood.