### PR TITLE
[DNM/Experiment] build-time const extraction of top level let decls

### DIFF
--- a/include/swift/AST/ConstTypeInfo.h
+++ b/include/swift/AST/ConstTypeInfo.h
@@ -46,6 +46,7 @@ public:
     InterpolatedString,
     NilLiteral,
     Runtime,
+    DefaultArgument,
     MemberFunctionCall
   };
 
@@ -533,6 +534,16 @@ public:
 
   static bool classof(const CompileTimeValue *T) {
     return T->getKind() == ValueKind::Runtime;
+  }
+};
+
+/// A representation of a defaulted argument value.
+class DefaultArgumentValue : public CompileTimeValue {
+public:
+  DefaultArgumentValue() : CompileTimeValue(ValueKind::DefaultArgument) {}
+
+  static bool classof(const CompileTimeValue *T) {
+    return T->getKind() == ValueKind::DefaultArgument;
   }
 };
 

--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -524,6 +524,10 @@ public:
   /// A file containing a list of protocols whose conformances require const value extraction.
   std::string ConstGatherProtocolListFilePath;
 
+  /// Names of top-level constant declarations whose initialization expressions
+  /// require const value extraction.
+  std::vector<std::string> ConstGatherTopLevelConstantNames;
+
   /// Cross import module information. Map from module name to the list of cross
   /// import overlay files that associate with that module.
   using CrossImportMap = llvm::StringMap<std::vector<std::string>>;

--- a/include/swift/ConstExtract/ConstExtract.h
+++ b/include/swift/ConstExtract/ConstExtract.h
@@ -56,10 +56,26 @@ std::vector<ConstValueTypeInfo>
 gatherConstValuesForModule(const std::unordered_set<std::string> &Protocols,
                            ModuleDecl *Module);
 
-/// Serialize a collection of \c ConstValueInfos to JSON at the
-/// provided output stream.
-bool writeAsJSONToFile(const std::vector<ConstValueTypeInfo> &ConstValueInfos,
-                       llvm::raw_ostream &OS, bool Compact = false);
+/// Gather the compile-time-known values of the initialization expressions of
+/// top-level constant declarations in this file whose names appear in
+/// \c ConstantNames.
+std::vector<ConstValueTypePropertyInfo>
+gatherConstValuesForTopLevelConstantsInPrimary(
+    const std::unordered_set<std::string> &ConstantNames, const SourceFile *File);
+
+/// Gather the compile-time-known values of the initialization expressions of
+/// top-level constant declarations in this module whose names appear in
+/// \c ConstantNames.
+std::vector<ConstValueTypePropertyInfo>
+gatherConstValuesForTopLevelConstantsInModule(
+    const std::unordered_set<std::string> &ConstantNames, ModuleDecl *Module);
+
+/// Serialize a collection of \c ConstValueInfos and top-level constant
+/// \c ConstValueTypePropertyInfos to JSON at the provided output stream.
+bool writeAsJSONToFile(
+    const std::vector<ConstValueTypeInfo> &ConstValueInfos,
+    const std::vector<ConstValueTypePropertyInfo> &TopLevelConstantInfos,
+    llvm::raw_ostream &OS, bool Compact = false);
 
 /// Remap prefix-mapped paths in const values JSON output. Scans for
 /// Returns true on error.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -118,6 +118,13 @@ def const_gather_protocols_file
     Flags<[FrontendOption, NoDriverOption, ArgumentIsPath]>,
     HelpText<"Specify a list of protocols for extraction of conformances 'const values'">;
 
+def const_gather_top_level_constant
+  : Separate<["-"], "const-gather-top-level-constant">, MetaVarName<"<name>">,
+    Flags<[FrontendOption, NoDriverOption]>,
+    HelpText<"Extract the 'const value' of the initialization expression of the "
+             "top-level 'let' constant with this name. May be specified more "
+             "than once">;
+
 let Flags = [FrontendOption, NoDriverOption] in {
 
 def triple : Separate<["-"], "triple">, Alias<target>;

--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -19,6 +19,7 @@
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticsFrontend.h"
 #include "swift/AST/Evaluator.h"
+#include "swift/AST/Pattern.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/Assertions.h"
@@ -433,7 +434,7 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
         return std::make_shared<DictionaryValue>(
             std::vector<std::shared_ptr<TupleValue>>());
       default:
-        break;
+        return std::make_shared<DefaultArgumentValue>();
       }
     } break;
 
