### PR TITLE
[cxx-interop] Do not crash importing non-escapable FRTs

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -302,6 +302,12 @@ ERROR(foreign_reference_type_unreachable, none,
       "foreign reference type '%0' has unreachable definition",
       (StringRef))
 
+ERROR(nonescapable_foreign_reference_type, none,
+      "%0 cannot be both a foreign reference type and non-escapable; foreign "
+      "reference types are imported as Swift classes, which are always "
+      "escapable",
+      (const clang::NamedDecl *))
+
 GROUPED_WARNING(unannotated_cxx_func_returning_frt, ForeignReferenceType, none,
         "cannot infer ownership of foreign reference value returned by %0",
         (const ValueDecl *))

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2474,14 +2474,25 @@ namespace {
         return nullptr;
       }
 
-      if (frtInfo.isReference())
+      if (frtInfo.isReference()) {
+        // Swift classes are always Escapable.
+        if (evaluateOrDefault(
+                Impl.SwiftContext.evaluator,
+                ClangTypeEscapability({decl->getTypeForDecl(), &Impl}),
+                CxxEscapability::Unknown) == CxxEscapability::NonEscapable) {
+          Impl.diagnose(HeaderLoc(decl->getLocation()),
+                        diag::nonescapable_foreign_reference_type, decl);
+          return nullptr;
+        }
+
         result = Impl.createDeclWithClangNode<ClassDecl>(
             decl, importer::convertClangAccess(decl->getAccess()), loc, name,
             loc, ArrayRef<InheritedEntry>{}, nullptr, dc, false);
-      else
+      } else {
         result = Impl.createDeclWithClangNode<StructDecl>(
             decl, importer::convertClangAccess(decl->getAccess()), loc, name,
             loc, ArrayRef<InheritedEntry>(), nullptr, dc);
+      }
       Impl.ImportedDecls[{decl->getCanonicalDecl(), getVersion()}] = result;
       // We've written a partial entry into ImportedDecls so that nested
       // member imports (especially those that recurse into us via
