### PR TITLE
[SIL/IRGen] Non-escaping `@called(once)` parameters

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ConstantCapturePropagation.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ConstantCapturePropagation.swift
@@ -252,7 +252,7 @@ private func rewritePartialApply(_ partialApply: PartialApplyInst, withSpecializ
       substitutionMap: specialized.genericSignature.isEmpty ? SubstitutionMap() : partialApply.substitutionMap,
       capturedArguments: arguments, calleeConvention: partialApply.calleeConvention,
       hasUnknownResultIsolation: partialApply.hasUnknownResultIsolation, isOnStack: partialApply.isOnStack,
-      isNested: partialApply.isNested)
+      isNested: partialApply.isNested, isCalledOnce: partialApply.isCalledOnce)
     newClosure = newPartialApply
   }
   partialApply.uses.replaceAll(with: newClosure, context)

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -316,6 +316,7 @@ extension ApplySite {
                                                 hasUnknownResultIsolation: partialAp.hasUnknownResultIsolation,
                                                 isOnStack: partialAp.isOnStack,
                                                 isNested:  partialAp.isNested,
+                                                isCalledOnce: partialAp.isCalledOnce,
                                                 argumentLocationsFrom: self)
       partialAp.replace(with: newApply, context)
 

--- a/SwiftCompilerSources/Sources/SIL/Builder.swift
+++ b/SwiftCompilerSources/Sources/SIL/Builder.swift
@@ -644,12 +644,13 @@ public struct Builder {
     isOnStack: Bool,
     /// If true this `partial_apply [on_stack]` must follow proper stack allocation nesting rules.
     isNested: Bool,
+    isCalledOnce: Bool,
     argumentLocationsFrom: ApplySite? = nil
   ) -> PartialApplyInst {
     return capturedArguments.withBridgedValues { capturedArgsRef in
       let pai = bridged.createPartialApply(function.bridged, capturedArgsRef, calleeConvention.bridged,
                                            substitutionMap.bridged, hasUnknownResultIsolation, isOnStack, isNested,
-                                           argumentLocationsFrom.bridged)
+                                           isCalledOnce, argumentLocationsFrom.bridged)
       return notifyNew(pai.getAs(PartialApplyInst.self))
     }
   }

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -1590,6 +1590,9 @@ class ClassifyBridgeObjectInst : SingleValueInstruction, UnaryInstruction {}
 final public class PartialApplyInst : SingleValueInstruction, ApplySite {
   public var numArguments: Int { bridged.PartialApplyInst_numArguments() }
 
+  /// True is this is a partial application of a `@called(once)` function value.
+  public var isCalledOnce: Bool { bridged.PartialApplyInst_isCalledOnce() }
+
   /// Warning: isOnStack returns false for all closures prior to ClosureLifetimeFixup, even if they capture on-stack
   /// addresses and need to be diagnosed as non-escaping closures. Use mayEscape to determine whether a closure is
   /// non-escaping prior to ClosureLifetimeFixup.

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -6159,7 +6159,8 @@ public:
   /// Thick swift noescape function types are trivial.
   bool isTrivialNoEscape() const {
     return isNoEscape() &&
-           getRepresentation() == SILFunctionTypeRepresentation::Thick;
+           getRepresentation() == SILFunctionTypeRepresentation::Thick &&
+           !isCalledOnce();
   }
 
   bool isDifferentiable() const { return getExtInfo().isDifferentiable(); }

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -880,6 +880,7 @@ struct BridgedInstruction {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDeclObj ObjCProtocolInst_getProtocol() const;
   BRIDGED_INLINE SwiftInt ObjectInst_getNumBaseElements() const;
   BRIDGED_INLINE SwiftInt PartialApply_getCalleeArgIndexOfFirstAppliedArg() const;
+  BRIDGED_INLINE bool PartialApplyInst_isCalledOnce() const;
   BRIDGED_INLINE bool PartialApplyInst_isOnStack() const;
   BRIDGED_INLINE bool PartialApplyInst_hasUnknownResultIsolation() const;
   BRIDGED_INLINE bool PartialApplyInst_isStackAllocationNested() const;
@@ -1438,12 +1439,13 @@ struct BridgedBuilder{
                                           BridgedType resultType) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createThinToThickFunction(BridgedValue fn,
                                                                                   BridgedType resultType) const;
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction
-  createPartialApply(BridgedValue fn, BridgedValueArray bridgedCapturedArgs,
-                     BridgedArgumentConvention calleeConvention,
-                     BridgedSubstitutionMap bridgedSubstitutionMap,
-                     bool hasUnknownIsolation, bool isOnStack, bool isNested,
-                     OptionalBridgedInstruction argLocsFrom) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createPartialApply(
+      BridgedValue fn, BridgedValueArray bridgedCapturedArgs,
+      BridgedArgumentConvention calleeConvention,
+      BridgedSubstitutionMap bridgedSubstitutionMap, bool hasUnknownIsolation,
+      bool isOnStack, bool isNested,
+      bool isCalledOnce,
+      OptionalBridgedInstruction argLocsFrom) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createBranch(BridgedBasicBlock destBlock,
                                                                      BridgedValueArray arguments) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createCondBranch(BridgedValue condition,

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -1571,6 +1571,10 @@ SwiftInt BridgedInstruction::PartialApply_getCalleeArgIndexOfFirstAppliedArg() c
   return swift::ApplySite(unbridged()).getSubstCalleeArgIndexOfFirstAppliedArg();
 }
 
+bool BridgedInstruction::PartialApplyInst_isCalledOnce() const {
+  return getAs<swift::PartialApplyInst>()->isCalledOnce();
+}
+
 bool BridgedInstruction::PartialApplyInst_isOnStack() const {
   return getAs<swift::PartialApplyInst>()->isOnStack();
 }
@@ -3010,7 +3014,7 @@ BridgedInstruction BridgedBuilder::createPartialApply(
     BridgedValue funcRef, BridgedValueArray bridgedCapturedArgs,
     BridgedArgumentConvention calleeConvention,
     BridgedSubstitutionMap bridgedSubstitutionMap, bool hasUnknownIsolation,
-    bool isOnStack, bool isNested,
+    bool isOnStack, bool isNested, bool isCalledOnce,
     OptionalBridgedInstruction argLocsFrom) const {
   llvm::SmallVector<swift::SILValue, 8> capturedArgs;
   llvm::ArrayRef<swift::SILValue> args =
@@ -3020,6 +3024,7 @@ BridgedInstruction BridgedBuilder::createPartialApply(
       args, getParameterConvention(calleeConvention),
       hasUnknownIsolation ? swift::SILFunctionTypeIsolation::forUnknown()
                           : swift::SILFunctionTypeIsolation::forErased(),
+      isCalledOnce,
       isOnStack ? swift::PartialApplyInst::OnStack
                 : swift::PartialApplyInst::NotOnStack,
       swift::StackAllocationIsNested_t(isNested),

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -378,7 +378,8 @@ public:
       SubstitutionMap subs, ParameterConvention calleeConvention,
       SILFunctionTypeIsolation resultIsolation,
       PartialApplyInst::OnStackKind onStack =
-          PartialApplyInst::OnStackKind::NotOnStack);
+          PartialApplyInst::OnStackKind::NotOnStack,
+      bool isCalledOnce = false);
 
   //===--------------------------------------------------------------------===//
   // CFG Manipulation
@@ -591,6 +592,7 @@ public:
       ArrayRef<SILValue> Args, ParameterConvention CalleeConvention,
       SILFunctionTypeIsolation ResultIsolation =
           SILFunctionTypeIsolation::forUnknown(),
+      bool IsCalledOnce = false,
       PartialApplyInst::OnStackKind OnStack =
           PartialApplyInst::OnStackKind::NotOnStack,
       StackAllocationIsNested_t IsNested = StackAllocationIsNested,
@@ -608,7 +610,8 @@ public:
            "Args");
     return insert(PartialApplyInst::create(
         getSILDebugLocation(Loc), Fn, Args, Subs, CalleeConvention,
-        ResultIsolation, *F, SpecializationInfo, OnStack, IsNested, ArgLocs));
+        ResultIsolation, *F, SpecializationInfo, OnStack, IsNested,
+        IsCalledOnce, ArgLocs));
   }
 
   BeginApplyInst *createBeginApply(

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1385,7 +1385,7 @@ SILCloner<ImplClass>::visitPartialApplyInst(PartialApplyInst *Inst) {
       getOpLocation(Inst->getLoc()), getOpValue(Inst->getCallee()),
       getOpSubstitutionMap(Inst->getSubstitutionMap()), Args,
       Inst->getCalleeConvention(), Inst->getResultIsolation(),
-      Inst->isOnStack(), Inst->isStackAllocationNested(),
+      Inst->isCalledOnce(), Inst->isOnStack(), Inst->isStackAllocationNested(),
       GenericSpecializationInformation::create(Inst, getBuilder()),
       ArgLocs ? std::optional<ArrayRef<SILLocation>>(*ArgLocs) : std::nullopt);
   recordClonedInstruction(Inst, NewInst);

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -3427,6 +3427,7 @@ private:
          SILFunctionTypeIsolation ResultIsolation, SILFunction &F,
          const GenericSpecializationInformation *SpecializationInfo,
          OnStackKind onStack, StackAllocationIsNested_t isNested,
+         bool isCalledOnce,
          std::optional<ArrayRef<SILLocation>> ArgLocs = std::nullopt);
 
 public:
@@ -3444,6 +3445,10 @@ public:
     return getFunctionType()->getIsolation();
   }
 
+  bool isCalledOnce() const {
+    return getFunctionType()->isCalledOnce();
+  }
+  
   OnStackKind isOnStack() const {
     return getFunctionType()->isNoEscape() ? OnStack : NotOnStack;
   }

--- a/include/swift/SIL/TypeSubstCloner.h
+++ b/include/swift/SIL/TypeSubstCloner.h
@@ -228,8 +228,10 @@ protected:
         getOpLocation(Inst->getLoc()), Helper.getCallee(),
         Helper.getSubstitutions(), Helper.getArguments(),
         Inst->getCalleeConvention(), Inst->getResultIsolation(),
-        Inst->isOnStack(), Inst->isStackAllocationNested(),
-        GenericSpecializationInformation::create(Inst, getBuilder()));
+        Inst->isCalledOnce(), Inst->isOnStack(),
+        Inst->isStackAllocationNested(),
+        GenericSpecializationInformation::create(Inst, getBuilder()),
+        std::nullopt);
     recordClonedInstruction(Inst, N);
   }
 

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -83,6 +83,7 @@
 #include "clang/AST/ASTContext.h"
 #include "clang/Basic/CodeGenOptions.h"
 #include "clang/CodeGen/CodeGenABITypes.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DerivedTypes.h"
