### PR TITLE
[6.4][stdlib] Fix Atomic.min/max using signed comparison on unsigned types

### DIFF
--- a/test/stdlib/Synchronization/Atomics/Basics/Tests.gyb-template
+++ b/test/stdlib/Synchronization/Atomics/Basics/Tests.gyb-template
@@ -352,6 +352,23 @@ suite.test("Atomic${label} ${name} ${order}") {
   expectEqual(val2.oldValue, result1)
   expectEqual(val2.newValue, result2)
   expectEqual(v.load(ordering: .relaxed), result2)
+
+  // The operands above stay in a narrow low range, where wrapping never occurs
+  // and signed and unsigned comparison agree. Repeat at the bounds of the type.
+  // https://github.com/swiftlang/swift/issues/91176
+  for extreme in [${type}.min, ${type}.max] {
+%       if name == "Min" or name == "Max":
+    let expected: ${type} = Swift.${lowerFirst(name)}(extreme, 1)
+%       else:
+    let expected: ${type} = extreme ${operator} 1
+%       end
+    let w = Atomic<${type}>(extreme)
+
+    let val3 = w.${lowerFirst(name)}(1, ordering: .${order})
+    expectEqual(val3.oldValue, extreme)
+    expectEqual(val3.newValue, expected)
+    expectEqual(w.load(ordering: .relaxed), expected)
+  }
 }
 
 %     end

--- a/utils/SwiftAtomics.py
+++ b/utils/SwiftAtomics.py
@@ -122,10 +122,14 @@ def llvmToCaseName(ordering):
         return "sequentiallyConsistent"
 
 
+# Note: 'operation' is the LLVM name from the second column of
+# integerOperations, so the comparisons below must be against the lowercase
+# spelling. Comparing against the capitalized Swift name silently selects the
+# signed builtin for unsigned types.
 def atomicOperationName(intType, operation):
-    if operation == "Min":
+    if operation == "min":
         return "umin" if intType.startswith("U") else "min"
-    if operation == "Max":
+    if operation == "max":
         return "umax" if intType.startswith("U") else "max"
     return operation
 


### PR DESCRIPTION
- **Explanation**: `Atomic.min` / `Atomic.max` lowered to the signed `atomicrmw min` / `max` for unsigned integer types. `atomicOperationName` in `utils/SwiftAtomics.py` compared its argument against the capitalized Swift operation names, while the gyb call sites pass the lowercase LLVM builtin names, so the `umin` / `umax` branches were unreachable. The `newValue` half of the returned tuple is computed with `Swift.min` / `Swift.max` and was already correct, so the two halves of the same tuple disagreed and the value left in memory was not the one reported to the caller. Comparing against the lowercase spelling selects the unsigned builtins.

- **Scope**: Unsigned `Atomic.min` / `.max` store the wrong value once an operand crosses the sign bit, and because these are `@_alwaysEmitIntoClient` the wrong instruction is baked into every binary built with the release; signed types are unaffected.

- **Issues**: https://github.com/swiftlang/swift/issues/91176

- **Original PRs**: https://github.com/swiftlang/swift/pull/91177

- **Risk**:  Low: four lines in a code generator, no compiler or ABI change, and the entire effect on generated code is a 140-line diff replacing `min` / `max` with `umin` / `umax` on unsigned types and nothing else.

- **Testing**: The integer operation tests previously used only the operands 3, 8 and 12, all below the sign bit, where signed and unsigned comparison agree. Every operation is now also exercised at `T.min` and `T.max`. Against an unfixed toolchain the new assertions fail for all five unsigned widths (10 each, `Min` and `Max` across five orderings) while every signed type and every other integer operation still passes. CI on the mainline PR passed on all six platforms, including Linux, macOS arm64 and Windows.

- **Reviewers**: Approved on the mainline PR by @lorentey and @Azoy, both code owners for the standard library.
