### PR TITLE
[region-isolation] Generalize isolation-history notes and wire up InOutSendingNotDisconnectedAtExit

### DIFF
--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -1182,6 +1182,13 @@ public:
   /// Returns true if this value has any isolation history stored.
   bool hasHistory() const { return bool(history.getHead()); }
 
+  /// True when this partition's history is being recorded, and so when it is
+  /// worth snapshotting the partition for a later isolation-history walk.
+  ///
+  /// Distinct from \c hasHistory(): a partition can be recording and not have
+  /// pushed anything yet.
+  bool isRecordingIsolationHistory() const { return history.isEnabled(); }
+
   /// Returns the number of nodes of stored history.
   ///
   /// NOTE: Do not use this in real code... only intended to be used in testing
@@ -1451,15 +1458,15 @@ public:
     Element sentElement;
     SILDynamicMergedIsolationInfo isolationRegionInfo;
 
-    /// The partition at the point where the error was emitted. Used for
-    /// isolation history rewinding.
-    Partition partition;
+    /// The partition at the point where the error was emitted, for isolation
+    /// history rewinding. None when history recording is off for this function.
+    std::optional<Partition> partition;
 
     SentNeverSendableError(const PartitionOp &op, Element sentElement,
                            SILDynamicMergedIsolationInfo isolationRegionInfo,
-                           const Partition &p)
+                           std::optional<Partition> &&p)
         : op(&op), sentElement(sentElement),
-          isolationRegionInfo(isolationRegionInfo), partition(p) {}
+          isolationRegionInfo(isolationRegionInfo), partition(std::move(p)) {}
 
     SentNeverSendableError(SentNeverSendableError &&other) = default;
     SentNeverSendableError &operator=(SentNeverSendableError &&other) = default;
@@ -2516,6 +2523,18 @@ public:
   }
 
 private:
+  /// A snapshot of the working partition for a later isolation-history walk, or
+  /// None when history recording is off for this function.
+  ///
+  /// Copying a Partition copies its element-to-region map, so an error that
+  /// will never have its history rewound should not pay for one. The immutable
+  /// history node chain itself is shared, not copied.
+  std::optional<Partition> getSnapshotForIsolationHistory() const {
+    if (!p.isRecordingIsolationHistory())
+      return {};
+    return p;
+  }
+
   /// To work around not having isolation in interface types, the type checker
   /// inserts casts and other AST nodes that are used to enrich the AST with
   /// isolation information. This results in Sendable functions being
@@ -2664,8 +2683,8 @@ private:
     }
 
     // Ok, we actually need to emit a call to the callback.
-    return handleError(
-        SentNeverSendableError(op, elt, dynamicMergedIsolationInfo, p));
+    return handleError(SentNeverSendableError(
+        op, elt, dynamicMergedIsolationInfo, getSnapshotForIsolationHistory()));
   }
 };
 

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -1532,10 +1532,15 @@ public:
     Element inoutSendingElement;
     SILDynamicMergedIsolationInfo isolationInfo;
 
+    /// The partition at the exiting terminator, for isolation history
+    /// rewinding. None when history recording is off for this function.
+    std::optional<Partition> partition;
+
     InOutSendingNotDisconnectedAtExitError(
         const PartitionOp &op, Element elt,
-        SILDynamicMergedIsolationInfo isolation)
-        : op(&op), inoutSendingElement(elt), isolationInfo(isolation) {}
+        SILDynamicMergedIsolationInfo isolation, std::optional<Partition> &&p)
+        : op(&op), inoutSendingElement(elt), isolationInfo(isolation),
+          partition(std::move(p)) {}
 
     InOutSendingNotDisconnectedAtExitError(
         InOutSendingNotDisconnectedAtExitError &&other) = default;
@@ -2432,7 +2437,8 @@ public:
 
         // Otherwise, we emit the normal not disconnected at exit error.
         handleError(InOutSendingNotDisconnectedAtExitError(
-            op, op.getOpArg1(), dynamicRegionIsolation));
+            op, op.getOpArg1(), dynamicRegionIsolation,
+            getSnapshotForIsolationHistory()));
         return;
       }
 

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -540,15 +540,63 @@ class IsolationHistoryNoteEmitter {
   }
 
 public:
-  /// Single-use entry point. Constructs an internal emitter from the inputs
-  /// and emits any isolation-history notes that apply.
-  static void emit(SILFunction *fn, RegionAnalysisFunctionInfo *functionInfo,
-                   RegionAnalysisValueMap &valueMap, Element sentElement,
-                   Partition &&partition,
-                   SILDynamicMergedIsolationInfo regionInfo) {
-    IsolationHistoryNoteEmitter emitter(fn, functionInfo, valueMap, sentElement,
-                                        std::move(partition), regionInfo);
-    emitter.emitHelper();
+  /// What a chain of isolation-history notes should explain.
+  ///
+  /// The walk answers questions of the form "how does element A reach element
+  /// B"; a request is the root question, and it comes in two shapes. Both are
+  /// already handled by the walk -- only the entry point distinguished them.
+  struct Request {
+    /// Which of the two questions this request asks.
+    enum class Kind {
+      /// "How did \c from become isolated to \c regionInfo's isolation?" The
+      /// chain terminates at the isolated value that put it there.
+      HowDidBecomeIsolatedTo,
+
+      /// "How did \c from become connected to \c to?" Every link is a plain
+      /// connection; there is no isolated value to terminate at.
+      HowDidBecomeConnectedTo,
+    };
+
+    /// The element whose route the chain explains: the near end, which the
+    /// notes read outward from.
+    Element from;
+
+    /// The far end, or None when the chain explains how \c from's region came
+    /// to be isolated rather than how it reaches one specific element.
+    std::optional<Element> to;
+
+    /// The isolation of the region \c from ended up in. Set only for
+    /// \c HowDidBecomeIsolatedTo requests, where it supplies the terminal
+    /// note's wording; a connect request has no isolated terminus.
+    std::optional<SILDynamicMergedIsolationInfo> regionInfo;
+
+    /// "How did \p elt become isolated to \p info's isolation?" The chain
+    /// terminates at the isolated value.
+    static Request howDidBecomeIsolatedTo(Element elt,
+                                          SILDynamicMergedIsolationInfo info) {
+      return Request{elt, std::nullopt, info};
+    }
+
+    /// "How did \p from become connected to \p to, i.e. how did the two come to
+    /// be in one region?" Every link is a plain connection; there is no
+    /// isolated value to terminate at.
+    static Request howDidBecomeConnectedTo(Element from, Element to) {
+      return Request{from, to, std::nullopt};
+    }
+
+    Kind getKind() const {
+      return to.has_value() ? Kind::HowDidBecomeConnectedTo
+                            : Kind::HowDidBecomeIsolatedTo;
+    }
+  };
+
+  /// Single-use entry point. Returns true when at least one note was emitted.
+  static bool emit(SILFunction *fn, RegionAnalysisFunctionInfo *functionInfo,
+                   RegionAnalysisValueMap &valueMap, Request request,
+                   Partition &&partition) {
+    IsolationHistoryNoteEmitter emitter(fn, functionInfo, valueMap, request,
+                                        std::move(partition));
+    return emitter.emitHelper();
   }
 
 private:
@@ -679,37 +727,48 @@ private:
   /// repeatedly.
   BasicBlockSet visitedBlocks;
 
-  /// The element whose path into the isolated region we are explaining.
-  Element inputSentElement;
+  /// The question this chain of notes answers: which element's route to
+  /// explain, where it ends, and -- for a \c HowDidBecomeIsolatedTo request
+  /// -- the isolation of the region it ended up in.
+  Request inputRequest;
 
   /// The input partition to use for our emission.
   Partition inputPartition;
 
-  /// Merged isolation info for the receiving region. Supplies the
-  /// task-isolated flag and the descriptive-kind string used in the
-  /// diagnostic format strings.
-  SILDynamicMergedIsolationInfo inputRegionInfo;
-
   IsolationHistoryNoteEmitter(SILFunction *fn,
                               RegionAnalysisFunctionInfo *functionInfo,
-                              RegionAnalysisValueMap &valueMap,
-                              Element sentElement, Partition &&partition,
-                              SILDynamicMergedIsolationInfo regionInfo)
+                              RegionAnalysisValueMap &valueMap, Request request,
+                              Partition &&partition)
       : inputFn(fn), inputValueMap(valueMap), inputFunctionInfo(functionInfo),
-        visitedBlocks(fn), inputSentElement(sentElement),
-        inputPartition(std::move(partition)), inputRegionInfo(regionInfo) {}
+        visitedBlocks(fn), inputRequest(request),
+        inputPartition(std::move(partition)) {}
 
-  void emitHelper() {
-    ISOLATION_HISTORY_LOG(
-        log() << "===== Explaining why the sent value in " << inputFn->getName()
-              << " is isolated =====\n";
-        log() << "The value being sent is %%" << inputSentElement << '\n';
-        log() << "It is being sent into: "
-              << inputRegionInfo.printForDiagnostics(inputFn)
-              << (inputRegionInfo->isTaskIsolated() ? " (task isolated)" : "")
-              << '\n';
-        log() << "Regions at the moment of the send: ";
-        inputPartition.print(llvm::dbgs()));
+  /// Announce the question being answered, in whichever of the two shapes the
+  /// request has. Only called from under \c ISOLATION_HISTORY_LOG.
+  void logRequestPreamble() const {
+    if (inputRequest.getKind() == Request::Kind::HowDidBecomeIsolatedTo) {
+      log() << "===== Explaining why the sent value in " << inputFn->getName()
+            << " is isolated =====\n";
+      log() << "The value being sent is %%" << inputRequest.from << '\n';
+      log() << "It is being sent into: "
+            << inputRequest.regionInfo->printForDiagnostics(inputFn)
+            << ((*inputRequest.regionInfo)->isTaskIsolated()
+                    ? " (task isolated)"
+                    : "")
+            << '\n';
+    } else {
+      log() << "===== Explaining how the two ends of a region in "
+            << inputFn->getName() << " came together =====\n";
+      log() << "The near end is %%" << inputRequest.from
+            << ", the far end is %%" << *inputRequest.to << '\n';
+    }
+
+    log() << "Regions at the moment of the send: ";
+    inputPartition.print(llvm::dbgs());
+  }
+
+  bool emitHelper() {
+    ISOLATION_HISTORY_LOG(logRequestPreamble());
 
     if (!shouldEmit()) {
       ISOLATION_HISTORY_LOG(
@@ -717,7 +776,7 @@ private:
           << "Nothing to explain: either these notes are turned off for this "
              "function, or the sent value is itself actor isolated rather than "
              "having been made isolated by a merge.\n");
-      return;
+      return false;
     }
 
     collectIsolationHistoryNotes();
@@ -743,7 +802,7 @@ private:
                             llvm::dbgs() << '\n';
                           });
 
-    emitNotes();
+    return emitNotes();
   }
 
   /// How an element should be spelled in a note.
@@ -847,21 +906,46 @@ private:
       const State &state, ArrayRef<SILBasicBlock *> joinedBlocks,
       unsigned pendingStart, SmallVectorImpl<State> &states);
 
-  void emitNotes();
+  /// Emit a diagnostic for each link of the chain. Returns true when at least
+  /// one was emitted.
+  bool emitNotes();
 
   /// Returns true when isolation-history emission is on for this function and
