### PR TITLE
LoopInvariantCodeMotion: Speculatively hoist `store [trivial]`

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
@@ -12,6 +12,10 @@
 
 import SIL
 
+private func log(_ message: @autoclosure () -> String) {
+  llvmDebug("loop-invariant-code-motion", message())
+}
+
 /// Hoist loop invariant code out of innermost loops.
 let loopInvariantCodeMotionPass = FunctionPass(name: "loop-invariant-code-motion") { function, context in
   for loop in context.loopTree.loops {
@@ -67,6 +71,8 @@ private struct MovableInstructions {
 private struct AnalyzedInstructions {
   /// Side effects of the loop.
   var loopSideEffects: StackWithCount<Instruction>
+  /// Non-load instructions that have no side effects but may read from memory.
+  var loopReadOnlyEffects: StackWithCount<Instruction>
   var loads: Stack<LoadInst>
   var stores: Stack<StoreInst>
   var scopedInsts: Stack<UnaryInstruction>
@@ -75,10 +81,13 @@ private struct AnalyzedInstructions {
   var dominatingBlocks: BasicBlockSet
 
   /// `true` if the loop has instructions which (may) read from memory, which are not in `Loads` and not in `sideEffects`.
-  var hasOtherMemReadingInsts = false
+  var hasOtherMemReadingInsts: Bool {
+    !loopReadOnlyEffects.isEmpty
+  }
   
   init (in loop: Loop, _ context: FunctionPassContext) {
     self.loopSideEffects = StackWithCount<Instruction>(context)
+    self.loopReadOnlyEffects = StackWithCount<Instruction>(context)
     self.loads = Stack<LoadInst>(context)
     self.stores = Stack<StoreInst>(context)
     self.scopedInsts = Stack<UnaryInstruction>(context)
@@ -87,6 +96,7 @@ private struct AnalyzedInstructions {
   
   mutating func deinitialize() {
     loopSideEffects.deinitialize()
+    loopReadOnlyEffects.deinitialize()
     loads.deinitialize()
     stores.deinitialize()
     scopedInsts.deinitialize()
@@ -107,7 +117,7 @@ private func analyzeLoopAndSplitLoads(loop: Loop, _ context: FunctionPassContext
 
   collectProjectableAccessPathsAndSplitLoads(in: loop, &analyzedInstructions, &movableInstructions, context)
 
-  collectSpeculativelyMovableInstructions(in: loop,  &movableInstructions)
+  collectSpeculativelyMovableInstructions(in: loop, analyzedInstructions, &movableInstructions, context)
 
   collectMovableInstructions(in: loop, analyzedInstructions, &movableInstructions, context)
     
@@ -139,7 +149,7 @@ private func analyzeInstructions(
       if inst.mayHaveSideEffects {
         analyzedInstructions.loopSideEffects.append(inst)
       } else if inst.mayReadFromMemory {
-        analyzedInstructions.hasOtherMemReadingInsts = true
+        analyzedInstructions.loopReadOnlyEffects.append(inst)
       }
     }
   }
@@ -178,12 +188,28 @@ private func collectProjectableAccessPathsAndSplitLoads(
 }
 
 /// Collect movable instructions, even if they are not executed in every loop iteration.
-private func collectSpeculativelyMovableInstructions(in loop: Loop, _ movableInstructions: inout MovableInstructions) {
+private func collectSpeculativelyMovableInstructions(in loop: Loop,
+                                                     _ analyzedInstructions: AnalyzedInstructions,
+                                                     _ movableInstructions: inout MovableInstructions,
+                                                     _ context: FunctionPassContext) {
+
+  var storeCounter = 0
+
   for bb in loop.loopBlocks {
     for inst in bb.instructions {
       switch inst {
-      case is LoadInst, is StoreInst:
+      case is LoadInst:
         movableInstructions.loadsAndStores.append(inst)
+      case let storeInst as StoreInst:
+        movableInstructions.loadsAndStores.append(inst)
+        
+        // Avoid quadratic complexity in corner cases. Usually, this limit will not be exceeded.
+        if storeCounter * analyzedInstructions.loopSideEffects.count >= 8000 {
+          break
+        }
+        storeCounter += 1
+        collectSpeculativelyHoistableStoreInstruction(in: loop, storeInst: storeInst, analyzedInstructions, &movableInstructions, context)
+
       case let refElementAddrInst as RefElementAddrInst:
         movableInstructions.speculativelyHoistable.append(refElementAddrInst)
       default:
@@ -191,6 +217,173 @@ private func collectSpeculativelyMovableInstructions(in loop: Loop, _ movableIns
       }
     }
   }
+}
+
+/// Collect a `store` instruction as speculatively hoistable if appropriate. If
+/// its destination is (part of) a stack allocation inside the loop, also
+/// potentially hoist that.
+private func collectSpeculativelyHoistableStoreInstruction(
+  in loop: Loop,
+  storeInst: StoreInst,
+  _ analyzedInstructions: AnalyzedInstructions,
+  _ movableInstructions: inout MovableInstructions,
+  _ context: FunctionPassContext
+) {
+
+  // Only attempt to hoist trivial stores for now. Hoisting an init or assign
+  // store could have visible side effects depending on the type's inits and
+  // deinit.
+  if storeInst.storeOwnership != .trivial {
+    return
+  }
+
+  // If the stored value is produced inside the loop, we cannot hoist the store.
+  if loop.contains(block: storeInst.source.parentBlock) {
+    return
+  }
+
+  let accessPath = storeInst.destination.accessPath
+
+  log("Processing candidate hoistable store:\n\(storeInst.description)")
+
+  // Even a trivial address can be projected out of a non-trivial one.
+  // Hoisting the store in this case could hoist it into a region
+  // where the base address is borrowed. Bail out to avoid this when
+  // the accessBase is not known to be trivial.
+  guard let baseAddress = accessPath.base.address
+  else {
+    log("Access base is unknown. Cannot hoist.")
+    return
+  }
+
+  guard baseAddress.type.isTrivial(in: storeInst.parentFunction)
+  else {
+    log("Access base is non-trivial. Cannot hoist.\n\(baseAddress).")
+    return
+  }
+
+  if !storesUniqueReadableValue(
+    analyzedInstructions: analyzedInstructions,
+    accessPath: accessPath, storeInst: storeInst, context)
+  {
+    log("Found an instruction with a read or write effect that prevents store hoisting.")
+    return
+  }
+
+  // We can only hoist the store if doing so would have no observable effects on
+  // the rest of the function. There are three main cases to consider:
+  // - an alloc_stack inside the loop,
+  // - an alloc_stack outside the loop or any other kind of address.
+  //
+  // An alloc_stack inside the loop is inaccessible after it ends, so hoisting
+  // can have no observable effects, though we must also hoist the alloc_stack.
+  //
+  // In other cases, the address lives after the end of the loop, so we can only
+  // hoist the store if the address is guaranteed to contain the stored value at
+  // loop exit. This is true if and only if the store dominates all exits. I.e.
+  // We can only hoist the store non-speculatively.
+  //
+  // In the following example, we cannot hoist the store because it is in a
+  // conditionally-executed branch.
+  //
+  //   var n = 5 // Local or global
+  //
+  //   for i in 0..<10 {
+  //     if pred(i) {
+  //       n = 6
+  //     }
+  //   }
+  //
+  //   print(n) // 5 or 6?
+  if case .stack(let allocStackInst) = accessPath.base,
+    loop.contains(block: allocStackInst.parentBlock)
+  {
+    log("Store writes to an alloc_stack inside the loop.\n\(allocStackInst)")
+    // speculatively hoistable instructions are hoisted before any other
+    // instructions, so we can only hoist the store and the alloc_stack together
+    // if the store writes directly to the alloc_stack.
+    if storeInst.destination != allocStackInst {
+      log("Store destination is not the alloc_stack. Cannot hoist.\n\(storeInst.destination)")
+      return
+    }
+    log("Hoisting alloc_stack and store.")
+    movableInstructions.speculativelyHoistable.append(allocStackInst)
+    movableInstructions.speculativelyHoistable.append(storeInst)
+    return
+  }
+
+  if !analyzedInstructions.dominatingBlocks.contains(storeInst.parentBlock) {
+    log("Store writes to an address outside the loop. Not safe to hoist speculatively.")
+    return
+  }
+
+  log("Store dominates all loop exits and latches. Safe to hoist.")
+  movableInstructions.speculativelyHoistable.append(storeInst)
+}
+
+
+/// Returns true only if `storeInst` dominates all reads that may alias with the
+/// provided path, and there are no potentially aliasing writes that may
+/// overwrite the value `storeInst` stored.
+///
+/// For efficiency, the implementation may not detect all such cases, for
+/// example, with stores in branches.
+private func storesUniqueReadableValue(
+  analyzedInstructions: AnalyzedInstructions,
+  accessPath: AccessPath, storeInst: StoreInst, _ context: FunctionPassContext
+) -> Bool {
+  precondition(storeInst.storeOwnership == .trivial)
+  let aliasAnalysis = context.aliasAnalysis
+  let domTree = context.dominatorTree
+  let storeAddr = storeInst.destination
+
+  /// If `inst` has a write effect on `storeAddr`, or it has a read effect and
+  /// is not dominated by `storeInst`, it has a conflicting effect. In this
+  /// case we know `storeInst` does not meet our conditions.
+  let hasConflictingEffect = { (inst: Instruction) in
+    log(inst.description)
+    // Ignore the store itself.
+
+    switch inst {
+    case storeInst:
+      log("   instruction does not conflict with itself")
+      return false
+    case is DeallocStackInst:
+      // dealloc_stack of a trivial type ignores the actual written value so
+      // we can ignore its memory effects
+      log("   ignoring the effects of dealloc_stack")
+      return false
+    default:
+      break
+    }
+
+    // Pass the original address value until we can fix alias analysis.
+    let effect = aliasAnalysis.getMemoryEffect(of: inst, on: storeAddr)
+    if effect.write {
+      log("    CONFLICTS: write effect")
+      return true
+    } else if effect.read && !storeInst.dominates(inst, domTree) {
+      log("    CONFLICTS: read effect and instruction is not dominated by the store")
+      return true
+    }
+
+    log("    no conflicting read or write effect")
+    return false
+  }
+
+  // loopSideEffects, loopReadOnlyEffects and loads partition the set of
+  // instructions with memory effects in the loop.
+  if analyzedInstructions.loopSideEffects.contains(where: hasConflictingEffect) {
+    return false
+  }
+  if analyzedInstructions.loopReadOnlyEffects.contains(where: hasConflictingEffect) {
+    return false
+  }
+  if analyzedInstructions.loads.contains(where: hasConflictingEffect) {
+    return false
+  }
+
+  return true
 }
 
 /// Collect movable instructions. Only includes instructions which are executed in every loop iteration.
@@ -228,7 +421,8 @@ private func collectMovableInstructions(
       case is UncheckedOwnershipConversionInst:
         break // TODO: Add support
       case is StoreInst:
-        break // Stores are moved out of the loop in `hoistAndSinkLoadsAndStores`
+          // Stores are moved out of the loop in `hoistAndSinkLoadsAndStores` and `speculativelyHoistInstructions`.
+          break
       case let condFailInst as CondFailInst:
         // We can (and must) hoist cond_fail instructions if the operand is
         // invariant. We must hoist them so that we preserve memory safety. A
@@ -349,7 +543,7 @@ private extension AnalyzedInstructions {
     
     return true
   }
-  
+
   /// Returns `true` if all stores to `accessPath` commonly dominate the loop exits.
   func storesCommonlyDominateExits(of loop: Loop, storingTo accessPath: AccessPath, _ context: FunctionPassContext) -> Bool {
     var exitingBlocksSet = BasicBlockSet(context)
@@ -565,17 +759,6 @@ private extension MovableInstructions {
     for scopedInst in scopedInsts {
       if let storeBorrowInst = scopedInst as? StoreBorrowInst {
         _ = storeBorrowInst.allocStack.hoist(outOf: loop, context)
-        
-        var sankFirst = false
-        for deallocStack in storeBorrowInst.allocStack.deallocations {
-          if sankFirst {
-            context.erase(instruction: deallocStack)
-          } else {
-            sankFirst = deallocStack.sink(outOf: loop, context)
-          }
-        }
-        
-        context.notifyInvalidatedStackNesting()
       }
 
       guard scopedInst.hoist(outOf: loop, context) else {
@@ -811,6 +994,23 @@ private extension MovableInstructions {
   }
 }
 
+private func hoistAllocAndDealloc(
+  allocStackInst: AllocStackInst, outOf loop: Loop, _ context: FunctionPassContext
+) {
+  allocStackInst.move(before: loop.preheader!.terminator, context)
+
+  var sankFirst = false
+  for deallocStack in allocStackInst.deallocations {
+    if sankFirst {
+      context.erase(instruction: deallocStack)
+    } else {
+      sankFirst = deallocStack.sink(outOf: loop, context)
+    }
+  }
+
+  context.notifyInvalidatedStackNesting()
+}
+  
 private extension Instruction {
   /// Returns `true` if this instruction follows the default hoisting heuristic which means it
   /// is not a terminator, allocation or deallocation and either a hoistable array semantics call or doesn't have memory effects.
@@ -842,6 +1042,9 @@ private extension Instruction {
       if let loadCopyInst = self as? LoadInst, loadCopyInst.loadOwnership == .copy {
         hoist(loadCopyInst: loadCopyInst, outOf: loop, context)
         return true
+      } else if let allocStackInst = self as? AllocStackInst {
+        hoistAllocAndDealloc(allocStackInst: allocStackInst, outOf: loop, context)
+        return true
       } else {
         move(before: terminator, context)
       }
@@ -868,7 +1071,7 @@ private extension Instruction {
       exitBlockBuilder.createEndBorrow(of: preheaderLoadBorrow)
     }
   }
-  
+
   func sink(outOf loop: Loop, _ context: FunctionPassContext) -> Bool {
     var changed = false
 

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
@@ -12,6 +12,10 @@
 
 import SIL
 
+private func log(_ message: @autoclosure () -> String) {
+  llvmDebug("loop-invariant-code-motion", message())
+}
+
 /// Hoist loop invariant code out of innermost loops.
 let loopInvariantCodeMotionPass = FunctionPass(name: "loop-invariant-code-motion") { function, context in
   for loop in context.loopTree.loops {
@@ -67,6 +71,8 @@ private struct MovableInstructions {
 private struct AnalyzedInstructions {
   /// Side effects of the loop.
   var loopSideEffects: StackWithCount<Instruction>
+  /// Non-load instructions that have no side effects but may read from memory.
+  var loopReadOnlyEffects: StackWithCount<Instruction>
   var loads: Stack<LoadInst>
   var stores: Stack<StoreInst>
   var scopedInsts: Stack<UnaryInstruction>
@@ -75,10 +81,13 @@ private struct AnalyzedInstructions {
   var dominatingBlocks: BasicBlockSet
 
   /// `true` if the loop has instructions which (may) read from memory, which are not in `Loads` and not in `sideEffects`.
-  var hasOtherMemReadingInsts = false
+  var hasOtherMemReadingInsts: Bool {
+    !loopReadOnlyEffects.isEmpty
+  }
   
   init (in loop: Loop, _ context: FunctionPassContext) {
     self.loopSideEffects = StackWithCount<Instruction>(context)
+    self.loopReadOnlyEffects = StackWithCount<Instruction>(context)
     self.loads = Stack<LoadInst>(context)
     self.stores = Stack<StoreInst>(context)
     self.scopedInsts = Stack<UnaryInstruction>(context)
@@ -87,6 +96,7 @@ private struct AnalyzedInstructions {
   
   mutating func deinitialize() {
     loopSideEffects.deinitialize()
+    loopReadOnlyEffects.deinitialize()
     loads.deinitialize()
     stores.deinitialize()
     scopedInsts.deinitialize()
@@ -107,7 +117,7 @@ private func analyzeLoopAndSplitLoads(loop: Loop, _ context: FunctionPassContext
 
   collectProjectableAccessPathsAndSplitLoads(in: loop, &analyzedInstructions, &movableInstructions, context)
 
-  collectSpeculativelyMovableInstructions(in: loop,  &movableInstructions)
+  collectSpeculativelyMovableInstructions(in: loop, analyzedInstructions, &movableInstructions, context)
 
   collectMovableInstructions(in: loop, analyzedInstructions, &movableInstructions, context)
     
@@ -139,7 +149,7 @@ private func analyzeInstructions(
       if inst.mayHaveSideEffects {
         analyzedInstructions.loopSideEffects.append(inst)
       } else if inst.mayReadFromMemory {
-        analyzedInstructions.hasOtherMemReadingInsts = true
+        analyzedInstructions.loopReadOnlyEffects.append(inst)
       }
     }
   }
@@ -178,12 +188,55 @@ private func collectProjectableAccessPathsAndSplitLoads(
 }
 
 /// Collect movable instructions, even if they are not executed in every loop iteration.
-private func collectSpeculativelyMovableInstructions(in loop: Loop, _ movableInstructions: inout MovableInstructions) {
+private func collectSpeculativelyMovableInstructions(in loop: Loop,
+                                                     _ analyzedInstructions: AnalyzedInstructions,
+                                                     _ movableInstructions: inout MovableInstructions,
+                                                     _ context: FunctionPassContext) {
+  var trivialStoreCounter = 0
+
   for bb in loop.loopBlocks {
     for inst in bb.instructions {
       switch inst {
-      case is LoadInst, is StoreInst:
+      case is LoadInst:
         movableInstructions.loadsAndStores.append(inst)
+      case let storeInst as StoreInst:
+        movableInstructions.loadsAndStores.append(inst)
+
+        // Trivial store instructions are also speculatively hoistable.
+        if storeInst.storeOwnership != .trivial {
+          break
+        }
+        
+        // Avoid quadratic complexity in corner cases. Usually, this limit will not be exceeded.
+        if trivialStoreCounter * analyzedInstructions.loopSideEffects.count >= 8000 {
+          break
+        }
+        trivialStoreCounter += 1
+
+        let accessPath = storeInst.destination.accessPath
+
+        if !analyzedInstructions.trivialStoreIsSpeculativelyHoistable(
+             outOf: loop, accessPath: accessPath, storeInst: storeInst, context)
+        {
+          break
+        }
+
+        // If the store's destination is an alloc_stack inside the loop, it must
+        // be hoisted before the store.
+        if case .stack(let allocStackInst) = accessPath.base,
+           loop.contains(block: allocStackInst.parentBlock) {
+          // Only hoist the alloc_stack if the store's other operand (the source) is
+          // loop-invariant; otherwise, the store cannot be hoisted.
+          if !loop.contains(block: storeInst.source.parentBlock),
+            storeInst.destination == allocStackInst
+              || !loop.contains(block: storeInst.destination.parentBlock)
+          {
+            movableInstructions.speculativelyHoistable.append(allocStackInst)
+            movableInstructions.speculativelyHoistable.append(storeInst)
+          }
+        } else {
+          movableInstructions.speculativelyHoistable.append(storeInst)
+        }
       case let refElementAddrInst as RefElementAddrInst:
         movableInstructions.speculativelyHoistable.append(refElementAddrInst)
       default:
@@ -228,7 +281,8 @@ private func collectMovableInstructions(
       case is UncheckedOwnershipConversionInst:
         break // TODO: Add support
       case is StoreInst:
-        break // Stores are moved out of the loop in `hoistAndSinkLoadsAndStores`
+          // Stores are moved out of the loop in `hoistAndSinkLoadsAndStores` and `speculativelyHoistInstructions`.
+          break
       case let condFailInst as CondFailInst:
         // We can (and must) hoist cond_fail instructions if the operand is
         // invariant. We must hoist them so that we preserve memory safety. A
@@ -347,6 +401,134 @@ private extension AnalyzedInstructions {
       return false
     }
     
+    return true
+  }
+
+  /// Returns true only if `storeInst` is speculatively hoistable out of `loop`.
+  func trivialStoreIsSpeculativelyHoistable(
+    outOf loop: Loop, accessPath: AccessPath, storeInst: StoreInst, _ context: FunctionPassContext
+  ) -> Bool {
+    precondition(storeInst.storeOwnership == .trivial)
+
+    log("Processing candidate hoistable store:\n\(storeInst.description)")
+
+    guard let address = accessPath.base.address,
+          address.type.isTrivial(in: storeInst.parentFunction)
+    else {
+      // Even a trivial address can be projected out of a non-trivial one.
+      // Hoisting the store in this case could hoist it into a region
+      // where the base address is borrowed. Bail out to avoid this when
+      // the accessBase is not known to be trivial.
+      log("Access base is unknown or non-trivial: \(accessPath.base.address?.description ?? "none").")
+      return false
+
+    }
+
+    if !storesUniqueReadableValue(
+      accessPath: accessPath, storeInst: storeInst, context)
+    {
+      log("Found an instruction with a read or write effect that prevents store hoisting.")
+      return false
+    }
+
+    // If a store in a non-exit-dominating block dominates all potentially
+    // aliased reads in the loop we may be able to hoist it speculatively. To do
+    // so, we have to ensure that the stored value could not be read after the
+    // loop. If the base address is an alloc_stack inside the loop, all uses
+    // will be inside the loop. If that alloc_stack is then hoisted, it will be
+    // safe to speculatively hoist the store.
+    //
+    // An alloc_stack outside the loop, or any non-alloc_stack access base,
+    // could be read after the loop. It is not safe to speculatively host the
+    // store in these cases. In the following example, hoisting the store would
+    // result in `n` always being set to 6, even if the predicate returned false
+    // on every iteration.
+    //
+    //   var n = 5 // Local or global
+    //   
+    //   for i in 0..<10 {
+    //     if pred(i) {
+    //       n = 6
+    //     }
+    //   }
+    //   
+    //   print(n) // 5 or 6?
+    if !dominatingBlocks.contains(storeInst.parentBlock) {
+      log("Block is not guaranteed to execute. Only hoistable if the access base is an alloc_stack inside the loop.")
+      switch accessPath.base {
+      case let .stack(allocStackInst):
+        if !loop.contains(block: allocStackInst.parentBlock) {
+          log("Access base is an alloc_stack outside the loop.")
+          return false
+        }
+      default:
+        log("Access base is not an alloc_stack.")
+        return false
+      }
+    }
+
+    log("Hoisting store.")
+    return true
+  }
+
+  /// Returns true only if `storeInst` dominates all reads that may alias with
+  /// this path, and there are no potentially aliasing writes that may overwrite
+  /// the value `storeInst` stored.
+  ///
+  /// For efficiency, the implementation may not detect all such cases, for
+  /// example, with stores in branches.
+  private func storesUniqueReadableValue(accessPath: AccessPath, storeInst: StoreInst, _ context: FunctionPassContext) -> Bool {
+    precondition(storeInst.storeOwnership == .trivial)
+    let aliasAnalysis = context.aliasAnalysis
+    let domTree = context.dominatorTree
+    let storeAddr = storeInst.destination
+
+    /// If `inst` has a write effect on `storeAddr`, or it has a read effect and
+    /// is not dominated by `storeInst`, it has a conflicting effect. In this
+    /// case we know `storeInst` does not meet our conditions.
+    let hasConflictingEffect = { (inst: Instruction) in
+      log(inst.description)
+      // Ignore the store itself.
+
+      switch inst {
+      case storeInst:
+        log("   instruction does not conflict with itself")
+        return false
+      case is DeallocStackInst:
+        // dealloc_stack of a trivial type ignores the actual written value so
+        // we can ignore its memory effects
+        log("   ignoring the effects of dealloc_stack")
+        return false
+      default:
+        break
+      }
+
+      // Pass the original address value until we can fix alias analysis.
+      let effect = aliasAnalysis.getMemoryEffect(of: inst, on: storeAddr)
+      if effect.write {
+        log("    CONFLICTS: write effect")
+        return true
+      } else if effect.read && !storeInst.dominates(inst, domTree) {
+        log("    CONFLICTS: read effect and instruction is not dominated by the store")
+        return true
+      }
+
+      log("    no conflicting read or write effect")
+      return false
+    }
+    
+    // loopSideEffects, loopReadOnlyEffects and loads partition the set of
+    // instructions with memory effects in the loop.
+    if loopSideEffects.contains(where: hasConflictingEffect) {
+      return false
+    }
+    if loopReadOnlyEffects.contains(where: hasConflictingEffect) {
+      return false
+    }
+    if loads.contains(where: hasConflictingEffect) {
+      return false
+    }
+
     return true
   }
   
@@ -565,17 +747,6 @@ private extension MovableInstructions {
     for scopedInst in scopedInsts {
       if let storeBorrowInst = scopedInst as? StoreBorrowInst {
         _ = storeBorrowInst.allocStack.hoist(outOf: loop, context)
-        
-        var sankFirst = false
-        for deallocStack in storeBorrowInst.allocStack.deallocations {
-          if sankFirst {
-            context.erase(instruction: deallocStack)
-          } else {
-            sankFirst = deallocStack.sink(outOf: loop, context)
-          }
-        }
-        
-        context.notifyInvalidatedStackNesting()
       }
 
       guard scopedInst.hoist(outOf: loop, context) else {
@@ -811,6 +982,21 @@ private extension MovableInstructions {
   }
 }
 
+func hoistAllocAndDealloc(allocStackInst: AllocStackInst, outOf loop: Loop, _ context: FunctionPassContext) {
+  allocStackInst.move(before: loop.preheader!.terminator, context)
+  
+  var sankFirst = false
+  for deallocStack in allocStackInst.deallocations {
+    if sankFirst {
+      context.erase(instruction: deallocStack)
+    } else {
+      sankFirst = deallocStack.sink(outOf: loop, context)
+    }
+  }
+  
+  context.notifyInvalidatedStackNesting()
+}
+  
 private extension Instruction {
   /// Returns `true` if this instruction follows the default hoisting heuristic which means it
   /// is not a terminator, allocation or deallocation and either a hoistable array semantics call or doesn't have memory effects.
@@ -842,6 +1028,9 @@ private extension Instruction {
       if let loadCopyInst = self as? LoadInst, loadCopyInst.loadOwnership == .copy {
         hoist(loadCopyInst: loadCopyInst, outOf: loop, context)
         return true
+      } else if let allocStackInst = self as? AllocStackInst {
+        hoistAllocAndDealloc(allocStackInst: allocStackInst, outOf: loop, context)
+        return true
       } else {
         move(before: terminator, context)
       }
@@ -868,7 +1057,7 @@ private extension Instruction {
       exitBlockBuilder.createEndBorrow(of: preheaderLoadBorrow)
     }
   }
-  
+
   func sink(outOf loop: Loop, _ context: FunctionPassContext) -> Bool {
     var changed = false
 

--- a/SwiftCompilerSources/Sources/SIL/Function.swift
+++ b/SwiftCompilerSources/Sources/SIL/Function.swift
@@ -692,6 +692,23 @@ extension Function {
                                                 withConvention: convention)
         return effects.memory.read
       },
+      // argumentMayWrite  (used by the MemoryLifetimeVerifier)
+      { (f: BridgedFunction, bridgedArgOp: BridgedOperand, bridgedAddr: BridgedValue) -> Bool in
+        let argOp = Operand(bridged: bridgedArgOp)
+        let addr = bridgedAddr.value
+        let applySite = argOp.instruction as! FullApplySite
+        let addrPath = addr.accessPath
+        let calleeArgIdx = applySite.calleeArgumentIndex(of: argOp)!
+        let convention = applySite.convention(of: argOp)!
+        assert(convention.isIndirectIn || convention.isInout)
+        let argPath = argOp.value.accessPath
+        assert(!argPath.isDistinct(from: addrPath))
+        let path = argPath.getProjection(to: addrPath) ?? SmallProjectionPath()
+        let effects = f.function.getSideEffects(forArgument: argOp.value.at(path),
+                                                atIndex: calleeArgIdx,
+                                                withConvention: convention)
+        return effects.memory.write
+      },
       // isDeinitBarrier
       { (f: BridgedFunction) -> Bool in
         return f.function.getSideEffects().isDeinitBarrier

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -642,16 +642,18 @@ struct BridgedFunction {
   typedef EffectInfo (* _Nonnull GetEffectInfoFn)(BridgedFunction, SwiftInt);
   typedef BridgedMemoryBehavior (* _Nonnull GetMemBehaviorFn)(BridgedFunction, bool);
   typedef bool (* _Nonnull ArgumentMayReadFn)(BridgedFunction, BridgedOperand, BridgedValue);
+  typedef bool (*_Nonnull ArgumentMayWriteFn)(BridgedFunction, BridgedOperand,
+                                              BridgedValue);
   typedef bool (* _Nonnull IsDeinitBarrierFn)(BridgedFunction);
 
-  static void registerBridging(SwiftMetatype metatype,
-              RegisterFn initFn, RegisterFn destroyFn,
-              WriteFn writeFn, ParseFn parseFn,
-              CopyEffectsFn copyEffectsFn,
-              GetEffectInfoFn effectInfoFn,
-              GetMemBehaviorFn memBehaviorFn,
-              ArgumentMayReadFn argumentMayReadFn,
-              IsDeinitBarrierFn isDeinitBarrierFn);
+  static void registerBridging(SwiftMetatype metatype, RegisterFn initFn,
+                               RegisterFn destroyFn, WriteFn writeFn,
+                               ParseFn parseFn, CopyEffectsFn copyEffectsFn,
+                               GetEffectInfoFn effectInfoFn,
+                               GetMemBehaviorFn memBehaviorFn,
+                               ArgumentMayReadFn argumentMayReadFn,
+                               ArgumentMayWriteFn argumentMayWriteFn,
+                               IsDeinitBarrierFn isDeinitBarrierFn);
 };
 
 struct OptionalBridgedFunction {

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -1313,6 +1313,7 @@ public:
 
   // Used by the MemoryLifetimeVerifier
   bool argumentMayRead(Operand *argOp, SILValue addr);
+  bool argumentMayWrite(Operand *argOp, SILValue addr);
 
   bool isDeinitBarrier();
 

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -218,6 +218,7 @@ static BridgedFunction::CopyEffectsFn copyEffectsFunction = nullptr;
 static BridgedFunction::GetEffectInfoFn getEffectInfoFunction = nullptr;
 static BridgedFunction::GetMemBehaviorFn getMemBehvaiorFunction = nullptr;
 static BridgedFunction::ArgumentMayReadFn argumentMayReadFunction = nullptr;
+static BridgedFunction::ArgumentMayWriteFn argumentMayWriteFunction = nullptr;
 static BridgedFunction::IsDeinitBarrierFn isDeinitBarrierFunction = nullptr;
 
 SILFunction::SILFunction(
@@ -1370,14 +1371,12 @@ void SILFunction::forEachSpecializeAttrTargetFunction(
   }
 }
 
-void BridgedFunction::registerBridging(SwiftMetatype metatype,
-            RegisterFn initFn, RegisterFn destroyFn,
-            WriteFn writeFn, ParseFn parseFn,
-            CopyEffectsFn copyEffectsFn,
-            GetEffectInfoFn effectInfoFn,
-            GetMemBehaviorFn memBehaviorFn,
-            ArgumentMayReadFn argumentMayReadFn,
-            IsDeinitBarrierFn isDeinitBarrierFn) {
+void BridgedFunction::registerBridging(
+    SwiftMetatype metatype, RegisterFn initFn, RegisterFn destroyFn,
+    WriteFn writeFn, ParseFn parseFn, CopyEffectsFn copyEffectsFn,
+    GetEffectInfoFn effectInfoFn, GetMemBehaviorFn memBehaviorFn,
+    ArgumentMayReadFn argumentMayReadFn, ArgumentMayWriteFn argumentMayWriteFn,
+    IsDeinitBarrierFn isDeinitBarrierFn) {
   functionMetatype = metatype;
   initFunction = initFn;
   destroyFunction = destroyFn;
@@ -1387,6 +1386,7 @@ void BridgedFunction::registerBridging(SwiftMetatype metatype,
   getEffectInfoFunction = effectInfoFn;
   getMemBehvaiorFunction = memBehaviorFn;
   argumentMayReadFunction = argumentMayReadFn;
+  argumentMayWriteFunction = argumentMayWriteFn;
   isDeinitBarrierFunction = isDeinitBarrierFn;
 }
 
@@ -1487,6 +1487,13 @@ bool SILFunction::argumentMayRead(Operand *argOp, SILValue addr) {
     return true;
 
   return argumentMayReadFunction({this}, {argOp}, {addr});
+}
+
+bool SILFunction::argumentMayWrite(Operand *argOp, SILValue addr) {
+  if (!argumentMayWriteFunction)
+    return true;
+
+  return argumentMayWriteFunction({this}, {argOp}, {addr});
 }
 
 bool SILFunction::isDeinitBarrier() {

--- a/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
+++ b/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
@@ -85,7 +85,25 @@ class MemoryLifetimeVerifier {
 
   void requireBitsSetForArgument(const Bits &bits, Operand *argOp);
 
+  void clearBitsForInArgument(Bits &bits, Operand *argOp, SILValue addr);
+
+  /// Iterate the callees of the apply that owns \p argOp and OR the results
+  /// of `hasArgumentEffect(callee, argOp, addr)`. Handles cases where callee
+  /// info is unavailable:
+  ///   - partial_apply                          → \p partialApplyResult
+  ///   - callee list unknown/incomplete         → \p unknownCalleesResult
+  ///   - \p addr is null                        → \p noAddressResult
+  ///   - callee has no argument effects computed → skipped
+  bool anyCalleeHasArgumentEffect(
+      Operand *argOp, SILValue addr, bool partialApplyResult,
+      bool unknownCalleesResult, bool noAddressResult,
+      llvm::function_ref<bool(SILFunction *, Operand *, SILValue)>
+          hasArgumentEffect);
+
   bool applyMayRead(Operand *argOp, SILValue addr);
+  /// Returns true if apply has known memory effects that indicate it cannot
+  /// write to addr.
+  bool applyMayNotWrite(Operand *argOp, SILValue addr);
 
   bool isStoreBorrowLocation(SILValue addr) {
     auto *loc = locations.getLocation(addr);
@@ -139,6 +157,23 @@ class MemoryLifetimeVerifier {
 
   void killBits(BitDataflow::BlockState &blockState, SILValue addr) {
     locations.killBits(blockState.genSet, blockState.killSet, addr);
+  }
+
+  bool isTrivialIndirectApplyArgumentNotWritten(Operand *argOp, SILValue addr) {
+    if (!ApplySite::classof(argOp->getUser())) {
+      // Not an apply
+      return false;
+    }
+    return addr->getType().isTrivial(function) && applyMayNotWrite(argOp, addr);
+  }
+
+  void killBitsForInArgument(BitDataflow::BlockState &blockState,
+                             Operand &argOp) {
+    SILValue addr = argOp.get();
+    if (isTrivialIndirectApplyArgumentNotWritten(&argOp, addr)) {
+      return;
+    }
+    killBits(blockState, addr);
   }
 
 public:
@@ -318,36 +353,74 @@ void MemoryLifetimeVerifier::requireBitsSetForArgument(const Bits &bits, Operand
   }
 }
 
-bool MemoryLifetimeVerifier::applyMayRead(Operand *argOp, SILValue addr) {
-  // Conservatively assume that a partial_apply does _not_ read an argument.
+void MemoryLifetimeVerifier::clearBitsForInArgument(Bits &bits, Operand *argOp,
+                                                    SILValue addr) {
+  // If a trivial type is passed as @in and the memory effects indicate that the
+  // address is not written to, then we can consider the address to still be
+  // initialised.
+  if (isTrivialIndirectApplyArgumentNotWritten(argOp, addr)) {
+    return;
+  }
+
+  locations.clearBits(bits, addr);
+}
+
+bool MemoryLifetimeVerifier::anyCalleeHasArgumentEffect(
+    Operand *argOp, SILValue addr, bool partialApplyResult,
+    bool unknownCalleesResult, bool noAddressResult,
+    llvm::function_ref<bool(SILFunction *, Operand *, SILValue)>
+        hasArgumentEffect) {
   if (isa<PartialApplyInst>(argOp->getUser()))
-    return false;
-  
+    return partialApplyResult;
+
   FullApplySite as(argOp->getUser());
   CalleeList callees;
   if (calleeCache) {
     callees = calleeCache->getCalleeList(as);
     if (callees.isIncomplete())
-      return true;
+      return unknownCalleesResult;
   } else if (auto *callee = as.getReferencedFunctionOrNull()) {
     callees = CalleeList(callee);
   } else {
-    return false;
+    return unknownCalleesResult;
   }
 
   if (!addr)
-    return false;
+    return noAddressResult;
 
   for (SILFunction *callee : callees) {
-    // If the callee has no side-effects computed, yet, ignore it.
-    // This can happen if a store to an unused inout has been eliminated at a call site
-    // and afterwards the callee is specialized and therefore doesn't have the required
-    // side-effects computed, yet.
-    if (callee->hasArgumentEffects() && callee->argumentMayRead(argOp, addr)) {
+    if (hasArgumentEffect(callee, argOp, addr))
       return true;
-    }
   }
   return false;
+}
+
+bool MemoryLifetimeVerifier::applyMayRead(Operand *argOp, SILValue addr) {
+  return anyCalleeHasArgumentEffect(
+      argOp, addr,
+      /*partialApplyResult=*/false,
+      /*unknownCalleesResult=*/true,
+      /*noAddressResult=*/false,
+      [](SILFunction *callee, Operand *op, SILValue a) {
+        // If the callee has no side-effects computed, yet, ignore it.
+        // This can happen if a store to an unused inout has been eliminated at
+        // a call site and afterwards the callee is specialized and therefore
+        // doesn't have the required side-effects computed, yet.
+        return callee->hasArgumentEffects() && callee->argumentMayRead(op, a);
+      });
+}
+
+bool MemoryLifetimeVerifier::applyMayNotWrite(Operand *argOp, SILValue addr) {
+  // Conservative direction is flipped: any uncertainty means we cannot prove
+  // the apply does *not* write, so we must return false in those cases.
+  return !anyCalleeHasArgumentEffect(
+      argOp, addr,
+      /*partialApplyResult=*/true,
+      /*unknownCalleesResult=*/true,
+      /*noAddressResult=*/true,
+      [](SILFunction *callee, Operand *op, SILValue a) {
+        return !callee->hasArgumentEffects() || callee->argumentMayWrite(op, a);
+      });
 }
 
 void MemoryLifetimeVerifier::requireNoStoreBorrowLocation(
@@ -598,7 +671,7 @@ void MemoryLifetimeVerifier::setFuncOperandBits(BlockState &state, Operand &op,
   switch (convention) {
     case SILArgumentConvention::Indirect_In_CXX:
     case SILArgumentConvention::Indirect_In:
-      killBits(state, op.get());
+      killBitsForInArgument(state, op);
       break;
     case SILArgumentConvention::Indirect_Out:
       // An `apply [nothrow]` does not initialize the indirect error result.
@@ -942,7 +1015,7 @@ void MemoryLifetimeVerifier::checkFuncArgument(Bits &bits, Operand &argumentOp,
     case SILArgumentConvention::Indirect_In_CXX:
     case SILArgumentConvention::Indirect_In:
       requireBitsSet(bits, argumentOp.get(), applyInst);
-      locations.clearBits(bits, argumentOp.get());
+      clearBitsForInArgument(bits, &argumentOp, argumentOp.get());
       break;
     case SILArgumentConvention::Indirect_Out:
       requireBitsClear(bits & locations.getNonTrivialLocations(),

--- a/test/SIL/memory_lifetime.sil
+++ b/test/SIL/memory_lifetime.sil
@@ -1086,3 +1086,96 @@ bb0:
   %r = tuple ()
   return %r
 }
+
+// Passing a trivial address as a @in parameter with read-only memory effects
+// does not deinitialise the address.
+sil @read_in : $@convention(thin) (@in Int) -> () {
+[%0: read v**]
+[global: ]
+}
+
+sil @make_index : $@convention(thin) () -> @out Int {
+[%0: write v**]
+[global: ]
+}
+
+sil [ossa] @in_read_only_trivial_no_deinit : $@convention(thin) (Int, Int) -> () {
+bb0(%0 : $Int, %1 : $Int):
+  %2 = integer_literal $Builtin.Int64, 1
+  %3 = integer_literal $Builtin.Int1, -1
+  %4 = struct_extract %1, #Int._value
+  %5 = integer_literal $Builtin.Int64, 0
+  %6 = builtin "cmp_eq_Int64"(%4, %5) : $Builtin.Int1
+  cond_br %6, bb5, bb1
+
+bb1:
+  %8 = alloc_stack $Int
+  store %0 to [trivial] %8
+  %10 = function_ref @make_index : $@convention(thin) () -> @out Int
+  %11 = function_ref @read_in : $@convention(thin) (@in Int) -> ()
+  br bb2(%5)
+
+bb2(%13 : $Builtin.Int64):
+  %16 = apply %11(%8) : $@convention(thin) (@in Int) -> ()
+  %18 = builtin "sadd_with_overflow_Int64"(%13, %2, %3) : $(Builtin.Int64, Builtin.Int1)
+  %19 = tuple_extract %18, 0
+  %20 = builtin "cmp_eq_Int64"(%19, %4) : $Builtin.Int1
+  cond_br %20, bb4, bb3
+
+bb3:
+  br bb2(%19)
+
+bb4:
+  dealloc_stack %8
+  br bb6
+
+bb5:
+  br bb6
+
+bb6:
+  %26 = tuple ()
+  return %26
+}
+
+
+sil @global_write : $@convention(thin) (@in Int) -> () {
+[global: write]
+}
+
+sil [ossa] @call_global_write : $@convention(thin) (Int, Int) -> () {
+bb0(%0 : $Int, %1 : $Int):
+  %2 = integer_literal $Builtin.Int64, 1
+  %3 = integer_literal $Builtin.Int1, -1
+  %4 = struct_extract %1, #Int._value
+  %5 = integer_literal $Builtin.Int64, 0
+  %6 = builtin "cmp_eq_Int64"(%4, %5) : $Builtin.Int1
+  cond_br %6, bb5, bb1
+
+bb1:
+  %8 = alloc_stack $Int
+  store %0 to [trivial] %8
+  %11 = function_ref @global_write : $@convention(thin) (@in Int) -> ()
+  br bb2(%5)
+
+bb2(%13 : $Builtin.Int64):
+  %16 = apply %11(%8) : $@convention(thin) (@in Int) -> ()
+  %18 = builtin "sadd_with_overflow_Int64"(%13, %2, %3) : $(Builtin.Int64, Builtin.Int1)
+  %19 = tuple_extract %18, 0
+  %20 = builtin "cmp_eq_Int64"(%19, %4) : $Builtin.Int1
+  cond_br %20, bb4, bb3
+
+bb3:
+  br bb2(%19)
+
+bb4:
+  dealloc_stack %8
+  br bb6
+
+bb5:
+  br bb6
+
+bb6:
+  %26 = tuple ()
+  return %26
+}
+

--- a/test/SIL/memory_lifetime_failures.sil
+++ b/test/SIL/memory_lifetime_failures.sil
@@ -997,3 +997,86 @@ bb0:
   %4 = tuple ()
   return %4
 }
+
+sil @read_write_in : $@convention(thin) (@in Int) -> () {
+[%0: read v**, write v**]
+[global: ]
+}
+
+// CHECK: SIL memory lifetime failure in @call_read_write_in: memory is not initialized, but should be
+sil [ossa] @call_read_write_in : $@convention(thin) (Int, Int) -> () {
+bb0(%0 : $Int, %1 : $Int):
+  %2 = integer_literal $Builtin.Int64, 1
+  %3 = integer_literal $Builtin.Int1, -1
+  %4 = struct_extract %1, #Int._value
+  %5 = integer_literal $Builtin.Int64, 0
+  %6 = builtin "cmp_eq_Int64"(%4, %5) : $Builtin.Int1
+  cond_br %6, bb5, bb1
+
+bb1:
+  %8 = alloc_stack $Int
+  store %0 to [trivial] %8
+  %11 = function_ref @read_write_in : $@convention(thin) (@in Int) -> ()
+  br bb2(%5)
+
+bb2(%13 : $Builtin.Int64):
+  %16 = apply %11(%8) : $@convention(thin) (@in Int) -> ()
+  %18 = builtin "sadd_with_overflow_Int64"(%13, %2, %3) : $(Builtin.Int64, Builtin.Int1)
+  %19 = tuple_extract %18, 0
+  %20 = builtin "cmp_eq_Int64"(%19, %4) : $Builtin.Int1
+  cond_br %20, bb4, bb3
+
+bb3:
+  br bb2(%19)
+
+bb4:
+  dealloc_stack %8
+  br bb6
+
+bb5:
+  br bb6
+
+bb6:
+  %26 = tuple ()
+  return %26
+}
+
+sil @unknown_in : $@convention(thin) (@in Int) -> ()
+
+// CHECK: SIL memory lifetime failure in @call_unknown_in: memory is not initialized, but should be
+sil [ossa] @call_unknown_in : $@convention(thin) (Int, Int) -> () {
+bb0(%0 : $Int, %1 : $Int):
+  %2 = integer_literal $Builtin.Int64, 1
+  %3 = integer_literal $Builtin.Int1, -1
+  %4 = struct_extract %1, #Int._value
+  %5 = integer_literal $Builtin.Int64, 0
+  %6 = builtin "cmp_eq_Int64"(%4, %5) : $Builtin.Int1
+  cond_br %6, bb5, bb1
+
+bb1:
+  %8 = alloc_stack $Int
+  store %0 to [trivial] %8
+  %11 = function_ref @unknown_in : $@convention(thin) (@in Int) -> ()
+  br bb2(%5)
+
+bb2(%13 : $Builtin.Int64):
+  %16 = apply %11(%8) : $@convention(thin) (@in Int) -> ()
+  %18 = builtin "sadd_with_overflow_Int64"(%13, %2, %3) : $(Builtin.Int64, Builtin.Int1)
+  %19 = tuple_extract %18, 0
+  %20 = builtin "cmp_eq_Int64"(%19, %4) : $Builtin.Int1
+  cond_br %20, bb4, bb3
+
+bb3:
+  br bb2(%19)
+
+bb4:
+  dealloc_stack %8
+  br bb6
+
+bb5:
+  br bb6
+
+bb6:
+  %26 = tuple ()
+  return %26
+}

--- a/test/SILOptimizer/inline_arrays.swift
+++ b/test/SILOptimizer/inline_arrays.swift
@@ -64,3 +64,135 @@ public struct S {
   }
 }
 
+// rdar://172132077 (Iterating over InlineArray copies the full array per iteration)
+//
+// The InlineArray is stored on the stack exactly once, and that allocation is
+// used in every iteration. Once we have large loadable address lowering, large
+// InlineArrays will be passed indirectly in SIL, allowing us to eliminate the
+// single top-level copy that remains.
+//
+// CHECK-LABEL: sil @$s4test25dontCopyEveryIterationBig1as5Int32Vs11InlineArrayVy$499_AEG_tF : $@convention(thin) (InlineArray<500, Int32>) -> Int32 {
+// CHECK:       bb0(%0 : $InlineArray<500, Int32>):
+// CHECK:         [[STK:%[0-9]+]] = alloc_stack
+// CHECK:         store %0 to [[STK]]
+// CHECK:       bb1:
+// CHECK-NOT:     = alloc_stack
+// CHECK-NOT:     store
+// CHECK:       } // end sil function '$s4test25dontCopyEveryIterationBig1as5Int32Vs11InlineArrayVy$499_AEG_tF'
+public func dontCopyEveryIterationBig(a: [500 of Int32]) -> Int32 {
+  var s: Int32 = 0
+  for i in a.indices {
+    s += a[i]
+  }
+  return s
+}
+
+// CHECK-LABEL: sil @$s4test31dontCopyEveryIterationBigBorrow1as5Int32Vs11InlineArrayVy$499_AEG_tF : $@convention(thin) (InlineArray<500, Int32>) -> Int32 {
+// CHECK:       bb0(%0 : @noImplicitCopy $InlineArray<500, Int32>):
+// CHECK:         [[STK:%[0-9]+]] = alloc_stack
+// CHECK:         store {{.*}} to [[STK]]
+// CHECK:       {{^}}bb1
+// CHECK-NOT:     = alloc_stack
+// CHECK-NOT:     store
+// CHECK:       } // end sil function '$s4test31dontCopyEveryIterationBigBorrow1as5Int32Vs11InlineArrayVy$499_AEG_tF'
+public func dontCopyEveryIterationBigBorrow(a: borrowing [500 of Int32]) -> Int32 {
+  var s: Int32 = 0
+  for i in a.indices {
+    s += a[i]
+  }
+  return s
+}
+
+// Take an array of indices to prevent loop unrolling.
+// CHECK-LABEL: sil @$s4test27dontCopyEveryIterationSmall1a7indicess5Int32Vs11InlineArrayVy$1_AFG_SayAFGtF : $@convention(thin) (InlineArray<2, Int32>, @guaranteed Array<Int32>) -> Int32 {
+// CHECK:       bb0(%0 : $InlineArray<2, Int32>, %1 : $Array<Int32>):
+// CHECK:       {{^}}bb1
+// CHECK:         [[STK:%[0-9]+]] = alloc_stack
+// CHECK:         store {{.*}} to [[STK]]
+// CHECK:       {{^}}bb2
+// CHECK-NOT:     = alloc_stack
+// CHECK-NOT:     store
+// CHECK:       } // end sil function '$s4test27dontCopyEveryIterationSmall1a7indicess5Int32Vs11InlineArrayVy$1_AFG_SayAFGtF'
+public func dontCopyEveryIterationSmall(a: [2 of Int32], indices: [Int32]) -> Int32 {
+  var s: Int32 = 0
+  for i in indices {
+    s += a[Int(i)]
+  }
+  return s
+}
+
+// Speculative store hoisting.
+// CHECK-LABEL: sil @$s4test36dontCopyEveryIterationBigConditional1a1fs5Int32Vs11InlineArrayVy$499_AFG_SbSiXEtF : $@convention(thin) (InlineArray<500, Int32>, @guaranteed @noescape @callee_guaranteed (Int) -> Bool) -> Int32 {
+// CHECK:       bb0(%0 : $InlineArray<500, Int32>, %1 : $@noescape @callee_guaranteed (Int) -> Bool):
+// CHECK:         [[STK:%[0-9]+]] = alloc_stack
+// CHECK:         store %0 to [[STK]]
+// CHECK:       {{^}}bb1
+// CHECK:       } // end sil function '$s4test36dontCopyEveryIterationBigConditional1a1fs5Int32Vs11InlineArrayVy$499_AFG_SbSiXEtF'
+public func dontCopyEveryIterationBigConditional(a: [500 of Int32], f: (Int) -> Bool) -> Int32 {
+  var s: Int32 = 0
+  for i in a.indices {
+    if f(i) {
+      s += a[i]
+    }
+  }
+  return s
+}
+
+// TODO: Speculatively hoist the store in this case, where the access base is outside the loop.
+// 
+// CHECK-LABEL: sil @$s4test38dontCopyEveryIterationSmallConditional1a7indices1fs5Int32Vs11InlineArrayVy$1_AGG_SayAGGSbSiXEtF : $@convention(thin) (InlineArray<2, Int32>, @guaranteed Array<Int32>, @guaranteed @noescape @callee_guaranteed (Int) -> Bool) -> Int32 {
+// CHECK:       bb0(%0 : $InlineArray<2, Int32>, %1 : $Array<Int32>, %2 : $@noescape @callee_guaranteed (Int) -> Bool):
+// CHECK:       bb1:
+// CHECK:       bb6:
+// CHECK:         alloc_stack
+// CHECK:         store
+// CHECK:       bb7:
+// CHECK:       } // end sil function '$s4test38dontCopyEveryIterationSmallConditional1a7indices1fs5Int32Vs11InlineArrayVy$1_AGG_SayAGGSbSiXEtF'
+public func dontCopyEveryIterationSmallConditional(a: [2 of Int32], indices: [Int32], f: (Int) -> Bool) -> Int32 {
+  var s: Int32 = 0
+  for i in indices {
+    if f(Int(i)) {
+      s += a[Int(i)]
+    }
+  }
+  return s
+}
+
+// TODO: Eliminate the redundant store in this case, where the loop is unrolled.
+//
+// CHECK-LABEL: sil @$s4test46dontCopyEveryIterationSmallConditionalUnrolled1a1fs5Int32Vs11InlineArrayVy$1_AFG_SbSiXEtF : $@convention(thin) (InlineArray<2, Int32>, @guaranteed @noescape @callee_guaranteed (Int) -> Bool) -> Int32 {
+// CHECK:         alloc_stack
+// CHECK:         store
+// CHECK:         store
+// CHECK:         dealloc_stack
+// CHECK-NOT:     alloc_stack
+// CHECK-NOT:     store
+// CHECK-NOT:     dealloc_stack
+// CHECK:       } // end sil function '$s4test46dontCopyEveryIterationSmallConditionalUnrolled1a1fs5Int32Vs11InlineArrayVy$1_AFG_SbSiXEtF'
+public func dontCopyEveryIterationSmallConditionalUnrolled(a: [2 of Int32], f: (Int) -> Bool) -> Int32 {
+  var s: Int32 = 0
+  for i in a.indices {
+    if f(i) {
+      s += a[i]
+    }
+  }
+  return s
+}
+
+// CHECK-LABEL: sil @$s4test5equalySbs11InlineArrayVy$31_SiG_AEtF : $@convention(thin) (InlineArray<32, Int>, InlineArray<32, Int>) -> Bool {
+// CHECK:       bb0(%0 : @noImplicitCopy $InlineArray<32, Int>, %1 : @noImplicitCopy $InlineArray<32, Int>):
+// CHECK:         [[STK1:%[0-9]+]] = alloc_stack
+// CHECK:         store {{.*}} to [[STK1]]
+// CHECK:         [[STK2:%[0-9]+]] = alloc_stack
+// CHECK:         store {{.*}} to [[STK2]]
+// CHECK:       {{^}}bb2
+// CHECK-NOT:     store
+// CHECK:       } // end sil function '$s4test5equalySbs11InlineArrayVy$31_SiG_AEtF'
+public func equal(_ lhs: borrowing [32 of Int], _ rhs: borrowing [32 of Int]) -> Bool {
+    for i in 0..<32 {
+        guard lhs[i] == rhs[i] else {
+            return false
+        }
+    }
+    return true
+}

--- a/test/SILOptimizer/licm.sil
+++ b/test/SILOptimizer/licm.sil
@@ -2519,3 +2519,645 @@ bb6:
   %r = tuple ()
   return %r 
 }
+
+// ==================================================================
+// Test trivial alloc_stack and store hoisting
+
+sil [ossa] @use_addr2 : $@convention(thin) (@inout Builtin.Int32) -> () {
+[global: ]
+[%0: write, read]
+}
+sil [ossa] @read_addr : $@convention(thin) (@in_guaranteed Builtin.Int32) -> () {
+[global: ]
+[%0: read]
+}
+sil [ossa] @next_idx : $@convention(thin) (Builtin.Word) -> Builtin.Word {
+[global: ]
+}
+
+sil [ossa] @unknown_effect : $@convention(thin) () -> ()
+
+// CHECK-LABEL:   sil [ossa] @hoist_dominating_store
+// CHECK:         {{^}}bb0
+// CHECK:           alloc_stack
+// CHECK:           store
+// CHECK:         {{^}}bb1
+// CHECK-NOT:       store
+// CHECK:           apply
+// CHECK:         {{^}}bb2:
+// CHECK:           dealloc_stack
+// CHECK:           return
+sil [ossa] @hoist_dominating_store : $@convention(thin) (Builtin.FixedArray<4, Builtin.Int32>, Builtin.Word) -> () {
+bb0(%0 : $Builtin.FixedArray<4, Builtin.Int32>, %1 : $Builtin.Word):
+  %313 = alloc_stack $Builtin.FixedArray<4, Builtin.Int32>
+  br bb1(%1)
+
+bb1(%idx : $Builtin.Word):
+  store %0 to [trivial] %313
+  %base = vector_base_addr %313
+  %next_idx = function_ref @next_idx : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %idx2 = apply %next_idx (%idx) : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %index_addr = index_addr %base, %idx
+
+  %f = function_ref @read_addr : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  %a = apply %f(%index_addr) : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  cond_br undef, bb3, bb2
+
+bb3:
+  br bb1(%idx2)
+
+bb2:
+  dealloc_stack %313
+  %52 = tuple ()
+  return %52 : $()
+}
+
+// CHECK-LABEL:   sil [ossa] @hoist_dominating_store_and_alloc
+// CHECK:         {{^}}bb0
+// CHECK:           alloc_stack
+// CHECK:           store
+// CHECK:         {{^}}bb1
+// CHECK-NOT:       store
+// CHECK:           apply
+// CHECK:         {{^}}bb2:
+// CHECK:           dealloc_stack
+// CHECK:           return
+sil [ossa] @hoist_dominating_store_and_alloc : $@convention(thin) (Builtin.FixedArray<4, Builtin.Int32>, Builtin.Word) -> () {
+bb0(%0 : $Builtin.FixedArray<4, Builtin.Int32>, %1 : $Builtin.Word):
+  br bb1(%1)
+
+bb1(%idx : $Builtin.Word):
+  %313 = alloc_stack $Builtin.FixedArray<4, Builtin.Int32>
+  store %0 to [trivial] %313
+  %base = vector_base_addr %313
+  %next_idx = function_ref @next_idx : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %idx2 = apply %next_idx (%idx) : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %index_addr = index_addr %base, %idx
+
+  %f = function_ref @read_addr : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  %a = apply %f(%index_addr) : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  dealloc_stack %313
+  cond_br undef, bb3, bb2
+
+bb3:
+  br bb1(%idx2)
+
+bb2:
+  %52 = tuple ()
+  return %52 : $()
+}
+
+// CHECK-LABEL:   sil [ossa] @hoist_dominating_store_load
+// CHECK:         {{^}}bb0
+// CHECK:           alloc_stack
+// CHECK:           store
+// CHECK:         {{^}}bb1
+// CHECK-NOT:       store
+// CHECK:           apply
+// CHECK:           load
+// CHECK:         {{^}}bb2:
+// CHECK:           dealloc_stack
+// CHECK:           return
+sil [ossa] @hoist_dominating_store_load : $@convention(thin) (Builtin.FixedArray<4, Builtin.Int32>, Builtin.Word) -> Builtin.Int32 {
+bb0(%0 : $Builtin.FixedArray<4, Builtin.Int32>, %1 : $Builtin.Word):
+  br bb1(%1)
+
+bb1(%idx : $Builtin.Word):
+  %313 = alloc_stack $Builtin.FixedArray<4, Builtin.Int32>
+  store %0 to [trivial] %313
+  %base = vector_base_addr %313
+  %next_idx = function_ref @next_idx : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %idx2 = apply %next_idx (%idx) : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %index_addr = index_addr %base, %idx
+
+  %a = load [trivial] %index_addr
+  dealloc_stack %313
+  cond_br undef, bb3, bb2
+
+bb3:
+  br bb1(%idx2)
+
+bb2:
+  return %a
+}
+
+// CHECK-LABEL:   sil [ossa] @hoist_dominating_store_non_alloc_base
+// CHECK:         {{^}}bb0
+// CHECK:           store
+// CHECK:         {{^}}bb1
+// CHECK-NOT:       store
+// CHECK:           apply
+// CHECK:         {{^}}bb2:
+// CHECK:           return
+sil [ossa] @hoist_dominating_store_non_alloc_base : $@convention(thin) (Builtin.FixedArray<4, Builtin.Int32>, Builtin.Word, @inout Builtin.FixedArray<4, Builtin.Int32>) -> () {
+bb0(%0 : $Builtin.FixedArray<4, Builtin.Int32>, %1 : $Builtin.Word, %2 : $*Builtin.FixedArray<4, Builtin.Int32>):
+  br bb1(%1)
+
+bb1(%idx : $Builtin.Word):
+  store %0 to [trivial] %2
+  %base = vector_base_addr %2
+  %next_idx = function_ref @next_idx : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %idx2 = apply %next_idx (%idx) : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %index_addr = index_addr %base, %idx
+
+  %f = function_ref @read_addr : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  %a = apply %f(%index_addr) : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  cond_br undef, bb3, bb2
+
+bb3:
+  br bb1(%idx2)
+
+bb2:
+  %52 = tuple ()
+  return %52 : $()
+}
+
+
+// CHECK-LABEL:   sil [ossa] @dont_hoist_multi_store
+// CHECK:         {{^}}bb0
+// CHECK:         {{^}}bb1
+// CHECK:           alloc_stack
+// CHECK:           store
+// CHECK:           apply
+// CHECK:           store
+// CHECK:           dealloc_stack
+// CHECK:         {{^}}bb2:
+// CHECK:           return
+sil [ossa] @dont_hoist_multi_store : $@convention(thin) (Builtin.FixedArray<4, Builtin.Int32>, Builtin.FixedArray<4, Builtin.Int32>, Builtin.Word) -> () {
+bb0(%0 : $Builtin.FixedArray<4, Builtin.Int32>, %1 : $Builtin.FixedArray<4, Builtin.Int32>, %2 : $Builtin.Word):
+  br bb1(%2)
+
+bb1(%idx : $Builtin.Word):
+  %313 = alloc_stack $Builtin.FixedArray<4, Builtin.Int32>
+  store %0 to [trivial] %313
+  %base = vector_base_addr %313
+  %next_idx = function_ref @next_idx : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %idx2 = apply %next_idx (%idx) : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %index_addr = index_addr %base, %idx
+
+  store %1 to [trivial] %313
+  dealloc_stack %313
+  cond_br undef, bb3, bb2
+
+bb3:
+  br bb1(%idx2)
+
+bb2:
+  %52 = tuple ()
+  return %52 : $()
+}
+
+// We do not currently hoist the store and alloc_stack if the store does not write directly to the alloc_stack.
+//
+// CHECK-LABEL:   sil [ossa] @dont_hoist_access_path
+// CHECK:         {{^}}bb0
+// CHECK:         {{^}}bb1
+// CHECK:           alloc_stack
+// CHECK:           struct_element_addr
+// CHECK:           store
+// CHECK:           dealloc_stack
+// CHECK:         {{^}}bb2:
+// CHECK:           return
+sil [ossa] @dont_hoist_access_path : $@convention(thin) (Int, S, Builtin.Word) -> () {
+bb0(%0 : $Int, %1 : @unowned $S, %2 : $Builtin.Word):
+  br bb1(%2)
+
+bb1(%idx : $Builtin.Word):
+  %313 = alloc_stack $S
+  %i_addr = struct_element_addr %313, #S.i
+  store %0 to [trivial] %i_addr
+  %next_idx = function_ref @next_idx : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %idx2 = apply %next_idx (%idx) : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  dealloc_stack %313
+  cond_br undef, bb3, bb2
+
+bb3:
+  br bb1(%idx2)
+
+bb2:
+  %52 = tuple ()
+  return %52 : $()
+}
+
+// CHECK-LABEL:   sil [ossa] @dont_hoist_write_effect
+// CHECK:         {{^}}bb0
+// CHECK:         {{^}}bb1
+// CHECK:           alloc_stack
+// CHECK:           store
+// CHECK:           apply
+// CHECK:           dealloc_stack
+// CHECK:         {{^}}bb2:
+// CHECK:           return
+sil [ossa] @dont_hoist_write_effect : $@convention(thin) (Builtin.FixedArray<4, Builtin.Int32>, Builtin.FixedArray<4, Builtin.Int32>, Builtin.Word) -> () {
+bb0(%0 : $Builtin.FixedArray<4, Builtin.Int32>, %1 : $Builtin.FixedArray<4, Builtin.Int32>, %2 : $Builtin.Word):
+  br bb1(%2)
+
+bb1(%idx : $Builtin.Word):
+  %313 = alloc_stack $Builtin.FixedArray<4, Builtin.Int32>
+  store %0 to [trivial] %313
+  %base = vector_base_addr %313
+  %next_idx = function_ref @next_idx : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %idx2 = apply %next_idx (%idx) : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %index_addr = index_addr %base, %idx
+
+  %f = function_ref @use_addr2 : $@convention(thin) (@inout Builtin.Int32) -> ()
+  %a = apply %f(%index_addr) : $@convention(thin) (@inout Builtin.Int32) -> ()
+  dealloc_stack %313
+  cond_br undef, bb3, bb2
+
+bb3:
+  br bb1(%idx2)
+
+bb2:
+  %52 = tuple ()
+  return %52 : $()
+}
+
+
+// CHECK-LABEL:   sil [ossa] @dont_hoist_unknown_effect
+// CHECK:         {{^}}bb0
+// CHECK:         {{^}}bb1
+// CHECK:           alloc_stack
+// CHECK:           store
+// CHECK:           apply
+// CHECK:           dealloc_stack
+// CHECK:         {{^}}bb2:
+// CHECK:           return
+sil [ossa] @dont_hoist_unknown_effect : $@convention(thin) (Builtin.FixedArray<4, Builtin.Int32>, Builtin.FixedArray<4, Builtin.Int32>, Builtin.Word) -> () {
+bb0(%0 : $Builtin.FixedArray<4, Builtin.Int32>, %1 : $Builtin.FixedArray<4, Builtin.Int32>, %2 : $Builtin.Word):
+  br bb1(%2)
+
+bb1(%idx : $Builtin.Word):
+  %313 = alloc_stack $Builtin.FixedArray<4, Builtin.Int32>
+  store %0 to [trivial] %313
+  %base = vector_base_addr %313
+  %next_idx = function_ref @next_idx : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %idx2 = apply %next_idx (%idx) : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %index_addr = index_addr %base, %idx
+
+  %f = function_ref @read_addr : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  %a = apply %f(%index_addr) : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  %unknown = function_ref @unknown_effect : $@convention(thin) () -> ()
+  apply %unknown() : $@convention(thin) () -> ()
+  dealloc_stack %313
+  cond_br undef, bb3, bb2
+
+bb3:
+  br bb1(%idx2)
+
+bb2:
+  %52 = tuple ()
+  return %52 : $()
+}
+
+
+// CHECK-LABEL:   sil [ossa] @dont_hoist_with_preceding_read
+// CHECK:         {{^}}bb0
+// CHECK:           alloc_stack
+// CHECK:           store %1
+// CHECK:         {{^}}bb1
+// CHECK:           apply
+// CHECK:           store %0
+// CHECK:         {{^}}bb2:
+// CHECK:           dealloc_stack
+// CHECK:           return
+sil [ossa] @dont_hoist_with_preceding_read : $@convention(thin) (Builtin.FixedArray<4, Builtin.Int32>, Builtin.FixedArray<4, Builtin.Int32>, Builtin.Word) -> () {
+bb0(%0 : $Builtin.FixedArray<4, Builtin.Int32>, %1 : $Builtin.FixedArray<4, Builtin.Int32>, %2 : $Builtin.Word):
+  %313 = alloc_stack $Builtin.FixedArray<4, Builtin.Int32>
+  store %1 to [trivial] %313
+  br bb1(%2)
+
+bb1(%idx : $Builtin.Word):
+  %base = vector_base_addr %313
+  %next_idx = function_ref @next_idx : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %idx2 = apply %next_idx (%idx) : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %index_addr = index_addr %base, %idx
+
+  %f = function_ref @read_addr : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  %a = apply %f(%index_addr) : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  store %0 to [trivial] %313
+  cond_br undef, bb3, bb2
+
+bb3:
+  br bb1(%idx2)
+
+bb2:
+  dealloc_stack %313
+  %52 = tuple ()
+  return %52 : $()
+}
+
+// CHECK-LABEL:   sil [ossa] @hoist_with_conditional_read_in_branch
+// CHECK:         {{^}}bb0
+// CHECK:           alloc_stack
+// CHECK:           store %0
+// CHECK:         {{^}}bb1
+// CHECK:           apply
+// CHECK:         {{^}}bb6:
+// CHECK:           dealloc_stack
+// CHECK:           return
+sil [ossa] @hoist_with_conditional_read_in_branch : $@convention(thin) (Builtin.FixedArray<4, Builtin.Int32>, Builtin.FixedArray<4, Builtin.Int32>, Builtin.Word) -> () {
+bb0(%0 : $Builtin.FixedArray<4, Builtin.Int32>, %1 : $Builtin.FixedArray<4, Builtin.Int32>, %2 : $Builtin.Word):
+  %313 = alloc_stack $Builtin.FixedArray<4, Builtin.Int32>
+  br bb1(%2)
+
+bb1(%idx : $Builtin.Word):
+  store %0 to [trivial] %313
+  %base = vector_base_addr %313
+  %next_idx = function_ref @next_idx : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %idx2 = apply %next_idx (%idx) : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %index_addr = index_addr %base, %idx
+
+  cond_br undef, bb2, bb6
+
+bb2:
+  cond_br undef, bb3, bb4
+
+bb3:
+  %f = function_ref @read_addr : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  %a = apply %f(%index_addr) : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  br bb5
+
+bb4:
+  br bb5
+
+bb5:
+  br bb1(%idx2)
+
+bb6:
+  dealloc_stack %313
+  %52 = tuple ()
+  return %52 : $()
+}
+
+
+// CHECK-LABEL:   sil [ossa] @dont_hoist_with_conditional_store_in_branch
+// CHECK:         {{^}}bb0
+// CHECK:           alloc_stack
+// CHECK:           store %1
+// CHECK-NOT:       store %0
+// CHECK:         {{^}}bb1
+// CHECK:         {{^}}bb3
+// CHECK:           store %0
+// CHECK:         {{^}}bb4
+// CHECK:         {{^}}bb5
+// CHECK:           apply
+// CHECK:         {{^}}bb6:
+// CHECK:           dealloc_stack
+// CHECK:           return
+sil [ossa] @dont_hoist_with_conditional_store_in_branch : $@convention(thin) (Builtin.FixedArray<4, Builtin.Int32>, Builtin.FixedArray<4, Builtin.Int32>, Builtin.Word) -> () {
+bb0(%0 : $Builtin.FixedArray<4, Builtin.Int32>, %1 : $Builtin.FixedArray<4, Builtin.Int32>, %2 : $Builtin.Word):
+  %313 = alloc_stack $Builtin.FixedArray<4, Builtin.Int32>
+  store %1 to [trivial] %313
+  br bb1(%2)
+
+bb1(%idx : $Builtin.Word):
+  %base = vector_base_addr %313
+  %next_idx = function_ref @next_idx : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %idx2 = apply %next_idx (%idx) : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %index_addr = index_addr %base, %idx
+
+  cond_br undef, bb2, bb6
+
+bb2:
+  cond_br undef, bb3, bb4
+
+bb3:
+  store %0 to [trivial] %313
+  br bb5
+
+bb4:
+  br bb5
+
+bb5:
+  %f = function_ref @read_addr : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  %a = apply %f(%index_addr) : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  br bb1(%idx2)
+
+bb6:
+  dealloc_stack %313
+  %52 = tuple ()
+  return %52 : $()
+}
+
+// If a store in a non-dominating block dominates all reads in the loop we may
+// be able to hoist it speculatively. To do so we have to ensure that the stored
+// value could not be read after the loop, at least in cases where the branch it
+// was hoisted from never executed. If the base address is an alloc_stack that
+// has been hoisted out of the loop, all uses will either be in the loop or
+// dealloc_stack; this case is common and cheap to check
+//
+// CHECK-LABEL:   sil [ossa] @hoist_dominating_store_speculatively
+// CHECK:         {{^}}bb0
+// CHECK:           alloc_stack
+// CHECK:           store %0
+// CHECK:         {{^}}bb1
+// CHECK-NOT:       store %0
+// CHECK:         {{^}}bb6:
+// CHECK:           dealloc_stack
+// CHECK:           return
+sil [ossa] @hoist_dominating_store_speculatively : $@convention(thin) (Builtin.FixedArray<4, Builtin.Int32>, Builtin.FixedArray<4, Builtin.Int32>, Builtin.Word) -> () {
+bb0(%0 : $Builtin.FixedArray<4, Builtin.Int32>, %1 : $Builtin.FixedArray<4, Builtin.Int32>, %2 : $Builtin.Word):
+  br bb1(%2)
+
+bb1(%idx : $Builtin.Word):
+  %next_idx = function_ref @next_idx : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %idx2 = apply %next_idx (%idx) : $@convention(thin) (Builtin.Word) -> Builtin.Word
+
+  cond_br undef, bb2, bb6
+
+bb2:
+  cond_br undef, bb3, bb4
+
+bb3:
+  %313 = alloc_stack $Builtin.FixedArray<4, Builtin.Int32>
+  %base = vector_base_addr %313
+  %index_addr = index_addr %base, %idx
+  store %0 to [trivial] %313
+  %f = function_ref @read_addr : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  %a = apply %f(%index_addr) : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  dealloc_stack %313
+  br bb5
+
+bb4:
+  br bb5
+
+bb5:
+  br bb1(%idx2)
+
+bb6:
+  %52 = tuple ()
+  return %52 : $()
+}
+
+// If the access base of the store lives outside the loop, we could have to
+// analyse the memory effects of all instructions between the end of the loop
+// and the end of its lifetime to know it is safe to hoist the store. We
+// currently do not, so bail.
+// 
+// CHECK-LABEL:   sil [ossa] @dont_hoist_dominating_store_speculatively_outer_alloc_stack
+// CHECK:         {{^}}bb0
+// CHECK:           alloc_stack
+// CHECK-NOT:       store %0
+// CHECK:         {{^}}bb3
+// CHECK:           store %0
+// CHECK:         {{^}}bb6:
+// CHECK:           dealloc_stack
+// CHECK:           return
+// CHECK:         } // end sil function 'dont_hoist_dominating_store_speculatively_outer_alloc_stack'
+sil [ossa] @dont_hoist_dominating_store_speculatively_outer_alloc_stack : $@convention(thin) (Builtin.FixedArray<4, Builtin.Int32>, Builtin.FixedArray<4, Builtin.Int32>, Builtin.Word) -> () {
+bb0(%0 : $Builtin.FixedArray<4, Builtin.Int32>, %1 : $Builtin.FixedArray<4, Builtin.Int32>, %2 : $Builtin.Word):
+  %313 = alloc_stack $Builtin.FixedArray<4, Builtin.Int32>
+  br bb1(%2)
+
+bb1(%idx : $Builtin.Word):
+  %next_idx = function_ref @next_idx : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %idx2 = apply %next_idx (%idx) : $@convention(thin) (Builtin.Word) -> Builtin.Word
+
+  cond_br undef, bb2, bb6
+
+bb2:
+  cond_br undef, bb3, bb4
+
+bb3:
+  %base = vector_base_addr %313
+  %index_addr = index_addr %base, %idx
+  store %0 to [trivial] %313
+  %f = function_ref @read_addr : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  %a = apply %f(%index_addr) : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  br bb5
+
+bb4:
+  br bb5
+
+bb5:
+  br bb1(%idx2)
+
+bb6:
+  dealloc_stack %313
+  %52 = tuple ()
+  return %52 : $()
+}
+
+// CHECK-LABEL:   sil [ossa] @dont_hoist_dominating_store_speculatively_non_alloc_stack_base
+// CHECK:         {{^}}bb0
+// CHECK-NOT:       alloc_stack
+// CHECK-NOT:       store %0
+// CHECK:         {{^}}bb3
+// CHECK:           store %0
+// CHECK:         {{^}}bb4
+// CHECK:         {{^}}bb6:
+// CHECK:           return
+// CHECK:         } // end sil function 'dont_hoist_dominating_store_speculatively_non_alloc_stack_base'
+sil [ossa] @dont_hoist_dominating_store_speculatively_non_alloc_stack_base : $@convention(thin) (Builtin.FixedArray<4, Builtin.Int32>, Builtin.FixedArray<4, Builtin.Int32>, Builtin.Word, @inout Builtin.FixedArray<4, Builtin.Int32>) -> () {
+bb0(%0 : $Builtin.FixedArray<4, Builtin.Int32>, %1 : $Builtin.FixedArray<4, Builtin.Int32>, %2 : $Builtin.Word, %3 : $*Builtin.FixedArray<4, Builtin.Int32>):
+  br bb1(%2)
+
+bb1(%idx : $Builtin.Word):
+  %next_idx = function_ref @next_idx : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %idx2 = apply %next_idx (%idx) : $@convention(thin) (Builtin.Word) -> Builtin.Word
+
+  cond_br undef, bb2, bb6
+
+bb2:
+  cond_br undef, bb3, bb4
+
+bb3:
+  %base = vector_base_addr %3
+  %index_addr = index_addr %base, %idx
+  store %0 to [trivial] %3
+  %f = function_ref @read_addr : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  %a = apply %f(%index_addr) : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  br bb5
+
+bb4:
+  br bb5
+
+bb5:
+  br bb1(%idx2)
+
+bb6:
+  %52 = tuple ()
+  return %52 : $()
+}
+
+sil @read_in : $@convention(thin) (@in Int32) -> () {
+[%0: read v**]
+[global: ]
+}
+
+// CHECK-LABEL: sil [ossa] @in_read_only_trivial_no_deinit : $@convention(thin) (Int32, Int32) -> () {
+// CHECK:       bb0(%0 : $Int32, %1 : $Int32):
+// CHECK:       bb1:
+// CHECK:         = alloc_stack
+// CHECK:         store
+// CHECK:       {{^}}bb2
+// CHECK-NOT:     store
+// CHECK:       bb4:
+// CHECK:         dealloc_stack
+// CHECK:       bb5:
+// CHECK-LABEL: } // end sil function 'in_read_only_trivial_no_deinit'
+sil [ossa] @in_read_only_trivial_no_deinit : $@convention(thin) (Int32, Int32) -> () {
+bb0(%0 : $Int32, %1 : $Int32):
+  %2 = integer_literal $Builtin.Int32, 1
+  %3 = integer_literal $Builtin.Int1, -1
+  %4 = struct_extract %1, #Int32._value
+  %5 = integer_literal $Builtin.Int32, 0
+  %6 = builtin "cmp_eq_Int32"(%4, %5) : $Builtin.Int1
+  cond_br %6, bb5, bb1
+
+bb1:
+  %11 = function_ref @read_in : $@convention(thin) (@in Int32) -> ()
+  br bb2(%5)
+
+bb2(%13 : $Builtin.Int32):
+  %8 = alloc_stack $Int32
+  store %0 to [trivial] %8
+  %16 = apply %11(%8) : $@convention(thin) (@in Int32) -> ()
+  %18 = builtin "sadd_with_overflow_Int32"(%13, %2, %3) : $(Builtin.Int32, Builtin.Int1)
+  %19 = tuple_extract %18, 0
+  %20 = builtin "cmp_eq_Int32"(%19, %4) : $Builtin.Int1
+  dealloc_stack %8
+  cond_br %20, bb4, bb3
+
+bb3:
+  br bb2(%19)
+
+bb4:
+  br bb6
+
+bb5:
+  br bb6
+
+bb6:
+  %26 = tuple ()
+  return %26
+}
+
+// CHECK-LABEL: sil [ossa] @dont_hoist_invariant_store_or_alloc : $@convention(thin) (Builtin.Word, Builtin.Word) -> Builtin.Word {
+// CHECK:       bb0(%0 : $Builtin.Word, %1 : $Builtin.Word):
+// CHECK:       bb1({{.*}}):
+// CHECK:         = alloc_stack
+// CHECK:         store
+// CHECK:         dealloc_stack
+// CHECK:       bb2:
+// CHECK:       } // end sil function 'dont_hoist_invariant_store_or_alloc'
+sil [ossa] @dont_hoist_invariant_store_or_alloc : $@convention(thin) (Builtin.Word, Builtin.Word) -> Builtin.Word {
+bb0(%0 : $Builtin.Word, %1 : $Builtin.Word):
+  br bb1(%1)
+
+bb1(%idx : $Builtin.Word):
+  %313 = alloc_stack $Builtin.Word
+  store %idx to [trivial] %313
+  %next_idx = function_ref @next_idx : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %idx2 = apply %next_idx (%idx) : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %a = load [trivial] %313
+  dealloc_stack %313
+  cond_br undef, bb3, bb2
+
+bb3:
+  br bb1(%idx2)
+
+bb2:
+  return %a
+}

--- a/test/SILOptimizer/licm.sil
+++ b/test/SILOptimizer/licm.sil
@@ -2519,3 +2519,582 @@ bb6:
   %r = tuple ()
   return %r 
 }
+
+// ==================================================================
+// Test trivial alloc_stack and store hoisting
+
+sil [ossa] @use_addr2 : $@convention(thin) (@inout Builtin.Int32) -> () {
+[global: ]
+[%0: write, read]
+}
+sil [ossa] @read_addr : $@convention(thin) (@in_guaranteed Builtin.Int32) -> () {
+[global: ]
+[%0: read]
+}
+sil [ossa] @next_idx : $@convention(thin) (Builtin.Word) -> Builtin.Word {
+[global: ]
+}
+
+sil [ossa] @unknown_effect : $@convention(thin) () -> ()
+
+// CHECK-LABEL:   sil [ossa] @hoist_dominating_store
+// CHECK:         {{^}}bb0
+// CHECK:           alloc_stack
+// CHECK:           store
+// CHECK:         {{^}}bb1
+// CHECK-NOT:       store
+// CHECK:           apply
+// CHECK:         {{^}}bb2:
+// CHECK:           dealloc_stack
+// CHECK:           return
+sil [ossa] @hoist_dominating_store : $@convention(thin) (Builtin.FixedArray<4, Builtin.Int32>, Builtin.Word) -> () {
+bb0(%0 : $Builtin.FixedArray<4, Builtin.Int32>, %1 : $Builtin.Word):
+  br bb1(%1)
+
+bb1(%idx : $Builtin.Word):
+  %313 = alloc_stack $Builtin.FixedArray<4, Builtin.Int32>
+  store %0 to [trivial] %313
+  %base = vector_base_addr %313
+  %next_idx = function_ref @next_idx : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %idx2 = apply %next_idx (%idx) : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %index_addr = index_addr %base, %idx
+
+  %f = function_ref @read_addr : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  %a = apply %f(%index_addr) : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  dealloc_stack %313
+  cond_br undef, bb3, bb2
+
+bb3:
+  br bb1(%idx2)
+
+bb2:
+  %52 = tuple ()
+  return %52 : $()
+}
+
+// CHECK-LABEL:   sil [ossa] @hoist_dominating_store_and_alloc
+// CHECK:         {{^}}bb0
+// CHECK:           alloc_stack
+// CHECK:           store
+// CHECK:         {{^}}bb1
+// CHECK-NOT:       store
+// CHECK:           apply
+// CHECK:         {{^}}bb2:
+// CHECK:           dealloc_stack
+// CHECK:           return
+sil [ossa] @hoist_dominating_store_and_alloc : $@convention(thin) (Builtin.FixedArray<4, Builtin.Int32>, Builtin.Word) -> () {
+bb0(%0 : $Builtin.FixedArray<4, Builtin.Int32>, %1 : $Builtin.Word):
+  %313 = alloc_stack $Builtin.FixedArray<4, Builtin.Int32>
+  br bb1(%1)
+
+bb1(%idx : $Builtin.Word):
+  store %0 to [trivial] %313
+  %base = vector_base_addr %313
+  %next_idx = function_ref @next_idx : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %idx2 = apply %next_idx (%idx) : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %index_addr = index_addr %base, %idx
+
+  %f = function_ref @read_addr : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  %a = apply %f(%index_addr) : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  cond_br undef, bb3, bb2
+
+bb3:
+  br bb1(%idx2)
+
+bb2:
+  dealloc_stack %313
+  %52 = tuple ()
+  return %52 : $()
+}
+
+// CHECK-LABEL:   sil [ossa] @hoist_dominating_store_load
+// CHECK:         {{^}}bb0
+// CHECK:           alloc_stack
+// CHECK:           store
+// CHECK:         {{^}}bb1
+// CHECK-NOT:       store
+// CHECK:           apply
+// CHECK:           load
+// CHECK:         {{^}}bb2:
+// CHECK:           dealloc_stack
+// CHECK:           return
+sil [ossa] @hoist_dominating_store_load : $@convention(thin) (Builtin.FixedArray<4, Builtin.Int32>, Builtin.Word) -> Builtin.Int32 {
+bb0(%0 : $Builtin.FixedArray<4, Builtin.Int32>, %1 : $Builtin.Word):
+  br bb1(%1)
+
+bb1(%idx : $Builtin.Word):
+  %313 = alloc_stack $Builtin.FixedArray<4, Builtin.Int32>
+  store %0 to [trivial] %313
+  %base = vector_base_addr %313
+  %next_idx = function_ref @next_idx : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %idx2 = apply %next_idx (%idx) : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %index_addr = index_addr %base, %idx
+
+  %a = load [trivial] %index_addr
+  dealloc_stack %313
+  cond_br undef, bb3, bb2
+
+bb3:
+  br bb1(%idx2)
+
+bb2:
+  return %a
+}
+
+
+// CHECK-LABEL:   sil [ossa] @dont_hoist_multi_store
+// CHECK:         {{^}}bb0
+// CHECK:         {{^}}bb1
+// CHECK:           alloc_stack
+// CHECK:           store
+// CHECK:           apply
+// CHECK:           store
+// CHECK:           dealloc_stack
+// CHECK:         {{^}}bb2:
+// CHECK:           return
+sil [ossa] @dont_hoist_multi_store : $@convention(thin) (Builtin.FixedArray<4, Builtin.Int32>, Builtin.FixedArray<4, Builtin.Int32>, Builtin.Word) -> () {
+bb0(%0 : $Builtin.FixedArray<4, Builtin.Int32>, %1 : $Builtin.FixedArray<4, Builtin.Int32>, %2 : $Builtin.Word):
+  br bb1(%2)
+
+bb1(%idx : $Builtin.Word):
+  %313 = alloc_stack $Builtin.FixedArray<4, Builtin.Int32>
+  store %0 to [trivial] %313
+  %base = vector_base_addr %313
+  %next_idx = function_ref @next_idx : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %idx2 = apply %next_idx (%idx) : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %index_addr = index_addr %base, %idx
+
+  store %1 to [trivial] %313
+  dealloc_stack %313
+  cond_br undef, bb3, bb2
+
+bb3:
+  br bb1(%idx2)
+
+bb2:
+  %52 = tuple ()
+  return %52 : $()
+}
+
+// CHECK-LABEL:   sil [ossa] @dont_hoist_write_effect
+// CHECK:         {{^}}bb0
+// CHECK:         {{^}}bb1
+// CHECK:           alloc_stack
+// CHECK:           store
+// CHECK:           apply
+// CHECK:           dealloc_stack
+// CHECK:         {{^}}bb2:
+// CHECK:           return
+sil [ossa] @dont_hoist_write_effect : $@convention(thin) (Builtin.FixedArray<4, Builtin.Int32>, Builtin.FixedArray<4, Builtin.Int32>, Builtin.Word) -> () {
+bb0(%0 : $Builtin.FixedArray<4, Builtin.Int32>, %1 : $Builtin.FixedArray<4, Builtin.Int32>, %2 : $Builtin.Word):
+  br bb1(%2)
+
+bb1(%idx : $Builtin.Word):
+  %313 = alloc_stack $Builtin.FixedArray<4, Builtin.Int32>
+  store %0 to [trivial] %313
+  %base = vector_base_addr %313
+  %next_idx = function_ref @next_idx : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %idx2 = apply %next_idx (%idx) : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %index_addr = index_addr %base, %idx
+
+  %f = function_ref @use_addr2 : $@convention(thin) (@inout Builtin.Int32) -> ()
+  %a = apply %f(%index_addr) : $@convention(thin) (@inout Builtin.Int32) -> ()
+  dealloc_stack %313
+  cond_br undef, bb3, bb2
+
+bb3:
+  br bb1(%idx2)
+
+bb2:
+  %52 = tuple ()
+  return %52 : $()
+}
+
+
+// CHECK-LABEL:   sil [ossa] @dont_hoist_unknown_effect
+// CHECK:         {{^}}bb0
+// CHECK:         {{^}}bb1
+// CHECK:           alloc_stack
+// CHECK:           store
+// CHECK:           apply
+// CHECK:           dealloc_stack
+// CHECK:         {{^}}bb2:
+// CHECK:           return
+sil [ossa] @dont_hoist_unknown_effect : $@convention(thin) (Builtin.FixedArray<4, Builtin.Int32>, Builtin.FixedArray<4, Builtin.Int32>, Builtin.Word) -> () {
+bb0(%0 : $Builtin.FixedArray<4, Builtin.Int32>, %1 : $Builtin.FixedArray<4, Builtin.Int32>, %2 : $Builtin.Word):
+  br bb1(%2)
+
+bb1(%idx : $Builtin.Word):
+  %313 = alloc_stack $Builtin.FixedArray<4, Builtin.Int32>
+  store %0 to [trivial] %313
+  %base = vector_base_addr %313
+  %next_idx = function_ref @next_idx : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %idx2 = apply %next_idx (%idx) : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %index_addr = index_addr %base, %idx
+
+  %f = function_ref @read_addr : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  %a = apply %f(%index_addr) : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  %unknown = function_ref @unknown_effect : $@convention(thin) () -> ()
+  apply %unknown() : $@convention(thin) () -> ()
+  dealloc_stack %313
+  cond_br undef, bb3, bb2
+
+bb3:
+  br bb1(%idx2)
+
+bb2:
+  %52 = tuple ()
+  return %52 : $()
+}
+
+
+// CHECK-LABEL:   sil [ossa] @dont_hoist_with_preceding_read
+// CHECK:         {{^}}bb0
+// CHECK:           alloc_stack
+// CHECK:           store %1
+// CHECK:         {{^}}bb1
+// CHECK:           apply
+// CHECK:           store %0
+// CHECK:         {{^}}bb2:
+// CHECK:           dealloc_stack
+// CHECK:           return
+sil [ossa] @dont_hoist_with_preceding_read : $@convention(thin) (Builtin.FixedArray<4, Builtin.Int32>, Builtin.FixedArray<4, Builtin.Int32>, Builtin.Word) -> () {
+bb0(%0 : $Builtin.FixedArray<4, Builtin.Int32>, %1 : $Builtin.FixedArray<4, Builtin.Int32>, %2 : $Builtin.Word):
+  %313 = alloc_stack $Builtin.FixedArray<4, Builtin.Int32>
+  store %1 to [trivial] %313
+  br bb1(%2)
+
+bb1(%idx : $Builtin.Word):
+  %base = vector_base_addr %313
+  %next_idx = function_ref @next_idx : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %idx2 = apply %next_idx (%idx) : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %index_addr = index_addr %base, %idx
+
+  %f = function_ref @read_addr : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  %a = apply %f(%index_addr) : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  store %0 to [trivial] %313
+  cond_br undef, bb3, bb2
+
+bb3:
+  br bb1(%idx2)
+
+bb2:
+  dealloc_stack %313
+  %52 = tuple ()
+  return %52 : $()
+}
+
+// CHECK-LABEL:   sil [ossa] @hoist_with_conditional_read_in_branch
+// CHECK:         {{^}}bb0
+// CHECK:           alloc_stack
+// CHECK:           store %0
+// CHECK:         {{^}}bb1
+// CHECK:           apply
+// CHECK:         {{^}}bb6:
+// CHECK:           dealloc_stack
+// CHECK:           return
+sil [ossa] @hoist_with_conditional_read_in_branch : $@convention(thin) (Builtin.FixedArray<4, Builtin.Int32>, Builtin.FixedArray<4, Builtin.Int32>, Builtin.Word) -> () {
+bb0(%0 : $Builtin.FixedArray<4, Builtin.Int32>, %1 : $Builtin.FixedArray<4, Builtin.Int32>, %2 : $Builtin.Word):
+  %313 = alloc_stack $Builtin.FixedArray<4, Builtin.Int32>
+  br bb1(%2)
+
+bb1(%idx : $Builtin.Word):
+  store %0 to [trivial] %313
+  %base = vector_base_addr %313
+  %next_idx = function_ref @next_idx : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %idx2 = apply %next_idx (%idx) : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %index_addr = index_addr %base, %idx
+
+  cond_br undef, bb2, bb6
+
+bb2:
+  cond_br undef, bb3, bb4
+
+bb3:
+  %f = function_ref @read_addr : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  %a = apply %f(%index_addr) : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  br bb5
+
+bb4:
+  br bb5
+
+bb5:
+  br bb1(%idx2)
+
+bb6:
+  dealloc_stack %313
+  %52 = tuple ()
+  return %52 : $()
+}
+
+
+// CHECK-LABEL:   sil [ossa] @dont_hoist_with_conditional_store_in_branch
+// CHECK:         {{^}}bb0
+// CHECK:           alloc_stack
+// CHECK:           store %1
+// CHECK-NOT:       store %0
+// CHECK:         {{^}}bb1
+// CHECK:         {{^}}bb3
+// CHECK:           store %0
+// CHECK:         {{^}}bb4
+// CHECK:         {{^}}bb5
+// CHECK:           apply
+// CHECK:         {{^}}bb6:
+// CHECK:           dealloc_stack
+// CHECK:           return
+sil [ossa] @dont_hoist_with_conditional_store_in_branch : $@convention(thin) (Builtin.FixedArray<4, Builtin.Int32>, Builtin.FixedArray<4, Builtin.Int32>, Builtin.Word) -> () {
+bb0(%0 : $Builtin.FixedArray<4, Builtin.Int32>, %1 : $Builtin.FixedArray<4, Builtin.Int32>, %2 : $Builtin.Word):
+  %313 = alloc_stack $Builtin.FixedArray<4, Builtin.Int32>
+  store %1 to [trivial] %313
+  br bb1(%2)
+
+bb1(%idx : $Builtin.Word):
+  %base = vector_base_addr %313
+  %next_idx = function_ref @next_idx : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %idx2 = apply %next_idx (%idx) : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %index_addr = index_addr %base, %idx
+
+  cond_br undef, bb2, bb6
+
+bb2:
+  cond_br undef, bb3, bb4
+
+bb3:
+  store %0 to [trivial] %313
+  br bb5
+
+bb4:
+  br bb5
+
+bb5:
+  %f = function_ref @read_addr : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  %a = apply %f(%index_addr) : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  br bb1(%idx2)
+
+bb6:
+  dealloc_stack %313
+  %52 = tuple ()
+  return %52 : $()
+}
+
+// If a store in a non-dominating block dominates all reads in the loop we may
+// be able to hoist it speculatively. To do so we have to ensure that the stored
+// value could not be read after the loop, at least in cases where the branch it
+// was hoisted from never executed. If the base address is an alloc_stack that
+// has been hoisted out of the loop, all uses will either be in the loop or
+// dealloc_stack; this case is common and cheap to check
+//
+// CHECK-LABEL:   sil [ossa] @hoist_dominating_store_speculatively
+// CHECK:         {{^}}bb0
+// CHECK:           alloc_stack
+// CHECK:           store %0
+// CHECK:         {{^}}bb1
+// CHECK-NOT:       store %0
+// CHECK:         {{^}}bb6:
+// CHECK:           dealloc_stack
+// CHECK:           return
+sil [ossa] @hoist_dominating_store_speculatively : $@convention(thin) (Builtin.FixedArray<4, Builtin.Int32>, Builtin.FixedArray<4, Builtin.Int32>, Builtin.Word) -> () {
+bb0(%0 : $Builtin.FixedArray<4, Builtin.Int32>, %1 : $Builtin.FixedArray<4, Builtin.Int32>, %2 : $Builtin.Word):
+  br bb1(%2)
+
+bb1(%idx : $Builtin.Word):
+  %next_idx = function_ref @next_idx : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %idx2 = apply %next_idx (%idx) : $@convention(thin) (Builtin.Word) -> Builtin.Word
+
+  cond_br undef, bb2, bb6
+
+bb2:
+  cond_br undef, bb3, bb4
+
+bb3:
+  %313 = alloc_stack $Builtin.FixedArray<4, Builtin.Int32>
+  %base = vector_base_addr %313
+  %index_addr = index_addr %base, %idx
+  store %0 to [trivial] %313
+  %f = function_ref @read_addr : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  %a = apply %f(%index_addr) : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  dealloc_stack %313
+  br bb5
+
+bb4:
+  br bb5
+
+bb5:
+  br bb1(%idx2)
+
+bb6:
+  %52 = tuple ()
+  return %52 : $()
+}
+
+// If the access base of the store lives outside the loop, we could have to
+// analyse the memory effects of all instructions between the end of the loop
+// and the end of its lifetime to know it is safe to hoist the store. We
+// currently do not, so bail.
+// 
+// CHECK-LABEL:   sil [ossa] @dont_hoist_dominating_store_speculatively_outer_alloc_stack
+// CHECK:         {{^}}bb0
+// CHECK:           alloc_stack
+// CHECK-NOT:       store %0
+// CHECK:         {{^}}bb3
+// CHECK:           store %0
+// CHECK:         {{^}}bb6:
+// CHECK:           dealloc_stack
+// CHECK:           return
+// CHECK:         } // end sil function 'dont_hoist_dominating_store_speculatively_outer_alloc_stack'
+sil [ossa] @dont_hoist_dominating_store_speculatively_outer_alloc_stack : $@convention(thin) (Builtin.FixedArray<4, Builtin.Int32>, Builtin.FixedArray<4, Builtin.Int32>, Builtin.Word) -> () {
+bb0(%0 : $Builtin.FixedArray<4, Builtin.Int32>, %1 : $Builtin.FixedArray<4, Builtin.Int32>, %2 : $Builtin.Word):
+  %313 = alloc_stack $Builtin.FixedArray<4, Builtin.Int32>
+  br bb1(%2)
+
+bb1(%idx : $Builtin.Word):
+  %next_idx = function_ref @next_idx : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %idx2 = apply %next_idx (%idx) : $@convention(thin) (Builtin.Word) -> Builtin.Word
+
+  cond_br undef, bb2, bb6
+
+bb2:
+  cond_br undef, bb3, bb4
+
+bb3:
+  %base = vector_base_addr %313
+  %index_addr = index_addr %base, %idx
+  store %0 to [trivial] %313
+  %f = function_ref @read_addr : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  %a = apply %f(%index_addr) : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  br bb5
+
+bb4:
+  br bb5
+
+bb5:
+  br bb1(%idx2)
+
+bb6:
+  dealloc_stack %313
+  %52 = tuple ()
+  return %52 : $()
+}
+
+// CHECK-LABEL:   sil [ossa] @dont_hoist_dominating_store_speculatively_non_alloc_stack_base
+// CHECK:         {{^}}bb0
+// CHECK-NOT:       alloc_stack
+// CHECK-NOT:       store %0
+// CHECK:         {{^}}bb3
+// CHECK:           store %0
+// CHECK:         {{^}}bb4
+// CHECK:         {{^}}bb6:
+// CHECK:           return
+// CHECK:         } // end sil function 'dont_hoist_dominating_store_speculatively_non_alloc_stack_base'
+sil [ossa] @dont_hoist_dominating_store_speculatively_non_alloc_stack_base : $@convention(thin) (Builtin.FixedArray<4, Builtin.Int32>, Builtin.FixedArray<4, Builtin.Int32>, Builtin.Word, @inout Builtin.FixedArray<4, Builtin.Int32>) -> () {
+bb0(%0 : $Builtin.FixedArray<4, Builtin.Int32>, %1 : $Builtin.FixedArray<4, Builtin.Int32>, %2 : $Builtin.Word, %3 : $*Builtin.FixedArray<4, Builtin.Int32>):
+  br bb1(%2)
+
+bb1(%idx : $Builtin.Word):
+  %next_idx = function_ref @next_idx : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %idx2 = apply %next_idx (%idx) : $@convention(thin) (Builtin.Word) -> Builtin.Word
+
+  cond_br undef, bb2, bb6
+
+bb2:
+  cond_br undef, bb3, bb4
+
+bb3:
+  %base = vector_base_addr %3
+  %index_addr = index_addr %base, %idx
+  store %0 to [trivial] %3
+  %f = function_ref @read_addr : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  %a = apply %f(%index_addr) : $@convention(thin) (@in_guaranteed Builtin.Int32) -> ()
+  br bb5
+
+bb4:
+  br bb5
+
+bb5:
+  br bb1(%idx2)
+
+bb6:
+  %52 = tuple ()
+  return %52 : $()
+}
+
+sil @read_in : $@convention(thin) (@in Int32) -> () {
+[%0: read v**]
+[global: ]
+}
+
+// CHECK-LABEL: sil [ossa] @in_read_only_trivial_no_deinit : $@convention(thin) (Int32, Int32) -> () {
+// CHECK:       bb0(%0 : $Int32, %1 : $Int32):
+// CHECK:       bb1:
+// CHECK:         = alloc_stack
+// CHECK:         store
+// CHECK:       {{^}}bb2
+// CHECK-NOT:     store
+// CHECK:       bb4:
+// CHECK:         dealloc_stack
+// CHECK:       bb5:
+// CHECK-LABEL: } // end sil function 'in_read_only_trivial_no_deinit'
+sil [ossa] @in_read_only_trivial_no_deinit : $@convention(thin) (Int32, Int32) -> () {
+bb0(%0 : $Int32, %1 : $Int32):
+  %2 = integer_literal $Builtin.Int32, 1
+  %3 = integer_literal $Builtin.Int1, -1
+  %4 = struct_extract %1, #Int32._value
+  %5 = integer_literal $Builtin.Int32, 0
+  %6 = builtin "cmp_eq_Int32"(%4, %5) : $Builtin.Int1
+  cond_br %6, bb5, bb1
+
+bb1:
+  %11 = function_ref @read_in : $@convention(thin) (@in Int32) -> ()
+  br bb2(%5)
+
+bb2(%13 : $Builtin.Int32):
+  %8 = alloc_stack $Int32
+  store %0 to [trivial] %8
+  %16 = apply %11(%8) : $@convention(thin) (@in Int32) -> ()
+  %18 = builtin "sadd_with_overflow_Int32"(%13, %2, %3) : $(Builtin.Int32, Builtin.Int1)
+  %19 = tuple_extract %18, 0
+  %20 = builtin "cmp_eq_Int32"(%19, %4) : $Builtin.Int1
+  dealloc_stack %8
+  cond_br %20, bb4, bb3
+
+bb3:
+  br bb2(%19)
+
+bb4:
+  br bb6
+
+bb5:
+  br bb6
+
+bb6:
+  %26 = tuple ()
+  return %26
+}
+
+// CHECK-LABEL: sil [ossa] @dont_hoist_invariant_store_or_alloc : $@convention(thin) (Builtin.Word, Builtin.Word) -> Builtin.Word {
+// CHECK:       bb0(%0 : $Builtin.Word, %1 : $Builtin.Word):
+// CHECK:       bb1({{.*}}):
+// CHECK:         = alloc_stack
+// CHECK:         store
+// CHECK:         dealloc_stack
+// CHECK:       bb2:
+// CHECK:       } // end sil function 'dont_hoist_invariant_store_or_alloc'
+sil [ossa] @dont_hoist_invariant_store_or_alloc : $@convention(thin) (Builtin.Word, Builtin.Word) -> Builtin.Word {
+bb0(%0 : $Builtin.Word, %1 : $Builtin.Word):
+  br bb1(%1)
+
+bb1(%idx : $Builtin.Word):
+  %313 = alloc_stack $Builtin.Word
+  store %idx to [trivial] %313
+  %next_idx = function_ref @next_idx : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %idx2 = apply %next_idx (%idx) : $@convention(thin) (Builtin.Word) -> Builtin.Word
+  %a = load [trivial] %313
+  dealloc_stack %313
+  cond_br undef, bb3, bb2
+
+bb3:
+  br bb1(%idx2)
+
+bb2:
+  return %a
+}


### PR DESCRIPTION
To hoist a store from an exit-dominating block (i.e. non-speculatively), we require that:
- The stored type and the type of the destination address's access base are both trivial.
  - This avoids ownership errors when a trivial address has been projected out of a non-trivial addresses that may be borrowed at the point the store would be hoisted to (e.g. `S.i` in `@store_and_load_borrow` in licm.sil).
- It is the only instruction in the loop that writes to its destination.
- It dominates all instructions in the loop that could read from its destination.

If the destination's access base is an `alloc_stack` inside the loop, hoist it alongside the `store`, similarly to how we hoist `store_borrow`'s `alloc_stack`.

To hoist a store from a non-exit-dominating block (i.e. speculatively), we additionally require that the access base is an `alloc_stack` inside the loop. This ensures that there are no uses of the address after the loop that could be affected by us hoisting the store speculatively.

Formally, passing an address to a function as an `@in` parameter consumes its contents, and the value should be considered deinitialized after the `apply`, even if the type is trivial. In practice, de-initialising a trivial type is often a no-op, so the compiler may determine that such a function has a `read` memory effect, but no `write` effect, on the address. This means that LICM would be able to hoist an `alloc_stack` and its initialising `store` out of a loop where the allocation's address is passed as `@in`. This would cause a memory lifetime error: the allocation would not be initialized after the first loop iteration.

We avoid this lifetime error by making MemoryLifetimeVerifier respect memory effects. If an address of a trivial type is passed as an `@in` parameter to a function that does not have a `write` memory effect on it, consider the address to still be initialised.

Fixes: rdar://172132077 (Iterating over InlineArray copies the full array per iteration)
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
