### PR TITLE
Adjust to "[clang][modules] Deserialize submodules lazily (#194968)"

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3118,14 +3118,14 @@ ClangModuleUnit *ClangImporter::Implementation::getWrapperForModule(
         // a tree, so these don't require deduplication.
         addImplicitImport(CurrModule, /*guaranteedUnique=*/true);
       }
-      for (auto *I : CurrModule->Imports) {
+      for (clang::Module *I : CurrModule->Imports) {
         // `underlying` is the current TLM. Only explicit submodules need to
         // be imported under the same TLM, which is handled above.
         if (I->getTopLevelModule() == underlying)
           continue;
         addImplicitImport(I, /*guaranteedUnique=*/false);
       }
-      for (auto *Submodule : CurrModule->submodules())
+      for (clang::Module *Submodule : CurrModule->submodules())
         SubmoduleWorklist.push_back(Submodule);
     }
   }
@@ -4094,7 +4094,7 @@ static void getImportDecls(ClangModuleUnit *ClangUnit, const clang::Module *M,
 
   ASTContext &Ctx = ClangUnit->getASTContext();
 
-  for (auto *ImportedMod : M->Imports) {
+  for (clang::Module *ImportedMod : M->Imports) {
     auto *ID = createImportDecl(Ctx, ClangUnit, ImportedMod, Exported);
     Results.push_back(ID);
   }

--- a/lib/SymbolGraphGen/ClangExportCompat.h
+++ b/lib/SymbolGraphGen/ClangExportCompat.h
@@ -1,0 +1,72 @@
+//===--- ClangExportCompat.h - clang::Module::ExportDecl Accessors --------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Representation-agnostic accessors for the elements of
+// clang::Module::Exports.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SYMBOLGRAPHGEN_CLANGEXPORTCOMPAT_H
+#define SWIFT_SYMBOLGRAPHGEN_CLANGEXPORTCOMPAT_H
+
+#include "clang/Basic/Module.h"
+#include "llvm/ADT/PointerIntPair.h"
+
+#include <utility>
+
+namespace swift {
+namespace symbolgraphgen {
+
+/// `clang::Module::ExportDecl` used to be a
+/// `llvm::PointerIntPair<clang::Module *, 1, bool>`, and is a
+/// `std::pair<clang::ModuleRef, bool>` as of
+/// f68d44dce63f1a94e60410e8817e0eed70fc0578
+/// (https://github.com/llvm/llvm-project/pull/194968), which introduced lazy
+/// deserialization of submodules. These overloads accept either representation
+/// so that this code builds against both; the `std::pair` ones are templated
+/// because `clang::ModuleRef` cannot be named in the older representation.
+/// They can be collapsed into direct member accesses once support for the
+/// older representation is no longer needed.
+/// @{
+
+/// The exported module, or null for a wildcard export that is not scoped to a
+/// submodule, e.g. `export *`.
+inline clang::Module *
+getExportedClangModule(const llvm::PointerIntPair<clang::Module *, 1, bool> &ED) {
+  return ED.getPointer();
+}
+
+template <typename ModuleRefTy>
+inline clang::Module *
+getExportedClangModule(const std::pair<ModuleRefTy, bool> &ED) {
+  // Note that in this representation, converting to `clang::Module *`
+  // materializes the module on demand.
+  return ED.first;
+}
+
+/// Whether this is a wildcard export, e.g. `export *` or `export Submodule.*`.
+inline bool
+isWildcardClangExport(const llvm::PointerIntPair<clang::Module *, 1, bool> &ED) {
+  return ED.getInt();
+}
+
+template <typename ModuleRefTy>
+inline bool isWildcardClangExport(const std::pair<ModuleRefTy, bool> &ED) {
+  return ED.second;
+}
+
+/// @}
+
+} // end namespace symbolgraphgen
+} // end namespace swift
+
+#endif // SWIFT_SYMBOLGRAPHGEN_CLANGEXPORTCOMPAT_H

--- a/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
+++ b/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
@@ -23,6 +23,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringSwitch.h"
 
+#include "ClangExportCompat.h"
 #include "SymbolGraphASTWalker.h"
 
 using namespace swift;
@@ -66,9 +67,9 @@ bool clangModuleExports(const clang::Module *ClangParent, const clang::Module *C
   if (!ClangParent || !CM) return false;
   if (ClangParent == CM) return true;
 
-  for (auto ClangExport : ClangParent->Exports) {
-    auto *ExportedModule = ClangExport.getPointer();
-    if (ClangExport.getInt()) {
+  for (const auto &ClangExport : ClangParent->Exports) {
+    clang::Module *ExportedModule = getExportedClangModule(ClangExport);
+    if (isWildcardClangExport(ClangExport)) {
       if (!ExportedModule && CM->isSubModuleOf(ClangParent)) {
         return true;
       } else if (ExportedModule && CM->isSubModuleOf(ExportedModule)) {

--- a/lib/SymbolGraphGen/SymbolGraphGen.cpp
+++ b/lib/SymbolGraphGen/SymbolGraphGen.cpp
@@ -23,6 +23,7 @@
 #include "llvm/Support/MD5.h"
 #include "llvm/Support/Path.h"
 
+#include "ClangExportCompat.h"
 #include "SymbolGraphASTWalker.h"
 
 using namespace swift;
@@ -125,20 +126,21 @@ int symbolgraphgen::emitSymbolGraphForModule(
   if (const auto *ClangModule = M->findUnderlyingClangModule()) {
     // Scan through the Clang module's exports and collect them for later
     // handling
-    for (auto ClangExport : ClangModule->Exports) {
-      if (ClangExport.getInt()) {
+    for (const auto &ClangExport : ClangModule->Exports) {
+      const clang::Module *ExportedModule = getExportedClangModule(ClangExport);
+      if (isWildcardClangExport(ClangExport)) {
         // Blanket exports are represented as a true boolean tag
-        if (const auto *ExportParent = ClangExport.getPointer()) {
+        if (ExportedModule) {
           // If a pointer is present, this is a scoped blanket export, like
           // `export Submodule.*`
-          WildcardExportClangModules.insert(ExportParent);
+          WildcardExportClangModules.insert(ExportedModule);
         } else {
           // Otherwise it represents a full blanket `export *`
           WildcardExportClangModules.insert(ClangModule);
         }
-      } else if (!ClangExport.getInt() && ClangExport.getPointer()) {
+      } else if (ExportedModule) {
         // This is an explicit `export Submodule`
-        ExportedClangModules.insert(ClangExport.getPointer());
+        ExportedClangModules.insert(ExportedModule);
       }
     }
 


### PR DESCRIPTION
llvm-project f68d44dce63f1a94e60410e8817e0eed70fc0578 (https://github.com/llvm/llvm-project/pull/194968) introduced lazy submodule deserialization. It replaced the raw `Module *` elements of `clang::Module::Imports` and of the `submodules()` range with a new `clang::ModuleRef` wrapper that implicitly materializes and converts to `Module *`, and changed `clang::Module::ExportDecl` from `llvm::PointerIntPair<Module *, 1, bool>` to `std::pair<ModuleRef, bool>`. Building against a branch that has it (e.g. stable/23.x) therefore fails:

  lib/ClangImporter/ClangImporter.cpp:3132:18: error: variable 'I' with type
  'auto *' has incompatible initializer of type 'const clang::ModuleRef'
  lib/SymbolGraphGen/SymbolGraphGen.cpp:129:23: error: no member named 'getInt'
  in 'std::pair<clang::ModuleRef, bool>'
  lib/SymbolGraphGen/SymbolGraphGen.cpp:131:52: error: no member named
  'getPointer' in 'std::pair<clang::ModuleRef, bool>'

The range-for loops only need their variables spelled `clang::Module *` rather than `auto *`. That is valid for `Module *` elements, and for `ModuleRef` elements it triggers the implicit conversion (which lazily deserializes the module), matching the intent and the existing loop bodies that use `I->` or pass the module on directly.

The `ExportDecl` accesses cannot be spelled the same way for both representations, so they now go through `getExportedClangModule()` and `isWildcardClangExport()` in lib/SymbolGraphGen/ClangExportCompat.h. Those are overloaded on the two representations instead of being guarded on a version macro; the `std::pair` overloads are templated because `clang::ModuleRef` cannot be named when the older representation is in use. They can be collapsed into direct member accesses once branches without #194968 no longer need to be supported.

This keeps building against branches both with and without #194968 -- e.g. stable/21.x, which main currently tracks, and stable/23.x, which rebranch tracks -- so that the adjustment need not be carried out of tree on rebranch.
