### PR TITLE
[Runtime] Trap overflow in size/layout computations.

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -19,10 +19,12 @@
 
 #include <atomic>
 #include <iterator>
+#include <limits>
 #include <type_traits>
 #include <utility>
 #include <string.h>
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/MathExtras.h"
 #include "swift/Strings.h"
 #include "swift/Runtime/Config.h"
 #include "swift/Runtime/Once.h"
@@ -1059,6 +1061,8 @@ public:
   }
   void setInstanceSize(StoredSize size) {
     assert(isTypeMetadata());
+    assert(size <= std::numeric_limits<decltype(InstanceSize)>::max() &&
+           "class instance size does not fit in the InstanceSize field");
     InstanceSize = size;
   }
 
@@ -1068,6 +1072,9 @@ public:
   }
   void setInstanceAddressPoint(StoredSize size) {
     assert(isTypeMetadata());
+    assert(size <= std::numeric_limits<decltype(InstanceAddressPoint)>::max() &&
+           "class instance address point does not fit in the "
+           "InstanceAddressPoint field");
     InstanceAddressPoint = size;
   }
 
@@ -2606,13 +2613,29 @@ struct TargetGenericBoxHeapMetadata : public TargetBoxHeapMetadata<Runtime> {
     return reinterpret_cast<OpaqueValue *>(bytes + Offset);
   }
 
