### PR TITLE
[ASTDumper] Avoid kicking `InitKindRequest`

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -9530,6 +9530,10 @@ public:
     return getAttrs().hasAttribute<RequiredAttr>();
   }
 
+  /// Retrieve the initializer kind if it has been computed, \c nullopt
+  /// otherwise. Should only be used by the ASTDumper.
+  std::optional<CtorInitializerKind> getCachedInitKind() const;
+
   /// Determine the kind of initializer this is.
   CtorInitializerKind getInitKind() const;
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2958,7 +2958,10 @@ namespace {
     void visitConstructorDecl(ConstructorDecl *CD, Label label) {
       printCommonAFD(CD, "constructor_decl", label);
       printFlag(CD->isRequired(), "required", DeclModifierColor);
-      printFlag(getDumpString(CD->getInitKind()), DeclModifierColor);
+      if (auto initKind =
+              isTypeChecked() ? CD->getInitKind() : CD->getCachedInitKind()) {
+        printFlag(getDumpString(*initKind), DeclModifierColor);
+      }
       if (CD->isFailable())
         printField((CD->isImplicitlyUnwrappedOptional()
                          ? "ImplicitlyUnwrappedOptional"

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -12430,21 +12430,15 @@ Type ConstructorDecl::getInitializerInterfaceType() {
   return InitializerInterfaceType;
 }
 
-CtorInitializerKind ConstructorDecl::getInitKind() const {
-  const auto *ED =
-      dyn_cast_or_null<ExtensionDecl>(getDeclContext()->getAsDecl());
-  if (ED && !ED->hasBeenBound()) {
-    // When the declaration context is an extension and this is called when the
-    // extended nominal hasn't be bound yet, e.g. dumping pre-typechecked AST,
-    // there is not enough information about extended nominal to use for
-    // computing init kind on InitKindRequest as bindExtensions is done at
-    // typechecking, so in that case just look to parsed attribute in init
-    // declaration.
-    return getAttrs().hasAttribute<ConvenienceAttr>()
-               ? CtorInitializerKind::Convenience
-               : CtorInitializerKind::Designated;
-  }
+std::optional<CtorInitializerKind> ConstructorDecl::getCachedInitKind() const {
+  auto &eval = getASTContext().evaluator;
+  auto *mutableThis = const_cast<ConstructorDecl *>(this);
+  if (!eval.hasCachedResult(InitKindRequest{mutableThis}))
+    return std::nullopt;
+  return getInitKind();
+}
 
+CtorInitializerKind ConstructorDecl::getInitKind() const {
   return evaluateOrDefault(getASTContext().evaluator,
     InitKindRequest{const_cast<ConstructorDecl *>(this)},
     CtorInitializerKind::Designated);

--- a/validation-test/compiler_crashers_fixed/issue-91100.swift
+++ b/validation-test/compiler_crashers_fixed/issue-91100.swift
@@ -1,0 +1,5 @@
+// RUN: not %target-swift-frontend %s -dump-parse
+// https://github.com/swiftlang/swift/issues/91100
+protocol P {
+actor A: P {
+    init() {


### PR DESCRIPTION
Only print the init kind if we have a value cached, or we're dumping a type-checked AST. This supersedes a prior bit of logic that attempted to infer the kind for an unbound extension.

Resolves #91100
rdar://183628209