### PR TITLE
Show "References" eyebrow on the compiler diagnostics landing page

### DIFF
--- a/userdocs/diagnostics/diagnostics.md
+++ b/userdocs/diagnostics/diagnostics.md
@@ -2,6 +2,7 @@
 
 @Metadata {
    @TechnologyRoot
+   @TitleHeading("References")
 }
 
 Documentation on diagnostics emitted by the compiler and settings that control them.


### PR DESCRIPTION
## Summary
- In the combined swift.org documentation, this catalog (`userdocs/diagnostics`) is listed under the "References" nav group, but its landing page had no `@TitleHeading` set, so no eyebrow was shown. Adding an explicit `@TitleHeading("References")` matches the pattern used for other combined-docs modules.

## Test plan
- N/A (single-line metadata addition; no build tooling change)