### PR TITLE
[Runtime] Reject more integer/metadata mixups in mangled name lookup.

### DIFF
--- a/include/swift/AST/ASTDemangler.h
+++ b/include/swift/AST/ASTDemangler.h
@@ -168,11 +168,12 @@ public:
                               Type parent);
 
   // This is used by the runtime's type lookup to catch the case where a mangled
-  // name specifies a value argument where a type argument is supposed to go.
-  // The AST builder doesn't have that problem so we skip that check entirely.
-  std::optional<bool> isValueGenericParameter(GenericTypeDecl *decl,
-                                              unsigned index) {
-    return std::nullopt;
+  // name binds a value argument where a type argument is supposed to go, or the
+  // reverse. The AST builder doesn't have that problem so we skip that check
+  // entirely.
+  llvm::SmallVector<bool, 8>
+  getValueGenericParameterFlags(GenericTypeDecl *decl, unsigned numArgs) {
+    return {};
   }
 
   Type createTupleType(ArrayRef<Type> eltTypes, ArrayRef<StringRef> labels);

--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -788,19 +788,24 @@ protected:
                                              typeAlias))
         return *error;
 
-      // Reject ill-formed manglings that bind a concrete integer value to a
-      // generic parameter that is not a value parameter (e.g. `Optional<99>`).
-      // This prevents the integer value from being interpreted as a metadata
-      // pointer and crashing.
+      // Reject ill-formed manglings that bind an argument of one sort to a
+      // generic parameter of the other, in either direction. The runtime
+      // represents a metadata pointer and an integer value as one punned word,
+      // so neither confusion is caught without an explicit check.
       auto genericArgsList = Node->getChild(1);
-      for (unsigned i = 0, e = genericArgsList->getNumChildren(); i != e; ++i) {
-        if (!isConcreteIntegerValue(genericArgsList->getChild(i)))
-          continue;
-        auto isValueParam = Builder.isValueGenericParameter(typeDecl, i);
-        if (isValueParam && !*isValueParam)
+      unsigned numArgs = genericArgsList->getNumChildren();
+      auto valueParamFlags =
+          Builder.getValueGenericParameterFlags(typeDecl, numArgs);
+      for (unsigned i = 0, e = valueParamFlags.size(); i != e; ++i) {
+        auto argNode = genericArgsList->getChild(i);
+        if (valueParamFlags[i]) {
+          if (!isValueGenericArgument(argNode))
+            return MAKE_NODE_TYPE_ERROR0(
+                argNode, "type bound to a value generic parameter");
+        } else if (isConcreteIntegerValue(argNode)) {
           return MAKE_NODE_TYPE_ERROR0(
-              genericArgsList->getChild(i),
-              "integer value bound to non-value generic parameter");
+              argNode, "integer value bound to non-value generic parameter");
+        }
       }
 
       return Builder.createBoundGenericType(typeDecl, args, parent);
@@ -1733,6 +1738,14 @@ protected:
                                     "fewer children (%zu) than required (2)",
                                     Node->getNumChildren());
       }
+
+      if (!isValueGenericArgument(Node->getChild(0)))
+        return MAKE_NODE_TYPE_ERROR0(
+            Node->getChild(0),
+            "type where a Builtin.FixedArray count is required");
+
+      // A count of zero and an unresolved count are both represented by a null,
+      // so the count gets no further check.
       auto size = decodeMangledGenericArgument(Node->getChild(0), depth + 1);
       if (size.isError())
         return size;
@@ -1740,6 +1753,13 @@ protected:
       auto element = decodeMangledType(Node->getChild(1), depth + 1);
       if (element.isError())
         return element;
+
+      // A dependent generic parameter with nothing to substitute it with
+      // decodes to a null type.
+      if (!element.getType())
+        return MAKE_NODE_TYPE_ERROR0(
+            Node->getChild(1),
+            "unresolved Builtin.FixedArray element type");
 
       return Builder.createBuiltinFixedArrayType(size.getType(),
                                                  element.getType());
@@ -1953,6 +1973,23 @@ private:
       node = node->getChild(0);
     return node->getKind() == NodeKind::Integer ||
            node->getKind() == NodeKind::NegativeInteger;
