### PR TITLE
Show "Libraries" eyebrow on the standard library documentation landing page

### DIFF
--- a/stdlib/stdlib.docc/Swift.md
+++ b/stdlib/stdlib.docc/Swift.md
@@ -2,6 +2,10 @@
 
 Build apps using a powerful open language.
 
+@Metadata {
+    @TitleHeading("Libraries")
+}
+
 ## Overview
 
 Swift includes modern features like type inference, optionals, and closures, which


### PR DESCRIPTION
## Summary
- The standard library's DocC catalog (`stdlib/stdlib.docc`) belongs to the "Libraries" nav group in the combined swift.org docs, but its title heading was unset, so no eyebrow was shown on the landing page.
- Adds a `@Metadata` block with `@TitleHeading("Libraries")` to `Swift.md` to match its nav group.

## Test plan
- [ ] Preview the DocC catalog and confirm the "Libraries" eyebrow appears above the title on the landing page.