### PR TITLE
[cherry-pick][ci] limit parallel link jobs in buildbot_linux_base to 4 (#88888)

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -940,6 +940,10 @@ llvm-cmake-options=
   -DCROSS_TOOLCHAIN_FLAGS_LLVM_NATIVE='-DCMAKE_C_COMPILER=clang;-DCMAKE_CXX_COMPILER=clang++'
   -DCLANG_DEFAULT_LINKER=gold
 
+# Limit link jobs to prevent OOM on newer linux platforms when building lldb tests
+lldb-extra-cmake-args=
+  -DLLVM_PARALLEL_LINK_JOBS=4
+
 [preset: buildbot_linux]
 mixin-preset=
     mixin_lightweight_assertions,no-stdlib-asserts


### PR DESCRIPTION
Cherry picking #88888 as we bring up more platforms for 6.4.x

- **Explanation**: Cherry picking #88888 as we bring up more platforms for 6.4.x to prevent OOM issues when building new platforms

- **Scope**:  Simply changes the linux build preset with a cmake flag

- **Issues**: NA

- **Original PRs**: #88888 

- **Risk**:  Very low.

- **Testing**: We run this on main in our CI builds and works fine
