### PR TITLE
[IRGen] fix oversized lifetime marker on coercion temporaries

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -5757,12 +5757,7 @@ StackAddress irgen::allocateForCoercion(IRGenFunction &IGF,
   llvm::Align alignment =
       std::max(DL.getABITypeAlign(fromTy), DL.getABITypeAlign(toTy));
 
-  // The lifetime markers emitted by emitStaticAlloca take a size in *bytes*.
-  // fromSize/toSize above are in bits (getTypeSizeInBits), so use the buffer
-  // type's allocation size here instead; otherwise the lifetime range is 8x too
-  // large and, once this temporary is coalesced into an async coroutine frame,
-  // spuriously covers adjacent live frame slots.
-  Size size(DL.getTypeAllocSize(bufferTy));
+  auto size = Size::forBits(std::max(fromSize, toSize));
   auto buffer = IGF.emitStaticAlloca(bufferTy, size,
                                      Alignment(alignment.value()),
                                      basename + ".coerced");

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -5757,7 +5757,12 @@ StackAddress irgen::allocateForCoercion(IRGenFunction &IGF,
   llvm::Align alignment =
       std::max(DL.getABITypeAlign(fromTy), DL.getABITypeAlign(toTy));
 
-  Size size(std::max(fromSize, toSize));
+  // The lifetime markers emitted by emitStaticAlloca take a size in *bytes*.
+  // fromSize/toSize above are in bits (getTypeSizeInBits), so use the buffer
+  // type's allocation size here instead; otherwise the lifetime range is 8x too
+  // large and, once this temporary is coalesced into an async coroutine frame,
+  // spuriously covers adjacent live frame slots.
+  Size size(DL.getTypeAllocSize(bufferTy));
   auto buffer = IGF.emitStaticAlloca(bufferTy, size,
                                      Alignment(alignment.value()),
                                      basename + ".coerced");

--- a/test/IRGen/arg_and_result_peepholes.swift
+++ b/test/IRGen/arg_and_result_peepholes.swift
@@ -9,7 +9,7 @@
 // CHECK:   [[ARG_MEM:%.*]] = alloca %TSo9BigStructV
 // CHECK:   [[TMP2:%.*]] = alloca %TSo9BigStructV
 // CHECK:   [[CALL:%.*]] = alloca %TSo9BigStructV
-// CHECK:   call void @llvm.lifetime.start.p0(i64 256, ptr [[TMP]])
+// CHECK:   call void @llvm.lifetime.start.p0(i64 32, ptr [[TMP]])
 // CHECK:   [[A1:%.*]] = getelementptr inbounds{{.*}} { i64, i64, i64, i64 }, ptr [[TMP]], i32 0, i32 0
 // CHECK:   store i64 %0, ptr [[A1]]
 // CHECK:   [[A2:%.*]] = getelementptr inbounds{{.*}} { i64, i64, i64, i64 }, ptr [[TMP]], i32 0, i32 1

--- a/test/IRGen/async_coercion_frame_lifetime_exec.swift
+++ b/test/IRGen/async_coercion_frame_lifetime_exec.swift
@@ -1,0 +1,34 @@
+// RUN: %target-run-simple-swift(-O) | %FileCheck %s
+// RUN: %target-run-simple-swift(-Onone) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+
+// End-to-end regression test for an IRGen miscompile at -O.
+//
+// A call-argument coercion temporary (irgen::allocateForCoercion) was created
+// with an llvm.lifetime marker sized in *bits* rather than *bytes* (8x too
+// large). Once that temporary was coalesced into the async coroutine frame by
+// CoroSplit, the oversized lifetime.end covered adjacent, still-live frame slots
+// -- here the spilled `self` -- and DSE then deleted those live stores. `self`
+// (and hence `a`/`b`) read back as zero at runtime. The enum payload must be
+// large enough (>= 8 bytes) to reach across the frame to the `self` slots.
+
+enum Project {
+    case projectID((UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8))
+}
+
+struct Holder {
+    let a = 67_108_864
+    let b = 6
+
+    func guardProbe(of project: Project) async {
+        guard case .projectID(let id) = project else { return }
+        // Before the fix, at -O this printed "self=Holder(a: 0, b: 0) a=0 b=0".
+        // CHECK: guard: self=Holder(a: 67108864, b: 6) a=67108864 b=6 id=66
+        print("guard: self=\(self) a=\(a) b=\(b) id=\(id.0)")
+    }
+}
+
+await Holder().guardProbe(of: .projectID((66, 2, 3, 4, 5, 6, 7, 8, 9)))

--- a/test/IRGen/coercion_temp_lifetime_size.swift
+++ b/test/IRGen/coercion_temp_lifetime_size.swift
@@ -1,0 +1,32 @@
+// RUN: %target-swift-frontend -parse-stdlib -enable-builtin-module -emit-ir %s | %FileCheck %s
+
+// The temporary alloca created for NativeConventionSchema coercion
+// (irgen::allocateForCoercion) must emit its llvm.lifetime markers with a size
+// equal to the temporary's size in *bytes*, not in *bits*.
+//
+// The size was computed with DataLayout::getTypeSizeInBits() and then handed to
+// a byte-denominated `Size`, producing an 8x-oversized lifetime range (e.g. 64
+// for an 8-byte temporary). That is harmless in isolation, but once such a
+// coercion temporary is coalesced into an async coroutine frame by CoroSplit,
+// the oversized lifetime.end spans adjacent, still-live frame slots (such as a
+// spilled `self`). DSE then legally drops those live stores, miscompiling the
+// function (self reads back as zero). See rdar/GenCall.cpp allocateForCoercion.
+
+// REQUIRES: PTRSIZE=64
+
+import Builtin
+
+struct B { var v: Builtin.Int8 }
+
+// An 8-byte value type whose ABI lowering coerces through memory to `{ i64 }`.
+enum E { case p((B, B, B, B, B, B, B, B)) }
+
+// CHECK-LABEL: define {{.*}} @"$s{{.*}}4take{{.*}}"
+// The coercion temporary is an 8-byte alloca...
+// CHECK: %temp-coercion.coerced = alloca { i64 }
+// ...so its lifetime marker must cover 8 bytes, not 64 (the size in bits).
+// CHECK-NOT: @llvm.lifetime.start.p0(i64 64, ptr %temp-coercion.coerced)
+// CHECK: call void @llvm.lifetime.start.p0(i64 8, ptr %temp-coercion.coerced)
+func take(_ e: E) -> B {
+  switch e { case .p(let t): return t.0 }
+}

--- a/test/IRGen/coercion_temp_lifetime_size.swift
+++ b/test/IRGen/coercion_temp_lifetime_size.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swift-frontend -parse-stdlib -enable-builtin-module -emit-ir %s | %FileCheck %s
+
+// The temporary alloca created for NativeConventionSchema coercion
+// (irgen::allocateForCoercion) must emit its llvm.lifetime markers with a size
+// equal to the temporary's size in *bytes*, not in *bits*.
+//
+// The size was computed with DataLayout::getTypeSizeInBits() and then handed to
+// a byte-denominated `Size`, producing an 8x-oversized lifetime range (e.g. 64
+// for an 8-byte temporary). That is harmless in isolation, but once such a
+// coercion temporary is coalesced into an async coroutine frame by CoroSplit,
+// the oversized lifetime.end spans adjacent, still-live frame slots (such as a
+// spilled `self`). DSE then legally drops those live stores, miscompiling the
+// function (self reads back as zero). See rdar/GenCall.cpp allocateForCoercion.
+
+import Builtin
+
+struct B { var v: Builtin.Int8 }
+
+// An 8-byte value type whose ABI lowering coerces through memory to `{ i64 }`.
+enum E { case p((B, B, B, B, B, B, B, B)) }
+
+// CHECK-LABEL: define {{.*}} @"$s{{.*}}4take{{.*}}"
+// The coercion temporary is an 8-byte alloca...
+// CHECK: %temp-coercion.coerced = alloca { i64 }
+// ...so its lifetime marker must cover 8 bytes, not 64 (the size in bits).
+// CHECK-NOT: @llvm.lifetime.start.p0(i64 64, ptr %temp-coercion.coerced)
+// CHECK: call void @llvm.lifetime.start.p0(i64 8, ptr %temp-coercion.coerced)
+func take(_ e: E) -> B {
+  switch e { case .p(let t): return t.0 }
+}


### PR DESCRIPTION
rdar://184133455

allocateForCoercion computed the alloca lifetime size with getTypeSizeInBits (bits) but passed it to a byte-denominated Size, producing an 8x-oversized llvm.lifetime range. Once such a temporary is coalesced into an async coroutine frame, the oversized lifetime.end spuriously covers adjacent live frame slots (e.g. spilled self); DSE then legally deletes those live stores, miscompiling the function. Use getTypeAllocSize (bytes) instead.

Adds an IRGen FileCheck regression test.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
