### PR TITLE
[Completion] Map base type into context for `addConstructorCallsForType`

### DIFF
--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -2011,7 +2011,7 @@ void CompletionLookup::foundDecl(ValueDecl *D, DeclVisibilityKind Reason,
 
     if (auto *NTD = dyn_cast<NominalTypeDecl>(D)) {
       addNominalTypeRef(NTD, Reason, dynamicLookupInfo);
-      addConstructorCallsForType(NTD->getDeclaredInterfaceType(),
+      addConstructorCallsForType(NTD->getDeclaredTypeInContext(),
                                  NTD->getName(), Reason, dynamicLookupInfo);
       return;
     }

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -615,87 +615,87 @@ Type CompletionLookup::getTypeOfMember(const ValueDecl *VD, Type ExprType) {
   }
   assert(!T.isNull());
 
-  if (ExprType) {
-    Type ContextTy = VD->getDeclContext()->getDeclaredInterfaceType();
-    if (ContextTy) {
-      // Look through lvalue types and metatypes
-      Type MaybeNominalType = ExprType->getRValueType();
+  if (!ExprType)
+    return T;
 
-      if (auto Metatype = MaybeNominalType->getAs<MetatypeType>())
-        MaybeNominalType = Metatype->getInstanceType();
+  ASSERT(!ExprType->hasTypeParameter() && "Expected contextual base type");
 
-      if (auto SelfType = MaybeNominalType->getAs<DynamicSelfType>())
-        MaybeNominalType = SelfType->getSelfType();
+  Type ContextTy = VD->getDeclContext()->getDeclaredInterfaceType();
+  if (!ContextTy)
+    return T;
 
-      // For optional protocol requirements and dynamic dispatch,
-      // strip off optionality from the base type, but only if
-      // we're not actually completing a member of Optional.
-      if (!ContextTy->getOptionalObjectType() &&
-          MaybeNominalType->getOptionalObjectType())
-        MaybeNominalType = MaybeNominalType->getOptionalObjectType();
+  // Look through lvalue types and metatypes
+  Type MaybeNominalType = ExprType->getRValueType();
 
-      // For dynamic lookup don't substitute in the base type.
-      if (MaybeNominalType->isAnyObject())
-        return T;
+  if (auto Metatype = MaybeNominalType->getAs<MetatypeType>())
+    MaybeNominalType = Metatype->getInstanceType();
 
-      // FIXME: Sometimes ExprType is the type of the member here,
-      // and not the type of the base. That is inconsistent and
-      // should be cleaned up.
-      if (!MaybeNominalType->mayHaveMembers())
-        return T;
+  if (auto SelfType = MaybeNominalType->getAs<DynamicSelfType>())
+    MaybeNominalType = SelfType->getSelfType();
 
-      // We can't do anything if the base type has unbound generic parameters.
-      if (MaybeNominalType->hasUnboundGenericType())
-        return T;
+  // For optional protocol requirements and dynamic dispatch,
+  // strip off optionality from the base type, but only if
+  // we're not actually completing a member of Optional.
+  if (!ContextTy->getOptionalObjectType() &&
+      MaybeNominalType->getOptionalObjectType())
+    MaybeNominalType = MaybeNominalType->getOptionalObjectType();
 
-      // If we are doing implicit member lookup on a protocol and we have found
-      // a declaration in a constrained extension, use the extension's `Self`
-      // type for the generic substitution.
-      // Eg in the following, the `Self` type returned by `qux` is
-      // `MyGeneric<Int>`, not `MyProto` because of the `Self` type restriction.
-      // ```
-      // protocol MyProto {}
-      // struct MyGeneric<T>: MyProto {}
-      // extension MyProto where Self == MyGeneric<Int> {
-      //   static func qux() -> Self { .init() }
-      // }
-      // func takeMyProto(_: any MyProto)  {}
-      // func test() {
-      //   takeMyProto(.#^COMPLETE^#)
-      // }
-      // ```
-      if (MaybeNominalType->isExistentialType()) {
-        Type SelfType;
-        if (auto *ED = dyn_cast<ExtensionDecl>(VD->getDeclContext())) {
-          if (ED->getSelfProtocolDecl() && ED->isConstrainedExtension()) {
-            auto Sig = ED->getGenericSignature();
-            SelfType = Sig->getConcreteType(ED->getSelfInterfaceType());
-          }
-        }
-        if (SelfType) {
-          MaybeNominalType = SelfType;
-        } else {
-          return T;
-        }
-      }
+  // For dynamic lookup don't substitute in the base type.
+  if (MaybeNominalType->isAnyObject())
+    return T;
 
-      // For everything else, substitute in the base type.
-      auto Subs = MaybeNominalType->getMemberSubstitutionMap(VD);
+  // FIXME: Sometimes ExprType is the type of the member here,
+  // and not the type of the base. That is inconsistent and
+  // should be cleaned up.
+  if (!MaybeNominalType->mayHaveMembers())
+    return T;
 
-      // For a GenericFunctionType, we only want to substitute the
-      // param/result types, as otherwise we might end up with a bad generic
-      // signature if there are ErrorTypes present in the base type. Note
-      // we pass in DesugarMemberTypes so that we see the actual concrete type
-      // witnesses instead of type alias types.
-      if (auto *GFT = T->getAs<GenericFunctionType>()) {
-        T = GFT->substGenericArgs(Subs, SubstFlags::DesugarMemberTypes);
-      } else {
-        T = T.subst(Subs, SubstFlags::DesugarMemberTypes);
+  // We can't do anything if the base type has unbound generic parameters.
+  if (MaybeNominalType->hasUnboundGenericType())
+    return T;
+
+  // If we are doing implicit member lookup on a protocol and we have found
+  // a declaration in a constrained extension, use the extension's `Self`
+  // type for the generic substitution.
+  // Eg in the following, the `Self` type returned by `qux` is
+  // `MyGeneric<Int>`, not `MyProto` because of the `Self` type restriction.
+  // ```
+  // protocol MyProto {}
+  // struct MyGeneric<T>: MyProto {}
+  // extension MyProto where Self == MyGeneric<Int> {
+  //   static func qux() -> Self { .init() }
+  // }
+  // func takeMyProto(_: any MyProto)  {}
+  // func test() {
+  //   takeMyProto(.#^COMPLETE^#)
+  // }
+  // ```
+  if (MaybeNominalType->isExistentialType()) {
+    Type SelfType;
+    if (auto *ED = dyn_cast<ExtensionDecl>(VD->getDeclContext())) {
+      if (ED->getSelfProtocolDecl() && ED->isConstrainedExtension()) {
+        auto Sig = ED->getGenericSignature();
+        SelfType = Sig->getConcreteType(ED->getSelfInterfaceType());
       }
     }
+    if (!SelfType)
+      return T;
+
+    MaybeNominalType = SelfType;
   }
 
-  return T;
+  // For everything else, substitute in the base type.
+  auto Subs = MaybeNominalType->getMemberSubstitutionMap(VD);
+
+  // For a GenericFunctionType, we only want to substitute the
+  // param/result types, as otherwise we might end up with a bad generic
+  // signature if there are ErrorTypes present in the base type. Note
+  // we pass in DesugarMemberTypes so that we see the actual concrete type
+  // witnesses instead of type alias types.
+  if (auto *GFT = T->getAs<GenericFunctionType>())
+    return GFT->substGenericArgs(Subs, SubstFlags::DesugarMemberTypes);
+
+  return T.subst(Subs, SubstFlags::DesugarMemberTypes);
 }
 
 Type CompletionLookup::getAssociatedTypeType(const AssociatedTypeDecl *ATD) {

--- a/validation-test/IDE/crashers_fixed/RequirementMachine-verify-inits-to-top-level.swift
+++ b/validation-test/IDE/crashers_fixed/RequirementMachine-verify-inits-to-top-level.swift
@@ -1,0 +1,11 @@
+// RUN: %batch-code-completion -code-complete-inits-in-postfix-expr
+protocol P {
+  init(x: Int)
+}
+extension P {
+  init(x: Int) {}
+}
+struct S<T, U>: P {}
+
+#^COMPLETE^#
+// COMPLETE: Decl[Constructor]/CurrModule: S({#x: Int#})[#S<T, U>#]; name=S(x:)


### PR DESCRIPTION
The logic here expects a contextual type, so map it into context. This fixes a crash where we could attempt to map a generic parameter using the wrong generic signature.

rdar://183803804