### PR TITLE
[Swiftify] generate safe wrappers for virtual methods of reference types

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6800,6 +6800,9 @@ ERROR(downcast_to_foreign_reference_type,none,
 ERROR(cxx_super_pure_virtual_call,none,
       "cannot use 'super' to call C++ pure virtual method %0; it has no base "
       "class implementation", (const ValueDecl *))
+ERROR(cxx_super_safe_interop_wrapper_call,none,
+      "calling safe interop wrapper %0 in foreign reference type %1 using "
+      "'super' is not supported", (const ValueDecl *, const ValueDecl *))
 ERROR(invalid_ownership_with_optional,none,
       "%0 variable cannot have optional type", (ReferenceOwnership))
 ERROR(invalid_ownership_not_optional,none,

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4680,6 +4680,9 @@ namespace {
                            Impl.SwiftContext.getIdentifier(staticCallName),
                            funcDecl->getName().getArgumentNames()));
               Impl.virtualThunkToOriginal[result] = funcDecl;
+              // swiftify is called on import, but the virtualThunkToOriginal
+              // mapping is not yet ready at that time, so call it again.
+              Impl.swiftify(result);
               return result;
             }
             Impl.markUnavailable(funcDecl,

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -42,6 +42,8 @@
 #include "clang/AST/Type.h"
 #include "clang/Basic/Module.h"
 #include "clang/Sema/Overload.h"
+#include "llvm-c/Types.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include <optional>
 
 using namespace swift;
@@ -945,16 +947,22 @@ void ClangImporter::Implementation::swiftify(AbstractFunctionDecl *MappedDecl) {
                                ForeignReferenceTypeInfoRequest({Record}), {})
           .getPrimarySuperclass();
     };
-    for (auto *Overridden : CxxMethod->overridden_methods()) {
-      auto *BaseRecord = Overridden->getParent()->getCanonicalDecl();
+    if (CxxMethod->size_overridden_methods() > 0) {
+      llvm::SmallPtrSet<const clang::CXXRecordDecl *, 16> SuperClasses;
       for (auto *Super = primarySuperclassOf(CxxMethod->getParent()); Super;
            Super = primarySuperclassOf(Super)) {
-        if (Super->getCanonicalDecl() == BaseRecord) {
-          // FIXME: We should still generate a safe wrapper if the superclass is
-          // missing one, or if this one would produce a different signature.
-          DLOG("Inherits the wrapper of an overridden virtual method, which "
-               "dispatches here\n");
-          return;
+        SuperClasses.insert(Super->getCanonicalDecl());
+      }
+      if (SuperClasses.size() > 0) {
+        for (auto *Overridden : CxxMethod->overridden_methods()) {
+          if (SuperClasses.count(Overridden->getParent()->getCanonicalDecl())) {
+            // FIXME: We should still generate a safe wrapper if the superclass
+            // is missing one, or if this one would produce a different
+            // signature.
+            DLOG("Inherits the wrapper of an overridden virtual method, which "
+                 "dispatches here\n");
+            return;
+          }
         }
       }
     }

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -32,6 +32,7 @@
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attr.h"
 #include "clang/AST/Decl.h"
+#include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclObjC.h"
 #include "clang/AST/DeclTemplate.h"
 #include "clang/AST/DeclarationName.h"
@@ -916,6 +917,15 @@ void ClangImporter::Implementation::swiftify(AbstractFunctionDecl *MappedDecl) {
   if (!SwiftifyImportDecl) {
     DLOG("_SwiftifyImport macro not found\n");
     return;
+  }
+
+  if (ClangDecl->isImplicit()) {
+    if (auto *F = dyn_cast<FuncDecl>(MappedDecl)) {
+      if (const FuncDecl *Orig = getOriginalForVirtualThunk(F)) {
+        DLOG("Remapping virtual thunk to original clang decl\n");
+        ClangDecl = dyn_cast<clang::FunctionDecl>(Orig->getClangDecl());
+      }
+    }
   }
 
   // For projects adopting SafeInteropWrappers we preserve the original

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -928,6 +928,38 @@ void ClangImporter::Implementation::swiftify(AbstractFunctionDecl *MappedDecl) {
     }
   }
 
+  // A method that overrides a virtual method needs no wrapper of its own if it
+  // inherits one: the base class wrapper calls the virtual method, so it already
+  // dispatches to this override, and a second wrapper here would only add an
+  // overload that cannot be resolved against the inherited one.
+  //
+  // The wrapper is only inherited when the C++ base class is imported as the
+  // Swift superclass. Reached any other way - through a value type base, or a
+  // base that is not the primary one - the base class wrapper is cloned rather
+  // than inherited and cannot be called, so this override does need its own. Ask
+  // for the primary superclass in Clang terms rather than looking at the Swift
+  // superclass, which is not necessarily set up yet while importing a member.
+  if (auto *CxxMethod = dyn_cast<clang::CXXMethodDecl>(ClangDecl)) {
+    auto primarySuperclassOf = [&](const clang::CXXRecordDecl *Record) {
+      return evaluateOrDefault(SwiftContext.evaluator,
+                               ForeignReferenceTypeInfoRequest({Record}), {})
+          .getPrimarySuperclass();
+    };
+    for (auto *Overridden : CxxMethod->overridden_methods()) {
+      auto *BaseRecord = Overridden->getParent()->getCanonicalDecl();
+      for (auto *Super = primarySuperclassOf(CxxMethod->getParent()); Super;
+           Super = primarySuperclassOf(Super)) {
+        if (Super->getCanonicalDecl() == BaseRecord) {
+          // FIXME: We should still generate a safe wrapper if the superclass is
+          // missing one, or if this one would produce a different signature.
+          DLOG("Inherits the wrapper of an overridden virtual method, which "
+               "dispatches here\n");
+          return;
+        }
+      }
+    }
+  }
+
   // For projects adopting SafeInteropWrappers we preserve the original
   // Optional-propagating signature unless they opt-in to the new one.
   const bool LegacyOptionalRequested =

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -131,10 +131,10 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
 
         // Verify warn_unqualified_access uses.
         checkUnqualifiedAccessUse(DRE);
-        
+
         // Verify that special decls are eliminated.
         checkForDeclWithSpecialTypeCheckingSemantics(DRE);
-        
+
         // Verify that `unsafeBitCast` isn't misused.
         checkForSuspiciousBitCasts(DRE, nullptr);
       }
@@ -150,16 +150,19 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
       if (auto *KPE = dyn_cast<KeyPathExpr>(E))
         checkForInvalidKeyPath(KPE);
 
-      // Verify that a 'super' call does not target a pure virtual C++ method.
-      if (auto selfApply = dyn_cast<SelfApplyExpr>(E))
+      // Verify that a 'super' call targets something it can reach: not a pure
+      // virtual C++ method, and not a safe interop wrapper.
+      if (auto selfApply = dyn_cast<SelfApplyExpr>(E)) {
         checkSuperCallToPureVirtualCXXMethod(selfApply);
+        checkSuperCallToSafeInteropWrapper(selfApply);
+      }
 
       // Check function calls, looking through implicit conversions on the
       // function and inspecting the arguments directly.
       if (auto *Call = dyn_cast<ApplyExpr>(E)) {
         // Warn about surprising implicit optional promotions.
         checkOptionalPromotions(Call);
-        
+
         // Check the callee, looking through implicit conversions.
         auto base = Call->getFn();
         unsigned uncurryLevel = 0;
@@ -231,7 +234,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
           }
         }
       }
-      
+
       // If we have an assignment expression, scout ahead for acceptable _'s.
       if (auto *AE = dyn_cast<AssignExpr>(E)) {
         auto destExpr = AE->getDest();
@@ -307,7 +310,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
         // Diagnose tuple expressions with duplicate element label.
         diagnoseDuplicateLabels(tupleExpr->getLoc(),
                                 tupleExpr->getElementNames());
-                                
+
         // Diagnose attempts to form a tuple with any noncopyable elements.
         if (E->getType()->isNoncopyable()
             && !Ctx.LangOpts.hasFeature(Feature::MoveOnlyTuples)) {
@@ -375,6 +378,33 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
           Ctx.Diags.diagnose(selfApply->getFn()->getLoc(),
                              diag::cxx_super_pure_virtual_call, func);
       }
+    }
+
+    /// A `super` call statically dispatches to the base class implementation,
+    /// but at the moment there is not static dispatch version of the safe
+    /// wrapper to remap this call to. The wrapped method itself can still be
+    // called through `super`.
+    /// FIXME: expand safe wrapper of the static call version of this function
+    /// and do the remapping.
+    void checkSuperCallToSafeInteropWrapper(SelfApplyExpr *selfApply) {
+      if (!selfApply->getBase()->isSuperExpr())
+        return;
+
+      auto func = dyn_cast_or_null<FuncDecl>(
+          selfApply->getCalledValue(/*skipFunctionConversions=*/true));
+      if (!func)
+        return;
+
+      auto classDecl = func->getDeclContext()->getSelfClassDecl();
+      if (!classDecl || !classDecl->isForeignReferenceType())
+        return;
+
+      if (!func->isInMacroExpansionFromClangHeader())
+        return;
+
+      Ctx.Diags.diagnose(selfApply->getFn()->getLoc(),
+                         diag::cxx_super_safe_interop_wrapper_call, func,
+                         classDecl);
     }
 
     /// Visit each component of the keypath and emit a diagnostic if they
@@ -902,7 +932,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
             .fixItInsert(DRE->getStartLoc(), namePlusDot);
       }
     }
-    
+
     void checkForDeclWithSpecialTypeCheckingSemantics(const DeclRefExpr *DRE) {
       // Referencing type(of:) and other decls with special type-checking
       // behavior as functions is not implemented. Maybe we could wrap up the
@@ -913,7 +943,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
                            DRE->getDecl()->getBaseIdentifier());
       }
     }
-    
+
     enum BitcastableNumberKind {
       BNK_None = 0,
       BNK_Int8,
@@ -947,23 +977,23 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
       MATCH_DECL(Float)
       MATCH_DECL(Double)
 #undef MATCH_DECL
-      
+
       return BNK_None;
     }
-    
+
     static constexpr unsigned BNKPair(BitcastableNumberKind a,
                                       BitcastableNumberKind b) {
       return (a << 8) | b;
     }
-    
+
     void checkForSuspiciousBitCasts(DeclRefExpr *DRE,
                                     Expr *Parent = nullptr) {
       if (DRE->getDecl() != Ctx.getUnsafeBitCast())
         return;
-      
+
       if (DRE->getDeclRef().getSubstitutions().empty())
         return;
-      
+
       // Don't check the same use of unsafeBitCast twice.
       if (!AlreadyDiagnosedBitCasts.insert(DRE).second)
         return;
@@ -974,7 +1004,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
 
       // Warn about `unsafeBitCast` formulations that are undefined behavior
       // or have better-defined alternative APIs that can be used instead.
-      
+
       // If we have a parent ApplyExpr that calls bitcast, extract the argument
       // for fixits.
       Expr *subExpr = nullptr;
@@ -993,7 +1023,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
                        Lexer::getLocForEndOfToken(Ctx.SourceMgr,
                                                   apply->getEndLoc()));
       }
-  
+
       // Casting to the same type or a superclass is a no-op.
       if (toTy->isEqual(fromTy) ||
           toTy->isExactSuperclassOf(fromTy)) {
@@ -1007,7 +1037,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
         }
         return;
       }
-      
+
      if (auto fromFnTy = fromTy->getAs<FunctionType>()) {
         if (auto toFnTy = toTy->getAs<FunctionType>()) {
           // Casting a nonescaping function to escaping is UB.
@@ -1026,7 +1056,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
           return;
         }
       }
-      
+
       // Unchecked casting to a subclass is better done by unsafeDowncast.
       if (fromTy->isBindableToSuperclassOf(toTy)) {
         Ctx.Diags.diagnose(DRE->getLoc(), diag::bitcasting_to_downcast,
@@ -1063,13 +1093,13 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
               before = "UnsafeMutablePointer(mutating: ";
               after = ")";
               break;
-              
+
             case PTK_UnsafeRawPointer:
               // UnsafeRawPointer(pointer)
               before = "UnsafeRawPointer(";
               after = ")";
               break;
-              
+
             case PTK_UnsafeMutableRawPointer:
               // UnsafeMutableRawPointer(mutating: rawPointer)
               before = fromPTK == PTK_UnsafeMutablePointer
@@ -1087,7 +1117,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
           }
           return;
         }
-        
+
         // Casting to a different typed pointer type should use
         // withMemoryRebound.
         if (!isRawPointerKind(fromPTK) && !isRawPointerKind(toPTK)) {
@@ -1096,7 +1126,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
                              fromTy, toTy);
           return;
         }
-        
+
         // Casting a raw pointer to a typed pointer should bind the memory
         // (or assume it's already bound).
         assert(isRawPointerKind(fromPTK) && !isRawPointerKind(toPTK)
@@ -1138,7 +1168,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
         }
         return;
       }
-      
+
       StringRef replaceBefore, replaceAfter;
       std::optional<Diag<Type, Type>> diagID;
       SmallString<64> replaceBeforeBuf;
@@ -1170,7 +1200,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
           replaceBefore = replaceBeforeBuf;
           replaceAfter = ")";
           break;
-        
+
         // Combos that can be bitPattern-ed with a constructor and sign flip
         case BNKPair(BNK_Int32, BNK_Float):
         case BNKPair(BNK_Int64, BNK_Double):
@@ -1187,14 +1217,14 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
           replaceBefore = replaceBeforeBuf;
           replaceAfter = "))";
           break;
-        
+
         // Combos that can be bitPattern-ed with a property
         case BNKPair(BNK_Float, BNK_UInt32):
         case BNKPair(BNK_Double, BNK_UInt64):
           diagID = diag::bitcasting_for_number_bit_pattern_property;
           replaceAfter = ".bitPattern";
           break;
-        
+
         // Combos that can be bitPattern-ed with a property and sign flip
         case BNKPair(BNK_Float, BNK_Int32):
         case BNKPair(BNK_Double, BNK_Int64):
@@ -1221,12 +1251,12 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
             llvm::raw_svector_ostream os(replaceBeforeBuf);
             toTy->print(os);
             os << "(bitPattern: ";
-            
+
             if (fromBNK == BNK_Int)
               os << "Int";
             else
               os << "UInt";
-            
+
             if (toBNK == BNK_Float
                 || toBNK == BNK_Int32
                 || toBNK == BNK_UInt32)
@@ -1245,7 +1275,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
             llvm::raw_svector_ostream os(replaceBeforeBuf);
             toTy->print(os);
             os << "(bitPattern: UInt";
-            
+
             if (toBNK == BNK_Float
                 || toBNK == BNK_Int32
                 || toBNK == BNK_UInt32)
@@ -1256,7 +1286,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
           replaceBefore = replaceBeforeBuf;
           replaceAfter = ")))";
           break;
-    
+
         // Combos that can be bitPattern-ed then converted from a sized type
         // to (U)Int.
         case BNKPair(BNK_Int32, BNK_UInt):
@@ -1280,7 +1310,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
           replaceBefore = replaceBeforeBuf;
           replaceAfter = "))";
           break;
-        
+
         case BNKPair(BNK_Float, BNK_UInt):
         case BNKPair(BNK_Double, BNK_UInt):
           diagID = diag::bitcasting_for_number_bit_pattern_property;
@@ -1292,7 +1322,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
           replaceBefore = replaceBeforeBuf;
           replaceAfter = ".bitPattern)";
           break;
-          
+
         case BNKPair(BNK_Float, BNK_Int):
         case BNKPair(BNK_Double, BNK_Int):
           diagID = diag::bitcasting_for_number_bit_pattern_property;
@@ -1304,7 +1334,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
           replaceBefore = replaceBeforeBuf;
           replaceAfter = ".bitPattern))";
           break;
-        
+
         // Combos that should be done with a value-preserving initializer.
         case BNKPair(BNK_Int, BNK_Int32):
         case BNKPair(BNK_Int, BNK_Int64):
@@ -1323,13 +1353,13 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
           replaceBefore = replaceBeforeBuf;
           replaceAfter = ")";
           break;
-        
+
         default:
           // Leave other combos alone.
           break;
         }
       }
