### PR TITLE
[Demangling] Fix capacity truncation and bound identifier expansion.

### DIFF
--- a/include/swift/Demangling/Demangler.h
+++ b/include/swift/Demangling/Demangler.h
@@ -20,6 +20,7 @@
 #define SWIFT_DEMANGLING_DEMANGLER_H
 
 #include "swift/Demangling/Demangle.h"
+#include "swift/Demangling/Errors.h"
 #include "swift/Demangling/ManglingFlavor.h"
 #include "swift/Demangling/NamespaceMacros.h"
 
@@ -75,6 +76,10 @@ class NodeFactory {
   /// True if some other NodeFactory borrowed free memory from this factory.
   bool isBorrowed = false;
 
+  /// Set when a size limit was exceeded and the demangling or remangling
+  /// cannot be completed.
+  bool TooComplex = false;
+
 #ifdef NODE_FACTORY_DEBUGGING
   size_t allocatedMemory = 0;
   static int nestingLevel;
@@ -86,6 +91,13 @@ public:
   /// Enabled only by the unit tests to test the failure paths.
   bool disableAssertionsForUnitTest = false;
 #endif
+
+  /// True if a size limit was exceeded. Once set, the result of the operation
+  /// in progress is incomplete and must be discarded.
+  bool isTooComplex() const { return TooComplex; }
+
+  /// Record that a size limit was exceeded.
+  void setTooComplex() { TooComplex = true; }
 
   NodeFactory() {
 #ifdef NODE_FACTORY_DEBUGGING
@@ -138,6 +150,8 @@ public:
   /// Allocates an object of type T or an array of objects of type T.
   template<typename T> T *Allocate(size_t NumObjects = 1) {
     assert(!isBorrowed);
+    if (NumObjects > SIZE_MAX / sizeof(T))
+      fatal(0, "too many objects requested from demangler allocator\n");
     size_t ObjectSize = NumObjects * sizeof(T);
     CurPtr = align(CurPtr, alignof(T));
 #ifdef NODE_FACTORY_DEBUGGING
@@ -146,12 +160,21 @@ public:
 #endif
 
     // Do we have enough space in the current slab?
-    if (!CurPtr || CurPtr + ObjectSize > End) {
+    if (!CurPtr || (size_t)(End - CurPtr) < ObjectSize) {
       // No. We have to malloc a new slab.
+      size_t MaxSlabSize = SIZE_MAX - sizeof(AllocatedSlab);
+      if (ObjectSize > MaxSlabSize - alignof(T))
+        fatal(0, "demangling allocation of %zu bytes is too large\n",
+              ObjectSize);
+      size_t MinSize = ObjectSize + alignof(T);
       // We double the slab size for each allocated slab.
-      SlabSize = std::max(SlabSize * 2, ObjectSize + alignof(T));
+      SlabSize = std::max(SlabSize <= MaxSlabSize / 2 ? SlabSize * 2
+                                                      : MaxSlabSize,
+                          MinSize);
       size_t AllocSize = sizeof(AllocatedSlab) + SlabSize;
       AllocatedSlab *newSlab = (AllocatedSlab *)malloc(AllocSize);
+      if (!newSlab)
+        fatal(0, "unable to allocate %zu bytes for demangling\n", AllocSize);
 
       // Insert the new slab in the single-linked list of slabs.
       newSlab->Previous = CurrentSlab;
@@ -180,10 +203,23 @@ public:
   /// new memory address.
   /// The \p Capacity is enlarged at least by \p MinGrowth, but can also be
   /// enlarged by a bigger value.
-  template<typename T> void Reallocate(T *&Objects, uint32_t &Capacity,
+  ///
+  /// Returns false if the new capacity or its byte size is not representable,
+  /// in which case \p Objects and \p Capacity are left unchanged.
+  template<typename T> bool Reallocate(T *&Objects, uint32_t &Capacity,
                                        size_t MinGrowth) {
     assert(!isBorrowed);
-    size_t OldAllocSize = Capacity * sizeof(T);
+
+    // The largest number of objects whose count fits in Capacity and whose
+    // byte size fits in size_t. Compute in uint64_t: Capacity is 32 bits, so
+    // the sums and products below cannot wrap on either a 32- or 64-bit
+    // target.
+    const uint64_t MaxObjects =
+        std::min((uint64_t)UINT32_MAX, (uint64_t)(SIZE_MAX / sizeof(T)));
+    if ((uint64_t)Capacity + MinGrowth > MaxObjects)
+      return false;
+
+    size_t OldAllocSize = (size_t)Capacity * sizeof(T);
     size_t AdditionalAlloc = MinGrowth * sizeof(T);
 
 #ifdef NODE_FACTORY_DEBUGGING
@@ -191,7 +227,7 @@ public:
           indent().c_str(), Capacity, OldAllocSize, MinGrowth, AdditionalAlloc);
 #endif
     if ((char *)Objects + OldAllocSize == CurPtr
-        && CurPtr + AdditionalAlloc <= End) {
+        && (size_t)(End - CurPtr) >= AdditionalAlloc) {
       // The existing array is at the end of the current slab and there is
       // enough space. So we are fine.
       CurPtr += AdditionalAlloc;
@@ -200,17 +236,24 @@ public:
       fprintf(stderr, "%s** can grow: %p\n", indent().c_str(), (void *)CurPtr);
       allocatedMemory += AdditionalAlloc;
 #endif
-      return;
+      return true;
     }
     // We need a new allocation.
-    size_t Growth = (MinGrowth >= 4 ? MinGrowth : 4);
-    if (Growth < Capacity * 2)
-      Growth = Capacity * 2;
-    T *NewObjects = Allocate<T>(Capacity + Growth);
+    uint64_t Growth = std::max<uint64_t>(MinGrowth, 4);
+    Growth = std::max(Growth, (uint64_t)Capacity * 2);
+    // Clamp the doubling so the new capacity stays representable. MinGrowth
+    // was already checked above.
+    if (Capacity + Growth > MaxObjects)
+      Growth = MaxObjects - Capacity;
+    // The clamp above bounds this by MaxObjects, so it fits in both size_t and
+    // Capacity.
+    size_t NewCapacity = (size_t)(Capacity + Growth);
+    T *NewObjects = Allocate<T>(NewCapacity);
     if (OldAllocSize)
       memcpy(NewObjects, Objects, OldAllocSize);
     Objects = NewObjects;
-    Capacity += Growth;
+    Capacity = (uint32_t)NewCapacity;
+    return true;
   }
 
   /// Copy a std::string to memory managed by the NodeFactory, returning a
@@ -304,9 +347,10 @@ public:
 
   /// Clears the content and re-allocates the buffer with an initial capacity.
   void init(NodeFactory &Factory, size_t InitialCapacity) {
+    assert(InitialCapacity <= UINT32_MAX && "capacity is not representable");
     Elems = Factory.Allocate<T>(InitialCapacity);
     NumElems = 0;
-    Capacity = InitialCapacity;
+    Capacity = (uint32_t)InitialCapacity;
   }
   
   void free() {
@@ -343,8 +387,12 @@ public:
   }
 
   void push_back(const T &NewElem, NodeFactory &Factory) {
-    if (NumElems >= Capacity)
-      Factory.Reallocate(Elems, Capacity, /*Growth*/ 1);
+    if (NumElems >= Capacity) {
+      if (!Factory.Reallocate(Elems, Capacity, /*Growth*/ 1)) {
+        Factory.setTooComplex();
+        return;
+      }
+    }
     assert(NumElems < Capacity);
     Elems[NumElems++] = NewElem;
   }
@@ -420,7 +468,15 @@ protected:
   static const int MaxNumWords = 26;
   StringRef Words[MaxNumWords];
   int NumWords = 0;
-  
+
+  /// Upper bound on the length of a single demangled identifier.
+  ///
+  /// Word substitution lets a short mangled name expand enormously, as each
+  /// one-letter reference re-appends a whole previously-seen word. The longest
+  /// mangled name in the demangler's test corpus is under 1 KB, so this leaves
+  /// ample headroom for real symbols.
+  static const size_t MaxIdentifierLength = 4 * 1024 * 1024;
+
   std::function<SymbolicReferenceResolver_t> SymbolicReferenceResolver;
 
   bool nextIf(StringRef str) {

--- a/include/swift/Demangling/Demangler.h
+++ b/include/swift/Demangling/Demangler.h
@@ -23,6 +23,7 @@
 #include "swift/Demangling/Errors.h"
 #include "swift/Demangling/ManglingFlavor.h"
 #include "swift/Demangling/NamespaceMacros.h"
+#include "llvm/Support/Alignment.h"
 
 //#define NODE_FACTORY_DEBUGGING
 
@@ -61,12 +62,6 @@ class NodeFactory {
   /// The slab size can only grow, even clear() does not reset the slab size.
   /// This initial size is good enough to fit most de-manglings.
   size_t SlabSize = 100 * sizeof(Node);
-
-  static char *align(char *Ptr, size_t Alignment) {
-    assert(Alignment > 0);
-    return (char*)(((uintptr_t)Ptr + Alignment - 1)
-                     & ~((uintptr_t)Alignment - 1));
-  }
 
   static void freeSlabs(AllocatedSlab *slab);
 
@@ -153,14 +148,17 @@ public:
     if (NumObjects > SIZE_MAX / sizeof(T))
       fatal(0, "too many objects requested from demangler allocator\n");
     size_t ObjectSize = NumObjects * sizeof(T);
-    CurPtr = align(CurPtr, alignof(T));
+    // Don't move CurPtr past End when aligning, which would make the space
+    // computation below wrap around.
+    size_t Padding = llvm::offsetToAlignedAddr(CurPtr, llvm::Align::Of<T>());
+    size_t Available = CurPtr ? (size_t)(End - CurPtr) : 0;
 #ifdef NODE_FACTORY_DEBUGGING
     fprintf(stderr, "%salloc %zu, CurPtr = %p\n", indent().c_str(), ObjectSize, (void *)CurPtr)
     allocatedMemory += ObjectSize;
 #endif
 
     // Do we have enough space in the current slab?
-    if (!CurPtr || (size_t)(End - CurPtr) < ObjectSize) {
+    if (!CurPtr || Available < Padding || Available - Padding < ObjectSize) {
       // No. We have to malloc a new slab.
       size_t MaxSlabSize = SIZE_MAX - sizeof(AllocatedSlab);
       if (ObjectSize > MaxSlabSize - alignof(T))
@@ -181,13 +179,15 @@ public:
       CurrentSlab = newSlab;
 
       // Initialize the pointers to the new slab.
-      CurPtr = align((char *)(newSlab + 1), alignof(T));
+      CurPtr = (char *)llvm::alignAddr(newSlab + 1, llvm::Align::Of<T>());
       End = (char *)newSlab + AllocSize;
       assert(CurPtr + ObjectSize <= End);
 #ifdef NODE_FACTORY_DEBUGGING
       fprintf(stderr, "%s** new slab %p, allocsize = %zu, CurPtr = %p, End = %p\n",
             indent().c_str(), newSlab, AllocSize, (void *)CurPtr, (void *)End);
 #endif
+    } else {
+      CurPtr += Padding;
     }
     T *AllocatedObj = (T *)CurPtr;
     CurPtr += ObjectSize;

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -401,8 +401,10 @@ void Node::addChild(NodePointer Child, NodeFactory &Factory) {
       Children.Nodes = nullptr;
       Children.Number = 0;
       Children.Capacity = 0;
-      Factory.Reallocate(Children.Nodes, Children.Capacity, 3);
-      assert(Children.Capacity >= 3);
+      // Growing from zero, so this cannot exceed the capacity limit.
+      bool grew = Factory.Reallocate(Children.Nodes, Children.Capacity, 3);
+      (void)grew;
+      assert(grew && Children.Capacity >= 3);
       Children.Nodes[0] = Child0;
       Children.Nodes[1] = Child1;
       Children.Nodes[2] = Child;
@@ -412,7 +414,10 @@ void Node::addChild(NodePointer Child, NodeFactory &Factory) {
     }
     case PayloadKind::ManyChildren:
       if (Children.Number >= Children.Capacity) {
-        Factory.Reallocate(Children.Nodes, Children.Capacity, 1);
+        if (!Factory.Reallocate(Children.Nodes, Children.Capacity, 1)) {
+          Factory.setTooComplex();
+          return;
+        }
       }
       assert(Children.Number < Children.Capacity);
       Children.Nodes[Children.Number++] = Child;
@@ -508,6 +513,7 @@ void NodeFactory::freeSlabs(AllocatedSlab *slab) {
   
 void NodeFactory::clear() {
   assert(!isBorrowed);
+  TooComplex = false;
   if (CurrentSlab) {
 #ifdef NODE_FACTORY_DEBUGGING
     fprintf(stderr, "%s## clear: allocated memory = %zu\n", indent().c_str(), allocatedMemory);
@@ -637,7 +643,9 @@ int NodeFactory::nestingLevel = 0;
 // Fast integer formatting
 namespace {
 
-// Format an unsigned integer into a buffer
+// Format an integer into a buffer, returning the number of characters written
+// not counting the terminating NUL. The buffer must have room for one byte
+// beyond that.
 template <typename U,
           typename std::enable_if<std::is_unsigned<U>::value, bool>::type = true>
 size_t int2str(U n, char *buf) {
@@ -679,7 +687,10 @@ size_t int2str(S n, char *buf) {
 
   if (n < 0) {
     *buf++ = '-';
-    return int2str(static_cast<U>(-n), buf);
+    // Negate in the unsigned type to avoid UB by negating the most negative
+    // value.
+    U magnitude = (U)0 - (U)n;
+    return 1 + int2str(magnitude, buf);
   }
   return int2str(static_cast<U>(n), buf);
 }
@@ -691,27 +702,46 @@ size_t int2str(S n, char *buf) {
 //////////////////////////////////
 
 void CharVector::append(StringRef Rhs, NodeFactory &Factory) {
-  if (NumElems + Rhs.size() > Capacity)
-    Factory.Reallocate(Elems, Capacity, /*Growth*/ Rhs.size());
+  // Compute in 64-bit so we don't overflow 32-bit quantities.
+  uint64_t NewSize = (uint64_t)NumElems + Rhs.size();
+  if (NewSize > Capacity) {
+    if (!Factory.Reallocate(Elems, Capacity, /*Growth*/ Rhs.size()) ||
+        NewSize > Capacity) {
+      Factory.setTooComplex();
+      return;
+    }
+  }
   memcpy(Elems + NumElems, Rhs.data(), Rhs.size());
-  NumElems += Rhs.size();
+  NumElems = (uint32_t)NewSize;
   assert(NumElems <= Capacity);
 }
 
 void CharVector::append(int Number, NodeFactory &Factory) {
-  const int MaxIntPrintSize = 11;
-  if (NumElems + MaxIntPrintSize > Capacity)
-    Factory.Reallocate(Elems, Capacity, /*Growth*/ MaxIntPrintSize);
-  int Length = int2str(Number, Elems + NumElems);
+  // 11 characters for -2147483648, plus the NUL that int2str writes.
+  const int MaxIntPrintSize = 12;
+  if ((uint64_t)NumElems + MaxIntPrintSize > Capacity) {
+    if (!Factory.Reallocate(Elems, Capacity, /*Growth*/ MaxIntPrintSize) ||
+        (uint64_t)NumElems + MaxIntPrintSize > Capacity) {
+      Factory.setTooComplex();
+      return;
+    }
+  }
+  size_t Length = int2str(Number, Elems + NumElems);
   assert(Length > 0 && Length < MaxIntPrintSize);
   NumElems += Length;
 }
 
 void CharVector::append(unsigned long long Number, NodeFactory &Factory) {
+  // 20 characters for 18446744073709551615, plus the NUL that int2str writes.
   const int MaxPrintSize = 21;
-  if (NumElems + MaxPrintSize > Capacity)
-    Factory.Reallocate(Elems, Capacity, /*Growth*/ MaxPrintSize);
-  int Length = int2str(Number, Elems + NumElems);
+  if ((uint64_t)NumElems + MaxPrintSize > Capacity) {
+    if (!Factory.Reallocate(Elems, Capacity, /*Growth*/ MaxPrintSize) ||
+        (uint64_t)NumElems + MaxPrintSize > Capacity) {
+      Factory.setTooComplex();
+      return;
+    }
+  }
+  size_t Length = int2str(Number, Elems + NumElems);
   assert(Length > 0 && Length < MaxPrintSize);
   NumElems += Length;
 }
@@ -815,6 +845,9 @@ NodePointer Demangler::demangleSymbol(StringRef MangledName,
   if (topLevel->getNumChildren() == 0)
     return nullptr;
 
+  if (isTooComplex())
+    return nullptr;
+
   return topLevel;
 }
 
@@ -831,6 +864,9 @@ NodePointer Demangler::demangleType(StringRef MangledName,
   if (popNode())
     return nullptr;
 
+  if (isTooComplex())
+    return nullptr;
+
   return Result;
 }
 
@@ -845,6 +881,8 @@ bool Demangler::parseAndPushNodes() {
 
     NodePointer Node = demangleOperator();
     if (!Node)
+      return false;
+    if (isTooComplex())
       return false;
     pushNode(Node);
   }
@@ -1326,6 +1364,8 @@ NodePointer Demangler::demangleIdentifier() {
       assert(WordIdx < MaxNumWords);
       StringRef Slice = Words[WordIdx];
       Identifier.append(Slice, *this);
+      if (Identifier.size() > MaxIdentifierLength)
+        return nullptr;
     }
     if (nextIf('0'))
       break;
@@ -1342,8 +1382,12 @@ NodePointer Demangler::demangleIdentifier() {
       if (!Punycode::decodePunycodeUTF8(Slice, PunycodedString))
         return nullptr;
       Identifier.append(StringRef(PunycodedString), *this);
+      if (Identifier.size() > MaxIdentifierLength)
+        return nullptr;
     } else {
       Identifier.append(Slice, *this);
+      if (Identifier.size() > MaxIdentifierLength)
+        return nullptr;
       int wordStartPos = -1;
       for (int Idx = 0, End = (int)Slice.size(); Idx <= End; ++Idx) {
         char c = (Idx < End ? Slice[Idx] : 0);

--- a/lib/Demangling/OldDemangler.cpp
+++ b/lib/Demangling/OldDemangler.cpp
@@ -2406,6 +2406,9 @@ NodePointer
 swift::Demangle::demangleOldSymbolAsNode(StringRef MangledName,
                                          NodeFactory &Factory) {
   OldDemangler demangler(MangledName, Factory);
-  return demangler.demangleTopLevel();
+  NodePointer result = demangler.demangleTopLevel();
+  if (Factory.isTooComplex())
+    return nullptr;
+  return result;
 }
 

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -3108,6 +3108,8 @@ Demangle::mangleNodeOld(NodePointer node) {
   ManglingError err = remangler.mangle(node, 0);
   if (!err.isSuccess())
     return err;
+  if (Factory.isTooComplex())
+    return ManglingError(ManglingError::TooComplex, node, 0);
 
   return remangler.str();
 }
@@ -3120,6 +3122,8 @@ Demangle::mangleNodeOld(NodePointer node, NodeFactory &Factory) {
   ManglingError err = remangler.mangle(node, 0);
   if (!err.isSuccess())
     return err;
+  if (Factory.isTooComplex())
+    return ManglingError(ManglingError::TooComplex, node, 0);
 
   return remangler.getBufferStr();
 }
@@ -3135,6 +3139,8 @@ Demangle::mangleNodeAsObjcCString(NodePointer node,
   if (!err.isSuccess())
     return err;
   remangler.append(StringRef("_", 2)); // Include the trailing 0 char.
+  if (Factory.isTooComplex())
+    return ManglingError(ManglingError::TooComplex, node, 0);
 
   return remangler.getBufferStr().data();
 }

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -4222,6 +4222,8 @@ ManglingErrorOr<std::string> Demangle::mangleNode(NodePointer node,
   ManglingError err = remangler.mangle(node, 0);
   if (!err.isSuccess())
     return err;
+  if (Factory.isTooComplex())
+    return ManglingError(ManglingError::TooComplex, node, 0);
 
   return remangler.str();
 }
@@ -4237,6 +4239,8 @@ ManglingErrorOr<llvm::StringRef> Demangle::mangleNode(NodePointer node,
   ManglingError err = remangler.mangle(node, 0);
   if (!err.isSuccess())
     return err;
+  if (Factory.isTooComplex())
+    return ManglingError(ManglingError::TooComplex, node, 0);
 
   return remangler.getBufferStr();
 }

--- a/test/Demangle/Inputs/gen_word_substitution.py
+++ b/test/Demangle/Inputs/gen_word_substitution.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""Emit a mangled name whose identifier expands past the demangler's limit.
+
+`0` enters word-substitution mode, the first identifier seeds Words[0] with a
+WORD_LENGTH-character word, and each following lowercase letter re-appends that
+whole word. WORD_LENGTH * SUBSTITUTIONS is exactly 4 MiB.
+"""
+
+import sys
+
+WORD_LENGTH = 2048
+SUBSTITUTIONS = int(sys.argv[1]) if len(sys.argv) > 1 else 2048
+
+print("$s0" + str(WORD_LENGTH) + ("x" * WORD_LENGTH)
+      + ("a" * SUBSTITUTIONS) + "0" + "3foo" + "V")

--- a/test/Demangle/identifier-expansion-limit.swift
+++ b/test/Demangle/identifier-expansion-limit.swift
@@ -1,0 +1,22 @@
+; This is not really a Swift source file: -*- Text -*-
+
+; Ensure that an identifier whose word substitutions expand past the
+; demangler's length limit is rejected gracefully: the name is passed through
+; unchanged, with no crash, hang, or fatal error.
+
+; We need python to build the input.
+UNSUPPORTED: OS=windows-msvc
+
+RUN: %empty-directory(%t)
+
+; 2048 substitutions of a 2048-character word is exactly the 4 MiB limit.
+RUN: %{python} %S/Inputs/gen_word_substitution.py 2048 > %t/over.txt
+RUN: swift-demangle < %t/over.txt 2>&1 | %FileCheck %s --check-prefix=OVER
+OVER: $s02048xxx
+OVER-SAME: 3fooV
+
+; One substitution fewer stays under the limit and still demangles.
+RUN: %{python} %S/Inputs/gen_word_substitution.py 2047 > %t/under.txt
+RUN: swift-demangle < %t/under.txt 2>&1 | %FileCheck %s --check-prefix=UNDER
+UNDER: xxx
+UNDER-SAME: .foo

--- a/unittests/Remangler/RemangleTest.cpp
+++ b/unittests/Remangler/RemangleTest.cpp
@@ -125,3 +125,46 @@ TEST(TestSwiftRemangler, DependentGenericConformanceRequirement) {
     ASSERT_FALSE(b.remangleSuccess(n));
   }
 }
+
+TEST(TestSwiftRemangler, IdentifierExpansionLimit) {
+  using namespace swift::Demangle;
+
+  // Word substitution lets each one-letter reference re-append a whole
+  // previously-seen word. 2048 references to a 2048-character word is exactly
+  // the identifier length limit.
+  std::string Word(2048, 'x');
+  std::string Mangled =
+      "$s0" + std::to_string(Word.size()) + Word + std::string(2048, 'a') +
+      "03fooV";
+
+  Demangler Dem;
+  ASSERT_EQ(Dem.demangleSymbol(Mangled), nullptr);
+  ASSERT_FALSE(Dem.isTooComplex());
+
+  // One reference fewer stays under the limit and demangles.
+  std::string Under =
+      "$s0" + std::to_string(Word.size()) + Word + std::string(2047, 'a') +
+      "03fooV";
+
+  Demangler UnderDem;
+  ASSERT_NE(UnderDem.demangleSymbol(Under), nullptr);
+}
+
+TEST(TestSwiftRemangler, TooComplexIsReportedNotFatal) {
+  using namespace swift::Demangle;
+
+  // A factory that has hit a size limit reports failure from both the
+  // demangler and the remangler rather than raising a fatal error.
+  Demangler Dem;
+  NodeBuilder b(Dem);
+  NodePointer n = b.GlobalTypeMangling(b.IntType());
+  ASSERT_TRUE(b.remangleSuccess(n));
+
+  Dem.setTooComplex();
+  ASSERT_TRUE(Dem.isTooComplex());
+  ASSERT_FALSE(b.remangleSuccess(n));
+
+  // clear() resets the failure so the factory can be reused.
+  Dem.clear();
+  ASSERT_FALSE(Dem.isTooComplex());
+}

--- a/unittests/Remangler/RemangleTest.cpp
+++ b/unittests/Remangler/RemangleTest.cpp
@@ -150,6 +150,21 @@ TEST(TestSwiftRemangler, IdentifierExpansionLimit) {
   ASSERT_NE(UnderDem.demangleSymbol(Under), nullptr);
 }
 
+TEST(TestSwiftRemangler, AllocateWithMisalignedSlabEnd) {
+  using namespace swift::Demangle;
+
+  // A char allocation big enough to force a new slab leaves the slab's end
+  // misaligned relative to Node. Allocating a Node afterwards must not read
+  // or write past the end of that slab.
+  NodeFactory Factory;
+  size_t Size = 100 * sizeof(Node) * 2 + 1;
+  char *Chars = Factory.Allocate<char>(Size);
+  memset(Chars, 'x', Size);
+
+  NodePointer N = Factory.createNode(Node::Kind::Identifier, "a");
+  ASSERT_EQ(N->getText(), "a");
+}
+
 TEST(TestSwiftRemangler, TooComplexIsReportedNotFatal) {
   using namespace swift::Demangle;
 


### PR DESCRIPTION
Prevent the 32-bit `Capacity` from wrapping around, resulting in an overly-small allocation.

Word substitution can expand a single identifier without bound, so cap the length of one demangled identifier.

Fix int2str not accounting for the '-' character when reporting the length of a negative number, and avoid a signed negation of the most negative value, which isn't representable in the signed type.

NULL-check the malloc in `NodeFactory::Allocate`, which dereferenced its result immediately.

rdar://183384935