### PR TITLE
[build-script] Skip libLTO in sanitizer presets

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -481,6 +481,8 @@ skip-test-xros
 
 enable-asan
 
+extra-llvm-cmake-options=-DLLVM_TOOL_LTO_BUILD=OFF
+
 [preset: buildbot_incremental_tsan,tools=RDA,stdlib=RDA]
 mixin-preset=buildbot_incremental_base_all_platforms
 
@@ -501,6 +503,8 @@ skip-build-watchos
 skip-test-watchos
 skip-build-xros
 skip-test-xros
+
+extra-llvm-cmake-options=-DLLVM_TOOL_LTO_BUILD=OFF
 
 [preset: buildbot_incremental_asan_ubsan,tools=RDA,stdlib=RDA]
 mixin-preset=buildbot_incremental_base_all_platforms
@@ -535,6 +539,8 @@ skip-test-xros
 
 enable-asan
 enable-ubsan
+
+extra-llvm-cmake-options=-DLLVM_TOOL_LTO_BUILD=OFF
 
 [preset: buildbot_incremental,lldb_asan_ubsan]
 mixin-preset=buildbot_incremental_base
@@ -603,6 +609,8 @@ skip-test-xros
 enable-asan
 
 swift-stdlib-build-type=RelWithDebInfo
+
+extra-llvm-cmake-options=-DLLVM_TOOL_LTO_BUILD=OFF
 
 # Don't do bootstrapping to speed up the build
 # TODO: use bootstrapping=hosttools


### PR DESCRIPTION
On macOS, ld dlopens libLTO.dylib eagerly at startup to probe LTO capabilities. When the swift-built libLTO is sanitized, dyld pulls the sanitizer runtime into ld's process, and AMFI's sanitizer-load platform policy on recent macOS versions rejects it, aborting the link. Skip building libLTO in the sanitizer presets so ld falls back to Xcode's unsanitized copy; these presets don't exercise LTO codegen.