-      
+
       // Casting a pointer to an int or back should also use bitPattern
       // initializers.
       if (fromPointee && toBNK) {
@@ -1345,7 +1375,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
           replaceBefore = replaceBeforeBuf;
           replaceAfter = ")";
           break;
-          
+
         case BNK_UInt64:
         case BNK_UInt32:
         case BNK_Int64:
@@ -1363,7 +1393,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
           replaceBefore = replaceBeforeBuf;
           replaceAfter = "))";
           break;
-        
+
         default:
           break;
         }
@@ -1381,7 +1411,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
           replaceBefore = replaceBeforeBuf;
           replaceAfter = ")";
           break;
-          
+
         case BNK_UInt64:
         case BNK_UInt32:
         case BNK_Int64:
@@ -1404,7 +1434,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
           break;
         }
       }
-      
+
       if (diagID) {
         auto d = Ctx.Diags.diagnose(DRE->getLoc(), *diagID, fromTy, toTy);
         if (subExpr) {
@@ -1418,7 +1448,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
       }
 
     }
-    
+
     /// Return true if this is a 'nil' literal.  This looks
     /// like this if the type is Optional<T>:
     ///
@@ -1468,7 +1498,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
       auto DRE = dyn_cast<DeclRefExpr>(fnExpr);
       if (!DRE || !DRE->getDecl()->isOperator())
         return;
-      
+
       auto lhs = BE->getLHS();
       auto rhs = BE->getRHS();
       auto calleeName = DRE->getDecl()->getBaseName();
@@ -1486,7 +1516,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
                 Lexer::getLocForEndOfToken(Ctx.SourceMgr, rhs->getEndLoc()));
         return;
       }
-      
+
       if (calleeName == "==" || calleeName == "!=" ||
           calleeName == "===" || calleeName == "!==") {
         if (((subExpr = isImplicitPromotionToOptional(lhs)) &&
@@ -1495,7 +1525,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
              (subExpr = isImplicitPromotionToOptional(rhs)))) {
           bool isTrue = calleeName == "!=" || calleeName == "!==";
           bool isNilLiteral = isa<NilLiteralExpr>(lhs) || isa<NilLiteralExpr>(rhs);
-              
+
           Ctx.Diags.diagnose(DRE->getLoc(), diag::nonoptional_compare_to_nil,
                              subExpr->getType(), isNilLiteral, isTrue)
             .highlight(lhs->getSourceRange())
@@ -1659,7 +1689,7 @@ static void diagRecursivePropertyAccess(const Expr *E, const DeclContext *DC) {
 
       if (auto *AE = dyn_cast<AssignExpr>(E)) {
         subExpr = AE->getDest();
-        
+
         // If we couldn't flatten this expression, don't explode.
         if (!subExpr)
           return Action::Continue(E);
@@ -1698,7 +1728,7 @@ static void diagRecursivePropertyAccess(const Expr *E, const DeclContext *DC) {
                                  Var->getName(), Accessor->isSetter());
             }
           }
-          
+
           // If this is a direct store in a "willSet", we reject this because
           // it is about to get overwritten.
           if (isStore &&
@@ -1716,7 +1746,7 @@ static void diagRecursivePropertyAccess(const Expr *E, const DeclContext *DC) {
         if (MRE->getMember().getDecl() == Var &&
             isa<DeclRefExpr>(MRE->getBase()) &&
             isImplicitSelfUse(MRE->getBase())) {
-          
+
           if (MRE->getAccessSemantics() == AccessSemantics::Ordinary) {
             bool shouldDiagnose = false;
             // Warn about any property access in the getter.
@@ -2679,7 +2709,7 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
       DC = DC->getParent();
     }
   }
-  
+
   const_cast<Expr *>(E)->walk(DiagnoseWalker(ctx, ACE));
 }
 
@@ -2936,7 +2966,7 @@ bool TypeChecker::getDefaultGenericArgumentsString(
   llvm::interleave(typeDecl->getInnermostGenericParamTypes(),
                    printGenericParamSummary,
                    [&] { genericParamText << ", "; });
-  
+
   genericParamText << ">";
   return true;
 }
@@ -3495,10 +3525,10 @@ class VarDeclUsageChecker : public ASTWalker {
     RK_Defined     = 1,      ///< Whether it was ever defined in this scope.
     RK_Read        = 2,      ///< Whether it was ever read.
     RK_Written     = 4,      ///< Whether it was ever written or passed inout.
-    
+
     RK_CaptureList = 8       ///< Var is an entry in a capture list.
   };
-  
+
   /// These are all of the variables that we are tracking.  VarDecls get added
   /// to this when the declaration is seen.  We use a MapVector to keep the
   /// diagnostics emission in deterministic order.
@@ -3518,9 +3548,9 @@ class VarDeclUsageChecker : public ASTWalker {
 #ifndef NDEBUG
   llvm::SmallPtrSet<Expr*, 32> AllExprsSeen;
 #endif
-  
+
   bool sawError = false;
-  
+
   VarDeclUsageChecker(const VarDeclUsageChecker &) = delete;
   void operator=(const VarDeclUsageChecker &) = delete;
 
@@ -3556,18 +3586,18 @@ public:
     // If the variable is implicit, ignore it.
     if (VD->isImplicit() || VD->getLoc().isInvalid())
       return false;
-    
+
     // If the variable is computed, ignore it.
     if (!VD->hasStorage())
       return false;
-    
+
     // If the variable was invalid, ignore it and notice that the code is
     // malformed.
     if (VD->isInvalid()) {
       sawError = true;
       return false;
     }
-    
+
     // If the variable is already unnamed, ignore it.
     if (!VD->hasName() || VD->getName().str() == "_")
       return false;
@@ -3584,7 +3614,7 @@ public:
 
   void markBaseOfStorageUse(Expr *E, ConcreteDeclRef decl, unsigned flags);
   void markBaseOfStorageUse(Expr *E, bool isMutating);
-  
+
   void markStoredOrInOutExpr(Expr *E, unsigned Flags);
 
   MacroWalking getMacroWalkingBehavior() const override {
@@ -3693,7 +3723,7 @@ public:
         }
       }
     }
-    
+
     // A fallthrough dest case's bound variable means the source case's
     // var of the same name is read.
     if (auto *fallthroughStmt = dyn_cast<FallthroughStmt>(S)) {
@@ -3701,7 +3731,7 @@ public:
         SmallVector<VarDecl *, 4> sourceVars;
         auto sourcePattern = sourceCase->getCaseLabelItems()[0].getPattern();
         sourcePattern->collectVariables(sourceVars);
-        
+
         auto destCase = fallthroughStmt->getFallthroughDest();
         auto destPattern = destCase->getCaseLabelItems()[0].getPattern();
         destPattern->forEachVariable([&](VarDecl *V) {
@@ -3727,7 +3757,7 @@ public:
     return Action::Continue(S);
   }
 };
-  
+
 /// An AST walker that determines the underlying type of an opaque return decl
 /// from its associated function body.
 class OpaqueUnderlyingTypeChecker : public ASTWalker {
@@ -4240,7 +4270,7 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
       isWrittenLet = (access & RK_Written) != 0;
       access &= ~RK_Written;
     }
-    
+
     // If this variable has WeakStorageType, then it can be mutated in ways we
     // don't know.
     if (var->getInterfaceType()->is<WeakStorageType>() &&
@@ -4264,7 +4294,7 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
                        var->getName());
         continue;
       }
-      
+
       // If the source of the VarDecl is a trivial PatternBinding with only a
       // single binding, rewrite the whole thing into an assignment.
       //    let x = foo()
@@ -4387,7 +4417,7 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
           continue;
         }
       }
-      
+
       // Otherwise, this is something more complex, perhaps
       //    let (a,b) = foo()
       if (isUsedInInactive(var))
@@ -4406,7 +4436,7 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
       }
       continue;
     }
-    
+
     // If this is a mutable 'var', and it was never written to, suggest
     // upgrading to 'let'.
     if (var->getIntroducer() == VarDecl::Introducer::Var
@@ -4464,7 +4494,7 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
         continue;
       }
     }
