### PR TITLE
[Build] Add SwiftAtomics.py to gyb_extra_sources.

### DIFF
--- a/Runtimes/Core/cmake/modules/gyb.cmake
+++ b/Runtimes/Core/cmake/modules/gyb.cmake
@@ -30,6 +30,7 @@ function(gyb_expand source output)
   list(APPEND GYB_DEPENDS
     "${source}"
     "${utils_dir}/GYBUnicodeDataUtils.py"
+    "${utils_dir}/SwiftAtomics.py"
     "${utils_dir}/SwiftIntTypes.py"
     "${utils_dir}/SwiftFloatingPointTypes.py"
     "${utils_dir}/UnicodeData/GraphemeBreakProperty.txt"

--- a/Runtimes/Overlay/cmake/modules/gyb.cmake
+++ b/Runtimes/Overlay/cmake/modules/gyb.cmake
@@ -30,6 +30,7 @@ function(gyb_expand source output)
   list(APPEND GYB_DEPENDS
     "${source}"
     "${utils_dir}/GYBUnicodeDataUtils.py"
+    "${utils_dir}/SwiftAtomics.py"
     "${utils_dir}/SwiftIntTypes.py"
     "${utils_dir}/SwiftFloatingPointTypes.py"
     "${utils_dir}/UnicodeData/GraphemeBreakProperty.txt"

--- a/Runtimes/Supplemental/cmake/modules/gyb.cmake
+++ b/Runtimes/Supplemental/cmake/modules/gyb.cmake
@@ -30,6 +30,7 @@ function(gyb_expand source output)
   list(APPEND GYB_DEPENDS
     "${source}"
     "${utils_dir}/GYBUnicodeDataUtils.py"
+    "${utils_dir}/SwiftAtomics.py"
     "${utils_dir}/SwiftIntTypes.py"
     "${utils_dir}/SwiftFloatingPointTypes.py"
     "${utils_dir}/UnicodeData/GraphemeBreakProperty.txt"

--- a/cmake/modules/SwiftHandleGybSources.cmake
+++ b/cmake/modules/SwiftHandleGybSources.cmake
@@ -119,6 +119,7 @@ function(handle_gyb_sources dependency_out_var_name sources_var_name)
   set(de_gybbed_sources)
   set(gyb_extra_sources
       "${SWIFT_SOURCE_DIR}/utils/GYBUnicodeDataUtils.py"
+      "${SWIFT_SOURCE_DIR}/utils/SwiftAtomics.py"
       "${SWIFT_SOURCE_DIR}/utils/SwiftIntTypes.py"
       "${SWIFT_SOURCE_DIR}/utils/SwiftFloatingPointTypes.py"
       "${SWIFT_SOURCE_DIR}/utils/UnicodeData/GraphemeBreakProperty.txt"


### PR DESCRIPTION
This flags that gybs need to be regenerated when SwiftAtomics.py changes, avoiding stale generated sources in incremental builds.