### PR TITLE
SIL,SILGen,IRGen: support one word COM existential representation

### DIFF
--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -78,6 +78,10 @@ enum class ExistentialRepresentation {
   /// The container may be able to directly adopt a class reference using
   /// init_existential_ref for some class types.
   Boxed,
+  /// The container is a single COM interface pointer. Copies and destroys
+  /// dispatch `AddRef` and `Release` through slots 1 and 2 of the interface
+  /// vtable. It carries netiher Swift type metadata nor witness tables.
+  COM,
 };
 
 /// The value category.

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -32,6 +32,7 @@
 #include "llvm/Support/raw_ostream.h"
 
 #include "BitPatternBuilder.h"
+#include "Callee.h"
 #include "EnumPayload.h"
 #include "Explosion.h"
 #include "FixedTypeInfo.h"
@@ -1491,7 +1492,128 @@ public:
     return ErrorProto;
   }
 };
-  
+
+/// A COM existential is the interface pointer itself. Unlike a class
+/// existential, this pointer is not a Swift heap-object address point and
+/// therefore must never be passed to Swift ARC.
+class COMExistentialTypeInfo final
+    : public SingleScalarTypeInfo<COMExistentialTypeInfo, LoadableTypeInfo> {
+  enum class Operation : unsigned {
+    AddRef = 1,
+    Release = 2,
+  };
+
+  void emit(IRGenFunction &IGF, llvm::Value *interface,
+            Operation operation) const {
+    auto *head = IGF.createBasicBlock(operation == Operation::AddRef
+                                          ? "com.addref"
+                                          : "com.release");
+    auto *tail = IGF.createBasicBlock("com.refcount.done");
+
+    IGF.Builder.CreateCondBr(IGF.Builder.CreateIsNotNull(interface), head, tail);
+    IGF.Builder.emitBlock(head);
+
+    // A COM interface pointer points at its vtable pointer. Slots 1 and 2 are
+    // AddRef and Release respectively, both with the foreign scalar ABI
+    // UInt32(void *)
+    Address instance(interface, IGF.IGM.Int8PtrTy, IGF.IGM.getPointerAlignment());
+    auto *load = IGF.Builder.CreateLoad(instance, "com.vtable");
+    Address vtable(load, IGF.IGM.Int8PtrTy, IGF.IGM.getPointerAlignment());
+    auto slot = IGF.Builder.CreateConstArrayGEP(vtable,
+                                                static_cast<unsigned>(operation),
+                                                IGF.IGM.getPointerSize(),
+                                                operation == Operation::AddRef
+                                                    ? "com.addref.slot"
+                                                    : "com.release.slot");
+    auto *method = IGF.Builder.CreateLoad(slot, "com.refcount.method");
+    auto *type = llvm::FunctionType::get(IGF.IGM.Int32Ty, {IGF.IGM.Int8PtrTy},
+                                         /*isVarArg=*/false);
+    Signature signature(type, llvm::AttributeList(), llvm::CallingConv::C);
+    auto function =
+        FunctionPointer::createUnsigned(FunctionPointer::Kind::Function,
+                                        method, signature);
+    auto *call = IGF.Builder.CreateCall(function, {interface});
+    call->setDoesNotThrow();
+    IGF.Builder.CreateBr(tail);
+
+    IGF.Builder.emitBlock(tail);
+  }
+
+public:
+  COMExistentialTypeInfo(llvm::PointerType *storage, Size size, Alignment align)
+      : SingleScalarTypeInfo(storage, size,
+                             SpareBitVector::getConstant(size.getValueInBits(),
+                                                         false),
+                             align, IsNotTriviallyDestroyable, IsCopyable,
+                             IsFixedSize, IsABIAccessible) {
+  }
+
+  static constexpr bool IsScalarTriviallyDestroyable = false;
+
+  void emitScalarRetain(IRGenFunction &IGF, llvm::Value *value,
+                        Atomicity atomicity) const {
+    emit(IGF, value, Operation::AddRef);
+  }
+
+  void emitScalarRelease(IRGenFunction &IGF, llvm::Value *value,
+                         Atomicity atomicity) const {
+    emit(IGF, value, Operation::Release);
+  }
+
+  void emitScalarFixLifetime(IRGenFunction &IGF, llvm::Value *value) const {
+    IGF.emitFixLifetime(value);
+  }
+
+  TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM, SILType T,
+                                        bool useStructLayout) const override {
+    // No existing scalar kind has COM's vtable-dispatch ownership semantics.
+    // Keep layout-driven value operations tied to this TypeInfo.
+    return IGM.typeLayoutCache.getOrCreateTypeInfoBasedEntry(*this, T);
+  }
+
+  bool mayHaveExtraInhabitants(IRGenModule &) const override {
+    return true;
+  }
+
+  unsigned getFixedExtraInhabitantCount(IRGenModule &) const override {
+    return 1;
+  }
+
+  APInt getFixedExtraInhabitantValue(IRGenModule &, unsigned bits,
+                                     unsigned index) const override {
+    assert(index == 0);
+    return APInt(bits, 0);
+  }
+
+  llvm::Value *
+  getExtraInhabitantIndex(IRGenFunction &IGF, Address source, SILType T,
+                          bool) const override {
+    source = IGF.Builder.CreateElementBitCast(source, IGF.IGM.IntPtrTy);
+    auto *value = IGF.Builder.CreateLoad(source);
+    auto *valid =
+        IGF.Builder.CreateICmpNE(value,
+                                 llvm::ConstantInt::get(IGF.IGM.IntPtrTy, 0));
+    // Null is extra inhabitant zero; valid pointers are reported as -1.
+    return IGF.Builder.CreateSExt(valid, IGF.IGM.Int32Ty);
+  }
+
+  void storeExtraInhabitant(IRGenFunction &IGF, llvm::Value *index,
+                            Address destination, SILType T,
+                            bool) const override {
+    destination =
+        IGF.Builder.CreateElementBitCast(destination, IGF.IGM.IntPtrTy);
+    IGF.Builder.CreateStore(llvm::ConstantInt::get(IGF.IGM.IntPtrTy, 0),
+                            destination);
+  }
+
+  bool canValueWitnessExtraInhabitantsUpTo(IRGenModule &,
+                                           unsigned index) const override {
+    // Refcount operations branch around null, allowing Optional to use it as
+    // the payload's first extra inhabitant.
+    return index == 0;
+  }
+};
+
 } // end anonymous namespace
 
 static const TypeInfo *