@@ -7329,6 +7340,11 @@ Decl *SwiftDeclConverter::importGlobalAsInitializer(
 
   auto importedType =
       Impl.importFunctionReturnType(dc, decl, allowNSUIntegerAsInt);
+  if (!importedType) {
+    Impl.addImportDiagnostic(decl, Diagnostic(diag::return_type_not_imported),
+                             decl->getSourceRange().getBegin());
+    return nullptr;
+  }
 
   // Update the failability appropriately based on the imported method type.
   bool failable = false, isIUO = false;

--- a/test/Interop/Cxx/class/nonescapable-errors.swift
+++ b/test/Interop/Cxx/class/nonescapable-errors.swift
@@ -201,6 +201,8 @@ const View* usedToCrash(const View* p) {
     return p;
 }
 
+View* usedToCrashAsInit(const int* p) SWIFT_NAME(View.init(p:));
+
 // expected-note@+1 {{escapable record 'Invalid' cannot have non-escapable field 'v'}}
 struct SWIFT_ESCAPABLE Invalid {
     View v;
@@ -369,6 +371,12 @@ public func importInvalid(_ x: Invalid) {}
 
 // expected-error@+1 {{cannot find type 'Invalid2' in scope}}
 public func importInvalid(_ x: Invalid2) {}
+
+// 'usedToCrashAsInit' returns a pointer to a non-escapable type, which cannot
+// be imported, so no 'init(p:)' is added to 'View'.
+public func droppedInitializer() {
+    _ = View(p: nil) // expected-error {{extraneous argument label 'p:' in call}}
+}
 
 // expected-LIFETIMES-error@+3 {{a function with a ~Escapable result needs a parameter to depend on}}
 // expected-LIFETIMES-note@+2 {{'@_lifetime(immortal)' can be used to indicate that values produced by this initializer have no lifetime dependencies}}

--- a/test/Interop/Cxx/foreign-reference/nonescapable-frt-errors.swift
+++ b/test/Interop/Cxx/foreign-reference/nonescapable-frt-errors.swift
@@ -1,0 +1,138 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -typecheck -verify %t%{fs-sep}direct.swift \
+// RUN:   -I %t%{fs-sep}Inputs \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   -disable-availability-checking \
+// RUN:   -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}direct.h
+
+// RUN: %target-swift-frontend -typecheck -verify %t%{fs-sep}apinotes.swift \
+// RUN:   -I %t%{fs-sep}Inputs \
+// RUN:   -Xcc -iapinotes-modules -Xcc %t%{fs-sep}Inputs \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   -disable-availability-checking \
+// RUN:   -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}apinotes.h
+
+//--- Inputs/module.modulemap
+module Direct {
+    header "direct.h"
+    requires cplusplus
+}
+module APINotes {
+    header "apinotes.h"
+    requires cplusplus
+}
+
+//--- Inputs/direct.h
+#include "swift/bridging"
+
+// expected-error@+1 {{'ImmortalNonEscapable' cannot be both a foreign reference type and non-escapable}}
+struct SWIFT_IMMORTAL_REFERENCE SWIFT_NONESCAPABLE ImmortalNonEscapable {
+  int value;
+};
+
+// A foreign reference type without accessible constructors is diagnosed too.
+// expected-error@+1 {{'ImmortalNonEscapableNoCtor' cannot be both a foreign reference type and non-escapable}}
+struct SWIFT_IMMORTAL_REFERENCE SWIFT_NONESCAPABLE ImmortalNonEscapableNoCtor {
+  int value;
+
+private:
+  ImmortalNonEscapableNoCtor();
+  ~ImmortalNonEscapableNoCtor();
+};
+
+struct SharedNonEscapable;
+void retainShared(SharedNonEscapable *);
+void releaseShared(SharedNonEscapable *);
+
+// expected-error@+2 {{'SharedNonEscapable' cannot be both a foreign reference type and non-escapable}}
+struct SWIFT_SHARED_REFERENCE(retainShared, releaseShared) SWIFT_NONESCAPABLE
+    SharedNonEscapable {
+  int value;
+};
+
+// Non-escapability inherited from a non-escapable foreign reference base.
+// expected-error@+1 {{'DerivedFromNonEscapable' cannot be both a foreign reference type and non-escapable}}
+struct SWIFT_IMMORTAL_REFERENCE DerivedFromNonEscapable
+    : ImmortalNonEscapable {};
+
+// Non-escapability inferred from a non-escapable field.
+struct SWIFT_NONESCAPABLE View {
+  int *pointer;
+};
+
+void retainWithField(class FRTWithNonEscapableField *);
+void releaseWithField(class FRTWithNonEscapableField *);
+
+// expected-error@+1 {{'FRTWithNonEscapableField' cannot be both a foreign reference type and non-escapable}}
+class FRTWithNonEscapableField {
+public:
+  View view;
+} SWIFT_SHARED_REFERENCE(retainWithField, releaseWithField);
+
+// expected-note@+1 {{escapable record 'ComplexFRTWithNonEscapableField' cannot have non-escapable field 'view'}}
+struct SWIFT_IMMORTAL_REFERENCE ComplexFRTWithNonEscapableField {
+  View view;
+  ~ComplexFRTWithNonEscapableField();
+  ComplexFRTWithNonEscapableField(const ComplexFRTWithNonEscapableField &);
+};
+
+// A foreign reference type with no escapability annotation is imported as usual.
+struct SWIFT_IMMORTAL_REFERENCE Immortal {
+  int value;
+};
+
+struct HoldsNonEscapableFRT {
+  // expected-note@+2 {{field 'field' unavailable (cannot import)}}
+  // expected-note@+1 {{pointer to non-escapable type 'ImmortalNonEscapable' cannot be imported}}
+  ImmortalNonEscapable *field;
+};
+
+struct SWIFT_IMMORTAL_REFERENCE ImmortalHoldsNonEscapableFRT {
+  // expected-note@+2 {{field 'field' unavailable (cannot import)}}
+  // expected-note@+1 {{pointer to non-escapable type 'ImmortalNonEscapable' cannot be imported}}
+  ImmortalNonEscapable *field;
+};
+
+//--- Inputs/apinotes.h
+#include "swift/bridging"
+
+// expected-error@+1 {{'AnnotatedViaAPINotes' cannot be both a foreign reference type and non-escapable}}
+struct SWIFT_IMMORTAL_REFERENCE AnnotatedViaAPINotes {
+  int value;
+};
+
+//--- Inputs/APINotes.apinotes
+Name: APINotes
+Tags:
+- Name: AnnotatedViaAPINotes
+  SwiftEscapable: false
+
+//--- direct.swift
+import Direct
+
+// The ill-formed types are not imported at all.
+public func useImmortal(_ x: ImmortalNonEscapable) {} // expected-error {{cannot find type 'ImmortalNonEscapable' in scope}}
+public func useImmortalNoCtor(_ x: ImmortalNonEscapableNoCtor) {} // expected-error {{cannot find type 'ImmortalNonEscapableNoCtor' in scope}}
+public func useShared(_ x: SharedNonEscapable) {} // expected-error {{cannot find type 'SharedNonEscapable' in scope}}
+public func useDerived(_ x: DerivedFromNonEscapable) {} // expected-error {{cannot find type 'DerivedFromNonEscapable' in scope}}
+public func useFRTWithNEField(_ x: FRTWithNonEscapableField) {} // expected-error {{cannot find type 'FRTWithNonEscapableField' in scope}}
+public func useComplexFRTWithNEField(_ x: ComplexFRTWithNonEscapableField) {} // expected-error {{cannot find type 'ComplexFRTWithNonEscapableField' in scope}}
+
+public func useEscapable(_ x: Immortal) -> Int32 { x.value }
+
+// Records with a non-escapable foreign reference field are imported without
+// that field.
+public func useHolder(_ x: HoldsNonEscapableFRT) {
+  _ = x.field // expected-error {{value of type 'HoldsNonEscapableFRT' has no member 'field'}}
+}
+
+public func useImmortalHolder(_ x: ImmortalHoldsNonEscapableFRT) {
+  _ = x.field // expected-error {{value of type 'ImmortalHoldsNonEscapableFRT' has no member 'field'}}
+}
+
+//--- apinotes.swift
+import APINotes
+
+public func useAnnotated(_ x: AnnotatedViaAPINotes) {} // expected-error {{cannot find type 'AnnotatedViaAPINotes' in scope}}


### PR DESCRIPTION
These cannot be represented in Swift, diagnose them instead of crashing.

rdar://184129478
rdar://183686936

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
