### PR TITLE
[Concurrency] Remove the public Swift declarations for actor entry points.

### DIFF
--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -256,8 +256,6 @@ IDENTIFIER(arrayLiteral)
 IDENTIFIER(dictionaryLiteral)
 IDENTIFIER(className)
 
-IDENTIFIER(_defaultActorInitialize)
-IDENTIFIER(_defaultActorDestroy)
 IDENTIFIER(unownedExecutor)
 
 IDENTIFIER_(ErrorType)

--- a/stdlib/public/Concurrency/Actor.swift
+++ b/stdlib/public/Concurrency/Actor.swift
@@ -74,22 +74,6 @@ public protocol Actor: AnyObject, Sendable {
   nonisolated var unownedExecutor: UnownedSerialExecutor { get }
 }
 
-/// Called to initialize the default actor instance in an actor.
-/// The implementation will call this within the actor's initializer.
-@available(SwiftStdlib 5.1, *)
-@_silgen_name("swift_defaultActor_initialize")
-public func _defaultActorInitialize(_ actor: AnyObject)
-
-@available(SwiftStdlib 5.9, *)
-@_silgen_name("swift_nonDefaultDistributedActor_initialize")
-public func _nonDefaultDistributedActorInitialize(_ actor: AnyObject)
-
-/// Called to destroy the default actor instance in an actor.
-/// The implementation will call this within the actor's deinit.
-@available(SwiftStdlib 5.1, *)
-@_silgen_name("swift_defaultActor_destroy")
-public func _defaultActorDestroy(_ actor: AnyObject)
-
 @available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_enqueueMainExecutor")
 @usableFromInline

--- a/test/api-digester/stability-concurrency-abi.test
+++ b/test/api-digester/stability-concurrency-abi.test
@@ -138,6 +138,12 @@ Func TaskLocal.get() has mangled name changing from '_Concurrency.TaskLocal.get(
 Func _taskIsCancelled(_:) has mangled name changing from '_Concurrency._taskIsCancelled(Builtin.NativeObject) -> Swift.Bool' to '_Concurrency._taskIsCancelled(_Concurrency._AsyncTask) -> Swift.Bool'
 Func _taskIsCancelled(_:) has parameter 0 type change from Builtin.NativeObject to _Concurrency._AsyncTask
 
+// These were @_silgen_name declarations of the default-actor runtime entry
+// points. The compiler emits calls directly to the C symbols. They shouldn't be
+// called manually, so they've been removed.
+Func _defaultActorDestroy(_:) has been removed
+Func _defaultActorInitialize(_:) has been removed
+
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)
 
 


### PR DESCRIPTION
Swift declarations for `swift_defaultActor_{initialize,destroy}` and `swift_nonDefaultDistributedActor_initialize` took `AnyObject`, but they assume the argument is an actor. Swift code could pass a non-actor object and trigger memory-unsafe behavior. These declarations are not necessary, as the compiler emits calls directly to the C symbols.

rdar://183452343