### PR TITLE
Reapply "[stdlib] Fix Atomic.min/max using signed comparison on unsig…

### DIFF
--- a/test/stdlib/Synchronization/Atomics/Basics/Tests.gyb-template
+++ b/test/stdlib/Synchronization/Atomics/Basics/Tests.gyb-template
@@ -352,6 +352,23 @@ suite.test("Atomic${label} ${name} ${order}") {
   expectEqual(val2.oldValue, result1)
   expectEqual(val2.newValue, result2)
   expectEqual(v.load(ordering: .relaxed), result2)
+
+  // The operands above stay in a narrow low range, where wrapping never occurs
+  // and signed and unsigned comparison agree. Repeat at the bounds of the type.
+  // https://github.com/swiftlang/swift/issues/91176
+  for extreme in [${type}.min, ${type}.max] {
+%       if name == "Min" or name == "Max":
+    let expected: ${type} = Swift.${lowerFirst(name)}(extreme, 1)
+%       else:
+    let expected: ${type} = extreme ${operator} 1
+%       end
+    let w = Atomic<${type}>(extreme)
+
+    let val3 = w.${lowerFirst(name)}(1, ordering: .${order})
+    expectEqual(val3.oldValue, extreme)
+    expectEqual(val3.newValue, expected)
+    expectEqual(w.load(ordering: .relaxed), expected)
+  }
 }
 
 %     end

--- a/utils/SwiftAtomics.py
+++ b/utils/SwiftAtomics.py
@@ -122,10 +122,14 @@ def llvmToCaseName(ordering):
         return "sequentiallyConsistent"
 
 
+# Note: 'operation' is the LLVM name from the second column of
+# integerOperations, so the comparisons below must be against the lowercase
+# spelling. Comparing against the capitalized Swift name silently selects the
+# signed builtin for unsigned types.
 def atomicOperationName(intType, operation):
-    if operation == "Min":
+    if operation == "min":
         return "umin" if intType.startswith("U") else "min"
-    if operation == "Max":
+    if operation == "max":
         return "umax" if intType.startswith("U") else "max"
     return operation
 


### PR DESCRIPTION
…ned types" (#91239)

This reverts commit a846b165d9d48d63fabde4c7054fa19414971f96.

The changes in this commit broke CI, so it was reverted in https://github.com/swiftlang/swift/pull/91239, but we also merged https://github.com/swiftlang/swift/pull/91223 which should resolve those issues.