-    
+
     // If this is a variable that was only written to, emit a warning.
     if ((access & RK_Read) == 0) {
       if (isUsedInInactive(var))
@@ -4539,22 +4569,22 @@ void VarDeclUsageChecker::markStoredOrInOutExpr(Expr *E, unsigned Flags) {
     sawError = true;
     return;
   }
-  
+
   // Ignore parens and other easy cases.
   E = E->getSemanticsProvidingExpr();
-  
+
   // If we found a decl that is being assigned to, then mark it.
   if (auto *DRE = dyn_cast<DeclRefExpr>(E)) {
     addMark(DRE->getDecl(), Flags);
     return;
   }
-  
+
   if (auto *TE = dyn_cast<TupleExpr>(E)) {
     for (auto &elt : TE->getElements())
       markStoredOrInOutExpr(elt, Flags);
     return;
   }
-  
+
   // If this is an assignment into a mutating subscript lvalue expr, then we
   // are mutating the base expression.  We also need to visit the index
   // expressions as loads though.
@@ -4564,7 +4594,7 @@ void VarDeclUsageChecker::markStoredOrInOutExpr(Expr *E, unsigned Flags) {
     markBaseOfStorageUse(SE->getBase(), SE->getDecl(), Flags);
     return;
   }
-  
+
   // Likewise for key path applications. An application of a WritableKeyPath
   // reads and writes its base; an application of a ReferenceWritableKeyPath
   // only reads its base; the other KeyPath types cannot be written at all.
@@ -4577,10 +4607,10 @@ void VarDeclUsageChecker::markStoredOrInOutExpr(Expr *E, unsigned Flags) {
     markBaseOfStorageUse(KPA->getBase(), isMutating);
     return;
   }
-  
+
   if (auto *ioe = dyn_cast<InOutExpr>(E))
     return markStoredOrInOutExpr(ioe->getSubExpr(), RK_Written|RK_Read);
-  
+
   if (auto *MRE = dyn_cast<MemberRefExpr>(E)) {
     markBaseOfStorageUse(MRE->getBase(), MRE->getMember(), Flags);
     return;
@@ -4588,7 +4618,7 @@ void VarDeclUsageChecker::markStoredOrInOutExpr(Expr *E, unsigned Flags) {
 
   if (auto *TEE = dyn_cast<TupleElementExpr>(E))
     return markStoredOrInOutExpr(TEE->getBase(), Flags);
-  
+
   if (auto *FVE = dyn_cast<ForceValueExpr>(E))
     return markStoredOrInOutExpr(FVE->getSubExpr(), Flags);
 
@@ -4659,19 +4689,19 @@ ASTWalker::PreWalkResult<Expr *> VarDeclUsageChecker::walkToExprPre(Expr *E) {
   // about.
   if (auto *assign = dyn_cast<AssignExpr>(E)) {
     markStoredOrInOutExpr(assign->getDest(), RK_Written);
-    
+
     // Don't walk into the LHS of the assignment, only the RHS.
     assign->getSrc()->walk(*this);
     return Action::SkipNode(E);
   }
-  
+
   // '&x' is a read and write of 'x'.
   if (auto *io = dyn_cast<InOutExpr>(E)) {
     markStoredOrInOutExpr(io->getSubExpr(), RK_Read|RK_Written);
     // Don't bother walking into this.
     return Action::SkipNode(E);
   }
-  
+
   // If we see an OpenExistentialExpr, remember the mapping for its OpaqueValue
   // and only walk the subexpr.
   if (auto *oee = dyn_cast<OpenExistentialExpr>(E)) {
@@ -4686,7 +4716,7 @@ ASTWalker::PreWalkResult<Expr *> VarDeclUsageChecker::walkToExprPre(Expr *E) {
       mapping->walk(*this);
     return Action::SkipNode(E);
   }
-  
+
   // If we saw an ErrorExpr, take note of this.
   if (isa<ErrorExpr>(E))
     sawError = true;
@@ -5326,7 +5356,7 @@ checkImplicitPromotionsInCondition(const StmtConditionElement &cond,
                                    ASTContext &ctx) {
   auto *p = cond.getPatternOrNull();
   if (!p) return;
-  
+
   if (auto *subExpr = isImplicitPromotionToOptional(cond.getInitializer())) {
     // If the subexpression was actually optional, then the pattern must be
     // checking for a type, which forced it to be promoted to a double optional
@@ -5859,7 +5889,7 @@ static void diagnoseUnintendedOptionalBehavior(const Expr *E,
       size_t optionalityDifference = 0;
       if (!isOptionalToAnyCoercion(srcType, destType, optionalityDifference))
         return;
-      
+
       // If we're implicitly unwrapping from IUO to Any then emit a custom
       // diagnostic
       if (hasImplicitlyUnwrappedResult(subExpr)) {
@@ -5880,7 +5910,7 @@ static void diagnoseUnintendedOptionalBehavior(const Expr *E,
                            /* from */ srcType, /* to */ destType)
             .highlight(subExpr->getSourceRange());
       }
-      
+
       if (optionalityDifference == 1) {
         Ctx.Diags.diagnose(subExpr->getLoc(), diag::default_optional_to_any)
             .highlight(subExpr->getSourceRange())
@@ -5982,12 +6012,12 @@ static void diagnoseUnintendedOptionalBehavior(const Expr *E,
       auto uncurriedType = fnDecl->getInterfaceType()->getAs<AnyFunctionType>();
       auto curriedType = uncurriedType->getResult()->getAs<AnyFunctionType>();
 
-      // I don't know why you'd use a zero-arg interpolator, but it obviously 
+      // I don't know why you'd use a zero-arg interpolator, but it obviously
       // doesn't interpolate an optional.
       if (curriedType->getNumParams() == 0)
         return false;
 
-      // If the first parameter explicitly accepts the type, this method 
+      // If the first parameter explicitly accepts the type, this method
       // presumably doesn't want us to warn about optional use.
       auto firstParamType =
         curriedType->getParams().front().getPlainType()->getRValueType();
@@ -6005,7 +6035,7 @@ static void diagnoseUnintendedOptionalBehavior(const Expr *E,
     Expr *
     getFirstArgIfUnintendedInterpolation(ArgumentList *args,
                                          UnintendedInterpolationKind kind) {
-      // Just check the first argument, which is usually the value 
+      // Just check the first argument, which is usually the value
       // being interpolated.
       if (args->empty())
         return nullptr;
@@ -6040,7 +6070,7 @@ static void diagnoseUnintendedOptionalBehavior(const Expr *E,
       }
       return "unknown";
     }
-    
+
     void diagnoseUnintendedInterpolation(CallExpr *segment,
                                          Expr * arg,
                                          UnintendedInterpolationKind kind) {
@@ -6053,7 +6083,7 @@ static void diagnoseUnintendedOptionalBehavior(const Expr *E,
       if (kind == UnintendedInterpolationKind::Optional) {
         auto wrappedArgType = arg->getType()->getRValueType()->getOptionalObjectType();
         auto baseTypeName = baseInterpolationTypeName(segment);
-        
+
         // Suggest using a default value parameter, but only for non-string values
         // when the base interpolation type is the default.
         if (!wrappedArgType->isString() && baseTypeName == "DefaultStringInterpolation")
@@ -6546,7 +6576,7 @@ diagnoseDictionaryLiteralDuplicateKeyEntries(const Expr *E,
       }
       return "'" + out + "'";
     }
-    
+
     bool shouldDiagnoseLiteral(const LiteralExpr *LE) {
       switch (LE->getKind()) {
       case ExprKind::IntegerLiteral:
@@ -6607,7 +6637,7 @@ diagnoseDictionaryLiteralDuplicateKeyEntries(const Expr *E,
         auto *LE = dyn_cast<LiteralExpr>(keyExpr);
         if (!LE)
           continue;
-        
+
         if (!shouldDiagnoseLiteral(LE))
           continue;
 
@@ -7039,7 +7069,7 @@ TypeChecker::omitNeedlessWords(AbstractFunctionDecl *afd) {
     paramTypes.push_back(getTypeNameForOmission(param->getInterfaceType())
                          .withDefaultArgument(param->isDefaultArgument()));
   }
-  
+
   // Handle contextual type, result type, and returnsSelf.
   Type contextType = afd->getDeclContext()->getDeclaredInterfaceType();
   Type resultType;

--- a/test/Interop/Cxx/swiftify-import/counted-by-method.swift
+++ b/test/Interop/Cxx/swiftify-import/counted-by-method.swift
@@ -261,14 +261,6 @@ struct InheritRef : public RefType {
   int refSubBasic(const int * __counted_by(len) p, int len) const;
   
   // no lifetimebound annotation on override
-  // expected-expansion@+8:97{{
-  //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-  //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload|}}
-  //   expected-remark@3{{macro content: |public final func refLifetimeboundVirtual(_ p: UnsafeBufferPointer<CInt>) -> UnsafeBufferPointer<CInt> {|}}
-  //   expected-remark@4{{macro content: |    let len = CInt(exactly: p.count)!|}}
-  //   expected-remark@5{{macro content: |    return unsafe UnsafeBufferPointer<CInt>(start: unsafe refLifetimeboundVirtual(p.baseAddress, len), count: Int(len))|}}
-  //   expected-remark@6{{macro content: |}|}}
-  // }}
   const int * __counted_by(len) refLifetimeboundVirtual(const int * __counted_by(len) p, int len) const override;
 };
 
@@ -284,27 +276,6 @@ struct InheritRefPrivate : RefType {
   int refPrivateSubBasic(const int * __counted_by(len) p, int len) const;
   
   // with lifetimebound annotation on override
-  // expected-expansion@+21:122{{
-  //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-  //   expected-apple-error@2{{instance method cannot be more available than enclosing scope}}
-  //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload|}}
-  //   expected-error@3{{instance method overrides a 'final' instance method}}
-  //   expected-remark@3{{macro content: |public final func refLifetimeboundVirtual(_ p: Span<CInt>) -> Span<CInt> {|}}
-  //   expected-remark@4{{macro content: |    let len = CInt(exactly: p.count)!|}}
-  //   expected-remark@5{{macro content: |    let _pPtr = p.withUnsafeBufferPointer {|}}
-  //   expected-remark@6{{macro content: |        unsafe $0|}}
-  //   expected-remark@7{{macro content: |    }|}}
-  //   expected-remark@8{{macro content: |    defer {|}}
-  //   expected-remark@9{{macro content: |        _fixLifetime(p)|}}
-  //   expected-remark@10{{macro content: |    }|}}
-  //   expected-remark@11{{macro content: |    let _resultValue: UnsafePointer<CInt>? = unsafe refLifetimeboundVirtual(_pPtr.baseAddress, len)|}}
-  //   expected-remark@12{{macro content: |    if unsafe _resultValue == nil {|}}
-  //   expected-remark@13{{macro content: |      precondition(len == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")|}}
-  //   expected-remark@14{{macro content: |      return Span<CInt>()|}}
-  //   expected-remark@15{{macro content: |    }|}}
-  //   expected-remark@16{{macro content: |    return unsafe _swiftifyOverrideLifetime(Span<CInt>(_unsafeStart: _resultValue!, count: Int(len)), copying: ())|}}
-  //   expected-remark@17{{macro content: |}|}}
-  // }}
   const int * __counted_by(len) refLifetimeboundVirtual(const int * __counted_by(len) p [[clang::lifetimebound]], int len) const override;
 };
 
@@ -316,7 +287,7 @@ module Test {
 
 //--- test.swift
 // GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -plugin-path %swift-plugin-dir -cxx-interoperability-mode=default -I %t -source-filename=x -Xcc -Wno-nullability-completeness > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift | sed -e 's/@available(macOS 13\.3\.0, \*)/@available(SwiftStdlib 5.8, *)/'
-// GENERATED-HASH: 403e609312afef578c43734ef19593bd4e9d6f6ee829930d750a4f40361617a7
+// GENERATED-HASH: a5d61faf4a14adb37e59220e887bdb0722bc41f0e742e193fc68b600cec455e1
 import Test
 
 
@@ -453,9 +424,6 @@ extension RefType {
 extension InheritRef {
   final func call_refLifetimeboundVirtual_InheritRef(_ p: UnsafePointer<CInt>!, _ len: CInt) -> UnsafePointer<CInt>! {
     return unsafe refLifetimeboundVirtual(p, len)
-  }
-  @_alwaysEmitIntoClient @_disfavoredOverload final func call_refLifetimeboundVirtual_InheritRef(_ p: UnsafeBufferPointer<CInt>) -> UnsafeBufferPointer<CInt> {
-    return unsafe refLifetimeboundVirtual(p)
   }
   final func call_refSubBasic_InheritRef(_ p: UnsafePointer<CInt>!, _ len: CInt) -> CInt {
     return unsafe refSubBasic(p, len)

--- a/test/Interop/Cxx/swiftify-import/counted-by-method.swift
+++ b/test/Interop/Cxx/swiftify-import/counted-by-method.swift
@@ -259,247 +259,223 @@ module Test {
 }
 
 //--- test.swift
-// disable auto-gen for now because the source order is not stable
-// ENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -plugin-path %swift-plugin-dir -cxx-interoperability-mode=default -I %t -source-filename=x -Xcc -Wno-nullability-completeness > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
-// GENERATED-HASH: f8bc7adafc1f268cc0352f805f88feac123cfd1c2387c000e0a14d1a5b538e0c
+// GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -plugin-path %swift-plugin-dir -cxx-interoperability-mode=default -I %t -source-filename=x -Xcc -Wno-nullability-completeness > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift | sed -e 's/@available(macOS 13\.3\.0, \*)/@available(SwiftStdlib 5.8, *)/'
+// GENERATED-HASH: 7a230d7adcf011a382f8baa31f49c3b051dc2d9ecbbe1cc2b01bfa73d0cc3e3a
 import Test
 
 
-func call_valBasic(_ self: ValueType, _ p: UnsafePointer<CInt>!, _ len: CInt) -> CInt {
-  return unsafe self.valBasic(p, len)
+extension ValueType {
+  func call_valBasic_ValueType(_ p: UnsafePointer<CInt>!, _ len: CInt) -> CInt {
+    return unsafe valBasic(p, len)
+  }
+  @_alwaysEmitIntoClient @_disfavoredOverload func call_valBasic_ValueType(_ p: UnsafeBufferPointer<CInt>) -> CInt {
+    return unsafe valBasic(p)
+  }
+  func call_valNoescape_ValueType(_ p: UnsafePointer<CInt>!, _ len: CInt) {
+    return unsafe valNoescape(p, len)
+  }
+  @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+    @_alwaysEmitIntoClient @_disfavoredOverload func call_valNoescape_ValueType(_ p: Span<CInt>) {
+    return valNoescape(p)
+  }
+  mutating func call_valNonconstSelf_ValueType(_ p: UnsafePointer<CInt>!, _ len: CInt) {
+    return unsafe valNonconstSelf(p, len)
+  }
+  @_alwaysEmitIntoClient @_disfavoredOverload mutating func call_valNonconstSelf_ValueType(_ p: UnsafeBufferPointer<CInt>) {
+    return unsafe valNonconstSelf(p)
+  }
+  func call_valBasicVirt_ValueType(_ p: UnsafePointer<CInt>!, _ len: CInt) -> CInt {
+    return unsafe valBasicVirt(p, len)
+  }
+  @_alwaysEmitIntoClient @_disfavoredOverload func call_valBasicVirt_ValueType(_ p: UnsafeBufferPointer<CInt>) -> CInt {
+    return unsafe valBasicVirt(p)
+  }
+  func call_valLifetimebound_ValueType(_ p: UnsafeMutablePointer<CInt>!, _ len: CInt) -> UnsafeMutablePointer<CInt>! {
+    return unsafe valLifetimebound(p, len)
+  }
+  func call_valLifetimeboundVirtual_ValueType(_ p: UnsafePointer<CInt>!, _ len: CInt) -> UnsafePointer<CInt>! {
+    return unsafe valLifetimeboundVirtual(p, len)
+  }
+  borrowing func call_valLifetimeboundSelf_ValueType(_ len: CInt) -> UnsafeMutablePointer<CInt>! {
+    return unsafe valLifetimeboundSelf(len)
+  }
 }
 
-func call_valNoescape(_ self: ValueType, _ p: UnsafePointer<CInt>!, _ len: CInt) {
-  return unsafe self.valNoescape(p, len)
-}
-func call_valNonconstSelf(_ self: inout ValueType, _ p: UnsafePointer<CInt>!, _ len: CInt) {
-  return unsafe self.valNonconstSelf(p, len)
-}
-
-func call_valBasicVirt(_ self: ValueType, _ p: UnsafePointer<CInt>!, _ len: CInt) -> CInt {
-  return unsafe self.valBasicVirt(p, len)
-}
-
-func call_valLifetimebound(_ self: ValueType, _ p: UnsafeMutablePointer<CInt>!, _ len: CInt) -> UnsafeMutablePointer<CInt>! {
-  return unsafe self.valLifetimebound(p, len)
-}
-
-func call_valLifetimeboundVirtual(_ self: ValueType, _ p: UnsafePointer<CInt>!, _ len: CInt) -> UnsafePointer<CInt>! {
-  return unsafe self.valLifetimeboundVirtual(p, len)
-}
-func call_valLifetimeboundSelf(_ self: ValueType, _ len: CInt) -> UnsafeMutablePointer<CInt>! {
-  return unsafe self.valLifetimeboundSelf(len)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-  @_alwaysEmitIntoClient @_disfavoredOverload public func call_valNoescape(_ self: ValueType, _ p: Span<CInt>) {
-  return self.valNoescape(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_valNonconstSelf(_ self: inout ValueType, _ p: UnsafeBufferPointer<CInt>) {
-  return unsafe self.valNonconstSelf(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_valBasic(_ self: ValueType, _ p: UnsafeBufferPointer<CInt>) -> CInt {
-  return unsafe self.valBasic(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_valBasicVirt(_ self: ValueType, _ p: UnsafeBufferPointer<CInt>) -> CInt {
-  return unsafe self.valBasicVirt(p)
-}
-
-func call_valBasic(_ self: InheritValue, _ p: UnsafePointer<CInt>!, _ len: CInt) -> CInt {
-  return unsafe self.valBasic(p, len)
-}
-
-func call_valNoescape(_ self: InheritValue, _ p: UnsafePointer<CInt>!, _ len: CInt) {
-  return unsafe self.valNoescape(p, len)
-}
-func call_valNonconstSelf(_ self: inout InheritValue, _ p: UnsafePointer<CInt>!, _ len: CInt) {
-  return unsafe self.valNonconstSelf(p, len)
-}
-
-func call_valBasicVirt(_ self: InheritValue, _ p: UnsafePointer<CInt>!, _ len: CInt) -> CInt {
-  return unsafe self.valBasicVirt(p, len)
-}
-
-func call_valLifetimebound(_ self: InheritValue, _ p: UnsafeMutablePointer<CInt>!, _ len: CInt) -> UnsafeMutablePointer<CInt>? {
-  return unsafe self.valLifetimebound(p, len)
-}
-func call_valLifetimeboundSelf(_ self: InheritValue, _ len: CInt) -> UnsafeMutablePointer<CInt>? {
-  return unsafe self.valLifetimeboundSelf(len)
+extension InheritValue {
+  func call_valBasic_InheritValue(_ p: UnsafeBufferPointer<CInt>) -> CInt {
+    // expected-apple-error@+2{{missing argument for parameter #2 in call}}
+    // expected-apple-error@+1{{cannot convert value of type 'UnsafeBufferPointer<CInt>' (aka 'UnsafeBufferPointer<Int32>') to expected argument type 'UnsafePointer<CInt>' (aka 'UnsafePointer<Int32>')}}
+    return unsafe valBasic(p)
+  }
+  func call_valBasic_InheritValue(_ p: UnsafePointer<CInt>!, _ len: CInt) -> CInt {
+    return unsafe valBasic(p, len)
+  }
+  func call_valNoescape_InheritValue(_ p: Span<CInt>) {
+    // expected-apple-error@+2{{missing argument for parameter #2 in call}}
+    // expected-apple-error@+1{{cannot convert value of type 'Span<CInt>' (aka 'Span<Int32>') to expected argument type 'UnsafePointer<CInt>' (aka 'UnsafePointer<Int32>')}}
+    return valNoescape(p)
+  }
+  func call_valNoescape_InheritValue(_ p: UnsafePointer<CInt>!, _ len: CInt) {
+    return unsafe valNoescape(p, len)
+  }
+  mutating func call_valNonconstSelf_InheritValue(_ p: UnsafeBufferPointer<CInt>) {
+    // expected-apple-error@+2{{missing argument for parameter #2 in call}}
+    // expected-apple-error@+1{{cannot convert value of type 'UnsafeBufferPointer<CInt>' (aka 'UnsafeBufferPointer<Int32>') to expected argument type 'UnsafePointer<CInt>' (aka 'UnsafePointer<Int32>')}}
+    return unsafe valNonconstSelf(p)
+  }
+  mutating func call_valNonconstSelf_InheritValue(_ p: UnsafePointer<CInt>!, _ len: CInt) {
+    return unsafe valNonconstSelf(p, len)
+  }
+  func call_valBasicVirt_InheritValue(_ p: UnsafeBufferPointer<CInt>) -> CInt {
+    // expected-apple-error@+2{{missing argument for parameter #2 in call}}
+    // expected-apple-error@+1{{cannot convert value of type 'UnsafeBufferPointer<CInt>' (aka 'UnsafeBufferPointer<Int32>') to expected argument type 'UnsafePointer<CInt>' (aka 'UnsafePointer<Int32>')}}
+    return unsafe valBasicVirt(p)
+  }
+  func call_valBasicVirt_InheritValue(_ p: UnsafePointer<CInt>!, _ len: CInt) -> CInt {
+    return unsafe valBasicVirt(p, len)
+  }
+  func call_valLifetimebound_InheritValue(_ p: UnsafeMutablePointer<CInt>!, _ len: CInt) -> UnsafeMutablePointer<CInt>? {
+    return unsafe valLifetimebound(p, len)
+  }
+  borrowing func call_valLifetimeboundSelf_InheritValue(_ len: CInt) -> UnsafeMutablePointer<CInt>? {
+    return unsafe valLifetimeboundSelf(len)
+  }
+  func call_valSubBasic_InheritValue(_ p: UnsafePointer<CInt>!, _ len: CInt) -> CInt {
+    return unsafe valSubBasic(p, len)
+  }
+  @_alwaysEmitIntoClient @_disfavoredOverload func call_valSubBasic_InheritValue(_ p: UnsafeBufferPointer<CInt>) -> CInt {
+    return unsafe valSubBasic(p)
+  }
+  func call_valLifetimeboundVirtual_InheritValue(_ p: UnsafePointer<CInt>!, _ len: CInt) -> UnsafePointer<CInt>! {
+    return unsafe valLifetimeboundVirtual(p, len)
+  }
+  @_alwaysEmitIntoClient @_disfavoredOverload func call_valLifetimeboundVirtual_InheritValue(_ p: UnsafeBufferPointer<CInt>) -> UnsafeBufferPointer<CInt> {
+    return unsafe valLifetimeboundVirtual(p)
+  }
 }
 
-func call_valSubBasic(_ self: InheritValue, _ p: UnsafePointer<CInt>!, _ len: CInt) -> CInt {
-  return unsafe self.valSubBasic(p, len)
+@available(SwiftStdlib 5.8, *)
+extension RefType {
+  final func call_refBasicVirt_RefType(_ p: UnsafePointer<CInt>!, _ len: CInt) -> CInt {
+    return unsafe refBasicVirt(p, len)
+  }
+  final func call_refLifetimeboundVirtual_RefType(_ p: UnsafePointer<CInt>!, _ len: CInt) -> UnsafePointer<CInt>! {
+    return unsafe refLifetimeboundVirtual(p, len)
+  }
+  final func call_refBasic_RefType(_ p: UnsafePointer<CInt>!, _ len: CInt) -> CInt {
+    return unsafe refBasic(p, len)
+  }
+  @_alwaysEmitIntoClient @_disfavoredOverload final func call_refBasic_RefType(_ p: UnsafeBufferPointer<CInt>) -> CInt {
+    return unsafe refBasic(p)
+  }
+  final func call_refNoescape_RefType(_ p: UnsafePointer<CInt>!, _ len: CInt) {
+    return unsafe refNoescape(p, len)
+  }
+  // expected-apple-error@+1{{instance method cannot be more available than enclosing scope}}
+  @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+    @_alwaysEmitIntoClient @_disfavoredOverload final func call_refNoescape_RefType(_ p: Span<CInt>) {
+    return refNoescape(p)
+  }
+  final func call_refNonconstSelf_RefType(_ p: UnsafePointer<CInt>!, _ len: CInt) {
+    return unsafe refNonconstSelf(p, len)
+  }
+  @_alwaysEmitIntoClient @_disfavoredOverload final func call_refNonconstSelf_RefType(_ p: UnsafeBufferPointer<CInt>) {
+    return unsafe refNonconstSelf(p)
+  }
+  final func call_refLifetimebound_RefType(_ p: UnsafeMutablePointer<CInt>!, _ len: CInt) -> UnsafeMutablePointer<CInt>! {
+    return unsafe refLifetimebound(p, len)
+  }
+  borrowing final func call_refLifetimeboundSelf_RefType(_ len: CInt) -> UnsafeMutablePointer<CInt>! {
+    return unsafe refLifetimeboundSelf(len)
+  }
 }
 
-func call_valLifetimeboundVirtual(_ self: InheritValue, _ p: UnsafePointer<CInt>!, _ len: CInt) -> UnsafePointer<CInt>! {
-  return unsafe self.valLifetimeboundVirtual(p, len)
+@available(SwiftStdlib 5.8, *)
+extension InheritRef {
+  final func call_refLifetimeboundVirtual_InheritRef(_ p: UnsafePointer<CInt>!, _ len: CInt) -> UnsafePointer<CInt>! {
+    return unsafe refLifetimeboundVirtual(p, len)
+  }
+  final func call_refSubBasic_InheritRef(_ p: UnsafePointer<CInt>!, _ len: CInt) -> CInt {
+    return unsafe refSubBasic(p, len)
+  }
+  @_alwaysEmitIntoClient @_disfavoredOverload final func call_refSubBasic_InheritRef(_ p: UnsafeBufferPointer<CInt>) -> CInt {
+    return unsafe refSubBasic(p)
+  }
+  final func call_refBasicVirt_RefType_super(_ p: UnsafePointer<CInt>!, _ len: CInt) -> CInt {
+    return unsafe super.refBasicVirt(p, len)
+  }
+  final func call_refLifetimeboundVirtual_RefType_super(_ p: UnsafePointer<CInt>!, _ len: CInt) -> UnsafePointer<CInt>! {
+    return unsafe super.refLifetimeboundVirtual(p, len)
+  }
+  final func call_refBasic_RefType_super(_ p: UnsafePointer<CInt>!, _ len: CInt) -> CInt {
+    return unsafe super.refBasic(p, len)
+  }
+  @_alwaysEmitIntoClient @_disfavoredOverload final func call_refBasic_RefType_super(_ p: UnsafeBufferPointer<CInt>) -> CInt {
+    return unsafe super.refBasic(p)
+  }
+  final func call_refNoescape_RefType_super(_ p: UnsafePointer<CInt>!, _ len: CInt) {
+    return unsafe super.refNoescape(p, len)
+  }
+  // expected-apple-error@+1{{instance method cannot be more available than enclosing scope}}
+  @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+    @_alwaysEmitIntoClient @_disfavoredOverload final func call_refNoescape_RefType_super(_ p: Span<CInt>) {
+    return super.refNoescape(p)
+  }
+  final func call_refNonconstSelf_RefType_super(_ p: UnsafePointer<CInt>!, _ len: CInt) {
+    return unsafe super.refNonconstSelf(p, len)
+  }
+  @_alwaysEmitIntoClient @_disfavoredOverload final func call_refNonconstSelf_RefType_super(_ p: UnsafeBufferPointer<CInt>) {
+    return unsafe super.refNonconstSelf(p)
+  }
+  final func call_refLifetimebound_RefType_super(_ p: UnsafeMutablePointer<CInt>!, _ len: CInt) -> UnsafeMutablePointer<CInt>! {
+    return unsafe super.refLifetimebound(p, len)
+  }
+  borrowing final func call_refLifetimeboundSelf_RefType_super(_ len: CInt) -> UnsafeMutablePointer<CInt>! {
+    return unsafe super.refLifetimeboundSelf(len)
+  }
 }
 
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_valLifetimeboundVirtual(_ self: InheritValue, _ p: UnsafeBufferPointer<CInt>) -> UnsafeBufferPointer<CInt> {
-  return unsafe self.valLifetimeboundVirtual(p)
-}
-
-// FIXME: safe wrappers are cloned but not available?
-func call_valNoescape(_ self: InheritValue, _ p: Span<CInt>) {
-  // expected-error@+2{{missing argument for parameter #2 in call}}
-  // expected-error@+1{{cannot convert value of type 'Span<CInt>' (aka 'Span<Int32>') to expected argument type 'UnsafePointer<CInt>' (aka 'UnsafePointer<Int32>')}}
-  return self.valNoescape(p)
-}
-func call_valNonconstSelf(_ self: inout InheritValue, _ p: UnsafeBufferPointer<CInt>) {
-  // expected-error@+2{{missing argument for parameter #2 in call}}
-  // expected-error@+1{{cannot convert value of type 'UnsafeBufferPointer<CInt>' (aka 'UnsafeBufferPointer<Int32>') to expected argument type 'UnsafePointer<CInt>' (aka 'UnsafePointer<Int32>')}}
-  return unsafe self.valNonconstSelf(p)
-}
-
-func call_valBasic(_ self: InheritValue, _ p: UnsafeBufferPointer<CInt>) -> CInt {
-  // expected-error@+2{{missing argument for parameter #2 in call}}
-  // expected-error@+1{{cannot convert value of type 'UnsafeBufferPointer<CInt>' (aka 'UnsafeBufferPointer<Int32>') to expected argument type 'UnsafePointer<CInt>' (aka 'UnsafePointer<Int32>')}}
-  return unsafe self.valBasic(p)
-}
-
-func call_valBasicVirt(_ self: InheritValue, _ p: UnsafeBufferPointer<CInt>) -> CInt {
-  // expected-error@+2{{missing argument for parameter #2 in call}}
-  // expected-error@+1{{cannot convert value of type 'UnsafeBufferPointer<CInt>' (aka 'UnsafeBufferPointer<Int32>') to expected argument type 'UnsafePointer<CInt>' (aka 'UnsafePointer<Int32>')}}
-  return unsafe self.valBasicVirt(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_valSubBasic(_ self: InheritValue, _ p: UnsafeBufferPointer<CInt>) -> CInt {
-  return unsafe self.valSubBasic(p)
-}
-
-func call_refBasicVirt(_ self: RefType, _ p: UnsafePointer<CInt>!, _ len: CInt) -> CInt {
-  return unsafe self.refBasicVirt(p, len)
-}
-
-func call_refLifetimeboundVirtual(_ self: RefType, _ p: UnsafePointer<CInt>!, _ len: CInt) -> UnsafePointer<CInt>! {
-  return unsafe self.refLifetimeboundVirtual(p, len)
-}
-
-func call_refBasic(_ self: RefType, _ p: UnsafePointer<CInt>!, _ len: CInt) -> CInt {
-  return unsafe self.refBasic(p, len)
-}
-
-func call_refNoescape(_ self: RefType, _ p: UnsafePointer<CInt>!, _ len: CInt) {
-  return unsafe self.refNoescape(p, len)
-}
-
-func call_refNonconstSelf(_ self: RefType, _ p: UnsafePointer<CInt>!, _ len: CInt) {
-  return unsafe self.refNonconstSelf(p, len)
-}
-
-func call_refLifetimebound(_ self: RefType, _ p: UnsafeMutablePointer<CInt>!, _ len: CInt) -> UnsafeMutablePointer<CInt>! {
-  return unsafe self.refLifetimebound(p, len)
-}
-func call_refLifetimeboundSelf(_ self: RefType, _ len: CInt) -> UnsafeMutablePointer<CInt>! {
-  return unsafe self.refLifetimeboundSelf(len)
-}
-
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-  @_alwaysEmitIntoClient @_disfavoredOverload public func call_refNoescape(_ self: RefType, _ p: Span<CInt>) {
-  return self.refNoescape(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_refBasic(_ self: RefType, _ p: UnsafeBufferPointer<CInt>) -> CInt {
-  return unsafe self.refBasic(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_refNonconstSelf(_ self: RefType, _ p: UnsafeBufferPointer<CInt>) {
-  return unsafe self.refNonconstSelf(p)
-}
-
-func call_refLifetimeboundVirtual(_ self: InheritRef, _ p: UnsafePointer<CInt>!, _ len: CInt) -> UnsafePointer<CInt>! {
-  return unsafe self.refLifetimeboundVirtual(p, len)
-}
-
-func call_refBasicVirt(_ self: InheritRef, _ p: UnsafePointer<CInt>!, _ len: CInt) -> CInt {
-  return unsafe self.refBasicVirt(p, len)
-}
-
-func call_refBasic(_ self: InheritRef, _ p: UnsafePointer<CInt>!, _ len: CInt) -> CInt {
-  return unsafe self.refBasic(p, len)
-}
-
-func call_refNoescape(_ self: InheritRef, _ p: UnsafePointer<CInt>!, _ len: CInt) {
-  return unsafe self.refNoescape(p, len)
-}
-
-func call_refNonconstSelf(_ self: InheritRef, _ p: UnsafePointer<CInt>!, _ len: CInt) {
-  return unsafe self.refNonconstSelf(p, len)
-}
-
-func call_refLifetimebound(_ self: InheritRef, _ p: UnsafeMutablePointer<CInt>!, _ len: CInt) -> UnsafeMutablePointer<CInt>? {
-  return unsafe self.refLifetimebound(p, len)
-}
-func call_refLifetimeboundSelf(_ self: InheritRef, _ len: CInt) -> UnsafeMutablePointer<CInt>? {
-  return unsafe self.refLifetimeboundSelf(len)
-}
-
-func call_refSubBasic(_ self: InheritRef, _ p: UnsafePointer<CInt>!, _ len: CInt) -> CInt {
-  return unsafe self.refSubBasic(p, len)
-}
-
-func call_refNoescape(_ self: InheritRef, _ p: Span<CInt>) {
-  return self.refNoescape(p)
-}
-
-func call_refBasic(_ self: InheritRef, _ p: UnsafeBufferPointer<CInt>) -> CInt {
-  return unsafe self.refBasic(p)
-}
-
-func call_refNonconstSelf(_ self: InheritRef, _ p: UnsafeBufferPointer<CInt>) {
-  return unsafe self.refNonconstSelf(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_refSubBasic(_ self: InheritRef, _ p: UnsafeBufferPointer<CInt>) -> CInt {
-  return unsafe self.refSubBasic(p)
-}
-
-func call_refLifetimeboundVirtual(_ self: InheritRefPrivate, _ p: UnsafePointer<CInt>!, _ len: CInt) -> UnsafePointer<CInt>! {
-  return unsafe self.refLifetimeboundVirtual(p, len)
-}
-
-func call_refBasicVirt(_ self: InheritRefPrivate, _ p: UnsafePointer<CInt>!, _ len: CInt) -> CInt {
-  return unsafe self.refBasicVirt(p, len)
-}
-
-func call_refBasic(_ self: InheritRefPrivate, _ p: UnsafePointer<CInt>!, _ len: CInt) -> CInt {
-  return unsafe self.refBasic(p, len)
-}
-
-func call_refNoescape(_ self: InheritRefPrivate, _ p: UnsafePointer<CInt>!, _ len: CInt) {
-  return unsafe self.refNoescape(p, len)
-}
-
-func call_refNonconstSelf(_ self: InheritRefPrivate, _ p: UnsafePointer<CInt>!, _ len: CInt) {
-  return unsafe self.refNonconstSelf(p, len)
-}
-
-func call_refLifetimebound(_ self: InheritRefPrivate, _ p: UnsafeMutablePointer<CInt>!, _ len: CInt) -> UnsafeMutablePointer<CInt>? {
-  return unsafe self.refLifetimebound(p, len)
-}
-func call_refLifetimeboundSelf(_ self: InheritRefPrivate, _ len: CInt) -> UnsafeMutablePointer<CInt>? {
-  return unsafe self.refLifetimeboundSelf(len)
-}
-
-func call_refPrivateSubBasic(_ self: InheritRefPrivate, _ p: UnsafePointer<CInt>!, _ len: CInt) -> CInt {
-  return unsafe self.refPrivateSubBasic(p, len)
-}
-
-func call_refNoescape(_ self: InheritRefPrivate, _ p: Span<CInt>) {
-  return self.refNoescape(p)
-}
-
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_refPrivateSubBasic(_ self: InheritRefPrivate, _ p: UnsafeBufferPointer<CInt>) -> CInt {
-  return unsafe self.refPrivateSubBasic(p)
-}
-
-func call_refBasic(_ self: InheritRefPrivate, _ p: UnsafeBufferPointer<CInt>) -> CInt {
-  return unsafe self.refBasic(p)
-}
-
-func call_refNonconstSelf(_ self: InheritRefPrivate, _ p: UnsafeBufferPointer<CInt>) {
-  return unsafe self.refNonconstSelf(p)
+@available(SwiftStdlib 5.8, *)
+extension InheritRefPrivate {
+  final func call_refLifetimeboundVirtual_InheritRefPrivate(_ p: UnsafePointer<CInt>!, _ len: CInt) -> UnsafePointer<CInt>! {
+    return unsafe refLifetimeboundVirtual(p, len)
+  }
+  final func call_refPrivateSubBasic_InheritRefPrivate(_ p: UnsafePointer<CInt>!, _ len: CInt) -> CInt {
+    return unsafe refPrivateSubBasic(p, len)
+  }
+  @_alwaysEmitIntoClient @_disfavoredOverload final func call_refPrivateSubBasic_InheritRefPrivate(_ p: UnsafeBufferPointer<CInt>) -> CInt {
+    return unsafe refPrivateSubBasic(p)
+  }
+  final func call_refBasicVirt_RefType_super(_ p: UnsafePointer<CInt>!, _ len: CInt) -> CInt {
+    return unsafe super.refBasicVirt(p, len)
+  }
+  final func call_refLifetimeboundVirtual_RefType_super(_ p: UnsafePointer<CInt>!, _ len: CInt) -> UnsafePointer<CInt>! {
+    return unsafe super.refLifetimeboundVirtual(p, len)
+  }
+  final func call_refBasic_RefType_super(_ p: UnsafePointer<CInt>!, _ len: CInt) -> CInt {
+    return unsafe super.refBasic(p, len)
+  }
+  @_alwaysEmitIntoClient @_disfavoredOverload final func call_refBasic_RefType_super(_ p: UnsafeBufferPointer<CInt>) -> CInt {
+    return unsafe super.refBasic(p)
+  }
+  final func call_refNoescape_RefType_super(_ p: UnsafePointer<CInt>!, _ len: CInt) {
+    return unsafe super.refNoescape(p, len)
+  }
+  // expected-apple-error@+1{{instance method cannot be more available than enclosing scope}}
+  @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+    @_alwaysEmitIntoClient @_disfavoredOverload final func call_refNoescape_RefType_super(_ p: Span<CInt>) {
+    return super.refNoescape(p)
+  }
+  final func call_refNonconstSelf_RefType_super(_ p: UnsafePointer<CInt>!, _ len: CInt) {
+    return unsafe super.refNonconstSelf(p, len)
+  }
+  @_alwaysEmitIntoClient @_disfavoredOverload final func call_refNonconstSelf_RefType_super(_ p: UnsafeBufferPointer<CInt>) {
+    return unsafe super.refNonconstSelf(p)
+  }
+  final func call_refLifetimebound_RefType_super(_ p: UnsafeMutablePointer<CInt>!, _ len: CInt) -> UnsafeMutablePointer<CInt>! {
+    return unsafe super.refLifetimebound(p, len)
+  }
+  borrowing final func call_refLifetimeboundSelf_RefType_super(_ len: CInt) -> UnsafeMutablePointer<CInt>! {
+    return unsafe super.refLifetimeboundSelf(len)
+  }
 }

--- a/test/Interop/Cxx/swiftify-import/counted-by-method.swift
+++ b/test/Interop/Cxx/swiftify-import/counted-by-method.swift
@@ -435,6 +435,7 @@ extension InheritRef {
     return unsafe super.refBasicVirt(p, len)
   }
   @_alwaysEmitIntoClient @_disfavoredOverload final func call_refBasicVirt_RefType_super(_ p: UnsafeBufferPointer<CInt>) -> CInt {
+    // expected-error@+1{{calling safe interop wrapper 'refBasicVirt' in foreign reference type 'RefType' using 'super' is not supported}}
     return unsafe super.refBasicVirt(p)
   }
   final func call_refLifetimeboundVirtual_RefType_super(_ p: UnsafePointer<CInt>!, _ len: CInt) -> UnsafePointer<CInt>! {
@@ -444,6 +445,7 @@ extension InheritRef {
     return unsafe super.refBasic(p, len)
   }
   @_alwaysEmitIntoClient @_disfavoredOverload final func call_refBasic_RefType_super(_ p: UnsafeBufferPointer<CInt>) -> CInt {
+    // expected-error@+1{{calling safe interop wrapper 'refBasic' in foreign reference type 'RefType' using 'super' is not supported}}
     return unsafe super.refBasic(p)
   }
   final func call_refNoescape_RefType_super(_ p: UnsafePointer<CInt>!, _ len: CInt) {
@@ -452,12 +454,14 @@ extension InheritRef {
   // expected-apple-error@+1{{instance method cannot be more available than enclosing scope}}
   @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
     @_alwaysEmitIntoClient @_disfavoredOverload final func call_refNoescape_RefType_super(_ p: Span<CInt>) {
+    // expected-error@+1{{calling safe interop wrapper 'refNoescape' in foreign reference type 'RefType' using 'super' is not supported}}
     return super.refNoescape(p)
   }
   final func call_refNonconstSelf_RefType_super(_ p: UnsafePointer<CInt>!, _ len: CInt) {
     return unsafe super.refNonconstSelf(p, len)
   }
   @_alwaysEmitIntoClient @_disfavoredOverload final func call_refNonconstSelf_RefType_super(_ p: UnsafeBufferPointer<CInt>) {
+    // expected-error@+1{{calling safe interop wrapper 'refNonconstSelf' in foreign reference type 'RefType' using 'super' is not supported}}
     return unsafe super.refNonconstSelf(p)
   }
   final func call_refLifetimebound_RefType_super(_ p: UnsafeMutablePointer<CInt>!, _ len: CInt) -> UnsafeMutablePointer<CInt>! {
@@ -483,6 +487,7 @@ extension InheritRefPrivate {
     return unsafe super.refBasicVirt(p, len)
   }
   @_alwaysEmitIntoClient @_disfavoredOverload final func call_refBasicVirt_RefType_super(_ p: UnsafeBufferPointer<CInt>) -> CInt {
+    // expected-error@+1{{calling safe interop wrapper 'refBasicVirt' in foreign reference type 'RefType' using 'super' is not supported}}
     return unsafe super.refBasicVirt(p)
   }
   final func call_refLifetimeboundVirtual_RefType_super(_ p: UnsafePointer<CInt>!, _ len: CInt) -> UnsafePointer<CInt>! {
@@ -492,6 +497,7 @@ extension InheritRefPrivate {
     return unsafe super.refBasic(p, len)
   }
   @_alwaysEmitIntoClient @_disfavoredOverload final func call_refBasic_RefType_super(_ p: UnsafeBufferPointer<CInt>) -> CInt {
+    // expected-error@+1{{calling safe interop wrapper 'refBasic' in foreign reference type 'RefType' using 'super' is not supported}}
     return unsafe super.refBasic(p)
   }
   final func call_refNoescape_RefType_super(_ p: UnsafePointer<CInt>!, _ len: CInt) {
@@ -500,12 +506,14 @@ extension InheritRefPrivate {
   // expected-apple-error@+1{{instance method cannot be more available than enclosing scope}}
   @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
     @_alwaysEmitIntoClient @_disfavoredOverload final func call_refNoescape_RefType_super(_ p: Span<CInt>) {
+    // expected-error@+1{{calling safe interop wrapper 'refNoescape' in foreign reference type 'RefType' using 'super' is not supported}}
     return super.refNoescape(p)
   }
   final func call_refNonconstSelf_RefType_super(_ p: UnsafePointer<CInt>!, _ len: CInt) {
     return unsafe super.refNonconstSelf(p, len)
   }
   @_alwaysEmitIntoClient @_disfavoredOverload final func call_refNonconstSelf_RefType_super(_ p: UnsafeBufferPointer<CInt>) {
+    // expected-error@+1{{calling safe interop wrapper 'refNonconstSelf' in foreign reference type 'RefType' using 'super' is not supported}}
     return unsafe super.refNonconstSelf(p)
   }
   final func call_refLifetimebound_RefType_super(_ p: UnsafeMutablePointer<CInt>!, _ len: CInt) -> UnsafeMutablePointer<CInt>! {

--- a/test/Interop/Cxx/swiftify-import/counted-by-method.swift
+++ b/test/Interop/Cxx/swiftify-import/counted-by-method.swift
@@ -184,7 +184,14 @@ struct SWIFT_REFERENCE RefType {
   // }}
   void refNonconstSelf(const int * __counted_by(len) p, int len);
 
-  // FIXME: no safe wrapper generated for virtual thunk on ref counted type
+  // expected-expansion@+8:68{{
+  //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+  //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload|}}
+  //   expected-remark@3{{macro content: |public final func refBasicVirt(_ p: UnsafeBufferPointer<CInt>) -> CInt {|}}
+  //   expected-remark@4{{macro content: |    let len = CInt(exactly: p.count)!|}}
+  //   expected-remark@5{{macro content: |    return unsafe refBasicVirt(p.baseAddress, len)|}}
+  //   expected-remark@6{{macro content: |}|}}
+  // }}
   virtual int refBasicVirt(const int * __counted_by(len) p, int len) const;
 
   // FIXME: merge availability with that of surrounding context
@@ -210,6 +217,26 @@ struct SWIFT_REFERENCE RefType {
   // }}
   int * __counted_by(len) refLifetimebound(int * __counted_by(len) p [[clang::lifetimebound]], int len) const;
 
+  // expected-expansion@+20:130{{
+  //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+  //   expected-apple-error@2{{instance method cannot be more available than enclosing scope}}
+  //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload|}}
+  //   expected-remark@3{{macro content: |public final func refLifetimeboundVirtual(_ p: Span<CInt>) -> Span<CInt> {|}}
+  //   expected-remark@4{{macro content: |    let len = CInt(exactly: p.count)!|}}
+  //   expected-remark@5{{macro content: |    let _pPtr = p.withUnsafeBufferPointer {|}}
+  //   expected-remark@6{{macro content: |        unsafe $0|}}
+  //   expected-remark@7{{macro content: |    }|}}
+  //   expected-remark@8{{macro content: |    defer {|}}
+  //   expected-remark@9{{macro content: |        _fixLifetime(p)|}}
+  //   expected-remark@10{{macro content: |    }|}}
+  //   expected-remark@11{{macro content: |    let _resultValue: UnsafePointer<CInt>? = unsafe refLifetimeboundVirtual(_pPtr.baseAddress, len)|}}
+  //   expected-remark@12{{macro content: |    if unsafe _resultValue == nil {|}}
+  //   expected-remark@13{{macro content: |      precondition(len == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")|}}
+  //   expected-remark@14{{macro content: |      return Span<CInt>()|}}
+  //   expected-remark@15{{macro content: |    }|}}
+  //   expected-remark@16{{macro content: |    return unsafe _swiftifyOverrideLifetime(Span<CInt>(_unsafeStart: _resultValue!, count: Int(len)), copying: ())|}}
+  //   expected-remark@17{{macro content: |}|}}
+  // }}
   virtual const int * __counted_by(len) refLifetimeboundVirtual(const int * __counted_by(len) p [[clang::lifetimebound]], int len) const;
 
   // expected-expansion@+7:55{{
@@ -234,6 +261,14 @@ struct InheritRef : public RefType {
   int refSubBasic(const int * __counted_by(len) p, int len) const;
   
   // no lifetimebound annotation on override
+  // expected-expansion@+8:97{{
+  //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+  //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload|}}
+  //   expected-remark@3{{macro content: |public final func refLifetimeboundVirtual(_ p: UnsafeBufferPointer<CInt>) -> UnsafeBufferPointer<CInt> {|}}
+  //   expected-remark@4{{macro content: |    let len = CInt(exactly: p.count)!|}}
+  //   expected-remark@5{{macro content: |    return unsafe UnsafeBufferPointer<CInt>(start: unsafe refLifetimeboundVirtual(p.baseAddress, len), count: Int(len))|}}
+  //   expected-remark@6{{macro content: |}|}}
+  // }}
   const int * __counted_by(len) refLifetimeboundVirtual(const int * __counted_by(len) p, int len) const override;
 };
 
@@ -249,6 +284,27 @@ struct InheritRefPrivate : RefType {
   int refPrivateSubBasic(const int * __counted_by(len) p, int len) const;
   
   // with lifetimebound annotation on override
+  // expected-expansion@+21:122{{
+  //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+  //   expected-apple-error@2{{instance method cannot be more available than enclosing scope}}
+  //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload|}}
+  //   expected-error@3{{instance method overrides a 'final' instance method}}
+  //   expected-remark@3{{macro content: |public final func refLifetimeboundVirtual(_ p: Span<CInt>) -> Span<CInt> {|}}
+  //   expected-remark@4{{macro content: |    let len = CInt(exactly: p.count)!|}}
+  //   expected-remark@5{{macro content: |    let _pPtr = p.withUnsafeBufferPointer {|}}
+  //   expected-remark@6{{macro content: |        unsafe $0|}}
+  //   expected-remark@7{{macro content: |    }|}}
+  //   expected-remark@8{{macro content: |    defer {|}}
+  //   expected-remark@9{{macro content: |        _fixLifetime(p)|}}
+  //   expected-remark@10{{macro content: |    }|}}
+  //   expected-remark@11{{macro content: |    let _resultValue: UnsafePointer<CInt>? = unsafe refLifetimeboundVirtual(_pPtr.baseAddress, len)|}}
+  //   expected-remark@12{{macro content: |    if unsafe _resultValue == nil {|}}
+  //   expected-remark@13{{macro content: |      precondition(len == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")|}}
+  //   expected-remark@14{{macro content: |      return Span<CInt>()|}}
+  //   expected-remark@15{{macro content: |    }|}}
+  //   expected-remark@16{{macro content: |    return unsafe _swiftifyOverrideLifetime(Span<CInt>(_unsafeStart: _resultValue!, count: Int(len)), copying: ())|}}
+  //   expected-remark@17{{macro content: |}|}}
+  // }}
   const int * __counted_by(len) refLifetimeboundVirtual(const int * __counted_by(len) p [[clang::lifetimebound]], int len) const override;
 };
 
@@ -260,7 +316,7 @@ module Test {
 
 //--- test.swift
 // GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -plugin-path %swift-plugin-dir -cxx-interoperability-mode=default -I %t -source-filename=x -Xcc -Wno-nullability-completeness > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift | sed -e 's/@available(macOS 13\.3\.0, \*)/@available(SwiftStdlib 5.8, *)/'
-// GENERATED-HASH: 7a230d7adcf011a382f8baa31f49c3b051dc2d9ecbbe1cc2b01bfa73d0cc3e3a
+// GENERATED-HASH: 403e609312afef578c43734ef19593bd4e9d6f6ee829930d750a4f40361617a7
 import Test
 
 
@@ -303,32 +359,32 @@ extension ValueType {
 
 extension InheritValue {
   func call_valBasic_InheritValue(_ p: UnsafeBufferPointer<CInt>) -> CInt {
-    // expected-apple-error@+2{{missing argument for parameter #2 in call}}
-    // expected-apple-error@+1{{cannot convert value of type 'UnsafeBufferPointer<CInt>' (aka 'UnsafeBufferPointer<Int32>') to expected argument type 'UnsafePointer<CInt>' (aka 'UnsafePointer<Int32>')}}
+    // expected-error@+2{{missing argument for parameter #2 in call}}
+    // expected-error@+1{{cannot convert value of type 'UnsafeBufferPointer<CInt>' (aka 'UnsafeBufferPointer<Int32>') to expected argument type 'UnsafePointer<CInt>' (aka 'UnsafePointer<Int32>')}}
     return unsafe valBasic(p)
   }
   func call_valBasic_InheritValue(_ p: UnsafePointer<CInt>!, _ len: CInt) -> CInt {
     return unsafe valBasic(p, len)
   }
   func call_valNoescape_InheritValue(_ p: Span<CInt>) {
-    // expected-apple-error@+2{{missing argument for parameter #2 in call}}
-    // expected-apple-error@+1{{cannot convert value of type 'Span<CInt>' (aka 'Span<Int32>') to expected argument type 'UnsafePointer<CInt>' (aka 'UnsafePointer<Int32>')}}
+    // expected-error@+2{{missing argument for parameter #2 in call}}
+    // expected-error@+1{{cannot convert value of type 'Span<CInt>' (aka 'Span<Int32>') to expected argument type 'UnsafePointer<CInt>' (aka 'UnsafePointer<Int32>')}}
     return valNoescape(p)
   }
   func call_valNoescape_InheritValue(_ p: UnsafePointer<CInt>!, _ len: CInt) {
     return unsafe valNoescape(p, len)
   }
   mutating func call_valNonconstSelf_InheritValue(_ p: UnsafeBufferPointer<CInt>) {
-    // expected-apple-error@+2{{missing argument for parameter #2 in call}}
-    // expected-apple-error@+1{{cannot convert value of type 'UnsafeBufferPointer<CInt>' (aka 'UnsafeBufferPointer<Int32>') to expected argument type 'UnsafePointer<CInt>' (aka 'UnsafePointer<Int32>')}}
+    // expected-error@+2{{missing argument for parameter #2 in call}}
+    // expected-error@+1{{cannot convert value of type 'UnsafeBufferPointer<CInt>' (aka 'UnsafeBufferPointer<Int32>') to expected argument type 'UnsafePointer<CInt>' (aka 'UnsafePointer<Int32>')}}
     return unsafe valNonconstSelf(p)
   }
   mutating func call_valNonconstSelf_InheritValue(_ p: UnsafePointer<CInt>!, _ len: CInt) {
     return unsafe valNonconstSelf(p, len)
   }
   func call_valBasicVirt_InheritValue(_ p: UnsafeBufferPointer<CInt>) -> CInt {
-    // expected-apple-error@+2{{missing argument for parameter #2 in call}}
-    // expected-apple-error@+1{{cannot convert value of type 'UnsafeBufferPointer<CInt>' (aka 'UnsafeBufferPointer<Int32>') to expected argument type 'UnsafePointer<CInt>' (aka 'UnsafePointer<Int32>')}}
+    // expected-error@+2{{missing argument for parameter #2 in call}}
+    // expected-error@+1{{cannot convert value of type 'UnsafeBufferPointer<CInt>' (aka 'UnsafeBufferPointer<Int32>') to expected argument type 'UnsafePointer<CInt>' (aka 'UnsafePointer<Int32>')}}
     return unsafe valBasicVirt(p)
   }
   func call_valBasicVirt_InheritValue(_ p: UnsafePointer<CInt>!, _ len: CInt) -> CInt {
@@ -358,6 +414,9 @@ extension InheritValue {
 extension RefType {
   final func call_refBasicVirt_RefType(_ p: UnsafePointer<CInt>!, _ len: CInt) -> CInt {
     return unsafe refBasicVirt(p, len)
+  }
+  @_alwaysEmitIntoClient @_disfavoredOverload final func call_refBasicVirt_RefType(_ p: UnsafeBufferPointer<CInt>) -> CInt {
+    return unsafe refBasicVirt(p)
   }
   final func call_refLifetimeboundVirtual_RefType(_ p: UnsafePointer<CInt>!, _ len: CInt) -> UnsafePointer<CInt>! {
     return unsafe refLifetimeboundVirtual(p, len)
@@ -395,6 +454,9 @@ extension InheritRef {
   final func call_refLifetimeboundVirtual_InheritRef(_ p: UnsafePointer<CInt>!, _ len: CInt) -> UnsafePointer<CInt>! {
     return unsafe refLifetimeboundVirtual(p, len)
   }
+  @_alwaysEmitIntoClient @_disfavoredOverload final func call_refLifetimeboundVirtual_InheritRef(_ p: UnsafeBufferPointer<CInt>) -> UnsafeBufferPointer<CInt> {
+    return unsafe refLifetimeboundVirtual(p)
+  }
   final func call_refSubBasic_InheritRef(_ p: UnsafePointer<CInt>!, _ len: CInt) -> CInt {
     return unsafe refSubBasic(p, len)
   }
@@ -403,6 +465,9 @@ extension InheritRef {
   }
   final func call_refBasicVirt_RefType_super(_ p: UnsafePointer<CInt>!, _ len: CInt) -> CInt {
     return unsafe super.refBasicVirt(p, len)
+  }
+  @_alwaysEmitIntoClient @_disfavoredOverload final func call_refBasicVirt_RefType_super(_ p: UnsafeBufferPointer<CInt>) -> CInt {
+    return unsafe super.refBasicVirt(p)
   }
   final func call_refLifetimeboundVirtual_RefType_super(_ p: UnsafePointer<CInt>!, _ len: CInt) -> UnsafePointer<CInt>! {
     return unsafe super.refLifetimeboundVirtual(p, len)
@@ -448,6 +513,9 @@ extension InheritRefPrivate {
   }
   final func call_refBasicVirt_RefType_super(_ p: UnsafePointer<CInt>!, _ len: CInt) -> CInt {
     return unsafe super.refBasicVirt(p, len)
+  }
+  @_alwaysEmitIntoClient @_disfavoredOverload final func call_refBasicVirt_RefType_super(_ p: UnsafeBufferPointer<CInt>) -> CInt {
+    return unsafe super.refBasicVirt(p)
   }
   final func call_refLifetimeboundVirtual_RefType_super(_ p: UnsafePointer<CInt>!, _ len: CInt) -> UnsafePointer<CInt>! {
     return unsafe super.refLifetimeboundVirtual(p, len)

--- a/test/Interop/Cxx/swiftify-import/counted-by-virtual-method-in-reference-type.swift
+++ b/test/Interop/Cxx/swiftify-import/counted-by-virtual-method-in-reference-type.swift
@@ -4,12 +4,6 @@
 // RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t -cxx-interoperability-mode=default \
 // RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions -verify-ignore-macro-note -eager-macro-checking
 
-// Check that ClangImporter infers and expands safe wrappers for C++
-// methods with __counted_by parameters.
-
-// FIXME: a virtual method on an imported reference type does not
-// currently get a safe wrapper, so RefType.sumVirtual below has no expansion.
-
 //--- test.h
 #define __counted_by(x) __attribute__((__counted_by__(x)))
 
@@ -51,7 +45,14 @@ struct SWIFT_REFERENCE RefType {
   // }}
   int sumNonVirtual(const int * __counted_by(len) values, int len) const;
 
-  // A virtual method on a reference type does NOT get a safe wrapper yet.
+  // expected-expansion@+8:71{{
+  //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+  //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload|}}
+  //   expected-remark@3{{macro content: |public final func sumVirtual(_ values: UnsafeBufferPointer<CInt>) -> CInt {|}}
+  //   expected-remark@4{{macro content: |    let len = CInt(exactly: values.count)!|}}
+  //   expected-remark@5{{macro content: |    return unsafe sumVirtual(values.baseAddress, len)|}}
+  //   expected-remark@6{{macro content: |}|}}
+  // }}
   virtual int sumVirtual(const int * __counted_by(len) values, int len) const;
 };
 

--- a/test/Interop/Cxx/swiftify-import/counted-by-virtual-method-in-reference-type.swift
+++ b/test/Interop/Cxx/swiftify-import/counted-by-virtual-method-in-reference-type.swift
@@ -1,0 +1,76 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t -cxx-interoperability-mode=default \
+// RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions -verify-ignore-macro-note -eager-macro-checking
+
+// Check that ClangImporter infers and expands safe wrappers for C++
+// methods with __counted_by parameters.
+
+// FIXME: a virtual method on an imported reference type does not
+// currently get a safe wrapper, so RefType.sumVirtual below has no expansion.
+
+//--- test.h
+#define __counted_by(x) __attribute__((__counted_by__(x)))
+
+#define SWIFT_REFERENCE \
+    __attribute__((swift_attr("import_reference"))) \
+    __attribute__((swift_attr("retain:immortal")))  \
+    __attribute__((swift_attr("release:immortal")))
+
+struct ValueType {
+  // expected-expansion@+8:66{{
+  //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+  //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload|}}
+  //   expected-remark@3{{macro content: |public func sumNonVirtual(_ values: UnsafeBufferPointer<CInt>) -> CInt {|}}
+  //   expected-remark@4{{macro content: |    let len = CInt(exactly: values.count)!|}}
+  //   expected-remark@5{{macro content: |    return unsafe sumNonVirtual(values.baseAddress, len)|}}
+  //   expected-remark@6{{macro content: |}|}}
+  // }}
+  int sumNonVirtual(const int * __counted_by(len) values, int len) const;
+
+  // expected-expansion@+8:71{{
+  //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+  //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload|}}
+  //   expected-remark@3{{macro content: |public func sumVirtual(_ values: UnsafeBufferPointer<CInt>) -> CInt {|}}
+  //   expected-remark@4{{macro content: |    let len = CInt(exactly: values.count)!|}}
+  //   expected-remark@5{{macro content: |    return unsafe sumVirtual(values.baseAddress, len)|}}
+  //   expected-remark@6{{macro content: |}|}}
+  // }}
+  virtual int sumVirtual(const int * __counted_by(len) values, int len) const;
+};
+
+struct SWIFT_REFERENCE RefType {
+  // expected-expansion@+8:66{{
+  //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+  //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload|}}
+  //   expected-remark@3{{macro content: |public final func sumNonVirtual(_ values: UnsafeBufferPointer<CInt>) -> CInt {|}}
+  //   expected-remark@4{{macro content: |    let len = CInt(exactly: values.count)!|}}
+  //   expected-remark@5{{macro content: |    return unsafe sumNonVirtual(values.baseAddress, len)|}}
+  //   expected-remark@6{{macro content: |}|}}
+  // }}
+  int sumNonVirtual(const int * __counted_by(len) values, int len) const;
+
+  // A virtual method on a reference type does NOT get a safe wrapper yet.
+  virtual int sumVirtual(const int * __counted_by(len) values, int len) const;
+};
+
+//--- module.modulemap
+module Test {
+  header "test.h"
+  requires cplusplus
+}
+
+//--- test.swift
+import Test
+
+func useValueType(_ v: ValueType, _ p: UnsafePointer<CInt>!) {
+  _ = v.sumNonVirtual(p, 1)
+  _ = v.sumVirtual(p, 1)
+}
+
+@available(macOS 13.3, *)
+func useRefType(_ r: RefType, _ p: UnsafePointer<CInt>!) {
+  _ = r.sumNonVirtual(p, 1)
+  _ = r.sumVirtual(p, 1)
+}

--- a/test/Interop/Cxx/swiftify-import/runtime.swift
+++ b/test/Interop/Cxx/swiftify-import/runtime.swift
@@ -452,52 +452,12 @@ let values: [CInt] = [1, 2, 3]
 
 #if NOT_YET_SUPPORTED
 // If any of these stop being an error, upgrade it to a proper runtime test case.
-extension Cube {
-  func callKindDirectViaSuper(_ values: Span<CInt>) -> Impl {
-    // FIXME: super.foo() calls to safe wrappers not supported
-    // expected-error@+1 {{ambiguous use of 'callKindDirect'}}
-    super.callKindDirect(values)
-  }
-}
-
-Suite.test("super. reaches a virtual base class implementation") {
-  // Prism::callKindDirect returns its own kind, so reaching it non-virtually
-  // through super. must not run Cube's override.
-  expectEqual(.prismKind, Cube.create().callKindDirectViaSuper(values.span))
-}
-
 Suite.test("hidden wrapper is ambiguous") {
   // FIXME: Cube's own wrapper and the one it inherits from Prism are both
   // visible, so the call cannot be resolved.
   // expected-error@+2 {{ambiguous use of 'derivedCallKindIndirect'}}
   expectEqual(.cubeHiddenKind,
               Cube.create().derivedCallKindIndirect(values.span))
-}
-
-Suite.test("ambiguous wrapper: virtual method of a reference type") {
-  // FIXME: the wrapper generated for Shape::callKindDirect and the one generated
-  // for this class's override are both visible and are not related by
-  // overriding, so neither wins. Macro-expanded peers never get an OverrideAttr,
-  // which is what lets the underlying methods resolve.
-  // Every ...Direct call below is blocked on this.
-  // expected-error@+1 {{ambiguous use of 'callKindDirect'}}
-  expectEqual(.slabKind, Slab.create().callKindDirect(values.span))
-}
-
-Suite.test("ambiguous wrapper: virtual method inherited two levels down") {
-  // expected-error@+1 {{ambiguous use of 'callKindDirect'}}
-  expectEqual(.cubeKind, Cube.create().callKindDirect(values.span))
-}
-
-Suite.test("ambiguous wrapper: virtual method with multiple inheritance") {
-  // expected-error@+1 {{ambiguous use of 'callKindDirect'}}
-  expectEqual(.multiKind, MultiDerived.create().callKindDirect(values.span))
-}
-
-Suite.test("ambiguous wrapper: virtual method of a class template") {
-  // expected-error@+2 {{ambiguous use of 'callKindDirect'}}
-  expectEqual(.templatedDerivedKind,
-              TemplatedDerivedInt.create().callKindDirect(values.span))
 }
 
 Suite.test("cloned wrapper: base that is not the primary base") {
@@ -552,6 +512,9 @@ extension Cube {
   func callKindIndirectViaSuper(_ values: Span<CInt>) -> Impl {
     super.callKindIndirect(values)
   }
+  func callKindDirectViaSuper(_ values: Span<CInt>) -> Impl {
+    super.callKindDirect(values)
+  }
   func derivedCallKindIndirectViaSuper(_ values: Span<CInt>) -> Impl {
     super.derivedCallKindIndirect(values)
   }
@@ -564,6 +527,12 @@ Suite.test("super. reaches the base class implementation of a wrapper") {
   // Cube hides Prism's member of the same name, and super. is currently the only
   // way to call the hidden wrapper: see the ambiguity in the guarded test below.
   expectEqual(.cubeKind, Cube.create().derivedCallKindIndirectViaSuper(values.span))
+
+  // FIXME: super.foo() cannot reach the base class implementation of a wrapped
+  // virtual method. The wrapper is not itself virtual, so super. only selects
+  // the base class wrapper, whose body still calls the virtual method and lands
+  // back in Cube's override. Prism::callKindDirect is unreachable from Swift.
+  expectEqual(.cubeKind, Cube.create().callKindDirectViaSuper(values.span))
 }
 
 Suite.test("multiple inheritance") {
@@ -594,18 +563,20 @@ Suite.test("curiously recurring template pattern") {
 }
 
 Suite.test("wrapper on a virtual method of a reference type") {
-  // These are the hierarchies where only one wrapper for the virtual method is
-  // visible at the call site, so the call resolves. Where the base class and the
-  // override each contribute one, it does not: see the guarded tests below.
-  //
+  // An override does not get a wrapper of its own when it inherits one, so there
+  // is a single wrapper per hierarchy and it dispatches to the override.
+  expectEqual(.slabKind, Slab.create().callKindDirect(values.span))
+  expectEqual(.cubeKind, Cube.create().callKindDirect(values.span))
+  expectEqual(.multiKind, MultiDerived.create().callKindDirect(values.span))
+  expectEqual(.templatedDerivedKind,
+              TemplatedDerivedInt.create().callKindDirect(values.span))
+
   // CRTPBase is a value type, so its wrapper is cloned rather than inherited and
-  // CRTPConcrete's override is the only candidate.
+  // CRTPConcrete's override keeps one of its own.
   expectEqual(.crtpKind, CRTPConcrete.create().baseCallKindDirect(values.span))
-  // Called on the base class itself, which only has its own wrapper. The dynamic
-  // type is still CRTPRefConcrete, so its override runs.
+  // Called on the base class, whose wrapper dispatches to the override.
   expectEqual(.crtpRefKind, makeCRTPRefBase()!.baseCallKindDirect(values.span))
-  // ValueBase is a value type, so again only RefDerived's override is a
-  // candidate.
+  // ValueBase is a value type, so again RefDerived's override keeps its own.
   expectEqual(.refDerivedKind, RefDerived.create().callKindDirect(values.span))
 }
 

--- a/test/Interop/Cxx/swiftify-import/runtime.swift
+++ b/test/Interop/Cxx/swiftify-import/runtime.swift
@@ -1,0 +1,646 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+// REQUIRES: std_span
+// REQUIRES: executable_test
+
+// UNSUPPORTED: back_deployment_runtime || use_os_stdlib
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
+
+// RUN: %target-run-simple-swift-split-file(test.swift -I %t%{fs-sep}Inputs -target %target-swift-6.2-abi-triple \
+// RUN:   -cxx-interoperability-mode=default -Xcc -std=c++20 -enable-experimental-feature SafeInteropWrappers)
+
+// Signal if unsupported functions start compiling to remind the author of creating a runtime test case.
+// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t%{fs-sep}Inputs \
+// RUN:   -target %target-swift-6.2-abi-triple -cxx-interoperability-mode=default -Xcc -std=c++20 \
+// RUN:   -enable-experimental-feature SafeInteropWrappers -D NOT_YET_SUPPORTED -verify \
+// RUN:   -suppress-notes %t/test.swift
+
+// This is the C++ counterpart of test/Interop/C/swiftify-import/runtime.swift.
+// The C test covers the shapes a safe wrapper can take: counts, sizes, spans,
+// out parameters, nullability and the bounds checks. This test deliberately
+// sticks to one wrapped signature,
+//
+//   Impl callKind(std::span<const int> values) const
+//
+// and varies the C++ concepts involved instead: virtual
+// dispatch, single and multiple inheritance, virtual (diamond) bases, reference
+// types deriving from value types, class templates, chained calls returning
+// `this`, non-const `this`, static member functions and constructors.
+//
+// Every function definition in the header returns its own value of the Impl
+// enum, and functions that only forward to another function return whatever that
+// one returned. Each test then names the implementation it expects to have run.
+// Wrong data and a wrong `this` are reported as named values as well, so a
+// failure says what went wrong rather than printing an unexpected number.
+//
+// Wrapped members come in two virtual function flavors:
+//
+//   - ...Indirect is implemented once in the base class and reaches the concrete
+//     class only by calling the virtual kind().
+//   - ...Direct is itself virtual, so each class has its own override returning
+//     its own kind.
+//
+// At the moment only value types get wrappers for the Direct flavor, so the
+// calls to a reference type's Direct members are commented out for now.
+
+//--- Inputs/module.modulemap
+module Test {
+  header "header.h"
+  requires cplusplus
+  export std.span
+}
+
+//--- Inputs/header.h
+#include <span>
+
+#define FRT_IMMORTAL                                                           \
+  __attribute__((swift_attr("import_reference")))                              \
+  __attribute__((swift_attr("retain:immortal")))                               \
+  __attribute__((swift_attr("release:immortal")))
+
+using IntSpan = std::span<const int>;
+
+enum class Impl {
+  // Reported instead of the implementation's own value when a wrapper called
+  // the right implementation with the wrong data or the wrong `this`.
+  unexpectedValues,
+  unexpectedSelf,
+  // What the recorded field below holds before C++ writes to it.
+  unwritten,
+
+  shapeStaticKind,
+  slabKind,
+  prismKind,
+  prismSelf,
+  cubeKind,
+  cubeHiddenKind,
+
+  multiKind,
+  secondMarker,
+  diamondKind,
+
+  templatedKind,
+  templatedDerivedKind,
+  crtpKind,
+  crtpSelf,
+  crtpBaseKind,
+  crtpRefKind,
+  crtpRefSelf,
+  crtpRefBaseKind,
+
+  valueBaseKind,
+  valueDerivedKind,
+  refDerivedKind,
+
+  spanConstructed,
+};
+
+inline bool areOneTwoThree(IntSpan values) {
+  return values.size() == 3 && values[0] == 1 && values[1] == 2 &&
+         values[2] == 3;
+}
+
+// An abstract foreign reference type. callKindIndirect is not virtual, but it
+// dispatches virtually internally.
+struct FRT_IMMORTAL Shape {
+  virtual Impl kind() const = 0;
+  virtual ~Shape() = default;
+
+  Impl callKindIndirect(IntSpan values [[clang::noescape]]) const {
+    if (!areOneTwoThree(values))
+      return Impl::unexpectedValues;
+    return kind();
+  }
+  virtual Impl callKindDirect(IntSpan values [[clang::noescape]]) const = 0;
+
+  // Non-const `this`: Swift reads the result back out of the recorded field.
+  void recordKindIndirect(IntSpan values [[clang::noescape]]) {
+    recorded = areOneTwoThree(values) ? kind() : Impl::unexpectedValues;
+  }
+
+  // Returns `this`, so that Swift can chain a second wrapped call onto the
+  // result of the first.
+  Shape *chainIndirect(IntSpan values [[clang::noescape]]) {
+    recordKindIndirect(values);
+    return this;
+  }
+
+  static Impl staticKind(IntSpan values [[clang::noescape]]) {
+    if (!areOneTwoThree(values))
+      return Impl::unexpectedValues;
+    return Impl::shapeStaticKind;
+  }
+
+  Impl recorded = Impl::unwritten;
+};
+
+struct Slab : Shape {
+  Impl kind() const override { return Impl::slabKind; }
+  Impl callKindDirect(IntSpan values [[clang::noescape]]) const override {
+    if (!areOneTwoThree(values))
+      return Impl::unexpectedValues;
+    return Impl::slabKind;
+  }
+  static Slab &create() {
+    static Slab instance;
+    return instance;
+  }
+};
+
+// A derived class that declares a wrapped method of its own and has a field of its own.
+struct Prism : Shape {
+  Impl kind() const override { return Impl::prismKind; }
+  Impl callKindDirect(IntSpan values [[clang::noescape]]) const override {
+    if (!areOneTwoThree(values))
+      return Impl::unexpectedValues;
+    return Impl::prismKind;
+  }
+
+  // Reading a field that only exists in the derived class, so a wrapper that
+  // passed the wrong `this` reports unexpectedSelf.
+  Impl derivedCallKindIndirect(IntSpan values [[clang::noescape]]) const {
+    if (selfMarker != Impl::prismSelf)
+      return Impl::unexpectedSelf;
+    return callKindIndirect(values);
+  }
+
+  static Prism &create() {
+    static Prism instance;
+    return instance;
+  }
+  Impl selfMarker = Impl::prismSelf;
+};
+
+// An intermediate class that overrides nothing, so that Cube below inherits
+// wrappers across two levels of the hierarchy.
+struct Passthrough : Prism {};
+
+struct Cube final : Passthrough {
+  Impl kind() const override { return Impl::cubeKind; }
+
+  // Hides Prism::derivedCallKindIndirect rather than overriding it, since
+  // neither is virtual. Swift's super.foo() syntax is what reaches the hidden one.
+  Impl derivedCallKindIndirect(IntSpan values [[clang::noescape]]) const {
+    if (!areOneTwoThree(values))
+      return Impl::unexpectedValues;
+    return Impl::cubeHiddenKind;
+  }
+  Impl callKindDirect(IntSpan values [[clang::noescape]]) const override {
+    if (!areOneTwoThree(values))
+      return Impl::unexpectedValues;
+    return Impl::cubeKind;
+  }
+  static Cube &create() {
+    static Cube instance;
+    return instance;
+  }
+};
+
+__attribute__((swift_name("makeShape(cube:)")))
+inline Shape *makeShape(bool cube) {
+  if (cube)
+    return &Cube::create();
+  return &Slab::create();
+}
+
+// A second base class, contributing a field and a wrapped method of its own.
+// Shape is the primary base, so Swift makes Shape the Swift superclass of
+// MultiDerived and clones Second's members into it.
+struct Second {
+  Impl secondCallKindIndirect(IntSpan values [[clang::noescape]]) const {
+    if (!areOneTwoThree(values))
+      return Impl::unexpectedValues;
+    return marker;
+  }
+  Impl marker = Impl::secondMarker;
+};
+
+struct MultiDerived : Shape, Second {
+  // Reaching Second's field requires `this` to be adjusted, so an override
+  // called with an unadjusted `this` reports unexpectedSelf.
+  Impl kind() const override {
+    return marker == Impl::secondMarker ? Impl::multiKind : Impl::unexpectedSelf;
+  }
+  Impl callKindDirect(IntSpan values [[clang::noescape]]) const override {
+    if (!areOneTwoThree(values))
+      return Impl::unexpectedValues;
+    return kind();
+  }
+  static MultiDerived &create() {
+    static MultiDerived instance;
+    return instance;
+  }
+};
+
+// The diamond pattern: Diamond has one shared VirtualBase subobject, reached
+// through a vbase offset rather than at a fixed offset from `this`.
+struct FRT_IMMORTAL VirtualBase {
+  virtual Impl kind() const = 0;
+  virtual ~VirtualBase() = default;
+
+  Impl callKindIndirect(IntSpan values [[clang::noescape]]) const {
+    if (!areOneTwoThree(values))
+      return Impl::unexpectedValues;
+    return kind();
+  }
+};
+
+struct Left : virtual VirtualBase {};
+struct Right : virtual VirtualBase {};
+
+struct Diamond : Left, Right {
+  Impl kind() const override { return Impl::diamondKind; }
+  static Diamond &create() {
+    static Diamond instance;
+    return instance;
+  }
+};
+
+// A class template. Its own members do not get wrappers, but a wrapper it
+// inherits from a non-template reference type does.
+template <class T>
+struct FRT_IMMORTAL Templated {
+  virtual Impl kind() const { return Impl::templatedKind; }
+  virtual ~Templated() = default;
+
+  Impl callKindIndirect(std::span<const T> values [[clang::noescape]]) const {
+    if (!areOneTwoThree(values))
+      return Impl::unexpectedValues;
+    return kind();
+  }
+
+  static Templated<T> &create() {
+    static Templated<T> instance;
+    return instance;
+  }
+};
+using TemplatedInt = Templated<int>;
+
+template <class T>
+struct TemplatedDerived : Shape {
+  Impl kind() const override { return Impl::templatedDerivedKind; }
+  Impl callKindDirect(IntSpan values [[clang::noescape]]) const override {
+    if (!areOneTwoThree(values))
+      return Impl::unexpectedValues;
+    return Impl::templatedDerivedKind;
+  }
+  static TemplatedDerived<T> &create() {
+    static TemplatedDerived<T> instance;
+    return instance;
+  }
+};
+using TemplatedDerivedInt = TemplatedDerived<int>;
+
+// The curiously recurring template pattern: CRTPBase resolves the call to the
+// derived class at compile time instead of through a vtable.
+template <class Derived>
+struct CRTPBase {
+  Impl dispatchKind() const {
+    return static_cast<const Derived *>(this)->kind();
+  }
+
+  // A wrapped member of the template itself, for contrast with the one
+  // CRTPConcrete declares below.
+  Impl baseCallKindIndirect(IntSpan values [[clang::noescape]]) const {
+    if (!areOneTwoThree(values))
+      return Impl::unexpectedValues;
+    return dispatchKind();
+  }
+
+  // A CRTP base has no reason to declare virtual functions , but nothing stops it from
+  // doing so, and the Direct flavor is what a class template's virtual member
+  // looks like.
+  virtual Impl baseCallKindDirect(IntSpan values [[clang::noescape]]) const {
+    if (!areOneTwoThree(values))
+      return Impl::unexpectedValues;
+    return Impl::crtpBaseKind;
+  }
+  virtual ~CRTPBase() = default;
+};
+
+struct FRT_IMMORTAL CRTPConcrete : CRTPBase<CRTPConcrete> {
+  // Not virtual: the static_cast in CRTPBase is what finds this, and it reads a
+  // field of its own, so a wrapper that passed the wrong `this` reports
+  // unexpectedSelf rather than the wrong kind.
+  Impl kind() const {
+    return selfMarker == Impl::crtpSelf ? Impl::crtpKind : Impl::unexpectedSelf;
+  }
+
+  Impl callKindIndirect(IntSpan values [[clang::noescape]]) const {
+    if (!areOneTwoThree(values))
+      return Impl::unexpectedValues;
+    return dispatchKind();
+  }
+  Impl baseCallKindDirect(IntSpan values [[clang::noescape]]) const override {
+    if (!areOneTwoThree(values))
+      return Impl::unexpectedValues;
+    return kind();
+  }
+
+  static CRTPConcrete &create() {
+    static CRTPConcrete instance;
+    return instance;
+  }
+  Impl selfMarker = Impl::crtpSelf;
+};
+
+// The same pattern with the CRTP base a reference type as well. Note that
+// CRTPRefConcrete inherits its reference semantics rather than repeating the
+// annotation: a class that annotates itself is imported as an independent class
+// with no Swift superclass, which is what puts CRTPConcrete above and RefDerived
+// below in the cloned-wrapper cases.
+template <class Derived>
+struct FRT_IMMORTAL CRTPRefBase {
+  Impl dispatchKind() const {
+    return static_cast<const Derived *>(this)->kind();
+  }
+
+  Impl baseCallKindIndirect(IntSpan values [[clang::noescape]]) const {
+    if (!areOneTwoThree(values))
+      return Impl::unexpectedValues;
+    return dispatchKind();
+  }
+  virtual Impl baseCallKindDirect(IntSpan values [[clang::noescape]]) const {
+    if (!areOneTwoThree(values))
+      return Impl::unexpectedValues;
+    return Impl::crtpRefBaseKind;
+  }
+  virtual ~CRTPRefBase() = default;
+};
+
+struct CRTPRefConcrete : CRTPRefBase<CRTPRefConcrete> {
+  Impl kind() const {
+    return selfMarker == Impl::crtpRefSelf ? Impl::crtpRefKind
+                                           : Impl::unexpectedSelf;
+  }
+  Impl baseCallKindDirect(IntSpan values [[clang::noescape]]) const override {
+    if (!areOneTwoThree(values))
+      return Impl::unexpectedValues;
+    return kind();
+  }
+
+  static CRTPRefConcrete &create() {
+    static CRTPRefConcrete instance;
+    return instance;
+  }
+  Impl selfMarker = Impl::crtpRefSelf;
+};
+
+using CRTPRefBaseOfConcrete = CRTPRefBase<CRTPRefConcrete>;
+
+inline CRTPRefBaseOfConcrete *makeCRTPRefBase() {
+  return &CRTPRefConcrete::create();
+}
+
+// A value type is polymorphic in C++ but not in Swift. Unlike a reference type
+// it does get a wrapper for its virtual methods.
+struct ValueBase {
+  virtual Impl kind() const { return Impl::valueBaseKind; }
+  virtual ~ValueBase() = default;
+
+  Impl callKindIndirect(IntSpan values [[clang::noescape]]) const {
+    if (!areOneTwoThree(values))
+      return Impl::unexpectedValues;
+    return kind();
+  }
+  virtual Impl callKindDirect(IntSpan values [[clang::noescape]]) const {
+    if (!areOneTwoThree(values))
+      return Impl::unexpectedValues;
+    return Impl::valueBaseKind;
+  }
+};
+
+struct ValueDerived : ValueBase {
+  Impl kind() const override { return Impl::valueDerivedKind; }
+  Impl callKindDirect(IntSpan values [[clang::noescape]]) const override {
+    if (!areOneTwoThree(values))
+      return Impl::unexpectedValues;
+    return Impl::valueDerivedKind;
+  }
+};
+
+// Only the derived class is annotated as a reference type, so the wrapper in the
+// value type base is cloned into a Swift class rather than inherited.
+struct FRT_IMMORTAL RefDerived : ValueBase {
+  Impl kind() const override { return Impl::refDerivedKind; }
+  Impl callKindDirect(IntSpan values [[clang::noescape]]) const override {
+    if (!areOneTwoThree(values))
+      return Impl::unexpectedValues;
+    return Impl::refDerivedKind;
+  }
+  static RefDerived &create() {
+    static RefDerived instance;
+    return instance;
+  }
+};
+
+struct SpanConstructed {
+  SpanConstructed(IntSpan values [[clang::noescape]])
+      : kind(areOneTwoThree(values) ? Impl::spanConstructed
+                                    : Impl::unexpectedValues) {}
+  Impl kind;
+};
+
+//--- test.swift
+import StdlibUnittest
+import Test
+
+var Suite = TestSuite("C++ safe interop wrappers")
+
+let values: [CInt] = [1, 2, 3]
+
+// MARK: - Reference type hierarchies
+
+#if NOT_YET_SUPPORTED
+// If any of these stop being an error, upgrade it to a proper runtime test case.
+extension Cube {
+  func callKindDirectViaSuper(_ values: Span<CInt>) -> Impl {
+    // FIXME: super.foo() calls to safe wrappers not supported
+    // expected-error@+1 {{cannot convert value of type 'Span<CInt>' (aka 'Span<Int32>') to expected argument type 'IntSpan'}}
+    super.callKindDirect(values)
+  }
+}
+
+Suite.test("super. reaches a virtual base class implementation") {
+  // Prism::callKindDirect returns its own kind, so reaching it non-virtually
+  // through super. must not run Cube's override.
+  expectEqual(.prismKind, Cube.create().callKindDirectViaSuper(values.span))
+}
+
+Suite.test("hidden wrapper is ambiguous") {
+  // FIXME: Cube's own wrapper and the one it inherits from Prism are both
+  // visible, so the call cannot be resolved.
+  // expected-error@+2 {{ambiguous use of 'derivedCallKindIndirect'}}
+  expectEqual(.cubeHiddenKind,
+              Cube.create().derivedCallKindIndirect(values.span))
+}
+
+Suite.test("no wrapper: virtual method of a reference type") {
+  // FIXME: a virtual method of a reference type gets no
+  // wrapper. Every ...Direct member below is blocked on this one bug.
+  // expected-error@+1 {{cannot convert value of type 'Span<CInt>' (aka 'Span<Int32>') to expected argument type 'IntSpan'}}
+  expectEqual(.slabKind, Slab.create().callKindDirect(values.span))
+}
+
+Suite.test("no wrapper: virtual method inherited two levels down") {
+  // expected-error@+1 {{cannot convert value of type 'Span<CInt>' (aka 'Span<Int32>') to expected argument type 'IntSpan'}}
+  expectEqual(.cubeKind, Cube.create().callKindDirect(values.span))
+}
+
+Suite.test("no wrapper: virtual method with multiple inheritance") {
+  // expected-error@+1 {{cannot convert value of type 'Span<CInt>' (aka 'Span<Int32>') to expected argument type 'IntSpan'}}
+  expectEqual(.multiKind, MultiDerived.create().callKindDirect(values.span))
+}
+
+Suite.test("no wrapper: virtual method of a class template") {
+  // expected-error@+2 {{cannot convert value of type 'Span<CInt>' (aka 'Span<Int32>') to expected argument type 'IntSpan'}}
+  expectEqual(.templatedDerivedKind,
+              TemplatedDerivedInt.create().callKindDirect(values.span))
+}
+
+Suite.test("no wrapper: virtual method of a CRTP base") {
+  // expected-error@+1 {{cannot convert value of type 'Span<CInt>' (aka 'Span<Int32>') to expected argument type 'IntSpan'}}
+  expectEqual(.crtpKind, CRTPConcrete.create().baseCallKindDirect(values.span))
+}
+
+Suite.test("no wrapper: virtual method of a reference type CRTP base") {
+  // expected-error@+1 {{cannot convert value of type 'Span<CInt>' (aka 'Span<Int32>') to expected argument type 'IntSpan'}}
+  expectEqual(.crtpRefKind, makeCRTPRefBase()!.baseCallKindDirect(values.span))
+}
+
+Suite.test("no wrapper: virtual method overridden by a reference type") {
+  // expected-error@+1 {{cannot convert value of type 'Span<CInt>' (aka 'Span<Int32>') to expected argument type 'IntSpan'}}
+  expectEqual(.refDerivedKind, RefDerived.create().callKindDirect(values.span))
+}
+
+Suite.test("cloned wrapper: base that is not the primary base") {
+  // Second is not the primary base, so Shape becomes the Swift superclass and Second's members are
+  // cloned into MultiDerived, but safe wrappers are not cloned.
+  // expected-error@+2 {{cannot convert value of type 'Span<CInt>' (aka 'Span<Int32>') to expected argument type 'IntSpan'}}
+  expectEqual(.secondMarker,
+              MultiDerived.create().secondCallKindIndirect(values.span))
+}
+
+Suite.test("cloned wrapper: virtual base") {
+  // A virtual base is never imported as the superclass, so Diamond has no superclass at all and clones everything.
+  // expected-error@+1 {{cannot convert value of type 'Span<CInt>' (aka 'Span<Int32>') to expected argument type 'IntSpan'}}
+  expectEqual(.diamondKind, Diamond.create().callKindIndirect(values.span))
+}
+
+Suite.test("cloned wrapper: value type base of a reference type") {
+  // A Swift class cannot inherit from a struct.
+  // expected-error@+1 {{cannot convert value of type 'Span<CInt>' (aka 'Span<Int32>') to expected argument type 'IntSpan'}}
+  expectEqual(.refDerivedKind, RefDerived.create().callKindIndirect(values.span))
+}
+
+Suite.test("cloned wrapper: value type derived class") {
+  // Swift structs have no inheritance at all, so a value type derived class clones every base member.
+  // FIXME: emit safe wrappers for cloned functions.
+  // expected-error@+1 {{cannot convert value of type 'Span<CInt>' (aka 'Span<Int32>') to expected argument type 'IntSpan'}}
+  expectEqual(.valueDerivedKind, ValueDerived().callKindIndirect(values.span))
+}
+
+Suite.test("cloned wrapper: CRTP base") {
+  // The CRTP base is a value type too, so even though the wrapper is inferred for CRTPBase<CRTPConcrete>,
+  // CRTPConcrete doesn't inherit the safe wrapper.
+  // expected-error@+2 {{cannot convert value of type 'Span<CInt>' (aka 'Span<Int32>') to expected argument type 'IntSpan'}}
+  expectEqual(.crtpKind,
+              CRTPConcrete.create().baseCallKindIndirect(values.span))
+}
+#endif
+
+Suite.test("virtual dispatch through a wrapper on the base class") {
+  expectEqual(.slabKind, Slab.create().callKindIndirect(values.span))
+  // Cube inherits the wrapper across two levels of the hierarchy.
+  expectEqual(.cubeKind, Cube.create().callKindIndirect(values.span))
+  // Reached through a base class reference, so Swift cannot see the dynamic type.
+  expectEqual(.cubeKind, makeShape(cube: true)!.callKindIndirect(values.span))
+}
+
+Suite.test("wrapper declared on a derived class") {
+  expectEqual(.prismKind, Prism.create().derivedCallKindIndirect(values.span))
+}
+
+extension Cube {
+  func callKindIndirectViaSuper(_ values: Span<CInt>) -> Impl {
+    super.callKindIndirect(values)
+  }
+  func derivedCallKindIndirectViaSuper(_ values: Span<CInt>) -> Impl {
+    super.derivedCallKindIndirect(values)
+  }
+}
+
+Suite.test("super. reaches the base class implementation of a wrapper") {
+  // Calling Shape's wrapper non-virtually still dispatches virtually inside it,
+  // so the kind is Cube's.
+  expectEqual(.cubeKind, Cube.create().callKindIndirectViaSuper(values.span))
+  // Cube hides Prism's member of the same name, and super. is currently the only
+  // way to call the hidden wrapper: see the ambiguity in the guarded test below.
+  expectEqual(.cubeKind, Cube.create().derivedCallKindIndirectViaSuper(values.span))
+}
+
+Suite.test("multiple inheritance") {
+  // MultiDerived::kind() reads a field of its second base class, so it reports
+  // unexpectedSelf if the wrapper passed a `this` that was not adjusted back to
+  // the most derived object.
+  expectEqual(.multiKind, MultiDerived.create().callKindIndirect(values.span))
+}
+
+Suite.test("member of a class template") {
+  expectEqual(.templatedKind, TemplatedInt.create().callKindIndirect(values.span))
+}
+
+Suite.test("class template deriving from a reference type") {
+  expectEqual(.templatedDerivedKind,
+              TemplatedDerivedInt.create().callKindIndirect(values.span))
+}
+
+Suite.test("curiously recurring template pattern") {
+  // The wrapper is declared on the concrete class, and its body reaches the
+  // concrete class again through CRTPBase's static_cast.
+  expectEqual(.crtpKind, CRTPConcrete.create().callKindIndirect(values.span))
+
+  // With the CRTP base a reference type too, the base's own wrapper is callable
+  // on a derived object handed back as the base. Its static_cast back down to
+  // CRTPRefConcrete finds the right object.
+  expectEqual(.crtpRefKind, makeCRTPRefBase()!.baseCallKindIndirect(values.span))
+}
+
+Suite.test("non-const this") {
+  let cube = Cube.create()
+  cube.recorded = .unwritten
+  cube.recordKindIndirect(values.span)
+  expectEqual(.cubeKind, cube.recorded)
+}
+
+Suite.test("chained calls through a returned this") {
+  let cube = Cube.create()
+  cube.recorded = .unwritten
+  expectEqual(.cubeKind, cube.chainIndirect(values.span)!.callKindIndirect(values.span))
+  // chainIndirect records the kind through `this->recorded`.
+  expectEqual(.cubeKind, cube.recorded)
+}
+
+Suite.test("static member function") {
+  expectEqual(.shapeStaticKind, Shape.staticKind(values.span))
+}
+
+// MARK: - Value types
+
+Suite.test("virtual dispatch through a wrapper on a value type") {
+  expectEqual(.valueBaseKind, ValueBase().callKindIndirect(values.span))
+}
+
+Suite.test("wrapper on a virtual method of a value type") {
+  // Unlike a reference type, a value type does get wrappers for the Direct
+  // flavor, both for the base implementation and for the override.
+  expectEqual(.valueBaseKind, ValueBase().callKindDirect(values.span))
+  expectEqual(.valueDerivedKind, ValueDerived().callKindDirect(values.span))
+}
+
+// MARK: - Constructors
+
+Suite.test("constructor") {
+  expectEqual(.spanConstructed, SpanConstructed(values.span).kind)
+}
+
+runAllTests()

--- a/test/Interop/Cxx/swiftify-import/runtime.swift
+++ b/test/Interop/Cxx/swiftify-import/runtime.swift
@@ -3,7 +3,6 @@
 // REQUIRES: executable_test
 
 // UNSUPPORTED: back_deployment_runtime || use_os_stdlib
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 // RUN: %target-run-simple-swift-split-file(test.swift -I %t%{fs-sep}Inputs -target %target-swift-6.2-abi-triple \
 // RUN:   -cxx-interoperability-mode=default -Xcc -std=c++20 -enable-experimental-feature SafeInteropWrappers)

--- a/test/Interop/Cxx/swiftify-import/runtime.swift
+++ b/test/Interop/Cxx/swiftify-import/runtime.swift
@@ -455,7 +455,7 @@ let values: [CInt] = [1, 2, 3]
 extension Cube {
   func callKindDirectViaSuper(_ values: Span<CInt>) -> Impl {
     // FIXME: super.foo() calls to safe wrappers not supported
-    // expected-error@+1 {{cannot convert value of type 'Span<CInt>' (aka 'Span<Int32>') to expected argument type 'IntSpan'}}
+    // expected-error@+1 {{ambiguous use of 'callKindDirect'}}
     super.callKindDirect(values)
   }
 }
@@ -474,42 +474,30 @@ Suite.test("hidden wrapper is ambiguous") {
               Cube.create().derivedCallKindIndirect(values.span))
 }
 
-Suite.test("no wrapper: virtual method of a reference type") {
-  // FIXME: a virtual method of a reference type gets no
-  // wrapper. Every ...Direct member below is blocked on this one bug.
-  // expected-error@+1 {{cannot convert value of type 'Span<CInt>' (aka 'Span<Int32>') to expected argument type 'IntSpan'}}
+Suite.test("ambiguous wrapper: virtual method of a reference type") {
+  // FIXME: the wrapper generated for Shape::callKindDirect and the one generated
+  // for this class's override are both visible and are not related by
+  // overriding, so neither wins. Macro-expanded peers never get an OverrideAttr,
+  // which is what lets the underlying methods resolve.
+  // Every ...Direct call below is blocked on this.
+  // expected-error@+1 {{ambiguous use of 'callKindDirect'}}
   expectEqual(.slabKind, Slab.create().callKindDirect(values.span))
 }
 
-Suite.test("no wrapper: virtual method inherited two levels down") {
-  // expected-error@+1 {{cannot convert value of type 'Span<CInt>' (aka 'Span<Int32>') to expected argument type 'IntSpan'}}
+Suite.test("ambiguous wrapper: virtual method inherited two levels down") {
+  // expected-error@+1 {{ambiguous use of 'callKindDirect'}}
   expectEqual(.cubeKind, Cube.create().callKindDirect(values.span))
 }
 
-Suite.test("no wrapper: virtual method with multiple inheritance") {
-  // expected-error@+1 {{cannot convert value of type 'Span<CInt>' (aka 'Span<Int32>') to expected argument type 'IntSpan'}}
+Suite.test("ambiguous wrapper: virtual method with multiple inheritance") {
+  // expected-error@+1 {{ambiguous use of 'callKindDirect'}}
   expectEqual(.multiKind, MultiDerived.create().callKindDirect(values.span))
 }
 
-Suite.test("no wrapper: virtual method of a class template") {
-  // expected-error@+2 {{cannot convert value of type 'Span<CInt>' (aka 'Span<Int32>') to expected argument type 'IntSpan'}}
+Suite.test("ambiguous wrapper: virtual method of a class template") {
+  // expected-error@+2 {{ambiguous use of 'callKindDirect'}}
   expectEqual(.templatedDerivedKind,
               TemplatedDerivedInt.create().callKindDirect(values.span))
-}
-
-Suite.test("no wrapper: virtual method of a CRTP base") {
-  // expected-error@+1 {{cannot convert value of type 'Span<CInt>' (aka 'Span<Int32>') to expected argument type 'IntSpan'}}
-  expectEqual(.crtpKind, CRTPConcrete.create().baseCallKindDirect(values.span))
-}
-
-Suite.test("no wrapper: virtual method of a reference type CRTP base") {
-  // expected-error@+1 {{cannot convert value of type 'Span<CInt>' (aka 'Span<Int32>') to expected argument type 'IntSpan'}}
-  expectEqual(.crtpRefKind, makeCRTPRefBase()!.baseCallKindDirect(values.span))
-}
-
-Suite.test("no wrapper: virtual method overridden by a reference type") {
-  // expected-error@+1 {{cannot convert value of type 'Span<CInt>' (aka 'Span<Int32>') to expected argument type 'IntSpan'}}
-  expectEqual(.refDerivedKind, RefDerived.create().callKindDirect(values.span))
 }
 
 Suite.test("cloned wrapper: base that is not the primary base") {
@@ -603,6 +591,22 @@ Suite.test("curiously recurring template pattern") {
   // on a derived object handed back as the base. Its static_cast back down to
   // CRTPRefConcrete finds the right object.
   expectEqual(.crtpRefKind, makeCRTPRefBase()!.baseCallKindIndirect(values.span))
+}
+
+Suite.test("wrapper on a virtual method of a reference type") {
+  // These are the hierarchies where only one wrapper for the virtual method is
+  // visible at the call site, so the call resolves. Where the base class and the
+  // override each contribute one, it does not: see the guarded tests below.
+  //
+  // CRTPBase is a value type, so its wrapper is cloned rather than inherited and
+  // CRTPConcrete's override is the only candidate.
+  expectEqual(.crtpKind, CRTPConcrete.create().baseCallKindDirect(values.span))
+  // Called on the base class itself, which only has its own wrapper. The dynamic
+  // type is still CRTPRefConcrete, so its override runs.
+  expectEqual(.crtpRefKind, makeCRTPRefBase()!.baseCallKindDirect(values.span))
+  // ValueBase is a value type, so again only RefDerived's override is a
+  // candidate.
+  expectEqual(.refDerivedKind, RefDerived.create().callKindDirect(values.span))
 }
 
 Suite.test("non-const this") {

--- a/test/Interop/Cxx/swiftify-import/runtime.swift
+++ b/test/Interop/Cxx/swiftify-import/runtime.swift
@@ -452,6 +452,31 @@ let values: [CInt] = [1, 2, 3]
 
 #if NOT_YET_SUPPORTED
 // If any of these stop being an error, upgrade it to a proper runtime test case.
+
+// FIXME: calling a wrapper through 'super' is rejected: only a wrapper for the
+// virtual dispatch thunk currently exists, so there is no static dispatch
+// version of the safe wrapper to remap the call to.
+extension Cube {
+  func callKindIndirectViaSuper(_ values: Span<CInt>) -> Impl {
+    // expected-error@+1 {{calling safe interop wrapper 'callKindIndirect' in foreign reference type 'Shape' using 'super' is not supported}}
+    super.callKindIndirect(values)
+  }
+}
+
+extension Cube {
+  func callKindDirectViaSuper(_ values: Span<CInt>) -> Impl {
+    // expected-error@+1 {{calling safe interop wrapper 'callKindDirect' in foreign reference type 'Shape' using 'super' is not supported}}
+    super.callKindDirect(values)
+  }
+}
+
+extension Cube {
+  func derivedCallKindIndirectViaSuper(_ values: Span<CInt>) -> Impl {
+    // expected-error@+1 {{calling safe interop wrapper 'derivedCallKindIndirect' in foreign reference type 'Prism' using 'super' is not supported}}
+    super.derivedCallKindIndirect(values)
+  }
+}
+
 Suite.test("hidden wrapper is ambiguous") {
   // FIXME: Cube's own wrapper and the one it inherits from Prism are both
   // visible, so the call cannot be resolved.
@@ -506,33 +531,6 @@ Suite.test("virtual dispatch through a wrapper on the base class") {
 
 Suite.test("wrapper declared on a derived class") {
   expectEqual(.prismKind, Prism.create().derivedCallKindIndirect(values.span))
-}
-
-extension Cube {
-  func callKindIndirectViaSuper(_ values: Span<CInt>) -> Impl {
-    super.callKindIndirect(values)
-  }
-  func callKindDirectViaSuper(_ values: Span<CInt>) -> Impl {
-    super.callKindDirect(values)
-  }
-  func derivedCallKindIndirectViaSuper(_ values: Span<CInt>) -> Impl {
-    super.derivedCallKindIndirect(values)
-  }
-}
-
-Suite.test("super. reaches the base class implementation of a wrapper") {
-  // Calling Shape's wrapper non-virtually still dispatches virtually inside it,
-  // so the kind is Cube's.
-  expectEqual(.cubeKind, Cube.create().callKindIndirectViaSuper(values.span))
-  // Cube hides Prism's member of the same name, and super. is currently the only
-  // way to call the hidden wrapper: see the ambiguity in the guarded test below.
-  expectEqual(.cubeKind, Cube.create().derivedCallKindIndirectViaSuper(values.span))
-
-  // FIXME: super.foo() cannot reach the base class implementation of a wrapped
-  // virtual method. The wrapper is not itself virtual, so super. only selects
-  // the base class wrapper, whose body still calls the virtual method and lands
-  // back in Cube's override. Prism::callKindDirect is unreachable from Swift.
-  expectEqual(.cubeKind, Cube.create().callKindDirectViaSuper(values.span))
 }
 
 Suite.test("multiple inheritance") {


### PR DESCRIPTION
A virtual C++ method of a foreign reference type is imported as a thunk that
performs the dynamic dispatch, and the original method is renamed to
prevent it from being picked up by name lookup. swiftify() ran before that
thunk existed, so the wrapper was attached to a declaration that Swift never
sees and no safe overload appeared for any virtual method of a reference type.

Swiftify the thunk instead: call swiftify() once the thunk has been created
and the mapping back to the original method has been recorded, so that
we can lookup the annotations on the original clang function.

The wrapper produced this way is `final` and forwards to the thunk, so calling
it effectively does dynamic dispatch even though the safe wrapper is not
virtual. To avoid name lookup clashes, derived types overriding the virtual
function don't get a safe wrapper. Calling the safe wrapper in the base class
gives the same result, with the caveat that they could differ in annotations,
but currently only the annotations on the base class decl are picked up.

We currently don't have a macro expansion for the static call version of the
function, so `super.foo()` still ends up calling the safe wrapper with the
dynamic dispatch, which is not what happens when you call the underlying
function with the same syntax. For now, emit an error when this occurs to
prevent surprising behaviour.

rdar://182530045