### PR TITLE
vim: add support for key paths and improve where clause handling

### DIFF
--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -183,8 +183,14 @@ syn match swiftVarName contained skipwhite skipempty nextgroup=swiftTypeDeclarat
 syn match swiftImplicitVarName
       \ /\$\<[A-Za-z_0-9]\+\>/
 
+" Codable & Equatable (protocol composition). contained, so it only ever
+" chains off an already-recognized type -- it can't be confused with the
+" bitwise-and operator in ordinary expressions.
+syn match swiftProtocolComposition contained skipwhite skipempty nextgroup=@swiftTypeContext
+      \ /&/
+
 " TypeName[Optionality]?
-syn match swiftType contained skipwhite skipempty nextgroup=swiftTypeParameters
+syn match swiftType contained skipwhite skipempty nextgroup=swiftTypeParameters,swiftProtocolComposition
       \ /\<[A-Za-z_][A-Za-z_0-9\.]*\>[!?]\?/
 " [Type:Type] (dictionary) or [Type] (array)
 syn region swiftType contained contains=swiftTypePair,@swiftTypeContext
@@ -350,6 +356,7 @@ hi def link swiftConstraint Special
 hi def link swiftTypeAliasValue Delimiter
 hi def link swiftTypeDeclaration Delimiter
 hi def link swiftTypeParameters Delimiter
+hi def link swiftProtocolComposition Operator
 hi def link swiftCastOp Operator
 
 hi def link swiftBoolean Boolean

--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -268,6 +268,15 @@ syn region swiftString contains=swiftInterpolationRegion
 syn region swiftInterpolationRegion contained contains=TOP
       \ matchgroup=swiftInterpolation start=/\\(/ end=/)/
 
+" #"..."#  Raw string: no escape processing at all except `\#(` for
+" interpolation. Only the single-`#` delimiter is handled; `##"..."##`
+" and higher would need matching delimiter counts on both ends, which a
+" plain start/end pair cannot enforce.
+syn region swiftString contains=swiftInterpolationRegion
+      \ start=/#"/ end=/"#/
+syn region swiftInterpolationRegion contained contains=TOP
+      \ matchgroup=swiftInterpolation start=/\\#(/ end=/)/
+
 syn match swiftTupleIndexNumber contains=swiftDecimal
       \ /\.[0-9]\+/
 

--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -38,7 +38,6 @@ syn keyword swiftKeyword
       \ throw
       \ try
       \ unsafe
-      \ where
       \ while
 syn match swiftMultiwordKeyword
       \ "indirect case"
@@ -189,8 +188,13 @@ syn match swiftImplicitVarName
 syn match swiftProtocolComposition contained skipwhite skipempty nextgroup=@swiftTypeContext
       \ /&/
 
+" `, subject ==` continues a same-type requirement after a comma; the
+" lookahead keeps ordinary tuple/parameter-list commas unaffected.
+syn match swiftWhereConstraintComma contained skipwhite skipempty nextgroup=swiftWhereConstraintSubject
+      \ /,\ze\s*[A-Za-z_][A-Za-z_0-9.]*\s*==/
+
 " TypeName[Optionality]?
-syn match swiftType contained skipwhite skipempty nextgroup=swiftTypeParameters,swiftProtocolComposition
+syn match swiftType contained skipwhite skipempty nextgroup=swiftTypeParameters,swiftProtocolComposition,swiftWhereConstraintComma
       \ /\<[A-Za-z_][A-Za-z_0-9\.]*\>[!?]\?/
 " [Type:Type] (dictionary) or [Type] (array)
 syn region swiftType contained contains=swiftTypePair,@swiftTypeContext
@@ -223,6 +227,15 @@ syn match swiftCastOp skipwhite skipempty nextgroup=@swiftTypeContext,swiftCoreT
       \ "\<is\>"
 syn match swiftCastOp skipwhite skipempty nextgroup=@swiftTypeContext,swiftCoreTypes
       \ "\<as\>[!?]\?"
+
+" where T == Int (same-type requirement); `:` conformance already works
+" without this, since swiftTypeDeclaration is not `contained`.
+syn match swiftWhereSameType contained skipwhite skipempty nextgroup=@swiftTypeContext
+      \ /==/
+syn match swiftWhereConstraintSubject contained skipwhite skipempty nextgroup=swiftWhereSameType
+      \ /\<[A-Za-z_][A-Za-z_0-9]*\>\%(\.[A-Za-z_][A-Za-z_0-9]*\)*/
+syn keyword swiftKeyword skipwhite skipempty nextgroup=swiftWhereConstraintSubject
+      \ where
 
 " ---- Literals ----
 
