### PR TITLE
Revert "[stdlib] Fix Atomic.min/max using signed comparison on unsigned types"

### DIFF
--- a/test/stdlib/Synchronization/Atomics/Basics/Tests.gyb-template
+++ b/test/stdlib/Synchronization/Atomics/Basics/Tests.gyb-template
@@ -352,23 +352,6 @@ suite.test("Atomic${label} ${name} ${order}") {
   expectEqual(val2.oldValue, result1)
   expectEqual(val2.newValue, result2)
   expectEqual(v.load(ordering: .relaxed), result2)
-
-  // The operands above stay in a narrow low range, where wrapping never occurs
-  // and signed and unsigned comparison agree. Repeat at the bounds of the type.
-  // https://github.com/swiftlang/swift/issues/91176
-  for extreme in [${type}.min, ${type}.max] {
-%       if name == "Min" or name == "Max":
-    let expected: ${type} = Swift.${lowerFirst(name)}(extreme, 1)
-%       else:
-    let expected: ${type} = extreme ${operator} 1
-%       end
-    let w = Atomic<${type}>(extreme)
-
-    let val3 = w.${lowerFirst(name)}(1, ordering: .${order})
-    expectEqual(val3.oldValue, extreme)
-    expectEqual(val3.newValue, expected)
-    expectEqual(w.load(ordering: .relaxed), expected)
-  }
 }
 
 %     end

--- a/utils/SwiftAtomics.py
+++ b/utils/SwiftAtomics.py
@@ -122,14 +122,10 @@ def llvmToCaseName(ordering):
         return "sequentiallyConsistent"
 
 
-# Note: 'operation' is the LLVM name from the second column of
-# integerOperations, so the comparisons below must be against the lowercase
-# spelling. Comparing against the capitalized Swift name silently selects the
-# signed builtin for unsigned types.
 def atomicOperationName(intType, operation):
-    if operation == "min":
+    if operation == "Min":
         return "umin" if intType.startswith("U") else "min"
-    if operation == "max":
+    if operation == "Max":
         return "umax" if intType.startswith("U") else "max"
     return operation
 


### PR DESCRIPTION
This reverts https://github.com/swiftlang/swift/pull/91177 because it is causing failures in PR smoke testing.
