### PR TITLE
[cxx-interop] Do not import classes declared within functions

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -10560,6 +10560,11 @@ DeclContext *ClangImporter::Implementation::importDeclContextImpl(
   // TranslationUnit DeclContext here.
   assert(!dc->isTranslationUnit());
 
+  // A declaration declared inside a function body (e.g. a local C++ class) has
+  // no Swift decl context to be imported into.
+  if (dc->isFunctionOrMethod())
+    return nullptr;
+
   auto decl = dyn_cast<clang::NamedDecl>(dc);
   if (!decl || !decl->getDeclName().isIdentifier())
     return nullptr;

--- a/test/Interop/Cxx/class/Inputs/local-class.h
+++ b/test/Interop/Cxx/class/Inputs/local-class.h
@@ -1,0 +1,43 @@
+struct DeducedReturnType {
+  static constexpr auto returnsLocalClass(int c) noexcept {
+    struct Local {
+      char chars[2];
+    };
+    return Local{{(char)c, '\0'}};
+  }
+};
+
+inline auto localClassInFreeFunction() {
+  struct Local {
+    int x;
+  };
+  return Local{42};
+}
+
+inline auto nestedLocalClass() {
+  struct LocalOuter {
+    struct LocalInner {
+      int x;
+    };
+    LocalInner inner;
+  };
+  return LocalOuter{{42}};
+}
+
+inline auto localClassInLambda() {
+  auto fn = []() {
+    struct LocalInLambda {
+      int x;
+    };
+    return LocalInLambda{42};
+  };
+  return fn();
+}
+
+// Records nested at non-local scope should still be imported.
+struct Outer {
+  struct Inner {
+    int x;
+  };
+  Inner inner;
+};

--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -121,6 +121,11 @@ module InvalidNestedStruct {
   requires cplusplus
 }
 
+module LocalClass {
+  header "local-class.h"
+  requires cplusplus
+}
+
 module ClassProtocolNameClash {
   header "class-protocol-name-clash.h"
   requires cplusplus

--- a/test/Interop/Cxx/class/local-class-module-interface.swift
+++ b/test/Interop/Cxx/class/local-class-module-interface.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=LocalClass -I %S/Inputs/ -source-filename=x -cxx-interoperability-mode=default 2>&1 | %FileCheck %s
+
+// Classes declared inside a function body are not imported.
+
+// CHECK-NOT: warning
+// CHECK-NOT: struct Local


### PR DESCRIPTION
This prevents a spurious warning from firing: `cycle detected while resolving ...`

rdar://184337062 / resolves https://github.com/swiftlang/swift/issues/91322

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
