### PR TITLE
[build-script] Ignore /opt/homebrew/lib when configuring Darwin builds

### DIFF
--- a/utils/swift_build_support/swift_build_support/build_script_invocation.py
+++ b/utils/swift_build_support/swift_build_support/build_script_invocation.py
@@ -388,7 +388,8 @@ class BuildScriptInvocation(object):
             # For additional isolation, disable pkg-config. Homebrew's pkg-config
             # prioritizes CommandLineTools paths, resulting in compile errors.
             args.extra_cmake_options += [
-                '-DCMAKE_IGNORE_PATH=/usr/lib;/usr/local/lib;/lib',
+                '-DCMAKE_IGNORE_PATH=/usr/lib;/usr/local/lib;/lib;'
+                '/opt/homebrew/lib',
                 '-DPKG_CONFIG_EXECUTABLE=/usr/bin/false',
             ]
 


### PR DESCRIPTION
Add `/opt/homebrew/lib` to the existing CMAKE_IGNORE_PATH isolation list, which only covered the Intel Homebrew prefix.

rdar://184231214