### PR TITLE
[rebranch] Adjust to "[Allocator] Drop RedZoneSize (non-sanitizer) and BytesAllocated members (#205711)"

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -911,7 +911,7 @@ ASTContext::ASTContext(
 
 void ASTContext::Implementation::dump(llvm::raw_ostream &os) const {
   os << "-------------------------------------------------\n";
-  os << "Arena\t0\t" << Allocator.getBytesAllocated() << "\n";
+  os << "Arena\t0\t" << Allocator.getTotalMemory() << "\n";
   Permanent.dump(os);
 
 #define SIZE(Name) os << #Name << "\t" << Name.size() << "\t0\n"
@@ -1015,7 +1015,7 @@ void ASTContext::setStatsReporter(UnifiedStatsReporter *stats) {
   Stats = stats;
 
   stats->getFrontendCounters().NumASTBytesAllocated =
-      getAllocator().getBytesAllocated();
+      getAllocator().getTotalMemory();
 
   if (stats->fineGrainedTimers())
     evaluator.setStatsReporter(stats);
@@ -3531,7 +3531,7 @@ size_t ASTContext::getSolverMemory() const {
 
   if (getImpl().CurrentConstraintSolverArena) {
     Size += getImpl().CurrentConstraintSolverArena->getTotalMemory();
-    Size += getImpl().CurrentConstraintSolverArena->Allocator.getBytesAllocated();
+    Size += getImpl().CurrentConstraintSolverArena->Allocator.getTotalMemory();
   }
 
   return Size;

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -674,7 +674,7 @@ ConstraintSystem::SolverState::~SolverState() {
   // it in one shot at the end.
   if (ctx.Stats) {
     auto &counters = ctx.Stats->getFrontendCounters();
-    int64_t bytes = CS.getAllocator().getBytesAllocated();
+    int64_t bytes = CS.getAllocator().getTotalMemory();
     counters.NumSolverBytesAllocated += bytes;
     counters.MaxSolverBytesAllocated =
         std::max(counters.MaxSolverBytesAllocated, bytes);

--- a/validation-test/Sema/type_checker_perf/slow/rdar120225470.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar120225470.swift
@@ -35,8 +35,8 @@ struct AssetBrowserView: View {
         ForEach(0..<(Int(assetsFetchResult.count/3))) { i in
           HStack {
             ForEach(0..<3) { j in
-              ZStack(alignment: .center) {
-                Image(uiImage: PHAsset.getUIImageFromPHAsset(asset: assetsFetchResult[j]()!)!)  // expected-error {{reasonable time}}
+              ZStack(alignment: .center) { // expected-error {{reasonable time}}
+                Image(uiImage: PHAsset.getUIImageFromPHAsset(asset: assetsFetchResult[j]()!)!)
                   .frame(width: 0, height: 0)
               }
               .frame(width: 0, height: 0)


### PR DESCRIPTION
```
error: no member named 'getBytesAllocated' in 'llvm::BumpPtrAllocatorImpl<>'
  os << "Arena\t0\t" << Allocator.getBytesAllocated() << "\n";
                        ~~~~~~~~~ ^
```

The upstream commit dropped the hot-path BytesAllocated counter and its getBytesAllocated() accessor, migrating in-tree consumers (clangd, clang's PPMemoryAllocationsTest) to getTotalMemory(). Mirror that here for the four memory-statistics call sites.

getTotalMemory() is public on both the LLVM we build against today (stable/21.x) and the rebranch LLVM (stable/23.x), so this compiles before and after the rebranch with no version-conditional code.

The reported figures do change. getTotalMemory() sums whole slab sizes (computeSlabSize(i) = 4096 << min(30, i / 128)) instead of returning the exact bytes handed out, so it now also counts per-slab tail slack, alignment padding, and the unfilled remainder of the current slab. The new value is therefore an upper bound on the old one, overshooting by a 4096-byte floor for tiny arenas and by low single-digit percent once the geometric slab growth kicks in.

That is acceptable for the three call sites that only report numbers -- the arena dump, NumASTBytesAllocated, and NumSolverBytesAllocated / MaxSolverBytesAllocated -- none of which any test checks. The fourth, ASTContext::getSolverMemory(), also feeds the -solver-memory-threshold "expression too complex" cutoff, but at the 512 MB default the effective threshold moves by a fraction of a percent.

See https://github.com/llvm/llvm-project/commit/ca59c69132eef55cc42bf8854706590dfddf5584 (https://github.com/llvm/llvm-project/pull/205711).