-  /// Get the allocation size of this box.
-  unsigned getAllocSize() const {
-    return Offset + BoxedType->getValueWitnesses()->getSize();
+  typename Runtime::StoredSize getAllocSize() const {
+    using StoredSize = typename Runtime::StoredSize;
+    return (StoredSize)Offset +
+           (StoredSize)BoxedType->getValueWitnesses()->getSize();
+  }
+
+  /// Get the allocation size of this box, writing it into \p result. Returns
+  /// false if the calculation overflowed and the size is not representable.
+  bool
+  getAllocSizeCheckingOverflow(typename Runtime::StoredSize &result) const {
+    using StoredSize = typename Runtime::StoredSize;
+    bool overflowed = false;
+    StoredSize size = llvm::SaturatingAdd(
+        (StoredSize)Offset,
+        (StoredSize)BoxedType->getValueWitnesses()->getSize(), &overflowed);
+    if (overflowed)
+      return false;
+    result = size;
+    return true;
   }
 
   /// Get the allocation alignment of this box.
-  unsigned getAllocAlignMask() const {
+  typename Runtime::StoredSize getAllocAlignMask() const {
     // Heap allocations are at least pointer aligned.
     return BoxedType->getValueWitnesses()->getAlignmentMask()
       | (alignof(void*) - 1);

--- a/include/swift/Basic/MathUtils.h
+++ b/include/swift/Basic/MathUtils.h
@@ -39,6 +39,18 @@ static inline size_t roundUpToAlignMask(size_t size, size_t alignMask) {
   return (size + alignMask) & ~alignMask;
 }
 
+/// Round the given value up to the given alignment, expressed as a mask,
+/// writing the result into \p result. Returns false if the rounding carried
+/// past SIZE_MAX.
+static inline bool roundUpToAlignMaskCheckingOverflow(size_t size,
+                                                      size_t alignMask,
+                                                      size_t &result) {
+  if (size > SIZE_MAX - alignMask)
+    return false;
+  result = (size + alignMask) & ~alignMask;
+  return true;
+}
+
 static inline unsigned popcount(unsigned value) {
 #if SWIFT_COMPILER_IS_MSVC && (defined(_M_IX86) || defined(_M_X64))
   // The __popcnt intrinsic is only available when targetting x86{_64} with MSVC.

--- a/stdlib/public/runtime/Enum.cpp
+++ b/stdlib/public/runtime/Enum.cpp
@@ -17,10 +17,12 @@
 #include "swift/Runtime/Metadata.h"
 #include "swift/Runtime/Enum.h"
 #include "swift/Runtime/Debug.h"
+#include "swift/Basic/MathUtils.h"
 #include "Private.h"
 #include "BytecodeLayouts.h"
 #include "EnumImpl.h"
 #include "MetadataCache.h"
+#include "llvm/Support/MathExtras.h"
 #include <cstring>
 #include <algorithm>
 
@@ -50,6 +52,39 @@ static EnumValueWitnessTable *getMutableVWTableForInit(EnumMetadata *self,
   self->setValueWitnesses(newTable);
 
   return newTable;
+}
+
+/// Add the tag bytes to a payload size, raising a fatal error if the sum is not
+/// representable.
+static size_t addTagBytesOrTrap(const EnumMetadata *enumType,
+                                size_t payloadSize, unsigned numTagBytes) {
+  bool overflowed = false;
+  size_t totalSize =
+      llvm::SaturatingAdd(payloadSize, (size_t)numTagBytes, &overflowed);
+  if (SWIFT_UNLIKELY(overflowed)) {
+    swift::fatalError(0,
+                      "enum %s has a payload size of %zu bytes, which leaves "
+                      "no room for %u tag bytes\n",
+                      enumType->getDescription()->Name.get(), payloadSize,
+                      numTagBytes);
+  }
+  return totalSize;
+}
+
+/// Round a size up to a stride, raising a fatal error if the rounding is not
+/// representable.
+static size_t strideForSizeOrTrap(const EnumMetadata *enumType, size_t size,
+                                  size_t alignMask) {
+  size_t stride;
+  if (SWIFT_UNLIKELY(
+          !roundUpToAlignMaskCheckingOverflow(size, alignMask, stride))) {
+    swift::fatalError(
+        0,
+        "enum %s has a size of %zu bytes, which cannot be rounded "
+        "up to an alignment of %zu\n",
+        enumType->getDescription()->Name.get(), size, alignMask + 1);
+  }
+  return stride == 0 ? 1 : stride;
 }
 
 void
@@ -152,9 +187,11 @@ swift::swift_initEnumMetadataSinglePayload(EnumMetadata *self,
     size = payloadSize;
     unusedExtraInhabitants = payloadNumExtraInhabitants - emptyCases;
   } else {
-    size = payloadSize + getEnumTagCounts(payloadSize,
-                                      emptyCases - payloadNumExtraInhabitants,
-                                        1 /*payload case*/).numTagBytes; ;
+    size = addTagBytesOrTrap(
+        self, payloadSize,
+        getEnumTagCounts(payloadSize, emptyCases - payloadNumExtraInhabitants,
+                         1 /*payload case*/)
+            .numTagBytes);
   }
 
   auto vwtable = getMutableVWTableForInit(self, layoutFlags);
@@ -174,8 +211,7 @@ swift::swift_initEnumMetadataSinglePayload(EnumMetadata *self,
           .withInlineStorage(
               ValueWitnessTable::isValueInline(isBT, size, align));
   layout.extraInhabitantCount = unusedExtraInhabitants;
-  auto rawStride = llvm::alignTo(size, align);
-  layout.stride = rawStride == 0 ? 1 : rawStride;
+  layout.stride = strideForSizeOrTrap(self, size, align - 1);
   
   // Substitute in better common value witnesses if we have them.
   // If the payload type is a single-refcounted pointer, and the enum has
@@ -261,7 +297,7 @@ static void swift_cvw_initEnumMetadataSinglePayloadWithLayoutStringImpl(
         getEnumTagCounts(payloadSize, emptyCases - payloadNumExtraInhabitants,
                          1 /*payload case*/)
             .numTagBytes;
-    size = payloadSize + extraTagBytes;
+    size = addTagBytesOrTrap(self, payloadSize, extraTagBytes);
   }
 
   auto vwtable = getMutableVWTableForInit(self, layoutFlags);
@@ -280,8 +316,7 @@ static void swift_cvw_initEnumMetadataSinglePayloadWithLayoutStringImpl(
       .withInlineStorage(
           ValueWitnessTable::isValueInline(isBT, size, align));
   layout.extraInhabitantCount = unusedExtraInhabitants;
-  auto rawStride = llvm::alignTo(size, align);
-  layout.stride = rawStride == 0 ? 1 : rawStride;
+  layout.stride = strideForSizeOrTrap(self, size, align - 1);
 
   auto xiElement = findXIElement(payloadType);
 
@@ -437,8 +472,9 @@ swift::swift_initEnumMetadataMultiPayload(EnumMetadata *enumType,
   auto tagCounts = getEnumTagCounts(payloadSize,
                                 enumType->getDescription()->getNumEmptyCases(),
                                 numPayloads);
-  unsigned totalSize = payloadSize + tagCounts.numTagBytes;
-  
+  size_t totalSize =
+      addTagBytesOrTrap(enumType, payloadSize, tagCounts.numTagBytes);
+
   // See whether there are extra inhabitants in the tag.
   unsigned numExtraInhabitants = tagCounts.numTagBytes == 4
     ? INT_MAX
@@ -449,19 +485,18 @@ swift::swift_initEnumMetadataMultiPayload(EnumMetadata *enumType,
   auto vwtable = getMutableVWTableForInit(enumType, layoutFlags);
 
   // Set up the layout info in the vwtable.
-  auto rawStride = (totalSize + alignMask) & ~alignMask;
-  TypeLayout layout{totalSize,
-                    rawStride == 0 ? 1 : rawStride,
+  auto stride = strideForSizeOrTrap(enumType, totalSize, alignMask);
+  TypeLayout layout{totalSize, stride,
                     ValueWitnessFlags()
-                     .withAlignmentMask(alignMask)
-                     .withPOD(isPOD)
-                     .withCopyable(isCopyable)
-                     .withBitwiseTakable(isBT)
-                     .withBitwiseBorrowable(isBB)
-                     .withAddressableForDependencies(isAFD)
-                     .withEnumWitnesses(true)
-                     .withInlineStorage(ValueWitnessTable::isValueInline(
-                         isBT, totalSize, alignMask + 1)),
+                        .withAlignmentMask(alignMask)
+                        .withPOD(isPOD)
+                        .withCopyable(isCopyable)
+                        .withBitwiseTakable(isBT)
+                        .withBitwiseBorrowable(isBB)
+                        .withAddressableForDependencies(isAFD)
+                        .withEnumWitnesses(true)
+                        .withInlineStorage(ValueWitnessTable::isValueInline(
+                            isBT, totalSize, alignMask + 1)),
                     numExtraInhabitants};
 
   installCommonValueWitnesses(layout, vwtable);
@@ -515,7 +550,8 @@ static void swift_cvw_initEnumMetadataMultiPayloadWithLayoutStringImpl(
   auto tagCounts = getEnumTagCounts(payloadSize,
                                 enumType->getDescription()->getNumEmptyCases(),
                                 numPayloads);
-  unsigned totalSize = payloadSize + tagCounts.numTagBytes;
+  size_t totalSize =
+      addTagBytesOrTrap(enumType, payloadSize, tagCounts.numTagBytes);
 
   // See whether there are extra inhabitants in the tag.
   unsigned numExtraInhabitants = tagCounts.numTagBytes == 4
@@ -594,19 +630,18 @@ static void swift_cvw_initEnumMetadataMultiPayloadWithLayoutStringImpl(
   }
 
   // Set up the layout info in the vwtable.
-  auto rawStride = (totalSize + alignMask) & ~alignMask;
-  TypeLayout layout{totalSize,
-                    rawStride == 0 ? 1 : rawStride,
+  auto stride = strideForSizeOrTrap(enumType, totalSize, alignMask);
+  TypeLayout layout{totalSize, stride,
                     ValueWitnessFlags()
-                     .withAlignmentMask(alignMask)
-                     .withPOD(isPOD)
-                     .withCopyable(isCopyable)
-                     .withBitwiseTakable(isBT)
-                     .withBitwiseBorrowable(isBB)
-                     .withAddressableForDependencies(isAFD)
-                     .withEnumWitnesses(true)
-                     .withInlineStorage(ValueWitnessTable::isValueInline(
-                         isBT, totalSize, alignMask + 1)),
+                        .withAlignmentMask(alignMask)
+                        .withPOD(isPOD)
+                        .withCopyable(isCopyable)
+                        .withBitwiseTakable(isBT)
+                        .withBitwiseBorrowable(isBB)
+                        .withAddressableForDependencies(isAFD)
+                        .withEnumWitnesses(true)
+                        .withInlineStorage(ValueWitnessTable::isValueInline(
+                            isBT, totalSize, alignMask + 1)),
                     numExtraInhabitants};
 
   installCommonValueWitnesses(layout, vwtable);
@@ -638,6 +673,8 @@ struct MultiPayloadLayout {
 static MultiPayloadLayout getMultiPayloadLayout(const EnumMetadata *enumType) {
   size_t payloadSize = enumType->getPayloadSize();
   size_t totalSize = enumType->getValueWitnesses()->size;
+  assert(totalSize >= payloadSize &&
+         "multi-payload enum size is smaller than its payload size");
   return {payloadSize, totalSize - payloadSize};
 }
 

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -363,6 +363,19 @@ HeapObject* swift_bufferAllocate(
   return swift::swift_allocObject(bufferType, size, alignMask);
 }
 
+/// Get a box's allocation size, raising a fatal error if it is not
+/// representable.
+static size_t getBoxAllocSizeOrTrap(const GenericBoxHeapMetadata *metadata) {
+  size_t allocSize;
+  if (SWIFT_UNLIKELY(!metadata->getAllocSizeCheckingOverflow(allocSize))) {
+    swift::fatalError(0,
+                      "box of type %s has an allocation size that is too large "
+                      "to be representable\n",
+                      swift_getTypeName(metadata->BoxedType, true).data);
+  }
+  return allocSize;
+}
+
 namespace {
 /// Heap object destructor for a generic box allocated with swift_allocBox.
 static SWIFT_CC(swift) void destroyGenericBox(SWIFT_CONTEXT HeapObject *o) {
@@ -440,7 +453,7 @@ BoxPair swift::swift_allocBox(const Metadata *type) {
   auto metadata = &Boxes.getOrInsert(type).first->Data;
 
   // Allocate and project the box.
-  auto allocation = swift_allocObject(metadata, metadata->getAllocSize(),
+  auto allocation = swift_allocObject(metadata, getBoxAllocSizeOrTrap(metadata),
                                       metadata->getAllocAlignMask());
   auto projection = metadata->project(allocation);
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -43,10 +43,12 @@
 #include "swift/Threading/Mutex.h"
 #include "swift/Threading/ThreadSanitizer.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/Support/MathExtras.h"
 #include <algorithm>
 #include <cctype>
 #include <cinttypes>
 #include <condition_variable>
+#include <limits>
 #include <new>
 #include <unordered_set>
 #include <vector>
@@ -1765,11 +1767,10 @@ vector_destroy(OpaqueValue *dest, const Metadata *metatype) {
   
   auto vectorType = cast<FixedArrayTypeMetadata>(metatype);
   auto destBytes = (char*)dest;
-  
-  for (unsigned i = 0, end = vectorType->getRealizedCount(),
-                stride = vectorType->Element->vw_stride();
-       i < end;
-       ++i, destBytes += stride) {
+
+  const intptr_t end = vectorType->getRealizedCount();
+  const size_t stride = vectorType->Element->vw_stride();
+  for (intptr_t i = 0; i < end; ++i, destBytes += stride) {
     vectorType->Element->vw_destroy((OpaqueValue*)destBytes);
   }
 }
@@ -1788,11 +1789,10 @@ vector_elementwise_transfer(OpaqueValue *dest, OpaqueValue *src,
   auto vectorType = cast<FixedArrayTypeMetadata>(metatype);
   auto destBytes = (char*)dest;
   auto srcBytes = (char*)src;
-  
-  for (unsigned i = 0, end = vectorType->getRealizedCount(),
-                stride = vectorType->Element->vw_stride();
-       i < end;
-       ++i, destBytes += stride, srcBytes += stride) {
+
+  const intptr_t end = vectorType->getRealizedCount();
+  const size_t stride = vectorType->Element->vw_stride();
+  for (intptr_t i = 0; i < end; ++i, destBytes += stride, srcBytes += stride) {
     elementFn(
       (OpaqueValue*)destBytes,
       (OpaqueValue*)srcBytes,
@@ -1902,8 +1902,19 @@ FixedArrayCacheEntry::tryInitialize(Metadata *metadata,
   assert(count > 0);
   Data.ValueWitnesses = &Witnesses;
   auto eltWitnesses = element->getValueWitnesses();
-  auto arraySize
-    = Witnesses.size = Witnesses.stride = eltWitnesses->stride * count;
+  size_t arraySize;
+  {
+    bool overflowed = false;
+    arraySize = llvm::SaturatingMultiply((size_t)eltWitnesses->stride,
+                                         (size_t)count, &overflowed);
+    if (SWIFT_UNLIKELY(overflowed)) {
+      swift::fatalError(0,
+                        "Builtin.FixedArray of %zd elements with stride %zu "
+                        "is too large to be representable\n",
+                        count, (size_t)eltWitnesses->stride);
+    }
+  }
+  Witnesses.size = Witnesses.stride = arraySize;
   // We take on most of the properties of the element type, except that an array
   // of elements might end up larger than an inline buffer, and the array is
   // always addressable for dependencies.
@@ -2608,17 +2619,20 @@ static constexpr TypeLayout getInitialLayoutForHeapObject() {
 /// calling a functor with the offset of each field, and returning the
 /// final layout characteristics of the type.
 ///
+/// Returns false if the running size overflows size_t, leaving \p layout
+/// untouched. \p setOffset will already have run for the elements preceding the
+/// overflow.
+///
 /// GetLayoutFn should have signature:
 ///   const TypeLayout *(ElementType &type);
 ///
 /// SetOffsetFn should have signature:
 ///   void (size_t index, ElementType &type, size_t offset)
-template<typename ElementType, typename GetLayoutFn, typename SetOffsetFn>
-static void performBasicLayout(TypeLayout &layout,
-                               ElementType *elements,
-                               size_t numElements,
-                               GetLayoutFn &&getLayout,
-                               SetOffsetFn &&setOffset) {
+template <typename ElementType, typename GetLayoutFn, typename SetOffsetFn>
+[[nodiscard]] static bool
+performBasicLayout(TypeLayout &layout, ElementType *elements,
+                   size_t numElements, GetLayoutFn &&getLayout,
+                   SetOffsetFn &&setOffset) {
   size_t size = layout.size;
   size_t alignMask = layout.flags.getAlignmentMask();
   bool isPOD = layout.flags.isPOD();
@@ -2631,13 +2645,18 @@ static void performBasicLayout(TypeLayout &layout,
 
     // Lay out this element.
     const TypeLayout *eltLayout = getLayout(i, elt);
-    size = roundUpToAlignMask(size, eltLayout->flags.getAlignmentMask());
+    if (SWIFT_UNLIKELY(!roundUpToAlignMaskCheckingOverflow(
+            size, eltLayout->flags.getAlignmentMask(), size)))
+      return false;
 
     // Report this record to the functor.
     setOffset(i, elt, size);
 
     // Update the size and alignment of the aggregate..
-    size += eltLayout->size;
+    bool overflowed = false;
+    size = llvm::SaturatingAdd(size, (size_t)eltLayout->size, &overflowed);
+    if (SWIFT_UNLIKELY(overflowed))
+      return false;
     alignMask = std::max(alignMask, eltLayout->flags.getAlignmentMask());
     if (!eltLayout->flags.isPOD()) isPOD = false;
     if (!eltLayout->flags.isCopyable()) isCopyable = false;
@@ -2649,6 +2668,13 @@ static void performBasicLayout(TypeLayout &layout,
   bool isInline =
       ValueWitnessTable::isValueInline(isBitwiseTakable, size, alignMask + 1);
 
+  // The stride rounds the size up again, which can carry even when the size
+  // itself did not.
+  size_t stride;
+  if (SWIFT_UNLIKELY(
+          !roundUpToAlignMaskCheckingOverflow(size, alignMask, stride)))
+    return false;
+
   layout.size = size;
   layout.flags = ValueWitnessFlags()
                      .withAlignmentMask(alignMask)
@@ -2659,16 +2685,95 @@ static void performBasicLayout(TypeLayout &layout,
                      .withAddressableForDependencies(isAddressableForDependencies)
                      .withInlineStorage(isInline);
   layout.extraInhabitantCount = 0;
-  layout.stride = std::max(size_t(1), roundUpToAlignMask(size, alignMask));
+  layout.stride = std::max(size_t(1), stride);
+  return true;
+}
+
+/// Report that a type's layout size is not representable and halt.
+SWIFT_RUNTIME_ATTRIBUTE_NORETURN SWIFT_RUNTIME_ATTRIBUTE_NOINLINE static void
+fatalLayoutOverflow(const char *kind, const char *name) {
+  swift::fatalError(
+      0, "%s %s has a layout size that is too large to be representable\n",
+      kind, name);
+}
+
+/// Report that a field offset doesn't fit the field offset vector and halt.
+SWIFT_RUNTIME_ATTRIBUTE_NORETURN SWIFT_RUNTIME_ATTRIBUTE_NOINLINE static void
+fatalFieldOffsetOverflow(const char *kind, const char *name) {
+  swift::fatalError(0,
+                    "%s %s has a field offset that does not fit in the 32-bit "
+                    "field offset vector\n",
+                    kind, name);
+}
+
+/// Report that a tuple's layout size is not representable and halt. Tuples are
+/// structural, so there is no name to report.
+SWIFT_RUNTIME_ATTRIBUTE_NORETURN SWIFT_RUNTIME_ATTRIBUTE_NOINLINE static void
+fatalTupleLayoutOverflow() {
+  swift::fatalError(
+      0, "tuple has a layout size that is too large to be representable\n");
+}
+
+/// Report that a tuple element offset doesn't fit the field it's published in
+/// and halt.
+SWIFT_RUNTIME_ATTRIBUTE_NORETURN SWIFT_RUNTIME_ATTRIBUTE_NOINLINE static void
+fatalTupleElementOffsetOverflow() {
+  swift::fatalError(0, "tuple has an element offset that does not fit in the "
+                       "32-bit element offset field\n");
+}
+
+/// Report that a class instance size doesn't fit the 32-bit field it's
+/// published in and halt.
+SWIFT_RUNTIME_ATTRIBUTE_NORETURN SWIFT_RUNTIME_ATTRIBUTE_NOINLINE static void
+fatalInstanceSizeOverflow(const char *name, size_t size) {
+  swift::fatalError(0,
+                    "class %s has an instance size of %zu bytes, which exceeds "
+                    "the 32-bit InstanceSize field\n",
+                    name, size);
+}
+
+/// Lay out a tuple, writing each element offset into \p elementOffsets, which
+/// may be null. Halts if the layout size is not representable, or if an element
+/// offset does not fit in \p OffsetTy.
+template <typename OffsetTy>
+static void getTupleTypeLayoutImpl(TypeLayout *result, OffsetTy *elementOffsets,
+                                   size_t numElements,
+                                   const TypeLayout *const *elements) {
+  *result = TypeLayout();
+  unsigned numExtraInhabitants = 0;
+  bool offsetTruncated = false;
+  if (SWIFT_UNLIKELY(!performBasicLayout(
+          *result, elements, numElements,
+          [](size_t i, const TypeLayout *elt) { return elt; },
+          [elementOffsets, &numExtraInhabitants,
+           &offsetTruncated](size_t i, const TypeLayout *elt, size_t offset) {
+            if (elementOffsets) {
+              if (SWIFT_UNLIKELY(offset >
+                                 (size_t)std::numeric_limits<OffsetTy>::max()))
+                offsetTruncated = true;
+              elementOffsets[i] = OffsetTy(offset);
+            }
+            numExtraInhabitants =
+                std::max(numExtraInhabitants, elt->getNumExtraInhabitants());
+          }))) {
+    fatalTupleLayoutOverflow();
+  }
+
+  if (SWIFT_UNLIKELY(offsetTruncated))
+    fatalTupleElementOffsetOverflow();
+
+  if (numExtraInhabitants > 0) {
+    *result = TypeLayout(result->size, result->stride, result->flags,
+                         numExtraInhabitants);
+  }
 }
 
 size_t swift::swift_getTupleTypeLayout2(TypeLayout *result,
                                         const TypeLayout *elt0,
                                         const TypeLayout *elt1) {
   const TypeLayout *elts[] = { elt0, elt1 };
-  uint32_t offsets[2];
-  swift_getTupleTypeLayout(result, offsets,
-                           TupleTypeFlags().withNumElements(2), elts);
+  size_t offsets[2];
+  getTupleTypeLayoutImpl(result, offsets, 2, elts);
   assert(offsets[0] == 0);
   return offsets[1];
 }
@@ -2678,9 +2783,8 @@ OffsetPair swift::swift_getTupleTypeLayout3(TypeLayout *result,
                                             const TypeLayout *elt1,
                                             const TypeLayout *elt2) {
   const TypeLayout *elts[] = { elt0, elt1, elt2 };
-  uint32_t offsets[3];
-  swift_getTupleTypeLayout(result, offsets,
-                           TupleTypeFlags().withNumElements(3), elts);
+  size_t offsets[3];
+  getTupleTypeLayoutImpl(result, offsets, 3, elts);
   assert(offsets[0] == 0);
   return {offsets[1], offsets[2]};
 }
@@ -2689,24 +2793,8 @@ void swift::swift_getTupleTypeLayout(TypeLayout *result,
                                      uint32_t *elementOffsets,
                                      TupleTypeFlags flags,
                                      const TypeLayout * const *elements) {
-  *result = TypeLayout();
-  unsigned numExtraInhabitants = 0;
-  performBasicLayout(*result, elements, flags.getNumElements(),
-    [](size_t i, const TypeLayout *elt) { return elt; },
-    [elementOffsets, &numExtraInhabitants]
-    (size_t i, const TypeLayout *elt, size_t offset) {
-      if (elementOffsets)
-        elementOffsets[i] = uint32_t(offset);
-      numExtraInhabitants = std::max(numExtraInhabitants,
-                                     elt->getNumExtraInhabitants());
-    });
-  
-  if (numExtraInhabitants > 0) {
-    *result = TypeLayout(result->size,
-                         result->stride,
-                         result->flags,
-                         numExtraInhabitants);
-  }
+  getTupleTypeLayoutImpl(result, elementOffsets, flags.getNumElements(),
+                         elements);
 }
 
 MetadataResponse
@@ -2826,13 +2914,25 @@ TupleCacheEntry::tryInitialize(Metadata *metadata,
 
   // Perform basic layout on the tuple.
   auto layout = getInitialLayoutForValueType();
-  performBasicLayout(layout, Data.getElements(), Data.NumElements,
-    [](size_t i, const TupleTypeMetadata::Element &elt) {
-      return elt.getTypeLayout();
-    },
-    [](size_t i, TupleTypeMetadata::Element &elt, size_t offset) {
-      elt.Offset = offset;
-    });
+  // Element::Offset is StoredSize on Apple platforms but uint32_t elsewhere.
+  bool offsetTruncated = false;
+  if (SWIFT_UNLIKELY(!performBasicLayout(
+          layout, Data.getElements(), Data.NumElements,
+          [](size_t i, const TupleTypeMetadata::Element &elt) {
+            return elt.getTypeLayout();
+          },
+          [&offsetTruncated](size_t i, TupleTypeMetadata::Element &elt,
+                             size_t offset) {
+            using OffsetTy = decltype(elt.Offset);
+            if (SWIFT_UNLIKELY(offset >
+                               (size_t)std::numeric_limits<OffsetTy>::max()))
+              offsetTruncated = true;
+            elt.Offset = offset;
+          }))) {
+    fatalTupleLayoutOverflow();
+  }
+  if (SWIFT_UNLIKELY(offsetTruncated))
+    fatalTupleElementOffsetOverflow();
 
   Witnesses.size = layout.size;
   Witnesses.flags = layout.flags;
@@ -3230,12 +3330,20 @@ void swift::swift_initStructMetadata(StructMetadata *structType,
                                      const TypeLayout *const *fieldTypes,
                                      uint32_t *fieldOffsets) {
   auto layout = getInitialLayoutForValueType();
-  performBasicLayout(
-      layout, fieldTypes, numFields,
-      [&](size_t i, const TypeLayout *fieldType) { return fieldType; },
-      [&](size_t i, const TypeLayout *fieldType, uint32_t offset) {
-        assignUnlessEqual(fieldOffsets[i], offset);
-      });
+  bool offsetTruncated = false;
+  if (SWIFT_UNLIKELY(!performBasicLayout(
+          layout, fieldTypes, numFields,
+          [&](size_t i, const TypeLayout *fieldType) { return fieldType; },
+          [&](size_t i, const TypeLayout *fieldType, size_t offset) {
+            if (SWIFT_UNLIKELY(offset > (size_t)UINT32_MAX))
+              offsetTruncated = true;
+            assignUnlessEqual(fieldOffsets[i], uint32_t(offset));
+          }))) {
+    fatalLayoutOverflow("struct", structType->getDescription()->Name.get());
+  }
+  if (SWIFT_UNLIKELY(offsetTruncated))
+    fatalFieldOffsetOverflow("struct",
+                             structType->getDescription()->Name.get());
 
   // If the struct is always noncopyable, we must honor that.
   if (structType->getDescription()->isUnconditionallySuppressing(
@@ -3274,17 +3382,26 @@ static void swift_cvw_initStructMetadataWithLayoutStringImpl(
   assert(structType->hasLayoutString());
 
   auto layout = getInitialLayoutForValueType();
-  performBasicLayout(
-      layout, fieldTypes, numFields,
-      [&](size_t i, const uint8_t *fieldType) {
-        if (fieldTags[i]) {
-          return (const TypeLayout*)fieldType;
-        }
-        return ((const Metadata*)fieldType)->getTypeLayout();
-      },
-      [&](size_t i, const uint8_t *fieldType, uint32_t offset) {
-        assignUnlessEqual(fieldOffsets[i], offset);
-      });
+  // The field offset vector is 32 bits wide.
+  bool offsetTruncated = false;
+  if (SWIFT_UNLIKELY(!performBasicLayout(
+          layout, fieldTypes, numFields,
+          [&](size_t i, const uint8_t *fieldType) {
+            if (fieldTags[i]) {
+              return (const TypeLayout *)fieldType;
+            }
+            return ((const Metadata *)fieldType)->getTypeLayout();
+          },
+          [&](size_t i, const uint8_t *fieldType, size_t offset) {
+            if (SWIFT_UNLIKELY(offset > (size_t)UINT32_MAX))
+              offsetTruncated = true;
+            assignUnlessEqual(fieldOffsets[i], uint32_t(offset));
+          }))) {
+    fatalLayoutOverflow("struct", structType->getDescription()->Name.get());
+  }
+  if (SWIFT_UNLIKELY(offsetTruncated))
+    fatalFieldOffsetOverflow("struct",
+                             structType->getDescription()->Name.get());
 
   // If the struct is always noncopyable, we must honor that.
   if (layout.flags.isCopyable() &&
@@ -4142,15 +4259,23 @@ static void initClassFieldOffsetVector(ClassMetadata *self,
     // Skip empty fields.
     if (fieldOffsets[i] == 0 && eltLayout->size == 0)
       continue;
-    auto offset = roundUpToAlignMask(size,
-                                     eltLayout->flags.getAlignmentMask());
+    size_t offset;
+    if (SWIFT_UNLIKELY(!roundUpToAlignMaskCheckingOverflow(
+            size, eltLayout->flags.getAlignmentMask(), offset)))
+      fatalLayoutOverflow("class", self->getDescription()->Name.get());
     fieldOffsets[i] = offset;
-    size = offset + eltLayout->size;
+    bool overflowed = false;
+    size = llvm::SaturatingAdd(offset, (size_t)eltLayout->size, &overflowed);
+    if (SWIFT_UNLIKELY(overflowed))
+      fatalLayoutOverflow("class", self->getDescription()->Name.get());
     alignMask = std::max(alignMask, eltLayout->flags.getAlignmentMask());
   }
 
   // Save the final size and alignment into the metadata record.
   assert(self->isTypeMetadata());
+  // InstanceSize is 32 bits. Ensure we don't overflow it.
+  if (SWIFT_UNLIKELY(size > (size_t)UINT32_MAX))
+    fatalInstanceSizeOverflow(self->getDescription()->Name.get(), size);
   self->setInstanceSize(size);
   self->setInstanceAlignMask(alignMask);
 
@@ -4662,8 +4787,13 @@ swift::swift_updatePureObjCClassMetadata(Class cls,
 
     // Skip empty fields.
     if (offset != 0 || eltLayout->size != 0) {
-      offset = roundUpToAlignMask(size, eltLayout->flags.getAlignmentMask());
-      size = offset + eltLayout->size;
+      if (SWIFT_UNLIKELY(!roundUpToAlignMaskCheckingOverflow(
+              size, eltLayout->flags.getAlignmentMask(), offset)))
+        fatalLayoutOverflow("class", rodata->Name);
+      bool overflowed = false;
+      size = llvm::SaturatingAdd(offset, (size_t)eltLayout->size, &overflowed);
+      if (SWIFT_UNLIKELY(overflowed))
+        fatalLayoutOverflow("class", rodata->Name);
       alignMask = std::max(alignMask, eltLayout->flags.getAlignmentMask());
 
       // Fill in the field offset global, if this ivar has one.
@@ -4696,7 +4826,10 @@ swift::swift_updatePureObjCClassMetadata(Class cls,
     }
   }
 
-  // Save the size into the Objective-C metadata.
+  // Save the size into the Objective-C metadata. Ensure we don't overflow the
+  // 32-bit size field.
+  if (SWIFT_UNLIKELY(size > (size_t)UINT32_MAX))
+    fatalInstanceSizeOverflow(rodata->Name, size);
   if (rodata->InstanceSize != size)
     rodata->InstanceSize = size;
 

--- a/test/Runtime/layout_overflow.swift
+++ b/test/Runtime/layout_overflow.swift
@@ -1,0 +1,90 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking %s -module-name main -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out
+// REQUIRES: executable_test
+// REQUIRES: PTRSIZE=64
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// SILGen passes an address where a borrowed InlineArray value is expected.
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
+
+// Ensure that various size computations trap when overflowing the 32-bit or
+// 64-bit values they're stored in, rather than wrapping and producing an
+// incorrect small value.
+
+import Swift
+import StdlibUnittest
+
+let tests = TestSuite("LayoutOverflow")
+
+func sizeOf<T>(_: T.Type) -> Int { MemoryLayout<T>.size }
+func strideOf<T>(_: T.Type) -> Int { MemoryLayout<T>.stride }
+
+struct TwoFields<let N: Int> {
+  var a: InlineArray<N, Int>
+  var b: InlineArray<N, Int>
+}
+
+class BigClass<let N: Int> {
+  var a = InlineArray<N, Int>(repeating: 0)
+  var b = 0
+}
+
+tests.test("nested Builtin.FixedArray whose cumulative stride overflows") {
+  expectCrashLater(
+    withMessage:
+      "Builtin.FixedArray of 2097152 elements with stride 35184372088832 is too large to be representable")
+  _ = _typeByName("$2097151_$2097151_$2097151_SiBVBVBV")
+}
+
+tests.test("Builtin.FixedArray whose stride times count overflows in one step") {
+  expectCrashLater(
+    withMessage:
+      "Builtin.FixedArray of 2147483647 elements with stride 17179869176 is too large to be representable")
+  _ = _typeByName("$2147483646_$2147483646_SiBVBV")
+}
+
+tests.test("genuine Builtin.FixedArray layouts are unaffected") {
+  let t = _typeByName("$3_SiBV")!
+  expectEqual(4 * MemoryLayout<Int>.stride, _openExistential(t, do: sizeOf))
+  expectEqual(4 * MemoryLayout<Int>.stride, _openExistential(t, do: strideOf))
+}
+
+tests.test("tuple aggregating two representable-but-unsummable fields") {
+  expectCrashLater(
+    withMessage: "tuple has a layout size that is too large to be representable")
+  _ = _typeByName("$1073741823_$1073741823_SiBVBV_$1073741823_$1073741823_SiBVBVt")
+}
+
+tests.test("struct field offset exceeding the 32-bit field offset vector") {
+  expectCrashLater(
+    withMessage:
+      "struct TwoFields has a field offset that does not fit in the 32-bit field offset vector")
+  _ = _typeByName("4main9TwoFieldsVy$2147483646_G")
+}
+
+tests.test("class instance size exceeding the 32-bit InstanceSize field") {
+  expectCrashLater(
+    withMessage: "class BigClass has an instance size of")
+  _ = _typeByName("4main8BigClassCy$2147483646_G")
+}
+
+tests.test("ordinary generic struct and class layouts still work") {
+  let s = _typeByName("4main9TwoFieldsVy$3_G")!
+  expectEqual(2 * 4 * MemoryLayout<Int>.stride,
+              _openExistential(s, do: sizeOf))
+  expectNotNil(_typeByName("4main8BigClassCy$3_G"))
+}
+
+tests.test("InlineArray of a representable size is still usable") {
+  var array = InlineArray<128, Int>(repeating: 7)
+  expectEqual(128 * MemoryLayout<Int>.stride,
+              MemoryLayout<InlineArray<128, Int>>.size)
+  expectEqual(7, array[0])
+  array[127] = 9
+  expectEqual(9, array[127])
+}
+
+runAllTests()


### PR DESCRIPTION
Extremely large types can be constructed with nested InlineArrays. Check for overflow and raise a fatal error to avoid computing an overly-small size that could get used at runtime.

rdar://183443736
rdar://183443761
rdar://183443861
rdar://183444097