### PR TITLE
Refine parameter names for improved clarity in the documentation

### DIFF
--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -55,7 +55,7 @@ func _canBeClass<T>(_: T.Type) -> Int8 {
 /// Returns the bits of the given instance, interpreted as having the specified
 /// type.
 ///
-/// Use this function only to convert the instance passed as `x` to a
+/// Use this function only to convert the instance passed as `instance` to a
 /// layout-compatible type when conversion through other means is not
 /// possible. Common conversions supported by the Swift standard library
 /// include the following:
@@ -84,18 +84,18 @@ func _canBeClass<T>(_: T.Type) -> Int8 {
 /// The programmer must ensure that the resulting reference has already been
 /// manually retained.
 ///
-/// Parameters:
-///   - x: The instance to cast to `type`.
-///   - type: The type to cast `x` to. `type` and the type of `x` must have the
+/// - Parameters:
+///   - instance: The instance to cast to `type`.
+///   - type: The type to cast `instance` to. `type` and the type of `instance` must have the
 ///     same size of memory representation and compatible memory layout.
-/// Returns: A new instance of type `U`, cast from `x`.
+/// - Returns: A new instance of type `U`, cast from `instance`.
 @inlinable // unsafe-performance
 @_transparent
 @unsafe
-public func unsafeBitCast<T, U>(_ x: T, to type: U.Type) -> U {
+public func unsafeBitCast<T, U>(_ instance: T, to type: U.Type) -> U {
   _precondition(MemoryLayout<T>.size == MemoryLayout<U>.size,
     "Can't unsafeBitCast between types of different sizes")
-  return Builtin.reinterpretCast(x)
+  return Builtin.reinterpretCast(instance)
 }
 
 /// Returns `x` as its concrete type `U`.

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -204,10 +204,10 @@ extension Character: CustomDebugStringConvertible {
 extension String {
   /// Creates a string containing the given character.
   ///
-  /// - Parameter c: The character to convert to a string.
+  /// - Parameter character: The character to convert to a string.
   @inlinable @inline(__always)
-  public init(_ c: Character) {
-    self.init(c._str._guts)
+  public init(_ character: Character) {
+    self.init(character._str._guts)
   }
 }
 

--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -13,21 +13,21 @@
 /// Extends the lifetime of the given instance.
 ///
 /// - Parameters:
-///   - x: An instance to preserve until this function returns.
+///   - instance: An instance to preserve until this function returns.
 @export(implementation)
 @_transparent
 public func extendLifetime<T: ~Copyable & ~Escapable>(
-  _ x: borrowing T
+  _ instance: borrowing T
 ) {
-  Builtin.fixLifetime(x)
+  Builtin.fixLifetime(instance)
 }
 
 /// Evaluates a closure while ensuring that the given instance is not destroyed
 /// before the closure returns.
 ///
 /// - Parameters:
-///   - x: An instance to preserve until the execution of `body` is completed.
-///   - body: A closure to execute that depends on the lifetime of `x` being
+///   - instance: An instance to preserve until the execution of `body` is completed.
+///   - body: A closure to execute that depends on the lifetime of `instance` being
 ///     extended. If `body` has a return value, that value is also used as the
 ///     return value for the `withExtendedLifetime(_:_:)` method.
 /// - Returns: The return value, if any, of the `body` closure parameter.
@@ -38,10 +38,10 @@ public func withExtendedLifetime<
   E: Error,
   Result: ~Copyable
 >(
-  _ x: borrowing T,
+  _ instance: borrowing T,
   _ body: () throws(E) -> Result
 ) throws(E) -> Result {
-  defer { _fixLifetime(x) }
+  defer { _fixLifetime(instance) }
   return try body()
 }
 
@@ -60,8 +60,8 @@ internal func __abi_withExtendedLifetime<T, Result>(
 /// before the closure returns.
 ///
 /// - Parameters:
-///   - x: An instance to preserve until the execution of `body` is completed.
-///   - body: A closure to execute that depends on the lifetime of `x` being
+///   - instance: An instance to preserve until the execution of `body` is completed.
+///   - body: A closure to execute that depends on the lifetime of `instance` being
 ///     extended. If `body` has a return value, that value is also used as the
 ///     return value for the `withExtendedLifetime(_:_:)` method.
 /// - Returns: The return value, if any, of the `body` closure parameter.
@@ -72,11 +72,11 @@ public func withExtendedLifetime<
   E: Error,
   Result: ~Copyable
 >(
-  _ x: borrowing T,
+  _ instance: borrowing T,
   _ body: (borrowing T) throws(E) -> Result
 ) throws(E) -> Result {
-  defer { _fixLifetime(x) }
-  return try body(x)
+  defer { _fixLifetime(instance) }
+  return try body(instance)
 }
 
 @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)

--- a/stdlib/public/core/MutableRef.swift
+++ b/stdlib/public/core/MutableRef.swift
@@ -33,8 +33,8 @@ public struct MutableRef<Value: ~Copyable>: ~Copyable, ~Escapable {
   /// 'unsafeAddress' as the mutable reference based on the mutating lifetime of
   /// the given 'owner' argument.
   ///
-  /// - Parameter pointer: The address to use to mutably reference an
-  ///                      instance of type `Value`.
+  /// - Parameter unsafeAddress: The address to use to mutably reference an
+  ///                            instance of type `Value`.
   /// - Parameter owner: The owning instance that this `MutableRef` instance's
   ///                    lifetime is based on.
   @available(StdlibDeploymentTarget 6.4, *)
@@ -43,10 +43,10 @@ public struct MutableRef<Value: ~Copyable>: ~Copyable, ~Escapable {
   @_lifetime(&owner)
   @_transparent
   public init<Owner: ~Copyable & ~Escapable>(
-    unsafeAddress pointer: UnsafeMutablePointer<Value>,
+    unsafeAddress: UnsafeMutablePointer<Value>,
     mutating owner: inout Owner
   ) {
-    unsafe self.pointer = pointer
+    unsafe self.pointer = unsafeAddress
   }
 }
 

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -944,14 +944,14 @@ extension Collection {
   ///     print(streetsSlice[0])
   ///     // error: Index out of bounds
   ///
-  /// - Parameter r: A range of the collection's indices. The bounds of
+  /// - Parameter range: A range of the collection's indices. The bounds of
   ///   the range must be valid indices of the collection.
   ///
   /// - Complexity: O(1)
   @inlinable
-  public subscript<R: RangeExpression>(r: R)
+  public subscript<R: RangeExpression>(range: R)
   -> SubSequence where R.Bound == Index {
-    return self[r.relative(to: self)]
+    return self[range.relative(to: self)]
   }
   
   @inlinable

--- a/stdlib/public/core/RangeSet.swift
+++ b/stdlib/public/core/RangeSet.swift
@@ -175,7 +175,7 @@ extension RangeSet {
   ///
   /// - Parameters:
   ///   - indices: The indices to include in the range set. All members of
-  ///   `indices` must be valid indicies of `collection` that aren't
+  ///   `indices` must be valid indices of `collection` that aren't
   ///   equal to the collection's `endIndex`.
   ///   - collection: The collection that contains `index`.
   @inlinable

--- a/stdlib/public/core/Ref.swift
+++ b/stdlib/public/core/Ref.swift
@@ -32,7 +32,7 @@ public struct Ref<Value: ~Copyable>: Copyable, ~Escapable {
   /// 'unsafeAddress' as the reference based on the borrowed lifetime of the
   /// given 'owner' argument.
   ///
-  /// - Parameter pointer: The address to use to reference an instance of
+  /// - Parameter unsafeAddress: The address to use to reference an instance of
   ///                            type `Value`.
   /// - Parameter owner: The owning instance that this `Ref` instance's
   ///                    lifetime is based on.
@@ -42,10 +42,10 @@ public struct Ref<Value: ~Copyable>: Copyable, ~Escapable {
   @_lifetime(borrow owner)
   @_transparent
   public init<Owner: ~Copyable & ~Escapable>(
-    unsafeAddress pointer: UnsafePointer<Value>,
+    unsafeAddress: UnsafePointer<Value>,
     borrowing owner: borrowing Owner
   ) {
-    builtin = unsafe Builtin.makeBorrow(pointer.pointee)
+    builtin = unsafe Builtin.makeBorrow(unsafeAddress.pointee)
   }
 }
 

--- a/stdlib/public/core/Repeat.swift
+++ b/stdlib/public/core/Repeat.swift
@@ -100,12 +100,12 @@ extension Repeated: RandomAccessCollection {
 ///
 /// - Parameters:
 ///   - element: The element to repeat.
-///   - n: The number of times to repeat `element`.
+///   - count: The number of times to repeat `element`.
 /// - Returns: A collection that contains `count` elements that are all
 ///   `element`.
 @inlinable // trivial-implementation
-public func repeatElement<T>(_ element: T, count n: Int) -> Repeated<T> {
-  return Repeated(_repeating: element, count: n)
+public func repeatElement<T>(_ element: T, count: Int) -> Repeated<T> {
+  return Repeated(_repeating: element, count: count)
 }
 
 extension Repeated: Sendable where Element: Sendable { }

--- a/stdlib/public/core/StringIndex.swift
+++ b/stdlib/public/core/StringIndex.swift
@@ -141,11 +141,11 @@ extension String.Index {
   ///
   /// - Parameters:
   ///   - offset: An offset in UTF-16 code units.
-  ///   - s: The string.
-  public init<S: StringProtocol>(utf16Offset offset: Int, in s: S) {
-    let (start, end) = (s.utf16.startIndex, s.utf16.endIndex)
+  ///   - string: The string.
+  public init<S: StringProtocol>(utf16Offset offset: Int, in string: S) {
+    let (start, end) = (string.utf16.startIndex, string.utf16.endIndex)
     guard offset >= 0,
-          let idx = s.utf16.index(start, offsetBy: offset, limitedBy: end)
+          let idx = string.utf16.index(start, offsetBy: offset, limitedBy: end)
     else {
       self = end.nextEncoded
       return

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift
@@ -212,12 +212,12 @@ extension String: RangeReplaceableCollection {
   ///
   /// - Parameters:
   ///   - newElement: The new character to insert into the string.
-  ///   - i: A valid index of the string. If `i` is equal to the string's end
+  ///   - index: A valid index of the string. If `index` is equal to the string's end
   ///     index, this methods appends `newElement` to the string.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the string.
-  public mutating func insert(_ newElement: Character, at i: Index) {
-    let i = _guts.validateInclusiveScalarIndex(i)
+  public mutating func insert(_ newElement: Character, at index: Index) {
+    let i = _guts.validateInclusiveScalarIndex(index)
     let range = unsafe Range(_uncheckedBounds: (i, i))
     _guts.replaceSubrange(range, with: newElement._str)
   }
@@ -230,7 +230,7 @@ extension String: RangeReplaceableCollection {
   /// - Parameters:
   ///   - newElements: A collection of `Character` elements to insert into the
   ///     string.
-  ///   - i: A valid index of the string. If `i` is equal to the string's end
+  ///   - index: A valid index of the string. If `index` is equal to the string's end
   ///     index, this methods appends the contents of `newElements` to the
   ///     string.
   ///
@@ -240,9 +240,9 @@ extension String: RangeReplaceableCollection {
   @_specialize(where S == Substring)
   @_specialize(where S == Array<Character>)
   public mutating func insert<S: Collection>(
-    contentsOf newElements: S, at i: Index
+    contentsOf newElements: S, at index: Index
   ) where S.Element == Character {
-    let i = _guts.validateInclusiveScalarIndex(i)
+    let i = _guts.validateInclusiveScalarIndex(index)
     let range = unsafe Range(_uncheckedBounds: (i, i))
     _guts.replaceSubrange(range, with: newElements)
   }
@@ -262,12 +262,12 @@ extension String: RangeReplaceableCollection {
   /// Calling this method invalidates any existing indices for use with this
   /// string.
   ///
-  /// - Parameter i: The position of the character to remove. `i` must be a
+  /// - Parameter position: The position of the character to remove. `position` must be a
   ///   valid index of the string that is not equal to the string's end index.
   /// - Returns: The character that was removed.
   @discardableResult
-  public mutating func remove(at i: Index) -> Character {
-    let i = _guts.validateScalarIndex(i)
+  public mutating func remove(at position: Index) -> Character {
+    let i = _guts.validateScalarIndex(position)
     let stride = _characterStride(startingAt: i)
     let j = Index(_encodedOffset: i._encodedOffset &+ stride)._scalarAligned
 

--- a/stdlib/public/core/StringUTF16View.swift
+++ b/stdlib/public/core/StringUTF16View.swift
@@ -415,11 +415,11 @@ extension String.UTF16View: BidirectionalCollection {
   ///     print("First character's UTF-16 code unit: \(greeting.utf16[i])")
   ///     // Prints "First character's UTF-16 code unit: 72"
   ///
-  /// - Parameter idx: A valid index of the view. `idx` must be
+  /// - Parameter position: A valid index of the view. `position` must be
   ///   less than the view's end index.
   @inlinable @inline(__always)
-  public subscript(idx: Index) -> UTF16.CodeUnit {
-    let idx = _guts.ensureMatchingEncoding(idx)
+  public subscript(position: Index) -> UTF16.CodeUnit {
+    let idx = _guts.ensureMatchingEncoding(position)
     _precondition(idx._encodedOffset < _guts.count,
       "String index is out of bounds")
     return self[_unchecked: idx]

--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -220,11 +220,11 @@ extension String.UTF8View: BidirectionalCollection {
   ///     print("First character's UTF-8 code unit: \(greeting.utf8[i])")
   ///     // Prints "First character's UTF-8 code unit: 72"
   ///
-  /// - Parameter i: A valid index of the view. `i`
+  /// - Parameter position: A valid index of the view. `position`
   ///   must be less than the view's end index.
   @inlinable @inline(__always)
-  public subscript(i: Index) -> UTF8.CodeUnit {
-    let i = _guts.ensureMatchingEncoding(i)
+  public subscript(position: Index) -> UTF8.CodeUnit {
+    let i = _guts.ensureMatchingEncoding(position)
     _precondition(i._encodedOffset < _guts.count,
       "String index is out of bounds")
     return self[_unchecked: i]

--- a/stdlib/public/core/UniqueArray/UniqueArray.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray.swift
@@ -156,15 +156,15 @@ extension UniqueArray where Element: ~Copyable {
   /// Ensure that the array has capacity to store the specified number of
   /// elements, by growing its storage buffer if necessary.
   ///
-  /// If `capacity < n`, then this operation reallocates the unique array's
-  /// storage to grow it; on return, the array's capacity becomes `n`.
+  /// If `capacity < minimumCapacity`, then this operation reallocates the unique array's
+  /// storage to grow it; on return, the array's capacity becomes `minimumCapacity`.
   /// Otherwise the array is left as is.
   ///
   /// - Complexity: O(`count`)
   @available(SwiftStdlib 6.4, *)
   @export(implementation)
-  public mutating func reserveCapacity(_ n: Int) {
-    _storage.reserveCapacity(n)
+  public mutating func reserveCapacity(_ minimumCapacity: Int) {
+    _storage.reserveCapacity(minimumCapacity)
   }
 
   @export(implementation)

--- a/stdlib/public/core/UniqueArray/UniqueArray.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray.swift
@@ -143,7 +143,7 @@ extension UniqueArray where Element: ~Copyable {
   /// buffer of the specified capacity, moving all existing elements
   /// to its new storage. The old storage is then deallocated.
   ///
-  /// - Parameter capacity: The desired new capacity. `newCapacity` must be
+  /// - Parameter newCapacity: The desired new capacity. `newCapacity` must be
   ///    greater than or equal to the current count.
   ///
   /// - Complexity: O(`count`)


### PR DESCRIPTION
This renames a number of parameter names to serve documentation as mentioned in the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/#parameter-names):

<blockquote>
<ul>
<li>
<p><b>Choose parameter names to serve documentation.</b> Even though parameter names do not appear at a function or method’s point of use, they play an important explanatory role.
<p>Choose these names to make documentation easy to read. For example, these names make documentation read naturally:

<pre><code>/// Return an `Array` containing the elements of `self`
/// that satisfy `<b>predicate</b>`.
func filter(_ <b>predicate</b>: (Element) -> Bool) -> [Generator.Element]

/// Replace the given `<b>subRange</b>` of elements with `<b>newElements</b>`.
mutating func replaceRange(_ <b>subRange</b>: Range, with <b>newElements</b>: [E])</code></pre>

<p>These, however, make the documentation awkward and ungrammatical:

<pre><code>/// Return an `Array` containing the elements of `self`
/// that satisfy `<b>includedInResult</b>`.
func filter(_ <b>includedInResult</b>: (Element) -> Bool) -> [Generator.Element]

/// Replace the range of elements indicated by `<b>r</b>` with
/// the contents of `<b>with</b>`.
mutating func replaceRange(_ <b>r</b>: Range, <b>with</b>: [E])</code></pre>
</ul>
</blockquote>

My intention is for these to be non-breaking changes to both API and ABI. If any of these changes _are_ breaking then I'll of course revert those changes.

As far as I'm aware, renaming the internal parameter name doesn't impact either the API or ABI. I _think_ that this also applies to renaming the parameter of a subscript (or operator) like in https://github.com/swiftlang/swift/commit/a2d1a8fe54f013094d6fa404e033cf4e0e6c8394. 