-  /// the sent element is "disconnected" (i.e., it became isolated by being
-  /// merged with an isolated value rather than being intrinsically isolated).
+  /// the request is one the walk can say anything about.
   bool shouldEmit() const {
     if (!swift::shouldEmitIsolationHistoryFor(inputFn))
       return false;
-    return inputValueMap.getIsolationRegion(inputSentElement).isDisconnected();
+
+    if (inputRequest.getKind() == Request::Kind::HowDidBecomeIsolatedTo) {
+      // Never format an isolation we cannot prove valid: printForDiagnostics
+      // report_fatal_error()s on the Invalid lattice element, and emitNotes()
+      // prints this one. An error carrying an isolation nobody validated gets
+      // no chain rather than a crash. (Some errors default their isolation to
+      // {} -- see InOutSendingReturnedError.)
+      if (!*inputRequest.regionInfo)
+        return false;
+
+      // An intrinsically isolated element was not *made* isolated by a merge,
+      // so there is no chain to describe.
+      return inputValueMap.getIsolationRegion(inputRequest.from)
+          .isDisconnected();
+    }
+
+    // For a connect request the two ends must actually be in one region here,
+    // since the walk explains a chain by finding the merge that separates them.
+    // Nothing to explain otherwise -- and no isolation requirement either:
+    // neither end need be isolated, so there is nothing to validate.
+    if (!inputPartition.isTrackingElement(inputRequest.from) ||
+        !inputPartition.isTrackingElement(*inputRequest.to))
+      return false;
+    return inputPartition.getRegion(inputRequest.from) ==
+           inputPartition.getRegion(*inputRequest.to);
   }
 
   void emitGenericOriginatingNote(SourceLoc loc, StringRef descriptiveKind) {
     inputFn->getASTContext().Diags.diagnose(
         loc, diag::regionbasedisolation_value_became_part_of_isolated_region,
-        descriptiveKind, inputRegionInfo->isTaskIsolated());
+        descriptiveKind, (*inputRequest.regionInfo)->isTaskIsolated());
   }
 };
 
@@ -949,16 +1033,16 @@ struct IsolationHistoryNoteEmitter::PartitionWrapper {
 
 } // namespace
 
-/// Work out how \c inputSentElement's region came to be isolated by *rewinding*
-/// the send-time partition one history node at a time
+/// Work out how the request's near end reached its far end -- or, when there is
+/// no far end, how its region came to be isolated -- by *rewinding* the
+/// send-time partition one history node at a time
 /// (\c Partition::popHistoryOnce), undoing each node's effect as we go.
 ///
 /// The walk answers questions of the form "how does this element reach that
-/// one", starting with "how did the sent element come to be in an isolated
-/// region". A merge that separates the two ends of a question answers it: the
-/// pair the merge names becomes a link of the chain, and the question splits
-/// into the two halves left over on either side of it. The walk is done when
-/// every question has been answered.
+/// one", starting with the request itself. A merge that separates the two ends
+/// of a question answers it: the pair the merge names becomes a link of the
+/// chain, and the question splits into the two halves left over on either side
+/// of it. The walk is done when every question has been answered.
 ///
 /// On exit, populates \c notes with one entry per link, each carrying the two
 /// elements to name, the location of the instruction that merged them, and
@@ -981,7 +1065,7 @@ void IsolationHistoryNoteEmitter::collectIsolationHistoryNotes() {
   // send-time partition we start from is stripped here.
   State initial{inputPartition.removingSendingOperandState(), {}};
   initial.openQuestions.push_back(
-      ChainQuestion{inputSentElement, std::nullopt, std::nullopt});
+      ChainQuestion{inputRequest.from, inputRequest.to, std::nullopt});
 
   // Paths still to try, newest first: a path is followed until it explains the
   // chain or dies, and only then does the walk back up to the next one.
@@ -1364,12 +1448,24 @@ void IsolationHistoryNoteEmitter::prepareStatesForPredecessors(
 /// question is rewound before the merges that explain either half. Nothing
 /// depends on that order -- every note names both of its ends and points at its
 /// own merge, so it reads on its own.
-void IsolationHistoryNoteEmitter::emitNotes() {
-  auto descriptiveKindStr = inputRegionInfo.printForDiagnostics(inputFn);
+///
+/// Returns true when at least one note was emitted.
+bool IsolationHistoryNoteEmitter::emitNotes() {
+  // Only a HowDidBecomeIsolatedTo request has an isolated terminus to
+  // describe, and only it carries an isolation to name it with.
+  StringRef descriptiveKindStr;
+  if (inputRequest.regionInfo)
+    descriptiveKindStr = inputRequest.regionInfo->printForDiagnostics(inputFn);
   auto &diags = inputFn->getASTContext().Diags;
+  bool emittedNote = false;
 
   for (unsigned i = 0, e = notes.size(); i != e; ++i) {
     const NoteToEmit &note = notes[i];
+
+    // rhsIsIsolatedSource is only ever set on the "looking for whatever
+    // isolated this" path in processState, which a connect request never takes.
+    assert((!note.rhsIsIsolatedSource || inputRequest.regionInfo) &&
+           "Connect request produced an isolated-source link?!");
 
     // The location comes from the sequence boundary behind the merge, which a
     // truncated history may never have reached.
@@ -1395,6 +1491,7 @@ void IsolationHistoryNoteEmitter::emitNotes() {
                       "so it only says where the value became isolated.\n");
         emitGenericOriginatingNote(note.mergeLoc.getSourceLoc(),
                                    descriptiveKindStr);
+        emittedNote = true;
         continue;
       }
 
@@ -1403,7 +1500,8 @@ void IsolationHistoryNoteEmitter::emitNotes() {
           diag::regionbasedisolation_chain_value_exposed_to_isolated_named,
           nearName->name, nearName->isCallResult, farName->name,
           farName->isCallResult, descriptiveKindStr,
-          inputRegionInfo->isTaskIsolated());
+          (*inputRequest.regionInfo)->isTaskIsolated());
+      emittedNote = true;
       continue;
     }
 
@@ -1439,7 +1537,10 @@ void IsolationHistoryNoteEmitter::emitNotes() {
                    diag::regionbasedisolation_chain_value_exposed,
                    subject->name, subject->isCallResult, object->name,
                    object->isCallResult);
+    emittedNote = true;
   }