@@ -580,7 +581,16 @@ extractTypePropertyInfo(VarDecl *propertyDecl) {
     propertyWrapperValues = extractPropertyWrapperAttrValues(propertyDecl);
 
   if (const auto binding = propertyDecl->getParentPatternBinding()) {
-    if (const auto originalInit = binding->getInit(0)) {
+    const auto entryIndex =
+        binding->getPatternEntryIndexForVarDecl(propertyDecl);
+
+    unsigned BoundVariables = 0;
+    binding->getPattern(entryIndex)->forEachVariable(
+        [&](VarDecl *) { ++BoundVariables; });
+
+    const auto originalInit =
+        BoundVariables == 1 ? binding->getInit(entryIndex) : nullptr;
+    if (originalInit) {
       return {propertyDecl,
               extractCompileTimeValue(originalInit,
                                       propertyDecl->getInnermostDeclContext()),
@@ -735,6 +745,69 @@ gatherConstValuesForPrimary(const std::unordered_set<std::string> &Protocols,
   for (auto *CD : ConformanceDecls)
     Result.emplace_back(evaluateOrDefault(
         CD->getASTContext().evaluator, ConstantValueInfoRequest{CD, SF}, {}));
+  return Result;
+}
+
+static void collectTopLevelConstantsInDecl(
+    Decl *D, const std::unordered_set<std::string> &ConstantNames,
+    std::vector<VarDecl *> &Constants) {
+  auto considerBinding = [&](PatternBindingDecl *PBD) {
+    for (auto Index : range(PBD->getNumPatternEntries()))
+      PBD->getPattern(Index)->forEachVariable([&](VarDecl *VD) {
+        if (!VD->isLet())
+          return;
+        if (ConstantNames.count(VD->getBaseName().userFacingName().str()) != 0)
+          Constants.push_back(VD);
+      });
+  };
+
+  if (auto *PBD = dyn_cast<PatternBindingDecl>(D)) {
+    considerBinding(PBD);
+    return;
+  }
+
+  // In script mode the binding is nested within a 'TopLevelCodeDecl'.
+  if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D)) {
+    if (auto *Body = TLCD->getBody())
+      for (auto Element : Body->getElements())
+        if (auto *NestedDecl = Element.dyn_cast<Decl *>())
+          if (auto *PBD = dyn_cast<PatternBindingDecl>(NestedDecl))
+            considerBinding(PBD);
+  }
+}
+
+std::vector<ConstValueTypePropertyInfo>
+gatherConstValuesForTopLevelConstantsInModule(
+    const std::unordered_set<std::string> &ConstantNames, ModuleDecl *Module) {
+  std::vector<ConstValueTypePropertyInfo> Result;
+  if (ConstantNames.empty())
+    return Result;
+
+  std::vector<VarDecl *> Constants;
+  for (auto *File : Module->getFiles()) {
+    if (auto *SF = dyn_cast<SourceFile>(File))
+      for (auto *D : SF->getTopLevelDecls())
+        collectTopLevelConstantsInDecl(D, ConstantNames, Constants);
+  }
+
+  for (auto *VD : Constants)
+    Result.push_back(extractTypePropertyInfo(VD));
+  return Result;
+}
+
+std::vector<ConstValueTypePropertyInfo>
+gatherConstValuesForTopLevelConstantsInPrimary(
+    const std::unordered_set<std::string> &ConstantNames, const SourceFile *SF) {
+  std::vector<ConstValueTypePropertyInfo> Result;
+  if (ConstantNames.empty())
+    return Result;
+
+  std::vector<VarDecl *> Constants;
+  for (auto *D : SF->getTopLevelDecls())
+    collectTopLevelConstantsInDecl(D, ConstantNames, Constants);
+
+  for (auto *VD : Constants)
+    Result.push_back(extractTypePropertyInfo(VD));
   return Result;
 }
 
@@ -1006,6 +1079,11 @@ void writeValue(llvm::json::OStream &JSON,
 
   case CompileTimeValue::ValueKind::Runtime: {
     JSON.attribute("valueKind", "Runtime");
+    break;
+  }
+
+  case CompileTimeValue::ValueKind::DefaultArgument: {
+    JSON.attribute("valueKind", "DefaultArgument");
     break;
   }
   }
@@ -1455,37 +1533,42 @@ void writeAssociatedTypeAliases(llvm::json::OStream &JSON,
   });
 }
 
+void writeVariableInfo(llvm::json::OStream &JSON,
+                       const ConstValueTypePropertyInfo &PropertyInfo,
+                       const NominalTypeDecl *NomTypeDecl) {
+  const auto *decl = PropertyInfo.VarDecl;
+  std::shared_ptr<CompileTimeValue> value = PropertyInfo.Value;
+  JSON.attribute("label", decl->getName().str().str());
+  JSON.attribute("type",
+                 toFullyQualifiedTypeNameString(decl->getInterfaceType()));
+  JSON.attribute("mangledTypeName", "n/a - deprecated");
+  JSON.attribute("isStatic", decl->isStatic() ? "true" : "false");
+  JSON.attribute("isComputed", !decl->hasStorage() ? "true" : "false");
+  writeLocationInformation(JSON, decl->getLoc(),
+                           decl->getDeclContext()->getASTContext());
+
+  if (NomTypeDecl &&
+      value.get()->getKind() == CompileTimeValue::ValueKind::Runtime) {
+    // Extract result builder information only if the variable has not
+    // used a different kind of initializer
+    if (auto builderValue = extractBuilderValueIfExists(NomTypeDecl, decl)) {
+      value = builderValue.value();
+    }
+  }
+
+  writeValue(JSON, value);
+  writePropertyWrapperAttributes(JSON, PropertyInfo.PropertyWrappers,
+                                 decl->getASTContext());
+  writeAvailabilityAttributes(JSON, *decl);
+}
+
 void writeProperties(llvm::json::OStream &JSON,
                      const ConstValueTypeInfo &TypeInfo,
                      const NominalTypeDecl &NomTypeDecl) {
   JSON.attributeArray("properties", [&] {
     for (const auto &PropertyInfo : TypeInfo.Properties) {
-      JSON.object([&] {
-        const auto *decl = PropertyInfo.VarDecl;
-        std::shared_ptr<CompileTimeValue> value = PropertyInfo.Value;
-        JSON.attribute("label", decl->getName().str().str());
-        JSON.attribute("type", toFullyQualifiedTypeNameString(
-            decl->getInterfaceType()));
-        JSON.attribute("mangledTypeName", "n/a - deprecated");
-        JSON.attribute("isStatic", decl->isStatic() ? "true" : "false");
-        JSON.attribute("isComputed", !decl->hasStorage() ? "true" : "false");
-        writeLocationInformation(JSON, decl->getLoc(),
-                                 decl->getDeclContext()->getASTContext());
-
-        if (value.get()->getKind() == CompileTimeValue::ValueKind::Runtime) {
-          // Extract result builder information only if the variable has not
-          // used a different kind of initializer
-          if (auto builderValue =
-                  extractBuilderValueIfExists(&NomTypeDecl, decl)) {
-            value = builderValue.value();
-          }
-        }
-
-        writeValue(JSON, value);
-        writePropertyWrapperAttributes(JSON, PropertyInfo.PropertyWrappers,
-                                       decl->getASTContext());
-        writeAvailabilityAttributes(JSON, *decl);
-      });
+      JSON.object(
+          [&] { writeVariableInfo(JSON, PropertyInfo, &NomTypeDecl); });
     }
   });
 }
@@ -1540,8 +1623,10 @@ void writeNominalTypeKind(llvm::json::OStream &JSON,
           .str());
 }
 
