### PR TITLE
[cxx-interop] Duplicated arguments labels in super-call original method

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4837,7 +4837,7 @@ namespace {
             // SILGen can substitute it for super calls.
             if (result) {
               SmallString<64> staticCallName("__staticCall_");
-              staticCallName += swiftName;
+              staticCallName += funcDecl->getNameStr();
 
               // Rename the original method to make sure it gets a distinct
               // mangled name from the thunk.

--- a/test/Interop/Cxx/foreign-reference/Inputs/super-virtual-dispatch.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/super-virtual-dispatch.h
@@ -96,3 +96,12 @@ struct FRT_IMMORTAL VirtuallyDerived : virtual Base {
     return instance;
   }
 };
+
+struct FRT_IMMORTAL AnotherBase {
+  virtual int virtualMethod(int i) const { return i; }
+  virtual ~AnotherBase() = default;
+};
+
+struct DerivedFromAnotherBase : AnotherBase {
+  int virtualMethod(int i) const override { return i + 1; }
+};

--- a/test/Interop/Cxx/foreign-reference/super-virtual-dispatch-silgen.swift
+++ b/test/Interop/Cxx/foreign-reference/super-virtual-dispatch-silgen.swift
@@ -20,6 +20,12 @@ extension DerivedWithUnrelatedBase {
   }
 }
 
+extension DerivedFromAnotherBase {
+  public func callSuperVirtual(_ n: Int32) -> Int32 {
+    return super.virtualMethod(n)
+  }
+}
+
 // CHECK-LABEL: Derived.callSuperVirtual()
 // CHECK-NOT: super_method
 // CHECK-NOT: objc_super_method
@@ -34,4 +40,12 @@ extension DerivedWithUnrelatedBase {
 // CHECK-NOT: _ZNK18LeafOverNoOverride
 // CHECK-NOT: __synthesizedVirtualCall
 // CHECK: function_ref {{.*}}Base{{.*}}__staticCall_virtualMethod
+// CHECK: end sil function
+
+// CHECK-LABEL: DerivedFromAnotherBase.callSuperVirtual(_:)
+// CHECK-NOT: super_method
+// CHECK-NOT: objc_super_method
+// CHECK-NOT: _ZNK18DerivedFromAnotherBase
+// CHECK-NOT: __synthesizedVirtualCall
+// CHECK-NOT: __staticCall_virtualMethod(_:){{.*}}(_:)
 // CHECK: end sil function


### PR DESCRIPTION
The original method backing `super.virtualMethod()` calls had the argument labels twice in its name, e.g. `__staticCall_virtualMethod(_:)(_:)`.

rdar://184217042

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
