### PR TITLE
[DebugInfo] Rework how alignment is emitted

### DIFF
--- a/lib/IRGen/DebugTypeInfo.cpp
+++ b/lib/IRGen/DebugTypeInfo.cpp
@@ -26,36 +26,25 @@
 using namespace swift;
 using namespace irgen;
 
-DebugTypeInfo::DebugTypeInfo(swift::Type Ty, Alignment Align,
-                             bool HasDefaultAlignment, bool IsMetadata,
-                             bool IsFixedBuffer,
+DebugTypeInfo::DebugTypeInfo(swift::Type Ty, std::optional<Alignment> Align,
+                             bool IsMetadata, bool IsFixedBuffer,
                              std::optional<uint32_t> NumExtraInhabitants)
     : Type(Ty.getPointer()), NumExtraInhabitants(NumExtraInhabitants),
-      Align(Align), DefaultAlignment(HasDefaultAlignment),
-      IsMetadataType(IsMetadata), IsFixedBuffer(IsFixedBuffer) {
-  assert(Align.getValue() != 0);
-}
-
-/// Determine whether this type has an attribute specifying a custom alignment.
-static bool hasDefaultAlignment(swift::Type Ty) {
-  if (auto CanTy = Ty->getCanonicalType())
-    if (auto *TyDecl = CanTy.getNominalOrBoundGenericNominal())
-      if (TyDecl->getAttrs().getAttribute<AlignmentAttr>()
-          || TyDecl->getAttrs().getAttribute<RawLayoutAttr>())
-        return false;
-  return true;
+      Align(Align), IsMetadataType(IsMetadata), IsFixedBuffer(IsFixedBuffer) {
+  assert((!Align || Align->getValue() != 0) && "zero alignment");
 }
 
 DebugTypeInfo DebugTypeInfo::getFromTypeInfo(swift::Type Ty, const TypeInfo &TI,
                                              IRGenModule &IGM) {
   std::optional<uint32_t> NumExtraInhabitants;
+  std::optional<Alignment> Align;
   if (TI.isFixedSize()) {
     const FixedTypeInfo &FixTy = *cast<const FixedTypeInfo>(&TI);
     NumExtraInhabitants = FixTy.getFixedExtraInhabitantCount(IGM);
+    Align = FixTy.getFixedAlignment();
   }
   assert(TI.getStorageType() && "StorageType is a nullptr");
-  return DebugTypeInfo(Ty.getPointer(), TI.getBestKnownAlignment(),
-                       ::hasDefaultAlignment(Ty),
+  return DebugTypeInfo(Ty.getPointer(), Align,
                        /* IsMetadataType = */ false,
                        /* IsFixedBuffer = */ false, NumExtraInhabitants);
 }
@@ -82,7 +71,6 @@ DebugTypeInfo DebugTypeInfo::getLocalVariable(VarDecl *Decl, swift::Type Ty,
 DebugTypeInfo DebugTypeInfo::getGlobalMetadata(swift::Type Ty, Size size,
                                                Alignment align) {
   DebugTypeInfo DbgTy(Ty.getPointer(), align,
-                      /* HasDefaultAlignment = */ true,
                       /* IsMetadataType = */ false);
   assert(!DbgTy.isContextArchetype() &&
          "type metadata cannot contain an archetype");
@@ -92,7 +80,6 @@ DebugTypeInfo DebugTypeInfo::getGlobalMetadata(swift::Type Ty, Size size,
 DebugTypeInfo DebugTypeInfo::getTypeMetadata(swift::Type Ty, Size size,
                                              Alignment align) {
   DebugTypeInfo DbgTy(Ty.getPointer(), align,
-                      /* HasDefaultAlignment = */ true,
                       /* IsMetadataType = */ true);
   assert(!DbgTy.isContextArchetype() &&
          "type metadata cannot contain an archetype");
@@ -135,7 +122,7 @@ DebugTypeInfo DebugTypeInfo::getGlobalFixedBuffer(SILGlobalVariable *GV,
                                                   Alignment Align,
                                                   IRGenModule &IGM) {
   auto *Type = getTypeForGlobal(GV, IGM);
-  DebugTypeInfo DbgTy(Type, Align, ::hasDefaultAlignment(Type),
+  DebugTypeInfo DbgTy(Type, Align,
                       /* IsMetadataType = */ false, /* IsFixedBuffer = */ true);
   assert(!DbgTy.isContextArchetype() &&
          "type of global variable cannot be an archetype");
@@ -145,7 +132,6 @@ DebugTypeInfo DebugTypeInfo::getGlobalFixedBuffer(SILGlobalVariable *GV,
 DebugTypeInfo DebugTypeInfo::getObjCClass(ClassDecl *theClass, Size SizeInBytes,
                                           Alignment align) {
   DebugTypeInfo DbgTy(theClass->getInterfaceType().getPointer(), align,
-                      /* HasDefaultAlignment = */ true,
                       /* IsMetadataType = */ false);
   assert(!DbgTy.isContextArchetype() &&
          "type of objc class cannot be an archetype");
@@ -185,7 +171,10 @@ LLVM_DUMP_METHOD void DebugTypeInfo::dump() const {
   llvm::errs() << "[";
   if (isForwardDecl())
     llvm::errs() << "forward ";
-  llvm::errs() << "Alignment " << Align.getValue() << "] ";
+  if (Align)
+    llvm::errs() << "Alignment " << Align->getValue() << "] ";
+  else
+    llvm::errs() << "Alignment unknown] ";
   if (auto *Type = getType())
     Type->dump(llvm::errs());
 }

--- a/lib/IRGen/DebugTypeInfo.h
+++ b/lib/IRGen/DebugTypeInfo.h
@@ -44,17 +44,17 @@ protected:
   /// Needed to determine the size of basic types and to determine
   /// the storage type for undefined variables.
   std::optional<uint32_t> NumExtraInhabitants;
-  Alignment Align;
-  bool DefaultAlignment = true;
+  /// The alignment of the type, if it is known.
+  std::optional<Alignment> Align;
   bool IsMetadataType = false;
   bool IsFixedBuffer = false;
   bool IsForwardDecl = false;
 
 public:
   DebugTypeInfo() = default;
-  DebugTypeInfo(swift::Type Ty, Alignment AlignInBytes = Alignment(1),
-                bool HasDefaultAlignment = true, bool IsMetadataType = false,
-                bool IsFixedBuffer = false,
+  DebugTypeInfo(swift::Type Ty,
+                std::optional<Alignment> AlignInBytes = std::nullopt,
+                bool IsMetadataType = false, bool IsFixedBuffer = false,
                 std::optional<uint32_t> NumExtraInhabitants = {});
 
   /// Create type for a local variable.
@@ -96,10 +96,13 @@ public:
     return false;
   }
 
-  Alignment getAlignment() const { return Align; }
+  std::optional<Alignment> getAlignment() const { return Align; }
+  /// The alignment in bits, or 0 when the alignment isn't known.
+  unsigned getAlignInBits(unsigned BitsPerByte) const {
+    return Align ? Align->getValue() * BitsPerByte : 0;
+  }
   bool isNull() const { return !Type; }
   bool isMetadataType() const { return IsMetadataType; }
-  bool hasDefaultAlignment() const { return DefaultAlignment; }
   bool isFixedBuffer() const { return IsFixedBuffer; }
   bool isForwardDecl() const { return IsForwardDecl; }
   std::optional<uint32_t> getNumExtraInhabitants() const {
@@ -147,8 +150,7 @@ template <> struct DenseMapInfo<swift::irgen::DebugTypeInfo> {
   }
   static swift::irgen::DebugTypeInfo getTombstoneKey() {
     return swift::irgen::DebugTypeInfo(
-        llvm::DenseMapInfo<swift::TypeBase *>::getTombstoneKey(),
-        swift::irgen::Alignment(), /* HasDefaultAlignment = */ false);
+        llvm::DenseMapInfo<swift::TypeBase *>::getTombstoneKey());
   }
   static unsigned getHashValue(swift::irgen::DebugTypeInfo Val) {
     return DenseMapInfo<swift::CanType>::getHashValue(Val.getType());

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1198,6 +1198,15 @@ private:
 
   unsigned getByteSize() { return CI.getTargetInfo().getCharWidth(); }
 
+  /// The alignment to record in the debug info for \p DbgTy, in bits, or 0 to
+  /// record none. The DWARF emitter checks for a 0 and omits DW_AT_alignment 
+  /// in that case.
+  unsigned getAlignInBits(DebugTypeInfo DbgTy) {
+    if (Opts.DebugInfoLevel <= IRGenDebugInfoLevel::ASTTypes)
+      return 0;
+    return DbgTy.getAlignInBits(getByteSize());
+  }
+
   llvm::DICompositeType *createStructType(
       NominalOrBoundGenericNominalType *Type, NominalTypeDecl *Decl,
       llvm::DIScope *Scope, llvm::DIFile *File, unsigned Line,
@@ -1218,8 +1227,7 @@ private:
                     IGM.getSILTypes().getAbstractionPattern(VD), memberTy),
                 IGM)) {
           MemberTypes.emplace_back(VD->getName().str(),
-                                   getByteSize() *
-                                       DbgTy->getAlignment().getValue(),
+                                   getAlignInBits(*DbgTy),
                                    getOrCreateType(*DbgTy));
           anchorTypeAliasesIn(memberTy);
         } else {
@@ -1279,7 +1287,7 @@ private:
                 IGM.getSILTypes().getAbstractionPattern(VD), memberTy),
             IGM);
         MemberTypes.emplace_back(VD->getName().str(),
-                                 getByteSize() * DbgTy.getAlignment().getValue(),
+                                 getAlignInBits(DbgTy),
                                  getOrCreateType(DbgTy));
         anchorTypeAliasesIn(memberTy);
       }
@@ -1531,8 +1539,7 @@ private:
             wrapInReferenceTypeIfIndirect(PayloadDITy, ElemDecl, Decl);
 
         MemberTypes.emplace_back(ElemDecl->getBaseIdentifier().str(),
-                                 getByteSize() *
-                                     ElemDbgTy->getAlignment().getValue(),
+                                 getAlignInBits(*ElemDbgTy),
                                  TrackingDIType(PayloadDITy));
         anchorTypeAliasesIn(PayloadTy);
       } else {
@@ -1593,8 +1600,7 @@ private:
             wrapInReferenceTypeIfIndirect(PayloadDITy, ElemDecl, Decl);
 
         MemberTypes.emplace_back(ElemDecl->getBaseIdentifier().str(),
-                                 getByteSize() *
-                                     ElemDbgTy->getAlignment().getValue(),
+                                 getAlignInBits(*ElemDbgTy),
                                  TrackingDIType(PayloadDITy));
         anchorTypeAliasesIn(PayloadTy);
       } else {
@@ -1636,9 +1642,9 @@ private:
   }
 
   llvm::DIType *getOrCreateDesugaredType(Type Ty, DebugTypeInfo DbgTy) {
-    DebugTypeInfo BlandDbgTy(
-        Ty, DbgTy.getAlignment(), DbgTy.hasDefaultAlignment(), false,
-        DbgTy.isFixedBuffer(), DbgTy.getNumExtraInhabitants());
+    DebugTypeInfo BlandDbgTy(Ty, DbgTy.getAlignment(), false,
+                             DbgTy.isFixedBuffer(),
+                             DbgTy.getNumExtraInhabitants());
     return getOrCreateType(BlandDbgTy);
   }
 
@@ -1869,8 +1875,7 @@ private:
           AbstractionPattern(genericSig, ElemTy->getCanonicalType()), ElemTy);
       auto DbgTy =
             DebugTypeInfo::getFromTypeInfo(ElemTy, elemTI, IGM);
-      MemberTypes.emplace_back("",
-                               getByteSize() * DbgTy.getAlignment().getValue(),
+      MemberTypes.emplace_back("", getAlignInBits(DbgTy),
                                getOrCreateType(DbgTy));
     }
     SmallVector<llvm::Metadata *, 16> Members;
@@ -1948,16 +1953,13 @@ private:
     // in the LLVM IR. For all types that are boxed in a struct, we are
     // emitting the storage size of the struct, but it may be necessary
     // to emit the (target!) size of the underlying basic type.
-    uint64_t SizeOfByte = CI.getTargetInfo().getCharWidth();
     std::optional<CompletedDebugTypeInfo> CompletedDbgTy = completeType(DbgTy);
     std::optional<uint64_t> SizeInBitsOrNull;
     if (CompletedDbgTy)
       SizeInBitsOrNull = CompletedDbgTy->getSizeInBits();
 
     uint64_t SizeInBits = SizeInBitsOrNull.value_or(0);
-    unsigned AlignInBits = DbgTy.hasDefaultAlignment()
-                               ? 0
-                               : DbgTy.getAlignment().getValue() * SizeOfByte;
+    unsigned AlignInBits = getAlignInBits(DbgTy);
     unsigned Encoding = 0;
     uint32_t NumExtraInhabitants = DbgTy.getNumExtraInhabitants().value_or(0);
 
@@ -2466,10 +2468,10 @@ private:
 
       // For TypeAlias types, the DeclContext for the aliased type is
       // in the decl of the alias type.
-      DebugTypeInfo AliasedDbgTy(
-          AliasedTy, DbgTy.getAlignment(), DbgTy.hasDefaultAlignment(),
-          /* IsMetadataType = */ false, DbgTy.isFixedBuffer(),
-          DbgTy.getNumExtraInhabitants());
+      DebugTypeInfo AliasedDbgTy(AliasedTy, DbgTy.getAlignment(),
+                                 /* IsMetadataType = */ false,
+                                 DbgTy.isFixedBuffer(),
+                                 DbgTy.getNumExtraInhabitants());
       auto *TypeDef = DBuilder.createTypedef(getOrCreateType(AliasedDbgTy),
                                              MangledName, L.File, 0, Scope);
       // Bound generic types don't reference their type parameters in ASTTypes

--- a/test/DebugInfo/alignment.swift
+++ b/test/DebugInfo/alignment.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir -gdwarf-types -o - | %FileCheck %s
 
 @_alignment(8)
 // CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "S8"
@@ -15,3 +15,31 @@ enum E16 {
 
 var s: S8
 var e: E16
+
+// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "MultiPayload"
+// CHECK-SAME:             size: 40, align: 32,
+enum MultiPayload {
+  case a(Int32)
+  case b(Bool)
+  case c
+}
+
+
+// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "SameAlignAsSize"
+// CHECK-SAME:             size: 64, align: 64,
+struct SameAlignAsSize { var x: Int64 }
+
+// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "Empty"
+// CHECK-NOT: size:
+// CHECK-SAME: align: 8,
+struct Empty {}
+
+// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "ZeroSizedPayload"
+// CHECK-NOT: size:
+// CHECK-SAME: align: 8,
+enum ZeroSizedPayload { case a(Empty) }
+
+var m: MultiPayload
+var a: SameAlignAsSize
+var t: Empty
+var z: ZeroSizedPayload

--- a/test/DebugInfo/classes.swift
+++ b/test/DebugInfo/classes.swift
@@ -6,7 +6,7 @@ class SomeClass {
 }
 
 // CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "SomeClass", 
-// CHECK-SAME: size: {{64|32}}, elements: 
+// CHECK-SAME: size: {{64|32}}, align: {{64|32}}, elements:
 // CHECK-SAME: runtimeLang: DW_LANG_Swift,{{.*}} identifier: "$s7classes9SomeClassCD")
 
 // CHECK: !DIDerivedType(tag: DW_TAG_member, name: "first",

--- a/test/DebugInfo/enum.swift
+++ b/test/DebugInfo/enum.swift
@@ -11,7 +11,7 @@ enum Either {
 // CHECK-SAME:             size: {{328|168}},
 
 // DWARF: !DICompositeType(tag: DW_TAG_structure_type, name: "Either",
-// DWARF-SAME:             size: {{328|168}}, num_extra_inhabitants: 253,
+// DWARF-SAME:             size: {{328|168}}, align: 64, num_extra_inhabitants: 253,
 // DWARF-SAME:             identifier: "$s4enum6EitherOD")
 
 // DWARF: !DICompositeType(tag: DW_TAG_variant_part

--- a/test/DebugInfo/raw_layout.swift
+++ b/test/DebugInfo/raw_layout.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -enable-experimental-feature RawLayout -emit-ir -g -o - | %FileCheck %s
+// RUN: %target-swift-frontend %s -enable-experimental-feature RawLayout -emit-ir -gdwarf-types -o - | %FileCheck %s
 
 // REQUIRES: swift_feature_RawLayout
 

--- a/test/DebugInfo/value-generics-embedded.swift
+++ b/test/DebugInfo/value-generics-embedded.swift
@@ -14,7 +14,7 @@
 
 // CHECK-DAG: ![[ELTS]] = !{![[STORAGE_MEMBER:.*]]}
 // CHECK-DAG: ![[STORAGE_MEMBER]] = !DIDerivedType(tag: DW_TAG_member, name: "_storage",{{.*}}baseType: ![[ARRAY:[0-9]+]], size: 64
-// CHECK-DAG: ![[ARRAY]] = !DICompositeType(tag: DW_TAG_array_type, baseType: ![[ELEMENT_TYPE]], size: 64, elements: ![[SUBRANGES:[0-9]+]])
+// CHECK-DAG: ![[ARRAY]] = !DICompositeType(tag: DW_TAG_array_type, baseType: ![[ELEMENT_TYPE]], size: 64, align: 64, elements: ![[SUBRANGES:[0-9]+]])
 // CHECK-DAG: ![[SUBRANGES]] = !{![[DIM:[0-9]+]]}
 // CHECK-DAG: ![[DIM]] = !DISubrange(count: 1)
 


### PR DESCRIPTION
Currently, an alignment is only emitted if a type is annotated with the @_alignment or @_rawLayout attributes. This is an issue for LLDB for several reasons:
- It cannot tell if a missing alignment means that its the type's natural alignment or if it's a type whose alignment is not computable (such as an unsepcialized generic).
- Even if it could tell, computing the alignment of Swift types is not trivial.

This patch changes how we emit the alignment in the following ways:
- in -g, never emit the alignment (we don't need it anyway).
- in -gdwarf-types, always emit the alignment if known.

This way LLDB can properly disambiguate between the cases.

Assisted-by: claude

rdar://184055269
