### PR TITLE
Optimizer: notify changes in `Context.inlineFunction`

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/ContextCommon.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/ContextCommon.swift
@@ -132,6 +132,8 @@ extension MutatingContext {
        !instAfterInlining.isDeleted {
       notifyNewInstructions(from: instBeforeInlining, to: instAfterInlining)
     }
+    notifyInstructionsChanged()
+    notifyBranchesChanged()
   }
 
   func loadFunction(function: Function, loadCalleesRecursively: Bool) -> Bool {


### PR DESCRIPTION
`inlineFunction` is bridged and therefore doesn't automatically notify changes. Fixes a (potential) analysis update problem.
