### PR TITLE
[Embedded] Diagnose casts to non-unique class types in Embedded Swift

### DIFF
--- a/SwiftCompilerSources/Sources/AST/Declarations.swift
+++ b/SwiftCompilerSources/Sources/AST/Declarations.swift
@@ -88,6 +88,19 @@ public class GenericTypeDecl: TypeDecl, GenericContext {
 public class NominalTypeDecl: GenericTypeDecl {
   final public var isGlobalActor: Bool { bridged.NominalType_isGlobalActor() }
 
+  /// True if this type should have a non-unique definition under the Embedded
+  /// Swift linkage model — i.e. its type metadata may be emitted redundantly
+  /// (as a `linkonce_odr`/`shared` copy) in every module that references it,
+  /// rather than there being a single unique definition. When true, an
+  /// identity-sensitive use across a module boundary (a class `as?`/`as!`
+  /// downcast, which compares metadata pointers) is unsound because the
+  /// allocating module and the casting module may see different metadata
+  /// records. Marking the type `@export(interface)` makes the definition
+  /// unique and flips this to false. Always false outside Embedded Swift.
+  final public var hasNonUniqueDefinition: Bool {
+    bridged.NominalType_hasNonUniqueDefinition()
+  }
+
   final public var valueTypeDestructor: DestructorDecl? {
     bridged.NominalType_getValueTypeDestructor().getAs(DestructorDecl.self)
   }

--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
@@ -121,12 +121,25 @@ private struct FunctionChecker {
          if !checkedCast.supportedInEmbeddedSwift {
            throw Diagnostic(.embedded_swift_dynamic_cast, at: instruction.location)
          }
+         try checkCastTargetUniqueness(checkedCast.targetFormalType, at: instruction.location)
        } else {
          let checkedCast = instruction as! UnconditionalCheckedCastAddrInst
          if !checkedCast.supportedInEmbeddedSwift {
            throw Diagnostic(.embedded_swift_dynamic_cast, at: instruction.location)
          }
+         try checkCastTargetUniqueness(checkedCast.targetFormalType, at: instruction.location)
        }
+
+    // The value-form checked casts (e.g. a class-bound `any P` downcast to a
+    // concrete class, `x as? C`) are lowered to an isa/metadata-pointer
+    // comparison. If the target class has a non-unique definition, the
+    // allocating module and this module may see different metadata records, so
+    // the cast silently fails at runtime. Diagnose it.
+    case let ccb as CheckedCastBranchInst:
+      try checkCastTargetUniqueness(ccb.targetFormalType, at: instruction.location)
+
+    case let ucc as UnconditionalCheckedCastInst:
+      try checkCastTargetUniqueness(ucc.targetFormalType, at: instruction.location)
 
     case let abi as AllocBoxInst:
       // It needs a bit of work to support alloc_box of generic non-copyable structs/enums with deinit,
@@ -211,6 +224,30 @@ private struct FunctionChecker {
     default:
       break
     }
+  }
+
+  // A class `as?`/`as!` downcast compares type-metadata pointers at runtime.
+  // In Embedded Swift a type's metadata is emitted with a non-unique
+  // definition unless the type is `@export(interface)` (or defined in the main
+  // module), so an object allocated in one module and downcast in another can
+  // compare against a different metadata record and the cast silently fails.
+  // Reject casting to such a type here (rdar://179424428).
+  mutating func checkCastTargetUniqueness(_ targetType: CanonicalType, at location: Location) throws {
+    // Only class metadata identity is at stake: `swift_dynamicCastClass`
+    // compares isa pointers. Struct/enum casts don't rely on a unique metadata
+    // record the same way.
+    //
+    // Generic classes are exempt: their metadata is instantiated on demand
+    // through the runtime metadata accessor, which uniques it, so the redundant
+    // per-module definitions still resolve to a single record at runtime.
+    guard targetType.isClass,
+          !targetType.isGenericAtAnyLevel,
+          let nominal = targetType.nominal,
+          nominal.hasNonUniqueDefinition
+    else {
+      return
+    }
+    throw Diagnostic(.embedded_swift_cast_to_nonunique_type, targetType.rawType, at: location)
   }
 
   mutating func checkApply(apply: ApplySite) throws {

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -2411,6 +2411,10 @@ final public class CheckedCastBranchInst : TermInst, UnaryInstruction {
   public var successBlock: BasicBlock { bridged.CheckedCastBranch_getSuccessBlock().block }
   public var failureBlock: BasicBlock { bridged.CheckedCastBranch_getFailureBlock().block }
 
+  public var targetFormalType: CanonicalType {
+    CanonicalType(bridged: bridged.CheckedCastBranch_getTargetFormalType())
+  }
+
   public func updateSourceFormalTypeFromOperandLoweredType() {
     bridged.CheckedCastBranch_updateSourceFormalTypeFromOperandLoweredType()
   }

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -358,6 +358,7 @@ struct BridgedDeclObj {
   BRIDGED_INLINE bool AbstractStorage_isConst() const;
   BRIDGED_INLINE bool GenericType_isGenericAtAnyLevel() const;
   BRIDGED_INLINE bool NominalType_isGlobalActor() const;
+  BRIDGED_INLINE bool NominalType_hasNonUniqueDefinition() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType
   NominalType_getDeclaredInterfaceType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType NominalType_getSelfInterfaceType() const;

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -236,6 +236,10 @@ bool BridgedDeclObj::NominalType_isGlobalActor() const {
   return getAs<swift::NominalTypeDecl>()->isGlobalActor();
 }
 
+bool BridgedDeclObj::NominalType_hasNonUniqueDefinition() const {
+  return getAs<swift::NominalTypeDecl>()->hasNonUniqueDefinition();
+}
+
 OptionalBridgedDeclObj BridgedDeclObj::NominalType_getValueTypeDestructor() const {
   return {getAs<swift::NominalTypeDecl>()->getValueTypeDestructor()};
 }

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3408,6 +3408,15 @@ public:
   /// Is this declaration 'final'?
   bool isFinal() const;
 
+  /// True if this declaration should have a non-unique definition based on
+  /// the Embedded Swift linkage model (i.e. its type metadata / code may be
+  /// emitted redundantly in every module that references it, rather than
+  /// having a single unique definition). Returns false outside Embedded Swift.
+  ///
+  /// This is the AST-level source of truth consulted by
+  /// `SILDeclRef::declHasNonUniqueDefinition`.
+  bool hasNonUniqueDefinition() const;
+
   /// Is this declaration marked with 'dynamic'?
   bool isDynamic() const;
 

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -403,6 +403,10 @@ GROUPED_ERROR(embedded_swift_keypath,EmbeddedRestrictions,none,
       "cannot use key path in embedded Swift", ())
 GROUPED_ERROR(embedded_swift_dynamic_cast,EmbeddedRestrictions,none,
       "cannot do dynamic casting in embedded Swift", ())
+GROUPED_ERROR(embedded_swift_cast_to_nonunique_type,EmbeddedRestrictions,none,
+      "cannot cast to %0 across a module boundary in embedded Swift because its "
+      "type metadata is not unique; mark %0 with '@export(interface)' in its "
+      "defining module", (Type))
 GROUPED_ERROR(embedded_capture_of_generic_value_with_deinit,EmbeddedRestrictions,none,
       "capturing generic non-copyable type with deinit in escaping closure not supported in embedded Swift", ())
 GROUPED_ERROR(embedded_call_generic_function,EmbeddedRestrictions,none,

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -963,6 +963,7 @@ struct BridgedInstruction {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE CheckedCastInstOptions
       UnconditionalCheckedCastAddr_getCheckedCastOptions() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedBasicBlock CheckedCastBranch_getSuccessBlock() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType CheckedCastBranch_getTargetFormalType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedBasicBlock CheckedCastBranch_getFailureBlock() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE CheckedCastInstOptions
       CheckedCastBranch_getCheckedCastOptions() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -1914,6 +1914,10 @@ BridgedBasicBlock BridgedInstruction::CheckedCastBranch_getSuccessBlock() const 
   return {getAs<swift::CheckedCastBranchInst>()->getSuccessBB()};
 }
 
+BridgedCanType BridgedInstruction::CheckedCastBranch_getTargetFormalType() const {
+  return {getAs<swift::CheckedCastBranchInst>()->getTargetFormalType()};
+}
+
 BridgedBasicBlock BridgedInstruction::CheckedCastBranch_getFailureBlock() const {
   return {getAs<swift::CheckedCastBranchInst>()->getFailureBB()};
 }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2546,6 +2546,31 @@ std::optional<StringRef> Decl::getSection() const {
                            SectionForDeclRequest{this}, std::nullopt);
 }
 
+bool ValueDecl::hasNonUniqueDefinition() const {
+  // This only forces the issue in embedded Swift.
+  if (!getASTContext().LangOpts.hasFeature(Feature::Embedded))
+    return false;
+
+  auto *module = getModuleContext();
+  auto &ctx = module->getASTContext();
+
+  switch (getEffectiveCodeGenerationModel()) {
+  case CodeGenerationModel::Implementation:
+    // When deferring all code generation, declarations are emitted as late
+    // as possible, so they must have non-unique definitions.
+    return true;
+
+  case CodeGenerationModel::Inlinable:
+    // If the declaration is not from the main module, treat its definition as
+    // non-unique.
+    return module != ctx.MainModule && ctx.MainModule;
+
+  case CodeGenerationModel::Interface:
+    return false;
+  }
+  llvm_unreachable("covered switch");
+}
+
 PatternBindingDecl::PatternBindingDecl(SourceLoc StaticLoc,
                                        StaticSpellingKind StaticSpelling,
                                        SourceLoc VarLoc,

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -1267,27 +1267,7 @@ bool SILDeclRef::declExposedToForeignLanguage(const ValueDecl *decl) {
 }
 
 bool SILDeclRef::declHasNonUniqueDefinition(const ValueDecl *decl) {
-  // This function only forces the issue in embedded.
-  if (!decl->getASTContext().LangOpts.hasFeature(Feature::Embedded))
-    return false;
-
-  auto module = decl->getModuleContext();
-  auto &ctx = module->getASTContext();
-
-  switch (decl->getEffectiveCodeGenerationModel()) {
-  case CodeGenerationModel::Implementation:
-    /// When deferring all code generation, declarations are emitted as late
-    /// as possible, so they must have non-unique definitions.
-    return true;
-
-  case CodeGenerationModel::Inlinable:
-    // If the declaration is not from the main module, treat its definition as
-    // non-unique.
-    return module != ctx.MainModule && ctx.MainModule;
-
-  case CodeGenerationModel::Interface:
-    return false;
-  }
+  return decl->hasNonUniqueDefinition();
 }
 
 bool SILDeclRef::isForeignToNativeThunk() const {

--- a/test/embedded/cast-to-nonunique-type-export.swift
+++ b/test/embedded/cast-to-nonunique-type-export.swift
@@ -1,0 +1,33 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// Marking the class @export(interface) gives it a unique metadata definition,
+// so the cross-module downcast is sound and must not be diagnosed.
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -wmo -parse-as-library -c -I %t %t/Lib.swift -o %t/Lib.o -emit-module -emit-module-path %t/Lib.swiftmodule -emit-empty-object-file
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -wmo -parse-as-library -emit-ir -verify -I %t %t/Main.swift
+
+// REQUIRES: swift_feature_Embedded
+
+// rdar://179424428
+
+//--- Lib.swift
+
+public protocol WriterProtocol: AnyObject {}
+public protocol ResourceWriter: WriterProtocol {}
+
+@export(interface)
+public final class PSWriterM3Demo: ResourceWriter {
+  public init() {}
+}
+
+@inline(never)
+public func makeWriter() -> any ResourceWriter { PSWriterM3Demo() }
+
+//--- Main.swift
+
+import Lib
+
+public func conditionalCast() -> Bool {
+  let w = makeWriter()
+  return (w as? PSWriterM3Demo) != nil // no error: @export(interface) makes the metadata unique
+}

--- a/test/embedded/cast-to-nonunique-type-same-module.swift
+++ b/test/embedded/cast-to-nonunique-type-same-module.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-emit-ir -parse-as-library -module-name main -verify %s -enable-experimental-feature Embedded -wmo
+
+// REQUIRES: swift_feature_Embedded
+
+// A class defined in the same module as the cast has a unique definition (the
+// main module's metadata), so a same-module downcast is fine and must not be
+// diagnosed as a cross-module non-unique cast. rdar://179424428
+
+public protocol WriterProtocol: AnyObject {}
+public protocol ResourceWriter: WriterProtocol {}
+
+public final class PSWriterM3Demo: ResourceWriter {
+  public init() {}
+}
+
+@inline(never)
+public func makeWriter() -> any ResourceWriter { PSWriterM3Demo() }
+
+public func sameModuleCast() -> Bool {
+  let w = makeWriter()
+  return (w as? PSWriterM3Demo) != nil // no error: same-module class has a unique definition
+}

--- a/test/embedded/cast-to-nonunique-type.swift
+++ b/test/embedded/cast-to-nonunique-type.swift
@@ -1,0 +1,38 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// The defining module builds fine; the cast lives in the consuming module.
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -wmo -parse-as-library -c -I %t %t/Lib.swift -o %t/Lib.o -emit-module -emit-module-path %t/Lib.swiftmodule -emit-empty-object-file
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -wmo -parse-as-library -emit-ir -verify -I %t %t/Main.swift
+
+// REQUIRES: swift_feature_Embedded
+
+// A class-bound existential downcast to a concrete class defined in another
+// module is unsound in Embedded Swift: the class's type metadata is emitted
+// per-module (linkonce_odr) unless it is @export(interface), so the metadata
+// record the cast compares against may differ from the one the allocating
+// module stamped into the object. Diagnose it. rdar://179424428
+
+//--- Lib.swift
+
+public protocol WriterProtocol: AnyObject {}
+public protocol ResourceWriter: WriterProtocol {}
+
+public final class PSWriterM3Demo: ResourceWriter {
+  public init() {}
+}
+
+//--- Main.swift
+
+import Lib
+
+// The writer is passed in as an existential so its dynamic type is opaque and
+// the cast cannot be folded away.
+
+public func conditionalCast(_ w: any ResourceWriter) -> PSWriterM3Demo? {
+  return w as? PSWriterM3Demo // expected-error {{cannot cast to 'PSWriterM3Demo' across a module boundary in embedded Swift because its type metadata is not unique; mark 'PSWriterM3Demo' with '@export(interface)' in its defining module}}
+}
+
+public func forcedCast(_ w: any ResourceWriter) -> PSWriterM3Demo {
+  return w as! PSWriterM3Demo // expected-error {{cannot cast to 'PSWriterM3Demo' across a module boundary in embedded Swift because its type metadata is not unique; mark 'PSWriterM3Demo' with '@export(interface)' in its defining module}}
+}


### PR DESCRIPTION
rdar://179424428

In Embedded Swift a class's type metadata is emitted per-module (linkonce_odr) unless the type is @export(interface), so an object allocated in one module and downcast to that class in another compares against a different metadata record and the cast silently fails.

Diagnose class as?/as!/is casts whose target has a non-unique definition and point the user at @export(interface). To answer that question about the cast target, lift the predicate out of SILDeclRef::declHasNonUniqueDefinition into ValueDecl::hasNonUniqueDefinition and bridge it. This also covers the value-form checked casts, which the pass didn't look at before.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
