### PR TITLE
[rbi] Rewrite isolation-history notes on top of real partition rewinding

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -1307,14 +1307,14 @@ GROUPED_NOTE(regionbasedisolation_value_became_part_of_isolated_region,
 
 GROUPED_NOTE(regionbasedisolation_chain_value_exposed,
      RegionIsolationIsolationHistory, none,
-     "%0 is connected to %1",
-     (Identifier, Identifier))
+     "%select{|result of }1%0 is connected to %select{|result of }3%2",
+     (Identifier, bool, Identifier, bool))
 
 GROUPED_NOTE(regionbasedisolation_chain_value_exposed_to_isolated_named,
      RegionIsolationIsolationHistory, none,
-     "%0 is connected to %1 which is accessible to "
-     "%select{%2 code|code in the current isolation context}3",
-     (Identifier, Identifier, StringRef, bool))
+     "%select{|result of }1%0 is connected to %select{|result of }3%2 which is "
+     "accessible to %select{%4 code|code in the current isolation context}5",
+     (Identifier, bool, Identifier, bool, StringRef, bool))
 
 // Concurrency related diagnostics
 ERROR(executor_factory_must_conform, none,

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -262,6 +262,15 @@ private:
 /// Partition must have no sends to use this. NOTE: There is a method that
 /// takes a Partition and produces a new Partition that does not have any
 /// sends.
+///
+/// Recording is opt-in per function. Only one client rewinds this history --
+/// the isolation-history notes on a sent-non-Sendable error -- and those notes
+/// are off unless the function asks for them (\c
+/// swift::shouldEmitIsolationHistoryFor). Recording anyway would push a node
+/// per PartitionOp per dataflow iteration for every function the region
+/// analysis runs on, so a Factory built with recording off makes every push a
+/// no-op and the history stays empty. Anything that rewinds asserts that
+/// recording was on, so the two gates cannot silently drift apart.
 class IsolationHistory {
 public:
   class Factory;
@@ -292,6 +301,10 @@ public:
   }
 
   Node *getHead() const { return head; }
+
+  /// True when the Factory backing this history records nodes. Every push is a
+  /// no-op when this is false.
+  bool isEnabled() const;
 
   /// Push a node that signals the end of a new sequence of history nodes that
   /// should execute together. Must be explicitly ended by a push sequence
@@ -556,17 +569,32 @@ class IsolationHistory::Factory {
 
   llvm::BumpPtrAllocator &allocator;
 
+  /// Whether the histories this hands out record anything. See the note on
+  /// \c IsolationHistory for why this is opt-in.
+  bool enabled;
+
 public:
-  Factory(llvm::BumpPtrAllocator &allocator) : allocator(allocator) {}
+  /// \p enabled whether the histories this hands out record nodes. Pass
+  /// \c swift::shouldEmitIsolationHistoryFor(fn) for the function being
+  /// analyzed; pass true only when the client is going to rewind the history
+  /// regardless, as the unit tests do.
+  Factory(llvm::BumpPtrAllocator &allocator, bool enabled)
+      : allocator(allocator), enabled(enabled) {}
 
   Factory(IsolationHistory::Factory &&other) = delete;
   Factory &operator=(IsolationHistory::Factory &&other) = delete;
   Factory(const IsolationHistory::Factory &other) = delete;
   Factory &operator=(const IsolationHistory::Factory &other) = delete;
 
+  bool isEnabled() const { return enabled; }
+
   /// Returns a new isolation history without any history.
   IsolationHistory get() { return IsolationHistory(this); }
 };
+
+inline bool IsolationHistory::isEnabled() const {
+  return factory && factory->enabled;
+}
 
 /// A struct that represents a specific "sending" operand of an ApplySite.
 struct SendingOperandState {

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -299,7 +299,12 @@ public:
   ///
   /// \p loc the SILLocation that identifies the instruction that the "package"
   /// of history nodes that this sequence boundary ends is associated with.
-  Node *pushHistorySequenceBoundary(SILLocation loc);
+  ///
+  /// \p inst the instruction whose PartitionOp produced that package, when the
+  /// boundary is pushed on behalf of one. Retained so that a client rewinding
+  /// the history can report which instruction it is undoing.
+  Node *pushHistorySequenceBoundary(SILLocation loc,
+                                    SILInstruction *inst = nullptr);
 
   /// Push onto the history list that \p value should be added into its own
   /// independent region.
@@ -389,6 +394,18 @@ private:
   /// The next pointer of the linked list.
   Node *next;
 
+  /// The payload of a SequenceBoundary node: the location the "package" of
+  /// history nodes this boundary ends is attributed to, plus the instruction
+  /// the PartitionOp that produced the package came from.
+  ///
+  /// The location is tracked separately from the instruction because for
+  /// PartitionOps sourced from a specific apply argument it is that argument's
+  /// per-argument location rather than the instruction's own location.
+  struct SequenceBoundaryInfo {
+    SILLocation loc;
+    SILInstruction *inst;
+  };
+
   /// Contains:
   ///
   /// 1. A SILBasicBlock * if we have a CFGHistoryJoin — the predecessor block
@@ -396,9 +413,9 @@ private:
   ///    not stored; it is recovered on demand as the head of that block's exit
   ///    partition (from RegionAnalysis), which also gives the full partition to
   ///    keep rewinding across the join.
-  /// 2. A SILLocation if we have a SequenceBoundary.
+  /// 2. A SequenceBoundaryInfo if we have a SequenceBoundary.
   /// 3. An element otherwise.
-  std::variant<Element, SILBasicBlock *, SILLocation> data;
+  std::variant<Element, SILBasicBlock *, SequenceBoundaryInfo> data;
 
   /// Number of additional element arguments stored in the tail allocated array.
   unsigned numAdditionalElements;
@@ -409,8 +426,8 @@ private:
   }
 
   Node(Kind kind, Node *next) : kind(kind), next(next), data(nullptr) {}
-  Node(Kind kind, Node *next, SILLocation loc)
-      : kind(kind), next(next), data(loc) {}
+  Node(Kind kind, Node *next, SILLocation loc, SILInstruction *inst)
+      : kind(kind), next(next), data(SequenceBoundaryInfo{loc, inst}) {}
   Node(Kind kind, Node *next, Element value)
       : kind(kind), next(next), data(value), numAdditionalElements(0) {}
   Node(Kind kind, Node *next, Element primaryElement,
@@ -491,7 +508,34 @@ public:
   std::optional<SILLocation> getHistoryBoundaryLoc() const {
     if (kind != SequenceBoundary)
       return {};
-    return std::get<SILLocation>(data);
+    return std::get<SequenceBoundaryInfo>(data).loc;
+  }
+
+  /// If this node is a sequence boundary, the instruction whose PartitionOp
+  /// produced the package of history nodes it ends. Null when the boundary was
+  /// not pushed on behalf of a specific instruction (e.g. the initial partition
+  /// built by \c Partition::singleRegion).
+  SILInstruction *getHistoryBoundaryInst() const {
+    if (kind != SequenceBoundary)
+      return nullptr;
+    return std::get<SequenceBoundaryInfo>(data).inst;
+  }
+
+  /// Returns true if rewinding this node changes the partition it is popped
+  /// from. Sequence boundaries and CFG joins are pure markers: rewinding them
+  /// leaves the element-to-region mapping alone.
+  bool doesRewindingMutatePartition() const {
+    switch (kind) {
+    case AddNewRegionForElement:
+    case RemoveLastElementFromRegion:
+    case RemoveElementFromRegion:
+    case MergeElementRegions:
+      return true;
+    case CFGHistoryJoin:
+    case SequenceBoundary:
+      return false;
+    }
+    llvm_unreachable("Covered switch isn't covered?!");
   }
 
   void print(ASTContext &ctx, llvm::raw_ostream &os,
@@ -500,6 +544,10 @@ public:
     print(ctx, os, 0);
   }
   SWIFT_DEBUG_DUMPER(dump(ASTContext &ctx)) { print(ctx, llvm::dbgs()); }
+
+  /// Print this node on a single line without a trailing newline.
+  void printOneLine(llvm::raw_ostream &os,
+                    const SourceManager &sourceMgr) const;
 };
 
 class IsolationHistory::Factory {
@@ -1171,8 +1219,9 @@ public:
   void printHistory(llvm::raw_ostream &os) const;
 
   /// See docs on \p history.pushHistorySequenceBoundary().
-  IsolationHistoryNode *pushHistorySequenceBoundary(SILLocation loc) {
-    return history.pushHistorySequenceBoundary(loc);
+  IsolationHistoryNode *
+  pushHistorySequenceBoundary(SILLocation loc, SILInstruction *inst = nullptr) {
+    return history.pushHistorySequenceBoundary(loc, inst);
   }
 
 private:
@@ -1902,6 +1951,8 @@ public:
   /// Some evaluators pass in mock operands that one cannot call getUser()
   /// upon. So to allow for this, provide a routine that our impl can override
   /// if they need to.
+  static SILInstruction *getUser(Operand *op) { return Impl::getUser(op); }
+
   static SILIsolationInfo getIsolationInfo(const PartitionOp &partitionOp) {
     return Impl::getIsolationInfo(partitionOp);
   }
@@ -2011,12 +2062,15 @@ public:
     // the apply's anchor location, so behavior is unchanged for functions
     // that haven't opted in to isolation-history.
     SILLocation loc = SILLocation::invalid();
+    SILInstruction *boundaryInst = nullptr;
     if (op.hasSourceInst()) {
-      loc = getLoc(op.getSourceInst());
+      boundaryInst = op.getSourceInst();
+      loc = getLoc(boundaryInst);
     } else if (Operand *srcOp = op.getSourceOp()) {
+      boundaryInst = getUser(srcOp);
       loc = getLoc(srcOp);
     }
-    p.pushHistorySequenceBoundary(loc);
+    p.pushHistorySequenceBoundary(loc, boundaryInst);
 
     switch (op.getKind()) {
     case PartitionOpKind::AssignDirect: {
@@ -2676,6 +2730,7 @@ struct PartitionOpEvaluatorBaseImpl : PartitionOpEvaluator<Subclass> {
       return as.getArgumentLoc(op);
     return op->getUser()->getLoc();
   }
+  static SILInstruction *getUser(Operand *op) { return op->getUser(); }
   static SILInstruction *getSourceInst(const PartitionOp &partitionOp) {
     return partitionOp.getSourceInst();
   }

--- a/include/swift/SILOptimizer/Utils/VariableNameUtils.h
+++ b/include/swift/SILOptimizer/Utils/VariableNameUtils.h
@@ -38,6 +38,20 @@ public:
     /// DISCUSSION: This may not be the correct semantics for all name inference
     /// since we may want to consider computed properties to be tied to self.
     InferSelfThroughAllAccessors = 0x1,
+
+    /// If set then when a call's result is bound directly to a variable, name
+    /// the result after the call that produced it -- spelled `foo()` -- rather
+    /// than after the variable being initialized.
+    ///
+    /// DISCUSSION: By default the inferrer prefers the variable, since that is
+    /// the name the user wrote for the value. A client explaining where a value
+    /// came from rather than what it is now wants the opposite, and wants the
+    /// name to read as the *result of calling* the function, not as a value
+    /// that merely shares the function's name. This only applies to the
+    /// `let x = foo()` shape, where the variable's name would otherwise be
+    /// taken from the initializing move_value [var_decl]; it does not change
+    /// how a value that is merely passed around is named.
+    NameCallResultAfterCallee = 0x2,
   };
 
   using Options = OptionSet<Flag>;
@@ -180,6 +194,12 @@ private:
   /// attribute that didn't carry a decl).
   ValueDecl *leafDecl = nullptr;
 
+  /// Set when the inferred name names a call rather than a variable -- i.e.
+  /// when \c Flag::NameCallResultAfterCallee applied and the name is the
+  /// spelling of the callee. A consumer needs this to phrase the name as the
+  /// *result of* that call; the name itself only says which call it was.
+  bool nameIsCallResult = false;
+
   /// The final string we computed.
   SmallString<64> &resultingString;
 
@@ -278,8 +298,17 @@ public:
   /// SourceLoc may be invalid when the inferred name has no associated
   /// providing source location (e.g., a single-component name coming
   /// directly from a debug_value with no usable loc).
+  ///
+  /// \p extraOptions additional inference options to apply on top of the
+  /// defaults this helper uses, for clients that want a different naming
+  /// policy (e.g. \c Flag::NameCallResultAfterCallee).
+  ///
+  /// \p nameIsCallResult if non-null, set to true when the returned name names
+  /// a call (see \c Flag::NameCallResultAfterCallee) rather than a variable, so
+  /// the caller can phrase it as the result of that call.
   static std::optional<std::pair<Identifier, SourceLoc>>
-  inferNameAndFirstPathComponent(SILValue value);
+  inferNameAndFirstPathComponent(SILValue value, Options extraOptions = {},
+                                 bool *nameIsCallResult = nullptr);
 
   /// Result of \c inferNameAndLeafDecl. Carries the joined+interned name,
   /// the first-name-providing source location (see \c firstNameProvidingLoc),
@@ -304,6 +333,10 @@ public:
   /// Returns the source location whose name was first pushed onto the name
   /// path during the walk. See \c firstNameProvidingLoc for details.
   SourceLoc getFirstNameProvidingLoc() const { return firstNameProvidingLoc; }
+
+  /// Whether the inferred name names a call rather than a variable. See
+  /// \c nameIsCallResult.
+  bool isNameACallResult() const { return nameIsCallResult; }
 
   /// Returns the leaf-most component's \c ValueDecl if \c drainVariableNamePath
   /// has run on a non-empty path whose leaf was a decl, otherwise null.

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -4774,7 +4774,7 @@ static bool canComputeRegionsForFunction(SILFunction *fn) {
 RegionAnalysisFunctionInfo::RegionAnalysisFunctionInfo(
     SILFunction *fn, PostOrderFunctionInfo *pofi)
     : allocator(), fn(fn), valueMap(fn), translator(), ptrSetFactory(allocator),
-      isolationHistoryFactory(allocator),
+      isolationHistoryFactory(allocator, shouldEmitIsolationHistoryFor(fn)),
       sendingOperandToStateMap(isolationHistoryFactory), blockStates(),
       pofi(pofi), solved(false), supportedFunction(true) {
   // Before we do anything, make sure that we support processing this function.
@@ -4923,7 +4923,7 @@ static FunctionTest PartitionOpsTest(
     "sil_regionanalysis_partitionoptranslation",
     [](auto &function, auto &arguments, auto &test) {
       llvm::BumpPtrAllocator allocator;
-      IsolationHistory::Factory historyFactory(allocator);
+      IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
       RegionAnalysisValueMap valueMap(&function);
       PartitionOpTranslator translator(
           &function,
@@ -4950,7 +4950,7 @@ static FunctionTest PartitionOpsBlockLoweringTest(
     "sil_regionanalysis_partitionoptranslation_block",
     [](auto &function, auto &arguments, auto &test) {
       llvm::BumpPtrAllocator allocator;
-      IsolationHistory::Factory historyFactory(allocator);
+      IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
       RegionAnalysisValueMap valueMap(&function);
       PartitionOpTranslator translator(
           &function,

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -830,7 +830,7 @@ private:
   /// could continue through that predecessor. See the use site for what "could"
   /// means.
   bool couldAnswer(const ChainQuestion &question,
-                   PartitionWrapper &exitPartition) const;
+                   const PartitionWrapper &exitPartition) const;
 
   /// Rewind \p state's partition until the chain is explained or the state's
   /// history runs out. Returns true when the chain was explained, in which case
@@ -868,14 +868,13 @@ private:
 /// Partition cannot answer on its own since isolation lives in the value map
 /// rather than in the element-to-region mapping.
 struct IsolationHistoryNoteEmitter::PartitionWrapper {
-  Partition &partition;
+  const Partition &partition;
   RegionAnalysisValueMap &valueMap;
 
-  PartitionWrapper(Partition &partition, RegionAnalysisValueMap &valueMap)
+  PartitionWrapper(const Partition &partition, RegionAnalysisValueMap &valueMap)
       : partition(partition), valueMap(valueMap) {}
 
-  operator Partition &() { return partition; }
-  Partition *operator->() const { return &partition; }
+  const Partition *operator->() const { return &partition; }
 
   enum ElementIsolationStatus {
     Disconnected = 0,
@@ -979,6 +978,8 @@ bool IsolationHistoryNoteEmitter::processState(State &&state,
                                                SmallVectorImpl<State> &states) {
   using Node = IsolationHistory::Node;
 
+  // Read-only view of the state's partition, for the isolation queries. The
+  // rewind itself mutates state.partition directly.
   PartitionWrapper partition(state.partition, inputValueMap);
 
   // Predecessor blocks reached at CFG joins while rewinding this state.
@@ -1001,7 +1002,7 @@ bool IsolationHistoryNoteEmitter::processState(State &&state,
   // single merge. Declared out here so the loop below does not reallocate.
   SmallVector<ChainQuestion, 8> stillUnanswered;
 
-  while (const auto *node = partition->popHistoryOnce(joinedBlocks)) {
+  while (const auto *node = state.partition.popHistoryOnce(joinedBlocks)) {
     SWIFT_DEFER {
       ISOLATION_HISTORY_LOG(
           auto &os = log(1); os << "Rewound: ";
@@ -1230,9 +1231,14 @@ bool IsolationHistoryNoteEmitter::processState(State &&state,
 
   // The chain -- or the location of its last notes -- is in the predecessors
   // whose exit partitions were joined into this one at a CFG merge point.
+  //
+  // Point at those partitions rather than copying them. Deciding whether a
+  // predecessor is worth trying only reads its exit partition, and a Partition
+  // copy also copies its element-to-region map, so the copy waits until we know
+  // the walk is going there.
   struct PredExit {
     SILBasicBlock *block;
-    Partition exit;
+    const Partition *exit;
   };
   SmallVector<PredExit, 4> preds;
   for (SILBasicBlock *predBlock : joinedBlocks) {
@@ -1250,11 +1256,7 @@ bool IsolationHistoryNoteEmitter::processState(State &&state,
       continue;
     }
 
-    // The history is rewound over region membership alone, so the sending
-    // operands recorded in the exit partition have to go.
-    preds.push_back({predBlock, predBlockState.get()
-                                    ->getExitPartition()
-                                    .removingSendingOperandState()});
+    preds.push_back({predBlock, &predBlockState.get()->getExitPartition()});
   }
 
   // What the walk still wants from a predecessor: the open questions when there
@@ -1280,7 +1282,7 @@ bool IsolationHistoryNoteEmitter::processState(State &&state,
   SmallVector<bool, 4> isCandidate(preds.size(), false);
   bool anyCandidate = false;
   for (unsigned i = 0, e = preds.size(); i != e; ++i) {
-    PartitionWrapper predPartition(preds[i].exit, inputValueMap);
+    PartitionWrapper predPartition(*preds[i].exit, inputValueMap);
     for (const ChainQuestion &question : wanted) {
       if (couldAnswer(question, predPartition)) {
         isCandidate[i] = true;
@@ -1301,12 +1303,16 @@ bool IsolationHistoryNoteEmitter::processState(State &&state,
 
     ISOLATION_HISTORY_LOG(log(1) << "Will continue the walk into bb"
                                  << preds[i].block->getDebugID() << ".\n");
+    // Now the copy is worth making. The history is rewound over region
+    // membership alone, so the sending operands recorded in the exit partition
+    // have to go.
+    //
     // Every path inherits the notes as they stand now, and the pending run
     // within them. Backtracking onto the path restores walkNotes to exactly
     // this.
-    states.push_back(State{std::move(preds[i].exit), openQuestions,
-                           unsigned(walkNotes.size()), pendingStart,
-                           allQuestionsAnswered});
+    states.push_back(State{preds[i].exit->removingSendingOperandState(),
+                           openQuestions, unsigned(walkNotes.size()),
+                           pendingStart, allQuestionsAnswered});
   }
 
   return false;
@@ -1326,7 +1332,7 @@ bool IsolationHistoryNoteEmitter::processState(State &&state,
 ///     element's region is isolated there. A branch where it is disconnected is
 ///     not where its isolation came from.
 bool IsolationHistoryNoteEmitter::couldAnswer(
-    const ChainQuestion &question, PartitionWrapper &exitPartition) const {
+    const ChainQuestion &question, const PartitionWrapper &exitPartition) const {
   if (!exitPartition->isTrackingElement(question.from))
     return false;
 

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -825,13 +825,6 @@ private:
 
   void collectIsolationHistoryNotes();
 
-  /// True when \p exitPartition -- the exit partition of a predecessor joined
-  /// at a CFG history join -- could answer \p question, i.e. when the chain
-  /// could continue through that predecessor. See the use site for what "could"
-  /// means.
-  bool couldAnswer(const ChainQuestion &question,
-                   const PartitionWrapper &exitPartition) const;
-
   /// Rewind \p state's partition until the chain is explained or the state's
   /// history runs out. Returns true when the chain was explained, in which case
   /// the chain has been copied from \c walkNotes onto \c notes. Otherwise
@@ -907,6 +900,35 @@ struct IsolationHistoryNoteEmitter::PartitionWrapper {
     if (isInIsolatedRegion(element))
       return ElementIsolationStatus::IndirectlyIsolated;
     return ElementIsolationStatus::Disconnected;
+  }
+
+  /// True when this partition -- the exit partition of a predecessor joined at
+  /// a CFG history join -- could answer \p question, i.e. when the chain could
+  /// continue through that predecessor.
+  ///
+  /// It could when what the question asks about has already come together here:
+  ///
+  ///   - For a question with both ends known, when the two ends are in one
+  ///     region. The merge that put them together is then somewhere in this
+  ///     predecessor's history. Where they are in different regions it was the
+  ///     join itself that brought them together, so that branch cannot explain
+  ///     the note.
+  ///
+  ///   - For a question still looking for whatever isolated its element, when
+  ///     that element's region is isolated here. A branch where it is
+  ///     disconnected is not where its isolation came from.
+  bool couldAnswer(const ChainQuestion &question) const {
+    if (!partition.isTrackingElement(question.from))
+      return false;
+
+    if (question.to) {
+      if (!partition.isTrackingElement(*question.to))
+        return false;
+      return partition.getRegion(question.from) ==
+             partition.getRegion(*question.to);
+    }
+
+    return isInIsolatedRegion(question.from);
   }
 };
 
@@ -1284,7 +1306,7 @@ bool IsolationHistoryNoteEmitter::processState(State &&state,
   for (unsigned i = 0, e = preds.size(); i != e; ++i) {
     PartitionWrapper predPartition(*preds[i].exit, inputValueMap);
     for (const ChainQuestion &question : wanted) {
-      if (couldAnswer(question, predPartition)) {
+      if (predPartition.couldAnswer(question)) {
         isCandidate[i] = true;
         anyCandidate = true;
         break;
@@ -1316,34 +1338,6 @@ bool IsolationHistoryNoteEmitter::processState(State &&state,
   }
 
   return false;
-}
-
-/// A predecessor could answer a question when what the question asks about has
-/// already come together at that predecessor's exit:
-///
-///   - For a question with both ends known, when the two ends are in one region
-///     there. The merge that put them together is then somewhere in that
-///     predecessor's history. Where they are in different regions it was the
-///     join itself that brought them together, so that branch cannot explain
-///     the link.
-///
-///   - For a question still looking for whatever isolated its element, when
-///   that
-///     element's region is isolated there. A branch where it is disconnected is
-///     not where its isolation came from.
-bool IsolationHistoryNoteEmitter::couldAnswer(
-    const ChainQuestion &question, const PartitionWrapper &exitPartition) const {
-  if (!exitPartition->isTrackingElement(question.from))
-    return false;
-
-  if (question.to) {
-    if (!exitPartition->isTrackingElement(*question.to))
-      return false;
-    return exitPartition->getRegion(question.from) ==
-           exitPartition->getRegion(*question.to);
-  }
-
-  return exitPartition.isInIsolatedRegion(question.from);
 }
 
 /// Emit the collected chain, one note per link, anchored at the merge that

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -461,9 +461,23 @@ static InFlightDiagnostic diagnoseNote(const PartitionOp &op, Diag<T...> diag,
 //                           MARK: IsolationHistory
 //===----------------------------------------------------------------------===//
 
-static bool shouldEmitIsolationHistory(SILFunction *fn) {
-  return swift::shouldEmitIsolationHistoryFor(fn);
-}
+// Logging for the isolation history walk that backs the optional notes we
+// attach to sent-non-Sendable errors. Since the walk rewinds history nodes that
+// no longer exist by the time a diagnostic is read, the only practical way to
+// debug a missing or misplaced note is to watch the walk happen.
+static llvm::cl::opt<bool> LogIsolationHistory(
+    "sil-regionbasedisolation-log-isolation-history",
+    llvm::cl::desc("Dump the isolation history of a sent-non-Sendable error "
+                   "and log the walk over it that emits isolation history "
+                   "notes"),
+    llvm::cl::Hidden);
+
+#define ISOLATION_HISTORY_LOG(...)                                             \
+  do {                                                                         \
+    if (LogIsolationHistory) {                                                 \
+      __VA_ARGS__;                                                             \
+    }                                                                          \
+  } while (0)
 
 namespace {
 
@@ -478,6 +492,53 @@ namespace {
 /// is disabled, when the sent element is itself isolated, or when no useful
 /// chain was found.
 class IsolationHistoryNoteEmitter {
+  /// Composition wrapper that extends the partition being rewound with the
+  /// isolation queries this walk needs. Defined below the class since only the
+  /// out-of-line \c collectIsolationHistoryNotes uses it.
+  struct PartitionWrapper;
+
+  /// Begin a log line at \p depth levels of indentation. Every line begins with
+  /// the same prefix so the log can be grepped out of a larger dump.
+  static llvm::raw_ostream &log(unsigned depth = 0) {
+    auto &os = llvm::dbgs();
+    os << "[isolation-history] ";
+    os.indent(2 * depth);
+    return os;
+  }
+
+  /// Print the instruction a sequence boundary was pushed for on a single line,
+  /// without a trailing newline. The SIL printer emits leading comment lines
+  /// for some instructions (e.g. the callee name above a function_ref) and a
+  /// trailing newline, so print into a scratch buffer and keep only the
+  /// instruction itself — a multi-line value here would break out of the log's
+  /// line prefix.
+  static void printBoundaryInstForLog(llvm::raw_ostream &os,
+                                      SILInstruction *inst) {
+    if (!inst) {
+      os << "<no instruction>";
+      return;
+    }
+
+    SmallString<128> buffer;
+    llvm::raw_svector_ostream bufferStream(buffer);
+    inst->print(bufferStream);
+
+    SmallVector<StringRef, 4> instLines;
+    StringRef(buffer).split(instLines, '\n', -1, false /*KeepEmpty*/);
+    for (StringRef line : instLines) {
+      StringRef trimmed = line.trim();
+      if (trimmed.empty() || trimmed.starts_with("//"))
+        continue;
+      os << trimmed;
+      return;
+    }
+
+    // Every line was a comment — fall back to the first one so the log still
+    // says something about this instruction.
+    os << (instLines.empty() ? StringRef("<unprintable>")
+                             : instLines[0].trim());
+  }
+
 public:
   /// Single-use entry point. Constructs an internal emitter from the inputs
   /// and emits any isolation-history notes that apply.
@@ -491,18 +552,89 @@ public:
   }
 
 private:
-  /// One named link in the chain of merges that brought a sent element into an
-  /// isolated region. The chain is ordered from the sent element back to the
-  /// isolated source: the first entry is the named local closest to the send,
-  /// the last is the named local merged directly with the isolated source.
-  struct ChainStep {
-    /// Source location of the declaration of \c name (the line of `let foo =
-    /// …`).
-    SourceLoc declLoc;
-    /// User-visible identifier of this chain link.
-    Identifier name;
-    /// The Element this name corresponds to.
-    Element element;
+  struct NoteToEmit {
+    Element lhsElt;
+    Element rhsElt;
+    SILLocation mergeLoc;
+    std::optional<unsigned> prevNoteIndex;
+
+    /// True when \c rhsElt is the actor-isolated value the chain terminates at
+    /// rather than another disconnected link, so this note gets the
+    /// "which is accessible to <isolation>" phrasing.
+    bool rhsIsIsolatedSource;
+  };
+
+  SmallVector<NoteToEmit, 8> notes;
+
+  /// An unanswered "how does \c from reach \c to" question.
+  ///
+  /// The walk is pairwise rather than single-focus because a merge can separate
+  /// the two from/to ends of a question while naming neither of them -- both
+  /// are passengers carried along by the merge, on opposite sides of the split.
+  /// Such a merge does not advance one focus by a hop; it splits the question
+  /// into two independent halves, each resolved by its own older merge.
+  ///
+  /// Example:
+  ///
+  ///   let y = Box1(x)     // merge %y with %box1result
+  ///   let z = Box2(y)     // merge %z with %box2result
+  ///   await send(z)
+  ///
+  /// The walk starts asking how %z reached the isolated region. Rewinding the
+  /// Box2 call answers that by separating %z from everything on %y's side, so
+  /// the question splits: how does %z reach %box2result, and how does
+  /// %box2result reach the isolated value. Rewinding the Box1 call then answers
+  /// the second half while naming neither %box2result nor %x -- both are
+  /// passengers -- and splits it again. A single-focus walk has nowhere to put
+  /// that: there is no one element to advance.
+  struct ChainQuestion {
+    /// The end of the question on the sent value's side.
+    Element from;
+
+    /// The other end, or None when we do not know it yet because we are still
+    /// looking for whatever made \c from's region isolated.
+    std::optional<Element> to;
+
+    /// Index in \c notes of the note this question was split out of, or
+    /// none for the question we started with.
+    std::optional<unsigned> parentNote;
+  };
+
+  /// One rewind in progress: the partition being rewound and everything the
+  /// walk has worked out from it so far.
+  ///
+  /// A CFG history join leaves the walk several paths to try, since the chain
+  /// may continue in any of the joined predecessors, and each path carries a
+  /// copy of this. That is why the walk's state lives here rather than on the
+  /// emitter: a path that turns out to be a dead end drops its copy, leaving
+  /// behind neither its half-answered questions nor notes about a branch that
+  /// did not isolate anything.
+  struct State {
+    /// The partition to keep rewinding. For the initial state this is the
+    /// partition at the moment of the send; for a later path it is the joined
+    /// predecessor's exit partition.
+    Partition partition;
+
+    /// The questions still to answer. The walk starts with one -- how did the
+    /// sent element come to be in an isolated region -- and answering a
+    /// question can split it in two, so this grows as well as shrinks. The
+    /// chain is fully explained when it drains.
+    SmallVector<ChainQuestion, 8> openQuestions;
+
+    /// The links discovered so far, in discovery order.
+    SmallVector<NoteToEmit, 8> notes;
+
+    /// Indices into \c notes of links still waiting for a location. A
+    /// PartitionOp pushes its sequence boundary before its nodes, so rewinding
+    /// reaches a merge before the boundary that names the instruction behind
+    /// it: a link's location is not known when the link is created and is
+    /// filled in when the boundary arrives.
+    SmallVector<unsigned, 4> pendingNotes;
+
+    /// Set once \c openQuestions drains. The walk cannot stop the moment that
+    /// happens: the links the answering merge created are still waiting for the
+    /// location of the instruction behind them.
+    bool allQuestionsAnswered = false;
   };
 
   /// The SIL function whose AST context is used for diagnostic emission and
@@ -518,6 +650,12 @@ private:
   /// block's exit partition when following a CFG history join.
   RegionAnalysisFunctionInfo *inputFunctionInfo;
 
+  /// Predecessor blocks the walk has already taken a path into. A join can be
+  /// reached from more than one path -- and a loop's history joins the block
+  /// back onto itself -- so without this the walk would rewind the same branch
+  /// repeatedly.
+  BasicBlockSet visitedBlocks;
+
   /// The element whose path into the isolated region we are explaining.
   Element inputSentElement;
 
@@ -529,124 +667,162 @@ private:
   /// diagnostic format strings.
   SILDynamicMergedIsolationInfo inputRegionInfo;
 
-  /// Source location of the originating merge — i.e., the merge that brought
-  /// a disconnected value into the actor-isolated region. Empty when no useful
-  /// note should be emitted (chain has no intermediate disconnected steps, or
-  /// no merge involving the element was found). Populated by
-  /// \c collectIsolationHistoryNotes.
-  std::optional<SILLocation> originatingLoc;
-
-  /// Named locals along the chain, ordered from sent end → isolated end.
-  /// `chainSteps[0]` is closest to the send; `chainSteps.back()` is closest
-  /// to the isolated source. Populated by \c collectIsolationHistoryNotes.
-  SmallVector<ChainStep, 4> chainSteps;
-
-  /// User-visible name of the isolated value that ended the chain, if one
-  /// could be inferred. Empty when the isolated source has no recoverable
-  /// name (e.g. a synthesised actor-introducing value). Populated by
-  /// \c collectIsolationHistoryNotes.
-  Identifier isolatedName;
-
-  /// The mutable state of the chain walk. \c tracked is the set of elements
-  /// known to be in the sent element's chain; the flags and \c isolatedElement
-  /// describe progress toward the isolated source. \c pendingTargetMerge is set
-  /// when the most recently rewound merge reached the isolated source — the
-  /// next SequenceBoundary holds its location. \c intermediateSeen gates
-  /// suppressing a trivial chain.
-  struct WalkState {
-    llvm::SmallSet<Element, 8> tracked;
-    bool pendingTargetMerge = false;
-    bool intermediateSeen = false;
-    Element isolatedElement = Element(0);
-    bool isolatedFound = false;
-  };
-
-  /// A saved (partition, walk-state) snapshot on the DFS worklist. When a merge
-  /// chain crosses a CFG join the joined branch lives in a predecessor block's
-  /// exit partition, so we push a frame per predecessor carrying the walk state
-  /// as of the join and explore them depth-first, backtracking on dead ends.
-  struct Frame {
-    Partition partition;
-    WalkState state;
-  };
-
-  /// The current walk state. \c processFrame restores this from the frame it is
-  /// given; on success it holds the winning frame's state, which names the
-  /// chain.
-  WalkState state;
-
-  /// DFS worklist of frames still to explore, and the set of predecessor blocks
-  /// already scheduled so a CFG cycle cannot rewind the same block forever.
-  SmallVector<Frame, 8> worklist;
-  llvm::SmallPtrSet<SILBasicBlock *, 8> visitedBlocks;
-
   IsolationHistoryNoteEmitter(SILFunction *fn,
                               RegionAnalysisFunctionInfo *functionInfo,
                               RegionAnalysisValueMap &valueMap,
                               Element sentElement, Partition &&partition,
                               SILDynamicMergedIsolationInfo regionInfo)
       : inputFn(fn), inputValueMap(valueMap), inputFunctionInfo(functionInfo),
-        inputSentElement(sentElement), inputPartition(std::move(partition)),
-        inputRegionInfo(regionInfo) {}
+        visitedBlocks(fn), inputSentElement(sentElement),
+        inputPartition(std::move(partition)), inputRegionInfo(regionInfo) {}
 
   void emitHelper() {
-    if (!shouldEmit())
+    ISOLATION_HISTORY_LOG(
+        log() << "===== Explaining why the sent value in " << inputFn->getName()
+              << " is isolated =====\n";
+        log() << "The value being sent is %%" << inputSentElement << '\n';
+        log() << "It is being sent into: "
+              << inputRegionInfo.printForDiagnostics(inputFn)
+              << (inputRegionInfo->isTaskIsolated() ? " (task isolated)" : "")
+              << '\n';
+        log() << "Regions at the moment of the send: ";
+        inputPartition.print(llvm::dbgs()));
+
+    if (!shouldEmit()) {
+      ISOLATION_HISTORY_LOG(
+          log()
+          << "Nothing to explain: either these notes are turned off for this "
+             "function, or the sent value is itself actor isolated rather than "
+             "having been made isolated by a merge.\n");
       return;
+    }
 
     collectIsolationHistoryNotes();
-    if (!originatingLoc)
-      return;
 
-    auto descriptiveKindStr = inputRegionInfo.printForDiagnostics(inputFn);
+    ISOLATION_HISTORY_LOG(log() << "Chain, in the order it was discovered:\n";
+                          for (unsigned i = 0, e = notes.size(); i != e; ++i) {
+                            auto &note = notes[i];
+                            log(1) << "[" << i << "] ";
+                            printElementForLog(llvm::dbgs(), note.lhsElt);
+                            llvm::dbgs() << " is connected to ";
+                            printElementForLog(llvm::dbgs(), note.rhsElt);
+                            if (note.rhsIsIsolatedSource)
+                              llvm::dbgs() << " (the isolated value)";
+                            llvm::dbgs() << ", parent: ";
+                            if (!note.prevNoteIndex)
+                              llvm::dbgs() << "none";
+                            else
+                              llvm::dbgs() << note.prevNoteIndex;
+                            llvm::dbgs() << ", at ";
+                            note.mergeLoc.getSourceLoc().print(
+                                llvm::dbgs(),
+                                inputFn->getASTContext().SourceMgr);
+                            llvm::dbgs() << '\n';
+                          });
 
-    if (chainSteps.empty()) {
-      // No named locals along the chain — emit the generic location-only note
-      // at the originating merge.
-      emitGenericOriginatingNote(originatingLoc->getSourceLoc(),
-                                 descriptiveKindStr);
-      return;
+    emitNotes();
+  }
+
+  /// How an element should be spelled in a note.
+  struct ElementName {
+    Identifier name;
+
+    /// True when \c name names the call that produced the value rather than a
+    /// variable, so the note has to read "result of 'foo()'".
+    bool isCallResult;
+  };
+
+  /// The name to print for \p elt, or None when the element has nothing worth
+  /// showing the user.
+  std::optional<ElementName> inferElementName(Element elt) const {
+    SILValue rep = inputValueMap.maybeGetRepresentative(elt);
+    if (!rep)
+      return {};
+
+    // These notes explain where a value came from, so when a link is the result
+    // of a call we want the callee's name rather than the name of the variable
+    // the result happened to be bound to.
+    VariableNameInferrer::Options nameOptions(
+        VariableNameInferrer::Flag::NameCallResultAfterCallee);
+    bool isCallResult = false;
+    auto namePair = VariableNameInferrer::inferNameAndFirstPathComponent(
+        rep, nameOptions, &isCallResult);
+
+    // VariableNameInferrer falls back to the literal identifier "unknown" when
+    // it cannot recover a name; that is never useful in a diagnostic, so treat
+    // it as no name at all.
+    if (!namePair || namePair->first.str() == "unknown")
+      return {};
+
+    return ElementName{namePair->first, isCallResult};
+  }
+
+  /// Print \p elt as its user-visible name when one can be inferred, falling
+  /// back to the element number. Only used by the log.
+  void printElementForLog(llvm::raw_ostream &os, Element elt) const {
+    if (SILValue rep = inputValueMap.maybeGetRepresentative(elt)) {
+      if (auto name = VariableNameInferrer::inferName(rep)) {
+        os << "'" << name->str() << "'";
+        return;
+      }
     }
+    os << "%%" << elt;
+  }
 
-    // If we have a named chain, emit one note per chain link describing the
-    // connection between named locals, ending at the originating note that
-    // names the isolated source.
-    //
-    // chainSteps is ordered newest→oldest: chainSteps[0] is closest to the
-    // send, chainSteps.back() is closest to the isolated source. For each
-    // step, the "predecessor" (the value it is connected to) is the
-    // next-older entry, or the isolated source for the last entry.
-    for (auto p : llvm::enumerate(ArrayRef(chainSteps).drop_back())) {
-      const auto &step = p.value();
-      // Intermediate link: this step is connected to the next-older step.
-      const auto &predecessor = chainSteps[p.index() + 1];
+  /// True when \p lhs and \p rhs are two spellings of one user-visible value,
+  /// so the merge that connected them is an artifact of lowering rather than
+  /// something the user wrote.
+  ///
+  /// The element actually sent for a call argument is such a spelling: SILGen
+  /// allocates a stack slot, stores the variable into it, and passes the slot,
+  /// which the region analysis tracks as an element of its own merged with the
+  /// variable's. A note about that merge reads "'y' is connected to 'y'".
+  ///
+  /// Recognised by the temporary having no var_decl while naming the same
+  /// variable: two values the user actually declared are never collapsed, even
+  /// when shadowing makes them share a name.
+  bool isSameUserValue(Element lhs, Element rhs) const {
+    SILValue lhsRep = inputValueMap.maybeGetRepresentative(lhs);
+    SILValue rhsRep = inputValueMap.maybeGetRepresentative(rhs);
+    if (!lhsRep || !rhsRep)
+      return false;
 
-      // Skip degenerate "X is connected to X" — happens when name
-      // inference resolves both ends of the link to the same identifier
-      // (e.g. a `let f: () -> () = { ... }` where the closure literal and
-      // the binding share the var-decl name).
-      if (step.name == predecessor.name)
-        continue;
-      emitChainLinkNote(step, predecessor);
-    }
+    if (lhsRep->isFromVarDecl() && rhsRep->isFromVarDecl())
+      return false;
 
-    // Emit an originating link note on back.
-    emitOriginatingLinkNote(chainSteps.back(), descriptiveKindStr);
+    // Compare the names the notes would actually print. A value named after the
+    // call that produced it does not read as the same thing as the variable
+    // that call's result was bound to, even though the inferrer will happily
+    // name both after that variable when not asked to prefer the callee.
+    auto lhsName = inferElementName(lhs);
+    auto rhsName = inferElementName(rhs);
+    return lhsName && rhsName && lhsName->name == rhsName->name &&
+           lhsName->isCallResult == rhsName->isCallResult;
   }
 
   void collectIsolationHistoryNotes();
 
-  /// Rewind one frame's partition, updating the walk-state members in place.
-  /// Returns true if the chain end was reached — \c originatingLoc is set for a
-  /// real chain and left empty for a suppressed trivial one. Otherwise
-  /// schedules a frame per joined predecessor block onto \c worklist and
+  /// True when \p exitPartition -- the exit partition of a predecessor joined
+  /// at a CFG history join -- could answer \p question, i.e. when the chain
+  /// could continue through that predecessor. See the use site for what "could"
+  /// means.
+  bool couldAnswer(const ChainQuestion &question,
+                   PartitionWrapper &exitPartition) const;
+
+  /// Rewind \p state's partition until the chain is explained or the state's
+  /// history runs out. Returns true when the chain was explained, in which case
+  /// the state's links have been moved onto \c notes. Otherwise records a path
+  /// on \p states for each joined predecessor the chain may continue in and
   /// returns false.
-  bool processFrame(Frame frame);
+  bool processState(State &&state, SmallVectorImpl<State> &states);
+
+  void emitNotes();
 
   /// Returns true when isolation-history emission is on for this function and
   /// the sent element is "disconnected" (i.e., it became isolated by being
   /// merged with an isolated value rather than being intrinsically isolated).
   bool shouldEmit() const {
-    if (!shouldEmitIsolationHistory(inputFn))
+    if (!swift::shouldEmitIsolationHistoryFor(inputFn))
       return false;
     return inputValueMap.getIsolationRegion(inputSentElement).isDisconnected();
   }
@@ -656,295 +832,560 @@ private:
         loc, diag::regionbasedisolation_value_became_part_of_isolated_region,
         descriptiveKind, inputRegionInfo->isTaskIsolated());
   }
+};
 
-  void emitChainLinkNote(const ChainStep &step, const ChainStep &predecessor) {
-    inputFn->getASTContext().Diags.diagnose(
-        step.declLoc, diag::regionbasedisolation_chain_value_exposed, step.name,
-        predecessor.name);
+/// A composition wrapper that adds behavior to a Partition without changing
+/// Partition itself: it holds the partition alongside the value map the extra
+/// behavior needs, and forwards through \c operator-> and an implicit
+/// conversion so it can be used anywhere the underlying partition can. In Swift
+/// this would just be a fileprivate extension on Partition; C++ has no
+/// extensions, so the added methods live on a local wrapper instead.
+///
+/// The behavior being added is "which elements here are isolated", which
+/// Partition cannot answer on its own since isolation lives in the value map
+/// rather than in the element-to-region mapping.
+struct IsolationHistoryNoteEmitter::PartitionWrapper {
+  Partition &partition;
+  RegionAnalysisValueMap &valueMap;
+
+  PartitionWrapper(Partition &partition, RegionAnalysisValueMap &valueMap)
+      : partition(partition), valueMap(valueMap) {}
+
+  operator Partition &() { return partition; }
+  Partition *operator->() const { return &partition; }
+
+  enum ElementIsolationStatus {
+    Disconnected = 0,
+    DirectlyIsolated = 1,
+    IndirectlyIsolated = 2,
+  };
+
+  // An element with no value-map entry is tracked in the history but is no
+  // longer a value we can reason about. Its isolation info is Invalid, which is
+  // a distinct kind from Disconnected, so isDisconnected() answers false for it
+  // and it would otherwise read as isolated.
+  bool isIsolated(Element element) const {
+    auto info = valueMap.getIsolationRegion(element);
+    return info && !info.isDisconnected();
   }
 
-  void emitOriginatingLinkNote(const ChainStep &step,
-                               StringRef descriptiveKind) {
-    if (!isolatedName.empty() && step.name != isolatedName) {
-      // Originating link: this step is connected to the named isolated
-      // source. Anchor at the originating merge's location, since that's
-      // where the sent value joined the isolated region.
-      inputFn->getASTContext().Diags.diagnose(
-          originatingLoc->getSourceLoc(),
-          diag::regionbasedisolation_chain_value_exposed_to_isolated_named,
-          step.name, isolatedName, descriptiveKind,
-          inputRegionInfo->isTaskIsolated());
-      return;
+  bool isInIsolatedRegion(Element element) const {
+    auto reg = partition.getRegion(element);
+    for (auto iter : partition.range()) {
+      if (iter.second == reg && isIsolated(iter.first)) {
+        return true;
+      }
     }
+    return false;
+  }
 
-    // Originating link without a useful named isolated source: fall back to
-    // the generic location-only note.
-    emitGenericOriginatingNote(originatingLoc->getSourceLoc(), descriptiveKind);
+  ElementIsolationStatus getStatus(Element element) const {
+    if (isIsolated(element))
+      return ElementIsolationStatus::DirectlyIsolated;
+    if (isInIsolatedRegion(element))
+      return ElementIsolationStatus::IndirectlyIsolated;
+    return ElementIsolationStatus::Disconnected;
   }
 };
 
 } // namespace
 
-/// Find the merge that brought \c inputSentElement's region into the isolated
-/// region by *rewinding* the send-time partition one history node at a time
+/// Work out how \c inputSentElement's region came to be isolated by *rewinding*
+/// the send-time partition one history node at a time
 /// (\c Partition::popHistoryOnce), undoing each node's effect as we go.
-/// Starting with a tracking set containing only \c inputSentElement, each
-/// MergeElementRegions we rewind past that involves a tracked element is
-/// examined: if any other element in it is itself isolated (per
-/// \c inputValueMap) that merge is the answer; otherwise the others are
-/// disconnected values that became isolated transitively, so we track them and
-/// keep rewinding.
 ///
-/// On exit, populates the output members:
-///   - \c originatingLoc: source location of the originating merge, or empty
-///     when no useful note should be emitted (chain has no intermediate
-///     disconnected steps, or no merge involving the element was found).
-///   - \c chainSteps: each named intermediate's declaration, ordered
-///     newest→oldest.
-///   - \c isolatedName: the user-visible name of the isolated source, if one
-///     could be recovered.
+/// The walk answers questions of the form "how does this element reach that
+/// one", starting with "how did the sent element come to be in an isolated
+/// region". A merge that separates the two ends of a question answers it: the
+/// pair the merge names becomes a link of the chain, and the question splits
+/// into the two halves left over on either side of it. The walk is done when
+/// every question has been answered.
 ///
-/// Names come from the element's equivalence-class representative
-/// (\c maybeGetRepresentative). Using the more specific value stamped on the
-/// merge node is a planned refinement.
+/// On exit, populates \c notes with one entry per link, each carrying the two
+/// elements to name, the location of the instruction that merged them, and
+/// whether the far end is the isolated value the chain terminates at.
+/// \c emitNotes turns that into diagnostics.
 ///
-/// If the chain has no intermediate disconnected steps — i.e.,
-/// \c inputSentElement is merged directly with an already-isolated element —
-/// \c originatingLoc is left empty. In that case the user is conceptually
-/// sending an already-isolated value (e.g. `transferToMain(x)` where `x` is
-/// task-isolated), so a "value was merged … here" note pointing at the same
-/// call site adds no information.
+/// Names are not resolved here: a link records elements, and \c emitNotes asks
+/// the value map for a name when it is about to print one.
 ///
 /// When rewinding reaches a CFGHistoryJoin the chain may continue in a
 /// predecessor block, whose history lives in that block's exit partition. We
-/// push a new frame for each such predecessor carrying the walk state as of the
-/// join, and explore frames depth-first so a dead-end predecessor path simply
-/// backtracks to the next frame.
+/// record a State for each such predecessor carrying the walk as it stands at
+/// the join, and explore them depth-first so a dead-end predecessor path simply
+/// backtracks onto the next one.
 void IsolationHistoryNoteEmitter::collectIsolationHistoryNotes() {
-  // Seed the walk state: only the sent element is tracked. popHistoryOnce
-  // requires that we not be tracking sending-operand state, so clear it on the
-  // send-time partition before seeding the first frame with it.
-  state.tracked.insert(inputSentElement);
-  state.isolatedElement = inputSentElement;
-  worklist.push_back(
-      Frame{inputPartition.removingSendingOperandState(), state});
+  // Both kinds of partition the walk rewinds have to be stripped of sending
+  // operand state first, since popHistoryOnce rewinds region membership alone
+  // and does not maintain the send information alongside it. For a joined
+  // predecessor's exit partition that happens where the path is recorded; the
+  // send-time partition we start from is stripped here.
+  State initial{inputPartition.removingSendingOperandState()};
+  initial.openQuestions.push_back(
+      ChainQuestion{inputSentElement, std::nullopt, std::nullopt});
 
-  // Explore frames depth-first. processFrame rewinds one frame, updating the
-  // walk-state members, and either records originatingLoc (done) or schedules a
-  // frame per joined predecessor block.
-  while (!worklist.empty() && !originatingLoc) {
-    Frame frame = std::move(worklist.back());
-    worklist.pop_back();
-    if (processFrame(std::move(frame)))
-      break;
+  // Paths still to try, newest first: a path is followed until it explains the
+  // chain or dies, and only then does the walk back up to the next one.
+  SmallVector<State, 4> states;
+  states.push_back(std::move(initial));
+
+  while (!states.empty()) {
+    State state = std::move(states.back());
+    states.pop_back();
+
+    ISOLATION_HISTORY_LOG(log() << "Rewinding a partition (" << states.size()
+                                << " other path(s) still to try): ";
+                          state.partition.print(llvm::dbgs()));
+
+    if (processState(std::move(state), states))
+      return;
   }
 
-  if (!originatingLoc)
-    return;
-
-  // Build the named-step list. For each tracked element other than the sent
-  // element, infer a user name + the source location of its declaration.
-  llvm::SmallDenseSet<const void *, 4> seenLocs;
-
-  // Look up the isolated source's user-visible name, if any. We do this first
-  // so we can skip chain steps whose name coincides with it (those are aliases
-  // of the isolated source rather than independent links in the chain).
-  //
-  // VariableNameInferrer falls back to the literal identifier "unknown" when it
-  // can't recover a name; that is never useful in a diagnostic, so treat it as
-  // no-name.
-  if (state.isolatedFound) {
-    if (SILValue rep =
-            inputValueMap.maybeGetRepresentative(state.isolatedElement)) {
-      auto namePair = VariableNameInferrer::inferNameAndFirstPathComponent(rep);
-      if (namePair && namePair->second.isValid() &&
-          namePair->first.str() != "unknown")
-        isolatedName = namePair->first;
-    }
-  }
-
-  for (Element elt : state.tracked) {
-    if (elt == inputSentElement)
-      continue;
-    SILValue rep = inputValueMap.maybeGetRepresentative(elt);
-    if (!rep)
-      continue;
-    auto namePair = VariableNameInferrer::inferNameAndFirstPathComponent(rep);
-    if (!namePair || !namePair->second.isValid() ||
-        namePair->first.str() == "unknown")
-      continue;
-    Identifier name = namePair->first;
-    SourceLoc declLoc = namePair->second;
-    // Skip elements whose inferred name matches the isolated source — these are
-    // aliases produced by copies along the chain that the name inferrer
-    // collapses back to the original.
-    if (!isolatedName.empty() && name == isolatedName)
-      continue;
-    if (!seenLocs.insert(declLoc.getOpaquePointerValue()).second)
-      continue;
-    chainSteps.push_back(ChainStep{declLoc, name, elt});
-  }
-
-  // Sort newest-first (highest source position first) so that chainSteps[0]
-  // is closest to the send and chainSteps.back() is closest to the isolated
-  // source. SourceLocs from the same buffer compare by raw pointer position.
-  llvm::sort(chainSteps, [](const ChainStep &lhs, const ChainStep &rhs) {
-    return rhs.declLoc.getOpaquePointerValue() <
-           lhs.declLoc.getOpaquePointerValue();
-  });
+  ISOLATION_HISTORY_LOG(
+      log() << "Tried every path and never explained the whole chain.\n");
 }
 
-bool IsolationHistoryNoteEmitter::processFrame(Frame frame) {
+bool IsolationHistoryNoteEmitter::processState(State &&state,
+                                               SmallVectorImpl<State> &states) {
   using Node = IsolationHistory::Node;
 
-  // Restore the walk state captured when this frame was scheduled.
-  Partition partition = std::move(frame.partition);
-  state = std::move(frame.state);
+  PartitionWrapper partition(state.partition, inputValueMap);
 
-  // Predecessor blocks reached at CFG joins while rewinding this frame.
+  // Predecessor blocks reached at CFG joins while rewinding this state.
   SmallVector<SILBasicBlock *, 4> joinedBlocks;
 
-  while (const Node *node = partition.popHistoryOnce(joinedBlocks)) {
+  // The instruction of the most recently rewound sequence boundary. History is
+  // rewound newest-first, and a package's boundary is popped just before the
+  // nodes that belong to it, so this names the instruction whose effect the
+  // nodes being rewound right now are undoing. Only read by the logging below.
+  SILInstruction *currentBoundaryInst = nullptr;
+
+  auto &pendingNotes = state.pendingNotes;
+  auto &openQuestions = state.openQuestions;
+  auto &links = state.notes;
+  bool &allQuestionsAnswered = state.allQuestionsAnswered;
+
+  // Scratch for rebuilding the open questions while answering them against a
+  // single merge. Declared out here so the loop below does not reallocate.
+  SmallVector<ChainQuestion, 8> stillUnanswered;
+
+  while (const auto *node = partition->popHistoryOnce(joinedBlocks)) {
+    SWIFT_DEFER {
+      ISOLATION_HISTORY_LOG(
+          auto &os = log(1); os << "Rewound: ";
+          node->printOneLine(os, inputFn->getASTContext().SourceMgr);
+          os << '\n';
+          // Name the instruction being undone: its own for a boundary, the
+          // enclosing package's for everything else.
+          auto &instOS = log(2);
+          instOS << "inst: ";
+          printBoundaryInstForLog(instOS, currentBoundaryInst); instOS << '\n';
+          // Only the node kinds that actually undo a region change alter the
+          // partition, so print the new partition just for those.
+          if (node->doesRewindingMutatePartition()) {
+            log(2) << "Partition is now: ";
+            partition->print(llvm::dbgs());
+          });
+    };
+
     switch (node->getKind()) {
     case Node::MergeElementRegions: {
-      Element rep = node->getFirstArgAsElement();
-      ArrayRef<Element> others = node->getAdditionalElementArgs();
+      // The two elements the program actually merged. Undoing the node has
+      // already put them in separate regions, along with whatever each of them
+      // carried: everything the merge moved is on snd's side, everything that
+      // stayed is on fst's.
+      //
+      // These are the values to NAME in a note. They are not what decides
+      // whether the note is emitted -- see below.
+      Element fst = node->getFirstArgAsElement();
+      Element snd = node->getAdditionalElementArgs().front();
 
-      // Is any element in this merge already tracked?
-      bool anyTracked = state.tracked.count(rep);
-      for (Element e : others)
-        anyTracked |= bool(state.tracked.count(e));
-      if (!anyTracked)
-        break;
+      if (fst == snd)
+        continue;
 
-      // Classify every not-yet-tracked element in the merge. An isolated
-      // element is the merge target that ends the chain; a disconnected one is
-      // another intermediate we keep following. Elements with no value-map
-      // entry (tracked transiently in history but no longer in the map) are
-      // ignored.
-      SmallVector<Element, 8> involved;
-      involved.push_back(rep);
-      involved.append(others.begin(), others.end());
-      for (Element e : involved) {
-        if (state.tracked.count(e))
-          continue;
-        auto info = inputValueMap.getIsolationRegion(e);
-        if (!info)
-          continue;
-        if (!info.isDisconnected()) {
-          state.pendingTargetMerge = true;
-          if (!state.isolatedFound) {
-            state.isolatedFound = true;
-            state.isolatedElement = e;
-          }
+      // Both must still be in the partition to ask which side anything is on.
+      if (!partition->isTrackingElement(fst) ||
+          !partition->isTrackingElement(snd))
+        continue;
+
+      Region fstRegion = partition->getRegion(fst);
+      Region sndRegion = partition->getRegion(snd);
+
+      // The undo should have separated them. If it did not, this node cannot
+      // have split any question's ends apart either.
+      if (fstRegion == sndRegion)
+        continue;
+
+      // Answer every question this merge separates.
+      //
+      // Recognition is REGIONAL, not by operand: a question is answered here if
+      // undoing this merge put its two ends in different regions. A merge whose
+      // operands are neither end still separates them -- both ends can be
+      // passengers carried along on opposite sides of the split -- and asking
+      // about regions does not care which element happened to be named or which
+      // side survived the split.
+      stillUnanswered.clear();
+      for (const ChainQuestion &question : openQuestions) {
+        if (!partition->isTrackingElement(question.from)) {
+          stillUnanswered.push_back(question);
           continue;
         }
-        state.tracked.insert(e);
-        state.intermediateSeen = true;
+
+        // Which side of the split is the sent-value end on?
+        Region fromRegion = partition->getRegion(question.from);
+        bool fromOnFstSide = fromRegion == fstRegion;
+        if (!fromOnFstSide && fromRegion != sndRegion) {
+          // Neither side: this merge did not touch this question.
+          stillUnanswered.push_back(question);
+          continue;
+        }
+
+        // Orient the operand pair so 'near' is the one on the sent value's
+        // side. Notes read near-to-far, matching the chain's direction.
+        Element nearElt = fromOnFstSide ? fst : snd;
+        Element farElt = fromOnFstSide ? snd : fst;
+        Region farRegion = fromOnFstSide ? sndRegion : fstRegion;
+
+        bool farIsIsolatedSource = false;
+        if (question.to) {
+          // Both ends known. This merge answers the question only if the far
+          // end is on the other side of the split.
+          if (!partition->isTrackingElement(*question.to) ||
+              partition->getRegion(*question.to) != farRegion) {
+            stillUnanswered.push_back(question);
+            continue;
+          }
+        } else {
+          // Looking for whatever isolated this element's region. Before the
+          // undo that region was isolated; if it still is, the isolation came
+          // from an older merge and this is not the one.
+          if (partition.isInIsolatedRegion(question.from)) {
+            stillUnanswered.push_back(question);
+            continue;
+          }
+          // from's region is disconnected now, so the isolated element went to
+          // the other side of this split.
+          farIsIsolatedSource = partition.isIsolated(farElt);
+        }
+
+        ISOLATION_HISTORY_LOG(
+            log(2) << "This merge separates %%" << question.from << " from ";
+            if (question.to) llvm::dbgs() << "%%" << *question.to;
+            else llvm::dbgs() << "the isolated value";
+            llvm::dbgs() << ". The program merged %%" << nearElt << " and %%"
+                         << farElt
+                         << ", so that is the connection to report.\n");
+
+        // A merge between two spellings of one value explains nothing, so it
+        // gets no note. The question still advances past it: whatever we needed
+        // to reach through 'near' we now need to reach through 'far'.
+        auto noteIndex = question.parentNote;
+        if (isSameUserValue(nearElt, farElt)) {
+          ISOLATION_HISTORY_LOG(
+              log(3)
+              << "%%" << nearElt << " and %%" << farElt
+              << " are the same value spelled two ways, so this merge is an "
+                 "artifact of lowering and gets no note.\n");
+        } else {
+          noteIndex = links.size();
+          pendingNotes.push_back(*noteIndex);
+          links.push_back(NoteToEmit{nearElt, farElt, SILLocation::invalid(),
+                                     question.parentNote, farIsIsolatedSource});
+        }
+
+        // The question splits in two: how does the sent-value end reach the
+        // operand on its side, and how does the operand on the far side reach
+        // the far end. Either half is already answered when its two elements
+        // coincide.
+        if (question.from != nearElt) {
+          ISOLATION_HISTORY_LOG(log(3)
+                                << "Still need to connect %%" << question.from
+                                << " to %%" << nearElt << ".\n");
+          stillUnanswered.push_back(
+              ChainQuestion{question.from, nearElt, noteIndex});
+        }
+        if (question.to) {
+          if (*question.to != farElt) {
+            ISOLATION_HISTORY_LOG(log(3) << "Still need to connect %%" << farElt
+                                         << " to %%" << *question.to << ".\n");
+            stillUnanswered.push_back(
+                ChainQuestion{farElt, *question.to, noteIndex});
+          }
+        } else if (!farIsIsolatedSource) {
+          // The far side is isolated but this element is not the isolated value
+          // itself, so it is another carrier and its own route still needs
+          // explaining.
+          ISOLATION_HISTORY_LOG(log(3)
+                                << "%%" << farElt
+                                << " is not the isolated value itself, so it "
+                                   "still needs its own explanation.\n");
+          stillUnanswered.push_back(
+              ChainQuestion{farElt, std::nullopt, noteIndex});
+        }
       }
-      break;
+      openQuestions.assign(stillUnanswered.begin(), stillUnanswered.end());
+
+      if (openQuestions.empty()) {
+        ISOLATION_HISTORY_LOG(
+            log(2)
+            << "Every connection is explained. Waiting for this merge's "
+               "boundary to learn which instruction to point the last notes "
+               "at.\n");
+        allQuestionsAnswered = true;
+      }
+      continue;
     }
 
-    case Node::SequenceBoundary:
-      if (state.pendingTargetMerge) {
-        if (auto loc = node->getHistoryBoundaryLoc()) {
-          if (state.intermediateSeen)
-            originatingLoc = loc;
-          // Either way (emitted or suppressed) we've found the chain end; the
-          // walk state now holds the winning frame's naming state.
-          return true;
-        }
-      }
-      state.pendingTargetMerge = false;
-      break;
+    case Node::SequenceBoundary: {
+      currentBoundaryInst = node->getHistoryBoundaryInst();
 
+      // This boundary names the instruction behind every merge rewound since
+      // the last one, so it is the location of the links they created.
+      auto loc = node->getHistoryBoundaryLoc();
+      assert(loc);
+      for (unsigned i : pendingNotes)
+        links[i].mergeLoc = *loc;
+      pendingNotes.clear();
+
+      // Every question has been answered and the last notes now have their
+      // locations, so there is nothing older worth rewinding for.
+      if (allQuestionsAnswered) {
+        ISOLATION_HISTORY_LOG(log(2)
+                              << "Done: the whole chain is explained.\n");
+        notes = std::move(links);
+        return true;
+      }
+      continue;
+    }
     case Node::CFGHistoryJoin:
+      // popHistoryOnce has recorded the predecessor block for us; the branch
+      // that was joined in is rewound as its own state once this one runs out
+      // of history.
+      continue;
     case Node::AddNewRegionForElement:
     case Node::RemoveLastElementFromRegion:
     case Node::RemoveElementFromRegion:
-      break;
+      continue;
     }
   }
 
-  // The chain continues into the predecessor blocks joined at this frame.
+  ISOLATION_HISTORY_LOG(
+      log(1) << "Ran out of history here. Questions still unanswered: "
+             << openQuestions.size() << ", links found: " << links.size()
+             << ", branches to continue into: " << joinedBlocks.size() << '\n');
+
+  // Every question was answered, so nothing older can add a link. What can
+  // still be missing is a location: a link is left waiting when the merge
+  // behind it was performed by the dataflow join rather than by a PartitionOp,
+  // so no boundary in this block names it. The instruction to blame for such a
+  // merge is the last one in the branch where the two ends actually came
+  // together, which is the first boundary the walk rewinds after taking a path
+  // into that predecessor.
   //
-  // A pendingTargetMerge still set here has no location: it came from a region
-  // unification the dataflow join introduced, not a user-written merge (which
-  // would have been followed by its SequenceBoundary in this same frame). If we
-  // explored every predecessor it would be pinned to the first boundary of
-  // whichever branch we happen to walk first — e.g. the 'else' arm of a
-  // diamond, which never touched the isolated value. So while such a merge is
-  // pending, find the branch responsible for the isolation and prune the rest.
-  //
-  // The signal is a *discriminating* element: one that is isolated at some
-  // predecessor's exit but merely disconnected at another's. Its isolation was
-  // introduced on the branch(es) where it is isolated, so the predecessors
-  // where it is disconnected did not cause it and are pruned. (Elements that
-  // are isolated everywhere, or absent, or disconnected everywhere — e.g.
-  // block- local temporaries — do not distinguish the branches and are
-  // ignored.)
+  // Keep the chain as it stands in case no other path improves on it, and stop
+  // here when there is no path left to try.
+  if (allQuestionsAnswered) {
+    if (notes.empty())
+      notes = links;
+    if (joinedBlocks.empty()) {
+      ISOLATION_HISTORY_LOG(
+          log(1) << "The chain is explained as far as the history goes.\n");
+      return true;
+    }
+  }
+
+  // The chain -- or the location of its last links -- is in the predecessors
+  // whose exit partitions were joined into this one at a CFG merge point.
   struct PredExit {
     SILBasicBlock *block;
     Partition exit;
   };
   SmallVector<PredExit, 4> preds;
   for (SILBasicBlock *predBlock : joinedBlocks) {
-    if (!visitedBlocks.insert(predBlock).second)
+    if (!visitedBlocks.insert(predBlock)) {
+      ISOLATION_HISTORY_LOG(log(1) << "Not rewinding joined pred bb"
+                                   << predBlock->getDebugID() << " again.\n");
       continue;
+    }
+
     auto predBlockState = inputFunctionInfo->getBlockState(predBlock);
-    if (!predBlockState)
+    if (!predBlockState) {
+      ISOLATION_HISTORY_LOG(log(1) << "Cannot rewind joined pred bb"
+                                   << predBlock->getDebugID()
+                                   << ": it has no block state.\n");
       continue;
+    }
+
+    // The history is rewound over region membership alone, so the sending
+    // operands recorded in the exit partition have to go.
     preds.push_back({predBlock, predBlockState.get()
                                     ->getExitPartition()
                                     .removingSendingOperandState()});
   }
 
-  SmallVector<bool, 4> resets(preds.size(), false);
-  if (state.pendingTargetMerge) {
-    for (Element e : state.tracked) {
-      // Classify e at each predecessor exit: isolated, or present-but-
-      // disconnected. (Absent predecessors are left out — they say nothing.)
-      SmallVector<bool, 4> isolatedInPred(preds.size(), false);
-      SmallVector<bool, 4> disconnectedInPred(preds.size(), false);
-      bool anyIsolated = false;
-      for (unsigned i = 0, n = preds.size(); i != n; ++i) {
-        if (!preds[i].exit.isTrackingElement(e))
-          continue;
-        bool isolatedHere = false;
-        Region region = preds[i].exit.getRegion(e);
-        for (auto pair : preds[i].exit.range()) {
-          if (pair.second != region)
-            continue;
-          auto info = inputValueMap.getIsolationRegion(pair.first);
-          if (info && !info.isDisconnected()) {
-            isolatedHere = true;
-            break;
-          }
-        }
-        isolatedInPred[i] = isolatedHere;
-        disconnectedInPred[i] = !isolatedHere;
-        anyIsolated |= isolatedHere;
-      }
+  // What the walk still wants from a predecessor: the open questions when there
+  // are any, and otherwise the ends of the links that are waiting for a
+  // location.
+  SmallVector<ChainQuestion, 4> wanted;
+  if (!openQuestions.empty()) {
+    wanted.append(openQuestions.begin(), openQuestions.end());
+  } else {
+    for (unsigned i : pendingNotes)
+      wanted.push_back(
+          ChainQuestion{links[i].lhsElt, links[i].rhsElt, std::nullopt});
+  }
 
-      // e discriminates only if it is isolated somewhere; then the branches
-      // where it is disconnected are the ones that reset it.
-      if (anyIsolated)
-        for (unsigned i = 0, n = preds.size(); i != n; ++i)
-          if (disconnectedInPred[i])
-            resets[i] = true;
+  // Only some of those predecessors can be where what we want happened, and
+  // rewinding one of the others would report merges from a branch the isolation
+  // never came through -- the arm of a diamond that assigns a fresh value has a
+  // history full of merges, none of them an answer.
+  //
+  // A predecessor is a candidate when its exit partition can answer something
+  // we want (see \c couldAnswer). If none of them can, the walk has lost track
+  // of what it is looking for, so rather than guess we try them all.
+  SmallVector<bool, 4> isCandidate(preds.size(), false);
+  bool anyCandidate = false;
+  for (unsigned i = 0, e = preds.size(); i != e; ++i) {
+    PartitionWrapper predPartition(preds[i].exit, inputValueMap);
+    for (const ChainQuestion &question : wanted) {
+      if (couldAnswer(question, predPartition)) {
+        isCandidate[i] = true;
+        anyCandidate = true;
+        break;
+      }
     }
   }
 
-  bool anyResponsible = false;
-  for (bool reset : resets)
-    anyResponsible |= !reset;
-
-  for (unsigned i = 0, n = preds.size(); i != n; ++i) {
-    if (state.pendingTargetMerge && anyResponsible && resets[i])
+  for (unsigned i = 0, e = preds.size(); i != e; ++i) {
+    if (anyCandidate && !isCandidate[i]) {
+      ISOLATION_HISTORY_LOG(
+          log(1) << "Nothing we are looking for came together in bb"
+                 << preds[i].block->getDebugID()
+                 << ", so the chain does not run through it. Skipping it.\n");
       continue;
-    worklist.push_back(Frame{std::move(preds[i].exit), state});
+    }
+
+    ISOLATION_HISTORY_LOG(log(1) << "Will continue the walk into bb"
+                                 << preds[i].block->getDebugID() << ".\n");
+    states.push_back(State{std::move(preds[i].exit), openQuestions, links,
+                           pendingNotes, allQuestionsAnswered});
   }
+
   return false;
+}
+
+/// A predecessor could answer a question when what the question asks about has
+/// already come together at that predecessor's exit:
+///
+///   - For a question with both ends known, when the two ends are in one region
+///     there. The merge that put them together is then somewhere in that
+///     predecessor's history. Where they are in different regions it was the
+///     join itself that brought them together, so that branch cannot explain
+///     the link.
+///
+///   - For a question still looking for whatever isolated its element, when
+///   that
+///     element's region is isolated there. A branch where it is disconnected is
+///     not where its isolation came from.
+bool IsolationHistoryNoteEmitter::couldAnswer(
+    const ChainQuestion &question, PartitionWrapper &exitPartition) const {
+  if (!exitPartition->isTrackingElement(question.from))
+    return false;
+
+  if (question.to) {
+    if (!exitPartition->isTrackingElement(*question.to))
+      return false;
+    return exitPartition->getRegion(question.from) ==
+           exitPartition->getRegion(*question.to);
+  }
+
+  return exitPartition.isInIsolatedRegion(question.from);
+}
+
+/// Emit the collected chain, one note per link, anchored at the merge that
+/// created the link.
+///
+/// The links are reported in the order the walk discovered them, which is not
+/// the order the chain reads in: a merge that separates the two ends of a
+/// question is rewound before the merges that explain either half. Nothing
+/// depends on that order -- every note names both of its ends and points at its
+/// own merge, so it reads on its own.
+void IsolationHistoryNoteEmitter::emitNotes() {
+  auto descriptiveKindStr = inputRegionInfo.printForDiagnostics(inputFn);
+  auto &diags = inputFn->getASTContext().Diags;
+
+  for (unsigned i = 0, e = notes.size(); i != e; ++i) {
+    const NoteToEmit &note = notes[i];
+
+    // The location comes from the sequence boundary behind the merge, which a
+    // truncated history may never have reached.
+    if (note.mergeLoc.isNull()) {
+      ISOLATION_HISTORY_LOG(log(1) << "No note for link [" << i
+                                   << "]: we never learned which instruction "
+                                      "performed the merge.\n");
+      continue;
+    }
+
+    auto nearName = inferElementName(note.lhsElt);
+    auto farName = inferElementName(note.rhsElt);
+
+    // The last link names the isolated value the chain ends at, so it gets the
+    // "which is accessible to <isolation>" phrasing. With no name to show for
+    // either end, all that is left to say is where the value entered the
+    // isolated region.
+    if (note.rhsIsIsolatedSource) {
+      if (!nearName || !farName || nearName->name == farName->name) {
+        ISOLATION_HISTORY_LOG(
+            log(1) << "Link [" << i
+                   << "] reaches the isolated value but cannot name both ends, "
+                      "so it only says where the value became isolated.\n");
+        emitGenericOriginatingNote(note.mergeLoc.getSourceLoc(),
+                                   descriptiveKindStr);
+        continue;
+      }
+
+      diags.diagnose(
+          note.mergeLoc.getSourceLoc(),
+          diag::regionbasedisolation_chain_value_exposed_to_isolated_named,
+          nearName->name, nearName->isCallResult, farName->name,
+          farName->isCallResult, descriptiveKindStr,
+          inputRegionInfo->isTaskIsolated());
+      continue;
+    }
+
+    if (!nearName || !farName) {
+      ISOLATION_HISTORY_LOG(log(1)
+                            << "No note for link [" << i
+                            << "]: one of its ends has no name we could show "
+                               "the user.\n");
+      continue;
+    }
+
+    // A call result is not something the reader can point at in their own code
+    // -- it names where a value came from -- so it reads as the object of a
+    // link, never its subject. Where the merge puts it on the left, turn the
+    // link around rather than saying "result of 'Foo.init()' is connected to
+    // 'c'".
+    const ElementName *subject = &*nearName;
+    const ElementName *object = &*farName;
+    if (subject->isCallResult && !object->isCallResult)
+      std::swap(subject, object);
+
+    // Name inference can resolve both ends to one identifier -- e.g. a closure
+    // literal and the `let` it is bound to. "'f' is connected to 'f'" explains
+    // nothing.
+    if (subject->name == object->name) {
+      ISOLATION_HISTORY_LOG(log(1)
+                            << "No note for link [" << i << "]: both ends are '"
+                            << subject->name << "'.\n");
+      continue;
+    }
+
+    diags.diagnose(note.mergeLoc.getSourceLoc(),
+                   diag::regionbasedisolation_chain_value_exposed,
+                   subject->name, subject->isCallResult, object->name,
+                   object->isCallResult);
+  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -564,7 +564,19 @@ private:
     bool rhsIsIsolatedSource;
   };
 
-  SmallVector<NoteToEmit, 8> notes;
+  /// The chain the walk settled on, one entry per note to emit. Filled in from
+  /// \c walkNotes once a path explains the chain.
+  SmallVector<NoteToEmit, 0> notes;
+
+  /// The notes the walk has discovered, shared by every path.
+  ///
+  /// Along one path this is append-only, but a path does two things to it that
+  /// the next one must not see: it appends notes of its own, and it fills in
+  /// locations on notes it inherited. Both are undone when the walk backtracks
+  /// onto another path, using that path's \c State::noteMark and
+  /// \c State::pendingStart. Sharing one buffer is what keeps State small
+  /// enough to copy per path without dragging a note vector along.
+  SmallVector<NoteToEmit, 0> walkNotes;
 
   /// An unanswered "how does \c from reach \c to" question.
   ///
@@ -605,10 +617,9 @@ private:
   ///
   /// A CFG history join leaves the walk several paths to try, since the chain
   /// may continue in any of the joined predecessors, and each path carries a
-  /// copy of this. That is why the walk's state lives here rather than on the
-  /// emitter: a path that turns out to be a dead end drops its copy, leaving
-  /// behind neither its half-answered questions nor notes about a branch that
-  /// did not isolate anything.
+  /// copy of this. So this is copied once per candidate predecessor and wants
+  /// to stay small. The notes themselves live in \c walkNotes rather than here;
+  /// a state refers to its share of them by the two marks below.
   struct State {
     /// The partition to keep rewinding. For the initial state this is the
     /// partition at the moment of the send; for a later path it is the joined
@@ -619,20 +630,32 @@ private:
     /// sent element come to be in an isolated region -- and answering a
     /// question can split it in two, so this grows as well as shrinks. The
     /// chain is fully explained when it drains.
-    SmallVector<ChainQuestion, 8> openQuestions;
+    ///
+    /// Unlike the notes this cannot be shared: \c processState rewrites it
+    /// wholesale for every merge it answers, so it is not append-only. One
+    /// question is always in flight, so keep room for that one inline.
+    SmallVector<ChainQuestion, 1> openQuestions;
 
-    /// The links discovered so far, in discovery order.
-    SmallVector<NoteToEmit, 8> notes;
+    /// Size of \c walkNotes when this state was created, i.e. the notes it
+    /// inherited. Backtracking onto this path drops everything the path tried
+    /// before it appended past this point.
+    unsigned noteMark = 0;
 
-    /// Indices into \c notes of links still waiting for a location. A
-    /// PartitionOp pushes its sequence boundary before its nodes, so rewinding
-    /// reaches a merge before the boundary that names the instruction behind
-    /// it: a link's location is not known when the link is created and is
-    /// filled in when the boundary arrives.
-    SmallVector<unsigned, 4> pendingNotes;
+    /// Index in \c walkNotes of the first inherited note still waiting for a
+    /// location, so the inherited pending notes are [pendingStart, noteMark).
+    ///
+    /// A PartitionOp pushes its sequence boundary before its nodes, so
+    /// rewinding reaches a merge before the boundary that names the instruction
+    /// behind it: a note's location is not known when the note is created and
+    /// is filled in when the boundary arrives. A merge the dataflow join
+    /// performed has no boundary in this block at all, so its notes stay
+    /// pending across the join and are located only once the walk takes a path
+    /// into the predecessor. Backtracking onto this path un-locates this range,
+    /// undoing whatever the path tried before it wrote there.
+    unsigned pendingStart = 0;
 
     /// Set once \c openQuestions drains. The walk cannot stop the moment that
-    /// happens: the links the answering merge created are still waiting for the
+    /// happens: the notes the answering merge created are still waiting for the
     /// location of the instruction behind them.
     bool allQuestionsAnswered = false;
   };
@@ -811,9 +834,9 @@ private:
 
   /// Rewind \p state's partition until the chain is explained or the state's
   /// history runs out. Returns true when the chain was explained, in which case
-  /// the state's links have been moved onto \c notes. Otherwise records a path
-  /// on \p states for each joined predecessor the chain may continue in and
-  /// returns false.
+  /// the chain has been copied from \c walkNotes onto \c notes. Otherwise
+  /// records a path on \p states for each joined predecessor the chain may
+  /// continue in and returns false.
   bool processState(State &&state, SmallVectorImpl<State> &states);
 
   void emitNotes();
@@ -920,7 +943,7 @@ void IsolationHistoryNoteEmitter::collectIsolationHistoryNotes() {
   // and does not maintain the send information alongside it. For a joined
   // predecessor's exit partition that happens where the path is recorded; the
   // send-time partition we start from is stripped here.
-  State initial{inputPartition.removingSendingOperandState()};
+  State initial{inputPartition.removingSendingOperandState(), {}};
   initial.openQuestions.push_back(
       ChainQuestion{inputSentElement, std::nullopt, std::nullopt});
 
@@ -932,6 +955,13 @@ void IsolationHistoryNoteEmitter::collectIsolationHistoryNotes() {
   while (!states.empty()) {
     State state = std::move(states.back());
     states.pop_back();
+
+    // Put the shared note buffer back the way this path left it. A path tried
+    // in the meantime appended notes of its own and located notes this one
+    // inherited, and neither belongs here.
+    walkNotes.truncate(state.noteMark);
+    for (unsigned i = state.pendingStart, e = state.noteMark; i != e; ++i)
+      walkNotes[i].mergeLoc = SILLocation::invalid();
 
     ISOLATION_HISTORY_LOG(log() << "Rewinding a partition (" << states.size()
                                 << " other path(s) still to try): ";
@@ -960,10 +990,12 @@ bool IsolationHistoryNoteEmitter::processState(State &&state,
   // nodes being rewound right now are undoing. Only read by the logging below.
   SILInstruction *currentBoundaryInst = nullptr;
 
-  auto &pendingNotes = state.pendingNotes;
   auto &openQuestions = state.openQuestions;
-  auto &links = state.notes;
   bool &allQuestionsAnswered = state.allQuestionsAnswered;
+
+  // Index of the first note still waiting for a location. Everything from here
+  // to the end of walkNotes is pending; everything before it is located.
+  unsigned pendingStart = state.pendingStart;
 
   // Scratch for rebuilding the open questions while answering them against a
   // single merge. Declared out here so the loop below does not reallocate.
@@ -1087,10 +1119,12 @@ bool IsolationHistoryNoteEmitter::processState(State &&state,
               << " are the same value spelled two ways, so this merge is an "
                  "artifact of lowering and gets no note.\n");
         } else {
-          noteIndex = links.size();
-          pendingNotes.push_back(*noteIndex);
-          links.push_back(NoteToEmit{nearElt, farElt, SILLocation::invalid(),
-                                     question.parentNote, farIsIsolatedSource});
+          // A new note is pending by construction: it goes on the end, and
+          // pendingStart already points at or before the end.
+          noteIndex = walkNotes.size();
+          walkNotes.push_back(
+              NoteToEmit{nearElt, farElt, SILLocation::invalid(),
+                         question.parentNote, farIsIsolatedSource});
         }
 
         // The question splits in two: how does the sent-value end reach the
@@ -1140,19 +1174,19 @@ bool IsolationHistoryNoteEmitter::processState(State &&state,
       currentBoundaryInst = node->getHistoryBoundaryInst();
 
       // This boundary names the instruction behind every merge rewound since
-      // the last one, so it is the location of the links they created.
+      // the last one, so it is the location of the notes they created.
       auto loc = node->getHistoryBoundaryLoc();
       assert(loc);
-      for (unsigned i : pendingNotes)
-        links[i].mergeLoc = *loc;
-      pendingNotes.clear();
+      for (unsigned i = pendingStart, e = walkNotes.size(); i != e; ++i)
+        walkNotes[i].mergeLoc = *loc;
+      pendingStart = walkNotes.size();
 
       // Every question has been answered and the last notes now have their
       // locations, so there is nothing older worth rewinding for.
       if (allQuestionsAnswered) {
         ISOLATION_HISTORY_LOG(log(2)
                               << "Done: the whole chain is explained.\n");
-        notes = std::move(links);
+        notes = walkNotes;
         return true;
       }
       continue;
@@ -1171,11 +1205,11 @@ bool IsolationHistoryNoteEmitter::processState(State &&state,
 
   ISOLATION_HISTORY_LOG(
       log(1) << "Ran out of history here. Questions still unanswered: "
-             << openQuestions.size() << ", links found: " << links.size()
+             << openQuestions.size() << ", notes found: " << walkNotes.size()
              << ", branches to continue into: " << joinedBlocks.size() << '\n');
 
-  // Every question was answered, so nothing older can add a link. What can
-  // still be missing is a location: a link is left waiting when the merge
+  // Every question was answered, so nothing older can add a note. What can
+  // still be missing is a location: a note is left waiting when the merge
   // behind it was performed by the dataflow join rather than by a PartitionOp,
   // so no boundary in this block names it. The instruction to blame for such a
   // merge is the last one in the branch where the two ends actually came
@@ -1186,7 +1220,7 @@ bool IsolationHistoryNoteEmitter::processState(State &&state,
   // here when there is no path left to try.
   if (allQuestionsAnswered) {
     if (notes.empty())
-      notes = links;
+      notes = walkNotes;
     if (joinedBlocks.empty()) {
       ISOLATION_HISTORY_LOG(
           log(1) << "The chain is explained as far as the history goes.\n");
@@ -1194,7 +1228,7 @@ bool IsolationHistoryNoteEmitter::processState(State &&state,
     }
   }
 
-  // The chain -- or the location of its last links -- is in the predecessors
+  // The chain -- or the location of its last notes -- is in the predecessors
   // whose exit partitions were joined into this one at a CFG merge point.
   struct PredExit {
     SILBasicBlock *block;
@@ -1224,15 +1258,15 @@ bool IsolationHistoryNoteEmitter::processState(State &&state,
   }
 
   // What the walk still wants from a predecessor: the open questions when there
-  // are any, and otherwise the ends of the links that are waiting for a
+  // are any, and otherwise the ends of the notes that are waiting for a
   // location.
   SmallVector<ChainQuestion, 4> wanted;
   if (!openQuestions.empty()) {
     wanted.append(openQuestions.begin(), openQuestions.end());
   } else {
-    for (unsigned i : pendingNotes)
-      wanted.push_back(
-          ChainQuestion{links[i].lhsElt, links[i].rhsElt, std::nullopt});
+    for (unsigned i = pendingStart, e = walkNotes.size(); i != e; ++i)
+      wanted.push_back(ChainQuestion{walkNotes[i].lhsElt, walkNotes[i].rhsElt,
+                                     std::nullopt});
   }
 
   // Only some of those predecessors can be where what we want happened, and
@@ -1267,8 +1301,12 @@ bool IsolationHistoryNoteEmitter::processState(State &&state,
 
     ISOLATION_HISTORY_LOG(log(1) << "Will continue the walk into bb"
                                  << preds[i].block->getDebugID() << ".\n");
-    states.push_back(State{std::move(preds[i].exit), openQuestions, links,
-                           pendingNotes, allQuestionsAnswered});
+    // Every path inherits the notes as they stand now, and the pending run
+    // within them. Backtracking onto the path restores walkNotes to exactly
+    // this.
+    states.push_back(State{std::move(preds[i].exit), openQuestions,
+                           unsigned(walkNotes.size()), pendingStart,
+                           allQuestionsAnswered});
   }
 
   return false;
@@ -1305,7 +1343,7 @@ bool IsolationHistoryNoteEmitter::couldAnswer(
 /// Emit the collected chain, one note per link, anchored at the merge that
 /// created the link.
 ///
-/// The links are reported in the order the walk discovered them, which is not
+/// The notes are reported in the order the walk discovered them, which is not
 /// the order the chain reads in: a merge that separates the two ends of a
 /// question is rewound before the merges that explain either half. Nothing
 /// depends on that order -- every note names both of its ends and points at its

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -832,6 +832,21 @@ private:
   /// continue in and returns false.
   bool processState(State &&state, SmallVectorImpl<State> &states);
 
+  /// Record a path on \p states for each predecessor in \p joinedBlocks that
+  /// the chain may continue in.
+  ///
+  /// The chain -- or the location of its last notes -- is in the predecessors
+  /// whose exit partitions were joined into \p state's partition at a CFG merge
+  /// point. Only some of them can be where what the walk is looking for
+  /// happened, so a predecessor whose exit partition cannot answer anything we
+  /// want is skipped rather than rewound.
+  ///
+  /// \p pendingStart is the state's pending-note mark as it stands now, which
+  /// rewinding has moved past the mark the state itself carries.
+  void prepareStatesForPredecessors(
+      const State &state, ArrayRef<SILBasicBlock *> joinedBlocks,
+      unsigned pendingStart, SmallVectorImpl<State> &states);
+
   void emitNotes();
 
   /// Returns true when isolation-history emission is on for this function and
@@ -981,7 +996,7 @@ void IsolationHistoryNoteEmitter::collectIsolationHistoryNotes() {
     // in the meantime appended notes of its own and located notes this one
     // inherited, and neither belongs here.
     walkNotes.truncate(state.noteMark);
-    for (unsigned i = state.pendingStart, e = state.noteMark; i != e; ++i)
+    for (unsigned i : range(state.pendingStart, state.noteMark))
       walkNotes[i].mergeLoc = SILLocation::invalid();
 
     ISOLATION_HISTORY_LOG(log() << "Rewinding a partition (" << states.size()
@@ -1044,6 +1059,16 @@ bool IsolationHistoryNoteEmitter::processState(State &&state,
     };
 
     switch (node->getKind()) {
+    case Node::CFGHistoryJoin:
+      // popHistoryOnce has recorded the predecessor block for us; the branch
+      // that was joined in is rewound as its own state once this one runs out
+      // of history.
+      continue;
+    case Node::AddNewRegionForElement:
+    case Node::RemoveLastElementFromRegion:
+    case Node::RemoveElementFromRegion:
+      continue;
+
     case Node::MergeElementRegions: {
       // The two elements the program actually merged. Undoing the node has
       // already put them in separate regions, along with whatever each of them
@@ -1214,15 +1239,6 @@ bool IsolationHistoryNoteEmitter::processState(State &&state,
       }
       continue;
     }
-    case Node::CFGHistoryJoin:
-      // popHistoryOnce has recorded the predecessor block for us; the branch
-      // that was joined in is rewound as its own state once this one runs out
-      // of history.
-      continue;
-    case Node::AddNewRegionForElement:
-    case Node::RemoveLastElementFromRegion:
-    case Node::RemoveElementFromRegion:
-      continue;
     }
   }
 
@@ -1251,13 +1267,17 @@ bool IsolationHistoryNoteEmitter::processState(State &&state,
     }
   }
 
-  // The chain -- or the location of its last notes -- is in the predecessors
-  // whose exit partitions were joined into this one at a CFG merge point.
-  //
-  // Point at those partitions rather than copying them. Deciding whether a
-  // predecessor is worth trying only reads its exit partition, and a Partition
-  // copy also copies its element-to-region map, so the copy waits until we know
-  // the walk is going there.
+  prepareStatesForPredecessors(state, joinedBlocks, pendingStart, states);
+  return false;
+}
+
+void IsolationHistoryNoteEmitter::prepareStatesForPredecessors(
+    const State &state, ArrayRef<SILBasicBlock *> joinedBlocks,
+    unsigned pendingStart, SmallVectorImpl<State> &states) {
+  // Point at the predecessors' exit partitions rather than copying them.
+  // Deciding whether a predecessor is worth trying only reads its exit
+  // partition, and a Partition copy also copies its element-to-region map, so
+  // the copy waits until we know the walk is going there.
   struct PredExit {
     SILBasicBlock *block;
     const Partition *exit;
@@ -1285,37 +1305,35 @@ bool IsolationHistoryNoteEmitter::processState(State &&state,
   // are any, and otherwise the ends of the notes that are waiting for a
   // location.
   SmallVector<ChainQuestion, 4> wanted;
-  if (!openQuestions.empty()) {
-    wanted.append(openQuestions.begin(), openQuestions.end());
+  if (!state.openQuestions.empty()) {
+    wanted.append(state.openQuestions.begin(), state.openQuestions.end());
   } else {
     for (unsigned i = pendingStart, e = walkNotes.size(); i != e; ++i)
       wanted.push_back(ChainQuestion{walkNotes[i].lhsElt, walkNotes[i].rhsElt,
                                      std::nullopt});
   }
 
-  // Only some of those predecessors can be where what we want happened, and
-  // rewinding one of the others would report merges from a branch the isolation
-  // never came through -- the arm of a diamond that assigns a fresh value has a
-  // history full of merges, none of them an answer.
+  // Rewinding a predecessor the chain never came through would report merges
+  // from a branch that has nothing to do with the isolation -- the arm of a
+  // diamond that assigns a fresh value has a history full of merges, none of
+  // them an answer.
   //
   // A predecessor is a candidate when its exit partition can answer something
   // we want (see \c couldAnswer). If none of them can, the walk has lost track
   // of what it is looking for, so rather than guess we try them all.
-  SmallVector<bool, 4> isCandidate(preds.size(), false);
-  bool anyCandidate = false;
-  for (unsigned i = 0, e = preds.size(); i != e; ++i) {
+  SmallBitVector isCandidate(preds.size());
+  for (unsigned i : indices(preds)) {
     PartitionWrapper predPartition(*preds[i].exit, inputValueMap);
     for (const ChainQuestion &question : wanted) {
       if (predPartition.couldAnswer(question)) {
         isCandidate[i] = true;
-        anyCandidate = true;
         break;
       }
     }
   }
 
-  for (unsigned i = 0, e = preds.size(); i != e; ++i) {
-    if (anyCandidate && !isCandidate[i]) {
+  for (unsigned i : indices(preds)) {
+    if (isCandidate.any() && !isCandidate[i]) {
       ISOLATION_HISTORY_LOG(
           log(1) << "Nothing we are looking for came together in bb"
                  << preds[i].block->getDebugID()
@@ -1333,11 +1351,9 @@ bool IsolationHistoryNoteEmitter::processState(State &&state,
     // within them. Backtracking onto the path restores walkNotes to exactly
     // this.
     states.push_back(State{preds[i].exit->removingSendingOperandState(),
-                           openQuestions, unsigned(walkNotes.size()),
-                           pendingStart, allQuestionsAnswered});
+                           state.openQuestions, unsigned(walkNotes.size()),
+                           pendingStart, state.allQuestionsAnswered});
   }
-
-  return false;
 }
 
 /// Emit the collected chain, one note per link, anchored at the merge that

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -815,6 +815,11 @@ Region Partition::merge(Element fst, Element snd, bool updateHistory) {
   assert(elementToRegionMap.at(fst) == elementToRegionMap.at(snd));
 
   // Now that we are correct/canonicalized, add the merge to our history.
+  //
+  // horizontalUpdate moved snd's *entire* region into fstRegion, so the
+  // elements it carried along have to be recorded too: popHistoryOnce reverses
+  // a merge by extracting the recorded elements, and an unrecorded passenger is
+  // left stranded in fstRegion for the rest of the rewind.
   if (updateHistory)
     pushMergeElementRegions(fst, snd, mergedElements);
   return result;
@@ -998,10 +1003,11 @@ IsolationHistory::pushNewElementRegion(Element element) {
 }
 
 IsolationHistory::Node *
-IsolationHistory::pushHistorySequenceBoundary(SILLocation loc) {
+IsolationHistory::pushHistorySequenceBoundary(SILLocation loc,
+                                              SILInstruction *inst) {
   unsigned size = Node::totalSizeToAlloc<Element>(0);
   void *mem = factory->allocator.Allocate(size, alignof(Node));
-  head = new (mem) Node(Node::SequenceBoundary, head, loc);
+  head = new (mem) Node(Node::SequenceBoundary, head, loc, inst);
   return getHead();
 }
 
@@ -1117,4 +1123,48 @@ void IsolationHistory::Node::print(ASTContext &ctx, llvm::raw_ostream &os,
     getHistoryBoundaryLoc()->print(os);
     break;
   }
+}
+
+void IsolationHistory::Node::printOneLine(
+    llvm::raw_ostream &os, const SourceManager &sourceMgr) const {
+  switch (getKind()) {
+  case AddNewRegionForElement:
+    os << "AddNewRegionForElement: %%" << getFirstArgAsElement();
+    return;
+  case RemoveLastElementFromRegion:
+    os << "RemoveLastElementFromRegion: %%" << getFirstArgAsElement();
+    return;
+  case RemoveElementFromRegion:
+    os << "RemoveElementFromRegion: %%" << getAdditionalElementArgs()[0]
+       << " from region of %%" << getFirstArgAsElement();
+    return;
+  case MergeElementRegions: {
+    os << "MergeElementRegions: into region of %%" << getFirstArgAsElement()
+       << " merged [";
+    bool isFirst = true;
+    for (Element e : getAdditionalElementArgs()) {
+      if (!isFirst)
+        os << ", ";
+      isFirst = false;
+      os << "%%" << e;
+    }
+    os << ']';
+    return;
+  }
+  case CFGHistoryJoin:
+    os << "CFGHistoryJoin: pred ";
+    if (auto *predBlock = getFirstArgAsBlock())
+      os << "bb" << predBlock->getDebugID();
+    else
+      os << "<none>";
+    return;
+  case SequenceBoundary:
+    os << "SequenceBoundary: ";
+    if (auto loc = getHistoryBoundaryLoc())
+      loc->print(os, sourceMgr);
+    else
+      os << "<no loc>";
+    return;
+  }
+  llvm_unreachable("Covered switch isn't covered?!");
 }

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -915,6 +915,16 @@ void Partition::horizontalUpdate(
 
 const IsolationHistory::Node *
 Partition::popHistoryOnce(SmallVectorImpl<SILBasicBlock *> &foundJoinedBlocks) {
+  // Rewinding a history that was never recorded silently finds nothing, which
+  // would read as "this value was never merged" rather than as a missing
+  // feature. Recording is gated on swift::shouldEmitIsolationHistoryFor and so
+  // is the only client that rewinds, so the two agreeing is an invariant, not a
+  // thing to handle.
+  assert(history.isEnabled() &&
+         "Rewinding an isolation history that was never recorded. The Factory "
+         "was built with recording off, but something is walking the history "
+         "anyway -- the recording gate and the consumer gate have drifted.");
+
   const auto *head = history.pop();
   if (!head)
     return nullptr;
@@ -996,6 +1006,9 @@ Partition::popHistoryOnce(SmallVectorImpl<SILBasicBlock *> &foundJoinedBlocks) {
 // independent region.
 IsolationHistory::Node *
 IsolationHistory::pushNewElementRegion(Element element) {
+  if (!isEnabled())
+    return nullptr;
+
   unsigned size = Node::totalSizeToAlloc<Element>(0);
   void *mem = factory->allocator.Allocate(size, alignof(Node));
   head = new (mem) Node(Node::AddNewRegionForElement, head, element);
@@ -1005,6 +1018,9 @@ IsolationHistory::pushNewElementRegion(Element element) {
 IsolationHistory::Node *
 IsolationHistory::pushHistorySequenceBoundary(SILLocation loc,
                                               SILInstruction *inst) {
+  if (!isEnabled())
+    return nullptr;
+
   unsigned size = Node::totalSizeToAlloc<Element>(0);
   void *mem = factory->allocator.Allocate(size, alignof(Node));
   head = new (mem) Node(Node::SequenceBoundary, head, loc, inst);
@@ -1014,6 +1030,9 @@ IsolationHistory::pushHistorySequenceBoundary(SILLocation loc,
 // Push onto the history that \p value should be removed from any region that it
 // is apart of and placed within its own separate region.
 void IsolationHistory::pushRemoveLastElementFromRegion(Element element) {
+  if (!isEnabled())
+    return;
+
   unsigned size = Node::totalSizeToAlloc<Element>(0);
   void *mem = factory->allocator.Allocate(size, alignof(Node));
   head = new (mem) Node(Node::RemoveLastElementFromRegion, head, element);
@@ -1021,6 +1040,9 @@ void IsolationHistory::pushRemoveLastElementFromRegion(Element element) {
 
 void IsolationHistory::pushRemoveElementFromRegion(
     Element otherElementInOldRegion, Element element) {
+  if (!isEnabled())
+    return;
+
   unsigned size = Node::totalSizeToAlloc<Element>(1);
   void *mem = factory->allocator.Allocate(size, alignof(Node));
   head = new (mem) Node(Node::RemoveElementFromRegion, head, element,
@@ -1030,6 +1052,9 @@ void IsolationHistory::pushRemoveElementFromRegion(
 void IsolationHistory::pushMergeElementRegions(Element elementInNewRegion,
                                                Element elementInOldRegion,
                                                ArrayRef<Element> eltsToMerge) {
+  if (!isEnabled())
+    return;
+
   assert(elementInNewRegion != elementInOldRegion);
   assert(llvm::none_of(eltsToMerge, [&](Element elt) {
     return elt == elementInNewRegion || elt == elementInOldRegion;
@@ -1044,6 +1069,9 @@ void IsolationHistory::pushMergeElementRegions(Element elementInNewRegion,
 // control-flow merge point. The joined history is not copied in; it is
 // recovered on demand as predBlock's exit-partition isolation history.
 void IsolationHistory::pushCFGHistoryJoin(SILBasicBlock *predBlock) {
+  if (!isEnabled())
+    return;
+
   // Without a predecessor block there is nothing to recover the joined history
   // from later, so there is nothing to record.
   if (!predBlock)

--- a/lib/SILOptimizer/Utils/VariableNameUtils.cpp
+++ b/lib/SILOptimizer/Utils/VariableNameUtils.cpp
@@ -513,6 +513,58 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
             if (auto debugVar = DebugVarCarryingInst(debugUse->getUser())) {
               assert(debugVar.getKind() ==
                      DebugVarCarryingInst::Kind::DebugValue);
+
+              // The variable being initialized is normally the better name,
+              // since it is what the user wrote for this value. A client that
+              // needs to explain where the value came from asks for the callee
+              // instead. Only override when this really is a call result whose
+              // callee can be named; otherwise there is nothing better to say.
+              if (options.contains(Flag::NameCallResultAfterCallee)) {
+                if (auto fas = CallResultNamer::getCallProducing(searchValue)) {
+                  auto cnd = namer.getCalleeNameAndDecl(fas);
+
+                  // An accessor's name is its storage's name, because in source
+                  // the user writes the property rather than a call. Spelling
+                  // that as 'slot()' would name something they never wrote, so
+                  // leave property reads to the normal naming path.
+                  bool calleeIsAccessor =
+                      cnd.decl && isa<AccessorDecl>(cnd.decl);
+
+                  if (!cnd.name.empty() && !calleeIsAccessor) {
+                    // Spell the component as a call, so the name reads as the
+                    // result of calling the function rather than as a value
+                    // that happens to share the function's name. Push it as
+                    // text rather than as the decl: the decl overload renders
+                    // the bare base name, which is exactly the ambiguity the
+                    // parens resolve. Interning keeps the StringRef alive past
+                    // this scope.
+                    SmallString<64> calleeCall;
+                    llvm::raw_svector_ostream calleeCallStream(calleeCall);
+
+                    // An initializer's base name is 'init', which names nothing
+                    // the reader can look for, and a type can have several
+                    // initializers. Qualify it with the type and keep the
+                    // argument labels -- 'KlassPair.init(_:_:)' -- so the
+                    // component names the initializer that actually ran.
+                    auto *ctor = dyn_cast_or_null<ConstructorDecl>(cnd.decl);
+                    auto *nominal =
+                        ctor ? ctor->getDeclContext()->getSelfNominalTypeDecl()
+                             : nullptr;
+                    if (ctor && nominal)
+                      calleeCallStream << nominal->getName() << '.'
+                                       << ctor->getName();
+                    else
+                      calleeCallStream << cnd.name << "()";
+
+                    pushPathComponent(
+                        astContext.getIdentifier(calleeCall).str(),
+                        fas.getLoc());
+                    nameIsCallResult = true;
+                    return searchValue;
+                  }
+                }
+              }
+
               pushPathComponent(debugVar.getName(), searchValue.getLoc());
 
               // We return the value, not the debug_info.
@@ -878,16 +930,21 @@ VariableNameInferrer::inferNameAndRoot(SILValue value) {
 }
 
 std::optional<std::pair<Identifier, SourceLoc>>
-VariableNameInferrer::inferNameAndFirstPathComponent(SILValue value) {
+VariableNameInferrer::inferNameAndFirstPathComponent(SILValue value,
+                                                     Options extraOptions,
+                                                     bool *nameIsCallResult) {
   auto *fn = value->getFunction();
   if (!fn)
     return {};
   VariableNameInferrer::Options options;
   options |= VariableNameInferrer::Flag::InferSelfThroughAllAccessors;
+  options |= extraOptions;
   SmallString<64> resultingName;
   VariableNameInferrer inferrer(fn, options, resultingName);
   if (!inferrer.inferByWalkingUsesToDefs(value))
     return {};
+  if (nameIsCallResult)
+    *nameIsCallResult = inferrer.isNameACallResult();
   return {{fn->getASTContext().getIdentifier(resultingName),
            inferrer.getFirstNameProvidingLoc()}};
 }

--- a/test/Concurrency/transfernonsendable_isolationhistory.sil
+++ b/test/Concurrency/transfernonsendable_isolationhistory.sil
@@ -79,8 +79,8 @@ bb0(%x : @guaranteed $NonSendableKlass):
   debug_value %x : $NonSendableKlass, let, name "x", argno 1
 
   %f1 = function_ref @mergeOne : $@convention(thin) (@guaranteed NonSendableKlass) -> @owned NonSendableKlass
-  %r1 = apply %f1(%x) : $@convention(thin) (@guaranteed NonSendableKlass) -> @owned NonSendableKlass // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
-  %y = move_value [lexical] [var_decl] %r1 : $NonSendableKlass
+  %r1 = apply %f1(%x) : $@convention(thin) (@guaranteed NonSendableKlass) -> @owned NonSendableKlass // expected-note {{result of 'mergeOne()' is connected to 'x' which is accessible to code in the current isolation context}}
+  %y = move_value [lexical] [var_decl] %r1 : $NonSendableKlass // expected-note {{'y' is connected to result of 'mergeOne()'}}
   debug_value %y : $NonSendableKlass, let, name "y"
 
   %addr = alloc_stack $NonSendableKlass
@@ -105,9 +105,9 @@ bb0(%x : @guaranteed $NonSendableKlass):
   %fresh = apply %mk() : $@convention(thin) () -> @owned NonSendableKlass
 
   %f2 = function_ref @mergeTwo : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> @owned NonSendableKlass
-  %r1 = apply %f2(%x, %fresh) : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> @owned NonSendableKlass // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+  %r1 = apply %f2(%x, %fresh) : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> @owned NonSendableKlass // expected-note {{result of 'mergeTwo()' is connected to 'x' which is accessible to code in the current isolation context}}
   destroy_value %fresh : $NonSendableKlass
-  %y = move_value [lexical] [var_decl] %r1 : $NonSendableKlass
+  %y = move_value [lexical] [var_decl] %r1 : $NonSendableKlass // expected-note {{'y' is connected to result of 'mergeTwo()'}}
   debug_value %y : $NonSendableKlass, let, name "y"
 
   %addr = alloc_stack $NonSendableKlass
@@ -130,15 +130,16 @@ bb0(%x : @guaranteed $NonSendableKlass):
   %f1 = function_ref @mergeOne : $@convention(thin) (@guaranteed NonSendableKlass) -> @owned NonSendableKlass
 
   // y = mergeOne(x)
-  %r1 = apply %f1(%x) : $@convention(thin) (@guaranteed NonSendableKlass) -> @owned NonSendableKlass // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
-  %y = move_value [lexical] [var_decl] %r1 : $NonSendableKlass
+  %r1 = apply %f1(%x) : $@convention(thin) (@guaranteed NonSendableKlass) -> @owned NonSendableKlass // expected-note {{result of 'mergeOne()' is connected to 'x' which is accessible to code in the current isolation context}}
+  %y = move_value [lexical] [var_decl] %r1 : $NonSendableKlass // expected-note {{'y' is connected to result of 'mergeOne()'}}
   debug_value %y : $NonSendableKlass, let, name "y"
 
   // z = mergeOne(y)
   %yb = begin_borrow %y : $NonSendableKlass
-  %r2 = apply %f1(%yb) : $@convention(thin) (@guaranteed NonSendableKlass) -> @owned NonSendableKlass // expected-note {{'z' is connected to 'y'}}
+  // expected-note@+1{{'y' is connected to result of 'mergeOne()'}}
+  %r2 = apply %f1(%yb) : $@convention(thin) (@guaranteed NonSendableKlass) -> @owned NonSendableKlass
   end_borrow %yb : $NonSendableKlass
-  %z = move_value [lexical] [var_decl] %r2 : $NonSendableKlass
+  %z = move_value [lexical] [var_decl] %r2 : $NonSendableKlass // expected-note {{'z' is connected to result of 'mergeOne()'}}
   debug_value %z : $NonSendableKlass, let, name "z"
 
   // send z
@@ -163,22 +164,24 @@ bb0(%x : @guaranteed $NonSendableKlass):
   %f1 = function_ref @mergeOne : $@convention(thin) (@guaranteed NonSendableKlass) -> @owned NonSendableKlass
 
   // y = mergeOne(x)
-  %r1 = apply %f1(%x) : $@convention(thin) (@guaranteed NonSendableKlass) -> @owned NonSendableKlass // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
-  %y = move_value [lexical] [var_decl] %r1 : $NonSendableKlass
+  %r1 = apply %f1(%x) : $@convention(thin) (@guaranteed NonSendableKlass) -> @owned NonSendableKlass // expected-note {{result of 'mergeOne()' is connected to 'x' which is accessible to code in the current isolation context}}
+  %y = move_value [lexical] [var_decl] %r1 : $NonSendableKlass // expected-note {{'y' is connected to result of 'mergeOne()'}}
   debug_value %y : $NonSendableKlass, let, name "y"
 
   // z = mergeOne(y)
   %yb = begin_borrow %y : $NonSendableKlass
-  %r2 = apply %f1(%yb) : $@convention(thin) (@guaranteed NonSendableKlass) -> @owned NonSendableKlass // expected-note {{'z' is connected to 'y'}}
+  // expected-note@+1{{'y' is connected to result of 'mergeOne()'}}
+  %r2 = apply %f1(%yb) : $@convention(thin) (@guaranteed NonSendableKlass) -> @owned NonSendableKlass
   end_borrow %yb : $NonSendableKlass
-  %z = move_value [lexical] [var_decl] %r2 : $NonSendableKlass
+  %z = move_value [lexical] [var_decl] %r2 : $NonSendableKlass // expected-note {{'z' is connected to result of 'mergeOne()'}}
   debug_value %z : $NonSendableKlass, let, name "z"
 
   // w = mergeOne(z)
   %zb = begin_borrow %z : $NonSendableKlass
-  %r3 = apply %f1(%zb) : $@convention(thin) (@guaranteed NonSendableKlass) -> @owned NonSendableKlass // expected-note {{'w' is connected to 'z'}}
+  // expected-note@+1{{'z' is connected to result of 'mergeOne()'}}
+  %r3 = apply %f1(%zb) : $@convention(thin) (@guaranteed NonSendableKlass) -> @owned NonSendableKlass
   end_borrow %zb : $NonSendableKlass
-  %w = move_value [lexical] [var_decl] %r3 : $NonSendableKlass
+  %w = move_value [lexical] [var_decl] %r3 : $NonSendableKlass // expected-note {{'w' is connected to result of 'mergeOne()'}}
   debug_value %w : $NonSendableKlass, let, name "w"
 
   // send w
@@ -235,14 +238,15 @@ bb0(%x : @guaranteed $NonSendableKlass, %cond : $Builtin.Int1):
 
   %mk = function_ref @makeFresh : $@convention(thin) () -> @owned NonSendableKlass
   %r0 = apply %mk() : $@convention(thin) () -> @owned NonSendableKlass
-  %y = move_value [lexical] [var_decl] %r0 : $NonSendableKlass
+  // expected-note@+1 {{result of 'makeFresh()' is connected to 'x' which is accessible to code in the current isolation context}}
+  %y = move_value [lexical] [var_decl] %r0 : $NonSendableKlass // expected-note {{'y' is connected to result of 'makeFresh()'}}
   debug_value %y : $NonSendableKlass, let, name "y"
   cond_br %cond, bb_merge, bb_no_merge
 
 bb_merge:
   %yb = begin_borrow %y : $NonSendableKlass
   %f2 = function_ref @mergeTwo : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> @owned NonSendableKlass
-  %rm = apply %f2(%x, %yb) : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> @owned NonSendableKlass // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+  %rm = apply %f2(%x, %yb) : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> @owned NonSendableKlass
   end_borrow %yb : $NonSendableKlass
   destroy_value %rm : $NonSendableKlass
   br bb_join
@@ -270,7 +274,7 @@ bb0(%x : @guaranteed $NonSendableKlass):
   debug_value %x : $NonSendableKlass, let, name "x", argno 1
   %xc = copy_value %x : $NonSendableKlass
   %y_addr = alloc_stack [lexical] [var_decl] $NonSendableKlass, var, name "y"
-  store %xc to [init] %y_addr : $*NonSendableKlass // expected-note {{value was merged into code in the current isolation context region here}}
+  store %xc to [init] %y_addr : $*NonSendableKlass // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
 
   %f = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   // expected-note@+1 {{sending value of non-Sendable type 'NonSendableKlass' to global actor '<null>'-isolated callee risks causing races in between code in the current isolation context and global actor '<null>'-isolated uses}}
@@ -372,9 +376,10 @@ bb0(%x : @guaranteed $NonSendableKlass):
   // y.slot = x merges y's region with x's. Need a borrow for ref_element_addr.
   %xc = copy_value %x : $NonSendableKlass
   %yb = begin_borrow %y : $ContainerKlass
-  %slot_addr = ref_element_addr %yb : $ContainerKlass, #ContainerKlass.slot // expected-note {{'y.slot' is connected to 'y'}}
+  // expected-note@+1{{'y' is connected to 'y.slot'}}
+  %slot_addr = ref_element_addr %yb : $ContainerKlass, #ContainerKlass.slot
   %access = begin_access [modify] [dynamic] %slot_addr : $*NonSendableKlass
-  store %xc to [assign] %access : $*NonSendableKlass // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+  store %xc to [assign] %access : $*NonSendableKlass // expected-note {{'y.slot' is connected to 'x' which is accessible to code in the current isolation context}}
   end_access %access : $*NonSendableKlass
   end_borrow %yb : $ContainerKlass
 
@@ -404,7 +409,7 @@ bb0(%x : @guaranteed $NonSendableKlass):
 
   %access = begin_access [modify] [static] %y_addr : $*NonSendableKlass
   %takeInout = function_ref @takeInout : $@convention(thin) (@inout NonSendableKlass, @guaranteed NonSendableKlass) -> ()
-  apply %takeInout(%access, %x) : $@convention(thin) (@inout NonSendableKlass, @guaranteed NonSendableKlass) -> () // expected-note {{'makeFresh' is connected to 'x' which is accessible to code in the current isolation context}}
+  apply %takeInout(%access, %x) : $@convention(thin) (@inout NonSendableKlass, @guaranteed NonSendableKlass) -> () // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
   end_access %access : $*NonSendableKlass
 
   %f = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()

--- a/test/Concurrency/transfernonsendable_isolationhistory.swift
+++ b/test/Concurrency/transfernonsendable_isolationhistory.swift
@@ -47,7 +47,8 @@ func single_step_tuple(_ x: NS) async {
 }
 
 func single_step_struct(_ x: NS) async {
-  let y = Box1(x) // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+  // expected-note@+1 {{'y' is connected to result of 'Box1.init(_:)'}}
+  let y = Box1(x) // expected-note {{result of 'Box1.init(_:)' is connected to 'x' which is accessible to code in the current isolation context}}
   await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
   // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
@@ -68,16 +69,21 @@ func suppress_direct(_ x: NS) async {
 ////////////////////////////////////////////////////////////////////////////////
 
 func chain_two_step(_ x: NS) async {
-  let y = Box1(x) // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
-  let z = Box2(y) // expected-note {{'z' is connected to 'y'}}
+  // expected-note@+1 {{result of 'Box1.init(_:)' is connected to 'x' which is accessible to code in the current isolation context}}
+  let y = Box1(x) // expected-note {{'y' is connected to result of 'Box1.init(_:)'}}
+  // expected-note@+1 {{'y' is connected to result of 'Box2.init(_:)'}}
+  let z = Box2(y) // expected-note {{'z' is connected to result of 'Box2.init(_:)'}}
   await transferToMain(z) // expected-warning {{sending 'z' risks causing data races}}
   // expected-note @-1 {{sending 'z' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
 
 func chain_three_step(_ x: NS) async {
-  let y = Box1(x) // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
-  let z = Box2(y) // expected-note {{'z' is connected to 'y'}}
-  let w = Box3(z) // expected-note {{'w' is connected to 'z'}}
+  // expected-note@+1 {{result of 'Box1.init(_:)' is connected to 'x' which is accessible to code in the current isolation context}}
+  let y = Box1(x) // expected-note {{'y' is connected to result of 'Box1.init(_:)'}}
+  // expected-note@+1 {{'y' is connected to result of 'Box2.init(_:)'}}
+  let z = Box2(y) // expected-note {{'z' is connected to result of 'Box2.init(_:)'}}
+  // expected-note@+1 {{'z' is connected to result of 'Box3.init(_:)'}}
+  let w = Box3(z) // expected-note {{'w' is connected to result of 'Box3.init(_:)'}}
   await transferToMain(w) // expected-warning {{sending 'w' risks causing data races}}
   // expected-note @-1 {{sending 'w' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
@@ -104,7 +110,8 @@ func combine(_ a: NS, _ b: NS) -> NS { a }
 func multi_isolated_params(_ x: NS, _ a: NS) async {
   // y is in the same region as both x and a. The originating note picks one
   // task-isolated parameter (whichever the chain walk reaches first).
-  let y = combine(x, a) // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+  // expected-note@+1 {{'y' is connected to result of 'combine()'}}
+  let y = combine(x, a) // expected-note {{result of 'combine()' is connected to 'x' which is accessible to code in the current isolation context}}
   await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
   // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
@@ -135,8 +142,9 @@ func cast_conditional(_ x: NS) async {
 ////////////////////////////////////////////////////////////////////////////////
 
 func global_actor_chain() async {
-  let y = await Box1(getCustomNS()) // expected-note {{'y' is connected to 'getCustomNS' which is accessible to global actor 'CustomActor'-isolated code}}
-  // expected-warning @-1 {{non-Sendable 'NS'-typed result can not be returned from global actor 'CustomActor'-isolated global function 'getCustomNS()' to nonisolated context}}
+  let y = await Box1(getCustomNS()) // expected-note {{result of 'Box1.init(_:)' is connected to 'getCustomNS' which is accessible to global actor 'CustomActor'-isolated code}}
+  // expected-note@-1 {{'y' is connected to result of 'Box1.init(_:)'}}
+  // expected-warning @-2 {{non-Sendable 'NS'-typed result can not be returned from global actor 'CustomActor'-isolated global function 'getCustomNS()' to nonisolated context}}
   await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
   // expected-note @-1 {{sending global actor 'CustomActor'-isolated 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
 }
@@ -152,8 +160,8 @@ final class NSContainer {
 
 func class_field_chain(_ x: NS) async {
   let bag = NSContainer()
-  bag.slot = x // expected-note {{'bag' is connected to 'x' which is accessible to code in the current isolation context}}
-  // expected-note @-1 {{'bag.slot' is connected to 'bag'}}
+  // expected-note@+1 {{'bag.slot' is connected to 'x'}}
+  bag.slot = x // expected-note {{'bag' is connected to 'bag.slot'}}
   await transferToMain(bag) // expected-warning {{sending 'bag' risks causing data races}}
   // expected-note @-1 {{sending 'bag' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
@@ -304,7 +312,7 @@ actor MyActor {
   var slot: NS = NS()
 
   func makeChainAndSend() async {
-    let y = self.slot // expected-note {{value was merged into 'self'-isolated code region here}}
+    let y = self.slot
     await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
     // expected-note @-1 {{sending 'self'-isolated 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
   }
@@ -318,8 +326,9 @@ actor MyActor {
 @CustomActor func transferToCustom<T>(_ t: T) async {}
 
 @MainActor func main_actor_chain() async {
-  let m = getMainNS() // expected-note {{'y' is connected to 'm' which is accessible to main actor-isolated code}}
-  let y = Box1(m)
+  let m = getMainNS() // expected-note {{'m' is connected to result of 'getMainNS()' which is accessible to main actor-isolated code}}
+  // expected-note@+1 {{'m' is connected to result of 'Box1.init(_:)'}}
+  let y = Box1(m) // expected-note {{'y' is connected to result of 'Box1.init(_:)'}}
   await transferToCustom(y) // expected-warning {{sending 'y' risks causing data races}}
   // expected-note @-1 {{sending main actor-isolated 'y' to global actor 'CustomActor'-isolated global function 'transferToCustom' risks causing data races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
 }
@@ -330,14 +339,17 @@ actor MyActor {
 // conventions on the parameter.
 ////////////////////////////////////////////////////////////////////////////////
 
-func consuming_param(_ x: consuming NS) async { // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+func consuming_param(_ x: consuming NS) async {
+  // expected-note@+2{{'x' is connected to result of 'Box1.init(_:)'}}
+  // expected-note@+1{{'y' is connected to result of 'Box1.init(_:)'}}
   let y = Box1(x)
   await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
   // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
 
 func borrowing_param(_ x: borrowing NS) async {
-  let y = Box1(copy x) // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+  // expected-note@+1 {{'y' is connected to result of 'Box1.init(_:)'}}
+  let y = Box1(copy x) // expected-note {{result of 'Box1.init(_:)' is connected to 'x' which is accessible to code in the current isolation context}}
   await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
   // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
@@ -372,7 +384,7 @@ indirect enum IndirectChain {
 }
 
 func indirect_enum_chain(_ x: NS) async {
-  let y = IndirectChain.leaf(x) // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+  let y = IndirectChain.leaf(x) // expected-note {{value was merged into code in the current isolation context region here}}
   await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
   // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
@@ -393,7 +405,7 @@ struct AddrOnlyBox<T> {
 }
 
 func addr_only_chain<T>(_ x: T) async {
-  let y = AddrOnlyBox(x) // expected-note {{value was merged into code in the current isolation context region here}}
+  let y = AddrOnlyBox(x) // expected-note {{'y' is connected to 'x'}}
   await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
   // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
@@ -408,7 +420,8 @@ func addr_only_chain<T>(_ x: T) async {
 ////////////////////////////////////////////////////////////////////////////////
 
 func unknown_legit_name(_ x: NS) async {
-  let unknown = x // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+  let unknown = x // expected-note {{value was merged into code in the current isolation context region here}}
+  // expected-note@+1{{'y' is connected to result of 'Box1.init(_:)'}}
   let y = Box1(unknown)
   await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
   // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
@@ -507,7 +520,7 @@ struct Wrap {
 }
 
 func wrap_chain(_ x: NS) async {
-  @Wrap var y: NS = x // expected-note {{'_y' is connected to 'x' which is accessible to code in the current isolation context}}
+  @Wrap var y: NS = x // expected-note {{value was merged into code in the current isolation context region here}}
   await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
   // expected-note @-1 {{'y' is connected to '_y'}}
   // expected-note @-2 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
@@ -529,9 +542,8 @@ func wrap_chain(_ x: NS) async {
 func makeOrThrow(_ x: NS) throws -> NS { x }
 
 func try_optional_chain(_ x: NS) async throws {
-  let y = try? makeOrThrow(x) // expected-note {{'y' is connected to 'z'}}
+  let y = try? makeOrThrow(x)
   if let z = y { // expected-note {{'z' is connected to 'x' which is accessible to code in the current isolation context}}
-    // expected-note @-1 {{'z' is connected to 'y'}}
     await transferToMain(z) // expected-warning {{sending 'z' risks causing data races}}
     // expected-note @-1 {{sending 'z' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
   }
@@ -629,6 +641,7 @@ func task_capture_chain(_ x: NS) async {
   // closure-capture-into-Task path bypasses the chain walker because
   // the merge happens at a closure argument rather than a
   // `transferToMain`-style apply.
+  // expected-note@+1{{'y' is connected to 'x' which is accessible to code in the current isolation context}}
   let y = x
   Task { @MainActor in _ = y } // expected-warning {{sending 'y' risks causing data races}}
   // expected-note @-1 {{'y' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
@@ -654,7 +667,7 @@ func inout_subscript_chain(_ x: NS) async {
   // 'b.contents' step is dropped — same root cause as
   // computed_prop_chain: the inout-setter form of mutation isn't
   // credited as a chain step.
-  b.contents.append(x) // expected-note {{'b' is connected to 'x' which is accessible to code in the current isolation context}}
+  b.contents.append(x) // expected-note {{'b' is connected to 'x'}}
   await transferToMain(b) // expected-warning {{sending 'b' risks causing data races}}
   // expected-note @-1 {{sending 'b' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 
@@ -706,8 +719,9 @@ func wrap(_ a: NS) -> NS { a }
 func freefunc_call_leak(_ x: NS) async {
   // FIXME: 'makeShared' is the callee, not a value. The chain walker
   // surfaces it as if it were an intermediate local.
-  let y = wrap(makeShared(x)) // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
-  // expected-note @-1 {{'makeShared' is connected to 'y'}}
+  let y = wrap(makeShared(x)) // expected-note {{'makeShared' is connected to 'x' which is accessible to code in the current isolation context}}
+  // expected-note@-1 {{'y' is connected to result of 'wrap()'}}
+  // expected-note @-2 {{'makeShared' is connected to result of 'wrap()'}}
   await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
   // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 
@@ -730,8 +744,8 @@ func freefunc_call_leak(_ x: NS) async {
 func dict_literal_chain(_ x: NS) async {
   // FIXME: '_allocateUninitializedArray' is a stdlib intrinsic, not a
   // user-visible identifier. It should never appear in a chain note.
-  var d: [String: NS] = [:] // expected-note {{'_allocateUninitializedArray' is connected to 'd'}}
-  d["k"] = x // expected-note {{'d' is connected to 'x' which is accessible to code in the current isolation context}}
+  var d: [String: NS] = [:]
+  d["k"] = x // expected-note {{'d' is connected to 'x'}}
   await transferToMain(d) // expected-warning {{sending 'd' risks causing data races}}
   // expected-note @-1 {{sending 'd' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 
@@ -752,9 +766,8 @@ func dict_literal_chain(_ x: NS) async {
 func iflet_reversed_chain(_ x: NS) async {
   // FIXME: this line is annotated with `'y' is reachable from 'z'`, but
   // z is declared on the NEXT line and the data flow is z ← y, not y ← z.
-  let y: NS? = x // expected-note {{'y' is connected to 'z'}}
+  let y: NS? = x
   if let z = y { // expected-note {{'z' is connected to 'x' which is accessible to code in the current isolation context}}
-    // expected-note @-1 {{'z' is connected to 'y'}}
     await transferToMain(z) // expected-warning {{sending 'z' risks causing data races}}
     // expected-note @-1 {{sending 'z' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
   }
@@ -775,9 +788,8 @@ func iflet_reversed_chain(_ x: NS) async {
 func result_case_let_reversed_chain(_ x: NS) async {
   // FIXME: `'r' is reachable from 'y'` is reversed — r is built from x
   // and exists before y is destructured out.
-  let r: Result<NS, Error> = .success(x) // expected-note {{'r' is connected to 'y'}}
+  let r: Result<NS, Error> = .success(x)
   if case let .success(y) = r { // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
-    // expected-note @-1 {{'y' is connected to 'r'}}
     await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
     // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
   }
@@ -802,8 +814,9 @@ func keypath_chain(_ x: NS) async {
   // FIXME: kp is a literal `\Bag.field` keypath; it has no value-flow
   // relationship to bag.
   bag.field = x // expected-note {{'bag' is connected to 'x' which is accessible to code in the current isolation context}}
-  let kp = \KPBag.field // expected-note {{'kp' is connected to 'bag'}}
-  let y = bag[keyPath: kp] // expected-note {{'swift_readAtKeyPath' is connected to 'kp'}}
+  let kp = \KPBag.field
+  // expected-note@+1 {{'y' is connected to 'swift_readAtKeyPath'}}
+  let y = bag[keyPath: kp] // expected-note {{'swift_readAtKeyPath' is connected to 'bag'}}
   await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
   // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 
@@ -829,6 +842,7 @@ func taskgroup_chain_dropped(_ x: NS) async {
   // from 'y') don't fire for the addTask closure-send warning; same shape
   // via Task.detached does emit them.
   await withTaskGroup(of: Void.self) { group in
+    // expected-note@+1 {{value was merged into code in the current isolation context region here}}
     group.addTask { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
       let w = z // expected-note {{closure captures 'z' which is accessible to code in the current isolation context}}
       // expected-note @-1 {{'w' is connected to 'z' which is accessible to code in the current isolation context}}
@@ -858,8 +872,7 @@ func continuation_chain(_ x: NS) async {
   // transferToMain). Chain step uses anonymous "value" wording.
   let y: NS = await withCheckedContinuation { cont in
     cont.resume(returning: mid) // expected-warning {{sending 'mid' risks causing data races}}
-    // expected-note @-1 {{value was merged into code in the current isolation context region here}}
-    // expected-note @-2 {{'mid' is passed as a 'sending' parameter; Uses in callee may race with code in the current isolation context}}
+    // expected-note @-1 {{'mid' is passed as a 'sending' parameter; Uses in callee may race with code in the current isolation context}}
   }
   let z = y
   await transferToMain(z)
@@ -888,8 +901,9 @@ func continuation_chain(_ x: NS) async {
 // per-arg loc array is not silently shifted by the indirect-result / error
 // prefix when the apply has neither.
 func per_arg_loc(_ x: NS) async {
+  // expected-note@+1{{'y' is connected to result of 'combine()'}}
   let y = combine(
-    x, // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+    x, // expected-note {{result of 'combine()' is connected to 'x' which is accessible to code in the current isolation context}}
     NS())
   await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
   // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
@@ -900,9 +914,10 @@ func per_arg_loc(_ x: NS) async {
 // slot. A bug that always wrote the first slot would anchor the note at
 // the `NS()` line above instead of the `x,` line below.
 func per_arg_loc_second(_ x: NS) async {
+  // expected-note@+1{{'y' is connected to result of 'combine()'}}
   let y = combine(
     NS(),
-    x) // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+    x) // expected-note {{value was merged into code in the current isolation context region here}}
   await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
   // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
@@ -915,8 +930,9 @@ func per_arg_loc_second(_ x: NS) async {
 func combineThrows(_ a: NS, _ b: NS) throws -> NS { a }
 
 func per_arg_loc_throws(_ x: NS) async throws {
+  // expected-note@+1{{'y' is connected to result of 'combineThrows()'}}
   let y = try combineThrows(
-    x, // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+    x, // expected-note {{result of 'combineThrows()' is connected to 'x' which is accessible to code in the current isolation context}}
     NS())
   await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
   // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
@@ -943,9 +959,9 @@ func per_arg_loc_coroutine(_ x: NS) async {
   // direction-reversed and 'bag'/'bag.slot' name the same region. Should
   // collapse to one chain step "y is connected to x" (revisit alongside
   // walker dedup / direction fix).
-  let y = combine( // expected-note {{'y' is connected to 'bag'}}
-    bag.slot, // expected-note {{'bag.slot' is connected to 'y'}}
-    x, // expected-note {{'bag' is connected to 'x' which is accessible to code in the current isolation context}}
+  let y = combine( // expected-note {{'y' is connected to result of 'combine()'}}
+    bag.slot, // expected-note {{'bag.slot' is connected to result of 'combine()'}}
+    x, // expected-note {{'bag.slot' is connected to 'x' which is accessible to code in the current isolation context}}
   )
   await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
   // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
@@ -1074,7 +1090,6 @@ func do_catch_chain(_ x: NS) async throws {
   var y = NS()
   do {
     y = try makeOrThrow(x) // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
-// expected-note @-1 {{'makeOrThrow' is connected to 'y'}}
   } catch {
     y = NS()
   }
@@ -1106,7 +1121,8 @@ func send_projection_of_isolated(_ x: NS) async {
   var box = Box1(NS())
   box.ns = x // expected-note {{'box' is connected to 'x' which is accessible to code in the current isolation context}}
   await transferToMain(box.ns) // expected-warning {{sending 'box.ns' risks causing data races}}
-// expected-note @-1 {{sending 'box.ns' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+  // expected-note@-1 {{'box.ns' is connected to 'box'}}
+// expected-note @-2 {{sending 'box.ns' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
 
 // FIXME: The write is 'box.b.b.ns = x', but the note collapses the whole access
@@ -1124,7 +1140,7 @@ func deep_projection_store(_ x: NS) async {
 actor SlotActor {
   var slot = NS()
   func probe() async {
-    let y = slot // expected-note {{value was merged into 'self'-isolated code region here}}
+    let y = slot
     await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
 // expected-note @-1 {{sending 'self'-isolated 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
   }
@@ -1134,8 +1150,1882 @@ actor SlotActor {
 // '_allocateUninitializedArray' as a chain step. An internal runtime name
 // should never appear in a user-facing note.
 func array_append_leak(_ x: NS) async {
-  var arr = [NS()] // expected-note {{'_allocateUninitializedArray' is connected to 'arr'}}
-  arr.append(x) // expected-note {{'arr' is connected to 'x' which is accessible to code in the current isolation context}}
+  var arr = [NS()]
+  arr.append(x) // expected-note {{'arr' is connected to 'x'}}
   await transferToMain(arr) // expected-warning {{sending 'arr' risks causing data races}}
   // expected-note @-1 {{sending 'arr' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// SEND/ISOLATION COMBINATION MATRIX.
+//
+// The sections above vary control flow. This one holds it fixed and varies the
+// two things that actually drive the note: *which* member of a region is sent,
+// and *how/when* the isolated value entered that region. Cases are grouped by
+// scenario rather than by correct-vs-wrong, so a group can mix both; each
+// individually-wrong case carries its own FIXME.
+//
+// Vocabulary used below: `b` is the task-isolated value, `a` is the value we
+// send, `c` is a carrier that `b` was merged into.
+////////////////////////////////////////////////////////////////////////////////
+
+struct KlassPair {
+  var first: NS
+  var second: NS
+  init(_ f: NS, _ s: NS) { first = f; second = s }
+}
+
+// Merges the regions of both arguments without producing a value: the merge is
+// a side effect of the argument list, and there is no destination to name.
+func mergeFn(_ a: NS, _ b: NS) {}
+
+////////////////////////////////////////////////////////////////////////////////
+// Merge via discarded apply arguments. Every other test in this file merges via
+// an assignment or an assigned apply result; here there is no dest value at all,
+// so the only nameable thing is the argument operand.
+////////////////////////////////////////////////////////////////////////////////
+
+func argmerge_two(_ x: NS) async {
+  let y = NS()
+  mergeFn(x, y) // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
+  // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func argmerge_transitive(_ x: NS) async {
+  let y = NS()
+  let z = NS()
+  mergeFn(x, y) // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+  // expected-note@+1{{'z' is connected to 'y'}}
+  mergeFn(z, y)
+  await transferToMain(z) // expected-warning {{sending 'z' risks causing data races}}
+  // expected-note @-1 {{sending 'z' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Argument order. `PartitionOp::Merge` records dest=representative and
+// src=operand, so which argument is the isolated one decides which value gets
+// stamped on the history node. The note should not depend on that ordering.
+////////////////////////////////////////////////////////////////////////////////
+
+func argmerge_isolated_first(_ x: NS) async {
+  let y = NS()
+  mergeFn(x, y) // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
+  // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func argmerge_isolated_second(_ x: NS) async {
+  let y = NS()
+  mergeFn(y, x) // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
+  // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Two distinct projections of one base. `k.first` and `k.second` are different
+// *values* that collapse to the same *element*, so a chain through them has two
+// steps that share one element -- the sharpest value-vs-element case.
+////////////////////////////////////////////////////////////////////////////////
+
+// FIXME: The isolated value enters through 'k.first' and leaves through
+// 'k.second', but neither field is named and the chain is inverted: 'y' is
+// reported as connected directly to 'x' (they never merged) and the 'k' step
+// anchors on the `var k` declaration rather than either store. Ideal:
+//   k.first = x    note: 'k.first' is connected to 'x' which is accessible to ...
+//   k.second = y   note: 'y' is connected to 'k.second'
+func two_projections_one_base(_ x: NS) async {
+  let y = NS()
+  var k = KlassPair(NS(), NS())
+  k.first = x // expected-note {{'k' is connected to 'x' which is accessible to code in the current isolation context}}
+  // expected-note@+1{{'y' is connected to 'k'}}
+  k.second = y
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
+  // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+// The chain enters `k` through `.second` and exits through `.first`.
+// FIXME: As above, neither projection is named and the 'k' step anchors on the
+// declaration instead of the store that actually connected it.
+func projection_enter_exit(_ x: NS) async {
+  let y = NS()
+  let z = NS()
+  var k = KlassPair(NS(), NS())
+  // expected-note@+1{{'k' is connected to 'y'}}
+  k.second = y
+  mergeFn(x, y) // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+  // expected-note@+1{{'z' is connected to 'k'}}
+  mergeFn(z, k.first)
+  await transferToMain(z) // expected-warning {{sending 'z' risks causing data races}}
+  // expected-note @-1 {{sending 'z' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Fixed setup, vary only which region member is sent. The region is
+// {x isolated, k, y} in all four; only the argument to transferToMain changes.
+//
+// FIXME: The first three emit byte-identical chain notes even though a
+// different value is sent each time. The chain should be anchored on the value
+// actually being sent.
+////////////////////////////////////////////////////////////////////////////////
+
+func send_container(_ x: NS) async {
+  let y = NS()
+  var k = KlassPair(NS(), NS())
+  k.first = x // expected-note {{'k' is connected to 'x' which is accessible to code in the current isolation context}}
+  k.second = y
+  await transferToMain(k) // expected-warning {{sending 'k' risks causing data races}}
+  // expected-note @-1 {{sending 'k' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func send_sibling_local(_ x: NS) async {
+  let y = NS()
+  var k = KlassPair(NS(), NS())
+  k.first = x // expected-note {{'k' is connected to 'x' which is accessible to code in the current isolation context}}
+  // expected-note@+1{{'y' is connected to 'k'}}
+  k.second = y
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
+  // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func send_projection_member(_ x: NS) async {
+  let y = NS()
+  var k = KlassPair(NS(), NS())
+  k.first = x // expected-note {{'k' is connected to 'x' which is accessible to code in the current isolation context}}
+  k.second = y
+  await transferToMain(k.second) // expected-warning {{sending 'k.second' risks causing data races}}
+  // expected-note@-1 {{'k.second' is connected to 'k'}}
+  // expected-note @-2 {{sending 'k.second' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+// Sending the isolated value itself out of a *populated* region. Correctly
+// suppressed: 'x' is not disconnected, so there is no chain to explain.
+// (`suppress_direct` above covers the same rule with a singleton region.)
+func send_isolated_from_populated_region(_ x: NS) async {
+  let y = NS()
+  var k = KlassPair(NS(), NS())
+  k.first = x
+  k.second = y
+  await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Bystander send: the sent value `a` was never party to the merge that brought
+// the isolated `b` into the region. `b` was merged into a carrier `c`; `a`
+// joined `c` by a separate merge. Crossed with the order of those two merges,
+// which reaches the same final partition by different histories:
+//   - isolation_after:  a joined c while the region was still disconnected
+//   - isolation_before: a joined a region that was already isolated
+//
+// FIXME (whole group): two defects, visible in every case below.
+//  1. The originating note claims "'a' is connected to 'b'" -- a connection
+//     that never existed in the history. 'a' and 'b' were never merged; the
+//     note should route through the carrier ('a' -> 'c' -> 'b').
+//  2. Merge order is not distinguished at all: the ..._after and ..._before
+//     variants produce byte-identical notes, as do all three threehop
+//     variants. The walk is reporting a closure over "elements ever connected"
+//     rather than the merge that actually introduced the isolation, so the
+//     originating location is order-independent when it should not be.
+////////////////////////////////////////////////////////////////////////////////
+
+func bystander_argmerge_isolation_after(_ b: NS) async {
+  let a = NS()
+  let c = NS()
+  // expected-note@+1{{'a' is connected to 'c'}}
+  mergeFn(a, c)
+  mergeFn(c, b) // expected-note {{'c' is connected to 'b' which is accessible to code in the current isolation context}}
+  await transferToMain(a) // expected-warning {{sending 'a' risks causing data races}}
+  // expected-note @-1 {{sending 'a' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func bystander_argmerge_isolation_before(_ b: NS) async {
+  let a = NS()
+  let c = NS()
+  mergeFn(c, b) // expected-note {{'c' is connected to 'b' which is accessible to code in the current isolation context}}
+  // expected-note@+1{{'a' is connected to 'c'}}
+  mergeFn(a, c)
+  await transferToMain(a) // expected-warning {{sending 'a' risks causing data races}}
+  // expected-note @-1 {{sending 'a' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func bystander_projection_isolation_after(_ b: NS) async {
+  let a = NS()
+  var c = KlassPair(NS(), NS())
+  // expected-note@+1{{'a' is connected to 'c'}}
+  c.first = a
+  c.second = b // expected-note {{'c' is connected to 'b' which is accessible to code in the current isolation context}}
+  await transferToMain(a) // expected-warning {{sending 'a' risks causing data races}}
+  // expected-note @-1 {{sending 'a' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func bystander_projection_isolation_before(_ b: NS) async {
+  let a = NS()
+  var c = KlassPair(NS(), NS())
+  c.second = b // expected-note {{'c' is connected to 'b' which is accessible to code in the current isolation context}}
+  // expected-note@+1{{'a' is connected to 'c'}}
+  c.first = a
+  await transferToMain(a) // expected-warning {{sending 'a' risks causing data races}}
+  // expected-note @-1 {{sending 'a' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+// Three hops: a -- c -- d, with b merged into d. The isolated value is now two
+// hops away from the sent value. Vary where in the sequence isolation attaches.
+func bystander_threehop_isolation_last(_ b: NS) async {
+  let a = NS()
+  let c = NS()
+  let d = NS()
+  // expected-note@+1{{'a' is connected to 'c'}}
+  mergeFn(a, c)
+  // expected-note@+1{{'c' is connected to 'd'}}
+  mergeFn(c, d)
+  mergeFn(d, b) // expected-note {{'d' is connected to 'b' which is accessible to code in the current isolation context}}
+  await transferToMain(a) // expected-warning {{sending 'a' risks causing data races}}
+  // expected-note @-1 {{sending 'a' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func bystander_threehop_isolation_first(_ b: NS) async {
+  let a = NS()
+  let c = NS()
+  let d = NS()
+  mergeFn(d, b) // expected-note {{'d' is connected to 'b' which is accessible to code in the current isolation context}}
+  // expected-note@+1{{'c' is connected to 'd'}}
+  mergeFn(c, d)
+  // expected-note@+1{{'a' is connected to 'c'}}
+  mergeFn(a, c)
+  await transferToMain(a) // expected-warning {{sending 'a' risks causing data races}}
+  // expected-note @-1 {{sending 'a' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func bystander_threehop_isolation_middle(_ b: NS) async {
+  let a = NS()
+  let c = NS()
+  let d = NS()
+  // expected-note@+1{{'c' is connected to 'd'}}
+  mergeFn(c, d)
+  mergeFn(d, b) // expected-note {{'d' is connected to 'b' which is accessible to code in the current isolation context}}
+  // expected-note@+1{{'a' is connected to 'c'}}
+  mergeFn(a, c)
+  await transferToMain(a) // expected-warning {{sending 'a' risks causing data races}}
+  // expected-note @-1 {{sending 'a' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// OVERWRITE / SEVERED CHAINS.
+//
+// Negative tests: the history still *contains* a merge with the isolated value,
+// but the connection was later severed, so nothing should be reported. These
+// are the cases that catch a chain walk which closes over "elements ever
+// connected" instead of consulting region membership at each step -- there is
+// no diagnostic to match, so -verify fails if any note appears.
+////////////////////////////////////////////////////////////////////////////////
+
+func overwrite_severs(_ b: NS) async {
+  var c = NS()
+  mergeFn(c, b)
+  c = NS()
+  let a = NS()
+  mergeFn(a, c)
+  await transferToMain(a)
+}
+
+func carrier_reassigned_between(_ b: NS) async {
+  let a = NS()
+  var c = NS()
+  mergeFn(a, c)
+  c = NS()
+  mergeFn(c, b)
+  await transferToMain(a)
+}
+
+// Contrast with the two above: overwriting a *field* does not sever, because the
+// field collapses to its base's element, so the isolated value stays in the
+// region. This pairing pins whole-variable-overwrite vs field-overwrite.
+func field_overwritten_twice(_ x: NS) async {
+  let y = NS()
+  var k = KlassPair(NS(), NS())
+  k.first = x // expected-note {{'k' is connected to 'x' which is accessible to code in the current isolation context}}
+  // expected-note@+1{{'y' is connected to 'k'}}
+  k.first = y
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
+  // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// FURTHER CROSSINGS — bystander x CFG join, inout operand, unnameable source.
+////////////////////////////////////////////////////////////////////////////////
+
+func mergeInout(_ a: inout NS, _ b: NS) {}
+
+func bystander_diamond(_ b: NS, _ flag: Bool) async {
+  let a = NS()
+  let c = NS()
+  mergeFn(a, c)
+  if flag {
+    mergeFn(c, b) // expected-note {{'a' is connected to 'b' which is accessible to code in the current isolation context}}
+  }
+  await transferToMain(a) // expected-warning {{sending 'a' risks causing data races}}
+  // expected-note @-1 {{sending 'a' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func inout_merge(_ b: NS) async {
+  var a = NS()
+  mergeInout(&a, b) // expected-note {{'a' is connected to 'b' which is accessible to code in the current isolation context}}
+  await transferToMain(a) // expected-warning {{sending 'a' risks causing data races}}
+  // expected-note @-1 {{sending 'a' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+actor BystanderProbe {
+  var slot = NS()
+  func run() async {
+    let a = NS()
+    let c = NS()
+    // expected-note@+1{{'a' is connected to 'c'}}
+    mergeFn(a, c)
+    // expected-note@+1{{'c' is connected to 'self.slot' which is accessible to 'self'-isolated code}}
+    mergeFn(c, slot)
+    await transferToMain(a) // expected-warning {{sending 'a' risks causing data races}}
+    // expected-note @-1 {{sending 'self'-isolated 'a' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// MERGE VIA CLOSURE CAPTURE.
+//
+// A closure that captures two non-Sendable values merges their regions, so the
+// closure itself acts as a carrier -- the captured values are never merged with
+// each other directly. Distinct from the Task/addTask cases above, where the
+// closure is *sent*; here the closure is merely formed and called locally.
+//
+// FIXME (whole group): three defects visible below.
+//  1. The closure local ('f', 'g') is surfaced as a chain step, but the user
+//     never wrote a connection between the closure and its captures -- the
+//     closure is the implementation of the capture, not a link the reader can
+//     act on. Worst case is 'f' is connected to 'g', a claim about two closures
+//     that means nothing at the source level.
+//  2. As in the other bystander groups, the originating note asserts
+//     "'a' is connected to 'b'" though 'a' and 'b' only ever met through the
+//     closure's capture list.
+//  3. Notes pile onto the closure-literal line rather than distributing across
+//     the captures that caused each merge.
+////////////////////////////////////////////////////////////////////////////////
+
+func useClosure(_ f: () -> ()) {}
+
+func closure_captures_both(_ b: NS) async {
+  let a = NS()
+  let f = { mergeFn(a, b) } // expected-note {{'a' is connected to 'b' which is accessible to code in the current isolation context}}
+  useClosure(f)
+  await transferToMain(a) // expected-warning {{sending 'a' risks causing data races}}
+  // expected-note @-1 {{sending 'a' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func closure_carrier_bystander(_ b: NS) async {
+  let a = NS()
+  let c = NS()
+  // expected-note@+1{{'a' is connected to 'c'}}
+  let f = { mergeFn(a, c) }
+  let g = { mergeFn(c, b) } // expected-note {{'c' is connected to 'b' which is accessible to code in the current isolation context}}
+  useClosure(f)
+  useClosure(g)
+  await transferToMain(a) // expected-warning {{sending 'a' risks causing data races}}
+  // expected-note @-1 {{sending 'a' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func closure_carrier_bystander_reversed(_ b: NS) async {
+  let a = NS()
+  let c = NS()
+  let g = { mergeFn(c, b) } // expected-note {{'c' is connected to 'b' which is accessible to code in the current isolation context}}
+  // expected-note@+1{{'a' is connected to 'c'}}
+  let f = { mergeFn(a, c) }
+  useClosure(g)
+  useClosure(f)
+  await transferToMain(a) // expected-warning {{sending 'a' risks causing data races}}
+  // expected-note @-1 {{sending 'a' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func closure_call_merge(_ b: NS) async {
+  let a = NS()
+  let f = { (n: NS) in mergeFn(n, b) }
+  f(a)
+  await transferToMain(a)
+}
+
+func send_closure_capturing_isolated(_ b: NS) async {
+  let f = { mergeFn(b, b) } // expected-note {{'f' is connected to 'b' which is accessible to code in the current isolation context}}
+  await transferToMain(f) // expected-warning {{sending 'f' risks causing data races}}
+  // expected-note @-1 {{sending 'f' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func closure_captures_var_byref(_ b: NS) async {
+  var a = NS()
+  let f = { a = b } // expected-note {{'a' is connected to 'b' which is accessible to code in the current isolation context}}
+  useClosure(f)
+  await transferToMain(a) // expected-warning {{sending 'a' risks causing data races}}
+  // expected-note @-1 {{sending 'a' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func closure_escaping_stored(_ b: NS) async {
+  let a = NS()
+  var stored: (() -> ())? = nil
+  stored = { mergeFn(a, b) } // expected-note {{'a' is connected to 'b' which is accessible to code in the current isolation context}}
+  _ = stored
+  await transferToMain(a) // expected-warning {{sending 'a' risks causing data races}}
+  // expected-note @-1 {{sending 'a' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func closure_nested(_ b: NS) async {
+  let a = NS()
+  let f = { { mergeFn(a, b) }() } // expected-note {{'a' is connected to 'b' which is accessible to code in the current isolation context}}
+  useClosure(f)
+  await transferToMain(a) // expected-warning {{sending 'a' risks causing data races}}
+  // expected-note @-1 {{sending 'a' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// WHAT MAKES THE CLOSURE ISOLATED.
+//
+// `closure_captures_both` above is the task-isolated-by-capture case: the
+// closure picks up isolation from a captured task-isolated value. These vary
+// that source -- an explicit global actor on the closure, and actor isolation
+// picked up by capturing actor state.
+//
+// NOTE: the explicitly-isolated closures below take a different diagnostic path
+// (the closure-capture error, not the sending error), and emit no chain notes at
+// all. They are here to pin that boundary.
+////////////////////////////////////////////////////////////////////////////////
+
+func useEscaping(_ f: @escaping () -> ()) {}
+
+func closure_global_actor_explicit() async {
+  let a = NS()
+  let f = { @MainActor in _ = a } // expected-warning {{sending 'a' risks causing data races}}
+  // expected-note @-1 {{'a' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+  useEscaping(f) // expected-warning {{converting function value of type '@MainActor () -> ()' to '() -> ()' loses global actor 'MainActor'}}
+  await transferToMain(a) // expected-note {{access can happen concurrently}}
+}
+
+func closure_custom_global_actor_explicit() async {
+  let a = NS()
+  let f = { @CustomActor in _ = a } // expected-warning {{sending 'a' risks causing data races}}
+  // expected-note @-1 {{'a' is captured by a global actor 'CustomActor'-isolated closure. global actor 'CustomActor'-isolated uses in closure may race against later nonisolated uses}}
+  useEscaping(f) // expected-warning {{converting function value of type '@CustomActor () -> ()' to '() -> ()' loses global actor 'CustomActor'}}
+  await transferToMain(a) // expected-note {{access can happen concurrently}}
+}
+
+actor StateHolder {
+  var slot = NS()
+
+  // Closure becomes actor-isolated by capturing actor-isolated state.
+  func viaCapturedState() async {
+    let a = NS()
+    let f = { mergeFn(a, self.slot) } // expected-warning {{sending 'a' risks causing data races}}
+    // expected-note @-1 {{'a' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later actor-isolated uses}}
+    useClosure(f)
+    await transferToMain(a) // expected-note {{access can happen concurrently}}
+  }
+
+  // Closure becomes actor-isolated by capturing self alongside the bystander.
+  func viaCapturedSelf() async {
+    let a = NS()
+    let f = { mergeFn(a, self.slot); _ = self } // expected-warning {{sending 'a' risks causing data races}}
+    // expected-note @-1 {{'a' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later actor-isolated uses}}
+    useClosure(f)
+    await transferToMain(a) // expected-note {{access can happen concurrently}}
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// SEND DESTINATION ISOLATION.
+//
+// The sections above vary where the isolation came *from*. This one varies where
+// the value is sent *to*, which selects the descriptive-kind string in both the
+// sending note and the originating chain note. Every other test in this file
+// sends to the same @MainActor global function.
+////////////////////////////////////////////////////////////////////////////////
+
+@CustomActor func toCustomFunc<T>(_ t: T) async {}
+
+struct MainMethodStruct { @MainActor func method<T>(_ t: T) async {} }
+final class MainMethodClass { @MainActor func method<T>(_ t: T) async {} }
+@MainActor struct IsolatedStruct { func method<T>(_ t: T) async {} }
+@MainActor final class IsolatedClass { func method<T>(_ t: T) async {} }
+actor Receiver { func take<T>(_ t: T) async {} }
+
+func dest_custom_global_actor_func(_ b: NS) async {
+  let a = NS()
+  mergeFn(a, b) // expected-note {{'a' is connected to 'b' which is accessible to code in the current isolation context}}
+  await toCustomFunc(a) // expected-warning {{sending 'a' risks causing data races}}
+  // expected-note @-1 {{sending 'a' to global actor 'CustomActor'-isolated global function 'toCustomFunc' risks causing data races between global actor 'CustomActor'-isolated code and code in the current isolation context}}
+}
+
+func dest_global_actor_method_on_struct(_ b: NS, _ s: MainMethodStruct) async {
+  let a = NS()
+  mergeFn(a, b) // expected-note {{'a' is connected to 'b' which is accessible to code in the current isolation context}}
+  await s.method(a) // expected-warning {{sending 'a' risks causing data races}}
+  // expected-note @-1 {{sending 'a' to main actor-isolated instance method 'method' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+// Two sends from one call: the bystander 'a' and the nonisolated receiver 'c'.
+func dest_global_actor_method_on_class(_ b: NS, _ c: MainMethodClass) async {
+  let a = NS()
+  mergeFn(a, b) // expected-note {{'a' is connected to 'b' which is accessible to code in the current isolation context}}
+  await c.method(a) // expected-warning {{sending 'a' risks causing data races}}
+  // expected-note @-1 {{sending 'a' to main actor-isolated instance method 'method' risks causing data races between main actor-isolated code and code in the current isolation context}}
+  // expected-warning @-2 {{sending 'c' risks causing data races}}
+  // expected-note @-3 {{sending 'c' to main actor-isolated instance method 'method' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func dest_method_on_isolated_struct(_ b: NS, _ s: IsolatedStruct) async {
+  let a = NS()
+  mergeFn(a, b) // expected-note {{'a' is connected to 'b' which is accessible to code in the current isolation context}}
+  await s.method(a) // expected-warning {{sending 'a' risks causing data races}}
+  // expected-note @-1 {{sending 'a' to main actor-isolated instance method 'method' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func dest_method_on_isolated_class(_ b: NS, _ c: IsolatedClass) async {
+  let a = NS()
+  mergeFn(a, b) // expected-note {{'a' is connected to 'b' which is accessible to code in the current isolation context}}
+  await c.method(a) // expected-warning {{sending 'a' risks causing data races}}
+  // expected-note @-1 {{sending 'a' to main actor-isolated instance method 'method' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func dest_actor_method(_ b: NS, _ r: Receiver) async {
+  let a = NS()
+  mergeFn(a, b) // expected-note {{'a' is connected to 'b' which is accessible to code in the current isolation context}}
+  await r.take(a) // expected-warning {{sending 'a' risks causing data races}}
+  // expected-note @-1 {{sending 'a' to actor-isolated instance method 'take' risks causing data races between actor-isolated code and code in the current isolation context}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// GLOBAL-ACTOR SOURCE REACHED BY MERGING.
+//
+// The right way to get a global-actor-isolated *source*: be inside the global
+// actor's context so the isolated value can be obtained legitimately, merge a
+// disconnected local into it, then send to a different isolation domain. (Doing
+// this from a nonisolated context instead fails earlier -- a non-Sendable result
+// cannot leave the actor -- so the value never becomes a usable source.)
+//
+// This also covers @concurrent as a send destination, which no other test uses.
+////////////////////////////////////////////////////////////////////////////////
+
+@concurrent func toConcurrent<T>(_ t: T) async {}
+
+@MainActor func ga_merge_send_other_actor() async {
+  let a = NS()
+  // expected-note@+1{{'m' is connected to result of 'getMainNS()' which is accessible to main actor-isolated code}}
+  let m = getMainNS()
+  mergeFn(a, m) // expected-note {{'a' is connected to 'm'}}
+  await transferToCustom(a) // expected-warning {{sending 'a' risks causing data races}}
+  // expected-note @-1 {{sending main actor-isolated 'a' to global actor 'CustomActor'-isolated global function 'transferToCustom' risks causing data races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
+}
+
+@MainActor func ga_merge_send_concurrent() async {
+  let a = NS()
+  // expected-note@+1{{'m' is connected to result of 'getMainNS()' which is accessible to main actor-isolated code}}
+  let m = getMainNS()
+  mergeFn(a, m) // expected-note {{'a' is connected to 'm'}}
+  await toConcurrent(a) // expected-warning {{sending 'a' risks causing data races}}
+  // expected-note @-1 {{sending main actor-isolated 'a' to @concurrent global function 'toConcurrent' risks causing data races between @concurrent and main actor-isolated uses}}
+}
+
+// FIXME: The bystander form of the two above emits NO chain note at all -- not
+// even a wrong one. 'a' joined carrier 'c', and 'c' is what merged with the
+// main-actor-isolated 'm', so the chain should read a -> c -> m. Contrast with
+// the task-isolated bystander cases above, which at least emit a (wrong) note;
+// with a global-actor source the explanation is dropped entirely.
+@MainActor func ga_bystander_send_concurrent() async {
+  let a = NS()
+  let c = NS()
+  // expected-note@+1{{'a' is connected to 'c'}}
+  mergeFn(a, c)
+  // expected-note@+1{{'m' is connected to result of 'getMainNS()' which is accessible to main actor-isolated code}}
+  let m = getMainNS()
+  // expected-note@+1{{'c' is connected to 'm'}}
+  mergeFn(c, m)
+  await toConcurrent(a) // expected-warning {{sending 'a' risks causing data races}}
+  // expected-note @-1 {{sending main actor-isolated 'a' to @concurrent global function 'toConcurrent' risks causing data races between @concurrent and main actor-isolated uses}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// ALREADY-SENT REGION.
+//
+// From inside a global-actor-isolated function, pass a disconnected local to a
+// *different* global actor's function -- which sends its whole region -- then
+// pass a sibling from that same region somewhere else. This is a use-after-send,
+// a different diagnostic path that the isolation-history walker does not
+// participate in. Pinned so the boundary is explicit.
+////////////////////////////////////////////////////////////////////////////////
+
+@CustomActor func sent_region_then_sibling_concurrent() async {
+  let a = NS()
+  let b = NS()
+  mergeFn(a, b)
+  await transferToMain(a) // expected-warning {{sending 'a' risks causing data races}}
+  // expected-note @-1 {{sending 'a' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local global actor 'CustomActor'-isolated uses}}
+  await toConcurrent(b) // expected-note {{access can happen concurrently}}
+}
+
+@CustomActor func sent_region_then_sibling_other_actor() async {
+  let a = NS()
+  let b = NS()
+  mergeFn(a, b)
+  await transferToMain(a) // expected-warning {{sending 'a' risks causing data races}}
+  // expected-note @-1 {{sending 'a' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local global actor 'CustomActor'-isolated uses}}
+  await transferToMain(b) // expected-note {{access can happen concurrently}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// SENT-NEVER-SENDABLE SUB-DIAGNOSTICS OTHER THAN AN ISOLATION CROSSING.
+//
+// Everything above reaches the SentNeverSendable emitter through one exit
+// path: an apply whose isolation crossing gives the value a name
+// (`emitNamedIsolation`). That emitter has several other exits, and each one
+// pairs a *different* primary diagnostic with the same history notes:
+//
+//   • a 'sending' parameter          -> emitNamedSendingNeverSendableToSendingParam
+//   • a 'sending' closure literal    -> initForSendingPartialApply
+//   • a 'sending' result             -> emitNamedSendingReturn
+//   • the typed (unnamed) fallbacks  -> emitTypedSendingNeverSendableToSendingParam
+//                                       emitPassToApply
+//
+// The notes are emitted from a SWIFT_DEFER in SentNeverSendableDiagnosticEmitter
+// ::emit(), so they attach regardless of which exit ran. These tests pin that:
+// they hold the history-note wording fixed while the primary diagnostic varies.
+////////////////////////////////////////////////////////////////////////////////
+
+func takeSending(_ x: sending NS) {}
+func takeSendingGeneric<T>(_ x: sending T) {}
+func takeSendingClosure(_ f: sending () -> ()) {}
+
+////////////////////////////////////////////////////////////////////////////////
+// 'sending' parameter destination. The primary note says "is passed as a
+// 'sending' parameter" instead of naming a callee isolation, but the chain
+// leading up to it is the ordinary one.
+////////////////////////////////////////////////////////////////////////////////
+
+func sending_param_chain(_ x: NS) async {
+  let y = x // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+  let z = y // expected-note {{'z' is connected to 'y'}}
+  takeSendingGeneric(z) // expected-warning {{sending 'z' risks causing data races}}
+  // expected-note @-1 {{'z' is passed as a 'sending' parameter; Uses in callee may race with code in the current isolation context}}
+  _ = x
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// 'sending' closure literal. Here the primary diagnostic anchors on the
+// *capture* inside the closure while the history notes anchor on the captured
+// locals' declarations — two independent anchor sources in one diagnostic.
+////////////////////////////////////////////////////////////////////////////////
+
+func sending_closure_literal_chain(_ x: NS) async {
+  let y = x // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+  let z = y // expected-note {{'z' is connected to 'y'}}
+  takeSendingClosure { _ = z } // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+  // expected-note @-1 {{closure captures 'z' which is accessible to code in the current isolation context}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// 'sending' result. The send is a `return`, not an apply, so this exits
+// emit() through the ReturnInst branch rather than the ApplyExpr branch.
+// Covered in sync, async, and throwing form since that branch asserts every
+// SILResultInfo carries IsSending.
+////////////////////////////////////////////////////////////////////////////////
+
+func sending_result_chain(_ x: NS) -> sending NS {
+  let y = x // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+  // expected-note@+1{{'z' is connected to 'y'}}
+  let z = y
+  return z // expected-warning {{sending 'z' risks causing data races}}
+  // expected-note @-1 {{'z' cannot be a 'sending' result. Code in the current task may race with caller uses}}
+}
+
+func sending_result_async_chain(_ x: NS) async -> sending NS {
+  let y = x // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+  // expected-note@+1{{'z' is connected to 'y'}}
+  let z = y
+  return z // expected-warning {{sending 'z' risks causing data races}}
+  // expected-note @-1 {{'z' cannot be a 'sending' result. Code in the current task may race with caller uses}}
+}
+
+func sending_result_throws_chain(_ x: NS) throws -> sending NS {
+  let y = x // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+  // expected-note@+1{{'z' is connected to 'y'}}
+  let z = y
+  return z // expected-warning {{sending 'z' risks causing data races}}
+  // expected-note @-1 {{'z' cannot be a 'sending' result. Code in the current task may race with caller uses}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// CONCRETE VS GENERIC CALLEE PARAMETER.
+//
+// Whether a chain link survives depends on the *callee's* parameter type, not
+// on anything the user wrote at the send site. A generic parameter forces a
+// copy into a temporary, which shows up in the history as an extra merge and
+// gives the walk an intermediate to report; a concrete parameter merges the
+// sent element directly with the isolated source, so the walk decides the
+// chain is trivial and suppresses a step.
+//
+// The pairs below are identical Swift apart from the callee they send to.
+////////////////////////////////////////////////////////////////////////////////
+
+@MainActor func transferToMainConcrete(_ t: NS) async {}
+
+// Generic callee, one hop: the note fires.
+func concrete_vs_generic_generic_one_hop(_ x: NS) async {
+  let y = x // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
+  // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+// FIXME: concrete callee, one hop: NO history note at all, though the source
+// is identical to the generic case above apart from the callee. The walk
+// rewinds `let y = x` as a merge of the sent element straight into 'x''s
+// region, never sets intermediateSeen, and suppresses the chain as trivial —
+// the suppression that exists for `transferToMain(x)`, where the user really
+// did send the isolated value itself. Here the user did write an intermediate
+// ('y'), so the note should fire.
+func concrete_vs_generic_concrete_one_hop(_ x: NS) async {
+  // expected-note@+1{{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+  let y = x
+  await transferToMainConcrete(y) // expected-warning {{sending 'y' risks causing data races}}
+  // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMainConcrete' risks causing data races between main actor-isolated code and code in the current isolation context}}
+
+  // IDEAL diagnostic — chain walker should emit:
+  //   let y = x:                          note: 'y' is connected to 'x' which is accessible to code in the current isolation context
+  //   await transferToMainConcrete(y):    warning: sending 'y' risks causing data races
+  //                                       note:    sending 'y' to main actor-isolated global function 'transferToMainConcrete' ...
+}
+
+// Generic callee, two hops: both links are reported.
+func concrete_vs_generic_generic_two_hop(_ x: NS) async {
+  let y = x // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+  let z = y // expected-note {{'z' is connected to 'y'}}
+  await transferToMain(z) // expected-warning {{sending 'z' risks causing data races}}
+  // expected-note @-1 {{sending 'z' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+// FIXME: concrete callee, two hops: the innermost link is dropped. 'y' is
+// connected to 'x' is reported, but 'z' is connected to 'y' is not, so the
+// chain silently starts one step away from the value actually named in the
+// warning. Same root cause as the one-hop case: the last merge before the
+// send is folded away when the parameter is concrete.
+func concrete_vs_generic_concrete_two_hop(_ x: NS) async {
+  let y = x // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+  // expected-note@+1{{'z' is connected to 'y'}}
+  let z = y
+  await transferToMainConcrete(z) // expected-warning {{sending 'z' risks causing data races}}
+  // expected-note @-1 {{sending 'z' to main actor-isolated global function 'transferToMainConcrete' risks causing data races between main actor-isolated code and code in the current isolation context}}
+
+  // IDEAL diagnostic — chain walker should additionally emit:
+  //   let z = y:                          note: 'z' is connected to 'y'
+}
+
+// The same asymmetry on the 'sending' parameter path, to show it is a property
+// of the callee's parameter type rather than of the isolation-crossing exit.
+// FIXME: 'z' is connected to 'y' is dropped; compare sending_param_chain
+// above, which is the same code against a generic 'sending' parameter.
+func sending_param_concrete_chain(_ x: NS) async {
+  let y = x // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+  // expected-note@+1{{'z' is connected to 'y'}}
+  let z = y
+  takeSending(z) // expected-warning {{sending 'z' risks causing data races}}
+  // expected-note @-1 {{'z' is passed as a 'sending' parameter; Uses in callee may race with code in the current isolation context}}
+  _ = x
+
+  // IDEAL diagnostic — chain walker should additionally emit:
+  //   let z = y:                          note: 'z' is connected to 'y'
+}
+
+// FIXME: the 'sending' result path folds the last link away too — 'z' is
+// connected to 'y' is missing from every sending_result_* test above. Pinned
+// once here rather than repeated on each.
+func sending_result_dropped_link(_ x: NS) -> sending NS {
+  let y = x // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+  // expected-note@+1{{'z' is connected to 'y'}}
+  let z = y
+  return z // expected-warning {{sending 'z' risks causing data races}}
+  // expected-note @-1 {{'z' cannot be a 'sending' result. Code in the current task may race with caller uses}}
+
+  // IDEAL diagnostic — chain walker should additionally emit:
+  //   let z = y:                          note: 'z' is connected to 'y'
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// MERGE TOPOLOGY x ORDERING MATRIX.
+//
+// Each group below fixes a merge topology -- which values get merged, ignoring
+// time -- and varies the order the merges happen in. The topology fixes how many
+// notes are correct; the ordering must not change that count. A group whose
+// count is not uniform is reporting a closure over "values ever connected"
+// rather than the merges the program actually performed.
+//
+// One note per merge the user wrote, anchored at that merge. A merge between two
+// spellings of a single value (the stack temporary SILGen creates for a call
+// argument) is an artifact of lowering and gets no note.
+//
+// The hard case is a merge that separates the two values being connected while
+// naming NEITHER of them -- both ride along as passengers on opposite sides of
+// the split. See the passenger_split group: in a balanced merge tree over N
+// carriers, only the two merges adjacent to the endpoints name an endpoint, so
+// recognising a merge by its operands misses almost all of them.
+////////////////////////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////////////////
+// Topology: direct. y -- x. 1 edge, 1 ordering.
+// Expect 1 note: the terminal one. There is no intermediate to report, but the
+// sent value is still disconnected and had to be told where its isolation came
+// from. (Contrast suppress_direct above, where the SENT value is itself the
+// isolated one and nothing is emitted.)
+////////////////////////////////////////////////////////////////////////////////
+
+func direct(_ x: NS) async {
+    let y = NS()
+    mergeFn(y, x) // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Topology: path, 1 carrier. y -- z -- x. 2 edges, 2 orderings.
+// Expect 2 notes each: 1 link + 1 terminal.
+//
+//   L = mergeFn(y, z)    I = mergeFn(z, x)
+////////////////////////////////////////////////////////////////////////////////
+
+func path1_link_isolate(_ x: NS) async {
+    let y = NS()
+    let z = NS()
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    mergeFn(z, x) // expected-note {{'z' is connected to 'x' which is accessible to code in the current isolation context}}
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func path1_isolate_link(_ x: NS) async {
+    let y = NS()
+    let z = NS()
+
+    mergeFn(z, x) // expected-note {{'z' is connected to 'x' which is accessible to code in the current isolation context}}
+
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Topology: path, 2 carriers. y -- w -- z -- x. 3 edges, all 3! = 6 orderings.
+// Expect 3 notes each: 2 links + 1 terminal.
+//
+//   L = mergeFn(y, w)    C = mergeFn(z, w)    I = mergeFn(z, x)
+//
+// This is the section that matters most: same shape six ways. v1 is known to
+// drop a hop on at least one ordering (see bystander_threehop_isolation_last
+// in transfernonsendable_isolationhistory.swift, which emits 2 where its
+// siblings emit 3), so a uniform count here is not a given.
+////////////////////////////////////////////////////////////////////////////////
+
+func path2_link_chain_isolate(_ x: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+
+    mergeFn(y, w) // expected-note {{'y' is connected to 'w'}}
+
+    mergeFn(z, w) // expected-note {{'w' is connected to 'z'}}
+
+    mergeFn(z, x) // expected-note {{'z' is connected to 'x' which is accessible to code in the current isolation context}}
+
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func path2_link_isolate_chain(_ x: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    mergeFn(y, w) // expected-note {{'y' is connected to 'w'}}
+    mergeFn(z, x) // expected-note {{'z' is connected to 'x' which is accessible to code in the current isolation context}}
+    mergeFn(z, w) // expected-note {{'w' is connected to 'z'}}
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func path2_chain_link_isolate(_ x: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    mergeFn(z, w) // expected-note {{'w' is connected to 'z'}}
+    mergeFn(y, w) // expected-note {{'y' is connected to 'w'}}
+    mergeFn(z, x) // expected-note {{'z' is connected to 'x' which is accessible to code in the current isolation context}}
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func path2_chain_isolate_link(_ x: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    mergeFn(z, w) // expected-note {{'w' is connected to 'z'}}
+    mergeFn(z, x) // expected-note {{'z' is connected to 'x' which is accessible to code in the current isolation context}}
+    mergeFn(y, w) // expected-note {{'y' is connected to 'w'}}
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func path2_isolate_link_chain(_ x: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    mergeFn(z, x) // expected-note {{'z' is connected to 'x' which is accessible to code in the current isolation context}}
+    mergeFn(y, w) // expected-note {{'y' is connected to 'w'}}
+    mergeFn(z, w) // expected-note {{'w' is connected to 'z'}}
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func path2_isolate_chain_link(_ x: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    mergeFn(z, x) // expected-note {{'z' is connected to 'x' which is accessible to code in the current isolation context}}
+    mergeFn(z, w) // expected-note {{'w' is connected to 'z'}}
+    mergeFn(y, w) // expected-note {{'y' is connected to 'w'}}
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Topology: fan -- INTENDED as one carrier reaching two separate isolated
+// values, y -- z, z -- x1, z -- x2. It is not actually that shape.
+//
+// ANSWERED: one terminal note, and the reason is that the second merge does not
+// exist. All non-Sendable function arguments are put in ONE region at entry
+// (RegionAnalysis.cpp: initialEntryBlockPartition = Partition::singleRegion of
+// the joined argument indices), so x1 and x2 are already region-mates before
+// the body runs. By the time `mergeFn(z, x2)` executes, z and x2 are in the same
+// region, and Partition::merge early-returns without pushing a history node.
+// The log confirms it: the boundaries for that line are present with no
+// MergeElementRegions between them, and the oldest node in the history is
+// `into region of %%0 merged [%%1]` -- the two parameters being joined at entry.
+//
+// So there is only one isolated region here, reached one way, and one terminal
+// note is right. This section does NOT exercise multiple isolated sources.
+//
+// The same applies to every group below that takes more than one NS parameter
+// (fanchain, fandepth, fanthree, splitdiamond, unevendiamond,
+// passenger_split_two_isolated, mixed_direct): the parameters are one region
+// from entry, so the second and later "isolate" merges push no history node and
+// the intended fan collapses to a path. Those groups are still useful as path
+// orderings, but they do NOT exercise multiple isolated sources. Two genuinely
+// independent isolated sources need two isolation DOMAINS, not two parameters.
+////////////////////////////////////////////////////////////////////////////////
+
+func fan_link_isolate_isolate(_ x1: NS, _ x2: NS) async {
+    let y = NS()
+    let z = NS()
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    mergeFn(z, x1) // expected-note {{'z' is connected to 'x1' which is accessible to code in the current isolation context}}
+    mergeFn(z, x2)
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func fan_isolate_isolate_link(_ x1: NS, _ x2: NS) async {
+    let y = NS()
+    let z = NS()
+    mergeFn(z, x1) // expected-note {{'z' is connected to 'x1' which is accessible to code in the current isolation context}}
+    mergeFn(z, x2)
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func fan_isolate_link_isolate(_ x1: NS, _ x2: NS) async {
+    let y = NS()
+    let z = NS()
+    mergeFn(z, x1) // expected-note {{'z' is connected to 'x1' which is accessible to code in the current isolation context}}
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    mergeFn(z, x2)
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Topology: fan over a 2-carrier chain, both isolated values at the far end.
+// y -- z -- w, then w -- x1 and w -- x2.
+// 3 disconnected (y, z, w), 2 isolated (x1, x2).
+//
+// The chain to the isolated pair is unambiguous -- y, z, w in that order -- so
+// the 2 link notes are not in question. What is in question is what happens
+// when the walk arrives at w and finds TWO isolated values there.
+//
+// This is the shape that stresses "split out all of the isolated elements
+// first": there are two to split out, and whichever is split first is the one
+// the focus meets first. If that decides which terminal note is emitted, the
+// answer depends on split order rather than on the program.
+////////////////////////////////////////////////////////////////////////////////
+
+func fanchain_links_then_isolates(_ x1: NS, _ x2: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    mergeFn(z, w) // expected-note {{'z' is connected to 'w'}}
+    mergeFn(w, x1) // expected-note {{'w' is connected to 'x1' which is accessible to code in the current isolation context}}
+    mergeFn(w, x2)
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func fanchain_isolates_then_links(_ x1: NS, _ x2: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    mergeFn(w, x1) // expected-note {{'w' is connected to 'x1' which is accessible to code in the current isolation context}}
+    mergeFn(w, x2)
+    mergeFn(z, w) // expected-note {{'z' is connected to 'w'}}
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func fanchain_interleaved(_ x1: NS, _ x2: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    mergeFn(w, x1) // expected-note {{'w' is connected to 'x1' which is accessible to code in the current isolation context}}
+    mergeFn(z, w) // expected-note {{'z' is connected to 'w'}}
+    mergeFn(w, x2)
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Topology: two isolated values attaching at DIFFERENT depths along the chain.
+// y -- z -- w, with z -- x1 (one hop from y) and w -- x2 (two hops).
+// 3 disconnected, 2 isolated.
+//
+// Unlike the section above, the two isolated values are not interchangeable:
+// x1 is reached after 1 link and x2 after 2. A focus that walks one route to
+// completion reports whichever it meets first and never learns about the
+// other. If only one chain is reported, is the nearer isolated value the right
+// one to report, or the farther?
+////////////////////////////////////////////////////////////////////////////////
+
+func fandepth_links_then_isolates(_ x1: NS, _ x2: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    mergeFn(z, w)
+    mergeFn(z, x1) // expected-note {{'z' is connected to 'x1' which is accessible to code in the current isolation context}}
+    mergeFn(w, x2)
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func fandepth_isolates_then_links(_ x1: NS, _ x2: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    mergeFn(z, x1) // expected-note {{'z' is connected to 'x1' which is accessible to code in the current isolation context}}
+    mergeFn(w, x2)
+    mergeFn(z, w)
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func fandepth_near_isolate_last(_ x1: NS, _ x2: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    mergeFn(w, x2) // expected-note {{'w' is connected to 'x2' which is accessible to code in the current isolation context}}
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    mergeFn(z, w) // expected-note {{'z' is connected to 'w'}}
+    mergeFn(z, x1)
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Topology: three isolated values over a 3-carrier chain.
+// y -- z -- w -- v, with z -- x1, w -- x2, v -- x3.
+// 4 disconnected, 3 isolated, one attaching at each depth.
+//
+// Pushes past two: if the answer for two isolated values is "report them all",
+// this says whether the structure generalises or whether two was a special
+// case that a pair of fields happened to cover.
+////////////////////////////////////////////////////////////////////////////////
+
+func fanthree_links_then_isolates(_ x1: NS, _ x2: NS, _ x3: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    let v = NS()
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    mergeFn(z, w)
+    mergeFn(w, v)
+    mergeFn(z, x1) // expected-note {{'z' is connected to 'x1' which is accessible to code in the current isolation context}}
+    mergeFn(w, x2)
+    mergeFn(v, x3)
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func fanthree_isolates_then_links(_ x1: NS, _ x2: NS, _ x3: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    let v = NS()
+    mergeFn(z, x1) // expected-note {{'z' is connected to 'x1' which is accessible to code in the current isolation context}}
+    mergeFn(w, x2)
+    mergeFn(v, x3)
+    mergeFn(w, v)
+    mergeFn(z, w)
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Orderings of the fanthree topology. Same 6 edges every time, 6! = 720
+// orderings; these are the ones that isolate a distinct structural property.
+//
+//   L  = mergeFn(y, z)     link: sent value attaches to the chain
+//   C1 = mergeFn(z, w)     chain, near
+//   C2 = mergeFn(w, v)     chain, far
+//   I1 = mergeFn(z, x1)    isolate at depth 1
+//   I2 = mergeFn(w, x2)    isolate at depth 2
+//   I3 = mergeFn(v, x3)    isolate at depth 3
+//
+// The two extremes already exist above: fanthree_isolates_then_links is
+// I1 I2 I3 C2 C1 L, and fanthree_links_then_isolates is L C1 C2 I1 I2 I3.
+//
+// The counts noted per case are derived from the rewind mechanism -- history
+// pops newest-first, a merge is only recognised when one operand is already
+// tracked, and tracking only grows by passing merges. They are PREDICTIONS,
+// not observations: nothing calls the v2 emitter yet. They are worth writing
+// down anyway because the spread is the point -- if the design is right, the
+// count should be the same across this whole section, and the mechanism says
+// it currently ranges from 0 to 6.
+////////////////////////////////////////////////////////////////////////////////
+
+// I1 I2 I3 L C1 C2 -- isolates still oldest, but the links run near-to-far
+// instead of far-to-near. Rewind meets C2 and C1 before anything is tracked,
+// so only z is ever reached: x2 and x3 drop out even though every isolating
+// merge is older than every link. Link ORDER alone decides how far the chain
+// is walked.
+func fanthree_links_near_to_far(_ x1: NS, _ x2: NS, _ x3: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    let v = NS()
+    mergeFn(z, x1) // expected-note {{'z' is connected to 'x1' which is accessible to code in the current isolation context}}
+    mergeFn(w, x2)
+    mergeFn(v, x3)
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    mergeFn(z, w)
+    mergeFn(w, v)
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+// I3 C2 I2 C1 I1 L -- each isolate sits immediately before the link that
+// reaches its attachment point. Rewind order is L I1 C1 I2 C2 I3, so every
+// element is tracked exactly when its merge arrives. Full recognition, and the
+// upper bound for this topology.
+func fanthree_interleaved_far_first(_ x1: NS, _ x2: NS, _ x3: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    let v = NS()
+    mergeFn(v, x3) // expected-note {{'v' is connected to 'x3' which is accessible to code in the current isolation context}}
+    mergeFn(w, v) // expected-note {{'w' is connected to 'v'}}
+    mergeFn(w, x2)
+    mergeFn(z, w) // expected-note {{'z' is connected to 'w'}}
+    mergeFn(z, x1)
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+// L I1 C1 I2 C2 I3 -- the mirror image: each isolate immediately AFTER its
+// link. Rewind meets every isolate before the link that would have tracked its
+// attachment point, so nothing is recognised at all. Same interleaving, other
+// direction, opposite outcome.
+func fanthree_interleaved_near_first(_ x1: NS, _ x2: NS, _ x3: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    let v = NS()
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    mergeFn(z, x1) // expected-note {{'z' is connected to 'x1' which is accessible to code in the current isolation context}}
+    mergeFn(z, w)
+    mergeFn(w, x2)
+    mergeFn(w, v)
+    mergeFn(v, x3)
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+// I1 I3 C2 C1 L I2 -- the MIDDLE isolate is newest, the rest in the
+// best-case order. Isolates exactly one isolated value out of the result while
+// leaving the chain walk otherwise intact.
+func fanthree_middle_isolate_newest(_ x1: NS, _ x2: NS, _ x3: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    let v = NS()
+    mergeFn(z, x1) // expected-note {{'z' is connected to 'x1' which is accessible to code in the current isolation context}}
+    mergeFn(v, x3)
+    mergeFn(w, v)
+    mergeFn(z, w)
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    mergeFn(w, x2)
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+// I2 I3 C2 C1 L I1 -- same, but the NEAREST isolate is the newest one. The
+// dropped value is the one closest to the sent value, which is arguably the
+// most relevant one to report.
+func fanthree_near_isolate_newest(_ x1: NS, _ x2: NS, _ x3: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    let v = NS()
+    mergeFn(w, x2) // expected-note {{'w' is connected to 'x2' which is accessible to code in the current isolation context}}
+    mergeFn(v, x3)
+    mergeFn(w, v)
+    mergeFn(z, w) // expected-note {{'z' is connected to 'w'}}
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    mergeFn(z, x1)
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+// I1 I2 C2 C1 L I3 -- and the FARTHEST isolate newest. Completes the trio:
+// with the other five merges fixed, moving each isolate to newest in turn
+// should drop exactly that one value and nothing else.
+func fanthree_far_isolate_newest(_ x1: NS, _ x2: NS, _ x3: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    let v = NS()
+    mergeFn(z, x1) // expected-note {{'z' is connected to 'x1' which is accessible to code in the current isolation context}}
+    mergeFn(w, x2)
+    mergeFn(w, v)
+    mergeFn(z, w)
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    mergeFn(v, x3)
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+// I1 I2 I3 C2 L C1 -- the link sits between the two chain merges. Rewind hits
+// C1 before y has reached z, so the near chain edge is missed and the walk
+// stops one hop in. Tests that the link's position matters independently of
+// the isolates'.
+func fanthree_link_between_chains(_ x1: NS, _ x2: NS, _ x3: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    let v = NS()
+    mergeFn(z, x1) // expected-note {{'z' is connected to 'x1' which is accessible to code in the current isolation context}}
+    mergeFn(w, x2)
+    mergeFn(v, x3)
+    mergeFn(w, v)
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    mergeFn(z, w)
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+// L I1 I2 I3 C2 C1 -- the sent value attaches FIRST, before anything else
+// exists. Every other merge is newer, so rewind reaches all of them while
+// tracking is still just {y}. Relevant to the "stop once the sentElement is an
+// operand" rule: here that merge is the oldest, so the stop fires last rather
+// than first.
+func fanthree_link_oldest(_ x1: NS, _ x2: NS, _ x3: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    let v = NS()
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    mergeFn(z, x1) // expected-note {{'z' is connected to 'x1' which is accessible to code in the current isolation context}}
+    mergeFn(w, x2)
+    mergeFn(v, x3)
+    mergeFn(w, v)
+    mergeFn(z, w)
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+// C1 C2 I1 I2 I3 L -- the whole carrier chain is built before any isolation
+// arrives, and the sent value attaches last. Rewind gets L first, so the stop
+// rule fires immediately; the chain edges are the oldest merges of all and are
+// only reached after every isolate has been undone.
+func fanthree_chains_before_isolates(_ x1: NS, _ x2: NS, _ x3: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    let v = NS()
+    mergeFn(z, w)
+    mergeFn(w, v)
+    mergeFn(z, x1) // expected-note {{'z' is connected to 'x1' which is accessible to code in the current isolation context}}
+    mergeFn(w, x2)
+    mergeFn(v, x3)
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Topology: one isolated value merged DIRECTLY into the sent value, a second
+// reached through a chain. y -- x1 direct, plus y -- z -- w -- x2.
+// 3 disconnected, 2 isolated.
+//
+// This is the case that stresses "stop once we find a merge that has the
+// sentElement as one of the operands". mergeFn(y, x1) is exactly such a merge,
+// and it is also the direct case that is normally SUPPRESSED as adding no
+// information. But y also reaches x2 through a real chain that does deserve
+// notes. So the stopping rule and the suppression rule both fire on a merge
+// that is not the whole story.
+//
+// Varying whether the direct merge is newest or oldest changes whether the
+// walk meets it before or after it has explored the chain.
+////////////////////////////////////////////////////////////////////////////////
+
+func mixed_direct_newest(_ x1: NS, _ x2: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    mergeFn(z, w) // expected-note {{'z' is connected to 'w'}}
+    mergeFn(w, x2) // expected-note {{'w' is connected to 'x2' which is accessible to code in the current isolation context}}
+    mergeFn(y, x1) // no merge
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func mixed_direct_newest2(_ x1: NS, _ x2: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    mergeFn(z, w) // (x1 x2) (y z w)
+    mergeFn(z, x2) // expected-note {{'z' is connected to 'x2' which is accessible to code in the current isolation context}}
+    mergeFn(y, x1) // no merge
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func passenger_split(_ x1: NS) async {
+    let y1 = NS()
+    let y2 = NS()
+    let y3 = NS()
+    let y4 = NS()
+    mergeFn(y3, y4) // expected-note {{'y3' is connected to 'y4'}}
+    mergeFn(y1, y2) // expected-note {{'y1' is connected to 'y2'}}
+    mergeFn(y2, y3) // expected-note {{'y2' is connected to 'y3'}}
+
+    mergeFn(y4, x1) // expected-note {{'y4' is connected to 'x1' which is accessible to code in the current isolation context}}
+    await transferToMain(y1) // expected-warning {{sending 'y1' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y1' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Passenger splits, stressed. A passenger split is a merge that separates the
+// two values we are trying to connect while naming NEITHER of them -- both are
+// passengers, on opposite sides of the split. passenger_split above has one.
+// These have several, so a rule that happens to survive a single one does not
+// survive here.
+//
+// The shape is: build the carriers up in pairs, then join the pairs, then join
+// the pairs of pairs. Every join separates the endpoints beneath it while naming
+// neither. A balanced merge tree over 2^k leaves has 2^k - 1 internal merges, of
+// which only the two adjacent to the endpoints are ever named by an operand.
+//
+// Why this is the stress case: recognition by "is an operand tracked" gets one
+// of these merges wrong and then never recovers, because the endpoints it would
+// need to track are exactly the ones it failed to learn. Recognition by "did
+// this merge put my endpoints in different regions" is unaffected by how many
+// there are, since it never consults operands at all.
+//
+// Note the discovery order is not the chain order. In passenger_split the
+// chain is y1-y2-y3-y4-x1 but the merges are found 4th, 2nd, 1st, 3rd. The more
+// splits there are the worse the permutation gets, so links have to be stitched
+// by endpoint after the fact rather than chained as they are discovered.
+////////////////////////////////////////////////////////////////////////////////
+
+// Balanced tree over 8 carriers: 4 pairs, 2 pairs-of-pairs, 1 root. The sent
+// value is the leftmost leaf and the isolated value attaches to the rightmost,
+// so the two endpoints are maximally far apart in the tree. Every one of the
+// 3 upper-level joins names neither endpoint.
+func passenger_split_balanced8(_ x1: NS) async {
+    let a1 = NS()
+    let a2 = NS()
+    let a3 = NS()
+    let a4 = NS()
+    let a5 = NS()
+    let a6 = NS()
+    let a7 = NS()
+    let a8 = NS()
+
+    // Level 1: four disjoint pairs. Neither endpoint is a passenger yet.
+    mergeFn(a1, a2) // expected-note {{'a1' is connected to 'a2'}}
+    mergeFn(a3, a4) // expected-note {{'a3' is connected to 'a4'}}
+    mergeFn(a5, a6) // expected-note {{'a5' is connected to 'a6'}}
+    mergeFn(a7, a8) // expected-note {{'a7' is connected to 'a8'}}
+
+    // Level 2: join the pairs. mergeFn(a2, a3) already separates (a1, a8) while
+    // naming neither of them.
+    mergeFn(a2, a3) // expected-note {{'a2' is connected to 'a3'}}
+    mergeFn(a6, a7) // expected-note {{'a6' is connected to 'a7'}}
+
+    // Level 3: the root. Also separates (a1, a8) without naming either.
+    mergeFn(a4, a5) // expected-note {{'a4' is connected to 'a5'}}
+
+    // Isolation enters at the far end.
+    mergeFn(a8, x1) // expected-note {{'a8' is connected to 'x1' which is accessible to code in the current isolation context}}
+    await transferToMain(a1) // expected-warning {{sending 'a1' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'a1' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+// Same tree, but the isolating merge comes FIRST. Now the whole tree is built
+// under an already-isolated region, so at every split both sides are
+// isolated. Distinguishes "did this split my endpoints" from anything that
+// keys off isolation status of the operands.
+func passenger_split_balanced8_isolate_first(_ x1: NS) async {
+    let a1 = NS()
+    let a2 = NS()
+    let a3 = NS()
+    let a4 = NS()
+    let a5 = NS()
+    let a6 = NS()
+    let a7 = NS()
+    let a8 = NS()
+
+    mergeFn(a8, x1) // expected-note {{'a8' is connected to 'x1' which is accessible to code in the current isolation context}}
+
+    mergeFn(a1, a2) // expected-note {{'a1' is connected to 'a2'}}
+    mergeFn(a3, a4) // expected-note {{'a3' is connected to 'a4'}}
+    mergeFn(a5, a6) // expected-note {{'a5' is connected to 'a6'}}
+    mergeFn(a7, a8) // expected-note {{'a7' is connected to 'a8'}}
+    mergeFn(a2, a3) // expected-note {{'a2' is connected to 'a3'}}
+    mergeFn(a6, a7) // expected-note {{'a6' is connected to 'a7'}}
+    mergeFn(a4, a5) // expected-note {{'a4' is connected to 'a5'}}
+    await transferToMain(a1) // expected-warning {{sending 'a1' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'a1' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+// Splits where the endpoints are in the MIDDLE of the tree rather than at the
+// edges. The sent value is a4 and isolation enters at a5, so the single root
+// mergeFn(a4, a5) names both endpoints -- but every merge under it separates
+// some sub-pair without naming it. Tests that those merges below the answer do
+// not generate spurious links once the answer is already found.
+func passenger_split_endpoints_adjacent(_ x1: NS) async {
+    let a1 = NS()
+    let a2 = NS()
+    let a3 = NS()
+    let a4 = NS()
+    let a5 = NS()
+    let a6 = NS()
+    let a7 = NS()
+    let a8 = NS()
+
+    mergeFn(a1, a2)
+    mergeFn(a3, a4)
+    mergeFn(a5, a6) // expected-note {{'a5' is connected to 'a6'}}
+    mergeFn(a7, a8) // expected-note {{'a7' is connected to 'a8'}}
+    mergeFn(a2, a3)
+    mergeFn(a6, a7) // expected-note {{'a6' is connected to 'a7'}}
+    mergeFn(a4, a5) // expected-note {{'a4' is connected to 'a5'}}
+
+    mergeFn(a8, x1) // expected-note {{'a8' is connected to 'x1' which is accessible to code in the current isolation context}}
+    await transferToMain(a4) // expected-warning {{sending 'a4' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'a4' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+// A deliberately unbalanced tree: a long left spine that is repeatedly joined
+// by single elements from the right. Each spine join separates the endpoints
+// without naming them, and they arrive in a strictly nested order rather than a
+// tree-shaped one.
+func passenger_split_spine(_ x1: NS) async {
+    let a1 = NS()
+    let a2 = NS()
+    let a3 = NS()
+    let a4 = NS()
+    let a5 = NS()
+    let a6 = NS()
+
+    mergeFn(a1, a2) // expected-note {{'a1' is connected to 'a2'}}
+    mergeFn(a2, a3) // expected-note {{'a2' is connected to 'a3'}}
+    mergeFn(a3, a4) // expected-note {{'a3' is connected to 'a4'}}
+    mergeFn(a4, a5) // expected-note {{'a4' is connected to 'a5'}}
+    mergeFn(a5, a6) // expected-note {{'a5' is connected to 'a6'}}
+
+    mergeFn(a6, x1) // expected-note {{'a6' is connected to 'x1' which is accessible to code in the current isolation context}}
+    await transferToMain(a1) // expected-warning {{sending 'a1' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'a1' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+// The spine built from the far end inward, so the merges arrive in the reverse
+// order relative to the chain. Pairs with passenger_split_spine: same
+// topology, opposite build direction.
+func passenger_split_spine_reversed(_ x1: NS) async {
+    let a1 = NS()
+    let a2 = NS()
+    let a3 = NS()
+    let a4 = NS()
+    let a5 = NS()
+    let a6 = NS()
+
+    mergeFn(a6, x1) // expected-note {{'a6' is connected to 'x1' which is accessible to code in the current isolation context}}
+    mergeFn(a5, a6) // expected-note {{'a5' is connected to 'a6'}}
+    mergeFn(a4, a5) // expected-note {{'a4' is connected to 'a5'}}
+    mergeFn(a3, a4) // expected-note {{'a3' is connected to 'a4'}}
+    mergeFn(a2, a3) // expected-note {{'a2' is connected to 'a3'}}
+    mergeFn(a1, a2) // expected-note {{'a1' is connected to 'a2'}}
+    await transferToMain(a1) // expected-warning {{sending 'a1' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'a1' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+// Passenger splits plus a second isolated value, so the walk has two endpoints
+// to reach through the same thicket of splits. x1 attaches at one end and x2 in
+// the middle of the tree.
+func passenger_split_two_isolated(_ x1: NS, _ x2: NS) async {
+    let a1 = NS()
+    let a2 = NS()
+    let a3 = NS()
+    let a4 = NS()
+    let a5 = NS()
+    let a6 = NS()
+    let a7 = NS()
+    let a8 = NS()
+
+    mergeFn(a1, a2) // expected-note {{'a1' is connected to 'a2'}}
+    mergeFn(a3, a4) // expected-note {{'a3' is connected to 'a4'}}
+    mergeFn(a5, a6) // expected-note {{'a5' is connected to 'a6'}}
+    mergeFn(a7, a8) // expected-note {{'a7' is connected to 'a8'}}
+    mergeFn(a2, a3) // expected-note {{'a2' is connected to 'a3'}}
+    mergeFn(a6, a7) // expected-note {{'a6' is connected to 'a7'}}
+    mergeFn(a4, a5) // expected-note {{'a4' is connected to 'a5'}}
+
+    mergeFn(a8, x1) // expected-note {{'a8' is connected to 'x1' which is accessible to code in the current isolation context}}
+    mergeFn(a5, x2)
+    await transferToMain(a1) // expected-warning {{sending 'a1' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'a1' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+// Passenger splits with a dead-end branch hanging off the middle. d is merged
+// into the tree but is on no route from a1 to the isolated value, so nothing
+// about it should be reported -- the over-reporting check, in the presence of
+// passenger splits.
+func passenger_split_with_deadend(_ x1: NS) async {
+    let a1 = NS()
+    let a2 = NS()
+    let a3 = NS()
+    let a4 = NS()
+    let a5 = NS()
+    let a6 = NS()
+    let d = NS()
+
+    mergeFn(a1, a2) // expected-note {{'a1' is connected to 'a2'}}
+    mergeFn(a3, a4) // expected-note {{'a3' is connected to 'a4'}}
+    mergeFn(a5, a6) // expected-note {{'a5' is connected to 'a6'}}
+    mergeFn(a2, a3) // expected-note {{'a2' is connected to 'a3'}}
+    mergeFn(a4, a5) // expected-note {{'a4' is connected to 'a5'}}
+
+    mergeFn(a3, d)
+
+    mergeFn(a6, x1) // expected-note {{'a6' is connected to 'x1' which is accessible to code in the current isolation context}}
+    await transferToMain(a1) // expected-warning {{sending 'a1' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'a1' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func mixed_direct_oldest(_ x1: NS, _ x2: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    mergeFn(y, x1) // expected-note {{'y' is connected to 'x1' which is accessible to code in the current isolation context}}
+    mergeFn(y, z) // (z y x1 x2) (w) // Then we do the same thing here.
+    mergeFn(z, w) // (z w y x1 x2 w) // See that w splits out, is disconnected, and y is still in isolated region. So just recurse into y's region.
+    mergeFn(w, x2) // No merge. Already in region.
+    await transferToMain(y) // Error. // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func mixed_direct_middle(_ x1: NS, _ x2: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    mergeFn(y, z)
+    mergeFn(y, x1) // expected-note {{'y' is connected to 'x1' which is accessible to code in the current isolation context}}
+    mergeFn(z, w)
+    mergeFn(w, x2)
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Topology: diamond. Two disjoint carrier paths to the SAME isolated value.
+// y -- z -- x and y -- w -- x. 4 edges.
+//
+// DECIDED: report the single chain path. There is one originating value, so a
+// second route adds no information the user needs -- it just spells out that
+// the region could have been reached another way. Whichever route is reported
+// must not depend on merge ordering.
+////////////////////////////////////////////////////////////////////////////////
+
+func diamond_left_first(_ x: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    mergeFn(z, x) // expected-note {{'z' is connected to 'x' which is accessible to code in the current isolation context}}
+    mergeFn(y, w)
+    mergeFn(w, x)
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func diamond_interleaved(_ x: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    mergeFn(y, w)
+    mergeFn(z, x) // expected-note {{'z' is connected to 'x' which is accessible to code in the current isolation context}}
+    mergeFn(w, x)
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func diamond_isolate_first(_ x: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    mergeFn(z, x) // expected-note {{'z' is connected to 'x' which is accessible to code in the current isolation context}}
+    mergeFn(w, x)
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    mergeFn(y, w)
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Topology: split diamond. Two disjoint routes ending at DIFFERENT isolated
+// values. y -- z -- x1 and y -- w -- x2. 3 disconnected, 2 isolated.
+//
+// The diamond above has one answer reachable two ways, so collapsing to a
+// single chain loses only a route. Here the two routes end somewhere
+// different, so collapsing loses an isolated value outright -- the user is
+// told about one actor when two are involved.
+//
+// Also the cleanest test of route independence: the two halves share only y,
+// so nothing about z should affect what is reported for w.
+////////////////////////////////////////////////////////////////////////////////
+
+func splitdiamond_left_route_first(_ x1: NS, _ x2: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    mergeFn(z, x1) // expected-note {{'z' is connected to 'x1' which is accessible to code in the current isolation context}}
+    mergeFn(y, w)
+    mergeFn(w, x2)
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func splitdiamond_links_then_isolates(_ x1: NS, _ x2: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    mergeFn(y, w)
+    mergeFn(z, x1) // expected-note {{'z' is connected to 'x1' which is accessible to code in the current isolation context}}
+    mergeFn(w, x2)
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func splitdiamond_isolates_then_links(_ x1: NS, _ x2: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    mergeFn(z, x1) // expected-note {{'z' is connected to 'x1' which is accessible to code in the current isolation context}}
+    mergeFn(w, x2)
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    mergeFn(y, w)
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Topology: diamond with unequal route lengths, two isolated values.
+// Short route y -- z -- x1. Long route y -- w -- v -- x2.
+// 4 disconnected, 2 isolated.
+//
+// Both routes must be walked to their own ends, and they end at different
+// depths. A walk that keeps a single "current focus" has to abandon one route
+// to follow the other; where it abandons is visible in which notes survive.
+////////////////////////////////////////////////////////////////////////////////
+
+func unevendiamond_short_first(_ x1: NS, _ x2: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    let v = NS()
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    mergeFn(z, x1) // expected-note {{'z' is connected to 'x1' which is accessible to code in the current isolation context}}
+    mergeFn(y, w)
+    mergeFn(w, v)
+    mergeFn(v, x2)
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func unevendiamond_long_first(_ x1: NS, _ x2: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    let v = NS()
+    mergeFn(y, w) // expected-note {{'y' is connected to 'w'}}
+    mergeFn(w, v) // expected-note {{'w' is connected to 'v'}}
+    mergeFn(v, x2) // expected-note {{'v' is connected to 'x2' which is accessible to code in the current isolation context}}
+    mergeFn(y, z)
+    mergeFn(z, x1)
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func unevendiamond_interleaved(_ x1: NS, _ x2: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    let v = NS()
+    mergeFn(y, w)
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    mergeFn(w, v)
+    mergeFn(z, x1) // expected-note {{'z' is connected to 'x1' which is accessible to code in the current isolation context}}
+    mergeFn(v, x2)
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Two isolated values from DIFFERENT isolation domains, rather than two
+// task-isolated parameters.
+//
+// Every multi-isolated case above uses parameters, which are all isolated the
+// same way, so a region holding two of them is coherent. Here one value is
+// main-actor isolated and the other belongs to an actor instance, which is a
+// different domain.
+//
+// Not obviously a note-counting question: merging across domains is what
+// IncompatibleRegionMergeError is for, so this may well diagnose before any
+// isolation-history note is reached. Worth knowing which fires, since if the
+// merge is rejected then a region can never hold two domains and the
+// multi-isolated cases above are all single-domain by construction.
+////////////////////////////////////////////////////////////////////////////////
+
+actor SomeActor {
+    var field = NS()
+    func getField() -> NS { field }
+}
+
+@MainActor func crossdomain_two_isolated(_ a: SomeActor) async {
+    let y = NS()
+    let z = NS()
+    // expected-note@+1{{'m' is connected to result of 'getMainNS()' which is accessible to main actor-isolated code}}
+    let m = getMainNS()
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    mergeFn(z, m) // expected-note {{'z' is connected to 'm'}}
+    await toConcurrent(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending main actor-isolated 'y' to @concurrent global function 'toConcurrent' risks causing data races between @concurrent and main actor-isolated uses}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Topology: dead-end branch. A value joins the sent value's region but is not
+// on the route to isolation. y -- d (never isolated), plus y -- z -- x.
+//
+// Expect 2 notes: the path1 answer. Nothing about 'd'. This is the only
+// section that tests OVER-reporting -- every case above can only fail by
+// emitting too few.
+////////////////////////////////////////////////////////////////////////////////
+
+func deadend_before(_ x: NS) async {
+    let y = NS()
+    let z = NS()
+    let d = NS()
+    mergeFn(y, d)
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    mergeFn(z, x) // expected-note {{'z' is connected to 'x' which is accessible to code in the current isolation context}}
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func deadend_between(_ x: NS) async {
+    let y = NS()
+    let z = NS()
+    let d = NS()
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    mergeFn(y, d)
+    mergeFn(z, x) // expected-note {{'z' is connected to 'x' which is accessible to code in the current isolation context}}
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func deadend_after(_ x: NS) async {
+    let y = NS()
+    let z = NS()
+    let d = NS()
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    mergeFn(z, x) // expected-note {{'z' is connected to 'x' which is accessible to code in the current isolation context}}
+    mergeFn(y, d)
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Topology: cycle. A redundant edge closes a loop among the carriers.
+// y -- z, z -- w, w -- y, then z -- x.
+//
+// Expect the path answer for whichever route is reported; the redundant edge
+// must not multiply notes or make the walk revisit an element.
+////////////////////////////////////////////////////////////////////////////////
+
+func cycle_close_before_isolate(_ x: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    mergeFn(z, w)
+    mergeFn(w, y)
+    mergeFn(z, x) // expected-note {{'z' is connected to 'x' which is accessible to code in the current isolation context}}
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+func cycle_close_after_isolate(_ x: NS) async {
+    let y = NS()
+    let z = NS()
+    let w = NS()
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    mergeFn(z, w)
+    mergeFn(z, x) // expected-note {{'z' is connected to 'x' which is accessible to code in the current isolation context}}
+    mergeFn(w, y)
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Degenerate merges. Expect these to change nothing.
+////////////////////////////////////////////////////////////////////////////////
+
+// Self merge: exercises the lhs == rhs branch.
+func degenerate_self_merge(_ x: NS) async {
+    let y = NS()
+    let z = NS()
+    mergeFn(y, y)
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    mergeFn(z, x) // expected-note {{'z' is connected to 'x' which is accessible to code in the current isolation context}}
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+// Re-merging two values already in one region. Partition::merge early-returns
+// before pushing history when the regions are equal, so no node should exist
+// and no extra note should appear.
+func degenerate_redundant_merge(_ x: NS) async {
+    let y = NS()
+    let z = NS()
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    mergeFn(y, z)
+    mergeFn(z, x) // expected-note {{'z' is connected to 'x' which is accessible to code in the current isolation context}}
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Survivor modifier. Same topology and ordering as path1, but the isolated
+// value is a local declared AFTER the sent value instead of a parameter.
+//
+// Region labels are region minima, so declaration order picks which side of a
+// merge survives the split -- and only the extracted side's passengers are
+// recorded in the node. Flipping the survivor can make the sent value an
+// unrecorded passenger, absent from the node entirely rather than merely
+// unread. Compare against path1_link_isolate / path1_isolate_link.
+//
+// Whether these actually flip depends on the element numbering the pass
+// assigns, which is worth reading off
+// -Xllvm -sil-regionbasedisolation-log-isolation-history rather than
+// predicting.
+////////////////////////////////////////////////////////////////////////////////
+
+@MainActor func survivor_isolated_declared_last_link_isolate() async {
+    let y = NS()
+    let z = NS()
+    // expected-note@+1{{'x' is connected to result of 'getMainNS()' which is accessible to main actor-isolated code}}
+    let x = getMainNS()
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    mergeFn(z, x) // expected-note {{'z' is connected to 'x'}}
+    await toConcurrent(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending main actor-isolated 'y' to @concurrent global function 'toConcurrent' risks causing data races between @concurrent and main actor-isolated uses}}
+}
+
+@MainActor func survivor_isolated_declared_last_isolate_link() async {
+    let y = NS()
+    let z = NS()
+    // expected-note@+1{{'x' is connected to result of 'getMainNS()' which is accessible to main actor-isolated code}}
+    let x = getMainNS()
+    mergeFn(z, x) // expected-note {{'z' is connected to 'x'}}
+    mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
+    await toConcurrent(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending main actor-isolated 'y' to @concurrent global function 'toConcurrent' risks causing data races between @concurrent and main actor-isolated uses}}
 }

--- a/unittests/SILOptimizer/IsolationHistory.cpp
+++ b/unittests/SILOptimizer/IsolationHistory.cpp
@@ -116,7 +116,7 @@ bool popOnePartitionOp(Partition &p, SmallVectorImpl<SILBasicBlock *> &blocks) {
 // walker assumes when it commits pendingTargetMerge.
 TEST(IsolationHistory, BoundaryAtHead) {
   llvm::BumpPtrAllocator allocator;
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
 
   Partition p(historyFactory.get());
   EXPECT_FALSE(p.hasHistory());
@@ -133,7 +133,7 @@ TEST(IsolationHistory, BoundaryAtHead) {
 // the element stored at firstArg. The returned Node* is the new head.
 TEST(IsolationHistory, PushNewElementRegionPrimitive) {
   llvm::BumpPtrAllocator allocator;
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
 
   IsolationHistory history = historyFactory.get();
   auto *node = history.pushNewElementRegion(Element(7));
@@ -150,7 +150,7 @@ TEST(IsolationHistory, PushNewElementRegionPrimitive) {
 // additionalElementArgs.
 TEST(IsolationHistory, PushMergeElementRegionsPrimitive) {
   llvm::BumpPtrAllocator allocator;
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
 
   IsolationHistory history = historyFactory.get();
   history.pushMergeElementRegions(Element(0), Element(2), {Element(5)});
@@ -172,7 +172,7 @@ TEST(IsolationHistory, PushMergeElementRegionsPrimitive) {
 // An empty singleRegion records nothing — no boundary, no add, no merge.
 TEST(IsolationHistory, SingleRegionEmpty) {
   llvm::BumpPtrAllocator allocator;
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
 
   SILLocation loc = SILLocation::invalid();
   auto p = Partition::singleRegion(loc, {}, historyFactory.get());
@@ -184,7 +184,7 @@ TEST(IsolationHistory, SingleRegionEmpty) {
 // A single element: one boundary + one AddNewRegionForElement, no merges.
 TEST(IsolationHistory, SingleRegionOneElement) {
   llvm::BumpPtrAllocator allocator;
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
 
   SILLocation loc = SILLocation::invalid();
   auto p = Partition::singleRegion(loc, {Element(7)}, historyFactory.get());
@@ -210,7 +210,7 @@ TEST(IsolationHistory, SingleRegionOneElement) {
 // lived in their own region, so each peer needs its own merge node.
 TEST(IsolationHistory, SingleRegionRecordsOneMergePerPeer) {
   llvm::BumpPtrAllocator allocator;
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
 
   SILLocation loc = SILLocation::invalid();
   auto p = Partition::singleRegion(
@@ -229,7 +229,7 @@ TEST(IsolationHistory, SingleRegionRecordsOneMergePerPeer) {
 // nodes cover the non-rep elements without duplicates.
 TEST(IsolationHistory, SingleRegionMergeNodesAreSinglePeer) {
   llvm::BumpPtrAllocator allocator;
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
 
   SILLocation loc = SILLocation::invalid();
   auto p = Partition::singleRegion(
@@ -263,7 +263,7 @@ TEST(IsolationHistory, SingleRegionMergeNodesAreSinglePeer) {
 // already removed.
 TEST(IsolationHistory, SingleRegionRoundTrip) {
   llvm::BumpPtrAllocator allocator;
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
 
   SILLocation loc = SILLocation::invalid();
   auto p = Partition::singleRegion(
@@ -304,7 +304,7 @@ TEST(IsolationHistory, SingleRegionRoundTrip) {
 // know.
 TEST(IsolationHistory, SingleRegionParentChainShape) {
   llvm::BumpPtrAllocator allocator;
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
 
   SILLocation loc = SILLocation::invalid();
   auto p = Partition::singleRegion(
@@ -352,7 +352,7 @@ TEST(IsolationHistory, SingleRegionParentChainShape) {
 // the smallest element. Here indices[0] == 3 but the rep must be 0.
 TEST(IsolationHistory, SingleRegionUnsortedRepIsMinimum) {
   llvm::BumpPtrAllocator allocator;
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
 
   SILLocation loc = SILLocation::invalid();
   auto p = Partition::singleRegion(
@@ -391,7 +391,7 @@ TEST(IsolationHistory, SingleRegionUnsortedRepIsMinimum) {
 #ifndef NDEBUG
 TEST(IsolationHistoryDeathTest, SingleRegionDuplicateIndexAsserts) {
   llvm::BumpPtrAllocator allocator;
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
   SILLocation loc = SILLocation::invalid();
 
   // Element 1 listed twice — caller bug.
@@ -408,7 +408,7 @@ TEST(IsolationHistoryDeathTest, SingleRegionDuplicateIndexAsserts) {
 // that each lives in a distinct region.
 TEST(IsolationHistory, SeparateRegionsShape) {
   llvm::BumpPtrAllocator allocator;
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
 
   SILLocation loc = SILLocation::invalid();
   auto p = makePartitionWithSeparateRegions(
@@ -440,7 +440,7 @@ TEST(IsolationHistory, SeparateRegionsShape) {
 // with — so the round-trip works on today's tree (with distinct indices).
 TEST(IsolationHistory, SeparateRegionsRoundTrip) {
   llvm::BumpPtrAllocator allocator;
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
 
   SILLocation loc = SILLocation::invalid();
   auto p = makePartitionWithSeparateRegions(
@@ -465,7 +465,7 @@ TEST(IsolationHistory, SeparateRegionsRoundTrip) {
 // history is caught.
 TEST(IsolationHistory, JoinPreservesAncestorBoundaryForExistingMerges) {
   llvm::BumpPtrAllocator allocator;
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
 
   SILLocation loc = SILLocation::invalid();
 
@@ -499,7 +499,7 @@ TEST(IsolationHistory, JoinPreservesAncestorBoundaryForExistingMerges) {
 // added to existing region" path, both push the AddNewRegionForElement.
 TEST(IsolationHistory, JoinSecondBranchPushPopAsymmetry) {
   llvm::BumpPtrAllocator allocator;
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
   SILLocation loc = SILLocation::invalid();
 
   // fst tracks only element 0.
@@ -538,7 +538,7 @@ TEST(IsolationHistory, JoinSecondBranchPushPopAsymmetry) {
 TEST(IsolationHistory, CreateVariable) {
   llvm::BumpPtrAllocator allocator;
   Partition::SendingOperandSetFactory factory(allocator);
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
   SmallVector<SILBasicBlock *, 8> joinedHistories;
   SendingOperandToStateMap transferringOpToStateMap(historyFactory);
 
@@ -566,7 +566,7 @@ TEST(IsolationHistory, CreateVariable) {
 TEST(IsolationHistory, AssignRegion) {
   llvm::BumpPtrAllocator allocator;
   Partition::SendingOperandSetFactory factory(allocator);
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
   SendingOperandToStateMap transferringOpToStateMap(historyFactory);
   SmallVector<SILBasicBlock *, 8> joinedHistories;
 
@@ -606,7 +606,7 @@ TEST(IsolationHistory, AssignRegion) {
 TEST(IsolationHistory, BuildNewRegionRepIsMerge) {
   llvm::BumpPtrAllocator allocator;
   Partition::SendingOperandSetFactory factory(allocator);
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
   SendingOperandToStateMap transferringOpToStateMap(historyFactory);
   SmallVector<SILBasicBlock *, 8> joinedHistories;
 
@@ -655,7 +655,7 @@ TEST(IsolationHistory, BuildNewRegionRepIsMerge) {
 TEST(IsolationHistory, ReturnFalseWhenNoneLeft) {
   llvm::BumpPtrAllocator allocator;
   Partition::SendingOperandSetFactory factory(allocator);
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
   SmallVector<SILBasicBlock *, 8> joinedHistories;
   SendingOperandToStateMap transferringOpToStateMap(historyFactory);
 
@@ -681,7 +681,7 @@ TEST(IsolationHistory, JoiningTwoEmpty) {
   // Make sure that we do sane things when we join empty history.
   llvm::BumpPtrAllocator allocator;
   Partition::SendingOperandSetFactory factory(allocator);
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
   SmallVector<SILBasicBlock *, 8> joinedHistories;
 
   Partition p1(historyFactory.get());
@@ -697,7 +697,7 @@ TEST(IsolationHistory, JoiningNotEmptyAndEmpty) {
   // Make sure that we do sane things when we join empty history.
   llvm::BumpPtrAllocator allocator;
   Partition::SendingOperandSetFactory factory(allocator);
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
   SmallVector<SILBasicBlock *, 8> joinedHistories;
   SendingOperandToStateMap transferringOpToStateMap(historyFactory);
 
@@ -723,7 +723,7 @@ TEST(IsolationHistory, JoiningEmptyAndNotEmpty) {
   // Make sure that we do sane things when we join empty history.
   llvm::BumpPtrAllocator allocator;
   Partition::SendingOperandSetFactory factory(allocator);
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
   SendingOperandToStateMap transferringOpToStateMap(historyFactory);
   SmallVector<SILBasicBlock *, 8> joinedHistories;
 
@@ -764,7 +764,7 @@ TEST(IsolationHistory, JoiningEmptyAndNotEmpty) {
 TEST(IsolationHistory, MergePassengerRoundTrip) {
   llvm::BumpPtrAllocator allocator;
   Partition::SendingOperandSetFactory factory(allocator);
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
   SendingOperandToStateMap opToStateMap(historyFactory);
   SmallVector<SILBasicBlock *, 8> joins;
 
@@ -828,7 +828,7 @@ TEST(IsolationHistory, MergePassengerRoundTrip) {
 TEST(IsolationHistory, MergePassengersRejoinOneRegion) {
   llvm::BumpPtrAllocator allocator;
   Partition::SendingOperandSetFactory factory(allocator);
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
   SendingOperandToStateMap opToStateMap(historyFactory);
   SmallVector<SILBasicBlock *, 8> joins;
 
@@ -886,7 +886,7 @@ TEST(IsolationHistory, MergePassengersRejoinOneRegion) {
 TEST(IsolationHistory, AssignDirectMovesElementRoundTrip) {
   llvm::BumpPtrAllocator allocator;
   Partition::SendingOperandSetFactory factory(allocator);
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
   SendingOperandToStateMap opToStateMap(historyFactory);
   SmallVector<SILBasicBlock *, 8> joins;
 

--- a/unittests/SILOptimizer/IsolationHistory.cpp
+++ b/unittests/SILOptimizer/IsolationHistory.cpp
@@ -745,6 +745,136 @@ TEST(IsolationHistory, JoiningEmptyAndNotEmpty) {
   EXPECT_TRUE(result.historySize() == 2);
 }
 
+// Partition::merge moves *every* element of snd's region into fst's region
+// (horizontalUpdate collects them into mergedElements), but the recorded
+// MergeElementRegions node names only the two operands. popHistoryOnce
+// reverses a merge by extracting additionalElementArgs, so an element that
+// came along as a passenger is left behind in fst's region.
+//
+// That stranding is not self-correcting. Extraction only ever moves
+// additionalElementArgs, never getFirstArgAsElement, and merge() orders the
+// node so the operand from the lower-labelled region is the survivor. So the
+// passenger is only pulled back out if some older node happens to name it as
+// its own snd -- and the node that put it in fst's region does not mention it
+// at all.
+//
+// Here {1, 2} is merged into {0}'s region using 2 as the operand, so the node
+// is (0, [2]) and element 1 is the passenger. Rewinding that merge must
+// restore {0} | {1, 2}.
+TEST(IsolationHistory, MergePassengerRoundTrip) {
+  llvm::BumpPtrAllocator allocator;
+  Partition::SendingOperandSetFactory factory(allocator);
+  IsolationHistory::Factory historyFactory(allocator);
+  SendingOperandToStateMap opToStateMap(historyFactory);
+  SmallVector<SILBasicBlock *, 8> joins;
+
+  // Two regions: {1, 2} and {0}. Region labels are the minimum element, so
+  // {1, 2} is labelled 1 and {0} is labelled 0.
+  Partition p(historyFactory.get());
+  {
+    MockedPartitionOpEvaluator eval(p, factory, opToStateMap);
+    eval.apply({PartitionOp::AssignFresh(Element(0)),
+                PartitionOp::AssignFresh(Element(1)),
+                PartitionOp::AssignFresh(Element(2)),
+                PartitionOp::Merge(Element(1), Element(2),
+                                   RegionMergeReason::Unknown)});
+  }
+  Partition snapshot = p;
+
+  {
+    PartitionTester before(p);
+    ASSERT_EQ(before.getRegion(1), before.getRegion(2));
+    ASSERT_NE(before.getRegion(0), before.getRegion(1));
+  }
+
+  // Merge {1, 2} into {0}'s region via operand 2. Since region(0) < region(1),
+  // 0 is the survivor and 2 is the extracted operand; 1 is carried along by
+  // horizontalUpdate without being named in the history node.
+  {
+    MockedPartitionOpEvaluator eval(p, factory, opToStateMap);
+    eval.apply({PartitionOp::Merge(Element(0), Element(2),
+                                   RegionMergeReason::Unknown)});
+  }
+
+  {
+    PartitionTester after(p);
+    ASSERT_EQ(after.getRegion(0), after.getRegion(1));
+    ASSERT_EQ(after.getRegion(0), after.getRegion(2));
+  }
+
+  popOnePartitionOp(p, joins);
+  EXPECT_TRUE(joins.empty());
+
+  PartitionTester rewound(p);
+  EXPECT_EQ(rewound.getRegion(1), rewound.getRegion(2))
+      << "Element 1 was a passenger of the merge and must return to element "
+         "2's region.";
+  EXPECT_NE(rewound.getRegion(0), rewound.getRegion(1))
+      << "Element 1 is stranded in element 0's region: Partition::merge "
+         "recorded only its two operands, so popHistoryOnce extracted 2 and "
+         "left 1 behind.";
+  EXPECT_TRUE(Partition::equals(p, snapshot))
+      << "Merge with a passenger element did not rewind cleanly.";
+}
+
+// The passengers must come back as *one* region, not as singletons. They were
+// region-mates of the extracted operand before the merge, so popHistoryOnce
+// re-merges each of them onto additionalElementArgs[0] after re-tracking it.
+// Dropping that re-merge splits a region the program never split: each
+// passenger would land in a fresh region of its own.
+//
+// Here {1, 2, 3} is merged into {0}'s region using 3 as the operand, so the
+// node is (0, [3, 1, 2]) and rewinding must restore {0} | {1, 2, 3}.
+TEST(IsolationHistory, MergePassengersRejoinOneRegion) {
+  llvm::BumpPtrAllocator allocator;
+  Partition::SendingOperandSetFactory factory(allocator);
+  IsolationHistory::Factory historyFactory(allocator);
+  SendingOperandToStateMap opToStateMap(historyFactory);
+  SmallVector<SILBasicBlock *, 8> joins;
+
+  Partition p(historyFactory.get());
+  {
+    MockedPartitionOpEvaluator eval(p, factory, opToStateMap);
+    eval.apply(
+        {PartitionOp::AssignFresh(Element(0)),
+         PartitionOp::AssignFresh(Element(1)),
+         PartitionOp::AssignFresh(Element(2)),
+         PartitionOp::AssignFresh(Element(3)),
+         PartitionOp::Merge(Element(1), Element(2), RegionMergeReason::Unknown),
+         PartitionOp::Merge(Element(1), Element(3),
+                            RegionMergeReason::Unknown)});
+  }
+  Partition snapshot = p;
+
+  {
+    PartitionTester before(p);
+    ASSERT_EQ(before.getRegion(1), before.getRegion(2));
+    ASSERT_EQ(before.getRegion(1), before.getRegion(3));
+    ASSERT_NE(before.getRegion(0), before.getRegion(1));
+  }
+
+  // 3 is the operand, so 1 and 2 ride along as passengers.
+  {
+    MockedPartitionOpEvaluator eval(p, factory, opToStateMap);
+    eval.apply({PartitionOp::Merge(Element(0), Element(3),
+                                   RegionMergeReason::Unknown)});
+  }
+
+  popOnePartitionOp(p, joins);
+  EXPECT_TRUE(joins.empty());
+
+  PartitionTester rewound(p);
+  EXPECT_EQ(rewound.getRegion(1), rewound.getRegion(2))
+      << "Passengers 1 and 2 were region-mates before the merge and must be "
+         "region-mates again.";
+  EXPECT_EQ(rewound.getRegion(1), rewound.getRegion(3))
+      << "Passengers must rejoin the extracted operand's region, not sit in "
+         "fresh regions of their own.";
+  EXPECT_NE(rewound.getRegion(0), rewound.getRegion(1));
+  EXPECT_TRUE(Partition::equals(p, snapshot))
+      << "Merge with multiple passengers did not rewind cleanly.";
+}
+
 // popHistoryOnce off-by-one when reversing RemoveElementFromRegion:
 // pushRemoveElementFromRegion stores the surviving sibling at
 // additionalElementArgs[0] (the only entry), but popHistoryOnce previously

--- a/unittests/SILOptimizer/PartitionUtilsTest.cpp
+++ b/unittests/SILOptimizer/PartitionUtilsTest.cpp
@@ -123,7 +123,7 @@ SILLocation fakeLoc = SILLocation::invalid();
 TEST(PartitionUtilsTest, TestMergeAndJoin) {
   llvm::BumpPtrAllocator allocator;
   Partition::SendingOperandSetFactory factory(allocator);
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
   SendingOperandToStateMap sendingOpToStateMap(historyFactory);
 
   Partition p1(historyFactory.get());
@@ -252,7 +252,7 @@ TEST(PartitionUtilsTest, TestMergeAndJoin) {
 TEST(PartitionUtilsTest, Join1) {
   llvm::BumpPtrAllocator allocator;
   Partition::SendingOperandSetFactory factory(allocator);
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
   SendingOperandToStateMap transferringOpToStateMap(historyFactory);
 
   Element data1[] = {Element(0), Element(1), Element(2),
@@ -295,7 +295,7 @@ TEST(PartitionUtilsTest, Join1) {
 TEST(PartitionUtilsTest, Join2) {
   llvm::BumpPtrAllocator allocator;
   Partition::SendingOperandSetFactory factory(allocator);
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
   SendingOperandToStateMap transferringOpToStateMap(historyFactory);
 
   Element data1[] = {Element(0), Element(1), Element(2),
@@ -344,7 +344,7 @@ TEST(PartitionUtilsTest, Join2) {
 TEST(PartitionUtilsTest, Join2Reversed) {
   llvm::BumpPtrAllocator allocator;
   Partition::SendingOperandSetFactory factory(allocator);
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
   SendingOperandToStateMap transferringOpToStateMap(historyFactory);
 
   Element data1[] = {Element(0), Element(1), Element(2),
@@ -393,7 +393,7 @@ TEST(PartitionUtilsTest, Join2Reversed) {
 TEST(PartitionUtilsTest, JoinLarge) {
   llvm::BumpPtrAllocator allocator;
   Partition::SendingOperandSetFactory factory(allocator);
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
   SendingOperandToStateMap transferringOpToStateMap(historyFactory);
 
   Element data1[] = {
@@ -534,7 +534,7 @@ TEST(PartitionUtilsTest, JoinLarge) {
 TEST(PartitionUtilsTest, TestAssign) {
   llvm::BumpPtrAllocator allocator;
   Partition::SendingOperandSetFactory factory(allocator);
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
   SendingOperandToStateMap transferringOpToStateMap(historyFactory);
 
   Partition p1(historyFactory.get());
@@ -625,7 +625,7 @@ TEST(PartitionUtilsTest, TestAssign) {
 TEST(PartitionUtilsTest, TestConsumeAndRequire) {
   llvm::BumpPtrAllocator allocator;
   Partition::SendingOperandSetFactory factory(allocator);
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
   SendingOperandToStateMap transferringOpToStateMap(historyFactory);
 
   Partition p(historyFactory.get());
@@ -724,7 +724,7 @@ TEST(PartitionUtilsTest, TestConsumeAndRequire) {
 TEST(PartitionUtilsTest, TestCopyConstructor) {
   llvm::BumpPtrAllocator allocator;
   Partition::SendingOperandSetFactory factory(allocator);
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
   SendingOperandToStateMap transferringOpToStateMap(historyFactory);
 
   Partition p1(historyFactory.get());
@@ -762,7 +762,7 @@ TEST(PartitionUtilsTest, TestCopyConstructor) {
 TEST(PartitionUtilsTest, TestUndoTransfer) {
   llvm::BumpPtrAllocator allocator;
   Partition::SendingOperandSetFactory factory(allocator);
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
   SendingOperandToStateMap transferringOpToStateMap(historyFactory);
 
   Partition p(historyFactory.get());
@@ -780,7 +780,7 @@ TEST(PartitionUtilsTest, TestUndoTransfer) {
 TEST(PartitionUtilsTest, TestLastEltInTransferredRegion) {
   llvm::BumpPtrAllocator allocator;
   Partition::SendingOperandSetFactory factory(allocator);
-  IsolationHistory::Factory historyFactory(allocator);
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
   SendingOperandToStateMap transferringOpToStateMap(historyFactory);
 
   // First make sure that we do this correctly with an assign fresh.

--- a/unittests/SILOptimizer/PartitionUtilsTest.cpp
+++ b/unittests/SILOptimizer/PartitionUtilsTest.cpp
@@ -81,6 +81,8 @@ struct MockedPartitionOpEvaluatorWithFailureCallback final
 
   static SILLocation getLoc(Operand *op) { return SILLocation::invalid(); }
 
+  static SILInstruction *getUser(Operand *op) { return nullptr; }
+
   static SILIsolationInfo getIsolationInfo(const PartitionOp &partitionOp) {
     return {};
   }

--- a/unittests/SILOptimizer/PartitionUtilsTestHelpers.h
+++ b/unittests/SILOptimizer/PartitionUtilsTestHelpers.h
@@ -81,6 +81,8 @@ struct MockedPartitionOpEvaluator final
 
   static SILLocation getLoc(Operand *) { return SILLocation::invalid(); }
 
+  static SILInstruction *getUser(Operand *) { return nullptr; }
+
   static SILIsolationInfo getIsolationInfo(const PartitionOp &) { return {}; }
 
   static SILInstruction *getSourceInst(const PartitionOp &) { return nullptr; }


### PR DESCRIPTION
Isolation-history notes tell the user how a sent value ended up in an isolated
region. They are the chain of "'x' is connected to 'y'" notes that hang off a
sent-non-Sendable error, ending at the value that made the region isolated.

The partition already records everything needed to answer that. It keeps a
history of the region operations that built it, and `popHistoryOnce` undoes those
operations one at a time. The old walk did not really read that history. It kept
one growing set of elements, counted any merge that touched the set as a step,
stopped at the first merge that turned up an isolated element, then sorted the
notes by line number and pointed every note at that one spot. Sorting by line
number guesses at the answer instead of reading it, so several common shapes came
out wrong. It was an experiment that did not work out.

This PR replaces that walk with one that rewinds the history for real. It also
adds the naming support the new notes need, and then three follow-up commits that
shrink the walk's per-fork state and tidy its structure.

## Scope of the rollout

The whole feature stays behind the existing gate: either the
`-sil-region-isolation-emit-isolation-history` frontend flag, or
`@diagnose(RegionIsolationIsolationHistory, as: <not ignored>)` on a single
decl. Nothing changes for a normal compile.

Within that gate, the notes are still wired into exactly one error class:
`SentNeverSendable`. The other region-isolation errors — `LocalUseAfterSend`,
`InOutSendingNotDisconnectedAtExit`, `InOutSendingReturned`,
`AssignNeverSendableIntoSendingResult`,
`InOutSendingParametersInSameRegion` — get no history notes yet.

That is deliberate. I wanted one query working end to end, on a large test suite,
before wiring up the rest. The walk is built around a general question — "how
does this element reach that one" — rather than around anything specific to
sending. Each of the other errors is a different starting question over the same
history, so rolling them out should mean seeding a different first question and
picking diagnostic wording, not writing another walk. I plan to do them in
follow-up PRs, one error class at a time.
