### PR TITLE
IRGen: Adjust to "[Reland][IR] Add initial support for the byte type (#186888)"

### DIFF
--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -130,6 +130,7 @@ static std::unique_ptr<SerializableLLVMType> serializeLLVMTypeImpl(
   case llvm::Type::ScalableVectorTyID:
   case llvm::Type::TypedPointerTyID:
   case llvm::Type::TargetExtTyID:
+  case llvm::Type::ByteTyID:
     llvm::report_fatal_error("unsupported LLVM storage type");
   }
 
@@ -189,6 +190,7 @@ deserializeLLVMTypeImpl(llvm::LLVMContext &ctx,
   case llvm::Type::ScalableVectorTyID:
   case llvm::Type::TypedPointerTyID:
   case llvm::Type::TargetExtTyID:
+  case llvm::Type::ByteTyID:
     llvm::report_fatal_error("unsupported serialized LLVM storage type");
   }
 


### PR DESCRIPTION
Throw the new `llvm::Type::TypeID` case in the "unsupported" bucket.

See https://github.com/llvm/llvm-project/commit/57568c288dbe629a5880584abe9868c4e31fc081 (https://github.com/llvm/llvm-project/pull/186888)