### PR TITLE
Add noalias attribute to all inout parameters

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -354,9 +354,7 @@ static void addInoutParameterAttributes(IRGenModule &IGM, SILType paramSILType,
   llvm::AttrBuilder b(IGM.getLLVMContext());
   // Thanks to exclusivity checking, it is not possible to alias inouts except
   // those that are inout_aliasable.
-  if (!aliasable && paramSILType.getASTType()->getAnyPointerElementType()) {
-    // To ward against issues with LLVM's alias analysis, for now, only add the
-    // attribute if it's a pointer being passed inout.
+  if (!aliasable) {
     b.addAttribute(llvm::Attribute::NoAlias);
   }
   // Bitwise takable value types are guaranteed not to capture

--- a/test/DebugInfo/move_function_dbginfo_async.swift
+++ b/test/DebugInfo/move_function_dbginfo_async.swift
@@ -93,7 +93,7 @@ public func letSimpleTest<T>(_ msg: __owned T) async {
 }
 
 // CHECK-LABEL: define swifttailcc void @"$s27move_function_dbginfo_async13varSimpleTestyyxz_xtYalF"(
-// CHECK-SAME:     ptr swiftasync %[[frame_ptr:.*]], ptr %1, ptr noalias %2, ptr %T)
+// CHECK-SAME:     ptr swiftasync %[[frame_ptr:.*]], ptr noalias %1, ptr noalias %2, ptr %T)
 // CHECK:   %[[frame_ptr_alloca:.*]] = alloca ptr,
 // CHECK:   store ptr %[[frame_ptr]], ptr %[[frame_ptr_alloca]]
 // CHECK:   #dbg_value(ptr %[[frame_ptr_alloca]], !{{[0-9]+}}, !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_deref)

--- a/test/DebugInfo/yielding_mutate.swift
+++ b/test/DebugInfo/yielding_mutate.swift
@@ -29,7 +29,7 @@ FINISH()
 
 
 // CHECK-LABEL: define {{.*}} @{{.*}}computed_property
-// CHECK-SAME:  ptr swiftself {{.*}} %[[self:.*]])
+// CHECK-SAME:  ptr noalias swiftself {{.*}} %[[self:.*]])
 // CHECK: %[[self_alloca:.*]] = alloca ptr
 // CHECK: #dbg_declare(ptr %[[self_alloca]], ![[SELF_DBG:.*]], !DIExpression(DW_OP_deref)
 // CHECK: call {{.*}} @llvm.coro.begin

--- a/test/Distributed/distributed_actor_accessor_thunks_64bit.swift
+++ b/test/Distributed/distributed_actor_accessor_thunks_64bit.swift
@@ -94,7 +94,7 @@ public distributed actor MyOtherActor {
 
 // CHECK: define hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple1yySiYaKFTE"
 
-// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple1yySiYaKFTETF"(ptr swiftasync %0, ptr %1, ptr %2, ptr %3, {{.*}}, ptr [[ACTOR:%.*]], ptr [[DECODER_TYPE:%.*]], ptr [[DECODER_PROTOCOL_WITNESS:%.*]])
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple1yySiYaKFTETF"(ptr swiftasync %0, ptr noalias %1, ptr %2, ptr %3, {{.*}}, ptr [[ACTOR:%.*]], ptr [[DECODER_TYPE:%.*]], ptr [[DECODER_PROTOCOL_WITNESS:%.*]])
 
 /// Read the current offset and cast an element to `Int`
 
@@ -194,7 +194,7 @@ public distributed actor MyOtherActor {
 // CHECK: define hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple3ySiSSYaKFTE"
 
 /// !!! in `simple3` interesting bits are: argument value extraction (because string is exploded into N arguments) and call to distributed thunk
-// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple3ySiSSYaKFTETF"(ptr swiftasync %0, ptr [[ARG_DECODER:%.*]], ptr [[ARG_TYPES:%.*]], ptr [[RESULT_BUFF:%.*]], ptr [[SUBS:%.*]], ptr [[WITNESS_TABLES:%.*]], i64 [[NUM_WITNESS_TABLES:%.*]], ptr [[ACTOR]], ptr [[DECODER_TYPE:%.*]], ptr [[DECODER_PROTOCOL_WITNESS:%.*]])
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple3ySiSSYaKFTETF"(ptr swiftasync %0, ptr noalias [[ARG_DECODER:%.*]], ptr [[ARG_TYPES:%.*]], ptr [[RESULT_BUFF:%.*]], ptr [[SUBS:%.*]], ptr [[WITNESS_TABLES:%.*]], i64 [[NUM_WITNESS_TABLES:%.*]], ptr [[ACTOR]], ptr [[DECODER_TYPE:%.*]], ptr [[DECODER_PROTOCOL_WITNESS:%.*]])
 
 
 // CHECK: [[ARG_SIZE:%.*]] = and i64 {{.*}}, -16
@@ -235,7 +235,7 @@ public distributed actor MyOtherActor {
 
 // CHECK: define hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC16single_case_enumyAA7SimpleEOAFYaKFTE"
 
-// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC16single_case_enumyAA7SimpleEOAFYaKFTETF"(ptr swiftasync %0, ptr [[ARG_DECODER:%.*]], ptr [[ARG_TYPES:%.*]], ptr [[RESULT_BUFF:%.*]], ptr [[SUBS:%.*]], ptr [[WITNESS_TABLES:%.*]], i64 [[NUM_WITNESS_TABLES:%.*]], ptr [[ACTOR]], ptr [[DECODER_TYPE]], ptr [[DECODER_PROTOCOL_WITNESS:%.*]])
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC16single_case_enumyAA7SimpleEOAFYaKFTETF"(ptr swiftasync %0, ptr noalias [[ARG_DECODER:%.*]], ptr [[ARG_TYPES:%.*]], ptr [[RESULT_BUFF:%.*]], ptr [[SUBS:%.*]], ptr [[WITNESS_TABLES:%.*]], i64 [[NUM_WITNESS_TABLES:%.*]], ptr [[ACTOR]], ptr [[DECODER_TYPE]], ptr [[DECODER_PROTOCOL_WITNESS:%.*]])
 
 /// Let's check that the call doesn't have any arguments and returns nothing.
 
@@ -276,7 +276,7 @@ public distributed actor MyOtherActor {
 
 // CHECK: define hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7complexyAA11LargeStructVSaySiG_AA3ObjCSSSgAFtYaKFTE"
 
-// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7complexyAA11LargeStructVSaySiG_AA3ObjCSSSgAFtYaKFTETF"(ptr swiftasync {{.*}}, ptr [[ARG_DECODER:%.*]], ptr [[ARG_TYPES:%.*]], ptr [[RESULT_BUFF:%.*]], ptr [[SUBS:%.*]], ptr [[WITNESS_TABLES:%.*]], i64 [[NUM_WITNESS_TABLES:%.*]], ptr [[DECODER_TYPE:%.*]], ptr [[DECODER_PROTOCOL_WITNESS:%.*]])
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7complexyAA11LargeStructVSaySiG_AA3ObjCSSSgAFtYaKFTETF"(ptr swiftasync {{.*}}, ptr noalias [[ARG_DECODER:%.*]], ptr [[ARG_TYPES:%.*]], ptr [[RESULT_BUFF:%.*]], ptr [[SUBS:%.*]], ptr [[WITNESS_TABLES:%.*]], i64 [[NUM_WITNESS_TABLES:%.*]], ptr [[DECODER_TYPE:%.*]], ptr [[DECODER_PROTOCOL_WITNESS:%.*]])
 
 /// First, let's check that all of the different argument types here are loaded correctly.
 
@@ -323,7 +323,7 @@ public distributed actor MyOtherActor {
 
 /// ---> Accessor for `genericArgs`
 
-// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC11genericArgsyyx_Sayq_GtYaKSeRzSERzSeR_SER_r0_lFTETF"(ptr swiftasync %0, ptr  [[ARG_DECODER:%.*]], ptr [[ARG_TYPES:%.*]], ptr [[RESULT_BUF:%.*]], ptr [[GENERIC_SUBS:%.*]], ptr [[WITNESS_TABLES:%.*]], i64 [[NUM_WITNESS_TABLES:%.*]], ptr [[ACTOR:%.*]], ptr [[DECODER_TYPE:%.*]], ptr [[DECODER_PROTOCOL_WITNESS:%.*]])
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC11genericArgsyyx_Sayq_GtYaKSeRzSERzSeR_SER_r0_lFTETF"(ptr swiftasync %0, ptr  noalias [[ARG_DECODER:%.*]], ptr [[ARG_TYPES:%.*]], ptr [[RESULT_BUF:%.*]], ptr [[GENERIC_SUBS:%.*]], ptr [[WITNESS_TABLES:%.*]], i64 [[NUM_WITNESS_TABLES:%.*]], ptr [[ACTOR:%.*]], ptr [[DECODER_TYPE:%.*]], ptr [[DECODER_PROTOCOL_WITNESS:%.*]])
 
 /// ---> Load `T`
 
@@ -372,7 +372,7 @@ public distributed actor MyOtherActor {
 
 /// Let's check that there is argument decoding since parameter list is empty
 
-// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors12MyOtherActorC5emptyyyYaKFTETF"(ptr swiftasync {{.*}}, ptr [[ARG_DECODER:%.*]], ptr [[ARG_TYPES:%.*]], ptr [[RESULT_BUFF:%.*]], ptr [[SUBS:%.*]], ptr [[WITNESS_TABLES:%.*]], i64 [[NUM_WITNESS_TABLES:%.*]], ptr {{.*}}, ptr [[DECODER_TYPE:%.*]], ptr [[DECODER_PROTOCOL_WITNESS:%.*]])
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors12MyOtherActorC5emptyyyYaKFTETF"(ptr swiftasync {{.*}}, ptr noalias [[ARG_DECODER:%.*]], ptr [[ARG_TYPES:%.*]], ptr [[RESULT_BUFF:%.*]], ptr [[SUBS:%.*]], ptr [[WITNESS_TABLES:%.*]], i64 [[NUM_WITNESS_TABLES:%.*]], ptr {{.*}}, ptr [[DECODER_TYPE:%.*]], ptr [[DECODER_PROTOCOL_WITNESS:%.*]])
 // CHECK-NEXT: entry:
 // CHECK-NEXT: {{.*}} = alloca ptr
 // CHECK-NEXT: %swifterror = alloca swifterror ptr

--- a/test/IRGen/access_markers.sil
+++ b/test/IRGen/access_markers.sil
@@ -95,7 +95,7 @@ sil @testPairedBox : $(@guaranteed { var () }) -> () {
 bb0(%0 : ${ var () }):
   // CHECK: entry:
   %2 = project_box %0 : ${ var () }, 0
-  //  CHECK-NEXT: call {{.*}}void @writeEmptyTuple(ptr captures(none) undef)
+  //  CHECK-NEXT: call {{.*}}void @writeEmptyTuple(ptr noalias captures(none) undef)
   %3 = begin_access [modify] [dynamic] %2 : $*()
   %write_fn = function_ref @writeEmptyTuple : $@convention(thin) (@inout ()) -> ()
   apply %write_fn(%3) : $@convention(thin) (@inout ()) -> ()

--- a/test/IRGen/addressable.swift
+++ b/test/IRGen/addressable.swift
@@ -28,7 +28,7 @@ public func testAddressableIn(_ holder: Holder) -> NE {
 
 // The parameter cannot be 'captures(none)'.
 //
-// CHECK-LABEL: define{{.*}} swiftcc void @"$s1A20testAddressableInoutyAA2NEVAA6HolderVzF"(ptr %0)
+// CHECK-LABEL: define{{.*}} swiftcc void @"$s1A20testAddressableInoutyAA2NEVAA6HolderVzF"(ptr noalias %0)
 public func testAddressableInout(_ holder: inout Holder) -> NE {
   getMutNE(&holder)
 }

--- a/test/IRGen/argument_attrs.sil
+++ b/test/IRGen/argument_attrs.sil
@@ -4,49 +4,49 @@ import Builtin
 
 struct Huge { var x, y, z, w, a, b, c, d, e, f: Builtin.Int32 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @arguments_in_def(ptr captures(none) dereferenceable(4) %0, ptr noalias captures(none) dereferenceable(4) %1, ptr noalias captures(none) dereferenceable(4) %2, ptr noalias captures(none) dereferenceable(40) %3, ptr noalias %4, ptr noalias captures(none) %5, ptr %T)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @arguments_in_def(ptr noalias captures(none) dereferenceable(4) %0, ptr noalias captures(none) dereferenceable(4) %1, ptr noalias captures(none) dereferenceable(4) %2, ptr noalias captures(none) dereferenceable(40) %3, ptr noalias %4, ptr noalias captures(none) %5, ptr %T)
 sil @arguments_in_def : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> () {
 entry(%1 : $*Builtin.Int32, %2 : $*Builtin.Int32, %3 : $*Builtin.Int32, %4 : $Huge, %5 : $*T, %6 : $*()):
-  // CHECK: call swiftcc void @arguments_in_decl(ptr captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(40) {{%.*}}, ptr noalias {{%.*}}, ptr noalias captures(none) {{%.*}}, ptr %T)
+  // CHECK: call swiftcc void @arguments_in_decl(ptr noalias captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(40) {{%.*}}, ptr noalias {{%.*}}, ptr noalias captures(none) {{%.*}}, ptr %T)
   %f = function_ref @arguments_in_decl : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> ()
   %x = apply %f<T>(%1, %2, %3, %4, %5, %6) : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> ()
-  // CHECK: call swiftcc void @arguments_in_def(ptr captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(40) {{%.*}}, ptr noalias {{%.*}}, ptr noalias captures(none) {{%.*}}, ptr %T)
+  // CHECK: call swiftcc void @arguments_in_def(ptr noalias captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(40) {{%.*}}, ptr noalias {{%.*}}, ptr noalias captures(none) {{%.*}}, ptr %T)
   %g = function_ref @arguments_in_def : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> ()
   %y = apply %g<T>(%1, %2, %3, %4, %5, %6) : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> ()
   return undef : $()
 }
 
-// CHECK-LABEL: declare{{( dllimport)?}} swiftcc void @arguments_in_decl(ptr captures(none) dereferenceable(4), ptr noalias captures(none) dereferenceable(4), ptr noalias captures(none) dereferenceable(4), ptr noalias captures(none) dereferenceable(40), ptr noalias, ptr noalias captures(none), ptr)
+// CHECK-LABEL: declare{{( dllimport)?}} swiftcc void @arguments_in_decl(ptr noalias captures(none) dereferenceable(4), ptr noalias captures(none) dereferenceable(4), ptr noalias captures(none) dereferenceable(4), ptr noalias captures(none) dereferenceable(40), ptr noalias, ptr noalias captures(none), ptr)
 sil @arguments_in_decl : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> ()
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @arguments_in_def_out(ptr noalias sret({{.*}}) captures(none) %0, ptr captures(none) dereferenceable(4) %1, ptr noalias captures(none) dereferenceable(4) %2, ptr noalias captures(none) dereferenceable(4) %3, ptr noalias captures(none) dereferenceable(40) %4, ptr noalias %5, ptr noalias captures(none) %6, ptr %T)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @arguments_in_def_out(ptr noalias sret({{.*}}) captures(none) %0, ptr noalias captures(none) dereferenceable(4) %1, ptr noalias captures(none) dereferenceable(4) %2, ptr noalias captures(none) dereferenceable(4) %3, ptr noalias captures(none) dereferenceable(40) %4, ptr noalias %5, ptr noalias captures(none) %6, ptr %T)
 sil @arguments_in_def_out : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> @out Builtin.Int32 {
 entry(%0 : $*Builtin.Int32, %1 : $*Builtin.Int32, %2 : $*Builtin.Int32, %3 : $*Builtin.Int32, %4 : $Huge, %5 : $*T, %6 : $*()):
-  // CHECK: call swiftcc void @arguments_in_decl_out(ptr noalias sret({{.*}}) captures(none) {{%.*}}, ptr captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(40) {{%.*}}, ptr noalias {{%.*}}, ptr noalias captures(none) {{%.*}}, ptr {{%.*}})
+  // CHECK: call swiftcc void @arguments_in_decl_out(ptr noalias sret({{.*}}) captures(none) {{%.*}}, ptr noalias captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(40) {{%.*}}, ptr noalias {{%.*}}, ptr noalias captures(none) {{%.*}}, ptr {{%.*}})
   %f = function_ref @arguments_in_decl_out : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> @out Builtin.Int32
   %x = apply %f<T>(%0, %1, %2, %3, %4, %5, %6) : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> @out Builtin.Int32
-  // CHECK: call swiftcc void @arguments_in_def_out(ptr noalias sret({{.*}}) captures(none) {{%.*}}, ptr captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(40) {{%.*}}, ptr noalias {{%.*}}, ptr noalias captures(none) {{%.*}}, ptr {{%.*}})
+  // CHECK: call swiftcc void @arguments_in_def_out(ptr noalias sret({{.*}}) captures(none) {{%.*}}, ptr noalias captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(40) {{%.*}}, ptr noalias {{%.*}}, ptr noalias captures(none) {{%.*}}, ptr {{%.*}})
   %g = function_ref @arguments_in_def_out : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> @out Builtin.Int32
   %y = apply %g<T>(%0, %1, %2, %3, %4, %5, %6) : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> @out Builtin.Int32
   return undef : $()
 }
 
-// CHECK-LABEL: declare{{( dllimport)?}} swiftcc void @arguments_in_decl_out(ptr noalias sret({{.*}}) captures(none), ptr captures(none) dereferenceable(4), ptr noalias captures(none) dereferenceable(4), ptr noalias captures(none) dereferenceable(4), ptr noalias captures(none) dereferenceable(40), ptr noalias, ptr noalias captures(none), ptr)
+// CHECK-LABEL: declare{{( dllimport)?}} swiftcc void @arguments_in_decl_out(ptr noalias sret({{.*}}) captures(none), ptr noalias captures(none) dereferenceable(4), ptr noalias captures(none) dereferenceable(4), ptr noalias captures(none) dereferenceable(4), ptr noalias captures(none) dereferenceable(40), ptr noalias, ptr noalias captures(none), ptr)
 sil @arguments_in_decl_out : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> @out Builtin.Int32
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @arguments_in_def_huge_ret(ptr noalias sret({{.*}}V) captures(none) %0, ptr captures(none) dereferenceable(4) %1, ptr noalias captures(none) dereferenceable(4) %2, ptr noalias captures(none) dereferenceable(4) %3, ptr noalias captures(none) dereferenceable(40) %4, ptr noalias %5, ptr noalias captures(none) %6, ptr %T)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @arguments_in_def_huge_ret(ptr noalias sret({{.*}}V) captures(none) %0, ptr noalias captures(none) dereferenceable(4) %1, ptr noalias captures(none) dereferenceable(4) %2, ptr noalias captures(none) dereferenceable(4) %3, ptr noalias captures(none) dereferenceable(40) %4, ptr noalias %5, ptr noalias captures(none) %6, ptr %T)
 sil @arguments_in_def_huge_ret : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> Huge {
 entry(%1 : $*Builtin.Int32, %2 : $*Builtin.Int32, %3 : $*Builtin.Int32, %4 : $Huge, %5 : $*T, %6 : $*()):
   %f = function_ref @arguments_in_decl_huge_ret : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> Huge
-  // CHECK: call swiftcc void @arguments_in_decl_huge_ret(ptr noalias sret({{.*}}) captures(none) {{%.*}}, ptr captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(40) {{%.*}}, ptr noalias {{%.*}}, ptr noalias captures(none) {{%.*}}, ptr {{%.*}})
+  // CHECK: call swiftcc void @arguments_in_decl_huge_ret(ptr noalias sret({{.*}}) captures(none) {{%.*}}, ptr noalias captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(40) {{%.*}}, ptr noalias {{%.*}}, ptr noalias captures(none) {{%.*}}, ptr {{%.*}})
   %x = apply %f<T>(%1, %2, %3, %4, %5, %6) : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> Huge
-  // CHECK: call swiftcc void @arguments_in_def_huge_ret(ptr noalias sret({{.*}}) captures(none) {{%.*}}, ptr captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(40) {{%.*}}, ptr noalias {{%.*}}, ptr noalias captures(none) {{%.*}}, ptr {{%.*}})
+  // CHECK: call swiftcc void @arguments_in_def_huge_ret(ptr noalias sret({{.*}}) captures(none) {{%.*}}, ptr noalias captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(4) {{%.*}}, ptr noalias captures(none) dereferenceable(40) {{%.*}}, ptr noalias {{%.*}}, ptr noalias captures(none) {{%.*}}, ptr {{%.*}})
   %g = function_ref @arguments_in_def_huge_ret : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> Huge
   %y = apply %g<T>(%1, %2, %3, %4, %5, %6) : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> Huge
   return %y : $Huge
 }
 
-// CHECK-LABEL: declare{{( dllimport)?}} swiftcc void @arguments_in_decl_huge_ret(ptr noalias sret({{.*}}) captures(none), ptr captures(none) dereferenceable(4), ptr noalias captures(none) dereferenceable(4), ptr noalias captures(none) dereferenceable(4), ptr noalias captures(none) dereferenceable(40), ptr noalias, ptr noalias captures(none), ptr)
+// CHECK-LABEL: declare{{( dllimport)?}} swiftcc void @arguments_in_decl_huge_ret(ptr noalias sret({{.*}}) captures(none), ptr noalias captures(none) dereferenceable(4), ptr noalias captures(none) dereferenceable(4), ptr noalias captures(none) dereferenceable(4), ptr noalias captures(none) dereferenceable(40), ptr noalias, ptr noalias captures(none), ptr)
 sil @arguments_in_decl_huge_ret : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> Huge
 
 

--- a/test/IRGen/borrow_accessor_protocol.swift
+++ b/test/IRGen/borrow_accessor_protocol.swift
@@ -15,7 +15,7 @@ public protocol Proto {
 // CHECK-EVO-LABEL: define{{.*}} swiftcc ptr @"$s24borrow_accessor_protocol5ProtoP4body4BodyQzvzTj"
 // CHECK-EVO:         [[WITNESS_ADDR:%.*]] = getelementptr inbounds ptr, ptr %2,
 // CHECK-EVO:         [[WITNESS:%.*]] = load ptr, ptr [[WITNESS_ADDR]]
-// CHECK-EVO:         [[RESULT:%.*]] = call swiftcc ptr [[WITNESS]](ptr swiftself %0, ptr %1, ptr %2)
+// CHECK-EVO:         [[RESULT:%.*]] = call swiftcc ptr [[WITNESS]](ptr noalias swiftself %0, ptr %1, ptr %2)
 // CHECK-EVO:         ret ptr [[RESULT]]
 
 public protocol ConcreteProto {
@@ -31,7 +31,7 @@ public protocol ConcreteProto {
 // CHECK-EVO-LABEL: define{{.*}} swiftcc ptr @"$s24borrow_accessor_protocol13ConcreteProtoP5valueSivzTj"
 // CHECK-EVO:         [[WITNESS_ADDR:%.*]] = getelementptr inbounds ptr, ptr %2,
 // CHECK-EVO:         [[WITNESS:%.*]] = load ptr, ptr [[WITNESS_ADDR]]
-// CHECK-EVO:         [[RESULT:%.*]] = call swiftcc ptr [[WITNESS]](ptr swiftself %0, ptr %1, ptr %2)
+// CHECK-EVO:         [[RESULT:%.*]] = call swiftcc ptr [[WITNESS]](ptr noalias swiftself %0, ptr %1, ptr %2)
 // CHECK-EVO:         ret ptr [[RESULT]]
 
 public protocol SubscriptProto {
@@ -48,5 +48,5 @@ public protocol SubscriptProto {
 // CHECK-EVO-LABEL: define{{.*}} swiftcc ptr @"$s24borrow_accessor_protocol14SubscriptProtoP{{[^"]*}}icizTj"
 // CHECK-EVO:         [[WITNESS_ADDR:%.*]] = getelementptr inbounds ptr, ptr %3,
 // CHECK-EVO:         [[WITNESS:%.*]] = load ptr, ptr [[WITNESS_ADDR]]
-// CHECK-EVO:         [[RESULT:%.*]] = call swiftcc ptr [[WITNESS]](i64 %0, ptr swiftself %1, ptr %2, ptr %3)
+// CHECK-EVO:         [[RESULT:%.*]] = call swiftcc ptr [[WITNESS]](i64 %0, ptr noalias swiftself %1, ptr %2, ptr %3)
 // CHECK-EVO:         ret ptr [[RESULT]]

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -696,11 +696,11 @@ func zeroInitializerEmpty() {
 // isUnique variants
 // ----------------------------------------------------------------------------
 
-// CHECK: define hidden {{.*}}void @"$s8builtins26acceptsBuiltinNativeObjectyyBoSgzF"(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK: define hidden {{.*}}void @"$s8builtins26acceptsBuiltinNativeObjectyyBoSgzF"(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 func acceptsBuiltinNativeObject(_ ref: inout Builtin.NativeObject?) {}
 
 // native
-// CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins8isUniqueyBi1_BoSgzF"(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins8isUniqueyBi1_BoSgzF"(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-NEXT: entry:
 // CHECK:      %[[LD_RC:.+]] = load ptr, ptr %0
 // CHECK-NEXT: %[[RET:.+]] = call zeroext i1 @swift_isUniquelyReferenced_native(ptr %[[LD_RC]])
@@ -710,7 +710,7 @@ func isUnique(_ ref: inout Builtin.NativeObject?) -> Bool {
 }
 
 // native nonNull
-// CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins8isUniqueyBi1_BozF"(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins8isUniqueyBi1_BozF"(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-NEXT: entry:
 // CHECK:      %[[LD_RC:.+]] = load ptr, ptr %0
 // CHECK:      %[[RET:.+]] = call zeroext i1 @swift_isUniquelyReferenced_nonNull_native(ptr %[[LD_RC]])
@@ -719,11 +719,11 @@ func isUnique(_ ref: inout Builtin.NativeObject) -> Bool {
   return Builtin.isUnique(&ref)
 }
 
-// CHECK: define hidden {{.*}}void @"$s8builtins16acceptsAnyObjectyyyXlSgzF"(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK: define hidden {{.*}}void @"$s8builtins16acceptsAnyObjectyyyXlSgzF"(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 func acceptsAnyObject(_ ref: inout Builtin.AnyObject?) {}
 
 // ObjC
-// CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins8isUniqueyBi1_yXlSgzF"(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins8isUniqueyBi1_yXlSgzF"(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-NEXT: entry:
 // CHECK:      [[ADDR:%.+]] = getelementptr inbounds{{.*}} [[OPTIONAL_ANYOBJECT_TY:%.*]], ptr %0, i32 0, i32 0
 // CHECK-NEXT: [[REF:%.+]] = load ptr, ptr [[ADDR]]
@@ -736,7 +736,7 @@ func isUnique(_ ref: inout Builtin.AnyObject?) -> Bool {
 
 // ObjC nonNull
 // CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins8isUniqueyBi1_yXlzF"
-// CHECK-SAME:    (ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-SAME:    (ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-NEXT: entry:
 // CHECK:      [[ADDR:%.+]] = getelementptr inbounds{{.*}} %AnyObject, ptr %0, i32 0, i32 0
 // CHECK:      [[REF:%.+]] = load ptr, ptr [[ADDR]]
@@ -748,7 +748,7 @@ func isUnique(_ ref: inout Builtin.AnyObject) -> Bool {
 }
 
 // BridgeObject nonNull
-// CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins8isUniqueyBi1_BbzF"(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins8isUniqueyBi1_BbzF"(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-NEXT: entry:
 // CHECK:      %[[LD:.+]] = load ptr, ptr %0
 // CHECK:      %[[RET:.+]] = call zeroext i1 @swift_isUniquelyReferenced{{(NonObjC)?}}_nonNull_bridgeObject(ptr %[[LD]])
@@ -764,7 +764,7 @@ func assumeTrue(_ x: Builtin.Int1) {
   Builtin.assume_Int1(x)
 }
 // BridgeObject nonNull
-// CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins15isUnique_nativeyBi1_BbzF"(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins15isUnique_nativeyBi1_BbzF"(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-NEXT: entry:
 // CHECK:      %[[LD:.+]] = load ptr, ptr %0
 // CHECK-NEXT: %[[RET:.+]] = call zeroext i1 @swift_isUniquelyReferenced_nonNull_native(ptr %[[LD]])
@@ -774,7 +774,7 @@ func isUnique_native(_ ref: inout Builtin.BridgeObject) -> Bool {
 }
 
 // ImplicitlyUnwrappedOptional argument to isUnique.
-// CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins11isUniqueIUOyBi1_BoSgzF"(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins11isUniqueIUOyBi1_BoSgzF"(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-NEXT: entry:
 // CHECK: call zeroext i1 @swift_isUniquelyReferenced_native(ptr
 // CHECK: ret i1
@@ -912,7 +912,7 @@ func getEnumTag<T>(_ x: T) -> UInt32 {
   UInt32(Builtin.getEnumTag(x))
 }
 
-// CHECK-LABEL: define {{.*}} swiftcc void @"$s8builtins13injectEnumTag_3tagyxz_s6UInt32VtlF"(ptr %0, i32 %1, ptr %T)
+// CHECK-LABEL: define {{.*}} swiftcc void @"$s8builtins13injectEnumTag_3tagyxz_s6UInt32VtlF"(ptr noalias %0, i32 %1, ptr %T)
 // CHECK: %DestructiveInjectEnumTag = load ptr, ptr {{%.*}}
 // CHECK: call void %DestructiveInjectEnumTag(ptr {{.*}} %0, i32 %1, ptr %T)
 func injectEnumTag<T>(_ x: inout T, tag: UInt32) {

--- a/test/IRGen/coroutine_accessors.swift
+++ b/test/IRGen/coroutine_accessors.swift
@@ -256,7 +256,7 @@ public var irm: Int {
 // CHECK-LABEL:     define{{.*}} { ptr, ptr } @"$s19coroutine_accessors1SV3irmSivx"(
 // CHECK-SAME:          ptr noalias [[FRAME:%[^,]+]],
 // CHECK-SAME:          ptr swiftcoro [[ALLOCATOR:%[^,]+]],
-// CHECK-SAME:          ptr swiftself captures(none) dereferenceable({{8|16}}) [[SELF:%[^)]+]]
+// CHECK-SAME:          ptr noalias swiftself captures(none) dereferenceable({{8|16}}) [[SELF:%[^)]+]]
 // CHECK-SAME:      )
 // CHECK-SAME:      {
 // CHECK:               [[ID:%[^,]+]] = call token @llvm.coro.id.retcon.once.dynamic(
@@ -430,7 +430,7 @@ public var force_yield_once_2_convention : () {
 // CHECK-LABEL: define{{.*}} { ptr, ptr } @increment_irm_yield_once_2(
 //                  ptr noalias %0
 // CHECK-SAME:      ptr swiftcoro [[ALLOCATOR:%[^,]+]]
-//                  ptr swiftself captures(none) dereferenceable(16) %2
+//                  ptr noalias swiftself captures(none) dereferenceable(16) %2
 // CHECK-SAME:  )
 // CHECK-SAME:  {
 //      :         [[SIZE_32:%[^,]+]] = load i32

--- a/test/IRGen/coroutine_accessors.swift
+++ b/test/IRGen/coroutine_accessors.swift
@@ -256,7 +256,7 @@ public var irm: Int {
 // CHECK-LABEL:     define{{.*}} { ptr, ptr } @"$s19coroutine_accessors1SV3irmSivx"(
 // CHECK-SAME:          ptr noalias [[FRAME:%[^,]+]],
 // CHECK-SAME:          ptr swiftcoro [[ALLOCATOR:%[^,]+]],
-// CHECK-SAME:          ptr swiftself captures(none) dereferenceable({{8|16}}) [[SELF:%[^)]+]]
+// CHECK-SAME:          ptr noalias swiftself captures(none) dereferenceable({{8|16}}) [[SELF:%[^)]+]]
 // CHECK-SAME:      )
 // CHECK-SAME:      {
 // CHECK:               [[ID:%[^,]+]] = call token @llvm.coro.id.retcon.once.dynamic(
@@ -424,7 +424,7 @@ public var force_yield_once_2_convention : () {
 // CHECK-LABEL: define{{.*}} { ptr, ptr } @increment_irm_yield_once_2(
 //                  ptr noalias %0
 // CHECK-SAME:      ptr swiftcoro [[ALLOCATOR:%[^,]+]]
-//                  ptr swiftself captures(none) dereferenceable(16) %2
+//                  ptr noalias swiftself captures(none) dereferenceable(16) %2
 // CHECK-SAME:  )
 // CHECK-SAME:  {
 //      :         [[SIZE_32:%[^,]+]] = load i32

--- a/test/IRGen/coroutine_accessors_backdeploy_async_56.swift
+++ b/test/IRGen/coroutine_accessors_backdeploy_async_56.swift
@@ -128,7 +128,7 @@ public var i: Int {
 
 // CHECK-LABEL: define{{.*}} void @increment_i_async(
 //                  ptr swiftasync %0
-// CHECK-SAME:      ptr swiftself captures(none) dereferenceable({{8|4}}) %1
+// CHECK-SAME:      ptr noalias swiftself captures(none) dereferenceable({{8|4}}) %1
 // CHECK-SAME:  )
 // CHECK-SAME:  {
 //      :         [[SIZE_32:%[^,]+]] = load i32

--- a/test/IRGen/coroutine_accessors_backdeploy_async_57.swift
+++ b/test/IRGen/coroutine_accessors_backdeploy_async_57.swift
@@ -101,7 +101,7 @@ public var i: Int {
 
 // CHECK-LABEL: define{{.*}} void @increment_i_async(
 //                  ptr swiftasync %0
-// CHECK-SAME:      ptr swiftself captures(none) dereferenceable({{8|4}}) %1
+// CHECK-SAME:      ptr noalias swiftself captures(none) dereferenceable({{8|4}}) %1
 // CHECK-SAME:  )
 // CHECK-SAME:  {
 //      :         [[SIZE_32:%[^,]+]] = load i32

--- a/test/IRGen/coroutine_accessors_future.swift
+++ b/test/IRGen/coroutine_accessors_future.swift
@@ -23,8 +23,8 @@ public struct OhOh {
 // CHECK: define{{.*}} swiftcc i64 @"$s26coroutine_accessors_future02OhD0V1gSivg"(i64 %0) #0
 
 // Setter definition
-// CHECK: define{{.*}} swiftcc void @"$s26coroutine_accessors_future02OhD0V1gSivs"(i64 %0, ptr swiftself captures(none) dereferenceable(8) %1) #0
+// CHECK: define{{.*}} swiftcc void @"$s26coroutine_accessors_future02OhD0V1gSivs"(i64 %0, ptr noalias swiftself captures(none) dereferenceable(8) %1) #0
 
 // yielding mutate definition
-// CHECK: define{{.*}} {{(swiftcc|swiftcorocc)}} { ptr, ptr } @"$s26coroutine_accessors_future02OhD0V1gSivx"(ptr noalias %0, ptr{{( swiftcoro)?}} %1, ptr swiftself captures(none) dereferenceable(8) %2)
+// CHECK: define{{.*}} {{(swiftcc|swiftcorocc)}} { ptr, ptr } @"$s26coroutine_accessors_future02OhD0V1gSivx"(ptr noalias %0, ptr{{( swiftcoro)?}} %1, ptr noalias swiftself captures(none) dereferenceable(8) %2)
 

--- a/test/IRGen/coroutine_accessors_past.swift
+++ b/test/IRGen/coroutine_accessors_past.swift
@@ -33,10 +33,10 @@ public struct OhOh {
 // CHECK: define{{.*}} swiftcc i64 @"$s24coroutine_accessors_past02OhD0V1gSivg"(i64 %0) #0
 
 // Setter definition
-// CHECK: define{{.*}} swiftcc void @"$s24coroutine_accessors_past02OhD0V1gSivs"(i64 %0, ptr swiftself captures(none) dereferenceable(8) %1) #0
+// CHECK: define{{.*}} swiftcc void @"$s24coroutine_accessors_past02OhD0V1gSivs"(i64 %0, ptr noalias swiftself captures(none) dereferenceable(8) %1) #0
 
 // yielding mutate definition
-// CHECK: define{{.*}} {{(swiftcc|swiftcorocc)}} { ptr, ptr } @"$s24coroutine_accessors_past02OhD0V1gSivx"(ptr noalias %0, ptr{{( swiftcoro)?}} %1, ptr swiftself captures(none) dereferenceable(8) %2) #1
+// CHECK: define{{.*}} {{(swiftcc|swiftcorocc)}} { ptr, ptr } @"$s24coroutine_accessors_past02OhD0V1gSivx"(ptr noalias %0, ptr{{( swiftcoro)?}} %1, ptr noalias swiftself captures(none) dereferenceable(8) %2)
 
 // The old `_modify` (yield_once_1) accessor must not appear anywhere.
 // NO-OLD-ABI-NOT: @"$s24coroutine_accessors_past02OhD0V1gSivM"

--- a/test/IRGen/coroutine_accessors_past.swift
+++ b/test/IRGen/coroutine_accessors_past.swift
@@ -26,11 +26,11 @@ public struct OhOh {
 // CHECK: define{{.*}} swiftcc i64 @"$s24coroutine_accessors_past02OhD0V1gSivg"(i64 %0) #0
 
 // Setter definition
-// CHECK: define{{.*}} swiftcc void @"$s24coroutine_accessors_past02OhD0V1gSivs"(i64 %0, ptr swiftself captures(none) dereferenceable(8) %1) #0
+// CHECK: define{{.*}} swiftcc void @"$s24coroutine_accessors_past02OhD0V1gSivs"(i64 %0, ptr noalias swiftself captures(none) dereferenceable(8) %1) #0
 
 // _modify definition
-// CHECK: define{{.*}} swiftcc { ptr, ptr } @"$s24coroutine_accessors_past02OhD0V1gSivM"(ptr noalias dereferenceable(32) %0, ptr swiftself captures(none) dereferenceable(8) %1) #1
+// CHECK: define{{.*}} swiftcc { ptr, ptr } @"$s24coroutine_accessors_past02OhD0V1gSivM"(ptr noalias dereferenceable(32) %0, ptr noalias swiftself captures(none) dereferenceable(8) %1) #1
 
 // yielding mutate definition
-// CHECK: define{{.*}} {{(swiftcc|swiftcorocc)}} { ptr, ptr } @"$s24coroutine_accessors_past02OhD0V1gSivx"(ptr noalias %0, ptr{{( swiftcoro)?}} %1, ptr swiftself captures(none) dereferenceable(8) %2) #1
+// CHECK: define{{.*}} {{(swiftcc|swiftcorocc)}} { ptr, ptr } @"$s24coroutine_accessors_past02OhD0V1gSivx"(ptr noalias %0, ptr{{( swiftcoro)?}} %1, ptr noalias swiftself captures(none) dereferenceable(8) %2) #1
 

--- a/test/IRGen/coroutine_accessors_past_resilient.swift
+++ b/test/IRGen/coroutine_accessors_past_resilient.swift
@@ -28,10 +28,10 @@ public struct OhOh {
 // CHECK: define{{.*}} swiftcc i64 @"$s34coroutine_accessors_past_resilient02OhE0V1gSivg"(ptr noalias swiftself captures(none) dereferenceable(8) %0) #{{[0-9]+}}
 
 // Setter definition
-// CHECK: define{{.*}} swiftcc void @"$s34coroutine_accessors_past_resilient02OhE0V1gSivs"(i64 %0, ptr swiftself captures(none) dereferenceable(8) %1) #{{[0-9]+}}
+// CHECK: define{{.*}} swiftcc void @"$s34coroutine_accessors_past_resilient02OhE0V1gSivs"(i64 %0, ptr noalias swiftself captures(none) dereferenceable(8) %1) #{{[0-9]+}}
 
 // _modify definition (old yield_once_1 ABI, kept for ABI stability)
-// CHECK: define{{.*}} swiftcc { ptr, ptr } @"$s34coroutine_accessors_past_resilient02OhE0V1gSivM"(ptr noalias dereferenceable(32) %0, ptr swiftself captures(none) dereferenceable(8) %1) #{{[0-9]+}}
+// CHECK: define{{.*}} swiftcc { ptr, ptr } @"$s34coroutine_accessors_past_resilient02OhE0V1gSivM"(ptr noalias dereferenceable(32) %0, ptr noalias swiftself captures(none) dereferenceable(8) %1) #{{[0-9]+}}
 
 // yielding mutate definition (new yield_once_2 ABI)
-// CHECK: define{{.*}} {{(swiftcc|swiftcorocc)}} { ptr, ptr } @"$s34coroutine_accessors_past_resilient02OhE0V1gSivx"(ptr noalias %0, ptr{{( swiftcoro)?}} %1, ptr swiftself captures(none) dereferenceable(8) %2) #{{[0-9]+}}
+// CHECK: define{{.*}} {{(swiftcc|swiftcorocc)}} { ptr, ptr } @"$s34coroutine_accessors_past_resilient02OhE0V1gSivx"(ptr noalias %0, ptr{{( swiftcoro)?}} %1, ptr noalias swiftself captures(none) dereferenceable(8) %2) #{{[0-9]+}}

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -238,7 +238,7 @@ dest(%u2 : $(Builtin.Int64, Builtin.Int64)):
   return %x : $()
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch_indirect(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK: entry:
 // CHECK:   br label %[[DEST:[0-9]+]]
 // CHECK: [[DEST]]:
@@ -274,7 +274,7 @@ entry(%0 : $Builtin.Int64, %1 : $Builtin.Int64):
   return %u : $Singleton
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_inject_indirect(i64 %0, i64 %1, ptr captures(none) dereferenceable({{.*}}) %2) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_inject_indirect(i64 %0, i64 %1, ptr noalias captures(none) dereferenceable({{.*}}) %2) {{.*}} {
 // CHECK: entry:
 // CHECK:   [[DATA_0_ADDR:%.*]] = getelementptr inbounds{{.*}} <{ i64, i64 }>, ptr %2, i32 0, i32 0
 // CHECK:   store i64 %0, ptr [[DATA_0_ADDR]]
@@ -349,7 +349,7 @@ end:
   return %x : $()
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @no_payload_switch_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @no_payload_switch_indirect(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 sil @no_payload_switch_indirect : $@convention(thin) (@inout NoPayloads) -> () {
 entry(%u : $*NoPayloads):
 // CHECK:   [[TAG_ADDR:%.*]] = getelementptr inbounds{{.*}} %T4enum10NoPayloadsO, ptr %0, i32 0, i32 0
@@ -398,7 +398,7 @@ entry:
   return %u : $NoPayloads
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @no_payload_inject_z_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @no_payload_inject_z_indirect(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK: entry:
 // CHECK:   [[TAG_ADDR:%.*]] = getelementptr inbounds{{.*}} %T4enum10NoPayloadsO, ptr %0, i32 0, i32 0
 // CHECK:   store i8 2, ptr [[TAG_ADDR]]
@@ -629,7 +629,7 @@ entry(%0 : $Builtin.Word):
   return %u : $SinglePayloadNoXI2
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_no_xi_inject_x_indirect([[WORD]] %0, ptr captures(none) dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_no_xi_inject_x_indirect([[WORD]] %0, ptr noalias captures(none) dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK: entry:
 // CHECK:   store [[WORD]] %0, ptr %1
 // CHECK:   [[T0:%.*]] = getelementptr inbounds{{.*}} %T4enum18SinglePayloadNoXI2O, ptr %1, i32 0, i32 1
@@ -655,7 +655,7 @@ entry:
   return %u : $SinglePayloadNoXI2
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_no_xi_inject_y_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_no_xi_inject_y_indirect(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK: entry:
 // CHECK:   store [[WORD]] 0, ptr %0
 // CHECK:   [[T0:%.*]] = getelementptr inbounds{{.*}} %T4enum18SinglePayloadNoXI2O, ptr %0, i32 0, i32 1
@@ -992,7 +992,7 @@ entry(%0 : $Builtin.Int63):
   return %u : $SinglePayloadSpareBit
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_spare_bit_inject_x_indirect(i64 %0, ptr captures(none) dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_spare_bit_inject_x_indirect(i64 %0, ptr noalias captures(none) dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[T:%.*]] = trunc i64 %0 to i63
 // CHECK-64:   [[BYTE:%.*]] = zext i63 [[T]] to i64
@@ -1019,7 +1019,7 @@ entry:
   return %u : $SinglePayloadSpareBit
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_spare_bit_inject_y_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_spare_bit_inject_y_indirect(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-64: entry:
 // --                0x8000_0000_0000_0000
 // CHECK-64:   store i64 -9223372036854775808, ptr %0
@@ -1308,7 +1308,7 @@ end(%z : $()):
   return %z : $()
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc i8 @dynamic_single_payload_empty_payload_load(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc i8 @dynamic_single_payload_empty_payload_load(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK: entry:
 // CHECK:   %1 = load i8, ptr %0
 // CHECK:   ret i8 %1
@@ -1319,7 +1319,7 @@ entry(%p : $*DynamicSinglePayload<()>):
   return %x : $DynamicSinglePayload<()>
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_empty_payload_store(ptr captures(none) dereferenceable({{.*}}) %0, i8 %1) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_empty_payload_store(ptr noalias captures(none) dereferenceable({{.*}}) %0, i8 %1) {{.*}} {
 // CHECK: entry:
 // CHECK:   store i8 %1, ptr %0
 // CHECK:   ret void
@@ -1444,7 +1444,7 @@ end:
   return %v : $()
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bits_switch_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bits_switch_indirect(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 sil @multi_payload_no_spare_bits_switch_indirect : $(@inout MultiPayloadNoSpareBits) -> () {
 entry(%u : $*MultiPayloadNoSpareBits):
 // CHECK-64:   [[PAYLOAD:%.*]] = load i64, ptr %0
@@ -1498,7 +1498,7 @@ entry(%0 : $Builtin.Int64):
   return %u : $MultiPayloadNoSpareBits
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bit_inject_x_indirect(i64 %0, ptr captures(none) dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bit_inject_x_indirect(i64 %0, ptr noalias captures(none) dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   store i64 %0, ptr %1
 // CHECK-64:   [[T0:%.*]] = getelementptr inbounds{{.*}} %T4enum23MultiPayloadNoSpareBitsO, ptr %1, i32 0, i32 1
@@ -1551,7 +1551,7 @@ entry:
   return %u : $MultiPayloadNoSpareBits
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bit_inject_a_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bit_inject_a_indirect(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   store i64 0, ptr %0
 // CHECK-64:   [[T0:%.*]] = getelementptr inbounds{{.*}} %T4enum23MultiPayloadNoSpareBitsO, ptr %0, i32 0, i32 1
@@ -1740,7 +1740,7 @@ entry(%0 : $Builtin.Int62):
   return %u : $MultiPayloadOneSpareBit
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_x_indirect(i64 %0, ptr captures(none) dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_x_indirect(i64 %0, ptr noalias captures(none) dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i62
 // CHECK-64:   [[BYTE:%.*]] = zext i62 [[NATIVECC_TRUNC]] to i64
@@ -1778,7 +1778,7 @@ entry(%0 : $Builtin.Int63):
   return %u : $MultiPayloadOneSpareBit
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_y_indirect(i64 %0, ptr captures(none) dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_y_indirect(i64 %0, ptr noalias captures(none) dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i63
 // CHECK-64:   [[BYTE:%.*]] = zext i63 [[NATIVECC_TRUNC]] to i64
@@ -1828,7 +1828,7 @@ entry:
   return %u : $MultiPayloadOneSpareBit
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_a_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_a_indirect(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-64: entry:
 // --                0x8000_0000_0000_0000
 // CHECK-64:   store i64 -9223372036854775808, ptr %0
@@ -1972,7 +1972,7 @@ entry(%0 : $Builtin.Int62):
   return %u : $MultiPayloadTwoSpareBits
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_x_indirect(i64 %0, ptr captures(none) dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_x_indirect(i64 %0, ptr noalias captures(none) dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i62
 // CHECK-64:   [[BYTE:%.*]] = zext i62 [[NATIVECC_TRUNC]] to i64
@@ -2006,7 +2006,7 @@ entry(%0 : $Builtin.Int60):
   return %u : $MultiPayloadTwoSpareBits
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_y_indirect(i64 %0, ptr captures(none) dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_y_indirect(i64 %0, ptr noalias captures(none) dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i60
 // CHECK-64:   [[BYTE:%.*]] = zext i60 [[NATIVECC_TRUNC]] to i64
@@ -2053,7 +2053,7 @@ entry:
   return %u : $MultiPayloadTwoSpareBits
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_a_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_a_indirect(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-64: entry:
 // --                0xC000_0000_0000_0000
 // CHECK-64:   store i64 -4611686018427387904, ptr %0

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -238,7 +238,7 @@ dest(%u2 : $(Builtin.Int64, Builtin.Int64)):
   return %x : $()
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch_indirect(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK: entry:
 // CHECK:   br label %[[DEST:[0-9]+]]
 // CHECK: [[DEST]]:

--- a/test/IRGen/enum_future.sil
+++ b/test/IRGen/enum_future.sil
@@ -242,7 +242,7 @@ dest(%u2 : $(Builtin.Int64, Builtin.Int64)):
   return %x : $()
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch_indirect(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK: entry:
 // CHECK:   br label %[[DEST:[0-9]+]]
 // CHECK: [[DEST]]:
@@ -278,7 +278,7 @@ entry(%0 : $Builtin.Int64, %1 : $Builtin.Int64):
   return %u : $Singleton
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_inject_indirect(i64 %0, i64 %1, ptr captures(none) dereferenceable({{.*}}) %2) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_inject_indirect(i64 %0, i64 %1, ptr noalias captures(none) dereferenceable({{.*}}) %2) {{.*}} {
 // CHECK: entry:
 // CHECK:   [[DATA_0_ADDR:%.*]] = getelementptr inbounds{{.*}} <{ i64, i64 }>, ptr %2, i32 0, i32 0
 // CHECK:   store i64 %0, ptr [[DATA_0_ADDR]]
@@ -353,7 +353,7 @@ end:
   return %x : $()
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @no_payload_switch_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @no_payload_switch_indirect(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 sil @no_payload_switch_indirect : $@convention(thin) (@inout NoPayloads) -> () {
 entry(%u : $*NoPayloads):
 // CHECK:   [[TAG_ADDR:%.*]] = getelementptr inbounds{{.*}} %T11enum_future10NoPayloadsO, ptr %0, i32 0, i32 0
@@ -402,7 +402,7 @@ entry:
   return %u : $NoPayloads
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @no_payload_inject_z_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @no_payload_inject_z_indirect(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK: entry:
 // CHECK:   [[TAG_ADDR:%.*]] = getelementptr inbounds{{.*}} %T11enum_future10NoPayloadsO, ptr %0, i32 0, i32 0
 // CHECK:   store i8 2, ptr [[TAG_ADDR]]
@@ -633,7 +633,7 @@ entry(%0 : $Builtin.Word):
   return %u : $SinglePayloadNoXI2
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_no_xi_inject_x_indirect([[WORD]] %0, ptr captures(none) dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_no_xi_inject_x_indirect([[WORD]] %0, ptr noalias captures(none) dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK: entry:
 // CHECK:   store [[WORD]] %0, ptr %1
 // CHECK:   [[T0:%.*]] = getelementptr inbounds{{.*}} %T11enum_future18SinglePayloadNoXI2O, ptr %1, i32 0, i32 1
@@ -659,7 +659,7 @@ entry:
   return %u : $SinglePayloadNoXI2
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_no_xi_inject_y_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_no_xi_inject_y_indirect(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK: entry:
 // CHECK:   store [[WORD]] 0, ptr %0
 // CHECK:   [[T0:%.*]] = getelementptr inbounds{{.*}} %T11enum_future18SinglePayloadNoXI2O, ptr %0, i32 0, i32 1
@@ -996,7 +996,7 @@ entry(%0 : $Builtin.Int63):
   return %u : $SinglePayloadSpareBit
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_spare_bit_inject_x_indirect(i64 %0, ptr captures(none) dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_spare_bit_inject_x_indirect(i64 %0, ptr noalias captures(none) dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[T:%.*]] = trunc i64 %0 to i63
 // CHECK-64:   [[BYTE:%.*]] = zext i63 [[T]] to i64
@@ -1023,7 +1023,7 @@ entry:
   return %u : $SinglePayloadSpareBit
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_spare_bit_inject_y_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_spare_bit_inject_y_indirect(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-64: entry:
 // --                0x8000_0000_0000_0000
 // CHECK-64:   store i64 -9223372036854775808, ptr %0
@@ -1318,7 +1318,7 @@ end(%z : $()):
   return %z : $()
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc i8 @dynamic_single_payload_empty_payload_load(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc i8 @dynamic_single_payload_empty_payload_load(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK: entry:
 // CHECK:   %1 = load i8, ptr %0
 // CHECK:   ret i8 %1
@@ -1329,7 +1329,7 @@ entry(%p : $*DynamicSinglePayload<()>):
   return %x : $DynamicSinglePayload<()>
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_empty_payload_store(ptr captures(none) dereferenceable({{.*}}) %0, i8 %1) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_empty_payload_store(ptr noalias captures(none) dereferenceable({{.*}}) %0, i8 %1) {{.*}} {
 // CHECK: entry:
 // CHECK:   store i8 %1, ptr %0
 // CHECK:   ret void
@@ -1454,7 +1454,7 @@ end:
   return %v : $()
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bits_switch_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bits_switch_indirect(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 sil @multi_payload_no_spare_bits_switch_indirect : $(@inout MultiPayloadNoSpareBits) -> () {
 entry(%u : $*MultiPayloadNoSpareBits):
 // CHECK-64:   [[PAYLOAD:%.*]] = load i64, ptr %0
@@ -1508,7 +1508,7 @@ entry(%0 : $Builtin.Int64):
   return %u : $MultiPayloadNoSpareBits
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bit_inject_x_indirect(i64 %0, ptr captures(none) dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bit_inject_x_indirect(i64 %0, ptr noalias captures(none) dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   store i64 %0, ptr %1
 // CHECK-64:   [[T0:%.*]] = getelementptr inbounds{{.*}} %T11enum_future23MultiPayloadNoSpareBitsO, ptr %1, i32 0, i32 1
@@ -1561,7 +1561,7 @@ entry:
   return %u : $MultiPayloadNoSpareBits
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bit_inject_a_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bit_inject_a_indirect(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   store i64 0, ptr %0
 // CHECK-64:   [[T0:%.*]] = getelementptr inbounds{{.*}} %T11enum_future23MultiPayloadNoSpareBitsO, ptr %0, i32 0, i32 1
@@ -1750,7 +1750,7 @@ entry(%0 : $Builtin.Int62):
   return %u : $MultiPayloadOneSpareBit
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_x_indirect(i64 %0, ptr captures(none) dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_x_indirect(i64 %0, ptr noalias captures(none) dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i62
 // CHECK-64:   [[VAL:%.*]] = zext i62 [[NATIVECC_TRUNC]] to i64
@@ -1788,7 +1788,7 @@ entry(%0 : $Builtin.Int63):
   return %u : $MultiPayloadOneSpareBit
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_y_indirect(i64 %0, ptr captures(none) dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_y_indirect(i64 %0, ptr noalias captures(none) dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i63
 // CHECK-64:   [[VAL:%.*]] = zext i63 [[NATIVECC_TRUNC]] to i64
@@ -1838,7 +1838,7 @@ entry:
   return %u : $MultiPayloadOneSpareBit
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_a_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_a_indirect(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-64: entry:
 // --                0x8000_0000_0000_0000
 // CHECK-64:   store i64 -9223372036854775808, ptr %0
@@ -1982,7 +1982,7 @@ entry(%0 : $Builtin.Int62):
   return %u : $MultiPayloadTwoSpareBits
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_x_indirect(i64 %0, ptr captures(none) dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_x_indirect(i64 %0, ptr noalias captures(none) dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i62
 // CHECK-64:   [[VAL:%.*]] = zext i62 [[NATIVECC_TRUNC]] to i64
@@ -2016,7 +2016,7 @@ entry(%0 : $Builtin.Int60):
   return %u : $MultiPayloadTwoSpareBits
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_y_indirect(i64 %0, ptr captures(none) dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_y_indirect(i64 %0, ptr noalias captures(none) dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i60
 // CHECK-64:   [[VAL:%.*]] = zext i60 [[NATIVECC_TRUNC]] to i64
@@ -2063,7 +2063,7 @@ entry:
   return %u : $MultiPayloadTwoSpareBits
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_a_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_a_indirect(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-64: entry:
 // --                0xC000_0000_0000_0000
 // CHECK-64:   store i64 -4611686018427387904, ptr %0

--- a/test/IRGen/enum_future.sil
+++ b/test/IRGen/enum_future.sil
@@ -242,7 +242,7 @@ dest(%u2 : $(Builtin.Int64, Builtin.Int64)):
   return %x : $()
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch_indirect(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK: entry:
 // CHECK:   br label %[[DEST:[0-9]+]]
 // CHECK: [[DEST]]:
@@ -996,7 +996,7 @@ entry(%0 : $Builtin.Int63):
   return %u : $SinglePayloadSpareBit
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_spare_bit_inject_x_indirect(i64 %0, ptr captures(none) dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_spare_bit_inject_x_indirect(i64 %0, ptr noalias captures(none) dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[T:%.*]] = trunc i64 %0 to i63
 // CHECK-64:   [[BYTE:%.*]] = zext i63 [[T]] to i64

--- a/test/IRGen/function_param_convention.sil
+++ b/test/IRGen/function_param_convention.sil
@@ -10,7 +10,7 @@ struct X {
 // Make sure we can irgen a SIL function with various parameter attributes
 // without choking. This is just a basic reality check.
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @foo(ptr noalias sret({{.*}}) captures(none) %0, ptr noalias captures(none) dereferenceable({{.*}}) %1, ptr captures(none) dereferenceable({{.*}}) %2, ptr noalias captures(none) dereferenceable({{.*}}) %3, i32 %4, i32 %5, i32 %6) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @foo(ptr noalias sret({{.*}}) captures(none) %0, ptr noalias captures(none) dereferenceable({{.*}}) %1, ptr noalias captures(none) dereferenceable({{.*}}) %2, ptr noalias captures(none) dereferenceable({{.*}}) %3, i32 %4, i32 %5, i32 %6) {{.*}} {
 
 sil @foo : $@convention(thin) (@in X, @inout X, @in_guaranteed X, @owned X, X, @guaranteed X) -> @out X {
 bb0(%0 : $*X, %1 : $*X, %2 : $*X, %3 : $*X, %4 : $X, %5 : $X, %6 : $X):

--- a/test/IRGen/generic_ternary.swift
+++ b/test/IRGen/generic_ternary.swift
@@ -4,7 +4,7 @@
 
 // <rdar://problem/13793646>
 struct OptionalStreamAdaptor<T : IteratorProtocol> {
-  // CHECK: define hidden swiftcc void @"$s15generic_ternary21OptionalStreamAdaptorV4next{{[_0-9a-zA-Z]*}}F"(ptr noalias sret({{.*}}) %0, ptr %"OptionalStreamAdaptor<T>", ptr swiftself captures(none) dereferenceable({{.*}}) %1)
+  // CHECK: define hidden swiftcc void @"$s15generic_ternary21OptionalStreamAdaptorV4next{{[_0-9a-zA-Z]*}}F"(ptr noalias sret({{.*}}) %0, ptr %"OptionalStreamAdaptor<T>", ptr noalias swiftself captures(none) dereferenceable({{.*}}) %1)
   mutating
   func next() -> Optional<T.Element> {
     return x[0].next()

--- a/test/IRGen/inout_noalias.swift
+++ b/test/IRGen/inout_noalias.swift
@@ -1,5 +1,21 @@
-// RUN: %target-swift-frontend %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir -disable-availability-checking | %FileCheck %s
+// RUN: %target-swift-frontend %s -O -emit-ir -disable-availability-checking | %FileCheck %s --check-prefix=CHECK-OPT
 
 // CHECK: define{{.*}}swiftcc void @swapPointers({{.*}}noalias{{.*}},{{.*}}noalias{{.*}})
 @_silgen_name("swapPointers")
 public func swapPointers<T>(_ lhs: inout UnsafePointer<T>, _ rhs: inout UnsafePointer<T>) {}
+
+// CHECK-OPT-LABEL: define{{.*}}swiftcc void @"$s13inout_noalias6rotateyys11InlineArrayVy$63_SdGz_AEzS2dtF"(ptr noalias captures(none) dereferenceable(512) %0, ptr noalias captures(none) dereferenceable(512) %1, double %2, double %3) {{.*}} {
+// CHECK-OPT-NOT:     %found.conflict
+// CHECK-OPT-NOT:     scalar.ph
+// CHECK-OPT:         vector.body
+// CHECK-OPT:       ret void
+public func rotate(_ x: inout InlineArray<64, Double>,
+                   _ y: inout InlineArray<64, Double>,
+                   _ c: Double, _ s: Double) {
+  for i in x.indices {
+    let xi = x[i], yi = y[i]
+    x[i] = c * xi + s * yi
+    y[i] = c * yi - s * xi
+  }
+}

--- a/test/IRGen/inout_noalias.swift
+++ b/test/IRGen/inout_noalias.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend %s -emit-ir -disable-availability-checking | %FileCheck %s
 // RUN: %target-swift-frontend %s -O -emit-ir -disable-availability-checking | %FileCheck %s --check-prefix=CHECK-OPT
+// UNSUPPORTED: CPU=wasm32
 
 // CHECK: define{{.*}}swiftcc void @swapPointers({{.*}}noalias{{.*}},{{.*}}noalias{{.*}})
 @_silgen_name("swapPointers")

--- a/test/IRGen/inout_noalias.swift
+++ b/test/IRGen/inout_noalias.swift
@@ -1,5 +1,21 @@
-// RUN: %target-swift-frontend %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir -disable-availability-checking | %FileCheck %s
+// RUN: %target-swift-frontend %s -O -emit-ir -disable-availability-checking | %FileCheck %s --check-prefix=CHECK-OPT
 
 // CHECK: define{{.*}}swiftcc void @swapPointers({{.*}}noalias{{.*}},{{.*}}noalias{{.*}})
 @_silgen_name("swapPointers")
 public func swapPointers<T>(_ lhs: inout UnsafePointer<T>, _ rhs: inout UnsafePointer<T>) {}
+
+// CHECK-OPT-LABEL: define swiftcc void @"$s13inout_noalias6rotateyys11InlineArrayVy$63_SdGz_AEzS2dtF"(ptr noalias captures(none) dereferenceable(512) %0, ptr noalias captures(none) dereferenceable(512) %1, double %2, double %3) #1 {
+// CHECK-OPT-NOT:     %found.conflict
+// CHECK-OPT-NOT:     scalar.ph
+// CHECK-OPT:         vector.body
+// CHECK-OPT:       ret void
+public func rotate(_ x: inout InlineArray<64, Double>,
+                   _ y: inout InlineArray<64, Double>,
+                   _ c: Double, _ s: Double) {
+  for i in x.indices {
+    let xi = x[i], yi = y[i]
+    x[i] = c * xi + s * yi
+    y[i] = c * yi - s * xi
+  }
+}

--- a/test/IRGen/inout_noalias.swift
+++ b/test/IRGen/inout_noalias.swift
@@ -5,7 +5,7 @@
 @_silgen_name("swapPointers")
 public func swapPointers<T>(_ lhs: inout UnsafePointer<T>, _ rhs: inout UnsafePointer<T>) {}
 
-// CHECK-OPT-LABEL: define swiftcc void @"$s13inout_noalias6rotateyys11InlineArrayVy$63_SdGz_AEzS2dtF"(ptr noalias captures(none) dereferenceable(512) %0, ptr noalias captures(none) dereferenceable(512) %1, double %2, double %3) #1 {
+// CHECK-OPT-LABEL: define {{.*}} swiftcc void @"$s13inout_noalias6rotateyys11InlineArrayVy$63_SdGz_AEzS2dtF"(ptr noalias captures(none) dereferenceable(512) %0, ptr noalias captures(none) dereferenceable(512) %1, double %2, double %3) {
 // CHECK-OPT-NOT:     %found.conflict
 // CHECK-OPT-NOT:     scalar.ph
 // CHECK-OPT:         vector.body

--- a/test/IRGen/non_nested.sil
+++ b/test/IRGen/non_nested.sil
@@ -15,7 +15,7 @@ sil @use_pack : $@convention(thin) <each τ_0_0> (@pack_guaranteed Pack{repeat e
 // CHECK: [[INIT_WITH_COPY_PTR:%.*]] = getelementptr inbounds ptr, ptr [[VALUE_WITNESS_TABLE]], i32 2
 // CHECK: [[INIT_WITH_COPY:%.*]] = load ptr, ptr [[INIT_WITH_COPY_PTR]]
 // CHECK: call ptr %InitializeWithCopy(ptr {{.*}}[[MALLOC]], ptr {{.*}}[[IN]], ptr [[META]])
-// CHECK: call swiftcc void @use_value(ptr [[MALLOC]], ptr [[META]])
+// CHECK: call swiftcc void @use_value(ptr noalias [[MALLOC]], ptr [[META]])
 // CHECK: call void @llvm.lifetime.end.p0({{.*}} -1, ptr [[MALLOC]])
 // CHECK: call void @free(ptr [[MALLOC]])
 // CHECK-NEXT: ret void
@@ -40,7 +40,7 @@ bb0(%0 : $*T):
 // CHECK: [[INIT_WITH_COPY_PTR:%.*]] = getelementptr inbounds ptr, ptr [[VALUE_WITNESS_TABLE]], i32 2
 // CHECK: [[INIT_WITH_COPY:%.*]] = load ptr, ptr [[INIT_WITH_COPY_PTR]]
 // CHECK: call ptr %InitializeWithCopy(ptr {{.*}}[[MALLOC]], ptr {{.*}}[[IN]], ptr [[META]])
-// CHECK: call swiftcc void @use_value(ptr [[MALLOC]], ptr [[META]])
+// CHECK: call swiftcc void @use_value(ptr noalias [[MALLOC]], ptr [[META]])
 // CHECK: call void @llvm.lifetime.end.p0({{.*}} -1, ptr [[MALLOC]])
 // CHECK: call void @free(ptr [[MALLOC]])
 // CHECK-NEXT: ret void

--- a/test/IRGen/partial_apply_coro.sil
+++ b/test/IRGen/partial_apply_coro.sil
@@ -774,7 +774,7 @@ entry(%a : $SwiftClass, %b: $SwiftClass):
 
 // CHECK-32-LABEL: define {{.*}} { ptr, i32 } @generic_captured_param
 // CHECK-64-LABEL: define {{.*}} { ptr, i64 } @generic_captured_param
-// CHECK-SAME: (ptr noalias dereferenceable([[BUFFER_SIZE:(16|32)]]) %[[CTX:.*]], [[ARG_TYPE:(i32|i64)]] %[[ARG0:.*]], ptr %[[ARG1:.*]], ptr %[[ARG2:.*]])
+// CHECK-SAME: (ptr noalias dereferenceable([[BUFFER_SIZE:(16|32)]]) %[[CTX:.*]], [[ARG_TYPE:(i32|i64)]] %[[ARG0:.*]], ptr noalias %[[ARG1:.*]], ptr %[[ARG2:.*]])
 // CHECK: entry:
 // CHECK:   %[[RET0:.*]] = insertvalue { ptr, [[ARG_TYPE]] } poison, ptr @generic_captured_param.resume.0, 0
 // CHECK:   %[[RET1:.*]] = insertvalue { ptr, [[ARG_TYPE]] } %[[RET0]], [[ARG_TYPE]] %[[ARG0]], 1
@@ -825,7 +825,7 @@ bb2:
 // CHECK:   %[[ARG1:.*]] = load ptr, ptr %[[PA_CTX]]
 // CHECK:   %[[FRAMEPTR:.*]] = getelementptr inbounds{{.*}} [[[BUFFER_SIZE]] x i8], ptr %[[FRAME]], i32 0, i32 0
 // CHECK:   call void @llvm.lifetime.start.p0(i64 [[BUFFER_SIZE]], ptr %[[FRAMEPTR]])
-// CHECK:   %[[YIELD_PAIR:.*]] = call swiftcc { ptr, [[ARG_TYPE]] } @generic_captured_param(ptr noalias dereferenceable([[BUFFER_SIZE]]) %[[FRAMEPTR]], [[ARG_TYPE]] %[[ARG0]], ptr %[[ARG1]], ptr @"$sSiN")
+// CHECK:   %[[YIELD_PAIR:.*]] = call swiftcc { ptr, [[ARG_TYPE]] } @generic_captured_param(ptr noalias dereferenceable([[BUFFER_SIZE]]) %[[FRAMEPTR]], [[ARG_TYPE]] %[[ARG0]], ptr noalias %[[ARG1]], ptr @"$sSiN")
 // CHECK:   %[[RESUME:.*]] = extractvalue { ptr, [[ARG_TYPE]] } %[[YIELD_PAIR]], 0
 // CHECK:   %[[SPILL2:.*]] = getelementptr inbounds %"$s22generic_captured_paramTA.Frame", ptr %[[SPILL]], i32 0, i32 1
 // CHECK:   store ptr %[[RESUME]], ptr %[[SPILL2]]
@@ -870,7 +870,7 @@ entry(%x : $Int):
 }
 
 // CHECK-LABEL: define {{.*}} { ptr, ptr } @generic_captured_and_open_param
-// CHECK: (ptr noalias dereferenceable([[BUFFER_SIZE]]) %0, ptr noalias %1, ptr %2, ptr %T)
+// CHECK: (ptr noalias dereferenceable([[BUFFER_SIZE]]) %0, ptr noalias %1, ptr noalias %2, ptr %T)
 sil public @generic_captured_and_open_param : $@yield_once @convention(thin) <T> (@in T, @inout T) -> (@yields @in T) {
 entry(%i : $*T, %io : $*T):
   %0 = builtin "int_trap"() : $Never
@@ -878,7 +878,7 @@ entry(%i : $*T, %io : $*T):
 }
 
 // CHECK-LABEL: define{{.*}} swiftcc { ptr, ptr } @partial_apply_open_generic_capture
-// CHECK-SAME: (ptr %[[ARG0:.*]], ptr %[[ARG1:.*]])
+// CHECK-SAME: (ptr noalias %[[ARG0:.*]], ptr %[[ARG1:.*]])
 // CHECK: entry:
 // CHECK:   %[[BOX:.*]] = call noalias ptr @swift_allocObject(ptr getelementptr inbounds (%swift.full_boxmetadata, ptr @metadata
 // CHECK:   %[[BOXPTR1:.*]] = getelementptr inbounds{{.*}} <{ %swift.refcounted, [{{4|8}} x i8], ptr }>, ptr %[[BOX]], i32 0, i32 1
@@ -901,7 +901,7 @@ entry(%i : $*T, %io : $*T):
 // CHECK:   %[[ARG2:.*]] = load ptr, ptr %[[PA_CTX2]]
 // CHECK:   %[[FRAMEPTR:.*]] = getelementptr inbounds{{.*}} [[[BUFFER_SIZE]] x i8], ptr %[[FRAME]], i32 0, i32 0
 // CHECK:   call void @llvm.lifetime.start.p0(i64 [[BUFFER_SIZE]], ptr %[[FRAMEPTR]])
-// CHECK:   %[[YIELD_PAIR:.*]] = call swiftcc { ptr, ptr } @generic_captured_and_open_param(ptr noalias dereferenceable([[BUFFER_SIZE]]) %[[FRAMEPTR]], ptr noalias %[[ARG0]], ptr %[[ARG2]], ptr %[[ARG1]])
+// CHECK:   %[[YIELD_PAIR:.*]] = call swiftcc { ptr, ptr } @generic_captured_and_open_param(ptr noalias dereferenceable([[BUFFER_SIZE]]) %[[FRAMEPTR]], ptr noalias %[[ARG0]], ptr noalias %[[ARG2]], ptr %[[ARG1]])
 // CHECK:   %[[RESUME:.*]] = extractvalue { ptr, ptr } %[[YIELD_PAIR]], 0
 // CHECK:   %[[SPILL2:.*]] = getelementptr inbounds %"$s31generic_captured_and_open_paramTA.Frame", ptr %[[SPILL]], i32 0, i32 1
 // CHECK:   store ptr %[[RESUME]], ptr %[[SPILL2]]

--- a/test/IRGen/pre_specialize.swift
+++ b/test/IRGen/pre_specialize.swift
@@ -42,11 +42,11 @@
 // specialized InternalThing.computedX.getter
 // CHECK-A-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc [[INT]] @"$s1A13InternalThingV9computedXxvgSi_Ts5"([[INT]]{{( returned)?}} %0)
 // specialized InternalThing.computedX.setter
-// CHECK-A-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingV9computedXxvsSi_Ts5"([[INT]] %0, ptr {{(nofree )?}}swiftself {{(writeonly )?}}captures(none) dereferenceable({{(4|8)}}){{.*}} %1)
+// CHECK-A-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingV9computedXxvsSi_Ts5"([[INT]] %0, ptr noalias {{(nofree )?}}swiftself {{(writeonly )?}}captures(none) dereferenceable({{(4|8)}}){{.*}} %1)
 // specialized InternalThing.subscript.getter
 // CHECK-A-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc [[INT]] @"$s1A13InternalThingVyxSicigSi_Ts5"([[INT]] %0, [[INT]]{{( returned)?}} %1)
 // specialized InternalThing.subscript.setter
-// CHECK-A-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingVyxSicisSi_Ts5"([[INT]] %0, [[INT]] %1, ptr {{(nofree )?}}swiftself {{(writeonly )?}}captures(none) dereferenceable({{(4|8)}}){{.*}} %2)
+// CHECK-A-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingVyxSicisSi_Ts5"([[INT]] %0, [[INT]] %1, ptr noalias {{(nofree )?}}swiftself {{(writeonly )?}}captures(none) dereferenceable({{(4|8)}}){{.*}} %2)
 
 // specialized InternalRef.compute()
 // CHECK-A-FRAG-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc [[INT:(i64|i32)]] @"$s1A11InternalRefC7computexyFAA09ResilientA10BoxedThingVySiG_Ts5"
@@ -75,13 +75,13 @@
 // CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @"$s1A13InternalThingV9computedXxvg1B07AnotherB0C_Ts5"(ptr{{( returned)?}} %0)
 
 // specialized InternalThing.computedX.setter
-// CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingV9computedXxvs1B07AnotherB0C_Ts5"(ptr %0, ptr {{(nofree )?}}swiftself captures(none) dereferenceable({{(4|8)}}) %1)
+// CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingV9computedXxvs1B07AnotherB0C_Ts5"(ptr %0, ptr noalias swiftself captures(none) dereferenceable({{(4|8)}}) %1)
 
 // specialized InternalThing.subscript.getter
 // CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @"$s1A13InternalThingVyxSicig1B07AnotherB0C_Ts5"([[INT:(i64|i32)]] %0, ptr{{( returned)?}} %1)
 
 // specialized InternalThing.subscript.setter
-// CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingVyxSicis1B07AnotherB0C_Ts5"(ptr %0, [[INT]] %1, ptr {{(nofree )?}}swiftself captures(none) dereferenceable({{(4|8)}}) %2)
+// CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingVyxSicis1B07AnotherB0C_Ts5"(ptr %0, [[INT]] %1, ptr noalias swiftself captures(none) dereferenceable({{(4|8)}}) %2)
 
 // specialized InternalRef.compute()
 // CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @"$s1A11InternalRefC7computexyF1B12AnotherThingC_Ts5

--- a/test/IRGen/pre_specialize.swift
+++ b/test/IRGen/pre_specialize.swift
@@ -42,11 +42,11 @@
 // specialized InternalThing.computedX.getter
 // CHECK-A-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc [[INT]] @"$s1A13InternalThingV9computedXxvgSi_Ts5"([[INT]]{{( returned)?}} %0)
 // specialized InternalThing.computedX.setter
-// CHECK-A-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingV9computedXxvsSi_Ts5"([[INT]] %0, ptr swiftself {{(writeonly )?}}captures(none) dereferenceable({{(4|8)}}){{.*}} %1)
+// CHECK-A-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingV9computedXxvsSi_Ts5"([[INT]] %0, ptr noalias swiftself {{(writeonly )?}}captures(none) dereferenceable({{(4|8)}}){{.*}} %1)
 // specialized InternalThing.subscript.getter
 // CHECK-A-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc [[INT]] @"$s1A13InternalThingVyxSicigSi_Ts5"([[INT]] %0, [[INT]]{{( returned)?}} %1)
 // specialized InternalThing.subscript.setter
-// CHECK-A-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingVyxSicisSi_Ts5"([[INT]] %0, [[INT]] %1, ptr swiftself {{(writeonly )?}}captures(none) dereferenceable({{(4|8)}}){{.*}} %2)
+// CHECK-A-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingVyxSicisSi_Ts5"([[INT]] %0, [[INT]] %1, ptr noalias swiftself {{(writeonly )?}}captures(none) dereferenceable({{(4|8)}}){{.*}} %2)
 
 // specialized InternalRef.compute()
 // CHECK-A-FRAG-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc [[INT:(i64|i32)]] @"$s1A11InternalRefC7computexyFAA09ResilientA10BoxedThingVySiG_Ts5"
@@ -75,13 +75,13 @@
 // CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @"$s1A13InternalThingV9computedXxvg1B07AnotherB0C_Ts5"(ptr{{( returned)?}} %0)
 
 // specialized InternalThing.computedX.setter
-// CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingV9computedXxvs1B07AnotherB0C_Ts5"(ptr %0, ptr swiftself captures(none) dereferenceable({{(4|8)}}) %1)
+// CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingV9computedXxvs1B07AnotherB0C_Ts5"(ptr %0, ptr noalias swiftself captures(none) dereferenceable({{(4|8)}}) %1)
 
 // specialized InternalThing.subscript.getter
 // CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @"$s1A13InternalThingVyxSicig1B07AnotherB0C_Ts5"([[INT:(i64|i32)]] %0, ptr{{( returned)?}} %1)
 
 // specialized InternalThing.subscript.setter
-// CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingVyxSicis1B07AnotherB0C_Ts5"(ptr %0, [[INT]] %1, ptr swiftself captures(none) dereferenceable({{(4|8)}}) %2)
+// CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingVyxSicis1B07AnotherB0C_Ts5"(ptr %0, [[INT]] %1, ptr noalias swiftself captures(none) dereferenceable({{(4|8)}}) %2)
 
 // specialized InternalRef.compute()
 // CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @"$s1A11InternalRefC7computexyF1B12AnotherThingC_Ts5

--- a/test/IRGen/protocol_resilience_thunks.swift
+++ b/test/IRGen/protocol_resilience_thunks.swift
@@ -84,18 +84,18 @@ public protocol MyResilientProtocol {
 // CHECK-NEXT: [[RESULT:%.*]] = call swiftcc i1 [[WITNESS]](ptr noalias swiftself %0, ptr %1, ptr %2)
 // CHECK-NEXT: ret i1 [[RESULT]]
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s26protocol_resilience_thunks19MyResilientProtocolP8propertySbvsTj"(i1 %0, ptr swiftself %1, ptr %2, ptr %3)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s26protocol_resilience_thunks19MyResilientProtocolP8propertySbvsTj"(i1 %0, ptr noalias swiftself %1, ptr %2, ptr %3)
 // CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds ptr, ptr %3, i32 7
 // CHECK-NEXT: [[WITNESS:%.*]] = load ptr, ptr [[WITNESS_ADDR]]
 // CHECK-arm64e-NEXT: ptrtoint ptr [[WITNESS_ADDR]] to i64
 // CHECK-arm64e-NEXT: call i64 @llvm.ptrauth.blend
-// CHECK-NEXT: call swiftcc void [[WITNESS]](i1 %0, ptr swiftself %1, ptr %2, ptr %3)
+// CHECK-NEXT: call swiftcc void [[WITNESS]](i1 %0, ptr noalias swiftself %1, ptr %2, ptr %3)
 // CHECK-NEXT: ret void
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @"$s26protocol_resilience_thunks19MyResilientProtocolP8propertySbvMTj"(ptr noalias dereferenceable({{16|32}}) %0, ptr swiftself %1, ptr %2, ptr %3)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @"$s26protocol_resilience_thunks19MyResilientProtocolP8propertySbvMTj"(ptr noalias dereferenceable({{16|32}}) %0, ptr noalias swiftself %1, ptr %2, ptr %3)
 // CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds ptr, ptr %3, i32 8
 // CHECK-NEXT: [[WITNESS:%.*]] = load ptr, ptr [[WITNESS_ADDR]]
 // CHECK-arm64e-NEXT: ptrtoint ptr [[WITNESS_ADDR]] to i64
 // CHECK-arm64e-NEXT: call i64 @llvm.ptrauth.blend
-// CHECK-NEXT: [[RESULT:%.*]] = call swiftcc { ptr, ptr } [[WITNESS]](ptr noalias dereferenceable({{16|32}}) %0, ptr swiftself %1, ptr %2, ptr %3)
+// CHECK-NEXT: [[RESULT:%.*]] = call swiftcc { ptr, ptr } [[WITNESS]](ptr noalias dereferenceable({{16|32}}) %0, ptr noalias swiftself %1, ptr %2, ptr %3)
 // CHECK-NEXT: ret { ptr, ptr } [[RESULT]]

--- a/test/IRGen/unconditional_checked_cast.sil
+++ b/test/IRGen/unconditional_checked_cast.sil
@@ -10,7 +10,7 @@ sil_vtable C {}
 class D : C {}
 sil_vtable D {}
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @downcast_test(ptr noalias sret({{.*}}) captures(none) %0, ptr captures(none) dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @downcast_test(ptr noalias sret({{.*}}) captures(none) %0, ptr noalias captures(none) dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK: entry:
 // CHECK-NEXT: [[INPUTPTR:%[0-9]+]] = load ptr, ptr [[INPUTPTRPTR:%[0-9]+]], align 8
 // CHECK-NEXT: [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$s26unconditional_checked_cast1DCMa"(i64 0)

--- a/test/IRGen/variadic_generics.sil
+++ b/test/IRGen/variadic_generics.sil
@@ -141,7 +141,7 @@ entry(%addr : $*T):
 }
 
 // CHECK-LABEL: define {{.*}}@test_tuple_pack_element_addr_1(
-// CHECK-SAME:        ptr [[TUPLE_ADDR:%[^,]+]], i{{(64|32)}} [[INDEX:%[^,]+]]
+// CHECK-SAME:        ptr noalias [[TUPLE_ADDR:%[^,]+]], i{{(64|32)}} [[INDEX:%[^,]+]]
 // CHECK:         [[ELT_TYPE:%.*]] = phi ptr [
 // CHECK:         [[RESPONSE:%[^,]+]] = call swiftcc %swift.metadata_response @swift_getTupleTypeMetadata
 // CHECK:         [[UNCAST_METADATA:%[^,]+]] = extractvalue %swift.metadata_response [[RESPONSE]], 0

--- a/test/IRGen/weak.sil
+++ b/test/IRGen/weak.sil
@@ -36,7 +36,7 @@ bb0(%0 : $*A, %1 : $Optional<C>):
   %4 = tuple ()
   return %4 : $()
 }
-// CHECK:    define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_weak_load_store(ptr dereferenceable({{.*}}) %0, ptr %1) {{.*}} {
+// CHECK:    define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_weak_load_store(ptr noalias dereferenceable({{.*}}) %0, ptr %1) {{.*}} {
 // CHECK:      [[X:%.*]] = getelementptr inbounds{{.*}} [[A:%T4weak1AV]], ptr %0, i32 0, i32 0
 // CHECK-NEXT: [[T0:%.*]] = call ptr @swift_weakLoadStrong(ptr [[X]])
 // CHECK-NEXT: call ptr @swift_weakAssign(ptr returned [[X]], ptr %1)
@@ -56,7 +56,7 @@ bb0(%0 : $*B, %1 : $Optional<P>):
   %4 = tuple ()
   return %4 : $()
 }
-// CHECK:    define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_weak_load_store_proto(ptr dereferenceable({{.*}}) %0, ptr %1, ptr %2)
+// CHECK:    define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_weak_load_store_proto(ptr noalias dereferenceable({{.*}}) %0, ptr %1, ptr %2)
 // CHECK:      [[X:%.*]] = getelementptr inbounds{{.*}} [[B:%T4weak1BV]], ptr %0, i32 0, i32 0
 // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds{{.*}} { [[WEAK:%swift.weak]], ptr }, ptr [[X]], i32 0, i32 0
 // CHECK-NEXT: [[T1:%.*]] = call ptr @swift_unknownObjectWeakLoadStrong(ptr [[T0]])

--- a/test/IRGen/weak.sil
+++ b/test/IRGen/weak.sil
@@ -36,7 +36,7 @@ bb0(%0 : $*A, %1 : $Optional<C>):
   %4 = tuple ()
   return %4 : $()
 }
-// CHECK:    define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_weak_load_store(ptr dereferenceable({{.*}}) %0, ptr %1) {{.*}} {
+// CHECK:    define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_weak_load_store(ptr noalias dereferenceable({{.*}}) %0, ptr %1) {{.*}} {
 // CHECK:      [[X:%.*]] = getelementptr inbounds{{.*}} [[A:%T4weak1AV]], ptr %0, i32 0, i32 0
 // CHECK-NEXT: [[T0:%.*]] = call ptr @swift_weakLoadStrong(ptr [[X]])
 // CHECK-NEXT: call ptr @swift_weakAssign(ptr returned [[X]], ptr %1)

--- a/test/Interop/Cxx/class/inheritance/virtual-methods-irgen.swift
+++ b/test/Interop/Cxx/class/inheritance/virtual-methods-irgen.swift
@@ -20,7 +20,7 @@ d4.f()
 // CHECK: call {{.*}} @{{_ZN8Derived31fEv|"\?f@Derived3@@UEAAHXZ"}}
 // CHECK: call swiftcc {{.*}} @"$sSo8Derived4V1fs5Int32VyF"
 
-// CHECK: define {{.*}} @"$sSo8Derived4V1fs5Int32VyF"(ptr swiftself dereferenceable
+// CHECK: define {{.*}} @"$sSo8Derived4V1fs5Int32VyF"(ptr noalias swiftself dereferenceable
 // CHECK: call {{.*}}  @{{.*}}__synthesizedBaseCall_{{.*}}
 
 // CHECK: define {{.*}}void @{{_ZN7DerivedIiE3fooEv|"\?foo@\?\$Derived@H@@UEAAXXZ"}}

--- a/test/Interop/Cxx/class/protocol-conformance-irgen.swift
+++ b/test/Interop/Cxx/class/protocol-conformance-irgen.swift
@@ -7,7 +7,7 @@ protocol HasReturn42 {
 }
 
 
-// CHECK: define {{.*}}i32 @"$sSo18ConformsToProtocolV4main11HasReturn42A2cDP8return42s5Int32VyFTW"(ptr swiftself captures(none) dereferenceable(1) %{{.*}}, ptr %{{.*}}, ptr %{{.*}})
+// CHECK: define {{.*}}i32 @"$sSo18ConformsToProtocolV4main11HasReturn42A2cDP8return42s5Int32VyFTW"(ptr noalias swiftself captures(none) dereferenceable(1) %{{.*}}, ptr %{{.*}}, ptr %{{.*}})
 // CHECK: [[OUT:%.*]] = call i32 @{{_ZN18ConformsToProtocol8return42Ev|"\?return42@ConformsToProtocol@@QEAAHXZ"}}(ptr
 // CHECK: ret i32 [[OUT]]
 

--- a/test/Interop/Cxx/extern-var/extern-var-irgen.swift
+++ b/test/Interop/Cxx/extern-var/extern-var-irgen.swift
@@ -44,4 +44,4 @@ public func passingVarAsInout() {
 }
 
 // CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main17passingVarAsInoutyyF"() #0
-// CHECK: call swiftcc void @"$s4main11modifyInoutyys5Int32VzF"(ptr captures(none) dereferenceable(4) @{{counter|"\?counter@@3HA"}})
+// CHECK: call swiftcc void @"$s4main11modifyInoutyys5Int32VzF"(ptr noalias captures(none) dereferenceable(4) @{{counter|"\?counter@@3HA"}})

--- a/test/Interop/Cxx/static/inline-static-member-var-irgen.swift
+++ b/test/Interop/Cxx/static/inline-static-member-var-irgen.swift
@@ -28,4 +28,4 @@ public func passingVarAsInout() {
 }
 
 // CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main17passingVarAsInoutyyF"()
-// CHECK: call swiftcc void @"$s4main11modifyInoutyys5Int32VzF"(ptr captures(none) dereferenceable(4) @{{_ZN22WithInlineStaticMember12staticMemberE|"\?staticMember@WithInlineStaticMember@@2HA"}})
+// CHECK: call swiftcc void @"$s4main11modifyInoutyys5Int32VzF"(ptr noalias captures(none) dereferenceable(4) @{{_ZN22WithInlineStaticMember12staticMemberE|"\?staticMember@WithInlineStaticMember@@2HA"}})

--- a/test/Interop/Cxx/static/static-var-irgen.swift
+++ b/test/Interop/Cxx/static/static-var-irgen.swift
@@ -85,7 +85,7 @@ public func passingVarAsInout() {
   modifyInout(&staticVar)
 }
 // CHECK: define {{.*}}void @"$s4main17passingVarAsInoutyyF"()
-// CHECK: call swiftcc void @"$s4main11modifyInoutyys5Int32VzF"(ptr captures(none) dereferenceable(4) @{{_ZL9staticVar|staticVar}})
+// CHECK: call swiftcc void @"$s4main11modifyInoutyys5Int32VzF"(ptr noalias captures(none) dereferenceable(4) @{{_ZL9staticVar|staticVar}})
 
 // CHECK: define internal void @_GLOBAL__sub_I__swift_imported_modules_()
 // CHECK: call void @{{__cxx_global_var_init|"\?\?__EstaticVarInit@@YAXXZ"}}()

--- a/test/Interop/Cxx/templates/mangling-irgen.swift
+++ b/test/Interop/Cxx/templates/mangling-irgen.swift
@@ -4,12 +4,12 @@ import Mangling
 
 public func receiveInstantiation(_ i: inout WrappedMagicBool) {}
 
-// CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main20receiveInstantiationyySo0025MagicWrapperCBool_lsFCfibVzF"(ptr captures(none) dereferenceable(1) %0)
+// CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main20receiveInstantiationyySo0025MagicWrapperCBool_lsFCfibVzF"(ptr noalias captures(none) dereferenceable(1) %0)
 
 public func receiveInstantiation(_ i: inout WrappedMagicInt) {}
 
 // Don't forget to update manglings.txt when changing s4main20receiveInstantiationyySo34__CxxTemplateInst12MagicWrapperIiEVzF
-// CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main20receiveInstantiationyySo0024MagicWrapperCInt_npAIefbVzF"(ptr captures(none) dereferenceable(1) %0)
+// CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main20receiveInstantiationyySo0024MagicWrapperCInt_npAIefbVzF"(ptr noalias captures(none) dereferenceable(1) %0)
 
 public func returnInstantiation() -> WrappedMagicInt {
   return WrappedMagicInt()

--- a/test/SILOptimizer/eager_specialize.sil
+++ b/test/SILOptimizer/eager_specialize.sil
@@ -698,7 +698,7 @@ bb0(%0 : $*Self, %1 : $*Self, %2 : $@thick Self.Type):
 
 // Check that a specialization for _Trivial(32) uses direct loads and stores
 // instead of value witness functions to load and store the value of a generic type.
-// CHECK-IRGEN-LABEL: define linkonce_odr hidden swiftcc void @"$s16eager_specialize18copyValueAndReturn_1sxx_xztlFxxxRlze31_lIetilr_Tp5"(ptr noalias sret(i32) captures(none) %0, ptr noalias captures(none) dereferenceable(4) %1, ptr captures(none) dereferenceable(4) %2, ptr %S
+// CHECK-IRGEN-LABEL: define linkonce_odr hidden swiftcc void @"$s16eager_specialize18copyValueAndReturn_1sxx_xztlFxxxRlze31_lIetilr_Tp5"(ptr noalias sret(i32) captures(none) %0, ptr noalias captures(none) dereferenceable(4) %1, ptr noalias captures(none) dereferenceable(4) %2, ptr %S
 // CHECK-IRGEN: entry:
 // CHECK-IRGEN:       %3 = load i32, ptr %2
 // CHECK-IRGEN-NEXT:  store i32 %3, ptr %0
@@ -707,7 +707,7 @@ bb0(%0 : $*Self, %1 : $*Self, %2 : $@thick Self.Type):
 
 // Check that a specialization for _Trivial(64) uses direct loads and stores
 // instead of value witness functions to load and store the value of a generic type.
-// CHECK-IRGEN-LABEL: define linkonce_odr hidden swiftcc void @"$s16eager_specialize18copyValueAndReturn_1sxx_xztlFxxxRlze63_lIetilr_Tp5"(ptr noalias sret(i64) captures(none) %0, ptr noalias captures(none) dereferenceable(8) %1, ptr captures(none) dereferenceable(8) %2, ptr %S
+// CHECK-IRGEN-LABEL: define linkonce_odr hidden swiftcc void @"$s16eager_specialize18copyValueAndReturn_1sxx_xztlFxxxRlze63_lIetilr_Tp5"(ptr noalias sret(i64) captures(none) %0, ptr noalias captures(none) dereferenceable(8) %1, ptr noalias captures(none) dereferenceable(8) %2, ptr %S
 // CHECK-IRGEN: entry:
 // CHECK-IRGEN:        %3 = load i64, ptr %2
 // CHECK-IRGEN-NEXT:   store i64 %3, ptr %0
@@ -716,7 +716,7 @@ bb0(%0 : $*Self, %1 : $*Self, %2 : $@thick Self.Type):
 
 // Check that a specialization for _Trivial does not call the 'destroy' value witness,
 // because it is known that the object is Trivial, i.e. contains no references.
-// CHECK-IRGEN-LABEL: define linkonce_odr hidden swiftcc void @"$s16eager_specialize19copyValueAndReturn2_1sxx_xztlFxxxRlzTlIetilr_Tp5"(ptr noalias sret(%swift.opaque) %0, ptr noalias %1, ptr %2, ptr %S
+// CHECK-IRGEN-LABEL: define linkonce_odr hidden swiftcc void @"$s16eager_specialize19copyValueAndReturn2_1sxx_xztlFxxxRlzTlIetilr_Tp5"(ptr noalias sret(%swift.opaque) %0, ptr noalias %1, ptr noalias %2, ptr %S
 // CHECK-IRGEN-NEXT: entry:
 // CHECK-IRGEN:   %3 = getelementptr inbounds ptr, ptr %S, i{{.*}} -1
 // CHECK-IRGEN-NEXT:   %S.valueWitnesses = load ptr, ptr %3

--- a/test/SILOptimizer/eager_specialize_ossa.sil
+++ b/test/SILOptimizer/eager_specialize_ossa.sil
@@ -886,7 +886,7 @@ bb0(%0 : $*Self, %1 : $*Self, %2 : $@thick Self.Type):
 
 // Check that a specialization for _Trivial(32) uses direct loads and stores
 // instead of value witness functions to load and store the value of a generic type.
-// CHECK-IRGEN-LABEL: define linkonce_odr hidden swiftcc void @"$s16eager_specialize18copyValueAndReturn_1sxx_xztlFxxxRlze31_lIetilr_Tp5"(ptr noalias sret(i32) captures(none) %0, ptr noalias captures(none) dereferenceable(4) %1, ptr captures(none) dereferenceable(4) %2, ptr %S
+// CHECK-IRGEN-LABEL: define linkonce_odr hidden swiftcc void @"$s16eager_specialize18copyValueAndReturn_1sxx_xztlFxxxRlze31_lIetilr_Tp5"(ptr noalias sret(i32) captures(none) %0, ptr noalias captures(none) dereferenceable(4) %1, ptr noalias captures(none) dereferenceable(4) %2, ptr %S
 // CHECK-IRGEN: entry:
 // CHECK-IRGEN:       %3 = load i32, ptr %2
 // CHECK-IRGEN-NEXT:  store i32 %3, ptr %0
@@ -895,7 +895,7 @@ bb0(%0 : $*Self, %1 : $*Self, %2 : $@thick Self.Type):
 
 // Check that a specialization for _Trivial(64) uses direct loads and stores
 // instead of value witness functions to load and store the value of a generic type.
-// CHECK-IRGEN-LABEL: define linkonce_odr hidden swiftcc void @"$s16eager_specialize18copyValueAndReturn_1sxx_xztlFxxxRlze63_lIetilr_Tp5"(ptr noalias sret(i64) captures(none) %0, ptr noalias captures(none) dereferenceable(8) %1, ptr captures(none) dereferenceable(8) %2, ptr %S
+// CHECK-IRGEN-LABEL: define linkonce_odr hidden swiftcc void @"$s16eager_specialize18copyValueAndReturn_1sxx_xztlFxxxRlze63_lIetilr_Tp5"(ptr noalias sret(i64) captures(none) %0, ptr noalias captures(none) dereferenceable(8) %1, ptr noalias captures(none) dereferenceable(8) %2, ptr %S
 // CHECK-IRGEN: entry:
 // CHECK-IRGEN:        %3 = load i64, ptr %2
 // CHECK-IRGEN-NEXT:   store i64 %3, ptr %0
@@ -904,7 +904,7 @@ bb0(%0 : $*Self, %1 : $*Self, %2 : $@thick Self.Type):
 
 // Check that a specialization for _Trivial does not call the 'destroy' value witness,
 // because it is known that the object is Trivial, i.e. contains no references.
-// CHECK-IRGEN-LABEL: define linkonce_odr hidden swiftcc void @"$s16eager_specialize19copyValueAndReturn2_1sxx_xztlFxxxRlzTlIetilr_Tp5"(ptr noalias sret(%swift.opaque) %0, ptr noalias %1, ptr %2, ptr %S
+// CHECK-IRGEN-LABEL: define linkonce_odr hidden swiftcc void @"$s16eager_specialize19copyValueAndReturn2_1sxx_xztlFxxxRlzTlIetilr_Tp5"(ptr noalias sret(%swift.opaque) %0, ptr noalias %1, ptr noalias %2, ptr %S
 // CHECK-IRGEN-NEXT: entry:
 // CHECK-IRGEN:   %3 = getelementptr inbounds ptr, ptr %S, i{{.*}} -1
 // CHECK-IRGEN-NEXT:   %S.valueWitnesses = load ptr, ptr %3


### PR DESCRIPTION
Swift guarantees exclusivity which means `inout` parameters with `@inout` parameter convention cannot alias. Previously only `inout` parameters of certain types had `noalias` attribute. Expand this to all `inout` parameters. 

This can avoid unnecessary `memcheck` and scalar loop generated by llvm's vectorizer in some cases.