### PR TITLE
[cxx-interop] Add timeout to a compiler crasher test

### DIFF
--- a/validation-test/compiler_crashers/CxxInterop/substOpaqueTypesWithUnderlyingTypes-3e9bbd.swift
+++ b/validation-test/compiler_crashers/CxxInterop/substOpaqueTypesWithUnderlyingTypes-3e9bbd.swift
@@ -1,4 +1,7 @@
-// {"extraArgs":["-experimental-allow-module-with-compiler-errors","-cxx-interoperability-mode=default","-emit-clang-header-min-access","internal","-emit-clang-header-path","/dev/null"],"kind":"typecheck","original":"d14aa7cb","signature":"substOpaqueTypesWithUnderlyingTypes"}
+// {"extraArgs":["-experimental-allow-module-with-compiler-errors","-cxx-interoperability-mode=default","-emit-clang-header-min-access","internal","-emit-clang-header-path","/dev/null"],"kind":"typecheck","original":"d14aa7cb","signature":"substOpaqueTypesWithUnderlyingTypes","stackOverflow":true}
+// This test crashes by overflowing the stack, set a suitable timeout to ensure it doesn't take too long.
+// RUN: not %{python} %swift_src_root/test/Inputs/timeout.py 60 \
+// RUN:             %target-swift-frontend -typecheck -experimental-allow-module-with-compiler-errors -cxx-interoperability-mode=default -emit-clang-header-min-access internal -emit-clang-header-path /dev/null %s || \
 // RUN: not --crash %target-swift-frontend -typecheck -experimental-allow-module-with-compiler-errors -cxx-interoperability-mode=default -emit-clang-header-min-access internal -emit-clang-header-path /dev/null %s
 protocol a
   func b -> some a {


### PR DESCRIPTION
This test is taking too long to fail on some CI machines, let's add a timeout to it.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