+
+  return emittedNote;
 }
 
 //===----------------------------------------------------------------------===//
@@ -3246,8 +3347,9 @@ class SentNeverSendableDiagnosticEmitter {
   /// region).
   Element sentElement;
 
-  /// The partition at the point of the error.
-  Partition partition;
+  /// The partition at the point of the error, or None when isolation-history
+  /// recording is off for this function and nobody will rewind it.
+  std::optional<Partition> partition;
 
   /// The region analysis for this function; forwarded to the isolation-history
   /// note emitter so it can recover predecessor exit partitions across joins.
@@ -3304,10 +3406,13 @@ private:
 } // namespace
 
 void SentNeverSendableDiagnosticEmitter::emitIsolationHistoryNoteIfNeeded() {
+  if (!partition)
+    return;
   IsolationHistoryNoteEmitter::emit(
       diagnosticEmitter.getOperand()->getFunction(), info, valueMap,
-      sentElement, std::move(partition),
-      diagnosticEmitter.getIsolationRegionInfo());
+      IsolationHistoryNoteEmitter::Request::howDidBecomeIsolatedTo(
+          sentElement, diagnosticEmitter.getIsolationRegionInfo()),
+      std::move(*partition));
 }
 
 bool SentNeverSendableDiagnosticEmitter::initForSendingPartialApply(

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -4465,6 +4465,15 @@ private:
   /// region at the terminator inst.
   SILDynamicMergedIsolationInfo actorIsolatedRegionInfo;
 
+  /// The region analysis for this function; forwarded to the isolation-history
+  /// note emitter so it can recover predecessor exit partitions across joins.
+  RegionAnalysisFunctionInfo *info;
+
+  /// The element of the 'inout sending' param, and the partition at the exit,
+  /// for the isolation-history notes.
+  Element inoutSendingElement;
+  std::optional<Partition> partition;
+
   bool emittedErrorDiagnostic = false;
 
 public:
@@ -4473,7 +4482,9 @@ public:
       : functionExitingInst(cast<TermInst>(error.op->getSourceInst())),
         inoutSendingParam(
             info->getValueMap().getRepresentative(error.inoutSendingElement)),
-        actorIsolatedRegionInfo(error.isolationInfo) {}
+        actorIsolatedRegionInfo(error.isolationInfo), info(info),
+        inoutSendingElement(error.inoutSendingElement),
+        partition(std::move(error.partition)) {}
 
   ~InOutSendingNotDisconnectedAtExitDiagnosticEmitter() {
     // If we were supposed to emit a diagnostic and didn't emit an unknown
@@ -4493,6 +4504,27 @@ public:
     EMIT_UNKNOWN_PATTERN_ERROR(InOutSendingNotDisconnectedDiagnosticEmitter,
                                functionExitingInst, getBehaviorLimit(),
                                /*pushToFuture=*/false);
+  }
+
+  /// Explain how the 'inout sending' parameter's region came to be isolated,
+  /// when isolation-history emission is on for this function.
+  ///
+  /// Deliberately still runs on emit()'s early unknown-pattern path: that is
+  /// an error about this same value, a chain is useful context for it, and
+  /// emitUnknownPatternError sets emittedErrorDiagnostic, so the note still
+  /// follows its error. Do not "fix" that by narrowing the defer.
+  void emitIsolationHistoryNoteIfNeeded() {
+    // A note has to follow the diagnostic it annotates. When emit() bailed
+    // without emitting anything the unknown-pattern error comes from our
+    // destructor -- after this defer runs -- so there is nothing to attach to
+    // yet.
+    if (!emittedErrorDiagnostic || !partition)
+      return;
+    IsolationHistoryNoteEmitter::emit(
+        getFunction(), info, info->getValueMap(),
+        IsolationHistoryNoteEmitter::Request::howDidBecomeIsolatedTo(
+            inoutSendingElement, actorIsolatedRegionInfo),
+        std::move(*partition));
   }
 
   void emit();
@@ -4543,6 +4575,9 @@ public:
 } // namespace
 
 void InOutSendingNotDisconnectedAtExitDiagnosticEmitter::emit() {
+  // Emit isolation history notes after the primary diagnostic returns.
+  SWIFT_DEFER { emitIsolationHistoryNoteIfNeeded(); };
+
   // We should always be able to find a name for an inout sending param. If we
   // do not, emit an unknown pattern error.
   auto varName = inferNameHelper(inoutSendingParam);

--- a/test/Concurrency/transfernonsendable_isolationhistory.swift
+++ b/test/Concurrency/transfernonsendable_isolationhistory.swift
@@ -3029,3 +3029,51 @@ func degenerate_redundant_merge(_ x: NS) async {
     mergeFn(y, z) // expected-note {{'y' is connected to 'z'}}
     await toConcurrent(y) // expected-warning {{sending 'y' risks causing data races; this is an error in the Swift 6 language mode}} expected-note {{sending main actor-isolated 'y' to @concurrent global function 'toConcurrent' risks causing data races between @concurrent and main actor-isolated uses}}
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// FIXME: A chain whose isolated source is an actor's stored property read
+// straight into a local produces NO history note at all, so this diagnostic
+// says a value is isolated without ever saying why -- on one of the most common
+// ways a value gets into an isolated region. The case below pins that so it
+// cannot change silently; when it is fixed, it should produce, on the
+// 'let z = ns' line:
+//
+//   'z' is connected to 'self.ns' which is accessible to 'self'-isolated code
+//
+// Two heuristics collide. Naming a call result after its callee deliberately
+// exempts accessors, since the user wrote a property rather than a call
+// (VariableNameUtils.cpp: "An accessor's name is its storage's name"), so the
+// getter's result is named after the variable it initializes -- 'z'. The walk's
+// isSameUserValue then sees both ends of the merge named 'z' and drops it as an
+// artifact of lowering, which is what that rule exists for: real SILGen
+// temporaries. Here it discards a semantically distinct value, and since this
+// was the only link the whole chain empties.
+//
+// Substituting anything that is not an accessor read restores the note -- see
+// 'chain_actor_via_method' below, which is the same shape through a method call
+// and does get its chain. That asymmetry is the bug's signature. Likely fix:
+// under Flag::NameCallResultAfterCallee, name an accessor result after its
+// storage rather than after the local, which is already what a read with no
+// local binding prints.
+////////////////////////////////////////////////////////////////////////////////
+
+actor ActorWithStoredNS {
+  var ns = NS()
+  func getNS() -> NS { NS() }
+
+  // FIXME: Should also produce the note quoted above, on the 'let z = ns' line.
+  func chain_actor_via_property() async {
+    let z = ns
+    await transferToMain(z) // expected-warning {{sending 'z' risks causing data races}}
+    // expected-note @-1 {{sending 'self'-isolated 'z' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
+  }
+
+  // The control for the FIXME above: identical shape, but the isolated source is
+  // a method result rather than an accessor result, so the chain is reported.
+  func chain_actor_via_method() async {
+    // expected-note@+1 {{'z' is connected to result of 'getNS()' which is accessible to 'self'-isolated code}}
+    let z = getNS()
+    await transferToMain(z) // expected-warning {{sending 'z' risks causing data races}}
+    // expected-note @-1 {{sending 'self'-isolated 'z' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
+  }
+}

--- a/test/Concurrency/transfernonsendable_isolationhistory_diagnose_attr.swift
+++ b/test/Concurrency/transfernonsendable_isolationhistory_diagnose_attr.swift
@@ -4,12 +4,15 @@
 
 // Verifies that the `@diagnose(RegionIsolationIsolationHistory, as: warning)`
 // attribute on a function opts that function in to isolation-history note
-// emission for SentNeverSendable diagnostics, even when the
-// `-sil-region-isolation-emit-isolation-history` frontend flag is not passed.
+// emission, even when the `-sil-region-isolation-emit-isolation-history`
+// frontend flag is not passed.
 //
 // Conversely, a function with no attribute should NOT emit isolation-history
-// notes. The `no_attr` function below validates this by omitting the
+// notes. The `no_attr` functions below validate this by omitting the
 // reachability-note expectation, so verify-mode fails if it fires.
+//
+// There is one opted-in / no-attribute pair per diagnostic that emits these
+// notes, since each consumer gates independently.
 
 @MainActor func transferToMain<T>(_ t: T) async {}
 
@@ -39,3 +42,26 @@ func no_attr(_ x: NS) async {
   await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
   // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// The same pair for the InOutSendingNotDisconnectedAtExit diagnostic. Each
+// diagnostic that grew history notes needs its own gate row: the recording gate
+// and the consuming gate are separate conditions that have to agree, and a
+// consumer that forgets to check is only caught on a path some test walks.
+////////////////////////////////////////////////////////////////////////////////
+
+@MainActor var globalNS = NS()
+
+@MainActor
+@diagnose(RegionIsolationIsolationHistory, as: warning)
+func inout_sending_opted_in(_ x: inout sending NS) {
+  // expected-note@+1 {{'x' is connected to 'globalNS' which is accessible to main actor-isolated code}}
+  x = globalNS
+} // expected-warning {{'inout sending' parameter 'x' cannot be main actor-isolated at end of function}}
+// expected-note @-1 {{main actor-isolated 'x' risks causing races in between main actor-isolated uses and caller uses since caller assumes value is not actor isolated}}
+
+@MainActor
+func inout_sending_no_attr(_ x: inout sending NS) {
+  x = globalNS
+} // expected-warning {{'inout sending' parameter 'x' cannot be main actor-isolated at end of function}}
+// expected-note @-1 {{main actor-isolated 'x' risks causing races in between main actor-isolated uses and caller uses since caller assumes value is not actor isolated}}

--- a/test/Concurrency/transfernonsendable_isolationhistory_inout_sending_not_disconnected.sil
+++ b/test/Concurrency/transfernonsendable_isolationhistory_inout_sending_not_disconnected.sil
@@ -1,0 +1,142 @@
+// RUN: %target-sil-opt -send-non-sendable -sil-region-isolation-emit-isolation-history -strict-concurrency=complete %s -o /dev/null -verify
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+// SIL coverage for isolation-history notes on the
+// InOutSendingNotDisconnectedAtExit diagnostic, which fires when an
+// 'inout sending' parameter's region is not disconnected at a function exit.
+// The primary diagnostic says only that the parameter is isolated at the
+// return; the history notes say *how* it got that way, by rewinding the
+// partition captured at the exiting terminator.
+//
+// The task-isolated first parameter is the isolated source in every case
+// here: a nonisolated @async function's non-sending arguments are
+// task-isolated, so merging the 'inout sending' parameter with one is the
+// smallest shape that reaches the diagnostic. `debug_value` supplies the
+// user-visible names the notes need — an unnamed link is silently dropped,
+// so a case that forgets it proves nothing.
+//
+// The primary warning and its non-history note use empty-body matchers so
+// this file survives unrelated diagnostic rewording. The chain notes have
+// their full text matched, since they are what is under test.
+//
+// NOT COVERED, and why: README.md §5 asks every work item for a suppression
+// case where the element is *directly* isolated rather than merged into an
+// isolated region, so that there is no chain to explain. That case cannot be
+// constructed for this diagnostic. SILIsolationInfo::get returns
+// getDisconnected() unconditionally for a sending function argument ("Sending
+// is always disconnected", SILIsolationInfo.cpp), and this diagnostic only
+// ever fires for an @sil_sending @inout parameter, so the element the chain
+// starts from is disconnected by construction and always got isolated by some
+// merge. The gate-off negative case instead lives in
+// transfernonsendable_isolationhistory_diagnose_attr.swift, which does not
+// pass -sil-region-isolation-emit-isolation-history.
+
+sil_stage raw
+
+import Swift
+import Builtin
+import _Concurrency
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+class NonSendableKlass {}
+
+sil @mergeOne  : $@convention(thin) (@guaranteed NonSendableKlass) -> @owned NonSendableKlass
+sil @makeFresh : $@convention(thin) () -> @owned NonSendableKlass
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+// MARK: One hop — the 'inout sending' parameter is stored to directly from the
+// task-isolated parameter, so a single terminal note explains the whole chain.
+sil [ossa] @inout_sending_one_hop : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_sending @inout NonSendableKlass) -> () {
+bb0(%x : @guaranteed $NonSendableKlass, %out : $*NonSendableKlass):
+  debug_value %x : $NonSendableKlass, let, name "x", argno 1
+  debug_value %out : $*NonSendableKlass, var, name "out", argno 2, expr op_deref
+
+  %c = copy_value %x : $NonSendableKlass
+  %acc = begin_access [modify] [unknown] %out : $*NonSendableKlass
+  // expected-note@+1 {{'out' is connected to 'x' which is accessible to code in the current isolation context}}
+  store %c to [assign] %acc : $*NonSendableKlass
+  end_access %acc : $*NonSendableKlass
+
+  %r = tuple ()
+  return %r : $() // expected-warning {{}} expected-note {{}}
+}
+
+// MARK: Two hops — routed through a named intermediate local 'y'. The chain
+// reads outward from the parameter: 'out' to 'y', 'y' to the apply result, and
+// the apply result to the task-isolated 'x'.
+sil [ossa] @inout_sending_two_hop : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_sending @inout NonSendableKlass) -> () {
+bb0(%x : @guaranteed $NonSendableKlass, %out : $*NonSendableKlass):
+  debug_value %x : $NonSendableKlass, let, name "x", argno 1
+  debug_value %out : $*NonSendableKlass, var, name "out", argno 2, expr op_deref
+
+  %f1 = function_ref @mergeOne : $@convention(thin) (@guaranteed NonSendableKlass) -> @owned NonSendableKlass
+  // expected-note@+1 {{result of 'mergeOne()' is connected to 'x' which is accessible to code in the current isolation context}}
+  %r1 = apply %f1(%x) : $@convention(thin) (@guaranteed NonSendableKlass) -> @owned NonSendableKlass
+  %y = move_value [lexical] [var_decl] %r1 : $NonSendableKlass // expected-note {{'y' is connected to result of 'mergeOne()'}}
+  debug_value %y : $NonSendableKlass, let, name "y"
+
+  %c = copy_value %y : $NonSendableKlass
+  %acc = begin_access [modify] [unknown] %out : $*NonSendableKlass
+  store %c to [assign] %acc : $*NonSendableKlass // expected-note {{'out' is connected to 'y'}}
+  end_access %acc : $*NonSendableKlass
+
+  destroy_value %y : $NonSendableKlass
+  %r = tuple ()
+  return %r : $() // expected-warning {{}} expected-note {{}}
+}
+
+// MARK: CFG diamond — the merge that isolates 'out' happens in one arm only.
+// The other arm assigns a fresh disconnected value and performs merges of its
+// own, none of which reach 'out'. The note must land in the merging arm, and
+// the unrelated arm must produce none: this is what exercises
+// prepareStatesForPredecessors' candidate filter, since the error is anchored
+// at a terminator rather than at an apply.
+sil [ossa] @inout_sending_diamond : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_sending @inout NonSendableKlass, Builtin.Int1) -> () {
+bb0(%x : @guaranteed $NonSendableKlass, %out : $*NonSendableKlass, %cond : $Builtin.Int1):
+  debug_value %x : $NonSendableKlass, let, name "x", argno 1
+  debug_value %out : $*NonSendableKlass, var, name "out", argno 2, expr op_deref
+  cond_br %cond, bb1, bb2
+
+// The merging arm: 'out' picks up the task-isolated region here.
+bb1:
+  %c1 = copy_value %x : $NonSendableKlass
+  %acc1 = begin_access [modify] [unknown] %out : $*NonSendableKlass
+  // expected-note@+1 {{'out' is connected to 'x' which is accessible to code in the current isolation context}}
+  store %c1 to [assign] %acc1 : $*NonSendableKlass
+  end_access %acc1 : $*NonSendableKlass
+  br bb3
+
+// The unrelated arm: a fresh value, merged with another fresh value, stored
+// into 'out'. Nothing here touches the isolated region, so nothing here should
+// be reported.
+bb2:
+  %mk = function_ref @makeFresh : $@convention(thin) () -> @owned NonSendableKlass
+  %fresh = apply %mk() : $@convention(thin) () -> @owned NonSendableKlass
+  %w = move_value [lexical] [var_decl] %fresh : $NonSendableKlass
+  debug_value %w : $NonSendableKlass, let, name "w"
+  %f1 = function_ref @mergeOne : $@convention(thin) (@guaranteed NonSendableKlass) -> @owned NonSendableKlass
+  %wb = begin_borrow %w : $NonSendableKlass
+  %r2 = apply %f1(%wb) : $@convention(thin) (@guaranteed NonSendableKlass) -> @owned NonSendableKlass
+  end_borrow %wb : $NonSendableKlass
+  %v = move_value [lexical] [var_decl] %r2 : $NonSendableKlass
+  debug_value %v : $NonSendableKlass, let, name "v"
+  %c2 = copy_value %v : $NonSendableKlass
+  %acc2 = begin_access [modify] [unknown] %out : $*NonSendableKlass
+  store %c2 to [assign] %acc2 : $*NonSendableKlass
+  end_access %acc2 : $*NonSendableKlass
+  destroy_value %v : $NonSendableKlass
+  destroy_value %w : $NonSendableKlass
+  br bb3
+
+bb3:
+  %r = tuple ()
+  return %r : $() // expected-warning {{}} expected-note {{}}
+}