@@ -1555,6 +1677,10 @@ static const TypeInfo *createExistentialTypeInfo(IRGenModule &IGM, CanType T) {
     // Error has a special runtime representation.
     return createErrorExistentialTypeInfo(IGM, layout);
   }
+
+  if (layout.getCOMInterface())
+    return new COMExistentialTypeInfo(IGM.Int8PtrTy, IGM.getPointerSize(),
+                                      IGM.getPointerAlignment());
 
   llvm::StructType *type;
 

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -7599,6 +7599,9 @@ void irgen::emitForeignTypeMetadata(IRGenModule &IGM, NominalTypeDecl *decl) {
 
 /// Get the runtime identifier for a special protocol, if any.
 SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
+  if (P->isCOMInterface())
+    return SpecialProtocol::COM;
+
   auto known = P->getKnownProtocolKind();
   if (!known)
     return SpecialProtocol::None;

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -1071,7 +1071,9 @@ private:
   void layoutProtocol() {
     auto PD = cast<ProtocolDecl>(NTD);
     FieldDescriptorKind Kind;
-    if (PD->isObjC())
+    if (PD->isCOMInterface())
+      Kind = FieldDescriptorKind::COMProtocol;
+    else if (PD->isObjC())
       Kind = FieldDescriptorKind::ObjCProtocol;
     else if (PD->requiresClass())
       Kind = FieldDescriptorKind::ClassProtocol;

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3430,6 +3430,8 @@ void IRGenSILFunction::visitExistentialMetatypeInst(
   SILType opType = op->getType();
 
   switch (opType.getPreferredExistentialRepresentation()) {
+  case ExistentialRepresentation::COM:
+    llvm_unreachable("COM existential metatype projection is not implemented");
   case ExistentialRepresentation::Metatype: {
     Explosion existential = getLoweredExplosion(op);
     emitMetatypeOfMetatype(*this, existential, opType, result);

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -576,6 +576,11 @@ SILType::getPreferredExistentialRepresentation(Type containedType) const {
     }
   }
 
+  // A COM interface existential is already its foreign object-model projection.
+  // It is neither a Swift class reference nor an opaque existential constraint.
+  if (layout.getCOMInterface())
+    return ExistentialRepresentation::COM;
+
   // A class-constrained protocol composition can adopt the conforming
   // class reference directly.
   if (layout.requiresClass())
@@ -590,6 +595,9 @@ bool
 SILType::canUseExistentialRepresentation(ExistentialRepresentation repr,
                                          Type containedType) const {
   switch (repr) {
+  case ExistentialRepresentation::COM:
+    return isExistentialType() &&
+      getASTType().getExistentialLayout().getCOMInterface();
   case ExistentialRepresentation::None:
     return !isAnyExistentialType();
   case ExistentialRepresentation::Opaque:

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -819,6 +819,18 @@ namespace {
                                IsTypeExpansionSensitive_t isSensitive) {
       switch (SILType::getPrimitiveObjectType(type)
                 .getPreferredExistentialRepresentation()) {
+      case ExistentialRepresentation::COM:
+        // COM existentials are fixed-size, loadable values with custom
+        // copy/destroy operations. They must not be classified as Swift
+        // reference-counted values: their sole pointer is an interface address,
+        // not a Swift heap-object address point.
+        return asImpl().handleNonTrivialAggregate(type, {IsNotTrivial,
+                                                         IsFixedABI,
+                                                         IsNotAddressOnly,
+                                                         IsNotResilient,
+                                                         isSensitive,
+                                                         DoesNotHaveRawPointer,
+                                                         IsLexical});
       case ExistentialRepresentation::None:
         llvm_unreachable("not an existential type?!");
       // Opaque existentials are address-only.
@@ -2376,7 +2388,14 @@ namespace {
       auto silType = SILType::getPrimitiveObjectType(type);
       return new (TC) OpaqueValueTypeLowering(silType, properties, Expansion);
     }
-    
+
+    TypeLowering *handleNonTrivialAggregate(CanType T,
+                                            SILTypeProperties properties) {
+      properties = mergeHasPack(HasPack_t(T->hasAnyPack()), properties);
+      auto type = SILType::getPrimitiveObjectType(T);
+      return new (TC) MiscNontrivialTypeLowering(type, properties, Expansion);
+    }
+
     TypeLowering *handleInfinite(CanType type,
                                  SILTypeProperties properties) {
       properties = mergeHasPack(HasPack_t(type->hasAnyPack()), properties);

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -909,6 +909,8 @@ RuntimeEffect swift::getRuntimeEffect(SILInstruction *inst, SILType &impactType)
     SILType opType = cast<ExistentialMetatypeInst>(inst)->getOperand()->getType();
     impactType = opType;
     switch (opType.getPreferredExistentialRepresentation()) {
+    case ExistentialRepresentation::COM:
+      return RuntimeEffect::MetaData | RuntimeEffect::Existential;
     case ExistentialRepresentation::Metatype:
     case ExistentialRepresentation::Boxed:
     case ExistentialRepresentation::Opaque:

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -612,6 +612,7 @@ public:
       break;
     }
     case ExistentialRepresentation::Class:
+    case ExistentialRepresentation::COM:
     case ExistentialRepresentation::Metatype:
     case ExistentialRepresentation::None:
       llvm_unreachable("not supported");
@@ -814,6 +815,8 @@ ManagedValue SILGenFunction::emitExistentialErasure(
     return B.createInitExistentialRef(loc, existentialTL.getLoweredType(),
                                       concreteFormalType, sub, conformances);
   }
+  case ExistentialRepresentation::COM:
+    llvm_unreachable("COM interface projection is not implemented");
   case ExistentialRepresentation::Boxed: {
     // We defer allocation of the box to when the address is demanded.
     // Create a stack slot to hold the box once it's allocated.
@@ -1005,6 +1008,8 @@ SILGenFunction::emitOpenExistential(
 
   SILType existentialType = existentialValue.getType();
   switch (existentialType.getPreferredExistentialRepresentation()) {
+  case ExistentialRepresentation::COM:
+    llvm_unreachable("opening a COM existential is not implemented");
   case ExistentialRepresentation::Opaque: {
     // With CoW existentials we can't consume the boxed value inside of
     // the existential. (We could only do so after a uniqueness check on

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -2058,6 +2058,7 @@ namespace {
     void emit(SILGenFunction &SGF, CleanupLocation l,
               ForUnwind_t forUnwind) override {
       switch (repr) {
+      case ExistentialRepresentation::COM:
       case ExistentialRepresentation::None:
       case ExistentialRepresentation::Class:
       case ExistentialRepresentation::Metatype:

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1039,6 +1039,8 @@ namespace {
 
       auto rep = base.getType().getPreferredExistentialRepresentation();
       switch (rep) {
+      case ExistentialRepresentation::COM:
+        llvm_unreachable("opening a COM existential is not implemented");
       case ExistentialRepresentation::Opaque:
         if (!base.getValue()->getType().isAddress()) {
           assert(!SGF.useLoweredAddresses());
@@ -6021,6 +6023,8 @@ SILGenFunction::emitOpenExistentialLValue(SILLocation loc,
   auto rep = lv.getTypeOfRValue()
     .getPreferredExistentialRepresentation();
   switch (rep) {
+  case ExistentialRepresentation::COM:
+    llvm_unreachable("opening a COM existential is not implemented");
   case ExistentialRepresentation::Opaque:
   case ExistentialRepresentation::Boxed: {
     lv.add<OpenOpaqueExistentialComponent>(openedArchetype, typeData);

--- a/test/IRGen/com-existential-representation.swift
+++ b/test/IRGen/com-existential-representation.swift
@@ -1,0 +1,69 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module-path %t/COM.swiftmodule -module-name COM -enable-experimental-com-interop %S/../Inputs/COM.swift
+// RUN: %target-swift-frontend -parse-as-library -module-name M -emit-ir -enable-experimental-com-interop -I %t %s | %FileCheck %s
+
+// REQUIRES: PTRSIZE=64
+
+import COM
+
+@com(interface: "10000000-0000-0000-0000-000000000001")
+public protocol IWidget { }
+
+// CHECK: @"$s{{.*}}16kExistentialSizeSivp" = {{.*}}constant %TSi <{ i64 8 }>
+public let kExistentialSize = MemoryLayout<any IWidget>.size
+
+// CHECK: @"$s{{.*}}24kOptionalExistentialSizeSivp" = {{.*}}constant %TSi <{ i64 8 }>
+public let kOptionalExistentialSize = MemoryLayout<(any IWidget)?>.size
+
+// The protocol descriptor marks the interface as the COM special protocol so
+// dynamically-created existential metadata selects the same representation.
+// CHECK-LABEL: @"$s{{.*}}7IWidgetMp" = {{.*}}constant
+// --       0x0009_0043: special protocol 02, non-class, unique, protocol context
+// CHECK-SAME: i32 589891,
+
+// Both the existential and Optional existential are one pointer.
+// CHECK-LABEL: define{{.*}} swiftcc ptr @"$s{{.*}}4copyyAA7IWidget_pAaC_pF"
+// CHECK-SAME: (ptr [[INTERFACE:%.*]])
+// CHECK:         icmp ne ptr [[INTERFACE]], null
+// CHECK:         load ptr, ptr [[INTERFACE]]
+// CHECK:         getelementptr inbounds ptr, ptr {{%.*}}, i{{32|64}} 1
+// CHECK:         load ptr, ptr {{%.*}}
+// CHECK:         call i32 {{%.*}}(ptr [[INTERFACE]])
+// CHECK-NOT:     call swift_retain
+// CHECK-NOT:     call swift_unknownObjectRetain
+// CHECK:         ret ptr [[INTERFACE]]
+public func copy(_ value: borrowing any IWidget) -> any IWidget {
+  copy value
+}
+
+// CHECK-LABEL: define{{.*}} swiftcc void @"$s{{.*}}7consumeyyAA7IWidget_pnF"(ptr
+// CHECK:         [[INTERFACE:%.*]] = load ptr, ptr
+// CHECK:         icmp ne ptr [[INTERFACE]], null
+// CHECK:         load ptr, ptr [[INTERFACE]]
+// CHECK:         getelementptr inbounds ptr, ptr {{%.*}}, i{{32|64}} 2
+// CHECK:         load ptr, ptr {{%.*}}
+// CHECK:         call i32 {{%.*}}(ptr [[INTERFACE]])
+// CHECK-NOT:     call swift_release
+// CHECK-NOT:     call swift_unknownObjectRelease
+// CHECK:         ret void
+public func consume(_ value: consuming any IWidget) { }
+
+public struct Holder {
+  public var value: any IWidget
+
+  // CHECK-LABEL: define{{.*}} swiftcc ptr @"$s{{.*}}6HolderVyAcA7IWidget_pcfC"(ptr
+  // CHECK:         ret ptr %0
+  public init(_ value: consuming any IWidget) {
+    self.value = value
+  }
+}
+
+// CHECK-LABEL: define{{.*}} swiftcc ptr @"$s{{.*}}4copy8optionalAA7IWidget_pSgA{{.*}}F"
+// CHECK-SAME: (ptr [[OPTIONAL:%.*]])
+// CHECK: icmp ne ptr [[OPTIONAL]], null
+// CHECK: getelementptr inbounds ptr, ptr {{%.*}}, i{{32|64}} 1
+// CHECK: call i32 {{%.*}}(ptr [[OPTIONAL]])
+// CHECK: ret ptr [[OPTIONAL]]
+public func copy(optional value: borrowing (any IWidget)?) -> (any IWidget)? {
+  copy value
+}

--- a/test/SILGen/com-existential-representation.swift
+++ b/test/SILGen/com-existential-representation.swift
@@ -1,0 +1,59 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module-path %t/COM.swiftmodule -module-name COM -enable-experimental-com-interop %S/../Inputs/COM.swift
+// RUN: %target-swift-frontend -parse-as-library -module-name M -emit-silgen -enable-experimental-com-interop -I %t %s | %FileCheck %s
+
+// REQUIRES: PTRSIZE=64
+
+// A COM existential is a loadable, nontrivial value. Copying and destroying it
+// must remain abstract SIL value operations so IRGen can use the COM vtable
+// instead of Swift ARC.
+
+@com(interface: "10000000-0000-0000-0000-000000000001")
+public protocol IWidget { }
+
+// CHECK-LABEL: sil [ossa] @$s{{.*}}4copyyAA7IWidget_pAaC_pF
+// CHECK-SAME:  @guaranteed any IWidget
+// CHECK-SAME:  @owned any IWidget
+// CHECK:         explicit_copy_value
+// CHECK-NOT:     strong_retain
+// CHECK:         return
+public func copy(_ value: borrowing any IWidget) -> any IWidget {
+  copy value
+}
+
+// CHECK-LABEL: sil [ossa] @$s{{.*}}7consumeyyAA7IWidget_pnF
+// CHECK-SAME:  @owned any IWidget
+// CHECK-NOT:     strong_release
+// CHECK:         destroy_value
+// CHECK:         return
+public func consume(_ value: consuming any IWidget) { }
+
+public struct Holder {
+  public var value: any IWidget
+
+  // CHECK-LABEL: sil [ossa] @$s{{.*}}6HolderV{{.*}}cfC
+  // CHECK-SAME:  @owned any IWidget
+  // CHECK-NOT:   init_existential
+  // CHECK:       return
+  public init(_ value: consuming any IWidget) {
+    self.value = value
+  }
+}
+
+// CHECK-LABEL: sil [ossa] @$s{{.*}}4copy8optionalAA7IWidget_pSgA{{.*}}F
+// CHECK-SAME:  @guaranteed Optional<any IWidget>
+// CHECK-SAME:  @owned Optional<any IWidget>
+// CHECK:       explicit_copy_value
+// CHECK-NOT:   strong_retain
+// CHECK:       return
+public func copy(optional value: borrowing (any IWidget)?) -> (any IWidget)? {
+  copy value
+}
+
+// CHECK-LABEL: sil [ossa] @$s{{.*}}4make5arraySayAA7IWidget_pGAaD_pn_tF
+// CHECK-SAME:  @owned any IWidget
+// CHECK-NOT:   init_existential
+// CHECK:       return
+public func make(array value: consuming any IWidget) -> [any IWidget] {
+  [value]
+}


### PR DESCRIPTION
This pull request adds initial support for COM interface existentials in Swift, introducing a new existential representation for protocols marked as COM interfaces. It implements the core runtime and IRGen logic for handling COM existentials as single interface pointers, with vtable-based AddRef/Release for reference counting. The changes include updates to the type system, IRGen, SIL lowering, and new tests to verify the representation and value semantics. Some SILGen and existential operations remain unimplemented and are guarded with assertions.

The most important changes are:

**COM Existential Representation and Type System Integration**
- Introduced `ExistentialRepresentation::COM` to represent COM interface existentials as single pointers, with appropriate reference counting via vtable slots. Updated `SILType`, type lowering, and existential representation queries to recognize and select the COM representation for eligible protocols. (`include/swift/SIL/SILType.h` [[1]](diffhunk://#diff-11b8d5761cebe1637811d5f7b0e5ce17fedc5b0e5c9df7beb7d601577487f66eR81-R84) `lib/SIL/IR/SILType.cpp` [[2]](diffhunk://#diff-979b04dc8f04d5e4ed74b20cacaecd4f7941a8a515f27f2dd8c5cff7cbb3f3f2R579-R583) [[3]](diffhunk://#diff-979b04dc8f04d5e4ed74b20cacaecd4f7941a8a515f27f2dd8c5cff7cbb3f3f2R598-R600) `lib/SIL/IR/TypeLowering.cpp` [[4]](diffhunk://#diff-f225973f74fb5d01a20a43ffa69ab2ee1652880a40733d654d4c20bba3612879R822-R833) [[5]](diffhunk://#diff-f225973f74fb5d01a20a43ffa69ab2ee1652880a40733d654d4c20bba3612879R2392-R2398)

**IRGen Support for COM Existentials**
- Added `COMExistentialTypeInfo` in IRGen to implement COM existential value operations, including emitting AddRef/Release calls through the interface vtable, handling extra inhabitants, and ensuring correct value semantics. Updated existential type info creation to select this representation for COM interfaces. (`lib/IRGen/GenExistential.cpp` [[1]](diffhunk://#diff-0d988e84b1fb2f2e0d7a83bbb9a558b6146116759ee7010f1739661a25a3e7fdR1496-R1616) [[2]](diffhunk://#diff-0d988e84b1fb2f2e0d7a83bbb9a558b6146116759ee7010f1739661a25a3e7fdR1681-R1684)
- Updated protocol metadata and reflection to mark COM interfaces as a special protocol kind, ensuring the runtime and tools recognize their representation. (`lib/IRGen/GenMeta.cpp` [[1]](diffhunk://#diff-56fe5ccc6780a820be0e933eca770d0413c87c5f9478f8aff2000eef9ecbbca2R7602-R7604) `lib/IRGen/GenReflection.cpp` [[2]](diffhunk://#diff-b3ed90142ed63e91e892d8c786ae44e5a3de99c501244edb36b871148c45a057L1074-R1076)

**SIL and SILGen Integration**
- Updated SIL lowering and runtime effect analysis to handle COM existentials as nontrivial, fixed-size, loadable values, and to avoid treating them as Swift reference-counted objects. (`lib/SIL/IR/TypeLowering.cpp` [[1]](diffhunk://#diff-f225973f74fb5d01a20a43ffa69ab2ee1652880a40733d654d4c20bba3612879R822-R833) `lib/SIL/Utils/InstructionUtils.cpp` [[2]](diffhunk://#diff-76f1ab1a422b006fbe4bffc09d0576d8aeb48dad17cffed645f90f2e2af868c6R912-R913)
- Added handling for COM existentials in SILGen, but left operations such as existential erasure and opening as unimplemented with assertions, as these require further work. (`lib/SILGen/SILGenConvert.cpp` [[1]](diffhunk://#diff-6620977427907628b10603b39c31a5c4dc2416a9b2352342200a2d80e35fee4bR615) [[2]](diffhunk://#diff-6620977427907628b10603b39c31a5c4dc2416a9b2352342200a2d80e35fee4bR818-R819) [[3]](diffhunk://#diff-6620977427907628b10603b39c31a5c4dc2416a9b2352342200a2d80e35fee4bR1011-R1012) `lib/SILGen/SILGenLValue.cpp` [[4]](diffhunk://#diff-8fe89f5d8fab0ea9daa87fb1afd64fc03faa3b46d50a36542902940bbb7b5648R1042-R1043) [[5]](diffhunk://#diff-8fe89f5d8fab0ea9daa87fb1afd64fc03faa3b46d50a36542902940bbb7b5648R6026-R6027) `lib/SILGen/SILGenDecl.cpp` [[6]](diffhunk://#diff-1ec20086508b338a0a2289d9903a368532d98b327a45d7b87206bf7a82c5378aR2061)

**Testing**
- Added IRGen and SILGen tests (`test/IRGen/com-existential-representation.swift`, `test/SILGen/com-existential-representation.swift`) to verify that COM existentials are represented as single pointers, that AddRef/Release are called correctly, and that Swift ARC is not used for these values. (`test/IRGen/com-existential-representation.swift` [[1]](diffhunk://#diff-00fa8e900475921351e5bcd0930c43d5a8532f1f33017d35ae9e7e463d8ab076R1-R69) `test/SILGen/com-existential-representation.swift` [[2]](diffhunk://#diff-73eeec0c3453ad2226f5961d357cdbb235ddd5a9607f83d8dc5d6b7155831a61R1-R59)

**Miscellaneous**
- Added necessary includes and small supporting changes to enable the new representation. (`lib/IRGen/GenExistential.cpp` [lib/IRGen/GenExistential.cppR35](diffhunk://#diff-0d988e84b1fb2f2e0d7a83bbb9a558b6146116759ee7010f1739661a25a3e7fdR35))

This lays the groundwork for COM interop by providing a correct representation and value semantics for COM existentials, with further work needed for full SILGen and language support.