@@ -654,8 +655,8 @@ const TypeInfo *TypeConverter::convertFunctionType(SILFunctionType *T) {
     // contexts into the pointer value, so let's not take any spare bits from
     // it.
     spareBits.appendClearBits(IGM.getPointerSize().getValueInBits());
-    
-    if (T->isNoEscape()) {
+
+    if (T->isTrivialNoEscape()) {
       // @noescape thick functions are trivial types.
       return FuncTypeInfo::create(
           CanSILFunctionType(T), IGM.NoEscapeFunctionPairTy,
@@ -1744,6 +1745,52 @@ getPartialApplicationForwarderEmission(
   }
 }
 
+/// This is a parameter convention-aware version of \c createDtorFn.
+///
+/// It's used by the partial application forwarder emitter to avoid
+/// destroying non-Copyable value captures that are moved into the
+/// call when the parameter convention is `Direct_Owned`.
+void destroyClosureContext(IRGenModule &IGM, IRGenFunction &forwarder,
+                           HeapLayout const *layout, llvm::Value *rawContextPtr,
+                           Address contextPtr,
+                           const llvm::BitVector &consumedFields) {
+  if (!layout) {
+    forwarder.emitNativeStrongRelease(rawContextPtr,
+                                      forwarder.getDefaultAtomicity());
+    return;
+  }
+
+  // If none of the parameters are owned, let's use release that would
+  // destroy all of the captures (fields of the closure context).
+  if (consumedFields.empty() || consumedFields.none()) {
+    forwarder.emitNativeStrongRelease(rawContextPtr,
+                                      forwarder.getDefaultAtomicity());
+    return;
+  }
+
+  HeapNonFixedOffsets offsets(forwarder, *layout);
+
+  // If not all of the parameters are owned by the call, let's destroy
+  // the un-owned ones which would completely de-initialize the
+  // context object and let us deallocate it as-if it was uninitialized.
+  llvm::BitVector fieldsToDestroy(consumedFields);
+  fieldsToDestroy.flip();
+  for (unsigned elementIdx : fieldsToDestroy.set_bits()) {
+    auto &field = layout->getElement(elementIdx);
+    if (field.isTriviallyDestroyable())
+      continue;
+
+    auto fieldTy = layout->getElementTypes()[elementIdx];
+    field.getType().destroy(
+        forwarder, field.project(forwarder, contextPtr, offsets), fieldTy,
+        /*isOutlined=*/true);
+  }
+
+  emitDeallocateUninitializedHeapObject(
+      forwarder, rawContextPtr, offsets.getSize(), offsets.getAlignMask(),
+      layout->computeTypedMallocTypeDescriptor(IGM));
+}
+
 } // end anonymous namespace
 
 /// Emit the forwarding stub function for a partial application.
@@ -1934,8 +1981,8 @@ static llvm::Value *emitPartialApplicationForwarder(
   bool isMethodCallee =
       origType->getRepresentation() == SILFunctionTypeRepresentation::Method;
   Explosion witnessMethodSelfValue;
-
   llvm::Value *lastCapturedFieldPtr = nullptr;
+  llvm::BitVector consumedFields(layout ? layout->getElements().size() : 0);
 
   // If there's a data pointer required, but it's a swift-retainable
   // value being passed as the context, just forward it down.
@@ -2112,8 +2159,14 @@ static llvm::Value *emitPartialApplicationForwarder(
         cast<LoadableTypeInfo>(fieldTI).loadAsTake(subIGF, fieldAddr, param);
         break;
       case ParameterConvention::Direct_Owned:
-        // Copy the value out at +1.
-        cast<LoadableTypeInfo>(fieldTI).loadAsCopy(subIGF, fieldAddr, param);
+        if (outType->isCalledOnce()) {
+          // Move value into the apply.
+          cast<LoadableTypeInfo>(fieldTI).loadAsTake(subIGF, fieldAddr, param);
+          consumedFields.set(fieldIndex);
+        } else {
+          // Copy the value out at +1.
+          cast<LoadableTypeInfo>(fieldTI).loadAsCopy(subIGF, fieldAddr, param);
+        }
         break;
       }
       
@@ -2167,7 +2220,7 @@ static llvm::Value *emitPartialApplicationForwarder(
     // nor any of the loads can throw.
     if (consumesContext && !dependsOnContextLifetime && rawData) {
       assert(!outType->isNoEscape() && "Trivial context must not be released");
-      subIGF.emitNativeStrongRelease(rawData, subIGF.getDefaultAtomicity());
+      destroyClosureContext(IGM, subIGF, layout, rawData, data, consumedFields);
     }
 
     // Now that we have bound generic parameters from the captured arguments
@@ -2288,7 +2341,7 @@ static llvm::Value *emitPartialApplicationForwarder(
   // If the parameters depended on the context, consume the context now.
   if (rawData && consumesContext && dependsOnContextLifetime) {
     assert(!outType->isNoEscape() && "Trivial context must not be released");
-    subIGF.emitNativeStrongRelease(rawData, subIGF.getDefaultAtomicity());
+    destroyClosureContext(IGM, subIGF, layout, rawData, data, consumedFields);
   }
 
   emission->createReturn(call);
@@ -2350,9 +2403,12 @@ std::optional<StackAddress> irgen::emitFunctionPartialApplication(
 
     auto &ti = IGF.getTypeInfoForLowered(argLoweringTy);
 
-    // Empty values don't matter.
+    // Empty values don't matter, unless they still require a nontrivial
+    // destroy (e.g. a zero-sized `~Copyable` type with a user-defined
+    // deinit captured by a `@called(once)` closure).
     auto schema = ti.getSchema();
-    if (schema.empty() && !param.isFormalIndirect())
+    if (schema.empty() && !param.isFormalIndirect() &&
+        ti.isTriviallyDestroyable(ResilienceExpansion::Maximal))
       return;
 
     argValTypes.push_back(argType);
@@ -2568,7 +2624,8 @@ std::optional<StackAddress> irgen::emitFunctionPartialApplication(
 
   std::optional<StackAddress> stackAddr;
 
-  if (args.empty() && layout.isKnownEmpty()) {
+  if (args.empty() && layout.isKnownEmpty() &&
+      layout.isTriviallyDestroyable()) {
     if (outType->isNoEscape())
       data = llvm::ConstantPointerNull::get(IGF.IGM.OpaquePtrTy);
     else

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -423,11 +423,9 @@ void emitDeallocateUninitializedHeapObjectTyped(IRGenFunction &IGF,
       {object, size, alignMask, typeDescriptor});
 }
 
-void emitDeallocateUninitializedHeapObject(IRGenFunction &IGF,
-                                           llvm::Value *object,
-                                           llvm::Value *size,
-                                           llvm::Value *alignMask,
-                                           std::optional<uint64_t> mallocTypeId) {
+void irgen::emitDeallocateUninitializedHeapObject(
+    IRGenFunction &IGF, llvm::Value *object, llvm::Value *size,
+    llvm::Value *alignMask, std::optional<uint64_t> mallocTypeId) {
   if (mallocTypeId) {
     auto descriptorConst = llvm::ConstantInt::get(IGF.IGM.Int64Ty,
                                                   *mallocTypeId);

--- a/lib/IRGen/GenHeap.h
+++ b/lib/IRGen/GenHeap.h
@@ -122,6 +122,14 @@ void emitDeallocateHeapObjectTyped(IRGenFunction &IGF,
                                    llvm::Value *alignMask,
                                    llvm::Value *typeDescriptor);
 
+/// Emit a heap object deallocation for an object none of whose fields were
+/// ever initialized (skips running any field destructors).
+void emitDeallocateUninitializedHeapObject(IRGenFunction &IGF,
+                                           llvm::Value *object,
+                                           llvm::Value *size,
+                                           llvm::Value *alignMask,
+                                           std::optional<uint64_t> mallocTypeId);
+
 /// Emit a class instance deallocation.
 void emitDeallocateClassInstance(IRGenFunction &IGF,
                                  llvm::Value *object,

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3638,7 +3638,7 @@ Callee LoweredValue::getCallee(IRGenFunction &IGF,
     assert(vector.size() == 2 && "thick function pointer with size != 2");
     llvm::Value *functionValue = vector[0];
     llvm::Value *contextValue = vector[1];
-    bool castToRefcountedContext = calleeInfo.OrigFnType->isNoEscape();
+    bool castToRefcountedContext = calleeInfo.OrigFnType->isTrivialNoEscape();
     return getSwiftFunctionPointerCallee(IGF, functionValue, contextValue,
                                          std::move(calleeInfo),
                                          castToRefcountedContext, true);
@@ -7460,7 +7460,11 @@ void IRGenSILFunction::visitConvertFunctionInst(swift::ConvertFunctionInst *i) {
 
 void IRGenSILFunction::visitConvertEscapeToNoEscapeInst(
     swift::ConvertEscapeToNoEscapeInst *i) {
-  // This instruction makes the context trivial.
+  // This instruction makes the context trivial, unless the result is a
+  // `@called(once)` closure, whose context remains a real refcounted object
+  // that must still be retained/released/destroyed correctly.
+  bool contextIsTrivial =
+      i->getType().castTo<SILFunctionType>()->isTrivialNoEscape();
   Explosion in = getLoweredExplosion(i->getOperand());
   Explosion out;
   // Differentiable functions contain multiple pairs of fn and ctx pointer.
@@ -7469,7 +7473,8 @@ void IRGenSILFunction::visitConvertEscapeToNoEscapeInst(
     llvm::Value *fn = in.claimNext();
     llvm::Value *ctx = in.claimNext();
     out.add(fn);
-    out.add(Builder.CreateBitCast(ctx, IGM.OpaquePtrTy));
+    out.add(contextIsTrivial ? Builder.CreateBitCast(ctx, IGM.OpaquePtrTy)
+                             : ctx);
   }
   setLoweredExplosion(i, out);
 }
@@ -7732,7 +7737,7 @@ void IRGenSILFunction::visitThinToThickFunctionInst(
   Explosion from = getLoweredExplosion(i->getOperand());
   Explosion to;
   to.add(Builder.CreateBitCast(from.claimNext(), IGM.FunctionPtrTy));
-  if (i->getType().castTo<SILFunctionType>()->isNoEscape())
+  if (i->getType().castTo<SILFunctionType>()->isTrivialNoEscape())
     to.add(llvm::ConstantPointerNull::get(IGM.OpaquePtrTy));
   else
     to.add(IGM.RefCountedNull);

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -2965,8 +2965,8 @@ void LoadableByAddress::recreateSingleApply(
     }
     auto newApply = applyBuilder.createPartialApply(
         castedApply->getLoc(), callee, applySite.getSubstitutionMap(), callArgs,
-        partialApplyConvention, resultIsolation, castedApply->isOnStack(),
-        castedApply->isStackAllocationNested());
+        partialApplyConvention, resultIsolation, castedApply->isCalledOnce(),
+        castedApply->isOnStack(), castedApply->isStackAllocationNested());
     castedApply->replaceAllUsesWith(newApply);
     break;
   }

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -272,7 +272,25 @@ OPERAND_OWNERSHIP(UnownedInstantaneousUse, UnmanagedAutoreleaseValue)
 OPERAND_OWNERSHIP(PointerEscape, ProjectBox) // The result is a T*.
 OPERAND_OWNERSHIP(PointerEscape, ProjectExistentialBox)
 OPERAND_OWNERSHIP(PointerEscape, UncheckedOwnershipConversion)
-OPERAND_OWNERSHIP(PointerEscape, ConvertEscapeToNoEscape)
+
+// For an ordinary (copyable) escaping closure, the pre-conversion operand
+// may still be used again after the conversion (e.g. a `var` read again
+// later), so treat the conversion conservatively as a non-consuming pointer
+// escape.
+//
+// A `@called(once)` function value is single-owner and move-only-checked,
+// so pre-conversion value doesn't survive to be used again -- any further
+// use would already be diagnosed as a double consumption by the move-only
+// checker. Treat the conversion as an ordinary forwarding consume in that
+// case, matching how `convert_function` and other function type conversions
+// are already treated, so ownership-based analyses don't need to
+// special-case this instruction.
+OperandOwnership OperandOwnershipClassifier::visitConvertEscapeToNoEscapeInst(
+    ConvertEscapeToNoEscapeInst *i) {
+  return i->getType().castTo<SILFunctionType>()->isCalledOnce()
+             ? OperandOwnership::ForwardingConsume
+             : OperandOwnership::PointerEscape;
+}
 
 // UncheckedBitwiseCast ownership behaves like RefToUnowned. It produces an
 // Unowned value from a non-trivial value, without consuming or borrowing the

--- a/lib/SIL/IR/SILBuilder.cpp
+++ b/lib/SIL/IR/SILBuilder.cpp
@@ -57,7 +57,7 @@ SILType SILBuilder::getPartialApplyResultType(
     TypeExpansionContext context, SILType origTy, unsigned argCount,
     SILModule &M, SubstitutionMap subs, ParameterConvention calleeConvention,
     SILFunctionTypeIsolation resultIsolation,
-    PartialApplyInst::OnStackKind onStack) {
+    PartialApplyInst::OnStackKind onStack, bool isCalledOnce) {
   CanSILFunctionType FTI = origTy.castTo<SILFunctionType>();
   if (!subs.empty())
     FTI = FTI->substGenericArgs(M, subs, context);
@@ -79,6 +79,8 @@ SILType SILBuilder::getPartialApplyResultType(
               argCount));
   if (onStack)
     extInfoBuilder = extInfoBuilder.withNoEscape();
+  if (isCalledOnce)
+    extInfoBuilder = extInfoBuilder.withCalledOnce();
   auto extInfo = extInfoBuilder.build();
 
   // If the original method has an @unowned_inner_pointer return, the partial

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -1053,14 +1053,14 @@ PartialApplyInst *PartialApplyInst::create(
     SubstitutionMap Subs, ParameterConvention calleeConvention,
     SILFunctionTypeIsolation resultIsolation, SILFunction &F,
     const GenericSpecializationInformation *specializationInfo,
-    OnStackKind onStack, StackAllocationIsNested_t isNested,
+    OnStackKind onStack, StackAllocationIsNested_t isNested, bool isCalledOnce,
     std::optional<ArrayRef<SILLocation>> ArgLocs) {
   SILType SubstCalleeTy = Callee->getType().substGenericArgs(
       F.getModule(), Subs, F.getTypeExpansionContext());
 
   SILType ClosureType = SILBuilder::getPartialApplyResultType(
       F.getTypeExpansionContext(), SubstCalleeTy, Args.size(), F.getModule(), {},
-      calleeConvention, resultIsolation, onStack);
+      calleeConvention, resultIsolation, onStack, isCalledOnce);
 
   SmallVector<SILValue, 32> TypeDependentOperands;
   collectTypeDependentOperands(TypeDependentOperands, F,

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1874,6 +1874,9 @@ public:
       if (!CI->isStackAllocationNested())
         *this << "[non_nested] ";
     }
+    if (CI->isCalledOnce()) {
+      *this << "[called_once] ";
+    }
     visitApplyInstBase(CI);
   }
 

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -7132,6 +7132,7 @@ bool SILParser::parseCallInstruction(SILLocation InstLoc,
   auto PartialApplyIsolation = SILFunctionTypeIsolation::forUnknown();
   ApplyOptions ApplyOpts;
   bool IsNoEscape = false;
+  bool IsCalledOnce = false;
 
   StringRef AttrName;
   SourceLoc AttrLoc;
@@ -7181,6 +7182,12 @@ bool SILParser::parseCallInstruction(SILLocation InstLoc,
     if (AttrName == "non_nested") {
       assert(!bool(AttrValue));
       isNested = StackAllocationIsNotNested;
+      continue;
+    }
+
+    if (AttrName == "called_once") {
+      assert(!bool(AttrValue));
+      IsCalledOnce = true;
       continue;
     }
 
@@ -7366,7 +7373,7 @@ bool SILParser::parseCallInstruction(SILLocation InstLoc,
     // FIXME: Why the arbitrary order difference in IRBuilder type argument?
     ResultVal = B.createPartialApply(
         InstLoc, FnVal, subs, Args, PartialApplyConvention,
-        PartialApplyIsolation,
+        PartialApplyIsolation, IsCalledOnce,
         IsNoEscape ? PartialApplyInst::OnStackKind::OnStack
                    : PartialApplyInst::OnStackKind::NotOnStack,
         isNested ? *isNested : StackAllocationIsNested);

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -69,16 +69,17 @@ PartialApplyInst *SILGenBuilder::createPartialApply(
     ParameterConvention CalleeConvention,
     SILFunctionTypeIsolation ResultIsolation,
     PartialApplyInst::OnStackKind OnStack, StackAllocationIsNested_t IsNested,
-    const GenericSpecializationInformation *SpecializationInfo) {
+    const GenericSpecializationInformation *SpecializationInfo,
+    bool IsCalledOnce) {
 
   // We completely drop the generic signature if all generic parameters were
   // concrete. Similar to emitRawApply.
   if (Subs && Subs.getGenericSignature()->areAllParamsConcrete())
     Subs = SubstitutionMap();
 
-  return SILBuilder::createPartialApply(Loc, Fn, Subs, Args, CalleeConvention,
-                                        ResultIsolation, OnStack, IsNested,
-                                        SpecializationInfo);
+  return SILBuilder::createPartialApply(
+      Loc, Fn, Subs, Args, CalleeConvention, ResultIsolation, IsCalledOnce,
+      OnStack, IsNested, SpecializationInfo, std::nullopt);
 }
 
 //===----------------------------------------------------------------------===//
@@ -89,7 +90,8 @@ ManagedValue SILGenBuilder::createPartialApply(SILLocation loc, SILValue fn,
                                                SubstitutionMap subs,
                                                ArrayRef<ManagedValue> args,
                                                ParameterConvention calleeConvention,
-                                         SILFunctionTypeIsolation resultIsolation) {
+                                               SILFunctionTypeIsolation resultIsolation,
+                                               bool isCalledOnce) {
   llvm::SmallVector<SILValue, 8> values;
   llvm::transform(args, std::back_inserter(values),
                   [&](ManagedValue mv) -> SILValue {
@@ -97,7 +99,9 @@ ManagedValue SILGenBuilder::createPartialApply(SILLocation loc, SILValue fn,
   });
   SILValue result =
       createPartialApply(loc, fn, subs, values, calleeConvention,
-                         resultIsolation);
+                         resultIsolation,
+                         PartialApplyInst::OnStackKind::NotOnStack,
+                         StackAllocationIsNested, nullptr, isCalledOnce);
   // Partial apply instructions create a box, so we need to put on a cleanup.
   return getSILGenFunction().emitManagedRValueWithCleanup(result);
 }

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -126,11 +126,32 @@ ManagedValue SILGenBuilder::createConvertEscapeToNoEscape(
          !fnType->isNoEscape() && resultFnType->isNoEscape() &&
          "Expect a escaping to noescape conversion");
   (void)fnType;
-  (void)resultFnType;
+
+  // For a `@called(once)` function value, the conversion is a
+  // ownership-consuming forwarding operation, so forward `fn`'s cleanup onto
+  // the result, exactly like the sibling `createConvertFunction` above does for
+  // other function conversions. Mark the conversion's lifetime as already
+  // guaranteed so that `ClosureLifetimeFixup` leaves it alone; the operand's
+  // lifetime is already exactly as long as it needs to be, by construction.
+  //
+  // `OperandOwnershipClassifier` treats `ConvertEscapeToNoEscapeInst` as
+  // `ForwardingConsume` as well when the result type is `@called(once)`.
+  if (resultFnType->isCalledOnce()) {
+    CleanupCloner cloner(*this, fn);
+    SILValue result =
+        createConvertEscapeToNoEscape(loc, fn.forward(getSILGenFunction()),
+                                      resultTy, /*lifetimeGuaranteed=*/true);
+    return cloner.clone(result);
+  }
+
+  // For an ordinary (copyable) escaping closure, the conversion doesn't
+  // consume its operand -- the original escaping value may still be used
+  // again afterwards -- so keep it alive with its own independent cleanup.
+
   SILValue fnValue = fn.getValue();
   SILValue result =
       createConvertEscapeToNoEscape(loc, fnValue, resultTy, false);
-  
+
   return SGF.emitManagedRValueWithCleanup(result);
 }
 

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -95,22 +95,25 @@ public:
       PartialApplyInst::OnStackKind OnStack =
           PartialApplyInst::OnStackKind::NotOnStack,
       StackAllocationIsNested_t IsNested = StackAllocationIsNested,
-      const GenericSpecializationInformation *SpecializationInfo = nullptr);
+      const GenericSpecializationInformation *SpecializationInfo = nullptr,
+      bool IsCalledOnce = false);
 
   ManagedValue createPartialApply(SILLocation loc, SILValue fn,
                                   SubstitutionMap subs,
                                   ArrayRef<ManagedValue> args,
                                   ParameterConvention calleeConvention,
                                   SILFunctionTypeIsolation resultIsolation =
-                                      SILFunctionTypeIsolation::forUnknown());
+                                      SILFunctionTypeIsolation::forUnknown(),
+                                  bool isCalledOnce = false);
   ManagedValue createPartialApply(SILLocation loc, ManagedValue fn,
                                   SubstitutionMap subs,
                                   ArrayRef<ManagedValue> args,
                                   ParameterConvention calleeConvention,
                                   SILFunctionTypeIsolation resultIsolation =
-                                      SILFunctionTypeIsolation::forUnknown()) {
+                                      SILFunctionTypeIsolation::forUnknown(),
+                                  bool isCalledOnce = false) {
     return createPartialApply(loc, fn.getValue(), subs, args,
-                              calleeConvention, resultIsolation);
+                              calleeConvention, resultIsolation, isCalledOnce);
   }
 
   using SILBuilder::createStructExtract;

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -1123,7 +1123,10 @@ SILGenFunction::emitClosureValue(SILLocation loc, SILDeclRef constant,
                             : SILFunctionTypeIsolation::forUnknown());
     auto toClosure =
       B.createPartialApply(loc, functionRef, subs, forwardedArgs,
-                           calleeConvention, resultIsolation);
+                           calleeConvention, resultIsolation,
+                           PartialApplyInst::OnStackKind::NotOnStack,
+                           StackAllocationIsNested, nullptr,
+                           typeContext.ExpectedLoweredType->isCalledOnce());
     result = emitManagedRValueWithCleanup(toClosure);
   }
 

--- a/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
+++ b/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
@@ -1581,8 +1581,8 @@ processPartialApplyInst(SILOptFunctionBuilder &funcBuilder,
   // in debug builds if the sizes ever diverge from this 1:1 invariant.
   auto *newPAI = builder.createPartialApply(
       pai->getLoc(), fnVal, pai->getSubstitutionMap(), args,
-      pai->getCalleeConvention(), pai->getResultIsolation(), pai->isOnStack(),
-      pai->isStackAllocationNested(),
+      pai->getCalleeConvention(), pai->getResultIsolation(),
+      pai->isCalledOnce(), pai->isOnStack(), pai->isStackAllocationNested(),
       /*SpecializationInfo=*/nullptr, ApplySite(pai).getArgumentLocs());
   pai->replaceAllUsesWith(newPAI);
   pai->eraseFromParent();

--- a/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
+++ b/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
@@ -650,7 +650,7 @@ static SILValue tryRewriteToPartialApplyStack(
   auto newPA = b.createPartialApply(
       origPA->getLoc(), origPA->getCallee(), origPA->getSubstitutionMap(), args,
       origPA->getCalleeConvention(), origPA->getResultIsolation(),
-      PartialApplyInst::OnStackKind::OnStack);
+      origPA->isCalledOnce(), PartialApplyInst::OnStackKind::OnStack);
 
   // Insert mark_dependence for any non-trivial address operands to the
   // partial_apply.

--- a/lib/SILOptimizer/Transforms/PartialApplySimplification.cpp
+++ b/lib/SILOptimizer/Transforms/PartialApplySimplification.cpp
@@ -395,7 +395,7 @@ rewriteKnownCalleeConventionOnly(SILFunction *callee,
       newInst = B.createPartialApply(loc, fr, site.getSubstitutionMap(), args,
                                      pa->getCalleeConvention(),
                                      pa->getResultIsolation(),
-                                     pa->isOnStack(),
+                                     pa->isCalledOnce(), pa->isOnStack(),
                                      pa->isStackAllocationNested());
       break;
     }
@@ -831,6 +831,7 @@ rewriteKnownCalleeWithExplicitContext(SILFunction *callee,
     case ApplySiteKind::PartialApplyInst: {
       auto oldPA = cast<PartialApplyInst>(site.getInstruction());
       auto paIsolation = oldPA->getResultIsolation();
+      auto paCalledOnce = oldPA->isCalledOnce();
       auto paConvention = isNoEscape ? ParameterConvention::Direct_Guaranteed
                                      : contextParam.getConvention();
       auto paOnStack = isNoEscape ? PartialApplyInst::OnStack
@@ -838,13 +839,9 @@ rewriteKnownCalleeWithExplicitContext(SILFunction *callee,
       auto paIsNested = (paOnStack && oldPA->isOnStack())
                           ? oldPA->isStackAllocationNested()
                           : StackAllocationIsNested;
-      auto newPA = B.createPartialApply(loc, newFunctionRef,
-                                     site.getSubstitutionMap(),
-                                     newArgs,
-                                     paConvention,
-                                     paIsolation,
-                                     paOnStack,
-                                     paIsNested);
+      auto newPA = B.createPartialApply(
+          loc, newFunctionRef, site.getSubstitutionMap(), newArgs, paConvention,
+          paIsolation, paCalledOnce, paOnStack, paIsNested);
       assert(isSimplePartialApply(newPA)
              && "partial apply wasn't simple after transformation?");
       newInst = newPA;

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -2850,9 +2850,9 @@ swift::replaceWithSpecializedCallee(ApplySite applySite, SILValue callee,
       });
     }
     auto *newPAI = builder.createPartialApply(
-        loc, callee, subs, arguments,
-        pai->getCalleeConvention(), pai->getResultIsolation(),
-        pai->isOnStack(), pai->isStackAllocationNested());
+        loc, callee, subs, arguments, pai->getCalleeConvention(),
+        pai->getResultIsolation(), pai->isCalledOnce(), pai->isOnStack(),
+        pai->isStackAllocationNested());
     pai->replaceAllUsesWith(newPAI);
     return newPAI;
   }
@@ -3715,9 +3715,9 @@ void swift::trySpecializeApplyOfGeneric(
     auto FnTy = Thunk->getLoweredFunctionType();
     Subs = SubstitutionMap::get(FnTy->getSubstGenericSignature(), Subs);
     SingleValueInstruction *newPAI = Builder.createPartialApply(
-      PAI->getLoc(), FRI, Subs, Arguments,
-      PAI->getCalleeConvention(), PAI->getResultIsolation(),
-      PAI->isOnStack(), PAI->isStackAllocationNested());
+        PAI->getLoc(), FRI, Subs, Arguments, PAI->getCalleeConvention(),
+        PAI->getResultIsolation(), PAI->isCalledOnce(), PAI->isOnStack(),
+        PAI->isStackAllocationNested());
     PAI->replaceAllUsesWith(newPAI);
     DeadApplies.insert(PAI);
     return;

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -690,6 +690,9 @@ public:
     if (auto *L = dyn_cast<LoadExpr>(E))
       return getReferencedNonCopyableValue(L->getSubExpr());
 
+    if (auto *FCE = dyn_cast<FunctionConversionExpr>(E))
+      return getReferencedNonCopyableValue(FCE->getSubExpr());
+
     auto *DRE = dyn_cast<DeclRefExpr>(E);
     if (!DRE)
       return nullptr;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4781,13 +4781,8 @@ NeverNullType TypeResolver::resolveASTFunctionType(
         parsedClangFunctionType = nullptr;
       }
 
-      if (!repr->isInvalid() && called->isOnce()) {
+      if (!repr->isInvalid() && called->isOnce())
         isCalledOnce = true;
-        // `@called(once)` implies `consuming` which means that the
-        // type should always be escaping in parameter positions.
-        if (parentOptions.is(TypeResolverContext::FunctionInput))
-          noescape = false;
-      }
     } else {
       diagnoseInvalid(repr, called->getAttrLoc(),
                       diag::requires_experimental_feature, "@called", false,
@@ -5735,6 +5730,11 @@ TypeResolver::resolveOwnershipTypeRepr(OwnershipTypeRepr *repr,
   case ParamSpecifier::Consuming:
     if (auto *fnTy = result->getAs<FunctionType>()) {
       if (fnTy->isNoEscape()) {
+        // `@called(once)` functions always have consuming semantics
+        // regardless of whether they are @escaping or not.
+        if (fnTy->isCalledOnce())
+          break;
+
         diagnoseInvalid(ownershipRepr, ownershipRepr->getLoc(),
                         diag::ownership_specifier_nonescaping_closure,
                         ownershipRepr->getSpecifierSpelling());

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -2520,7 +2520,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     // FIXME: Why the arbitrary order difference in IRBuilder type argument?
     ResultInst = Builder.createPartialApply(
         Loc, FnVal, Substitutions, Args, closureTy->getCalleeConvention(),
-        closureTy->getIsolation(), onStack, isNested,
+        closureTy->getIsolation(), closureTy->isCalledOnce(), onStack, isNested,
         /*SpecializationInfo=*/nullptr, argLocsRef);
     break;
   }

--- a/test/IRGen/called_once_consuming_captures.swift
+++ b/test/IRGen/called_once_consuming_captures.swift
@@ -1,0 +1,123 @@
+// RUN: %target-swift-emit-ir -module-name test -enable-experimental-feature CalledAttribute %s | %FileCheck %s
+
+// REQUIRES: swift_feature_CalledAttribute
+// REQUIRES: PTRSIZE=64
+
+// A `@called(once)` closure that consumes a noncopyable capture moves it
+// directly into the closure's context (instead of boxing it), so the
+// partial-apply forwarder that runs the closure's underlying implementation
+// must take (not copy) the value out of the context, and must not let
+// the context's normal, shared per-field destructor destroy it a second
+// time when the context itself is released.
+
+public func callOnce(_ f: @called(once) () -> ()) { f() }
+public func dontCallOnce(_ f: @called(once) () -> ()) { /* never called */ }
+public func callOnceEscaping(_ f: @escaping @called(once) () -> ()) { f() }
+public func dontCallOnceEscaping(_ f: @escaping @called(once) () -> ()) { /* never called */ }
+
+// CHECK-LABEL: define{{.*}} swiftcc void @"$s4test12dontCallOnceyyyyXEnF"(ptr %0, ptr %1)
+// CHECK: [[CTX_ADDR:%.*]] = getelementptr inbounds{{.*}} %swift.function, ptr %f, i32 0, i32 1
+// CHECK: [[CTX:%.*]] = load ptr, ptr [[CTX_ADDR]]
+// CHECK: call void @swift_release(ptr [[CTX]])
+
+// CHECK-LABEL: define{{.*}} swiftcc void @"$s4test20dontCallOnceEscapingyyyyXOnF"(ptr %0, ptr %1)
+// CHECK: [[CTX_ADDR:%.*]] = getelementptr inbounds{{.*}} %swift.function, ptr %f, i32 0, i32 1
+// CHECK: [[CTX:%.*]] = load ptr, ptr [[CTX_ADDR]]
+// CHECK: call void @swift_release(ptr [[CTX]])
+
+public struct Resource: ~Copyable {
+  var x: Int
+  public init(x: Int) { self.x = x }
+  deinit { print("Resource") }
+  public consuming func use() { print("used \(x)") }
+}
+
+final class Tracker {
+  deinit { print("Tracker") }
+}
+
+// A closure whose only capture is consumed (`Direct_Owned`): the whole
+// context is drained by the forwarder, so it's deallocated as if it were
+// never initialized -- no field destructor runs on release.
+//
+// CHECK-LABEL: define{{.*}} swiftcc void @"$s4test16allOwnedCapturesyySiFyyXEfU_TA"(ptr swiftself %0)
+// CHECK:  [[FIELD_ADDR:%.*]] = getelementptr inbounds{{.*}} <{ %swift.refcounted, %T4test8ResourceV }>, ptr %0, i32 0, i32 1
+// CHECK:  [[X_ADDR:%.*]] = getelementptr inbounds{{.*}} %T4test8ResourceV, ptr [[FIELD_ADDR]], i32 0, i32 0
+// CHECK:  [[VALUE:%.*]] = load i64, ptr [[X_ADDR]]
+// CHECK:  call void @swift_deallocUninitializedObject(ptr %0,
+// CHECK:  tail call swiftcc void @"$s4test16allOwnedCapturesyySiFyyXEfU_"(i64 [[VALUE]])
+public func allOwnedCaptures(_ x: Int) {
+  let r = Resource(x: x)
+  callOnce { r.use() }
+}
+
+// A closure that mixes a consumed capture (`Direct_Owned`, `r`) with a
+// borrowed one (`Direct_Guaranteed`, `t`): the forwarder still needs to
+// release the surviving `t` field, but must skip the already-taken `r`
+// field, then free the context's memory as uninitialized rather than run
+// its normal shared destructor over every field.
+//
+// CHECK-LABEL: define{{.*}} swiftcc void @"$s4test13mixedCapturesyySiFyyXEfU_TA"(ptr swiftself %0)
+// CHECK:  [[TRACKER_ADDR:%.*]] = getelementptr inbounds{{.*}} <{ %swift.refcounted, ptr, %T4test8ResourceV }>, ptr %0, i32 0, i32 1
+// CHECK:  [[TRACKER:%.*]] = load ptr, ptr [[TRACKER_ADDR]]
+// CHECK:  [[RESOURCE_ADDR:%.*]] = getelementptr inbounds{{.*}} <{ %swift.refcounted, ptr, %T4test8ResourceV }>, ptr %0, i32 0, i32 2
+// CHECK:  [[X_ADDR:%.*]] = getelementptr inbounds{{.*}} %T4test8ResourceV, ptr [[RESOURCE_ADDR]], i32 0, i32 0
+// CHECK:  [[VALUE:%.*]] = load i64, ptr [[X_ADDR]]
+// CHECK:  call swiftcc void @"$s4test13mixedCapturesyySiFyyXEfU_"(ptr [[TRACKER]], i64 [[VALUE]])
+// CHECK:  [[TO_DESTROY_ADDR:%.*]] = getelementptr inbounds{{.*}} <{ %swift.refcounted, ptr, %T4test8ResourceV }>, ptr %0, i32 0, i32 1
+// CHECK:  [[TO_DESTROY:%.*]] = load ptr, ptr [[TO_DESTROY_ADDR]]
+// CHECK:  call void @swift_release(ptr [[TO_DESTROY]])
+// CHECK:  call void @swift_deallocUninitializedObject(ptr %0,
+public func mixedCaptures(_ x: Int) {
+  let r = Resource(x: x)
+  let t = Tracker()
+  callOnce {
+    _ = t
+    r.use()
+  }
+}
+
+// A `@called(once)` closure that is never called: the context is never
+// touched by a forwarder, so it's released through `dontCallOnce` above
+// (i.e. `f`'s ordinary, whole-object release) -- which runs the context's
+// normal shared destructor, since nothing was ever taken out of it.
+public func neverCalled(_ x: Int) {
+  let r = Resource(x: x)
+  dontCallOnce { r.use() }
+}
+
+// CHECK-LABEL: define{{.*}} swiftcc void @"$s4test24allOwnedCapturesEscapingyySiFyyXOfU_TA"(ptr swiftself %0)
+// CHECK:  [[FIELD_ADDR:%.*]] = getelementptr inbounds{{.*}} <{ %swift.refcounted, %T4test8ResourceV }>, ptr %0, i32 0, i32 1
+// CHECK:  [[X_ADDR:%.*]] = getelementptr inbounds{{.*}} %T4test8ResourceV, ptr [[FIELD_ADDR]], i32 0, i32 0
+// CHECK:  [[VALUE:%.*]] = load i64, ptr [[X_ADDR]]
+// CHECK:  call void @swift_deallocUninitializedObject(ptr %0,
+// CHECK:  tail call swiftcc void @"$s4test24allOwnedCapturesEscapingyySiFyyXOfU_"(i64 [[VALUE]])
+public func allOwnedCapturesEscaping(_ x: Int) {
+  let r = Resource(x: x)
+  callOnceEscaping { r.use() }
+}
+
+// CHECK-LABEL: define{{.*}} swiftcc void @"$s4test21mixedCapturesEscapingyySiFyyXOfU_TA"(ptr swiftself %0)
+// CHECK:  [[TRACKER_ADDR:%.*]] = getelementptr inbounds{{.*}} <{ %swift.refcounted, ptr, %T4test8ResourceV }>, ptr %0, i32 0, i32 1
+// CHECK:  [[TRACKER:%.*]] = load ptr, ptr [[TRACKER_ADDR]]
+// CHECK:  [[RESOURCE_ADDR:%.*]] = getelementptr inbounds{{.*}} <{ %swift.refcounted, ptr, %T4test8ResourceV }>, ptr %0, i32 0, i32 2
+// CHECK:  [[X_ADDR:%.*]] = getelementptr inbounds{{.*}} %T4test8ResourceV, ptr [[RESOURCE_ADDR]], i32 0, i32 0
+// CHECK:  [[VALUE:%.*]] = load i64, ptr [[X_ADDR]]
+// CHECK:  call swiftcc void @"$s4test21mixedCapturesEscapingyySiFyyXOfU_"(ptr [[TRACKER]], i64 [[VALUE]])
+// CHECK:  [[TO_DESTROY_ADDR:%.*]] = getelementptr inbounds{{.*}} <{ %swift.refcounted, ptr, %T4test8ResourceV }>, ptr %0, i32 0, i32 1
+// CHECK:  [[TO_DESTROY:%.*]] = load ptr, ptr [[TO_DESTROY_ADDR]]
+// CHECK:  call void @swift_release(ptr [[TO_DESTROY]])
+// CHECK:  call void @swift_deallocUninitializedObject(ptr %0,
+public func mixedCapturesEscaping(_ x: Int) {
+  let r = Resource(x: x)
+  let t = Tracker()
+  callOnceEscaping {
+    _ = t
+    r.use()
+  }
+}
+
+public func neverCalledEscaping(_ x: Int) {
+  let r = Resource(x: x)
+  dontCallOnceEscaping { r.use() }
+}

--- a/test/Interpreter/called_once.swift
+++ b/test/Interpreter/called_once.swift
@@ -3,6 +3,13 @@
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_CalledAttribute
 
+struct Resource: ~Copyable {
+  let tag: String
+  init(_ tag: String) { self.tag = tag }
+  deinit { print("Resource(\(tag)) deinit") }
+  consuming func use() { print("Resource(\(tag)) used") }
+}
+
 func makeClosure(_ tag: String) -> @called(once) () -> Void {
   return { print("called \(tag)") }
 }
@@ -65,3 +72,161 @@ func testNestedClosures() {
 
 // CHECK-NEXT: called nested
 testNestedClosures()
+
+// A `@called(once)` closure with a consuming capture that is never called
+// must still destroy the capture when it goes out of scope.
+func testConsumingCaptureNeverCalled() {
+  let r = Resource("neverCalled")
+  let g = { @called(once) in r.use() }
+  _ = g
+}
+
+// CHECK-NEXT: Resource(neverCalled) deinit
+testConsumingCaptureNeverCalled()
+
+// A `@called(once)` closure with a consuming capture that *is* called: the
+// capture must be destroyed exactly once, by the use inside the closure body,
+// not a second time when the closure's own context is torn down.
+func testConsumingCaptureCalled() {
+  let r = Resource("called")
+  let g = { @called(once) in r.use() }
+  g()
+}
+
+// CHECK-NEXT: Resource(called) used
+// CHECK-NEXT: Resource(called) deinit
+testConsumingCaptureCalled()
+
+// A closure mixing a consumed capture with a borrowed one: the borrowed
+// capture must still be destroyed when the context is released, while the
+// consumed one must be destroyed exactly once (by its use), not twice.
+final class Tracker {
+  let tag: String
+  init(_ tag: String) { self.tag = tag }
+  deinit { print("Tracker(\(tag)) deinit") }
+}
+
+func testMixedConsumingAndBorrowingCaptures() {
+  let r = Resource("mixed")
+  let t = Tracker("mixed")
+  let g = { @called(once) in
+    _ = t
+    r.use()
+  }
+  g()
+}
+
+// CHECK-NEXT: Resource(mixed) used
+// CHECK-NEXT: Resource(mixed) deinit
+// CHECK-NEXT: Tracker(mixed) deinit
+testMixedConsumingAndBorrowingCaptures()
+
+// A zero-sized `~Copyable` consuming capture must still be destroyed
+// (regression test: an empty capture must not be dropped from the
+// context's layout, since it would then never be destroyed at all).
+struct EmptyResource: ~Copyable {
+  deinit { print("EmptyResource deinit") }
+  consuming func use() { print("EmptyResource used") }
+}
+
+func testEmptyConsumingCaptureCalled() {
+  let r = EmptyResource()
+  let g = { @called(once) in r.use() }
+  g()
+}
+
+// CHECK-NEXT: EmptyResource used
+// CHECK-NEXT: EmptyResource deinit
+testEmptyConsumingCaptureCalled()
+
+func testEmptyConsumingCaptureNeverCalled() {
+  let r = EmptyResource()
+  let g = { @called(once) in r.use() }
+  _ = g
+}
+
+// CHECK-NEXT: EmptyResource deinit
+testEmptyConsumingCaptureNeverCalled()
+
+// The same scenarios via a parameter (not just a local `let`), exercising
+// the `@called(once)` parameter binding path rather than closure formation.
+func acceptsCalledOnce(_ f: @called(once) () -> Void) { /* never called */ }
+
+func testParameterNeverCalled() {
+  let r = Resource("param")
+  acceptsCalledOnce { r.use() }
+}
+
+// CHECK-NEXT: Resource(param) deinit
+testParameterNeverCalled()
+
+func acceptsAndCallsCalledOnce(_ f: @called(once) () -> Void) {
+  f()
+}
+
+func testParameterCalled() {
+  let r = Resource("paramCalled")
+  acceptsAndCallsCalledOnce { r.use() }
+}
+
+// CHECK-NEXT: Resource(paramCalled) used
+// CHECK-NEXT: Resource(paramCalled) deinit
+testParameterCalled()
+
+// Everything below duplicates the consuming-capture scenarios above for
+// `@escaping @called(once)` closures, to make sure escaping closures don't
+// behave any differently from noescape ones.
+
+func acceptsCalledOnceEscaping(_ f: @escaping @called(once) () -> Void) { /* never called */ }
+
+func acceptsAndCallsCalledOnceEscaping(_ f: @escaping @called(once) () -> Void) {
+  f()
+}
+
+func testConsumingCaptureCalledEscaping() {
+  let r = Resource("calledEscaping")
+  acceptsAndCallsCalledOnceEscaping { r.use() }
+}
+
+// CHECK-NEXT: Resource(calledEscaping) used
+// CHECK-NEXT: Resource(calledEscaping) deinit
+testConsumingCaptureCalledEscaping()
+
+func testConsumingCaptureNeverCalledEscaping() {
+  let r = Resource("neverCalledEscaping")
+  acceptsCalledOnceEscaping { r.use() }
+}
+
+// CHECK-NEXT: Resource(neverCalledEscaping) deinit
+testConsumingCaptureNeverCalledEscaping()
+
+func testMixedConsumingAndBorrowingCapturesEscaping() {
+  let r = Resource("mixedEscaping")
+  let t = Tracker("mixedEscaping")
+  acceptsAndCallsCalledOnceEscaping {
+    _ = t
+    r.use()
+  }
+}
+
+// CHECK-NEXT: Resource(mixedEscaping) used
+// CHECK-NEXT: Resource(mixedEscaping) deinit
+// CHECK-NEXT: Tracker(mixedEscaping) deinit
+testMixedConsumingAndBorrowingCapturesEscaping()
+
+func testEmptyConsumingCaptureCalledEscaping() {
+  let r = EmptyResource()
+  acceptsAndCallsCalledOnceEscaping { r.use() }
+}
+
+// CHECK-NEXT: EmptyResource used
+// CHECK-NEXT: EmptyResource deinit
+testEmptyConsumingCaptureCalledEscaping()
+
+func testEmptyConsumingCaptureNeverCalledEscaping() {
+  let r = EmptyResource()
+  acceptsCalledOnceEscaping { r.use() }
+}
+
+// CHECK-NEXT: EmptyResource deinit
+testEmptyConsumingCaptureNeverCalledEscaping()

--- a/test/ModuleInterface/called_once.swift
+++ b/test/ModuleInterface/called_once.swift
@@ -12,12 +12,12 @@
 public typealias FnType = @called(once) () -> ()
 
 // CHECK: #if compiler(>=5.3) && $CalledAttribute
-// CHECK: public func test1(_: consuming @escaping @called(once) () -> ())
+// CHECK: public func test1(_: consuming @called(once) () -> ())
 // CHECK: #endif
 public func test1(_: @called(once) () -> ()) {}
 
 // CHECK: #if compiler(>=5.3) && $CalledAttribute
-// CHECK: public func test2(_: consuming @autoclosure @escaping @called(once) () -> ())
+// CHECK: public func test2(_: consuming @autoclosure @called(once) () -> ())
 // CHECK: #endif
 public func test2(_: @autoclosure @called(once) () -> ()) {}
 
@@ -26,6 +26,11 @@ public func test2(_: @autoclosure @called(once) () -> ()) {}
 // CHECK: #endif
 public func test3(_: () -> @called(once) () -> Void) {}
 
+// CHECK: #if compiler(>=5.3) && $CalledAttribute
+// CHECK: public func test4(_: consuming @escaping @called(once) () -> ())
+// CHECK: #endif
+public func test4(_: @escaping @called(once) () -> ()) {}
+
 public struct Test: ~Copyable {
   // CHECK: #if compiler(>=5.3) && $CalledAttribute
   // CHECK: public let prop: (@called(once) () -> Swift::Void)?
@@ -33,7 +38,7 @@ public struct Test: ~Copyable {
   public let prop: (@called(once) () -> Void)? = nil
 
   // CHECK: #if compiler(>=5.3) && $CalledAttribute
-  // CHECK: public func f(_: (consuming @escaping @called(once) () -> Swift::Void) -> Swift::Void)
+  // CHECK: public func f(_: (consuming @called(once) () -> Swift::Void) -> Swift::Void)
   // CHECK: #endif
   public func f(_: (@called(once) () -> Void) -> Void) {}
 }

--- a/test/SIL/Parser/called_once.sil
+++ b/test/SIL/Parser/called_once.sil
@@ -30,4 +30,34 @@ bb0:
   return %r : $@called(once) @callee_guaranteed () -> ()
 }
 
+// `partial_apply` can directly produce a `@called(once)` result via the
+// `[called_once]` attribute, without a separate `convert_function`.
+// CHECK-LABEL: sil [ossa] @produce_called_once_directly : $@convention(thin) () -> @owned @called(once) @callee_guaranteed () -> () {
+// CHECK:   [[F:%.*]] = function_ref @thin_callee : $@convention(thin) () -> ()
+// CHECK:   [[PA:%.*]] = partial_apply [callee_guaranteed] [called_once] [[F]]() : $@convention(thin) () -> ()
+// CHECK:   return [[PA]] : $@called(once) @callee_guaranteed () -> ()
+// CHECK: } // end sil function 'produce_called_once_directly'
+sil [ossa] @produce_called_once_directly : $@convention(thin) () -> @owned @called(once) @callee_guaranteed () -> () {
+bb0:
+  %f = function_ref @thin_callee : $@convention(thin) () -> ()
+  %pa = partial_apply [callee_guaranteed] [called_once] %f() : $@convention(thin) () -> ()
+  return %pa : $@called(once) @callee_guaranteed () -> ()
+}
+
+// The same attribute applied to a `partial_apply` that captures an argument,
+// mirroring how SILGen forms a `@called(once)` closure with a capture.
+// CHECK-LABEL: sil [ossa] @produce_called_once_with_capture : $@convention(thin) (@owned Builtin.NativeObject) -> @owned @called(once) @callee_owned () -> () {
+// CHECK: bb0([[ARG:%.*]] : @owned $Builtin.NativeObject):
+// CHECK:   [[F:%.*]] = function_ref @thin_callee_with_capture : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+// CHECK:   [[PA:%.*]] = partial_apply [called_once] [[F]]([[ARG]]) : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+// CHECK:   return [[PA]] : $@called(once) @callee_owned () -> ()
+// CHECK: } // end sil function 'produce_called_once_with_capture'
+sil [ossa] @produce_called_once_with_capture : $@convention(thin) (@owned Builtin.NativeObject) -> @owned @called(once) @callee_owned () -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %f = function_ref @thin_callee_with_capture : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+  %pa = partial_apply [called_once] %f(%0) : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+  return %pa : $@called(once) @callee_owned () -> ()
+}
+
 sil @thin_callee : $@convention(thin) () -> ()
+sil @thin_callee_with_capture : $@convention(thin) (@owned Builtin.NativeObject) -> ()

--- a/test/SIL/called_once.swift
+++ b/test/SIL/called_once.swift
@@ -67,37 +67,37 @@ func testCalledInLoop(_ f: @called(once) () -> Void) { // expected-error {{'f' c
   }
 }
 
-func testWrappedInLocalClosure(_ f: @called(once) () -> Void) {
+func testWrappedInLocalClosure(_ f: @escaping @called(once) () -> Void) {
   let g = { @called(once) [f] in f() }
   g() // Ok
 }
 
-func testWrappedInLocalClosureImplicitly(_ f: @called(once) () -> Void) {
+func testWrappedInLocalClosureImplicitly(_ f: @escaping @called(once) () -> Void) {
   let g = { @called(once) in f() }
   g()
 }
 
-func testWrappedInLocalClosureAndReassigned1(_ f: @called(once) () -> Void) {
+func testWrappedInLocalClosureAndReassigned1(_ f: @escaping @called(once) () -> Void) {
   var g = { @called(once) in f() }
   g()
   g = { }
   g()
 }
 
-func testWrappedInLocalClosureAndReassigned2(_ f: @called(once) () -> Void) {
+func testWrappedInLocalClosureAndReassigned2(_ f: @escaping @called(once) () -> Void) {
   let g = { @called(once) in f() }
   f = { }
   g()
 }
 
-func testWrappedInLocalClosureAndReassigned3(_ f: @called(once) () -> Void) {
+func testWrappedInLocalClosureAndReassigned3(_ f: @escaping @called(once) () -> Void) {
   let g = { @called(once) in f() }
   f = { }
   g()
   f()
 }
 
-func testWrappedInLocalClosureAndReassignedMultiConsume(_ f: @called(once) () -> Void) { // expected-error {{'f' consumed more than once}}
+func testWrappedInLocalClosureAndReassignedMultiConsume(_ f: @escaping @called(once) () -> Void) { // expected-error {{'f' consumed more than once}}
   let g = { @called(once) in f() } // expected-note {{consumed here}}
   f() // expected-note {{consumed again here}}
   f = { }
@@ -106,6 +106,10 @@ func testWrappedInLocalClosureAndReassignedMultiConsume(_ f: @called(once) () ->
 }
 
 func passThroughParam(fn: @called(once) () -> Void) {
+  testCallOnce(fn) // Ok
+}
+
+func passThroughEscapingParam(fn: @escaping @called(once) () -> Void) {
   testCallOnce(fn) // Ok
 }
 
@@ -125,7 +129,7 @@ func passThroughClosureOptionalAndUnwrap(fn: consuming (@called(once) () -> Void
   _ = fn
 }
 
-func testEarlyReturnBeforeCall(cond: Bool, _ f: @called(once) () -> Void) {
+func testEarlyReturnBeforeCall(cond: Bool, _ f: @escaping @called(once) () -> Void) {
   if cond { return }
   f()
 }
@@ -148,8 +152,8 @@ func localCaptureThenCall() {
 }
 
 func captureInRegularClosure(
-  f: @called(once) () -> Void,
-  g: @called(once) () -> Void,
+  f: @escaping @called(once) () -> Void,
+  g: @escaping @called(once) () -> Void,
   optF: consuming (@called(once) () -> Void)? = nil
 ) {
   _ = { [f] in f() } // expected-error {{noncopyable 'f' cannot be consumed when captured by an escaping closure or borrowed by a non-Escapable type}}
@@ -182,7 +186,7 @@ func testSwitchEachCaseCallsOnce(_ x: Int, _ f: @called(once) () -> Void) {
 // Capturing `f` into `a` consumes it right there; calling `f()` again directly
 // afterward must be caught locally, without any interprocedural reasoning
 // about what `a`'s body does with its capture.
-func testParamCaptureThenCallDirectly(f: @called(once) () -> Void) { // expected-error {{'f' consumed more than once}}
+func testParamCaptureThenCallDirectly(f: @escaping @called(once) () -> Void) { // expected-error {{'f' consumed more than once}}
   let a = { @called(once) in f() } // expected-note {{consumed here}}
   f() // expected-note {{consumed again here}}
   a()
@@ -190,7 +194,7 @@ func testParamCaptureThenCallDirectly(f: @called(once) () -> Void) { // expected
 
 // Same value captured by two different `@called(once)` closures without an
 // intervening reassignment - only the first capture may consume it.
-func testCapturedByTwoClosures(_ f: @called(once) () -> Void) { // expected-error {{'f' consumed more than once}}
+func testCapturedByTwoClosures(_ f: @escaping @called(once) () -> Void) { // expected-error {{'f' consumed more than once}}
   let a = { @called(once) in f() } // expected-note {{consumed here}}
   let b = { @called(once) in f() } // expected-note {{consumed again here}}
   a()
@@ -198,7 +202,7 @@ func testCapturedByTwoClosures(_ f: @called(once) () -> Void) { // expected-erro
 }
 
 // ... but capturing into two closures along mutually exclusive paths is fine.
-func testCapturedByTwoClosuresMutuallyExclusive(_ f: @called(once) () -> Void, cond: Bool) {
+func testCapturedByTwoClosuresMutuallyExclusive(_ f: @escaping @called(once) () -> Void, cond: Bool) {
   if cond {
     let a = { @called(once) in f() }
     a()
@@ -210,7 +214,7 @@ func testCapturedByTwoClosuresMutuallyExclusive(_ f: @called(once) () -> Void, c
 
 // A closure capturing multiple independent `@called(once)` values may call
 // each of them once.
-func testClosureCapturesTwoIndependentValues(f: @called(once) () -> Void, g: @called(once) () -> Void) {
+func testClosureCapturesTwoIndependentValues(f: @escaping @called(once) () -> Void, g: @escaping @called(once) () -> Void) {
   let a = { @called(once) in
     f()
     g()
@@ -220,7 +224,7 @@ func testClosureCapturesTwoIndependentValues(f: @called(once) () -> Void, g: @ca
 
 // The "at most once" checking still applies *inside* the closure body to its
 // own captures.
-func testClosureCapturesAndDoubleCallsOneOfThem(f: @called(once) () -> Void, g: @called(once) () -> Void) { // expected-error 2 {{'f' consumed more than once}}
+func testClosureCapturesAndDoubleCallsOneOfThem(f: @escaping @called(once) () -> Void, g: @called(once) () -> Void) { // expected-error 2 {{'f' consumed more than once}}
   let a = { @called(once) in
     f() // expected-note 2 {{consumed here}}
     f() // expected-note 2 {{consumed again here}}
@@ -230,7 +234,7 @@ func testClosureCapturesAndDoubleCallsOneOfThem(f: @called(once) () -> Void, g: 
 
 // A `@called(once)` value can also be captured alongside ordinary (copyable)
 // values without disturbing their capture kind.
-func testMixedCaptureKinds(_ f: @called(once) () -> Void, x: Int) {
+func testMixedCaptureKinds(_ f: @escaping @called(once) () -> Void, x: Int) {
   let g = { @called(once) in
     print(x)
     f()
@@ -240,13 +244,13 @@ func testMixedCaptureKinds(_ f: @called(once) () -> Void, x: Int) {
 
 // Nesting: an outer `@called(once)` closure capturing an inner one that
 // itself captures the original value.
-func testNestedCalledOnceClosures(_ f: @called(once) () -> Void) {
+func testNestedCalledOnceClosures(_ f: @escaping @called(once) () -> Void) {
   let inner = { @called(once) in f() }
   let outer = { @called(once) in inner() }
   outer()
 }
 
-func testNestedCalledOnceClosuresDouble(_ f: @called(once) () -> Void) {
+func testNestedCalledOnceClosuresDouble(_ f: @escaping @called(once) () -> Void) {
   let inner = { @called(once) in f() }
   let outer = { @called(once) in inner() }
   // expected-error@-1 {{'outer' consumed more than once}}
@@ -256,11 +260,11 @@ func testNestedCalledOnceClosuresDouble(_ f: @called(once) () -> Void) {
 
 // Returning a closure that captures a `@called(once)` value: the capture is
 // consumed where the closure literal is formed, not where it's later called.
-func makeWrapper(_ f: @called(once) () -> Void) -> @called(once) () -> Void {
+func makeWrapper(_ f: @escaping @called(once) () -> Void) -> @called(once) () -> Void {
   return { @called(once) in f() }
 }
 
-func testUseWrapper(_ f: @called(once) () -> Void) {
+func testUseWrapper(_ f: @escaping @called(once) () -> Void) {
   let w = makeWrapper(f)
   w()
 }
@@ -268,7 +272,7 @@ func testUseWrapper(_ f: @called(once) () -> Void) {
 // A captured `var` follows the same "consumed at formation" rule as a `let`;
 // reassigning it afterward is ordinary reinitialization, and using the new
 // value again later is fine.
-func testVarCaptureReassignedAfterFormation(_ f: @called(once) () -> Void) {
+func testVarCaptureReassignedAfterFormation(_ f: @escaping @called(once) () -> Void) {
   var f = f
   let g = { @called(once) in f() }
   f = makeClosure()
@@ -278,7 +282,7 @@ func testVarCaptureReassignedAfterFormation(_ f: @called(once) () -> Void) {
 
 // Without the reassignment, using `f` again after it was captured is a
 // double consumption, exactly as it would be for a `let`.
-func testVarCaptureUsedAgainWithoutReassignment(_ f: @called(once) () -> Void) {
+func testVarCaptureUsedAgainWithoutReassignment(_ f: @escaping @called(once) () -> Void) {
   var f = f // expected-warning {{variable 'f' was never mutated; consider changing to 'let' constant}}
   // expected-error@-1 {{'f' consumed more than once}}
   let g = { @called(once) in f() } // expected-note {{consumed here}}
@@ -288,7 +292,7 @@ func testVarCaptureUsedAgainWithoutReassignment(_ f: @called(once) () -> Void) {
 
 // Explicit capture-list renaming (`[g2 = f]`) goes through the same
 // consuming-capture path as a plain `[f]` capture.
-func testCaptureListRename(_ f: @called(once) () -> Void) {
+func testCaptureListRename(_ f: @escaping @called(once) () -> Void) {
   let g = { @called(once) [g2 = f] in g2() }
   g()
 }
@@ -298,7 +302,7 @@ do {
   struct S1: ~Copyable {
     let operation: @called(once) () -> Void
     
-    init(operation: @called(once) () -> Void) {
+    init(operation: @escaping @called(once) () -> Void) {
       // okay; the parameter is implicitly 'consuming'
       self.operation = operation
     }
@@ -311,7 +315,7 @@ do {
   struct S2: ~Copyable {
     let operation: @called(once) () -> Void
     
-    init(operation: @called(once) () -> Void) {
+    init(operation: @escaping @called(once) () -> Void) {
       self.operation = operation
     }
 

--- a/test/SILGen/called_once.swift
+++ b/test/SILGen/called_once.swift
@@ -6,30 +6,44 @@ func makeClosure() -> @called(once) () -> Void {
   return {}
 }
 
-// CHECK-LABEL: sil hidden [ossa] @$s11called_once12testCallOnceyyyyXOnF : $@convention(thin) (@owned @called(once) @callee_owned () -> ()) -> () {
-// CHECK: bb0([[F:%.*]] : @owned $@called(once) @callee_owned () -> ()):
+// CHECK-LABEL: sil hidden [ossa] @$s11called_once12testCallOnceyyyyXEnF : $@convention(thin) (@owned @noescape @called(once) @callee_owned () -> ()) -> () {
+// CHECK: bb0([[F:%.*]] : @owned $@noescape @called(once) @callee_owned () -> ()):
 // CHECK:  [[LOCAL:%.*]] = alloc_box ${ let @called(once) @callee_owned () -> () }, let, name "local"
-// CHECK:  [[CLOSURE_REF:%.*]] = function_ref @$s11called_once12testCallOnceyyyyXOnFyyXOfU_ : $@convention(thin) () -> ()
+// CHECK:  [[CLOSURE_REF:%.*]] = function_ref @$s11called_once12testCallOnceyyyyXEnFyyXOfU_ : $@convention(thin) () -> ()
 // CHECK:  [[CLOSURE_CALLED_ONCE:%.*]] = convert_function [[CLOSURE_REF]] : $@convention(thin) () -> () to $@convention(thin) @called(once) () -> ()
-// CHECK: } // end sil function '$s11called_once12testCallOnceyyyyXOnF'
+// CHECK: } // end sil function '$s11called_once12testCallOnceyyyyXEnF'
 func testCallOnce(_ f: @called(once) () -> Void) {
   let local: @called(once) () -> Void = {}
   _ = local
 }
 
 func run() {
-  // CHECK-LABEL: sil private [ossa] @$s11called_once3runyyFyyXOfU_ : $@convention(thin) () -> ()
+  // CHECK-LABEL: sil private [ossa] @$s11called_once3runyyFyyXEfU_ : $@convention(thin) () -> ()
   testCallOnce { }
 }
 
-// CHECK-LABEL: sil hidden [ossa] @$s11called_once22testClosureWithCapture1fyyyXOn_tF : $@convention(thin) (@owned @called(once) @callee_owned () -> ()) -> () {
-// CHECK:  [[FN:%.*]] = begin_borrow [lexical] [var_decl] %1 : ${ var @called(once) @callee_owned () -> () }
-// CHECK:  [[FN_PROJ:%.*]] = project_box [[FN]] : ${ var @called(once) @callee_owned () -> () }
+// `@escaping` `@called(once)` parameters keep `@callee_owned` (no `@noescape`)
+// throughout - contrast with `testCallOnce` above, where `f` is implicitly
+// `@noescape` and every occurrence of its type carries that annotation.
+// CHECK-LABEL: sil hidden [ossa] @$s11called_once20testCallOnceEscapingyyyyXOnF : $@convention(thin) (@owned @called(once) @callee_owned () -> ()) -> () {
+// CHECK: bb0([[F:%.*]] : @owned $@called(once) @callee_owned () -> ()):
+// CHECK:  [[LOCAL:%.*]] = alloc_box ${ let @called(once) @callee_owned () -> () }, let, name "local"
+// CHECK:  [[CLOSURE_REF:%.*]] = function_ref @$s11called_once20testCallOnceEscapingyyyyXOnFyyXOfU_ : $@convention(thin) () -> ()
+// CHECK:  [[CLOSURE_CALLED_ONCE:%.*]] = convert_function [[CLOSURE_REF]] : $@convention(thin) () -> () to $@convention(thin) @called(once) () -> ()
+// CHECK: } // end sil function '$s11called_once20testCallOnceEscapingyyyyXOnF'
+func testCallOnceEscaping(_ f: @escaping @called(once) () -> Void) {
+  let local: @called(once) () -> Void = {}
+  _ = local
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s11called_once22testClosureWithCapture1fyyyXEn_tF : $@convention(thin) (@owned @noescape @called(once) @callee_owned () -> ()) -> () {
+// CHECK:  [[FN:%.*]] = begin_borrow [lexical] [var_decl] %1 : ${ var @noescape @called(once) @callee_owned () -> () }
+// CHECK:  [[FN_PROJ:%.*]] = project_box [[FN]] : ${ var @noescape @called(once) @callee_owned () -> () }
 // CHECK:  [[G_PROJ:%.*]] = project_box {{.*}} : ${ let @called(once) @callee_owned () -> () }, 0
-// CHECK:  [[CLOSURE_REF:%.*]] = function_ref @$s11called_once22testClosureWithCapture1fyyyXOn_tFyyXOfU_ : $@convention(thin) (@owned @called(once) @callee_owned () -> ()) -> ()
-// CHECK:  [[FN_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[FN_PROJ]] : $*@called(once) @callee_owned () -> ()
-// CHECK:  [[FN_VALUE:%.*]] = load [take] [[FN_ADDR]] : $*@called(once) @callee_owned () -> ()
-// CHECK:  [[CLOSURE_WITH_CAPTURE:%.*]] = partial_apply [[CLOSURE_REF]]([[FN_VALUE]]) : $@convention(thin) (@owned @called(once) @callee_owned () -> ()) -> ()
+// CHECK:  [[CLOSURE_REF:%.*]] = function_ref @$s11called_once22testClosureWithCapture1fyyyXEn_tFyyXOfU_ : $@convention(thin) (@owned @noescape @called(once) @callee_owned () -> ()) -> ()
+// CHECK:  [[FN_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[FN_PROJ]] : $*@noescape @called(once) @callee_owned () -> ()
+// CHECK:  [[FN_VALUE:%.*]] = load [take] [[FN_ADDR]] : $*@noescape @called(once) @callee_owned () -> ()
+// CHECK:  [[CLOSURE_WITH_CAPTURE:%.*]] = partial_apply [[CLOSURE_REF]]([[FN_VALUE]]) : $@convention(thin) (@owned @noescape @called(once) @callee_owned () -> ()) -> ()
 // CHECK:  [[G_CLOSURE:%.*]] = convert_function [[CLOSURE_WITH_CAPTURE]] : $@callee_owned () -> () to $@called(once) @callee_owned () -> ()
 // CHECK:  store [[G_CLOSURE]] to [init] [[G_PROJ]]
 // CHECK:  [[X_BOX:%.*]] = alloc_box ${ let @called(once) @callee_owned () -> () }, let, name "x"
@@ -41,20 +55,20 @@ func run() {
 // CHECK:  [[X_ADDR:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[X_PROJ]] : $*@called(once) @callee_owned () -> ()
 // CHECK:  [[X_FAKE_COPY:%.*]] = load [copy] [[X_ADDR]] : $*@called(once) @callee_owned () -> ()
 // CHECK:  apply [[X_FAKE_COPY]]() : $@called(once) @callee_owned () -> ()
-// CHECK: } // end sil function '$s11called_once22testClosureWithCapture1fyyyXOn_tF'
+// CHECK: } // end sil function '$s11called_once22testClosureWithCapture1fyyyXEn_tF'
 
 // Make sure that the closure uses `consumable_and_assignable` to access the capture.
-// CHECK-LABEL: sil private [ossa] @$s11called_once22testClosureWithCapture1fyyyXOn_tFyyXOfU_ : $@convention(thin) (@owned @called(once) @callee_owned () -> ()) -> () {
-// CHECK: bb0([[F_CAPTURE:%.*]] : @closureCapture @owned $@called(once) @callee_owned () -> ()):
-// CHECK:  [[F_BOX:%.*]] = alloc_stack $@called(once) @callee_owned () -> (), var, name "f"
-// CHECK:  [[F_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[F_BOX]] : $*@called(once) @callee_owned () -> ()
-// CHECK:  store [[F_CAPTURE:%.*]] to [init] [[F_ADDR]] : $*@called(once) @callee_owned () -> ()
-// CHECK:  [[F_ADDR_2:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[F_ADDR]] : $*@called(once) @callee_owned () -> ()
-// CHECK:  [[F_ADDR_ACCESS:%.*]] = begin_access [read] [unknown] [[F_ADDR_2]] : $*@called(once) @callee_owned () -> ()
-// CHECK:  [[F_FAKE_COPY:%.*]] = load [copy] [[F_ADDR_ACCESS]] : $*@called(once) @callee_owned () -> ()
-// CHECK:  end_access [[F_ADDR_ACCESS]] : $*@called(once) @callee_owned () -> ()
-// CHECK:  apply [[F_FAKE_COPY]]() : $@called(once) @callee_owned () -> ()
-// CHECK: } // end sil function '$s11called_once22testClosureWithCapture1fyyyXOn_tFyyXOfU_'
+// CHECK-LABEL: sil private [ossa] @$s11called_once22testClosureWithCapture1fyyyXEn_tFyyXOfU_ : $@convention(thin) (@owned @noescape @called(once) @callee_owned () -> ()) -> () {
+// CHECK: bb0([[F_CAPTURE:%.*]] : @closureCapture @owned $@noescape @called(once) @callee_owned () -> ()):
+// CHECK:  [[F_BOX:%.*]] = alloc_stack $@noescape @called(once) @callee_owned () -> (), var, name "f"
+// CHECK:  [[F_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[F_BOX]] : $*@noescape @called(once) @callee_owned () -> ()
+// CHECK:  store [[F_CAPTURE:%.*]] to [init] [[F_ADDR]] : $*@noescape @called(once) @callee_owned () -> ()
+// CHECK:  [[F_ADDR_2:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[F_ADDR]] : $*@noescape @called(once) @callee_owned () -> ()
+// CHECK:  [[F_ADDR_ACCESS:%.*]] = begin_access [read] [unknown] [[F_ADDR_2]] : $*@noescape @called(once) @callee_owned () -> ()
+// CHECK:  [[F_FAKE_COPY:%.*]] = load [copy] [[F_ADDR_ACCESS]] : $*@noescape @called(once) @callee_owned () -> ()
+// CHECK:  end_access [[F_ADDR_ACCESS]] : $*@noescape @called(once) @callee_owned () -> ()
+// CHECK:  apply [[F_FAKE_COPY]]() : $@noescape @called(once) @callee_owned () -> ()
+// CHECK: } // end sil function '$s11called_once22testClosureWithCapture1fyyyXEn_tFyyXOfU_'
 func testClosureWithCapture(f: @called(once) () -> Void) {
   let g = { @called(once) in f() }
   let x = g
@@ -67,43 +81,44 @@ func testClosureWithCapture(f: @called(once) () -> Void) {
 // via the pre-existing [assignable_but_not_consumable] + assign idiom, and
 // does not disturb the value already moved into `g`.
 //
-// CHECK-LABEL: sil hidden [ossa] @$s11called_once25testClosureWithVarCaptureyyyyXOnF : $@convention(thin) (@owned @called(once) @callee_owned () -> ()) -> () {
-// CHECK: bb0([[F_PARAM:%.*]] : @owned $@called(once) @callee_owned () -> ()):
-// CHECK:  [[F_PARAM_BOX:%.*]] = alloc_box ${ var @called(once) @callee_owned () -> () }, var, name "f"
-// CHECK:  [[F_PARAM_BORROW:%.*]] = begin_borrow [lexical] [var_decl] [[F_PARAM_BOX]] : ${ var @called(once) @callee_owned () -> () }
-// CHECK:  [[F_PARAM_PROJ:%.*]] = project_box [[F_PARAM_BORROW]] : ${ var @called(once) @callee_owned () -> () }, 0
-// CHECK:  store [[F_PARAM]] to [init] [[F_PARAM_PROJ]] : $*@called(once) @callee_owned () -> ()
-// CHECK:  [[F_BOX:%.*]] = alloc_box ${ var @called(once) @callee_owned () -> () }, var, name "f"
-// CHECK:  [[F_BORROW:%.*]] = begin_borrow [lexical] [var_decl] [[F_BOX]] : ${ var @called(once) @callee_owned () -> () }
-// CHECK:  [[F_PROJ:%.*]] = project_box [[F_BORROW]] : ${ var @called(once) @callee_owned () -> () }, 0
-// CHECK:  [[F_PARAM_READ:%.*]] = begin_access [read] [unknown] [[F_PARAM_PROJ]] : $*@called(once) @callee_owned () -> ()
-// CHECK:  [[F_PARAM_ADDR:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[F_PARAM_READ]] : $*@called(once) @callee_owned () -> ()
-// CHECK:  copy_addr [[F_PARAM_ADDR]] to [init] [[F_PROJ]] : $*@called(once) @callee_owned () -> ()
+// CHECK-LABEL: sil hidden [ossa] @$s11called_once25testClosureWithVarCaptureyyyyXEnF : $@convention(thin) (@owned @noescape @called(once) @callee_owned () -> ()) -> () {
+// CHECK: bb0([[F_PARAM:%.*]] : @owned $@noescape @called(once) @callee_owned () -> ()):
+// CHECK:  [[F_PARAM_BOX:%.*]] = alloc_box ${ var @noescape @called(once) @callee_owned () -> () }, var, name "f"
+// CHECK:  [[F_PARAM_BORROW:%.*]] = begin_borrow [lexical] [var_decl] [[F_PARAM_BOX]] : ${ var @noescape @called(once) @callee_owned () -> () }
+// CHECK:  [[F_PARAM_PROJ:%.*]] = project_box [[F_PARAM_BORROW]] : ${ var @noescape @called(once) @callee_owned () -> () }, 0
+// CHECK:  store [[F_PARAM]] to [init] [[F_PARAM_PROJ]] : $*@noescape @called(once) @callee_owned () -> ()
+// CHECK:  [[F_BOX:%.*]] = alloc_box ${ var @noescape @called(once) @callee_owned () -> () }, var, name "f"
+// CHECK:  [[F_BORROW:%.*]] = begin_borrow [lexical] [var_decl] [[F_BOX]] : ${ var @noescape @called(once) @callee_owned () -> () }
+// CHECK:  [[F_PROJ:%.*]] = project_box [[F_BORROW]] : ${ var @noescape @called(once) @callee_owned () -> () }, 0
+// CHECK:  [[F_PARAM_READ:%.*]] = begin_access [read] [unknown] [[F_PARAM_PROJ]] : $*@noescape @called(once) @callee_owned () -> ()
+// CHECK:  [[F_PARAM_ADDR:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[F_PARAM_READ]] : $*@noescape @called(once) @callee_owned () -> ()
+// CHECK:  copy_addr [[F_PARAM_ADDR]] to [init] [[F_PROJ]] : $*@noescape @called(once) @callee_owned () -> ()
 // CHECK:  [[G_PROJ:%.*]] = project_box {{.*}} : ${ let @called(once) @callee_owned () -> () }, 0
-// CHECK:  [[F_TAKE_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[F_PROJ]] : $*@called(once) @callee_owned () -> ()
-// CHECK:  [[F_VALUE:%.*]] = load [take] [[F_TAKE_ADDR]] : $*@called(once) @callee_owned () -> ()
-// CHECK:  [[CLOSURE:%.*]] = partial_apply {{.*}}([[F_VALUE]]) : $@convention(thin) (@owned @called(once) @callee_owned () -> ()) -> ()
+// CHECK:  [[F_TAKE_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[F_PROJ]] : $*@noescape @called(once) @callee_owned () -> ()
+// CHECK:  [[F_VALUE:%.*]] = load [take] [[F_TAKE_ADDR]] : $*@noescape @called(once) @callee_owned () -> ()
+// CHECK:  [[CLOSURE:%.*]] = partial_apply {{.*}}([[F_VALUE]]) : $@convention(thin) (@owned @noescape @called(once) @callee_owned () -> ()) -> ()
 // CHECK:  [[G_CLOSURE:%.*]] = convert_function [[CLOSURE]]
 // CHECK:  store [[G_CLOSURE]] to [init] [[G_PROJ]]
 // CHECK:  [[NEW_VALUE:%.*]] = apply {{.*}}() : $@convention(thin) () -> @owned @called(once) @callee_owned () -> ()
-// CHECK:  [[F_ACCESS:%.*]] = begin_access [modify] [unknown] [[F_PROJ]] : $*@called(once) @callee_owned () -> ()
-// CHECK:  [[F_WRITE_ADDR:%.*]] = mark_unresolved_non_copyable_value [assignable_but_not_consumable] [[F_ACCESS]] : $*@called(once) @callee_owned () -> ()
-// CHECK:  assign [[NEW_VALUE]] to [[F_WRITE_ADDR]] : $*@called(once) @callee_owned () -> ()
-// CHECK: } // end sil function '$s11called_once25testClosureWithVarCaptureyyyyXOnF'
+// CHECK:  [[NEW_VALUE_NOESCAPE:%.*]] = convert_escape_to_noescape [[NEW_VALUE]] : $@called(once) @callee_owned () -> () to $@noescape @called(once) @callee_owned () -> ()
+// CHECK:  [[F_ACCESS:%.*]] = begin_access [modify] [unknown] [[F_PROJ]] : $*@noescape @called(once) @callee_owned () -> ()
+// CHECK:  [[F_WRITE_ADDR:%.*]] = mark_unresolved_non_copyable_value [assignable_but_not_consumable] [[F_ACCESS]] : $*@noescape @called(once) @callee_owned () -> ()
+// CHECK:  assign [[NEW_VALUE_NOESCAPE]] to [[F_WRITE_ADDR]] : $*@noescape @called(once) @callee_owned () -> ()
+// CHECK: } // end sil function '$s11called_once25testClosureWithVarCaptureyyyyXEnF'
 
 // The closure body's own capture is rebound into a local `var` via a fresh
 // `alloc_stack`, not a box - it never escapes further, so there's nothing to
 // promote from a box in the first place.
-// CHECK-LABEL: sil private [ossa] @$s11called_once25testClosureWithVarCaptureyyyyXOnFyyXOfU_ : $@convention(thin) (@owned @called(once) @callee_owned () -> ()) -> () {
-// CHECK: bb0([[F_CAPTURE:%.*]] : @closureCapture @owned $@called(once) @callee_owned () -> ()):
-// CHECK:  [[F_STACK:%.*]] = alloc_stack $@called(once) @callee_owned () -> (), var, name "f"
-// CHECK:  [[F_INIT_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[F_STACK]] : $*@called(once) @callee_owned () -> ()
-// CHECK:  store [[F_CAPTURE]] to [init] [[F_INIT_ADDR]] : $*@called(once) @callee_owned () -> ()
-// CHECK:  [[F_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[F_INIT_ADDR]] : $*@called(once) @callee_owned () -> ()
-// CHECK:  [[F_READ:%.*]] = begin_access [read] [unknown] [[F_ADDR]] : $*@called(once) @callee_owned () -> ()
-// CHECK:  [[F_FAKE_COPY:%.*]] = load [copy] [[F_READ]] : $*@called(once) @callee_owned () -> ()
-// CHECK:  apply [[F_FAKE_COPY]]() : $@called(once) @callee_owned () -> ()
-// CHECK: } // end sil function '$s11called_once25testClosureWithVarCaptureyyyyXOnFyyXOfU_'
+// CHECK-LABEL: sil private [ossa] @$s11called_once25testClosureWithVarCaptureyyyyXEnFyyXOfU_ : $@convention(thin) (@owned @noescape @called(once) @callee_owned () -> ()) -> () {
+// CHECK: bb0([[F_CAPTURE:%.*]] : @closureCapture @owned $@noescape @called(once) @callee_owned () -> ()):
+// CHECK:  [[F_STACK:%.*]] = alloc_stack $@noescape @called(once) @callee_owned () -> (), var, name "f"
+// CHECK:  [[F_INIT_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[F_STACK]] : $*@noescape @called(once) @callee_owned () -> ()
+// CHECK:  store [[F_CAPTURE]] to [init] [[F_INIT_ADDR]] : $*@noescape @called(once) @callee_owned () -> ()
+// CHECK:  [[F_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[F_INIT_ADDR]] : $*@noescape @called(once) @callee_owned () -> ()
+// CHECK:  [[F_READ:%.*]] = begin_access [read] [unknown] [[F_ADDR]] : $*@noescape @called(once) @callee_owned () -> ()
+// CHECK:  [[F_FAKE_COPY:%.*]] = load [copy] [[F_READ]] : $*@noescape @called(once) @callee_owned () -> ()
+// CHECK:  apply [[F_FAKE_COPY]]() : $@noescape @called(once) @callee_owned () -> ()
+// CHECK: } // end sil function '$s11called_once25testClosureWithVarCaptureyyyyXEnFyyXOfU_'
 func testClosureWithVarCapture(_ f: @called(once) () -> Void) {
   var f = f
   let g = { @called(once) in f() }
@@ -119,25 +134,25 @@ func testClosureWithVarCapture(_ f: @called(once) () -> Void) {
 // is still moved out of its box via [consumable_and_assignable] + load [take]
 // at the point the closure literal is formed.
 //
-// CHECK-LABEL: sil hidden [ossa] @$s11called_once21testMixedCaptureKindsyyyyXOnF : $@convention(thin) (@owned @called(once) @callee_owned () -> ()) -> () {
-// CHECK:  [[F_PROJ:%.*]] = project_box {{.*}} : ${ var @called(once) @callee_owned () -> () }, 0
+// CHECK-LABEL: sil hidden [ossa] @$s11called_once21testMixedCaptureKindsyyyyXEnF : $@convention(thin) (@owned @noescape @called(once) @callee_owned () -> ()) -> () {
+// CHECK:  [[F_PROJ:%.*]] = project_box {{.*}} : ${ var @noescape @called(once) @callee_owned () -> () }, 0
 // CHECK:  [[COUNT_BOX:%.*]] = alloc_box ${ var Int }, var, name "count"
 // CHECK:  [[COUNT_BORROW:%.*]] = begin_borrow [var_decl] [[COUNT_BOX]] : ${ var Int }
 // CHECK:  [[COUNT_BOX_COPY:%.*]] = copy_value [[COUNT_BORROW]] : ${ var Int }
-// CHECK:  [[F_TAKE_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[F_PROJ]] : $*@called(once) @callee_owned () -> ()
-// CHECK:  [[F_VALUE:%.*]] = load [take] [[F_TAKE_ADDR]] : $*@called(once) @callee_owned () -> ()
-// CHECK:  partial_apply {{.*}}([[COUNT_BOX_COPY]], [[F_VALUE]]) : $@convention(thin) (@guaranteed { var Int }, @owned @called(once) @callee_owned () -> ()) -> ()
-// CHECK: } // end sil function '$s11called_once21testMixedCaptureKindsyyyyXOnF'
+// CHECK:  [[F_TAKE_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[F_PROJ]] : $*@noescape @called(once) @callee_owned () -> ()
+// CHECK:  [[F_VALUE:%.*]] = load [take] [[F_TAKE_ADDR]] : $*@noescape @called(once) @callee_owned () -> ()
+// CHECK:  partial_apply {{.*}}([[COUNT_BOX_COPY]], [[F_VALUE]]) : $@convention(thin) (@guaranteed { var Int }, @owned @noescape @called(once) @callee_owned () -> ()) -> ()
+// CHECK: } // end sil function '$s11called_once21testMixedCaptureKindsyyyyXEnF'
 
-// CHECK-LABEL: sil private [ossa] @$s11called_once21testMixedCaptureKindsyyyyXOnFyyXOfU_ : $@convention(thin) (@guaranteed { var Int }, @owned @called(once) @callee_owned () -> ()) -> () {
-// CHECK: bb0([[COUNT_CAPTURE:%.*]] : @closureCapture @guaranteed ${ var Int }, [[F_CAPTURE:%.*]] : @closureCapture @owned $@called(once) @callee_owned () -> ()):
+// CHECK-LABEL: sil private [ossa] @$s11called_once21testMixedCaptureKindsyyyyXEnFyyXOfU_ : $@convention(thin) (@guaranteed { var Int }, @owned @noescape @called(once) @callee_owned () -> ()) -> () {
+// CHECK: bb0([[COUNT_CAPTURE:%.*]] : @closureCapture @guaranteed ${ var Int }, [[F_CAPTURE:%.*]] : @closureCapture @owned $@noescape @called(once) @callee_owned () -> ()):
 // CHECK:  [[COUNT_PROJ:%.*]] = project_box [[COUNT_CAPTURE]] : ${ var Int }, 0
-// CHECK:  [[F_STACK:%.*]] = alloc_stack $@called(once) @callee_owned () -> (), var, name "f"
-// CHECK:  [[F_INIT_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[F_STACK]] : $*@called(once) @callee_owned () -> ()
-// CHECK:  store [[F_CAPTURE]] to [init] [[F_INIT_ADDR]] : $*@called(once) @callee_owned () -> ()
+// CHECK:  [[F_STACK:%.*]] = alloc_stack $@noescape @called(once) @callee_owned () -> (), var, name "f"
+// CHECK:  [[F_INIT_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[F_STACK]] : $*@noescape @called(once) @callee_owned () -> ()
+// CHECK:  store [[F_CAPTURE]] to [init] [[F_INIT_ADDR]] : $*@noescape @called(once) @callee_owned () -> ()
 // CHECK:  [[COUNT_ACCESS:%.*]] = begin_access [modify] [unknown] [[COUNT_PROJ]] : $*Int
 // CHECK:  end_access [[COUNT_ACCESS]] : $*Int
-// CHECK: } // end sil function '$s11called_once21testMixedCaptureKindsyyyyXOnFyyXOfU_'
+// CHECK: } // end sil function '$s11called_once21testMixedCaptureKindsyyyyXEnFyyXOfU_'
 func testMixedCaptureKinds(_ f: @called(once) () -> Void) {
   var count = 0
   let g = { @called(once) in

--- a/test/SILGen/called_once.swift
+++ b/test/SILGen/called_once.swift
@@ -43,9 +43,8 @@ func testCallOnceEscaping(_ f: @escaping @called(once) () -> Void) {
 // CHECK:  [[CLOSURE_REF:%.*]] = function_ref @$s11called_once22testClosureWithCapture1fyyyXEn_tFyyXOfU_ : $@convention(thin) (@owned @noescape @called(once) @callee_owned () -> ()) -> ()
 // CHECK:  [[FN_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[FN_PROJ]] : $*@noescape @called(once) @callee_owned () -> ()
 // CHECK:  [[FN_VALUE:%.*]] = load [take] [[FN_ADDR]] : $*@noescape @called(once) @callee_owned () -> ()
-// CHECK:  [[CLOSURE_WITH_CAPTURE:%.*]] = partial_apply [[CLOSURE_REF]]([[FN_VALUE]]) : $@convention(thin) (@owned @noescape @called(once) @callee_owned () -> ()) -> ()
-// CHECK:  [[G_CLOSURE:%.*]] = convert_function [[CLOSURE_WITH_CAPTURE]] : $@callee_owned () -> () to $@called(once) @callee_owned () -> ()
-// CHECK:  store [[G_CLOSURE]] to [init] [[G_PROJ]]
+// CHECK:  [[CLOSURE_WITH_CAPTURE:%.*]] = partial_apply [called_once] [[CLOSURE_REF]]([[FN_VALUE]]) : $@convention(thin) (@owned @noescape @called(once) @callee_owned () -> ()) -> ()
+// CHECK:  store [[CLOSURE_WITH_CAPTURE]] to [init] [[G_PROJ]]
 // CHECK:  [[X_BOX:%.*]] = alloc_box ${ let @called(once) @callee_owned () -> () }, let, name "x"
 // CHECK:  [[BORROWED_X_BOX:%.*]] = begin_borrow [lexical] [var_decl] [[X_BOX]] : ${ let @called(once) @callee_owned () -> () }
 // CHECK:  [[X_PROJ:%.*]] = project_box [[BORROWED_X_BOX]] : ${ let @called(once) @callee_owned () -> () }
@@ -96,9 +95,8 @@ func testClosureWithCapture(f: @called(once) () -> Void) {
 // CHECK:  [[G_PROJ:%.*]] = project_box {{.*}} : ${ let @called(once) @callee_owned () -> () }, 0
 // CHECK:  [[F_TAKE_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[F_PROJ]] : $*@noescape @called(once) @callee_owned () -> ()
 // CHECK:  [[F_VALUE:%.*]] = load [take] [[F_TAKE_ADDR]] : $*@noescape @called(once) @callee_owned () -> ()
-// CHECK:  [[CLOSURE:%.*]] = partial_apply {{.*}}([[F_VALUE]]) : $@convention(thin) (@owned @noescape @called(once) @callee_owned () -> ()) -> ()
-// CHECK:  [[G_CLOSURE:%.*]] = convert_function [[CLOSURE]]
-// CHECK:  store [[G_CLOSURE]] to [init] [[G_PROJ]]
+// CHECK:  [[CLOSURE:%.*]] = partial_apply [called_once] {{.*}}([[F_VALUE]]) : $@convention(thin) (@owned @noescape @called(once) @callee_owned () -> ()) -> ()
+// CHECK:  store [[CLOSURE]] to [init] [[G_PROJ]]
 // CHECK:  [[NEW_VALUE:%.*]] = apply {{.*}}() : $@convention(thin) () -> @owned @called(once) @callee_owned () -> ()
 // CHECK:  [[NEW_VALUE_NOESCAPE:%.*]] = convert_escape_to_noescape [[NEW_VALUE]] : $@called(once) @callee_owned () -> () to $@noescape @called(once) @callee_owned () -> ()
 // CHECK:  [[F_ACCESS:%.*]] = begin_access [modify] [unknown] [[F_PROJ]] : $*@noescape @called(once) @callee_owned () -> ()
@@ -141,7 +139,7 @@ func testClosureWithVarCapture(_ f: @called(once) () -> Void) {
 // CHECK:  [[COUNT_BOX_COPY:%.*]] = copy_value [[COUNT_BORROW]] : ${ var Int }
 // CHECK:  [[F_TAKE_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[F_PROJ]] : $*@noescape @called(once) @callee_owned () -> ()
 // CHECK:  [[F_VALUE:%.*]] = load [take] [[F_TAKE_ADDR]] : $*@noescape @called(once) @callee_owned () -> ()
-// CHECK:  partial_apply {{.*}}([[COUNT_BOX_COPY]], [[F_VALUE]]) : $@convention(thin) (@guaranteed { var Int }, @owned @noescape @called(once) @callee_owned () -> ()) -> ()
+// CHECK:  partial_apply [called_once] {{.*}}([[COUNT_BOX_COPY]], [[F_VALUE]]) : $@convention(thin) (@guaranteed { var Int }, @owned @noescape @called(once) @callee_owned () -> ()) -> ()
 // CHECK: } // end sil function '$s11called_once21testMixedCaptureKindsyyyyXEnF'
 
 // CHECK-LABEL: sil private [ossa] @$s11called_once21testMixedCaptureKindsyyyyXEnFyyXOfU_ : $@convention(thin) (@guaranteed { var Int }, @owned @noescape @called(once) @callee_owned () -> ()) -> () {

--- a/test/SILGen/called_once_consuming_captures.swift
+++ b/test/SILGen/called_once_consuming_captures.swift
@@ -183,11 +183,11 @@ func testMixedConsumingAndBorrowingCaptures(_ consumed: consuming Resource, _ bo
 // CHECK:  [[CLOSURE_G:%.*]] = function_ref @$s30called_once_consuming_captures27tesReassignmentOfProperties2r12r2yAA8ResourceVn_AFntFyyXOfU_
 // CHECK:  [[R1_TAKE_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[R1_PROJ]] : $*Resource
 // CHECK:  [[R1_VALUE:%.*]] = load [take] [[R1_TAKE_ADDR]] : $*Resource
-// CHECK:  partial_apply [[CLOSURE_G]]({{.*}}, [[R1_VALUE]]) : $@convention(thin) (@guaranteed { var S }, @owned Resource) -> ()
+// CHECK:  partial_apply [called_once] [[CLOSURE_G]]({{.*}}, [[R1_VALUE]]) : $@convention(thin) (@guaranteed { var S }, @owned Resource) -> ()
 // CHECK:  [[CLOSURE_H:%.*]] = function_ref @$s30called_once_consuming_captures27tesReassignmentOfProperties2r12r2yAA8ResourceVn_AFntFyyXOfU0_
 // CHECK:  [[R2_TAKE_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[R2_PROJ]] : $*Resource
 // CHECK:  [[R2_VALUE:%.*]] = load [take] [[R2_TAKE_ADDR]] : $*Resource
-// CHECK:  partial_apply [[CLOSURE_H]]({{.*}}, [[R2_VALUE]]) : $@convention(thin) (@guaranteed C, @owned Resource) -> ()
+// CHECK:  partial_apply [called_once] [[CLOSURE_H]]({{.*}}, [[R2_VALUE]]) : $@convention(thin) (@guaranteed C, @owned Resource) -> ()
 // CHECK: } // end sil function '$s30called_once_consuming_captures27tesReassignmentOfProperties2r12r2yAA8ResourceVn_AFntF'
 
 // CHECK-LABEL: sil private [ossa] @$s30called_once_consuming_captures27tesReassignmentOfProperties2r12r2yAA8ResourceVn_AFntFyyXOfU_ : $@convention(thin) (@guaranteed { var S }, @owned Resource) -> () {

--- a/test/Sema/called_once.swift
+++ b/test/Sema/called_once.swift
@@ -37,14 +37,14 @@ func contravariant() {
   func consumesCalledOnce(_: @called(once) () -> Void) {}
 
   var wrapperFn: (@escaping () -> Void) -> Void = consumes
-  var wrapperOnce: (@called(once) () -> Void) -> Void = consumesCalledOnce
+  var wrapperOnce: (@escaping @called(once) () -> Void) -> Void = consumesCalledOnce
 
   wrapperFn = wrapperOnce // Ok
   wrapperOnce = wrapperFn
   // expected-error@-1 {{invalid conversion from '@called(once)' function of type '@called(once) () -> Void' to function type '() -> Void'}}
 }
 
-func impliedEscaping(onceFn: @called(once) () -> Void) {
+func impliedEscaping(onceFn: @escaping @called(once) () -> Void) {
   func takesEscaping(_ f: @escaping () -> Void) {}
   takesEscaping(onceFn) // no diagnostics about `@escaping`
   // expected-error@-1 {{invalid conversion from '@called(once)' function of type '@called(once) () -> Void' to function type '() -> Void'}}
@@ -52,7 +52,7 @@ func impliedEscaping(onceFn: @called(once) () -> Void) {
 
 protocol P {
   func run(_: @called(once) () -> Void)
-  // expected-note@-1 {{protocol requires function 'run' with type '(consuming @escaping @called(once) () -> Void) -> ()'}}
+  // expected-note@-1 {{protocol requires function 'run' with type '(consuming @called(once) () -> Void) -> ()'}}
 }
 
 struct S1: P { // expected-error {{type 'S1' does not conform to protocol 'P'}} expected-note {{add stubs for conformance}}


### PR DESCRIPTION
- AST: `@called(once)` no longer implies `@escaping`.
- SIL: escaping -> no-escape conversion for `@called(once)` now forwarding consume of an operand because such values are non-Copyable and have consuming semantics.
- IRGen: Consumed captures weren't being destroyed correctly because they were treated as copies and non-escaping used to mean trivial but it no longer does for `@called(once)` values.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