--- a/test/Concurrency/transfernonsendable_isolationhistory_inout_sending_not_disconnected.swift
+++ b/test/Concurrency/transfernonsendable_isolationhistory_inout_sending_not_disconnected.swift
@@ -1,0 +1,111 @@
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -parse-as-library -sil-region-isolation-emit-isolation-history -verify %s -o /dev/null
+
+// REQUIRES: concurrency
+
+// Swift-source coverage for isolation-history notes on the
+// InOutSendingNotDisconnectedAtExit diagnostic. The companion
+// transfernonsendable_isolationhistory_inout_sending_not_disconnected.sil
+// covers the per-merge-kind axes directly; this file exists so we know the
+// chain survives real SILGen output, where the loads, temporaries and
+// per-argument locations are the ones the compiler actually emits rather than
+// ones we authored.
+//
+// The primary diagnostic uses an empty-body matcher; the chain notes have
+// their full text matched, since they are what is under test.
+//
+// FIXME: A chain whose isolated source is an actor's stored property read
+// directly into a local is truncated: it explains its first hop and then stops,
+// never naming the isolated value or where the value entered the isolated
+// region. 'twoHop' below pins that truncation so the bug does not change
+// silently; the note it *should* also produce is spelled out at that case.
+//
+// The cause is two individually-reasonable heuristics colliding. Naming a call
+// result after its callee deliberately exempts accessors, because in source the
+// user wrote a property rather than a call (VariableNameUtils.cpp: "An
+// accessor's name is its storage's name"), so the getter's result is named
+// after the variable it initializes -- 'z'. The walk's isSameUserValue then
+// sees both ends of the merge named 'z' and drops the link as an artifact of
+// lowering, which is what that rule is for: real SILGen temporaries. Here it
+// discards a semantically distinct value.
+//
+// This predates isolation-history notes on this diagnostic; it equally
+// truncates the already-shipping SentNeverSendable notes, where 'let z = ns;
+// await send(z)' inside an actor emits no history note at all. Verified against
+// a build of the tree before this series. Reading a global actor-isolated
+// variable does not collapse this way, so 'globalTwoHop' below does get its
+// terminal note -- the asymmetry between those two cases is the bug's
+// signature. Likely fix: under Flag::NameCallResultAfterCallee, name an
+// accessor result after its storage ('self.ns') rather than after the local,
+// which is already what the no-local case prints.
+//
+// One further shape is pinned, and is intended behavior rather than a bug: the
+// chain reads outward from the parameter, so the note naming the isolated
+// source is the *last* one, and on a multi-hop chain the notes are reported in
+// discovery order rather than reading order.
+
+class NonSendableKlass {}
+
+@MainActor var globalKlass = NonSendableKlass()
+
+////////////////////////////////////////////////////////////////////////////////
+// One hop — the 'inout sending' parameter is assigned the isolated value
+// directly, so one terminal note explains the whole chain.
+////////////////////////////////////////////////////////////////////////////////
+
+actor MyActor {
+  var ns = NonSendableKlass()
+
+  func oneHop(_ x: inout sending NonSendableKlass) {
+    // expected-note@+1 {{'x' is connected to 'self.ns' which is accessible to 'self'-isolated code}}
+    x = ns
+  } // expected-warning {{}} expected-note {{}}
+
+  // FIXME: Truncated chain -- see the FIXME in the header comment. This reports
+  // only the first hop and never explains how 'z' became 'self'-isolated, so
+  // the reader is told 'x' is connected to a local that is itself unexplained.
+  // When the accessor-naming bug is fixed, this case should additionally
+  // produce, on the 'let z = ns' line:
+  //   'z' is connected to 'self.ns' which is accessible to 'self'-isolated code
+  // which is what the equivalent global-actor case ('globalTwoHop') already
+  // produces today.
+  func twoHop(_ x: inout sending NonSendableKlass) {
+    let z = ns
+    x = z // expected-note {{'x' is connected to 'z'}}
+  } // expected-warning {{}} expected-note {{}}
+}
+
+@MainActor
+func globalOneHop(_ x: inout sending NonSendableKlass) {
+  // expected-note@+1 {{'x' is connected to 'globalKlass' which is accessible to main actor-isolated code}}
+  x = globalKlass
+} // expected-warning {{}} expected-note {{}}
+
+////////////////////////////////////////////////////////////////////////////////
+// Two hops — routed through a named local. Unlike the actor case above, a
+// global actor-isolated variable does not collapse onto the local's name, so
+// both links are reported.
+////////////////////////////////////////////////////////////////////////////////
+
+@MainActor
+func globalTwoHop(_ x: inout sending NonSendableKlass) {
+  // expected-note@+1 {{'z' is connected to 'globalKlass' which is accessible to main actor-isolated code}}
+  let z = globalKlass
+  x = z // expected-note {{'x' is connected to 'z'}}
+} // expected-warning {{}} expected-note {{}}
+
+////////////////////////////////////////////////////////////////////////////////
+// CFG diamond — only one arm merges the parameter into the isolated region.
+// The note must land in that arm; the other arm assigns a fresh disconnected
+// value and must produce none.
+////////////////////////////////////////////////////////////////////////////////
+
+@MainActor
+func diamond(_ x: inout sending NonSendableKlass, _ cond: Bool) {
+  if cond {
+    // expected-note@+1 {{'x' is connected to 'globalKlass' which is accessible to main actor-isolated code}}
+    x = globalKlass
+  } else {
+    let fresh = NonSendableKlass()
+    x = fresh
+  }
+} // expected-warning {{}} expected-note {{}}

