### PR TITLE
SIL: Make DebugValueInst::setDebugReconstructionBlock free the previous block

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -5931,13 +5931,12 @@ public:
     return ReconstructionBlock;
   }
 
-  /// Sets the debug-only basic block for this instruction.
+  /// Sets the debug-only basic block for this instruction. If one is already
+  /// attached, it is freed.
   /// This should not be called by optimization passes. Optimization passes
   /// and debug information salvage operations should append to existing
   /// blocks using getOrCreateDebugReconstructionBlock.
-  void setDebugReconstructionBlock(SILBasicBlock *BB) {
-    ReconstructionBlock = BB;
-  }
+  void setDebugReconstructionBlock(SILBasicBlock *BB);
 
   /// Clones the reconstruction block from \p src onto this debug value.
   void cloneReconstructionBlockFrom(DebugValueInst *src);

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -195,14 +195,9 @@ void SILInstruction::dropNonOperandReferences() {
     return;
   }
 
-  // If we have a DebugValueInst with a debug reconstruction block, drop it.
-  if (auto *DVI = dyn_cast<DebugValueInst>(this)) {
-    if (auto *DebugBB = DVI->getDebugReconstructionBlock()) {
-      DebugBB->dropAllReferences();
-      DebugBB->eraseAllInstructions(getModule());
-      DVI->setDebugReconstructionBlock(nullptr);
-    }
-  }
+  // If we have a DebugValueInst with a debug reconstruction block, free it.
+  if (auto *DVI = dyn_cast<DebugValueInst>(this))
+    DVI->setDebugReconstructionBlock(nullptr);
 }
 
 namespace {

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -608,10 +608,19 @@ SILBasicBlock *DebugValueInst::getOrCreateDebugReconstructionBlock() {
   return block;
 }
 
+void DebugValueInst::setDebugReconstructionBlock(SILBasicBlock *BB) {
+  // Free the existing reconstruction block if we have one.
+  if (ReconstructionBlock)
+    ReconstructionBlock->~SILBasicBlock();
+  ReconstructionBlock = BB;
+}
+
 void DebugValueInst::cloneReconstructionBlockFrom(DebugValueInst *src) {
   auto *srcBB = src->getDebugReconstructionBlock();
-  if (!srcBB)
+  if (!srcBB) {
+    setDebugReconstructionBlock(nullptr);
     return;
+  }
   auto *newBB = getFunction()->createEmptyDebugReconstructionBlock();
   setDebugReconstructionBlock(newBB);
   DebugBasicBlockCloner(*getFunction())


### PR DESCRIPTION
This avoids a leak if the debug reconstruction block contains more than 1 argument, which doesn't happen currently but will soon.

This also makes the design of DebugValueInst better, by making it harder to leak the debug reconstruction block.
