### PR TITLE
[SILGen] Apply the implicit isolation parameter offset to convention lookups

### DIFF
--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -1479,6 +1479,7 @@ emitObjCThunkArguments(SILGenFunction &SGF, SILLocation loc, SILDeclRef thunk,
   assert(bridgedArgs.size() == nativeInputs.size() - bool(nativeInputsHasImplicitIsolatedParam));
   for (unsigned i = 0, size = bridgedArgs.size(); i < size; ++i) {
     unsigned nativeParamIndex = i + nativeInputsHasImplicitIsolatedParam;
+    auto nativeParam = nativeInputs[nativeParamIndex];
     // Consider the bridged values to be "call results" since they're coming
     // from potentially nil-unsound ObjC callers.
     ManagedValue native = SGF.emitBridgedToNativeValue(
@@ -1491,21 +1492,21 @@ emitObjCThunkArguments(SILGenFunction &SGF, SILLocation loc, SILDeclRef thunk,
 
     // This can happen if the value is resilient in the calling convention
     // but not resilient locally.
-    if (fnConv.isSILIndirect(nativeInputs[i]) &&
+    if (fnConv.isSILIndirect(nativeParam) &&
         !native.getType().isAddress()) {
       auto buf = SGF.emitTemporaryAllocation(loc, native.getType());
       native.forwardInto(SGF, loc, buf);
       native = SGF.emitManagedBufferWithCleanup(buf);
-    } else if (!fnConv.isSILIndirect(nativeInputs[i]) &&
+    } else if (!fnConv.isSILIndirect(nativeParam) &&
                native.getType().isAddress() && SGF.useLoweredAddresses()) {
       // Load the value if the argument has an address type and the native
       // function expects the argument to be passed directly.
       native = SGF.emitManagedLoadCopy(loc, native.getValue());
     }
 
-    if (nativeInputs[i].isConsumedInCaller()) {
+    if (nativeParam.isConsumedInCaller()) {
       argValue = native.forward(SGF);
-    } else if (nativeInputs[i].isGuaranteedInCaller()) {
+    } else if (nativeParam.isGuaranteedInCaller()) {
       argValue = native.borrow(SGF, loc).getUnmanagedValue();
     } else {
       argValue = native.getValue();

--- a/test/Concurrency/attr_execution/nonisolated_nonsending_objc.swift
+++ b/test/Concurrency/attr_execution/nonisolated_nonsending_objc.swift
@@ -44,4 +44,24 @@ class Test: NSObject {
   // CHECK: } // end sil function '$s27nonisolated_nonsending_objc4TestC12testImplicityyySSYbcYaFyyYacfU_To'
   @objc func testImplicit(_: @Sendable @escaping (String) -> Void) async {
   }
+
+  // The implicit isolation parameter shifts the native parameter list, so
+  // parameter conventions have to be looked up at the shifted index too.
+  // `Any` is address-only, so consulting the isolation parameter's (direct)
+  // convention instead would attempt to load the bridged argument.
+
+  // CHECK: // Test.testIndirect(_:)
+  // CHECK-NEXT: // Isolation: nonisolated(nonsending)
+  // CHECK-LABEL: sil hidden [ossa] @$s27nonisolated_nonsending_objc4TestC12testIndirectyyypYaF : $@convention(method) @caller_isolated @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed Any, @guaranteed Test) -> ()
+
+  // @objc closure #1 in Test.testIndirect(_:)
+  // CHECK-LABEL: sil shared [thunk] [ossa] @$s27nonisolated_nonsending_objc4TestC12testIndirectyyypYaFyyYacfU_To : $@convention(thin) @Sendable @async (AnyObject, @convention(block) () -> (), Test) -> () {
+  // CHECK: [[ACTOR:%.*]] = enum $Optional<any Actor>, #Optional.none!enumelt
+  // CHECK: [[BUILTIN_ACTOR:%.*]] = unchecked_value_cast [[ACTOR]] to $Builtin.ImplicitActor
+  // CHECK: [[ARG:%.*]] = alloc_stack $Any
+  // CHECK: [[TEST_INDIRECT_REF:%.*]] = function_ref @$s27nonisolated_nonsending_objc4TestC12testIndirectyyypYaF : $@convention(method) @caller_isolated @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed Any, @guaranteed Test) -> ()
+  // CHECK-NEXT: apply [[TEST_INDIRECT_REF]]([[BUILTIN_ACTOR]], [[ARG]], {{.*}}) : $@convention(method) @caller_isolated @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed Any, @guaranteed Test) -> ()
+  // CHECK: } // end sil function '$s27nonisolated_nonsending_objc4TestC12testIndirectyyypYaFyyYacfU_To'
+  @objc nonisolated(nonsending) func testIndirect(_: Any) async {
+  }
 }


### PR DESCRIPTION
`emitObjCThunkArguments` bridges ObjC thunk arguments into the native parameter list. When the native declaration is `nonisolated(nonsending)`, its SIL type carries an implicit leading isolation parameter that the ObjC entry point does not have, so the two lists are offset by one. The loop computes `nativeParamIndex` for exactly that reason, but only uses it in one of the five places that index into the native parameter list:

```c++
unsigned nativeParamIndex = i + nativeInputsHasImplicitIsolatedParam;

ManagedValue native = SGF.emitBridgedToNativeValue(
    loc, bridgedArgs[i], bridgedFormalTypes[i], nativeFormalTypes[i],
    swiftFnTy->getParameters()[nativeParamIndex].getSILStorageType(...),  // offset applied
    SGFContext(), /*isCallResult*/ true);

if (fnConv.isSILIndirect(nativeInputs[i]) && ...)          // not applied
} else if (!fnConv.isSILIndirect(nativeInputs[i]) && ...)  // not applied
if (nativeInputs[i].isConsumedInCaller()) {                // not applied
} else if (nativeInputs[i].isGuaranteedInCaller()) {       // not applied
```

(`bridgedFormalTypes` and `nativeFormalTypes` are formal parameter lists, which do not include the isolation parameter, so indexing those with `i` is correct.)

The isolation parameter is direct, so the shift stays invisible as long as the parameter it shifts onto is also direct. It becomes observable as soon as one is indirect:

```swift
import Foundation

class C: NSObject {
    @objc nonisolated(nonsending) func f(_ u: URL) async -> Bool { true }
}
```

```
$@convention(method) @caller_isolated @async (
  @sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor,  // [0] direct
  @in_guaranteed URL,                                                           // [1] indirect
  @guaranteed C                                                                 // [2]
) -> Bool
```

At `i == 0` the storage type is correctly taken from `[1]`, so the bridged value is an address, but the convention is read from `[0]` and reports "direct". The `else if` branch then loads the address. `URL` is address-only, so `emitManagedLoadCopy` reaches `llvm_unreachable` in `AddressOnlyTypeLowering::emitLoadOfCopy`:

```
calling emitLoadOfCopy on non-loadable type
UNREACHABLE executed at swift/lib/SIL/IR/TypeLowering.cpp:2017!
```

In a no-assertions build `llvm_unreachable` is `__builtin_unreachable()`, so released toolchains segfault instead, with no message:

```
4. While silgen emitNativeToForeignThunk SIL function "@$s4null1CC1fySb10Foundation3URLVYaFTo".
3  libsystem_platform.dylib  _sigtramp + 56
4  swift-frontend            swift::Lowering::SILGenFunction::emitManagedLoadCopy(...) + 72
5  swift-frontend            swift::Lowering::SILGenFunction::emitNativeToForeignThunk(swift::SILDeclRef) + 4844
```

That is what https://github.com/swiftlang/swift/issues/88789 reports.

The same shift also feeds `isConsumedInCaller()` and `isGuaranteedInCaller()`, so a parameter list whose conventions happen to line up could be miscompiled rather than crash. I have no reproducer for that, but it is the same index calculation, so it is covered by the same fix.

This is a follow-up to cfb11a3f4d95a7710c27c75dfc37f874fc422d9a (#85685), which introduced `nativeParamIndex` and fixed the storage type lookup. Every parameter in the test it added is direct, so the remaining lookups were not covered. The regression test here adds an indirect parameter to the same file, using `Any` so that it works with the mock SDK.

When there is no implicit isolation parameter `nativeParamIndex == i`, so the change is a no-op for every other declaration.

### Testing

`test/SILGen` and `test/Concurrency` pass locally on arm64 macOS with a `--release-debuginfo` build: 1385 discovered, 1358 passed, 1 expectedly failed, 26 unsupported, 0 unexpected failures.

Every one of these crashed before the change and compiles after it: `URL`, `Any`, `(NSString, URL)`, `async throws` + `URL`, a declaration in an extension, and a `URLSessionTaskDelegate` witness. `NSString`, `Data`, `@concurrent` and `@MainActor` compiled before and still do.

Resolves https://github.com/swiftlang/swift/issues/88789.