### PR TITLE
Sema: Include the `@` when highlighting an attribute in a diagnostic

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5851,7 +5851,7 @@ void AttributeChecker::checkBackDeployedAttrs(
         if (auto unavailableAttr = attrDecl->getUnavailableAttr()) {
           diagnose(unavailableAttr->getParsedAttr()->AtLoc,
                    diag::availability_marked_unavailable, VD)
-              .highlight(unavailableAttr->getParsedAttr()->getRange());
+              .highlight(unavailableAttr->getParsedAttr()->getRangeWithAt());
           break;
         }
 
@@ -5882,7 +5882,7 @@ void AttributeChecker::checkBackDeployedAttrs(
         diagnose(availableAttr.getParsedAttr()->AtLoc,
                  diag::availability_introduced_in_version, VD,
                  introDomainAndRange->getDomain(), introRange)
-            .highlight(availableAttr.getParsedAttr()->getRange());
+            .highlight(availableAttr.getParsedAttr()->getRangeWithAt());
         continue;
       }
     }
@@ -9107,9 +9107,9 @@ AttributeChecker::visitAddressableForDependenciesAttr(
 void AttributeChecker::visitUnsafeAttr(UnsafeAttr *attr) {
   if (auto safeAttr = D->getAttrs().getAttribute<SafeAttr>()) {
     D->diagnose(diag::safe_and_unsafe_attr, D)
-      .highlight(attr->getRange())
-      .highlight(safeAttr->getRange())
-      .warnInSwiftInterface(D->getDeclContext());
+        .highlight(attr->getRangeWithAt())
+        .highlight(safeAttr->getRangeWithAt())
+        .warnInSwiftInterface(D->getDeclContext());
   }
 }
 

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1712,7 +1712,7 @@ static void diagnoseIfDeprecated(SourceRange referenceRange,
                   decl, attr.isPlatformSpecific(), domain,
                   deprecatedRange.hasMinimumVersion(), deprecatedRange,
                   /*message*/ StringRef())
-        .highlight(attr.getParsedAttr()->getRange());
+        .highlight(attr.getParsedAttr()->getRangeWithAt());
     return;
   }
 
@@ -1729,7 +1729,7 @@ static void diagnoseIfDeprecated(SourceRange referenceRange,
                   decl, attr.isPlatformSpecific(), domain,
                   deprecatedRange.hasMinimumVersion(), deprecatedRange,
                   EncodedMessage.Message)
-        .highlight(attr.getParsedAttr()->getRange());
+        .highlight(attr.getParsedAttr()->getRangeWithAt());
   } else {
     unsigned rawReplaceKind = static_cast<unsigned>(
         replacementDeclKind.value_or(ReplacementDeclKind::None));
@@ -1738,7 +1738,7 @@ static void diagnoseIfDeprecated(SourceRange referenceRange,
                   decl, attr.isPlatformSpecific(), domain,
                   deprecatedRange.hasMinimumVersion(), deprecatedRange,
                   replacementDeclKind.has_value(), rawReplaceKind, newName)
-        .highlight(attr.getParsedAttr()->getRange());
+        .highlight(attr.getParsedAttr()->getRangeWithAt());
   }
 
   if (!rawRename.empty() && !isa<AccessorDecl>(decl)) {
@@ -1775,7 +1775,7 @@ static bool diagnoseIfDeprecated(SourceLoc loc,
                   attr.isPlatformSpecific(), domain,
                   deprecatedRange.hasMinimumVersion(), deprecatedRange,
                   /*message*/ StringRef())
-        .highlight(attr.getParsedAttr()->getRange());
+        .highlight(attr.getParsedAttr()->getRangeWithAt());
     return true;
   }
 
@@ -1785,7 +1785,7 @@ static bool diagnoseIfDeprecated(SourceLoc loc,
                 attr.isPlatformSpecific(), domain,
                 deprecatedRange.hasMinimumVersion(), deprecatedRange,
                 encodedMessage.Message)
-      .highlight(attr.getParsedAttr()->getRange());
+      .highlight(attr.getParsedAttr()->getRangeWithAt());
   return true;
 }
 
@@ -1921,7 +1921,7 @@ bool diagnoseExplicitUnavailability(SourceLoc loc,
     diags
         .diagnose(ext, diag::conformance_availability_marked_unavailable, type,
                   proto)
-        .highlight(attr.getParsedAttr()->getRange());
+        .highlight(attr.getParsedAttr()->getRangeWithAt());
     break;
   case AvailabilityRestriction::Reason::UnavailableUnintroduced:
     diags.diagnose(ext, diag::conformance_availability_introduced_in_version,
@@ -1932,7 +1932,7 @@ bool diagnoseExplicitUnavailability(SourceLoc loc,
     diags
         .diagnose(ext, diag::conformance_availability_obsoleted, type, proto,
                   domainAndRange.getDomain(), domainAndRange.getRange())
-        .highlight(attr.getParsedAttr()->getRange());
+        .highlight(attr.getParsedAttr()->getRangeWithAt());
     break;
   case AvailabilityRestriction::Reason::Unintroduced:
   case AvailabilityRestriction::Reason::Deprecated:
@@ -2277,7 +2277,7 @@ bool diagnoseExplicitUnavailability(
         .limitBehavior(limit);
   }
 
-  auto sourceRange = Attr.getParsedAttr()->getRange();
+  auto sourceRange = Attr.getParsedAttr()->getRangeWithAt();
   switch (restriction.getReason()) {
   case AvailabilityRestriction::Reason::UnavailableUnconditionally:
     diags.diagnose(D, diag::availability_marked_unavailable, D)


### PR DESCRIPTION
`DeclAttribute::getRange()` starts at the attribute's name rather than its `@`, which is stored separately in `AtLoc`. For every parsed attribute that takes arguments the range is built as `SourceRange(Loc, ...)` where `Loc` is the name location, so parsing an `@available(*, unavailable)` attribute yields the range covering the characters `available(*, unavailable)`.

That range can't be rendered by the swift-syntax diagnostic renderer, which maps each highlight range onto a syntax node by walking up from the token at the start of the range until it finds a node with exactly matching bounds. No node spans `available(...)` so the walk reaches the root and the highlight is silently dropped.

Use `getRangeWithAt()` consistently when highlighting attributes in diagnostics so that the highlights do not get dropped.