@@ -358,6 +371,8 @@ hi def link swiftTypeDeclaration Delimiter
 hi def link swiftTypeParameters Delimiter
 hi def link swiftProtocolComposition Operator
 hi def link swiftCastOp Operator
+hi def link swiftWhereConstraintSubject Identifier
+hi def link swiftWhereSameType Operator
 
 hi def link swiftBoolean Boolean
 hi def link swiftNil Constant

--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -246,6 +246,12 @@ syn region swiftInterpolationRegion contained contains=TOP
 
 syn match swiftTupleIndexNumber contains=swiftDecimal
       \ /\.[0-9]\+/
+
+" \Type.path or \.path (key path literal). The whole path is a single
+" token, since a plain regex cannot distinguish the leading type name
+" from the member names that follow it.
+syn match swiftKeyPath
+      \ /\\\%([A-Za-z_][A-Za-z_0-9]*\)\?\%(\.[A-Za-z_][A-Za-z_0-9]*[?!]\?\)\+/
 syn match swiftDecimal contained
       \ /[0-9]\+/
 
@@ -350,6 +356,7 @@ hi def link swiftBin Number
 hi def link swiftChar Character
 hi def link swiftString String
 hi def link swiftInterpolation Special
+hi def link swiftKeyPath Special
 
 hi def link swiftOperator Operator
 hi def link swiftNilOps Operator

--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -241,6 +241,11 @@ syn match swiftChar
 
 syn region swiftString contains=swiftInterpolationRegion
       \ start=/"/ skip=/\\\\\|\\"/ end=/"/
+" """..."""  Must be defined after the single-line swiftString above so
+" it wins when both could start at the same `"`, per :syn-priority (the
+" item defined last has priority for matches starting at the same spot).
+syn region swiftString contains=swiftInterpolationRegion
+      \ start=/"""/ skip=/\\\\\|\\"/ end=/"""/
 syn region swiftInterpolationRegion contained contains=TOP
       \ matchgroup=swiftInterpolation start=/\\(/ end=/)/
 

--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -67,15 +67,17 @@ syn keyword swiftLabel
 
 " ---- Modifiers & specifiers ----
 
-" nonisolated(unsafe), nonisolated(nonsending)
+" nonisolated(unsafe), nonisolated(nonsending), unowned(safe), unowned(unsafe)
 syn keyword swiftModifierArgument contained
       \ nonsending
+      \ safe
       \ unsafe
 syn region swiftModifierArguments contained transparent
       \ matchgroup=Delimiter start=/(/ end=/)/
       \ contains=swiftModifierArgument
 syn keyword swiftDefinitionModifier skipwhite skipempty nextgroup=swiftModifierArguments
       \ nonisolated
+      \ unowned
 
 syn keyword swiftDefinitionModifier
       \ async


### PR DESCRIPTION
This pull request updates the Swift syntax highlighting rules in `utils/vim/syntax/swift.vim` to better support modern Swift language features and improve code readability in Vim. The changes enhance support for protocol composition, same-type requirements, new string literal forms, and key path literals, and refine how keywords and modifiers are matched and highlighted.

**Syntax improvements for Swift language features:**

* Added support for protocol composition (`&` in types), same-type requirements (`==` in `where` clauses), and improved handling of `where` constraints in type declarations and generics. [[1]](diffhunk://#diff-00d745ba43737aa26576b1f8e67b3370a8717074454d27158c36ddcfa20a0e09R185-R197) [[2]](diffhunk://#diff-00d745ba43737aa26576b1f8e67b3370a8717074454d27158c36ddcfa20a0e09R231-R239)
* Improved string literal matching to support multi-line strings (`"""..."""`) and raw strings (`#"...“#`), and added support for key path literals (e.g., `\Type.path`).
* Enhanced highlighting for new and existing syntax elements: protocol composition operators, same-type constraints, and key path literals. [[1]](diffhunk://#diff-00d745ba43737aa26576b1f8e67b3370a8717074454d27158c36ddcfa20a0e09R381-R384) [[2]](diffhunk://#diff-00d745ba43737aa26576b1f8e67b3370a8717074454d27158c36ddcfa20a0e09R395)

**Keyword and modifier adjustments:**

* Updated the `swiftKeyword` and `swiftDefinitionModifier` lists to adjust how `where` is matched (now contextually, not as a standalone keyword), and added support for new modifier arguments like `unowned(safe)` and `unowned(unsafe)`. [[1]](diffhunk://#diff-00d745ba43737aa26576b1f8e67b3370a8717074454d27158c36ddcfa20a0e09L41) [[2]](diffhunk://#diff-00d745ba43737aa26576b1f8e67b3370a8717074454d27158c36ddcfa20a0e09L70-R79)

These changes make Swift editing in Vim more accurate and up-to-date with current language features, improving both syntax recognition and visual clarity.