### PR TITLE
[6.4][stdlib] Fix Atomic.min/max using signed comparison on unsigned types

### DIFF
--- a/Runtimes/Supplemental/Synchronization/CMakeLists.txt
+++ b/Runtimes/Supplemental/Synchronization/CMakeLists.txt
@@ -115,8 +115,14 @@ add_link_options($<$<PLATFORM_ID:Windows>:LINKER:/WX>)
 # Ensure all symbols are fully resolved on Linux
 add_link_options($<$<PLATFORM_ID:Android,Linux>:LINKER:-z,defs>)
 
-gyb_expand(Atomics/AtomicIntegers.swift.gyb Atomics/AtomicIntegers.swift)
-gyb_expand(Atomics/AtomicStorage.swift.gyb Atomics/AtomicStorage.swift)
+gyb_expand(Atomics/AtomicIntegers.swift.gyb
+  Atomics/AtomicIntegers.swift
+  DEPENDS "${SwiftSynchronization_SWIFTC_SOURCE_DIR}/utils/SwiftAtomics.py"
+)
+gyb_expand(Atomics/AtomicStorage.swift.gyb
+  Atomics/AtomicStorage.swift
+  DEPENDS "${SwiftSynchronization_SWIFTC_SOURCE_DIR}/utils/SwiftAtomics.py"
+)
 
 add_library(swiftSynchronization
   Atomics/Atomic.swift

--- a/cmake/modules/SwiftHandleGybSources.cmake
+++ b/cmake/modules/SwiftHandleGybSources.cmake
@@ -120,6 +120,7 @@ function(handle_gyb_sources dependency_out_var_name sources_var_name)
   set(gyb_extra_sources
       "${SWIFT_SOURCE_DIR}/utils/GYBUnicodeDataUtils.py"
       "${SWIFT_SOURCE_DIR}/utils/SwiftIntTypes.py"
+      "${SWIFT_SOURCE_DIR}/utils/SwiftAtomics.py"
       "${SWIFT_SOURCE_DIR}/utils/SwiftFloatingPointTypes.py"
       "${SWIFT_SOURCE_DIR}/utils/UnicodeData/GraphemeBreakProperty.txt"
       "${SWIFT_SOURCE_DIR}/utils/UnicodeData/GraphemeBreakTest.txt"

--- a/test/stdlib/Synchronization/Atomics/Basics/Tests.gyb-template
+++ b/test/stdlib/Synchronization/Atomics/Basics/Tests.gyb-template
@@ -352,6 +352,23 @@ suite.test("Atomic${label} ${name} ${order}") {
   expectEqual(val2.oldValue, result1)
   expectEqual(val2.newValue, result2)
   expectEqual(v.load(ordering: .relaxed), result2)
+
+  // The operands above stay in a narrow low range, where wrapping never occurs
+  // and signed and unsigned comparison agree. Repeat at the bounds of the type.
+  // https://github.com/swiftlang/swift/issues/91176
+  for extreme in [${type}.min, ${type}.max] {
+%       if name == "Min" or name == "Max":
+    let expected: ${type} = Swift.${lowerFirst(name)}(extreme, 1)
+%       else:
+    let expected: ${type} = extreme ${operator} 1
+%       end
+    let w = Atomic<${type}>(extreme)
+
+    let val3 = w.${lowerFirst(name)}(1, ordering: .${order})
+    expectEqual(val3.oldValue, extreme)
+    expectEqual(val3.newValue, expected)
+    expectEqual(w.load(ordering: .relaxed), expected)
+  }
 }
 
 %     end

--- a/utils/SwiftAtomics.py
+++ b/utils/SwiftAtomics.py
@@ -122,10 +122,14 @@ def llvmToCaseName(ordering):
         return "sequentiallyConsistent"
 
 
+# Note: 'operation' is the LLVM name from the second column of
+# integerOperations, so the comparisons below must be against the lowercase
+# spelling. Comparing against the capitalized Swift name silently selects the
+# signed builtin for unsigned types.
 def atomicOperationName(intType, operation):
-    if operation == "Min":
+    if operation == "min":
         return "umin" if intType.startswith("U") else "min"
-    if operation == "Max":
+    if operation == "max":
         return "umax" if intType.startswith("U") else "max"
     return operation
 


### PR DESCRIPTION
- **Explanation**: Two cherry-picks. `Atomic.min` / `Atomic.max` lowered to the signed `atomicrmw min` / `max` for unsigned integer types, because `atomicOperationName` in `utils/SwiftAtomics.py` compared against the capitalized Swift operation names while the gyb call sites pass the lowercase LLVM builtin names, leaving the `umin` / `umax` branches unreachable. The stored value therefore contradicted both SE-0410 and the `newValue` the same call returns. The second cherry-pick adds the missing gyb dependency edge on `utils/SwiftAtomics.py`, without which an incremental build does not regenerate `AtomicIntegers.swift` when only that file changes.

- **Scope**: Unsigned `Atomic.min` / `.max` store the wrong value once an operand crosses the sign bit, and because these are `@_alwaysEmitIntoClient` the wrong instruction is baked into every binary built with the release; signed types are unaffected.

- **Issues**: https://github.com/swiftlang/swift/issues/91176

- **Original PRs**: #91177 (original fix), #91223 (build dependency), #91241 (reapply)

- **Risk**: Low: four lines in a code generator plus two build dependency edges, and the entire effect on generated code is a diff replacing `min` / `max` with `umin` / `umax` on unsigned types and nothing else. The build change is not optional here: without it, incremental builders keep a stale `AtomicIntegers.swift`, which is what broke CI on main and led to the revert in #91239.

- **Testing**: The integer operation tests previously used only the operands 3, 8 and 12, all below the sign bit, where signed and unsigned comparison agree. Every operation is now also exercised at `T.min` and `T.max`. Against an unfixed toolchain the new assertions fail for all five unsigned widths (10 each, `Min` and `Max` across five orderings) while every signed type and every other integer operation still passes. CI on the mainline PRs passed on all platforms.

- **Reviewers**: #91177 was approved by @lorentey and @Azoy, both code owners for the standard library. #91223 is by @etcwilde. The reapply #91241 was authored and merged by @Azoy.