### PR TITLE
Add early exit in isBarrierForDestroy for default-deinit types

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -632,6 +632,11 @@ extension Instruction {
     guard let nominal = type.nominal else {
       return true
     }
+
+    guard type.mayHaveCustomDeinit(in: parentFunction) else {
+      return false
+    }
+
     if nominal.valueTypeDestructor != nil {
       guard let deinitFunc = context.lookupDeinit(ofNominal: nominal) else {
         return true


### PR DESCRIPTION
If a non-copyable nominal type only has default deinitialization, its destroy cannot have semantically visible side effects, so no instruction can be a barrier for it. Bail out before doing the deinit lookup and the recursive walk over struct fields and enum payloads.
