### PR TITLE
Windows: adjust build process

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -853,8 +853,7 @@ enum Project {
 
   EarlySwiftDriver
   EarlySwiftDriverSQLite
-  Stage0Compilers
-  Stage0XML2
+  CompilerXML2
   BootstrapRuntime
   BootstrapOverlay
   BootstrapRuntimeModule
@@ -877,7 +876,6 @@ enum Project {
 
   CDispatch
   Stage2Compilers
-  Stage2XML2
   Compilers
   FoundationMacros
   TestingMacros
@@ -1764,19 +1762,6 @@ function Get-PinnedToolchainToolsDir() {
 }
 
 function Get-PinnedToolchainSDK([OS] $OS = $BuildPlatform.OS, [string] $Identifier = $OS.ToString()) {
-  # NOTE: the pinned snapshot ships TWO SDKs side-by-side:
-  #   * `<OS>.sdk`             — built with library evolution ON (resilient)
-  #   * `<OS>Experimental.sdk` — built with library evolution OFF
-  # The single `swiftCore.dll` shipped under `Runtimes/<ver>/usr/bin/` is the
-  # resilient one.  Compiler-build callers (whose binaries dynamically load
-  # that DLL) MUST link against `<OS>.sdk` — linking against the non-resilient
-  # swiftmodule leads to runtime metadata-state mismatches (e.g. `swift_check
-  # MetadataState` illegal-instruction faulting on `DecodingError.Context`
-  # during plugin JSON message decoding).
-  #
-  # Static-stdlib clients of pinned (Build-EarlySwiftDriver) opt explicitly
-  # into `<OS>Experimental.sdk` and don't load the runtime DLL, so the
-  # resilience mismatch doesn't reach them.
   return [IO.Path]::Combine("$BinaryCache\", "toolchains", $ToolchainVersionIdentifier,
     "LocalApp", "Programs", "Swift", "Platforms", $PinnedVersion,
     "$($OS.ToString()).platform", "Developer", "SDKs", "$Identifier.sdk")
@@ -1889,58 +1874,6 @@ $Compilers = @{
     }
   }
 
-  Stage0 = @{
-    C = @{
-      Executable        = [IO.Path]::Combine((Get-ProjectToolchainBin $BuildPlatform Stage0Compilers), "clang-cl.exe")
-      DriverStyle       = [DriverStyle]::ClangCL
-      Flags             = @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:inline")
-      DebugFlags        = { param([string] $Format)
-        if ($Format -eq "dwarf") { @("-clang:-gdwarf") } else { @() }
-      }
-      AssumeFunctional  = $true
-    }
-
-    CXX = @{
-      Executable        = [IO.Path]::Combine((Get-ProjectToolchainBin $BuildPlatform Stage0Compilers), "clang-cl.exe")
-      DriverStyle       = [DriverStyle]::ClangCL
-      Flags             = @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:inline", "/Zc:__cplusplus")
-      DebugFlags        = { param([string] $Format)
-        if ($Format -eq "dwarf") { @("-clang:-gdwarf") } else { @() }
-      }
-      AssumeFunctional  = $true
-    }
-
-    GNUC = @{
-      Executable        = [IO.Path]::Combine((Get-ProjectToolchainBin $BuildPlatform Stage0Compilers), "clang.exe")
-      DriverStyle       = [DriverStyle]::GNU
-      Flags             = @("-fno-stack-protector", "-ffunction-sections", "-fdata-sections", "-fomit-frame-pointer", "-finline-functions")
-      DebugFlags        = { param([string] $Format)
-        if ($Format -eq "dwarf") { @("-gdwarf") } else { @("-gcodeview") }
-      }
-      AssumeFunctional  = $true
-    }
-
-    GNUCXX = @{
-      Executable        = [IO.Path]::Combine((Get-ProjectToolchainBin $BuildPlatform Stage0Compilers), "clang++.exe")
-      DriverStyle       = [DriverStyle]::GNU
-      Flags             = @("-fno-stack-protector", "-ffunction-sections", "-fdata-sections", "-fomit-frame-pointer", "-finline-functions")
-      DebugFlags        = { param([string] $Format)
-        if ($Format -eq "dwarf") { @("-gdwarf") } else { @("-gcodeview") }
-      }
-      AssumeFunctional  = $true
-    }
-
-    Swift = @{
-      Executable        = [IO.Path]::Combine((Get-ProjectToolchainBin $BuildPlatform Stage0Compilers), "swiftc.exe")
-      DriverStyle       = [DriverStyle]::Swift
-      Flags             = @()
-      DebugFlags        = { param([string] $Format)
-        @("-g", "-debug-info-format=${Format}")
-      }
-      AssumeFunctional  = $true
-    }
-  }
-
   Stage1 = @{
     C = @{
       Executable        = [IO.Path]::Combine((Get-ProjectToolchainBin $BuildPlatform Stage1Compilers), "clang-cl.exe")
@@ -2008,16 +1941,6 @@ $Assemblers = @{
       if ($Format -eq "dwarf") { @("-clang:-gdwarf") } else { @("-clang:-gcodeview") }
     }
     AssumeFunctional  = $false
-  }
-
-  Stage0 = @{
-    Executable        = [IO.Path]::Combine((Get-ProjectToolchainBin $BuildPlatform Stage0Compilers), "clang-cl.exe")
-    DriverStyle       = [DriverStyle]::ClangCL
-    Flags             = @()
-    DebugFlags        = { param([string] $Format)
-      if ($Format -eq "dwarf") { @("-clang:-gdwarf") } else { @("-clang:-gcodeview") }
-    }
-    AssumeFunctional  = $true
   }
 
   Stage1 = @{
@@ -2594,8 +2517,7 @@ function Copy-CMarkRuntimeToToolchain([Hashtable] $Platform, [string] $Toolchain
 
 function Copy-WindowsRuntimeToToolchain([Hashtable] $Platform,
                                         [string]    $ToolchainRoot,
-                                        [string]    $RuntimeLocation,
-                                        [switch]    $PrivateSxSRuntime) {
+                                        [string]    $RuntimeLocation) {
   if ($Platform.OS -ne [OS]::Windows) {
     return
   }
@@ -2607,20 +2529,16 @@ function Copy-WindowsRuntimeToToolchain([Hashtable] $Platform,
   $BinDir = [IO.Path]::Combine($ToolchainRoot, "usr", "bin")
   New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
 
-  $RuntimeFiles = if ($PrivateSxSRuntime) {
-    @(
-      Get-ChildItem -Path $RuntimeLocation -Directory |
-        ForEach-Object {
-          $DLL = Join-Path $_.FullName "$($_.Name).dll"
-          if (Test-Path $DLL -PathType Leaf) {
-            Get-Item $DLL
-          }
-        } |
-        Sort-Object Name
-    )
-  } else {
-    @(Get-ChildItem -Path $RuntimeLocation -File | Sort-Object Name)
-  }
+  $RuntimeFiles = @(
+    Get-ChildItem -Path $RuntimeLocation -Directory |
+      ForEach-Object {
+        $DLL = Join-Path $_.FullName "$($_.Name).dll"
+        if (Test-Path $DLL -PathType Leaf) {
+          Get-Item $DLL
+        }
+      } |
+      Sort-Object Name
+  )
   $DLLCount = @($RuntimeFiles | Where-Object { $_.Extension -ieq ".dll" }).Count
   if ($DLLCount -eq 0) {
     throw "Copy-WindowsRuntimeToToolchain: no DLLs found under '$RuntimeLocation'."
@@ -2877,7 +2795,6 @@ function Build-Compilers([Hashtable] $Platform,
                          [string]    $SwiftSDK         = (Get-PinnedToolchainSDK -OS $Platform.OS),
                          [string]    $ToolchainRoot    = "$(Get-InstallDir $Platform)\Toolchains\$ProductVersion+$Variant",
                          [string]    $RuntimeLocation  = $null,
-                         [switch]    $PrivateSxSRuntime,
                          [string]    $DispatchPackage  = $null,
                          [string]    $CacheScript      = "$SourceCache\swift\cmake\caches\Windows-$($Platform.Architecture.LLVMName).cmake") {
   New-Item -ItemType Directory -Path $BinaryCache\$($HostPlatform.Triple) -ErrorAction Ignore | Out-Null
@@ -2897,7 +2814,7 @@ function Build-Compilers([Hashtable] $Platform,
 
   Copy-CMarkRuntimeToToolchain $Platform $ToolchainRoot
   if ($RuntimeLocation) {
-    Copy-WindowsRuntimeToToolchain $Platform $ToolchainRoot $RuntimeLocation -PrivateSxSRuntime:$PrivateSxSRuntime
+    Copy-WindowsRuntimeToToolchain $Platform $ToolchainRoot $RuntimeLocation
   }
 }
 
@@ -5694,50 +5611,27 @@ if ($Toolchain) {
   Invoke-BuildStep Build-SQLite $BuildPlatform -CCompiler $Compilers.Host.C -Phase EarlySwiftDriver
   Invoke-BuildStep Build-EarlySwiftDriver $BuildPlatform
 
-  # ── Stage0 Compiler ───────────────────────────────────────────────────────
-  Invoke-BuildStep Build-XML2 $BuildPlatform -CCompiler $Compilers.Host.C -CXXCompiler $Compilers.Host.CXX -Phase "Stage0"
-  Invoke-BuildStep Build-Compilers $BuildPlatform -Variant "Asserts" -Project Stage0Compilers @{
-    CacheScript     = "$SourceCache\swift\cmake\caches\Windows-Bootstrap-Stage0-$($BuildPlatform.Architecture.LLVMName).cmake";
+  # ── Stage1 Compiler ───────────────────────────────────────────────────────
+  Invoke-BuildStep Build-XML2 $BuildPlatform -CCompiler $Compilers.Host.C -CXXCompiler $Compilers.Host.CXX -Phase "Bootstrap"
+  Invoke-BuildStep Build-Compilers $BuildPlatform -Variant "Asserts" -Project Stage1Compilers @{
+    CacheScript     = "$SourceCache\swift\cmake\caches\Windows-Bootstrap-Stage1-$($BuildPlatform.Architecture.LLVMName).cmake";
     CCompiler       = $Compilers.Host.C;
     CXXCompiler     = $Compilers.Host.CXX;
     SwiftCompiler   = $Compilers.Pinned.Swift;
     SwiftSDK        = Get-PinnedToolchainSDK -OS $BuildPlatform.OS;
-    ToolchainRoot   = Get-ProjectToolchainRoot $BuildPlatform Stage0Compilers;
-    RuntimeLocation = Get-PinnedToolchainToolsDir;
-    PrivateSxSRuntime = $true;
-  }
-
-  # ── Bootstrap SDK ─────────────────────────────────────────────────────────
-  Invoke-BuildStep Build-SDK $BuildPlatform -Context @{
-    SDKIdentifier         = "Bootstrap";
-    Variant               = "Bootstrap";
-    Compilers             = $Compilers.Stage0;
-    Static                = $false;
-    BuildFoundation       = $false;
-    InstallRuntimeToStage = $false;
-    SupplementalRuntimes  = @("StringProcessing");
-  }
-
-  # ── Stage1 Compiler ───────────────────────────────────────────────────────
-  Invoke-BuildStep Build-Compilers $BuildPlatform -Variant "Asserts" -Project Stage1Compilers @{
-    CacheScript     = "$SourceCache\swift\cmake\caches\Windows-Bootstrap-Stage1-$($BuildPlatform.Architecture.LLVMName).cmake";
-    CCompiler       = $Compilers.Stage0.C;
-    CXXCompiler     = $Compilers.Stage0.CXX;
-    SwiftCompiler   = $Compilers.Stage0.Swift;
-    SwiftSDK        = Get-SwiftSDK -OS $BuildPlatform.OS -Identifier Bootstrap;
     ToolchainRoot   = Get-ProjectToolchainRoot $BuildPlatform Stage1Compilers;
-    RuntimeLocation = Get-SDKRuntimeBin $BuildPlatform (Get-SwiftSDK -OS $BuildPlatform.OS -Identifier Bootstrap) $false;
+    RuntimeLocation = Get-PinnedToolchainToolsDir;
   }
 
   # ── Host Platform SDK ─────────────────────────────────────────────────────
   Invoke-BuildStep Build-BootstrapFoundationMacros $BuildPlatform @{
-    SwiftCompiler   = $Compilers.Stage0.Swift;
-    SwiftSDK        = (Get-SwiftSDK -OS $BuildPlatform.OS -Identifier Bootstrap);
+    SwiftCompiler   = $Compilers.Pinned.Swift;
+    SwiftSDK        = Get-PinnedToolchainSDK -OS $BuildPlatform.OS;
     SwiftSyntax_DIR = (Get-ProjectCMakeModules $BuildPlatform Stage1Compilers);
   }
   Invoke-BuildStep Build-BootstrapTestingMacros $BuildPlatform @{
-    SwiftCompiler   = $Compilers.Stage0.Swift;
-    SwiftSDK        = (Get-SwiftSDK -OS $BuildPlatform.OS -Identifier Bootstrap);
+    SwiftCompiler   = $Compilers.Pinned.Swift;
+    SwiftSDK        = Get-PinnedToolchainSDK -OS $BuildPlatform.OS;
     SwiftSyntax_DIR = (Get-ProjectCMakeModules $BuildPlatform Stage1Compilers);
   }
 
@@ -5752,7 +5646,7 @@ if ($Toolchain) {
 
   # ── Stage2 Compiler ───────────────────────────────────────────────────────
   Invoke-BuildStep Build-CMark $HostPlatform
-  Invoke-BuildStep Build-XML2 $HostPlatform -CCompiler $Compilers.Stage1.C -CXXCompiler $Compilers.Stage1.CXX -Phase "Stage2"
+  Invoke-BuildStep Build-XML2 $HostPlatform -CCompiler $Compilers.Stage1.C -CXXCompiler $Compilers.Stage1.CXX -Phase "Compiler"
   Invoke-BuildStep Build-Compilers $HostPlatform -Variant "Asserts" -Project Stage2Compilers @{
     CCompiler       = $Compilers.Stage1.C;
     CXXCompiler     = $Compilers.Stage1.CXX;

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -259,14 +259,14 @@ if ($UseHostToolchain -is [string]) {
 
 $DefaultPinned = @{
   AMD64 = @{
-    PinnedBuild = "https://download.swift.org/development/windows10/swift-DEVELOPMENT-SNAPSHOT-2026-03-16-a/swift-DEVELOPMENT-SNAPSHOT-2026-03-16-a-windows10.exe";
-    PinnedSHA256 = "34C90B5535A2D137C874A12D591201D2C3E324FB437CE51B6D057B8A8BA2CC4E";
-    PinnedVersion = "0.0.0";
+    PinnedBuild = "https://download.swift.org/swift-6.4.x-branch/windows10/swift-6.4.x-DEVELOPMENT-SNAPSHOT-2026-08-01-a/swift-6.4.x-DEVELOPMENT-SNAPSHOT-2026-08-01-a-windows10.exe";
+    PinnedSHA256 = "C9C3E64A05E5ED0857C2DF5B099113251F326CE73A05E1C88D0AB6F8EFE04BA2";
+    PinnedVersion = "6.4.0";
   };
   ARM64 = @{
-    PinnedBuild = "https://download.swift.org/development/windows10-arm64/swift-DEVELOPMENT-SNAPSHOT-2026-03-16-a/swift-DEVELOPMENT-SNAPSHOT-2026-03-16-a-windows10-arm64.exe"
-    PinnedSHA256 = "A60198647128269812AA00179801725BBD58D714AE52F2D19E7D0133DC035BF2";
-    PinnedVersion = "0.0.0";
+    PinnedBuild = "https://download.swift.org/swift-6.4.x-branch/windows10-arm64/swift-6.4.x-DEVELOPMENT-SNAPSHOT-2026-08-01-a/swift-6.4.x-DEVELOPMENT-SNAPSHOT-2026-08-01-a-windows10-arm64.exe"
+    PinnedSHA256 = "9481876E76B42A4FFA7B5394EA47C664FA899CBD6F1986E4770E8D9F3E21F773";
+    PinnedVersion = "6.4.0";
   };
 }
 
@@ -970,15 +970,13 @@ function Get-TargetInfo([Hashtable] $Platform) {
   # Cache the result of "swiftc -print-target-info" as $Platform.Cache.TargetInfo
   $CacheKey = "TargetInfo"
   if (-not $Platform.Cache.ContainsKey($CacheKey)) {
-    [void](Invoke-IsolatingEnvVars {
-      $env:Path = "$(Get-PinnedToolchainRuntime);$(Get-PinnedToolchainToolsDir);${env:Path}"
-      $TargetInfo = & swiftc -target $Platform.Triple -print-target-info
-      if ($LastExitCode -ne 0) {
-        throw "Unable to print target info for '$($Platform.Triple)'"
-      }
-      $TargetInfo = $TargetInfo | ConvertFrom-JSON
-      $Platform.Cache[$CacheKey] = $TargetInfo.target
-    })
+    $SwiftCompiler = Join-Path (Get-PinnedToolchainToolsDir) "swiftc.exe"
+    $TargetInfo = & $SwiftCompiler -target $Platform.Triple -print-target-info
+    if ($LastExitCode -ne 0) {
+      throw "Unable to print target info for '$($Platform.Triple)'"
+    }
+    $TargetInfo = $TargetInfo | ConvertFrom-JSON
+    $Platform.Cache[$CacheKey] = $TargetInfo.target
   }
   return $Platform.Cache[$CacheKey]
 }
@@ -1583,16 +1581,14 @@ function Get-Dependencies {
 
       # Write-Output "Extracting '$InstallerExeName' ..."
 
-      # The new runtime MSI is built to expand files into the immediate directory. So, setup the installation location.
-      New-Item -ItemType Directory -ErrorAction Ignore $BinaryCache\toolchains\$ToolchainName\LocalApp\Programs\Swift\Runtimes\$PinnedVersion\usr\bin | Out-Null
       Invoke-WithDotNetRuntime {
         Invoke-Program (Get-DotNet) "$($WiX.Path)\wix.dll" -- burn extract -acceptEula $WiX.EulaIdentifier $BinaryCache\$InstallerExeName -out $BinaryCache\toolchains\ -outba $BinaryCache\toolchains\
       }
+      New-Item -ItemType Directory -Path $destination -Force | Out-Null
       subst X: "$BinaryCache\toolchains\$ToolchainName"
       Get-ChildItem "$BinaryCache\toolchains\WixAttachedContainer" -Filter "*.msi" | ForEach-Object {
         $LogFile = [System.IO.Path]::ChangeExtension($_.Name, "log")
-        $TARGETDIR = if ($_.Name -eq "rtl.msi") { "X:\LocalApp\Programs\Swift\Runtimes\$PinnedVersion\usr\bin" } else { "X:\" }
-        Invoke-Program -OutNull msiexec.exe /lvx! $BinaryCache\toolchains\$LogFile /qn /a $BinaryCache\toolchains\WixAttachedContainer\$($_.Name) ALLUSERS=0 TARGETDIR=$TARGETDIR
+        Invoke-Program -OutNull msiexec.exe /lvx! $BinaryCache\toolchains\$LogFile /qn /a $BinaryCache\toolchains\WixAttachedContainer\$($_.Name) ALLUSERS=0 TARGETDIR=X:\
       }
       subst /d X:
     }
@@ -1784,12 +1780,6 @@ function Get-PinnedToolchainSDK([OS] $OS = $BuildPlatform.OS, [string] $Identifi
   return [IO.Path]::Combine("$BinaryCache\", "toolchains", $ToolchainVersionIdentifier,
     "LocalApp", "Programs", "Swift", "Platforms", $PinnedVersion,
     "$($OS.ToString()).platform", "Developer", "SDKs", "$Identifier.sdk")
-}
-
-function Get-PinnedToolchainRuntime() {
-  return [IO.Path]::Combine("$BinaryCache\", "toolchains", $ToolchainVersionIdentifier,
-    "LocalApp", "Programs", "Swift", "Runtimes", $PinnedVersion,
-    "usr", "bin")
 }
 
 function Add-KeyValueIfNew([hashtable]$Hashtable, [string]$Key, [string]$Value) {
@@ -2604,7 +2594,8 @@ function Copy-CMarkRuntimeToToolchain([Hashtable] $Platform, [string] $Toolchain
 
 function Copy-WindowsRuntimeToToolchain([Hashtable] $Platform,
                                         [string]    $ToolchainRoot,
-                                        [string]    $RuntimeLocation) {
+                                        [string]    $RuntimeLocation,
+                                        [switch]    $PrivateSxSRuntime) {
   if ($Platform.OS -ne [OS]::Windows) {
     return
   }
@@ -2616,7 +2607,20 @@ function Copy-WindowsRuntimeToToolchain([Hashtable] $Platform,
   $BinDir = [IO.Path]::Combine($ToolchainRoot, "usr", "bin")
   New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
 
-  $RuntimeFiles = @(Get-ChildItem -Path $RuntimeLocation -File | Sort-Object Name)
+  $RuntimeFiles = if ($PrivateSxSRuntime) {
+    @(
+      Get-ChildItem -Path $RuntimeLocation -Directory |
+        ForEach-Object {
+          $DLL = Join-Path $_.FullName "$($_.Name).dll"
+          if (Test-Path $DLL -PathType Leaf) {
+            Get-Item $DLL
+          }
+        } |
+        Sort-Object Name
+    )
+  } else {
+    @(Get-ChildItem -Path $RuntimeLocation -File | Sort-Object Name)
+  }
   $DLLCount = @($RuntimeFiles | Where-Object { $_.Extension -ieq ".dll" }).Count
   if ($DLLCount -eq 0) {
     throw "Copy-WindowsRuntimeToToolchain: no DLLs found under '$RuntimeLocation'."
@@ -2670,36 +2674,30 @@ function Build-BuildTools([Hashtable] $Platform) {
 }
 
 function Build-EarlySwiftDriver([Hashtable] $Platform) {
-  # `-static-stdlib` requires static-stdlib content under `lib/swift_static/`,
-  # which only the experimental SDK in pinned ships; the resilient `Windows
-  # .sdk` only has the dynamic stdlib.  Hence the explicit `-Identifier`.
-  Invoke-IsolatingEnvVars {
-    $env:Path = "$(Get-PinnedToolchainRuntime);${env:Path}"
-    Build-CMakeProject `
-      -Src $SourceCache\swift-driver `
-      -Bin (Get-ProjectBinaryCache $Platform EarlySwiftDriver) `
-      -Platform $Platform `
-      -CCompiler $Compilers.Pinned.C `
-      -CXXCompiler $Compilers.Pinned.CXX `
-      -SwiftCompiler $Compilers.Pinned.Swift `
-      -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS -Identifier "$($Platform.OS)Experimental") `
-      -BuildTargets default `
-      -Defines @{
-        BUILD_SHARED_LIBS = "NO";
-        BUILD_TESTING = "NO";
-        CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
-        # TODO(compnerd) - remove `-Xfrontend -use-static-resource-dir` - this is inferred by the `-static-stdlib`.
-        CMAKE_Swift_FLAGS = @("-static-stdlib", "-Xfrontend", "-use-static-resource-dir");
-        SWIFT_DRIVER_BUILD_TOOLS = "NO";
-        SQLite3_INCLUDE_DIR = "$SourceCache\swift-toolchain-sqlite\Sources\CSQLite\include";
-        SQLite3_LIBRARY = "$(Get-ProjectBinaryCache $Platform EarlySwiftDriverSQLite)\SQLite3.lib";
+  Build-CMakeProject `
+    -Src $SourceCache\swift-driver `
+    -Bin (Get-ProjectBinaryCache $Platform EarlySwiftDriver) `
+    -Platform $Platform `
+    -CCompiler $Compilers.Pinned.C `
+    -CXXCompiler $Compilers.Pinned.CXX `
+    -SwiftCompiler $Compilers.Pinned.Swift `
+    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS) `
+    -BuildTargets default `
+    -Defines @{
+      BUILD_SHARED_LIBS = "NO";
+      BUILD_TESTING = "NO";
+      CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
+      # TODO(compnerd) - remove `-Xfrontend -use-static-resource-dir` - this is inferred by the `-static-stdlib`.
+      CMAKE_Swift_FLAGS = @("-static-stdlib", "-Xfrontend", "-use-static-resource-dir");
+      SWIFT_DRIVER_BUILD_TOOLS = "NO";
+      SQLite3_INCLUDE_DIR = "$SourceCache\swift-toolchain-sqlite\Sources\CSQLite\include";
+      SQLite3_LIBRARY = "$(Get-ProjectBinaryCache $Platform EarlySwiftDriverSQLite)\SQLite3.lib";
 
-        # Prevent re-cloning the sources
-        FETCHCONTENT_SOURCE_DIR_ARGUMENTPARSER = "$SourceCache\swift-argument-parser";
-        FETCHCONTENT_SOURCE_DIR_LLBUILD = "$SourceCache\llbuild";
-        FETCHCONTENT_SOURCE_DIR_TOOLSSUPPORTCORE = "$SourceCache\swift-tools-support-core";
-      }
-  }
+      # Prevent re-cloning the sources
+      FETCHCONTENT_SOURCE_DIR_ARGUMENTPARSER = "$SourceCache\swift-argument-parser";
+      FETCHCONTENT_SOURCE_DIR_LLBUILD = "$SourceCache\llbuild";
+      FETCHCONTENT_SOURCE_DIR_TOOLSSUPPORTCORE = "$SourceCache\swift-tools-support-core";
+    }
 }
 
 function Write-PList {
@@ -2879,32 +2877,27 @@ function Build-Compilers([Hashtable] $Platform,
                          [string]    $SwiftSDK         = (Get-PinnedToolchainSDK -OS $Platform.OS),
                          [string]    $ToolchainRoot    = "$(Get-InstallDir $Platform)\Toolchains\$ProductVersion+$Variant",
                          [string]    $RuntimeLocation  = $null,
+                         [switch]    $PrivateSxSRuntime,
                          [string]    $DispatchPackage  = $null,
                          [string]    $CacheScript      = "$SourceCache\swift\cmake\caches\Windows-$($Platform.Architecture.LLVMName).cmake") {
   New-Item -ItemType Directory -Path $BinaryCache\$($HostPlatform.Triple) -ErrorAction Ignore | Out-Null
 
-  Invoke-IsolatingEnvVars {
-    if ($SwiftCompiler -and $SwiftCompiler.Executable -eq $Compilers.Pinned.Swift.Executable) {
-      $env:Path = "$(Get-PinnedToolchainRuntime);${env:Path}"
-    }
-
-    Build-CMakeProject `
-      -Src $SourceCache\llvm-project\llvm `
-      -Bin (Get-ProjectBinaryCache $Platform $Project) `
-      -InstallTo "$ToolchainRoot\usr" `
-      -Platform $Platform `
-      -CCompiler $CCompiler `
-      -CXXCompiler $CXXCompiler `
-      -SwiftCompiler $SwiftCompiler `
-      -SwiftSDK $SwiftSDK `
-      -BuildTargets @("install-distribution") `
-      -CacheScript $CacheScript `
-      -Defines (Get-CompilersDefines $Platform $Variant -SwiftSDK $SwiftSDK -DispatchPackage $DispatchPackage)
-  }
+  Build-CMakeProject `
+    -Src $SourceCache\llvm-project\llvm `
+    -Bin (Get-ProjectBinaryCache $Platform $Project) `
+    -InstallTo "$ToolchainRoot\usr" `
+    -Platform $Platform `
+    -CCompiler $CCompiler `
+    -CXXCompiler $CXXCompiler `
+    -SwiftCompiler $SwiftCompiler `
+    -SwiftSDK $SwiftSDK `
+    -BuildTargets @("install-distribution") `
+    -CacheScript $CacheScript `
+    -Defines (Get-CompilersDefines $Platform $Variant -SwiftSDK $SwiftSDK -DispatchPackage $DispatchPackage)
 
   Copy-CMarkRuntimeToToolchain $Platform $ToolchainRoot
   if ($RuntimeLocation) {
-    Copy-WindowsRuntimeToToolchain $Platform $ToolchainRoot $RuntimeLocation
+    Copy-WindowsRuntimeToToolchain $Platform $ToolchainRoot $RuntimeLocation -PrivateSxSRuntime:$PrivateSxSRuntime
   }
 }
 
@@ -5710,7 +5703,8 @@ if ($Toolchain) {
     SwiftCompiler   = $Compilers.Pinned.Swift;
     SwiftSDK        = Get-PinnedToolchainSDK -OS $BuildPlatform.OS;
     ToolchainRoot   = Get-ProjectToolchainRoot $BuildPlatform Stage0Compilers;
-    RuntimeLocation = Get-PinnedToolchainRuntime;
+    RuntimeLocation = Get-PinnedToolchainToolsDir;
+    PrivateSxSRuntime = $true;
   }
 
   # ── Bootstrap SDK ─────────────────────────────────────────────────────────


### PR DESCRIPTION
This pull request makes significant changes to the Windows toolchain bootstrap process in `utils/build.ps1`, simplifying the build stages and updating the toolchain to a newer Swift 6.4 snapshot. The main focus is on removing the "Stage0" bootstrap compiler and SDK, streamlining the build to use the pinned toolchain directly for early build steps, and updating related logic and references.

**Toolchain Update:**
* Updated the pinned toolchain to use the Swift 6.4 development snapshot (2026-08-01) for both AMD64 and ARM64, with new download URLs, SHA256 hashes, and version numbers.

**Bootstrap Process Simplification:**
* Removed all logic, build steps, and configuration related to the "Stage0" compiler and SDK, including the `Stage0Compilers` project, Stage0 entries in `$Compilers` and `$Assemblers`, and Stage0 build steps. The build now starts with the pinned toolchain for early steps and proceeds directly to building the Stage1 compiler. [[1]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L856-R856) [[2]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L880) [[3]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L1902-L1953) [[4]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L2023-L2032) [[5]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L5704-R5633)

**Project and Build Step Refactoring:**
* Renamed or repurposed project phases: replaced `Stage0XML2` with `CompilerXML2`, and updated XML2 build phases to align with the new bootstrap process. [[1]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L856-R856) [[2]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L5761-R5648)
* Updated build steps for FoundationMacros and TestingMacros to use the pinned toolchain's Swift compiler and SDK instead of Stage0.

**SDK and Runtime Handling:**
* Removed the experimental SDK selection and related comments, standardizing on the resilient SDK for all compiler builds. Simplified how the runtime is extracted and used during the build. [[1]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L1771-L1794) [[2]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L1586-R1588) [[3]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L2673-R2601) [[4]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L2886-L2890) [[5]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L2903)

**Miscellaneous Improvements:**
* Improved runtime DLL discovery logic in `Copy-WindowsRuntimeToToolchain` to reliably find and copy the correct DLLs.
* Simplified environment variable handling for toolchain paths during build steps. [[1]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L973-L981) [[2]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L2673-R2601) [[3]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L2886-L2890)

These changes modernize and streamline the Windows Swift toolchain bootstrap, reducing complexity and potential points of failure.