### PR TITLE
LifetimeResolution: initial implementation

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
@@ -34,6 +34,7 @@ swift_compiler_sources(Optimizer
   LifetimeDependenceDiagnostics.swift
   LifetimeDependenceInsertion.swift
   LifetimeDependenceScopeFixup.swift
+  LifetimeResolution.swift
   LoopInvariantCodeMotion.swift
   ObjectOutliner.swift
   ObjCBridgingOptimization.swift
@@ -43,6 +44,7 @@ swift_compiler_sources(Optimizer
   NamedReturnValueOptimization.swift
   RedundantLoadElimination.swift
   ReleaseDevirtualizer.swift
+  RemoveSILGenLifetimes.swift
   SimplificationPasses.swift
   StackPromotion.swift
   StripObjectHeaders.swift

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/DestroyHoisting.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/DestroyHoisting.swift
@@ -107,7 +107,7 @@ private func optimize(value: Value, _ context: FunctionPassContext) {
   }
   defer { minimalLiverange.deinitialize() }
 
-  hoistDestroys(of: value, toEndOf: minimalLiverange, restrictingTo: &hoistableDestroys, context)
+  placeDestroys(of: value, atBoundaryOf: minimalLiverange, reusing: &hoistableDestroys, context)
 }
 
 private func selectHoistableDestroys(of value: Value, _ context: FunctionPassContext) -> (Bool, InstructionSet) {
@@ -130,66 +130,87 @@ private func selectHoistableDestroys(of value: Value, _ context: FunctionPassCon
   return (foundDestroys, hoistableDestroys)
 }
 
-private func hoistDestroys(of value: Value,
-                           toEndOf minimalLiverange: InstructionRange,
-                           restrictingTo hoistableDestroys: inout InstructionSet,
-                           _ context: FunctionPassContext)
+/// Places the scope-ending instructions of `value` at the boundary of `liverange`.
+///
+/// Ends move in either direction: when `liverange` reaches beyond the existing ends they sink.
+/// `isEnd` recognizes an existing end among `value`'s uses and `createEnd` emits a new one at the
+/// builder's insertion point; parameterizing both is what lets this place `end_access` as well as
+/// `destroy_value`. Ends in `reusableEnds` are kept where the boundary already falls on them and
+/// erased otherwise.
+internal func placeScopeEnds(of value: Value,
+                             atBoundaryOf liverange: InstructionRange,
+                             reusing reusableEnds: inout InstructionSet,
+                             isEnd: (Operand) -> Bool,
+                             createEnd: (Builder) -> (),
+                             _ context: FunctionPassContext)
 {
-  // The liverange, excluding regions which end up in `destroy_value [dead_end]`.
-  var nonDeadEndRange = BasicBlockRange(begin: value.parentBlock, context)
-  defer { nonDeadEndRange.deinitialize() }
-  nonDeadEndRange.insert(contentsOf: value.uses.users(ofType: DestroyValueInst.self)
-                                          .filter{ !$0.isDeadEnd }.map { $0.parentBlock })
+  createEnds(for: value, atEndPointsOf: liverange, reusing: &reusableEnds,
+             isEnd: isEnd, createEnd: createEnd, context)
 
-  createNewDestroys(for: value, atEndPointsOf: minimalLiverange, reusing: &hoistableDestroys,
-                    nonDeadEndRange: nonDeadEndRange, context)
+  createEnds(for: value, atExitPointsOf: liverange, reusing: &reusableEnds,
+             createEnd: createEnd, context)
 
-  createNewDestroys(for: value, atExitPointsOf: minimalLiverange, reusing: &hoistableDestroys,
-                    nonDeadEndRange: nonDeadEndRange, context)
-
-  removeDestroys(of: value, restrictingTo: hoistableDestroys, context)
+  removeEnds(of: value, restrictingTo: reusableEnds, isEnd: isEnd, context)
 }
 
-private func createNewDestroys(
+/// Places `destroy_value`s of the owned `value` at the boundary of `liverange`.
+internal func placeDestroys(of value: Value,
+                            atBoundaryOf liverange: InstructionRange,
+                            reusing reusableDestroys: inout InstructionSet,
+                            _ context: FunctionPassContext)
+{
+  let deadEndBlocks = context.deadEndBlocks
+  placeScopeEnds(of: value, atBoundaryOf: liverange, reusing: &reusableDestroys,
+                 isEnd: { $0.endsLifetime },
+                 createEnd: {
+                   $0.createDestroyValue(operand: value,
+                                         isDeadEnd: deadEndBlocks.isDeadEnd($0.insertionBlock!))
+                 },
+                 context)
+}
+
+private func createEnds(
   for value: Value,
   atEndPointsOf liverange: InstructionRange,
-  reusing hoistableDestroys: inout InstructionSet,
-  nonDeadEndRange: BasicBlockRange,
+  reusing reusableEnds: inout InstructionSet,
+  isEnd: (Operand) -> Bool,
+  createEnd: (Builder) -> (),
   _ context: FunctionPassContext
 ) {
   for endInst in liverange.ends {
-    if !endInst.endsLifetime(of: value) {
-      Builder.insert(after: endInst, context) { builder in
-        builder.createDestroy(of: value, reusing: &hoistableDestroys, nonDeadEndRange: nonDeadEndRange)
-      }
+    if endInst.operands.contains(where: { $0.value == value && isEnd($0) }) {
+      // The boundary already falls on an end of `value`. Keep that one instead of adding a
+      // duplicate next to it, and don't let `removeEnds` erase it.
+      reusableEnds.erase(endInst)
+      continue
+    }
+    Builder.insert(after: endInst, context) { builder in
+      builder.createEnd(reusing: &reusableEnds, createEnd)
     }
   }
 }
 
-private func createNewDestroys(
+private func createEnds(
   for value: Value,
   atExitPointsOf liverange: InstructionRange,
-  reusing hoistableDestroys: inout InstructionSet,
-  nonDeadEndRange: BasicBlockRange,
+  reusing reusableEnds: inout InstructionSet,
+  createEnd: (Builder) -> (),
   _ context: FunctionPassContext
 ) {
   for exitBlock in liverange.exitBlocks {
     let builder = Builder(atBeginOf: exitBlock, context)
-    builder.createDestroy(of: value, reusing: &hoistableDestroys, nonDeadEndRange: nonDeadEndRange)
+    builder.createEnd(reusing: &reusableEnds, createEnd)
   }
 }
 
-private func removeDestroys(
+private func removeEnds(
   of value: Value,
-  restrictingTo hoistableDestroys: InstructionSet,
+  restrictingTo reusableEnds: InstructionSet,
+  isEnd: (Operand) -> Bool,
   _ context: FunctionPassContext
 ) {
-  for use in value.uses {
-    if let destroy = use.instruction as? DestroyValueInst,
-       hoistableDestroys.contains(destroy)
-    {
-      context.erase(instruction: destroy)
-    }
+  for use in value.uses where isEnd(use) && reusableEnds.contains(use.instruction) {
+    context.erase(instruction: use.instruction)
   }
 }
 
@@ -302,17 +323,14 @@ private func isTakeOrDestroy(
 }
 
 private extension Builder {
-  func createDestroy(of value: Value,
-                     reusing hoistableDestroys: inout InstructionSet,
-                     nonDeadEndRange: BasicBlockRange) {
+  func createEnd(reusing reusableEnds: inout InstructionSet, _ createEnd: (Builder) -> ()) {
     guard case .before(let insertionPoint) = insertionPoint else {
       fatalError("unexpected kind of insertion point")
     }
-    if hoistableDestroys.contains(insertionPoint) {
-      hoistableDestroys.erase(insertionPoint)
+    if reusableEnds.contains(insertionPoint) {
+      reusableEnds.erase(insertionPoint)
     } else {
-      createDestroyValue(operand: value,
-                         isDeadEnd: !nonDeadEndRange.inclusiveRangeContains(insertionPoint.parentBlock))
+      createEnd(self)
     }
   }
 }

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
@@ -1104,7 +1104,7 @@ private extension BeginApplyInst {
 /// Visit all dependent uses.
 ///
 /// Set 'dependsOnCaller' if a use escapes the function.
-private struct LifetimeDependentUseWalker : LifetimeDependenceDefUseWalker {
+internal struct LifetimeDependentUseWalker : LifetimeDependenceDefUseWalker {
   let function: Function
   let context: Context
   let visitor: (Instruction) -> WalkResult

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeResolution.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeResolution.swift
@@ -1,0 +1,441 @@
+//===--- LifetimeResolution.swift -----------------------------------------==//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import AST
+import SIL
+
+private func log(_ message: @autoclosure () -> String) {
+  llvmDebug("lifetime-resolution", message())
+}
+
+let lifetimeResolutionPass = FunctionPass(name: "lifetime-resolution") {
+  (function: Function, context: FunctionPassContext) in
+
+  guard function.hasOwnership else { return }
+
+  // Process results in reverse post-order to ensure dependent uses are already resolved.
+  // TODO: resolve `.guaranteed` values too. It should amount to having all consuming uses
+  //   require a copy, including those on the boundary, and inserting end_access/end_borrow.
+  for block in function.blocks.reversed() {
+    for inst in block.instructions.reversed() {
+      for result in inst.results where result.ownership == .owned {
+        resolve(result, context)
+      }
+    }
+    for argument in block.arguments where argument.ownership == .owned {
+      resolve(argument, context)
+    }
+  }
+}
+
+private func resolve(_ root: Value, _ context: FunctionPassContext) {
+  // TODO: A trivial-typed value has no lifetime to resolve at the moment.
+  if root.type.isTrivial(in: root.parentFunction) {
+    return
+  }
+
+  log("\n\nLifetimeResolution.resolve(\(root))\n\n")
+
+  var uses = PartitionedUses(of: root, context)
+  defer { uses.deinitialize() }
+
+  // Step 0: Find and partition uses of the values.
+  uses.partitionUses()
+
+  log(uses.description)
+
+  // If there are absolutely no liveness uses, there's nothing to do.
+  guard uses.haveLivenessUses() else {
+    // TODO: Eventually this pass should ensure a destroy is placed right after the def.
+    return
+  }
+
+  // Step 1: Resolve where copies are required to ensure there are no consumes before uses.
+  var liverange = uses.insertCopies()
+  defer { liverange.deinitialize() }
+
+
+  // Step 2: Insert destroys after non-consuming boundary users, using the same liverange.
+  guard !uses.hasUnboundedUse else {
+    // TODO: for now, trust SILGen's placement of destroy_value.
+    //  We probably should extend liveness until scope-ends.
+    log("not placing destroys: liveness is not bounded")
+    return
+  }
+
+  var hoistableDestroys: InstructionSet = InstructionSet(context)
+  defer { hoistableDestroys.deinitialize() }
+  hoistableDestroys.insert(contentsOf: uses.lifetimeLimits)
+
+  log("replacing destroys: \(hoistableDestroys)")
+  placeDestroys(of: root, atBoundaryOf: liverange, reusing: &hoistableDestroys, context)
+}
+
+private struct PartitionedUses: CustomStringConvertible {
+  // The uses of this value that are partitioned.
+  let root: Value
+
+  let context: FunctionPassContext
+
+  // Lifetime delimiting instructions.
+  //
+  // These instructions represent the limits of permitted liveness for the value,
+  // if otherwise not consumed upon reaching the instruction.
+  // TODO: these should be some sort of new end_scope instruction that are used to limit how late
+  //  a destroy/end_access can be inserted.
+  var lifetimeLimits: Stack<DestroyValueInst>
+
+  // Uses that require ownership of the value (not guaranteed).
+  var consumes: Stack<Operand>
+
+  // These are indirect uses of the root, including deinit barriers and dependent uses.
+  var indirectUses: Stack<Instruction>
+
+  // Uses that otherwise do not fit into the other buckets.
+  var uses: Stack<Operand>
+
+  // Set when some use's contribution to liveness could not be bounded, so that liveness must be
+  // fully extended to lifetimeLimits, rather than hoisted above an unseen use.
+  var hasUnboundedUse = false
+
+  let localReachabilityCache = LocalVariableReachabilityCache()
+
+  init(of root: Value, _ context: FunctionPassContext) {
+    self.root = root
+    self.context = context
+    self.consumes = Stack(context)
+    self.lifetimeLimits = Stack(context)
+    self.uses = Stack(context)
+    self.indirectUses = Stack(context)
+  }
+
+  mutating func deinitialize() {
+    consumes.deinitialize()
+    lifetimeLimits.deinitialize()
+    uses.deinitialize()
+    indirectUses.deinitialize()
+  }
+
+  // After partitioning, are there any non-destroy uses?
+  func haveLivenessUses() -> Bool { !uses.isEmpty || !indirectUses.isEmpty || !consumes.isEmpty }
+
+  var description: String {
+    return """
+           PartitionedUses of: \(root)) [
+             uses = \(uses)
+             consumes = \(consumes)
+             indirectUses = \(indirectUses)
+             hasUnboundedUse = \(hasUnboundedUse)
+           ]
+           """
+  }
+
+  mutating func partitionUses() {
+    // TODO: should we use an InteriorUseWalker or some other robust walker?
+    for use in root.uses {
+      switch (use.ownership) {
+      case .destroyingConsume:
+        fallthrough
+      case .forwardingConsume:
+        // Perhaps Operand.isScopeEndingUse or Operand.endsLifetime is also useful here?
+        if let destroy = use.instruction as? DestroyValueInst {
+          lifetimeLimits.append(destroy)
+          continue
+        }
+
+        consumes.append(use)
+
+      default:
+        collectUse(use)
+      }
+    }
+
+    // Only lexical roots need to include deinit barriers.
+    // TODO: study https://gist.github.com/atrick/cc03c4d07fb0a7bee92c223ae5e5695b and the current implementation
+    //   to tailor destroy insertion correctly for non-copyable types.
+    if root.isInLexicalLiverange(context) {
+      addDeinitBarriers(of: root)
+    }
+  }
+
+  // A use that opens a scope keeps the value live until that scope closes, so record the
+  // scope-ending uses in its place: they post-dominate the opening use, so they alone
+  // delimit the liveness it contributes.
+  private mutating func collectUse(_ use: Operand) {
+    let borrowInst = BorrowingInstruction(use.instruction)
+    if let borrowInst = borrowInst,
+       collectScopeEnds(of: borrowInst) {
+      return
+    }
+
+    uses.append(use)
+
+    if let markDep = use.instruction as? MarkDependenceInstruction,
+       use == markDep.baseOperand {
+      collectDependentUses(of: markDep)
+    } else if borrowInst != nil {
+      // The scope can't be determined from lifetime-ending uses and isn't a dependence we can
+      // walk, so liveness past this use is unknown.
+      hasUnboundedUse = true
+    }
+  }
+
+  // Records the instructions closing borrowInst's scope. Returns true if we were able to find
+  // all scope ends. Otherwise, there may be escaping dependency or unhandled mark_dependence.
+  private mutating func collectScopeEnds(of borrowInst: BorrowingInstruction) -> Bool {
+    // TODO: remove this stack by changing visitScopeEndingOperands to take a non-escaping
+    // closure, as visitInnerBorrowUses also wants.
+    var ends = Stack<Instruction>(context)
+    defer { ends.deinitialize() }
+    let result = borrowInst.visitScopeEndingOperands(context) {
+      ends.push($0.instruction)
+      return .continueWalk
+    }
+    guard result == .continueWalk else {
+      return false
+    }
+    indirectUses.append(contentsOf: ends)
+    return true
+  }
+
+  // The value depending on `markDep` keeps the root alive through its own uses, which are not
+  // uses of the root. Record them so that liveness respects them.
+  private mutating func collectDependentUses(of markDep: MarkDependenceInstruction) {
+    guard let dependence = LifetimeDependence(markDep, context) else {
+      hasUnboundedUse = true
+      return
+    }
+    // The walker only tracks ~Escapable and @noescape dependents; for anything else it reports
+    // success having collected nothing.
+    guard !dependence.dependentValue.mayEscape else {
+      hasUnboundedUse = true
+      return
+    }
+    var dependentUses = Stack<Instruction>(context)
+    defer { dependentUses.deinitialize() }
+    var walker = LifetimeDependentUseWalker(root.parentFunction, localReachabilityCache, context) {
+      dependentUses.push($0)
+      return .continueWalk
+    }
+    defer { walker.deinitialize() }
+    if walker.walkDown(dependence: dependence) == .abortWalk {
+      hasUnboundedUse = true
+    }
+    indirectUses.append(contentsOf: dependentUses)
+  }
+
+  private mutating func addDeinitBarriers(of root: Value) {
+    var liverange = InstructionRange(for: root, context)
+    defer { liverange.deinitialize() }
+
+    liverange.insert(contentsOf: consumes.users)
+    liverange.insert(contentsOf: uses.users)
+
+    collectDeinitBarriers(into: &indirectUses, liverange: liverange,
+      lifetimeLimits: lifetimeLimits, def: root, context)
+  }
+
+  // We do this by computing the LiveRange of only the non-destroy / non-scope-ending
+  // uses. This lets us see which consuming uses are within the live range, rather
+  // than on the boundary of its liveness (i.e., last use). Those inner consuming uses
+  // are exactly where copies are required.
+  //
+  //                  ┌─────────┐
+  //               ┌──┼ x = ... ┼──┐
+  //               │  └─────────┘  │
+  //               │               │
+  //            ┌──▼───────┐  ┌────▼─────┐
+  // boundary ─►│consume(x)│  │consume(x)│
+  //            └──────┬───┘  │use(x)    │◄─ boundary
+  //                   │      └─┬────────┘
+  //                   │        │
+  //                  ┌▼────────▼┐
+  //                  │destroy(x)│
+  //                  └──────────┘
+  //
+  //                       │  After copy resolution, consumes appear
+  //                       │  only on the boundary, if at all.
+  //                       ▼
+  //
+  //                  ┌─────────┐
+  //               ┌──┼ x = ... ┼──┐
+  //               │  └─────────┘  │
+  //               │               │
+  //            ┌──▼───────┐  ┌────▼──────┐
+  // boundary ─►│consume(x)│  │y = copy(x)│
+  //            └──────┬───┘  │consume(y) │
+  //                   │      │use(x)     │◄─ boundary
+  //                   │      └─┬─────────┘
+  //                   │        │
+  //                  ┌▼────────▼┐
+  //                  │destroy(x)│
+  //                  └──────────┘
+  //
+  // Crucially, the live range of certain roots includes deinit barriers,
+  // which causes some final consumes to need a copy anyway:
+  //
+  // Liveness before insertion for some lexical roots:
+  //       ┌─────────┐
+  //    ┌──┼ x = ... ┼──┐
+  //    │  └─────────┘  │
+  //    │               │
+  // ┌──▼───────┐  ┌────▼─────┐
+  // │consume(x)│  │use(x)    │
+  // └──────┬───┘  └─┬────────┘
+  //        │        │
+  //        │        │
+  //       ┌▼────────▼┐
+  //       │barrier() │ ◄─ liveness boundary of x
+  //       │destroy(x)│
+  //       └──────────┘
+  //
+  //
+  // Since the consume is interior with respect to this
+  // deinit-barrier extended liveness, it consumes a copy instead:
+  //        ┌─────────┐
+  //     ┌──┼ x = ... ┼──┐
+  //     │  └─────────┘  │
+  //     │               │
+  //  ┌──▼───────┐  ┌────▼─────┐
+  //  │y = copy x│  │use(x)    │
+  //  │consume(y)│  └─┬────────┘
+  //  └──────┬───┘    │
+  //         │        │
+  //        ┌▼────────▼┐
+  //        │barrier() │ ◄─ boundary
+  //        │destroy(x)│
+  //        └──────────┘
+  mutating func insertCopies() -> InstructionRange {
+    // TODO: reuse the InstructionRange from `addDeinitBarriers` if it was computed?
+    var liverange = InstructionRange(for: root, context)
+
+    // Omit the destroys from the liverange during copy resolution. They're hoisted afterwards.
+    liverange.insert(contentsOf: consumes.users)
+    liverange.insert(contentsOf: uses.users)
+    liverange.insert(contentsOf: indirectUses)  // Deinit barriers must be treated as uses.
+    if hasUnboundedUse {
+      // Liveness past an unbounded use is unknown, so the extend liveness to scope-ends.
+      liverange.insert(contentsOf: lifetimeLimits)
+    }
+    log("liverange during insertCopies:\n\(liverange)")
+
+    // If there's no consumes, there's no copies to insert.
+    if consumes.isEmpty {
+      return liverange
+    }
+
+    // Convert the set of *all* consumes into a set that only contains *boundary* consumes.
+    var boundaryConsumes: Stack<Operand> = Stack(context)
+    while let cons = consumes.pop() {
+      // TODO: how to handle consume and use within the same instruction efficiently?
+      // It's effectively when the instructions among the 'consumes' overlap with each other, or with any overlap with
+      // the instructions in the 'consumes' set.
+      if liverange.contains(cons.instruction) {
+        log("will insert a copy for operand: \(cons) to convert this into a non-consuming use: \(cons.instruction)")
+        replaceWithCopy(cons, context)
+        uses.append(cons)
+        continue
+      }
+
+      boundaryConsumes.push(cons)
+    }
+    consumes.deinitialize()
+    consumes = boundaryConsumes
+
+    // NOTE: this returned liverange doesn't accurately reflect the Operand.user instructions whose consuming use was
+    // replaced with a copy!
+    return liverange
+  }
+}
+
+// Collects all deinit barriers that exist on any path from the given lifetimeLimits towards the
+// definition, stopping at the boundary of `liverange`.
+private func collectDeinitBarriers(
+  into barriers: inout Stack<Instruction>,
+  liverange: InstructionRange,
+  lifetimeLimits: Stack<DestroyValueInst>,
+  def: Value,
+  _ context: FunctionPassContext
+) {
+  log("liverange during collectDeinitBarriers:\n\(liverange)")
+
+  let calleeAnalysis = context.calleeAnalysis
+  let defInst = def.definingInstruction
+  let defBlock = def.parentBlock
+
+  enum ScanResult {
+    case foundBarrier(Instruction)
+    case hitBoundary
+    case exhausted
+  }
+
+  // Scans backward within a single block, starting at (and including) `first`.
+  // A block argument has no defining instruction, so running out of instructions in its
+  // block is itself the boundary.
+  func scan(from first: Instruction?, in block: BasicBlock) -> ScanResult {
+    for inst in ReverseInstructionList(first: first) {
+      if inst == defInst || liverange.inclusiveRangeContains(inst) {
+        return .hitBoundary
+      }
+      if inst.isDeinitBarrier(calleeAnalysis) {
+        return .foundBarrier(inst)
+      }
+    }
+    return block == defBlock ? .hitBoundary : .exhausted
+  }
+
+  var worklist = BasicBlockWorklist(context)
+  defer { worklist.deinitialize() }
+
+  for destroy in lifetimeLimits {
+    // Scan the block containing this lifetime limit backwards, stopping the first time we find either
+    //  - a deinit barrier
+    //  - a current boundary of liveness
+    switch scan(from: destroy.previous, in: destroy.parentBlock) {
+    case .foundBarrier(let barrier):
+      barriers.append(barrier)
+      continue
+    case .hitBoundary:
+      continue
+    case .exhausted:
+      break
+    }
+
+    // If the same block had no barrier or liveness boundary; keep walking
+    // backward into unvisited predecessor blocks.
+    worklist.pushIfNotVisited(contentsOf: destroy.parentBlock.predecessors)
+
+    while let block = worklist.pop() {
+      switch scan(from: block.terminator, in: block) {
+      case .foundBarrier(let barrier):
+        barriers.append(barrier)
+      case .hitBoundary:
+        break
+      case .exhausted:
+        worklist.pushIfNotVisited(contentsOf: block.predecessors)
+      }
+    }
+  }
+}
+
+// Given an operand in the consume set, convert its use into a copy.
+private func replaceWithCopy(_ op: Operand, _ context: FunctionPassContext) {
+  let builder = Builder(before: op.instruction, context)
+  let copyValue = builder.createCopyValue(operand: op.value)
+  op.set(to: copyValue, context)
+}
+
+let lifetimeResolutionResolveTest = FunctionTest("lifetime_resolution_resolve") {
+  function, arguments, context in
+  let root = arguments.takeValue()
+  resolve(root, context)
+}

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/RemoveSILGenLifetimes.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/RemoveSILGenLifetimes.swift
@@ -1,0 +1,38 @@
+//===--- RemoveSILGenLifetimes.swift -----------------------------------------==//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SIL
+
+// Until SILGen gets out of the business of trying to manage lifetimes, we
+// clean and remove instructions so that lifetimes can derived from solely from
+// uses during LifetimeResolution.
+let removeSILGenLifetimesPass = FunctionPass(name: "remove-silgen-lifetimes") {
+  (function: Function, context: FunctionPassContext) in
+
+  func processInst(_ inst: Instruction) {
+    switch inst {
+    // TODO: until LifetimeResolution handles copies of guaranteed values,
+    //  limit deletion to copies of owned values.
+    case let copy as CopyValueInst where copy.operand.value.ownership == .owned:
+      copy.replace(with: copy.operand.value, context)
+
+    default:
+      return
+    }
+  }
+
+  for block in function.blocks {
+    for inst in block.instructions {
+      processInst(inst)
+    }
+  }
+}

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -113,6 +113,8 @@ private func registerSwiftPasses() {
   registerPass(lifetimeDependenceDiagnosticsPass, { lifetimeDependenceDiagnosticsPass.run($0) })
   registerPass(lifetimeDependenceInsertionPass, { lifetimeDependenceInsertionPass.run($0) })
   registerPass(lifetimeDependenceScopeFixupPass, { lifetimeDependenceScopeFixupPass.run($0) })
+  registerPass(removeSILGenLifetimesPass, { removeSILGenLifetimesPass.run($0) })
+  registerPass(lifetimeResolutionPass, { lifetimeResolutionPass.run($0) })
   registerPass(copyToBorrowOptimization, { copyToBorrowOptimization.run($0) })
   registerPass(tempRValueElimination, { tempRValueElimination.run($0) })
   registerPass(mandatoryTempRValueElimination, { mandatoryTempRValueElimination.run($0) })

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/Test.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/Test.swift
@@ -65,6 +65,7 @@ public func registerOptimizerTests() {
     lifetimeDependenceRootTest,
     lifetimeDependenceScopeTest,
     lifetimeDependenceUseTest,
+    lifetimeResolutionResolveTest,
     linearLivenessTest,
     localVariableReachableUsesTest,
     localVariableReachingAssignmentsTest,

--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -149,6 +149,9 @@ public:
   /// Enables SIL-level diagnostics for NonescapableTypes.
   bool EnableLifetimeDependenceDiagnostics = true;
 
+  /// Enables the LifetimeResolution passes and infrastructure.
+  bool EnableLifetimeResolution = false;
+
   /// Enable diagnostics requiring WMO (for @noLocks, @noAllocation
   /// annotations, Embedded Swift, and class specialization). SourceKit is the
   /// only consumer that has this disabled today (as it disables WMO

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1533,6 +1533,13 @@ def disable_lifetime_dependence_diagnostics :
   Flag<["-"], "disable-lifetime-dependence-diagnostics">,
   HelpText<"Disable lifetime dependence diagnostics for Nonescapable types.">;
 
+def enable_lifetime_resolution :
+  Flag<["-"], "enable-lifetime-resolution">,
+  HelpText<"Enable lifetime resolution in SIL.">;
+def disable_lifetime_resolution :
+  Flag<["-"], "disable-lifetime-resolution">,
+  HelpText<"Disable lifetime resolution in SIL.">;
+
 def enable_aggressive_reg2mem :
   Flag<["-"], "enable-aggressive-reg2mem">,
   HelpText<"Enable a more aggressive reg2mem heuristic">;

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -110,6 +110,10 @@ PASS(LifetimeDependenceInsertion,
 PASS(LifetimeDependenceScopeFixup,
      "lifetime-dependence-scope-fixup",
      "Fixup scope for lifetime dependence")
+PASS(RemoveSILGenLifetimes, "remove-silgen-lifetimes",
+     "Remove SILGen's lifetimes in preparation for LifetimeResolution")
+PASS(LifetimeResolution, "lifetime-resolution",
+     "Resolve lifetimes based on uses")
 PASS(MergeBorrowScopes, "merge-borrow-scopes",
      "Merge borrow scopes")
 PASS(MergeCondFails, "merge-cond_fails",

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3352,6 +3352,10 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
       Args.hasFlag(OPT_enable_lifetime_dependence_diagnostics,
                    OPT_disable_lifetime_dependence_diagnostics,
                    Opts.EnableLifetimeDependenceDiagnostics);
+  Opts.EnableLifetimeResolution =
+      Args.hasFlag(OPT_enable_lifetime_resolution,
+                   OPT_disable_lifetime_resolution,
+                   Opts.EnableLifetimeResolution);
 
   Opts.VerifyAll |= Args.hasArg(OPT_sil_verify_all);
   Opts.VerifyNone |= Args.hasArg(OPT_sil_verify_none);

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -307,6 +307,16 @@ SILPassPipelinePlan::getSILGenPassPipeline(const SILOptions &Options) {
   P.startPipeline("SILGen Passes");
 
   P.addSILGenCleanup();
+
+  if (P.getOptions().EnableLifetimeResolution) {
+    if (P.getOptions().EnableLifetimeDependenceDiagnostics)
+      P.addLifetimeDependenceInsertion();
+
+    P.addRemoveSILGenLifetimes();
+    P.addLifetimeResolution();
+    return P;
+  }
+
   if (P.getOptions().EnableLifetimeDependenceDiagnostics) {
     P.addLifetimeDependenceInsertion();
     P.addLifetimeDependenceScopeFixup();

--- a/test/SILOptimizer/lifetime_resolution_resolve_markdep.sil
+++ b/test/SILOptimizer/lifetime_resolution_resolve_markdep.sil
@@ -1,0 +1,260 @@
+// RUN: %target-sil-opt %s -test-runner -sil-verify-none \
+// RUN:   -enable-experimental-feature Lifetimes \
+// RUN:   | %FileCheck %s
+
+// REQUIRES: swift_feature_Lifetimes
+
+// `mark_dependence` coverage for `lifetime_resolution_resolve`.
+
+sil_stage raw
+
+import Builtin
+import Swift
+
+class Kl {}
+
+struct NE : ~Escapable {
+  var p: UnsafeRawPointer
+
+  @_lifetime(immortal)
+  init()
+}
+
+sil @getK : $@convention(thin) () -> @owned Kl
+sil @consumeK : $@convention(thin) (@owned Kl) -> ()
+sil @useRawPtr : $@convention(thin) (Builtin.RawPointer) -> ()
+sil @makeNE : $@convention(thin) (@guaranteed Kl) -> @lifetime(borrow 0) @owned NE
+sil @useNE : $@convention(thin) (@guaranteed NE) -> ()
+
+
+// A bare `mark_dependence` is [escaping]: the dependent value's uses cannot be enumerated, so
+// the destroy stays put instead of hoisting to the mark_dependence.
+
+// CHECK-LABEL: sil [ossa] @test_markdep_escaping :
+// CHECK:      [[V:%.*]] = apply {{%.*}}() : $@convention(thin) () -> @owned Kl
+// CHECK:      [[DEP:%.*]] = mark_dependence {{%.*}} on [[V]]
+// CHECK-NEXT: apply {{%.*}}([[DEP]]) : $@convention(thin) (Builtin.RawPointer) -> ()
+// CHECK-NEXT: destroy_value [[V]]
+// CHECK-LABEL: } // end sil function
+sil [ossa] @test_markdep_escaping : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %usePtrFn = function_ref @useRawPtr : $@convention(thin) (Builtin.RawPointer) -> ()
+  %0 = apply %getFn() : $@convention(thin) () -> @owned Kl
+  specify_test "lifetime_resolution_resolve %0"
+  %ptr = ref_to_raw_pointer %0 to $Builtin.RawPointer
+  %dep = mark_dependence %ptr on %0
+  apply %usePtrFn(%dep) : $@convention(thin) (Builtin.RawPointer) -> ()
+  destroy_value %0
+  %t = tuple ()
+  return %t
+}
+
+
+// [unresolved] with an Escapable dependent.
+
+// CHECK-LABEL: sil [ossa] @test_markdep_unresolved_trivial :
+// CHECK:      [[V:%.*]] = apply {{%.*}}() : $@convention(thin) () -> @owned Kl
+// CHECK:      [[DEP:%.*]] = mark_dependence [unresolved] {{%.*}} on [[V]]
+// CHECK-NEXT: apply {{%.*}}([[DEP]]) : $@convention(thin) (Builtin.RawPointer) -> ()
+// CHECK-NEXT: destroy_value [[V]]
+// CHECK-LABEL: } // end sil function
+sil [ossa] @test_markdep_unresolved_trivial : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %usePtrFn = function_ref @useRawPtr : $@convention(thin) (Builtin.RawPointer) -> ()
+  %0 = apply %getFn() : $@convention(thin) () -> @owned Kl
+  specify_test "lifetime_resolution_resolve %0"
+  %ptr = ref_to_raw_pointer %0 to $Builtin.RawPointer
+  %dep = mark_dependence [unresolved] %ptr on %0
+  apply %usePtrFn(%dep) : $@convention(thin) (Builtin.RawPointer) -> ()
+  destroy_value %0
+  %t = tuple ()
+  return %t
+}
+
+
+// [unresolved] with a ~Escapable dependent: the uses are enumerable.
+
+// CHECK-LABEL: sil [ossa] @test_markdep_unresolved_ne :
+// CHECK:      [[V:%.*]] = apply {{%.*}}() : $@convention(thin) () -> @owned Kl
+// CHECK:      [[DEP:%.*]] = mark_dependence [unresolved] {{%.*}} on [[V]]
+// CHECK-NEXT: apply {{%.*}}([[DEP]]) : $@convention(thin) (@guaranteed NE) -> ()
+// CHECK-NEXT: destroy_value [[DEP]]
+// CHECK-NEXT: destroy_value [[V]]
+// CHECK-LABEL: } // end sil function
+sil [ossa] @test_markdep_unresolved_ne : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %makeFn = function_ref @makeNE : $@convention(thin) (@guaranteed Kl) -> @lifetime(borrow 0) @owned NE
+  %useFn = function_ref @useNE : $@convention(thin) (@guaranteed NE) -> ()
+  %0 = apply %getFn() : $@convention(thin) () -> @owned Kl
+  specify_test "lifetime_resolution_resolve %0"
+  %ne = apply %makeFn(%0) : $@convention(thin) (@guaranteed Kl) -> @lifetime(borrow 0) @owned NE
+  %dep = mark_dependence [unresolved] %ne on %0
+  apply %useFn(%dep) : $@convention(thin) (@guaranteed NE) -> ()
+  destroy_value %dep
+  destroy_value %0
+  %t = tuple ()
+  return %t
+}
+
+
+// Same as above, but the base's destroy starts out above the dependent's uses,
+// so the destroy is sunk.
+
+// CHECK-LABEL: sil [ossa] @test_markdep_unresolved_ne_sink :
+// CHECK:      [[V:%.*]] = apply {{%.*}}() : $@convention(thin) () -> @owned Kl
+// CHECK:      [[DEP:%.*]] = mark_dependence [unresolved] {{%.*}} on [[V]]
+// CHECK-NEXT: apply {{%.*}}([[DEP]]) : $@convention(thin) (@guaranteed NE) -> ()
+// CHECK-NEXT: destroy_value [[DEP]]
+// CHECK-NEXT: destroy_value [[V]]
+// CHECK-LABEL: } // end sil function
+sil [ossa] @test_markdep_unresolved_ne_sink : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %makeFn = function_ref @makeNE : $@convention(thin) (@guaranteed Kl) -> @lifetime(borrow 0) @owned NE
+  %useFn = function_ref @useNE : $@convention(thin) (@guaranteed NE) -> ()
+  %0 = apply %getFn() : $@convention(thin) () -> @owned Kl
+  specify_test "lifetime_resolution_resolve %0"
+  %ne = apply %makeFn(%0) : $@convention(thin) (@guaranteed Kl) -> @lifetime(borrow 0) @owned NE
+  %dep = mark_dependence [unresolved] %ne on %0
+  destroy_value %0
+  apply %useFn(%dep) : $@convention(thin) (@guaranteed NE) -> ()
+  destroy_value %dep
+  %t = tuple ()
+  return %t
+}
+
+
+// Sinking into a successor block.
+
+// CHECK-LABEL: sil [ossa] @test_markdep_unresolved_ne_sink_across_branch :
+// CHECK:      [[V:%.*]] = apply {{%.*}}() : $@convention(thin) () -> @owned Kl
+// CHECK:      [[DEP:%.*]] = mark_dependence [unresolved] {{%.*}} on [[V]]
+// CHECK-NEXT: br bb1
+// CHECK:      bb1:
+// CHECK-NEXT: apply {{%.*}}([[DEP]]) : $@convention(thin) (@guaranteed NE) -> ()
+// CHECK-NEXT: destroy_value [[DEP]]
+// CHECK-NEXT: destroy_value [[V]]
+// CHECK-LABEL: } // end sil function
+sil [ossa] @test_markdep_unresolved_ne_sink_across_branch : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %makeFn = function_ref @makeNE : $@convention(thin) (@guaranteed Kl) -> @lifetime(borrow 0) @owned NE
+  %useFn = function_ref @useNE : $@convention(thin) (@guaranteed NE) -> ()
+  %0 = apply %getFn() : $@convention(thin) () -> @owned Kl
+  specify_test "lifetime_resolution_resolve %0"
+  %ne = apply %makeFn(%0) : $@convention(thin) (@guaranteed Kl) -> @lifetime(borrow 0) @owned NE
+  %dep = mark_dependence [unresolved] %ne on %0
+  destroy_value %0
+  br bb1
+
+bb1:
+  apply %useFn(%dep) : $@convention(thin) (@guaranteed NE) -> ()
+  destroy_value %dep
+  %t = tuple ()
+  return %t
+}
+
+
+// [nonescaping] whose result is an owned Escapable object has a scoped lifetime, so its
+// scope-ending uses bound liveness directly.
+
+// CHECK-LABEL: sil [ossa] @test_markdep_nonescaping_scoped :
+// CHECK:      [[V:%.*]] = apply {{%.*}}() : $@convention(thin) () -> @owned Kl
+// CHECK-NEXT: [[K2:%.*]] = apply {{%.*}}() : $@convention(thin) () -> @owned Kl
+// CHECK-NEXT: [[DEP:%.*]] = mark_dependence [nonescaping] [[K2]] on [[V]]
+// CHECK-NEXT: destroy_value [[DEP]]
+// CHECK-NEXT: destroy_value [[V]]
+// CHECK-LABEL: } // end sil function
+sil [ossa] @test_markdep_nonescaping_scoped : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %0 = apply %getFn() : $@convention(thin) () -> @owned Kl
+  %1 = apply %getFn() : $@convention(thin) () -> @owned Kl
+  specify_test "lifetime_resolution_resolve %0"
+  %dep = mark_dependence [nonescaping] %1 on %0
+  destroy_value %dep
+  destroy_value %0
+  %t = tuple ()
+  return %t
+}
+
+
+// [nonescaping] with a trivial result has no scoped lifetime, so there are no scope-ending uses
+// to key off.
+
+// CHECK-LABEL: sil [ossa] @test_markdep_nonescaping_unscoped :
+// CHECK:      [[V:%.*]] = apply {{%.*}}() : $@convention(thin) () -> @owned Kl
+// CHECK:      [[DEP:%.*]] = mark_dependence [nonescaping] {{%.*}} on [[V]]
+// CHECK-NEXT: apply {{%.*}}([[DEP]]) : $@convention(thin) (Builtin.RawPointer) -> ()
+// CHECK-NEXT: destroy_value [[V]]
+// CHECK-LABEL: } // end sil function
+sil [ossa] @test_markdep_nonescaping_unscoped : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %usePtrFn = function_ref @useRawPtr : $@convention(thin) (Builtin.RawPointer) -> ()
+  %0 = apply %getFn() : $@convention(thin) () -> @owned Kl
+  specify_test "lifetime_resolution_resolve %0"
+  %ptr = ref_to_raw_pointer %0 to $Builtin.RawPointer
+  %dep = mark_dependence [nonescaping] %ptr on %0
+  apply %usePtrFn(%dep) : $@convention(thin) (Builtin.RawPointer) -> ()
+  destroy_value %0
+  %t = tuple ()
+  return %t
+}
+
+
+// A consume between the mark_dependence and the dependent's use is interior with respect to the
+// pinned liverange, so it takes a copy instead of ending the base's lifetime early.
+
+// CHECK-LABEL: sil [ossa] @test_markdep_escaping_interior_consume :
+// CHECK:      [[V:%.*]] = apply {{%.*}}() : $@convention(thin) () -> @owned Kl
+// CHECK:      [[DEP:%.*]] = mark_dependence {{%.*}} on [[V]]
+// CHECK-NEXT: [[COPY:%.*]] = copy_value [[V]]
+// CHECK-NEXT: apply {{%.*}}([[COPY]]) : $@convention(thin) (@owned Kl) -> ()
+// CHECK-NEXT: apply {{%.*}}([[DEP]]) : $@convention(thin) (Builtin.RawPointer) -> ()
+// CHECK-NEXT: destroy_value [[V]]
+// CHECK-LABEL: } // end sil function
+sil [ossa] @test_markdep_escaping_interior_consume : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %consFn = function_ref @consumeK : $@convention(thin) (@owned Kl) -> ()
+  %usePtrFn = function_ref @useRawPtr : $@convention(thin) (Builtin.RawPointer) -> ()
+  %0 = apply %getFn() : $@convention(thin) () -> @owned Kl
+  specify_test "lifetime_resolution_resolve %0"
+  %ptr = ref_to_raw_pointer %0 to $Builtin.RawPointer
+  %dep = mark_dependence %ptr on %0
+  apply %consFn(%0) : $@convention(thin) (@owned Kl) -> ()
+  apply %usePtrFn(%dep) : $@convention(thin) (Builtin.RawPointer) -> ()
+  destroy_value %0
+  %t = tuple ()
+  return %t
+}
+
+// mark_dependence_addr onto Escapable memory: reachable uses of that memory are not tracked.
+
+// CHECK-LABEL: sil [ossa] @test_markdep_addr :
+// CHECK:      [[V:%.*]] = apply {{%.*}}() : $@convention(thin) () -> @owned Kl
+// CHECK:      [[STK:%.*]] = alloc_stack $Kl
+// CHECK:      mark_dependence_addr [unresolved] [[STK]] on [[V]]
+// CHECK-NEXT: destroy_addr [[STK]]
+// CHECK-NEXT: dealloc_stack [[STK]]
+// CHECK-NEXT: destroy_value [[V]]
+// CHECK-LABEL: } // end sil function
+sil [ossa] @test_markdep_addr : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %0 = apply %getFn() : $@convention(thin) () -> @owned Kl
+  %1 = apply %getFn() : $@convention(thin) () -> @owned Kl
+  %stk = alloc_stack $Kl
+  store %1 to [init] %stk
+  specify_test "lifetime_resolution_resolve %0"
+  mark_dependence_addr [unresolved] %stk on %0
+  destroy_addr %stk
+  dealloc_stack %stk
+  destroy_value %0
+  %t = tuple ()
+  return %t
+}

--- a/test/SILOptimizer/lifetime_resolution_resolve_unit.sil
+++ b/test/SILOptimizer/lifetime_resolution_resolve_unit.sil
@@ -1,0 +1,810 @@
+// RUN: %target-sil-opt %s -test-runner -sil-verify-none | %FileCheck %s
+
+sil_stage raw
+
+import Builtin
+import Swift
+
+class Kl {}
+class Sub : Kl {}
+struct Wrapper { var k: Kl }
+
+sil @getK : $@convention(thin) () -> @owned Kl
+sil @useK : $@convention(thin) (@guaranteed Kl) -> ()
+sil @consumeK : $@convention(thin) (@owned Kl) -> ()
+sil @consumeTwoK : $@convention(thin) (@owned Kl, @owned Kl) -> ()
+sil @barrierK : $@convention(thin) () -> ()
+sil @useRawPtr : $@convention(thin) (Builtin.RawPointer) -> ()
+
+
+
+// CHECK-LABEL: sil [ossa] @test_copy_before_interior_consume :
+// CHECK:      [[V:%.*]] = apply {{%.*}}() : $@convention(thin) () -> @owned Kl
+// CHECK-NEXT: [[COPY:%.*]] = copy_value [[V]]
+// CHECK-NEXT: apply {{%.*}}([[COPY]]) : $@convention(thin) (@owned Kl) -> ()
+// CHECK-NEXT: apply {{%.*}}([[V]]) : $@convention(thin) (@guaranteed Kl) -> ()
+// CHECK-NEXT: destroy_value [[V]]
+// CHECK-LABEL: } // end sil function
+sil [ossa] @test_copy_before_interior_consume : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %useFn = function_ref @useK : $@convention(thin) (@guaranteed Kl) -> ()
+  %consFn = function_ref @consumeK : $@convention(thin) (@owned Kl) -> ()
+  %0 = apply %getFn() : $@convention(thin) () -> @owned Kl
+  specify_test "lifetime_resolution_resolve %0"
+  apply %consFn(%0) : $@convention(thin) (@owned Kl) -> ()
+  apply %useFn(%0) : $@convention(thin) (@guaranteed Kl) -> ()
+  destroy_value %0
+  %t = tuple ()
+  return %t
+}
+
+
+
+// CHECK-LABEL: sil [ossa] @test_use_before_final_consume :
+// CHECK:      [[V:%.*]] = apply {{%.*}}() : $@convention(thin) () -> @owned Kl
+// CHECK-NEXT: apply {{%.*}}([[V]]) : $@convention(thin) (@guaranteed Kl) -> ()
+// CHECK-NEXT: apply {{%.*}}([[V]]) : $@convention(thin) (@owned Kl) -> ()
+// CHECK-NOT:  destroy_value
+// CHECK-LABEL: } // end sil function
+sil [ossa] @test_use_before_final_consume : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %useFn = function_ref @useK : $@convention(thin) (@guaranteed Kl) -> ()
+  %consFn = function_ref @consumeK : $@convention(thin) (@owned Kl) -> ()
+  %0 = apply %getFn() : $@convention(thin) () -> @owned Kl
+  specify_test "lifetime_resolution_resolve %0"
+  apply %useFn(%0) : $@convention(thin) (@guaranteed Kl) -> ()
+  apply %consFn(%0) : $@convention(thin) (@owned Kl) -> ()
+  destroy_value %0
+  %t = tuple ()
+  return %t
+}
+
+
+
+// CHECK-LABEL: sil [ossa] @test_hoist_destroy_across_branch :
+// CHECK: [[V:%.*]] = apply {{%.*}}() : $@convention(thin) () -> @owned Kl
+
+// CHECK: bb1:
+// CHECK-NEXT: apply {{%.*}}([[V]]) : $@convention(thin) (@owned Kl) -> ()
+// CHECK-NEXT: br bb3
+
+// CHECK: bb2:
+// CHECK-NEXT: apply {{%.*}}([[V]]) : $@convention(thin) (@guaranteed Kl) -> ()
+// CHECK-NEXT: destroy_value [[V]]
+// CHECK-NEXT: br bb3
+
+// CHECK-NOT:  destroy_value
+// CHECK: } // end sil function
+sil [ossa] @test_hoist_destroy_across_branch : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %useFn = function_ref @useK : $@convention(thin) (@guaranteed Kl) -> ()
+  %consFn = function_ref @consumeK : $@convention(thin) (@owned Kl) -> ()
+  %0 = apply %getFn() : $@convention(thin) () -> @owned Kl
+  specify_test "lifetime_resolution_resolve %0"
+  cond_br undef, bb1, bb2
+
+bb1:
+  apply %consFn(%0) : $@convention(thin) (@owned Kl) -> ()
+  br bb3
+
+bb2:
+  apply %useFn(%0) : $@convention(thin) (@guaranteed Kl) -> ()
+  br bb3
+
+bb3:
+  destroy_value %0
+  %t = tuple ()
+  return %t
+}
+
+
+
+// CHECK-LABEL: sil [ossa] @test_copy_and_hoist_across_branch :
+// CHECK: [[V:%.*]] = apply {{%.*}}() : $@convention(thin) () -> @owned Kl
+
+// CHECK: bb1:
+// CHECK-NEXT: apply {{%.*}}([[V]]) : $@convention(thin) (@guaranteed Kl) -> ()
+// CHECK-NEXT: [[COPY:%.*]] = copy_value [[V]]
+// CHECK-NEXT: apply {{%.*}}([[COPY]]) : $@convention(thin) (@owned Kl) -> ()
+// CHECK-NEXT: apply {{%.*}}([[V]]) : $@convention(thin) (@guaranteed Kl) -> ()
+// CHECK-NEXT: destroy_value [[V]]
+// CHECK-NEXT: br bb3
+
+// CHECK: bb2:
+// CHECK-NEXT: apply {{%.*}}([[V]]) : $@convention(thin) (@owned Kl) -> ()
+// CHECK-NEXT: br bb3
+
+// CHECK-NOT: destroy_value
+// CHECK: } // end sil function
+sil [ossa] @test_copy_and_hoist_across_branch : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %useFn = function_ref @useK : $@convention(thin) (@guaranteed Kl) -> ()
+  %consFn = function_ref @consumeK : $@convention(thin) (@owned Kl) -> ()
+  %0 = apply %getFn() : $@convention(thin) () -> @owned Kl
+  specify_test "lifetime_resolution_resolve %0"
+  cond_br undef, bb1, bb2
+
+bb1:
+  apply %useFn(%0) : $@convention(thin) (@guaranteed Kl) -> ()
+  apply %consFn(%0) : $@convention(thin) (@owned Kl) -> ()
+  apply %useFn(%0) : $@convention(thin) (@guaranteed Kl) -> ()
+  br bb3
+
+bb2:
+  apply %consFn(%0) : $@convention(thin) (@owned Kl) -> ()
+  br bb3
+
+bb3:
+  destroy_value %0
+  %t = tuple ()
+  return %t
+}
+
+
+
+// CHECK-LABEL: sil [ossa] @test_hoist_into_dead_end :
+// CHECK: [[V:%.*]] = apply {{%.*}}() : $@convention(thin) () -> @owned Kl
+
+// CHECK: bb1:
+// CHECK-NEXT: apply {{%.*}}([[V]]) : $@convention(thin) (@owned Kl) -> ()
+// CHECK-NEXT: br bb3
+
+// CHECK: bb2:
+// CHECK-NEXT: apply {{%.*}}([[V]]) : $@convention(thin) (@guaranteed Kl) -> ()
+// CHECK-NEXT: destroy_value [dead_end] [[V]]
+// CHECK-NEXT: apply
+// CHECK-NEXT: unreachable
+
+// CHECK-NOT:  destroy_value
+// CHECK: } // end sil function
+sil [ossa] @test_hoist_into_dead_end : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %useFn = function_ref @useK : $@convention(thin) (@guaranteed Kl) -> ()
+  %consFn = function_ref @consumeK : $@convention(thin) (@owned Kl) -> ()
+  %failFn = function_ref @barrierK : $@convention(thin) () -> ()
+  %0 = apply %getFn() : $@convention(thin) () -> @owned Kl
+  specify_test "lifetime_resolution_resolve %0"
+  cond_br undef, bb1, bb2
+
+bb1:
+  apply %consFn(%0) : $@convention(thin) (@owned Kl) -> ()
+  br bb3
+
+bb2:
+  apply %useFn(%0) : $@convention(thin) (@guaranteed Kl) -> ()
+  apply %failFn() : $@convention(thin) () -> ()
+  unreachable
+
+bb3:
+  destroy_value %0
+  %t = tuple ()
+  return %t
+}
+
+
+
+// CHECK-LABEL: sil [ossa] @test_consume_inside_loop :
+// CHECK: [[V:%.*]] = apply {{%.*}}() : $@convention(thin) () -> @owned Kl
+
+// CHECK: bb1:
+// CHECK-NEXT: [[COPY:%.*]] = copy_value [[V]]
+// CHECK-NEXT: apply {{%.*}}([[COPY]]) : $@convention(thin) (@owned Kl) -> ()
+// CHECK-NEXT: cond_br undef, bb1, bb2
+
+// CHECK: bb2:
+// CHECK-NEXT: destroy_value [[V]]
+// CHECK: } // end sil function
+sil [ossa] @test_consume_inside_loop : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %consFn = function_ref @consumeK : $@convention(thin) (@owned Kl) -> ()
+  %0 = apply %getFn() : $@convention(thin) () -> @owned Kl
+  specify_test "lifetime_resolution_resolve %0"
+  br bb1
+
+bb1:
+  apply %consFn(%0) : $@convention(thin) (@owned Kl) -> ()
+  cond_br undef, bb1, bb2
+
+bb2:
+  destroy_value %0
+  %t = tuple ()
+  return %t
+}
+
+
+
+// CHECK-LABEL: sil [ossa] @test_copy_before_assign :
+// CHECK:      [[V:%.*]] = apply {{%.*}}() : $@convention(thin) () -> @owned Kl
+// CHECK-NEXT: [[ADDR:%.*]] = alloc_stack $Kl
+// CHECK-NEXT: [[COPY:%.*]] = copy_value [[V]]
+// CHECK-NEXT: assign [[COPY]] to [[ADDR]]
+// CHECK-NEXT: apply {{%.*}}([[V]]) : $@convention(thin) (@guaranteed Kl) -> ()
+// CHECK-NEXT: destroy_value [[V]]
+// CHECK-NEXT: destroy_addr [[ADDR]]
+// CHECK-LABEL: } // end sil function
+sil [ossa] @test_copy_before_assign : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %useFn = function_ref @useK : $@convention(thin) (@guaranteed Kl) -> ()
+  %0 = apply %getFn() : $@convention(thin) () -> @owned Kl
+  %addr = alloc_stack $Kl
+  specify_test "lifetime_resolution_resolve %0"
+  assign %0 to %addr : $*Kl
+  apply %useFn(%0) : $@convention(thin) (@guaranteed Kl) -> ()
+  destroy_value %0
+  destroy_addr %addr : $*Kl
+  dealloc_stack %addr : $*Kl
+  %t = tuple ()
+  return %t
+}
+
+
+
+// CHECK-LABEL: sil [ossa] @test_hoist_destroy_across_assign_branch :
+// CHECK: [[V:%.*]] = apply {{%.*}}() : $@convention(thin) () -> @owned Kl
+// CHECK: [[ADDR:%.*]] = alloc_stack $Kl
+
+// CHECK: bb1:
+// CHECK-NEXT: assign [[V]] to [[ADDR]]
+// CHECK-NEXT: br bb3
+
+// CHECK: bb2:
+// CHECK-NEXT: apply {{%.*}}([[V]]) : $@convention(thin) (@guaranteed Kl) -> ()
+// CHECK-NEXT: destroy_value [[V]]
+// CHECK-NEXT: br bb3
+
+// CHECK: bb3:
+// CHECK-NOT:  destroy_value
+// CHECK-LABEL: } // end sil function
+sil [ossa] @test_hoist_destroy_across_assign_branch : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %useFn = function_ref @useK : $@convention(thin) (@guaranteed Kl) -> ()
+  %0 = apply %getFn() : $@convention(thin) () -> @owned Kl
+  %addr = alloc_stack $Kl
+  specify_test "lifetime_resolution_resolve %0"
+  cond_br undef, bb1, bb2
+
+bb1:
+  assign %0 to %addr : $*Kl
+  br bb3
+
+bb2:
+  apply %useFn(%0) : $@convention(thin) (@guaranteed Kl) -> ()
+  br bb3
+
+bb3:
+  destroy_value %0
+  destroy_addr %addr : $*Kl
+  dealloc_stack %addr : $*Kl
+  %t = tuple ()
+  return %t
+}
+
+
+// A deinit barrier appearing between the lifetime end-point of a lexical value and a final consume
+// forces that consume to only consume a copy, keeping the original value live.
+
+// CHECK-LABEL: sil [ossa] @test_deinit_barrier_forces_boundary_consume_copy :
+// CHECK:      [[V:%.*]] = apply {{%.*}}() : $@convention(thin) () -> @owned Kl
+// CHECK-NEXT: [[LEX:%.*]] = move_value [lexical] [[V]]
+// CHECK-NEXT: [[LEX_COPY:%.*]] = copy_value [[LEX]]
+// CHECK-NEXT: apply {{%.*}}([[LEX_COPY]]) : $@convention(thin) (@owned Kl) -> ()
+// CHECK-NEXT: apply {{%.*}}() : $@convention(thin) () -> ()
+// CHECK-NEXT: destroy_value [[LEX]]
+// CHECK-LABEL: } // end sil function
+sil [ossa] @test_deinit_barrier_forces_boundary_consume_copy : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %consumeFn = function_ref @consumeK : $@convention(thin) (@owned Kl) -> ()
+  %barrierFn = function_ref @barrierK : $@convention(thin) () -> ()
+  %raw = apply %getFn() : $@convention(thin) () -> @owned Kl
+  %0 = move_value [lexical] %raw
+  specify_test "lifetime_resolution_resolve %0"
+  apply %consumeFn(%0) : $@convention(thin) (@owned Kl) -> ()
+  apply %barrierFn() : $@convention(thin) () -> ()
+  destroy_value %0
+  %t = tuple ()
+  return %t
+}
+
+
+// A lexical value's destroy must not be hoisted across a deinit barrier that lies
+// between its last non-consuming use and its original scope-end destroy.
+
+// CHECK-LABEL: sil [ossa] @test_lexical_no_hoist_across_barrier :
+// CHECK:      [[V:%.*]] = apply {{%.*}}() : $@convention(thin) () -> @owned Kl
+// CHECK-NEXT: [[LEX:%.*]] = move_value [lexical] [[V]]
+// CHECK-NEXT: apply {{%.*}}([[LEX]]) : $@convention(thin) (@guaranteed Kl) -> ()
+// CHECK-NEXT: apply {{%.*}}() : $@convention(thin) () -> ()
+// CHECK-NEXT: destroy_value [[LEX]]
+// CHECK-LABEL: } // end sil function
+sil [ossa] @test_lexical_no_hoist_across_barrier : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %useFn = function_ref @useK : $@convention(thin) (@guaranteed Kl) -> ()
+  %barrierFn = function_ref @barrierK : $@convention(thin) () -> ()
+  %raw = apply %getFn() : $@convention(thin) () -> @owned Kl
+  %0 = move_value [lexical] %raw
+  specify_test "lifetime_resolution_resolve %0"
+  apply %useFn(%0) : $@convention(thin) (@guaranteed Kl) -> ()
+  apply %barrierFn() : $@convention(thin) () -> ()
+  destroy_value %0
+  %t = tuple ()
+  return %t
+}
+
+// Similar to above, but now we have no use of the value, yet there is a deinit barrier
+// before the destroy:
+
+// CHECK-LABEL: sil [ossa] @test_dead_def_lexical_barrier :
+// CHECK:      [[LEX:%.*]] = move_value [lexical]
+// CHECK:      apply {{%.*}}() : $@convention(thin) () -> ()
+// CHECK-NEXT: destroy_value [[LEX]]
+// CHECK-LABEL: } // end sil function
+sil [ossa] @test_dead_def_lexical_barrier : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %barrierFn = function_ref @barrierK : $@convention(thin) () -> ()
+  %raw = apply %getFn() : $@convention(thin) () -> @owned Kl
+  %0 = move_value [lexical] %raw
+  specify_test "lifetime_resolution_resolve %0"
+  apply %barrierFn() : $@convention(thin) () -> ()
+  destroy_value %0
+  %t = tuple ()
+  return %t
+}
+
+
+
+// Contrast with the above: absent a real deinit barrier, a lexical value's destroy
+// still hoists to its last non-consuming use, same as a non-lexical value would.
+
+// CHECK-LABEL: sil [ossa] @test_lexical_hoist_without_barrier :
+// CHECK:      [[V:%.*]] = apply {{%.*}}() : $@convention(thin) () -> @owned Kl
+// CHECK-NEXT: [[LEX:%.*]] = move_value [lexical] [[V]]
+// CHECK-NEXT: apply {{%.*}}([[LEX]]) : $@convention(thin) (@guaranteed Kl) -> ()
+// CHECK-NEXT: destroy_value [[LEX]]
+// CHECK-NEXT: tuple ()
+// CHECK-LABEL: } // end sil function
+sil [ossa] @test_lexical_hoist_without_barrier : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %useFn = function_ref @useK : $@convention(thin) (@guaranteed Kl) -> ()
+  %raw = apply %getFn() : $@convention(thin) () -> @owned Kl
+  %0 = move_value [lexical] %raw
+  specify_test "lifetime_resolution_resolve %0"
+  apply %useFn(%0) : $@convention(thin) (@guaranteed Kl) -> ()
+  %ignore = tuple ()
+  destroy_value %0
+  %t = tuple ()
+  return %t
+}
+
+
+
+// Branching version: one arm consumes the lexical value outright (no destroy needed
+// there), the other has a non-consuming use followed by a deinit barrier before the
+// merge point's shared destroy. The barrier must block hoisting on the using arm only.
+
+// CHECK-LABEL: sil [ossa] @test_lexical_hoist_across_branch_with_barrier :
+// CHECK: [[V:%.*]] = apply {{%.*}}() : $@convention(thin) () -> @owned Kl
+// CHECK-NEXT: [[LEX:%.*]] = move_value [lexical] [[V]]
+
+// CHECK: bb1:
+// CHECK-NEXT: apply {{%.*}}([[LEX]]) : $@convention(thin) (@owned Kl) -> ()
+// CHECK-NEXT: br bb3
+
+// CHECK: bb2:
+// CHECK-NEXT: apply {{%.*}}([[LEX]]) : $@convention(thin) (@guaranteed Kl) -> ()
+// CHECK-NEXT: apply {{%.*}}() : $@convention(thin) () -> ()
+// CHECK-NEXT: destroy_value [[LEX]]
+// CHECK-NEXT: br bb3
+
+// CHECK: bb3:
+// CHECK-NOT: destroy_value
+// CHECK-LABEL: } // end sil function
+sil [ossa] @test_lexical_hoist_across_branch_with_barrier : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %useFn = function_ref @useK : $@convention(thin) (@guaranteed Kl) -> ()
+  %consFn = function_ref @consumeK : $@convention(thin) (@owned Kl) -> ()
+  %barrierFn = function_ref @barrierK : $@convention(thin) () -> ()
+  %raw = apply %getFn() : $@convention(thin) () -> @owned Kl
+  %0 = move_value [lexical] %raw
+  specify_test "lifetime_resolution_resolve %0"
+  cond_br undef, bb1, bb2
+
+bb1:
+  apply %consFn(%0) : $@convention(thin) (@owned Kl) -> ()
+  br bb3
+
+bb2:
+  apply %useFn(%0) : $@convention(thin) (@guaranteed Kl) -> ()
+  apply %barrierFn() : $@convention(thin) () -> ()
+  br bb3
+
+bb3:
+  destroy_value %0
+  %t = tuple ()
+  return %t
+}
+
+// Similar to above, but now the barrier is at the join point.
+// Since we cannot destroy the lexical value before the barrier, a copy is required on the consuming side.
+
+// CHECK-LABEL: sil [ossa] @test_lexical_hoist_join_point_barrier :
+// CHECK: [[V:%.*]] = apply {{%.*}}() : $@convention(thin) () -> @owned Kl
+// CHECK-NEXT: [[LEX:%.*]] = move_value [lexical] [[V]]
+
+// CHECK: bb1:
+// CHECK-NEXT: [[LEX_COPY:%.*]] = copy_value [[LEX]]
+// CHECK-NEXT: apply {{%.*}}([[LEX_COPY]]) : $@convention(thin) (@owned Kl) -> ()
+// CHECK-NEXT: br bb3
+
+// CHECK: bb2:
+// CHECK-NEXT: apply {{%.*}}([[LEX]]) : $@convention(thin) (@guaranteed Kl) -> ()
+// CHECK-NEXT: br bb3
+
+// CHECK: bb3:
+// CHECK-NEXT: apply {{%.*}}() : $@convention(thin) () -> ()
+// CHECK-NEXT: destroy_value [[LEX]]
+// CHECK-LABEL: } // end sil function
+sil [ossa] @test_lexical_hoist_join_point_barrier : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %useFn = function_ref @useK : $@convention(thin) (@guaranteed Kl) -> ()
+  %consFn = function_ref @consumeK : $@convention(thin) (@owned Kl) -> ()
+  %barrierFn = function_ref @barrierK : $@convention(thin) () -> ()
+  %raw = apply %getFn() : $@convention(thin) () -> @owned Kl
+  %0 = move_value [lexical] %raw
+  specify_test "lifetime_resolution_resolve %0"
+  cond_br undef, bb1, bb2
+
+bb1:
+  apply %consFn(%0) : $@convention(thin) (@owned Kl) -> ()
+  br bb3
+
+bb2:
+  apply %useFn(%0) : $@convention(thin) (@guaranteed Kl) -> ()
+  br bb3
+
+bb3:
+  apply %barrierFn() : $@convention(thin) () -> ()
+  destroy_value %0
+  %t = tuple ()
+  return %t
+}
+
+
+// CHECK-LABEL: sil [ossa] @test_use_before_branch_consume :
+// CHECK:      [[V:%.*]] = apply {{%.*}}() : $@convention(thin) () -> @owned Kl
+// CHECK-NEXT: apply {{%.*}}([[V]]) : $@convention(thin) (@guaranteed Kl) -> ()
+// CHECK-NEXT: cond_br
+
+// CHECK: bb1:
+// CHECK-NEXT: apply {{%.*}}([[V]]) : $@convention(thin) (@owned Kl) -> ()
+// CHECK-NEXT: br bb3
+
+// CHECK: bb2:
+// CHECK-NEXT: destroy_value [[V]]
+// CHECK-NEXT: br bb3
+// CHECK-NOT:  destroy_value
+// CHECK-LABEL: } // end sil function
+sil [ossa] @test_use_before_branch_consume : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %useFn = function_ref @useK : $@convention(thin) (@guaranteed Kl) -> ()
+  %consFn = function_ref @consumeK : $@convention(thin) (@owned Kl) -> ()
+  %0 = apply %getFn() : $@convention(thin) () -> @owned Kl
+  specify_test "lifetime_resolution_resolve %0"
+  apply %useFn(%0) : $@convention(thin) (@guaranteed Kl) -> ()
+  cond_br undef, bb1, bb2
+
+bb1:
+  apply %consFn(%0) : $@convention(thin) (@owned Kl) -> ()
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  destroy_value %0
+  %t = tuple ()
+  return %t
+}
+
+
+// CHECK-LABEL: sil [ossa] @test_interior_destroy :
+// CHECK:      [[V:%.*]] = mark_uninitialized [rootself] %0
+// CHECK-NEXT: return [[V]]
+// CHECK-NEXT: } // end sil function
+sil [ossa] @test_interior_destroy : $@convention(method) (@owned Kl) -> @owned Kl {
+bb0(%0 : @owned $Kl):
+  debug_value %0, let, name "self", argno 1
+  %2 = mark_uninitialized [rootself] %0
+  specify_test "lifetime_resolution_resolve %2"
+  destroy_value %2
+  return %2
+}
+
+
+// A borrow scope is an interval, not a point: the destroy must land after the `end_borrow`,
+// never inside the scope.
+
+// CHECK-LABEL: sil [ossa] @test_borrow_scope :
+// CHECK:      [[V:%.*]] = apply {{%.*}}() : $@convention(thin) () -> @owned Kl
+// CHECK-NEXT: [[B:%.*]] = begin_borrow [[V]]
+// CHECK-NEXT: apply {{%.*}}([[B]]) : $@convention(thin) (@guaranteed Kl) -> ()
+// CHECK-NEXT: end_borrow [[B]]
+// CHECK-NEXT: destroy_value [[V]]
+// CHECK-LABEL: } // end sil function
+sil [ossa] @test_borrow_scope : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %useFn = function_ref @useK : $@convention(thin) (@guaranteed Kl) -> ()
+  %0 = apply %getFn() : $@convention(thin) () -> @owned Kl
+  specify_test "lifetime_resolution_resolve %0"
+  %b = begin_borrow %0
+  apply %useFn(%b) : $@convention(thin) (@guaranteed Kl) -> ()
+  end_borrow %b
+  destroy_value %0
+  %t = tuple ()
+  return %t
+}
+
+
+
+// CHECK-LABEL: sil [ossa] @test_borrow_scope_then_consume :
+// CHECK:      [[V:%.*]] = apply {{%.*}}() : $@convention(thin) () -> @owned Kl
+// CHECK-NEXT: [[B:%.*]] = begin_borrow [[V]]
+// CHECK-NEXT: apply {{%.*}}([[B]]) : $@convention(thin) (@guaranteed Kl) -> ()
+// CHECK-NEXT: end_borrow [[B]]
+// CHECK-NEXT: apply {{%.*}}([[V]]) : $@convention(thin) (@owned Kl) -> ()
+// CHECK-NOT:  destroy_value
+// CHECK-LABEL: } // end sil function
+sil [ossa] @test_borrow_scope_then_consume : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %useFn = function_ref @useK : $@convention(thin) (@guaranteed Kl) -> ()
+  %consFn = function_ref @consumeK : $@convention(thin) (@owned Kl) -> ()
+  %0 = apply %getFn() : $@convention(thin) () -> @owned Kl
+  specify_test "lifetime_resolution_resolve %0"
+  %b = begin_borrow %0
+  apply %useFn(%b) : $@convention(thin) (@guaranteed Kl) -> ()
+  end_borrow %b
+  apply %consFn(%0) : $@convention(thin) (@owned Kl) -> ()
+  destroy_value %0
+  %t = tuple ()
+  return %t
+}
+
+
+
+// Consumed on one path with no non-consuming use anywhere: the other path still needs a
+// destroy, which lands at its entry.
+
+// CHECK-LABEL: sil [ossa] @test_consume_one_path_no_use :
+// CHECK:      [[V:%.*]] = apply {{%.*}}() : $@convention(thin) () -> @owned Kl
+
+// CHECK: bb1:
+// CHECK-NEXT: apply {{%.*}}([[V]]) : $@convention(thin) (@owned Kl) -> ()
+// CHECK-NEXT: br bb3
+
+// CHECK: bb2:
+// CHECK-NEXT: destroy_value [[V]]
+// CHECK-NEXT: br bb3
+
+// CHECK: bb3:
+// CHECK-NOT:  destroy_value
+// CHECK-LABEL: } // end sil function
+sil [ossa] @test_consume_one_path_no_use : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %consFn = function_ref @consumeK : $@convention(thin) (@owned Kl) -> ()
+  %0 = apply %getFn() : $@convention(thin) () -> @owned Kl
+  specify_test "lifetime_resolution_resolve %0"
+  cond_br undef, bb1, bb2
+
+bb1:
+  apply %consFn(%0) : $@convention(thin) (@owned Kl) -> ()
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  destroy_value %0
+  %t = tuple ()
+  return %t
+}
+
+
+
+// The root's only use is a forwarding consume, so it needs no destroy of its own; the
+// forwarded aggregate keeps its.
+
+// CHECK-LABEL: sil [ossa] @test_forwarding_consume_only :
+// CHECK:      [[V:%.*]] = apply {{%.*}}() : $@convention(thin) () -> @owned Kl
+// CHECK-NEXT: [[W:%.*]] = struct $Wrapper ([[V]])
+// CHECK-NEXT: destroy_value [[W]]
+// CHECK-NOT:  destroy_value [[V]]
+// CHECK-LABEL: } // end sil function
+sil [ossa] @test_forwarding_consume_only : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %0 = apply %getFn() : $@convention(thin) () -> @owned Kl
+  specify_test "lifetime_resolution_resolve %0"
+  %1 = struct $Wrapper (%0 : $Kl)
+  destroy_value %1
+  %t = tuple ()
+  return %t
+}
+
+
+
+// A lexical value consumed at every boundary point needs no destroy, even though a deinit
+// barrier sits below the consume.
+
+// CHECK-LABEL: sil [ossa] @test_lexical_barrier_below_consume :
+// CHECK:      [[V:%.*]] = apply {{%.*}}() : $@convention(thin) () -> @owned Kl
+// CHECK-NEXT: [[LEX:%.*]] = move_value [lexical] [var_decl] [[V]]
+// CHECK-NEXT: apply {{%.*}}([[LEX]]) : $@convention(thin) (@guaranteed Kl) -> ()
+// CHECK-NEXT: destroy_value [[LEX]]
+// CHECK-NOT:  destroy_value [[V]]
+// CHECK-LABEL: } // end sil function
+sil [ossa] @test_lexical_barrier_below_consume : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %useFn = function_ref @useK : $@convention(thin) (@guaranteed Kl) -> ()
+  %0 = apply %getFn() : $@convention(thin) () -> @owned Kl
+  specify_test "lifetime_resolution_resolve %0"
+  %1 = move_value [lexical] [var_decl] %0
+  apply %useFn(%1) : $@convention(thin) (@guaranteed Kl) -> ()
+  destroy_value %1
+  destroy_value %0
+  %t = tuple ()
+  return %t
+}
+
+// CHECK-LABEL: sil [ossa] @test_lexical_barrier_below_consume_branch :
+// CHECK:      [[LEX:%.*]] = move_value [lexical]
+
+// CHECK: bb1:
+// CHECK-NEXT: [[LEX_COPY:%.*]] = copy_value [[LEX]]
+// CHECK-NEXT: apply {{%.*}}([[LEX_COPY]]) : $@convention(thin) (@owned Kl) -> ()
+// CHECK-NEXT: apply {{%.*}}() : $@convention(thin) () -> ()
+// CHECK-NEXT: destroy_value [[LEX]]
+// CHECK-NEXT: br bb3
+
+// CHECK: bb2:
+// CHECK-NEXT: apply {{%.*}}([[LEX]]) : $@convention(thin) (@guaranteed Kl) -> ()
+// CHECK-NEXT: apply {{%.*}}() : $@convention(thin) () -> ()
+// CHECK-NEXT: destroy_value [[LEX]]
+// CHECK-NEXT: br bb3
+
+// CHECK: bb3:
+// CHECK-NOT:  destroy_value
+// CHECK-LABEL: } // end sil function
+sil [ossa] @test_lexical_barrier_below_consume_branch : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %useFn = function_ref @useK : $@convention(thin) (@guaranteed Kl) -> ()
+  %consFn = function_ref @consumeK : $@convention(thin) (@owned Kl) -> ()
+  %barrierFn = function_ref @barrierK : $@convention(thin) () -> ()
+  %raw = apply %getFn() : $@convention(thin) () -> @owned Kl
+  %0 = move_value [lexical] %raw
+  specify_test "lifetime_resolution_resolve %0"
+  cond_br undef, bb1, bb2
+
+bb1:
+  apply %consFn(%0) : $@convention(thin) (@owned Kl) -> ()
+  apply %barrierFn() : $@convention(thin) () -> ()
+  br bb3
+
+bb2:
+  apply %useFn(%0) : $@convention(thin) (@guaranteed Kl) -> ()
+  apply %barrierFn() : $@convention(thin) () -> ()
+  br bb3
+
+bb3:
+  destroy_value %0
+  %t = tuple ()
+  return %t
+}
+
+// CHECK-LABEL: sil [ossa] @test_no_use_destroy :
+// CHECK:      [[V:%.*]] = apply {{%.*}}() : $@convention(thin) () -> @owned Kl
+// CHECK-NEXT: destroy_value [[V]]
+// CHECK: } // end sil function
+sil [ossa] @test_no_use_destroy : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %0 = apply %getFn() : $@convention(thin) () -> @owned Kl
+  specify_test "lifetime_resolution_resolve %0"
+  destroy_value %0
+  %t = tuple ()
+  return %t
+}
+
+// CHECK-LABEL: sil [ossa] @test_dead_def_distant_destroy :
+// CHECK:      [[V:%.*]] = apply {{%.*}}() : $@convention(thin) () -> @owned Kl
+// CHECK:      destroy_value [[V]]
+// CHECK-LABEL: } // end sil function
+sil [ossa] @test_dead_def_distant_destroy : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %barrierFn = function_ref @barrierK : $@convention(thin) () -> ()
+  %0 = apply %getFn() : $@convention(thin) () -> @owned Kl
+  specify_test "lifetime_resolution_resolve %0"
+  apply %barrierFn() : $@convention(thin) () -> ()
+  destroy_value %0
+  %t = tuple ()
+  return %t
+}
+
+
+
+// CHECK-LABEL: sil [ossa] @test_dead_def_block_arg :
+// CHECK: bb2([[V:%.*]] : @owned $Kl):
+// CHECK:      destroy_value [[V]]
+// CHECK-LABEL: } // end sil function
+sil [ossa] @test_dead_def_block_arg : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %0 = apply %getFn() : $@convention(thin) () -> @owned Kl
+  checked_cast_br Kl in %0 to Sub, bb1, bb2
+
+bb1(%1 : @owned $Sub):
+  destroy_value %1
+  br bb3
+
+bb2(%2 : @owned $Kl):
+  specify_test "lifetime_resolution_resolve @argument"
+  destroy_value %2
+  br bb3
+
+bb3:
+  %t = tuple ()
+  return %t
+}
+
+// An `@owned` block argument has no defining instruction, but is still resolved. It is
+// lexical, so the barrier below its use blocks hoisting.
+
+// CHECK-LABEL: sil [ossa] @test_owned_block_arg :
+// CHECK: bb0([[V:%.*]] : @owned $Kl):
+// CHECK:      apply {{%.*}}([[V]]) : $@convention(thin) (@guaranteed Kl) -> ()
+// CHECK-NEXT: apply {{%.*}}() : $@convention(thin) () -> ()
+// CHECK-NEXT: destroy_value [[V]]
+// CHECK-LABEL: } // end sil function
+sil [ossa] @test_owned_block_arg : $@convention(thin) (@owned Kl) -> () {
+bb0(%0 : @owned $Kl):
+  %useFn = function_ref @useK : $@convention(thin) (@guaranteed Kl) -> ()
+  %barrierFn = function_ref @barrierK : $@convention(thin) () -> ()
+  specify_test "lifetime_resolution_resolve @argument[0]"
+  apply %useFn(%0) : $@convention(thin) (@guaranteed Kl) -> ()
+  apply %barrierFn() : $@convention(thin) () -> ()
+  destroy_value %0
+  %t = tuple ()
+  return %t
+}
+
+
+// CHECK-LABEL: sil [ossa] @test_trivial_root :
+// CHECK:      integer_literal $Builtin.Int64, 0
+// CHECK-NEXT: tuple ()
+// CHECK-LABEL: } // end sil function
+sil [ossa] @test_trivial_root : $@convention(thin) () -> () {
+bb0:
+  %0 = integer_literal $Builtin.Int64, 0
+  specify_test "lifetime_resolution_resolve %0"
+  %t = tuple ()
+  return %t
+}

