### PR TITLE
[cxx-interop] Do not emit errors for `#define macro (size_t)-1`

### DIFF
--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -108,6 +108,15 @@ static bool applyCUnsignedIntegerCastExpr(llvm::APSInt &Value,
   return true;
 }
 
+static bool importedSwiftTypeIsUnsigned(Type type, const ASTContext &ctx) {
+  auto nominal = type->getAnyNominal();
+  if (!nominal)
+    return false;
+  return nominal == ctx.getUIntDecl()   || nominal == ctx.getUInt8Decl()  ||
+         nominal == ctx.getUInt16Decl() || nominal == ctx.getUInt32Decl() ||
+         nominal == ctx.getUInt64Decl() || nominal == ctx.getUInt128Decl();
+}
+
 static ValueDecl *
 createMacroConstant(ClangImporter::Implementation &Impl,
                     const clang::MacroInfo *macro,
@@ -191,8 +200,13 @@ static ValueDecl *importNumericLiteral(ClangImporter::Implementation &Impl,
           value.flipAllBits();
         }
       }
-      applyCUnsignedIntegerCastExpr(value, castType,
-                                    Impl.getClangASTContext());
+      // Only honor the C unsigned integer cast when the constant is actually
+      // imported as an unsigned Swift type. Several unsigned C types (e.g.
+      // NSUInteger, size_t) are imported as the signed 'Int', and forcing the
+      // value unsigned there would overflow the signed Swift type.
+      if (importedSwiftTypeIsUnsigned(constantType, ctx))
+        applyCUnsignedIntegerCastExpr(value, castType,
+                                      Impl.getClangASTContext());
 
       // Make sure the destination type actually conforms to the builtin literal
       // protocol or is Bool before attempting to import, otherwise we'll crash
@@ -919,14 +933,23 @@ static ValueDecl *importMacro(ClangImporter::Implementation &impl,
       return nullptr;
     }
 
-    if (applyCUnsignedIntegerCastExpr(resultValue, castType,
-                                      impl.getClangASTContext())) {
-      resultSwiftType = impl.importTypeIgnoreIUO(
+    // Honor an unsigned cast only when the cast type is imported as an unsigned
+    // Swift type. Several unsigned C types (e.g. NSUInteger, size_t) are
+    // imported as signed Int, and forcing the value unsigned would overflow.
+    if (!castType.isNull() && castType->isIntegerType() &&
+        !castType->isBooleanType() &&
+        castType->isUnsignedIntegerOrEnumerationType()) {
+      Type castSwiftType = impl.importTypeIgnoreIUO(
           castType, ImportTypeKind::Value,
           ImportDiagnosticAdder(impl, macro, macro->getDefinitionLoc()),
           isInSystemModule(DC), Bridgeability::None, ImportTypeAttrs());
-      if (!resultSwiftType)
+      if (!castSwiftType)
         return nullptr;
+      if (importedSwiftTypeIsUnsigned(castSwiftType, impl.SwiftContext)) {
+        applyCUnsignedIntegerCastExpr(resultValue, castType,
+                                      impl.getClangASTContext());
+        resultSwiftType = castSwiftType;
+      }
     }
 
     return createMacroConstant(impl, macro, II, name, DC,

--- a/test/ClangImporter/macro_integer_casts.swift
+++ b/test/ClangImporter/macro_integer_casts.swift
@@ -1,7 +1,13 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -verify
 
+// The overflow diagnostics for imported macro constants are emitted during
+// SILGen.
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil %s -verify -o /dev/null
+
 import macros
 
 let _: CUnsignedInt = CAST_UNSIGNED_MINUS_ONE
 let _: CUnsignedInt = CAST_UNSIGNED_MINUS_TEN
 let _: TEST_DWORD = CAST_TYPEDEF_UNSIGNED_MINUS_ONE
+let _: Int = CAST_SIZE_T_MINUS_ONE
+let _: Int = CAST_NSUINTEGER_MINUS_ONE

--- a/test/ClangImporter/macro_literals.swift
+++ b/test/ClangImporter/macro_literals.swift
@@ -129,6 +129,14 @@ func testCStyleIntegerCasts() {
   // CHECK: %[[P2:.*]] = integer_literal $Builtin.Int32, -1, loc {{.*}}
   // CHECK: %{{.*}} = struct $UInt32 (%[[P2]] : $Builtin.Int32), loc {{.*}}
   _ = CAST_TYPEDEF_UNSIGNED_MINUS_ONE as TEST_DWORD
+
+  // CHECK: %[[P3:.*]] = integer_literal $Builtin.Int{{[0-9]+}}, -1, loc {{.*}}
+  // CHECK: %{{.*}} = struct $Int (%[[P3]] : $Builtin.Int{{[0-9]+}}), loc {{.*}}
+  _ = CAST_SIZE_T_MINUS_ONE as Int
+
+  // CHECK: %[[P4:.*]] = integer_literal $Builtin.Int{{[0-9]+}}, -1, loc {{.*}}
+  // CHECK: %{{.*}} = struct $Int (%[[P4]] : $Builtin.Int{{[0-9]+}}), loc {{.*}}
+  _ = CAST_NSUINTEGER_MINUS_ONE as Int
 }
 
 // CHECK-LABEL: // testIntegerComparisons()

--- a/test/Inputs/clang-importer-sdk/usr/include/macros.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/macros.h
@@ -121,6 +121,11 @@ typedef unsigned int TEST_DWORD;
 #define CAST_UNSIGNED_MINUS_TEN ((unsigned)-10)
 #define CAST_TYPEDEF_UNSIGNED_MINUS_ONE ((TEST_DWORD)-1)
 
+#define CAST_SIZE_T_MINUS_ONE ((size_t)-1)
+
+typedef unsigned long NSUInteger;
+#define CAST_NSUINTEGER_MINUS_ONE ((NSUInteger)-1)
+
 // Integer Comparisons.
 
 #define EQUAL_FALSE            (99 == 66)


### PR DESCRIPTION
The changes in 4130ebf6 started triggering a new diagnostic for usages of macros which expand into a C-style cast to a type which is unsigned in C, but is imported as signed in Swift. Examples of such types are `size_t`, `NSUInteger`.

These casts are legitimate, let's not emit diagnostics for them.

rdar://183954530

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
