### PR TITLE
[cxx-interop] Do not crash when passing temporary tuple as a const ref C++ parameter

### DIFF
--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -503,6 +503,10 @@ const clang::Type *getClangFunctionParameterType(const clang::Type *ty,
 static
 const clang::Type *getClangArrayElementType(const clang::Type *ty,
                                             unsigned index) {
+  // A fixed-size array can be imported as a tuple either directly or through
+  // a C++ reference to it. In the latter case strip the reference.
+  if (ty->isReferenceType())
+    ty = ty->getPointeeType().getTypePtr();
   return ty->castAsArrayTypeUnsafe()->getElementType().getTypePtr();
 }
 
@@ -1546,6 +1550,11 @@ unsigned AbstractionPattern::getLoweredParamIndex(unsigned formalIndex) const {
 }
 
 unsigned AbstractionPattern::getFlattenedValueCount() const {
+  // A C++ reference to an array that is imported as a tuple is passed as a
+  // single indirect value, not exploded into its elements.
+  if (isClangType() && getClangType()->isReferenceType())
+    return 1;
+
   // The count is always 1 unless the original type is a tuple.
   if (!isTuple())
     return 1;

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2168,9 +2168,16 @@ private:
     }
 
     // Tuples get expanded unless they're inout.
-    if (origType.isTuple() && ownership != ValueOwnership::InOut) {
-      expandTuple(ownership, formalParamIndex,
-                  forSelf, origType, substType, origFlags);
+    //
+    // However, a C++ reference to an aggregate imported as a tuple is
+    // passed as a single indirect value rather than exploded into its
+    // elements, so fall through to the indirect handling below.
+    bool isClangReference =
+        origType.isClangType() && origType.getClangType()->isReferenceType();
+    if (origType.isTuple() && ownership != ValueOwnership::InOut &&
+        !isClangReference) {
+      expandTuple(ownership, formalParamIndex, forSelf, origType, substType,
+                  origFlags);
       return;
     }
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3917,7 +3917,12 @@ private:
     if (!arg.hasLValueType()) {
       // If the unsubstituted function type has a parameter of tuple type,
       // explode the tuple value.
-      if (origParamType.isTuple()) {
+      //
+      // However, a C++ reference to an aggregate imported as a tuple is passed
+      // as a single indirect value rather than exploded into its elements.
+      bool isClangReference = origParamType.isClangType() &&
+                              origParamType.getClangType()->isReferenceType();
+      if (origParamType.isTuple() && !isClangReference) {
         emitExpanded(std::move(arg), origParamType);
         return;
       }

--- a/test/Interop/Cxx/reference/Inputs/reference.h
+++ b/test/Interop/Cxx/reference/Inputs/reference.h
@@ -47,4 +47,20 @@ const T &constRefToTemplate(const T &t) { return t; }
 template<class T>
 void refToDependentParam(ClassTemplate<T> &param) { }
 
+inline unsigned sumArrayRef4(const unsigned char (&a)[4]) {
+  return a[0] + a[1] + a[2] + a[3];
+}
+
+inline unsigned sumArrayRValueRef4(unsigned char (&&a)[4]) {
+  return a[0] + a[1] + a[2] + a[3];
+}
+
+// A typedef of a typedef of an array, mirroring the shape of Darwin's uuid_t.
+typedef unsigned char ByteArray16[16];
+typedef ByteArray16 ByteArray16Typealias;
+
+inline unsigned firstByteOfArrayRefTypealias(const ByteArray16Typealias &a) {
+  return a[0];
+}
+
 #endif // TEST_INTEROP_CXX_REFERENCE_INPUTS_REFERENCE_H

--- a/test/Interop/Cxx/reference/Inputs/reference.h
+++ b/test/Interop/Cxx/reference/Inputs/reference.h
@@ -47,4 +47,16 @@ const T &constRefToTemplate(const T &t) { return t; }
 template<class T>
 void refToDependentParam(ClassTemplate<T> &param) { }
 
+inline unsigned sumArrayRef4(const unsigned char (&a)[4]) {
+  return a[0] + a[1] + a[2] + a[3];
+}
+
+// A typedef of a typedef of an array, mirroring the shape of Darwin's uuid_t.
+typedef unsigned char ByteArray16[16];
+typedef ByteArray16 ByteArray16Typealias;
+
+inline unsigned firstByteOfArrayRefTypealias(const ByteArray16Typealias &a) {
+  return a[0];
+}
+
 #endif // TEST_INTEROP_CXX_REFERENCE_INPUTS_REFERENCE_H

--- a/test/Interop/Cxx/reference/reference.swift
+++ b/test/Interop/Cxx/reference/reference.swift
@@ -12,6 +12,8 @@ import StdlibUnittest
 
 var ReferenceTestSuite = TestSuite("Reference")
 
+func makeTuple() -> (UInt8, UInt8, UInt8, UInt8) { (10, 20, 30, 40) }
+
 ReferenceTestSuite.test("read-lvalue-reference") {
   expectNotEqual(13, getStaticInt())
   setStaticInt(13)
@@ -107,6 +109,28 @@ ReferenceTestSuite.test("const reference to template") {
 ReferenceTestSuite.test("rvalue reference of trivial type") {
   setStaticIntRvalueRef(consuming: 2)
   expectEqual(2, getStaticInt())
+}
+
+ReferenceTestSuite.test("const reference to array") {
+  let tuple: (UInt8, UInt8, UInt8, UInt8) = (10, 20, 30, 40)
+  expectEqual(100, sumArrayRef4(tuple))
+}
+
+ReferenceTestSuite.test("const reference to array temporary") {
+  expectEqual(100, sumArrayRef4((10, 20, 30, 40)))
+  expectEqual(100, sumArrayRef4(makeTuple()))
+}
+
+ReferenceTestSuite.test("rvalue reference to array") {
+  let tuple: (UInt8, UInt8, UInt8, UInt8) = (10, 20, 30, 40)
+  expectEqual(100, sumArrayRValueRef4(consuming: tuple))
+  expectEqual(100, sumArrayRValueRef4(consuming: (10, 20, 30, 40)))
+}
+
+ReferenceTestSuite.test("const reference to array typealias") {
+  let bytes: ByteArray16Typealias = (7, 0, 0, 0, 0, 0, 0, 0,
+                                     0, 0, 0, 0, 0, 0, 0, 0)
+  expectEqual(7, firstByteOfArrayRefTypealias(bytes))
 }
 
 runAllTests()

--- a/test/Interop/Cxx/reference/reference.swift
+++ b/test/Interop/Cxx/reference/reference.swift
@@ -109,4 +109,15 @@ ReferenceTestSuite.test("rvalue reference of trivial type") {
   expectEqual(2, getStaticInt())
 }
 
+ReferenceTestSuite.test("const reference to array") {
+  let tuple: (UInt8, UInt8, UInt8, UInt8) = (10, 20, 30, 40)
+  expectEqual(100, sumArrayRef4(tuple))
+}
+
+ReferenceTestSuite.test("const reference to array typealias") {
+  let bytes: ByteArray16Typealias = (7, 0, 0, 0, 0, 0, 0, 0,
+                                     0, 0, 0, 0, 0, 0, 0, 0)
+  expectEqual(7, firstByteOfArrayRefTypealias(bytes))
+}
+
 runAllTests()


### PR DESCRIPTION
When passing a Swift tuple to a C++ function as a const reference parameter, make sure it is passed as a single indirect value, not exploded into its elements.

rdar://183743808

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