--- a/test/SILOptimizer/lifetime_resolution_resolve_unit_xfail.sil
+++ b/test/SILOptimizer/lifetime_resolution_resolve_unit_xfail.sil
@@ -1,0 +1,39 @@
+// RUN: %target-sil-opt %s -test-runner -sil-verify-none | %FileCheck %s
+
+// XFAIL: *
+
+// Corner cases for `lifetime_resolution_resolve` that do not hold yet. The CHECK lines
+// describe the intended result, not the current one.
+
+sil_stage raw
+
+import Builtin
+import Swift
+
+class Kl {}
+class Sub : Kl {}
+
+sil @getK : $@convention(thin) () -> @owned Kl
+sil @useK : $@convention(thin) (@guaranteed Kl) -> ()
+sil @consumeK : $@convention(thin) (@owned Kl) -> ()
+sil @consumeTwoK : $@convention(thin) (@owned Kl, @owned Kl) -> ()
+sil @barrierK : $@convention(thin) () -> ()
+
+
+// Two consuming operands on the same instruction: exactly one of them must take a copy,
+// otherwise %0 is consumed twice.
+// CHECK-LABEL: sil [ossa] @test_two_consumes_one_instruction :
+// CHECK:      [[V:%.*]] = apply {{%.*}}() : $@convention(thin) () -> @owned Kl
+// CHECK-NEXT: [[COPY:%.*]] = copy_value [[V]]
+// CHECK-NEXT: apply {{%.*}}({{.*}}[[COPY]]{{.*}}) : $@convention(thin) (@owned Kl, @owned Kl) -> ()
+// CHECK-LABEL: } // end sil function
+sil [ossa] @test_two_consumes_one_instruction : $@convention(thin) () -> () {
+bb0:
+  %getFn = function_ref @getK : $@convention(thin) () -> @owned Kl
+  %consTwoFn = function_ref @consumeTwoK : $@convention(thin) (@owned Kl, @owned Kl) -> ()
+  %0 = apply %getFn() : $@convention(thin) () -> @owned Kl
+  specify_test "lifetime_resolution_resolve %0"
+  apply %consTwoFn(%0, %0) : $@convention(thin) (@owned Kl, @owned Kl) -> ()
+  %t = tuple ()
+  return %t
+}

