### PR TITLE
[Embedded] Loosen restrictions on generic methods in classes

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -8590,6 +8590,20 @@ public:
   /// vtable.
   bool needsNewVTableEntry() const;
 
+  /// Whether this is a generic method of a class that Embedded Swift must
+  /// dispatch statically, because it cannot be given a vtable entry.
+  ///
+  /// Embedded Swift has no unspecialized generic code, so a generic method
+  /// cannot appear in a vtable: there is no single implementation to put there.
+  /// Rather than reject such methods outright, they are dispatched statically
+  /// and kept out of the vtable entirely. The type checker makes that sound by
+  /// rejecting the two ways a static dispatch could be wrong -- an `open`
+  /// generic method, which a subclass in another module could override, and an
+  /// `override` of a generic method within this module.
+  ///
+  /// Returns false outside of Embedded Swift.
+  bool mustBeStaticallyDispatchedInEmbedded() const;
+
   /// True if the decl is a method which introduces a new witness table entry.
   bool requiresNewWitnessTableEntry() const {
     return getOverriddenDecls().empty();

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -9131,6 +9131,13 @@ GROUPED_WARNING(generic_nonfinal_in_embedded_swift, EmbeddedRestrictions,
                 none,
                 "generic %kind0 in a class %select{must be 'final'|cannot be 'required'}1 in Embedded Swift",
                 (const Decl *, bool))
+GROUPED_ERROR(generic_open_in_embedded_swift, EmbeddedRestrictions, none,
+              "generic %kind0 in a class cannot be 'open' in Embedded Swift",
+              (const Decl *))
+GROUPED_ERROR(generic_override_in_embedded_swift, EmbeddedRestrictions, none,
+              "generic %kind0 in a class cannot override another method in "
+              "Embedded Swift",
+              (const Decl *))
 GROUPED_WARNING(use_generic_member_of_existential_in_embedded_swift,
                 EmbeddedRestrictions, none,
                 "cannot use generic %kind0 on a value of type %1 in Embedded Swift",

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -162,6 +162,18 @@ public:
   /// pointer is \c nullptr. The result is cached.
   CanGenericSignature getCanonicalSignature() const;
 
+  /// Whether this signature is more generic than \p outerSig in a way that
+  /// affects ABI.
+  ///
+  /// Differences that don't affect ABI are ignored, such as requirements that
+  /// only add conformances to marker protocols. Either signature may be null.
+  ///
+  /// This is the notion Embedded Swift uses to decide whether a member is
+  /// "generic" relative to the context that declares it: a method of a generic
+  /// class that only uses the class's own generic parameters is not more
+  /// generic than the class, and needs no separate specialization.
+  bool isABIMoreGenericThan(GenericSignature outerSig) const;
+
   // Support for FoldingSet.
   void Profile(llvm::FoldingSetNodeID &id) const;
 

--- a/include/swift/SIL/SILVTableVisitor.h
+++ b/include/swift/SIL/SILVTableVisitor.h
@@ -99,6 +99,13 @@ template <class T> class SILVTableVisitor {
             /*allowUsableFromInline=*/true))
         break;
 
+      // In Embedded Swift a generic method has no vtable entry to override.
+      if (auto *baseFn =
+              dyn_cast<AbstractFunctionDecl>(baseRef.getDecl())) {
+        if (baseFn->mustBeStaticallyDispatchedInEmbedded())
+          break;
+      }
+
       asDerived().addMethodOverride(baseRef, declRef);
       nextRef = baseRef;
     }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -11274,6 +11274,32 @@ bool AbstractFunctionDecl::needsNewVTableEntry() const {
       false);
 }
 
