### PR TITLE
SILGen: Collect default `Copyable` and `Escapable` conformances when visiting existential-opening instructions.

### DIFF
--- a/lib/AST/LocalArchetypeRequirementCollector.cpp
+++ b/lib/AST/LocalArchetypeRequirementCollector.cpp
@@ -156,7 +156,7 @@ GenericSignature swift::buildGenericSignatureWithCapturedEnvironments(
                                collector.OuterSig,
                                collector.Params,
                                collector.Requirements,
-                               DefaultRequirementOptions());
+                               ExpandDefaults);
 }
 
 Type MapLocalArchetypesOutOfContext::getInterfaceType(

--- a/test/SILGen/copyable_conformance_in_call_substitutions.swift
+++ b/test/SILGen/copyable_conformance_in_call_substitutions.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend -emit-silgen -verify -swift-version 6 %s
+
+func checkFunctionCall<T, Arg0>(_ lhs: T, calling f: (T, Arg0) -> Bool, _ arg: Arg0) -> Bool {
+    return f(lhs, arg)
+}
+
+protocol Eq: ~Copyable {
+  static func ==(_ a: borrowing Self, _ b: borrowing Self) -> Bool
+}
+
+extension Eq {
+   static func ==(_ a: borrowing Self, _ b: borrowing Self) -> Bool { true }
+}
+
+extension Eq {
+    func isEqual(to rhs: any Eq) -> Bool { (rhs as? Self)! == self }
+}
+
+struct S: Eq { var a: Int }
+
+func test() {
+    let lhs: any Eq = S(a: 1)
+    let rhs: any Eq = S(a: 1)
+    _ = checkFunctionCall(lhs, calling: { $0.isEqual(to: $1) }, rhs)
+}

--- a/validation-test/compiler_crashers/collectExistentialConformances-766dbf.swift
+++ b/validation-test/compiler_crashers/collectExistentialConformances-766dbf.swift
@@ -1,5 +1,5 @@
 // {"kind":"emit-silgen","languageMode":6,"original":"8b10024f","signature":"swift::collectExistentialConformances(swift::CanType, swift::CanType, bool)","signatureAssert":"Assertion failed: (conformance), function collectExistentialConformances","signatureNext":"Lowering::SILGenFunction::emitTransformExistential"}
-// RUN: not --crash %target-swift-frontend -emit-silgen -swift-version 6 %s
+// RUN: %target-swift-frontend -emit-silgen -swift-version 6 %s
 protocol a {
   static func b(c: AnyObject)
 }


### PR DESCRIPTION
Neglecting this meant we were losing the `Copyable`/`Escapable` conformance info when visiting these expressions in SIL. Fixes rdar://179823115.
