### PR TITLE
[6.4.x] AST: Weak link Span symbols for deployment targets < anyAppleOS 26

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -208,6 +208,12 @@ namespace swift {
     /// declarations introduced at the deployment target.
     bool WeakLinkAtTarget = false;
 
+    /// Causes the compiler to use weak linkage for symbols belonging to
+    /// declarations that are back deployed by the Span compatibility library
+    /// when the deployment target predates the OS release that introduced
+    /// those declarations.
+    bool WeakLinkSpanCompatibilityLib = false;
+
     /// Should the editor placeholder error be downgraded to a warning?
     bool WarnOnEditorPlaceholder = false;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1877,6 +1877,14 @@ def enable_autolinking_runtime_compatibility_bytecode_layouts
       HelpText<"Enable autolinking for the bytecode layouts runtime "
                "compatibility library">;
 
+def weak_link_span_compatibility_lib
+    : Flag<[ "-" ], "weak-link-span-compatibility-lib">,
+      Flags<[ FrontendOption ]>,
+      HelpText<"Weakly link the symbols that are back deployed by the Span "
+               "compatibility library instead of strongly linking them, when "
+               "the deployment target predates the OS release that introduced "
+               "them">;
+
 def emit_symbol_graph: Flag<["-"], "emit-symbol-graph">,
   Flags<[FrontendOption, NoInteractiveOption, SupplementaryOutput, HelpHidden]>,
   HelpText<"Emit a symbol graph">;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1484,25 +1484,54 @@ LifetimeAnnotation Decl::getLifetimeAnnotation() const {
   return getLifetimeAnnotationFromAttributes();
 }
 
-AvailabilityRange Decl::getAvailabilityForLinkage() const {
-  ASTContext &ctx = getASTContext();
+/// Returns the lower bound for linkage availability of \p decl since it may be
+/// different than the decl's annotated availability in some rare circumstances.
+static std::optional<AvailabilityRange>
+minimumAvailabilityForLinkage(const Decl *decl) {
+  ASTContext &ctx = decl->getASTContext();
 
+  if (ctx.LangOpts.hasFeature(Feature::Embedded))
+    return std::nullopt;
+
+  // If this entity comes from the concurrency module, adjust its availability
+  // for linkage purposes up to Swift 5.5, so that we use weak references any
+  // time we reference those symbols when back-deploying concurrency.
+  if (decl->getModuleContext()->isConcurrencyModule())
+    return ctx.getConcurrencyAvailability();
+
+  if (!decl->getModuleContext()->isStdlibModule())
+    return std::nullopt;
+
+  // If the decl belongs to the Span back deployment compatibility library and
+  // weak linkage of that library's symbols was requested, adjust the
+  // availability for linkage to Swift 6.2 to force weak linkage for any
+  // deployment target prior to the introduction of these symbols in the
+  // operating system.
+  if (ctx.LangOpts.WeakLinkSpanCompatibilityLib) {
+    for (auto *attr :
+         decl->getAttrs().getAttributes<OriginallyDefinedInAttr>()) {
+      auto activePlatform = attr->isActivePlatform(ctx);
+      if (activePlatform &&
+          activePlatform->LinkerModuleName == "CompatibilitySpan")
+        return AvailabilityRange{activePlatform->Version};
+    }
+  }
+
+  return std::nullopt;
+}
+
+AvailabilityRange Decl::getAvailabilityForLinkage() const {
   // When computing availability for linkage, use the "before" version from
   // the @backDeployed attribute, if present.
   if (auto backDeployedAttrAndRange = getBackDeployedAttrAndRange())
     return backDeployedAttrAndRange->second;
 
-  auto containingContext = AvailabilityInference::annotatedAvailableRange(this);
-  if (containingContext.has_value()) {
-    // If this entity comes from the concurrency module, adjust its
-    // availability for linkage purposes up to Swift 5.5, so that we use
-    // weak references any time we reference those symbols when back-deploying
-    // concurrency.
-    if (getModuleContext()->getName() == ctx.Id_Concurrency) {
-      containingContext->intersectWith(ctx.getConcurrencyAvailability());
-    }
+  auto annotatedRange = AvailabilityInference::annotatedAvailableRange(this);
+  if (annotatedRange.has_value()) {
+    if (auto minRange = minimumAvailabilityForLinkage(this))
+      annotatedRange->intersectWith(*minRange);
 
-    return *containingContext;
+    return *annotatedRange;
   }
 
   // FIXME: Adopt Decl::parentDeclForAvailability()

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -308,6 +308,8 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_require_explicit_availability_EQ);
   inputArgs.AddLastArg(arguments, options::OPT_require_explicit_sendable);
   inputArgs.AddLastArg(arguments, options::OPT_check_api_availability_only);
+  inputArgs.AddLastArg(arguments,
+                       options::OPT_weak_link_span_compatibility_lib);
   inputArgs.AddLastArg(arguments, options::OPT_enable_testing);
   inputArgs.AddLastArg(arguments, options::OPT_enable_private_imports);
   inputArgs.AddLastArg(arguments, options::OPT_g_Group);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1204,6 +1204,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   Opts.WeakLinkAtTarget |= Args.hasArg(OPT_weak_link_at_target);
 
+  Opts.WeakLinkSpanCompatibilityLib |=
+      Args.hasArg(OPT_weak_link_span_compatibility_lib);
+
   Opts.WarnOnEditorPlaceholder |= Args.hasArg(OPT_warn_on_editor_placeholder);
 
   auto setUnsignedIntegerArgument =

--- a/test/IRGen/backward_deploy_span.swift
+++ b/test/IRGen/backward_deploy_span.swift
@@ -1,14 +1,120 @@
-// RUN: %target-swift-frontend -target %target-cpu-apple-macos12 -emit-ir -o - -primary-file %s | %FileCheck %s
-// REQUIRES: OS=macosx
+// The symbols of the types that are back deployed by the Span compatibility
+// library are strongly linked by default (CHECK-STRONG). They are weakly linked
+// (CHECK-WEAK) when -weak-link-span-compatibility-lib is specified and the
+// deployment target predates the OS releases that introduced those types.
+//
+// Deployment targets with a runtime that cannot demangle these types must
+// access their metadata with accessor calls (CHECK-ACCESSOR), while newer
+// runtimes instantiate metadata from mangled names (CHECK-DEMANGLE).
 
-func useGenericMetatype(_ type: any ~Escapable.Type) { }
+// RUN: %target-swift-frontend -target %target-swift-5.5-abi-triple -emit-ir -o - -primary-file %s | %FileCheck %s --check-prefixes=CHECK,CHECK-ACCESSOR,CHECK-STRONG,CHECK-ACCESSOR-STRONG
+// RUN: %target-swift-frontend -target %target-swift-5.5-abi-triple -weak-link-span-compatibility-lib -emit-ir -o - -primary-file %s | %FileCheck %s --check-prefixes=CHECK,CHECK-ACCESSOR,CHECK-WEAK,CHECK-ACCESSOR-WEAK
+// RUN: %target-swift-frontend -target %target-swift-6.1-abi-triple -emit-ir -o - -primary-file %s | %FileCheck %s --check-prefixes=CHECK,CHECK-DEMANGLE,CHECK-STRONG,CHECK-DEMANGLE-STRONG
+// RUN: %target-swift-frontend -target %target-swift-6.1-abi-triple -weak-link-span-compatibility-lib -emit-ir -o - -primary-file %s | %FileCheck %s --check-prefixes=CHECK,CHECK-DEMANGLE,CHECK-WEAK,CHECK-DEMANGLE-WEAK
+// RUN: %target-swift-frontend -target %target-swift-6.2-abi-triple -emit-ir -o - -primary-file %s | %FileCheck %s --check-prefixes=CHECK,CHECK-DEMANGLE,CHECK-STRONG,CHECK-DEMANGLE-STRONG
+// RUN: %target-swift-frontend -target %target-swift-6.2-abi-triple -weak-link-span-compatibility-lib -emit-ir -o - -primary-file %s | %FileCheck %s --check-prefixes=CHECK,CHECK-DEMANGLE,CHECK-STRONG,CHECK-DEMANGLE-STRONG
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos
+
+// CHECK-WEAK-DAG: @"$ss7RawSpanVN" = extern_weak global
+// CHECK-WEAK-DAG: @"$ss14MutableRawSpanVN" = extern_weak global
+// CHECK-WEAK-DAG: @"$ss13OutputRawSpanVN" = extern_weak global
+// CHECK-STRONG-DAG: @"$ss7RawSpanVN" = external global
+// CHECK-STRONG-DAG: @"$ss14MutableRawSpanVN" = external global
+// CHECK-STRONG-DAG: @"$ss13OutputRawSpanVN" = external global
+
+// CHECK-DEMANGLE-WEAK-DAG: @"$ss4SpanVMn" = extern_weak global
+// CHECK-DEMANGLE-WEAK-DAG: @"$ss11MutableSpanVMn" = extern_weak global
+// CHECK-DEMANGLE-WEAK-DAG: @"$ss10OutputSpanVMn" = extern_weak global
+// CHECK-DEMANGLE-STRONG-DAG: @"$ss4SpanVMn" = external global
+// CHECK-DEMANGLE-STRONG-DAG: @"$ss11MutableSpanVMn" = external global
+// CHECK-DEMANGLE-STRONG-DAG: @"$ss10OutputSpanVMn" = external global
+
+func useGenericMetatype(_: any (~Copyable & ~Escapable).Type) { }
 
 // CHECK-LABEL: define hidden swiftcc void @"$s20backward_deploy_span11testSpanIntyyF"()
 func testSpanInt() {
-  // CHECK: call swiftcc %swift.metadata_response @"$ss4SpanVySiGMa"
-  // CHECK: call swiftcc void @"$s20backward_deploy_span18useGenericMetatypeyyypRi0_s_XPXpF"
+  // CHECK-ACCESSOR: call swiftcc %swift.metadata_response @"$ss4SpanVySiGMa"
+  // CHECK-DEMANGLE: call ptr @__swift_instantiateConcreteTypeFromMangledName(ptr @"$ss4SpanVySiGMD")
+  // CHECK: call swiftcc void @"$s20backward_deploy_span18useGenericMetatypeyyypRi_s_Ri0_sXPXpF"
   useGenericMetatype(Span<Int>.self)
 }
 
-// CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$ss4SpanVySiGMa"
-// CHECK: call swiftcc %swift.metadata_response @"$ss4SpanVMa"({{i32|i64}} %0, ptr @"$sSiN")
+// CHECK-ACCESSOR-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$ss4SpanVySiGMa"
+// CHECK-ACCESSOR: call swiftcc %swift.metadata_response @"$ss4SpanVMa"({{i32|i64}} %0, ptr @"$sSiN")
+// CHECK-ACCESSOR-WEAK: declare extern_weak swiftcc %swift.metadata_response @"$ss4SpanVMa"
+// CHECK-ACCESSOR-STRONG: declare swiftcc %swift.metadata_response @"$ss4SpanVMa"
+
+// CHECK-LABEL: define hidden swiftcc void @"$s20backward_deploy_span18testMutableSpanIntyyF"()
+func testMutableSpanInt() {
+  // CHECK-ACCESSOR: call swiftcc %swift.metadata_response @"$ss11MutableSpanVySiGMa"
+  // CHECK-DEMANGLE: call ptr @__swift_instantiateConcreteTypeFromMangledName(ptr @"$ss11MutableSpanVySiGMD")
+  // CHECK: call swiftcc void @"$s20backward_deploy_span18useGenericMetatypeyyypRi_s_Ri0_sXPXpF"
+  useGenericMetatype(MutableSpan<Int>.self)
+}
+
+// CHECK-ACCESSOR-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$ss11MutableSpanVySiGMa"
+// CHECK-ACCESSOR: call swiftcc %swift.metadata_response @"$ss11MutableSpanVMa"({{i32|i64}} %0, ptr @"$sSiN")
+// CHECK-ACCESSOR-WEAK: declare extern_weak swiftcc %swift.metadata_response @"$ss11MutableSpanVMa"
+// CHECK-ACCESSOR-STRONG: declare swiftcc %swift.metadata_response @"$ss11MutableSpanVMa"
+
+// CHECK-LABEL: define hidden swiftcc void @"$s20backward_deploy_span17testOutputSpanIntyyF"()
+func testOutputSpanInt() {
+  // CHECK-ACCESSOR: call swiftcc %swift.metadata_response @"$ss10OutputSpanVySiGMa"
+  // CHECK-DEMANGLE: call ptr @__swift_instantiateConcreteTypeFromMangledName(ptr @"$ss10OutputSpanVySiGMD")
+  // CHECK: call swiftcc void @"$s20backward_deploy_span18useGenericMetatypeyyypRi_s_Ri0_sXPXpF"
+  useGenericMetatype(OutputSpan<Int>.self)
+}
+
+// CHECK-ACCESSOR-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$ss10OutputSpanVySiGMa"
+// CHECK-ACCESSOR: call swiftcc %swift.metadata_response @"$ss10OutputSpanVMa"({{i32|i64}} %0, ptr @"$sSiN")
+// CHECK-ACCESSOR-WEAK: declare extern_weak swiftcc %swift.metadata_response @"$ss10OutputSpanVMa"
+// CHECK-ACCESSOR-STRONG: declare swiftcc %swift.metadata_response @"$ss10OutputSpanVMa"
+
+// CHECK-LABEL: define hidden swiftcc void @"$s20backward_deploy_span15testSpanGenericyyxmlF"(
+func testSpanGeneric<T>(_: T.Type) {
+  // CHECK: call swiftcc %swift.metadata_response @"$ss4SpanVMa"({{i32|i64}} 0, ptr %T)
+  // CHECK: call swiftcc void @"$s20backward_deploy_span18useGenericMetatypeyyypRi_s_Ri0_sXPXpF"
+  useGenericMetatype(Span<T>.self)
+}
+
+// CHECK-DEMANGLE-WEAK: declare extern_weak swiftcc %swift.metadata_response @"$ss4SpanVMa"
+// CHECK-DEMANGLE-STRONG: declare swiftcc %swift.metadata_response @"$ss4SpanVMa"
+
+// CHECK-LABEL: define hidden swiftcc void @"$s20backward_deploy_span22testMutableSpanGenericyyxmlF"(
+func testMutableSpanGeneric<T>(_: T.Type) {
+  // CHECK: call swiftcc %swift.metadata_response @"$ss11MutableSpanVMa"({{i32|i64}} 0, ptr %T)
+  // CHECK: call swiftcc void @"$s20backward_deploy_span18useGenericMetatypeyyypRi_s_Ri0_sXPXpF"
+  useGenericMetatype(MutableSpan<T>.self)
+}
+
+// CHECK-DEMANGLE-WEAK: declare extern_weak swiftcc %swift.metadata_response @"$ss11MutableSpanVMa"
+// CHECK-DEMANGLE-STRONG: declare swiftcc %swift.metadata_response @"$ss11MutableSpanVMa"
+
+// CHECK-LABEL: define hidden swiftcc void @"$s20backward_deploy_span21testOutputSpanGenericyyxmlF"(
+func testOutputSpanGeneric<T>(_: T.Type) {
+  // CHECK: call swiftcc %swift.metadata_response @"$ss10OutputSpanVMa"({{i32|i64}} 0, ptr %T)
+  // CHECK: call swiftcc void @"$s20backward_deploy_span18useGenericMetatypeyyypRi_s_Ri0_sXPXpF"
+  useGenericMetatype(OutputSpan<T>.self)
+}
+
+// CHECK-DEMANGLE-WEAK: declare extern_weak swiftcc %swift.metadata_response @"$ss10OutputSpanVMa"
+// CHECK-DEMANGLE-STRONG: declare swiftcc %swift.metadata_response @"$ss10OutputSpanVMa"
+
+// CHECK-LABEL: define hidden swiftcc void @"$s20backward_deploy_span11testRawSpanyyF"()
+func testRawSpan() {
+  // CHECK: call swiftcc void @"$s20backward_deploy_span18useGenericMetatypeyyypRi_s_Ri0_sXPXpF"(ptr @"$ss7RawSpanVN")
+  useGenericMetatype(RawSpan.self)
+}
+
+// CHECK-LABEL: define hidden swiftcc void @"$s20backward_deploy_span18testMutableRawSpanyyF"()
+func testMutableRawSpan() {
+  // CHECK: call swiftcc void @"$s20backward_deploy_span18useGenericMetatypeyyypRi_s_Ri0_sXPXpF"(ptr @"$ss14MutableRawSpanVN")
+  useGenericMetatype(MutableRawSpan.self)
+}
+
+// CHECK-LABEL: define hidden swiftcc void @"$s20backward_deploy_span17testOutputRawSpanyyF"()
+func testOutputRawSpan() {
+  // CHECK: call swiftcc void @"$s20backward_deploy_span18useGenericMetatypeyyypRi_s_Ri0_sXPXpF"(ptr @"$ss13OutputRawSpanVN")
+  useGenericMetatype(OutputRawSpan.self)
+}


### PR DESCRIPTION
- **Explanation:** Weak link `Span` symbols on all deployment targets earlier than anyAppleOS 26 when the `-weak-link-span-compatibility-lib` flag is specified. The benefit of this change is that it fixes an emergent regression relative to Swift 6.3. Without this change, it is no longer possible to build a back deployed executable that takes care to only use `Span` on macOS 26 and later without also distributing the `Span` compatibility library with the executable. This regressions emerged because SwiftPM raised the implicit deployment target for macOS from 10.13 to 12, crossing a threshold that now causes the Span symbols to be strongly linked unconditionally based on their annotated availability of macOS 10.14.4.
- **Scope:** Changes the linkage of `Span`, `MutableSpan`, and `OutputSpan` type metadata symbols when compiling with deployment targets earlier than anyAppleOS 26.
- **Issue/Radar:** rdar://183779335
- **Original PR:** https://github.com/swiftlang/swift/pull/91273
- **Risk:** Low. The new behavior is opt-in using a new frontend flag so it should not affect any existing projects.
- **Testing:** Expanded compiler tests.
- **Reviewer:** @DougGregor 