+bool AbstractFunctionDecl::mustBeStaticallyDispatchedInEmbedded() const {
+  if (!getASTContext().LangOpts.hasFeature(Feature::Embedded))
+    return false;
+
+  // Only members written directly in a class are dispatched through a vtable.
+  auto *classDecl = dyn_cast<ClassDecl>(getDeclContext());
+  if (!classDecl)
+    return false;
+
+  // A `final` method (or a method of a `final` class) is already statically
+  // dispatched and never has a vtable entry, so there is nothing to decide.
+  if (classDecl->isSemanticallyFinal() || isSemanticallyFinal())
+    return false;
+
+  // Initializers are reached through the metatype rather than an instance, and
+  // a `required` generic initializer genuinely cannot be dispatched; that is
+  // diagnosed separately rather than silently made static.
+  if (isa<ConstructorDecl>(this))
+    return false;
+
+  // Only generic methods are a problem: a non-generic method of a generic class
+  // still has one implementation per specialization.
+  return getGenericSignature().isABIMoreGenericThan(
+      classDecl->getGenericSignature());
+}
+
 ParamDecl *AbstractFunctionDecl::getImplicitSelfDecl(bool createIfNeeded) {
   auto **selfDecl = getImplicitSelfDeclStorage();
 

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -289,6 +289,40 @@ CanGenericSignature::getCanonical(ArrayRef<GenericTypeParamType *> params,
   return CanGenericSignature(canSig);
 }
 
+bool GenericSignature::isABIMoreGenericThan(GenericSignature outerSig) const {
+  auto canInnerSig = getCanonicalSignature();
+  auto canOuterSig = outerSig.getCanonicalSignature();
+  if (canInnerSig == canOuterSig)
+    return false;
+
+  // The inner signature added generic parameters.
+  if (canOuterSig.getGenericParams().size() !=
+        canInnerSig.getGenericParams().size())
+    return true;
+
+  // Look at the requirements of the inner signature that aren't satisfied
+  // by the outer signature, to see if there are any requirements that aren't
+  // just marker protocols.
+  auto requirements = canInnerSig.requirementsNotSatisfiedBy(canOuterSig);
+  for (const auto &req : requirements) {
+    switch (req.getKind()) {
+    case RequirementKind::Conformance:
+      if (req.getProtocolDecl()->isMarkerProtocol())
+        continue;
+
+      return true;
+
+    case RequirementKind::Superclass:
+    case RequirementKind::Layout:
+    case RequirementKind::SameShape:
+    case RequirementKind::SameType:
+      return true;
+    }
+  }
+
+  return false;
+}
+
 CanGenericSignature GenericSignature::getCanonicalSignature() const {
   // If the underlying pointer is null, return `CanGenericSignature()`.
   if (isNull())

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -60,6 +60,12 @@ swift::getMethodDispatch(AbstractFunctionDecl *method) {
     if (method->isFinal())
       return MethodDispatch::Static;
 
+    // Embedded Swift cannot put a generic method in a vtable, so these are
+    // dispatched statically. The type checker rejects the cases where that
+    // would be observable (`open`, or an override).
+    if (method->mustBeStaticallyDispatchedInEmbedded())
+      return MethodDispatch::Static;
+
     // Imported class methods are dynamically dispatched.
     if (method->isObjC() && method->hasClangNode())
       return MethodDispatch::Class;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1055,6 +1055,12 @@ NeedsNewVTableEntryRequest::evaluate(Evaluator &evaluator,
   if (decl->isFinal() || decl->shouldUseObjCDispatch() || decl->hasClangNode())
     return false;
 
+  // Embedded Swift has no unspecialized generic code, so there is no single
+  // implementation to put in a vtable slot for a generic method. Such methods
+  // are dispatched statically instead.
+  if (decl->mustBeStaticallyDispatchedInEmbedded())
+    return false;
+
   auto &ctx = dc->getASTContext();
 
   // Initializers are not normally inherited, but required initializers can

--- a/lib/Sema/TypeCheckEmbedded.cpp
+++ b/lib/Sema/TypeCheckEmbedded.cpp
@@ -78,42 +78,6 @@ swift::shouldDiagnoseEmbeddedLimitations(const DeclContext *dc, SourceLoc loc,
   return DiagnosticBehavior::Unspecified;
 }
 
-/// Determine whether the inner signature is more generic than the outer
-/// signature, ignoring differences that
-static bool isABIMoreGenericThan(GenericSignature innerSig, GenericSignature outerSig) {
-  auto canInnerSig = innerSig.getCanonicalSignature();
-  auto canOuterSig = outerSig.getCanonicalSignature();
-  if (canInnerSig == canOuterSig)
-    return false;
-
-  // The inner signature added generic parameters.
-  if (canOuterSig.getGenericParams().size() !=
-        canInnerSig.getGenericParams().size())
-    return true;
-
-  // Look at the requirements of the inner signature that aren't satisfied
-  // by the outer signature, to see if there are any requirements that aren't
-  // just marker protocols.
-  auto requirements = canInnerSig.requirementsNotSatisfiedBy(canOuterSig);
-  for (const auto &req : requirements) {
-    switch (req.getKind()) {
-    case RequirementKind::Conformance:
-      if (req.getProtocolDecl()->isMarkerProtocol())
-        continue;
-
-      return true;
-
-    case RequirementKind::Superclass:
-    case RequirementKind::Layout:
-    case RequirementKind::SameShape:
-    case RequirementKind::SameType:
-      return true;
-    }
-  }
-
-  return false;
-}
-
 /// Check embedded restrictions in the signature of the given function.
 void swift::checkEmbeddedRestrictionsInSignature(
     const AbstractFunctionDecl *func) {
@@ -122,18 +86,45 @@ void swift::checkEmbeddedRestrictionsInSignature(
   if (!behavior)
     return;
 
-  // If we're in a class, one cannot have a non-final generic function.
-  if (auto classDecl = dyn_cast<ClassDecl>(func->getDeclContext())) {
-    if (!classDecl->isSemanticallyFinal() &&
-        ((isa<FuncDecl>(func) && !func->isSemanticallyFinal()) ||
-         (isa<ConstructorDecl>(func) &&
-          cast<ConstructorDecl>(func)->isRequired())) &&
-        isABIMoreGenericThan(func->getGenericSignature(),
-                             classDecl->getGenericSignature())) {
+  auto classDecl = dyn_cast<ClassDecl>(func->getDeclContext());
+  if (!classDecl)
+    return;
+
+  // A `required` generic initializer is reached through the metatype of a
+  // dynamic type, so there is no way to dispatch it statically.
+  if (auto ctor = dyn_cast<ConstructorDecl>(func)) {
+    if (ctor->isRequired() && !classDecl->isSemanticallyFinal() &&
+        func->getGenericSignature().isABIMoreGenericThan(
+            classDecl->getGenericSignature())) {
       func->diagnose(diag::generic_nonfinal_in_embedded_swift, func,
-                     isa<ConstructorDecl>(func))
+                     /*isRequiredInit=*/true)
         .limitBehavior(defaultEmbeddedLimitationForError(func, func->getLoc()));
     }
+    return;
+  }
+
+  // A generic method of a class is dispatched statically and kept out of the
+  // vtable. That is only sound if nothing can override it, so reject the two
+  // ways an override could arise.
+  if (classDecl->isSemanticallyFinal() ||
+      !func->getGenericSignature().isABIMoreGenericThan(
+          classDecl->getGenericSignature()))
+    return;
+
+  // An override needs the overridden method to have a vtable entry to dispatch
+  // through, which a generic method does not get. Diagnose this before `open`,
+  // since an `open` override should be described as the override problem.
+  if (func->getOverriddenDecl()) {
+    func->diagnose(diag::generic_override_in_embedded_swift, func)
+      .limitBehavior(defaultEmbeddedLimitationForError(func, func->getLoc()));
+    return;
+  }
+
+  // An `open` method can be overridden from another module, which we would
+  // never see -- so this has to be rejected at the declaration.
+  if (func->getFormalAccess() == AccessLevel::Open) {
+    func->diagnose(diag::generic_open_in_embedded_swift, func)
+      .limitBehavior(defaultEmbeddedLimitationForError(func, func->getLoc()));
   }
 }
 
@@ -145,9 +136,10 @@ void swift::diagnoseGenericMemberOfExistentialInEmbedded(
   if (!behavior)
     return;
 
-  if (isABIMoreGenericThan(
-          member->getInnermostDeclContext()->getGenericSignatureOfContext(),
-          member->getDeclContext()->getGenericSignatureOfContext())) {
+  if (member->getInnermostDeclContext()
+          ->getGenericSignatureOfContext()
+          .isABIMoreGenericThan(
+              member->getDeclContext()->getGenericSignatureOfContext())) {
     dc->getASTContext().Diags.diagnose(loc, diag::use_generic_member_of_existential_in_embedded_swift, member,
         baseType)
       .limitBehavior(*behavior);

--- a/test/embedded/classes-generic-methods-cross-module.swift
+++ b/test/embedded/classes-generic-methods-cross-module.swift
@@ -1,0 +1,68 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library -wmo -O %t/Lib.swift -module-name Lib -emit-module -emit-module-path %t/Lib.swiftmodule -c -o %t/Lib.o
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library -wmo -O -I %t %t/main.swift -module-name main -c -o %t/main.o
+// RUN: %target-embedded-link %t/Lib.o %t/main.o -o %t/a.out %target-clang-resource-dir-opt -dead_strip
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// A client cannot override the library's generic method. Because the library
+// was forced to declare it non-`open`, ordinary access control already rejects
+// this -- which is the point: the embedded rule turns what would have been a
+// link-time or call-site problem into an existing, well-understood one.
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library -wmo -O -I %t -verify %t/bad.swift -module-name bad -c -o /dev/null
+
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx
+// REQUIRES: swift_feature_Embedded
+
+//--- Lib.swift
+
+open class Widget {
+  public var tag: Int32
+  public init(tag: Int32) { self.tag = tag }
+
+  // Statically dispatched, and not `open`, so no client can override it.
+  public func measure<T>(_: T) -> Int32 { tag &+ Int32(MemoryLayout<T>.size) }
+
+  // Ordinary virtual method: clients may override this.
+  open func describe() -> Int32 { tag }
+}
+
+//--- main.swift
+
+import Lib
+
+final class Gadget: Widget {
+  override func describe() -> Int32 { tag &+ 1 }
+}
+
+@inline(never) func measureIt(_ w: Widget) -> Int32 { w.measure(Int32(0)) }
+@inline(never) func describeIt(_ w: Widget) -> Int32 { w.describe() }
+
+@main
+struct Main {
+  static func main() {
+    let w = Widget(tag: 10)
+    let g = Gadget(tag: 20)
+
+    // The generic method is the library's implementation in both cases.
+    print(measureIt(w) == 14 ? "OK!" : "FAIL")   // CHECK: OK!
+    print(measureIt(g) == 24 ? "OK!" : "FAIL")   // CHECK-NEXT: OK!
+
+    // The non-generic `open` method still dispatches virtually.
+    print(describeIt(w) == 10 ? "OK!" : "FAIL")  // CHECK-NEXT: OK!
+    print(describeIt(g) == 21 ? "OK!" : "FAIL")  // CHECK-NEXT: OK!
+  }
+}
+
+//--- bad.swift
+
+import Lib
+
+class Broken: Widget {
+  override func measure<T>(_: T) -> Int32 { 0 }
+  // expected-error@-1{{overriding non-open instance method outside of its defining module}}
+  // expected-error@-2{{generic instance method 'measure' in a class cannot override another method in Embedded Swift}}
+}

--- a/test/embedded/classes-generic-methods-vtable.swift
+++ b/test/embedded/classes-generic-methods-vtable.swift
@@ -1,0 +1,44 @@
+// A generic method of a class is dispatched statically in Embedded Swift and
+// kept out of the vtable, because there is no unspecialized implementation to
+// put in a vtable slot. A non-generic sibling keeps its entry and stays
+// overridable.
+//
+// RUN: %target-swift-emit-sil %s -enable-experimental-feature Embedded -parse-stdlib -wmo -module-name cgv -o - | %FileCheck %s
+
+// REQUIRES: swift_feature_Embedded
+
+public class Base {
+  public func generic<T>(_: T) { }
+  public func nonGeneric() { }
+  public final func finalNonGeneric() { }
+}
+
+public class Derived: Base {
+  public override func nonGeneric() { }
+}
+
+// A generic class: a method that is generic only over the class's own
+// parameters is *not* more generic than the class, so it keeps its entry.
+public class GenericBase<T> {
+  public func usesClassParam(_: T) { }
+  public func alsoGeneric<U>(_: U) { }
+}
+
+// CHECK-LABEL: sil_vtable Base {
+// CHECK-NOT:     #Base.generic
+// CHECK-DAG:     #Base.nonGeneric
+// CHECK-NOT:     #Base.generic
+// CHECK:       }
+
+// The `final` method is excluded for the usual reason, not this one.
+// CHECK-LABEL: sil_vtable Derived {
+// CHECK-NOT:     #Base.generic
+// CHECK-DAG:     #Base.nonGeneric{{.*}}override
+// CHECK-NOT:     #Base.generic
+// CHECK:       }
+
+// CHECK-LABEL: sil_vtable GenericBase {
+// CHECK-NOT:     #GenericBase.alsoGeneric
+// CHECK-DAG:     #GenericBase.usesClassParam
+// CHECK-NOT:     #GenericBase.alsoGeneric
+// CHECK:       }

--- a/test/embedded/classes-generic-methods.swift
+++ b/test/embedded/classes-generic-methods.swift
@@ -1,0 +1,109 @@
+// Embedded Swift has no unspecialized generic code, so a generic method cannot
+// be given a vtable entry: there is no single implementation to put there.
+// Rather than reject every non-final generic method, they are dispatched
+// statically and kept out of the vtable. The type checker makes that sound by
+// rejecting the only two ways an override could exist:
+//
+//   * `open` -- a subclass in another module could override it, and we would
+//     never see that subclass.
+//   * `override` -- an override within this module would need the base method
+//     to have a vtable entry to dispatch through.
+
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature Embedded -parse-stdlib -wmo
+
+// REQUIRES: swift_feature_Embedded
+
+// ---------------------------------------------------------------------------
+// Accepted: nothing can override these.
+// ---------------------------------------------------------------------------
+
+public class Plain {
+  public func generic<T>(_: T) { }
+  internal func internalGeneric<T>(_: T) { }
+  private func privateGeneric<T>(_: T) { }
+  public final func finalGeneric<T>(_: T) { }
+  public class func staticGeneric<T>(_: T) { }
+  public func nonGeneric() { }
+}
+
+// An `open` class may still have `public` generic methods: `public` is not
+// overridable from another module.
+open class OpenClass {
+  public func generic<T>(_: T) { }
+  open func nonGeneric() { }
+}
+
+public final class FinalClass {
+  public func generic<T>(_: T) { }
+}
+
+// A generic method whose genericity comes only from the class is not itself
+// generic, so it keeps its vtable entry and can be overridden.
+public class GenericClass<T> {
+  public func usesClassParam(_: T) { }
+}
+public class GenericSub<T>: GenericClass<T> {
+  public override func usesClassParam(_: T) { }
+}
+
+// ---------------------------------------------------------------------------
+// Rejected: `open` generic methods.
+// ---------------------------------------------------------------------------
+
+open class HasOpenGenerics {
+  open func openGeneric<T>(_: T) { }
+  // expected-error@-1{{generic instance method 'openGeneric' in a class cannot be 'open' in Embedded Swift}}
+
+  open class func openStaticGeneric<T>(_: T) { }
+  // expected-error@-1{{generic class method 'openStaticGeneric' in a class cannot be 'open' in Embedded Swift}}
+}
+
+// `final` overrides the openness, so this is fine.
+open class OpenButFinalMember {
+  public final func f<T>(_: T) { }
+}
+
+// ---------------------------------------------------------------------------
+// Rejected: overrides of generic methods.
+// ---------------------------------------------------------------------------
+
+public class Base {
+  public func generic<T>(_: T) { }
+  public func nonGeneric() { }
+}
+
+public class Derived: Base {
+  public override func generic<T>(_: T) { }
+  // expected-error@-1{{generic instance method 'generic' in a class cannot override another method in Embedded Swift}}
+
+  // Overriding a non-generic method is unaffected.
+  public override func nonGeneric() { }
+}
+
+// The error is on the override, not the base, so a base with no override is
+// still accepted (see `Plain` above). An override two levels down is also
+// caught.
+public class Middle: Base { }
+public class Bottom: Middle {
+  public override func generic<T>(_: T) { }
+  // expected-error@-1{{generic instance method 'generic' in a class cannot override another method in Embedded Swift}}
+}
+
+// A `final` override is still an override -- the base would need the vtable
+// entry regardless.
+public class FinalOverride: Base {
+  public final override func generic<T>(_: T) { }
+  // expected-error@-1{{generic instance method 'generic' in a class cannot override another method in Embedded Swift}}
+}
+
+// ---------------------------------------------------------------------------
+// `required` generic initializers are a separate rule: they are reached through
+// a dynamic type's metatype, so they cannot be dispatched statically at all.
+// ---------------------------------------------------------------------------
+
+public class Inits {
+  public init<T>(value: T) { }        // okay, directly called
+  public required init() { }          // okay, non-generic
+  public required init<T>(other: T) { }
+  // expected-warning@-1{{generic initializer 'init(other:)' in a class cannot be 'required' in Embedded Swift}}
+}

--- a/test/embedded/classes-non-final-method-no-stdlib.swift
+++ b/test/embedded/classes-non-final-method-no-stdlib.swift
@@ -1,10 +1,14 @@
+// A generic method of a class is dispatched statically in Embedded Swift and
+// kept out of the vtable, so a non-final one is fine as long as nothing can
+// override it. None of these are `open` or overridden, so all of them are
+// accepted -- this file used to be entirely diagnostics.
+
 // RUN: %target-swift-emit-ir -verify %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none -wmo
 
 // REQUIRES: swift_feature_Embedded
 
 public class MyClass {
-  public func foo<T>(t: T) { } // expected-warning {{generic instance method 'foo(t:)' in a class must be 'final' in Embedded Swift}}
-  // expected-error@-1{{classes cannot have a non-final, generic method 'foo(t:)' in embedded Swift}}
+  public func foo<T>(t: T) { }
   public func bar() { }
 }
 
@@ -23,9 +27,10 @@ func testit2() -> C2<S> {
   return C2(x: S())
 }
 
+// `open` class, but the generic method is only `public`, so it cannot be
+// overridden from another module.
 open class C3<X> {
-  public func foo<T>(t: T) {} // expected-warning {{generic instance method 'foo(t:)' in a class must be 'final' in Embedded Swift}}
-  // expected-error@-1{{classes cannot have a non-final, generic method 'foo(t:)' in embedded Swift}}
+  public func foo<T>(t: T) {}
 }
 
 func testit3() -> C3<S> {
@@ -33,4 +38,3 @@ func testit3() -> C3<S> {
   c.foo(t: S())
   return c
 }
-

--- a/test/embedded/restrictions.swift
+++ b/test/embedded/restrictions.swift
@@ -64,10 +64,13 @@ public struct MyStruct {
 
 protocol P { }
 
+// A generic method of a class is dispatched statically and kept out of the
+// vtable, so it is fine as long as nothing can override it. Only `open` and
+// `override` are rejected; see classes-generic-methods.swift.
 class MyGenericClass<T> {
-  func f<U>(value: U) { } // expected-warning{{generic instance method 'f(value:)' in a class must be 'final' in Embedded Swift}}
+  func f<U>(value: U) { } // okay, statically dispatched
   func g() { }
-  class func h() where T: P { } // expected-warning{{generic class method 'h()' in a class must be 'final' in Embedded Swift}}
+  class func h() where T: P { } // okay, statically dispatched
 
   init<U>(value: U) { } // okay, can be directly called
 

--- a/userdocs/diagnostics/embedded-restrictions.md
+++ b/userdocs/diagnostics/embedded-restrictions.md
@@ -21,14 +21,18 @@ Diagnostics in the `EmbeddedRestrictions` group describe those language features
         }
       }
 
-* Non-final generic methods in a class, which are prohibited because they cannot be specialized for every possible call site. For example:
+* Overriding and `open` generic methods in a class, which are prohibited because they cannot be specialized for every possible call site. For example:
 
-      class MyGenericClass<T> {
-        func f<U>(value: U) { } // warning: generic instance method 'f(value:)' in a class must be 'final' in Embedded Swift
+      open class MyGenericClass<T> {
+        open func f<U>(value: U) { }  // warning: generic instance method 'f(value:)' in a class cannot be 'open' in Embedded Swift
 
         func g() { } // okay, not generic relative to the class itself
 
-        class func h() where T: P { } // warning: generic class method 'h()' in a class must be 'final' in Embedded Swift
+        class func h() where T: P { }
+      }
+
+      class MyGenericSubclass<T>: MyGenericClass<T> {
+        override class func h() where T: P { } // warning: generic class method 'h' in a class cannot override another method in Embedded Swift
       }
 
 * Generic methods used on values of protocol type, which are prohibited because they cannot be specialized for every possible call site. For example:


### PR DESCRIPTION
Embedded Swift prohibits non-final generic methods because there is no way to specialize them. The restrictions here were overly broad, because the problem is overriding rather than declaration.

Loosen the restriction a bit to the following:
* A generic method of a class cannot be `open`
* A generic method of a class cannot be overridden

This keeps the rule module-local, because only `open` APIs can be overridden outside of the module, and within a module we can see all overrides to diagnose them. It is also expected to require fewer source-code changes for embedded (i.e., you don't need to sprinkle "final" around).

Make sure that generic methods never make it into the vtable, because this is being staged in via a warning (like all of the embedded restrictions).

Tracked by rdar://182122563.
