### PR TITLE
[RemoteInspection] Validate a reflection record's self-reported element stride.

### DIFF
--- a/include/swift/RemoteInspection/TypeRefBuilder.h
+++ b/include/swift/RemoteInspection/TypeRefBuilder.h
@@ -119,13 +119,22 @@ public:
         return;
       }
       auto NextSize = Self::getCurrentRecordSize(NextRecord);
-      if (NextSize > Size) {
+      if (!NextSize) {
+        std::cerr << "!!! Reflection record has an invalid record stride\n"
+                  << std::endl;
+        std::cerr << "Section Type: " << Name << std::endl;
+        // Set this iterator equal to the end. This section is effectively
+        // empty.
+        this->Size = 0;
+        return;
+      }
+      if (*NextSize > Size) {
         std::cerr
             << "!!! Reflection section too small to contain first record\n"
             << std::endl;
         std::cerr << "Section Type: " << Name << std::endl;
         std::cerr << "Section size: " << Size
-                  << ", size of first record: " << NextSize << std::endl;
+                  << ", size of first record: " << *NextSize << std::endl;
         // Set this iterator equal to the end. This section is effectively
         // empty.
         this->Size = 0;
@@ -142,8 +151,19 @@ public:
   Self &operator++() {
     auto CurRecord = this->operator*();
     auto CurSize = Self::getCurrentRecordSize(CurRecord);
-    Cur = Cur.atByteOffset(CurSize);
-    Size -= CurSize;
+    if (!CurSize || *CurSize > Size) {
+      // Every record is validated before it becomes the current one, so this
+      // should not happen. Check anyway: advancing by an unvalidated size would
+      // move Cur outside the section and underflow Size.
+      assert(false && "iterating an unvalidated reflection record size");
+      std::cerr << "!!! Reflection record has an invalid record stride\n"
+                << std::endl;
+      std::cerr << "Section Type: " << Name << std::endl;
+      Size = 0;
+      return asImpl();
+    }
+    Cur = Cur.atByteOffset(*CurSize);
+    Size -= *CurSize;
 
     if (Size > 0) {
       if (Size < Self::getMinimumRecordSize()) {
@@ -154,7 +174,16 @@ public:
       }
       auto NextRecord = this->operator*();
       auto NextSize = Self::getCurrentRecordSize(NextRecord);
-      if (NextSize > Size) {
+      if (!NextSize) {
+        std::cerr << "!!! Reflection record has an invalid record stride\n"
+                  << std::endl;
+        std::cerr << "Section Type: " << Name << std::endl;
+        std::cerr << "Offset in section: " << (OriginalSize - Size)
+                  << std::endl;
+        Size = 0;
+        return asImpl();
+      }
+      if (*NextSize > Size) {
         int offset = (int)(OriginalSize - Size);
         std::cerr << "!!! Reflection section too small to contain next record\n"
                   << std::endl;
@@ -162,7 +191,7 @@ public:
         std::cerr << "Remaining section size: " << Size
                   << ", total section size: " << OriginalSize
                   << ", offset in section: " << offset
-                  << ", size of next record: " << NextSize << std::endl;
+                  << ", size of next record: " << *NextSize << std::endl;
         const uint8_t *p =
             reinterpret_cast<const uint8_t *>(Cur.getLocalBuffer());
         std::cerr << "Last bytes of previous record: ";
@@ -207,8 +236,14 @@ public:
   FieldDescriptorIterator(RemoteRef<void> Cur, uint64_t Size)
       : ReflectionSectionIteratorBase(Cur, Size, "FieldDescriptor") {}
 
-  static uint64_t getCurrentRecordSize(RemoteRef<FieldDescriptor> FR) {
-    return sizeof(FieldDescriptor) + FR->NumFields * FR->FieldRecordSize;
+  static std::optional<uint64_t>
+  getCurrentRecordSize(RemoteRef<FieldDescriptor> FR) {
+    // We only ever emit FieldRecordSize equal to sizeof(FieldRecord). If it's
+    // anything else, consider it to be bad data and ignore it.
+    if (FR->FieldRecordSize != sizeof(FieldRecord))
+      return std::nullopt;
+    return sizeof(FieldDescriptor) +
+           (uint64_t)FR->NumFields * (uint64_t)FR->FieldRecordSize;
   }
 };
 using FieldSection = ReflectionSection<FieldDescriptorIterator>;
@@ -220,10 +255,16 @@ public:
   AssociatedTypeIterator(RemoteRef<void> Cur, uint64_t Size)
       : ReflectionSectionIteratorBase(Cur, Size, "AssociatedType") {}
 
-  static uint64_t
+  static std::optional<uint64_t>
   getCurrentRecordSize(RemoteRef<AssociatedTypeDescriptor> ATR) {
+    // We only ever emit AssociatedTypeRecordSize equal to
+    // sizeof(AssociatedTypeRecord). If it's anything else, consider it to be
+    // bad data and ignore it.
+    if (ATR->AssociatedTypeRecordSize != sizeof(AssociatedTypeRecord))
+      return std::nullopt;
     return sizeof(AssociatedTypeDescriptor) +
-           ATR->NumAssociatedTypes * ATR->AssociatedTypeRecordSize;
+           (uint64_t)ATR->NumAssociatedTypes *
+               (uint64_t)ATR->AssociatedTypeRecordSize;
   }
 };
 using AssociatedTypeSection = ReflectionSection<AssociatedTypeIterator>;
@@ -235,7 +276,8 @@ public:
   BuiltinTypeDescriptorIterator(RemoteRef<void> Cur, uint64_t Size)
       : ReflectionSectionIteratorBase(Cur, Size, "BuiltinTypeDescriptor") {}
 
-  static uint64_t getCurrentRecordSize(RemoteRef<BuiltinTypeDescriptor> ATR) {
+  static std::optional<uint64_t>
+  getCurrentRecordSize(RemoteRef<BuiltinTypeDescriptor> ATR) {
     return sizeof(BuiltinTypeDescriptor);
   }
 };
@@ -248,10 +290,12 @@ public:
   CaptureDescriptorIterator(RemoteRef<void> Cur, uint64_t Size)
       : ReflectionSectionIteratorBase(Cur, Size, "CaptureDescriptor") {}
 
-  static uint64_t getCurrentRecordSize(RemoteRef<CaptureDescriptor> CR) {
+  static std::optional<uint64_t>
+  getCurrentRecordSize(RemoteRef<CaptureDescriptor> CR) {
+    // Use 64-bit arithmetic to avoid overflowing with extremely large values.
     return sizeof(CaptureDescriptor) +
-           CR->NumCaptureTypes * sizeof(CaptureTypeRecord) +
-           CR->NumMetadataSources * sizeof(MetadataSourceRecord);
+           (uint64_t)CR->NumCaptureTypes * sizeof(CaptureTypeRecord) +
+           (uint64_t)CR->NumMetadataSources * sizeof(MetadataSourceRecord);
   }
 };
 using CaptureSection = ReflectionSection<CaptureDescriptorIterator>;
@@ -263,7 +307,7 @@ public:
   MultiPayloadEnumDescriptorIterator(RemoteRef<void> Cur, uint64_t Size)
       : ReflectionSectionIteratorBase(Cur, Size, "MultiPayloadEnum") {}
 
-  static uint64_t
+  static std::optional<uint64_t>
   getCurrentRecordSize(RemoteRef<MultiPayloadEnumDescriptor> MPER) {
     return MPER->getSizeInBytes();
   }


### PR DESCRIPTION
Reflection descriptors carry an element stride alongside an element count. Require the stride match the expected value, and ignore the data otherwise, to protect from misbehavior when inspecting corrupted data. Perform size calculations in 64-bit to avoid overflow.

rdar://183388935