--- a/unittests/SILOptimizer/IsolationHistory.cpp
+++ b/unittests/SILOptimizer/IsolationHistory.cpp
@@ -927,3 +927,89 @@ TEST(IsolationHistory, AssignDirectMovesElementRoundTrip) {
       << "AssignDirect that moved an element across regions did not "
          "rewind cleanly.";
 }
+
+//===----------------------------------------------------------------------===//
+//                      MARK: History recording gate
+//===----------------------------------------------------------------------===//
+
+// A partition built from a disabled Factory records nothing at all, no matter
+// what is done to it. isRecordingIsolationHistory() is the gate every consumer
+// keys off before it snapshots a partition to rewind later, so pin that it
+// tracks the thing that actually controls recording: with it false, there is no
+// history to walk and popHistoryOnce would assert.
+TEST(IsolationHistory, RecordingDisabledPartitionHasNoHistory) {
+  llvm::BumpPtrAllocator allocator;
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/false);
+
+  SILLocation loc = SILLocation::invalid();
+  // Same mutations as SingleRegionRecordsOneMergePerPeer, which records a
+  // boundary, four AddNewRegionForElement nodes and three merges when enabled.
+  auto p = Partition::singleRegion(
+      loc, {Element(0), Element(1), Element(2), Element(3)},
+      historyFactory.get());
+
+  EXPECT_FALSE(p.isRecordingIsolationHistory());
+  EXPECT_FALSE(p.hasHistory());
+  EXPECT_EQ(p.historySize(), 0u);
+  EXPECT_EQ(p.getIsolationHistory().getHead(), nullptr);
+
+  // The region mapping itself is unaffected by the gate -- only the history is.
+  PartitionTester tester(p);
+  EXPECT_EQ(tester.getRegion(0), tester.getRegion(3));
+}
+
+// isRecordingIsolationHistory() is not a synonym for hasHistory(): an enabled
+// partition reports recording before anything has been pushed to it. Consumers
+// rely on the distinction, since they decide whether to snapshot a partition
+// before knowing whether the walk will find anything in it.
+TEST(IsolationHistory, RecordingEnabledPartitionReportsRecording) {
+  llvm::BumpPtrAllocator allocator;
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
+
+  Partition p(historyFactory.get());
+  EXPECT_TRUE(p.isRecordingIsolationHistory());
+  EXPECT_FALSE(p.hasHistory());
+  EXPECT_EQ(p.historySize(), 0u);
+
+  p.pushHistorySequenceBoundary(SILLocation::invalid());
+
+  EXPECT_TRUE(p.isRecordingIsolationHistory());
+  EXPECT_TRUE(p.hasHistory());
+}
+
+// Copying a Partition shares the immutable history node chain rather than
+// duplicating it, and rewinding the copy leaves the source's history alone.
+// This is what makes snapshotting a partition for a later isolation-history
+// walk cheap, and what lets two walks run off one snapshot: each walk rewinds
+// its own copy.
+TEST(IsolationHistory, SnapshotSharesHistoryWithSource) {
+  llvm::BumpPtrAllocator allocator;
+  IsolationHistory::Factory historyFactory(allocator, /*enabled=*/true);
+
+  SILLocation loc = SILLocation::invalid();
+  auto p = Partition::singleRegion(
+      loc, {Element(0), Element(1), Element(2), Element(3)},
+      historyFactory.get());
+  ASSERT_TRUE(p.hasHistory());
+
+  Partition snapshot = p;
+  EXPECT_TRUE(snapshot.isRecordingIsolationHistory());
+  EXPECT_EQ(snapshot.historySize(), p.historySize());
+  // The chain is shared, not copied: both heads are the same node.
+  EXPECT_EQ(snapshot.getIsolationHistory().getHead(),
+            p.getIsolationHistory().getHead());
+
+  const IsolationHistory::Node *sourceHead = p.getIsolationHistory().getHead();
+  unsigned sourceSize = p.historySize();
+
+  llvm::SmallVector<SILBasicBlock *, 4> joins;
+  while (popOnePartitionOp(snapshot, joins))
+    continue;
+  EXPECT_FALSE(snapshot.hasHistory());
+  EXPECT_TRUE(joins.empty());
+
+  EXPECT_EQ(p.getIsolationHistory().getHead(), sourceHead)
+      << "Rewinding a snapshot moved the source partition's history head.";
+  EXPECT_EQ(p.historySize(), sourceSize)
+      << "Rewinding a snapshot consumed the source partition's history.";
+}


