### PR TITLE
[stdlib] fix assertionFailure's implicit return value

### DIFF
--- a/stdlib/public/core/Assert.swift
+++ b/stdlib/public/core/Assert.swift
@@ -12,9 +12,9 @@
 
 /// Performs a traditional C-style assert with an optional message.
 ///
-/// Use this function for internal consistency checks that are active during testing
-/// but do not impact performance of shipping code. To check for invalid usage
-/// in Release builds, see `precondition(_:_:file:line:)`.
+/// Use this function for internal consistency checks that are active during
+/// testing but do not impact performance of shipping code. To check for invalid
+/// usage in Release builds, see `precondition(_:_:file:line:)`.
 ///
 /// * In playgrounds and `-Onone` builds (the default for Xcode's Debug
 ///   configuration): If `condition` evaluates to `false`, stop program

--- a/stdlib/public/core/Assert.swift
+++ b/stdlib/public/core/Assert.swift
@@ -171,8 +171,9 @@ public func assertionFailure(
   file: StaticString = #file, line: UInt = #line
 ) {
   if _isDebugAssertConfiguration() {
-    _assertionFailure(kind: .fatal(), message(), file: file, line: line,
-      flags: _fatalErrorFlags())
+    _opaqueAssertionFailure(
+      kind: .fatal(), message(), file: file, line: line, flags: _fatalErrorFlags()
+    )
   }
   else if _isFastAssertConfiguration() {
     _conditionallyUnreachable()
@@ -186,8 +187,9 @@ public func assertionFailure(
   file: StaticString = #file, line: UInt = #line
 ) {
   if _isDebugAssertConfiguration() {
-    _assertionFailure(kind: .fatal(), message(), file: file, line: line,
-      flags: _fatalErrorFlags())
+    _assertionFailure(
+      kind: .fatal(), message(), file: file, line: line, flags: _fatalErrorFlags()
+    )
   }
   else if _isFastAssertConfiguration() {
     _conditionallyUnreachable()

--- a/stdlib/public/core/AssertCommon.swift
+++ b/stdlib/public/core/AssertCommon.swift
@@ -247,8 +247,9 @@ internal func _assertionFailure(
   flags: UInt32
 ) -> Never {
 #if !$Embedded
-  _assertionFailure(kind._failureMessagePrefix(), message,
-    file: file, line: line, flags: flags)
+  _assertionFailure(
+    kind._failureMessagePrefix(), message, file: file, line: line, flags: flags
+  )
 #else
   if _isDebugAssertConfiguration() {
     var message = message
@@ -258,6 +259,21 @@ internal func _assertionFailure(
   }
   Builtin.int_trap()
 #endif
+}
+
+/// An opaque wrapper around `_assertionFailure`. This function should be used
+/// only in the implementation of user-level assertions.
+///
+/// Conceals the `Never`-returning nature of `_assertionFailure()` from the
+/// mandatory inlining pass.
+@export(implementation)
+@inline(never)
+internal func _opaqueAssertionFailure(
+  kind: Int, _ message: String,
+  file: StaticString, line: UInt,
+  flags: UInt32
+) {
+  _assertionFailure(kind: kind, message, file: file, line: line, flags: flags)
 }
 
 /// This function should be used only in the implementation of user-level

--- a/validation-test/stdlib/AssertConfiguration.swift
+++ b/validation-test/stdlib/AssertConfiguration.swift
@@ -1,0 +1,30 @@
+// RUN: %target-run-stdlib-swift(-O -assert-config Debug)
+// RUN: %target-run-stdlib-swift(-O -assert-config Release)
+// RUN: %target-run-stdlib-swift(-Onone -assert-config Debug)
+// RUN: %target-run-stdlib-swift(-Onone -assert-config Release)
+
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+var suite = TestSuite("issue 85382 tests")
+
+suite.test("reproducer")
+.require(.crashTesting)
+.code {
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  assertionFailure("Should only crash in debug mode.")
+}
+
+suite.test("counter-example")
+.require(.crashTesting)
+.code {
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  assert(false, "Should only crash in debug mode.")
+}
+
+runAllTests()

--- a/validation-test/stdlib/AssertDiagnosticsSIL.swift
+++ b/validation-test/stdlib/AssertDiagnosticsSIL.swift
@@ -1,7 +1,17 @@
-// RUN: %target-swift-frontend %s -emit-sil -verify
+// RUN: %target-swift-frontend -emit-sil -verify -O -assert-config Debug       %s -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -verify -O -assert-config Release     %s -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -verify -Onone -assert-config Debug   %s -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -verify -Onone -assert-config Release %s -o /dev/null
 
 func assertionFailure_isNotNoreturn() -> Int {
   _ = 0 // Don't implicitly return the assertionFailure call.
   assertionFailure("")
 } // expected-error {{missing return in global function expected to return 'Int'}}
 
+func rdar183643880Reproducer(item: String?) {
+  guard let item else {
+    assertionFailure("")
+  } // expected-error {{'guard' body must not fall through}}
+
+  print(".some: \(item)")
+}

--- a/validation-test/stdlib/AssertDiagnosticsSIL.swift
+++ b/validation-test/stdlib/AssertDiagnosticsSIL.swift
@@ -1,10 +1,7 @@
 // RUN: %target-swift-frontend %s -emit-sil -verify
 
-// assertionFailure() is now @_transparent (previously @inlinable), so the
-// compiler can see that it never returns, eliminating the "missing return" error.
-func assertionFailure_isNoreturn() -> Int {
-  _ = 0
+func assertionFailure_isNotNoreturn() -> Int {
+  _ = 0 // Don't implicitly return the assertionFailure call.
   assertionFailure("")
-  // No error expected - assertionFailure() is recognized as Never-returning
-}
+} // expected-error {{missing return in global function expected to return 'Int'}}
 


### PR DESCRIPTION
In https://github.com/swiftlang/swift/pull/85473, an attempt to correct the release-mode behaviour of `assertionFailure()` meant that it now implicitly returning `Never` in debug mode.

This works around the issue by hiding call to the internal `func _assertionFailure() -> Never` inside an opaque helper method that returns an inhabited type (`Void`).

Addresses rdar://183643880, https://github.com/swiftlang/swift/issues/85382, and https://github.com/swiftlang/swift/pull/85473#discussion_r2680097312.