--- a/test/SILOptimizer/lifetime_resolution_silgen.swift
+++ b/test/SILOptimizer/lifetime_resolution_silgen.swift
@@ -1,0 +1,142 @@
+// RUN: %target-swift-frontend -emit-silgen-ossa -enable-lifetime-resolution \
+// RUN:   -enable-experimental-feature LifetimeDependence %s | %FileCheck %s
+
+// REQUIRES: swift_feature_LifetimeDependence
+
+class Kl {}
+enum Enum { case some(Kl); case none }
+enum Trivial { case red, green }
+
+func Use(_ k: Kl) {}
+func Consume(_ k: __owned Kl) {}
+
+// A consume as the last use needs no copy, and no destroy survives.
+
+// CHECK-LABEL: sil hidden [ossa] @$s{{.*}}BorrowThenConsume
+// CHECK:      [[X:%.*]] = move_value [lexical] [var_decl]
+// CHECK:      apply {{%.*}}([[X]]) : $@convention(thin) (@guaranteed Kl) -> ()
+// CHECK:      apply {{%.*}}([[X]]) : $@convention(thin) (@owned Kl) -> ()
+// CHECK-NOT:  copy_value
+// CHECK-NOT:  destroy_value
+// CHECK-LABEL: } // end sil function
+func BorrowThenConsume() {
+  let x = Kl()
+  Use(x)
+  Consume(x)
+}
+
+// A consume in the interior of the live range takes exactly one copy; the original is
+// destroyed after its last use.
+
+// CHECK-LABEL: sil hidden [ossa] @$s{{.*}}ConsumeThenBorrow
+// CHECK:      [[X:%.*]] = move_value [lexical] [var_decl]
+// CHECK:      [[COPY:%.*]] = copy_value [[X]]
+// CHECK-NEXT: apply {{%.*}}([[COPY]]) : $@convention(thin) (@owned Kl) -> ()
+// CHECK:      apply {{%.*}}([[X]]) : $@convention(thin) (@guaranteed Kl) -> ()
+// CHECK-NEXT: destroy_value [[X]]
+// CHECK-LABEL: } // end sil function
+func ConsumeThenBorrow() {
+  let x = Kl()
+  Consume(x)
+  Use(x)
+}
+
+// A `var` is box-backed, so its uses sit inside a `begin_borrow [lexical]` scope. The box's
+// destroy must stay below the `end_borrow` that closes that scope.
+
+// CHECK-LABEL: sil hidden [ossa] @$s{{.*}}VarReassign
+// CHECK:      [[BOX:%.*]] = alloc_box ${ var Kl }
+// CHECK-NEXT: [[BORROW:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
+// CHECK:      end_borrow [[BORROW]]
+// CHECK-NEXT: destroy_value [[BOX]]
+// CHECK-LABEL: } // end sil function
+func VarReassign() {
+  var x = Kl()
+  Consume(x)
+  x = Kl()
+  Use(x)
+}
+
+// The `@owned` enum is a block argument's source: SILGen borrows it to switch, so the
+// payload is guaranteed and its `copy_value` is a real ownership conversion that must
+// survive. The enum's own destroy sinks into both arms.
+
+// CHECK-LABEL: sil hidden [ossa] @$s{{.*}}SwitchPayload
+// CHECK:      bb0([[E:%.*]] : @owned $Enum):
+// CHECK:      [[B:%.*]] = begin_borrow [[E]]
+// CHECK:      switch_enum [[B]]
+// CHECK:      bb1([[PAYLOAD:%.*]] : @guaranteed $Kl):
+// CHECK-NEXT: [[COPY:%.*]] = copy_value [[PAYLOAD]]
+// CHECK-NEXT: [[K:%.*]] = move_value [lexical] [var_decl] [[COPY]]
+// CHECK:      apply {{%.*}}([[K]]) : $@convention(thin) (@owned Kl) -> ()
+// CHECK-NEXT: end_borrow [[B]]
+// CHECK-NEXT: destroy_value [[E]]
+// CHECK-LABEL: } // end sil function
+func SwitchPayload(_ e: __owned Enum) {
+  switch e {
+  case .some(let k): Consume(k)
+  case .none: break
+  }
+}
+
+// An `@owned` parameter is a block argument, which has no defining instruction. It still
+// gets resolved: its destroy lands right after its last use.
+
+// CHECK-LABEL: sil hidden [ossa] @$s{{.*}}OwnedArgument
+// CHECK:      bb0([[K:%.*]] : @owned $Kl):
+// CHECK:      apply {{%.*}}([[K]]) : $@convention(thin) (@guaranteed Kl) -> ()
+// CHECK-NEXT: destroy_value [[K]]
+// CHECK-LABEL: } // end sil function
+func OwnedArgument(_ k: __owned Kl) {
+  Use(k)
+}
+
+// A trivial value has no lifetime to resolve. The synthesized `__derived_enum_equals` is
+// full of `load [trivial]`, which must never reach destroy insertion.
+
+// CHECK-LABEL: sil hidden [ossa] @$s{{.*}}TrivialCompare
+// CHECK-NOT:  destroy_value
+// CHECK-LABEL: } // end sil function
+func TrivialCompare(_ a: Trivial, _ b: Trivial) -> Bool {
+  return a == b
+}
+
+// The implicit String-to-C-pointer conversion emits a bare (i.e. [escaping])
+// `mark_dependence` on the owner returned by the conversion. The owner's destroy must stay
+// below the call that consumes the pointer; hoisting it to the mark_dependence makes the
+// callee read freed memory.
+
+func TakesCPointer(_ p: UnsafePointer<CChar>) {}
+
+// CHECK-LABEL: sil hidden [ossa] @$s{{.*}}StringToPointer
+// CHECK:      [[OWNER:%[0-9]+]] = apply {{.*}}@owned Optional<AnyObject>
+// CHECK:      [[DEP:%.*]] = mark_dependence {{%.*}} on [[OWNER]]
+// CHECK:      apply {{%.*}}([[DEP]]) : $@convention(thin) (UnsafePointer<Int8>) -> ()
+// CHECK-NEXT: destroy_value [[OWNER]]
+// CHECK-LABEL: } // end sil function
+func StringToPointer(_ s: String) {
+  TakesCPointer(s)
+}
+
+// A ~Escapable dependent value's uses are enumerable, so they extend the base's liveness. The
+// base must outlive the dependent, not the other way around.
+
+struct NE: ~Escapable { let p: UnsafeRawPointer }
+class Buf { let p = UnsafeRawPointer(bitPattern: 1)! }
+
+func MakeNE(_ b: borrowing Buf) -> NE { NE(p: b.p) }
+func UseNE(_ n: borrowing NE) {}
+
+// CHECK-LABEL: sil hidden [ossa] @$s{{.*}}NEDependent
+// CHECK:      [[B:%.*]] = move_value [lexical] [var_decl]
+// CHECK:      [[DEP:%.*]] = mark_dependence [unresolved] {{%.*}} on [[B]]
+// CHECK-NEXT: [[N:%.*]] = move_value [var_decl] [[DEP]]
+// CHECK:      apply {{%.*}}([[N]]) : $@convention(thin) (@guaranteed NE) -> ()
+// CHECK-NEXT: destroy_value [[N]]
+// CHECK-NEXT: destroy_value [[B]]
+// CHECK-LABEL: } // end sil function
+func NEDependent() {
+  let b = Buf()
+  let n = MakeNE(b)
+  UseNE(n)
+}


### PR DESCRIPTION
LifetimeResolution is a rethink of how lifetimes of values are canonicalized after SILGen. It's currently experimental and enabled with frontend flag `-enable-lifetime-resolution`. As a first step, we're focusing on resolving `copy_value` and then inserting the appropriate `destroy_value`'s. 

This pass takes SIL that is not valid OSSA, because it is missing the needed `copy_value` instructions (currently implemented by deleting them just prior, in RemoveSILGenLifetimes). The "resolving" part of the name is the process of inserting them only where they need to go, based on operand ownership / uses in SIL. This yields copy-minimal SIL (similar to what running MandatoryCopyPropagation would give you).

We'd like to have this go further, and have SILGen not emit any `destroy_value`'s, either, instead emitting a higher-level `end_scope`  instruction that denotes the end of lexical scopes. LifetimeResolution would then insert destroys where they need to go (strictly after last use, or with respect to deinit barriers for lexical values) up to those end_scope limits. The existence of dependent values and an explicit `consume` operator already makes these destroys coming out of SILGen invalid anyway, so this pass aims to be the point at which they're resolved correctly.