### PR TITLE
LoadableByAddress: fix use of deallocated stack memory in the load peephole

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -4280,6 +4280,47 @@ static bool isSoleUserOf(LoadInst *load, SILInstruction *next) {
     return false;
   return true;
 }
+
+/// Returns true if the address which is assigned to \p inst's result is a
+/// projection of (or an alias for) the address which is assigned to \p inst's
+/// operand - as opposed to a new stack location the value is copied into.
+/// Must be kept in sync with the AssignAddressToDef visitors below.
+static bool resultAliasesOperandAddress(AddressAssignment &assignment,
+                                        SILInstruction *inst) {
+  switch (inst->getKind()) {
+  case SILInstructionKind::TupleExtractInst:
+  case SILInstructionKind::StructExtractInst:
+  case SILInstructionKind::UncheckedTrivialBitCastInst:
+  case SILInstructionKind::UncheckedBitwiseCastInst:
+  case SILInstructionKind::MarkDependenceInst:
+  case SILInstructionKind::EndCOWMutationInst:
+    return assignment.isLargeLoadableType(
+        cast<SingleValueInstruction>(inst)->getType());
+  default:
+    return false;
+  }
+}
+
+/// Returns true if \p inst forwards the address of its operand - possibly via a
+/// chain of such instructions - to a result which is used somewhere else than
+/// in the immediately following instruction.
+///
+/// In this case the operand's address needs to stay valid until those uses,
+/// which is not guaranteed. For example, the address can be a stack location
+/// which is deallocated right after \p inst.
+static bool forwardsAddressBeyondNextInstruction(AddressAssignment &assignment,
+                                                 SILInstruction *inst) {
+  while (resultAliasesOperandAddress(assignment, inst)) {
+    auto *result = cast<SingleValueInstruction>(inst);
+    // Terminators are never address forwarding, so there is a next instruction.
+    auto *next = &*std::next(inst->getIterator());
+    if (!result->hasOneUse() || result->getSingleUse()->getUser() != next)
+      return true;
+    inst = next;
+  }
+  return false;
+}
+
 namespace {
 class AssignAddressToDef : SILInstructionVisitor<AssignAddressToDef> {
   friend SILVisitorBase<AssignAddressToDef>;
@@ -4390,9 +4431,15 @@ protected:
 
   void visitLoadInst(LoadInst *load) {
     auto *defInst = load->getOperand()->getDefiningInstruction();
+    auto *nextInst = &*std::next(load->getIterator());
     // Forward the address of the load if its sole user immediately follows the
     // load instructions and if it was not the result of a coroutine.
-    if (isSoleUserOf(load, &*++load->getIterator()) &&
+    // Don't do this if the user forwards the address to a result which is used
+    // beyond the following instruction, because then the address would be
+    // needed at those uses. For example after the load's source location is
+    // deallocated.
+    if (isSoleUserOf(load, nextInst) &&
+        !forwardsAddressBeyondNextInstruction(assignment, nextInst) &&
         (!defInst || !isa<BeginApplyInst>(defInst))) {
       assignment.markForDeletion(load);
       assignment.mapValueToAddress(origValue, load->getOperand());

--- a/test/IRGen/loadable_by_address_reg2mem_fixed_array.sil
+++ b/test/IRGen/loadable_by_address_reg2mem_fixed_array.sil
@@ -10,6 +10,10 @@ import Swift
 
 sil_stage canonical
 
+struct S {
+  @_hasStorage var x: Builtin.FixedArray<16, Builtin.Int64>
+}
+
 // CHECK: sil @test1 : $@convention(thin) (@in_guaranteed Builtin.FixedArray<16, Builtin.Int64>) -> () {
 // CHECK-NOT: load
 // CHECK-NOT: store
@@ -30,6 +34,58 @@ bb0(%0 : $Builtin.FixedArray<16, Builtin.Int64>):
   store %3 to %2 : $*Builtin.FixedArray<16, Builtin.Int64>
   dealloc_stack %2 : $*Builtin.FixedArray<16, Builtin.Int64>
   dealloc_stack %1 : $*Builtin.FixedArray<16, Builtin.Int64>
+  %t = tuple ()
+  return %t : $()
+}
+
+// The address of the load must not be forwarded to the bitcast, because the
+// bitcast's result is used after the load's source location is deallocated.
+
+// CHECK: sil @test_cast_of_forwarded_load :
+// CHECK:   [[COPY:%[^ ]+]] = alloc_stack $Builtin.FixedArray<16, Builtin.Int64>
+// CHECK:   [[SRC:%[^ ]+]] = alloc_stack $Builtin.FixedArray<16, Builtin.Int64>
+// CHECK:   copy_addr [take] [[SRC]] to [init] [[COPY]] : $*Builtin.FixedArray<16, Builtin.Int64>
+// CHECK:   [[CAST:%[^ ]+]] = unchecked_addr_cast [[COPY]] : $*Builtin.FixedArray<16, Builtin.Int64> to $*S
+// CHECK:   dealloc_stack [[SRC]] : $*Builtin.FixedArray<16, Builtin.Int64>
+// CHECK:   copy_addr [take] [[CAST]] to [init] %1 : $*S
+// CHECK:   dealloc_stack [[COPY]] : $*Builtin.FixedArray<16, Builtin.Int64>
+// CHECK: } // end sil function 'test_cast_of_forwarded_load'
+sil @test_cast_of_forwarded_load : $@convention(thin) (Builtin.FixedArray<16, Builtin.Int64>, @inout S) -> () {
+bb0(%0 : $Builtin.FixedArray<16, Builtin.Int64>, %1 : $*S):
+  %2 = alloc_stack $Builtin.FixedArray<16, Builtin.Int64>
+  store %0 to %2 : $*Builtin.FixedArray<16, Builtin.Int64>
+  %3 = load %2 : $*Builtin.FixedArray<16, Builtin.Int64>
+  %4 = unchecked_trivial_bit_cast %3 : $Builtin.FixedArray<16, Builtin.Int64> to $S
+  dealloc_stack %2 : $*Builtin.FixedArray<16, Builtin.Int64>
+  br bb1
+
+bb1:
+  store %4 to %1 : $*S
+  %t = tuple ()
+  return %t : $()
+}
+
+// Same for a mark_dependence, which also forwards the address of its operand.
+
+// CHECK: sil @test_mark_dependence_of_forwarded_load :
+// CHECK:   [[COPY:%[^ ]+]] = alloc_stack $Builtin.FixedArray<16, Builtin.Int64>
+// CHECK:   [[SRC:%[^ ]+]] = alloc_stack $Builtin.FixedArray<16, Builtin.Int64>
+// CHECK:   copy_addr [take] [[SRC]] to [init] [[COPY]] : $*Builtin.FixedArray<16, Builtin.Int64>
+// CHECK:   dealloc_stack [[SRC]] : $*Builtin.FixedArray<16, Builtin.Int64>
+// CHECK:   copy_addr [take] [[COPY]] to [init] %1 : $*Builtin.FixedArray<16, Builtin.Int64>
+// CHECK:   dealloc_stack [[COPY]] : $*Builtin.FixedArray<16, Builtin.Int64>
+// CHECK: } // end sil function 'test_mark_dependence_of_forwarded_load'
+sil @test_mark_dependence_of_forwarded_load : $@convention(thin) (Builtin.FixedArray<16, Builtin.Int64>, @inout Builtin.FixedArray<16, Builtin.Int64>, @guaranteed AnyObject) -> () {
+bb0(%0 : $Builtin.FixedArray<16, Builtin.Int64>, %1 : $*Builtin.FixedArray<16, Builtin.Int64>, %2 : $AnyObject):
+  %3 = alloc_stack $Builtin.FixedArray<16, Builtin.Int64>
+  store %0 to %3 : $*Builtin.FixedArray<16, Builtin.Int64>
+  %4 = load %3 : $*Builtin.FixedArray<16, Builtin.Int64>
+  %5 = mark_dependence %4 : $Builtin.FixedArray<16, Builtin.Int64> on %2 : $AnyObject
+  dealloc_stack %3 : $*Builtin.FixedArray<16, Builtin.Int64>
+  br bb1
+
+bb1:
+  store %5 to %1 : $*Builtin.FixedArray<16, Builtin.Int64>
   %t = tuple ()
   return %t : $()
 }

--- a/test/Interpreter/inline_array_memory_rebound.swift
+++ b/test/Interpreter/inline_array_memory_rebound.swift
@@ -1,0 +1,41 @@
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -Xfrontend -disable-availability-checking) | %FileCheck %s
+
+// REQUIRES: executable_test
+
+// UNSUPPORTED: back_deployment_runtime || use_os_stdlib
+
+// Reading an InlineArray element is not supported with opaque values, yet.
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
+
+typealias Tuple16 = (UInt8,UInt8,UInt8,UInt8,UInt8,UInt8,UInt8,UInt8,
+                     UInt8,UInt8,UInt8,UInt8,UInt8,UInt8,UInt8,UInt8)
+
+// The `bytes` value is a bitcast of a value which is loaded from a temporary
+// stack location. LoadableByAddress must not let `bytes` alias that temporary,
+// because it is destroyed before `bytes` is appended to the array.
+@inline(never)
+func copyOut(_ src: [Tuple16]) -> [InlineArray<16, UInt8>] {
+    var out = [InlineArray<16, UInt8>]()
+    for tuple in src {
+        let bytes = withUnsafeBytes(of: tuple) {
+            $0.withMemoryRebound(to: InlineArray<16, UInt8>.self) {
+                $0[0]
+            }
+        }
+        out.append(bytes)
+    }
+    return out
+}
+
+// CHECK: PASS
+func testit() {
+  let got = copyOut([(3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3)])[0]
+  var ok = true
+  for i in 0..<16 {
+    if got[i] != 3 { ok = false }
+  }
+  print(ok ? "PASS" : "FAIL")
+}
+
+testit()


### PR DESCRIPTION
If the sole user of a `load` immediately follows the load, the pass forwards the load's source address instead of copying the value. This is wrong if that user forwards the address to its own result - e.g. an `unchecked_trivial_bit_cast` - because the result can be used far away from the load, even after the load's source location has been deallocated.

IRGen then emits a `llvm.lifetime.end` before those uses and LLVM removes the resulting copy from dead stack memory, which miscompiled code like

```
  withUnsafeBytes(of: tuple) {
    $0.withMemoryRebound(to: [16 of UInt8].self) { $0[0] }
  }
```

Don't forward the address in this case, but copy the loaded value into a new stack location, whose lifetime covers all its uses.

Fixes a miscompile
https://github.com/swiftlang/swift/issues/91283
rdar://184126943