+  }
+
+  /// Whether \p node (after unwrapping a \c Type node) is well-formed in a
+  /// value generic parameter position: either a literal integer, or a
+  /// dependent generic parameter reference, which is how a value parameter is
+  /// spelled before substitution.
+  static bool isValueGenericArgument(Demangle::NodePointer node) {
+    if (node->getKind() == NodeKind::Type && node->getNumChildren() == 1)
+      node = node->getChild(0);
+    switch (node->getKind()) {
+    case NodeKind::Integer:
+    case NodeKind::NegativeInteger:
+    case NodeKind::DependentGenericParamType:
+      return true;
+    default:
+      return false;
+    }
   }
 
   std::optional<TypeLookupError>

--- a/include/swift/RemoteInspection/TypeRefBuilder.h
+++ b/include/swift/RemoteInspection/TypeRefBuilder.h
@@ -986,9 +986,9 @@ public:
   // TypeRefs model generic values as distinct IntegerTypeRefs, so a value
   // argument is never misinterpreted as a type; the demangler's value/type
   // consistency check is unnecessary here.
-  std::optional<bool> isValueGenericParameter(const BuiltTypeDecl &,
-                                              unsigned index) {
-    return std::nullopt;
+  llvm::SmallVector<bool, 8>
+  getValueGenericParameterFlags(const BuiltTypeDecl &, unsigned numArgs) {
+    return {};
   }
 
   const TypeRef *createNegativeIntegerType(intptr_t value) {

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1955,18 +1955,33 @@ public:
     return createNominalType(typeAliasDecl, parent);
   }
 
-  /// Determine whether the generic parameter at the given index is a value
-  /// parameter. Returns std::nullopt if the type isn't generic or the index is
-  /// out of range.
-  std::optional<bool> isValueGenericParameter(BuiltTypeDecl anyTypeDecl,
-                                              unsigned index) const {
+  /// Which of the \p numArgs generic arguments a mangled name binds to
+  /// \p anyTypeDecl are bound to value generic parameters. Returns an empty
+  /// vector if \p anyTypeDecl isn't a generic type, or if the argument count
+  /// matches neither of the two shapes createBoundGenericType accepts: just
+  /// this type's own parameters, or, for a type with no parent, the complete
+  /// set across every level of nesting.
+  llvm::SmallVector<bool, 8>
+  getValueGenericParameterFlags(BuiltTypeDecl anyTypeDecl,
+                                unsigned numArgs) const {
     auto typeDecl = dyn_cast<TypeContextDescriptor>(anyTypeDecl);
-    if (!typeDecl)
-      return std::nullopt;
+    if (!typeDecl || !typeDecl->isGeneric())
+      return {};
     auto localParams = getLocalGenericParams(typeDecl);
-    if (index >= localParams.size())
-      return std::nullopt;
-    return localParams[index].getKind() == GenericParamKind::Value;
+    auto allParams = typeDecl->getGenericContext()->getGenericParams();
+    llvm::ArrayRef<GenericParamDescriptor> params;
+    if (numArgs == localParams.size())
+      params = localParams;
+    else if (numArgs == allParams.size())
+      params = allParams;
+    else
+      return {};
+
+    llvm::SmallVector<bool, 8> flags;
+    flags.reserve(params.size());
+    for (auto param : params)
+      flags.push_back(param.getKind() == GenericParamKind::Value);
+    return flags;
   }
 
   TypeLookupErrorOr<BuiltType>
@@ -2492,6 +2507,11 @@ public:
 
   TypeLookupErrorOr<BuiltType> createBuiltinFixedArrayType(BuiltType size,
                                                            BuiltType element) {
+    if (!element.isMetadata())
+      return TYPE_LOOKUP_ERROR_FMT("Tried to build a Builtin.FixedArray "
+                                   "without metadata for the element type");
+    // A count is indistinguishable from a metadata pointer or a pack here, so
+    // the decoder is where a count spelled as a type gets rejected.
     return BuiltType(swift_getFixedArrayTypeMetadata(MetadataState::Abstract,
                                                      size.getValue(),
                                                      element.getMetadata()));

--- a/test/Runtime/value_generic_mangling_mismatch.swift
+++ b/test/Runtime/value_generic_mangling_mismatch.swift
@@ -6,21 +6,33 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-// A mangled type name may place an integer (value) generic argument where a
-// type is expected, e.g. `_typeByName("$99_Sg")` asks for `Optional<99>`. The
-// runtime represents metadata and values the same way, so without validation
-// the integer is misinterpreted as a type metadata pointer and dereferenced,
-// crashing. Such names must instead fail the lookup gracefully, while genuine
-// value generics (an integer in a value parameter) keep working.
+// Ensure that a mangled type name binding a generic argument of one sort to a
+// generic parameter of the other, in either direction, fails the lookup
+// gracefully rather than confusing a metadata pointer with an integer value,
+// and that genuine value generics keep resolving. A mangled `$N_` is the value
+// N + 1, and rejected integers come in pairs: an even value is
+// indistinguishable from a metadata pointer, while an odd one is caught by the
+// runtime's metadata/pack discriminator.
 
 import Swift
 import StdlibUnittest
 
+#if _runtime(_ObjC)
+import Foundation
+#endif
+
 struct ValG<let N: Int> {}
 struct OuterG<T> { struct ValInner<let M: Int> {} }
 struct PairG<T, U> {}
+struct Holder<let N: Int, T> { var storage: InlineArray<N, T>? = nil }
+struct A<T> { struct B<let M: Int> { struct C<U> { struct D<let K: Int> {} } } }
+struct ValOuter<let N: Int> { struct TypeInner<T> {} }
 protocol P {}
 struct S: P {}
+
+#if _runtime(_ObjC)
+class ValClass<T, let N: Int> {}
+#endif
 
 let tests = TestSuite("ValueGenericManglingMismatch")
 
@@ -105,5 +117,104 @@ tests.test("integer where a Builtin.FixedArray element type is expected fails gr
   expectNil(_typeByName("$2_$99_BV"))
   expectNil(_typeByName("$2_$98_BV"))
 }
+
+tests.test("type where a Builtin.FixedArray count is expected fails gracefully") {
+  expectNil(_typeByName("SiSiBV"))
+  expectNil(_typeByName("SdSiBV"))
+  expectNil(_typeByName("$2_SiBVSiBV"))
+}
+
+tests.test("type bound to a value generic parameter fails gracefully") {
+  expectNil(_typeByName("s11InlineArrayVySiSiG"))
+  expectNil(_typeByName("s11InlineArrayVySSSiG"))
+  expectNil(_typeByName("4main4ValGVySiG"))
+  expectNil(_typeByName("4main6OuterGV8ValInnerVySi_SiG"))
+  expectNil(_typeByName("4main1AV1BVySi_SiG"))
+  expectNil(_typeByName("4main1AV1BV1CV1DVySi_$2__SS_SiG"))
+  expectNil(_typeByName("4main1AV1BVy$2__$2_G"))
+  expectNil(_typeByName("4main1AV1BV1CV1DVySi_$2__$9__$6_G"))
+}
+
+// A mangled name may bind either just the innermost type's own parameters, as
+// above, or the complete set across every level of nesting in one argument
+// list. The two shapes index different parameter lists.
+tests.test("wrong argument sort in a whole-nesting argument list fails gracefully") {
+  expectNil(_typeByName("4main8ValOuterV9TypeInnerVySiSSG"))
+  expectNil(_typeByName("4main1AV1BVySiSiG"))
+  expectNil(_typeByName("4main1AV1BV1CV1DVySi$2_SSSiG"))
+  expectNil(_typeByName("4main1AV1BVy$2_$2_G"))
+  expectNil(_typeByName("4main1AV1BV1CV1DVySi$2_$9_$6_G"))
+}
+
+tests.test("unresolved Builtin.FixedArray element type fails gracefully") {
+  expectNil(_typeByName("$3_xBV"))
+  expectNil(_typeByName("$3_qd__BV"))
+  expectNil(_typeByName("SixBV"))
+}
+
+tests.test("pack in a Builtin.FixedArray position fails gracefully") {
+  expectNil(_typeByName("$2_Si_SSQPBV"))
+  expectNil(_typeByName("Si_SSQPSiBV"))
+}
+
+tests.test("genuine Builtin.FixedArray manglings still resolve") {
+  func sizeOf<T>(_: T.Type) -> Int { MemoryLayout<T>.size }
+  if let t = expectNotNil(_typeByName("$3_SiBV")) {
+    expectEqual(4 * MemoryLayout<Int>.stride, _openExistential(t, do: sizeOf))
+  }
+  // A negative count and an unresolved dependent count both lay out like the
+  // empty tuple.
+  if let t = expectNotNil(_typeByName("$n0_SiBV")) {
+    expectEqual(0, _openExistential(t, do: sizeOf))
+  }
+  if let t = expectNotNil(_typeByName("xSiBV")) {
+    expectEqual(0, _openExistential(t, do: sizeOf))
+  }
+}
+
+tests.test("genuine value generic manglings still resolve") {
+  expectEqual(InlineArray<4, String>.self,
+              _typeByName("s11InlineArrayVy$3_SSG")!)
+  expectEqual(InlineArray<0, Int>.self, _typeByName("s11InlineArrayVy$_SiG")!)
+  expectEqual(InlineArray<2, InlineArray<3, Int>>.self,
+              _typeByName("s11InlineArrayVy$1_ABy$2_SiGG")!)
+  expectEqual([InlineArray<3, Double>].self,
+              _typeByName("Says11InlineArrayVy$2_SdGG")!)
+  expectEqual(Optional<InlineArray<7, UInt8>>.self,
+              _typeByName("s11InlineArrayVy$6_s5UInt8VGSg")!)
+  expectEqual(Holder<3, Int>.self, _typeByName("4main6HolderVy$2_SiG")!)
+  expectEqual(Holder<9, InlineArray<2, Int>>.self,
+              _typeByName("4main6HolderVy$8_s11InlineArrayVy$1_SiGG")!)
+  expectEqual(A<Int>.B<3>.self, _typeByName("4main1AV1BVySi_$2_G")!)
+  expectEqual(A<Int>.B<3>.C<String>.D<7>.self,
+              _typeByName("4main1AV1BV1CV1DVySi_$2__SS_$6_G")!)
+}
+
+tests.test("genuine value generics in a whole-nesting argument list still resolve") {
+  expectEqual(ValOuter<3>.TypeInner<String>.self,
+              _typeByName("4main8ValOuterV9TypeInnerVy$2_SSG")!)
+  expectEqual(A<Int>.B<3>.self, _typeByName("4main1AV1BVySi$2_G")!)
+  expectEqual(A<Int>.B<3>.C<String>.D<7>.self,
+              _typeByName("4main1AV1BV1CV1DVySi$2_SS$6_G")!)
+}
+
+// The runtime mangles metadata using a symbolic reference to the innermost
+// nominal type, which produces the whole-nesting shape.
+tests.test("metadata for a nested value generic round-trips through its mangled name") {
+  expectEqual("main.ValOuter<3>.TypeInner<Swift.String>",
+              _typeName(ValOuter<3>.TypeInner<String>.self))
+  expectEqual(ValOuter<3>.TypeInner<String>.self,
+              _typeByName(_mangledTypeName(ValOuter<3>.TypeInner<String>.self)!)!)
+  expectEqual(A<Int>.B<3>.C<String>.D<7>.self,
+              _typeByName(_mangledTypeName(A<Int>.B<3>.C<String>.D<7>.self)!)!)
+}
+
+#if _runtime(_ObjC)
+// objc_getClass routes an unprefixed mangled name through the same lookup.
+tests.test("type bound to a value generic parameter fails gracefully through objc_getClass") {
+  expectNotNil(NSClassFromString(_mangledTypeName(ValClass<Int, 5>.self)!))
+  expectNil(NSClassFromString("4main8ValClassCySiSiG"))
+}
+#endif
 
 runAllTests()


### PR DESCRIPTION
Reject mangled name lookups of constructs like `InlineArray<Int, Int>`. This is a followup from ed45cd89c53ef37c779ccdb7fb157c1dc9d6ae0e which rejected integers in metadata positions such as `Optional<99>`. This change rejects metadata where integers are expected, rejects a metadata pack or an unresolved dependent parameter as a `Builtin.FixedArray` element type, and fixes one hole where an integer in a metadata position wouldn't be rejected.

rdar://183444018