-bool writeAsJSONToFile(const std::vector<ConstValueTypeInfo> &ConstValueInfos,
-                       llvm::raw_ostream &OS, bool Compact) {
+bool writeAsJSONToFile(
+    const std::vector<ConstValueTypeInfo> &ConstValueInfos,
+    const std::vector<ConstValueTypePropertyInfo> &TopLevelConstantInfos,
+    llvm::raw_ostream &OS, bool Compact) {
   llvm::json::OStream JSON(OS, Compact ? 0 : 2);
   JSON.array([&] {
     for (const auto &TypeInfo : ConstValueInfos) {
@@ -1565,6 +1650,13 @@ bool writeAsJSONToFile(const std::vector<ConstValueTypeInfo> &ConstValueInfos,
         writeProperties(JSON, TypeInfo, *NomTypeDecl);
         writeEnumCases(JSON, TypeInfo.EnumElements);
         writeAvailabilityAttributes(JSON, *NomTypeDecl);
+      });
+    }
+
+    for (const auto &ConstantInfo : TopLevelConstantInfos) {
+      JSON.object([&] {
+        JSON.attribute("kind", "topLevelConstant");
+        writeVariableInfo(JSON, ConstantInfo, /*NomTypeDecl=*/nullptr);
       });
     }
   });

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2640,6 +2640,9 @@ static bool ParseSearchPathArgs(SearchPathOptions &Opts, ArgList &Args,
                                      OPT_const_gather_protocols_list))
     Opts.ConstGatherProtocolListFilePath = A->getValue();
 
