### PR TITLE
SimplifyCopyValue: Don't destructure large aggregates

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyCopyValue.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyCopyValue.swift
@@ -55,6 +55,7 @@ extension CopyValueInst : OnoneSimplifiable, SILCombineSimplifiable {
 /// Preconditions:
 ///   * The `destroy_value` must be in the same basic block as the `copy_value`
 ///   * There are no uses of the copy or its forwarding instructions inside the owned value's liverange
+///   * The destructure creates at most `maxNumDestroysToCreate` element-wise destroys
 ///
 private func tryRemoveProjectedCopy(copy: CopyValueInst, _ context: SimplifyContext) {
   let block = copy.parentBlock
@@ -78,6 +79,19 @@ private func tryRemoveProjectedCopy(copy: CopyValueInst, _ context: SimplifyCont
   }
 
   guard checkForwardingChain(from: copy, to: destroy) else {
+    return
+  }
+
+  // A destructure is just another way of expanding an aggregate operation into element-wise
+  // operations, so it is bounded by the same limit: up to `maxNumFieldsToExpand` fields the
+  // aggregate's `destroy_value` is expanded into element-wise destroys anyway, which makes the
+  // destructure free and removing the `copy_value` a win. Beyond it the `destroy_value` is kept
+  // whole and emitted as a single call to an outlined destroy helper, and destructuring would
+  // trade that one call for a destroy of every single field.
+  guard canDestructure(ownedValue.type, path: projectionPath,
+                       creatingFewerDestroysThan: Type.maxNumFieldsToExpand,
+                       in: copy.parentFunction)
+  else {
     return
   }
 
@@ -145,6 +159,56 @@ private func getProjectionPath(of value: Value,
   default:
     return (initialPath, root: value)
   }
+}
+
+/// Returns true if `createDestructureChain` creates fewer than `limit` `destroy_value`
+/// instructions for `path`, and that number can be determined at all.
+private func canDestructure(_ type: Type, path: SmallProjectionPath,
+                            creatingFewerDestroysThan limit: Int, in function: Function) -> Bool {
+  return areDestroysToCreateIsMoreThanLimit(for: type, path: path, limit: limit, in: function) != nil
+}
+
+/// Returns the number of `destroy_value` instructions which `createDestructureChain` creates for
+/// `path`, or nil if that number cannot be determined or reaches `limit`.
+private func areDestroysToCreateIsMoreThanLimit(for type: Type, path: SmallProjectionPath, limit: Int,
+                                   in function: Function) -> Int? {
+  let (kind, index, subPath) = path.pop()
+
+  switch kind {
+  case .root:
+    return 0
+  case .structField:
+    guard let fields = type.getNominalFields(in: function) else {
+      return nil
+    }
+    return areDestroysToCreateIsMoreThanLimit(for: fields, at: index, subPath: subPath,
+                                              limit: limit, in: function)
+  case .tupleField:
+    return areDestroysToCreateIsMoreThanLimit(for: type.tupleElements, at: index, subPath: subPath,
+                                              limit: limit, in: function)
+  default:
+    return nil
+  }
+}
+
+private func areDestroysToCreateIsMoreThanLimit<Elements: RandomAccessCollection>(
+  for elements: Elements, at index: Int, subPath: SmallProjectionPath, limit: Int,
+  in function: Function
+) -> Int? where Elements.Element == Type, Elements.Index == Int {
+  guard index < elements.count,
+        var num = areDestroysToCreateIsMoreThanLimit(for: elements[index], path: subPath,
+                                                     limit: limit, in: function)
+  else {
+    return nil
+  }
+  for elementIdx in elements.indices
+      where elementIdx != index && !elements[elementIdx].isTrivial(in: function) {
+    num += 1
+    if num >= limit {
+      return nil
+    }
+  }
+  return num
 }
 
 private func createDestructureChain(of value: Value, path: SmallProjectionPath, _ builder: Builder) -> Value {

--- a/SwiftCompilerSources/Sources/SIL/Type.swift
+++ b/SwiftCompilerSources/Sources/SIL/Type.swift
@@ -176,6 +176,10 @@ public struct Type : TypeProperties, CustomStringConvertible, NoReflectionChildr
     return PackElementArray(type: self)
   }
 
+  public static var maxNumFieldsToExpand: Int {
+    BridgedType.getMaxNumFieldsToExpand()
+  }
+
   /// Returns nil if the nominal is a resilient type because in this case the complete list
   /// of fields is not known.
   public func getNominalFields(in function: Function) -> NominalFieldsArray? {

--- a/include/swift/SIL/InstructionUtils.h
+++ b/include/swift/SIL/InstructionUtils.h
@@ -240,6 +240,15 @@ bool visitExplodedTupleValue(SILValue value,
 std::pair<SILFunction *, SILWitnessTable *>
 lookUpFunctionInWitnessTable(WitnessMethodInst *wmi, SILModule::LinkingMode linkingMode);
 
+/// The maximum number of fields of an aggregate which is still expanded into
+/// element-wise operations.
+///
+/// Expanding a wider aggregate costs code size: an aggregate copy or destroy
+/// which is not expanded is emitted by IRGen as a single call to an outlined
+/// helper function, whereas an expanded one becomes an operation on every
+/// single field. It also increases register pressure.
+constexpr unsigned MaxNumFieldsToExpand = 6;
+
 /// True if a type can be expanded without a significant increase to code size.
 ///
 /// False if expanding a type is invalid. For example, expanding a

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -302,6 +302,7 @@ struct BridgedType {
   BRIDGED_INLINE SWIFT_IMPORT_UNSAFE BridgedASTType getRawLayoutSubstitutedCountType() const;
   BRIDGED_INLINE bool mayHaveCustomDeinit(BridgedFunction f) const;
   BRIDGED_INLINE SwiftInt getCaseIdxOfEnumType(BridgedStringRef name) const;
+  static BRIDGED_INLINE SwiftInt getMaxNumFieldsToExpand();
   static BRIDGED_INLINE SwiftInt getNumBoxFields(BridgedCanType boxTy);
   static SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getBoxFieldType(BridgedCanType boxTy,
                                                                         SwiftInt idx, BridgedFunction f);

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -21,6 +21,7 @@
 
 #include "SILBridging.h"
 #include "swift/AST/Builtins.h"
+#include "swift/SIL/InstructionUtils.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/StorageImpl.h"
@@ -430,6 +431,10 @@ bool BridgedType::mayHaveCustomDeinit(BridgedFunction f) const {
 
 SwiftInt BridgedType::getCaseIdxOfEnumType(BridgedStringRef name) const {
   return unbridged().getCaseIdxOfEnumType(name.unbridged());
+}
+
+SwiftInt BridgedType::getMaxNumFieldsToExpand() {
+  return swift::MaxNumFieldsToExpand;
 }
 
 SwiftInt BridgedType::getNumBoxFields(BridgedCanType boxTy) {

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -1499,5 +1499,5 @@ bool swift::shouldExpand(SILModule &module, SILType ty) {
   }
 
   unsigned numFields = module.Types.countNumberOfFields(ty, expansion);
-  return (numFields <= 6);
+  return (numFields <= MaxNumFieldsToExpand);
 }

--- a/test/SILOptimizer/simplify_copy_value.sil
+++ b/test/SILOptimizer/simplify_copy_value.sil
@@ -27,6 +27,18 @@ struct S3 {
   @_hasStorage let ci: (Int, C)
 }
 
+// Large enough that destructuring would create more than `maxNumDestroysToCreate` destroys.
+struct SLarge {
+  @_hasStorage let c1: C
+  @_hasStorage let c2: C
+  @_hasStorage let c3: C
+  @_hasStorage let c4: C
+  @_hasStorage let c5: C
+  @_hasStorage let c6: C
+  @_hasStorage let c7: C
+  @_hasStorage let c8: C
+}
+
 sil @takeOwnedC : $@convention(thin) (@owned C) -> ()
 
 // CHECK-LABEL: sil [ossa] @remove_copy :
@@ -107,6 +119,24 @@ sil [ossa] @projected_copy_second_field : $@convention(thin) (@owned S2) -> @own
 bb0(%0 : @owned $S2):
   %1 = begin_borrow %0
   %2 = struct_extract %1, #S2.c2
+  %3 = copy_value %2
+  end_borrow %1
+  destroy_value %0
+  return %3
+}
+
+// Large struct: destructuring would replace the single aggregate destroy_value with 7
+// element-wise destroys, which costs far more code than the removed copy saves.
+// The copy must be kept.
+//
+// CHECK-LABEL: sil [ossa] @projected_copy_large_struct :
+// CHECK:         copy_value
+// CHECK-NOT:     destructure_struct
+// CHECK:       } // end sil function 'projected_copy_large_struct'
+sil [ossa] @projected_copy_large_struct : $@convention(thin) (@owned SLarge) -> @owned C {
+bb0(%0 : @owned $SLarge):
+  %1 = begin_borrow %0
+  %2 = struct_extract %1, #SLarge.c1
   %3 = copy_value %2
   end_borrow %1
   destroy_value %0


### PR DESCRIPTION
To remove a single `copy_value` of a projected field, `tryRemoveProjectedCopy` (https://github.com/swiftlang/swift/pull/90263) replaces the aggregate's `destroy_value` with a destructure plus an element-wise `destroy_value` of every other field. For a large aggregate that trades one instruction for one per field:

```swift
class C {}

struct S {
  let f0: C
  ...                            // more fields than MaxNumFieldsToExpand
  let f99: C
}

@inline(never) func makeS() -> S
func project() -> C { makeS().f0 }
```

`project` before the simplification:

```
sil [ossa] @project : $@convention(thin) () -> @owned C {
bb0:
  %0 = function_ref @makes : $@convention(thin) () -> @owned S
  %1 = apply %0() : $@convention(thin) () -> @owned S
  %2 = begin_borrow %1
  %3 = struct_extract %2, #S.f0
  %4 = copy_value %3
  end_borrow %2
  destroy_value %1
  return %4
}
```

and after it:

```
bb0:
  %0 = function_ref @makes : $@convention(thin) () -> @owned S
  %1 = apply %0() : $@convention(thin) () -> @owned S
  %2 = begin_borrow %1
  end_borrow %2
  (%3, %4, %5, ..., %102) = destructure_struct %1
  destroy_value %4
  destroy_value %5
  ...                                    // one per remaining field
  destroy_value %102
  return %3
}
```

A destructure is just another way of expanding an aggregate operation into element-wise operations, so this patch bounds it by the same limit (`MaxNumFieldsToExpand`). Beyond it the `destroy_value` is kept whole and IRGen emits it as a single call to an outlined destroy helper, and destructuring trades that one call for a destroy of every single field.

The regression was originally found in our wasm application build. Its wasm CODE section between the 2026-06-24-a and 2026-07-11-a toolchains:

|      | 2026-06-24-a | 2026-07-11-a |       delta |    x |
|------|-------------:|-------------:|------------:|-----:|
| Code section size |   72,583,929 |  112,601,771 | +40,017,842 | 1.55 |