### PR TITLE
[DebugInfo] Encode class-constrained and objc-constrained protocols

### DIFF
--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -1984,6 +1984,8 @@ Address irgen::emitOpaqueExistentialContainerInit(IRGenFunction &IGF,
   llvm::Value *metadata = IGF.emitTypeMetadataRef(formalSrcType);
   IGF.Builder.CreateStore(metadata, destLayout.projectMetadataRef(IGF, dest));
 
+  if (IGF.IGM.isEmbeddedWithExistentials() && IGF.IGM.DebugInfo)
+    IGF.IGM.DebugInfo->emitExistentialPayloadType(formalSrcType);
 
   // Next, write the protocol witness tables.
   forEachProtocolWitnessTable(IGF, formalSrcType, &metadata,

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -290,6 +290,17 @@ public:
   void emitPackCountParameter(IRGenFunction &IGF, llvm::Value *Metadata,
                               SILDebugVariable VarInfo);
 
+  void emitExistentialPayloadType(swift::Type Ty) {
+    if (Opts.DebugInfoLevel <= IRGenDebugInfoLevel::ASTTypes)
+      return;
+    if (!Ty || Ty->hasTypeParameter() || Ty->hasArchetype())
+      return;
+
+    auto DbgTy = DebugTypeInfo::getFromTypeInfo(
+        Ty, IGM.getTypeInfoForUnlowered(Ty), IGM);
+    anchorType(getOrCreateType(DbgTy));
+  }
+
   /// Return flags which enable debug info emission for call sites, provided
   /// that it is supported and enabled.
   llvm::DINode::DIFlags getCallSiteRelatedAttrs() const;
@@ -2239,16 +2250,25 @@ private:
 
       llvm::DINodeArray Annotations = nullptr;
       if (auto *PD = dyn_cast_or_null<ProtocolDecl>(Decl)) {
-        if (PD->isMarkerProtocol()) {
+        SmallVector<llvm::Metadata *, 2> Annots;
+        auto addFlag = [&](StringRef Name) {
           llvm::Metadata *Ops[2] = {
-              llvm::MDString::get(IGM.getLLVMContext(),
-                                  StringRef("swift.MarkerProtocol")),
+              llvm::MDString::get(IGM.getLLVMContext(), Name),
               llvm::ConstantAsMetadata::get(llvm::ConstantInt::get(
                   llvm::Type::getInt1Ty(IGM.getLLVMContext()), true))};
-          SmallVector<llvm::Metadata *, 1> Annots = {
-              llvm::MDNode::get(IGM.getLLVMContext(), Ops)};
+          Annots.push_back(llvm::MDNode::get(IGM.getLLVMContext(), Ops));
+        };
+
+        if (PD->isMarkerProtocol())
+          addFlag("swift.MarkerProtocol");
+
+        if (PD->isObjC())
+          addFlag("swift.ObjCProtocol");
+        else if (PD->requiresClass())
+          addFlag("swift.ClassConstrainedProtocol");
+
+        if (!Annots.empty())
           Annotations = DBuilder.getOrCreateArray(Annots);
-        }
       }
 
       return createOpaqueStruct(Scope, Decl ? Decl->getNameStr() : MangledName,
@@ -4487,6 +4507,10 @@ void IRGenDebugInfo::emitPackCountParameter(IRGenFunction &IGF,
                                             SILDebugVariable VarInfo) {
   static_cast<IRGenDebugInfoImpl *>(this)->emitPackCountParameter(IGF, Metadata,
                                                                   VarInfo);
+}
+
+void IRGenDebugInfo::emitExistentialPayloadType(swift::Type Ty) {
+  static_cast<IRGenDebugInfoImpl *>(this)->emitExistentialPayloadType(Ty);
 }
 
 llvm::DIBuilder &IRGenDebugInfo::getBuilder() {

--- a/lib/IRGen/IRGenDebugInfo.h
+++ b/lib/IRGen/IRGenDebugInfo.h
@@ -193,6 +193,14 @@ public:
   void emitPackCountParameter(IRGenFunction &IGF, llvm::Value *Metadata,
                               SILDebugVariable VarInfo);
 
+  /// Emit and retain complete debug info for a type that is only ever used as
+  /// the payload of an existential.
+  ///
+  /// Debug info is otherwise only emitted for types that some variable or
+  /// parameter has, so a type that appears solely inside an existential gets
+  /// none.
+  void emitExistentialPayloadType(swift::Type Ty);
+
   /// Return the DIBuilder.
   llvm::DIBuilder &getBuilder();
 };

--- a/test/DebugInfo/protocol_class_constraint.swift
+++ b/test/DebugInfo/protocol_class_constraint.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s
+
+class Base {}
+
+protocol Opaque {}
+protocol AnyObjectBound: AnyObject {}
+protocol SuperclassBound: Base {}
+
+class C: Opaque, AnyObjectBound {}
+class D: Base, SuperclassBound {}
+
+func f() {
+  let opaque: any Opaque = C()
+  let anyObjectBound: any AnyObjectBound = C()
+  let superclassBound: any SuperclassBound = D()
+}
+
+// Both a class constraint spelled as AnyObject and one implied by a superclass
+// requirement are annotated, and share the annotation.
+// CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "AnyObjectBound"{{.*}}annotations: ![[ANNOT:[0-9]+]]
+// CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "SuperclassBound"{{.*}}annotations: ![[ANNOT]]
+// CHECK-DAG: ![[ANNOT]] = !{![[ENTRY:[0-9]+]]}
+// CHECK-DAG: ![[ENTRY]] = !{!"swift.ClassConstrainedProtocol", i1 true}
+
+// An unconstrained protocol carries no annotation, which is what gives it the
+// plain Protocol field descriptor kind.
+// CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "Opaque"{{.*}}identifier: "{{.*}}6Opaque_pD")

--- a/test/DebugInfo/protocol_objc_annotation.swift
+++ b/test/DebugInfo/protocol_objc_annotation.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+@objc protocol ObjCBound {}
+
+// An @objc protocol has no witness table, which the debugger needs to know to
+// lay out an existential of it.
+// CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "ObjCBound"{{.*}}annotations: ![[ANNOT:[0-9]+]]
+// CHECK-DAG: ![[ANNOT]] = !{![[ENTRY:[0-9]+]]}
+// CHECK-DAG: ![[ENTRY]] = !{!"swift.ObjCProtocol", i1 true}
+
+class C: NSObject, ObjCBound {}
+
+func f() {
+  let objcBound: any ObjCBound = C()
+}


### PR DESCRIPTION
A protocol's constraint decides the layout of an existential of it: a class-constrained existential is a reference plus witness tables, while an opaque one also has an inline buffer and a metadata pointer. Without reflection metadata, there's no way to tell which case a protocol is, so we need to encode it in DWARF.

Assisted-by: claude

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
