### PR TITLE
Fix two annoying problems with sil-opt and other SIL tools

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -280,6 +280,15 @@ public:
 
   void setRuntimeResourcePath(StringRef Path);
 
+  /// Recompute the implicit search paths for the runtime libraries and
+  /// frameworks.
+  ///
+  /// These paths depend on the target, the SDK path and on language options -
+  /// e.g. Embedded Swift uses its own set of runtime libraries. Tools which
+  /// modify LangOptions directly, instead of going through parseArgs(), need to
+  /// call this afterwards.
+  void updateImplicitSearchPaths();
+
   /// Compute the default prebuilt module cache path for a given resource path
   /// and SDK version. This function is also used by LLDB.
   static std::string

--- a/lib/DriverTool/sil_llvm_gen_main.cpp
+++ b/lib/DriverTool/sil_llvm_gen_main.cpp
@@ -405,6 +405,11 @@ int sil_llvm_gen_main(ArrayRef<const char *> argv, void *MainAddr) {
   Invocation.getLangOptions().EnableCXXInterop = options.EnableCxxInterop;
   Invocation.computeCXXStdlibOptions();
 
+  // The implicit search paths depend on the language options - e.g. Embedded
+  // Swift picks up its runtime libraries from a different directory. Recompute
+  // them now that all language options are set.
+  Invocation.updateImplicitSearchPaths();
+
   // Setup the IRGen Options.
   IRGenOptions &Opts = Invocation.getIRGenOptions();
   Opts.OutputKind = options.OutputKind;

--- a/lib/DriverTool/sil_opt_main.cpp
+++ b/lib/DriverTool/sil_opt_main.cpp
@@ -837,6 +837,11 @@ int sil_opt_main(ArrayRef<const char *> argv, void *MainAddr) {
     Invocation.getLangOptions().enableFeature(Feature::RegionBasedIsolation);
   }
 
+  // The implicit search paths depend on the language options - e.g. Embedded
+  // Swift picks up its runtime libraries from a different directory. Recompute
+  // them now that all language options are set.
+  Invocation.updateImplicitSearchPaths();
+
   Invocation.getDiagnosticOptions().VerifyMode =
       options.VerifyMode ? DiagnosticOptions::Verify
                          : DiagnosticOptions::NoVerify;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -448,6 +448,11 @@ void CompilerInvocation::setRuntimeResourcePath(StringRef Path) {
   updateRuntimeLibraryPaths(SearchPathOpts, FrontendOpts, LangOpts, SDKInfo);
 }
 
+void CompilerInvocation::updateImplicitSearchPaths() {
+  updateRuntimeLibraryPaths(SearchPathOpts, FrontendOpts, LangOpts, SDKInfo);
+  updateImplicitFrameworkSearchPaths(SearchPathOpts, LangOpts, SDKInfo);
+}
+
 void CompilerInvocation::setTargetTriple(StringRef Triple) {
   setTargetTriple(llvm::Triple(Triple));
 }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -4597,10 +4597,16 @@ CompilerInvocation::setUpInputForSILTool(
   bool hasSerializedAST = result.status == serialization::Status::Valid;
 
   if (hasSerializedAST) {
-    const StringRef stem = !moduleNameArg.empty()
-                               ? moduleNameArg
-                               : llvm::sys::path::stem(inputFilename);
-    setModuleName(stem);
+    // Prefer the module name which is recorded in the module file itself over
+    // the file name: the file name is not necessarily the module name, e.g. for
+    // modules in a `<module-name>.swiftmodule` directory, where the file is
+    // named after the target.
+    StringRef moduleName = moduleNameArg;
+    if (moduleName.empty() && Lexer::isIdentifier(result.name))
+      moduleName = result.name;
+    if (moduleName.empty())
+      moduleName = llvm::sys::path::stem(inputFilename);
+    setModuleName(moduleName);
     getFrontendOptions().InputMode =
         FrontendOptions::ParseInputMode::SwiftLibrary;
   } else {

--- a/test/SIL/Serialization/deserialize_stdlib.sil
+++ b/test/SIL/Serialization/deserialize_stdlib.sil
@@ -3,4 +3,9 @@
 // RUN: %llvm-bcanalyzer %platform-module-dir/Swift.swiftmodule/%target-swiftmodule-name > %t || %llvm-bcanalyzer %platform-module-dir/Swift.swiftmodule > %t
 // RUN: %FileCheck %s < %t
 
+// Without -module-name, the module name must be taken from the module file and
+// not from the file name, which is the target triple for modules in a
+// `Swift.swiftmodule` directory.
+// RUN: %target-sil-opt %platform-module-dir/Swift.swiftmodule/%target-swiftmodule-name > /dev/null || %target-sil-opt %platform-module-dir/Swift.swiftmodule > /dev/null
+
 // CHECK-NOT: Unknown

--- a/test/embedded/sil-tools-stdlib-search-path.sil
+++ b/test/embedded/sil-tools-stdlib-search-path.sil
@@ -1,0 +1,19 @@
+// Without an explicit -I, the SIL tools must pick up the embedded stdlib from
+// the "embedded" sub-directory of the resource directory.
+// Note: sil-llvm-gen shares this code path, but %target-sil-llvm-gen doesn't
+// pass the test resource directory, so it cannot be tested here.
+
+// RUN: %target-sil-opt -enable-experimental-feature Embedded %s -o /dev/null
+
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: embedded_stdlib
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+sil @testit : $@convention(thin) (Int) -> Int {
+bb0(%0 : $Int):
+  return %0
+}


### PR DESCRIPTION
### Pick up the embedded stdlib in embedded Swift mode 

sil-opt and sil-llvm-gen don't go through `CompilerInvocation::parseArgs`, but
set LangOptions directly. So the implicit search paths were still computed for
the host platform when `-enable-experimental-feature Embedded` was passed, and
importing the (non-embedded) stdlib failed.

Add CompilerInvocation::updateImplicitSearchPaths() and call it in both tools
once all language options are set.

### Get the module name from the module file, if possible

When reading a swiftmodule file, the module name was derived from the file name.
That's wrong for modules in a `<module-name>.swiftmodule` directory, where the
file is named after the target, e.g. `arm64-apple-macos.swiftmodule`. It caused
an assertion because the resulting module name is not an identifier.

Instead, prefer the module name which is recorded in the module file itself and
only fall back to the file name if it's not available.
