### PR TITLE
[cxx-interop] Consider an FRT with an unsafe base an unsafe type

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8860,16 +8860,12 @@ ExplicitSafety ClangDeclExplicitSafety::evaluate(
     Evaluator &evaluator, ClangDeclExplicitSafetyDescriptor desc) const {
   // FIXME: Also similar to hasPointerInSubobjects
 
-  if (desc.isClass)
-    // Safety for class types is handled a bit differently than other types.
-    // If it is not explicitly marked unsafe, it is always explicitly safe.
-    return hasSwiftAttribute(desc.decl, {"unsafe", "unsafe(always)"})
-               ? ExplicitSafety::Unsafe
-               : ExplicitSafety::Safe;
-
   // Clang record types are considered explicitly unsafe if any of their fields,
-  // base classes, and template type parameters are unsafe. We use a stack for
-  // this recursive traversal.
+  // base classes, and template type parameters are unsafe. Types imported as
+  // classes are treated differently: the lifetime of their storage is managed
+  // automatically and safely by reference counting, so their fields do not make
+  // them unsafe; only annotations on themselves and on their base classes do.
+  // We use a stack for this recursive traversal.
   //
   // Invariant: if any Decl in the stack is unsafe, then desc.decl is unsafe.
   llvm::SmallVector<const clang::Decl *, 4> stack;
@@ -8910,6 +8906,28 @@ ExplicitSafety ClangDeclExplicitSafety::evaluate(
 
     if (hasSwiftAttribute(decl, {"safe"}))
       continue;
+
+    if (desc.isClass) {
+      // Safety for class types is handled a bit differently than other types:
+      // unsafety is inherited from the base classes, but nothing else makes a
+      // class unsafe. Note that the bases of a type imported as a class are
+      // imported as classes as well.
+      auto *cxxRecordDecl = dyn_cast<clang::CXXRecordDecl>(decl);
+      if (!cxxRecordDecl || !cxxRecordDecl->hasDefinition())
+        continue;
+      for (auto base : cxxRecordDecl->getDefinition()->bases()) {
+        // The base may be a `clang::TemplateSpecializationType`, which has no
+        // record decl to check.
+        auto *baseDecl = base.getType()->getAsCXXRecordDecl();
+        if (!baseDecl)
+          continue;
+        if (auto *baseDefinition = baseDecl->getDefinition())
+          baseDecl = baseDefinition;
+        if (seen.insert(baseDecl).second)
+          stack.push_back(baseDecl);
+      }
+      continue;
+    }
 
     // Enums are always safe
     if (isa<clang::EnumDecl>(decl))

--- a/test/Interop/Cxx/class/safe-interop-mode.swift
+++ b/test/Interop/Cxx/class/safe-interop-mode.swift
@@ -132,6 +132,36 @@ inline void releaseSharedObject(SharedObject *) {}
 
 struct DerivedFromSharedObject : SharedObject {};
 
+// Unsafety of a reference type is inherited by the types derived from it, just
+// like for value types.
+struct HasUnsafeReferenceBase : UnsafeReference {};
+struct HasUnsafeReferenceBaseTransitively : HasUnsafeReferenceBase {};
+struct SWIFT_SAFE WrapsUnsafeReferenceBase : UnsafeReference {};
+struct DerivedFromWrapsUnsafeReferenceBase : WrapsUnsafeReferenceBase {};
+
+class SWIFT_UNSAFE ExplicitlyUnsafeSharedObject {
+} SWIFT_SHARED_REFERENCE(retainExplicitlyUnsafeSharedObject,
+                         releaseExplicitlyUnsafeSharedObject);
+
+inline void retainExplicitlyUnsafeSharedObject(ExplicitlyUnsafeSharedObject *) {}
+inline void releaseExplicitlyUnsafeSharedObject(ExplicitlyUnsafeSharedObject *) {}
+
+struct HasExplicitlyUnsafeSharedObjectBase : ExplicitlyUnsafeSharedObject {};
+
+// The base class may be a class template specialization, as in CRTP.
+template <class Derived>
+struct SWIFT_UNSAFE_REFERENCE CRTPBase {};
+
+struct HasCRTPBase : CRTPBase<HasCRTPBase> {};
+struct SWIFT_SAFE WrapsCRTPBase : CRTPBase<WrapsCRTPBase> {};
+
+template <class T> struct DerivedFromParam : T {};
+using HasUnsafeReferenceParamBase = DerivedFromParam<UnsafeReference>;
+
+template <class T> struct MiddleTemplate : CRTPBase<MiddleTemplate<T>> {};
+template <class T> struct BottomTemplate : MiddleTemplate<T> {};
+using HasCRTPBaseTransitively = BottomTemplate<int>;
+
 struct OwnedData {
   SpanOfInt getView() const [[clang::lifetimebound]];
   void takeSharedObject(SharedObject *) const;
@@ -329,6 +359,36 @@ func useSharedReference(frt: SharedObject, x: OwnedData) {
 func useSharedReference(frt: DerivedFromSharedObject, h: HoldsShared) {
   let _ = frt
   let _ = h.getObj()
+}
+
+@available(SwiftStdlib 5.8, *)
+func unsafeReferenceBases(a: HasUnsafeReferenceBase,
+                          b: HasUnsafeReferenceBaseTransitively,
+                          c: WrapsUnsafeReferenceBase,
+                          d: DerivedFromWrapsUnsafeReferenceBase,
+                          e: ExplicitlyUnsafeSharedObject,
+                          f: HasExplicitlyUnsafeSharedObjectBase,
+                          g: HasCRTPBase,
+                          h: WrapsCRTPBase,
+                          i: HasUnsafeReferenceParamBase,
+                          j: HasCRTPBaseTransitively) {
+  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  _ = a // expected-note{{reference to parameter 'a' involves unsafe type}}
+  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  _ = b // expected-note{{reference to parameter 'b' involves unsafe type}}
+  _ = c
+  _ = d
+  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  _ = e // expected-note{{reference to parameter 'e' involves unsafe type}}
+  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  _ = f // expected-note{{reference to parameter 'f' involves unsafe type}}
+  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  _ = g // expected-note{{reference to parameter 'g' involves unsafe type}}
+  _ = h
+  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  _ = i // expected-note{{reference to parameter 'i' involves unsafe type}}
+  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  _ = j // expected-note{{reference to parameter 'j' involves unsafe type}}
 }
 
 func useTTakeInt(x: TTakeInt) {


### PR DESCRIPTION
When a FRT is derived from an unsafe type we should consider it as unsfe and the user needs to explicitly mark it as safe to signal that the unsafety of the base was encapsulated.

rdar://184066972

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
