### PR TITLE
SIL: make dynamic access scopes a deinit barrier

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -188,6 +188,11 @@ public class Instruction : CustomStringConvertible, Hashable {
     switch self {
     case SIL.isFullApplySite, is EndApplyInst, is AbortApplyInst:
       return true
+    case let endAccess as EndAccessInst where endAccess.beginAccess.enforcement == .dynamic:
+      // A deinitializer can read and write class properties, global variables or boxes - which are
+      // protected by dynamic access scopes: the deinit could modify the memory which the access
+      // scope is reading, or vice versa.
+      return true
     default:
       return mayAccessPointerOrGlobal || mayLoadWeakOrUnowned || maySynchronize
     }

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -149,52 +149,53 @@ public class Instruction : CustomStringConvertible, Hashable {
     return bridged.mayHaveSideEffects()
   }
 
-  public final var mayAccessPointerOrGlobal: Bool {
-    guard mayReadOrWriteMemory else {
-      return false
-    }
+  /// True if arbitrary functions may be called by this instruction.
+  /// This can be either directly, e.g. by an `apply` instruction, or indirectly by destroying a value which
+  /// might have a deinitializer which can call functions.
+  public var mayCallFunction: Bool { false }
+
+  public final var isDeinitBarrier: Bool {
     switch self {
-    case is BuiltinInst:
-      // Consider all builtins that read/write memory to access pointers.
+    case SIL.isFullApplySite, is EndApplyInst, is AbortApplyInst:
       return true
+
+    case is LoadWeakInst, is LoadUnownedInst, is StrongCopyUnownedValueInst, is StrongCopyUnmanagedValueInst:
+      // Moving a destroy over a load-weak changes its behavior, because if the object is destroyed
+      // before the load-weak it yields nil.
+      return true
+
+    case is HopToExecutorInst:
+      // A synchronization point.
+      return true
+
+    case let endAccess as EndAccessInst where endAccess.beginAccess.enforcement == .dynamic:
+      // A deinitializer can read and write class properties, global variables or boxes - which are
+      // protected by dynamic access scopes: the deinit could modify the memory which the access
+      // scope is reading, or vice versa.
+      return true
+
+    case let builtin as BuiltinInst:
+      // A memory accessing builtin can be an implicit load weak, a synchronization point or a
+      // pointer access.
+      return builtin.mayReadOrWriteMemory
+
     case let endBorrow as EndBorrowInst:
+      // Accessing memory via an arbitrary pointer is a deinit barrier, because it may conflict
+      // with a pointer access in a de-initializer.
       switch endBorrow.borrow {
       case let loadBorrow as LoadBorrowInst:
         return FindPointerOrGlobalWalker.mayAccessPointerOrGlobal(loadBorrow.address)
       default:
         return false
       }
+
     default:
-      return operands.contains { op in
-        FindPointerOrGlobalWalker.mayAccessPointerOrGlobal(op.value)
-      }
-    }
-  }
-
-  /// True if arbitrary functions may be called by this instruction.
-  /// This can be either directly, e.g. by an `apply` instruction, or indirectly by destroying a value which
-  /// might have a deinitializer which can call functions.
-  public var mayCallFunction: Bool { false }
-
-  public final var mayLoadWeakOrUnowned: Bool {
-    return bridged.mayLoadWeakOrUnowned()
-  }
-
-  public final var maySynchronize: Bool {
-    return bridged.maySynchronize()
-  }
-
-  public final var isDeinitBarrier: Bool {
-    switch self {
-    case SIL.isFullApplySite, is EndApplyInst, is AbortApplyInst:
-      return true
-    case let endAccess as EndAccessInst where endAccess.beginAccess.enforcement == .dynamic:
-      // A deinitializer can read and write class properties, global variables or boxes - which are
-      // protected by dynamic access scopes: the deinit could modify the memory which the access
-      // scope is reading, or vice versa.
-      return true
-    default:
-      return mayAccessPointerOrGlobal || mayLoadWeakOrUnowned || maySynchronize
+      // Accessing memory via an arbitrary pointer or a global is a deinit barrier, because it may
+      // conflict with such an access in a de-initializer.
+      return mayReadOrWriteMemory &&
+             operands.contains { op in
+               FindPointerOrGlobalWalker.mayAccessPointerOrGlobal(op.value)
+             }
     }
   }
 

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -245,18 +245,6 @@ inline bool accessKindMayConflict(SILAccessKind a, SILAccessKind b) {
   return !(a == SILAccessKind::Read && b == SILAccessKind::Read);
 }
 
-/// Whether \p instruction accesses storage whose representation is either (1)
-/// unidentified such as by reading a pointer or (2) global.
-bool mayAccessPointer(SILInstruction *instruction);
-
-/// Whether this instruction loads or copies a value whose storage does not
-/// increment the stored value's reference count.
-bool mayLoadWeakOrUnowned(SILInstruction* instruction);
-
-/// Conservatively, whether this instruction could involve a synchronization
-/// point like a memory barrier, lock or syscall.
-bool maySynchronize(SILInstruction* instruction);
-
 } // end namespace swift
 
 //===----------------------------------------------------------------------===//

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -747,9 +747,6 @@ struct BridgedInstruction {
   BRIDGED_INLINE bool mayRelease() const;
   BRIDGED_INLINE bool mayHaveSideEffects() const;
   BRIDGED_INLINE bool maySuspend() const;
-  bool mayAccessPointer() const;
-  bool mayLoadWeakOrUnowned() const;
-  bool maySynchronize() const;
   BRIDGED_INLINE bool shouldBeForwarding() const;
   BRIDGED_INLINE bool isIdenticalTo(BridgedInstruction inst) const;
   BRIDGED_INLINE SwiftInt getRawIndexInBlock() const;

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -435,53 +435,6 @@ bool swift::isLetAddress(SILValue address) {
 }
 
 //===----------------------------------------------------------------------===//
-//                      MARK: Deinitialization barriers.
-//===----------------------------------------------------------------------===//
-
-bool swift::mayAccessPointer(SILInstruction *instruction) {
-  assert(!FullApplySite::isa(instruction) && !isa<EndApplyInst>(instruction) &&
-         !isa<AbortApplyInst>(instruction));
-  if (!instruction->mayReadOrWriteMemory())
-    return false;
-  if (isa<BuiltinInst>(instruction)) {
-    // Consider all builtins that read/write memory to access pointers.
-    return true;
-  }
-  bool retval = false;
-  visitAccessedAddress(instruction, [&retval](Operand *operand) {
-    auto accessStorage = AccessStorage::compute(operand->get());
-    auto kind = accessStorage.getKind();
-    if (kind == AccessRepresentation::Kind::Unidentified ||
-        kind == AccessRepresentation::Kind::Global)
-      retval = true;
-  });
-  return retval;
-}
-
-bool swift::mayLoadWeakOrUnowned(SILInstruction *instruction) {
-  assert(!FullApplySite::isa(instruction) && !isa<EndApplyInst>(instruction) &&
-         !isa<AbortApplyInst>(instruction));
-  if (isa<BuiltinInst>(instruction)) {
-    return instruction->mayReadOrWriteMemory();
-  }
-  return isa<LoadWeakInst>(instruction) 
-      || isa<LoadUnownedInst>(instruction) 
-      || isa<StrongCopyUnownedValueInst>(instruction)
-      || isa<StrongCopyUnmanagedValueInst>(instruction);
-}
-
-/// Conservatively, whether this instruction could involve a synchronization
-/// point like a memory barrier, lock or syscall.
-bool swift::maySynchronize(SILInstruction *instruction) {
-  assert(!FullApplySite::isa(instruction) && !isa<EndApplyInst>(instruction) &&
-         !isa<AbortApplyInst>(instruction));
-  if (isa<BuiltinInst>(instruction)) {
-    return instruction->mayReadOrWriteMemory();
-  }
-  return isa<HopToExecutorInst>(instruction);
-}
-
-//===----------------------------------------------------------------------===//
 //                         MARK: AccessRepresentation
 //===----------------------------------------------------------------------===//
 

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -595,18 +595,6 @@ BridgedOwnedString BridgedInstruction::getDebugDescription() const {
   return BridgedOwnedString(str);
 }
 
-bool BridgedInstruction::mayAccessPointer() const {
-  return ::mayAccessPointer(unbridged());
-}
-
-bool BridgedInstruction::mayLoadWeakOrUnowned() const {
-  return ::mayLoadWeakOrUnowned(unbridged());
-}
-
-bool BridgedInstruction::maySynchronize() const {
-  return ::maySynchronize(unbridged());
-}
-
 BridgedType
 BridgedInstruction::KeyPathInst_getStaticInstanceClassType() const {
   return getAs<swift::KeyPathInst>()->getStaticInstanceClassType();

--- a/test/SIL/manual_ownership.swift
+++ b/test/SIL/manual_ownership.swift
@@ -195,13 +195,14 @@ func reassignments_1_fixed_2() {
 public func basic_loop_trivial_values(_ t: Triangle, _ xs: [Triangle]) {
   var p: Pair = t.a
   for x in xs { // expected-warning {{independent copy of 'xs' is required}}
+                // expected-warning@-1 {{accessing 'x' may produce a copy}}
     p = p.midpoint(x.a)
   }
   t.a = p
 }
 public func basic_loop_trivial_values_fixed(_ t: Triangle, _ xs: [Triangle]) {
   var p: Pair = t.a
-  for x in copy xs {
+  for x in copy xs { // expected-warning {{accessing 'x' may produce a copy}}
     p = p.midpoint(x.a)
   }
   t.a = p
@@ -216,6 +217,7 @@ public func basic_loop_trivial_values_fixed(_ t: Triangle, _ xs: [Triangle]) {
 public func basic_loop_nontrivial_values(_ t: Triangle, _ xs: [Triangle]) {
   var p: Pair = t.nontrivial.a // expected-warning {{accessing 't.nontrivial' may produce a copy}}
   for x in xs { // expected-warning {{independent copy of 'xs' is required}}
+                // expected-warning@-1 {{accessing 'x' may produce a copy}}
     p = p.midpoint(x.nontrivial.a) // expected-warning {{accessing 'x.nontrivial' may produce a copy}}
   }
   t.nontrivial.a = p // expected-warning {{accessing 't.nontrivial' may produce a copy}}
@@ -223,7 +225,7 @@ public func basic_loop_nontrivial_values(_ t: Triangle, _ xs: [Triangle]) {
 
 public func basic_loop_nontrivial_values_fixed(_ t: Triangle, _ xs: [Triangle]) {
   var p: Pair = (copy t.nontrivial).a
-  for x in copy xs {
+  for x in copy xs { // expected-warning {{accessing 'x' may produce a copy}}
     p = p.midpoint((copy x.nontrivial).a)
   }
   (copy t.nontrivial).a = p
@@ -233,7 +235,7 @@ public func basic_loop_nontrivial_values_reduced_copies(_ t: Triangle, _ xs: [Tr
   // FIXME: confusing variable names are chosen (rdar://161360537)
   let nt = t.nontrivial // expected-warning {{accessing 'nt' may produce a copy}}
   var p: Pair = nt.a
-  for x in copy xs {
+  for x in copy xs { // expected-warning {{accessing 'x' may produce a copy}}
     let xnt = x.nontrivial // expected-warning {{accessing 'xnt' may produce a copy}}
     p = p.midpoint(xnt.a)
   }
@@ -242,7 +244,7 @@ public func basic_loop_nontrivial_values_reduced_copies(_ t: Triangle, _ xs: [Tr
 public func basic_loop_nontrivial_values_reduced_copies_fixed(_ t: Triangle, _ xs: [Triangle]) {
   let nt = copy t.nontrivial
   var p: Pair = nt.a
-  for x in copy xs {
+  for x in copy xs { // expected-warning {{accessing 'x' may produce a copy}}
     let xnt = copy x.nontrivial
     p = p.midpoint(xnt.a)
   }

--- a/test/SILOptimizer/copy_propagation.sil
+++ b/test/SILOptimizer/copy_propagation.sil
@@ -359,17 +359,9 @@ class Y {}
 
 sil [ossa] @getObject : $@convention(thin) () -> @owned AnyObject
 
-// No overlap (access ignored):
-//     def
-//     use
-//     begin_access
-//     end_access
-//     destroy
-//
 // CHECK-LABEL: sil [ossa] @testNoOverlapInLiveBlock : $@convention(thin) () -> () {
 // CHECK:   [[DEF:%.*]] = apply %{{.*}}() : $@convention(thin) () -> @owned AnyObject
-// CHECK-NOT: copy_value
-// CHECK:   store [[DEF]] to [init]
+// CHECK:   copy_value
 // CHECK:   begin_access
 // CHECK:   end_access
 // CHECK: bb1:
@@ -401,19 +393,9 @@ bb1:
   return %v : $()
 }
 
-// No overlap (access ignored):
-//     def
-//     use
-//     br...
-// bb...
-//     begin_access
-//     end_access
-//     destroy
-//
 // CHECK-LABEL: sil [ossa] @testNoOverlapInDeadBlock : $@convention(thin) () -> () {
 // CHECK:   [[DEF:%.*]] = apply %{{.*}}() : $@convention(thin) () -> @owned AnyObject
-// CHECK-NOT: copy_value
-// CHECK:   store [[DEF]] to [init] %{{.*}} : $*AnyObject
+// CHECK:   copy_value
 // CHECK: br bb1
 // CHECK: bb1:
 // CHECK:   begin_access

--- a/test/SILOptimizer/cross-module-effects.swift
+++ b/test/SILOptimizer/cross-module-effects.swift
@@ -25,7 +25,7 @@ public final class X {
 
 // CHECK-FR-MODULE-LABEL: sil [canonical] @$s6Module17noInlineNoEffectsySiAA1XCF :
 // CHECK-FR-MODULE-NEXT:  [%0: noescape **, read c0.v**]
-// CHECK-FR-MODULE-NEXT:  [global: ]
+// CHECK-FR-MODULE-NEXT:  [global: deinit_barrier]
 // CHECK-FR-MODULE-NEXT:  {{^[^[]}}
 // CHECK-LE-MODULE-NOT: @$s6Module17noInlineNoEffectsySiAA1XCF
 public func noInlineNoEffects(_ x: X) -> Int {
@@ -34,7 +34,7 @@ public func noInlineNoEffects(_ x: X) -> Int {
 
 // CHECK-FR-MODULE-LABEL: sil [serialized] [noinline] [canonical] {{.*}}@$s6Module15inlineNoEffectsySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
 // CHECK-FR-MODULE-NEXT:  [%0: noescape **, read c0.v**]
-// CHECK-FR-MODULE-NEXT:  [global: ]
+// CHECK-FR-MODULE-NEXT:  [global: deinit_barrier]
 // CHECK-FR-MODULE-NEXT:  {{^[^[]}}
 // CHECK-LE-MODULE-LABEL: sil [serialized] [noinline] [canonical] {{.*}}@$s6Module15inlineNoEffectsySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
 // CHECK-LE-MODULE-NEXT:  {{^[^[]}}
@@ -46,7 +46,7 @@ public func inlineNoEffects(_ x: X) -> Int {
 
 // CHECK-FR-MODULE-LABEL: sil [canonical] @$s6Module14internalCalleeySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
 // CHECK-FR-MODULE-NEXT:  [%0: noescape **, read c0.v**]
-// CHECK-FR-MODULE-NEXT:  [global: ]
+// CHECK-FR-MODULE-NEXT:  [global: deinit_barrier]
 // CHECK-FR-MODULE-NEXT:  {{^[^[]}}
 // CHECK-LE-MODULE-LABEL: sil [canonical] @$s6Module14internalCalleeySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int{{$}}
 @usableFromInline
@@ -56,7 +56,7 @@ func internalCallee(_ x: X) -> Int {
 
 // CHECK-FR-MODULE-LABEL: sil [canonical] @$s6Module19noInlineWithEffectsySiAA1XCF :
 // CHECK-FR-MODULE-NEXT:  [%0: noescape! **, read c0.v**]
-// CHECK-FR-MODULE-NEXT:  [global: ]
+// CHECK-FR-MODULE-NEXT:  [global: deinit_barrier]
 // CHECK-FR-MODULE-NEXT:  {{^[^[]}}
 // CHECK-LE-MODULE-NOT: @$s6Module19noInlineWithEffectsySiAA1XCF
 @_effects(notEscaping x.**)
@@ -66,7 +66,7 @@ public func noInlineWithEffects(_ x: X) -> Int {
 
 // CHECK-FR-MODULE-LABEL: sil [serialized] [noinline] [canonical] {{.*}}@$s6Module17inlineWithEffectsySiAA1XCF :
 // CHECK-FR-MODULE-NEXT:  [%0: noescape! **, read c0.v**]
-// CHECK-FR-MODULE-NEXT:  [global: ]
+// CHECK-FR-MODULE-NEXT:  [global: deinit_barrier]
 // CHECK-FR-MODULE-NEXT:  {{^[^[]}}
 // CHECK-LE-MODULE-LABEL: sil [serialized] [noinline] [canonical] {{.*}}@$s6Module17inlineWithEffectsySiAA1XCF :
 // CHECK-LE-MODULE-NEXT:  [%0: noescape! **]
@@ -84,7 +84,7 @@ public func inlineWithEffects(_ x: X) -> Int {
 
 // CHECK-FR-MODULE-LABEL: sil [serialized] [noinline] [canonical] [ossa] @$s6Module12simpleInlineySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
 // CHECK-FR-MODULE-NEXT:  [%0: noescape **, read c0.v**]
-// CHECK-FR-MODULE-NEXT:  [global: ]
+// CHECK-FR-MODULE-NEXT:  [global: deinit_barrier]
 // CHECK-FR-MODULE-NEXT:  {{^[^[]}}
 // CHECK-LE-MODULE-LABEL: sil [serialized] [noinline] [canonical] [ossa] @$s6Module12simpleInlineySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
 // CHECK-LE-MODULE-NEXT:  {{^[^[]}}
@@ -125,7 +125,7 @@ public func callit1() -> Int {
 
 // CHECK-FR-MAIN-LABEL: sil @$s6Module17noInlineNoEffectsySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int
 // CHECK-FR-MAIN-NEXT:  [%0: noescape **, read c0.v**]
-// CHECK-FR-MAIN-NEXT:  [global: ]
+// CHECK-FR-MAIN-NEXT:  [global: deinit_barrier]
 // CHECK-FR-MAIN-NEXT:  {{^[^[]}}
 // CHECK-LE-MAIN-LABEL: sil @$s6Module17noInlineNoEffectsySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int{{$}}
 
@@ -141,7 +141,7 @@ public func callit2() -> Int {
 
 // CHECK-FR-MAIN-LABEL: sil public_external [noinline] @$s6Module15inlineNoEffectsySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
 // CHECK-FR-MAIN-NEXT:  [%0: noescape **, read c0.v**]
-// CHECK-FR-MAIN-NEXT:  [global: ]
+// CHECK-FR-MAIN-NEXT:  [global: deinit_barrier]
 // CHECK-FR-MAIN-NEXT:  {{^[^[]}}
 // CHECK-LE-MAIN-LABEL: sil public_external [noinline] @$s6Module15inlineNoEffectsySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
 // CHECK-LE-MAIN-NEXT:  {{^[^[]}}
@@ -189,7 +189,7 @@ public func callit5() -> Int {
 
 // CHECK-FR-MAIN-LABEL: sil public_external [noinline] @$s6Module12simpleInlineySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
 // CHECK-FR-MAIN-NEXT:  [%0: noescape **, read c0.v**]
-// CHECK-FR-MAIN-NEXT:  [global: ]
+// CHECK-FR-MAIN-NEXT:  [global: deinit_barrier]
 // CHECK-FR-MAIN-NEXT:  {{^[^[]}}
 // CHECK-LE-MAIN-LABEL: sil public_external [noinline] @$s6Module12simpleInlineySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
 // CHECK-LE-MAIN-NEXT:  {{^[^[]}}
@@ -217,7 +217,7 @@ public func callit6() -> X? {
 
 // CHECK-FR-MAIN-LABEL: sil @$s6Module14internalCalleeySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
 // CHECK-FR-MAIN-NEXT:  [%0: noescape **, read c0.v**]
-// CHECK-FR-MAIN-NEXT:  [global: ]
+// CHECK-FR-MAIN-NEXT:  [global: deinit_barrier]
 // CHECK-FR-MAIN-NEXT:  {{^[^[]}}
 // CHECK-LE-MAIN-LABEL: sil @$s6Module14internalCalleeySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int{{$}}
 

--- a/test/SILOptimizer/deinit_barrier.sil
+++ b/test/SILOptimizer/deinit_barrier.sil
@@ -175,6 +175,80 @@ bb0(%0 : $*C):
   return %r
 }
 
+class D {
+  var f: Int32
+}
+
+// A deinit can write class properties, so the `end_access` of a dynamically enforced access
+// scope is a barrier. Only the `end_access` is - a destroy is moved backwards, so it must not
+// get past the end of the scope.
+// CHECK-LABEL: begin running test 1 of {{[0-9]+}} on test_dynamic_access_of_class_property: is_deinit_barrier
+// CHECK:  begin_access [read] [dynamic]
+// CHECK:  false
+// CHECK-LABEL: end running test 1 of {{[0-9]+}} on test_dynamic_access_of_class_property: is_deinit_barrier
+// CHECK-LABEL: begin running test 2 of {{[0-9]+}} on test_dynamic_access_of_class_property: is_deinit_barrier
+// CHECK:  end_access
+// CHECK:  true
+// CHECK-LABEL: end running test 2 of {{[0-9]+}} on test_dynamic_access_of_class_property: is_deinit_barrier
+sil [ossa] @test_dynamic_access_of_class_property : $@convention(thin) (@guaranteed D) -> Int32 {
+bb0(%0 : @guaranteed $D):
+  %1 = ref_element_addr %0, #D.f
+  specify_test "is_deinit_barrier @instruction"
+  %2 = begin_access [read] [dynamic] %1
+  %3 = load [trivial] %2
+  specify_test "is_deinit_barrier @instruction"
+  end_access %2
+  return %3
+}
+
+// A statically enforced access is not a barrier by itself. The generic checks still apply,
+// and a class property is neither a pointer nor a global.
+// CHECK-LABEL: begin running test 1 of {{[0-9]+}} on test_static_access_of_class_property: is_deinit_barrier
+// CHECK:  end_access
+// CHECK:  false
+// CHECK-LABEL: end running test 1 of {{[0-9]+}} on test_static_access_of_class_property: is_deinit_barrier
+sil [ossa] @test_static_access_of_class_property : $@convention(thin) (@guaranteed D) -> Int32 {
+bb0(%0 : @guaranteed $D):
+  %1 = ref_element_addr %0, #D.f
+  %2 = begin_access [read] [static] %1
+  %3 = load [trivial] %2
+  specify_test "is_deinit_barrier @instruction"
+  end_access %2
+  return %3
+}
+
+// A deinit can also write global variables.
+// CHECK-LABEL: begin running test 1 of {{[0-9]+}} on test_dynamic_access_of_global: is_deinit_barrier
+// CHECK:  end_access
+// CHECK:  true
+// CHECK-LABEL: end running test 1 of {{[0-9]+}} on test_dynamic_access_of_global: is_deinit_barrier
+sil [ossa] @test_dynamic_access_of_global : $@convention(thin) () -> Int32 {
+bb0:
+  %0 = global_addr @global_var : $*Int32
+  %1 = begin_access [read] [dynamic] %0
+  %2 = load [trivial] %1
+  specify_test "is_deinit_barrier @instruction"
+  end_access %1
+  return %2
+}
+
+// Even with static enforcement the access to a global is a barrier, because the generic
+// checks are still applied. Note that `access-enforcement-wmo` can turn accesses to globals
+// into statically enforced accesses.
+// CHECK-LABEL: begin running test 1 of {{[0-9]+}} on test_static_access_of_global: is_deinit_barrier
+// CHECK:  end_access
+// CHECK:  true
+// CHECK-LABEL: end running test 1 of {{[0-9]+}} on test_static_access_of_global: is_deinit_barrier
+sil [ossa] @test_static_access_of_global : $@convention(thin) () -> Int32 {
+bb0:
+  %0 = global_addr @global_var : $*Int32
+  %1 = begin_access [read] [static] %0
+  %2 = load [trivial] %1
+  specify_test "is_deinit_barrier @instruction"
+  end_access %1
+  return %2
+}
+
 // CHECK-LABEL: begin running test {{.*}} on rdar120656227: is_deinit_barrier
 // CHECK:       builtin "int_memmove_RawPointer_RawPointer_Int64"
 // CHECK:       true

--- a/test/SILOptimizer/deinit_barrier_dynamic_access.swift
+++ b/test/SILOptimizer/deinit_barrier_dynamic_access.swift
@@ -1,0 +1,64 @@
+// RUN: %target-run-simple-swift(-O) | %FileCheck %s
+
+// REQUIRES: executable_test
+
+// rdar://183126067
+// The lifetime of `c1` must not be shortened to end before the `sum()` loop, because
+// `Container.deinit` writes the `next` fields which that loop is reading.
+// The loop reads those fields through dynamically enforced access scopes, so the
+// `end_access` instructions must be deinit barriers.
+
+final class Node {
+  var value: Int
+  var next: Node?
+
+  init(_ v: Int) { value = v }
+}
+
+final class Container {
+  var head: Node?
+  var tail: Node?
+
+  func append(_ value: Int) {
+    let node = Node(value)
+    if let t = tail {
+      t.next = node
+      tail = node
+    } else {
+      head = node
+      tail = node
+    }
+  }
+
+  func sum() -> Int {
+    var result = 0
+    var current = head
+    while let c = current {
+      result += c.value
+      current = c.next
+    }
+    return result
+  }
+
+  deinit {
+    // Unlink the nodes to avoid a deep recursive deallocation.
+    var current = head
+    while let c = current {
+      let n = c.next
+      c.next = nil
+      current = n
+    }
+  }
+}
+
+@inline(never)
+func testSumIsNotAffectedByDeinit() -> Int {
+  let c1 = Container()
+  for i in 1..<10 {
+    c1.append(i)
+  }
+  return c1.sum()
+}
+
+// CHECK: result=45
+print("result=\(testSumIsNotAffectedByDeinit())")

--- a/test/SILOptimizer/side_effects.sil
+++ b/test/SILOptimizer/side_effects.sil
@@ -328,7 +328,7 @@ bb0(%0 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>):
 
 // CHECK-LABEL: sil [ossa] @projections
 // CHECK-NEXT:  [%0: read e1.0.s0.c0.s0.v**]
-// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  [global: deinit_barrier]
 // CHECK-NEXT:  {{^[^[]}}
 sil [ossa] @projections : $@convention(thin) (@guaranteed EP) -> Builtin.Int32 {
 bb0(%0 : @guaranteed $EP):
@@ -979,7 +979,7 @@ bb0(%0 : $*Int32):
 
 // CHECK-LABEL: sil [ossa] @$writeToHead
 // CHECK-NEXT:  [%0: write s0.c0.v**]
-// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  [global: deinit_barrier]
 // CHECK-NEXT:  {{^[^[]}}
 sil [ossa] @$writeToHead : $@convention(thin) (@guaranteed S) -> () {
 bb0(%0 : @guaranteed $S):
@@ -1000,7 +1000,7 @@ bb0(%0 : @guaranteed $S):
 // CHECK-LABEL: sil [ossa] @storeToArgs
 // CHECK-NEXT:  [%0: noescape **, write c0.v**]
 // CHECK-NEXT:  [%1: noescape **, write c0.v**]
-// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  [global: deinit_barrier]
 // CHECK-NEXT:  {{^[^[]}}
 sil [ossa] @storeToArgs : $@convention(thin) (@guaranteed List, @guaranteed List) -> () {
 [%0: noescape **]
@@ -1090,7 +1090,7 @@ bb3(%6 : $Builtin.RawPointer) :
 
 // CHECK-LABEL: sil [ossa] @calleeWriteToHead
 // CHECK-NEXT:  [%0: write s0.c0.v**]
-// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  [global: deinit_barrier]
 // CHECK-NEXT:  {{^[^[]}}
 sil [ossa] @calleeWriteToHead : $@convention(thin) (@guaranteed S) -> () {
 bb0(%0 : @guaranteed $S):
@@ -1126,7 +1126,7 @@ bb0(%0 : @guaranteed $List):
 
 // CHECK-LABEL: sil [ossa] @readIdentifiedBoxArg
 // CHECK-NEXT:  [%0: read c0.v**]
-// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  [global: deinit_barrier]
 // CHECK-NEXT:  {{^[^[]}}
 sil [ossa] @readIdentifiedBoxArg : $@convention(thin) (@guaranteed { var Int32 }) -> Int32 {
 bb0(%0 : @guaranteed ${ var Int32 }):


### PR DESCRIPTION
A deinitializer can read and write class properties, global variables or boxes - which are
protected by dynamic access scopes: the deinit could modify the memory which the access
scope is reading, or vice versa.

Fixes a mis-compile
rdar://183126067

Also, consolidate the deinit barrier logic in `isDeinitBarrier`. This is pure refactoring and no functional change.