### PR TITLE
[26.04] mark InFlightSubstitution-lookupConformance-577ddb.swift unsupported on 26.04

### DIFF
--- a/validation-test/compiler_crashers/CxxInterop/InFlightSubstitution-lookupConformance-577ddb.swift
+++ b/validation-test/compiler_crashers/CxxInterop/InFlightSubstitution-lookupConformance-577ddb.swift
@@ -1,5 +1,8 @@
 // {"extraArgs":["-experimental-allow-module-with-compiler-errors","-cxx-interoperability-mode=default","-emit-clang-header-min-access","internal","-emit-clang-header-path","/dev/null"],"kind":"typecheck","original":"001bd4a5","signature":"swift::InFlightSubstitution::lookupConformance(swift::Type, swift::ProtocolDecl*, unsigned int)","stackOverflow":true}
 // This test crashes by overflowing the stack, set a suitable timeout to ensure it doesn't take too long.
+//
+// UNSUPPORTED: LinuxDistribution=ubuntu-26.04
+//
 // RUN: not %{python} %swift_src_root/test/Inputs/timeout.py 60 \
 // RUN:             %target-swift-frontend -typecheck -experimental-allow-module-with-compiler-errors -cxx-interoperability-mode=default -emit-clang-header-min-access internal -emit-clang-header-path /dev/null %s || \
 // RUN: not --crash %target-swift-frontend -typecheck -experimental-allow-module-with-compiler-errors -cxx-interoperability-mode=default -emit-clang-header-min-access internal -emit-clang-header-path /dev/null %s


### PR DESCRIPTION
I think the python harness isn't killing all he child process spawned when a stack is overflowing. For now mark as unsupported on 26.04 to prevent hanging