+  for (auto A : Args.getAllArgValues(options::OPT_const_gather_top_level_constant))
+    Opts.ConstGatherTopLevelConstantNames.push_back(A);
+
   for (auto A : Args.getAllArgValues(options::OPT_serialized_path_obfuscate)) {
     auto SplitMap = StringRef(A).split('=');
     Opts.DeserializedPathRecoverer.addMapping(SplitMap.first, SplitMap.second);

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -707,21 +707,24 @@ static void emitSwiftdepsForAllPrimaryInputsIfNeeded(
 /// prefix-remapped pretty-printed JSON is written to disk. Without CAS,
 /// pretty-printed JSON is written directly.
 /// Returns true on error.
-static bool writeConstValues(CompilerInstance &Instance,
-                             const std::vector<ConstValueTypeInfo> &ConstValues,
-                             StringRef ConstValuesFilePath) {
+static bool writeConstValues(
+    CompilerInstance &Instance,
+    const std::vector<ConstValueTypeInfo> &ConstValues,
+    const std::vector<ConstValueTypePropertyInfo> &TopLevelConstantConstValues,
+    StringRef ConstValuesFilePath) {
   return withOutputPath(
       Instance.getDiags(), Instance.getOutputBackend(), ConstValuesFilePath,
       [&](llvm::raw_ostream &OS) {
         if (!Instance.supportCaching()) {
           // Caching not enabled, write output directly.
-          writeAsJSONToFile(ConstValues, OS);
+          writeAsJSONToFile(ConstValues, TopLevelConstantConstValues, OS);
           return false;
         }
         // Using CAS, the path need to be remapped.
         std::string Buffer;
         llvm::raw_string_ostream BufferOS(Buffer);
-        writeAsJSONToFile(ConstValues, BufferOS, /*Compact=*/true);
+        writeAsJSONToFile(ConstValues, TopLevelConstantConstValues, BufferOS,
+                          /*Compact=*/true);
         if (auto err =
                 Instance.getCASOutputBackend().storeSupplementaryOutputFile(
                     ConstValuesFilePath, Buffer)) {
@@ -741,9 +744,11 @@ static bool emitConstValuesForWholeModuleIfNeeded(
     CompilerInstance &Instance) {
   const auto &Invocation = Instance.getInvocation();
   const auto &frontendOpts = Invocation.getFrontendOptions();
+  const auto &searchPathOpts = Instance.getASTContext().SearchPathOpts;
   auto constExtractProtocolListPath =
-      Instance.getASTContext().SearchPathOpts.ConstGatherProtocolListFilePath;
-  if (constExtractProtocolListPath.empty())
+      searchPathOpts.ConstGatherProtocolListFilePath;
+  if (constExtractProtocolListPath.empty() &&
+      searchPathOpts.ConstGatherTopLevelConstantNames.empty())
     return false;
   if (!frontendOpts.InputsAndOutputs.hasConstValuesOutputPath())
     return false;
@@ -756,33 +761,54 @@ static bool emitConstValuesForWholeModuleIfNeeded(
   // List of protocols whose conforming nominal types
   // we should extract compile-time-known values from
   std::unordered_set<std::string> Protocols;
-  bool inputParseSuccess = parseProtocolListFromFile(
-      constExtractProtocolListPath, Instance.getDiags(),
-      Instance.getFileSystem(), Protocols);
-  if (!inputParseSuccess)
-    return true;
+  if (!constExtractProtocolListPath.empty()) {
+    bool inputParseSuccess = parseProtocolListFromFile(
+        constExtractProtocolListPath, Instance.getDiags(),
+        Instance.getFileSystem(), Protocols);
+    if (!inputParseSuccess)
+      return true;
+  }
 
+  // Names of top-level constants whose initialization expressions
+  // we should extract compile-time-known values from
+  const std::unordered_set<std::string> TopLevelConstantNames(
+      searchPathOpts.ConstGatherTopLevelConstantNames.begin(),
+      searchPathOpts.ConstGatherTopLevelConstantNames.end());
+
+  auto *Module = Instance.getMainModule();
   return writeConstValues(
-      Instance, gatherConstValuesForModule(Protocols, Instance.getMainModule()),
+      Instance, gatherConstValuesForModule(Protocols, Module),
+      gatherConstValuesForTopLevelConstantsInModule(TopLevelConstantNames, Module),
       ConstValuesFilePath);
 }
 
 static void emitConstValuesForAllPrimaryInputsIfNeeded(
     CompilerInstance &Instance) {
   const auto &Invocation = Instance.getInvocation();
+  const auto &searchPathOpts = Instance.getASTContext().SearchPathOpts;
   auto constExtractProtocolListPath =
-      Instance.getASTContext().SearchPathOpts.ConstGatherProtocolListFilePath;
-  if (constExtractProtocolListPath.empty())
+      searchPathOpts.ConstGatherProtocolListFilePath;
+  if (constExtractProtocolListPath.empty() &&
+      searchPathOpts.ConstGatherTopLevelConstantNames.empty())
     return;
 
   // List of protocols whose conforming nominal types
   // we should extract compile-time-known values from
   std::unordered_set<std::string> Protocols;
-  bool inputParseSuccess = parseProtocolListFromFile(
-      constExtractProtocolListPath, Instance.getDiags(),
-      Instance.getFileSystem(), Protocols);
-  if (!inputParseSuccess)
-    return;
+  if (!constExtractProtocolListPath.empty()) {
+    bool inputParseSuccess = parseProtocolListFromFile(
+        constExtractProtocolListPath, Instance.getDiags(),
+        Instance.getFileSystem(), Protocols);
+    if (!inputParseSuccess)
+      return;
+  }
+
+  // Names of top-level constants whose initialization expressions
+  // we should extract compile-time-known values from
+  const std::unordered_set<std::string> TopLevelConstantNames(
+      searchPathOpts.ConstGatherTopLevelConstantNames.begin(),
+      searchPathOpts.ConstGatherTopLevelConstantNames.end());
+
   for (auto *SF : Instance.getPrimarySourceFiles()) {
     const std::string &ConstValuesFilePath =
         Invocation.getConstValuesFilePathForPrimary(
@@ -790,8 +816,10 @@ static void emitConstValuesForAllPrimaryInputsIfNeeded(
     if (ConstValuesFilePath.empty())
       continue;
 
-    writeConstValues(Instance, gatherConstValuesForPrimary(Protocols, SF),
-                     ConstValuesFilePath);
+    writeConstValues(
+        Instance, gatherConstValuesForPrimary(Protocols, SF),
+        gatherConstValuesForTopLevelConstantsInPrimary(TopLevelConstantNames, SF),
+        ConstValuesFilePath);
   }
 }
 

--- a/test/CAS/const-protocol-values.swift
+++ b/test/CAS/const-protocol-values.swift
@@ -21,6 +21,7 @@
 // RUN:   -typecheck -cache-compile-job -cas-path %t/cas \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   -module-name Test -cache-replay-prefix-map /^tmp %t -const-gather-protocols-file /^tmp/protocols.json \
+// RUN:   -const-gather-top-level-constant topLevel \
 // RUN:   /^tmp/test.swift @%t/MyApp.cmd -emit-const-values-path %t/main.module.swiftconstvalues
 
 // RUN: %FileCheck %s < %t/main.module.swiftconstvalues
@@ -29,6 +30,7 @@
 // RUN:   -typecheck -cache-compile-job -cas-path %t/cas \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   -module-name Test -cache-replay-prefix-map /^tmp %t -const-gather-protocols-file /^tmp/protocols.json \
+// RUN:   -const-gather-top-level-constant topLevel \
 // RUN:   /^tmp/test.swift @%t/MyApp.cmd -emit-const-values-path %t/main.module2.swiftconstvalues -Rcache-compile-job 2>&1 | %FileCheck %s --check-prefix=HIT
 
 // HIT: remark: replay output file 'TMP_DIR/main.module2.swiftconstvalues'
@@ -108,6 +110,18 @@
 // CHECK-NEXT:       }
 // CHECK-NEXT:     ],
 // CHECK-NEXT:     "typeName": "Test.MyFoo"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "file": "TMP_DIR/test.swift",
+// CHECK-NEXT:     "isComputed": "false",
+// CHECK-NEXT:     "isStatic": "false",
+// CHECK-NEXT:     "kind": "topLevelConstant",
+// CHECK-NEXT:     "label": "topLevel",
+// CHECK-NEXT:     "line": 21,
+// CHECK-NEXT:     "mangledTypeName": "n/a - deprecated",
+// CHECK-NEXT:     "type": "Swift.String",
+// CHECK-NEXT:     "value": "Top",
+// CHECK-NEXT:     "valueKind": "RawLiteral"
 // CHECK-NEXT:   }
 // CHECK-NEXT: ]
 
@@ -135,6 +149,8 @@ public struct MyFoo : Foo {
 
   @Zero var value: Int
 }
+
+let topLevel = "Top"
 
 //--- protocols.json
 ["Foo"]

--- a/test/ConstExtraction/ExtractDefaultArguments.swift
+++ b/test/ConstExtraction/ExtractDefaultArguments.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module -module-name ResilientLib -enable-library-evolution -o %t/ResilientLib.swiftmodule %S/Inputs/DefaultArgumentsLib.swift
+
+// RUN: %target-swift-frontend -typecheck -emit-const-values-path %t/ExtractDefaultArguments.swiftconstvalues -const-gather-top-level-constant value -I %t -primary-file %s
+// RUN: cat %t/ExtractDefaultArguments.swiftconstvalues 2>&1 | %FileCheck %s
+
+import ResilientLib
+
+let value = Thing(name: "n", locallyPassed: false)
+
+// CHECK:      "valueKind": "InitCall",
+// CHECK:          "label": "name",
+// CHECK-NEXT:     "type": "Swift.String",
+// CHECK-NEXT:     "valueKind": "RawLiteral",
+// CHECK-NEXT:     "value": "n"
+// CHECK:          "label": "flag",
+// CHECK-NEXT:     "type": "Swift.Bool",
+// CHECK-NEXT:     "valueKind": "DefaultArgument"
+// CHECK:          "label": "items",
+// CHECK-NEXT:     "type": "Swift.Array<Swift.String>",
+// CHECK-NEXT:     "valueKind": "DefaultArgument"
+// CHECK:          "label": "opt",
+// CHECK-NEXT:     "type": "Swift.Optional<Swift.String>",
+// CHECK-NEXT:     "valueKind": "NilLiteral"
+// CHECK:          "label": "locallyPassed",
+// CHECK-NEXT:     "type": "Swift.Bool",
+// CHECK-NEXT:     "valueKind": "RawLiteral",
+// CHECK-NEXT:     "value": "false"

--- a/test/ConstExtraction/ExtractMultipleBindings.swift
+++ b/test/ConstExtraction/ExtractMultipleBindings.swift
@@ -1,0 +1,26 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -typecheck -emit-const-values-path %t/ExtractMultipleBindings.swiftconstvalues -const-gather-top-level-constant first -const-gather-top-level-constant second -const-gather-top-level-constant third -const-gather-top-level-constant left -const-gather-top-level-constant right -primary-file %s
+// RUN: cat %t/ExtractMultipleBindings.swiftconstvalues 2>&1 | %FileCheck %s
+
+let first = 1, second = 2, third = 3
+
+let (left, right) = (10, 20)
+
+// CHECK:        "label": "first",
+// CHECK:        "valueKind": "RawLiteral",
+// CHECK-NEXT:   "value": "1"
+
+// CHECK:        "label": "second",
+// CHECK:        "valueKind": "RawLiteral",
+// CHECK-NEXT:   "value": "2"
+
+// CHECK:        "label": "third",
+// CHECK:        "valueKind": "RawLiteral",
+// CHECK-NEXT:   "value": "3"
+
+// CHECK:        "label": "left",
+// CHECK:        "valueKind": "Runtime"
+
+// CHECK:        "label": "right",
+// CHECK:        "valueKind": "Runtime"

--- a/test/ConstExtraction/ExtractTopLevelConstants.swift
+++ b/test/ConstExtraction/ExtractTopLevelConstants.swift
@@ -1,0 +1,130 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -typecheck -emit-const-values-path %t/ExtractTopLevelConstants.swiftconstvalues -const-gather-top-level-constant extracted -const-gather-top-level-constant mutable -const-gather-top-level-constant computed -const-gather-top-level-constant destructured -primary-file %s
+// RUN: cat %t/ExtractTopLevelConstants.swiftconstvalues 2>&1 | %FileCheck %s
+
+public struct Item {
+    var name: String
+    static func item(name: String, tags: [String] = []) -> Item {
+        Item(name: name)
+    }
+}
+
+public struct Bag {
+    var label: String
+    var items: [Item]
+}
+
+let notRequested = "ignored"
+
+let extracted = Bag(
+    label: "bag",
+    items: [.item(name: "first"), .item(name: "second", tags: ["a"])]
+)
+
+var mutable = 1
+var computed: Int { 42 }
+
+let (destructured, alsoDestructured) = ("x", "y")
+
+struct NotExtracted {
+    let unrelated: Int = 0
+}
+
+func containsShadowingLocal() {
+    let extracted = "local"
+    _ = extracted
+}
+
+// CHECK:      [
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": "topLevelConstant",
+// CHECK-NEXT:     "label": "extracted",
+// CHECK-NEXT:     "type": "ExtractTopLevelConstants.Bag",
+// CHECK-NEXT:     "mangledTypeName": "n/a - deprecated",
+// CHECK-NEXT:     "isStatic": "false",
+// CHECK-NEXT:     "isComputed": "false",
+// CHECK-NEXT:     "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractTopLevelConstants.swift",
+// CHECK-NEXT:     "line": 20,
+// CHECK-NEXT:     "valueKind": "InitCall",
+// CHECK-NEXT:     "value": {
+// CHECK-NEXT:       "type": "ExtractTopLevelConstants.Bag",
+// CHECK-NEXT:       "arguments": [
+// CHECK-NEXT:         {
+// CHECK-NEXT:           "label": "label",
+// CHECK-NEXT:           "type": "Swift.String",
+// CHECK-NEXT:           "valueKind": "RawLiteral",
+// CHECK-NEXT:           "value": "bag"
+// CHECK-NEXT:         },
+// CHECK-NEXT:         {
+// CHECK-NEXT:           "label": "items",
+// CHECK-NEXT:           "type": "Swift.Array<ExtractTopLevelConstants.Item>",
+// CHECK-NEXT:           "valueKind": "Array",
+// CHECK-NEXT:           "value": [
+// CHECK-NEXT:             {
+// CHECK-NEXT:               "valueKind": "StaticFunctionCall",
+// CHECK-NEXT:               "value": {
+// CHECK-NEXT:                 "type": "ExtractTopLevelConstants.Item",
+// CHECK-NEXT:                 "memberLabel": "item",
+// CHECK-NEXT:                 "arguments": [
+// CHECK-NEXT:                   {
+// CHECK-NEXT:                     "label": "name",
+// CHECK-NEXT:                     "type": "Swift.String",
+// CHECK-NEXT:                     "valueKind": "RawLiteral",
+// CHECK-NEXT:                     "value": "first"
+// CHECK-NEXT:                   },
+// CHECK-NEXT:                   {
+// CHECK-NEXT:                     "label": "tags",
+// CHECK-NEXT:                     "type": "Swift.Array<Swift.String>",
+// CHECK-NEXT:                     "valueKind": "Array",
+// CHECK-NEXT:                     "value": []
+// CHECK-NEXT:                   }
+// CHECK-NEXT:                 ]
+// CHECK-NEXT:               }
+// CHECK-NEXT:             },
+// CHECK-NEXT:             {
+// CHECK-NEXT:               "valueKind": "StaticFunctionCall",
+// CHECK-NEXT:               "value": {
+// CHECK-NEXT:                 "type": "ExtractTopLevelConstants.Item",
+// CHECK-NEXT:                 "memberLabel": "item",
+// CHECK-NEXT:                 "arguments": [
+// CHECK-NEXT:                   {
+// CHECK-NEXT:                     "label": "name",
+// CHECK-NEXT:                     "type": "Swift.String",
+// CHECK-NEXT:                     "valueKind": "RawLiteral",
+// CHECK-NEXT:                     "value": "second"
+// CHECK-NEXT:                   },
+// CHECK-NEXT:                   {
+// CHECK-NEXT:                     "label": "tags",
+// CHECK-NEXT:                     "type": "Swift.Array<Swift.String>",
+// CHECK-NEXT:                     "valueKind": "Array",
+// CHECK-NEXT:                     "value": [
+// CHECK-NEXT:                       {
+// CHECK-NEXT:                         "valueKind": "RawLiteral",
+// CHECK-NEXT:                         "value": "a"
+// CHECK-NEXT:                       }
+// CHECK-NEXT:                     ]
+// CHECK-NEXT:                   }
+// CHECK-NEXT:                 ]
+// CHECK-NEXT:               }
+// CHECK-NEXT:             }
+// CHECK-NEXT:           ]
+// CHECK-NEXT:         }
+// CHECK-NEXT:       ]
+// CHECK-NEXT:     }
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": "topLevelConstant",
+// CHECK-NEXT:     "label": "destructured",
+// CHECK-NEXT:     "type": "Swift.String",
+// CHECK-NEXT:     "mangledTypeName": "n/a - deprecated",
+// CHECK-NEXT:     "isStatic": "false",
+// CHECK-NEXT:     "isComputed": "false",
+// CHECK-NEXT:     "file": "{{.*}}ExtractTopLevelConstants.swift",
+// CHECK-NEXT:     "line": 28,
+// CHECK-NEXT:     "valueKind": "Runtime"
+// CHECK-NEXT:   }
+// CHECK-NEXT: ]
+
+// CHECK-NOT: "label": "mutable"
+// CHECK-NOT: "label": "computed"

--- a/test/ConstExtraction/ExtractTopLevelConstantsScriptMode.swift
+++ b/test/ConstExtraction/ExtractTopLevelConstantsScriptMode.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: cp %s %t/main.swift
+// RUN: %target-swift-frontend -typecheck -emit-const-values-path %t/out.swiftconstvalues -const-gather-top-level-constant greeting %t/main.swift
+// RUN: cat %t/out.swiftconstvalues 2>&1 | %FileCheck %s
+
+let greeting = "hello"
+
+// CHECK:      [
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": "topLevelConstant",
+// CHECK-NEXT:     "label": "greeting",
+// CHECK-NEXT:     "type": "Swift.String",
+// CHECK-NEXT:     "mangledTypeName": "n/a - deprecated",
+// CHECK-NEXT:     "isStatic": "false",
+// CHECK-NEXT:     "isComputed": "false",
+// CHECK-NEXT:     "file": "{{.*}}main.swift",
+// CHECK-NEXT:     "line": 6,
+// CHECK-NEXT:     "valueKind": "RawLiteral",
+// CHECK-NEXT:     "value": "hello"
+// CHECK-NEXT:   }
+// CHECK-NEXT: ]

--- a/test/ConstExtraction/Inputs/DefaultArgumentsLib.swift
+++ b/test/ConstExtraction/Inputs/DefaultArgumentsLib.swift
@@ -1,0 +1,13 @@
+public struct Thing {
+    public var name: String
+
+    public init(
+        name: String,
+        flag: Bool = true,
+        items: [String] = [],
+        opt: String? = nil,
+        locallyPassed: Bool = true
+    ) {
+        self.name = name
+    }
+}


### PR DESCRIPTION
Experiment with extending the build time protocol extraction machinery to top level `let decls`, to see if it would be a suitable alternative to the SwiftSyntax based parsing in https://github.com/swiftlang/swift-package-manager/pull/9759. The main benefit over syntax-based parsing is we'd still be type checking the expressions, reducing the risk of a manifest which can be loaded by the new loader but would fail to compile when loaded by the fallback loader. The main downside is we lose support for evaluating things like array concatenation.