### PR DESCRIPTION
Isolation-history notes explain *how* a value ended up in an isolated region,
by rewinding the partition captured at the point of the error. Today only
SentNeverSendable emits them. This is the groundwork for the other emitters,  
plus the first of them.

**1. Generalize the note emitter entry point.** The walk could always answer   
two questions -- "how did this element become isolated" and "how did these two                                            
elements come to share a region" -- since `ChainQuestion::to` is optional, but                                            
the entry point only exposed the first. Wrap the question in a `Request` with a                                           
`Kind` for the two shapes (`HowDidBecomeIsolatedTo`, `HowDidBecomeConnectedTo`)                                           
and drive `emit()` off it, so each future caller builds a `Request` and inherits
`shouldEmit()`'s per-shape preconditions rather than repeating them -- notably                                            
that an isolated request must carry a valid isolation, since `emitNotes()`
prints it and `printForDiagnostics` `report_fatal_error()`s on `Invalid`.     
`SentNeverSendableError::partition` also becomes optional, filled from the new
`getSnapshotForIsolationHistory()`, so an error whose history nobody will rewind                                          
stops paying for a `Partition` copy. No diagnostic output changes.          
                                                                                                                          
**2. Emit the notes for InOutSendingNotDisconnectedAtExit.** This diagnostic       
says an `inout sending` parameter is isolated at a function exit but not how it
got that way, which is exactly what the caller needs, since it is entitled to
treat the parameter as being in its own region on return. The note hangs off a
`SWIFT_DEFER` gated on `emittedErrorDiagnostic`, so it covers every return in
`emit()` and can never precede its error.