### PR TITLE
[stdlib] Improve doc-comments for `extracting(...)` functions.

### DIFF
--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -1075,10 +1075,6 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
-  ///
   /// - Parameter maxLength: The maximum number of bytes to return.
   ///   `maxLength` must be greater than or equal to zero.
   /// - Returns: A span with at most `maxLength` bytes.
@@ -1105,10 +1101,6 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
-  ///
   /// - Parameter maxLength: The maximum number of bytes to return.
   ///   `maxLength` must be greater than or equal to zero.
   /// - Returns: A span with at most `maxLength` bytes.
@@ -1126,10 +1118,6 @@ extension MutableRawSpan {
   ///
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the bytes.
-  ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
   ///
   /// - Parameter maxLength: The maximum number of bytes to return.
   ///   `maxLength` must be greater than or equal to zero.
@@ -1155,10 +1143,6 @@ extension MutableRawSpan {
   /// the span, the result is an empty span.
   ///
   /// The returned span represents a mutation of this span.
-  ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
   ///
   /// - Parameter k: The number of bytes to drop off the end of
   ///   the span. `k` must be greater than or equal to zero.
@@ -1186,10 +1170,6 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
-  ///
   /// - Parameter k: The number of bytes to drop off the end of
   ///   the span. `k` must be greater than or equal to zero.
   /// - Returns: A span leaving off the specified number of bytes at the end.
@@ -1206,10 +1186,6 @@ extension MutableRawSpan {
   ///
   /// If the number of bytes to drop exceeds the number of bytes in
   /// the span, the result is an empty span.
-  ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
   ///
   /// - Parameter k: The number of bytes to drop off the end of
   ///   the span. `k` must be greater than or equal to zero.

--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -1125,7 +1125,7 @@ extension MutableRawSpan {
 #endif
   }
 
-  /// Returns a span over all but the given number of trailing bytes.
+  /// Returns a span over all but the specified number of trailing bytes.
   ///
   /// If the number of bytes to drop exceeds the number of bytes in
   /// the span, the result is an empty span.
@@ -1151,7 +1151,7 @@ extension MutableRawSpan {
 #endif
   }
 
-  /// Returns a span over all but the given number of trailing bytes.
+  /// Returns a span over all but the specified number of trailing bytes.
   ///
   /// If the number of bytes to drop exceeds the number of bytes in
   /// the span, the result is an empty span.
@@ -1170,7 +1170,7 @@ extension MutableRawSpan {
     _mutatingExtracting(droppingLast: k)
   }
 
-  /// Returns a span over all but the given number of trailing bytes.
+  /// Returns a span over all but the specified number of trailing bytes.
   ///
   /// If the number of bytes to drop exceeds the number of bytes in
   /// the span, the result is an empty span.
@@ -1194,8 +1194,8 @@ extension MutableRawSpan {
 #endif
   }
 
-  /// Returns a span containing the trailing bytes of the span,
-  /// up to the given maximum length.
+  /// Returns a span containing the trailing bytes of this span,
+  /// up to the specified maximum length.
   ///
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the bytes.
@@ -1225,8 +1225,8 @@ extension MutableRawSpan {
 #endif
   }
 
-  /// Returns a span containing the trailing bytes of the span,
-  /// up to the given maximum length.
+  /// Returns a span containing the trailing bytes of this span,
+  /// up to the specified maximum length.
   ///
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the bytes.
@@ -1249,8 +1249,8 @@ extension MutableRawSpan {
     _mutatingExtracting(last: maxLength)
   }
 
-  /// Returns a span containing the trailing bytes of the span,
-  /// up to the given maximum length.
+  /// Returns a span containing the trailing bytes of this span,
+  /// up to the specified maximum length.
   ///
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the bytes.
@@ -1278,7 +1278,7 @@ extension MutableRawSpan {
 #endif
   }
 
-  /// Returns a span over all but the given number of initial bytes.
+  /// Returns a span over all but the specified number of initial bytes.
   ///
   /// If the number of bytes to drop exceeds the number of bytes in
   /// the span, the result is an empty span.
@@ -1309,7 +1309,7 @@ extension MutableRawSpan {
 #endif
   }
 
-  /// Returns a span over all but the given number of initial bytes.
+  /// Returns a span over all but the specified number of initial bytes.
   ///
   /// If the number of bytes to drop exceeds the number of bytes in
   /// the span, the result is an empty span.
@@ -1332,7 +1332,7 @@ extension MutableRawSpan {
     _mutatingExtracting(droppingFirst: k)
   }
 
-  /// Returns a span over all but the given number of initial bytes.
+  /// Returns a span over all but the specified number of initial bytes.
   ///
   /// If the number of bytes to drop exceeds the number of bytes in
   /// the span, the result is an empty span.

--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -710,9 +710,8 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first byte is always at offset 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of positions. Every position in
   ///   this range must be within the bounds of this `MutableRawSpan`.
@@ -735,9 +734,8 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first byte is always at offset 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of positions. Every position in
   ///   this range must be within the bounds of this `MutableRawSpan`.
@@ -754,9 +752,8 @@ extension MutableRawSpan {
   /// Constructs a new span over the bytes within the supplied range of
   /// positions within this span.
   ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first byte is always at offset 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of positions. Every position in
   ///   this range must be within the bounds of this `MutableRawSpan`.
@@ -779,9 +776,8 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first byte is always at offset 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
@@ -804,9 +800,8 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first byte is always at offset 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
@@ -826,9 +821,8 @@ extension MutableRawSpan {
   /// Constructs a new span over the bytes within the supplied range of
   /// positions within this span.
   ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first byte is always at offset 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
@@ -851,9 +845,8 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first byte is always at offset 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of positions. Every position in
   ///   this range must be within the bounds of this `MutableRawSpan`.
@@ -873,9 +866,8 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first byte is always at offset 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of positions. Every position in
   ///   this range must be within the bounds of this `MutableRawSpan`.
@@ -894,9 +886,8 @@ extension MutableRawSpan {
   /// Constructs a new span over the bytes within the supplied range of
   /// positions within this span.
   ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first byte is always at offset 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of positions. Every position in
   ///   this range must be within the bounds of this `MutableRawSpan`.
@@ -916,9 +907,8 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first byte is always at offset 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
@@ -944,9 +934,8 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first byte is always at offset 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
@@ -968,9 +957,8 @@ extension MutableRawSpan {
   /// Constructs a new span over the bytes within the supplied range of
   /// positions within this span.
   ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first byte is always at offset 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
@@ -995,9 +983,8 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first byte is always at offset 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Returns: A `MutableRawSpan` over all the bytes of this span.
   ///
@@ -1020,9 +1007,8 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first byte is always at offset 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Returns: A `MutableRawSpan` over all the bytes of this span.
   ///
@@ -1036,9 +1022,8 @@ extension MutableRawSpan {
 
   /// Constructs a new span over all the bytes of this span.
   ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first byte is always at offset 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Returns: A `MutableRawSpan` over all the bytes of this span.
   ///
@@ -1202,9 +1187,8 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first byte is always at offset 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Parameter maxLength: The maximum number of bytes to return.
   ///   `maxLength` must be greater than or equal to zero.
@@ -1233,9 +1217,8 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first byte is always at offset 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Parameter maxLength: The maximum number of bytes to return.
   ///   `maxLength` must be greater than or equal to zero.
@@ -1255,9 +1238,8 @@ extension MutableRawSpan {
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the bytes.
   ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first byte is always at offset 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Parameter maxLength: The maximum number of bytes to return.
   ///   `maxLength` must be greater than or equal to zero.
@@ -1285,9 +1267,8 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first byte is always at offset 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Parameter k: The number of bytes to drop from the beginning of
   ///   the span. `k` must be greater than or equal to zero.
@@ -1316,9 +1297,8 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first byte is always at offset 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Parameter k: The number of bytes to drop from the beginning of
   ///   the span. `k` must be greater than or equal to zero.
@@ -1337,9 +1317,8 @@ extension MutableRawSpan {
   /// If the number of bytes to drop exceeds the number of bytes in
   /// the span, the result is an empty span.
   ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first byte is always at offset 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Parameter k: The number of bytes to drop from the beginning of
   ///   the span. `k` must be greater than or equal to zero.

--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -710,7 +710,7 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first byte is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -736,7 +736,7 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first byte is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -756,7 +756,7 @@ extension MutableRawSpan {
   /// Constructs a new span over the bytes within the supplied range of
   /// positions within this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first byte is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -782,7 +782,7 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first byte is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -808,7 +808,7 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first byte is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -831,7 +831,7 @@ extension MutableRawSpan {
   /// Constructs a new span over the bytes within the supplied range of
   /// positions within this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first byte is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -857,7 +857,7 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first byte is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -880,7 +880,7 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first byte is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -902,7 +902,7 @@ extension MutableRawSpan {
   /// Constructs a new span over the bytes within the supplied range of
   /// positions within this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first byte is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -925,7 +925,7 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first byte is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -954,7 +954,7 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first byte is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -979,7 +979,7 @@ extension MutableRawSpan {
   /// Constructs a new span over the bytes within the supplied range of
   /// positions within this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first byte is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -1007,7 +1007,7 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first byte is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -1032,7 +1032,7 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first byte is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -1048,7 +1048,7 @@ extension MutableRawSpan {
 
   /// Constructs a new span over all the bytes of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first byte is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -1075,7 +1075,7 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first byte is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -1105,7 +1105,7 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first byte is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -1127,7 +1127,7 @@ extension MutableRawSpan {
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the bytes.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first byte is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -1156,7 +1156,7 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first byte is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -1186,7 +1186,7 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first byte is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -1207,7 +1207,7 @@ extension MutableRawSpan {
   /// If the number of bytes to drop exceeds the number of bytes in
   /// the span, the result is an empty span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first byte is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -1238,7 +1238,7 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first byte is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -1269,7 +1269,7 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first byte is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -1291,7 +1291,7 @@ extension MutableRawSpan {
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the bytes.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first byte is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -1321,7 +1321,7 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first byte is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -1352,7 +1352,7 @@ extension MutableRawSpan {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first byte is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -1373,7 +1373,7 @@ extension MutableRawSpan {
   /// If the number of bytes to drop exceeds the number of bytes in
   /// the span, the result is an empty span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first byte is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///

--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -715,8 +715,7 @@ extension MutableRawSpan {
   /// span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of positions. Every position in
-  ///     this range must be within the bounds of this `MutableRawSpan`.
-  ///
+  ///   this range must be within the bounds of this `MutableRawSpan`.
   /// - Returns: A `MutableRawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -741,8 +740,7 @@ extension MutableRawSpan {
   /// span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of positions. Every position in
-  ///     this range must be within the bounds of this `MutableRawSpan`.
-  ///
+  ///   this range must be within the bounds of this `MutableRawSpan`.
   /// - Returns: A `MutableRawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -761,8 +759,7 @@ extension MutableRawSpan {
   /// span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of positions. Every position in
-  ///     this range must be within the bounds of this `MutableRawSpan`.
-  ///
+  ///   this range must be within the bounds of this `MutableRawSpan`.
   /// - Returns: A `MutableRawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -789,8 +786,7 @@ extension MutableRawSpan {
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
   /// - Parameter bounds: A valid range of positions. Every position in
-  ///     this range must be within the bounds of this `MutableRawSpan`.
-  ///
+  ///   this range must be within the bounds of this `MutableRawSpan`.
   /// - Returns: A `MutableRawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -815,8 +811,7 @@ extension MutableRawSpan {
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
   /// - Parameter bounds: A valid range of positions. Every position in
-  ///     this range must be within the bounds of this `MutableRawSpan`.
-  ///
+  ///   this range must be within the bounds of this `MutableRawSpan`.
   /// - Returns: A `MutableRawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -838,8 +833,7 @@ extension MutableRawSpan {
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
   /// - Parameter bounds: A valid range of positions. Every position in
-  ///     this range must be within the bounds of this `MutableRawSpan`.
-  ///
+  ///   this range must be within the bounds of this `MutableRawSpan`.
   /// - Returns: A `MutableRawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -862,8 +856,7 @@ extension MutableRawSpan {
   /// span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of positions. Every position in
-  ///     this range must be within the bounds of this `MutableRawSpan`.
-  ///
+  ///   this range must be within the bounds of this `MutableRawSpan`.
   /// - Returns: A `MutableRawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -885,8 +878,7 @@ extension MutableRawSpan {
   /// span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of positions. Every position in
-  ///     this range must be within the bounds of this `MutableRawSpan`.
-  ///
+  ///   this range must be within the bounds of this `MutableRawSpan`.
   /// - Returns: A `MutableRawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -907,8 +899,7 @@ extension MutableRawSpan {
   /// span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of positions. Every position in
-  ///     this range must be within the bounds of this `MutableRawSpan`.
-  ///
+  ///   this range must be within the bounds of this `MutableRawSpan`.
   /// - Returns: A `MutableRawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -932,8 +923,7 @@ extension MutableRawSpan {
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
   /// - Parameter bounds: A valid range of positions. Every position in
-  ///     this range must be within the bounds of this `MutableRawSpan`.
-  ///
+  ///   this range must be within the bounds of this `MutableRawSpan`.
   /// - Returns: A `MutableRawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -961,8 +951,7 @@ extension MutableRawSpan {
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
   /// - Parameter bounds: A valid range of positions. Every position in
-  ///     this range must be within the bounds of this `MutableRawSpan`.
-  ///
+  ///   this range must be within the bounds of this `MutableRawSpan`.
   /// - Returns: A `MutableRawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -986,8 +975,7 @@ extension MutableRawSpan {
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
   /// - Parameter bounds: A valid range of positions. Every position in
-  ///     this range must be within the bounds of this `MutableRawSpan`.
-  ///
+  ///   this range must be within the bounds of this `MutableRawSpan`.
   /// - Returns: A `MutableRawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)

--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -1134,7 +1134,7 @@ extension MutableRawSpan {
   ///
   /// - Parameter k: The number of bytes to drop off the end of
   ///   the span. `k` must be greater than or equal to zero.
-  /// - Returns: A span leaving off the specified number of bytes at the end.
+  /// - Returns: A span leaving off the specified number of trailing bytes.
   ///
   /// - Complexity: O(1)
   @export(implementation)
@@ -1160,7 +1160,7 @@ extension MutableRawSpan {
   ///
   /// - Parameter k: The number of bytes to drop off the end of
   ///   the span. `k` must be greater than or equal to zero.
-  /// - Returns: A span leaving off the specified number of bytes at the end.
+  /// - Returns: A span leaving off the specified number of trailing bytes.
   ///
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(droppingLast:)")
@@ -1177,7 +1177,7 @@ extension MutableRawSpan {
   ///
   /// - Parameter k: The number of bytes to drop off the end of
   ///   the span. `k` must be greater than or equal to zero.
-  /// - Returns: A span leaving off the specified number of bytes at the end.
+  /// - Returns: A span leaving off the specified number of trailing bytes.
   ///
   /// - Complexity: O(1)
   @export(implementation)

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -646,8 +646,7 @@ extension MutableSpan where Element: ~Copyable {
   /// span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of indices. Every index in
-  ///     this range must be within the bounds of this `MutableSpan`.
-  ///
+  ///   this range must be within the bounds of this `MutableSpan`.
   /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -672,8 +671,7 @@ extension MutableSpan where Element: ~Copyable {
   /// span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of indices. Every index in
-  ///     this range must be within the bounds of this `MutableSpan`.
-  ///
+  ///   this range must be within the bounds of this `MutableSpan`.
   /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -692,8 +690,7 @@ extension MutableSpan where Element: ~Copyable {
   /// span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of indices. Every index in
-  ///     this range must be within the bounds of this `MutableSpan`.
-  ///
+  ///   this range must be within the bounds of this `MutableSpan`.
   /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -720,8 +717,7 @@ extension MutableSpan where Element: ~Copyable {
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
   /// - Parameter bounds: A valid range of indices. Every index in
-  ///     this range must be within the bounds of this `MutableSpan`.
-  ///
+  ///   this range must be within the bounds of this `MutableSpan`.
   /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -747,8 +743,7 @@ extension MutableSpan where Element: ~Copyable {
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
   /// - Parameter bounds: A valid range of indices. Every index in
-  ///     this range must be within the bounds of this `MutableSpan`.
-  ///
+  ///   this range must be within the bounds of this `MutableSpan`.
   /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -770,8 +765,7 @@ extension MutableSpan where Element: ~Copyable {
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
   /// - Parameter bounds: A valid range of indices. Every index in
-  ///     this range must be within the bounds of this `MutableSpan`.
-  ///
+  ///   this range must be within the bounds of this `MutableSpan`.
   /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -795,8 +789,7 @@ extension MutableSpan where Element: ~Copyable {
   /// span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of indices. Every index in
-  ///     this range must be within the bounds of this `MutableSpan`.
-  ///
+  ///   this range must be within the bounds of this `MutableSpan`.
   /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -818,8 +811,7 @@ extension MutableSpan where Element: ~Copyable {
   /// span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of indices. Every index in
-  ///     this range must be within the bounds of this `MutableSpan`.
-  ///
+  ///   this range must be within the bounds of this `MutableSpan`.
   /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -840,8 +832,7 @@ extension MutableSpan where Element: ~Copyable {
   /// span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of indices. Every index in
-  ///     this range must be within the bounds of this `MutableSpan`.
-  ///
+  ///   this range must be within the bounds of this `MutableSpan`.
   /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -865,8 +856,7 @@ extension MutableSpan where Element: ~Copyable {
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
   /// - Parameter bounds: A valid range of indices. Every index in
-  ///     this range must be within the bounds of this `MutableSpan`.
-  ///
+  ///   this range must be within the bounds of this `MutableSpan`.
   /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -894,8 +884,7 @@ extension MutableSpan where Element: ~Copyable {
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
   /// - Parameter bounds: A valid range of indices. Every index in
-  ///     this range must be within the bounds of this `MutableSpan`.
-  ///
+  ///   this range must be within the bounds of this `MutableSpan`.
   /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -919,8 +908,7 @@ extension MutableSpan where Element: ~Copyable {
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
   /// - Parameter bounds: A valid range of indices. Every index in
-  ///     this range must be within the bounds of this `MutableSpan`.
-  ///
+  ///   this range must be within the bounds of this `MutableSpan`.
   /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -636,19 +636,19 @@ extension MutableSpan {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableSpan where Element: ~Copyable {
 
-  /// Constructs a new span over the items within the supplied range of
+  /// Constructs a new span over the elements within the supplied range of
   /// indices within this span.
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at index 0; unlike buffer
+  /// The returned span's first element is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `MutableSpan`.
   ///
-  /// - Returns: A `MutableSpan` over the items within `bounds`.
+  /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
   @export(implementation)
@@ -662,19 +662,19 @@ extension MutableSpan where Element: ~Copyable {
     return unsafe _mutatingExtracting(unchecked: bounds)
   }
 
-  /// Constructs a new span over the items within the supplied range of
+  /// Constructs a new span over the elements within the supplied range of
   /// indices within this span.
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at index 0; unlike buffer
+  /// The returned span's first element is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `MutableSpan`.
   ///
-  /// - Returns: A `MutableSpan` over the items within `bounds`.
+  /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(_:)")
@@ -684,17 +684,17 @@ extension MutableSpan where Element: ~Copyable {
     _mutatingExtracting(bounds)
   }
 
-  /// Constructs a new span over the items within the supplied range of
+  /// Constructs a new span over the elements within the supplied range of
   /// indices within this span.
   ///
-  /// The returned span's first item is always at index 0; unlike buffer
+  /// The returned span's first element is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `MutableSpan`.
   ///
-  /// - Returns: A `MutableSpan` over the items within `bounds`.
+  /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
   @export(implementation)
@@ -708,12 +708,12 @@ extension MutableSpan where Element: ~Copyable {
     return unsafe _consumingExtracting(unchecked: bounds)
   }
 
-  /// Constructs a new span over the items within the supplied range of
+  /// Constructs a new span over the elements within the supplied range of
   /// indices within this span.
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at index 0; unlike buffer
+  /// The returned span's first element is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -722,7 +722,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `MutableSpan`.
   ///
-  /// - Returns: A `MutableSpan` over the items within `bounds`.
+  /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
   @unsafe
@@ -735,12 +735,12 @@ extension MutableSpan where Element: ~Copyable {
     return unsafe _overrideLifetime(newSpan, mutating: &self)
   }
 
-  /// Constructs a new span over the items within the supplied range of
+  /// Constructs a new span over the elements within the supplied range of
   /// indices within this span.
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at index 0; unlike buffer
+  /// The returned span's first element is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -749,7 +749,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `MutableSpan`.
   ///
-  /// - Returns: A `MutableSpan` over the items within `bounds`.
+  /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
   @unsafe
@@ -760,10 +760,10 @@ extension MutableSpan where Element: ~Copyable {
     unsafe _mutatingExtracting(unchecked: bounds)
   }
 
-  /// Constructs a new span over the items within the supplied range of
+  /// Constructs a new span over the elements within the supplied range of
   /// indices within this span.
   ///
-  /// The returned span's first item is always at index 0; unlike buffer
+  /// The returned span's first element is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -772,7 +772,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `MutableSpan`.
   ///
-  /// - Returns: A `MutableSpan` over the items within `bounds`.
+  /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
   @unsafe
@@ -785,19 +785,19 @@ extension MutableSpan where Element: ~Copyable {
     return unsafe _overrideLifetime(newSpan, copying: self)
   }
 
-  /// Constructs a new span over the items within the supplied range of
+  /// Constructs a new span over the elements within the supplied range of
   /// indices within this span.
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at index 0; unlike buffer
+  /// The returned span's first element is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `MutableSpan`.
   ///
-  /// - Returns: A `MutableSpan` over the items within `bounds`.
+  /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
   @export(implementation)
@@ -808,19 +808,19 @@ extension MutableSpan where Element: ~Copyable {
     _mutatingExtracting(bounds.relative(to: indices))
   }
 
-  /// Constructs a new span over the items within the supplied range of
+  /// Constructs a new span over the elements within the supplied range of
   /// indices within this span.
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at index 0; unlike buffer
+  /// The returned span's first element is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `MutableSpan`.
   ///
-  /// - Returns: A `MutableSpan` over the items within `bounds`.
+  /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(_:)")
@@ -832,17 +832,17 @@ extension MutableSpan where Element: ~Copyable {
     _mutatingExtracting(bounds)
   }
 
-  /// Constructs a new span over the items within the supplied range of
+  /// Constructs a new span over the elements within the supplied range of
   /// indices within this span.
   ///
-  /// The returned span's first item is always at index 0; unlike buffer
+  /// The returned span's first element is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `MutableSpan`.
   ///
-  /// - Returns: A `MutableSpan` over the items within `bounds`.
+  /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
   @export(implementation)
@@ -853,12 +853,12 @@ extension MutableSpan where Element: ~Copyable {
     _consumingExtracting(bounds.relative(to: indices))
   }
 
-  /// Constructs a new span over the items within the supplied range of
+  /// Constructs a new span over the elements within the supplied range of
   /// indices within this span.
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at index 0; unlike buffer
+  /// The returned span's first element is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -867,7 +867,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `MutableSpan`.
   ///
-  /// - Returns: A `MutableSpan` over the items within `bounds`.
+  /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
   @unsafe
@@ -882,12 +882,12 @@ extension MutableSpan where Element: ~Copyable {
     return unsafe _mutatingExtracting(unchecked: range)
   }
 
-  /// Constructs a new span over the items within the supplied range of
+  /// Constructs a new span over the elements within the supplied range of
   /// indices within this span.
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at index 0; unlike buffer
+  /// The returned span's first element is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -896,7 +896,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `MutableSpan`.
   ///
-  /// - Returns: A `MutableSpan` over the items within `bounds`.
+  /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
   @unsafe
@@ -909,10 +909,10 @@ extension MutableSpan where Element: ~Copyable {
     unsafe _mutatingExtracting(unchecked: bounds)
   }
 
-  /// Constructs a new span over the items within the supplied range of
+  /// Constructs a new span over the elements within the supplied range of
   /// indices within this span.
   ///
-  /// The returned span's first item is always at index 0; unlike buffer
+  /// The returned span's first element is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -921,7 +921,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `MutableSpan`.
   ///
-  /// - Returns: A `MutableSpan` over the items within `bounds`.
+  /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
   @unsafe
@@ -936,15 +936,15 @@ extension MutableSpan where Element: ~Copyable {
     return unsafe _consumingExtracting(unchecked: range)
   }
 
-  /// Constructs a new span over all the items of this span.
+  /// Constructs a new span over all the elements of this span.
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at index 0; unlike buffer
+  /// The returned span's first element is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Returns: A `MutableSpan` over all the items of this span.
+  /// - Returns: A `MutableSpan` over all the elements of this span.
   ///
   /// - Complexity: O(1)
   @export(implementation)
@@ -961,15 +961,15 @@ extension MutableSpan where Element: ~Copyable {
     mutating get { _mutatingExtracting(...) }
   }
 
-  /// Constructs a new span over all the items of this span.
+  /// Constructs a new span over all the elements of this span.
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at index 0; unlike buffer
+  /// The returned span's first element is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Returns: A `MutableSpan` over all the items of this span.
+  /// - Returns: A `MutableSpan` over all the elements of this span.
   ///
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(_:)")
@@ -979,13 +979,13 @@ extension MutableSpan where Element: ~Copyable {
     _mutatingExtracting(...)
   }
 
-  /// Constructs a new span over all the items of this span.
+  /// Constructs a new span over all the elements of this span.
   ///
-  /// The returned span's first item is always at index 0; unlike buffer
+  /// The returned span's first element is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Returns: A `MutableSpan` over all the items of this span.
+  /// - Returns: A `MutableSpan` over all the elements of this span.
   ///
   /// - Complexity: O(1)
   @export(implementation)
@@ -1147,7 +1147,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at index 0; unlike buffer
+  /// The returned span's first element is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -1179,7 +1179,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at index 0; unlike buffer
+  /// The returned span's first element is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -1201,7 +1201,7 @@ extension MutableSpan where Element: ~Copyable {
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the elements.
   ///
-  /// The returned span's first item is always at index 0; unlike buffer
+  /// The returned span's first element is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -1232,7 +1232,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at index 0; unlike buffer
+  /// The returned span's first element is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -1264,7 +1264,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at index 0; unlike buffer
+  /// The returned span's first element is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -1285,7 +1285,7 @@ extension MutableSpan where Element: ~Copyable {
   /// If the number of elements to drop exceeds the number of elements in
   /// the span, the result is an empty span.
   ///
-  /// The returned span's first item is always at index 0; unlike buffer
+  /// The returned span's first element is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -645,8 +645,8 @@ extension MutableSpan where Element: ~Copyable {
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Parameter bounds: A valid range of indices. Every index in
-  ///   this range must be within the bounds of this `MutableSpan`.
+  /// - Parameter bounds: A valid range of indices. Every index in this range
+  ///   must be within the bounds of this `MutableSpan`.
   /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -670,8 +670,8 @@ extension MutableSpan where Element: ~Copyable {
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Parameter bounds: A valid range of indices. Every index in
-  ///   this range must be within the bounds of this `MutableSpan`.
+  /// - Parameter bounds: A valid range of indices. Every index in this range
+  ///   must be within the bounds of this `MutableSpan`.
   /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -689,8 +689,8 @@ extension MutableSpan where Element: ~Copyable {
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Parameter bounds: A valid range of indices. Every index in
-  ///   this range must be within the bounds of this `MutableSpan`.
+  /// - Parameter bounds: A valid range of indices. Every index in this range
+  ///   must be within the bounds of this `MutableSpan`.
   /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -716,8 +716,8 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
-  /// - Parameter bounds: A valid range of indices. Every index in
-  ///   this range must be within the bounds of this `MutableSpan`.
+  /// - Parameter bounds: A valid range of indices. Every index in this range
+  ///   must be within the bounds of this `MutableSpan`.
   /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -742,8 +742,8 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
-  /// - Parameter bounds: A valid range of indices. Every index in
-  ///   this range must be within the bounds of this `MutableSpan`.
+  /// - Parameter bounds: A valid range of indices. Every index in this range
+  ///   must be within the bounds of this `MutableSpan`.
   /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -764,8 +764,8 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
-  /// - Parameter bounds: A valid range of indices. Every index in
-  ///   this range must be within the bounds of this `MutableSpan`.
+  /// - Parameter bounds: A valid range of indices. Every index in this range
+  ///   must be within the bounds of this `MutableSpan`.
   /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -788,8 +788,8 @@ extension MutableSpan where Element: ~Copyable {
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Parameter bounds: A valid range of indices. Every index in
-  ///   this range must be within the bounds of this `MutableSpan`.
+  /// - Parameter bounds: A valid range of indices. Every index in this range
+  ///   must be within the bounds of this `MutableSpan`.
   /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -810,8 +810,8 @@ extension MutableSpan where Element: ~Copyable {
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Parameter bounds: A valid range of indices. Every index in
-  ///   this range must be within the bounds of this `MutableSpan`.
+  /// - Parameter bounds: A valid range of indices. Every index in this range
+  ///   must be within the bounds of this `MutableSpan`.
   /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -831,8 +831,8 @@ extension MutableSpan where Element: ~Copyable {
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Parameter bounds: A valid range of indices. Every index in
-  ///   this range must be within the bounds of this `MutableSpan`.
+  /// - Parameter bounds: A valid range of indices. Every index in this range
+  ///   must be within the bounds of this `MutableSpan`.
   /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -855,8 +855,8 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
-  /// - Parameter bounds: A valid range of indices. Every index in
-  ///   this range must be within the bounds of this `MutableSpan`.
+  /// - Parameter bounds: A valid range of indices. Every index in this range
+  ///   must be within the bounds of this `MutableSpan`.
   /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -883,8 +883,8 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
-  /// - Parameter bounds: A valid range of indices. Every index in
-  ///   this range must be within the bounds of this `MutableSpan`.
+  /// - Parameter bounds: A valid range of indices. Every index in this range
+  ///   must be within the bounds of this `MutableSpan`.
   /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -907,8 +907,8 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
-  /// - Parameter bounds: A valid range of indices. Every index in
-  ///   this range must be within the bounds of this `MutableSpan`.
+  /// - Parameter bounds: A valid range of indices. Every index in this range
+  ///   must be within the bounds of this `MutableSpan`.
   /// - Returns: A `MutableSpan` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -641,7 +641,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first item is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -667,7 +667,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first item is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -687,7 +687,7 @@ extension MutableSpan where Element: ~Copyable {
   /// Constructs a new span over the items within the supplied range of
   /// indices within this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first item is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -713,7 +713,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first item is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -740,7 +740,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first item is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -763,7 +763,7 @@ extension MutableSpan where Element: ~Copyable {
   /// Constructs a new span over the items within the supplied range of
   /// indices within this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first item is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -790,7 +790,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first item is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -813,7 +813,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first item is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -835,7 +835,7 @@ extension MutableSpan where Element: ~Copyable {
   /// Constructs a new span over the items within the supplied range of
   /// indices within this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first item is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -858,7 +858,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first item is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -887,7 +887,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first item is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -912,7 +912,7 @@ extension MutableSpan where Element: ~Copyable {
   /// Constructs a new span over the items within the supplied range of
   /// indices within this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first item is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -940,7 +940,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first item is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -965,7 +965,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first item is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -981,7 +981,7 @@ extension MutableSpan where Element: ~Copyable {
 
   /// Constructs a new span over all the items of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first item is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -1147,7 +1147,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first item is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -1179,7 +1179,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first item is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -1201,7 +1201,7 @@ extension MutableSpan where Element: ~Copyable {
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the elements.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first item is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -1232,7 +1232,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first item is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -1264,7 +1264,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first item is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -1285,7 +1285,7 @@ extension MutableSpan where Element: ~Copyable {
   /// If the number of elements to drop exceeds the number of elements in
   /// the span, the result is an empty span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first item is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -641,9 +641,8 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first element is always at index 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first element is always at index 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of indices. Every index in this range
   ///   must be within the bounds of this `MutableSpan`.
@@ -666,9 +665,8 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first element is always at index 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first element is always at index 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of indices. Every index in this range
   ///   must be within the bounds of this `MutableSpan`.
@@ -685,9 +683,8 @@ extension MutableSpan where Element: ~Copyable {
   /// Constructs a new span over the elements within the supplied range of
   /// indices within this span.
   ///
-  /// The returned span's first element is always at index 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first element is always at index 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of indices. Every index in this range
   ///   must be within the bounds of this `MutableSpan`.
@@ -710,9 +707,8 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first element is always at index 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first element is always at index 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
@@ -736,9 +732,8 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first element is always at index 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first element is always at index 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
@@ -758,9 +753,8 @@ extension MutableSpan where Element: ~Copyable {
   /// Constructs a new span over the elements within the supplied range of
   /// indices within this span.
   ///
-  /// The returned span's first element is always at index 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first element is always at index 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
@@ -784,9 +778,8 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first element is always at index 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first element is always at index 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of indices. Every index in this range
   ///   must be within the bounds of this `MutableSpan`.
@@ -806,9 +799,8 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first element is always at index 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first element is always at index 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of indices. Every index in this range
   ///   must be within the bounds of this `MutableSpan`.
@@ -827,9 +819,8 @@ extension MutableSpan where Element: ~Copyable {
   /// Constructs a new span over the elements within the supplied range of
   /// indices within this span.
   ///
-  /// The returned span's first element is always at index 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first element is always at index 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of indices. Every index in this range
   ///   must be within the bounds of this `MutableSpan`.
@@ -849,9 +840,8 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first element is always at index 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first element is always at index 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
@@ -877,9 +867,8 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first element is always at index 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first element is always at index 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
@@ -901,9 +890,8 @@ extension MutableSpan where Element: ~Copyable {
   /// Constructs a new span over the elements within the supplied range of
   /// indices within this span.
   ///
-  /// The returned span's first element is always at index 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first element is always at index 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
@@ -928,9 +916,8 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first element is always at index 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first element is always at index 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Returns: A `MutableSpan` over all the elements of this span.
   ///
@@ -953,9 +940,8 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first element is always at index 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first element is always at index 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Returns: A `MutableSpan` over all the elements of this span.
   ///
@@ -969,9 +955,8 @@ extension MutableSpan where Element: ~Copyable {
 
   /// Constructs a new span over all the elements of this span.
   ///
-  /// The returned span's first element is always at index 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first element is always at index 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Returns: A `MutableSpan` over all the elements of this span.
   ///
@@ -1135,9 +1120,8 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first element is always at index 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first element is always at index 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Parameter maxLength: The maximum number of elements to return.
   ///   `maxLength` must be greater than or equal to zero.
@@ -1167,9 +1151,8 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first element is always at index 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first element is always at index 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Parameter maxLength: The maximum number of elements to return.
   ///   `maxLength` must be greater than or equal to zero.
@@ -1189,9 +1172,8 @@ extension MutableSpan where Element: ~Copyable {
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the elements.
   ///
-  /// The returned span's first element is always at index 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first element is always at index 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Parameter maxLength: The maximum number of elements to return.
   ///   `maxLength` must be greater than or equal to zero.
@@ -1220,9 +1202,8 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first element is always at index 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first element is always at index 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Parameter k: The number of elements to drop from the beginning of
   ///   the span. `k` must be greater than or equal to zero.
@@ -1252,9 +1233,8 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first element is always at index 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first element is always at index 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Parameter k: The number of elements to drop from the beginning of
   ///   the span. `k` must be greater than or equal to zero.
@@ -1273,9 +1253,8 @@ extension MutableSpan where Element: ~Copyable {
   /// If the number of elements to drop exceeds the number of elements in
   /// the span, the result is an empty span.
   ///
-  /// The returned span's first element is always at index 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first element is always at index 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Parameter k: The number of elements to drop from the beginning of
   ///   the span. `k` must be greater than or equal to zero.

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -1058,7 +1058,7 @@ extension MutableSpan where Element: ~Copyable {
 #endif
   }
 
-  /// Returns a span over all but the given number of trailing elements.
+  /// Returns a span over all but the specified number of trailing elements.
   ///
   /// If the number of elements to drop exceeds the number of elements in
   /// the span, the result is an empty span.
@@ -1084,7 +1084,7 @@ extension MutableSpan where Element: ~Copyable {
 #endif
   }
 
-  /// Returns a span over all but the given number of trailing elements.
+  /// Returns a span over all but the specified number of trailing elements.
   ///
   /// If the number of elements to drop exceeds the number of elements in
   /// the span, the result is an empty span.
@@ -1103,7 +1103,7 @@ extension MutableSpan where Element: ~Copyable {
     _mutatingExtracting(droppingLast: k)
   }
 
-  /// Returns a span over all but the given number of trailing elements.
+  /// Returns a span over all but the specified number of trailing elements.
   ///
   /// If the number of elements to drop exceeds the number of elements in
   /// the span, the result is an empty span.
@@ -1127,8 +1127,8 @@ extension MutableSpan where Element: ~Copyable {
 #endif
   }
 
-  /// Returns a span containing the trailing elements of the span,
-  /// up to the given maximum length.
+  /// Returns a span containing the trailing elements of this span,
+  /// up to the specified maximum length.
   ///
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the elements.
@@ -1159,8 +1159,8 @@ extension MutableSpan where Element: ~Copyable {
 #endif
   }
 
-  /// Returns a span containing the trailing elements of the span,
-  /// up to the given maximum length.
+  /// Returns a span containing the trailing elements of this span,
+  /// up to the specified maximum length.
   ///
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the elements.
@@ -1183,8 +1183,8 @@ extension MutableSpan where Element: ~Copyable {
     _mutatingExtracting(last: maxLength)
   }
 
-  /// Returns a span containing the trailing elements of the span,
-  /// up to the given maximum length.
+  /// Returns a span containing the trailing elements of this span,
+  /// up to the specified maximum length.
   ///
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the elements.
@@ -1213,7 +1213,7 @@ extension MutableSpan where Element: ~Copyable {
 #endif
   }
 
-  /// Returns a span over all but the given number of initial elements.
+  /// Returns a span over all but the specified number of initial elements.
   ///
   /// If the number of elements to drop exceeds the number of elements in
   /// the span, the result is an empty span.
@@ -1245,7 +1245,7 @@ extension MutableSpan where Element: ~Copyable {
 #endif
   }
 
-  /// Returns a span over all but the given number of initial elements.
+  /// Returns a span over all but the specified number of initial elements.
   ///
   /// If the number of elements to drop exceeds the number of elements in
   /// the span, the result is an empty span.
@@ -1268,7 +1268,7 @@ extension MutableSpan where Element: ~Copyable {
     _mutatingExtracting(droppingFirst: k)
   }
 
-  /// Returns a span over all but the given number of initial elements.
+  /// Returns a span over all but the specified number of initial elements.
   ///
   /// If the number of elements to drop exceeds the number of elements in
   /// the span, the result is an empty span.

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -1067,7 +1067,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Parameter k: The number of elements to drop off the end of
   ///   the span. `k` must be greater than or equal to zero.
-  /// - Returns: A span leaving off the specified number of elements at the end.
+  /// - Returns: A span leaving off the specified number of trailing elements.
   ///
   /// - Complexity: O(1)
   @export(implementation)
@@ -1093,7 +1093,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Parameter k: The number of elements to drop off the end of
   ///   the span. `k` must be greater than or equal to zero.
-  /// - Returns: A span leaving off the specified number of elements at the end.
+  /// - Returns: A span leaving off the specified number of trailing elements.
   ///
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(droppingLast:)")
@@ -1110,7 +1110,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Parameter k: The number of elements to drop off the end of
   ///   the span. `k` must be greater than or equal to zero.
-  /// - Returns: A span leaving off the specified number of elements at the end.
+  /// - Returns: A span leaving off the specified number of trailing elements.
   ///
   /// - Complexity: O(1)
   @export(implementation)

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -1008,10 +1008,6 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
-  ///
   /// - Parameter maxLength: The maximum number of elements to return.
   ///   `maxLength` must be greater than or equal to zero.
   /// - Returns: A span with at most `maxLength` elements.
@@ -1038,10 +1034,6 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
-  ///
   /// - Parameter maxLength: The maximum number of elements to return.
   ///   `maxLength` must be greater than or equal to zero.
   /// - Returns: A span with at most `maxLength` elements.
@@ -1059,10 +1051,6 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the elements.
-  ///
-  /// The returned span's first item is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
   ///
   /// - Parameter maxLength: The maximum number of elements to return.
   ///   `maxLength` must be greater than or equal to zero.
@@ -1088,10 +1076,6 @@ extension MutableSpan where Element: ~Copyable {
   /// the span, the result is an empty span.
   ///
   /// The returned span represents a mutation of this span.
-  ///
-  /// The returned span's first item is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
   ///
   /// - Parameter k: The number of elements to drop off the end of
   ///   the span. `k` must be greater than or equal to zero.
@@ -1119,10 +1103,6 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The returned span represents a mutation of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
-  ///
   /// - Parameter k: The number of elements to drop off the end of
   ///   the span. `k` must be greater than or equal to zero.
   /// - Returns: A span leaving off the specified number of elements at the end.
@@ -1139,10 +1119,6 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// If the number of elements to drop exceeds the number of elements in
   /// the span, the result is an empty span.
-  ///
-  /// The returned span's first item is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
   ///
   /// - Parameter k: The number of elements to drop off the end of
   ///   the span. `k` must be greater than or equal to zero.

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -882,7 +882,7 @@ extension RawSpan {
     extracting(first: maxLength)
   }
 
-  /// Returns a span over all but the given number of trailing bytes.
+  /// Returns a span over all but the specified number of trailing bytes.
   ///
   /// If the number of bytes to drop exceeds the number of bytes in
   /// the span, the result is an empty span.
@@ -909,8 +909,8 @@ extension RawSpan {
     extracting(droppingLast: k)
   }
 
-  /// Returns a span containing the trailing bytes of the span,
-  /// up to the given maximum length.
+  /// Returns a span containing the trailing bytes of this span,
+  /// up to the specified maximum length.
   ///
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the bytes.
@@ -943,7 +943,7 @@ extension RawSpan {
     extracting(last: maxLength)
   }
 
-  /// Returns a span over all but the given number of initial bytes.
+  /// Returns a span over all but the specified number of initial bytes.
   ///
   /// If the number of bytes to drop exceeds the number of bytes in
   /// the span, the result is an empty span.

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -865,10 +865,6 @@ extension RawSpan {
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the bytes.
   ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
-  ///
   /// - Parameter maxLength: The maximum number of bytes to return.
   ///   `maxLength` must be greater than or equal to zero.
   /// - Returns: A span with at most `maxLength` bytes.
@@ -894,10 +890,6 @@ extension RawSpan {
   ///
   /// If the number of bytes to drop exceeds the number of bytes in
   /// the span, the result is an empty span.
-  ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
   ///
   /// - Parameter k: The number of bytes to drop off the end of
   ///   the span. `k` must be greater than or equal to zero.

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -437,8 +437,7 @@ extension RawSpan {
   /// span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of positions. Every position in
-  ///     this range must be within the bounds of this `RawSpan`.
-  ///
+  ///   this range must be within the bounds of this `RawSpan`.
   /// - Returns: A `RawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -470,8 +469,7 @@ extension RawSpan {
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
   /// - Parameter bounds: A valid range of positions. Every position in
-  ///     this range must be within the bounds of this `RawSpan`.
-  ///
+  ///   this range must be within the bounds of this `RawSpan`.
   /// - Returns: A `RawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -500,8 +498,7 @@ extension RawSpan {
   /// span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of positions. Every position in
-  ///     this range must be within the bounds of this `RawSpan`.
-  ///
+  ///   this range must be within the bounds of this `RawSpan`.
   /// - Returns: A `RawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -528,8 +525,7 @@ extension RawSpan {
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
   /// - Parameter bounds: A valid range of positions. Every position in
-  ///     this range must be within the bounds of this `RawSpan`.
-  ///
+  ///   this range must be within the bounds of this `RawSpan`.
   /// - Returns: A `RawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -889,7 +889,7 @@ extension RawSpan {
   ///
   /// - Parameter k: The number of bytes to drop off the end of
   ///   the span. `k` must be greater than or equal to zero.
-  /// - Returns: A span leaving off the specified number of bytes at the end.
+  /// - Returns: A span leaving off the specified number of trailing bytes.
   ///
   /// - Complexity: O(1)
   @export(implementation)

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -432,9 +432,8 @@ extension RawSpan {
   /// Constructs a new span over the bytes within the supplied range of
   /// positions within this span.
   ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first byte is always at offset 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of positions. Every position in
   ///   this range must be within the bounds of this `RawSpan`.
@@ -462,9 +461,8 @@ extension RawSpan {
   /// Constructs a new span over the bytes within the supplied range of
   /// positions within this span.
   ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first byte is always at offset 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
@@ -493,9 +491,8 @@ extension RawSpan {
   /// Constructs a new span over the bytes within the supplied range of
   /// positions within this span.
   ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first byte is always at offset 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of positions. Every position in
   ///   this range must be within the bounds of this `RawSpan`.
@@ -518,9 +515,8 @@ extension RawSpan {
   /// Constructs a new span over the bytes within the supplied range of
   /// positions within this span.
   ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first byte is always at offset 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
@@ -551,9 +547,8 @@ extension RawSpan {
 
   /// Constructs a new span over all the bytes of this span.
   ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first byte is always at offset 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Returns: A `RawSpan` over all the bytes of this span.
   ///
@@ -915,9 +910,8 @@ extension RawSpan {
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the bytes.
   ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first byte is always at offset 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Parameter maxLength: The maximum number of bytes to return.
   ///   `maxLength` must be greater than or equal to zero.
@@ -948,9 +942,8 @@ extension RawSpan {
   /// If the number of bytes to drop exceeds the number of bytes in
   /// the span, the result is an empty span.
   ///
-  /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first byte is always at offset 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Parameter k: The number of bytes to drop from the beginning of
   ///   the span. `k` must be greater than or equal to zero.

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -875,7 +875,7 @@ extension Span where Element: ~Copyable {
     extracting(first: maxLength)
   }
 
-  /// Returns a span over all but the given number of trailing elements.
+  /// Returns a span over all but the specified number of trailing elements.
   ///
   /// If the number of elements to drop exceeds the number of elements in
   /// the span, the result is an empty span.
@@ -901,8 +901,8 @@ extension Span where Element: ~Copyable {
     extracting(droppingLast: k)
   }
 
-  /// Returns a span containing the trailing elements of the span,
-  /// up to the given maximum length.
+  /// Returns a span containing the trailing elements of this span,
+  /// up to the specified maximum length.
   ///
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the elements.
@@ -936,7 +936,7 @@ extension Span where Element: ~Copyable {
     extracting(last: maxLength)
   }
 
-  /// Returns a span over all but the given number of initial elements.
+  /// Returns a span over all but the specified number of initial elements.
   ///
   /// If the number of elements to drop exceeds the number of elements in
   /// the span, the result is an empty span.

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -574,9 +574,8 @@ extension Span where Element: ~Copyable {
   /// Constructs a new span over the elements within the supplied range of
   /// indices within this span.
   ///
-  /// The returned span's first element is always at index 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first element is always at index 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of indices. Every index in this range
   ///   must be within the bounds of this `Span`.
@@ -604,9 +603,8 @@ extension Span where Element: ~Copyable {
   /// Constructs a new span over the elements within the supplied range of
   /// indices within this span.
   ///
-  /// The returned span's first element is always at index 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first element is always at index 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
@@ -638,9 +636,8 @@ extension Span where Element: ~Copyable {
   /// Constructs a new span over the elements within the supplied range of
   /// indices within this span.
   ///
-  /// The returned span's first element is always at index 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first element is always at index 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of indices. Every index in this range
   ///   must be within the bounds of this `Span`.
@@ -665,9 +662,8 @@ extension Span where Element: ~Copyable {
   /// Constructs a new span over the elements within the supplied range of
   /// indices within this span.
   ///
-  /// The returned span's first element is always at index 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first element is always at index 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
@@ -698,9 +694,8 @@ extension Span where Element: ~Copyable {
 
   /// Constructs a new span over all the elements of this span.
   ///
-  /// The returned span's first element is always at index 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first element is always at index 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Returns: A `Span` over all the elements of this span.
   ///
@@ -907,9 +902,8 @@ extension Span where Element: ~Copyable {
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the elements.
   ///
-  /// The returned span's first element is always at index 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first element is always at index 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Parameter maxLength: The maximum number of elements to return.
   ///   `maxLength` must be greater than or equal to zero.
@@ -941,9 +935,8 @@ extension Span where Element: ~Copyable {
   /// If the number of elements to drop exceeds the number of elements in
   /// the span, the result is an empty span.
   ///
-  /// The returned span's first element is always at index 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
+  /// The returned span's first element is always at index 0. Extracted spans
+  /// do not share their indices with the span from which they are extracted.
   ///
   /// - Parameter k: The number of elements to drop from the beginning of
   ///   the span. `k` must be greater than or equal to zero.

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -579,8 +579,7 @@ extension Span where Element: ~Copyable {
   /// span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of indices. Every index in
-  ///     this range must be within the bounds of this `Span`.
-  ///
+  ///   this range must be within the bounds of this `Span`.
   /// - Returns: A `Span` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -612,8 +611,7 @@ extension Span where Element: ~Copyable {
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
   /// - Parameter bounds: A valid range of indices. Every index in
-  ///     this range must be within the bounds of this `Span`.
-  ///
+  ///   this range must be within the bounds of this `Span`.
   /// - Returns: A `Span` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -645,8 +643,7 @@ extension Span where Element: ~Copyable {
   /// span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of indices. Every index in
-  ///     this range must be within the bounds of this `Span`.
-  ///
+  ///   this range must be within the bounds of this `Span`.
   /// - Returns: A `Span` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -675,8 +672,7 @@ extension Span where Element: ~Copyable {
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
   /// - Parameter bounds: A valid range of indices. Every index in
-  ///     this range must be within the bounds of this `Span`.
-  ///
+  ///   this range must be within the bounds of this `Span`.
   /// - Returns: A `Span` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -882,7 +882,7 @@ extension Span where Element: ~Copyable {
   ///
   /// - Parameter k: The number of elements to drop off the end of
   ///   the span. `k` must be greater than or equal to zero.
-  /// - Returns: A span leaving off the specified number of elements at the end.
+  /// - Returns: A span leaving off the specified number of trailing elements.
   ///
   /// - Complexity: O(1)
   @export(implementation)

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -574,7 +574,7 @@ extension Span where Element: ~Copyable {
   /// Constructs a new span over the items within the supplied range of
   /// indices within this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first item is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -605,7 +605,7 @@ extension Span where Element: ~Copyable {
   /// Constructs a new span over the items within the supplied range of
   /// indices within this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first item is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -640,7 +640,7 @@ extension Span where Element: ~Copyable {
   /// Constructs a new span over the items within the supplied range of
   /// indices within this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first item is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -668,7 +668,7 @@ extension Span where Element: ~Copyable {
   /// Constructs a new span over the items within the supplied range of
   /// indices within this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first item is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -702,7 +702,7 @@ extension Span where Element: ~Copyable {
 
   /// Constructs a new span over all the items of this span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first item is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -911,7 +911,7 @@ extension Span where Element: ~Copyable {
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the elements.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first item is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -945,7 +945,7 @@ extension Span where Element: ~Copyable {
   /// If the number of elements to drop exceeds the number of elements in
   /// the span, the result is an empty span.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
+  /// The returned span's first item is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -571,17 +571,17 @@ extension Span where Element: ConvertibleToBytes {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Span where Element: ~Copyable {
 
-  /// Constructs a new span over the items within the supplied range of
+  /// Constructs a new span over the elements within the supplied range of
   /// indices within this span.
   ///
-  /// The returned span's first item is always at index 0; unlike buffer
+  /// The returned span's first element is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `Span`.
   ///
-  /// - Returns: A `Span` over the items within `bounds`.
+  /// - Returns: A `Span` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
   @export(implementation)
@@ -602,10 +602,10 @@ extension Span where Element: ~Copyable {
     extracting(bounds)
   }
 
-  /// Constructs a new span over the items within the supplied range of
+  /// Constructs a new span over the elements within the supplied range of
   /// indices within this span.
   ///
-  /// The returned span's first item is always at index 0; unlike buffer
+  /// The returned span's first element is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -614,7 +614,7 @@ extension Span where Element: ~Copyable {
   /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `Span`.
   ///
-  /// - Returns: A `Span` over the items within `bounds`.
+  /// - Returns: A `Span` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
   @unsafe
@@ -637,17 +637,17 @@ extension Span where Element: ~Copyable {
     unsafe extracting(unchecked: bounds)
   }
 
-  /// Constructs a new span over the items within the supplied range of
+  /// Constructs a new span over the elements within the supplied range of
   /// indices within this span.
   ///
-  /// The returned span's first item is always at index 0; unlike buffer
+  /// The returned span's first element is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `Span`.
   ///
-  /// - Returns: A `Span` over the items within `bounds`.
+  /// - Returns: A `Span` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
   @export(implementation)
@@ -665,10 +665,10 @@ extension Span where Element: ~Copyable {
     extracting(bounds)
   }
 
-  /// Constructs a new span over the items within the supplied range of
+  /// Constructs a new span over the elements within the supplied range of
   /// indices within this span.
   ///
-  /// The returned span's first item is always at index 0; unlike buffer
+  /// The returned span's first element is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -677,7 +677,7 @@ extension Span where Element: ~Copyable {
   /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `Span`.
   ///
-  /// - Returns: A `Span` over the items within `bounds`.
+  /// - Returns: A `Span` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
   @unsafe
@@ -700,13 +700,13 @@ extension Span where Element: ~Copyable {
     unsafe extracting(unchecked: bounds)
   }
 
-  /// Constructs a new span over all the items of this span.
+  /// Constructs a new span over all the elements of this span.
   ///
-  /// The returned span's first item is always at index 0; unlike buffer
+  /// The returned span's first element is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Returns: A `Span` over all the items of this span.
+  /// - Returns: A `Span` over all the elements of this span.
   ///
   /// - Complexity: O(1)
   @export(implementation)
@@ -911,7 +911,7 @@ extension Span where Element: ~Copyable {
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the elements.
   ///
-  /// The returned span's first item is always at index 0; unlike buffer
+  /// The returned span's first element is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
@@ -945,7 +945,7 @@ extension Span where Element: ~Copyable {
   /// If the number of elements to drop exceeds the number of elements in
   /// the span, the result is an empty span.
   ///
-  /// The returned span's first item is always at index 0; unlike buffer
+  /// The returned span's first element is always at index 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -578,8 +578,8 @@ extension Span where Element: ~Copyable {
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Parameter bounds: A valid range of indices. Every index in
-  ///   this range must be within the bounds of this `Span`.
+  /// - Parameter bounds: A valid range of indices. Every index in this range
+  ///   must be within the bounds of this `Span`.
   /// - Returns: A `Span` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -610,8 +610,8 @@ extension Span where Element: ~Copyable {
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
-  /// - Parameter bounds: A valid range of indices. Every index in
-  ///   this range must be within the bounds of this `Span`.
+  /// - Parameter bounds: A valid range of indices. Every index in this range
+  ///   must be within the bounds of this `Span`.
   /// - Returns: A `Span` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -642,8 +642,8 @@ extension Span where Element: ~Copyable {
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Parameter bounds: A valid range of indices. Every index in
-  ///   this range must be within the bounds of this `Span`.
+  /// - Parameter bounds: A valid range of indices. Every index in this range
+  ///   must be within the bounds of this `Span`.
   /// - Returns: A `Span` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
@@ -671,8 +671,8 @@ extension Span where Element: ~Copyable {
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
-  /// - Parameter bounds: A valid range of indices. Every index in
-  ///   this range must be within the bounds of this `Span`.
+  /// - Parameter bounds: A valid range of indices. Every index in this range
+  ///   must be within the bounds of this `Span`.
   /// - Returns: A `Span` over the elements within `bounds`.
   ///
   /// - Complexity: O(1)

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -858,10 +858,6 @@ extension Span where Element: ~Copyable {
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the elements.
   ///
-  /// The returned span's first item is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
-  ///
   /// - Parameter maxLength: The maximum number of elements to return.
   ///   `maxLength` must be greater than or equal to zero.
   /// - Returns: A span with at most `maxLength` elements.
@@ -887,10 +883,6 @@ extension Span where Element: ~Copyable {
   ///
   /// If the number of elements to drop exceeds the number of elements in
   /// the span, the result is an empty span.
-  ///
-  /// The returned span's first item is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
   ///
   /// - Parameter k: The number of elements to drop off the end of
   ///   the span. `k` must be greater than or equal to zero.

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -491,7 +491,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   /// supplied range of indices in the memory region addressed by this buffer
   /// pointer.
   ///
-  /// The returned buffer's first element is always at index 0; unlike buffer
+  /// The returned buffer's first element is always at index 0. Unlike buffer
   /// slices, extracted buffers do not share their indices with the
   /// original buffer pointer.
   ///
@@ -533,7 +533,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   /// supplied range of indices in the memory region addressed by this buffer
   /// pointer.
   ///
-  /// The returned buffer's first element is always at index 0; unlike buffer
+  /// The returned buffer's first element is always at index 0. Unlike buffer
   /// slices, extracted buffers do not share their indices with the
   /// original buffer pointer.
   ///
@@ -569,7 +569,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
 
   /// Returns a buffer over all the elements of this buffer.
   ///
-  /// The returned buffer's first element is always at index 0; unlike buffer
+  /// The returned buffer's first element is always at index 0. Unlike buffer
   /// slices, extracted buffers do not share their indices with the
   /// original buffer pointer.
   ///
@@ -597,7 +597,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   /// supplied range of indices in the memory region addressed by this buffer
   /// pointer.
   ///
-  /// The returned buffer's first element is always at index 0; unlike buffer
+  /// The returned buffer's first element is always at index 0. Unlike buffer
   /// slices, extracted buffers do not share their indices with the
   /// original buffer pointer.
   ///
@@ -618,7 +618,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   /// supplied range of indices in the memory region addressed by this buffer
   /// pointer.
   ///
-  /// The returned buffer's first element is always at index 0; unlike buffer
+  /// The returned buffer's first element is always at index 0. Unlike buffer
   /// slices, extracted buffers do not share their indices with the
   /// original buffer pointer.
   ///
@@ -682,7 +682,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   /// If the maximum length exceeds the length of this buffer,
   /// the result contains all the elements.
   ///
-  /// The returned buffer's first element is always at index 0; unlike buffer
+  /// The returned buffer's first element is always at index 0. Unlike buffer
   /// slices, extracted buffers do not share their indices with the
   /// original buffer pointer.
   ///
@@ -706,7 +706,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   /// If the number of elements to drop exceeds the number of elements in
   /// the buffer, the result is an empty buffer.
   ///
-  /// The returned buffer's first element is always at index 0; unlike buffer
+  /// The returned buffer's first element is always at index 0. Unlike buffer
   /// slices, extracted buffers do not share their indices with the
   /// original buffer pointer.
   ///

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -514,7 +514,8 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   /// However, unlike slicing, the `extracting` operation remains available even
   /// if `Element` happens to be noncopyable.
   ///
-  /// - Parameter bounds: A valid range of indices within this buffer.
+  /// - Parameter bounds: A valid range of indices. Every index in this range
+  ///   must be within the bounds of this buffer.
   /// - Returns: A new buffer pointer over the elements at `bounds`.
   ///
   /// - Complexity: O(1)
@@ -555,7 +556,8 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   /// However, unlike slicing, the `extracting` operation remains available even
   /// if `Element` happens to be noncopyable.
   ///
-  /// - Parameter bounds: A valid range of indices within this buffer.
+  /// - Parameter bounds: A valid range of indices. Every index in this range
+  ///   must be within the bounds of this buffer.
   /// - Returns: A new buffer pointer over the elements at `bounds`.
   ///
   /// - Complexity: O(1)
@@ -601,7 +603,8 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
-  /// - Parameter bounds: A valid range of indices within this buffer.
+  /// - Parameter bounds: A valid range of indices. Every index in this range
+  ///   must be within the bounds of this buffer.
   /// - Returns: A new buffer pointer over the elements at `bounds`.
   ///
   /// - Complexity: O(1)
@@ -621,7 +624,8 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
-  /// - Parameter bounds: A valid range of indices within this buffer.
+  /// - Parameter bounds: A valid range of indices. Every index in this range
+  ///   must be within the bounds of this buffer.
   /// - Returns: A new buffer pointer over the elements at `bounds`.
   ///
   /// - Complexity: O(1)

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -487,10 +487,11 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
 }
 
 extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
-  /// Constructs a standalone buffer pointer over the items within the supplied
-  /// range of indices in the memory region addressed by this buffer pointer.
+  /// Constructs a standalone buffer pointer over the elements within the
+  /// supplied range of indices in the memory region addressed by this buffer
+  /// pointer.
   ///
-  /// The returned buffer's first item is always at index 0; unlike buffer
+  /// The returned buffer's first element is always at index 0; unlike buffer
   /// slices, extracted buffers do not share their indices with the
   /// original buffer pointer.
   ///
@@ -514,7 +515,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   /// if `Element` happens to be noncopyable.
   ///
   /// - Parameter bounds: A valid range of indices within this buffer.
-  /// - Returns: A new buffer pointer over the items at `bounds`.
+  /// - Returns: A new buffer pointer over the elements at `bounds`.
   ///
   /// - Complexity: O(1)
   @export(implementation)
@@ -527,10 +528,11 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
     return unsafe Self(start: start + bounds.lowerBound, count: bounds.count)
   }
 
-  /// Constructs a standalone buffer pointer over the items within the supplied
-  /// range of indices in the memory region addressed by this buffer pointer.
+  /// Constructs a standalone buffer pointer over the elements within the
+  /// supplied range of indices in the memory region addressed by this buffer
+  /// pointer.
   ///
-  /// The returned buffer's first item is always at index 0; unlike buffer
+  /// The returned buffer's first element is always at index 0; unlike buffer
   /// slices, extracted buffers do not share their indices with the
   /// original buffer pointer.
   ///
@@ -554,7 +556,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   /// if `Element` happens to be noncopyable.
   ///
   /// - Parameter bounds: A valid range of indices within this buffer.
-  /// - Returns: A new buffer pointer over the items at `bounds`.
+  /// - Returns: A new buffer pointer over the elements at `bounds`.
   ///
   /// - Complexity: O(1)
   @export(implementation)
@@ -565,7 +567,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
 
   /// Extracts and returns a copy of the entire buffer.
   ///
-  /// The returned buffer's first item is always at index 0; unlike buffer
+  /// The returned buffer's first element is always at index 0; unlike buffer
   /// slices, extracted buffers do not share their indices with the
   /// original buffer pointer.
   ///
@@ -589,17 +591,18 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
     unsafe self
   }
 
-  /// Constructs a standalone buffer pointer over the items within the supplied
-  /// range of indices in the memory region addressed by this buffer pointer.
+  /// Constructs a standalone buffer pointer over the elements within the
+  /// supplied range of indices in the memory region addressed by this buffer
+  /// pointer.
   ///
-  /// The returned buffer's first item is always at index 0; unlike buffer
+  /// The returned buffer's first element is always at index 0; unlike buffer
   /// slices, extracted buffers do not share their indices with the
   /// original buffer pointer.
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
   /// - Parameter bounds: A valid range of indices within this buffer.
-  /// - Returns: A new buffer pointer over the items at `bounds`.
+  /// - Returns: A new buffer pointer over the elements at `bounds`.
   ///
   /// - Complexity: O(1)
   @export(implementation)
@@ -608,17 +611,18 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
     return unsafe Self(start: newStart, count: bounds.count)
   }
 
-  /// Constructs a standalone buffer pointer over the items within the supplied
-  /// range of indices in the memory region addressed by this buffer pointer.
+  /// Constructs a standalone buffer pointer over the elements within the
+  /// supplied range of indices in the memory region addressed by this buffer
+  /// pointer.
   ///
-  /// The returned buffer's first item is always at index 0; unlike buffer
+  /// The returned buffer's first element is always at index 0; unlike buffer
   /// slices, extracted buffers do not share their indices with the
   /// original buffer pointer.
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
   /// - Parameter bounds: A valid range of indices within this buffer.
-  /// - Returns: A new buffer pointer over the items at `bounds`.
+  /// - Returns: A new buffer pointer over the elements at `bounds`.
   ///
   /// - Complexity: O(1)
   @export(implementation)
@@ -674,7 +678,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   /// If the maximum length exceeds the length of this buffer,
   /// the result contains all the elements.
   ///
-  /// The returned buffer's first item is always at index 0; unlike buffer
+  /// The returned buffer's first element is always at index 0; unlike buffer
   /// slices, extracted buffers do not share their indices with the
   /// original buffer pointer.
   ///
@@ -698,7 +702,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   /// If the number of elements to drop exceeds the number of elements in
   /// the buffer, the result is an empty buffer.
   ///
-  /// The returned buffer's first item is always at index 0; unlike buffer
+  /// The returned buffer's first element is always at index 0; unlike buffer
   /// slices, extracted buffers do not share their indices with the
   /// original buffer pointer.
   ///
@@ -727,7 +731,8 @@ extension UnsafeMutableBufferPointer where Element: Copyable {
   ///
   /// The `source` buffer must fit entirely in `self`.
   ///
-  /// - Returns: The index after the last item that was initialized in this buffer.
+  /// - Returns: The index after the last element that was initialized in
+  ///   this buffer.
   @export(implementation)
   internal func _initializePrefix(
     copying source: UnsafeBufferPointer<Element>

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -491,7 +491,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   /// range of positions in the memory region addressed by this buffer pointer.
   ///
   /// The returned buffer's first item is always at index 0; unlike buffer
-  /// slices, extracted buffers do not generally share their indices with the
+  /// slices, extracted buffers do not share their indices with the
   /// original buffer pointer.
   ///
   ///     withUnsafeTemporaryAllocation(of: Int.self, capacity: 5) { buffer in
@@ -531,7 +531,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   /// range of positions in the memory region addressed by this buffer pointer.
   ///
   /// The returned buffer's first item is always at index 0; unlike buffer
-  /// slices, extracted buffers do not generally share their indices with the
+  /// slices, extracted buffers do not share their indices with the
   /// original buffer pointer.
   ///
   ///     withUnsafeTemporaryAllocation(of: Int.self, capacity: 5) { buffer in
@@ -565,6 +565,10 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
 
   /// Extracts and returns a copy of the entire buffer.
   ///
+  /// The returned buffer's first item is always at index 0; unlike buffer
+  /// slices, extracted buffers do not share their indices with the
+  /// original buffer pointer.
+  ///
   /// When `Element` is copyable, the `extracting` operation is equivalent to
   /// slicing the buffer then rebasing the resulting buffer slice:
   ///
@@ -589,7 +593,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   /// range of positions in the memory region addressed by this buffer pointer.
   ///
   /// The returned buffer's first item is always at index 0; unlike buffer
-  /// slices, extracted buffers do not generally share their indices with the
+  /// slices, extracted buffers do not share their indices with the
   /// original buffer pointer.
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
@@ -608,7 +612,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   /// range of positions in the memory region addressed by this buffer pointer.
   ///
   /// The returned buffer's first item is always at index 0; unlike buffer
-  /// slices, extracted buffers do not generally share their indices with the
+  /// slices, extracted buffers do not share their indices with the
   /// original buffer pointer.
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
@@ -631,6 +635,10 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   /// If the maximum length exceeds the length of this buffer,
   /// the result contains all the elements.
   ///
+  /// The returned buffer's first item is always at index 0; unlike buffer
+  /// slices, extracted buffers do not share their indices with the
+  /// original buffer pointer.
+  ///
   /// - Parameter maxLength: The maximum number of elements to return.
   ///   `maxLength` must be greater than or equal to zero.
   /// - Returns: A buffer pointer with at most `maxLength` elements.
@@ -649,6 +657,10 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   ///
   /// If the number of elements to drop exceeds the number of elements in
   /// the buffer, the result is an empty buffer.
+  ///
+  /// The returned buffer's first item is always at index 0; unlike buffer
+  /// slices, extracted buffers do not share their indices with the
+  /// original buffer pointer.
   ///
   /// - Parameter k: The number of elements to drop off the end of the buffer.
   ///   `k` must be greater than or equal to zero.
@@ -670,6 +682,10 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   /// If the maximum length exceeds the length of this buffer,
   /// the result contains all the elements.
   ///
+  /// The returned buffer's first item is always at index 0; unlike buffer
+  /// slices, extracted buffers do not share their indices with the
+  /// original buffer pointer.
+  ///
   /// - Parameter maxLength: The maximum number of elements to return.
   ///   `maxLength` must be greater than or equal to zero.
   /// - Returns: A buffer pointer with at most `maxLength` elements.
@@ -689,6 +705,10 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   ///
   /// If the number of elements to drop exceeds the number of elements in
   /// the buffer, the result is an empty buffer.
+  ///
+  /// The returned buffer's first item is always at index 0; unlike buffer
+  /// slices, extracted buffers do not share their indices with the
+  /// original buffer pointer.
   ///
   /// - Parameter k: The number of elements to drop from the beginning of the
   ///   buffer. `k` must be greater than or equal to zero.

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -515,6 +515,8 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   ///
   /// - Parameter bounds: A valid range of indices within this buffer.
   /// - Returns: A new buffer pointer over the items at `bounds`.
+  ///
+  /// - Complexity: O(1)
   @export(implementation)
   @safe
   public func extracting(_ bounds: Range<Int>) -> Self {
@@ -553,6 +555,8 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   ///
   /// - Parameter bounds: A valid range of indices within this buffer.
   /// - Returns: A new buffer pointer over the items at `bounds`.
+  ///
+  /// - Complexity: O(1)
   @export(implementation)
   @safe
   public func extracting(_ bounds: some RangeExpression<Int>) -> Self {
@@ -573,6 +577,8 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   /// even if `Element` happens to be noncopyable.
   ///
   /// - Returns: The same buffer as `self`.
+  ///
+  /// - Complexity: O(1)
   @export(implementation)
   @safe
   public func extracting(_ bounds: UnboundedRange) -> Self {
@@ -590,6 +596,8 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   ///
   /// - Parameter bounds: A valid range of indices within this buffer.
   /// - Returns: A new buffer pointer over the items at `bounds`.
+  ///
+  /// - Complexity: O(1)
   @export(implementation)
   public func extracting(unchecked bounds: Range<Int>) -> Self {
     let newStart = unsafe _position?.advanced(by: bounds.lowerBound)
@@ -607,6 +615,8 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   ///
   /// - Parameter bounds: A valid range of indices within this buffer.
   /// - Returns: A new buffer pointer over the items at `bounds`.
+  ///
+  /// - Complexity: O(1)
   @export(implementation)
   public func extracting(unchecked bounds: ClosedRange<Int>) -> Self {
     let range = unsafe Range(
@@ -624,6 +634,8 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   /// - Parameter maxLength: The maximum number of elements to return.
   ///   `maxLength` must be greater than or equal to zero.
   /// - Returns: A buffer pointer with at most `maxLength` elements.
+  ///
+  /// - Complexity: O(1)
   @export(implementation)
   @safe
   public func extracting(first maxLength: Int) -> Self {
@@ -642,6 +654,8 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   ///   `k` must be greater than or equal to zero.
   /// - Returns: A buffer pointer leaving off the specified number of trailing
   ///   elements.
+  ///
+  /// - Complexity: O(1)
   @export(implementation)
   @safe
   public func extracting(droppingLast k: Int) -> Self {
@@ -659,6 +673,8 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   /// - Parameter maxLength: The maximum number of elements to return.
   ///   `maxLength` must be greater than or equal to zero.
   /// - Returns: A buffer pointer with at most `maxLength` elements.
+  ///
+  /// - Complexity: O(1)
   @export(implementation)
   @safe
   public func extracting(last maxLength: Int) -> Self {
@@ -678,6 +694,8 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   ///   buffer. `k` must be greater than or equal to zero.
   /// - Returns: A buffer pointer starting after the specified number of
   ///   elements.
+  ///
+  /// - Complexity: O(1)
   @export(implementation)
   @safe
   public func extracting(droppingFirst k: Int) -> Self {

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -507,7 +507,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   /// slicing the buffer then rebasing the resulting buffer slice:
   ///
   ///     let a = buffer.extracting(i ..< j)
-  ///     let b = UnsafeBufferPointer(rebasing: buffer[i ..< j])
+  ///     let b = ${Self}(rebasing: buffer[i ..< j])
   ///     // `a` and `b` are now holding the same buffer
   ///
   /// However, unlike slicing, the `extracting` operation remains available even
@@ -544,8 +544,8 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   /// When `Element` is copyable, the `extracting` operation is equivalent to
   /// slicing the buffer then rebasing the resulting buffer slice:
   ///
-  ///     let a = buffer.extracting(i ..< j)
-  ///     let b = UnsafeBufferPointer(rebasing: buffer[i ..< j])
+  ///     let a = buffer.extracting(i...)
+  ///     let b = ${Self}(rebasing: buffer[i...])
   ///     // `a` and `b` are now holding the same buffer
   ///
   /// However, unlike slicing, the `extracting` operation remains available even
@@ -566,7 +566,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   ///
   ///     let a = buffer
   ///     let b = buffer.extracting(...)
-  ///     let c = UnsafeBufferPointer(rebasing: buffer[...])
+  ///     let c = ${Self}(rebasing: buffer[...])
   ///     // `a`, `b` and `c` are now all referring to the same buffer
   ///
   /// Note that unlike slicing, the `extracting` operation remains available

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -656,7 +656,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
     return unsafe Self(_uncheckedStart: _position, count: newCount)
   }
 
-  /// Returns a buffer pointer over all but the given number of trailing
+  /// Returns a buffer pointer over all but the specified number of trailing
   /// elements.
   ///
   /// If the number of elements to drop exceeds the number of elements in
@@ -677,7 +677,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   }
 
   /// Returns a buffer pointer containing the trailing elements of this buffer,
-  /// up to the given maximum length.
+  /// up to the specified maximum length.
   ///
   /// If the maximum length exceeds the length of this buffer,
   /// the result contains all the elements.
@@ -700,7 +700,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
     return unsafe Self(_uncheckedStart: newStart, count: newCount)
   }
 
-  /// Returns a buffer pointer over all but the given number of initial
+  /// Returns a buffer pointer over all but the specified number of initial
   /// elements.
   ///
   /// If the number of elements to drop exceeds the number of elements in

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -516,7 +516,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   ///
   /// - Parameter bounds: A valid range of indices. Every index in this range
   ///   must be within the bounds of this buffer.
-  /// - Returns: A new buffer pointer over the elements at `bounds`.
+  /// - Returns: A buffer pointer over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
   @export(implementation)
@@ -558,7 +558,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   ///
   /// - Parameter bounds: A valid range of indices. Every index in this range
   ///   must be within the bounds of this buffer.
-  /// - Returns: A new buffer pointer over the elements at `bounds`.
+  /// - Returns: A buffer pointer over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
   @export(implementation)
@@ -605,7 +605,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   ///
   /// - Parameter bounds: A valid range of indices. Every index in this range
   ///   must be within the bounds of this buffer.
-  /// - Returns: A new buffer pointer over the elements at `bounds`.
+  /// - Returns: A buffer pointer over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
   @export(implementation)
@@ -626,7 +626,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   ///
   /// - Parameter bounds: A valid range of indices. Every index in this range
   ///   must be within the bounds of this buffer.
-  /// - Returns: A new buffer pointer over the elements at `bounds`.
+  /// - Returns: A buffer pointer over the elements within `bounds`.
   ///
   /// - Complexity: O(1)
   @export(implementation)

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -635,10 +635,6 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   /// If the maximum length exceeds the length of this buffer,
   /// the result contains all the elements.
   ///
-  /// The returned buffer's first item is always at index 0; unlike buffer
-  /// slices, extracted buffers do not share their indices with the
-  /// original buffer pointer.
-  ///
   /// - Parameter maxLength: The maximum number of elements to return.
   ///   `maxLength` must be greater than or equal to zero.
   /// - Returns: A buffer pointer with at most `maxLength` elements.
@@ -657,10 +653,6 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   ///
   /// If the number of elements to drop exceeds the number of elements in
   /// the buffer, the result is an empty buffer.
-  ///
-  /// The returned buffer's first item is always at index 0; unlike buffer
-  /// slices, extracted buffers do not share their indices with the
-  /// original buffer pointer.
   ///
   /// - Parameter k: The number of elements to drop off the end of the buffer.
   ///   `k` must be greater than or equal to zero.

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -488,7 +488,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
 
 extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   /// Constructs a standalone buffer pointer over the items within the supplied
-  /// range of positions in the memory region addressed by this buffer pointer.
+  /// range of indices in the memory region addressed by this buffer pointer.
   ///
   /// The returned buffer's first item is always at index 0; unlike buffer
   /// slices, extracted buffers do not share their indices with the
@@ -528,7 +528,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   }
 
   /// Constructs a standalone buffer pointer over the items within the supplied
-  /// range of positions in the memory region addressed by this buffer pointer.
+  /// range of indices in the memory region addressed by this buffer pointer.
   ///
   /// The returned buffer's first item is always at index 0; unlike buffer
   /// slices, extracted buffers do not share their indices with the
@@ -590,7 +590,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   }
 
   /// Constructs a standalone buffer pointer over the items within the supplied
-  /// range of positions in the memory region addressed by this buffer pointer.
+  /// range of indices in the memory region addressed by this buffer pointer.
   ///
   /// The returned buffer's first item is always at index 0; unlike buffer
   /// slices, extracted buffers do not share their indices with the
@@ -609,7 +609,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   }
 
   /// Constructs a standalone buffer pointer over the items within the supplied
-  /// range of positions in the memory region addressed by this buffer pointer.
+  /// range of indices in the memory region addressed by this buffer pointer.
   ///
   /// The returned buffer's first item is always at index 0; unlike buffer
   /// slices, extracted buffers do not share their indices with the

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -615,8 +615,8 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
     return unsafe extracting(unchecked: range)
   }
 
-  /// Constructs a standalone buffer pointer over the initial elements of
-  /// this buffer, up to the specified maximum length.
+  /// Returns a buffer pointer containing the initial elements of this buffer,
+  /// up to the specified maximum length.
   ///
   /// If the maximum length exceeds the length of this buffer,
   /// the result contains all the elements.

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -565,7 +565,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
     extracting(bounds.relative(to: unsafe Range(uncheckedBounds: (0, count))))
   }
 
-  /// Extracts and returns a copy of the entire buffer.
+  /// Returns a buffer over all the elements of this buffer.
   ///
   /// The returned buffer's first element is always at index 0; unlike buffer
   /// slices, extracted buffers do not share their indices with the

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1249,7 +1249,7 @@ extension Unsafe${Mutable}RawBufferPointer {
     extracting(bounds.relative(to: unsafe Range(uncheckedBounds: (0, count))))
   }
 
-  /// Extracts and returns a copy of the entire buffer.
+  /// Returns a buffer over all the bytes of this buffer.
   ///
   /// The returned buffer's first byte is always at offset 0; unlike buffer
   /// slices, extracted buffers do not share their indices with the

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1219,6 +1219,8 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///
   /// - Parameter bounds: A valid range of byte offsets within this buffer.
   /// - Returns: A new buffer pointer over the bytes at `bounds`.
+  ///
+  /// - Complexity: O(1)
   @export(implementation)
   @safe
   public func extracting(_ bounds: Range<Int>) -> Self {
@@ -1239,6 +1241,8 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///
   /// - Parameter bounds: A valid range of byte offsets within this buffer.
   /// - Returns: A new buffer pointer over the bytes at `bounds`.
+  ///
+  /// - Complexity: O(1)
   @export(implementation)
   @safe
   public func extracting(_ bounds: some RangeExpression<Int>) -> Self {
@@ -1248,6 +1252,8 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// Extracts and returns a copy of the entire buffer.
   ///
   /// - Returns: The same buffer as `self`.
+  ///
+  /// - Complexity: O(1)
   @export(implementation)
   @safe
   public func extracting(_ bounds: UnboundedRange) -> Self {
@@ -1265,6 +1271,8 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///
   /// - Parameter bounds: A valid range of byte offsets within this buffer.
   /// - Returns: A new buffer pointer over the bytes at `bounds`.
+  ///
+  /// - Complexity: O(1)
   @export(implementation)
   public func extracting(unchecked bounds: Range<Int>) -> Self {
     let newStart = unsafe baseAddress?.advanced(by: bounds.lowerBound)
@@ -1282,6 +1290,8 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///
   /// - Parameter bounds: A valid range of byte offsets within this buffer.
   /// - Returns: A new buffer pointer over the bytes at `bounds`.
+  ///
+  /// - Complexity: O(1)
   @export(implementation)
   public func extracting(unchecked bounds: ClosedRange<Int>) -> Self {
     let range = unsafe Range(
@@ -1299,6 +1309,8 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// - Parameter maxLength: The maximum number of bytes to return.
   ///   `maxLength` must be greater than or equal to zero.
   /// - Returns: A buffer pointer with at most `maxLength` bytes.
+  ///
+  /// - Complexity: O(1)
   @export(implementation)
   @safe
   public func extracting(first maxLength: Int) -> Self {
@@ -1316,6 +1328,8 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///   `k` must be greater than or equal to zero.
   /// - Returns: A buffer pointer leaving off the specified number of trailing
   ///   bytes.
+  ///
+  /// - Complexity: O(1)
   @export(implementation)
   @safe
   public func extracting(droppingLast k: Int) -> Self {
@@ -1334,6 +1348,8 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// - Parameter maxLength: The maximum number of bytes to return.
   ///   `maxLength` must be greater than or equal to zero.
   /// - Returns: A buffer pointer with at most `maxLength` bytes.
+  ///
+  /// - Complexity: O(1)
   @export(implementation)
   @safe
   public func extracting(last maxLength: Int) -> Self {
@@ -1351,6 +1367,8 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// - Parameter k: The number of bytes to drop from the beginning of the
   ///   buffer. `k` must be greater than or equal to zero.
   /// - Returns: A buffer pointer starting after the specified number of bytes.
+  ///
+  /// - Complexity: O(1)
   @export(implementation)
   @safe
   public func extracting(droppingFirst k: Int) -> Self {

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1310,10 +1310,6 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// If the maximum length exceeds the length of this buffer,
   /// the result contains all the bytes.
   ///
-  /// The returned buffer's first byte is always at offset 0; unlike buffer
-  /// slices, extracted buffers do not share their indices with the
-  /// original buffer pointer.
-  ///
   /// - Parameter maxLength: The maximum number of bytes to return.
   ///   `maxLength` must be greater than or equal to zero.
   /// - Returns: A buffer pointer with at most `maxLength` bytes.
@@ -1331,10 +1327,6 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///
   /// If the number of bytes to drop exceeds the number of bytes in the buffer,
   /// the result is an empty buffer.
-  ///
-  /// The returned buffer's first byte is always at offset 0; unlike buffer
-  /// slices, extracted buffers do not share their indices with the
-  /// original buffer pointer.
   ///
   /// - Parameter k: The number of bytes to drop off the end of the buffer.
   ///   `k` must be greater than or equal to zero.

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1290,8 +1290,8 @@ extension Unsafe${Mutable}RawBufferPointer {
     return unsafe extracting(unchecked: range)
   }
 
-  /// Constructs a standalone buffer pointer over the initial bytes of
-  /// this buffer, up to the specified maximum length.
+  /// Returns a buffer pointer containing the initial bytes of this buffer,
+  /// up to the specified maximum length.
   ///
   /// If the maximum length exceeds the length of this buffer,
   /// the result contains all the bytes.

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1214,7 +1214,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// range of positions in the memory region addressed by this buffer pointer.
   ///
   /// The returned buffer's first byte is always at offset 0; unlike buffer
-  /// slices, extracted buffers do not generally share their indices with the
+  /// slices, extracted buffers do not share their indices with the
   /// original buffer pointer.
   ///
   /// - Parameter bounds: A valid range of byte offsets within this buffer.
@@ -1236,7 +1236,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// range of positions in the memory region addressed by this buffer pointer.
   ///
   /// The returned buffer's first byte is always at offset 0; unlike buffer
-  /// slices, extracted buffers do not generally share their indices with the
+  /// slices, extracted buffers do not share their indices with the
   /// original buffer pointer.
   ///
   /// - Parameter bounds: A valid range of byte offsets within this buffer.
@@ -1251,6 +1251,10 @@ extension Unsafe${Mutable}RawBufferPointer {
 
   /// Extracts and returns a copy of the entire buffer.
   ///
+  /// The returned buffer's first byte is always at offset 0; unlike buffer
+  /// slices, extracted buffers do not share their indices with the
+  /// original buffer pointer.
+  ///
   /// - Returns: The same buffer as `self`.
   ///
   /// - Complexity: O(1)
@@ -1264,7 +1268,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// range of positions in the memory region addressed by this buffer pointer.
   ///
   /// The returned buffer's first byte is always at offset 0; unlike buffer
-  /// slices, extracted buffers do not generally share their indices with the
+  /// slices, extracted buffers do not share their indices with the
   /// original buffer pointer.
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
@@ -1283,7 +1287,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// range of positions in the memory region addressed by this buffer pointer.
   ///
   /// The returned buffer's first byte is always at offset 0; unlike buffer
-  /// slices, extracted buffers do not generally share their indices with the
+  /// slices, extracted buffers do not share their indices with the
   /// original buffer pointer.
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
@@ -1306,6 +1310,10 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// If the maximum length exceeds the length of this buffer,
   /// the result contains all the bytes.
   ///
+  /// The returned buffer's first byte is always at offset 0; unlike buffer
+  /// slices, extracted buffers do not share their indices with the
+  /// original buffer pointer.
+  ///
   /// - Parameter maxLength: The maximum number of bytes to return.
   ///   `maxLength` must be greater than or equal to zero.
   /// - Returns: A buffer pointer with at most `maxLength` bytes.
@@ -1323,6 +1331,10 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///
   /// If the number of bytes to drop exceeds the number of bytes in the buffer,
   /// the result is an empty buffer.
+  ///
+  /// The returned buffer's first byte is always at offset 0; unlike buffer
+  /// slices, extracted buffers do not share their indices with the
+  /// original buffer pointer.
   ///
   /// - Parameter k: The number of bytes to drop off the end of the buffer.
   ///   `k` must be greater than or equal to zero.
@@ -1345,6 +1357,10 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// If the maximum length exceeds the length of this buffer,
   /// the result contains all the bytes.
   ///
+  /// The returned buffer's first byte is always at offset 0; unlike buffer
+  /// slices, extracted buffers do not share their indices with the
+  /// original buffer pointer.
+  ///
   /// - Parameter maxLength: The maximum number of bytes to return.
   ///   `maxLength` must be greater than or equal to zero.
   /// - Returns: A buffer pointer with at most `maxLength` bytes.
@@ -1363,6 +1379,10 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///
   /// If the number of bytes to drop exceeds the number of bytes in the buffer,
   /// the result is an empty buffer.
+  ///
+  /// The returned buffer's first byte is always at offset 0; unlike buffer
+  /// slices, extracted buffers do not share their indices with the
+  /// original buffer pointer.
   ///
   /// - Parameter k: The number of bytes to drop from the beginning of the
   ///   buffer. `k` must be greater than or equal to zero.

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1219,7 +1219,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///
   /// - Parameter bounds: A valid range of byte offsets. Every byte offset in
   ///   this range must be within the bounds of this buffer.
-  /// - Returns: A new buffer pointer over the bytes at `bounds`.
+  /// - Returns: A buffer pointer over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
   @export(implementation)
@@ -1242,7 +1242,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///
   /// - Parameter bounds: A valid range of byte offsets. Every byte offset in
   ///   this range must be within the bounds of this buffer.
-  /// - Returns: A new buffer pointer over the bytes at `bounds`.
+  /// - Returns: A buffer pointer over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
   @export(implementation)
@@ -1277,7 +1277,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///
   /// - Parameter bounds: A valid range of byte offsets. Every byte offset in
   ///   this range must be within the bounds of this buffer.
-  /// - Returns: A new buffer pointer over the bytes at `bounds`.
+  /// - Returns: A buffer pointer over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
   @export(implementation)
@@ -1297,7 +1297,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///
   /// - Parameter bounds: A valid range of byte offsets. Every byte offset in
   ///   this range must be within the bounds of this buffer.
-  /// - Returns: A new buffer pointer over the bytes at `bounds`.
+  /// - Returns: A buffer pointer over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
   @export(implementation)

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1213,7 +1213,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// Constructs a standalone buffer pointer over the bytes within the supplied
   /// range of positions in the memory region addressed by this buffer pointer.
   ///
-  /// The returned buffer's first byte is always at offset 0; unlike buffer
+  /// The returned buffer's first byte is always at offset 0. Unlike buffer
   /// slices, extracted buffers do not share their indices with the
   /// original buffer pointer.
   ///
@@ -1236,7 +1236,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// Constructs a standalone buffer pointer over the bytes within the supplied
   /// range of positions in the memory region addressed by this buffer pointer.
   ///
-  /// The returned buffer's first byte is always at offset 0; unlike buffer
+  /// The returned buffer's first byte is always at offset 0. Unlike buffer
   /// slices, extracted buffers do not share their indices with the
   /// original buffer pointer.
   ///
@@ -1253,7 +1253,7 @@ extension Unsafe${Mutable}RawBufferPointer {
 
   /// Returns a buffer over all the bytes of this buffer.
   ///
-  /// The returned buffer's first byte is always at offset 0; unlike buffer
+  /// The returned buffer's first byte is always at offset 0. Unlike buffer
   /// slices, extracted buffers do not share their indices with the
   /// original buffer pointer.
   ///
@@ -1269,7 +1269,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// Constructs a standalone buffer pointer over the bytes within the supplied
   /// range of positions in the memory region addressed by this buffer pointer.
   ///
-  /// The returned buffer's first byte is always at offset 0; unlike buffer
+  /// The returned buffer's first byte is always at offset 0. Unlike buffer
   /// slices, extracted buffers do not share their indices with the
   /// original buffer pointer.
   ///
@@ -1289,7 +1289,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// Constructs a standalone buffer pointer over the bytes within the supplied
   /// range of positions in the memory region addressed by this buffer pointer.
   ///
-  /// The returned buffer's first byte is always at offset 0; unlike buffer
+  /// The returned buffer's first byte is always at offset 0. Unlike buffer
   /// slices, extracted buffers do not share their indices with the
   /// original buffer pointer.
   ///
@@ -1354,7 +1354,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// If the maximum length exceeds the length of this buffer,
   /// the result contains all the bytes.
   ///
-  /// The returned buffer's first byte is always at offset 0; unlike buffer
+  /// The returned buffer's first byte is always at offset 0. Unlike buffer
   /// slices, extracted buffers do not share their indices with the
   /// original buffer pointer.
   ///
@@ -1378,7 +1378,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// If the number of bytes to drop exceeds the number of bytes in the buffer,
   /// the result is an empty buffer.
   ///
-  /// The returned buffer's first byte is always at offset 0; unlike buffer
+  /// The returned buffer's first byte is always at offset 0. Unlike buffer
   /// slices, extracted buffers do not share their indices with the
   /// original buffer pointer.
   ///

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1217,7 +1217,8 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// slices, extracted buffers do not share their indices with the
   /// original buffer pointer.
   ///
-  /// - Parameter bounds: A valid range of byte offsets within this buffer.
+  /// - Parameter bounds: A valid range of byte offsets. Every byte offset in
+  ///   this range must be within the bounds of this buffer.
   /// - Returns: A new buffer pointer over the bytes at `bounds`.
   ///
   /// - Complexity: O(1)
@@ -1239,7 +1240,8 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// slices, extracted buffers do not share their indices with the
   /// original buffer pointer.
   ///
-  /// - Parameter bounds: A valid range of byte offsets within this buffer.
+  /// - Parameter bounds: A valid range of byte offsets. Every byte offset in
+  ///   this range must be within the bounds of this buffer.
   /// - Returns: A new buffer pointer over the bytes at `bounds`.
   ///
   /// - Complexity: O(1)
@@ -1273,7 +1275,8 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
-  /// - Parameter bounds: A valid range of byte offsets within this buffer.
+  /// - Parameter bounds: A valid range of byte offsets. Every byte offset in
+  ///   this range must be within the bounds of this buffer.
   /// - Returns: A new buffer pointer over the bytes at `bounds`.
   ///
   /// - Complexity: O(1)
@@ -1292,7 +1295,8 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
-  /// - Parameter bounds: A valid range of byte offsets within this buffer.
+  /// - Parameter bounds: A valid range of byte offsets. Every byte offset in
+  ///   this range must be within the bounds of this buffer.
   /// - Returns: A new buffer pointer over the bytes at `bounds`.
   ///
   /// - Complexity: O(1)

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1327,7 +1327,8 @@ extension Unsafe${Mutable}RawBufferPointer {
     return unsafe Self(_uncheckedStart: baseAddress, count: newCount)
   }
 
-  /// Returns a buffer pointer over all but the given number of trailing bytes.
+  /// Returns a buffer pointer over all but the specified number of trailing
+  /// bytes.
   ///
   /// If the number of bytes to drop exceeds the number of bytes in the buffer,
   /// the result is an empty buffer.
@@ -1348,7 +1349,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   }
 
   /// Returns a buffer pointer containing the trailing bytes of this buffer,
-  /// up to the given maximum length.
+  /// up to the specified maximum length.
   ///
   /// If the maximum length exceeds the length of this buffer,
   /// the result contains all the bytes.
@@ -1371,7 +1372,8 @@ extension Unsafe${Mutable}RawBufferPointer {
     return unsafe Self(_uncheckedStart: newStart, count: newCount)
   }
 
-  /// Returns a buffer pointer over all but the given number of initial bytes.
+  /// Returns a buffer pointer over all but the specified number of initial
+  /// bytes.
   ///
   /// If the number of bytes to drop exceeds the number of bytes in the buffer,
   /// the result is an empty buffer.


### PR DESCRIPTION
This improves the uniformity of the doc-comments for the various `extracting()` functions. They exist for the `Span` family and the `UnsafeBufferPointer` family and were added over several months by two different authors. As a result, they had been quite inconsistent in phrasing and formatting, usually unintentionally and sometimes confusingly.

Changes in comments only. Proof-reading assisted by LLM.