### PR TITLE
Warn when combining -g with -disable-reflection-metadata

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -95,6 +95,10 @@ WARNING(warning_option_requires_specific_sanitizer, none,
       "option '%0' has no effect when '%1' sanitizer is disabled. Use -sanitize=%1 to "
       "enable the sanitizer", (StringRef, StringRef))
 
+WARNING(warning_reflection_metadata_disabled_with_debug_info, none,
+      "debug info is requested with option '%0' but option '%1' will prevent "
+      "variable inspection in the debugger", (StringRef, StringRef))
+
 ERROR(error_option_missing_required_argument, none,
       "option '%0' is missing a required argument (%1)", (StringRef, StringRef))
 ERROR(error_option_missing_required_output_kind, none,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3957,6 +3957,22 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
     Opts.EnableReflectionNames = true;
   }
 
+  // LLDB needs reflection metadata to inspect variables of non-embedded Swift
+  // programs. Embedded Swift promotes -g to -gdwarf-types and relies on the
+  // DWARF type information instead, so it is exempt from this warning.
+  if (Opts.ReflectionMetadata == ReflectionMetadataMode::None &&
+      Opts.DebugInfoLevel == IRGenDebugInfoLevel::ASTTypes &&
+      !LangOpts.hasFeature(Feature::Embedded)) {
+    const Arg *DebugInfoArg = Args.getLastArg(OPT_g_Group);
+    const Arg *NoReflectionArg =
+        Args.getLastArg(OPT_disable_reflection_metadata);
+    if (DebugInfoArg && NoReflectionArg)
+      Diags.diagnose(SourceLoc(),
+                     diag::warning_reflection_metadata_disabled_with_debug_info,
+                     DebugInfoArg->getAsString(Args),
+                     NoReflectionArg->getAsString(Args));
+  }
+
   if (Args.hasArg(OPT_enable_anonymous_context_mangled_names))
     Opts.EnableAnonymousContextMangledNames = true;
 

--- a/test/Frontend/disable-reflection-metadata-debug-info.swift
+++ b/test/Frontend/disable-reflection-metadata-debug-info.swift
@@ -1,0 +1,40 @@
+// LLDB needs reflection metadata to inspect variables, so -g combined with
+// -disable-reflection-metadata should produce a warning.
+// RUN: %target-swift-frontend -emit-ir -o /dev/null -g -disable-reflection-metadata %s 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -emit-ir -o /dev/null -g -disable-reflection-metadata -warnings-as-errors %s 2>&1 | %FileCheck %s --check-prefix=ERROR
+
+// Line tables don't describe variables in the first place, so there is nothing
+// to lose. -warnings-as-errors turns the absence of the warning into a hard
+// failure, which an --allow-empty FileCheck alone would not catch.
+// RUN: %target-swift-frontend -emit-ir -o /dev/null -gline-tables-only -disable-reflection-metadata %s 2>&1 | %FileCheck %s --check-prefix=NO-WARNING --allow-empty
+// RUN: %target-swift-frontend -emit-ir -o /dev/null -gline-tables-only -disable-reflection-metadata -warnings-as-errors %s
+// Order doesn't matter, and neither does -gline-tables-only winning over -g.
+// RUN: %target-swift-frontend -emit-ir -o /dev/null -disable-reflection-metadata -gline-tables-only -warnings-as-errors %s
+// RUN: %target-swift-frontend -emit-ir -o /dev/null -g -gline-tables-only -disable-reflection-metadata -warnings-as-errors %s
+// ... but -g winning over -gline-tables-only does warn.
+// RUN: %target-swift-frontend -emit-ir -o /dev/null -gline-tables-only -g -disable-reflection-metadata %s 2>&1 | %FileCheck %s
+
+// -gnone and no -g at all have no variables to inspect either.
+// RUN: %target-swift-frontend -emit-ir -o /dev/null -gnone -disable-reflection-metadata -warnings-as-errors %s
+// RUN: %target-swift-frontend -emit-ir -o /dev/null -disable-reflection-metadata -warnings-as-errors %s
+
+// -gdwarf-types describes variables in DWARF, so the debugger doesn't have to
+// fall back onto reflection metadata.
+// RUN: %target-swift-frontend -emit-ir -o /dev/null -gdwarf-types -disable-reflection-metadata -warnings-as-errors %s
+
+// The debugger still gets its reflection metadata here.
+// RUN: %target-swift-frontend -emit-ir -o /dev/null -g -disable-reflection-metadata -reflection-metadata-for-debugger-only -warnings-as-errors %s
+// RUN: %target-swift-frontend -emit-ir -o /dev/null -g -reflection-metadata-for-debugger-only -warnings-as-errors %s
+
+// Dropping only the reflection names keeps the metadata itself.
+// RUN: %target-swift-frontend -emit-ir -o /dev/null -g -disable-reflection-names -warnings-as-errors %s
+
+// CHECK: warning: debug info is requested with option '-g' but option '-disable-reflection-metadata' will prevent variable inspection in the debugger
+// ERROR: error: debug info is requested with option '-g' but option '-disable-reflection-metadata' will prevent variable inspection in the debugger
+
+// NO-WARNING-NOT: warning
+
+func f() {
+  let x = 42
+  print(x)
+}

--- a/test/embedded/debug-info-reflection-metadata.swift
+++ b/test/embedded/debug-info-reflection-metadata.swift
@@ -1,0 +1,12 @@
+// Embedded Swift promotes -g to -gdwarf-types and describes types in DWARF,
+// so there is no need to warn about disabling reflection metadata.
+
+// RUN: %target-swift-frontend -emit-ir -o /dev/null -g -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none -wmo %s 2>&1 | %FileCheck %s --allow-empty
+// RUN: %target-swift-frontend -emit-ir -o /dev/null -g -disable-reflection-metadata -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none -wmo %s 2>&1 | %FileCheck %s --allow-empty
+
+// REQUIRES: swift_feature_Embedded
+
+// CHECK-NOT: warning
+
+public struct S {}
+public func f(s: S) {}


### PR DESCRIPTION
Combining these two flags is an oxymoron since -g adds variable debug info over -gline-tables-only but stripping reflection metadata makes variables uninspectable. When reflection metadata is not needed/wanted a good solution would be to use embedded Swift instead, which is fully debuggable without reflection metadata.

rdar://184164398

Assisted-by: claude
