### PR TITLE
Embedded: Fix Observation configure error in embedded-only stdlib

### DIFF
--- a/stdlib/public/Observation/Sources/Observation/CMakeLists.txt
+++ b/stdlib/public/Observation/Sources/Observation/CMakeLists.txt
@@ -83,6 +83,8 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB
 
   set(_embedded_observation_all_triples "${EMBEDDED_STDLIB_TARGET_TRIPLES}")
 
+  list(APPEND LLVM_OPTIONAL_SOURCES ThreadLocal.cpp)
+
   foreach(entry ${_embedded_observation_triples})
     string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
     list(GET list 1 mod)


### PR DESCRIPTION
Embedded-only stdlib builds configure with an empty `SWIFT_SDKS`, so the non-embedded `swiftObservation` target never runs and never registers `ThreadLocal.cpp` with LLVM's source-list check. Marking it optional matches what Concurrency already does for `ExecutorImpl.cpp`.

rdar://184326879